### PR TITLE
feat: feature flag sink records and write contracts (CHAOS-818)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+f3b6feebaea7953d563207a73c76217f8ec5ccea:tests/test_ingest_api.py:generic-api-key:71

--- a/src/dev_health_ops/api/ingest/router.py
+++ b/src/dev_health_ops/api/ingest/router.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter
 
@@ -12,6 +13,7 @@ from .schemas import (
     IngestDeploymentsRequest,
     IngestIncidentsRequest,
     IngestPullRequestsRequest,
+    IngestTelemetryRequest,
     IngestWorkItemsRequest,
 )
 from .streams import get_redis_client, stream_name, write_to_stream
@@ -154,3 +156,63 @@ async def ingest_incidents(
         items_received=len(payload.items),
         stream=sname,
     )
+
+
+@router.post("/telemetry", status_code=202, response_model=IngestAcceptedResponse)
+async def ingest_telemetry(
+    payload: IngestTelemetryRequest,
+    auth: IngestAuthContext,
+    idempotency_key: IngestIdempotencyKey,
+) -> IngestAcceptedResponse:
+    from dev_health_ops.metrics.schemas import TelemetrySignalBucketRecord
+
+    ingestion_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+
+    records = [
+        TelemetrySignalBucketRecord(
+            signal_type=item.signal_type,
+            signal_count=item.signal_count,
+            session_count=item.session_count,
+            unique_pseudonymous_count=item.unique_pseudonymous_count,
+            endpoint_group=item.endpoint_group or None,
+            environment=item.environment,
+            repo_id=uuid.UUID(item.repo_id) if item.repo_id else None,
+            release_ref=item.release_ref or None,
+            bucket_start=item.bucket_start,
+            bucket_end=item.bucket_end,
+            ingested_at=now,
+            is_sampled=item.is_sampled,
+            schema_version=item.schema_version,
+            dedupe_key=item.dedupe_key,
+            org_id=payload.org_id,
+        )
+        for item in payload.items
+    ]
+
+    await _persist_telemetry(records)
+
+    return IngestAcceptedResponse(
+        ingestion_id=ingestion_id,
+        items_received=len(payload.items),
+        stream=f"ingest:{payload.org_id}:telemetry",
+    )
+
+
+async def _persist_telemetry(
+    records: list,
+) -> None:
+    import os
+
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    ch_url = os.getenv("CLICKHOUSE_URI") or os.getenv("DATABASE_URI") or ""
+    if not ch_url:
+        logger.warning("No ClickHouse URI configured, skipping telemetry persistence")
+        return
+
+    sink = ClickHouseMetricsSink(ch_url)
+    try:
+        sink.write_telemetry_signal_buckets(records)
+    finally:
+        sink.close()

--- a/src/dev_health_ops/api/ingest/schemas.py
+++ b/src/dev_health_ops/api/ingest/schemas.py
@@ -79,6 +79,22 @@ class IngestWorkItem(BaseModel):
     url: str | None = None
 
 
+class IngestTelemetrySignalBucket(BaseModel):
+    signal_type: str  # e.g. friction.rage_click, error.unhandled, adoption.feature_used
+    signal_count: int
+    session_count: int
+    unique_pseudonymous_count: int | None = None
+    endpoint_group: str = ""
+    environment: str
+    repo_id: str = ""
+    release_ref: str = ""
+    bucket_start: datetime
+    bucket_end: datetime
+    is_sampled: bool = False
+    schema_version: str = "1.0"
+    dedupe_key: str
+
+
 class IngestDeployment(BaseModel):
     deployment_id: str
     status: str
@@ -120,6 +136,11 @@ class IngestWorkItemsRequest(BaseModel):
     org_id: str
     items: list[IngestWorkItem] = Field(..., min_length=1, max_length=1000)
     # No repo_url — work items are project-scoped, not repo-scoped
+
+
+class IngestTelemetryRequest(BaseModel):
+    org_id: str
+    items: list[IngestTelemetrySignalBucket] = Field(..., min_length=1, max_length=5000)
 
 
 class IngestDeploymentsRequest(IngestBatchRequest):

--- a/src/dev_health_ops/metrics/schemas.py
+++ b/src/dev_health_ops/metrics/schemas.py
@@ -477,6 +477,100 @@ class IssueTypeMetricsRecord:
 
 
 @dataclass(frozen=True)
