### PR TITLE
feat: add platform stats endpoint for superadmin dashboard (#447)

### DIFF
--- a/src/dev_health_ops/api/admin/router.py
+++ b/src/dev_health_ops/api/admin/router.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Annotated, AsyncGenerator, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Header, Query
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.services.audit import (
@@ -32,7 +32,13 @@ from dev_health_ops.api.services.users import (
     UserService,
 )
 from dev_health_ops.db import get_postgres_session
-from dev_health_ops.models.settings import JobRun, ScheduledJob, SettingCategory
+from dev_health_ops.models.settings import (
+    JobRun,
+    ScheduledJob,
+    SettingCategory,
+    SyncConfiguration,
+)
+from dev_health_ops.models.users import Membership, Organization, User
 
 from .schemas import (
     AuditLogListResponse,
@@ -61,6 +67,7 @@ from .schemas import (
     OrganizationResponse,
     OrganizationUpdate,
     OwnershipTransfer,
+    PlatformStatsResponse,
     JiraActivityInferenceResponse,
     RetentionExecuteResponse,
     RetentionPolicyCreate,
@@ -1502,6 +1509,97 @@ async def delete_organization(
     if not deleted:
         raise HTTPException(status_code=404, detail="Organization not found")
     return {"deleted": True}
+
+
+@router.get("/platform/stats", response_model=PlatformStatsResponse)
+async def platform_stats(
+    session: AsyncSession = Depends(get_session),
+) -> PlatformStatsResponse:
+    total_organizations = (
+        await session.execute(select(func.count()).select_from(Organization))
+    ).scalar_one()
+    active_organizations = (
+        await session.execute(
+            select(func.count())
+            .select_from(Organization)
+            .where(Organization.is_active.is_(True))
+        )
+    ).scalar_one()
+    total_users = (
+        await session.execute(select(func.count()).select_from(User))
+    ).scalar_one()
+    active_users = (
+        await session.execute(
+            select(func.count()).select_from(User).where(User.is_active.is_(True))
+        )
+    ).scalar_one()
+    superuser_count = (
+        await session.execute(
+            select(func.count()).select_from(User).where(User.is_superuser.is_(True))
+        )
+    ).scalar_one()
+    total_memberships = (
+        await session.execute(select(func.count()).select_from(Membership))
+    ).scalar_one()
+
+    tier_rows = (
+        await session.execute(
+            select(Organization.tier, func.count()).group_by(Organization.tier)
+        )
+    ).all()
+    tier_distribution = {str(tier): int(count) for tier, count in tier_rows}
+
+    total_sync_configs = (
+        await session.execute(select(func.count()).select_from(SyncConfiguration))
+    ).scalar_one()
+    active_sync_configs = (
+        await session.execute(
+            select(func.count())
+            .select_from(SyncConfiguration)
+            .where(SyncConfiguration.is_active.is_(True))
+        )
+    ).scalar_one()
+
+    since = datetime.now(timezone.utc) - timedelta(hours=24)
+    recent_sync_filter = (
+        SyncConfiguration.last_sync_at.is_not(None),
+        SyncConfiguration.last_sync_at >= since,
+    )
+
+    recent_syncs_success = (
+        await session.execute(
+            select(func.count())
+            .select_from(SyncConfiguration)
+            .where(
+                *recent_sync_filter,
+                SyncConfiguration.last_sync_success.is_(True),
+            )
+        )
+    ).scalar_one()
+    recent_syncs_failed = (
+        await session.execute(
+            select(func.count())
+            .select_from(SyncConfiguration)
+            .where(
+                *recent_sync_filter,
+                SyncConfiguration.last_sync_success.is_(False),
+            )
+        )
+    ).scalar_one()
+
+    return PlatformStatsResponse(
+        total_organizations=int(total_organizations),
+        active_organizations=int(active_organizations),
+        total_users=int(total_users),
+        active_users=int(active_users),
+        superuser_count=int(superuser_count),
+        total_memberships=int(total_memberships),
+        tier_distribution=tier_distribution,
+        total_sync_configs=int(total_sync_configs),
+        active_sync_configs=int(active_sync_configs),
+        recent_syncs_success=int(recent_syncs_success),
+        recent_syncs_failed=int(recent_syncs_failed),
+    )
 
 
 @router.get("/orgs/{org_id}/members", response_model=list[MembershipResponse])

--- a/src/dev_health_ops/api/admin/schemas.py
+++ b/src/dev_health_ops/api/admin/schemas.py
@@ -597,3 +597,17 @@ class RetentionPolicyListResponse(BaseModel):
 class RetentionExecuteResponse(BaseModel):
     deleted_count: int
     error: Optional[str] = None
+
+
+class PlatformStatsResponse(BaseModel):
+    total_organizations: int
+    active_organizations: int
+    total_users: int
+    active_users: int
+    superuser_count: int
+    total_memberships: int
+    tier_distribution: dict[str, int]
+    total_sync_configs: int
+    active_sync_configs: int
+    recent_syncs_success: int
+    recent_syncs_failed: int

--- a/tests/test_platform_stats.py
+++ b/tests/test_platform_stats.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.admin.router import get_session
+from dev_health_ops.api.main import app
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import IntegrationCredential, SyncConfiguration
+from dev_health_ops.models.users import Membership, Organization, User
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "platform-stats.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=[
+                    User.__table__,
+                    Organization.__table__,
+                    Membership.__table__,
+                    IntegrationCredential.__table__,
+                    SyncConfiguration.__table__,
+                ],
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(session_maker):
+    async def _override_get_session():
+        async with session_maker() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = _override_get_session
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_platform_stats_returns_expected_schema(client: AsyncClient):
+    response = await client.get("/api/v1/admin/platform/stats")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body.keys()) == {
+        "total_organizations",
+        "active_organizations",
+        "total_users",
+        "active_users",
+        "superuser_count",
+        "total_memberships",
+        "tier_distribution",
+        "total_sync_configs",
+        "active_sync_configs",
+        "recent_syncs_success",
+        "recent_syncs_failed",
+    }
+    assert body["tier_distribution"] == {}
+
+
+@pytest.mark.asyncio
+async def test_platform_stats_returns_seeded_aggregations(
+    client: AsyncClient,
+    session_maker,
+):
+    now = datetime.now(timezone.utc)
+
+    org_one = Organization(
+        id=uuid.uuid4(),
+        slug="org-one",
+        name="Org One",
+        tier="community",
+        is_active=True,
+    )
+    org_two = Organization(
+        id=uuid.uuid4(),
+        slug="org-two",
+        name="Org Two",
+        tier="enterprise",
+        is_active=False,
+    )
+
+    user_one = User(
+        id=uuid.uuid4(),
+        email="one@example.com",
+        is_active=True,
+        is_superuser=False,
+    )
+    user_two = User(
+        id=uuid.uuid4(),
+        email="two@example.com",
+        is_active=True,
+        is_superuser=True,
+    )
+    user_three = User(
+        id=uuid.uuid4(),
+        email="three@example.com",
+        is_active=False,
+        is_superuser=False,
+    )
+
+    sync_recent_ok_one = SyncConfiguration(
+        org_id=str(org_one.id),
+        name="sync-recent-ok-1",
+        provider="github",
+        is_active=True,
+        sync_targets=[],
+        sync_options={},
+    )
+    sync_recent_ok_one.last_sync_at = now - timedelta(hours=1)
+    sync_recent_ok_one.last_sync_success = True
+
+    sync_recent_fail = SyncConfiguration(
+        org_id=str(org_one.id),
+        name="sync-recent-fail",
+        provider="gitlab",
+        is_active=True,
+        sync_targets=[],
+        sync_options={},
+    )
+    sync_recent_fail.last_sync_at = now - timedelta(hours=2)
+    sync_recent_fail.last_sync_success = False
+
+    sync_recent_ok_two = SyncConfiguration(
+        org_id=str(org_two.id),
+        name="sync-recent-ok-2",
+        provider="jira",
+        is_active=False,
+        sync_targets=[],
+        sync_options={},
+    )
+    sync_recent_ok_two.last_sync_at = now - timedelta(hours=3)
+    sync_recent_ok_two.last_sync_success = True
+
+    sync_old_ok = SyncConfiguration(
+        org_id=str(org_two.id),
+        name="sync-old-ok",
+        provider="github",
+        is_active=True,
+        sync_targets=[],
+        sync_options={},
+    )
+    sync_old_ok.last_sync_at = now - timedelta(days=2)
+    sync_old_ok.last_sync_success = True
+
+    async with session_maker() as session:
+        session.add_all([org_one, org_two, user_one, user_two, user_three])
+
+        session.add_all(
+            [
+                Membership(org_id=org_one.id, user_id=user_one.id, role="owner"),
+                Membership(org_id=org_one.id, user_id=user_two.id, role="admin"),
+                Membership(org_id=org_two.id, user_id=user_three.id, role="member"),
+            ]
+        )
+
+        session.add_all(
+            [
+                sync_recent_ok_one,
+                sync_recent_fail,
+                sync_recent_ok_two,
+                sync_old_ok,
+            ]
+        )
+
+        await session.commit()
+
+    response = await client.get("/api/v1/admin/platform/stats")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_organizations"] == 2
+    assert body["active_organizations"] == 1
+    assert body["total_users"] == 3
+    assert body["active_users"] == 2
+    assert body["superuser_count"] == 1
+    assert body["total_memberships"] == 3
+    assert body["tier_distribution"] == {"community": 1, "enterprise": 1}
+    assert body["total_sync_configs"] == 4
+    assert body["active_sync_configs"] == 3
+    assert body["recent_syncs_success"] == 2
+    assert body["recent_syncs_failed"] == 1


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/admin/platform/stats` endpoint returning platform-wide aggregations from PostgreSQL
- Adds `PlatformStatsResponse` schema with org/user/membership counts, tier distribution, and sync health metrics
- 2 tests covering schema structure and seeded data assertions

## Details

Part of Global Admin Phase 2 (#447). This endpoint powers the superadmin dashboard in dev-health-web (PR full-chaos/dev-health-web#169).

**Stats returned:**
| Category | Metrics |
|----------|---------|
| Organizations | total, active, tier distribution |
| Users | total, active, superuser count |
| Memberships | total across all orgs |
| Sync Health | total/active configs, 24h success/failure counts |

## Changed Files
- `src/dev_health_ops/api/admin/schemas.py` — `PlatformStatsResponse` schema
- `src/dev_health_ops/api/admin/router.py` — `/platform/stats` endpoint with inline aggregation queries
- `tests/test_platform_stats.py` — 2 async tests with SQLite test DB