### PR TITLE
fix(ci): required-check gate jobs to unblock auto-merge (CHAOS-1296)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main", "!dependabot/**"]
   pull_request:
     branches: ["**"]
+  merge_group:
   schedule:
     - cron: "30 1 * * 0"
   workflow_dispatch:

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -3,6 +3,7 @@ name: Build Docker images
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [ "**" ]
     types: [ opened, edited, synchronize, reopened, ready_for_review ]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
               - 'pyproject.toml'
               - 'scripts/**'
 
-  lint:
+  lint-job:
     needs: [changes]
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -72,3 +72,28 @@ jobs:
         continue-on-error: true
         run: |
           mypy --install-types --non-interactive .
+
+  # Required-status-check gate. Branch protection requires a check named
+  # exactly "lint". The aggregator always runs and treats skipped (path
+  # filter, e.g. docs-only PRs) as pass so PRs are never blocked waiting
+  # on a status that will never report. Do not remove.
+  lint:
+    name: lint
+    if: always()
+    needs: [lint-job]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate lint result
+        env:
+          LINT_RESULT: ${{ needs.lint-job.result }}
+        run: |
+          echo "lint-job result: ${LINT_RESULT}"
+          case "${LINT_RESULT}" in
+            success|skipped)
+              echo "lint gate passed"
+              ;;
+            failure|cancelled|*)
+              echo "lint gate failed"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: ["**"]
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ "**" ]
+  merge_group:
   workflow_dispatch:
 
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: ["**"]
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
               - 'Makefile'
               - 'scripts/**'
 
-  test:
+  test-matrix:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04-arm
@@ -125,3 +125,28 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
+
+  # Required-status-check gate. Branch protection requires a check named
+  # exactly "test"; the matrix above produces "test (3.11)"..."test (3.14)"
+  # which never match. This aggregator always runs, treating skipped (path
+  # filter) as pass and failure/cancelled as fail. Do not remove.
+  test:
+    name: test
+    if: always()
+    needs: [test-matrix]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate matrix result
+        env:
+          MATRIX_RESULT: ${{ needs.test-matrix.result }}
+        run: |
+          echo "test-matrix result: ${MATRIX_RESULT}"
+          case "${MATRIX_RESULT}" in
+            success|skipped)
+              echo "test gate passed"
+              ;;
+            failure|cancelled|*)
+              echo "test gate failed"
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
## Summary

Fixes **two compounding bugs** that caused PRs to sit idle and never auto-merge.

Closes CHAOS-1296

## Bug 1 — Required check `test` was never reported

The branch protection ruleset (`rulesets/5324160`) requires GitHub Actions status checks named **exactly**:

```json
[{"context": "test"}, {"context": "lint"}]
```

The actual checks reported on every PR were:

| Check | State |
|---|---|
| `test (3.11)` | ✅ |
| `test (3.12)` | ✅ |
| `test (3.13)` | ✅ |
| `test (3.14)` | ✅ |
| `lint` | ✅ |

The naked `test` context **never appeared** because of the `python-version` matrix in `test.yml` — GitHub appends the matrix dimension to the check name. So `test` sat in *"Expected — Waiting for status to be reported"* indefinitely, blocking auto-merge.

There was a second latent bug here too: both workflows gate the real job on a paths-filter (`needs.changes.outputs.code == 'true'`). Job-level `if:` skips do **not** generate the synthetic success that workflow-level `paths:` skips do, so docs-only PRs would also stall on `lint`.

### Fix 1: required-check gate jobs

Each workflow gets a thin aggregator job that:

- Has `name:` matching the required check exactly (`test` / `lint`)
- Runs always (`if: always()`)
- Aggregates the underlying job's `result`:
  - `success` / `skipped` → pass (path-filter skip is expected behavior)
  - `failure` / `cancelled` → fail

Robust to: matrix changes, path-filter skips, merge-queue branches.

## Bug 2 — Workflows didn't trigger on `merge_group` events

The ruleset also has `merge_queue` enabled with `grouping_strategy: ALLGREEN`. When a PR enters the queue, GitHub creates a temporary `gh-readonly-queue/main/pr-<N>-<base>-<head>` branch and fires `merge_group` events expecting workflows to run on it. The queue verifies the actual merge result against the *latest* base — not the stale PR commit — to catch semantic merge conflicts.

**No workflow in this repo had `on: merge_group:`.** Confirmed via:

```
$ gh api 'repos/.../actions/runs?event=merge_group'
Total merge_group runs ever: 0
```

So the queue created the temp branch, fired `merge_group`, **zero workflows responded**, required `test` and `lint` checks never reported, and the queue timed out after 60 minutes (`check_response_timeout_minutes`).

`../web/.github/workflows/tests.yml` line 7 has exactly the missing piece (`merge_group:`).

### Fix 2: merge_group triggers

Added `merge_group:` to every PR-triggered workflow except `auto-release.yml` (post-merge tagger that intentionally only runs on closed PRs and would create skipped runs on the queue branch).

## Test plan

This PR itself proves Fix 1: it only touches `.github/workflows/`, outside the path filter, so `test-matrix` and `lint-job` are SKIPPED while `test` and `lint` gate jobs are SUCCESS. Pre-fix, this PR would have stalled forever.

Fix 2 will be exercised when this PR is added to the merge queue — `merge_group` workflow runs should show up, and required checks should pass on the queue branch.

## Files changed

**Commit 1** (gate jobs):
- `.github/workflows/test.yml` — rename `test` → `test-matrix`, add `test` gate job
- `.github/workflows/lint.yml` — rename `lint` → `lint-job`, add `lint` gate job

**Commit 2** (merge_group triggers):
- `.github/workflows/test.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/codeql-analysis.yml`
- `.github/workflows/governance.yml`
- `.github/workflows/security-scan.yml`
- `.github/workflows/live-e2e.yml`
- `.github/workflows/docker-images.yml`

## Frontend impact

None — CI-only change.

SCREENSHOT-WAIVER: CI/workflow change only, no frontend rendering impact.