### PR TITLE
fix(CHAOS-1191): populate team_id in TestOps daily metrics

### DIFF
--- a/src/dev_health_ops/metrics/compute_testops.py
+++ b/src/dev_health_ops/metrics/compute_testops.py
@@ -17,7 +17,23 @@ from dev_health_ops.metrics.testops_schemas import (
     TestMetricsDailyRecord,
     TestSuiteResultRow,
 )
+from dev_health_ops.providers.teams import RepoPatternTeamResolver
 from dev_health_ops.utils.datetime import to_utc
+
+
+def _resolve_repo_team(
+    repo_id: uuid.UUID,
+    row_team_id: str | None,
+    repo_team_resolver: RepoPatternTeamResolver | None,
+    repo_names_by_id: dict[uuid.UUID, str] | None,
+) -> str | None:
+    if row_team_id:
+        return row_team_id
+    if repo_team_resolver is None:
+        return None
+    repo_name = (repo_names_by_id or {}).get(repo_id)
+    team_id, _ = repo_team_resolver.resolve(repo_name)
+    return team_id
 
 
 def _normalize_pipeline_status(status: str | None) -> str:
@@ -92,6 +108,8 @@ def compute_pipeline_metrics_daily(
     pipeline_runs: Sequence[PipelineRunExtendedRow],
     job_runs: Sequence[JobRunRow],
     computed_at: datetime,
+    repo_team_resolver: RepoPatternTeamResolver | None = None,
+    repo_names_by_id: dict[uuid.UUID, str] | None = None,
 ) -> list[PipelineMetricsDailyRecord]:
     del job_runs
 
