### PR TITLE
feat(fixtures): densify cross-team co-occurrence for chord chart (CHAOS-1291)

### DIFF
--- a/src/dev_health_ops/fixtures/generator.py
+++ b/src/dev_health_ops/fixtures/generator.py
@@ -1424,7 +1424,13 @@ class SyntheticDataGenerator:
                     )
                 )
 
-        for (
+        fallback_team_plan = self._build_fallback_team_plan(
+            items_to_process=items_to_process,
+            member_map=member_map,
+            teams_to_use=teams_to_use,
+        )
+
+        for item_index, (
             work_item_id,
             provider,
             item_type,
@@ -1432,7 +1438,7 @@ class SyntheticDataGenerator:
             created_at,
             started_at,
             completed_at,
-        ) in items_to_process:
+        ) in enumerate(items_to_process):
             if started_at is None or completed_at is None:
                 continue
 
@@ -1447,7 +1453,10 @@ class SyntheticDataGenerator:
                 if entry:
                     team_id, team_name = entry
             if team_id is None:
-                team_id, team_name = random.choice(teams_to_use)
+                team_id, team_name = fallback_team_plan.get(
+                    item_index,
+                    teams_to_use[0],
+                )
 
             efficiency = random.uniform(0.1, 0.6)
             active_hours = cycle_time * efficiency
@@ -1502,6 +1511,118 @@ class SyntheticDataGenerator:
                     member_map[str(member).strip().lower()] = (team.id, team.name)
             return member_map
         return self.get_team_assignment().get("member_map", {})
+
+    def _stable_hash_int(self, *parts: object) -> int:
+        payload = "::".join(str(part) for part in parts)
+        return int(hashlib.sha256(payload.encode("utf-8")).hexdigest(), 16)
+
+    def _allocate_fallback_team_counts(
+        self,
+        work_item_count: int,
+        weights: list[int],
+    ) -> list[int]:
+        if work_item_count <= 0 or not weights:
+            return []
+
+        team_count = min(work_item_count, len(weights))
+        counts = [1] * team_count
+        remaining = work_item_count - team_count
+        if remaining <= 0:
+            return counts
+
+        selected_weights = weights[:team_count]
+        total_weight = sum(selected_weights)
+        remainders: list[tuple[float, int]] = []
+        for idx, weight in enumerate(selected_weights):
+            exact = remaining * weight / total_weight
+            extra = int(exact)
+            counts[idx] += extra
+            remainders.append((exact - extra, idx))
+
+        assigned = sum(counts)
+        for _, idx in sorted(remainders, key=lambda item: (-item[0], item[1]))[
+            : work_item_count - assigned
+        ]:
+            counts[idx] += 1
+
+        return counts
+
+    def _build_fallback_team_sequence(
+        self,
+        completed_day: date,
+        work_item_count: int,
+        teams_to_use: list[tuple[str, str]],
+    ) -> list[tuple[str, str]]:
+        if work_item_count <= 0 or not teams_to_use:
+            return []
+        if len(teams_to_use) == 1:
+            return [teams_to_use[0]] * work_item_count
+
+        if work_item_count >= 6 and len(teams_to_use) >= 4:
+            selected_team_count = 4
+            weights = [5, 3, 2, 1]
+        elif work_item_count >= 4 and len(teams_to_use) >= 3:
+            selected_team_count = 3
+            weights = [6, 3, 1]
+        else:
+            selected_team_count = 2
+            weights = [7, 3]
+
+        start = self._stable_hash_int(
+            self.repo_name,
+            completed_day.isoformat(),
+            "team-fallback",
+        ) % len(teams_to_use)
+        rotated = [
+            teams_to_use[(start + i) % len(teams_to_use)] for i in range(len(teams_to_use))
+        ]
+        selected_teams = rotated[:selected_team_count]
+        counts = self._allocate_fallback_team_counts(work_item_count, weights)
+
+        sequence: list[tuple[str, str]] = []
+        for team, count in zip(selected_teams, counts, strict=False):
+            sequence.extend([team] * count)
+        return sequence
+
+    def _build_fallback_team_plan(
+        self,
+        items_to_process: list[
+            tuple[str, str, str, str | None, datetime, datetime | None, datetime | None]
+        ],
+        member_map: dict[str, tuple[str, str]],
+        teams_to_use: list[tuple[str, str]],
+    ) -> dict[int, tuple[str, str]]:
+        plan: dict[int, tuple[str, str]] = {}
+        unresolved_by_cell: dict[tuple[str, date], list[int]] = {}
+
+        for idx, item in enumerate(items_to_process):
+            _, _, _, assignee, _, started_at, completed_at = item
+            if started_at is None or completed_at is None:
+                continue
+            if (completed_at - started_at).total_seconds() <= 0:
+                continue
+            if assignee and member_map.get(str(assignee).strip().lower()):
+                continue
+            unresolved_by_cell.setdefault((self.repo_name, completed_at.date()), []).append(idx)
+
+        for (_, completed_day), indices in unresolved_by_cell.items():
+            sequence = self._build_fallback_team_sequence(
+                completed_day=completed_day,
+                work_item_count=len(indices),
+                teams_to_use=teams_to_use,
+            )
+            ordered_indices = sorted(
+                indices,
+                key=lambda item_idx: (
+                    items_to_process[item_idx][6]
+                    or datetime.min.replace(tzinfo=timezone.utc),
+                    items_to_process[item_idx][0],
+                ),
+            )
+            for item_idx, team in zip(ordered_indices, sequence, strict=False):
+                plan[item_idx] = team
+
+        return plan
 
     def generate_user_metrics_daily(
         self,

--- a/src/dev_health_ops/fixtures/generator.py
+++ b/src/dev_health_ops/fixtures/generator.py
@@ -1574,7 +1574,8 @@ class SyntheticDataGenerator:
             "team-fallback",
         ) % len(teams_to_use)
         rotated = [
-            teams_to_use[(start + i) % len(teams_to_use)] for i in range(len(teams_to_use))
+            teams_to_use[(start + i) % len(teams_to_use)]
+            for i in range(len(teams_to_use))
         ]
         selected_teams = rotated[:selected_team_count]
         counts = self._allocate_fallback_team_counts(work_item_count, weights)
