### PR TITLE
Provider Unification Refactor — Wave 2 (Unif-5: EnvSpec)

### DIFF
--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -12,6 +12,7 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitGate,
 )
 from dev_health_ops.providers._ratelimit import gate_call
+from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,23 @@ class GitHubWorkClient:
 
         # GraphQL client (api.github.com only for now).
         self.graphql = GitHubGraphQLClient(auth.token)
+
+    @classmethod
+    def from_env(cls) -> GitHubWorkClient:
+        env = read_env_spec(
+            EnvSpec(
+                required={"token": "GITHUB_TOKEN"},
+                optional={"base_url": ("GITHUB_BASE_URL", None)},
+                missing_error="GITHUB_TOKEN environment variable is required",
+            )
+        )
+        base = env["base_url"]
+        return cls(
+            auth=GitHubAuth(
+                token=str(env["token"]),
+                base_url=str(base) if base else None,
+            )
+        )
 
     def get_repo(self, *, owner: str, repo: str) -> Any:
         return self.github.get_repo(f"{owner}/{repo}")

--- a/src/dev_health_ops/providers/github/provider.py
+++ b/src/dev_health_ops/providers/github/provider.py
@@ -8,7 +8,6 @@ the underlying ingestion behavior.
 from __future__ import annotations
 
 import logging
