### PR TITLE
fix: enforce org_id scoping in GraphQL loaders and scope resolver

### DIFF
--- a/src/dev_health_ops/api/graphql/loaders/repo_loader.py
+++ b/src/dev_health_ops/api/graphql/loaders/repo_loader.py
@@ -45,7 +45,9 @@ class RepoLoader(CachedDataLoader[str, Optional[RepoData]]):
             cache: Optional cache backend for cross-request caching.
             cache_ttl: Cache TTL in seconds.
         """
-        super().__init__(org_id=org_id, cache=cache, cache_ttl=cache_ttl, cache_prefix="repo")
+        super().__init__(
+            org_id=org_id, cache=cache, cache_ttl=cache_ttl, cache_prefix="repo"
+        )
         self._client = client
         self._org_id = org_id
 
@@ -73,8 +75,9 @@ class RepoLoader(CachedDataLoader[str, Optional[RepoData]]):
                 language
             FROM repos
             WHERE id IN %(repo_ids)s
+              AND org_id = %(org_id)s
         """
-        params = {"repo_ids": list(keys)}
+        params = {"repo_ids": list(keys), "org_id": self._org_id}
 
         try:
             rows = await query_dicts(self._client, sql, params)
@@ -122,7 +125,9 @@ class RepoByNameLoader(CachedDataLoader[str, Optional[RepoData]]):
             cache: Optional cache backend for cross-request caching.
             cache_ttl: Cache TTL in seconds.
         """
-        super().__init__(org_id=org_id, cache=cache, cache_ttl=cache_ttl, cache_prefix="repo_name")
+        super().__init__(
+            org_id=org_id, cache=cache, cache_ttl=cache_ttl, cache_prefix="repo_name"
+        )
         self._client = client
         self._org_id = org_id
 
@@ -150,8 +155,9 @@ class RepoByNameLoader(CachedDataLoader[str, Optional[RepoData]]):
                 language
             FROM repos
             WHERE lower(name) IN %(repo_names)s
+              AND org_id = %(org_id)s
         """
-        params = {"repo_names": [k.lower() for k in keys]}
+        params = {"repo_names": [k.lower() for k in keys], "org_id": self._org_id}
 
         try:
             rows = await query_dicts(self._client, sql, params)

--- a/src/dev_health_ops/api/graphql/loaders/team_loader.py
+++ b/src/dev_health_ops/api/graphql/loaders/team_loader.py
@@ -44,7 +44,9 @@ class TeamLoader(CachedDataLoader[str, Optional[TeamData]]):
             cache: Optional cache backend for cross-request caching.
             cache_ttl: Cache TTL in seconds.
         """
-        super().__init__(org_id=org_id, cache=cache, cache_ttl=cache_ttl, cache_prefix="team")
+        super().__init__(
+            org_id=org_id, cache=cache, cache_ttl=cache_ttl, cache_prefix="team"
+        )
         self._client = client
         self._org_id = org_id
 
@@ -72,9 +74,10 @@ class TeamLoader(CachedDataLoader[str, Optional[TeamData]]):
                 count() OVER (PARTITION BY team_id) as member_count
             FROM work_item_cycle_times
             WHERE team_id IN %(team_ids)s
+              AND org_id = %(org_id)s
             ORDER BY team_id
         """
-        params = {"team_ids": list(keys)}
+        params = {"team_ids": list(keys), "org_id": self._org_id}
 
         try:
             rows = await query_dicts(self._client, sql, params)
@@ -122,7 +125,9 @@ class TeamByNameLoader(CachedDataLoader[str, Optional[TeamData]]):
             cache: Optional cache backend for cross-request caching.
             cache_ttl: Cache TTL in seconds.
         """
-        super().__init__(org_id=org_id, cache=cache, cache_ttl=cache_ttl, cache_prefix="team_name")
+        super().__init__(
+            org_id=org_id, cache=cache, cache_ttl=cache_ttl, cache_prefix="team_name"
+        )
         self._client = client
         self._org_id = org_id
 
@@ -149,9 +154,10 @@ class TeamByNameLoader(CachedDataLoader[str, Optional[TeamData]]):
                 count() OVER (PARTITION BY team_id) as member_count
             FROM work_item_cycle_times
             WHERE lower(team_name) IN %(team_names)s
+              AND org_id = %(org_id)s
             ORDER BY team_name
         """
