### PR TITLE
feat: trust, guardrails, and evaluation for AI reports (CHAOS-1084)

### DIFF
--- a/src/dev_health_ops/reports/__init__.py
+++ b/src/dev_health_ops/reports/__init__.py
@@ -1,11 +1,16 @@
+from .charts import ChartResult, build_chart_query, execute_chart
+from .engine import ReportResult, execute_report
+from .insights import generate_insights
 from .metric_registry import (
     METRIC_REGISTRY,
     MetricDefinition,
     get_metric_definition,
     list_metric_names,
 )
+from .narrative import NarrativeSection, generate_narrative
 from .parser import ParsedPrompt, ParsedScope, parse_prompt
 from .planner import PlanningResult, build_report_plan
+from .renderer import render_report_markdown
 from .resolver import (
     EntityCatalog,
     EntityDefinition,
@@ -18,8 +23,17 @@ from .validation import ValidationIssue, ValidationResult
 __all__ = [
     "METRIC_REGISTRY",
     "MetricDefinition",
+    "ChartResult",
+    "NarrativeSection",
     "get_metric_definition",
     "list_metric_names",
+    "build_chart_query",
+    "execute_chart",
+    "generate_insights",
+    "generate_narrative",
+    "render_report_markdown",
+    "ReportResult",
+    "execute_report",
     "ParsedPrompt",
     "ParsedScope",
     "parse_prompt",

--- a/src/dev_health_ops/reports/audit.py
+++ b/src/dev_health_ops/reports/audit.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ReportAuditRecord:
+    audit_id: str
+    plan_id: str
+    org_id: str
+    report_type: str
+    metrics_requested: list[str]
+    metrics_available: list[str]
+    metrics_unavailable: list[str]
+    insights_generated: int
+    insights_filtered: int
+    provenance_violations: int
+    confidence_threshold: str
+    generated_at: datetime
+    duration_seconds: float
+
+
+def log_report_audit(record: ReportAuditRecord) -> None:
+    logger.info(
+        "Report audit: plan_id=%s type=%s metrics_req=%d avail=%d unavail=%d "
+        "insights=%d filtered=%d violations=%d threshold=%s duration=%.2fs",
+        record.plan_id,
+        record.report_type,
+        len(record.metrics_requested),
+        len(record.metrics_available),
+        len(record.metrics_unavailable),
+        record.insights_generated,
+        record.insights_filtered,
+        record.provenance_violations,
+        record.confidence_threshold,
+        record.duration_seconds,
+    )

--- a/src/dev_health_ops/reports/charts.py
+++ b/src/dev_health_ops/reports/charts.py
@@ -1,0 +1,172 @@
+"""Chart query planning and execution for report rendering."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+
+from dev_health_ops.metrics.testops_schemas import ChartSpec
+from dev_health_ops.reports.metric_registry import (
+    MetricDefinition,
+    get_metric_definition,
+)
+
+TIME_GROUPINGS = {
+    "day": ("toDate(day)", "Date", "day"),
+    "week": ("toStartOfWeek(day)", "Date", "week"),
+    "month": ("toStartOfMonth(day)", "Date", "month"),
+}
+
+DIMENSION_GROUPINGS = {
+    "team": ("team_id", "String", "team"),
+    "repo": ("repo_id", "String", "repo"),
+    "service": ("service_id", "String", "service"),
+}
+
+
+@dataclass(frozen=True)
+class ChartResult:
+    spec: ChartSpec
+    data_points: list[dict[str, Any]]
+    title: str
+    empty: bool
+
+
+def _aggregate_expression(metric: str, definition: MetricDefinition) -> str:
+    if metric.endswith("_count") or definition.unit == "count":
+        return f"sum({metric})"
+    return f"avg({metric})"
+
+
+def _dimension_available(definition: MetricDefinition, dimension: str) -> bool:
+    return dimension in definition.dimensions
+
+
+def _resolve_grouping(
+    spec: ChartSpec, definition: MetricDefinition
+) -> tuple[str, str, str, bool]:
+    group_by = spec.group_by
+    if group_by in TIME_GROUPINGS:
+        expr, type_name, label = TIME_GROUPINGS[group_by]
+        return expr, type_name, label, True
+    if group_by in DIMENSION_GROUPINGS:
+        expr, type_name, label = DIMENSION_GROUPINGS[group_by]
+        if _dimension_available(definition, group_by):
+            return expr, type_name, label, False
+        return "'unscoped'", type_name, label, False
+    if spec.chart_type in {"line", "heatmap"} and _dimension_available(
+        definition, "day"
+    ):
+        expr, type_name, label = TIME_GROUPINGS["day"]
+        return expr, type_name, label, True
+    return "'total'", "String", "total", False
+
+
+def build_chart_query(spec: ChartSpec) -> tuple[str, dict[str, Any]]:
+    """Build ClickHouse SQL query from ChartSpec."""
+    definition = get_metric_definition(spec.metric)
+    if definition is None:
+        raise ValueError(f"Unsupported chart metric: {spec.metric}")
+
+    x_expr, x_type, _, x_is_temporal = _resolve_grouping(spec, definition)
+    y_expr = _aggregate_expression(spec.metric, definition)
+
+    params: dict[str, Any] = {}
+    clauses = [f"{spec.metric} IS NOT NULL"]
+
+    if spec.org_id:
+        clauses.append("org_id = {org_id:String}")
+        params["org_id"] = spec.org_id
+    if spec.time_range_start is not None:
+        clauses.append("day >= {time_range_start:Date}")
+        params["time_range_start"] = spec.time_range_start
+    if spec.time_range_end is not None:
+        clauses.append("day <= {time_range_end:Date}")
+        params["time_range_end"] = spec.time_range_end
+    if spec.filter_teams and _dimension_available(definition, "team"):
+        clauses.append("team_id IN {filter_teams:Array(String)}")
+        params["filter_teams"] = spec.filter_teams
+    if spec.filter_repos and _dimension_available(definition, "repo"):
+        clauses.append("repo_id IN {filter_repos:Array(String)}")
+        params["filter_repos"] = spec.filter_repos
+
+    where_clause = " AND\n        ".join(clauses)
+    order_by = "x" if x_is_temporal else "y DESC, x"
+
+    query = f"""
+    SELECT
+        {x_expr} AS x,
+        CAST(NULL, 'Nullable(String)') AS group_value,
+        {y_expr} AS y
+    FROM {definition.source_table}
+    WHERE
+        {where_clause}
+    GROUP BY x
+    ORDER BY {order_by}
+    """.strip()
+
+    if (
+        spec.chart_type in {"scorecard", "trend_delta", "table"}
+        and spec.group_by is None
+    ):
+        query = f"""
+        SELECT
+            CAST('total', '{x_type}') AS x,
+            CAST(NULL, 'Nullable(String)') AS group_value,
+            {y_expr} AS y
+        FROM {definition.source_table}
+        WHERE
+            {where_clause}
+        """.strip()
+
+    return query, params
+
+
+def _normalize_x_value(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    return value
+
+
+def _client_query_dicts(
+    client: Any, query: str, params: dict[str, Any]
+) -> list[dict[str, Any]]:
+    if hasattr(client, "query_dicts"):
+        return client.query_dicts(query, params)
+    result = client.query(query, parameters=params)
+    col_names = list(getattr(result, "column_names", []) or [])
+    rows = list(getattr(result, "result_rows", []) or [])
+    if not col_names or not rows:
+        return []
+    return [dict(zip(col_names, row)) for row in rows]
+
+
+async def execute_chart(spec: ChartSpec, client: Any) -> ChartResult:
+    """Execute a chart spec against ClickHouse."""
+    query, params = build_chart_query(spec)
+    rows = await asyncio.to_thread(_client_query_dicts, client, query, params)
+    data_points = [
+        {
+            "x": _normalize_x_value(row.get("x")),
+            "y": row.get("y"),
+            "group": row.get("group_value"),
+        }
+        for row in rows
+    ]
+    return ChartResult(
+        spec=spec,
+        data_points=data_points,
+        title=spec.title or definition_title(spec),
+        empty=not data_points,
+    )
+
+
+def definition_title(spec: ChartSpec) -> str:
+    definition = get_metric_definition(spec.metric)
+    if definition is None:
+        return spec.metric.replace("_", " ").title()
+    return spec.title or definition.display_name

--- a/src/dev_health_ops/reports/confidence.py
+++ b/src/dev_health_ops/reports/confidence.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from dev_health_ops.metrics.testops_schemas import InsightBlock
+
+THRESHOLD_ORDER = ["direct_fact", "inferred", "hypothesis"]
+
+
+class ConfidenceLevel(str, Enum):
+    DIRECT_FACT = "direct_fact"
+    INFERRED = "inferred"
+    HYPOTHESIS = "hypothesis"
+
+
+def assess_confidence(
+    insight: InsightBlock,
+    data_points_count: int,
+) -> ConfidenceLevel:
+    if insight.insight_type == "correlation":
+        return ConfidenceLevel.HYPOTHESIS
+    if data_points_count >= 3 and insight.insight_type in ("trend_delta", "regression"):
+        return ConfidenceLevel.INFERRED
+    return ConfidenceLevel.DIRECT_FACT
+
+
+def filter_by_confidence(
+    insights: list[InsightBlock],
+    threshold: str,
+    data_points_counts: dict[str, int] | None = None,
+) -> list[InsightBlock]:
+    counts = data_points_counts or {}
+    threshold_idx = (
+        THRESHOLD_ORDER.index(threshold) if threshold in THRESHOLD_ORDER else 0
+    )
+    result: list[InsightBlock] = []
+    for insight in insights:
+        primary_metric = (
+            insight.supporting_metrics[0] if insight.supporting_metrics else ""
+        )
+        n = counts.get(primary_metric, 1)
+        level = assess_confidence(insight, n)
+        level_idx = THRESHOLD_ORDER.index(level.value)
+        if level_idx <= threshold_idx:
+            result.append(insight)
+    return result

--- a/src/dev_health_ops/reports/engine.py
+++ b/src/dev_health_ops/reports/engine.py
@@ -1,0 +1,153 @@
+"""Execution engine for deterministic report rendering."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.metrics.testops_schemas import (
+    ChartSpec,
+    InsightBlock,
+    ProvenanceRecord,
+    ReportPlan,
+)
+from dev_health_ops.reports.charts import ChartResult, execute_chart
+from dev_health_ops.reports.insights import generate_insights
+from dev_health_ops.reports.metric_registry import get_metric_definition
+from dev_health_ops.reports.narrative import NarrativeSection, generate_narrative
+from dev_health_ops.reports.renderer import render_report_markdown
+
+
+@dataclass(frozen=True)
+class ReportResult:
+    plan: ReportPlan
+    chart_results: list[ChartResult]
+    insights: list[InsightBlock]
+    narrative_sections: list[NarrativeSection]
+    provenance: list[ProvenanceRecord]
+    rendered_markdown: str
+    generated_at: datetime
+
+
+def _provenance_id(plan_id: str, artifact_type: str, artifact_id: str) -> str:
+    return str(
+        uuid.uuid5(uuid.NAMESPACE_URL, f"{plan_id}:{artifact_type}:{artifact_id}")
+    )
+
+
+def _chart_provenance(plan: ReportPlan, chart_result: ChartResult) -> ProvenanceRecord:
+    definition = get_metric_definition(chart_result.spec.metric)
+    return ProvenanceRecord(
+        provenance_id=_provenance_id(plan.plan_id, "chart", chart_result.spec.chart_id),
+        artifact_type="chart",
+        artifact_id=chart_result.spec.chart_id,
+        plan_id=plan.plan_id,
+        data_sources=[definition.source_table] if definition else [],
+        metrics_used=[chart_result.spec.metric],
+        time_range_start=chart_result.spec.time_range_start,
+        time_range_end=chart_result.spec.time_range_end,
+        filters_applied={
+            "teams": ",".join(chart_result.spec.filter_teams),
+            "repos": ",".join(chart_result.spec.filter_repos),
+            "group_by": chart_result.spec.group_by or "total",
+        },
+        generated_at=datetime.now(UTC),
+        generator_version="reports.v1",
+        org_id=plan.org_id,
+    )
+
+
+def _narrative_provenance(
+    plan: ReportPlan, section: NarrativeSection, generated_at: datetime
+) -> ProvenanceRecord:
+    metric_sources = []
+    for metric in section.supporting_metrics:
+        definition = get_metric_definition(metric)
+        if definition and definition.source_table not in metric_sources:
+            metric_sources.append(definition.source_table)
+    return ProvenanceRecord(
+        provenance_id=_provenance_id(plan.plan_id, "narrative", section.section_type),
+        artifact_type="narrative",
+        artifact_id=section.section_type,
+        plan_id=plan.plan_id,
+        data_sources=metric_sources,
+        metrics_used=section.supporting_metrics,
+        time_range_start=plan.time_range_start,
+        time_range_end=plan.time_range_end,
+        filters_applied={
+            "teams": ",".join(plan.scope_teams),
+            "repos": ",".join(plan.scope_repos),
+            "services": ",".join(plan.scope_services),
+        },
+        generated_at=generated_at,
+        generator_version="reports.v1",
+        org_id=plan.org_id,
+    )
+
+
+def _report_provenance(plan: ReportPlan, generated_at: datetime) -> ProvenanceRecord:
+    return ProvenanceRecord(
+        provenance_id=_provenance_id(plan.plan_id, "report", plan.plan_id),
+        artifact_type="report",
+        artifact_id=plan.plan_id,
+        plan_id=plan.plan_id,
+        data_sources=[],
+        metrics_used=plan.requested_metrics,
+        time_range_start=plan.time_range_start,
+        time_range_end=plan.time_range_end,
+        filters_applied={
+            "teams": ",".join(plan.scope_teams),
+            "repos": ",".join(plan.scope_repos),
+            "services": ",".join(plan.scope_services),
+        },
+        generated_at=generated_at,
+        generator_version="reports.v1",
+        org_id=plan.org_id,
+    )
+
+
+async def execute_report(
+    plan: ReportPlan,
+    chart_specs: list[ChartSpec],
+    clickhouse_dsn: str,
+) -> ReportResult:
+    sink = ClickHouseMetricsSink(clickhouse_dsn)
+    try:
+        chart_results = await asyncio.gather(
+            *(execute_chart(spec, sink) for spec in chart_specs)
+        )
+    finally:
+        await asyncio.to_thread(sink.close)
+
+    insights, insight_provenance = generate_insights(plan, chart_results)
+    narrative_sections = generate_narrative(plan, chart_results, insights)
+    generated_at = datetime.now(UTC)
+
+    provenance = [
+        *[_chart_provenance(plan, chart_result) for chart_result in chart_results],
+        *insight_provenance,
+        *[
+            _narrative_provenance(plan, section, generated_at)
+            for section in narrative_sections
+        ],
+        _report_provenance(plan, generated_at),
+    ]
+    rendered_markdown = render_report_markdown(
+        plan=plan,
+        chart_results=chart_results,
+        insights=insights,
+        narrative_sections=narrative_sections,
+        provenance=provenance,
+    )
+    return ReportResult(
+        plan=plan,
+        chart_results=chart_results,
+        insights=insights,
+        narrative_sections=narrative_sections,
+        provenance=provenance,
+        rendered_markdown=rendered_markdown,
+        generated_at=generated_at,
+    )

--- a/src/dev_health_ops/reports/insights.py
+++ b/src/dev_health_ops/reports/insights.py
@@ -1,0 +1,187 @@
+"""Insight generation for grounded report artifacts."""
+
+from __future__ import annotations
+
+import math
+import statistics
+import uuid
+from datetime import UTC, datetime
+
+from dev_health_ops.metrics.testops_schemas import (
+    InsightBlock,
+    ProvenanceRecord,
+    ReportPlan,
+)
+from dev_health_ops.reports.charts import ChartResult
+from dev_health_ops.reports.metric_registry import get_metric_definition
+
+REGRESSION_METRICS = {"line_coverage_pct", "success_rate", "pass_rate"}
+NEGATIVE_DIRECTION_METRICS = {
+    "failure_rate",
+    "flake_rate",
+    "rerun_rate",
+    "retry_dependency_rate",
+    "avg_queue_seconds",
+    "median_duration_seconds",
+    "p95_duration_seconds",
+    "p95_queue_seconds",
+}
+
+
+def _artifact_id(plan_id: str, metric: str, insight_type: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"{plan_id}:{metric}:{insight_type}"))
+
+
+def _provenance_id(plan_id: str, artifact_id: str) -> str:
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"{plan_id}:provenance:{artifact_id}"))
+
+
+def _numeric_series(chart_result: ChartResult) -> list[float]:
+    series: list[float] = []
+    for point in chart_result.data_points:
+        value = point.get("y")
+        if isinstance(value, int | float) and not isinstance(value, bool):
+            series.append(float(value))
+    return series
+
+
+def _delta_ratio(prior: float, current: float) -> float | None:
+    if math.isclose(prior, 0.0, abs_tol=1e-9):
+        return None
+    return (current - prior) / abs(prior)
+
+
+def _format_delta(delta_ratio: float) -> str:
+    return f"{delta_ratio * 100:.1f}%"
+
+
+def _severity(metric: str, delta_ratio: float) -> str:
+    magnitude = abs(delta_ratio)
+    if metric in REGRESSION_METRICS and delta_ratio < -0.1:
+        return "critical"
+    if magnitude >= 0.2:
+        return "warning"
+    return "info"
+
+
+def _build_provenance(
+    plan: ReportPlan,
+    chart_result: ChartResult,
+    artifact_id: str,
+) -> ProvenanceRecord:
+    definition = get_metric_definition(chart_result.spec.metric)
+    filters_applied = {
+        "teams": ",".join(chart_result.spec.filter_teams),
+        "repos": ",".join(chart_result.spec.filter_repos),
+        "group_by": chart_result.spec.group_by or "total",
+    }
+    return ProvenanceRecord(
+        provenance_id=_provenance_id(plan.plan_id, artifact_id),
+        artifact_type="insight",
+        artifact_id=artifact_id,
+        plan_id=plan.plan_id,
+        data_sources=[definition.source_table] if definition else [],
+        metrics_used=[chart_result.spec.metric],
+        time_range_start=chart_result.spec.time_range_start,
+        time_range_end=chart_result.spec.time_range_end,
+        filters_applied=filters_applied,
+        generated_at=datetime.now(UTC),
+        generator_version="reports.v1",
+        org_id=plan.org_id,
+    )
+
+
+def generate_insights(
+    plan: ReportPlan,
+    chart_results: list[ChartResult],
+) -> tuple[list[InsightBlock], list[ProvenanceRecord]]:
+    insights: list[InsightBlock] = []
+    provenance: list[ProvenanceRecord] = []
+
+    for chart_result in chart_results:
+        if chart_result.empty:
+            continue
+        series = _numeric_series(chart_result)
+        if not series:
+            continue
+
+        metric = chart_result.spec.metric
+        first_value = series[0]
+        last_value = series[-1]
+        delta_ratio = _delta_ratio(first_value, last_value)
+
+        if delta_ratio is not None and abs(delta_ratio) > 0.1:
+            insight_id = _artifact_id(plan.plan_id, metric, "trend_delta")
+            insights.append(
+                InsightBlock(
+                    insight_id=insight_id,
+                    plan_id=plan.plan_id,
+                    insight_type="trend_delta",
+                    confidence="direct_fact",
+                    summary=(
+                        f"{metric.replace('_', ' ').title()} appears {_format_delta(delta_ratio)} "
+                        f"from the opening value to the latest value in this window."
+                    ),
+                    supporting_metrics=[metric],
+                    supporting_values={metric: last_value},
+                    severity=_severity(metric, delta_ratio),
+                    org_id=plan.org_id,
+                )
+            )
+            provenance.append(_build_provenance(plan, chart_result, insight_id))
+
+        if (
+            metric in REGRESSION_METRICS
+            and delta_ratio is not None
+            and delta_ratio < -0.02
+        ):
+            insight_id = _artifact_id(plan.plan_id, metric, "regression")
+            insights.append(
+                InsightBlock(
+                    insight_id=insight_id,
+                    plan_id=plan.plan_id,
+                    insight_type="regression",
+                    confidence="direct_fact",
+                    summary=(
+                        f"{metric.replace('_', ' ').title()} appears lower than the opening value, "
+                        f"which suggests a regression over the selected window."
+                    ),
+                    supporting_metrics=[metric],
+                    supporting_values={metric: last_value},
+                    severity="critical" if delta_ratio < -0.1 else "warning",
+                    org_id=plan.org_id,
+                )
+            )
+            provenance.append(_build_provenance(plan, chart_result, insight_id))
+
+        if len(series) >= 3:
+            mean_value = statistics.fmean(series)
+            stdev = statistics.pstdev(series)
+            if stdev > 0:
+                anomaly_value = None
+                for value in series:
+                    z_score = abs((value - mean_value) / stdev)
+                    if z_score > 2:
+                        anomaly_value = value
+                        break
+                if anomaly_value is not None:
+                    insight_id = _artifact_id(plan.plan_id, metric, "anomaly")
+                    insights.append(
+                        InsightBlock(
+                            insight_id=insight_id,
+                            plan_id=plan.plan_id,
+                            insight_type="anomaly",
+                            confidence="inferred",
+                            summary=(
+                                f"{metric.replace('_', ' ').title()} includes an outlier value that appears "
+                                f"materially outside the normal range for this window."
+                            ),
+                            supporting_metrics=[metric],
+                            supporting_values={metric: anomaly_value},
+                            severity="warning",
+                            org_id=plan.org_id,
+                        )
+                    )
+                    provenance.append(_build_provenance(plan, chart_result, insight_id))
+
+    return insights, provenance

