### PR TITLE
feat: per-org feature gating for SaaS multi-tenancy

### DIFF
--- a/src/dev_health_ops/licensing/gating.py
+++ b/src/dev_health_ops/licensing/gating.py
@@ -313,7 +313,39 @@ def get_license_manager() -> LicenseManager:
     return LicenseManager.get_instance()
 
 
-def get_entitlements() -> dict:
+def get_entitlements(org_id: str | None = None) -> dict:
+    if org_id is not None:
+        try:
+            org_uuid = uuid.UUID(org_id)
+            from dev_health_ops.db import get_postgres_session_sync
+            from dev_health_ops.api.services.licensing import (
+                FeatureService,
+                TierLimitService,
+            )
+
+            with get_postgres_session_sync() as session:
+                limit_svc = TierLimitService(session)
+                limits = limit_svc.get_all_limits(org_uuid)
+
+                feature_svc = FeatureService(session)
+                features = {}
+                for feat_key in DEFAULT_FEATURES.get(LicenseTier.ENTERPRISE, {}).keys():
+                    features[feat_key] = feature_svc.has_feature(org_uuid, feat_key)
+
+                return {
+                    "tier": "unknown",
+                    "features": features,
+                    "limits": limits,
+                    "is_licensed": True,
+                    "in_grace_period": False,
+                }
+        except Exception:
+            logger.debug(
+                "DB entitlements check failed for org '%s', falling back",
+                org_id,
+                exc_info=True,
+            )
+
     manager = get_license_manager()
     tier = manager.tier
 
@@ -337,7 +369,63 @@ def get_entitlements() -> dict:
     }
 
 
-def has_feature(feature: str, *, log_denial: bool = True) -> bool:
+def _check_feature_for_org(org_id: str, feature: str) -> bool:
+    """Check feature access for a specific org using the DB-backed FeatureService.
+
+    Used in SaaS mode where each org has its own tier in the database.
+    Falls back to global LicenseManager check if the DB query fails.
+    """
+    try:
+        org_uuid = uuid.UUID(org_id)
+    except (ValueError, AttributeError):
+        logger.debug(
+            "Invalid org_id '%s' for feature check, falling back to global", org_id
+        )
+        return has_feature(feature, log_denial=True)
+
+    try:
+        from dev_health_ops.db import get_postgres_session_sync
+        from dev_health_ops.api.services.licensing import FeatureService
+
+        with get_postgres_session_sync() as session:
+            feature_svc = FeatureService(session)
+            access = feature_svc.check_feature_access(org_uuid, feature)
+            if not access.allowed:
+                audit_logger = get_license_audit_logger()
+                audit_logger.log_feature_access_denied(
+                    feature=feature,
+                    current_tier="unknown",
+                    required_tier=None,
+                )
+            return access.allowed
+    except Exception:
+        logger.debug(
+            "DB feature check failed for org '%s', falling back to global",
+            org_id,
+            exc_info=True,
+        )
+        return has_feature(feature, log_denial=True)
+
+
+def _extract_org_id(args: tuple, kwargs: dict) -> str | None:
+    """Extract org_id from function arguments.
+
+    Looks for org_id in kwargs (from FastAPI Depends injection).
+    """
+    return kwargs.get("org_id")
+
+
+def has_feature(
+    feature: str, *, org_id: str | None = None, log_denial: bool = True
+) -> bool:
+    """Check if a feature is available.
+
+    In SaaS mode (org_id provided), checks the org's tier in the database.
+    In self-hosted mode (no org_id), checks the global LicenseManager singleton.
+    """
+    if org_id is not None:
+        return _check_feature_for_org(org_id, feature)
+
     manager = get_license_manager()
 
     if manager.payload:
