### PR TITLE
feat(analytics): add flow_matrix REPO + WORK_TYPE templates with bridge density (CHAOS-1292)

### DIFF
--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -374,6 +374,13 @@ def compile_flow_matrix(
         "timeout": timeout,
     }
 
+    # The TEAM / REPO / WORK_TYPE branches intentionally do not thread
+    # `filter_clause`; those templates source from work_item_cycle_times +
+    # work_items where the filter column set (investment_area etc.) doesn't
+    # apply. Only the sankey fallback — which queries investment_metrics_daily —
+    # uses filters. Callers that need filtered flow matrices for same-dim TEAM /
+    # REPO / WORK_TYPE should open a follow-up to wire filter columns into the
+    # two underlying tables first.
     if dimension == Dimension.TEAM:
         nodes_sql = flow_matrix_team_nodes_template()
         edge_sql = flow_matrix_team_edges_template()

--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -14,8 +14,12 @@ from .filter_translation import translate_filters
 from .templates import (
     breakdown_template,
     catalog_values_template,
+    flow_matrix_repo_edges_template,
+    flow_matrix_repo_nodes_template,
     flow_matrix_team_edges_template,
     flow_matrix_team_nodes_template,
+    flow_matrix_work_type_edges_template,
+    flow_matrix_work_type_nodes_template,
     sankey_edges_template,
     sankey_nodes_template,
     timeseries_template,
@@ -337,16 +341,19 @@ def compile_flow_matrix(
     Produces the same (nodes_queries, edges_queries) tuple shape as
     compile_sankey so _execute_sankey_inner can execute either.
 
-    For TEAM, edges come from work_item_cycle_times: each work item's first
-    team (argMin by day) is the source and its last team (argMax by day) is
-    the target. Only cross-team handoffs are emitted, giving an asymmetric
-    signal that unlocks the chord's directional modes. Nodes also come from
-    work_item_cycle_times so node ids and edge endpoints stay consistent.
+    For TEAM, edges come from a self-join on work_item_cycle_times bridged
+    through (work_scope_id, day): every pair of teams that completed work in
+    the same scope on the same day becomes an edge, valued by the SOURCE
+    team's distinct work_item count. That yields an asymmetric signal that
+    unlocks the chord's directional modes.
 
-    For REPO and WORK_TYPE the schema doesn't carry a natural directional
-    team-level-equivalent signal per work item, so the existing same-column
-    self-aggregation is used. These dimensions will mostly emit self-loops
-    (which the frontend drops) — tracked as follow-up.
+    For REPO (CHAOS-1292), edges come from the same table joined to
+    work_items (for repo_id) and bridged through (team_id, day) — i.e., when
+    the same team touches multiple repos on one day those repos become
+    cross-edges. For WORK_TYPE, the bridge is (repo_id, day) — multiple
+    work_types on the same repo+day become cross-edges. In all three cases
+    nodes are sourced from the same underlying data so node ids and edge
+    endpoints stay consistent.
     """
     dimension = validate_dimension(request.dimension)
     measure = validate_measure(request.measure)
@@ -369,10 +376,23 @@ def compile_flow_matrix(
 
     if dimension == Dimension.TEAM:
         nodes_sql = flow_matrix_team_nodes_template()
+        edge_sql = flow_matrix_team_edges_template()
         nodes_params = {**common_params, "limit_per_dim": request.max_nodes}
         nodes_params = enforce_org_scope(org_id, nodes_params)
-
-        edge_sql = flow_matrix_team_edges_template()
+        edge_params = {**common_params, "max_edges": request.max_edges}
+        edge_params = enforce_org_scope(org_id, edge_params)
+    elif dimension == Dimension.REPO:
+        nodes_sql = flow_matrix_repo_nodes_template()
+        edge_sql = flow_matrix_repo_edges_template()
+        nodes_params = {**common_params, "limit_per_dim": request.max_nodes}
+        nodes_params = enforce_org_scope(org_id, nodes_params)
+        edge_params = {**common_params, "max_edges": request.max_edges}
+        edge_params = enforce_org_scope(org_id, edge_params)
+    elif dimension == Dimension.WORK_TYPE:
+        nodes_sql = flow_matrix_work_type_nodes_template()
+        edge_sql = flow_matrix_work_type_edges_template()
+        nodes_params = {**common_params, "limit_per_dim": request.max_nodes}
+        nodes_params = enforce_org_scope(org_id, nodes_params)
         edge_params = {**common_params, "max_edges": request.max_edges}
         edge_params = enforce_org_scope(org_id, edge_params)
     else:

--- a/src/dev_health_ops/api/graphql/sql/templates.py
+++ b/src/dev_health_ops/api/graphql/sql/templates.py
@@ -293,6 +293,7 @@ INNER JOIN enriched AS b
   AND a.day = b.day
   AND a.org_id = b.org_id
 WHERE a.team_id IS NOT NULL AND a.team_id != ''
+  AND b.team_id IS NOT NULL AND b.team_id != ''
   AND a.repo_id IS NOT NULL
   AND b.repo_id IS NOT NULL
   AND a.repo_id != b.repo_id
@@ -306,8 +307,9 @@ SETTINGS max_execution_time = %(timeout)s
 def flow_matrix_work_type_nodes_template() -> str:
     """Nodes query for WORK_TYPE flow matrix.
 
-    Counts distinct work items per work_item_type in the window. Sourced
-    from the same enrichment as the edges template so node ids line up.
+    Counts distinct work items per work_item_type in the window. Uses the
+    same cycle_times × work_items JOIN as the edges template so node ids and
+    edge endpoints stay consistent.
     """
     return """
 SELECT
@@ -319,7 +321,7 @@ INNER JOIN work_items AS wi ON wct.work_item_id = wi.work_item_id
 WHERE wct.day >= %(start_date)s AND wct.day <= %(end_date)s
   AND wct.org_id = %(org_id)s
   AND wi.org_id = %(org_id)s
-  AND wi.type != ''
+  AND wi.type IS NOT NULL AND wi.type != ''
 GROUP BY node_id
 ORDER BY value DESC
 LIMIT %(limit_per_dim)s
@@ -356,8 +358,8 @@ INNER JOIN enriched AS b
   AND a.org_id = b.org_id
 WHERE a.repo_id IS NOT NULL
   AND b.repo_id IS NOT NULL
-  AND a.work_item_type != ''
-  AND b.work_item_type != ''
+  AND a.work_item_type IS NOT NULL AND a.work_item_type != ''
+  AND b.work_item_type IS NOT NULL AND b.work_item_type != ''
   AND a.work_item_type != b.work_item_type
 GROUP BY source, target
 ORDER BY value DESC

--- a/src/dev_health_ops/api/graphql/sql/templates.py
+++ b/src/dev_health_ops/api/graphql/sql/templates.py
@@ -216,6 +216,156 @@ SETTINGS max_execution_time = %(timeout)s
 """
 
 
+_FLOW_MATRIX_ENRICHED_CTE = """WITH enriched AS (
+    SELECT
+        wct.work_item_id,
+        wct.team_id,
+        wct.day,
+        wct.org_id,
+        wi.repo_id,
+        wi.type AS work_item_type
+    FROM work_item_cycle_times AS wct
+    INNER JOIN work_items AS wi ON wct.work_item_id = wi.work_item_id
+    WHERE wct.org_id = %(org_id)s
+      AND wct.day >= %(start_date)s AND wct.day <= %(end_date)s
+      AND wi.org_id = %(org_id)s
+)"""
+
+
+def flow_matrix_repo_nodes_template() -> str:
+    """Nodes query for REPO flow matrix.
+
+    Counts distinct work items per repo in the window. Sourced from
+    work_item_cycle_times (for the day filter) joined to work_items (for
+    repo_id) — the same enrichment used by the REPO edges template so node
+    ids and edge endpoints are guaranteed to line up.
+    """
+    return """
+SELECT
+    'REPO' AS dimension,
+    toString(wi.repo_id) AS node_id,
+    uniqExact(wct.work_item_id) AS value
+FROM work_item_cycle_times AS wct
+INNER JOIN work_items AS wi ON wct.work_item_id = wi.work_item_id
+WHERE wct.day >= %(start_date)s AND wct.day <= %(end_date)s
+  AND wct.org_id = %(org_id)s
+  AND wi.org_id = %(org_id)s
+  AND wi.repo_id IS NOT NULL
+GROUP BY node_id
+ORDER BY value DESC
+LIMIT %(limit_per_dim)s
+SETTINGS max_execution_time = %(timeout)s
+"""
+
+
+def flow_matrix_repo_edges_template() -> str:
+    """Asymmetric cross-repo edges bridged through (team_id, day).
+
+    work_item_cycle_times carries team_id + day per work item but NOT repo_id;
+    work_items carries repo_id. An INNER JOIN on work_item_id produces an
+    enriched per-item row. Self-joining that enriched set on (team_id, day,
+    org_id) gives every pair of repos that the same team touched on the same
+    day — the REPO analog of TEAM's (work_scope_id, day) bridge.
+
+    The edge value is `uniqExact(a.work_item_id)` — the count of SOURCE
+    repo's distinct work items in the shared team+day cell, not the cartesian
+    product. So edge (r1 -> r2) counts r1's items and (r2 -> r1) counts r2's,
+    and the matrix is asymmetric whenever the two repos contribute different
+    volumes to the shared team+day buckets. That unlocks the chord's
+    directional modes (outflow / inflow / net) for the REPO dimension.
+
+    Semantic: "repo A's work in team+day buckets also touched by repo B" —
+    i.e., cross-repo cooperation through shared team effort. It is NOT a
+    handoff (schema doesn't encode those natively), but a real directional
+    signal that populates on any org with teams spanning multiple repos.
+    """
+    return f"""
+{_FLOW_MATRIX_ENRICHED_CTE}
+SELECT
+    'REPO' AS source_dimension,
+    'REPO' AS target_dimension,
+    toString(a.repo_id) AS source,
+    toString(b.repo_id) AS target,
+    uniqExact(a.work_item_id) AS value
+FROM enriched AS a
+INNER JOIN enriched AS b
+  ON a.team_id = b.team_id
+  AND a.day = b.day
+  AND a.org_id = b.org_id
+WHERE a.team_id IS NOT NULL AND a.team_id != ''
+  AND a.repo_id IS NOT NULL
+  AND b.repo_id IS NOT NULL
+  AND a.repo_id != b.repo_id
+GROUP BY source, target
+ORDER BY value DESC
+LIMIT %(max_edges)s
+SETTINGS max_execution_time = %(timeout)s
+"""
+
+
+def flow_matrix_work_type_nodes_template() -> str:
+    """Nodes query for WORK_TYPE flow matrix.
+
+    Counts distinct work items per work_item_type in the window. Sourced
+    from the same enrichment as the edges template so node ids line up.
+    """
+    return """
+SELECT
+    'WORK_TYPE' AS dimension,
+    wi.type AS node_id,
+    uniqExact(wct.work_item_id) AS value
+FROM work_item_cycle_times AS wct
+INNER JOIN work_items AS wi ON wct.work_item_id = wi.work_item_id
+WHERE wct.day >= %(start_date)s AND wct.day <= %(end_date)s
+  AND wct.org_id = %(org_id)s
+  AND wi.org_id = %(org_id)s
+  AND wi.type != ''
+GROUP BY node_id
+ORDER BY value DESC
+LIMIT %(limit_per_dim)s
+SETTINGS max_execution_time = %(timeout)s
+"""
+
+
+def flow_matrix_work_type_edges_template() -> str:
+    """Asymmetric cross-work_type edges bridged through (repo_id, day).
+
+    Uses the same enrichment CTE as the REPO edges template. Self-joins on
+    (repo_id, day, org_id) so every pair of work_types completed in the same
+    repo on the same day becomes an edge. Excludes self-loops.
+
+    Edge value = SOURCE work_type's distinct work items in the bridged cell,
+    producing an asymmetric matrix whenever two work_types have different
+    volumes in shared repo+day buckets.
+
+    Semantic: "work_type A's items in repo+day buckets that also contained
+    work_type B" — cross-type cooperation within a repo on a single day.
+    """
+    return f"""
+{_FLOW_MATRIX_ENRICHED_CTE}
+SELECT
+    'WORK_TYPE' AS source_dimension,
+    'WORK_TYPE' AS target_dimension,
+    a.work_item_type AS source,
+    b.work_item_type AS target,
+    uniqExact(a.work_item_id) AS value
+FROM enriched AS a
+INNER JOIN enriched AS b
+  ON a.repo_id = b.repo_id
+  AND a.day = b.day
+  AND a.org_id = b.org_id
+WHERE a.repo_id IS NOT NULL
+  AND b.repo_id IS NOT NULL
+  AND a.work_item_type != ''
+  AND b.work_item_type != ''
+  AND a.work_item_type != b.work_item_type
+GROUP BY source, target
+ORDER BY value DESC
+LIMIT %(max_edges)s
+SETTINGS max_execution_time = %(timeout)s
+"""
+
+
 def catalog_values_template(
     dimension: Dimension,
     source_table: str = "investment_metrics_daily",

--- a/src/dev_health_ops/fixtures/generator.py
+++ b/src/dev_health_ops/fixtures/generator.py
@@ -1990,7 +1990,60 @@ class SyntheticDataGenerator:
 
         # Sort by created_at for realism
         items.sort(key=lambda x: x.created_at)
+        items = self._ensure_work_type_cooccurrence(items)
         return items
+
+    def _ensure_work_type_cooccurrence(
+        self,
+        items: list[WorkItem],
+    ) -> list[WorkItem]:
+        """Guarantee >=2 distinct work_item types per (repo_id, day) bucket
+        with >=2 items. Without this pass, random per-item type selection
+        can produce monotype buckets on low-item days, leaving the
+        flow_matrix WORK_TYPE template (which bridges on repo_id + day)
+        with zero cross-type edges for that day. CHAOS-1292.
+
+        WorkItem is frozen, so we rewrite the offending item's type via
+        dataclasses.replace. Deterministic: the LAST item in each monotype
+        bucket is flipped to the next type in preference order, so the same
+        input always produces the same output.
+        """
+        if len(items) < 2:
+            return items
+
+        from collections import defaultdict
+        from dataclasses import replace
+
+        type_preference: list[WorkItemType] = ["story", "task", "bug"]
+
+        bucket_indices: dict[date, list[int]] = defaultdict(list)
+        for idx, item in enumerate(items):
+            bucket_day = (
+                item.completed_at or item.started_at or item.created_at
+            ).date()
+            bucket_indices[bucket_day].append(idx)
+
+        rewrites: dict[int, WorkItemType] = {}
+        for indices in bucket_indices.values():
+            if len(indices) < 2:
+                continue
+            bucket_types = {items[i].type for i in indices}
+            if len(bucket_types) >= 2:
+                continue
+            current_type = items[indices[0]].type
+            alt_type = next(
+                (t for t in type_preference if t != current_type),
+                type_preference[0],
+            )
+            rewrites[indices[-1]] = alt_type
+
+        if not rewrites:
+            return items
+
+        return [
+            replace(item, type=rewrites[idx]) if idx in rewrites else item
+            for idx, item in enumerate(items)
+        ]
 
     def generate_teams_config(self) -> dict[str, Any]:
         """

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -87,7 +87,41 @@ def _build_repo_team_assignments(all_teams, repo_count: int, seed: int | None):
             repo_to_teams[idx].append(team)
             team_to_repos[team.id].append(idx)
 
+    _verify_repo_cooccurrence_density(team_to_repos, owned_repo_count=len(owned_repos))
     return [repo_to_teams[idx] for idx in range(repo_count)]
+
+
+def _verify_repo_cooccurrence_density(
+    team_to_repos: dict[str, list[int]],
+    *,
+    owned_repo_count: int,
+    min_multi_repo_teams: int = 2,
+) -> None:
+    """Guarantee REPO bridge density for the flow_matrix chord view (CHAOS-1292).
+
+    The flow_matrix REPO template bridges on (team_id, day) and emits an
+    edge only when the same team touches different repos on the same day.
+    Without multi-repo teams in the assignment plan, the chord's Repository
+    dimension renders empty regardless of data volume. Assert the invariant
+    here so regressions in _build_repo_team_assignments surface at fixture
+    generation time, not at the chord UI.
+
+    When there's only one owned repo in the plan the invariant is vacuously
+    satisfied — bridge edges are impossible by construction and not
+    expected by the flow_matrix template.
+    """
+    if owned_repo_count < 2:
+        return
+    multi_repo_teams = sum(
+        1 for repo_indices in team_to_repos.values() if len(set(repo_indices)) >= 2
+    )
+    if multi_repo_teams < min_multi_repo_teams:
+        raise AssertionError(
+            "REPO bridge density insufficient for chord flow_matrix: "
+            f"only {multi_repo_teams} team(s) span multiple repos "
+            f"(need >= {min_multi_repo_teams}). The chord Repository "
+            "dimension would render empty. Check _build_repo_team_assignments."
+        )
 
 
 async def _seed_auth_data(session, user_data: dict) -> None:

--- a/tests/fixtures/test_bridge_density.py
+++ b/tests/fixtures/test_bridge_density.py
@@ -19,7 +19,6 @@ production or in a reviewer's screenshot comparison.
 from __future__ import annotations
 
 from collections import Counter, defaultdict
-from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -28,11 +27,6 @@ from dev_health_ops.fixtures.runner import (
     _build_repo_team_assignments,
     _verify_repo_cooccurrence_density,
 )
-
-
-class _Stub:
-    def __init__(self, team_id: str) -> None:
-        self.id = team_id
 
 
 class TestWorkTypeCooccurrence:
@@ -52,9 +46,7 @@ class TestWorkTypeCooccurrence:
 
         by_day: dict[object, set[str]] = defaultdict(set)
         for item in items:
-            day = (
-                item.completed_at or item.started_at or item.created_at
-            ).date()
+            day = (item.completed_at or item.started_at or item.created_at).date()
             by_day[day].add(item.type)
 
         bad_buckets = [
@@ -159,9 +151,7 @@ class TestFlowMatrixCrossEntityEdgeCount:
         appearing in the same bridge bucket."""
         buckets: dict[tuple, set[str]] = defaultdict(set)
         for item in items:
-            day = (
-                item.completed_at or item.started_at or item.created_at
-            ).date()
+            day = (item.completed_at or item.started_at or item.created_at).date()
             bridge_val = getattr(item, bridge_key)
             dim_val = getattr(item, dim_key)
             if not bridge_val or not dim_val:
@@ -185,9 +175,7 @@ class TestFlowMatrixCrossEntityEdgeCount:
         # All items share a single repo_id in this generator, so the (repo,
         # day) bridge reduces to (day) here — still a valid proxy for
         # the WORK_TYPE cross-type guarantee inside one repo.
-        pairs = self._cross_entity_pairs(
-            items, bridge_key="repo_id", dim_key="type"
-        )
+        pairs = self._cross_entity_pairs(items, bridge_key="repo_id", dim_key="type")
         assert pairs >= 5, (
             f"Only {pairs} cross-type pairs in 30d fixture — WORK_TYPE "
             "chord would fall below the >= 5 success criterion."

--- a/tests/fixtures/test_bridge_density.py
+++ b/tests/fixtures/test_bridge_density.py
@@ -1,0 +1,194 @@
+"""Bridge-density tests for chord flow_matrix (CHAOS-1292).
+
+Guards the fixture-side invariants the flow_matrix REPO and WORK_TYPE
+templates depend on:
+
+- Every (repo_id, day) bucket with >= 2 work items produces >= 2 distinct
+  work_item_type values (so the WORK_TYPE bridge-join can emit cross-type
+  edges).
+- At least two teams touch multiple repos in the runner's per-org team
+  assignment plan (so the REPO bridge-join on team_id + day can emit
+  cross-repo edges).
+
+Regression test charter: if CHAOS-1291's team co-occurrence logic or the
+runner's _build_repo_team_assignments weights are refactored, this test
+file fails LOUDLY so the chord's empty-state isn't discovered only in
+production or in a reviewer's screenshot comparison.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dev_health_ops.fixtures.generator import SyntheticDataGenerator
+from dev_health_ops.fixtures.runner import (
+    _build_repo_team_assignments,
+    _verify_repo_cooccurrence_density,
+)
+
+
+class _Stub:
+    def __init__(self, team_id: str) -> None:
+        self.id = team_id
+
+
+class TestWorkTypeCooccurrence:
+    """generator._ensure_work_type_cooccurrence guarantees per-day diversity."""
+
+    def _make_generator(self) -> SyntheticDataGenerator:
+        return SyntheticDataGenerator(
+            repo_name="acme/demo-app",
+            provider="github",
+            seed=17,
+        )
+
+    def test_single_day_with_multiple_items_yields_multiple_types(self) -> None:
+        """A (repo, day) bucket with >=2 items must span >=2 work_types."""
+        gen = self._make_generator()
+        items = gen.generate_work_items(days=1)
+
+        by_day: dict[object, set[str]] = defaultdict(set)
+        for item in items:
+            day = (
+                item.completed_at or item.started_at or item.created_at
+            ).date()
+            by_day[day].add(item.type)
+
+        bad_buckets = [
+            (day, types)
+            for day, types in by_day.items()
+            if sum(
+                1
+                for i in items
+                if (i.completed_at or i.started_at or i.created_at).date() == day
+            )
+            >= 2
+            and len(types) < 2
+        ]
+        assert bad_buckets == [], (
+            f"Monotype buckets found: {bad_buckets}. "
+            "_ensure_work_type_cooccurrence must flip one item per bucket."
+        )
+
+    def test_rewriting_is_deterministic(self) -> None:
+        """Same seed -> same rewrites. Non-flaky regression surface."""
+        first = [i.type for i in self._make_generator().generate_work_items(days=7)]
+        second = [i.type for i in self._make_generator().generate_work_items(days=7)]
+        assert first == second
+
+    def test_does_not_touch_already_diverse_buckets(self) -> None:
+        """When a bucket already has diverse types, the pass is a no-op for it.
+
+        Indirect check: type distribution over a 30-day run stays close to
+        the configured investment-weighted expectation (some bugs, mostly
+        story/task), not skewed to the flip preference alone.
+        """
+        gen = self._make_generator()
+        items = gen.generate_work_items(days=30)
+        counts = Counter(i.type for i in items)
+        # Bug ratio should stay plausible (<= 40%) — the co-occurrence pass
+        # only flips monotype buckets, not diverse ones, so the bulk stays
+        # driven by random.random() > 0.85 bias.
+        total = sum(counts.values())
+        assert counts.get("bug", 0) / max(total, 1) <= 0.4
+
+
+class TestRepoCooccurrenceVerification:
+    """Runner-side invariant: >=2 teams span multiple repos."""
+
+    def test_default_assignments_meet_minimum(self) -> None:
+        """Happy path: the standard 10-team x 4-repo assignment produces
+        enough multi-repo teams to generate cross-repo flow_matrix edges."""
+        teams = SyntheticDataGenerator(
+            repo_name="acme/demo-app", seed=5
+        ).generate_teams(count=10)
+        assignments = _build_repo_team_assignments(teams, repo_count=4, seed=5)
+        team_to_repos: dict[str, set[int]] = defaultdict(set)
+        for repo_idx, repo_teams in enumerate(assignments):
+            for team in repo_teams:
+                team_to_repos[team.id].add(repo_idx)
+        multi_repo = sum(1 for r in team_to_repos.values() if len(r) >= 2)
+        assert multi_repo >= 2, (
+            f"Only {multi_repo} team(s) span multiple repos; CHAOS-1292 "
+            f"chord REPO view needs >= 2."
+        )
+
+    def test_single_repo_plan_is_vacuously_ok(self) -> None:
+        """With 1 owned repo, bridge edges are impossible by construction —
+        the verifier must NOT raise just because density is 0."""
+        team_to_repos = {"team-a": [0], "team-b": [0]}
+        _verify_repo_cooccurrence_density(team_to_repos, owned_repo_count=1)
+
+    def test_raises_on_sparse_multi_repo_assignments(self) -> None:
+        """If only one team spans multiple repos the verifier raises — the
+        chord Repository view would render effectively empty."""
+        team_to_repos = {
+            "team-a": [0, 1],
+            "team-b": [0],
+            "team-c": [1],
+        }
+        with pytest.raises(AssertionError, match="REPO bridge density insufficient"):
+            _verify_repo_cooccurrence_density(team_to_repos, owned_repo_count=3)
+
+    def test_dedupes_duplicate_repo_entries(self) -> None:
+        """Multi-team assignments can record the same (team, repo) pair twice;
+        uniqueness is what matters for bridge density."""
+        team_to_repos = {
+            "team-a": [0, 0, 1],
+            "team-b": [0, 0],
+            "team-c": [1, 2],
+        }
+        _verify_repo_cooccurrence_density(team_to_repos, owned_repo_count=3)
+
+
+class TestFlowMatrixCrossEntityEdgeCount:
+    """End-to-end fixture check: the number of NON-self-loop entries we'd
+    compute from a full fixture run meets CHAOS-1292's >= 5 success criterion
+    for both dimensions. Pure Python — no DB required."""
+
+    def _cross_entity_pairs(
+        self,
+        items: list[object],
+        bridge_key: str,
+        dim_key: str,
+    ) -> int:
+        """Count distinct ordered (dim_a, dim_b) pairs with dim_a != dim_b
+        appearing in the same bridge bucket."""
+        buckets: dict[tuple, set[str]] = defaultdict(set)
+        for item in items:
+            day = (
+                item.completed_at or item.started_at or item.created_at
+            ).date()
+            bridge_val = getattr(item, bridge_key)
+            dim_val = getattr(item, dim_key)
+            if not bridge_val or not dim_val:
+                continue
+            buckets[(bridge_val, day)].add(str(dim_val))
+        pairs = set()
+        for values in buckets.values():
+            for a in values:
+                for b in values:
+                    if a != b:
+                        pairs.add((a, b))
+        return len(pairs)
+
+    def test_work_type_cross_edges_meet_min_five(self) -> None:
+        """Generated work_items produce >= 5 ordered cross-type pairs when
+        bridged through (repo_id, day)."""
+        gen = SyntheticDataGenerator(
+            repo_name="acme/demo-app", provider="github", seed=13
+        )
+        items = gen.generate_work_items(days=30)
+        # All items share a single repo_id in this generator, so the (repo,
+        # day) bridge reduces to (day) here — still a valid proxy for
+        # the WORK_TYPE cross-type guarantee inside one repo.
+        pairs = self._cross_entity_pairs(
+            items, bridge_key="repo_id", dim_key="type"
+        )
+        assert pairs >= 5, (
+            f"Only {pairs} cross-type pairs in 30d fixture — WORK_TYPE "
+            "chord would fall below the >= 5 success criterion."
+        )

--- a/tests/graphql/test_flow_matrix.py
+++ b/tests/graphql/test_flow_matrix.py
@@ -1,4 +1,4 @@
-"""Tests for the analytics.flowMatrix resolver (CHAOS-1289).
+"""Tests for the analytics.flowMatrix resolver (CHAOS-1289 / CHAOS-1292).
 
 Validates the same-dimension flow matrix path end-to-end:
 - compile_flow_matrix produces the expected (nodes, edges) SQL shape
@@ -7,6 +7,7 @@ Validates the same-dimension flow matrix path end-to-end:
 - _execute_sankey_inner correctly handles same-dim rows, prefixing ids with
   the shared dimension (e.g., "team:EngineeringA")
 - validate_sub_request_count counts flow_matrix toward the budget
+- REPO + WORK_TYPE dims use asymmetric bridge-joined templates (CHAOS-1292)
 """
 
 from __future__ import annotations
@@ -24,6 +25,12 @@ from dev_health_ops.api.graphql.errors import ValidationError
 from dev_health_ops.api.graphql.sql.compiler import (
     FlowMatrixRequest,
     compile_flow_matrix,
+)
+from dev_health_ops.api.graphql.sql.templates import (
+    flow_matrix_repo_edges_template,
+    flow_matrix_repo_nodes_template,
+    flow_matrix_work_type_edges_template,
+    flow_matrix_work_type_nodes_template,
 )
 
 
@@ -98,6 +105,127 @@ class TestCompileFlowMatrix:
         _, edges_queries = compile_flow_matrix(req, org_id="org-1")
         _, edges_params = edges_queries[0]
         assert edges_params["max_edges"] == 137
+
+    def test_repo_dimension_routes_to_flow_matrix_template(self) -> None:
+        """REPO must not fall through to the sankey same-column self-aggregation
+        path anymore — it routes to the dedicated bridge-joined template."""
+        nodes_queries, edges_queries = compile_flow_matrix(_req("repo"), org_id="org-1")
+        nodes_sql, _ = nodes_queries[0]
+        edges_sql, _ = edges_queries[0]
+        assert "'REPO' AS source_dimension" in edges_sql
+        assert "INNER JOIN work_items" in edges_sql
+        assert "'REPO' AS dimension" in nodes_sql
+
+    def test_work_type_dimension_routes_to_flow_matrix_template(self) -> None:
+        """Same for WORK_TYPE — bridge-joined template, not sankey fallback."""
+        nodes_queries, edges_queries = compile_flow_matrix(
+            _req("work_type"), org_id="org-1"
+        )
+        nodes_sql, _ = nodes_queries[0]
+        edges_sql, _ = edges_queries[0]
+        assert "'WORK_TYPE' AS source_dimension" in edges_sql
+        assert "INNER JOIN work_items" in edges_sql
+        assert "'WORK_TYPE' AS dimension" in nodes_sql
+
+
+class TestRepoEdgesTemplate:
+    """CHAOS-1292: REPO edges use the same asymmetric-cooccurrence shape as
+    TEAM, bridged via (team_id, day) instead of (work_scope_id, day)."""
+
+    def test_self_joins_on_team_day_bridge(self) -> None:
+        sql = flow_matrix_repo_edges_template()
+        assert "a.team_id = b.team_id" in sql
+        assert "a.day = b.day" in sql
+        assert "a.org_id = b.org_id" in sql
+
+    def test_excludes_self_loops(self) -> None:
+        """a.repo_id != b.repo_id drops self-loops at the SQL layer so the
+        frontend doesn't have to filter empty ribbons."""
+        sql = flow_matrix_repo_edges_template()
+        assert "a.repo_id != b.repo_id" in sql
+
+    def test_counts_source_side_items_for_asymmetry(self) -> None:
+        """Edge value = SOURCE repo's distinct work items in the bridged cell.
+        Edge (r1 -> r2).value counts r1's items; (r2 -> r1).value counts r2's.
+        That's what makes the matrix asymmetric — same invariant as TEAM."""
+        sql = flow_matrix_repo_edges_template()
+        assert "uniqExact(a.work_item_id) AS value" in sql
+
+    def test_enriches_cycle_times_with_work_items_repo_id(self) -> None:
+        """work_item_cycle_times lacks repo_id — enrich via INNER JOIN to
+        work_items on work_item_id."""
+        sql = flow_matrix_repo_edges_template()
+        assert "work_item_cycle_times" in sql
+        assert "INNER JOIN work_items" in sql
+        assert "wct.work_item_id = wi.work_item_id" in sql
+
+    def test_emits_repo_dimension_tag(self) -> None:
+        sql = flow_matrix_repo_edges_template()
+        assert "'REPO' AS source_dimension" in sql
+        assert "'REPO' AS target_dimension" in sql
+
+
+class TestWorkTypeEdgesTemplate:
+    """CHAOS-1292: WORK_TYPE edges bridged via (repo_id, day)."""
+
+    def test_self_joins_on_repo_day_bridge(self) -> None:
+        sql = flow_matrix_work_type_edges_template()
+        assert "a.repo_id = b.repo_id" in sql
+        assert "a.day = b.day" in sql
+        assert "a.org_id = b.org_id" in sql
+
+    def test_excludes_self_loops(self) -> None:
+        sql = flow_matrix_work_type_edges_template()
+        assert "a.work_item_type != b.work_item_type" in sql
+
+    def test_counts_source_side_items_for_asymmetry(self) -> None:
+        sql = flow_matrix_work_type_edges_template()
+        assert "uniqExact(a.work_item_id) AS value" in sql
+
+    def test_enriches_cycle_times_with_work_items_type(self) -> None:
+        sql = flow_matrix_work_type_edges_template()
+        assert "work_item_cycle_times" in sql
+        assert "INNER JOIN work_items" in sql
+        assert "wi.type AS work_item_type" in sql
+
+    def test_emits_work_type_dimension_tag(self) -> None:
+        sql = flow_matrix_work_type_edges_template()
+        assert "'WORK_TYPE' AS source_dimension" in sql
+        assert "'WORK_TYPE' AS target_dimension" in sql
+
+
+class TestRepoNodesTemplate:
+    """Node template must produce node_ids that line up with edge endpoints."""
+
+    def test_queries_enriched_cycle_times_source(self) -> None:
+        sql = flow_matrix_repo_nodes_template()
+        assert "work_item_cycle_times" in sql
+        assert "INNER JOIN work_items" in sql
+
+    def test_emits_repo_dimension_tag_and_repo_node_id(self) -> None:
+        sql = flow_matrix_repo_nodes_template()
+        assert "'REPO' AS dimension" in sql
+        assert "toString(wi.repo_id) AS node_id" in sql
+
+    def test_counts_distinct_work_items(self) -> None:
+        sql = flow_matrix_repo_nodes_template()
+        assert "uniqExact(wct.work_item_id) AS value" in sql
+
+
+class TestWorkTypeNodesTemplate:
+    def test_queries_enriched_cycle_times_source(self) -> None:
+        sql = flow_matrix_work_type_nodes_template()
+        assert "work_item_cycle_times" in sql
+        assert "INNER JOIN work_items" in sql
+
+    def test_emits_work_type_dimension_tag_and_type_node_id(self) -> None:
+        sql = flow_matrix_work_type_nodes_template()
+        assert "'WORK_TYPE' AS dimension" in sql
+        assert "wi.type AS node_id" in sql
+
+    def test_counts_distinct_work_items(self) -> None:
+        sql = flow_matrix_work_type_nodes_template()
+        assert "uniqExact(wct.work_item_id) AS value" in sql
 
 
 class TestValidateSubRequestCount:

--- a/tests/graphql/test_flow_matrix.py
+++ b/tests/graphql/test_flow_matrix.py
@@ -164,6 +164,14 @@ class TestRepoEdgesTemplate:
         assert "'REPO' AS source_dimension" in sql
         assert "'REPO' AS target_dimension" in sql
 
+    def test_guards_both_sides_of_bridge_against_null_and_empty_team(self) -> None:
+        """Without b-side guards, empty-string team_ids would match each other
+        via the JOIN on a.team_id = b.team_id and emit spurious edges. Both
+        sides of the join must filter NULL + empty."""
+        sql = flow_matrix_repo_edges_template()
+        assert "a.team_id IS NOT NULL AND a.team_id != ''" in sql
+        assert "b.team_id IS NOT NULL AND b.team_id != ''" in sql
+
 
 class TestWorkTypeEdgesTemplate:
     """CHAOS-1292: WORK_TYPE edges bridged via (repo_id, day)."""
@@ -192,6 +200,16 @@ class TestWorkTypeEdgesTemplate:
         sql = flow_matrix_work_type_edges_template()
         assert "'WORK_TYPE' AS source_dimension" in sql
         assert "'WORK_TYPE' AS target_dimension" in sql
+
+    def test_guards_work_item_type_against_null_and_empty(self) -> None:
+        """Defensive: guard both IS NOT NULL and != '' on both sides so
+        NULL-typed items can't produce NULL nodes and empty strings can't
+        match each other across the JOIN."""
+        sql = flow_matrix_work_type_edges_template()
+        assert "a.work_item_type IS NOT NULL" in sql
+        assert "a.work_item_type != ''" in sql
+        assert "b.work_item_type IS NOT NULL" in sql
+        assert "b.work_item_type != ''" in sql
 
 
 class TestRepoNodesTemplate:
@@ -226,6 +244,11 @@ class TestWorkTypeNodesTemplate:
     def test_counts_distinct_work_items(self) -> None:
         sql = flow_matrix_work_type_nodes_template()
         assert "uniqExact(wct.work_item_id) AS value" in sql
+
+    def test_guards_type_against_null_and_empty(self) -> None:
+        sql = flow_matrix_work_type_nodes_template()
+        assert "wi.type IS NOT NULL" in sql
+        assert "wi.type != ''" in sql
 
 
 class TestValidateSubRequestCount:

--- a/tests/graphql/test_flow_matrix_live.py
+++ b/tests/graphql/test_flow_matrix_live.py
@@ -1,9 +1,10 @@
-"""Live-ClickHouse integration tests for analytics.flowMatrix (CHAOS-1289).
+"""Live-ClickHouse integration tests for analytics.flowMatrix (CHAOS-1289 / CHAOS-1292).
 
 Exercises the real compile → execute pipeline against a running ClickHouse
 with seeded demo data. Complements test_flow_matrix.py (which mocks
 query_dicts) by proving that the SQL actually returns non-empty, asymmetric
-cross-team edges end-to-end.
+cross-entity edges end-to-end for all three same-dim groupings:
+TEAM (CHAOS-1289), REPO (CHAOS-1292), WORK_TYPE (CHAOS-1292).
 
 Run locally with:
   CLICKHOUSE_URI=clickhouse://ch:ch@localhost:8123/default \\
@@ -39,15 +40,15 @@ pytestmark = [
 ]
 
 
-async def _run_team_flow_matrix(days: int = 90):
-    """Compile and execute a TEAM flow matrix against live ClickHouse."""
+async def _run_flow_matrix(dimension: str, days: int = 90):
+    """Compile and execute a flow matrix for any same-dim grouping."""
     from dev_health_ops.api.queries.client import get_global_client
 
     end = date.today()
     start = end - timedelta(days=days)
 
     req = FlowMatrixRequest(
-        dimension="team",
+        dimension=dimension,
         measure="count",
         start_date=start,
         end_date=end,
@@ -58,6 +59,10 @@ async def _run_team_flow_matrix(days: int = 90):
     nodes_queries, edges_queries = compile_flow_matrix(req, org_id=TEST_ORG_ID)
     client = await get_global_client(CLICKHOUSE_URI)
     return await _execute_sankey_inner(client, nodes_queries, edges_queries)
+
+
+async def _run_team_flow_matrix(days: int = 90):
+    return await _run_flow_matrix("team", days=days)
 
 
 async def test_team_flow_matrix_returns_nodes() -> None:
@@ -121,3 +126,67 @@ async def test_team_flow_matrix_edge_endpoints_subset_of_nodes() -> None:
     orphan_targets = {e.target for e in edges if e.target not in node_ids}
     assert not orphan_sources, f"edge sources missing from nodes: {orphan_sources}"
     assert not orphan_targets, f"edge targets missing from nodes: {orphan_targets}"
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-1292: REPO + WORK_TYPE live flow matrix coverage.
+# Mirror the TEAM contract above — nodes populate, cross-entity edges exist,
+# asymmetric, endpoints subset of nodes, all self-loops filtered.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "dimension,prefix,ticket_min_edges",
+    [
+        ("repo", "REPO", 5),
+        ("work_type", "WORK_TYPE", 5),
+    ],
+)
+async def test_flow_matrix_cross_entity_coverage(
+    dimension: str, prefix: str, ticket_min_edges: int
+) -> None:
+    """Covers CHAOS-1292 success criteria in one test body: for each of
+    REPO and WORK_TYPE, verify nodes populate, >= ticket_min_edges non-self-loop
+    cross-entity edges exist, at least one bidirectional pair is asymmetric,
+    and all edge endpoints are present in the nodes set.
+
+    Runs against live ClickHouse using CLICKHOUSE_URI + TEST_ORG_ID.
+    """
+    nodes, edges = await _run_flow_matrix(dimension)
+
+    assert len(nodes) > 0, f"no {prefix} nodes returned; chord will be empty"
+    assert all(n.dimension == prefix for n in nodes)
+    assert all(n.id.startswith(f"{prefix}:") for n in nodes)
+    assert all(n.value > 0 for n in nodes)
+
+    assert len(edges) >= ticket_min_edges, (
+        f"{prefix} flow matrix returned {len(edges)} edges; ticket requires "
+        f">= {ticket_min_edges} non-self-loop cross-entity edges. The bridge "
+        "templates or fixture density may be broken."
+    )
+    assert all(e.source != e.target for e in edges), (
+        f"self-loops leaked into {prefix} edges; server-side filter failed"
+    )
+    assert all(e.source.startswith(f"{prefix}:") for e in edges)
+    assert all(e.target.startswith(f"{prefix}:") for e in edges)
+
+    pair_values = {(e.source, e.target): e.value for e in edges}
+    asymmetric = 0
+    for (src, tgt), forward in pair_values.items():
+        reverse = pair_values.get((tgt, src))
+        if reverse is not None and forward != reverse:
+            asymmetric += 1
+    assert asymmetric > 0, (
+        f"all {prefix} bidirectional pairs are symmetric — chord's "
+        "inflow/outflow/net modes will collapse."
+    )
+
+    node_ids = {n.id for n in nodes}
+    orphan_sources = {e.source for e in edges if e.source not in node_ids}
+    orphan_targets = {e.target for e in edges if e.target not in node_ids}
+    assert not orphan_sources, (
+        f"{prefix} edge sources missing from nodes: {orphan_sources}"
+    )
+    assert not orphan_targets, (
+        f"{prefix} edge targets missing from nodes: {orphan_targets}"
+    )


### PR DESCRIPTION
## Summary
- Adds `flow_matrix_repo_{edges,nodes}_template` and `flow_matrix_work_type_{edges,nodes}_template` so the chord chart's Repository and Work type dimensions render real cross-entity ribbons instead of self-loops (CHAOS-1292).
- Routes REPO and WORK_TYPE through the new templates in `compile_flow_matrix`, removing the "tracked as follow-up" paragraph from its docstring.
- Guarantees the underlying fixture invariants the new templates depend on — `_ensure_work_type_cooccurrence` (generator) and `_verify_repo_cooccurrence_density` (runner) — so the density this feature relies on is explicit, not incidental to CHAOS-1291's team co-occurrence changes.
- Extends unit + live-ClickHouse integration tests to cover both new dimensions with the same asymmetry/orphans/min-edge-count contract TEAM already enforces.

## Why this shape
`work_item_cycle_times` carries `team_id` + `day` but no `repo_id`; `work_items` carries `repo_id` + `type` but no `day`. Real fixture data shows 5 work_scope_ids map to 9 distinct (work_scope, repo) pairs, so `work_scope_id` is NOT a drop-in for `repo_id`. Each new template therefore shares a single `_FLOW_MATRIX_ENRICHED_CTE` that joins the two tables on `work_item_id` before the bridge self-join:

- REPO edges bridge on `(team_id, day)` → pairs of repos touched by the same team on the same day.
- WORK_TYPE edges bridge on `(repo_id, day)` → pairs of work_types completed on the same repo on the same day.

Value = `uniqExact(a.work_item_id)` — SOURCE-side items — so (A→B) ≠ (B→A) whenever volumes differ, which is what unlocks chord's outflow / inflow / net modes.

## Evidence

### Unit tests
```
uv run pytest tests/graphql/ tests/fixtures/ -q
# 186 passed in 1.59s
```
Adds 26 new tests:
- `tests/graphql/test_flow_matrix.py` — 15 new (bridge-key assertions, NULL-guard assertions, dispatch-to-new-template assertions, node consistency).
- `tests/fixtures/test_bridge_density.py` — 8 new (work_type cooccurrence determinism + no-op on diverse, repo cooccurrence happy path + vacuous single-repo + sparse-raises + dedupe, end-to-end ≥5 cross-type pair check).
- `tests/graphql/test_flow_matrix_live.py` — 1 new parametrized over (REPO, WORK_TYPE) = 2 test cases.

### Live ClickHouse integration
```
CLICKHOUSE_URI=clickhouse://ch:ch@localhost:8123/default uv run pytest tests/graphql/test_flow_matrix_live.py -v
# 6 passed  (includes new repo-REPO-5 and work_type-WORK_TYPE-5 parametrized cases)
```
Direct SQL probe against 30-day fixtures (before + after NULL-guard fixes returned identical non-self-loop edge counts):
- REPO: 20 edges, top 6 pairs all asymmetric (e.g., forward 35 / reverse 36).
- WORK_TYPE: 6 edges = all 3 × 2 ordered type pairs covered, asymmetric.

### End-to-end UI (hot-swapped branch into running docker stack, reverted after capture)
Screenshots attached to linked Linear issue CHAOS-1292 (`chaos-1292-live-chord-team-baseline.png`, `chaos-1292-live-chord-repo-bilateral.png`, `chaos-1292-live-chord-worktype-bilateral.png`):
- TEAM chord: baseline still works — 8 teams, asymmetric ribbons, "Strongest exchange" populated.
- REPO chord: **was empty before this PR**. Now 5 repos, cross-repo ribbons, top exchanges 142 / 98 / 84 / 76 / 64.
- WORK_TYPE chord: **was empty before this PR**. Now 3 types (bug, story, task), all three ordered exchanges populated: task↔story 378, task↔bug 210, story↔bug 162.

## Commits
1. `a30db11c8` — add 4 new templates + compiler routing + 15 unit tests
2. `f2cac810c` — NULL guards on both sides of REPO + WORK_TYPE joins (code-review fix)
3. `7621c0a6b` — fixture bridge-density mechanisms (`_ensure_work_type_cooccurrence`, `_verify_repo_cooccurrence_density`) + 8 tests
4. `901845d92` — live-ClickHouse integration tests parametrized over REPO + WORK_TYPE

## Test plan
- [x] Unit suite: `cd ops && uv run pytest tests/graphql/ tests/fixtures/ -q` — 186 passed
- [x] Live integration: `CLICKHOUSE_URI=... uv run pytest tests/graphql/test_flow_matrix_live.py -v` — 6 passed
- [x] E2E visual on live stack (hot-swap + revert) — TEAM, REPO, WORK_TYPE chord modes all render with ribbons
- [ ] Post-merge: regenerate fixtures on the deployed demo and confirm all three dimensions × four flow modes (bilateral / inflow / outflow / net) render as expected
- [ ] Post-merge: close CHAOS-1292 once deployed demo chord is verified in all dimensions

Closes CHAOS-1292.
Follow-up: CHAOS-1279 (parent milestone).