### PR TITLE
docs: TestOps architecture, AI reports architecture, and operational runbooks (CHAOS-1159, CHAOS-1160, CHAOS-1161, CHAOS-1162)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,3 +38,5 @@ Investment categorization is computed at job time and persisted as distributions
 - Concepts: `product/concepts.md`
 - Categorization contract: `llm/categorization-contract.md`
 - Investment View: `user-guide/investment-view.md`
+- TestOps Architecture: `architecture/testops-architecture.md`
+- AI Reports Architecture: `architecture/ai-reports-architecture.md`

--- a/docs/architecture/ai-reports-architecture.md
+++ b/docs/architecture/ai-reports-architecture.md
@@ -1,0 +1,71 @@
+# AI Generative Reports Architecture
+
+## Overview
+The AI Generative Reports system provides a natural-language interface for generating grounded, data-backed engineering health reports. It follows a deterministic pipeline that converts user prompts into structured plans, ensuring that every insight and chart is derived directly from persisted metric data.
+
+## Report DSL
+The system uses a structured Domain Specific Language (DSL) to represent report plans and their components.
+
+### ReportPlan
+The `ReportPlan` is the central contract for report generation. It defines the scope, time range, and sections of a report.
+- **report_type**: The template to use (e.g., `weekly_health`, `monthly_review`).
+- **audience**: The target audience level (`executive`, `team_lead`, `developer`).
+- **scope**: Lists of teams, repos, and services to include.
+- **time_range**: Explicit start and end dates for the analysis.
+
+### ChartSpec
+Defines a specific visualization to be included in the report.
+- **chart_type**: The visual representation (`line`, `bar`, `heatmap`, `scorecard`).
+- **metric**: The canonical metric name from the registry.
+- **group_by**: The dimension used for aggregation (e.g., `team`, `week`).
+
+### InsightBlock
+Represents a structured observation derived from data analysis.
+- **insight_type**: The nature of the insight (`trend_delta`, `anomaly`, `regression`).
+- **confidence**: The level of certainty (`direct_fact`, `inferred`, `hypothesis`).
+- **supporting_metrics**: References to the specific data points that back the insight.
+
+### ProvenanceRecord
+Provides an audit trail for every artifact in a report. It tracks the data sources, filters, and time ranges used to generate a specific chart or insight, ensuring transparency and reproducibility.
+
+## Pipeline Stages
+
+### 1. Prompt Parsing
+The `parser.py` module uses regex and keyword matching to extract intent from natural-language prompts.
+- **Intent Extraction**: Identifies the requested report type, audience, and metrics.
+- **Scope Resolution**: Extracts mentions of teams, repositories, and services.
+- **Time Range Parsing**: Handles relative terms (e.g., "last week", "past 30 days") and explicit date ranges.
+
+### 2. Metric & Entity Resolution
+The `resolver.py` module maps parsed terms to canonical system entities.
+- **Metric Mapping**: Uses the `metric_registry.py` to resolve aliases (e.g., "ci success" -> `success_rate`).
+- **Entity Catalog**: Matches team and repo names against the `EntityCatalog` to resolve internal IDs.
+
+### 3. Report Planning
+The `planner.py` module assembles the `ReportPlan` and `ChartSpec` objects.
+- **Template Selection**: Selects a pre-defined template from `templates.py` based on the report type.
+- **Validation**: Ensures that the requested metrics and entities exist and that the time range is valid.
+- **Chart Generation**: Populates chart specifications based on template defaults and user overrides.
+
+### 4. Report Rendering (Planned)
+The rendering engine is currently in the planning phase. It will be responsible for:
+- **Execution**: Querying ClickHouse for the required metric data.
+- **Narrative Generation**: Constructing a grounded narrative based on the `ReportPlan`.
+- **Insight Extraction**: Identifying trends and anomalies to populate `InsightBlock` records.
+
+## Trust Model
+The architecture is built on a foundation of trust and verifiability.
+- **Data Grounding**: Only persisted metric data is used for report generation. Freeform LLM claims are forbidden.
+- **Confidence Labeling**: Every insight is tagged with a confidence level to distinguish between direct facts and inferred patterns.
+- **Provenance**: Every artifact includes a link to its data source and generation parameters.
+- **Language Rules**: The system uses cautious language (*appears*, *suggests*) rather than definitive statements (*is*, *was*) for inferred insights.
+
+## Report Templates
+The system includes several pre-built templates in `templates.py`:
+
+| Template | Purpose | Key Metrics |
+| :--- | :--- | :--- |
+| **Weekly Health** | Team-level weekly summary. | `items_completed`, `cycle_time_p50_hours`, `flake_rate` |
+| **Monthly Review** | Executive-level monthly trend analysis. | `lead_time_p50_hours`, `success_rate`, `line_coverage_pct` |
+| **Quality Trend** | Deep dive into testing and reliability. | `flake_rate`, `failure_rate`, `coverage_regression_count` |
+| **CI Stability** | Infrastructure and pipeline health review. | `success_rate`, `median_duration_seconds`, `avg_queue_seconds` |

