### PR TITLE
refactor: extract shared processor utilities and base class

### DIFF
--- a/src/dev_health_ops/processors/base.py
+++ b/src/dev_health_ops/processors/base.py
@@ -1,0 +1,115 @@
+"""Base processor providing shared orchestration patterns.
+
+Extracted from common patterns in github.py and gitlab.py processors.
+Existing processor functions remain as-is; new processors can subclass
+BaseProcessor for standardized pipeline management.
+"""
+
+from __future__ import annotations
+
+import abc
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+_sentinel = object()
+
+
+class BaseProcessor(abc.ABC, Generic[T, R]):
+    """Abstract base for processors that process items through a concurrent pipeline.
+
+    Encapsulates the common pattern:
+    1. Create a results queue with bounded size
+    2. Spawn a consumer task that drains results
+    3. Process items concurrently with a semaphore
+    4. Wait for all results to be consumed
+    """
+
+    def __init__(
+        self,
+        *,
+        max_concurrent: int = 4,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.max_concurrent = max(1, max_concurrent)
+        self.logger = logger or logging.getLogger(self.__class__.__name__)
+
+    @abc.abstractmethod
+    async def process_single(self, item: T) -> R:
+        """Process a single item. Subclasses must implement."""
+
+    @abc.abstractmethod
+    async def store_result(self, result: R) -> None:
+        """Persist a single result. Subclasses must implement."""
+
+    async def run_sync_in_executor(self, func: Callable[..., Any], *args: Any) -> Any:
+        """Run a synchronous function in the default executor."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+    async def process_batch(self, items: list[T]) -> int:
+        """Process a batch of items through the concurrent pipeline."""
+        if not items:
+            return 0
+
+        results_queue: asyncio.Queue[Any] = asyncio.Queue(
+            maxsize=max(1, self.max_concurrent * 2)
+        )
+        processed = 0
+        errors = 0
+
+        async def _consume() -> None:
+            while True:
+                result = await results_queue.get()
+                try:
+                    if result is _sentinel:
+                        return
+                    await self.store_result(result)
+                finally:
+                    results_queue.task_done()
+
+        consumer = asyncio.create_task(_consume())
+        semaphore = asyncio.Semaphore(self.max_concurrent)
+
+        async def _process_one(item: T) -> None:
+            nonlocal processed, errors
+            async with semaphore:
+                try:
+                    result = await self.process_single(item)
+                    await results_queue.put(result)
+                    processed += 1
+                except Exception as exc:
+                    errors += 1
+                    self.logger.warning("Failed to process item: %s", exc)
+
+        tasks = [asyncio.create_task(_process_one(item)) for item in items]
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+        await results_queue.join()
+        await results_queue.put(_sentinel)
+        await consumer
+
+        if errors:
+            self.logger.info(
+                "Batch complete: %d processed, %d errors", processed, errors
+            )
+
+        return processed
+
+    async def on_before_batch(self, items: list[T]) -> list[T]:
+        """Hook called before batch processing."""
+        return items
+
+    async def on_after_batch(self, processed_count: int) -> None:
+        """Hook called after batch processing completes."""
+
+    async def run(self, items: list[T]) -> int:
+        """Full pipeline: before_hook -> process_batch -> after_hook."""
+        filtered_items = await self.on_before_batch(items)
+        count = await self.process_batch(filtered_items)
+        await self.on_after_batch(count)
+        return count

--- a/src/dev_health_ops/processors/fetch_utils.py
+++ b/src/dev_health_ops/processors/fetch_utils.py
@@ -1,0 +1,152 @@
+"""Shared fetch/batch utilities for GitHub and GitLab processors.
+
+Extracted from duplicated patterns in github.py and gitlab.py to reduce
+code duplication and provide a single source of truth for common operations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import datetime
+from typing import Any, Callable, Coroutine, List, Optional
+
+from dev_health_ops.utils import BATCH_SIZE
+
+logger = logging.getLogger(__name__)
+
+
+def safe_parse_datetime(value: Any) -> Optional[datetime]:
+    """Parse a datetime from a string or datetime, handling "Z" suffix."""
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+coerce_datetime = safe_parse_datetime
+
+
+def extract_retry_after(exc: BaseException, connector: Any = None) -> Optional[float]:
+    """Extract retry delay seconds from connector helper or exception headers."""
+    retry_after: Optional[float] = None
+
+    if connector is not None and hasattr(connector, "_rate_limit_reset_delay_seconds"):
+        try:
+            raw_delay = connector._rate_limit_reset_delay_seconds()
+            if raw_delay is not None:
+                retry_after = float(raw_delay)
+                return retry_after
+        except Exception:
+            logger.debug("Connector retry-after extraction failed", exc_info=True)
+
+    headers = getattr(exc, "headers", None)
+    if not isinstance(headers, dict):
+        return None
+
+    headers_ci = {str(k).lower(): v for k, v in headers.items()}
+    raw_retry_after = headers_ci.get("retry-after")
+    if raw_retry_after is not None:
+        try:
+            return float(raw_retry_after)
+        except (TypeError, ValueError):
+            return None
+
+    raw_reset = headers_ci.get("x-ratelimit-reset")
+    if raw_reset is not None:
+        try:
+            return max(0.0, float(raw_reset) - time.time())
+        except (TypeError, ValueError):
+            return None
+
+    return None
+
+
+class SyncBatchCollector:
+    """Collects items and flushes to an async store when batch_size is reached.
+
+    For use in sync contexts (run_in_executor) that store to an async store.
+    """
+
+    def __init__(
+        self,
+        flush_coro_fn: Callable[[List[Any]], Coroutine[Any, Any, Any]],
+        loop: asyncio.AbstractEventLoop,
+        batch_size: int = BATCH_SIZE,
+    ):
+        self._flush_coro_fn = flush_coro_fn
+        self._loop = loop
+        self._batch_size = batch_size
+        self._batch: list[Any] = []
+        self._total = 0
+
+    def add(self, item: Any) -> None:
+        self._batch.append(item)
+        self._total += 1
+        if len(self._batch) >= self._batch_size:
+            self.flush()
+
+    def flush(self) -> None:
+        if self._batch:
+            asyncio.run_coroutine_threadsafe(
+                self._flush_coro_fn(list(self._batch)),
+                self._loop,
+            ).result()
+            self._batch.clear()
+
+    @property
+    def total(self) -> int:
+        return self._total
+
+    def __enter__(self) -> "SyncBatchCollector":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        self.flush()
+        return False
+
+
+class AsyncBatchCollector:
+    """Collects items and flushes to an async store when batch_size is reached.
+
+    For use in async contexts.
+    """
+
+    def __init__(
+        self,
+        flush_coro_fn: Callable[[List[Any]], Coroutine[Any, Any, Any]],
+        batch_size: int = BATCH_SIZE,
+    ):
+        self._flush_coro_fn = flush_coro_fn
+        self._batch_size = batch_size
+        self._batch: list[Any] = []
+        self._total = 0
+
+    def add(self, item: Any) -> None:
+        self._batch.append(item)
+        self._total += 1
+
+    async def maybe_flush(self) -> None:
+        if len(self._batch) >= self._batch_size:
+            await self.flush()
+
+    async def flush(self) -> None:
+        if self._batch:
+            await self._flush_coro_fn(list(self._batch))
+            self._batch.clear()
+
+    @property
+    def total(self) -> int:
+        return self._total
+
+    async def __aenter__(self) -> "AsyncBatchCollector":
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        await self.flush()
+        return False

--- a/tests/test_base_processor.py
+++ b/tests/test_base_processor.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import threading
+
+import pytest
+
+from dev_health_ops.processors.base import BaseProcessor
+
+
+class _TestProcessor(BaseProcessor[str, str]):
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self.processed_items: list[str] = []
+        self.stored_results: list[str] = []
+
+    async def process_single(self, item: str) -> str:
+        self.processed_items.append(item)
+        return f"result:{item}"
+
+    async def store_result(self, result: str) -> None:
+        self.stored_results.append(result)
+
+
+class TestBaseProcessorContract:
+    def test_cannot_instantiate_abc(self) -> None:
+        with pytest.raises(TypeError):
+            BaseProcessor(max_concurrent=1)
+
+    def test_subclass_must_implement_process_single(self) -> None:
+        class MissingProcessSingle(BaseProcessor[str, str]):
+            async def store_result(self, result: str) -> None:
+                return None
+
+        with pytest.raises(TypeError):
+            MissingProcessSingle()
+
+    def test_subclass_must_implement_store_result(self) -> None:
+        class MissingStoreResult(BaseProcessor[str, str]):
+            async def process_single(self, item: str) -> str:
+                return item
+
+        with pytest.raises(TypeError):
+            MissingStoreResult()
+
+
+class TestProcessBatch:
+    @pytest.mark.asyncio
+    async def test_empty_batch(self) -> None:
+        processor = _TestProcessor()
+        count = await processor.process_batch([])
+        assert count == 0
+        assert processor.processed_items == []
+        assert processor.stored_results == []
+
+    @pytest.mark.asyncio
+    async def test_single_item(self) -> None:
+        processor = _TestProcessor()
+        count = await processor.process_batch(["a"])
+        assert count == 1
+        assert processor.processed_items == ["a"]
+        assert processor.stored_results == ["result:a"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_items(self) -> None:
+        processor = _TestProcessor()
+        items = ["a", "b", "c"]
+        count = await processor.process_batch(items)
+        assert count == len(items)
+        assert sorted(processor.processed_items) == sorted(items)
+        assert sorted(processor.stored_results) == sorted(
+            [f"result:{item}" for item in items]
+        )
+
+    @pytest.mark.asyncio
+    async def test_respects_max_concurrent(self) -> None:
+        class ConcurrencyProcessor(_TestProcessor):
+            def __init__(self, **kwargs: object) -> None:
+                super().__init__(**kwargs)
+                self.lock = asyncio.Lock()
+                self.in_flight = 0
+                self.max_seen = 0
+                self.started = asyncio.Event()
+                self.release = asyncio.Event()
+
+            async def process_single(self, item: str) -> str:
+                async with self.lock:
+                    self.in_flight += 1
+                    self.max_seen = max(self.max_seen, self.in_flight)
+                    if self.in_flight == self.max_concurrent:
+                        self.started.set()
+
+                await self.release.wait()
+                result = await super().process_single(item)
+
+                async with self.lock:
+                    self.in_flight -= 1
+                return result
+
+        processor = ConcurrencyProcessor(max_concurrent=2)
+        task = asyncio.create_task(processor.process_batch(["a", "b", "c", "d"]))
+
+        await asyncio.wait_for(processor.started.wait(), timeout=1.0)
+        assert processor.max_seen <= 2
+
+        processor.release.set()
+        count = await asyncio.wait_for(task, timeout=1.0)
+        assert count == 4
+        assert processor.max_seen == 2
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self) -> None:
+        class FailingProcessor(_TestProcessor):
+            async def process_single(self, item: str) -> str:
+                if item == "bad":
+                    raise ValueError("boom")
+                return await super().process_single(item)
+
+        processor = FailingProcessor()
+        items = ["ok1", "bad", "ok2"]
+        count = await processor.process_batch(items)
+
+        assert count == 2
+        assert sorted(processor.stored_results) == ["result:ok1", "result:ok2"]
+
+    @pytest.mark.asyncio
+    async def test_store_result_called_for_each(self) -> None:
+        processor = _TestProcessor()
+        items = ["a", "b", "c", "d"]
+        count = await processor.process_batch(items)
+        assert count == len(items)
+        assert len(processor.stored_results) == len(items)
+
+
+class TestRunSyncInExecutor:
+    @pytest.mark.asyncio
+    async def test_runs_sync_func(self) -> None:
+        processor = _TestProcessor()
+        main_thread_id = threading.get_ident()
+
+        def blocking_thread_id() -> int:
+            return threading.get_ident()
+
+        executor_thread_id = await processor.run_sync_in_executor(blocking_thread_id)
+        assert executor_thread_id != main_thread_id
+
+    @pytest.mark.asyncio
+    async def test_returns_result(self) -> None:
+        processor = _TestProcessor()
+
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        result = await processor.run_sync_in_executor(add, 2, 3)
+        assert result == 5
+
+
+class TestRunMethod:
+    @pytest.mark.asyncio
+    async def test_calls_hooks(self) -> None:
+        class HookProcessor(_TestProcessor):
+            def __init__(self) -> None:
+                super().__init__()
+                self.events: list[str] = []
+
+            async def on_before_batch(self, items: list[str]) -> list[str]:
+                self.events.append("before")
+                return items
+
+            async def on_after_batch(self, processed_count: int) -> None:
+                self.events.append(f"after:{processed_count}")
+
+        processor = HookProcessor()
+        count = await processor.run(["a", "b"])
+
+        assert count == 2
+        assert processor.events == ["before", "after:2"]
+
+    @pytest.mark.asyncio
+    async def test_before_hook_can_filter(self) -> None:
+        class FilterProcessor(_TestProcessor):
+            async def on_before_batch(self, items: list[str]) -> list[str]:
+                return [item for item in items if item != "skip"]
+
+        processor = FilterProcessor()
+        count = await processor.run(["a", "skip", "b"])
+
+        assert count == 2
+        assert sorted(processor.processed_items) == ["a", "b"]
+        assert sorted(processor.stored_results) == ["result:a", "result:b"]
+
+
+class TestSentinelIsolation:
+    def test_sentinel_not_exported(self) -> None:
+        module = importlib.import_module("dev_health_ops.processors.base")
+        assert "_sentinel" in module.__dict__
+        assert "sentinel" not in module.__dict__
+        if hasattr(module, "__all__"):
+            assert "_sentinel" not in module.__all__

--- a/tests/test_fetch_utils.py
+++ b/tests/test_fetch_utils.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from dev_health_ops.processors.fetch_utils import (
+    AsyncBatchCollector,
+    SyncBatchCollector,
+    coerce_datetime,
+    extract_retry_after,
+    safe_parse_datetime,
+)
+
+
+class _CompletedFuture:
+    def result(self):
+        return None
+
+
+class _ExcWithHeaders(Exception):
+    def __init__(self, headers):
+        super().__init__("rate limited")
+        self.headers = headers
+
+
+class TestSafeParseDateTime:
+    def test_datetime_passthrough(self):
+        dt = datetime(2025, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+        assert safe_parse_datetime(dt) is dt
+
+    def test_string_iso(self):
+        parsed = safe_parse_datetime("2025-01-02T03:04:05+00:00")
+        assert parsed == datetime(2025, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+    def test_string_z_suffix(self):
+        parsed = safe_parse_datetime("2025-01-02T03:04:05Z")
+        assert parsed == datetime(2025, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+    def test_invalid_string(self):
+        assert safe_parse_datetime("not-a-date") is None
+
+    def test_none_input(self):
+        assert safe_parse_datetime(None) is None
+
+    def test_int_input(self):
+        assert safe_parse_datetime(123) is None
+
+
+class TestCoerceDatetime:
+    def test_alias(self):
+        assert coerce_datetime is safe_parse_datetime
+
+
+class TestExtractRetryAfter:
+    def test_from_connector_method(self):
+        class _Connector:
+            def _rate_limit_reset_delay_seconds(self):
+                return 4.5
+
+        exc = _ExcWithHeaders({"Retry-After": "2"})
+        assert extract_retry_after(exc, connector=_Connector()) == pytest.approx(4.5)
+
+    def test_from_retry_after_header(self):
+        exc = _ExcWithHeaders({"Retry-After": "3"})
+        assert extract_retry_after(exc) == pytest.approx(3.0)
+
+    def test_from_retry_after_header_case_insensitive(self):
+        exc = _ExcWithHeaders({"retry-after": "7"})
+        assert extract_retry_after(exc) == pytest.approx(7.0)
+
+    def test_from_ratelimit_reset_header(self, monkeypatch):
+        monkeypatch.setattr(
+            "dev_health_ops.processors.fetch_utils.time.time", lambda: 100.0
+        )
+        exc = _ExcWithHeaders({"x-ratelimit-reset": "110"})
+        assert extract_retry_after(exc) == pytest.approx(10.0)
+
+    def test_no_headers(self):
+        exc = Exception("no headers")
+        assert extract_retry_after(exc) is None
+
+    def test_connector_method_fails(self):
+        class _Connector:
+            def _rate_limit_reset_delay_seconds(self):
+                raise RuntimeError("broken")
+
+        exc = _ExcWithHeaders({"Retry-After": "9"})
+        assert extract_retry_after(exc, connector=_Connector()) == pytest.approx(9.0)
+
+    def test_no_connector(self):
+        exc = _ExcWithHeaders({"Retry-After": "8"})
+        assert extract_retry_after(exc, connector=None) == pytest.approx(8.0)
+
+
+class TestSyncBatchCollector:
+    def test_basic_collection(self, monkeypatch):
+        calls = []
+
+        async def flush_fn(items):
+            calls.append(items)
+
+        def _run_threadsafe(coro, _loop):
+            asyncio.run(coro)
+            return _CompletedFuture()
+
+        monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", _run_threadsafe)
+
+        collector = SyncBatchCollector(flush_fn, loop=object(), batch_size=2)
+        collector.add(1)
+        assert calls == []
+        collector.add(2)
+
+        assert calls == [[1, 2]]
+
+    def test_context_manager_flushes_remainder(self, monkeypatch):
+        calls = []
+
+        async def flush_fn(items):
+            calls.append(items)
+
+        def _run_threadsafe(coro, _loop):
+            asyncio.run(coro)
+            return _CompletedFuture()
+
+        monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", _run_threadsafe)
+
+        with SyncBatchCollector(flush_fn, loop=object(), batch_size=3) as collector:
+            collector.add("a")
+            collector.add("b")
+
+        assert calls == [["a", "b"]]
+
+    def test_total_count(self, monkeypatch):
+        async def flush_fn(_items):
+            return None
+
+        def _run_threadsafe(coro, _loop):
+            asyncio.run(coro)
+            return _CompletedFuture()
+
+        monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", _run_threadsafe)
+
+        collector = SyncBatchCollector(flush_fn, loop=object(), batch_size=2)
+        collector.add(1)
+        collector.add(2)
+        collector.add(3)
+        collector.flush()
+        assert collector.total == 3
+
+    def test_empty_flush_is_noop(self, monkeypatch):
+        called = False
+
+        async def flush_fn(_items):
+            nonlocal called
+            called = True
+
+        def _run_threadsafe(coro, _loop):
+            asyncio.run(coro)
+            return _CompletedFuture()
+
+        monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", _run_threadsafe)
+
+        collector = SyncBatchCollector(flush_fn, loop=object(), batch_size=2)
+        collector.flush()
+        assert called is False
+
+
+class TestAsyncBatchCollector:
+    @pytest.mark.asyncio
+    async def test_basic_collection(self):
+        calls = []
+
+        async def flush_fn(items):
+            calls.append(items)
+
+        collector = AsyncBatchCollector(flush_fn, batch_size=2)
+        collector.add(1)
+        await collector.maybe_flush()
+        assert calls == []
+
+        collector.add(2)
+        await collector.maybe_flush()
+        assert calls == [[1, 2]]
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager(self):
+        calls = []
+
+        async def flush_fn(items):
+            calls.append(items)
+
+        async with AsyncBatchCollector(flush_fn, batch_size=10) as collector:
+            collector.add("x")
+            collector.add("y")
+
+        assert calls == [["x", "y"]]
+
+    @pytest.mark.asyncio
+    async def test_total_count(self):
+        async def flush_fn(_items):
+            return None
+
+        collector = AsyncBatchCollector(flush_fn, batch_size=2)
+        collector.add(1)
+        collector.add(2)
+        await collector.maybe_flush()
+        collector.add(3)
+        await collector.flush()
+        assert collector.total == 3
+
+    @pytest.mark.asyncio
+    async def test_empty_flush_is_noop(self):
+        called = False
+
+        async def flush_fn(_items):
+            nonlocal called
+            called = True
+
+        collector = AsyncBatchCollector(flush_fn, batch_size=2)
+        await collector.flush()
+        assert called is False


### PR DESCRIPTION
## Summary

- Extract shared fetch/batch patterns from `github.py` and `gitlab.py` into `processors/fetch_utils.py`
- Add `BaseProcessor` ABC in `processors/base.py` encapsulating the common queue/consumer/semaphore concurrent pipeline

## What's Added

### `fetch_utils.py` — Shared fetch utilities
- `safe_parse_datetime(value)` / `coerce_datetime(value)` — consolidates 7 duplicate `datetime.fromisoformat(value.replace("Z", "+00:00"))` call sites
- `extract_retry_after(exc, connector)` — consolidates ~60 lines of duplicated rate-limit header extraction from github.py/gitlab.py
- `SyncBatchCollector` — context manager for batching items in sync contexts (run_in_executor) with auto-flush to async stores
- `AsyncBatchCollector` — same pattern for pure-async contexts

### `base.py` — BaseProcessor ABC
- `process_single(item)` / `store_result(result)` abstract methods
- `process_batch(items)` — queue + consumer + semaphore concurrent pipeline (extracted from `process_github_repos_batch` / `process_gitlab_projects_batch`)
- `run_sync_in_executor(func, *args)` — wraps `loop.run_in_executor`
- `on_before_batch` / `on_after_batch` hooks
- `run(items)` — full pipeline with hooks

## Approach

**Additive only** — no existing processor code is modified. Existing `github.py`, `gitlab.py`, `local.py`, and `sync.py` are untouched. Future PRs can adopt these utilities to reduce duplication incrementally.

## Testing

- 22 new tests for `fetch_utils.py` (datetime parsing, retry extraction, sync/async batch collectors)
- 14 new tests for `base.py` (ABC contract, batch processing, concurrency limits, error handling, hooks, executor)
- Full suite: **1310 passed**, 5 skipped, 0 failures

## Related

- Beads: `dev-health-hops-0ki` (Phase 2.1), `dev-health-ops-l48` (Phase 2.2)
- Part of processor refactoring tracked in GitHub #355