### PR TITLE
fix(cli): accept --org and other globals after subcommand (CHAOS-1557)

### DIFF
--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -119,13 +119,32 @@ async def _cmd_maintenance_cleanup_all(_ns: argparse.Namespace) -> int:
     )
     return 0
 
+
 _GLOBAL_FLAG_SPECS: tuple[tuple[tuple[str, ...], dict[str, object]], ...] = (
-    (("--log-level",), {"dest": "log_level", "help": "(global) Logging level. See root --help."}),
+    (
+        ("--log-level",),
+        {"dest": "log_level", "help": "(global) Logging level. See root --help."},
+    ),
     (("--db",), {"dest": "db", "help": "(global) PostgreSQL URI. See root --help."}),
-    (("--analytics-db",), {"dest": "analytics_db", "help": "(global) ClickHouse URI. See root --help."}),
-    (("--org",), {"dest": "org", "help": "(global) Organization ID for multi-tenant scoping. See root --help."}),
-    (("-l", "--llm-provider"), {"dest": "llm_provider", "help": "(global) LLM provider. See root --help."}),
-    (("-m", "--model"), {"dest": "model", "help": "(global) LLM model. See root --help."}),
+    (
+        ("--analytics-db",),
+        {"dest": "analytics_db", "help": "(global) ClickHouse URI. See root --help."},
+    ),
+    (
+        ("--org",),
+        {
+            "dest": "org",
+            "help": "(global) Organization ID for multi-tenant scoping. See root --help.",
+        },
+    ),
+    (
+        ("-l", "--llm-provider"),
+        {"dest": "llm_provider", "help": "(global) LLM provider. See root --help."},
+    ),
+    (
+        ("-m", "--model"),
+        {"dest": "model", "help": "(global) LLM model. See root --help."},
+    ),
 )
 
 

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -187,8 +187,15 @@ def _propagate_global_args_to_subparsers(parser: argparse.ArgumentParser) -> Non
                     # help is set per-spec to advertise the flag on every leaf
                     **kwargs,  # type: ignore[arg-type]
                 )
-            except argparse.ArgumentError:
-                pass
+            except argparse.ArgumentError as exc:
+                # Best-effort propagation: some leaf parsers may already define
+                # an equivalent/conflicting option. Keep building the CLI tree.
+                logging.debug(
+                    "Skipping global flag propagation for %s on parser %s: %s",
+                    option_strings,
+                    p.prog,
+                    exc,
+                )
 
     walk(parser)
 

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -119,6 +119,60 @@ async def _cmd_maintenance_cleanup_all(_ns: argparse.Namespace) -> int:
     )
     return 0
 
+_GLOBAL_FLAG_SPECS: tuple[tuple[tuple[str, ...], dict[str, object]], ...] = (
+    (("--log-level",), {"dest": "log_level", "help": "(global) Logging level. See root --help."}),
+    (("--db",), {"dest": "db", "help": "(global) PostgreSQL URI. See root --help."}),
+    (("--analytics-db",), {"dest": "analytics_db", "help": "(global) ClickHouse URI. See root --help."}),
+    (("--org",), {"dest": "org", "help": "(global) Organization ID for multi-tenant scoping. See root --help."}),
+    (("-l", "--llm-provider"), {"dest": "llm_provider", "help": "(global) LLM provider. See root --help."}),
+    (("-m", "--model"), {"dest": "model", "help": "(global) LLM model. See root --help."}),
+)
+
+
+def _propagate_global_args_to_subparsers(parser: argparse.ArgumentParser) -> None:
+    """Re-add root-parser globals on every leaf subparser.
+
+    Argparse normally requires global flags (e.g. ``--org``) to appear BEFORE
+    the subcommand. This walks the subparser tree and adds each global flag
+    to every leaf parser with ``default=SUPPRESS`` so users can write either:
+
+        dev-hops --org X fixtures generate ...
+        dev-hops fixtures generate --org X ...
+
+    Both forms populate ``ns.<dest>``. ``SUPPRESS`` ensures omitting the flag
+    on the leaf does not clobber the value supplied on the root parser.
+    """
+    visited: set[int] = set()
+
+    def walk(p: argparse.ArgumentParser) -> None:
+        if id(p) in visited:
+            return
+        visited.add(id(p))
+        sub_actions = [
+            a for a in p._actions if isinstance(a, argparse._SubParsersAction)
+        ]
+        if sub_actions:
+            for sa in sub_actions:
+                for child in sa.choices.values():
+                    walk(child)
+            return
+        # leaf parser: attach global flags if not already present
+        existing = {opt for a in p._actions for opt in a.option_strings}
+        for option_strings, kwargs in _GLOBAL_FLAG_SPECS:
+            if any(opt in existing for opt in option_strings):
+                continue
+            try:
+                p.add_argument(
+                    *option_strings,
+                    default=argparse.SUPPRESS,
+                    # help is set per-spec to advertise the flag on every leaf
+                    **kwargs,  # type: ignore[arg-type]
+                )
+            except argparse.ArgumentError:
+                pass
+
+    walk(parser)
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -229,6 +283,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     cleanup_all_parser.set_defaults(func=_cmd_maintenance_cleanup_all)
 
