### PR TITLE
docs: add Work Graph View documentation and update PRD/roadmap

### DIFF
--- a/docs/product/prd.md
+++ b/docs/product/prd.md
@@ -27,6 +27,8 @@ This system is explicitly designed to avoid turning metrics into scorecards.
    Churn, hotspots, ownership concentration.
 4. **Well-being signals (team-level)**  
    After-hours and weekend ratios; pattern drift.
+5. **Work Graph (entity relationships)**  
+   Traversable graph of issues → PRs → commits → files with provenance tracking.
 
 ## Guardrails (non-negotiable)
 - No person-to-person comparisons.
@@ -50,12 +52,14 @@ This system is explicitly designed to avoid turning metrics into scorecards.
 - **Visualizations**: Heatmaps, Flame diagrams (timeline + hierarchical), Sankey, Treemap, Sunburst
 - **Connectors**: GitHub, GitLab, Jira, Local Git, Synthetic
 - **DORA Metrics**: MTTR, change failure rate, deployment frequency, lead time
+- **Work Graph API**: GraphQL `workGraphEdges` query with filters (PR #273)
 
 ### Remaining (see `docs/roadmap.md`)
 - Capacity planning (forecast completion)
 - Identity linking (Work Items → Git commits)
 - Work Item repo filtering by tags/settings
 - Dashboard filter fixes
+- Work Graph Frontend: Related entities UI, interactive explorer (dev-health-web#88)
 
 ## References
 - `dev-health-ops/AGENTS.md` (repo rules)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -57,7 +57,14 @@ This checklist tracks what is complete and what remains to finalize `dev-health-
 
 ### API Enhancements
 
-- [ ] **GraphQL Work Graph API**: Add resolvers and types for work_graph_edges traversal queries. ([#265](https://github.com/full-chaos/dev-health-ops/issues/265))
+- [x] **GraphQL Work Graph API**: Add resolvers and types for work_graph_edges traversal queries. ([#265](https://github.com/full-chaos/dev-health-ops/issues/265), [PR #273](https://github.com/full-chaos/dev-health-ops/pull/273))
+
+### Frontend (dev-health-web)
+
+- [ ] **Work Graph GraphQL types**: Add query definitions and TypeScript types for workGraphEdges API. ([dev-health-web#89](https://github.com/full-chaos/dev-health-web/issues/89))
+- [ ] **Related Entities - Issue page**: Show linked PRs, blocking issues on issue detail page. ([dev-health-web#90](https://github.com/full-chaos/dev-health-web/issues/90))
+- [ ] **Related Entities - PR page**: Show linked issues and commits on PR detail page. ([dev-health-web#91](https://github.com/full-chaos/dev-health-web/issues/91))
+- [ ] **Work Graph Explorer**: Interactive graph visualization for entity relationships. ([dev-health-web#92](https://github.com/full-chaos/dev-health-web/issues/92))
 
 ### Testing + Docs
 

--- a/docs/user-guide/views-index.md
+++ b/docs/user-guide/views-index.md
@@ -10,6 +10,7 @@ Each view answers a specific operational question. Views are explanations with d
 - PR Flow (stage breakdown)
 - Quadrants (raw-value state classification)
 - Flame diagrams (single-point decomposition)
+- Work Graph (entity relationships, related entities)
 
 ## Interpretation rules
 - Trends over snapshots.

--- a/docs/user-guide/views/work-graph.md
+++ b/docs/user-guide/views/work-graph.md
@@ -1,0 +1,154 @@
+# Work Graph View
+
+The Work Graph View visualizes entity relationships across issues, PRs, commits, and files.
+
+## Purpose
+
+Answer questions like:
+- Which PRs implement this issue?
+- What commits are in this PR?
+- Which files are most touched by this work stream?
+- What issues are blocking progress?
+
+## Data Model
+
+### Node Types
+| Type | Description | Example ID |
+|------|-------------|------------|
+| `issue` | Work item from Jira/GitHub/GitLab | `PROJ-123`, `github:org/repo#42` |
+| `pr` | Pull request / Merge request | `github:org/repo:pr:99` |
+| `commit` | Git commit | `abc123def...` |
+| `file` | Source file | `src/lib/utils.ts` |
+
+### Edge Types
+
+**Issue ↔ Issue**
+- `blocks` / `is_blocked_by` — Blocking relationships
+- `relates` / `is_related_to` — Related work
+- `duplicates` / `is_duplicate_of` — Duplicate issues
+- `parent_of` / `child_of` — Hierarchy (epics/subtasks)
+
+**Issue ↔ PR**
+- `implements` — PR implements the issue
+- `fixes` — PR fixes the issue (typically bugs)
+- `references` — PR mentions the issue
+
+**PR ↔ Commit**
+- `contains` — PR contains the commit
+
+**Commit ↔ File**
+- `touches` — Commit modifies the file
+
+### Provenance
+Each edge has a provenance indicating how it was discovered:
+- `native` — From provider API (e.g., Jira issue links)
+- `explicit_text` — Parsed from text (e.g., "Closes #123" in PR description)
+- `heuristic` — Inferred by rules (e.g., branch naming patterns)
+
+### Confidence
+Edges have a confidence score (0.0 - 1.0):
+- `1.0` — Native provider links
+- `0.8-0.9` — Explicit text patterns (e.g., "fixes #123")
+- `0.5-0.7` — Heuristic inference
+
+## GraphQL API
+
+### Query
+```graphql
+query WorkGraphEdges($orgId: String!, $filters: WorkGraphEdgeFilterInput) {
+  workGraphEdges(orgId: $orgId, filters: $filters) {
+    edges {
+      edgeId
+      sourceType
+      sourceId
+      targetType
+      targetId
+      edgeType
+      provenance
+      confidence
+      evidence
+      repoId
+      provider
+    }
+    totalCount
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+  }
+}
+```
+
+### Filters
+| Filter | Type | Description |
+|--------|------|-------------|
+| `repoIds` | `[String]` | Filter by repository IDs |
+| `sourceType` | `WorkGraphNodeType` | Filter by source node type |
+| `targetType` | `WorkGraphNodeType` | Filter by target node type |
+| `edgeType` | `WorkGraphEdgeType` | Filter by relationship type |
+| `nodeId` | `String` | Find all edges connected to a node |
+| `limit` | `Int` | Max results (default 1000) |
+
+### Example: Find PRs that implement an issue
+```graphql
+{
+  workGraphEdges(orgId: "my-org", filters: {
+    nodeId: "PROJ-123",
+    edgeType: IMPLEMENTS
+  }) {
+    edges {
+      sourceId  # PR ID
+      targetId  # Issue ID (PROJ-123)
+      evidence  # "Implements PROJ-123" from PR title
+    }
+  }
+}
+```
+
+### Example: Find commits in a PR
+```graphql
+{
+  workGraphEdges(orgId: "my-org", filters: {
+    sourceType: PR,
+    sourceId: "github:org/repo:pr:99",
+    edgeType: CONTAINS
+  }) {
+    edges {
+      targetId    # Commit hash
+      confidence  # 1.0 for native
+    }
+  }
+}
+```
+
+## UI Components (Planned)
+
+### Related Entities Section
+On issue/PR detail pages, show:
+- Linked PRs/issues with relationship type
+- Commits (on PR pages)
+- Blocking/blocked-by indicators
+
+### Work Graph Explorer
+Interactive graph visualization:
+- Start from a seed node (e.g., selected issue)
+- Expand to see connected entities
+- Filter by node/edge types
+- Click to navigate to entity details
+
+See: [dev-health-web#88](https://github.com/full-chaos/dev-health-web/issues/88)
+
+## Interpretation Guidelines
+
+1. **Provenance matters** — Native edges are authoritative; heuristic edges are suggestions
+2. **Missing edges ≠ no relationship** — Depends on provider configuration and parsing
+3. **Use for navigation, not scoring** — The graph supports exploration, not metrics
+4. **Evidence is extractive** — `evidence` field contains the actual text that created the edge
+
+## Related Documentation
+
+- [Work Graph Contract](../work-graph.md) — Core model documentation
+- [Investment View](investment-mix.md) — How themes map to work
+- [PR Flow](pr-flow.md) — PR lifecycle visualization

--- a/docs/user-guide/work-graph.md
+++ b/docs/user-guide/work-graph.md
@@ -4,13 +4,33 @@ The work graph is the structure that links evidence and supports drill-down.
 
 ## What it is
 A graph-like model of WorkUnits and relationships:
-- work item ↔ PR ↔ commits ↔ files ↔ incidents (when present)
+- issue ↔ PR ↔ commits ↔ files (with provenance tracking)
+
+## Node Types
+- **Issue**: Work items from Jira, GitHub Issues, GitLab Issues
+- **PR**: Pull requests / Merge requests
+- **Commit**: Git commits
+- **File**: Source files touched by commits
+
+## Edge Types
+- **Issue ↔ Issue**: blocks, relates, duplicates, parent_of/child_of
+- **Issue ↔ PR**: implements, fixes, references
+- **PR ↔ Commit**: contains
+- **Commit ↔ File**: touches
 
 ## Why it exists
 - Enables explainability without recomputation.
 - Provides drill-down paths from aggregates to evidence.
 - Supports flow and investment distribution materialization.
+- Powers "Related Entities" views on detail pages.
 
 ## What it is not
 - A replacement for provider-native objects.
 - A scoring layer.
+
+## API and Visualization
+
+See [Work Graph View](views/work-graph.md) for:
+- GraphQL API documentation (`workGraphEdges` query)
+- Filter options
+- UI component plans (Related Entities, Work Graph Explorer)


### PR DESCRIPTION
## Summary

Documentation updates for the Work Graph feature following GraphQL API implementation (#273).

## Changes

### PRD (`docs/product/prd.md`)
- Added Work Graph as 5th product pillar
- Marked Work Graph API as implemented
- Added FE work to remaining tasks

### Roadmap (`docs/roadmap.md`)
- Marked GraphQL Work Graph API as complete (PR #273)
- Added new Frontend section with related tasks:
  - dev-health-web#89: GraphQL types
  - dev-health-web#90: Issue page related entities
  - dev-health-web#91: PR page related entities
  - dev-health-web#92: Work Graph Explorer

### New Documentation
- `docs/user-guide/views/work-graph.md` - Comprehensive Work Graph View docs:
  - Node and edge type reference
  - GraphQL API documentation with examples
  - Filter options
  - UI component plans
  - Interpretation guidelines

### Updated Documentation
- `docs/user-guide/work-graph.md` - Updated model docs with API link
- `docs/user-guide/views-index.md` - Added Work Graph to views list

## Related Issues
- Backend: #265 (closed), PR #273 (merged)
- Frontend: dev-health-web#88, #89, #90, #91, #92