### PR TITLE
fix: bridge PG team_mappings to CH teams for filters and chart team assignment

### DIFF
--- a/src/dev_health_ops/api/queries/filters.py
+++ b/src/dev_health_ops/api/queries/filters.py
@@ -23,8 +23,8 @@ async def fetch_filter_options(client: Any) -> Dict[str, List[str]]:
         SELECT DISTINCT value
         FROM (
             SELECT id AS value
-            FROM teams
-            WHERE id != ''
+            FROM teams FINAL
+            WHERE id != '' AND is_active = 1
 
             UNION ALL
 

--- a/src/dev_health_ops/migrations/clickhouse/025_teams_project_repo.sql
+++ b/src/dev_health_ops/migrations/clickhouse/025_teams_project_repo.sql
@@ -1,0 +1,3 @@
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS project_keys Array(String) DEFAULT [];
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS repo_patterns Array(String) DEFAULT [];
+ALTER TABLE teams ADD COLUMN IF NOT EXISTS is_active UInt8 DEFAULT 1;

--- a/src/dev_health_ops/providers/team_bridge.py
+++ b/src/dev_health_ops/providers/team_bridge.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from typing import Any, List
+
+from sqlalchemy import select
+
+from dev_health_ops.db import get_postgres_session_sync
+from dev_health_ops.models.settings import TeamMapping
+from dev_health_ops.storage.clickhouse import ClickHouseStore
+
+
+def _parse_json_array(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(v) for v in value if v is not None]
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return []
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                return [str(v) for v in parsed if v is not None]
+        except Exception:
+            return []
+    return []
+
+
+def _clickhouse_uri() -> str:
+    uri = (
+        os.getenv("CLICKHOUSE_URI")
+        or os.getenv("DATABASE_URI")
+        or os.getenv("DATABASE_URL")
+    )
+    if not uri:
+        raise RuntimeError("Missing CLICKHOUSE_URI or DATABASE_URI for team bridge")
+    return uri
+
+
+def bridge_teams_to_clickhouse(org_id: str = "default") -> int:
+    teams_payload: List[dict[str, Any]] = []
+
+    with get_postgres_session_sync() as session:
+        mappings = (
+            session.execute(
+                select(TeamMapping).where(
+                    TeamMapping.org_id == org_id,
+                    TeamMapping.is_active.is_(True),
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        for mapping in mappings:
+            team_id = str(mapping.team_id or "").strip()
+            if not team_id:
+                continue
+            teams_payload.append(
+                {
+                    "id": team_id,
+                    "team_uuid": uuid.uuid5(
+                        uuid.NAMESPACE_URL, f"team:{org_id}:{team_id}"
+                    ),
+                    "name": str(mapping.name or team_id),
+                    "description": mapping.description,
+                    "project_keys": _parse_json_array(mapping.project_keys),
+                    "repo_patterns": _parse_json_array(mapping.repo_patterns),
+                    "members": [],
+                    "is_active": 1,
+                    "org_id": org_id,
+                    "updated_at": mapping.updated_at,
+                }
+            )
+
+    async def _run() -> None:
+        async with ClickHouseStore(_clickhouse_uri()) as store:
+            await store.ensure_tables()
+            await store.insert_teams(teams_payload)
+
+    asyncio.run(_run())
+    return len(teams_payload)

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -967,14 +967,23 @@ class ClickHouseStore:
         rows: List[Dict[str, Any]] = []
         for item in teams:
             if isinstance(item, dict):
+                team_id = str(item.get("id") or "")
                 rows.append(
                     {
-                        "id": item.get("id"),
+                        "id": team_id,
+                        "team_uuid": self._normalize_uuid(
+                            item.get("team_uuid")
+                            or uuid.uuid5(uuid.NAMESPACE_URL, f"team:{team_id}")
+                        ),
                         "name": item.get("name"),
                         "description": item.get("description"),
                         "members": item.get("members") or [],
+                        "project_keys": item.get("project_keys") or [],
+                        "repo_patterns": item.get("repo_patterns") or [],
+                        "is_active": int(item.get("is_active", 1)),
                         "updated_at": self._normalize_datetime(item.get("updated_at")),
                         "last_synced": synced_at,
+                        "org_id": item.get("org_id") or "default",
                     }
                 )
             else:
@@ -985,10 +994,14 @@ class ClickHouseStore:
                         "name": getattr(item, "name"),
                         "description": getattr(item, "description"),
                         "members": getattr(item, "members", []) or [],
+                        "project_keys": getattr(item, "project_keys", []) or [],
+                        "repo_patterns": getattr(item, "repo_patterns", []) or [],
+                        "is_active": int(getattr(item, "is_active", 1) or 0),
                         "updated_at": self._normalize_datetime(
                             getattr(item, "updated_at")
                         ),
                         "last_synced": synced_at,
+                        "org_id": getattr(item, "org_id", "default") or "default",
                     }
                 )
 
@@ -1000,8 +1013,12 @@ class ClickHouseStore:
                 "name",
                 "description",
                 "members",
+                "project_keys",
+                "repo_patterns",
+                "is_active",
                 "updated_at",
                 "last_synced",
+                "org_id",
             ],
             rows,
         )


### PR DESCRIPTION
## Summary

Fixes the bug where imported teams don't appear in filter dropdowns or charts. The root cause is that team data lives in PostgreSQL `team_mappings` but was never synced to the ClickHouse `teams` table used by analytics queries.

## Changes

### Bridge: PG → CH team sync
- **CH migration 025**: Adds `project_keys`, `repo_patterns`, `is_active` columns to CH `teams` table
- **`team_bridge.py`**: New module that reads active `team_mappings` from PG and upserts into CH `teams` via `ClickHouseStore`
- **`sync_teams_to_analytics` Celery task**: Wraps the bridge function, dispatched from admin team endpoints
- **Admin router**: Triggers sync after team import, create/update, approve changes, and member confirmation

### Work Item Team Assignment
- **`ProjectKeyTeamResolver`**: Maps `work_scope_id` (project key) → `(team_id, team_name)` using `team_mappings.project_keys`
- Wired into `compute_work_item_metrics_daily()` and `compute_work_item_state_durations_daily()` — project_key matching takes priority, falls back to identity-based resolution

### Git Metrics Team Assignment
- **`RepoPatternTeamResolver`**: Maps repo names → `(team_id, team_name)` using `team_mappings.repo_patterns` with exact and glob prefix matching
- Wired into `compute_daily_metrics()` and `compute_team_wellbeing_metrics_daily()` — used as fallback when member-based `TeamResolver` has no match

### Sink & Query Updates
- **`ClickHouseMetricsSink.insert_teams()`**: New method for bulk inserting teams
- **`ClickHouseMetricsSink.get_all_teams()`**: Now returns `project_keys` and `repo_patterns`
- **`ClickHouseStore.insert_teams()`**: Extended to write new columns
- **Filter query**: Adds `FINAL` and `is_active = 1` filter to teams subquery

## Data Flow (After Fix)

```
Admin UI → PG team_mappings → sync_teams_to_analytics → CH teams
                                                            ↓
Daily Metrics:   TeamResolver(members) + RepoPatternTeamResolver(repo_patterns)
Work Item Metrics: ProjectKeyTeamResolver(project_keys) + TeamResolver(members)
Filters:         CH teams (is_active=1) + metrics team_ids
```

## Testing

After merge:
1. Run `sync_teams_to_analytics` task (or trigger from admin UI)
2. Verify `SELECT * FROM teams FINAL` in CH shows imported teams
3. Re-run daily metrics to backfill team assignments
4. Verify filter dropdown shows real team names