### PR TITLE
ci: apply clickhouse marker filter to ci_tests() coverage path

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -228,8 +228,10 @@ ci_tests() {
   fi
 
   run_step "ruff (lint gates)" ruff check --select=E9,F63,F7,F82 .
+  # Mirror unit_tests()'s marker filter: skip `clickhouse`-marked tests that
+  # need a seeded live ClickHouse (opt-in locally via `pytest -m clickhouse`).
   run_pytest_step "unit tests with coverage >= ${coverage_threshold}" "${JUNIT_XML_UNIT}" \
-    tests -v --tb=short -m "not benchmark" \
+    tests -v --tb=short -m "not benchmark and not clickhouse" \
     --ignore=tests/test_connectors_integration.py \
     --ignore=tests/test_private_repo_access.py \
     --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under="${coverage_threshold}"


### PR DESCRIPTION
## Summary
Follow-up to PR #683 (CHAOS-1289). Prior CI fix only updated `unit_tests()` in `ci/run_tests.sh:150`, but the matrix build actually uses the `ci` tier, which invokes `ci_tests()` with its own pytest call at line 232 that kept `-m "not benchmark"`. The four `@pytest.mark.clickhouse` live tests ran against CI's ephemeral ClickHouse and failed with auth errors.

Extend the filter to `-m "not benchmark and not clickhouse"` in the coverage-gated path so both entry points behave consistently.

## Test plan
- [x] `python -m pytest tests/graphql/test_flow_matrix_live.py -m "not benchmark and not clickhouse" --collect-only` → 0 collected (4 deselected). ✅
- [x] `python -m pytest tests/graphql -m "clickhouse" --collect-only` → 4 live tests selected (opt-in path still works). ✅
- [ ] Wait for CI matrix across 3.11/3.12/3.13/3.14 to go green.

## Why this slipped
Two copies of the pytest invocation exist (`unit_tests()` and `ci_tests()`). A future cleanup could DRY them into a shared array variable so the filter only has to be updated in one place.