### PR TITLE
fix(admin): allow superadmin global user list and search

### DIFF
--- a/src/dev_health_ops/api/admin/router.py
+++ b/src/dev_health_ops/api/admin/router.py
@@ -169,6 +169,14 @@ async def _ensure_org_admin_access(
         )
 
 
+def _get_org_id_for_non_superuser(current_user: AuthenticatedUser) -> str:
+    if current_user.is_superuser:
+        return current_user.org_id or ""
+    if not current_user.org_id:
+        raise HTTPException(status_code=403, detail="Organization context required")
+    return current_user.org_id
+
+
 @router.get("/settings/categories")
 async def list_setting_categories() -> list[str]:
     return [c.value for c in SettingCategory]
@@ -1291,13 +1299,28 @@ async def list_users(
     limit: int = 100,
     offset: int = 0,
     active_only: bool = True,
+    q: str | None = Query(default=None, min_length=1, max_length=200),
     session: AsyncSession = Depends(get_session),
-    org_id: str = Depends(get_admin_org_id),
+    current_user: AuthenticatedUser = Depends(require_admin),
 ) -> list[UserResponse]:
     svc = UserService(session)
-    users = await svc.list_by_org(
-        org_id, limit=limit, offset=offset, active_only=active_only
-    )
+    search = q.strip() if q and q.strip() else None
+    if current_user.is_superuser:
+        users = await svc.list_all(
+            limit=limit,
+            offset=offset,
+            active_only=active_only,
+            search=search,
+        )
+    else:
+        org_id = _get_org_id_for_non_superuser(current_user)
+        users = await svc.list_by_org(
+            org_id,
+            limit=limit,
+            offset=offset,
+            active_only=active_only,
+            search=search,
+        )
     return [
         UserResponse(
             id=str(u.id),
@@ -1321,9 +1344,9 @@ async def list_users(
 async def get_user(
     user_id: str,
     session: AsyncSession = Depends(get_session),
-    org_id: str = Depends(get_admin_org_id),
     current_user: AuthenticatedUser = Depends(require_admin),
 ) -> UserResponse:
+    org_id = _get_org_id_for_non_superuser(current_user)
     svc = UserService(session)
     user = await svc.get_by_id(user_id)
     if not user:
@@ -1385,9 +1408,9 @@ async def update_user(
     user_id: str,
     payload: UserUpdate,
     session: AsyncSession = Depends(get_session),
-    org_id: str = Depends(get_admin_org_id),
     current_user: AuthenticatedUser = Depends(require_admin),
 ) -> UserResponse:
+    org_id = _get_org_id_for_non_superuser(current_user)
     svc = UserService(session)
     existing_user = await svc.get_by_id(user_id)
     if not existing_user:
@@ -1429,9 +1452,9 @@ async def set_user_password(
     user_id: str,
     payload: UserSetPassword,
     session: AsyncSession = Depends(get_session),
-    org_id: str = Depends(get_admin_org_id),
     current_user: AuthenticatedUser = Depends(require_admin),
 ) -> dict:
+    org_id = _get_org_id_for_non_superuser(current_user)
     svc = UserService(session)
     user = await svc.get_by_id(user_id)
     if not user:
@@ -1450,9 +1473,9 @@ async def set_user_password(
 async def delete_user(
     user_id: str,
     session: AsyncSession = Depends(get_session),
-    org_id: str = Depends(get_admin_org_id),
     current_user: AuthenticatedUser = Depends(require_admin),
 ) -> dict:
+    org_id = _get_org_id_for_non_superuser(current_user)
     svc = UserService(session)
     user = await svc.get_by_id(user_id)
     if not user:

--- a/src/dev_health_ops/api/services/users.py
+++ b/src/dev_health_ops/api/services/users.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.models.users import (
@@ -65,16 +65,34 @@ class UserService:
         return result.scalar_one_or_none()
 
     async def list_all(
-        self, limit: int = 100, offset: int = 0, active_only: bool = True
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        active_only: bool = True,
+        search: str | None = None,
     ) -> list[User]:
         stmt = select(User).order_by(User.created_at.desc()).limit(limit).offset(offset)
         if active_only:
             stmt = stmt.where(User.is_active == True)  # noqa: E712
+        if search:
+            pattern = f"%{search.lower()}%"
+            stmt = stmt.where(
+                or_(
+                    func.lower(User.email).like(pattern),
+                    func.lower(func.coalesce(User.username, "")).like(pattern),
+                    func.lower(func.coalesce(User.full_name, "")).like(pattern),
+                )
+            )
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
 
     async def list_by_org(
-        self, org_id: str, limit: int = 100, offset: int = 0, active_only: bool = True
+        self,
+        org_id: str,
+        limit: int = 100,
+        offset: int = 0,
+        active_only: bool = True,
+        search: str | None = None,
     ) -> list[User]:
         stmt = (
             select(User)
@@ -86,6 +104,15 @@ class UserService:
         )
         if active_only:
             stmt = stmt.where(User.is_active == True)  # noqa: E712
+        if search:
+            pattern = f"%{search.lower()}%"
+            stmt = stmt.where(
+                or_(
+                    func.lower(User.email).like(pattern),
+                    func.lower(func.coalesce(User.username, "")).like(pattern),
+                    func.lower(func.coalesce(User.full_name, "")).like(pattern),
+                )
+            )
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
 

--- a/tests/test_admin_users_scope.py
+++ b/tests/test_admin_users_scope.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.admin.middleware import require_admin
+from dev_health_ops.api.admin.router import get_session
+from dev_health_ops.api.main import app
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import Membership, Organization, User
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "admin-users-scope.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=[
+                    User.__table__,
+                    Organization.__table__,
+                    Membership.__table__,
+                ],
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_state(session_maker):
+    org_a = Organization(id=uuid.uuid4(), slug="org-a", name="Org A")
+    org_b = Organization(id=uuid.uuid4(), slug="org-b", name="Org B")
+
+    user_a = User(
+        id=uuid.uuid4(),
+        email="alice@example.com",
+        username="alice",
+        full_name="Alice Alpha",
+        is_active=True,
+    )
+    user_b = User(
+        id=uuid.uuid4(),
+        email="bob@example.com",
+        username="bob",
+        full_name="Bob Beta",
+        is_active=True,
+    )
+    user_c = User(
+        id=uuid.uuid4(),
+        email="charlie@example.com",
+        username="charlie",
+        full_name="Charlie Gamma",
+        is_active=False,
+    )
+
+    async with session_maker() as session:
+        session.add_all([org_a, org_b, user_a, user_b, user_c])
+        session.add_all(
+            [
+                Membership(org_id=org_a.id, user_id=user_a.id, role="owner"),
+                Membership(org_id=org_b.id, user_id=user_b.id, role="member"),
+                Membership(org_id=org_a.id, user_id=user_c.id, role="member"),
+            ]
+        )
+        await session.commit()
+
+    return {
+        "org_a": str(org_a.id),
+        "org_b": str(org_b.id),
+        "user_a": str(user_a.id),
+        "user_b": str(user_b.id),
+        "user_c": str(user_c.id),
+    }
+
+
+@pytest_asyncio.fixture
+async def client(session_maker):
+    current_user = {
+        "value": AuthenticatedUser(
+            user_id="admin-user",
+            email="admin@example.com",
+            org_id="",
+            role="owner",
+            is_superuser=False,
+        )
+    }
+
+    async def _override_get_session():
+        async with session_maker() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = _override_get_session
+    app.dependency_overrides[require_admin] = lambda: current_user["value"]
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client, current_user
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_superadmin_users_list_is_global(client, seeded_state):
+    async_client, current_user = client
+    current_user["value"] = AuthenticatedUser(
+        user_id="super-user",
+        email="super@example.com",
+        org_id=seeded_state["org_a"],
+        role="owner",
+        is_superuser=True,
+    )
+
+    response = await async_client.get("/api/v1/admin/users")
+
+    assert response.status_code == 200
+    body = response.json()
+    emails = {row["email"] for row in body}
+    assert emails == {"alice@example.com", "bob@example.com"}
+
+
+@pytest.mark.asyncio
+async def test_org_admin_users_list_stays_org_scoped(client, seeded_state):
+    async_client, current_user = client
+    current_user["value"] = AuthenticatedUser(
+        user_id="org-admin",
+        email="org-admin@example.com",
+        org_id=seeded_state["org_a"],
+        role="owner",
+        is_superuser=False,
+    )
+
+    response = await async_client.get("/api/v1/admin/users")
+
+    assert response.status_code == 200
+    body = response.json()
+    emails = {row["email"] for row in body}
+    assert emails == {"alice@example.com"}
+
+
+@pytest.mark.asyncio
+async def test_users_search_honors_scope_for_superadmin_and_org_admin(
+    client, seeded_state
+):
+    async_client, current_user = client
+
+    current_user["value"] = AuthenticatedUser(
+        user_id="super-user",
+        email="super@example.com",
+        org_id=seeded_state["org_a"],
+        role="owner",
+        is_superuser=True,
+    )
+    super_response = await async_client.get("/api/v1/admin/users?q=bob")
+    assert super_response.status_code == 200
+    assert [row["email"] for row in super_response.json()] == ["bob@example.com"]
+
+    current_user["value"] = AuthenticatedUser(
+        user_id="org-admin",
+        email="org-admin@example.com",
+        org_id=seeded_state["org_a"],
+        role="owner",
+        is_superuser=False,
+    )
+    org_response = await async_client.get("/api/v1/admin/users?q=bob")
+    assert org_response.status_code == 200
+    assert org_response.json() == []


### PR DESCRIPTION
## Summary
- branch `/api/v1/admin/users` by role so superadmins get global results while org admins remain org-scoped
- add optional `q` search filtering for `email`, `username`, and `full_name` in both global and org-scoped user listing paths
- add regression tests covering superadmin global listing, org-admin scoping, and scoped search behavior

## Validation
- `pytest tests/test_admin_users_scope.py tests/test_admin_credentials.py`

SCREENSHOT-WAIVER: backend/API and test-only changes; UI screenshots are attached in companion web PR.