### PR TITLE
feat: scoring model — health dimensions with TestOps signals (CHAOS-1169)

### DIFF
--- a/docs/architecture/scoring-methodology.md
+++ b/docs/architecture/scoring-methodology.md
@@ -1,0 +1,106 @@
+# Scoring Methodology
+
+The platform-health scoring model blends TestOps and engineering signals into
+four dimensions. Each dimension produces a 0.0–1.0 score where higher values
+*suggest* better health. The composite score blends all four dimensions.
+
+> **Language note:** Scores are hypothesis starters, not verdicts. They
+> *appear* to indicate patterns — they do not *determine* outcomes.
+
+---
+
+## Dimensions
+
+### Delivery (weight 0.30)
+
+Captures how smoothly code changes flow from commit to production.
+
+| Signal                 | Weight | Source Table                        | Normalisation                                         |
+|------------------------|--------|-------------------------------------|-------------------------------------------------------|
+| pipeline_success_rate  | 0.35   | testops_pipeline_metrics_daily      | Direct (0.0–1.0 rate)                                 |
+| pipeline_duration_p95  | 0.25   | testops_pipeline_metrics_daily      | Inverse linear, ceiling 3 600 s (1 h)                 |
+| pr_cycle_time          | 0.25   | repo_metrics_daily                  | Inverse linear, ceiling 168 h (1 w)                   |
+| throughput             | 0.15   | repo_metrics_daily                  | Linear, ceiling 50 PRs/day                            |
+
+### Durability (weight 0.25)
+
+Reflects test and coverage robustness — how likely changes are to survive.
+
+| Signal                    | Weight | Source Table                        | Normalisation                             |
+|---------------------------|--------|-------------------------------------|-------------------------------------------|
+| coverage_line_pct         | 0.30   | testops_coverage_metrics_daily      | Divide by 100                             |
+| test_pass_rate            | 0.30   | testops_test_metrics_daily          | Direct (0.0–1.0 rate)                     |
+| test_flake_rate_inverse   | 0.25   | testops_test_metrics_daily          | 1 − flake_rate                            |
+| coverage_branch_pct       | 0.15   | testops_coverage_metrics_daily      | Divide by 100                             |
+
+### Well-being (weight 0.25)
+
+Surfaces indicators that *lean towards* unsustainable work patterns.
+
+| Signal                         | Weight | Source Table                        | Normalisation                           |
+|--------------------------------|--------|-------------------------------------|-----------------------------------------|
+| pipeline_queue_time_inverse    | 0.30   | testops_pipeline_metrics_daily      | 1 − (queue_sec / 600)                  |
+| rerun_rate_inverse             | 0.25   | testops_pipeline_metrics_daily      | 1 − rerun_rate                          |
+| after_hours_ratio_inverse      | 0.25   | team_metrics_daily                  | 1 − after_hours_commit_ratio            |
+| weekend_ratio_inverse          | 0.20   | team_metrics_daily                  | 1 − weekend_commit_ratio                |
+
+### Dynamics (weight 0.20)
+
+Gauges team responsiveness and flow health — how quickly the system recovers.
+
+| Signal                          | Weight | Source Table                        | Normalisation                          |
+|---------------------------------|--------|-------------------------------------|----------------------------------------|
+| quality_drag_inverse            | 0.35   | testops_quality_drag                | 1 − (drag_hours / 8)                  |
+| failure_ownership               | 0.25   | testops_pipeline_metrics_daily      | rerun_rate where failure_count > 0     |
+| wip_congestion_inverse          | 0.20   | work_item_metrics_daily             | 1 − wip_congestion_ratio              |
+| pipeline_failure_rate_inverse   | 0.20   | testops_pipeline_metrics_daily      | 1 − failure_rate                       |
+
+---
+
+## Composite Score
+
+```
+composite = Σ (dimension_score × dimension_weight) / Σ dimension_weight
+```
+
+Dimension weights:
+
+| Dimension  | Weight |
+|------------|--------|
+| Delivery   | 0.30   |
+| Durability | 0.25   |
+| Well-being | 0.25   |
+| Dynamics   | 0.20   |
+
+When a dimension has no data, its weight is excluded from the denominator so
+the composite adjusts to available evidence.
+
+---
+
+## Missing Data
+
+- Individual signals that cannot be fetched return `None` and are excluded
+  from the dimension's weighted average.
+- If *all* signals in a dimension are missing, the dimension score is `None`
+  and excluded from the composite.
+- If *no* dimensions can be scored, the composite score is `None`.
+
+---
+
+## Normalisation Contract
+
+All normalised values are clamped to `[0.0, 1.0]`.
+
+- **Direct signals** (rates already in 0–1): used as-is.
+- **Inverse signals** (lower raw value appears healthier): `1.0 − normalised`.
+- **Ceiling-based** (unbounded raw values): `raw / ceiling`, clamped.
+
+---
+
+## Interpretation Guidance
+
+Scores are **trends, not absolutes**. A composite score of 0.72 does not mean
+the team "appears 72% healthy" — it *suggests* that the available signals lean
+toward a generally positive pattern relative to the configured ceilings.
+
+Avoid using scores for person-to-person comparison or performance evaluation.

--- a/src/dev_health_ops/metrics/scoring/__init__.py
+++ b/src/dev_health_ops/metrics/scoring/__init__.py
@@ -1,0 +1,25 @@
+"""Platform health scoring — dimension scorers and composite score."""
+
+from dev_health_ops.metrics.scoring.composite import CompositeScorer
+from dev_health_ops.metrics.scoring.delivery import DeliveryScorer
+from dev_health_ops.metrics.scoring.dimensions import DimensionScorer
+from dev_health_ops.metrics.scoring.durability import DurabilityScorer
+from dev_health_ops.metrics.scoring.dynamics import DynamicsScorer
+from dev_health_ops.metrics.scoring.schemas import (
+    CompositeScore,
+    DimensionScore,
+    SignalValue,
+)
+from dev_health_ops.metrics.scoring.wellbeing import WellbeingScorer
+
+__all__ = [
+    "CompositeScore",
+    "CompositeScorer",
+    "DeliveryScorer",
+    "DimensionScore",
+    "DimensionScorer",
+    "DurabilityScorer",
+    "DynamicsScorer",
+    "SignalValue",
+    "WellbeingScorer",
+]