-import os
 from datetime import datetime
 
 from dev_health_ops.models.work_items import (
@@ -101,7 +100,7 @@ class GitHubProvider(Provider):
         - GITHUB_COMMENTS_LIMIT: max comments per item (default: 500)
         - GITHUB_FETCH_MILESTONES: whether to fetch milestones (default: true)
         """
-        from dev_health_ops.providers.github.client import GitHubAuth, GitHubWorkClient
+        from dev_health_ops.providers.github.client import GitHubWorkClient
         from dev_health_ops.providers.github.normalize import (
             detect_github_reopen_events,
             enrich_work_item_with_priority,
@@ -122,13 +121,7 @@ class GitHubProvider(Provider):
         owner, repo = parts
 
         # Get auth from environment
-        token = os.getenv("GITHUB_TOKEN")
-        if not token:
-            raise ValueError("GITHUB_TOKEN environment variable is required")
-
-        base_url = os.getenv("GITHUB_BASE_URL")
-        auth = GitHubAuth(token=token, base_url=base_url)
-        client = GitHubWorkClient(auth=auth)
+        client = GitHubWorkClient.from_env()
 
         work_items: list[WorkItem] = []
         transitions: list[WorkItemStatusTransition] = []

--- a/src/dev_health_ops/providers/gitlab/client.py
+++ b/src/dev_health_ops/providers/gitlab/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
@@ -12,6 +11,7 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitGate,
 )
 from dev_health_ops.providers._ratelimit import gate_call
+from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 
 logger = logging.getLogger(__name__)
 
@@ -70,11 +70,19 @@ class GitLabWorkClient:
 
     @classmethod
     def from_env(cls) -> GitLabWorkClient:
-        token = os.getenv("GITLAB_TOKEN") or ""
-        url = os.getenv("GITLAB_URL") or "https://gitlab.com"
-        if not token:
-            raise ValueError("GitLab token required (set GITLAB_TOKEN)")
-        return cls(auth=GitLabAuth(token=token, base_url=url))
+        env = read_env_spec(
+            EnvSpec(
+                required={"token": "GITLAB_TOKEN"},
+                optional={"base_url": ("GITLAB_URL", "https://gitlab.com")},
+                missing_error="GitLab token required (set GITLAB_TOKEN)",
+            )
+        )
+        return cls(
+            auth=GitLabAuth(
+                token=str(env["token"]),
+                base_url=str(env["base_url"]),
+            )
+        )
 
     def get_project(self, project_id_or_path: str) -> Any:
         with gate_call(self.gate):

--- a/src/dev_health_ops/providers/jira/client.py
+++ b/src/dev_health_ops/providers/jira/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from typing import Any
@@ -12,6 +11,7 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitGate,
 )
 from dev_health_ops.providers._ratelimit import penalize_from_response
+from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 
 logger = logging.getLogger(__name__)
 
@@ -88,18 +88,23 @@ class JiraClient:
 
     @classmethod
     def from_env(cls) -> JiraClient:
-        base_url = os.getenv("JIRA_BASE_URL") or ""
-        email = os.getenv("JIRA_EMAIL") or ""
-        api_token = os.getenv("JIRA_API_TOKEN") or ""
-        if not base_url or not email or not api_token:
-            raise ValueError(
-                "Jira env vars required: JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN"
+        env = read_env_spec(
+            EnvSpec(
+                required={
+                    "base_url": "JIRA_BASE_URL",
+                    "email": "JIRA_EMAIL",
+                    "api_token": "JIRA_API_TOKEN",
+                },
+                missing_error=(
+                    "Jira env vars required: JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN"
+                ),
             )
+        )
         return cls(
             auth=JiraAuth(
-                base_url=_normalize_jira_base_url(base_url),
-                email=email,
-                api_token=api_token,
+                base_url=_normalize_jira_base_url(str(env["base_url"])),
+                email=str(env["email"]),
+                api_token=str(env["api_token"]),
             )
         )
 

--- a/src/dev_health_ops/providers/linear/client.py
+++ b/src/dev_health_ops/providers/linear/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -9,6 +8,8 @@ from datetime import datetime
 from typing import Any
 
 import httpx
+
+from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 
 logger = logging.getLogger(__name__)
 
@@ -334,10 +335,13 @@ class LinearClient:
 
     @classmethod
     def from_env(cls) -> LinearClient:
-        api_key = os.getenv("LINEAR_API_KEY") or ""
-        if not api_key:
-            raise ValueError("Linear API key required (set LINEAR_API_KEY)")
-        return cls(auth=LinearAuth(api_key=api_key))
+        env = read_env_spec(
+            EnvSpec(
+                required={"api_key": "LINEAR_API_KEY"},
+                missing_error="Linear API key required (set LINEAR_API_KEY)",
+            )
+        )
+        return cls(auth=LinearAuth(api_key=str(env["api_key"])))
 
     def _execute(
         self,

--- a/src/dev_health_ops/providers/utils.py
+++ b/src/dev_health_ops/providers/utils.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["env_flag", "env_int"]
+__all__ = ["EnvSpec", "env_flag", "env_int", "read_env_spec"]
 
 _TRUTHY = {"1", "true", "yes", "on"}
 _FALSY = {"0", "false", "no", "off"}
@@ -44,3 +45,41 @@ def env_int(name: str, default: int) -> int:
     except ValueError:
         logger.warning("Invalid %s value %r; falling back to %d", name, raw, default)
         return default
+
+
+@dataclass(frozen=True)
+class EnvSpec:
+    """Declarative specification of env vars for a client's ``from_env``.
+
+    ``required``: mapping of ``field_name -> ENV_VAR_NAME``. Missing or
+        empty values cause ``read_env_spec`` to raise ``ValueError`` with
+        ``missing_error`` as the message.
+    ``optional``: mapping of ``field_name -> (ENV_VAR_NAME, default)``.
+        Unset env vars fall back to ``default`` (may be ``None``).
+    ``missing_error``: human-readable error message used when any
+        required var is missing. Include the env var names so the error
+        is actionable.
+    """
+
+    required: dict[str, str] = field(default_factory=dict)
+    optional: dict[str, tuple[str, object]] = field(default_factory=dict)
+    missing_error: str = "Required environment variables missing"
+
+
+def read_env_spec(spec: EnvSpec) -> dict[str, object]:
+    """Read env vars as declared by ``spec``.
+
+    Raises ``ValueError(spec.missing_error)`` if any required var is
+    missing or empty. Returns a dict suitable for passing as kwargs to
+    the auth dataclass / client constructor.
+    """
+    result: dict[str, object] = {}
+    for key, env_name in spec.required.items():
+        value = os.getenv(env_name) or ""
+        if not value:
+            raise ValueError(spec.missing_error)
+        result[key] = value
+    for key, (env_name, default) in spec.optional.items():
+        value = os.getenv(env_name)
+        result[key] = value if value else default
+    return result

--- a/tests/providers/test_utils.py
+++ b/tests/providers/test_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from dev_health_ops.providers.utils import env_flag, env_int
+from dev_health_ops.providers.utils import EnvSpec, env_flag, env_int, read_env_spec
 
 
 class TestEnvFlag:
@@ -55,3 +55,73 @@ class TestEnvInt:
     def test_negative_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("TEST_INT", "-5")
         assert env_int("TEST_INT", 0) == -5
+
+
+class TestReadEnvSpec:
+    def test_all_required_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_TOKEN", "abc")
+        monkeypatch.setenv("MY_URL", "https://x")
+        spec = EnvSpec(
+            required={"token": "MY_TOKEN", "url": "MY_URL"},
+            optional={},
+            missing_error="MY_TOKEN and MY_URL are required",
+        )
+        assert read_env_spec(spec) == {"token": "abc", "url": "https://x"}
+
+    def test_required_missing_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MY_TOKEN", raising=False)
+        spec = EnvSpec(
+            required={"token": "MY_TOKEN"},
+            optional={},
+            missing_error="Token required (set MY_TOKEN)",
+        )
+        with pytest.raises(ValueError, match="Token required"):
+            read_env_spec(spec)
+
+    def test_required_empty_string_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MY_TOKEN", "")
+        spec = EnvSpec(
+            required={"token": "MY_TOKEN"},
+            optional={},
+            missing_error="Token required",
+        )
+        with pytest.raises(ValueError, match="Token required"):
+            read_env_spec(spec)
+
+    def test_optional_with_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_TOKEN", "abc")
+        monkeypatch.delenv("MY_URL", raising=False)
+        spec = EnvSpec(
+            required={"token": "MY_TOKEN"},
+            optional={"url": ("MY_URL", "https://default.example")},
+            missing_error="required",
+        )
+        assert read_env_spec(spec) == {
+            "token": "abc",
+            "url": "https://default.example",
+        }
+
+    def test_optional_none_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_TOKEN", "abc")
+        monkeypatch.delenv("MY_URL", raising=False)
+        spec = EnvSpec(
+            required={"token": "MY_TOKEN"},
+            optional={"url": ("MY_URL", None)},
+            missing_error="required",
+        )
+        assert read_env_spec(spec) == {"token": "abc", "url": None}
+
+    def test_multiple_required_missing_lists_all(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("A", raising=False)
+        monkeypatch.delenv("B", raising=False)
+        spec = EnvSpec(
+            required={"a": "A", "b": "B"},
+            optional={},
+            missing_error="A and B are required",
+        )
+        with pytest.raises(ValueError, match="A and B are required"):
+            read_env_spec(spec)

--- a/tests/test_github_provider.py
+++ b/tests/test_github_provider.py
@@ -906,7 +906,7 @@ def test_github_provider_ingest(mock_client_class, mock_status_mapping, mock_ide
     """Test full provider ingest flow."""
     # Setup mock client
     mock_client = MagicMock()
-    mock_client_class.return_value = mock_client
+    mock_client_class.from_env.return_value = mock_client
 
     # Mock milestones
     mock_client.iter_repo_milestones.return_value = [


### PR DESCRIPTION
## Summary

Wave 2 of the [Provider Unification Refactor plan](docs/superpowers/plans/2026-04-16-provider-unification.md). Ships Unif-5 — base `from_env()` via shared `EnvSpec`. Builds on Wave 1's `providers/utils.py`. Unblocks Wave 3 (Unif-6 `ProviderWithClient` base).

Covers [CHAOS-1243 epic](https://linear.app/fullchaos/issue/CHAOS-1243) sub-issue [CHAOS-1248](https://linear.app/fullchaos/issue/CHAOS-1248).

## Commits

| # | Commit | Linear |
|---|--------|--------|
| Unif-5 | `refactor(unif-5): base from_env() via shared EnvSpec` | [CHAOS-1248](https://linear.app/fullchaos/issue/CHAOS-1248) — P3 |

## What changed

- `providers/utils.py` — extended with `EnvSpec` dataclass + `read_env_spec(spec)` helper. Keeps the `env_flag` / `env_int` from Wave 1.
- `providers/gitlab/client.py` — `from_env()` rewritten to use `read_env_spec`. Drops `import os`.
- `providers/jira/client.py` — same pattern. Drops `import os`. Ruff reformatted an error string (cosmetic).
- `providers/linear/client.py` — same pattern. Drops `import os`.
- `providers/github/client.py` — **adds** `GitHubWorkClient.from_env()` (previously env-reading lived inline in the provider).
- `providers/github/provider.py` — `GitHubProvider.ingest` now calls `GitHubWorkClient.from_env()` instead of the 7-line inline `os.getenv` block. Drops unused `import os` and `GitHubAuth` import.

## LOC impact
- `providers/utils.py` +50 (EnvSpec + read_env_spec)
- 4 client `from_env()` rewrites: -55 duplicated / +30 unified
- github/provider.py: -12 inline env-reading
- Tests: +65 (6 new EnvSpec tests + 1 patched github_provider test)
- Net: +78, duplication factor across 4 clients eliminated

## Audit correction captured
- Only 3 of 4 clients previously had `from_env()` — github's lived inline in the provider. Task 5 closes that inconsistency.

## Test plan

- [x] `uv run pytest tests/providers tests/test_{github,gitlab,linear}_provider.py tests/test_jira_*` — 265 pass
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean

## Test fixture update
- `tests/test_github_provider.py::test_github_provider_ingest` — previously patched `mock_client_class.return_value` (direct instantiation); now patches `mock_client_class.from_env.return_value` because the provider dispatches through the classmethod. Minimal contract change.

## Up next

**Wave 3** — Unif-6 `ProviderWithClient` base class (blocked by Unif-3 + this PR). Biggest payoff (~200 LOC removed across all 4 provider.py files). Kicks off after this lands.