### PR TITLE
feat: add is_superuser to UserUpdate schema

### DIFF
--- a/src/dev_health_ops/api/admin/router.py
+++ b/src/dev_health_ops/api/admin/router.py
@@ -1346,6 +1346,7 @@ async def update_user(
             avatar_url=payload.avatar_url,
             is_active=payload.is_active,
             is_verified=payload.is_verified,
+            is_superuser=payload.is_superuser,
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/src/dev_health_ops/api/admin/schemas.py
+++ b/src/dev_health_ops/api/admin/schemas.py
@@ -372,6 +372,7 @@ class UserUpdate(BaseModel):
     avatar_url: Optional[str] = None
     is_active: Optional[bool] = None
     is_verified: Optional[bool] = None
+    is_superuser: Optional[bool] = None
 
 
 class UserSetPassword(BaseModel):

--- a/src/dev_health_ops/api/services/users.py
+++ b/src/dev_health_ops/api/services/users.py
@@ -125,6 +125,7 @@ class UserService:
         avatar_url: str | None = None,
         is_active: bool | None = None,
         is_verified: bool | None = None,
+        is_superuser: bool | None = None,
     ) -> User | None:
         user = await self.get_by_id(user_id)
         if not user:
@@ -151,6 +152,8 @@ class UserService:
             user.is_active = is_active
         if is_verified is not None:
             user.is_verified = is_verified
+        if is_superuser is not None:
+            user.is_superuser = is_superuser
 
         user.updated_at = datetime.now(timezone.utc)
         await self.session.flush()


### PR DESCRIPTION
## Summary

- Adds `is_superuser` field to `UserUpdate` schema, `UserService.update()`, and the `PATCH /admin/users/{id}` handler
- Enables the superadmin UI to toggle superuser status via the user edit form

## Changes

- `schemas.py`: Added `is_superuser: Optional[bool] = None` to `UserUpdate`
- `services/users.py`: Added `is_superuser` parameter to `UserService.update()`
- `router.py`: Pass `payload.is_superuser` to `svc.update()`