### PR TITLE
sec: GraphQL hardening — disable GraphiQL/introspection + depth/alias/size limits

### DIFF
--- a/docs/api/graphql-security.md
+++ b/docs/api/graphql-security.md
@@ -1,0 +1,22 @@
+# GraphQL security posture
+
+The `/graphql` endpoint is locked down by default. Production-like environments
+disable the browser IDE, disable schema introspection, apply validation limits,
+and reject oversized request bodies before Strawberry parses the query.
+
+Environment controls:
+
+- `ENVIRONMENT` (fallbacks: `APP_ENV`, `ENV`) defaults to `production`.
+  `development`, `dev`, and `local` are treated as local development.
+- `GRAPHQL_IDE_ENABLED=true` explicitly exposes GraphiQL. If unset, GraphiQL is
+  enabled only in local development and disabled everywhere else.
+- `GRAPHQL_INTROSPECTION_ENABLED=true` explicitly allows `__schema` and other
+  introspection fields. If unset, introspection is disabled outside development.
+- `GRAPHQL_SECURITY_ENABLED=false` disables the production hardening rules for
+  local diagnostics. If unset, hardening is enabled outside development.
+- `GRAPHQL_MAX_QUERY_BYTES` sets the HTTP body limit for `/graphql` requests.
+  The safe default is `16384` bytes (16 KB).
+
+Default validation limits are intentionally conservative: maximum selection
+depth is 12 and maximum aliases per operation is 15. Resolver-level cost limits
+remain separate and continue to protect analytics workloads after validation.

--- a/src/dev_health_ops/api/graphql/app.py
+++ b/src/dev_health_ops/api/graphql/app.py
@@ -12,6 +12,7 @@ from strawberry.fastapi import GraphQLRouter
 from .context import GraphQLContext, build_context
 from .persisted import get_schema_version
 from .schema import schema
+from .security import is_graphql_ide_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +131,7 @@ def create_graphql_app(
         schema=schema,
         context_getter=context_getter,
         path="",
+        graphql_ide="graphiql" if is_graphql_ide_enabled() else None,
     )
 
     return router
