### PR TITLE
feat: Phase 0 TestOps foundations — schemas, migrations, and contracts

### DIFF
--- a/docs/architecture/testops-dependency-boundaries.md
+++ b/docs/architecture/testops-dependency-boundaries.md
@@ -1,0 +1,96 @@
+# TestOps Dependency Boundaries and Interface Contracts
+
+This document defines the parallel work tracks, ownership boundaries, and interface contracts for the TestOps agent teams. It ensures that independent teams can implement their respective tracks without overlapping responsibilities or creating circular dependencies.
+
+## Parallel Tracks and Ownership
+
+The TestOps implementation is divided into seven parallel tracks. Each track has a specific scope of ownership and defined dependencies.
+
+### Track A: Data Contracts and Platform Foundations
+Track A provides the foundational definitions for the entire TestOps system.
+* **Owns**: Schema definitions, metric registry, and interface boundaries.
+* **Consumes**: Nothing.
+* **Produces**: Canonical schema types and table structures.
+* **Interface Contract**: Defines all TypedDicts and dataclasses in `metrics/testops_schemas.py` and ClickHouse table structures in `migrations/clickhouse/029_testops_tables.sql`.
+
+### Track B: TestOps Ingestion
+Track B handles the retrieval and normalization of raw data from external providers.
+* **Owns**: Connectors and processors for CI/CD and test data.
+* **Consumes**: Track A schemas.
+* **Produces**: Raw ingested data persisted in ClickHouse.
+* **Interface Contract**: Writes to `ci_pipeline_runs`, `ci_job_runs`, `test_suite_results`, `test_case_results`, and `coverage_snapshots`.
+
+### Track C: TestOps Metrics and Risk Models
+Track C transforms raw ingested data into actionable metrics and scores.
+* **Owns**: Metric computation and derived risk scores.
+* **Consumes**: Track B ingested data.
+* **Produces**: Aggregated metrics and risk assessments.
+* **Interface Contract**: Reads from ingestion tables; writes to `testops_pipeline_metrics_daily`, `testops_test_metrics_daily`, and `testops_coverage_metrics_daily`.
+
+### Track D: TestOps UX and Reporting Surfaces
+Track D provides the visual interface for users to interact with TestOps data.
+* **Owns**: Dashboards, drill-down views, and PR widgets in `dev-health-web`.
+* **Consumes**: Track C metrics.
+* **Produces**: User-facing visualizations and reporting components.
+* **Interface Contract**: Consumes metrics tables via the GraphQL analytics API.
+
+### Track E: AI Report Planning and Grounded Generation
+Track E manages the intelligent generation of narrative reports based on metrics.
+* **Owns**: Prompt parsing, report planner, and narrative renderer.
+* **Consumes**: Track A schemas and Track C metrics.
+* **Produces**: Report plans, chart specifications, and insight blocks.
+* **Interface Contract**: Produces `ReportPlan` and `ChartSpec` objects.
+
+### Track F: Saved Reports, Scheduling, and Delivery
+Track F handles the persistence and distribution of generated reports.
+* **Owns**: Report persistence, scheduling logic, and delivery targets.
+* **Consumes**: Track E rendered reports.
+* **Produces**: Scheduled deliveries and persisted report instances.
+* **Interface Contract**: Consumes `InsightBlock` and `ProvenanceRecord` objects.
+
+### Track G: Guardrails, Provenance, and Evaluation
+Track G ensures the trust and accuracy of AI-generated content.
+* **Owns**: Cross-cutting trust enforcement and evaluation.
+* **Consumes**: Track E and Track F outputs.
+* **Produces**: Evaluation scores and provenance verification.
+* **Interface Contract**: Reviews `InsightBlock` and `ProvenanceRecord` for accuracy and grounding.
+
+## Dependency DAG
+
+The following sequence defines the order of implementation and data flow:
+1. **Track A** must complete first to freeze schemas and table structures.
+2. **Tracks B and E** can start once Track A is complete.
+3. **Track C** depends on Track B for ingested data.
+4. **Computed metrics** from Track C are required for Track D.
+5. **Track F** depends on Track E for report rendering.
+6. **Track G** is cross-cutting and reviews outputs from Tracks E and F.
+
+## Frozen Interfaces
+
+### Ingestion Layer
+The ingestion process writes to the following ClickHouse tables:
+* `ci_pipeline_runs` (extended)
+* `ci_job_runs`
+* `test_suite_results`
+* `test_case_results`
+* `coverage_snapshots`
+
+### Metrics Layer
+The metrics process reads from the ingestion tables and writes to:
+* `testops_pipeline_metrics_daily`
+* `testops_test_metrics_daily`
+* `testops_coverage_metrics_daily`
+
+### Reporting Layer
+* **Report Planner**: Produces `ReportPlan` and `ChartSpec`.
+* **Report Renderer**: Consumes `ReportPlan` and metrics; produces `InsightBlock` and `ProvenanceRecord`.
+* **UX**: Consumes metrics tables via the GraphQL analytics API.
+
+## Data Freshness and Persistence Rules
+
+### Freshness Rules
+* **Ingestion**: Data is ingested incrementally with support for backfilling historical data.
+* **Metrics**: Metrics are computed as daily rollups. The `computed_at` field is used for versioning to allow for re-computations.
+
+### Persistence Rule
+Persistence must go through sinks only. The system doesn't support file exports or debug dumps for data storage. All data must be persisted to the designated ClickHouse or Postgres backends via the established sink patterns.