@@ -1603,7 +1604,9 @@ class SyntheticDataGenerator:
                 continue
             if assignee and member_map.get(str(assignee).strip().lower()):
                 continue
-            unresolved_by_cell.setdefault((self.repo_name, completed_at.date()), []).append(idx)
+            unresolved_by_cell.setdefault(
+                (self.repo_name, completed_at.date()), []
+            ).append(idx)
 
         for (_, completed_day), indices in unresolved_by_cell.items():
             sequence = self._build_fallback_team_sequence(

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -1398,7 +1398,10 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         "--with-metrics", action="store_true", help="Also generate derived metrics."
     )
     fix_gen.add_argument(
-        "--team-count", type=int, default=10, help="Number of synthetic teams to create."
+        "--team-count",
+        type=int,
+        default=10,
+        help="Number of synthetic teams to create.",
     )
     fix_gen.set_defaults(func=run_fixtures_generation)
 

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -136,7 +136,7 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
 
         repo_count = max(1, ns.repo_count)
         base_name = ns.repo_name
-        team_count = getattr(ns, "team_count", 8)
+        team_count = getattr(ns, "team_count", 10)
         team_assignment = SyntheticDataGenerator(
             repo_name=base_name, seed=ns.seed
         ).get_team_assignment(count=team_count)
@@ -1398,7 +1398,7 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         "--with-metrics", action="store_true", help="Also generate derived metrics."
     )
     fix_gen.add_argument(
-        "--team-count", type=int, default=8, help="Number of synthetic teams to create."
+        "--team-count", type=int, default=10, help="Number of synthetic teams to create."
     )
     fix_gen.set_defaults(func=run_fixtures_generation)
 

