### PR TITLE
feat: TestOps synthetic data — job runs, test executions, coverage snapshots (CHAOS-1185)

### DIFF
--- a/src/dev_health_ops/fixtures/generator.py
+++ b/src/dev_health_ops/fixtures/generator.py
@@ -733,7 +733,6 @@ class SyntheticDataGenerator:
         branch_target = branch_coverage
 
         sorted_days = sorted(runs_by_day.keys())
-        prev_line_coverage = line_coverage
 
         for day in sorted_days:
             day_runs = runs_by_day[day]
@@ -748,9 +747,6 @@ class SyntheticDataGenerator:
             branch_coverage = max(30.0, min(95.0, branch_coverage + branch_delta))
 
             branch_coverage = min(branch_coverage, line_coverage - 2.0)
-
-            coverage_delta_pct = line_coverage - prev_line_coverage
-            prev_line_coverage = line_coverage
 
             lines_covered = int(lines_total * line_coverage / 100.0)
             branches_total = int(lines_total * 0.3)

--- a/src/dev_health_ops/fixtures/generator.py
+++ b/src/dev_health_ops/fixtures/generator.py
@@ -439,6 +439,350 @@ class SyntheticDataGenerator:
             current_date += timedelta(days=1)
         return runs
 
+    def generate_ci_job_runs(
+        self, pipeline_runs: list[CiPipelineRun]
+    ) -> list[dict[str, Any]]:
+        """Generate CI job runs for each pipeline run.
+
+        Returns dicts matching JobRunRow schema from testops_schemas.
+        Each pipeline run gets 2-5 jobs (build, test, lint, deploy, integration-test).
+        Status distribution: 75% success, 15% failed, 10% skipped
+        (failed pipelines have higher job failure rate).
+        """
+        job_names = ["build", "test", "lint", "deploy", "integration-test"]
+        duration_ranges: dict[str, tuple[int, int]] = {
+            "build": (120, 600),
+            "test": (180, 900),
+            "lint": (60, 180),
+            "deploy": (120, 1200),
+            "integration-test": (300, 1200),
+        }
+        job_runs: list[dict[str, Any]] = []
+
+        for pipeline in pipeline_runs:
+            num_jobs = random.randint(2, 5)
+            selected_jobs = random.sample(job_names, k=min(num_jobs, len(job_names)))
+            pipeline_failed = getattr(pipeline, "status", None) == "failed"
+
+            for job_idx, job_name in enumerate(selected_jobs):
+                queue_offset_seconds = random.randint(10, 300)
+                pipeline_queued = getattr(pipeline, "queued_at", None)
+                pipeline_started = getattr(pipeline, "started_at", None)
+                if pipeline_queued is None:
+                    pipeline_queued = pipeline_started
+                if pipeline_queued is None:
+                    continue
+
+                job_queued_at = pipeline_queued + timedelta(
+                    seconds=queue_offset_seconds + job_idx * 60
+                )
+                job_started_at = job_queued_at + timedelta(
+                    seconds=random.randint(10, 300)
+                )
+
+                dur_min, dur_max = duration_ranges.get(job_name, (60, 600))
+                duration_seconds = random.randint(dur_min, dur_max)
+                job_finished_at = job_started_at + timedelta(seconds=duration_seconds)
+
+                if pipeline_failed:
+                    status = random.choices(
+                        ["success", "failed", "skipped"],
+                        weights=[0.4, 0.45, 0.15],
+                        k=1,
+                    )[0]
+                else:
+                    status = random.choices(
+                        ["success", "failed", "skipped"],
+                        weights=[0.75, 0.15, 0.10],
+                        k=1,
+                    )[0]
+
+                job_id = f"{pipeline.run_id}-job-{job_idx}"
+
+                job_runs.append(
+                    {
+                        "repo_id": pipeline.repo_id,
+                        "run_id": pipeline.run_id,
+                        "job_id": job_id,
+                        "job_name": job_name,
+                        "stage": None,
+                        "status": status,
+                        "started_at": job_started_at,
+                        "finished_at": job_finished_at,
+                        "duration_seconds": float(duration_seconds),
+                        "runner_type": "hosted",
+                        "retry_attempt": 0,
+                        "org_id": "",
+                    }
+                )
+
+        return job_runs
+
+    def generate_test_executions(
+        self,
+        job_runs: list[dict[str, Any]],
+        days: int = 30,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Generate test suite and case results for test/integration-test jobs.
+
+        Returns dict with 'suite_results' (TestSuiteResultRow dicts) and
+        'case_results' (TestCaseResultRow dicts).
+        """
+        suite_results: list[dict[str, Any]] = []
+        case_results: list[dict[str, Any]] = []
+
+        flaky_test_names = [
+            "test_api_timeout",
+            "test_race_condition_handler",
+            "test_concurrent_db_writes",
+            "test_websocket_reconnect",
+            "test_cache_invalidation",
+            "test_async_event_ordering",
+            "test_retry_backoff_timing",
+            "test_session_expiry_edge",
+        ]
+
+        test_name_pools = {
+            "test": [
+                "test_user_creation",
+                "test_login_flow",
+                "test_data_validation",
+                "test_error_handling",
+                "test_pagination",
+                "test_search_query",
+                "test_permission_check",
+                "test_rate_limiter",
+                "test_input_sanitization",
+                "test_config_loading",
+                "test_db_connection",
+                "test_cache_hit",
+                "test_serialization",
+                "test_middleware_chain",
+                "test_health_endpoint",
+            ],
+            "integration-test": [
+                "test_end_to_end_signup",
+                "test_payment_flow",
+                "test_webhook_delivery",
+                "test_third_party_sync",
+                "test_bulk_import",
+                "test_report_generation",
+                "test_notification_pipeline",
+                "test_data_export",
+            ],
+        }
+
+        for job in job_runs:
+            job_name = job.get("job_name", "")
+            if job_name not in ("test", "integration-test"):
+                continue
+
+            repo_id = job["repo_id"]
+            run_id = job["run_id"]
+            job_id = job["job_id"]
+
+            total_tests = random.randint(50, 500)
+
+            is_bad_run = random.random() < 0.08
+            if is_bad_run:
+                pass_rate = random.uniform(0.65, 0.75)
+            else:
+                pass_rate = random.uniform(0.85, 0.98)
+
+            passed = int(total_tests * pass_rate)
+            flake_rate = random.uniform(0.02, 0.08)
+            flaky_count = max(0, int(total_tests * flake_rate))
+            skipped = random.randint(0, max(1, total_tests // 20))
+            failed = total_tests - passed - skipped
+            if failed < 0:
+                failed = 0
+                passed = total_tests - skipped
+
+            suite_duration = random.uniform(30.0, 600.0)
+
+            suite_name = f"{job_name}_suite_{job_id}"
+            suite_id = f"suite-{run_id}-{job_id}"
+
+            job_started = job.get("started_at")
+            job_finished = job.get("finished_at")
+
+            suite_results.append(
+                {
+                    "repo_id": repo_id,
+                    "run_id": run_id,
+                    "suite_id": suite_id,
+                    "suite_name": suite_name,
+                    "framework": "pytest" if job_name == "test" else "playwright",
+                    "environment": "linux-x64",
+                    "total_count": total_tests,
+                    "passed_count": passed,
+                    "failed_count": failed,
+                    "skipped_count": skipped,
+                    "error_count": 0,
+                    "quarantined_count": 0,
+                    "retried_count": flaky_count,
+                    "duration_seconds": suite_duration,
+                    "started_at": job_started,
+                    "finished_at": job_finished,
+                    "team_id": None,
+                    "service_id": None,
+                    "org_id": "",
+                }
+            )
+
+            name_pool = test_name_pools.get(job_name, test_name_pools["test"])
+            all_names = list(name_pool) + list(flaky_test_names)
+
+            case_names: list[str] = []
+            for i in range(total_tests):
+                base = all_names[i % len(all_names)]
+                suffix = f"_{i // len(all_names)}" if i >= len(all_names) else ""
+                case_names.append(f"{base}{suffix}")
+
+            flaky_indices = set(
+                random.sample(range(total_tests), k=min(flaky_count, total_tests))
+            )
+
+            passed_so_far = 0
+            failed_so_far = 0
+            skipped_so_far = 0
+
+            for case_idx, case_name in enumerate(case_names):
+                if case_idx in flaky_indices:
+                    case_status = "passed"
+                    retry_attempt = 1
+                    passed_so_far += 1
+                elif skipped_so_far < skipped and random.random() < 0.3:
+                    case_status = "skipped"
+                    retry_attempt = 0
+                    skipped_so_far += 1
+                elif failed_so_far < failed and random.random() < (
+                    failed / max(1, total_tests - case_idx)
+                ):
+                    case_status = "failed"
+                    retry_attempt = 0
+                    failed_so_far += 1
+                else:
+                    case_status = "passed"
+                    retry_attempt = 0
+                    passed_so_far += 1
+
+                case_duration = random.uniform(
+                    0.01, suite_duration / max(1, total_tests) * 3
+                )
+
+                case_id = f"case-{suite_id}-{case_idx}"
+                failure_message = None
+                failure_type = None
+                if case_status == "failed":
+                    failure_type = random.choice(
+                        ["assertion", "timeout", "error", "infrastructure"]
+                    )
+                    failure_message = f"Expected condition not met in {case_name}"
+
+                case_results.append(
+                    {
+                        "repo_id": repo_id,
+                        "run_id": run_id,
+                        "suite_id": suite_id,
+                        "case_id": case_id,
+                        "case_name": case_name,
+                        "class_name": suite_name,
+                        "status": case_status,
+                        "duration_seconds": case_duration,
+                        "retry_attempt": retry_attempt,
+                        "failure_message": failure_message,
+                        "failure_type": failure_type,
+                        "stack_trace": None,
+                        "is_quarantined": False,
+                        "org_id": "",
+                    }
+                )
+
+        return {"suite_results": suite_results, "case_results": case_results}
+
+    def generate_coverage_snapshots(
+        self,
+        pipeline_runs: list[CiPipelineRun],
+        days: int = 30,
+    ) -> list[dict[str, Any]]:
+        """Generate daily coverage snapshots tied to pipeline runs.
+
+        Returns dicts matching CoverageSnapshotRow schema.
+        Uses random walk with mean reversion for realistic drift.
+        One snapshot per day per repo (picks a pipeline run from that day).
+        """
+        if not pipeline_runs:
+            return []
+
+        snapshots: list[dict[str, Any]] = []
+
+        runs_by_day: dict[date, list[CiPipelineRun]] = {}
+        for run in pipeline_runs:
+            started = getattr(run, "started_at", None)
+            if started is None:
+                continue
+            day = started.date()
+            runs_by_day.setdefault(day, []).append(run)
+
+        line_coverage = random.uniform(70.0, 90.0)
+        branch_coverage = line_coverage - random.uniform(5.0, 15.0)
+        lines_total = random.randint(8000, 50000)
+
+        line_target = line_coverage
+        branch_target = branch_coverage
+
+        sorted_days = sorted(runs_by_day.keys())
+        prev_line_coverage = line_coverage
+
+        for day in sorted_days:
+            day_runs = runs_by_day[day]
+            chosen_run = random.choice(day_runs)
+
+            line_delta = random.gauss(0, 0.5)
+            line_delta += (line_target - line_coverage) * 0.1
+            line_coverage = max(40.0, min(99.0, line_coverage + line_delta))
+
+            branch_delta = random.gauss(0, 0.4)
+            branch_delta += (branch_target - branch_coverage) * 0.1
+            branch_coverage = max(30.0, min(95.0, branch_coverage + branch_delta))
+
+            branch_coverage = min(branch_coverage, line_coverage - 2.0)
+
+            coverage_delta_pct = line_coverage - prev_line_coverage
+            prev_line_coverage = line_coverage
+
+            lines_covered = int(lines_total * line_coverage / 100.0)
+            branches_total = int(lines_total * 0.3)
+            branches_covered = int(branches_total * branch_coverage / 100.0)
+
+            snapshot_id = f"cov-{chosen_run.run_id}-{day.isoformat()}"
+
+            snapshots.append(
+                {
+                    "repo_id": self.repo_id,
+                    "run_id": chosen_run.run_id,
+                    "snapshot_id": snapshot_id,
+                    "report_format": "lcov",
+                    "lines_total": lines_total,
+                    "lines_covered": lines_covered,
+                    "line_coverage_pct": round(line_coverage, 2),
+                    "branches_total": branches_total,
+                    "branches_covered": branches_covered,
+                    "branch_coverage_pct": round(branch_coverage, 2),
+                    "functions_total": None,
+                    "functions_covered": None,
+                    "commit_hash": None,
+                    "branch": "main",
+                    "pr_number": None,
+                    "team_id": None,
+                    "service_id": None,
+                    "org_id": "",
+                }
+            )
+
+        return snapshots
+
     def generate_deployments(
         self,
         days: int = 30,

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -369,6 +369,39 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                 store.insert_incidents, incidents, allow_parallel=allow_parallel_inserts
             )
 
+            # 6b. TestOps raw data (ci_job_runs, test results, coverage)
+            if hasattr(store, "insert_ci_job_runs"):
+                job_runs = generator.generate_ci_job_runs(pipeline_runs)
+                await _insert_batches(
+                    store.insert_ci_job_runs,
+                    job_runs,
+                    allow_parallel=allow_parallel_inserts,
+                )
+
+                test_data = generator.generate_test_executions(job_runs, days=ns.days)
+                if hasattr(store, "insert_test_suite_results"):
+                    await _insert_batches(
+                        store.insert_test_suite_results,
+                        test_data["suite_results"],
+                        allow_parallel=allow_parallel_inserts,
+                    )
+                if hasattr(store, "insert_test_case_results"):
+                    await _insert_batches(
+                        store.insert_test_case_results,
+                        test_data["case_results"],
+                        allow_parallel=allow_parallel_inserts,
+                    )
+
+                coverage_snapshots = generator.generate_coverage_snapshots(
+                    pipeline_runs, days=ns.days
+                )
+                if hasattr(store, "insert_coverage_snapshots"):
+                    await _insert_batches(
+                        store.insert_coverage_snapshots,
+                        coverage_snapshots,
+                        allow_parallel=allow_parallel_inserts,
+                    )
+
             # 7. Blame
             blame_data = generator.generate_blame(commits)
             await _insert_batches(

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -847,6 +847,52 @@ class ClickHouseStore:
             rows,
         )
 
+    async def insert_ci_job_runs(self, jobs: list[dict[str, Any]]) -> None:
+        if not jobs:
+            return
+        synced_at_default = self._normalize_datetime(datetime.now(timezone.utc))
+        rows: list[dict[str, Any]] = []
+        for item in jobs:
+            rows.append(
+                {
+                    "repo_id": self._normalize_uuid(item.get("repo_id")),
+                    "run_id": str(item.get("run_id") or ""),
+                    "job_id": str(item.get("job_id") or ""),
+                    "job_name": str(item.get("job_name") or ""),
+                    "stage": item.get("stage"),
+                    "status": item.get("status"),
+                    "started_at": self._normalize_datetime(item.get("started_at")),
+                    "finished_at": self._normalize_datetime(item.get("finished_at")),
+                    "duration_seconds": item.get("duration_seconds"),
+                    "runner_type": item.get("runner_type"),
+                    "retry_attempt": int(item.get("retry_attempt") or 0),
+                    "org_id": str(item.get("org_id") or ""),
+                    "last_synced": self._normalize_datetime(
+                        item.get("last_synced") or synced_at_default
+                    ),
+                }
+            )
+
+        await self._insert_rows(
+            "ci_job_runs",
+            [
+                "repo_id",
+                "run_id",
+                "job_id",
+                "job_name",
+                "stage",
+                "status",
+                "started_at",
+                "finished_at",
+                "duration_seconds",
+                "runner_type",
+                "retry_attempt",
+                "org_id",
+                "last_synced",
+            ],
+            rows,
+        )
+
     async def insert_deployments(self, deployments: list[Deployment]) -> None:
         if not deployments:
             return

--- a/tests/test_fixtures_testops.py
+++ b/tests/test_fixtures_testops.py
@@ -1,5 +1,3 @@
-import uuid
-
 import pytest
 
 from dev_health_ops.fixtures.generator import SyntheticDataGenerator

--- a/tests/test_fixtures_testops.py
+++ b/tests/test_fixtures_testops.py
@@ -1,0 +1,210 @@
+import uuid
+
+import pytest
+
+from dev_health_ops.fixtures.generator import SyntheticDataGenerator
+from dev_health_ops.models.git import CiPipelineRun
+
+
+@pytest.fixture
+def generator() -> SyntheticDataGenerator:
+    return SyntheticDataGenerator(repo_name="acme/demo-app", seed=42)
+
+
+@pytest.fixture
+def pipeline_runs(generator: SyntheticDataGenerator) -> list[CiPipelineRun]:
+    return generator.generate_ci_pipeline_runs(days=7, runs_per_day=3)
+
+
+class TestGenerateCiJobRuns:
+    def test_returns_nonempty(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        job_runs = generator.generate_ci_job_runs(pipeline_runs)
+        assert len(job_runs) > 0
+
+    def test_each_job_references_valid_pipeline(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        run_ids = {pr.run_id for pr in pipeline_runs}
+        job_runs = generator.generate_ci_job_runs(pipeline_runs)
+        for job in job_runs:
+            assert job["run_id"] in run_ids
+
+    def test_job_has_required_fields(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        job_runs = generator.generate_ci_job_runs(pipeline_runs)
+        required = {
+            "repo_id",
+            "run_id",
+            "job_id",
+            "job_name",
+            "status",
+            "started_at",
+            "finished_at",
+            "duration_seconds",
+        }
+        for job in job_runs[:10]:
+            assert required.issubset(job.keys()), (
+                f"Missing keys: {required - job.keys()}"
+            )
+
+    def test_status_values(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        job_runs = generator.generate_ci_job_runs(pipeline_runs)
+        valid_statuses = {"success", "failed", "skipped"}
+        for job in job_runs:
+            assert job["status"] in valid_statuses
+
+    def test_job_names_are_valid(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        valid_names = {"build", "test", "lint", "deploy", "integration-test"}
+        job_runs = generator.generate_ci_job_runs(pipeline_runs)
+        for job in job_runs:
+            assert job["job_name"] in valid_names
+
+    def test_two_to_five_jobs_per_pipeline(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        job_runs = generator.generate_ci_job_runs(pipeline_runs)
+        jobs_per_pipeline: dict[str, int] = {}
+        for job in job_runs:
+            jobs_per_pipeline[job["run_id"]] = (
+                jobs_per_pipeline.get(job["run_id"], 0) + 1
+            )
+        for count in jobs_per_pipeline.values():
+            assert 2 <= count <= 5
+
+    def test_empty_pipeline_list(self, generator: SyntheticDataGenerator) -> None:
+        assert generator.generate_ci_job_runs([]) == []
+
+
+class TestGenerateTestExecutions:
+    def test_returns_suite_and_case_results(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        job_runs = generator.generate_ci_job_runs(pipeline_runs)
+        result = generator.generate_test_executions(job_runs)
+        assert "suite_results" in result
+        assert "case_results" in result
+
+    def test_only_test_jobs_produce_results(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        job_runs = generator.generate_ci_job_runs(pipeline_runs)
+        test_job_count = sum(
+            1 for j in job_runs if j["job_name"] in ("test", "integration-test")
+        )
+        result = generator.generate_test_executions(job_runs)
+        assert len(result["suite_results"]) == test_job_count
+
+    def test_suite_counts_are_consistent(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        job_runs = generator.generate_ci_job_runs(pipeline_runs)
+        result = generator.generate_test_executions(job_runs)
+        for suite in result["suite_results"]:
+            total = suite["total_count"]
+            assert total >= 50
+            assert total <= 500
+            assert suite["passed_count"] >= 0
+            assert suite["failed_count"] >= 0
+            assert suite["skipped_count"] >= 0
+
+    def test_case_results_reference_valid_suites(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        job_runs = generator.generate_ci_job_runs(pipeline_runs)
+        result = generator.generate_test_executions(job_runs)
+        suite_ids = {s["suite_id"] for s in result["suite_results"]}
+        for case in result["case_results"][:50]:
+            assert case["suite_id"] in suite_ids
+
+    def test_case_required_fields(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        job_runs = generator.generate_ci_job_runs(pipeline_runs)
+        result = generator.generate_test_executions(job_runs)
+        required = {
+            "repo_id",
+            "run_id",
+            "suite_id",
+            "case_id",
+            "case_name",
+            "status",
+            "duration_seconds",
+        }
+        for case in result["case_results"][:10]:
+            assert required.issubset(case.keys())
+
+    def test_case_statuses(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        job_runs = generator.generate_ci_job_runs(pipeline_runs)
+        result = generator.generate_test_executions(job_runs)
+        valid = {"passed", "failed", "skipped"}
+        for case in result["case_results"]:
+            assert case["status"] in valid
+
+    def test_empty_job_runs(self, generator: SyntheticDataGenerator) -> None:
+        result = generator.generate_test_executions([])
+        assert result["suite_results"] == []
+        assert result["case_results"] == []
+
+
+class TestGenerateCoverageSnapshots:
+    def test_returns_snapshots(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        snapshots = generator.generate_coverage_snapshots(pipeline_runs, days=7)
+        assert len(snapshots) > 0
+
+    def test_line_coverage_in_range(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        snapshots = generator.generate_coverage_snapshots(pipeline_runs, days=7)
+        for snap in snapshots:
+            assert 0.0 <= snap["line_coverage_pct"] <= 100.0
+
+    def test_branch_coverage_less_than_line(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        snapshots = generator.generate_coverage_snapshots(pipeline_runs, days=7)
+        for snap in snapshots:
+            assert snap["branch_coverage_pct"] <= snap["line_coverage_pct"]
+
+    def test_required_fields(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        snapshots = generator.generate_coverage_snapshots(pipeline_runs, days=7)
+        required = {
+            "repo_id",
+            "run_id",
+            "snapshot_id",
+            "lines_total",
+            "lines_covered",
+            "line_coverage_pct",
+        }
+        for snap in snapshots[:5]:
+            assert required.issubset(snap.keys())
+
+    def test_lines_covered_consistent(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        snapshots = generator.generate_coverage_snapshots(pipeline_runs, days=7)
+        for snap in snapshots:
+            assert snap["lines_covered"] <= snap["lines_total"]
+
+    def test_references_valid_pipeline_runs(
+        self, generator: SyntheticDataGenerator, pipeline_runs: list[CiPipelineRun]
+    ) -> None:
+        run_ids = {pr.run_id for pr in pipeline_runs}
+        snapshots = generator.generate_coverage_snapshots(pipeline_runs, days=7)
+        for snap in snapshots:
+            assert snap["run_id"] in run_ids
+
+    def test_empty_pipeline_list(self, generator: SyntheticDataGenerator) -> None:
+        assert generator.generate_coverage_snapshots([], days=7) == []


### PR DESCRIPTION
## Summary
- 3 new generator methods for TestOps raw data: `generate_ci_job_runs`, `generate_test_executions`, `generate_coverage_snapshots`
- Wired into fixture runner so `dev-hops fixtures generate --with-metrics` populates all TestOps tables
- 21 new tests covering field shapes, referential integrity, and value ranges

## Problem
The fixture generator only created `CiPipelineRun` records. The TestOps compute pipeline (`compute_testops`) needs 3 additional raw tables to produce dashboard metrics:
- `ci_job_runs` — job-level pipeline data
- `test_executions` (suite + case results) — test pass/fail/flake data
- `coverage_snapshots` — daily line/branch coverage

Without this data, `testops_test_metrics_daily` and `testops_coverage_metrics_daily` were empty.

## Issues
Closes CHAOS-1185

## Changes
- `fixtures/generator.py` — 3 new methods with realistic distributions (85-98% pass rate, 2-8% flake rate, 70-90% coverage with random walk)
- `fixtures/runner.py` — Section 6b wires generators after pipeline run insertion
- `storage/clickhouse.py` — Added `insert_ci_job_runs` method
- `tests/test_fixtures_testops.py` — 21 tests (7 per generator)

SCREENSHOT-WAIVER: Backend-only fixture generation — no rendered UI affected