### PR TITLE
fix: pass team_map to IC metrics and track cross-provider identity issue

### DIFF
--- a/src/dev_health_ops/metrics/compute_ic.py
+++ b/src/dev_health_ops/metrics/compute_ic.py
@@ -49,7 +49,7 @@ def compute_ic_metrics_daily(
         git_map[identity] = r
 
     # Process WI metrics
-    # TODO: Find a way to map JIRA/LinearB/whatever to git commits more reliably.
+    # Cross-provider identity mapping is a known limitation (see GH#416).
     # Currently we rely on identity_mapping.yaml to normalize identities separately
     # for Git (via compute.py) and WorkItems (via compute_work_items.py).
     wi_map: Dict[str, WorkItemUserMetricsDailyRecord] = {}

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -440,7 +440,7 @@ async def run_daily_metrics_job(
         ic_metrics = compute_ic_metrics_daily(
             git_metrics=result.user_metrics,
             wi_metrics=wi_user_metrics,
-            team_map={},  # TODO: Pass actual team map if available
+            team_map=load_team_map(),
         )
         for s in sinks:
             s.write_user_metrics(ic_metrics)


### PR DESCRIPTION
## Summary

- **job_daily.py**: `compute_ic_metrics_daily()` was called with `team_map={}` while `compute_ic_landscape_rolling()` on the next line correctly used `load_team_map()`. This meant IC daily metrics never resolved teams from the identity→team mapping, producing `unassigned` team_ids for users who should have been attributed.
- **compute_ic.py**: Replaced the TODO comment with a reference to GH#416, which tracks the cross-provider identity mapping improvement as a proper issue.

## Changes

| File | Change |
|------|--------|
| `metrics/job_daily.py` | `team_map={}` → `team_map=load_team_map()` |
| `metrics/compute_ic.py` | TODO → GH#416 reference |

Closes #416 (tracking issue created, not the fix itself — the TODO is now documented)