@@ -141,7 +143,6 @@ def get_graphql_info() -> dict:
         "schema_version": get_schema_version(),
         "endpoints": {
             "graphql": "/graphql",
-            "graphiql": "/graphql",
             "subscriptions": "/graphql",
         },
         "features": [

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 import strawberry
+from strawberry.extensions import AddValidationRules
 from strawberry.types import Info
 
 from .context import GraphQLContext
@@ -48,6 +49,7 @@ from .resolvers.reports import (
     resolve_trigger_report,
     resolve_update_saved_report,
 )
+from .security import get_graphql_validation_rules
 from .subscriptions import Subscription
 
 logger = logging.getLogger(__name__)
@@ -294,5 +296,5 @@ schema = strawberry.Schema(
     query=Query,
     mutation=Mutation,
     subscription=Subscription,
-    extensions=[OrgIdAuthExtension],
+    extensions=[OrgIdAuthExtension, AddValidationRules(get_graphql_validation_rules())],
 )

--- a/src/dev_health_ops/api/graphql/security.py
+++ b/src/dev_health_ops/api/graphql/security.py
@@ -1,0 +1,270 @@
+"""Security controls for the GraphQL API.
+
+The repository does not have a single canonical application environment helper;
+GraphQL hardening therefore follows the deployment variables already used by
+observability integrations (environment names default to production) while also
+accepting the common APP_ENV/ENV fallbacks for local tooling.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterable
+from typing import Any
+
+from graphql import GraphQLError
+from graphql.language.ast import FieldNode
+from graphql.validation import ASTValidationRule, ValidationRule
+from graphql.validation.rules.custom.no_schema_introspection import (
+    NoSchemaIntrospectionCustomRule,
+)
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+MAX_GRAPHQL_DEPTH = 12
+MAX_GRAPHQL_ALIASES = 15
+DEFAULT_GRAPHQL_MAX_QUERY_BYTES = 16 * 1024
+
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSY = {"0", "false", "no", "off"}
+
+
+def _env_flag(name: str) -> bool | None:
+    raw = os.getenv(name)
+    if raw is None:
+        return None
+    value = raw.strip().lower()
+    if value in _TRUTHY:
+        return True
+    if value in _FALSY:
+        return False
+    return None
+
+
+def environment_name() -> str:
+    """Return the current application environment name.
+
+    ENVIRONMENT is the primary knob documented for deployments. APP_ENV and ENV
+    are accepted as compatibility fallbacks because no project-wide settings
+    module currently defines a stronger convention.
+    """
+
+    return (
+        os.getenv("ENVIRONMENT")
+        or os.getenv("APP_ENV")
+        or os.getenv("ENV")
+        or "production"
+    ).strip().lower()
+
+
+def is_development_environment() -> bool:
+    """Return True only for explicitly local development environments."""
+
+    return environment_name() in {"development", "dev", "local"}
+
+
+def is_graphql_hardening_enabled() -> bool:
+    """Return whether production GraphQL validation/size hardening is enabled."""
+
+    override = _env_flag("GRAPHQL_SECURITY_ENABLED")
+    if override is not None:
+        return override
+    return not is_development_environment()
+
+
+def is_graphql_ide_enabled() -> bool:
+    """Return whether the in-browser GraphiQL IDE should be exposed."""
+
+    override = _env_flag("GRAPHQL_IDE_ENABLED")
+    if override is not None:
+        return override
+    return is_development_environment()
+
+
+def is_graphql_introspection_enabled() -> bool:
+    """Return whether schema introspection is allowed."""
+
+    override = _env_flag("GRAPHQL_INTROSPECTION_ENABLED")
+    if override is not None:
+        return override
+    return not is_graphql_hardening_enabled()
+
+
+class MaxDepthLimit(ValidationRule):
+    """Reject operations deeper than the documented production depth limit.
+
+    A small in-tree validator avoids adding another dependency solely for depth
+    and alias limits. The default depth of 12 allows normal analytics query
+    shapes while blocking pathological nested selection sets before execution.
+    """
+
+    max_depth = MAX_GRAPHQL_DEPTH
+
+    def __init__(self, context: Any) -> None:
+        super().__init__(context)
+        self._depth = 0
+        self._reported = False
+
+    def enter_field(self, node: FieldNode, *_args: Any) -> None:
+        self._depth += 1
+        if not self._reported and self._depth > self.max_depth:
+            self._reported = True
+            self.report_error(
+                GraphQLError(
+                    f"GraphQL query depth exceeds limit of {self.max_depth}",
+                    [node],
+                )
+            )
+
+    def leave_field(self, _node: FieldNode, *_args: Any) -> None:
+        self._depth -= 1
+
+
+class MaxAliasLimit(ValidationRule):
+    """Reject operations with too many aliases.
+
+    The default alias cap of 15 blocks alias-amplification attacks while leaving
+    enough headroom for dashboard clients that fan out several related fields.
+    """
+
+    max_aliases = MAX_GRAPHQL_ALIASES
+
+    def __init__(self, context: Any) -> None:
+        super().__init__(context)
+        self._aliases = 0
+        self._reported = False
+
+    def enter_field(self, node: FieldNode, *_args: Any) -> None:
+        if node.alias is None:
+            return
+        self._aliases += 1
+        if not self._reported and self._aliases > self.max_aliases:
+            self._reported = True
+            self.report_error(
+                GraphQLError(
+                    f"GraphQL alias count exceeds limit of {self.max_aliases}",
+                    [node],
+                )
+            )
+
+
+def get_graphql_validation_rules() -> list[type[ASTValidationRule]]:
+    """Return validation rules for the current environment."""
+
+    rules: list[type[ASTValidationRule]] = []
+    if is_graphql_hardening_enabled():
+        rules.extend([MaxDepthLimit, MaxAliasLimit])
+    if not is_graphql_introspection_enabled():
+        rules.append(NoSchemaIntrospectionCustomRule)
+    return rules
+
+
+def get_graphql_max_query_bytes() -> int:
+    """Return the configured HTTP request body limit for /graphql."""
+
+    raw = os.getenv("GRAPHQL_MAX_QUERY_BYTES")
+    if raw is None:
+        return DEFAULT_GRAPHQL_MAX_QUERY_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_GRAPHQL_MAX_QUERY_BYTES
+    return max(1, value)
+
+
+class GraphQLQuerySizeLimitMiddleware:
+    """Reject oversized /graphql request bodies before GraphQL parsing."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if (
+            scope["type"] == "http"
+            and scope.get("method") == "GET"
+            and str(scope.get("path", "")).startswith("/graphql")
+            and not is_graphql_ide_enabled()
+            and _accepts_html(scope)
+        ):
+            await self._send_not_found(send)
+            return
+
+        if (
+            scope["type"] != "http"
+            or scope.get("method") not in {"POST", "PUT", "PATCH"}
+            or not str(scope.get("path", "")).startswith("/graphql")
+            or not is_graphql_hardening_enabled()
+        ):
+            await self.app(scope, receive, send)
+            return
+
+        limit = get_graphql_max_query_bytes()
+        body_messages: list[Message] = []
+        body_size = 0
+        more_body = True
+
+        while more_body:
+            message = await receive()
+            body_messages.append(message)
+            if message["type"] != "http.request":
+                break
+            body = message.get("body", b"")
+            body_size += len(body)
+            more_body = bool(message.get("more_body", False))
+            if body_size > limit:
+                await self._send_too_large(send, limit)
+                return
+
+        replay = _ReplayReceive(body_messages)
+        await self.app(scope, replay, send)
+
+    async def _send_not_found(self, send: Send) -> None:
+        payload = json.dumps({"detail": "Not Found"}).encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 404,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(payload)).encode("ascii")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": payload})
+
+    async def _send_too_large(self, send: Send, limit: int) -> None:
+        payload = json.dumps(
+            {
+                "detail": {
+                    "message": "GraphQL request body exceeds size limit",
+                    "limit_bytes": limit,
+                }
+            }
+        ).encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 413,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(payload)).encode("ascii")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": payload})
+
+
+class _ReplayReceive:
+    def __init__(self, messages: Iterable[Message]) -> None:
+        self._messages = list(messages)
+
+    async def __call__(self) -> Message:
+        if self._messages:
+            return self._messages.pop(0)
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+
+def _accepts_html(scope: Scope) -> bool:
+    headers = dict(scope.get("headers", []))
+    accept = headers.get(b"accept", b"").decode("latin1")
+    return "text/html" in accept

