### PR TITLE
feat: register feature flag measures in analytics API

### DIFF
--- a/src/dev_health_ops/api/graphql/models/inputs.py
+++ b/src/dev_health_ops/api/graphql/models/inputs.py
@@ -40,6 +40,10 @@ class MeasureInput(Enum):
     COVERAGE_LINE_PCT = "coverage_line_pct"
     COVERAGE_BRANCH_PCT = "coverage_branch_pct"
     COVERAGE_DELTA_PCT = "coverage_delta_pct"
+    FLAG_FRICTION_DELTA = "flag_friction_delta"
+    FLAG_ERROR_RATE_DELTA = "flag_error_rate_delta"
+    FLAG_COVERAGE_RATIO = "flag_coverage_ratio"
+    FLAG_ACTIVATION_RATE = "flag_activation_rate"
 
 
 @strawberry.enum

--- a/src/dev_health_ops/api/graphql/sql/validate.py
+++ b/src/dev_health_ops/api/graphql/sql/validate.py
@@ -64,6 +64,10 @@ class Measure(str, Enum):
     COVERAGE_LINE_PCT = "coverage_line_pct"
     COVERAGE_BRANCH_PCT = "coverage_branch_pct"
     COVERAGE_DELTA_PCT = "coverage_delta_pct"
+    FLAG_FRICTION_DELTA = "flag_friction_delta"
+    FLAG_ERROR_RATE_DELTA = "flag_error_rate_delta"
+    FLAG_COVERAGE_RATIO = "flag_coverage_ratio"
+    FLAG_ACTIVATION_RATE = "flag_activation_rate"
 
     @classmethod
     def values(cls) -> list[str]:
@@ -106,6 +110,13 @@ class Measure(str, Enum):
             cls.COVERAGE_DELTA_PCT: "AVG(coverage_delta_pct)",
         }
         mapping.update(testops_mapping)
+        ff_mapping: dict[Measure, str] = {
+            cls.FLAG_FRICTION_DELTA: "AVG(release_user_friction_delta) * 100",
+            cls.FLAG_ERROR_RATE_DELTA: "AVG(release_error_rate_delta) * 100",
+            cls.FLAG_COVERAGE_RATIO: "AVG(coverage_ratio) * 100",
+            cls.FLAG_ACTIVATION_RATE: "AVG(flag_activation_rate) * 100",
+        }
+        mapping.update(ff_mapping)
         return mapping[measure]
 
     @classmethod
@@ -124,6 +135,13 @@ class Measure(str, Enum):
             cls.COVERAGE_BRANCH_PCT: "testops_coverage_metrics_daily",
             cls.COVERAGE_DELTA_PCT: "testops_coverage_metrics_daily",
         }
+        ff_tables: dict[Measure, str] = {
+            cls.FLAG_FRICTION_DELTA: "release_impact_daily",
+            cls.FLAG_ERROR_RATE_DELTA: "release_impact_daily",
+            cls.FLAG_COVERAGE_RATIO: "release_impact_daily",
+            cls.FLAG_ACTIVATION_RATE: "release_impact_daily",
+        }
+        testops_tables.update(ff_tables)
         return testops_tables.get(measure)
 
 


### PR DESCRIPTION
## Summary

- Adds 4 new measures to the GraphQL analytics API: `FLAG_FRICTION_DELTA`, `FLAG_ERROR_RATE_DELTA`, `FLAG_COVERAGE_RATIO`, `FLAG_ACTIVATION_RATE`
- Maps each to `AVG(column) * 100` on the `release_impact_daily` ClickHouse table
- Registers in both `Measure` (validate.py) and `MeasureInput` (inputs.py) enums

## Context

The feature flags dashboard in dev-health-web shows "Trend" placeholder text instead of sparkline charts because the frontend has no backend timeseries endpoint to query. This PR exposes the existing `release_impact_daily` data through the analytics batch API so the web can request daily timeseries for feature flag metrics.

## Changes

| File | Change |
|---|---|
| `api/graphql/sql/validate.py` | Add 4 `Measure` enum values, `db_expression` (AVG aggregations), and `source_table` mappings to `release_impact_daily` |
| `api/graphql/models/inputs.py` | Add matching `MeasureInput` enum values |

## Companion PR

- **dev-health-web**: full-chaos/dev-health-web#406 (queries these new measures and wires to sparklines)

SCREENSHOT-WAIVER: Backend-only change — no rendered UI output