### PR TITLE
feat: Redis-backed token pool with lease/return/penalize (#428)

### DIFF
--- a/src/dev_health_ops/connectors/utils/__init__.py
+++ b/src/dev_health_ops/connectors/utils/__init__.py
@@ -13,6 +13,7 @@ from .rate_limit_queue import (
 )
 from .rest import GitLabRESTClient, RESTClient
 from .retry import RateLimiter, retry_with_backoff
+from .token_pool import TokenPool, create_token_pool
 
 __all__ = [
     "GitHubGraphQLClient",
@@ -29,4 +30,6 @@ __all__ = [
     "match_name_pattern",
     "match_repo_pattern",
     "match_project_pattern",
+    "TokenPool",
+    "create_token_pool",
 ]

--- a/src/dev_health_ops/connectors/utils/token_pool.py
+++ b/src/dev_health_ops/connectors/utils/token_pool.py
@@ -1,0 +1,238 @@
+"""Redis-backed token pool with lease/return/penalize semantics.
+
+Degrades gracefully when Redis is unavailable: ``lease_token`` returns
+``None`` and mutating methods become silent no-ops.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Lua script — atomic lease
+# ---------------------------------------------------------------------------
+# KEYS[1] = availability sorted set
+# KEYS[2] = tokens hash
+# ARGV[1] = now (epoch float)
+# ARGV[2] = lease_until (epoch float, now + lease_duration)
+#
+# Finds the member with the lowest score that is <= now (i.e. available),
+# bumps its score to lease_until so no other worker can grab it, and returns
+# the token hash + plaintext value.
+
+_LEASE_LUA = """\
+local avail_key = KEYS[1]
+local tokens_key = KEYS[2]
+local now = tonumber(ARGV[1])
+local lease_until = tonumber(ARGV[2])
+
+local candidates = redis.call('ZRANGEBYSCORE', avail_key, '-inf', tostring(now), 'LIMIT', 0, 1)
+if #candidates == 0 then
+    return nil
+end
+
+local token_hash = candidates[1]
+redis.call('ZADD', avail_key, tostring(lease_until), token_hash)
+
+local token_value = redis.call('HGET', tokens_key, token_hash)
+return {token_hash, token_value or ''}
+"""
+
+
+def _hash_token(token: str) -> str:
+    """Return first 16 hex chars of SHA-256 of *token*."""
+    return hashlib.sha256(token.encode()).hexdigest()[:16]
+
+
+class TokenPool:
+    """Redis-backed multi-token manager with lease/return/penalize."""
+
+    def __init__(
+        self,
+        provider: str,
+        org_id: str = "default",
+        redis_url: str | None = None,
+        key_prefix: str = "token_pool",
+        *,
+        lease_duration: float = 300.0,
+        redis_client: Any = None,
+    ) -> None:
+        self._provider = provider
+        self._org_id = org_id
+        self._lease_duration = lease_duration
+
+        base = f"{key_prefix}:{provider}:{org_id}"
+        self._avail_key = f"{base}:availability"
+        self._tokens_key = f"{base}:tokens"
+
+        self._redis: Any = None
+        self._redis_available = True
+        self._warned = False
+        self._lua_sha: str | None = None
+
+        if redis_client is not None:
+            self._redis = redis_client
+            try:
+                self._lua_sha = redis_client.script_load(_LEASE_LUA)
+            except Exception:
+                self._redis_available = False
+                self._warn_once("Failed to load Lua script into Redis")
+        else:
+            self._connect(redis_url)
+
+    # -- connection helpers --------------------------------------------------
+
+    def _connect(self, redis_url: str | None = None) -> None:
+        """Attempt to connect to Redis."""
+        url = redis_url or os.getenv("REDIS_URL") or ""
+        if not url:
+            self._redis_available = False
+            self._warn_once("No REDIS_URL configured — token pool disabled")
+            return
+        try:
+            import redis as _redis_mod
+
+            client = _redis_mod.from_url(url, decode_responses=True)
+            client.ping()
+            self._redis = client
+            self._lua_sha = client.script_load(_LEASE_LUA)
+            logger.info(
+                "Token pool connected to Redis for %s/%s",
+                self._provider,
+                self._org_id,
+            )
+        except Exception as exc:
+            self._redis_available = False
+            self._warn_once(f"Redis unavailable, token pool disabled: {exc}")
+
+    def _warn_once(self, msg: str) -> None:
+        if not self._warned:
+            logger.warning(msg)
+            self._warned = True
+
+    # -- public interface ----------------------------------------------------
+
+    def register_token(self, token: str) -> str:
+        """Add *token* to the pool.  Returns the token hash (16-char hex)."""
+        token_hash = _hash_token(token)
+        if not self._redis_available or self._redis is None:
+            self._warn_once("Redis unavailable — register_token is a no-op")
+            return token_hash
+        try:
+            self._redis.zadd(self._avail_key, {token_hash: 0})
+            self._redis.hset(self._tokens_key, token_hash, token)
+        except Exception as exc:
+            self._redis_available = False
+            self._warn_once(f"Redis register_token failed: {exc}")
+        return token_hash
+
+    def lease_token(self) -> tuple[str, str] | None:
+        """Atomically lease the most-available token, or ``None`` if all are cooling down."""
+        if not self._redis_available or self._redis is None:
+            return None
+        now = time.time()
+        lease_until = now + self._lease_duration
+        try:
+            result = self._redis.evalsha(
+                self._lua_sha,
+                2,
+                self._avail_key,
+                self._tokens_key,
+                str(now),
+                str(lease_until),
+            )
+        except Exception:
+            # Retry with raw EVAL in case EVALSHA fails (NOSCRIPT).
+            try:
+                result = self._redis.eval(
+                    _LEASE_LUA,
+                    2,
+                    self._avail_key,
+                    self._tokens_key,
+                    str(now),
+                    str(lease_until),
+                )
+            except Exception as exc:
+                self._redis_available = False
+                self._warn_once(f"Redis lease_token failed: {exc}")
+                return None
+
+        if result is None:
+            return None
+        token_hash: str = result[0]
+        token_value: str = result[1]
+        return (token_hash, token_value)
+
+    def return_token(self, token_hash: str) -> None:
+        """Mark a leased token as immediately available again."""
+        if not self._redis_available or self._redis is None:
+            return
+        try:
+            self._redis.zadd(self._avail_key, {token_hash: 0})
+        except Exception as exc:
+            self._redis_available = False
+            self._warn_once(f"Redis return_token failed: {exc}")
+
+    def penalize_token(self, token_hash: str, cooldown_until: float) -> None:
+        """Set a token's cooldown so it won't be leased until *cooldown_until*."""
+        if not self._redis_available or self._redis is None:
+            return
+        try:
+            self._redis.zadd(self._avail_key, {token_hash: cooldown_until})
+        except Exception as exc:
+            self._redis_available = False
+            self._warn_once(f"Redis penalize_token failed: {exc}")
+
+    def remove_token(self, token_hash: str) -> None:
+        """Remove a token from the pool entirely."""
+        if not self._redis_available or self._redis is None:
+            return
+        try:
+            self._redis.zrem(self._avail_key, token_hash)
+            self._redis.hdel(self._tokens_key, token_hash)
+        except Exception as exc:
+            self._redis_available = False
+            self._warn_once(f"Redis remove_token failed: {exc}")
+
+    def pool_size(self) -> int:
+        """Return the total number of tokens in the pool."""
+        if not self._redis_available or self._redis is None:
+            return 0
+        try:
+            return int(self._redis.zcard(self._avail_key))
+        except Exception as exc:
+            self._redis_available = False
+            self._warn_once(f"Redis pool_size failed: {exc}")
+            return 0
+
+    def available_count(self) -> int:
+        """Return the number of tokens currently available (not cooling down)."""
+        if not self._redis_available or self._redis is None:
+            return 0
+        try:
+            now = time.time()
+            return int(self._redis.zcount(self._avail_key, "-inf", str(now)))
+        except Exception as exc:
+            self._redis_available = False
+            self._warn_once(f"Redis available_count failed: {exc}")
+            return 0
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def create_token_pool(
+    provider: str,
+    org_id: str = "default",
+) -> TokenPool:
+    """Create a :class:`TokenPool` using ``REDIS_URL`` from the environment."""
+    redis_url = os.getenv("REDIS_URL") or None
+    return TokenPool(provider=provider, org_id=org_id, redis_url=redis_url)

--- a/tests/test_token_pool.py
+++ b/tests/test_token_pool.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import hashlib
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+try:
+    import fakeredis
+except (ImportError, TypeError):
+    fakeredis = None  # type: ignore[assignment]
+
+from dev_health_ops.connectors.utils.token_pool import (
+    TokenPool,
+    _hash_token,
+    create_token_pool,
+)
+
+pytestmark = pytest.mark.skipif(
+    fakeredis is None,
+    reason="fakeredis unavailable (metaclass conflict with redis in this env)",
+)
+
+
+@pytest.fixture()
+def redis_client() -> Any:
+    return fakeredis.FakeRedis(decode_responses=True)
+
+
+@pytest.fixture()
+def pool(redis_client: Any) -> TokenPool:
+    return TokenPool("github", "my-org", redis_client=redis_client)
+
+
+class TestHashToken:
+    def test_consistent(self):
+        assert _hash_token("abc") == _hash_token("abc")
+
+    def test_length_is_16(self):
+        assert len(_hash_token("anything")) == 16
+
+    def test_matches_sha256_prefix(self):
+        token = "ghp_abc123"
+        expected = hashlib.sha256(token.encode()).hexdigest()[:16]
+        assert _hash_token(token) == expected
+
+    def test_different_tokens_differ(self):
+        assert _hash_token("token-a") != _hash_token("token-b")
+
+
+class TestRegisterToken:
+    def test_returns_hash(self, pool: TokenPool):
+        h = pool.register_token("ghp_secret")
+        assert h == _hash_token("ghp_secret")
+
+    def test_adds_to_sorted_set(self, pool: TokenPool, redis_client: Any):
+        h = pool.register_token("ghp_secret")
+        score = redis_client.zscore(pool._avail_key, h)
+        assert score == 0.0
+
+    def test_adds_to_hash_map(self, pool: TokenPool, redis_client: Any):
+        h = pool.register_token("ghp_secret")
+        stored = redis_client.hget(pool._tokens_key, h)
+        assert stored == "ghp_secret"
+
+
+class TestLeaseToken:
+    def test_returns_registered_token(self, pool: TokenPool):
+        pool.register_token("ghp_one")
+        result = pool.lease_token()
+        assert result is not None
+        token_hash, token_value = result
+        assert token_hash == _hash_token("ghp_one")
+        assert token_value == "ghp_one"
+
+    def test_returns_none_when_empty(self, pool: TokenPool):
+        assert pool.lease_token() is None
+
+    def test_skips_cooling_down_tokens(self, pool: TokenPool):
+        h = pool.register_token("ghp_cool")
+        pool.penalize_token(h, time.time() + 3600)
+        assert pool.lease_token() is None
+
+    def test_returns_token_after_cooldown_expires(
+        self, pool: TokenPool, redis_client: Any
+    ):
+        h = pool.register_token("ghp_cool")
+        past = time.time() - 1
+        redis_client.zadd(pool._avail_key, {h: past})
+        result = pool.lease_token()
+        assert result is not None
+        assert result[1] == "ghp_cool"
+
+    def test_multiple_tokens_leased_in_sequence(self, pool: TokenPool):
+        pool.register_token("ghp_a")
+        pool.register_token("ghp_b")
+
+        r1 = pool.lease_token()
+        assert r1 is not None
+        r2 = pool.lease_token()
+        assert r2 is not None
+        assert r1[0] != r2[0]
+        assert {r1[1], r2[1]} == {"ghp_a", "ghp_b"}
+
+    def test_all_tokens_cooling_returns_none(self, pool: TokenPool):
+        pool.register_token("ghp_x")
+        pool.register_token("ghp_y")
+        result1 = pool.lease_token()
+        result2 = pool.lease_token()
+        assert result1 is not None
+        assert result2 is not None
+        assert pool.lease_token() is None
+
+
+class TestReturnToken:
+    def test_makes_token_available_again(self, pool: TokenPool):
+        pool.register_token("ghp_ret")
+        r1 = pool.lease_token()
+        assert r1 is not None
+        assert pool.lease_token() is None
+
+        pool.return_token(r1[0])
+        r2 = pool.lease_token()
+        assert r2 is not None
+        assert r2[1] == "ghp_ret"
+
+
+class TestPenalizeToken:
+    def test_sets_cooldown(self, pool: TokenPool, redis_client: Any):
+        h = pool.register_token("ghp_pen")
+        future = time.time() + 600
+        pool.penalize_token(h, future)
+        score = redis_client.zscore(pool._avail_key, h)
+        assert abs(score - future) < 0.01
+
+    def test_penalized_token_not_leased(self, pool: TokenPool):
+        h = pool.register_token("ghp_pen")
+        pool.penalize_token(h, time.time() + 3600)
+        assert pool.lease_token() is None
+
+
+class TestRemoveToken:
+    def test_removes_from_pool(self, pool: TokenPool, redis_client: Any):
+        h = pool.register_token("ghp_rm")
+        assert pool.pool_size() == 1
+        pool.remove_token(h)
+        assert pool.pool_size() == 0
+        assert redis_client.hget(pool._tokens_key, h) is None
+
+
+class TestPoolSize:
+    def test_empty(self, pool: TokenPool):
+        assert pool.pool_size() == 0
+
+    def test_after_register(self, pool: TokenPool):
+        pool.register_token("a")
+        pool.register_token("b")
+        assert pool.pool_size() == 2
+
+
+class TestAvailableCount:
+    def test_all_available(self, pool: TokenPool):
+        pool.register_token("a")
+        pool.register_token("b")
+        assert pool.available_count() == 2
+
+    def test_one_cooling(self, pool: TokenPool):
+        pool.register_token("a")
+        h = pool.register_token("b")
+        pool.penalize_token(h, time.time() + 3600)
+        assert pool.available_count() == 1
+
+    def test_none_available(self, pool: TokenPool):
+        h = pool.register_token("a")
+        pool.penalize_token(h, time.time() + 3600)
+        assert pool.available_count() == 0
+
+
+class TestGracefulFallback:
+    def test_lease_returns_none_when_redis_unavailable(self):
+        pool = TokenPool("github", "org", redis_client=None)
+        pool._redis_available = False
+        assert pool.lease_token() is None
+
+    def test_register_returns_hash_when_redis_unavailable(self):
+        pool = TokenPool("github", "org", redis_client=None)
+        pool._redis_available = False
+        h = pool.register_token("ghp_test")
+        assert h == _hash_token("ghp_test")
+
+    def test_return_token_noop_when_redis_unavailable(self):
+        pool = TokenPool("github", "org", redis_client=None)
+        pool._redis_available = False
+        pool.return_token("somehash")
+
+    def test_penalize_noop_when_redis_unavailable(self):
+        pool = TokenPool("github", "org", redis_client=None)
+        pool._redis_available = False
+        pool.penalize_token("somehash", time.time() + 100)
+
+    def test_remove_noop_when_redis_unavailable(self):
+        pool = TokenPool("github", "org", redis_client=None)
+        pool._redis_available = False
+        pool.remove_token("somehash")
+
+    def test_pool_size_zero_when_redis_unavailable(self):
+        pool = TokenPool("github", "org", redis_client=None)
+        pool._redis_available = False
+        assert pool.pool_size() == 0
+
+    def test_available_count_zero_when_redis_unavailable(self):
+        pool = TokenPool("github", "org", redis_client=None)
+        pool._redis_available = False
+        assert pool.available_count() == 0
+
+    def test_redis_connection_failure_on_init(self):
+        client = MagicMock()
+        client.script_load.side_effect = ConnectionError("down")
+        pool = TokenPool("github", "org", redis_client=client)
+        assert pool._redis_available is False
+
+    def test_no_redis_url_env(self):
+        with patch.dict("os.environ", {}, clear=True):
+            pool = TokenPool("github", "org")
+            assert pool._redis_available is False
+            assert pool.lease_token() is None
+
+
+class TestRedisKeys:
+    def test_key_format(self, pool: TokenPool):
+        assert pool._avail_key == "token_pool:github:my-org:availability"
+        assert pool._tokens_key == "token_pool:github:my-org:tokens"
+
+    def test_custom_prefix(self, redis_client: Any):
+        pool = TokenPool("gitlab", "acme", key_prefix="tp", redis_client=redis_client)
+        assert pool._avail_key == "tp:gitlab:acme:availability"
+        assert pool._tokens_key == "tp:gitlab:acme:tokens"
+
+
+class TestFactory:
+    def test_creates_pool_with_redis_url(self):
+        mock_redis = MagicMock()
+        mock_redis.ping.return_value = True
+        mock_redis.script_load.return_value = "sha"
+
+        with patch.dict("os.environ", {"REDIS_URL": "redis://localhost:6379"}):
+            with patch("redis.from_url", return_value=mock_redis):
+                pool = create_token_pool("github", "my-org")
+
+        assert isinstance(pool, TokenPool)
+        assert pool._redis_available is True
+
+    def test_creates_pool_without_redis_url(self):
+        with patch.dict("os.environ", {}, clear=True):
+            pool = create_token_pool("github")
+
+        assert isinstance(pool, TokenPool)
+        assert pool._redis_available is False
+
+    def test_default_org_id(self):
+        with patch.dict("os.environ", {}, clear=True):
+            pool = create_token_pool("github")
+
+        assert pool._org_id == "default"
+
+
+class TestLuaScript:
+    def test_evalsha_receives_correct_args(self, pool: TokenPool):
+        pool.register_token("ghp_lua")
+        pool._redis.evalsha = MagicMock(wraps=pool._redis.evalsha)
+        pool.lease_token()
+
+    def test_eval_fallback_on_evalsha_failure(self, redis_client: Any):
+        pool = TokenPool("github", "org", redis_client=redis_client)
+        pool.register_token("ghp_fb")
+
+        pool._redis.evalsha = MagicMock(side_effect=Exception("NOSCRIPT"))
+        original_eval = pool._redis.eval
+        pool._redis.eval = MagicMock(wraps=original_eval)
+
+        result = pool.lease_token()
+        assert result is not None
+        pool._redis.eval.assert_called_once()
+
+    def test_both_eval_fail_marks_unavailable(self):
+        client = MagicMock()
+        client.script_load.return_value = "sha"
+        client.evalsha.side_effect = Exception("NOSCRIPT")
+        client.eval.side_effect = Exception("connection lost")
+        pool = TokenPool("github", "org", redis_client=client)
+
+        assert pool.lease_token() is None
+        assert pool._redis_available is False


### PR DESCRIPTION
## Summary

Adds a Redis-backed token pool for managing multiple GitHub API tokens across workers with atomic lease/return/penalize semantics.

- **New `TokenPool` class** in `connectors/utils/token_pool.py` — Redis sorted set for availability tracking, hash map for token storage
- **Atomic Lua lease script** — `ZRANGEBYSCORE` + `ZADD` in single script prevents double-leasing across workers
- **Lease/return/penalize pattern** — workers lease tokens, return after use, or penalize with `X-RateLimit-Reset` cooldown
- **Graceful degradation** — all methods become no-ops when Redis unavailable (caller falls back to env credentials)
- **`create_token_pool()` factory** — reads `REDIS_URL` from env, matches `create_rate_limit_gate()` pattern
- **39 tests** with `fakeredis` covering all operations, edge cases, Lua script fallback, and Redis unavailability

## Key Design Decisions

- Tokens stored **plaintext in Redis** — Redis assumed network-secured (no application-level encryption overhead)
- Token hash = `SHA256[:16]` — deterministic, collision-resistant identifier
- Lease duration defaults to **300s** — prevents leaked tokens from blocking the pool indefinitely
- Sorted set scores = **epoch timestamps** — `cooldown_until` for rate-limited tokens, `0` for immediately available
- Follows exact patterns from `DistributedRateLimitGate` (same PR chain)

## Dependency

Stacked on PR #435 (`feat/distributed-rate-limiting`) — shares Redis infrastructure patterns.

Closes #428