### PR TITLE
feat(CHAOS-1207): bridge plan subscription to org feature enablement

### DIFF
--- a/src/dev_health_ops/api/billing/subscription_service.py
+++ b/src/dev_health_ops/api/billing/subscription_service.py
@@ -13,6 +13,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
+# Terminal subscription statuses that indicate the subscription is no longer active.
+_CANCELLED_STATUSES: frozenset[str] = frozenset({"canceled", "incomplete_expired"})
+
 
 async def has_had_trial(org_id: str | uuid.UUID, session: AsyncSession) -> bool:
     """Check if an org has ever had a trial subscription."""
@@ -101,6 +104,9 @@ class SubscriptionService:
         existing.trial_end = self._to_dt(getattr(stripe_sub, "trial_end", None), True)
         existing.metadata_ = self._as_dict(getattr(stripe_sub, "metadata", {}))
         existing.updated_at = datetime.now(timezone.utc)
+
+        # Bridge: sync OrgLicense from plan feature bundles within the same transaction.
+        await self._sync_org_license(existing)
 
         await self.db.flush()
         return existing
@@ -293,6 +299,148 @@ class SubscriptionService:
             select(BillingPrice).where(stripe_id_field == stripe_price_id)
         )
         return result.scalar_one_or_none()
+
+    async def _sync_org_license(self, subscription: Any) -> None:
+        """Upsert OrgLicense from the plan's feature bundles.
+
+        Called inside ``upsert_from_stripe``; runs in the same transaction so that
+        Subscription + OrgLicense are committed atomically.  If anything goes wrong
+        we log and re-raise so the caller's flush/commit fails, rolling back both.
+        """
+        try:
+            billing_module = importlib.import_module("dev_health_ops.models.billing")
+            licensing_module = importlib.import_module("dev_health_ops.models.licensing")
+        except ImportError:
+            logger.warning(
+                "billing/licensing modules not available; skipping org-license sync"
+            )
+            return
+
+        BillingPlan = getattr(billing_module, "BillingPlan", None)
+        PlanFeatureBundle = getattr(billing_module, "PlanFeatureBundle", None)
+        FeatureBundle = getattr(billing_module, "FeatureBundle", None)
+        OrgLicense = getattr(licensing_module, "OrgLicense", None)
+
+        if None in (BillingPlan, PlanFeatureBundle, FeatureBundle, OrgLicense):
+            logger.warning(
+                "Required model classes missing from billing/licensing; skipping sync"
+            )
+            return
+
+        org_id: uuid.UUID = subscription.org_id
+        billing_plan_id = subscription.billing_plan_id
+        status: str = str(getattr(subscription, "status", "active") or "active")
+        current_period_end = getattr(subscription, "current_period_end", None)
+
+        # --- Determine tier and feature set ---
+        is_cancelled = status in _CANCELLED_STATUSES
+
+        if is_cancelled:
+            tier_str = "community"
+            feature_keys: list[str] = []
+            expires_at = None
+        else:
+            # Load the BillingPlan.
+            plan_result = await self.db.execute(
+                select(BillingPlan).where(BillingPlan.id == billing_plan_id)
+            )
+            plan = plan_result.scalar_one_or_none()
+            if plan is None:
+                logger.warning(
+                    "BillingPlan %s not found for subscription org_id=%s; "
+                    "skipping org-license sync",
+                    billing_plan_id,
+                    org_id,
+                )
+                return
+
+            tier_str = str(plan.tier or "community")
+
+            # Resolve all FeatureBundle rows for this plan.
+            bundle_rows_result = await self.db.execute(
+                select(FeatureBundle)
+                .join(
+                    PlanFeatureBundle,
+                    PlanFeatureBundle.bundle_id == FeatureBundle.id,
+                )
+                .where(PlanFeatureBundle.plan_id == billing_plan_id)
+            )
+            bundles = list(bundle_rows_result.scalars().all())
+
+            # Flatten and deduplicate feature keys, validating against registry.
+            known_keys = self._known_feature_keys()
+            raw_keys: set[str] = set()
+            for bundle in bundles:
+                bundle_features = bundle.features or []
+                if isinstance(bundle_features, dict):
+                    bundle_features = list(bundle_features.keys())
+                for key in bundle_features:
+                    key_str = str(key)
+                    if key_str not in known_keys:
+                        logger.warning(
+                            "Bundle %s references unknown feature key %r; "
+                            "skipping key (CHAOS-1207 defensive mode)",
+                            bundle.key,
+                            key_str,
+                        )
+                        continue
+                    raw_keys.add(key_str)
+
+            feature_keys = sorted(raw_keys)
+            expires_at = current_period_end
+
+        # --- Upsert OrgLicense (keyed on org_id — one license per org) ---
+        existing_result = await self.db.execute(
+            select(OrgLicense).where(OrgLicense.org_id == org_id)
+        )
+        org_license = existing_result.scalar_one_or_none()
+
+        customer_id = str(getattr(subscription, "stripe_customer_id", "") or "")
+
+        if org_license is None:
+            org_license = OrgLicense(
+                org_id=org_id,
+                tier=tier_str,
+                license_type="saas",
+                features_override=feature_keys,
+                expires_at=expires_at,
+                customer_id=customer_id or None,
+            )
+            self.db.add(org_license)
+        else:
+            org_license.tier = tier_str
+            org_license.features_override = feature_keys
+            org_license.expires_at = expires_at
+            org_license.is_valid = not is_cancelled
+            org_license.updated_at = datetime.now(timezone.utc)
+            if customer_id:
+                org_license.customer_id = customer_id
+
+        logger.info(
+            "OrgLicense synced: org_id=%s tier=%s features=%d cancelled=%s",
+            org_id,
+            tier_str,
+            len(feature_keys),
+            is_cancelled,
+        )
+
+    @staticmethod
+    def _known_feature_keys() -> frozenset[str]:
+        """Return the canonical feature key set from STANDARD_FEATURES registry.
+
+        Returns an empty frozenset if the registry is unavailable (fail-open).
+        """
+        try:
+            licensing_module = importlib.import_module("dev_health_ops.models.licensing")
+            standard_features = getattr(licensing_module, "STANDARD_FEATURES", None)
+            if standard_features is None:
+                return frozenset()
+            return frozenset(entry[0] for entry in standard_features)
+        except Exception:
+            logger.warning(
+                "Could not load STANDARD_FEATURES registry for key validation"
+            )
+            return frozenset()
 
     @staticmethod
     def _extract_stripe_price_id(stripe_sub: Any) -> str | None:

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -790,3 +790,396 @@ def test_get_tier_price_id():
         reset_price_tier_map()
         assert get_tier_price_id(LicenseTier.TEAM) == "price_t"
         assert get_tier_price_id(LicenseTier.ENTERPRISE) is None
