### PR TITLE
refactor: store job status as integer codes in database

### DIFF
--- a/src/dev_health_ops/alembic/versions/j0e1f2g3h4i5_numeric_job_status.py
+++ b/src/dev_health_ops/alembic/versions/j0e1f2g3h4i5_numeric_job_status.py
@@ -1,0 +1,106 @@
+"""Convert job status columns from text to integer.
+
+Revision ID: j0e1f2g3h4i5
+Revises: i9d0e1f2g3h4
+Create Date: 2026-02-09 23:55:00
+
+Migrates scheduled_jobs.status, scheduled_jobs.last_run_status, and
+job_runs.status from text labels to integer codes. The API layer maps
+integers back to labels for external consumers.
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "j0e1f2g3h4i5"
+down_revision: Union[str, None] = "i9d0e1f2g3h4"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+JOB_STATUS_MAP = {"active": 0, "paused": 1, "disabled": 2}
+RUN_STATUS_MAP = {"pending": 0, "running": 1, "success": 2, "failed": 3, "cancelled": 4}
+
+JOB_STATUS_REVERSE = {v: k for k, v in JOB_STATUS_MAP.items()}
+RUN_STATUS_REVERSE = {v: k for k, v in RUN_STATUS_MAP.items()}
+
+
+def upgrade() -> None:
+    op.add_column("scheduled_jobs", sa.Column("status_int", sa.Integer, nullable=True))
+    op.add_column(
+        "scheduled_jobs", sa.Column("last_run_status_int", sa.Integer, nullable=True)
+    )
+    op.add_column("job_runs", sa.Column("status_int", sa.Integer, nullable=True))
+
+    for text_val, int_val in JOB_STATUS_MAP.items():
+        op.execute(
+            f"UPDATE scheduled_jobs SET status_int = {int_val} WHERE status = '{text_val}'"
+        )
+
+    for text_val, int_val in RUN_STATUS_MAP.items():
+        op.execute(
+            f"UPDATE scheduled_jobs SET last_run_status_int = {int_val} WHERE last_run_status = '{text_val}'"
+        )
+        op.execute(
+            f"UPDATE job_runs SET status_int = {int_val} WHERE status = '{text_val}'"
+        )
+
+    op.execute("UPDATE scheduled_jobs SET status_int = 0 WHERE status_int IS NULL")
+    op.execute("UPDATE job_runs SET status_int = 0 WHERE status_int IS NULL")
+
+    op.drop_column("scheduled_jobs", "status")
+    op.drop_column("scheduled_jobs", "last_run_status")
+    op.drop_column("job_runs", "status")
+
+    op.alter_column(
+        "scheduled_jobs", "status_int", new_column_name="status", nullable=False
+    )
+    op.alter_column(
+        "scheduled_jobs", "last_run_status_int", new_column_name="last_run_status"
+    )
+    op.alter_column("job_runs", "status_int", new_column_name="status", nullable=False)
+
+    op.create_index("ix_job_runs_status", "job_runs", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_job_runs_status", table_name="job_runs")
+
+    op.add_column("scheduled_jobs", sa.Column("status_text", sa.Text, nullable=True))
+    op.add_column(
+        "scheduled_jobs", sa.Column("last_run_status_text", sa.Text, nullable=True)
+    )
+    op.add_column("job_runs", sa.Column("status_text", sa.Text, nullable=True))
+
+    for text_val, int_val in JOB_STATUS_MAP.items():
+        op.execute(
+            f"UPDATE scheduled_jobs SET status_text = '{text_val}' WHERE status = {int_val}"
+        )
+
+    for text_val, int_val in RUN_STATUS_MAP.items():
+        op.execute(
+            f"UPDATE scheduled_jobs SET last_run_status_text = '{text_val}' WHERE last_run_status = {int_val}"
+        )
+        op.execute(
+            f"UPDATE job_runs SET status_text = '{text_val}' WHERE status = {int_val}"
+        )
+
+    op.execute(
+        "UPDATE scheduled_jobs SET status_text = 'active' WHERE status_text IS NULL"
+    )
+    op.execute("UPDATE job_runs SET status_text = 'pending' WHERE status_text IS NULL")
+
+    op.drop_column("scheduled_jobs", "status")
+    op.drop_column("scheduled_jobs", "last_run_status")
+    op.drop_column("job_runs", "status")
+
+    op.alter_column(
+        "scheduled_jobs", "status_text", new_column_name="status", nullable=False
+    )
+    op.alter_column(
+        "scheduled_jobs", "last_run_status_text", new_column_name="last_run_status"
+    )
+    op.alter_column("job_runs", "status_text", new_column_name="status", nullable=False)
+
+    op.create_index("ix_job_runs_status", "job_runs", ["status"])

--- a/src/dev_health_ops/api/admin/router.py
+++ b/src/dev_health_ops/api/admin/router.py
@@ -39,6 +39,7 @@ from .schemas import (
     IntegrationCredentialCreate,
     IntegrationCredentialResponse,
     IntegrationCredentialUpdate,
+    JOB_RUN_STATUS_LABELS,
     JobRunResponse,
     IPAllowlistCreate,
     IPAllowlistListResponse,
@@ -626,7 +627,7 @@ async def list_sync_config_jobs(
         JobRunResponse(
             id=str(run.id),
             job_id=str(run.job_id),
-            status=run.status,
+            status=JOB_RUN_STATUS_LABELS.get(run.status, "unknown"),
             started_at=run.started_at,
             completed_at=run.completed_at,
             duration_seconds=run.duration_seconds,

--- a/src/dev_health_ops/api/admin/schemas.py
+++ b/src/dev_health_ops/api/admin/schemas.py
@@ -114,6 +114,15 @@ class SyncConfigUpdate(BaseModel):
     is_active: Optional[bool] = None
 
 
+JOB_RUN_STATUS_LABELS: dict[int, str] = {
+    0: "pending",
+    1: "running",
+    2: "success",
+    3: "failed",
+    4: "cancelled",
+}
+
+
 class JobRunResponse(BaseModel):
     id: str
     job_id: str

--- a/src/dev_health_ops/models/settings.py
+++ b/src/dev_health_ops/models/settings.py
@@ -55,22 +55,18 @@ class IntegrationProvider(str, Enum):
     ATLASSIAN = "atlassian"
 
 
-class JobStatus(str, Enum):
-    """Status of a scheduled job."""
-
-    ACTIVE = "active"
-    PAUSED = "paused"
-    DISABLED = "disabled"
+class JobStatus(int, Enum):
+    ACTIVE = 0
+    PAUSED = 1
+    DISABLED = 2
 
 
-class JobRunStatus(str, Enum):
-    """Status of a job run."""
-
-    PENDING = "pending"
-    RUNNING = "running"
-    SUCCESS = "success"
-    FAILED = "failed"
-    CANCELLED = "cancelled"
+class JobRunStatus(int, Enum):
+    PENDING = 0
+    RUNNING = 1
+    SUCCESS = 2
+    FAILED = 3
+    CANCELLED = 4
 
 
 class Setting(Base):
@@ -322,11 +318,11 @@ class ScheduledJob(Base):
     )
     sync_config = relationship("SyncConfiguration")
 
-    status = Column(Text, nullable=False, default=JobStatus.ACTIVE.value)
+    status = Column(Integer, nullable=False, default=JobStatus.ACTIVE.value)
     is_running = Column(Boolean, nullable=False, default=False)
 
     last_run_at = Column(DateTime(timezone=True), nullable=True)
-    last_run_status = Column(Text, nullable=True)
+    last_run_status = Column(Integer, nullable=True)
     last_run_duration_seconds = Column(Integer, nullable=True)
     last_run_error = Column(Text, nullable=True)
     next_run_at = Column(DateTime(timezone=True), nullable=True)
@@ -360,7 +356,7 @@ class ScheduledJob(Base):
         job_config: Optional[dict] = None,
         sync_config_id: Optional[uuid.UUID] = None,
         tz: str = "UTC",
-        status: str = JobStatus.ACTIVE.value,
+        status: int = JobStatus.ACTIVE.value,
     ):
         self.id = uuid.uuid4()
         self.org_id = org_id
@@ -395,7 +391,7 @@ class JobRun(Base):
     )
     job = relationship("ScheduledJob")
 
-    status = Column(Text, nullable=False, default=JobRunStatus.PENDING.value)
+    status = Column(Integer, nullable=False, default=JobRunStatus.PENDING.value)
     started_at = Column(DateTime(timezone=True), nullable=True)
     completed_at = Column(DateTime(timezone=True), nullable=True)
     duration_seconds = Column(Integer, nullable=True)
@@ -426,7 +422,7 @@ class JobRun(Base):
         self,
         job_id: uuid.UUID,
         triggered_by: str = "scheduler",
-        status: str = JobRunStatus.PENDING.value,
+        status: int = JobRunStatus.PENDING.value,
     ):
         self.id = uuid.uuid4()
         self.job_id = job_id


### PR DESCRIPTION
## Summary

- Replace text-based status columns (`scheduled_jobs.status`, `scheduled_jobs.last_run_status`, `job_runs.status`) with integer codes (0-4)
- API layer maps integers back to human-readable labels via `JOB_RUN_STATUS_LABELS` dict
- Includes Alembic migration (`j0e1f2g3h4i5`) with full reversibility

## Changes

| File | Change |
|------|--------|
| `models/settings.py` | `JobStatus` and `JobRunStatus` enums changed from `str, Enum` to `int, Enum`; columns from `Text` to `Integer` |
| `api/admin/schemas.py` | Added `JOB_RUN_STATUS_LABELS` mapping dict |
| `api/admin/router.py` | Job history endpoint now maps int→string via label dict |
| `alembic/versions/j0e1f2...` | Migration: adds temp `*_int` columns, maps values, drops old, renames |

## Rationale

Database should store semantic-free integer codes rather than display-layer text strings. This decouples storage from presentation and makes status comparisons cheaper.

## Testing

- Migration verified against live Postgres (columns now `integer` type)
- API endpoint `/sync-configs/{id}/jobs` confirmed returning correct string labels (`"success"`, `"running"`, etc.)
- Ruff lint clean