### PR TITLE
fix: resolve 'tag is needed' error in parallel docker builds

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -91,6 +91,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.versioning.outputs.python_version }}
+          tags: ghcr.io/${{ github.repository_owner }}/dev-hops-${{ matrix.target }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || github.event.inputs.push_images == 'true') }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
This PR adds the missing repository name to the Docker build jobs to resolve the 'tag is needed when pushing to registry' error.