### PR TITLE
refactor(CHAOS-1204): break cyclic import — move STANDARD_FEATURES to licensing/registry

### DIFF
--- a/src/dev_health_ops/alembic/versions/0006_seed_feature_flags.py
+++ b/src/dev_health_ops/alembic/versions/0006_seed_feature_flags.py
@@ -26,6 +26,10 @@ down_revision: str | None = "0005"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
+# Alembic reads the four names above via module introspection; declare them
+# as public to quiet `py/unused-global-variable`.
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
 # Keys seeded by this migration — used in downgrade() to delete only these rows.
 # Must stay in sync with STANDARD_FEATURES in models/licensing.py.
 # Inlined here to avoid importing application code at migration runtime.

--- a/src/dev_health_ops/licensing/__init__.py
+++ b/src/dev_health_ops/licensing/__init__.py
@@ -18,13 +18,17 @@ from dev_health_ops.licensing.generator import (
     sign_license,
     sign_payload,
 )
+from dev_health_ops.licensing.registry import (
+    STANDARD_FEATURES,
+    get_features_for_tier,
+)
 from dev_health_ops.licensing.types import (
     DEFAULT_LIMITS,
     GRACE_DAYS,
+    FeatureCategory,
     LicenseLimits,
     LicensePayload,
     LicenseTier,
-    get_features_for_tier,
 )
 from dev_health_ops.licensing.validator import (
     LicenseExpiredError,
@@ -40,6 +44,8 @@ __all__ = [
     "LicensePayload",
     "DEFAULT_LIMITS",
     "GRACE_DAYS",
+    "FeatureCategory",
+    "STANDARD_FEATURES",
     "get_features_for_tier",
     # Validator
     "LicenseValidator",

--- a/src/dev_health_ops/licensing/gating.py
+++ b/src/dev_health_ops/licensing/gating.py
@@ -11,11 +11,11 @@ from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from dev_health_ops.licensing.registry import get_features_for_tier
 from dev_health_ops.licensing.types import (
     DEFAULT_LIMITS,
     LicensePayload,
     LicenseTier,
-    get_features_for_tier,
 )
 from dev_health_ops.licensing.validator import LicenseValidator, ValidationResult
 

--- a/src/dev_health_ops/licensing/generator.py
+++ b/src/dev_health_ops/licensing/generator.py
@@ -12,13 +12,13 @@ from uuid import uuid4
 
 from nacl.signing import SigningKey
 
+from dev_health_ops.licensing.registry import get_features_for_tier
 from dev_health_ops.licensing.types import (
     DEFAULT_LIMITS,
     GRACE_DAYS,
     LicenseLimits,
     LicensePayload,
     LicenseTier,
-    get_features_for_tier,
 )
 
 

--- a/src/dev_health_ops/licensing/registry.py
+++ b/src/dev_health_ops/licensing/registry.py
@@ -1,0 +1,205 @@
+"""Canonical feature registry.
+
+Single source of truth for feature keys. Lives in `licensing/` (not `models/`)
+so it can be imported without pulling in SQLAlchemy, and without creating
+a cycle between `models.licensing` and `licensing.types`.
+"""
+
+from __future__ import annotations
+
+from dev_health_ops.licensing.types import TIER_ORDER, FeatureCategory, LicenseTier
+
+STANDARD_FEATURE_ROW = tuple[str, str, FeatureCategory, LicenseTier, str]
+
+
+def get_features_for_tier(tier: LicenseTier) -> dict[str, bool]:
+    """Return a feature-key → enabled dict for the given tier.
+
+    A feature is enabled when its ``min_tier`` is <= the requested tier.
+    Canonical single source of truth (replaces the deleted ``DEFAULT_FEATURES``).
+    """
+    tier_index = TIER_ORDER.index(tier) if tier in TIER_ORDER else 0
+    result: dict[str, bool] = {}
+    for key, _name, _category, min_tier, _desc in STANDARD_FEATURES:
+        min_index = TIER_ORDER.index(min_tier) if min_tier in TIER_ORDER else 0
+        result[key] = tier_index >= min_index
+    return result
+
+
+STANDARD_FEATURES: list[STANDARD_FEATURE_ROW] = [
+    (
+        "git_sync",
+        "Git Sync",
+        FeatureCategory.CORE,
+        LicenseTier.COMMUNITY,
+        "Sync git commits and PRs",
+    ),
+    (
+        "work_items_sync",
+        "Work Items Sync",
+        FeatureCategory.CORE,
+        LicenseTier.COMMUNITY,
+        "Sync work items from providers",
+    ),
+    (
+        "basic_analytics",
+        "Basic Analytics",
+        FeatureCategory.ANALYTICS,
+        LicenseTier.COMMUNITY,
+        "Basic metrics and dashboards",
+    ),
+    (
+        "team_management",
+        "Team Management",
+        FeatureCategory.CORE,
+        LicenseTier.COMMUNITY,
+        "Basic team configuration",
+    ),
+    (
+        "github_integration",
+        "GitHub Integration",
+        FeatureCategory.INTEGRATIONS,
+        LicenseTier.TEAM,
+        "GitHub provider integration",
+    ),
+    (
+        "gitlab_integration",
+        "GitLab Integration",
+        FeatureCategory.INTEGRATIONS,
+        LicenseTier.TEAM,
+        "GitLab provider integration",
+    ),
+    (
+        "jira_integration",
+        "Jira Integration",
+        FeatureCategory.INTEGRATIONS,
+        LicenseTier.TEAM,
+        "Jira provider integration",
+    ),
+    (
+        "investment_view",
+        "Investment View",
+        FeatureCategory.ANALYTICS,
+        LicenseTier.TEAM,
+        "Investment categorization view",
+    ),
+    (
+        "api_access",
+        "API Access",
+        FeatureCategory.CORE,
+        LicenseTier.TEAM,
+        "REST and GraphQL API access",
+    ),
+    (
+        "capacity_forecast",
+        "Capacity Forecast",
+        FeatureCategory.ANALYTICS,
+        LicenseTier.TEAM,
+        "Capacity planning forecasts",
+    ),
+    (
+        "work_graph",
+        "Work Graph",
+        FeatureCategory.ANALYTICS,
+        LicenseTier.TEAM,
+        "Work graph analysis",
+    ),
+    (
+        "quadrant_analysis",
+        "Quadrant Analysis",
+        FeatureCategory.ANALYTICS,
+        LicenseTier.TEAM,
+        "Quadrant metrics analysis",
+    ),
+    (
+        "linear_integration",
+        "Linear Integration",
+        FeatureCategory.INTEGRATIONS,
+        LicenseTier.TEAM,
+        "Linear provider integration",
+    ),
+    (
+        "llm_categorization",
+        "LLM Categorization",
+        FeatureCategory.ANALYTICS,
+        LicenseTier.TEAM,
+        "AI-powered work categorization",
+    ),
+    (
+        "webhooks",
+        "Webhooks",
+        FeatureCategory.INTEGRATIONS,
+        LicenseTier.TEAM,
+        "Webhook ingestion",
+    ),
+    (
+        "scheduled_jobs",
+        "Scheduled Jobs",
+        FeatureCategory.CORE,
+        LicenseTier.TEAM,
+        "Automated scheduled sync jobs",
+    ),
+    (
+        "sso_saml",
+        "SAML SSO",
+        FeatureCategory.SECURITY,
+        LicenseTier.ENTERPRISE,
+        "SAML single sign-on",
+    ),
+    (
+        "sso_oidc",
+        "OIDC SSO",
+        FeatureCategory.SECURITY,
+        LicenseTier.ENTERPRISE,
+        "OIDC single sign-on",
+    ),
+    (
+        "audit_log",
+        "Audit Log",
+        FeatureCategory.COMPLIANCE,
+        LicenseTier.ENTERPRISE,
+        "Audit logging",
+    ),
+    (
+        "custom_retention",
+        "Custom Retention",
+        FeatureCategory.COMPLIANCE,
+        LicenseTier.ENTERPRISE,
+        "Custom data retention policies",
+    ),
+    (
+        "ip_allowlist",
+        "IP Allowlist",
+        FeatureCategory.SECURITY,
+        LicenseTier.ENTERPRISE,
+        "IP address allowlisting",
+    ),
+    (
+        "data_export",
+        "Data Export",
+        FeatureCategory.COMPLIANCE,
+        LicenseTier.ENTERPRISE,
+        "Bulk data export",
+    ),
+    (
+        "multi_org",
+        "Multi-Organization",
+        FeatureCategory.ADMIN,
+        LicenseTier.ENTERPRISE,
+        "Multiple organization support",
+    ),
+    (
+        "custom_branding",
+        "Custom Branding",
+        FeatureCategory.ADMIN,
+        LicenseTier.ENTERPRISE,
+        "Custom branding and white-label",
+    ),
+    (
+        "priority_support",
+        "Priority Support",
+        FeatureCategory.ADMIN,
+        LicenseTier.ENTERPRISE,
+        "Priority support SLA",
+    ),
+]

--- a/src/dev_health_ops/licensing/types.py
+++ b/src/dev_health_ops/licensing/types.py
@@ -12,6 +12,17 @@ class LicenseTier(str, Enum):
     ENTERPRISE = "enterprise"
 
 
+class FeatureCategory(str, Enum):
+    """Categories for grouping features."""
+
+    CORE = "core"
+    ANALYTICS = "analytics"
+    INTEGRATIONS = "integrations"
+    SECURITY = "security"
+    COMPLIANCE = "compliance"
+    ADMIN = "admin"
+
+
 class LicenseLimits(BaseModel):
     users: int = Field(description="Max users, -1 for unlimited")
     repos: int = Field(description="Max repos, -1 for unlimited")
@@ -55,28 +66,8 @@ GRACE_DAYS: dict[LicenseTier, int] = {
 }
 
 # Tier ordering for comparison (higher index = higher tier)
-_TIER_ORDER: list[LicenseTier] = [
+TIER_ORDER: list[LicenseTier] = [
     LicenseTier.COMMUNITY,
     LicenseTier.TEAM,
     LicenseTier.ENTERPRISE,
 ]
-
-
-def get_features_for_tier(tier: LicenseTier) -> dict[str, bool]:
-    """Return a feature-key → enabled dict for the given tier.
-
-    A feature is enabled when its ``min_tier`` is <= the requested tier.
-    This is the single source of truth replacing the deleted ``DEFAULT_FEATURES``.
-    Lazily imports STANDARD_FEATURES from models.licensing to avoid circular imports.
-    """
-    # Lazy import to break the circular dependency:
-    # models/licensing.py imports licensing.types → licensing/__init__ → gating.py
-    # → models/licensing.py (circular if imported at module level)
-    from dev_health_ops.models.licensing import STANDARD_FEATURES  # noqa: PLC0415
-
-    tier_index = _TIER_ORDER.index(tier) if tier in _TIER_ORDER else 0
-    result: dict[str, bool] = {}
-    for key, _name, _category, min_tier, _desc in STANDARD_FEATURES:
-        min_index = _TIER_ORDER.index(min_tier) if min_tier in _TIER_ORDER else 0
-        result[key] = tier_index >= min_index
-    return result

--- a/src/dev_health_ops/models/licensing.py
+++ b/src/dev_health_ops/models/licensing.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
-from enum import Enum
 
 from sqlalchemy import (
     JSON,
@@ -28,19 +27,16 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 
+# Back-compat re-exports: callers that imported these from `models.licensing`
+# pre-refactor should keep working. Canonical homes are licensing/{types,registry}.py.
+from dev_health_ops.licensing.registry import (
+    STANDARD_FEATURES as STANDARD_FEATURES,  # noqa: F401
+)
+from dev_health_ops.licensing.types import (
+    FeatureCategory as FeatureCategory,  # noqa: F401
+)
 from dev_health_ops.licensing.types import LicenseTier
 from dev_health_ops.models.git import GUID, Base
-
-
-class FeatureCategory(str, Enum):
-    """Categories for grouping features."""
-
-    CORE = "core"
-    ANALYTICS = "analytics"
-    INTEGRATIONS = "integrations"
-    SECURITY = "security"
-    COMPLIANCE = "compliance"
-    ADMIN = "admin"
 
 
 class FeatureFlag(Base):
@@ -515,187 +511,3 @@ TIER_LIMITS_DEFAULTS = {
 
 # Backward-compat alias — existing code imports TIER_LIMITS
 TIER_LIMITS = TIER_LIMITS_DEFAULTS
-
-STANDARD_FEATURES = [
-    (
-        "git_sync",
-        "Git Sync",
-        FeatureCategory.CORE,
-        LicenseTier.COMMUNITY,
-        "Sync git commits and PRs",
-    ),
-    (
-        "work_items_sync",
-        "Work Items Sync",
-        FeatureCategory.CORE,
-        LicenseTier.COMMUNITY,
-        "Sync work items from providers",
-    ),
-    (
-        "basic_analytics",
-        "Basic Analytics",
-        FeatureCategory.ANALYTICS,
-        LicenseTier.COMMUNITY,
-        "Basic metrics and dashboards",
-    ),
-    (
-        "team_management",
-        "Team Management",
-        FeatureCategory.CORE,
-        LicenseTier.COMMUNITY,
-        "Basic team configuration",
-    ),
-    (
-        "github_integration",
-        "GitHub Integration",
-        FeatureCategory.INTEGRATIONS,
-        LicenseTier.TEAM,
-        "GitHub provider integration",
-    ),
-    (
-        "gitlab_integration",
-        "GitLab Integration",
-        FeatureCategory.INTEGRATIONS,
-        LicenseTier.TEAM,
-        "GitLab provider integration",
-    ),
-    (
-        "jira_integration",
-        "Jira Integration",
-        FeatureCategory.INTEGRATIONS,
-        LicenseTier.TEAM,
-        "Jira provider integration",
-    ),
-    (
-        "investment_view",
-        "Investment View",
-        FeatureCategory.ANALYTICS,
-        LicenseTier.TEAM,
-        "Investment categorization view",
-    ),
-    (
-        "api_access",
-        "API Access",
-        FeatureCategory.CORE,
-        LicenseTier.TEAM,
-        "REST and GraphQL API access",
-    ),
-    (
-        "capacity_forecast",
-        "Capacity Forecast",
-        FeatureCategory.ANALYTICS,
-        LicenseTier.TEAM,
-        "Capacity planning forecasts",
-    ),
-    (
-        "work_graph",
-        "Work Graph",
-        FeatureCategory.ANALYTICS,
-        LicenseTier.TEAM,
-        "Work graph analysis",
-    ),
-    (
-        "quadrant_analysis",
-        "Quadrant Analysis",
-        FeatureCategory.ANALYTICS,
-        LicenseTier.TEAM,
-        "Quadrant metrics analysis",
-    ),
-    (
-        "linear_integration",
-        "Linear Integration",
-        FeatureCategory.INTEGRATIONS,
-        LicenseTier.TEAM,
-        "Linear provider integration",
-    ),
-    (
-        "llm_categorization",
-        "LLM Categorization",
-        FeatureCategory.ANALYTICS,
-        LicenseTier.TEAM,
-        "AI-powered work categorization",
-    ),
-    (
-        "webhooks",
-        "Webhooks",
-        FeatureCategory.INTEGRATIONS,
-        LicenseTier.TEAM,
-        "Webhook ingestion",
-    ),
-    (
-        "scheduled_jobs",
-        "Scheduled Jobs",
-        FeatureCategory.CORE,
-        LicenseTier.TEAM,
-        "Automated scheduled sync jobs",
-    ),
-    (
-        "sso_saml",
-        "SAML SSO",
-        FeatureCategory.SECURITY,
-        LicenseTier.ENTERPRISE,
-        "SAML single sign-on",
-    ),
-    (
-        "sso_oidc",
-        "OIDC SSO",
-        FeatureCategory.SECURITY,
-        LicenseTier.ENTERPRISE,
-        "OIDC single sign-on",
-    ),
-    (
-        "audit_log",
-        "Audit Log",
-        FeatureCategory.COMPLIANCE,
-        LicenseTier.ENTERPRISE,
-        "Audit logging",
-    ),
-    (
-        "custom_retention",
-        "Custom Retention",
-        FeatureCategory.COMPLIANCE,
-        LicenseTier.ENTERPRISE,
-        "Custom data retention policies",
-    ),
-    (
-        "ip_allowlist",
-        "IP Allowlist",
-        FeatureCategory.SECURITY,
-        LicenseTier.ENTERPRISE,
-        "IP address allowlisting",
-    ),
-    (
-        "data_export",
-        "Data Export",
-        FeatureCategory.COMPLIANCE,
-        LicenseTier.ENTERPRISE,
-        "Bulk data export",
-    ),
-    (
-        "multi_org",
-        "Multi-Organization",
-        FeatureCategory.ADMIN,
-        LicenseTier.ENTERPRISE,
-        "Multiple organization support",
-    ),
-    (
-        "custom_branding",
-        "Custom Branding",
-        FeatureCategory.ADMIN,
-        LicenseTier.ENTERPRISE,
-        "Custom branding and white-label",
-    ),
-    (
-        "priority_support",
-        "Priority Support",
-        FeatureCategory.ADMIN,
-        LicenseTier.ENTERPRISE,
-        "Priority support SLA",
-    ),
-]
-
-# Re-export get_features_for_tier for callers that import from models.licensing.
-# The canonical definition lives in licensing.types to avoid circular imports.
-from dev_health_ops.licensing.types import (  # noqa: E402,F401,I001
-    get_features_for_tier as get_features_for_tier,
-)

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -17,11 +17,11 @@ from dev_health_ops.licensing import (
     sign_license,
     sign_payload,
 )
+from dev_health_ops.licensing.registry import get_features_for_tier
 from dev_health_ops.licensing.types import (
     DEFAULT_LIMITS,
     GRACE_DAYS,
     LicenseLimits,
-    get_features_for_tier,
 )
 
 


### PR DESCRIPTION
## Summary

Follow-up to #667 addressing CodeQL `py/cyclic-import` findings that were not caught before the original merge.

## Changes
- New module `licensing/registry.py` owns `STANDARD_FEATURES` and `get_features_for_tier` (single source of truth, no SQLAlchemy dependency)
- `licensing/types.py` gains `FeatureCategory` and `TIER_ORDER` (moved from `models/licensing.py`)
- `models/licensing.py` re-exports both names for back-compat with existing callers (`from ... import STANDARD_FEATURES as STANDARD_FEATURES # noqa: F401`)
- Alembic migration `0006_seed_feature_flags.py` declares `__all__` on the four Alembic-introspected module globals to quiet `py/unused-global-variable`

## Import graph (post-refactor, acyclic)
```
models/licensing.py
    → licensing/registry.py → licensing/types.py
    → licensing/types.py
licensing/{gating,generator,__init__}.py → licensing/registry.py
                                         → licensing/types.py
```
No module both imports and is imported by another.

## Test plan
- [x] 95 licensing tests pass
- [x] 101 billing+admin+licensing tests pass (1 pre-existing `test_checkout_invalid_tier` failure unrelated — SQLite `max_overflow`)
- [x] `ruff format --check` + `ruff check` clean

SCREENSHOT-WAIVER: Internal module restructure, no rendered output changes.