### PR TITLE
sec: workflow permissions + action SHA pinning

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,5 +1,8 @@
 name: Claude Code Review
 
+permissions:
+  contents: read
+
 on:
   issue_comment:
     types: [created]
@@ -16,6 +19,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     runs-on: ubuntu-latest
+    # Claude review needs PR, issue, and OIDC write access to post feedback.
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/cloud-deploy.yml
+++ b/.github/workflows/cloud-deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy cloud services
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,10 +14,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    # CodeQL needs SARIF upload and audit access for security results.
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   governance:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,10 +11,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   integration:
     name: Integration Tests (conditional)
     runs-on: ubuntu-24.04-arm
+    # Integration tests need package read access for dependency installs.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -42,6 +45,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    # Lint job needs package read access for dependency installs.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -46,6 +49,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    # Live E2E needs package read access for dependency installs.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,6 +14,7 @@ jobs:
   build-and-publish:
     name: Build and Publish
     runs-on: ubuntu-latest
+    # Trusted publishing needs OIDC token exchange for PyPI.
     permissions:
       contents: read
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing

--- a/.github/workflows/scheduled-scan.yml
+++ b/.github/workflows/scheduled-scan.yml
@@ -14,10 +14,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload pip-audit report
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pip-audit-weekly-report
           path: pip-audit-report.md

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pip-audit:
     name: Dependency Vulnerability Scan (pip-audit)
@@ -19,10 +22,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -52,7 +55,7 @@ jobs:
 
       - name: Upload pip-audit report
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pip-audit-report
           path: pip-audit-report.md
@@ -87,6 +90,7 @@ jobs:
     name: Gitleaks Secret Scan
     runs-on: ubuntu-latest
     continue-on-error: true
+    # Gitleaks needs security-events write access to upload findings.
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -40,6 +43,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04-arm
+    # Test matrix needs package read access for dependency installs.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -41,6 +44,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    # Typecheck job needs package read access for dependency installs.
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
## Summary
- Relates to CHAOS-1535 and CHAOS-1536.
- Adds explicit read-only top-level permissions to workflows missing them, while keeping only the minimal per-job escalations that already existed or are required.
- Pins the remaining floating GitHub Actions refs to exact commit SHAs.

## Files changed
- .github/workflows/claude-code-review.yml
- .github/workflows/cloud-deploy.yml
- .github/workflows/codeql-analysis.yml
- .github/workflows/governance.yml
- .github/workflows/integration.yml
- .github/workflows/lint.yml
- .github/workflows/live-e2e.yml
- .github/workflows/publish-pypi.yml
- .github/workflows/scheduled-scan.yml
- .github/workflows/security-scan.yml
- .github/workflows/test.yml
- .github/workflows/typecheck.yml

## Per-job escalations kept/annotated
- claude-code-review: PR/issue write + id-token write for review posting.
- codeql-analysis: actions read + security-events write for CodeQL SARIF upload.
- integration/lint/live-e2e/test/typecheck: packages read for dependency installs.
- publish-pypi: id-token write for trusted publishing.
- security-scan (gitleaks): security-events write for findings upload.

## SHA pinning
- actions/checkout -> de0fac2e4500dabe0009e67214ff5f5447ce83dd
- actions/setup-python -> a309ff8b426b58ec0e2a45f0f869d46889d02405
- actions/upload-artifact -> 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a