+
+
+# ---------------------------------------------------------------------------
+# G4 (CHAOS-1207) — Bridge: plan subscription → org feature enablement
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def bridge_db(tmp_path):
+    """SQLite in-memory DB with all billing + licensing tables for bridge tests."""
+    from datetime import datetime, timezone
+
+    import sqlalchemy as sa
+    from sqlalchemy import event as sa_event
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    from dev_health_ops.models.billing import BillingPlan, BillingPrice, FeatureBundle, PlanFeatureBundle
+    from dev_health_ops.models.git import Base
+    from dev_health_ops.models.licensing import OrgLicense
+    from dev_health_ops.models.subscriptions import Subscription, SubscriptionEvent
+    from dev_health_ops.models.users import Organization
+
+    db_path = tmp_path / "bridge.db"
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+    )
+
+    @sa_event.listens_for(engine.sync_engine, "connect")
+    def _set_fk(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+        # SQLite doesn't have now(); register it so server_default=sa.text("now()") works.
+        dbapi_conn.create_function(
+            "now",
+            0,
+            lambda: datetime.now(timezone.utc).isoformat(sep=" "),
+        )
+
+    _tables = [
+        Organization.__table__,
+        BillingPlan.__table__,
+        BillingPrice.__table__,
+        FeatureBundle.__table__,
+        PlanFeatureBundle.__table__,
+        Subscription.__table__,
+        SubscriptionEvent.__table__,
+        OrgLicense.__table__,
+    ]
+
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=_tables))
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def _seed_enterprise_plan(session, plan_id, price_id, bundle_id):
+    """Insert an enterprise BillingPlan with a FeatureBundle into the DB."""
+    import uuid
+    from datetime import datetime, timezone
+
+    from dev_health_ops.models.billing import BillingPlan, BillingPrice, FeatureBundle, PlanFeatureBundle
+
+    now = datetime.now(timezone.utc)
+    plan = BillingPlan(
+        id=plan_id,
+        key="enterprise-monthly",
+        name="Enterprise Monthly",
+        tier="enterprise",
+        created_at=now,
+        updated_at=now,
+    )
+    price = BillingPrice(
+        id=price_id,
+        plan_id=plan_id,
+        interval="monthly",
+        amount=49900,
+        created_at=now,
+        updated_at=now,
+    )
+    bundle = FeatureBundle(
+        id=bundle_id,
+        key="enterprise-core",
+        name="Enterprise Core",
+        features=["sso_saml", "audit_log", "ip_allowlist"],
+        created_at=now,
+        updated_at=now,
+    )
+    pfb = PlanFeatureBundle(
+        id=uuid.uuid4(),
+        plan_id=plan_id,
+        bundle_id=bundle_id,
+    )
+    session.add_all([plan, price, bundle, pfb])
+    await session.commit()
+
+
+def _make_stripe_sub(
+    sub_id: str,
+    stripe_price_id: str,
+    org_id,
+    status: str = "active",
+    current_period_end: float = 2_000_000_000.0,
+    customer: str = "cus_test",
+):
+    """Build a minimal Stripe subscription SimpleNamespace."""
+    from types import SimpleNamespace
+
+    price_ns = SimpleNamespace(id=stripe_price_id)
+    item_ns = SimpleNamespace(price=price_ns)
+    items_ns = SimpleNamespace(data=[item_ns])
+    return SimpleNamespace(
+        id=sub_id,
+        customer=customer,
+        status=status,
+        metadata={"org_id": str(org_id)},
+        current_period_start=1_700_000_000.0,
+        current_period_end=current_period_end,
+        cancel_at_period_end=False,
+        canceled_at=None,
+        trial_start=None,
+        trial_end=None,
+        items=items_ns,
+    )
+
+
+@pytest.mark.asyncio
+async def test_subscription_creates_org_license(bridge_db):
+    """Enterprise subscription creates OrgLicense with enterprise tier + plan features."""
+    import uuid
+
+    from sqlalchemy import select
+
+    from dev_health_ops.api.billing.subscription_service import SubscriptionService
+    from dev_health_ops.models.licensing import OrgLicense
+
+    org_id = uuid.uuid4()
+    plan_id = uuid.uuid4()
+    price_id = uuid.uuid4()
+    bundle_id = uuid.uuid4()
+    stripe_price_id = "price_enterprise_monthly"
+
+    async with bridge_db() as session:
+        from sqlalchemy import select as sa_select
+
+        from dev_health_ops.models.billing import BillingPrice
+        from dev_health_ops.models.users import Organization
+
+        await _seed_enterprise_plan(session, plan_id, price_id, bundle_id)
+
+        # Update stripe_price_id on the BillingPrice row.
+        price_row = (await session.execute(sa_select(BillingPrice).where(BillingPrice.id == price_id))).scalar_one()
+        price_row.stripe_price_id = stripe_price_id
+        await session.commit()
+
+        # Insert a minimal Organization row (needed for FK).
+        org = Organization(id=org_id, slug=f"acme-corp-{org_id.hex[:8]}", name="Acme Corp")
+        session.add(org)
+        await session.commit()
+
+    stripe_sub = _make_stripe_sub("sub_new_1", stripe_price_id, org_id)
+
+    async with bridge_db() as session:
+        svc = SubscriptionService(session)
+        await svc.upsert_from_stripe(stripe_sub, org_id)
+        await session.commit()
+
+    async with bridge_db() as session:
+        lic = (await session.execute(select(OrgLicense).where(OrgLicense.org_id == org_id))).scalar_one_or_none()
+        assert lic is not None, "OrgLicense must be created after subscription upsert"
+        assert lic.tier == "enterprise"
+        features = lic.features_override
+        assert isinstance(features, list)
+        assert "sso_saml" in features
+        assert "audit_log" in features
+        assert "ip_allowlist" in features
+
+
+@pytest.mark.asyncio
+async def test_subscription_update_does_not_duplicate_license(bridge_db):
+    """Upserting an existing subscription updates OrgLicense without duplicating."""
+    import uuid
+
+    from sqlalchemy import select
+
+    from dev_health_ops.api.billing.subscription_service import SubscriptionService
+    from dev_health_ops.models.licensing import OrgLicense
+
+    org_id = uuid.uuid4()
+    plan_id = uuid.uuid4()
+    price_id = uuid.uuid4()
+    bundle_id = uuid.uuid4()
+    stripe_price_id = "price_ent_upd"
+    stripe_sub_id = "sub_upd_1"
+
+    async with bridge_db() as session:
+        from sqlalchemy import select as sa_select
+
+        from dev_health_ops.models.billing import BillingPrice
+        from dev_health_ops.models.users import Organization
+
+        await _seed_enterprise_plan(session, plan_id, price_id, bundle_id)
+        price_row = (await session.execute(sa_select(BillingPrice).where(BillingPrice.id == price_id))).scalar_one()
+        price_row.stripe_price_id = stripe_price_id
+        await session.commit()
+
+        org = Organization(id=org_id, slug=f"acme-corp-2-{org_id.hex[:8]}", name="Acme Corp 2")
+        session.add(org)
+        await session.commit()
+
+    # First upsert — creates.
+    stripe_sub = _make_stripe_sub(stripe_sub_id, stripe_price_id, org_id)
+    async with bridge_db() as session:
+        svc = SubscriptionService(session)
+        await svc.upsert_from_stripe(stripe_sub, org_id)
+        await session.commit()
+
+    # Second upsert with updated period — must update, not duplicate.
+    stripe_sub2 = _make_stripe_sub(stripe_sub_id, stripe_price_id, org_id, current_period_end=2_100_000_000.0)
+    async with bridge_db() as session:
+        svc = SubscriptionService(session)
+        await svc.upsert_from_stripe(stripe_sub2, org_id)
+        await session.commit()
+
+    async with bridge_db() as session:
+        rows = (await session.execute(select(OrgLicense).where(OrgLicense.org_id == org_id))).scalars().all()
+        assert len(rows) == 1, "Upsert must not duplicate OrgLicense rows"
+        assert rows[0].tier == "enterprise"
+
+
+@pytest.mark.asyncio
+async def test_subscription_cancellation_downgrades_license(bridge_db):
+    """Cancelled subscription downgrades OrgLicense to community; row survives."""
+    import uuid
+
+    from sqlalchemy import select
+
+    from dev_health_ops.api.billing.subscription_service import SubscriptionService
+    from dev_health_ops.models.licensing import OrgLicense
+
+    org_id = uuid.uuid4()
+    plan_id = uuid.uuid4()
+    price_id = uuid.uuid4()
+    bundle_id = uuid.uuid4()
+    stripe_price_id = "price_ent_cancel"
+    stripe_sub_id = "sub_cancel_1"
+
+    async with bridge_db() as session:
+        from sqlalchemy import select as sa_select
+
+        from dev_health_ops.models.billing import BillingPrice
+        from dev_health_ops.models.users import Organization
+
+        await _seed_enterprise_plan(session, plan_id, price_id, bundle_id)
+        price_row = (await session.execute(sa_select(BillingPrice).where(BillingPrice.id == price_id))).scalar_one()
+        price_row.stripe_price_id = stripe_price_id
+        await session.commit()
+
+        org = Organization(id=org_id, slug=f"cancelling-corp-{org_id.hex[:8]}", name="Cancelling Corp")
+        session.add(org)
+        await session.commit()
+
+    # Active subscription first.
+    stripe_sub = _make_stripe_sub(stripe_sub_id, stripe_price_id, org_id)
+    async with bridge_db() as session:
+        svc = SubscriptionService(session)
+        await svc.upsert_from_stripe(stripe_sub, org_id)
+        await session.commit()
+
+    # Cancel the subscription.
+    stripe_cancelled = _make_stripe_sub(stripe_sub_id, stripe_price_id, org_id, status="canceled")
+    async with bridge_db() as session:
+        svc = SubscriptionService(session)
+        await svc.upsert_from_stripe(stripe_cancelled, org_id)
+        await session.commit()
+
+    async with bridge_db() as session:
+        lic = (await session.execute(select(OrgLicense).where(OrgLicense.org_id == org_id))).scalar_one_or_none()
+        assert lic is not None, "OrgLicense row must survive cancellation (audit trail)"
+        assert lic.tier == "community", "Cancelled subscription must downgrade to community"
+        assert lic.is_valid is False, "Cancelled OrgLicense must be marked invalid"
+        assert lic.features_override == [], "No features for community downgrade"
+
+
+@pytest.mark.asyncio
+async def test_bridge_skips_unknown_keys(bridge_db, caplog):
+    """Bundle with an unknown feature key logs a warning but does not raise."""
+    import logging
+    import uuid
+
+    from dev_health_ops.api.billing.subscription_service import SubscriptionService
+
+    org_id = uuid.uuid4()
+    plan_id = uuid.uuid4()
+    price_id = uuid.uuid4()
+    bundle_id = uuid.uuid4()
+    stripe_price_id = "price_unknown_keys"
+
+    async with bridge_db() as session:
+        from datetime import datetime, timezone
+
+        from sqlalchemy import select as sa_select
+
+        from dev_health_ops.models.billing import BillingPlan, BillingPrice, FeatureBundle, PlanFeatureBundle
+        from dev_health_ops.models.users import Organization
+
+        now = datetime.now(timezone.utc)
+        plan = BillingPlan(id=plan_id, key="team-monthly", name="Team Monthly", tier="team", created_at=now, updated_at=now)
+        price = BillingPrice(id=price_id, plan_id=plan_id, interval="monthly", amount=2900, stripe_price_id=stripe_price_id, created_at=now, updated_at=now)
+        # Bundle with one valid key and one bogus key.
+        bundle = FeatureBundle(id=bundle_id, key="team-core", name="Team Core", features=["api_access", "totally_unknown_feature_xyz"], created_at=now, updated_at=now)
+        pfb = PlanFeatureBundle(id=uuid.uuid4(), plan_id=plan_id, bundle_id=bundle_id)
+        org = Organization(id=org_id, slug=f"bad-bundle-{org_id.hex[:8]}", name="Bad Bundle Corp")
+        session.add_all([plan, price, bundle, pfb, org])
+        await session.commit()
+
+    stripe_sub = _make_stripe_sub("sub_unk_1", stripe_price_id, org_id)
+
+    with caplog.at_level(logging.WARNING, logger="dev_health_ops.api.billing.subscription_service"):
+        async with bridge_db() as session:
+            svc = SubscriptionService(session)
+            # Must not raise.
+            await svc.upsert_from_stripe(stripe_sub, org_id)
+            await session.commit()
+
+    assert any("unknown feature key" in r.message for r in caplog.records), (
+        "A warning must be logged for the unknown feature key"
+    )
+
+    from sqlalchemy import select
+
+    from dev_health_ops.models.licensing import OrgLicense
+
+    async with bridge_db() as session:
+        lic = (await session.execute(select(OrgLicense).where(OrgLicense.org_id == org_id))).scalar_one_or_none()
+        assert lic is not None
+        # Valid key survived; bogus key was dropped.
+        assert "api_access" in (lic.features_override or [])
+        assert "totally_unknown_feature_xyz" not in (lic.features_override or [])
+
+
+@pytest.mark.asyncio
+async def test_bridge_failure_rolls_back_subscription(bridge_db):
+    """If OrgLicense write fails, the entire transaction (including Subscription) rolls back."""
+    import uuid
+
+    from sqlalchemy import select
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from dev_health_ops.api.billing.subscription_service import SubscriptionService
+    from dev_health_ops.models.subscriptions import Subscription
+
+    org_id = uuid.uuid4()
+    plan_id = uuid.uuid4()
+    price_id = uuid.uuid4()
+    bundle_id = uuid.uuid4()
+    stripe_price_id = "price_atomic_test"
+    stripe_sub_id = "sub_atomic_1"
+
+    async with bridge_db() as session:
+        from sqlalchemy import select as sa_select
+
+        from dev_health_ops.models.billing import BillingPrice
+        from dev_health_ops.models.users import Organization
+
+        await _seed_enterprise_plan(session, plan_id, price_id, bundle_id)
+        price_row = (await session.execute(sa_select(BillingPrice).where(BillingPrice.id == price_id))).scalar_one()
+        price_row.stripe_price_id = stripe_price_id
+        await session.commit()
+
+        org = Organization(id=org_id, slug=f"atomic-corp-{org_id.hex[:8]}", name="Atomic Corp")
+        session.add(org)
+        await session.commit()
+
+    stripe_sub = _make_stripe_sub(stripe_sub_id, stripe_price_id, org_id)
+
+    # Patch _sync_org_license to raise, simulating a DB write failure.
+    with patch.object(SubscriptionService, "_sync_org_license", side_effect=SQLAlchemyError("simulated write failure")):
+        with pytest.raises(SQLAlchemyError):
+            async with bridge_db() as session:
+                svc = SubscriptionService(session)
+                await svc.upsert_from_stripe(stripe_sub, org_id)
+                await session.commit()
+
+    # Subscription must not have been committed.
+    async with bridge_db() as session:
+        sub_row = (await session.execute(select(Subscription).where(Subscription.stripe_subscription_id == stripe_sub_id))).scalar_one_or_none()
+        assert sub_row is None, "Subscription must be rolled back when OrgLicense write fails"


