### PR TITLE
docs: remediate ops setup and enterprise runbooks (CHAOS-512)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ CLICKHOUSE_URI="clickhouse://ch:ch@localhost:8123/default"
 # Legacy fallback (deprecated - use POSTGRES_URI and CLICKHOUSE_URI above)
 # DATABASE_URI will auto-route based on connection string type
 # DATABASE_URI="clickhouse://ch:ch@localhost:8123/default"
+# DATABASE_URL="clickhouse://ch:ch@localhost:8123/default"
 
 # Redis (for Celery workers and caching)
 REDIS_URL="redis://localhost:6379/0"
@@ -80,6 +81,21 @@ ATLASSIAN_CLOUD_ID="your-cloud-id"
 # JIRA_FETCH_WORKLOGS="false"       # Fetch issue worklogs (time tracking)
 # JIRA_FETCH_BOARD_SPRINTS="false"  # Fetch all sprints via board iteration
 # JIRA_OPS_PROJECT_TYPES="SERVICE_DESK"  # Jira project types for ops team sync
+
+# ----------------------------------------------------------------------------
+# Linear
+# ----------------------------------------------------------------------------
+# Required for Linear work-item sync provider
+# LINEAR_API_KEY="lin_api_xxxxxxxxxxxxxxxxxx"
+# Optional: max comments fetched per Linear issue (0 means no limit)
+# LINEAR_COMMENTS_LIMIT="0"
+
+# ----------------------------------------------------------------------------
+# API/Auth Runtime
+# ----------------------------------------------------------------------------
+# APP_BASE_URL="http://localhost:8000"        # OAuth/SSO callback base
+# JWT_SECRET_KEY="change-me-in-production"    # JWT signing secret
+# SETTINGS_ENCRYPTION_KEY="change-me-in-production"  # Settings encryption key
 
 # ----------------------------------------------------------------------------
 # Grafana (optional - for plugin publishing)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Notes:
 - **GitHub**: Requires `repo` scope on your personal access token
 - **GitLab**: Requires `read_api` and `read_repository` scopes on your private token
 
-See [`PRIVATE_REPO_TESTING.md`](./PRIVATE_REPO_TESTING.md) for detailed instructions on setting up and testing private repository access, or [`VERIFICATION_SUMMARY.md`](./VERIFICATION_SUMMARY.md) for a comprehensive overview.
+See [`docs/PRIVATE_REPO_TESTING.md`](docs/PRIVATE_REPO_TESTING.md) for detailed instructions on setting up and testing private repository access.
 
 ## Batch Repository Processing ✅
 
@@ -306,16 +306,23 @@ This project supports PostgreSQL, MongoDB, SQLite, and ClickHouse as storage bac
 
 ### Environment Variables
 
