### PR TITLE
fix: add concurrency groups and deduplicate CI triggers

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ on:
     - cron: "30 1 * * 0"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -23,6 +23,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches: ["main"]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   integration:
     name: Integration Tests (conditional)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,10 +2,14 @@ name: Lint
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
     branches: ["**"]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,13 @@ name: Tests
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
     branches: ["**"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Fixes duplicate CI runs on pull requests and adds concurrency groups to prevent resource waste.

## Changes

- **test.yml**: Push trigger now only on `main` (was all branches), PR on all branches. Adds concurrency with cancel-in-progress.
- **lint.yml**: Push trigger now only on `main` (was all branches), PR on all branches. Adds concurrency with cancel-in-progress.
- **codeql-analysis.yml**: Adds concurrency with cancel-in-progress: false (security scans should not be cancelled).
- **docker-images.yml**: Adds concurrency with cancel-in-progress: true (PR builds don't push, so duplication is acceptable but concurrency prevents resource waste).
- **integration.yml**: Adds concurrency with cancel-in-progress: false (integration tests should not be cancelled).

## Why

Previously, every PR commit triggered BOTH the `push` event (all branches) AND the `pull_request` event, causing tests/lint to run twice. The new trigger configuration ensures:
- PR commits only trigger `pull_request` event
- Main branch merges only trigger `push` event
- Concurrency groups prevent stale runs from consuming resources

The concurrency group pattern `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}` ensures:
- PR runs are grouped by PR number (new push cancels old run)
- Main branch runs are grouped by ref (new merge cancels stale run)