--- a/src/dev_health_ops/metrics/scoring/composite.py
+++ b/src/dev_health_ops/metrics/scoring/composite.py
@@ -1,0 +1,64 @@
+"""Composite scorer blending all four health dimensions."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from dev_health_ops.metrics.scoring.delivery import DeliveryScorer
+from dev_health_ops.metrics.scoring.dimensions import ClickHouseClient
+from dev_health_ops.metrics.scoring.durability import DurabilityScorer
+from dev_health_ops.metrics.scoring.dynamics import DynamicsScorer
+from dev_health_ops.metrics.scoring.schemas import CompositeScore, DimensionScore
+from dev_health_ops.metrics.scoring.wellbeing import WellbeingScorer
+
+_DIMENSION_WEIGHTS: dict[str, float] = {
+    "delivery": 0.30,
+    "durability": 0.25,
+    "wellbeing": 0.25,
+    "dynamics": 0.20,
+}
+
+
+class CompositeScorer:
+    def __init__(self) -> None:
+        self._scorers = [
+            DeliveryScorer(),
+            DurabilityScorer(),
+            WellbeingScorer(),
+            DynamicsScorer(),
+        ]
+
+    def compute(
+        self,
+        client: ClickHouseClient,
+        org_id: str,
+        day: date,
+        team_id: str | None = None,
+        computed_at: datetime | None = None,
+    ) -> CompositeScore:
+        now = computed_at or datetime.utcnow()
+        dimensions: list[DimensionScore] = []
+        weighted_sum = 0.0
+        weight_sum = 0.0
+
+        for scorer in self._scorers:
+            dim_score = scorer.compute(
+                client, org_id, day, team_id=team_id, computed_at=now
+            )
+            dimensions.append(dim_score)
+
+            if dim_score.score is not None:
+                w = _DIMENSION_WEIGHTS[dim_score.dimension]
+                weighted_sum += dim_score.score * w
+                weight_sum += w
+
+        composite = round(weighted_sum / weight_sum, 4) if weight_sum > 0 else None
+
+        return CompositeScore(
+            score=composite,
+            dimensions=dimensions,
+            day=day,
+            org_id=org_id,
+            team_id=team_id,
+            computed_at=now,
+        )

--- a/src/dev_health_ops/metrics/scoring/delivery.py
+++ b/src/dev_health_ops/metrics/scoring/delivery.py
@@ -1,0 +1,108 @@
+"""Delivery dimension scorer.
+
+Signals: pipeline_success_rate, pipeline_duration_p95, pr_cycle_time, throughput.
+Sources: testops_pipeline_metrics_daily, repo_metrics_daily.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from dev_health_ops.metrics.scoring.dimensions import (
+    ClickHouseClient,
+    DimensionScorer,
+    _clamp,
+)
+
+_PIPELINE_TABLE = "testops_pipeline_metrics_daily"
+_REPO_TABLE = "repo_metrics_daily"
+
+_DURATION_P95_CEILING_SEC = 3600.0  # 1h
+_PR_CYCLE_CEILING_HOURS = 168.0  # 1w
+_THROUGHPUT_CEILING = 50.0  # PRs/day
+
+
+class DeliveryScorer(DimensionScorer):
+    @property
+    def dimension_name(self) -> str:
+        return "delivery"
+
+    @property
+    def signal_definitions(self) -> list[tuple[str, float, str]]:
+        return [
+            ("pipeline_success_rate", 0.35, _PIPELINE_TABLE),
+            ("pipeline_duration_p95", 0.25, _PIPELINE_TABLE),
+            ("pr_cycle_time", 0.25, _REPO_TABLE),
+            ("throughput", 0.15, _REPO_TABLE),
+        ]
+
+    def _fetch_signals(
+        self,
+        client: ClickHouseClient,
+        org_id: str,
+        day: date,
+        team_id: str | None,
+    ) -> dict[str, float | None]:
+        signals: dict[str, float | None] = {}
+
+        team_clause = "AND team_id = {team_id:String}" if team_id else ""
+        pipeline_query = f"""
+            SELECT
+                avgMerge(success_rate) AS avg_success_rate,
+                maxMerge(p95_duration_seconds) AS max_p95_duration
+            FROM (
+                SELECT
+                    avgState(success_rate) AS success_rate,
+                    maxState(p95_duration_seconds) AS p95_duration_seconds
+                FROM {_PIPELINE_TABLE}
+                WHERE org_id = {{org_id:String}}
+                  AND day = {{day:Date}}
+                  {team_clause}
+                GROUP BY repo_id
+            )
+        """
+        params: dict[str, object] = {"org_id": org_id, "day": str(day)}
+        if team_id:
+            params["team_id"] = team_id
+
+        result = client.query(pipeline_query, parameters=params)
+        if result.result_rows:
+            row = result.result_rows[0]
+            col_map = {n: i for i, n in enumerate(result.column_names)}
+
+            success_rate = row[col_map["avg_success_rate"]]
+            if success_rate is not None:
+                signals["pipeline_success_rate"] = float(success_rate)
+
+            p95_dur = row[col_map["max_p95_duration"]]
+            if p95_dur is not None:
+                signals["pipeline_duration_p95"] = _clamp(
+                    1.0 - float(p95_dur) / _DURATION_P95_CEILING_SEC
+                )
+
+        repo_query = f"""
+            SELECT
+                avg(median_pr_cycle_hours) AS avg_pr_cycle,
+                sum(prs_merged)            AS total_prs_merged
+            FROM {_REPO_TABLE}
+            WHERE org_id = {{org_id:String}}
+              AND day = {{day:Date}}
+        """
+        result = client.query(
+            repo_query, parameters={"org_id": org_id, "day": str(day)}
+        )
+        if result.result_rows:
+            row = result.result_rows[0]
+            col_map = {n: i for i, n in enumerate(result.column_names)}
+
+            pr_cycle = row[col_map["avg_pr_cycle"]]
+            if pr_cycle is not None:
+                signals["pr_cycle_time"] = _clamp(
+                    1.0 - float(pr_cycle) / _PR_CYCLE_CEILING_HOURS
+                )
+
+            prs_merged = row[col_map["total_prs_merged"]]
+            if prs_merged is not None and prs_merged > 0:
+                signals["throughput"] = _clamp(float(prs_merged) / _THROUGHPUT_CEILING)
+
+        return signals