-- **`DATABASE_URI`** (optional): Default DB URI for `dev-hops metrics daily --db ...` and for Alembic migrations. Also accepts `DATABASE_URL` as an alias.
-- **`SECONDARY_DATABASE_URI`** (optional): Secondary database URI for `--sink both` mode (writes to both primary and secondary databases).
-- **`DB_ECHO`** (optional): Enable SQL query logging for PostgreSQL and SQLite. Set to `true`, `1`, or `yes` (case-insensitive) to enable. Any other value (including `false`, `0`, `no`, or unset) disables it. Default: `false`. Note: Enabling this in production can expose sensitive data and impact performance.
-- **`REPO_UUID`** (optional): UUID for the repository. If not provided, a deterministic UUID will be derived from the git repository's remote URL (or repository path if no remote exists). This ensures the same repository always gets the same UUID across runs.
-- **`MAX_WORKERS`** (optional): Number of parallel workers for processing git blame data. Higher values can speed up processing but use more CPU and memory. Default: `4`
-- **`LOG_LEVEL`** (optional): Logging level (e.g. `INFO`, `DEBUG`). Default: `INFO`
-- **`DISABLE_DOTENV`** (optional): Set to `1` to disable `.env` loading from the repo root.
-- **`GITHUB_TOKEN`** (optional): Default GitHub token when `--auth` is not provided.
-- **`GITLAB_TOKEN`** (optional): Default GitLab token when `--auth` is not provided.
-- **`GITLAB_URL`** (optional): Default GitLab base URL when `--gitlab-url` is not provided (default: `https://gitlab.com`).
+| Variable | Status | Used for |
+|----------|--------|----------|
+| `POSTGRES_URI` | Required (semantic DB) | Users/orgs/settings, admin flows, Alembic-backed services |
+| `CLICKHOUSE_URI` | Required (analytics DB) | Sync pipelines, metrics jobs, analytics APIs |
+| `DATABASE_URI` | Deprecated fallback | Legacy DB resolver paths (prefer `POSTGRES_URI` + `CLICKHOUSE_URI`) |
+| `DATABASE_URL` | Deprecated alias | Alias fallback alongside `DATABASE_URI` |
+| `SECONDARY_DATABASE_URI` | Optional | Dual-write mode (`--sink both`) |
+| `GITHUB_TOKEN` / `GITLAB_TOKEN` | Optional | Provider auth defaults when `--auth` is omitted |
+| `GITLAB_URL` | Optional | GitLab host override (default `https://gitlab.com`) |
+| `JIRA_*` / `ATLASSIAN_*` | Optional | Jira/Atlassian work-item ingestion and AGG integration |
+| `LINEAR_API_KEY` | Optional | Linear work-item ingestion (`sync work-items --provider linear`) |
+| `APP_BASE_URL` | Optional | API callback origins (billing + SSO routes) |
+| `JWT_SECRET_KEY` / `SETTINGS_ENCRYPTION_KEY` | Required in production | Auth token signing and settings encryption |
+| `DB_ECHO`, `LOG_LEVEL`, `DISABLE_DOTENV` | Optional | Diagnostics/runtime behavior toggles |
+| `REPO_UUID`, `MAX_WORKERS` | Optional | Repository identity and processing parallelism |
+
+Deprecated variables are still honored for compatibility, but new setup should use `POSTGRES_URI` and `CLICKHOUSE_URI`.
 
 ### Command-Line Arguments
 

