### PR TITLE
feat(CHAOS-1208): add admin PATCH endpoint for feature flag properties

### DIFF
--- a/src/dev_health_ops/api/admin/routers/features.py
+++ b/src/dev_health_ops/api/admin/routers/features.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from dev_health_ops.api.admin.middleware import require_superuser
 from dev_health_ops.api.admin.schemas import (
     FeatureFlagResponse,
+    FeatureFlagUpdateRequest,
     FeatureOverrideCreate,
     FeatureOverrideResponse,
 )
@@ -154,3 +155,46 @@ async def delete_feature_override(
 
     await session.delete(override)
     await session.flush()
+
+
+@router.patch("/feature-flags/{flag_id}", response_model=FeatureFlagResponse)
+async def update_feature_flag(
+    flag_id: str,
+    payload: FeatureFlagUpdateRequest,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(require_superuser),
+) -> FeatureFlagResponse:
+    """Update patchable properties of a feature flag.
+
+    Only is_enabled, is_beta, and is_deprecated may be updated.
+    name, key, min_tier, and category are immutable via this endpoint.
+    """
+    flag_uuid = uuid.UUID(flag_id)
+    result = await session.execute(
+        select(FeatureFlag).where(FeatureFlag.id == flag_uuid)
+    )
+    flag = result.scalar_one_or_none()
+    if flag is None:
+        raise HTTPException(status_code=404, detail="Feature flag not found")
+
+    if payload.is_enabled is not None:
+        flag.is_enabled = payload.is_enabled
+    if payload.is_beta is not None:
+        flag.is_beta = payload.is_beta
+    if payload.is_deprecated is not None:
+        flag.is_deprecated = payload.is_deprecated
+
+    await session.flush()
+
+    return FeatureFlagResponse(
+        id=str(flag.id),
+        key=flag.key,
+        name=flag.name,
+        description=flag.description,
+        category=flag.category,
+        min_tier=flag.min_tier,
+        is_enabled=bool(flag.is_enabled),
+        is_beta=bool(flag.is_beta),
+        is_deprecated=bool(flag.is_deprecated),
+        created_at=flag.created_at,
+    )

--- a/src/dev_health_ops/api/admin/schemas.py
+++ b/src/dev_health_ops/api/admin/schemas.py
@@ -559,6 +559,18 @@ class FeatureFlagResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class FeatureFlagUpdateRequest(BaseModel):
+    """Patchable fields for a FeatureFlag row.
+
+    Only is_enabled, is_beta, and is_deprecated may be updated here.
+    key, name, min_tier, and category are immutable via this endpoint.
+    """
+
+    is_enabled: bool | None = None
+    is_beta: bool | None = None
+    is_deprecated: bool | None = None
+
+
 class FeatureOverrideCreate(BaseModel):
     feature_id: str
     is_enabled: bool = True

--- a/tests/api/admin/test_feature_flag_crud.py
+++ b/tests/api/admin/test_feature_flag_crud.py
@@ -33,7 +33,7 @@ _features_router = _features_router_module.router
 _common_module = importlib.import_module("dev_health_ops.api.admin.routers.common")
 _get_session = _common_module.get_session
 
-_middleware_module = importlib.import_module("dev_health_ops.api.admin.middleware")
+_unused_middleware_module = importlib.import_module("dev_health_ops.api.admin.middleware")
 
 
 def _build_user(*, superuser: bool) -> AuthenticatedUser:

--- a/tests/api/admin/test_feature_flag_crud.py
+++ b/tests/api/admin/test_feature_flag_crud.py
@@ -5,6 +5,7 @@ Verifies:
 - 403 when non-superuser attempts to patch
 - Individual field updates (only is_enabled, only is_beta, only is_deprecated)
 """
+
 from __future__ import annotations
 
 import importlib
@@ -21,7 +22,6 @@ from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.licensing import FeatureFlag
 
-
 _TABLES = [FeatureFlag.__table__]
 
 # Import the actual module (not the re-exported router object)
@@ -30,9 +30,7 @@ _features_router_module = importlib.import_module(
 )
 _features_router = _features_router_module.router
 
-_common_module = importlib.import_module(
-    "dev_health_ops.api.admin.routers.common"
-)
+_common_module = importlib.import_module("dev_health_ops.api.admin.routers.common")
 _get_session = _common_module.get_session
 
 _middleware_module = importlib.import_module("dev_health_ops.api.admin.middleware")
@@ -151,7 +149,7 @@ async def test_patch_only_is_enabled(session_maker, seeded_flag):
     assert response.status_code == 200
     data = response.json()
     assert data["is_enabled"] is False
-    assert data["is_beta"] is False      # unchanged from seed
+    assert data["is_beta"] is False  # unchanged from seed
     assert data["is_deprecated"] is False  # unchanged from seed
 
 
@@ -169,7 +167,7 @@ async def test_patch_only_is_beta(session_maker, seeded_flag):
 
     assert response.status_code == 200
     data = response.json()
-    assert data["is_enabled"] is True    # unchanged from seed
+    assert data["is_enabled"] is True  # unchanged from seed
     assert data["is_beta"] is True
     assert data["is_deprecated"] is False  # unchanged from seed
 
@@ -188,8 +186,8 @@ async def test_patch_only_is_deprecated(session_maker, seeded_flag):
 
     assert response.status_code == 200
     data = response.json()
-    assert data["is_enabled"] is True    # unchanged from seed
-    assert data["is_beta"] is False      # unchanged from seed
+    assert data["is_enabled"] is True  # unchanged from seed
+    assert data["is_beta"] is False  # unchanged from seed
     assert data["is_deprecated"] is True
 
 

--- a/tests/api/admin/test_feature_flag_crud.py
+++ b/tests/api/admin/test_feature_flag_crud.py
@@ -1,0 +1,209 @@
+"""Tests for CHAOS-1208: admin PATCH endpoint for feature flag properties.
+
+Verifies:
+- 200 when superuser patches a flag (full and partial updates)
+- 403 when non-superuser attempts to patch
+- Individual field updates (only is_enabled, only is_beta, only is_deprecated)
+"""
+from __future__ import annotations
+
+import importlib
+import uuid
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.auth.router import get_current_user
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.licensing import FeatureFlag
+
+
+_TABLES = [FeatureFlag.__table__]
+
+# Import the actual module (not the re-exported router object)
+_features_router_module = importlib.import_module(
+    "dev_health_ops.api.admin.routers.features"
+)
+_features_router = _features_router_module.router
+
+_common_module = importlib.import_module(
+    "dev_health_ops.api.admin.routers.common"
+)
+_get_session = _common_module.get_session
+
+_middleware_module = importlib.import_module("dev_health_ops.api.admin.middleware")
+
+
+def _build_user(*, superuser: bool) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        email="admin@example.com",
+        org_id=str(uuid.uuid4()),
+        role="owner",
+        is_superuser=superuser,
+    )
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path):
+    db_path = tmp_path / "feature-flag-crud.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_flag(session_maker):
+    flag = FeatureFlag(
+        key="test_feature",
+        name="Test Feature",
+        description="A test feature flag",
+        is_enabled=True,
+        is_beta=False,
+        is_deprecated=False,
+    )
+    async with session_maker() as session:
+        session.add(flag)
+        await session.commit()
+        flag_id = str(flag.id)
+    return flag_id
+
+
+def _make_app(session_maker, override_user):
+    app = FastAPI()
+    app.include_router(_features_router, prefix="/api/v1/admin")
+
+    async def _session_override():
+        async with session_maker() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    app.dependency_overrides[get_current_user] = lambda: override_user
+    app.dependency_overrides[_get_session] = _session_override
+    return app
+
+
+@pytest.mark.asyncio
+async def test_superuser_patch_flag_returns_200(session_maker, seeded_flag):
+    """Superuser can patch all three fields at once."""
+    app = _make_app(session_maker, _build_user(superuser=True))
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            f"/api/v1/admin/feature-flags/{seeded_flag}",
+            json={"is_enabled": False, "is_beta": True, "is_deprecated": True},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_enabled"] is False
+    assert data["is_beta"] is True
+    assert data["is_deprecated"] is True
+    assert data["id"] == seeded_flag
+    assert data["key"] == "test_feature"
+
+
+@pytest.mark.asyncio
+async def test_non_superuser_patch_flag_returns_403(session_maker, seeded_flag):
+    """Non-superuser (org admin) cannot patch feature flags."""
+    app = _make_app(session_maker, _build_user(superuser=False))
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            f"/api/v1/admin/feature-flags/{seeded_flag}",
+            json={"is_enabled": False},
+        )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_patch_only_is_enabled(session_maker, seeded_flag):
+    """Patching only is_enabled leaves is_beta and is_deprecated unchanged."""
+    app = _make_app(session_maker, _build_user(superuser=True))
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            f"/api/v1/admin/feature-flags/{seeded_flag}",
+            json={"is_enabled": False},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_enabled"] is False
+    assert data["is_beta"] is False      # unchanged from seed
+    assert data["is_deprecated"] is False  # unchanged from seed
+
+
+@pytest.mark.asyncio
+async def test_patch_only_is_beta(session_maker, seeded_flag):
+    """Patching only is_beta leaves is_enabled and is_deprecated unchanged."""
+    app = _make_app(session_maker, _build_user(superuser=True))
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            f"/api/v1/admin/feature-flags/{seeded_flag}",
+            json={"is_beta": True},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_enabled"] is True    # unchanged from seed
+    assert data["is_beta"] is True
+    assert data["is_deprecated"] is False  # unchanged from seed
+
+
+@pytest.mark.asyncio
+async def test_patch_only_is_deprecated(session_maker, seeded_flag):
+    """Patching only is_deprecated leaves is_enabled and is_beta unchanged."""
+    app = _make_app(session_maker, _build_user(superuser=True))
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            f"/api/v1/admin/feature-flags/{seeded_flag}",
+            json={"is_deprecated": True},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_enabled"] is True    # unchanged from seed
+    assert data["is_beta"] is False      # unchanged from seed
+    assert data["is_deprecated"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_nonexistent_flag_returns_404(session_maker):
+    """Patching a flag that does not exist returns 404."""
+    app = _make_app(session_maker, _build_user(superuser=True))
+    transport = ASGITransport(app=app)
+    nonexistent_id = str(uuid.uuid4())
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            f"/api/v1/admin/feature-flags/{nonexistent_id}",
+            json={"is_enabled": False},
+        )
+
+    assert response.status_code == 404

--- a/tests/api/admin/test_feature_flag_crud.py
+++ b/tests/api/admin/test_feature_flag_crud.py
@@ -33,7 +33,9 @@ _features_router = _features_router_module.router
 _common_module = importlib.import_module("dev_health_ops.api.admin.routers.common")
 _get_session = _common_module.get_session
 
-_unused_middleware_module = importlib.import_module("dev_health_ops.api.admin.middleware")
+_unused_middleware_module = importlib.import_module(
+    "dev_health_ops.api.admin.middleware"
+)
 
 
 def _build_user(*, superuser: bool) -> AuthenticatedUser:


### PR DESCRIPTION
## Summary

- Adds `PATCH /api/v1/admin/feature-flags/{flag_id}` — superadmin endpoint to toggle `is_enabled`, `is_beta`, `is_deprecated` on `FeatureFlag` rows
- Adds `FeatureFlagUpdateRequest` Pydantic schema (three `Optional[bool]` fields)
- Immutable fields (`name`, `key`, `min_tier`, `category`) are not patchable here
- Uses same `require_superuser` guard as all other admin endpoints in this file

## Files changed

- `src/dev_health_ops/api/admin/schemas.py` — adds `FeatureFlagUpdateRequest`
- `src/dev_health_ops/api/admin/routers/features.py` — adds `PATCH /feature-flags/{flag_id}` endpoint
- `tests/api/admin/test_feature_flag_crud.py` — 6 new tests

## Test plan

- [x] `pytest tests/api/admin/test_feature_flag_crud.py` — all 6 pass
  - [x] 200 superuser patches all three fields
  - [x] 403 non-superuser rejected
  - [x] Patch only `is_enabled` (other fields unchanged)
  - [x] Patch only `is_beta` (other fields unchanged)
  - [x] Patch only `is_deprecated` (other fields unchanged)
  - [x] 404 for nonexistent flag

Closes CHAOS-1208

Design spec: https://github.com/full-chaos/dev-health-ops/blob/chore/chaos-1203-spec/ops/docs/superpowers/specs/2026-04-15-chaos-1203-feature-flag-billing-reconcile-design.md

SCREENSHOT-WAIVER: backend-only admin endpoint, no frontend rendering impact