### PR TITLE
feat(credentials): add worker credential resolver for enterprise DB credentials

### DIFF
--- a/src/dev_health_ops/credentials/__init__.py
+++ b/src/dev_health_ops/credentials/__init__.py
@@ -1,0 +1,47 @@
+"""Credential resolution module for Enterprise worker credential management.
+
+This module provides a unified interface for resolving provider credentials,
+supporting both database-stored encrypted credentials (Enterprise) and
+environment variable fallback (development/OSS).
+
+Usage:
+    from dev_health_ops.credentials import CredentialResolver, ProviderCredentials
+
+    # Async context (API, async workers)
+    async with get_async_session() as session:
+        resolver = CredentialResolver(session, org_id="my-org")
+        creds = await resolver.resolve("github")
+        token = creds.token
+
+    # Sync context (Celery workers, CLI)
+    from dev_health_ops.credentials import resolve_credentials_sync
+    creds = resolve_credentials_sync("github", org_id="my-org", db_url=db_url)
+"""
+
+from dev_health_ops.credentials.resolver import (
+    CredentialResolver,
+    CredentialResolutionError,
+    resolve_credentials_sync,
+)
+from dev_health_ops.credentials.types import (
+    AtlassianCredentials,
+    CredentialSource,
+    GitHubCredentials,
+    GitLabCredentials,
+    JiraCredentials,
+    LinearCredentials,
+    ProviderCredentials,
+)
+
+__all__ = [
+    "AtlassianCredentials",
+    "CredentialResolver",
+    "CredentialResolutionError",
+    "CredentialSource",
+    "GitHubCredentials",
+    "GitLabCredentials",
+    "JiraCredentials",
+    "LinearCredentials",
+    "ProviderCredentials",
+    "resolve_credentials_sync",
+]

