### PR TITLE
fix: set org_id on fixture-generated teams

### DIFF
--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -139,6 +139,8 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
             all_teams, repo_count, ns.seed
         )
         if hasattr(store, "insert_teams") and all_teams:
+            for team in all_teams:
+                team.org_id = org_id
             await store.insert_teams(all_teams)
             logging.info("Inserted %d synthetic teams.", len(all_teams))
 

--- a/src/dev_health_ops/models/teams.py
+++ b/src/dev_health_ops/models/teams.py
@@ -33,6 +33,7 @@ class Team(Base):
         members: list[str] | None = None,
         updated_at: datetime | None = None,
         team_uuid: uuid.UUID | None = None,
+        org_id: str = "",
     ):
         self.id = id
         self.team_uuid = team_uuid or uuid.uuid4()
@@ -40,6 +41,7 @@ class Team(Base):
         self.description = description
         self.members = members or []
         self.updated_at = updated_at or datetime.now(timezone.utc)
+        self.org_id = org_id
 
 
 class JiraProjectOpsTeamLink(Base):


### PR DESCRIPTION
## Summary
- `Team.__init__` did not accept `org_id`, so fixture-generated teams were inserted with empty `org_id`. Since all queries filter by `org_id`, teams were invisible to the API.
- Add `org_id` parameter to `Team.__init__` and set it in the fixture runner before insertion.

## Changes
- `src/dev_health_ops/models/teams.py` — add `org_id` kwarg to `Team.__init__`
- `src/dev_health_ops/fixtures/runner.py` — set `org_id` on each team before `insert_teams`

TEST-EVIDENCE: `Team.__init__` now accepts `org_id` with default `""` preserving backward compat. The fixture runner sets `org_id = org_id` (from CLI `--org` or the default fixture org UUID) on all teams before insertion. Existing tests pass on 3.11-3.14 — the new kwarg is additive with a default value.

RISK-NOTES: Additive change — new optional kwarg with default `""` matches the existing column `server_default=""`. Only affects fixture-generated teams (production teams are synced via providers which already set org_id). Rollback: revert single commit. No migration needed.