+    _propagate_global_args_to_subparsers(parser)
     return parser
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -411,3 +411,78 @@ class TestSyncTimeWindowCLIArguments:
         )
         assert str(args.since) == "2025-01-01"
         assert str(args.date) == "2025-01-02"
+
+
+class TestGlobalFlagsPropagateToSubparsers:
+    """Regression: global flags (--org, --db, --analytics-db, --log-level,
+    --llm-provider, --model) must be accepted EITHER before OR after the
+    subcommand. Previously argparse rejected the after-subcommand form with
+    `unrecognized arguments: --org X`."""
+
+    def test_org_accepted_after_fixtures_generate(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            ["fixtures", "generate", "--org", "acme-org", "--days", "1"]
+        )
+        assert args.org == "acme-org"
+        assert args.days == 1
+
+    def test_org_accepted_after_sync_git(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "sync",
+                "git",
+                "--provider",
+                "github",
+                "--search",
+                "org/*",
+                "--org",
+                "acme-org",
+            ]
+        )
+        assert args.org == "acme-org"
+
+    def test_org_accepted_after_metrics_daily(self):
+        parser = build_parser()
+        args = parser.parse_args(["metrics", "daily", "--org", "acme-org"])
+        assert args.org == "acme-org"
+
+    def test_org_accepted_after_audit_perf(self):
+        parser = build_parser()
+        args = parser.parse_args(["audit", "perf", "--org", "acme-org"])
+        assert args.org == "acme-org"
+
+    def test_org_before_subcommand_still_works(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            ["--org", "acme-org", "fixtures", "generate", "--days", "1"]
+        )
+        assert args.org == "acme-org"
+
+    def test_db_analytics_db_and_log_level_propagate_to_leaves(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "fixtures",
+                "generate",
+                "--db",
+                "sqlite+aiosqlite:///:memory:",
+                "--analytics-db",
+                "clickhouse://localhost:8123/default",
+                "--log-level",
+                "DEBUG",
+            ]
+        )
+        assert args.db == "sqlite+aiosqlite:///:memory:"
+        assert args.analytics_db == "clickhouse://localhost:8123/default"
+        assert args.log_level == "DEBUG"
+
+    def test_root_default_preserved_when_leaf_flag_omitted(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            ["--org", "from-root", "fixtures", "generate", "--days", "1"]
+        )
+        # Leaf parser uses default=SUPPRESS, so omitting --org on the leaf must
+        # NOT clobber the value supplied before the subcommand.
+        assert args.org == "from-root"


### PR DESCRIPTION
Closes [CHAOS-1557](https://linear.app/fullchaos/issue/CHAOS-1557).

## Problem

Global argparse flags (`--org`, `--db`, `--analytics-db`, `--log-level`, `--llm-provider`, `--model`) were defined only on the **root** parser. They had to be passed BEFORE the subcommand, and they did not appear in subcommand `--help` output:

```
$ dev-hops fixtures generate --org X --days 30
dev-health-ops: error: unrecognized arguments: --org X
```

Affected every subcommand that consumes `ns.org` — fixtures, sync git/prs/blame/cicd/deployments/incidents/teams, metrics daily/dora/complexity/ff/release, audit perf/coverage/completeness/schema, work-graph, backfill.

## Fix

Walk the subparser tree at the end of `build_parser()` and add each global flag to every leaf subparser with `default=argparse.SUPPRESS`. The `SUPPRESS` default means omitting the flag on the leaf does **not** clobber a value supplied on the root parser. Help text marks each propagated flag as `(global)` so users discover them from per-subcommand `--help`.

Both invocation styles now work:

```
dev-hops --org X fixtures generate --days 30   # before subcommand (still works)
dev-hops fixtures generate --org X --days 30   # after subcommand  (now works)
```

## Verification

- 7 new regression tests in `tests/test_utils.py::TestGlobalFlagsPropagateToSubparsers` cover the after-subcommand position on `fixtures generate`, `sync git`, `metrics daily`, `audit perf`, plus `--db`/`--analytics-db`/`--log-level` propagation, plus the SUPPRESS-preserves-root-default semantics.
- Full `tests/test_utils.py` + related CLI tests: **78 passed**.
- `mypy` clean, `ruff` clean.

## Diff scope

- `src/dev_health_ops/cli.py` — `+55` lines (new helper + one call site)
- `tests/test_utils.py` — `+75` lines (new test class)

No subparser registration files touched. No behaviour change for callers that already used the before-subcommand form or the `ORG_ID` env var.

SCREENSHOT-WAIVER: CLI argparse change, no frontend impact.