### PR TITLE
docs: remove license-svc references, document ops billing endpoints

### DIFF
--- a/docs/architecture/adr/001-enterprise-edition.md
+++ b/docs/architecture/adr/001-enterprise-edition.md
@@ -2,7 +2,7 @@
 
 **Status**: PARTIALLY DECIDED  
 **Created**: 2026-01-30  
-**Updated**: 2026-02-01  
+**Updated**: 2026-02-08  
 **Parent Issue**: [#299](https://github.com/full-chaos/dev-health-ops/issues/299)
 
 ## Context
@@ -313,14 +313,14 @@ As of February 2026, the platform is shifting to a SaaS-first model to accelerat
 
 ### Rationale
 - **Fastest path to value**: Users can sign up and start seeing insights in minutes without managing infrastructure.
-- **Simplified Billing**: Stripe integration via `license-svc` provides a seamless upgrade path.
+- **Simplified Billing**: Stripe integration built directly into `dev-health-ops` provides a seamless upgrade path with no external billing service.
 - **Operational Efficiency**: Managed updates and maintenance ensure all users are on the latest version.
 
 ### Implementation
 - **Primary**: Managed SaaS with logical isolation via `org_id`. All onboarding, documentation, and default examples should assume this path.
 - **Secondary**: Self-hosted Enterprise with Ed25519 license keys. Documented as an alternative for data sovereignty / air-gapped requirements.
-- **Billing**: Integrated Stripe checkout and portal via `license-svc` (private).
-- **Entitlements**: Real-time tier updates in `dev-health-ops` via `license-svc` webhooks.
+- **Billing**: Stripe checkout, portal, and webhook processing built into `dev-health-ops` (`/api/v1/billing/*` endpoints).
+- **Entitlements**: Real-time tier updates via Stripe webhooks directly to `dev-health-ops`, with Ed25519-signed JWT licenses.
 
 ---
 
@@ -357,3 +357,4 @@ As of February 2026, the platform is shifting to a SaaS-first model to accelerat
 | 2026-02-01 | Marked Decision 4: Licensing Model as DECIDED (BSL) |
 | 2026-02-01 | Created docs/architecture/licensing.md with Ed25519 JWT specification |
 | 2026-02-05 | Added Decision 7: SaaS-First Deployment Model - DECIDED SaaS primary |
+| 2026-02-08 | Updated Decision 7: Removed license-svc references — billing now built into dev-health-ops |

--- a/docs/ops/enterprise-test-plan.md
+++ b/docs/ops/enterprise-test-plan.md
@@ -44,32 +44,35 @@ export SSO_TEST_IDP_URL="https://idp.test.local"
 ```bash
 # License configuration (for self-hosted enterprise features)
 export LICENSE_PUBLIC_KEY="<base64-encoded-ed25519-public-key>"
-export LICENSE_KEY="<valid-license-key>"  # Generate from license-svc
+export LICENSE_KEY="<valid-license-key>"  # Generate from ops CLI (see below)
 ```
 
-> **Note**: SaaS deployments manage entitlements via webhook (no license key needed). License keys are for self-hosted testing only.
+> **Note**: SaaS deployments manage entitlements via Stripe webhooks directly to `dev-health-ops` (no license key needed). License keys are for self-hosted testing only.
 
 ### 1.2 Test License Keys
 
-> **SaaS Entitlements**: In SaaS deployments, entitlements are managed via webhook from `license-svc` → `dev-health-ops`. No license key environment variable is needed. The license key generation below is for **self-hosted testing only**.
+> **SaaS Entitlements**: In SaaS deployments, entitlements are managed via Stripe webhooks sent directly to `dev-health-ops` at `/api/v1/billing/webhooks/stripe`. No license key environment variable is needed. The license key generation below is for **self-hosted testing only**.
 
-Generate test licenses for each tier using the `license-svc`:
+Generate test licenses for each tier using the `dev-health-ops` CLI:
 
 ```bash
+# Generate an Ed25519 keypair (one-time setup)
+python -m dev_health_ops.cli admin licenses keygen
+
 # Community tier (no license needed - default behavior)
 unset LICENSE_KEY
 
 # Team tier license
-export LICENSE_KEY="$(license-svc generate --tier team --org test-org --days 30)"
+export LICENSE_KEY="$(python -m dev_health_ops.cli admin licenses create --tier team --org test-org --days 30)"
 
 # Enterprise tier license
-export LICENSE_KEY="$(license-svc generate --tier enterprise --org test-org --days 30)"
+export LICENSE_KEY="$(python -m dev_health_ops.cli admin licenses create --tier enterprise --org test-org --days 30)"
 
 # Expired license (for grace period testing)
-export LICENSE_KEY="$(license-svc generate --tier enterprise --org test-org --days -1)"
+export LICENSE_KEY="$(python -m dev_health_ops.cli admin licenses create --tier enterprise --org test-org --days -1)"
 
 # Hard-expired license (past grace period)
-export LICENSE_KEY="$(license-svc generate --tier enterprise --org test-org --days -45)"
+export LICENSE_KEY="$(python -m dev_health_ops.cli admin licenses create --tier enterprise --org test-org --days -45)"
 ```
 
 ### 1.3 Test Data Setup

--- a/docs/self-hosted-quickstart.md
+++ b/docs/self-hosted-quickstart.md
@@ -310,6 +310,18 @@ dev-hops sync work-items --provider github \
 | `JIRA_API_TOKEN` | Jira API token | — |
 | `JIRA_URL` | Jira instance URL | — |
 
+### Billing (SaaS Only)
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `STRIPE_SECRET_KEY` | Stripe API secret key | — |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret | — |
+| `STRIPE_PRICE_ID_TEAM` | Stripe Price ID for Team tier | — |
+| `STRIPE_PRICE_ID_ENTERPRISE` | Stripe Price ID for Enterprise tier | — |
+| `LICENSE_PRIVATE_KEY` | Ed25519 private key for license signing (base64) | — |
+
+> **Note**: Billing variables are only required for SaaS deployments that process Stripe subscriptions. Self-hosted deployments use offline Ed25519 license keys instead (set `DEV_HEALTH_LICENSE`).
+
 ---
 
 ## Upgrading


### PR DESCRIPTION
## Summary

Removes all stale `license-svc` references from documentation now that billing is built directly into `dev-health-ops`. Adds missing Stripe webhook and billing env var documentation.

## Changes

### Updated (6 files)
- **`docs/architecture/licensing.md`** — SaaS entitlement path now shows Stripe webhooks going directly to ops; updated flow diagram from 3-hop to 2-hop
- **`docs/architecture/enterprise-overview.md`** — Reduced from 3 components to 2 (web + ops); removed license-svc from repo responsibilities table; updated flow diagram
- **`docs/architecture/adr/001-enterprise-edition.md`** — Decision 7 rationale and implementation updated; added changelog entry
- **`docs/ops/enterprise-test-plan.md`** — License generation commands now use `python -m dev_health_ops.cli admin licenses create` instead of `license-svc generate`
- **`docs/self-hosted-quickstart.md`** — Added "Billing (SaaS Only)" env var section with `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID_TEAM`, `STRIPE_PRICE_ID_ENTERPRISE`, `LICENSE_PRIVATE_KEY`
- **`docs/webhooks.md`** — Added full Stripe webhook setup section with endpoint table and required env vars

### Already correct (no changes needed)
- `docs/monetization-strategy.md` — Already updated in prior merge
- `docs/self-hosted-quickstart.md` architecture diagram — Correctly shows only web + ops (no license-svc)

## New architecture (documented)

```
┌──────────────┐      ┌──────────────┐
│    Stripe    │─────▶│dev-health-ops│
└──────────────┘      └──────────────┘
       │                     │
1. Subscription       2. Process event,
   event (webhook)       sign JWT license,
   POST /api/v1/         update org tier,
   billing/webhooks/     gate features
   stripe
```

## Verification
- `grep -r 'license-svc' docs/` returns only the ADR changelog entry (intentional — documents what was removed)