### PR TITLE
sec: rate-limit correctness (CHAOS-1553, CHAOS-1554)

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -99,6 +99,7 @@ jobs:
           POSTGRES_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
           LIVE_E2E_FIXTURE_SEED: "20260219"
           LIVE_E2E_API_LOG_FILE: ./live-e2e-api.log
+          ENVIRONMENT: test
         run: |
           chmod +x ci/run_tests.sh ci/run_live_backend_e2e.sh
           ./ci/run_tests.sh live-e2e

--- a/docs/ops/deployment-guide.md
+++ b/docs/ops/deployment-guide.md
@@ -64,6 +64,14 @@ All deployment methods use the same environment variables:
 | `BATCH_SIZE` | Records per batch | 100 |
 | `MAX_WORKERS` | Parallel workers | 4 |
 
+### Rate Limiting
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `REDIS_URL` | Redis connection URL for distributed rate-limit storage. **Required in non-dev environments** — the API will refuse to start without it when `ENVIRONMENT` is not `development`/`local`/`test`. | — |
+| `TRUSTED_PROXIES` | Comma-separated list of trusted proxy IPs or CIDRs (e.g. `10.0.0.1,10.0.0.2`). Only peers in this list are allowed to set the `X-Forwarded-For` header for rate-limit key extraction. When unset, `X-Forwarded-For` is ignored and the TCP peer address is used. | — |
+
+> **Security note:** Never leave `TRUSTED_PROXIES` empty behind a load balancer — rate limits would key on the LB IP rather than the real client. Conversely, setting it when running without a proxy would allow header spoofing by any client.
 ---
 
 ## Kubernetes Deployment

--- a/src/dev_health_ops/api/_health.py
+++ b/src/dev_health_ops/api/_health.py
@@ -13,6 +13,7 @@ import os
 from urllib.parse import urlparse
 
 from dev_health_ops.api.middleware.rate_limit import LIMITER_BACKEND
+
 from .queries.client import clickhouse_client, query_dicts
 
 DEFAULT_CLICKHOUSE_URI = "clickhouse://localhost:8123/default"

--- a/src/dev_health_ops/api/_health.py
+++ b/src/dev_health_ops/api/_health.py
@@ -12,6 +12,7 @@ import asyncio
 import os
 from urllib.parse import urlparse
 
+from dev_health_ops.api.middleware.rate_limit import LIMITER_BACKEND
 from .queries.client import clickhouse_client, query_dicts
 
 DEFAULT_CLICKHOUSE_URI = "clickhouse://localhost:8123/default"
@@ -155,12 +156,21 @@ async def _check_celery_health() -> tuple[str, str]:
         return "celery", "down"
 
 
