### PR TITLE
perf(github): batch PR reviews and comments via GraphQL (CHAOS-645)

### DIFF
--- a/src/dev_health_ops/connectors/github.py
+++ b/src/dev_health_ops/connectors/github.py
@@ -560,14 +560,20 @@ class GitHubConnector(GitConnector):
                 for r in connection.get("nodes") or []:
                     if not isinstance(r, dict):
                         continue
-                    author = r.get("author") if isinstance(r.get("author"), dict) else {}
+                    author = (
+                        r.get("author") if isinstance(r.get("author"), dict) else {}
+                    )
                     submitted_at = None
                     if r.get("submittedAt"):
                         submitted_at = datetime.fromisoformat(
                             str(r["submittedAt"]).replace("Z", "+00:00")
                         )
-                    raw_id = r.get("databaseId") or r.get("fullDatabaseId") or r.get("id")
-                    review_url = r.get("url") or f"{pr.get('url')}#pullrequestreview-{raw_id}"
+                    raw_id = (
+                        r.get("databaseId") or r.get("fullDatabaseId") or r.get("id")
+                    )
+                    review_url = (
+                        r.get("url") or f"{pr.get('url')}#pullrequestreview-{raw_id}"
+                    )
                     reviews.append(
                         PullRequestReview(
                             id=str(raw_id),

--- a/src/dev_health_ops/connectors/github.py
+++ b/src/dev_health_ops/connectors/github.py
@@ -521,20 +521,70 @@ class GitHubConnector(GitConnector):
         :return: List of PullRequestReview objects.
         """
         try:
-            gh_repo = self.github.get_repo(f"{owner}/{repo}")
-            gh_pr = gh_repo.get_pull(number)
-            reviews = []
-            for r in gh_pr.get_reviews():
-                reviews.append(
-                    PullRequestReview(
-                        id=str(r.id),
-                        reviewer=r.user.login if r.user else "Unknown",
-                        state=r.state,
-                        submitted_at=r.submitted_at,
-                        body=r.body,
-                        url=gh_pr.html_url + f"#pullrequestreview-{r.id}",
-                    )
+            query = """
+            query($owner: String!, $repo: String!, $number: Int!, $after: String) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $number) {
+                  url
+                  reviews(first: 100, after: $after) {
+                    nodes {
+                      id
+                      databaseId
+                      fullDatabaseId
+                      state
+                      submittedAt
+                      body
+                      url
+                      author { login }
+                    }
+                    pageInfo { hasNextPage endCursor }
+                  }
+                }
+              }
+            }
+            """
+            reviews: list[PullRequestReview] = []
+            after: str | None = None
+            while True:
+                data = self.graphql.query(
+                    query,
+                    variables={
+                        "owner": owner,
+                        "repo": repo,
+                        "number": int(number),
+                        "after": after,
+                    },
                 )
+                pr = ((data or {}).get("repository") or {}).get("pullRequest") or {}
+                connection = pr.get("reviews") or {}
+                for r in connection.get("nodes") or []:
+                    if not isinstance(r, dict):
+                        continue
+                    author = r.get("author") if isinstance(r.get("author"), dict) else {}
+                    submitted_at = None
+                    if r.get("submittedAt"):
+                        submitted_at = datetime.fromisoformat(
+                            str(r["submittedAt"]).replace("Z", "+00:00")
+                        )
+                    raw_id = r.get("databaseId") or r.get("fullDatabaseId") or r.get("id")
+                    review_url = r.get("url") or f"{pr.get('url')}#pullrequestreview-{raw_id}"
+                    reviews.append(
+                        PullRequestReview(
+                            id=str(raw_id),
+                            reviewer=(author or {}).get("login") or "Unknown",
+                            state=str(r.get("state") or ""),
+                            submitted_at=submitted_at,
+                            body=r.get("body"),
+                            url=str(review_url) if review_url else None,
+                        )
+                    )
+                page_info = connection.get("pageInfo") or {}
+                if not page_info.get("hasNextPage"):
+                    break
+                cursor = page_info.get("endCursor")
+                if not isinstance(cursor, str) or not cursor:
+                    break
+                after = cursor
             return reviews
         except Exception as e:
             self._handle_github_exception(e)

--- a/src/dev_health_ops/providers/_ratelimit.py
+++ b/src/dev_health_ops/providers/_ratelimit.py
@@ -48,8 +48,13 @@ def gate_call(
     gate.wait_sync()
     try:
         yield
-    except Exception:
-        gate.penalize(retry_after)
+    except Exception as exc:
+        effective_retry_after = retry_after
+        if effective_retry_after is None:
+            candidate = getattr(exc, "retry_after_seconds", None)
+            if isinstance(candidate, int | float):
+                effective_retry_after = float(candidate)
+        gate.penalize(effective_retry_after)
         if swallow:
             return
         raise

--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -616,7 +616,10 @@ class GitHubWorkClient:
                 for node in self._connection_nodes(comments_connection)
             ]
             comments_cursor = self._connection_cursor(comments_connection)
-            while comments_cursor and self._remaining_limit(comments_limit, len(comments)) != 0:
+            while (
+                comments_cursor
+                and self._remaining_limit(comments_limit, len(comments)) != 0
+            ):
                 remaining = self._remaining_limit(comments_limit, len(comments))
                 more = self._fetch_pr_social_data_page(
                     owner=owner,
@@ -627,7 +630,9 @@ class GitHubWorkClient:
                     reviews_first=0,
                     comments_after=comments_cursor,
                 ).get(number, {})
-                more_connection = more.get("comments") if isinstance(more, dict) else None
+                more_connection = (
+                    more.get("comments") if isinstance(more, dict) else None
+                )
                 comments.extend(
                     self._comment_from_graphql(node)
                     for node in self._connection_nodes(more_connection)
@@ -637,8 +642,13 @@ class GitHubWorkClient:
             reviews_connection = pr_node.get("reviews")
             reviews_nodes = self._connection_nodes(reviews_connection)
             reviews_cursor = self._connection_cursor(reviews_connection)
-            while reviews_cursor and self._remaining_limit(reviews_limit, len(reviews_nodes)) != 0:
-                remaining_reviews = self._remaining_limit(reviews_limit, len(reviews_nodes))
+            while (
+                reviews_cursor
+                and self._remaining_limit(reviews_limit, len(reviews_nodes)) != 0
+            ):
+                remaining_reviews = self._remaining_limit(
+                    reviews_limit, len(reviews_nodes)
+                )
                 more = self._fetch_pr_social_data_page(
                     owner=owner,
                     repo=repo,
@@ -660,12 +670,17 @@ class GitHubWorkClient:
                     self._comment_from_graphql(node)
                     for node in self._connection_nodes(review_comment_connection)
                 )
-                review_comment_cursor = self._connection_cursor(review_comment_connection)
+                review_comment_cursor = self._connection_cursor(
+                    review_comment_connection
+                )
                 review_node_id = review_node.get("id")
                 while (
                     isinstance(review_node_id, str)
                     and review_comment_cursor
-                    and self._remaining_limit(review_comments_limit, len(review_comments)) != 0
+                    and self._remaining_limit(
+                        review_comments_limit, len(review_comments)
+                    )
+                    != 0
                 ):
                     remaining_comments = self._remaining_limit(
                         review_comments_limit, len(review_comments)
@@ -864,7 +879,9 @@ class GitHubWorkClient:
                     all_changes.extend(changes)
                     raw_changes_cursor = changes_page_info.get("endCursor")
                     changes_cursor = (
-                        raw_changes_cursor if isinstance(raw_changes_cursor, str) else None
+                        raw_changes_cursor
+                        if isinstance(raw_changes_cursor, str)
+                        else None
                     )
 
                     # Fetch remaining changes for this specific item

--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import json
 import logging
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Protocol, TypedDict, TypeVar
 
 from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
@@ -24,6 +25,22 @@ logger = logging.getLogger(__name__)
 _TItem = TypeVar("_TItem")
 
 
+def _parse_github_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 class _GitHubLabelLike(Protocol):
     name: object
 
@@ -32,6 +49,39 @@ class _GitHubUserLike(Protocol):
     email: object
     login: object
     name: object
+
+
+@dataclass
+class GitHubGraphQLUser:
+    login: object = None
+    email: object = None
+    name: object = None
+
+
+@dataclass
+class GitHubGraphQLComment:
+    id: object
+    created_at: object
+    user: object
+    body: object
+
+
+@dataclass
+class GitHubGraphQLReview:
+    id: object
+    reviewer: object
+    state: object
+    submitted_at: object
+    body: object
+    url: object
+
+
+@dataclass(frozen=True)
+class BatchedPRPayload:
+    number: int
+    issue_comments: tuple[GitHubGraphQLComment, ...]
+    review_comments: tuple[GitHubGraphQLComment, ...]
+    reviews: tuple[GitHubGraphQLReview, ...]
 
 
 class _GitHubEventLike(Protocol):
@@ -294,6 +344,357 @@ class GitHubWorkClient:
         """
         yield from self._iter_with_limit(pr.get_review_comments(), limit=limit)
 