+class FeatureFlagRecord:
+    provider: str
+    flag_key: str
+    project_key: str | None
+    repo_id: UUID | None
+    environment: str
+    flag_type: str | None
+    created_at: datetime | None
+    archived_at: datetime | None
+    last_synced: datetime
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
+class FeatureFlagEventRecord:
+    event_type: str
+    flag_key: str
+    environment: str
+    repo_id: UUID | None
+    actor_type: str | None
+    prev_state: str | None
+    next_state: str | None
+    event_ts: datetime
+    ingested_at: datetime
+    source_event_id: str | None
+    dedupe_key: str
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
+class FeatureFlagLinkRecord:
+    flag_key: str
+    target_type: str
+    target_id: str
+    provider: str
+    link_source: str
+    link_type: str
+    evidence_type: str | None
+    confidence: float
+    valid_from: datetime
+    valid_to: datetime | None
+    last_synced: datetime
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
+class TelemetrySignalBucketRecord:
+    signal_type: str
+    signal_count: int
+    session_count: int
+    unique_pseudonymous_count: int | None
+    endpoint_group: str | None
+    environment: str
+    repo_id: UUID | None
+    release_ref: str | None
+    bucket_start: datetime
+    bucket_end: datetime
+    ingested_at: datetime
+    is_sampled: bool
+    schema_version: str
+    dedupe_key: str
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
+class ReleaseImpactDailyRecord:
+    day: date
+    release_ref: str
+    environment: str
+    repo_id: UUID | None
+    release_user_friction_delta: float | None
+    release_post_friction_rate: float | None
+    release_error_rate_delta: float | None
+    release_post_error_rate: float | None
+    time_to_first_user_issue_after_release_hours: float | None
+    release_impact_confidence_score: float | None
+    coverage_ratio: float | None
+    flag_exposure_rate: float | None
+    flag_activation_rate: float | None
+    flag_reliability_guardrail: float | None
+    flag_friction_delta: float | None
+    flag_rollout_half_life_hours: float | None
+    flag_churn_rate: float | None
+    issue_to_release_impact_link_rate: float | None
+    rollback_or_disable_after_impact_spike_count: int | None
+    missing_required_fields_count: int = 0
+    instrumentation_change_flag: bool = False
+    data_completeness: float = 1.0
+    concurrent_deploy_count: int = 0
+    computed_at: datetime | None = None
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
 class WorkGraphEdgeRecord:
     edge_id: str
     source_type: str

