### PR TITLE
feat: parallelize daily metrics with repo partitioning and checkpoints (#422, #423, #424)

### DIFF
--- a/src/dev_health_ops/alembic/versions/l2g3h4i5j6k7_add_metric_checkpoints.py
+++ b/src/dev_health_ops/alembic/versions/l2g3h4i5j6k7_add_metric_checkpoints.py
@@ -1,0 +1,92 @@
+"""Add metric_checkpoints table.
+
+Revision ID: l2g3h4i5j6k7
+Revises: k1f2g3h4i5j6
+Create Date: 2026-02-12 10:00:00
+
+Adds the metric_checkpoints table for tracking metrics computation
+watermarks.  Enables resume-on-failure and distributed coordination
+for the partitioned daily-metrics pipeline (gh-422, gh-423).
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "l2g3h4i5j6k7"
+down_revision: Union[str, None] = "k1f2g3h4i5j6"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "metric_checkpoints",
+        sa.Column("id", sa.dialects.postgresql.UUID(), primary_key=True),
+        sa.Column("org_id", sa.Text(), nullable=False, server_default="default"),
+        sa.Column("repo_id", sa.dialects.postgresql.UUID(), nullable=True),
+        sa.Column(
+            "metric_type",
+            sa.Text(),
+            nullable=False,
+            comment="Computation scope: daily_batch, daily_finalize, rebuild",
+        ),
+        sa.Column(
+            "day",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            comment="Target date",
+        ),
+        sa.Column(
+            "status",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+            comment="0=pending, 1=running, 2=completed, 3=failed",
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column(
+            "worker_id",
+            sa.Text(),
+            nullable=True,
+            comment="Celery task ID for distributed locking",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "org_id",
+            "repo_id",
+            "metric_type",
+            "day",
+            name="uq_checkpoint_scope",
+        ),
+    )
+    op.create_index(
+        "ix_checkpoint_status_day",
+        "metric_checkpoints",
+        ["status", "day"],
+    )
+    op.create_index(
+        "ix_checkpoint_org_type_day",
+        "metric_checkpoints",
+        ["org_id", "metric_type", "day"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_checkpoint_org_type_day", table_name="metric_checkpoints")
+    op.drop_index("ix_checkpoint_status_day", table_name="metric_checkpoints")
+    op.drop_table("metric_checkpoints")

--- a/src/dev_health_ops/metrics/checkpoints.py
+++ b/src/dev_health_ops/metrics/checkpoints.py
@@ -1,0 +1,253 @@
+"""CRUD operations for MetricCheckpoint model.
+
+This module provides synchronous data-access functions for managing metric computation
+checkpoints. Checkpoints track the completion state of metric computations per
+(org, repo, type, day) scope, enabling:
+
+- Resume-on-failure: skip repos that already completed for a given day
+- Distributed coordination: prevent duplicate computation across workers
+- Backfill tracking: know exactly which (repo, day) pairs have been computed
+- Crash recovery: reset stale RUNNING checkpoints back to PENDING
+
+All functions use synchronous SQLAlchemy sessions (Session, not AsyncSession)
+and are designed to run inside Celery tasks via get_postgres_session_sync().
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.checkpoints import CheckpointStatus, MetricCheckpoint
+
+
+def get_checkpoint(
+    session: Session,
+    org_id: str,
+    repo_id: Optional[uuid.UUID],
+    metric_type: str,
+    day: datetime,
+) -> Optional[MetricCheckpoint]:
+    """Retrieve a checkpoint by its unique scope.
+
+    Args:
+        session: SQLAlchemy synchronous session
+        org_id: Organization identifier
+        repo_id: Repository identifier (may be None for finalize checkpoints)
+        metric_type: Metric computation type (e.g., 'daily_batch', 'daily_finalize')
+        day: Target date (timezone-aware datetime)
+
+    Returns:
+        MetricCheckpoint if found, None otherwise
+    """
+    return (
+        session.query(MetricCheckpoint)
+        .filter(
+            MetricCheckpoint.org_id == org_id,
+            MetricCheckpoint.repo_id == repo_id,
+            MetricCheckpoint.metric_type == metric_type,
+            MetricCheckpoint.day == day,
+        )
+        .first()
+    )
+
+
+def mark_running(
+    session: Session,
+    org_id: str,
+    repo_id: Optional[uuid.UUID],
+    metric_type: str,
+    day: datetime,
+    worker_id: str,
+) -> MetricCheckpoint:
+    """Create or update a checkpoint to RUNNING status.
+
+    Upsert pattern: creates a new checkpoint if it doesn't exist, or updates
+    an existing one to RUNNING status with the given worker_id and started_at.
+
+    Args:
+        session: SQLAlchemy synchronous session
+        org_id: Organization identifier
+        repo_id: Repository identifier (may be None for finalize checkpoints)
+        metric_type: Metric computation type
+        day: Target date (timezone-aware datetime)
+        worker_id: Celery task ID for distributed locking
+
+    Returns:
+        Updated or created MetricCheckpoint with status=RUNNING
+    """
+    checkpoint = get_checkpoint(session, org_id, repo_id, metric_type, day)
+
+    if checkpoint is None:
+        checkpoint = MetricCheckpoint(
+            org_id=org_id,
+            repo_id=repo_id,
+            metric_type=metric_type,
+            day=day,
+            status=CheckpointStatus.RUNNING,
+            started_at=datetime.now(timezone.utc),
+            worker_id=worker_id,
+        )
+        session.add(checkpoint)
+    else:
+        checkpoint.status = CheckpointStatus.RUNNING
+        checkpoint.started_at = datetime.now(timezone.utc)
+        checkpoint.worker_id = worker_id
+
+    session.flush()
+    return checkpoint
+
+
+def mark_completed(session: Session, checkpoint_id: uuid.UUID) -> None:
+    """Mark a checkpoint as COMPLETED.
+
+    Args:
+        session: SQLAlchemy synchronous session
+        checkpoint_id: UUID of the checkpoint to update
+
+    Raises:
+        ValueError: If checkpoint not found
+    """
+    checkpoint = (
+        session.query(MetricCheckpoint)
+        .filter(MetricCheckpoint.id == checkpoint_id)
+        .first()
+    )
+
+    if checkpoint is None:
+        raise ValueError(f"Checkpoint {checkpoint_id} not found")
+
+    checkpoint.status = CheckpointStatus.COMPLETED
+    checkpoint.completed_at = datetime.now(timezone.utc)
+    session.flush()
+
+
+def mark_failed(
+    session: Session,
+    checkpoint_id: uuid.UUID,
+    error: str,
+) -> None:
+    """Mark a checkpoint as FAILED with error message.
+
+    Args:
+        session: SQLAlchemy synchronous session
+        checkpoint_id: UUID of the checkpoint to update
+        error: Error message describing the failure
+
+    Raises:
+        ValueError: If checkpoint not found
+    """
+    checkpoint = (
+        session.query(MetricCheckpoint)
+        .filter(MetricCheckpoint.id == checkpoint_id)
+        .first()
+    )
+
+    if checkpoint is None:
+        raise ValueError(f"Checkpoint {checkpoint_id} not found")
+
+    checkpoint.status = CheckpointStatus.FAILED
+    checkpoint.error = error
+    session.flush()
+
+
+def is_completed(
+    session: Session,
+    org_id: str,
+    repo_id: Optional[uuid.UUID],
+    metric_type: str,
+    day: datetime,
+) -> bool:
+    """Check if a checkpoint has completed successfully.
+
+    Args:
+        session: SQLAlchemy synchronous session
+        org_id: Organization identifier
+        repo_id: Repository identifier (may be None for finalize checkpoints)
+        metric_type: Metric computation type
+        day: Target date (timezone-aware datetime)
+
+    Returns:
+        True if checkpoint exists and status is COMPLETED, False otherwise
+    """
+    checkpoint = get_checkpoint(session, org_id, repo_id, metric_type, day)
+    return checkpoint is not None and checkpoint.status == CheckpointStatus.COMPLETED
+
+
+def get_incomplete_repos(
+    session: Session,
+    org_id: str,
+    metric_type: str,
+    day: datetime,
+    all_repo_ids: list[uuid.UUID],
+) -> list[uuid.UUID]:
+    """Get repo IDs that have not yet completed for the given scope.
+
+    Returns the subset of all_repo_ids where either:
+    - No checkpoint exists for (org_id, repo_id, metric_type, day)
+    - A checkpoint exists but status != COMPLETED
+
+    Args:
+        session: SQLAlchemy synchronous session
+        org_id: Organization identifier
+        metric_type: Metric computation type
+        day: Target date (timezone-aware datetime)
+        all_repo_ids: List of all repo IDs to check
+
+    Returns:
+        List of repo IDs that are incomplete (not yet COMPLETED)
+    """
+    completed_repos = (
+        session.query(MetricCheckpoint.repo_id)
+        .filter(
+            MetricCheckpoint.org_id == org_id,
+            MetricCheckpoint.metric_type == metric_type,
+            MetricCheckpoint.day == day,
+            MetricCheckpoint.status == CheckpointStatus.COMPLETED,
+        )
+        .all()
+    )
+
+    completed_set = {row[0] for row in completed_repos}
+    return [repo_id for repo_id in all_repo_ids if repo_id not in completed_set]
+
+
+def reset_stale_running(
+    session: Session,
+    stale_threshold_minutes: int = 60,
+) -> int:
+    """Reset RUNNING checkpoints older than threshold back to PENDING.
+
+    Used for crash recovery: if a worker dies while processing a checkpoint,
+    this function resets it so another worker can retry.
+
+    Args:
+        session: SQLAlchemy synchronous session
+        stale_threshold_minutes: Age threshold in minutes (default 60)
+
+    Returns:
+        Number of checkpoints reset
+    """
+    now = datetime.now(timezone.utc)
+    stale_cutoff = now - timedelta(minutes=stale_threshold_minutes)
+
+    stale_checkpoints = (
+        session.query(MetricCheckpoint)
+        .filter(
+            MetricCheckpoint.status == CheckpointStatus.RUNNING,
+            MetricCheckpoint.started_at < stale_cutoff,
+        )
+        .all()
+    )
+
+    count = len(stale_checkpoints)
+    for checkpoint in stale_checkpoints:
+        checkpoint.status = CheckpointStatus.PENDING
+        checkpoint.started_at = None
+        checkpoint.worker_id = None
+
+    session.flush()
+    return count

--- a/src/dev_health_ops/models/__init__.py
+++ b/src/dev_health_ops/models/__init__.py
@@ -46,6 +46,7 @@ from .sso import (
     SSOProvider,
     SSOProviderStatus,
 )
+from .checkpoints import CheckpointStatus, MetricCheckpoint
 from .ip_allowlist import OrgIPAllowlist
 from .retention import (
     OrgRetentionPolicy,
@@ -57,6 +58,7 @@ __all__ = [
     "AuditLog",
     "AuditResourceType",
     "AuthProvider",
+    "CheckpointStatus",
     "FeatureCategory",
     "FeatureFlag",
     "Base",
@@ -73,6 +75,7 @@ __all__ = [
     "JobStatus",
     "MemberRole",
     "Membership",
+    "MetricCheckpoint",
     "Organization",
     "OrgFeatureOverride",
     "OrgIPAllowlist",

--- a/src/dev_health_ops/models/checkpoints.py
+++ b/src/dev_health_ops/models/checkpoints.py
@@ -1,0 +1,100 @@
+"""Metric checkpoint models for tracking computation watermarks.
+
+Checkpoints enable:
+- Resume-on-failure: skip repos that already completed for a given day
+- Distributed coordination: prevent duplicate computation across workers
+- Backfill tracking: know exactly which (repo, day) pairs have been computed
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from enum import IntEnum
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Index,
+    Integer,
+    Text,
+    UniqueConstraint,
+)
+
+from dev_health_ops.models.git import Base, GUID
+
+
+class CheckpointStatus(IntEnum):
+    PENDING = 0
+    RUNNING = 1
+    COMPLETED = 2
+    FAILED = 3
+
+
+class MetricCheckpoint(Base):
+    """Tracks completion state of metric computations per (org, repo, type, day).
+
+    Used by the partitioned metrics pipeline to:
+    - Skip already-completed repos on retry/resume
+    - Track which worker is processing a given scope
+    - Record errors for failed computations
+    - Enable the ``metrics rebuild`` CLI to target specific gaps
+
+    The ``repo_id`` column is nullable: NULL represents a "finalize" checkpoint
+    that covers cross-repo aggregations (e.g. IC landscape rolling).
+    """
+
+    __tablename__ = "metric_checkpoints"
+
+    id = Column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id = Column(Text, nullable=False, default="default")
+    repo_id = Column(GUID, nullable=True)
+    metric_type = Column(
+        Text,
+        nullable=False,
+        comment="Computation scope: daily_batch, daily_finalize, rebuild",
+    )
+    day = Column(DateTime(timezone=True), nullable=False, comment="Target date")
+    status = Column(
+        Integer,
+        nullable=False,
+        default=CheckpointStatus.PENDING,
+        comment="0=pending, 1=running, 2=completed, 3=failed",
+    )
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    error = Column(Text, nullable=True)
+    worker_id = Column(
+        Text, nullable=True, comment="Celery task ID for distributed locking"
+    )
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id",
+            "repo_id",
+            "metric_type",
+            "day",
+            name="uq_checkpoint_scope",
+        ),
+        Index("ix_checkpoint_status_day", "status", "day"),
+        Index("ix_checkpoint_org_type_day", "org_id", "metric_type", "day"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<MetricCheckpoint("
+            f"org={self.org_id!r}, repo={self.repo_id}, "
+            f"type={self.metric_type!r}, day={self.day}, "
+            f"status={self.status})>"
+        )

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -30,8 +30,9 @@ task_max_retries = 3
 task_default_queue = "default"
 task_queues = {
     "default": {},
-    "metrics": {},  # Long-running metrics jobs
-    "sync": {},  # Data sync tasks
+    "metrics": {},
+    "sync": {},
+    "webhooks": {},
 }
 
 # Beat schedule (periodic tasks)
@@ -47,9 +48,9 @@ beat_schedule = {
         "options": {"queue": "default"},
     },
     "run-daily-metrics": {
-        "task": "dev_health_ops.workers.tasks.run_daily_metrics",
+        "task": "dev_health_ops.workers.tasks.dispatch_daily_metrics_partitioned",
         "schedule": crontab(hour=1, minute=0),
-        "options": {"queue": "metrics"},
+        "options": {"queue": "default"},
     },
     "sync-team-drift": {
         "task": "dev_health_ops.workers.tasks.sync_team_drift",

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -16,6 +16,8 @@ import uuid
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Optional
 
+from celery import chord
+
 from dev_health_ops.workers.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
@@ -680,6 +682,308 @@ def run_daily_metrics(
         logger.exception("Daily metrics task failed: %s", exc)
         # Retry with exponential backoff
         raise self.retry(exc=exc, countdown=60 * (2**self.request.retries))
+
+
+@celery_app.task(bind=True, queue="default")
+def dispatch_daily_metrics_partitioned(
+    self,
+    db_url: Optional[str] = None,
+    day: Optional[str] = None,
+    backfill_days: int = 1,
+    batch_size: int = 5,
+    sink: str = "auto",
+    provider: str = "auto",
+    org_id: str = "default",
+) -> dict:
+    """Orchestrator: discover repos, partition into batches, fan out via chord.
+
+    For each day in the backfill range, dispatches a chord of
+    ``run_daily_metrics_batch`` tasks with a ``run_daily_metrics_finalize_task``
+    callback.
+
+    Args:
+        db_url: Database connection string (defaults to env)
+        day: Target day as ISO string (defaults to today)
+        backfill_days: Number of days to backfill
+        batch_size: Number of repos per batch task
+        sink: Sink type (auto|clickhouse)
+        provider: Work item provider (auto|all|jira|github|gitlab|none)
+        org_id: Organization scope
+
+    Returns:
+        dict with dispatched count, batch_count, and days
+    """
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    db_url = db_url or _get_db_url()
+    target_day = date.fromisoformat(day) if day else date.today()
+
+    logger.info(
+        "dispatch_daily_metrics_partitioned: day=%s backfill=%d batch_size=%d",
+        target_day.isoformat(),
+        backfill_days,
+        batch_size,
+    )
+
+    try:
+        ch_sink = ClickHouseMetricsSink(db_url)
+        rows = ch_sink.client.query("SELECT id FROM repos").result_rows
+        repo_ids = [str(row[0]) for row in rows]
+    except Exception as exc:
+        logger.exception("Failed to discover repos for partitioned dispatch: %s", exc)
+        return {"status": "error", "error": str(exc)}
+
+    if not repo_ids:
+        logger.warning("No repos found — nothing to dispatch")
+        return {"status": "no_repos", "dispatched": 0}
+
+    batches = [
+        repo_ids[i : i + batch_size] for i in range(0, len(repo_ids), batch_size)
+    ]
+
+    days_list = [target_day - timedelta(days=i) for i in range(backfill_days)]
+
+    total_dispatched = 0
+    for d in days_list:
+        day_iso = d.isoformat()
+        chord(
+            [
+                run_daily_metrics_batch.s(
+                    repo_ids=[str(rid) for rid in batch],
+                    day=day_iso,
+                    db_url=db_url,
+                    sink=sink,
+                    provider=provider,
+                    org_id=org_id,
+                )
+                for batch in batches
+            ],
+            run_daily_metrics_finalize_task.s(
+                day=day_iso,
+                db_url=db_url,
+                sink=sink,
+                org_id=org_id,
+            ),
+        )()
+        total_dispatched += len(batches)
+
+    logger.info(
+        "dispatch_daily_metrics_partitioned: dispatched %d batches across %d days",
+        total_dispatched,
+        len(days_list),
+    )
+
+    return {
+        "status": "dispatched",
+        "repo_count": len(repo_ids),
+        "batch_count": len(batches),
+        "days": len(days_list),
+        "total_dispatched": total_dispatched,
+    }
+
+
+@celery_app.task(bind=True, max_retries=3, queue="metrics")
+def run_daily_metrics_batch(
+    self,
+    repo_ids: list[str],
+    day: str,
+    db_url: Optional[str] = None,
+    sink: str = "auto",
+    provider: str = "auto",
+    org_id: str = "default",
+) -> dict:
+    """Worker: compute daily metrics for a batch of repos (single day).
+
+    Processes each repo independently so one failure does not kill the batch.
+    Uses checkpoint CRUD to track progress and skip already-completed repos.
+
+    Args:
+        repo_ids: List of repository UUID strings
+        day: Target day as ISO string
+        db_url: Database connection string
+        sink: Sink type
+        provider: Work item provider
+        org_id: Organization scope
+
+    Returns:
+        dict with per-repo results
+    """
+    from datetime import time
+
+    from dev_health_ops.db import get_postgres_session_sync
+    from dev_health_ops.metrics.checkpoints import (
+        is_completed,
+        mark_completed,
+        mark_failed,
+        mark_running,
+    )
+    from dev_health_ops.metrics.job_daily import run_daily_metrics_job
+
+    db_url = db_url or _get_db_url()
+    target_day = date.fromisoformat(day)
+    checkpoint_day = datetime.combine(target_day, time.min, tzinfo=timezone.utc)
+
+    results: dict[str, Any] = {}
+
+    for repo_id in repo_ids:
+        repo_id_uuid = uuid.UUID(repo_id)
+        try:
+            with get_postgres_session_sync() as session:
+                if is_completed(
+                    session, org_id, repo_id_uuid, "daily_batch", checkpoint_day
+                ):
+                    logger.info(
+                        "Skipping already-completed repo %s for day %s",
+                        repo_id,
+                        day,
+                    )
+                    results[repo_id] = {
+                        "status": "skipped",
+                        "reason": "already_completed",
+                    }
+                    continue
+
+                checkpoint = mark_running(
+                    session,
+                    org_id,
+                    repo_id_uuid,
+                    "daily_batch",
+                    checkpoint_day,
+                    self.request.id,
+                )
+                checkpoint_id = checkpoint.id
+
+            asyncio.run(
+                run_daily_metrics_job(
+                    db_url=db_url,
+                    day=target_day,
+                    backfill_days=1,
+                    repo_id=repo_id_uuid,
+                    skip_finalize=True,
+                    sink=sink,
+                    provider=provider,
+                    org_id=org_id,
+                )
+            )
+
+            with get_postgres_session_sync() as session:
+                mark_completed(session, checkpoint_id)
+
+            results[repo_id] = {"status": "success"}
+
+        except Exception as exc:
+            logger.exception(
+                "run_daily_metrics_batch failed for repo %s day %s: %s",
+                repo_id,
+                day,
+                exc,
+            )
+            try:
+                with get_postgres_session_sync() as session:
+                    mark_failed(session, checkpoint_id, str(exc))
+            except Exception as mark_exc:
+                logger.error("Failed to mark checkpoint as failed: %s", mark_exc)
+
+            results[repo_id] = {"status": "failed", "error": str(exc)}
+
+    return {
+        "day": day,
+        "repo_count": len(repo_ids),
+        "results": results,
+    }
+
+
+@celery_app.task(bind=True, max_retries=2, queue="metrics")
+def run_daily_metrics_finalize_task(
+    self,
+    batch_results: list,
+    day: str,
+    db_url: Optional[str] = None,
+    sink: str = "auto",
+    org_id: str = "default",
+) -> dict:
+    """Chord callback: finalize daily metrics after all batches complete.
+
+    Runs the finalize step (rollups, aggregations) and invalidates caches.
+    Named with ``_task`` suffix to avoid collision with
+    ``job_daily.run_daily_metrics_finalize``.
+
+    Args:
+        batch_results: List of results from header tasks (chord callback arg)
+        day: Target day as ISO string
+        db_url: Database connection string
+        sink: Sink type
+        org_id: Organization scope
+
+    Returns:
+        dict with finalize status
+    """
+    from datetime import time
+
+    from dev_health_ops.db import get_postgres_session_sync
+    from dev_health_ops.metrics.checkpoints import (
+        mark_completed,
+        mark_failed,
+        mark_running,
+    )
+    from dev_health_ops.metrics.job_daily import (
+        run_daily_metrics_finalize as _run_finalize,
+    )
+
+    db_url = db_url or _get_db_url()
+    target_day = date.fromisoformat(day)
+    checkpoint_day = datetime.combine(target_day, time.min, tzinfo=timezone.utc)
+
+    logger.info(
+        "run_daily_metrics_finalize_task: day=%s batches=%d",
+        day,
+        len(batch_results) if batch_results else 0,
+    )
+
+    checkpoint_id = None
+    try:
+        with get_postgres_session_sync() as session:
+            checkpoint = mark_running(
+                session, org_id, None, "daily_finalize", checkpoint_day, self.request.id
+            )
+            checkpoint_id = checkpoint.id
+
+        asyncio.run(
+            _run_finalize(
+                db_url=db_url,
+                day=target_day,
+                org_id=org_id,
+                sink=sink,
+            )
+        )
+
+        _invalidate_metrics_cache(day, org_id)
+
+        if checkpoint_id is not None:
+            with get_postgres_session_sync() as session:
+                mark_completed(session, checkpoint_id)
+
+        return {
+            "status": "success",
+            "day": day,
+            "batches_received": len(batch_results) if batch_results else 0,
+        }
+
+    except Exception as exc:
+        logger.exception(
+            "run_daily_metrics_finalize_task failed for day %s: %s", day, exc
+        )
+
+        if checkpoint_id is not None:
+            try:
+                with get_postgres_session_sync() as session:
+                    mark_failed(session, checkpoint_id, str(exc))
+            except Exception as mark_exc:
+                logger.error(
+                    "Failed to mark finalize checkpoint as failed: %s", mark_exc
+                )
+
+        raise self.retry(exc=exc, countdown=120 * (2**self.request.retries))
 
 
 def _invalidate_metrics_cache(day: str, org_id: str = "default") -> None:

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -1,0 +1,171 @@
+import uuid
+from datetime import date, datetime, time, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.checkpoints import CheckpointStatus, MetricCheckpoint
+from dev_health_ops.models.git import Base
+from dev_health_ops.metrics.checkpoints import (
+    get_checkpoint,
+    get_incomplete_repos,
+    is_completed,
+    mark_completed,
+    mark_failed,
+    mark_running,
+    reset_stale_running,
+)
+
+DAY = datetime.combine(date(2025, 1, 15), time.min, tzinfo=timezone.utc)
+ORG_ID = "default"
+METRIC_TYPE = "daily_batch"
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def test_mark_running_creates_new_checkpoint(db_session):
+    repo_id = uuid.uuid4()
+    worker_id = "celery-task-abc"
+
+    cp = mark_running(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY, worker_id)
+
+    assert cp.status == CheckpointStatus.RUNNING
+    assert cp.org_id == ORG_ID
+    assert cp.repo_id == repo_id
+    assert cp.metric_type == METRIC_TYPE
+    assert cp.day == DAY
+    assert cp.worker_id == worker_id
+    assert cp.started_at is not None
+
+
+def test_mark_running_updates_existing(db_session):
+    repo_id = uuid.uuid4()
+
+    cp1 = mark_running(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY, "worker-1")
+    cp1_id = cp1.id
+
+    cp2 = mark_running(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY, "worker-2")
+
+    assert cp2.id == cp1_id
+    assert cp2.worker_id == "worker-2"
+    count = db_session.query(MetricCheckpoint).count()
+    assert count == 1
+
+
+def test_get_checkpoint_returns_none_for_missing(db_session):
+    result = get_checkpoint(db_session, ORG_ID, uuid.uuid4(), METRIC_TYPE, DAY)
+    assert result is None
+
+
+def test_get_checkpoint_returns_existing(db_session):
+    repo_id = uuid.uuid4()
+    mark_running(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY, "w1")
+
+    result = get_checkpoint(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY)
+    assert result is not None
+    assert result.repo_id == repo_id
+    assert result.status == CheckpointStatus.RUNNING
+
+
+def test_mark_completed_sets_status_and_timestamp(db_session):
+    repo_id = uuid.uuid4()
+    cp = mark_running(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY, "w1")
+
+    mark_completed(db_session, cp.id)
+
+    refreshed = get_checkpoint(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY)
+    assert refreshed.status == CheckpointStatus.COMPLETED
+    assert refreshed.completed_at is not None
+
+
+def test_mark_completed_raises_for_missing_id(db_session):
+    with pytest.raises(ValueError, match="not found"):
+        mark_completed(db_session, uuid.uuid4())
+
+
+def test_mark_failed_sets_status_and_error(db_session):
+    repo_id = uuid.uuid4()
+    cp = mark_running(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY, "w1")
+
+    mark_failed(db_session, cp.id, "connection timeout")
+
+    refreshed = get_checkpoint(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY)
+    assert refreshed.status == CheckpointStatus.FAILED
+    assert refreshed.error == "connection timeout"
+
+
+def test_mark_failed_raises_for_missing_id(db_session):
+    with pytest.raises(ValueError, match="not found"):
+        mark_failed(db_session, uuid.uuid4(), "some error")
+
+
+def test_is_completed_true_when_completed(db_session):
+    repo_id = uuid.uuid4()
+    cp = mark_running(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY, "w1")
+    mark_completed(db_session, cp.id)
+
+    assert is_completed(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY) is True
+
+
+def test_is_completed_false_when_running(db_session):
+    repo_id = uuid.uuid4()
+    mark_running(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY, "w1")
+
+    assert is_completed(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY) is False
+
+
+def test_is_completed_false_when_no_checkpoint(db_session):
+    assert is_completed(db_session, ORG_ID, uuid.uuid4(), METRIC_TYPE, DAY) is False
+
+
+def test_get_incomplete_repos(db_session):
+    repo_completed = uuid.uuid4()
+    repo_running = uuid.uuid4()
+    repo_none = uuid.uuid4()
+
+    cp = mark_running(db_session, ORG_ID, repo_completed, METRIC_TYPE, DAY, "w1")
+    mark_completed(db_session, cp.id)
+
+    mark_running(db_session, ORG_ID, repo_running, METRIC_TYPE, DAY, "w2")
+
+    all_repos = [repo_completed, repo_running, repo_none]
+    incomplete = get_incomplete_repos(db_session, ORG_ID, METRIC_TYPE, DAY, all_repos)
+
+    assert repo_completed not in incomplete
+    assert repo_running in incomplete
+    assert repo_none in incomplete
+    assert len(incomplete) == 2
+
+
+def test_reset_stale_running(db_session):
+    repo_id = uuid.uuid4()
+    cp = mark_running(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY, "w1")
+    cp.started_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    db_session.flush()
+
+    count = reset_stale_running(db_session, stale_threshold_minutes=60)
+
+    assert count == 1
+    refreshed = get_checkpoint(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY)
+    assert refreshed.status == CheckpointStatus.PENDING
+    assert refreshed.started_at is None
+    assert refreshed.worker_id is None
+
+
+def test_reset_stale_running_ignores_recent(db_session):
+    repo_id = uuid.uuid4()
+    mark_running(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY, "w1")
+
+    count = reset_stale_running(db_session, stale_threshold_minutes=60)
+
+    assert count == 0
+    refreshed = get_checkpoint(db_session, ORG_ID, repo_id, METRIC_TYPE, DAY)
+    assert refreshed.status == CheckpointStatus.RUNNING

--- a/tests/test_p1_bug_fixes.py
+++ b/tests/test_p1_bug_fixes.py
@@ -71,8 +71,12 @@ class TestBeatScheduleMetrics:
 
         assert "run-daily-metrics" in beat_schedule
         entry = beat_schedule["run-daily-metrics"]
-        assert entry["task"] == "dev_health_ops.workers.tasks.run_daily_metrics"
-        assert entry["options"]["queue"] == "metrics"
+        # gh-422: beat schedule now dispatches partitioned metrics
+        assert (
+            entry["task"]
+            == "dev_health_ops.workers.tasks.dispatch_daily_metrics_partitioned"
+        )
+        assert entry["options"]["queue"] == "default"
 
     def test_beat_schedule_contains_metrics_dispatcher(self):
         from dev_health_ops.workers.config import beat_schedule

--- a/tests/test_parallel_metrics.py
+++ b/tests/test_parallel_metrics.py
@@ -1,0 +1,313 @@
+import uuid
+from contextlib import contextmanager
+from datetime import date, datetime, time, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.checkpoints import CheckpointStatus
+from dev_health_ops.models.git import Base
+from dev_health_ops.metrics.checkpoints import (
+    get_checkpoint,
+    mark_completed,
+    mark_running,
+)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@contextmanager
+def _fake_session_ctx(session):
+    yield session
+
+
+class TestDispatchDailyMetricsPartitioned:
+    @patch("dev_health_ops.workers.tasks.chord")
+    @patch("dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink")
+    def test_discovers_repos_and_creates_batches(self, mock_sink_cls, mock_chord):
+        from dev_health_ops.workers.tasks import dispatch_daily_metrics_partitioned
+
+        fake_rows = [(str(uuid.uuid4()),) for _ in range(7)]
+        mock_sink_instance = MagicMock()
+        mock_sink_instance.client.query.return_value.result_rows = fake_rows
+        mock_sink_cls.return_value = mock_sink_instance
+
+        mock_chord_instance = MagicMock()
+        mock_chord.return_value = mock_chord_instance
+
+        task = dispatch_daily_metrics_partitioned
+        task.push_request(id="dispatch-1")
+        try:
+            result = task(
+                db_url="clickhouse://fake",
+                day="2025-01-15",
+                backfill_days=1,
+                batch_size=3,
+            )
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "dispatched"
+        assert result["repo_count"] == 7
+        assert result["batch_count"] == 3
+        mock_chord.assert_called_once()
+        mock_chord_instance.assert_called_once()
+
+    @patch("dev_health_ops.workers.tasks.chord")
+    @patch("dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink")
+    def test_returns_no_repos_when_empty(self, mock_sink_cls, mock_chord):
+        from dev_health_ops.workers.tasks import dispatch_daily_metrics_partitioned
+
+        mock_sink_instance = MagicMock()
+        mock_sink_instance.client.query.return_value.result_rows = []
+        mock_sink_cls.return_value = mock_sink_instance
+
+        task = dispatch_daily_metrics_partitioned
+        task.push_request(id="dispatch-2")
+        try:
+            result = task(db_url="clickhouse://fake", day="2025-01-15")
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "no_repos"
+        assert result["dispatched"] == 0
+        mock_chord.assert_not_called()
+
+    @patch("dev_health_ops.workers.tasks.chord")
+    @patch("dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink")
+    def test_chord_callback_is_finalize_task(self, mock_sink_cls, mock_chord):
+        from dev_health_ops.workers.tasks import (
+            dispatch_daily_metrics_partitioned,
+            run_daily_metrics_finalize_task,
+        )
+
+        fake_rows = [(str(uuid.uuid4()),)]
+        mock_sink_instance = MagicMock()
+        mock_sink_instance.client.query.return_value.result_rows = fake_rows
+        mock_sink_cls.return_value = mock_sink_instance
+
+        mock_chord_instance = MagicMock()
+        mock_chord.return_value = mock_chord_instance
+
+        task = dispatch_daily_metrics_partitioned
+        task.push_request(id="dispatch-3")
+        try:
+            task(db_url="clickhouse://fake", day="2025-01-15")
+        finally:
+            task.pop_request()
+
+        args, kwargs = mock_chord.call_args
+        callback = kwargs.get("callback") if kwargs else args[1]
+        assert callback.task == run_daily_metrics_finalize_task.name
+
+
+class TestRunDailyMetricsBatch:
+    @patch("asyncio.run")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_marks_running_then_completed_on_success(
+        self, mock_get_session, mock_asyncio_run, db_session
+    ):
+        from dev_health_ops.workers.tasks import run_daily_metrics_batch
+
+        mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
+        mock_asyncio_run.return_value = None
+
+        repo_id = uuid.uuid4()
+        task = run_daily_metrics_batch
+        task.push_request(id="celery-task-123")
+        try:
+            result = task(
+                repo_ids=[str(repo_id)],
+                day="2025-01-15",
+                db_url="clickhouse://fake",
+            )
+        finally:
+            task.pop_request()
+
+        assert result["results"][str(repo_id)]["status"] == "success"
+        mock_asyncio_run.assert_called_once()
+
+        checkpoint_day = datetime.combine(
+            date(2025, 1, 15), time.min, tzinfo=timezone.utc
+        )
+        cp = get_checkpoint(
+            db_session, "default", repo_id, "daily_batch", checkpoint_day
+        )
+        assert cp is not None
+        assert cp.status == CheckpointStatus.COMPLETED
+
+    @patch("asyncio.run")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_marks_failed_on_exception(
+        self, mock_get_session, mock_asyncio_run, db_session
+    ):
+        from dev_health_ops.workers.tasks import run_daily_metrics_batch
+
+        mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
+        mock_asyncio_run.side_effect = RuntimeError("boom")
+
+        repo_id = uuid.uuid4()
+        task = run_daily_metrics_batch
+        task.push_request(id="celery-task-456")
+        try:
+            result = task(
+                repo_ids=[str(repo_id)],
+                day="2025-01-15",
+                db_url="clickhouse://fake",
+            )
+        finally:
+            task.pop_request()
+
+        assert result["results"][str(repo_id)]["status"] == "failed"
+        assert "boom" in result["results"][str(repo_id)]["error"]
+
+        checkpoint_day = datetime.combine(
+            date(2025, 1, 15), time.min, tzinfo=timezone.utc
+        )
+        cp = get_checkpoint(
+            db_session, "default", repo_id, "daily_batch", checkpoint_day
+        )
+        assert cp is not None
+        assert cp.status == CheckpointStatus.FAILED
+        assert cp.error == "boom"
+
+    @patch("asyncio.run")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_skips_already_completed_repos(
+        self, mock_get_session, mock_asyncio_run, db_session
+    ):
+        from dev_health_ops.workers.tasks import run_daily_metrics_batch
+
+        mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
+
+        repo_id = uuid.uuid4()
+        checkpoint_day = datetime.combine(
+            date(2025, 1, 15), time.min, tzinfo=timezone.utc
+        )
+        cp = mark_running(
+            db_session, "default", repo_id, "daily_batch", checkpoint_day, "old-worker"
+        )
+        mark_completed(db_session, cp.id)
+
+        task = run_daily_metrics_batch
+        task.push_request(id="celery-task-789")
+        try:
+            result = task(
+                repo_ids=[str(repo_id)],
+                day="2025-01-15",
+                db_url="clickhouse://fake",
+            )
+        finally:
+            task.pop_request()
+
+        assert result["results"][str(repo_id)]["status"] == "skipped"
+        mock_asyncio_run.assert_not_called()
+
+
+class TestRunDailyMetricsFinalizeTask:
+    @patch("dev_health_ops.workers.tasks._invalidate_metrics_cache")
+    @patch("asyncio.run")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_calls_finalize_and_invalidates_cache(
+        self, mock_get_session, mock_asyncio_run, mock_invalidate, db_session
+    ):
+        from dev_health_ops.workers.tasks import run_daily_metrics_finalize_task
+
+        mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
+        mock_asyncio_run.return_value = None
+
+        task = run_daily_metrics_finalize_task
+        task.push_request(id="finalize-task-1", retries=0)
+        try:
+            result = task(
+                batch_results=[{"day": "2025-01-15", "results": {}}],
+                day="2025-01-15",
+                db_url="clickhouse://fake",
+            )
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "success"
+        mock_asyncio_run.assert_called_once()
+        mock_invalidate.assert_called_once_with("2025-01-15", "default")
+
+        checkpoint_day = datetime.combine(
+            date(2025, 1, 15), time.min, tzinfo=timezone.utc
+        )
+        cp = get_checkpoint(
+            db_session, "default", None, "daily_finalize", checkpoint_day
+        )
+        assert cp is not None
+        assert cp.status == CheckpointStatus.COMPLETED
+
+    @patch("dev_health_ops.workers.tasks._invalidate_metrics_cache")
+    @patch("asyncio.run")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_marks_failed_on_finalize_error(
+        self, mock_get_session, mock_asyncio_run, mock_invalidate, db_session
+    ):
+        from dev_health_ops.workers.tasks import run_daily_metrics_finalize_task
+
+        mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
+        mock_asyncio_run.side_effect = RuntimeError("finalize exploded")
+
+        task = run_daily_metrics_finalize_task
+        task.push_request(id="finalize-task-2", retries=0)
+        original_retry = task.retry
+        task.retry = MagicMock(side_effect=RuntimeError("retry"))
+        try:
+            with pytest.raises(RuntimeError, match="retry"):
+                task(
+                    batch_results=[],
+                    day="2025-01-15",
+                    db_url="clickhouse://fake",
+                )
+        finally:
+            task.retry = original_retry
+            task.pop_request()
+
+        checkpoint_day = datetime.combine(
+            date(2025, 1, 15), time.min, tzinfo=timezone.utc
+        )
+        cp = get_checkpoint(
+            db_session, "default", None, "daily_finalize", checkpoint_day
+        )
+        assert cp is not None
+        assert cp.status == CheckpointStatus.FAILED
+
+
+class TestTaskRegistration:
+    def test_tasks_have_celery_attributes(self):
+        from dev_health_ops.workers.tasks import (
+            dispatch_daily_metrics_partitioned,
+            run_daily_metrics_batch,
+            run_daily_metrics_finalize_task,
+        )
+
+        for task in [
+            dispatch_daily_metrics_partitioned,
+            run_daily_metrics_batch,
+            run_daily_metrics_finalize_task,
+        ]:
+            assert hasattr(task, "apply_async")
+            assert hasattr(task, "delay")
+
+    def test_task_queue_assignments(self):
+        from dev_health_ops.workers.tasks import (
+            dispatch_daily_metrics_partitioned,
+            run_daily_metrics_batch,
+            run_daily_metrics_finalize_task,
+        )
+
+        assert dispatch_daily_metrics_partitioned.queue == "default"
+        assert run_daily_metrics_batch.queue == "metrics"
+        assert run_daily_metrics_finalize_task.queue == "metrics"


### PR DESCRIPTION
## Summary

- Fan out daily metrics computation into per-repo-batch Celery tasks using chord (fan-out + callback) for horizontal scalability
- Add checkpoint tracking (PostgreSQL `metric_checkpoints` table) for resume-on-failure and distributed coordination
- Add `metrics rebuild` CLI command for targeted backfills

## Changes

### New files
- **`models/checkpoints.py`** — `MetricCheckpoint` model + `CheckpointStatus` IntEnum
- **`alembic/versions/l2g3h4i5j6k7_add_metric_checkpoints.py`** — Migration adding `metric_checkpoints` table with unique constraint + indexes
- **`metrics/checkpoints.py`** — 7 CRUD functions: get_checkpoint, mark_running, mark_completed, mark_failed, is_completed, get_incomplete_repos, reset_stale_running
- **`tests/test_checkpoints.py`** — 14 unit tests for all CRUD functions
- **`tests/test_parallel_metrics.py`** — 10 tests for Celery task registration, dispatch, batch, and finalize

### Modified files
- **`models/__init__.py`** — Export `CheckpointStatus`, `MetricCheckpoint`
- **`metrics/job_daily.py`** — Add `skip_finalize` param, extract `run_daily_metrics_finalize()`, add `metrics rebuild` CLI
- **`workers/tasks.py`** — 3 new tasks: `dispatch_daily_metrics_partitioned` (orchestrator), `run_daily_metrics_batch` (worker), `run_daily_metrics_finalize_task` (chord callback)
- **`workers/config.py`** — Beat schedule uses partitioned dispatch, add `webhooks` queue
- **`tests/test_p1_bug_fixes.py`** — Update beat schedule assertion for new task name

## Architecture

```
dispatch_daily_metrics_partitioned (1am UTC, default queue)
  → discovers repos from ClickHouse
  → partitions into batches of 5
  → for each day: chord([batch tasks], finalize callback)

run_daily_metrics_batch (metrics queue)
  → per-repo: check checkpoint → skip if completed
  → mark RUNNING → compute → mark COMPLETED (or FAILED)

run_daily_metrics_finalize_task (metrics queue, chord callback)
  → loads persisted user metrics from ClickHouse
  → computes IC metrics + landscape rolling
  → invalidates GraphQL cache
```

## Backward Compatibility

- Existing `run_daily_metrics` task untouched
- `_dispatch_post_sync_tasks` still uses `run_daily_metrics`
- CLI `metrics daily` command unchanged
- New `metrics rebuild` command added

## Test Results

```
1461 passed, 5 skipped, 0 failed
ruff: All checks passed!
```

Closes #422, closes #423, closes #424