### PR TITLE
feat: add sync-config CRUD endpoints (GET/PATCH/DELETE, trigger)

### DIFF
--- a/src/dev_health_ops/api/services/settings.py
+++ b/src/dev_health_ops/api/services/settings.py
@@ -329,6 +329,21 @@ class SyncConfigurationService:
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
 
+    async def get_by_id(self, config_id: str) -> Optional[SyncConfiguration]:
+        """Get a sync configuration by ID."""
+        import uuid as uuid_module
+
+        try:
+            uid = uuid_module.UUID(config_id)
+        except ValueError:
+            return None
+        stmt = select(SyncConfiguration).where(
+            SyncConfiguration.org_id == self.org_id,
+            SyncConfiguration.id == uid,
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
     async def create(
         self,
         name: str,


### PR DESCRIPTION
## Summary

- Add missing sync-config endpoints: `GET /:id`, `PATCH /:id`, `DELETE /:id`, `POST /:id/trigger`
- Add `get_by_id()` to `SyncConfigurationService` (frontend sends UUIDs, existing `get()` uses names)
- Extract `_sync_config_to_response()` helper to DRY model→schema conversion

## Context

The frontend (`dev-health-web`) had full API client methods for sync-config CRUD but the backend only exposed list and create. All edit/pause/delete/trigger operations returned 404.

## Testing

All endpoints verified against running instance:
- `GET /sync-configs/{id}` → 200
- `PATCH /sync-configs/{id}` → 200 (toggle active verified)
- `DELETE /sync-configs/{id}` → 204
- `POST /sync-configs/{id}/trigger` → 202
- Invalid ID → 404

Companion frontend PR: full-chaos/dev-health-web#152