--- a/src/dev_health_ops/metrics/scoring/dimensions.py
+++ b/src/dev_health_ops/metrics/scoring/dimensions.py
@@ -1,0 +1,113 @@
+"""Base scorer abstraction for platform-health dimensions.
+
+Each concrete dimension scorer queries ClickHouse for the relevant daily
+metrics, normalises each signal to 0.0-1.0, and returns a weighted
+:class:`DimensionScore`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import date, datetime
+from typing import Protocol
+
+from dev_health_ops.metrics.scoring.schemas import DimensionScore, SignalValue
+
+
+class ClickHouseClient(Protocol):
+    """Minimal subset of the ``clickhouse_connect`` client used by scorers."""
+
+    def query(self, query: str, parameters: dict | None = None) -> QueryResult: ...  # noqa: E704
+
+
+class QueryResult(Protocol):
+    """Minimal result protocol returned by :meth:`ClickHouseClient.query`."""
+
+    @property
+    def result_rows(self) -> list[tuple]: ...  # noqa: E704
+
+    @property
+    def column_names(self) -> list[str]: ...  # noqa: E704
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    """Clamp *value* between *lo* and *hi*."""
+    return max(lo, min(hi, value))
+
+
+class DimensionScorer(ABC):
+    """Abstract base for a single health-dimension scorer.
+
+    Subclasses define *dimension_name* and *signal_definitions* then implement
+    :meth:`_fetch_signals` to pull raw metric values from ClickHouse.
+    """
+
+    @property
+    @abstractmethod
+    def dimension_name(self) -> str:
+        """Human-readable dimension label (e.g. ``delivery``)."""
+
+    @property
+    @abstractmethod
+    def signal_definitions(self) -> list[tuple[str, float, str]]:
+        """Ordered list of ``(signal_name, weight, source_table)``."""
+
+    @abstractmethod
+    def _fetch_signals(
+        self,
+        client: ClickHouseClient,
+        org_id: str,
+        day: date,
+        team_id: str | None,
+    ) -> dict[str, float | None]:
+        """Return a mapping of signal_name -> raw metric value.
+
+        Implementations should query ClickHouse and return ``None`` for any
+        signal where data is unavailable.
+        """
+
+    def compute(
+        self,
+        client: ClickHouseClient,
+        org_id: str,
+        day: date,
+        team_id: str | None = None,
+        computed_at: datetime | None = None,
+    ) -> DimensionScore:
+        """Score the dimension for a given org/team/day."""
+        raw_signals = self._fetch_signals(client, org_id, day, team_id)
+
+        signal_values: list[SignalValue] = []
+        weighted_sum = 0.0
+        weight_sum = 0.0
+
+        for name, weight, source_table in self.signal_definitions:
+            raw = raw_signals.get(name)
+            if raw is not None:
+                normalized = _clamp(raw)
+                weighted_sum += normalized * weight
+                weight_sum += weight
+            else:
+                normalized = None
+
+            signal_values.append(
+                SignalValue(
+                    name=name,
+                    raw_value=raw,
+                    normalized_value=normalized,
+                    weight=weight,
+                    source_table=source_table,
+                )
+            )
+
+        score = round(weighted_sum / weight_sum, 4) if weight_sum > 0 else None
+
+        return DimensionScore(
+            dimension=self.dimension_name,
+            score=score,
+            signals=signal_values,
+            day=day,
+            org_id=org_id,
+            team_id=team_id,
+            computed_at=computed_at or datetime.utcnow(),
+        )

--- a/src/dev_health_ops/metrics/scoring/dimensions.py
+++ b/src/dev_health_ops/metrics/scoring/dimensions.py
@@ -14,20 +14,18 @@ from typing import Protocol
 from dev_health_ops.metrics.scoring.schemas import DimensionScore, SignalValue
 
 
+class QueryResult(Protocol):
+    """Minimal result protocol returned by ClickHouseClient.query."""
+
+    result_rows: list[tuple]
+    column_names: list[str]
+
+
 class ClickHouseClient(Protocol):
     """Minimal subset of the ``clickhouse_connect`` client used by scorers."""
 
-    def query(self, query: str, parameters: dict | None = None) -> QueryResult: ...  # noqa: E704
-
-
-class QueryResult(Protocol):
-    """Minimal result protocol returned by :meth:`ClickHouseClient.query`."""
-
-    @property
-    def result_rows(self) -> list[tuple]: ...  # noqa: E704
-
-    @property
-    def column_names(self) -> list[str]: ...  # noqa: E704
+    def query(self, query: str, parameters: dict | None = None) -> QueryResult:
+        """Execute a ClickHouse query and return the result."""
 
 
 def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:

--- a/src/dev_health_ops/metrics/scoring/durability.py
+++ b/src/dev_health_ops/metrics/scoring/durability.py
@@ -1,0 +1,93 @@
+"""Durability dimension scorer.
+
+Signals: coverage_line_pct, test_pass_rate, test_flake_rate_inverse, coverage_branch_pct.
+Sources: testops_test_metrics_daily, testops_coverage_metrics_daily.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from dev_health_ops.metrics.scoring.dimensions import (
+    ClickHouseClient,
+    DimensionScorer,
+    _clamp,
+)
+
+_TEST_TABLE = "testops_test_metrics_daily"
+_COVERAGE_TABLE = "testops_coverage_metrics_daily"
+
+
+class DurabilityScorer(DimensionScorer):
+    @property
+    def dimension_name(self) -> str:
+        return "durability"
+
+    @property
+    def signal_definitions(self) -> list[tuple[str, float, str]]:
+        return [
+            ("coverage_line_pct", 0.30, _COVERAGE_TABLE),
+            ("test_pass_rate", 0.30, _TEST_TABLE),
+            ("test_flake_rate_inverse", 0.25, _TEST_TABLE),
+            ("coverage_branch_pct", 0.15, _COVERAGE_TABLE),
+        ]
+
+    def _fetch_signals(
+        self,
+        client: ClickHouseClient,
+        org_id: str,
+        day: date,
+        team_id: str | None,
+    ) -> dict[str, float | None]:
+        signals: dict[str, float | None] = {}
+
+        team_clause = "AND team_id = {team_id:String}" if team_id else ""
+        test_query = f"""
+            SELECT
+                avg(pass_rate)  AS avg_pass_rate,
+                avg(flake_rate) AS avg_flake_rate
+            FROM {_TEST_TABLE}
+            WHERE org_id = {{org_id:String}}
+              AND day = {{day:Date}}
+              {team_clause}
+        """
+        params: dict[str, object] = {"org_id": org_id, "day": str(day)}
+        if team_id:
+            params["team_id"] = team_id
+
+        result = client.query(test_query, parameters=params)
+        if result.result_rows:
+            row = result.result_rows[0]
+            col_map = {n: i for i, n in enumerate(result.column_names)}
+
+            pass_rate = row[col_map["avg_pass_rate"]]
+            if pass_rate is not None:
+                signals["test_pass_rate"] = _clamp(float(pass_rate))
+
+            flake_rate = row[col_map["avg_flake_rate"]]
+            if flake_rate is not None:
+                signals["test_flake_rate_inverse"] = _clamp(1.0 - float(flake_rate))
+
+        cov_query = f"""
+            SELECT
+                avg(line_coverage_pct)   AS avg_line_cov,
+                avg(branch_coverage_pct) AS avg_branch_cov
+            FROM {_COVERAGE_TABLE}
+            WHERE org_id = {{org_id:String}}
+              AND day = {{day:Date}}
+              {team_clause}
+        """
+        result = client.query(cov_query, parameters=params)
+        if result.result_rows:
+            row = result.result_rows[0]
+            col_map = {n: i for i, n in enumerate(result.column_names)}
+
+            line_cov = row[col_map["avg_line_cov"]]
+            if line_cov is not None:
+                signals["coverage_line_pct"] = _clamp(float(line_cov) / 100.0)
+
+            branch_cov = row[col_map["avg_branch_cov"]]
+            if branch_cov is not None:
+                signals["coverage_branch_pct"] = _clamp(float(branch_cov) / 100.0)
+
+        return signals

