### PR TITLE
fix: resolve duplicate Alembic migration heads

### DIFF
--- a/src/dev_health_ops/alembic/versions/0007_seed_feature_flags.py
+++ b/src/dev_health_ops/alembic/versions/0007_seed_feature_flags.py
@@ -1,7 +1,7 @@
 """Seed feature_flags table from STANDARD_FEATURES registry.
 
-Revision ID: 0006
-Revises: 0005
+Revision ID: 0007
+Revises: 0006
 Create Date: 2026-04-15 00:00:00
 
 Seeds all 25 STANDARD_FEATURES rows into the feature_flags table so the DB
@@ -21,8 +21,8 @@ from datetime import datetime, timezone
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "0006"
-down_revision: str | None = "0005"
+revision: str = "0007"
+down_revision: str | None = "0006"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Summary

- Renumbers `0006_seed_feature_flags.py` → `0007_seed_feature_flags.py` with `down_revision = "0006"`
- Restores a single linear Alembic head (was: two `0006` revisions both depending on `0005`)

## Problem

PRs #667 and #668 both created revision `0006` with `down_revision = "0005"`. After both merged, `alembic upgrade head` fails with:

```
Multiple head revisions are present for given argument 'head'
```

This breaks the `live-e2e` CI job on all PRs in dev-health-web.

## Fix

`0006_override_updated_by_and_price_cascade` merged first (13:51) so it keeps revision `0006`. `0006_seed_feature_flags` merged second (13:59), so it becomes `0007` depending on `0006`.

The two migrations are independent (different tables), so ordering doesn't affect correctness.

SCREENSHOT-WAIVER: Migration-only change — no rendered UI output