### PR TITLE
Add feature flag sync providers and graph edges

### DIFF
--- a/src/dev_health_ops/api/admin/router.py
+++ b/src/dev_health_ops/api/admin/router.py
@@ -22,6 +22,7 @@ from .routers.credentials import (
     _test_github_connection,
     _test_gitlab_connection,
     _test_jira_connection,
+    _test_launchdarkly_connection,
     _test_linear_connection,
 )
 
@@ -49,5 +50,6 @@ __all__ = [
     "_test_github_connection",
     "_test_gitlab_connection",
     "_test_jira_connection",
+    "_test_launchdarkly_connection",
     "_test_linear_connection",
 ]

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -291,6 +291,8 @@ async def test_connection(
             success, details = await _test_jira_connection(creds)
         elif payload.provider == "linear":
             success, details = await _test_linear_connection(creds)
+        elif payload.provider == "launchdarkly":
+            success, details = await _test_launchdarkly_connection(creds)
         else:
             error = f"Unknown provider: {payload.provider}"
     except Exception as e:
@@ -456,3 +458,18 @@ async def _test_linear_connection(creds: dict) -> tuple[bool, dict]:
             if viewer:
                 return True, {"user": viewer.get("email"), "name": viewer.get("name")}
         return False, {"status": resp.status_code, "error": resp.text[:200]}
+
+
+async def _test_launchdarkly_connection(creds: dict) -> tuple[bool, dict]:
+    from dev_health_ops.connectors.launchdarkly import LaunchDarklyConnector
+
+    api_key = creds.get("api_key")
+    project_key = creds.get("project_key")
+    if not api_key or not project_key:
+        return False, {"error": "Missing required credentials (api_key, project_key)"}
+
+    async with LaunchDarklyConnector(
+        api_key=api_key, project_key=project_key
+    ) as connector:
+        flags = await connector.get_flags(project_key)
+        return True, {"project_key": project_key, "flag_count": len(flags)}

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -30,9 +30,18 @@ router = APIRouter()
 # Jira/Linear only support work-items; Git/CI/CD come from code hosts.
 PROVIDER_SYNC_TARGETS: dict[str, list[str]] = {
     "github": ["git", "prs", "cicd", "deployments", "incidents", "work-items"],
-    "gitlab": ["git", "prs", "cicd", "deployments", "incidents", "work-items"],
+    "gitlab": [
+        "git",
+        "prs",
+        "cicd",
+        "deployments",
+        "incidents",
+        "work-items",
+        "feature-flags",
+    ],
     "jira": ["work-items"],
     "linear": ["work-items"],
+    "launchdarkly": ["feature-flags"],
 }
 
 

--- a/src/dev_health_ops/connectors/gitlab.py
+++ b/src/dev_health_ops/connectors/gitlab.py
@@ -6,6 +6,7 @@ contributors, statistics, merge requests, and blame information from GitLab.
 """
 
 import logging
+import urllib.parse
 from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
@@ -334,6 +335,52 @@ class GitLabConnector(GitConnector):
         except Exception as e:
             self._handle_gitlab_exception(e)
             return []
+
+    @retry_with_backoff(
+        max_retries=3,
+        initial_delay=1.0,
+        exceptions=(RateLimitException, APIException),
+    )
+    def get_feature_flags(
+        self,
+        project_id_or_path: int | str,
+        *,
+        per_page: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch feature flags for a GitLab project via the management API."""
+        encoded_project = urllib.parse.quote(str(project_id_or_path), safe="")
+        endpoint = f"projects/{encoded_project}/feature_flags"
+        page = 1
+        effective_per_page = per_page or self.per_page
+        flags: list[dict[str, Any]] = []
+
+        while True:
+            batch = self.rest_client.get_list(
+                endpoint,
+                params={"page": page, "per_page": effective_per_page},
+            )
+            if not batch:
+                break
+            flags.extend(batch)
+            if len(batch) < effective_per_page:
+                break
+            page += 1
+
+        logger.info(
+            "Fetched %d GitLab feature flags for project %s",
+            len(flags),
+            project_id_or_path,
+        )
+        return flags
+
+    def get_project_name(self, project_id_or_path: int | str) -> str:
+        """Return the canonical path for a GitLab project."""
+        project = self.get_project(project_id_or_path)
+        return str(
+            getattr(project, "path_with_namespace", None)
+            or getattr(project, "path", None)
+            or project_id_or_path
+        )
 
     @retry_with_backoff(
         max_retries=3,

--- a/src/dev_health_ops/fixtures/generator.py
+++ b/src/dev_health_ops/fixtures/generator.py
@@ -860,10 +860,14 @@ class SyntheticDataGenerator:
         days: int = 30,
         deployments_per_day: int = 2,
         pr_numbers: list[int] | None = None,
+        release_refs: list[str] | None = None,
     ) -> list[Deployment]:
         deployments = []
         end_date = datetime.now(timezone.utc)
         start_date = end_date - timedelta(days=days)
+
+        if not release_refs:
+            release_refs = self._default_release_refs(days)
 
         deploy_index = 0
         current_date = start_date
@@ -885,6 +889,8 @@ class SyntheticDataGenerator:
                 if pr_numbers:
                     pr_number = random.choice(pr_numbers)
 
+                release_ref = random.choice(release_refs)
+
                 deploy_index += 1
                 deployments.append(
                     Deployment(
@@ -897,6 +903,8 @@ class SyntheticDataGenerator:
                         deployed_at=deployed_at,
                         merged_at=merged_at,
                         pull_request_number=pr_number,
+                        release_ref=release_ref,
+                        release_ref_confidence=1.0,
                     )
                 )
             current_date += timedelta(days=1)
@@ -3079,6 +3087,7 @@ class SyntheticDataGenerator:
         org_id: str = "",
         issue_ids: list[str] | None = None,
         pr_numbers: list[int] | None = None,
+        release_refs: list[str] | None = None,
     ) -> list[FeatureFlagLinkRecord]:
         """Generate flag-to-work-item links."""
         links: list[FeatureFlagLinkRecord] = []
