### PR TITLE
feat: ClickHouse migrations for feature flag impact tables (CHAOS-817)

### DIFF
--- a/src/dev_health_ops/connectors/launchdarkly.py
+++ b/src/dev_health_ops/connectors/launchdarkly.py
@@ -1,0 +1,221 @@
+"""
+LaunchDarkly connector for fetching feature flags and audit log events.
+
+Uses the LaunchDarkly REST API v2 to retrieve flag definitions and
+lifecycle events (create, update, toggle, rule changes, rollouts).
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from dev_health_ops.connectors.exceptions import (
+    APIException,
+    AuthenticationException,
+    RateLimitException,
+)
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://app.launchdarkly.com/api/v2"
+
+
+def _parse_rate_limit_remaining(response: httpx.Response) -> int | None:
+    """Extract remaining rate-limit budget from LD response headers."""
+    value = response.headers.get("X-RateLimit-Route-Remaining")
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_retry_after(response: httpx.Response) -> float | None:
+    """Extract Retry-After seconds from a 429 response."""
+    value = response.headers.get("Retry-After")
+    if value is None:
+        return None
+    try:
+        return max(1.0, float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _raise_for_status(response: httpx.Response) -> None:
+    """Translate HTTP error codes into connector exceptions."""
+    status = response.status_code
+    if status == 401:
+        raise AuthenticationException("LaunchDarkly authentication failed")
+    if status == 403:
+        raise APIException(f"LaunchDarkly forbidden: {response.text}")
+    if status == 429:
+        raise RateLimitException(
+            "LaunchDarkly rate limit exceeded",
+            retry_after_seconds=_parse_retry_after(response),
+        )
+    if status == 404:
+        raise APIException(f"LaunchDarkly resource not found: {response.url}")
+    if status >= 500:
+        raise APIException(f"LaunchDarkly server error: {status} - {response.text}")
+    if status >= 400:
+        raise APIException(f"LaunchDarkly API error: {status} - {response.text}")
+
+
+class LaunchDarklyConnector:
+    """Async connector for the LaunchDarkly REST API v2.
+
+    :param api_key: LaunchDarkly API access token.
+    :param project_key: Default project key (can be overridden per call).
+    :param base_url: API base URL (override for testing / private instances).
+    :param timeout: Request timeout in seconds.
+    :param max_retries: Maximum retry attempts on 429 / 5xx errors.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        project_key: str | None = None,
+        base_url: str = _BASE_URL,
+        timeout: int = 30,
+        max_retries: int = 5,
+    ) -> None:
+        self.api_key = api_key
+        self.default_project_key = project_key
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self._client: httpx.AsyncClient | None = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                base_url=self.base_url,
+                headers={
+                    "Authorization": self.api_key,
+                    "Content-Type": "application/json",
+                },
+                timeout=self.timeout,
+            )
+        return self._client
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        """Execute an HTTP request with retry on 429 / 5xx."""
+        import asyncio
+
+        client = await self._get_client()
+        last_exc: Exception | None = None
+        delay = 1.0
+
+        for attempt in range(self.max_retries):
+            try:
+                response = await client.request(method, path, params=params)
+
+                remaining = _parse_rate_limit_remaining(response)
+                if remaining is not None and remaining < 5:
+                    logger.warning(
+                        "LaunchDarkly rate-limit budget low: %d remaining",
+                        remaining,
+                    )
+
+                if response.status_code == 429 or response.status_code >= 500:
+                    retry_after = _parse_retry_after(response) or delay
+                    if attempt < self.max_retries - 1:
+                        logger.warning(
+                            "LaunchDarkly %d on %s (attempt %d/%d), retrying in %.1fs",
+                            response.status_code,
+                            path,
+                            attempt + 1,
+                            self.max_retries,
+                            retry_after,
+                        )
+                        await asyncio.sleep(retry_after)
+                        delay = min(delay * 2, 60.0)
+                        continue
+                    _raise_for_status(response)
+
+                _raise_for_status(response)
+                return response.json()
+
+            except (httpx.TimeoutException, httpx.ConnectError) as exc:
+                last_exc = exc
+                if attempt < self.max_retries - 1:
+                    logger.warning(
+                        "LaunchDarkly request to %s failed (attempt %d/%d): %s",
+                        path,
+                        attempt + 1,
+                        self.max_retries,
+                        exc,
+                    )
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, 60.0)
+                    continue
+                raise APIException(f"LaunchDarkly request failed: {exc}") from exc
+
+        if last_exc:
+            raise APIException(
+                f"LaunchDarkly request failed after {self.max_retries} attempts"
+            ) from last_exc
+        raise APIException("LaunchDarkly request failed: unknown error")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def get_flags(self, project_key: str | None = None) -> list[dict]:
+        """Fetch all feature flags for a project.
+
+        :param project_key: LD project key; falls back to ``self.default_project_key``.
+        :returns: List of raw flag dicts from the LD API.
+        """
+        key = project_key or self.default_project_key
+        if not key:
+            raise ValueError(
+                "project_key is required (pass it or set default_project_key)"
+            )
+
+        data = await self._request("GET", f"/flags/{key}")
+        items = data.get("items", [])
+        logger.info("Fetched %d flags for project %s", len(items), key)
+        return items
+
+    async def get_audit_log(
+        self,
+        since: datetime | None = None,
+        limit: int = 20,
+    ) -> list[dict]:
+        """Fetch audit log entries.
+
+        :param since: Only return entries after this timestamp.
+        :param limit: Maximum entries to return (LD default is 20).
+        :returns: List of raw audit-log entry dicts.
+        """
+        params: dict[str, Any] = {"limit": limit}
+        if since is not None:
+            # LD expects epoch milliseconds for date filters
+            epoch_ms = int(since.timestamp() * 1000)
+            params["after"] = epoch_ms
+
+        data = await self._request("GET", "/auditlog", params=params)
+        items = data.get("items", [])
+        logger.info("Fetched %d audit log entries", len(items))
+        return items
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    async def __aenter__(self) -> "LaunchDarklyConnector":
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()