--- a/docs/architecture/testops-architecture.md
+++ b/docs/architecture/testops-architecture.md
@@ -1,0 +1,63 @@
+# TestOps Architecture
+
+## Overview
+TestOps extends the Dev Health platform to provide deep visibility into CI/CD pipeline health, test reliability, and code coverage. It enables teams to identify bottlenecks in their delivery process, detect flaky tests before they impact productivity, and track coverage trends across services and repositories.
+
+## Data Pipeline
+
+### Ingestion Layer
+The TestOps ingestion layer fetches raw execution data from CI/CD providers and parses test/coverage artifacts.
+
+- **CI/CD Connectors** (`src/dev_health_ops/connectors/testops/`):
+    - `github_actions.py`: Fetches workflow and job runs from GitHub Actions.
+    - `gitlab_ci.py`: Fetches pipeline and job data from GitLab CI.
+    - `base.py`: Defines the `BasePipelineAdapter` and `PipelineSyncBatch` contracts.
+- **Test Result Processors** (`src/dev_health_ops/processors/testops_tests.py`):
+    - Parses JUnit XML and other test report formats.
+    - Normalizes test suites and cases into canonical models.
+- **Coverage Processors** (`src/dev_health_ops/processors/testops_coverage.py`):
+    - Parses Cobertura, LCOV, and JaCoCo reports.
+    - Aggregates coverage metrics at the snapshot level.
+
+### Storage Layer
+TestOps data is persisted in ClickHouse for high-performance analytics. The schema is defined in `src/dev_health_ops/migrations/clickhouse/029_testops_tables.sql`.
+
+- **Raw Event Tables**:
+    - `ci_pipeline_runs`: Extended with TestOps fields (duration, queue time, trigger source).
+    - `ci_job_runs`: Individual job/stage execution data.
+    - `test_suite_results`: Aggregated suite-level outcomes.
+    - `test_case_results`: Atomic test case outcomes, including failure messages and stack traces.
+    - `coverage_snapshots`: Aggregate and per-file coverage data.
+
+- **Daily Metrics Tables**:
+    - `testops_pipeline_metrics_daily`: Daily rollups of pipeline performance.
+    - `testops_test_metrics_daily`: Daily rollups of test reliability and flakiness.
+    - `testops_coverage_metrics_daily`: Daily rollups of code coverage trends.
+
+### Metrics Layer
+Metrics are computed daily from raw event tables and persisted in the daily metrics tables.
+
+- **Pipeline Health**: Success rates, failure rates, and cancellation rates.
+- **Pipeline Performance**: Median and P95 duration, average and P95 queue time.
+- **Test Reliability**: Pass rates, failure rates, and flake detection.
+- **Flake Detection**: Identified when a test case flips between pass and fail within the same run window or exhibits inconsistent behavior across retries.
+- **Coverage Trends**: Line and branch coverage percentages, coverage deltas, and regression tracking.
+
+### Entity Resolution
+TestOps uses path-based attribution to map test suites and coverage snapshots to services and teams.
+
+- **Service Mapping**: The `attribute_service_from_path` logic in `testops_tests.py` inspects file paths (e.g., `services/auth-service/...`) to attribute work to specific services.
+- **Ownership Attribution**: Services are linked to teams via the platform's central entity catalog, allowing TestOps metrics to roll up to team and organization levels.
+
+## Metric Definitions
+
+| Metric | Definition | Unit | Table | Computation |
+| :--- | :--- | :--- | :--- | :--- |
+| **Success Rate** | Share of pipeline runs that completed successfully. | ratio | `testops_pipeline_metrics_daily` | `success_count / pipelines_count` |
+| **Median Duration** | Median time from pipeline start to finish. | seconds | `testops_pipeline_metrics_daily` | `quantile(0.5)(duration_seconds)` |
+| **P95 Queue Time** | 95th percentile time spent waiting in queue. | seconds | `testops_pipeline_metrics_daily` | `quantile(0.95)(queue_seconds)` |
+| **Flake Rate** | Share of test cases exhibiting inconsistent outcomes. | ratio | `testops_test_metrics_daily` | `flake_count / total_cases` |
+| **Pass Rate** | Share of executed test cases that passed. | ratio | `testops_test_metrics_daily` | `passed_count / total_cases` |
+| **Line Coverage** | Percentage of code lines covered by tests. | percent | `testops_coverage_metrics_daily` | `lines_covered / lines_total` |
+| **Coverage Delta** | Change in coverage percentage from prior day. | percent | `testops_coverage_metrics_daily` | `current_pct - prior_pct` |
+| **Rerun Rate** | Share of pipeline runs that were retries. | ratio | `testops_pipeline_metrics_daily` | `retry_count / pipelines_count` |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -61,6 +61,12 @@ Note: Jira Ops/Service Desk incidents are planned once project-to-repo or deploy
 
 - `team_metrics_daily`
 
