### PR TITLE
fix: repo-pattern team resolver takes priority over identity-based resolver

### DIFF
--- a/src/dev_health_ops/metrics/compute.py
+++ b/src/dev_health_ops/metrics/compute.py
@@ -386,14 +386,14 @@ def compute_daily_metrics(
     ):
         team_id = "unassigned"
         team_name = "Unassigned"
-        if team_resolver is not None:
-            t_id, t_name = team_resolver.resolve(author_identity)
+        if repo_team_resolver is not None:
+            repo_name = (repo_names_by_id or {}).get(repo_id)
+            t_id, t_name = repo_team_resolver.resolve(repo_name)
             if t_id:
                 team_id = t_id
                 team_name = t_name or t_id
-        if (not team_id or team_id == "unassigned") and repo_team_resolver is not None:
-            repo_name = (repo_names_by_id or {}).get(repo_id)
-            t_id, t_name = repo_team_resolver.resolve(repo_name)
+        if (not team_id or team_id == "unassigned") and team_resolver is not None:
+            t_id, t_name = team_resolver.resolve(author_identity)
             if t_id:
                 team_id = t_id
                 team_name = t_name or t_id

--- a/src/dev_health_ops/metrics/compute_wellbeing.py
+++ b/src/dev_health_ops/metrics/compute_wellbeing.py
@@ -74,11 +74,11 @@ def compute_team_wellbeing_metrics_daily(
             continue
         team_id = None
         team_name = None
-        if team_resolver is not None:
-            team_id, team_name = team_resolver.resolve(identity)
-        if (not team_id) and repo_team_resolver is not None:
+        if repo_team_resolver is not None:
             repo_name = (repo_names_by_id or {}).get(_key[0])
             team_id, team_name = repo_team_resolver.resolve(repo_name)
+        if (not team_id) and team_resolver is not None:
+            team_id, team_name = team_resolver.resolve(identity)
         if not team_id:
             team_id = unknown_team_id
             team_name = unknown_team_name


### PR DESCRIPTION
## Summary
- Explicit repo/project assignments via `team_mappings.repo_patterns` now override identity-based team membership during metric computation.
- Previously, the identity resolver ran first and always won when a user belonged to any team — even when the repo was explicitly assigned to a different team via patterns.

## Root Cause
In `compute.py` and `compute_wellbeing.py`, the resolver order was:
1. Identity-based resolver (team membership by email)
2. Repo-pattern resolver (team ownership by repo name) — **only as fallback**

This meant a commit by `david@example.com` (member of fixture `team-e`) on repo `acme/demo-app-13` (assigned to `API` team) was attributed to `team-e` because the identity resolver matched first.

## Fix
Swapped the priority in both files:
1. **Repo-pattern resolver first** (explicit repo → team assignment)
2. **Identity resolver as fallback** (only when no repo pattern matches)

This aligns with `compute_work_items.py` which already had the correct priority (`project_key_resolver` before `team_resolver`).

## Changes
| File | Change |
|------|--------|
| `metrics/compute.py` | Swap resolver order: repo-pattern first, identity fallback |
| `metrics/compute_wellbeing.py` | Same swap |

## Verification
After fix + 30-day metrics recompute:
- `acme/demo-app-13` metrics: `team_id = 'API'` (was `team-e`)
- `team_metrics_daily` has 27 rows for API team
- Filter endpoint returns API team with attributed work