### PR TITLE
feat: deployment release_ref enrichment and persistence (CHAOS-819)

### DIFF
--- a/src/dev_health_ops/api/ingest/persist.py
+++ b/src/dev_health_ops/api/ingest/persist.py
@@ -6,6 +6,7 @@ import logging
 import os
 import uuid
 
+from dev_health_ops.processors.release_ref import get_release_ref_enrichment
 from dev_health_ops.storage.clickhouse import ClickHouseStore
 
 logger = logging.getLogger(__name__)
@@ -101,6 +102,13 @@ async def _persist_deployments(store: ClickHouseStore, items: list[dict]) -> Non
         item.pop("_org_id", None)
         item.pop("_ingestion_id", None)
         item["repo_id"] = _repo_id_from_url(repo_url)
+        enrichment = get_release_ref_enrichment(item, "generic")
+        item["release_ref"] = item.get("release_ref") or enrichment.release_ref
+        item["release_ref_confidence"] = (
+            item.get("release_ref_confidence")
+            if item.get("release_ref_confidence") is not None
+            else enrichment.confidence
+        )
         rows.append(item)
     if rows:
         await store.insert_deployments(rows)

--- a/src/dev_health_ops/api/ingest/schemas.py
+++ b/src/dev_health_ops/api/ingest/schemas.py
@@ -87,6 +87,8 @@ class IngestDeployment(BaseModel):
     finished_at: datetime | None = None
     deployed_at: datetime | None = None
     pull_request_number: int | None = None
+    release_ref: str | None = None
+    release_ref_confidence: float | None = None
 
 
 class IngestIncident(BaseModel):

--- a/src/dev_health_ops/connectors/utils/rest.py
+++ b/src/dev_health_ops/connectors/utils/rest.py
@@ -343,6 +343,38 @@ class GitLabRESTClient(RESTClient):
         )
         return mrs
 