--- a/src/dev_health_ops/metrics/scoring/dynamics.py
+++ b/src/dev_health_ops/metrics/scoring/dynamics.py
@@ -1,0 +1,109 @@
+"""Dynamics dimension scorer.
+
+Signals: quality_drag_inverse, failure_ownership, wip_congestion_inverse,
+         pipeline_failure_rate_inverse.
+Sources: testops_quality_drag, testops_pipeline_metrics_daily, work_item_metrics_daily.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from dev_health_ops.metrics.scoring.dimensions import (
+    ClickHouseClient,
+    DimensionScorer,
+    _clamp,
+)
+
+_QUALITY_DRAG_TABLE = "testops_quality_drag"
+_PIPELINE_TABLE = "testops_pipeline_metrics_daily"
+_WORK_ITEM_TABLE = "work_item_metrics_daily"
+
+_DRAG_CEILING_HOURS = 8.0  # hours/day ceiling
+
+
+class DynamicsScorer(DimensionScorer):
+    @property
+    def dimension_name(self) -> str:
+        return "dynamics"
+
+    @property
+    def signal_definitions(self) -> list[tuple[str, float, str]]:
+        return [
+            ("quality_drag_inverse", 0.35, _QUALITY_DRAG_TABLE),
+            ("failure_ownership", 0.25, _PIPELINE_TABLE),
+            ("wip_congestion_inverse", 0.20, _WORK_ITEM_TABLE),
+            ("pipeline_failure_rate_inverse", 0.20, _PIPELINE_TABLE),
+        ]
+
+    def _fetch_signals(
+        self,
+        client: ClickHouseClient,
+        org_id: str,
+        day: date,
+        team_id: str | None,
+    ) -> dict[str, float | None]:
+        signals: dict[str, float | None] = {}
+
+        team_clause = "AND team_id = {team_id:String}" if team_id else ""
+        params: dict[str, object] = {"org_id": org_id, "day": str(day)}
+        if team_id:
+            params["team_id"] = team_id
+
+        drag_query = f"""
+            SELECT avg(drag_hours) AS avg_drag
+            FROM {_QUALITY_DRAG_TABLE}
+            WHERE org_id = {{org_id:String}}
+              AND day = {{day:Date}}
+              {team_clause}
+        """
+        result = client.query(drag_query, parameters=params)
+        if result.result_rows:
+            row = result.result_rows[0]
+            col_map = {n: i for i, n in enumerate(result.column_names)}
+            drag = row[col_map["avg_drag"]]
+            if drag is not None:
+                signals["quality_drag_inverse"] = _clamp(
+                    1.0 - float(drag) / _DRAG_CEILING_HOURS
+                )
+
+        pipeline_query = f"""
+            SELECT
+                avg(failure_rate)                       AS avg_failure_rate,
+                avgIf(rerun_rate, failure_count > 0)    AS avg_rerun_on_failure
+            FROM {_PIPELINE_TABLE}
+            WHERE org_id = {{org_id:String}}
+              AND day = {{day:Date}}
+              {team_clause}
+        """
+        result = client.query(pipeline_query, parameters=params)
+        if result.result_rows:
+            row = result.result_rows[0]
+            col_map = {n: i for i, n in enumerate(result.column_names)}
+
+            failure_rate = row[col_map["avg_failure_rate"]]
+            if failure_rate is not None:
+                signals["pipeline_failure_rate_inverse"] = _clamp(
+                    1.0 - float(failure_rate)
+                )
+
+            rerun_on_failure = row[col_map["avg_rerun_on_failure"]]
+            if rerun_on_failure is not None:
+                signals["failure_ownership"] = _clamp(float(rerun_on_failure))
+
+        wip_query = f"""
+            SELECT avg(wip_congestion_ratio) AS avg_congestion
+            FROM {_WORK_ITEM_TABLE}
+            WHERE org_id = {{org_id:String}}
+              AND day = {{day:Date}}
+              {team_clause}
+        """
+        result = client.query(wip_query, parameters=params)
+        if result.result_rows:
+            row = result.result_rows[0]
+            col_map = {n: i for i, n in enumerate(result.column_names)}
+            congestion = row[col_map["avg_congestion"]]
+            if congestion is not None:
+                signals["wip_congestion_inverse"] = _clamp(1.0 - float(congestion))
+
+        return signals

--- a/src/dev_health_ops/metrics/scoring/schemas.py
+++ b/src/dev_health_ops/metrics/scoring/schemas.py
@@ -1,0 +1,75 @@
+"""Scoring model data contracts.
+
+Defines the value objects used by dimension scorers and the composite scorer.
+All scores are normalized to the 0.0-1.0 range where higher suggests better health.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+
+
+@dataclass(frozen=True)
+class SignalValue:
+    """A single normalised signal contributing to a dimension score.
+
+    Attributes:
+        name: Canonical signal identifier (e.g. ``pipeline_success_rate``).
+        raw_value: The original metric value before normalisation.
+        normalized_value: Value mapped to 0.0-1.0 (higher appears healthier).
+        weight: Relative importance within the parent dimension (0.0-1.0).
+        source_table: ClickHouse table the raw value was drawn from.
+    """
+
+    name: str
+    raw_value: float | None
+    normalized_value: float | None
+    weight: float
+    source_table: str
+
+
+@dataclass(frozen=True)
+class DimensionScore:
+    """Weighted score for a single health dimension.
+
+    Attributes:
+        dimension: Human-readable dimension label (e.g. ``delivery``).
+        score: Weighted blend of available signals (0.0-1.0), or ``None``
+            when no signals could be computed.
+        signals: Breakdown of individual signal contributions.
+        day: The calendar day this score covers.
+        org_id: Organisation scope.
+        team_id: Optional team scope (``None`` for org-wide).
+        computed_at: Timestamp of computation.
+    """
+
+    dimension: str
+    score: float | None
+    signals: list[SignalValue] = field(default_factory=list)
+    day: date | None = None
+    org_id: str = ""
+    team_id: str | None = None
+    computed_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class CompositeScore:
+    """Blended platform-health score across all dimensions.
+
+    Attributes:
+        score: Weighted composite of dimension scores (0.0-1.0), or ``None``
+            when no dimensions could be scored.
+        dimensions: Per-dimension breakdowns.
+        day: Calendar day.
+        org_id: Organisation scope.
+        team_id: Optional team scope.
+        computed_at: Timestamp of computation.
+    """
+
+    score: float | None
+    dimensions: list[DimensionScore] = field(default_factory=list)
+    day: date | None = None
+    org_id: str = ""
+    team_id: str | None = None
+    computed_at: datetime | None = None