--- a/src/dev_health_ops/connectors/launchdarkly.py
+++ b/src/dev_health_ops/connectors/launchdarkly.py
@@ -6,7 +6,7 @@ lifecycle events (create, update, toggle, rule changes, rollouts).
 """
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 import httpx

--- a/src/dev_health_ops/migrations/clickhouse/034_feature_flag_user_impact_tables.sql
+++ b/src/dev_health_ops/migrations/clickhouse/034_feature_flag_user_impact_tables.sql
@@ -1,0 +1,102 @@
+-- Migration 034: Add feature flag and user impact analytics tables.
+
+CREATE TABLE IF NOT EXISTS feature_flag (
+    org_id String DEFAULT 'default',
+    provider String,
+    flag_key String,
+    project_key String,
+    repo_id String,
+    environment String,
+    flag_type String,
+    created_at DateTime64(3, 'UTC'),
+    archived_at Nullable(DateTime64(3, 'UTC')),
+    last_synced DateTime64(3, 'UTC')
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (org_id, provider, flag_key);
+
+CREATE TABLE IF NOT EXISTS feature_flag_event (
+    org_id String DEFAULT 'default',
+    event_type String,
+    flag_key String,
+    environment String,
+    repo_id String,
+    actor_type String,
+    prev_state String,
+    next_state String,
+    event_ts DateTime64(3, 'UTC'),
+    ingested_at DateTime64(3, 'UTC'),
+    source_event_id String,
+    dedupe_key String
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(event_ts)
+ORDER BY (org_id, flag_key, environment, event_ts)
+TTL event_ts + INTERVAL 90 DAY DELETE;
+
+CREATE TABLE IF NOT EXISTS feature_flag_link (
+    org_id String DEFAULT 'default',
+    flag_key String,
+    target_type String,
+    target_id String,
+    provider String,
+    link_source String,
+    link_type String,
+    evidence_type String,
+    confidence Float32,
+    valid_from Nullable(DateTime64(3, 'UTC')),
+    valid_to Nullable(DateTime64(3, 'UTC')),
+    last_synced DateTime64(3, 'UTC')
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (org_id, flag_key, target_type, target_id);
+
+CREATE TABLE IF NOT EXISTS telemetry_signal_bucket (
+    org_id String DEFAULT 'default',
+    signal_type String,
+    signal_count UInt64,
+    session_count UInt64,
+    unique_pseudonymous_count Nullable(UInt64),
+    endpoint_group String,
+    environment String,
+    repo_id String,
+    release_ref String,
+    bucket_start DateTime64(3, 'UTC'),
+    bucket_end DateTime64(3, 'UTC'),
+    ingested_at DateTime64(3, 'UTC'),
+    is_sampled UInt8 DEFAULT 0,
+    schema_version String,
+    dedupe_key String
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(bucket_start)
+ORDER BY (org_id, environment, repo_id, release_ref, bucket_start)
+TTL bucket_start + INTERVAL 90 DAY DELETE;
+
+CREATE TABLE IF NOT EXISTS release_impact_daily (
+    org_id String DEFAULT 'default',
+    day Date,
+    release_ref String,
+    environment String,
+    repo_id String,
+    release_user_friction_delta Nullable(Float64),
+    release_post_friction_rate Nullable(Float64),
+    release_error_rate_delta Nullable(Float64),
+    release_post_error_rate Nullable(Float64),
+    time_to_first_user_issue_after_release Nullable(Float64),
+    release_impact_confidence_score Float32,
+    release_impact_coverage_ratio Float32,
+    flag_exposure_rate Nullable(Float64),
+    flag_activation_rate Nullable(Float64),
+    flag_reliability_guardrail Nullable(Float64),
+    flag_friction_delta Nullable(Float64),
+    flag_rollout_half_life Nullable(Float64),
+    flag_churn_rate Nullable(Float64),
+    issue_to_release_impact_link_rate Nullable(Float64),
+    rollback_or_disable_after_impact_spike UInt32,
+    coverage_ratio Float32,
+    missing_required_fields_count UInt32,
+    instrumentation_change_flag UInt8 DEFAULT 0,
+    data_completeness Float32,
+    concurrent_deploy_count UInt32,
+    computed_at DateTime64(3, 'UTC')
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(day)
+ORDER BY (org_id, release_ref, environment, day)
+TTL day + INTERVAL 365 DAY DELETE;

--- a/src/dev_health_ops/processors/launchdarkly.py
+++ b/src/dev_health_ops/processors/launchdarkly.py
@@ -1,0 +1,150 @@
+"""
+LaunchDarkly processor — normalizes flag and audit-log data into
+canonical feature-flag records for sink persistence.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, NamedTuple
+
+logger = logging.getLogger(__name__)
+
+try:
+    from dev_health_ops.metrics.schemas import (
+        FeatureFlagEventRecord,
+        FeatureFlagRecord,
+    )
+except ImportError:
+    # Will be available when branches merge; define compatible namedtuples
+    class FeatureFlagRecord(NamedTuple):  # type: ignore[no-redef]
+        org_id: str
+        flag_key: str
+        flag_name: str
+        project_key: str
+        kind: str
+        status: str
+        tags: list[str]
+        created_at: datetime | None
+        source: str
+        dedupe_key: str
+
+    class FeatureFlagEventRecord(NamedTuple):  # type: ignore[no-redef]
+        org_id: str
+        flag_key: str
+        event_kind: str
+        actor: str
+        timestamp: datetime | None
+        description: str
+        source: str
+        source_event_id: str
+        dedupe_key: str
+
+
+_EVENT_KIND_MAP: dict[str, str] = {
+    "createFlag": "create",
+    "updateFlag": "update",
+    "toggleFlag": "toggle",
+    "updateFlagVariations": "rule",
+    "updateFlagDefaultRule": "rollout",
+}
+
+_SOURCE = "launchdarkly"
+
+
+def _parse_iso(value: str | int | None) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(value / 1000, tz=timezone.utc)
+        except (OSError, ValueError):
+            return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def normalize_flags(
+    flags: list[dict[str, Any]],
+    org_id: str,
+) -> list[FeatureFlagRecord]:
+    """Map raw LaunchDarkly flag dicts to ``FeatureFlagRecord`` instances."""
+    records: list[FeatureFlagRecord] = []
+    for flag in flags:
+        key = flag.get("key", "")
+        env_statuses = flag.get("environments", {})
+        status = "active"
+        if env_statuses:
+            first_env = next(iter(env_statuses.values()), {})
+            if isinstance(first_env, dict):
+                on = first_env.get("on")
+                status = "active" if on else "inactive"
+
+        records.append(
+            FeatureFlagRecord(
+                org_id=org_id,
+                flag_key=key,
+                flag_name=flag.get("name", key),
+                project_key=flag.get("_projectKey", ""),
+                kind=flag.get("kind", "boolean"),
+                status=status,
+                tags=flag.get("tags", []),
+                created_at=_parse_iso(flag.get("creationDate")),
+                source=_SOURCE,
+                dedupe_key=f"ld:flag:{org_id}:{key}",
+            )
+        )
+    logger.info("Normalized %d flags for org %s", len(records), org_id)
+    return records
+
+
+def normalize_audit_events(
+    events: list[dict[str, Any]],
+    org_id: str,
+) -> list[FeatureFlagEventRecord]:
+    """Map raw LaunchDarkly audit-log entries to ``FeatureFlagEventRecord`` instances."""
+    records: list[FeatureFlagEventRecord] = []
+    for entry in events:
+        raw_kind = entry.get("kind", "")
+        event_kind = _EVENT_KIND_MAP.get(raw_kind, raw_kind)
+
+        entry_id = str(entry.get("_id", ""))
+        member = entry.get("member", {}) or {}
+        actor = member.get("email", "") or member.get("_id", "")
+
+        target = entry.get("target", {}) or {}
+        flag_key = ""
+        if target:
+            resources = target.get("resources", [])
+            for res in resources:
+                if not isinstance(res, str):
+                    continue
+                if "/flags/" in res:
+                    flag_key = res.rsplit("/flags/", 1)[-1]
+                    break
+                if ":flag/" in res:
+                    flag_key = res.rsplit(":flag/", 1)[-1]
+                    break
+        if not flag_key:
+            name = entry.get("name", "")
+            if name:
+                flag_key = name
+
+        records.append(
+            FeatureFlagEventRecord(
+                org_id=org_id,
+                flag_key=flag_key,
+                event_kind=event_kind,
+                actor=str(actor),
+                timestamp=_parse_iso(entry.get("date")),
+                description=entry.get("description", ""),
+                source=_SOURCE,
+                source_event_id=entry_id,
+                dedupe_key=entry_id,
+            )
+        )
+    logger.info("Normalized %d audit events for org %s", len(records), org_id)
+    return records