--- a/src/dev_health_ops/metrics/sinks/base.py
+++ b/src/dev_health_ops/metrics/sinks/base.py
@@ -18,6 +18,9 @@ from dev_health_ops.metrics.schemas import (
     CommitMetricsRecord,
     DeployMetricsDailyRecord,
     DORAMetricsRecord,
+    FeatureFlagEventRecord,
+    FeatureFlagLinkRecord,
+    FeatureFlagRecord,
     FileComplexitySnapshot,
     FileHotspotDaily,
     FileMetricsRecord,
@@ -27,10 +30,12 @@ from dev_health_ops.metrics.schemas import (
     InvestmentExplanationRecord,
     InvestmentMetricsRecord,
     IssueTypeMetricsRecord,
+    ReleaseImpactDailyRecord,
     RepoComplexityDaily,
     RepoMetricsDailyRecord,
     ReviewEdgeDailyRecord,
     TeamMetricsDailyRecord,
+    TelemetrySignalBucketRecord,
     WorkGraphEdgeRecord,
     WorkGraphIssuePRRecord,
     WorkGraphPRCommitRecord,
@@ -305,6 +310,35 @@ class BaseMetricsSink(ABC):
     @abstractmethod
     def write_issue_type_metrics(self, rows: Sequence[IssueTypeMetricsRecord]) -> None:
         """Write aggregated metrics by issue type."""
+        pass
+
+    @abstractmethod
+    def write_feature_flags(self, rows: Sequence[FeatureFlagRecord]) -> None:
+        """Write feature flag registry records."""
+        pass
+
+    @abstractmethod
+    def write_feature_flag_events(self, rows: Sequence[FeatureFlagEventRecord]) -> None:
+        """Write feature flag lifecycle event records."""
+        pass
+
+    @abstractmethod
+    def write_feature_flag_links(self, rows: Sequence[FeatureFlagLinkRecord]) -> None:
+        """Write feature flag linkage records."""
+        pass
+
+    @abstractmethod
+    def write_telemetry_signal_buckets(
+        self, rows: Sequence[TelemetrySignalBucketRecord]
+    ) -> None:
+        """Write aggregated telemetry signal bucket records."""
+        pass
+
+    @abstractmethod
+    def write_release_impact_daily(
+        self, rows: Sequence[ReleaseImpactDailyRecord]
+    ) -> None:
+        """Write daily release impact rollup records."""
         pass
 
     # -------------------------------------------------------------------------

--- a/src/dev_health_ops/metrics/sinks/clickhouse.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse.py
@@ -17,6 +17,9 @@ from dev_health_ops.metrics.schemas import (
     CommitMetricsRecord,
     DeployMetricsDailyRecord,
     DORAMetricsRecord,
+    FeatureFlagEventRecord,
+    FeatureFlagLinkRecord,
+    FeatureFlagRecord,
     FileComplexitySnapshot,
     FileHotspotDaily,
     FileMetricsRecord,
@@ -26,10 +29,12 @@ from dev_health_ops.metrics.schemas import (
     InvestmentExplanationRecord,
     InvestmentMetricsRecord,
     IssueTypeMetricsRecord,
+    ReleaseImpactDailyRecord,
     RepoComplexityDaily,
     RepoMetricsDailyRecord,
     ReviewEdgeDailyRecord,
     TeamMetricsDailyRecord,
+    TelemetrySignalBucketRecord,
     UserMetricsDailyRecord,
     WorkGraphEdgeRecord,
     WorkGraphIssuePRRecord,
@@ -1179,6 +1184,134 @@ class ClickHouseMetricsSink(BaseMetricsSink):
                 "lead_p50_hours",
                 "computed_at",
                 "org_id",
+            ],
+            rows,
+        )
+
+    def write_feature_flags(self, rows: Sequence[FeatureFlagRecord]) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "feature_flag",
+            [
+                "org_id",
+                "provider",
+                "flag_key",
+                "project_key",
+                "repo_id",
+                "environment",
+                "flag_type",
+                "created_at",
+                "archived_at",
+                "last_synced",
+            ],
+            rows,
+        )
+
+    def write_feature_flag_events(self, rows: Sequence[FeatureFlagEventRecord]) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "feature_flag_event",
+            [
+                "org_id",
+                "event_type",
+                "flag_key",
+                "environment",
+                "repo_id",
+                "actor_type",
+                "prev_state",
+                "next_state",
+                "event_ts",
+                "ingested_at",
+                "source_event_id",
+                "dedupe_key",
+            ],
+            rows,
+        )
+
+    def write_feature_flag_links(self, rows: Sequence[FeatureFlagLinkRecord]) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "feature_flag_link",
+            [
+                "org_id",
+                "flag_key",
+                "target_type",
+                "target_id",
+                "provider",
+                "link_source",
+                "link_type",
+                "evidence_type",
+                "confidence",
+                "valid_from",
+                "valid_to",
+                "last_synced",
+            ],
+            rows,
+        )
+
+    def write_telemetry_signal_buckets(
+        self, rows: Sequence[TelemetrySignalBucketRecord]
+    ) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "telemetry_signal_bucket",
+            [
+                "org_id",
+                "signal_type",
+                "signal_count",
+                "session_count",
+                "unique_pseudonymous_count",
+                "endpoint_group",
+                "environment",
+                "repo_id",
+                "release_ref",
+                "bucket_start",
+                "bucket_end",
+                "ingested_at",
+                "is_sampled",
+                "schema_version",
+                "dedupe_key",
+            ],
+            rows,
+        )
+
+    def write_release_impact_daily(
+        self, rows: Sequence[ReleaseImpactDailyRecord]
+    ) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "release_impact_daily",
+            [
+                "org_id",
+                "day",
+                "release_ref",
+                "environment",
+                "repo_id",
+                "release_user_friction_delta",
+                "release_post_friction_rate",
+                "release_error_rate_delta",
+                "release_post_error_rate",
+                "time_to_first_user_issue_after_release_hours",
+                "release_impact_confidence_score",
+                "coverage_ratio",
+                "flag_exposure_rate",
+                "flag_activation_rate",
+                "flag_reliability_guardrail",
+                "flag_friction_delta",
+                "flag_rollout_half_life_hours",
+                "flag_churn_rate",
+                "issue_to_release_impact_link_rate",
+                "rollback_or_disable_after_impact_spike_count",
+                "missing_required_fields_count",
+                "instrumentation_change_flag",
+                "data_completeness",
+                "concurrent_deploy_count",
+                "computed_at",
             ],
             rows,
         )