--- a/src/dev_health_ops/metrics/scoring/wellbeing.py
+++ b/src/dev_health_ops/metrics/scoring/wellbeing.py
@@ -1,0 +1,103 @@
+"""Well-being dimension scorer.
+
+Signals: pipeline_queue_time_inverse, rerun_rate_inverse,
+         after_hours_ratio_inverse, weekend_ratio_inverse.
+Sources: testops_pipeline_metrics_daily, team_metrics_daily.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from dev_health_ops.metrics.scoring.dimensions import (
+    ClickHouseClient,
+    DimensionScorer,
+    _clamp,
+)
+
+_PIPELINE_TABLE = "testops_pipeline_metrics_daily"
+_TEAM_TABLE = "team_metrics_daily"
+
+_QUEUE_CEILING_SEC = 600.0  # 10 min
+
+
+class WellbeingScorer(DimensionScorer):
+    @property
+    def dimension_name(self) -> str:
+        return "wellbeing"
+
+    @property
+    def signal_definitions(self) -> list[tuple[str, float, str]]:
+        return [
+            ("pipeline_queue_time_inverse", 0.30, _PIPELINE_TABLE),
+            ("rerun_rate_inverse", 0.25, _PIPELINE_TABLE),
+            ("after_hours_ratio_inverse", 0.25, _TEAM_TABLE),
+            ("weekend_ratio_inverse", 0.20, _TEAM_TABLE),
+        ]
+
+    def _fetch_signals(
+        self,
+        client: ClickHouseClient,
+        org_id: str,
+        day: date,
+        team_id: str | None,
+    ) -> dict[str, float | None]:
+        signals: dict[str, float | None] = {}
+
+        team_clause = "AND team_id = {team_id:String}" if team_id else ""
+        pipeline_query = f"""
+            SELECT
+                avg(avg_queue_seconds) AS avg_queue,
+                avg(rerun_rate)        AS avg_rerun
+            FROM {_PIPELINE_TABLE}
+            WHERE org_id = {{org_id:String}}
+              AND day = {{day:Date}}
+              {team_clause}
+        """
+        params: dict[str, object] = {"org_id": org_id, "day": str(day)}
+        if team_id:
+            params["team_id"] = team_id
+
+        result = client.query(pipeline_query, parameters=params)
+        if result.result_rows:
+            row = result.result_rows[0]
+            col_map = {n: i for i, n in enumerate(result.column_names)}
+
+            avg_queue = row[col_map["avg_queue"]]
+            if avg_queue is not None:
+                signals["pipeline_queue_time_inverse"] = _clamp(
+                    1.0 - float(avg_queue) / _QUEUE_CEILING_SEC
+                )
+
+            rerun_rate = row[col_map["avg_rerun"]]
+            if rerun_rate is not None:
+                signals["rerun_rate_inverse"] = _clamp(1.0 - float(rerun_rate))
+
+        team_filter = "AND team_id = {team_id:String}" if team_id else ""
+        team_query = f"""
+            SELECT
+                avg(after_hours_commit_ratio) AS avg_after_hours,
+                avg(weekend_commit_ratio)     AS avg_weekend
+            FROM {_TEAM_TABLE}
+            WHERE org_id = {{org_id:String}}
+              AND day = {{day:Date}}
+              {team_filter}
+        """
+        team_params: dict[str, object] = {"org_id": org_id, "day": str(day)}
+        if team_id:
+            team_params["team_id"] = team_id
+
+        result = client.query(team_query, parameters=team_params)
+        if result.result_rows:
+            row = result.result_rows[0]
+            col_map = {n: i for i, n in enumerate(result.column_names)}
+
+            after_hours = row[col_map["avg_after_hours"]]
+            if after_hours is not None:
+                signals["after_hours_ratio_inverse"] = _clamp(1.0 - float(after_hours))
+
+            weekend = row[col_map["avg_weekend"]]
+            if weekend is not None:
+                signals["weekend_ratio_inverse"] = _clamp(1.0 - float(weekend))
+
+        return signals

--- a/tests/metrics/test_scoring.py
+++ b/tests/metrics/test_scoring.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+
+import pytest
+
+from dev_health_ops.metrics.scoring.composite import CompositeScorer
+from dev_health_ops.metrics.scoring.delivery import DeliveryScorer
+from dev_health_ops.metrics.scoring.durability import DurabilityScorer
+from dev_health_ops.metrics.scoring.dynamics import DynamicsScorer
+from dev_health_ops.metrics.scoring.schemas import CompositeScore, DimensionScore
+from dev_health_ops.metrics.scoring.wellbeing import WellbeingScorer
+
+
+@dataclass
+class FakeQueryResult:
+    result_rows: list[tuple] = field(default_factory=list)
+    column_names: list[str] = field(default_factory=list)
+
+
+class FakeClickHouseClient:
+    def __init__(self, responses: dict[str, FakeQueryResult] | None = None) -> None:
+        self._responses = responses or {}
+        self._default = FakeQueryResult()
+        self.queries: list[str] = []
+
+    def query(self, query: str, parameters: dict | None = None) -> FakeQueryResult:
+        self.queries.append(query)
+        for key, result in self._responses.items():
+            if key in query:
+                return result
+        return self._default
+
+
+_DAY = date(2025, 6, 15)
+_NOW = datetime(2025, 6, 15, 12, 0, 0)
+_ORG = "test-org"
+
+
+class TestDeliveryScorer:
+    def test_all_signals_present(self) -> None:
+        client = FakeClickHouseClient(
+            {
+                "testops_pipeline_metrics_daily": FakeQueryResult(
+                    result_rows=[(0.92, 1200.0)],
+                    column_names=["avg_success_rate", "max_p95_duration"],
+                ),
+                "repo_metrics_daily": FakeQueryResult(
+                    result_rows=[(24.0, 10)],
+                    column_names=["avg_pr_cycle", "total_prs_merged"],
+                ),
+            }
+        )
+        scorer = DeliveryScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+
+        assert result.dimension == "delivery"
+        assert result.score is not None
+        assert 0.0 <= result.score <= 1.0
+        assert len(result.signals) == 4
+
+        signal_map = {s.name: s for s in result.signals}
+        assert signal_map["pipeline_success_rate"].raw_value == pytest.approx(0.92)
+        assert signal_map["pipeline_success_rate"].normalized_value == pytest.approx(
+            0.92
+        )
+        assert signal_map["pipeline_duration_p95"].normalized_value == pytest.approx(
+            1.0 - 1200.0 / 3600.0
+        )
+        assert signal_map["pr_cycle_time"].normalized_value == pytest.approx(
+            1.0 - 24.0 / 168.0
+        )
+        assert signal_map["throughput"].normalized_value == pytest.approx(10.0 / 50.0)
+
+    def test_missing_pipeline_data(self) -> None:
+        client = FakeClickHouseClient(
+            {
+                "repo_metrics_daily": FakeQueryResult(
+                    result_rows=[(48.0, 5)],
+                    column_names=["avg_pr_cycle", "total_prs_merged"],
+                ),
+            }
+        )
+        scorer = DeliveryScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+
+        assert result.score is not None
+        signal_map = {s.name: s for s in result.signals}
+        assert signal_map["pipeline_success_rate"].normalized_value is None
+        assert signal_map["pr_cycle_time"].normalized_value is not None
+
+    def test_team_id_passed(self) -> None:
+        client = FakeClickHouseClient()
+        scorer = DeliveryScorer()
+        result = scorer.compute(client, _ORG, _DAY, team_id="team-1", computed_at=_NOW)
+        assert result.team_id == "team-1"
+        assert any("team_id" in q for q in client.queries)
+
+
+class TestDurabilityScorer:
+    def test_all_signals_present(self) -> None:
+        client = FakeClickHouseClient(
+            {
+                "testops_test_metrics_daily": FakeQueryResult(
+                    result_rows=[(0.95, 0.08)],
+                    column_names=["avg_pass_rate", "avg_flake_rate"],
+                ),
+                "testops_coverage_metrics_daily": FakeQueryResult(
+                    result_rows=[(82.5, 70.0)],
+                    column_names=["avg_line_cov", "avg_branch_cov"],
+                ),
+            }
+        )
+        scorer = DurabilityScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+
+        assert result.score is not None
+        assert 0.0 <= result.score <= 1.0
+        signal_map = {s.name: s for s in result.signals}
+        assert signal_map["test_pass_rate"].normalized_value == pytest.approx(0.95)
+        assert signal_map["test_flake_rate_inverse"].normalized_value == pytest.approx(
+            0.92
+        )
+        assert signal_map["coverage_line_pct"].normalized_value == pytest.approx(0.825)
+        assert signal_map["coverage_branch_pct"].normalized_value == pytest.approx(0.70)
+
+    def test_no_coverage_data(self) -> None:
+        client = FakeClickHouseClient(
+            {
+                "testops_test_metrics_daily": FakeQueryResult(
+                    result_rows=[(0.99, 0.01)],
+                    column_names=["avg_pass_rate", "avg_flake_rate"],
+                ),
+            }
+        )
+        scorer = DurabilityScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+
+        assert result.score is not None
+        signal_map = {s.name: s for s in result.signals}
+        assert signal_map["coverage_line_pct"].normalized_value is None
+
+
+class TestWellbeingScorer:
+    def test_all_signals_present(self) -> None:
+        client = FakeClickHouseClient(
+            {
+                "testops_pipeline_metrics_daily": FakeQueryResult(
+                    result_rows=[(120.0, 0.15)],
+                    column_names=["avg_queue", "avg_rerun"],
+                ),
+                "team_metrics_daily": FakeQueryResult(
+                    result_rows=[(0.12, 0.05)],
+                    column_names=["avg_after_hours", "avg_weekend"],
+                ),
+            }
+        )
+        scorer = WellbeingScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+
+        assert result.score is not None
+        assert 0.0 <= result.score <= 1.0
+        signal_map = {s.name: s for s in result.signals}
+        assert signal_map[
+            "pipeline_queue_time_inverse"
+        ].normalized_value == pytest.approx(1.0 - 120.0 / 600.0)
+        assert signal_map["rerun_rate_inverse"].normalized_value == pytest.approx(0.85)
+        assert signal_map[
+            "after_hours_ratio_inverse"
+        ].normalized_value == pytest.approx(0.88)
+        assert signal_map["weekend_ratio_inverse"].normalized_value == pytest.approx(
+            0.95
+        )
+
+    def test_no_data(self) -> None:
+        client = FakeClickHouseClient()
+        scorer = WellbeingScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+        assert result.score is None
+
+
+class TestDynamicsScorer:
+    def test_all_signals_present(self) -> None:
+        client = FakeClickHouseClient(
+            {
+                "testops_quality_drag": FakeQueryResult(
+                    result_rows=[(2.5,)],
+                    column_names=["avg_drag"],
+                ),
+                "testops_pipeline_metrics_daily": FakeQueryResult(
+                    result_rows=[(0.1, 0.6)],
+                    column_names=["avg_failure_rate", "avg_rerun_on_failure"],
+                ),
+                "work_item_metrics_daily": FakeQueryResult(
+                    result_rows=[(0.3,)],
+                    column_names=["avg_congestion"],
+                ),
+            }
+        )
+        scorer = DynamicsScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+
+        assert result.score is not None
+        assert 0.0 <= result.score <= 1.0
+        signal_map = {s.name: s for s in result.signals}
+        assert signal_map["quality_drag_inverse"].normalized_value == pytest.approx(
+            1.0 - 2.5 / 8.0
+        )
+        assert signal_map[
+            "pipeline_failure_rate_inverse"
+        ].normalized_value == pytest.approx(0.9)
+        assert signal_map["failure_ownership"].normalized_value == pytest.approx(0.6)
+        assert signal_map["wip_congestion_inverse"].normalized_value == pytest.approx(
+            0.7
+        )
+
+    def test_partial_data(self) -> None:
+        client = FakeClickHouseClient(
+            {
+                "testops_pipeline_metrics_daily": FakeQueryResult(
+                    result_rows=[(0.2, 0.4)],
+                    column_names=["avg_failure_rate", "avg_rerun_on_failure"],
+                ),
+            }
+        )
+        scorer = DynamicsScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+        assert result.score is not None
+        signal_map = {s.name: s for s in result.signals}
+        assert signal_map["quality_drag_inverse"].normalized_value is None
+        assert signal_map["wip_congestion_inverse"].normalized_value is None
+
+
+class TestCompositeScorer:
+    def test_full_composite(self) -> None:
+        client = FakeClickHouseClient(
+            {
+                "testops_pipeline_metrics_daily": FakeQueryResult(
+                    result_rows=[(0.9, 900.0, 60.0, 0.1, 0.08, 0.5)],
+                    column_names=[
+                        "avg_success_rate",
+                        "max_p95_duration",
+                        "avg_queue",
+                        "avg_rerun",
+                        "avg_failure_rate",
+                        "avg_rerun_on_failure",
+                    ],
+                ),
+                "repo_metrics_daily": FakeQueryResult(
+                    result_rows=[(20.0, 8)],
+                    column_names=["avg_pr_cycle", "total_prs_merged"],
+                ),
+                "testops_test_metrics_daily": FakeQueryResult(
+                    result_rows=[(0.96, 0.03)],
+                    column_names=["avg_pass_rate", "avg_flake_rate"],
+                ),
+                "testops_coverage_metrics_daily": FakeQueryResult(
+                    result_rows=[(85.0, 72.0)],
+                    column_names=["avg_line_cov", "avg_branch_cov"],
+                ),
+                "team_metrics_daily": FakeQueryResult(
+                    result_rows=[(0.08, 0.02)],
+                    column_names=["avg_after_hours", "avg_weekend"],
+                ),
+                "testops_quality_drag": FakeQueryResult(
+                    result_rows=[(1.5,)],
+                    column_names=["avg_drag"],
+                ),
+                "work_item_metrics_daily": FakeQueryResult(
+                    result_rows=[(0.2,)],
+                    column_names=["avg_congestion"],
+                ),
+            }
+        )
+        scorer = CompositeScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+
+        assert isinstance(result, CompositeScore)
+        assert result.score is not None
+        assert 0.0 <= result.score <= 1.0
+        assert len(result.dimensions) == 4
+        assert result.day == _DAY
+        assert result.org_id == _ORG
+
+        dim_map = {d.dimension: d for d in result.dimensions}
+        for name in ("delivery", "durability", "wellbeing", "dynamics"):
+            assert dim_map[name].score is not None
+
+    def test_composite_no_data(self) -> None:
+        client = FakeClickHouseClient()
+        scorer = CompositeScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+        assert result.score is None
+        assert len(result.dimensions) == 4
+
+    def test_composite_partial_dimensions(self) -> None:
+        client = FakeClickHouseClient(
+            {
+                "testops_test_metrics_daily": FakeQueryResult(
+                    result_rows=[(0.90, 0.05)],
+                    column_names=["avg_pass_rate", "avg_flake_rate"],
+                ),
+            }
+        )
+        scorer = CompositeScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+
+        assert result.score is not None
+        dim_map = {d.dimension: d for d in result.dimensions}
+        assert dim_map["durability"].score is not None
+        assert dim_map["delivery"].score is None
+
+
+class TestEdgeCases:
+    def test_clamp_extreme_values(self) -> None:
+        client = FakeClickHouseClient(
+            {
+                "testops_pipeline_metrics_daily": FakeQueryResult(
+                    result_rows=[(1.5, 99999.0)],
+                    column_names=["avg_success_rate", "max_p95_duration"],
+                ),
+                "repo_metrics_daily": FakeQueryResult(
+                    result_rows=[(500.0, 200)],
+                    column_names=["avg_pr_cycle", "total_prs_merged"],
+                ),
+            }
+        )
+        scorer = DeliveryScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+
+        signal_map = {s.name: s for s in result.signals}
+        assert signal_map["pipeline_success_rate"].normalized_value == 1.0
+        assert signal_map["pipeline_duration_p95"].normalized_value == 0.0
+        assert signal_map["pr_cycle_time"].normalized_value == 0.0
+        assert signal_map["throughput"].normalized_value == 1.0
+
+    def test_zero_throughput(self) -> None:
+        client = FakeClickHouseClient(
+            {
+                "repo_metrics_daily": FakeQueryResult(
+                    result_rows=[(0.0, 0)],
+                    column_names=["avg_pr_cycle", "total_prs_merged"],
+                ),
+            }
+        )
+        scorer = DeliveryScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+        signal_map = {s.name: s for s in result.signals}
+        assert signal_map["throughput"].normalized_value is None
+
+    def test_none_values_in_row(self) -> None:
+        client = FakeClickHouseClient(
+            {
+                "testops_pipeline_metrics_daily": FakeQueryResult(
+                    result_rows=[(None, None)],
+                    column_names=["avg_success_rate", "max_p95_duration"],
+                ),
+            }
+        )
+        scorer = DeliveryScorer()
+        result = scorer.compute(client, _ORG, _DAY, computed_at=_NOW)
+        signal_map = {s.name: s for s in result.signals}
+        assert signal_map["pipeline_success_rate"].normalized_value is None
+        assert signal_map["pipeline_duration_p95"].normalized_value is None
+
+    def test_dimension_score_frozen(self) -> None:
+        score = DimensionScore(dimension="test", score=0.5)
+        with pytest.raises(AttributeError):
+            score.score = 0.9  # type: ignore[misc]
+
+    def test_signal_weights_sum(self) -> None:
+        for scorer_cls in (
+            DeliveryScorer,
+            DurabilityScorer,
+            WellbeingScorer,
+            DynamicsScorer,
+        ):
+            scorer = scorer_cls()
+            total = sum(w for _, w, _ in scorer.signal_definitions)
+            assert total == pytest.approx(1.0), (
+                f"{scorer.dimension_name} signal weights sum to {total}"
+            )


### PR DESCRIPTION
## Summary
- 4 health dimension scorers (Delivery, Durability, Well-being, Dynamics) wired to TestOps metrics
- Composite team health score (weighted 0-1 blend of all dimensions)
- Scoring methodology documentation with signal weights and normalization

## Issues
Closes CHAOS-1174, CHAOS-1175, CHAOS-1176, CHAOS-1177, CHAOS-1178
Closes CHAOS-1169

## Dimensions
| Dimension | Weight | Key Signals |
|-----------|--------|-------------|
| Delivery | 0.30 | pipeline_success_rate, pipeline_duration_p95, pr_cycle_time, throughput |
| Durability | 0.25 | coverage_line_pct, test_pass_rate, flake_rate_inverse, coverage_branch_pct |
| Well-being | 0.25 | queue_time_inverse, rerun_rate_inverse, after_hours_inverse, weekend_inverse |
| Dynamics | 0.20 | quality_drag_inverse, failure_ownership, wip_congestion_inverse, failure_rate_inverse |

## Changes
- `metrics/scoring/` — 8 new modules (schemas, dimensions, 4 scorers, composite, __init__)
- `docs/architecture/scoring-methodology.md` — methodology documentation
- `tests/metrics/test_scoring.py` — 17 tests

SCREENSHOT-WAIVER: Backend-only scoring module — no rendered UI