### PR TITLE
feat: saved reports — definitions, templates, scheduling, execution history (CHAOS-1083)

### DIFF
--- a/src/dev_health_ops/alembic/versions/0005_add_saved_reports_tables.py
+++ b/src/dev_health_ops/alembic/versions/0005_add_saved_reports_tables.py
@@ -11,6 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects.postgresql import UUID
 
+# Alembic reads these module-level variables at runtime for migration ordering.
 revision: str = "0005"
 down_revision: str | None = "0004"
 branch_labels: str | Sequence[str] | None = None

--- a/src/dev_health_ops/alembic/versions/0005_add_saved_reports_tables.py
+++ b/src/dev_health_ops/alembic/versions/0005_add_saved_reports_tables.py
@@ -1,0 +1,104 @@
+"""Add saved_reports and report_runs tables.
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-04-10 00:00:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "saved_reports",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", sa.Text(), nullable=False, server_default="", index=True),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("report_plan", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column("is_template", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "template_source_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("saved_reports.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("parameters", sa.JSON(), nullable=True),
+        sa.Column(
+            "schedule_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("scheduled_jobs.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_run_status", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("created_by", sa.Text(), nullable=True),
+    )
+    op.create_index("ix_saved_reports_org_name", "saved_reports", ["org_id", "name"])
+    op.create_index(
+        "ix_saved_reports_org_template", "saved_reports", ["org_id", "is_template"]
+    )
+
+    op.create_table(
+        "report_runs",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "report_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("saved_reports.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("status", sa.Text(), nullable=False, server_default="pending"),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("duration_seconds", sa.Float(), nullable=True),
+        sa.Column("rendered_markdown", sa.Text(), nullable=True),
+        sa.Column("artifact_url", sa.Text(), nullable=True),
+        sa.Column("provenance_records", sa.JSON(), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("error_traceback", sa.Text(), nullable=True),
+        sa.Column("triggered_by", sa.Text(), nullable=False, server_default="manual"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_report_runs_report_created", "report_runs", ["report_id", "created_at"]
+    )
+    op.create_index("ix_report_runs_status", "report_runs", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_report_runs_status", table_name="report_runs")
+    op.drop_index("ix_report_runs_report_created", table_name="report_runs")
+    op.drop_table("report_runs")
+
+    op.drop_index("ix_saved_reports_org_template", table_name="saved_reports")
+    op.drop_index("ix_saved_reports_org_name", table_name="saved_reports")
+    op.drop_table("saved_reports")

--- a/src/dev_health_ops/api/graphql/resolvers/reports.py
+++ b/src/dev_health_ops/api/graphql/resolvers/reports.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import strawberry
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.models.reports import ReportRun, ReportRunStatus, SavedReport
+from dev_health_ops.models.settings import JobStatus, ScheduledJob
+
+
+@strawberry.type
+class SavedReportType:
+    id: str
+    org_id: str
+    name: str
+    description: str | None
+    report_plan: strawberry.scalars.JSON
+    is_template: bool
+    template_source_id: str | None
+    parameters: strawberry.scalars.JSON | None
+    schedule_id: str | None
+    is_active: bool
+    last_run_at: datetime | None
+    last_run_status: str | None
+    created_at: datetime
+    updated_at: datetime
+    created_by: str | None
+
+
+@strawberry.type
+class ReportRunType:
+    id: str
+    report_id: str
+    status: str
+    started_at: datetime | None
+    completed_at: datetime | None
+    duration_seconds: float | None
+    rendered_markdown: str | None
+    artifact_url: str | None
+    provenance_records: strawberry.scalars.JSON | None
+    error: str | None
+    triggered_by: str
+    created_at: datetime
+
+
+@strawberry.type
+class SavedReportConnection:
+    items: list[SavedReportType]
+    total: int
+
+
+@strawberry.type
+class ReportRunConnection:
+    items: list[ReportRunType]
+    total: int
+
+
+@strawberry.input
+class CreateSavedReportInput:
+    name: str
+    description: str | None = None
+    report_plan: strawberry.scalars.JSON | None = None
+    is_template: bool = False
+    parameters: strawberry.scalars.JSON | None = None
+    schedule_cron: str | None = None
+    schedule_timezone: str = "UTC"
+
+
+@strawberry.input
+class UpdateSavedReportInput:
+    name: str | None = None
+    description: str | None = None
+    report_plan: strawberry.scalars.JSON | None = None
+    is_template: bool | None = None
+    parameters: strawberry.scalars.JSON | None = None
+    is_active: bool | None = None
+    schedule_cron: str | None = None
+    schedule_timezone: str | None = None
+
+
+@strawberry.input
+class CloneSavedReportInput:
+    source_report_id: str
+    new_name: str | None = None
+    parameter_overrides: strawberry.scalars.JSON | None = None
+
+
+def _to_saved_report_type(report: SavedReport) -> SavedReportType:
+    return SavedReportType(
+        id=str(report.id),
+        org_id=report.org_id,
+        name=report.name,
+        description=report.description,
+        report_plan=report.report_plan,
+        is_template=report.is_template,
+        template_source_id=str(report.template_source_id)
+        if report.template_source_id
+        else None,
+        parameters=report.parameters,
+        schedule_id=str(report.schedule_id) if report.schedule_id else None,
+        is_active=report.is_active,
+        last_run_at=report.last_run_at,
+        last_run_status=report.last_run_status,
+        created_at=report.created_at,
+        updated_at=report.updated_at,
+        created_by=report.created_by,
+    )
+
+
+def _to_report_run_type(run: ReportRun) -> ReportRunType:
+    return ReportRunType(
+        id=str(run.id),
+        report_id=str(run.report_id),
+        status=run.status,
+        started_at=run.started_at,
+        completed_at=run.completed_at,
+        duration_seconds=run.duration_seconds,
+        rendered_markdown=run.rendered_markdown,
+        artifact_url=run.artifact_url,
+        provenance_records=run.provenance_records,
+        error=run.error,
+        triggered_by=run.triggered_by,
+        created_at=run.created_at,
+    )
+
+
+async def _get_session(context) -> AsyncSession:
+    from dev_health_ops.db import get_postgres_session
+
+    return get_postgres_session()
+
+
+async def _ensure_or_update_schedule(
+    session: AsyncSession,
+    report: SavedReport,
+    cron: str | None,
+    tz: str = "UTC",
+) -> None:
+    if cron is None:
+        return
+
+    if report.schedule_id:
+        result = await session.execute(
+            select(ScheduledJob).where(ScheduledJob.id == report.schedule_id)
+        )
+        existing_job = result.scalar_one_or_none()
+        if existing_job:
+            existing_job.schedule_cron = cron
+            existing_job.timezone = tz
+            existing_job.updated_at = datetime.now(timezone.utc)
+            return
+
+    job = ScheduledJob(
+        name=f"report:{report.name}",
+        job_type="report",
+        schedule_cron=cron,
+        org_id=report.org_id,
+        job_config={"report_id": str(report.id)},
+        tz=tz,
+        status=JobStatus.ACTIVE.value,
+    )
+    session.add(job)
+    await session.flush()
+    report.schedule_id = job.id
+
+
+async def resolve_saved_reports(
+    org_id: str,
+    limit: int = 50,
+    offset: int = 0,
+) -> SavedReportConnection:
+    from dev_health_ops.db import get_postgres_session
+
+    async with get_postgres_session() as session:
+        count_result = await session.execute(
+            select(SavedReport).where(SavedReport.org_id == org_id)
+        )
+        total = len(count_result.scalars().all())
+
+        result = await session.execute(
+            select(SavedReport)
+            .where(SavedReport.org_id == org_id)
+            .order_by(SavedReport.updated_at.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+        reports = result.scalars().all()
+
+    return SavedReportConnection(
+        items=[_to_saved_report_type(r) for r in reports],
+        total=total,
+    )
+
+
+async def resolve_saved_report(
+    org_id: str,
+    report_id: str,
+) -> SavedReportType | None:
+    from dev_health_ops.db import get_postgres_session
+
+    async with get_postgres_session() as session:
+        result = await session.execute(
+            select(SavedReport).where(
+                SavedReport.org_id == org_id,
+                SavedReport.id == uuid.UUID(report_id),
+            )
+        )
+        report = result.scalar_one_or_none()
+
+    if report is None:
+        return None
+    return _to_saved_report_type(report)
+
+
+async def resolve_report_runs(
+    org_id: str,
+    report_id: str,
+    limit: int = 50,
+) -> ReportRunConnection:
+    from dev_health_ops.db import get_postgres_session
+
+    async with get_postgres_session() as session:
+        report_result = await session.execute(
+            select(SavedReport).where(
+                SavedReport.org_id == org_id,
+                SavedReport.id == uuid.UUID(report_id),
+            )
+        )
+        report = report_result.scalar_one_or_none()
+        if report is None:
+            return ReportRunConnection(items=[], total=0)
+
+        count_result = await session.execute(
+            select(ReportRun).where(ReportRun.report_id == report.id)
+        )
+        total = len(count_result.scalars().all())
+
+        result = await session.execute(
+            select(ReportRun)
+            .where(ReportRun.report_id == report.id)
+            .order_by(ReportRun.created_at.desc())
+            .limit(limit)
+        )
+        runs = result.scalars().all()
+
+    return ReportRunConnection(
+        items=[_to_report_run_type(r) for r in runs],
+        total=total,
+    )
+
+
+async def resolve_create_saved_report(
+    org_id: str,
+    input: CreateSavedReportInput,
+) -> SavedReportType:
+    from dev_health_ops.db import get_postgres_session
+
+    async with get_postgres_session() as session:
+        report = SavedReport(
+            name=input.name,
+            org_id=org_id,
+            description=input.description,
+            report_plan=input.report_plan or {},
+            is_template=input.is_template,
+            parameters=input.parameters or {},
+        )
+        session.add(report)
+        await session.flush()
+
+        if input.schedule_cron:
+            await _ensure_or_update_schedule(
+                session, report, input.schedule_cron, input.schedule_timezone
+            )
+
+    return _to_saved_report_type(report)
+
+
+async def resolve_update_saved_report(
+    org_id: str,
+    report_id: str,
+    input: UpdateSavedReportInput,
+) -> SavedReportType | None:
+    from dev_health_ops.db import get_postgres_session
+
+    async with get_postgres_session() as session:
+        result = await session.execute(
+            select(SavedReport).where(
+                SavedReport.org_id == org_id,
+                SavedReport.id == uuid.UUID(report_id),
+            )
+        )
+        report = result.scalar_one_or_none()
+        if report is None:
+            return None
+
+        if input.name is not None:
+            report.name = input.name
+        if input.description is not None:
+            report.description = input.description
+        if input.report_plan is not None:
+            report.report_plan = input.report_plan
+        if input.is_template is not None:
+            report.is_template = input.is_template
+        if input.parameters is not None:
+            report.parameters = input.parameters
+        if input.is_active is not None:
+            report.is_active = input.is_active
+
+        report.updated_at = datetime.now(timezone.utc)
+
+        if input.schedule_cron is not None:
+            await _ensure_or_update_schedule(
+                session,
+                report,
+                input.schedule_cron,
+                input.schedule_timezone or "UTC",
+            )
+
+    return _to_saved_report_type(report)
+
+
+async def resolve_delete_saved_report(
+    org_id: str,
+    report_id: str,
+) -> bool:
+    from dev_health_ops.db import get_postgres_session
+
+    async with get_postgres_session() as session:
+        result = await session.execute(
+            select(SavedReport).where(
+                SavedReport.org_id == org_id,
+                SavedReport.id == uuid.UUID(report_id),
+            )
+        )
+        report = result.scalar_one_or_none()
+        if report is None:
+            return False
+
+        await session.delete(report)
+
+    return True
+
+
+async def resolve_clone_saved_report(
+    org_id: str,
+    input: CloneSavedReportInput,
+) -> SavedReportType | None:
+    from dev_health_ops.db import get_postgres_session
+
+    async with get_postgres_session() as session:
+        result = await session.execute(
+            select(SavedReport).where(
+                SavedReport.org_id == org_id,
+                SavedReport.id == uuid.UUID(input.source_report_id),
+            )
+        )
+        source = result.scalar_one_or_none()
+        if source is None:
+            return None
+
+        cloned = source.clone(
+            new_name=input.new_name,
+            parameter_overrides=input.parameter_overrides,
+        )
+        session.add(cloned)
+
+    return _to_saved_report_type(cloned)
+
+
+async def resolve_trigger_report(
+    org_id: str,
+    report_id: str,
+) -> ReportRunType | None:
+    from dev_health_ops.db import get_postgres_session
+
+    async with get_postgres_session() as session:
+        result = await session.execute(
+            select(SavedReport).where(
+                SavedReport.org_id == org_id,
+                SavedReport.id == uuid.UUID(report_id),
+            )
+        )
+        report = result.scalar_one_or_none()
+        if report is None:
+            return None
+
+        run = ReportRun(
+            report_id=report.id,
+            triggered_by="api",
+            status=ReportRunStatus.PENDING.value,
+        )
+        session.add(run)
+        await session.flush()
+
+    try:
+        from dev_health_ops.workers.report_task import execute_saved_report
+
+        execute_saved_report.apply_async(
+            kwargs={"report_id": str(report.id), "run_id": str(run.id)},
+            queue="reports",
+        )
+    except (ImportError, AttributeError):
+        pass
+
+    return _to_report_run_type(run)

--- a/src/dev_health_ops/api/graphql/resolvers/reports.py
+++ b/src/dev_health_ops/api/graphql/resolvers/reports.py
@@ -407,6 +407,8 @@ async def resolve_trigger_report(
             queue="reports",
         )
     except (ImportError, AttributeError):
+        # Celery may not be available in test/dev environments;
+        # the report run record is still created for manual pickup.
         pass
 
     return _to_report_run_type(run)

--- a/src/dev_health_ops/api/graphql/resolvers/reports.py
+++ b/src/dev_health_ops/api/graphql/resolvers/reports.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timezone
 
 import strawberry
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.models.reports import ReportRun, ReportRunStatus, SavedReport
@@ -176,9 +176,11 @@ async def resolve_saved_reports(
 
     async with get_postgres_session() as session:
         count_result = await session.execute(
-            select(SavedReport).where(SavedReport.org_id == org_id)
+            select(func.count())
+            .select_from(SavedReport)
+            .where(SavedReport.org_id == org_id)
         )
-        total = len(count_result.scalars().all())
+        total = count_result.scalar() or 0
 
         result = await session.execute(
             select(SavedReport)
@@ -234,9 +236,11 @@ async def resolve_report_runs(
             return ReportRunConnection(items=[], total=0)
 
         count_result = await session.execute(
-            select(ReportRun).where(ReportRun.report_id == report.id)
+            select(func.count())
+            .select_from(ReportRun)
+            .where(ReportRun.report_id == report.id)
         )
-        total = len(count_result.scalars().all())
+        total = count_result.scalar() or 0
 
         result = await session.execute(
             select(ReportRun)

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -27,6 +27,23 @@ from .models.outputs import (
 )
 from .resolvers.analytics import resolve_analytics
 from .resolvers.catalog import resolve_catalog
+from .resolvers.reports import (
+    CloneSavedReportInput,
+    CreateSavedReportInput,
+    ReportRunConnection,
+    ReportRunType,
+    SavedReportConnection,
+    SavedReportType,
+    UpdateSavedReportInput,
+    resolve_clone_saved_report,
+    resolve_create_saved_report,
+    resolve_delete_saved_report,
+    resolve_report_runs,
+    resolve_saved_report,
+    resolve_saved_reports,
+    resolve_trigger_report,
+    resolve_update_saved_report,
+)
 from .subscriptions import Subscription
 
 logger = logging.getLogger(__name__)
@@ -141,6 +158,35 @@ class Query:
         context = get_context(info)
         return await resolve_work_graph_edges(context, filters)
 
+    @strawberry.field(description="List saved reports for an organization")
+    async def saved_reports(
+        self,
+        info: Info,
+        org_id: str,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> SavedReportConnection:
+        return await resolve_saved_reports(org_id, limit, offset)
+
+    @strawberry.field(description="Get a saved report by ID")
+    async def saved_report(
+        self,
+        info: Info,
+        org_id: str,
+        report_id: str,
+    ) -> SavedReportType | None:
+        return await resolve_saved_report(org_id, report_id)
+
+    @strawberry.field(description="List report runs for a saved report")
+    async def report_runs(
+        self,
+        info: Info,
+        org_id: str,
+        report_id: str,
+        limit: int = 50,
+    ) -> ReportRunConnection:
+        return await resolve_report_runs(org_id, report_id, limit)
+
     @strawberry.field(description="Compute capacity forecast on-demand")
     async def capacity_forecast(
         self,
@@ -166,10 +212,58 @@ class Query:
         return await resolve_capacity_forecasts(context, filters)
 
 
-# Create the Strawberry schema with OrgIdAuthExtension to enforce org scoping
-# centrally rather than repeating the guard in every resolver.
+@strawberry.type
+class Mutation:
+    @strawberry.mutation(description="Create a new saved report")
+    async def create_saved_report(
+        self,
+        info: Info,
+        org_id: str,
+        input: CreateSavedReportInput,
+    ) -> SavedReportType:
+        return await resolve_create_saved_report(org_id, input)
+
+    @strawberry.mutation(description="Update an existing saved report")
+    async def update_saved_report(
+        self,
+        info: Info,
+        org_id: str,
+        report_id: str,
+        input: UpdateSavedReportInput,
+    ) -> SavedReportType | None:
+        return await resolve_update_saved_report(org_id, report_id, input)
+
+    @strawberry.mutation(description="Delete a saved report")
+    async def delete_saved_report(
+        self,
+        info: Info,
+        org_id: str,
+        report_id: str,
+    ) -> bool:
+        return await resolve_delete_saved_report(org_id, report_id)
+
+    @strawberry.mutation(description="Clone a saved report with optional overrides")
+    async def clone_saved_report(
+        self,
+        info: Info,
+        org_id: str,
+        input: CloneSavedReportInput,
+    ) -> SavedReportType | None:
+        return await resolve_clone_saved_report(org_id, input)
+
+    @strawberry.mutation(description="Trigger a manual report execution")
+    async def trigger_report(
+        self,
+        info: Info,
+        org_id: str,
+        report_id: str,
+    ) -> ReportRunType | None:
+        return await resolve_trigger_report(org_id, report_id)
+
+
 schema = strawberry.Schema(
     query=Query,
+    mutation=Mutation,
     subscription=Subscription,
     extensions=[OrgIdAuthExtension],
 )

--- a/src/dev_health_ops/models/__init__.py
+++ b/src/dev_health_ops/models/__init__.py
@@ -28,6 +28,11 @@ from .licensing import (
 from .org_invite import OrgInvite
 from .refresh_token import RefreshToken
 from .refunds import Refund, RefundStatus
+from .reports import (
+    ReportRun,
+    ReportRunStatus,
+    SavedReport,
+)
 from .retention import (
     OrgRetentionPolicy,
     RetentionResourceType,
@@ -112,10 +117,13 @@ __all__ = [
     "Refund",
     "RefundStatus",
     "RefreshToken",
+    "ReportRun",
+    "ReportRunStatus",
     "Repo",
     "RetentionResourceType",
     "Subscription",
     "SubscriptionEvent",
+    "SavedReport",
     "ScheduledJob",
     "Setting",
     "SettingCategory",

--- a/src/dev_health_ops/models/reports.py
+++ b/src/dev_health_ops/models/reports.py
@@ -1,0 +1,225 @@
+"""Saved report and report run models.
+
+Persistence flows through Postgres semantic layer only — no file exports.
+"""
+
+from __future__ import annotations
+
+import copy
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Text,
+)
+from sqlalchemy.orm import relationship
+
+from dev_health_ops.models.git import GUID, Base
+
+
+class ReportRunStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+class SavedReport(Base):
+    __tablename__ = "saved_reports"
+
+    id = Column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id = Column(Text, nullable=False, index=True, server_default="")
+    name = Column(Text, nullable=False, comment="Display name for this report")
+    description = Column(Text, nullable=True)
+
+    report_plan = Column(
+        JSON,
+        nullable=False,
+        default=dict,
+        comment="Serialized ReportPlan dataclass as JSON",
+    )
+
+    is_template = Column(Boolean, nullable=False, default=False)
+    template_source_id = Column(
+        GUID,
+        ForeignKey("saved_reports.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="ID of the report this was cloned from",
+    )
+
+    parameters = Column(
+        JSON,
+        nullable=True,
+        default=dict,
+        comment="Parameterized fields: team, repo, date_range overrides",
+    )
+
+    schedule_id = Column(
+        GUID,
+        ForeignKey("scheduled_jobs.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="FK to scheduled_jobs for recurring execution",
+    )
+    schedule = relationship("ScheduledJob", foreign_keys=[schedule_id])
+
+    is_active = Column(Boolean, nullable=False, default=True)
+    last_run_at = Column(DateTime(timezone=True), nullable=True)
+    last_run_status = Column(Text, nullable=True, comment="Last execution status")
+
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+    created_by = Column(Text, nullable=True, comment="User or system that created this")
+
+    runs = relationship(
+        "ReportRun",
+        back_populates="report",
+        cascade="all, delete-orphan",
+        lazy="raise",
+    )
+    template_source = relationship(
+        "SavedReport",
+        remote_side="SavedReport.id",
+        foreign_keys=[template_source_id],
+        lazy="raise",
+    )
+
+    __table_args__ = (
+        Index("ix_saved_reports_org_name", "org_id", "name"),
+        Index("ix_saved_reports_org_template", "org_id", "is_template"),
+    )
+
+    def __init__(
+        self,
+        name: str,
+        org_id: str = "",
+        description: str | None = None,
+        report_plan: dict | None = None,
+        is_template: bool = False,
+        template_source_id: uuid.UUID | None = None,
+        parameters: dict | None = None,
+        schedule_id: uuid.UUID | None = None,
+        is_active: bool = True,
+        created_by: str | None = None,
+    ):
+        self.id = uuid.uuid4()
+        self.org_id = org_id
+        self.name = name
+        self.description = description
+        self.report_plan = report_plan or {}
+        self.is_template = is_template
+        self.template_source_id = template_source_id
+        self.parameters = parameters or {}
+        self.schedule_id = schedule_id
+        self.is_active = is_active
+        self.created_by = created_by
+        self.created_at = datetime.now(timezone.utc)
+        self.updated_at = datetime.now(timezone.utc)
+
+    def clone(
+        self,
+        new_name: str | None = None,
+        parameter_overrides: dict | None = None,
+    ) -> SavedReport:
+        """Deep copy this report with a new ID. Sets template_source_id to self.id."""
+        cloned_plan = copy.deepcopy(self.report_plan)
+        cloned_params = copy.deepcopy(self.parameters or {})
+        if parameter_overrides:
+            cloned_params.update(parameter_overrides)
+
+        return SavedReport(
+            name=new_name or f"{self.name} (Copy)",
+            org_id=self.org_id,
+            description=self.description,
+            report_plan=cloned_plan,
+            is_template=False,
+            template_source_id=self.id,
+            parameters=cloned_params,
+            is_active=True,
+            created_by=self.created_by,
+        )
+
+
+class ReportRun(Base):
+    __tablename__ = "report_runs"
+
+    id = Column(GUID, primary_key=True, default=uuid.uuid4)
+    report_id = Column(
+        GUID,
+        ForeignKey("saved_reports.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    report = relationship("SavedReport", back_populates="runs")
+
+    status = Column(
+        Text,
+        nullable=False,
+        default=ReportRunStatus.PENDING.value,
+    )
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    duration_seconds = Column(Float, nullable=True)
+
+    rendered_markdown = Column(Text, nullable=True, comment="Rendered report markdown")
+    artifact_url = Column(
+        Text,
+        nullable=True,
+        comment="URL to externally stored artifact (future use)",
+    )
+
+    provenance_records = Column(
+        JSON,
+        nullable=True,
+        default=list,
+        comment="List of provenance records for this run",
+    )
+
+    error = Column(Text, nullable=True)
+    error_traceback = Column(Text, nullable=True)
+
+    triggered_by = Column(
+        Text,
+        nullable=False,
+        default="manual",
+        comment="What triggered this run: scheduler, manual, api",
+    )
+
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        Index("ix_report_runs_report_created", "report_id", "created_at"),
+        Index("ix_report_runs_status", "status"),
+    )
+
+    def __init__(
+        self,
+        report_id: uuid.UUID,
+        triggered_by: str = "manual",
+        status: str = ReportRunStatus.PENDING.value,
+    ):
+        self.id = uuid.uuid4()
+        self.report_id = report_id
+        self.triggered_by = triggered_by
+        self.status = status
+        self.created_at = datetime.now(timezone.utc)

--- a/src/dev_health_ops/reports/export.py
+++ b/src/dev_health_ops/reports/export.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.reports import ReportRun, ReportRunStatus, SavedReport
+
+
+def persist_report_run(
+    session: Session,
+    run_id: str,
+    report_id: str,
+    rendered_markdown: str,
+    provenance: list[dict] | None = None,
+) -> None:
+    run = session.execute(select(ReportRun).where(ReportRun.id == run_id)).scalar_one()
+
+    now = datetime.now(timezone.utc)
+    run.status = ReportRunStatus.SUCCESS.value
+    run.completed_at = now
+    if run.started_at:
+        run.duration_seconds = (now - run.started_at).total_seconds()
+    run.rendered_markdown = rendered_markdown
+    run.provenance_records = provenance or []
+
+    report = session.execute(
+        select(SavedReport).where(SavedReport.id == report_id)
+    ).scalar_one()
+    report.last_run_at = now
+    report.last_run_status = ReportRunStatus.SUCCESS.value
+    report.updated_at = now

--- a/src/dev_health_ops/workers/report_scheduler.py
+++ b/src/dev_health_ops/workers/report_scheduler.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from dev_health_ops.workers.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    bind=True, name="dev_health_ops.workers.tasks.dispatch_scheduled_reports"
+)
+def dispatch_scheduled_reports(self) -> dict:
+    from croniter import croniter
+
+    from dev_health_ops.db import get_postgres_session_sync
+    from dev_health_ops.models.reports import ReportRun, ReportRunStatus, SavedReport
+    from dev_health_ops.models.settings import JobStatus, ScheduledJob
+
+    now = datetime.now(timezone.utc)
+    dispatched: list[str] = []
+    skipped = 0
+
+    try:
+        with get_postgres_session_sync() as session:
+            jobs = (
+                session.query(ScheduledJob)
+                .filter(
+                    ScheduledJob.job_type == "report",
+                    ScheduledJob.status == JobStatus.ACTIVE.value,
+                    ScheduledJob.is_running.is_(False),
+                )
+                .all()
+            )
+
+            for job in jobs:
+                report = (
+                    session.query(SavedReport)
+                    .filter(
+                        SavedReport.schedule_id == job.id,
+                        SavedReport.is_active.is_(True),
+                    )
+                    .one_or_none()
+                )
+
+                if report is None:
+                    skipped += 1
+                    continue
+
+                last_run = report.last_run_at or report.created_at
+                cron = croniter(job.schedule_cron, last_run)
+                next_run = cron.get_next(datetime)
+
+                if next_run <= now:
+                    run = ReportRun(
+                        report_id=report.id,
+                        triggered_by="scheduler",
+                        status=ReportRunStatus.PENDING.value,
+                    )
+                    session.add(run)
+                    session.flush()
+
+                    from dev_health_ops.workers.report_task import (
+                        execute_saved_report,
+                    )
+
+                    execute_saved_report.apply_async(
+                        kwargs={
+                            "report_id": str(report.id),
+                            "run_id": str(run.id),
+                        },
+                        queue="reports",
+                    )
+                    dispatched.append(str(report.id))
+                else:
+                    skipped += 1
+
+    except Exception:
+        logger.exception("dispatch_scheduled_reports failed")
+
+    logger.info(
+        "Scheduled report dispatch: dispatched=%d skipped=%d",
+        len(dispatched),
+        skipped,
+    )
+    return {"dispatched": dispatched, "skipped": skipped}

--- a/src/dev_health_ops/workers/report_task.py
+++ b/src/dev_health_ops/workers/report_task.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import traceback
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+
+from dev_health_ops.workers.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(bind=True, name="dev_health_ops.workers.tasks.execute_saved_report")
+def execute_saved_report(self, report_id: str, run_id: str) -> dict:
+    from dev_health_ops.db import get_postgres_session_sync, require_clickhouse_uri
+    from dev_health_ops.models.reports import ReportRun, ReportRunStatus, SavedReport
+    from dev_health_ops.reports.export import persist_report_run
+
+    with get_postgres_session_sync() as session:
+        report = session.execute(
+            select(SavedReport).where(SavedReport.id == report_id)
+        ).scalar_one_or_none()
+
+        if report is None:
+            logger.error("SavedReport %s not found", report_id)
+            return {"status": "error", "reason": "report_not_found"}
+
+        run = session.execute(
+            select(ReportRun).where(ReportRun.id == run_id)
+        ).scalar_one_or_none()
+
+        if run is None:
+            logger.error("ReportRun %s not found", run_id)
+            return {"status": "error", "reason": "run_not_found"}
+
+        run.status = ReportRunStatus.RUNNING.value
+        run.started_at = datetime.now(timezone.utc)
+        session.commit()
+
+    try:
+        from dev_health_ops.db import reset_async_engines
+        from dev_health_ops.metrics.testops_schemas import ChartSpec, ReportPlan
+        from dev_health_ops.reports.engine import execute_report
+
+        reset_async_engines()
+
+        clickhouse_dsn = require_clickhouse_uri()
+
+        with get_postgres_session_sync() as session:
+            report = session.execute(
+                select(SavedReport).where(SavedReport.id == report_id)
+            ).scalar_one()
+            plan_data = report.report_plan or {}
+
+        plan = ReportPlan(**plan_data) if plan_data else None
+        if plan is None:
+            raise ValueError("Report has no valid plan")
+
+        chart_specs = [ChartSpec(**spec) for spec in plan_data.get("chart_specs", [])]
+
+        result = asyncio.run(execute_report(plan, chart_specs, clickhouse_dsn))
+
+        with get_postgres_session_sync() as session:
+            persist_report_run(
+                session=session,
+                run_id=run_id,
+                report_id=report_id,
+                rendered_markdown=result.rendered_markdown,
+                provenance=[
+                    {
+                        "provenance_id": p.provenance_id,
+                        "artifact_type": p.artifact_type,
+                        "artifact_id": p.artifact_id,
+                    }
+                    for p in result.provenance
+                ],
+            )
+
+        return {"status": "success", "run_id": run_id}
+
+    except Exception as exc:
+        logger.exception("Report execution failed for run %s", run_id)
+        with get_postgres_session_sync() as session:
+            run = session.execute(
+                select(ReportRun).where(ReportRun.id == run_id)
+            ).scalar_one_or_none()
+            if run:
+                run.status = ReportRunStatus.FAILED.value
+                run.completed_at = datetime.now(timezone.utc)
+                if run.started_at:
+                    run.duration_seconds = (
+                        run.completed_at - run.started_at
+                    ).total_seconds()
+                run.error = str(exc)
+                run.error_traceback = traceback.format_exc()
+                session.commit()
+
+            report_obj = session.execute(
+                select(SavedReport).where(SavedReport.id == report_id)
+            ).scalar_one_or_none()
+            if report_obj:
+                report_obj.last_run_at = datetime.now(timezone.utc)
+                report_obj.last_run_status = ReportRunStatus.FAILED.value
+                session.commit()
+
+        return {"status": "failed", "run_id": run_id, "error": str(exc)}

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -11,6 +11,8 @@ from dev_health_ops.workers.product_tasks import (
     run_capacity_forecast_job,
     sync_teams_to_analytics,
 )
+from dev_health_ops.workers.report_scheduler import dispatch_scheduled_reports
+from dev_health_ops.workers.report_task import execute_saved_report
 from dev_health_ops.workers.sync_batch import (
     _batch_sync_callback,
     _get_batch_size,
@@ -60,7 +62,9 @@ __all__ = [
     "dispatch_batch_sync",
     "dispatch_daily_metrics_partitioned",
     "dispatch_scheduled_metrics",
+    "dispatch_scheduled_reports",
     "dispatch_scheduled_syncs",
+    "execute_saved_report",
     "health_check",
     "phone_home_heartbeat",
     "process_webhook_event",

--- a/tests/api/test_saved_reports.py
+++ b/tests/api/test_saved_reports.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.reports import ReportRun, ReportRunStatus, SavedReport
+from dev_health_ops.models.settings import ScheduledJob
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "saved-reports-api.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=[
+                    SavedReport.__table__,
+                    ReportRun.__table__,
+                    ScheduledJob.__table__,
+                ],
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_reports(session_maker):
+    org_id = "test-org"
+    async with session_maker() as session:
+        r1 = SavedReport(
+            name="Weekly Health",
+            org_id=org_id,
+            report_plan={"report_type": "weekly_health", "plan_id": "p1"},
+            parameters={"team": "backend"},
+        )
+        r2 = SavedReport(
+            name="Monthly Review",
+            org_id=org_id,
+            report_plan={"report_type": "monthly_review", "plan_id": "p2"},
+            is_template=True,
+        )
+        session.add_all([r1, r2])
+        await session.commit()
+
+        run1 = ReportRun(
+            report_id=r1.id,
+            triggered_by="manual",
+            status=ReportRunStatus.SUCCESS.value,
+        )
+        run1.rendered_markdown = "# Weekly Health\nAll good."
+        session.add(run1)
+        await session.commit()
+
+    return {
+        "org_id": org_id,
+        "report1_id": str(r1.id),
+        "report2_id": str(r2.id),
+        "run1_id": str(run1.id),
+    }
+
+
+def _make_mock_session(session_maker):
+    @asynccontextmanager
+    async def mock_get_postgres_session():
+        async with session_maker() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    return mock_get_postgres_session
+
+
+@pytest.mark.asyncio
+async def test_resolve_saved_reports(monkeypatch, session_maker, seeded_reports):
+    from dev_health_ops.api.graphql.resolvers import reports as reports_mod
+
+    monkeypatch.setattr(
+        "dev_health_ops.db.get_postgres_session",
+        _make_mock_session(session_maker),
+    )
+
+    result = await reports_mod.resolve_saved_reports(
+        org_id=seeded_reports["org_id"], limit=50, offset=0
+    )
+    assert result.total == 2
+    assert len(result.items) == 2
+    names = {r.name for r in result.items}
+    assert "Weekly Health" in names
+    assert "Monthly Review" in names
+
+
+@pytest.mark.asyncio
+async def test_resolve_saved_report_by_id(monkeypatch, session_maker, seeded_reports):
+    from dev_health_ops.api.graphql.resolvers import reports as reports_mod
+
+    monkeypatch.setattr(
+        "dev_health_ops.db.get_postgres_session",
+        _make_mock_session(session_maker),
+    )
+
+    result = await reports_mod.resolve_saved_report(
+        org_id=seeded_reports["org_id"],
+        report_id=seeded_reports["report1_id"],
+    )
+    assert result is not None
+    assert result.name == "Weekly Health"
+
+    missing = await reports_mod.resolve_saved_report(
+        org_id=seeded_reports["org_id"],
+        report_id=str(uuid.uuid4()),
+    )
+    assert missing is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_report_runs(monkeypatch, session_maker, seeded_reports):
+    from dev_health_ops.api.graphql.resolvers import reports as reports_mod
+
+    monkeypatch.setattr(
+        "dev_health_ops.db.get_postgres_session",
+        _make_mock_session(session_maker),
+    )
+
+    result = await reports_mod.resolve_report_runs(
+        org_id=seeded_reports["org_id"],
+        report_id=seeded_reports["report1_id"],
+        limit=10,
+    )
+    assert result.total == 1
+    assert result.items[0].status == "success"
+    assert result.items[0].rendered_markdown == "# Weekly Health\nAll good."
+
+
+@pytest.mark.asyncio
+async def test_create_and_delete_saved_report(
+    monkeypatch, session_maker, seeded_reports
+):
+    from dev_health_ops.api.graphql.resolvers import reports as reports_mod
+
+    monkeypatch.setattr(
+        "dev_health_ops.db.get_postgres_session",
+        _make_mock_session(session_maker),
+    )
+
+    created = await reports_mod.resolve_create_saved_report(
+        org_id=seeded_reports["org_id"],
+        input=reports_mod.CreateSavedReportInput(
+            name="New Report",
+            description="Test creation",
+            report_plan={"report_type": "custom"},
+        ),
+    )
+    assert created.name == "New Report"
+    assert created.description == "Test creation"
+
+    deleted = await reports_mod.resolve_delete_saved_report(
+        org_id=seeded_reports["org_id"],
+        report_id=created.id,
+    )
+    assert deleted is True
+
+    gone = await reports_mod.resolve_saved_report(
+        org_id=seeded_reports["org_id"],
+        report_id=created.id,
+    )
+    assert gone is None
+
+
+@pytest.mark.asyncio
+async def test_clone_saved_report(monkeypatch, session_maker, seeded_reports):
+    from dev_health_ops.api.graphql.resolvers import reports as reports_mod
+
+    monkeypatch.setattr(
+        "dev_health_ops.db.get_postgres_session",
+        _make_mock_session(session_maker),
+    )
+
+    cloned = await reports_mod.resolve_clone_saved_report(
+        org_id=seeded_reports["org_id"],
+        input=reports_mod.CloneSavedReportInput(
+            source_report_id=seeded_reports["report1_id"],
+            new_name="Cloned Weekly",
+            parameter_overrides={"team": "frontend"},
+        ),
+    )
+    assert cloned is not None
+    assert cloned.name == "Cloned Weekly"
+    assert cloned.template_source_id == seeded_reports["report1_id"]
+
+
+@pytest.mark.asyncio
+async def test_update_saved_report(monkeypatch, session_maker, seeded_reports):
+    from dev_health_ops.api.graphql.resolvers import reports as reports_mod
+
+    monkeypatch.setattr(
+        "dev_health_ops.db.get_postgres_session",
+        _make_mock_session(session_maker),
+    )
+
+    updated = await reports_mod.resolve_update_saved_report(
+        org_id=seeded_reports["org_id"],
+        report_id=seeded_reports["report1_id"],
+        input=reports_mod.UpdateSavedReportInput(
+            name="Updated Weekly Health",
+            is_active=False,
+        ),
+    )
+    assert updated is not None
+    assert updated.name == "Updated Weekly Health"
+    assert updated.is_active is False

--- a/tests/models/test_reports.py
+++ b/tests/models/test_reports.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.reports import ReportRun, ReportRunStatus, SavedReport
+from dev_health_ops.models.settings import ScheduledJob
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "reports-test.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=[
+                    SavedReport.__table__,
+                    ReportRun.__table__,
+                    ScheduledJob.__table__,
+                ],
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_saved_report_creation(session_maker):
+    async with session_maker() as session:
+        report = SavedReport(
+            name="Weekly Health",
+            org_id="org-1",
+            description="Weekly team health report",
+            report_plan={"report_type": "weekly_health", "plan_id": "p1"},
+            is_template=False,
+            parameters={"team": "backend"},
+        )
+        session.add(report)
+        await session.commit()
+
+        assert report.id is not None
+        assert report.name == "Weekly Health"
+        assert report.org_id == "org-1"
+        assert report.report_plan["report_type"] == "weekly_health"
+        assert report.is_active is True
+        assert report.is_template is False
+
+
+@pytest.mark.asyncio
+async def test_saved_report_clone(session_maker):
+    async with session_maker() as session:
+        original = SavedReport(
+            name="Monthly Review",
+            org_id="org-1",
+            report_plan={"report_type": "monthly_review", "plan_id": "p2"},
+            parameters={"team": "platform", "date_range": "last_month"},
+        )
+        session.add(original)
+        await session.commit()
+
+        cloned = original.clone(
+            new_name="Monthly Review (Q1)",
+            parameter_overrides={"team": "frontend"},
+        )
+        session.add(cloned)
+        await session.commit()
+
+        assert cloned.id != original.id
+        assert cloned.name == "Monthly Review (Q1)"
+        assert cloned.template_source_id == original.id
+        assert cloned.is_template is False
+        assert cloned.parameters["team"] == "frontend"
+        assert cloned.parameters["date_range"] == "last_month"
+        assert cloned.report_plan["report_type"] == "monthly_review"
+
+
+@pytest.mark.asyncio
+async def test_saved_report_clone_default_name(session_maker):
+    async with session_maker() as session:
+        original = SavedReport(name="Sprint Report", org_id="org-1")
+        session.add(original)
+        await session.commit()
+
+        cloned = original.clone()
+        assert cloned.name == "Sprint Report (Copy)"
+
+
+@pytest.mark.asyncio
+async def test_report_run_creation(session_maker):
+    async with session_maker() as session:
+        report = SavedReport(name="Test Report", org_id="org-1")
+        session.add(report)
+        await session.commit()
+
+        run = ReportRun(
+            report_id=report.id,
+            triggered_by="manual",
+        )
+        session.add(run)
+        await session.commit()
+
+        assert run.id is not None
+        assert run.report_id == report.id
+        assert run.status == ReportRunStatus.PENDING.value
+        assert run.triggered_by == "manual"
+        assert run.rendered_markdown is None
+        assert run.error is None
+
+
+@pytest.mark.asyncio
+async def test_report_run_status_enum():
+    assert ReportRunStatus.PENDING.value == "pending"
+    assert ReportRunStatus.RUNNING.value == "running"
+    assert ReportRunStatus.SUCCESS.value == "success"
+    assert ReportRunStatus.FAILED.value == "failed"
+
+
+@pytest.mark.asyncio
+async def test_saved_report_template_flag(session_maker):
+    async with session_maker() as session:
+        template = SavedReport(
+            name="Template: Quality Trend",
+            org_id="org-1",
+            report_plan={"report_type": "quality_trend"},
+            is_template=True,
+        )
+        session.add(template)
+        await session.commit()
+
+        assert template.is_template is True
+
+        cloned = template.clone(new_name="Q1 Quality Trend")
+        assert cloned.is_template is False
+        assert cloned.template_source_id == template.id


### PR DESCRIPTION
## Summary
- SavedReport + ReportRun SQLAlchemy models with Alembic migration
- 5 GraphQL mutations (create, update, delete, clone, trigger) and 3 queries
- Celery task for scheduled report execution using existing ScheduledJob pattern
- Markdown persistence via ReportRun (no file exports — sinks only)
- 12 tests (6 model + 6 API) all passing

## Issues
Closes CHAOS-1147, CHAOS-1148, CHAOS-1149, CHAOS-1150, CHAOS-1152
Closes CHAOS-1083

## Changes
### New Files (9)
- `models/reports.py` — SavedReport, ReportRun, ReportRunStatus
- `alembic/versions/0005_add_saved_reports_tables.py` — Migration
- `api/graphql/resolvers/reports.py` — Strawberry types + resolvers
- `workers/report_task.py` — Celery execute_saved_report
- `workers/report_scheduler.py` — dispatch_scheduled_reports
- `reports/export.py` — persist_report_run
- `tests/models/test_reports.py` — 6 model tests
- `tests/api/test_saved_reports.py` — 6 API tests

### Modified Files (3)
- `models/__init__.py` — Export new models
- `api/graphql/schema.py` — Added queries + Mutation type
- `workers/tasks.py` — Import/export new tasks

SCREENSHOT-WAIVER: Backend-only changes — no rendered UI affected