### PR TITLE
fix: provider-aware sync targets + GET /sync-targets endpoint

### DIFF
--- a/src/dev_health_ops/api/admin/router.py
+++ b/src/dev_health_ops/api/admin/router.py
@@ -82,6 +82,15 @@ from .schemas import (
 
 logger = logging.getLogger(__name__)
 
+# Canonical mapping of provider → supported sync targets.
+# Jira/Linear only support work-items; Git/CI/CD come from code hosts.
+PROVIDER_SYNC_TARGETS: dict[str, list[str]] = {
+    "github": ["git", "prs", "cicd", "deployments", "incidents", "work-items"],
+    "gitlab": ["git", "prs", "cicd", "deployments", "incidents", "work-items"],
+    "jira": ["work-items"],
+    "linear": ["work-items"],
+}
+
 router = APIRouter(prefix="/api/v1/admin", tags=["admin"])
 
 
@@ -475,6 +484,11 @@ async def _test_linear_connection(creds: dict) -> tuple[bool, dict]:
             if viewer:
                 return True, {"user": viewer.get("email"), "name": viewer.get("name")}
         return False, {"status": resp.status_code, "error": resp.text[:200]}
+
+
+@router.get("/sync-targets")
+async def get_provider_sync_targets() -> dict[str, list[str]]:
+    return PROVIDER_SYNC_TARGETS
 
 
 @router.get("/sync-configs", response_model=list[SyncConfigResponse])


### PR DESCRIPTION
## Summary
- Adds `PROVIDER_SYNC_TARGETS` canonical mapping (provider → supported sync targets)
- Adds `GET /api/v1/admin/sync-targets` endpoint returning the mapping
- Jira/Linear → `["work-items"]` only; GitHub/GitLab → all 6 targets

Closes #400

**Frontend counterpart:** full-chaos/dev-health-web (fix/sync-targets-provider-aware)