### PR TITLE
feat(github): add GitHub App authentication (CHAOS-68)

### DIFF
--- a/.progress.log
+++ b/.progress.log
@@ -1,0 +1,8 @@
+2026-04-25T00:00:00Z CHAOS-68 resumed; Linear moved to In Progress.
+2026-04-25T00:00:00Z Read root and dev-health-ops AGENTS guidance; verified branch feat/chaos-68-github-app-auth is clean except progress log and follows origin/main.
+2026-04-25T00:00:00Z Located sync CLI in src/dev_health_ops/processors/sync.py, GitHub connector/client auth code, resolver tests, and CLI docs.
+2026-04-25T00:00:00Z Added GitHub App JWT signing and installation-token cache/refresh utility plus dynamic GraphQL token provider support.
+2026-04-25T00:00:00Z Integrated GitHubCredentials App/PAT discrimination into connector, work client, resolver env loading, processors, and sync CLI flags.
+2026-04-25T00:00:00Z Added pytest coverage for JWT payload signing, installation token exchange cache, connector/client branching, resolver env key paths, and sync CLI parsing/validation.
+2026-04-25T00:00:00Z Documented GitHub App authentication setup and CLI auth precedence/backward compatibility.
+2026-04-25T00:00:00Z Quality gates: scoped pytest passed (59 tests); ruff check passed; ruff format --check passed. LSP diagnostics tool reported stale/pre-existing Pyright issues on large modules after passing targeted new-file checks.

--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -64,6 +64,14 @@ dev-hops sync git --provider github \
   --owner torvalds \
   --repo linux
 
+# GitHub App
+dev-hops sync git --provider github \
+  --github-app-id "$GITHUB_APP_ID" \
+  --github-app-key-path "$GITHUB_APP_PRIVATE_KEY_PATH" \
+  --github-app-installation-id "$GITHUB_APP_INSTALLATION_ID" \
+  --owner my-org \
+  --repo my-repo
+
 # GitLab
 dev-hops sync git --provider gitlab \
   --auth "$GITLAB_TOKEN" \
@@ -74,6 +82,8 @@ dev-hops sync git --provider gitlab \
 | Option | Description |
 |--------|-------------|
 | `--provider` | `local`, `github`, `gitlab` |
+| `--auth` | GitHub/GitLab token override (PAT mode for GitHub) |
+| `--github-app-id`, `--github-app-key-path`, `--github-app-installation-id` | GitHub App auth flags. Mutually exclusive with PAT auth. |
 | `--repo-path` | Path to local repo |
 | `--owner`, `--repo` | GitHub owner/repo |
 | `--project-id` | GitLab project ID |
@@ -83,6 +93,8 @@ dev-hops sync git --provider gitlab \
 | `--sink` | Analytics backend (`clickhouse` only; default) |
 
 `--date` is a deprecated hidden alias for `--before`.
+
+GitHub authentication precedence is CLI flags > environment variables > stored database credentials. Use either PAT auth (`--auth` or `GITHUB_TOKEN`) or GitHub App auth, not both. See [GitHub App authentication](../user-guide/github-app-auth.md).
 
 ### `sync prs`
 

--- a/docs/user-guide/github-app-auth.md
+++ b/docs/user-guide/github-app-auth.md
@@ -1,0 +1,61 @@
+# GitHub App authentication
+
+Dev Health can authenticate GitHub syncs with either a personal access token (PAT) or a GitHub App installation token. GitHub App auth is useful for organization-wide installs, fine-grained permissions, and higher installation rate limits.
+
+## Required GitHub App permissions
+
+Grant only the permissions needed for the sync target you run:
+
+- Repository contents: read
+- Metadata: read
+- Pull requests: read (for `sync prs`)
+- Issues: read (for GitHub work item sync)
+- Actions / deployments / security events: read when using the corresponding sync targets
+
+Install the app on the organization or repositories you want Dev Health to ingest.
+
+## Environment variables
+
+```bash
+export GITHUB_APP_ID="123456"
+export GITHUB_APP_PRIVATE_KEY_PATH="/secure/path/dev-health-github-app.pem"
+export GITHUB_APP_INSTALLATION_ID="987654"
+```
+
+Then run a GitHub sync without `--auth`:
+
+```bash
+dev-hops sync git --provider github --owner my-org --repo my-repo
+```
+
+## CLI flags
+
+CLI flags take precedence over environment variables and stored database credentials:
+
+```bash
+dev-hops sync git --provider github \
+  --github-app-id "123456" \
+  --github-app-key-path "/secure/path/dev-health-github-app.pem" \
+  --github-app-installation-id "987654" \
+  --owner my-org \
+  --repo my-repo
+```
+
+## Authentication precedence and compatibility
+
+GitHub sync resolves credentials in this order:
+
+1. CLI flags (`--auth` or the GitHub App flags)
+2. Environment variables (`GITHUB_TOKEN` or the GitHub App env vars)
+3. Stored organization credentials, when `--org` and `--db`/`POSTGRES_URI` are available
+
+Exactly one auth mode is allowed for the selected source: PAT XOR GitHub App. Existing PAT usage is unchanged:
+
+```bash
+export GITHUB_TOKEN="ghp_..."
+dev-hops sync git --provider github --owner my-org --repo my-repo
+
+dev-hops sync git --provider github --auth "$GITHUB_TOKEN" --owner my-org --repo my-repo
+```
+
+Private keys, app JWTs, and installation tokens are never logged by Dev Health.