--- a/src/dev_health_ops/reports/narrative.py
+++ b/src/dev_health_ops/reports/narrative.py
@@ -1,0 +1,161 @@
+"""Template-based grounded narrative generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dev_health_ops.metrics.testops_schemas import InsightBlock, ReportPlan
+from dev_health_ops.reports.charts import ChartResult
+from dev_health_ops.reports.metric_registry import get_metric_definition
+
+SECTION_METRICS = {
+    "summary": (),
+    "delivery": ("items_completed", "cycle_time_p50_hours", "lead_time_p50_hours"),
+    "quality": (
+        "failure_rate",
+        "pass_rate",
+        "line_coverage_pct",
+        "coverage_regression_count",
+    ),
+    "testops": (
+        "success_rate",
+        "flake_rate",
+        "rerun_rate",
+        "retry_dependency_rate",
+        "avg_queue_seconds",
+        "median_duration_seconds",
+    ),
+    "wellbeing": ("after_hours_commit_ratio", "weekend_commit_ratio"),
+}
+
+SECTION_TITLES = {
+    "summary": "Summary",
+    "delivery": "Delivery",
+    "quality": "Quality",
+    "testops": "TestOps",
+    "wellbeing": "Wellbeing",
+}
+
+
+@dataclass(frozen=True)
+class NarrativeSection:
+    section_type: str
+    title: str
+    body: str
+    supporting_metrics: list[str]
+
+
+def _format_value(metric: str, value: float) -> str:
+    definition = get_metric_definition(metric)
+    unit = definition.unit if definition else "unitless"
+    if unit == "ratio":
+        return f"{value * 100:.1f}%"
+    if unit == "percent":
+        return f"{value:.1f}%"
+    if unit == "seconds":
+        return f"{value:.1f}s"
+    if unit == "minutes":
+        return f"{value:.1f}m"
+    if unit == "hours":
+        return f"{value:.1f}h"
+    if unit == "count":
+        return f"{value:.0f}"
+    return f"{value:.2f}"
+
+
+def _metric_display(metric: str) -> str:
+    definition = get_metric_definition(metric)
+    if definition is None:
+        return metric.replace("_", " ").title()
+    return definition.display_name
+
+
+def _latest_value(chart_result: ChartResult) -> float | None:
+    if not chart_result.data_points:
+        return None
+    value = chart_result.data_points[-1].get("y")
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def _prior_value(chart_result: ChartResult) -> float | None:
+    if len(chart_result.data_points) < 2:
+        return None
+    value = chart_result.data_points[0].get("y")
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def _sentence_for_chart(chart_result: ChartResult) -> str | None:
+    metric = chart_result.spec.metric
+    current = _latest_value(chart_result)
+    if current is None:
+        return None
+    prior = _prior_value(chart_result)
+    display = _metric_display(metric)
+    current_text = _format_value(metric, current)
+    if prior is None:
+        return f"{display} appears near {current_text} for the selected window."
+    prior_text = _format_value(metric, prior)
+    return f"{display} appears near {current_text}, compared with {prior_text} at the opening of the selected window."
+
+
+def _relevant_metrics(section_type: str, chart_results: list[ChartResult]) -> list[str]:
+    available_metrics = [
+        chart.spec.metric for chart in chart_results if not chart.empty
+    ]
+    if section_type == "summary":
+        return list(dict.fromkeys(available_metrics[:3]))
+    desired = SECTION_METRICS.get(section_type, ())
+    return [metric for metric in desired if metric in available_metrics]
+
+
+def generate_narrative(
+    plan: ReportPlan,
+    chart_results: list[ChartResult],
+    insights: list[InsightBlock],
+) -> list[NarrativeSection]:
+    chart_by_metric = {
+        chart_result.spec.metric: chart_result
+        for chart_result in chart_results
+        if not chart_result.empty
+    }
+    sections: list[NarrativeSection] = []
+
+    for section_type in plan.sections:
+        metrics = _relevant_metrics(section_type, chart_results)
+        sentences = []
+        for metric in metrics:
+            sentence = _sentence_for_chart(chart_by_metric[metric])
+            if sentence:
+                sentences.append(sentence)
+
+        section_insights = [
+            insight
+            for insight in insights
+            if set(insight.supporting_metrics).intersection(metrics)
+        ]
+        if section_insights:
+            highlight = section_insights[0]
+            sentences.append(
+                f"Current evidence suggests: {highlight.summary[0].lower() + highlight.summary[1:]}"
+            )
+
+        body = "\n\n".join(sentences)
+        if not body:
+            body = "Available evidence appears limited for this section in the current report window."
+
+        sections.append(
+            NarrativeSection(
+                section_type=section_type,
+                title=SECTION_TITLES.get(
+                    section_type, section_type.replace("_", " ").title()
+                ),
+                body=body,
+                supporting_metrics=metrics,
+            )
+        )
+
+    return sections

--- a/src/dev_health_ops/reports/provenance.py
+++ b/src/dev_health_ops/reports/provenance.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dev_health_ops.metrics.testops_schemas import InsightBlock
+from dev_health_ops.reports.charts import ChartResult
+from dev_health_ops.reports.narrative import NarrativeSection
+
+
+@dataclass(frozen=True)
+class ProvenanceValidation:
+    valid: bool
+    violations: list[str]
+
+
+def _available_metrics(chart_results: list[ChartResult]) -> set[str]:
+    return {cr.spec.metric for cr in chart_results}
+
+
+def validate_narrative_provenance(
+    narrative_sections: list[NarrativeSection],
+    chart_results: list[ChartResult],
+) -> ProvenanceValidation:
+    available = _available_metrics(chart_results)
+    violations: list[str] = []
+    for section in narrative_sections:
+        for metric in section.supporting_metrics:
+            if metric not in available:
+                violations.append(
+                    f"Section '{section.section_type}' references metric "
+                    f"'{metric}' not present in chart results"
+                )
+    return ProvenanceValidation(valid=len(violations) == 0, violations=violations)
+
+
+def validate_insight_provenance(
+    insights: list[InsightBlock],
+    chart_results: list[ChartResult],
+) -> ProvenanceValidation:
+    available = _available_metrics(chart_results)
+    violations: list[str] = []
+    for insight in insights:
+        for metric in insight.supporting_metrics:
+            if metric not in available:
+                violations.append(
+                    f"Insight '{insight.insight_type}' references metric "
+                    f"'{metric}' not present in chart results"
+                )
+    return ProvenanceValidation(valid=len(violations) == 0, violations=violations)

--- a/src/dev_health_ops/reports/renderer.py
+++ b/src/dev_health_ops/reports/renderer.py
@@ -1,0 +1,140 @@
+"""Markdown report rendering."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from dev_health_ops.metrics.testops_schemas import (
+    InsightBlock,
+    ProvenanceRecord,
+    ReportPlan,
+)
+from dev_health_ops.reports.charts import ChartResult
+from dev_health_ops.reports.narrative import NarrativeSection
+
+
+def _format_time_range(plan: ReportPlan) -> str:
+    if plan.time_range_start and plan.time_range_end:
+        return (
+            f"{plan.time_range_start.isoformat()} → {plan.time_range_end.isoformat()}"
+        )
+    return "unspecified window"
+
+
+def _format_scope(plan: ReportPlan) -> str:
+    parts = []
+    if plan.scope_teams:
+        parts.append(f"teams={', '.join(plan.scope_teams)}")
+    if plan.scope_repos:
+        parts.append(f"repos={', '.join(plan.scope_repos)}")
+    if plan.scope_services:
+        parts.append(f"services={', '.join(plan.scope_services)}")
+    return " | ".join(parts) if parts else "global"
+
+
+def _render_insights(insights: list[InsightBlock]) -> str:
+    if not insights:
+        return "No grounded insights for this section."
+    lines = []
+    for insight in insights:
+        lines.append(
+            f"- **{insight.confidence} · {insight.severity}** — {insight.summary}"
+        )
+    return "\n".join(lines)
+
+
+def _render_chart_table(chart_result: ChartResult) -> str:
+    if chart_result.empty:
+        return f"#### {chart_result.title}\n\n_No data returned for this chart._"
+    lines = [
+        f"#### {chart_result.title}",
+        "",
+        "| x | y | group |",
+        "| --- | ---: | --- |",
+    ]
+    for point in chart_result.data_points:
+        lines.append(
+            f"| {point.get('x', '')} | {point.get('y', '')} | {point.get('group', '') or ''} |"
+        )
+    return "\n".join(lines)
+
+
+def _render_provenance(provenance: list[ProvenanceRecord]) -> str:
+    lines = ["## Provenance", ""]
+    if not provenance:
+        lines.append("No provenance records available.")
+        return "\n".join(lines)
+    for record in provenance:
+        sources = ", ".join(record.data_sources) or "n/a"
+        metrics = ", ".join(record.metrics_used) or "n/a"
+        lines.append(
+            f"- **{record.artifact_type}:{record.artifact_id}** — sources: {sources}; metrics: {metrics}"
+        )
+    return "\n".join(lines)
+
+
+def render_report_markdown(
+    plan: ReportPlan,
+    chart_results: list[ChartResult],
+    insights: list[InsightBlock],
+    narrative_sections: list[NarrativeSection],
+    provenance: list[ProvenanceRecord],
+) -> str:
+    summary_section = next(
+        (
+            section
+            for section in narrative_sections
+            if section.section_type == "summary"
+        ),
+        None,
+    )
+    lines = [
+        f"# {plan.report_type.replace('_', ' ').title()} Report — {_format_time_range(plan)}",
+        "",
+        "## Summary",
+        summary_section.body
+        if summary_section
+        else "Available evidence appears limited for this summary.",
+        "",
+    ]
+
+    for section in narrative_sections:
+        if section.section_type == "summary":
+            continue
+        section_insights = [
+            insight
+            for insight in insights
+            if set(insight.supporting_metrics).intersection(section.supporting_metrics)
+        ]
+        section_charts = [
+            chart
+            for chart in chart_results
+            if chart.spec.metric in section.supporting_metrics
+        ]
+        lines.extend(
+            [
+                f"## {section.title}",
+                section.body,
+                "",
+                "### Insights",
+                _render_insights(section_insights),
+                "",
+                "### Charts",
+            ]
+        )
+        if section_charts:
+            for chart in section_charts:
+                lines.extend([_render_chart_table(chart), ""])
+        else:
+            lines.extend(["No charts linked to this section.", ""])
+
+    lines.extend([_render_provenance(provenance), ""])
+
+    generated_at = (plan.created_at or datetime.now(UTC)).isoformat()
+    lines.extend(
+        [
+            "---",
+            f"Generated at {generated_at} | Confidence: {plan.confidence_threshold} | Scope: {_format_scope(plan)}",
+        ]
+    )
+    return "\n".join(lines).strip() + "\n"

