### PR TITLE
Security Hardening Sprint Q2 (10 findings, 1 PR)

### DIFF
--- a/ci/run_live_backend_e2e.sh
+++ b/ci/run_live_backend_e2e.sh
@@ -236,12 +236,26 @@ echo "==> generating deterministic ClickHouse fixtures (metrics + work graph)"
     --with-work-graph
 )
 
+# JWT_SECRET_KEY is now required (no SHA256 derivation fallback) — derive the same
+# value generate_auth_token() uses so tokens match between API and e2e client.
+if [ -z "${JWT_SECRET_KEY:-}" ]; then
+  JWT_SECRET_KEY="$(
+    ENC_KEY_INPUT="${SETTINGS_ENCRYPTION_KEY:-dev-key-not-for-prod}" run_python - <<'PY'
+import hashlib, os
+enc_key = os.environ["ENC_KEY_INPUT"]
+print(hashlib.sha256(enc_key.encode()).hexdigest())
+PY
+  )"
+  export JWT_SECRET_KEY
+fi
+
 echo "==> starting API at ${BASE_URL}"
 (
   export DISABLE_DOTENV=1
   export DATABASE_URI="${DATABASE_URI}"
   export CLICKHOUSE_URI="${CLICKHOUSE_URI}"
   export POSTGRES_URI="${POSTGRES_URI}"
+  export JWT_SECRET_KEY="${JWT_SECRET_KEY}"
   exec_dev_hops \
     --db "${POSTGRES_URI}" \
     --analytics-db "${CLICKHOUSE_URI}" \

--- a/docs/superpowers/plans/2026-04-16-security-sprint.md
+++ b/docs/superpowers/plans/2026-04-16-security-sprint.md
@@ -1,0 +1,1744 @@
+# Security Sprint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close ten security findings (IDOR via X-Org-Id, missing admin auth, SAML XXE surface, JWT fallback secret, SSO domain bypass, forwarded-IP spoofing, drilldown tenant re-check, generic 500 leak, missing security headers, swallowed JWT errors) without regressing existing behaviour.
+
+**Architecture:** Touch only the smallest surface per finding. Prefer defense-in-depth (every layer re-asserts org ownership; every IP read consults a trusted-proxy allowlist). Fail closed on security-critical config (JWT_SECRET_KEY, defusedxml).
+
+**Tech Stack:** Python 3.11+, FastAPI / Starlette ASGI, SQLAlchemy async, pytest + pytest-asyncio, httpx ASGITransport for in-process API tests. Test style matches `tests/api/test_impersonation_middleware.py` (ASGI-level) and `tests/api/auth/test_jwt_secret.py` (unit-level env-var tests).
+
+**Repo conventions verified:**
+- Admin auth dep: `require_admin` in `src/dev_health_ops/api/admin/middleware.py`
+- Current-user dep: `get_current_user` in `src/dev_health_ops/api/auth/router.py`
+- Membership model: `dev_health_ops.models.users.Membership` (has `user_id`, `org_id`)
+- Org-id contextvar: `dev_health_ops.api.services.auth._current_org_id` (get/set via `get_current_org_id` / `set_current_org_id`)
+- Forwarded-IP helper: `dev_health_ops.api.middleware.rate_limit.get_forwarded_ip`
+
+---
+
+## Task 1: Membership check in OrgIdMiddleware
+
+**Files:**
+- Modify: `src/dev_health_ops/api/middleware/__init__.py`
+- Test: `tests/api/test_org_id_middleware_membership.py` (new)
+
+**Goal:** Reject requests whose `X-Org-Id` header does not match any `Membership` row for the authenticated user (or is not the user's JWT org_id when JWT present). Currently the middleware accepts any header value — an IDOR (attacker with any valid JWT can read another tenant's data).
+
+- [ ] **Step 1.1: Write failing ASGI test (header + non-member org)**
+
+Create `tests/api/test_org_id_middleware_membership.py`:
+
+```python
+"""Membership-aware X-Org-Id middleware tests (CHAOS security sprint).
+
+Verifies that OrgIdMiddleware rejects a forged X-Org-Id header pointing at
+an org the authenticated user is NOT a member of.
+"""
+from __future__ import annotations
+
+import types
+import uuid
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from dev_health_ops.api.middleware import OrgIdMiddleware
+from dev_health_ops.api.services.auth import (
+    _current_org_id,
+    AuthenticatedUser,
+    get_current_org_id,
+)
+
+
+def _fake_user(user_id: str, jwt_org_id: str) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=user_id,
+        email="u@example.com",
+        org_id=jwt_org_id,
+        role="member",
+    )
+
+
+def _build_app(captured: dict) -> Any:
+    async def _handler(scope, receive, send):
+        captured["org_id"] = get_current_org_id()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"{}"})
+
+    return OrgIdMiddleware(_handler)
+
+
+@pytest.mark.asyncio
+async def test_header_for_non_member_org_is_rejected():
+    """X-Org-Id header for an org the user does NOT belong to must 403."""
+    user_id = str(uuid.uuid4())
+    member_org = str(uuid.uuid4())
+    foreign_org = str(uuid.uuid4())
+    user = _fake_user(user_id, member_org)
+
+    captured: dict = {}
+    app = _build_app(captured)
+
+    with (
+        patch(
+            "dev_health_ops.api.middleware.get_authenticated_user_from_headers",
+            return_value=user,
+        ),
+        patch(
+            "dev_health_ops.api.middleware.user_is_member_of_org",
+            return_value=False,
+        ),
+    ):
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/",
+                    headers={
+                        "authorization": "Bearer tok",
+                        "x-org-id": foreign_org,
+                    },
+                )
+        finally:
+            _current_org_id.set(None)
+
+    assert response.status_code == 403, response.text
+    assert captured.get("org_id") is None
+```
+
+- [ ] **Step 1.2: Run test to verify failure**
+
+Run: `uv run pytest tests/api/test_org_id_middleware_membership.py::test_header_for_non_member_org_is_rejected -xvs`
+Expected: FAIL — `get_authenticated_user_from_headers` / `user_is_member_of_org` do not yet exist on the middleware module (AttributeError).
+
+- [ ] **Step 1.3: Implement membership check in middleware**
+
+Replace the body of `src/dev_health_ops/api/middleware/__init__.py` with:
+
+```python
+"""Per-request org_id extraction middleware.
+
+Sets the org_id contextvar for every HTTP request from:
+  1. X-Org-Id header (authoritative - sent by frontend for all API calls)
+  2. JWT org_id claim (fallback - when header is absent)
+
+IDOR protection: the X-Org-Id header is ONLY accepted if the authenticated
+user has a Membership row for that org (or the JWT org_id matches). Any
+other value yields HTTP 403.
+
+This is the SINGLE enforcement point for tenant scoping. All downstream
+ClickHouse queries auto-inject org_id via query_dicts().
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid as uuid_mod
+from typing import Iterable
+
+from sqlalchemy import select
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from dev_health_ops.api.services.auth import (
+    AuthenticatedUser,
+    _current_org_id,
+    extract_token_from_header,
+    get_auth_service,
+    set_current_org_id,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_authenticated_user_from_headers(
+    headers: Iterable[tuple[bytes, bytes]],
+) -> AuthenticatedUser | None:
+    for key, value in headers:
+        if key == b"authorization":
+            token = extract_token_from_header(value.decode("latin-1"))
+            if not token:
+                return None
+            return get_auth_service().get_authenticated_user(token)
+    return None
+
+
+async def user_is_member_of_org(user_id: str, org_id: str) -> bool:
+    """Return True iff the user has an active Membership for org_id."""
+    try:
+        user_uuid = uuid_mod.UUID(user_id)
+        org_uuid = uuid_mod.UUID(org_id)
+    except (ValueError, TypeError):
+        return False
+
+    from dev_health_ops.db import get_postgres_session
+    from dev_health_ops.models.users import Membership
+
+    async with get_postgres_session() as session:
+        result = await session.execute(
+            select(Membership.id)
+            .where(Membership.user_id == user_uuid)
+            .where(Membership.org_id == org_uuid)
+            .limit(1)
+        )
+        return result.scalar_one_or_none() is not None
+
+
+def _forbidden_response(message: str) -> tuple[bytes, bytes]:
+    body = json.dumps({"detail": message}).encode("utf-8")
+    return body, b"application/json"
+
+
+class OrgIdMiddleware:
+    """Pure ASGI middleware — extracts org_id, verifies membership, sets contextvar."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        headers = scope.get("headers", [])
+        header_org_id: str | None = None
+        for key, value in headers:
+            if key == b"x-org-id":
+                header_org_id = value.decode("latin-1").strip() or None
+                break
+
+        user = get_authenticated_user_from_headers(headers)
+
+        resolved_org_id: str | None = None
+        if header_org_id:
+            if user is None:
+                await self._deny(send, "Authentication required for X-Org-Id")
+                return
+            if header_org_id == user.org_id:
+                resolved_org_id = header_org_id
+            elif await user_is_member_of_org(user.user_id, header_org_id):
+                resolved_org_id = header_org_id
+            else:
+                logger.warning(
+                    "X-Org-Id rejected: user=%s tried to access org=%s",
+                    user.user_id,
+                    header_org_id,
+                )
+                await self._deny(send, "X-Org-Id not permitted for this user")
+                return
+        elif user is not None and user.org_id:
+            resolved_org_id = user.org_id
+
+        token = set_current_org_id(resolved_org_id) if resolved_org_id else None
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            if token is not None:
+                _current_org_id.reset(token)
+
+    @staticmethod
+    async def _deny(send: Send, message: str) -> None:
+        body = json.dumps({"detail": message}).encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 403,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+
+
+__all__ = ["OrgIdMiddleware", "get_authenticated_user_from_headers", "user_is_member_of_org"]
+```
+
+- [ ] **Step 1.4: Run failing test again — it should now pass**
+
+Run: `uv run pytest tests/api/test_org_id_middleware_membership.py::test_header_for_non_member_org_is_rejected -xvs`
+Expected: PASS.
+
+- [ ] **Step 1.5: Add two more behaviour tests (happy-path + JWT-only)**
+
+Append to the same test file:
+
+```python
+@pytest.mark.asyncio
+async def test_header_for_member_org_is_accepted():
+    """X-Org-Id for an org the user IS a member of must be accepted."""
+    user_id = str(uuid.uuid4())
+    member_org = str(uuid.uuid4())
+    secondary_org = str(uuid.uuid4())
+    user = _fake_user(user_id, member_org)
+
+    captured: dict = {}
+    app = _build_app(captured)
+
+    with (
+        patch(
+            "dev_health_ops.api.middleware.get_authenticated_user_from_headers",
+            return_value=user,
+        ),
+        patch(
+            "dev_health_ops.api.middleware.user_is_member_of_org",
+            return_value=True,
+        ),
+    ):
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/",
+                    headers={
+                        "authorization": "Bearer tok",
+                        "x-org-id": secondary_org,
+                    },
+                )
+        finally:
+            _current_org_id.set(None)
+
+    assert response.status_code == 200
+    assert captured["org_id"] == secondary_org
+
+
+@pytest.mark.asyncio
+async def test_missing_header_falls_back_to_jwt_org():
+    """No X-Org-Id: JWT org_id is used and no membership check is performed."""
+    user_id = str(uuid.uuid4())
+    jwt_org = str(uuid.uuid4())
+    user = _fake_user(user_id, jwt_org)
+
+    captured: dict = {}
+    app = _build_app(captured)
+
+    with patch(
+        "dev_health_ops.api.middleware.get_authenticated_user_from_headers",
+        return_value=user,
+    ):
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get("/", headers={"authorization": "Bearer tok"})
+        finally:
+            _current_org_id.set(None)
+
+    assert response.status_code == 200
+    assert captured["org_id"] == jwt_org
+```
+
+- [ ] **Step 1.6: Run full test file — all three must pass**
+
+Run: `uv run pytest tests/api/test_org_id_middleware_membership.py -xvs`
+Expected: 3 passed.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add src/dev_health_ops/api/middleware/__init__.py tests/api/test_org_id_middleware_membership.py
+git commit -m "fix(security): enforce membership check on X-Org-Id header (IDOR)"
+```
+
+---
+
+## Task 2: Admin org-GET requires auth
+
+**Files:**
+- Modify: `src/dev_health_ops/api/admin/routers/orgs.py` (the `GET /orgs/{org_id}` handler, lines 67-86)
+- Test: `tests/api/admin/test_orgs_auth.py` (new)
+
+**Goal:** Add `Depends(require_superuser)` to `GET /admin/orgs/{org_id}` so anonymous callers cannot read any org by UUID. All siblings on the same router already gate on `require_superuser` or `require_admin`; only this GET was missed.
+
+- [ ] **Step 2.1: Write failing auth-required test**
+
+Create `tests/api/admin/test_orgs_auth.py`:
+
+```python
+"""Auth-dependency tests for admin orgs router (CHAOS security sprint)."""
+from __future__ import annotations
+
+import importlib
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import Organization
+
+orgs_router_module = importlib.import_module(
+    "dev_health_ops.api.admin.routers.orgs"
+)
+admin_common = importlib.import_module("dev_health_ops.api.admin.routers.common")
+admin_middleware = importlib.import_module("dev_health_ops.api.admin.middleware")
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "orgs-auth.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn, tables=[Organization.__table__]
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def _seed_org(session_maker) -> str:
+    org_id = uuid.uuid4()
+    org = Organization(id=org_id, slug=f"o-{org_id.hex[:8]}", name="Acme")
+    async with session_maker() as session:
+        session.add(org)
+        await session.commit()
+    return str(org_id)
+
+
+def _app(session_maker, current_user: AuthenticatedUser | None):
+    app = FastAPI()
+    app.include_router(orgs_router_module.router, prefix="/admin")
+
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+            await session.commit()
+
+    app.dependency_overrides[admin_common.get_session] = _session_override
+    if current_user is not None:
+        from dev_health_ops.api.auth.router import get_current_user
+
+        app.dependency_overrides[get_current_user] = lambda: current_user
+    return app
+
+
+@pytest.mark.asyncio
+async def test_get_org_by_id_rejects_anonymous(session_maker):
+    """GET /admin/orgs/{id} must 401 when no bearer token is supplied."""
+    org_id = await _seed_org(session_maker)
+    app = _app(session_maker, current_user=None)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get(f"/admin/orgs/{org_id}")
+    assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
+async def test_get_org_by_id_rejects_non_superuser(session_maker):
+    """GET /admin/orgs/{id} must 403 when caller is not a superuser."""
+    org_id = await _seed_org(session_maker)
+    member = AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        email="m@example.com",
+        org_id=str(uuid.uuid4()),
+        role="member",
+        is_superuser=False,
+    )
+    app = _app(session_maker, current_user=member)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get(f"/admin/orgs/{org_id}")
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_get_org_by_id_accepts_superuser(session_maker):
+    """GET /admin/orgs/{id} must 200 for superuser."""
+    org_id = await _seed_org(session_maker)
+    su = AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        email="su@example.com",
+        org_id=str(uuid.uuid4()),
+        role="owner",
+        is_superuser=True,
+    )
+    app = _app(session_maker, current_user=su)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get(f"/admin/orgs/{org_id}")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["id"] == org_id
+```
+
+- [ ] **Step 2.2: Run tests to verify two failures**
+
+Run: `uv run pytest tests/api/admin/test_orgs_auth.py -xvs`
+Expected: `test_get_org_by_id_rejects_anonymous` and `test_get_org_by_id_rejects_non_superuser` FAIL with 200 (currently unauthenticated). `test_get_org_by_id_accepts_superuser` likely PASSES already.
+
+- [ ] **Step 2.3: Add auth dependency to the handler**
+
+In `src/dev_health_ops/api/admin/routers/orgs.py`, change lines 67-71 from:
+
+```python
+@router.get("/orgs/{org_id}", response_model=OrganizationResponse)
+async def get_organization(
+    org_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> OrganizationResponse:
+```
+
+to:
+
+```python
+@router.get("/orgs/{org_id}", response_model=OrganizationResponse)
+async def get_organization(
+    org_id: str,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(require_superuser),
+) -> OrganizationResponse:
+```
+
+(`require_superuser` is already imported on line 10 and `AuthenticatedUser` on line 22 — no new imports needed.)
+
+- [ ] **Step 2.4: Run tests to verify pass**
+
+Run: `uv run pytest tests/api/admin/test_orgs_auth.py -xvs`
+Expected: 3 passed.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/dev_health_ops/api/admin/routers/orgs.py tests/api/admin/test_orgs_auth.py
+git commit -m "fix(security): require superuser on GET /admin/orgs/{org_id}"
+```
+
+---
+
+## Task 3: Make defusedxml required & remove stdlib XML import
+
+**Files:**
+- Modify: `pyproject.toml` (move defusedxml out of `enterprise-sso` extra, into core deps)
+- Modify: `src/dev_health_ops/api/services/sso.py` (remove top-level `from xml.etree import ElementTree`, use defusedxml types everywhere, remove try/except fallback in `_parse_saml_xml`)
+- Test: `tests/api/services/test_sso_xxe.py` (new)
+
+**Goal:** Eliminate the stdlib XML import surface entirely — defusedxml becomes a hard dep and the parser raises on any DOCTYPE/entity-expansion attempt. Current `_parse_saml_xml` already raises if defusedxml is missing but the `from xml.etree import ElementTree` at module top-level still exists (used for `ElementTree.Element` annotations + `ElementTree.ParseError`). Replace with the defusedxml equivalents so no stdlib XML can ever be exercised.
+
+- [ ] **Step 3.1: Write failing XXE test**
+
+Create `tests/api/services/test_sso_xxe.py`:
+
+```python
+"""XXE-resistance tests for SAML XML parsing (CHAOS security sprint)."""
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.services.sso import SAMLProcessingError, SSOService
+
+
+XXE_PAYLOAD = b"""<?xml version="1.0"?>
+<!DOCTYPE foo [
+  <!ELEMENT foo ANY >
+  <!ENTITY xxe SYSTEM "file:///etc/passwd" >
+]>
+<foo>&xxe;</foo>
+"""
+
+
+def test_parse_saml_xml_rejects_doctype_payload():
+    """defusedxml must reject any DOCTYPE declaration (XXE protection)."""
+    with pytest.raises(SAMLProcessingError):
+        SSOService._parse_saml_xml(XXE_PAYLOAD)
+
+
+def test_parse_saml_xml_rejects_external_entity():
+    """External entity resolution must be impossible."""
+    payload = b"""<?xml version="1.0"?>
+<!DOCTYPE lolz [<!ENTITY lol "lol">]>
+<lolz>&lol;</lolz>
+"""
+    with pytest.raises(SAMLProcessingError):
+        SSOService._parse_saml_xml(payload)
+
+
+def test_parse_saml_xml_accepts_benign_xml():
+    """Sanity: a well-formed SAML-shaped document still parses."""
+    xml = b"<samlp:Response xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'/>"
+    tree = SSOService._parse_saml_xml(xml)
+    assert tree.tag.endswith("Response")
+```
+
+- [ ] **Step 3.2: Run test — two should fail today**
+
+Run: `uv run pytest tests/api/services/test_sso_xxe.py -xvs`
+Expected: `test_parse_saml_xml_rejects_doctype_payload` and `test_parse_saml_xml_rejects_external_entity` may already pass (defusedxml is installed in the dev env) — if so, the value of this task is removing the stdlib import so it cannot silently regress. Re-run after step 3.3 to confirm.
+
+- [ ] **Step 3.3: Move defusedxml from extra to core dep in pyproject.toml**
+
+Find the dependency section in `pyproject.toml` (around `dependencies = [`) and add `"defusedxml>=0.7.0",` if not already present in core. Then update the `enterprise-sso` extra to drop `defusedxml` (keep `signxml`):
+
+Before:
+```toml
+enterprise-sso = ["defusedxml>=0.7.0", "signxml>=3.0.0"]
+```
+
+After:
+```toml
+enterprise-sso = ["signxml>=3.0.0"]
+```
+
+In the core `dependencies = [...]` list, append:
+```toml
+    "defusedxml>=0.7.0",
+```
+
+(Keep alphabetical order if the existing list is alphabetical; otherwise add at the end.)
+
+- [ ] **Step 3.4: Remove stdlib XML import and simplify `_parse_saml_xml`**
+
+Edit `src/dev_health_ops/api/services/sso.py`:
+
+Replace line 13 (`from xml.etree import ElementTree`) with:
+
+```python
+from defusedxml import ElementTree as DefusedElementTree
+from defusedxml.common import DefusedXmlException
+from xml.etree.ElementTree import Element, ParseError
+```
+
+(`Element` and `ParseError` are pure Python types/exceptions; importing them from the stdlib is safe — they do not trigger XML parsing. The parser itself comes exclusively from defusedxml.)
+
+Then update the body of `_parse_saml_xml` (lines 653-668) to:
+
+```python
+    @staticmethod
+    def _parse_saml_xml(xml_bytes: bytes) -> Element:
+        try:
+            return DefusedElementTree.fromstring(xml_bytes)
+        except DefusedXmlException as exc:
+            raise SAMLProcessingError("Unsafe SAML XML rejected") from exc
+        except ParseError as exc:
+            raise SAMLProcessingError("Invalid SAML XML") from exc
+```
+
+Finally, fix all the annotations that previously said `ElementTree.Element` to say `Element`:
+
+Run: `uv run rg -n 'ElementTree\.Element' src/dev_health_ops/api/services/sso.py`
+
+For each hit, replace `ElementTree.Element` with `Element` (the type we imported directly). Same for `ElementTree.ParseError` → `ParseError`.
+
+- [ ] **Step 3.5: Re-run XXE tests — all three must pass**
+
+Run: `uv run pytest tests/api/services/test_sso_xxe.py -xvs`
+Expected: 3 passed.
+
+- [ ] **Step 3.6: Run SSO regression tests to catch broken annotations**
+
+Run: `uv run pytest tests/api/services/test_sso.py tests/api/auth/test_sso_module.py -xvs`
+Expected: all pass (no behavioural change, only imports/types changed).
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add pyproject.toml src/dev_health_ops/api/services/sso.py tests/api/services/test_sso_xxe.py
+git commit -m "fix(security): make defusedxml a hard dep; remove stdlib XML import in SSO"
+```
+
+---
+
+## Task 4: JWT_SECRET_KEY must be set (no derivation fallback)
+
+**Files:**
+- Modify: `src/dev_health_ops/api/services/auth.py` (the `_get_jwt_secret` function, lines 96-128)
+- Modify: `tests/api/auth/test_jwt_secret.py` (existing tests expect the fallback behaviour — rewrite)
+
+**Goal:** Always fail if `JWT_SECRET_KEY` is unset. The current code derives a secret via SHA256 of `SETTINGS_ENCRYPTION_KEY` which is a long-lived encryption key whose compromise is catastrophic (it additionally can decrypt stored secrets). Breaking the two makes key-rotation safer.
+
+- [ ] **Step 4.1: Update the existing test file to expect the new behaviour**
+
+Edit `tests/api/auth/test_jwt_secret.py`. Replace the entire file contents with:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.services.auth import _get_jwt_secret
+
+
+def _clear_secret_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "JWT_SECRET_KEY",
+        "SETTINGS_ENCRYPTION_KEY",
+        "ENVIRONMENT",
+        "ENV",
+        "RAILWAY_ENVIRONMENT",
+        "FLY_APP_NAME",
+        "RENDER_SERVICE_ID",
+        "KUBERNETES_SERVICE_HOST",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_jwt_secret_key_env_var_is_used_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_secret_env(monkeypatch)
+    jwt_secret = "this-is-a-very-secure-secret-key-12345"
+    monkeypatch.setenv("JWT_SECRET_KEY", jwt_secret)
+
+    assert _get_jwt_secret() == jwt_secret
+
+
+def test_missing_jwt_secret_raises_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JWT_SECRET_KEY absent in ANY environment must fail closed."""
+    _clear_secret_env(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="JWT_SECRET_KEY"):
+        _get_jwt_secret()
+
+
+def test_missing_jwt_secret_with_settings_encryption_key_still_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SETTINGS_ENCRYPTION_KEY must NOT be used as a fallback."""
+    _clear_secret_env(monkeypatch)
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "some-dev-key")
+    monkeypatch.setenv("ENVIRONMENT", "development")
+
+    with pytest.raises(RuntimeError, match="JWT_SECRET_KEY"):
+        _get_jwt_secret()
+
+
+def test_short_secret_raises_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_secret_env(monkeypatch)
+    monkeypatch.setenv("JWT_SECRET_KEY", "too-short")
+
+    with pytest.raises(ValueError, match="JWT secret must be at least 32 characters"):
+        _get_jwt_secret()
+```
+
+- [ ] **Step 4.2: Run tests — the two new `_raises` tests must fail**
+
+Run: `uv run pytest tests/api/auth/test_jwt_secret.py -xvs`
+Expected: `test_missing_jwt_secret_raises_runtime_error` and `test_missing_jwt_secret_with_settings_encryption_key_still_raises` FAIL (the current code silently returns a derived value).
+
+- [ ] **Step 4.3: Simplify `_get_jwt_secret` to fail closed**
+
+Replace lines 96-128 of `src/dev_health_ops/api/services/auth.py` (the `_get_jwt_secret` function) with:
+
+```python
+def _get_jwt_secret() -> str:
+    secret = os.getenv("JWT_SECRET_KEY")
+    if not secret:
+        raise RuntimeError(
+            "JWT_SECRET_KEY is required and must be set in the environment. "
+            "Derivation from SETTINGS_ENCRYPTION_KEY is no longer supported."
+        )
+    if len(secret) < 32:
+        raise ValueError("JWT secret must be at least 32 characters")
+    return secret
+```
+
+Also remove the now-unused `hashlib` import if it is not used elsewhere in the file:
+
+Run: `uv run rg -n 'hashlib' src/dev_health_ops/api/services/auth.py`
+
+If the only remaining hit is the `import hashlib` line, delete that import. If hashlib is used elsewhere in the file, leave the import.
+
+- [ ] **Step 4.4: Run tests — all four must pass**
+
+Run: `uv run pytest tests/api/auth/test_jwt_secret.py -xvs`
+Expected: 4 passed.
+
+- [ ] **Step 4.5: Run wider auth test suite to catch callers relying on the fallback**
+
+Run: `uv run pytest tests/api/auth/ -xvs`
+Expected: all pass. If any test fails due to unset JWT_SECRET_KEY, fix the test (use `monkeypatch.setenv("JWT_SECRET_KEY", "x" * 40)`) rather than restoring the fallback.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add src/dev_health_ops/api/services/auth.py tests/api/auth/test_jwt_secret.py
+git commit -m "fix(security): require JWT_SECRET_KEY; remove SHA256 fallback derivation"
+```
+
+---
+
+## Task 5: Enforce `allowed_domains` on SSO auto-provision
+
+**Files:**
+- Modify: `src/dev_health_ops/api/services/sso.py` (the `provision_or_get_user` method, lines 585-651)
+- Test: `tests/api/services/test_sso_allowed_domains.py` (new)
+
+**Goal:** When an SSO provider has `allowed_domains = ['acme.com']` and auto-provisioning is enabled, a federated identity for `attacker@evil.com` must be rejected. Currently `allowed_domains` is stored but never consulted.
+
+- [ ] **Step 5.1: Write failing domain-check test**
+
+Create `tests/api/services/test_sso_allowed_domains.py`:
+
+```python
+"""Enforcement tests for SSO allowed_domains (CHAOS security sprint)."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dev_health_ops.api.services.sso import SSOProcessingError, SSOService
+from dev_health_ops.models.sso import SSOProvider
+
+
+def _provider(allowed_domains, auto_provision=True):
+    return SSOProvider(
+        id=uuid.uuid4(),
+        org_id=uuid.uuid4(),
+        name="Acme SSO",
+        protocol="oidc",
+        config={},
+        auto_provision_users=auto_provision,
+        allowed_domains=allowed_domains,
+    )
+
+
+def _service_with_provider(provider):
+    session = MagicMock()
+    session.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+    )
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    svc = SSOService(session)
+    svc.get_provider = AsyncMock(return_value=provider)
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_disallowed_domain_is_rejected_on_autoprovision():
+    """A user whose email domain is not in allowed_domains must 403."""
+    provider = _provider(allowed_domains=["acme.com"])
+    svc = _service_with_provider(provider)
+
+    with pytest.raises(SSOProcessingError, match="domain"):
+        await svc.provision_or_get_user(
+            org_id=provider.org_id,
+            email="attacker@evil.com",
+            name="A Person",
+            provider_id=provider.id,
+            external_id="ext-1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_allowed_domain_is_accepted_case_insensitive():
+    """Email domain matching (case-insensitive) must succeed."""
+    provider = _provider(allowed_domains=["Acme.COM"])
+    svc = _service_with_provider(provider)
+
+    user, _membership, returned_provider = await svc.provision_or_get_user(
+        org_id=provider.org_id,
+        email="alice@acme.com",
+        name="Alice",
+        provider_id=provider.id,
+        external_id="ext-2",
+    )
+    assert user.email == "alice@acme.com"
+    assert returned_provider is provider
+
+
+@pytest.mark.asyncio
+async def test_empty_allowed_domains_list_allows_all():
+    """When allowed_domains is None or empty, any domain is accepted (no regression)."""
+    provider = _provider(allowed_domains=None)
+    svc = _service_with_provider(provider)
+
+    user, _m, _p = await svc.provision_or_get_user(
+        org_id=provider.org_id,
+        email="any@anything.io",
+        name="Any",
+        provider_id=provider.id,
+        external_id="ext-3",
+    )
+    assert user.email == "any@anything.io"
+```
+
+- [ ] **Step 5.2: Run tests — domain-rejection must fail**
+
+Run: `uv run pytest tests/api/services/test_sso_allowed_domains.py -xvs`
+Expected: `test_disallowed_domain_is_rejected_on_autoprovision` FAILS (no check today).
+
+- [ ] **Step 5.3: Add domain enforcement to `provision_or_get_user`**
+
+In `src/dev_health_ops/api/services/sso.py`, modify the `provision_or_get_user` method (around line 592 after the `provider` lookup). Insert the following block immediately before the `stmt = select(User).where(User.email == email)` line:
+
+```python
+        allowed = [d.strip().lower() for d in (provider.allowed_domains or []) if d]
+        if allowed:
+            try:
+                _, domain = email.rsplit("@", 1)
+            except ValueError as exc:
+                raise SSOProcessingError("Invalid email from IdP") from exc
+            if domain.lower() not in allowed:
+                logger.warning(
+                    "SSO provision rejected: domain=%s not in allowed_domains for provider=%s",
+                    sanitize_for_log(domain),
+                    provider.id,
+                )
+                raise SSOProcessingError(
+                    "Email domain is not permitted for this SSO provider"
+                )
+```
+
+(`sanitize_for_log` is already imported on line 22.)
+
+- [ ] **Step 5.4: Run tests — all three must pass**
+
+Run: `uv run pytest tests/api/services/test_sso_allowed_domains.py -xvs`
+Expected: 3 passed.
+
+- [ ] **Step 5.5: Run existing SSO test suite to catch regressions**
+
+Run: `uv run pytest tests/api/services/test_sso.py tests/api/auth/test_sso_module.py -xvs`
+Expected: all pass.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add src/dev_health_ops/api/services/sso.py tests/api/services/test_sso_allowed_domains.py
+git commit -m "fix(security): enforce SSO allowed_domains on user auto-provision"
+```
+
+---
+
+## Task 6: Trust X-Forwarded-For only from `TRUSTED_PROXIES`
+
+**Files:**
+- Modify: `src/dev_health_ops/api/middleware/rate_limit.py` (the `get_forwarded_ip` function, lines 65-75)
+- Test: `tests/api/test_forwarded_ip_trust.py` (new)
+
+**Goal:** Only read `X-Forwarded-For` when the TCP peer (`request.client.host`) is in a configurable `TRUSTED_PROXIES` allowlist. A direct-to-API attacker could otherwise spoof rate-limit keys via a forged header.
+
+- [ ] **Step 6.1: Write failing trust-boundary tests**
+
+Create `tests/api/test_forwarded_ip_trust.py`:
+
+```python
+"""X-Forwarded-For trust boundary tests (CHAOS security sprint)."""
+from __future__ import annotations
+
+import pytest
+from fastapi import Request
+
+from dev_health_ops.api.middleware.rate_limit import get_forwarded_ip
+
+
+def _make_request(
+    client_host: str,
+    xff: str | None = None,
+) -> Request:
+    headers: list[tuple[bytes, bytes]] = []
+    if xff is not None:
+        headers.append((b"x-forwarded-for", xff.encode("latin-1")))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": headers,
+        "client": (client_host, 12345),
+    }
+    return Request(scope)
+
+
+def test_xff_ignored_from_untrusted_peer(monkeypatch):
+    """XFF from a random internet peer must NOT be honoured."""
+    monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.1")
+    req = _make_request(client_host="1.2.3.4", xff="203.0.113.1")
+    assert get_forwarded_ip(req) == "1.2.3.4"
+
+
+def test_xff_honoured_from_trusted_peer(monkeypatch):
+    """XFF from a listed trusted proxy must be used as the real client."""
+    monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.1,10.0.0.2")
+    req = _make_request(client_host="10.0.0.2", xff="203.0.113.1")
+    assert get_forwarded_ip(req) == "203.0.113.1"
+
+
+def test_xff_missing_returns_peer(monkeypatch):
+    """No XFF: peer IP is returned regardless of trust."""
+    monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.1")
+    req = _make_request(client_host="10.0.0.1", xff=None)
+    assert get_forwarded_ip(req) == "10.0.0.1"
+
+
+def test_trusted_proxies_unset_disables_xff(monkeypatch):
+    """Unset/empty TRUSTED_PROXIES must fail-closed: never trust XFF."""
+    monkeypatch.delenv("TRUSTED_PROXIES", raising=False)
+    req = _make_request(client_host="10.0.0.1", xff="203.0.113.1")
+    assert get_forwarded_ip(req) == "10.0.0.1"
+
+
+def test_xff_takes_first_entry(monkeypatch):
+    """When trusted, the leftmost XFF entry is the original client."""
+    monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.1")
+    req = _make_request(
+        client_host="10.0.0.1", xff="203.0.113.1, 10.0.0.1"
+    )
+    assert get_forwarded_ip(req) == "203.0.113.1"
+```
+
+- [ ] **Step 6.2: Run tests — most should fail today**
+
+Run: `uv run pytest tests/api/test_forwarded_ip_trust.py -xvs`
+Expected: `test_xff_ignored_from_untrusted_peer` and `test_trusted_proxies_unset_disables_xff` FAIL (current code trusts XFF unconditionally).
+
+- [ ] **Step 6.3: Implement trusted-proxy allowlist**
+
+Edit `src/dev_health_ops/api/middleware/rate_limit.py`. Replace lines 65-75 (the `get_forwarded_ip` function) with:
+
+```python
+def _trusted_proxies() -> frozenset[str]:
+    """Return the configured set of trusted proxy IPs (fail-closed: empty if unset)."""
+    raw = os.getenv("TRUSTED_PROXIES", "")
+    return frozenset(p.strip() for p in raw.split(",") if p.strip())
+
+
+def get_forwarded_ip(request: Request) -> str:
+    """Return real client IP via X-Forwarded-For, honoured only if the TCP peer
+    is in the TRUSTED_PROXIES allowlist.
+
+    Behind a reverse proxy (Next.js rewrite, nginx, etc.) the TCP peer is the
+    proxy, not the end-user. X-Forwarded-For carries the original IP — but it
+    is attacker-controlled when sent directly to the API, so we only trust it
+    when the peer address is an expected proxy.
+    """
+    peer = (request.client.host if request.client else None) or "unknown"
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded and peer in _trusted_proxies():
+        return forwarded.split(",")[0].strip()
+    return peer
+```
+
+- [ ] **Step 6.4: Run tests — all five must pass**
+
+Run: `uv run pytest tests/api/test_forwarded_ip_trust.py -xvs`
+Expected: 5 passed.
+
+- [ ] **Step 6.5: Run rate-limit/auth test suite for regressions**
+
+Run: `uv run pytest tests/api/test_rate_limit_config.py tests/api/auth/ -xvs`
+Expected: all pass. If any test fails because it relied on the old trusting behaviour, add `monkeypatch.setenv("TRUSTED_PROXIES", "testclient")` to that test (httpx's ASGITransport sets peer to `testclient`).
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add src/dev_health_ops/api/middleware/rate_limit.py tests/api/test_forwarded_ip_trust.py
+git commit -m "fix(security): trust X-Forwarded-For only from TRUSTED_PROXIES allowlist"
+```
+
+---
+
+## Task 7: Service-layer org-ownership re-check in drilldown queries
+
+**Files:**
+- Modify: `src/dev_health_ops/api/queries/drilldown.py` (both `fetch_pull_requests` and `fetch_issues`)
+- Test: `tests/api/queries/test_drilldown_org_check.py` (new)
+
+**Goal:** Independent defense-in-depth — even if the middleware contextvar is ever mis-set, a drilldown query must refuse to execute when its caller-provided `org_id` disagrees with `get_current_org_id()`. Also raise on empty `org_id`.
+
+- [ ] **Step 7.1: Write failing assertion test**
+
+Create `tests/api/queries/test_drilldown_org_check.py`:
+
+```python
+"""Defense-in-depth org_id re-check for drilldown queries (CHAOS security sprint)."""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.queries.drilldown import fetch_issues, fetch_pull_requests
+from dev_health_ops.api.services.auth import _current_org_id, set_current_org_id
+
+
+class _Sink:
+    def __init__(self) -> None:
+        self.last_params: dict[str, Any] | None = None
+
+    def query_dicts(
+        self, query: str, params: dict[str, Any] | None
+    ) -> list[dict[str, Any]]:
+        self.last_params = params
+        return []
+
+
+@pytest.mark.asyncio
+async def test_fetch_pull_requests_rejects_empty_org_id():
+    try:
+        _current_org_id.set(None)
+        with pytest.raises(ValueError, match="org_id"):
+            await fetch_pull_requests(
+                _Sink(),
+                start_day=date(2024, 1, 1),
+                end_day=date(2024, 1, 2),
+                scope_filter="",
+                scope_params={},
+                org_id="",
+            )
+    finally:
+        _current_org_id.set(None)
+
+
+@pytest.mark.asyncio
+async def test_fetch_pull_requests_rejects_context_mismatch():
+    try:
+        set_current_org_id("org-A")
+        with pytest.raises(PermissionError, match="org_id mismatch"):
+            await fetch_pull_requests(
+                _Sink(),
+                start_day=date(2024, 1, 1),
+                end_day=date(2024, 1, 2),
+                scope_filter="",
+                scope_params={},
+                org_id="org-B",
+            )
+    finally:
+        _current_org_id.set(None)
+
+
+@pytest.mark.asyncio
+async def test_fetch_issues_rejects_context_mismatch():
+    try:
+        set_current_org_id("org-A")
+        with pytest.raises(PermissionError, match="org_id mismatch"):
+            await fetch_issues(
+                _Sink(),
+                start_day=date(2024, 1, 1),
+                end_day=date(2024, 1, 2),
+                scope_filter="",
+                scope_params={},
+                org_id="org-B",
+            )
+    finally:
+        _current_org_id.set(None)
+
+
+@pytest.mark.asyncio
+async def test_fetch_issues_allows_matching_org_id():
+    try:
+        set_current_org_id("org-X")
+        sink = _Sink()
+        await fetch_issues(
+            sink,
+            start_day=date(2024, 1, 1),
+            end_day=date(2024, 1, 2),
+            scope_filter="",
+            scope_params={},
+            org_id="org-X",
+        )
+        assert sink.last_params is not None
+        assert sink.last_params["org_id"] == "org-X"
+    finally:
+        _current_org_id.set(None)
+```
+
+- [ ] **Step 7.2: Run tests — mismatch/empty tests must fail**
+
+Run: `uv run pytest tests/api/queries/test_drilldown_org_check.py -xvs`
+Expected: the three negative-path tests FAIL (no guard today).
+
+- [ ] **Step 7.3: Add guards to both fetch functions**
+
+Edit `src/dev_health_ops/api/queries/drilldown.py`. Immediately after the `from .client import query_dicts` import on line 6, add:
+
+```python
+from dev_health_ops.api.services.auth import get_current_org_id
+
+
+def _assert_org_id(org_id: str) -> None:
+    if not org_id:
+        raise ValueError("org_id is required for drilldown queries")
+    ctx = get_current_org_id()
+    if ctx is not None and ctx != org_id:
+        raise PermissionError(
+            f"org_id mismatch: contextvar={ctx!r} caller={org_id!r}"
+        )
+```
+
+Then at the top of both `fetch_pull_requests` (inside the function body, before the `query = f"""..."""`) and `fetch_issues`, add:
+
+```python
+    _assert_org_id(org_id)
+```
+
+Concretely, after this change the beginning of `fetch_pull_requests` reads:
+
+```python
+async def fetch_pull_requests(
+    client: Any,
+    *,
+    start_day: date,
+    end_day: date,
+    scope_filter: str,
+    scope_params: dict[str, Any],
+    limit: int = 50,
+    org_id: str = "",
+) -> list[dict[str, Any]]:
+    _assert_org_id(org_id)
+    query = f"""
+        SELECT
+            ...
+    """
+```
+
+and similarly for `fetch_issues`.
+
+- [ ] **Step 7.4: Run tests — all four must pass**
+
+Run: `uv run pytest tests/api/queries/test_drilldown_org_check.py -xvs`
+Expected: 4 passed.
+
+- [ ] **Step 7.5: Run regression suite**
+
+Run: `uv run pytest tests/api/queries/ tests/api/test_main_app_integration.py -xvs`
+Expected: all pass. If an existing test calls these helpers without setting the contextvar and passes a non-empty org_id, it will still pass (our assert only fires when contextvar is non-None).
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add src/dev_health_ops/api/queries/drilldown.py tests/api/queries/test_drilldown_org_check.py
+git commit -m "fix(security): re-check org_id in drilldown queries (defense-in-depth)"
+```
+
+---
+
+## Task 8: Sanitized generic 500 exception handler
+
+**Files:**
+- Modify: `src/dev_health_ops/api/main.py` (add a new exception handler near existing handlers around line 374)
+- Test: `tests/api/test_generic_exception_handler.py` (new)
+
+**Goal:** Install a FastAPI-level `Exception` handler that returns a fixed `{"detail": "Internal Server Error"}` JSON body (plus a correlation id) and logs the real exception at ERROR with stack trace. Today an unhandled exception falls through to Starlette's default formatting which can leak class names or tracebacks depending on config. This also unifies error shape for the frontend.
+
+- [ ] **Step 8.1: Write failing test**
+
+Create `tests/api/test_generic_exception_handler.py`:
+
+```python
+"""Generic 500 exception handler returns sanitized JSON (CHAOS security sprint)."""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from dev_health_ops.api.main import _generic_exception_handler
+
+
+@pytest.fixture
+def sanitized_app() -> FastAPI:
+    app = FastAPI()
+    app.add_exception_handler(Exception, _generic_exception_handler)
+
+    @app.get("/boom")
+    async def boom():
+        raise RuntimeError("super secret internal: DB password=hunter2")
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_500_body_is_generic(sanitized_app):
+    async with AsyncClient(
+        transport=ASGITransport(app=sanitized_app),
+        base_url="http://test",
+        raise_app_exceptions=False,
+    ) as ac:
+        resp = await ac.get("/boom")
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body == {"detail": "Internal Server Error"}
+
+
+@pytest.mark.asyncio
+async def test_500_does_not_leak_exception_text(sanitized_app):
+    async with AsyncClient(
+        transport=ASGITransport(app=sanitized_app),
+        base_url="http://test",
+        raise_app_exceptions=False,
+    ) as ac:
+        resp = await ac.get("/boom")
+    assert "hunter2" not in resp.text
+    assert "RuntimeError" not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_500_logs_original_exception(sanitized_app, caplog):
+    import logging
+
+    caplog.set_level(logging.ERROR, logger="dev_health_ops.api.main")
+    async with AsyncClient(
+        transport=ASGITransport(app=sanitized_app),
+        base_url="http://test",
+        raise_app_exceptions=False,
+    ) as ac:
+        await ac.get("/boom")
+    # The full text must appear in the logs, not the response.
+    assert any("hunter2" in rec.message or "hunter2" in (rec.exc_text or "")
+               for rec in caplog.records)
+```
+
+- [ ] **Step 8.2: Run test — import will fail**
+
+Run: `uv run pytest tests/api/test_generic_exception_handler.py -xvs`
+Expected: ImportError for `_generic_exception_handler` (symbol does not exist).
+
+- [ ] **Step 8.3: Add the handler and register it**
+
+Edit `src/dev_health_ops/api/main.py`. Immediately after the existing `_validation_error_handler` function (after line 366), add:
+
+```python
+async def _generic_exception_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    """Catch-all 500 handler that returns a sanitized response.
+
+    Logs the real exception with stack trace at ERROR level so operators can
+    investigate via logs/Sentry, but never leaks internals to the client.
+    """
+    logger.error(
+        "Unhandled exception on %s %s",
+        request.method,
+        request.url.path,
+        exc_info=exc,
+    )
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal Server Error"},
+    )
+```
+
+Then, after line 374 (`app.add_exception_handler(RequestValidationError, _validation_error_handler)`), add:
+
+```python
+app.add_exception_handler(Exception, _generic_exception_handler)
+```
+
+- [ ] **Step 8.4: Run test — all three must pass**
+
+Run: `uv run pytest tests/api/test_generic_exception_handler.py -xvs`
+Expected: 3 passed.
+
+- [ ] **Step 8.5: Run app-integration suite**
+
+Run: `uv run pytest tests/api/test_main_app_integration.py -xvs`
+Expected: all pass — the new handler only triggers for otherwise-unhandled exceptions, so it should not interfere with existing HTTPException responses.
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add src/dev_health_ops/api/main.py tests/api/test_generic_exception_handler.py
+git commit -m "fix(security): add sanitized generic 500 exception handler"
+```
+
+---
+
+## Task 9: Security-headers middleware (HSTS, nosniff, frame-deny, CSP)
+
+**Files:**
+- Create: `src/dev_health_ops/api/middleware/security_headers.py`
+- Modify: `src/dev_health_ops/api/main.py` (register the middleware alongside CORS, around line 386)
+- Test: `tests/api/test_security_headers.py` (new)
+
+**Goal:** Inject `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, and a conservative `Content-Security-Policy` on every API response. Missing today.
+
+- [ ] **Step 9.1: Write failing test**
+
+Create `tests/api/test_security_headers.py`:
+
+```python
+"""Security-headers middleware tests (CHAOS security sprint)."""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from dev_health_ops.api.middleware.security_headers import SecurityHeadersMiddleware
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    a = FastAPI()
+    a.add_middleware(SecurityHeadersMiddleware)
+
+    @a.get("/ping")
+    async def ping() -> dict[str, str]:
+        return {"pong": "ok"}
+
+    return a
+
+
+@pytest.mark.asyncio
+async def test_response_includes_hsts(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get("/ping")
+    hsts = resp.headers.get("strict-transport-security", "")
+    assert "max-age=" in hsts
+    assert "includeSubDomains" in hsts
+
+
+@pytest.mark.asyncio
+async def test_response_includes_nosniff_and_frame_deny(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get("/ping")
+    assert resp.headers.get("x-content-type-options") == "nosniff"
+    assert resp.headers.get("x-frame-options") == "DENY"
+
+
+@pytest.mark.asyncio
+async def test_response_includes_referrer_policy_and_csp(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get("/ping")
+    assert resp.headers.get("referrer-policy") == "strict-origin-when-cross-origin"
+    csp = resp.headers.get("content-security-policy", "")
+    assert "default-src 'none'" in csp
+    assert "frame-ancestors 'none'" in csp
+
+
+@pytest.mark.asyncio
+async def test_existing_headers_are_not_overridden(app):
+    @app.get("/custom")
+    async def custom():
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(
+            content={"ok": True},
+            headers={"x-frame-options": "SAMEORIGIN"},
+        )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get("/custom")
+    # Middleware must NOT stomp an explicit per-response choice.
+    assert resp.headers.get("x-frame-options") == "SAMEORIGIN"
+```
+
+- [ ] **Step 9.2: Run test — import fails**
+
+Run: `uv run pytest tests/api/test_security_headers.py -xvs`
+Expected: ImportError for `SecurityHeadersMiddleware`.
+
+- [ ] **Step 9.3: Create the middleware**
+
+Create `src/dev_health_ops/api/middleware/security_headers.py`:
+
+```python
+"""Security-headers middleware.
+
+Injects a conservative set of response headers on every HTTP response:
+
+- Strict-Transport-Security: HSTS with 1y max-age and subdomain coverage
+- X-Content-Type-Options: nosniff
+- X-Frame-Options: DENY
+- Referrer-Policy: strict-origin-when-cross-origin
+- Content-Security-Policy: lock down by default (API returns JSON)
+
+Pre-existing headers set by downstream handlers are preserved (case-insensitive
+match); the middleware only adds what's missing.
+"""
+
+from __future__ import annotations
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_DEFAULT_HEADERS: tuple[tuple[bytes, bytes], ...] = (
+    (b"strict-transport-security", b"max-age=31536000; includeSubDomains"),
+    (b"x-content-type-options", b"nosniff"),
+    (b"x-frame-options", b"DENY"),
+    (b"referrer-policy", b"strict-origin-when-cross-origin"),
+    (
+        b"content-security-policy",
+        b"default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+    ),
+)
+
+
+class SecurityHeadersMiddleware:
+    """Pure ASGI middleware that adds security headers to every response."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def _send(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                existing = {k.lower() for k, _ in message.get("headers", [])}
+                headers = list(message.get("headers", []))
+                for name, value in _DEFAULT_HEADERS:
+                    if name not in existing:
+                        headers.append((name, value))
+                message["headers"] = headers
+            await send(message)
+
+        await self.app(scope, receive, _send)
+
+
+__all__ = ["SecurityHeadersMiddleware"]
+```
+
+- [ ] **Step 9.4: Run tests — all four must pass**
+
+Run: `uv run pytest tests/api/test_security_headers.py -xvs`
+Expected: 4 passed.
+
+- [ ] **Step 9.5: Register the middleware in `main.py`**
+
+Edit `src/dev_health_ops/api/main.py`. Near the top of the middleware imports (around line 33 where `OrgIdMiddleware` is imported), add:
+
+```python
+from dev_health_ops.api.middleware.security_headers import SecurityHeadersMiddleware
+```
+
+Then, immediately after the `app.add_middleware(CORSMiddleware, ...)` block (after line 386), add:
+
+```python
+app.add_middleware(SecurityHeadersMiddleware)
+```
+
+(ASGI middlewares run last-added-first; placing SecurityHeadersMiddleware after CORS means it runs *before* CORS on the way in and *after* CORS on the way out — correct order for response-header injection.)
+
+- [ ] **Step 9.6: Run app-integration suite to confirm no regression**
+
+Run: `uv run pytest tests/api/test_main_app_integration.py tests/api/test_security_headers.py -xvs`
+Expected: all pass.
+
+- [ ] **Step 9.7: Commit**
+
+```bash
+git add src/dev_health_ops/api/middleware/security_headers.py \
+        src/dev_health_ops/api/main.py \
+        tests/api/test_security_headers.py
+git commit -m "feat(security): add security-headers middleware (HSTS, nosniff, CSP)"
+```
+
+---
+
+## Task 10: Narrow the bare `except Exception` in `_extract_unverified_org_and_subject`
+
+**Files:**
+- Modify: `src/dev_health_ops/api/auth/router.py` (function `_extract_unverified_org_and_subject`, lines 946-956)
+- Test: `tests/api/auth/test_extract_unverified_claims.py` (new)
+
+**Goal:** Replace the catch-all with targeted JOSE exceptions and log the failure. Silent swallowing today makes production triage impossible.
+
+- [ ] **Step 10.1: Write failing test**
+
+Create `tests/api/auth/test_extract_unverified_claims.py`:
+
+```python
+"""Tests for narrowed exception handling in _extract_unverified_org_and_subject."""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from dev_health_ops.api.auth.router import _extract_unverified_org_and_subject
+
+
+def test_returns_none_tuple_for_malformed_token(caplog):
+    """A malformed token must yield (None, None) AND emit a debug log."""
+    caplog.set_level(logging.DEBUG, logger="dev_health_ops.api.auth.router")
+    org, sub = _extract_unverified_org_and_subject("not.a.token")
+    assert (org, sub) == (None, None)
+    assert any(
+        "unverified claims" in rec.message.lower()
+        for rec in caplog.records
+    )
+
+
+def test_returns_none_tuple_for_empty_token():
+    org, sub = _extract_unverified_org_and_subject("")
+    assert (org, sub) == (None, None)
+
+
+def test_returns_tuple_for_valid_unsigned_token():
+    """A syntactically valid JWT (even if signature invalid) yields claims."""
+    import base64
+    import json
+
+    def _b64(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+    header = _b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    payload = _b64(
+        json.dumps(
+            {"sub": "user-1", "org_id": "00000000-0000-0000-0000-000000000001"}
+        ).encode()
+    )
+    signature = _b64(b"\x00" * 32)
+    token = f"{header}.{payload}.{signature}"
+
+    org, sub = _extract_unverified_org_and_subject(token)
+    assert sub == "user-1"
+    assert org is not None
+    assert str(org) == "00000000-0000-0000-0000-000000000001"
+```
+
+- [ ] **Step 10.2: Run test — first test fails (no log today)**
+
+Run: `uv run pytest tests/api/auth/test_extract_unverified_claims.py -xvs`
+Expected: `test_returns_none_tuple_for_malformed_token` FAILS (no log emitted).
+
+- [ ] **Step 10.3: Narrow exceptions and add logging**
+
+Edit `src/dev_health_ops/api/auth/router.py`. Replace lines 946-956 (the `_extract_unverified_org_and_subject` function) with:
+
+```python
+def _extract_unverified_org_and_subject(
+    token: str,
+) -> tuple[uuid_mod.UUID | None, str | None]:
+    try:
+        from jose import jwt
+        from jose.exceptions import JOSEError
+
+        claims = jwt.get_unverified_claims(token)
+    except (JOSEError, ValueError, AttributeError, TypeError) as exc:
+        logger.debug("Could not parse unverified claims: %s", exc)
+        return None, None
+    except ImportError:
+        logger.error("jose not installed — cannot extract unverified claims")
+        return None, None
+
+    return _parse_uuid(claims.get("org_id")), claims.get("sub")
+```
+
+- [ ] **Step 10.4: Run tests — all three must pass**
+
+Run: `uv run pytest tests/api/auth/test_extract_unverified_claims.py -xvs`
+Expected: 3 passed.
+
+- [ ] **Step 10.5: Run auth-router regression suite**
+
+Run: `uv run pytest tests/api/auth/ -xvs`
+Expected: all pass — behavior on malformed tokens (returning the tuple of Nones) is unchanged.
+
+- [ ] **Step 10.6: Commit**
+
+```bash
+git add src/dev_health_ops/api/auth/router.py tests/api/auth/test_extract_unverified_claims.py
+git commit -m "fix(security): narrow exception handling in _extract_unverified_org_and_subject"
+```
+
+---
+
+## Full Regression & Wrap-Up
+
+- [ ] **Step F.1: Run the complete API test package**
+
+Run: `uv run pytest tests/api/ -x`
+Expected: all tests pass.
+
+- [ ] **Step F.2: Run static-analysis & type-check if the project defines them**
+
+Run: `uv run ruff check src/dev_health_ops/api tests/api`
+Run: `uv run mypy src/dev_health_ops/api || true`
+Fix any new findings introduced by the above tasks (e.g. unused imports from the defusedxml switch, unused `hashlib` after Task 4).
+
+- [ ] **Step F.3: Open PR**
+
+```bash
+gh pr create --title "security: close 10 audit findings (CHAOS security sprint)" --body "$(cat <<'EOF'
+## Summary
+- Membership check on X-Org-Id (IDOR fix)
+- Superuser auth on GET /admin/orgs/{id}
+- defusedxml is a hard dep; stdlib XML import removed
+- JWT_SECRET_KEY required (no SHA256 fallback)
+- SSO allowed_domains enforced on auto-provision
+- X-Forwarded-For trusted only from TRUSTED_PROXIES allowlist
+- Drilldown queries re-assert org_id vs contextvar
+- Sanitized generic 500 exception handler
+- Security-headers middleware (HSTS, nosniff, frame-deny, CSP)
+- Narrowed bare Exception in _extract_unverified_org_and_subject with logging
+
+## Test plan
+- [x] All new tests pass: `uv run pytest tests/api/ -x`
+- [x] Existing auth & SSO regression suites green
+- [x] Manual: verify X-Org-Id header with JWT for another tenant is rejected with 403
+- [x] Manual: verify /admin/orgs/{id} returns 401 unauthenticated, 403 non-superuser
+- [x] Manual: start API without JWT_SECRET_KEY — expect RuntimeError at first token op
+- [x] Manual: hit any endpoint — curl -I shows HSTS, X-Frame-Options, CSP
+EOF
+)"
+```
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (OrgId middleware hardening)
+   ├── conceptually protects against abuse of Tasks 7 drilldown endpoints; still independent to ship
+   └── DOES NOT block any other task
+
+Task 2 (Admin orgs auth)              independent
+Task 3 (defusedxml hardening)         independent
+Task 4 (JWT_SECRET_KEY required)      independent — may require local .env update before other tasks' tests run
+Task 5 (SSO allowed_domains)          independent
+Task 6 (TRUSTED_PROXIES)              independent
+Task 7 (Drilldown org re-check)       independent; strengthens Task 1 but does not depend on it
+Task 8 (Generic 500 handler)          independent
+Task 9 (Security-headers middleware)  independent
+Task 10 (Narrow bare except)          independent
+```
+
+All ten tasks are file-independent and can be dispatched to separate sub-agents in parallel. The only cross-cutting concern is Task 4: after merging Task 4, any CI/local `.env.example` that omitted `JWT_SECRET_KEY` must be updated. If Tasks are executed sequentially, run Task 4 early so subsequent tasks catch missing-env-var failures in their own local test runs.
+
+## Removed findings
+
+None. All ten findings were verified against the code before plan authorship:
+
+- Finding 1 (IDOR via X-Org-Id): confirmed at `src/dev_health_ops/api/middleware/__init__.py:51`.
+- Finding 2 (Admin GET missing auth): confirmed at `src/dev_health_ops/api/admin/routers/orgs.py:67`.
+- Finding 3 (SAML XML surface): re-framed — `defusedxml` is already required at runtime (the code raises on ImportError), but the stdlib `xml.etree.ElementTree` import on line 13 is still the source of the `Element` type and `ParseError` exception class. Task 3 therefore (a) promotes defusedxml to a hard dep and (b) removes the stdlib parser completely, eliminating the audit finding without changing behaviour in happy-path.
+- Finding 4 (JWT derivation): confirmed at `src/dev_health_ops/api/services/auth.py:102`.
+- Finding 5 (allowed_domains): confirmed — column stored, never read in `provision_or_get_user`.
+- Finding 6 (X-Forwarded-For trust): confirmed at `src/dev_health_ops/api/middleware/rate_limit.py:71-75`.
+- Finding 7 (drilldown org re-check): service layer takes `org_id` as parameter but never asserts it against `get_current_org_id()`; Task 7 adds that assertion.
+- Finding 8 (verbose errors): the *streaming* handler is already generic. Real gap is the absence of a generic `Exception` handler at the FastAPI app level — Task 8 addresses that.
+- Finding 9 (missing headers): confirmed — CORSMiddleware sets CORS headers but no HSTS/CSP/etc.
+- Finding 10 (bare except): confirmed at `src/dev_health_ops/api/auth/router.py:953`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
   "bcrypt>=4.0.0",
   "email-validator>=2.0.0",
   "PyNaCl>=1.5.0",
+  "defusedxml>=0.7.0",
   "stripe>=7.0.0",
   "resend>=2.5.0",
   # Observability
@@ -83,7 +84,7 @@ dev = [
   "fakeredis[valkey]",
   "pip-audit>=2.7.0",
 ]
-enterprise-sso = ["defusedxml>=0.7.0", "signxml>=3.0.0"]
+enterprise-sso = ["signxml>=3.0.0"]
 
 [project.urls]
 Repository = "https://github.com/chrisgeo/dev-health-ops"

--- a/src/dev_health_ops/api/admin/routers/orgs.py
+++ b/src/dev_health_ops/api/admin/routers/orgs.py
@@ -68,6 +68,7 @@ async def list_organizations(
 async def get_organization(
     org_id: str,
     session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(require_superuser),
 ) -> OrganizationResponse:
     svc = OrganizationService(session)
     org = await svc.get_by_id(org_id)

--- a/src/dev_health_ops/api/auth/router.py
+++ b/src/dev_health_ops/api/auth/router.py
@@ -946,11 +946,13 @@ async def _issue_membership_tokens(
 def _extract_unverified_org_and_subject(
     token: str,
 ) -> tuple[uuid_mod.UUID | None, str | None]:
-    try:
-        from jose import jwt
+    import jwt as _jwt
+    from jwt.exceptions import InvalidTokenError
 
-        claims = jwt.get_unverified_claims(token)
-    except Exception:
+    try:
+        claims = _jwt.decode(token, options={"verify_signature": False})
+    except (InvalidTokenError, ValueError, AttributeError, TypeError) as exc:
+        logger.debug("Could not parse unverified claims: %s", exc)
         return None, None
 
     return _parse_uuid(claims.get("org_id")), claims.get("sub")

--- a/src/dev_health_ops/api/auth/router.py
+++ b/src/dev_health_ops/api/auth/router.py
@@ -958,8 +958,9 @@ def _extract_unverified_org_and_subject(
     from jwt.exceptions import InvalidTokenError
 
     try:
+        # Intentional: audit-logging only — see docstring above. Callers emit the
+        # result straight to emit_audit_log; never used for authorization.
         # nosemgrep: python.jwt.security.unverified-jwt-decode.unverified-jwt-decode
-        # Intentional: audit-logging only — see docstring above.
         claims = _jwt.decode(token, options={"verify_signature": False})
     except (InvalidTokenError, ValueError, AttributeError, TypeError) as exc:
         logger.debug("Could not parse unverified claims: %s", exc)

--- a/src/dev_health_ops/api/auth/router.py
+++ b/src/dev_health_ops/api/auth/router.py
@@ -946,10 +946,20 @@ async def _issue_membership_tokens(
 def _extract_unverified_org_and_subject(
     token: str,
 ) -> tuple[uuid_mod.UUID | None, str | None]:
+    """Extract org_id/subject from an already-rejected refresh token for audit logging.
+
+    This is deliberately unverified. Callers invoke this function AFTER
+    validate_token has already failed — the only purpose is to emit an audit
+    log entry describing which org a failed refresh attempt targeted. The
+    returned org_id is never used for authorization; it is passed straight to
+    emit_audit_log.
+    """
     import jwt as _jwt
     from jwt.exceptions import InvalidTokenError
 
     try:
+        # nosemgrep: python.jwt.security.unverified-jwt-decode.unverified-jwt-decode
+        # Intentional: audit-logging only — see docstring above.
         claims = _jwt.decode(token, options={"verify_signature": False})
     except (InvalidTokenError, ValueError, AttributeError, TypeError) as exc:
         logger.debug("Could not parse unverified claims: %s", exc)

--- a/src/dev_health_ops/api/graphql/loaders/dimension_loader.py
+++ b/src/dev_health_ops/api/graphql/loaders/dimension_loader.py
@@ -98,4 +98,8 @@ def get_measure_descriptions() -> dict[str, str]:
         Measure.COVERAGE_LINE_PCT.value: "Line coverage percentage",
         Measure.COVERAGE_BRANCH_PCT.value: "Branch coverage percentage",
         Measure.COVERAGE_DELTA_PCT.value: "Coverage change from prior period",
+        Measure.FLAG_FRICTION_DELTA.value: "Feature flag friction delta (error-rate change gated by flag)",
+        Measure.FLAG_ERROR_RATE_DELTA.value: "Error-rate change attributable to feature flag rollout",
+        Measure.FLAG_COVERAGE_RATIO.value: "Share of flagged code paths exercised by tests",
+        Measure.FLAG_ACTIVATION_RATE.value: "Rate of feature flag activations over time",
     }

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -34,6 +34,7 @@ from dev_health_ops.api.middleware import OrgIdMiddleware
 from dev_health_ops.api.middleware.correlation_id import CorrelationIdMiddleware
 from dev_health_ops.api.middleware.impersonation import ImpersonationMiddleware
 from dev_health_ops.api.middleware.rate_limit import limiter
+from dev_health_ops.api.middleware.security_headers import SecurityHeadersMiddleware
 from dev_health_ops.api.telemetry.router import router as telemetry_router
 from dev_health_ops.licensing import LicenseManager
 
@@ -405,6 +406,7 @@ app.add_middleware(
     allow_headers=["Authorization", "Content-Type", "X-Org-Id", "X-Request-ID"],
     expose_headers=["X-Request-ID"],
 )
+app.add_middleware(SecurityHeadersMiddleware)
 OriginValidationMiddleware = import_module(
     "dev_health_ops.api.middleware.csrf"
 ).OriginValidationMiddleware

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -367,9 +367,7 @@ def _validation_error_handler(
     )
 
 
-async def _generic_exception_handler(
-    request: Request, exc: Exception
-) -> JSONResponse:
+async def _generic_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     """Catch-all 500 handler that returns a sanitized response.
 
     Logs the real exception with stack trace at ERROR level so operators can

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -366,12 +366,33 @@ def _validation_error_handler(
     )
 
 
+async def _generic_exception_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    """Catch-all 500 handler that returns a sanitized response.
+
+    Logs the real exception with stack trace at ERROR level so operators can
+    investigate via logs/Sentry, but never leaks internals to the client.
+    """
+    logger.error(
+        "Unhandled exception on %s %s",
+        request.method,
+        request.url.path,
+        exc_info=exc,
+    )
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal Server Error"},
+    )
+
+
 app.state.limiter = limiter
 app.add_exception_handler(
     RateLimitExceeded,
     _rate_limit_handler,
 )
 app.add_exception_handler(RequestValidationError, _validation_error_handler)
+app.add_exception_handler(Exception, _generic_exception_handler)
 
 _cors_origins_raw = os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000")
 _cors_origins = [o.strip() for o in _cors_origins_raw.split(",") if o.strip()]

--- a/src/dev_health_ops/api/middleware/__init__.py
+++ b/src/dev_health_ops/api/middleware/__init__.py
@@ -87,11 +87,13 @@ class OrgIdMiddleware:
         user = get_authenticated_user_from_headers(headers)
 
         resolved_org_id: str | None = None
-        if header_org_id:
-            if user is None:
-                await self._deny(send, "Authentication required for X-Org-Id")
-                return
-            if header_org_id == user.org_id:
+        if header_org_id and user is not None:
+            # IDOR check: authenticated user's X-Org-Id must match their JWT
+            # org_id or an existing Membership. Mismatch → 403. Superusers are
+            # permitted to scope to any org (intentional — admin API contract).
+            if user.is_superuser:
+                resolved_org_id = header_org_id
+            elif header_org_id == user.org_id:
                 resolved_org_id = header_org_id
             elif await user_is_member_of_org(user.user_id, header_org_id):
                 resolved_org_id = header_org_id
@@ -105,6 +107,9 @@ class OrgIdMiddleware:
                 return
         elif user is not None and user.org_id:
             resolved_org_id = user.org_id
+        # Anonymous requests with an X-Org-Id header: pass through. The header
+        # is not a security claim without auth — downstream endpoints that
+        # require auth will 401 via their own dependencies.
 
         token = set_current_org_id(resolved_org_id) if resolved_org_id else None
         try:

--- a/src/dev_health_ops/api/middleware/__init__.py
+++ b/src/dev_health_ops/api/middleware/__init__.py
@@ -4,17 +4,70 @@ Sets the org_id contextvar for every HTTP request from:
   1. X-Org-Id header (authoritative - sent by frontend for all API calls)
   2. JWT org_id claim (fallback - when header is absent)
 
+IDOR protection: the X-Org-Id header is ONLY accepted if the authenticated
+user has a Membership row for that org (or the JWT org_id matches). Any
+other value yields HTTP 403.
+
 This is the SINGLE enforcement point for tenant scoping. All downstream
 ClickHouse queries auto-inject org_id via query_dicts().
 """
 
 from __future__ import annotations
 
+import json
+import logging
+import uuid as uuid_mod
+from collections.abc import Iterable
+
+from sqlalchemy import select
 from starlette.types import ASGIApp, Receive, Scope, Send
+
+from dev_health_ops.api.services.auth import (
+    AuthenticatedUser,
+    _current_org_id,
+    extract_token_from_header,
+    get_auth_service,
+    set_current_org_id,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_authenticated_user_from_headers(
+    headers: Iterable[tuple[bytes, bytes]],
+) -> AuthenticatedUser | None:
+    for key, value in headers:
+        if key == b"authorization":
+            token = extract_token_from_header(value.decode("latin-1"))
+            if not token:
+                return None
+            return get_auth_service().get_authenticated_user(token)
+    return None
+
+
+async def user_is_member_of_org(user_id: str, org_id: str) -> bool:
+    """Return True iff the user has an active Membership for org_id."""
+    try:
+        user_uuid = uuid_mod.UUID(user_id)
+        org_uuid = uuid_mod.UUID(org_id)
+    except (ValueError, TypeError):
+        return False
+
+    from dev_health_ops.db import get_postgres_session
+    from dev_health_ops.models.users import Membership
+
+    async with get_postgres_session() as session:
+        result = await session.execute(
+            select(Membership.id)
+            .where(Membership.user_id == user_uuid)
+            .where(Membership.org_id == org_uuid)
+            .limit(1)
+        )
+        return result.scalar_one_or_none() is not None
 
 
 class OrgIdMiddleware:
-    """Pure ASGI middleware - extracts org_id and sets request-scoped contextvar."""
+    """Pure ASGI middleware — extracts org_id, verifies membership, sets contextvar."""
 
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
@@ -24,11 +77,36 @@ class OrgIdMiddleware:
             await self.app(scope, receive, send)
             return
 
-        from dev_health_ops.api.services.auth import _current_org_id, set_current_org_id
+        headers = scope.get("headers", [])
+        header_org_id: str | None = None
+        for key, value in headers:
+            if key == b"x-org-id":
+                header_org_id = value.decode("latin-1").strip() or None
+                break
 
-        org_id = self._extract_org_id(scope)
-        token = set_current_org_id(org_id) if org_id else None
+        user = get_authenticated_user_from_headers(headers)
 
+        resolved_org_id: str | None = None
+        if header_org_id:
+            if user is None:
+                await self._deny(send, "Authentication required for X-Org-Id")
+                return
+            if header_org_id == user.org_id:
+                resolved_org_id = header_org_id
+            elif await user_is_member_of_org(user.user_id, header_org_id):
+                resolved_org_id = header_org_id
+            else:
+                logger.warning(
+                    "X-Org-Id rejected: user=%s tried to access org=%s",
+                    user.user_id,
+                    header_org_id,
+                )
+                await self._deny(send, "X-Org-Id not permitted for this user")
+                return
+        elif user is not None and user.org_id:
+            resolved_org_id = user.org_id
+
+        token = set_current_org_id(resolved_org_id) if resolved_org_id else None
         try:
             await self.app(scope, receive, send)
         finally:
@@ -36,33 +114,23 @@ class OrgIdMiddleware:
                 _current_org_id.reset(token)
 
     @staticmethod
-    def _extract_org_id(scope: Scope) -> str | None:
-        """Extract org_id from ASGI headers: X-Org-Id first, then JWT fallback."""
-        from dev_health_ops.api.services.auth import (
-            extract_token_from_header,
-            get_auth_service,
+    async def _deny(send: Send, message: str) -> None:
+        body = json.dumps({"detail": message}).encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 403,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                ],
+            }
         )
-
-        org_id: str | None = None
-        auth_value: str | None = None
-
-        for key, value in scope.get("headers", []):
-            if key == b"x-org-id":
-                org_id = value.decode("latin-1")
-            elif key == b"authorization":
-                auth_value = value.decode("latin-1")
-
-        if org_id:
-            return org_id
-
-        if auth_value:
-            token_str = extract_token_from_header(auth_value)
-            if token_str:
-                user = get_auth_service().get_authenticated_user(token_str)
-                if user and user.org_id:
-                    return user.org_id
-
-        return None
+        await send({"type": "http.response.body", "body": body})
 
 
-__all__ = ["OrgIdMiddleware"]
+__all__ = [
+    "OrgIdMiddleware",
+    "get_authenticated_user_from_headers",
+    "user_is_member_of_org",
+]

--- a/src/dev_health_ops/api/middleware/rate_limit.py
+++ b/src/dev_health_ops/api/middleware/rate_limit.py
@@ -62,17 +62,26 @@ def get_auth_key(request: Request) -> str:
     return f"{ip}:{email}"
 
 
-def get_forwarded_ip(request: Request) -> str:
-    """Return real client IP via X-Forwarded-For, falling back to peer IP.
+def _trusted_proxies() -> frozenset[str]:
+    """Return the configured set of trusted proxy IPs (fail-closed: empty if unset)."""
+    raw = os.getenv("TRUSTED_PROXIES", "")
+    return frozenset(p.strip() for p in raw.split(",") if p.strip())
 
-    Behind a reverse proxy (Next.js rewrite, nginx, etc.) the TCP peer is
-    the proxy, not the end-user.  X-Forwarded-For carries the original IP.
+
+def get_forwarded_ip(request: Request) -> str:
+    """Return real client IP via X-Forwarded-For, honoured only if the TCP peer
+    is in the TRUSTED_PROXIES allowlist.
+
+    Behind a reverse proxy (Next.js rewrite, nginx, etc.) the TCP peer is the
+    proxy, not the end-user. X-Forwarded-For carries the original IP — but it
+    is attacker-controlled when sent directly to the API, so we only trust it
+    when the peer address is an expected proxy.
     """
+    peer = (request.client.host if request.client else None) or "unknown"
     forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        # First entry is the original client
+    if forwarded and peer in _trusted_proxies():
         return forwarded.split(",")[0].strip()
-    return get_remote_address(request) or "unknown"
+    return peer
 
 
 def get_admin_user_key(request: Request) -> str:

--- a/src/dev_health_ops/api/middleware/security_headers.py
+++ b/src/dev_health_ops/api/middleware/security_headers.py
@@ -1,0 +1,55 @@
+"""Security-headers middleware.
+
+Injects a conservative set of response headers on every HTTP response:
+
+- Strict-Transport-Security: HSTS with 1y max-age and subdomain coverage
+- X-Content-Type-Options: nosniff
+- X-Frame-Options: DENY
+- Referrer-Policy: strict-origin-when-cross-origin
+- Content-Security-Policy: lock down by default (API returns JSON)
+
+Pre-existing headers set by downstream handlers are preserved (case-insensitive
+match); the middleware only adds what's missing.
+"""
+
+from __future__ import annotations
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_DEFAULT_HEADERS: tuple[tuple[bytes, bytes], ...] = (
+    (b"strict-transport-security", b"max-age=31536000; includeSubDomains"),
+    (b"x-content-type-options", b"nosniff"),
+    (b"x-frame-options", b"DENY"),
+    (b"referrer-policy", b"strict-origin-when-cross-origin"),
+    (
+        b"content-security-policy",
+        b"default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+    ),
+)
+
+
+class SecurityHeadersMiddleware:
+    """Pure ASGI middleware that adds security headers to every response."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def _send(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                existing = {k.lower() for k, _ in message.get("headers", [])}
+                headers = list(message.get("headers", []))
+                for name, value in _DEFAULT_HEADERS:
+                    if name not in existing:
+                        headers.append((name, value))
+                message["headers"] = headers
+            await send(message)
+
+        await self.app(scope, receive, _send)
+
+
+__all__ = ["SecurityHeadersMiddleware"]

--- a/src/dev_health_ops/api/queries/drilldown.py
+++ b/src/dev_health_ops/api/queries/drilldown.py
@@ -3,7 +3,19 @@ from __future__ import annotations
 from datetime import date
 from typing import Any
 
+from dev_health_ops.api.services.auth import get_current_org_id
+
 from .client import query_dicts
+
+
+def _assert_org_id(org_id: str) -> None:
+    if not org_id:
+        raise ValueError("org_id is required for drilldown queries")
+    ctx = get_current_org_id()
+    if ctx is not None and ctx != org_id:
+        raise PermissionError(
+            f"org_id mismatch: contextvar={ctx!r} caller={org_id!r}"
+        )
 
 
 async def fetch_pull_requests(
@@ -16,6 +28,7 @@ async def fetch_pull_requests(
     limit: int = 50,
     org_id: str = "",
 ) -> list[dict[str, Any]]:
+    _assert_org_id(org_id)
     query = f"""
         SELECT
             repo_id,
@@ -55,6 +68,7 @@ async def fetch_issues(
     limit: int = 50,
     org_id: str = "",
 ) -> list[dict[str, Any]]:
+    _assert_org_id(org_id)
     query = f"""
         SELECT
             work_item_id,

--- a/src/dev_health_ops/api/queries/drilldown.py
+++ b/src/dev_health_ops/api/queries/drilldown.py
@@ -13,9 +13,7 @@ def _assert_org_id(org_id: str) -> None:
         raise ValueError("org_id is required for drilldown queries")
     ctx = get_current_org_id()
     if ctx is not None and ctx != org_id:
-        raise PermissionError(
-            f"org_id mismatch: contextvar={ctx!r} caller={org_id!r}"
-        )
+        raise PermissionError(f"org_id mismatch: contextvar={ctx!r} caller={org_id!r}")
 
 
 async def fetch_pull_requests(

--- a/src/dev_health_ops/api/services/auth.py
+++ b/src/dev_health_ops/api/services/auth.py
@@ -7,7 +7,6 @@ for the GraphQL API and REST endpoints.
 from __future__ import annotations
 
 import contextvars
-import hashlib
 import logging
 import os
 import uuid
@@ -96,33 +95,10 @@ JWT_AUDIENCE = os.getenv("JWT_AUDIENCE", "dev-health-api")
 def _get_jwt_secret() -> str:
     secret = os.getenv("JWT_SECRET_KEY")
     if not secret:
-        logger.warning(
-            "JWT_SECRET_KEY not set, using derived key from SETTINGS_ENCRYPTION_KEY"
+        raise RuntimeError(
+            "JWT_SECRET_KEY is required and must be set in the environment. "
+            "Derivation from SETTINGS_ENCRYPTION_KEY is no longer supported."
         )
-        encryption_key = os.getenv("SETTINGS_ENCRYPTION_KEY", "dev-key-not-for-prod")
-        secret = hashlib.sha256(encryption_key.encode()).hexdigest()
-
-        environment = (
-            (os.getenv("ENVIRONMENT") or os.getenv("ENV") or "").strip().lower()
-        )
-        has_platform_production_hint = any(
-            os.getenv(var)
-            for var in (
-                "RAILWAY_ENVIRONMENT",
-                "FLY_APP_NAME",
-                "RENDER_SERVICE_ID",
-                "KUBERNETES_SERVICE_HOST",
-            )
-        )
-        is_production = (
-            environment in {"production", "prod"} or has_platform_production_hint
-        )
-
-        if encryption_key == "dev-key-not-for-prod" and is_production:
-            raise RuntimeError(
-                "JWT_SECRET_KEY must be explicitly set in production environments"
-            )
-
     if len(secret) < 32:
         raise ValueError("JWT secret must be at least 32 characters")
     return secret

--- a/src/dev_health_ops/api/services/sso.py
+++ b/src/dev_health_ops/api/services/sso.py
@@ -10,10 +10,12 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import urlencode, urlparse
-from xml.etree import ElementTree
+from xml.etree.ElementTree import Element, ParseError
 
 import httpx
 import jwt
+from defusedxml import ElementTree as DefusedElementTree
+from defusedxml.common import DefusedXmlException
 from jwt import PyJWKClient
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -651,25 +653,17 @@ class SSOService:
         return user, membership, provider
 
     @staticmethod
-    def _parse_saml_xml(xml_bytes: bytes) -> ElementTree.Element:
+    def _parse_saml_xml(xml_bytes: bytes) -> Element:
         try:
-            try:
-                from defusedxml import ElementTree as safe_tree
-
-                return safe_tree.fromstring(xml_bytes)
-            except ImportError as exc:
-                logger.error(
-                    "defusedxml is required for secure SAML XML parsing but is not installed"
-                )
-                raise SAMLProcessingError(
-                    "SAML processing requires the 'defusedxml' package to be installed"
-                ) from exc
-        except ElementTree.ParseError as exc:
+            return DefusedElementTree.fromstring(xml_bytes)
+        except DefusedXmlException as exc:
+            raise SAMLProcessingError("Unsafe SAML XML rejected") from exc
+        except ParseError as exc:
             raise SAMLProcessingError("Invalid SAML XML") from exc
 
     @staticmethod
     def _find_text(
-        element: ElementTree.Element,
+        element: Element,
         path: str,
         namespaces: Mapping[str, str],
     ) -> str | None:
@@ -679,7 +673,7 @@ class SSOService:
         return node.text.strip()
 
     def _validate_saml_signature(
-        self, xml_root: ElementTree.Element, certificate: str | None
+        self, xml_root: Element, certificate: str | None
     ) -> None:
         if not certificate:
             raise SAMLProcessingError("SAML certificate is required for validation")
@@ -698,7 +692,7 @@ class SSOService:
 
     @staticmethod
     def _extract_saml_attributes(
-        assertion: ElementTree.Element,
+        assertion: Element,
         namespaces: Mapping[str, str],
     ) -> dict[str, str]:
         attributes: dict[str, str] = {}
@@ -725,8 +719,8 @@ class SSOService:
 
     def _validate_saml_timestamps(
         self,
-        assertion: ElementTree.Element,
-        subject_confirmation: ElementTree.Element,
+        assertion: Element,
+        subject_confirmation: Element,
         namespaces: Mapping[str, str],
     ) -> None:
         now = datetime.now(timezone.utc)

--- a/src/dev_health_ops/api/services/sso.py
+++ b/src/dev_health_ops/api/services/sso.py
@@ -596,6 +596,22 @@ class SSOService:
         if not provider:
             raise SSOProcessingError("SSO provider not found")
 
+        allowed = [d.strip().lower() for d in (provider.allowed_domains or []) if d]
+        if allowed:
+            try:
+                _, domain = email.rsplit("@", 1)
+            except ValueError as exc:
+                raise SSOProcessingError("Invalid email from IdP") from exc
+            if domain.lower() not in allowed:
+                logger.warning(
+                    "SSO provision rejected: domain=%s not in allowed_domains for provider=%s",
+                    sanitize_for_log(domain),
+                    provider.id,
+                )
+                raise SSOProcessingError(
+                    "Email domain is not permitted for this SSO provider"
+                )
+
         stmt = select(User).where(User.email == email)
         result = await self.session.execute(stmt)
         user = result.scalar_one_or_none()

--- a/tests/api/admin/test_orgs_auth.py
+++ b/tests/api/admin/test_orgs_auth.py
@@ -1,0 +1,115 @@
+"""Auth-dependency tests for admin orgs router (CHAOS security sprint)."""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import Organization
+
+orgs_router_module = importlib.import_module("dev_health_ops.api.admin.routers.orgs")
+admin_common = importlib.import_module("dev_health_ops.api.admin.routers.common")
+admin_middleware = importlib.import_module("dev_health_ops.api.admin.middleware")
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "orgs-auth.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn, tables=[Organization.__table__]
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def _seed_org(session_maker) -> str:
+    org_id = uuid.uuid4()
+    org = Organization(id=org_id, slug=f"o-{org_id.hex[:8]}", name="Acme")
+    async with session_maker() as session:
+        session.add(org)
+        await session.commit()
+    return str(org_id)
+
+
+def _app(session_maker, current_user: AuthenticatedUser | None):
+    app = FastAPI()
+    app.include_router(orgs_router_module.router, prefix="/admin")
+
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+            await session.commit()
+
+    app.dependency_overrides[admin_common.get_session] = _session_override
+    if current_user is not None:
+        from dev_health_ops.api.auth.router import get_current_user
+
+        app.dependency_overrides[get_current_user] = lambda: current_user
+    return app
+
+
+@pytest.mark.asyncio
+async def test_get_org_by_id_rejects_anonymous(session_maker):
+    """GET /admin/orgs/{id} must 401 when no bearer token is supplied."""
+    org_id = await _seed_org(session_maker)
+    app = _app(session_maker, current_user=None)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get(f"/admin/orgs/{org_id}")
+    assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
+async def test_get_org_by_id_rejects_non_superuser(session_maker):
+    """GET /admin/orgs/{id} must 403 when caller is not a superuser."""
+    org_id = await _seed_org(session_maker)
+    member = AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        email="m@example.com",
+        org_id=str(uuid.uuid4()),
+        role="member",
+        is_superuser=False,
+    )
+    app = _app(session_maker, current_user=member)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get(f"/admin/orgs/{org_id}")
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_get_org_by_id_accepts_superuser(session_maker):
+    """GET /admin/orgs/{id} must 200 for superuser."""
+    org_id = await _seed_org(session_maker)
+    su = AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        email="su@example.com",
+        org_id=str(uuid.uuid4()),
+        role="owner",
+        is_superuser=True,
+    )
+    app = _app(session_maker, current_user=su)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get(f"/admin/orgs/{org_id}")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["id"] == org_id

--- a/tests/api/auth/test_extract_unverified_claims.py
+++ b/tests/api/auth/test_extract_unverified_claims.py
@@ -1,0 +1,43 @@
+"""Tests for narrowed exception handling in _extract_unverified_org_and_subject."""
+
+from __future__ import annotations
+
+import logging
+
+from dev_health_ops.api.auth.router import _extract_unverified_org_and_subject
+
+
+def test_returns_none_tuple_for_malformed_token(caplog):
+    """A malformed token must yield (None, None) AND emit a debug log."""
+    caplog.set_level(logging.DEBUG, logger="dev_health_ops.api.auth.router")
+    org, sub = _extract_unverified_org_and_subject("not.a.token")
+    assert (org, sub) == (None, None)
+    assert any("unverified claims" in rec.message.lower() for rec in caplog.records)
+
+
+def test_returns_none_tuple_for_empty_token():
+    org, sub = _extract_unverified_org_and_subject("")
+    assert (org, sub) == (None, None)
+
+
+def test_returns_tuple_for_valid_unsigned_token():
+    """A syntactically valid JWT (even if signature invalid) yields claims."""
+    import base64
+    import json
+
+    def _b64(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+    header = _b64(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    payload = _b64(
+        json.dumps(
+            {"sub": "user-1", "org_id": "00000000-0000-0000-0000-000000000001"}
+        ).encode()
+    )
+    signature = _b64(b"\x00" * 32)
+    token = f"{header}.{payload}.{signature}"
+
+    org, sub = _extract_unverified_org_and_subject(token)
+    assert sub == "user-1"
+    assert org is not None
+    assert str(org) == "00000000-0000-0000-0000-000000000001"

--- a/tests/api/auth/test_jwt_secret.py
+++ b/tests/api/auth/test_jwt_secret.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-
 import pytest
 
 from dev_health_ops.api.services.auth import _get_jwt_secret
@@ -31,28 +29,25 @@ def test_jwt_secret_key_env_var_is_used_when_set(
     assert _get_jwt_secret() == jwt_secret
 
 
-def test_fallback_to_settings_encryption_key_works_in_dev(
+def test_missing_jwt_secret_raises_runtime_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """JWT_SECRET_KEY absent in ANY environment must fail closed."""
     _clear_secret_env(monkeypatch)
-    encryption_key = "local-dev-encryption-key"
-    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", encryption_key)
+
+    with pytest.raises(RuntimeError, match="JWT_SECRET_KEY"):
+        _get_jwt_secret()
+
+
+def test_missing_jwt_secret_with_settings_encryption_key_still_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SETTINGS_ENCRYPTION_KEY must NOT be used as a fallback."""
+    _clear_secret_env(monkeypatch)
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "some-dev-key")
     monkeypatch.setenv("ENVIRONMENT", "development")
 
-    expected = hashlib.sha256(encryption_key.encode()).hexdigest()
-    assert _get_jwt_secret() == expected
-
-
-def test_insecure_default_raises_runtime_error_in_production(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _clear_secret_env(monkeypatch)
-    monkeypatch.setenv("ENVIRONMENT", "production")
-
-    with pytest.raises(
-        RuntimeError,
-        match="JWT_SECRET_KEY must be explicitly set in production environments",
-    ):
+    with pytest.raises(RuntimeError, match="JWT_SECRET_KEY"):
         _get_jwt_secret()
 
 

--- a/tests/api/queries/test_drilldown_org_check.py
+++ b/tests/api/queries/test_drilldown_org_check.py
@@ -1,0 +1,91 @@
+"""Defense-in-depth org_id re-check for drilldown queries (CHAOS security sprint)."""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.queries.drilldown import fetch_issues, fetch_pull_requests
+from dev_health_ops.api.services.auth import _current_org_id, set_current_org_id
+
+
+class _Sink:
+    def __init__(self) -> None:
+        self.last_params: dict[str, Any] | None = None
+
+    def query_dicts(
+        self, query: str, params: dict[str, Any] | None
+    ) -> list[dict[str, Any]]:
+        self.last_params = params
+        return []
+
+
+@pytest.mark.asyncio
+async def test_fetch_pull_requests_rejects_empty_org_id():
+    try:
+        _current_org_id.set(None)
+        with pytest.raises(ValueError, match="org_id"):
+            await fetch_pull_requests(
+                _Sink(),
+                start_day=date(2024, 1, 1),
+                end_day=date(2024, 1, 2),
+                scope_filter="",
+                scope_params={},
+                org_id="",
+            )
+    finally:
+        _current_org_id.set(None)
+
+
+@pytest.mark.asyncio
+async def test_fetch_pull_requests_rejects_context_mismatch():
+    try:
+        set_current_org_id("org-A")
+        with pytest.raises(PermissionError, match="org_id mismatch"):
+            await fetch_pull_requests(
+                _Sink(),
+                start_day=date(2024, 1, 1),
+                end_day=date(2024, 1, 2),
+                scope_filter="",
+                scope_params={},
+                org_id="org-B",
+            )
+    finally:
+        _current_org_id.set(None)
+
+
+@pytest.mark.asyncio
+async def test_fetch_issues_rejects_context_mismatch():
+    try:
+        set_current_org_id("org-A")
+        with pytest.raises(PermissionError, match="org_id mismatch"):
+            await fetch_issues(
+                _Sink(),
+                start_day=date(2024, 1, 1),
+                end_day=date(2024, 1, 2),
+                scope_filter="",
+                scope_params={},
+                org_id="org-B",
+            )
+    finally:
+        _current_org_id.set(None)
+
+
+@pytest.mark.asyncio
+async def test_fetch_issues_allows_matching_org_id():
+    try:
+        set_current_org_id("org-X")
+        sink = _Sink()
+        await fetch_issues(
+            sink,
+            start_day=date(2024, 1, 1),
+            end_day=date(2024, 1, 2),
+            scope_filter="",
+            scope_params={},
+            org_id="org-X",
+        )
+        assert sink.last_params is not None
+        assert sink.last_params["org_id"] == "org-X"
+    finally:
+        _current_org_id.set(None)

--- a/tests/api/queries/test_drilldown_org_check.py
+++ b/tests/api/queries/test_drilldown_org_check.py
@@ -1,4 +1,5 @@
 """Defense-in-depth org_id re-check for drilldown queries (CHAOS security sprint)."""
+
 from __future__ import annotations
 
 from datetime import date

--- a/tests/api/services/test_sso_allowed_domains.py
+++ b/tests/api/services/test_sso_allowed_domains.py
@@ -1,4 +1,5 @@
 """Enforcement tests for SSO allowed_domains (CHAOS security sprint)."""
+
 from __future__ import annotations
 
 import uuid

--- a/tests/api/services/test_sso_allowed_domains.py
+++ b/tests/api/services/test_sso_allowed_domains.py
@@ -1,0 +1,82 @@
+"""Enforcement tests for SSO allowed_domains (CHAOS security sprint)."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dev_health_ops.api.services.sso import SSOProcessingError, SSOService
+from dev_health_ops.models.sso import SSOProvider
+
+
+def _provider(allowed_domains, auto_provision=True):
+    return SSOProvider(
+        org_id=uuid.uuid4(),
+        name="Acme SSO",
+        protocol="oidc",
+        config={},
+        auto_provision_users=auto_provision,
+        allowed_domains=allowed_domains,
+    )
+
+
+def _service_with_provider(provider):
+    session = MagicMock()
+    session.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+    )
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    svc = SSOService(session)
+    svc.get_provider = AsyncMock(return_value=provider)
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_disallowed_domain_is_rejected_on_autoprovision():
+    """A user whose email domain is not in allowed_domains must 403."""
+    provider = _provider(allowed_domains=["acme.com"])
+    svc = _service_with_provider(provider)
+
+    with pytest.raises(SSOProcessingError, match="domain"):
+        await svc.provision_or_get_user(
+            org_id=provider.org_id,
+            email="attacker@evil.com",
+            name="A Person",
+            provider_id=provider.id,
+            external_id="ext-1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_allowed_domain_is_accepted_case_insensitive():
+    """Email domain matching (case-insensitive) must succeed."""
+    provider = _provider(allowed_domains=["Acme.COM"])
+    svc = _service_with_provider(provider)
+
+    user, _membership, returned_provider = await svc.provision_or_get_user(
+        org_id=provider.org_id,
+        email="alice@acme.com",
+        name="Alice",
+        provider_id=provider.id,
+        external_id="ext-2",
+    )
+    assert user.email == "alice@acme.com"
+    assert returned_provider is provider
+
+
+@pytest.mark.asyncio
+async def test_empty_allowed_domains_list_allows_all():
+    """When allowed_domains is None or empty, any domain is accepted (no regression)."""
+    provider = _provider(allowed_domains=None)
+    svc = _service_with_provider(provider)
+
+    user, _m, _p = await svc.provision_or_get_user(
+        org_id=provider.org_id,
+        email="any@anything.io",
+        name="Any",
+        provider_id=provider.id,
+        external_id="ext-3",
+    )
+    assert user.email == "any@anything.io"

--- a/tests/api/services/test_sso_xxe.py
+++ b/tests/api/services/test_sso_xxe.py
@@ -1,10 +1,10 @@
 """XXE-resistance tests for SAML XML parsing (CHAOS security sprint)."""
+
 from __future__ import annotations
 
 import pytest
 
 from dev_health_ops.api.services.sso import SAMLProcessingError, SSOService
-
 
 XXE_PAYLOAD = b"""<?xml version="1.0"?>
 <!DOCTYPE foo [

--- a/tests/api/services/test_sso_xxe.py
+++ b/tests/api/services/test_sso_xxe.py
@@ -1,0 +1,38 @@
+"""XXE-resistance tests for SAML XML parsing (CHAOS security sprint)."""
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.services.sso import SAMLProcessingError, SSOService
+
+
+XXE_PAYLOAD = b"""<?xml version="1.0"?>
+<!DOCTYPE foo [
+  <!ELEMENT foo ANY >
+  <!ENTITY xxe SYSTEM "file:///etc/passwd" >
+]>
+<foo>&xxe;</foo>
+"""
+
+
+def test_parse_saml_xml_rejects_doctype_payload():
+    """defusedxml must reject any DOCTYPE declaration (XXE protection)."""
+    with pytest.raises(SAMLProcessingError):
+        SSOService._parse_saml_xml(XXE_PAYLOAD)
+
+
+def test_parse_saml_xml_rejects_external_entity():
+    """External entity resolution must be impossible."""
+    payload = b"""<?xml version="1.0"?>
+<!DOCTYPE lolz [<!ENTITY lol "lol">]>
+<lolz>&lol;</lolz>
+"""
+    with pytest.raises(SAMLProcessingError):
+        SSOService._parse_saml_xml(payload)
+
+
+def test_parse_saml_xml_accepts_benign_xml():
+    """Sanity: a well-formed SAML-shaped document still parses."""
+    xml = b"<samlp:Response xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'/>"
+    tree = SSOService._parse_saml_xml(xml)
+    assert tree.tag.endswith("Response")

--- a/tests/api/test_forwarded_ip_trust.py
+++ b/tests/api/test_forwarded_ip_trust.py
@@ -1,0 +1,61 @@
+"""X-Forwarded-For trust boundary tests (CHAOS security sprint)."""
+from __future__ import annotations
+
+import pytest
+from fastapi import Request
+
+from dev_health_ops.api.middleware.rate_limit import get_forwarded_ip
+
+
+def _make_request(
+    client_host: str,
+    xff: str | None = None,
+) -> Request:
+    headers: list[tuple[bytes, bytes]] = []
+    if xff is not None:
+        headers.append((b"x-forwarded-for", xff.encode("latin-1")))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": headers,
+        "client": (client_host, 12345),
+    }
+    return Request(scope)
+
+
+def test_xff_ignored_from_untrusted_peer(monkeypatch):
+    """XFF from a random internet peer must NOT be honoured."""
+    monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.1")
+    req = _make_request(client_host="1.2.3.4", xff="203.0.113.1")
+    assert get_forwarded_ip(req) == "1.2.3.4"
+
+
+def test_xff_honoured_from_trusted_peer(monkeypatch):
+    """XFF from a listed trusted proxy must be used as the real client."""
+    monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.1,10.0.0.2")
+    req = _make_request(client_host="10.0.0.2", xff="203.0.113.1")
+    assert get_forwarded_ip(req) == "203.0.113.1"
+
+
+def test_xff_missing_returns_peer(monkeypatch):
+    """No XFF: peer IP is returned regardless of trust."""
+    monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.1")
+    req = _make_request(client_host="10.0.0.1", xff=None)
+    assert get_forwarded_ip(req) == "10.0.0.1"
+
+
+def test_trusted_proxies_unset_disables_xff(monkeypatch):
+    """Unset/empty TRUSTED_PROXIES must fail-closed: never trust XFF."""
+    monkeypatch.delenv("TRUSTED_PROXIES", raising=False)
+    req = _make_request(client_host="10.0.0.1", xff="203.0.113.1")
+    assert get_forwarded_ip(req) == "10.0.0.1"
+
+
+def test_xff_takes_first_entry(monkeypatch):
+    """When trusted, the leftmost XFF entry is the original client."""
+    monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.1")
+    req = _make_request(
+        client_host="10.0.0.1", xff="203.0.113.1, 10.0.0.1"
+    )
+    assert get_forwarded_ip(req) == "203.0.113.1"

--- a/tests/api/test_forwarded_ip_trust.py
+++ b/tests/api/test_forwarded_ip_trust.py
@@ -1,7 +1,7 @@
 """X-Forwarded-For trust boundary tests (CHAOS security sprint)."""
+
 from __future__ import annotations
 
-import pytest
 from fastapi import Request
 
 from dev_health_ops.api.middleware.rate_limit import get_forwarded_ip
@@ -55,7 +55,5 @@ def test_trusted_proxies_unset_disables_xff(monkeypatch):
 def test_xff_takes_first_entry(monkeypatch):
     """When trusted, the leftmost XFF entry is the original client."""
     monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.1")
-    req = _make_request(
-        client_host="10.0.0.1", xff="203.0.113.1, 10.0.0.1"
-    )
+    req = _make_request(client_host="10.0.0.1", xff="203.0.113.1, 10.0.0.1")
     assert get_forwarded_ip(req) == "203.0.113.1"

--- a/tests/api/test_generic_exception_handler.py
+++ b/tests/api/test_generic_exception_handler.py
@@ -1,4 +1,5 @@
 """Generic 500 exception handler returns sanitized JSON (CHAOS security sprint)."""
+
 from __future__ import annotations
 
 import pytest
@@ -54,5 +55,7 @@ async def test_500_logs_original_exception(sanitized_app, caplog):
     ) as ac:
         await ac.get("/boom")
     # The full text must appear in the logs, not the response.
-    assert any("hunter2" in rec.message or "hunter2" in (rec.exc_text or "")
-               for rec in caplog.records)
+    assert any(
+        "hunter2" in rec.message or "hunter2" in (rec.exc_text or "")
+        for rec in caplog.records
+    )

--- a/tests/api/test_generic_exception_handler.py
+++ b/tests/api/test_generic_exception_handler.py
@@ -1,0 +1,58 @@
+"""Generic 500 exception handler returns sanitized JSON (CHAOS security sprint)."""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from dev_health_ops.api.main import _generic_exception_handler
+
+
+@pytest.fixture
+def sanitized_app() -> FastAPI:
+    app = FastAPI()
+    app.add_exception_handler(Exception, _generic_exception_handler)
+
+    @app.get("/boom")
+    async def boom():
+        raise RuntimeError("super secret internal: DB password=hunter2")
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_500_body_is_generic(sanitized_app):
+    async with AsyncClient(
+        transport=ASGITransport(app=sanitized_app, raise_app_exceptions=False),
+        base_url="http://test",
+    ) as ac:
+        resp = await ac.get("/boom")
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body == {"detail": "Internal Server Error"}
+
+
+@pytest.mark.asyncio
+async def test_500_does_not_leak_exception_text(sanitized_app):
+    async with AsyncClient(
+        transport=ASGITransport(app=sanitized_app, raise_app_exceptions=False),
+        base_url="http://test",
+    ) as ac:
+        resp = await ac.get("/boom")
+    assert "hunter2" not in resp.text
+    assert "RuntimeError" not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_500_logs_original_exception(sanitized_app, caplog):
+    import logging
+
+    caplog.set_level(logging.ERROR, logger="dev_health_ops.api.main")
+    async with AsyncClient(
+        transport=ASGITransport(app=sanitized_app, raise_app_exceptions=False),
+        base_url="http://test",
+    ) as ac:
+        await ac.get("/boom")
+    # The full text must appear in the logs, not the response.
+    assert any("hunter2" in rec.message or "hunter2" in (rec.exc_text or "")
+               for rec in caplog.records)

--- a/tests/api/test_org_id_middleware_membership.py
+++ b/tests/api/test_org_id_middleware_membership.py
@@ -126,6 +126,75 @@ async def test_header_for_member_org_is_accepted():
 
 
 @pytest.mark.asyncio
+async def test_superuser_with_header_bypasses_membership_check():
+    """Superusers may scope to any org via X-Org-Id without a Membership row."""
+    user_id = str(uuid.uuid4())
+    home_org = str(uuid.uuid4())
+    other_org = str(uuid.uuid4())
+    super_user = AuthenticatedUser(
+        user_id=user_id,
+        email="root@example.com",
+        org_id=home_org,
+        role="owner",
+        is_superuser=True,
+    )
+
+    captured: dict = {}
+    app = _build_app(captured)
+
+    with patch(
+        "dev_health_ops.api.middleware.get_authenticated_user_from_headers",
+        return_value=super_user,
+    ):
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/",
+                    headers={
+                        "authorization": "Bearer tok",
+                        "x-org-id": other_org,
+                    },
+                )
+        finally:
+            _current_org_id.set(None)
+
+    assert response.status_code == 200
+    assert captured["org_id"] == other_org
+
+
+@pytest.mark.asyncio
+async def test_anonymous_request_with_header_passes_through():
+    """Unauthenticated requests with X-Org-Id must NOT be 403-ed by middleware.
+
+    Downstream endpoints that require auth will 401 via their own dependencies;
+    the X-Org-Id header carries no security claim without a JWT anyway.
+    """
+    foreign_org = str(uuid.uuid4())
+
+    captured: dict = {}
+    app = _build_app(captured)
+
+    with patch(
+        "dev_health_ops.api.middleware.get_authenticated_user_from_headers",
+        return_value=None,
+    ):
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get("/", headers={"x-org-id": foreign_org})
+        finally:
+            _current_org_id.set(None)
+
+    assert response.status_code == 200
+    assert captured.get("org_id") is None
+
+
+@pytest.mark.asyncio
 async def test_missing_header_falls_back_to_jwt_org():
     """No X-Org-Id: JWT org_id is used and no membership check is performed."""
     user_id = str(uuid.uuid4())

--- a/tests/api/test_org_id_middleware_membership.py
+++ b/tests/api/test_org_id_middleware_membership.py
@@ -1,0 +1,154 @@
+"""Membership-aware X-Org-Id middleware tests (CHAOS security sprint).
+
+Verifies that OrgIdMiddleware rejects a forged X-Org-Id header pointing at
+an org the authenticated user is NOT a member of.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from dev_health_ops.api.middleware import OrgIdMiddleware
+from dev_health_ops.api.services.auth import (
+    AuthenticatedUser,
+    _current_org_id,
+    get_current_org_id,
+)
+
+
+def _fake_user(user_id: str, jwt_org_id: str) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=user_id,
+        email="u@example.com",
+        org_id=jwt_org_id,
+        role="member",
+    )
+
+
+def _build_app(captured: dict) -> Any:
+    async def _handler(scope, receive, send):
+        captured["org_id"] = get_current_org_id()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"{}"})
+
+    return OrgIdMiddleware(_handler)
+
+
+@pytest.mark.asyncio
+async def test_header_for_non_member_org_is_rejected():
+    """X-Org-Id header for an org the user does NOT belong to must 403."""
+    user_id = str(uuid.uuid4())
+    member_org = str(uuid.uuid4())
+    foreign_org = str(uuid.uuid4())
+    user = _fake_user(user_id, member_org)
+
+    captured: dict = {}
+    app = _build_app(captured)
+
+    with (
+        patch(
+            "dev_health_ops.api.middleware.get_authenticated_user_from_headers",
+            return_value=user,
+        ),
+        patch(
+            "dev_health_ops.api.middleware.user_is_member_of_org",
+            return_value=False,
+        ),
+    ):
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/",
+                    headers={
+                        "authorization": "Bearer tok",
+                        "x-org-id": foreign_org,
+                    },
+                )
+        finally:
+            _current_org_id.set(None)
+
+    assert response.status_code == 403, response.text
+    assert captured.get("org_id") is None
+
+
+@pytest.mark.asyncio
+async def test_header_for_member_org_is_accepted():
+    """X-Org-Id for an org the user IS a member of must be accepted."""
+    user_id = str(uuid.uuid4())
+    member_org = str(uuid.uuid4())
+    secondary_org = str(uuid.uuid4())
+    user = _fake_user(user_id, member_org)
+
+    captured: dict = {}
+    app = _build_app(captured)
+
+    with (
+        patch(
+            "dev_health_ops.api.middleware.get_authenticated_user_from_headers",
+            return_value=user,
+        ),
+        patch(
+            "dev_health_ops.api.middleware.user_is_member_of_org",
+            return_value=True,
+        ),
+    ):
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/",
+                    headers={
+                        "authorization": "Bearer tok",
+                        "x-org-id": secondary_org,
+                    },
+                )
+        finally:
+            _current_org_id.set(None)
+
+    assert response.status_code == 200
+    assert captured["org_id"] == secondary_org
+
+
+@pytest.mark.asyncio
+async def test_missing_header_falls_back_to_jwt_org():
+    """No X-Org-Id: JWT org_id is used and no membership check is performed."""
+    user_id = str(uuid.uuid4())
+    jwt_org = str(uuid.uuid4())
+    user = _fake_user(user_id, jwt_org)
+
+    captured: dict = {}
+    app = _build_app(captured)
+
+    with patch(
+        "dev_health_ops.api.middleware.get_authenticated_user_from_headers",
+        return_value=user,
+    ):
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get(
+                    "/", headers={"authorization": "Bearer tok"}
+                )
+        finally:
+            _current_org_id.set(None)
+
+    assert response.status_code == 200
+    assert captured["org_id"] == jwt_org

--- a/tests/api/test_security_headers.py
+++ b/tests/api/test_security_headers.py
@@ -1,4 +1,5 @@
 """Security-headers middleware tests (CHAOS security sprint)."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/api/test_security_headers.py
+++ b/tests/api/test_security_headers.py
@@ -1,0 +1,72 @@
+"""Security-headers middleware tests (CHAOS security sprint)."""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from dev_health_ops.api.middleware.security_headers import SecurityHeadersMiddleware
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    a = FastAPI()
+    a.add_middleware(SecurityHeadersMiddleware)
+
+    @a.get("/ping")
+    async def ping() -> dict[str, str]:
+        return {"pong": "ok"}
+
+    return a
+
+
+@pytest.mark.asyncio
+async def test_response_includes_hsts(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get("/ping")
+    hsts = resp.headers.get("strict-transport-security", "")
+    assert "max-age=" in hsts
+    assert "includeSubDomains" in hsts
+
+
+@pytest.mark.asyncio
+async def test_response_includes_nosniff_and_frame_deny(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get("/ping")
+    assert resp.headers.get("x-content-type-options") == "nosniff"
+    assert resp.headers.get("x-frame-options") == "DENY"
+
+
+@pytest.mark.asyncio
+async def test_response_includes_referrer_policy_and_csp(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get("/ping")
+    assert resp.headers.get("referrer-policy") == "strict-origin-when-cross-origin"
+    csp = resp.headers.get("content-security-policy", "")
+    assert "default-src 'none'" in csp
+    assert "frame-ancestors 'none'" in csp
+
+
+@pytest.mark.asyncio
+async def test_existing_headers_are_not_overridden(app):
+    @app.get("/custom")
+    async def custom():
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(
+            content={"ok": True},
+            headers={"x-frame-options": "SAMEORIGIN"},
+        )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.get("/custom")
+    # Middleware must NOT stomp an explicit per-response choice.
+    assert resp.headers.get("x-frame-options") == "SAMEORIGIN"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,15 @@ from git import Repo as GitRepo
 
 @pytest.fixture(autouse=True)
 def setup_test_env(monkeypatch):
-    """Ensure a default DATABASE_URI is set for tests."""
+    """Ensure a default DATABASE_URI and JWT_SECRET_KEY are set for tests."""
     monkeypatch.setenv("DATABASE_URI", "sqlite:///:memory:")
+    # JWT_SECRET_KEY is now a hard requirement with no derivation fallback
+    # (CHAOS-1266). Provide a safe default for tests; tests that need to
+    # assert the "unset" behaviour use monkeypatch.delenv to override.
+    monkeypatch.setenv(
+        "JWT_SECRET_KEY",
+        "test-jwt-secret-key-at-least-32-characters-long",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/uv.lock
+++ b/uv.lock
@@ -821,6 +821,7 @@ dependencies = [
     { name = "celery", extra = ["redis"] },
     { name = "clickhouse-connect" },
     { name = "croniter" },
+    { name = "defusedxml" },
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "gitpython" },
@@ -871,7 +872,6 @@ dev = [
     { name = "ruff" },
 ]
 enterprise-sso = [
-    { name = "defusedxml" },
     { name = "signxml" },
 ]
 
@@ -886,7 +886,7 @@ requires-dist = [
     { name = "celery", extras = ["redis"], specifier = ">=5.3.0" },
     { name = "clickhouse-connect" },
     { name = "croniter", specifier = ">=1.3.0" },
-    { name = "defusedxml", marker = "extra == 'enterprise-sso'", specifier = ">=0.7.0" },
+    { name = "defusedxml", specifier = ">=0.7.0" },
     { name = "email-validator", specifier = ">=2.0.0" },
     { name = "fakeredis", extras = ["valkey"], marker = "extra == 'dev'" },
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Ships all 10 findings from the 2026-04-16 repo security audit as one atomic PR. Covers [CHAOS-1257 epic](https://linear.app/fullchaos/issue/CHAOS-1257) and 10 sub-issues ([CHAOS-1260](https://linear.app/fullchaos/issue/CHAOS-1260) through [CHAOS-1273](https://linear.app/fullchaos/issue/CHAOS-1273)).

Full plan: `docs/superpowers/plans/2026-04-16-security-sprint.md` (1744 lines, committed in this PR).

## Commits

| # | Commit | Linear |
|---|--------|--------|
| Sec-1 | `feat(sec-1): enforce X-Org-Id membership check in middleware` | [CHAOS-1260](https://linear.app/fullchaos/issue/CHAOS-1260) — **P1 Urgent** |
| Sec-2 | `feat(sec-2): require superuser auth on admin GET /orgs/{org_id}` | [CHAOS-1261](https://linear.app/fullchaos/issue/CHAOS-1261) — P2 |
| Sec-3 | `fix(sec-3): make defusedxml a hard dep, remove XXE fallback` | [CHAOS-1262](https://linear.app/fullchaos/issue/CHAOS-1262) — P2 |
| Sec-4 | `fix(sec-4): require JWT_SECRET_KEY, remove SHA256 derivation fallback` | [CHAOS-1266](https://linear.app/fullchaos/issue/CHAOS-1266) — P2 |
| Sec-5 | `fix(sec-5): enforce SSO allowed_domains on auto-provision` | [CHAOS-1267](https://linear.app/fullchaos/issue/CHAOS-1267) — P3 |
| Sec-6 | `fix(sec-6): honor TRUSTED_PROXIES for X-Forwarded-For` | [CHAOS-1268](https://linear.app/fullchaos/issue/CHAOS-1268) — P3 |
| Sec-7 | `fix(sec-7): re-check org_id ownership in drilldown queries` | [CHAOS-1270](https://linear.app/fullchaos/issue/CHAOS-1270) — P3 |
| Sec-8 | `feat(sec-8): sanitized generic 500 exception handler` | [CHAOS-1271](https://linear.app/fullchaos/issue/CHAOS-1271) — P4 |
| Sec-9 | `feat(sec-9): add security-headers middleware` | [CHAOS-1272](https://linear.app/fullchaos/issue/CHAOS-1272) — P4 |
| Sec-10 | `fix(sec-10): narrow bare except in _extract_unverified_org_and_subject` | [CHAOS-1273](https://linear.app/fullchaos/issue/CHAOS-1273) — P4 |

## Notable Behavior Changes

- **Sec-1** (IDOR): `X-Org-Id` forgery now returns 403. Any code that legitimately spoofs org context in tests may need to switch to a valid membership fixture.
- **Sec-4** (JWT): `JWT_SECRET_KEY` is now **required** in every environment. Deployments without it will fail at startup. Test suite sets a default in `tests/conftest.py`.
- **Sec-6** (TRUSTED_PROXIES): Behind a proxy? Set `TRUSTED_PROXIES=<peer-ips>` (comma-separated) or your existing rate-limiting will start ignoring `X-Forwarded-For` and using the proxy's IP.
- **Sec-10**: Refresh-token audit logging now actually captures org_id/subject (the `from jose import jwt` orphan never worked; switched to pyjwt).

## New Env Var

- `TRUSTED_PROXIES` — comma-separated allowlist of peer IPs permitted to set `X-Forwarded-For`. When unset, `X-Forwarded-For` is ignored (fail-closed).

## Test plan

- [x] `uv run pytest tests/api -q` on the merged branch — 429 pass, 1 pre-existing failure (`test_resend_verification_always_returns_200`, confirmed failing on pristine `main` — Redis rate-limit state leaks between tests; not introduced here)
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean (after format commit)
- [ ] Manual: confirm no production services break on JWT_SECRET_KEY requirement (prior deploys may have been relying on SHA256 fallback silently)
- [ ] Manual: confirm TRUSTED_PROXIES is set in prod envs before this merges, otherwise rate limits will show proxy IP instead of client IP

## Process note

This PR was produced by three parallel agents working in separate worktrees (`sec-a`, `sec-b`, `sec-c`), cherry-picked onto one epic branch. Each commit maps 1:1 to a Linear sub-issue for traceability.