+    def get_deployments(
+        self,
+        project_id: int,
+        page: int = 1,
+        per_page: int = 100,
+        order_by: str | None = None,
+        sort: str | None = None,
+    ) -> list[dict[str, Any]]:
+        endpoint = f"projects/{project_id}/deployments"
+        params: dict[str, Any] = {
+            "page": page,
+            "per_page": per_page,
+        }
+        if order_by:
+            params["order_by"] = order_by
+        if sort:
+            params["sort"] = sort
+        return self.get_list(endpoint, params=params)
+
+    def get_releases(
+        self,
+        project_id: int,
+        page: int = 1,
+        per_page: int = 100,
+    ) -> list[dict[str, Any]]:
+        endpoint = f"projects/{project_id}/releases"
+        params: dict[str, Any] = {
+            "page": page,
+            "per_page": per_page,
+        }
+        return self.get_list(endpoint, params=params)
+
     def get_dora_metrics(
         self,
         project_id: int,

--- a/src/dev_health_ops/metrics/schemas.py
+++ b/src/dev_health_ops/metrics/schemas.py
@@ -75,6 +75,8 @@ class DeploymentRow(TypedDict):
     deployed_at: datetime | None
     merged_at: NotRequired[datetime | None]
     pull_request_number: NotRequired[int | None]
+    release_ref: NotRequired[str]
+    release_ref_confidence: NotRequired[float]
 
 
 class IncidentRow(TypedDict):

--- a/src/dev_health_ops/migrations/clickhouse/000_raw_tables.sql
+++ b/src/dev_health_ops/migrations/clickhouse/000_raw_tables.sql
@@ -115,6 +115,8 @@ CREATE TABLE IF NOT EXISTS deployments (
     deployed_at Nullable(DateTime64(3, 'UTC')),
     merged_at Nullable(DateTime64(3, 'UTC')),
     pull_request_number Nullable(UInt32),
+    release_ref String DEFAULT '',
+    release_ref_confidence Float64 DEFAULT 0.0,
     last_synced DateTime64(3, 'UTC')
 ) ENGINE = ReplacingMergeTree(last_synced)
 ORDER BY (repo_id, deployment_id);

--- a/src/dev_health_ops/migrations/clickhouse/028_add_release_ref_to_deployments.py
+++ b/src/dev_health_ops/migrations/clickhouse/028_add_release_ref_to_deployments.py
@@ -1,0 +1,28 @@
+"""Migration 028: add release_ref fields to deployments.
+
+Adds canonical release join fields so deployments can be linked to telemetry and
+release impact metrics. Idempotent on existing databases.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def upgrade(client):
+    log.info("Starting migration 028: add release_ref columns to deployments")
+    client.command(
+        """
+        ALTER TABLE deployments
+        ADD COLUMN IF NOT EXISTS release_ref String DEFAULT ''
+        """
+    )
+    client.command(
+        """
+        ALTER TABLE deployments
+        ADD COLUMN IF NOT EXISTS release_ref_confidence Float64 DEFAULT 0.0
+        """
+    )
+    log.info("Completed migration 028: release_ref columns available on deployments")

--- a/src/dev_health_ops/models/git.py
+++ b/src/dev_health_ops/models/git.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Boolean,
     Column,
     DateTime,
+    Float,
     ForeignKey,
     ForeignKeyConstraint,
     Integer,
@@ -668,6 +669,8 @@ class Deployment(Base):
     deployed_at = Column(DateTime(timezone=True))
     merged_at = Column(DateTime(timezone=True))
     pull_request_number = Column(Integer)
+    release_ref = Column(Text, nullable=False, default="")
+    release_ref_confidence = Column(Float, nullable=False, default=0.0)
     last_synced = Column(
         DateTime(timezone=True),
         nullable=False,

--- a/src/dev_health_ops/processors/__init__.py
+++ b/src/dev_health_ops/processors/__init__.py
@@ -1,3 +1,14 @@
+from .release_ref import (
+    ReleaseRefEnrichment,
+    enrich_release_ref,
+    get_release_ref_enrichment,
+)
 from .testops_pipeline import PipelineIngestionResult, TestOpsPipelineProcessor
 
-__all__ = ["PipelineIngestionResult", "TestOpsPipelineProcessor"]
+__all__ = [
+    "PipelineIngestionResult",
+    "ReleaseRefEnrichment",
+    "TestOpsPipelineProcessor",
+    "enrich_release_ref",
+    "get_release_ref_enrichment",
+]

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -16,6 +16,7 @@ from dev_health_ops.models.git import (
     Incident,
     Repo,
 )
+from dev_health_ops.processors.release_ref import get_release_ref_enrichment
 from dev_health_ops.processors.base_git import (
     BaseGitProcessor,
     backfill_file_records,
@@ -300,6 +301,12 @@ def _fetch_github_deployments_sync(gh_repo, repo_id, max_deployments, since):
     deployments = []
     if not hasattr(gh_repo, "get_deployments"):
         return deployments
+    release_objects = []
+    if hasattr(gh_repo, "get_releases"):
+        try:
+            release_objects = list(gh_repo.get_releases()[:max_deployments])
+        except Exception as exc:
+            logging.debug("Failed to fetch GitHub releases for release_ref: %s", exc)
     try:
         raw_deployments = list(gh_repo.get_deployments()[:max_deployments])
     except Exception as exc:
@@ -312,6 +319,11 @@ def _fetch_github_deployments_sync(gh_repo, repo_id, max_deployments, since):
             continue
         if since is not None and created_at.astimezone(timezone.utc) < since:
             continue
+        enrichment = get_release_ref_enrichment(
+            dep,
+            "github",
+            releases=release_objects,
+        )
         deployments.append(
             Deployment(
                 repo_id=repo_id,
@@ -323,6 +335,8 @@ def _fetch_github_deployments_sync(gh_repo, repo_id, max_deployments, since):
                 deployed_at=created_at,
                 merged_at=None,
                 pull_request_number=None,
+                release_ref=enrichment.release_ref,
+                release_ref_confidence=enrichment.confidence,
             )
         )
     return deployments

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -16,7 +16,6 @@ from dev_health_ops.models.git import (
     Incident,
     Repo,
 )
-from dev_health_ops.processors.release_ref import get_release_ref_enrichment
 from dev_health_ops.processors.base_git import (
     BaseGitProcessor,
     backfill_file_records,
@@ -30,6 +29,7 @@ from dev_health_ops.processors.fetch_utils import (
 from dev_health_ops.processors.fetch_utils import (
     safe_parse_datetime as _coerce_datetime,
 )
+from dev_health_ops.processors.release_ref import get_release_ref_enrichment
 from dev_health_ops.processors.storage_protocol import GitSyncStore
 from dev_health_ops.providers.pr_state import normalize_pr_state
 from dev_health_ops.utils import (

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -16,6 +16,7 @@ from dev_health_ops.models.git import (
     Incident,
     Repo,
 )
+from dev_health_ops.processors.release_ref import get_release_ref_enrichment
 from dev_health_ops.processors.base_git import (
     BaseGitProcessor,
     backfill_file_records,
@@ -406,6 +407,14 @@ def _fetch_gitlab_deployments_sync(
 ):
     """Sync helper to fetch GitLab deployments."""
     deployments = []
+    release_objects = []
+    try:
+        release_objects = connector.rest_client.get_releases(
+            project_id=project_id,
+            per_page=min(max_deployments, 100),
+        )
+    except Exception as exc:
+        logging.debug("Failed to fetch GitLab releases for release_ref: %s", exc)
     try:
         # Use REST API to fetch deployments
         raw_deployments = connector.rest_client.get_deployments(
@@ -436,6 +445,16 @@ def _fetch_gitlab_deployments_sync(
         if finished_at_str:
             finished_at = safe_parse_datetime(finished_at_str)
 
+        enrichment = get_release_ref_enrichment(
+            {
+                **dep,
+                "deployment_id": str(dep.get("id", "")),
+                "deployment_iid": dep.get("iid"),
+            },
+            "gitlab",
+            releases=release_objects,
+        )
+
         deployments.append(
             Deployment(
                 repo_id=repo_id,
@@ -449,6 +468,8 @@ def _fetch_gitlab_deployments_sync(
                 deployed_at=created_at,
                 merged_at=None,
                 pull_request_number=None,
+                release_ref=enrichment.release_ref,
+                release_ref_confidence=enrichment.confidence,
             )
         )
 

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -16,7 +16,6 @@ from dev_health_ops.models.git import (
     Incident,
     Repo,
 )
-from dev_health_ops.processors.release_ref import get_release_ref_enrichment
 from dev_health_ops.processors.base_git import (
     BaseGitProcessor,
     backfill_file_records,
@@ -26,6 +25,7 @@ from dev_health_ops.processors.fetch_utils import (
     AsyncBatchCollector,
     safe_parse_datetime,
 )
+from dev_health_ops.processors.release_ref import get_release_ref_enrichment
 from dev_health_ops.processors.storage_protocol import GitSyncStore
 from dev_health_ops.providers.pr_state import normalize_pr_state
 from dev_health_ops.utils import (

--- a/src/dev_health_ops/processors/release_ref.py
+++ b/src/dev_health_ops/processors/release_ref.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class ReleaseRefEnrichment:
+    release_ref: str
+    confidence: float
+    source: str
+
+
+def enrich_release_ref(
+    deployment: Any,
+    provider: str,
+    *,
+    releases: list[Any] | None = None,
+) -> str:
+    return get_release_ref_enrichment(
+        deployment,
+        provider,
+        releases=releases,
+    ).release_ref
+
+
+def get_release_ref_enrichment(
+    deployment: Any,
+    provider: str,
+    *,
+    releases: list[Any] | None = None,
+) -> ReleaseRefEnrichment:
+    normalized_provider = provider.lower().strip()
+    explicit_ref = _extract_explicit_release_ref(deployment)
+    if explicit_ref:
+        return ReleaseRefEnrichment(
+            release_ref=explicit_ref,
+            confidence=_extract_explicit_confidence(deployment),
+            source="explicit",
+        )
+
+    if normalized_provider == "github":
+        tag = _resolve_github_tag(deployment, releases or [])
+        if tag:
+            return ReleaseRefEnrichment(tag, 1.0, "github_release")
+        fallback = _string_value(deployment, "deployment_id") or _string_value(
+            deployment, "id"
+        )
+        return ReleaseRefEnrichment(fallback, 0.3, "deployment_id_fallback")
+
+    if normalized_provider == "gitlab":
+        tag = _resolve_gitlab_tag(deployment, releases or [])
+        if tag:
+            return ReleaseRefEnrichment(tag, 1.0, "gitlab_release")
+        fallback = (
+            _string_value(deployment, "deployment_iid")
+            or _string_value(deployment, "iid")
+            or _string_value(deployment, "deployment_id")
+            or _string_value(deployment, "id")
+        )
+        return ReleaseRefEnrichment(fallback, 0.3, "deployment_iid_fallback")
+
+    fallback = (
+        _string_value(deployment, "deployment_id")
+        or _string_value(deployment, "id")
+        or ""
+    )
+    return ReleaseRefEnrichment(fallback, 0.3, "generic_fallback")
+
+
+def _extract_explicit_release_ref(deployment: Any) -> str:
+    for key in (
+        "release_ref",
+        "release",
+        "release_tag",
+        "tag_name",
+        "tag",
+        "version",
+    ):
+        value = _string_value(deployment, key)
+        if value:
+            return value
+
+    payload = _mapping_value(deployment, "payload")
+    if payload:
+        for key in (
+            "release_ref",
+            "release",
+            "release_tag",
+            "tag_name",
+            "tag",
+            "version",
+        ):
+            value = _string_value(payload, key)
+            if value:
+                return value
+
+    return ""
+
+
+def _extract_explicit_confidence(deployment: Any) -> float:
+    confidence = _raw_value(deployment, "release_ref_confidence")
+    if confidence is None:
+        payload = _mapping_value(deployment, "payload")
+        confidence = _raw_value(payload, "release_ref_confidence")
+    try:
+        if confidence is not None:
+            return max(0.0, min(1.0, float(confidence)))
+    except (TypeError, ValueError):
+        pass
+    return 1.0
+
+
+def _resolve_github_tag(deployment: Any, releases: list[Any]) -> str:
+    candidates = {
+        _string_value(deployment, "ref"),
+        _string_value(deployment, "tag"),
+        _string_value(deployment, "tag_name"),
+    }
+    payload = _mapping_value(deployment, "payload")
+    candidates.update(
+        {
+            _string_value(payload, "ref"),
+            _string_value(payload, "tag"),
+            _string_value(payload, "tag_name"),
+            _string_value(payload, "release_tag"),
+        }
+    )
+    clean_candidates = {candidate for candidate in candidates if candidate}
+    if not clean_candidates:
+        return ""
+    for release in releases:
+        tag_name = _string_value(release, "tag_name")
+        if tag_name and tag_name in clean_candidates:
+            return tag_name
+    return ""
+
+
+def _resolve_gitlab_tag(deployment: Any, releases: list[Any]) -> str:
+    candidates = {
+        _string_value(deployment, "ref"),
+        _string_value(deployment, "tag"),
+        _string_value(deployment, "tag_name"),
+    }
+    clean_candidates = {candidate for candidate in candidates if candidate}
+    if not clean_candidates:
+        return ""
+    for release in releases:
+        tag_name = _string_value(release, "tag_name")
+        if tag_name and tag_name in clean_candidates:
+            return tag_name
+    return ""
+
+
+def _mapping_value(value: Any, key: str) -> Mapping[str, Any] | None:
+    raw = _raw_value(value, key)
+    return raw if isinstance(raw, Mapping) else None
+
+
+def _string_value(value: Any, key: str) -> str:
+    raw = _raw_value(value, key)
+    if raw is None:
+        return ""
+    text = str(raw).strip()
+    return text
+
+
+def _raw_value(value: Any, key: str) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return value.get(key)
+    if hasattr(value, key):
+        return getattr(value, key)
+    raw_data = getattr(value, "raw_data", None)
+    if isinstance(raw_data, Mapping):
+        return raw_data.get(key)
+    return None

--- a/src/dev_health_ops/processors/release_ref.py
+++ b/src/dev_health_ops/processors/release_ref.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 
 @dataclass(frozen=True)

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -915,6 +915,10 @@ class ClickHouseStore:
                         ),
                         "merged_at": self._normalize_datetime(item.get("merged_at")),
                         "pull_request_number": item.get("pull_request_number"),
+                        "release_ref": str(item.get("release_ref") or ""),
+                        "release_ref_confidence": float(
+                            item.get("release_ref_confidence") or 0.0
+                        ),
                         "last_synced": self._normalize_datetime(
                             item.get("last_synced") or synced_at_default
                         ),
@@ -942,6 +946,10 @@ class ClickHouseStore:
                         "pull_request_number": getattr(
                             item, "pull_request_number", None
                         ),
+                        "release_ref": str(getattr(item, "release_ref", "") or ""),
+                        "release_ref_confidence": float(
+                            getattr(item, "release_ref_confidence", 0.0) or 0.0
+                        ),
                         "last_synced": self._normalize_datetime(
                             getattr(item, "last_synced", None) or synced_at_default
                         ),
@@ -960,6 +968,8 @@ class ClickHouseStore:
                 "deployed_at",
                 "merged_at",
                 "pull_request_number",
+                "release_ref",
+                "release_ref_confidence",
                 "last_synced",
             ],
             rows,

--- a/src/dev_health_ops/storage/mixins/cicd.py
+++ b/src/dev_health_ops/storage/mixins/cicd.py
@@ -66,6 +66,8 @@ class CicdMixin:
                     "deployed_at": item.get("deployed_at"),
                     "merged_at": item.get("merged_at"),
                     "pull_request_number": item.get("pull_request_number"),
+                    "release_ref": item.get("release_ref", ""),
+                    "release_ref_confidence": item.get("release_ref_confidence", 0.0),
                     "last_synced": item.get("last_synced") or synced_at_default,
                 }
             else:
@@ -79,6 +81,10 @@ class CicdMixin:
                     "deployed_at": getattr(item, "deployed_at", None),
                     "merged_at": getattr(item, "merged_at", None),
                     "pull_request_number": getattr(item, "pull_request_number", None),
+                    "release_ref": getattr(item, "release_ref", ""),
+                    "release_ref_confidence": getattr(
+                        item, "release_ref_confidence", 0.0
+                    ),
                     "last_synced": getattr(item, "last_synced", None)
                     or synced_at_default,
                 }
@@ -96,6 +102,8 @@ class CicdMixin:
                 "deployed_at",
                 "merged_at",
                 "pull_request_number",
+                "release_ref",
+                "release_ref_confidence",
                 "last_synced",
             ],
         )

--- a/tests/test_ingest_persist.py
+++ b/tests/test_ingest_persist.py
@@ -166,6 +166,8 @@ class TestPersistDeployments:
         store.insert_deployments.assert_awaited_once()
         call_args = store.insert_deployments.call_args[0][0]
         assert "repo_id" in call_args[0]
+        assert call_args[0]["release_ref"] == "d-1"
+        assert call_args[0]["release_ref_confidence"] == pytest.approx(0.3)
 
 
 @pytest.mark.asyncio

--- a/tests/test_processors_gitlab.py
+++ b/tests/test_processors_gitlab.py
@@ -186,10 +186,13 @@ def test_fetch_gitlab_pipelines_sync():
 
 def test_fetch_gitlab_deployments_sync():
     mock_connector = Mock()
+    mock_connector.rest_client.get_releases.return_value = [{"tag_name": "v1.2.3"}]
     mock_connector.rest_client.get_deployments.return_value = [
         {
             "id": 101,
+            "iid": 12,
             "status": "success",
+            "ref": "v1.2.3",
             "environment": {"name": "production"},
             "created_at": "2023-01-02T00:00:00Z",
             "finished_at": "2023-01-02T00:10:00Z",
@@ -203,6 +206,8 @@ def test_fetch_gitlab_deployments_sync():
     assert len(deployments) == 1
     assert deployments[0].deployment_id == "101"
     assert deployments[0].environment == "production"
+    assert deployments[0].release_ref == "v1.2.3"
+    assert deployments[0].release_ref_confidence == pytest.approx(1.0)
     assert deployments[0].deployed_at == datetime(
         2023, 1, 2, 0, 0, 0, tzinfo=timezone.utc
     )

--- a/tests/test_release_ref.py
+++ b/tests/test_release_ref.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from importlib import import_module
+from types import SimpleNamespace
+
+import pytest
+
+get_release_ref_enrichment = import_module(
+    "dev_health_ops.processors.release_ref"
+).get_release_ref_enrichment
+
+
+def test_github_release_ref_prefers_release_tag() -> None:
+    deployment = SimpleNamespace(id=101, ref="v2.0.0", payload={})
+
+    enrichment = get_release_ref_enrichment(
+        deployment,
+        "github",
+        releases=[SimpleNamespace(tag_name="v2.0.0")],
+    )
+
+    assert enrichment.release_ref == "v2.0.0"
+    assert enrichment.confidence == pytest.approx(1.0)
+
+
+def test_github_release_ref_falls_back_to_deployment_id() -> None:
+    deployment = {"deployment_id": "gh-deploy-1"}
+
+    enrichment = get_release_ref_enrichment(deployment, "github")
+
+    assert enrichment.release_ref == "gh-deploy-1"
+    assert enrichment.confidence == pytest.approx(0.3)
+
+
+def test_gitlab_release_ref_falls_back_to_deployment_iid() -> None:
+    deployment = {"id": 901, "iid": 42}
+
+    enrichment = get_release_ref_enrichment(deployment, "gitlab")
+
+    assert enrichment.release_ref == "42"
+    assert enrichment.confidence == pytest.approx(0.3)
+
+
+def test_generic_release_ref_uses_explicit_value_when_present() -> None:
+    deployment = {"deployment_id": "generic-1", "release_ref": "2026.04.14"}
+
+    enrichment = get_release_ref_enrichment(deployment, "generic")
+
+    assert enrichment.release_ref == "2026.04.14"
+    assert enrichment.confidence == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- Adds `processors/release_ref.py` with enrichment helpers for GitHub (tag), GitLab (tag/iid), and generic (deployment_id fallback)
- Confidence semantics: 1.0 native tag, 0.3 heuristic fallback
- Migration 028: adds `release_ref` + `release_ref_confidence` columns to deployments table
- Wires enrichment into GitHub and GitLab processors and generic ingest persist
- Updates storage mixins and ClickHouse sink for new deployment fields
- Adds `get_releases` to GitLab REST client
- Tests pass: test_release_ref, test_processors_gitlab, test_ingest_persist, test_migrations_clickhouse

## Linear
Closes CHAOS-819 | Project: Feature Flag + User Impact Mapping (Phase 0)