### PR TITLE
feat: add capacity forecast Celery task with weekly beat schedule

### DIFF
--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -61,6 +61,12 @@ beat_schedule = {
         "schedule": crontab(hour=3, minute=0),
         "options": {"queue": "sync"},
     },
+    "run-capacity-forecast": {
+        "task": "dev_health_ops.workers.tasks.run_capacity_forecast_job",
+        "schedule": crontab(hour=4, minute=0, day_of_week="monday"),
+        "kwargs": {"all_teams": True},
+        "options": {"queue": "metrics"},
+    },
 }
 
 # Result settings


### PR DESCRIPTION
## Summary

Adds a new Celery task wrapper for capacity forecasting with a weekly beat schedule entry. The task runs every Monday at 04:00 UTC for all teams.

## Changes

- **New task**: `run_capacity_forecast_job` in `src/dev_health_ops/workers/tasks.py`
  - Wraps `run_capacity_forecast` from `dev_health_ops.metrics.job_capacity`
  - Supports team-specific, work-scope-specific, or all-teams forecasting
  - Configurable history window (default 90 days) and simulation count (default 10000)
  - Max 2 retries with exponential backoff (120s base)

- **Beat schedule entry**: `run-capacity-forecast` in `src/dev_health_ops/workers/config.py`
  - Runs weekly on Mondays at 04:00 UTC
  - Executes with `all_teams=True` by default
  - Routed to `metrics` queue

## Feature Flagging

This task is feature-flagged and will only execute if the capacity forecasting job module is available and properly configured.