### PR TITLE
audit: convert to multi-stage Docker build, use python:3.12-slim (CHAOS-682)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,38 +1,63 @@
-FROM python:3.14-slim AS base
+# ── Stage 1: builder ──────────────────────────────────────────────────────────
+# Install build dependencies and compile wheels. This stage is NOT shipped.
+FROM python:3.12-slim AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-  PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1
 
 WORKDIR /build
 
-COPY . .
-RUN apt update && apt install -y build-essential git wget
+# Install build-time system deps (gcc, build-essential, git for setuptools-scm)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    git \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
 
+# Receive the pretend version so setuptools-scm can produce a version string
+# in environments without a git history (e.g. Docker build in CI).
 ARG SETUPTOOLS_SCM_PRETEND_VERSION
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
 
-RUN pip install --no-cache-dir .
-RUN rm -rf /build
+COPY . .
 
-WORKDIR /app
-RUN mkdir -p /app
-# Ensure config files are available if needed
-# COPY --from=base /usr/local/lib/python3.14/site-packages/dev_health_ops/config /app/config
+# Build and install into a prefix that we can copy into the runtime image
+RUN pip install --no-cache-dir --prefix=/install .
+
+
+# ── Stage 2: runtime ──────────────────────────────────────────────────────────
+# Minimal image — no build tools, only the installed package and its runtime deps.
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Copy installed packages from builder (no build tools follow)
+COPY --from=builder /install /usr/local
 
 RUN useradd --create-home --shell /bin/bash appuser
+
+WORKDIR /app
+
 USER appuser
 
-FROM base AS api
+
+# ── API target ────────────────────────────────────────────────────────────────
+FROM runtime AS api
+
 EXPOSE 8000
 
 # Readiness probe — fast check, no external dependency validation
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
-  CMD wget --spider -q http://localhost:8000/ready || exit 1
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/ready')" || exit 1
 
 ENTRYPOINT ["dev-hops", "api"]
 CMD ["--host", "0.0.0.0", "--port", "8000"]
 
 
-FROM base AS runner
+# ── Generic runner target ──────────────────────────────────────────────────────
+FROM runtime AS runner
+
 ENTRYPOINT ["dev-hops"]
 CMD ["--help"]


### PR DESCRIPTION
## Summary

- Converts `docker/Dockerfile` to a proper two-stage build:
  - **Stage 1 (builder)**: installs `build-essential`, `gcc`, `git`, `wget`; compiles and installs the package into `/install` prefix
  - **Stage 2 (runtime)**: starts from a clean `python:3.12-slim`; copies only the `/install` prefix from builder — **no build tools in the final image**
- Changes base image from `python:3.14-slim` (unreleased) to `python:3.12-slim` (current stable LTS)
- Preserves `api` and `runner` final targets
- Replaces `wget` health-check with a pure-Python `urllib.request` check (wget no longer available in runtime image)

## Benefits

- **Reduced attack surface**: gcc, build-essential, git, wget are not present in production containers
- **Smaller image size**: runtime image only contains the installed Python packages and runtime
- **Stable base**: python:3.12-slim instead of unreleased 3.14

## Test plan

- [ ] `docker build --target api -t dev-health-ops:api docker/` succeeds
- [ ] `docker build --target runner -t dev-health-ops:runner docker/` succeeds  
- [ ] `docker run dev-health-ops:api --version` works
- [ ] `gcc` and `build-essential` are absent from the runtime image: `docker run dev-health-ops:api which gcc` returns non-zero

Closes CHAOS-682