--- a/src/dev_health_ops/connectors/github.py
+++ b/src/dev_health_ops/connectors/github.py
@@ -9,7 +9,7 @@ import inspect
 import logging
 import time
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import requests
 from github import Auth, Github, GithubException, RateLimitExceededException
@@ -41,12 +41,16 @@ from dev_health_ops.connectors.utils import (
     match_repo_pattern,
     retry_with_backoff,
 )
+from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
 from dev_health_ops.metrics.prometheus import (
     record_github_api_request,
     record_github_rate_limit,
 )
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from dev_health_ops.credentials.types import GitHubCredentials
 
 
 class GitHubConnector(GitConnector):
@@ -59,7 +63,8 @@ class GitHubConnector(GitConnector):
 
     def __init__(
         self,
-        token: str,
+        token: str | None = None,
+        credentials: "GitHubCredentials | None" = None,
         base_url: str | None = None,
         per_page: int = 100,
         max_workers: int = 4,
@@ -68,11 +73,32 @@ class GitHubConnector(GitConnector):
         Initialize GitHub connector.
 
         :param token: GitHub personal access token.
+        :param credentials: Resolved GitHub credentials (PAT or App auth).
         :param base_url: Optional base URL for GitHub Enterprise.
         :param per_page: Number of items per page for pagination.
         :param max_workers: Maximum concurrent workers for operations.
         """
         super().__init__(per_page=per_page, max_workers=max_workers)
+        if credentials is not None:
+            base_url = credentials.base_url or base_url
+
+        self._app_token_provider: GitHubAppTokenProvider | None = None
+        if credentials is not None and credentials.is_app_auth:
+            assert credentials.app_id is not None
+            assert credentials.private_key is not None
+            assert credentials.installation_id is not None
+            self._app_token_provider = GitHubAppTokenProvider(
+                app_id=credentials.app_id,
+                private_key=credentials.private_key,
+                installation_id=credentials.installation_id,
+            )
+            token = self._app_token_provider.get_token()
+        elif credentials is not None:
+            token = credentials.token
+
+        if not token:
+            raise ValueError("GitHubConnector requires token or credentials")
+
         self.token = token
 
         # Initialize PyGithub client
@@ -83,7 +109,12 @@ class GitHubConnector(GitConnector):
             self.github = Github(auth=auth, per_page=per_page)
 
         # Initialize GraphQL client for blame operations
-        self.graphql = GitHubGraphQLClient(token)
+        token_provider = (
+            self._app_token_provider.get_token
+            if self._app_token_provider is not None
+            else None
+        )
+        self.graphql = GitHubGraphQLClient(token, token_provider=token_provider)
 
     def _handle_github_exception(self, e: Exception) -> None:
         """

--- a/src/dev_health_ops/connectors/utils/__init__.py
+++ b/src/dev_health_ops/connectors/utils/__init__.py
@@ -2,6 +2,11 @@
 Utility modules for connectors.
 """
 
+from .github_app import (
+    GitHubAppAuthError,
+    GitHubAppTokenProvider,
+    create_github_app_jwt,
+)
 from .graphql import GitHubGraphQLClient
 from .pagination import AsyncPaginationHandler, PaginationHandler
 from .patterns import match_name_pattern, match_project_pattern, match_repo_pattern
@@ -17,6 +22,9 @@ from .token_pool import TokenPool, create_token_pool
 
 __all__ = [
     "GitHubGraphQLClient",
+    "GitHubAppAuthError",
+    "GitHubAppTokenProvider",
+    "create_github_app_jwt",
     "PaginationHandler",
     "AsyncPaginationHandler",
     "DistributedRateLimitGate",

--- a/src/dev_health_ops/connectors/utils/github_app.py
+++ b/src/dev_health_ops/connectors/utils/github_app.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import jwt
+import requests
+
+GITHUB_API_BASE_URL = "https://api.github.com"
+JWT_TTL_SECONDS = 600
+INSTALLATION_TOKEN_REFRESH_WINDOW_SECONDS = 300
+
+
+class GitHubAppAuthError(RuntimeError):
+    """Raised when GitHub App authentication cannot produce an access token."""
+
+
+@dataclass(frozen=True)
+class InstallationToken:
+    token: str
+    expires_at: datetime
+
+
+def create_github_app_jwt(
+    *,
+    app_id: str,
+    private_key: str,
+    now: int | None = None,
+) -> str:
+    """Sign a GitHub App JWT with RS256.
+
+    GitHub requires ``iss`` to be the App ID and ``exp`` no more than ten
+    minutes in the future. ``iat`` is backdated slightly to tolerate clock skew.
+    """
+    issued_at = int(now if now is not None else time.time()) - 60
+    payload = {
+        "iat": issued_at,
+        "exp": issued_at + JWT_TTL_SECONDS,
+        "iss": str(app_id),
+    }
+    return str(jwt.encode(payload, private_key, algorithm="RS256"))
+
+
+class GitHubAppTokenProvider:
+    """Caches and refreshes GitHub App installation access tokens."""
+
+    def __init__(
+        self,
+        *,
+        app_id: str,
+        private_key: str,
+        installation_id: str,
+        api_base_url: str = GITHUB_API_BASE_URL,
+        timeout: int = 30,
+        refresh_window_seconds: int = INSTALLATION_TOKEN_REFRESH_WINDOW_SECONDS,
+    ) -> None:
+        if not app_id:
+            raise ValueError("GitHub App auth requires app_id")
+        if not private_key:
+            raise ValueError("GitHub App auth requires private_key")
+        if not installation_id:
+            raise ValueError("GitHub App auth requires installation_id")
+
+        self.app_id = str(app_id)
+        self.private_key = private_key
+        self.installation_id = str(installation_id)
+        self.api_base_url = api_base_url.rstrip("/")
+        self.timeout = timeout
+        self.refresh_window_seconds = refresh_window_seconds
+        self._cached: InstallationToken | None = None
+
+    def get_token(self) -> str:
+        """Return a cached installation token or refresh near expiry."""
+        if self._cached and not self._expires_soon(self._cached.expires_at):
+            return self._cached.token
+        self._cached = self._exchange_installation_token()
+        return self._cached.token
+
+    def _expires_soon(self, expires_at: datetime) -> bool:
+        now = datetime.now(timezone.utc)
+        return (expires_at - now).total_seconds() <= self.refresh_window_seconds
+
+    def _exchange_installation_token(self) -> InstallationToken:
+        app_jwt = create_github_app_jwt(
+            app_id=self.app_id,
+            private_key=self.private_key,
+        )
+        url = (
+            f"{self.api_base_url}/app/installations/"
+            f"{self.installation_id}/access_tokens"
+        )
+        response = requests.post(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {app_jwt}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=self.timeout,
+        )
+        if response.status_code >= 400:
+            raise GitHubAppAuthError(
+                f"GitHub App installation token exchange failed: HTTP {response.status_code}"
+            )
+
+        data: dict[str, Any] = response.json()
+        token = data.get("token")
+        expires_at_raw = data.get("expires_at")
+        if not token or not expires_at_raw:
+            raise GitHubAppAuthError(
+                "GitHub App installation token response missing token or expires_at"
+            )
+
+        expires_at = datetime.fromisoformat(str(expires_at_raw).replace("Z", "+00:00"))
+        return InstallationToken(token=str(token), expires_at=expires_at)

--- a/src/dev_health_ops/connectors/utils/graphql.py
+++ b/src/dev_health_ops/connectors/utils/graphql.py
@@ -7,6 +7,7 @@ particularly for operations not well-supported by PyGithub such as blame.
 
 import logging
 import time
+from collections.abc import Callable
 from typing import Any
 
 import requests
@@ -45,18 +46,32 @@ class GitHubGraphQLClient:
 
     GRAPHQL_ENDPOINT = "https://api.github.com/graphql"
 
-    def __init__(self, token: str, timeout: int = 30):
+    def __init__(
+        self,
+        token: str | None = None,
+        timeout: int = 30,
+        token_provider: Callable[[], str] | None = None,
+    ):
         """
         Initialize GitHub GraphQL client.
 
         :param token: GitHub personal access token.
         :param timeout: Request timeout in seconds.
         """
+        if not token and token_provider is None:
+            raise ValueError("GitHubGraphQLClient requires token or token_provider")
         self.token = token
         self.timeout = timeout
+        self.token_provider = token_provider
         self.headers = {
-            "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
+        }
+
+    def _headers(self) -> dict[str, str]:
+        token = self.token_provider() if self.token_provider is not None else self.token
+        return {
+            **self.headers,
+            "Authorization": f"Bearer {token}",
         }
 
     @retry_with_backoff(
@@ -80,7 +95,7 @@ class GitHubGraphQLClient:
         :raises RateLimitException: If rate limit is exceeded.
         :raises APIException: If API returns an error.
         """
-        payload = {"query": query}
+        payload: dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = variables
 
@@ -88,7 +103,7 @@ class GitHubGraphQLClient:
             response = requests.post(
                 self.GRAPHQL_ENDPOINT,
                 json=payload,
-                headers=self.headers,
+                headers=self._headers(),
                 timeout=self.timeout,
             )
 

--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -24,7 +24,13 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=ProviderCredentials)
 
 PROVIDER_ENV_VARS: dict[str, dict[str, str]] = {
-    "github": {"token": "GITHUB_TOKEN", "base_url": "GITHUB_URL"},
+    "github": {
+        "token": "GITHUB_TOKEN",
+        "base_url": "GITHUB_URL",
+        "app_id": "GITHUB_APP_ID",
+        "private_key_path": "GITHUB_APP_PRIVATE_KEY_PATH",
+        "installation_id": "GITHUB_APP_INSTALLATION_ID",
+    },
     "gitlab": {"token": "GITLAB_TOKEN", "base_url": "GITLAB_URL"},
     "jira": {
         "api_token": "JIRA_API_TOKEN",
@@ -200,6 +206,12 @@ class CredentialResolver:
     ) -> T:
         cred_dict = {k: v for k, v in cred_dict.items() if v is not None}
 
+        if cred_type is GitHubCredentials and "private_key" not in cred_dict:
+            private_key_path = cred_dict.get("private_key_path")
+            if private_key_path:
+                with open(str(private_key_path), encoding="utf-8") as key_file:
+                    cred_dict["private_key"] = key_file.read()
+
         cred_dict["source"] = source
         cred_dict["credential_name"] = credential_name
 
@@ -292,8 +304,13 @@ class _EnvOnlyResolver:
         cred_type = PROVIDER_CREDENTIAL_TYPES[provider]
 
         try:
+            if cred_type is GitHubCredentials and "private_key" not in cred_dict:
+                private_key_path = cred_dict.get("private_key_path")
+                if private_key_path:
+                    with open(str(private_key_path), encoding="utf-8") as key_file:
+                        cred_dict["private_key"] = key_file.read()
             cred_dict["source"] = CredentialSource.ENVIRONMENT
             cred_dict["credential_name"] = credential_name
             return cred_type(**cred_dict)
-        except (ValueError, TypeError):
+        except (OSError, ValueError, TypeError):
             return None

--- a/src/dev_health_ops/credentials/types.py
+++ b/src/dev_health_ops/credentials/types.py
@@ -53,19 +53,30 @@ class GitHubCredentials(ProviderCredentials):
 
     app_id: str | None = None
     private_key: str | None = None
+    private_key_path: str | None = None
     installation_id: str | None = None
     base_url: str | None = None
 
     def __post_init__(self) -> None:
-        if not self.token and not (self.app_id and self.private_key):
+        has_token = bool(self.token)
+        has_app_fields = bool(self.app_id or self.private_key or self.installation_id)
+        has_complete_app = bool(
+            self.app_id and self.private_key and self.installation_id
+        )
+
+        if has_token and has_app_fields:
             raise ValueError(
-                "GitHub credentials require either 'token' or 'app_id' + 'private_key'"
+                "GitHub credentials require exactly one auth mode: token or GitHub App"
+            )
+        if not has_token and not has_complete_app:
+            raise ValueError(
+                "GitHub credentials require either 'token' or 'app_id' + 'private_key' + 'installation_id'"
             )
 
     @property
     def is_app_auth(self) -> bool:
         """Check if using GitHub App authentication."""
-        return bool(self.app_id and self.private_key)
+        return bool(self.app_id and self.private_key and self.installation_id)
 
 
 @dataclass

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
+from dev_health_ops.credentials.types import GitHubCredentials
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models import git as git_models
 from dev_health_ops.models.git import (
@@ -859,7 +860,7 @@ async def process_github_repo(
     store: GitSyncStore | Any,
     owner: str,
     repo_name: str,
-    token: str,
+    token: str | GitHubCredentials,
     fetch_blame: bool = False,
     blame_only: bool = False,
     max_commits: int | None = None,
@@ -881,7 +882,11 @@ async def process_github_repo(
     loop = asyncio.get_running_loop()
     ingestion_sink = IngestionSink(store)
 
-    connector = GitHubConnector(token=token)
+    connector = (
+        GitHubConnector(credentials=token)
+        if isinstance(token, GitHubCredentials)
+        else GitHubConnector(token=token)
+    )
     try:
         # 1. Fetch Repo Info
         logging.info("Fetching repository information...")
@@ -1086,7 +1091,7 @@ async def process_github_repo(
 
 async def process_github_repos_batch(
     store: Any,
-    token: str,
+    token: str | GitHubCredentials,
     org_name: str = None,
     user_name: str = None,
     pattern: str = None,
@@ -1114,7 +1119,11 @@ async def process_github_repos_batch(
         raise RuntimeError("Connectors unavailable. Install required dependencies.")
 
     logging.info("=== GitHub Batch Repository Processing ===")
-    connector = GitHubConnector(token=token)
+    connector = (
+        GitHubConnector(credentials=token)
+        if isinstance(token, GitHubCredentials)
+        else GitHubConnector(token=token)
+    )
     loop = asyncio.get_running_loop()
     ingestion_sink = IngestionSink(store)
 

--- a/src/dev_health_ops/processors/sync.py
+++ b/src/dev_health_ops/processors/sync.py
@@ -111,10 +111,10 @@ def _build_github_cli_or_env_credentials(
 def _resolve_github_sync_credentials(ns: argparse.Namespace) -> GitHubCredentials:
     """Resolve GitHub sync auth with precedence CLI > env > DB."""
     cli_credentials = _build_github_cli_or_env_credentials(
-        token=ns.auth,
-        app_id=ns.github_app_id,
-        private_key_path=ns.github_app_key_path,
-        installation_id=ns.github_app_installation_id,
+        token=getattr(ns, "auth", None),
+        app_id=getattr(ns, "github_app_id", None),
+        private_key_path=getattr(ns, "github_app_key_path", None),
+        installation_id=getattr(ns, "github_app_installation_id", None),
         credential_name="cli",
     )
     if cli_credentials is not None:

--- a/src/dev_health_ops/processors/sync.py
+++ b/src/dev_health_ops/processors/sync.py
@@ -2,6 +2,12 @@ import argparse
 import asyncio
 import os
 
+from dev_health_ops.credentials import (
+    CredentialResolutionError,
+    CredentialSource,
+    GitHubCredentials,
+    resolve_credentials_sync,
+)
 from dev_health_ops.db import resolve_sink_uri
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.processors.github import (
@@ -50,6 +56,105 @@ def _resolve_synthetic_repo_name(ns: argparse.Namespace) -> str:
     return "acme/demo-app"
 
 
+def _read_github_app_private_key(path: str) -> str:
+    try:
+        with open(path, encoding="utf-8") as key_file:
+            return key_file.read()
+    except OSError as exc:
+        raise SystemExit(f"Unable to read GitHub App private key file: {path}") from exc
+
+
+def _build_github_cli_or_env_credentials(
+    *,
+    token: str | None,
+    app_id: str | None,
+    private_key_path: str | None,
+    installation_id: str | None,
+    base_url: str | None = None,
+    credential_name: str = "default",
+) -> GitHubCredentials | None:
+    has_token = bool(token)
+    app_values = [app_id, private_key_path, installation_id]
+    has_any_app = any(app_values)
+    has_all_app = all(app_values)
+
+    if has_token and has_any_app:
+        raise SystemExit(
+            "GitHub auth must use exactly one mode: PAT (--auth/GITHUB_TOKEN) XOR GitHub App."
+        )
+    if has_any_app and not has_all_app:
+        raise SystemExit(
+            "GitHub App auth requires app id, private key path, and installation id."
+        )
+    if has_token:
+        return GitHubCredentials(
+            token=token,
+            base_url=base_url,
+            source=CredentialSource.ENVIRONMENT,
+            credential_name=credential_name,
+        )
+    if has_all_app:
+        assert app_id is not None
+        assert private_key_path is not None
+        assert installation_id is not None
+        return GitHubCredentials(
+            app_id=app_id,
+            private_key=_read_github_app_private_key(private_key_path),
+            installation_id=installation_id,
+            base_url=base_url,
+            source=CredentialSource.ENVIRONMENT,
+            credential_name=credential_name,
+        )
+    return None
+
+
+def _resolve_github_sync_credentials(ns: argparse.Namespace) -> GitHubCredentials:
+    """Resolve GitHub sync auth with precedence CLI > env > DB."""
+    cli_credentials = _build_github_cli_or_env_credentials(
+        token=ns.auth,
+        app_id=ns.github_app_id,
+        private_key_path=ns.github_app_key_path,
+        installation_id=ns.github_app_installation_id,
+        credential_name="cli",
+    )
+    if cli_credentials is not None:
+        return cli_credentials
+
+    env_credentials = _build_github_cli_or_env_credentials(
+        token=os.getenv("GITHUB_TOKEN"),
+        app_id=os.getenv("GITHUB_APP_ID"),
+        private_key_path=os.getenv("GITHUB_APP_PRIVATE_KEY_PATH"),
+        installation_id=os.getenv("GITHUB_APP_INSTALLATION_ID"),
+        base_url=os.getenv("GITHUB_URL") or os.getenv("GITHUB_BASE_URL"),
+        credential_name="environment",
+    )
+    if env_credentials is not None:
+        return env_credentials
+
+    db_url = (
+        getattr(ns, "db", None)
+        or os.getenv("POSTGRES_URI")
+        or os.getenv("DATABASE_URI")
+    )
+    org_id = getattr(ns, "org", None)
+    if db_url and org_id:
+        try:
+            credentials = resolve_credentials_sync(
+                "github",
+                org_id=org_id,
+                db_url=db_url,
+                allow_env_fallback=False,
+            )
+        except CredentialResolutionError:
+            credentials = None
+        if isinstance(credentials, GitHubCredentials):
+            return credentials
+
+    raise SystemExit(
+        "Missing GitHub credentials (pass --auth, set GITHUB_TOKEN, configure GitHub App flags/env vars, or configure DB credentials)."
+    )
+
+
 async def sync_local_target(ns: argparse.Namespace, target: str) -> int:
     if target not in {"git", "prs", "blame"}:
         raise SystemExit("Local provider supports only git, prs, or blame targets.")
@@ -82,9 +187,7 @@ async def sync_local_target(ns: argparse.Namespace, target: str) -> int:
 
 
 async def sync_github_target(ns: argparse.Namespace, target: str) -> int:
-    token = ns.auth or os.getenv("GITHUB_TOKEN") or ""
-    if not token:
-        raise SystemExit("Missing GitHub token (pass --auth or set GITHUB_TOKEN).")
+    credentials = _resolve_github_sync_credentials(ns)
 
     db_uri = resolve_sink_uri(ns)
     validate_sink(ns)
@@ -99,7 +202,7 @@ async def sync_github_target(ns: argparse.Namespace, target: str) -> int:
             user_name = str(ns.owner or "") if not ns.group else ""
             batch_kwargs = {
                 "store": store,
-                "token": token,
+                "token": credentials,
                 "org_name": org_name,
                 "user_name": user_name,
                 "pattern": ns.search,
@@ -131,7 +234,7 @@ async def sync_github_target(ns: argparse.Namespace, target: str) -> int:
             store,
             ns.owner,
             ns.repo,
-            token,
+            credentials,
             blame_only=flags["blame_only"],
             max_commits=max_commits,
             sync_git=flags["sync_git"],
@@ -296,6 +399,15 @@ def _add_sync_target_args(parser: argparse.ArgumentParser) -> None:
         help="Source provider for the sync job.",
     )
     parser.add_argument("--auth", help="Provider token override (GitHub/GitLab).")
+    parser.add_argument("--github-app-id", help="GitHub App ID (GitHub provider).")
+    parser.add_argument(
+        "--github-app-key-path",
+        help="Path to GitHub App private key PEM (GitHub provider).",
+    )
+    parser.add_argument(
+        "--github-app-installation-id",
+        help="GitHub App installation ID (GitHub provider).",
+    )
     parser.add_argument(
         "--repo-path", default=".", help="Local git repo path (local provider)."
     )

--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -12,7 +12,10 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitConfig,
     RateLimitGate,
 )
-from dev_health_ops.credentials.resolver import resolve_credentials_sync
+from dev_health_ops.credentials.resolver import (
+    CredentialResolutionError,
+    resolve_credentials_sync,
+)
 from dev_health_ops.credentials.types import GitHubCredentials
 from dev_health_ops.providers._ratelimit import gate_call
 
@@ -133,7 +136,14 @@ class GitHubWorkClient:
 
     @classmethod
     def from_env(cls) -> GitHubWorkClient:
-        credentials = resolve_credentials_sync("github", allow_env_fallback=True)
+        try:
+            credentials = resolve_credentials_sync("github", allow_env_fallback=True)
+        except CredentialResolutionError as exc:
+            raise ValueError(
+                "GITHUB_TOKEN environment variable is required (or configure GitHub App "
+                "credentials via GITHUB_APP_ID/GITHUB_APP_PRIVATE_KEY_PATH/"
+                "GITHUB_APP_INSTALLATION_ID, or store credentials in the database)."
+            ) from exc
         if not isinstance(credentials, GitHubCredentials):
             raise ValueError("Resolved credentials are not GitHub credentials")
         return cls(auth=GitHubAuth.from_credentials(credentials))

--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -6,13 +6,15 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Protocol, TypedDict
 
+from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
 from dev_health_ops.connectors.utils.graphql import GitHubGraphQLClient
 from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitConfig,
     RateLimitGate,
 )
+from dev_health_ops.credentials.resolver import resolve_credentials_sync
+from dev_health_ops.credentials.types import GitHubCredentials
 from dev_health_ops.providers._ratelimit import gate_call
-from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 
 logger = logging.getLogger(__name__)
 
@@ -53,8 +55,25 @@ class ProjectV2ItemNode(TypedDict, total=False):
 
 @dataclass(frozen=True)
 class GitHubAuth:
-    token: str
+    token: str | None = None
+    app_id: str | None = None
+    private_key: str | None = None
+    installation_id: str | None = None
     base_url: str | None = None  # GitHub Enterprise REST base URL (optional)
+
+    @classmethod
+    def from_credentials(cls, credentials: GitHubCredentials) -> GitHubAuth:
+        return cls(
+            token=credentials.token,
+            app_id=credentials.app_id,
+            private_key=credentials.private_key,
+            installation_id=credentials.installation_id,
+            base_url=credentials.base_url,
+        )
+
+    @property
+    def is_app_auth(self) -> bool:
+        return bool(self.app_id and self.private_key and self.installation_id)
 
 
 class GitHubWorkClient:
@@ -76,38 +95,48 @@ class GitHubWorkClient:
         self.auth = auth
         self.per_page = max(1, min(100, int(per_page)))
         self.gate = gate or RateLimitGate(RateLimitConfig(initial_backoff_seconds=1.0))
+        self._app_token_provider: GitHubAppTokenProvider | None = None
+
+        token = auth.token
+        if auth.is_app_auth:
+            assert auth.app_id is not None
+            assert auth.private_key is not None
+            assert auth.installation_id is not None
+            self._app_token_provider = GitHubAppTokenProvider(
+                app_id=auth.app_id,
+                private_key=auth.private_key,
+                installation_id=auth.installation_id,
+            )
+            token = self._app_token_provider.get_token()
+        if not token:
+            raise ValueError("GitHubWorkClient requires token or GitHub App auth")
 
         if auth.base_url:
             self.github = Github(
                 base_url=auth.base_url,
-                login_or_token=auth.token,
+                login_or_token=token,
                 per_page=self.per_page,
             )
         else:
             self.github = Github(
-                login_or_token=auth.token,
+                login_or_token=token,
                 per_page=self.per_page,
             )
 
         # GraphQL client (api.github.com only for now).
-        self.graphql = GitHubGraphQLClient(auth.token)
+        token_provider = (
+            self._app_token_provider.get_token
+            if self._app_token_provider is not None
+            else None
+        )
+        self.graphql = GitHubGraphQLClient(token, token_provider=token_provider)
 
     @classmethod
     def from_env(cls) -> GitHubWorkClient:
-        env = read_env_spec(
-            EnvSpec(
-                required={"token": "GITHUB_TOKEN"},
-                optional={"base_url": ("GITHUB_BASE_URL", None)},
-                missing_error="GITHUB_TOKEN environment variable is required",
-            )
-        )
-        base = env["base_url"]
-        return cls(
-            auth=GitHubAuth(
-                token=str(env["token"]),
-                base_url=str(base) if base else None,
-            )
-        )
+        credentials = resolve_credentials_sync("github", allow_env_fallback=True)
+        if not isinstance(credentials, GitHubCredentials):
+            raise ValueError("Resolved credentials are not GitHub credentials")
+        return cls(auth=GitHubAuth.from_credentials(credentials))
 
     def get_repo(self, *, owner: str, repo: str) -> Any:
         return self.github.get_repo(f"{owner}/{repo}")

--- a/tests/test_credential_resolver.py
+++ b/tests/test_credential_resolver.py
@@ -54,6 +54,17 @@ class TestGitHubCredentials:
         assert creds.is_app_auth is True
         assert creds.token is None
 
+    def test_invalid_mixed_token_and_app_auth(self):
+        with pytest.raises(ValueError, match="exactly one auth mode"):
+            GitHubCredentials(
+                token="ghp_test",
+                app_id="12345",
+                private_key="key",
+                installation_id="67890",
+                source=CredentialSource.DATABASE,
+                credential_name="default",
+            )
+
     def test_invalid_missing_token_and_app(self):
         with pytest.raises(ValueError, match="require either 'token' or 'app_id'"):
             GitHubCredentials(
@@ -478,6 +489,35 @@ class TestCredentialResolver:
             assert result.is_app_auth is True
             assert result.app_id == "12345"
             assert result.installation_id == "67890"
+
+    @pytest.mark.asyncio
+    async def test_github_app_auth_from_environment_key_path(self, resolver, tmp_path):
+        """Test resolving GitHub App credentials from environment key path."""
+        key_path = tmp_path / "github-app.pem"
+        key_path.write_text("synthetic-private-key", encoding="utf-8")
+
+        with patch(
+            "dev_health_ops.api.services.settings.IntegrationCredentialsService"
+        ) as mock_svc_class:
+            mock_svc = AsyncMock()
+            mock_svc.get_decrypted_credentials = AsyncMock(return_value=None)
+            mock_svc_class.return_value = mock_svc
+
+            with patch.dict(
+                os.environ,
+                {
+                    "GITHUB_APP_ID": "12345",
+                    "GITHUB_APP_PRIVATE_KEY_PATH": str(key_path),
+                    "GITHUB_APP_INSTALLATION_ID": "67890",
+                },
+                clear=False,
+            ):
+                os.environ.pop("GITHUB_TOKEN", None)
+                result = await resolver.resolve("github")
+
+        assert isinstance(result, GitHubCredentials)
+        assert result.is_app_auth is True
+        assert result.private_key == "synthetic-private-key"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_github_app_auth.py
+++ b/tests/test_github_app_auth.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock, patch
+
+import pytest
+
+from dev_health_ops.cli import build_parser
+from dev_health_ops.connectors.github import GitHubConnector
+from dev_health_ops.connectors.utils.github_app import (
+    GitHubAppTokenProvider,
+    create_github_app_jwt,
+)
+from dev_health_ops.credentials import CredentialSource, GitHubCredentials
+from dev_health_ops.processors.sync import _resolve_github_sync_credentials
+from dev_health_ops.providers.github.client import GitHubAuth, GitHubWorkClient
+
+
+def test_create_github_app_jwt_signs_rs256_with_app_id() -> None:
+    with patch("dev_health_ops.connectors.utils.github_app.jwt.encode") as encode:
+        encode.return_value = "signed.jwt"
+
+        token = create_github_app_jwt(
+            app_id="12345",
+            private_key="synthetic-private-key",
+            now=1_700_000_000,
+        )
+
+    assert token == "signed.jwt"
+    payload = encode.call_args.args[0]
+    assert payload["iss"] == "12345"
+    assert payload["exp"] - payload["iat"] == 600
+    encode.assert_called_once_with(payload, "synthetic-private-key", algorithm="RS256")
+
+
+def test_installation_token_exchange_caches_until_refresh_window() -> None:
+    expires_at = (datetime.now(timezone.utc) + timedelta(minutes=20)).isoformat()
+    response = Mock(status_code=201)
+    response.json.return_value = {
+        "token": "installation-token",
+        "expires_at": expires_at,
+    }
+
+    with (
+        patch(
+            "dev_health_ops.connectors.utils.github_app.create_github_app_jwt",
+            return_value="app-jwt",
+        ),
+        patch(
+            "dev_health_ops.connectors.utils.github_app.requests.post",
+            return_value=response,
+        ) as post,
+    ):
+        provider = GitHubAppTokenProvider(
+            app_id="12345",
+            private_key="synthetic-private-key",
+            installation_id="67890",
+        )
+        first = provider.get_token()
+        second = provider.get_token()
+
+    assert first == "installation-token"
+    assert second == "installation-token"
+    post.assert_called_once()
+    assert post.call_args.args[0].endswith("/app/installations/67890/access_tokens")
+    assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer app-jwt"
+
+
+def test_github_connector_branches_to_app_token_provider() -> None:
+    credentials = GitHubCredentials(
+        app_id="12345",
+        private_key="synthetic-private-key",
+        installation_id="67890",
+        source=CredentialSource.ENVIRONMENT,
+    )
+
+    with (
+        patch(
+            "dev_health_ops.connectors.github.GitHubAppTokenProvider"
+        ) as provider_cls,
+        patch("dev_health_ops.connectors.github.Github") as github_cls,
+        patch("dev_health_ops.connectors.github.GitHubGraphQLClient") as graphql_cls,
+    ):
+        provider = provider_cls.return_value
+        provider.get_token.return_value = "installation-token"
+
+        connector = GitHubConnector(credentials=credentials)
+
+    assert connector.token == "installation-token"
+    provider_cls.assert_called_once_with(
+        app_id="12345",
+        private_key="synthetic-private-key",
+        installation_id="67890",
+    )
+    github_cls.assert_called_once()
+    graphql_cls.assert_called_once()
+    assert graphql_cls.call_args.kwargs["token_provider"] == provider.get_token
+
+
+def test_github_work_client_branches_to_app_token_provider() -> None:
+    auth = GitHubAuth(
+        app_id="12345",
+        private_key="synthetic-private-key",
+        installation_id="67890",
+    )
+
+    with (
+        patch(
+            "dev_health_ops.providers.github.client.GitHubAppTokenProvider"
+        ) as provider_cls,
+        patch("github.Github") as github_cls,
+        patch(
+            "dev_health_ops.providers.github.client.GitHubGraphQLClient"
+        ) as graphql_cls,
+    ):
+        provider = provider_cls.return_value
+        provider.get_token.return_value = "installation-token"
+
+        client = GitHubWorkClient(auth=auth)
+
+    assert client.auth.is_app_auth is True
+    provider_cls.assert_called_once_with(
+        app_id="12345",
+        private_key="synthetic-private-key",
+        installation_id="67890",
+    )
+    github_cls.assert_called_once()
+    graphql_cls.assert_called_once()
+    assert graphql_cls.call_args.kwargs["token_provider"] == provider.get_token
+
+
+def test_sync_git_cli_parses_github_app_flags_and_resolves_credentials(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    key_path = tmp_path / "github-app.pem"
+    key_path.write_text("synthetic-private-key", encoding="utf-8")
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_APP_ID", raising=False)
+    monkeypatch.delenv("GITHUB_APP_PRIVATE_KEY_PATH", raising=False)
+    monkeypatch.delenv("GITHUB_APP_INSTALLATION_ID", raising=False)
+
+    ns = build_parser().parse_args(
+        [
+            "sync",
+            "git",
+            "--provider",
+            "github",
+            "--github-app-id",
+            "12345",
+            "--github-app-key-path",
+            str(key_path),
+            "--github-app-installation-id",
+            "67890",
+            "--owner",
+            "org",
+            "--repo",
+            "repo",
+        ]
+    )
+
+    credentials = _resolve_github_sync_credentials(ns)
+
+    assert credentials.is_app_auth is True
+    assert credentials.app_id == "12345"
+    assert credentials.private_key == "synthetic-private-key"
+    assert credentials.installation_id == "67890"
+
+
+def test_sync_git_cli_rejects_pat_and_app_flags(tmp_path) -> None:
+    key_path = tmp_path / "github-app.pem"
+    key_path.write_text("synthetic-private-key", encoding="utf-8")
+    ns = build_parser().parse_args(
+        [
+            "sync",
+            "git",
+            "--provider",
+            "github",
+            "--auth",
+            "ghp_pat",
+            "--github-app-id",
+            "12345",
+            "--github-app-key-path",
+            str(key_path),
+            "--github-app-installation-id",
+            "67890",
+            "--owner",
+            "org",
+            "--repo",
+            "repo",
+        ]
+    )
+
+    with pytest.raises(SystemExit, match="exactly one mode"):
+        _resolve_github_sync_credentials(ns)


### PR DESCRIPTION
## Summary
- Adds GitHub App JWT signing plus installation token exchange with cached refresh near expiry.
- Supports resolved GitHub App credentials across the connector, work-item client, credential resolver, and `dev-hops sync git` auth flags.
- Documents setup and preserves PAT auth via `GITHUB_TOKEN` / `--auth`.

## Why
GitHub Apps provide higher installation rate limits, fine-grained permissions, and organization-wide installation without user PAT expiration issues.

## Setup
See `docs/user-guide/github-app-auth.md`.

## Backward compatibility
Existing PAT flows are unchanged: `GITHUB_TOKEN` and `--auth` still work. GitHub sync validates PAT XOR GitHub App for the selected auth source.

## Test plan
- `pytest tests/test_github_app_auth.py tests/test_credential_resolver.py tests/test_github_connector.py tests/providers/test_github_iter_with_limit.py`
- `ruff check src/dev_health_ops/connectors/utils/github_app.py src/dev_health_ops/connectors/utils/graphql.py src/dev_health_ops/connectors/utils/__init__.py src/dev_health_ops/connectors/github.py src/dev_health_ops/providers/github/client.py src/dev_health_ops/credentials/types.py src/dev_health_ops/credentials/resolver.py src/dev_health_ops/processors/github.py src/dev_health_ops/processors/sync.py tests/test_github_app_auth.py tests/test_credential_resolver.py`
- `ruff format --check src/dev_health_ops/connectors/utils/github_app.py src/dev_health_ops/connectors/utils/graphql.py src/dev_health_ops/connectors/utils/__init__.py src/dev_health_ops/connectors/github.py src/dev_health_ops/providers/github/client.py src/dev_health_ops/credentials/types.py src/dev_health_ops/credentials/resolver.py src/dev_health_ops/processors/github.py src/dev_health_ops/processors/sync.py tests/test_github_app_auth.py tests/test_credential_resolver.py`

SCREENSHOT-WAIVER: Backend/CLI auth change only; no rendered UI output changed.

Closes CHAOS-68