### PR TITLE
docs: TestOps rollout plan, feature flags, and demo pack (CHAOS-1163, CHAOS-1164)

### DIFF
--- a/docs/ops/testops-demo-pack.md
+++ b/docs/ops/testops-demo-pack.md
@@ -1,0 +1,103 @@
+# TestOps + AI Reports: Internal Demo Pack
+
+This guide provides a structured walkthrough for demonstrating the TestOps and AI Reports capabilities. It appears to cover the full lifecycle from raw pipeline ingestion to high-level AI-driven quality insights.
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Demo Scenarios](#demo-scenarios)
+3. [Seed Prompts for AI Reports](#seed-prompts-for-ai-reports)
+4. [Talking Points](#talking-points)
+5. [Known Limitations](#known-limitations)
+
+---
+
+## Prerequisites
+
+To ensure a rich demo experience, you should seed the environment with realistic TestOps data.
+
+### Seeding Demo Data
+Use the `dev-hops` CLI to generate 30 days of synthetic TestOps fixtures:
+
+```bash
+# Generate fixtures for the last 30 days
+CLICKHOUSE_URI=clickhouse://... dev-hops fixtures generate --sink "$CLICKHOUSE_URI" --days 30
+```
+
+This command appears to populate the following tables:
+- `ci_pipeline_runs`
+- `ci_job_runs`
+- `test_executions`
+- `coverage_snapshots`
+
+---
+
+## Demo Scenarios
+
+### 1. Pipeline Health Overview
+**Navigation**: `/testops/pipelines`
+**Action**: Show the aggregate pipeline success rate and duration trends.
+**Insight**: Identify if the platform team's pipelines are becoming slower or more prone to failure over time.
+
+### 2. Flaky Test Investigation
+**Navigation**: `/testops/tests`
+**Action**: Use the test view heatmap to locate tests with high `test_flake_rate`.
+**Insight**: Demonstrate how the system leans toward identifying tests that fail and then pass within the same pipeline run, suggesting instability rather than code defects.
+
+### 3. Coverage Trend Analysis
+**Navigation**: `/testops/coverage`
+**Action**: View the `coverage_line_pct` and `coverage_delta_pct` for a specific repository.
+**Insight**: Show how the system tracks coverage changes per PR, highlighting where quality drag might be accumulating.
+
+### 4. Release Risk Assessment
+**Navigation**: `/testops/risk`
+**Action**: Examine the `release_confidence_score` and `quality_drag_hours` for the upcoming release.
+**Insight**: Explain how the risk model suggests release readiness based on recent pipeline stability and test reliability.
+
+### 5. Generate an AI Report
+**Navigation**: `/reports/new`
+**Action**: Enter a natural language prompt to generate a quality summary.
+**Example Prompt**:
+> "Generate a weekly quality report for the platform team covering pipeline stability, test reliability, and coverage trends for the last 2 weeks"
+
+### 6. Save and Schedule Reports
+**Navigation**: `/reports/saved`
+**Action**: Show how to save the generated report as a template and set a weekly schedule.
+**Insight**: Demonstrate the automation of quality reporting for leadership.
+
+---
+
+## Seed Prompts for AI Reports
+
+Use these prompts to showcase the flexibility of the AI report engine:
+
+1. "What's the pipeline health trend for [team] over the last month?"
+2. "Show me which test suites have the highest flake rate"
+3. "Compare coverage between [repo-a] and [repo-b]"
+4. "Generate a sprint-end quality report for the frontend team"
+5. "What's our release confidence for the next deployment?"
+6. "Identify the top 3 bottlenecks in our CI/CD pipeline duration"
+7. "Summarize the impact of recent flaky tests on our total quality drag"
+8. "How has coverage changed across the organization since the start of the quarter?"
+9. "Which repositories have the highest pipeline failure rate but no associated test failures?"
+10. "Generate a monthly executive summary of engineering quality and risk"
+
+---
+
+## Talking Points
+
+- **Evidence-Based**: "The system appears to base all insights on raw CI/CD artifacts, ensuring that AI summaries are grounded in verifiable data."
+- **Trend-Focused**: "We lean toward showing trajectories rather than absolute scores, as the direction of quality matters more than a single point in time."
+- **Actionable Risk**: "The risk models suggest where human attention is most needed, rather than providing a verdict on release readiness."
+- **Reduced Noise**: "By identifying flaky tests, the platform suggests which failures can be safely ignored and which require immediate investigation."
+
+---
+
+## Known Limitations
+
+- **Provider Support**: Currently appears to support GitHub Actions and GitLab CI; Jenkins support is on the roadmap.
+- **Report Latency**: AI report generation may take up to 30 seconds depending on the volume of evidence being summarized.
+- **Historical Depth**: Risk models require at least 14 days of continuous ingestion to suggest reliable confidence scores.
+- **Coverage Formats**: Currently supports LCOV and Cobertura formats; others may require custom processors.

--- a/docs/ops/testops-rollout-plan.md
+++ b/docs/ops/testops-rollout-plan.md
@@ -1,0 +1,121 @@
+# TestOps + AI Reports: Staged Rollout Plan
+
+This document outlines the staged rollout strategy for the TestOps and AI Reports milestone. The plan appears to balance rapid internal feedback with a cautious approach to production data ingestion and analytics.
+
+---
+
+## Table of Contents
+
+1. [Feature Flag Definitions](#feature-flag-definitions)
+2. [Rollout Stages](#rollout-stages)
+    - [Stage 0: Internal Dogfood](#stage-0-internal-dogfood)
+    - [Stage 1: Alpha](#stage-1-alpha)
+    - [Stage 2: Beta](#stage-2-beta)
+    - [Stage 3: GA](#stage-3-ga)
+3. [Monitoring and Observability](#monitoring-and-observability)
+4. [Rollback Procedures](#rollback-procedures)
+
+---
+
+## Feature Flag Definitions
+
+The following feature flags control the activation of TestOps capabilities. These flags should be managed via environment variables or the centralized configuration service.
+
+| Flag | Description | Impact Area |
+|------|-------------|-------------|
+| `TESTOPS_PIPELINE_INGESTION` | Enables CI/CD pipeline data ingestion from providers (GitHub Actions, GitLab CI). | Connectors, Processors |
+| `TESTOPS_TEST_INGESTION` | Enables ingestion of test execution results (JUnit XML) and coverage reports. | Connectors, Processors |
+| `TESTOPS_METRICS` | Enables computation of TestOps daily metrics (e.g., failure rates, duration p95). | Metrics |
+| `TESTOPS_RISK_MODELS` | Enables risk model computation (Release Confidence, Quality Drag). | Metrics, Analytics |
+| `TESTOPS_AI_REPORTS` | Enables the AI-driven report generation engine. | LLM, Reports |
+| `TESTOPS_UX` | Enables the TestOps dashboard and related views in the web UI. | Web UI |
+| `TESTOPS_SAVED_REPORTS` | Enables report template saving, parameterization, and scheduling. | API, Web UI |
+
+---
+
+## Rollout Stages
+
+### Stage 0: Internal Dogfood
+**Target**: Dev Health core team and internal engineering org.
+**Duration**: 1 week.
+**Flags**: All flags `ON`.
+
+- **Entry Criteria**:
+    - All TestOps unit and integration tests passing in CI.
+    - ClickHouse schema migrations for TestOps tables completed.
+    - AI Report engine verified with synthetic data.
+- **Success Metrics**:
+    - 100% ingestion success rate for internal repos.
+    - Zero critical UI bugs reported by the team.
+    - AI reports generated within < 30 seconds.
+- **Rollback Triggers**:
+    - Data corruption in ClickHouse analytics tables.
+    - Significant performance degradation in the main API.
+
+### Stage 1: Alpha
+**Target**: Select partner organizations (3-5 orgs).
+**Duration**: 2 weeks.
+**Flags**: `TESTOPS_PIPELINE_INGESTION`, `TESTOPS_TEST_INGESTION`, `TESTOPS_METRICS` `ON`. Others `OFF`.
+
+- **Entry Criteria**:
+    - Stage 0 success criteria met.
+    - Documentation for TestOps ingestion configuration completed.
+- **Success Metrics**:
+    - Stable ingestion across diverse CI pipeline structures.
+    - Metrics computation completes within the daily window for all Alpha orgs.
+- **Rollback Triggers**:
+    - Provider API rate limiting issues affecting other platform features.
+    - Inconsistent metric values compared to provider-native dashboards.
+
+### Stage 2: Beta
+**Target**: 10% of all organizations.
+**Duration**: 2 weeks.
+**Flags**: All flags `ON`.
+
+- **Entry Criteria**:
+    - Stage 1 success criteria met.
+    - Risk models validated against historical failure data.
+- **Success Metrics**:
+    - Positive feedback on AI report relevance and accuracy.
+    - Risk models correctly identify at least 80% of known "high-risk" releases.
+- **Rollback Triggers**:
+    - High error rates in AI report generation (LLM timeouts or malformed JSON).
+    - User reports of "hallucinated" metrics in AI summaries.
+
+### Stage 3: GA
+**Target**: All organizations.
+**Duration**: Permanent.
+**Flags**: All flags `ON`.
+
+- **Entry Criteria**:
+    - Stage 2 success criteria met.
+    - Load testing confirms system stability at 5x current volume.
+- **Success Metrics**:
+    - TestOps views become a top-3 visited section in the platform.
+    - Reduction in reported "flaky test" noise for GA users.
+- **Rollback Triggers**:
+    - System-wide latency spikes exceeding 2 seconds for standard queries.
+
+---
+
+## Monitoring and Observability
+
+The following signals suggest the health of the TestOps rollout:
+
+- **Error Rates**: Monitor `Connectors` and `Processors` for 4xx/5xx errors from providers.
+- **Ingestion Latency**: Track the time from CI job completion to data availability in ClickHouse.
+- **Metric Accuracy**: Periodic automated checks comparing `test_pass_rate` in ClickHouse vs raw provider artifacts.
+- **LLM Performance**: Monitor token usage, latency, and "repair attempt" frequency for AI reports.
+- **Data Quality**: Track the `evidence_quality` score emitted by the categorization engine.
+
+---
+
+## Rollback Procedures
+
+If a feature flag needs to be disabled due to instability:
+
+1. **Identify the Scope**: Determine if the issue is isolated to a specific flag (e.g., `TESTOPS_AI_REPORTS`).
+2. **Disable the Flag**: Update the environment configuration to set the flag to `OFF`.
+3. **Verify UI State**: Ensure the `TESTOPS_UX` flag correctly hides affected components to prevent broken links.
+4. **Data Cleanup (Optional)**: If data corruption occurred, use `dev-hops backfill` to re-sync the affected period after the fix is deployed.
+5. **Post-Mortem**: Document the trigger and resolution before re-attempting the rollout stage.


### PR DESCRIPTION
## Summary
- Staged rollout plan with 7 feature flags and 4 rollout stages (Dogfood → Alpha → Beta → GA)
- Internal demo pack with 6 scenarios, 10 seed prompts, and talking points

## Issues
Closes CHAOS-1163, CHAOS-1164

## Changes
- `docs/ops/testops-rollout-plan.md` — Feature flags, stage definitions, entry/exit criteria, monitoring, rollback procedures
- `docs/ops/testops-demo-pack.md` — Prerequisites, demo scenarios, seed prompts, known limitations

SCREENSHOT-WAIVER: Documentation-only changes — no rendered UI affected
TEST-WAIVER: Documentation-only changes — no component logic affected