-        params = {"team_names": [k.lower() for k in keys]}
+        params = {"team_names": [k.lower() for k in keys], "org_id": self._org_id}
 
         try:
             rows = await query_dicts(self._client, sql, params)

--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -403,11 +403,13 @@ async def resolve_analytics(
                     FROM {base_table}
                     {joins}
                     WHERE {date_filter}
+                      AND org_id = %(org_id)s
                 """
 
                 cov_params = {
                     "start_date": request.start_date,
                     "end_date": request.end_date,
+                    "org_id": org_id,
                 }
 
                 try:

--- a/src/dev_health_ops/api/queries/scopes.py
+++ b/src/dev_health_ops/api/queries/scopes.py
@@ -19,7 +19,21 @@ async def resolve_repo_id(
 ) -> Optional[str]:
     repo_uuid = parse_uuid(repo_ref)
     if repo_uuid:
-        return str(repo_uuid)
+        query = """
+            SELECT id
+            FROM repos
+            WHERE id = %(repo_id)s
+              AND org_id = %(org_id)s
+            LIMIT 1
+        """
+        rows = await query_dicts(
+            sink,
+            query,
+            {"repo_id": str(repo_uuid), "org_id": org_id},
+        )
+        if not rows:
+            return None
+        return str(rows[0]["id"])
     query = """
         SELECT id
         FROM repos
@@ -27,8 +41,7 @@ async def resolve_repo_id(
           AND org_id = %(org_id)s
         LIMIT 1
     """
-    params = {"repo_name": repo_ref}
-    params["org_id"] = org_id
+    params = {"repo_name": repo_ref, "org_id": org_id}
     rows = await query_dicts(sink, query, params)
     if not rows:
         return None
@@ -44,7 +57,9 @@ async def resolve_repo_ids(
             continue
         repo_uuid = parse_uuid(repo_ref)
         if repo_uuid:
-            resolved.append(str(repo_uuid))
+            verified_repo_id = await resolve_repo_id(sink, repo_ref, org_id=org_id)
+            if verified_repo_id:
+                resolved.append(verified_repo_id)
             continue
         repo_id = await resolve_repo_id(sink, repo_ref, org_id=org_id)
         if repo_id:
@@ -67,8 +82,7 @@ async def resolve_repo_ids_for_teams(
         WHERE team_id IN %(team_ids)s
           AND org_id = %(org_id)s
     """
-    params = {"team_ids": team_list}
-    params["org_id"] = org_id
+    params = {"team_ids": team_list, "org_id": org_id}
     rows = await query_dicts(sink, query, params)
     return [str(row.get("id")) for row in rows if row.get("id")]
 

--- a/tests/api/graphql/loaders/test_loader_org_scoping.py
+++ b/tests/api/graphql/loaders/test_loader_org_scoping.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.graphql.loaders.repo_loader import RepoByNameLoader, RepoLoader
+from dev_health_ops.api.graphql.loaders.team_loader import TeamByNameLoader, TeamLoader
+
+
+@pytest.mark.asyncio
+async def test_repo_loader_scopes_query_by_org_id(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_query_dicts(_client, sql, params):
+        captured["sql"] = sql
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    loader = RepoLoader(client=object(), org_id="org-A")
+    await loader.batch_load(["repo-1"])
+
+    assert "AND org_id = %(org_id)s" in str(captured["sql"])
+    assert captured["params"]["org_id"] == "org-A"
+
+
+@pytest.mark.asyncio
+async def test_repo_by_name_loader_scopes_query_by_org_id(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_query_dicts(_client, sql, params):
+        captured["sql"] = sql
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    loader = RepoByNameLoader(client=object(), org_id="org-A")
+    await loader.batch_load(["Repo-One"])
+
+    assert "AND org_id = %(org_id)s" in str(captured["sql"])
+    assert captured["params"]["org_id"] == "org-A"
+
+
+@pytest.mark.asyncio
+async def test_team_loader_scopes_query_by_org_id(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_query_dicts(_client, sql, params):
+        captured["sql"] = sql
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    loader = TeamLoader(client=object(), org_id="org-A")
+    await loader.batch_load(["team-1"])
+
+    assert "AND org_id = %(org_id)s" in str(captured["sql"])
+    assert captured["params"]["org_id"] == "org-A"
+
+
+@pytest.mark.asyncio
+async def test_team_by_name_loader_scopes_query_by_org_id(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_query_dicts(_client, sql, params):
+        captured["sql"] = sql
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    loader = TeamByNameLoader(client=object(), org_id="org-A")
+    await loader.batch_load(["Core Team"])
+
+    assert "AND org_id = %(org_id)s" in str(captured["sql"])
+    assert captured["params"]["org_id"] == "org-A"

--- a/tests/api/queries/test_scopes.py
+++ b/tests/api/queries/test_scopes.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+import dev_health_ops.api.queries.scopes as scopes
+
+
+@pytest.mark.asyncio
+async def test_resolve_repo_id_uuid_returns_none_when_org_does_not_own_repo(
+    monkeypatch,
+):
+    repo_id = "11111111-1111-1111-1111-111111111111"
+
+    async def _fake_query_dicts(_sink, query: str, params):
+        assert "WHERE id = %(repo_id)s" in query
+        assert params == {"repo_id": repo_id, "org_id": "org-b"}
+        return []
+
+    monkeypatch.setattr(scopes, "query_dicts", _fake_query_dicts)
+
+    resolved = await scopes.resolve_repo_id(object(), repo_id, org_id="org-b")
+
+    assert resolved is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_repo_id_uuid_returns_id_when_org_owns_repo(monkeypatch):
+    repo_id = "22222222-2222-2222-2222-222222222222"
+
+    async def _fake_query_dicts(_sink, query: str, params):
+        assert "WHERE id = %(repo_id)s" in query
+        assert params == {"repo_id": repo_id, "org_id": "org-a"}
+        return [{"id": repo_id}]
+
+    monkeypatch.setattr(scopes, "query_dicts", _fake_query_dicts)
+
+    resolved = await scopes.resolve_repo_id(object(), repo_id, org_id="org-a")
+
+    assert resolved == repo_id
+
+
+@pytest.mark.asyncio
+async def test_resolve_repo_ids_mixed_refs_are_org_scoped(monkeypatch):
+    owned_uuid = "33333333-3333-3333-3333-333333333333"
+    foreign_uuid = "44444444-4444-4444-4444-444444444444"
+    calls = []
+
+    async def _fake_query_dicts(_sink, query: str, params):
+        calls.append({"query": query, "params": params})
+        if "WHERE id = %(repo_id)s" in query:
+            if params == {"repo_id": owned_uuid, "org_id": "org-a"}:
+                return [{"id": owned_uuid}]
+            return []
+        if "WHERE repo = %(repo_name)s" in query:
+            if params == {"repo_name": "org-a/repo-1", "org_id": "org-a"}:
+                return [{"id": "repo-name-id"}]
+            return []
+        return []
+
+    monkeypatch.setattr(scopes, "query_dicts", _fake_query_dicts)
+
+    resolved = await scopes.resolve_repo_ids(
+        object(),
+        [owned_uuid, foreign_uuid, "org-a/repo-1", "org-b/repo-2"],
+        org_id="org-a",
+    )
+
+    assert resolved == [owned_uuid, "repo-name-id"]
+    assert all(call["params"]["org_id"] == "org-a" for call in calls)

--- a/tests/graphql/test_resolvers.py
+++ b/tests/graphql/test_resolvers.py
@@ -9,6 +9,14 @@ import pytest
 
 from dev_health_ops.api.graphql.context import GraphQLContext
 from dev_health_ops.api.graphql.errors import AuthorizationError, CostLimitExceededError
+from dev_health_ops.api.graphql.models.inputs import (
+    AnalyticsRequestInput,
+    DateRangeInput,
+    DimensionInput,
+    MeasureInput,
+    SankeyRequestInput,
+)
+from dev_health_ops.api.graphql.resolvers.analytics import resolve_analytics
 from dev_health_ops.api.graphql.resolvers.catalog import resolve_catalog
 
 
@@ -234,3 +242,50 @@ class TestAuthzFunctions:
 
         with pytest.raises(AuthorizationError):
             enforce_org_scope("", {})
+
+
+class TestResolveAnalytics:
+    @pytest.mark.asyncio
+    async def test_sankey_coverage_query_scopes_by_org_id(self, monkeypatch):
+        captured_sql: list[str] = []
+        captured_params: list[dict[str, Any]] = []
+
+        async def fake_query_dicts(_client, sql, params):
+            captured_sql.append(sql)
+            captured_params.append(params)
+            return [{"total": 10, "assigned_team": 5, "assigned_repo": 4}]
+
+        def fake_compile_sankey(_request, _org_id, _timeout, filters=None):
+            return [], []
+
+        monkeypatch.setattr(
+            "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.api.graphql.resolvers.analytics.compile_sankey",
+            fake_compile_sankey,
+        )
+
+        context = GraphQLContext(
+            org_id="tenant-123",
+            db_url="clickhouse://localhost:8123/default",
+            client=MockClient(),
+        )
+        batch = AnalyticsRequestInput(
+            timeseries=[],
+            breakdowns=[],
+            sankey=SankeyRequestInput(
+                path=[DimensionInput.TEAM, DimensionInput.REPO],
+                measure=MeasureInput.COUNT,
+                date_range=DateRangeInput(
+                    start_date=date(2025, 1, 1),
+                    end_date=date(2025, 1, 31),
+                ),
+            ),
+        )
+
+        await resolve_analytics(context, batch)
+
+        assert len(captured_sql) == 1
+        assert "AND org_id = %(org_id)s" in captured_sql[0]
+        assert captured_params[0]["org_id"] == "tenant-123"


### PR DESCRIPTION
## Summary

- **Security fix**: Add `org_id` filtering to all GraphQL DataLoader SQL queries (`RepoLoader`, `RepoByNameLoader`, `TeamLoader`, `TeamByNameLoader`) to prevent cross-tenant data leakage
- **Security fix**: `resolve_repo_id` now verifies UUID-based repo refs against the requesting org instead of blindly trusting the UUID
- **Security fix**: Sankey coverage query in analytics resolver now scopes by `org_id`

## Changes

| File | Change |
|------|--------|
| `loaders/repo_loader.py` | Added `AND org_id = %(org_id)s` to both `RepoLoader` and `RepoByNameLoader` SQL |
| `loaders/team_loader.py` | Added `AND org_id = %(org_id)s` to both `TeamLoader` and `TeamByNameLoader` SQL |
| `resolvers/analytics.py` | Added `org_id` filter to sankey coverage query |
| `queries/scopes.py` | Fixed `resolve_repo_id` to verify UUID repo ownership; consolidated param construction |
| `tests/api/graphql/loaders/test_loader_org_scoping.py` | New: 4 tests verifying all loaders scope by org_id |
| `tests/api/queries/test_scopes.py` | New: 3 tests for scope resolver org isolation |
| `tests/graphql/test_resolvers.py` | Added sankey coverage org_id scoping test |

## Testing

All 1832 tests pass. 0 failures. Ruff clean.

SCREENSHOT-WAIVER: Backend-only changes — no frontend rendering affected