### PR DESCRIPTION
## Summary

Subscribing to a billing plan now automatically grants the plan's bundled features to the org.

- Adds `SubscriptionService._sync_org_license()` called from `upsert_from_stripe()` in the same DB transaction
- Resolves plan → `plan_feature_bundles` → `feature_bundles.features` → flattens + dedupes keys
- Validates keys against canonical `STANDARD_FEATURES`; unknown keys logged as warnings and skipped (defensive mode; strict enforcement is in PR #669 for G3)
- Cancellation (`status ∈ {canceled, incomplete_expired}`) → downgrade `OrgLicense` to community tier, empty features, preserved row for audit
- Idempotent: keyed on `org_id`; re-runs don't duplicate or flicker
- Atomic: `OrgLicense` write failure rolls back subscription write (shared SQLAlchemy transaction)

## Files changed
- `src/dev_health_ops/api/billing/subscription_service.py` — `_sync_org_license`, `_known_feature_keys`, `_CANCELLED_STATUSES`
- `tests/test_billing.py` — 5 new G4 bridge tests + `bridge_db` fixture

## Test plan
- [x] `test_subscription_creates_org_license`
- [x] `test_subscription_update_does_not_duplicate_license`
- [x] `test_subscription_cancellation_downgrades_license`
- [x] `test_bridge_skips_unknown_keys`
- [x] `test_bridge_failure_rolls_back_subscription`

All 5 pass. 3 pre-existing `test_checkout_*` failures unrelated (SQLite `max_overflow` bug present on G1 base).

SCREENSHOT-WAIVER: Backend service layer only; no rendered output.

**Depends on:** PR #667 (CHAOS-1204, G1 canonical registry). Merge #667 first, then rebase this onto `main`.

Design: `ops/docs/superpowers/specs/2026-04-15-chaos-1203-feature-flag-billing-reconcile-design.md`

Closes CHAOS-1207