### PR TITLE
audit: ruff hard CI gate, delete .flake8 (CHAOS-653)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,0 @@
-[flake8]
-max-line-length = 100
-exclude = .git,.venv,venv,__pycache__,docs,build,dist
-ignore = E203, E501, W503
-per-file-ignores =
-    __init__.py: F401

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,6 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run ruff (format check)
-        continue-on-error: true
         run: |
           ruff format --check .
 

--- a/tests/test_token_pool.py
+++ b/tests/test_token_pool.py
@@ -38,7 +38,9 @@ def _fakeredis_supports_lua() -> bool:
 
 
 _HAS_LUA = _fakeredis_supports_lua()
-requires_lua = pytest.mark.skipif(not _HAS_LUA, reason="fakeredis Lua scripting unavailable")
+requires_lua = pytest.mark.skipif(
+    not _HAS_LUA, reason="fakeredis Lua scripting unavailable"
+)
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- Delete `.flake8` (superseded by `[tool.ruff]` in `pyproject.toml`)
- Make `ruff format --check` a hard CI gate by removing `continue-on-error: true` from `lint.yml`
- Fix formatting in `tests/test_token_pool.py` so the hard gate passes
- `ruff check` and `ruff format --check` both pass clean on full codebase (553 files)

## Linear Issue
CHAOS-653

## Test plan
- [x] `ruff check .` passes — All checks passed!
- [x] `ruff format --check .` passes — 553 files already formatted
- [x] `.flake8` deleted, no duplicate lint config
- [x] CI lint gate no longer has `continue-on-error` for format check

## SCREENSHOT-WAIVER
No frontend impact — CI configuration and formatting only.