+    def iter_pr_social_data_batch(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        prs: Sequence[_GitHubPullRequestLike],
+        comments_limit: int | None = None,
+        review_comments_limit: int | None = None,
+        reviews_limit: int | None = None,
+        batch_size: int = 50,
+    ) -> Iterable[BatchedPRPayload]:
+        """Fetch PR issue comments, reviews, and review comments in GraphQL batches.
+
+        The query uses ``repository.pullRequest(number: ...)`` aliases instead of
+        ``repository.pullRequests`` pagination because callers already iterate PRs
+        through PyGithub and pass concrete PR objects. Aliases let us preserve that
+        iterator contract while collapsing N per-PR REST calls into one GraphQL
+        query per up-to-50 PRs. Nested connections are page-limited to control
+        GraphQL cost and are paginated per PR only when the first page indicates
+        more data.
+        """
+        numbers: list[int] = []
+        for pr in prs:
+            number = int(getattr(pr, "number", 0) or 0)
+            if number > 0:
+                numbers.append(number)
+
+        if not numbers:
+            return
+
+        page_size = max(1, min(50, int(batch_size)))
+        for index in range(0, len(numbers), page_size):
+            chunk = numbers[index : index + page_size]
+            initial = self._fetch_pr_social_data_page(
+                owner=owner,
+                repo=repo,
+                numbers=chunk,
+                comments_first=self._connection_first(comments_limit),
+                review_comments_first=self._connection_first(review_comments_limit),
+                reviews_first=self._connection_first(reviews_limit),
+            )
+            yield from self._complete_pr_social_payloads(
+                owner=owner,
+                repo=repo,
+                initial=initial,
+                comments_limit=comments_limit,
+                review_comments_limit=review_comments_limit,
+                reviews_limit=reviews_limit,
+            )
+
+    def iter_pr_comments_batch(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        prs: Sequence[_GitHubPullRequestLike],
+        limit: int | None = None,
+    ) -> Iterable[tuple[int, tuple[GitHubGraphQLComment, ...]]]:
+        """Return issue-style PR comments keyed by PR number."""
+        for payload in self.iter_pr_social_data_batch(
+            owner=owner,
+            repo=repo,
+            prs=prs,
+            comments_limit=limit,
+            review_comments_limit=0,
+            reviews_limit=0,
+        ):
+            yield payload.number, payload.issue_comments
+
+    def iter_pr_review_comments_batch(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        prs: Sequence[_GitHubPullRequestLike],
+        limit: int | None = None,
+    ) -> Iterable[tuple[int, tuple[GitHubGraphQLComment, ...]]]:
+        """Return review comments keyed by PR number."""
+        for payload in self.iter_pr_social_data_batch(
+            owner=owner,
+            repo=repo,
+            prs=prs,
+            comments_limit=0,
+            review_comments_limit=limit,
+            reviews_limit=limit,
+        ):
+            yield payload.number, payload.review_comments
+
+    def iter_pr_reviews_batch(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        prs: Sequence[_GitHubPullRequestLike],
+        limit: int | None = None,
+    ) -> Iterable[tuple[int, tuple[GitHubGraphQLReview, ...]]]:
+        """Return reviews keyed by PR number."""
+        for payload in self.iter_pr_social_data_batch(
+            owner=owner,
+            repo=repo,
+            prs=prs,
+            comments_limit=0,
+            review_comments_limit=0,
+            reviews_limit=limit,
+        ):
+            yield payload.number, payload.reviews
+
+    @staticmethod
+    def _connection_first(limit: int | None) -> int:
+        if limit is not None and int(limit) <= 0:
+            return 0
+        if limit is None:
+            return 100
+        return max(1, min(100, int(limit)))
+
+    @staticmethod
+    def _remaining_limit(limit: int | None, current_count: int) -> int | None:
+        if limit is None:
+            return None
+        return max(0, int(limit) - current_count)
+
+    @staticmethod
+    def _connection_nodes(connection: dict[str, Any] | None) -> list[dict[str, Any]]:
+        if not connection:
+            return []
+        nodes = connection.get("nodes") or []
+        return [node for node in nodes if isinstance(node, dict)]
+
+    @staticmethod
+    def _connection_cursor(connection: dict[str, Any] | None) -> str | None:
+        page_info = (connection or {}).get("pageInfo") or {}
+        if not isinstance(page_info, dict) or not page_info.get("hasNextPage"):
+            return None
+        cursor = page_info.get("endCursor")
+        return cursor if isinstance(cursor, str) and cursor else None
+
+    @staticmethod
+    def _graphql_arg(value: object) -> str:
+        return json.dumps(value)
+
+    @classmethod
+    def _comment_from_graphql(cls, node: dict[str, Any]) -> GitHubGraphQLComment:
+        author = node.get("author") if isinstance(node.get("author"), dict) else {}
+        user = GitHubGraphQLUser(login=(author or {}).get("login"))
+        raw_id = node.get("databaseId") or node.get("fullDatabaseId") or node.get("id")
+        return GitHubGraphQLComment(
+            id=raw_id,
+            created_at=_parse_github_datetime(node.get("createdAt")),
+            user=user,
+            body=node.get("body") or "",
+        )
+
+    @classmethod
+    def _review_from_graphql(cls, node: dict[str, Any]) -> GitHubGraphQLReview:
+        author = node.get("author") if isinstance(node.get("author"), dict) else {}
+        raw_id = node.get("databaseId") or node.get("fullDatabaseId") or node.get("id")
+        return GitHubGraphQLReview(
+            id=raw_id,
+            reviewer=(author or {}).get("login") or "Unknown",
+            state=node.get("state") or "",
+            submitted_at=_parse_github_datetime(node.get("submittedAt")),
+            body=node.get("body") or "",
+            url=node.get("url"),
+        )
+
+    def _fetch_pr_social_data_page(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        numbers: Sequence[int],
+        comments_first: int,
+        review_comments_first: int,
+        reviews_first: int,
+        comments_after: str | None = None,
+        reviews_after: str | None = None,
+    ) -> dict[int, dict[str, Any]]:
+        aliases: list[str] = []
+        for idx, number in enumerate(numbers):
+            fields = ["number"]
+            if comments_first > 0:
+                comments_after_arg = self._graphql_arg(comments_after)
+                fields.append(
+                    f"comments(first: {comments_first}, after: {comments_after_arg}, orderBy: {{field: UPDATED_AT, direction: ASC}}) "
+                    "{ nodes { id databaseId fullDatabaseId body createdAt author { login } } "
+                    "pageInfo { hasNextPage endCursor } }"
+                )
+            if reviews_first > 0:
+                review_fields = [
+                    "id databaseId fullDatabaseId body state submittedAt url author { login }"
+                ]
+                if review_comments_first > 0:
+                    review_fields.append(
+                        f"comments(first: {review_comments_first}) "
+                        "{ nodes { id databaseId fullDatabaseId body createdAt author { login } } "
+                        "pageInfo { hasNextPage endCursor } }"
+                    )
+                reviews_after_arg = self._graphql_arg(reviews_after)
+                fields.append(
+                    f"reviews(first: {reviews_first}, after: {reviews_after_arg}) "
+                    f"{{ nodes {{ {' '.join(review_fields)} }} pageInfo {{ hasNextPage endCursor }} }}"
+                )
+            aliases.append(
+                f"pr{idx}: pullRequest(number: {int(number)}) {{ {' '.join(fields)} }}"
+            )
+
+        aliases_query = "\n".join(aliases)
+        query = f"""
+        query($owner: String!, $repo: String!) {{
+          repository(owner: $owner, name: $repo) {{
+            {aliases_query}
+          }}
+        }}
+        """
+        with gate_call(self.gate):
+            data = self.graphql.query(
+                query,
+                variables={"owner": owner, "repo": repo},
+            )
+        repository = (data or {}).get("repository") or {}
+        result: dict[int, dict[str, Any]] = {}
+        for idx, number in enumerate(numbers):
+            pr_node = repository.get(f"pr{idx}") or {}
+            if isinstance(pr_node, dict):
+                result[int(number)] = pr_node
+        return result
+
+    def _fetch_review_comments_page(
+        self,
+        *,
+        review_id: str,
+        first: int,
+        after: str | None,
+    ) -> dict[str, Any] | None:
+        query = """
+        query($reviewId: ID!, $first: Int!, $after: String) {
+          node(id: $reviewId) {
+            ... on PullRequestReview {
+              comments(first: $first, after: $after) {
+                nodes { id databaseId fullDatabaseId body createdAt author { login } }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        }
+        """
+        with gate_call(self.gate):
+            data = self.graphql.query(
+                query,
+                variables={"reviewId": review_id, "first": first, "after": after},
+            )
+        node = (data or {}).get("node") or {}
+        comments = node.get("comments") if isinstance(node, dict) else None
+        return comments if isinstance(comments, dict) else None
+
+    def _complete_pr_social_payloads(
+        self,
+        *,
+        owner: str,
+        repo: str,
+        initial: dict[int, dict[str, Any]],
+        comments_limit: int | None,
+        review_comments_limit: int | None,
+        reviews_limit: int | None,
+    ) -> Iterable[BatchedPRPayload]:
+        for number, pr_node in initial.items():
+            comments_connection = pr_node.get("comments")
+            comments = [
+                self._comment_from_graphql(node)
+                for node in self._connection_nodes(comments_connection)
+            ]
+            comments_cursor = self._connection_cursor(comments_connection)
+            while comments_cursor and self._remaining_limit(comments_limit, len(comments)) != 0:
+                remaining = self._remaining_limit(comments_limit, len(comments))
+                more = self._fetch_pr_social_data_page(
+                    owner=owner,
+                    repo=repo,
+                    numbers=[number],
+                    comments_first=self._connection_first(remaining),
+                    review_comments_first=0,
+                    reviews_first=0,
+                    comments_after=comments_cursor,
+                ).get(number, {})
+                more_connection = more.get("comments") if isinstance(more, dict) else None
+                comments.extend(
+                    self._comment_from_graphql(node)
+                    for node in self._connection_nodes(more_connection)
+                )
+                comments_cursor = self._connection_cursor(more_connection)
+
+            reviews_connection = pr_node.get("reviews")
+            reviews_nodes = self._connection_nodes(reviews_connection)
+            reviews_cursor = self._connection_cursor(reviews_connection)
+            while reviews_cursor and self._remaining_limit(reviews_limit, len(reviews_nodes)) != 0:
+                remaining_reviews = self._remaining_limit(reviews_limit, len(reviews_nodes))
+                more = self._fetch_pr_social_data_page(
+                    owner=owner,
+                    repo=repo,
+                    numbers=[number],
+                    comments_first=0,
+                    review_comments_first=self._connection_first(review_comments_limit),
+                    reviews_first=self._connection_first(remaining_reviews),
+                    reviews_after=reviews_cursor,
+                ).get(number, {})
+                more_reviews = more.get("reviews") if isinstance(more, dict) else None
+                reviews_nodes.extend(self._connection_nodes(more_reviews))
+                reviews_cursor = self._connection_cursor(more_reviews)
+
+            reviews = [self._review_from_graphql(node) for node in reviews_nodes]
+            review_comments: list[GitHubGraphQLComment] = []
+            for review_node in reviews_nodes:
+                review_comment_connection = review_node.get("comments")
+                review_comments.extend(
+                    self._comment_from_graphql(node)
+                    for node in self._connection_nodes(review_comment_connection)
+                )
+                review_comment_cursor = self._connection_cursor(review_comment_connection)
+                review_node_id = review_node.get("id")
+                while (
+                    isinstance(review_node_id, str)
+                    and review_comment_cursor
+                    and self._remaining_limit(review_comments_limit, len(review_comments)) != 0
+                ):
+                    remaining_comments = self._remaining_limit(
+                        review_comments_limit, len(review_comments)
+                    )
+                    more_comments = self._fetch_review_comments_page(
+                        review_id=review_node_id,
+                        first=self._connection_first(remaining_comments),
+                        after=review_comment_cursor,
+                    )
+                    review_comments.extend(
+                        self._comment_from_graphql(node)
+                        for node in self._connection_nodes(more_comments)
+                    )
+                    review_comment_cursor = self._connection_cursor(more_comments)
+
+            if comments_limit is not None:
+                comments = comments[: int(comments_limit)]
+            if reviews_limit is not None:
+                reviews = reviews[: int(reviews_limit)]
+            if review_comments_limit is not None:
+                review_comments = review_comments[: int(review_comments_limit)]
+
+            yield BatchedPRPayload(
+                number=number,
+                issue_comments=tuple(comments),
+                review_comments=tuple(review_comments),
+                reviews=tuple(reviews),
+            )
+
     def iter_repo_milestones(
         self,
         *,
@@ -461,13 +862,16 @@ class GitHubWorkClient:
                 if changes_page_info.get("hasNextPage"):
                     all_changes: list[dict[str, object]] = []
                     all_changes.extend(changes)
-                    changes_cursor = changes_page_info.get("endCursor")
+                    raw_changes_cursor = changes_page_info.get("endCursor")
+                    changes_cursor = (
+                        raw_changes_cursor if isinstance(raw_changes_cursor, str) else None
+                    )
 
                     # Fetch remaining changes for this specific item
                     while changes_cursor:
                         with gate_call(self.gate):
                             more_changes = self._fetch_item_changes(
-                                item_id=item.get("id"),
+                                item_id=str(item.get("id")),
                                 after=changes_cursor,
                             )
 
@@ -476,7 +880,12 @@ class GitHubWorkClient:
 
                         all_changes.extend(more_changes.get("nodes") or [])
                         changes_page_info = more_changes.get("pageInfo") or {}
-                        changes_cursor = changes_page_info.get("endCursor")
+                        raw_changes_cursor = changes_page_info.get("endCursor")
+                        changes_cursor = (
+                            raw_changes_cursor
+                            if isinstance(raw_changes_cursor, str)
+                            else None
+                        )
 
                         if not changes_page_info.get("hasNextPage"):
                             break

--- a/src/dev_health_ops/providers/github/provider.py
+++ b/src/dev_health_ops/providers/github/provider.py
@@ -24,7 +24,10 @@ from dev_health_ops.providers.base import (
     ProviderCapabilities,
     ProviderWithClient,
 )
-from dev_health_ops.providers.github.client import GitHubWorkClient
+from dev_health_ops.providers.github.client import (
+    GitHubGraphQLComment,
+    GitHubWorkClient,
+)
 from dev_health_ops.providers.normalize_common import to_utc as _to_utc
 from dev_health_ops.providers.utils import env_flag as _env_flag
 from dev_health_ops.providers.utils import env_int
@@ -225,12 +228,27 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                     if remaining_limit <= 0:
                         remaining_limit = None
 
-                for pr in client.iter_pull_requests(
-                    owner=owner,
-                    repo=repo,
-                    state="all",
-                    limit=remaining_limit,
-                ):
+                prs = list(
+                    client.iter_pull_requests(
+                        owner=owner,
+                        repo=repo,
+                        state="all",
+                        limit=remaining_limit,
+                    )
+                )
+                pr_comments_by_number: dict[int, tuple[GitHubGraphQLComment, ...]] = {}
+                if fetch_comments:
+                    pr_comments_by_number = {
+                        number: comments
+                        for number, comments in client.iter_pr_comments_batch(
+                            owner=owner,
+                            repo=repo,
+                            prs=prs,
+                            limit=comments_limit,
+                        )
+                    }
+
+                for pr in prs:
                     if ctx.limit is not None and fetched_count >= ctx.limit:
                         break
 
@@ -273,9 +291,9 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                     # Fetch comments for interactions
                     if fetch_comments:
                         try:
-                            for comment in client.iter_pr_comments(
-                                pr, limit=comments_limit
-                            ):
+                            pr_number = int(getattr(pr, "number", 0) or 0)
+                            comments = pr_comments_by_number.get(pr_number, ())
+                            for comment in comments:
                                 event = github_comment_to_interaction_event(
                                     comment=comment,
                                     work_item_id=wi.work_item_id,

--- a/tests/providers/test_github_pr_social_batch.py
+++ b/tests/providers/test_github_pr_social_batch.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dev_health_ops.connectors.exceptions import APIException, RateLimitException
+from dev_health_ops.providers.github.client import GitHubAuth, GitHubWorkClient
+
+
+def _client() -> tuple[GitHubWorkClient, MagicMock, MagicMock]:
+    gate = MagicMock()
+    with patch("github.Github"), patch(
+        "dev_health_ops.providers.github.client.GitHubGraphQLClient"
+    ) as graphql_cls:
+        client = GitHubWorkClient(auth=GitHubAuth(token="token"), gate=gate)
+    return client, graphql_cls.return_value, gate
+
+
+def _pr(number: int) -> MagicMock:
+    pr = MagicMock()
+    pr.number = number
+    pr.get_comments.side_effect = AssertionError("REST comments should not be used")
+    pr.get_review_comments.side_effect = AssertionError(
+        "REST review comments should not be used"
+    )
+    return pr
+
+
+def _comment_node(comment_id: int, body: str = "comment") -> dict[str, object]:
+    return {
+        "id": f"IC_{comment_id}",
+        "databaseId": comment_id,
+        "fullDatabaseId": str(comment_id),
+        "body": body,
+        "createdAt": "2026-01-02T03:04:05Z",
+        "author": {"login": "octocat"},
+    }
+
+
+def _review_node(review_id: int) -> dict[str, object]:
+    return {
+        "id": f"PRR_{review_id}",
+        "databaseId": review_id,
+        "fullDatabaseId": str(review_id),
+        "body": "LGTM",
+        "state": "APPROVED",
+        "submittedAt": "2026-01-03T03:04:05Z",
+        "url": f"https://github.test/review/{review_id}",
+        "author": {"login": "reviewer"},
+        "comments": {
+            "nodes": [_comment_node(review_id + 1000, "review comment")],
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+        },
+    }
+
+
+def test_batched_pr_comments_fetches_n_prs_with_one_graphql_call() -> None:
+    client, graphql, _gate = _client()
+    prs = [_pr(number) for number in range(1, 6)]
+    graphql.query.return_value = {
+        "repository": {
+            f"pr{idx}": {
+                "number": number,
+                "comments": {
+                    "nodes": [_comment_node(number)],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                },
+            }
+            for idx, number in enumerate(range(1, 6))
+        }
+    }
+
+    result = dict(
+        client.iter_pr_comments_batch(owner="owner", repo="repo", prs=prs, limit=100)
+    )
+
+    assert sorted(result) == [1, 2, 3, 4, 5]
+    assert result[1][0].id == 1
+    assert result[1][0].body == "comment"
+    assert getattr(result[1][0].user, "login") == "octocat"
+    assert result[1][0].created_at == datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    assert graphql.query.call_count == 1
+    for pr in prs:
+        pr.get_comments.assert_not_called()
+
+
+def test_batched_pr_social_data_paginates_nested_connections() -> None:
+    client, graphql, _gate = _client()
+    graphql.query.side_effect = [
+        {
+            "repository": {
+                "pr0": {
+                    "number": 1,
+                    "comments": {
+                        "nodes": [_comment_node(1)],
+                        "pageInfo": {"hasNextPage": True, "endCursor": "c1"},
+                    },
+                    "reviews": {
+                        "nodes": [_review_node(10)],
+                        "pageInfo": {"hasNextPage": True, "endCursor": "r1"},
+                    },
+                }
+            }
+        },
+        {
+            "repository": {
+                "pr0": {
+                    "number": 1,
+                    "comments": {
+                        "nodes": [_comment_node(2)],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    },
+                }
+            }
+        },
+        {
+            "repository": {
+                "pr0": {
+                    "number": 1,
+                    "reviews": {
+                        "nodes": [_review_node(11)],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    },
+                }
+            }
+        },
+    ]
+
+    payload = next(
+        iter(client.iter_pr_social_data_batch(
+            owner="owner",
+            repo="repo",
+            prs=[_pr(1)],
+            comments_limit=10,
+            review_comments_limit=10,
+            reviews_limit=10,
+        ))
+    )
+
+    assert [comment.id for comment in payload.issue_comments] == [1, 2]
+    assert [review.id for review in payload.reviews] == [10, 11]
+    assert [comment.body for comment in payload.review_comments] == [
+        "review comment",
+        "review comment",
+    ]
+    assert graphql.query.call_count == 3
+
+
+def test_batched_pr_social_data_handles_empty_connections() -> None:
+    client, graphql, _gate = _client()
+    graphql.query.return_value = {
+        "repository": {
+            "pr0": {
+                "number": 1,
+                "comments": {"nodes": [], "pageInfo": {"hasNextPage": False}},
+                "reviews": {"nodes": [], "pageInfo": {"hasNextPage": False}},
+            }
+        }
+    }
+
+    payload = next(
+        iter(client.iter_pr_social_data_batch(owner="owner", repo="repo", prs=[_pr(1)]))
+    )
+
+    assert payload.issue_comments == ()
+    assert payload.review_comments == ()
+    assert payload.reviews == ()
+
+
+def test_batched_pr_social_data_surfaces_graphql_errors() -> None:
+    client, graphql, gate = _client()
+    graphql.query.side_effect = APIException("GraphQL errors: bad field")
+
+    with pytest.raises(APIException):
+        list(client.iter_pr_comments_batch(owner="owner", repo="repo", prs=[_pr(1)]))
+
+    gate.penalize.assert_called_once()
+
+
+def test_batched_pr_social_data_penalizes_retry_after_on_rate_limit() -> None:
+    client, graphql, gate = _client()
+    graphql.query.side_effect = RateLimitException(
+        "limited", retry_after_seconds=42.0
+    )
+
+    with pytest.raises(RateLimitException):
+        list(client.iter_pr_comments_batch(owner="owner", repo="repo", prs=[_pr(1)]))
+
+    gate.penalize.assert_called_once_with(42.0)
+
+
+def test_batched_pr_reviews_preserve_rest_consumed_fields() -> None:
+    client, graphql, _gate = _client()
+    graphql.query.return_value = {
+        "repository": {
+            "pr0": {
+                "number": 1,
+                "reviews": {
+                    "nodes": [_review_node(10)],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                },
+            }
+        }
+    }
+
+    reviews = dict(
+        client.iter_pr_reviews_batch(owner="owner", repo="repo", prs=[_pr(1)], limit=10)
+    )[1]
+
+    assert reviews[0].id == 10
+    assert reviews[0].reviewer == "reviewer"
+    assert reviews[0].state == "APPROVED"
+    assert reviews[0].submitted_at == datetime(2026, 1, 3, 3, 4, 5, tzinfo=timezone.utc)
+    assert reviews[0].body == "LGTM"
+    assert reviews[0].url == "https://github.test/review/10"

--- a/tests/providers/test_github_pr_social_batch.py
+++ b/tests/providers/test_github_pr_social_batch.py
@@ -11,9 +11,12 @@ from dev_health_ops.providers.github.client import GitHubAuth, GitHubWorkClient
 
 def _client() -> tuple[GitHubWorkClient, MagicMock, MagicMock]:
     gate = MagicMock()
-    with patch("github.Github"), patch(
-        "dev_health_ops.providers.github.client.GitHubGraphQLClient"
-    ) as graphql_cls:
+    with (
+        patch("github.Github"),
+        patch(
+            "dev_health_ops.providers.github.client.GitHubGraphQLClient"
+        ) as graphql_cls,
+    ):
         client = GitHubWorkClient(auth=GitHubAuth(token="token"), gate=gate)
     return client, graphql_cls.return_value, gate
 
@@ -129,14 +132,16 @@ def test_batched_pr_social_data_paginates_nested_connections() -> None:
     ]
 
     payload = next(
-        iter(client.iter_pr_social_data_batch(
-            owner="owner",
-            repo="repo",
-            prs=[_pr(1)],
-            comments_limit=10,
-            review_comments_limit=10,
-            reviews_limit=10,
-        ))
+        iter(
+            client.iter_pr_social_data_batch(
+                owner="owner",
+                repo="repo",
+                prs=[_pr(1)],
+                comments_limit=10,
+                review_comments_limit=10,
+                reviews_limit=10,
+            )
+        )
     )
 
     assert [comment.id for comment in payload.issue_comments] == [1, 2]
@@ -181,9 +186,7 @@ def test_batched_pr_social_data_surfaces_graphql_errors() -> None:
 
 def test_batched_pr_social_data_penalizes_retry_after_on_rate_limit() -> None:
     client, graphql, gate = _client()
-    graphql.query.side_effect = RateLimitException(
-        "limited", retry_after_seconds=42.0
-    )
+    graphql.query.side_effect = RateLimitException("limited", retry_after_seconds=42.0)
 
     with pytest.raises(RateLimitException):
         list(client.iter_pr_comments_batch(owner="owner", repo="repo", prs=[_pr(1)]))

--- a/tests/test_github_connector.py
+++ b/tests/test_github_connector.py
@@ -191,3 +191,64 @@ class TestGitHubConnectorRepositories:
         assert len(repos) == 1
         assert repos[0].name == "org-repo"
         mock_github_instance.get_organization.assert_called_once_with("myorg")
+
+
+def test_get_pull_request_reviews_uses_graphql_pagination() -> None:
+    with patch("dev_health_ops.connectors.github.Github"), patch(
+        "dev_health_ops.connectors.github.GitHubGraphQLClient"
+    ) as graphql_cls:
+        graphql = graphql_cls.return_value
+        graphql.query.side_effect = [
+            {
+                "repository": {
+                    "pullRequest": {
+                        "url": "https://github.test/o/r/pull/1",
+                        "reviews": {
+                            "nodes": [
+                                {
+                                    "id": "PRR_1",
+                                    "databaseId": 1,
+                                    "fullDatabaseId": "1",
+                                    "state": "APPROVED",
+                                    "submittedAt": "2026-01-02T03:04:05Z",
+                                    "body": "LGTM",
+                                    "url": "https://github.test/review/1",
+                                    "author": {"login": "reviewer"},
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                        },
+                    }
+                }
+            },
+            {
+                "repository": {
+                    "pullRequest": {
+                        "url": "https://github.test/o/r/pull/1",
+                        "reviews": {
+                            "nodes": [
+                                {
+                                    "id": "PRR_2",
+                                    "databaseId": 2,
+                                    "fullDatabaseId": "2",
+                                    "state": "CHANGES_REQUESTED",
+                                    "submittedAt": None,
+                                    "body": None,
+                                    "url": None,
+                                    "author": None,
+                                }
+                            ],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        },
+                    }
+                }
+            },
+        ]
+
+        connector = GitHubConnector(token="token")
+        reviews = connector.get_pull_request_reviews("owner", "repo", 1)
+
+    assert [review.id for review in reviews] == ["1", "2"]
+    assert reviews[0].reviewer == "reviewer"
+    assert reviews[1].reviewer == "Unknown"
+    assert graphql.query.call_count == 2

--- a/tests/test_github_connector.py
+++ b/tests/test_github_connector.py
@@ -194,9 +194,10 @@ class TestGitHubConnectorRepositories:
 
 
 def test_get_pull_request_reviews_uses_graphql_pagination() -> None:
-    with patch("dev_health_ops.connectors.github.Github"), patch(
-        "dev_health_ops.connectors.github.GitHubGraphQLClient"
-    ) as graphql_cls:
+    with (
+        patch("dev_health_ops.connectors.github.Github"),
+        patch("dev_health_ops.connectors.github.GitHubGraphQLClient") as graphql_cls,
+    ):
         graphql = graphql_cls.return_value
         graphql.query.side_effect = [
             {


### PR DESCRIPTION
## Problem
CHAOS-645 reported GitHub API rate-limit exhaustion from per-PR REST calls for PR reviews and comments. The issue paths were stale; the active code is under `src/dev_health_ops/providers/github/` plus the legacy `src/dev_health_ops/connectors/github.py` path.

## Approach
- Added GraphQL batched PR social-data fetching in `GitHubWorkClient` using `repository.pullRequest(number: ...)` aliases so existing PyGithub PR iteration and downstream iterator APIs remain compatible.
- Batched issue comments, review comments, and reviews with nested pagination; extra GraphQL calls occur only when a PR exceeds a connection page.
- Migrated `GitHubProvider` PR comment ingestion to the batch API and migrated legacy connector `get_pull_request_reviews()` to GraphQL pagination.
- Preserved rate-limit gating through `gate_call` and now forwards exception `retry_after_seconds` into `RateLimitGate.penalize()`.

## API-call shape
Before: provider PR comments were 1 REST `get_comments()` call per PR, and connector reviews were `get_repo()` + `get_pull()` + 1 REST `get_reviews()` page walk per PR (effectively O(N) PR social-data calls, plus nested REST pagination).
After: up to 50 PRs per GraphQL query via aliases for first pages; additional calls are only nested pagination for PRs whose comments/reviews exceed page size. For N PRs with in-page social data: `ceil(N/50)` GraphQL calls.

## Files changed
- `src/dev_health_ops/providers/github/client.py`
- `src/dev_health_ops/providers/github/provider.py`
- `src/dev_health_ops/connectors/github.py`
- `src/dev_health_ops/providers/_ratelimit.py`
- `tests/providers/test_github_pr_social_batch.py`
- `tests/test_github_connector.py`

## Testing
- `uv run pytest tests/providers tests/test_github_provider.py tests/test_github_connector.py -x -q` — 177 passed
- `uv run ruff check src/dev_health_ops/providers/github src/dev_health_ops/connectors/github.py src/dev_health_ops/providers/_ratelimit.py tests/providers/test_github_pr_social_batch.py tests/test_github_connector.py` — passed
- `uv run mypy src/dev_health_ops/providers/github/client.py src/dev_health_ops/providers/github/provider.py src/dev_health_ops/connectors/github.py src/dev_health_ops/providers/_ratelimit.py tests/providers/test_github_pr_social_batch.py tests/test_github_connector.py` — passed
- LSP diagnostics clean on every edited Python file

SCREENSHOT-WAIVER: backend-only GitHub ingestion change; no rendered UI affected.

Closes CHAOS-645