### PR TITLE
fix: team bridge sync crash — ensure_tables AttributeError

### DIFF
--- a/src/dev_health_ops/providers/team_bridge.py
+++ b/src/dev_health_ops/providers/team_bridge.py
@@ -80,7 +80,6 @@ def bridge_teams_to_clickhouse(org_id: str = "default") -> int:
 
     async def _run() -> None:
         async with ClickHouseStore(_clickhouse_uri()) as store:
-            await store.ensure_tables()
             await store.insert_teams(teams_payload)
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- `bridge_teams_to_clickhouse()` called `store.ensure_tables()` which doesn't exist on `ClickHouseStore`. The method is `_ensure_tables()` (private) and runs automatically in `__aenter__` via the async context manager.
- This caused the `sync_teams_to_analytics` Celery task to fail with `AttributeError`, preventing PG teams from being synced to ClickHouse and leaving team filters empty.

## Root Cause
Introduced in PR #412 — the bridge function called a non-existent public method. The fix removes the redundant call since `async with ClickHouseStore(...)` already handles schema initialization.

## Change
1 line removed from `providers/team_bridge.py`.

## Verification
After applying this fix locally:
- `bridge_teams_to_clickhouse()` succeeds, syncing 14 teams
- `/api/v1/filters/options` returns 21 teams (14 real + 6 fixture + 1 unassigned)
- CH `teams` table shows all teams with correct `project_keys`, `repo_patterns`, and `is_active`