### PR TITLE
fix(ci): reduce permissions in grafana plugin release workflow to fix caller mismatch

### DIFF
--- a/.github/workflows/release-grafana-plugin.yml
+++ b/.github/workflows/release-grafana-plugin.yml
@@ -1,6 +1,7 @@
 name: Release Grafana Plugin
 
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
- Reduce permissions in Grafana plugin release workflow to fix the caller mismatch