--- a/src/dev_health_ops/api/graphql/security.py
+++ b/src/dev_health_ops/api/graphql/security.py
@@ -50,11 +50,15 @@ def environment_name() -> str:
     """
 
     return (
-        os.getenv("ENVIRONMENT")
-        or os.getenv("APP_ENV")
-        or os.getenv("ENV")
-        or "production"
-    ).strip().lower()
+        (
+            os.getenv("ENVIRONMENT")
+            or os.getenv("APP_ENV")
+            or os.getenv("ENV")
+            or "production"
+        )
+        .strip()
+        .lower()
+    )
 
 
 def is_development_environment() -> bool:

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -44,6 +44,7 @@ from .auth import router as auth_router
 from .auth.router import get_current_user
 from .billing import router as billing_router
 from .graphql.app import create_graphql_app
+from .graphql.security import GraphQLQuerySizeLimitMiddleware
 from .ingest import router as ingest_router
 from .licensing import router as licensing_router
 from .models.filters import (
@@ -318,10 +319,14 @@ async def lifespan(app: FastAPI):
 
             async with get_postgres_session() as _session:
                 await validate_bundle_keys(_session)
-        except FeatureBundleIntegrityError:
-            # Integrity check failed; re-raise to abort startup.
-            raise
         except Exception as _exc:
+            from dev_health_ops.api.billing.bundle_validation import (
+                FeatureBundleIntegrityError,
+            )
+
+            if isinstance(_exc, FeatureBundleIntegrityError):
+                # Integrity check failed; re-raise to abort startup.
+                raise
             logger.warning(
                 "FeatureBundle key validation skipped (DB not ready): %s", _exc
             )
@@ -405,6 +410,7 @@ app.add_middleware(
     expose_headers=["X-Request-ID"],
 )
 app.add_middleware(SecurityHeadersMiddleware)
+app.add_middleware(GraphQLQuerySizeLimitMiddleware)
 OriginValidationMiddleware = import_module(
     "dev_health_ops.api.middleware.csrf"
 ).OriginValidationMiddleware

--- a/tests/api/graphql/test_graphql_hardening.py
+++ b/tests/api/graphql/test_graphql_hardening.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Callable, Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+GRAPHQL_MODULES = [
+    "dev_health_ops.api.graphql.security",
+    "dev_health_ops.api.graphql.schema",
+    "dev_health_ops.api.graphql.app",
+]
+
+
+@pytest.fixture
+def graphql_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[Callable[[str], TestClient]]:
+    def _build(environment: str, *, security_enabled: bool | None = None) -> TestClient:
+        monkeypatch.setenv("ENVIRONMENT", environment)
+        monkeypatch.setenv("GRAPHQL_AUTH_REQUIRED", "false")
+        monkeypatch.delenv("GRAPHQL_IDE_ENABLED", raising=False)
+        monkeypatch.delenv("GRAPHQL_INTROSPECTION_ENABLED", raising=False)
+        monkeypatch.delenv("GRAPHQL_SECURITY_ENABLED", raising=False)
+        monkeypatch.delenv("GRAPHQL_MAX_QUERY_BYTES", raising=False)
+        if security_enabled is not None:
+            monkeypatch.setenv(
+                "GRAPHQL_SECURITY_ENABLED", "true" if security_enabled else "false"
+            )
+
+        for module_name in GRAPHQL_MODULES:
+            sys.modules.pop(module_name, None)
+
+        security = importlib.import_module("dev_health_ops.api.graphql.security")
+        graphql_app = importlib.import_module("dev_health_ops.api.graphql.app")
+
+        app = FastAPI()
+        app.add_middleware(security.GraphQLQuerySizeLimitMiddleware)
+        app.include_router(graphql_app.create_graphql_app(), prefix="/graphql")
+        return TestClient(app, raise_server_exceptions=False)
+
+    yield _build
+
+
+def test_graphiql_disabled_outside_development(graphql_client):
+    client = graphql_client("production")
+
+    response = client.get("/graphql?org_id=test-org", headers={"accept": "text/html"})
+
+    assert response.status_code == 404
+
+
+def test_graphiql_enabled_in_development(graphql_client):
+    client = graphql_client("development")
+
+    response = client.get("/graphql?org_id=test-org", headers={"accept": "text/html"})
+
+    assert response.status_code == 200
+    assert "GraphiQL" in response.text
+
+
+@pytest.mark.parametrize(
+    ("environment", "expect_error"),
+    [("production", True), ("development", False)],
+)
+def test_introspection_rejected_outside_development(
+    graphql_client, environment: str, expect_error: bool
+):
+    client = graphql_client(environment)
+
+    response = client.post(
+        "/graphql?org_id=test-org", json={"query": "{ __schema { queryType { name } } }"}
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    if expect_error:
+        assert "errors" in payload
+        assert "introspection" in payload["errors"][0]["message"].lower()
+    else:
+        assert "errors" not in payload
+        assert payload["data"]["__schema"]["queryType"]["name"] == "Query"
+
+
+def test_query_exceeding_depth_limit_rejected(graphql_client):
+    client = graphql_client("production")
+    deep_query = "{ __type(name: \"Query\") { " + "ofType { " * 13 + "name" + " }" * 13 + " } }"
+
+    response = client.post("/graphql?org_id=test-org", json={"query": deep_query})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "errors" in payload
+    assert any(
+        "depth exceeds limit of 12" in error["message"] for error in payload["errors"]
+    )
+
+
+def test_query_exceeding_alias_limit_rejected(graphql_client):
+    client = graphql_client("production")
+    aliases = " ".join(f"a{i}: __typename" for i in range(16))
+
+    response = client.post("/graphql?org_id=test-org", json={"query": "{ " + aliases + " }"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "errors" in payload
+    assert "alias count exceeds limit of 15" in payload["errors"][0]["message"]
+
+
+def test_query_size_limit_rejected_before_parsing(graphql_client):
+    client = graphql_client("production")
+    oversized_query = "{ __typename }" + (" " * (16 * 1024))
+
+    response = client.post("/graphql?org_id=test-org", json={"query": oversized_query})
+
+    assert response.status_code == 413
+    assert response.json()["detail"]["message"] == "GraphQL request body exceeds size limit"
+
+
+def test_development_environment_permits_alias_depth_and_size_cases(graphql_client):
+    client = graphql_client("development")
+    aliases = " ".join(f"a{i}: __typename" for i in range(16))
+    oversized_query = "{ __typename }" + (" " * (16 * 1024))
+
+    alias_response = client.post(
+        "/graphql?org_id=test-org", json={"query": "{ " + aliases + " }"}
+    )
+    size_response = client.post("/graphql?org_id=test-org", json={"query": oversized_query})
+
+    assert alias_response.status_code == 200
+    assert "errors" not in alias_response.json()
+    assert size_response.status_code == 200
+    assert "errors" not in size_response.json()

--- a/tests/api/graphql/test_graphql_hardening.py
+++ b/tests/api/graphql/test_graphql_hardening.py
@@ -8,7 +8,6 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-
 GRAPHQL_MODULES = [
     "dev_health_ops.api.graphql.security",
     "dev_health_ops.api.graphql.schema",
@@ -17,7 +16,9 @@ GRAPHQL_MODULES = [
 
 
 @pytest.fixture
-def graphql_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[Callable[[str], TestClient]]:
+def graphql_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Callable[[str], TestClient]]:
     def _build(environment: str, *, security_enabled: bool | None = None) -> TestClient:
         monkeypatch.setenv("ENVIRONMENT", environment)
         monkeypatch.setenv("GRAPHQL_AUTH_REQUIRED", "false")
@@ -71,7 +72,8 @@ def test_introspection_rejected_outside_development(
     client = graphql_client(environment)
 
     response = client.post(
-        "/graphql?org_id=test-org", json={"query": "{ __schema { queryType { name } } }"}
+        "/graphql?org_id=test-org",
+        json={"query": "{ __schema { queryType { name } } }"},
     )
 
     assert response.status_code == 200
@@ -86,7 +88,9 @@ def test_introspection_rejected_outside_development(
 
 def test_query_exceeding_depth_limit_rejected(graphql_client):
     client = graphql_client("production")
-    deep_query = "{ __type(name: \"Query\") { " + "ofType { " * 13 + "name" + " }" * 13 + " } }"
+    deep_query = (
+        '{ __type(name: "Query") { ' + "ofType { " * 13 + "name" + " }" * 13 + " } }"
+    )
 
     response = client.post("/graphql?org_id=test-org", json={"query": deep_query})
 
@@ -102,7 +106,9 @@ def test_query_exceeding_alias_limit_rejected(graphql_client):
     client = graphql_client("production")
     aliases = " ".join(f"a{i}: __typename" for i in range(16))
 
-    response = client.post("/graphql?org_id=test-org", json={"query": "{ " + aliases + " }"})
+    response = client.post(
+        "/graphql?org_id=test-org", json={"query": "{ " + aliases + " }"}
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -117,7 +123,10 @@ def test_query_size_limit_rejected_before_parsing(graphql_client):
     response = client.post("/graphql?org_id=test-org", json={"query": oversized_query})
 
     assert response.status_code == 413
-    assert response.json()["detail"]["message"] == "GraphQL request body exceeds size limit"
+    assert (
+        response.json()["detail"]["message"]
+        == "GraphQL request body exceeds size limit"
+    )
 
 
 def test_development_environment_permits_alias_depth_and_size_cases(graphql_client):
@@ -128,7 +137,9 @@ def test_development_environment_permits_alias_depth_and_size_cases(graphql_clie
     alias_response = client.post(
         "/graphql?org_id=test-org", json={"query": "{ " + aliases + " }"}
     )
-    size_response = client.post("/graphql?org_id=test-org", json={"query": oversized_query})
+    size_response = client.post(
+        "/graphql?org_id=test-org", json={"query": oversized_query}
+    )
 
     assert alias_response.status_code == 200
     assert "errors" not in alias_response.json()


### PR DESCRIPTION
## Summary
- Closes design work for CHAOS-1550 and CHAOS-1551 by disabling GraphiQL and schema introspection outside development by default.
- Adds global Strawberry validation hardening via graphql-core rules: depth limit 12, alias limit 15, and `NoSchemaIntrospectionCustomRule`.
- Adds an ASGI HTTP body limit for `/graphql` before parsing (default 16 KB) and updates API docs with the security posture.

## Design choices
- Safe defaults: `ENVIRONMENT` defaults to `production`; GraphiQL/introspection are off unless local development or explicitly opted in.
- Env controls: `GRAPHQL_IDE_ENABLED`, `GRAPHQL_INTROSPECTION_ENABLED`, `GRAPHQL_SECURITY_ENABLED`, `GRAPHQL_MAX_QUERY_BYTES`.
- Small in-tree depth/alias validators avoid a new dependency for two bounded validation rules; resolver cost controls remain unchanged.
- `get_graphql_info()` no longer advertises GraphiQL because clients should not rely on IDE availability.

## Verification
- `pytest tests/api/graphql/ -x -q` → 39 passed.
- `lsp_diagnostics` clean on changed Python files.

## Notes
- Docs partially address CHAOS-1555 posture documentation, but CHAOS-1555 is intentionally not closed here.
- SCREENSHOT-WAIVER: backend GraphQL security posture only; no rendered frontend output changes.