### PR TITLE
fix(packaging): include html/txt data files in setuptools package-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ py-modules = ["cli", "investment_taxonomy", "storage", "utils"]
 include-package-data = true
 
 [tool.setuptools.package-data]
-"*" = ["**/*.sql", "**/*.yaml", "**/*.yml", "**/*.json", "**/*.mako"]
+"*" = ["**/*.sql", "**/*.yaml", "**/*.yml", "**/*.json", "**/*.mako", "**/*.html", "**/*.txt"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Summary

- Adds `**/*.html` and `**/*.txt` to `[tool.setuptools.package-data]` in `pyproject.toml`

## Problem

Email templates (`.html`) and runtime data files (`.txt`) were not listed in the setuptools package-data globs. When the package is pip-installed inside Docker — where `.git` is absent and `include-package-data = true` cannot enumerate VCS-tracked files — these files were excluded from `site-packages`.

This caused `ValueError: Email template 'verification' not found` on user registration, and would also break:
- **Password validation** (`data/common_passwords.txt`)
- **LLM prompt loading** (`llm/prompts/investment_mix_explain_prompt.txt`)

## Fix

One-line change: add `"**/*.html", "**/*.txt"` to the existing package-data glob list.

## Verification

After merging, rebuild the Docker image and confirm `/usr/local/lib/python3.14/site-packages/dev_health_ops/templates/email/` contains all 8 HTML templates.