### PR TITLE
fix: scope admin user listing by X-Org-Id header for superusers

### DIFF
--- a/src/dev_health_ops/api/admin/routers/users.py
+++ b/src/dev_health_ops/api/admin/routers/users.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request

--- a/src/dev_health_ops/api/admin/routers/users.py
+++ b/src/dev_health_ops/api/admin/routers/users.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -38,12 +40,24 @@ async def list_users(
     offset: int = 0,
     active_only: bool = True,
     q: str | None = Query(default=None, min_length=1, max_length=200),
+    x_org_id: Annotated[str | None, Header(alias="X-Org-Id")] = None,
     session: AsyncSession = Depends(get_session),
     current_user: AuthenticatedUser = Depends(require_admin),
 ) -> list[UserResponse]:
     svc = UserService(session)
     search = q.strip() if q and q.strip() else None
-    if current_user.is_superuser:
+    # X-Org-Id header present → org-scoped view (admin page).
+    # Absent + superuser → global view (superadmin page or impersonation).
+    # Absent + non-superuser → scoped to JWT org_id.
+    if x_org_id:
+        users = await svc.list_by_org(
+            x_org_id,
+            limit=limit,
+            offset=offset,
+            active_only=active_only,
+            search=search,
+        )
+    elif current_user.is_superuser:
         users = await svc.list_all(
             limit=limit,
             offset=offset,

--- a/tests/test_admin_users_scope.py
+++ b/tests/test_admin_users_scope.py
@@ -178,3 +178,44 @@ async def test_users_search_honors_scope_for_superadmin_and_org_admin(
     org_response = await async_client.get("/api/v1/admin/users?q=bob")
     assert org_response.status_code == 200
     assert org_response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_superadmin_with_org_header_is_org_scoped(client, seeded_state):
+    async_client, current_user = client
+    current_user["value"] = AuthenticatedUser(
+        user_id="super-user",
+        email="super@example.com",
+        org_id=seeded_state["org_a"],
+        role="owner",
+        is_superuser=True,
+    )
+
+    response = await async_client.get(
+        "/api/v1/admin/users",
+        headers={"X-Org-Id": seeded_state["org_a"]},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    emails = {row["email"] for row in body}
+    assert emails == {"alice@example.com"}
+
+
+@pytest.mark.asyncio
+async def test_superadmin_without_org_header_is_global(client, seeded_state):
+    async_client, current_user = client
+    current_user["value"] = AuthenticatedUser(
+        user_id="super-user",
+        email="super@example.com",
+        org_id=seeded_state["org_a"],
+        role="owner",
+        is_superuser=True,
+    )
+
+    response = await async_client.get("/api/v1/admin/users")
+
+    assert response.status_code == 200
+    body = response.json()
+    emails = {row["email"] for row in body}
+    assert emails == {"alice@example.com", "bob@example.com"}


### PR DESCRIPTION
## Summary

- Superusers on `/admin/users` saw **all platform users** instead of only the current org's members. The `list_users` endpoint checked `is_superuser` → `list_all()`, ignoring the `X-Org-Id` header the frontend already sends.
- Now the endpoint reads `X-Org-Id`: present → org-scoped (`list_by_org`), absent + superuser → global (`list_all`), absent + non-superuser → JWT org_id (unchanged).
- Added 2 tests: superuser **with** `X-Org-Id` → org-scoped, superuser **without** → global.

## Test Plan

All 5 tests in `test_admin_users_scope.py` pass (3 existing + 2 new).

SCREENSHOT-WAIVER: Backend-only fix — no rendered frontend changes.