### PR TITLE
Security hardening: Retry-After cap + OrgScopedQuery alias validator

### DIFF
--- a/src/dev_health_ops/connectors/utils/rate_limit_queue.py
+++ b/src/dev_health_ops/connectors/utils/rate_limit_queue.py
@@ -63,9 +63,13 @@ class RateLimitGate:
                     self._config.max_backoff_seconds,
                 )
             else:
-                # If we get an explicit server reset delay, keep exponential
-                # backoff state but still honor the explicit delay.
-                delay_seconds = max(0.0, float(delay_seconds))
+                # Clamp explicit (e.g. server-provided Retry-After) delays
+                # to the configured max so a malicious or misbehaving upstream
+                # cannot park the gate for an unbounded period.
+                delay_seconds = max(
+                    0.0,
+                    min(float(delay_seconds), self._config.max_backoff_seconds),
+                )
 
             now = time.time()
             self._next_allowed_at = max(
@@ -205,7 +209,12 @@ class DistributedRateLimitGate(RateLimitGate):
                     self._config.max_backoff_seconds,
                 )
             else:
-                delay_seconds = max(0.0, float(delay_seconds))
+                # Clamp explicit delay (e.g. Retry-After) to max_backoff_seconds
+                # so an upstream-supplied value cannot park the gate unbounded.
+                delay_seconds = max(
+                    0.0,
+                    min(float(delay_seconds), self._config.max_backoff_seconds),
+                )
 
             now = time.time()
             proposed = now + delay_seconds

--- a/src/dev_health_ops/metrics/query_builder.py
+++ b/src/dev_health_ops/metrics/query_builder.py
@@ -22,7 +22,19 @@ class OrgScopedQuery:
         return bool(self.org_id)
 
     def filter(self, *, alias: str = "") -> str:
-        """Return ``" AND {alias?.}org_id = {org_id:String}"`` or ``""``."""
+        """Return ``" AND {alias?.}org_id = {org_id:String}"`` or ``""``.
+
+        ``alias`` is interpolated into SQL directly and MUST be a valid SQL
+        identifier (ASCII letters/digits/underscore, non-digit first char).
+        Defense in depth: all known call sites pass hardcoded literals, but
+        a stray user-supplied value would be a SQL-injection vector without
+        this check.
+        """
+        if alias and not alias.isidentifier():
+            raise ValueError(
+                "OrgScopedQuery.filter: alias must be a valid identifier, "
+                f"got {alias!r}"
+            )
         if not self.org_id:
             return ""
         col = f"{alias}.org_id" if alias else "org_id"

--- a/tests/metrics/test_query_builder.py
+++ b/tests/metrics/test_query_builder.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from dev_health_ops.metrics.query_builder import OrgScopedQuery
 
 
@@ -39,3 +41,26 @@ class TestOrgScopedQuery:
     def test_bool_truthiness(self) -> None:
         assert bool(OrgScopedQuery("")) is False
         assert bool(OrgScopedQuery("acme")) is True
+
+    @pytest.mark.parametrize(
+        "bad_alias",
+        [
+            "c; DROP TABLE users--",
+            "c OR 1=1",
+            "c.d",
+            "1c",
+            "c-d",
+            "c d",
+            "'; --",
+        ],
+    )
+    def test_filter_rejects_non_identifier_alias(self, bad_alias: str) -> None:
+        q = OrgScopedQuery("acme")
+        with pytest.raises(ValueError, match="valid identifier"):
+            q.filter(alias=bad_alias)
+
+    def test_filter_accepts_snake_case_alias(self) -> None:
+        q = OrgScopedQuery("acme")
+        assert (
+            q.filter(alias="work_units") == " AND work_units.org_id = {org_id:String}"
+        )

--- a/tests/test_distributed_rate_limit.py
+++ b/tests/test_distributed_rate_limit.py
@@ -150,6 +150,38 @@ class TestDistributedPenalize:
         assert gate._next_allowed_at >= first
 
 
