### PR TITLE
feat: add Jira activity-based team member inference (gh-397)

### DIFF
--- a/src/dev_health_ops/api/admin/schemas.py
+++ b/src/dev_health_ops/api/admin/schemas.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -270,6 +270,45 @@ class ConfirmMembersRequest(BaseModel):
 
 
 class ConfirmMembersResponse(BaseModel):
+    linked: int
+    created: int
+    skipped: int
+
+
+class InferredMember(BaseModel):
+    account_id: str
+    display_name: Optional[str] = None
+    email: Optional[str] = None
+    activity_count: int = Field(ge=0)
+    confidence: Literal["core", "active", "peripheral"]
+    roles: list[Literal["assignee", "reporter", "commenter"]] = Field(
+        default_factory=list
+    )
+    last_active: Optional[datetime] = None
+
+
+class JiraActivityInferenceResponse(BaseModel):
+    team_id: str
+    project_key: str
+    window_days: int
+    inferred_members: list[InferredMember]
+    total: int
+
+
+class ConfirmInferredMemberAction(BaseModel):
+    account_id: str
+    action: Literal["add", "skip"]
+    canonical_id: Optional[str] = None
+    display_name: Optional[str] = None
+    email: Optional[str] = None
+
+
+class ConfirmInferredMembersRequest(BaseModel):
+    team_id: str
+    members: list[ConfirmInferredMemberAction] = Field(default_factory=list)
+
+
+class ConfirmInferredMembersResponse(BaseModel):
     linked: int
     created: int
     skipped: int


### PR DESCRIPTION
## Summary
Phase 4 of the Enterprise Auto-import Teams epic (#299).

- **Activity-based inference**: Queries Jira issues over a configurable window (default 90 days) and extracts unique assignees, reporters, and creators
- **Confidence classification**: Core (5+ issues), Active (2-4 issues), Peripheral (1 issue)
- **Admin confirmation**: All inferred memberships require explicit admin action before any identity changes
- **Identity linking**: Supports linking to existing identities or creating new ones with `jira:{accountId}` canonical format

### New Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/admin/teams/{team_id}/infer-members?window_days=90` | Infer members from Jira activity |
| POST | `/api/v1/admin/teams/{team_id}/confirm-inferred-members` | Confirm inferred member additions |

### Key Design Decisions
- **Inference, not authority**: All results clearly labeled as inferred from activity patterns
- **No auto-add**: Admin confirmation required for every membership change
- **Lightweight**: Uses issue assignee/reporter/creator fields only (no changelog or comment fetching)
- **Reuses existing JiraClient**: Same `iter_issues` + `JiraAuth` pattern used by work-items sync

Closes #397