--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Optional, Type, TypeVar
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.credentials.types import (
+    AtlassianCredentials,
+    CredentialSource,
+    GitHubCredentials,
+    GitLabCredentials,
+    JiraCredentials,
+    LinearCredentials,
+    ProviderCredentials,
+)
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=ProviderCredentials)
+
+PROVIDER_ENV_VARS: dict[str, dict[str, str]] = {
+    "github": {"token": "GITHUB_TOKEN", "base_url": "GITHUB_URL"},
+    "gitlab": {"token": "GITLAB_TOKEN", "base_url": "GITLAB_URL"},
+    "jira": {
+        "api_token": "JIRA_API_TOKEN",
+        "email": "JIRA_EMAIL",
+        "base_url": "JIRA_BASE_URL",
+    },
+    "linear": {"api_key": "LINEAR_API_KEY"},
+    "atlassian": {
+        "api_token": "ATLASSIAN_API_TOKEN",
+        "email": "ATLASSIAN_EMAIL",
+        "cloud_id": "ATLASSIAN_CLOUD_ID",
+    },
+}
+
+PROVIDER_CREDENTIAL_TYPES: dict[str, Type[ProviderCredentials]] = {
+    "github": GitHubCredentials,
+    "gitlab": GitLabCredentials,
+    "jira": JiraCredentials,
+    "linear": LinearCredentials,
+    "atlassian": AtlassianCredentials,
+}
+
+
+class CredentialResolutionError(Exception):
+    def __init__(
+        self,
+        provider: str,
+        message: str,
+        org_id: str = "default",
+        credential_name: str = "default",
+    ):
+        self.provider = provider
+        self.org_id = org_id
+        self.credential_name = credential_name
+        super().__init__(message)
+
+
+class CredentialResolver:
+    def __init__(
+        self,
+        session: AsyncSession,
+        org_id: str = "default",
+        allow_env_fallback: bool = True,
+    ):
+        self.session = session
+        self.org_id = org_id
+        self.allow_env_fallback = allow_env_fallback
+
+    async def resolve(
+        self,
+        provider: str,
+        credential_name: str = "default",
+    ) -> ProviderCredentials:
+        provider = provider.lower()
+
+        if provider not in PROVIDER_CREDENTIAL_TYPES:
+            raise CredentialResolutionError(
+                provider=provider,
+                message=f"Unknown provider: {provider}. Supported: {list(PROVIDER_CREDENTIAL_TYPES.keys())}",
+                org_id=self.org_id,
+                credential_name=credential_name,
+            )
+
+        db_creds = await self._try_database(provider, credential_name)
+        if db_creds is not None:
+            logger.info(
+                "Resolved %s credentials from database for org=%s name=%s",
+                provider,
+                self.org_id,
+                credential_name,
+            )
+            return db_creds
+
+        if self.allow_env_fallback:
+            env_creds = self._try_environment(provider, credential_name)
+            if env_creds is not None:
+                logger.info(
+                    "Resolved %s credentials from environment (fallback)",
+                    provider,
+                )
+                return env_creds
+
+        env_vars = PROVIDER_ENV_VARS.get(provider, {})
+        env_var_names = ", ".join(env_vars.values())
+
+        raise CredentialResolutionError(
+            provider=provider,
+            message=(
+                f"No {provider} credentials found. "
+                f"Configure credentials via Admin API or set environment variables: {env_var_names}"
+            ),
+            org_id=self.org_id,
+            credential_name=credential_name,
+        )
+
+    async def _try_database(
+        self,
+        provider: str,
+        credential_name: str,
+    ) -> Optional[ProviderCredentials]:
+        try:
+            from dev_health_ops.api.services.settings import (
+                IntegrationCredentialsService,
+            )
+
+            svc = IntegrationCredentialsService(self.session, self.org_id)
+            cred_dict = await svc.get_decrypted_credentials(provider, credential_name)
+
+            if cred_dict is None:
+                return None
+
+            cred_type = PROVIDER_CREDENTIAL_TYPES[provider]
+            return self._build_credential(
+                cred_type,
+                cred_dict,
+                source=CredentialSource.DATABASE,
+                credential_name=credential_name,
+            )
+
+        except Exception as e:
+            logger.warning(
+                "Failed to fetch %s credentials from database: %s",
+                provider,
+                e,
+            )
+            return None
+
+    def _try_environment(
+        self,
+        provider: str,
+        credential_name: str,
+    ) -> Optional[ProviderCredentials]:
+        env_map = PROVIDER_ENV_VARS.get(provider, {})
+        if not env_map:
+            return None
+
+        cred_dict: dict[str, Any] = {}
+        for field_name, env_var in env_map.items():
+            value = os.getenv(env_var)
+            if value:
+                cred_dict[field_name] = value
+
+        if not cred_dict:
+            return None
+
+        cred_type = PROVIDER_CREDENTIAL_TYPES[provider]
+
+        try:
+            return self._build_credential(
+                cred_type,
+                cred_dict,
+                source=CredentialSource.ENVIRONMENT,
+                credential_name=credential_name,
+            )
+        except (ValueError, TypeError) as e:
+            logger.debug(
+                "Incomplete %s credentials from environment: %s",
+                provider,
+                e,
+            )
+            return None
+
+    def _build_credential(
+        self,
+        cred_type: Type[T],
+        cred_dict: dict[str, Any],
+        source: CredentialSource,
+        credential_name: str,
+    ) -> T:
+        cred_dict = {k: v for k, v in cred_dict.items() if v is not None}
+
+        cred_dict["source"] = source
+        cred_dict["credential_name"] = credential_name
+
+        return cred_type(**cred_dict)
+
+
+def resolve_credentials_sync(
+    provider: str,
+    org_id: str = "default",
+    credential_name: str = "default",
+    db_url: Optional[str] = None,
+    allow_env_fallback: bool = True,
+) -> ProviderCredentials:
+    db_url = db_url or os.getenv("DATABASE_URI") or os.getenv("DATABASE_URL")
+
+    if not db_url:
+        if allow_env_fallback:
+            resolver = _EnvOnlyResolver()
+            creds = resolver.resolve_from_env(provider, credential_name)
+            if creds is not None:
+                return creds
+
+        raise CredentialResolutionError(
+            provider=provider,
+            message=(
+                f"No database URL configured and no {provider} environment credentials found. "
+                "Set DATABASE_URI or configure provider-specific environment variables."
+            ),
+            org_id=org_id,
+            credential_name=credential_name,
+        )
+
+    async def _resolve() -> ProviderCredentials:
+        from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+        engine = create_async_engine(db_url, pool_pre_ping=True)
+        async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+        async with async_session_factory() as session:
+            resolver = CredentialResolver(
+                session=session,
+                org_id=org_id,
+                allow_env_fallback=allow_env_fallback,
+            )
+            return await resolver.resolve(provider, credential_name)
+
+    try:
+        asyncio.get_running_loop()
+        raise RuntimeError(
+            "resolve_credentials_sync cannot be called from async context. "
+            "Use CredentialResolver.resolve() instead."
+        )
+    except RuntimeError:
+        pass
+
+    return asyncio.run(_resolve())
+
+
+class _EnvOnlyResolver:
+    def resolve_from_env(
+        self,
+        provider: str,
+        credential_name: str = "default",
+    ) -> Optional[ProviderCredentials]:
+        provider = provider.lower()
+        if provider not in PROVIDER_CREDENTIAL_TYPES:
+            return None
+
+        env_map = PROVIDER_ENV_VARS.get(provider, {})
+        if not env_map:
+            return None
+
+        cred_dict: dict[str, Any] = {}
+        for field_name, env_var in env_map.items():
+            value = os.getenv(env_var)
+            if value:
+                cred_dict[field_name] = value
+
+        if not cred_dict:
+            return None
+
+        cred_type = PROVIDER_CREDENTIAL_TYPES[provider]
+
+        try:
+            cred_dict["source"] = CredentialSource.ENVIRONMENT
+            cred_dict["credential_name"] = credential_name
+            return cred_type(**cred_dict)
+        except (ValueError, TypeError):
+            return None

