### PR TITLE
refactor(fixtures): align WorkUnit validation with product semantics (CHAOS-105)

### DIFF
--- a/.progress.log
+++ b/.progress.log
@@ -1,0 +1,6 @@
+2026-04-25T23:23:44Z CHAOS-105 moved to In Progress
+2026-04-25T23:24:00Z Read root platform guidance from session context and dev-health-ops AGENTS.md from worktree
+2026-04-25T23:25:00Z Wrote CHAOS-105 decision note under docs/decisions
+2026-04-25T23:26:00Z Refactored fixture validation to check persisted WorkUnit investment density and repo/team coverage
+2026-04-25T23:27:00Z Added fixture validation unit tests for density and coverage behavior
+2026-04-25T23:28:00Z Quality gates: pytest tests/test_fixtures_runner.py passed; ruff check and format --check passed; mypy surfaced existing project-wide errors; LSP clean for tests and runner has pre-existing diagnostics outside CHAOS-105 changes

--- a/docs/decisions/chaos-105-fixture-validation-revisit.md
+++ b/docs/decisions/chaos-105-fixture-validation-revisit.md
@@ -1,0 +1,44 @@
+# CHAOS-105: Fixture validation for WorkUnit investment records
+
+## Context
+
+Fixture validation previously treated Work Graph connected components as the proxy
+for WorkUnits and required at least `max(2, repo_count)` components. That check
+was useful while the graph builder and fixtures were immature, but it now conflicts
+with the product contract: WorkUnits are evidence containers for issues, PRs,
+commits, incidents, and related artifacts, not a category or a topology target.
+The production materializer still starts from connected graph components, but the
+observable contract for the Investment View is the persisted
+`WorkUnitInvestmentRecord` distribution rendered by the visualization layer.
+
+## Decision
+
+Replace the component-count threshold with validation that inspects the persisted
+investment output. Fixture validation should continue to require non-empty graph
+edges and evidence bundles with at least `MIN_EVIDENCE_CHARS`, but it should judge
+Investment View readiness by three persisted-data signals: a non-trivial count of
+`work_unit_investment_records`, repository coverage across expected fixture repos,
+and team coverage against expected fixture teams. Repository and team checks are
+coverage checks, not topology checks; they assert that generated evidence reaches
+the scopes the UI can filter and aggregate by.
+
+## Alternatives
+
+One option was to keep the connected-component threshold and tune it again. That
+would preserve the current CI behavior but keep encoding topology as a product
+semantic. Another option was to delete the validation entirely and rely only on
+frontend smoke tests. That would avoid false failures, but it would allow fixture
+runs with empty or scope-less investment records to pass until a visualization
+breaks. A third option was to validate only raw graph prerequisites. That confirms
+source data exists, but not that the materialized Investment View contract exists.
+
+## Consequences
+
+Existing fixture databases may fail validation if they were generated without
+`--with-metrics`/materialized investment records, or if their records lack repo or
+team evidence. This is intentional: such fixtures are not sufficient for the
+Investment View. The validation no longer fails merely because graph topology
+collapses into fewer connected components than repos, which better matches the
+many-to-many relationships among teams, projects, and repositories. Future changes
+should adjust density or coverage thresholds only when the persisted Investment
+View contract changes, not when graph shape changes.

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -20,6 +20,10 @@ from dev_health_ops.storage import SQLAlchemyStore, resolve_db_type, run_with_st
 from dev_health_ops.utils import BATCH_SIZE, MAX_WORKERS
 from dev_health_ops.work_graph.runner import materialize_fixture_investments
 
