### PR TITLE
fix(connectors): address Copilot review feedback for Teams connector

### DIFF
--- a/tests/test_teams_connector.py
+++ b/tests/test_teams_connector.py
@@ -325,6 +325,7 @@ class TestTeamsConnectorFromEnv:
                 "AZURE_CLIENT_ID": "test-client",
                 "AZURE_CLIENT_SECRET": "test-secret",
             },
+            clear=True,
         ):
             connector = TeamsConnector.from_env()
             assert connector.client.tenant_id == "test-tenant"


### PR DESCRIPTION
## Summary
Follow-up to #319 addressing Copilot review feedback:

- Use `asyncio.run()` instead of deprecated `get_event_loop()` (Python 3.11+ compatibility)
- Add proper error handling for nextLink pagination requests (prevents silent partial data)
- Clamp token expiry buffer to prevent negative lifetime on short-lived tokens
- Isolate test environment with `patch.dict(..., clear=True)`