### PR TITLE
test: phase 3 reliability hardening

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,12 +39,26 @@ jobs:
           SKIP_INTEGRATION_TESTS: ${{ secrets.SKIP_INTEGRATION_TESTS }}
         run: |
           chmod +x ci/run_tests.sh
-          ./ci/run_tests.sh integration
+          mkdir -p test-results/logs
+          set -o pipefail
+          ./ci/run_tests.sh integration 2>&1 | tee test-results/logs/integration.log
 
-      - name: Upload integration test logs
+      - name: Upload integration junit report
         if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: integration-junit
+          path: test-results/junit/integration.xml
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload integration logs on failure
+        if: failure()
         uses: actions/upload-artifact@v6
         with:
           name: integration-logs
           path: |
+            test-results/logs/*.log
             **/pytest.log
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,11 +65,33 @@ jobs:
           COVERAGE_THRESHOLD: "50"
         run: |
           chmod +x ci/run_tests.sh
+          mkdir -p test-results/logs
+          set -o pipefail
           if [ "${{ matrix.python-version }}" = "3.11" ]; then
-            ./ci/run_tests.sh ci
+            ./ci/run_tests.sh ci 2>&1 | tee test-results/logs/ci-${{ matrix.python-version }}.log
           else
-            ./ci/run_tests.sh unit
+            ./ci/run_tests.sh unit 2>&1 | tee test-results/logs/unit-${{ matrix.python-version }}.log
           fi
+
+      - name: Upload junit test reports
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: junit-${{ matrix.python-version }}
+          path: test-results/junit/*.xml
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload pytest logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: pytest-logs-${{ matrix.python-version }}
+          path: |
+            test-results/logs/*.log
+            **/pytest.log
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload coverage reports
         if: matrix.python-version == '3.11'

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Notes:
 - `integration` is token-aware. It uses `GITHUB_TOKEN`/`GITLAB_TOKEN` (or `GH_TOKEN`/`GL_TOKEN`) when available, and skips cleanly when not provided.
 - `ci` always blocks on `flake8` + coverage-gated unit tests (`COVERAGE_THRESHOLD`, default `50`), then optional integration/e2e tiers.
 - `black`, `isort`, and `mypy` run as advisory checks by default. Set `STRICT_QUALITY_GATES=1` to make them blocking.
+- pytest tiers emit diagnostics by default (`-ra` summary + `--durations`, configurable via `PYTEST_DURATIONS`).
+- JUnit XML paths are stable: `test-results/junit/unit.xml`, `test-results/junit/integration.xml`, and `test-results/junit/e2e.xml` (overridable via `TEST_RESULTS_DIR`/`JUNIT_XML_*` env vars).
+- Set `PYTEST_SINGLE_RETRY=1` to enable a single retry for failing pytest tiers.
 
 ## Private Repository Support ✅
 

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -15,6 +15,11 @@ Tiers:
   integration  Run integration tests (skips when tokens are not set)
   e2e          Run end-to-end tests if present
   ci           Run blocking quality gates + coverage-gated unit tests + optional integration/e2e
+
+Environment:
+  PYTEST_SINGLE_RETRY=1  Retry a failing pytest tier once
+  PYTEST_DURATIONS=25    Emit the slowest N test durations in output
+  TEST_RESULTS_DIR=...   Base directory for junit outputs (default: ./test-results)
 EOF
 }
 
@@ -29,6 +34,18 @@ cd "$ROOT_DIR" || exit "$EXIT_FAILURE"
 
 export PYTHONUNBUFFERED="${PYTHONUNBUFFERED:-1}"
 export PYTHONHASHSEED="${PYTHONHASHSEED:-0}"
+
+TEST_RESULTS_DIR="${TEST_RESULTS_DIR:-${ROOT_DIR}/test-results}"
+JUNIT_RESULTS_DIR="${JUNIT_RESULTS_DIR:-${TEST_RESULTS_DIR}/junit}"
+mkdir -p "${JUNIT_RESULTS_DIR}"
+
+JUNIT_XML_UNIT="${JUNIT_XML_UNIT:-${JUNIT_RESULTS_DIR}/unit.xml}"
+JUNIT_XML_INTEGRATION="${JUNIT_XML_INTEGRATION:-${JUNIT_RESULTS_DIR}/integration.xml}"
+JUNIT_XML_E2E="${JUNIT_XML_E2E:-${JUNIT_RESULTS_DIR}/e2e.xml}"
+
+PYTEST_SINGLE_RETRY="${PYTEST_SINGLE_RETRY:-0}"
+PYTEST_DURATIONS="${PYTEST_DURATIONS:-25}"
+PYTEST_DIAGNOSTIC_OPTS=(-ra "--durations=${PYTEST_DURATIONS}")
 
 HAS_POETRY=0
 HAS_UV=0
