### PR TITLE
fix: return user info in /auth/refresh response

### DIFF
--- a/src/dev_health_ops/api/auth/router.py
+++ b/src/dev_health_ops/api/auth/router.py
@@ -105,6 +105,7 @@ class TokenRefreshResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
     expires_in: int
+    user: "UserInfo | None" = None
 
 
 class TokenValidateRequest(BaseModel):
@@ -411,6 +412,13 @@ async def refresh_token(payload: TokenRefreshRequest) -> TokenRefreshResponse:
         access_token=new_access_token,
         token_type="bearer",
         expires_in=3600,
+        user=UserInfo(
+            id=user_id,
+            email=str(user.email),
+            org_id=org_id,
+            role=role,
+            is_superuser=bool(user.is_superuser),
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

- The `/auth/refresh` response now includes a `user` field with `id`, `email`, `org_id`, `role`, and `is_superuser`
- This allows the frontend to sync session fields after a token refresh, preventing stale claims from persisting

## Root Cause

Before ops#461, the refresh endpoint read `email`, `role`, `is_superuser` from the refresh token payload (which only carries `sub` and `org_id`), producing tokens with empty email, `role="member"`, and `is_superuser=false`. Users who refreshed during that window have stale session tokens that persist until they log out.

By returning user info in the refresh response, the frontend can now update its session state to match the actual token claims.