### PR TITLE
fix(api): use CLICKHOUSE_URI for all analytics endpoints

### DIFF
--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -129,10 +129,6 @@ def _clickhouse_url() -> str:
 
 
 def _analytics_db_url() -> str:
-    return _clickhouse_url()
-
-
-def _analytics_db_url() -> str:
     uri = os.getenv("CLICKHOUSE_URI")
     if not uri:
         raise RuntimeError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,15 @@ def setup_test_env(monkeypatch):
     monkeypatch.setenv("DATABASE_URI", "sqlite:///:memory:")
 
 
+@pytest.fixture(autouse=True)
+def mock_analytics_db_url(monkeypatch):
+    """Mock analytics DB URL so endpoints don't return 503 in tests."""
+    monkeypatch.setattr(
+        "dev_health_ops.api.main._analytics_db_url",
+        lambda: "clickhouse://localhost:8123/default",
+    )
+
+
 @pytest.fixture
 def repo_path():
     """Return the path to the current repository for testing."""

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -34,15 +34,6 @@ def client():
     return TestClient(app)
 
 
-@pytest.fixture(autouse=True)
-def mock_db_url(monkeypatch):
-    """Set a dummy DATABASE_URL so endpoints don't return 503."""
-    monkeypatch.setattr(
-        "dev_health_ops.api.main._db_url",
-        lambda: "clickhouse://localhost:8123/default",
-    )
-
-
 def test_home_endpoint_schema(client, monkeypatch):
     sample = HomeResponse(
         freshness=Freshness(


### PR DESCRIPTION
Analytics endpoints were using _db_url() which returns DATABASE_URI (PostgreSQL), causing 503 errors when running ClickHouse queries against Postgres.

Added _analytics_db_url() that requires CLICKHOUSE_URI and updated all 31 analytics endpoints to use it. No single-db fallback - dual database setup is now required.