### PR TITLE
feat: Phase 4 — Metric promotion gates, stable registry, rejected metrics docs

### DIFF
--- a/docs/product/feature-flag-metric-promotion.md
+++ b/docs/product/feature-flag-metric-promotion.md
@@ -1,0 +1,253 @@
+# Feature Flag Metric Promotion Gates
+
+_Decision date: 2026-04-15_
+_Tracking: CHAOS-831 (Phase 4: Promotion Gates)_
+_Rejection log: CHAOS-832_
+
+## Purpose
+
+This document defines the acceptance criteria used to evaluate each candidate metric from the [Feature Flag + User Impact PRD](feature-flag-user-impact-prd.md) (lines 229-253). Metrics that pass all gates are promoted to the **stable** registry. Metrics that pass most gates ship as **provisional** (beta). Metrics that fail critical gates are **rejected** with documented rationale.
+
+## Promotion Gates
+
+### Gate 1: Implementability
+
+**Question**: Is the metric fully computed by `release_impact.py` or a companion module?
+
+| Verdict | Criteria |
+|---------|----------|
+| PASS | Metric is computed end-to-end and written to `ReleaseImpactDailyRecord` via ClickHouse sink |
+| PARTIAL | Schema field exists in `ReleaseImpactDailyRecord` but computation returns `None` (stubbed) |
+| FAIL | No schema field, no computation path |
+
+**Evidence source**: `src/dev_health_ops/metrics/release_impact.py`, `src/dev_health_ops/metrics/schemas.py`
+
+### Gate 2: Confidence Floor
+
+**Question**: Can this metric achieve `coverage >= 0.70` (the "show" display gate) in typical deployments?
+
+| Verdict | Criteria |
+|---------|----------|
+| PASS | Min sample is achievable for teams with >= 50 daily sessions; coverage threshold is realistic |
+| WARN | Min sample requires high-traffic environments (>= 1000 events); many teams will see "warn" or "suppress" |
+| FAIL | Min sample is unrealistic for most deployments; metric will almost always be suppressed |
+
+**Reference**: `confidence.py` display gates — show >= 0.70, warn >= 0.50, suppress < 0.50
+
+### Gate 3: Misuse Risk
+
+**Question**: Could this metric be used punitively against individuals?
+
+| Verdict | Criteria |
+|---------|----------|
+| PASS | Metric is scoped to release/environment/team; no individual attribution possible |
+| WARN | Metric could be narrowed to individual via filtering (e.g., single-person team) |
+| FAIL | Metric inherently identifies or ranks individuals |
+
+**Reference**: Platform mission — "accessibility over extraction, learning not judgment"
+
+### Gate 4: Signal Quality
+
+**Question**: Does the metric have a clear, testable denominator? Is `min_sample` achievable?
+
+| Verdict | Criteria |
+|---------|----------|
+| PASS | Denominator is well-defined (session_count, eligible_sessions, etc.), min_sample is documented and testable |
+| WARN | Denominator depends on external data quality (e.g., work graph linkage) |
+| FAIL | No clear denominator or min_sample is undefined |
+
+### Gate 5: Interpretation Clarity
+
+**Question**: Can a non-technical user understand what this metric means from the user guide?
+
+| Verdict | Criteria |
+|---------|----------|
+| PASS | Metric has plain-language description in user guide with approved hedging language |
+| WARN | Metric is documented but requires statistical literacy to interpret |
+| FAIL | No user-facing documentation; metric is internal/diagnostic only |
+
+## Verdict Matrix
+
+Each metric receives a per-gate verdict. The overall promotion decision follows:
+
+| Overall | Rule |
+|---------|------|
+| **PROMOTE** (stable) | All gates PASS, or all PASS with at most one WARN on non-critical gate |
+| **PROVISIONAL** (beta) | Implementability is PARTIAL, or 2+ WARN verdicts, but no FAIL on Gate 3 (misuse) |
+| **REJECT** | Any FAIL on Gate 1 (not implemented at all), Gate 3 (misuse risk), or 3+ FAIL verdicts |
+
+## Evaluation Results
+
+### Release Metrics
+
+#### `release_user_friction_delta` — PROMOTE
+
+| Gate | Verdict | Notes |
+|------|---------|-------|
+| Implementability | PASS | Fully computed via `_compute_delta()` with `friction.%` signal pattern. Written to `release_user_friction_delta` field. |
+| Confidence floor | PASS | Min sample 300 sessions is achievable for teams with moderate traffic. Display gate system handles low-coverage gracefully. |
+| Misuse risk | PASS | Scoped to release × environment. No individual attribution. |
+| Signal quality | PASS | Denominator is `session_count` from `telemetry_signal_bucket`. Min sample (300) is documented and enforced in code (`_MIN_SESSIONS_FRICTION`). |
+| Interpretation clarity | PASS | User guide provides plain-language description with approved hedging ("appears elevated"). |
+
+#### `release_error_rate_delta` — PROMOTE
+
+| Gate | Verdict | Notes |
+|------|---------|-------|
+| Implementability | PASS | Fully computed via `_compute_delta()` with `error.%` signal pattern. Written to `release_error_rate_delta` field. |
+| Confidence floor | WARN | Min sample 1000 events is high; smaller teams may frequently see "suppress" gate. However, the metric degrades gracefully (returns `None` when insufficient). |
+| Misuse risk | PASS | Scoped to release × environment. |
+| Signal quality | PASS | Denominator is `session_count`. Min sample (1000) enforced via `_MIN_EVENTS_ERROR`. |
+| Interpretation clarity | PASS | User guide documents with hedging language ("suggests a potential regression"). |
+
+#### `time_to_first_user_issue_after_release` — PROVISIONAL
+
+| Gate | Verdict | Notes |
+|------|---------|-------|
+| Implementability | PARTIAL | `_time_to_first_friction_spike()` computes time-to-first-friction-signal (telemetry-based proxy), but the PRD specifies time-to-first-*user-reported-issue* via work graph linkage. Current implementation is a telemetry approximation, not the full work-graph-linked version. |
+| Confidence floor | WARN | Requires at least 1 linked issue — many releases will have zero linked issues, producing `None`. |
+| Misuse risk | PASS | Scoped to release × environment. |
+| Signal quality | WARN | Denominator is implicit (1 linked issue). The "linked issue" definition depends on work graph edge quality which varies by provider. |
+| Interpretation clarity | PASS | User guide explains clearly ("hours between deployment and first linked user reported issue"). |
+
+**Condition for promotion**: Implement full work-graph-linked version (issue `created_at` - `deployment.completed_at`) instead of telemetry proxy. Track via CHAOS-832.
+
+#### `release_impact_confidence_score` — PROMOTE
+
+| Gate | Verdict | Notes |
+|------|---------|-------|
+| Implementability | PASS | Fully computed via `_compute_confidence()` with weighted factors (coverage 0.35, sample 0.35, confound 0.30). Also has dedicated `compute_impact_confidence()` in `confidence.py`. |
+| Confidence floor | PASS | Meta-metric — always computable when any release data exists. |
+| Misuse risk | PASS | Diagnostic metric, not a performance indicator. |
+| Signal quality | PASS | Factors are well-defined: coverage_ratio, sample_size, concurrent_deploy_count. |
+| Interpretation clarity | PASS | User guide explains visibility gates (show/warn/suppress). Labeled as "not a business KPI" in PRD. |
+
+#### `release_impact_coverage_ratio` — PROMOTE
+
+| Gate | Verdict | Notes |
+|------|---------|-------|
+| Implementability | PASS | Computed as `releases_with_telemetry / total_releases_on_day` in `_compute_day()`. Written to `coverage_ratio` field. |
+| Confidence floor | PASS | Always computable when deployment data exists. |
+| Misuse risk | PASS | Data quality indicator, no individual attribution. |
+| Signal quality | PASS | Clear denominator (total releases on day). |
+| Interpretation clarity | PASS | Displayed alongside every impact metric per PRD. User guide documents the visibility gate table. |
+
+### Flag Metrics
+
+#### `flag_exposure_rate` — PROVISIONAL
+
+| Gate | Verdict | Notes |
+|------|---------|-------|
+| Implementability | PARTIAL | Schema field exists in `ReleaseImpactDailyRecord` (`flag_exposure_rate`) but computation returns `None`. Requires flag evaluation event ingestion (session-level flag exposure tracking). |
+| Confidence floor | PASS | Min sample 200 eligible sessions is reasonable for flagged features. |
+| Misuse risk | PASS | Scoped to flag × environment. Session-based denominator avoids user identification. |
+| Signal quality | PASS | Denominator (`eligible_sessions`) is well-defined. MVP uses session-based counting. |
+| Interpretation clarity | PASS | User guide explains ("verifies rollout rules are reaching intended audience"). |
+
+**Condition for promotion**: Implement computation from `feature_flag_events` + `telemetry_signal_bucket` join. Track via CHAOS-832.
+
+#### `flag_activation_rate` — PROVISIONAL
+
+| Gate | Verdict | Notes |
+|------|---------|-------|
+| Implementability | PARTIAL | Schema field exists (`flag_activation_rate`) but returns `None`. Requires per-flag success action contract definition. |
+| Confidence floor | PASS | Min sample 100 exposed sessions is achievable. |
+| Misuse risk | PASS | Session-scoped, no individual attribution. |
+| Signal quality | WARN | "Activated" depends on per-flag success action definition — requires configuration contract that doesn't exist yet. |
+| Interpretation clarity | PASS | User guide explains ("measures effectiveness in driving desired user behavior"). |
+
+**Condition for promotion**: Define success action contract in `feature_flag_link` config. Implement computation. Track via CHAOS-832.
+
+#### `flag_reliability_guardrail` — PROVISIONAL
+
+| Gate | Verdict | Notes |
+|------|---------|-------|
+| Implementability | PARTIAL | Schema field exists (`flag_reliability_guardrail`) but returns `None`. Computation requires session-level flag exposure join with error signals. |
+| Confidence floor | PASS | Min sample 300 sessions is reasonable. |
+| Misuse risk | PASS | Guardrail metric, scoped to flag cohort. |
+| Signal quality | PASS | Clear denominator (total_sessions for exposed cohort). Numerator well-defined (zero error/crash signals). |
+| Interpretation clarity | PASS | User guide explains ("safety check ensures flag isn't introducing silent failures"). |
+
+**Condition for promotion**: Implement exposed-cohort error-free session computation. Track via CHAOS-832.
+
+#### `flag_friction_delta` — PROVISIONAL
+
+| Gate | Verdict | Notes |
+|------|---------|-------|
+| Implementability | PARTIAL | Schema field exists (`flag_friction_delta`) but returns `None`. Same formula as release friction delta but scoped to flag exposure window. |
+| Confidence floor | PASS | Min sample 200 sessions is achievable. |
+| Misuse risk | PASS | Scoped to flag × environment. |
+| Signal quality | WARN | Requires session-level flag evaluation signal and contamination exclusion (multiple concurrent flags). Contamination logic exists in `confidence.py` but isn't wired to computation. |
+| Interpretation clarity | PASS | Follows same interpretation pattern as release friction delta. |
+
+**Condition for promotion**: Wire contamination exclusion from `compute_cohort_contamination()`. Implement flag-scoped delta computation. Track via CHAOS-832.
+
+#### `flag_rollout_half_life` — REJECT
+
+| Gate | Verdict | Notes |
+|------|---------|-------|
+| Implementability | PARTIAL | Schema field exists (`flag_rollout_half_life`) but returns `None`. |
+| Confidence floor | WARN | Requires 2 rollout events minimum — many flags use binary toggles with no incremental rollout, producing no data. |
+| Misuse risk | PASS | Operational metric, no individual attribution. |
+| Signal quality | FAIL | Denominator is provider-specific (LaunchDarkly percentage events vs GitLab incremental steps). No unified abstraction exists. Cross-provider comparison is meaningless. |
+| Interpretation clarity | WARN | Requires understanding of provider-specific rollout mechanics. Non-technical users cannot interpret without context. |
+
+**Rejection rationale**: Provider-specific denominator makes cross-provider comparison invalid. Signal quality gate fails — no unified rollout progression abstraction exists. Revisit if a provider-agnostic rollout stage model is designed. Logged in CHAOS-832.
+
+#### `flag_churn_rate` — REJECT
+
+| Gate | Verdict | Notes |
+|------|---------|-------|
+| Implementability | PARTIAL | Schema field exists (`flag_churn_rate`) but returns `None`. |
+| Confidence floor | PASS | No min sample — count-based metric. |
+| Misuse risk | WARN | "Churn rate" framing could be used to pressure teams into fewer flag changes, discouraging safe incremental rollouts. Conflicts with platform mission of "learning, not judgment." |
+| Signal quality | WARN | Denominator (weeks_in_window) is clear, but "toggle" and "rule_change" event types vary significantly across providers. A rule change adding a user segment is not equivalent to a panic toggle-off. |
+| Interpretation clarity | FAIL | "Volatility indicator" is ambiguous — high churn could mean healthy iteration or panic. Without context, this metric invites misinterpretation. No user guide entry exists. |
+
+**Rejection rationale**: Misuse risk (pressuring against flag changes) combined with interpretation ambiguity. The metric conflates healthy iteration with instability. Logged in CHAOS-832.
+
+### Data Quality / Linkage Metrics
+
+#### `issue_to_release_impact_link_rate` — PROVISIONAL
+
+| Gate | Verdict | Notes |
+|------|---------|-------|
+| Implementability | PARTIAL | Schema field exists (`issue_to_release_impact_link_rate`) but returns `None`. Requires work graph edge traversal (issue → PR → deployment → release). |
+| Confidence floor | WARN | Min sample 50 work items over 30 days — achievable for active teams but many smaller teams won't meet threshold. |
+| Misuse risk | PASS | Data quality signal, no individual attribution. |
+| Signal quality | PASS | Denominator (completed work items) is well-defined via existing work-item completion semantics. |
+| Interpretation clarity | PASS | Clear meaning: "what fraction of completed work has measurable post-release signal." |
+
+**Condition for promotion**: Implement work graph traversal computation. Track via CHAOS-832.
+
+#### `rollback_or_disable_after_impact_spike` — PROVISIONAL
+
+| Gate | Verdict | Notes |
+|------|---------|-------|
+| Implementability | PARTIAL | Schema field exists (`rollback_or_disable_after_impact_spike`) but returns `None`. Requires joining flag events (toggle_off, rollback, disable) with deployment timestamps. |
+| Confidence floor | PASS | Count-based, no min sample. |
+| Misuse risk | PASS | Stability response marker, no individual attribution. |
+| Signal quality | WARN | "Impact spike" is not formally defined — the PRD says "no dependency on undefined alert mechanism." Current definition uses temporal correlation only (within 72h of deploy). |
+| Interpretation clarity | PASS | Clear meaning: count of defensive actions after deployment. |
+
+**Condition for promotion**: Implement flag event join with deployment window. Clarify "impact spike" trigger definition. Track via CHAOS-832.
+
+## Summary
+
+| Metric | Verdict | Gate Results |
+|--------|---------|-------------|
+| `release_user_friction_delta` | **PROMOTE** | 5/5 PASS |
+| `release_error_rate_delta` | **PROMOTE** | 4 PASS, 1 WARN |
+| `release_impact_confidence_score` | **PROMOTE** | 5/5 PASS |
+| `release_impact_coverage_ratio` | **PROMOTE** | 5/5 PASS |
+| `time_to_first_user_issue_after_release` | **PROVISIONAL** | 1 PARTIAL, 2 WARN, 2 PASS |
+| `flag_exposure_rate` | **PROVISIONAL** | 1 PARTIAL, 4 PASS |
+| `flag_activation_rate` | **PROVISIONAL** | 1 PARTIAL, 1 WARN, 3 PASS |
+| `flag_reliability_guardrail` | **PROVISIONAL** | 1 PARTIAL, 4 PASS |
+| `flag_friction_delta` | **PROVISIONAL** | 1 PARTIAL, 1 WARN, 3 PASS |
+| `flag_rollout_half_life` | **REJECT** | 1 PARTIAL, 1 FAIL, 2 WARN, 1 PASS |
+| `flag_churn_rate` | **REJECT** | 1 PARTIAL, 1 FAIL, 2 WARN, 1 PASS |
+| `issue_to_release_impact_link_rate` | **PROVISIONAL** | 1 PARTIAL, 1 WARN, 3 PASS |
+| `rollback_or_disable_after_impact_spike` | **PROVISIONAL** | 1 PARTIAL, 1 WARN, 3 PASS |
+
+**Totals**: 4 PROMOTE, 7 PROVISIONAL, 2 REJECT

