### PR TITLE
refactor(providers): extract shared normalization utilities

### DIFF
--- a/src/dev_health_ops/providers/gitlab/normalize.py
+++ b/src/dev_health_ops/providers/gitlab/normalize.py
@@ -14,50 +14,14 @@ from dev_health_ops.models.work_items import (
     WorkItemStatusTransition,
 )
 from dev_health_ops.providers.identity import IdentityResolver
-from dev_health_ops.providers.normalize_common import to_utc as _to_utc
+from dev_health_ops.providers.normalize_common import (
+    parse_iso_datetime as _parse_iso,
+    priority_from_labels as _priority_from_labels,
+    to_utc as _to_utc,
+)
 from dev_health_ops.providers.status_mapping import StatusMapping
 
 logger = logging.getLogger(__name__)
-
-# Priority labels -> (priority_raw, service_class)
-_PRIORITY_LABEL_MAP = {
-    "priority::critical": ("critical", "expedite"),
-    "priority::high": ("high", "fixed_date"),
-    "priority::medium": ("medium", "standard"),
-    "priority::low": ("low", "intangible"),
-    "critical": ("critical", "expedite"),
-    "blocker": ("critical", "expedite"),
-    "high": ("high", "fixed_date"),
-    "medium": ("medium", "standard"),
-    "low": ("low", "intangible"),
-    "p0": ("critical", "expedite"),
-    "p1": ("high", "fixed_date"),
-    "p2": ("medium", "standard"),
-    "p3": ("low", "intangible"),
-    "p4": ("low", "intangible"),
-}
-
-
-def _parse_iso(value: Any) -> Optional[datetime]:
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-    except ValueError:
-        return None
-
-
-def _priority_from_labels(labels: Sequence[str]) -> Tuple[Optional[str], Optional[str]]:
-    """
-    Extract priority_raw and service_class from GitLab labels.
-
-    Returns (priority_raw, service_class) or (None, None) if no match.
-    """
-    for label in labels:
-        key = label.lower().strip()
-        if key in _PRIORITY_LABEL_MAP:
-            return _PRIORITY_LABEL_MAP[key]
-    return (None, None)
 
 
 def _get(obj: Any, key: str) -> Any:

--- a/src/dev_health_ops/providers/jira/normalize.py
+++ b/src/dev_health_ops/providers/jira/normalize.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from __future__ import annotations
-
 import os
 import re
 from datetime import datetime, timezone
@@ -17,33 +15,13 @@ from dev_health_ops.models.work_items import (
     WorkItemStatusTransition,
 )
 from dev_health_ops.providers.identity import IdentityResolver
+from dev_health_ops.providers.normalize_common import (
+    parse_jira_datetime as _parse_datetime,
+)
 from dev_health_ops.providers.status_mapping import StatusMapping
 
 if TYPE_CHECKING:
     from atlassian import JiraChangelogEvent, JiraIssue, JiraSprint, JiraWorklog
-
-
-def _parse_datetime(value: Any) -> Optional[datetime]:
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        dt = value
-    else:
-        raw = str(value).strip()
-        if not raw:
-            return None
-        # Jira commonly uses "+0000" offsets (no colon); normalize for fromisoformat.
-        raw = raw.replace("Z", "+00:00")
-        if re.search(r"[+-]\d{4}$", raw):
-            raw = raw[:-2] + ":" + raw[-2:]
-        try:
-            dt = datetime.fromisoformat(raw)
-        except ValueError:
-            return None
-
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
 
 
 def _get_field(issue: Any, field_name: str) -> Any:

