### PR TITLE
docs(CHAOS-1192): document rate vs coverage scale convention

### DIFF
--- a/src/dev_health_ops/api/graphql/sql/validate.py
+++ b/src/dev_health_ops/api/graphql/sql/validate.py
@@ -85,9 +85,12 @@ class Measure(str, Enum):
                 cls.CYCLE_TIME_HOURS: "AVG(cycle_p50_hours)",
                 cls.THROUGHPUT: "SUM(work_items_completed)",
             }
-        # Rate columns are stored as 0.0-1.0 fractions; multiply by 100 so
-        # frontends receive percentages (0-100) consistently with the
-        # coverage_*_pct columns that already store percentages.
+        # Scale normalization boundary (CHAOS-1192): ClickHouse stores `_rate`
+        # columns as 0.0-1.0 fractions while `_pct` columns already hold
+        # 0-100. Multiply rates by 100 here so the GraphQL API emits a single
+        # 0-100 scale to all frontends. See the scale convention docstring in
+        # metrics/testops_schemas.py; remove the * 100 once option 1 of
+        # CHAOS-1192 (column rename + backfill) lands.
         testops_mapping: dict[Measure, str] = {
             cls.PIPELINE_SUCCESS_RATE: "AVG(success_rate) * 100",
             cls.PIPELINE_FAILURE_RATE: "AVG(failure_rate) * 100",

--- a/src/dev_health_ops/metrics/testops_schemas.py
+++ b/src/dev_health_ops/metrics/testops_schemas.py
@@ -13,6 +13,37 @@ layers. Changes must be coordinated across all downstream consumers.
 Existing infrastructure this extends:
 - metrics/schemas.py: PipelineRunRow, CICDMetricsDailyRecord, DORAMetricsRecord
 - migrations/clickhouse/000_raw_tables.sql: ci_pipeline_runs, deployments, incidents
+
+Scale convention (CHAOS-1192)
+-----------------------------
+Two numeric scales coexist in these schemas. Follow the suffix rule below when
+adding new columns or fields; the GraphQL boundary in
+``api/graphql/sql/validate.py`` multiplies 0.0-1.0 values by 100 so the API
+always emits 0-100. Direct SQL callers (Grafana, ad-hoc analysis) must know
+the scale of the column they are reading.
+
+Stored as 0.0-1.0 fractions (suffixes ``_rate``, ``_score``, ``_factor``,
+``_penalty``, ``_index``):
+
+- ``testops_pipeline_metrics_daily``: ``success_rate``, ``failure_rate``,
+  ``cancel_rate``, ``rerun_rate``
+- ``testops_test_metrics_daily``: ``pass_rate``, ``failure_rate``,
+  ``flake_rate``, ``retry_dependency_rate``, ``failure_recurrence_score``
+- ``ReleaseConfidenceRecord``: ``confidence_score``, all ``*_factor`` and
+  ``*_penalty`` fields
+- ``PipelineStabilityRecord``: ``stability_index``, ``success_rate_7d``,
+  ``failure_clustering_score``
+
+Stored as 0-100 percentages (suffix ``_pct``):
+
+- ``testops_coverage_metrics_daily``: ``line_coverage_pct``,
+  ``branch_coverage_pct``, ``coverage_delta_pct``
+- ``CoverageSnapshotRow``: ``line_coverage_pct``, ``branch_coverage_pct``
+
+Naming rule: ``_rate`` / ``_score`` / ``_factor`` / ``_penalty`` / ``_index``
+store 0.0-1.0; ``_pct`` stores 0-100. A full migration to a single scale is
+tracked as option 1 of CHAOS-1192; until then, document-and-normalize-at-the-
+boundary is the accepted convention.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
Documents the existing 0.0–1.0 rate vs 0–100 coverage scale convention in `metrics/testops_schemas.py` module docstring + clarifies the `* 100` scaling at the GraphQL boundary in `validate.py`.

Per CHAOS-1192, ticket explicitly opted for "Option 2: document, don't migrate" — no schema rename, no migration.

## Test plan
- [x] `ruff check` passes
- [x] Doc-only change; no runtime behavior affected

TEST-EVIDENCE:
- `ruff check src/dev_health_ops/metrics/testops_schemas.py src/dev_health_ops/api/graphql/sql/validate.py` → All checks passed.
- No code paths modified — changes are limited to a module docstring and an inline comment. No unit/integration tests required.

RISK-NOTES:
- Blast radius: zero — comment + docstring only, no executable code touched.
- Rollback: revert this single commit; no migration to undo.
- Follow-up: CHAOS-1192 option 1 (column rename to enforce convention via the type system) is deferred per ticket; no follow-up issue needed at this time.

Closes CHAOS-1192