### PR TITLE
fix(types): models layer mypy clean (1/8 of CHAOS-1386)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,3 +155,31 @@ per-file-ignores = { "__init__.py" = [
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.mypy]
+python_version = "3.13"
+files = ["src", "tests", "scripts"]
+mypy_path = "src"
+plugins = ["pydantic.mypy"]
+namespace_packages = true
+explicit_package_bases = true
+show_error_codes = true
+pretty = true
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+no_implicit_optional = true
+check_untyped_defs = true
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+
+[[tool.mypy.overrides]]
+module = [
+  "celery",
+  "celery.*",
+  "atlassian",
+  "atlassian.*",
+  "radon",
+  "radon.*",
+]
+ignore_missing_imports = true

--- a/src/dev_health_ops/models/atlassian_ops.py
+++ b/src/dev_health_ops/models/atlassian_ops.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, Text
+from sqlalchemy import DateTime, Text
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dev_health_ops.models.git import Base
 
@@ -44,15 +45,17 @@ class AtlassianOpsSchedule:
 class AtlassianOpsIncidentModel(Base):
     __tablename__ = "atlassian_ops_incidents"
 
-    id = Column(Text, primary_key=True)
-    url = Column(Text, nullable=True)
-    summary = Column(Text, nullable=False)
-    description = Column(Text, nullable=True)
-    status = Column(Text, nullable=False)
-    severity = Column(Text, nullable=False)
-    created_at = Column(DateTime(timezone=True), nullable=False)
-    provider_id = Column(Text, nullable=True)
-    last_synced = Column(
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    severity: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    provider_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_synced: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
@@ -62,14 +65,22 @@ class AtlassianOpsIncidentModel(Base):
 class AtlassianOpsAlertModel(Base):
     __tablename__ = "atlassian_ops_alerts"
 
-    id = Column(Text, primary_key=True)
-    status = Column(Text, nullable=False)
-    priority = Column(Text, nullable=False)
-    created_at = Column(DateTime(timezone=True), nullable=False)
-    acknowledged_at = Column(DateTime(timezone=True), nullable=True)
-    snoozed_at = Column(DateTime(timezone=True), nullable=True)
-    closed_at = Column(DateTime(timezone=True), nullable=True)
-    last_synced = Column(
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    priority: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    acknowledged_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    snoozed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    closed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_synced: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
@@ -79,10 +90,10 @@ class AtlassianOpsAlertModel(Base):
 class AtlassianOpsScheduleModel(Base):
     __tablename__ = "atlassian_ops_schedules"
 
-    id = Column(Text, primary_key=True)
-    name = Column(Text, nullable=False)
-    timezone = Column(Text, nullable=True)
-    last_synced = Column(
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    timezone: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_synced: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),

--- a/src/dev_health_ops/models/audit.py
+++ b/src/dev_health_ops/models/audit.py
@@ -16,19 +16,21 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
     JSON,
-    Column,
     DateTime,
     ForeignKey,
     Index,
     Text,
 )
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dev_health_ops.models.git import GUID, Base
+
+if TYPE_CHECKING:
+    from .users import Organization, User
 
 
 class AuditAction(str, Enum):
@@ -150,8 +152,8 @@ class AuditLog(Base):
 
     __tablename__ = "audit_logs"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    org_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=False,
@@ -160,7 +162,7 @@ class AuditLog(Base):
     )
 
     # Who performed the action (null for system-triggered actions)
-    user_id = Column(
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
         GUID(),
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
@@ -169,7 +171,7 @@ class AuditLog(Base):
     )
 
     # What action was performed
-    action = Column(
+    action: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         index=True,
@@ -177,13 +179,13 @@ class AuditLog(Base):
     )
 
     # What resource was affected
-    resource_type = Column(
+    resource_type: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         index=True,
         comment="Type of resource (user, credential, setting, etc.)",
     )
-    resource_id = Column(
+    resource_id: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         index=True,
@@ -191,18 +193,18 @@ class AuditLog(Base):
     )
 
     # Context and details
-    description = Column(
+    description: Mapped[str | None] = mapped_column(
         Text,
         nullable=True,
         comment="Human-readable description of the action",
     )
-    changes = Column(
+    changes: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
         default=dict,
         comment="Before/after values for updates, or created values",
     )
-    request_metadata = Column(
+    request_metadata: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
         default=dict,
@@ -210,20 +212,20 @@ class AuditLog(Base):
     )
 
     # Status tracking
-    status = Column(
+    status: Mapped[str | None] = mapped_column(
         Text,
         nullable=False,
         default="success",
         comment="Action status: success or failure",
     )
-    error_message = Column(
+    error_message: Mapped[str | None] = mapped_column(
         Text,
         nullable=True,
         comment="Error message if status is failure",
     )
 
     # Timestamp (immutable - no updated_at for audit logs)
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
@@ -232,8 +234,8 @@ class AuditLog(Base):
     )
 
     # Relationships
-    organization = relationship("Organization")
-    user = relationship("User")
+    organization: Mapped[Organization] = relationship("Organization")
+    user: Mapped[User | None] = relationship("User")
 
     # Indexes for common query patterns
     __table_args__ = (

--- a/src/dev_health_ops/models/backfill.py
+++ b/src/dev_health_ops/models/backfill.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import uuid
+from datetime import date, datetime
 
-from sqlalchemy import Column, Date, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import Date, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dev_health_ops.models.git import GUID, Base
 
@@ -10,27 +12,37 @@ from dev_health_ops.models.git import GUID, Base
 class BackfillJob(Base):
     __tablename__ = "backfill_jobs"
 
-    id = Column(GUID, primary_key=True, default=uuid.uuid4)
-    org_id = Column(String, nullable=False, index=True)
-    sync_config_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    sync_config_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("sync_configurations.id", ondelete="CASCADE"),
         nullable=False,
     )
-    celery_task_id = Column(String, nullable=True)
-    status = Column(String, nullable=False, default="pending")
-    since_date = Column(Date, nullable=False)
-    before_date = Column(Date, nullable=False)
-    total_chunks = Column(Integer, nullable=False, default=0)
-    completed_chunks = Column(Integer, nullable=False, default=0)
-    failed_chunks = Column(Integer, nullable=False, default=0)
-    error_message = Column(Text, nullable=True)
-    started_at = Column(DateTime(timezone=True), nullable=True)
-    completed_at = Column(DateTime(timezone=True), nullable=True)
-    created_at = Column(
+    celery_task_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    status: Mapped[str | None] = mapped_column(
+        String, nullable=False, default="pending"
+    )
+    since_date: Mapped[date] = mapped_column(Date, nullable=False)
+    before_date: Mapped[date] = mapped_column(Date, nullable=False)
+    total_chunks: Mapped[int | None] = mapped_column(Integer, nullable=False, default=0)
+    completed_chunks: Mapped[int | None] = mapped_column(
+        Integer, nullable=False, default=0
+    )
+    failed_chunks: Mapped[int | None] = mapped_column(
+        Integer, nullable=False, default=0
+    )
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         server_default=func.now(),

--- a/src/dev_health_ops/models/billing.py
+++ b/src/dev_health_ops/models/billing.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 from enum import Enum
+from typing import Any
 
 import sqlalchemy as sa
 from sqlalchemy import (
     JSON,
     Boolean,
-    Column,
     DateTime,
     ForeignKey,
     Integer,
     Text,
     UniqueConstraint,
 )
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dev_health_ops.models.git import GUID, Base
 
@@ -26,19 +28,27 @@ class BillingInterval(str, Enum):
 class BillingPlan(Base):
     __tablename__ = "billing_plans"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    key = Column(Text, nullable=False, unique=True, index=True)
-    name = Column(Text, nullable=False)
-    description = Column(Text, nullable=True)
-    tier = Column(Text, nullable=False)
-    is_active = Column(Boolean, server_default="true", nullable=False)
-    display_order = Column(Integer, server_default="0", nullable=False)
-    stripe_product_id = Column(Text, nullable=True, unique=True)
-    metadata_ = Column("metadata", JSON, server_default="{}", nullable=False)
-    created_at = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    key: Mapped[str] = mapped_column(Text, nullable=False, unique=True, index=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    tier: Mapped[str] = mapped_column(Text, nullable=False)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, server_default="true", nullable=False
+    )
+    display_order: Mapped[int] = mapped_column(
+        Integer, server_default="0", nullable=False
+    )
+    stripe_product_id: Mapped[str | None] = mapped_column(
+        Text, nullable=True, unique=True
+    )
+    metadata_: Mapped[dict[str, Any]] = mapped_column(
+        "metadata", JSON, server_default="{}", nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
     )
 
@@ -46,22 +56,26 @@ class BillingPlan(Base):
 class BillingPrice(Base):
     __tablename__ = "billing_prices"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    plan_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    plan_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("billing_plans.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    interval = Column(Text, nullable=False)
-    amount = Column(Integer, nullable=False)
-    currency = Column(Text, server_default="usd", nullable=False)
-    is_active = Column(Boolean, server_default="true", nullable=False)
-    stripe_price_id = Column(Text, nullable=True, unique=True)
-    created_at = Column(
+    interval: Mapped[str] = mapped_column(Text, nullable=False)
+    amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    currency: Mapped[str] = mapped_column(Text, server_default="usd", nullable=False)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, server_default="true", nullable=False
+    )
+    stripe_price_id: Mapped[str | None] = mapped_column(
+        Text, nullable=True, unique=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
     )
 
@@ -69,15 +83,15 @@ class BillingPrice(Base):
 class FeatureBundle(Base):
     __tablename__ = "feature_bundles"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    key = Column(Text, nullable=False, unique=True, index=True)
-    name = Column(Text, nullable=False)
-    description = Column(Text, nullable=True)
-    features = Column(JSON, nullable=False)
-    created_at = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    key: Mapped[str] = mapped_column(Text, nullable=False, unique=True, index=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    features: Mapped[dict[str, Any] | list[str]] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
     )
 
@@ -85,9 +99,11 @@ class FeatureBundle(Base):
 class PlanFeatureBundle(Base):
     __tablename__ = "plan_feature_bundles"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    plan_id = Column(GUID(), ForeignKey("billing_plans.id"), nullable=False, index=True)
-    bundle_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    plan_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), ForeignKey("billing_plans.id"), nullable=False, index=True
+    )
+    bundle_id: Mapped[uuid.UUID] = mapped_column(
         GUID(), ForeignKey("feature_bundles.id"), nullable=False, index=True
     )
 

--- a/src/dev_health_ops/models/billing_audit.py
+++ b/src/dev_health_ops/models/billing_audit.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
+from typing import Any
 
 import sqlalchemy as sa
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, Index, Text
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, Text
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dev_health_ops.models.git import GUID, Base
 
@@ -11,18 +14,24 @@ from dev_health_ops.models.git import GUID, Base
 class BillingAuditLog(Base):
     __tablename__ = "billing_audit_log"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    org_id = Column(GUID(), ForeignKey("organizations.id"), nullable=False, index=True)
-    actor_id = Column(GUID(), ForeignKey("users.id"), nullable=True)
-    action = Column(Text, nullable=False)
-    resource_type = Column(Text, nullable=False)
-    resource_id = Column(GUID(), nullable=False)
-    description = Column(Text, nullable=False)
-    stripe_event_id = Column(Text, nullable=True)
-    local_state = Column(JSON, nullable=True)
-    stripe_state = Column(JSON, nullable=True)
-    reconciliation_status = Column(Text, nullable=True)
-    created_at = Column(DateTime(timezone=True), server_default=sa.text("now()"))
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), ForeignKey("organizations.id"), nullable=False, index=True
+    )
+    actor_id: Mapped[uuid.UUID | None] = mapped_column(
+        GUID(), ForeignKey("users.id"), nullable=True
+    )
+    action: Mapped[str] = mapped_column(Text, nullable=False)
+    resource_type: Mapped[str] = mapped_column(Text, nullable=False)
+    resource_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    stripe_event_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    local_state: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    stripe_state: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    reconciliation_status: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), server_default=sa.text("now()")
+    )
 
     __table_args__ = (
         Index("ix_billing_audit_log_org_created", "org_id", "created_at"),

--- a/src/dev_health_ops/models/checkpoints.py
+++ b/src/dev_health_ops/models/checkpoints.py
@@ -13,13 +13,13 @@ from datetime import datetime, timezone
 from enum import IntEnum
 
 from sqlalchemy import (
-    Column,
     DateTime,
     Index,
     Integer,
     Text,
     UniqueConstraint,
 )
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dev_health_ops.models.git import GUID, Base
 
@@ -46,33 +46,39 @@ class MetricCheckpoint(Base):
 
     __tablename__ = "metric_checkpoints"
 
-    id = Column(GUID, primary_key=True, default=uuid.uuid4)
-    org_id = Column(Text, nullable=False)
-    repo_id = Column(GUID, nullable=True)
-    metric_type = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(Text, nullable=False)
+    repo_id: Mapped[uuid.UUID | None] = mapped_column(GUID, nullable=True)
+    metric_type: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         comment="Computation scope: daily_batch, daily_finalize, rebuild",
     )
