### PR TITLE
fix(docker): install git in runtime stage for GitPython (CHAOS-682)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,10 @@ FROM python:3.12-slim AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
+# GitPython requires the git binary at runtime
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy installed packages from builder (no build tools follow)
 COPY --from=builder /install /usr/local
 


### PR DESCRIPTION
## Summary

- Adds `git` to the Docker runtime stage (`python:3.12-slim`). The multi-stage build (introduced in CHAOS-682) only installed `git` in the builder stage for `setuptools-scm`, but `GitPython` requires the `git` binary at runtime.
- Without this fix, the API container crashes on startup with `ImportError: Bad git executable`.

## Changes

- `docker/Dockerfile`: Added `RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*` to the runtime stage.

## Verification

- Rebuilt the API container and confirmed it starts successfully with uvicorn serving on port 8000.
- No `ImportError` in container logs.

SCREENSHOT-WAIVER: Backend-only Docker change, no rendered frontend output.