### PR TITLE
feat(CHAOS-1190): wire benchmarking compute fns into daily metrics job

### DIFF
--- a/src/dev_health_ops/metrics/benchmarking/runner.py
+++ b/src/dev_health_ops/metrics/benchmarking/runner.py
@@ -1,0 +1,285 @@
+"""Orchestrator that wires the benchmarking compute functions into the daily job.
+
+The benchmarking compute primitives (baselines, anomalies, correlations, maturity
+bands, period comparisons) all exist as pure functions. This module fetches the
+underlying time-series from the sink, invokes each primitive across a default
+metric set, and persists the results via the sink's ``write_*`` methods.
+
+Each metric is wrapped in its own try/except so a single failure does not halt
+the overall run.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from dev_health_ops.metrics.benchmarking import generate_benchmark_insights
+from dev_health_ops.metrics.benchmarking._common import (
+    fetch_metric_series_by_scope,
+)
+from dev_health_ops.metrics.benchmarking.anomalies import (
+    build_metric_anomalies_from_clickhouse,
+)
+from dev_health_ops.metrics.benchmarking.baselines import (
+    build_internal_baselines_from_clickhouse,
+)
+from dev_health_ops.metrics.benchmarking.correlations import (
+    DEFAULT_CORRELATION_PAIRS,
+    build_metric_correlation_from_clickhouse,
+)
+from dev_health_ops.metrics.benchmarking.maturity import classify_maturity_bands
+from dev_health_ops.metrics.benchmarking.period_comparison import (
+    compute_period_comparison,
+)
+from dev_health_ops.metrics.testops_schemas import (
+    BenchmarkAnomalyRecord,
+    BenchmarkBaselineRecord,
+    MaturityBandRecord,
+    MetricCorrelationRecord,
+    PeriodComparisonRecord,
+)
+
+logger = logging.getLogger(__name__)
+
+# (metric_name, scope_type) pairs to benchmark. Covers pipeline/test/coverage
+# tables so each of the six benchmark tables gets populated.
+DEFAULT_BENCHMARK_METRICS: tuple[tuple[str, str], ...] = (
+    ("success_rate", "repo"),
+    ("failure_rate", "repo"),
+    ("p95_duration_seconds", "repo"),
+    ("rerun_rate", "team"),
+    ("pass_rate", "repo"),
+    ("flake_rate", "team"),
+    ("failure_recurrence_score", "team"),
+    ("line_coverage_pct", "repo"),
+    ("branch_coverage_pct", "repo"),
+    ("coverage_delta_pct", "repo"),
+)
+
+# Period comparison windows: current 7d vs prior 7d.
+PERIOD_COMPARISON_CURRENT_DAYS = 7
+PERIOD_COMPARISON_PRIOR_DAYS = 7
+
+# Correlation window (days).
+CORRELATION_WINDOW_DAYS = 30
+
+
+def _build_period_comparisons(
+    sink: Any,
+    *,
+    metric_name: str,
+    scope_type: str,
+    as_of_day: date,
+    computed_at: datetime,
+    org_id: str,
+) -> list[PeriodComparisonRecord]:
+    """Loop scopes manually since the ``_from_clickhouse`` helper is single-scope."""
+    current_end = as_of_day
+    current_start = as_of_day - timedelta(days=PERIOD_COMPARISON_CURRENT_DAYS - 1)
+    prior_end = current_start - timedelta(days=1)
+    prior_start = prior_end - timedelta(days=PERIOD_COMPARISON_PRIOR_DAYS - 1)
+
+    current_series = fetch_metric_series_by_scope(
+        sink,
+        metric_name=metric_name,
+        start_day=current_start,
+        end_day=current_end,
+        scope_type=scope_type,
+    )
+    prior_series = fetch_metric_series_by_scope(
+        sink,
+        metric_name=metric_name,
+        start_day=prior_start,
+        end_day=prior_end,
+        scope_type=scope_type,
+    )
+
+    records: list[PeriodComparisonRecord] = []
+    for scope_key in sorted(set(current_series) & set(prior_series)):
+        record = compute_period_comparison(
+            metric_name=metric_name,
+            scope_type=scope_type,
+            scope_key=scope_key,
+            current_period_start=current_start,
+            current_period_end=current_end,
+            comparison_period_start=prior_start,
+            comparison_period_end=prior_end,
+            current_period_points=current_series[scope_key],
+            comparison_period_points=prior_series[scope_key],
+            computed_at=computed_at,
+            org_id=org_id,
+        )
+        if record is not None:
+            records.append(record)
+    return records
+
+
+def compute_benchmarking_for_day(
+    sink: Any,
+    *,
+    as_of_day: date,
+    computed_at: datetime,
+    org_id: str,
+    metrics: tuple[tuple[str, str], ...] = DEFAULT_BENCHMARK_METRICS,
+    correlation_pairs: tuple[tuple[str, str, str], ...] = DEFAULT_CORRELATION_PAIRS,
+) -> dict[str, list[Any]]:
+    """Compute all benchmarking records for the given day.
+
+    Returns a dict with keys ``baselines``, ``maturity_bands``, ``anomalies``,
+    ``period_comparisons``, ``correlations``, ``insights``. Each metric and
+    correlation pair is isolated via try/except so one failure cannot halt the
+    rest of the run.
+    """
+    baselines: list[BenchmarkBaselineRecord] = []
+    maturity_bands: list[MaturityBandRecord] = []
+    anomalies: list[BenchmarkAnomalyRecord] = []
+    period_comparisons: list[PeriodComparisonRecord] = []
+    correlations: list[MetricCorrelationRecord] = []
+
+    for metric_name, scope_type in metrics:
+        try:
+            metric_baselines = build_internal_baselines_from_clickhouse(
+                sink,
+                metric_name=metric_name,
+                scope_type=scope_type,
+                as_of_day=as_of_day,
+                computed_at=computed_at,
+                org_id=org_id,
+            )
+            baselines.extend(metric_baselines)
+            maturity_bands.extend(
+                classify_maturity_bands(metric_baselines, computed_at=computed_at)
+            )
+        except Exception as exc:
+            logger.warning(
+                "Benchmark baselines failed: metric=%s scope=%s err=%s",
+                metric_name,
+                scope_type,
+                exc,
+            )
+
+        try:
+            anomalies.extend(
+                build_metric_anomalies_from_clickhouse(
+                    sink,
+                    metric_name=metric_name,
+                    scope_type=scope_type,
+                    as_of_day=as_of_day,
+                    computed_at=computed_at,
+                    org_id=org_id,
+                )
+            )
+        except Exception as exc:
+            logger.warning(
+                "Benchmark anomalies failed: metric=%s scope=%s err=%s",
+                metric_name,
+                scope_type,
+                exc,
+            )
+
+        try:
+            period_comparisons.extend(
+                _build_period_comparisons(
+                    sink,
+                    metric_name=metric_name,
+                    scope_type=scope_type,
+                    as_of_day=as_of_day,
+                    computed_at=computed_at,
+                    org_id=org_id,
+                )
+            )
+        except Exception as exc:
+            logger.warning(
+                "Period comparison failed: metric=%s scope=%s err=%s",
+                metric_name,
+                scope_type,
+                exc,
+            )
+
+    corr_end = as_of_day
+    corr_start = as_of_day - timedelta(days=CORRELATION_WINDOW_DAYS - 1)
+    for metric_name, paired_metric_name, scope_type in correlation_pairs:
+        try:
+            correlations.extend(
+                build_metric_correlation_from_clickhouse(
+                    sink,
+                    metric_name=metric_name,
+                    paired_metric_name=paired_metric_name,
+                    scope_type=scope_type,
+                    period_start=corr_start,
+                    period_end=corr_end,
+                    computed_at=computed_at,
+                    org_id=org_id,
+                )
+            )
+        except Exception as exc:
+            logger.warning(
+                "Correlation failed: %s vs %s scope=%s err=%s",
+                metric_name,
+                paired_metric_name,
+                scope_type,
+                exc,
+            )
+
+    insights = generate_benchmark_insights(
+        period_comparisons=period_comparisons,
+        anomalies=anomalies,
+        correlations=correlations,
+        computed_at=computed_at,
+    )
+
+    return {
+        "baselines": baselines,
+        "maturity_bands": maturity_bands,
+        "anomalies": anomalies,
+        "period_comparisons": period_comparisons,
+        "correlations": correlations,
+        "insights": insights,
+    }
+
+
+def write_benchmarking_outputs(sink: Any, outputs: dict[str, list[Any]]) -> None:
+    """Persist benchmarking records to the sink."""
+    if outputs.get("baselines"):
+        sink.write_benchmark_baselines(outputs["baselines"])
+    if outputs.get("maturity_bands"):
+        sink.write_maturity_bands(outputs["maturity_bands"])
+    if outputs.get("anomalies"):
+        sink.write_benchmark_anomalies(outputs["anomalies"])
+    if outputs.get("period_comparisons"):
+        sink.write_period_comparisons(outputs["period_comparisons"])
+    if outputs.get("correlations"):
+        sink.write_metric_correlations(outputs["correlations"])
+    if outputs.get("insights"):
+        sink.write_benchmark_insights(outputs["insights"])
+
+
+def run_benchmarking_for_day(
+    sink: Any,
+    *,
+    as_of_day: date,
+    computed_at: datetime,
+    org_id: str,
+) -> dict[str, list[Any]]:
+    """Convenience wrapper: compute + write for a single day."""
+    outputs = compute_benchmarking_for_day(
+        sink,
+        as_of_day=as_of_day,
+        computed_at=computed_at,
+        org_id=org_id,
+    )
+    write_benchmarking_outputs(sink, outputs)
+    return outputs
+
+
+__all__ = [
+    "CORRELATION_WINDOW_DAYS",
+    "DEFAULT_BENCHMARK_METRICS",
+    "PERIOD_COMPARISON_CURRENT_DAYS",
+    "PERIOD_COMPARISON_PRIOR_DAYS",
+    "compute_benchmarking_for_day",
+    "run_benchmarking_for_day",
+    "write_benchmarking_outputs",
+]

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from dev_health_ops.db import resolve_sink_uri
+from dev_health_ops.metrics.benchmarking.runner import run_benchmarking_for_day
 from dev_health_ops.metrics.compute import compute_daily_metrics
 from dev_health_ops.metrics.compute_cicd import compute_cicd_metrics_daily
 from dev_health_ops.metrics.compute_deployments import compute_deploy_metrics_daily
@@ -470,6 +471,19 @@ async def run_daily_metrics_job(
                 s.write_quality_drag(quality_drag)
             if pipeline_stab:
                 s.write_pipeline_stability(pipeline_stab)
+
+        # Benchmarking (baselines, maturity, anomalies, period comparisons,
+        # correlations, insights). Reads from ClickHouse via the sink.
+        for s in sinks:
+            try:
+                run_benchmarking_for_day(
+                    s,
+                    as_of_day=d,
+                    computed_at=computed_at,
+                    org_id=org_id,
+                )
+            except Exception as exc:
+                logger.warning("Benchmarking run failed for day=%s: %s", d, exc)
 
         if not skip_finalize:
             ic_metrics = compute_ic_metrics_daily(

--- a/tests/metrics/test_benchmarking_runner.py
+++ b/tests/metrics/test_benchmarking_runner.py
@@ -1,0 +1,140 @@
+"""Unit tests for the benchmarking runner.
+
+Uses a fake sink that returns canned ``query_dicts`` results per metric, and
+asserts that every benchmark ``write_*`` method receives non-empty rows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+from dev_health_ops.metrics.benchmarking._common import METRIC_DEFINITIONS
+from dev_health_ops.metrics.benchmarking.runner import (
+    DEFAULT_BENCHMARK_METRICS,
+    compute_benchmarking_for_day,
+    run_benchmarking_for_day,
+)
+
+AS_OF = date(2026, 4, 10)
+COMPUTED_AT = datetime(2026, 4, 10, 12, 0, tzinfo=timezone.utc)
+ORG = "test-org"
+
+
+class FakeSink:
+    """Minimal sink that returns deterministic time-series via query_dicts."""
+
+    def __init__(self) -> None:
+        self.baselines: list[Any] = []
+        self.maturity_bands: list[Any] = []
+        self.anomalies: list[Any] = []
+        self.period_comparisons: list[Any] = []
+        self.correlations: list[Any] = []
+        self.insights: list[Any] = []
+
+    def query_dicts(
+        self, query: str, params: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        start_day = params["start_day"] if params else AS_OF - timedelta(days=40)
+        end_day = params["end_day"] if params else AS_OF
+
+        # Produce three scopes with a mild linear trend so anomalies may trigger
+        # when the final day spikes.
+        rows: list[dict[str, Any]] = []
+        scopes = ["scope-a", "scope-b", "scope-c"]
+        day = start_day
+        idx = 0
+        while day <= end_day:
+            for i, scope in enumerate(scopes):
+                # Base trend + per-scope offset + a spike on the last day of scope-a
+                value = 0.5 + (i * 0.1) + (idx * 0.005)
+                if scope == "scope-a" and day == end_day:
+                    value += 0.8  # force an anomaly
+                rows.append({"scope_key": scope, "day": day, "value": value})
+            idx += 1
+            day += timedelta(days=1)
+        return rows
+
+    def write_benchmark_baselines(self, rows: Sequence[Any]) -> None:
+        self.baselines.extend(rows)
+
+    def write_maturity_bands(self, rows: Sequence[Any]) -> None:
+        self.maturity_bands.extend(rows)
+
+    def write_benchmark_anomalies(self, rows: Sequence[Any]) -> None:
+        self.anomalies.extend(rows)
+
+    def write_period_comparisons(self, rows: Sequence[Any]) -> None:
+        self.period_comparisons.extend(rows)
+
+    def write_metric_correlations(self, rows: Sequence[Any]) -> None:
+        self.correlations.extend(rows)
+
+    def write_benchmark_insights(self, rows: Sequence[Any]) -> None:
+        self.insights.extend(rows)
+
+
+def test_default_metrics_are_supported() -> None:
+    for metric_name, scope_type in DEFAULT_BENCHMARK_METRICS:
+        definition = METRIC_DEFINITIONS[metric_name]
+        assert scope_type in definition.scope_support, (
+            f"{metric_name} does not support scope {scope_type}"
+        )
+
+
+def test_compute_benchmarking_populates_all_categories() -> None:
+    sink = FakeSink()
+    outputs = compute_benchmarking_for_day(
+        sink,
+        as_of_day=AS_OF,
+        computed_at=COMPUTED_AT,
+        org_id=ORG,
+    )
+    assert outputs["baselines"], "expected baselines"
+    assert outputs["maturity_bands"], "expected maturity bands"
+    assert outputs["anomalies"], "expected anomalies (spike was injected)"
+    assert outputs["period_comparisons"], "expected period comparisons"
+    assert outputs["correlations"], "expected correlations"
+    assert outputs["insights"], "expected insights derived from outputs"
+
+
+def test_run_benchmarking_writes_to_all_six_sinks() -> None:
+    sink = FakeSink()
+    run_benchmarking_for_day(
+        sink,
+        as_of_day=AS_OF,
+        computed_at=COMPUTED_AT,
+        org_id=ORG,
+    )
+    assert sink.baselines
+    assert sink.maturity_bands
+    assert sink.anomalies
+    assert sink.period_comparisons
+    assert sink.correlations
+    assert sink.insights
+
+
+def test_failing_metric_does_not_halt_run() -> None:
+    class FlakySink(FakeSink):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        def query_dicts(
+            self, query: str, params: dict[str, Any] | None = None
+        ) -> list[dict[str, Any]]:
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("simulated query failure")
+            return super().query_dicts(query, params)
+
+    sink = FlakySink()
+    outputs = compute_benchmarking_for_day(
+        sink,
+        as_of_day=AS_OF,
+        computed_at=COMPUTED_AT,
+        org_id=ORG,
+    )
+    # Despite one failure, the rest of the metrics still produce records.
+    assert outputs["baselines"]


### PR DESCRIPTION
## Summary

CHAOS-1170 shipped benchmarking compute primitives in `src/dev_health_ops/metrics/benchmarking/` but left them uncalled. The six benchmark tables stayed empty. This PR wires them into the daily metrics job.

- **NEW** `metrics/benchmarking/runner.py` — `compute_benchmarking_for_day`, `write_benchmarking_outputs`, `run_benchmarking_for_day`. Runs 10 default metrics spanning pipeline/test/coverage tables plus `DEFAULT_CORRELATION_PAIRS`. Each metric is wrapped in try/except so one failure does not halt the run.
- Period comparisons loop scopes via `fetch_metric_series_by_scope` (the `_from_clickhouse` helper is single-scope).
- **PATCH** `metrics/job_daily.py` — invokes the runner per-day after the TestOps-risk write block (mirrors PR #644 pattern).
- **Unit test** with fake sink asserts all six `write_*` methods receive non-empty rows and that a simulated query failure does not halt the run.

Note: branched off `feat/chaos-1188-testops-fixes` but that stack branch does not exist on GitHub, so this PR targets `main`. Rebase as needed once the parent lands.

## Test plan
- [x] `pytest tests/metrics/test_benchmarking.py tests/metrics/test_benchmarking_runner.py` — all pass
- [x] `ruff check` — clean
- [x] Full `tests/metrics/` + fixture runner tests pass (pre-existing `test_fixed_date_forecast` date-dependent failure unrelated)
- [ ] Post-deploy: verify the six benchmark tables have `count() > 0` after daily run

Linear: CHAOS-1190