### PR TITLE
Ensure fixtures initialize DB tables

### DIFF
--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -86,6 +86,9 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
     db_type = resolve_db_type(ns.db, ns.db_type)
 
     async def _handler(store):
+        if isinstance(store, SQLAlchemyStore):
+            await store.ensure_tables()
+
         repo_count = max(1, ns.repo_count)
         base_name = ns.repo_name
         team_count = getattr(ns, "team_count", 8)


### PR DESCRIPTION
## Summary
- [x] ensure fixtures generation initializes SQLAlchemy tables before inserts
- [x] add regression test that fixtures invoke ensure_tables

## Testing
- [x] pytest tests/test_fixtures_runner.py -k ensures_tables