+async def _check_rate_limiter_backend() -> tuple[str, str]:
+    """Report the configured rate-limiter storage backend (redis / memory / noop).
+
+    Informational only — not included in the overall health status.
+    """
+    return "rate_limiter", LIMITER_BACKEND
+
+
 __all__ = [
     "DEFAULT_CLICKHOUSE_URI",
     "_analytics_db_url",
     "_check_celery_health",
     "_check_clickhouse_health",
     "_check_postgres_health",
+    "_check_rate_limiter_backend",
     "_check_redis_health",
     "_check_sqlalchemy_health",
     "_check_sqlalchemy_health_async",

--- a/src/dev_health_ops/api/_lifespan.py
+++ b/src/dev_health_ops/api/_lifespan.py
@@ -12,6 +12,7 @@ import logging
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
+from dev_health_ops.api.middleware.rate_limit import verify_rate_limit_config
 from dev_health_ops.licensing import LicenseManager
 
 from ._health import _postgres_url
@@ -37,6 +38,9 @@ async def lifespan(app: FastAPI):
     Shutdown:
       * Close the global ClickHouse client.
     """
+    # Validate rate-limit configuration — hard-fails in prod without REDIS_URL (CHAOS-1554).
+    verify_rate_limit_config()
+
     # Initialize licensing
     try:
         manager = LicenseManager.initialize()

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -36,6 +36,7 @@ from ._health import (
     _check_celery_health,
     _check_clickhouse_health,
     _check_postgres_health,
+    _check_rate_limiter_backend,
     _check_redis_health,
 )
 from ._lifespan import lifespan
@@ -225,6 +226,10 @@ async def health() -> HealthResponse | JSONResponse:
             key, status_val = result
             services[key] = status_val
             required_statuses.append(status_val)
+
+    # Rate-limiter backend is informational — not counted toward overall health.
+    _, rl_status = await _check_rate_limiter_backend()
+    services["rate_limiter"] = rl_status
 
     overall = (
         "ok"

--- a/src/dev_health_ops/api/middleware/rate_limit.py
+++ b/src/dev_health_ops/api/middleware/rate_limit.py
@@ -112,8 +112,15 @@ class _NoOpLimiter:
 def _is_dev_or_test() -> bool:
     """Return True when running in a local-development or test environment."""
     env = (
-        os.getenv("ENVIRONMENT") or os.getenv("APP_ENV") or os.getenv("ENV") or "production"
-    ).strip().lower()
+        (
+            os.getenv("ENVIRONMENT")
+            or os.getenv("APP_ENV")
+            or os.getenv("ENV")
+            or "production"
+        )
+        .strip()
+        .lower()
+    )
     return env in {"development", "dev", "local", "test", "testing"}
 
 
@@ -124,13 +131,6 @@ _log = logging.getLogger(__name__)
 
 
 if Limiter is not None:
-    if _REDIS_URL is None and not _is_dev_or_test():
-        raise RuntimeError(
-            "REDIS_URL must be set in non-development environments. "
-            "In-memory rate-limit storage (memory://) is per-process and "
-            "ineffective across multiple replicas. "
-            "Set REDIS_URL, or set ENVIRONMENT=development to suppress."
-        )
     _storage_uri = _REDIS_URL if _REDIS_URL else "memory://"
     LIMITER_BACKEND = "redis" if _REDIS_URL else "memory"
     limiter = Limiter(
@@ -151,15 +151,35 @@ if Limiter is not None:
             "Set TRUSTED_PROXIES (comma-separated IPs/CIDRs) when behind a load balancer."
         )
 else:
-    if not _is_dev_or_test():
-        raise RuntimeError(
-            "slowapi is not installed but is required in non-development environments. "
-            "Install slowapi (dev_health_ops API dependencies) or set "
-            "ENVIRONMENT=development to suppress."
-        )
-    limiter = _NoOpLimiter()  # type: ignore[assignment,unused-ignore]
+    limiter = _NoOpLimiter()  # type: ignore[assignment]
     LIMITER_BACKEND = "noop"
     _log.warning(
         "slowapi not installed — rate limiting disabled (NoOp). "
         "Acceptable for local development only."
     )
+
+
+def verify_rate_limit_config() -> None:
+    """Validate rate-limit configuration for the current environment.
+
+    Must be called from the application startup (lifespan), not at module
+    import time. Raises RuntimeError if the configuration is unsafe for
+    production. Deferring to startup keeps test imports and type-checking
+    import-clean while still enforcing the CHAOS-1554 safety contract.
+    """
+    if _is_dev_or_test():
+        return
+    redis_url = os.getenv("REDIS_URL")
+    if Limiter is None:
+        raise RuntimeError(
+            "slowapi is not installed but is required in non-development environments. "
+            "Install slowapi (dev_health_ops API dependencies) or set "
+            "ENVIRONMENT=development to suppress."
+        )
+    if redis_url is None:
+        raise RuntimeError(
+            "REDIS_URL must be set in non-development environments. "
+            "In-memory rate-limit storage (memory://) is per-process and "
+            "ineffective across multiple replicas. "
+            "Set REDIS_URL, or set ENVIRONMENT=development to suppress."
+        )

--- a/src/dev_health_ops/api/middleware/rate_limit.py
+++ b/src/dev_health_ops/api/middleware/rate_limit.py
@@ -109,14 +109,57 @@ class _NoOpLimiter:
         return _decorator
 
 
+def _is_dev_or_test() -> bool:
+    """Return True when running in a local-development or test environment."""
+    env = (
+        os.getenv("ENVIRONMENT") or os.getenv("APP_ENV") or os.getenv("ENV") or "production"
+    ).strip().lower()
+    return env in {"development", "dev", "local", "test", "testing"}
+
+
+#: Exposed for /health endpoint — reports the active rate-limiter backend.
+LIMITER_BACKEND: str = "unknown"
+
+_log = logging.getLogger(__name__)
+
+
 if Limiter is not None:
+    if _REDIS_URL is None and not _is_dev_or_test():
+        raise RuntimeError(
+            "REDIS_URL must be set in non-development environments. "
+            "In-memory rate-limit storage (memory://) is per-process and "
+            "ineffective across multiple replicas. "
+            "Set REDIS_URL, or set ENVIRONMENT=development to suppress."
+        )
+    _storage_uri = _REDIS_URL if _REDIS_URL else "memory://"
+    LIMITER_BACKEND = "redis" if _REDIS_URL else "memory"
     limiter = Limiter(
-        key_func=get_remote_address,
-        storage_uri=_REDIS_URL if _REDIS_URL else "memory://",
+        key_func=get_forwarded_ip,
+        storage_uri=_storage_uri,
     )
     if _REDIS_URL:
-        logging.getLogger(__name__).info(
-            "Rate limiter using Redis storage: %s", _REDIS_URL[:20] + "..."
+        _log.info("Rate limiter using Redis storage: %s", _REDIS_URL[:20] + "...")
+    else:
+        _log.warning(
+            "REDIS_URL not set — rate limiter using in-memory storage "
+            "(per-process, not cluster-wide). Acceptable for local dev only."
+        )
+    if not _trusted_proxies():
+        _log.warning(
+            "TRUSTED_PROXIES is not set — X-Forwarded-For headers will be ignored "
+            "and rate limiting will key on TCP peer address only. "
+            "Set TRUSTED_PROXIES (comma-separated IPs/CIDRs) when behind a load balancer."
         )
 else:
+    if not _is_dev_or_test():
+        raise RuntimeError(
+            "slowapi is not installed but is required in non-development environments. "
+            "Install slowapi (dev_health_ops API dependencies) or set "
+            "ENVIRONMENT=development to suppress."
+        )
     limiter = _NoOpLimiter()  # type: ignore[assignment,unused-ignore]
+    LIMITER_BACKEND = "noop"
+    _log.warning(
+        "slowapi not installed — rate limiting disabled (NoOp). "
+        "Acceptable for local development only."
+    )

--- a/src/dev_health_ops/api/middleware/rate_limit.py
+++ b/src/dev_health_ops/api/middleware/rate_limit.py
@@ -129,6 +129,10 @@ LIMITER_BACKEND: str = "unknown"
 
 _log = logging.getLogger(__name__)
 
+#: Module-level type annotation enables both Limiter and _NoOpLimiter assignments
+#: in the conditional below without requiring type: ignore.
+limiter: Limiter | _NoOpLimiter
+
 
 if Limiter is not None:
     _storage_uri = _REDIS_URL if _REDIS_URL else "memory://"

--- a/src/dev_health_ops/api/middleware/rate_limit.py
+++ b/src/dev_health_ops/api/middleware/rate_limit.py
@@ -151,7 +151,7 @@ if Limiter is not None:
             "Set TRUSTED_PROXIES (comma-separated IPs/CIDRs) when behind a load balancer."
         )
 else:
-    limiter = _NoOpLimiter()  # type: ignore[assignment]
+    limiter = _NoOpLimiter()
     LIMITER_BACKEND = "noop"
     _log.warning(
         "slowapi not installed — rate limiting disabled (NoOp). "

--- a/tests/api/test_rate_limit_config.py
+++ b/tests/api/test_rate_limit_config.py
@@ -56,8 +56,8 @@ def _reload_rate_limit_noop(
     sys.modules.pop(module_name, None)
 
     # Make slowapi unimportable so the try/except in rate_limit.py sets Limiter = None.
-    monkeypatch.setitem(sys.modules, "slowapi", None)  # type: ignore[arg-type]
-    monkeypatch.setitem(sys.modules, "slowapi.util", None)  # type: ignore[arg-type]
+    monkeypatch.setitem(sys.modules, "slowapi", None)
+    monkeypatch.setitem(sys.modules, "slowapi.util", None)
 
     return importlib.import_module(module_name)
 
@@ -104,8 +104,11 @@ def test_rate_limiter_backend_redis_when_redis_url_set(monkeypatch):
 
 def test_rate_limiter_raises_in_prod_without_redis(monkeypatch):
     """Production startup must raise RuntimeError when REDIS_URL is missing (CHAOS-1554)."""
+    module, _ = _reload_rate_limit(
+        monkeypatch, redis_url=None, environment="production"
+    )
     with pytest.raises(RuntimeError, match="REDIS_URL must be set"):
-        _reload_rate_limit(monkeypatch, redis_url=None, environment="production")
+        module.verify_rate_limit_config()
 
 
 def test_rate_limiter_memory_allowed_in_development(monkeypatch):
@@ -128,8 +131,9 @@ def test_rate_limiter_memory_allowed_in_test_env(monkeypatch):
 
 def test_noop_limiter_raises_in_prod(monkeypatch):
     """slowapi absent in prod must raise RuntimeError, never silently disable limits (CHAOS-1554)."""
+    module = _reload_rate_limit_noop(monkeypatch, environment="production")
     with pytest.raises(RuntimeError, match="slowapi is not installed"):
-        _reload_rate_limit_noop(monkeypatch, environment="production")
+        module.verify_rate_limit_config()
 
 
 def test_noop_limiter_allowed_in_development(monkeypatch):

--- a/tests/api/test_rate_limit_config.py
+++ b/tests/api/test_rate_limit_config.py
@@ -2,19 +2,35 @@ from __future__ import annotations
 
 import importlib
 import sys
+from types import ModuleType
+
+import pytest
 
 
-def _load_rate_limit_module(monkeypatch, redis_url: str | None):
-    captured: dict[str, object] = {}
-
-    class _FakeLimiter:
-        def __init__(self, **kwargs):
-            captured.update(kwargs)
-
+def _reload_rate_limit(
+    monkeypatch,
+    *,
+    redis_url: str | None,
+    environment: str | None = None,
+) -> tuple[ModuleType, dict[str, object]]:
+    """Reload rate_limit module under controlled env, using a FakeLimiter to capture kwargs."""
     if redis_url is None:
         monkeypatch.delenv("REDIS_URL", raising=False)
     else:
         monkeypatch.setenv("REDIS_URL", redis_url)
+
+    if environment is None:
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.delenv("APP_ENV", raising=False)
+        monkeypatch.delenv("ENV", raising=False)
+    else:
+        monkeypatch.setenv("ENVIRONMENT", environment)
+
+    captured: dict[str, object] = {}
+
+    class _FakeLimiter:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
 
     module_name = "dev_health_ops.api.middleware.rate_limit"
     sys.modules.pop(module_name, None)
@@ -24,14 +40,99 @@ def _load_rate_limit_module(monkeypatch, redis_url: str | None):
     return module, captured
 
 
-def test_rate_limiter_uses_memory_storage_when_redis_url_missing(monkeypatch):
-    _module, limiter_kwargs = _load_rate_limit_module(monkeypatch, redis_url=None)
+def _reload_rate_limit_noop(
+    monkeypatch,
+    *,
+    environment: str | None = None,
+) -> ModuleType:
+    """Reload rate_limit with slowapi made unimportable (simulates missing install)."""
+    if environment is None:
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+    else:
+        monkeypatch.setenv("ENVIRONMENT", environment)
+    monkeypatch.delenv("REDIS_URL", raising=False)
 
-    assert limiter_kwargs["storage_uri"] == "memory://"
+    module_name = "dev_health_ops.api.middleware.rate_limit"
+    sys.modules.pop(module_name, None)
+
+    # Make slowapi unimportable so the try/except in rate_limit.py sets Limiter = None.
+    monkeypatch.setitem(sys.modules, "slowapi", None)  # type: ignore[arg-type]
+    monkeypatch.setitem(sys.modules, "slowapi.util", None)  # type: ignore[arg-type]
+
+    return importlib.import_module(module_name)
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-1553: key_func must be get_forwarded_ip
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limiter_key_func_is_get_forwarded_ip(monkeypatch):
+    """key_func must be get_forwarded_ip, not get_remote_address (CHAOS-1553)."""
+    module, captured = _reload_rate_limit(
+        monkeypatch,
+        redis_url="redis://localhost:6379/0",
+        environment="development",
+    )
+    # Compare against the function from the *same* reloaded module instance.
+    assert captured.get("key_func") is module.get_forwarded_ip
 
 
 def test_rate_limiter_accepts_redis_storage_uri(monkeypatch):
+    """When REDIS_URL is set, the limiter must use it as storage_uri."""
     redis_url = "redis://localhost:6379/0"
-    _module, limiter_kwargs = _load_rate_limit_module(monkeypatch, redis_url=redis_url)
+    _module, captured = _reload_rate_limit(
+        monkeypatch, redis_url=redis_url, environment="development"
+    )
+    assert captured["storage_uri"] == redis_url
 
-    assert limiter_kwargs["storage_uri"] == redis_url
+
+def test_rate_limiter_backend_redis_when_redis_url_set(monkeypatch):
+    """LIMITER_BACKEND must be 'redis' when REDIS_URL is configured."""
+    module, _ = _reload_rate_limit(
+        monkeypatch,
+        redis_url="redis://localhost:6379/0",
+        environment="development",
+    )
+    assert module.LIMITER_BACKEND == "redis"
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-1554: no silent fallback to memory:// in prod; no silent NoOp in prod
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limiter_raises_in_prod_without_redis(monkeypatch):
+    """Production startup must raise RuntimeError when REDIS_URL is missing (CHAOS-1554)."""
+    with pytest.raises(RuntimeError, match="REDIS_URL must be set"):
+        _reload_rate_limit(monkeypatch, redis_url=None, environment="production")
+
+
+def test_rate_limiter_memory_allowed_in_development(monkeypatch):
+    """Dev environment may fall back to in-memory storage."""
+    module, captured = _reload_rate_limit(
+        monkeypatch, redis_url=None, environment="development"
+    )
+    assert captured["storage_uri"] == "memory://"
+    assert module.LIMITER_BACKEND == "memory"
+
+
+def test_rate_limiter_memory_allowed_in_test_env(monkeypatch):
+    """Test environment may fall back to in-memory storage."""
+    module, captured = _reload_rate_limit(
+        monkeypatch, redis_url=None, environment="test"
+    )
+    assert captured["storage_uri"] == "memory://"
+    assert module.LIMITER_BACKEND == "memory"
+
+
+def test_noop_limiter_raises_in_prod(monkeypatch):
+    """slowapi absent in prod must raise RuntimeError, never silently disable limits (CHAOS-1554)."""
+    with pytest.raises(RuntimeError, match="slowapi is not installed"):
+        _reload_rate_limit_noop(monkeypatch, environment="production")
+
+
+def test_noop_limiter_allowed_in_development(monkeypatch):
+    """slowapi absent in dev is acceptable — NoOp limiter is used."""
+    module = _reload_rate_limit_noop(monkeypatch, environment="development")
+    assert module.LIMITER_BACKEND == "noop"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,9 @@ def setup_test_env(monkeypatch):
         "JWT_SECRET_KEY",
         "test-jwt-secret-key-at-least-32-characters-long",
     )
+    # Rate limiter (CHAOS-1554) hard-fails at startup when REDIS_URL is unset
+    # in non-dev environments. Mark tests as a dev-equivalent environment.
+    monkeypatch.setenv("ENVIRONMENT", "test")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- Switch rate limiter key_func to `get_forwarded_ip` with trusted proxy gating (CHAOS-1553): prevents rate-limit key spoofing via forged `X-Forwarded-For` from untrusted peers
- Fail loudly when Redis is missing in non-dev environments; never silently fall back to per-process `memory://` (CHAOS-1554)
- Block startup when `slowapi` is absent in production — `_NoOpLimiter` is no longer silent
- Expose rate-limiter backend state in `/health` as an informational `rate_limiter` service key
- Document `REDIS_URL` (required in prod) and `TRUSTED_PROXIES` env vars in `docs/ops/deployment-guide.md`

## Changes
- `src/dev_health_ops/api/middleware/rate_limit.py`: key_func fix, startup guards, `LIMITER_BACKEND` export, TRUSTED_PROXIES warning
- `src/dev_health_ops/api/main.py`: import `LIMITER_BACKEND`, add `_check_rate_limiter_backend()`, include in `/health` services
- `tests/api/test_rate_limit_config.py`: 9 tests covering key_func, memory fallback in dev/test, RuntimeError in prod, NoOp in dev/prod
- `docs/ops/deployment-guide.md`: Rate Limiting env var table

## Linear
- CHAOS-1553
- CHAOS-1554

## SCREENSHOT-WAIVER
No frontend rendering changes — purely backend middleware and health endpoint.