### PR TITLE
feat: add 'dev-hops admin billing seed' for default plans

### DIFF
--- a/src/dev_health_ops/api/admin/cli.py
+++ b/src/dev_health_ops/api/admin/cli.py
@@ -162,6 +162,92 @@ async def _seed_features_async(ns: argparse.Namespace) -> int:
 def seed_features(ns: argparse.Namespace) -> int:
     return asyncio.run(_seed_features_async(ns))
 
+async def _seed_billing_plans_async(ns: argparse.Namespace) -> int:
+    from sqlalchemy import select
+    from dev_health_ops.models.billing import BillingPlan, BillingPrice
+
+    STANDARD_PLANS = [
+        {
+            "key": "community",
+            "name": "Community",
+            "description": "For individuals and small teams getting started with engineering analytics.",
+            "tier": "community",
+            "display_order": 0,
+            "prices": [
+                {"interval": "monthly", "amount": 0, "currency": "usd"},
+                {"interval": "yearly", "amount": 0, "currency": "usd"},
+            ],
+        },
+        {
+            "key": "team",
+            "name": "Team",
+            "description": "For growing teams that need full visibility into delivery health and investment patterns.",
+            "tier": "team",
+            "display_order": 1,
+            "prices": [
+                {"interval": "monthly", "amount": 1200, "currency": "usd"},
+                {"interval": "yearly", "amount": 11500, "currency": "usd"},
+            ],
+        },
+        {
+            "key": "enterprise",
+            "name": "Enterprise",
+            "description": "For organizations that need enterprise-grade security, compliance, and dedicated support.",
+            "tier": "enterprise",
+            "display_order": 2,
+            "prices": [
+                {"interval": "monthly", "amount": 12900, "currency": "usd"},
+                {"interval": "yearly", "amount": 124000, "currency": "usd"},
+            ],
+        },
+    ]
+
+    session = await _get_session(ns)
+    try:
+        result = await session.execute(select(BillingPlan.key))
+        existing = {row[0] for row in result.all()}
+        created = 0
+
+        for plan_data in STANDARD_PLANS:
+            if plan_data["key"] in existing:
+                continue
+
+            plan = BillingPlan(
+                key=plan_data["key"],
+                name=plan_data["name"],
+                description=plan_data["description"],
+                tier=plan_data["tier"],
+                display_order=plan_data["display_order"],
+            )
+            session.add(plan)
+            await session.flush()  # get plan.id
+
+            for price_data in plan_data["prices"]:
+                price = BillingPrice(
+                    plan_id=plan.id,
+                    interval=price_data["interval"],
+                    amount=price_data["amount"],
+                    currency=price_data["currency"],
+                )
+                session.add(price)
+
+            created += 1
+
+        if created:
+            await session.commit()
+            print(f"Seeded {created} billing plan(s) with prices.")
+        else:
+            print("All standard billing plans already exist.")
+        return 0
+    except Exception as e:
+        print(f"Error: {e}")
+        return 1
+    finally:
+        await session.close()
+
+
+def seed_billing_plans(ns: argparse.Namespace) -> int:
+    return asyncio.run(_seed_billing_plans_async(ns))
 
 def licenses_keygen_cmd(ns: argparse.Namespace) -> int:
     from dev_health_ops.licensing.generator import generate_keypair
@@ -299,3 +385,13 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         "seed", help="Seed standard feature flags into the database."
     )
     features_seed.set_defaults(func=seed_features)
+
+    billing_parser = admin_sub.add_parser("billing", help="Billing plan management.")
+    billing_sub = billing_parser.add_subparsers(
+        dest="billing_command", required=True
+    )
+
+    billing_seed = billing_sub.add_parser(
+        "seed", help="Seed standard billing plans (Community, Team, Enterprise) with prices."
+    )
+    billing_seed.set_defaults(func=seed_billing_plans)

--- a/tests/test_billing_seed.py
+++ b/tests/test_billing_seed.py
@@ -1,0 +1,65 @@
+"""Tests for billing plan seeding (dev-hops admin billing seed)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from dev_health_ops.api.billing.plans import router as billing_router
+from dev_health_ops.api.auth.router import get_current_user
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.db import postgres_session_dependency
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(billing_router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_seed_billing_plans_creates_three_plans():
+    """The seed function creates Community, Team, and Enterprise plans."""
+    from dev_health_ops.api.admin.cli import _seed_billing_plans_async
+
+    mock_session = AsyncMock()
+    # Simulate empty database (no existing plans)
+    mock_result = MagicMock()
+    mock_result.all.return_value = []
+    mock_session.execute.return_value = mock_result
+
+    ns = MagicMock()
+
+    with patch("dev_health_ops.api.admin.cli._get_session", return_value=mock_session):
+        result = await _seed_billing_plans_async(ns)
+
+    assert result == 0
+    # 3 plans + 6 prices (2 per plan) = 9 session.add calls
+    assert mock_session.add.call_count == 9
+    mock_session.commit.assert_awaited_once()
+    mock_session.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_seed_billing_plans_skips_existing():
+    """The seed function skips plans that already exist."""
+    from dev_health_ops.api.admin.cli import _seed_billing_plans_async
+
+    mock_session = AsyncMock()
+    # Simulate all three plans already exist
+    mock_result = MagicMock()
+    mock_result.all.return_value = [("community",), ("team",), ("enterprise",)]
+    mock_session.execute.return_value = mock_result
+
+    ns = MagicMock()
+
+    with patch("dev_health_ops.api.admin.cli._get_session", return_value=mock_session):
+        result = await _seed_billing_plans_async(ns)
+
+    assert result == 0
+    mock_session.add.assert_not_called()
+    mock_session.commit.assert_not_awaited()
+    mock_session.close.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Adds `dev-hops admin billing seed` CLI command to seed Community, Team, and Enterprise billing plans
- Idempotent — skips plans that already exist in the database
- Prices match the marketing pricing page

## Plans Seeded

| Plan | Monthly | Yearly |
|------|---------|--------|
| Community | $0 (Free) | $0 |
| Team | $12/user/mo | $115/user/yr |
| Enterprise | $129/user/mo | $1,240/user/yr |

## Changes

- `src/dev_health_ops/api/admin/cli.py` — Added `_seed_billing_plans_async`, `seed_billing_plans`, and CLI parser for `admin billing seed`
- `tests/test_billing_seed.py` — 2 tests: creates plans when empty, skips when already exist

## Context

Community-tier users see "No active subscription" on the admin billing page because no plans exist in the database. This command seeds the default plans so the pricing page and billing settings have data to display.

SCREENSHOT-WAIVER: Backend-only CLI command — no rendered UI affected