--- a/src/dev_health_ops/reports/unsupported.py
+++ b/src/dev_health_ops/reports/unsupported.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dev_health_ops.reports.charts import ChartResult
+
+
+@dataclass(frozen=True)
+class MetricAvailability:
+    metric: str
+    available: bool
+    reason: str | None
+
+
+def check_metric_availability(
+    requested_metrics: list[str],
+    chart_results: list[ChartResult],
+) -> list[MetricAvailability]:
+    available_metrics = {cr.spec.metric for cr in chart_results if not cr.empty}
+    all_metrics = {cr.spec.metric for cr in chart_results}
+    result: list[MetricAvailability] = []
+    for metric in requested_metrics:
+        if metric in available_metrics:
+            result.append(
+                MetricAvailability(metric=metric, available=True, reason=None)
+            )
+        elif metric in all_metrics:
+            result.append(
+                MetricAvailability(
+                    metric=metric, available=False, reason="time_range_empty"
+                )
+            )
+        else:
+            result.append(
+                MetricAvailability(
+                    metric=metric, available=False, reason="not_computed"
+                )
+            )
+    return result
+
+
+def generate_availability_notice(unavailable: list[MetricAvailability]) -> str:
+    if not unavailable:
+        return ""
+    lines = [
+        "> **Note:** Some requested metrics have limited data in this report window:\n"
+    ]
+    for ma in unavailable:
+        reason_text = {
+            "time_range_empty": "no data in selected time range",
+            "not_computed": "metric not yet computed",
+            "no_data": "no data available",
+        }.get(ma.reason or "", ma.reason or "unavailable")
+        lines.append(f"> - **{ma.metric}**: {reason_text}")
+    return "\n".join(lines)

