### PR TITLE
fix(docker): add wget to runtime stage for healthcheck probes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,8 +33,8 @@ FROM python:3.12-slim AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-# GitPython requires the git binary at runtime
-RUN apt-get update && apt-get install -y --no-install-recommends git \
+# GitPython requires git; wget used by Docker/compose healthchecks
+RUN apt-get update && apt-get install -y --no-install-recommends git wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy installed packages from builder (no build tools follow)


### PR DESCRIPTION
## Summary

- Adds `wget` to the Docker runtime stage alongside `git`. The compose.yml healthcheck uses `wget --spider` to probe `/health`, but `wget` was missing from `python:3.12-slim` after the multi-stage build conversion.
- Without this, the container reports `unhealthy` despite the API running fine.

## Changes

- `docker/Dockerfile`: Added `wget` to the existing runtime `apt-get install` line.

SCREENSHOT-WAIVER: Backend-only Docker change, no rendered frontend output.