### PR TITLE
feat: add launchdarkly and telemetry sync config providers (CHAOS-821)

### DIFF
--- a/src/dev_health_ops/credentials/__init__.py
+++ b/src/dev_health_ops/credentials/__init__.py
@@ -29,8 +29,10 @@ from dev_health_ops.credentials.types import (
     GitHubCredentials,
     GitLabCredentials,
     JiraCredentials,
+    LaunchDarklyCredentials,
     LinearCredentials,
     ProviderCredentials,
+    TelemetryCredentials,
 )
 
 __all__ = [
@@ -41,7 +43,9 @@ __all__ = [
     "GitHubCredentials",
     "GitLabCredentials",
     "JiraCredentials",
+    "LaunchDarklyCredentials",
     "LinearCredentials",
     "ProviderCredentials",
+    "TelemetryCredentials",
     "resolve_credentials_sync",
 ]

--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -13,8 +13,10 @@ from dev_health_ops.credentials.types import (
     GitHubCredentials,
     GitLabCredentials,
     JiraCredentials,
+    LaunchDarklyCredentials,
     LinearCredentials,
     ProviderCredentials,
+    TelemetryCredentials,
 )
 
 logger = logging.getLogger(__name__)
@@ -35,6 +37,8 @@ PROVIDER_ENV_VARS: dict[str, dict[str, str]] = {
         "email": "ATLASSIAN_EMAIL",
         "cloud_id": "ATLASSIAN_CLOUD_ID",
     },
+    "launchdarkly": {"api_key": "LAUNCHDARKLY_API_KEY"},
+    "telemetry": {"api_key": "TELEMETRY_API_KEY"},
 }
 
 PROVIDER_CREDENTIAL_TYPES: dict[str, type[ProviderCredentials]] = {
@@ -43,6 +47,8 @@ PROVIDER_CREDENTIAL_TYPES: dict[str, type[ProviderCredentials]] = {
     "jira": JiraCredentials,
     "linear": LinearCredentials,
     "atlassian": AtlassianCredentials,
+    "launchdarkly": LaunchDarklyCredentials,
+    "telemetry": TelemetryCredentials,
 }
 
 

--- a/src/dev_health_ops/credentials/types.py
+++ b/src/dev_health_ops/credentials/types.py
@@ -138,3 +138,36 @@ class AtlassianCredentials(ProviderCredentials):
             raise ValueError("Atlassian credentials require 'api_token'")
         if not self.email:
             raise ValueError("Atlassian credentials require 'email'")
+
+
+@dataclass
+class LaunchDarklyCredentials(ProviderCredentials):
+    """LaunchDarkly provider credentials.
+
+    Supports API key authentication with optional project/environment scoping.
+    """
+
+    provider: str = "launchdarkly"
+    api_key: str = ""
+    project_key: str | None = None
+    environment: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.api_key:
+            raise ValueError("LaunchDarkly credentials require 'api_key'")
+
+
+@dataclass
+class TelemetryCredentials(ProviderCredentials):
+    """Telemetry provider credentials.
+
+    Supports API key authentication with optional schema version.
+    """
+
+    provider: str = "telemetry"
+    api_key: str = ""
+    schema_version: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.api_key:
+            raise ValueError("Telemetry credentials require 'api_key'")

--- a/src/dev_health_ops/providers/registry.py
+++ b/src/dev_health_ops/providers/registry.py
@@ -108,5 +108,18 @@ def _register_builtins() -> None:
 
     register_provider("linear", _linear_factory)
 
+    # Stub providers — connectors not yet implemented
+    def _launchdarkly_factory() -> Provider:
+        raise NotImplementedError(
+            "LaunchDarkly connector not yet implemented (CHAOS-822)"
+        )
+
+    register_provider("launchdarkly", _launchdarkly_factory)
+
+    def _telemetry_factory() -> Provider:
+        raise NotImplementedError("Telemetry connector not yet implemented (CHAOS-823)")
+
+    register_provider("telemetry", _telemetry_factory)
+
 
 _register_builtins()

--- a/tests/test_ff_credentials.py
+++ b/tests/test_ff_credentials.py
@@ -1,0 +1,51 @@
+"""Tests for feature flag provider credential types and registry."""
+
+from dev_health_ops.credentials import LaunchDarklyCredentials, TelemetryCredentials
+from dev_health_ops.credentials.resolver import (
+    PROVIDER_CREDENTIAL_TYPES,
+    PROVIDER_ENV_VARS,
+)
+from dev_health_ops.providers.registry import PROVIDER_REGISTRY
+
+
+def test_launchdarkly_credentials_fields():
+    creds = LaunchDarklyCredentials(api_key="test-key")
+    assert creds.api_key == "test-key"
+    assert creds.project_key is None
+    assert creds.environment is None
+
+
+def test_launchdarkly_credentials_with_optionals():
+    creds = LaunchDarklyCredentials(
+        api_key="test-key", project_key="my-project", environment="production"
+    )
+    assert creds.project_key == "my-project"
+    assert creds.environment == "production"
+
+
+def test_telemetry_credentials_fields():
+    creds = TelemetryCredentials(api_key="test-key")
+    assert creds.api_key == "test-key"
+    assert creds.schema_version == "1.0"
+
+
+def test_telemetry_credentials_custom_version():
+    creds = TelemetryCredentials(api_key="test-key", schema_version="2.0")
+    assert creds.schema_version == "2.0"
+
+
+def test_providers_registered_in_env_vars():
+    assert "launchdarkly" in PROVIDER_ENV_VARS
+    assert "telemetry" in PROVIDER_ENV_VARS
+
+
+def test_providers_registered_in_credential_types():
+    assert "launchdarkly" in PROVIDER_CREDENTIAL_TYPES
+    assert PROVIDER_CREDENTIAL_TYPES["launchdarkly"] is LaunchDarklyCredentials
+    assert "telemetry" in PROVIDER_CREDENTIAL_TYPES
+    assert PROVIDER_CREDENTIAL_TYPES["telemetry"] is TelemetryCredentials
+
+
+def test_providers_registered_in_registry():
+    assert "launchdarkly" in PROVIDER_REGISTRY
+    assert "telemetry" in PROVIDER_REGISTRY


### PR DESCRIPTION
## Summary
- Adds `LaunchDarklyCredentials` and `TelemetryCredentials` dataclasses for sync config
- Registers both providers in credential resolver (env var mappings, credential types)
- Adds stub provider factories in registry (raise NotImplementedError referencing CHAOS-822/823)

## Linear
Closes CHAOS-821 | Project: Feature Flag + User Impact Mapping (Phase 1)