-    day = Column(DateTime(timezone=True), nullable=False, comment="Target date")
-    status = Column(
+    day: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, comment="Target date"
+    )
+    status: Mapped[int | None] = mapped_column(
         Integer,
         nullable=False,
         default=CheckpointStatus.PENDING,
         comment="0=pending, 1=running, 2=completed, 3=failed",
     )
-    started_at = Column(DateTime(timezone=True), nullable=True)
-    completed_at = Column(DateTime(timezone=True), nullable=True)
-    error = Column(Text, nullable=True)
-    worker_id = Column(
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    worker_id: Mapped[str | None] = mapped_column(
         Text, nullable=True, comment="Celery task ID for distributed locking"
     )
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),

--- a/src/dev_health_ops/models/email_verification_token.py
+++ b/src/dev_health_ops/models/email_verification_token.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, ForeignKey, Index, Text
+from sqlalchemy import DateTime, ForeignKey, Index, Text
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dev_health_ops.models.git import GUID, Base
 
@@ -11,16 +12,20 @@ from dev_health_ops.models.git import GUID, Base
 class EmailVerificationToken(Base):
     __tablename__ = "email_verification_tokens"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    user_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    token_hash = Column(Text, nullable=False, unique=True, index=True)
-    expires_at = Column(DateTime(timezone=True), nullable=False)
-    created_at = Column(
+    token_hash: Mapped[str] = mapped_column(
+        Text, nullable=False, unique=True, index=True
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         nullable=False,

--- a/src/dev_health_ops/models/git.py
+++ b/src/dev_health_ops/models/git.py
@@ -3,13 +3,14 @@ import logging
 import os
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 
 from git import Repo as GitRepo
+from git.objects.commit import Commit
 from sqlalchemy import (
     CHAR,
     JSON,
     Boolean,
-    Column,
     DateTime,
     Float,
     ForeignKey,
@@ -19,12 +20,14 @@ from sqlalchemy import (
     TypeDecorator,
 )
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
-from sqlalchemy.orm import declarative_base, relationship
-
-Base = declarative_base()
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
-class GUID(TypeDecorator):
+class Base(DeclarativeBase):
+    pass
+
+
+class GUID(TypeDecorator[uuid.UUID]):
     """Platform-independent GUID type.
 
     Uses PostgreSQL's UUID type for PostgreSQL, otherwise uses
@@ -34,13 +37,15 @@ class GUID(TypeDecorator):
     impl = CHAR
     cache_ok = True
 
-    def load_dialect_impl(self, dialect):
+    def load_dialect_impl(self, dialect: Any) -> Any:
         if dialect.name == "postgresql":
             return dialect.type_descriptor(PGUUID())
         else:
             return dialect.type_descriptor(CHAR(32))
 
-    def process_bind_param(self, value, dialect):
+    def process_bind_param(
+        self, value: uuid.UUID | str | None, dialect: Any
+    ) -> str | None:
         if value is None:
             return value
         elif dialect.name == "postgresql":
@@ -52,7 +57,9 @@ class GUID(TypeDecorator):
                 # hex string
                 return value.hex
 
-    def process_result_value(self, value, dialect):
+    def process_result_value(
+        self, value: uuid.UUID | str | None, dialect: Any
+    ) -> uuid.UUID | None:
         if value is None:
             return value
         else:
@@ -153,7 +160,74 @@ def get_repo_uuid(repo_path: str) -> uuid.UUID:
 class Repo(Base, GitRepo):
     __tablename__ = "repos"
 
-    def __init__(self, repo_path: str | None = None, **kwargs):
+    id: Mapped[uuid.UUID] = mapped_column(
+        GUID,
+        primary_key=True,
+        default=uuid.uuid4,
+        comment="MergeStat identifier for the repo",
+    )
+    repo: Mapped[str] = mapped_column(Text, nullable=False, comment="URL for the repo")
+    ref: Mapped[str | None] = mapped_column(Text, comment="ref for the repo")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        comment="timestamp of when the MergeStat repo entry was created",
+    )
+    settings: Mapped[dict[str, Any]] = mapped_column(
+        JSON, nullable=False, default=dict, comment="JSON settings for the repo"
+    )
+    provider: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="unknown",
+        comment="sync provider (github, gitlab, local, synthetic)",
+    )
+    repo_tags: Mapped[list[str]] = mapped_column(
+        "tags",
+        JSON,
+        key="repo_tags",
+        nullable=False,
+        default=list,
+        comment="array of tags for the repo",
+    )
+
+    git_refs: Mapped[list["GitRef"]] = relationship("GitRef", back_populates="repo")
+    git_files: Mapped[list["GitFile"]] = relationship("GitFile", back_populates="repo")
+    git_commits: Mapped[list["GitCommit"]] = relationship(
+        "GitCommit", back_populates="repo"
+    )
+    git_commit_stats: Mapped[list["GitCommitStat"]] = relationship(
+        "GitCommitStat", back_populates="repo"
+    )
+    git_blames: Mapped[list["GitBlame"]] = relationship(
+        "GitBlame", back_populates="repo"
+    )
+    git_pull_requests: Mapped[list["GitPullRequest"]] = relationship(
+        "GitPullRequest", back_populates="repo"
+    )
+    ci_pipeline_runs: Mapped[list["CiPipelineRun"]] = relationship(
+        "CiPipelineRun",
+        back_populates="repo",
+        cascade="all, delete-orphan",
+    )
+    deployments: Mapped[list["Deployment"]] = relationship(
+        "Deployment",
+        back_populates="repo",
+        cascade="all, delete-orphan",
+    )
+    incidents: Mapped[list["Incident"]] = relationship(
+        "Incident",
+        back_populates="repo",
+        cascade="all, delete-orphan",
+    )
+    security_alerts: Mapped[list["SecurityAlert"]] = relationship(
+        "SecurityAlert",
+        back_populates="repo",
+        cascade="all, delete-orphan",
+    )
+
+    def __init__(self, repo_path: str | None = None, **kwargs: Any) -> None:
         """
         Initialize the Repo class with the given repository path.
 
@@ -190,213 +264,151 @@ class Repo(Base, GitRepo):
         if repo_path:
             GitRepo.__init__(self, repo_path)  # Initialize GitPython Repo
 
-    id = Column(
-        GUID,
-        primary_key=True,
-        default=uuid.uuid4,
-        comment="MergeStat identifier for the repo",
-    )
-    repo = Column(Text, nullable=False, comment="URL for the repo")
-    ref = Column(Text, comment="ref for the repo")
-    created_at = Column(
-        DateTime(timezone=True),
-        nullable=False,
-        default=lambda: datetime.now(timezone.utc),
-        comment="timestamp of when the MergeStat repo entry was created",
-    )
-    settings = Column(
-        JSON, nullable=False, default=dict, comment="JSON settings for the repo"
-    )
-    provider = Column(
-        Text,
-        nullable=False,
-        default="unknown",
-        comment="sync provider (github, gitlab, local, synthetic)",
-    )
-    repo_tags = Column(
-        "tags",
-        JSON,
-        key="repo_tags",
-        nullable=False,
-        default=list,
-        comment="array of tags for the repo",
-    )
-    # repo_import_id = Column(
-    #     GUID,
-    #     ForeignKey("mergestat.repo_imports.id", ondelete="CASCADE"),
-    #     comment="foreign key for mergestat.repo_imports.id",
-    # )
-    # provider = Column(
-    #     GUID,
-    #     ForeignKey("mergestat.providers.id", ondelete="CASCADE"),
-    #     nullable=False,
-    # )
-
-    # Relationships
-    git_refs = relationship("GitRef", back_populates="repo")
-    git_files = relationship("GitFile", back_populates="repo")
-    git_commits = relationship("GitCommit", back_populates="repo")
-    git_commit_stats = relationship("GitCommitStat", back_populates="repo")
-    git_blames = relationship("GitBlame", back_populates="repo")
-    git_pull_requests = relationship("GitPullRequest", back_populates="repo")
-    ci_pipeline_runs = relationship(
-        "CiPipelineRun",
-        back_populates="repo",
-        cascade="all, delete-orphan",
-    )
-    deployments = relationship(
-        "Deployment",
-        back_populates="repo",
-        cascade="all, delete-orphan",
-    )
-    incidents = relationship(
-        "Incident",
-        back_populates="repo",
-        cascade="all, delete-orphan",
-    )
-    security_alerts = relationship(
-        "SecurityAlert",
-        back_populates="repo",
-        cascade="all, delete-orphan",
-    )
-
 
 class GitRef(Base):
     __tablename__ = "git_refs"
-    repo_id = Column(
+    repo_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("repos.id", ondelete="CASCADE"),
         primary_key=True,
         comment="foreign key for public.repos.id",
     )
-    full_name = Column(Text, primary_key=True)
-    hash = Column(Text, comment="hash of the commit for refs that are not of type tag")
-    name = Column(Text, comment="name of the ref")
-    remote = Column(Text, comment="remote of the ref")
-    target = Column(Text, comment="target of the ref")
-    type = Column(Text, comment="type of the ref")
-    tag_commit_hash = Column(
+    full_name: Mapped[str] = mapped_column(Text, primary_key=True)
+    hash: Mapped[str | None] = mapped_column(
+        Text, comment="hash of the commit for refs that are not of type tag"
+    )
+    name: Mapped[str | None] = mapped_column(Text, comment="name of the ref")
+    remote: Mapped[str | None] = mapped_column(Text, comment="remote of the ref")
+    target: Mapped[str | None] = mapped_column(Text, comment="target of the ref")
+    type: Mapped[str | None] = mapped_column(Text, comment="type of the ref")
+    tag_commit_hash: Mapped[str | None] = mapped_column(
         Text, comment="hash of the commit for refs that are of type tag"
     )
-    last_synced = Column(
+    last_synced: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         comment="timestamp when record was synced into the MergeStat database",
     )
 
-    # Relationships
-    repo = relationship("Repo", back_populates="git_refs")
+    repo: Mapped[Repo] = relationship("Repo", back_populates="git_refs")
 
 
 class GitFile(Base):
     __tablename__ = "git_files"
-    repo_id = Column(
+    repo_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("repos.id", ondelete="CASCADE"),
         primary_key=True,
         comment="foreign key for public.repos.id",
     )
-    path = Column(Text, primary_key=True, comment="path of the file")
-    executable = Column(
+    path: Mapped[str] = mapped_column(
+        Text, primary_key=True, comment="path of the file"
+    )
+    executable: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,
         comment="boolean to determine if the file is an executable",
     )
-    contents = Column(Text, comment="contents of the file")
-    last_synced = Column(
+    contents: Mapped[str | None] = mapped_column(Text, comment="contents of the file")
+    last_synced: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         comment="timestamp when record was synced into the MergeStat database",
     )
 
-    # Relationships
-    repo = relationship("Repo", back_populates="git_files")
+    repo: Mapped[Repo] = relationship("Repo", back_populates="git_files")
 
 
 class GitCommit(Base):
     __tablename__ = "git_commits"
-    repo_id = Column(
+    repo_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("repos.id", ondelete="CASCADE"),
         primary_key=True,
         comment="foreign key for public.repos.id",
     )
-    hash = Column(Text, primary_key=True, comment="hash of the commit")
-    message = Column(Text, comment="message of the commit")
-    author_name = Column(Text, comment="name of the author of the modification")
-    author_email = Column(Text, comment="email of the author of the modification")
-    author_when = Column(
+    hash: Mapped[str] = mapped_column(
+        Text, primary_key=True, comment="hash of the commit"
+    )
+    message: Mapped[str | None] = mapped_column(Text, comment="message of the commit")
+    author_name: Mapped[str | None] = mapped_column(
+        Text, comment="name of the author of the modification"
+    )
+    author_email: Mapped[str | None] = mapped_column(
+        Text, comment="email of the author of the modification"
+    )
+    author_when: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         comment="timestamp of when the modification was authored",
     )
-    committer_name = Column(
+    committer_name: Mapped[str | None] = mapped_column(
         Text, comment="name of the author who committed the modification"
     )
-    committer_email = Column(
+    committer_email: Mapped[str | None] = mapped_column(
         Text, comment="email of the author who committed the modification"
     )
-    committer_when = Column(
+    committer_when: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         comment="timestamp of when the commit was made",
     )
-    parents = Column(
+    parents: Mapped[int] = mapped_column(
         Integer, nullable=False, comment="the number of parents of the commit"
     )
-    last_synced = Column(
+    last_synced: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         comment="timestamp when record was synced into the MergeStat database",
     )
 
-    # Relationships
-    repo = relationship("Repo", back_populates="git_commits")
+    repo: Mapped[Repo] = relationship("Repo", back_populates="git_commits")
 
 
 class GitCommitStat(Base):
     __tablename__ = "git_commit_stats"
-    repo_id = Column(
+    repo_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("repos.id", ondelete="CASCADE"),
         primary_key=True,
         comment="foreign key for public.repos.id",
     )
-    commit_hash = Column(Text, primary_key=True, comment="hash of the commit")
-    file_path = Column(
+    commit_hash: Mapped[str] = mapped_column(
+        Text, primary_key=True, comment="hash of the commit"
+    )
+    file_path: Mapped[str] = mapped_column(
         Text, primary_key=True, comment="path of the file the modification was made in"
     )
-    additions = Column(
+    additions: Mapped[int] = mapped_column(
         Integer,
         nullable=False,
         comment="the number of additions in this path of the commit",
     )
-    deletions = Column(
+    deletions: Mapped[int] = mapped_column(
         Integer,
         nullable=False,
         comment="the number of deletions in this path of the commit",
     )
-    old_file_mode = Column(
+    old_file_mode: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         default="unknown",
         comment="old file mode derived from git mode",
     )
-    new_file_mode = Column(
+    new_file_mode: Mapped[str | None] = mapped_column(
         Text, default="unknown", comment="new file mode derived from git mode"
     )
-    last_synced = Column(
+    last_synced: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         comment="timestamp when record was synced into the MergeStat database",
     )
 
-    # Relationships
-    repo = relationship("Repo", back_populates="git_commit_stats")
+    repo: Mapped[Repo] = relationship("Repo", back_populates="git_commit_stats")
 
 
 class GitBlameMixin:
@@ -410,7 +422,7 @@ class GitBlameMixin:
         filepath: str,
         repo_uuid: uuid.UUID,
         repo: GitRepo | None = None,
-    ) -> list[tuple]:
+    ) -> list[tuple[uuid.UUID, str, str, datetime, str, int, str, str]]:
         """
         Fetch blame data for a given file using gitpython.
 
@@ -433,9 +445,22 @@ class GitBlameMixin:
                         continue
                     commit = item[0]
                     lines = item[1]
-                    if commit is None or lines is None:
+                    if (
+                        commit is None
+                        or lines is None
+                        or not isinstance(commit, Commit)
+                        or not isinstance(lines, list)
+                    ):
                         continue
                     for line in lines:
+                        if isinstance(line, bytes):
+                            line_text = line.decode("utf-8", errors="replace").rstrip(
+                                "\n"
+                            )
+                        elif isinstance(line, str):
+                            line_text = line.rstrip("\n")
+                        else:
+                            line_text = str(line).rstrip("\n")
                         author_email = getattr(commit.author, "email", "unknown")
                         author_name = getattr(commit.author, "name", "unknown")
                         committed_datetime = getattr(
@@ -451,7 +476,7 @@ class GitBlameMixin:
                                 committed_datetime,
                                 hexsha,
                                 line_no,
-                                line.rstrip("\n") if line else "",
+                                line_text,
                                 rel_path,
                             )
                         )
@@ -463,40 +488,49 @@ class GitBlameMixin:
 
 class GitBlame(Base, GitBlameMixin):
     __tablename__ = "git_blame"
-    repo_id = Column(
+    repo_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("repos.id", ondelete="CASCADE"),
         primary_key=True,
         comment="foreign key for public.repos.id",
     )
-    path = Column(
+    path: Mapped[str] = mapped_column(
         Text, primary_key=True, comment="path of the file the modification was made in"
     )
-    line_no = Column(
+    line_no: Mapped[int] = mapped_column(
         Integer, primary_key=True, comment="line number of the modification"
     )
-    author_email = Column(Text, comment="email of the author who modified the line")
-    author_name = Column(Text, comment="name of the author who modified the line")
-    author_when = Column(
+    author_email: Mapped[str | None] = mapped_column(
+        Text, comment="email of the author who modified the line"
+    )
+    author_name: Mapped[str | None] = mapped_column(
+        Text, comment="name of the author who modified the line"
+    )
+    author_when: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         comment="timestamp of when the modification was authored",
     )
-    commit_hash = Column(
+    commit_hash: Mapped[str | None] = mapped_column(
         Text, comment="hash of the commit the modification was made in"
     )
-    line = Column(Text, comment="content of the line")
-    last_synced = Column(
+    line: Mapped[str | None] = mapped_column(Text, comment="content of the line")
+    last_synced: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         comment="timestamp when record was synced into the MergeStat database",
     )
 
-    # Relationships
-    repo = relationship("Repo", back_populates="git_blames")
+    repo: Mapped[Repo] = relationship("Repo", back_populates="git_blames")
 
     @classmethod
-    def process_file(cls, repo_path, filepath, repo_uuid, repo=None):
+    def process_file(
+        cls,
+        repo_path: str,
+        filepath: str,
+        repo_uuid: uuid.UUID,
+        repo: GitRepo | None = None,
+    ) -> list["GitBlame"]:
         """
         Process a file to fetch blame data and return it as a list of GitBlame objects.
 
@@ -524,57 +558,80 @@ class GitBlame(Base, GitBlameMixin):
 
 class GitPullRequest(Base):
     __tablename__ = "git_pull_requests"
-    repo_id = Column(
+    repo_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("repos.id", ondelete="CASCADE"),
         primary_key=True,
         comment="foreign key for public.repos.id",
     )
-    number = Column(Integer, primary_key=True, comment="pull request number")
-    title = Column(Text, comment="title of the pull request")
-    body = Column(Text, comment="description/body of the pull request")
-    state = Column(Text, comment="state of the pull request (open, closed, merged)")
-    author_name = Column(Text, comment="username of the author")
-    author_email = Column(Text, comment="email of the author (if available)")
-    created_at = Column(
+    number: Mapped[int] = mapped_column(
+        Integer, primary_key=True, comment="pull request number"
+    )
+    title: Mapped[str | None] = mapped_column(Text, comment="title of the pull request")
+    body: Mapped[str | None] = mapped_column(
+        Text, comment="description/body of the pull request"
+    )
+    state: Mapped[str | None] = mapped_column(
+        Text, comment="state of the pull request (open, closed, merged)"
+    )
+    author_name: Mapped[str | None] = mapped_column(
+        Text, comment="username of the author"
+    )
+    author_email: Mapped[str | None] = mapped_column(
+        Text, comment="email of the author (if available)"
+    )
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         comment="timestamp when PR was created",
     )
-    merged_at = Column(
+    merged_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         comment="timestamp when PR was merged",
     )
-    closed_at = Column(
+    closed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         comment="timestamp when PR was closed",
     )
-    head_branch = Column(Text, comment="name of the head branch")
-    base_branch = Column(Text, comment="name of the base branch")
-    additions = Column(Integer, comment="total line additions in the PR")
-    deletions = Column(Integer, comment="total line deletions in the PR")
-    changed_files = Column(Integer, comment="total number of files changed in the PR")
-    first_review_at = Column(
+    head_branch: Mapped[str | None] = mapped_column(
+        Text, comment="name of the head branch"
+    )
+    base_branch: Mapped[str | None] = mapped_column(
+        Text, comment="name of the base branch"
+    )
+    additions: Mapped[int | None] = mapped_column(
+        Integer, comment="total line additions in the PR"
+    )
+    deletions: Mapped[int | None] = mapped_column(
+        Integer, comment="total line deletions in the PR"
+    )
+    changed_files: Mapped[int | None] = mapped_column(
+        Integer, comment="total number of files changed in the PR"
+    )
+    first_review_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), comment="timestamp of the first review"
     )
-    first_comment_at = Column(
+    first_comment_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), comment="timestamp of the first comment"
     )
-    changes_requested_count = Column(
+    changes_requested_count: Mapped[int | None] = mapped_column(
         Integer, default=0, comment="number of times changes were requested"
     )
-    reviews_count = Column(Integer, default=0, comment="total number of reviews")
-    comments_count = Column(Integer, default=0, comment="total number of comments")
-    last_synced = Column(
+    reviews_count: Mapped[int | None] = mapped_column(
+        Integer, default=0, comment="total number of reviews"
+    )
+    comments_count: Mapped[int | None] = mapped_column(
+        Integer, default=0, comment="total number of comments"
+    )
+    last_synced: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         comment="timestamp when record was synced into the MergeStat database",
     )
 
-    # Relationships
-    repo = relationship("Repo", back_populates="git_pull_requests")
-    reviews = relationship(
+    repo: Mapped[Repo] = relationship("Repo", back_populates="git_pull_requests")
+    reviews: Mapped[list["GitPullRequestReview"]] = relationship(
         "GitPullRequestReview",
         primaryjoin="and_(GitPullRequest.repo_id==GitPullRequestReview.repo_id, GitPullRequest.number==GitPullRequestReview.number)",
         foreign_keys="[GitPullRequestReview.repo_id, GitPullRequestReview.number]",
@@ -585,39 +642,40 @@ class GitPullRequest(Base):
 
 class GitPullRequestReview(Base):
     __tablename__ = "git_pull_request_reviews"
-    repo_id = Column(
+    repo_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("repos.id", ondelete="CASCADE"),
         primary_key=True,
     )
-    number = Column(
+    number: Mapped[int] = mapped_column(
         Integer,
         primary_key=True,
     )
-    review_id = Column(
+    review_id: Mapped[str] = mapped_column(
         Text,
         primary_key=True,
         comment="unique identifier for the review (e.g. GitHub review ID)",
     )
-    reviewer = Column(Text, nullable=False, comment="identity of the reviewer")
-    state = Column(
+    reviewer: Mapped[str] = mapped_column(
+        Text, nullable=False, comment="identity of the reviewer"
+    )
+    state: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         comment="state of the review (APPROVED, CHANGES_REQUESTED, etc.)",
     )
-    submitted_at = Column(
+    submitted_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         comment="timestamp when review was submitted",
     )
-    last_synced = Column(
+    last_synced: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
 
-    # Relationships
-    pr = relationship(
+    pr: Mapped[GitPullRequest] = relationship(
         "GitPullRequest",
         primaryjoin="and_(GitPullRequestReview.repo_id==GitPullRequest.repo_id, GitPullRequestReview.number==GitPullRequest.number)",
         foreign_keys="[GitPullRequestReview.repo_id, GitPullRequestReview.number]",
@@ -635,69 +693,75 @@ class GitPullRequestReview(Base):
 
 class CiPipelineRun(Base):
     __tablename__ = "ci_pipeline_runs"
-    repo_id = Column(
+    repo_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("repos.id", ondelete="CASCADE"),
         primary_key=True,
     )
-    run_id = Column(Text, primary_key=True)
-    status = Column(Text)
-    queued_at = Column(DateTime(timezone=True))
-    started_at = Column(DateTime(timezone=True), nullable=False)
-    finished_at = Column(DateTime(timezone=True))
-    last_synced = Column(
+    run_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    status: Mapped[str | None] = mapped_column(Text)
+    queued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    last_synced: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
 
-    repo = relationship("Repo", back_populates="ci_pipeline_runs")
+    repo: Mapped[Repo] = relationship("Repo", back_populates="ci_pipeline_runs")
 
 
 class Deployment(Base):
     __tablename__ = "deployments"
-    repo_id = Column(
+    repo_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("repos.id", ondelete="CASCADE"),
         primary_key=True,
     )
-    deployment_id = Column(Text, primary_key=True)
-    status = Column(Text)
-    environment = Column(Text)
-    started_at = Column(DateTime(timezone=True))
-    finished_at = Column(DateTime(timezone=True))
-    deployed_at = Column(DateTime(timezone=True))
-    merged_at = Column(DateTime(timezone=True))
-    pull_request_number = Column(Integer)
-    release_ref = Column(Text, nullable=False, default="")
-    release_ref_confidence = Column(Float, nullable=False, default=0.0)
-    last_synced = Column(
+    deployment_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    status: Mapped[str | None] = mapped_column(Text)
+    environment: Mapped[str | None] = mapped_column(Text)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    deployed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    merged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    pull_request_number: Mapped[int | None] = mapped_column(Integer)
+    release_ref: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    release_ref_confidence: Mapped[float] = mapped_column(
+        Float, nullable=False, default=0.0
+    )
+    last_synced: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
 
-    repo = relationship("Repo", back_populates="deployments")
+    repo: Mapped[Repo] = relationship("Repo", back_populates="deployments")
 
 
 class Incident(Base):
     __tablename__ = "incidents"
-    repo_id = Column(
+    repo_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("repos.id", ondelete="CASCADE"),
         primary_key=True,
     )
-    incident_id = Column(Text, primary_key=True)
-    status = Column(Text)
-    started_at = Column(DateTime(timezone=True), nullable=False)
-    resolved_at = Column(DateTime(timezone=True))
-    last_synced = Column(
+    incident_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    status: Mapped[str | None] = mapped_column(Text)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    last_synced: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
 
-    repo = relationship("Repo", back_populates="incidents")
+    repo: Mapped[Repo] = relationship("Repo", back_populates="incidents")
 
 
 class SecurityAlert(Base):
@@ -708,32 +772,44 @@ class SecurityAlert(Base):
     """
 
     __tablename__ = "security_alerts"
-    repo_id = Column(
+    repo_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("repos.id", ondelete="CASCADE"),
         primary_key=True,
     )
-    alert_id = Column(Text, primary_key=True)
-    source = Column(
+    alert_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    source: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         doc="Alert source: dependabot, code_scanning, advisory, "
         "gitlab_vulnerability, gitlab_dependency",
     )
-    severity = Column(Text, doc="low, medium, high, critical, unknown")
-    state = Column(Text, doc="open, fixed, dismissed, detected, confirmed, resolved")
-    package_name = Column(Text, doc="Affected package name (if applicable)")
-    cve_id = Column(Text, doc="CVE identifier (if available)")
-    url = Column(Text, doc="URL to the alert detail page")
-    title = Column(Text, doc="Alert title or summary")
-    description = Column(Text, doc="Alert description or rule description")
-    created_at = Column(DateTime(timezone=True), nullable=False)
-    fixed_at = Column(DateTime(timezone=True))
-    dismissed_at = Column(DateTime(timezone=True))
-    last_synced = Column(
+    severity: Mapped[str | None] = mapped_column(
+        Text, doc="low, medium, high, critical, unknown"
+    )
+    state: Mapped[str | None] = mapped_column(
+        Text, doc="open, fixed, dismissed, detected, confirmed, resolved"
+    )
+    package_name: Mapped[str | None] = mapped_column(
+        Text, doc="Affected package name (if applicable)"
+    )
+    cve_id: Mapped[str | None] = mapped_column(
+        Text, doc="CVE identifier (if available)"
+    )
+    url: Mapped[str | None] = mapped_column(Text, doc="URL to the alert detail page")
+    title: Mapped[str | None] = mapped_column(Text, doc="Alert title or summary")
+    description: Mapped[str | None] = mapped_column(
+        Text, doc="Alert description or rule description"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    fixed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    dismissed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    last_synced: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
 
-    repo = relationship("Repo", back_populates="security_alerts")
+    repo: Mapped[Repo] = relationship("Repo", back_populates="security_alerts")

--- a/src/dev_health_ops/models/impersonation.py
+++ b/src/dev_health_ops/models/impersonation.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKey, String, Text
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dev_health_ops.models.git import GUID, Base
 
@@ -16,10 +17,10 @@ class ImpersonationSession(Base):
 
     __tablename__ = "impersonation_sessions"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
 
     # Admin initiating the impersonation
-    admin_user_id = Column(
+    admin_user_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("users.id", ondelete="RESTRICT"),
         nullable=False,
@@ -27,7 +28,7 @@ class ImpersonationSession(Base):
     )
 
     # Target user being impersonated
-    target_user_id = Column(
+    target_user_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("users.id", ondelete="RESTRICT"),
         nullable=False,
@@ -35,7 +36,7 @@ class ImpersonationSession(Base):
     )
 
     # Organization within which impersonation occurs
-    target_org_id = Column(
+    target_org_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("organizations.id", ondelete="RESTRICT"),
         nullable=False,
@@ -43,20 +44,24 @@ class ImpersonationSession(Base):
     )
 
     # Role type for the impersonated session
-    target_role = Column(String(50), nullable=False)
+    target_role: Mapped[str] = mapped_column(String(50), nullable=False)
 
     # Timestamps
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    expires_at = Column(DateTime(timezone=True), nullable=False)
-    ended_at = Column(DateTime(timezone=True), nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Optional client data for auditing
-    ip_address = Column(String(45), nullable=True)
-    user_agent = Column(Text, nullable=True)
+    ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Data integrity: admin cannot impersonate themselves
     __table_args__ = (

--- a/src/dev_health_ops/models/invoices.py
+++ b/src/dev_health_ops/models/invoices.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
+from typing import Any
 
 import sqlalchemy as sa
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, Integer, Text
-from sqlalchemy.orm import relationship
+from sqlalchemy import JSON, DateTime, ForeignKey, Integer, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .git import GUID, Base
 
@@ -12,35 +14,61 @@ from .git import GUID, Base
 class Invoice(Base):
     __tablename__ = "invoices"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    org_id = Column(GUID(), ForeignKey("organizations.id"), nullable=False, index=True)
-    subscription_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), ForeignKey("organizations.id"), nullable=False, index=True
+    )
+    subscription_id: Mapped[uuid.UUID | None] = mapped_column(
         GUID(),
         ForeignKey("subscriptions.id"),
         nullable=True,
         index=True,
     )
-    stripe_invoice_id = Column(Text, unique=True, nullable=False, index=True)
-    stripe_customer_id = Column(Text, nullable=False, index=True)
-    status = Column(Text, nullable=False)
-    amount_due = Column(Integer, nullable=False)
-    amount_paid = Column(Integer, server_default="0", nullable=False)
-    amount_remaining = Column(Integer, server_default="0", nullable=False)
-    currency = Column(Text, server_default="usd", nullable=False)
-    period_start = Column(DateTime(timezone=True), nullable=True)
-    period_end = Column(DateTime(timezone=True), nullable=True)
-    hosted_invoice_url = Column(Text, nullable=True)
-    pdf_url = Column(Text, nullable=True)
-    payment_intent_id = Column(Text, nullable=True)
-    finalized_at = Column(DateTime(timezone=True), nullable=True)
-    paid_at = Column(DateTime(timezone=True), nullable=True)
-    voided_at = Column(DateTime(timezone=True), nullable=True)
-    attempt_count = Column(Integer, server_default="0", nullable=False)
-    metadata_ = Column("metadata", JSON, server_default="{}", nullable=False)
-    created_at = Column(DateTime(timezone=True), server_default=sa.text("now()"))
-    updated_at = Column(DateTime(timezone=True), server_default=sa.text("now()"))
+    stripe_invoice_id: Mapped[str] = mapped_column(
+        Text, unique=True, nullable=False, index=True
+    )
+    stripe_customer_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    amount_due: Mapped[int] = mapped_column(Integer, nullable=False)
+    amount_paid: Mapped[int] = mapped_column(
+        Integer, server_default="0", nullable=False
+    )
+    amount_remaining: Mapped[int] = mapped_column(
+        Integer, server_default="0", nullable=False
+    )
+    currency: Mapped[str] = mapped_column(Text, server_default="usd", nullable=False)
+    period_start: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    period_end: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    hosted_invoice_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    pdf_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    payment_intent_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    finalized_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    paid_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    voided_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    attempt_count: Mapped[int] = mapped_column(
+        Integer, server_default="0", nullable=False
+    )
+    metadata_: Mapped[dict[str, Any]] = mapped_column(
+        "metadata", JSON, server_default="{}", nullable=False
+    )
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), server_default=sa.text("now()")
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), server_default=sa.text("now()")
+    )
 
-    line_items = relationship(
+    line_items: Mapped[list[InvoiceLineItem]] = relationship(
         "InvoiceLineItem",
         back_populates="invoice",
         cascade="all, delete-orphan",
@@ -50,19 +78,23 @@ class Invoice(Base):
 class InvoiceLineItem(Base):
     __tablename__ = "invoice_line_items"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    invoice_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    invoice_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("invoices.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    stripe_line_item_id = Column(Text, nullable=True)
-    description = Column(Text, nullable=True)
-    amount = Column(Integer, nullable=False)
-    quantity = Column(Integer, server_default="1", nullable=False)
-    period_start = Column(DateTime(timezone=True), nullable=True)
-    period_end = Column(DateTime(timezone=True), nullable=True)
-    stripe_price_id = Column(Text, nullable=True)
+    stripe_line_item_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    quantity: Mapped[int] = mapped_column(Integer, server_default="1", nullable=False)
+    period_start: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    period_end: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    stripe_price_id: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    invoice = relationship("Invoice", back_populates="line_items")
+    invoice: Mapped[Invoice] = relationship("Invoice", back_populates="line_items")

--- a/src/dev_health_ops/models/ip_allowlist.py
+++ b/src/dev_health_ops/models/ip_allowlist.py
@@ -3,56 +3,61 @@ from __future__ import annotations
 import ipaddress
 import uuid
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from sqlalchemy import (
     Boolean,
-    Column,
     DateTime,
     ForeignKey,
     Index,
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dev_health_ops.models.git import GUID, Base
+
+if TYPE_CHECKING:
+    from .users import Organization, User
 
 
 class OrgIPAllowlist(Base):
     __tablename__ = "org_ip_allowlist"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    org_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
 
-    ip_range = Column(Text, nullable=False)
-    description = Column(Text, nullable=True)
-    is_active = Column(Boolean, nullable=False, default=True)
+    ip_range: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
-    created_by_id = Column(
+    created_by_id: Mapped[uuid.UUID | None] = mapped_column(
         GUID(),
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
-    expires_at = Column(DateTime(timezone=True), nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
-    organization = relationship("Organization")
-    created_by = relationship("User")
+    organization: Mapped[Organization] = relationship("Organization")
+    created_by: Mapped[User | None] = relationship("User")
 
     __table_args__ = (
         UniqueConstraint("org_id", "ip_range", name="uq_org_ip_allowlist_org_range"),

--- a/src/dev_health_ops/models/licensing.py
+++ b/src/dev_health_ops/models/licensing.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
     JSON,
     Boolean,
-    Column,
     DateTime,
     ForeignKey,
     Index,
@@ -25,7 +25,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 # Back-compat re-exports: callers that imported these from `models.licensing`
 # pre-refactor should keep working. Canonical homes are licensing/{types,registry}.py.
@@ -37,6 +37,9 @@ from dev_health_ops.licensing.types import (
 )
 from dev_health_ops.licensing.types import LicenseTier
 from dev_health_ops.models.git import GUID, Base
+
+if TYPE_CHECKING:
+    from .users import Organization, User
 
 
 class FeatureFlag(Base):
@@ -54,59 +57,61 @@ class FeatureFlag(Base):
 
     __tablename__ = "feature_flags"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    key = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    key: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         unique=True,
         index=True,
         comment="Unique feature identifier (e.g., 'capacity_forecast', 'sso_saml')",
     )
-    name = Column(Text, nullable=False, comment="Human-readable feature name")
-    description = Column(Text, nullable=True)
-    category = Column(
+    name: Mapped[str] = mapped_column(
+        Text, nullable=False, comment="Human-readable feature name"
+    )
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    category: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         default=FeatureCategory.CORE.value,
         index=True,
     )
 
-    min_tier = Column(
+    min_tier: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         default=LicenseTier.COMMUNITY.value,
         comment="Minimum tier required to access this feature",
     )
-    is_enabled = Column(
+    is_enabled: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,
         default=True,
         comment="Global kill switch for this feature",
     )
-    is_beta = Column(
+    is_beta: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,
         default=False,
         comment="Whether this feature is in beta",
     )
-    is_deprecated = Column(
+    is_deprecated: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,
         default=False,
         comment="Whether this feature is deprecated",
     )
-    config_schema = Column(
+    config_schema: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
         comment="JSON Schema for feature-specific configuration",
     )
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
@@ -123,8 +128,8 @@ class FeatureFlag(Base):
         is_enabled: bool = True,
         is_beta: bool = False,
         is_deprecated: bool = False,
-        config_schema: dict | None = None,
-    ):
+        config_schema: dict[str, Any] | None = None,
+    ) -> None:
         self.id = uuid.uuid4()
         self.key = key
         self.name = name
@@ -156,69 +161,69 @@ class OrgFeatureOverride(Base):
 
     __tablename__ = "org_feature_overrides"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    org_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    feature_id = Column(
+    feature_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("feature_flags.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
 
-    is_enabled = Column(
+    is_enabled: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,
         default=True,
         comment="Override: True=force enable, False=force disable",
     )
-    expires_at = Column(
+    expires_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=True,
         comment="When this override expires (null = never)",
     )
-    config = Column(
+    config: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
         default=dict,
         comment="Feature-specific configuration for this org",
     )
-    reason = Column(
+    reason: Mapped[str | None] = mapped_column(
         Text,
         nullable=True,
         comment="Why this override was created (support ticket, promotion, etc.)",
     )
-    created_by = Column(
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
         GUID(),
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )
-    updated_by = Column(
+    updated_by: Mapped[uuid.UUID | None] = mapped_column(
         GUID(),
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
 
-    organization = relationship("Organization")
-    feature = relationship("FeatureFlag")
-    creator = relationship("User", foreign_keys=[created_by])
-    updater = relationship("User", foreign_keys=[updated_by])
+    organization: Mapped[Organization] = relationship("Organization")
+    feature: Mapped[FeatureFlag] = relationship("FeatureFlag")
+    creator: Mapped[User | None] = relationship("User", foreign_keys=[created_by])
+    updater: Mapped[User | None] = relationship("User", foreign_keys=[updated_by])
 
     __table_args__ = (
         UniqueConstraint("org_id", "feature_id", name="uq_org_feature_override"),
@@ -232,11 +237,11 @@ class OrgFeatureOverride(Base):
         feature_id: uuid.UUID,
         is_enabled: bool = True,
         expires_at: datetime | None = None,
-        config: dict | None = None,
+        config: dict[str, Any] | None = None,
         reason: str | None = None,
         created_by: uuid.UUID | None = None,
         updated_by: uuid.UUID | None = None,
-    ):
+    ) -> None:
         self.id = uuid.uuid4()
         self.org_id = org_id
         self.feature_id = feature_id
@@ -265,8 +270,8 @@ class OrgLicense(Base):
 
     __tablename__ = "org_licenses"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    org_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=False,
@@ -274,90 +279,90 @@ class OrgLicense(Base):
         index=True,
     )
 
-    license_key = Column(
+    license_key: Mapped[str | None] = mapped_column(
         Text,
         nullable=True,
         comment="Encrypted license key (JWT)",
     )
-    tier = Column(
+    tier: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         default=LicenseTier.COMMUNITY.value,
         comment="Decoded tier from license",
     )
-    licensed_users = Column(
+    licensed_users: Mapped[int | None] = mapped_column(
         Integer,
         nullable=True,
         comment="Max users allowed (null = unlimited)",
     )
-    licensed_repos = Column(
+    licensed_repos: Mapped[int | None] = mapped_column(
         Integer,
         nullable=True,
         comment="Max repos allowed (null = unlimited)",
     )
-    issued_at = Column(
+    issued_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=True,
         comment="When the license was issued",
     )
-    expires_at = Column(
+    expires_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=True,
         comment="When the license expires (null = never)",
     )
-    is_valid = Column(
+    is_valid: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,
         default=True,
         comment="Whether the license passed validation",
     )
-    validation_error = Column(
+    validation_error: Mapped[str | None] = mapped_column(
         Text,
         nullable=True,
         comment="Error message if validation failed",
     )
-    last_validated_at = Column(
+    last_validated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=True,
         comment="When the license was last validated",
     )
-    license_type = Column(
+    license_type: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         default="saas",
         comment="License type: saas, self-hosted, trial, evaluation",
     )
-    customer_id = Column(
+    customer_id: Mapped[str | None] = mapped_column(
         Text,
         nullable=True,
         comment="External customer ID (Stripe, etc.)",
     )
-    features_override = Column(
+    features_override: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
         default=dict,
         comment="Feature overrides encoded in license",
     )
-    limits_override = Column(
+    limits_override: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
         default=dict,
         comment="Limit overrides encoded in license",
     )
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
 
-    organization = relationship("Organization")
+    organization: Mapped[Organization] = relationship("Organization")
 
     def __init__(
         self,
@@ -370,9 +375,9 @@ class OrgLicense(Base):
         expires_at: datetime | None = None,
         license_type: str = "saas",
         customer_id: str | None = None,
-        features_override: dict | None = None,
-        limits_override: dict | None = None,
-    ):
+        features_override: dict[str, Any] | None = None,
+        limits_override: dict[str, Any] | None = None,
+    ) -> None:
         self.id = uuid.uuid4()
         self.org_id = org_id
         self.tier = tier
@@ -406,35 +411,35 @@ class TierLimit(Base):
 
     __tablename__ = "tier_limits"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    tier = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    tier: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         index=True,
         comment="Tier this limit applies to (community, team, enterprise)",
     )
-    limit_key = Column(
+    limit_key: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         comment="Limit identifier (e.g. max_repos, backfill_days)",
     )
-    limit_value = Column(
+    limit_value: Mapped[str | None] = mapped_column(
         Text,
         nullable=True,
         comment="Limit value as text (null = unlimited). Cast to int/float at read time.",
     )
-    description = Column(
+    description: Mapped[str | None] = mapped_column(
         Text,
         nullable=True,
         comment="Human-readable explanation of this limit",
     )
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
@@ -449,7 +454,7 @@ class TierLimit(Base):
         limit_key: str,
         limit_value: str | None = None,
         description: str | None = None,
-    ):
+    ) -> None:
         self.id = uuid.uuid4()
         self.tier = tier
         self.limit_key = limit_key

--- a/src/dev_health_ops/models/org_invite.py
+++ b/src/dev_health_ops/models/org_invite.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, ForeignKey, Index, Text
+from sqlalchemy import DateTime, ForeignKey, Index, Text
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dev_health_ops.models.git import GUID, Base
 
@@ -11,31 +12,39 @@ from dev_health_ops.models.git import GUID, Base
 class OrgInvite(Base):
     __tablename__ = "org_invites"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    org_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    email = Column(Text, nullable=False, index=True)
-    role = Column(Text, nullable=False, default="member")
-    token_hash = Column(Text, nullable=False, unique=True, index=True)
-    invited_by_id = Column(
+    email: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    role: Mapped[str | None] = mapped_column(Text, nullable=False, default="member")
+    token_hash: Mapped[str] = mapped_column(
+        Text, nullable=False, unique=True, index=True
+    )
+    invited_by_id: Mapped[uuid.UUID | None] = mapped_column(
         GUID(),
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
     )
-    status = Column(Text, nullable=False, default="pending", index=True)
-    expires_at = Column(DateTime(timezone=True), nullable=False)
-    accepted_at = Column(DateTime(timezone=True), nullable=True)
-    created_at = Column(
+    status: Mapped[str | None] = mapped_column(
+        Text, nullable=False, default="pending", index=True
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    accepted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         nullable=False,
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),

--- a/src/dev_health_ops/models/password_reset_token.py
+++ b/src/dev_health_ops/models/password_reset_token.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, ForeignKey, Index, Text
+from sqlalchemy import DateTime, ForeignKey, Index, Text
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dev_health_ops.models.git import GUID, Base
 
@@ -11,16 +12,20 @@ from dev_health_ops.models.git import GUID, Base
 class PasswordResetToken(Base):
     __tablename__ = "password_reset_tokens"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    user_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    token_hash = Column(Text, nullable=False, unique=True, index=True)
-    expires_at = Column(DateTime(timezone=True), nullable=False)
-    created_at = Column(
+    token_hash: Mapped[str] = mapped_column(
+        Text, nullable=False, unique=True, index=True
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         nullable=False,

--- a/src/dev_health_ops/models/refresh_token.py
+++ b/src/dev_health_ops/models/refresh_token.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, ForeignKey, Index, Text
+from sqlalchemy import DateTime, ForeignKey, Index, Text
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dev_health_ops.models.git import GUID, Base
 
@@ -15,26 +16,32 @@ class RefreshToken(Base):
 
     __tablename__ = "refresh_tokens"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    user_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    org_id = Column(
+    org_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=False,
     )
-    token_hash = Column(Text, nullable=False, unique=True, index=True)
-    family_id = Column(GUID(), nullable=False, index=True)
-    expires_at = Column(DateTime(timezone=True), nullable=False)
-    revoked_at = Column(DateTime(timezone=True), nullable=True)
-    replaced_by_hash = Column(Text, nullable=True)
-    ip_address = Column(Text, nullable=True)
-    user_agent = Column(Text, nullable=True)
-    created_at = Column(
+    token_hash: Mapped[str] = mapped_column(
+        Text, nullable=False, unique=True, index=True
+    )
+    family_id: Mapped[uuid.UUID] = mapped_column(GUID(), nullable=False, index=True)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    replaced_by_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    ip_address: Mapped[str | None] = mapped_column(Text, nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         nullable=False,

--- a/src/dev_health_ops/models/refunds.py
+++ b/src/dev_health_ops/models/refunds.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 from enum import Enum
+from typing import Any
 
 import sqlalchemy as sa
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, Integer, Text
+from sqlalchemy import JSON, DateTime, ForeignKey, Integer, Text
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dev_health_ops.models.git import GUID, Base
 
@@ -19,22 +22,36 @@ class RefundStatus(str, Enum):
 class Refund(Base):
     __tablename__ = "refunds"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    org_id = Column(GUID(), ForeignKey("organizations.id"), nullable=False, index=True)
-    invoice_id = Column(GUID(), ForeignKey("invoices.id"), nullable=True, index=True)
-    subscription_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), ForeignKey("organizations.id"), nullable=False, index=True
+    )
+    invoice_id: Mapped[uuid.UUID | None] = mapped_column(
+        GUID(), ForeignKey("invoices.id"), nullable=True, index=True
+    )
+    subscription_id: Mapped[uuid.UUID | None] = mapped_column(
         GUID(), ForeignKey("subscriptions.id"), nullable=True, index=True
     )
-    stripe_refund_id = Column(Text, unique=True, nullable=False, index=True)
-    stripe_charge_id = Column(Text, nullable=False, index=True)
-    stripe_payment_intent_id = Column(Text, nullable=True)
-    amount = Column(Integer, nullable=False)
-    currency = Column(Text, server_default="usd", nullable=False)
-    status = Column(Text, nullable=False, server_default="pending")
-    reason = Column(Text, nullable=True)
-    description = Column(Text, nullable=True)
-    failure_reason = Column(Text, nullable=True)
-    initiated_by = Column(GUID(), ForeignKey("users.id"), nullable=True)
-    metadata_ = Column("metadata", JSON, server_default="{}", nullable=False)
-    created_at = Column(DateTime(timezone=True), server_default=sa.text("now()"))
-    updated_at = Column(DateTime(timezone=True), server_default=sa.text("now()"))
+    stripe_refund_id: Mapped[str] = mapped_column(
+        Text, unique=True, nullable=False, index=True
+    )
+    stripe_charge_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    stripe_payment_intent_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    amount: Mapped[int] = mapped_column(Integer, nullable=False)
+    currency: Mapped[str] = mapped_column(Text, server_default="usd", nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default="pending")
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    failure_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    initiated_by: Mapped[uuid.UUID | None] = mapped_column(
+        GUID(), ForeignKey("users.id"), nullable=True
+    )
+    metadata_: Mapped[dict[str, Any]] = mapped_column(
+        "metadata", JSON, server_default="{}", nullable=False
+    )
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), server_default=sa.text("now()")
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), server_default=sa.text("now()")
+    )

--- a/src/dev_health_ops/models/reports.py
+++ b/src/dev_health_ops/models/reports.py
@@ -9,20 +9,23 @@ import copy
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
     JSON,
     Boolean,
-    Column,
     DateTime,
     Float,
     ForeignKey,
     Index,
     Text,
 )
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dev_health_ops.models.git import GUID, Base
+
+if TYPE_CHECKING:
+    from .settings import ScheduledJob
 
 
 class ReportRunStatus(str, Enum):
@@ -35,65 +38,77 @@ class ReportRunStatus(str, Enum):
 class SavedReport(Base):
     __tablename__ = "saved_reports"
 
-    id = Column(GUID, primary_key=True, default=uuid.uuid4)
-    org_id = Column(Text, nullable=False, index=True, server_default="")
-    name = Column(Text, nullable=False, comment="Display name for this report")
-    description = Column(Text, nullable=True)
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(
+        Text, nullable=False, index=True, server_default=""
+    )
+    name: Mapped[str] = mapped_column(
+        Text, nullable=False, comment="Display name for this report"
+    )
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    report_plan = Column(
+    report_plan: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=False,
         default=dict,
         comment="Serialized ReportPlan dataclass as JSON",
     )
 
-    is_template = Column(Boolean, nullable=False, default=False)
-    template_source_id = Column(
+    is_template: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    template_source_id: Mapped[uuid.UUID | None] = mapped_column(
         GUID,
         ForeignKey("saved_reports.id", ondelete="SET NULL"),
         nullable=True,
         comment="ID of the report this was cloned from",
     )
 
-    parameters = Column(
+    parameters: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
         default=dict,
         comment="Parameterized fields: team, repo, date_range overrides",
     )
 
-    schedule_id = Column(
+    schedule_id: Mapped[uuid.UUID | None] = mapped_column(
         GUID,
         ForeignKey("scheduled_jobs.id", ondelete="SET NULL"),
         nullable=True,
         comment="FK to scheduled_jobs for recurring execution",
     )
-    schedule = relationship("ScheduledJob", foreign_keys=[schedule_id])
+    schedule: Mapped[ScheduledJob | None] = relationship(
+        "ScheduledJob", foreign_keys=[schedule_id]
+    )
 
-    is_active = Column(Boolean, nullable=False, default=True)
-    last_run_at = Column(DateTime(timezone=True), nullable=True)
-    last_run_status = Column(Text, nullable=True, comment="Last execution status")
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    last_run_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_run_status: Mapped[str | None] = mapped_column(
+        Text, nullable=True, comment="Last execution status"
+    )
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
-    created_by = Column(Text, nullable=True, comment="User or system that created this")
+    created_by: Mapped[str | None] = mapped_column(
+        Text, nullable=True, comment="User or system that created this"
+    )
 
-    runs = relationship(
+    runs: Mapped[list[ReportRun]] = relationship(
         "ReportRun",
         back_populates="report",
         cascade="all, delete-orphan",
         lazy="raise",
     )
-    template_source = relationship(
+    template_source: Mapped[SavedReport | None] = relationship(
         "SavedReport",
         remote_side="SavedReport.id",
         foreign_keys=[template_source_id],
@@ -135,11 +150,11 @@ class SavedReport(Base):
     def clone(
         self,
         new_name: str | None = None,
-        parameter_overrides: dict | None = None,
+        parameter_overrides: dict[str, Any] | None = None,
     ) -> SavedReport:
         """Deep copy this report with a new ID. Sets template_source_id to self.id."""
         cloned_plan = copy.deepcopy(self.report_plan)
-        cloned_params = copy.deepcopy(self.parameters or {})
+        cloned_params: dict[str, Any] = copy.deepcopy(self.parameters or {})
         if parameter_overrides:
             cloned_params.update(parameter_overrides)
 
@@ -159,49 +174,55 @@ class SavedReport(Base):
 class ReportRun(Base):
     __tablename__ = "report_runs"
 
-    id = Column(GUID, primary_key=True, default=uuid.uuid4)
-    report_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    report_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("saved_reports.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    report = relationship("SavedReport", back_populates="runs")
+    report: Mapped[SavedReport] = relationship("SavedReport", back_populates="runs")
 
-    status = Column(
+    status: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         default=ReportRunStatus.PENDING.value,
     )
-    started_at = Column(DateTime(timezone=True), nullable=True)
-    completed_at = Column(DateTime(timezone=True), nullable=True)
-    duration_seconds = Column(Float, nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    duration_seconds: Mapped[float | None] = mapped_column(Float, nullable=True)
 
-    rendered_markdown = Column(Text, nullable=True, comment="Rendered report markdown")
-    artifact_url = Column(
+    rendered_markdown: Mapped[str | None] = mapped_column(
+        Text, nullable=True, comment="Rendered report markdown"
+    )
+    artifact_url: Mapped[str | None] = mapped_column(
         Text,
         nullable=True,
         comment="URL to externally stored artifact (future use)",
     )
 
-    provenance_records = Column(
+    provenance_records: Mapped[list[dict[str, Any]] | None] = mapped_column(
         JSON,
         nullable=True,
         default=list,
         comment="List of provenance records for this run",
     )
 
-    error = Column(Text, nullable=True)
-    error_traceback = Column(Text, nullable=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error_traceback: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    triggered_by = Column(
+    triggered_by: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         default="manual",
         comment="What triggered this run: scheduler, manual, api",
     )
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),

--- a/src/dev_health_ops/models/retention.py
+++ b/src/dev_health_ops/models/retention.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
+from typing import TYPE_CHECKING
 
 from sqlalchemy import (
     Boolean,
-    Column,
     DateTime,
     ForeignKey,
     Index,
@@ -15,9 +15,12 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dev_health_ops.models.git import GUID, Base
+
+if TYPE_CHECKING:
+    from .users import Organization, User
 
 
 class RetentionResourceType(str, Enum):
@@ -31,45 +34,53 @@ class RetentionResourceType(str, Enum):
 class OrgRetentionPolicy(Base):
     __tablename__ = "org_retention_policies"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    org_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
 
-    resource_type = Column(
+    resource_type: Mapped[str] = mapped_column(
         String(50),
         nullable=False,
     )
-    retention_days = Column(Integer, nullable=False, default=90)
-    description = Column(Text, nullable=True)
-    is_active = Column(Boolean, nullable=False, default=True)
+    retention_days: Mapped[int] = mapped_column(Integer, nullable=False, default=90)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
-    last_run_at = Column(DateTime(timezone=True), nullable=True)
-    last_run_deleted_count = Column(Integer, nullable=True)
-    next_run_at = Column(DateTime(timezone=True), nullable=True)
+    last_run_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_run_deleted_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    next_run_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
-    created_by_id = Column(
+    created_by_id: Mapped[uuid.UUID | None] = mapped_column(
         GUID(),
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
 
-    organization = relationship("Organization", back_populates="retention_policies")
-    created_by = relationship("User", foreign_keys=[created_by_id])
+    organization: Mapped[Organization] = relationship(
+        "Organization", back_populates="retention_policies"
+    )
+    created_by: Mapped[User | None] = relationship(
+        "User", foreign_keys=[created_by_id]
+    )
 
     __table_args__ = (
         UniqueConstraint("org_id", "resource_type", name="uq_org_retention_resource"),

--- a/src/dev_health_ops/models/settings.py
+++ b/src/dev_health_ops/models/settings.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
+from typing import Any
 
 from sqlalchemy import (
     JSON,
     Boolean,
-    Column,
     DateTime,
     ForeignKey,
     Index,
@@ -24,7 +24,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dev_health_ops.models.git import GUID, Base
 
@@ -79,19 +79,23 @@ class Setting(Base):
 
     __tablename__ = "settings"
 
-    id = Column(GUID, primary_key=True, default=uuid.uuid4)
-    org_id = Column(Text, nullable=False, index=True, server_default="")
-    category = Column(Text, nullable=False, index=True)
-    key = Column(Text, nullable=False)
-    value = Column(Text, nullable=True, comment="Setting value (may be encrypted)")
-    is_encrypted = Column(Boolean, nullable=False, default=False)
-    description = Column(Text, nullable=True)
-    created_at = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(
+        Text, nullable=False, index=True, server_default=""
+    )
+    category: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    key: Mapped[str] = mapped_column(Text, nullable=False)
+    value: Mapped[str | None] = mapped_column(
+        Text, nullable=True, comment="Setting value (may be encrypted)"
+    )
+    is_encrypted: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
@@ -113,9 +117,9 @@ class Setting(Base):
         org_id: str | None = None,
         is_encrypted: bool = False,
         description: str | None = None,
-    ):
+    ) -> None:
         self.id = uuid.uuid4()
-        self.org_id = org_id
+        self.org_id = org_id or ""
         self.category = category
         self.key = key
         self.value = value
@@ -134,35 +138,41 @@ class IntegrationCredential(Base):
 
     __tablename__ = "integration_credentials"
 
-    id = Column(GUID, primary_key=True, default=uuid.uuid4)
-    org_id = Column(Text, nullable=False, index=True, server_default="")
-    provider = Column(Text, nullable=False, index=True)
-    name = Column(Text, nullable=False, comment="Display name for this credential set")
-    is_active = Column(Boolean, nullable=False, default=True)
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(
+        Text, nullable=False, index=True, server_default=""
+    )
+    provider: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    name: Mapped[str] = mapped_column(
+        Text, nullable=False, comment="Display name for this credential set"
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
-    credentials_encrypted = Column(
+    credentials_encrypted: Mapped[str | None] = mapped_column(
         Text,
         nullable=True,
         comment="Encrypted JSON containing provider-specific credentials",
     )
 
-    config = Column(
+    config: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
         default=dict,
         comment="Non-sensitive provider configuration (base URLs, options)",
     )
 
-    last_test_at = Column(DateTime(timezone=True), nullable=True)
-    last_test_success = Column(Boolean, nullable=True)
-    last_test_error = Column(Text, nullable=True)
+    last_test_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_test_success: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    last_test_error: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
@@ -182,11 +192,11 @@ class IntegrationCredential(Base):
         name: str,
         org_id: str | None = None,
         credentials_encrypted: str | None = None,
-        config: dict | None = None,
+        config: dict[str, Any] | None = None,
         is_active: bool = True,
-    ):
+    ) -> None:
         self.id = uuid.uuid4()
-        self.org_id = org_id
+        self.org_id = org_id or ""
         self.provider = provider
         self.name = name
         self.is_active = is_active
@@ -205,68 +215,76 @@ class SyncConfiguration(Base):
 
     __tablename__ = "sync_configurations"
 
-    id = Column(GUID, primary_key=True, default=uuid.uuid4)
-    org_id = Column(Text, nullable=False, index=True, server_default="")
-    name = Column(Text, nullable=False, comment="Display name for this sync config")
-    provider = Column(Text, nullable=False, index=True)
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(
+        Text, nullable=False, index=True, server_default=""
+    )
+    name: Mapped[str] = mapped_column(
+        Text, nullable=False, comment="Display name for this sync config"
+    )
+    provider: Mapped[str] = mapped_column(Text, nullable=False, index=True)
 
-    credential_id = Column(
+    credential_id: Mapped[uuid.UUID | None] = mapped_column(
         GUID,
         ForeignKey("integration_credentials.id", ondelete="SET NULL"),
         nullable=True,
     )
-    credential = relationship("IntegrationCredential")
+    credential: Mapped[IntegrationCredential | None] = relationship(
+        "IntegrationCredential"
+    )
 
-    sync_targets = Column(
+    sync_targets: Mapped[list[str]] = mapped_column(
         JSON,
         nullable=False,
         default=list,
         comment="List of targets to sync (repos, projects, etc.)",
     )
 
-    sync_options = Column(
+    sync_options: Mapped[dict[str, Any]] = mapped_column(
         JSON,
         nullable=False,
         default=dict,
         comment="Provider-specific sync options",
     )
 
-    is_active = Column(Boolean, nullable=False, default=True)
-    last_sync_at = Column(DateTime(timezone=True), nullable=True)
-    last_sync_success = Column(Boolean, nullable=True)
-    last_sync_error = Column(Text, nullable=True)
-    last_sync_stats = Column(
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    last_sync_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_sync_success: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    last_sync_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_sync_stats: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
         comment="Stats from last sync (items synced, duration, etc.)",
     )
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
 
-    parent_id = Column(
+    parent_id: Mapped[uuid.UUID | None] = mapped_column(
         GUID,
         ForeignKey("sync_configurations.id", ondelete="CASCADE"),
         nullable=True,
         index=True,
     )
-    parent = relationship(
+    parent: Mapped[SyncConfiguration | None] = relationship(
         "SyncConfiguration",
         remote_side="SyncConfiguration.id",
         back_populates="children",
         foreign_keys=[parent_id],
         lazy="raise",
     )
-    children = relationship(
+    children: Mapped[list[SyncConfiguration]] = relationship(
         "SyncConfiguration",
         back_populates="parent",
         cascade="all, delete-orphan",
@@ -285,13 +303,13 @@ class SyncConfiguration(Base):
         provider: str,
         org_id: str | None = None,
         credential_id: uuid.UUID | None = None,
-        sync_targets: list | None = None,
-        sync_options: dict | None = None,
+        sync_targets: list[str] | None = None,
+        sync_options: dict[str, Any] | None = None,
         is_active: bool = True,
         parent_id: uuid.UUID | None = None,
-    ):
+    ) -> None:
         self.id = uuid.uuid4()
-        self.org_id = org_id
+        self.org_id = org_id or ""
         self.name = name
         self.provider = provider
         self.credential_id = credential_id
@@ -312,51 +330,63 @@ class ScheduledJob(Base):
 
     __tablename__ = "scheduled_jobs"
 
-    id = Column(GUID, primary_key=True, default=uuid.uuid4)
-    org_id = Column(Text, nullable=False, index=True, server_default="")
-    name = Column(Text, nullable=False, comment="Display name for this job")
-    job_type = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(
+        Text, nullable=False, index=True, server_default=""
+    )
+    name: Mapped[str] = mapped_column(
+        Text, nullable=False, comment="Display name for this job"
+    )
+    job_type: Mapped[str] = mapped_column(
         Text, nullable=False, index=True, comment="Type of job (sync, metrics, etc.)"
     )
 
-    schedule_cron = Column(
+    schedule_cron: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         comment="Cron expression for scheduling (e.g., '0 * * * *' for hourly)",
     )
-    timezone = Column(Text, nullable=False, default="UTC")
+    timezone: Mapped[str] = mapped_column(Text, nullable=False, default="UTC")
 
-    job_config = Column(
+    job_config: Mapped[dict[str, Any]] = mapped_column(
         JSON,
         nullable=False,
         default=dict,
         comment="Job-specific configuration",
     )
 
-    sync_config_id = Column(
+    sync_config_id: Mapped[uuid.UUID | None] = mapped_column(
         GUID,
         ForeignKey("sync_configurations.id", ondelete="SET NULL"),
         nullable=True,
     )
-    sync_config = relationship("SyncConfiguration")
+    sync_config: Mapped[SyncConfiguration | None] = relationship("SyncConfiguration")
 
-    status = Column(Integer, nullable=False, default=JobStatus.ACTIVE.value)
-    is_running = Column(Boolean, nullable=False, default=False)
+    status: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=JobStatus.ACTIVE.value
+    )
+    is_running: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
-    last_run_at = Column(DateTime(timezone=True), nullable=True)
-    last_run_status = Column(Integer, nullable=True)
-    last_run_duration_seconds = Column(Integer, nullable=True)
-    last_run_error = Column(Text, nullable=True)
-    next_run_at = Column(DateTime(timezone=True), nullable=True)
-    run_count = Column(Integer, nullable=False, default=0)
-    failure_count = Column(Integer, nullable=False, default=0)
+    last_run_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_run_status: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    last_run_duration_seconds: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
+    last_run_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    next_run_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    run_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    failure_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
@@ -375,13 +405,13 @@ class ScheduledJob(Base):
         job_type: str,
         schedule_cron: str,
         org_id: str | None = None,
-        job_config: dict | None = None,
+        job_config: dict[str, Any] | None = None,
         sync_config_id: uuid.UUID | None = None,
         tz: str = "UTC",
         status: int = JobStatus.ACTIVE.value,
-    ):
+    ) -> None:
         self.id = uuid.uuid4()
-        self.org_id = org_id
+        self.org_id = org_id or ""
         self.name = name
         self.job_type = job_type
         self.schedule_cron = schedule_cron
@@ -404,32 +434,40 @@ class JobRun(Base):
 
     __tablename__ = "job_runs"
 
-    id = Column(GUID, primary_key=True, default=uuid.uuid4)
-    job_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    job_id: Mapped[uuid.UUID] = mapped_column(
         GUID,
         ForeignKey("scheduled_jobs.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    job = relationship("ScheduledJob")
+    job: Mapped[ScheduledJob] = relationship("ScheduledJob")
 
-    status = Column(Integer, nullable=False, default=JobRunStatus.PENDING.value)
-    started_at = Column(DateTime(timezone=True), nullable=True)
-    completed_at = Column(DateTime(timezone=True), nullable=True)
-    duration_seconds = Column(Integer, nullable=True)
+    status: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=JobRunStatus.PENDING.value
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    duration_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
-    result = Column(JSON, nullable=True, comment="Job execution results/stats")
-    error = Column(Text, nullable=True)
-    error_traceback = Column(Text, nullable=True)
+    result: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, nullable=True, comment="Job execution results/stats"
+    )
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error_traceback: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    triggered_by = Column(
+    triggered_by: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         default="scheduler",
         comment="What triggered this run (scheduler, manual, webhook)",
     )
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
@@ -445,7 +483,7 @@ class JobRun(Base):
         job_id: uuid.UUID,
         triggered_by: str = "scheduler",
         status: int = JobRunStatus.PENDING.value,
-    ):
+    ) -> None:
         self.id = uuid.uuid4()
         self.job_id = job_id
         self.triggered_by = triggered_by
@@ -462,40 +500,42 @@ class IdentityMapping(Base):
 
     __tablename__ = "identity_mappings"
 
-    id = Column(GUID, primary_key=True, default=uuid.uuid4)
-    org_id = Column(Text, nullable=False, index=True, server_default="")
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(
+        Text, nullable=False, index=True, server_default=""
+    )
 
-    canonical_id = Column(
+    canonical_id: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         index=True,
         comment="Canonical identity (usually email or unique ID)",
     )
-    display_name = Column(Text, nullable=True)
-    email = Column(Text, nullable=True, index=True)
+    display_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    email: Mapped[str | None] = mapped_column(Text, nullable=True, index=True)
 
-    provider_identities = Column(
+    provider_identities: Mapped[dict[str, list[str]]] = mapped_column(
         JSON,
         nullable=False,
         default=dict,
         comment="Map of provider -> [identities] (e.g., {'github': ['user1'], 'jira': ['accountId']})",
     )
 
-    team_ids = Column(
+    team_ids: Mapped[list[str]] = mapped_column(
         JSON,
         nullable=False,
         default=list,
         comment="List of team IDs this identity belongs to",
     )
 
-    is_active = Column(Boolean, nullable=False, default=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
@@ -513,12 +553,12 @@ class IdentityMapping(Base):
         org_id: str | None = None,
         display_name: str | None = None,
         email: str | None = None,
-        provider_identities: dict | None = None,
-        team_ids: list | None = None,
+        provider_identities: dict[str, list[str]] | None = None,
+        team_ids: list[str] | None = None,
         is_active: bool = True,
-    ):
+    ) -> None:
         self.id = uuid.uuid4()
-        self.org_id = org_id
+        self.org_id = org_id or ""
         self.canonical_id = canonical_id
         self.display_name = display_name
         self.email = email
@@ -537,63 +577,67 @@ class TeamMapping(Base):
 
     __tablename__ = "team_mappings"
 
-    id = Column(GUID, primary_key=True, default=uuid.uuid4)
-    org_id = Column(Text, nullable=False, index=True, server_default="")
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(
+        Text, nullable=False, index=True, server_default=""
+    )
 
-    team_id = Column(Text, nullable=False, comment="Unique team identifier (slug)")
-    name = Column(Text, nullable=False, comment="Team display name")
-    description = Column(Text, nullable=True)
+    team_id: Mapped[str] = mapped_column(
+        Text, nullable=False, comment="Unique team identifier (slug)"
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False, comment="Team display name")
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    repo_patterns = Column(
+    repo_patterns: Mapped[list[str]] = mapped_column(
         JSON,
         nullable=False,
         default=list,
         comment="List of repo patterns (glob) this team owns",
     )
-    project_keys = Column(
+    project_keys: Mapped[list[str]] = mapped_column(
         JSON,
         nullable=False,
         default=list,
         comment="List of Jira/Linear project keys",
     )
 
-    extra_data = Column(
+    extra_data: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
         default=dict,
         comment="Additional team data (cost center, manager, etc.)",
     )
-    managed_fields = Column(
+    managed_fields: Mapped[list[str]] = mapped_column(
         JSON,
         nullable=False,
         default=list,
         comment="Fields the provider owns (e.g. name, repo_patterns)",
     )
-    sync_policy = Column(
+    sync_policy: Mapped[int] = mapped_column(
         Integer,
         nullable=False,
         default=1,
         comment="0=merge (auto-apply), 1=flag (review), 2=manual_only",
     )
-    flagged_changes = Column(
+    flagged_changes: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
         comment="Pending provider-suggested changes for admin review",
     )
-    last_drift_sync_at = Column(
+    last_drift_sync_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=True,
         comment="Last time this team was checked for drift",
     )
 
-    is_active = Column(Boolean, nullable=False, default=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
@@ -610,16 +654,16 @@ class TeamMapping(Base):
         name: str,
         org_id: str | None = None,
         description: str | None = None,
-        repo_patterns: list | None = None,
-        project_keys: list | None = None,
-        extra_data: dict | None = None,
-        managed_fields: list | None = None,
+        repo_patterns: list[str] | None = None,
+        project_keys: list[str] | None = None,
+        extra_data: dict[str, Any] | None = None,
+        managed_fields: list[str] | None = None,
         sync_policy: int = 1,
-        flagged_changes: dict | None = None,
+        flagged_changes: dict[str, Any] | None = None,
         is_active: bool = True,
-    ):
+    ) -> None:
         self.id = uuid.uuid4()
-        self.org_id = org_id
+        self.org_id = org_id or ""
         self.team_id = team_id
         self.name = name
         self.description = description
@@ -643,24 +687,24 @@ class SyncWatermark(Base):
 
     __tablename__ = "sync_watermarks"
 
-    id = Column(GUID, primary_key=True, default=uuid.uuid4)
-    org_id = Column(Text, nullable=False, server_default="")
-    repo_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    repo_id: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         comment="owner/repo for GitHub, project_id for GitLab",
     )
-    target = Column(
+    target: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         comment="Sync target: git, prs, cicd, deployments, incidents, work-items",
     )
-    last_synced_at = Column(
+    last_synced_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=True,
         comment="Timestamp of last successful sync for this target",
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
@@ -680,9 +724,9 @@ class SyncWatermark(Base):
         target: str,
         org_id: str | None = None,
         last_synced_at: datetime | None = None,
-    ):
+    ) -> None:
         self.id = uuid.uuid4()
-        self.org_id = org_id
+        self.org_id = org_id or ""
         self.repo_id = repo_id
         self.target = target
         self.last_synced_at = last_synced_at

--- a/src/dev_health_ops/models/sso.py
+++ b/src/dev_health_ops/models/sso.py
@@ -3,21 +3,23 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
     JSON,
     Boolean,
-    Column,
     DateTime,
     ForeignKey,
     Index,
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dev_health_ops.models.git import GUID, Base
+
+if TYPE_CHECKING:
+    from .users import Organization
 
 
 class SSOProtocol(str, Enum):
@@ -38,39 +40,39 @@ class SSOProviderStatus(str, Enum):
 class SSOProvider(Base):
     __tablename__ = "sso_providers"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    org_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
 
-    name = Column(Text, nullable=False)
-    protocol = Column(Text, nullable=False, index=True)
-    status = Column(
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    protocol: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    status: Mapped[str | None] = mapped_column(
         Text,
         nullable=False,
         default=SSOProviderStatus.PENDING_SETUP.value,
     )
 
     # Common SSO settings
-    is_default = Column(
+    is_default: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,
         default=False,
     )
-    allow_idp_initiated = Column(
+    allow_idp_initiated: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,
         default=False,
     )
-    auto_provision_users = Column(
+    auto_provision_users: Mapped[bool] = mapped_column(
         Boolean,
         nullable=False,
         default=True,
     )
-    default_role = Column(
+    default_role: Mapped[str] = mapped_column(
         Text,
         nullable=False,
         default="member",
@@ -97,43 +99,49 @@ class SSOProvider(Base):
     # - scopes: Requested scopes
     # - claim_mapping: Map OIDC claims to user fields
 
-    config = Column(
+    config: Mapped[dict[str, Any]] = mapped_column(
         JSON,
         nullable=False,
         default=dict,
     )
-    encrypted_secrets = Column(
+    encrypted_secrets: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
         default=dict,
     )
 
     # Domain restrictions for this provider
-    allowed_domains = Column(
+    allowed_domains: Mapped[list[str] | None] = mapped_column(
         JSON,
         nullable=True,
         default=list,
     )
 
     # Last sync/validation timestamps
-    last_metadata_sync_at = Column(DateTime(timezone=True), nullable=True)
-    last_login_at = Column(DateTime(timezone=True), nullable=True)
-    last_error = Column(Text, nullable=True)
-    last_error_at = Column(DateTime(timezone=True), nullable=True)
+    last_metadata_sync_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_login_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_error_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
 
-    organization = relationship("Organization")
+    organization: Mapped[Organization] = relationship("Organization")
 
     __table_args__ = (
         UniqueConstraint("org_id", "name", name="uq_sso_provider_org_name"),

--- a/src/dev_health_ops/models/subscriptions.py
+++ b/src/dev_health_ops/models/subscriptions.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
+from typing import Any
 
 import sqlalchemy as sa
-from sqlalchemy import JSON, Boolean, Column, DateTime, ForeignKey, Text
+from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Text
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dev_health_ops.models.git import GUID, Base
 
@@ -11,37 +14,67 @@ from dev_health_ops.models.git import GUID, Base
 class Subscription(Base):
     __tablename__ = "subscriptions"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    org_id = Column(GUID(), ForeignKey("organizations.id"), nullable=False, index=True)
-    billing_plan_id = Column(GUID(), ForeignKey("billing_plans.id"), nullable=False)
-    billing_price_id = Column(GUID(), ForeignKey("billing_prices.id"), nullable=False)
-    stripe_subscription_id = Column(Text, unique=True, nullable=False, index=True)
-    stripe_customer_id = Column(Text, nullable=False, index=True)
-    status = Column(Text, nullable=False)
-    current_period_start = Column(DateTime(timezone=True), nullable=False)
-    current_period_end = Column(DateTime(timezone=True), nullable=False)
-    cancel_at_period_end = Column(Boolean, server_default="false")
-    canceled_at = Column(DateTime(timezone=True), nullable=True)
-    trial_start = Column(DateTime(timezone=True), nullable=True)
-    trial_end = Column(DateTime(timezone=True), nullable=True)
-    metadata_ = Column("metadata", JSON, server_default="{}", nullable=False)
-    created_at = Column(DateTime(timezone=True), server_default=sa.text("now()"))
-    updated_at = Column(DateTime(timezone=True), server_default=sa.text("now()"))
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), ForeignKey("organizations.id"), nullable=False, index=True
+    )
+    billing_plan_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), ForeignKey("billing_plans.id"), nullable=False
+    )
+    billing_price_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(), ForeignKey("billing_prices.id"), nullable=False
+    )
+    stripe_subscription_id: Mapped[str] = mapped_column(
+        Text, unique=True, nullable=False, index=True
+    )
+    stripe_customer_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    current_period_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    current_period_end: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    cancel_at_period_end: Mapped[bool | None] = mapped_column(
+        Boolean, server_default="false"
+    )
+    canceled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    trial_start: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    trial_end: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    metadata_: Mapped[dict[str, Any]] = mapped_column(
+        "metadata", JSON, server_default="{}", nullable=False
+    )
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), server_default=sa.text("now()")
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), server_default=sa.text("now()")
+    )
 
 
 class SubscriptionEvent(Base):
     __tablename__ = "subscription_events"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    subscription_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    subscription_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("subscriptions.id"),
         nullable=False,
         index=True,
     )
-    stripe_event_id = Column(Text, unique=True, nullable=False)
-    event_type = Column(Text, nullable=False)
-    previous_status = Column(Text, nullable=True)
-    new_status = Column(Text, nullable=False)
-    payload = Column(JSON, server_default="{}", nullable=False)
-    processed_at = Column(DateTime(timezone=True), server_default=sa.text("now()"))
+    stripe_event_id: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)
+    previous_status: Mapped[str | None] = mapped_column(Text, nullable=True)
+    new_status: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(
+        JSON, server_default="{}", nullable=False
+    )
+    processed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), server_default=sa.text("now()")
+    )

--- a/src/dev_health_ops/models/teams.py
+++ b/src/dev_health_ops/models/teams.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import JSON, Column, DateTime, Text
+from sqlalchemy import JSON, DateTime, Text
+from sqlalchemy.orm import Mapped, mapped_column
 
 from dev_health_ops.models.git import GUID, Base
 
@@ -11,15 +12,23 @@ from dev_health_ops.models.git import GUID, Base
 class Team(Base):
     __tablename__ = "teams"
 
-    id = Column(Text, primary_key=True, comment="Unique team identifier (slug)")
-    org_id = Column(Text, nullable=False, index=True, server_default="")
-    team_uuid = Column(
+    id: Mapped[str] = mapped_column(
+        Text, primary_key=True, comment="Unique team identifier (slug)"
+    )
+    org_id: Mapped[str] = mapped_column(
+        Text, nullable=False, index=True, server_default=""
+    )
+    team_uuid: Mapped[uuid.UUID | None] = mapped_column(
         GUID, unique=True, default=uuid.uuid4, comment="Internal unique identifier"
     )
-    name = Column(Text, nullable=False, comment="Team display name")
-    description = Column(Text, nullable=True, comment="Team description")
-    members = Column(JSON, default=list, comment="List of member identities")
-    updated_at = Column(
+    name: Mapped[str] = mapped_column(Text, nullable=False, comment="Team display name")
+    description: Mapped[str | None] = mapped_column(
+        Text, nullable=True, comment="Team description"
+    )
+    members: Mapped[list[str] | None] = mapped_column(
+        JSON, default=list, comment="List of member identities"
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
@@ -47,11 +56,19 @@ class Team(Base):
 class JiraProjectOpsTeamLink(Base):
     __tablename__ = "jira_project_ops_team_links"
 
-    project_key = Column(Text, primary_key=True, comment="Jira project key")
-    ops_team_id = Column(Text, primary_key=True, comment="Atlassian Ops team ID")
-    project_name = Column(Text, nullable=False, comment="Jira project name")
-    ops_team_name = Column(Text, nullable=False, comment="Atlassian Ops team name")
-    updated_at = Column(
+    project_key: Mapped[str] = mapped_column(
+        Text, primary_key=True, comment="Jira project key"
+    )
+    ops_team_id: Mapped[str] = mapped_column(
+        Text, primary_key=True, comment="Atlassian Ops team ID"
+    )
+    project_name: Mapped[str] = mapped_column(
+        Text, nullable=False, comment="Jira project name"
+    )
+    ops_team_name: Mapped[str] = mapped_column(
+        Text, nullable=False, comment="Atlassian Ops team name"
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),

--- a/src/dev_health_ops/models/users.py
+++ b/src/dev_health_ops/models/users.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import (
     JSON,
     Boolean,
-    Column,
     DateTime,
     ForeignKey,
     Index,
@@ -25,9 +25,12 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dev_health_ops.models.git import GUID, Base
+
+if TYPE_CHECKING:
+    from .retention import OrgRetentionPolicy
 
 
 class MemberRole(str, Enum):
@@ -59,30 +62,42 @@ class User(Base):
 
     __tablename__ = "users"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    email = Column(Text, nullable=False, unique=True, index=True)
-    username = Column(Text, nullable=True, unique=True, index=True)
-    password_hash = Column(Text, nullable=True)  # Null for OAuth users
-    full_name = Column(Text, nullable=True)
-    avatar_url = Column(Text, nullable=True)
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    email: Mapped[str] = mapped_column(Text, nullable=False, unique=True, index=True)
+    username: Mapped[str | None] = mapped_column(
+        Text, nullable=True, unique=True, index=True
+    )
+    password_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    full_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    avatar_url: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Auth provider info
-    auth_provider = Column(Text, default=AuthProvider.LOCAL.value)
-    auth_provider_id = Column(Text, nullable=True)  # External provider user ID
+    auth_provider: Mapped[str | None] = mapped_column(
+        Text, default=AuthProvider.LOCAL.value
+    )
+    auth_provider_id: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Account status
-    is_active = Column(Boolean, default=True, nullable=False)
-    is_verified = Column(Boolean, default=False, nullable=False)
-    is_superuser = Column(Boolean, default=False, nullable=False)
+    is_active: Mapped[bool | None] = mapped_column(
+        Boolean, default=True, nullable=False
+    )
+    is_verified: Mapped[bool | None] = mapped_column(
+        Boolean, default=False, nullable=False
+    )
+    is_superuser: Mapped[bool | None] = mapped_column(
+        Boolean, default=False, nullable=False
+    )
 
     # Timestamps
-    last_login_at = Column(DateTime(timezone=True), nullable=True)
-    created_at = Column(
+    last_login_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         nullable=False,
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
@@ -90,7 +105,7 @@ class User(Base):
     )
 
     # Relationships
-    memberships = relationship(
+    memberships: Mapped[list[Membership]] = relationship(
         "Membership",
         back_populates="user",
         foreign_keys="Membership.user_id",
@@ -108,17 +123,23 @@ class User(Base):
 class LoginAttempt(Base):
     __tablename__ = "login_attempts"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    email = Column(Text, nullable=False, unique=True, index=True)
-    attempt_count = Column(Integer, nullable=False, default=0)
-    first_attempt_at = Column(DateTime(timezone=True), nullable=True)
-    locked_until = Column(DateTime(timezone=True), nullable=True)
-    created_at = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    email: Mapped[str] = mapped_column(Text, nullable=False, unique=True, index=True)
+    attempt_count: Mapped[int | None] = mapped_column(
+        Integer, nullable=False, default=0
+    )
+    first_attempt_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    locked_until: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         nullable=False,
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
@@ -140,28 +161,32 @@ class Organization(Base):
 
     __tablename__ = "organizations"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    slug = Column(Text, nullable=False, unique=True, index=True)
-    name = Column(Text, nullable=False)
-    description = Column(Text, nullable=True)
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    slug: Mapped[str] = mapped_column(Text, nullable=False, unique=True, index=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Organization settings (non-sensitive config)
-    settings = Column(JSON, default=dict, nullable=False)
+    settings: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, default=dict, nullable=False
+    )
 
     # Billing/tier info (for SaaS)
-    tier = Column(Text, default="community", nullable=False)
-    stripe_customer_id = Column(Text, nullable=True)
+    tier: Mapped[str | None] = mapped_column(Text, default="community", nullable=False)
+    stripe_customer_id: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Status
-    is_active = Column(Boolean, default=True, nullable=False)
+    is_active: Mapped[bool | None] = mapped_column(
+        Boolean, default=True, nullable=False
+    )
 
     # Timestamps
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         nullable=False,
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
@@ -169,12 +194,12 @@ class Organization(Base):
     )
 
     # Relationships
-    memberships = relationship(
+    memberships: Mapped[list[Membership]] = relationship(
         "Membership",
         back_populates="organization",
         cascade="all, delete-orphan",
     )
-    retention_policies = relationship(
+    retention_policies: Mapped[list[OrgRetentionPolicy]] = relationship(
         "OrgRetentionPolicy",
         back_populates="organization",
         cascade="all, delete-orphan",
@@ -194,40 +219,44 @@ class Membership(Base):
 
     __tablename__ = "memberships"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
 
-    user_id = Column(
+    user_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    org_id = Column(
+    org_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
 
-    role = Column(Text, default=MemberRole.MEMBER.value, nullable=False)
+    role: Mapped[str | None] = mapped_column(
+        Text, default=MemberRole.MEMBER.value, nullable=False
+    )
 
     # Who invited this user (optional)
-    invited_by_id = Column(
+    invited_by_id: Mapped[uuid.UUID | None] = mapped_column(
         GUID(),
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )
 
     # When the user accepted/joined
-    joined_at = Column(DateTime(timezone=True), nullable=True)
+    joined_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Timestamps
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         nullable=False,
     )
-    updated_at = Column(
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
@@ -235,16 +264,16 @@ class Membership(Base):
     )
 
     # Relationships
-    user = relationship(
+    user: Mapped[User] = relationship(
         "User",
         back_populates="memberships",
         foreign_keys=[user_id],
     )
-    organization = relationship(
+    organization: Mapped[Organization] = relationship(
         "Organization",
         back_populates="memberships",
     )
-    invited_by = relationship(
+    invited_by: Mapped[User | None] = relationship(
         "User",
         foreign_keys=[invited_by_id],
     )
@@ -267,13 +296,13 @@ class Permission(Base):
 
     __tablename__ = "permissions"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    name = Column(Text, nullable=False, unique=True, index=True)
-    description = Column(Text, nullable=True)
-    resource = Column(Text, nullable=False, index=True)
-    action = Column(Text, nullable=False)
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(Text, nullable=False, unique=True, index=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    resource: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    action: Mapped[str] = mapped_column(Text, nullable=False)
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         nullable=False,
@@ -297,22 +326,22 @@ class RolePermission(Base):
 
     __tablename__ = "role_permissions"
 
-    id = Column(GUID(), primary_key=True, default=uuid.uuid4)
-    role = Column(Text, nullable=False, index=True)
-    permission_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(GUID(), primary_key=True, default=uuid.uuid4)
+    role: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    permission_id: Mapped[uuid.UUID] = mapped_column(
         GUID(),
         ForeignKey("permissions.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
 
-    created_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         nullable=False,
     )
 
-    permission = relationship("Permission")
+    permission: Mapped[Permission] = relationship("Permission")
 
     __table_args__ = (
         UniqueConstraint("role", "permission_id", name="uq_role_permission"),


### PR DESCRIPTION
## Summary
First of 8 PRs fixing CHAOS-1386 (1,724 mypy errors). This PR fixes ~250 errors in the SQLAlchemy/Pydantic models layer.

## Changes
- Converted old-style `Column(...)` declarations to SQLAlchemy 2 typed `Mapped[T] = mapped_column(...)` per Oracle doctrine A1
- Added `[tool.mypy]` config block to pyproject.toml (per Oracle doctrine Section B)
- Added per-module overrides for missing-stub libraries (celery, atlassian, radon)

## Linear
- Closes CHAOS-1387
- Part of CHAOS-1386

## Verification
- `mypy src/dev_health_ops/models/` → 0 errors
- `ruff format --check . && ruff check .` → clean
- Targeted tests pass

## Doctrine Reference
See `.sisyphus/plans/CHAOS-1386-oracle-patterns.md` (committed in this PR if not already) for the canonical fix patterns applied.