### PR TITLE
fix: investment materialize CLI defaults to CLICKHOUSE_URI

### DIFF
--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -288,8 +288,8 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
     )
     investment_materialize.add_argument(
         "--db",
-        default=os.getenv("DATABASE_URI") or os.getenv("DATABASE_URL"),
-        help="ClickHouse connection string (clickhouse://user:pass@host:port/db).",
+        default=os.getenv("CLICKHOUSE_URI"),
+        help="ClickHouse connection string (clickhouse://user:pass@host:port/db). Env: CLICKHOUSE_URI",
     )
     investment_materialize.add_argument(
         "--from",


### PR DESCRIPTION
## Problem

`dev-hops work-graph investment materialize` defaulted `--db` to `DATABASE_URI` (PostgreSQL):

```
2026-02-11 11:50:50,920 INFO dev_health_ops.metrics.sinks.factory: Creating postgres sink from DSN
```

The investment queries (`work_graph/investment/queries.py`) use ClickHouse-specific SQL (`toString()`, ClickHouse table names), so a Postgres sink fails.

## Root Cause

```python
# runner.py line 290-291 (before)
"--db",
default=os.getenv("DATABASE_URI") or os.getenv("DATABASE_URL"),
```

The help text said "ClickHouse connection string" but the default read the PostgreSQL env var.

## Fix

```python
# runner.py line 290-291 (after)
"--db",
default=os.getenv("CLICKHOUSE_URI"),
```

Matches the convention used everywhere else: `cli.py`, `fixtures/runner.py`, `workers/tasks.py`, `api/runner.py`.

## One-line change

`runner.py`: `DATABASE_URI` → `CLICKHOUSE_URI` for the investment materialize `--db` default.