+class TestLocalGatePenalizeClamping:
+    """Explicit delay (e.g. server Retry-After) must be clamped to max_backoff."""
+
+    def test_explicit_delay_above_max_is_clamped(self):
+        cfg = RateLimitConfig(max_backoff_seconds=60.0)
+        gate = RateLimitGate(cfg)
+        applied = gate.penalize(99_999_999.0)
+        assert applied == 60.0
+
+    def test_explicit_delay_below_max_is_preserved(self):
+        cfg = RateLimitConfig(max_backoff_seconds=60.0)
+        gate = RateLimitGate(cfg)
+        assert gate.penalize(10.0) == 10.0
+
+    def test_negative_delay_is_zero(self):
+        cfg = RateLimitConfig(max_backoff_seconds=60.0)
+        gate = RateLimitGate(cfg)
+        assert gate.penalize(-5.0) == 0.0
+
+
+class TestDistributedGatePenalizeClamping:
+    def test_explicit_delay_above_max_is_clamped(self):
+        cfg = RateLimitConfig(max_backoff_seconds=30.0)
+        client = _make_redis_mock()
+        # force local-fallback path so we can inspect applied delay deterministically
+        gate = DistributedRateLimitGate("gh", config=cfg, redis_client=client)
+        gate._redis_available = False
+        before = time.time()
+        gate.penalize(10_000.0)
+        assert gate._next_allowed_at - before <= 30.0 + 0.5
+
+
 class TestDistributedSleepSeconds:
     def test_reads_from_redis(self):
         client = _make_redis_mock()


### PR DESCRIPTION
## Summary

Two low-priority hardenings flagged during the Wave 1 Provider Unification review. Neither is exploitable today — both are defense-in-depth.

## Changes

### 1. Clamp explicit `Retry-After` delays to `max_backoff_seconds`
**Files:** `src/dev_health_ops/connectors/utils/rate_limit_queue.py`

`RateLimitGate.penalize(delay_seconds)` and `DistributedRateLimitGate.penalize(delay_seconds)` previously honored any explicit delay without an upper bound. A malicious or misbehaving upstream sending `Retry-After: 99999999` could park a worker for ~3 years.

Fix: both penalize paths now apply `min(float(delay), max_backoff_seconds)`. Default `max_backoff_seconds = 300.0` (5 minutes), configurable per `RateLimitConfig`.

### 2. Reject non-identifier `OrgScopedQuery.filter(alias=...)`
**Files:** `src/dev_health_ops/metrics/query_builder.py`

`alias` is f-string-interpolated into ClickHouse SQL. All current call sites pass hardcoded literals (`"c"`, `"p"`, `"s"`) — safe today. A future developer passing user-supplied input would open a SQL-injection vector.

Fix: raise `ValueError` when `alias` is set and not a valid Python identifier (ASCII letters/digits/underscore, non-digit first char). Empty string still allowed.

## Tests

- `tests/test_distributed_rate_limit.py::TestLocalGatePenalizeClamping` — 3 cases (above-max clamped, below-max preserved, negative → 0)
- `tests/test_distributed_rate_limit.py::TestDistributedGatePenalizeClamping` — 1 case (local-fallback path clamps too)
- `tests/metrics/test_query_builder.py::TestOrgScopedQuery::test_filter_rejects_non_identifier_alias` — 7 parametrized cases (SQL-injection attempt strings)
- `tests/metrics/test_query_builder.py::TestOrgScopedQuery::test_filter_accepts_snake_case_alias` — sanity check that legitimate aliases like `work_units` pass

## Test plan

- [x] `uv run pytest tests/metrics/test_query_builder.py tests/test_distributed_rate_limit.py` — 56 pass
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] No behavior change for legitimate call sites (all existing providers/metrics tests pass)

## Milestone

Closes out the April 2026 repo-audit milestone: 3 tracks (security, performance, refactor) shipped across PRs #675, #676, #677, #678, #679. This is the final cleanup.