### PR TITLE
feat(CHAOS-1188): TestOps benchmarking + team_id + scale-doc fixes

### DIFF
--- a/src/dev_health_ops/api/graphql/sql/validate.py
+++ b/src/dev_health_ops/api/graphql/sql/validate.py
@@ -85,9 +85,12 @@ class Measure(str, Enum):
                 cls.CYCLE_TIME_HOURS: "AVG(cycle_p50_hours)",
                 cls.THROUGHPUT: "SUM(work_items_completed)",
             }
-        # Rate columns are stored as 0.0-1.0 fractions; multiply by 100 so
-        # frontends receive percentages (0-100) consistently with the
-        # coverage_*_pct columns that already store percentages.
+        # Scale normalization boundary (CHAOS-1192): ClickHouse stores `_rate`
+        # columns as 0.0-1.0 fractions while `_pct` columns already hold
+        # 0-100. Multiply rates by 100 here so the GraphQL API emits a single
+        # 0-100 scale to all frontends. See the scale convention docstring in
+        # metrics/testops_schemas.py; remove the * 100 once option 1 of
+        # CHAOS-1192 (column rename + backfill) lands.
         testops_mapping: dict[Measure, str] = {
             cls.PIPELINE_SUCCESS_RATE: "AVG(success_rate) * 100",
             cls.PIPELINE_FAILURE_RATE: "AVG(failure_rate) * 100",

--- a/src/dev_health_ops/metrics/benchmarking/runner.py
+++ b/src/dev_health_ops/metrics/benchmarking/runner.py
@@ -1,0 +1,285 @@
+"""Orchestrator that wires the benchmarking compute functions into the daily job.
+
+The benchmarking compute primitives (baselines, anomalies, correlations, maturity
+bands, period comparisons) all exist as pure functions. This module fetches the
+underlying time-series from the sink, invokes each primitive across a default
+metric set, and persists the results via the sink's ``write_*`` methods.
+
+Each metric is wrapped in its own try/except so a single failure does not halt
+the overall run.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from dev_health_ops.metrics.benchmarking import generate_benchmark_insights
+from dev_health_ops.metrics.benchmarking._common import (
+    fetch_metric_series_by_scope,
+)
+from dev_health_ops.metrics.benchmarking.anomalies import (
+    build_metric_anomalies_from_clickhouse,
+)
+from dev_health_ops.metrics.benchmarking.baselines import (
+    build_internal_baselines_from_clickhouse,
+)
+from dev_health_ops.metrics.benchmarking.correlations import (
+    DEFAULT_CORRELATION_PAIRS,
+    build_metric_correlation_from_clickhouse,
+)
+from dev_health_ops.metrics.benchmarking.maturity import classify_maturity_bands
+from dev_health_ops.metrics.benchmarking.period_comparison import (
+    compute_period_comparison,
+)
+from dev_health_ops.metrics.testops_schemas import (
+    BenchmarkAnomalyRecord,
+    BenchmarkBaselineRecord,
+    MaturityBandRecord,
+    MetricCorrelationRecord,
+    PeriodComparisonRecord,
+)
+
+logger = logging.getLogger(__name__)
+
+# (metric_name, scope_type) pairs to benchmark. Covers pipeline/test/coverage
+# tables so each of the six benchmark tables gets populated.
+DEFAULT_BENCHMARK_METRICS: tuple[tuple[str, str], ...] = (
+    ("success_rate", "repo"),
+    ("failure_rate", "repo"),
+    ("p95_duration_seconds", "repo"),
+    ("rerun_rate", "team"),
+    ("pass_rate", "repo"),
+    ("flake_rate", "team"),
+    ("failure_recurrence_score", "team"),
+    ("line_coverage_pct", "repo"),
+    ("branch_coverage_pct", "repo"),
+    ("coverage_delta_pct", "repo"),
+)
+
+# Period comparison windows: current 7d vs prior 7d.
+PERIOD_COMPARISON_CURRENT_DAYS = 7
+PERIOD_COMPARISON_PRIOR_DAYS = 7
+
+# Correlation window (days).
+CORRELATION_WINDOW_DAYS = 30
+
+
+def _build_period_comparisons(
+    sink: Any,
+    *,
+    metric_name: str,
+    scope_type: str,
+    as_of_day: date,
+    computed_at: datetime,
+    org_id: str,
+) -> list[PeriodComparisonRecord]:
+    """Loop scopes manually since the ``_from_clickhouse`` helper is single-scope."""
+    current_end = as_of_day
+    current_start = as_of_day - timedelta(days=PERIOD_COMPARISON_CURRENT_DAYS - 1)
+    prior_end = current_start - timedelta(days=1)
+    prior_start = prior_end - timedelta(days=PERIOD_COMPARISON_PRIOR_DAYS - 1)
+
+    current_series = fetch_metric_series_by_scope(
+        sink,
+        metric_name=metric_name,
+        start_day=current_start,
+        end_day=current_end,
+        scope_type=scope_type,
+    )
+    prior_series = fetch_metric_series_by_scope(
+        sink,
+        metric_name=metric_name,
+        start_day=prior_start,
+        end_day=prior_end,
+        scope_type=scope_type,
+    )
+
+    records: list[PeriodComparisonRecord] = []
+    for scope_key in sorted(set(current_series) & set(prior_series)):
+        record = compute_period_comparison(
+            metric_name=metric_name,
+            scope_type=scope_type,
+            scope_key=scope_key,
+            current_period_start=current_start,
+            current_period_end=current_end,
+            comparison_period_start=prior_start,
+            comparison_period_end=prior_end,
+            current_period_points=current_series[scope_key],
+            comparison_period_points=prior_series[scope_key],
+            computed_at=computed_at,
+            org_id=org_id,
+        )
+        if record is not None:
+            records.append(record)
+    return records
+
+
+def compute_benchmarking_for_day(
+    sink: Any,
+    *,
+    as_of_day: date,
+    computed_at: datetime,
+    org_id: str,
+    metrics: tuple[tuple[str, str], ...] = DEFAULT_BENCHMARK_METRICS,
+    correlation_pairs: tuple[tuple[str, str, str], ...] = DEFAULT_CORRELATION_PAIRS,
+) -> dict[str, list[Any]]:
+    """Compute all benchmarking records for the given day.
+
+    Returns a dict with keys ``baselines``, ``maturity_bands``, ``anomalies``,
+    ``period_comparisons``, ``correlations``, ``insights``. Each metric and
+    correlation pair is isolated via try/except so one failure cannot halt the
+    rest of the run.
+    """
+    baselines: list[BenchmarkBaselineRecord] = []
+    maturity_bands: list[MaturityBandRecord] = []
+    anomalies: list[BenchmarkAnomalyRecord] = []
+    period_comparisons: list[PeriodComparisonRecord] = []
+    correlations: list[MetricCorrelationRecord] = []
+
+    for metric_name, scope_type in metrics:
+        try:
+            metric_baselines = build_internal_baselines_from_clickhouse(
+                sink,
+                metric_name=metric_name,
+                scope_type=scope_type,
+                as_of_day=as_of_day,
+                computed_at=computed_at,
+                org_id=org_id,
+            )
+            baselines.extend(metric_baselines)
+            maturity_bands.extend(
+                classify_maturity_bands(metric_baselines, computed_at=computed_at)
+            )
+        except Exception as exc:
+            logger.warning(
+                "Benchmark baselines failed: metric=%s scope=%s err=%s",
+                metric_name,
+                scope_type,
+                exc,
+            )
+
+        try:
+            anomalies.extend(
+                build_metric_anomalies_from_clickhouse(
+                    sink,
+                    metric_name=metric_name,
+                    scope_type=scope_type,
+                    as_of_day=as_of_day,
+                    computed_at=computed_at,
+                    org_id=org_id,
+                )
+            )
+        except Exception as exc:
+            logger.warning(
+                "Benchmark anomalies failed: metric=%s scope=%s err=%s",
+                metric_name,
+                scope_type,
+                exc,
+            )
+
+        try:
+            period_comparisons.extend(
+                _build_period_comparisons(
+                    sink,
+                    metric_name=metric_name,
+                    scope_type=scope_type,
+                    as_of_day=as_of_day,
+                    computed_at=computed_at,
+                    org_id=org_id,
+                )
+            )
+        except Exception as exc:
+            logger.warning(
+                "Period comparison failed: metric=%s scope=%s err=%s",
+                metric_name,
+                scope_type,
+                exc,
+            )
+
+    corr_end = as_of_day
+    corr_start = as_of_day - timedelta(days=CORRELATION_WINDOW_DAYS - 1)
+    for metric_name, paired_metric_name, scope_type in correlation_pairs:
+        try:
+            correlations.extend(
+                build_metric_correlation_from_clickhouse(
+                    sink,
+                    metric_name=metric_name,
+                    paired_metric_name=paired_metric_name,
+                    scope_type=scope_type,
+                    period_start=corr_start,
+                    period_end=corr_end,
+                    computed_at=computed_at,
+                    org_id=org_id,
+                )
+            )
+        except Exception as exc:
+            logger.warning(
+                "Correlation failed: %s vs %s scope=%s err=%s",
+                metric_name,
+                paired_metric_name,
+                scope_type,
+                exc,
+            )
+
+    insights = generate_benchmark_insights(
+        period_comparisons=period_comparisons,
+        anomalies=anomalies,
+        correlations=correlations,
+        computed_at=computed_at,
+    )
+
+    return {
+        "baselines": baselines,
+        "maturity_bands": maturity_bands,
+        "anomalies": anomalies,
+        "period_comparisons": period_comparisons,
+        "correlations": correlations,
+        "insights": insights,
+    }
+
+
+def write_benchmarking_outputs(sink: Any, outputs: dict[str, list[Any]]) -> None:
+    """Persist benchmarking records to the sink."""
+    if outputs.get("baselines"):
+        sink.write_benchmark_baselines(outputs["baselines"])
+    if outputs.get("maturity_bands"):
+        sink.write_maturity_bands(outputs["maturity_bands"])
+    if outputs.get("anomalies"):
+        sink.write_benchmark_anomalies(outputs["anomalies"])
+    if outputs.get("period_comparisons"):
+        sink.write_period_comparisons(outputs["period_comparisons"])
+    if outputs.get("correlations"):
+        sink.write_metric_correlations(outputs["correlations"])
+    if outputs.get("insights"):
+        sink.write_benchmark_insights(outputs["insights"])
+
+
+def run_benchmarking_for_day(
+    sink: Any,
+    *,
+    as_of_day: date,
+    computed_at: datetime,
+    org_id: str,
+) -> dict[str, list[Any]]:
+    """Convenience wrapper: compute + write for a single day."""
+    outputs = compute_benchmarking_for_day(
+        sink,
+        as_of_day=as_of_day,
+        computed_at=computed_at,
+        org_id=org_id,
+    )
+    write_benchmarking_outputs(sink, outputs)
+    return outputs
+
+
+__all__ = [
+    "CORRELATION_WINDOW_DAYS",
+    "DEFAULT_BENCHMARK_METRICS",
+    "PERIOD_COMPARISON_CURRENT_DAYS",
+    "PERIOD_COMPARISON_PRIOR_DAYS",
+    "compute_benchmarking_for_day",
+    "run_benchmarking_for_day",
+    "write_benchmarking_outputs",
+]

--- a/src/dev_health_ops/metrics/compute_testops.py
+++ b/src/dev_health_ops/metrics/compute_testops.py
@@ -17,7 +17,23 @@ from dev_health_ops.metrics.testops_schemas import (
     TestMetricsDailyRecord,
     TestSuiteResultRow,
 )
+from dev_health_ops.providers.teams import RepoPatternTeamResolver
 from dev_health_ops.utils.datetime import to_utc
+
+
+def _resolve_repo_team(
+    repo_id: uuid.UUID,
+    row_team_id: str | None,
+    repo_team_resolver: RepoPatternTeamResolver | None,
+    repo_names_by_id: dict[uuid.UUID, str] | None,
+) -> str | None:
+    if row_team_id:
+        return row_team_id
+    if repo_team_resolver is None:
+        return None
+    repo_name = (repo_names_by_id or {}).get(repo_id)
+    team_id, _ = repo_team_resolver.resolve(repo_name)
+    return team_id
 
 
 def _normalize_pipeline_status(status: str | None) -> str:
@@ -92,6 +108,8 @@ def compute_pipeline_metrics_daily(
     pipeline_runs: Sequence[PipelineRunExtendedRow],
     job_runs: Sequence[JobRunRow],
     computed_at: datetime,
+    repo_team_resolver: RepoPatternTeamResolver | None = None,
+    repo_names_by_id: dict[uuid.UUID, str] | None = None,
 ) -> list[PipelineMetricsDailyRecord]:
     del job_runs
 
@@ -105,7 +123,9 @@ def compute_pipeline_metrics_daily(
             continue
 
         repo_id = row["repo_id"]
-        team_id = row.get("team_id")
+        team_id = _resolve_repo_team(
+            repo_id, row.get("team_id"), repo_team_resolver, repo_names_by_id
+        )
         service_id = row.get("service_id")
         key = (repo_id, team_id, service_id)
         bucket = by_group.get(key)
@@ -190,6 +210,8 @@ def compute_test_metrics_daily(
     suite_results: Sequence[TestSuiteResultRow],
     case_results: Sequence[TestCaseResultRow],
     computed_at: datetime,
+    repo_team_resolver: RepoPatternTeamResolver | None = None,
+    repo_names_by_id: dict[uuid.UUID, str] | None = None,
 ) -> list[TestMetricsDailyRecord]:
     start, end = _utc_day_window(day)
     computed_at_utc = to_utc(computed_at)
@@ -308,7 +330,12 @@ def compute_test_metrics_daily(
                 if current_failed_names
                 else 0.0,
                 computed_at=computed_at_utc,
-                team_id=first_suite.get("team_id") if first_suite else None,
+                team_id=_resolve_repo_team(
+                    repo_id,
+                    first_suite.get("team_id") if first_suite else None,
+                    repo_team_resolver,
+                    repo_names_by_id,
+                ),
                 service_id=first_suite.get("service_id") if first_suite else None,
                 org_id=str(first_suite.get("org_id", "") if first_suite else ""),
             )
@@ -323,6 +350,8 @@ def compute_coverage_metrics_daily(
     snapshots: Sequence[CoverageSnapshotRow],
     prior_snapshots: Sequence[CoverageSnapshotRow] | None,
     computed_at: datetime,
+    repo_team_resolver: RepoPatternTeamResolver | None = None,
+    repo_names_by_id: dict[uuid.UUID, str] | None = None,
 ) -> list[CoverageMetricsDailyRecord]:
     computed_at_utc = to_utc(computed_at)
 
@@ -382,7 +411,12 @@ def compute_coverage_metrics_daily(
                 uncovered_files_count=0,
                 coverage_regression_count=0,
                 computed_at=computed_at_utc,
-                team_id=snapshot.get("team_id"),
+                team_id=_resolve_repo_team(
+                    repo_id,
+                    snapshot.get("team_id"),
+                    repo_team_resolver,
+                    repo_names_by_id,
+                ),
                 service_id=snapshot.get("service_id"),
                 org_id=str(snapshot.get("org_id", "")),
             )

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -397,18 +397,24 @@ async def run_daily_metrics_job(
             pipeline_runs=testops_pipeline_rows,
             job_runs=testops_job_rows,
             computed_at=computed_at,
+            repo_team_resolver=repo_team_resolver,
+            repo_names_by_id=repo_names_by_id,
         )
         testops_test_metrics = compute_test_metrics_daily(
             day=d,
             suite_results=testops_suite_rows,
             case_results=testops_case_rows,
             computed_at=computed_at,
+            repo_team_resolver=repo_team_resolver,
+            repo_names_by_id=repo_names_by_id,
         )
         testops_coverage_metrics = compute_coverage_metrics_daily(
             day=d,
             snapshots=coverage_rows,
             prior_snapshots=prior_coverage_rows,
             computed_at=computed_at,
+            repo_team_resolver=repo_team_resolver,
+            repo_names_by_id=repo_names_by_id,
         )
         deploy_metrics = compute_deploy_metrics_daily(
             day=d, deployments=deployment_rows, computed_at=computed_at

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from dev_health_ops.db import resolve_sink_uri
+from dev_health_ops.metrics.benchmarking.runner import run_benchmarking_for_day
 from dev_health_ops.metrics.compute import compute_daily_metrics
 from dev_health_ops.metrics.compute_cicd import compute_cicd_metrics_daily
 from dev_health_ops.metrics.compute_deployments import compute_deploy_metrics_daily
@@ -470,6 +471,19 @@ async def run_daily_metrics_job(
                 s.write_quality_drag(quality_drag)
             if pipeline_stab:
                 s.write_pipeline_stability(pipeline_stab)
+
+        # Benchmarking (baselines, maturity, anomalies, period comparisons,
+        # correlations, insights). Reads from ClickHouse via the sink.
+        for s in sinks:
+            try:
+                run_benchmarking_for_day(
+                    s,
+                    as_of_day=d,
+                    computed_at=computed_at,
+                    org_id=org_id,
+                )
+            except Exception as exc:
+                logger.warning("Benchmarking run failed for day=%s: %s", d, exc)
 
         if not skip_finalize:
             ic_metrics = compute_ic_metrics_daily(

--- a/src/dev_health_ops/metrics/testops_schemas.py
+++ b/src/dev_health_ops/metrics/testops_schemas.py
@@ -13,6 +13,37 @@ layers. Changes must be coordinated across all downstream consumers.
 Existing infrastructure this extends:
 - metrics/schemas.py: PipelineRunRow, CICDMetricsDailyRecord, DORAMetricsRecord
 - migrations/clickhouse/000_raw_tables.sql: ci_pipeline_runs, deployments, incidents
+
+Scale convention (CHAOS-1192)
+-----------------------------
+Two numeric scales coexist in these schemas. Follow the suffix rule below when
+adding new columns or fields; the GraphQL boundary in
+``api/graphql/sql/validate.py`` multiplies 0.0-1.0 values by 100 so the API
+always emits 0-100. Direct SQL callers (Grafana, ad-hoc analysis) must know
+the scale of the column they are reading.
+
+Stored as 0.0-1.0 fractions (suffixes ``_rate``, ``_score``, ``_factor``,
+``_penalty``, ``_index``):
+
+- ``testops_pipeline_metrics_daily``: ``success_rate``, ``failure_rate``,
+  ``cancel_rate``, ``rerun_rate``
+- ``testops_test_metrics_daily``: ``pass_rate``, ``failure_rate``,
+  ``flake_rate``, ``retry_dependency_rate``, ``failure_recurrence_score``
+- ``ReleaseConfidenceRecord``: ``confidence_score``, all ``*_factor`` and
+  ``*_penalty`` fields
+- ``PipelineStabilityRecord``: ``stability_index``, ``success_rate_7d``,
+  ``failure_clustering_score``
+
+Stored as 0-100 percentages (suffix ``_pct``):
+
+- ``testops_coverage_metrics_daily``: ``line_coverage_pct``,
+  ``branch_coverage_pct``, ``coverage_delta_pct``
+- ``CoverageSnapshotRow``: ``line_coverage_pct``, ``branch_coverage_pct``
+
+Naming rule: ``_rate`` / ``_score`` / ``_factor`` / ``_penalty`` / ``_index``
+store 0.0-1.0; ``_pct`` stores 0-100. A full migration to a single scale is
+tracked as option 1 of CHAOS-1192; until then, document-and-normalize-at-the-
+boundary is the accepted convention.
 """
 
 from __future__ import annotations

--- a/tests/metrics/test_benchmarking_runner.py
+++ b/tests/metrics/test_benchmarking_runner.py
@@ -1,0 +1,140 @@
+"""Unit tests for the benchmarking runner.
+
+Uses a fake sink that returns canned ``query_dicts`` results per metric, and
+asserts that every benchmark ``write_*`` method receives non-empty rows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+from dev_health_ops.metrics.benchmarking._common import METRIC_DEFINITIONS
+from dev_health_ops.metrics.benchmarking.runner import (
+    DEFAULT_BENCHMARK_METRICS,
+    compute_benchmarking_for_day,
+    run_benchmarking_for_day,
+)
+
+AS_OF = date(2026, 4, 10)
+COMPUTED_AT = datetime(2026, 4, 10, 12, 0, tzinfo=timezone.utc)
+ORG = "test-org"
+
+
+class FakeSink:
+    """Minimal sink that returns deterministic time-series via query_dicts."""
+
+    def __init__(self) -> None:
+        self.baselines: list[Any] = []
+        self.maturity_bands: list[Any] = []
+        self.anomalies: list[Any] = []
+        self.period_comparisons: list[Any] = []
+        self.correlations: list[Any] = []
+        self.insights: list[Any] = []
+
+    def query_dicts(
+        self, query: str, params: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        start_day = params["start_day"] if params else AS_OF - timedelta(days=40)
+        end_day = params["end_day"] if params else AS_OF
+
+        # Produce three scopes with a mild linear trend so anomalies may trigger
+        # when the final day spikes.
+        rows: list[dict[str, Any]] = []
+        scopes = ["scope-a", "scope-b", "scope-c"]
+        day = start_day
+        idx = 0
+        while day <= end_day:
+            for i, scope in enumerate(scopes):
+                # Base trend + per-scope offset + a spike on the last day of scope-a
+                value = 0.5 + (i * 0.1) + (idx * 0.005)
+                if scope == "scope-a" and day == end_day:
+                    value += 0.8  # force an anomaly
+                rows.append({"scope_key": scope, "day": day, "value": value})
+            idx += 1
+            day += timedelta(days=1)
+        return rows
+
+    def write_benchmark_baselines(self, rows: Sequence[Any]) -> None:
+        self.baselines.extend(rows)
+
+    def write_maturity_bands(self, rows: Sequence[Any]) -> None:
+        self.maturity_bands.extend(rows)
+
+    def write_benchmark_anomalies(self, rows: Sequence[Any]) -> None:
+        self.anomalies.extend(rows)
+
+    def write_period_comparisons(self, rows: Sequence[Any]) -> None:
+        self.period_comparisons.extend(rows)
+
+    def write_metric_correlations(self, rows: Sequence[Any]) -> None:
+        self.correlations.extend(rows)
+
+    def write_benchmark_insights(self, rows: Sequence[Any]) -> None:
+        self.insights.extend(rows)
+
+
+def test_default_metrics_are_supported() -> None:
+    for metric_name, scope_type in DEFAULT_BENCHMARK_METRICS:
+        definition = METRIC_DEFINITIONS[metric_name]
+        assert scope_type in definition.scope_support, (
+            f"{metric_name} does not support scope {scope_type}"
+        )
+
+
+def test_compute_benchmarking_populates_all_categories() -> None:
+    sink = FakeSink()
+    outputs = compute_benchmarking_for_day(
+        sink,
+        as_of_day=AS_OF,
+        computed_at=COMPUTED_AT,
+        org_id=ORG,
+    )
+    assert outputs["baselines"], "expected baselines"
+    assert outputs["maturity_bands"], "expected maturity bands"
+    assert outputs["anomalies"], "expected anomalies (spike was injected)"
+    assert outputs["period_comparisons"], "expected period comparisons"
+    assert outputs["correlations"], "expected correlations"
+    assert outputs["insights"], "expected insights derived from outputs"
+
+
+def test_run_benchmarking_writes_to_all_six_sinks() -> None:
+    sink = FakeSink()
+    run_benchmarking_for_day(
+        sink,
+        as_of_day=AS_OF,
+        computed_at=COMPUTED_AT,
+        org_id=ORG,
+    )
+    assert sink.baselines
+    assert sink.maturity_bands
+    assert sink.anomalies
+    assert sink.period_comparisons
+    assert sink.correlations
+    assert sink.insights
+
+
+def test_failing_metric_does_not_halt_run() -> None:
+    class FlakySink(FakeSink):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        def query_dicts(
+            self, query: str, params: dict[str, Any] | None = None
+        ) -> list[dict[str, Any]]:
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("simulated query failure")
+            return super().query_dicts(query, params)
+
+    sink = FlakySink()
+    outputs = compute_benchmarking_for_day(
+        sink,
+        as_of_day=AS_OF,
+        computed_at=COMPUTED_AT,
+        org_id=ORG,
+    )
+    # Despite one failure, the rest of the metrics still produce records.
+    assert outputs["baselines"]

--- a/tests/metrics/test_compute_testops.py
+++ b/tests/metrics/test_compute_testops.py
@@ -362,6 +362,84 @@ def test_compute_coverage_metrics_daily_uses_latest_snapshot_and_delta():
     assert rec_b.branch_coverage_pct is None
 
 
+def test_compute_testops_metrics_resolve_team_via_repo_resolver_when_row_team_id_missing():
+    """CHAOS-1191: resolver fallback populates team_id when raw rows lack it."""
+    from dev_health_ops.providers.teams import build_repo_pattern_resolver
+
+    day = date(2026, 2, 18)
+    repo_a = uuid4()
+    repo_team_resolver = build_repo_pattern_resolver(
+        [{"id": "team-x", "name": "Team X", "repo_patterns": ["acme/api"]}]
+    )
+    repo_names_by_id = {repo_a: "acme/api"}
+    computed_at = datetime(2026, 2, 18, 13, 0, tzinfo=timezone.utc)
+
+    pipeline_records = compute_pipeline_metrics_daily(
+        day=day,
+        pipeline_runs=[
+            {
+                "repo_id": repo_a,
+                "run_id": "001",
+                "provider": "github_actions",
+                "status": "success",
+                "queued_at": datetime(2026, 2, 18, 9, 58, tzinfo=timezone.utc),
+                "started_at": datetime(2026, 2, 18, 10, 0, tzinfo=timezone.utc),
+                "finished_at": datetime(2026, 2, 18, 10, 5, tzinfo=timezone.utc),
+                "retry_count": 0,
+            }
+        ],
+        job_runs=[],
+        computed_at=computed_at,
+        repo_team_resolver=repo_team_resolver,
+        repo_names_by_id=repo_names_by_id,
+    )
+    assert pipeline_records[0].team_id == "team-x"
+
+    test_records = compute_test_metrics_daily(
+        day=day,
+        suite_results=[
+            {
+                "repo_id": repo_a,
+                "run_id": "r1",
+                "started_at": datetime(2026, 2, 18, 10, 0, tzinfo=timezone.utc),
+                "finished_at": datetime(2026, 2, 18, 10, 1, tzinfo=timezone.utc),
+                "total_count": 1,
+                "passed_count": 1,
+                "failed_count": 0,
+                "error_count": 0,
+                "skipped_count": 0,
+                "quarantined_count": 0,
+                "duration_seconds": 60,
+            }
+        ],
+        case_results=[],
+        computed_at=computed_at,
+        repo_team_resolver=repo_team_resolver,
+        repo_names_by_id=repo_names_by_id,
+    )
+    assert test_records[0].team_id == "team-x"
+
+    coverage_records = compute_coverage_metrics_daily(
+        day=day,
+        snapshots=[
+            {
+                "repo_id": repo_a,
+                "run_id": "r1",
+                "snapshot_id": "s1",
+                "line_coverage_pct": 80.0,
+                "branch_coverage_pct": 70.0,
+                "lines_total": 100,
+                "lines_covered": 80,
+            }
+        ],
+        prior_snapshots=None,
+        computed_at=computed_at,
+        repo_team_resolver=repo_team_resolver,
+        repo_names_by_id=repo_names_by_id,
+    )
+    assert coverage_records[0].team_id == "team-x"
+
+
 def test_compute_coverage_metrics_daily_returns_empty_for_no_snapshots():
     records = compute_coverage_metrics_daily(
         day=date(2026, 2, 18),


### PR DESCRIPTION
## Summary
Rollup PR for the CHAOS-1188 TestOps fixes milestone. Aggregates three child PRs that stack into this branch:

- #645 — feat(CHAOS-1190): wire benchmarking compute fns into daily metrics job (merged)
- #647 — fix(CHAOS-1191): populate team_id in TestOps daily metrics
- #648 — docs(CHAOS-1192): document rate vs coverage scale convention

Merge children into this branch first, then this rolls up to main.

## Test plan
- [ ] All child PRs green and reviewed
- [ ] Fixture smoke run: 6 benchmark tables populated
- [ ] team_id non-NULL in TestOps daily metric tables after fixture rerun

TEST-EVIDENCE:
- Per child PR; aggregated CI runs on this branch HEAD will exercise the combined diff.

RISK-NOTES:
- Blast radius: TestOps daily metrics pipeline + GraphQL schema docstring. No DB schema changes.
- Rollback: revert this rollup commit; child PR commits are independently revertable.
- Follow-up: CHAOS-1192 option 1 (column rename) deferred per ticket.