--- a/src/dev_health_ops/credentials/types.py
+++ b/src/dev_health_ops/credentials/types.py
@@ -1,0 +1,140 @@
+"""Credential type definitions for provider authentication.
+
+Defines typed dataclasses for each supported provider's credentials,
+ensuring type safety and clear documentation of required fields.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+class CredentialSource(str, Enum):
+    """Source of the resolved credentials."""
+
+    DATABASE = "database"
+    ENVIRONMENT = "environment"
+
+
+@dataclass(kw_only=True)
+class ProviderCredentials:
+    """Base class for provider credentials.
+
+    All provider-specific credential classes inherit from this.
+    """
+
+    provider: str
+    source: CredentialSource
+    credential_name: str = "default"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def is_from_db(self) -> bool:
+        """Check if credentials came from database (enterprise mode)."""
+        return self.source == CredentialSource.DATABASE
+
+    def is_from_env(self) -> bool:
+        """Check if credentials came from environment (dev/OSS mode)."""
+        return self.source == CredentialSource.ENVIRONMENT
+
+
+@dataclass
+class GitHubCredentials(ProviderCredentials):
+    """GitHub provider credentials.
+
+    Supports:
+    - Personal Access Token (token field)
+    - GitHub App authentication (app_id + private_key + installation_id)
+    """
+
+    provider: str = "github"
+    token: Optional[str] = None
+
+    app_id: Optional[str] = None
+    private_key: Optional[str] = None
+    installation_id: Optional[str] = None
+    base_url: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.token and not (self.app_id and self.private_key):
+            raise ValueError(
+                "GitHub credentials require either 'token' or 'app_id' + 'private_key'"
+            )
+
+    @property
+    def is_app_auth(self) -> bool:
+        """Check if using GitHub App authentication."""
+        return bool(self.app_id and self.private_key)
+
+
+@dataclass
+class GitLabCredentials(ProviderCredentials):
+    """GitLab provider credentials.
+
+    Supports personal access token authentication.
+    """
+
+    provider: str = "gitlab"
+    token: str = ""
+
+    base_url: str = "https://gitlab.com"
+
+    def __post_init__(self) -> None:
+        if not self.token:
+            raise ValueError("GitLab credentials require 'token'")
+
+
+@dataclass
+class JiraCredentials(ProviderCredentials):
+    """Jira/Atlassian provider credentials.
+
+    Supports API token authentication with email.
+    """
+
+    provider: str = "jira"
+    api_token: str = ""
+    email: str = ""
+    base_url: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.api_token:
+            raise ValueError("Jira credentials require 'api_token'")
+        if not self.email:
+            raise ValueError("Jira credentials require 'email'")
+        if not self.base_url:
+            raise ValueError("Jira credentials require 'base_url'")
+
+
+@dataclass
+class LinearCredentials(ProviderCredentials):
+    """Linear provider credentials.
+
+    Supports API key authentication.
+    """
+
+    provider: str = "linear"
+    api_key: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.api_key:
+            raise ValueError("Linear credentials require 'api_key'")
+
+
+@dataclass
+class AtlassianCredentials(ProviderCredentials):
+    """Atlassian Cloud credentials (GraphQL Gateway).
+
+    Used for Atlassian GraphQL API access.
+    """
+
+    provider: str = "atlassian"
+    api_token: str = ""
+    email: str = ""
+    cloud_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.api_token:
+            raise ValueError("Atlassian credentials require 'api_token'")
+        if not self.email:
+            raise ValueError("Atlassian credentials require 'email'")

--- a/src/dev_health_ops/models/audit.py
+++ b/src/dev_health_ops/models/audit.py
@@ -90,6 +90,7 @@ class AuditAction(str, Enum):
     CREDENTIAL_CREATED = "credential_created"
     CREDENTIAL_UPDATED = "credential_updated"
     CREDENTIAL_DELETED = "credential_deleted"
+    CREDENTIAL_ACCESSED = "credential_accessed"
 
     # Generic
     OTHER = "other"

--- a/tests/test_credential_resolver.py
+++ b/tests/test_credential_resolver.py
@@ -1,0 +1,638 @@
+"""Tests for the credential resolver module.
+
+Covers:
+- Database credential resolution (mocked IntegrationCredentialsService)
+- Environment variable fallback
+- Error handling when no credentials available
+- All provider credential types (GitHub, GitLab, Jira, Linear, Atlassian)
+- CredentialResolutionError messages
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev_health_ops.credentials import (
+    AtlassianCredentials,
+    CredentialResolutionError,
+    CredentialResolver,
+    CredentialSource,
+    GitHubCredentials,
+    GitLabCredentials,
+    JiraCredentials,
+    LinearCredentials,
+    resolve_credentials_sync,
+)
+
+
+# ---------------------------------------------------------------------------
+# Credential Type Validation Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubCredentials:
+    def test_valid_with_token(self):
+        creds = GitHubCredentials(
+            token="ghp_test_token",
+            source=CredentialSource.DATABASE,
+            credential_name="default",
+        )
+        assert creds.token == "ghp_test_token"
+        assert creds.is_app_auth is False
+        assert creds.is_from_db() is True
+
+    def test_valid_with_app_auth(self):
+        creds = GitHubCredentials(
+            app_id="12345",
+            private_key="-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----",
+            installation_id="67890",
+            source=CredentialSource.DATABASE,
+            credential_name="default",
+        )
+        assert creds.is_app_auth is True
+        assert creds.token is None
+
+    def test_invalid_missing_token_and_app(self):
+        with pytest.raises(ValueError, match="require either 'token' or 'app_id'"):
+            GitHubCredentials(
+                source=CredentialSource.DATABASE,
+                credential_name="default",
+            )
+
+    def test_base_url_optional(self):
+        creds = GitHubCredentials(
+            token="ghp_test",
+            base_url="https://github.example.com",
+            source=CredentialSource.ENVIRONMENT,
+            credential_name="default",
+        )
+        assert creds.base_url == "https://github.example.com"
+        assert creds.is_from_env() is True
+
+
+class TestGitLabCredentials:
+    def test_valid_credentials(self):
+        creds = GitLabCredentials(
+            token="glpat-test-token",
+            base_url="https://gitlab.example.com",
+            source=CredentialSource.DATABASE,
+            credential_name="default",
+        )
+        assert creds.token == "glpat-test-token"
+        assert creds.base_url == "https://gitlab.example.com"
+
+    def test_default_base_url(self):
+        creds = GitLabCredentials(
+            token="glpat-test",
+            source=CredentialSource.DATABASE,
+            credential_name="default",
+        )
+        assert creds.base_url == "https://gitlab.com"
+
+    def test_invalid_missing_token(self):
+        with pytest.raises(ValueError, match="require 'token'"):
+            GitLabCredentials(
+                source=CredentialSource.DATABASE,
+                credential_name="default",
+            )
+
+
+class TestJiraCredentials:
+    def test_valid_credentials(self):
+        creds = JiraCredentials(
+            api_token="test-api-token",
+            email="user@example.com",
+            base_url="https://company.atlassian.net",
+            source=CredentialSource.DATABASE,
+            credential_name="default",
+        )
+        assert creds.api_token == "test-api-token"
+        assert creds.email == "user@example.com"
+        assert creds.base_url == "https://company.atlassian.net"
+
+    def test_invalid_missing_api_token(self):
+        with pytest.raises(ValueError, match="require 'api_token'"):
+            JiraCredentials(
+                email="user@example.com",
+                base_url="https://company.atlassian.net",
+                source=CredentialSource.DATABASE,
+                credential_name="default",
+            )
+
+    def test_invalid_missing_email(self):
+        with pytest.raises(ValueError, match="require 'email'"):
+            JiraCredentials(
+                api_token="test-token",
+                base_url="https://company.atlassian.net",
+                source=CredentialSource.DATABASE,
+                credential_name="default",
+            )
+
+    def test_invalid_missing_base_url(self):
+        with pytest.raises(ValueError, match="require 'base_url'"):
+            JiraCredentials(
+                api_token="test-token",
+                email="user@example.com",
+                source=CredentialSource.DATABASE,
+                credential_name="default",
+            )
+
+
+class TestLinearCredentials:
+    def test_valid_credentials(self):
+        creds = LinearCredentials(
+            api_key="lin_api_test_key",
+            source=CredentialSource.DATABASE,
+            credential_name="default",
+        )
+        assert creds.api_key == "lin_api_test_key"
+
+    def test_invalid_missing_api_key(self):
+        with pytest.raises(ValueError, match="require 'api_key'"):
+            LinearCredentials(
+                source=CredentialSource.DATABASE,
+                credential_name="default",
+            )
+
+
+class TestAtlassianCredentials:
+    def test_valid_credentials(self):
+        creds = AtlassianCredentials(
+            api_token="atlassian-api-token",
+            email="user@example.com",
+            cloud_id="abc123-cloud-id",
+            source=CredentialSource.DATABASE,
+            credential_name="default",
+        )
+        assert creds.api_token == "atlassian-api-token"
+        assert creds.email == "user@example.com"
+        assert creds.cloud_id == "abc123-cloud-id"
+
+    def test_cloud_id_optional(self):
+        creds = AtlassianCredentials(
+            api_token="atlassian-api-token",
+            email="user@example.com",
+            source=CredentialSource.DATABASE,
+            credential_name="default",
+        )
+        assert creds.cloud_id is None
+
+    def test_invalid_missing_api_token(self):
+        with pytest.raises(ValueError, match="require 'api_token'"):
+            AtlassianCredentials(
+                email="user@example.com",
+                source=CredentialSource.DATABASE,
+                credential_name="default",
+            )
+
+    def test_invalid_missing_email(self):
+        with pytest.raises(ValueError, match="require 'email'"):
+            AtlassianCredentials(
+                api_token="test-token",
+                source=CredentialSource.DATABASE,
+                credential_name="default",
+            )
+
+
+# ---------------------------------------------------------------------------
+# CredentialResolver Async Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialResolver:
+    @pytest.fixture
+    def mock_session(self):
+        """Create a mock async session."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def resolver(self, mock_session):
+        """Create a resolver with mocked session."""
+        return CredentialResolver(
+            session=mock_session,
+            org_id="test-org",
+            allow_env_fallback=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolve_github_from_database(self, resolver):
+        """Test resolving GitHub credentials from database."""
+        mock_creds = {
+            "token": "ghp_database_token",
+            "base_url": "https://github.example.com",
+        }
+
+        with patch(
+            "dev_health_ops.api.services.settings.IntegrationCredentialsService"
+        ) as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc.get_decrypted_credentials = AsyncMock(return_value=mock_creds)
+            mock_svc_class.return_value = mock_svc
+
+            result = await resolver.resolve("github")
+
+            assert isinstance(result, GitHubCredentials)
+            assert result.token == "ghp_database_token"
+            assert result.base_url == "https://github.example.com"
+            assert result.source == CredentialSource.DATABASE
+            mock_svc.get_decrypted_credentials.assert_called_once_with(
+                "github", "default"
+            )
+
+    @pytest.mark.asyncio
+    async def test_resolve_gitlab_from_database(self, resolver):
+        """Test resolving GitLab credentials from database."""
+        mock_creds = {
+            "token": "glpat-database-token",
+            "base_url": "https://gitlab.example.com",
+        }
+
+        with patch(
+            "dev_health_ops.api.services.settings.IntegrationCredentialsService"
+        ) as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc.get_decrypted_credentials = AsyncMock(return_value=mock_creds)
+            mock_svc_class.return_value = mock_svc
+
+            result = await resolver.resolve("gitlab")
+
+            assert isinstance(result, GitLabCredentials)
+            assert result.token == "glpat-database-token"
+            assert result.source == CredentialSource.DATABASE
+
+    @pytest.mark.asyncio
+    async def test_resolve_jira_from_database(self, resolver):
+        """Test resolving Jira credentials from database."""
+        mock_creds = {
+            "api_token": "jira-api-token",
+            "email": "user@example.com",
+            "base_url": "https://company.atlassian.net",
+        }
+
+        with patch(
+            "dev_health_ops.api.services.settings.IntegrationCredentialsService"
+        ) as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc.get_decrypted_credentials = AsyncMock(return_value=mock_creds)
+            mock_svc_class.return_value = mock_svc
+
+            result = await resolver.resolve("jira")
+
+            assert isinstance(result, JiraCredentials)
+            assert result.api_token == "jira-api-token"
+            assert result.email == "user@example.com"
+            assert result.source == CredentialSource.DATABASE
+
+    @pytest.mark.asyncio
+    async def test_resolve_linear_from_database(self, resolver):
+        """Test resolving Linear credentials from database."""
+        mock_creds = {"api_key": "lin_api_database_key"}
+
+        with patch(
+            "dev_health_ops.api.services.settings.IntegrationCredentialsService"
+        ) as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc.get_decrypted_credentials = AsyncMock(return_value=mock_creds)
+            mock_svc_class.return_value = mock_svc
+
+            result = await resolver.resolve("linear")
+
+            assert isinstance(result, LinearCredentials)
+            assert result.api_key == "lin_api_database_key"
+            assert result.source == CredentialSource.DATABASE
+
+    @pytest.mark.asyncio
+    async def test_resolve_atlassian_from_database(self, resolver):
+        """Test resolving Atlassian credentials from database."""
+        mock_creds = {
+            "api_token": "atlassian-token",
+            "email": "user@example.com",
+            "cloud_id": "cloud-123",
+        }
+
+        with patch(
+            "dev_health_ops.api.services.settings.IntegrationCredentialsService"
+        ) as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc.get_decrypted_credentials = AsyncMock(return_value=mock_creds)
+            mock_svc_class.return_value = mock_svc
+
+            result = await resolver.resolve("atlassian")
+
+            assert isinstance(result, AtlassianCredentials)
+            assert result.api_token == "atlassian-token"
+            assert result.cloud_id == "cloud-123"
+            assert result.source == CredentialSource.DATABASE
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_environment(self, resolver):
+        """Test fallback to environment when database returns None."""
+        with patch(
+            "dev_health_ops.api.services.settings.IntegrationCredentialsService"
+        ) as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc.get_decrypted_credentials = AsyncMock(return_value=None)
+            mock_svc_class.return_value = mock_svc
+
+            with patch.dict(os.environ, {"GITHUB_TOKEN": "ghp_env_token"}, clear=False):
+                result = await resolver.resolve("github")
+
+                assert isinstance(result, GitHubCredentials)
+                assert result.token == "ghp_env_token"
+                assert result.source == CredentialSource.ENVIRONMENT
+
+    @pytest.mark.asyncio
+    async def test_fallback_disabled(self, mock_session):
+        """Test error when env fallback is disabled and DB has no creds."""
+        resolver = CredentialResolver(
+            session=mock_session,
+            org_id="test-org",
+            allow_env_fallback=False,
+        )
+
+        with patch(
+            "dev_health_ops.api.services.settings.IntegrationCredentialsService"
+        ) as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc.get_decrypted_credentials = AsyncMock(return_value=None)
+            mock_svc_class.return_value = mock_svc
+
+            with pytest.raises(CredentialResolutionError) as exc_info:
+                await resolver.resolve("github")
+
+            assert exc_info.value.provider == "github"
+            assert "No github credentials found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_error_no_credentials_found(self, resolver):
+        """Test error when neither DB nor env has credentials."""
+        with patch(
+            "dev_health_ops.api.services.settings.IntegrationCredentialsService"
+        ) as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc.get_decrypted_credentials = AsyncMock(return_value=None)
+            mock_svc_class.return_value = mock_svc
+
+            env_patch = {
+                "GITHUB_TOKEN": "",
+                "GITHUB_URL": "",
+            }
+            with patch.dict(os.environ, env_patch, clear=False):
+                os.environ.pop("GITHUB_TOKEN", None)
+                os.environ.pop("GITHUB_URL", None)
+
+                with pytest.raises(CredentialResolutionError) as exc_info:
+                    await resolver.resolve("github")
+
+                assert exc_info.value.provider == "github"
+                assert exc_info.value.org_id == "test-org"
+                assert "GITHUB_TOKEN" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_error_unknown_provider(self, resolver):
+        """Test error for unknown provider."""
+        with pytest.raises(CredentialResolutionError) as exc_info:
+            await resolver.resolve("unknown_provider")
+
+        assert exc_info.value.provider == "unknown_provider"
+        assert "Unknown provider" in str(exc_info.value)
+        assert "github" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_custom_credential_name(self, resolver):
+        """Test resolving with custom credential name."""
+        mock_creds = {"token": "ghp_custom_token"}
+
+        with patch(
+            "dev_health_ops.api.services.settings.IntegrationCredentialsService"
+        ) as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc.get_decrypted_credentials = AsyncMock(return_value=mock_creds)
+            mock_svc_class.return_value = mock_svc
+
+            result = await resolver.resolve("github", credential_name="production")
+
+            assert result.credential_name == "production"
+            mock_svc.get_decrypted_credentials.assert_called_once_with(
+                "github", "production"
+            )
+
+    @pytest.mark.asyncio
+    async def test_database_error_falls_back_to_env(self, resolver):
+        """Test that database errors gracefully fall back to env."""
+        with patch(
+            "dev_health_ops.api.services.settings.IntegrationCredentialsService"
+        ) as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc.get_decrypted_credentials = AsyncMock(
+                side_effect=Exception("DB connection failed")
+            )
+            mock_svc_class.return_value = mock_svc
+
+            with patch.dict(
+                os.environ, {"GITHUB_TOKEN": "ghp_fallback_token"}, clear=False
+            ):
+                result = await resolver.resolve("github")
+
+                assert isinstance(result, GitHubCredentials)
+                assert result.token == "ghp_fallback_token"
+                assert result.source == CredentialSource.ENVIRONMENT
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_provider(self, resolver):
+        """Test that provider names are case-insensitive."""
+        mock_creds = {"token": "ghp_test"}
+
+        with patch(
+            "dev_health_ops.api.services.settings.IntegrationCredentialsService"
+        ) as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc.get_decrypted_credentials = AsyncMock(return_value=mock_creds)
+            mock_svc_class.return_value = mock_svc
+
+            result = await resolver.resolve("GITHUB")
+
+            assert isinstance(result, GitHubCredentials)
+
+    @pytest.mark.asyncio
+    async def test_github_app_auth_from_database(self, resolver):
+        """Test resolving GitHub App credentials from database."""
+        mock_creds = {
+            "app_id": "12345",
+            "private_key": "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----",
+            "installation_id": "67890",
+        }
+
+        with patch(
+            "dev_health_ops.api.services.settings.IntegrationCredentialsService"
+        ) as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc.get_decrypted_credentials = AsyncMock(return_value=mock_creds)
+            mock_svc_class.return_value = mock_svc
+
+            result = await resolver.resolve("github")
+
+            assert isinstance(result, GitHubCredentials)
+            assert result.is_app_auth is True
+            assert result.app_id == "12345"
+            assert result.installation_id == "67890"
+
+
+# ---------------------------------------------------------------------------
+# resolve_credentials_sync Tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCredentialsSync:
+    def test_env_only_when_no_db_url(self):
+        """Test env-only resolution when no DATABASE_URI configured."""
+        env_patch = {
+            "DATABASE_URI": "",
+            "DATABASE_URL": "",
+            "GITHUB_TOKEN": "ghp_env_only_token",
+        }
+
+        with patch.dict(os.environ, env_patch, clear=False):
+            os.environ.pop("DATABASE_URI", None)
+            os.environ.pop("DATABASE_URL", None)
+
+            result = resolve_credentials_sync("github")
+
+            assert isinstance(result, GitHubCredentials)
+            assert result.token == "ghp_env_only_token"
+            assert result.source == CredentialSource.ENVIRONMENT
+
+    def test_error_no_db_and_no_env(self):
+        """Test error when no DB URL and no env credentials."""
+        env_patch = {
+            "DATABASE_URI": "",
+            "DATABASE_URL": "",
+            "GITHUB_TOKEN": "",
+        }
+
+        with patch.dict(os.environ, env_patch, clear=False):
+            os.environ.pop("DATABASE_URI", None)
+            os.environ.pop("DATABASE_URL", None)
+            os.environ.pop("GITHUB_TOKEN", None)
+
+            with pytest.raises(CredentialResolutionError) as exc_info:
+                resolve_credentials_sync("github")
+
+            assert "No database URL configured" in str(exc_info.value)
+            assert "DATABASE_URI" in str(exc_info.value)
+
+    def test_env_only_jira_requires_all_fields(self):
+        """Test that Jira env-only resolution requires all fields."""
+        env_patch = {
+            "DATABASE_URI": "",
+            "JIRA_API_TOKEN": "jira-token",
+            "JIRA_EMAIL": "user@example.com",
+        }
+
+        with patch.dict(os.environ, env_patch, clear=False):
+            os.environ.pop("DATABASE_URI", None)
+            os.environ.pop("DATABASE_URL", None)
+            os.environ.pop("JIRA_BASE_URL", None)
+
+            with pytest.raises(CredentialResolutionError):
+                resolve_credentials_sync("jira")
+
+    def test_env_only_jira_with_all_fields(self):
+        """Test successful Jira env-only resolution."""
+        env_patch = {
+            "DATABASE_URI": "",
+            "JIRA_API_TOKEN": "jira-token",
+            "JIRA_EMAIL": "user@example.com",
+            "JIRA_BASE_URL": "https://company.atlassian.net",
+        }
+
+        with patch.dict(os.environ, env_patch, clear=False):
+            os.environ.pop("DATABASE_URI", None)
+            os.environ.pop("DATABASE_URL", None)
+
+            result = resolve_credentials_sync("jira")
+
+            assert isinstance(result, JiraCredentials)
+            assert result.api_token == "jira-token"
+            assert result.email == "user@example.com"
+            assert result.source == CredentialSource.ENVIRONMENT
+
+    def test_respects_allow_env_fallback_false(self):
+        """Test that allow_env_fallback=False is respected."""
+        env_patch = {
+            "DATABASE_URI": "",
+            "GITHUB_TOKEN": "ghp_should_not_use",
+        }
+
+        with patch.dict(os.environ, env_patch, clear=False):
+            os.environ.pop("DATABASE_URI", None)
+            os.environ.pop("DATABASE_URL", None)
+
+            with pytest.raises(CredentialResolutionError):
+                resolve_credentials_sync("github", allow_env_fallback=False)
+
+
+# ---------------------------------------------------------------------------
+# CredentialResolutionError Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialResolutionError:
+    def test_error_contains_provider_info(self):
+        error = CredentialResolutionError(
+            provider="github",
+            message="Test error message",
+            org_id="my-org",
+            credential_name="production",
+        )
+
+        assert error.provider == "github"
+        assert error.org_id == "my-org"
+        assert error.credential_name == "production"
+        assert "Test error message" in str(error)
+
+    def test_error_default_values(self):
+        error = CredentialResolutionError(
+            provider="gitlab",
+            message="Test",
+        )
+
+        assert error.org_id == "default"
+        assert error.credential_name == "default"
+
+
+# ---------------------------------------------------------------------------
+# ProviderCredentials Base Class Tests
+# ---------------------------------------------------------------------------
+
+
+class TestProviderCredentials:
+    def test_is_from_db(self):
+        creds = GitHubCredentials(
+            token="test",
+            source=CredentialSource.DATABASE,
+            credential_name="default",
+        )
+        assert creds.is_from_db() is True
+        assert creds.is_from_env() is False
+
+    def test_is_from_env(self):
+        creds = GitHubCredentials(
+            token="test",
+            source=CredentialSource.ENVIRONMENT,
+            credential_name="default",
+        )
+        assert creds.is_from_db() is False
+        assert creds.is_from_env() is True
+
+    def test_extra_field(self):
+        creds = GitHubCredentials(
+            token="test",
+            source=CredentialSource.DATABASE,
+            credential_name="default",
+            extra={"custom_field": "custom_value"},
+        )
+        assert creds.extra["custom_field"] == "custom_value"


### PR DESCRIPTION
## Summary

Implements `CredentialResolver` for workers to resolve provider credentials from database (enterprise) or environment variables (dev/OSS fallback).

- Add `credentials` module with typed dataclasses for each provider (GitHub, GitLab, Jira, Linear, Atlassian)
- `CredentialResolver` async class for API/async contexts
- `resolve_credentials_sync()` wrapper for Celery workers
- Database-first resolution with env var fallback
- Add `CREDENTIAL_ACCESSED` audit action
- Comprehensive unit tests (40 tests covering all providers)

## Usage

```python
# Async context (API, async workers)
async with get_async_session() as session:
    resolver = CredentialResolver(session, org_id="my-org")
    creds = await resolver.resolve("github")
    token = creds.token

# Sync context (Celery workers, CLI)
from dev_health_ops.credentials import resolve_credentials_sync
creds = resolve_credentials_sync("github", org_id="my-org", db_url=db_url)
```

## Test Results

```
40 passed in 0.67s
All checks passed! (ruff)
```

Closes #341