### PR TITLE
fix(fixtures): Postgres membership mapping now respects --org / org_id (CHAOS-1558)

### DIFF
--- a/src/dev_health_ops/fixtures/generator.py
+++ b/src/dev_health_ops/fixtures/generator.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import random
+import re
 import uuid
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, cast
@@ -2821,6 +2822,7 @@ class SyntheticDataGenerator:
         *,
         default_password: str = "devhealth123",
         include_admin: bool = True,
+        org_id: str | None = None,
     ) -> dict[str, Any]:
         import bcrypt
 
@@ -2837,10 +2839,31 @@ class SyntheticDataGenerator:
             default_password.encode("utf-8"), bcrypt.gensalt()
         ).decode("utf-8")
 
+        _DEFAULT_NS = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+        # Resolve the target Postgres Organization identity from the supplied
+        # CLI/sink-level org_id, so that seeded users/memberships/licenses live
+        # in the SAME tenant as the analytics rows. Without this, the fixture
+        # generator hardcoded "default-org" and broke multi-tenant scoping.
+        if org_id:
+            try:
+                target_org_uuid = uuid.UUID(org_id)
+                _slug_seed = f"fixture-{target_org_uuid.hex[:8]}"
+            except ValueError:
+                target_org_uuid = uuid.uuid5(_DEFAULT_NS, org_id)
+                # Slug must satisfy uniqueness AND be deterministic per org_id.
+                _safe = re.sub(r"[^a-z0-9-]+", "-", org_id.lower()).strip("-")
+                _slug_seed = (_safe or f"fixture-{target_org_uuid.hex[:8]}")[:60]
+            target_slug = _slug_seed
+            target_name = f"Fixture Org ({org_id})"
+        else:
+            target_org_uuid = uuid.uuid5(_DEFAULT_NS, "default-org")
+            target_slug = "default-org"
+            target_name = "Default Organization"
+
         if include_admin:
             admin_user = User(
                 id=uuid.uuid5(
-                    uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+                    _DEFAULT_NS,
                     "admin@devhealth.example",
                 ),
                 email="admin@devhealth.example",
@@ -2855,11 +2878,9 @@ class SyntheticDataGenerator:
             users.append(admin_user)
 
             admin_org = Organization(
-                id=uuid.uuid5(
-                    uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), "default-org"
-                ),
-                slug="default-org",
-                name="Default Organization",
+                id=target_org_uuid,
+                slug=target_slug,
+                name=target_name,
                 tier="enterprise",
                 is_active=True,
             )
@@ -2892,9 +2913,7 @@ class SyntheticDataGenerator:
             default_org_id = orgs[0].id
 
         for name, email in self.authors[:5]:
-            user_id = uuid.uuid5(
-                uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), email
-            )
+            user_id = uuid.uuid5(_DEFAULT_NS, email)
             user = User(
                 id=user_id,
                 email=email,

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -307,7 +307,9 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
         # Seed users/orgs/memberships/licenses into PostgreSQL (auth layer).
         # This must happen regardless of which analytics sink is used.
         user_generator = SyntheticDataGenerator(repo_name=base_name, seed=ns.seed)
-        user_data: dict[str, Any] | None = user_generator.generate_users()
+        user_data: dict[str, Any] | None = user_generator.generate_users(
+            org_id=org_id,
+        )
 
         if isinstance(store, SQLAlchemyStore) and db_type == "postgres":
             async with store.session_factory() as session:

--- a/tests/test_fixtures_runner.py
+++ b/tests/test_fixtures_runner.py
@@ -256,3 +256,85 @@ def test_work_unit_investment_validation_rejects_low_repo_or_team_coverage():
         )
         is False
     )
+
+
+class TestGenerateUsersRespectsOrgId:
+    """Regression: ``generate_users(org_id=...)`` MUST stamp the supplied org_id
+    onto the Organization row and every Membership/license, so that synthetic
+    Postgres tenants line up with analytics-side org_id (CHAOS-1558)."""
+
+    _UUID_ORG = "11111111-1111-1111-1111-111111111111"
+
+    def test_supplied_uuid_propagates_to_org_and_memberships(self):
+        import uuid
+
+        gen = SyntheticDataGenerator(repo_name="acme/demo", seed=1)
+        data = gen.generate_users(org_id=self._UUID_ORG)
+
+        # Exactly one organization is produced (the admin org).
+        assert len(data["organizations"]) == 1
+        org = data["organizations"][0]
+        assert org.id == uuid.UUID(self._UUID_ORG)
+        # Slug must be deterministic AND derived from org_id, not hardcoded.
+        assert org.slug != "default-org"
+        assert org.slug == f"fixture-{uuid.UUID(self._UUID_ORG).hex[:8]}"
+
+        # Every membership (admin + first 5 authors) must target the supplied org.
+        assert len(data["memberships"]) >= 2, "expected admin + at least 1 author"
+        for m in data["memberships"]:
+            assert m.org_id == uuid.UUID(self._UUID_ORG), (
+                f"membership {m.id} for user {m.user_id} bound to wrong org "
+                f"{m.org_id}; expected {self._UUID_ORG}"
+            )
+
+        # License must also be tenant-scoped.
+        assert len(data["licenses"]) == 1
+        assert data["licenses"][0].org_id == uuid.UUID(self._UUID_ORG)
+
+    def test_non_uuid_org_id_hashed_deterministically(self):
+        import uuid
+
+        _NS = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+        expected = uuid.uuid5(_NS, "acme-engineering")
+
+        gen = SyntheticDataGenerator(repo_name="acme/demo", seed=1)
+        data = gen.generate_users(org_id="acme-engineering")
+
+        assert data["organizations"][0].id == expected
+        assert data["organizations"][0].slug == "acme-engineering"
+        for m in data["memberships"]:
+            assert m.org_id == expected
+
+    def test_default_behaviour_preserved_when_org_id_omitted(self):
+        import uuid
+
+        _NS = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+        expected = uuid.uuid5(_NS, "default-org")
+
+        gen = SyntheticDataGenerator(repo_name="acme/demo", seed=1)
+        data = gen.generate_users()  # no org_id
+
+        assert data["organizations"][0].id == expected
+        assert data["organizations"][0].slug == "default-org"
+        assert data["organizations"][0].name == "Default Organization"
+        for m in data["memberships"]:
+            assert m.org_id == expected
+
+    def test_org_id_with_unsafe_slug_chars_is_sanitised(self):
+        import uuid
+
+        gen = SyntheticDataGenerator(repo_name="acme/demo", seed=1)
+        # Mixed case, spaces, slashes, etc. must not break slug uniqueness.
+        data = gen.generate_users(org_id="ACME Engineering / R&D")
+
+        slug = data["organizations"][0].slug
+        # Slug must be non-empty, lowercase, and free of unsafe chars.
+        assert slug, "slug must not be empty after sanitisation"
+        assert slug == slug.lower()
+        assert all(c.isalnum() or c == "-" for c in slug)
+
+        # All memberships still tie to the same derived org UUID.
+        org_uuid = data["organizations"][0].id
+        assert isinstance(org_uuid, uuid.UUID)
+        for m in data["memberships"]:
+            assert m.org_id == org_uuid


