### PR TITLE
feat: add team membership discovery and identity linking (gh-396)

### DIFF
--- a/src/dev_health_ops/api/admin/schemas.py
+++ b/src/dev_health_ops/api/admin/schemas.py
@@ -234,6 +234,47 @@ class TeamImportResponse(BaseModel):
     details: list[dict[str, Any]] = Field(default_factory=list)
 
 
+class DiscoveredMember(BaseModel):
+    provider_type: str
+    provider_identity: str
+    display_name: Optional[str] = None
+    email: Optional[str] = None
+    role: Optional[str] = None
+
+
+class MemberMatchResult(BaseModel):
+    discovered: DiscoveredMember
+    match_status: str = Field(pattern="^(matched|suggested|unmatched)$")
+    matched_identity: Optional[IdentityMappingResponse] = None
+    confidence: Optional[float] = None
+    suggestion_reason: Optional[str] = None
+
+
+class TeamMembersDiscoverResponse(BaseModel):
+    team_id: str
+    provider: str
+    members: list[MemberMatchResult]
+    total: int
+
+
+class ConfirmMemberLink(BaseModel):
+    provider_identity: str
+    provider: str = Field(pattern="^(github|gitlab|jira)$")
+    canonical_id: str
+    action: str = Field(pattern="^(link|create|skip)$")
+
+
+class ConfirmMembersRequest(BaseModel):
+    team_id: str
+    links: list[ConfirmMemberLink]
+
+
+class ConfirmMembersResponse(BaseModel):
+    linked: int
+    created: int
+    skipped: int
+
+
 class FlaggedChange(BaseModel):
     team_id: str
     team_name: str

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -56,6 +56,11 @@ beat_schedule = {
         "schedule": crontab(hour=2, minute=30),
         "options": {"queue": "sync"},
     },
+    "reconcile-team-members": {
+        "task": "dev_health_ops.workers.tasks.reconcile_team_members",
+        "schedule": crontab(hour=3, minute=0),
+        "options": {"queue": "sync"},
+    },
 }
 
 # Result settings


### PR DESCRIPTION
## Summary
Phase 3 of the Enterprise Auto-import Teams epic (#299).

- **Member discovery** from GitHub (team members), GitLab (group members), and Jira (project lead only)
- **Identity matching pipeline**: exact provider identity match → email suggestion → display name fuzzy match → unmatched
- **Admin confirmation workflow**: `GET /teams/{id}/discover-members` + `POST /teams/{id}/confirm-members`
- **ClickHouse reconciler**: Celery beat task rebuilds `teams.members` array from `IdentityMapping.team_ids` daily at 03:00 UTC

### New Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/admin/teams/{team_id}/discover-members?provider=<github\|gitlab\|jira>` | Discover + match members |
| POST | `/api/v1/admin/teams/{team_id}/confirm-members` | Confirm identity links |

### Key Design Decisions
- **No auto-linking**: All identity matches require explicit admin confirmation
- **IdentityMapping.team_ids is authoritative**: Team members in ClickHouse are a derived projection
- **Jira limitation**: Only project lead available via REST (activity inference is Phase 4)

Closes #396