--- a/tests/fixtures/test_team_cooccurrence.py
+++ b/tests/fixtures/test_team_cooccurrence.py
@@ -1,0 +1,89 @@
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+
+from dev_health_ops.fixtures.generator import SyntheticDataGenerator
+from dev_health_ops.fixtures.runner import _build_repo_team_assignments
+from dev_health_ops.models.work_items import WorkItem
+
+
+def _build_work_item(
+    index: int,
+    completed_at: datetime,
+    assignees: list[str] | None = None,
+) -> WorkItem:
+    started_at = completed_at - timedelta(hours=24)
+    created_at = started_at - timedelta(hours=12)
+    return WorkItem(
+        work_item_id=f"gh:acme/demo-app#{index}",
+        provider="github",
+        title=f"Synthetic item {index}",
+        type="task",
+        status="done",
+        status_raw="done",
+        created_at=created_at,
+        updated_at=completed_at,
+        started_at=started_at,
+        completed_at=completed_at,
+        closed_at=completed_at,
+        project_id="acme/demo-app",
+        project_key="acme/demo-app",
+        assignees=assignees or [],
+    )
+
+
+def test_cycle_times_fallback_spreads_same_cell_across_multiple_teams_asymmetrically() -> None:
+    teams = SyntheticDataGenerator(repo_name="acme/demo-app", seed=7).generate_teams(count=4)
+    generator = SyntheticDataGenerator(
+        repo_name="acme/demo-app",
+        provider="github",
+        seed=11,
+        assigned_teams=teams,
+    )
+    completed_at = datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc)
+    work_items = [_build_work_item(index=i, completed_at=completed_at) for i in range(6)]
+
+    generate_cycle_times = getattr(generator, "generate_work_item_cycle_times")
+    cycle_times = generate_cycle_times(work_items=work_items)
+
+    counts = Counter(record.team_id for record in cycle_times)
+    assert len(counts) >= 2
+    assert max(counts.values()) > min(counts.values())
+
+
+def test_assignee_resolution_wins_over_fallback_distribution() -> None:
+    teams = SyntheticDataGenerator(repo_name="acme/demo-app", seed=21).generate_teams(count=4)
+    generator = SyntheticDataGenerator(
+        repo_name="acme/demo-app",
+        provider="github",
+        seed=42,
+        assigned_teams=teams,
+    )
+    completed_at = datetime(2026, 4, 21, 15, 0, tzinfo=timezone.utc)
+    explicit_member = str(teams[0].members[0])
+    work_items = [
+        _build_work_item(index=1, completed_at=completed_at, assignees=[explicit_member]),
+        _build_work_item(index=2, completed_at=completed_at),
+        _build_work_item(index=3, completed_at=completed_at),
+        _build_work_item(index=4, completed_at=completed_at),
+    ]
+
+    generate_cycle_times = getattr(generator, "generate_work_item_cycle_times")
+    cycle_times = generate_cycle_times(work_items=work_items)
+
+    assigned_record = next(record for record in cycle_times if record.assignee == explicit_member)
+    assert assigned_record.team_id == teams[0].id
+    assert assigned_record.team_name == teams[0].name
+
+    fallback_counts = Counter(
+        record.team_id for record in cycle_times if record.assignee != explicit_member
+    )
+    assert len(fallback_counts) >= 2
+
+
+def test_repo_team_assignments_default_shape_supports_top_n_other_bucket() -> None:
+    teams = SyntheticDataGenerator(repo_name="acme/demo-app", seed=5).generate_teams(count=10)
+
+    assignments = _build_repo_team_assignments(teams, repo_count=6, seed=5)
+
+    assigned_team_ids = {team.id for repo_teams in assignments for team in repo_teams}
+    assert len(assigned_team_ids) == 10

--- a/tests/fixtures/test_team_cooccurrence.py
+++ b/tests/fixtures/test_team_cooccurrence.py
@@ -31,8 +31,12 @@ def _build_work_item(
     )
 
 
-def test_cycle_times_fallback_spreads_same_cell_across_multiple_teams_asymmetrically() -> None:
-    teams = SyntheticDataGenerator(repo_name="acme/demo-app", seed=7).generate_teams(count=4)
+def test_cycle_times_fallback_spreads_same_cell_across_multiple_teams_asymmetrically() -> (
+    None
+):
+    teams = SyntheticDataGenerator(repo_name="acme/demo-app", seed=7).generate_teams(
+        count=4
+    )
     generator = SyntheticDataGenerator(
         repo_name="acme/demo-app",
         provider="github",
@@ -40,7 +44,9 @@ def test_cycle_times_fallback_spreads_same_cell_across_multiple_teams_asymmetric
         assigned_teams=teams,
     )
     completed_at = datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc)
