### PR TITLE
fix: check organizations.tier fallback + ungated platform audit logs

### DIFF
--- a/src/dev_health_ops/api/admin/router.py
+++ b/src/dev_health_ops/api/admin/router.py
@@ -1926,7 +1926,6 @@ async def list_audit_logs(
 
 
 @router.get("/platform/audit-logs", response_model=AuditLogListResponse)
-@require_feature("audit_log", required_tier="enterprise")
 async def list_platform_audit_logs(
     session: AsyncSession = Depends(get_session),
     user_id: Optional[str] = Query(None, description="Filter by user ID"),


### PR DESCRIPTION
## Summary

- `_check_org_feature_async` now queries the `organizations.tier` column when no `org_licenses` record exists for the org. This fixes 402 errors for orgs that have `tier=enterprise` in the organizations table but no dedicated `OrgLicense` row (e.g. "Test Org").
- Removes `@require_feature("audit_log")` from `/platform/audit-logs` endpoint — platform-level audit logs are a superadmin feature and should not be gated on an org-scoped enterprise plan.

## Changes

- **`src/dev_health_ops/licensing/gating.py`**: Added Organization.tier fallback query in `_check_org_feature_async`
- **`src/dev_health_ops/api/admin/router.py`**: Removed `@require_feature` decorator from `list_platform_audit_logs`
- **`tests/test_per_org_gating.py`**: Added 3 tests for the Organization.tier fallback (enterprise allows, community denies, no org returns false). Updated existing test name for clarity.

## Testing

All 25 tests in `test_per_org_gating.py` pass.