--- a/tests/reports/test_engine.py
+++ b/tests/reports/test_engine.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+schemas = importlib.import_module("dev_health_ops.metrics.testops_schemas")
+charts = importlib.import_module("dev_health_ops.reports.charts")
+engine = importlib.import_module("dev_health_ops.reports.engine")
+insights_module = importlib.import_module("dev_health_ops.reports.insights")
+narrative_module = importlib.import_module("dev_health_ops.reports.narrative")
+renderer_module = importlib.import_module("dev_health_ops.reports.renderer")
+
+ChartSpec = schemas.ChartSpec
+ReportPlan = schemas.ReportPlan
+build_chart_query = charts.build_chart_query
+execute_chart = charts.execute_chart
+execute_report = engine.execute_report
+generate_insights = insights_module.generate_insights
+generate_narrative = narrative_module.generate_narrative
+render_report_markdown = renderer_module.render_report_markdown
+
+
+class FakeClient:
+    def __init__(self, rows):
+        self.rows = rows
+        self.calls = []
+        self.closed = False
+
+    def query_dicts(self, query, params):
+        self.calls.append((query, params))
+        return self.rows
+
+    def close(self):
+        self.closed = True
+
+
+def _plan() -> ReportPlan:
+    return ReportPlan(
+        plan_id="plan-1",
+        report_type="weekly_health",
+        audience="team_lead",
+        scope_teams=["team-a"],
+        scope_repos=["repo-a"],
+        time_range_start=date(2026, 1, 1),
+        time_range_end=date(2026, 1, 7),
+        comparison_period="prior_week",
+        sections=["summary", "quality", "testops"],
+        requested_metrics=["success_rate", "line_coverage_pct"],
+        requested_charts=["chart-1", "chart-2"],
+        created_at=datetime(2026, 1, 8, tzinfo=UTC),
+        org_id="org-1",
+    )
+
+
+def _chart_spec(
+    metric: str, *, chart_id: str, group_by: str | None = "day"
+) -> ChartSpec:
+    return ChartSpec(
+        chart_id=chart_id,
+        plan_id="plan-1",
+        chart_type="line" if group_by else "scorecard",
+        metric=metric,
+        group_by=group_by,
+        filter_teams=["team-a"],
+        filter_repos=["repo-a"],
+        time_range_start=date(2026, 1, 1),
+        time_range_end=date(2026, 1, 7),
+        title=f"{metric} title",
+        org_id="org-1",
+    )
+
+
+def test_build_chart_query_with_day_grouping_and_filters():
+    spec = _chart_spec("flake_rate", chart_id="chart-1", group_by="day")
+    query, params = build_chart_query(spec)
+
+    assert "FROM testops_test_metrics_daily" in query
+    assert "toDate(day) AS x" in query
+    assert "avg(flake_rate) AS y" in query
+    assert "team_id IN {filter_teams:Array(String)}" in query
+    assert "repo_id IN {filter_repos:Array(String)}" in query
+    assert params["org_id"] == "org-1"
+    assert params["time_range_start"] == date(2026, 1, 1)
+    assert params["time_range_end"] == date(2026, 1, 7)
+
+
+def test_build_chart_query_with_month_grouping_uses_time_bucket():
+    spec = _chart_spec("line_coverage_pct", chart_id="chart-2", group_by="month")
+    query, _ = build_chart_query(spec)
+
+    assert "toStartOfMonth(day) AS x" in query
+    assert "FROM testops_coverage_metrics_daily" in query
+
+
+@pytest.mark.asyncio
+async def test_execute_chart_returns_structured_points():
+    client = FakeClient([{"x": date(2026, 1, 1), "y": 0.96, "group_value": None}])
+    result = await execute_chart(
+        _chart_spec("success_rate", chart_id="chart-1"), client
+    )
+
+    assert not result.empty
+    assert result.data_points == [{"x": "2026-01-01", "y": 0.96, "group": None}]
+
+
+def test_generate_insights_creates_trend_regression_and_provenance():
+    chart_results = [
+        charts.ChartResult(
+            spec=_chart_spec("line_coverage_pct", chart_id="chart-2"),
+            data_points=[
+                {"x": "2026-01-01", "y": 82.0, "group": None},
+                {"x": "2026-01-02", "y": 79.0, "group": None},
+                {"x": "2026-01-03", "y": 70.0, "group": None},
+            ],
+            title="coverage",
+            empty=False,
+        )
+    ]
+
+    insights, provenance = generate_insights(_plan(), chart_results)
+
+    assert any(insight.insight_type == "trend_delta" for insight in insights)
+    assert any(insight.insight_type == "regression" for insight in insights)
+    assert all(record.artifact_type == "insight" for record in provenance)
+    assert {record.artifact_id for record in provenance} == {
+        insight.insight_id for insight in insights
+    }
+
+
+def test_generate_narrative_stays_grounded_to_available_metrics():
+    chart_results = [
+        charts.ChartResult(
+            spec=_chart_spec("success_rate", chart_id="chart-1"),
+            data_points=[
+                {"x": "2026-01-01", "y": 0.91, "group": None},
+                {"x": "2026-01-07", "y": 0.95, "group": None},
+            ],
+            title="Success rate",
+            empty=False,
+        )
+    ]
+    insights, _ = generate_insights(_plan(), chart_results)
+
+    sections = generate_narrative(_plan(), chart_results, insights)
+    summary = next(section for section in sections if section.section_type == "summary")
+
+    assert "Success Rate appears near 95.0%" in summary.body
+    assert "line coverage" not in summary.body.lower()
+    assert summary.supporting_metrics == ["success_rate"]
+
+
+def test_render_report_markdown_outputs_expected_sections():
+    chart_result = charts.ChartResult(
+        spec=_chart_spec("success_rate", chart_id="chart-1"),
+        data_points=[{"x": "2026-01-01", "y": 0.95, "group": None}],
+        title="Success rate",
+        empty=False,
+    )
+    insights, provenance = generate_insights(_plan(), [chart_result])
+    narrative_sections = generate_narrative(_plan(), [chart_result], insights)
+
+    markdown = render_report_markdown(
+        plan=_plan(),
+        chart_results=[chart_result],
+        insights=insights,
+        narrative_sections=narrative_sections,
+        provenance=provenance,
+    )
+
+    assert "# Weekly Health Report" in markdown
+    assert "## Summary" in markdown
+    assert "### Insights" in markdown
+    assert "### Charts" in markdown
+    assert "## Provenance" in markdown
+    assert "Generated at 2026-01-08T00:00:00+00:00" in markdown
+
+
+def test_empty_data_handling_produces_empty_chart_and_limited_narrative():
+    chart_result = charts.ChartResult(
+        spec=_chart_spec("success_rate", chart_id="chart-1"),
+        data_points=[],
+        title="Success rate",
+        empty=True,
+    )
+    insights, provenance = generate_insights(_plan(), [chart_result])
+    sections = generate_narrative(_plan(), [chart_result], insights)
+    markdown = render_report_markdown(
+        _plan(), [chart_result], insights, sections, provenance
+    )
+
+    assert insights == []
+    assert provenance == []
+    assert "Available evidence appears limited" in markdown
+    assert (
+        "_No data returned for this chart._" in markdown
+        or "No charts linked" in markdown
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_report_creates_provenance_for_all_artifacts(monkeypatch):
+
+    fake_sink = FakeClient(
+        [
+            {"x": date(2026, 1, 1), "y": 0.91, "group_value": None},
+            {"x": date(2026, 1, 7), "y": 0.95, "group_value": None},
+        ]
+    )
+
+    monkeypatch.setattr(
+        "dev_health_ops.reports.engine.ClickHouseMetricsSink",
+        lambda dsn: fake_sink,
+    )
+
+    report = await execute_report(
+        _plan(), [_chart_spec("success_rate", chart_id="chart-1")], "clickhouse://test"
+    )
+
+    artifact_types = {record.artifact_type for record in report.provenance}
+    assert {"chart", "narrative", "report"}.issubset(artifact_types)
+    assert report.chart_results[0].data_points[-1]["y"] == 0.95
+    assert report.rendered_markdown.startswith("# Weekly Health Report")
+    assert fake_sink.closed

--- a/tests/reports/test_trust.py
+++ b/tests/reports/test_trust.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, date, datetime
+
+from dev_health_ops.metrics.testops_schemas import ChartSpec, InsightBlock
+from dev_health_ops.reports.audit import ReportAuditRecord, log_report_audit
+from dev_health_ops.reports.charts import ChartResult
+from dev_health_ops.reports.confidence import (
+    ConfidenceLevel,
+    assess_confidence,
+    filter_by_confidence,
+)
+from dev_health_ops.reports.narrative import NarrativeSection
+from dev_health_ops.reports.provenance import (
+    validate_insight_provenance,
+    validate_narrative_provenance,
+)
+from dev_health_ops.reports.unsupported import (
+    check_metric_availability,
+    generate_availability_notice,
+)
+
+PLAN_ID = "plan-001"
+NOW = datetime(2025, 4, 10, 12, 0, 0, tzinfo=UTC)
+
+
+def _chart_spec(metric: str) -> ChartSpec:
+    return ChartSpec(
+        chart_id=f"chart-{metric}",
+        plan_id=PLAN_ID,
+        chart_type="timeseries",
+        metric=metric,
+        group_by="day",
+        filter_teams=[],
+        filter_repos=[],
+        time_range_start=date(2025, 4, 1),
+        time_range_end=date(2025, 4, 10),
+        title=f"{metric} chart",
+        org_id="org-1",
+    )
+
+
+def _chart_result(metric: str, empty: bool = False) -> ChartResult:
+    return ChartResult(
+        spec=_chart_spec(metric),
+        data_points=[] if empty else [{"x": "2025-04-10", "y": 0.95, "group": None}],
+        title=f"{metric} chart",
+        empty=empty,
+    )
+
+
+def _insight(metric: str, insight_type: str = "trend_delta") -> InsightBlock:
+    return InsightBlock(
+        insight_id=f"ins-{metric}",
+        plan_id=PLAN_ID,
+        insight_type=insight_type,
+        confidence="direct_fact",
+        summary=f"{metric} appears to have changed.",
+        supporting_metrics=[metric],
+        supporting_values={metric: 0.95},
+        severity="medium",
+    )
+
+
+def test_narrative_provenance_valid():
+    charts = [_chart_result("success_rate"), _chart_result("flake_rate")]
+    sections = [
+        NarrativeSection(
+            section_type="testops",
+            title="TestOps",
+            body="Pipeline success rate appears stable.",
+            supporting_metrics=["success_rate"],
+        )
+    ]
+    result = validate_narrative_provenance(sections, charts)
+    assert result.valid
+    assert result.violations == []
+
+
+def test_narrative_provenance_catches_ungrounded():
+    charts = [_chart_result("success_rate")]
+    sections = [
+        NarrativeSection(
+            section_type="quality",
+            title="Quality",
+            body="Coverage appears lower.",
+            supporting_metrics=["line_coverage_pct"],
+        )
+    ]
+    result = validate_narrative_provenance(sections, charts)
+    assert not result.valid
+    assert len(result.violations) == 1
+    assert "line_coverage_pct" in result.violations[0]
+
+
+def test_insight_provenance_catches_missing_metric():
+    charts = [_chart_result("success_rate")]
+    insights = [_insight("nonexistent_metric")]
+    result = validate_insight_provenance(insights, charts)
+    assert not result.valid
+    assert len(result.violations) == 1
+
+
+def test_confidence_direct_fact():
+    insight = _insight("success_rate", "trend_delta")
+    level = assess_confidence(insight, data_points_count=1)
+    assert level == ConfidenceLevel.DIRECT_FACT
+
+
+def test_confidence_inferred():
+    insight = _insight("success_rate", "trend_delta")
+    level = assess_confidence(insight, data_points_count=5)
+    assert level == ConfidenceLevel.INFERRED
+
+
+def test_confidence_hypothesis():
+    insight = _insight("success_rate", "correlation")
+    level = assess_confidence(insight, data_points_count=10)
+    assert level == ConfidenceLevel.HYPOTHESIS
+
+
+def test_filter_by_confidence_direct_fact_threshold():
+    insights = [
+        _insight("success_rate", "trend_delta"),
+        _insight("flake_rate", "correlation"),
+    ]
+    filtered = filter_by_confidence(
+        insights,
+        threshold="direct_fact",
+        data_points_counts={"success_rate": 1, "flake_rate": 10},
+    )
+    assert len(filtered) == 1
+    assert filtered[0].supporting_metrics[0] == "success_rate"
+
+
+def test_filter_by_confidence_inferred_threshold():
+    insights = [
+        _insight("success_rate", "trend_delta"),
+        _insight("flake_rate", "correlation"),
+        _insight("pass_rate", "regression"),
+    ]
+    filtered = filter_by_confidence(
+        insights,
+        threshold="inferred",
+        data_points_counts={"success_rate": 5, "flake_rate": 10, "pass_rate": 4},
+    )
+    assert len(filtered) == 2
+    metrics = {i.supporting_metrics[0] for i in filtered}
+    assert "success_rate" in metrics
+    assert "pass_rate" in metrics
+
+
+def test_metric_availability_mixed():
+    charts = [_chart_result("success_rate"), _chart_result("flake_rate", empty=True)]
+    result = check_metric_availability(
+        ["success_rate", "flake_rate", "nonexistent"],
+        charts,
+    )
+    assert result[0].available is True
+    assert result[1].available is False
+    assert result[1].reason == "time_range_empty"
+    assert result[2].available is False
+    assert result[2].reason == "not_computed"
+
+
+def test_availability_notice_format():
+    from dev_health_ops.reports.unsupported import MetricAvailability
+
+    unavailable = [
+        MetricAvailability(
+            metric="flake_rate", available=False, reason="time_range_empty"
+        ),
+    ]
+    notice = generate_availability_notice(unavailable)
+    assert "flake_rate" in notice
+    assert "no data in selected time range" in notice
+
+
+def test_availability_notice_empty():
+    assert generate_availability_notice([]) == ""
+
+
+def test_audit_record_logs(caplog):
+    record = ReportAuditRecord(
+        audit_id="aud-1",
+        plan_id="plan-1",
+        org_id="org-1",
+        report_type="weekly_health",
+        metrics_requested=["success_rate", "flake_rate"],
+        metrics_available=["success_rate"],
+        metrics_unavailable=["flake_rate"],
+        insights_generated=5,
+        insights_filtered=2,
+        provenance_violations=0,
+        confidence_threshold="direct_fact",
+        generated_at=NOW,
+        duration_seconds=1.5,
+    )
+    with caplog.at_level(logging.INFO, logger="dev_health_ops.reports.audit"):
+        log_report_audit(record)
+    assert "plan_id=plan-1" in caplog.text
+    assert "metrics_req=2" in caplog.text


### PR DESCRIPTION
## Summary
- Adds provenance enforcement — validates narrative/insight claims trace to actual chart data
- Adds confidence labeling (direct_fact/inferred/hypothesis) with threshold filtering
- Adds metric availability checking with graceful notices for missing data
- Adds structured audit logging for report generation
- 12 unit tests passing

## Linear
CHAOS-1084, CHAOS-1153, CHAOS-1154, CHAOS-1155, CHAOS-1156, CHAOS-1157

SCREENSHOT-WAIVER: Backend-only report guardrails, no rendered frontend output