### PR TITLE
fix(api): support HEAD method on /health endpoint for wget --spider

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,12 @@
 FROM python:3.14-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+  PYTHONUNBUFFERED=1
 
 WORKDIR /build
 
 COPY . .
-RUN apt update && apt install -y build-essential git
+RUN apt update && apt install -y build-essential git wget
 
 ARG SETUPTOOLS_SCM_PRETEND_VERSION
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -322,7 +322,7 @@ app.include_router(admin_router)
 app.include_router(auth_router)
 
 
-@app.get("/health", response_model=HealthResponse)
+@app.api_route("/health", methods=["GET", "HEAD"], response_model=HealthResponse)
 async def health() -> HealthResponse | JSONResponse:
     services = {}
     required_services = []


### PR DESCRIPTION
## Summary

- Fix `/health` endpoint returning 405 for HEAD requests, breaking `wget --spider` health checks
- Add wget to Dockerfile for container-based health checks

## Problem

Docker Compose and Kubernetes health checks using `wget --spider` fail because the endpoint only accepted GET:

```bash
wget --spider http://localhost:8000/health
# HTTP request sent, awaiting response... 405 Method Not Allowed
```

## Solution

Use `@app.api_route()` with both methods instead of `@app.get()`:

```python
@app.api_route("/health", methods=["GET", "HEAD"], response_model=HealthResponse)
```

FastAPI automatically handles HEAD by returning headers without body.

Fixes #353