@@ -105,7 +123,9 @@ def compute_pipeline_metrics_daily(
             continue
 
         repo_id = row["repo_id"]
-        team_id = row.get("team_id")
+        team_id = _resolve_repo_team(
+            repo_id, row.get("team_id"), repo_team_resolver, repo_names_by_id
+        )
         service_id = row.get("service_id")
         key = (repo_id, team_id, service_id)
         bucket = by_group.get(key)
@@ -190,6 +210,8 @@ def compute_test_metrics_daily(
     suite_results: Sequence[TestSuiteResultRow],
     case_results: Sequence[TestCaseResultRow],
     computed_at: datetime,
+    repo_team_resolver: RepoPatternTeamResolver | None = None,
+    repo_names_by_id: dict[uuid.UUID, str] | None = None,
 ) -> list[TestMetricsDailyRecord]:
     start, end = _utc_day_window(day)
     computed_at_utc = to_utc(computed_at)
@@ -308,7 +330,12 @@ def compute_test_metrics_daily(
                 if current_failed_names
                 else 0.0,
                 computed_at=computed_at_utc,
-                team_id=first_suite.get("team_id") if first_suite else None,
+                team_id=_resolve_repo_team(
+                    repo_id,
+                    first_suite.get("team_id") if first_suite else None,
+                    repo_team_resolver,
+                    repo_names_by_id,
+                ),
                 service_id=first_suite.get("service_id") if first_suite else None,
                 org_id=str(first_suite.get("org_id", "") if first_suite else ""),
             )
@@ -323,6 +350,8 @@ def compute_coverage_metrics_daily(
     snapshots: Sequence[CoverageSnapshotRow],
     prior_snapshots: Sequence[CoverageSnapshotRow] | None,
     computed_at: datetime,
+    repo_team_resolver: RepoPatternTeamResolver | None = None,
+    repo_names_by_id: dict[uuid.UUID, str] | None = None,
 ) -> list[CoverageMetricsDailyRecord]:
     computed_at_utc = to_utc(computed_at)
 
@@ -382,7 +411,12 @@ def compute_coverage_metrics_daily(
                 uncovered_files_count=0,
                 coverage_regression_count=0,
                 computed_at=computed_at_utc,
-                team_id=snapshot.get("team_id"),
+                team_id=_resolve_repo_team(
+                    repo_id,
+                    snapshot.get("team_id"),
+                    repo_team_resolver,
+                    repo_names_by_id,
+                ),
                 service_id=snapshot.get("service_id"),
                 org_id=str(snapshot.get("org_id", "")),
             )

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -396,18 +396,24 @@ async def run_daily_metrics_job(
             pipeline_runs=testops_pipeline_rows,
             job_runs=testops_job_rows,
             computed_at=computed_at,
+            repo_team_resolver=repo_team_resolver,
+            repo_names_by_id=repo_names_by_id,
         )
         testops_test_metrics = compute_test_metrics_daily(
             day=d,
             suite_results=testops_suite_rows,
             case_results=testops_case_rows,
             computed_at=computed_at,
+            repo_team_resolver=repo_team_resolver,
+            repo_names_by_id=repo_names_by_id,
         )
         testops_coverage_metrics = compute_coverage_metrics_daily(
             day=d,
             snapshots=coverage_rows,
             prior_snapshots=prior_coverage_rows,
             computed_at=computed_at,
+            repo_team_resolver=repo_team_resolver,
+            repo_names_by_id=repo_names_by_id,
         )
         deploy_metrics = compute_deploy_metrics_daily(
             day=d, deployments=deployment_rows, computed_at=computed_at

--- a/tests/metrics/test_compute_testops.py
+++ b/tests/metrics/test_compute_testops.py
@@ -362,6 +362,84 @@ def test_compute_coverage_metrics_daily_uses_latest_snapshot_and_delta():
     assert rec_b.branch_coverage_pct is None
 
 
+def test_compute_testops_metrics_resolve_team_via_repo_resolver_when_row_team_id_missing():
+    """CHAOS-1191: resolver fallback populates team_id when raw rows lack it."""
+    from dev_health_ops.providers.teams import build_repo_pattern_resolver
+
+    day = date(2026, 2, 18)
+    repo_a = uuid4()
+    repo_team_resolver = build_repo_pattern_resolver(
+        [{"id": "team-x", "name": "Team X", "repo_patterns": ["acme/api"]}]
+    )
+    repo_names_by_id = {repo_a: "acme/api"}
+    computed_at = datetime(2026, 2, 18, 13, 0, tzinfo=timezone.utc)
+
+    pipeline_records = compute_pipeline_metrics_daily(
+        day=day,
+        pipeline_runs=[
+            {
+                "repo_id": repo_a,
+                "run_id": "001",
+                "provider": "github_actions",
+                "status": "success",
+                "queued_at": datetime(2026, 2, 18, 9, 58, tzinfo=timezone.utc),
+                "started_at": datetime(2026, 2, 18, 10, 0, tzinfo=timezone.utc),
+                "finished_at": datetime(2026, 2, 18, 10, 5, tzinfo=timezone.utc),
+                "retry_count": 0,
+            }
+        ],
+        job_runs=[],
+        computed_at=computed_at,
+        repo_team_resolver=repo_team_resolver,
+        repo_names_by_id=repo_names_by_id,
+    )
+    assert pipeline_records[0].team_id == "team-x"
+
+    test_records = compute_test_metrics_daily(
+        day=day,
+        suite_results=[
+            {
+                "repo_id": repo_a,
+                "run_id": "r1",
+                "started_at": datetime(2026, 2, 18, 10, 0, tzinfo=timezone.utc),
+                "finished_at": datetime(2026, 2, 18, 10, 1, tzinfo=timezone.utc),
+                "total_count": 1,
+                "passed_count": 1,
+                "failed_count": 0,
+                "error_count": 0,
+                "skipped_count": 0,
+                "quarantined_count": 0,
+                "duration_seconds": 60,
+            }
+        ],
+        case_results=[],
+        computed_at=computed_at,
+        repo_team_resolver=repo_team_resolver,
+        repo_names_by_id=repo_names_by_id,
+    )
+    assert test_records[0].team_id == "team-x"
+
+    coverage_records = compute_coverage_metrics_daily(
+        day=day,
+        snapshots=[
+            {
+                "repo_id": repo_a,
+                "run_id": "r1",
+                "snapshot_id": "s1",
+                "line_coverage_pct": 80.0,
+                "branch_coverage_pct": 70.0,
+                "lines_total": 100,
+                "lines_covered": 80,
+            }
+        ],
+        prior_snapshots=None,
+        computed_at=computed_at,
+        repo_team_resolver=repo_team_resolver,
+        repo_names_by_id=repo_names_by_id,
+    )
+    assert coverage_records[0].team_id == "team-x"
+
+
 def test_compute_coverage_metrics_daily_returns_empty_for_no_snapshots():
     records = compute_coverage_metrics_daily(
         day=date(2026, 2, 18),


### PR DESCRIPTION
## Summary
- Thread `RepoPatternTeamResolver` + `repo_names_by_id` into `compute_pipeline_metrics_daily`, `compute_test_metrics_daily`, and `compute_coverage_metrics_daily`.
- When a raw row's `team_id` is NULL, fall back to resolving via repo (mirrors `compute_team_wellbeing` / `compute_daily_metrics`).
- Wire both through `job_daily.py` (already builds them for git/wellbeing).
- Risk metrics (release confidence, quality drag, pipeline stability) inherit team_id from these records — fixed transitively.

## Why
All rows in `testops_pipeline_metrics_daily`, `testops_test_metrics_daily`, and `testops_coverage_metrics_daily` had `team_id IS NULL`, collapsing breakdown queries into a single `unassigned` bucket and emptying per-team trend pages.

## Test plan
- [x] New unit test exercises resolver fallback for all three compute functions
- [x] `pytest tests/metrics/test_compute_testops.py` — 7 passed
- [x] `ruff check` — clean
- [x] No regressions in `tests/metrics/` (pre-existing capacity test failure unrelated)

Closes CHAOS-1191