@@ -83,6 +100,38 @@ run_step() {
   fi
 }
 
+run_pytest_step() {
+  local label="$1"
+  local junit_xml="$2"
+  shift 2
+
+  local max_attempts=1
+  if [ "${PYTEST_SINGLE_RETRY}" = "1" ]; then
+    max_attempts=2
+  fi
+
+  local attempt=1
+  local rc=0
+  while [ "${attempt}" -le "${max_attempts}" ]; do
+    echo "==> ${label} (attempt ${attempt}/${max_attempts})"
+    run_cmd pytest "$@" "${PYTEST_DIAGNOSTIC_OPTS[@]}" --junitxml="${junit_xml}"
+    rc=$?
+    if [ "${rc}" -eq 0 ]; then
+      echo "JUnit XML: ${junit_xml}"
+      return 0
+    fi
+
+    if [ "${attempt}" -lt "${max_attempts}" ]; then
+      echo "WARN: ${label} failed (exit ${rc}); retrying once because PYTEST_SINGLE_RETRY=1."
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  echo "ERROR: ${label} failed (exit ${rc})"
+  echo "JUnit XML (may be partial): ${junit_xml}"
+  exit "$EXIT_FAILURE"
+}
+
 run_advisory_step() {
   local label="$1"
   shift
@@ -94,10 +143,17 @@ run_advisory_step() {
   fi
 }
 
+emit_junit_paths() {
+  echo "JUnit XML paths:"
+  echo "  unit: ${JUNIT_XML_UNIT}"
+  echo "  integration: ${JUNIT_XML_INTEGRATION}"
+  echo "  e2e: ${JUNIT_XML_E2E}"
+}
+
 unit_tests() {
   require_cmd pytest
-  run_step "unit tests" \
-    pytest tests -v --tb=short -m "not benchmark" \
+  run_pytest_step "unit tests" "${JUNIT_XML_UNIT}" \
+    tests -v --tb=short -m "not benchmark" \
     --ignore=tests/test_connectors_integration.py \
     --ignore=tests/test_private_repo_access.py
 }
@@ -127,8 +183,8 @@ integration_tests() {
     return 0
   fi
 
-  run_step "integration tests" \
-    pytest tests/test_connectors_integration.py tests/test_private_repo_access.py -q
+  run_pytest_step "integration tests" "${JUNIT_XML_INTEGRATION}" \
+    tests/test_connectors_integration.py tests/test_private_repo_access.py -q
 }
 
 e2e_tests() {
@@ -148,9 +204,9 @@ e2e_tests() {
   fi
 
   if [ -d "tests/e2e" ]; then
-    run_step "e2e tests" pytest tests/e2e -v --tb=short
+    run_pytest_step "e2e tests" "${JUNIT_XML_E2E}" tests/e2e -v --tb=short
   else
-    run_step "e2e tests" pytest tests -v --tb=short -k "e2e"
+    run_pytest_step "e2e tests" "${JUNIT_XML_E2E}" tests -v --tb=short -k "e2e"
   fi
 }
 
@@ -175,14 +231,16 @@ ci_tests() {
   fi
 
   run_step "flake8 (lint)" flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-  run_step "unit tests with coverage >= ${coverage_threshold}" \
-    pytest tests -v --tb=short -m "not benchmark" \
+  run_pytest_step "unit tests with coverage >= ${coverage_threshold}" "${JUNIT_XML_UNIT}" \
+    tests -v --tb=short -m "not benchmark" \
     --ignore=tests/test_connectors_integration.py \
     --ignore=tests/test_private_repo_access.py \
     --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under="${coverage_threshold}"
   integration_tests
   e2e_tests
 }
+
+emit_junit_paths
 
 case "$TIER" in
   unit)


### PR DESCRIPTION
Summary: add pytest reliability knobs and stable junit outputs in ci/run_tests.sh, and upload junit plus failure logs in test and integration workflows. Validation: bash syntax check and unit tier run passed.