### PR TITLE
audit: add pip-audit dependency vulnerability scanning in CI (CHAOS-661)

### DIFF
--- a/.github/workflows/scheduled-scan.yml
+++ b/.github/workflows/scheduled-scan.yml
@@ -1,0 +1,54 @@
+name: Scheduled Dependency Scan
+
+on:
+  schedule:
+    # Every Monday at 08:00 UTC
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+jobs:
+  pip-audit-weekly:
+    name: Weekly Dependency Vulnerability Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install pip-audit
+        run: pip install "pip-audit>=2.7.0"
+
+      - name: Run pip-audit
+        run: |
+          # Build ignore flags from repo-controlled allowlist (not user input)
+          IGNORE_ARGS=""
+          if [ -f .pip-audit-ignore ]; then
+            while IFS= read -r line; do
+              [[ "$line" =~ ^[[:space:]]*# ]] && continue
+              [[ -z "${line// }" ]] && continue
+              CVE=$(echo "$line" | awk '{print $1}')
+              IGNORE_ARGS="$IGNORE_ARGS --ignore-vuln $CVE"
+            done < .pip-audit-ignore
+          fi
+          # shellcheck disable=SC2086
+          pip-audit \
+            --requirement requirements.txt \
+            --vulnerability-service pypi \
+            --format markdown \
+            --output pip-audit-report.md \
+            $IGNORE_ARGS
+
+      - name: Upload pip-audit report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pip-audit-weekly-report
+          path: pip-audit-report.md
+          if-no-files-found: ignore
+          retention-days: 90

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,6 +1,8 @@
 name: Security Scan
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -9,6 +11,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pip-audit:
+    name: Dependency Vulnerability Scan (pip-audit)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install pip-audit
+        run: pip install "pip-audit>=2.7.0"
+
+      - name: Run pip-audit (fail on any vulnerability)
+        run: |
+          # Build ignore flags from repo-controlled allowlist (not user input)
+          IGNORE_ARGS=""
+          if [ -f .pip-audit-ignore ]; then
+            while IFS= read -r line; do
+              [[ "$line" =~ ^[[:space:]]*# ]] && continue
+              [[ -z "${line// }" ]] && continue
+              CVE=$(echo "$line" | awk '{print $1}')
+              IGNORE_ARGS="$IGNORE_ARGS --ignore-vuln $CVE"
+            done < .pip-audit-ignore
+          fi
+          # shellcheck disable=SC2086
+          pip-audit \
+            --requirement requirements.txt \
+            --vulnerability-service pypi \
+            --format markdown \
+            --output pip-audit-report.md \
+            $IGNORE_ARGS
+
+      - name: Upload pip-audit report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pip-audit-report
+          path: pip-audit-report.md
+          if-no-files-found: ignore
+          retention-days: 30
+
   semgrep:
     name: Semgrep SAST
     runs-on: ubuntu-latest

--- a/.pip-audit-ignore
+++ b/.pip-audit-ignore
@@ -1,0 +1,11 @@
+# pip-audit CVE allowlist
+# Format: <CVE-ID> <package-name> <reason> [<expiry-date>]
+#
+# Add entries here for acknowledged CVEs that have been reviewed and accepted.
+# Each entry should include the CVE ID, affected package, reason for acceptance,
+# and an optional expiry date after which the ignore should be reconsidered.
+#
+# Example:
+# PYSEC-2024-123 some-package Accepted risk, no fix available yet. Review by 2025-06-01.
+#
+# Currently no CVEs are acknowledged/ignored.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dev = [
   "pytest-cov",
   "pytest-xdist>=3.8.0,<4.0.0",
   "fakeredis",
+  "pip-audit>=2.7.0",
 ]
 enterprise-sso = [
   "defusedxml>=0.7.0",


### PR DESCRIPTION
## Summary

- Adds `pip-audit` step to `security-scan.yml` to scan for known CVEs on every PR and push to main
- Creates `scheduled-scan.yml` for weekly Monday vulnerability scans
- Adds `.pip-audit-ignore` allowlist file for acknowledged CVEs
- Adds `pip-audit>=2.7.0` to `[project.optional-dependencies] dev` in `pyproject.toml`

## Test plan

- [ ] CI runs pip-audit step on PRs targeting main
- [ ] CI fails if new unfixed vulnerabilities are found in requirements.txt
- [ ] `.pip-audit-ignore` entries suppress known/acknowledged CVEs
- [ ] Scheduled weekly scan workflow appears in Actions tab
- [ ] Artifact `pip-audit-report.md` is uploaded after each scan

Closes CHAOS-661