### PR TITLE
feat: TestOps metrics engine — pipeline, test, coverage compute (CHAOS-1078)

### DIFF
--- a/src/dev_health_ops/metrics/compute_testops.py
+++ b/src/dev_health_ops/metrics/compute_testops.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import date, datetime
+
+from dev_health_ops.metrics.compute import _median, _percentile, _utc_day_window
+from dev_health_ops.metrics.testops_schemas import (
+    CoverageMetricsDailyRecord,
+    CoverageSnapshotRow,
+    JobRunRow,
+    PipelineMetricsDailyRecord,
+    PipelineRunExtendedRow,
+    TestCaseResultRow,
+    TestMetricsDailyRecord,
+    TestSuiteResultRow,
+)
+from dev_health_ops.utils.datetime import to_utc
+
+
+def _normalize_pipeline_status(status: str | None) -> str:
+    normalized = (status or "").strip().lower()
+    if normalized in {"success", "succeeded", "passed"}:
+        return "success"
+    if normalized in {"failure", "failed", "error", "errors", "timeout", "timed_out"}:
+        return "failure"
+    if normalized in {"cancelled", "canceled", "cancel"}:
+        return "cancelled"
+    return normalized
+
+
+def _normalize_test_status(status: str | None) -> str:
+    normalized = (status or "").strip().lower()
+    if normalized in {"success", "succeeded", "passed"}:
+        return "passed"
+    if normalized in {"failure", "failed", "error", "errors", "timeout", "timed_out"}:
+        return "failed"
+    if normalized in {"quarantined", "quarantine"}:
+        return "quarantined"
+    if normalized in {"skipped", "skip"}:
+        return "skipped"
+    return normalized
+
+
+def _safe_duration_seconds(
+    started_at: datetime | None,
+    finished_at: datetime | None,
+    explicit_seconds: float | None,
+) -> float | None:
+    if explicit_seconds is not None and explicit_seconds >= 0:
+        return float(explicit_seconds)
+    if started_at is None or finished_at is None:
+        return None
+    duration_seconds = (to_utc(finished_at) - to_utc(started_at)).total_seconds()
+    return float(duration_seconds) if duration_seconds >= 0 else None
+
+
+def _safe_queue_seconds(
+    queued_at: datetime | None,
+    started_at: datetime | None,
+    explicit_seconds: float | None,
+) -> float | None:
+    if explicit_seconds is not None and explicit_seconds >= 0:
+        return float(explicit_seconds)
+    if queued_at is None or started_at is None:
+        return None
+    queue_seconds = (to_utc(started_at) - to_utc(queued_at)).total_seconds()
+    return float(queue_seconds) if queue_seconds >= 0 else None
+
+
+def _latest_snapshot_key(snapshot: CoverageSnapshotRow) -> tuple[str, str]:
+    return (str(snapshot.get("run_id") or ""), str(snapshot.get("snapshot_id") or ""))
+
+
+@dataclass
+class _PipelineBucket:
+    pipelines: int = 0
+    success: int = 0
+    failure: int = 0
+    cancelled: int = 0
+    reruns: int = 0
+    durations: list[float] = field(default_factory=list)
+    queues: list[float] = field(default_factory=list)
+    org_id: str = ""
+
+
+def compute_pipeline_metrics_daily(
+    *,
+    day: date,
+    pipeline_runs: Sequence[PipelineRunExtendedRow],
+    job_runs: Sequence[JobRunRow],
+    computed_at: datetime,
+) -> list[PipelineMetricsDailyRecord]:
+    del job_runs
+
+    start, end = _utc_day_window(day)
+    computed_at_utc = to_utc(computed_at)
+
+    by_group: dict[tuple[uuid.UUID, str | None, str | None], _PipelineBucket] = {}
+    for row in pipeline_runs:
+        started_at = to_utc(row["started_at"])
+        if not (start <= started_at < end):
+            continue
+
+        repo_id = row["repo_id"]
+        team_id = row.get("team_id")
+        service_id = row.get("service_id")
+        key = (repo_id, team_id, service_id)
+        bucket = by_group.get(key)
+        if bucket is None:
+            bucket = _PipelineBucket(org_id=str(row.get("org_id") or ""))
+            by_group[key] = bucket
+
+        bucket.pipelines += 1
+        status = _normalize_pipeline_status(row.get("status"))
+        if status == "success":
+            bucket.success += 1
+        elif status == "failure":
+            bucket.failure += 1
+        elif status == "cancelled":
+            bucket.cancelled += 1
+
+        if int(row.get("retry_count") or 0) > 0:
+            bucket.reruns += 1
+
+        duration_seconds = _safe_duration_seconds(
+            row.get("started_at"),
+            row.get("finished_at"),
+            row.get("duration_seconds"),
+        )
+        if duration_seconds is not None:
+            bucket.durations.append(duration_seconds)
+
+        queue_seconds = _safe_queue_seconds(
+            row.get("queued_at"),
+            row.get("started_at"),
+            row.get("queue_seconds"),
+        )
+        if queue_seconds is not None:
+            bucket.queues.append(queue_seconds)
+
+    records: list[PipelineMetricsDailyRecord] = []
+    for (repo_id, team_id, service_id), bucket in sorted(
+        by_group.items(),
+        key=lambda item: (str(item[0][0]), item[0][1] or "", item[0][2] or ""),
+    ):
+        pipelines = bucket.pipelines
+        success = bucket.success
+        failure = bucket.failure
+        cancelled = bucket.cancelled
+        reruns = bucket.reruns
+        durations = list(bucket.durations)
+        queues = list(bucket.queues)
+
+        records.append(
+            PipelineMetricsDailyRecord(
+                repo_id=repo_id,
+                day=day,
+                pipelines_count=pipelines,
+                success_count=success,
+                failure_count=failure,
+                cancelled_count=cancelled,
+                success_rate=(success / pipelines) if pipelines else 0.0,
+                failure_rate=(failure / pipelines) if pipelines else 0.0,
+                cancel_rate=(cancelled / pipelines) if pipelines else 0.0,
+                rerun_rate=(reruns / pipelines) if pipelines else 0.0,
+                median_duration_seconds=float(_median(durations))
+                if durations
+                else None,
+                p95_duration_seconds=float(_percentile(durations, 95.0))
+                if durations
+                else None,
+                avg_queue_seconds=float(sum(queues) / len(queues)) if queues else None,
+                p95_queue_seconds=float(_percentile(queues, 95.0)) if queues else None,
+                computed_at=computed_at_utc,
+                team_id=team_id,
+                service_id=service_id,
+                org_id=bucket.org_id,
+            )
+        )
+
+    return records
+
+
+def compute_test_metrics_daily(
+    *,
+    day: date,
+    suite_results: Sequence[TestSuiteResultRow],
+    case_results: Sequence[TestCaseResultRow],
+    computed_at: datetime,
+) -> list[TestMetricsDailyRecord]:
+    start, end = _utc_day_window(day)
+    computed_at_utc = to_utc(computed_at)
+
+    current_suites_by_repo: dict[uuid.UUID, list[TestSuiteResultRow]] = defaultdict(
+        list
+    )
+    current_run_ids_by_repo: dict[uuid.UUID, set[str]] = defaultdict(set)
+    for row in suite_results:
+        suite_time = row.get("started_at") or row.get("finished_at")
+        if suite_time is None:
+            continue
+        suite_time_utc = to_utc(suite_time)
+        if not (start <= suite_time_utc < end):
+            continue
+        repo_id = row["repo_id"]
+        current_suites_by_repo[repo_id].append(row)
+        current_run_ids_by_repo[repo_id].add(str(row["run_id"]))
+
+    current_cases_by_repo: dict[uuid.UUID, list[TestCaseResultRow]] = defaultdict(list)
+    historical_failed_names_by_repo: dict[uuid.UUID, set[str]] = defaultdict(set)
+    for row in case_results:
+        repo_id = row["repo_id"]
+        run_id = str(row["run_id"])
+        normalized_status = _normalize_test_status(row.get("status"))
+        if run_id in current_run_ids_by_repo.get(repo_id, set()):
+            current_cases_by_repo[repo_id].append(row)
+        elif normalized_status == "failed":
+            historical_failed_names_by_repo[repo_id].add(
+                str(row.get("case_name") or "")
+            )
+
+    records: list[TestMetricsDailyRecord] = []
+    repo_ids = sorted(
+        set(current_suites_by_repo.keys()) | set(current_cases_by_repo.keys()), key=str
+    )
+    for repo_id in repo_ids:
+        repo_suites = current_suites_by_repo.get(repo_id, [])
+        repo_cases = current_cases_by_repo.get(repo_id, [])
+        if not repo_suites and not repo_cases:
+            continue
+
+        total_cases = sum(int(row.get("total_count") or 0) for row in repo_suites)
+        passed_count = sum(int(row.get("passed_count") or 0) for row in repo_suites)
+        failed_count = sum(
+            int(row.get("failed_count") or 0) + int(row.get("error_count") or 0)
+            for row in repo_suites
+        )
+        skipped_count = sum(int(row.get("skipped_count") or 0) for row in repo_suites)
+        quarantined_count = sum(
+            int(row.get("quarantined_count") or 0) for row in repo_suites
+        )
+        suite_durations = [
+            float(duration)
+            for duration in (row.get("duration_seconds") for row in repo_suites)
+            if duration is not None and duration >= 0
+        ]
+
+        case_statuses: dict[str, set[str]] = defaultdict(set)
+        retry_attempts_by_case: dict[str, set[int]] = defaultdict(set)
+        current_failed_names: set[str] = set()
+        for row in repo_cases:
+            case_name = str(row.get("case_name") or "")
+            if not case_name:
+                continue
+            normalized_status = _normalize_test_status(row.get("status"))
+            case_statuses[case_name].add(normalized_status)
+            retry_attempts_by_case[case_name].add(int(row.get("retry_attempt") or 0))
+            if normalized_status == "failed":
+                current_failed_names.add(case_name)
+
+        distinct_cases = len(case_statuses)
+        flake_cases = sum(
+            1
+            for statuses in case_statuses.values()
+            if "passed" in statuses and "failed" in statuses
+        )
+        retry_dependent_cases = sum(
+            1
+            for case_name, statuses in case_statuses.items()
+            if "passed" in statuses
+            and any(
+                attempt > 0 for attempt in retry_attempts_by_case.get(case_name, set())
+            )
+        )
+        recurrent_failures = len(
+            current_failed_names & historical_failed_names_by_repo.get(repo_id, set())
+        )
+
+        first_suite = repo_suites[0] if repo_suites else None
+        records.append(
+            TestMetricsDailyRecord(
+                repo_id=repo_id,
+                day=day,
+                total_cases=total_cases,
+                passed_count=passed_count,
+                failed_count=failed_count,
+                skipped_count=skipped_count,
+                quarantined_count=quarantined_count,
+                pass_rate=(passed_count / total_cases) if total_cases else 0.0,
+                failure_rate=(failed_count / total_cases) if total_cases else 0.0,
+                flake_rate=(flake_cases / distinct_cases) if distinct_cases else 0.0,
+                retry_dependency_rate=(retry_dependent_cases / distinct_cases)
+                if distinct_cases
+                else 0.0,
+                total_suites=len(repo_suites),
+                suite_duration_p50_seconds=float(_median(suite_durations))
+                if suite_durations
+                else None,
+                suite_duration_p95_seconds=float(_percentile(suite_durations, 95.0))
+                if suite_durations
+                else None,
+                failure_recurrence_score=(
+                    recurrent_failures / len(current_failed_names)
+                )
+                if current_failed_names
+                else 0.0,
+                computed_at=computed_at_utc,
+                team_id=first_suite.get("team_id") if first_suite else None,
+                service_id=first_suite.get("service_id") if first_suite else None,
+                org_id=str(first_suite.get("org_id", "") if first_suite else ""),
+            )
+        )
+
+    return records
+
+
+def compute_coverage_metrics_daily(
+    *,
+    day: date,
+    snapshots: Sequence[CoverageSnapshotRow],
+    prior_snapshots: Sequence[CoverageSnapshotRow] | None,
+    computed_at: datetime,
+) -> list[CoverageMetricsDailyRecord]:
+    computed_at_utc = to_utc(computed_at)
+
+    latest_current_by_repo: dict[uuid.UUID, CoverageSnapshotRow] = {}
+    for snapshot in snapshots:
+        repo_id = snapshot["repo_id"]
+        existing = latest_current_by_repo.get(repo_id)
+        if existing is None or _latest_snapshot_key(snapshot) > _latest_snapshot_key(
+            existing
+        ):
+            latest_current_by_repo[repo_id] = snapshot
+
+    latest_prior_by_repo: dict[uuid.UUID, CoverageSnapshotRow] = {}
+    for snapshot in prior_snapshots or []:
+        repo_id = snapshot["repo_id"]
+        existing = latest_prior_by_repo.get(repo_id)
+        if existing is None or _latest_snapshot_key(snapshot) > _latest_snapshot_key(
+            existing
+        ):
+            latest_prior_by_repo[repo_id] = snapshot
+
+    records: list[CoverageMetricsDailyRecord] = []
+    for repo_id, snapshot in sorted(
+        latest_current_by_repo.items(), key=lambda item: str(item[0])
+    ):
+        prior_snapshot = latest_prior_by_repo.get(repo_id)
+        current_line_coverage = snapshot.get("line_coverage_pct")
+        current_branch_coverage = snapshot.get("branch_coverage_pct")
+        current_lines_total = snapshot.get("lines_total")
+        current_lines_covered = snapshot.get("lines_covered")
+        prior_line_coverage = (
+            prior_snapshot.get("line_coverage_pct")
+            if prior_snapshot is not None
+            else None
+        )
+        coverage_delta_pct = None
+        if current_line_coverage is not None and prior_line_coverage is not None:
+            coverage_delta_pct = float(current_line_coverage - prior_line_coverage)
+
+        records.append(
+            CoverageMetricsDailyRecord(
+                repo_id=repo_id,
+                day=day,
+                line_coverage_pct=float(current_line_coverage)
+                if current_line_coverage is not None
+                else None,
+                branch_coverage_pct=float(current_branch_coverage)
+                if current_branch_coverage is not None
+                else None,
+                lines_total=int(current_lines_total)
+                if current_lines_total is not None
+                else None,
+                lines_covered=int(current_lines_covered)
+                if current_lines_covered is not None
+                else None,
+                coverage_delta_pct=coverage_delta_pct,
+                uncovered_files_count=0,
+                coverage_regression_count=0,
+                computed_at=computed_at_utc,
+                team_id=snapshot.get("team_id"),
+                service_id=snapshot.get("service_id"),
+                org_id=str(snapshot.get("org_id", "")),
+            )
+        )
+
+    return records

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -19,6 +19,11 @@ from dev_health_ops.metrics.compute_ic import (
     compute_ic_metrics_daily,
 )
 from dev_health_ops.metrics.compute_incidents import compute_incident_metrics_daily