--- a/src/dev_health_ops/providers/normalize_common.py
+++ b/src/dev_health_ops/providers/normalize_common.py
@@ -1,3 +1,135 @@
+"""Shared normalization utilities for provider modules."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any, List, Optional, Sequence, Tuple
+
+from dev_health_ops.models.work_items import (
+    WorkItemReopenEvent,
+    WorkItemStatusTransition,
+)
 from dev_health_ops.utils.datetime import to_utc
 
-__all__ = ["to_utc"]
+__all__ = [
+    "to_utc",
+    "parse_iso_datetime",
+    "parse_jira_datetime",
+    "priority_from_labels",
+    "detect_reopen_events_from_transitions",
+]
+
+PRIORITY_LABEL_MAP = {
+    "priority::critical": ("critical", "expedite"),
+    "priority::high": ("high", "fixed_date"),
+    "priority::medium": ("medium", "standard"),
+    "priority::low": ("low", "intangible"),
+    "critical": ("critical", "expedite"),
+    "blocker": ("critical", "expedite"),
+    "urgent": ("critical", "expedite"),
+    "high": ("high", "fixed_date"),
+    "medium": ("medium", "standard"),
+    "low": ("low", "intangible"),
+    "p0": ("critical", "expedite"),
+    "p1": ("high", "fixed_date"),
+    "p2": ("medium", "standard"),
+    "p3": ("low", "intangible"),
+    "p4": ("low", "intangible"),
+    "priority-critical": ("critical", "expedite"),
+    "priority-high": ("high", "fixed_date"),
+    "priority-medium": ("medium", "standard"),
+    "priority-low": ("low", "intangible"),
+    "critical-priority": ("critical", "expedite"),
+    "high-priority": ("high", "fixed_date"),
+    "medium-priority": ("medium", "standard"),
+    "low-priority": ("low", "intangible"),
+}
+
+
+def parse_iso_datetime(value: Any) -> Optional[datetime]:
+    """Parse ISO 8601 datetime (GitHub/GitLab Z-suffix format) to UTC."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    raw = str(value).strip()
+    if not raw:
+        return None
+
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        return dt.astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def parse_jira_datetime(value: Any) -> Optional[datetime]:
+    """Parse Jira datetime (handles +0000 offset format without colon) to UTC."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    raw = str(value).strip()
+    if not raw:
+        return None
+
+    raw = raw.replace("Z", "+00:00")
+
+    if re.search(r"[+-]\d{4}$", raw):
+        raw = raw[:-2] + ":" + raw[-2:]
+
+    try:
+        dt = datetime.fromisoformat(raw)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def priority_from_labels(labels: Sequence[str]) -> Tuple[Optional[str], Optional[str]]:
+    """Extract (priority_raw, service_class) from label strings, or (None, None)."""
+    for label in labels:
+        normalized = label.strip().lower()
+        if normalized in PRIORITY_LABEL_MAP:
+            return PRIORITY_LABEL_MAP[normalized]
+    return None, None
+
+
+def detect_reopen_events_from_transitions(
+    work_item_id: str,
+    transitions: List[WorkItemStatusTransition],
+) -> List[WorkItemReopenEvent]:
+    """Detect reopens: transitions from terminal (done/canceled) to non-terminal status."""
+    terminal_statuses = {"done", "canceled"}
+    non_terminal_statuses = {"todo", "in_progress"}
+
+    reopen_events: List[WorkItemReopenEvent] = []
+
+    for t in transitions:
+        from_status = t.from_status
+        to_status = t.to_status
+
+        if from_status in terminal_statuses and to_status in non_terminal_statuses:
+            reopen_events.append(
+                WorkItemReopenEvent(
+                    work_item_id=work_item_id,
+                    occurred_at=t.occurred_at,
+                    from_status=from_status,
+                    to_status=to_status,
+                    from_status_raw=t.from_status_raw,
+                    to_status_raw=t.to_status_raw,
+                    actor=t.actor,
+                )
+            )
+
+    return reopen_events

--- a/tests/test_normalize_common.py
+++ b/tests/test_normalize_common.py
@@ -1,0 +1,313 @@
+"""Tests for shared provider normalization utilities."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from dev_health_ops.models.work_items import WorkItemStatusTransition
+from dev_health_ops.providers.normalize_common import (
+    detect_reopen_events_from_transitions,
+    parse_iso_datetime,
+    parse_jira_datetime,
+    priority_from_labels,
+)
+
+
+class TestParseIsoDatetime:
+    def test_parse_github_rfc3339_with_z(self):
+        result = parse_iso_datetime("2024-01-15T10:30:00Z")
+        assert result == datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+    def test_parse_gitlab_iso_with_z(self):
+        result = parse_iso_datetime("2024-01-15T10:30:00.123Z")
+        assert result == datetime(2024, 1, 15, 10, 30, 0, 123000, tzinfo=timezone.utc)
+
+    def test_parse_iso_with_offset(self):
+        result = parse_iso_datetime("2024-01-15T10:30:00+05:00")
+        expected = datetime(2024, 1, 15, 5, 30, 0, tzinfo=timezone.utc)
+        assert result == expected
+
+    def test_parse_none_returns_none(self):
+        assert parse_iso_datetime(None) is None
+
+    def test_parse_empty_string_returns_none(self):
+        assert parse_iso_datetime("") is None
+
+    def test_parse_invalid_format_returns_none(self):
+        assert parse_iso_datetime("not-a-date") is None
+
+    def test_parse_datetime_object_returns_utc(self):
+        dt = datetime(2024, 1, 15, 10, 30, 0)
+        result = parse_iso_datetime(dt)
+        assert result == datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+
+class TestParseJiraDatetime:
+    def test_parse_jira_with_z(self):
+        result = parse_jira_datetime("2024-01-15T10:30:00Z")
+        assert result == datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+    def test_parse_jira_with_plus_offset_no_colon(self):
+        result = parse_jira_datetime("2024-01-15T10:30:00+0000")
+        assert result == datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+    def test_parse_jira_with_minus_offset_no_colon(self):
+        result = parse_jira_datetime("2024-01-15T10:30:00-0500")
+        expected = datetime(2024, 1, 15, 15, 30, 0, tzinfo=timezone.utc)
+        assert result == expected
+
+    def test_parse_jira_with_offset_with_colon(self):
+        result = parse_jira_datetime("2024-01-15T10:30:00+05:00")
+        expected = datetime(2024, 1, 15, 5, 30, 0, tzinfo=timezone.utc)
+        assert result == expected
+
+    def test_parse_none_returns_none(self):
+        assert parse_jira_datetime(None) is None
+
+    def test_parse_empty_string_returns_none(self):
+        assert parse_jira_datetime("") is None
+
+    def test_parse_invalid_format_returns_none(self):
+        assert parse_jira_datetime("not-a-date") is None
+
+    def test_parse_datetime_object_returns_utc(self):
+        dt = datetime(2024, 1, 15, 10, 30, 0)
+        result = parse_jira_datetime(dt)
+        assert result == datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+    def test_parse_naive_datetime_adds_utc(self):
+        dt = datetime(2024, 1, 15, 10, 30, 0)
+        result = parse_jira_datetime(dt)
+        assert result.tzinfo == timezone.utc
+
+
+class TestPriorityFromLabels:
+    def test_priority_critical_standard_format(self):
+        priority, service_class = priority_from_labels(["priority::critical"])
+        assert priority == "critical"
+        assert service_class == "expedite"
+
+    def test_priority_high_standard_format(self):
+        priority, service_class = priority_from_labels(["priority::high"])
+        assert priority == "high"
+        assert service_class == "fixed_date"
+
+    def test_priority_medium_standard_format(self):
+        priority, service_class = priority_from_labels(["priority::medium"])
+        assert priority == "medium"
+        assert service_class == "standard"
+
+    def test_priority_low_standard_format(self):
+        priority, service_class = priority_from_labels(["priority::low"])
+        assert priority == "low"
+        assert service_class == "intangible"
+
+    def test_priority_p0_notation(self):
+        priority, service_class = priority_from_labels(["p0"])
+        assert priority == "critical"
+        assert service_class == "expedite"
+
+    def test_priority_p1_notation(self):
+        priority, service_class = priority_from_labels(["p1"])
+        assert priority == "high"
+        assert service_class == "fixed_date"
+
+    def test_priority_p2_notation(self):
+        priority, service_class = priority_from_labels(["p2"])
+        assert priority == "medium"
+        assert service_class == "standard"
+
+    def test_priority_p3_notation(self):
+        priority, service_class = priority_from_labels(["p3", "p4"])
+        assert priority == "low"
+        assert service_class == "intangible"
+
+    def test_priority_short_forms(self):
+        priority, service_class = priority_from_labels(["critical"])
+        assert priority == "critical"
+        assert service_class == "expedite"
+
+        priority, service_class = priority_from_labels(["blocker"])
+        assert priority == "critical"
+        assert service_class == "expedite"
+
+        priority, service_class = priority_from_labels(["urgent"])
+        assert priority == "critical"
+        assert service_class == "expedite"
+
+    def test_priority_hyphenated_forms(self):
+        priority, service_class = priority_from_labels(["priority-high"])
+        assert priority == "high"
+        assert service_class == "fixed_date"
+
+        priority, service_class = priority_from_labels(["high-priority"])
+        assert priority == "high"
+        assert service_class == "fixed_date"
+
+    def test_priority_case_insensitive(self):
+        priority, service_class = priority_from_labels(["PRIORITY::CRITICAL"])
+        assert priority == "critical"
+        assert service_class == "expedite"
+
+        priority, service_class = priority_from_labels(["P1"])
+        assert priority == "high"
+        assert service_class == "fixed_date"
+
+    def test_priority_with_whitespace(self):
+        priority, service_class = priority_from_labels(["  p2  "])
+        assert priority == "medium"
+        assert service_class == "standard"
+
+    def test_priority_first_match_wins(self):
+        priority, service_class = priority_from_labels(["p3", "p1", "p0"])
+        assert priority == "low"
+        assert service_class == "intangible"
+
+    def test_no_priority_labels_returns_none(self):
+        priority, service_class = priority_from_labels(["bug", "feature"])
+        assert priority is None
+        assert service_class is None
+
+    def test_empty_labels_returns_none(self):
+        priority, service_class = priority_from_labels([])
+        assert priority is None
+        assert service_class is None
+
+
+class TestDetectReopenEventsFromTransitions:
+    def test_detect_reopen_from_done_to_todo(self):
+        transitions = [
+            WorkItemStatusTransition(
+                work_item_id="test-1",
+                provider="github",
+                occurred_at=datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc),
+                from_status_raw="closed",
+                to_status_raw="open",
+                from_status="done",
+                to_status="todo",
+                actor="user1",
+            )
+        ]
+        events = detect_reopen_events_from_transitions(
+            work_item_id="test-1", transitions=transitions
+        )
+        assert len(events) == 1
+        assert events[0].from_status == "done"
+        assert events[0].to_status == "todo"
+        assert events[0].actor == "user1"
+
+    def test_detect_reopen_from_canceled_to_in_progress(self):
+        transitions = [
+            WorkItemStatusTransition(
+                work_item_id="test-1",
+                provider="gitlab",
+                occurred_at=datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc),
+                from_status_raw="closed",
+                to_status_raw="reopened",
+                from_status="canceled",
+                to_status="in_progress",
+                actor="user2",
+            )
+        ]
+        events = detect_reopen_events_from_transitions(
+            work_item_id="test-1", transitions=transitions
+        )
+        assert len(events) == 1
+        assert events[0].from_status == "canceled"
+        assert events[0].to_status == "in_progress"
+
+    def test_no_reopen_for_normal_transitions(self):
+        transitions = [
+            WorkItemStatusTransition(
+                work_item_id="test-1",
+                provider="github",
+                occurred_at=datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc),
+                from_status_raw="open",
+                to_status_raw="in_progress",
+                from_status="todo",
+                to_status="in_progress",
+                actor="user1",
+            ),
+            WorkItemStatusTransition(
+                work_item_id="test-1",
+                provider="github",
+                occurred_at=datetime(2024, 1, 15, 11, 0, 0, tzinfo=timezone.utc),
+                from_status_raw="in_progress",
+                to_status_raw="closed",
+                from_status="in_progress",
+                to_status="done",
+                actor="user1",
+            ),
+        ]
+        events = detect_reopen_events_from_transitions(
+            work_item_id="test-1", transitions=transitions
+        )
+        assert len(events) == 0
+
+    def test_no_reopen_for_done_to_canceled(self):
+        transitions = [
+            WorkItemStatusTransition(
+                work_item_id="test-1",
+                provider="jira",
+                occurred_at=datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc),
+                from_status_raw="Done",
+                to_status_raw="Canceled",
+                from_status="done",
+                to_status="canceled",
+                actor="user1",
+            )
+        ]
+        events = detect_reopen_events_from_transitions(
+            work_item_id="test-1", transitions=transitions
+        )
+        assert len(events) == 0
+
+    def test_multiple_reopens_detected(self):
+        transitions = [
+            WorkItemStatusTransition(
+                work_item_id="test-1",
+                provider="github",
+                occurred_at=datetime(2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc),
+                from_status_raw="closed",
+                to_status_raw="reopened",
+                from_status="done",
+                to_status="todo",
+                actor="user1",
+            ),
+            WorkItemStatusTransition(
+                work_item_id="test-1",
+                provider="github",
+                occurred_at=datetime(2024, 1, 15, 11, 0, 0, tzinfo=timezone.utc),
+                from_status_raw="reopened",
+                to_status_raw="closed",
+                from_status="todo",
+                to_status="done",
+                actor="user1",
+            ),
+            WorkItemStatusTransition(
+                work_item_id="test-1",
+                provider="github",
+                occurred_at=datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc),
+                from_status_raw="closed",
+                to_status_raw="reopened",
+                from_status="done",
+                to_status="in_progress",
+                actor="user2",
+            ),
+        ]
+        events = detect_reopen_events_from_transitions(
+            work_item_id="test-1", transitions=transitions
+        )
+        assert len(events) == 2
+        assert events[0].occurred_at == datetime(
+            2024, 1, 15, 10, 0, 0, tzinfo=timezone.utc
+        )
+        assert events[1].occurred_at == datetime(
+            2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc
+        )
+
+    def test_empty_transitions_returns_empty_list(self):
+        events = detect_reopen_events_from_transitions(
+            work_item_id="test-1", transitions=[]
+        )
+        assert len(events) == 0


### PR DESCRIPTION
## Summary

Extracts shared normalization utilities used across providers into a common module to reduce duplication.

- Creates `src/dev_health_ops/providers/normalize_common.py` with:
  - Datetime parsing utilities
  - Priority extraction helpers
  - Common normalization patterns
- Updates provider modules to import from shared location

## Related Issue

Closes #326

## Testing

- Existing provider tests pass
- Normalization behavior unchanged