### PR TITLE
docs: scope aiosqlite policy (CHAOS-1547)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,23 @@ Goal: understand **boundaries** (ingest → normalize → persist → metricize 
 
 > **ClickHouse is the only supported analytics backend.** MongoDB, PostgreSQL, and SQLite support for analytics is deprecated.
 
+#### aiosqlite scope
+
+`aiosqlite` is intentionally kept as a SQLite driver alias for narrow, non-production use only.
+
+Allowed:
+
+* Test fixtures under `tests/`, including in-memory API endpoint tests that use `httpx.ASGITransport`.
+* Local-only ephemeral development with `sqlite:///path`.
+
+Forbidden:
+
+* Any production semantic database; use PostgreSQL.
+* Any analytics backend; use ClickHouse.
+* CI long-run pipelines or durable environments.
+
+The SQLite URL normalization paths in `src/dev_health_ops/db.py` and `metrics/db_utils.py` are intentional compatibility helpers, not permission to use SQLite beyond the scopes above.
+
 Backend selection:
 
 * Semantic DB: CLI `--db` or `POSTGRES_URI` (legacy fallback: `DATABASE_URI`).

--- a/docs/architecture/database-architecture.md
+++ b/docs/architecture/database-architecture.md
@@ -33,6 +33,8 @@ Dev Health Ops uses a dual-database architecture separating **semantic** (operat
 
 Analytics queries use ClickHouse-specific features (ARRAY JOIN, JSONExtract, argMax) that have no equivalent in other backends. Attempting to use a non-ClickHouse backend for analytics endpoints returns a clear validation error (ValueError) directing users to configure `CLICKHOUSE_URI`.
 
+SQLite via `aiosqlite` remains allowed only for test fixtures and local-only ephemeral development. It must not be used for production semantic data, analytics, CI long-run pipelines, or durable environments; the `sqlite+aiosqlite` URL normalization helpers in `src/dev_health_ops/db.py` and `metrics/db_utils.py` exist for that narrow compatibility scope.
+
 ### What requires ClickHouse
 
 | Feature | Requires ClickHouse | Notes |


### PR DESCRIPTION
## Summary
- Explicitly scope aiosqlite as allowed for tests + local dev only; forbidden for analytics + production semantic DB
- Update AGENTS.md storage section
- Address [CHAOS-1547](https://linear.app/fullchaos/issue/CHAOS-1547)

## Verification
- ci/run_tests.sh unit passes
- No source code changes