### PR DESCRIPTION
Closes [CHAOS-1558](https://linear.app/fullchaos/issue/CHAOS-1558).

## Bug

When the user runs:

```
dev-hops --org <UUID> fixtures generate ...
```

…the Postgres-side seeding of `users` / `organizations` / `memberships` / `org_licenses` completely ignores `--org`. `SyntheticDataGenerator.generate_users()` hardcoded the Organization as:

```python
admin_org = Organization(
    id=uuid.uuid5(NAMESPACE, "default-org"),   # always the same UUID
    slug="default-org",                        # unique constraint
    name="Default Organization",
    ...
)
```

The membership rows for the admin user and the first 5 synthetic authors all bind to that hardcoded UUID. The `OrgLicense` row is bound to the same hardcoded org. The fixtures runner makes it worse by never passing the resolved CLI `org_id` into `generate_users()`, even though it correctly stamps the same `org_id` onto analytics teams at [`runner.py:302`](https://github.com/full-chaos/dev-health-ops/blob/main/src/dev_health_ops/fixtures/runner.py#L302).

### Impact matrix

| Layer | Before this PR | After |
|---|---|---|
| Analytics teams (ClickHouse) | ✅ stamped with `--org` | ✅ unchanged |
| Postgres `organizations.id` | ❌ hardcoded `uuid5(NS, "default-org")` | ✅ derived from `--org` |
| Postgres `organizations.slug` | ❌ `"default-org"` (collision risk) | ✅ derived from `--org`, sanitised |
| Postgres `memberships.org_id` (admin + 5 authors) | ❌ hardcoded | ✅ matches `--org` |
| Postgres `org_licenses.org_id` | ❌ hardcoded | ✅ matches `--org` |

Symptom in production fixtures: RLS / admin guards / impersonation that scope by `org_id` see zero overlap between seeded users and seeded analytics.

## Bonus: silent test bug spotted

`tests/test_fixtures_runner.py` had `ns.org_id="test-org"` but the runner reads `getattr(ns, "org", ...)`. The tests have always passed for the wrong reason — they never exercised the org path. Existing tests are left intact (they still serve as smoke coverage) but new regression tests now drive `generate_users()` directly so the behaviour is locked in.

## Fix

1. **`generate_users(*, org_id: str | None = None)`** — accepts a target org. UUID strings are parsed; non-UUID strings are hashed via `uuid.uuid5(NS, org_id)` so any `--org` value yields a stable, deterministic `Organization.id`. Slug is derived from `org_id` (sanitised against `[a-z0-9-]`) so two different `--org` values produce two distinct Organizations without colliding on the unique-slug constraint. Default behaviour preserved when `org_id` is omitted.
2. **`fixtures/runner.py:310`** — `user_generator.generate_users(org_id=org_id)`. The resolved CLI org is now forwarded.

## Tests

`TestGenerateUsersRespectsOrgId` (4 new tests):
- `test_supplied_uuid_propagates_to_org_and_memberships` — verifies the Organization, every Membership, and the License all bind to the supplied UUID.
- `test_non_uuid_org_id_hashed_deterministically` — verifies a bare string like `"acme-engineering"` deterministically maps to `uuid5(NS, "acme-engineering")` with a matching slug.
- `test_default_behaviour_preserved_when_org_id_omitted` — verifies the `"default-org"` UUID / slug / name still applies when `org_id` is not passed (no migration churn for callers using defaults).
- `test_org_id_with_unsafe_slug_chars_is_sanitised` — verifies slugs survive mixed case, spaces, `/`, `&` and still satisfy the unique-slug invariant.

## Verification

- `tests/test_fixtures_runner.py` — 12 passed (8 existing + 4 new)
- 93 fixture/CLI tests across `test_fixtures_*.py` + `test_utils.py` pass
- `mypy` clean, `ruff` clean
- Diff: `+113 / -10` across only `generator.py`, `runner.py`, `test_fixtures_runner.py`

SCREENSHOT-WAIVER: Backend fixture-generation fix, no frontend rendering impact.