@@ -416,37 +504,33 @@ def require_feature(
     required_tier: str | None = None,
     raise_http: bool = True,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    def _deny(org_id: str | None) -> None:
+        current_tier = get_license_manager().tier.value
+        if raise_http:
+            raise HTTPException(
+                status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                detail={
+                    "error": "feature_not_licensed",
+                    "feature": feature,
+                    "required_tier": required_tier,
+                    "current_tier": current_tier,
+                },
+            )
+        raise FeatureNotLicensedError(feature, required_tier)
+
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @functools.wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            if not has_feature(feature):
-                if raise_http:
-                    raise HTTPException(
-                        status_code=status.HTTP_402_PAYMENT_REQUIRED,
-                        detail={
-                            "error": "feature_not_licensed",
-                            "feature": feature,
-                            "required_tier": required_tier,
-                            "current_tier": get_license_manager().tier.value,
-                        },
-                    )
-                raise FeatureNotLicensedError(feature, required_tier)
+            org_id = _extract_org_id(args, kwargs)
+            if not has_feature(feature, org_id=org_id):
+                _deny(org_id)
             return func(*args, **kwargs)
 
         @functools.wraps(func)
         async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            if not has_feature(feature):
-                if raise_http:
-                    raise HTTPException(
-                        status_code=status.HTTP_402_PAYMENT_REQUIRED,
-                        detail={
-                            "error": "feature_not_licensed",
-                            "feature": feature,
-                            "required_tier": required_tier,
-                            "current_tier": get_license_manager().tier.value,
-                        },
-                    )
-                raise FeatureNotLicensedError(feature, required_tier)
+            org_id = _extract_org_id(args, kwargs)
+            if not has_feature(feature, org_id=org_id):
+                _deny(org_id)
             return await func(*args, **kwargs)
 
         import inspect

--- a/tests/test_per_org_gating.py
+++ b/tests/test_per_org_gating.py
@@ -1,0 +1,230 @@
+"""Tests for per-org feature gating (SaaS mode).
+
+Validates that require_feature and has_feature correctly delegate to
+the DB-backed FeatureService when org_id is provided, and fall back
+to the global LicenseManager when it is not.
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from dev_health_ops.licensing.gating import (
+    LicenseManager,
+    LicenseAuditLogger,
+    _check_feature_for_org,
+    _extract_org_id,
+    has_feature,
+    require_feature,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    LicenseManager.reset()
+    LicenseAuditLogger.reset()
+    yield
+    LicenseManager.reset()
+    LicenseAuditLogger.reset()
+
+
+class TestExtractOrgId:
+    def test_returns_org_id_from_kwargs(self):
+        assert _extract_org_id((), {"org_id": "abc-123"}) == "abc-123"
+
+    def test_returns_none_when_missing(self):
+        assert _extract_org_id((), {"session": "something"}) is None
+
+    def test_returns_none_for_empty_kwargs(self):
+        assert _extract_org_id((), {}) is None
+
+
+class TestCheckFeatureForOrg:
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    @patch("dev_health_ops.api.services.licensing.FeatureService")
+    def test_allows_feature_when_service_allows(self, MockFeatureSvc, mock_session_ctx):
+        org_uuid = uuid.uuid4()
+        mock_session = MagicMock()
+        mock_session_ctx.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        MockFeatureSvc.return_value.check_feature_access.return_value = MagicMock(
+            allowed=True
+        )
+        result = _check_feature_for_org(str(org_uuid), "team_dashboard")
+
+        assert result is True
+
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    @patch("dev_health_ops.api.services.licensing.FeatureService")
+    def test_denies_feature_when_service_denies(self, MockFeatureSvc, mock_session_ctx):
+        org_uuid = uuid.uuid4()
+        mock_session = MagicMock()
+        mock_session_ctx.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        MockFeatureSvc.return_value.check_feature_access.return_value = MagicMock(
+            allowed=False, reason="Requires enterprise tier"
+        )
+        result = _check_feature_for_org(str(org_uuid), "sso")
+
+        assert result is False
+
+    def test_falls_back_to_global_on_invalid_uuid(self):
+        LicenseManager.initialize()
+        result = _check_feature_for_org("not-a-uuid", "basic_analytics")
+        assert result is True
+
+    @patch(
+        "dev_health_ops.db.get_postgres_session_sync",
+        side_effect=Exception("DB unavailable"),
+    )
+    def test_falls_back_to_global_on_db_error(self, _mock):
+        LicenseManager.initialize()
+        result = _check_feature_for_org(str(uuid.uuid4()), "basic_analytics")
+        assert result is True
+
+
+class TestHasFeatureWithOrgId:
+    def test_without_org_id_uses_global(self):
+        LicenseManager.initialize()
+        assert has_feature("basic_analytics") is True
+        assert has_feature("sso") is False
+
+    @patch("dev_health_ops.licensing.gating._check_feature_for_org")
+    def test_with_org_id_delegates_to_per_org(self, mock_check):
+        mock_check.return_value = True
+        org_id = str(uuid.uuid4())
+        result = has_feature("sso", org_id=org_id)
+        assert result is True
+        mock_check.assert_called_once_with(org_id, "sso")
+
+    @patch("dev_health_ops.licensing.gating._check_feature_for_org")
+    def test_with_org_id_denied(self, mock_check):
+        mock_check.return_value = False
+        result = has_feature("sso", org_id=str(uuid.uuid4()))
+        assert result is False
+
+
+class TestRequireFeatureWithOrgId:
+    @patch("dev_health_ops.licensing.gating._check_feature_for_org")
+    def test_sync_passes_org_id_from_kwargs(self, mock_check):
+        mock_check.return_value = True
+        org_id = str(uuid.uuid4())
+
+        @require_feature("sso", raise_http=False)
+        def my_endpoint(org_id: str = "default"):
+            return "success"
+
+        result = my_endpoint(org_id=org_id)
+        assert result == "success"
+        mock_check.assert_called_once_with(org_id, "sso")
+
+    @patch("dev_health_ops.licensing.gating._check_feature_for_org")
+    def test_sync_denied_with_org_id_raises_http(self, mock_check):
+        mock_check.return_value = False
+        org_id = str(uuid.uuid4())
+
+        @require_feature("sso", required_tier="enterprise", raise_http=True)
+        def my_endpoint(org_id: str = "default"):
+            return "success"
+
+        with pytest.raises(HTTPException) as exc_info:
+            my_endpoint(org_id=org_id)
+
+        assert exc_info.value.status_code == 402
+        assert exc_info.value.detail["feature"] == "sso"
+
+    @pytest.mark.asyncio
+    @patch("dev_health_ops.licensing.gating._check_feature_for_org")
+    async def test_async_passes_org_id_from_kwargs(self, mock_check):
+        mock_check.return_value = True
+        org_id = str(uuid.uuid4())
+
+        @require_feature("sso", raise_http=False)
+        async def my_endpoint(org_id: str = "default"):
+            return "async success"
+
+        result = await my_endpoint(org_id=org_id)
+        assert result == "async success"
+        mock_check.assert_called_once_with(org_id, "sso")
+
+    @pytest.mark.asyncio
+    @patch("dev_health_ops.licensing.gating._check_feature_for_org")
+    async def test_async_denied_with_org_id(self, mock_check):
+        mock_check.return_value = False
+        org_id = str(uuid.uuid4())
+
+        @require_feature("sso", raise_http=True)
+        async def my_endpoint(org_id: str = "default"):
+            return "async success"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await my_endpoint(org_id=org_id)
+
+        assert exc_info.value.status_code == 402
+
+    def test_without_org_id_uses_global_path(self):
+        LicenseManager.initialize()
+
+        @require_feature("basic_analytics", raise_http=False)
+        def my_endpoint():
+            return "success"
+
+        assert my_endpoint() == "success"
+
+    def test_without_org_id_denied_uses_global_path(self):
+        LicenseManager.initialize()
+
+        @require_feature("sso", raise_http=True)
+        def my_endpoint():
+            return "success"
+
+        with pytest.raises(HTTPException) as exc_info:
+            my_endpoint()
+        assert exc_info.value.status_code == 402
+
+
+class TestGetEntitlementsWithOrgId:
+    def test_without_org_id_returns_global(self):
+        from dev_health_ops.licensing.gating import get_entitlements
+
+        LicenseManager.initialize()
+        result = get_entitlements()
+        assert result["tier"] == "community"
+        assert result["is_licensed"] is False
+
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    @patch("dev_health_ops.api.services.licensing.TierLimitService")
+    @patch("dev_health_ops.api.services.licensing.FeatureService")
+    def test_with_org_id_queries_db(
+        self, MockFeatureSvc, MockLimitSvc, mock_session_ctx
+    ):
+        from dev_health_ops.licensing.gating import get_entitlements
+
+        org_uuid = uuid.uuid4()
+        mock_session = MagicMock()
+        mock_session_ctx.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_limits = {"max_users": 25, "max_repos": 10}
+        MockLimitSvc.return_value.get_all_limits.return_value = mock_limits
+        MockFeatureSvc.return_value.has_feature.return_value = True
+
+        result = get_entitlements(org_id=str(org_uuid))
+
+        assert result["limits"] == mock_limits
+        assert result["is_licensed"] is True
+
+    @patch(
+        "dev_health_ops.db.get_postgres_session_sync",
+        side_effect=Exception("DB down"),
+    )
+    def test_with_org_id_falls_back_on_error(self, _mock):
+        from dev_health_ops.licensing.gating import get_entitlements
+
+        LicenseManager.initialize()
+        result = get_entitlements(org_id=str(uuid.uuid4()))
+        assert result["tier"] == "community"


### PR DESCRIPTION
## Summary

- `require_feature` and `has_feature` in `gating.py` now accept `org_id` to delegate to the DB-backed `FeatureService` for per-org tier checks instead of only using the global `LicenseManager` singleton
- When `org_id` is present in function kwargs (injected by FastAPI `Depends(get_org_id)`), the decorator automatically uses the per-org DB path
- Falls back gracefully to global check when DB is unavailable or `org_id` is not provided
- `get_entitlements()` also supports per-org lookups

## Why

The `@require_feature` decorator in admin and auth routes previously only checked a global `LICENSE_KEY` env var (self-hosted mode). In SaaS mode, there's no global license key — each org has its own tier in the `organizations` table. This meant a paying org and a free org on the same instance would get identical features.

The GraphQL layer already had per-org gating via `FeatureService` in `authz.py`. This change brings the REST API routes to parity.

## Behavior

| Mode | How it works |
|------|-------------|
| **SaaS** (no `LICENSE_KEY`, org tiers in DB) | Decorator detects `org_id` kwarg → queries `FeatureService` → checks org's tier against `FeatureFlag.min_tier` |
| **Self-hosted** (`LICENSE_KEY` set) | No `org_id` in kwargs → global `LicenseManager` singleton as before |
| **DB failure** | Catches exception → falls back to global check → no 500s |

## Tests

19 new tests in `test_per_org_gating.py` covering:
- `_extract_org_id` helper
- `_check_feature_for_org` with mocked DB (allow, deny, invalid UUID fallback, DB error fallback)
- `has_feature` with and without `org_id`
- `require_feature` decorator with `org_id` in kwargs (sync + async, allow + deny)
- `get_entitlements` with per-org DB lookup and fallback

All 78 licensing tests pass (19 new + 52 existing + 7 webhook).

Closes gap #6 from SaaS deployment readiness analysis.