@@ -3091,12 +3100,17 @@ class SyntheticDataGenerator:
         if pr_numbers:
             for prn in pr_numbers:
                 targets.append(("pr", f"{self.repo_id}#pr{prn}"))
+        if release_refs:
+            for release_ref in release_refs:
+                targets.append(("release", release_ref))
 
         if not targets:
             for i in range(min(len(flags), 10)):
                 targets.append(("issue", f"{self.repo_name}-{100 + i}"))
             for i in range(min(len(flags), 5)):
                 targets.append(("pr", f"{self.repo_id}#pr{i + 1}"))
+            for release_ref in self._default_release_refs(max(len(flags), 7)):
+                targets.append(("release", release_ref))
 
         confidence_profiles = [
             (1.0, "native", "api_link"),
@@ -3123,7 +3137,13 @@ class SyntheticDataGenerator:
                         target_id=target_id,
                         provider=flag.provider,
                         link_source=link_source,
-                        link_type="controls" if target_type == "pr" else "tracks",
+                        link_type=(
+                            "controls"
+                            if target_type == "pr"
+                            else "rollout"
+                            if target_type == "release"
+                            else "tracks"
+                        ),
                         evidence_type=evidence_type,
                         confidence=confidence,
                         valid_from=flag_created,
@@ -3148,7 +3168,7 @@ class SyntheticDataGenerator:
         start = now - timedelta(days=days)
 
         if not release_refs:
-            release_refs = [f"v1.{i}.0" for i in range(max(1, days // 7))]
+            release_refs = self._default_release_refs(days)
 
         environments = ["production", "staging"]
         endpoint_groups = ["/api/checkout", "/api/auth", "/api/search", None]
@@ -3215,7 +3235,7 @@ class SyntheticDataGenerator:
         computed_at = now
 
         if not release_refs:
-            release_refs = [f"v1.{i}.0" for i in range(max(1, days // 7))]
+            release_refs = self._default_release_refs(days)
 
         environments = ["production", "staging"]
 
@@ -3264,3 +3284,6 @@ class SyntheticDataGenerator:
                     )
 
         return records
+
+    def _default_release_refs(self, days: int) -> list[str]:
+        return [f"v1.{i}.0" for i in range(max(1, days // 7))]

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -5,7 +5,7 @@ import os
 import random
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import cast
+from typing import Any, cast
 
 from dev_health_ops.fixtures.generator import SyntheticDataGenerator
 from dev_health_ops.licensing.gating import LicenseManager
@@ -116,7 +116,12 @@ async def _seed_auth_data(session, user_data: dict) -> None:
 async def run_fixtures_generation(ns: argparse.Namespace) -> int:
     now = datetime.now(timezone.utc)
     db_type = resolve_db_type(ns.sink, ns.db_type)
-    fixture_data: dict[str, list] = {"work_items": [], "transitions": [], "teams": []}
+    fixture_data: dict[str, list] = {
+        "work_items": [],
+        "transitions": [],
+        "teams": [],
+        "feature_flag_contexts": [],
+    }
 
     # Default to the fixture org UUID so demo data is queryable out of the box.
     _default_org = str(
@@ -363,8 +368,9 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
             # 6. CI/CD + Deployments + Incidents
             pr_numbers = [pr.number for pr in prs]
             pipeline_runs = generator.generate_ci_pipeline_runs(days=ns.days)
+            release_refs = ff_release_refs = generator._default_release_refs(ns.days)
             deployments = generator.generate_deployments(
-                days=ns.days, pr_numbers=pr_numbers
+                days=ns.days, pr_numbers=pr_numbers, release_refs=release_refs
             )
             incidents = generator.generate_incidents(days=ns.days)
             await _insert_batches(
@@ -379,6 +385,18 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
             )
             await _insert_batches(
                 store.insert_incidents, incidents, allow_parallel=allow_parallel_inserts
+            )
+
+            fixture_data["feature_flag_contexts"].append(
+                {
+                    "repo_name": r_name,
+                    "repo_id": generator.repo_id,
+                    "provider": ns.provider,
+                    "prs": prs,
+                    "deployments": deployments,
+                    "work_items": work_items,
+                    "release_refs": ff_release_refs,
+                }
             )
 
             # 6c. Security alerts
@@ -451,6 +469,9 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
 
     await run_with_store(ns.sink, db_type, _handler, org_id=org_id)
 
+    all_ff_flags: list = []
+    feature_flag_graph_contexts: list[dict[str, Any]] = []
+
     if ns.with_metrics:
         await run_daily_metrics_job(
             db_url=ns.sink,
@@ -470,7 +491,6 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                 )
             sink = ClickHouseMetricsSink(ns.sink)
 
-            all_ff_flags: list = []
             all_ff_events: list = []
 
             if sink:
@@ -525,6 +545,9 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                         ns.repo_name if _repo_count == 1 else f"{ns.repo_name}-{i + 1}"
                     )
                     seed_value = (int(ns.seed) + i) if ns.seed is not None else None
+                    repo_context = cast(
+                        dict[str, Any], fixture_data["feature_flag_contexts"][i]
+                    )
                     metric_gen = SyntheticDataGenerator(
                         repo_name=r_name, seed=seed_value
                     )
@@ -570,6 +593,17 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                         sink.write_file_hotspot_daily(hotspot_records)
 
                     ff_gen = SyntheticDataGenerator(repo_name=r_name, seed=seed_value)
+                    release_refs = list(repo_context.get("release_refs") or [])
+                    issue_ids = [
+                        str(getattr(item, "work_item_id", "") or "")
+                        for item in cast(list, repo_context.get("work_items") or [])
+                        if str(getattr(item, "work_item_id", "") or "")
+                    ]
+                    pr_numbers = [
+                        int(getattr(pr, "number", 0))
+                        for pr in cast(list, repo_context.get("prs") or [])
+                        if int(getattr(pr, "number", 0) or 0) > 0
+                    ]
                     ff_flags = ff_gen.generate_feature_flags(org_id=org_id)
                     all_ff_flags.extend(ff_flags)
                     if hasattr(sink, "write_feature_flags") and ff_flags:
@@ -583,13 +617,17 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                         sink.write_feature_flag_events(ff_events)
 
                     ff_links = ff_gen.generate_feature_flag_links(
-                        ff_flags, org_id=org_id
+                        ff_flags,
+                        org_id=org_id,
+                        issue_ids=issue_ids,
+                        pr_numbers=pr_numbers,
+                        release_refs=release_refs,
                     )
                     if hasattr(sink, "write_feature_flag_links") and ff_links:
                         sink.write_feature_flag_links(ff_links)
 
                     telemetry_buckets = ff_gen.generate_telemetry_signal_buckets(
-                        days=ns.days, org_id=org_id
+                        days=ns.days, org_id=org_id, release_refs=release_refs
                     )
                     if (
                         hasattr(sink, "write_telemetry_signal_buckets")
@@ -598,10 +636,20 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                         sink.write_telemetry_signal_buckets(telemetry_buckets)
 
                     release_impact = ff_gen.generate_release_impact_daily(
-                        days=ns.days, org_id=org_id
+                        days=ns.days, org_id=org_id, release_refs=release_refs
                     )
                     if hasattr(sink, "write_release_impact_daily") and release_impact:
                         sink.write_release_impact_daily(release_impact)
+
+                    feature_flag_graph_contexts.append(
+                        {
+                            "flags": ff_flags,
+                            "events": ff_events,
+                            "links": ff_links,
+                            "release_impact": release_impact,
+                            "repo_context": repo_context,
+                        }
+                    )
 
                     logging.info(
                         "Wrote %d feature flags, %d events, %d links, "
@@ -642,6 +690,11 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
 
     if ns.with_work_graph:
         from dev_health_ops.work_graph.builder import BuildConfig, WorkGraphBuilder
+        from dev_health_ops.work_graph.ids import (
+            generate_feature_flag_id,
+            generate_release_id,
+        )
+        from dev_health_ops.work_graph.models import EdgeType, NodeType, Provenance
 
         config = BuildConfig(
             dsn=ns.sink,
@@ -664,6 +717,212 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                 logging.info(
                     "Added %d feature flag nodes to work graph.", len(all_ff_flags)
                 )
+            if ns.with_metrics:
+                for context in feature_flag_graph_contexts:
+                    flags = cast(list, context.get("flags") or [])
+                    events = cast(list, context.get("events") or [])
+                    links = cast(list, context.get("links") or [])
+                    release_impact = cast(list, context.get("release_impact") or [])
+                    repo_context = cast(
+                        dict[str, Any], context.get("repo_context") or {}
+                    )
+                    deployments = cast(list, repo_context.get("deployments") or [])
+
+                    flags_by_key = {flag.flag_key: flag for flag in flags}
+                    flag_ids = {
+                        flag.flag_key: generate_feature_flag_id(
+                            org_id,
+                            flag.provider,
+                            flag.project_key or "",
+                            flag.flag_key,
+                        )
+                        for flag in flags
+                    }
+                    release_ids: dict[str, str] = {}
+
+                    for deployment in deployments:
+                        release_ref = str(getattr(deployment, "release_ref", "") or "")
+                        if not release_ref:
+                            continue
+                        release_id = release_ids.setdefault(
+                            release_ref, generate_release_id(org_id, release_ref)
+                        )
+                        builder.add_release_node(
+                            release_ref=release_ref,
+                            environment=str(
+                                getattr(deployment, "environment", "production")
+                                or "production"
+                            ),
+                            provider=str(repo_context.get("provider") or "synthetic"),
+                            repo_id=getattr(deployment, "repo_id", None),
+                            event_ts=getattr(deployment, "deployed_at", None),
+                        )
+                        pr_number = getattr(deployment, "pull_request_number", None)
+                        if pr_number:
+                            pr_id = f"{deployment.repo_id}#pr{pr_number}"
+                            builder.add_release_edge(
+                                release_id=release_id,
+                                target_id=pr_id,
+                                target_type=NodeType.PR,
+                                edge_type=EdgeType.INTRODUCED_BY,
+                                confidence=float(
+                                    getattr(
+                                        deployment,
+                                        "release_ref_confidence",
+                                        1.0,
+                                    )
+                                    or 1.0
+                                ),
+                                evidence=f"deployment:{deployment.deployment_id}",
+                                provenance=Provenance.NATIVE,
+                                repo_id=getattr(deployment, "repo_id", None),
+                                event_ts=getattr(deployment, "deployed_at", None),
+                            )
+
+                    release_refs_by_flag: dict[str, list[str]] = {}
+                    for link in links:
+                        flag = flags_by_key.get(link.flag_key)
+                        flag_id = flag_ids.get(link.flag_key)
+                        if flag is None or flag_id is None:
+                            continue
+
+                        if link.target_type == "issue":
+                            builder.add_feature_flag_edge(
+                                flag_id=flag_id,
+                                target_type=NodeType.ISSUE,
+                                target_id=link.target_id,
+                                edge_type=EdgeType.GUARDS,
+                                confidence=link.confidence,
+                                evidence=f"{link.link_type}:{link.evidence_type or 'synthetic'}",
+                                provenance=builder._parse_provenance(link.link_source),
+                                repo_id=flag.repo_id,
+                                provider=flag.provider,
+                                event_ts=link.valid_from,
+                            )
+                        elif link.target_type == "pr":
+                            builder.add_feature_flag_edge(
+                                flag_id=flag_id,
+                                target_type=NodeType.PR,
+                                target_id=link.target_id,
+                                edge_type=EdgeType.REFERENCES,
+                                confidence=link.confidence,
+                                evidence=f"{link.link_type}:{link.evidence_type or 'synthetic'}",
+                                provenance=builder._parse_provenance(link.link_source),
+                                repo_id=flag.repo_id,
+                                provider=flag.provider,
+                                event_ts=link.valid_from,
+                            )
+                        elif link.target_type == "release":
+                            release_refs_by_flag.setdefault(link.flag_key, []).append(
+                                link.target_id
+                            )
+                            release_ids.setdefault(
+                                link.target_id,
+                                generate_release_id(org_id, link.target_id),
+                            )
+
+                    latest_event_by_flag: dict[str, Any] = {}
+                    for event in events:
+                        existing = latest_event_by_flag.get(event.flag_key)
+                        if existing is None or event.event_ts > existing.event_ts:
+                            latest_event_by_flag[event.flag_key] = event
+
+                    for flag_key, linked_release_refs in release_refs_by_flag.items():
+                        flag = flags_by_key.get(flag_key)
+                        flag_id = flag_ids.get(flag_key)
+                        latest_event = latest_event_by_flag.get(flag_key)
+                        if flag is None or flag_id is None or latest_event is None:
+                            continue
+                        release_ref = linked_release_refs[0]
+                        release_id = release_ids.setdefault(
+                            release_ref, generate_release_id(org_id, release_ref)
+                        )
+                        builder.add_feature_flag_edge(
+                            flag_id=flag_id,
+                            target_type=NodeType.RELEASE,
+                            target_id=release_id,
+                            edge_type=EdgeType.CONFIG_CHANGED_BY,
+                            confidence=1.0
+                            if latest_event.event_type == "toggle"
+                            else 0.8,
+                            evidence=(
+                                f"{latest_event.event_ts.isoformat()}"
+                                f"|{latest_event.event_type}"
+                                f"|{latest_event.next_state or ''}"
+                            ),
+                            provenance=Provenance.NATIVE,
+                            repo_id=flag.repo_id,
+                            provider=flag.provider,
+                            event_ts=latest_event.event_ts,
+                        )
+
+                    impact_seen: set[tuple[str, str, str]] = set()
+                    for impact in release_impact:
+                        release_ref = str(getattr(impact, "release_ref", "") or "")
+                        release_id = release_ids.get(release_ref)
+                        if not release_id:
+                            continue
+                        for (
+                            flag_key,
+                            linked_release_refs,
+                        ) in release_refs_by_flag.items():
+                            if release_ref not in linked_release_refs:
+                                continue
+                            flag_id = flag_ids.get(flag_key)
+                            if flag_id is None:
+                                continue
+                            impact_specs = [
+                                (
+                                    "friction",
+                                    abs(
+                                        float(
+                                            getattr(
+                                                impact,
+                                                "release_user_friction_delta",
+                                                0.0,
+                                            )
+                                            or 0.0
+                                        )
+                                    ),
+                                ),
+                                (
+                                    "error",
+                                    abs(
+                                        float(
+                                            getattr(
+                                                impact,
+                                                "release_error_rate_delta",
+                                                0.0,
+                                            )
+                                            or 0.0
+                                        )
+                                    ),
+                                ),
+                            ]
+                            for metric_name, confidence in impact_specs:
+                                dedupe_key = (release_id, flag_id, metric_name)
+                                if dedupe_key in impact_seen:
+                                    continue
+                                impact_seen.add(dedupe_key)
+                                builder.add_release_edge(
+                                    release_id=release_id,
+                                    target_id=flag_id,
+                                    target_type=NodeType.FEATURE_FLAG,
+                                    edge_type=EdgeType.IMPACTS,
+                                    confidence=min(confidence, 1.0),
+                                    evidence=(
+                                        f"{metric_name}:release={release_ref}"
+                                        f"|env={getattr(impact, 'environment', '')}"
+                                        f"|confidence={min(confidence, 1.0):.4f}"
+                                    ),
+                                    provenance=Provenance.HEURISTIC,
+                                    repo_id=getattr(impact, "repo_id", None),
+                                    event_ts=datetime.combine(
+                                        getattr(impact, "day"),
+                                        datetime.min.time(),
+                                        tzinfo=timezone.utc,
+                                    ),
+                                )
             if config.from_date and config.to_date:
                 await materialize_fixture_investments(
                     db_url=ns.sink,

--- a/src/dev_health_ops/processors/gitlab_feature_flags.py
+++ b/src/dev_health_ops/processors/gitlab_feature_flags.py
@@ -1,0 +1,91 @@
+"""GitLab feature-flag normalization helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from dev_health_ops.metrics.schemas import FeatureFlagEventRecord, FeatureFlagRecord
+
+
+def _parse_gitlab_datetime(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_environment_scopes(flag: dict[str, Any]) -> list[str]:
+    scopes: list[str] = []
+    for strategy in flag.get("strategies") or []:
+        for scope in strategy.get("scopes") or []:
+            env_scope = str(scope.get("environment_scope") or "").strip()
+            if env_scope and env_scope not in scopes:
+                scopes.append(env_scope)
+    return scopes or [""]
+
+
+def normalize_gitlab_feature_flags(
+    flags: list[dict[str, Any]],
+    *,
+    project_key: str,
+    org_id: str,
+    repo_id: Any = None,
+) -> list[FeatureFlagRecord]:
+    now = datetime.now(timezone.utc)
+    records: list[FeatureFlagRecord] = []
+    for flag in flags:
+        scopes = _extract_environment_scopes(flag)
+        created_at = _parse_gitlab_datetime(flag.get("created_at")) or now
+        for environment in scopes:
+            records.append(
+                FeatureFlagRecord(
+                    provider="gitlab",
+                    flag_key=str(flag.get("name") or flag.get("key") or ""),
+                    project_key=project_key,
+                    repo_id=repo_id,
+                    environment=environment,
+                    flag_type=str(flag.get("version") or "new_version_flag"),
+                    created_at=created_at,
+                    archived_at=None,
+                    last_synced=now,
+                    org_id=org_id,
+                )
+            )
+    return records
+
+
+def snapshot_gitlab_feature_flag_events(
+    flags: list[dict[str, Any]],
+    *,
+    project_key: str,
+    org_id: str,
+    repo_id: Any = None,
+    observed_at: datetime | None = None,
+) -> list[FeatureFlagEventRecord]:
+    now = observed_at or datetime.now(timezone.utc)
+    records: list[FeatureFlagEventRecord] = []
+    for flag in flags:
+        flag_key = str(flag.get("name") or flag.get("key") or "")
+        state = "on" if bool(flag.get("active")) else "off"
+        event_ts = _parse_gitlab_datetime(flag.get("updated_at")) or now
+        for environment in _extract_environment_scopes(flag):
+            records.append(
+                FeatureFlagEventRecord(
+                    event_type="toggle",
+                    flag_key=flag_key,
+                    environment=environment,
+                    repo_id=repo_id,
+                    actor_type="snapshot",
+                    prev_state=None,
+                    next_state=state,
+                    event_ts=event_ts,
+                    ingested_at=now,
+                    source_event_id=flag_key or None,
+                    dedupe_key=f"gitlab:{project_key}:{flag_key}:{environment}:{state}",
+                    org_id=org_id,
+                )
+            )
+    return records

--- a/src/dev_health_ops/work_graph/builder.py
+++ b/src/dev_health_ops/work_graph/builder.py
@@ -252,10 +252,11 @@ class WorkGraphBuilder:
     def add_release_edge(
         self,
         release_id: str,
-        pr_id: str,
+        target_id: str,
         edge_type: EdgeType,
         confidence: float,
         *,
+        target_type: NodeType = NodeType.PR,
         evidence: str = "",
         provenance: Provenance = Provenance.NATIVE,
         repo_id: uuid.UUID | None = None,
@@ -266,20 +267,59 @@ class WorkGraphBuilder:
             NodeType.RELEASE,
             release_id,
             edge_type,
-            NodeType.PR,
-            pr_id,
+            target_type,
+            target_id,
         )
         edge = WorkGraphEdge(
             edge_id=edge_id,
             source_type=NodeType.RELEASE,
             source_id=release_id,
-            target_type=NodeType.PR,
-            target_id=pr_id,
+            target_type=target_type,
+            target_id=target_id,
             edge_type=edge_type,
             provenance=provenance,
             confidence=confidence,
             evidence=evidence,
             repo_id=repo_id or self.config.repo_id,
+            event_ts=event_ts or self._now,
+        )
+        self._write_edges([edge])
+        return edge
+
+    def add_feature_flag_edge(
+        self,
+        flag_id: str,
+        target_type: NodeType,
+        target_id: str,
+        edge_type: EdgeType,
+        confidence: float,
+        *,
+        evidence: str = "",
+        provenance: Provenance = Provenance.NATIVE,
+        repo_id: uuid.UUID | None = None,
+        provider: str | None = None,
+        event_ts: datetime | None = None,
+    ) -> WorkGraphEdge:
+        """Create an edge from a FEATURE_FLAG node to another graph node."""
+        edge_id = generate_edge_id(
+            NodeType.FEATURE_FLAG,
+            flag_id,
+            edge_type,
+            target_type,
+            target_id,
+        )
+        edge = WorkGraphEdge(
+            edge_id=edge_id,
+            source_type=NodeType.FEATURE_FLAG,
+            source_id=flag_id,
+            target_type=target_type,
+            target_id=target_id,
+            edge_type=edge_type,
+            provenance=provenance,
+            confidence=confidence,
+            evidence=evidence,
+            repo_id=repo_id or self.config.repo_id,
+            provider=provider,
             event_ts=event_ts or self._now,
         )
         self._write_edges([edge])

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -23,6 +23,256 @@ from dev_health_ops.workers.task_utils import (
 logger = logging.getLogger(__name__)
 
 
+def _sync_launchdarkly_feature_flags(
+    *,
+    db_url: str,
+    org_id: str,
+    credentials: dict[str, Any],
+    sync_options: dict[str, Any],
+    since_dt: datetime | None,
+) -> dict[str, Any]:
+    from dev_health_ops.connectors.launchdarkly import LaunchDarklyConnector
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+    from dev_health_ops.processors.launchdarkly import (
+        normalize_audit_events,
+        normalize_flags,
+    )
+    from dev_health_ops.work_graph.builder import BuildConfig, WorkGraphBuilder
+    from dev_health_ops.work_graph.ids import generate_feature_flag_id
+    from dev_health_ops.work_graph.models import EdgeType, NodeType, Provenance
+
+    api_key = str(credentials.get("api_key") or "")
+    project_key = str(
+        credentials.get("project_key") or sync_options.get("project_key") or ""
+    )
+    environment = str(
+        credentials.get("environment") or sync_options.get("environment") or ""
+    )
+    if not api_key or not project_key:
+        raise ValueError(
+            "LaunchDarkly feature-flag sync requires api_key and project_key"
+        )
+    if not db_url.startswith("clickhouse://"):
+        raise ValueError(
+            "Feature-flag sync requires CLICKHOUSE_URI / ClickHouse analytics sink"
+        )
+
+    async def _run() -> dict[str, Any]:
+        async with LaunchDarklyConnector(
+            api_key=api_key, project_key=project_key
+        ) as connector:
+            raw_flags = await connector.get_flags(project_key)
+            raw_events = await connector.get_audit_log(since=since_dt, limit=200)
+
+        flags = normalize_flags(raw_flags, org_id)
+        if environment:
+            flags = [
+                flag.__class__(
+                    provider=flag.provider,
+                    flag_key=flag.flag_key,
+                    project_key=flag.project_key,
+                    repo_id=flag.repo_id,
+                    environment=environment,
+                    flag_type=flag.flag_type,
+                    created_at=flag.created_at,
+                    archived_at=flag.archived_at,
+                    last_synced=flag.last_synced,
+                    org_id=flag.org_id,
+                )
+                for flag in flags
+            ]
+        events = normalize_audit_events(raw_events, org_id)
+        if environment:
+            events = [
+                event.__class__(
+                    event_type=event.event_type,
+                    flag_key=event.flag_key,
+                    environment=event.environment or environment,
+                    repo_id=event.repo_id,
+                    actor_type=event.actor_type,
+                    prev_state=event.prev_state,
+                    next_state=event.next_state,
+                    event_ts=event.event_ts,
+                    ingested_at=event.ingested_at,
+                    source_event_id=event.source_event_id,
+                    dedupe_key=event.dedupe_key,
+                    org_id=event.org_id,
+                )
+                for event in events
+            ]
+
+        sink = ClickHouseMetricsSink(db_url)
+        sink.org_id = org_id  # type: ignore[attr-defined]
+        builder = WorkGraphBuilder(BuildConfig(dsn=db_url, org_id=org_id))
+        try:
+            sink.write_feature_flags(flags)
+            sink.write_feature_flag_events(events)
+
+            latest_events: dict[str, Any] = {}
+            for event in events:
+                existing = latest_events.get(event.flag_key)
+                if existing is None or event.event_ts > existing.event_ts:
+                    latest_events[event.flag_key] = event
+
+            for flag in flags:
+                builder.add_feature_flag_node(
+                    flag_key=flag.flag_key,
+                    provider=flag.provider,
+                    project_key=flag.project_key or project_key,
+                    repo_id=flag.repo_id,
+                    event_ts=flag.created_at,
+                )
+                latest_event = latest_events.get(flag.flag_key)
+                if latest_event is None:
+                    continue
+                flag_id = generate_feature_flag_id(
+                    org_id,
+                    flag.provider,
+                    flag.project_key or project_key,
+                    flag.flag_key,
+                )
+                builder.add_feature_flag_edge(
+                    flag_id=flag_id,
+                    target_type=NodeType.FEATURE_FLAG,
+                    target_id=flag_id,
+                    edge_type=EdgeType.CONFIG_CHANGED_BY,
+                    confidence=1.0,
+                    evidence=(
+                        f"{latest_event.event_ts.isoformat()}"
+                        f"|{latest_event.event_type}"
+                        f"|{latest_event.next_state or ''}"
+                    ),
+                    provenance=Provenance.NATIVE,
+                    provider=flag.provider,
+                    event_ts=latest_event.event_ts,
+                )
+        finally:
+            builder.close()
+            sink.close()
+
+        return {
+            "flags_synced": len(flags),
+            "events_synced": len(events),
+            "project_key": project_key,
+            "environment": environment or None,
+        }
+
+    return run_async(_run())
+
+
+def _sync_gitlab_feature_flags(
+    *,
+    db_url: str,
+    org_id: str,
+    credentials: dict[str, Any],
+    sync_options: dict[str, Any],
+) -> dict[str, Any]:
+    from dev_health_ops.connectors.gitlab import GitLabConnector
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+    from dev_health_ops.processors.gitlab_feature_flags import (
+        normalize_gitlab_feature_flags,
+        snapshot_gitlab_feature_flag_events,
+    )
+    from dev_health_ops.work_graph.builder import BuildConfig, WorkGraphBuilder
+    from dev_health_ops.work_graph.ids import generate_feature_flag_id
+    from dev_health_ops.work_graph.models import EdgeType, NodeType, Provenance
+
+    token = str(credentials.get("token") or "")
+    gitlab_url = str(
+        credentials.get("url")
+        or credentials.get("base_url")
+        or sync_options.get("gitlab_url")
+        or "https://gitlab.com"
+    )
+    project_id_or_path = (
+        sync_options.get("project_id")
+        or sync_options.get("repo")
+        or sync_options.get("project_key")
+    )
+    if not token or not project_id_or_path:
+        raise ValueError(
+            "GitLab feature-flag sync requires token and project_id/project path"
+        )
+    if not db_url.startswith("clickhouse://"):
+        raise ValueError(
+            "Feature-flag sync requires CLICKHOUSE_URI / ClickHouse analytics sink"
+        )
+
+    connector = GitLabConnector(url=gitlab_url, private_token=token)
+    raw_flags = connector.get_feature_flags(project_id_or_path)
+    project_key = connector.get_project_name(project_id_or_path)
+    repo_id = None
+
+    flags = normalize_gitlab_feature_flags(
+        raw_flags,
+        project_key=project_key,
+        org_id=org_id,
+        repo_id=repo_id,
+    )
+    events = snapshot_gitlab_feature_flag_events(
+        raw_flags,
+        project_key=project_key,
+        org_id=org_id,
+        repo_id=repo_id,
+    )
+
+    sink = ClickHouseMetricsSink(db_url)
+    sink.org_id = org_id  # type: ignore[attr-defined]
+    builder = WorkGraphBuilder(BuildConfig(dsn=db_url, org_id=org_id))
+    try:
+        sink.write_feature_flags(flags)
+        sink.write_feature_flag_events(events)
+
+        latest_events: dict[str, Any] = {}
+        for event in events:
+            existing = latest_events.get(event.flag_key)
+            if existing is None or event.event_ts > existing.event_ts:
+                latest_events[event.flag_key] = event
+
+        for flag in flags:
+            builder.add_feature_flag_node(
+                flag_key=flag.flag_key,
+                provider=flag.provider,
+                project_key=flag.project_key or project_key,
+                repo_id=flag.repo_id,
+                event_ts=flag.created_at,
+            )
+            latest_event = latest_events.get(flag.flag_key)
+            if latest_event is None:
+                continue
+            flag_id = generate_feature_flag_id(
+                org_id,
+                flag.provider,
+                flag.project_key or project_key,
+                flag.flag_key,
+            )
+            builder.add_feature_flag_edge(
+                flag_id=flag_id,
+                target_type=NodeType.FEATURE_FLAG,
+                target_id=flag_id,
+                edge_type=EdgeType.CONFIG_CHANGED_BY,
+                confidence=1.0,
+                evidence=(
+                    f"{latest_event.event_ts.isoformat()}"
+                    f"|{latest_event.event_type}"
+                    f"|{latest_event.next_state or ''}"
+                ),
+                provenance=Provenance.NATIVE,
+                provider=flag.provider,
+                event_ts=latest_event.event_ts,
+            )
+    finally:
+        builder.close()
+        sink.close()
+
+    return {
+        "flags_synced": len(flags),
+        "events_synced": len(events),
+        "project_key": project_key,
+        "gitlab_url": gitlab_url,
+    }
+
+
 def _dispatch_post_sync_tasks(
     *,
     provider: str,
@@ -212,9 +462,18 @@ def run_sync_config(
             if _owr:
                 repo_id_for_watermark = f"{_owr[0]}/{_owr[1]}"
         elif provider == "gitlab":
-            _pid = sync_options.get("project_id")
+            _pid = sync_options.get("project_id") or sync_options.get("repo")
             if _pid is not None:
                 repo_id_for_watermark = str(_pid)
+        elif provider == "launchdarkly":
+            project_key = sync_options.get("project_key") or credentials.get(
+                "project_key"
+            )
+            environment = sync_options.get("environment") or credentials.get(
+                "environment"
+            )
+            if project_key:
+                repo_id_for_watermark = f"{project_key}:{environment or 'default'}"
 
         if repo_id_for_watermark and not full_resync:
             with get_postgres_session_sync() as session:
@@ -262,34 +521,65 @@ def run_sync_config(
             )
 
         elif provider == "gitlab":
-            project_id = sync_options.get("project_id")
-            if project_id is None:
-                raise ValueError("Missing GitLab project_id in sync options")
-
-            token = str(credentials.get("token") or "")
-            if not token:
-                raise ValueError("Missing GitLab token for sync configuration")
-
-            gitlab_url = str(sync_options.get("gitlab_url", "https://gitlab.com"))
-            merged_flags = _merge_sync_flags(sync_targets)
-
-            async def _gitlab_handler(store):
-                await process_gitlab_project(
-                    store=store,
-                    project_id=int(project_id),
-                    token=token,
-                    gitlab_url=gitlab_url,
-                    since=since_dt,
-                    **merged_flags,
+            feature_flag_requested = "feature-flags" in sync_targets
+            gitlab_targets = [
+                target for target in sync_targets if target != "feature-flags"
+            ]
+            if feature_flag_requested:
+                result_payload["feature_flags"] = _sync_gitlab_feature_flags(
+                    db_url=db_url,
+                    org_id=org_id,
+                    credentials=credentials,
+                    sync_options=sync_options,
                 )
 
-            run_async(run_with_store(db_url, db_type, _gitlab_handler, org_id=org_id))
-            result_payload.update(
-                {
-                    "project_id": int(project_id),
-                    "gitlab_url": gitlab_url,
-                    "flags": merged_flags,
-                }
+            if not gitlab_targets:
+                completed_at = datetime.now(timezone.utc)
+                duration_seconds = int((completed_at - started_at).total_seconds())
+            else:
+                project_id = sync_options.get("project_id")
+                if project_id is None:
+                    raise ValueError("Missing GitLab project_id in sync options")
+
+                token = str(credentials.get("token") or "")
+                if not token:
+                    raise ValueError("Missing GitLab token for sync configuration")
+
+                gitlab_url = str(sync_options.get("gitlab_url", "https://gitlab.com"))
+                merged_flags = _merge_sync_flags(gitlab_targets)
+
+                async def _gitlab_handler(store):
+                    await process_gitlab_project(
+                        store=store,
+                        project_id=int(project_id),
+                        token=token,
+                        gitlab_url=gitlab_url,
+                        since=since_dt,
+                        **merged_flags,
+                    )
+
+                run_async(
+                    run_with_store(db_url, db_type, _gitlab_handler, org_id=org_id)
+                )
+                result_payload.update(
+                    {
+                        "project_id": int(project_id),
+                        "gitlab_url": gitlab_url,
+                        "flags": merged_flags,
+                    }
+                )
+
+        elif provider == "launchdarkly":
+            if "feature-flags" not in sync_targets:
+                raise ValueError(
+                    "LaunchDarkly sync configurations currently support only the feature-flags target"
+                )
+            result_payload["feature_flags"] = _sync_launchdarkly_feature_flags(
+                db_url=db_url,
+                org_id=org_id,
+                credentials=credentials,
+                sync_options=sync_options,
+                since_dt=since_dt,
             )
 
         elif provider == "jira":

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -534,8 +534,7 @@ def run_sync_config(
                 )
 
             if not gitlab_targets:
-                completed_at = datetime.now(timezone.utc)
-                duration_seconds = int((completed_at - started_at).total_seconds())
+                pass  # feature-flags-only sync handled above
             else:
                 project_id = sync_options.get("project_id")
                 if project_id is None:

--- a/src/dev_health_ops/workers/task_utils.py
+++ b/src/dev_health_ops/workers/task_utils.py
@@ -80,6 +80,7 @@ def _inject_provider_token(provider: str, token: str) -> None:
     env_var = {
         "github": "GITHUB_TOKEN",
         "gitlab": "GITLAB_TOKEN",
+        "launchdarkly": "LAUNCHDARKLY_API_KEY",
         # Extended provider env var mappings
         "linear": "LINEAR_API_KEY",
         "jira": "JIRA_API_TOKEN",
@@ -96,6 +97,8 @@ def _extract_provider_token(provider: str, credentials: dict[str, Any]) -> str:
         return str(credentials.get("api_key") or credentials.get("apiKey") or "")
     if provider == "jira":
         return str(credentials.get("api_token") or credentials.get("apiToken") or "")
+    if provider == "launchdarkly":
+        return str(credentials.get("api_key") or credentials.get("apiKey") or "")
     # GitHub, GitLab, and others use "token"
     return str(credentials.get("token") or "")
 

--- a/tests/test_admin_sync_targets.py
+++ b/tests/test_admin_sync_targets.py
@@ -1,0 +1,6 @@
+from dev_health_ops.api.admin.routers.sync import PROVIDER_SYNC_TARGETS
+
+
+def test_provider_sync_targets_include_feature_flag_sources():
+    assert "feature-flags" in PROVIDER_SYNC_TARGETS["gitlab"]
+    assert PROVIDER_SYNC_TARGETS["launchdarkly"] == ["feature-flags"]

--- a/tests/test_gitlab_feature_flags.py
+++ b/tests/test_gitlab_feature_flags.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dev_health_ops.processors.gitlab_feature_flags import (
+    normalize_gitlab_feature_flags,
+    snapshot_gitlab_feature_flag_events,
+)
+
+
+def test_normalize_gitlab_feature_flags_emits_one_record_per_environment_scope():
+    flags = [
+        {
+            "name": "awesome_feature",
+            "active": True,
+            "version": "new_version_flag",
+            "created_at": "2026-04-10T12:00:00Z",
+            "updated_at": "2026-04-15T12:00:00Z",
+            "strategies": [
+                {"scopes": [{"environment_scope": "production"}]},
+                {"scopes": [{"environment_scope": "staging"}]},
+            ],
+        }
+    ]
+
+    records = normalize_gitlab_feature_flags(
+        flags,
+        project_key="group/project",
+        org_id="org-1",
+    )
+
+    assert len(records) == 2
+    assert {record.environment for record in records} == {"production", "staging"}
+    assert {record.flag_key for record in records} == {"awesome_feature"}
+    assert all(record.provider == "gitlab" for record in records)
+    assert all(record.project_key == "group/project" for record in records)
+
+
+def test_snapshot_gitlab_feature_flag_events_tracks_current_toggle_state():
+    flags = [
+        {
+            "name": "awesome_feature",
+            "active": False,
+            "updated_at": "2026-04-15T14:30:00Z",
+            "strategies": [
+                {"scopes": [{"environment_scope": "production"}]},
+                {"scopes": [{"environment_scope": "*"}]},
+            ],
+        }
+    ]
+
+    events = snapshot_gitlab_feature_flag_events(
+        flags,
+        project_key="group/project",
+        org_id="org-1",
+    )
+
+    assert len(events) == 2
+    assert {event.environment for event in events} == {"production", "*"}
+    assert all(event.event_type == "toggle" for event in events)
+    assert all(event.next_state == "off" for event in events)
+    assert all(
+        event.dedupe_key.startswith("gitlab:group/project:awesome_feature")
+        for event in events
+    )


### PR DESCRIPTION
## Summary
- align synthetic feature flag fixtures with the work graph by generating release, PR, and flag relationships the frontend actually queries
- add GitLab feature flag ingestion primitives plus LaunchDarkly and GitLab feature-flag sync support in admin and worker runtime paths
- expose feature-flag provider targets in admin sync APIs and cover the new provider paths with focused tests

## Verification
- python -m py_compile on edited feature-flag sync and fixture modules
- python -m pytest tests/test_gitlab_feature_flags.py tests/test_admin_sync_targets.py tests/test_launchdarkly.py tests/test_gitlab_connector.py -q
- python -m pytest tests -q -k \"feature_flag or fixtures or work_graph\"

## Notes
- Companion frontend PR: https://github.com/full-chaos/dev-health-web/pull/405