--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -1,0 +1,19 @@
+# Alerting
+
+Dev-health-ops does not ship a single built-in alert pack. Configure alert rules in your visualization platform based on your team goals and thresholds.
+
+## Suggested rollout
+
+1. Identify the operational metrics your team reviews daily.
+2. Define ownership and response expectations for each alert.
+3. Validate alert behavior in a staging environment before production rollout.
+
+## Inputs for alert design
+
+- Metrics catalog: [Metrics](./metrics.md)
+- View semantics and interpretation: [Views Index](./user-guide/views-index.md)
+- Deployment and operations constraints: [Deployment Guide](./ops/deployment-guide.md)
+
+## Enterprise validation
+
+If you are validating enterprise rollout, include alert-related checks in your runbook alongside [Enterprise Features Manual Test Plan](./ops/enterprise-test-plan.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,14 @@
+# Configuration
+
+Use this page as the quick index for environment and deployment configuration.
+
+## Environment variables
+
+- Start with the template in `.env.example` at the repository root.
+- For dual-database setup details, see [Database Architecture](./architecture/database-architecture.md).
+
+## Operational reference
+
+- CLI environment variable details: [CLI Reference](./ops/cli-reference.md#environment-variables)
+- End-to-end bootstrap flow: [Self-Hosted Quickstart](./self-hosted-quickstart.md)
+- Deployment-specific guidance: [Deployment Guide](./ops/deployment-guide.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,11 +72,12 @@ See [Database Architecture](architecture/database-architecture.md) for details.
 
 ## Environment notes
 
-CLI flags override environment variables. Common env vars:
+CLI flags override environment variables.
 
-- `POSTGRES_URI` - PostgreSQL for semantic data (users, settings)
-- `CLICKHOUSE_URI` - ClickHouse for analytics data
-- `DATABASE_URI` - Legacy fallback (deprecated)
-- `GITHUB_TOKEN`
-- `GITLAB_TOKEN`
-- `REPO_PATH`
+| Variable | Status | Purpose |
+|----------|--------|---------|
+| `POSTGRES_URI` | Required | Semantic data (users, settings, credentials) |
+| `CLICKHOUSE_URI` | Required | Analytics data (sync + metrics) |
+| `DATABASE_URI` / `DATABASE_URL` | Deprecated fallback | Legacy resolver paths; keep only for compatibility |
+| `GITHUB_TOKEN`, `GITLAB_TOKEN`, `JIRA_*`, `ATLASSIAN_*`, `LINEAR_API_KEY` | Optional | Provider auth for sync commands |
+| `APP_BASE_URL`, `JWT_SECRET_KEY`, `SETTINGS_ENCRYPTION_KEY` | Optional in dev, required in production | API callback/auth/encryption settings |

--- a/docs/ops/enterprise-test-plan.md
+++ b/docs/ops/enterprise-test-plan.md
@@ -1,8 +1,8 @@
 # Enterprise Features Manual Test Plan
 
 > **Document Status**: Active  
-> **Last Updated**: 2026-02-05  
-> **Related Issues**: [#338](https://github.com/full-chaos/dev-health-ops/issues/338), [#299](https://github.com/full-chaos/dev-health-ops/issues/299)
+> **Last Updated**: 2026-02-25  
+> **Related Issues**: [#338](https://github.com/full-chaos/dev-health-ops/issues/338), [#299](https://github.com/full-chaos/dev-health-ops/issues/299), CHAOS-512, CHAOS-516
 
 This document defines step-by-step manual test procedures for validating enterprise features across SaaS and self-hosted deployments.
 
@@ -20,6 +20,87 @@ This document defines step-by-step manual test procedures for validating enterpr
 8. [Limit Enforcement](#8-limit-enforcement)
 9. [Admin Portal](#9-admin-portal)
 10. [Deployment-Specific Tests](#10-deployment-specific-tests)
+11. [Execution Workflow and Batches (CHAOS-516)](#11-execution-workflow-and-batches-chaos-516)
+
+---
+
+## 11. Execution Workflow and Batches (CHAOS-516)
+
+This section converts the full manual plan into executable batches. Existing section test cases remain unchanged and are executed through the batch workflow below.
+
+### 11.1 Phase Order
+
+- **Phase A - Foundation**: Batch A1
+- **Phase B - Access and Identity**: Batch B1, Batch B2
+- **Phase C - Enterprise Controls**: Batch C1, Batch C2, Batch C3
+- **Phase D - Limits and Operations**: Batch D1, Batch D2
+
+### 11.2 Batch Catalog
+
+| Batch | Scope (Existing Sections) | Required Prerequisites | Owner | Evidence Template ID | Exit Criteria |
+|------|----------------------------|------------------------|-------|----------------------|---------------|
+| A1 | Section 1 + Section 2 + Section 10.1-10.3 | Env vars set, fixtures created, deployment target selected | QA Lead | `EV-BATCH-A1` | Licensing and deployment baseline validated |
+| B1 | Section 3 + Section 9.1-9.3 | A1 complete, owner/admin/editor/viewer accounts active | QA + Security | `EV-BATCH-B1` | RBAC and admin surface behavior validated |
+| B2 | Section 4 | B1 complete, IdP sandbox available, enterprise entitlement active | QA + IAM Owner | `EV-BATCH-B2` | SAML/OIDC flows and SSO edge cases validated |
+| C1 | Section 5 | B1 complete, enterprise entitlement active | QA + Compliance | `EV-BATCH-C1` | Audit generation/query/detail/gating validated |
+| C2 | Section 6 | C1 complete, retention test dataset seeded | QA + Data Governance | `EV-BATCH-C2` | Retention lifecycle behavior validated |
+| C3 | Section 7 | B1 complete, test CIDRs and request replay setup available | QA + Security | `EV-BATCH-C3` | Allowlist CRUD and enforcement validated |
+| D1 | Section 8 | A1 complete, tier-specific org fixtures prepared | QA + Platform | `EV-BATCH-D1` | Tier limits and rate behaviors validated |
+| D2 | Section 9.4 + regression sweep across Sections 2-9 | B2/C1/C2/C3/D1 complete | QA Lead | `EV-BATCH-D2` | Credential flow and final regression signoff complete |
+
+### 11.3 Batch Prerequisite Checklist
+
+| Checkpoint | Description | Owner | Evidence Required | Status |
+|-----------|-------------|-------|-------------------|--------|
+| PR-1 | Test environment initialized (Section 1.1-1.4) | QA Lead | Environment export, startup logs, health checks | [ ] |
+| PR-2 | Tier fixtures and account roles prepared | QA + Platform | Entitlements output + user/org seed logs | [ ] |
+| PR-3 | IdP integrations available for SAML/OIDC | IAM Owner | Provider metadata and callback endpoint verification | [ ] |
+| PR-4 | Audit/retention datasets seeded for delete/query checks | Compliance | Record counts before execution | [ ] |
+| PR-5 | Network paths available for allowlist scenarios | Security | Source IP inventory and test route capture | [ ] |
+
+### 11.4 Evidence Capture Template
+
+Use one record per executed batch and attach it to the issue comment or test run note.
+
+| Field | Value |
+|------|-------|
+| Template ID | `EV-BATCH-<BATCH-ID>` |
+| Linear Issue | `CHAOS-516` |
+| Parent Issue | `CHAOS-512` |
+| Batch ID | |
+| Sections Covered | |
+| Owner | |
+| Support Roles | |
+| Environment | SaaS / Self-Hosted / Both |
+| Build/Commit Ref | |
+| Start Time (UTC) | |
+| End Time (UTC) | |
+| Result | Pass / Fail / Blocked |
+| Blocked By | `CHAOS-176`, `CHAOS-184`, `CHAOS-185`, `CHAOS-136`, or `none` |
+| Evidence Links | API responses, logs, screenshots, exports |
+| Notes / Deviations | |
+
+### 11.5 Explicit Blocked-By Mapping
+
+| Blocked Area | Affected Batches | Blocked By (Linear) | Dependency Reason | Unblock Validation |
+|-------------|------------------|---------------------|-------------------|-------------------|
+| SSO provider provisioning and login flows (Section 4) | B2, D2 | `CHAOS-176` | Upstream SSO plumbing and provider lifecycle must be stable before full manual execution | Provider create/activate/login paths complete without known blocker tags |
+| Audit event visibility and query fidelity (Section 5) | C1, D2 | `CHAOS-184` | Audit event schema/query behavior must match expected contract for manual validation | Audit list/detail/filter endpoints return expected event payloads |
+| Retention execution + legal hold path (Section 6) | C2, D2 | `CHAOS-185` | Retention policy execution and hold semantics require upstream completion | Execute/delete/history behavior matches expected outcomes without bypasses |
+| IP allowlist enforcement and edge behavior (Section 7) | C3, D2 | `CHAOS-136` | Allowlist middleware/control-path needs upstream fixes before deterministic testing | Allowed/blocked decisions consistently match configured CIDRs |
+
+### 11.6 Batch Execution Tracker
+
+| Batch | Planned Window | Owner | Result | Evidence ID | Blocked By | Notes |
+|------|----------------|-------|--------|-------------|------------|-------|
+| A1 | | | [ ] Pass [ ] Fail [ ] Blocked | | | |
+| B1 | | | [ ] Pass [ ] Fail [ ] Blocked | | | |
+| B2 | | | [ ] Pass [ ] Fail [ ] Blocked | | | |
+| C1 | | | [ ] Pass [ ] Fail [ ] Blocked | | | |
+| C2 | | | [ ] Pass [ ] Fail [ ] Blocked | | | |
+| C3 | | | [ ] Pass [ ] Fail [ ] Blocked | | | |
+| D1 | | | [ ] Pass [ ] Fail [ ] Blocked | | | |
+| D2 | | | [ ] Pass [ ] Fail [ ] Blocked | | | |
 
 ---
 
@@ -560,6 +641,6 @@ helm install dev-health fullchaos/dev-health-platform \
 
 - [Enterprise Overview](../architecture/enterprise-overview.md)
 - [Licensing Architecture](../architecture/licensing.md)
-- [SSO Setup Guide](./sso-setup.md) (TODO)
+- [SSO Setup Guide](../sso-setup.md)
 - [ADR-001: Enterprise Edition](../architecture/adr/001-enterprise-edition.md)
 - [Self-Hosted Quickstart](../self-hosted-quickstart.md)

--- a/docs/ops/stripe-billing-runbook.md
+++ b/docs/ops/stripe-billing-runbook.md
@@ -1,0 +1,235 @@
+# Stripe Billing Runbook
+
+This runbook covers how to operate Stripe-backed billing in `dev-health-ops` across local development, CI, and production operations.
+
+## Deployment Paths
+
+| Path | Stripe required | Core mechanism |
+|---|---|---|
+| SaaS | Yes | Stripe checkout, portal, and webhook flow |
+| Self-hosted | No | Offline license flow (`DEV_HEALTH_LICENSE`) |
+
+If you are self-hosting only, skip Stripe setup and use `DEV_HEALTH_LICENSE` as documented in the self-hosted guides.
+
+## Billing API Contract (Current)
+
+The runbook assumes the current billing endpoints in `dev_health_ops.api.billing.router`:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/v1/billing/webhooks/stripe` | `POST` | Receives Stripe webhook events |
+| `/api/v1/billing/checkout` | `POST` | Creates Stripe Checkout sessions |
+| `/api/v1/billing/portal` | `POST` | Creates Stripe Billing Portal sessions |
+| `/api/v1/billing/entitlements/{org_id}` | `GET` | Returns org entitlements |
+| `/api/v1/billing/audit` | `GET` | Lists billing audit and reconciliation entries (superadmin) |
+| `/api/v1/billing/audit/{audit_id}` | `GET` | Gets one billing audit entry (superadmin) |
+| `/api/v1/billing/audit/{audit_id}/resolve` | `POST` | Marks mismatch resolution (superadmin) |
+| `/api/v1/billing/reconcile` | `POST` | Triggers reconciliation run (superadmin) |
+
+## Required Environment Variables (SaaS)
+
+Set these before running API billing flows:
+
+```bash
+export STRIPE_SECRET_KEY="sk_test_..."
+export STRIPE_WEBHOOK_SECRET="whsec_..."
+export STRIPE_PRICE_ID_TEAM="price_..."
+export STRIPE_PRICE_ID_ENTERPRISE="price_..."
+export LICENSE_PRIVATE_KEY="<base64-ed25519-private-key>"
+```
+
+Optional but recommended for checkout URL validation:
+
+```bash
+export APP_BASE_URL="http://localhost:3000"
+export ALLOWED_CHECKOUT_DOMAINS="http://localhost:3000,https://staging.example.com"
+```
+
+## Local Workflow (SaaS)
+
+### 1) Start API with billing env
+
+```bash
+# Example local API startup
+export CLICKHOUSE_URI="clickhouse://localhost:8123/default"
+export POSTGRES_URI="postgresql+asyncpg://postgres:postgres@localhost:5432/devhealth"
+dev-hops api --db "$CLICKHOUSE_URI" --host 0.0.0.0 --port 8000 --reload
+```
+
+### 2) Install and authenticate Stripe CLI
+
+```bash
+# macOS (Homebrew)
+brew install stripe/stripe-cli/stripe
+
+# Authenticate Stripe CLI for your Stripe account
+stripe login
+```
+
+### 3) Forward Stripe events to local webhook endpoint
+
+```bash
+stripe listen \
+  --forward-to http://127.0.0.1:8000/api/v1/billing/webhooks/stripe \
+  --events checkout.session.completed,customer.subscription.created,customer.subscription.updated,customer.subscription.deleted,invoice.created,invoice.updated,invoice.finalized,invoice.paid,invoice.payment_failed,invoice.voided,charge.refunded,charge.refund.updated
+```
+
+Copy the emitted signing secret (`whsec_...`) and set it as `STRIPE_WEBHOOK_SECRET` in your shell where the API runs.
+
+### 4) Trigger local event flows
+
+```bash
+# Simulate checkout completion
+stripe trigger checkout.session.completed
+
+# Simulate recurring invoice events
+stripe trigger invoice.paid
+stripe trigger invoice.payment_failed
+
+# Simulate subscription updates
+stripe trigger customer.subscription.updated
+```
+
+### 5) Validate API-level outcomes
+
+```bash
+# Health check
+curl http://127.0.0.1:8000/health
+
+# Trigger reconciliation (requires superadmin auth in real environments)
+curl -X POST "http://127.0.0.1:8000/api/v1/billing/reconcile"
+```
+
+## Webhook Replay, Retry, and Idempotency
+
+### Stripe retry model
+
+- Stripe retries failed deliveries automatically.
+- Manual replays can come from Stripe Dashboard or Stripe CLI.
+- Your API must tolerate at-least-once delivery.
+
+### Current idempotency behavior in `dev-health-ops`
+
+- Invoice webhook handling checks duplicate Stripe event IDs before processing invoice writes.
+- Duplicate invoice events are skipped and logged.
+- For subscription/refund mismatches or replay uncertainty, use reconciliation and audit endpoints.
+
+### Safe replay playbook
+
+1. Confirm the webhook endpoint returns non-2xx or missed state change.
+2. Replay specific events:
+
+```bash
+# List recent events
+stripe events list --limit 20
+
+# Replay one event to the local endpoint
+stripe events resend evt_123 --webhook-endpoint we_123
+```
+
+3. Run reconciliation:
+
+```bash
+curl -X POST "http://127.0.0.1:8000/api/v1/billing/reconcile"
+```
+
+4. Inspect audit trail for unresolved mismatches:
+
+```bash
+curl "http://127.0.0.1:8000/api/v1/billing/audit?org_id=<org-uuid>"
+```
+
+## Ops Workflow (SaaS Production)
+
+### Incident triage checklist
+
+1. Verify env vars in runtime (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, price IDs, `LICENSE_PRIVATE_KEY`).
+2. Verify Stripe webhook endpoint URL exactly matches:
+   - `https://<your-domain>/api/v1/billing/webhooks/stripe`
+3. Verify Stripe endpoint event subscriptions include the billing lifecycle events listed in this runbook.
+4. Confirm webhook delivery status in Stripe Dashboard (response code + body).
+5. Trigger reconciliation and review mismatches via audit endpoints.
+
+### Reconciliation commands
+
+Use either API endpoint or CLI:
+
+```bash
+# API
+curl -X POST "https://<your-domain>/api/v1/billing/reconcile"
+
+# CLI (from ops runtime with DB/env configured)
+python -m dev_health_ops.cli billing reconcile
+
+# Scoped reconcile by org
+python -m dev_health_ops.cli billing reconcile --org-id <org-uuid>
+
+# Reconcile invoices since timestamp
+python -m dev_health_ops.cli billing reconcile --org-id <org-uuid> --since 2026-02-24T00:00:00
+```
+
+### Resolving mismatches
+
+1. Pull mismatch entries from `/api/v1/billing/audit`.
+2. Investigate local vs Stripe state.
+3. Mark resolved when remediation completes:
+
+```bash
+curl -X POST "https://<your-domain>/api/v1/billing/audit/<audit-id>/resolve" \
+  -H "Content-Type: application/json" \
+  -d '{"resolution":"manual correction applied after Stripe replay"}'
+```
+
+## CI Workflow
+
+### Secret handling
+
+- Store Stripe values in CI secret manager, never in repo files:
+  - `STRIPE_SECRET_KEY`
+  - `STRIPE_WEBHOOK_SECRET`
+  - `STRIPE_PRICE_ID_TEAM`
+  - `STRIPE_PRICE_ID_ENTERPRISE`
+  - `LICENSE_PRIVATE_KEY`
+- Inject them as environment variables at job runtime.
+
+Example (generic CI shell step):
+
+```bash
+export STRIPE_SECRET_KEY="$CI_STRIPE_SECRET_KEY"
+export STRIPE_WEBHOOK_SECRET="$CI_STRIPE_WEBHOOK_SECRET"
+export STRIPE_PRICE_ID_TEAM="$CI_STRIPE_PRICE_ID_TEAM"
+export STRIPE_PRICE_ID_ENTERPRISE="$CI_STRIPE_PRICE_ID_ENTERPRISE"
+export LICENSE_PRIVATE_KEY="$CI_LICENSE_PRIVATE_KEY"
+pytest -q tests/test_billing.py tests/test_subscriptions.py tests/test_invoices.py tests/test_refunds.py
+```
+
+### CI guardrails
+
+- Use Stripe test-mode keys only (`sk_test_...`).
+- Avoid printing secret values in logs.
+- Keep webhook-signature tests deterministic by stubbing payload/signature where possible.
+
+## Stripe Test Card Matrix
+
+Use Stripe test mode and these cards during checkout/billing validation:
+
+| Scenario | Card number | Notes |
+|---|---|---|
+| Successful payment | `4242 4242 4242 4242` | Baseline success path |
+| Generic decline | `4000 0000 0000 0002` | Payment declined |
+| Insufficient funds | `4000 0000 0000 9995` | Insufficient funds path |
+| 3DS required | `4000 0025 0000 3155` | Authentication flow required |
+| Expired card | `4000 0000 0000 0069` | Expiration failure path |
+| Incorrect CVC | `4000 0000 0000 0127` | CVC validation failure |
+
+For all test cards, use any future expiry date, any 3-digit CVC, and any postal code.
+
+## Self-Hosted Note
+
+Self-hosted deployments do not require Stripe endpoint configuration. Use offline license keys and set:
+
+```bash
+export DEV_HEALTH_LICENSE="<signed-license-token>"
+```
+
+Reference: [`self-hosted-quickstart.md`](../self-hosted-quickstart.md).

--- a/docs/self-hosted-quickstart.md
+++ b/docs/self-hosted-quickstart.md
@@ -322,6 +322,8 @@ dev-hops sync work-items --provider github \
 
 > **Note**: Billing variables are only required for SaaS deployments that process Stripe subscriptions. Self-hosted deployments use offline Ed25519 license keys instead (set `DEV_HEALTH_LICENSE`).
 
+If you run SaaS billing flows, use the dedicated [Stripe Billing Runbook](./ops/stripe-billing-runbook.md) for webhook forwarding, replay/retry, CI secret handling, and reconciliation operations.
+
 ---
 
 ## Upgrading

--- a/docs/sso-setup.md
+++ b/docs/sso-setup.md
@@ -1,0 +1,21 @@
+# SSO Setup
+
+This page links to the current enterprise SSO architecture and validation flow.
+
+## Before you start
+
+- Confirm your organization is on an enterprise tier deployment.
+- Ensure your environment is configured per [Self-Hosted Quickstart](./self-hosted-quickstart.md) when running self-hosted.
+
+## Architecture and behavior
+
+- Enterprise feature model: [Enterprise Overview](./architecture/enterprise-overview.md)
+- Licensing and entitlement behavior: [Licensing Architecture](./architecture/licensing.md)
+
+## Validation flow
+
+- Manual SSO and enterprise validation steps: [Enterprise Features Manual Test Plan](./ops/enterprise-test-plan.md#4-sso-authentication)
+
+## Next step
+
+- Continue onboarding with [Alerting](./alerting.md)

--- a/docs/team-configuration.md
+++ b/docs/team-configuration.md
@@ -1,0 +1,18 @@
+# Team Configuration
+
+This guide covers the fastest path to mapping repositories and providers to teams.
+
+## Recommended path
+
+1. Define your team mapping source (YAML file, Jira, GitHub, GitLab, or synthetic).
+2. Run `dev-hops sync teams` with the appropriate provider.
+3. Recompute daily metrics so team-scoped views include the latest mappings.
+
+## Command reference
+
+For provider-specific commands and flags, use [CLI Reference - sync teams](./ops/cli-reference.md#sync-teams).
+
+## Next onboarding steps
+
+- Enterprise SSO configuration: [SSO Setup](./sso-setup.md)
+- Deployment and operations checks: [Enterprise Features Manual Test Plan](./ops/enterprise-test-plan.md)

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -91,3 +91,5 @@ Stripe webhooks are used for real-time subscription management in SaaS deploymen
 | `LICENSE_PRIVATE_KEY` | Ed25519 private key for signing JWT licenses (base64-encoded) |
 
 > **Note**: Stripe webhooks are only relevant for SaaS deployments. Self-hosted deployments use offline Ed25519 license keys and do not require Stripe configuration.
+
+For full local/CI/ops guidance (Stripe CLI forwarding, replay/retry, reconciliation, and test cards), see the [Stripe Billing Runbook](./ops/stripe-billing-runbook.md).


### PR DESCRIPTION
## Summary
- resolve broken onboarding docs links by adding missing setup pages and correcting enterprise test-plan references
- add a Stripe billing runbook with local CLI webhook flow, replay/retry guidance, reconciliation steps, and CI secret handling
- align ops environment variable documentation with dual-database architecture and current provider/runtime variables

## Validation
- `PYENV_VERSION=dev-health mkdocs build -q`
- internal markdown link check across `docs/` (missing links: 0)

## Tracking
- CHAOS-512
- CHAOS-513
- CHAOS-514
- CHAOS-516
- CHAOS-517