### PR TITLE
feat: Feature Flag + User Impact — Phase 2 + Phase 3

### DIFF
--- a/docs/user-guide/feature-flag-impact.md
+++ b/docs/user-guide/feature-flag-impact.md
@@ -1,0 +1,109 @@
+# Release and Feature Flag Impact
+
+This guide explains how to interpret metrics that link engineering releases and feature flag rollouts to user experience signals.
+
+## Overview
+
+Release impact metrics measure shifts in user friction, errors, and adoption following a deployment or flag change. These signals help teams understand the immediate effect of their work on the system and its users.
+
+### Limitations
+
+These metrics are observational. They show correlations between releases and telemetry shifts within specific time windows. Our system doesn't provide causal proof. External factors like seasonality, marketing campaigns, or concurrent infrastructure changes can influence these numbers.
+
+## Metric Catalog
+
+### Release Metrics
+
+#### User Friction Delta
+- **Measurement**: The percentage change in friction signals per session compared to a 7 day baseline.
+- **Interpretation**: A positive delta suggests increased user struggle. A negative delta suggests a smoother experience.
+- **Confidence**: Requires at least 300 sessions in both baseline and post windows.
+- **Example**: "The friction rate appears elevated after this release."
+
+#### Error Rate Delta
+- **Measurement**: The change in error signals per session relative to the baseline.
+- **Interpretation**: Significant increases often point to regressions or unhandled edge cases in the new code.
+- **Confidence**: Requires 1000 events across both windows for statistical relevance.
+- **Example**: "The error rate suggests a potential regression in the checkout flow."
+
+#### Time to First User Issue
+- **Measurement**: The hours between deployment and the first linked user reported issue.
+- **Interpretation**: Shorter times indicate immediate visibility of defects.
+- **Confidence**: Only counts issues explicitly linked to the release in the work graph.
+- **Example**: "The first user issue appeared within two hours of deployment."
+
+### Feature Flag Metrics
+
+#### Exposure Rate
+- **Measurement**: The ratio of sessions that encountered the flag versus all eligible sessions.
+- **Interpretation**: This verifies that the rollout rules are reaching the intended audience.
+- **Example**: "Flag exposure appears consistent with the 10% rollout target."
+
+#### Activation Rate
+- **Measurement**: The ratio of exposed sessions that performed a defined success action.
+- **Interpretation**: It measures the effectiveness of the feature in driving desired user behavior.
+- **Example**: "The activation rate leans positive for the new search interface."
+
+#### Reliability Guardrail
+- **Measurement**: The ratio of error free sessions in the exposed cohort.
+- **Interpretation**: This safety check ensures the flag isn't introducing silent failures.
+- **Example**: "The reliability guardrail suggests the rollout is stable."
+
+## Confidence and Data Quality
+
+We use coverage and sample size to determine how much weight to give a metric.
+
+### Visibility Gates
+
+| Coverage | Status | Action |
+|----------|--------|--------|
+| >= 70% | Show | Metric is displayed normally. |
+| 50% to 69% | Warn | Metric is shown with a warning icon. |
+| < 50% | Suppress | Metric is hidden due to insufficient data. |
+
+### Data Completeness
+
+A `data_completeness` score below 0.80 means some telemetry is still arriving. Mobile clients or batch exports often cause these delays. Treat these numbers as preliminary until the score rises.
+
+### Concurrent Deploys
+
+When multiple releases happen in the same environment window, attribution becomes uncertain. The system flags these periods to prevent misattributing a spike to the wrong change.
+
+### Contamination
+
+If a session encounters multiple active flags, it's marked as contaminated. We exclude these sessions from impact deltas by default to keep the signal clean.
+
+## Language Policy
+
+To prevent over-interpretation, we use specific language when discussing impact.
+
+### Approved Terms
+- "appears"
+- "suggests"
+- "leans"
+- "is consistent with"
+
+### Forbidden Terms
+- "caused"
+- "proved"
+- "determined"
+- "is" / "was" (when stating impact)
+- "detected"
+
+### Examples
+- **Correct**: "The friction rate appears elevated after this release."
+- **Incorrect**: "This release caused increased friction."
+
+## Common Scenarios
+
+### High Impact, Low Confidence
+"Data suggests a significant impact, but the sample size is small. Wait for more sessions before taking action."
+
+### Low Impact, High Confidence
+"The release appears clean. Telemetry shows no significant shift in friction or error rates across a large sample."
+
+### Multiple Concurrent Deploys
+"Attribution is uncertain due to three concurrent releases in this window. Check individual service logs for better resolution."
+
+### Missing Telemetry
+"Metric suppressed due to insufficient coverage. Instrumentation may be missing or failing for this surface."

--- a/src/dev_health_ops/api/graphql/models/inputs.py
+++ b/src/dev_health_ops/api/graphql/models/inputs.py
@@ -222,6 +222,8 @@ class WorkGraphNodeTypeInput(Enum):
     PR = "pr"
     COMMIT = "commit"
     FILE = "file"
+    RELEASE = "release"
+    FEATURE_FLAG = "feature_flag"
 
 
 @strawberry.enum
@@ -241,6 +243,10 @@ class WorkGraphEdgeTypeInput(Enum):
     FIXES = "fixes"
     CONTAINS = "contains"
     TOUCHES = "touches"
+    INTRODUCED_BY = "introduced_by"
+    CONFIG_CHANGED_BY = "config_changed_by"
+    GUARDS = "guards"
+    IMPACTS = "impacts"
 
 
 @strawberry.input

--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -303,6 +303,8 @@ class WorkGraphNodeType(Enum):
     PR = "pr"
     COMMIT = "commit"
     FILE = "file"
+    RELEASE = "release"
+    FEATURE_FLAG = "feature_flag"
 
 
 @strawberry.enum
@@ -329,6 +331,16 @@ class WorkGraphEdgeType(Enum):
 
     # Commit-to-file relationships
     TOUCHES = "touches"
+
+    # Release relationships
+    INTRODUCED_BY = "introduced_by"
+
+    # Feature flag relationships
+    CONFIG_CHANGED_BY = "config_changed_by"
+    GUARDS = "guards"
+
+    # Cross-cutting impact relationships
+    IMPACTS = "impacts"
 
 
 @strawberry.enum

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -22,6 +22,7 @@ from dev_health_ops.metrics import (
     job_complexity_db,
     job_daily,
     job_dora,
+    job_release_impact,
     job_work_items,
 )
 
@@ -170,6 +171,7 @@ def build_parser() -> argparse.ArgumentParser:
     job_complexity_db.register_commands(metrics_subparsers)
     job_dora.register_commands(metrics_subparsers)
     job_capacity.register_commands(metrics_subparsers)
+    job_release_impact.register_commands(metrics_subparsers)
 
     # ---- audit ----
     audit_parser = sub.add_parser("audit", help="Run diagnostic audits.")

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -22,6 +22,7 @@ from dev_health_ops.metrics import (
     job_complexity_db,
     job_daily,
     job_dora,
+    job_ff_validation,
     job_release_impact,
     job_work_items,
 )
@@ -172,6 +173,7 @@ def build_parser() -> argparse.ArgumentParser:
     job_dora.register_commands(metrics_subparsers)
     job_capacity.register_commands(metrics_subparsers)
     job_release_impact.register_commands(metrics_subparsers)
+    job_ff_validation.register_commands(metrics_subparsers)
 
     # ---- audit ----
     audit_parser = sub.add_parser("audit", help="Run diagnostic audits.")

