### PR TITLE
feat: feature override CRUD, feature flags list, cross-org audit endpoints (Phases 4+5)

### DIFF
--- a/src/dev_health_ops/api/admin/schemas.py
+++ b/src/dev_health_ops/api/admin/schemas.py
@@ -477,6 +477,44 @@ class AuditLogFilter(BaseModel):
     end_date: Optional[datetime] = None
 
 
+class FeatureFlagResponse(BaseModel):
+    id: str
+    key: str
+    name: str
+    description: Optional[str]
+    category: str
+    min_tier: str
+    is_enabled: bool
+    is_beta: bool
+    is_deprecated: bool
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FeatureOverrideCreate(BaseModel):
+    feature_id: str
+    is_enabled: bool = True
+    expires_at: Optional[datetime] = None
+    config: Optional[dict[str, Any]] = None
+    reason: Optional[str] = None
+
+
+class FeatureOverrideResponse(BaseModel):
+    id: str
+    org_id: str
+    feature_id: str
+    feature_key: str
+    is_enabled: bool
+    expires_at: Optional[datetime]
+    config: Optional[dict[str, Any]]
+    reason: Optional[str]
+    created_by: Optional[str]
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class ImpersonateRequest(BaseModel):
     target_user_id: str
 


### PR DESCRIPTION
## Summary

Backend endpoints for superadmin Phases 4 (Licensing) and 5 (Audit):

**Phase 4 — Licensing & Entitlements:**
- `GET /api/v1/admin/feature-flags` — list all feature flags with tier requirements
- `GET /api/v1/admin/orgs/{org_id}/feature-overrides` — list per-org overrides (joins FeatureFlag for key)
- `POST /api/v1/admin/orgs/{org_id}/feature-overrides` — create override (validates feature_id exists)
- `DELETE /api/v1/admin/orgs/{org_id}/feature-overrides/{id}` — remove override

**Phase 5 — Cross-Org Audit:**
- `GET /api/v1/admin/platform/audit-logs` — same filters as org audit but without org_id scoping, for superadmin global view

## New Schemas

- `FeatureFlagResponse` — id, key, name, description, category, min_tier, is_enabled, is_beta, is_deprecated
- `FeatureOverrideCreate` — feature_id, is_enabled, expires_at, config, reason
- `FeatureOverrideResponse` — full override with joined feature_key