--- a/docs/product/feature-flag-rejected-metrics.md
+++ b/docs/product/feature-flag-rejected-metrics.md
@@ -1,0 +1,73 @@
+# Rejected and Deferred Metrics: Feature Flag & User Impact
+
+This document outlines the metrics evaluated during the Feature Flag + User Impact initiative that were either rejected for production use or deferred to future phases.
+
+## Rejected Metrics (Do Not Ship)
+
+The following metrics were evaluated but failed to meet the platform's standards for signal quality, privacy, or safety.
+
+### 1. Release Impact by Author
+- **Definition**: Aggregating `release_user_friction_delta` and `release_error_rate_delta` by the primary author of the deployment or associated commits.
+- **Rejection Reason**: High misuse risk (person-to-person ranking).
+- **Misuse Scenario**: Engineering managers using "Impact Scores" in performance reviews, leading to developers avoiding high-risk but necessary changes or "gaming" the metric by splitting risky changes into smaller, unattributed chunks.
+- **Mitigation if Reconsidered**: Aggregate at the Team or Repository level only. Ensure individual attribution is never exposed in the UI or API.
+
+### 2. Unattributed Telemetry Spike Rate
+- **Definition**: The frequency of significant telemetry shifts (friction/errors) that cannot be linked to any release or feature flag within the attribution window.
+- **Rejection Reason**: Low signal quality / Attribution too weak.
+- **Misuse Scenario**: Teams spending hours "debugging the platform" to find a missing link for a spike that was actually caused by an external factor (e.g., a third-party API outage) that the system isn't instrumented to track.
+- **Mitigation if Reconsidered**: Only display when `release_impact_coverage_ratio` is > 90% and concurrent deploy count is zero, providing a "clean room" for attribution.
+
+### 3. Low-Traffic Flag Activation
+- **Definition**: `flag_activation_rate` for flags with fewer than 100 exposed sessions.
+- **Rejection Reason**: Insufficient denominator.
+- **Misuse Scenario**: A product manager sees a 50% activation rate on a new feature and decides to kill the old version, not realizing the 50% represents only 2 out of 4 users.
+- **Mitigation if Reconsidered**: Strict enforcement of `DisplayGate` logic. Suppress any metric where the denominator is below the `min_sample` threshold defined in the PRD.
+
+!!! warning "Privacy Concern"
+    Any metric requiring `unique_user_id` linkage was rejected for Phase 1 to maintain the platform's "pseudonymous by default" stance. User-based metrics are deferred until the User Identity service is fully audited.
+
+## Deferred Metrics (Future Phase)
+
+These metrics are conceptually sound but require infrastructure or data sources not available in the current phase.
+
+### 1. User-Based Exposure Rate
+- **What's missing**: `unique_pseudonymous_count` in telemetry buckets. Current metrics rely on session-based denominators which can overcount repeat users.
+- **Estimated effort**: Medium. Requires telemetry schema updates and processor logic to handle cardinality estimation (e.g., HyperLogLog).
+- **Recommended phase**: Phase 5 (User Identity & Persistence).
+
+### 2. Flag Activation Rate (Full Implementation)
+- **What's missing**: A standardized "success action" contract. Currently, the system doesn't know which telemetry signal constitutes "success" for a specific flag without manual configuration.
+- **Estimated effort**: High. Requires a UI for mapping telemetry events to specific feature flags and a more flexible work graph edge type.
+- **Recommended phase**: Phase 6 (Product Analytics Integration).
+
+### 3. Flag Rollout Half-Life
+- **What's missing**: Ingestion of provider-specific rollout events (e.g., LaunchDarkly percentage changes or GitLab incremental rollout steps).
+- **Estimated effort**: Medium. Requires connector updates for each supported provider to fetch audit logs/events.
+- **Recommended phase**: Phase 5 (Provider Deep Integration).
+
+## Rollout Recommendations
+
+### 1. GA Rollout Plan
+1.  **Internal Dogfooding**: Enable for the `dev-health` development team to monitor our own releases.
+2.  **Private Beta**: Enable for 3-5 high-traffic repositories with mature telemetry instrumentation.
+3.  **General Availability**: Enable for all customers, starting with `release_impact` metrics, followed by `flag_impact` as connectors are configured.
+
+### 2. Feature Flag for the Feature Flags
+Use the existing billing and tiering system to gate these analytics.
+- **Flag**: `billing.release_analytics`
+- **Behavior**: Gates the "Release Impact" and "Flag Insights" tabs in the web UI.
+
+### 3. Data Retention
+To balance analytical depth with storage costs:
+- **Raw Telemetry**: 90 days (allows for recomputation of recent deltas).
+- **Derived Impact Records**: 365 days (allows for year-over-year trend analysis).
+
+### 4. Monitoring during Rollout
+- **Coverage Ratios**: Monitor `release_impact_coverage_ratio` across the fleet. If it stays below 50%, investigate instrumentation gaps.
+- **Confidence Distributions**: Watch for a high percentage of "Heuristic" provenance. This indicates that teams aren't using native linking (tags/PR refs).
+- **User Feedback**: Specifically monitor for "Language Policy" friction—do users find the "appears/suggests" terminology helpful or frustrating?
+
+### 5. Escape Hatches
+- **Global Toggle**: `RELEASE_IMPACT_ENABLED` environment variable to kill all impact processing if ClickHouse load spikes.
+- **Per-Repo Exclusion**: A `disabled_metrics` list in the repository configuration to suppress specific signals that are known to be noisy.