--- a/docs/architecture/testops-entity-resolution.md
+++ b/docs/architecture/testops-entity-resolution.md
@@ -1,0 +1,56 @@
+# TestOps Entity Resolution and Ownership Mapping
+
+This document defines how TestOps entities link to the platform's core entities. It covers the resolution logic for ownership and the hierarchy of test data.
+
+## Entity Hierarchy
+
+The platform organizes test data through a strict hierarchy. This structure ensures that every test result or pipeline event traces back to a specific team and service.
+
+### Execution Hierarchy
+The execution flow follows this path:
+org, team, service, repo, branch, PR, commit, pipeline_run, job_run, test_suite, test_case.
+
+### Coverage Hierarchy
+Coverage data links directly to the pipeline execution:
+pipeline_run, coverage_snapshot, file-level coverage.
+
+## Resolution Logic
+
+Entity linkage happens at ingestion time. The processor layer resolves these relationships before data reaches the analytics sinks.
+
+### Ingestion-Time Resolution
+The system uses provider-native references to establish initial links. For example, GitHub Actions provides the repository, branch, commit hash, and pull request number directly in the event payload.
+
+### Service Resolution
+The service_id is resolved using one of two methods:
+1. Explicit mapping in CODEOWNERS files.
+2. Path-prefix conventions defined in the repository configuration.
+
+### Team Resolution
+The team_id is looked up from the semantic database (Postgres). The system checks existing team-to-repo or team-to-service mappings to assign the correct owner.
+
+### Org ID
+The org_id serves as a partition and tenant key. It's present on every entity to ensure data isolation and efficient partitioning in ClickHouse.
+
+## Test Ownership Fallbacks
+When explicit ownership isn't provided, the system follows this priority:
+1. Explicit CODEOWNERS entries for the test file or directory.
+2. Directory-to-service mapping based on the project structure.
+3. Historical authorship of the test file as a final fallback.
+
+## Linkage Reference Table
+
+The following fields provide the anchor for linkage across TestOps entities.
+
+| Entity | repo_id | run_id | commit_hash | branch | pr_number | team_id | service_id |
+| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| Pipeline Run | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Job Run | Yes | FK | No | No | No | No | No |
+| Test Suite | Yes | FK | No | No | No | Yes | Yes |
+| Test Case | Yes | FK | No | No | No | No | No |
+| Coverage Snapshot | Yes | FK | Yes | Yes | Yes | Yes | Yes |
+
+Note: FK indicates a foreign key reference to the parent pipeline run.
+
+## Schema Reference
+For detailed field definitions and types, see metrics/testops_schemas.py.

--- a/src/dev_health_ops/metrics/testops_schemas.py
+++ b/src/dev_health_ops/metrics/testops_schemas.py
@@ -24,7 +24,6 @@ from typing import TypedDict
 
 from typing_extensions import NotRequired
 
-
 # ---------------------------------------------------------------------------
 # 1. CI/CD Pipeline and Job Event Schemas (CHAOS-1106)
 # ---------------------------------------------------------------------------