+### TestOps (v2)
+
+- `testops_pipeline_metrics_daily` (pipeline health and performance)
+- `testops_test_metrics_daily` (test reliability and flakiness)
+- `testops_coverage_metrics_daily` (code coverage trends)
+
 ## Metric Definitions
 
 ### Commit size bucketing
@@ -360,6 +366,17 @@ Categorizes engineering effort into investment areas (e.g., "New Value", "Securi
   - `delivery_units`: Story points or count of work items completed.
   - `churn_loc`: Sum of additions + deletions associated with the area.
 - **Configuration**: `config/investment_areas.yaml` defines the matching rules and priorities.
+
+## TestOps Metrics
+
+TestOps metrics provide visibility into CI/CD health, test reliability, and coverage.
+
+- **Pipeline Health**: `success_rate`, `failure_rate`, `rerun_rate`.
+- **Pipeline Performance**: `median_duration_seconds`, `avg_queue_seconds`.
+- **Test Reliability**: `pass_rate`, `flake_rate`, `retry_dependency_rate`.
+- **Coverage**: `line_coverage_pct`, `branch_coverage_pct`, `coverage_delta_pct`.
+
+For detailed definitions and computation logic, see `architecture/testops-architecture.md`.
 
 ## Views and interpretations
 

--- a/docs/ops/runbook-ingestion-failures.md
+++ b/docs/ops/runbook-ingestion-failures.md
@@ -1,0 +1,75 @@
+# Runbook: TestOps Ingestion Failures
+
+## Overview
+This runbook provides diagnostic and recovery steps for failures in the TestOps data ingestion pipeline, including CI/CD events, test results, and coverage snapshots.
+
+## Common Failure Modes
+
+### 1. API Rate Limits
+- **Symptoms**: Logs show 403 or 429 status codes from GitHub or GitLab.
+- **Cause**: The ingestion process has exceeded the provider's API rate limit.
+- **Resolution**: Wait for the rate limit to reset. Consider increasing the `per_page` setting or reducing sync frequency.
+
+### 2. Authentication Failures
+- **Symptoms**: `AuthenticationException` in logs; 401 status codes.
+- **Cause**: Expired or invalid `GITHUB_TOKEN` or `GITLAB_TOKEN`.
+- **Resolution**: Verify and update the relevant environment variables.
+
+### 3. Malformed Artifacts
+- **Symptoms**: Errors during JUnit XML or coverage report parsing.
+- **Cause**: Invalid XML structure or unsupported report format.
+- **Resolution**: Inspect the raw artifact from the CI provider. Ensure the test framework is configured to output standard JUnit XML.
+
+### 4. Network Timeouts
+- **Symptoms**: `ConnectTimeout` or `ReadTimeout` errors.
+- **Cause**: Intermittent network issues or slow provider APIs.
+- **Resolution**: The system will automatically retry. If persistent, check the provider's status page.
+
+## Diagnostic Steps
+
+### 1. Check Application Logs
+Search for TestOps-specific errors:
+```bash
+grep -i "testops" /var/log/dev-health-ops.log
+```
+
+### 2. Verify ClickHouse Data
+Check the latest synced records for a specific repository:
+```sql
+SELECT repo_id, max(last_synced) 
+FROM ci_pipeline_runs 
+WHERE repo_id = '...' 
+GROUP BY repo_id;
+```
+
+### 3. Inspect Job Status
+Check for failed jobs in the `ci_job_runs` table:
+```sql
+SELECT job_name, status, started_at 
+FROM ci_job_runs 
+WHERE status = 'failure' 
+ORDER BY started_at DESC 
+LIMIT 10;
+```
+
+## Recovery Procedures
+
+### 1. Manual Sync Trigger
+Trigger a manual sync for the affected provider:
+```bash
+dev-hops sync testops --provider github --owner <org> --repo <repo>
+```
+
+### 2. Data Backfill
+If data is missing for a specific period, use the backfill command:
+```bash
+dev-hops backfill run --since 2024-01-01 --until 2024-01-07 --repo <repo_id>
+```
+
+### 3. Clear Watermarks
+If the sync is stuck due to a bad cursor, you may need to clear the watermark in the metadata store (PostgreSQL) to force a full re-sync of recent data.
+
+## Alert Thresholds
+- **Sync Latency**: Alert if `last_synced` for any active repo is > 4 hours old.
+- **Failure Rate**: Alert if > 10% of ingestion attempts fail over a 1-hour window.
+- **Auth Errors**: Alert immediately on any `AuthenticationException`.

--- a/docs/ops/runbook-report-failures.md
+++ b/docs/ops/runbook-report-failures.md
@@ -1,0 +1,70 @@
+# Runbook: AI Report Generation Failures
+
+## Overview
+This runbook covers diagnostic and recovery steps for failures in the AI Generative Reports pipeline, from prompt parsing to report planning.
+
+## Common Failure Modes
+
+### 1. Invalid Prompt
+- **Symptoms**: `PlanningResult` returns `ok=False` with validation errors.
+- **Cause**: The prompt contains unsupported metrics, unknown entities, or an invalid time range.
+- **Resolution**: Refine the prompt to use canonical metric names or recognized team/repo names.
+
+### 2. Missing Metrics
+- **Symptoms**: Report plan is created, but charts are empty or missing data.
+- **Cause**: The requested metrics have not been computed for the specified time range or scope.
+- **Resolution**: Ensure that the daily metrics rollups (`dev-hops metrics daily`) have completed successfully.
+
+### 3. Empty Data Scope
+- **Symptoms**: Valid plan, but no data found in ClickHouse.
+- **Cause**: The selected teams or repos had no activity during the requested time range.
+- **Resolution**: Expand the time range or check the scope of the report.
+
+### 4. LLM Provider Failures
+- **Symptoms**: Timeouts or errors during prompt parsing or insight generation.
+- **Cause**: Issues with the underlying LLM provider (e.g., Anthropic, OpenAI).
+- **Resolution**: Check the provider's status page. The system will automatically retry transient failures.
+
+## Diagnostic Steps
+
+### 1. Inspect Planning Validation
+Check the `invalid_reasons` field in the `ParsedPrompt` or the `ValidationResult` in the `PlanningResult`.
+- `invalid_time_range`: The start date is after the end date.
+- `unresolved_metrics`: The prompt uses terms that don't map to the registry.
+- `unresolved_entities`: The requested teams or repos were not found in the catalog.
+
+### 2. Verify Metric Availability
+Query ClickHouse to ensure data exists for the requested metric and scope:
+```sql
+SELECT count() 
+FROM testops_pipeline_metrics_daily 
+WHERE repo_id = '...' AND day >= '2024-01-01';
+```
+
+### 3. Check Report Plan Persistence
+Verify that the `ReportPlan` was successfully persisted in the `report_plans` table:
+```sql
+SELECT * FROM report_plans WHERE plan_id = '...';
+```
+
+## Recovery Procedures
+
+### 1. Adjust Prompt
+If the failure is due to an invalid prompt, try a more explicit request:
+- Use "past 7 days" instead of vague time references.
+- Use full repository names (e.g., `org/repo`).
+- Reference metrics from the canonical registry (e.g., "cycle time", "success rate").
+
+### 2. Trigger Metrics Computation
+If metrics are missing, manually trigger the daily rollup:
+```bash
+dev-hops metrics daily --day 2024-04-10
+```
+
+### 3. Re-run Report Request
+Once the underlying data or prompt issues are resolved, re-submit the report request through the API or UI.
+
+## Escalation Paths
+- **Parsing Logic Issues**: Escalate to the Engineering team if the parser consistently fails to recognize valid intents.
+- **Data Discrepancies**: Escalate to the Data Engineering team if persisted metrics do not match expectations.
+- **LLM Reliability**: Escalate to the Platform team if provider timeouts exceed acceptable thresholds.


### PR DESCRIPTION
## Summary
- Documents TestOps architecture: ingestion, storage, metrics layers, entity resolution
- Documents AI report architecture: DSL, pipeline stages, trust model
- Adds operational runbooks for ingestion and report-generation failures

## Linear
CHAOS-1085, CHAOS-1159, CHAOS-1160, CHAOS-1161, CHAOS-1162

SCREENSHOT-WAIVER: Documentation-only changes, no rendered frontend output