### PR TITLE
sec: harden credential encryption at rest (audit + KDF + rotation)

### DIFF
--- a/docs/security/credential-encryption-audit-2026-05-17.md
+++ b/docs/security/credential-encryption-audit-2026-05-17.md
@@ -1,0 +1,84 @@
+# Credential encryption at rest audit — 2026-05-17
+
+Scope: SQLAlchemy models under `src/dev_health_ops/models/`, with focused review of settings, SSO, credential, token, billing, subscription, and identity-related storage. This audit reframes CHAOS-1552 as hardening: encryption already existed in `dev_health_ops.core.encryption` and callers use it for the primary credential paths.
+
+## Summary by table
+
+| Table | Secret-bearing column(s) | Encrypted at rest? | Risk | Action |
+| --- | --- | --- | --- | --- |
+| `settings` | `value` when `is_encrypted=true` | Yes, through `SettingsService.set(..., encrypt=True)` → `encrypt_value`; read via `SettingsService.get` → `decrypt_value` | Medium | Harden KDF/versioning; operators must set `encrypt=True` for sensitive settings. |
+| `integration_credentials` | `credentials_encrypted` | Yes, through `IntegrationCredentialsService.set` → JSON serialize → `encrypt_value`; read via service/worker `decrypt_value` | Low | Harden KDF/versioning; run v0→v1 re-encryption utility. |
+| `sso_providers` | `encrypted_secrets` values such as OIDC `client_secret` | Yes for service-managed writes via `SSOService.create_provider/update_provider` → per-value `encrypt_value`; OIDC token exchange decrypts via `decrypt_value` | Medium | Harden KDF/versioning; retain legacy plaintext fallback until separately migrated/removed. |
+| `sso_providers` | `config` JSON | No, but reviewed contents are non-secret SAML/OIDC metadata; SAML certificate is public IdP signing material | Low | Keep secrets in `encrypted_secrets`; do not add client secrets to `config`. |
+| `refresh_tokens` | `token_hash`, `replaced_by_hash` | Not encrypted; token material is hashed, not stored | Low | No encryption required; continue storing only hashes. |
+| `password_reset_tokens` | `token_hash` | Not encrypted; token material is hashed, not stored | Low | No encryption required; continue storing only hashes. |
+| `email_verification_tokens` | `token_hash` | Not encrypted; token material is hashed, not stored | Low | No encryption required; continue storing only hashes. |
+| `billing_audit_log` | `local_state`, `stripe_state` | No | Low | Reviewed as audit/provider state, not credential storage; avoid logging webhook secrets or payment secrets. |
+| `billing_plans`, `billing_prices`, `subscriptions`, `subscription_events` | Stripe IDs, metadata | No | Low | IDs are not API credentials; avoid storing provider secrets in metadata. |
+
+## Detailed findings
+
+### `settings.value`
+
+- Location: `src/dev_health_ops/models/settings.py`, `Setting.value` with `Setting.is_encrypted`.
+- Secret types: generic application secrets stored as settings when callers pass `encrypt=True`.
+- Encryption path: `src/dev_health_ops/api/services/settings.py` `SettingsService.set` encrypts values with `encrypt_value` when `encrypt=True`; `SettingsService.get` decrypts when `is_encrypted` is true.
+- Status: encrypted at rest for encrypted settings.
+- Severity: Medium, because correctness depends on callers marking sensitive settings with `encrypt=True`.
+- Recommendation: keep sensitive settings on this path, document operator expectations, and use the v0→v1 re-encryption utility after deployment.
+
+### `integration_credentials.credentials_encrypted`
+
+- Location: `src/dev_health_ops/models/settings.py`, `IntegrationCredential.credentials_encrypted`.
+- Secret types: provider API tokens/keys for GitHub, GitLab, Jira, Linear, Atlassian, LaunchDarkly, telemetry, and similar integrations.
+- Encryption path: `IntegrationCredentialsService.set` normalizes credential keys, serializes the credential JSON, and writes `encrypt_value(json.dumps(credentials))`; `IntegrationCredentialsService.get/get_decrypted` and `workers/task_utils.py` decrypt with `decrypt_value`.
+- Status: encrypted at rest.
+- Severity: Low after hardening; previously used a raw SHA-256-derived Fernet key.
+- Recommendation: run `python scripts/reencrypt_settings_credentials.py --apply` to rewrite legacy unprefixed ciphertexts as `v1:`.
+
+### `sso_providers.encrypted_secrets`
+
+- Location: `src/dev_health_ops/models/sso.py`, `SSOProvider.encrypted_secrets`.
+- Secret types: OIDC/OAuth client secrets and transient SSO state/nonce values when supplied as secret fields.
+- Encryption path: `SSOService.create_provider` and `SSOService.update_provider` encrypt every string value in `encrypted_secrets`; `_exchange_oidc_code` decrypts `client_secret` before token exchange.
+- Status: encrypted at rest for service-managed writes.
+- Severity: Medium, because `_exchange_oidc_code` still has a compatibility fallback that treats undecryptable `client_secret` as pre-encryption plaintext.
+- Recommendation: use the v0→v1 re-encryption utility for encrypted values and file a follow-up to remove plaintext fallback after confirming no legacy plaintext rows remain.
+
+### `sso_providers.config`
+
+- Location: `src/dev_health_ops/models/sso.py`, `SSOProvider.config`.
+- Secret types: none expected. The model comments list SAML IdP entity/URLs, public signing certificate, OIDC issuer/endpoints/JWKS, scopes, and claim mapping.
+- Encryption path: none.
+- Status: not encrypted; acceptable for non-secret metadata.
+- Severity: Low.
+- Recommendation: keep OIDC `client_secret` out of `config`; store it only in `encrypted_secrets`.
+
+### Token tables
+
+- Locations:
+  - `src/dev_health_ops/models/refresh_token.py`, `RefreshToken.token_hash`, `RefreshToken.replaced_by_hash`
+  - `src/dev_health_ops/models/password_reset_token.py`, `PasswordResetToken.token_hash`
+  - `src/dev_health_ops/models/email_verification_token.py`, `EmailVerificationToken.token_hash`
+- Secret types: bearer token equivalents, but only hashes are persisted.
+- Encryption path: none; not required because plaintext token material is not stored.
+- Status: hashed at rest.
+- Severity: Low.
+- Recommendation: continue storing hashes only.
+
+### Billing and subscription models
+
+- Locations:
+  - `src/dev_health_ops/models/billing.py`
+  - `src/dev_health_ops/models/billing_audit.py`
+  - `src/dev_health_ops/models/subscriptions.py`
+- Secret types: none identified. Stored values are Stripe product/price/customer/subscription IDs, metadata, events, and audit snapshots.
+- Encryption path: none.
+- Status: not encrypted; no credential columns identified.
+- Severity: Low.
+- Recommendation: ensure audit/event state never includes Stripe webhook signing secrets, API keys, or payment secrets.
+
+## Dependency discovery
+
+- `cryptography` is used directly by `dev_health_ops.core.encryption` and is now declared as a direct dependency.
+- `PyNaCl` is used by licensing (`src/dev_health_ops/licensing/generator.py`, `src/dev_health_ops/licensing/validator.py`) and is not removed.

