### PR TITLE
fix: restore semantic/analytics DB split in live-e2e harness

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run live-e2e tier
         env:
           DISABLE_DOTENV: "1"
-          DATABASE_URI: clickhouse://ch:ch@localhost:8123/default
+          DATABASE_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
           CLICKHOUSE_URI: clickhouse://ch:ch@localhost:8123/default
           POSTGRES_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
           LIVE_E2E_FIXTURE_SEED: "20260219"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,12 @@ This file is intentionally short. The canonical instructions live in the MkDocs 
 ## Read-first (in order)
 1. **Product intent and guardrails**: `docs/product/prd.md`, `docs/product/concepts.md`
 2. **Pipeline boundaries**: `docs/architecture/data-pipeline.md`
-3. **Investment model (canonical)**: `docs/user-guide/investment-view.md`, `docs/product/investment-taxonomy.md`
-4. **LLM contract (compute-time only)**: `docs/llm/categorization-contract.md`
-5. **Views and interpretation**: `docs/user-guide/views-index.md`, `docs/visualizations/patterns.md`
-6. **API surface**: `docs/api/graphql-overview.md`, `docs/api/view-mapping.md`
-7. **How to run it**: `docs/ops/cli-reference.md`
+3. **Dual database contract (semantic vs analytics)**: `docs/architecture/database-architecture.md`, `docs/ops/cli-reference.md`
+4. **Investment model (canonical)**: `docs/user-guide/investment-view.md`, `docs/product/investment-taxonomy.md`
+5. **LLM contract (compute-time only)**: `docs/llm/categorization-contract.md`
+6. **Views and interpretation**: `docs/user-guide/views-index.md`, `docs/visualizations/patterns.md`
+7. **API surface**: `docs/api/graphql-overview.md`, `docs/api/view-mapping.md`
+8. **How to run it**: `README.md` (test tiers), `ci/run_tests.sh`, `ci/run_live_backend_e2e.sh`
 
 ## Non-negotiables (summary)
 - **WorkUnits are evidence containers, not categories.**
@@ -108,8 +109,9 @@ Goal: understand **boundaries** (ingest → normalize → persist → metricize 
 
 Backend selection:
 
-* CLI `--db` flag or `DATABASE_URI`
-* Secondary sink via `SECONDARY_DATABASE_URI` when using `sink='both'`.
+* Semantic DB: CLI `--db` or `POSTGRES_URI` (legacy fallback: `DATABASE_URI`).
+* Analytics DB: CLI `--analytics-db` or `CLICKHOUSE_URI`.
+* Secondary sink: `SECONDARY_DATABASE_URI` when using `sink='both'`.
 
 ---
 
@@ -220,25 +222,25 @@ Explanation format:
 
 * Git data (local):
 
-  * `dev-hops sync git --provider local --db "$DATABASE_URI" --repo-path /path/to/repo`
+  * `CLICKHOUSE_URI=clickhouse://... dev-hops sync git --provider local --repo-path /path/to/repo`
 
 * Work items:
 
-  * `dev-hops sync work-items --provider <jira|github|gitlab|synthetic|all> -s "org/*" --db "$DATABASE_URI"`
+  * `CLICKHOUSE_URI=clickhouse://... dev-hops sync work-items --provider <jira|github|gitlab|synthetic|all> -s "org/*"`
 
 * Teams:
 
-  * `dev-hops sync teams --provider <config|jira|jira-ops|synthetic|ms-teams|github|gitlab> --db "$DATABASE_URI"`
+  * `POSTGRES_URI=postgresql+asyncpg://... dev-hops sync teams --provider <config|jira|jira-ops|synthetic|ms-teams|github|gitlab>`
 
 ### 6.2 Generate synthetic data
 
-* `dev-hops fixtures generate --db "$DATABASE_URI" --days 30`
+* `CLICKHOUSE_URI=clickhouse://... dev-hops fixtures generate --sink "$CLICKHOUSE_URI" --days 30`
 
 ### 6.3 Compute metrics
 
 * Daily rollups:
 
-  * `dev-hops metrics daily --db "$DATABASE_URI"`
+  * `CLICKHOUSE_URI=clickhouse://... dev-hops metrics daily`
 
 ---
 

--- a/ci/run_live_backend_e2e.sh
+++ b/ci/run_live_backend_e2e.sh
@@ -62,9 +62,9 @@ require_cmd curl
 CLICKHOUSE_URI_DEFAULT="clickhouse://ch:ch@127.0.0.1:8123/default"
 POSTGRES_URI_DEFAULT="postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/test_db"
 
-CLICKHOUSE_URI="${CLICKHOUSE_URI:-${DATABASE_URI:-${CLICKHOUSE_URI_DEFAULT}}}"
+CLICKHOUSE_URI="${CLICKHOUSE_URI:-${CLICKHOUSE_URI_DEFAULT}}"
 POSTGRES_URI="${POSTGRES_URI:-${POSTGRES_URI_DEFAULT}}"
-DATABASE_URI="${CLICKHOUSE_URI}"
+DATABASE_URI="${POSTGRES_URI}"
 
 API_HOST="${LIVE_E2E_API_HOST:-127.0.0.1}"
 API_PORT="${LIVE_E2E_API_PORT:-18080}"
@@ -177,7 +177,7 @@ echo "==> starting API at ${BASE_URL}"
   export CLICKHOUSE_URI="${CLICKHOUSE_URI}"
   export POSTGRES_URI="${POSTGRES_URI}"
   exec_dev_hops \
-    --db "${CLICKHOUSE_URI}" \
+    --db "${POSTGRES_URI}" \
     --analytics-db "${CLICKHOUSE_URI}" \
     api --host "${API_HOST}" --port "${API_PORT}"
 ) >"${API_LOG_FILE}" 2>&1 &
@@ -210,7 +210,7 @@ import pathlib
 import sys
 
 payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
-assert payload.get("backend") == "clickhouse", payload
+assert payload.get("backend") == "postgres", payload
 assert payload.get("limits", {}).get("max_days") == 365, payload
 assert payload.get("limits", {}).get("max_repos") == 1000, payload
 supported = payload.get("supported_endpoints", [])


### PR DESCRIPTION
## Summary
- keep live backend e2e harness aligned with dual-db architecture
- wire semantic DB to Postgres (`--db` / `DATABASE_URI`) and analytics DB to ClickHouse (`--analytics-db` / `CLICKHOUSE_URI`)
- update live-e2e workflow env defaults to match the same split
- update `AGENTS.md` to point directly to architecture and CLI docs for DB routing and test harness entrypoints

## Why
PR #467 introduced a regression in the live harness by forcing `--db` to ClickHouse. That bypassed the documented separation where semantic data belongs to Postgres and analytics data to ClickHouse.

## Validation
- `POSTGRES_URI=postgresql+asyncpg://devhealth:devhealth@127.0.0.1:5432/devhealth CLICKHOUSE_URI=clickhouse://ch:ch@127.0.0.1:8123/default DATABASE_URI=postgresql+asyncpg://devhealth:devhealth@127.0.0.1:5432/devhealth ./ci/run_tests.sh live-e2e`

## Follow-up docs issues
- #469
- #470
