### PR TITLE
feat: API key auth, HMAC verification, and idempotency for ingest API (#431)

### DIFF
--- a/src/dev_health_ops/api/ingest/auth.py
+++ b/src/dev_health_ops/api/ingest/auth.py
@@ -1,0 +1,152 @@
+"""Ingest API authentication, HMAC signature verification, and idempotency.
+
+Authentication layers:
+- API Key: X-API-Key header validated against INGEST_API_KEYS env var
+- HMAC Signature: Optional X-Signature-256 header (sha256=<hex>) using INGEST_SIGNING_SECRET
+- Idempotency: Optional X-Idempotency-Key header with Redis-backed deduplication
+
+All layers degrade gracefully when not configured (permissive mode for development).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+from typing import Annotated
+
+from fastapi import Depends, Header, HTTPException, Request
+
+logger = logging.getLogger(__name__)
+
+
+def _get_api_keys() -> list[str]:
+    """Get valid API keys from environment.
+
+    Returns empty list if INGEST_API_KEYS is not set (auth disabled).
+    """
+    raw = os.getenv("INGEST_API_KEYS", "")
+    if not raw.strip():
+        return []
+    return [k.strip() for k in raw.split(",") if k.strip()]
+
+
+def _get_signing_secret() -> str | None:
+    """Get HMAC signing secret from environment."""
+    return os.getenv("INGEST_SIGNING_SECRET") or None
+
+
+async def _get_raw_body(request: Request) -> bytes:
+    """Extract raw request body for signature validation.
+
+    FastAPI consumes the body stream, so we cache it for reuse.
+    """
+    if not hasattr(request.state, "raw_body"):
+        request.state.raw_body = await request.body()
+    return request.state.raw_body
+
+
+def _verify_signature(
+    body: bytes,
+    signature_header: str | None,
+    secret: str,
+) -> bool:
+    """Verify HMAC-SHA256 signature.
+
+    Args:
+        body: Raw request body bytes
+        signature_header: Value of X-Signature-256 header (sha256=<hex>)
+        secret: Configured signing secret
+
+    Returns:
+        True if signature is valid, False otherwise
+    """
+    if not signature_header:
+        return False
+
+    if not signature_header.startswith("sha256="):
+        return False
+
+    expected_signature = signature_header[7:]
+    computed = hmac.new(
+        secret.encode("utf-8"),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
+
+    return hmac.compare_digest(computed, expected_signature)
+
+
+async def validate_ingest_auth(
+    request: Request,
+    x_api_key: Annotated[str | None, Header()] = None,
+    x_signature_256: Annotated[str | None, Header()] = None,
+) -> dict:
+    """FastAPI dependency to validate ingest API authentication.
+
+    Validates API key and optional HMAC signature. Both layers degrade
+    gracefully when their respective env vars are not configured.
+
+    Returns:
+        Auth context dict with validation metadata.
+
+    Raises:
+        HTTPException: 401 if authentication fails.
+    """
+    valid_keys = _get_api_keys()
+    if valid_keys:
+        if not x_api_key or x_api_key not in valid_keys:
+            raise HTTPException(status_code=401, detail="Invalid API key")
+
+    signing_secret = _get_signing_secret()
+    if signing_secret:
+        body = await _get_raw_body(request)
+        if not _verify_signature(body, x_signature_256, signing_secret):
+            raise HTTPException(status_code=401, detail="Invalid signature")
+
+    return {
+        "api_key_present": x_api_key is not None,
+        "signature_verified": signing_secret is not None,
+    }
+
+
+async def check_idempotency(
+    request: Request,
+    x_idempotency_key: Annotated[str | None, Header()] = None,
+) -> str | None:
+    """FastAPI dependency for idempotency checking.
+
+    If an idempotency key is provided, checks Redis for duplicates.
+    Gracefully degrades if Redis is unavailable.
+
+    Returns:
+        The idempotency key if provided and not duplicate, None otherwise.
+
+    Raises:
+        HTTPException: 409 if duplicate request detected.
+    """
+    if not x_idempotency_key:
+        return None
+
+    redis_url = os.getenv("REDIS_URL")
+    if not redis_url:
+        return x_idempotency_key
+
+    try:
+        import redis
+
+        rc = redis.from_url(redis_url, decode_responses=True)
+        was_set = rc.set(f"idem:{x_idempotency_key}", "1", nx=True, ex=86400)
+        if not was_set:
+            raise HTTPException(status_code=409, detail="Duplicate request")
+        return x_idempotency_key
+    except HTTPException:
+        raise
+    except Exception:
+        logger.warning("Redis unavailable for idempotency check, skipping")
+        return x_idempotency_key
+
+
+IngestAuthContext = Annotated[dict, Depends(validate_ingest_auth)]
+IngestIdempotencyKey = Annotated[str | None, Depends(check_idempotency)]

--- a/src/dev_health_ops/api/ingest/router.py
+++ b/src/dev_health_ops/api/ingest/router.py
@@ -6,6 +6,7 @@ import uuid
 
 from fastapi import APIRouter
 
+from .auth import IngestAuthContext, IngestIdempotencyKey
 from .schemas import (
     IngestAcceptedResponse,
     IngestCommitsRequest,
@@ -45,7 +46,11 @@ def _write_to_stream(redis_client, stream_name: str, data: dict) -> bool:
 
 
 @router.post("/commits", status_code=202, response_model=IngestAcceptedResponse)
-def ingest_commits(payload: IngestCommitsRequest) -> IngestAcceptedResponse:
+async def ingest_commits(
+    payload: IngestCommitsRequest,
+    auth: IngestAuthContext,
+    idempotency_key: IngestIdempotencyKey,
+) -> IngestAcceptedResponse:
     ingestion_id = str(uuid.uuid4())
     stream_name = f"ingest:{payload.org_id}:commits"
 
@@ -68,7 +73,11 @@ def ingest_commits(payload: IngestCommitsRequest) -> IngestAcceptedResponse:
 
 
 @router.post("/pull-requests", status_code=202, response_model=IngestAcceptedResponse)
-def ingest_pull_requests(payload: IngestPullRequestsRequest) -> IngestAcceptedResponse:
+async def ingest_pull_requests(
+    payload: IngestPullRequestsRequest,
+    auth: IngestAuthContext,
+    idempotency_key: IngestIdempotencyKey,
+) -> IngestAcceptedResponse:
     ingestion_id = str(uuid.uuid4())
     stream_name = f"ingest:{payload.org_id}:pull-requests"
 
@@ -91,7 +100,11 @@ def ingest_pull_requests(payload: IngestPullRequestsRequest) -> IngestAcceptedRe
 
 
 @router.post("/work-items", status_code=202, response_model=IngestAcceptedResponse)
-def ingest_work_items(payload: IngestWorkItemsRequest) -> IngestAcceptedResponse:
+async def ingest_work_items(
+    payload: IngestWorkItemsRequest,
+    auth: IngestAuthContext,
+    idempotency_key: IngestIdempotencyKey,
+) -> IngestAcceptedResponse:
     ingestion_id = str(uuid.uuid4())
     stream_name = f"ingest:{payload.org_id}:work-items"
 
@@ -114,7 +127,11 @@ def ingest_work_items(payload: IngestWorkItemsRequest) -> IngestAcceptedResponse
 
 
 @router.post("/deployments", status_code=202, response_model=IngestAcceptedResponse)
-def ingest_deployments(payload: IngestDeploymentsRequest) -> IngestAcceptedResponse:
+async def ingest_deployments(
+    payload: IngestDeploymentsRequest,
+    auth: IngestAuthContext,
+    idempotency_key: IngestIdempotencyKey,
+) -> IngestAcceptedResponse:
     ingestion_id = str(uuid.uuid4())
     stream_name = f"ingest:{payload.org_id}:deployments"
 
@@ -137,7 +154,11 @@ def ingest_deployments(payload: IngestDeploymentsRequest) -> IngestAcceptedRespo
 
 
 @router.post("/incidents", status_code=202, response_model=IngestAcceptedResponse)
-def ingest_incidents(payload: IngestIncidentsRequest) -> IngestAcceptedResponse:
+async def ingest_incidents(
+    payload: IngestIncidentsRequest,
+    auth: IngestAuthContext,
+    idempotency_key: IngestIdempotencyKey,
+) -> IngestAcceptedResponse:
     ingestion_id = str(uuid.uuid4())
     stream_name = f"ingest:{payload.org_id}:incidents"
 

--- a/tests/test_ingest_auth.py
+++ b/tests/test_ingest_auth.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from dev_health_ops.api.main import app
+
+ENDPOINT = "/api/v1/ingest/commits"
+VALID_PAYLOAD = {
+    "repo_url": "https://github.com/org/repo",
+    "items": [
+        {
+            "hash": "abc123",
+            "message": "fix: resolve login bug",
+            "author_name": "Alice",
+            "author_email": "alice@example.com",
+            "author_when": "2025-01-15T10:00:00Z",
+        }
+    ],
+}
+
+
+def _compute_signature(body: bytes, secret: str) -> str:
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_auth_disabled_no_env_var(client, monkeypatch):
+    monkeypatch.delenv("INGEST_API_KEYS", raising=False)
+    monkeypatch.delenv("INGEST_SIGNING_SECRET", raising=False)
+    resp = await client.post(ENDPOINT, json=VALID_PAYLOAD)
+    assert resp.status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_auth_enabled_valid_key(client, monkeypatch):
+    monkeypatch.setenv("INGEST_API_KEYS", "key-one,key-two")
+    monkeypatch.delenv("INGEST_SIGNING_SECRET", raising=False)
+    resp = await client.post(
+        ENDPOINT, json=VALID_PAYLOAD, headers={"X-API-Key": "key-one"}
+    )
+    assert resp.status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_auth_enabled_invalid_key(client, monkeypatch):
+    monkeypatch.setenv("INGEST_API_KEYS", "key-one,key-two")
+    monkeypatch.delenv("INGEST_SIGNING_SECRET", raising=False)
+    resp = await client.post(
+        ENDPOINT, json=VALID_PAYLOAD, headers={"X-API-Key": "wrong-key"}
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid API key"
+
+
+@pytest.mark.asyncio
+async def test_auth_enabled_missing_key(client, monkeypatch):
+    monkeypatch.setenv("INGEST_API_KEYS", "key-one")
+    monkeypatch.delenv("INGEST_SIGNING_SECRET", raising=False)
+    resp = await client.post(ENDPOINT, json=VALID_PAYLOAD)
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid API key"
+
+
+@pytest.mark.asyncio
+async def test_hmac_disabled_no_signing_secret(client, monkeypatch):
+    monkeypatch.delenv("INGEST_API_KEYS", raising=False)
+    monkeypatch.delenv("INGEST_SIGNING_SECRET", raising=False)
+    resp = await client.post(ENDPOINT, json=VALID_PAYLOAD)
+    assert resp.status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_hmac_enabled_valid_signature(client, monkeypatch):
+    monkeypatch.delenv("INGEST_API_KEYS", raising=False)
+    monkeypatch.setenv("INGEST_SIGNING_SECRET", "my-secret")
+    body = json.dumps(VALID_PAYLOAD).encode("utf-8")
+    sig = _compute_signature(body, "my-secret")
+    resp = await client.post(
+        ENDPOINT,
+        content=body,
+        headers={"Content-Type": "application/json", "X-Signature-256": sig},
+    )
+    assert resp.status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_hmac_enabled_invalid_signature(client, monkeypatch):
+    monkeypatch.delenv("INGEST_API_KEYS", raising=False)
+    monkeypatch.setenv("INGEST_SIGNING_SECRET", "my-secret")
+    resp = await client.post(
+        ENDPOINT,
+        json=VALID_PAYLOAD,
+        headers={"X-Signature-256": "sha256=badhex"},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid signature"
+
+
+@pytest.mark.asyncio
+async def test_hmac_enabled_missing_signature_header(client, monkeypatch):
+    monkeypatch.delenv("INGEST_API_KEYS", raising=False)
+    monkeypatch.setenv("INGEST_SIGNING_SECRET", "my-secret")
+    resp = await client.post(ENDPOINT, json=VALID_PAYLOAD)
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid signature"
+
+
+@pytest.mark.asyncio
+async def test_idempotency_first_request(client, monkeypatch):
+    monkeypatch.delenv("INGEST_API_KEYS", raising=False)
+    monkeypatch.delenv("INGEST_SIGNING_SECRET", raising=False)
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+
+    mock_rc = MagicMock()
+    mock_rc.set.return_value = True
+    mock_redis_mod = MagicMock()
+    mock_redis_mod.from_url.return_value = mock_rc
+
+    with patch.dict(sys.modules, {"redis": mock_redis_mod}):
+        resp = await client.post(
+            ENDPOINT,
+            json=VALID_PAYLOAD,
+            headers={"X-Idempotency-Key": "req-001"},
+        )
+
+    assert resp.status_code == 202
+    mock_rc.set.assert_called_once_with("idem:req-001", "1", nx=True, ex=86400)
+
+
+@pytest.mark.asyncio
+async def test_idempotency_duplicate_request(client, monkeypatch):
+    monkeypatch.delenv("INGEST_API_KEYS", raising=False)
+    monkeypatch.delenv("INGEST_SIGNING_SECRET", raising=False)
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+
+    mock_rc = MagicMock()
+    mock_rc.set.return_value = False
+    mock_redis_mod = MagicMock()
+    mock_redis_mod.from_url.return_value = mock_rc
+
+    with patch.dict(sys.modules, {"redis": mock_redis_mod}):
+        resp = await client.post(
+            ENDPOINT,
+            json=VALID_PAYLOAD,
+            headers={"X-Idempotency-Key": "req-001"},
+        )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "Duplicate request"
+
+
+@pytest.mark.asyncio
+async def test_idempotency_redis_unavailable(client, monkeypatch):
+    monkeypatch.delenv("INGEST_API_KEYS", raising=False)
+    monkeypatch.delenv("INGEST_SIGNING_SECRET", raising=False)
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+
+    mock_redis_mod = MagicMock()
+    mock_redis_mod.from_url.side_effect = ConnectionError("Redis down")
+
+    with patch.dict(sys.modules, {"redis": mock_redis_mod}):
+        resp = await client.post(
+            ENDPOINT,
+            json=VALID_PAYLOAD,
+            headers={"X-Idempotency-Key": "req-001"},
+        )
+
+    assert resp.status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_no_idempotency_key(client, monkeypatch):
+    monkeypatch.delenv("INGEST_API_KEYS", raising=False)
+    monkeypatch.delenv("INGEST_SIGNING_SECRET", raising=False)
+    resp = await client.post(ENDPOINT, json=VALID_PAYLOAD)
+    assert resp.status_code == 202


### PR DESCRIPTION
## Summary

Adds authentication and reliability layers to the ingest API endpoints. Stacked on #439 (ingest endpoints).

Closes #431

## Auth Layers

| Layer | Header | Config | Behavior |
|-------|--------|--------|----------|
| API Key | `X-API-Key` | `INGEST_API_KEYS` env var | Permissive when unset; 401 when set + invalid |
| HMAC Signature | `X-Signature-256` | `INGEST_SIGNING_SECRET` env var | Optional; skipped when unset |
| Idempotency | `X-Idempotency-Key` | Redis (`REDIS_URL`) | Optional; 409 on duplicate; degrades without Redis |

## Design Decisions

- **Env-based auth** rather than DB-backed — simple, appropriate for current scale
- **Permissive by default** — no env vars = auth disabled (dev-friendly)
- **FastAPI DI pattern** matches existing `webhooks/auth.py` exactly (`Annotated[..., Depends()]`)
- **Idempotency via Redis SET NX** with 24hr TTL — prevents duplicate ingestion from retries
- **Graceful degradation** — Redis unavailable = skip idempotency check (log warning)
- **409 Conflict** for duplicate idempotency keys (not 200 with cached response — simpler)

## Files

**New:**
- `src/dev_health_ops/api/ingest/auth.py` — `validate_ingest_auth` + `check_idempotency` dependencies
- `tests/test_ingest_auth.py` — 12 async tests

**Modified:**
- `src/dev_health_ops/api/ingest/router.py` — wire auth + idempotency into all 5 endpoints

## Test Results

- 12 new auth tests pass
- 13 existing ingest API tests still pass
- Full suite: 1577 passed, 44 skipped, 0 failures