### PR TITLE
feat: TestOps risk models — release confidence, quality drag, pipeline stability (CHAOS-1079)

### DIFF
--- a/src/dev_health_ops/metrics/compute_testops_risk.py
+++ b/src/dev_health_ops/metrics/compute_testops_risk.py
@@ -1,0 +1,272 @@
+"""TestOps risk model computations: release confidence, quality drag, pipeline stability."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Sequence
+from datetime import date, datetime
+
+from dev_health_ops.metrics.testops_schemas import (
+    CoverageMetricsDailyRecord,
+    PipelineMetricsDailyRecord,
+    PipelineStabilityRecord,
+    QualityDragRecord,
+    ReleaseConfidenceRecord,
+    TestMetricsDailyRecord,
+)
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, value))
+
+
+def compute_release_confidence(
+    *,
+    day: date,
+    pipeline_metrics: Sequence[PipelineMetricsDailyRecord],
+    test_metrics: Sequence[TestMetricsDailyRecord],
+    coverage_metrics: Sequence[CoverageMetricsDailyRecord],
+    computed_at: datetime,
+) -> list[ReleaseConfidenceRecord]:
+    repo_ids: set[uuid.UUID] = set()
+    pipe_by_repo: dict[uuid.UUID, PipelineMetricsDailyRecord] = {}
+    test_by_repo: dict[uuid.UUID, TestMetricsDailyRecord] = {}
+    cov_by_repo: dict[uuid.UUID, CoverageMetricsDailyRecord] = {}
+
+    for m in pipeline_metrics:
+        pipe_by_repo[m.repo_id] = m
+        repo_ids.add(m.repo_id)
+    for m in test_metrics:
+        test_by_repo[m.repo_id] = m
+        repo_ids.add(m.repo_id)
+    for m in coverage_metrics:
+        cov_by_repo[m.repo_id] = m
+        repo_ids.add(m.repo_id)
+
+    results: list[ReleaseConfidenceRecord] = []
+    for repo_id in sorted(repo_ids, key=str):
+        pipe = pipe_by_repo.get(repo_id)
+        test = test_by_repo.get(repo_id)
+        cov = cov_by_repo.get(repo_id)
+
+        success_rate = pipe.success_rate if pipe else 0.0
+        pass_rate = test.pass_rate if test else 0.0
+        coverage_pct = (cov.line_coverage_pct or 0.0) if cov else 0.0
+        flake_rate = test.flake_rate if test else 0.0
+        failure_recurrence = test.failure_recurrence_score if test else 0.0
+        coverage_delta = (cov.coverage_delta_pct or 0.0) if cov else 0.0
+
+        pipeline_factor = 0.4 * success_rate
+        test_factor = 0.3 * pass_rate
+        cov_factor = 0.2 * _clamp(coverage_pct / 100.0)
+        flake_factor = 0.1 * (1.0 - flake_rate)
+
+        base_score = pipeline_factor + test_factor + cov_factor + flake_factor
+
+        flake_penalty = 0.1 if flake_rate > 0.05 else 0.0
+        regression_penalty = 0.0
+        if coverage_delta < -2.0:
+            regression_penalty += 0.05
+        if failure_recurrence > 0.3:
+            regression_penalty += 0.1
+
+        score = _clamp(base_score - flake_penalty - regression_penalty)
+
+        factors = {
+            "pipeline_success_rate": round(success_rate, 4),
+            "test_pass_rate": round(pass_rate, 4),
+            "coverage_pct": round(coverage_pct, 2),
+            "flake_rate": round(flake_rate, 4),
+            "failure_recurrence": round(failure_recurrence, 4),
+            "coverage_delta_pct": round(coverage_delta, 2),
+            "base_score": round(base_score, 4),
+            "flake_penalty": round(flake_penalty, 4),
+            "regression_penalty": round(regression_penalty, 4),
+        }
+
+        results.append(
+            ReleaseConfidenceRecord(
+                repo_id=repo_id,
+                day=day,
+                confidence_score=round(score, 4),
+                pipeline_success_factor=round(pipeline_factor, 4),
+                test_pass_factor=round(test_factor, 4),
+                coverage_factor=round(cov_factor, 4),
+                flake_penalty=round(flake_penalty, 4),
+                regression_penalty=round(regression_penalty, 4),
+                factors_json=json.dumps(factors),
+                computed_at=computed_at,
+                team_id=pipe.team_id if pipe else (test.team_id if test else None),
+                service_id=pipe.service_id
+                if pipe
+                else (test.service_id if test else None),
+                org_id=(pipe.org_id if pipe else (test.org_id if test else "")),
+            )
+        )
+    return results
+
+
+def compute_quality_drag(
+    *,
+    day: date,
+    pipeline_metrics: Sequence[PipelineMetricsDailyRecord],
+    test_metrics: Sequence[TestMetricsDailyRecord],
+    computed_at: datetime,
+) -> list[QualityDragRecord]:
+    repo_ids: set[uuid.UUID] = set()
+    pipe_by_repo: dict[uuid.UUID, PipelineMetricsDailyRecord] = {}
+    test_by_repo: dict[uuid.UUID, TestMetricsDailyRecord] = {}
+
+    for m in pipeline_metrics:
+        pipe_by_repo[m.repo_id] = m
+        repo_ids.add(m.repo_id)
+    for m in test_metrics:
+        test_by_repo[m.repo_id] = m
+        repo_ids.add(m.repo_id)
+
+    results: list[QualityDragRecord] = []
+    for repo_id in sorted(repo_ids, key=str):
+        pipe = pipe_by_repo.get(repo_id)
+        test = test_by_repo.get(repo_id)
+
+        median_dur = (pipe.median_duration_seconds or 0.0) if pipe else 0.0
+        failure_count = pipe.failure_count if pipe else 0
+        pipelines_count = pipe.pipelines_count if pipe else 0
+        avg_queue = (pipe.avg_queue_seconds or 0.0) if pipe else 0.0
+        rerun_rate = pipe.rerun_rate if pipe else 0.0
+
+        flake_rate = test.flake_rate if test else 0.0
+        total_cases = test.total_cases if test else 0
+
+        failure_rework_hours = failure_count * median_dur / 3600.0
+        flake_investigation_hours = flake_rate * total_cases * 0.25
+        queue_wait_hours = pipelines_count * avg_queue / 3600.0
+        retry_overhead_hours = rerun_rate * pipelines_count * median_dur / 3600.0
+
+        drag_hours = (
+            failure_rework_hours
+            + flake_investigation_hours
+            + queue_wait_hours
+            + retry_overhead_hours
+        )
+
+        factors = {
+            "failure_count": failure_count,
+            "median_duration_seconds": round(median_dur, 2),
+            "pipelines_count": pipelines_count,
+            "avg_queue_seconds": round(avg_queue, 2),
+            "rerun_rate": round(rerun_rate, 4),
+            "flake_rate": round(flake_rate, 4),
+            "total_cases": total_cases,
+        }
+
+        results.append(
+            QualityDragRecord(
+                repo_id=repo_id,
+                day=day,
+                drag_hours=round(drag_hours, 4),
+                failure_rework_hours=round(failure_rework_hours, 4),
+                flake_investigation_hours=round(flake_investigation_hours, 4),
+                queue_wait_hours=round(queue_wait_hours, 4),
+                retry_overhead_hours=round(retry_overhead_hours, 4),
+                factors_json=json.dumps(factors),
+                computed_at=computed_at,
+                team_id=pipe.team_id if pipe else (test.team_id if test else None),
+                service_id=pipe.service_id
+                if pipe
+                else (test.service_id if test else None),
+                org_id=(pipe.org_id if pipe else (test.org_id if test else "")),
+            )
+        )
+    return results
+
+
+def compute_pipeline_stability(
+    *,
+    day: date,
+    pipeline_metrics_7d: Sequence[PipelineMetricsDailyRecord],
+    computed_at: datetime,
+) -> list[PipelineStabilityRecord]:
+    by_repo: dict[uuid.UUID, list[PipelineMetricsDailyRecord]] = {}
+    for m in pipeline_metrics_7d:
+        by_repo.setdefault(m.repo_id, []).append(m)
+
+    results: list[PipelineStabilityRecord] = []
+    for repo_id in sorted(by_repo, key=str):
+        days_data = sorted(by_repo[repo_id], key=lambda m: m.day)
+
+        n = len(days_data)
+        if n == 0:
+            continue
+
+        weights = [1.0 + i * 0.5 for i in range(n)]
+        total_weight = sum(weights)
+        success_rate_7d = (
+            sum(m.success_rate * w for m, w in zip(days_data, weights)) / total_weight
+        )
+
+        if n >= 2:
+            x_mean = (n - 1) / 2.0
+            y_mean = sum(m.success_rate for m in days_data) / n
+            num = sum(
+                (i - x_mean) * (m.success_rate - y_mean)
+                for i, m in enumerate(days_data)
+            )
+            den = sum((i - x_mean) ** 2 for i in range(n))
+            success_rate_trend = num / den if den > 0 else 0.0
+        else:
+            success_rate_trend = 0.0
+
+        consecutive_failures = 0
+        total_failures = 0
+        for i, m in enumerate(days_data):
+            if m.failure_count > 0:
+                total_failures += 1
+                if i > 0 and days_data[i - 1].failure_count > 0:
+                    consecutive_failures += 1
+
+        failure_clustering = (
+            consecutive_failures / max(total_failures, 1) if total_failures > 0 else 0.0
+        )
+
+        durations = [
+            m.median_duration_seconds
+            for m in days_data
+            if m.median_duration_seconds is not None and m.failure_count > 0
+        ]
+        median_recovery = None
+        if durations:
+            sorted_d = sorted(durations)
+            mid = len(sorted_d) // 2
+            median_recovery = (
+                sorted_d[mid]
+                if len(sorted_d) % 2 == 1
+                else (sorted_d[mid - 1] + sorted_d[mid]) / 2.0
+            )
+
+        stability = _clamp(
+            success_rate_7d
+            * (1.0 - failure_clustering)
+            * (1.0 + min(success_rate_trend, 0.1))
+        )
+
+        latest = days_data[-1]
+        results.append(
+            PipelineStabilityRecord(
+                repo_id=repo_id,
+                day=day,
+                stability_index=round(stability, 4),
+                success_rate_7d=round(success_rate_7d, 4),
+                success_rate_trend=round(success_rate_trend, 4),
+                failure_clustering_score=round(failure_clustering, 4),
+                median_recovery_time_seconds=(
+                    round(median_recovery, 2) if median_recovery is not None else None
+                ),
+                computed_at=computed_at,
+                team_id=latest.team_id,
+                service_id=latest.service_id,
+                org_id=latest.org_id,
+            )
+        )
+    return results

--- a/src/dev_health_ops/metrics/sinks/base.py
+++ b/src/dev_health_ops/metrics/sinks/base.py
@@ -44,6 +44,9 @@ from dev_health_ops.metrics.schemas import (
 from dev_health_ops.metrics.testops_schemas import (
     CoverageMetricsDailyRecord,
     PipelineMetricsDailyRecord,
+    PipelineStabilityRecord,
+    QualityDragRecord,
+    ReleaseConfidenceRecord,
     TestMetricsDailyRecord,
 )
 from dev_health_ops.models.work_items import (
@@ -227,6 +230,15 @@ class BaseMetricsSink(ABC):
         self, rows: Sequence[CoverageMetricsDailyRecord]
     ) -> None:
         """Write daily TestOps coverage metrics."""
+
+    def write_release_confidence(self, rows: Sequence[ReleaseConfidenceRecord]) -> None:
+        pass
+
+    def write_quality_drag(self, rows: Sequence[QualityDragRecord]) -> None:
+        pass
+
+    def write_pipeline_stability(self, rows: Sequence[PipelineStabilityRecord]) -> None:
+        pass
 
     # -------------------------------------------------------------------------
     # Complexity / hotspot metrics

--- a/src/dev_health_ops/metrics/sinks/clickhouse.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse.py
@@ -45,6 +45,9 @@ from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 from dev_health_ops.metrics.testops_schemas import (
     CoverageMetricsDailyRecord,
     PipelineMetricsDailyRecord,
+    PipelineStabilityRecord,
+    QualityDragRecord,
+    ReleaseConfidenceRecord,
     TestMetricsDailyRecord,
 )
 from dev_health_ops.models.work_items import (
@@ -823,6 +826,72 @@ class ClickHouseMetricsSink(BaseMetricsSink):
                 "coverage_delta_pct",
                 "uncovered_files_count",
                 "coverage_regression_count",
+                "team_id",
+                "service_id",
+                "org_id",
+                "computed_at",
+            ],
+            rows,
+        )
+
+    def write_release_confidence(self, rows: Sequence[ReleaseConfidenceRecord]) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "testops_release_confidence",
+            [
+                "repo_id",
+                "day",
+                "confidence_score",
+                "pipeline_success_factor",
+                "test_pass_factor",
+                "coverage_factor",
+                "flake_penalty",
+                "regression_penalty",
+                "factors_json",
+                "team_id",
+                "service_id",
+                "org_id",
+                "computed_at",
+            ],
+            rows,
+        )
+
+    def write_quality_drag(self, rows: Sequence[QualityDragRecord]) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "testops_quality_drag",
+            [
+                "repo_id",
+                "day",
+                "drag_hours",
+                "failure_rework_hours",
+                "flake_investigation_hours",
+                "queue_wait_hours",
+                "retry_overhead_hours",
+                "factors_json",
+                "team_id",
+                "service_id",
+                "org_id",
+                "computed_at",
+            ],
+            rows,
+        )
+
+    def write_pipeline_stability(self, rows: Sequence[PipelineStabilityRecord]) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "testops_pipeline_stability",
+            [
+                "repo_id",
+                "day",
+                "stability_index",
+                "success_rate_7d",
+                "success_rate_trend",
+                "failure_clustering_score",
+                "median_recovery_time_seconds",
                 "team_id",
                 "service_id",
                 "org_id",

--- a/src/dev_health_ops/metrics/testops_schemas.py
+++ b/src/dev_health_ops/metrics/testops_schemas.py
@@ -353,3 +353,62 @@ class CoverageMetricsDailyRecord:
     team_id: str | None = None
     service_id: str | None = None
     org_id: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Risk Model Records (CHAOS-1079)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReleaseConfidenceRecord:
+    """Composite release confidence score combining pipeline, test, and coverage signals."""
+
+    repo_id: uuid.UUID
+    day: date
+    confidence_score: float  # 0.0-1.0
+    pipeline_success_factor: float
+    test_pass_factor: float
+    coverage_factor: float
+    flake_penalty: float
+    regression_penalty: float
+    factors_json: str  # JSON explainability payload
+    computed_at: datetime
+    team_id: str | None = None
+    service_id: str | None = None
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
+class QualityDragRecord:
+    """Estimated hours wasted due to CI/test quality issues."""
+
+    repo_id: uuid.UUID
+    day: date
+    drag_hours: float
+    failure_rework_hours: float
+    flake_investigation_hours: float
+    queue_wait_hours: float
+    retry_overhead_hours: float
+    factors_json: str
+    computed_at: datetime
+    team_id: str | None = None
+    service_id: str | None = None
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
+class PipelineStabilityRecord:
+    """Rolling pipeline stability index with trend analysis."""
+
+    repo_id: uuid.UUID
+    day: date
+    stability_index: float  # 0.0-1.0 (1.0 = perfectly stable)
+    success_rate_7d: float
+    success_rate_trend: float  # positive = improving
+    failure_clustering_score: float  # 0=random, 1=clustered
+    median_recovery_time_seconds: float | None
+    computed_at: datetime
+    team_id: str | None = None
+    service_id: str | None = None
+    org_id: str = ""

--- a/src/dev_health_ops/migrations/clickhouse/030_testops_risk_tables.sql
+++ b/src/dev_health_ops/migrations/clickhouse/030_testops_risk_tables.sql
@@ -1,0 +1,52 @@
+-- TestOps risk model tables (CHAOS-1079).
+
+CREATE TABLE IF NOT EXISTS testops_release_confidence (
+    repo_id UUID,
+    day Date,
+    confidence_score Float64,
+    pipeline_success_factor Float64,
+    test_pass_factor Float64,
+    coverage_factor Float64,
+    flake_penalty Float64,
+    regression_penalty Float64,
+    factors_json String DEFAULT '{}',
+    team_id Nullable(String),
+    service_id Nullable(String),
+    org_id LowCardinality(String) DEFAULT '',
+    computed_at DateTime('UTC')
+) ENGINE MergeTree
+PARTITION BY toYYYYMM(day)
+ORDER BY (repo_id, day);
+
+CREATE TABLE IF NOT EXISTS testops_quality_drag (
+    repo_id UUID,
+    day Date,
+    drag_hours Float64,
+    failure_rework_hours Float64,
+    flake_investigation_hours Float64,
+    queue_wait_hours Float64,
+    retry_overhead_hours Float64,
+    factors_json String DEFAULT '{}',
+    team_id Nullable(String),
+    service_id Nullable(String),
+    org_id LowCardinality(String) DEFAULT '',
+    computed_at DateTime('UTC')
+) ENGINE MergeTree
+PARTITION BY toYYYYMM(day)
+ORDER BY (repo_id, day);
+
+CREATE TABLE IF NOT EXISTS testops_pipeline_stability (
+    repo_id UUID,
+    day Date,
+    stability_index Float64,
+    success_rate_7d Float64,
+    success_rate_trend Float64,
+    failure_clustering_score Float64,
+    median_recovery_time_seconds Nullable(Float64),
+    team_id Nullable(String),
+    service_id Nullable(String),
+    org_id LowCardinality(String) DEFAULT '',
+    computed_at DateTime('UTC')
+) ENGINE MergeTree
+PARTITION BY toYYYYMM(day)
+ORDER BY (repo_id, day);

--- a/tests/metrics/test_compute_testops_risk.py
+++ b/tests/metrics/test_compute_testops_risk.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import date, datetime, timezone
+
+from dev_health_ops.metrics.compute_testops_risk import (
+    compute_pipeline_stability,
+    compute_quality_drag,
+    compute_release_confidence,
+)
+from dev_health_ops.metrics.testops_schemas import (
+    CoverageMetricsDailyRecord,
+    PipelineMetricsDailyRecord,
+    TestMetricsDailyRecord,
+)
+
+REPO_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+DAY = date(2025, 4, 10)
+NOW = datetime(2025, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _pipe(
+    repo_id: uuid.UUID = REPO_A,
+    day: date = DAY,
+    success_rate: float = 0.9,
+    failure_count: int = 2,
+    pipelines_count: int = 20,
+    median_duration_seconds: float = 300.0,
+    avg_queue_seconds: float = 30.0,
+    rerun_rate: float = 0.1,
+) -> PipelineMetricsDailyRecord:
+    return PipelineMetricsDailyRecord(
+        repo_id=repo_id,
+        day=day,
+        pipelines_count=pipelines_count,
+        success_count=int(pipelines_count * success_rate),
+        failure_count=failure_count,
+        cancelled_count=0,
+        success_rate=success_rate,
+        failure_rate=1 - success_rate,
+        cancel_rate=0.0,
+        rerun_rate=rerun_rate,
+        median_duration_seconds=median_duration_seconds,
+        p95_duration_seconds=600.0,
+        avg_queue_seconds=avg_queue_seconds,
+        p95_queue_seconds=60.0,
+        computed_at=NOW,
+    )
+
+
+def _test(
+    repo_id: uuid.UUID = REPO_A,
+    day: date = DAY,
+    pass_rate: float = 0.95,
+    flake_rate: float = 0.02,
+    total_cases: int = 100,
+    failure_recurrence_score: float = 0.1,
+) -> TestMetricsDailyRecord:
+    return TestMetricsDailyRecord(
+        repo_id=repo_id,
+        day=day,
+        total_cases=total_cases,
+        passed_count=int(total_cases * pass_rate),
+        failed_count=int(total_cases * (1 - pass_rate)),
+        skipped_count=0,
+        quarantined_count=0,
+        pass_rate=pass_rate,
+        failure_rate=1 - pass_rate,
+        flake_rate=flake_rate,
+        retry_dependency_rate=0.0,
+        total_suites=5,
+        suite_duration_p50_seconds=60.0,
+        suite_duration_p95_seconds=120.0,
+        failure_recurrence_score=failure_recurrence_score,
+        computed_at=NOW,
+    )
+
+
+def _cov(
+    repo_id: uuid.UUID = REPO_A,
+    day: date = DAY,
+    line_coverage_pct: float = 80.0,
+    coverage_delta_pct: float = 0.5,
+) -> CoverageMetricsDailyRecord:
+    return CoverageMetricsDailyRecord(
+        repo_id=repo_id,
+        day=day,
+        line_coverage_pct=line_coverage_pct,
+        branch_coverage_pct=70.0,
+        lines_total=10000,
+        lines_covered=8000,
+        coverage_delta_pct=coverage_delta_pct,
+        uncovered_files_count=0,
+        coverage_regression_count=0,
+        computed_at=NOW,
+    )
+
+
+def test_release_confidence_healthy_repo():
+    results = compute_release_confidence(
+        day=DAY,
+        pipeline_metrics=[_pipe(success_rate=0.95)],
+        test_metrics=[_test(pass_rate=0.98, flake_rate=0.01)],
+        coverage_metrics=[_cov(line_coverage_pct=85.0)],
+        computed_at=NOW,
+    )
+    assert len(results) == 1
+    r = results[0]
+    assert r.confidence_score > 0.8
+    assert r.flake_penalty == 0.0
+    assert r.regression_penalty == 0.0
+    factors = json.loads(r.factors_json)
+    assert "pipeline_success_rate" in factors
+
+
+def test_release_confidence_with_penalties():
+    results = compute_release_confidence(
+        day=DAY,
+        pipeline_metrics=[_pipe(success_rate=0.7)],
+        test_metrics=[
+            _test(pass_rate=0.8, flake_rate=0.1, failure_recurrence_score=0.5)
+        ],
+        coverage_metrics=[_cov(line_coverage_pct=50.0, coverage_delta_pct=-5.0)],
+        computed_at=NOW,
+    )
+    r = results[0]
+    assert r.flake_penalty == 0.1
+    assert r.regression_penalty == 0.15
+    assert r.confidence_score < 0.7
+
+
+def test_release_confidence_empty_inputs():
+    results = compute_release_confidence(
+        day=DAY,
+        pipeline_metrics=[],
+        test_metrics=[],
+        coverage_metrics=[],
+        computed_at=NOW,
+    )
+    assert results == []
+
+
+def test_quality_drag_computation():
+    results = compute_quality_drag(
+        day=DAY,
+        pipeline_metrics=[
+            _pipe(
+                failure_count=5,
+                pipelines_count=20,
+                median_duration_seconds=600,
+                avg_queue_seconds=60,
+                rerun_rate=0.15,
+            )
+        ],
+        test_metrics=[_test(flake_rate=0.04, total_cases=200)],
+        computed_at=NOW,
+    )
+    assert len(results) == 1
+    r = results[0]
+    assert r.failure_rework_hours > 0
+    assert r.flake_investigation_hours > 0
+    assert r.queue_wait_hours > 0
+    assert r.retry_overhead_hours > 0
+    expected_sum = (
+        r.failure_rework_hours
+        + r.flake_investigation_hours
+        + r.queue_wait_hours
+        + r.retry_overhead_hours
+    )
+    assert abs(r.drag_hours - expected_sum) < 0.01
+
+
+def test_quality_drag_zero_failures():
+    results = compute_quality_drag(
+        day=DAY,
+        pipeline_metrics=[
+            _pipe(failure_count=0, rerun_rate=0.0, avg_queue_seconds=0.0)
+        ],
+        test_metrics=[_test(flake_rate=0.0, total_cases=100)],
+        computed_at=NOW,
+    )
+    r = results[0]
+    assert r.drag_hours == 0.0
+
+
+def test_pipeline_stability_improving_trend():
+    metrics_7d = [
+        _pipe(day=date(2025, 4, d), success_rate=0.8 + d * 0.02, failure_count=0)
+        for d in range(4, 11)
+    ]
+    results = compute_pipeline_stability(
+        day=DAY, pipeline_metrics_7d=metrics_7d, computed_at=NOW
+    )
+    assert len(results) == 1
+    r = results[0]
+    assert r.success_rate_trend > 0
+    assert r.stability_index > 0.5
+
+
+def test_pipeline_stability_single_day():
+    results = compute_pipeline_stability(
+        day=DAY,
+        pipeline_metrics_7d=[_pipe(success_rate=1.0, failure_count=0)],
+        computed_at=NOW,
+    )
+    assert len(results) == 1
+    r = results[0]
+    assert r.success_rate_trend == 0.0
+    assert r.stability_index > 0.9
+
+
+def test_pipeline_stability_all_failures():
+    metrics_7d = [
+        _pipe(day=date(2025, 4, d), success_rate=0.0, failure_count=20)
+        for d in range(4, 11)
+    ]
+    results = compute_pipeline_stability(
+        day=DAY, pipeline_metrics_7d=metrics_7d, computed_at=NOW
+    )
+    r = results[0]
+    assert r.stability_index == 0.0
+    assert r.failure_clustering_score > 0


### PR DESCRIPTION
## Summary
- Adds release confidence scoring (composite of pipeline success, test pass rate, coverage, flake rate with penalties)
- Adds quality drag estimation (hours wasted on failure rework, flake investigation, queue wait, retry overhead)
- Adds pipeline stability index (weighted 7d average, trend analysis, failure clustering)
- ClickHouse migration for 3 risk model tables
- 8 unit tests passing

## Linear
CHAOS-1079, CHAOS-1122, CHAOS-1123, CHAOS-1124, CHAOS-1125

SCREENSHOT-WAIVER: Backend-only compute and storage changes, no rendered frontend output