### PR TITLE
sec: hashlib.md5 usedforsecurity + password Field bounds (CHAOS-1545, CHAOS-1546)

### DIFF
--- a/src/dev_health_ops/api/admin/schemas.py
+++ b/src/dev_health_ops/api/admin/schemas.py
@@ -402,7 +402,7 @@ class UserResponse(BaseModel):
 
 class UserCreate(BaseModel):
     email: str = Field(..., min_length=1)
-    password: str | None = Field(default=None, min_length=8)
+    password: str | None = Field(default=None, min_length=8, max_length=128)
     username: str | None = None
     full_name: str | None = None
     auth_provider: str = "local"
@@ -422,8 +422,8 @@ class UserUpdate(BaseModel):
 
 
 class UserSetPassword(BaseModel):
-    admin_password: str = Field(..., min_length=8)
-    password: str = Field(..., min_length=8)
+    admin_password: str = Field(..., min_length=8, max_length=128)
+    password: str = Field(..., min_length=8, max_length=128)
 
 
 # ---- Organization schemas ----

--- a/src/dev_health_ops/api/auth/routers/login.py
+++ b/src/dev_health_ops/api/auth/routers/login.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 import bcrypt
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy import func, select
 
 from dev_health_ops.api.middleware.rate_limit import (
@@ -48,7 +48,7 @@ router = APIRouter()
 
 class LoginRequest(BaseModel):
     email: EmailStr
-    password: str
+    password: str = Field(max_length=128)
     org_id: str | None = None
 
 

--- a/src/dev_health_ops/api/auth/routers/password_reset.py
+++ b/src/dev_health_ops/api/auth/routers/password_reset.py
@@ -4,7 +4,7 @@ import importlib
 import logging
 
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy import func, select
 
 from dev_health_ops.api.middleware.rate_limit import get_auth_key, limiter
@@ -25,7 +25,7 @@ class ForgotPasswordRequest(BaseModel):
 
 class ResetPasswordRequest(BaseModel):
     token: str
-    new_password: str
+    new_password: str = Field(min_length=8, max_length=128)
 
 
 @router.post("/forgot-password", response_model=VerifyEmailResponse)

--- a/src/dev_health_ops/api/auth/routers/register.py
+++ b/src/dev_health_ops/api/auth/routers/register.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 import bcrypt
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy import func, select
 
 from dev_health_ops.api.middleware.rate_limit import (
@@ -30,7 +30,7 @@ router = APIRouter()
 
 class RegisterRequest(BaseModel):
     email: EmailStr
-    password: str
+    password: str = Field(min_length=8, max_length=128)
     full_name: str | None = None
     org_name: str | None = None
 

--- a/src/dev_health_ops/api/services/people_identity.py
+++ b/src/dev_health_ops/api/services/people_identity.py
@@ -55,7 +55,7 @@ def load_identity_aliases() -> dict[str, list[str]]:
 
 
 def person_id_for_identity(identity: str) -> str:
-    digest = hashlib.md5(identity.encode("utf-8")).hexdigest()
+    digest = hashlib.md5(identity.encode("utf-8"), usedforsecurity=False).hexdigest()
     return digest.lower()
 
 

--- a/src/dev_health_ops/connectors/base.py
+++ b/src/dev_health_ops/connectors/base.py
@@ -229,7 +229,7 @@ class GitConnector(ABC):
         # Sort kwargs to ensure stability
         sorted_args = sorted(kwargs.items())
         args_str = json.dumps(sorted_args, default=str)
-        args_hash = hashlib.md5(args_str.encode()).hexdigest()
+        args_hash = hashlib.md5(args_str.encode(), usedforsecurity=False).hexdigest()
         return f"{self.cache_prefix}{method}:{args_hash}"
 
     def _get_cached_item(self, key: str, model_class: Any) -> Any | None:

--- a/src/dev_health_ops/fixtures/generators/investments.py
+++ b/src/dev_health_ops/fixtures/generators/investments.py
@@ -237,7 +237,8 @@ class InvestmentsGeneratorMixin(BaseGeneratorMixin):
                         from_ts.isoformat(),
                         to_ts.isoformat(),
                     ]
-                ).encode("utf-8")
+                ).encode("utf-8"),
+                usedforsecurity=False,
             ).hexdigest()
 
             records.append(

--- a/tests/api/auth/test_password_reset.py
+++ b/tests/api/auth/test_password_reset.py
@@ -221,3 +221,36 @@ async def test_reset_password_expired_token_returns_400(
     )
     assert response.status_code == 400
     assert response.json()["detail"]["message"] == "Invalid or expired token"
+
+
+@pytest.mark.asyncio
+async def test_reset_password_new_password_too_short_rejected(
+    client, session_maker, seeded_user
+):
+    """Pydantic Field(min_length=8) rejects 7-char new_password with 422."""
+    async_client, _ = client
+    async with session_maker() as session:
+        token = await create_password_reset_token(session, seeded_user.id)
+        await session.commit()
+    response = await async_client.post(
+        "/api/v1/auth/reset-password",
+        json={"token": token, "new_password": "Ab1!xyz"},  # 7 chars
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_reset_password_new_password_too_long_rejected(
+    client, session_maker, seeded_user
+):
+    """Pydantic Field(max_length=128) rejects 129-char new_password with 422."""
+    async_client, _ = client
+    async with session_maker() as session:
+        token = await create_password_reset_token(session, seeded_user.id)
+        await session.commit()
+    long_password = "A1!" + "a" * 126  # 129 chars
+    response = await async_client.post(
+        "/api/v1/auth/reset-password",
+        json={"token": token, "new_password": long_password},
+    )
+    assert response.status_code == 422

--- a/tests/api/auth/test_register.py
+++ b/tests/api/auth/test_register.py
@@ -273,7 +273,7 @@ async def test_register_password_too_short_returns_422(client):
         json={"email": "short@example.com", "password": "Short1"},
     )
     assert response.status_code == 422
-    assert response.json()["detail"]["message"] == "Password validation failed"
+    assert response.json()["detail"]["message"] == "Validation failed"
     assert response.json()["detail"]["errors"]
 
 
@@ -333,3 +333,26 @@ async def test_register_email_send_failure_does_not_break_registration(
     data = response.json()
     assert "user_id" in data
     assert "org_id" in data
+
+
+@pytest.mark.asyncio
+async def test_register_password_field_min_length_rejected(client):
+    """Pydantic Field(min_length=8) rejects 7-char passwords before handler."""
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={"email": "minlen@example.com", "password": "Abc123!"},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"]["message"] == "Validation failed"
+
+
+@pytest.mark.asyncio
+async def test_register_password_field_max_length_rejected(client):
+    """Pydantic Field(max_length=128) rejects 129-char passwords before handler."""
+    long_password = "A1!" + "a" * 126  # 129 chars
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={"email": "maxlen@example.com", "password": long_password},
+    )
+    assert response.status_code == 422
+    assert response.json()["detail"]["message"] == "Validation failed"


### PR DESCRIPTION
## Summary
- Pass `usedforsecurity=False` to all non-cryptographic md5 calls (FIPS-mode safe): `connectors/base.py` (cache key), `api/services/people_identity.py` (identity digest), `fixtures/generator.py` (synthetic data hash)
- Tighten password Pydantic Field bounds to (min=8, max=128) on register + every adjacent flow
- Defense-in-depth before bcrypt 72-byte truncation

## Models touched (CHAOS-1546)
| File | Model | Change |
|------|-------|--------|
| `api/auth/routers/register.py` | `RegisterRequest.password` | `str` → `Field(min_length=8, max_length=128)` |
| `api/auth/routers/password_reset.py` | `ResetPasswordRequest.new_password` | `str` → `Field(min_length=8, max_length=128)` |
| `api/auth/routers/login.py` | `LoginRequest.password` | `str` → `Field(max_length=128)` (DoS prevention only; no min to avoid locking existing accounts) |
| `api/admin/schemas.py` | `UserCreate.password` | `Field(min_length=8)` → `Field(min_length=8, max_length=128)` |
| `api/admin/schemas.py` | `UserSetPassword.admin_password` | `Field(min_length=8)` → `Field(min_length=8, max_length=128)` |
| `api/admin/schemas.py` | `UserSetPassword.password` | `Field(min_length=8)` → `Field(min_length=8, max_length=128)` |

## hashlib.md5 audit (CHAOS-1545)
All three sites are non-security uses (cache keys, identity digests, fixture hashes). No SHA-1 usages found.
- `connectors/base.py:232` — cache key
- `api/services/people_identity.py:58` — identity digest
- `fixtures/generator.py:2680` — synthetic data deterministic hash

## Linear
- CHAOS-1545
- CHAOS-1546