### PR TITLE
fix: implement SaaS onboarding flow — orgless login + onboard endpoint

### DIFF
--- a/src/dev_health_ops/api/services/auth.py
+++ b/src/dev_health_ops/api/services/auth.py
@@ -75,7 +75,7 @@ class AuthService:
         self,
         user_id: str,
         email: str,
-        org_id: str,
+        org_id: str = "",
         role: str = "member",
         is_superuser: bool = False,
         username: str | None = None,
@@ -111,7 +111,7 @@ class AuthService:
     def create_refresh_token(
         self,
         user_id: str,
-        org_id: str,
+        org_id: str = "",
         expires_delta: timedelta | None = None,
     ) -> str:
         """Create a JWT refresh token."""
@@ -134,7 +134,7 @@ class AuthService:
         self,
         user_id: str,
         email: str,
-        org_id: str,
+        org_id: str = "",
         role: str = "member",
         is_superuser: bool = False,
         username: str | None = None,

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import uuid
+import importlib
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import bcrypt
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from dev_health_ops.api.services.auth import AuthService, AuthenticatedUser
+from dev_health_ops.models.users import Membership, Organization
+
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+
+class FakeResult:
+    def __init__(self, scalar=None, first_row=None):
+        self._scalar = scalar
+        self._first_row = first_row
+
+    def scalar_one_or_none(self):
+        return self._scalar
+
+    def first(self):
+        return self._first_row
+
+
+class FakeSession:
+    def __init__(self, execute_results: list[FakeResult]):
+        self._execute_results = execute_results
+        self._execute_index = 0
+        self.added: list[object] = []
+        self.commit_count = 0
+
+    async def execute(self, _stmt):
+        result = self._execute_results[self._execute_index]
+        self._execute_index += 1
+        return result
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def flush(self):
+        for obj in self.added:
+            if getattr(obj, "id", None) is None:
+                setattr(obj, "id", uuid.uuid4())
+
+    async def commit(self):
+        self.commit_count += 1
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(auth_router_module.router)
+    return app
+
+
+def _local_user(email: str, password: str) -> SimpleNamespace:
+    password_hash = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode(
+        "utf-8"
+    )
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        email=email,
+        username="test-user",
+        full_name="Test User",
+        password_hash=password_hash,
+        is_active=True,
+        is_superuser=False,
+        last_login_at=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_login_without_membership_returns_needs_onboarding(monkeypatch):
+    app = _make_app()
+    auth_service = AuthService(secret_key="onboarding-test-secret")
+    user = _local_user("orgless@example.com", "password123")
+    session = FakeSession(
+        execute_results=[
+            FakeResult(scalar=user),
+            FakeResult(scalar=None),
+        ]
+    )
+
+    @asynccontextmanager
+    async def fake_db():
+        yield session
+
+    monkeypatch.setattr(auth_router_module, "get_postgres_session", fake_db)
+    monkeypatch.setattr(auth_router_module, "get_auth_service", lambda: auth_service)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "orgless@example.com", "password": "password123"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["needs_onboarding"] is True
+    assert payload["user"]["org_id"] is None
+    assert payload["user"]["role"] == "member"
+    assert payload["access_token"]
+    assert payload["refresh_token"]
+
+
+@pytest.mark.asyncio
+async def test_login_with_membership_returns_needs_onboarding_false(monkeypatch):
+    app = _make_app()
+    auth_service = AuthService(secret_key="onboarding-test-secret")
+    user = _local_user("member@example.com", "password123")
+    org_id = uuid.uuid4()
+    membership = SimpleNamespace(org_id=org_id, role="admin")
+    session = FakeSession(
+        execute_results=[
+            FakeResult(scalar=user),
+            FakeResult(scalar=membership),
+        ]
+    )
+
+    @asynccontextmanager
+    async def fake_db():
+        yield session
+
+    monkeypatch.setattr(auth_router_module, "get_postgres_session", fake_db)
+    monkeypatch.setattr(auth_router_module, "get_auth_service", lambda: auth_service)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "member@example.com", "password": "password123"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["needs_onboarding"] is False
+    assert payload["user"]["org_id"] == str(org_id)
+    assert payload["user"]["role"] == "admin"
+
+
+@pytest.mark.asyncio
+async def test_onboard_create_org_creates_org_membership_and_tokens(monkeypatch):
+    app = _make_app()
+    auth_service = AuthService(secret_key="onboarding-test-secret")
+    user_id = uuid.uuid4()
+    db_user = SimpleNamespace(
+        id=user_id,
+        email="newuser@example.com",
+        username="newuser",
+        full_name="New User",
+        is_superuser=False,
+    )
+    session = FakeSession(
+        execute_results=[
+            FakeResult(scalar=db_user),
+            FakeResult(first_row=None),
+        ]
+    )
+    app.dependency_overrides[auth_router_module.get_current_user] = lambda: (
+        AuthenticatedUser(
+            user_id=str(user_id),
+            email="newuser@example.com",
+            org_id="",
+            role="member",
+        )
+    )
+
+    @asynccontextmanager
+    async def fake_db():
+        yield session
+
+    monkeypatch.setattr(auth_router_module, "get_postgres_session", fake_db)
+    monkeypatch.setattr(auth_router_module, "get_auth_service", lambda: auth_service)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/auth/onboard",
+            json={"action": "create_org", "org_name": "Acme Platform"},
+        )
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["org_name"] == "Acme Platform"
+    assert payload["role"] == "owner"
+    assert payload["org_id"]
+    assert payload["access_token"]
+    assert payload["refresh_token"]
+    assert any(isinstance(item, Organization) for item in session.added)
+    assert any(isinstance(item, Membership) for item in session.added)
+
+
+@pytest.mark.asyncio
+async def test_onboard_when_already_onboarded_returns_400(monkeypatch):
+    app = _make_app()
+    user_id = uuid.uuid4()
+    db_user = SimpleNamespace(
+        id=user_id,
+        email="existing@example.com",
+        username="existing",
+        full_name="Existing User",
+        is_superuser=False,
+    )
+    session = FakeSession(
+        execute_results=[
+            FakeResult(scalar=db_user),
+            FakeResult(first_row=(uuid.uuid4(),)),
+        ]
+    )
+    app.dependency_overrides[auth_router_module.get_current_user] = lambda: (
+        AuthenticatedUser(
+            user_id=str(user_id),
+            email="existing@example.com",
+            org_id="",
+            role="member",
+        )
+    )
+
+    @asynccontextmanager
+    async def fake_db():
+        yield session
+
+    monkeypatch.setattr(auth_router_module, "get_postgres_session", fake_db)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/auth/onboard",
+            json={"action": "create_org", "org_name": "Should Fail"},
+        )
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Already onboarded"
+
+
+@pytest.mark.asyncio
+async def test_onboard_requires_authentication():
+    app = _make_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/api/v1/auth/onboard",
+            json={"action": "create_org", "org_name": "Unauthorized"},
+        )
+
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

- New users (OAuth, admin-created, CLI) no longer auto-join the first org in the database
- Users without org membership receive an orgless JWT with `needs_onboarding=true`
- New `POST /api/v1/auth/onboard` endpoint lets users create their org or join via invite

## Problem

All 5 user creation paths except `POST /auth/register` produced orphaned users or silently assigned them to the first org in the DB. This breaks multi-tenant SaaS semantics where self-signup users should get their own org and invited users should join a specific org.

## Changes

| File | Change |
|------|--------|
| `api/auth/router.py` | Login allows orgless users, returns `needs_onboarding` flag; new `/onboard` endpoint |
| `api/auth/sso/router.py` | OAuth callback no longer auto-creates membership for new users |
| `api/services/auth.py` | Token helpers default `org_id=""` for orgless users |
| `api/services/sso.py` | `provision_or_get_user` returns `Optional[Membership]` |
| `tests/test_onboarding.py` | 5 new tests covering login + onboard flow |

## Testing

- `python -m pytest -q` → 1786 passed, 5 skipped ✅
- Frontend companion PR: full-chaos/dev-health-web (same branch name)

## Future Work

- `action="join_org"` with invite codes (returns 501 currently)
- Admin API / CLI user creation should optionally specify org

Fixes #477