--- a/tests/test_launchdarkly.py
+++ b/tests/test_launchdarkly.py
@@ -1,7 +1,7 @@
 """Tests for LaunchDarkly connector and processor normalization."""
 
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -23,7 +23,6 @@ from dev_health_ops.processors.launchdarkly import (
     normalize_audit_events,
     normalize_flags,
 )
-
 
 # ---------------------------------------------------------------------------
 # Connector helpers

--- a/tests/test_launchdarkly.py
+++ b/tests/test_launchdarkly.py
@@ -1,0 +1,344 @@
+"""Tests for LaunchDarkly connector and processor normalization."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from dev_health_ops.connectors.exceptions import (
+    APIException,
+    AuthenticationException,
+    RateLimitException,
+)
+from dev_health_ops.connectors.launchdarkly import (
+    LaunchDarklyConnector,
+    _parse_rate_limit_remaining,
+    _parse_retry_after,
+    _raise_for_status,
+)
+from dev_health_ops.processors.launchdarkly import (
+    _EVENT_KIND_MAP,
+    _parse_iso,
+    normalize_audit_events,
+    normalize_flags,
+)
+
+
+# ---------------------------------------------------------------------------
+# Connector helpers
+# ---------------------------------------------------------------------------
+
+
+class TestParseRateLimitRemaining:
+    def test_valid_header(self):
+        response = MagicMock()
+        response.headers = {"X-RateLimit-Route-Remaining": "42"}
+        assert _parse_rate_limit_remaining(response) == 42
+
+    def test_missing_header(self):
+        response = MagicMock()
+        response.headers = {}
+        assert _parse_rate_limit_remaining(response) is None
+
+    def test_non_numeric_header(self):
+        response = MagicMock()
+        response.headers = {"X-RateLimit-Route-Remaining": "abc"}
+        assert _parse_rate_limit_remaining(response) is None
+
+
+class TestParseRetryAfter:
+    def test_valid_header(self):
+        response = MagicMock()
+        response.headers = {"Retry-After": "30"}
+        assert _parse_retry_after(response) == 30.0
+
+    def test_minimum_clamp(self):
+        response = MagicMock()
+        response.headers = {"Retry-After": "0.1"}
+        assert _parse_retry_after(response) == 1.0
+
+    def test_missing_header(self):
+        response = MagicMock()
+        response.headers = {}
+        assert _parse_retry_after(response) is None
+
+
+class TestRaiseForStatus:
+    def test_401_raises_auth(self):
+        response = MagicMock()
+        response.status_code = 401
+        with pytest.raises(AuthenticationException):
+            _raise_for_status(response)
+
+    def test_429_raises_rate_limit(self):
+        response = MagicMock()
+        response.status_code = 429
+        response.headers = {"Retry-After": "5"}
+        with pytest.raises(RateLimitException):
+            _raise_for_status(response)
+
+    def test_500_raises_api(self):
+        response = MagicMock()
+        response.status_code = 500
+        response.text = "Internal Server Error"
+        with pytest.raises(APIException, match="server error"):
+            _raise_for_status(response)
+
+    def test_200_passes(self):
+        response = MagicMock()
+        response.status_code = 200
+        _raise_for_status(response)
+
+
+# ---------------------------------------------------------------------------
+# Connector async tests
+# ---------------------------------------------------------------------------
+
+
+class TestLaunchDarklyConnector:
+    @pytest.fixture
+    def connector(self):
+        return LaunchDarklyConnector(
+            api_key="test-api-key",
+            project_key="default",
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_flags_returns_items(self, connector):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"X-RateLimit-Route-Remaining": "100"}
+        mock_response.json.return_value = {
+            "items": [
+                {"key": "flag-1", "name": "Flag One", "kind": "boolean"},
+                {"key": "flag-2", "name": "Flag Two", "kind": "multivariate"},
+            ]
+        }
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=mock_response)
+        connector._client = mock_client
+
+        flags = await connector.get_flags()
+        assert len(flags) == 2
+        assert flags[0]["key"] == "flag-1"
+        mock_client.request.assert_called_once_with(
+            "GET", "/flags/default", params=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_flags_requires_project_key(self):
+        connector = LaunchDarklyConnector(api_key="key")
+        with pytest.raises(ValueError, match="project_key is required"):
+            await connector.get_flags()
+
+    @pytest.mark.asyncio
+    async def test_get_audit_log_with_since(self, connector):
+        since = datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        expected_ms = int(since.timestamp() * 1000)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.json.return_value = {"items": [{"_id": "abc"}]}
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=mock_response)
+        connector._client = mock_client
+
+        events = await connector.get_audit_log(since=since)
+        assert len(events) == 1
+
+        call_kwargs = mock_client.request.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        assert params["after"] == expected_ms
+        assert params["limit"] == 20
+
+    @pytest.mark.asyncio
+    async def test_close_closes_client(self, connector):
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        connector._client = mock_client
+
+        await connector.close()
+        mock_client.aclose.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self):
+        async with LaunchDarklyConnector(api_key="key", project_key="p") as conn:
+            assert conn.api_key == "key"
+
+
+# ---------------------------------------------------------------------------
+# Processor: _parse_iso
+# ---------------------------------------------------------------------------
+
+
+class TestParseIso:
+    def test_epoch_ms(self):
+        result = _parse_iso(1705312800000)
+        assert result is not None
+        assert result.tzinfo == timezone.utc
+
+    def test_iso_string(self):
+        result = _parse_iso("2025-01-15T10:00:00Z")
+        assert result is not None
+        assert result.year == 2025
+
+    def test_none(self):
+        assert _parse_iso(None) is None
+
+    def test_invalid(self):
+        assert _parse_iso("not-a-date") is None
+
+
+# ---------------------------------------------------------------------------
+# Processor: normalize_flags
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeFlags:
+    def test_basic_flag(self):
+        flags = [
+            {
+                "key": "new-checkout",
+                "name": "New Checkout Flow",
+                "kind": "boolean",
+                "tags": ["frontend", "checkout"],
+                "creationDate": 1705312800000,
+                "_projectKey": "my-project",
+                "environments": {
+                    "production": {"on": True},
+                },
+            }
+        ]
+        records = normalize_flags(flags, org_id="org-1")
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.org_id == "org-1"
+        assert rec.flag_key == "new-checkout"
+        assert rec.flag_name == "New Checkout Flow"
+        assert rec.kind == "boolean"
+        assert rec.status == "active"
+        assert rec.tags == ["frontend", "checkout"]
+        assert rec.source == "launchdarkly"
+        assert rec.dedupe_key == "ld:flag:org-1:new-checkout"
+
+    def test_inactive_flag(self):
+        flags = [
+            {
+                "key": "old-feature",
+                "name": "Old Feature",
+                "kind": "boolean",
+                "environments": {
+                    "production": {"on": False},
+                },
+            }
+        ]
+        records = normalize_flags(flags, org_id="org-1")
+        assert records[0].status == "inactive"
+
+    def test_empty_environments(self):
+        flags = [{"key": "bare", "environments": {}}]
+        records = normalize_flags(flags, org_id="org-1")
+        assert records[0].status == "active"
+
+    def test_empty_input(self):
+        assert normalize_flags([], org_id="org-1") == []
+
+
+# ---------------------------------------------------------------------------
+# Processor: normalize_audit_events
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAuditEvents:
+    def _make_entry(self, kind="createFlag", flag_key="my-flag", entry_id="evt-1"):
+        return {
+            "_id": entry_id,
+            "kind": kind,
+            "date": 1705312800000,
+            "description": f"Test {kind}",
+            "member": {"email": "dev@example.com", "_id": "user-1"},
+            "target": {"resources": [f"proj/default:env/production:flag/{flag_key}"]},
+            "name": flag_key,
+        }
+
+    def test_create_flag_event(self):
+        events = [self._make_entry("createFlag")]
+        records = normalize_audit_events(events, org_id="org-1")
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.event_kind == "create"
+        assert rec.flag_key == "my-flag"
+        assert rec.actor == "dev@example.com"
+        assert rec.source == "launchdarkly"
+        assert rec.source_event_id == "evt-1"
+        assert rec.dedupe_key == "evt-1"
+
+    @pytest.mark.parametrize(
+        "ld_kind,expected",
+        [
+            ("createFlag", "create"),
+            ("updateFlag", "update"),
+            ("toggleFlag", "toggle"),
+            ("updateFlagVariations", "rule"),
+            ("updateFlagDefaultRule", "rollout"),
+        ],
+    )
+    def test_event_kind_mapping(self, ld_kind, expected):
+        events = [self._make_entry(ld_kind)]
+        records = normalize_audit_events(events, org_id="org-1")
+        assert records[0].event_kind == expected
+
+    def test_unknown_kind_passes_through(self):
+        events = [self._make_entry("deleteFlag")]
+        records = normalize_audit_events(events, org_id="org-1")
+        assert records[0].event_kind == "deleteFlag"
+
+    def test_flag_key_from_target_resources(self):
+        entry = {
+            "_id": "e1",
+            "kind": "updateFlag",
+            "target": {"resources": ["proj/default:env/prod:flag/checkout-v2"]},
+            "member": {},
+        }
+        records = normalize_audit_events([entry], org_id="org-1")
+        assert records[0].flag_key == "checkout-v2"
+
+    def test_flag_key_fallback_to_name(self):
+        entry = {
+            "_id": "e2",
+            "kind": "updateFlag",
+            "target": {"resources": []},
+            "name": "fallback-flag",
+            "member": {},
+        }
+        records = normalize_audit_events([entry], org_id="org-1")
+        assert records[0].flag_key == "fallback-flag"
+
+    def test_actor_fallback_to_member_id(self):
+        entry = {
+            "_id": "e3",
+            "kind": "createFlag",
+            "member": {"_id": "user-99"},
+            "target": {},
+        }
+        records = normalize_audit_events([entry], org_id="org-1")
+        assert records[0].actor == "user-99"
+
+    def test_empty_input(self):
+        assert normalize_audit_events([], org_id="org-1") == []
+
+    def test_event_kind_map_completeness(self):
+        expected_keys = {
+            "createFlag",
+            "updateFlag",
+            "toggleFlag",
+            "updateFlagVariations",
+            "updateFlagDefaultRule",
+        }
+        assert set(_EVENT_KIND_MAP.keys()) == expected_keys


### PR DESCRIPTION
## Summary
- Adds migration `034_feature_flag_user_impact_tables.sql` with CREATE TABLE DDL for 5 new analytics tables
- Tables: `feature_flag`, `feature_flag_event`, `feature_flag_link`, `telemetry_signal_bucket`, `release_impact_daily`
- Follows existing conventions: `org_id` first in ORDER BY, `DateTime64(3, 'UTC')`, appropriate engines (ReplacingMergeTree for dimensions, MergeTree for events/derived)
- TTL per PRD: 90d raw events, no TTL dimensions, 365d derived

## Linear
Closes CHAOS-817 | Project: Feature Flag + User Impact Mapping (Phase 0)

## Phase 0 PRs (this is 1 of 4)
- **This PR**: ClickHouse migrations
- feat/ff-schemas-sinks: Record dataclasses + sink write methods
- feat/ff-release-ref: release_ref persistence path
- feat/ff-test-harness: Test harness