### PR TITLE
feat: generate OrgLicense in fixture data

### DIFF
--- a/src/dev_health_ops/fixtures/generator.py
+++ b/src/dev_health_ops/fixtures/generator.py
@@ -1554,10 +1554,12 @@ class SyntheticDataGenerator:
     ) -> Dict[str, Any]:
         import bcrypt
         from dev_health_ops.models.users import User, Organization, Membership
+        from dev_health_ops.models.licensing import OrgLicense, Tier
 
         users = []
         orgs = []
         memberships = []
+        licenses = []
 
         password_hash = bcrypt.hashpw(
             default_password.encode("utf-8"), bcrypt.gensalt()
@@ -1600,6 +1602,18 @@ class SyntheticDataGenerator:
                 )
             )
 
+            licenses.append(
+                OrgLicense(
+                    org_id=admin_org.id,
+                    tier=Tier.ENTERPRISE.value,
+                    license_type="saas",
+                    licensed_users=None,
+                    licensed_repos=None,
+                    issued_at=datetime.now(timezone.utc),
+                    expires_at=datetime.now(timezone.utc) + timedelta(days=365),
+                )
+            )
+
         default_org_id = None
         if orgs:
             default_org_id = orgs[0].id
@@ -1635,5 +1649,6 @@ class SyntheticDataGenerator:
             "users": users,
             "organizations": orgs,
             "memberships": memberships,
+            "licenses": licenses,
             "default_password": default_password,
         }

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -122,11 +122,15 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                 for membership in user_data["memberships"]:
                     await session.merge(membership)
                 await session.commit()
+                for org_license in user_data.get("licenses", []):
+                    await session.merge(org_license)
+                await session.commit()
             logging.info(
-                "Inserted %d users, %d orgs, %d memberships.",
+                "Inserted %d users, %d orgs, %d memberships, %d licenses.",
                 len(user_data["users"]),
                 len(user_data["organizations"]),
                 len(user_data["memberships"]),
+                len(user_data.get("licenses", [])),
             )
 
         allow_parallel_inserts = not isinstance(store, SQLAlchemyStore)


### PR DESCRIPTION
## Summary

- Fixture generator now creates an enterprise `OrgLicense` for the default org, matching its `tier="enterprise"` setting
- Runner inserts licenses alongside users, orgs, and memberships so the platform boots with a fully licensed state
- Without this, the licensing router falls back to community tier even though the org is configured as enterprise

## Changes

- **generator.py**: `generate_users()` now imports `OrgLicense`/`Tier` from licensing models and appends an enterprise license to the return dict
- **runner.py**: Inserts `licenses` from user_data after memberships; updated log message to include license count

## Testing

- All 18 existing fixture tests pass
- Verified `generate_users()` returns `licenses` key with 1 enterprise OrgLicense