--- a/docs/product/feature-flag-stable-metrics.md
+++ b/docs/product/feature-flag-stable-metrics.md
@@ -1,0 +1,189 @@
+# Feature Flag + User Impact: Stable Metric Registry
+
+_Effective: 2026-04-15_
+_Source: [Promotion Gates](feature-flag-metric-promotion.md) (CHAOS-831)_
+_Rejection log: CHAOS-832_
+
+## Overview
+
+This registry lists all metrics that have passed promotion gates and are approved for production display. Metrics are classified as **stable** (fully validated) or **provisional** (shipping with beta label, pending further validation).
+
+Rejected metrics are documented in the [promotion gates](feature-flag-metric-promotion.md) document and tracked in CHAOS-832.
+
+---
+
+## Stable Metrics
+
+These metrics are fully implemented, have clear denominators, achievable confidence floors, and no misuse risk. They are approved for unconditional display (subject to standard visibility gates).
+
+### `release_user_friction_delta`
+
+| Property | Value |
+|----------|-------|
+| **Label** | Release Friction Delta |
+| **Unit** | ratio (relative change) |
+| **Formula** | `(mean(friction/session, post) - mean(friction/session, baseline)) / mean(friction/session, baseline)` |
+| **Baseline window** | 7 days pre-deploy |
+| **Post window** | 24-72 hours post-deploy |
+| **Min sample** | 300 sessions in both windows |
+| **Denominator** | `session_count` from `telemetry_signal_bucket` |
+| **Display gate** | Standard (show >= 0.70 coverage, warn >= 0.50, suppress < 0.50) |
+| **Companion** | `release_post_friction_rate` (absolute rate) |
+
+**Caveats**: Observational only — does not prove causation. Concurrent deploys dilute attribution (see `concurrent_deploy_count`). Hedging language required in all UX copy.
+
+### `release_error_rate_delta`
+
+| Property | Value |
+|----------|-------|
+| **Label** | Release Error Rate Delta |
+| **Unit** | ratio (relative change) |
+| **Formula** | `(mean(error/session, post) - mean(error/session, baseline)) / mean(error/session, baseline)` |
+| **Baseline window** | 7 days pre-deploy |
+| **Post window** | 24-72 hours post-deploy |
+| **Min sample** | 1000 events across both windows |
+| **Denominator** | `session_count` from `telemetry_signal_bucket` |
+| **Display gate** | Standard |
+| **Companion** | `release_post_error_rate` (absolute rate) |
+
+**Caveats**: Higher min sample means smaller teams will frequently see "warn" or "suppress" gates. This is by design — low-sample error rates are unreliable. Same observational/hedging caveats as friction delta.
+
+### `release_impact_confidence_score`
+
+| Property | Value |
+|----------|-------|
+| **Label** | Impact Confidence Score |
+| **Unit** | 0.0 to 1.0 |
+| **Formula** | `0.35 * coverage_ratio + 0.35 * sample_sufficiency + 0.30 * confounder_penalty` |
+| **Scope** | Per release × environment |
+| **Display** | Accompanies all impact metrics; drives visibility gates |
+
+**Caveats**: Meta-metric, not a business KPI. Weights (0.35/0.35/0.30) were calibrated during prototype phase. Do not use for cross-team comparison.
+
+### `release_impact_coverage_ratio`
+
+| Property | Value |
+|----------|-------|
+| **Label** | Impact Coverage Ratio |
+| **Unit** | 0.0 to 1.0 |
+| **Formula** | `releases_with_telemetry / total_releases_on_day` |
+| **Scope** | Per day × org |
+| **Display** | Shown alongside every impact metric |
+
+**Caveats**: Data quality indicator. Low coverage means telemetry instrumentation is incomplete, not that releases are problematic.
+
+---
+
+## Provisional Metrics (Beta)
+
+These metrics have schema support and clear definitions but are not yet fully computed. They ship with a **beta** label in the UI and are subject to the conditions listed below for promotion to stable.
+
+### `time_to_first_user_issue_after_release`
+
+| Property | Value |
+|----------|-------|
+| **Label** | Time to First User Issue |
+| **Unit** | hours |
+| **Formula** | `min(issue.created_at) - deployment.completed_at` (work-graph-linked issues) |
+| **Min sample** | 1 linked issue |
+| **Current state** | Telemetry proxy implemented (friction spike timing). Full work-graph version pending. |
+| **Promotion condition** | Implement work-graph-linked issue lookup. Validate against 3+ repos with known incident timelines. |
+
+### `flag_exposure_rate`
+
+| Property | Value |
+|----------|-------|
+| **Label** | Flag Exposure Rate |
+| **Unit** | ratio |
+| **Formula** | `exposed_sessions / eligible_sessions` |
+| **Min sample** | 200 eligible sessions |
+| **Current state** | Schema field exists. Computation stubbed (`None`). |
+| **Promotion condition** | Implement computation from flag evaluation events joined with session telemetry. |
+
+### `flag_activation_rate`
+
+| Property | Value |
+|----------|-------|
+| **Label** | Flag Activation Rate |
+| **Unit** | ratio |
+| **Formula** | `activated_sessions / exposed_sessions` |
+| **Min sample** | 100 exposed sessions |
+| **Current state** | Schema field exists. Computation stubbed (`None`). |
+| **Promotion condition** | Define per-flag success action contract in `feature_flag_link` config. Implement computation. |
+
+### `flag_reliability_guardrail`
+
+| Property | Value |
+|----------|-------|
+| **Label** | Flag Reliability Guardrail |
+| **Unit** | ratio |
+| **Formula** | `error_free_sessions / total_sessions` (exposed cohort) |
+| **Min sample** | 300 sessions |
+| **Current state** | Schema field exists. Computation stubbed (`None`). |
+| **Promotion condition** | Implement exposed-cohort error-free session computation from flag evaluation + telemetry join. |
+
+### `flag_friction_delta`
+
+| Property | Value |
+|----------|-------|
+| **Label** | Flag Friction Delta |
+| **Unit** | ratio |
+| **Formula** | Same as `release_user_friction_delta` but scoped to flag exposure window |
+| **Min sample** | 200 sessions |
+| **Current state** | Schema field exists. Computation stubbed (`None`). Contamination logic exists in `confidence.py` but not wired. |
+| **Promotion condition** | Wire `compute_cohort_contamination()` to exclude multi-flag sessions. Implement flag-scoped delta. |
+
+### `issue_to_release_impact_link_rate`
+
+| Property | Value |
+|----------|-------|
+| **Label** | Issue-to-Release Link Rate |
+| **Unit** | 0.0 to 1.0 |
+| **Formula** | `completed_items_with_coverage / completed_items` (rolling 30d) |
+| **Min sample** | 50 work items |
+| **Current state** | Schema field exists. Computation stubbed (`None`). |
+| **Promotion condition** | Implement work graph edge traversal (issue → PR → deployment → release). |
+
+### `rollback_or_disable_after_impact_spike`
+
+| Property | Value |
+|----------|-------|
+| **Label** | Rollback/Disable After Impact |
+| **Unit** | count |
+| **Formula** | Count of flag disable/rollback events within 72h of deploy |
+| **Current state** | Schema field exists. Computation stubbed (`None`). |
+| **Promotion condition** | Implement flag event join with deployment window. Clarify "impact spike" trigger definition. |
+
+---
+
+## Rejected Metrics
+
+The following metrics failed critical promotion gates and are **not shipped**. See [promotion gates](feature-flag-metric-promotion.md) for full rationale.
+
+| Metric | Rejection Reason |
+|--------|-----------------|
+| `flag_rollout_half_life` | Provider-specific denominator (LaunchDarkly vs GitLab rollout mechanics) makes cross-provider comparison invalid. No unified rollout stage abstraction exists. |
+| `flag_churn_rate` | Misuse risk — "volatility" framing pressures against healthy flag iteration. Interpretation ambiguity — high churn conflates healthy iteration with instability. No user guide entry. |
+
+Rejected metrics are tracked in CHAOS-832 for potential future reconsideration if underlying issues are resolved.
+
+---
+
+## Display Contract
+
+All metrics in this registry follow the standard visibility gate system:
+
+| Coverage | Gate | UX Behavior |
+|----------|------|-------------|
+| >= 0.70 | `show` | Metric displayed normally |
+| 0.50 - 0.69 | `warn` | Metric shown with warning icon and data quality note |
+| < 0.50 | `suppress` | Metric hidden; "insufficient data" placeholder shown |
+
+Provisional metrics additionally display a **beta** badge and tooltip explaining the metric is under validation.
+
+## Language Policy
+
+All metric labels and descriptions in the UI must use approved hedging language:
+
+- **Allowed**: appears, suggests, leans, is consistent with
+- **Forbidden**: caused, proved, determined, is/was (when stating impact), detected


### PR DESCRIPTION
## Summary

Final phase of the Feature Flag + User Impact Mapping initiative — productization decision artifacts.

### CHAOS-831: Promotion Gates + Stable Metric Selection
- Created `docs/product/feature-flag-metric-promotion.md` — 5 promotion gates (implementability, confidence floor, misuse risk, signal quality, interpretation clarity)
- Created `docs/product/feature-flag-stable-metrics.md` — stable registry with verdicts:
  - **4 PROMOTE**: friction delta, error delta, confidence score, coverage ratio
  - **7 PROVISIONAL**: flag exposure/activation/reliability/friction, rollback count, link rate, missing fields
  - **2 REJECT**: flag_rollout_half_life (provider-specific denominator), flag_churn_rate (misuse risk)

### CHAOS-832: Rejected Metrics + Rollout Recommendations
- Created `docs/product/feature-flag-rejected-metrics.md` — rejection rationale, misuse scenarios, deferred metrics, GA rollout plan, data retention, monitoring, escape hatches

## Linear
Project: Feature Flag + User Impact Mapping
Closes CHAOS-831 CHAOS-832