+MIN_WORK_UNIT_INVESTMENT_RECORDS = 5
+MIN_WORK_UNIT_REPO_COVERAGE = 0.9
+MIN_WORK_UNIT_TEAM_COVERAGE = 0.8
+
 
 async def _insert_batches(
     insert_fn, items, batch_size: int = BATCH_SIZE, allow_parallel: bool = True
@@ -122,6 +126,119 @@ def _verify_repo_cooccurrence_density(
             f"(need >= {min_multi_repo_teams}). The chord Repository "
             "dimension would render empty. Check _build_repo_team_assignments."
         )
+
+
+def _query_int(client: Any, sql: str) -> int:
+    return int(client.query(sql).result_rows[0][0])
+
+
+def validate_work_unit_investment_density_and_coverage(
+    client: Any,
+    *,
+    table_exists,
+) -> bool:
+    """Validate persisted Investment View readiness, not graph topology."""
+    if not table_exists("work_unit_investments"):
+        logging.error(
+            "FAIL: work_unit_investments missing (run fixtures with --with-metrics "
+            "and --with-work-graph)."
+        )
+        return False
+    if not table_exists("repo_metrics_daily"):
+        logging.error(
+            "FAIL: repo_metrics_daily missing (run fixtures with --with-metrics)."
+        )
+        return False
+    if not table_exists("team_metrics_daily"):
+        logging.error(
+            "FAIL: team_metrics_daily missing (run fixtures with --with-metrics)."
+        )
+        return False
+
+    record_count = _query_int(client, "SELECT count() FROM work_unit_investments")
+    expected_repos = _query_int(
+        client,
+        """
+        SELECT countDistinct(repo_id)
+        FROM repo_metrics_daily
+        WHERE notEmpty(toString(repo_id))
+        """,
+    )
+    expected_teams = _query_int(
+        client,
+        """
+        SELECT countDistinct(team_id)
+        FROM team_metrics_daily
+        WHERE lower(ifNull(nullIf(team_id, ''), 'unassigned')) != 'unassigned'
+        """,
+    )
+    covered_repos = _query_int(
+        client,
+        """
+        SELECT countDistinct(repo_id)
+        FROM work_unit_investments
+        WHERE notEmpty(toString(repo_id))
+        """,
+    )
+    covered_teams = _query_int(
+        client,
+        """
+        SELECT countDistinct(wict.team_id)
+        FROM work_unit_investments AS wui
+        INNER JOIN work_item_cycle_times AS wict
+          ON position(
+            wui.structural_evidence_json,
+            concat('"', wict.work_item_id, '"')
+          ) > 0
+        WHERE lower(ifNull(nullIf(wict.team_id, ''), 'unassigned')) != 'unassigned'
+        """,
+    )
+
+    min_records = max(
+        MIN_WORK_UNIT_INVESTMENT_RECORDS,
+        expected_repos * 2,
+        expected_teams,
+    )
+    repo_coverage = covered_repos / expected_repos if expected_repos else 0.0
+    team_coverage = covered_teams / expected_teams if expected_teams else 0.0
+
+    logging.info(
+        "WorkUnit investments: records=%d (min_required=%d), "
+        "repo_coverage=%.1f%% (%d/%d), team_coverage=%.1f%% (%d/%d)",
+        record_count,
+        min_records,
+        repo_coverage * 100.0,
+        covered_repos,
+        expected_repos,
+        team_coverage * 100.0,
+        covered_teams,
+        expected_teams,
+    )
+
+    if record_count < min_records:
+        logging.error(
+            "FAIL: work_unit_investments density too low (records=%d, required>=%d).",
+            record_count,
+            min_records,
+        )
+        return False
+    if repo_coverage < MIN_WORK_UNIT_REPO_COVERAGE:
+        logging.error(
+            "FAIL: work_unit_investments repo coverage too low "
+            "(covered=%.1f%%, target>=%.1f%%).",
+            repo_coverage * 100.0,
+            MIN_WORK_UNIT_REPO_COVERAGE * 100.0,
+        )
+        return False
+    if team_coverage < MIN_WORK_UNIT_TEAM_COVERAGE:
+        logging.error(
+            "FAIL: work_unit_investments team coverage too low "
+            "(covered=%.1f%%, target>=%.1f%%).",
+            team_coverage * 100.0,
+            MIN_WORK_UNIT_TEAM_COVERAGE * 100.0,
+        )
+        return False
+    return True
 
 
 async def _seed_auth_data(session, user_data: dict) -> None:
@@ -1224,7 +1341,7 @@ def run_fixtures_validation(ns: argparse.Namespace) -> int:
         logging.error(f"FAIL: Could not validate prerequisites: {e}")
         return 1
 
-    # 3. Check work_graph_edges + components
+    # 3. Check work_graph_edges and persisted WorkUnit investment coverage
     try:
         edges = fetch_work_graph_edges(sink)
         if not edges:
@@ -1258,29 +1375,18 @@ def run_fixtures_validation(ns: argparse.Namespace) -> int:
                     stack.append(neighbor)
             components.append(group)
 
-        component_count = len(components)
-        distinct_repos = int(
-            client.query("SELECT countDistinct(repo_id) FROM work_items").result_rows[
-                0
-            ][0]
-        )
-        min_components = max(2, distinct_repos)
         logging.info(
-            "WorkUnits (connected components): %d (min_required=%d, repos=%d)",
-            component_count,
-            min_components,
-            distinct_repos,
+            "Work graph connected components: %d (used for evidence sampling only)",
+            len(components),
         )
-        if component_count < min_components:
-            logging.error(
-                "FAIL: WorkUnits too low (components=%d, required>=%d).",
-                component_count,
-                min_components,
-            )
+
+        if not validate_work_unit_investment_density_and_coverage(
+            client, table_exists=_table_exists
+        ):
             return 1
 
     except Exception as e:
-        logging.error(f"FAIL: Could not validate work graph edges/components: {e}")
+        logging.error(f"FAIL: Could not validate work graph investment coverage: {e}")
         return 1
 
     # 4. Evidence sanity (sample bundles)

--- a/tests/test_fixtures_runner.py
+++ b/tests/test_fixtures_runner.py
@@ -2,6 +2,7 @@ import argparse
 
 import pytest
 
+from dev_health_ops.fixtures import runner
 from dev_health_ops.fixtures.generator import SyntheticDataGenerator
 from dev_health_ops.fixtures.runner import (
     _build_repo_team_assignments,
@@ -164,3 +165,94 @@ async def test_fixtures_generation_initializes_license_manager(tmp_path):
 
     LicenseManager.reset()
     LicenseAuditLogger.reset()
+
+
+class _QueryResult:
+    def __init__(self, value: int):
+        self.result_rows = [(value,)]
+
+
+class _ValidationClient:
+    def __init__(
+        self,
+        *,
+        records: int = 12,
+        expected_repos: int = 3,
+        expected_teams: int = 4,
+        covered_repos: int = 3,
+        covered_teams: int = 4,
+    ):
+        self.records = records
+        self.expected_repos = expected_repos
+        self.expected_teams = expected_teams
+        self.covered_repos = covered_repos
+        self.covered_teams = covered_teams
+
+    def query(self, sql: str):
+        normalized = " ".join(sql.split())
+        if "FROM work_unit_investments AS wui" in normalized:
+            return _QueryResult(self.covered_teams)
+        if "FROM work_unit_investments" in normalized:
+            if "countDistinct(repo_id)" in normalized:
+                return _QueryResult(self.covered_repos)
+            return _QueryResult(self.records)
+        if "FROM repo_metrics_daily" in normalized:
+            return _QueryResult(self.expected_repos)
+        if "FROM team_metrics_daily" in normalized:
+            return _QueryResult(self.expected_teams)
+        raise AssertionError(f"Unexpected query: {normalized}")
+
+
+def _all_tables_exist(name: str) -> bool:
+    return name in {
+        "work_unit_investments",
+        "repo_metrics_daily",
+        "team_metrics_daily",
+    }
+
+
+def test_work_unit_investment_validation_accepts_density_and_coverage():
+    client = _ValidationClient()
+    validate = getattr(runner, "validate_work_unit_investment_density_and_coverage")
+
+    assert (
+        validate(
+            client,
+            table_exists=_all_tables_exist,
+        )
+        is True
+    )
+
+
+def test_work_unit_investment_validation_rejects_low_density():
+    client = _ValidationClient(records=4, expected_repos=3, expected_teams=4)
+    validate = getattr(runner, "validate_work_unit_investment_density_and_coverage")
+
+    assert (
+        validate(
+            client,
+            table_exists=_all_tables_exist,
+        )
+        is False
+    )
+
+
+def test_work_unit_investment_validation_rejects_low_repo_or_team_coverage():
+    low_repo_client = _ValidationClient(covered_repos=2, expected_repos=3)
+    low_team_client = _ValidationClient(covered_teams=2, expected_teams=4)
+    validate = getattr(runner, "validate_work_unit_investment_density_and_coverage")
+
+    assert (
+        validate(
+            low_repo_client,
+            table_exists=_all_tables_exist,
+        )
+        is False
+    )
+    assert (
+        validate(
+            low_team_client,
+            table_exists=_all_tables_exist,
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary
- Documents the CHAOS-105 decision in `docs/decisions/chaos-105-fixture-validation-revisit.md`.
- Removes the `max(2, repo_count)` connected-component threshold as a WorkUnit proxy.
- Adds persisted `work_unit_investments` density plus repo/team coverage validation while keeping `MIN_EVIDENCE_CHARS` evidence sanity.

## Migration impact
Existing fixture databases generated without `--with-metrics` / materialized `work_unit_investments`, or with investment records that do not cover expected repo/team scopes, will now fail validation. Fixtures no longer fail solely because graph topology has fewer connected components than repos.

## Acceptance Criteria
- [x] Decision note added
- [x] Component-count threshold removed
- [x] Density and repo/team coverage checks added
- [x] Evidence sanity retained
- [x] Fixture validation tests updated
- [x] `pytest tests/test_fixtures_runner.py`
- [x] `ruff check src/dev_health_ops/fixtures/runner.py tests/test_fixtures_runner.py`
- [x] `ruff format --check src/dev_health_ops/fixtures/runner.py tests/test_fixtures_runner.py`

SCREENSHOT-WAIVER: Backend fixture validation only; no rendered frontend output changes.

Closes CHAOS-105