+from dev_health_ops.metrics.compute_testops import (
+    compute_coverage_metrics_daily,
+    compute_pipeline_metrics_daily,
+    compute_test_metrics_daily,
+)
 from dev_health_ops.metrics.compute_wellbeing import (
     compute_team_wellbeing_metrics_daily,
 )
@@ -239,14 +244,35 @@ async def run_daily_metrics_job(
         )
         daily_commit_cache[d] = commit_rows
 
+        testops_loader: Any = loader
         pipeline_rows, deployment_rows = await loader.load_cicd_data(
             start, end, repo_id=repo_id, repo_name=repo_name
+        )
+        h_start_date = d - timedelta(days=29)
+        (
+            testops_pipeline_rows,
+            testops_job_rows,
+        ) = await testops_loader.load_testops_pipeline_data(start, end, repo_id=repo_id)
+        (
+            testops_suite_rows,
+            testops_case_rows,
+        ) = await testops_loader.load_testops_test_data(
+            datetime.combine(h_start_date, time.min, tzinfo=timezone.utc),
+            end,
+            repo_id=repo_id,
+        )
+        coverage_rows = await testops_loader.load_testops_coverage_data(
+            start, end, repo_id=repo_id
+        )
+        prior_coverage_rows = await testops_loader.load_testops_coverage_data(
+            datetime.combine(d - timedelta(days=30), time.min, tzinfo=timezone.utc),
+            start,
+            repo_id=repo_id,
         )
         incident_rows = await loader.load_incidents(
             start, end, repo_id=repo_id, repo_name=repo_name
         )
 