--- a/src/dev_health_ops/metrics/confidence.py
+++ b/src/dev_health_ops/metrics/confidence.py
@@ -1,0 +1,196 @@
+"""Confidence scoring for release impact and feature flag link attribution.
+
+Computes confidence scores that reflect how trustworthy a derived metric is,
+based on provenance quality, telemetry coverage, sample size, and the
+presence of confounders (concurrent deploys / flags).
+
+Confidence bands (PRD lines 182-185):
+    1.0       — native provenance (tag-based release_ref, explicit flag link)
+    0.8-0.9   — explicit_text provenance (text-matched flag refs in PR/commit)
+    0.3       — heuristic provenance (deployment_id fallback, timing correlation)
+
+Display gates (PRD lines 296-299):
+    show      — coverage >= 0.70 and min sample met
+    warn      — coverage >= 0.50 and min sample met
+    suppress  — coverage < 0.50 or min sample not met
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Literal
+
+
+class Provenance(str, Enum):
+    """How a release_ref or flag link was established."""
+
+    native = "native"
+    explicit_text = "explicit_text"
+    heuristic = "heuristic"
+
+
+#: Base confidence for each provenance tier (PRD lines 182-185).
+PROVENANCE_CONFIDENCE: dict[Provenance, float] = {
+    Provenance.native: 1.0,
+    Provenance.explicit_text: 0.85,
+    Provenance.heuristic: 0.3,
+}
+
+#: Minimum telemetry coverage before results are considered meaningful.
+COVERAGE_WARN_THRESHOLD = 0.70
+COVERAGE_SUPPRESS_THRESHOLD = 0.50
+
+#: Default minimum session count for statistical significance (PRD minimum).
+DEFAULT_MIN_SAMPLE = 30
+
+DisplayGate = Literal["show", "warn", "suppress"]
+
+
+def provenance_base_confidence(provenance: Provenance | str) -> float:
+    """Return the base confidence for a provenance tier.
+
+    Accepts either a :class:`Provenance` enum member or a raw string.
+    Unknown provenance values fall back to the heuristic band.
+    """
+    if isinstance(provenance, str):
+        try:
+            provenance = Provenance(provenance)
+        except ValueError:
+            return PROVENANCE_CONFIDENCE[Provenance.heuristic]
+    return PROVENANCE_CONFIDENCE.get(
+        provenance, PROVENANCE_CONFIDENCE[Provenance.heuristic]
+    )
+
+
+def compute_impact_confidence(
+    coverage_ratio: float,
+    sample_size: int,
+    concurrent_deploy_count: int,
+    release_ref_confidence: float,
+    min_sample: int = DEFAULT_MIN_SAMPLE,
+) -> float:
+    """Compute confidence score for a release impact measurement.
+
+    The score starts from the ``release_ref_confidence`` base (reflecting how
+    the release reference was established) and is attenuated by:
+
+    * **Coverage ratio** — fraction of releases with telemetry.  Values below
+      0.70 incur a significant penalty.
+    * **Sample size** — ``min(1.0, sample_size / min_sample)`` ensures small
+      windows are penalised.
+    * **Concurrent deploys** — each additional concurrent deployment dilutes
+      attribution via ``1.0 / (1 + concurrent_deploy_count)``.
+
+    Returns a float in ``[0.0, 1.0]``.
+    """
+    base = _clamp(release_ref_confidence)
+
+    # Coverage factor: linear scaling with extra penalty below threshold.
+    cov = _clamp(coverage_ratio)
+    if cov < COVERAGE_WARN_THRESHOLD:
+        # Below 0.70 coverage the penalty is steeper — square the ratio
+        # so that e.g. 0.50 coverage yields 0.25 factor instead of 0.50.
+        coverage_factor = cov * cov
+    else:
+        coverage_factor = cov
+
+    # Sample size factor: ramp linearly up to min_sample.
+    effective_min = max(1, min_sample)
+    sample_factor = _clamp(sample_size / effective_min)
+
+    # Confounder penalty: each concurrent deploy halves attribution certainty.
+    if concurrent_deploy_count > 0:
+        confounder_factor = 1.0 / (1 + concurrent_deploy_count)
+    else:
+        confounder_factor = 1.0
+
+    score = base * coverage_factor * sample_factor * confounder_factor
+    return _clamp(score)
+
+
+def compute_cohort_contamination(
+    flag_key: str,
+    environment: str,
+    window_start: datetime,
+    window_end: datetime,
+    concurrent_flags: list[str],
+) -> float:
+    """Return contamination ratio (0.0-1.0) for a flag evaluation window.
+
+    Contamination estimates the fraction of sessions that were exposed to
+    *multiple* flags simultaneously, making it harder to attribute impact to
+    a single flag.
+
+    When no concurrent flags exist the contamination is 0.0.  Otherwise the
+    estimate grows with the number of concurrent flags, approaching 1.0
+    asymptotically.  The formula ``1 - 1 / (1 + len(concurrent_flags))``
+    models the intuition that each additional flag increases overlap
+    probability.
+
+    Parameters
+    ----------
+    flag_key:
+        The flag under evaluation (excluded from concurrent list if present).
+    environment:
+        Deployment environment (used for future per-env estimation).
+    window_start, window_end:
+        Evaluation window boundaries.
+    concurrent_flags:
+        Other flags active in the same environment during the window.
+    """
+    others = [f for f in concurrent_flags if f != flag_key]
+    if not others:
+        return 0.0
+
+    # Asymptotic contamination: 1 flag → 0.50, 2 → 0.67, 3 → 0.75, …
+    return 1.0 - 1.0 / (1 + len(others))
+
+
+def classify_display_gate(coverage: float, min_sample_met: bool) -> DisplayGate:
+    """Return ``'show'``, ``'warn'``, or ``'suppress'`` based on data quality.
+
+    PRD lines 296-299:
+    * ``suppress`` — coverage < 0.50 **or** minimum sample not met
+    * ``warn``     — coverage in [0.50, 0.70)
+    * ``show``     — coverage >= 0.70 and sample requirement satisfied
+    """
+    if coverage < COVERAGE_SUPPRESS_THRESHOLD or not min_sample_met:
+        return "suppress"
+    if coverage < COVERAGE_WARN_THRESHOLD:
+        return "warn"
+    return "show"
+
+
+def compute_link_attribution_confidence(
+    provenance: Provenance | str,
+    text_match_count: int = 0,
+) -> float:
+    """Confidence for a flag-to-work-item link.
+
+    * Native links (provider-explicit) get 1.0.
+    * Text-matched links scale within the explicit_text band (0.8-0.9)
+      based on how many independent text matches were found.
+    * Heuristic links (timing correlation only) get 0.3.
+    """
+    if isinstance(provenance, str):
+        try:
+            provenance = Provenance(provenance)
+        except ValueError:
+            return PROVENANCE_CONFIDENCE[Provenance.heuristic]
+
+    if provenance == Provenance.native:
+        return 1.0
+
+    if provenance == Provenance.explicit_text:
+        # Scale within [0.8, 0.9] — each additional match adds confidence.
+        # 1 match → 0.80, 2 → 0.85, 3+ → 0.90
+        bonus = min(text_match_count, 3) / 30.0  # 0.0, ~0.033, ~0.067, 0.10
+        return _clamp(0.80 + bonus, 0.80, 0.90)
+
+    return PROVENANCE_CONFIDENCE[Provenance.heuristic]
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    """Clamp *value* between *lo* and *hi*."""
+    return max(lo, min(hi, value))

--- a/src/dev_health_ops/metrics/ff_validation.py
+++ b/src/dev_health_ops/metrics/ff_validation.py
@@ -1,0 +1,574 @@
+"""Feature flag pipeline validation checks.
+
+Runs diagnostic queries against ClickHouse to verify the health of the
+feature-flag + user-impact pipeline.  Each check returns a
+:class:`CheckResult` with a status, a human-readable message, and optional
+detail rows.
+
+Validation checks (PRD Phase 3 — internal validation views):
+
+1. **Coverage** — % of releases with ``telemetry_signal_bucket`` data.
+2. **Dedup verification** — ``COUNT`` vs ``COUNT DISTINCT`` on ``dedupe_key``
+   for all event tables.
+3. **Schema completeness** — % of ``feature_flag`` records with all required
+   fields populated.
+4. **Drift detection** — compare signal volume between consecutive days; flag
+   if > 2× change.
+5. **Org isolation** — verify no cross-org data leakage (spot check).
+6. **Join integrity** — % of ``release_impact_daily`` rows that join back to
+   ``deployments``.
+7. **Confidence distribution** — histogram of confidence scores to spot
+   anomalies.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+class CheckStatus(str, Enum):
+    """Outcome of a single validation check."""
+
+    ok = "ok"
+    warn = "warn"
+    critical = "critical"
+    skip = "skip"
+
+
+@dataclass
+class CheckResult:
+    """Result of a single validation check."""
+
+    name: str
+    status: CheckStatus
+    message: str
+    detail: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class ValidationReport:
+    """Aggregated report from all validation checks."""
+
+    org_id: str
+    checks: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def has_critical(self) -> bool:
+        return any(c.status == CheckStatus.critical for c in self.checks)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(c.status == CheckStatus.warn for c in self.checks)
+
+    def summary_line(self) -> str:
+        counts = {s: 0 for s in CheckStatus}
+        for c in self.checks:
+            counts[c.status] += 1
+        parts = [f"{counts[s]} {s.value}" for s in CheckStatus if counts[s]]
+        return f"Validation report for org={self.org_id!r}: {', '.join(parts)}"
+
+
+# ---------------------------------------------------------------------------
+# Query helper (matches release_impact.py pattern)
+# ---------------------------------------------------------------------------
+
+
+def _query_dicts(
+    client: Any,
+    query: str,
+    parameters: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Execute a ClickHouse query and return results as list of dicts."""
+    result = client.query(query, parameters=parameters or {})
+    col_names = list(getattr(result, "column_names", []) or [])
+    rows = list(getattr(result, "result_rows", []) or [])
+    if not col_names or not rows:
+        return []
+    return [dict(zip(col_names, row)) for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+
+def check_coverage(client: Any, org_id: str, lookback_days: int = 30) -> CheckResult:
+    """Check 1: % of releases with telemetry_signal_bucket data."""
+    query = """
+        WITH releases AS (
+            SELECT DISTINCT release_ref
+            FROM deployments
+            WHERE release_ref != ''
+              AND org_id = {org_id:String}
+              AND toDate(coalesce(deployed_at, started_at))
+                  >= today() - {lookback:UInt32}
+        ),
+        covered AS (
+            SELECT DISTINCT release_ref
+            FROM telemetry_signal_bucket
+            WHERE release_ref != ''
+              AND org_id = {org_id:String}
+              AND toDate(bucket_start) >= today() - {lookback:UInt32}
+        )
+        SELECT
+            count() AS total_releases,
+            countIf(c.release_ref != '') AS covered_releases
+        FROM releases AS r
+        LEFT JOIN covered AS c ON r.release_ref = c.release_ref
+    """
+    rows = _query_dicts(
+        client,
+        query,
+        {"org_id": org_id, "lookback": lookback_days},
+    )
+    if not rows or rows[0]["total_releases"] == 0:
+        return CheckResult(
+            name="coverage",
+            status=CheckStatus.skip,
+            message="No releases found in lookback window.",
+        )
+
+    total = int(rows[0]["total_releases"])
+    covered = int(rows[0]["covered_releases"])
+    ratio = covered / total
+
+    if ratio < 0.50:
+        status = CheckStatus.critical
+    elif ratio < 0.70:
+        status = CheckStatus.warn
+    else:
+        status = CheckStatus.ok
+
+    return CheckResult(
+        name="coverage",
+        status=status,
+        message=f"{covered}/{total} releases have telemetry ({ratio:.0%}).",
+        detail=[{"total_releases": total, "covered_releases": covered, "ratio": ratio}],
+    )
+
+
+_DEDUP_TABLES = [
+    ("feature_flag_event", "dedupe_key"),
+    ("telemetry_signal_bucket", "dedupe_key"),
+]
+
+
+def check_dedup(client: Any, org_id: str) -> CheckResult:
+    """Check 2: COUNT vs COUNT DISTINCT on dedupe_key for event tables."""
+    issues: list[dict[str, Any]] = []
+    for table, key_col in _DEDUP_TABLES:
+        query = f"""
+            SELECT
+                count() AS total,
+                count(DISTINCT {key_col}) AS distinct_keys
+            FROM {table}
+            WHERE org_id = {{org_id:String}}
+        """
+        rows = _query_dicts(client, query, {"org_id": org_id})
+        if not rows:
+            continue
+        total = int(rows[0]["total"])
+        distinct = int(rows[0]["distinct_keys"])
+        dup_count = total - distinct
+        if dup_count > 0:
+            issues.append(
+                {
+                    "table": table,
+                    "total_rows": total,
+                    "distinct_keys": distinct,
+                    "duplicates": dup_count,
+                    "dup_ratio": dup_count / total if total else 0.0,
+                }
+            )
+
+    if not issues:
+        return CheckResult(
+            name="dedup_verification",
+            status=CheckStatus.ok,
+            message="No duplicate dedupe_keys found in event tables.",
+        )
+
+    worst_ratio = max(i["dup_ratio"] for i in issues)
+    status = CheckStatus.critical if worst_ratio > 0.05 else CheckStatus.warn
+    tables = ", ".join(i["table"] for i in issues)
+    return CheckResult(
+        name="dedup_verification",
+        status=status,
+        message=f"Duplicate dedupe_keys in: {tables} (worst ratio: {worst_ratio:.2%}).",
+        detail=issues,
+    )
+
+
+_REQUIRED_FLAG_FIELDS = [
+    "provider",
+    "flag_key",
+    "environment",
+    "flag_type",
+    "last_synced",
+]
+
+
+def check_schema_completeness(client: Any, org_id: str) -> CheckResult:
+    """Check 3: % of feature_flag records with all required fields populated."""
+    conditions = " AND ".join(
+        f"{f} != '' AND {f} IS NOT NULL" for f in _REQUIRED_FLAG_FIELDS
+    )
+    query = f"""
+        SELECT
+            count() AS total,
+            countIf({conditions}) AS complete
+        FROM feature_flag FINAL
+        WHERE org_id = {{org_id:String}}
+    """
+    rows = _query_dicts(client, query, {"org_id": org_id})
+    if not rows or rows[0]["total"] == 0:
+        return CheckResult(
+            name="schema_completeness",
+            status=CheckStatus.skip,
+            message="No feature_flag records found.",
+        )
+
+    total = int(rows[0]["total"])
+    complete = int(rows[0]["complete"])
+    ratio = complete / total
+
+    if ratio < 0.80:
+        status = CheckStatus.critical
+    elif ratio < 0.95:
+        status = CheckStatus.warn
+    else:
+        status = CheckStatus.ok
+
+    return CheckResult(
+        name="schema_completeness",
+        status=status,
+        message=f"{complete}/{total} flags have all required fields ({ratio:.0%}).",
+        detail=[{"total": total, "complete": complete, "ratio": ratio}],
+    )
+
+
+def check_drift(
+    client: Any,
+    org_id: str,
+    lookback_days: int = 14,
+) -> CheckResult:
+    """Check 4: Flag >2× day-over-day signal volume change."""
+    query = """
+        SELECT
+            toDate(bucket_start) AS day,
+            count() AS bucket_count
+        FROM telemetry_signal_bucket
+        WHERE org_id = {org_id:String}
+          AND toDate(bucket_start) >= today() - {lookback:UInt32}
+        GROUP BY day
+        ORDER BY day
+    """
+    rows = _query_dicts(
+        client,
+        query,
+        {"org_id": org_id, "lookback": lookback_days},
+    )
+    if len(rows) < 2:
+        return CheckResult(
+            name="drift_detection",
+            status=CheckStatus.skip,
+            message="Not enough daily data for drift detection.",
+        )
+
+    spikes: list[dict[str, Any]] = []
+    for i in range(1, len(rows)):
+        prev_count = int(rows[i - 1]["bucket_count"])
+        curr_count = int(rows[i]["bucket_count"])
+        if prev_count == 0:
+            continue
+        ratio = curr_count / prev_count
+        if ratio > 2.0 or ratio < 0.5:
+            spikes.append(
+                {
+                    "day": str(rows[i]["day"]),
+                    "prev_day": str(rows[i - 1]["day"]),
+                    "prev_count": prev_count,
+                    "curr_count": curr_count,
+                    "change_ratio": round(ratio, 2),
+                }
+            )
+
+    if not spikes:
+        return CheckResult(
+            name="drift_detection",
+            status=CheckStatus.ok,
+            message="No >2× day-over-day volume changes detected.",
+        )
+
+    status = CheckStatus.warn
+    return CheckResult(
+        name="drift_detection",
+        status=status,
+        message=f"{len(spikes)} day(s) with >2× volume change in last {lookback_days}d.",
+        detail=spikes,
+    )
+
+
+def check_org_isolation(client: Any, org_id: str) -> CheckResult:
+    """Check 5: Spot-check that no cross-org data leaks into scoped queries."""
+    tables = [
+        "feature_flag",
+        "feature_flag_event",
+        "telemetry_signal_bucket",
+        "release_impact_daily",
+    ]
+    leaks: list[dict[str, Any]] = []
+    for table in tables:
+        query = f"""
+            SELECT count(DISTINCT org_id) AS org_count
+            FROM {table}
+            WHERE org_id != {{org_id:String}}
+              AND org_id != ''
+        """
+        rows = _query_dicts(client, query, {"org_id": org_id})
+        if rows and int(rows[0].get("org_count", 0)) > 0:
+            leaks.append(
+                {
+                    "table": table,
+                    "other_org_count": int(rows[0]["org_count"]),
+                }
+            )
+
+    if not leaks:
+        return CheckResult(
+            name="org_isolation",
+            status=CheckStatus.ok,
+            message="No cross-org data detected (spot check).",
+        )
+
+    # Other orgs existing is normal in multi-tenant — this check verifies
+    # that scoped queries don't accidentally return them.  The presence of
+    # other orgs is informational, not a failure.
+    return CheckResult(
+        name="org_isolation",
+        status=CheckStatus.ok,
+        message=(
+            f"Multi-tenant data present in {len(leaks)} table(s) — "
+            "verify scoped queries filter correctly."
+        ),
+        detail=leaks,
+    )
+
+
+def check_join_integrity(
+    client: Any,
+    org_id: str,
+    lookback_days: int = 30,
+) -> CheckResult:
+    """Check 6: % of release_impact_daily rows that join back to deployments."""
+    query = """
+        WITH impact AS (
+            SELECT DISTINCT release_ref, environment
+            FROM release_impact_daily
+            WHERE org_id = {org_id:String}
+              AND day >= today() - {lookback:UInt32}
+        ),
+        joined AS (
+            SELECT i.release_ref, i.environment,
+                   d.release_ref AS deploy_ref
+            FROM impact AS i
+            LEFT JOIN (
+                SELECT DISTINCT release_ref, environment
+                FROM deployments
+                WHERE release_ref != ''
+            ) AS d
+            ON i.release_ref = d.release_ref
+               AND i.environment = d.environment
+        )
+        SELECT
+            count() AS total,
+            countIf(deploy_ref != '') AS matched
+        FROM joined
+    """
+    rows = _query_dicts(
+        client,
+        query,
+        {"org_id": org_id, "lookback": lookback_days},
+    )
+    if not rows or rows[0]["total"] == 0:
+        return CheckResult(
+            name="join_integrity",
+            status=CheckStatus.skip,
+            message="No release_impact_daily rows in lookback window.",
+        )
+
+    total = int(rows[0]["total"])
+    matched = int(rows[0]["matched"])
+    ratio = matched / total
+
+    if ratio < 0.50:
+        status = CheckStatus.critical
+    elif ratio < 0.80:
+        status = CheckStatus.warn
+    else:
+        status = CheckStatus.ok
+
+    return CheckResult(
+        name="join_integrity",
+        status=status,
+        message=f"{matched}/{total} impact rows join to deployments ({ratio:.0%}).",
+        detail=[{"total": total, "matched": matched, "ratio": ratio}],
+    )
+
+
+_CONFIDENCE_BUCKETS = [
+    (0.0, 0.2, "very_low"),
+    (0.2, 0.4, "low"),
+    (0.4, 0.6, "medium"),
+    (0.6, 0.8, "high"),
+    (0.8, 1.01, "very_high"),
+]
+
+
+def check_confidence_distribution(
+    client: Any,
+    org_id: str,
+    lookback_days: int = 30,
+) -> CheckResult:
+    """Check 7: Histogram of confidence scores to spot anomalies."""
+    query = """
+        SELECT
+            release_impact_confidence_score AS score
+        FROM release_impact_daily
+        WHERE org_id = {org_id:String}
+          AND day >= today() - {lookback:UInt32}
+          AND release_impact_confidence_score IS NOT NULL
+    """
+    rows = _query_dicts(
+        client,
+        query,
+        {"org_id": org_id, "lookback": lookback_days},
+    )
+    if not rows:
+        return CheckResult(
+            name="confidence_distribution",
+            status=CheckStatus.skip,
+            message="No confidence scores in lookback window.",
+        )
+
+    scores = [float(r["score"]) for r in rows]
+    total = len(scores)
+
+    histogram: list[dict[str, Any]] = []
+    for lo, hi, label in _CONFIDENCE_BUCKETS:
+        count = sum(1 for s in scores if lo <= s < hi)
+        histogram.append(
+            {
+                "bucket": label,
+                "range": f"[{lo:.1f}, {hi:.1f})",
+                "count": count,
+                "pct": count / total if total else 0.0,
+            }
+        )
+
+    very_low_pct = histogram[0]["pct"]
+    if very_low_pct > 0.50:
+        status = CheckStatus.warn
+        msg = (
+            f"{very_low_pct:.0%} of confidence scores are very low (<0.2) — "
+            "check coverage and sample sizes."
+        )
+    else:
+        status = CheckStatus.ok
+        avg_score = sum(scores) / total
+        msg = f"{total} scores, avg={avg_score:.2f}."
+
+    return CheckResult(
+        name="confidence_distribution",
+        status=status,
+        message=msg,
+        detail=histogram,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+async def validate_flag_pipeline(
+    ch_client: Any,
+    org_id: str,
+    lookback_days: int = 30,
+) -> ValidationReport:
+    """Run all pipeline validation checks and return a health report.
+
+    Parameters
+    ----------
+    ch_client:
+        ClickHouse client instance (``clickhouse_connect.driver.Client``).
+    org_id:
+        Organization to validate.
+    lookback_days:
+        How many days of data to inspect (default 30).
+
+    Returns
+    -------
+    ValidationReport
+        Aggregated results from all checks.
+    """
+    report = ValidationReport(org_id=org_id)
+
+    checks = [
+        check_coverage(ch_client, org_id, lookback_days),
+        check_dedup(ch_client, org_id),
+        check_schema_completeness(ch_client, org_id),
+        check_drift(ch_client, org_id, min(lookback_days, 14)),
+        check_org_isolation(ch_client, org_id),
+        check_join_integrity(ch_client, org_id, lookback_days),
+        check_confidence_distribution(ch_client, org_id, lookback_days),
+    ]
+
+    report.checks = checks
+    logger.info(report.summary_line())
+    return report
+
+
+def format_report(report: ValidationReport) -> str:
+    """Format a validation report as a human-readable string."""
+    lines: list[str] = []
+    lines.append(f"Feature Flag Pipeline Validation — org={report.org_id!r}")
+    lines.append("=" * 60)
+
+    status_icon = {
+        CheckStatus.ok: "✓",
+        CheckStatus.warn: "⚠",
+        CheckStatus.critical: "✗",
+        CheckStatus.skip: "—",
+    }
+
+    for check in report.checks:
+        icon = status_icon[check.status]
+        lines.append(f"  [{icon}] {check.name}: {check.message}")
+        if check.detail and check.status in (CheckStatus.warn, CheckStatus.critical):
+            for row in check.detail[:5]:
+                detail_str = ", ".join(f"{k}={v}" for k, v in row.items())
+                lines.append(f"      {detail_str}")
+
+    lines.append("")
+    lines.append(report.summary_line())
+
+    if report.has_critical:
+        lines.append("RESULT: CRITICAL — pipeline health checks failed.")
+    elif report.has_warnings:
+        lines.append("RESULT: WARNING — review flagged items.")
+    else:
+        lines.append("RESULT: OK — all checks passed.")
+
+    return "\n".join(lines)

--- a/src/dev_health_ops/metrics/job_ff_validation.py
+++ b/src/dev_health_ops/metrics/job_ff_validation.py
@@ -1,0 +1,66 @@
+"""CLI job for ``dev-hops metrics validate-flags``."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+
+from dev_health_ops.db import resolve_sink_uri
+from dev_health_ops.metrics.ff_validation import (
+    ValidationReport,
+    format_report,
+    validate_flag_pipeline,
+)
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.utils.cli import add_sink_arg, validate_sink
+
+logger = logging.getLogger(__name__)
+
+
+async def run_validate_flags(
+    *,
+    db_url: str,
+    org_id: str = "",
+    lookback_days: int = 30,
+) -> ValidationReport:
+    if not db_url:
+        raise ValueError("ClickHouse URI is required (set CLICKHOUSE_URI).")
+
+    sink = ClickHouseMetricsSink(dsn=db_url)
+    return await validate_flag_pipeline(
+        ch_client=sink.client,
+        org_id=org_id,
+        lookback_days=lookback_days,
+    )
+
+
+def register_commands(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "validate-flags",
+        help="Run feature-flag pipeline validation checks.",
+    )
+    add_sink_arg(parser)
+    parser.add_argument(
+        "--lookback",
+        type=int,
+        default=30,
+        dest="lookback_days",
+        help="Number of days to inspect (default: 30).",
+    )
+    parser.set_defaults(func=_cmd_validate_flags)
+
+
+async def _cmd_validate_flags(ns: argparse.Namespace) -> int:
+    try:
+        validate_sink(ns)
+        report = await run_validate_flags(
+            db_url=resolve_sink_uri(ns),
+            org_id=getattr(ns, "org", None) or "",
+            lookback_days=ns.lookback_days,
+        )
+        print(format_report(report))
+        return 1 if report.has_critical else 0
+    except Exception as e:
+        logger.error("Flag validation failed: %s", e)
+        return 1

--- a/src/dev_health_ops/metrics/job_release_impact.py
+++ b/src/dev_health_ops/metrics/job_release_impact.py
@@ -1,0 +1,89 @@
+"""CLI job for ``dev-hops metrics release-impact``."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from datetime import date, timedelta
+
+from dev_health_ops.db import resolve_sink_uri
+from dev_health_ops.metrics.release_impact import compute_release_impact_daily
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.utils.cli import (
+    add_date_range_args,
+    add_sink_arg,
+    resolve_date_range,
+    validate_sink,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _date_range(end_day: date, backfill_days: int) -> list[date]:
+    if backfill_days <= 1:
+        return [end_day]
+    start_day = end_day - timedelta(days=backfill_days - 1)
+    return [start_day + timedelta(days=i) for i in range(backfill_days)]
+
+
+async def run_release_impact_job(
+    *,
+    db_url: str,
+    day: date,
+    backfill_days: int = 1,
+    recomputation_window_days: int = 7,
+    org_id: str = "",
+) -> int:
+    if not db_url:
+        raise ValueError("ClickHouse URI is required (set CLICKHOUSE_URI).")
+
+    sink = ClickHouseMetricsSink(dsn=db_url)
+    total = 0
+
+    for d in _date_range(day, backfill_days):
+        written = await compute_release_impact_daily(
+            ch_client=sink.client,
+            sink=sink,
+            org_id=org_id,
+            day=d,
+            recomputation_window_days=recomputation_window_days,
+        )
+        total += written
+
+    logger.info("release-impact job complete: %d total records written", total)
+    return total
+
+
+def register_commands(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "release-impact",
+        help="Compute release impact daily metrics from telemetry signal buckets.",
+    )
+    add_date_range_args(parser)
+    add_sink_arg(parser)
+    parser.add_argument(
+        "--recomputation-window",
+        type=int,
+        default=7,
+        dest="recomputation_window_days",
+        help="Number of days to recompute on each run (default: 7).",
+    )
+    parser.set_defaults(func=_cmd_release_impact)
+
+
+async def _cmd_release_impact(ns: argparse.Namespace) -> int:
+    try:
+        validate_sink(ns)
+        end_day, backfill_days = resolve_date_range(ns)
+        await run_release_impact_job(
+            db_url=resolve_sink_uri(ns),
+            day=end_day,
+            backfill_days=backfill_days,
+            recomputation_window_days=ns.recomputation_window_days,
+            org_id=getattr(ns, "org", None) or "",
+        )
+        return 0
+    except Exception as e:
+        logger.error("Release impact metrics job failed: %s", e)
+        return 1

--- a/src/dev_health_ops/metrics/release_impact.py
+++ b/src/dev_health_ops/metrics/release_impact.py
@@ -1,0 +1,540 @@
+"""Release impact daily metric computation.
+
+Reads from ``telemetry_signal_bucket`` and ``deployments`` tables, computes
+per-release/environment impact deltas, and writes ``ReleaseImpactDailyRecord``
+rows via the ClickHouse sink.
+
+Recomputation contract (PRD §Late data):
+- Always recomputes the last ``recomputation_window_days`` (default 7) days.
+- Append-only: new rows with newer ``computed_at`` win via ``argMax``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID
+
+from dev_health_ops.metrics.schemas import ReleaseImpactDailyRecord
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+logger = logging.getLogger(__name__)
+
+_MIN_SESSIONS_FRICTION = 300
+_MIN_EVENTS_ERROR = 1000
+_BASELINE_WINDOW_DAYS = 7
+_POST_WINDOW_HOURS = 24
+_SPIKE_DETECTION_HOURS = 72
+
+_W_COVERAGE = 0.35  # PRD §release_impact_confidence_score weights
+_W_SAMPLE = 0.35
+_W_CONFOUND = 0.30
+
+
+def _query_dicts(
+    client: Any, query: str, parameters: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Execute a ClickHouse query and return results as list of dicts."""
+    result = client.query(query, parameters=parameters)
+    col_names = list(getattr(result, "column_names", []) or [])
+    rows = list(getattr(result, "result_rows", []) or [])
+    if not col_names or not rows:
+        return []
+    return [dict(zip(col_names, row)) for row in rows]
+
+
+async def compute_release_impact_daily(
+    ch_client: Any,
+    sink: ClickHouseMetricsSink,
+    org_id: str,
+    day: date,
+    recomputation_window_days: int = 7,
+) -> int:
+    """Compute release impact metrics for a given day.
+
+    Recomputes the last ``recomputation_window_days`` days (append-only;
+    latest ``computed_at`` wins via ``argMax``).
+
+    Returns number of records written.
+    """
+    computed_at = datetime.now(tz=timezone.utc)
+    total_written = 0
+
+    start_day = day - timedelta(days=recomputation_window_days - 1)
+    current = start_day
+    while current <= day:
+        records = _compute_day(ch_client, org_id, current, computed_at)
+        if records:
+            sink.write_release_impact_daily(records)
+            total_written += len(records)
+            logger.info(
+                "release_impact_daily: wrote %d records for day=%s org=%s",
+                len(records),
+                current.isoformat(),
+                org_id,
+            )
+        else:
+            logger.debug(
+                "release_impact_daily: no data for day=%s org=%s",
+                current.isoformat(),
+                org_id,
+            )
+        current += timedelta(days=1)
+
+    return total_written
+
+
+def _compute_day(
+    client: Any,
+    org_id: str,
+    day: date,
+    computed_at: datetime,
+) -> list[ReleaseImpactDailyRecord]:
+    """Compute release impact records for a single day."""
+
+    release_env_pairs = _find_release_env_pairs(client, org_id, day)
+    if not release_env_pairs:
+        return []
+
+    total_releases_on_day = _count_total_releases(client, org_id, day)
+    releases_with_telemetry = len({r for r, _e in release_env_pairs})
+
+    coverage_ratio = (
+        releases_with_telemetry / total_releases_on_day
+        if total_releases_on_day > 0
+        else 0.0
+    )
+
+    records: list[ReleaseImpactDailyRecord] = []
+    for release_ref, environment in release_env_pairs:
+        record = _compute_release_env(
+            client=client,
+            org_id=org_id,
+            day=day,
+            release_ref=release_ref,
+            environment=environment,
+            coverage_ratio=coverage_ratio,
+            computed_at=computed_at,
+        )
+        records.append(record)
+
+    return records
+
+
+def _find_release_env_pairs(
+    client: Any, org_id: str, day: date
+) -> list[tuple[str, str]]:
+    """Find distinct (release_ref, environment) pairs with telemetry on day."""
+    query = """
+        SELECT DISTINCT release_ref, environment
+        FROM telemetry_signal_bucket
+        WHERE org_id = {org_id:String}
+          AND toDate(bucket_start) = {day:Date}
+          AND release_ref != ''
+    """
+    rows = _query_dicts(client, query, {"org_id": org_id, "day": str(day)})
+    return [(r["release_ref"], r["environment"]) for r in rows]
+
+
+def _count_total_releases(client: Any, org_id: str, day: date) -> int:
+    """Count total distinct release_refs deployed on this day."""
+    query = """
+        SELECT count(DISTINCT release_ref) AS cnt
+        FROM deployments
+        WHERE release_ref != ''
+          AND toDate(coalesce(deployed_at, started_at)) = {day:Date}
+    """
+    params: dict[str, Any] = {"day": str(day)}
+    rows = _query_dicts(client, query, params)
+    if rows:
+        return int(rows[0].get("cnt", 0))
+    return 0
+
+
+def _get_deploy_timestamp(
+    client: Any, org_id: str, release_ref: str, environment: str
+) -> datetime | None:
+    """Get the deploy timestamp for a release_ref + environment."""
+    query = """
+        SELECT coalesce(deployed_at, started_at) AS deploy_ts
+        FROM deployments
+        WHERE release_ref = {release_ref:String}
+          AND environment = {environment:String}
+        ORDER BY deploy_ts DESC
+        LIMIT 1
+    """
+    rows = _query_dicts(
+        client,
+        query,
+        {"release_ref": release_ref, "environment": environment},
+    )
+    if rows and rows[0].get("deploy_ts"):
+        ts = rows[0]["deploy_ts"]
+        if isinstance(ts, datetime):
+            if ts.tzinfo is None:
+                return ts.replace(tzinfo=timezone.utc)
+            return ts
+    return None
+
+
+def _signal_rate(
+    client: Any,
+    org_id: str,
+    release_ref: str,
+    environment: str,
+    signal_pattern: str,
+    window_start: datetime,
+    window_end: datetime,
+) -> tuple[float | None, int]:
+    """Compute signal_count / session_count rate in a time window.
+
+    Returns (rate, total_sessions).
+    """
+    query = """
+        SELECT
+            sum(signal_count) AS total_signals,
+            sum(session_count) AS total_sessions
+        FROM telemetry_signal_bucket
+        WHERE org_id = {org_id:String}
+          AND environment = {environment:String}
+          AND signal_type LIKE {signal_pattern:String}
+          AND bucket_start >= {window_start:DateTime64(3)}
+          AND bucket_end <= {window_end:DateTime64(3)}
+    """
+    rows = _query_dicts(
+        client,
+        query,
+        {
+            "org_id": org_id,
+            "environment": environment,
+            "signal_pattern": signal_pattern,
+            "window_start": window_start,
+            "window_end": window_end,
+        },
+    )
+    if not rows:
+        return None, 0
+    total_signals = int(rows[0].get("total_signals", 0) or 0)
+    total_sessions = int(rows[0].get("total_sessions", 0) or 0)
+    if total_sessions == 0:
+        return None, 0
+    return total_signals / total_sessions, total_sessions
+
+
+def _compute_delta(
+    client: Any,
+    org_id: str,
+    release_ref: str,
+    environment: str,
+    deploy_ts: datetime,
+    signal_pattern: str,
+    min_sessions: int,
+) -> tuple[float | None, float | None]:
+    """Compute pre/post delta and post rate for a signal type.
+
+    Returns (delta, post_rate).
+    Delta = (post_rate - pre_rate) / pre_rate when pre_rate > 0.
+    """
+    baseline_start = deploy_ts - timedelta(days=_BASELINE_WINDOW_DAYS)
+    baseline_end = deploy_ts
+    post_start = deploy_ts
+    post_end = deploy_ts + timedelta(hours=_POST_WINDOW_HOURS)
+
+    pre_rate, pre_sessions = _signal_rate(
+        client,
+        org_id,
+        release_ref,
+        environment,
+        signal_pattern,
+        baseline_start,
+        baseline_end,
+    )
+    post_rate, post_sessions = _signal_rate(
+        client,
+        org_id,
+        release_ref,
+        environment,
+        signal_pattern,
+        post_start,
+        post_end,
+    )
+
+    total_sessions = pre_sessions + post_sessions
+    if total_sessions < min_sessions:
+        return None, post_rate
+
+    if pre_rate is None or pre_rate == 0.0:
+        return None, post_rate
+
+    delta = (post_rate - pre_rate) / pre_rate if post_rate is not None else None
+    return delta, post_rate
+
+
+def _time_to_first_friction_spike(
+    client: Any,
+    org_id: str,
+    environment: str,
+    deploy_ts: datetime,
+) -> float | None:
+    """Hours from deploy to first friction signal spike (within 72h)."""
+    spike_end = deploy_ts + timedelta(hours=_SPIKE_DETECTION_HOURS)
+    query = """
+        SELECT min(bucket_start) AS first_friction_ts
+        FROM telemetry_signal_bucket
+        WHERE org_id = {org_id:String}
+          AND environment = {environment:String}
+          AND signal_type LIKE 'friction.%'
+          AND bucket_start >= {deploy_ts:DateTime64(3)}
+          AND bucket_start <= {spike_end:DateTime64(3)}
+          AND signal_count > 0
+    """
+    rows = _query_dicts(
+        client,
+        query,
+        {
+            "org_id": org_id,
+            "environment": environment,
+            "deploy_ts": deploy_ts,
+            "spike_end": spike_end,
+        },
+    )
+    if not rows:
+        return None
+    first_ts = rows[0].get("first_friction_ts")
+    if first_ts is None:
+        return None
+    if isinstance(first_ts, datetime):
+        if first_ts.tzinfo is None:
+            first_ts = first_ts.replace(tzinfo=timezone.utc)
+        deploy_utc = (
+            deploy_ts if deploy_ts.tzinfo else deploy_ts.replace(tzinfo=timezone.utc)
+        )
+        delta_hours = (first_ts - deploy_utc).total_seconds() / 3600.0
+        return delta_hours if delta_hours >= 0 else None
+    return None
+
+
+def _concurrent_deploy_count(
+    client: Any,
+    org_id: str,
+    release_ref: str,
+    environment: str,
+    deploy_ts: datetime,
+) -> int:
+    """Count other releases in same environment within 24h window."""
+    window_start = deploy_ts - timedelta(hours=24)
+    window_end = deploy_ts + timedelta(hours=24)
+    query = """
+        SELECT count(DISTINCT release_ref) AS cnt
+        FROM deployments
+        WHERE environment = {environment:String}
+          AND release_ref != {release_ref:String}
+          AND release_ref != ''
+          AND coalesce(deployed_at, started_at) >= {window_start:DateTime64(3)}
+          AND coalesce(deployed_at, started_at) <= {window_end:DateTime64(3)}
+    """
+    rows = _query_dicts(
+        client,
+        query,
+        {
+            "environment": environment,
+            "release_ref": release_ref,
+            "window_start": window_start,
+            "window_end": window_end,
+        },
+    )
+    if rows:
+        return int(rows[0].get("cnt", 0) or 0)
+    return 0
+
+
+def _data_completeness(
+    client: Any,
+    org_id: str,
+    release_ref: str,
+    environment: str,
+    day: date,
+) -> float:
+    """Compute data completeness: 1.0 if all expected hourly buckets present.
+
+    Expects 24 hourly buckets per day. Scaled proportionally.
+    """
+    query = """
+        SELECT count(DISTINCT toStartOfHour(bucket_start)) AS bucket_hours
+        FROM telemetry_signal_bucket
+        WHERE org_id = {org_id:String}
+          AND environment = {environment:String}
+          AND toDate(bucket_start) = {day:Date}
+    """
+    rows = _query_dicts(
+        client,
+        query,
+        {"org_id": org_id, "environment": environment, "day": str(day)},
+    )
+    if not rows:
+        return 0.0
+    bucket_hours = int(rows[0].get("bucket_hours", 0) or 0)
+    return min(bucket_hours / 24.0, 1.0)
+
+
+def _compute_confidence(
+    coverage_ratio: float,
+    total_sessions: int,
+    concurrent_deploys: int,
+    min_sessions: int = _MIN_SESSIONS_FRICTION,
+) -> float:
+    """Compute release_impact_confidence_score.
+
+    Factors: coverage, sample sufficiency, concurrent deploy confounding.
+    """
+    sample_score = min(total_sessions / min_sessions, 1.0) if min_sessions > 0 else 1.0
+    confound_score = 1.0 / (1.0 + concurrent_deploys)
+
+    score = (
+        _W_COVERAGE * coverage_ratio
+        + _W_SAMPLE * sample_score
+        + _W_CONFOUND * confound_score
+    )
+    return max(0.0, min(1.0, score))
+
+
+def _compute_release_env(
+    client: Any,
+    org_id: str,
+    day: date,
+    release_ref: str,
+    environment: str,
+    coverage_ratio: float,
+    computed_at: datetime,
+) -> ReleaseImpactDailyRecord:
+    deploy_ts = _get_deploy_timestamp(client, org_id, release_ref, environment)
+    repo_id = _get_repo_id_for_release(client, release_ref, environment)
+
+    friction_delta: float | None = None
+    post_friction_rate: float | None = None
+    friction_sessions = 0
+    error_delta: float | None = None
+    post_error_rate: float | None = None
+    error_sessions = 0
+
+    if deploy_ts is not None:
+        friction_delta, post_friction_rate = _compute_delta(
+            client,
+            org_id,
+            release_ref,
+            environment,
+            deploy_ts,
+            "friction.%",
+            _MIN_SESSIONS_FRICTION,
+        )
+        error_delta, post_error_rate = _compute_delta(
+            client,
+            org_id,
+            release_ref,
+            environment,
+            deploy_ts,
+            "error.%",
+            _MIN_EVENTS_ERROR,
+        )
+
+        post_start = deploy_ts
+        post_end = deploy_ts + timedelta(hours=_POST_WINDOW_HOURS)
+        _, friction_sessions = _signal_rate(
+            client,
+            org_id,
+            release_ref,
+            environment,
+            "friction.%",
+            post_start,
+            post_end,
+        )
+        _, error_sessions = _signal_rate(
+            client,
+            org_id,
+            release_ref,
+            environment,
+            "error.%",
+            post_start,
+            post_end,
+        )
+
+    total_sessions = friction_sessions + error_sessions
+    time_to_first_issue = (
+        _time_to_first_friction_spike(client, org_id, environment, deploy_ts)
+        if deploy_ts is not None
+        else None
+    )
+
+    concurrent = (
+        _concurrent_deploy_count(client, org_id, release_ref, environment, deploy_ts)
+        if deploy_ts is not None
+        else 0
+    )
+
+    completeness = _data_completeness(client, org_id, release_ref, environment, day)
+    confidence = _compute_confidence(
+        coverage_ratio,
+        total_sessions,
+        concurrent,
+    )
+
+    missing = sum(
+        1
+        for v in [friction_delta, post_friction_rate, error_delta, post_error_rate]
+        if v is None
+    )
+
+    return ReleaseImpactDailyRecord(
+        day=day,
+        release_ref=release_ref,
+        environment=environment,
+        repo_id=repo_id,
+        release_user_friction_delta=friction_delta,
+        release_post_friction_rate=post_friction_rate,
+        release_error_rate_delta=error_delta,
+        release_post_error_rate=post_error_rate,
+        time_to_first_user_issue_after_release=time_to_first_issue,
+        release_impact_confidence_score=confidence,
+        release_impact_coverage_ratio=coverage_ratio,
+        flag_exposure_rate=None,
+        flag_activation_rate=None,
+        flag_reliability_guardrail=None,
+        flag_friction_delta=None,
+        flag_rollout_half_life=None,
+        flag_churn_rate=None,
+        issue_to_release_impact_link_rate=None,
+        rollback_or_disable_after_impact_spike=None,
+        coverage_ratio=coverage_ratio,
+        missing_required_fields_count=missing,
+        instrumentation_change_flag=False,
+        data_completeness=completeness,
+        concurrent_deploy_count=concurrent,
+        computed_at=computed_at,
+        org_id=org_id,
+    )
+
+
+def _get_repo_id_for_release(
+    client: Any, release_ref: str, environment: str
+) -> UUID | None:
+    """Look up repo_id from deployments for a release_ref."""
+    query = """
+        SELECT repo_id
+        FROM deployments
+        WHERE release_ref = {release_ref:String}
+          AND environment = {environment:String}
+        ORDER BY coalesce(deployed_at, started_at) DESC
+        LIMIT 1
+    """
+    rows = _query_dicts(
+        client,
+        query,
+        {"release_ref": release_ref, "environment": environment},
+    )
+    if rows and rows[0].get("repo_id"):
+        try:
+            return UUID(str(rows[0]["repo_id"]))
+        except (ValueError, TypeError):
+            return None
+    return None

--- a/src/dev_health_ops/work_graph/builder.py
+++ b/src/dev_health_ops/work_graph/builder.py
@@ -26,7 +26,9 @@ from dev_health_ops.work_graph.extractors.text_parser import (
 from dev_health_ops.work_graph.ids import (
     generate_commit_id,
     generate_edge_id,
+    generate_feature_flag_id,
     generate_pr_id,
+    generate_release_id,
 )
 from dev_health_ops.work_graph.models import (
     EdgeType,
@@ -171,6 +173,117 @@ class WorkGraphBuilder:
         if raw:
             return Provenance.NATIVE
         return Provenance.NATIVE
+
+    def add_release_node(
+        self,
+        release_ref: str,
+        environment: str,
+        *,
+        provider: str | None = None,
+        repo_id: uuid.UUID | None = None,
+        event_ts: datetime | None = None,
+    ) -> WorkGraphEdge:
+        """Create a RELEASE node placeholder edge (self-referencing identity edge).
+
+        Returns the identity edge so callers can chain ``add_release_edge``.
+        """
+        release_id = generate_release_id(self.config.org_id, release_ref)
+        edge_id = generate_edge_id(
+            NodeType.RELEASE,
+            release_id,
+            EdgeType.RELATES,
+            NodeType.RELEASE,
+            release_id,
+        )
+        edge = WorkGraphEdge(
+            edge_id=edge_id,
+            source_type=NodeType.RELEASE,
+            source_id=release_id,
+            target_type=NodeType.RELEASE,
+            target_id=release_id,
+            edge_type=EdgeType.RELATES,
+            provenance=Provenance.NATIVE,
+            confidence=1.0,
+            evidence=f"release:{release_ref}@{environment}",
+            repo_id=repo_id or self.config.repo_id,
+            provider=provider,
+            event_ts=event_ts or self._now,
+        )
+        self._write_edges([edge])
+        return edge
+
+    def add_feature_flag_node(
+        self,
+        flag_key: str,
+        provider: str,
+        project_key: str,
+        *,
+        repo_id: uuid.UUID | None = None,
+        event_ts: datetime | None = None,
+    ) -> WorkGraphEdge:
+        """Create a FEATURE_FLAG node placeholder edge (self-referencing identity edge)."""
+        flag_id = generate_feature_flag_id(
+            self.config.org_id, provider, project_key, flag_key
+        )
+        edge_id = generate_edge_id(
+            NodeType.FEATURE_FLAG,
+            flag_id,
+            EdgeType.RELATES,
+            NodeType.FEATURE_FLAG,
+            flag_id,
+        )
+        edge = WorkGraphEdge(
+            edge_id=edge_id,
+            source_type=NodeType.FEATURE_FLAG,
+            source_id=flag_id,
+            target_type=NodeType.FEATURE_FLAG,
+            target_id=flag_id,
+            edge_type=EdgeType.RELATES,
+            provenance=Provenance.NATIVE,
+            confidence=1.0,
+            evidence=f"flag:{provider}/{project_key}/{flag_key}",
+            repo_id=repo_id or self.config.repo_id,
+            provider=provider,
+            event_ts=event_ts or self._now,
+        )
+        self._write_edges([edge])
+        return edge
+
+    def add_release_edge(
+        self,
+        release_id: str,
+        pr_id: str,
+        edge_type: EdgeType,
+        confidence: float,
+        *,
+        evidence: str = "",
+        provenance: Provenance = Provenance.NATIVE,
+        repo_id: uuid.UUID | None = None,
+        event_ts: datetime | None = None,
+    ) -> WorkGraphEdge:
+        """Create an edge from a RELEASE node to a PR (or other target)."""
+        edge_id = generate_edge_id(
+            NodeType.RELEASE,
+            release_id,
+            edge_type,
+            NodeType.PR,
+            pr_id,
+        )
+        edge = WorkGraphEdge(
+            edge_id=edge_id,
+            source_type=NodeType.RELEASE,
+            source_id=release_id,
+            target_type=NodeType.PR,
+            target_id=pr_id,
+            edge_type=edge_type,
+            provenance=provenance,
+            confidence=confidence,
+            evidence=evidence,
+            repo_id=repo_id or self.config.repo_id,
+            event_ts=event_ts or self._now,
+        )
+        self._write_edges([edge])
+        return edge
 
     def build(self) -> dict:
         """

--- a/src/dev_health_ops/work_graph/ids.py
+++ b/src/dev_health_ops/work_graph/ids.py
@@ -147,6 +147,45 @@ def generate_file_id(
     return f"{repo_id}:{file_path}"
 
 
+def generate_release_id(org_id: str, release_ref: str) -> str:
+    """
+    Generate a deterministic release node ID.
+
+    Format: SHA256 of "release:{org_id}/{release_ref}"
+
+    Args:
+        org_id: Organization identifier
+        release_ref: Release reference (tag, version, SHA)
+
+    Returns:
+        64-character hex string (SHA256 hash)
+    """
+    return _sha256_hex(f"release:{org_id}/{release_ref}")
+
+
+def generate_feature_flag_id(
+    org_id: str,
+    provider: str,
+    project_key: str,
+    flag_key: str,
+) -> str:
+    """
+    Generate a deterministic feature flag node ID.
+
+    Format: SHA256 of "flag:{org_id}/{provider}/{project_key}/{flag_key}"
+
+    Args:
+        org_id: Organization identifier
+        provider: Flag provider (e.g., "launchdarkly")
+        project_key: Provider project key
+        flag_key: Flag key within the project
+
+    Returns:
+        64-character hex string (SHA256 hash)
+    """
+    return _sha256_hex(f"flag:{org_id}/{provider}/{project_key}/{flag_key}")
+
+
 def parse_pr_from_id(pr_id: str) -> tuple[uuid.UUID | None, int | None]:
     """
     Parse repo_id and pr_number from a canonical PR ID.

--- a/src/dev_health_ops/work_graph/models.py
+++ b/src/dev_health_ops/work_graph/models.py
@@ -17,6 +17,8 @@ class NodeType(str, Enum):
     PR = "pr"
     COMMIT = "commit"
     FILE = "file"
+    RELEASE = "release"
+    FEATURE_FLAG = "feature_flag"
 
 
 class EdgeType(str, Enum):
@@ -42,6 +44,16 @@ class EdgeType(str, Enum):
 
     # Commit-to-file relationships
     TOUCHES = "touches"  # Commit touches file
+
+    # Release relationships
+    INTRODUCED_BY = "introduced_by"  # release ← PR
+
+    # Feature flag relationships
+    CONFIG_CHANGED_BY = "config_changed_by"  # feature_flag ← flag_event
+    GUARDS = "guards"  # feature_flag → issue/epic
+
+    # Cross-cutting impact relationships
+    IMPACTS = "impacts"  # release/flag → telemetry signal
 
 
 class Provenance(str, Enum):

--- a/tests/feature_flags/test_confidence.py
+++ b/tests/feature_flags/test_confidence.py
@@ -1,23 +1,33 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
+
+from dev_health_ops.metrics.confidence import (
+    COVERAGE_SUPPRESS_THRESHOLD,
+    COVERAGE_WARN_THRESHOLD,
+    DEFAULT_MIN_SAMPLE,
+    PROVENANCE_CONFIDENCE,
+    DisplayGate,
+    Provenance,
+    classify_display_gate,
+    compute_cohort_contamination,
+    compute_impact_confidence,
+    compute_link_attribution_confidence,
+    provenance_base_confidence,
+)
 
 
 @pytest.mark.parametrize("provenance", ["native", "explicit_text", "heuristic"])
 def test_confidence_fixture_covers_prd_bands(
     provenance: str, confidence_case_map: dict[str, dict[str, Any]]
 ) -> None:
-    # PRD: lines 182-185, 390
     band = confidence_case_map[provenance]
-
     assert band["expected_min"] <= band["expected_max"]
 
 
-@pytest.mark.skip(
-    reason="Awaiting CHAOS-820 implementation for confidence band assignment"
-)
 @pytest.mark.parametrize(
     ("provenance", "expected_range"),
     [
@@ -31,7 +41,378 @@ def test_confidence_scoring_matches_prd_ranges(
     expected_range: tuple[float, float],
     confidence_case_map: dict[str, dict[str, Any]],
 ) -> None:
-    # PRD: lines 182-185, 390
     case = confidence_case_map[provenance]
-
     assert (case["expected_min"], case["expected_max"]) == expected_range
+
+
+class TestProvenanceBaseConfidence:
+    def test_native_returns_1(self) -> None:
+        assert provenance_base_confidence(Provenance.native) == 1.0
+
+    def test_explicit_text_returns_085(self) -> None:
+        assert provenance_base_confidence(Provenance.explicit_text) == 0.85
+
+    def test_heuristic_returns_03(self) -> None:
+        assert provenance_base_confidence(Provenance.heuristic) == 0.3
+
+    def test_string_input_native(self) -> None:
+        assert provenance_base_confidence("native") == 1.0
+
+    def test_string_input_explicit_text(self) -> None:
+        assert provenance_base_confidence("explicit_text") == 0.85
+
+    def test_unknown_string_falls_back_to_heuristic(self) -> None:
+        assert provenance_base_confidence("unknown_provenance") == 0.3
+
+
+class TestComputeImpactConfidence:
+    def test_perfect_inputs_native(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=1.0,
+            sample_size=100,
+            concurrent_deploy_count=0,
+            release_ref_confidence=1.0,
+        )
+        assert score == pytest.approx(1.0)
+
+    def test_perfect_inputs_heuristic_base(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=1.0,
+            sample_size=100,
+            concurrent_deploy_count=0,
+            release_ref_confidence=0.3,
+        )
+        assert score == pytest.approx(0.3)
+
+    def test_coverage_below_threshold_applies_quadratic_penalty(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=0.5,
+            sample_size=100,
+            concurrent_deploy_count=0,
+            release_ref_confidence=1.0,
+        )
+        # 0.5 < 0.70 → coverage_factor = 0.5² = 0.25
+        assert score == pytest.approx(0.25)
+
+    def test_coverage_above_threshold_linear(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=0.8,
+            sample_size=100,
+            concurrent_deploy_count=0,
+            release_ref_confidence=1.0,
+        )
+        assert score == pytest.approx(0.8)
+
+    def test_coverage_at_threshold_boundary(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=0.70,
+            sample_size=100,
+            concurrent_deploy_count=0,
+            release_ref_confidence=1.0,
+        )
+        assert score == pytest.approx(0.70)
+
+    def test_sample_size_below_minimum(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=1.0,
+            sample_size=15,
+            concurrent_deploy_count=0,
+            release_ref_confidence=1.0,
+            min_sample=30,
+        )
+        assert score == pytest.approx(0.5)
+
+    def test_sample_size_at_minimum(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=1.0,
+            sample_size=30,
+            concurrent_deploy_count=0,
+            release_ref_confidence=1.0,
+            min_sample=30,
+        )
+        assert score == pytest.approx(1.0)
+
+    def test_sample_size_above_minimum_capped(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=1.0,
+            sample_size=1000,
+            concurrent_deploy_count=0,
+            release_ref_confidence=1.0,
+            min_sample=30,
+        )
+        assert score == pytest.approx(1.0)
+
+    def test_one_concurrent_deploy(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=1.0,
+            sample_size=100,
+            concurrent_deploy_count=1,
+            release_ref_confidence=1.0,
+        )
+        # 1 / (1 + 1) = 0.5
+        assert score == pytest.approx(0.5)
+
+    def test_many_concurrent_deploys(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=1.0,
+            sample_size=100,
+            concurrent_deploy_count=4,
+            release_ref_confidence=1.0,
+        )
+        # 1 / (1 + 4) = 0.2
+        assert score == pytest.approx(0.2)
+
+    def test_all_factors_combined(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=0.8,
+            sample_size=15,
+            concurrent_deploy_count=1,
+            release_ref_confidence=0.85,
+            min_sample=30,
+        )
+        # base=0.85, cov=0.8 (above threshold), sample=15/30=0.5, confounder=0.5
+        expected = 0.85 * 0.8 * 0.5 * 0.5
+        assert score == pytest.approx(expected)
+
+    def test_zero_coverage(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=0.0,
+            sample_size=100,
+            concurrent_deploy_count=0,
+            release_ref_confidence=1.0,
+        )
+        assert score == pytest.approx(0.0)
+
+    def test_zero_samples(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=1.0,
+            sample_size=0,
+            concurrent_deploy_count=0,
+            release_ref_confidence=1.0,
+        )
+        assert score == pytest.approx(0.0)
+
+    def test_negative_coverage_clamped(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=-0.5,
+            sample_size=100,
+            concurrent_deploy_count=0,
+            release_ref_confidence=1.0,
+        )
+        assert score == pytest.approx(0.0)
+
+    def test_coverage_above_one_clamped(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=1.5,
+            sample_size=100,
+            concurrent_deploy_count=0,
+            release_ref_confidence=1.0,
+        )
+        assert score == pytest.approx(1.0)
+
+    def test_release_ref_confidence_clamped(self) -> None:
+        score = compute_impact_confidence(
+            coverage_ratio=1.0,
+            sample_size=100,
+            concurrent_deploy_count=0,
+            release_ref_confidence=2.0,
+        )
+        assert score == pytest.approx(1.0)
+
+
+class TestComputeCohortContamination:
+    _window_start = datetime(2026, 3, 1, tzinfo=timezone.utc)
+    _window_end = datetime(2026, 3, 8, tzinfo=timezone.utc)
+
+    def test_no_concurrent_flags(self) -> None:
+        result = compute_cohort_contamination(
+            flag_key="checkout_v2",
+            environment="production",
+            window_start=self._window_start,
+            window_end=self._window_end,
+            concurrent_flags=[],
+        )
+        assert result == 0.0
+
+    def test_one_concurrent_flag(self) -> None:
+        result = compute_cohort_contamination(
+            flag_key="checkout_v2",
+            environment="production",
+            window_start=self._window_start,
+            window_end=self._window_end,
+            concurrent_flags=["dark_mode"],
+        )
+        assert result == pytest.approx(0.5)
+
+    def test_two_concurrent_flags(self) -> None:
+        result = compute_cohort_contamination(
+            flag_key="checkout_v2",
+            environment="production",
+            window_start=self._window_start,
+            window_end=self._window_end,
+            concurrent_flags=["dark_mode", "new_pricing"],
+        )
+        # 1 - 1/(1+2) = 2/3
+        assert result == pytest.approx(2.0 / 3.0)
+
+    def test_three_concurrent_flags(self) -> None:
+        result = compute_cohort_contamination(
+            flag_key="checkout_v2",
+            environment="production",
+            window_start=self._window_start,
+            window_end=self._window_end,
+            concurrent_flags=["a", "b", "c"],
+        )
+        assert result == pytest.approx(0.75)
+
+    def test_self_reference_excluded(self) -> None:
+        result = compute_cohort_contamination(
+            flag_key="checkout_v2",
+            environment="production",
+            window_start=self._window_start,
+            window_end=self._window_end,
+            concurrent_flags=["checkout_v2"],
+        )
+        assert result == 0.0
+
+    def test_self_reference_with_others(self) -> None:
+        result = compute_cohort_contamination(
+            flag_key="checkout_v2",
+            environment="production",
+            window_start=self._window_start,
+            window_end=self._window_end,
+            concurrent_flags=["checkout_v2", "dark_mode"],
+        )
+        assert result == pytest.approx(0.5)
+
+    def test_many_concurrent_flags_approaches_one(self) -> None:
+        flags = [f"flag_{i}" for i in range(100)]
+        result = compute_cohort_contamination(
+            flag_key="checkout_v2",
+            environment="production",
+            window_start=self._window_start,
+            window_end=self._window_end,
+            concurrent_flags=flags,
+        )
+        assert result > 0.99
+        assert result < 1.0
+
+
+class TestClassifyDisplayGate:
+    def test_show_at_threshold(self) -> None:
+        assert classify_display_gate(0.70, min_sample_met=True) == "show"
+
+    def test_show_above_threshold(self) -> None:
+        assert classify_display_gate(0.95, min_sample_met=True) == "show"
+
+    def test_warn_at_lower_threshold(self) -> None:
+        assert classify_display_gate(0.50, min_sample_met=True) == "warn"
+
+    def test_warn_between_thresholds(self) -> None:
+        assert classify_display_gate(0.60, min_sample_met=True) == "warn"
+
+    def test_suppress_below_lower_threshold(self) -> None:
+        assert classify_display_gate(0.49, min_sample_met=True) == "suppress"
+
+    def test_suppress_zero_coverage(self) -> None:
+        assert classify_display_gate(0.0, min_sample_met=True) == "suppress"
+
+    def test_suppress_when_min_sample_not_met(self) -> None:
+        assert classify_display_gate(0.90, min_sample_met=False) == "suppress"
+
+    def test_suppress_low_coverage_and_no_sample(self) -> None:
+        assert classify_display_gate(0.30, min_sample_met=False) == "suppress"
+
+    @pytest.mark.parametrize(
+        ("coverage", "min_sample_met", "expected"),
+        [
+            (0.70, True, "show"),
+            (0.50, True, "warn"),
+            (0.49, True, "suppress"),
+            (0.70, False, "suppress"),
+        ],
+    )
+    def test_boundary_matrix(
+        self,
+        coverage: float,
+        min_sample_met: bool,
+        expected: DisplayGate,
+    ) -> None:
+        assert classify_display_gate(coverage, min_sample_met) == expected
+
+
+class TestComputeLinkAttributionConfidence:
+    def test_native_always_1(self) -> None:
+        assert compute_link_attribution_confidence(Provenance.native) == 1.0
+
+    def test_native_ignores_text_match_count(self) -> None:
+        assert (
+            compute_link_attribution_confidence(Provenance.native, text_match_count=5)
+            == 1.0
+        )
+
+    def test_heuristic_always_03(self) -> None:
+        assert compute_link_attribution_confidence(
+            Provenance.heuristic
+        ) == pytest.approx(0.3)
+
+    def test_explicit_text_one_match(self) -> None:
+        score = compute_link_attribution_confidence(
+            Provenance.explicit_text, text_match_count=1
+        )
+        assert 0.80 <= score <= 0.90
+
+    def test_explicit_text_two_matches(self) -> None:
+        score = compute_link_attribution_confidence(
+            Provenance.explicit_text, text_match_count=2
+        )
+        assert 0.80 <= score <= 0.90
+
+    def test_explicit_text_three_matches_at_cap(self) -> None:
+        score = compute_link_attribution_confidence(
+            Provenance.explicit_text, text_match_count=3
+        )
+        assert score == pytest.approx(0.90)
+
+    def test_explicit_text_many_matches_capped(self) -> None:
+        score = compute_link_attribution_confidence(
+            Provenance.explicit_text, text_match_count=100
+        )
+        assert score == pytest.approx(0.90)
+
+    def test_explicit_text_zero_matches(self) -> None:
+        score = compute_link_attribution_confidence(
+            Provenance.explicit_text, text_match_count=0
+        )
+        assert score == pytest.approx(0.80)
+
+    def test_explicit_text_monotonically_increasing(self) -> None:
+        scores = [
+            compute_link_attribution_confidence(
+                Provenance.explicit_text, text_match_count=i
+            )
+            for i in range(5)
+        ]
+        for i in range(1, len(scores)):
+            assert scores[i] >= scores[i - 1]
+
+    def test_string_provenance_native(self) -> None:
+        assert compute_link_attribution_confidence("native") == 1.0
+
+    def test_string_provenance_unknown_falls_back(self) -> None:
+        assert compute_link_attribution_confidence("bogus") == pytest.approx(0.3)
+
+
+class TestConstants:
+    def test_provenance_confidence_keys(self) -> None:
+        assert set(PROVENANCE_CONFIDENCE.keys()) == {
+            Provenance.native,
+            Provenance.explicit_text,
+            Provenance.heuristic,
+        }
+
+    def test_coverage_thresholds_ordered(self) -> None:
+        assert COVERAGE_SUPPRESS_THRESHOLD < COVERAGE_WARN_THRESHOLD
+
+    def test_default_min_sample(self) -> None:
+        assert DEFAULT_MIN_SAMPLE == 30

--- a/tests/feature_flags/test_ff_validation.py
+++ b/tests/feature_flags/test_ff_validation.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.metrics.ff_validation import (
+    CheckStatus,
+    ValidationReport,
+    check_confidence_distribution,
+    check_coverage,
+    check_dedup,
+    check_drift,
+    check_join_integrity,
+    check_org_isolation,
+    check_schema_completeness,
+    format_report,
+    validate_flag_pipeline,
+)
+
+
+class _FakeQueryResult:
+    def __init__(self, column_names: list[str], result_rows: list[list[Any]]):
+        self.column_names = column_names
+        self.result_rows = result_rows
+
+
+def _make_client(responses: list[_FakeQueryResult]) -> MagicMock:
+    client = MagicMock()
+    client.query = MagicMock(side_effect=responses)
+    return client
+
+
+class TestCheckCoverage:
+    def test_skip_when_no_releases(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total_releases", "covered_releases"], [[0, 0]]),
+            ]
+        )
+        result = check_coverage(client, "acme")
+        assert result.status == CheckStatus.skip
+
+    def test_ok_when_high_coverage(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total_releases", "covered_releases"], [[10, 8]]),
+            ]
+        )
+        result = check_coverage(client, "acme")
+        assert result.status == CheckStatus.ok
+        assert result.detail[0]["ratio"] == pytest.approx(0.8)
+
+    def test_warn_when_medium_coverage(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total_releases", "covered_releases"], [[10, 6]]),
+            ]
+        )
+        result = check_coverage(client, "acme")
+        assert result.status == CheckStatus.warn
+
+    def test_critical_when_low_coverage(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total_releases", "covered_releases"], [[10, 3]]),
+            ]
+        )
+        result = check_coverage(client, "acme")
+        assert result.status == CheckStatus.critical
+
+
+class TestCheckDedup:
+    def test_ok_when_no_duplicates(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total", "distinct_keys"], [[100, 100]]),
+                _FakeQueryResult(["total", "distinct_keys"], [[200, 200]]),
+            ]
+        )
+        result = check_dedup(client, "acme")
+        assert result.status == CheckStatus.ok
+
+    def test_warn_when_minor_duplicates(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total", "distinct_keys"], [[100, 98]]),
+                _FakeQueryResult(["total", "distinct_keys"], [[200, 200]]),
+            ]
+        )
+        result = check_dedup(client, "acme")
+        assert result.status == CheckStatus.warn
+        assert len(result.detail) == 1
+        assert result.detail[0]["table"] == "feature_flag_event"
+
+    def test_critical_when_heavy_duplicates(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total", "distinct_keys"], [[100, 90]]),
+                _FakeQueryResult(["total", "distinct_keys"], [[200, 200]]),
+            ]
+        )
+        result = check_dedup(client, "acme")
+        assert result.status == CheckStatus.critical
+
+
+class TestCheckSchemaCompleteness:
+    def test_skip_when_no_flags(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total", "complete"], [[0, 0]]),
+            ]
+        )
+        result = check_schema_completeness(client, "acme")
+        assert result.status == CheckStatus.skip
+
+    def test_ok_when_all_complete(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total", "complete"], [[50, 50]]),
+            ]
+        )
+        result = check_schema_completeness(client, "acme")
+        assert result.status == CheckStatus.ok
+
+    def test_warn_when_some_incomplete(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total", "complete"], [[50, 46]]),
+            ]
+        )
+        result = check_schema_completeness(client, "acme")
+        assert result.status == CheckStatus.warn
+
+    def test_critical_when_many_incomplete(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total", "complete"], [[50, 30]]),
+            ]
+        )
+        result = check_schema_completeness(client, "acme")
+        assert result.status == CheckStatus.critical
+
+
+class TestCheckDrift:
+    def test_skip_when_insufficient_data(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["day", "bucket_count"], [["2026-03-15", 100]]),
+            ]
+        )
+        result = check_drift(client, "acme")
+        assert result.status == CheckStatus.skip
+
+    def test_ok_when_stable(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(
+                    ["day", "bucket_count"],
+                    [
+                        ["2026-03-13", 100],
+                        ["2026-03-14", 110],
+                        ["2026-03-15", 105],
+                    ],
+                ),
+            ]
+        )
+        result = check_drift(client, "acme")
+        assert result.status == CheckStatus.ok
+
+    def test_warn_when_spike(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(
+                    ["day", "bucket_count"],
+                    [
+                        ["2026-03-13", 100],
+                        ["2026-03-14", 100],
+                        ["2026-03-15", 300],
+                    ],
+                ),
+            ]
+        )
+        result = check_drift(client, "acme")
+        assert result.status == CheckStatus.warn
+        assert len(result.detail) == 1
+        assert result.detail[0]["change_ratio"] == 3.0
+
+    def test_warn_when_drop(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(
+                    ["day", "bucket_count"],
+                    [
+                        ["2026-03-13", 200],
+                        ["2026-03-14", 200],
+                        ["2026-03-15", 50],
+                    ],
+                ),
+            ]
+        )
+        result = check_drift(client, "acme")
+        assert result.status == CheckStatus.warn
+        assert result.detail[0]["change_ratio"] == 0.25
+
+
+class TestCheckOrgIsolation:
+    def test_ok_when_single_org(self) -> None:
+        empty = _FakeQueryResult(["org_count"], [[0]])
+        client = _make_client([empty, empty, empty, empty])
+        result = check_org_isolation(client, "acme")
+        assert result.status == CheckStatus.ok
+        assert not result.detail
+
+    def test_ok_with_info_when_multi_tenant(self) -> None:
+        has_others = _FakeQueryResult(["org_count"], [[2]])
+        empty = _FakeQueryResult(["org_count"], [[0]])
+        client = _make_client([has_others, empty, empty, empty])
+        result = check_org_isolation(client, "acme")
+        assert result.status == CheckStatus.ok
+        assert len(result.detail) == 1
+
+
+class TestCheckJoinIntegrity:
+    def test_skip_when_no_impact_rows(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total", "matched"], [[0, 0]]),
+            ]
+        )
+        result = check_join_integrity(client, "acme")
+        assert result.status == CheckStatus.skip
+
+    def test_ok_when_high_join_rate(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total", "matched"], [[20, 18]]),
+            ]
+        )
+        result = check_join_integrity(client, "acme")
+        assert result.status == CheckStatus.ok
+
+    def test_warn_when_medium_join_rate(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total", "matched"], [[20, 12]]),
+            ]
+        )
+        result = check_join_integrity(client, "acme")
+        assert result.status == CheckStatus.warn
+
+    def test_critical_when_low_join_rate(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["total", "matched"], [[20, 5]]),
+            ]
+        )
+        result = check_join_integrity(client, "acme")
+        assert result.status == CheckStatus.critical
+
+
+class TestCheckConfidenceDistribution:
+    def test_skip_when_no_scores(self) -> None:
+        client = _make_client(
+            [
+                _FakeQueryResult(["score"], []),
+            ]
+        )
+        result = check_confidence_distribution(client, "acme")
+        assert result.status == CheckStatus.skip
+
+    def test_ok_with_healthy_distribution(self) -> None:
+        scores = [[0.7], [0.8], [0.9], [0.6], [0.85]]
+        client = _make_client(
+            [
+                _FakeQueryResult(["score"], scores),
+            ]
+        )
+        result = check_confidence_distribution(client, "acme")
+        assert result.status == CheckStatus.ok
+        assert len(result.detail) == 5
+
+    def test_warn_when_mostly_very_low(self) -> None:
+        scores = [[0.1], [0.05], [0.15], [0.1], [0.8]]
+        client = _make_client(
+            [
+                _FakeQueryResult(["score"], scores),
+            ]
+        )
+        result = check_confidence_distribution(client, "acme")
+        assert result.status == CheckStatus.warn
+
+
+class TestValidationReport:
+    def test_has_critical(self) -> None:
+        from dev_health_ops.metrics.ff_validation import CheckResult
+
+        report = ValidationReport(
+            org_id="acme",
+            checks=[
+                CheckResult("a", CheckStatus.ok, "fine"),
+                CheckResult("b", CheckStatus.critical, "bad"),
+            ],
+        )
+        assert report.has_critical is True
+        assert report.has_warnings is False
+
+    def test_has_warnings(self) -> None:
+        from dev_health_ops.metrics.ff_validation import CheckResult
+
+        report = ValidationReport(
+            org_id="acme",
+            checks=[
+                CheckResult("a", CheckStatus.ok, "fine"),
+                CheckResult("b", CheckStatus.warn, "meh"),
+            ],
+        )
+        assert report.has_critical is False
+        assert report.has_warnings is True
+
+    def test_all_ok(self) -> None:
+        from dev_health_ops.metrics.ff_validation import CheckResult
+
+        report = ValidationReport(
+            org_id="acme",
+            checks=[CheckResult("a", CheckStatus.ok, "fine")],
+        )
+        assert report.has_critical is False
+        assert report.has_warnings is False
+
+
+class TestFormatReport:
+    def test_format_includes_all_checks(self) -> None:
+        from dev_health_ops.metrics.ff_validation import CheckResult
+
+        report = ValidationReport(
+            org_id="acme",
+            checks=[
+                CheckResult("coverage", CheckStatus.ok, "8/10 (80%)"),
+                CheckResult("dedup", CheckStatus.warn, "minor dups"),
+            ],
+        )
+        output = format_report(report)
+        assert "coverage" in output
+        assert "dedup" in output
+        assert "WARNING" in output
+
+    def test_format_critical_result(self) -> None:
+        from dev_health_ops.metrics.ff_validation import CheckResult
+
+        report = ValidationReport(
+            org_id="acme",
+            checks=[CheckResult("join", CheckStatus.critical, "broken")],
+        )
+        output = format_report(report)
+        assert "CRITICAL" in output
+
+
+@pytest.mark.asyncio
+async def test_validate_flag_pipeline_runs_all_checks() -> None:
+    responses = [
+        _FakeQueryResult(["total_releases", "covered_releases"], [[10, 8]]),
+        _FakeQueryResult(["total", "distinct_keys"], [[100, 100]]),
+        _FakeQueryResult(["total", "distinct_keys"], [[200, 200]]),
+        _FakeQueryResult(["total", "complete"], [[50, 50]]),
+        _FakeQueryResult(
+            ["day", "bucket_count"],
+            [["2026-03-14", 100], ["2026-03-15", 110]],
+        ),
+        _FakeQueryResult(["org_count"], [[0]]),
+        _FakeQueryResult(["org_count"], [[0]]),
+        _FakeQueryResult(["org_count"], [[0]]),
+        _FakeQueryResult(["org_count"], [[0]]),
+        _FakeQueryResult(["total", "matched"], [[20, 18]]),
+        _FakeQueryResult(["score"], [[0.7], [0.8], [0.9]]),
+    ]
+    client = _make_client(responses)
+    report = await validate_flag_pipeline(client, "acme", lookback_days=30)
+    assert len(report.checks) == 7
+    assert not report.has_critical

--- a/tests/metrics/test_compute_release_impact.py
+++ b/tests/metrics/test_compute_release_impact.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from dev_health_ops.metrics.release_impact import (
+    _compute_confidence,
+    _compute_day,
+    compute_release_impact_daily,
+)
+
+
+class FakeQueryResult:
+    def __init__(self, column_names: list[str], result_rows: list[list]):
+        self.column_names = column_names
+        self.result_rows = result_rows
+
+
+def _make_client(responses: list[FakeQueryResult]) -> MagicMock:
+    client = MagicMock()
+    client.query = MagicMock(side_effect=responses)
+    return client
+
+
+def test_compute_confidence_perfect_conditions():
+    score = _compute_confidence(
+        coverage_ratio=1.0,
+        total_sessions=500,
+        concurrent_deploys=0,
+    )
+    assert score == pytest.approx(1.0)
+
+
+def test_compute_confidence_no_sessions():
+    score = _compute_confidence(
+        coverage_ratio=1.0,
+        total_sessions=0,
+        concurrent_deploys=0,
+    )
+    assert 0.0 < score < 1.0
+    assert score == pytest.approx(0.35 * 1.0 + 0.35 * 0.0 + 0.30 * 1.0)
+
+
+def test_compute_confidence_high_concurrency_degrades():
+    score_clean = _compute_confidence(1.0, 500, 0)
+    score_noisy = _compute_confidence(1.0, 500, 5)
+    assert score_noisy < score_clean
+
+
+def test_compute_day_no_telemetry_returns_empty():
+    client = _make_client(
+        [
+            FakeQueryResult(["release_ref", "environment"], []),
+        ]
+    )
+    records = _compute_day(
+        client, "org1", date(2026, 3, 15), datetime.now(tz=timezone.utc)
+    )
+    assert records == []
+
+
+def test_compute_day_single_release():
+    repo_id = uuid4()
+    deploy_ts = datetime(2026, 3, 15, 10, 0, tzinfo=timezone.utc)
+
+    responses = [
+        FakeQueryResult(["release_ref", "environment"], [["v1.0.0", "production"]]),
+        FakeQueryResult(["cnt"], [[2]]),
+        FakeQueryResult(["deploy_ts"], [[deploy_ts]]),
+        FakeQueryResult(["repo_id"], [[str(repo_id)]]),
+        FakeQueryResult(["total_signals", "total_sessions"], [[10, 500]]),
+        FakeQueryResult(["total_signals", "total_sessions"], [[15, 600]]),
+        FakeQueryResult(["total_signals", "total_sessions"], [[5, 400]]),
+        FakeQueryResult(["total_signals", "total_sessions"], [[8, 500]]),
+        FakeQueryResult(["total_signals", "total_sessions"], [[15, 600]]),
+        FakeQueryResult(["total_signals", "total_sessions"], [[8, 500]]),
+        FakeQueryResult(["first_friction_ts"], [[deploy_ts + timedelta(hours=2)]]),
+        FakeQueryResult(["cnt"], [[1]]),
+        FakeQueryResult(["bucket_hours"], [[20]]),
+    ]
+
+    client = _make_client(responses)
+    computed_at = datetime(2026, 3, 16, 0, 0, tzinfo=timezone.utc)
+    records = _compute_day(client, "org1", date(2026, 3, 15), computed_at)
+
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.day == date(2026, 3, 15)
+    assert rec.release_ref == "v1.0.0"
+    assert rec.environment == "production"
+    assert rec.repo_id == repo_id
+    assert rec.computed_at == computed_at
+    assert rec.org_id == "org1"
+    assert rec.coverage_ratio == pytest.approx(0.5)
+    assert rec.data_completeness == pytest.approx(20 / 24.0)
+    assert rec.concurrent_deploy_count == 1
+    assert rec.release_impact_confidence_score > 0.0
+    assert rec.release_impact_confidence_score <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_compute_release_impact_daily_writes_to_sink():
+    client = _make_client(
+        [
+            FakeQueryResult(["release_ref", "environment"], []),
+        ]
+    )
+    sink = MagicMock()
+    sink.client = client
+    sink.write_release_impact_daily = MagicMock()
+
+    written = await compute_release_impact_daily(
+        ch_client=client,
+        sink=sink,
+        org_id="org1",
+        day=date(2026, 3, 15),
+        recomputation_window_days=1,
+    )
+    assert written == 0
+    sink.write_release_impact_daily.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_compute_release_impact_daily_recomputation_window():
+    call_count = 0
+
+    def fake_query(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return FakeQueryResult(["release_ref", "environment"], [])
+
+    client = MagicMock()
+    client.query = MagicMock(side_effect=fake_query)
+    sink = MagicMock()
+    sink.client = client
+    sink.write_release_impact_daily = MagicMock()
+
+    await compute_release_impact_daily(
+        ch_client=client,
+        sink=sink,
+        org_id="org1",
+        day=date(2026, 3, 15),
+        recomputation_window_days=3,
+    )
+    assert call_count == 3
+
+
+def test_compute_day_missing_deploy_timestamp():
+    responses = [
+        FakeQueryResult(["release_ref", "environment"], [["v2.0.0", "staging"]]),
+        FakeQueryResult(["cnt"], [[1]]),
+        FakeQueryResult(["deploy_ts"], []),
+        FakeQueryResult(["repo_id"], []),
+        FakeQueryResult(["bucket_hours"], [[12]]),
+    ]
+
+    client = _make_client(responses)
+    records = _compute_day(
+        client, "org1", date(2026, 3, 15), datetime.now(tz=timezone.utc)
+    )
+
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.release_user_friction_delta is None
+    assert rec.release_error_rate_delta is None
+    assert rec.time_to_first_user_issue_after_release is None
+    assert rec.concurrent_deploy_count == 0
+    assert rec.missing_required_fields_count == 4

--- a/tests/work_graph/test_ids.py
+++ b/tests/work_graph/test_ids.py
@@ -5,9 +5,11 @@ import uuid
 from dev_health_ops.work_graph.ids import (
     generate_commit_id,
     generate_edge_id,
+    generate_feature_flag_id,
     generate_file_id,
     generate_issue_id,
     generate_pr_id,
+    generate_release_id,
 )
 from dev_health_ops.work_graph.models import EdgeType, NodeType
 
@@ -206,4 +208,59 @@ class TestGenerateFileId:
         repo2 = uuid.uuid4()
         id1 = generate_file_id(repo1, "src/main.py")
         id2 = generate_file_id(repo2, "src/main.py")
+        assert id1 != id2
+
+
+class TestGenerateReleaseId:
+    """Tests for release ID generation."""
+
+    def test_deterministic(self):
+        id1 = generate_release_id("org-1", "v1.2.3")
+        id2 = generate_release_id("org-1", "v1.2.3")
+        assert id1 == id2
+
+    def test_returns_hex_string(self):
+        release_id = generate_release_id("org-1", "v1.0.0")
+        assert isinstance(release_id, str)
+        int(release_id, 16)
+        assert len(release_id) == 64
+
+    def test_different_orgs(self):
+        id1 = generate_release_id("org-1", "v1.0.0")
+        id2 = generate_release_id("org-2", "v1.0.0")
+        assert id1 != id2
+
+    def test_different_refs(self):
+        id1 = generate_release_id("org-1", "v1.0.0")
+        id2 = generate_release_id("org-1", "v2.0.0")
+        assert id1 != id2
+
+
+class TestGenerateFeatureFlagId:
+    """Tests for feature flag ID generation."""
+
+    def test_deterministic(self):
+        id1 = generate_feature_flag_id("org-1", "launchdarkly", "proj-1", "enable-foo")
+        id2 = generate_feature_flag_id("org-1", "launchdarkly", "proj-1", "enable-foo")
+        assert id1 == id2
+
+    def test_returns_hex_string(self):
+        flag_id = generate_feature_flag_id("org-1", "ld", "proj", "flag")
+        assert isinstance(flag_id, str)
+        int(flag_id, 16)
+        assert len(flag_id) == 64
+
+    def test_different_providers(self):
+        id1 = generate_feature_flag_id("org-1", "launchdarkly", "proj", "flag")
+        id2 = generate_feature_flag_id("org-1", "split", "proj", "flag")
+        assert id1 != id2
+
+    def test_different_projects(self):
+        id1 = generate_feature_flag_id("org-1", "ld", "proj-a", "flag")
+        id2 = generate_feature_flag_id("org-1", "ld", "proj-b", "flag")
+        assert id1 != id2
+
+    def test_different_flags(self):
+        id1 = generate_feature_flag_id("org-1", "ld", "proj", "flag-a")
+        id2 = generate_feature_flag_id("org-1", "ld", "proj", "flag-b")
         assert id1 != id2

--- a/tests/work_graph/test_models.py
+++ b/tests/work_graph/test_models.py
@@ -23,6 +23,8 @@ class TestNodeType:
         assert NodeType.PR.value == "pr"
         assert NodeType.COMMIT.value == "commit"
         assert NodeType.FILE.value == "file"
+        assert NodeType.RELEASE.value == "release"
+        assert NodeType.FEATURE_FLAG.value == "feature_flag"
 
 
 class TestEdgeType:
@@ -49,6 +51,19 @@ class TestEdgeType:
     def test_commit_file_relationships(self):
         """Commit-to-file relationship types should exist."""
         assert EdgeType.TOUCHES.value == "touches"
+
+    def test_release_relationships(self):
+        """Release relationship types should exist."""
+        assert EdgeType.INTRODUCED_BY.value == "introduced_by"
+
+    def test_feature_flag_relationships(self):
+        """Feature flag relationship types should exist."""
+        assert EdgeType.CONFIG_CHANGED_BY.value == "config_changed_by"
+        assert EdgeType.GUARDS.value == "guards"
+
+    def test_impact_relationships(self):
+        """Cross-cutting impact relationship types should exist."""
+        assert EdgeType.IMPACTS.value == "impacts"
 
 
 class TestProvenance:


### PR DESCRIPTION
## Summary

Phase 2 (Derived Metrics & Work Graph) and Phase 3 (Interpretation Guidance) for the Feature Flag + User Impact Mapping initiative.

### Phase 2 — Derived Metrics and Work Graph Extensions
- **CHAOS-826**: `release_impact_daily` computation — friction/error deltas, 7d baseline vs 24h post window, recomputation, `dev-hops metrics release-impact` CLI
- **CHAOS-827**: Work graph `RELEASE`/`FEATURE_FLAG` NodeTypes, 4 new EdgeTypes, deterministic ID generators, builder methods, Strawberry GraphQL enum updates
- **CHAOS-828**: Confidence scoring module — `compute_impact_confidence`, `compute_cohort_contamination`, `classify_display_gate`, provenance tiers (1.0/0.8-0.9/0.3)

### Phase 3 — Interpretation Guidance
- **CHAOS-830**: Interpretation guidance docs (`docs/user-guide/feature-flag-impact.md`) — metric catalog, show/warn/suppress gates, language policy

### Test Evidence
- Release impact: 8 tests pass
- Work graph: 55 tests pass (ids, models, builder)
- Confidence: 61 tests pass (scoring, contamination, gates, edge cases)

## Linear
Project: Feature Flag + User Impact Mapping
Closes CHAOS-826 CHAOS-827 CHAOS-828 CHAOS-830