### PR TITLE
feat: investment materialization without LLM — blank explanations when no provider

### DIFF
--- a/src/dev_health_ops/api/models/schemas.py
+++ b/src/dev_health_ops/api/models/schemas.py
@@ -208,7 +208,9 @@ class InvestmentMixExplanation(BaseModel):
     confidence: InvestmentConfidence
     what_to_check_next: List[InvestmentActionItem] = Field(default_factory=list)
     anti_claims: List[str] = Field(default_factory=list)
-    status: Optional[Literal["valid", "invalid_json", "invalid_llm_output"]] = None
+    status: Optional[
+        Literal["valid", "invalid_json", "invalid_llm_output", "llm_unavailable"]
+    ] = None
 
 
 class WorkUnitTimeRange(BaseModel):

--- a/src/dev_health_ops/api/services/investment_mix_explain.py
+++ b/src/dev_health_ops/api/services/investment_mix_explain.py
@@ -24,7 +24,7 @@ from ..models.schemas import (
     InvestmentMixExplanation,
 )
 from .investment import build_investment_response
-from dev_health_ops.llm import get_provider
+from dev_health_ops.llm import get_provider, is_llm_available
 from .work_units import build_work_unit_investments
 from dev_health_ops.api.utils.logging import sanitize_for_log
 
@@ -112,6 +112,22 @@ async def explain_investment_mix(
             safe_resolved_theme,
         )
         theme = theme_of(subcategory)
+
+    if not is_llm_available(llm_provider):
+        return InvestmentMixExplanation(
+            summary="",
+            top_findings=[],
+            confidence=InvestmentConfidence(
+                level="unknown",
+                quality_mean=None,
+                quality_stddev=None,
+                band_mix={},
+                drivers=[],
+            ),
+            what_to_check_next=[],
+            anti_claims=[],
+            status="llm_unavailable",
+        )
 
     # Compute cache key for lookup
     cache_key = _compute_cache_key(filters, theme, subcategory)

--- a/src/dev_health_ops/api/services/work_unit_explain.py
+++ b/src/dev_health_ops/api/services/work_unit_explain.py
@@ -21,7 +21,7 @@ from dev_health_ops.llm.explainers.work_unit_explainer import (
     validate_explanation_language,
 )
 from ..models.schemas import EvidenceQuality, WorkUnitExplanation, WorkUnitInvestment
-from dev_health_ops.llm import get_provider
+from dev_health_ops.llm import get_provider, is_llm_available
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +49,17 @@ async def explain_work_unit(
     Returns:
         Structured WorkUnitExplanation with validated content
     """
+    if not is_llm_available(llm_provider):
+        return WorkUnitExplanation(
+            work_unit_id=investment.work_unit_id,
+            ai_generated=False,
+            summary="",
+            category_rationale={},
+            evidence_highlights=[],
+            uncertainty_disclosure="",
+            evidence_quality_limits="",
+        )
+
     # 1. Extract only allowed inputs
     inputs = extract_allowed_inputs(
         work_unit_id=investment.work_unit_id,

--- a/src/dev_health_ops/llm/__init__.py
+++ b/src/dev_health_ops/llm/__init__.py
@@ -1,3 +1,3 @@
-from .providers import LLMProvider, get_provider
+from .providers import LLMProvider, get_provider, is_llm_available
 
-__all__ = ["LLMProvider", "get_provider"]
+__all__ = ["LLMProvider", "get_provider", "is_llm_available"]

--- a/src/dev_health_ops/llm/cli.py
+++ b/src/dev_health_ops/llm/cli.py
@@ -13,7 +13,8 @@ def add_llm_arguments(parser: argparse.ArgumentParser) -> None:
         "-l",
         "--llm-provider",
         default=os.getenv("LLM_PROVIDER", "auto"),
-        help="LLM provider (auto, openai, anthropic, local, mock, etc.)",
+        help="LLM provider (auto, openai, anthropic, local, mock, none). "
+        "Use 'none' to compute distributions without LLM explanations.",
     )
     parser.add_argument(
         "-m",

--- a/src/dev_health_ops/llm/explainers/investment_mix_explainer.py
+++ b/src/dev_health_ops/llm/explainers/investment_mix_explainer.py
@@ -45,7 +45,9 @@ class InvestmentMixExplainOutput(TypedDict):
     confidence: Confidence
     what_to_check_next: List[ActionItem]
     anti_claims: List[str]
-    status: Optional[Literal["valid", "invalid_json", "invalid_llm_output"]]
+    status: Optional[
+        Literal["valid", "invalid_json", "invalid_llm_output", "llm_unavailable"]
+    ]
 
 
 _FORBIDDEN_WORDS = (" should ", " should.", " should,", " determined ", " detected ")


### PR DESCRIPTION
## Summary
- Investment numbers (subcategory distributions) already compute via MockProvider when no LLM API keys are set (`auto` → `mock`). This PR adds graceful degradation for the **explanation** endpoints.
- When no real LLM is configured, `explain_work_unit` and `explain_investment_mix` return blank responses with `status="llm_unavailable"` instead of generating mock text.
- Adds `is_llm_available()` utility and `"none"` provider option for explicit opt-out.

## Changes
| File | Change |
|------|--------|
| `llm/providers/__init__.py` | `is_llm_available()` + `"none"` provider support |
| `llm/__init__.py` | Re-export `is_llm_available` |
| `llm/cli.py` | Updated help text |
| `api/services/work_unit_explain.py` | Short-circuit blank explanation when no LLM |
| `api/services/investment_mix_explain.py` | Short-circuit blank explanation when no LLM |
| `api/models/schemas.py` | Added `"llm_unavailable"` to status literal |
| `llm/explainers/investment_mix_explainer.py` | Added `"llm_unavailable"` to TypedDict |
| `tests/api/test_work_unit_explain.py` | 7 new tests |

## How it works
- **Materialization (compute-time)**: Unchanged. `auto` with no keys → `MockProvider` → keyword-heuristic subcategory distributions. Numbers always compute.
- **Explanation (UX-time)**: `is_llm_available()` checks if a real provider is configured. If not, returns blank explanation immediately (no LLM call, no mock text).
- **`"none"` provider**: Explicitly opt out of LLM. Uses MockProvider for numbers, blank for explanations. Useful for `--llm-provider none` on CLI.

## Testing
- 15/15 tests pass (7 new + 8 existing)
- New tests cover: `is_llm_available` for none/mock/auto/openai, `get_provider("none")`, blank explanation path