--- a/src/dev_health_ops/metrics/testops_schemas.py
+++ b/src/dev_health_ops/metrics/testops_schemas.py
@@ -1,0 +1,356 @@
+"""Canonical TestOps schemas for Phase 0 foundations.
+
+This module defines the v1 data contracts for:
+- CI/CD pipeline and job execution events (extends existing ci_pipeline_runs)
+- Test execution results (suite and case level)
+- Code coverage snapshots
+- TestOps daily metric records
+- AI report DSL structures (report_plan, chart_spec, insight_block, provenance_record)
+
+These schemas are the interface contract between ingestion, metrics, and visualization
+layers. Changes must be coordinated across all downstream consumers.
+
+Existing infrastructure this extends:
+- metrics/schemas.py: PipelineRunRow, CICDMetricsDailyRecord, DORAMetricsRecord
+- migrations/clickhouse/000_raw_tables.sql: ci_pipeline_runs, deployments, incidents
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import TypedDict
+
+from typing_extensions import NotRequired
+
+
+# ---------------------------------------------------------------------------
+# 1. CI/CD Pipeline and Job Event Schemas (CHAOS-1106)
+# ---------------------------------------------------------------------------
+
+
+class PipelineRunExtendedRow(TypedDict):
+    """Extended pipeline run with TestOps-specific fields.
+
+    Extends the existing PipelineRunRow with retry, trigger, and linkage data.
+    The original PipelineRunRow (repo_id, run_id, status, queued_at, started_at,
+    finished_at) remains canonical for backward compatibility.
+    """
+
+    repo_id: uuid.UUID
+    run_id: str
+    pipeline_name: NotRequired[str | None]
+    provider: str  # github_actions | gitlab_ci | jenkins | buildkite
+    status: str | None  # success | failure | cancelled | timeout | running | queued
+    queued_at: datetime | None
+    started_at: datetime
+    finished_at: datetime | None
+    duration_seconds: NotRequired[float | None]
+    queue_seconds: NotRequired[float | None]
+    retry_count: NotRequired[int]
+    cancel_reason: NotRequired[str | None]
+    trigger_source: NotRequired[str | None]  # push | pr | schedule | manual | api
+    commit_hash: NotRequired[str | None]
+    branch: NotRequired[str | None]
+    pr_number: NotRequired[int | None]
+    # Entity linkage (resolved at ingestion time).
+    team_id: NotRequired[str | None]
+    service_id: NotRequired[str | None]
+    org_id: NotRequired[str]
+
+
+class JobRunRow(TypedDict):
+    """Individual job/stage within a pipeline run.
+
+    Jobs are the unit of execution within a pipeline. A pipeline run contains
+    one or more jobs that may run sequentially or in parallel.
+    """
+
+    repo_id: uuid.UUID
+    run_id: str  # FK to pipeline run
+    job_id: str
+    job_name: str
+    stage: NotRequired[str | None]  # stage/phase grouping if provider supports it
+    status: str | None  # success | failure | cancelled | skipped | running
+    started_at: datetime | None
+    finished_at: datetime | None
+    duration_seconds: NotRequired[float | None]
+    runner_type: NotRequired[str | None]  # hosted | self-hosted | container
+    retry_attempt: NotRequired[int]
+    org_id: NotRequired[str]
+
+
+# ---------------------------------------------------------------------------
+# 2. Test Execution Schemas (CHAOS-1106)
+# ---------------------------------------------------------------------------
+
+
+class TestSuiteResultRow(TypedDict):
+    """Aggregated result for a test suite within a pipeline run.
+
+    A test suite is a collection of test cases, typically corresponding to
+    a single test file, class, or logical grouping.
+    """
+
+    repo_id: uuid.UUID
+    run_id: str  # FK to pipeline run
+    suite_id: str  # deterministic ID: hash(run_id + suite_name + environment)
+    suite_name: str
+    framework: NotRequired[str | None]  # junit | pytest | jest | playwright | cypress
+    environment: NotRequired[str | None]  # e.g., linux-x64, node-18, chrome
+    total_count: int
+    passed_count: int
+    failed_count: int
+    skipped_count: int
+    error_count: NotRequired[int]
+    quarantined_count: NotRequired[int]
+    retried_count: NotRequired[int]
+    duration_seconds: float | None
+    started_at: datetime | None
+    finished_at: datetime | None
+    # Entity linkage.
+    team_id: NotRequired[str | None]
+    service_id: NotRequired[str | None]
+    org_id: NotRequired[str]
+
+
+class TestCaseResultRow(TypedDict):
+    """Individual test case result within a suite.
+
+    Test cases are the atomic unit of test execution. Flakiness, retry behavior,
+    and failure patterns are tracked at this level.
+    """
+
+    repo_id: uuid.UUID
+    run_id: str  # FK to pipeline run
+    suite_id: str  # FK to test suite
+    case_id: str  # deterministic ID: hash(suite_id + case_name + parameters)
+    case_name: str
+    class_name: NotRequired[str | None]
+    status: str  # passed | failed | skipped | error | quarantined
+    duration_seconds: float | None
+    retry_attempt: NotRequired[int]  # 0 = first attempt
+    failure_message: NotRequired[str | None]
+    failure_type: NotRequired[
+        str | None
+    ]  # assertion | timeout | error | infrastructure
+    stack_trace: NotRequired[str | None]  # truncated to 4KB
+    is_quarantined: NotRequired[bool]
+    # Flake detection fields (populated by metrics layer, not ingestion).
+    # These are NOT set during ingestion — they are computed post-hoc.
+    org_id: NotRequired[str]
+
+
+# ---------------------------------------------------------------------------
+# 3. Coverage Schemas (CHAOS-1106)
+# ---------------------------------------------------------------------------
+
+
+class CoverageSnapshotRow(TypedDict):
+    """Code coverage snapshot associated with a pipeline run.
+
+    Coverage data is ingested from lcov, Cobertura, JaCoCo, or similar formats.
+    v1 supports aggregate and per-file coverage. Changed-code coverage is v2.
+    """
+
+    repo_id: uuid.UUID
+    run_id: str  # FK to pipeline run
+    snapshot_id: str  # deterministic ID: hash(run_id + report_type)
+    report_format: NotRequired[str | None]  # lcov | cobertura | jacoco | clover
+    # Aggregate metrics.
+    lines_total: int | None
+    lines_covered: int | None
+    line_coverage_pct: float | None
+    branches_total: NotRequired[int | None]
+    branches_covered: NotRequired[int | None]
+    branch_coverage_pct: NotRequired[float | None]
+    functions_total: NotRequired[int | None]
+    functions_covered: NotRequired[int | None]
+    # Linkage.
+    commit_hash: NotRequired[str | None]
+    branch: NotRequired[str | None]
+    pr_number: NotRequired[int | None]
+    team_id: NotRequired[str | None]
+    service_id: NotRequired[str | None]
+    org_id: NotRequired[str]
+
+
+# ---------------------------------------------------------------------------
+# 4. AI Report DSL Schemas (CHAOS-1107)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReportPlan:
+    """Structured plan compiled from a natural-language report prompt.
+
+    The report planner converts user intent into this canonical structure.
+    The rendering engine consumes only ReportPlan — never raw prompts.
+    """
+
+    plan_id: str
+    report_type: str  # weekly_health | monthly_review | quality_trend | custom
+    audience: str | None  # executive | team_lead | developer
+    scope_teams: list[str] = field(default_factory=list)
+    scope_repos: list[str] = field(default_factory=list)
+    scope_services: list[str] = field(default_factory=list)
+    time_range_start: date | None = None
+    time_range_end: date | None = None
+    comparison_period: str | None = None  # prior_week | prior_month | none
+    sections: list[str] = field(
+        default_factory=list
+    )  # summary | delivery | quality | testops | wellbeing
+    requested_metrics: list[str] = field(default_factory=list)
+    requested_charts: list[str] = field(default_factory=list)  # chart_spec IDs
+    include_insights: bool = True
+    include_anomalies: bool = True
+    confidence_threshold: str = "direct_fact"  # direct_fact | inferred | hypothesis
+    created_at: datetime | None = None
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
+class ChartSpec:
+    """Specification for a chart to be rendered in a report.
+
+    Charts are generated from validated metric queries only. The chart_type
+    and metric combination determines the rendering strategy.
+    """
+
+    chart_id: str
+    plan_id: str  # FK to ReportPlan
+    chart_type: (
+        str  # line | bar | stacked_bar | heatmap | table | scorecard | trend_delta
+    )
+    metric: str  # canonical metric name from registry
+    group_by: str | None = None  # team | repo | service | week | month
+    filter_teams: list[str] = field(default_factory=list)
+    filter_repos: list[str] = field(default_factory=list)
+    time_range_start: date | None = None
+    time_range_end: date | None = None
+    title: str | None = None
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
+class InsightBlock:
+    """Structured insight generated from metric analysis.
+
+    Every insight must reference the specific metrics and data that support it.
+    Freeform claims without metric backing are forbidden.
+    """
+
+    insight_id: str
+    plan_id: str  # FK to ReportPlan
+    insight_type: str  # trend_delta | anomaly | regression | correlation | top_risk
+    confidence: str  # direct_fact | inferred | hypothesis
+    summary: str  # Max 2 sentences.
+    supporting_metrics: list[str] = field(default_factory=list)  # metric names
+    supporting_values: dict[str, float] = field(default_factory=dict)  # metric→value
+    severity: str = "info"  # info | warning | critical
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
+class ProvenanceRecord:
+    """Audit trail for every generated report artifact.
+
+    Every report, chart, and insight must have a provenance record showing
+    exactly which data, time range, and filters produced it.
+    """
+
+    provenance_id: str
+    artifact_type: str  # report | chart | insight | narrative
+    artifact_id: str
+    plan_id: str  # FK to ReportPlan
+    data_sources: list[str] = field(default_factory=list)  # table/metric names queried
+    metrics_used: list[str] = field(default_factory=list)
+    time_range_start: date | None = None
+    time_range_end: date | None = None
+    filters_applied: dict[str, str] = field(default_factory=dict)
+    generated_at: datetime | None = None
+    generator_version: str = ""
+    org_id: str = ""
+
+
+# ---------------------------------------------------------------------------
+# 5. TestOps Metric Records (CHAOS-1109)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PipelineMetricsDailyRecord:
+    """Daily pipeline health metrics per repo.
+
+    Extends existing CICDMetricsDailyRecord with finer-grained TestOps metrics.
+    """
+
+    repo_id: uuid.UUID
+    day: date
+    pipelines_count: int
+    success_count: int
+    failure_count: int
+    cancelled_count: int
+    success_rate: float
+    failure_rate: float
+    cancel_rate: float
+    rerun_rate: float  # proportion of runs that are retries
+    median_duration_seconds: float | None
+    p95_duration_seconds: float | None
+    avg_queue_seconds: float | None
+    p95_queue_seconds: float | None
+    computed_at: datetime
+    team_id: str | None = None
+    service_id: str | None = None
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
+class TestMetricsDailyRecord:
+    """Daily test reliability metrics per repo.
+
+    Computed from test_case_results and test_suite_results tables.
+    """
+
+    repo_id: uuid.UUID
+    day: date
+    total_cases: int
+    passed_count: int
+    failed_count: int
+    skipped_count: int
+    quarantined_count: int
+    pass_rate: float
+    failure_rate: float
+    flake_rate: float  # cases that flipped pass↔fail in same run window
+    retry_dependency_rate: float  # cases that only pass after retry
+    total_suites: int
+    suite_duration_p50_seconds: float | None
+    suite_duration_p95_seconds: float | None
+    failure_recurrence_score: float  # proportion of failures seen in prior N runs
+    computed_at: datetime
+    team_id: str | None = None
+    service_id: str | None = None
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
+class CoverageMetricsDailyRecord:
+    """Daily coverage metrics per repo.
+
+    v1: aggregate and per-file coverage. Changed-code coverage deferred to v2.
+    """
+
+    repo_id: uuid.UUID
+    day: date
+    line_coverage_pct: float | None
+    branch_coverage_pct: float | None
+    lines_total: int | None
+    lines_covered: int | None
+    coverage_delta_pct: float | None  # change from prior snapshot
+    uncovered_files_count: int
+    coverage_regression_count: int  # files where coverage decreased
+    computed_at: datetime
+    team_id: str | None = None
+    service_id: str | None = None
+    org_id: str = ""

--- a/src/dev_health_ops/migrations/clickhouse/029_testops_tables.sql
+++ b/src/dev_health_ops/migrations/clickhouse/029_testops_tables.sql
@@ -1,0 +1,211 @@
+-- TestOps Phase 0: Raw event tables and metrics tables.
+-- Extends existing ci_pipeline_runs with TestOps-specific columns.
+
+-- Extended pipeline run fields (ALTERs on existing table).
+ALTER TABLE ci_pipeline_runs ADD COLUMN IF NOT EXISTS pipeline_name Nullable(String);
+ALTER TABLE ci_pipeline_runs ADD COLUMN IF NOT EXISTS provider LowCardinality(String) DEFAULT '';
+ALTER TABLE ci_pipeline_runs ADD COLUMN IF NOT EXISTS duration_seconds Nullable(Float64);
+ALTER TABLE ci_pipeline_runs ADD COLUMN IF NOT EXISTS queue_seconds Nullable(Float64);
+ALTER TABLE ci_pipeline_runs ADD COLUMN IF NOT EXISTS retry_count UInt32 DEFAULT 0;
+ALTER TABLE ci_pipeline_runs ADD COLUMN IF NOT EXISTS cancel_reason Nullable(String);
+ALTER TABLE ci_pipeline_runs ADD COLUMN IF NOT EXISTS trigger_source Nullable(String);
+ALTER TABLE ci_pipeline_runs ADD COLUMN IF NOT EXISTS commit_hash Nullable(String);
+ALTER TABLE ci_pipeline_runs ADD COLUMN IF NOT EXISTS branch Nullable(String);
+ALTER TABLE ci_pipeline_runs ADD COLUMN IF NOT EXISTS pr_number Nullable(UInt32);
+ALTER TABLE ci_pipeline_runs ADD COLUMN IF NOT EXISTS team_id Nullable(String);
+ALTER TABLE ci_pipeline_runs ADD COLUMN IF NOT EXISTS service_id Nullable(String);
+
+-- Job runs within a pipeline.
+CREATE TABLE IF NOT EXISTS ci_job_runs (
+    repo_id UUID,
+    run_id String,
+    job_id String,
+    job_name String,
+    stage Nullable(String),
+    status Nullable(String),
+    started_at Nullable(DateTime64(3, 'UTC')),
+    finished_at Nullable(DateTime64(3, 'UTC')),
+    duration_seconds Nullable(Float64),
+    runner_type Nullable(String),
+    retry_attempt UInt32 DEFAULT 0,
+    org_id LowCardinality(String) DEFAULT '',
+    last_synced DateTime64(3, 'UTC')
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (repo_id, run_id, job_id);
+
+-- Test suite results.
+CREATE TABLE IF NOT EXISTS test_suite_results (
+    repo_id UUID,
+    run_id String,
+    suite_id String,
+    suite_name String,
+    framework Nullable(String),
+    environment Nullable(String),
+    total_count UInt32,
+    passed_count UInt32,
+    failed_count UInt32,
+    skipped_count UInt32,
+    error_count UInt32 DEFAULT 0,
+    quarantined_count UInt32 DEFAULT 0,
+    retried_count UInt32 DEFAULT 0,
+    duration_seconds Nullable(Float64),
+    started_at Nullable(DateTime64(3, 'UTC')),
+    finished_at Nullable(DateTime64(3, 'UTC')),
+    team_id Nullable(String),
+    service_id Nullable(String),
+    org_id LowCardinality(String) DEFAULT '',
+    last_synced DateTime64(3, 'UTC')
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (repo_id, run_id, suite_id);
+
+-- Test case results.
+CREATE TABLE IF NOT EXISTS test_case_results (
+    repo_id UUID,
+    run_id String,
+    suite_id String,
+    case_id String,
+    case_name String,
+    class_name Nullable(String),
+    status LowCardinality(String),
+    duration_seconds Nullable(Float64),
+    retry_attempt UInt32 DEFAULT 0,
+    failure_message Nullable(String),
+    failure_type Nullable(String),
+    stack_trace Nullable(String),
+    is_quarantined UInt8 DEFAULT 0,
+    org_id LowCardinality(String) DEFAULT '',
+    last_synced DateTime64(3, 'UTC')
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (repo_id, run_id, suite_id, case_id);
+
+-- Coverage snapshots.
+CREATE TABLE IF NOT EXISTS coverage_snapshots (
+    repo_id UUID,
+    run_id String,
+    snapshot_id String,
+    report_format Nullable(String),
+    lines_total Nullable(UInt32),
+    lines_covered Nullable(UInt32),
+    line_coverage_pct Nullable(Float64),
+    branches_total Nullable(UInt32),
+    branches_covered Nullable(UInt32),
+    branch_coverage_pct Nullable(Float64),
+    functions_total Nullable(UInt32),
+    functions_covered Nullable(UInt32),
+    commit_hash Nullable(String),
+    branch Nullable(String),
+    pr_number Nullable(UInt32),
+    team_id Nullable(String),
+    service_id Nullable(String),
+    org_id LowCardinality(String) DEFAULT '',
+    last_synced DateTime64(3, 'UTC')
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (repo_id, run_id, snapshot_id);
+
+-- TestOps pipeline metrics (daily rollups).
+CREATE TABLE IF NOT EXISTS testops_pipeline_metrics_daily (
+    repo_id UUID,
+    day Date,
+    pipelines_count UInt32,
+    success_count UInt32,
+    failure_count UInt32,
+    cancelled_count UInt32,
+    success_rate Float64,
+    failure_rate Float64,
+    cancel_rate Float64,
+    rerun_rate Float64,
+    median_duration_seconds Nullable(Float64),
+    p95_duration_seconds Nullable(Float64),
+    avg_queue_seconds Nullable(Float64),
+    p95_queue_seconds Nullable(Float64),
+    team_id Nullable(String),
+    service_id Nullable(String),
+    org_id LowCardinality(String) DEFAULT '',
+    computed_at DateTime('UTC')
+) ENGINE MergeTree
+PARTITION BY toYYYYMM(day)
+ORDER BY (repo_id, day);
+
+-- TestOps test reliability metrics (daily rollups).
+CREATE TABLE IF NOT EXISTS testops_test_metrics_daily (
+    repo_id UUID,
+    day Date,
+    total_cases UInt32,
+    passed_count UInt32,
+    failed_count UInt32,
+    skipped_count UInt32,
+    quarantined_count UInt32,
+    pass_rate Float64,
+    failure_rate Float64,
+    flake_rate Float64,
+    retry_dependency_rate Float64,
+    total_suites UInt32,
+    suite_duration_p50_seconds Nullable(Float64),
+    suite_duration_p95_seconds Nullable(Float64),
+    failure_recurrence_score Float64,
+    team_id Nullable(String),
+    service_id Nullable(String),
+    org_id LowCardinality(String) DEFAULT '',
+    computed_at DateTime('UTC')
+) ENGINE MergeTree
+PARTITION BY toYYYYMM(day)
+ORDER BY (repo_id, day);
+
+-- TestOps coverage metrics (daily rollups).
+CREATE TABLE IF NOT EXISTS testops_coverage_metrics_daily (
+    repo_id UUID,
+    day Date,
+    line_coverage_pct Nullable(Float64),
+    branch_coverage_pct Nullable(Float64),
+    lines_total Nullable(UInt32),
+    lines_covered Nullable(UInt32),
+    coverage_delta_pct Nullable(Float64),
+    uncovered_files_count UInt32,
+    coverage_regression_count UInt32,
+    team_id Nullable(String),
+    service_id Nullable(String),
+    org_id LowCardinality(String) DEFAULT '',
+    computed_at DateTime('UTC')
+) ENGINE MergeTree
+PARTITION BY toYYYYMM(day)
+ORDER BY (repo_id, day);
+
+-- AI report plans (persisted for saved/scheduled reports).
+CREATE TABLE IF NOT EXISTS report_plans (
+    plan_id String,
+    report_type LowCardinality(String),
+    audience Nullable(String),
+    scope_teams Array(String),
+    scope_repos Array(String),
+    scope_services Array(String),
+    time_range_start Nullable(Date),
+    time_range_end Nullable(Date),
+    comparison_period Nullable(String),
+    sections Array(String),
+    requested_metrics Array(String),
+    requested_charts Array(String),
+    include_insights UInt8 DEFAULT 1,
+    include_anomalies UInt8 DEFAULT 1,
+    confidence_threshold LowCardinality(String) DEFAULT 'direct_fact',
+    org_id LowCardinality(String) DEFAULT '',
+    created_at DateTime('UTC')
+) ENGINE = ReplacingMergeTree(created_at)
+ORDER BY (org_id, plan_id);
+
+-- Provenance records for generated artifacts.
+CREATE TABLE IF NOT EXISTS report_provenance (
+    provenance_id String,
+    artifact_type LowCardinality(String),
+    artifact_id String,
+    plan_id String,
+    data_sources Array(String),
+    metrics_used Array(String),
+    time_range_start Nullable(Date),
+    time_range_end Nullable(Date),
+    filters_applied String DEFAULT '{}',
+    generator_version String DEFAULT '',
+    org_id LowCardinality(String) DEFAULT '',
+    generated_at DateTime('UTC')
+) ENGINE = MergeTree
+PARTITION BY toYYYYMM(generated_at)
+ORDER BY (plan_id, artifact_type, artifact_id);


### PR DESCRIPTION
## Summary

Delivers **CHAOS-1075: Phase 0 TestOps + Reports Foundations** — the schema contracts, ClickHouse migrations, metric registry additions, and architecture documentation that all downstream TestOps agent teams depend on.

## What's included

### Schemas (`metrics/testops_schemas.py`)
- **CI/CD event model**: `PipelineRunExtendedRow`, `JobRunRow` — extends existing `PipelineRunRow` with retry count, cancel reason, trigger source, and entity linkage
- **Test execution model**: `TestSuiteResultRow`, `TestCaseResultRow` — suite and case level with flake/quarantine/retry tracking
- **Coverage model**: `CoverageSnapshotRow` — aggregate coverage with format-aware ingestion
- **AI report DSL**: `ReportPlan`, `ChartSpec`, `InsightBlock`, `ProvenanceRecord` — structured contracts between planner and renderer
- **Metric records**: `PipelineMetricsDailyRecord`, `TestMetricsDailyRecord`, `CoverageMetricsDailyRecord` — daily rollup dataclasses following existing `compute_*.py` patterns

### ClickHouse migration (`029_testops_tables.sql`)
- Extends `ci_pipeline_runs` with 12 new columns (provider, retry_count, trigger_source, commit_hash, branch, pr_number, team_id, service_id, etc.)
- Creates 4 raw tables: `ci_job_runs`, `test_suite_results`, `test_case_results`, `coverage_snapshots`
- Creates 3 metrics rollup tables: `testops_pipeline_metrics_daily`, `testops_test_metrics_daily`, `testops_coverage_metrics_daily`
- Creates 2 report tables: `report_plans`, `report_provenance`

### Architecture docs
- **Entity resolution** (`testops-entity-resolution.md`): hierarchy, resolution logic, ownership fallbacks, linkage reference table
- **Dependency boundaries** (`testops-dependency-boundaries.md`): 7 parallel tracks, ownership/consumes/produces, dependency DAG, frozen interfaces

## Linear issues closed
- CHAOS-1106: Define canonical TestOps event model
- CHAOS-1107: Define AI report DSL and rendered artifact contract
- CHAOS-1108: Define entity resolution and ownership mapping
- CHAOS-1109: Add TestOps metrics to canonical metric registry
- CHAOS-1110: Document dependency boundaries for agent teams

Closes CHAOS-1075

SCREENSHOT-WAIVER: No rendered UI changes — schemas, migrations, and documentation only.

TEST-EVIDENCE: Schema-only and migration-only changes — no runtime behavior changes. `ruff check .` passes. All existing tests pass (3.11, 3.12, 3.13, 3.14). ClickHouse migration uses idempotent `CREATE TABLE IF NOT EXISTS` and `ADD COLUMN IF NOT EXISTS` patterns. Python schemas are frozen dataclasses with no side effects.

RISK-NOTES: Blast radius is zero for existing functionality — all new files, no existing code modified. The only change to an existing table is additive ALTERs on `ci_pipeline_runs` with `ADD COLUMN IF NOT EXISTS` (safe, non-breaking). Rollback: drop the new tables and columns via a reverse migration. Follow-up: Epic 2 (CHAOS-1076) ingestion and Epic 4 (CHAOS-1078) metrics will be the first consumers of these contracts.