### PR TITLE
fix(security): resolve GitHub code-scanning warnings

### DIFF
--- a/examples/batch_processing_example.py
+++ b/examples/batch_processing_example.py
@@ -122,9 +122,7 @@ async def async_main():
         return
 
     print("=== Async Batch Processing Example ===")
-    connector = GitHubConnector(token=token)
-
-    try:
+    with GitHubConnector(token=token) as connector:
         results = await connector.get_repos_with_stats_async(
             user_name="chrisgeo",
             pattern="chrisgeo/*",
@@ -139,8 +137,6 @@ async def async_main():
         successful = sum(1 for r in results if r.success)
         print(f"\nAsync processing completed: {successful}/{len(results)} successful")
 
-    finally:
-        connector.close()
 
 
 if __name__ == "__main__":

--- a/examples/batch_processing_example.py
+++ b/examples/batch_processing_example.py
@@ -138,7 +138,6 @@ async def async_main():
         print(f"\nAsync processing completed: {successful}/{len(results)} successful")
 
 
-
 if __name__ == "__main__":
     import argparse
 

--- a/examples/integration_example.py
+++ b/examples/integration_example.py
@@ -32,108 +32,106 @@ async def github_to_storage_example():
     print("=== GitHub to Storage Integration ===\n")
 
     # Initialize connector
-    connector = GitHubConnector(token=token)
+    with GitHubConnector(token=token) as connector:
 
-    try:
-        # Get a repository
-        print("Fetching repositories...")
-        repos = connector.list_repositories(max_repos=1)
+        try:
+            # Get a repository
+            print("Fetching repositories...")
+            repos = connector.list_repositories(max_repos=1)
 
-        if not repos:
-            print("No repositories found")
-            return
+            if not repos:
+                print("No repositories found")
+                return
 
-        repo = repos[0]
-        print(f"Using repository: {repo.full_name}\n")
+            repo = repos[0]
+            print(f"Using repository: {repo.full_name}\n")
 
-        # Store repository in database
-        async with SQLAlchemyStore(db_conn) as store:
-            # Create Repo object for database
-            db_repo = Repo(
-                repo_path=None,  # Not a local repo
-                repo=repo.full_name,
-                settings={"source": "github", "repo_id": repo.id},
-                tags=["github", repo.language] if repo.language else ["github"],
-            )
-
-            print(f"Storing repository: {db_repo.repo}")
-            await store.insert_repo(db_repo)
-            print(f"Repository stored with ID: {db_repo.id}\n")
-
-            # Get and store commits
-            print("Fetching commits...")
-            _, repo_name = repo.full_name.split("/")
-
-            # For demo purposes, we'll use PyGithub to get commits
-            gh_repo = connector.github.get_repo(repo.full_name)
-            commits: list[Any] = list(gh_repo.get_commits()[:5])  # Get first 5 commits
-
-            commit_objects = []
-            for commit in commits:
-                git_commit = GitCommit(
-                    repo_id=db_repo.id,
-                    hash=commit.sha,
-                    message=commit.commit.message,
-                    author_name=(
-                        commit.commit.author.name if commit.commit.author else "Unknown"
-                    ),
-                    author_email=(
-                        commit.commit.author.email if commit.commit.author else ""
-                    ),
-                    author_when=(
-                        commit.commit.author.date
-                        if commit.commit.author
-                        else datetime.now(timezone.utc)
-                    ),
-                    committer_name=(
-                        commit.commit.committer.name
-                        if commit.commit.committer
-                        else "Unknown"
-                    ),
-                    committer_email=(
-                        commit.commit.committer.email if commit.commit.committer else ""
-                    ),
-                    committer_when=(
-                        commit.commit.committer.date
-                        if commit.commit.committer
-                        else datetime.now(timezone.utc)
-                    ),
-                    parents=len(commit.parents),
+            # Store repository in database
+            async with SQLAlchemyStore(db_conn) as store:
+                # Create Repo object for database
+                db_repo = Repo(
+                    repo_path=None,  # Not a local repo
+                    repo=repo.full_name,
+                    settings={"source": "github", "repo_id": repo.id},
+                    tags=["github", repo.language] if repo.language else ["github"],
                 )
-                commit_objects.append(git_commit)
-                # Extract first line of commit message
-                first_line = commit.commit.message.split("\n")[0][:50]
-                print(f"  - {commit.sha[:8]}: {first_line}")
 
-            await store.insert_git_commit_data(commit_objects)
-            print(f"\nStored {len(commit_objects)} commits")
+                print(f"Storing repository: {db_repo.repo}")
+                await store.insert_repo(db_repo)
+                print(f"Repository stored with ID: {db_repo.id}\n")
 
-            # Get and store commit stats
-            print("\nFetching commit stats...")
-            stats_objects = []
-            for commit in commits[:3]:  # Just first 3 for demo
-                for file in commit.files:
-                    stat = GitCommitStat(
+                # Get and store commits
+                print("Fetching commits...")
+                _, repo_name = repo.full_name.split("/")
+
+                # For demo purposes, we'll use PyGithub to get commits
+                gh_repo = connector.github.get_repo(repo.full_name)
+                commits: list[Any] = list(gh_repo.get_commits()[:5])  # Get first 5 commits
+
+                commit_objects = []
+                for commit in commits:
+                    git_commit = GitCommit(
                         repo_id=db_repo.id,
-                        commit_hash=commit.sha,
-                        file_path=file.filename,
-                        additions=file.additions,
-                        deletions=file.deletions,
-                        old_file_mode="unknown",
-                        new_file_mode="unknown",
+                        hash=commit.sha,
+                        message=commit.commit.message,
+                        author_name=(
+                            commit.commit.author.name if commit.commit.author else "Unknown"
+                        ),
+                        author_email=(
+                            commit.commit.author.email if commit.commit.author else ""
+                        ),
+                        author_when=(
+                            commit.commit.author.date
+                            if commit.commit.author
+                            else datetime.now(timezone.utc)
+                        ),
+                        committer_name=(
+                            commit.commit.committer.name
+                            if commit.commit.committer
+                            else "Unknown"
+                        ),
+                        committer_email=(
+                            commit.commit.committer.email if commit.commit.committer else ""
+                        ),
+                        committer_when=(
+                            commit.commit.committer.date
+                            if commit.commit.committer
+                            else datetime.now(timezone.utc)
+                        ),
+                        parents=len(commit.parents),
                     )
-                    stats_objects.append(stat)
+                    commit_objects.append(git_commit)
+                    # Extract first line of commit message
+                    first_line = commit.commit.message.split("\n")[0][:50]
+                    print(f"  - {commit.sha[:8]}: {first_line}")
 
-            await store.insert_git_commit_stats(stats_objects)
-            print(f"Stored {len(stats_objects)} commit stats")
+                await store.insert_git_commit_data(commit_objects)
+                print(f"\nStored {len(commit_objects)} commits")
 
-    except Exception as e:
-        print(f"Error: {e}")
-        import traceback
+                # Get and store commit stats
+                print("\nFetching commit stats...")
+                stats_objects = []
+                for commit in commits[:3]:  # Just first 3 for demo
+                    for file in commit.files:
+                        stat = GitCommitStat(
+                            repo_id=db_repo.id,
+                            commit_hash=commit.sha,
+                            file_path=file.filename,
+                            additions=file.additions,
+                            deletions=file.deletions,
+                            old_file_mode="unknown",
+                            new_file_mode="unknown",
+                        )
+                        stats_objects.append(stat)
 
-        traceback.print_exc()
-    finally:
-        connector.close()
+                await store.insert_git_commit_stats(stats_objects)
+                print(f"Stored {len(stats_objects)} commit stats")
+
+        except Exception as e:
+            print(f"Error: {e}")
+            import traceback
+
+            traceback.print_exc()
 
 
 async def gitlab_to_storage_example():
@@ -149,96 +147,94 @@ async def gitlab_to_storage_example():
     print("\n\n=== GitLab to Storage Integration ===\n")
 
     # Initialize connector
-    connector = GitLabConnector(private_token=token)
+    with GitLabConnector(private_token=token) as connector:
 
-    try:
-        # Get a project
-        print("Fetching projects...")
-        projects = connector.list_projects(max_projects=1)
+        try:
+            # Get a project
+            print("Fetching projects...")
+            projects = connector.list_projects(max_projects=1)
 
-        if not projects:
-            print("No projects found")
-            return
+            if not projects:
+                print("No projects found")
+                return
 
-        project = projects[0]
-        print(f"Using project: {project.full_name}\n")
+            project = projects[0]
+            print(f"Using project: {project.full_name}\n")
 
-        # Store project in database
-        async with SQLAlchemyStore(db_conn) as store:
-            # Create Repo object for database
-            db_repo = Repo(
-                repo_path=None,  # Not a local repo
-                repo=project.full_name,
-                settings={"source": "gitlab", "project_id": project.id},
-                tags=["gitlab"],
-            )
-
-            print(f"Storing project: {db_repo.repo}")
-            await store.insert_repo(db_repo)
-            print(f"Project stored with ID: {db_repo.id}\n")
-
-            # Get and store commits
-            print("Fetching commits...")
-            gl_project = connector.gitlab.projects.get(project.id)
-            commits = gl_project.commits.list(per_page=5, get_all=False)
-
-            commit_objects = []
-            for commit in commits:
-                git_commit = GitCommit(
-                    repo_id=db_repo.id,
-                    hash=commit.id,
-                    message=commit.message,
-                    author_name=(
-                        commit.author_name
-                        if hasattr(commit, "author_name")
-                        else "Unknown"
-                    ),
-                    author_email=(
-                        commit.author_email if hasattr(commit, "author_email") else ""
-                    ),
-                    author_when=(
-                        datetime.fromisoformat(
-                            commit.authored_date.replace("Z", "+00:00")
-                        )
-                        if hasattr(commit, "authored_date")
-                        else datetime.now(timezone.utc)
-                    ),
-                    committer_name=(
-                        commit.committer_name
-                        if hasattr(commit, "committer_name")
-                        else "Unknown"
-                    ),
-                    committer_email=(
-                        commit.committer_email
-                        if hasattr(commit, "committer_email")
-                        else ""
-                    ),
-                    committer_when=(
-                        datetime.fromisoformat(
-                            commit.committed_date.replace("Z", "+00:00")
-                        )
-                        if hasattr(commit, "committed_date")
-                        else datetime.now(timezone.utc)
-                    ),
-                    parents=(
-                        len(commit.parent_ids) if hasattr(commit, "parent_ids") else 0
-                    ),
+            # Store project in database
+            async with SQLAlchemyStore(db_conn) as store:
+                # Create Repo object for database
+                db_repo = Repo(
+                    repo_path=None,  # Not a local repo
+                    repo=project.full_name,
+                    settings={"source": "gitlab", "project_id": project.id},
+                    tags=["gitlab"],
                 )
-                commit_objects.append(git_commit)
-                # Extract first line of commit message
-                first_line = commit.message.split("\n")[0][:50]
-                print(f"  - {commit.id[:8]}: {first_line}")
 
-            await store.insert_git_commit_data(commit_objects)
-            print(f"\nStored {len(commit_objects)} commits")
+                print(f"Storing project: {db_repo.repo}")
+                await store.insert_repo(db_repo)
+                print(f"Project stored with ID: {db_repo.id}\n")
 
-    except Exception as e:
-        print(f"Error: {e}")
-        import traceback
+                # Get and store commits
+                print("Fetching commits...")
+                gl_project = connector.gitlab.projects.get(project.id)
+                commits = gl_project.commits.list(per_page=5, get_all=False)
 
-        traceback.print_exc()
-    finally:
-        connector.close()
+                commit_objects = []
+                for commit in commits:
+                    git_commit = GitCommit(
+                        repo_id=db_repo.id,
+                        hash=commit.id,
+                        message=commit.message,
+                        author_name=(
+                            commit.author_name
+                            if hasattr(commit, "author_name")
+                            else "Unknown"
+                        ),
+                        author_email=(
+                            commit.author_email if hasattr(commit, "author_email") else ""
+                        ),
+                        author_when=(
+                            datetime.fromisoformat(
+                                commit.authored_date.replace("Z", "+00:00")
+                            )
+                            if hasattr(commit, "authored_date")
+                            else datetime.now(timezone.utc)
+                        ),
+                        committer_name=(
+                            commit.committer_name
+                            if hasattr(commit, "committer_name")
+                            else "Unknown"
+                        ),
+                        committer_email=(
+                            commit.committer_email
+                            if hasattr(commit, "committer_email")
+                            else ""
+                        ),
+                        committer_when=(
+                            datetime.fromisoformat(
+                                commit.committed_date.replace("Z", "+00:00")
+                            )
+                            if hasattr(commit, "committed_date")
+                            else datetime.now(timezone.utc)
+                        ),
+                        parents=(
+                            len(commit.parent_ids) if hasattr(commit, "parent_ids") else 0
+                        ),
+                    )
+                    commit_objects.append(git_commit)
+                    # Extract first line of commit message
+                    first_line = commit.message.split("\n")[0][:50]
+                    print(f"  - {commit.id[:8]}: {first_line}")
+
+                await store.insert_git_commit_data(commit_objects)
+                print(f"\nStored {len(commit_objects)} commits")
+
+        except Exception as e:
+            print(f"Error: {e}")
+            import traceback
+
+            traceback.print_exc()
 
 
 async def main():

--- a/examples/integration_example.py
+++ b/examples/integration_example.py
@@ -33,7 +33,6 @@ async def github_to_storage_example():
 
     # Initialize connector
     with GitHubConnector(token=token) as connector:
-
         try:
             # Get a repository
             print("Fetching repositories...")
@@ -66,7 +65,9 @@ async def github_to_storage_example():
 
                 # For demo purposes, we'll use PyGithub to get commits
                 gh_repo = connector.github.get_repo(repo.full_name)
-                commits: list[Any] = list(gh_repo.get_commits()[:5])  # Get first 5 commits
+                commits: list[Any] = list(
+                    gh_repo.get_commits()[:5]
+                )  # Get first 5 commits
 
                 commit_objects = []
                 for commit in commits:
@@ -75,7 +76,9 @@ async def github_to_storage_example():
                         hash=commit.sha,
                         message=commit.commit.message,
                         author_name=(
-                            commit.commit.author.name if commit.commit.author else "Unknown"
+                            commit.commit.author.name
+                            if commit.commit.author
+                            else "Unknown"
                         ),
                         author_email=(
                             commit.commit.author.email if commit.commit.author else ""
@@ -91,7 +94,9 @@ async def github_to_storage_example():
                             else "Unknown"
                         ),
                         committer_email=(
-                            commit.commit.committer.email if commit.commit.committer else ""
+                            commit.commit.committer.email
+                            if commit.commit.committer
+                            else ""
                         ),
                         committer_when=(
                             commit.commit.committer.date
@@ -148,7 +153,6 @@ async def gitlab_to_storage_example():
 
     # Initialize connector
     with GitLabConnector(private_token=token) as connector:
-
         try:
             # Get a project
             print("Fetching projects...")
@@ -192,7 +196,9 @@ async def gitlab_to_storage_example():
                             else "Unknown"
                         ),
                         author_email=(
-                            commit.author_email if hasattr(commit, "author_email") else ""
+                            commit.author_email
+                            if hasattr(commit, "author_email")
+                            else ""
                         ),
                         author_when=(
                             datetime.fromisoformat(
@@ -219,7 +225,9 @@ async def gitlab_to_storage_example():
                             else datetime.now(timezone.utc)
                         ),
                         parents=(
-                            len(commit.parent_ids) if hasattr(commit, "parent_ids") else 0
+                            len(commit.parent_ids)
+                            if hasattr(commit, "parent_ids")
+                            else 0
                         ),
                     )
                     commit_objects.append(git_commit)

--- a/examples/private_repo_example.py
+++ b/examples/private_repo_example.py
@@ -57,7 +57,6 @@ def test_github_private_repo():
     print(f"Using token: {token[:10]}...")
 
     with GitHubConnector(token=token) as connector:
-
         try:
             # Test 1: List user's repositories (should include private ones)
             print("\n1. Listing user's repositories...")
@@ -71,8 +70,12 @@ def test_github_private_repo():
                     break
 
             if not found:
-                print(f"   ⚠️  Private repository {private_repo} not found in user's repos")
-                print("   This might mean the token doesn't have access to this repository")
+                print(
+                    f"   ⚠️  Private repository {private_repo} not found in user's repos"
+                )
+                print(
+                    "   This might mean the token doesn't have access to this repository"
+                )
 
             # Test 2: Get repository statistics
             print("\n2. Fetching repository statistics...")
@@ -84,7 +87,9 @@ def test_github_private_repo():
 
             # Test 3: Get contributors
             print("\n3. Fetching contributors...")
-            contributors = connector.get_contributors(owner, repo_name, max_contributors=5)
+            contributors = connector.get_contributors(
+                owner, repo_name, max_contributors=5
+            )
             print(f"   ✅ Found {len(contributors)} contributors")
             for contributor in contributors[:3]:
                 print(f"      - {contributor.username}")
@@ -121,7 +126,6 @@ def test_github_private_repo():
             return False
 
 
-
 def test_gitlab_private_project():
     """Test accessing a GitLab private project."""
     print("\n" + "=" * 70)
@@ -149,7 +153,6 @@ def test_gitlab_private_project():
     print(f"Using token: {token[:10]}...")
 
     with GitLabConnector(url=gitlab_url, private_token=token) as connector:
-
         try:
             # Test 1: Get project details
             print("\n1. Fetching project details...")
@@ -208,7 +211,9 @@ def test_gitlab_private_project():
             # Test 4: List user's projects (should include private ones)
             print("\n4. Listing accessible projects...")
             projects = connector.list_projects(max_projects=10)
-            print(f"   ✅ Found {len(projects)} accessible projects (may include private)")
+            print(
+                f"   ✅ Found {len(projects)} accessible projects (may include private)"
+            )
 
             print("\n✅ Successfully accessed private GitLab project!")
             return True
@@ -234,7 +239,6 @@ def test_gitlab_private_project():
             print(f"\n❌ Unexpected error: {e}")
             traceback.print_exc()
             return False
-
 
 
 def main():

--- a/examples/private_repo_example.py
+++ b/examples/private_repo_example.py
@@ -56,72 +56,70 @@ def test_github_private_repo():
     print(f"\nAttempting to access private repository: {private_repo}")
     print(f"Using token: {token[:10]}...")
 
-    connector = GitHubConnector(token=token)
+    with GitHubConnector(token=token) as connector:
 
-    try:
-        # Test 1: List user's repositories (should include private ones)
-        print("\n1. Listing user's repositories...")
-        repos = connector.list_repositories(user_name=owner, max_repos=50)
+        try:
+            # Test 1: List user's repositories (should include private ones)
+            print("\n1. Listing user's repositories...")
+            repos = connector.list_repositories(user_name=owner, max_repos=50)
 
-        found = False
-        for repo in repos:
-            if repo.full_name == private_repo:
-                found = True
-                print(f"   ✅ Found private repository: {repo.full_name}")
-                break
+            found = False
+            for repo in repos:
+                if repo.full_name == private_repo:
+                    found = True
+                    print(f"   ✅ Found private repository: {repo.full_name}")
+                    break
 
-        if not found:
-            print(f"   ⚠️  Private repository {private_repo} not found in user's repos")
-            print("   This might mean the token doesn't have access to this repository")
+            if not found:
+                print(f"   ⚠️  Private repository {private_repo} not found in user's repos")
+                print("   This might mean the token doesn't have access to this repository")
 
-        # Test 2: Get repository statistics
-        print("\n2. Fetching repository statistics...")
-        stats = connector.get_repo_stats(owner, repo_name, max_commits=10)
-        print(f"   ✅ Total commits: {stats.total_commits}")
-        print(f"   ✅ Total additions: {stats.additions}")
-        print(f"   ✅ Total deletions: {stats.deletions}")
-        print(f"   ✅ Authors: {len(stats.authors)}")
+            # Test 2: Get repository statistics
+            print("\n2. Fetching repository statistics...")
+            stats = connector.get_repo_stats(owner, repo_name, max_commits=10)
+            print(f"   ✅ Total commits: {stats.total_commits}")
+            print(f"   ✅ Total additions: {stats.additions}")
+            print(f"   ✅ Total deletions: {stats.deletions}")
+            print(f"   ✅ Authors: {len(stats.authors)}")
 
-        # Test 3: Get contributors
-        print("\n3. Fetching contributors...")
-        contributors = connector.get_contributors(owner, repo_name, max_contributors=5)
-        print(f"   ✅ Found {len(contributors)} contributors")
-        for contributor in contributors[:3]:
-            print(f"      - {contributor.username}")
+            # Test 3: Get contributors
+            print("\n3. Fetching contributors...")
+            contributors = connector.get_contributors(owner, repo_name, max_contributors=5)
+            print(f"   ✅ Found {len(contributors)} contributors")
+            for contributor in contributors[:3]:
+                print(f"      - {contributor.username}")
 
-        # Test 4: Check rate limit
-        print("\n4. Checking rate limit...")
-        rate_limit = connector.get_rate_limit()
-        print(
-            f"   ✅ Rate limit: {rate_limit['remaining']}/{rate_limit['limit']} remaining"
-        )
-
-        print("\n✅ Successfully accessed private GitHub repository!")
-        return True
-
-    except AuthenticationException as e:
-        print(f"\n❌ Authentication failed: {e}")
-        print("   Make sure your GITHUB_TOKEN has the 'repo' scope")
-        print("   Go to https://github.com/settings/tokens to verify")
-        return False
-
-    except APIException as e:
-        if "404" in str(e):
-            print(f"\n❌ Repository not found: {e}")
+            # Test 4: Check rate limit
+            print("\n4. Checking rate limit...")
+            rate_limit = connector.get_rate_limit()
             print(
-                "   Either the repository doesn't exist or your token doesn't have access"
+                f"   ✅ Rate limit: {rate_limit['remaining']}/{rate_limit['limit']} remaining"
             )
-        else:
-            print(f"\n❌ API error: {e}")
-        return False
 
-    except Exception as e:
-        print(f"\n❌ Unexpected error: {e}")
-        traceback.print_exc()
-        return False
+            print("\n✅ Successfully accessed private GitHub repository!")
+            return True
 
-    finally:
-        connector.close()
+        except AuthenticationException as e:
+            print(f"\n❌ Authentication failed: {e}")
+            print("   Make sure your GITHUB_TOKEN has the 'repo' scope")
+            print("   Go to https://github.com/settings/tokens to verify")
+            return False
+
+        except APIException as e:
+            if "404" in str(e):
+                print(f"\n❌ Repository not found: {e}")
+                print(
+                    "   Either the repository doesn't exist or your token doesn't have access"
+                )
+            else:
+                print(f"\n❌ API error: {e}")
+            return False
+
+        except Exception as e:
+            print(f"\n❌ Unexpected error: {e}")
+            traceback.print_exc()
+            return False
+
 
 
 def test_gitlab_private_project():
@@ -150,95 +148,93 @@ def test_gitlab_private_project():
     print(f"GitLab URL: {gitlab_url}")
     print(f"Using token: {token[:10]}...")
 
-    connector = GitLabConnector(url=gitlab_url, private_token=token)
+    with GitLabConnector(url=gitlab_url, private_token=token) as connector:
 
-    try:
-        # Test 1: Get project details
-        print("\n1. Fetching project details...")
         try:
-            # Direct python-gitlab API call to verify basic access
-            project = connector.gitlab.projects.get(private_project)
-            print(f"   ✅ Found project: {project.name}")
+            # Test 1: Get project details
+            print("\n1. Fetching project details...")
+            try:
+                # Direct python-gitlab API call to verify basic access
+                project = connector.gitlab.projects.get(private_project)
+                print(f"   ✅ Found project: {project.name}")
+                print(
+                    f"   ✅ Full path: {project.path_with_namespace if hasattr(project, 'path_with_namespace') else 'N/A'}"
+                )
+            except Exception as e:
+                # python-gitlab can raise various exceptions depending on the error
+                print(f"   ❌ Failed to access project: {e}")
+                return False
+
+            # Determine project identifier for subsequent calls
+            project_identifier = private_project
+
+            # Test 2: Get project statistics
+            print("\n2. Fetching project statistics...")
+            try:
+                stats = connector.get_repo_stats_by_project(
+                    project_name=project_identifier, max_commits=10
+                )
+            except Exception:
+                if str(private_project).isdigit():
+                    stats = connector.get_repo_stats_by_project(
+                        project_id=int(private_project), max_commits=10
+                    )
+                else:
+                    raise
+
+            print(f"   ✅ Total commits: {stats.total_commits}")
+            print(f"   ✅ Total additions: {stats.additions}")
+            print(f"   ✅ Total deletions: {stats.deletions}")
+            print(f"   ✅ Authors: {len(stats.authors)}")
+
+            # Test 3: Get contributors
+            print("\n3. Fetching contributors...")
+            try:
+                contributors = connector.get_contributors_by_project(
+                    project_name=project_identifier, max_contributors=5
+                )
+            except Exception:
+                if str(private_project).isdigit():
+                    contributors = connector.get_contributors_by_project(
+                        project_id=int(private_project), max_contributors=5
+                    )
+                else:
+                    raise
+
+            print(f"   ✅ Found {len(contributors)} contributors")
+            for contributor in contributors[:3]:
+                print(f"      - {contributor.username}")
+
+            # Test 4: List user's projects (should include private ones)
+            print("\n4. Listing accessible projects...")
+            projects = connector.list_projects(max_projects=10)
+            print(f"   ✅ Found {len(projects)} accessible projects (may include private)")
+
+            print("\n✅ Successfully accessed private GitLab project!")
+            return True
+
+        except AuthenticationException as e:
+            print(f"\n❌ Authentication failed: {e}")
             print(
-                f"   ✅ Full path: {project.path_with_namespace if hasattr(project, 'path_with_namespace') else 'N/A'}"
+                "   Make sure your GITLAB_TOKEN has 'read_api' and 'read_repository' scopes"
             )
-        except Exception as e:
-            # python-gitlab can raise various exceptions depending on the error
-            print(f"   ❌ Failed to access project: {e}")
             return False
 
-        # Determine project identifier for subsequent calls
-        project_identifier = private_project
-
-        # Test 2: Get project statistics
-        print("\n2. Fetching project statistics...")
-        try:
-            stats = connector.get_repo_stats_by_project(
-                project_name=project_identifier, max_commits=10
-            )
-        except Exception:
-            if str(private_project).isdigit():
-                stats = connector.get_repo_stats_by_project(
-                    project_id=int(private_project), max_commits=10
+        except APIException as e:
+            if "404" in str(e):
+                print(f"\n❌ Project not found: {e}")
+                print(
+                    "   Either the project doesn't exist or your token doesn't have access"
                 )
             else:
-                raise
+                print(f"\n❌ API error: {e}")
+            return False
 
-        print(f"   ✅ Total commits: {stats.total_commits}")
-        print(f"   ✅ Total additions: {stats.additions}")
-        print(f"   ✅ Total deletions: {stats.deletions}")
-        print(f"   ✅ Authors: {len(stats.authors)}")
+        except Exception as e:
+            print(f"\n❌ Unexpected error: {e}")
+            traceback.print_exc()
+            return False
 
-        # Test 3: Get contributors
-        print("\n3. Fetching contributors...")
-        try:
-            contributors = connector.get_contributors_by_project(
-                project_name=project_identifier, max_contributors=5
-            )
-        except Exception:
-            if str(private_project).isdigit():
-                contributors = connector.get_contributors_by_project(
-                    project_id=int(private_project), max_contributors=5
-                )
-            else:
-                raise
-
-        print(f"   ✅ Found {len(contributors)} contributors")
-        for contributor in contributors[:3]:
-            print(f"      - {contributor.username}")
-
-        # Test 4: List user's projects (should include private ones)
-        print("\n4. Listing accessible projects...")
-        projects = connector.list_projects(max_projects=10)
-        print(f"   ✅ Found {len(projects)} accessible projects (may include private)")
-
-        print("\n✅ Successfully accessed private GitLab project!")
-        return True
-
-    except AuthenticationException as e:
-        print(f"\n❌ Authentication failed: {e}")
-        print(
-            "   Make sure your GITLAB_TOKEN has 'read_api' and 'read_repository' scopes"
-        )
-        return False
-
-    except APIException as e:
-        if "404" in str(e):
-            print(f"\n❌ Project not found: {e}")
-            print(
-                "   Either the project doesn't exist or your token doesn't have access"
-            )
-        else:
-            print(f"\n❌ API error: {e}")
-        return False
-
-    except Exception as e:
-        print(f"\n❌ Unexpected error: {e}")
-        traceback.print_exc()
-        return False
-
-    finally:
-        connector.close()
 
 
 def main():

--- a/src/dev_health_ops/api/services/settings.py
+++ b/src/dev_health_ops/api/services/settings.py
@@ -710,8 +710,7 @@ class TeamDiscoveryService:
             from dev_health_ops.providers.linear.client import LinearAuth, LinearClient
 
             DiscoveredTeam = _get_discovered_team_cls()
-            client = LinearClient(auth=LinearAuth(api_key=api_key))
-            try:
+            with LinearClient(auth=LinearAuth(api_key=api_key)) as client:
                 teams: list[Any] = []
                 for team in client.iter_teams():
                     teams.append(
@@ -724,8 +723,6 @@ class TeamDiscoveryService:
                         )
                     )
                 return teams
-            finally:
-                client.close()
 
         return await asyncio.to_thread(_discover)
 

--- a/src/dev_health_ops/connectors/launchdarkly.py
+++ b/src/dev_health_ops/connectors/launchdarkly.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import httpx
 
+from dev_health_ops.api.utils.logging import sanitize_for_log
 from dev_health_ops.connectors.exceptions import (
     APIException,
     AuthenticationException,
@@ -131,7 +132,7 @@ class LaunchDarklyConnector:
                         logger.warning(
                             "LaunchDarkly %d on %s (attempt %d/%d), retrying in %.1fs",
                             response.status_code,
-                            path,
+                            sanitize_for_log(path),
                             attempt + 1,
                             self.max_retries,
                             retry_after,
@@ -149,7 +150,7 @@ class LaunchDarklyConnector:
                 if attempt < self.max_retries - 1:
                     logger.warning(
                         "LaunchDarkly request to %s failed (attempt %d/%d): %s",
-                        path,
+                        sanitize_for_log(path),
                         attempt + 1,
                         self.max_retries,
                         exc,
@@ -194,7 +195,7 @@ class LaunchDarklyConnector:
             if len(all_items) >= total or len(items) < limit:
                 break
             offset += limit
-        logger.info("Fetched %d flags for project %s", len(all_items), key)
+        logger.info("Fetched %d flags for project %s", len(all_items), sanitize_for_log(key))
         return all_items
 
     async def get_audit_log(

--- a/src/dev_health_ops/connectors/launchdarkly.py
+++ b/src/dev_health_ops/connectors/launchdarkly.py
@@ -195,7 +195,9 @@ class LaunchDarklyConnector:
             if len(all_items) >= total or len(items) < limit:
                 break
             offset += limit
-        logger.info("Fetched %d flags for project %s", len(all_items), sanitize_for_log(key))
+        logger.info(
+            "Fetched %d flags for project %s", len(all_items), sanitize_for_log(key)
+        )
         return all_items
 
     async def get_audit_log(

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -908,196 +908,197 @@ async def process_github_repo(
         else GitHubConnector(token=token)
     )
     try:
-        # 1. Fetch Repo Info
-        logging.info("Fetching repository information...")
-        gh_repo = await loop.run_in_executor(
-            None, _fetch_github_repo_info_sync, connector, owner, repo_name
-        )
-
-        # Create/Insert Repo
-        repo_info = Repository(
-            id=gh_repo.id,
-            name=gh_repo.name,
-            full_name=gh_repo.full_name,
-            default_branch=gh_repo.default_branch,
-            description=gh_repo.description,
-            url=gh_repo.html_url,
-            created_at=gh_repo.created_at,
-            updated_at=gh_repo.updated_at,
-            language=gh_repo.language,
-            stars=gh_repo.stargazers_count,
-            forks=gh_repo.forks_count,
-        )
-
-        db_repo = Repo(
-            repo_path=None,
-            repo=repo_info.full_name,
-            provider="github",
-            settings={
-                "source": "github",
-                "repo_id": repo_info.id,
-                "url": repo_info.url,
-                "default_branch": repo_info.default_branch,
-            },
-            tags=[
-                "github",
-                repo_info.language,
-            ]
-            if repo_info.language
-            else ["github"],
-        )
-
-        await ingestion_sink.insert_repo(db_repo)
-        logging.info(f"Repository stored: {db_repo.repo} ({db_repo.id})")
-
-        if blame_only:
-            await _backfill_github_missing_data(
-                store=store,
-                ingestion_sink=ingestion_sink,
-                connector=connector,
-                db_repo=db_repo,
-                repo_full_name=repo_info.full_name,
-                default_branch=repo_info.default_branch,
-                max_commits=max_commits,
-                blame_only=True,
-            )
-            logging.info(
-                "Completed blame-only sync for GitHub repository: %s/%s",
-                owner,
-                repo_name,
-            )
-            return
-
-        if sync_git:
-            # 2. Fetch Commits
-            if max_commits is None:
-                logging.info("Fetching all commits from GitHub...")
-            else:
-                logging.info(f"Fetching up to {max_commits} commits from GitHub...")
-            raw_commits, commit_objects = await loop.run_in_executor(
-                None,
-                _fetch_github_commits_sync,
-                gh_repo,
-                max_commits,
-                db_repo.id,
-                since,
+        with connector:
+            # 1. Fetch Repo Info
+            logging.info("Fetching repository information...")
+            gh_repo = await loop.run_in_executor(
+                None, _fetch_github_repo_info_sync, connector, owner, repo_name
             )
 
-            if commit_objects:
-                await ingestion_sink.insert_git_commit_data(commit_objects)
-                logging.info(f"Stored {len(commit_objects)} commits from GitHub")
-
-            # 3. Fetch Stats
-            logging.info("Fetching commit stats from GitHub...")
-            stats_limit = 50 if max_commits is None else min(max_commits, 50)
-            stats_objects = await loop.run_in_executor(
-                None,
-                _fetch_github_commit_stats_sync,
-                raw_commits,
-                db_repo.id,
-                stats_limit,
-                since,
+            # Create/Insert Repo
+            repo_info = Repository(
+                id=gh_repo.id,
+                name=gh_repo.name,
+                full_name=gh_repo.full_name,
+                default_branch=gh_repo.default_branch,
+                description=gh_repo.description,
+                url=gh_repo.html_url,
+                created_at=gh_repo.created_at,
+                updated_at=gh_repo.updated_at,
+                language=gh_repo.language,
+                stars=gh_repo.stargazers_count,
+                forks=gh_repo.forks_count,
             )
 
-            if stats_objects:
-                await ingestion_sink.insert_git_commit_stats(stats_objects)
+            db_repo = Repo(
+                repo_path=None,
+                repo=repo_info.full_name,
+                provider="github",
+                settings={
+                    "source": "github",
+                    "repo_id": repo_info.id,
+                    "url": repo_info.url,
+                    "default_branch": repo_info.default_branch,
+                },
+                tags=[
+                    "github",
+                    repo_info.language,
+                ]
+                if repo_info.language
+                else ["github"],
+            )
+
+            await ingestion_sink.insert_repo(db_repo)
+            logging.info(f"Repository stored: {db_repo.repo} ({db_repo.id})")
+
+            if blame_only:
+                await _backfill_github_missing_data(
+                    store=store,
+                    ingestion_sink=ingestion_sink,
+                    connector=connector,
+                    db_repo=db_repo,
+                    repo_full_name=repo_info.full_name,
+                    default_branch=repo_info.default_branch,
+                    max_commits=max_commits,
+                    blame_only=True,
+                )
                 logging.info(
-                    "Stored %d commit stats from GitHub",
-                    len(stats_objects),
+                    "Completed blame-only sync for GitHub repository: %s/%s",
+                    owner,
+                    repo_name,
+                )
+                return
+
+            if sync_git:
+                # 2. Fetch Commits
+                if max_commits is None:
+                    logging.info("Fetching all commits from GitHub...")
+                else:
+                    logging.info(f"Fetching up to {max_commits} commits from GitHub...")
+                raw_commits, commit_objects = await loop.run_in_executor(
+                    None,
+                    _fetch_github_commits_sync,
+                    gh_repo,
+                    max_commits,
+                    db_repo.id,
+                    since,
                 )
 
-        if sync_prs:
-            # 4. Fetch PRs
-            logging.info("Fetching pull requests from GitHub...")
-            pr_total = await loop.run_in_executor(
-                None,
-                _sync_github_prs_to_store,
-                connector,
-                owner,
-                repo_name,
-                db_repo.id,
-                ingestion_sink,
-                loop,
-                BATCH_SIZE,
-                "all",
-                None,
-                since,
-            )
-            logging.info(f"Stored {pr_total} pull requests from GitHub")
+                if commit_objects:
+                    await ingestion_sink.insert_git_commit_data(commit_objects)
+                    logging.info(f"Stored {len(commit_objects)} commits from GitHub")
 
-        if sync_cicd:
-            logging.info("Fetching CI/CD workflow runs from GitHub...")
-            pipeline_runs = await loop.run_in_executor(
-                None,
-                _fetch_github_workflow_runs_sync,
-                gh_repo,
-                db_repo.id,
-                BATCH_SIZE,
-                since,
-            )
-            if pipeline_runs:
-                await ingestion_sink.insert_ci_pipeline_runs(pipeline_runs)
-                logging.info("Stored %d workflow runs", len(pipeline_runs))
-
-        if sync_deployments:
-            logging.info("Fetching deployments from GitHub...")
-            deployments = await loop.run_in_executor(
-                None,
-                _fetch_github_deployments_sync,
-                gh_repo,
-                db_repo.id,
-                BATCH_SIZE,
-                since,
-            )
-            if deployments:
-                await ingestion_sink.insert_deployments(deployments)
-                logging.info("Stored %d deployments", len(deployments))
-
-        if sync_incidents:
-            logging.info("Fetching incident issues from GitHub...")
-            incidents = await loop.run_in_executor(
-                None,
-                _fetch_github_incidents_sync,
-                gh_repo,
-                db_repo.id,
-                BATCH_SIZE,
-                since,
-            )
-            if incidents:
-                await ingestion_sink.insert_incidents(incidents)
-                logging.info("Stored %d incidents", len(incidents))
-
-        if sync_security:
-            logging.info("Fetching security alerts from GitHub...")
-            security_alerts = await loop.run_in_executor(
-                None,
-                _fetch_github_security_alerts_sync,
-                connector,
-                owner,
-                repo_name,
-                db_repo.id,
-                BATCH_SIZE,
-                since,
-            )
-            if security_alerts:
-                insert_security_alerts = getattr(
-                    ingestion_sink, "insert_security_alerts"
+                # 3. Fetch Stats
+                logging.info("Fetching commit stats from GitHub...")
+                stats_limit = 50 if max_commits is None else min(max_commits, 50)
+                stats_objects = await loop.run_in_executor(
+                    None,
+                    _fetch_github_commit_stats_sync,
+                    raw_commits,
+                    db_repo.id,
+                    stats_limit,
+                    since,
                 )
-                await insert_security_alerts(security_alerts)
-                logging.info("Stored %d security alerts", len(security_alerts))
 
-        # 5. Fetch Blame (Optional & Stubbed)
-        if fetch_blame:
-            logging.info("Fetching blame data (file list) from GitHub...")
-            await loop.run_in_executor(
-                None, _fetch_github_blame_sync, gh_repo, db_repo.id
+                if stats_objects:
+                    await ingestion_sink.insert_git_commit_stats(stats_objects)
+                    logging.info(
+                        "Stored %d commit stats from GitHub",
+                        len(stats_objects),
+                    )
+
+            if sync_prs:
+                # 4. Fetch PRs
+                logging.info("Fetching pull requests from GitHub...")
+                pr_total = await loop.run_in_executor(
+                    None,
+                    _sync_github_prs_to_store,
+                    connector,
+                    owner,
+                    repo_name,
+                    db_repo.id,
+                    ingestion_sink,
+                    loop,
+                    BATCH_SIZE,
+                    "all",
+                    None,
+                    since,
+                )
+                logging.info(f"Stored {pr_total} pull requests from GitHub")
+
+            if sync_cicd:
+                logging.info("Fetching CI/CD workflow runs from GitHub...")
+                pipeline_runs = await loop.run_in_executor(
+                    None,
+                    _fetch_github_workflow_runs_sync,
+                    gh_repo,
+                    db_repo.id,
+                    BATCH_SIZE,
+                    since,
+                )
+                if pipeline_runs:
+                    await ingestion_sink.insert_ci_pipeline_runs(pipeline_runs)
+                    logging.info("Stored %d workflow runs", len(pipeline_runs))
+
+            if sync_deployments:
+                logging.info("Fetching deployments from GitHub...")
+                deployments = await loop.run_in_executor(
+                    None,
+                    _fetch_github_deployments_sync,
+                    gh_repo,
+                    db_repo.id,
+                    BATCH_SIZE,
+                    since,
+                )
+                if deployments:
+                    await ingestion_sink.insert_deployments(deployments)
+                    logging.info("Stored %d deployments", len(deployments))
+
+            if sync_incidents:
+                logging.info("Fetching incident issues from GitHub...")
+                incidents = await loop.run_in_executor(
+                    None,
+                    _fetch_github_incidents_sync,
+                    gh_repo,
+                    db_repo.id,
+                    BATCH_SIZE,
+                    since,
+                )
+                if incidents:
+                    await ingestion_sink.insert_incidents(incidents)
+                    logging.info("Stored %d incidents", len(incidents))
+
+            if sync_security:
+                logging.info("Fetching security alerts from GitHub...")
+                security_alerts = await loop.run_in_executor(
+                    None,
+                    _fetch_github_security_alerts_sync,
+                    connector,
+                    owner,
+                    repo_name,
+                    db_repo.id,
+                    BATCH_SIZE,
+                    since,
+                )
+                if security_alerts:
+                    insert_security_alerts = getattr(
+                        ingestion_sink, "insert_security_alerts"
+                    )
+                    await insert_security_alerts(security_alerts)
+                    logging.info("Stored %d security alerts", len(security_alerts))
+
+            # 5. Fetch Blame (Optional & Stubbed)
+            if fetch_blame:
+                logging.info("Fetching blame data (file list) from GitHub...")
+                await loop.run_in_executor(
+                    None, _fetch_github_blame_sync, gh_repo, db_repo.id
+                )
+
+            logging.info(
+                "Successfully processed GitHub repository: %s/%s",
+                owner,
+                repo_name,
             )
-
-        logging.info(
-            "Successfully processed GitHub repository: %s/%s",
-            owner,
-            repo_name,
-        )
 
     except ConnectorException as e:
         logging.error(f"Connector error: {e}")
@@ -1105,8 +1106,6 @@ async def process_github_repo(
     except Exception as e:
         logging.error(f"Error processing GitHub repository: {e}")
         raise
-    finally:
-        connector.close()
 
 
 async def process_github_repos_batch(
@@ -1435,38 +1434,25 @@ async def process_github_repos_batch(
                 loop.call_soon_threadsafe(_enqueue)
 
     try:
-        if sync_git:
-            results_queue = asyncio.Queue(maxsize=max(1, max_concurrent * 2))
+        with connector:
+            if sync_git:
+                results_queue = asyncio.Queue(maxsize=max(1, max_concurrent * 2))
 
-            async def _consume_results() -> None:
-                assert results_queue is not None
-                while True:
-                    item = await results_queue.get()
-                    try:
-                        if item is _queue_sentinel:
-                            return
-                        await store_result(item)
-                    finally:
-                        results_queue.task_done()
+                async def _consume_results() -> None:
+                    assert results_queue is not None
+                    while True:
+                        item = await results_queue.get()
+                        try:
+                            if item is _queue_sentinel:
+                                return
+                            await store_result(item)
+                        finally:
+                            results_queue.task_done()
 
-            consumer_task = asyncio.create_task(_consume_results())
+                consumer_task = asyncio.create_task(_consume_results())
 
-            if use_async:
-                await connector.get_repos_with_stats_async(
-                    org_name=org_name,
-                    user_name=user_name,
-                    pattern=pattern,
-                    batch_size=batch_size,
-                    max_concurrent=max_concurrent,
-                    rate_limit_delay=rate_limit_delay,
-                    max_commits_per_repo=max_commits_per_repo,
-                    max_repos=max_repos,
-                    on_repo_complete=on_repo_complete,
-                )
-            else:
-                await loop.run_in_executor(
-                    None,
-                    lambda: connector.get_repos_with_stats(
+                if use_async:
+                    await connector.get_repos_with_stats_async(
                         org_name=org_name,
                         user_name=user_name,
                         pattern=pattern,
@@ -1476,54 +1462,68 @@ async def process_github_repos_batch(
                         max_commits_per_repo=max_commits_per_repo,
                         max_repos=max_repos,
                         on_repo_complete=on_repo_complete,
+                    )
+                else:
+                    await loop.run_in_executor(
+                        None,
+                        lambda: connector.get_repos_with_stats(
+                            org_name=org_name,
+                            user_name=user_name,
+                            pattern=pattern,
+                            batch_size=batch_size,
+                            max_concurrent=max_concurrent,
+                            rate_limit_delay=rate_limit_delay,
+                            max_commits_per_repo=max_commits_per_repo,
+                            max_repos=max_repos,
+                            on_repo_complete=on_repo_complete,
+                        ),
+                    )
+
+                await results_queue.join()
+                await results_queue.put(_queue_sentinel)
+                await consumer_task
+            else:
+                repos = await loop.run_in_executor(
+                    None,
+                    lambda: connector.list_repositories(
+                        org_name=org_name,
+                        user_name=user_name,
+                        pattern=pattern,
+                        max_repos=max_repos,
                     ),
                 )
+                semaphore = asyncio.Semaphore(max(1, max_concurrent))
 
-            await results_queue.join()
-            await results_queue.put(_queue_sentinel)
-            await consumer_task
-        else:
-            repos = await loop.run_in_executor(
-                None,
-                lambda: connector.list_repositories(
-                    org_name=org_name,
-                    user_name=user_name,
-                    pattern=pattern,
-                    max_repos=max_repos,
-                ),
-            )
-            semaphore = asyncio.Semaphore(max(1, max_concurrent))
-
-            async def _process_repo(repo_info) -> None:
-                async with semaphore:
-                    result = BatchResult(
-                        repository=repo_info,
-                        stats=None,
-                        success=True,
-                    )
-                    try:
-                        await store_result(result)
-                    except Exception as e:
+                async def _process_repo(repo_info) -> None:
+                    async with semaphore:
                         result = BatchResult(
                             repository=repo_info,
                             stats=None,
-                            error=str(e),
-                            success=False,
+                            success=True,
                         )
-                    on_repo_complete(result)
+                        try:
+                            await store_result(result)
+                        except Exception as e:
+                            result = BatchResult(
+                                repository=repo_info,
+                                stats=None,
+                                error=str(e),
+                                success=False,
+                            )
+                        on_repo_complete(result)
 
-            tasks = [asyncio.create_task(_process_repo(repo)) for repo in repos]
-            if tasks:
-                await asyncio.gather(*tasks)
+                tasks = [asyncio.create_task(_process_repo(repo)) for repo in repos]
+                if tasks:
+                    await asyncio.gather(*tasks)
 
-        # Summary
-        successful = sum(1 for r in all_results if r.success)
-        failed = sum(1 for r in all_results if not r.success)
-        logging.info("=== Batch Processing Complete ===")
-        logging.info(f"  Successful: {successful}")
-        logging.info(f"  Failed: {failed}")
-        logging.info(f"  Total: {len(all_results)}")
-        logging.info(f"  Stored: {stored_count}")
+            # Summary
+            successful = sum(1 for r in all_results if r.success)
+            failed = sum(1 for r in all_results if not r.success)
+            logging.info("=== Batch Processing Complete ===")
+            logging.info(f"  Successful: {successful}")
+            logging.info(f"  Failed: {failed}")
+            logging.info(f"  Total: {len(all_results)}")
+            logging.info(f"  Stored: {stored_count}")
 
     except ConnectorException as e:
         logging.error(f"Connector error: {e}")
@@ -1531,5 +1531,3 @@ async def process_github_repos_batch(
     except Exception as e:
         logging.error(f"Error in batch processing: {e}")
         raise
-    finally:
-        connector.close()

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -304,6 +304,12 @@ async def test_process_github_repos_batch_upserts_during_async_processing(monkey
         def close(self):
             return
 
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
 
     await processors.github.process_github_repos_batch(
@@ -405,6 +411,12 @@ async def test_process_github_repos_batch_stores_commits_and_stats(monkeypatch):
 
         def close(self):
             return
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
     monkeypatch.setattr(

--- a/tests/test_connectors_integration.py
+++ b/tests/test_connectors_integration.py
@@ -50,9 +50,7 @@ class TestGitHubIntegration:
         if not token:
             pytest.skip("GITHUB_TOKEN environment variable not set")
 
-        connector = GitHubConnector(token=token)
-
-        try:
+        with GitHubConnector(token=token) as connector:
             # Fetch first 10 repos from github organization
             repos = connector.list_repositories(org_name="github", max_repos=10)
 
@@ -71,8 +69,6 @@ class TestGitHubIntegration:
             for repo in repos[:5]:  # Print first 5
                 print(f"  - {repo.full_name} (⭐ {repo.stars})")
 
-        finally:
-            connector.close()
 
     def test_list_public_repos_from_user(self):
         """Test fetching first 10 public repos from a GitHub user."""
@@ -81,9 +77,7 @@ class TestGitHubIntegration:
         if not token:
             pytest.skip("GITHUB_TOKEN environment variable not set")
 
-        connector = GitHubConnector(token=token)
-
-        try:
+        with GitHubConnector(token=token) as connector:
             # Fetch first 10 repos from torvalds (Linus Torvalds)
             repos = connector.list_repositories(user_name="torvalds", max_repos=10)
 
@@ -102,8 +96,6 @@ class TestGitHubIntegration:
             for repo in repos[:5]:  # Print first 5
                 print(f"  - {repo.full_name} (⭐ {repo.stars})")
 
-        finally:
-            connector.close()
 
     def test_search_public_repos(self):
         """Test searching for public repositories."""
@@ -112,9 +104,7 @@ class TestGitHubIntegration:
         if not token:
             pytest.skip("GITHUB_TOKEN environment variable not set")
 
-        connector = GitHubConnector(token=token)
-
-        try:
+        with GitHubConnector(token=token) as connector:
             # Search for Python repositories
             repos = connector.list_repositories(
                 search="python language:python", max_repos=10
@@ -134,8 +124,6 @@ class TestGitHubIntegration:
             for repo in repos[:5]:  # Print first 5
                 print(f"  - {repo.full_name} (⭐ {repo.stars})")
 
-        finally:
-            connector.close()
 
 
 @pytest.mark.skipif(
@@ -148,11 +136,9 @@ class TestGitLabIntegration:
     def test_list_public_projects_from_gitlab(self):
         """Test fetching first 10 public projects from GitLab."""
         # Use unauthenticated connector for public projects
-        connector = GitLabConnector(
+        with GitLabConnector(
             url="https://gitlab.com", private_token=os.getenv("GITLAB_TOKEN")
-        )
-
-        try:
+        ) as connector:
             # Fetch first 10 public projects
             try:
                 projects = connector.list_projects(max_projects=10)
@@ -174,17 +160,13 @@ class TestGitLabIntegration:
             for project in projects[:5]:  # Print first 5
                 print(f"  - {project.full_name} (⭐ {project.stars})")
 
-        finally:
-            connector.close()
 
     def test_list_public_projects_from_gitlab_group(self):
         """Test fetching first 10 public projects from a GitLab group."""
         # Use unauthenticated connector for public projects
-        connector = GitLabConnector(
+        with GitLabConnector(
             url="https://gitlab.com", private_token=os.getenv("GITLAB_TOKEN")
-        )
-
-        try:
+        ) as connector:
             # Fetch first 10 repos from gitlab-org group
             try:
                 projects = connector.list_projects(
@@ -210,17 +192,13 @@ class TestGitLabIntegration:
             for project in projects[:5]:  # Print first 5
                 print(f"  - {project.full_name} (⭐ {project.stars})")
 
-        finally:
-            connector.close()
 
     def test_search_public_projects(self):
         """Test searching for public projects on GitLab."""
         # Use unauthenticated connector for public projects
-        connector = GitLabConnector(
+        with GitLabConnector(
             url="https://gitlab.com", private_token=os.getenv("GITLAB_TOKEN")
-        )
-
-        try:
+        ) as connector:
             # Search for docker projects
             projects = connector.list_projects(search="docker", max_projects=10)
 
@@ -238,5 +216,3 @@ class TestGitLabIntegration:
             for project in projects[:5]:  # Print first 5
                 print(f"  - {project.full_name} (⭐ {project.stars})")
 
-        finally:
-            connector.close()

--- a/tests/test_connectors_integration.py
+++ b/tests/test_connectors_integration.py
@@ -69,7 +69,6 @@ class TestGitHubIntegration:
             for repo in repos[:5]:  # Print first 5
                 print(f"  - {repo.full_name} (⭐ {repo.stars})")
 
-
     def test_list_public_repos_from_user(self):
         """Test fetching first 10 public repos from a GitHub user."""
         # Skip if no token provided
@@ -95,7 +94,6 @@ class TestGitHubIntegration:
             print(f"\nFetched {len(repos)} repositories from torvalds user:")
             for repo in repos[:5]:  # Print first 5
                 print(f"  - {repo.full_name} (⭐ {repo.stars})")
-
 
     def test_search_public_repos(self):
         """Test searching for public repositories."""
@@ -123,7 +121,6 @@ class TestGitHubIntegration:
             print(f"\nFound {len(repos)} Python repositories:")
             for repo in repos[:5]:  # Print first 5
                 print(f"  - {repo.full_name} (⭐ {repo.stars})")
-
 
 
 @pytest.mark.skipif(
@@ -160,7 +157,6 @@ class TestGitLabIntegration:
             for project in projects[:5]:  # Print first 5
                 print(f"  - {project.full_name} (⭐ {project.stars})")
 
-
     def test_list_public_projects_from_gitlab_group(self):
         """Test fetching first 10 public projects from a GitLab group."""
         # Use unauthenticated connector for public projects
@@ -192,7 +188,6 @@ class TestGitLabIntegration:
             for project in projects[:5]:  # Print first 5
                 print(f"  - {project.full_name} (⭐ {project.stars})")
 
-
     def test_search_public_projects(self):
         """Test searching for public projects on GitLab."""
         # Use unauthenticated connector for public projects
@@ -215,4 +210,3 @@ class TestGitLabIntegration:
             print(f"\nFound {len(projects)} projects matching 'docker':")
             for project in projects[:5]:  # Print first 5
                 print(f"  - {project.full_name} (⭐ {project.stars})")
-

--- a/tests/test_github_repo_stats_author_404.py
+++ b/tests/test_github_repo_stats_author_404.py
@@ -42,9 +42,7 @@ class _Repo:
 
 
 def test_get_repo_stats_does_not_fail_on_author_profile_404(monkeypatch):
-    connector = GitHubConnector(token="test_token")
-
-    try:
+    with GitHubConnector(token="test_token") as connector:
         monkeypatch.setattr(
             connector.github,
             "get_repo",
@@ -57,5 +55,3 @@ def test_get_repo_stats_does_not_fail_on_author_profile_404(monkeypatch):
         assert stats.deletions == 2
         assert len(stats.authors) == 1
         assert stats.authors[0].username == "deleted-user"
-    finally:
-        connector.close()

--- a/tests/test_linear_team_sync.py
+++ b/tests/test_linear_team_sync.py
@@ -335,6 +335,7 @@ class TestDiscoverLinear:
 
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
+        mock_client.__enter__.return_value = mock_client
         mock_client.iter_teams.return_value = [
             {
                 "id": "team-eng",
@@ -367,6 +368,7 @@ class TestDiscoverLinear:
 
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
+        mock_client.__enter__.return_value = mock_client
         mock_client.iter_teams.return_value = []
 
         service = TeamDiscoveryService.__new__(TeamDiscoveryService)
@@ -383,6 +385,7 @@ class TestDiscoverLinear:
 
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
+        mock_client.__enter__.return_value = mock_client
         mock_client.iter_teams.return_value = [
             {
                 "id": "team-eng",
@@ -402,11 +405,12 @@ class TestDiscoverLinear:
     def test_discover_linear_client_closed_on_success(
         self, mock_client_class: MagicMock
     ) -> None:
-        """discover_linear() always closes the client (via finally block)."""
+        """discover_linear() always closes the client (via context manager __exit__)."""
         from dev_health_ops.api.services.settings import TeamDiscoveryService
 
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
+        mock_client.__enter__.return_value = mock_client
         mock_client.iter_teams.return_value = [
             {
                 "id": "team-eng",
@@ -419,4 +423,5 @@ class TestDiscoverLinear:
         service = TeamDiscoveryService.__new__(TeamDiscoveryService)
         asyncio.run(service.discover_linear(api_key="test-key"))
 
-        mock_client.close.assert_called_once()
+        # Context-manager protocol guarantees cleanup via __exit__
+        mock_client.__exit__.assert_called_once()

--- a/tests/test_private_repo_access.py
+++ b/tests/test_private_repo_access.py
@@ -74,82 +74,79 @@ class TestGitHubPrivateRepoAccess:
                 f"GITHUB_PRIVATE_REPO should be in 'owner/repo' format, got: {private_repo}"
             )
 
-        connector = GitHubConnector(token=token)
+        with GitHubConnector(token=token) as connector:
+            try:
+                # Test 1: Fetch the private repository directly
+                print(f"\nTest 1: Fetching private repository {owner}/{repo_name}...")
+                repos = connector.list_repositories(user_name=owner, max_repos=50)
 
-        try:
-            # Test 1: Fetch the private repository directly
-            print(f"\nTest 1: Fetching private repository {owner}/{repo_name}...")
-            repos = connector.list_repositories(user_name=owner, max_repos=50)
+                # Find the private repo in the list
+                private_repo_found = None
+                for repo in repos:
+                    if repo.full_name == private_repo:
+                        private_repo_found = repo
+                        break
 
-            # Find the private repo in the list
-            private_repo_found = None
-            for repo in repos:
-                if repo.full_name == private_repo:
-                    private_repo_found = repo
-                    break
-
-            assert private_repo_found is not None, (
-                f"Private repository {private_repo} not found in user's repositories"
-            )
-            print(
-                f"  ✓ Successfully found private repository: {private_repo_found.full_name}"
-            )
-
-            # Test 2: Get repository statistics
-            print("\nTest 2: Fetching stats for private repository...")
-            stats = connector.get_repo_stats(owner, repo_name, max_commits=10)
-
-            assert stats is not None, "Should return stats for private repository"
-            assert stats.total_commits > 0, "Private repository should have commits"
-            print(f"  ✓ Successfully fetched stats: {stats.total_commits} commits")
-
-            # Test 3: Get contributors
-            print("\nTest 3: Fetching contributors for private repository...")
-            contributors = connector.get_contributors(
-                owner, repo_name, max_contributors=5
-            )
-
-            assert contributors is not None, (
-                "Should return contributors for private repository"
-            )
-            assert len(contributors) > 0, (
-                "Private repository should have at least one contributor"
-            )
-            print(f"  ✓ Successfully fetched {len(contributors)} contributors")
-
-            # Test 4: Get pull requests
-            print("\nTest 4: Fetching pull requests for private repository...")
-            prs = connector.get_pull_requests(owner, repo_name, state="all", max_prs=5)
-
-            assert prs is not None, (
-                "Should return PRs list (even if empty) for private repository"
-            )
-            print(f"  ✓ Successfully fetched {len(prs)} pull requests")
-
-            # Test 5: Check rate limit
-            print("\nTest 5: Checking rate limit status...")
-            rate_limit = connector.get_rate_limit()
-
-            assert rate_limit is not None, "Should return rate limit info"
-            assert rate_limit["limit"] > 0, "Should have a rate limit"
-            print(
-                f"  ✓ Rate limit: {rate_limit['remaining']}/{rate_limit['limit']} remaining"
-            )
-
-            print(f"\n✅ All tests passed for private repository {private_repo}")
-
-        except AuthenticationException as e:
-            pytest.fail(
-                f"Authentication failed. Ensure GITHUB_TOKEN has 'repo' scope for private repositories. Error: {e}"
-            )
-        except APIException as e:
-            if "404" in str(e):
-                pytest.fail(
-                    f"Repository not found. Ensure the token has access to {private_repo}. Error: {e}"
+                assert private_repo_found is not None, (
+                    f"Private repository {private_repo} not found in user's repositories"
                 )
-            raise
-        finally:
-            connector.close()
+                print(
+                    f"  ✓ Successfully found private repository: {private_repo_found.full_name}"
+                )
+
+                # Test 2: Get repository statistics
+                print("\nTest 2: Fetching stats for private repository...")
+                stats = connector.get_repo_stats(owner, repo_name, max_commits=10)
+
+                assert stats is not None, "Should return stats for private repository"
+                assert stats.total_commits > 0, "Private repository should have commits"
+                print(f"  ✓ Successfully fetched stats: {stats.total_commits} commits")
+
+                # Test 3: Get contributors
+                print("\nTest 3: Fetching contributors for private repository...")
+                contributors = connector.get_contributors(
+                    owner, repo_name, max_contributors=5
+                )
+
+                assert contributors is not None, (
+                    "Should return contributors for private repository"
+                )
+                assert len(contributors) > 0, (
+                    "Private repository should have at least one contributor"
+                )
+                print(f"  ✓ Successfully fetched {len(contributors)} contributors")
+
+                # Test 4: Get pull requests
+                print("\nTest 4: Fetching pull requests for private repository...")
+                prs = connector.get_pull_requests(owner, repo_name, state="all", max_prs=5)
+
+                assert prs is not None, (
+                    "Should return PRs list (even if empty) for private repository"
+                )
+                print(f"  ✓ Successfully fetched {len(prs)} pull requests")
+
+                # Test 5: Check rate limit
+                print("\nTest 5: Checking rate limit status...")
+                rate_limit = connector.get_rate_limit()
+
+                assert rate_limit is not None, "Should return rate limit info"
+                assert rate_limit["limit"] > 0, "Should have a rate limit"
+                print(
+                    f"  ✓ Rate limit: {rate_limit['remaining']}/{rate_limit['limit']} remaining"
+                )
+
+                print(f"\n✅ All tests passed for private repository {private_repo}")
+
+            except AuthenticationException as e:
+                pytest.fail(
+                    f"Authentication failed. Ensure GITHUB_TOKEN has 'repo' scope for private repositories. Error: {e}"
+                )
+            except APIException as e:
+                if "404" in str(e):
+                    pytest.fail(
+                        f"Repository not found. Ensure the token has access to {private_repo}. Error: {e}"
+                    )
+                raise
 
     def test_access_private_repo_without_token(self):
         """Test that accessing private repos without a token fails appropriately."""
@@ -166,9 +163,7 @@ class TestGitHubPrivateRepoAccess:
         if not token:
             pytest.skip("GITHUB_TOKEN environment variable not set")
 
-        connector = GitHubConnector(token=token)
-
-        try:
+        with GitHubConnector(token=token) as connector:
             # Fetch authenticated user's repositories
             print("\nFetching authenticated user's repositories (including private)...")
             repos = connector.list_repositories(max_repos=50)
@@ -185,8 +180,6 @@ class TestGitHubPrivateRepoAccess:
             for repo in repos[:5]:
                 print(f"  - {repo.full_name}")
 
-        finally:
-            connector.close()
 
 
 @pytest.mark.skipif(skip_integration or skip_gitlab_network, reason=gitlab_skip_reason)
@@ -208,110 +201,105 @@ class TestGitLabPrivateProjectAccess:
                 "Set it to project name (e.g., 'group/project') or project ID of a private project you have access to."
             )
 
-        connector = GitLabConnector(url=gitlab_url, private_token=token)
-
-        try:
-            # Test 1: Fetch the private project directly
-            print(f"\nTest 1: Fetching private project {private_project}...")
-
-            # Try to get the project (works with both name and ID)
-            # Note: This is a direct python-gitlab API call, not wrapped by connector
+        with GitLabConnector(url=gitlab_url, private_token=token) as connector:
             try:
-                project = connector.gitlab.projects.get(private_project)
-                print(f"  ✓ Successfully accessed private project: {project.name}")
-                project_identifier = private_project
-            except Exception as e:
-                # python-gitlab can raise various exceptions (GitlabAuthenticationError, GitlabGetError, etc.)
-                pytest.fail(f"Failed to access private project {private_project}: {e}")
+                # Test 1: Fetch the private project directly
+                print(f"\nTest 1: Fetching private project {private_project}...")
 
-            # Test 2: List projects (should include private ones)
-            print("\nTest 2: Listing accessible projects (including private)...")
-            projects = connector.list_projects(max_projects=20)
+                # Try to get the project (works with both name and ID)
+                # Note: This is a direct python-gitlab API call, not wrapped by connector
+                try:
+                    project = connector.gitlab.projects.get(private_project)
+                    print(f"  ✓ Successfully accessed private project: {project.name}")
+                    project_identifier = private_project
+                except Exception as e:
+                    # python-gitlab can raise various exceptions (GitlabAuthenticationError, GitlabGetError, etc.)
+                    pytest.fail(f"Failed to access private project {private_project}: {e}")
 
-            assert len(projects) > 0, "User should have access to at least one project"
-            print(
-                f"  ✓ Successfully fetched {len(projects)} projects (may include private)"
-            )
+                # Test 2: List projects (should include private ones)
+                print("\nTest 2: Listing accessible projects (including private)...")
+                projects = connector.list_projects(max_projects=20)
 
-            # Test 3: Get project statistics
-            print("\nTest 3: Fetching stats for private project...")
-            try:
-                stats = connector.get_repo_stats_by_project(
-                    project_name=project_identifier, max_commits=10
+                assert len(projects) > 0, "User should have access to at least one project"
+                print(
+                    f"  ✓ Successfully fetched {len(projects)} projects (may include private)"
                 )
-            except APIException:
-                # Fallback to project_id if project_name doesn't work
-                if str(private_project).isdigit():
+
+                # Test 3: Get project statistics
+                print("\nTest 3: Fetching stats for private project...")
+                try:
                     stats = connector.get_repo_stats_by_project(
-                        project_id=int(private_project), max_commits=10
+                        project_name=project_identifier, max_commits=10
                     )
-                else:
-                    raise
+                except APIException:
+                    # Fallback to project_id if project_name doesn't work
+                    if str(private_project).isdigit():
+                        stats = connector.get_repo_stats_by_project(
+                            project_id=int(private_project), max_commits=10
+                        )
+                    else:
+                        raise
 
-            assert stats is not None, "Should return stats for private project"
-            print(f"  ✓ Successfully fetched stats: {stats.total_commits} commits")
+                assert stats is not None, "Should return stats for private project"
+                print(f"  ✓ Successfully fetched stats: {stats.total_commits} commits")
 
-            # Test 4: Get contributors
-            print("\nTest 4: Fetching contributors for private project...")
-            try:
-                contributors = connector.get_contributors_by_project(
-                    project_name=project_identifier, max_contributors=5
-                )
-            except APIException:
-                if str(private_project).isdigit():
+                # Test 4: Get contributors
+                print("\nTest 4: Fetching contributors for private project...")
+                try:
                     contributors = connector.get_contributors_by_project(
-                        project_id=int(private_project), max_contributors=5
+                        project_name=project_identifier, max_contributors=5
                     )
-                else:
-                    raise
+                except APIException:
+                    if str(private_project).isdigit():
+                        contributors = connector.get_contributors_by_project(
+                            project_id=int(private_project), max_contributors=5
+                        )
+                    else:
+                        raise
 
-            assert contributors is not None, (
-                "Should return contributors for private project"
-            )
-            print(f"  ✓ Successfully fetched {len(contributors)} contributors")
-
-            # Test 5: Get merge requests
-            print("\nTest 5: Fetching merge requests for private project...")
-            try:
-                mrs = connector.get_merge_requests(
-                    project_name=project_identifier, state="all", max_mrs=5
+                assert contributors is not None, (
+                    "Should return contributors for private project"
                 )
-            except APIException:
-                if str(private_project).isdigit():
+                print(f"  ✓ Successfully fetched {len(contributors)} contributors")
+
+                # Test 5: Get merge requests
+                print("\nTest 5: Fetching merge requests for private project...")
+                try:
                     mrs = connector.get_merge_requests(
-                        project_id=int(private_project), state="all", max_mrs=5
+                        project_name=project_identifier, state="all", max_mrs=5
                     )
-                else:
-                    raise
+                except APIException:
+                    if str(private_project).isdigit():
+                        mrs = connector.get_merge_requests(
+                            project_id=int(private_project), state="all", max_mrs=5
+                        )
+                    else:
+                        raise
 
-            assert mrs is not None, (
-                "Should return MRs list (even if empty) for private project"
-            )
-            print(f"  ✓ Successfully fetched {len(mrs)} merge requests")
-
-            print(f"\n✅ All tests passed for private project {private_project}")
-
-        except AuthenticationException as e:
-            pytest.fail(
-                f"Authentication failed. Ensure GITLAB_TOKEN has appropriate permissions for private projects. Error: {e}"
-            )
-        except APIException as e:
-            if "404" in str(e):
-                pytest.fail(
-                    f"Project not found. Ensure the token has access to {private_project}. Error: {e}"
+                assert mrs is not None, (
+                    "Should return MRs list (even if empty) for private project"
                 )
-            raise
-        finally:
-            connector.close()
+                print(f"  ✓ Successfully fetched {len(mrs)} merge requests")
+
+                print(f"\n✅ All tests passed for private project {private_project}")
+
+            except AuthenticationException as e:
+                pytest.fail(
+                    f"Authentication failed. Ensure GITLAB_TOKEN has appropriate permissions for private projects. Error: {e}"
+                )
+            except APIException as e:
+                if "404" in str(e):
+                    pytest.fail(
+                        f"Project not found. Ensure the token has access to {private_project}. Error: {e}"
+                    )
+                raise
 
     def test_access_private_project_without_token(self):
         """Test that accessing private projects without a token fails appropriately."""
         private_project = os.getenv("GITLAB_PRIVATE_PROJECT", "some-private/project")
 
         # Initialize connector without token
-        connector = GitLabConnector(url="https://gitlab.com", private_token=None)
-
-        try:
+        with GitLabConnector(url="https://gitlab.com", private_token=None) as connector:
             # Attempt to access a private project (should fail)
             print("\nAttempting to access private project without authentication...")
 
@@ -330,8 +318,6 @@ class TestGitLabPrivateProjectAccess:
                     or "unauthorized" in str(e).lower()
                 ), f"Expected authentication error, got: {e}"
 
-        finally:
-            connector.close()
 
     def test_list_user_projects_includes_private(self):
         """Test that listing user's projects includes private projects."""
@@ -341,9 +327,7 @@ class TestGitLabPrivateProjectAccess:
         if not token:
             pytest.skip("GITLAB_TOKEN environment variable not set")
 
-        connector = GitLabConnector(url=gitlab_url, private_token=token)
-
-        try:
+        with GitLabConnector(url=gitlab_url, private_token=token) as connector:
             # Fetch user's accessible projects
             print("\nFetching user's accessible projects (including private)...")
             projects = connector.list_projects(max_projects=20)
@@ -356,8 +340,6 @@ class TestGitLabPrivateProjectAccess:
             for project in projects[:5]:
                 print(f"  - {project.full_name}")
 
-        finally:
-            connector.close()
 
 
 @pytest.mark.skipif(skip_integration, reason="Integration tests disabled")
@@ -368,9 +350,7 @@ class TestPrivateRepoTokenValidation:
         """Test that GitHub connector fails gracefully with invalid token."""
         invalid_token = "ghp_invalid_token_1234567890"
 
-        connector = GitHubConnector(token=invalid_token)
-
-        try:
+        with GitHubConnector(token=invalid_token) as connector:
             # Attempt to list repositories with invalid token
             print("\nTesting GitHub with invalid token...")
 
@@ -379,8 +359,6 @@ class TestPrivateRepoTokenValidation:
 
             print(f"  ✓ Correctly raised exception: {type(exc_info.value).__name__}")
 
-        finally:
-            connector.close()
 
     def test_gitlab_invalid_token(self):
         """Test that GitLab connector fails gracefully with invalid token."""

--- a/tests/test_private_repo_access.py
+++ b/tests/test_private_repo_access.py
@@ -67,12 +67,11 @@ class TestGitHubPrivateRepoAccess:
 
         # Parse owner and repo
 
-        try:
-            owner, repo_name = private_repo.split("/")
-        except ValueError:
+        if "/" not in private_repo:
             pytest.fail(
                 f"GITHUB_PRIVATE_REPO should be in 'owner/repo' format, got: {private_repo}"
             )
+        owner, repo_name = private_repo.split("/", 1)
 
         with GitHubConnector(token=token) as connector:
             try:
@@ -118,7 +117,9 @@ class TestGitHubPrivateRepoAccess:
 
                 # Test 4: Get pull requests
                 print("\nTest 4: Fetching pull requests for private repository...")
-                prs = connector.get_pull_requests(owner, repo_name, state="all", max_prs=5)
+                prs = connector.get_pull_requests(
+                    owner, repo_name, state="all", max_prs=5
+                )
 
                 assert prs is not None, (
                     "Should return PRs list (even if empty) for private repository"
@@ -181,7 +182,6 @@ class TestGitHubPrivateRepoAccess:
                 print(f"  - {repo.full_name}")
 
 
-
 @pytest.mark.skipif(skip_integration or skip_gitlab_network, reason=gitlab_skip_reason)
 class TestGitLabPrivateProjectAccess:
     """Integration tests for GitLab connector with private projects."""
@@ -208,19 +208,23 @@ class TestGitLabPrivateProjectAccess:
 
                 # Try to get the project (works with both name and ID)
                 # Note: This is a direct python-gitlab API call, not wrapped by connector
+                project_identifier = private_project
                 try:
                     project = connector.gitlab.projects.get(private_project)
                     print(f"  ✓ Successfully accessed private project: {project.name}")
-                    project_identifier = private_project
                 except Exception as e:
                     # python-gitlab can raise various exceptions (GitlabAuthenticationError, GitlabGetError, etc.)
-                    pytest.fail(f"Failed to access private project {private_project}: {e}")
+                    pytest.fail(
+                        f"Failed to access private project {private_project}: {e}"
+                    )
 
                 # Test 2: List projects (should include private ones)
                 print("\nTest 2: Listing accessible projects (including private)...")
                 projects = connector.list_projects(max_projects=20)
 
-                assert len(projects) > 0, "User should have access to at least one project"
+                assert len(projects) > 0, (
+                    "User should have access to at least one project"
+                )
                 print(
                     f"  ✓ Successfully fetched {len(projects)} projects (may include private)"
                 )
@@ -318,7 +322,6 @@ class TestGitLabPrivateProjectAccess:
                     or "unauthorized" in str(e).lower()
                 ), f"Expected authentication error, got: {e}"
 
-
     def test_list_user_projects_includes_private(self):
         """Test that listing user's projects includes private projects."""
         token = os.getenv("GITLAB_TOKEN")
@@ -341,7 +344,6 @@ class TestGitLabPrivateProjectAccess:
                 print(f"  - {project.full_name}")
 
 
-
 @pytest.mark.skipif(skip_integration, reason="Integration tests disabled")
 class TestPrivateRepoTokenValidation:
     """Tests for token validation and error handling."""
@@ -358,7 +360,6 @@ class TestPrivateRepoTokenValidation:
                 connector.list_repositories(max_repos=1)
 
             print(f"  ✓ Correctly raised exception: {type(exc_info.value).__name__}")
-
 
     def test_gitlab_invalid_token(self):
         """Test that GitLab connector fails gracefully with invalid token."""


### PR DESCRIPTION
## Summary

Triaged all 81 open GitHub code-scanning alerts:

- 🔴 **Fixed 3 ERRORs** (`py/log-injection`) — sanitized user-controlled `path` and `key` values flowing into `logger.warning/info(...)` in `connectors/launchdarkly.py` using the existing `sanitize_for_log` helper.
- ⚪ **Fixed 21 NOTEs** (`py/should-use-with`) — converted `try/finally: client.close()` patterns to `with ... as client:` across tests, examples, and 2 production sites (`LinearClient` in `settings.py`, `GitHubConnector` in `processors/github.py`).
- 🛑 **Dismissed 57 false positives via the Code Scanning API** with per-alert justification:
  - 32 × `py/ineffectual-statement` — Protocol/abstract method `...` bodies (PEP 544 canonical idiom).
  - 22 × `py/unused-global-variable` — Alembic migration metadata (`revision`/`down_revision`/`branch_labels`/`depends_on`) read by module introspection; `_GIT_TARGETS`/`_WORK_ITEM_TARGETS` imported cross-module by `workers/sync_runtime.py`.
  - 3 × `py/unreachable-statement` — `pytest.raises` catches the inner exception so post-with statements are reachable; CodeQL doesn't model pytest semantics.

## Approach

A team of 4 parallel code-medium agents handled the fixes; the orchestrator (Sisyphus) handled triage, verification, and false-positive dismissals via `gh api`.

## Verification

- ✅ LSP diagnostics clean on all 9 modified files.
- ✅ `python -m py_compile` passes on every modified file.
- ✅ 15 tests in modified test files collected; **12 passed, 3 skipped** (token-gated integration tests — expected).
- ✅ Existing `try/except` error handling preserved verbatim where present (production `processors/github.py` kept outer `try/except ConnectorException/Exception` and used `with connector:` for cleanup).
- ⏳ CodeQL will re-evaluate the 24 fixed alerts on the next scan and auto-close them.

## Files Changed

| File | Sites |
|---|---|
| `src/dev_health_ops/connectors/launchdarkly.py` | 3 log-injection sanitizations + new import |
| `src/dev_health_ops/api/services/settings.py` | 1 `with LinearClient(...) as client` conversion |
| `src/dev_health_ops/processors/github.py` | 2 `with connector:` insertions (outer try/except preserved) |
| `tests/test_connectors_integration.py` | 6 sites |
| `tests/test_private_repo_access.py` | 6 sites |
| `tests/test_github_repo_stats_author_404.py` | 1 site |
| `examples/batch_processing_example.py` | 1 site |
| `examples/integration_example.py` | 2 sites |
| `examples/private_repo_example.py` | 2 sites |

SCREENSHOT-WAIVER: backend-only change — no frontend rendering impact (logging sanitization + resource cleanup pattern only).