-        h_start_date = d - timedelta(days=29)
         h_commit_rows = await _get_cached_commits_for_window(h_start_date, d)
 
         work_items: list[Any] = []
@@ -357,6 +383,24 @@ async def run_daily_metrics_job(
         cicd_metrics = compute_cicd_metrics_daily(
             day=d, pipeline_runs=pipeline_rows, computed_at=computed_at
         )
+        testops_pipeline_metrics = compute_pipeline_metrics_daily(
+            day=d,
+            pipeline_runs=testops_pipeline_rows,
+            job_runs=testops_job_rows,
+            computed_at=computed_at,
+        )
+        testops_test_metrics = compute_test_metrics_daily(
+            day=d,
+            suite_results=testops_suite_rows,
+            case_results=testops_case_rows,
+            computed_at=computed_at,
+        )
+        testops_coverage_metrics = compute_coverage_metrics_daily(
+            day=d,
+            snapshots=coverage_rows,
+            prior_snapshots=prior_coverage_rows,
+            computed_at=computed_at,
+        )
         deploy_metrics = compute_deploy_metrics_daily(
             day=d, deployments=deployment_rows, computed_at=computed_at
         )
@@ -378,6 +422,9 @@ async def run_daily_metrics_job(
                 s.write_work_item_cycle_times(wi_cycle_times)
             s.write_review_edges(review_edges)
             s.write_cicd_metrics(cicd_metrics)
+            s.write_testops_pipeline_metrics(testops_pipeline_metrics)
+            s.write_testops_test_metrics(testops_test_metrics)
+            s.write_testops_coverage_metrics(testops_coverage_metrics)
             s.write_deploy_metrics(deploy_metrics)
             s.write_incident_metrics(incident_metrics)
             if all_file_metrics:
@@ -575,7 +622,7 @@ async def _cmd_metrics_daily(ns: argparse.Namespace) -> int:
             include_commit_metrics=ns.commit_metrics,
             sink=ns.sink,
             provider=ns.provider,
-            org_id=getattr(ns, "org", None),
+            org_id=getattr(ns, "org", None) or "",
         )
         return 0
     except Exception as e:
@@ -588,7 +635,7 @@ async def _cmd_metrics_rebuild(ns: argparse.Namespace) -> int:
         validate_sink(ns)
         end_day, backfill_days = resolve_date_range(ns)
         db_url = resolve_sink_uri(ns)
-        org_id = getattr(ns, "org", None)
+        org_id = getattr(ns, "org", None) or ""
         repo_ids: list[uuid.UUID] = ns.repo_ids or []
         days = _date_range(end_day, backfill_days)
 

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import date, datetime, timedelta, timezone
-from typing import Any
+from typing import Any, cast
 
 from dev_health_ops.metrics.loaders.base import (
     DataLoader,
@@ -19,6 +19,13 @@ from dev_health_ops.metrics.schemas import (
     PipelineRunRow,
     PullRequestReviewRow,
     PullRequestRow,
+)
+from dev_health_ops.metrics.testops_schemas import (
+    CoverageSnapshotRow,
+    JobRunRow,
+    PipelineRunExtendedRow,
+    TestCaseResultRow,
+    TestSuiteResultRow,
 )
 from dev_health_ops.models.atlassian_ops import (
     AtlassianOpsAlert,
@@ -310,6 +317,197 @@ class ClickHouseDataLoader(DataLoader):
         """
         dicts = await _clickhouse_query_dicts(self.client, query, params)
         return [dict(d) for d in dicts]  # type: ignore
+
+    async def load_testops_pipeline_data(
+        self,
+        start: datetime,
+        end: datetime,
+        repo_id: uuid.UUID | None,
+    ) -> tuple[list[PipelineRunExtendedRow], list[JobRunRow]]:
+        params: dict[str, Any] = {"start": naive_utc(start), "end": naive_utc(end)}
+        repo_filter = ""
+        if repo_id is not None:
+            params["repo_id"] = str(repo_id)
+            repo_filter = " AND repo_id = {repo_id:UUID}"
+
+        org_filter = self._org_filter()
+        params = self._inject_org_id(params)
+
+        pipeline_query = f"""
+        SELECT
+          repo_id,
+          run_id,
+          pipeline_name,
+          provider,
+          status,
+          queued_at,
+          started_at,
+          finished_at,
+          duration_seconds,
+          queue_seconds,
+          retry_count,
+          cancel_reason,
+          trigger_source,
+          commit_hash,
+          branch,
+          pr_number,
+          team_id,
+          service_id,
+          org_id
+        FROM ci_pipeline_runs
+        WHERE started_at >= {{start:DateTime}} AND started_at < {{end:DateTime}}
+        {repo_filter}
+        {org_filter}
+        """
+        job_query = f"""
+        SELECT
+          j.repo_id,
+          j.run_id,
+          j.job_id,
+          j.job_name,
+          j.stage,
+          j.status,
+          j.started_at,
+          j.finished_at,
+          j.duration_seconds,
+          j.runner_type,
+          j.retry_attempt,
+          j.org_id
+        FROM ci_job_runs AS j
+        INNER JOIN ci_pipeline_runs AS p
+          ON (p.repo_id = j.repo_id) AND (p.run_id = j.run_id)
+        WHERE p.started_at >= {{start:DateTime}} AND p.started_at < {{end:DateTime}}
+        {repo_filter.replace("repo_id", "p.repo_id") if repo_id is not None else ""}
+        {self._org_filter(alias="p")}
+        """
+
+        pipeline_dicts = await _clickhouse_query_dicts(
+            self.client, pipeline_query, params
+        )
+        job_dicts = await _clickhouse_query_dicts(self.client, job_query, params)
+        return (
+            [cast(PipelineRunExtendedRow, dict(row)) for row in pipeline_dicts],
+            [cast(JobRunRow, dict(row)) for row in job_dicts],
+        )
+
+    async def load_testops_test_data(
+        self,
+        start: datetime,
+        end: datetime,
+        repo_id: uuid.UUID | None,
+    ) -> tuple[list[TestSuiteResultRow], list[TestCaseResultRow]]:
+        params: dict[str, Any] = {"start": naive_utc(start), "end": naive_utc(end)}
+        repo_filter = ""
+        if repo_id is not None:
+            params["repo_id"] = str(repo_id)
+            repo_filter = " AND repo_id = {repo_id:UUID}"
+
+        org_filter = self._org_filter()
+        params = self._inject_org_id(params)
+
+        suite_query = f"""
+        SELECT
+          repo_id,
+          run_id,
+          suite_id,
+          suite_name,
+          framework,
+          environment,
+          total_count,
+          passed_count,
+          failed_count,
+          skipped_count,
+          error_count,
+          quarantined_count,
+          retried_count,
+          duration_seconds,
+          started_at,
+          finished_at,
+          team_id,
+          service_id,
+          org_id
+        FROM test_suite_results
+        WHERE coalesce(started_at, finished_at) >= {{start:DateTime}}
+          AND coalesce(started_at, finished_at) < {{end:DateTime}}
+        {repo_filter}
+        {org_filter}
+        """
+        case_query = f"""
+        SELECT
+          c.repo_id,
+          c.run_id,
+          c.suite_id,
+          c.case_id,
+          c.case_name,
+          c.class_name,
+          c.status,
+          c.duration_seconds,
+          c.retry_attempt,
+          c.failure_message,
+          c.failure_type,
+          c.stack_trace,
+          c.is_quarantined,
+          c.org_id
+        FROM test_case_results AS c
+        INNER JOIN test_suite_results AS s
+          ON (s.repo_id = c.repo_id)
+         AND (s.run_id = c.run_id)
+         AND (s.suite_id = c.suite_id)
+        WHERE coalesce(s.started_at, s.finished_at) >= {{start:DateTime}}
+          AND coalesce(s.started_at, s.finished_at) < {{end:DateTime}}
+        {repo_filter.replace("repo_id", "s.repo_id") if repo_id is not None else ""}
+        {self._org_filter(alias="s")}
+        """
+
+        suite_dicts = await _clickhouse_query_dicts(self.client, suite_query, params)
+        case_dicts = await _clickhouse_query_dicts(self.client, case_query, params)
+        return (
+            [cast(TestSuiteResultRow, dict(row)) for row in suite_dicts],
+            [cast(TestCaseResultRow, dict(row)) for row in case_dicts],
+        )
+
+    async def load_testops_coverage_data(
+        self,
+        start: datetime,
+        end: datetime,
+        repo_id: uuid.UUID | None,
+    ) -> list[CoverageSnapshotRow]:
+        params: dict[str, Any] = {"start": naive_utc(start), "end": naive_utc(end)}
+        repo_filter = ""
+        if repo_id is not None:
+            params["repo_id"] = str(repo_id)
+            repo_filter = " AND p.repo_id = {repo_id:UUID}"
+
+        params = self._inject_org_id(params)
+        query = f"""
+        SELECT
+          c.repo_id,
+          c.run_id,
+          c.snapshot_id,
+          c.report_format,
+          c.lines_total,
+          c.lines_covered,
+          c.line_coverage_pct,
+          c.branches_total,
+          c.branches_covered,
+          c.branch_coverage_pct,
+          c.functions_total,
+          c.functions_covered,
+          c.commit_hash,
+          c.branch,
+          c.pr_number,
+          c.team_id,
+          c.service_id,
+          c.org_id
+        FROM coverage_snapshots AS c
+        INNER JOIN ci_pipeline_runs AS p
+          ON (p.repo_id = c.repo_id) AND (p.run_id = c.run_id)
+        WHERE p.started_at >= {{start:DateTime}} AND p.started_at < {{end:DateTime}}
+        {repo_filter}
+        {self._org_filter(alias="p")}
+        """
+        dicts = await _clickhouse_query_dicts(self.client, query, params)
+        return [cast(CoverageSnapshotRow, dict(row)) for row in dicts]
 
     async def load_blame_concentration(
         self,

--- a/src/dev_health_ops/metrics/sinks/base.py
+++ b/src/dev_health_ops/metrics/sinks/base.py
@@ -41,6 +41,11 @@ from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
 )
+from dev_health_ops.metrics.testops_schemas import (
+    CoverageMetricsDailyRecord,
+    PipelineMetricsDailyRecord,
+    TestMetricsDailyRecord,
+)
 from dev_health_ops.models.work_items import (
     Sprint,
     WorkItem,
@@ -204,6 +209,24 @@ class BaseMetricsSink(ABC):
     @abstractmethod
     def write_dora_metrics(self, rows: Sequence[DORAMetricsRecord]) -> None:
         """Write pre-computed DORA metrics from providers."""
+
+    @abstractmethod
+    def write_testops_pipeline_metrics(
+        self, rows: Sequence[PipelineMetricsDailyRecord]
+    ) -> None:
+        """Write daily TestOps pipeline health metrics."""
+
+    @abstractmethod
+    def write_testops_test_metrics(
+        self, rows: Sequence[TestMetricsDailyRecord]
+    ) -> None:
+        """Write daily TestOps test reliability metrics."""
+
+    @abstractmethod
+    def write_testops_coverage_metrics(
+        self, rows: Sequence[CoverageMetricsDailyRecord]
+    ) -> None:
+        """Write daily TestOps coverage metrics."""
 
     # -------------------------------------------------------------------------
     # Complexity / hotspot metrics

--- a/src/dev_health_ops/metrics/sinks/clickhouse.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse.py
@@ -42,6 +42,11 @@ from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentRecord,
 )
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+from dev_health_ops.metrics.testops_schemas import (
+    CoverageMetricsDailyRecord,
+    PipelineMetricsDailyRecord,
+    TestMetricsDailyRecord,
+)
 from dev_health_ops.models.work_items import (
     Sprint,
     WorkItemDependency,
@@ -736,6 +741,92 @@ class ClickHouseMetricsSink(BaseMetricsSink):
                 "value",
                 "computed_at",
                 "org_id",
+            ],
+            rows,
+        )
+
+    def write_testops_pipeline_metrics(
+        self, rows: Sequence[PipelineMetricsDailyRecord]
+    ) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "testops_pipeline_metrics_daily",
+            [
+                "repo_id",
+                "day",
+                "pipelines_count",
+                "success_count",
+                "failure_count",
+                "cancelled_count",
+                "success_rate",
+                "failure_rate",
+                "cancel_rate",
+                "rerun_rate",
+                "median_duration_seconds",
+                "p95_duration_seconds",
+                "avg_queue_seconds",
+                "p95_queue_seconds",
+                "team_id",
+                "service_id",
+                "org_id",
+                "computed_at",
+            ],
+            rows,
+        )
+
+    def write_testops_test_metrics(
+        self, rows: Sequence[TestMetricsDailyRecord]
+    ) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "testops_test_metrics_daily",
+            [
+                "repo_id",
+                "day",
+                "total_cases",
+                "passed_count",
+                "failed_count",
+                "skipped_count",
+                "quarantined_count",
+                "pass_rate",
+                "failure_rate",
+                "flake_rate",
+                "retry_dependency_rate",
+                "total_suites",
+                "suite_duration_p50_seconds",
+                "suite_duration_p95_seconds",
+                "failure_recurrence_score",
+                "team_id",
+                "service_id",
+                "org_id",
+                "computed_at",
+            ],
+            rows,
+        )
+
+    def write_testops_coverage_metrics(
+        self, rows: Sequence[CoverageMetricsDailyRecord]
+    ) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "testops_coverage_metrics_daily",
+            [
+                "repo_id",
+                "day",
+                "line_coverage_pct",
+                "branch_coverage_pct",
+                "lines_total",
+                "lines_covered",
+                "coverage_delta_pct",
+                "uncovered_files_count",
+                "coverage_regression_count",
+                "team_id",
+                "service_id",
+                "org_id",
+                "computed_at",
             ],
             rows,
         )

--- a/tests/metrics/test_compute_testops.py
+++ b/tests/metrics/test_compute_testops.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from dev_health_ops.metrics.compute_testops import (
+    compute_coverage_metrics_daily,
+    compute_pipeline_metrics_daily,
+    compute_test_metrics_daily,
+)
+
+
+def test_compute_pipeline_metrics_daily_groups_by_repo_and_team_service():
+    day = date(2026, 2, 18)
+    repo_a = uuid4()
+    repo_b = uuid4()
+
+    records = compute_pipeline_metrics_daily(
+        day=day,
+        pipeline_runs=[
+            {
+                "repo_id": repo_a,
+                "run_id": "001",
+                "provider": "github_actions",
+                "status": "success",
+                "queued_at": datetime(2026, 2, 18, 9, 58, tzinfo=timezone.utc),
+                "started_at": datetime(2026, 2, 18, 10, 0, tzinfo=timezone.utc),
+                "finished_at": datetime(2026, 2, 18, 10, 5, tzinfo=timezone.utc),
+                "retry_count": 0,
+                "team_id": "team-a",
+                "service_id": "svc-a",
+            },
+            {
+                "repo_id": repo_a,
+                "run_id": "002",
+                "provider": "github_actions",
+                "status": "failed",
+                "queued_at": datetime(2026, 2, 18, 10, 55, tzinfo=timezone.utc),
+                "started_at": datetime(2026, 2, 18, 11, 0, tzinfo=timezone.utc),
+                "finished_at": datetime(2026, 2, 18, 11, 20, tzinfo=timezone.utc),
+                "retry_count": 1,
+                "team_id": "team-a",
+                "service_id": "svc-a",
+            },
+            {
+                "repo_id": repo_b,
+                "run_id": "010",
+                "provider": "github_actions",
+                "status": "cancelled",
+                "queued_at": datetime(2026, 2, 18, 7, 59, tzinfo=timezone.utc),
+                "started_at": datetime(2026, 2, 18, 8, 0, tzinfo=timezone.utc),
+                "finished_at": datetime(2026, 2, 18, 8, 0, tzinfo=timezone.utc),
+                "retry_count": 0,
+            },
+            {
+                "repo_id": repo_a,
+                "run_id": "old",
+                "provider": "github_actions",
+                "status": "success",
+                "queued_at": None,
+                "started_at": datetime(2026, 2, 17, 23, 59, tzinfo=timezone.utc),
+                "finished_at": datetime(2026, 2, 18, 0, 5, tzinfo=timezone.utc),
+            },
+        ],
+        job_runs=[],
+        computed_at=datetime(2026, 2, 18, 13, 0, tzinfo=timezone.utc),
+    )
+
+    rec_a = next(r for r in records if r.repo_id == repo_a)
+    assert rec_a.team_id == "team-a"
+    assert rec_a.service_id == "svc-a"
+    assert rec_a.pipelines_count == 2
+    assert rec_a.success_count == 1
+    assert rec_a.failure_count == 1
+    assert rec_a.cancelled_count == 0
+    assert rec_a.success_rate == pytest.approx(0.5)
+    assert rec_a.failure_rate == pytest.approx(0.5)
+    assert rec_a.cancel_rate == pytest.approx(0.0)
+    assert rec_a.rerun_rate == pytest.approx(0.5)
+    assert rec_a.median_duration_seconds == pytest.approx(750.0)
+    assert rec_a.p95_duration_seconds == pytest.approx(1155.0)
+    assert rec_a.avg_queue_seconds == pytest.approx(210.0)
+    assert rec_a.p95_queue_seconds == pytest.approx(291.0)
+
+    rec_b = next(r for r in records if r.repo_id == repo_b)
+    assert rec_b.pipelines_count == 1
+    assert rec_b.cancelled_count == 1
+    assert rec_b.median_duration_seconds == pytest.approx(0.0)
+    assert rec_b.avg_queue_seconds == pytest.approx(60.0)
+
+
+def test_compute_pipeline_metrics_daily_returns_empty_for_no_matching_rows():
+    records = compute_pipeline_metrics_daily(
+        day=date(2026, 2, 18),
+        pipeline_runs=[],
+        job_runs=[],
+        computed_at=datetime(2026, 2, 18, 13, 0, tzinfo=timezone.utc),
+    )
+
+    assert records == []
+
+
+def test_compute_test_metrics_daily_detects_flakes_and_failure_recurrence():
+    day = date(2026, 2, 18)
+    repo_a = uuid4()
+    repo_b = uuid4()
+
+    suite_results = [
+        {
+            "repo_id": repo_a,
+            "run_id": "run-a-current",
+            "suite_id": "suite-a-1",
+            "suite_name": "suite-a-1",
+            "total_count": 4,
+            "passed_count": 2,
+            "failed_count": 1,
+            "skipped_count": 1,
+            "error_count": 0,
+            "quarantined_count": 1,
+            "retried_count": 1,
+            "duration_seconds": 30.0,
+            "started_at": datetime(2026, 2, 18, 10, 0, tzinfo=timezone.utc),
+            "finished_at": datetime(2026, 2, 18, 10, 1, tzinfo=timezone.utc),
+            "team_id": "team-a",
+            "service_id": "svc-a",
+        },
+        {
+            "repo_id": repo_a,
+            "run_id": "run-a-current-2",
+            "suite_id": "suite-a-2",
+            "suite_name": "suite-a-2",
+            "total_count": 2,
+            "passed_count": 1,
+            "failed_count": 1,
+            "skipped_count": 0,
+            "error_count": 1,
+            "quarantined_count": 0,
+            "retried_count": 1,
+            "duration_seconds": 50.0,
+            "started_at": datetime(2026, 2, 18, 11, 0, tzinfo=timezone.utc),
+            "finished_at": datetime(2026, 2, 18, 11, 2, tzinfo=timezone.utc),
+        },
+        {
+            "repo_id": repo_a,
+            "run_id": "run-a-history",
+            "suite_id": "suite-a-old",
+            "suite_name": "suite-a-old",
+            "total_count": 1,
+            "passed_count": 0,
+            "failed_count": 1,
+            "skipped_count": 0,
+            "duration_seconds": 20.0,
+            "started_at": datetime(2026, 2, 17, 11, 0, tzinfo=timezone.utc),
+            "finished_at": datetime(2026, 2, 17, 11, 1, tzinfo=timezone.utc),
+        },
+        {
+            "repo_id": repo_b,
+            "run_id": "run-b-current",
+            "suite_id": "suite-b-1",
+            "suite_name": "suite-b-1",
+            "total_count": 1,
+            "passed_count": 1,
+            "failed_count": 0,
+            "skipped_count": 0,
+            "duration_seconds": 0.0,
+            "started_at": datetime(2026, 2, 18, 9, 0, tzinfo=timezone.utc),
+            "finished_at": datetime(2026, 2, 18, 9, 0, tzinfo=timezone.utc),
+        },
+    ]
+
+    case_results = [
+        {
+            "repo_id": repo_a,
+            "run_id": "run-a-current",
+            "suite_id": "suite-a-1",
+            "case_id": "a1-1",
+            "case_name": "test_flaky",
+            "status": "failed",
+            "duration_seconds": 5.0,
+            "retry_attempt": 0,
+        },
+        {
+            "repo_id": repo_a,
+            "run_id": "run-a-current",
+            "suite_id": "suite-a-1",
+            "case_id": "a1-1-retry",
+            "case_name": "test_flaky",
+            "status": "passed",
+            "duration_seconds": 4.0,
+            "retry_attempt": 1,
+        },
+        {
+            "repo_id": repo_a,
+            "run_id": "run-a-current",
+            "suite_id": "suite-a-1",
+            "case_id": "a1-2",
+            "case_name": "test_recurring_failure",
+            "status": "failed",
+            "duration_seconds": 2.0,
+            "retry_attempt": 0,
+        },
+        {
+            "repo_id": repo_a,
+            "run_id": "run-a-current",
+            "suite_id": "suite-a-1",
+            "case_id": "a1-3",
+            "case_name": "test_skipped",
+            "status": "skipped",
+            "duration_seconds": 0.0,
+            "retry_attempt": 0,
+        },
+        {
+            "repo_id": repo_a,
+            "run_id": "run-a-current-2",
+            "suite_id": "suite-a-2",
+            "case_id": "a2-1",
+            "case_name": "test_clean_pass",
+            "status": "passed",
+            "duration_seconds": 1.0,
+            "retry_attempt": 0,
+        },
+        {
+            "repo_id": repo_a,
+            "run_id": "run-a-current-2",
+            "suite_id": "suite-a-2",
+            "case_id": "a2-2",
+            "case_name": "test_quarantined",
+            "status": "quarantined",
+            "duration_seconds": 1.0,
+            "retry_attempt": 0,
+        },
+        {
+            "repo_id": repo_a,
+            "run_id": "run-a-history",
+            "suite_id": "suite-a-old",
+            "case_id": "a-old-1",
+            "case_name": "test_recurring_failure",
+            "status": "failed",
+            "duration_seconds": 1.0,
+            "retry_attempt": 0,
+        },
+        {
+            "repo_id": repo_b,
+            "run_id": "run-b-current",
+            "suite_id": "suite-b-1",
+            "case_id": "b1-1",
+            "case_name": "test_repo_b",
+            "status": "passed",
+            "duration_seconds": 0.0,
+            "retry_attempt": 0,
+        },
+    ]
+
+    records = compute_test_metrics_daily(
+        day=day,
+        suite_results=suite_results,
+        case_results=case_results,
+        computed_at=datetime(2026, 2, 18, 13, 0, tzinfo=timezone.utc),
+    )
+
+    rec_a = next(r for r in records if r.repo_id == repo_a)
+    assert rec_a.total_cases == 6
+    assert rec_a.passed_count == 3
+    assert rec_a.failed_count == 3
+    assert rec_a.skipped_count == 1
+    assert rec_a.quarantined_count == 1
+    assert rec_a.pass_rate == pytest.approx(0.5)
+    assert rec_a.failure_rate == pytest.approx(0.5)
+    assert rec_a.flake_rate == pytest.approx(0.2)
+    assert rec_a.retry_dependency_rate == pytest.approx(0.2)
+    assert rec_a.total_suites == 2
+    assert rec_a.suite_duration_p50_seconds == pytest.approx(40.0)
+    assert rec_a.suite_duration_p95_seconds == pytest.approx(49.0)
+    assert rec_a.failure_recurrence_score == pytest.approx(0.5)
+    assert rec_a.team_id == "team-a"
+    assert rec_a.service_id == "svc-a"
+
+    rec_b = next(r for r in records if r.repo_id == repo_b)
+    assert rec_b.total_cases == 1
+    assert rec_b.pass_rate == pytest.approx(1.0)
+    assert rec_b.flake_rate == pytest.approx(0.0)
+    assert rec_b.retry_dependency_rate == pytest.approx(0.0)
+    assert rec_b.suite_duration_p50_seconds == pytest.approx(0.0)
+
+
+def test_compute_test_metrics_daily_handles_empty_inputs():
+    records = compute_test_metrics_daily(
+        day=date(2026, 2, 18),
+        suite_results=[],
+        case_results=[],
+        computed_at=datetime(2026, 2, 18, 13, 0, tzinfo=timezone.utc),
+    )
+
+    assert records == []
+
+
+def test_compute_coverage_metrics_daily_uses_latest_snapshot_and_delta():
+    day = date(2026, 2, 18)
+    repo_a = uuid4()
+    repo_b = uuid4()
+
+    records = compute_coverage_metrics_daily(
+        day=day,
+        snapshots=[
+            {
+                "repo_id": repo_a,
+                "run_id": "001",
+                "snapshot_id": "snap-1",
+                "lines_total": 100,
+                "lines_covered": 80,
+                "line_coverage_pct": 80.0,
+                "branch_coverage_pct": 70.0,
+                "team_id": "team-a",
+            },
+            {
+                "repo_id": repo_a,
+                "run_id": "002",
+                "snapshot_id": "snap-2",
+                "lines_total": 100,
+                "lines_covered": 85,
+                "line_coverage_pct": 85.0,
+                "branch_coverage_pct": 75.0,
+                "team_id": "team-a",
+            },
+            {
+                "repo_id": repo_b,
+                "run_id": "010",
+                "snapshot_id": "snap-10",
+                "lines_total": 50,
+                "lines_covered": 45,
+                "line_coverage_pct": 90.0,
+                "branch_coverage_pct": None,
+            },
+        ],
+        prior_snapshots=[
+            {
+                "repo_id": repo_a,
+                "run_id": "000",
+                "snapshot_id": "snap-old",
+                "lines_total": 100,
+                "lines_covered": 82,
+                "line_coverage_pct": 82.0,
+                "branch_coverage_pct": 72.0,
+            }
+        ],
+        computed_at=datetime(2026, 2, 18, 13, 0, tzinfo=timezone.utc),
+    )
+
+    rec_a = next(r for r in records if r.repo_id == repo_a)
+    assert rec_a.line_coverage_pct == pytest.approx(85.0)
+    assert rec_a.branch_coverage_pct == pytest.approx(75.0)
+    assert rec_a.lines_total == 100
+    assert rec_a.lines_covered == 85
+    assert rec_a.coverage_delta_pct == pytest.approx(3.0)
+    assert rec_a.uncovered_files_count == 0
+    assert rec_a.coverage_regression_count == 0
+
+    rec_b = next(r for r in records if r.repo_id == repo_b)
+    assert rec_b.coverage_delta_pct is None
+    assert rec_b.branch_coverage_pct is None
+
+
+def test_compute_coverage_metrics_daily_returns_empty_for_no_snapshots():
+    records = compute_coverage_metrics_daily(
+        day=date(2026, 2, 18),
+        snapshots=[],
+        prior_snapshots=None,
+        computed_at=datetime(2026, 2, 18, 13, 0, tzinfo=timezone.utc),
+    )
+
+    assert records == []


### PR DESCRIPTION
## Summary
- Implements `compute_testops.py` with three pure compute functions for pipeline health, test reliability, and coverage metrics
- Adds ClickHouse sink methods and data loader methods for TestOps metric tables
- Wires TestOps compute into the daily metrics job (`job_daily.py`)
- 6 unit tests passing

## Linear
CHAOS-1078, CHAOS-1101, CHAOS-1102, CHAOS-1103