--- a/docs/security/credential-encryption-rotation.md
+++ b/docs/security/credential-encryption-rotation.md
@@ -1,0 +1,43 @@
+# Credential encryption key rotation
+
+This runbook rotates data protected by `SETTINGS_ENCRYPTION_KEY` without breaking existing rows.
+
+## Current format
+
+- `v1:` ciphertexts use Fernet with a PBKDF2-HMAC-SHA256 derived key.
+- PBKDF2 uses `SETTINGS_ENCRYPTION_SALT` and 600,000 iterations.
+- Legacy rows without a prefix are still decrypted with the old SHA-256-derived key for backwards compatibility.
+- The built-in salt is for backwards compatibility only. Production must set an explicit stable `SETTINGS_ENCRYPTION_SALT`.
+
+## Rotate from legacy v0 rows to v1
+
+1. Confirm the current key and salt are present in the runtime environment:
+   - `SETTINGS_ENCRYPTION_KEY=<current key>`
+   - `SETTINGS_ENCRYPTION_SALT=<explicit production salt>`
+   - `POSTGRES_URI=<semantic database>`
+2. Dry-run the upgrade:
+   ```bash
+   python scripts/reencrypt_settings_credentials.py
+   ```
+3. Apply the upgrade:
+   ```bash
+   python scripts/reencrypt_settings_credentials.py --apply
+   ```
+4. Restart API and worker processes so all writers emit `v1:` ciphertexts.
+5. Re-run the dry-run command. `upgraded=0` and `failed=0` should be reported.
+
+## Rotate `SETTINGS_ENCRYPTION_KEY`
+
+1. Keep the old key deployed.
+2. Run the v0-to-v1 upgrade above until no legacy rows remain.
+3. Take an encrypted database backup.
+4. In a maintenance window, deploy code configured with the new key and the same salt.
+5. Re-encrypt each encrypted value by decrypting with the old key and encrypting with the new key. If the old key is no longer available to the same process, run this as a controlled one-off job that has both values as separate environment variables and calls `decrypt_value` with the old key before writing with the new key.
+6. Restart all API and worker processes with only the new `SETTINGS_ENCRYPTION_KEY`.
+7. Validate settings, integration credential test connections, and SSO login flows.
+
+## Recovery
+
+- If decryption errors appear immediately after rotation, restore the previous `SETTINGS_ENCRYPTION_KEY` and restart API/workers.
+- If the re-encryption utility reports failures, stop and inspect the affected rows before retrying. Failures usually mean the row is plaintext, corrupted, or encrypted with an unexpected key.
+- If a deployment accidentally omits `SETTINGS_ENCRYPTION_SALT`, restore the explicit production salt and restart before writing new credentials.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ dependencies = [
   "PyJWT>=2.8.0",
   "bcrypt>=4.0.0",
   "email-validator>=2.0.0",
+  "cryptography>=41.0.0",
+  # Used by licensing Ed25519 signing/verification; do not remove with credential hardening.
   "PyNaCl>=1.5.0",
   "defusedxml>=0.7.0",
   "stripe>=7.0.0",

--- a/scripts/reencrypt_settings_credentials.py
+++ b/scripts/reencrypt_settings_credentials.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+"""Re-encrypt legacy v0 credential ciphertexts to v1 in place.
+
+This utility upgrades rows encrypted with the pre-v1 SHA-256-derived Fernet key.
+It is idempotent: values already prefixed with ``v1:`` are skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import select
+
+from dev_health_ops.core.encryption import is_v1_ciphertext, reencrypt_legacy_value
+from dev_health_ops.db import get_postgres_session
+from dev_health_ops.models.settings import IntegrationCredential, Setting
+from dev_health_ops.models.sso import SSOProvider
+
+
+@dataclass
+class ReencryptStats:
+    scanned: int = 0
+    upgraded: int = 0
+    skipped_v1: int = 0
+    failed: int = 0
+
+    def merge(self, other: "ReencryptStats") -> None:
+        self.scanned += other.scanned
+        self.upgraded += other.upgraded
+        self.skipped_v1 += other.skipped_v1
+        self.failed += other.failed
+
+
+def _upgrade_ciphertext(value: str | None) -> tuple[str | None, str]:
+    if not value:
+        return value, "empty"
+    if is_v1_ciphertext(value):
+        return value, "v1"
+    return reencrypt_legacy_value(value), "upgraded"
+
+
+async def _upgrade_settings(dry_run: bool) -> ReencryptStats:
+    stats = ReencryptStats()
+    async with get_postgres_session() as session:
+        result = await session.execute(
+            select(Setting).where(
+                Setting.is_encrypted == True,  # noqa: E712
+                Setting.value.is_not(None),
+            )
+        )
+        for row in result.scalars():
+            stats.scanned += 1
+            try:
+                upgraded, status = _upgrade_ciphertext(row.value)
+            except ValueError:
+                stats.failed += 1
+                continue
+            if status == "v1":
+                stats.skipped_v1 += 1
+            elif status == "upgraded":
+                stats.upgraded += 1
+                if not dry_run:
+                    row.value = upgraded
+        if not dry_run:
+            await session.commit()
+    return stats
+
+
+async def _upgrade_integration_credentials(dry_run: bool) -> ReencryptStats:
+    stats = ReencryptStats()
+    async with get_postgres_session() as session:
+        result = await session.execute(
+            select(IntegrationCredential).where(
+                IntegrationCredential.credentials_encrypted.is_not(None)
+            )
+        )
+        for row in result.scalars():
+            stats.scanned += 1
+            try:
+                upgraded, status = _upgrade_ciphertext(row.credentials_encrypted)
+            except ValueError:
+                stats.failed += 1
+                continue
+            if status == "v1":
+                stats.skipped_v1 += 1
+            elif status == "upgraded":
+                stats.upgraded += 1
+                if not dry_run:
+                    row.credentials_encrypted = upgraded
+        if not dry_run:
+            await session.commit()
+    return stats
+
+
+def _upgrade_secret_map(value: dict[str, Any] | None, stats: ReencryptStats) -> bool:
+    changed = False
+    if not value:
+        return changed
+    for key, item in list(value.items()):
+        if not isinstance(item, str):
+            continue
+        stats.scanned += 1
+        try:
+            upgraded, status = _upgrade_ciphertext(item)
+        except ValueError:
+            stats.failed += 1
+            continue
+        if status == "v1":
+            stats.skipped_v1 += 1
+        elif status == "upgraded":
+            stats.upgraded += 1
+            value[key] = upgraded
+            changed = True
+    return changed
+
+
+async def _upgrade_sso_secrets(dry_run: bool) -> ReencryptStats:
+    stats = ReencryptStats()
+    async with get_postgres_session() as session:
+        result = await session.execute(
+            select(SSOProvider).where(SSOProvider.encrypted_secrets.is_not(None))
+        )
+        for row in result.scalars():
+            secrets = dict(row.encrypted_secrets or {})
+            changed = _upgrade_secret_map(secrets, stats)
+            if changed and not dry_run:
+                row.encrypted_secrets = secrets
+        if not dry_run:
+            await session.commit()
+    return stats
+
+
+async def _run(dry_run: bool) -> ReencryptStats:
+    total = ReencryptStats()
+    for upgrade in (
+        _upgrade_settings,
+        _upgrade_integration_credentials,
+        _upgrade_sso_secrets,
+    ):
+        total.merge(await upgrade(dry_run))
+    return total
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Re-encrypt legacy v0 settings/credential ciphertexts to v1."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write upgraded ciphertexts. Without this flag the command is dry-run only.",
+    )
+    args = parser.parse_args()
+
+    stats = asyncio.run(_run(dry_run=not args.apply))
+    mode = "apply" if args.apply else "dry-run"
+    print(
+        f"mode={mode} scanned={stats.scanned} upgraded={stats.upgraded} "
+        f"skipped_v1={stats.skipped_v1} failed={stats.failed}"
+    )
+    if stats.failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reencrypt_settings_credentials.py
+++ b/scripts/reencrypt_settings_credentials.py
@@ -27,7 +27,7 @@ class ReencryptStats:
     skipped_v1: int = 0
     failed: int = 0
 
-    def merge(self, other: "ReencryptStats") -> None:
+    def merge(self, other: ReencryptStats) -> None:
         self.scanned += other.scanned
         self.upgraded += other.upgraded
         self.skipped_v1 += other.skipped_v1

--- a/src/dev_health_ops/core/encryption.py
+++ b/src/dev_health_ops/core/encryption.py
@@ -12,41 +12,101 @@ import base64
 import hashlib
 import logging
 import os
+from hmac import compare_digest
 
 from cryptography.fernet import Fernet, InvalidToken
 
 logger = logging.getLogger(__name__)
 
+KEY_VERSION_PREFIX = "v1:"
+PBKDF2_ITERATIONS = 600_000
+
+# Backwards-compatibility default only. Production deployments should set an
+# explicit, stable SETTINGS_ENCRYPTION_SALT before writing v1 ciphertexts.
+DEFAULT_SETTINGS_ENCRYPTION_SALT = "dev-health-ops-settings-encryption-v1"
+
 
 def _derive_key(secret: str) -> bytes:
-    """Derive a Fernet-compatible key from a secret string using SHA-256."""
+    """Derive a Fernet-compatible v1 key with PBKDF2-HMAC-SHA256."""
+    salt = os.getenv(
+        "SETTINGS_ENCRYPTION_SALT",
+        DEFAULT_SETTINGS_ENCRYPTION_SALT,
+    ).encode()
+    digest = hashlib.pbkdf2_hmac(
+        "sha256",
+        secret.encode(),
+        salt,
+        PBKDF2_ITERATIONS,
+        dklen=32,
+    )
+    return base64.urlsafe_b64encode(digest)
+
+
+def _derive_legacy_key(secret: str) -> bytes:
+    """Derive the legacy v0 Fernet key from raw SHA-256 for old rows."""
     digest = hashlib.sha256(secret.encode()).digest()
     return base64.urlsafe_b64encode(digest)
 
 
-def _get_encryption_key() -> bytes:
-    """Get the encryption key from environment, deriving it if needed."""
+def _get_encryption_secret() -> str:
+    """Get the encryption secret from environment."""
     secret = os.getenv("SETTINGS_ENCRYPTION_KEY")
     if not secret:
         raise RuntimeError(
             "SETTINGS_ENCRYPTION_KEY environment variable is required for encryption"
         )
-    return _derive_key(secret)
+    return secret
+
+
+def _get_encryption_key() -> bytes:
+    """Get the current v1 encryption key from environment."""
+    return _derive_key(_get_encryption_secret())
+
+
+def _get_legacy_encryption_key() -> bytes:
+    """Get the legacy v0 encryption key from environment."""
+    return _derive_legacy_key(_get_encryption_secret())
+
+
+def is_v1_ciphertext(value: str | None) -> bool:
+    """Return True when a value has the current v1 ciphertext prefix."""
+    return bool(value) and value.startswith(KEY_VERSION_PREFIX)
 
 
 def encrypt_value(plaintext: str) -> str:
-    """Encrypt a plaintext string and return base64-encoded ciphertext."""
+    """Encrypt a plaintext string and return version-prefixed ciphertext."""
     key = _get_encryption_key()
     f = Fernet(key)
-    return f.encrypt(plaintext.encode()).decode()
+    return f"{KEY_VERSION_PREFIX}{f.encrypt(plaintext.encode()).decode()}"
 
 
 def decrypt_value(ciphertext: str) -> str:
-    """Decrypt a base64-encoded ciphertext and return plaintext."""
-    key = _get_encryption_key()
+    """Decrypt v1 or legacy v0 ciphertext and return plaintext."""
+    if ciphertext.startswith(KEY_VERSION_PREFIX):
+        key = _get_encryption_key()
+        token = ciphertext.removeprefix(KEY_VERSION_PREFIX)
+    elif ciphertext.startswith("v") and ":" in ciphertext:
+        version = ciphertext.split(":", 1)[0]
+        logger.error("Unsupported encrypted value version: %s", version)
+        raise ValueError("Decryption failed - unsupported ciphertext version")
+    else:
+        key = _get_legacy_encryption_key()
+        token = ciphertext
+
     f = Fernet(key)
     try:
-        return f.decrypt(ciphertext.encode()).decode()
+        return f.decrypt(token.encode()).decode()
     except InvalidToken:
         logger.error("Failed to decrypt value - invalid token or wrong key")
         raise ValueError("Decryption failed - check SETTINGS_ENCRYPTION_KEY")
+
+
+def reencrypt_legacy_value(ciphertext: str) -> str:
+    """Return v1 ciphertext for a legacy v0 value; leave v1 values unchanged."""
+    if is_v1_ciphertext(ciphertext):
+        return ciphertext
+    plaintext = decrypt_value(ciphertext)
+    new_ciphertext = encrypt_value(plaintext)
+    if compare_digest(new_ciphertext, ciphertext):
+        raise ValueError("Re-encryption failed to produce a new ciphertext version")
+    return new_ciphertext

--- a/src/dev_health_ops/core/encryption.py
+++ b/src/dev_health_ops/core/encryption.py
@@ -86,8 +86,11 @@ def decrypt_value(ciphertext: str) -> str:
         key = _get_encryption_key()
         token = ciphertext.removeprefix(KEY_VERSION_PREFIX)
     elif ciphertext.startswith("v") and ":" in ciphertext:
-        version = ciphertext.split(":", 1)[0]
-        logger.error("Unsupported encrypted value version: %s", version)
+        # NOTE: deliberately do not log the parsed version prefix. CodeQL
+        # (py/clear-text-logging-sensitive-data) flags any logging of values
+        # derived from ciphertext, even when the derived value is only a
+        # short non-secret tag like "v2". The exception message below is
+        # sufficient for operators; full ciphertext is never persisted to logs.
         raise ValueError("Decryption failed - unsupported ciphertext version")
     else:
         key = _get_legacy_encryption_key()

--- a/src/dev_health_ops/core/encryption.py
+++ b/src/dev_health_ops/core/encryption.py
@@ -70,7 +70,7 @@ def _get_legacy_encryption_key() -> bytes:
 
 def is_v1_ciphertext(value: str | None) -> bool:
     """Return True when a value has the current v1 ciphertext prefix."""
-    return bool(value) and value.startswith(KEY_VERSION_PREFIX)
+    return value is not None and value.startswith(KEY_VERSION_PREFIX)
 
 
 def encrypt_value(plaintext: str) -> str:

--- a/tests/core/test_encryption.py
+++ b/tests/core/test_encryption.py
@@ -29,10 +29,14 @@ def test_round_trip_encrypts_and_decrypts(monkeypatch: pytest.MonkeyPatch) -> No
     assert encryption.decrypt_value(ciphertext) == "super-secret"
 
 
-def test_pbkdf2_key_derivation_is_deterministic(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_pbkdf2_key_derivation_is_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     _set_key(monkeypatch)
 
-    assert encryption._derive_key("same-secret") == encryption._derive_key("same-secret")
+    assert encryption._derive_key("same-secret") == encryption._derive_key(
+        "same-secret"
+    )
     assert encryption._derive_key("same-secret") != encryption._derive_legacy_key(
         "same-secret"
     )

--- a/tests/core/test_encryption.py
+++ b/tests/core/test_encryption.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+
+import pytest
+from cryptography.fernet import Fernet
+
+from dev_health_ops.core import encryption
+
+
+def _set_key(monkeypatch: pytest.MonkeyPatch, key: str = "test-key") -> None:
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", key)
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_SALT", "test-salt")
+
+
+def _legacy_ciphertext(secret: str, plaintext: str) -> str:
+    digest = hashlib.sha256(secret.encode()).digest()
+    key = base64.urlsafe_b64encode(digest)
+    return Fernet(key).encrypt(plaintext.encode()).decode()
+
+
+def test_round_trip_encrypts_and_decrypts(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_key(monkeypatch)
+
+    ciphertext = encryption.encrypt_value("super-secret")
+
+    assert ciphertext != "super-secret"
+    assert encryption.decrypt_value(ciphertext) == "super-secret"
+
+
+def test_pbkdf2_key_derivation_is_deterministic(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_key(monkeypatch)
+
+    assert encryption._derive_key("same-secret") == encryption._derive_key("same-secret")
+    assert encryption._derive_key("same-secret") != encryption._derive_legacy_key(
+        "same-secret"
+    )
+
+
+def test_legacy_v0_ciphertext_still_decrypts(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_key(monkeypatch, "legacy-secret")
+    ciphertext = _legacy_ciphertext("legacy-secret", "old-row-value")
+
+    assert not ciphertext.startswith(encryption.KEY_VERSION_PREFIX)
+    assert encryption.decrypt_value(ciphertext) == "old-row-value"
+
+
+def test_v1_ciphertext_gets_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_key(monkeypatch)
+
+    assert encryption.encrypt_value("new-row-value").startswith(
+        encryption.KEY_VERSION_PREFIX
+    )
+
+
+def test_wrong_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_key(monkeypatch, "correct-key")
+    ciphertext = encryption.encrypt_value("secret")
+
+    _set_key(monkeypatch, "wrong-key")
+
+    with pytest.raises(ValueError, match="Decryption failed"):
+        encryption.decrypt_value(ciphertext)
+
+
+def test_malformed_ciphertext_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_key(monkeypatch)
+
+    with pytest.raises(ValueError, match="Decryption failed"):
+        encryption.decrypt_value(f"{encryption.KEY_VERSION_PREFIX}not-fernet")
+
+
+def test_missing_env_var_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SETTINGS_ENCRYPTION_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="SETTINGS_ENCRYPTION_KEY"):
+        encryption.encrypt_value("secret")
+
+
+def test_salt_change_cannot_decrypt(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_key(monkeypatch)
+    ciphertext = encryption.encrypt_value("salt-bound-secret")
+
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_SALT", "different-salt")
+
+    with pytest.raises(ValueError, match="Decryption failed"):
+        encryption.decrypt_value(ciphertext)
+
+
+def test_reencrypt_legacy_value_returns_v1(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_key(monkeypatch, "legacy-secret")
+    legacy = _legacy_ciphertext("legacy-secret", "old-row-value")
+
+    upgraded = encryption.reencrypt_legacy_value(legacy)
+
+    assert upgraded.startswith(encryption.KEY_VERSION_PREFIX)
+    assert encryption.decrypt_value(upgraded) == "old-row-value"


### PR DESCRIPTION
## Summary
- Links CHAOS-1552.
- Audits SQLAlchemy secret storage and commits `docs/security/credential-encryption-audit-2026-05-17.md`.
- Hardens credential encryption with PBKDF2-HMAC-SHA256, explicit salt support, `v1:` ciphertext prefixing, and legacy v0 decrypt fallback.
- Adds a v0→v1 re-encryption utility plus key rotation runbook.

## Audit findings
- `settings.value` is encrypted when `is_encrypted=true`; risk is caller misuse.
- `integration_credentials.credentials_encrypted` is encrypted via IntegrationCredentialsService.
- `sso_providers.encrypted_secrets` is encrypted for service-managed writes; plaintext compatibility fallback remains for legacy rows.
- Token tables store hashes only, not plaintext tokens.
- Billing/subscription tables store provider IDs/audit state; no credential columns identified.

## Verification
- `pytest tests/core/test_encryption.py -x -q` ✅ 9 passed
- `pytest tests/api/services/ -x -q -k "settings or sso"` ✅ 13 passed
- `lsp_diagnostics` on changed Python files ✅ clean
- `alembic upgrade head` attempted against SQLite and configured Postgres; SQLite hit existing 0001 SQLite-incompatible DDL, Postgres connection was unavailable in local environment. No Alembic migration is included because no plaintext secret column requiring schema/data migration was identified.

SCREENSHOT-WAIVER: backend encryption/docs/tooling only; no rendered frontend output changes.