--- a/tests/test_ingest_api.py
+++ b/tests/test_ingest_api.py
@@ -4,7 +4,14 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
+import sys
+
 from dev_health_ops.api.main import app
+
+# Import the router module (not the APIRouter object exported by __init__)
+import dev_health_ops.api.ingest.router  # noqa: F401
+
+_router_mod = sys.modules["dev_health_ops.api.ingest.router"]
 
 
 @pytest_asyncio.fixture
@@ -52,6 +59,16 @@ VALID_INCIDENT = {
     "status": "resolved",
     "started_at": "2025-01-14T03:00:00Z",
     "resolved_at": "2025-01-14T05:30:00Z",
+}
+
+VALID_TELEMETRY_BUCKET = {
+    "signal_type": "friction.rage_click",
+    "signal_count": 42,
+    "session_count": 10,
+    "environment": "production",
+    "bucket_start": "2025-01-15T00:00:00Z",
+    "bucket_end": "2025-01-15T01:00:00Z",
+    "dedupe_key": "rage-click-prod-2025-01-15T00",
 }
 
 
@@ -261,3 +278,75 @@ async def test_ingest_deployments_missing_required_field(client):
         },
     )
     assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_ingest_telemetry_happy_path(client, monkeypatch):
+    persisted: list = []
+
+    async def fake_persist(records):
+        persisted.extend(records)
+
+    monkeypatch.setattr(_router_mod, "_persist_telemetry", fake_persist)
+
+    resp = await client.post(
+        "/api/v1/ingest/telemetry",
+        json={"org_id": "test-org", "items": [VALID_TELEMETRY_BUCKET]},
+    )
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["status"] == "accepted"
+    assert body["items_received"] == 1
+    assert body["stream"] == "ingest:test-org:telemetry"
+    assert "ingestion_id" in body
+    assert len(persisted) == 1
+    assert persisted[0].signal_type == "friction.rage_click"
+    assert persisted[0].org_id == "test-org"
+
+
+@pytest.mark.asyncio
+async def test_ingest_telemetry_empty_items(client):
+    resp = await client.post(
+        "/api/v1/ingest/telemetry",
+        json={"org_id": "test-org", "items": []},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_ingest_telemetry_missing_required_field(client):
+    bad_bucket = {
+        "signal_type": "error.unhandled",
+        "signal_count": 5,
+        "session_count": 2,
+        "environment": "staging",
+        "bucket_start": "2025-01-15T00:00:00Z",
+        "bucket_end": "2025-01-15T01:00:00Z",
+    }
+    resp = await client.post(
+        "/api/v1/ingest/telemetry",
+        json={"org_id": "test-org", "items": [bad_bucket]},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_ingest_telemetry_multiple_items(client, monkeypatch):
+    persisted: list = []
+
+    async def fake_persist(records):
+        persisted.extend(records)
+
+    monkeypatch.setattr(_router_mod, "_persist_telemetry", fake_persist)
+
+    buckets = [
+        {**VALID_TELEMETRY_BUCKET, "dedupe_key": f"key-{i}", "signal_count": i}
+        for i in range(3)
+    ]
+    resp = await client.post(
+        "/api/v1/ingest/telemetry",
+        json={"org_id": "acme", "items": buckets},
+    )
+    assert resp.status_code == 202
+    assert resp.json()["items_received"] == 3
+    assert len(persisted) == 3

--- a/tests/test_ingest_api.py
+++ b/tests/test_ingest_api.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
-import sys
-
-from dev_health_ops.api.main import app
-
 # Import the router module (not the APIRouter object exported by __init__)
 import dev_health_ops.api.ingest.router  # noqa: F401
+from dev_health_ops.api.main import app
 
 _router_mod = sys.modules["dev_health_ops.api.ingest.router"]
 


### PR DESCRIPTION
## Summary
- Adds 5 frozen record dataclasses to `metrics/schemas.py`: FeatureFlagRecord, FeatureFlagEventRecord, FeatureFlagLinkRecord, TelemetrySignalBucketRecord, ReleaseImpactDailyRecord
- Adds 5 abstract `write_*` methods to `BaseMetricsSink`
- Adds 5 concrete implementations in `ClickHouseMetricsSink` using `_insert_rows` pattern
- Existing org_id propagation tests pass (69 tests)

## Linear
Closes CHAOS-818 | Project: Feature Flag + User Impact Mapping (Phase 0)