-    work_items = [_build_work_item(index=i, completed_at=completed_at) for i in range(6)]
+    work_items = [
+        _build_work_item(index=i, completed_at=completed_at) for i in range(6)
+    ]
 
     generate_cycle_times = getattr(generator, "generate_work_item_cycle_times")
     cycle_times = generate_cycle_times(work_items=work_items)
@@ -51,7 +57,9 @@ def test_cycle_times_fallback_spreads_same_cell_across_multiple_teams_asymmetric
 
 
 def test_assignee_resolution_wins_over_fallback_distribution() -> None:
-    teams = SyntheticDataGenerator(repo_name="acme/demo-app", seed=21).generate_teams(count=4)
+    teams = SyntheticDataGenerator(repo_name="acme/demo-app", seed=21).generate_teams(
+        count=4
+    )
     generator = SyntheticDataGenerator(
         repo_name="acme/demo-app",
         provider="github",
@@ -61,7 +69,9 @@ def test_assignee_resolution_wins_over_fallback_distribution() -> None:
     completed_at = datetime(2026, 4, 21, 15, 0, tzinfo=timezone.utc)
     explicit_member = str(teams[0].members[0])
     work_items = [
-        _build_work_item(index=1, completed_at=completed_at, assignees=[explicit_member]),
+        _build_work_item(
+            index=1, completed_at=completed_at, assignees=[explicit_member]
+        ),
         _build_work_item(index=2, completed_at=completed_at),
         _build_work_item(index=3, completed_at=completed_at),
         _build_work_item(index=4, completed_at=completed_at),
@@ -70,7 +80,9 @@ def test_assignee_resolution_wins_over_fallback_distribution() -> None:
     generate_cycle_times = getattr(generator, "generate_work_item_cycle_times")
     cycle_times = generate_cycle_times(work_items=work_items)
 
-    assigned_record = next(record for record in cycle_times if record.assignee == explicit_member)
+    assigned_record = next(
+        record for record in cycle_times if record.assignee == explicit_member
+    )
     assert assigned_record.team_id == teams[0].id
     assert assigned_record.team_name == teams[0].name
 
@@ -81,7 +93,9 @@ def test_assignee_resolution_wins_over_fallback_distribution() -> None:
 
 
 def test_repo_team_assignments_default_shape_supports_top_n_other_bucket() -> None:
-    teams = SyntheticDataGenerator(repo_name="acme/demo-app", seed=5).generate_teams(count=10)
+    teams = SyntheticDataGenerator(repo_name="acme/demo-app", seed=5).generate_teams(
+        count=10
+    )
 
     assignments = _build_repo_team_assignments(teams, repo_count=6, seed=5)
 


### PR DESCRIPTION
Linear: https://linear.app/fullchaos/issue/CHAOS-1291/fixtures-densify-cross-team-co-occurrence-for-chord-chart-team-dim

## Summary
- replace the fallback team assignment in `generate_work_item_cycle_times` with deterministic per-day weighted splits so shared `(repo, day)` cells produce multi-team asymmetric TEAM↔TEAM edges
- raise the fixture CLI default team count to 10 so the chord demo hits the top-N overflow path and renders an `Other` bucket
- add fixture tests covering asymmetric multi-team cells, assignee precedence, and default repo-team coverage

## Test plan
- `cd ops && uv run pytest tests/fixtures/ -v`
- `docker compose exec -T api sh -lc 'dev-hops migrate clickhouse && dev-hops --org f6e5d6e2-9e47-41cb-a13f-bc5bf63dfa83 fixtures generate --days 30 --sink "$CLICKHOUSE_URI" --with-metrics'`
- queried `analytics.flowMatrix(dimension: TEAM)` for `2026-03-23..2026-04-22` and verified `node_count=11`, `edge_count=52`, `nonself_edge_count=52`, example asymmetry `TEAM:team-j -> TEAM:unassigned = 9` vs reverse `8`
- visual smoke on `http://localhost:3000/demo` for Bilateral / Outflow / Inflow / Net plus populated summary panel

## Screenshots
- `/tmp/chaos-1291-bilateral.png`
- `/tmp/chaos-1291-outflow.png`
- `/tmp/chaos-1291-inflow.png`
- `/tmp/chaos-1291-net.png`
- `/tmp/chaos-1291-summary.png`