### PR TITLE
feat(attribution): canonical storage for AI attribution (CHAOS-1579)

### DIFF
--- a/docs/architecture/ai-attribution.md
+++ b/docs/architecture/ai-attribution.md
@@ -1,0 +1,210 @@
+# AI Attribution Architecture
+
+> **Canonical contract for CHAOS-1579 (storage) and CHAOS-1580 (ingestion).**
+
+## Overview
+
+AI attribution tracks which engineering artifacts (PRs, commits, issues, reviews, workflow runs)
+had AI involvement, what kind, how confident, and which signal produced that conclusion.
+
+Attribution is **evidence, not verdict** — every detected signal is preserved raw.  Resolution
+(which signal "wins" for a given subject) happens at read time via the `ai_attribution_resolved`
+view, not at write time.
+
+---
+
+## Data Model
+
+### Enumerations
+
+#### `AIAttributionSource` — where the signal came from
+
+| Value              | Description                           |
+| ------------------ | ------------------------------------- |
+| `pr_label`         | Explicit label on the PR              |
+| `bot_author`       | GitHub App / known bot user           |
+| `commit_trailer`   | `AI-Assisted-By` / `Co-authored-by` AI bot trailer |
+| `branch_name`      | Weak heuristic from branch name       |
+| `pr_body`          | Weak heuristic from PR body text      |
+| `ci_annotation`    | CI workflow step annotation           |
+| `manual`           | User override — always wins           |
+
+#### `AIAttributionKind` — type of involvement
+
+| Value           | Description                                    |
+| --------------- | ---------------------------------------------- |
+| `ai_assisted`   | Human-authored with AI assistance              |
+| `agent_created` | Autonomous agent produced this artifact        |
+| `ai_review`     | AI performed the review                        |
+| `unknown`       | Signal detected but kind unclear — do not guess |
+
+### `AIAttributionSignal`
+
+Lightweight detection output from `providers/_ai_detection.py`.  Does not carry
+org/subject context — the normalization caller attaches context and promotes to
+`AIAttributionRecord` via `AIAttributionRecord.from_signal(...)`.
+
+### `AIAttributionRecord`
+
+Full persisted record.  One record per detected signal per subject.
+
+| Field           | Type                | Notes                                     |
+| --------------- | ------------------- | ----------------------------------------- |
+| `record_id`     | `UUID`              | Surrogate ID; used for supersession links |
+| `org_id`        | `UUID`              | Organization scope                        |
+| `provider`      | `str`               | `github` / `gitlab` / `jira` / `local`   |
+| `subject_type`  | `SubjectType`       | `pull_request` / `commit` / etc.          |
+| `subject_id`    | `str`               | Provider-native ID                        |
+| `repo_id`       | `UUID \| None`      | Repository scope (optional)               |
+| `kind`          | `AIAttributionKind` | Type of AI involvement                    |
+| `source`        | `AIAttributionSource` | Signal origin                           |
+| `confidence`    | `float`             | `[0.0, 1.0]`                             |
+| `actor`         | `str \| None`       | Bot name / agent name / `"human"`         |
+| `evidence`      | `dict[str, object]` | Raw signal payload (serialized to JSON)   |
+| `observed_at`   | `datetime`          | When signal was emitted by provider       |
+| `ingested_at`   | `datetime`          | When record was created (auto-set)        |
+| `superseded_by` | `UUID \| None`      | `record_id` of the MANUAL override        |
+
+---
+
+## Source Precedence
+
+```
+MANUAL > pr_label > bot_author > commit_trailer > ci_annotation > branch_name > pr_body
+```
+
+Precedence is applied at **read time** by the `ai_attribution_resolved` view.
+Lower precedence integer = higher authority.
+
+| Source           | Priority |
+| ---------------- | -------- |
+| `manual`         | 1        |
+| `pr_label`       | 2        |
+| `bot_author`     | 3        |
+| `commit_trailer` | 4        |
+| `ci_annotation`  | 5        |
+| `branch_name`    | 6        |
+| `pr_body`        | 7        |
+
+---
+
+## Storage Architecture
+
+### Database selection
+
+AI attribution is **pure analytics data** — it has no semantic-layer identity, is not
+joined to Postgres tables, and carries no billing or access-control implications.
+
+> **All AI attribution reads and writes go through ClickHouse only.**
+
+No SQLAlchemy mixin is defined.  If future requirements surface a Postgres-backed
+attribution presence (e.g., user-managed overrides in the settings API), introduce an
+Alembic migration at that point.
+
+### ClickHouse table: `ai_attribution`
+
+```sql
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(observed_at)
+ORDER BY (org_id, provider, subject_type, subject_id, source)
+```
+
+- **Deduplication key**: `(org_id, provider, subject_type, subject_id, source)`
+- **Latest wins**: re-inserting the same key with a newer `computed_at` supersedes the row
+- Multiple sources for the same subject all have distinct keys and are all persisted
+
+### ClickHouse view: `ai_attribution_resolved`
+
+A **plain `VIEW`** (not an incremental `MATERIALIZED VIEW`) that picks the
+highest-precedence, non-superseded record per `(org_id, subject_type, subject_id)`.
+
+```sql
+SELECT ...
+FROM (
+    SELECT *,
+        multiIf(source = 'manual', 1, source = 'pr_label', 2, ...) AS _source_priority
+    FROM ai_attribution FINAL
+    WHERE superseded_by IS NULL
+)
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY org_id, subject_type, subject_id
+    ORDER BY _source_priority ASC, confidence DESC
+) = 1;
+```
+
+**Why not a true incremental MV?**
+Incremental ClickHouse MVs process newly inserted rows only.  Selecting the globally
+highest-precedence record per subject requires visibility across all rows for that
+subject, which incremental aggregation cannot provide correctly.  The base table's
+`ReplacingMergeTree` handles write-time deduplication per source; this plain VIEW
+handles read-time cross-source precedence resolution.
+
+**Performance note**: `FINAL` on a `ReplacingMergeTree` can be slow at scale.
+Consider:
+- Running `OPTIMIZE TABLE ai_attribution FINAL` periodically to compact segments
+- Querying with `max_threads` and partition pruning on `observed_at`
+
+---
+
+## Write Path
+
+```
+Normalization (providers/_ai_detection.py)
+    → AIAttributionSignal(s)
+    → AIAttributionRecord.from_signal(...)
+    → AIAttributionMixin.write_ai_attribution([...])
+    → ClickHouse: ai_attribution (ReplacingMergeTree)
+```
+
+Key invariants:
+- **Every detected signal is persisted** — do not collapse signals before writing
+- **Sink only** — no file exports, no debug dumps
+- **Idempotent** — same `(org_id, provider, subject_type, subject_id, source)` re-inserted is safe
+
+## Read Path
+
+```
+ClickHouse: SELECT * FROM ai_attribution_resolved
+    WHERE org_id = ? AND subject_type = ? AND subject_id = ?
+```
+
+Returns: one row per subject with the effective attribution (highest precedence, non-superseded).
+
+---
+
+## Supersession (MANUAL overrides)
+
+When a user manually overrides attribution:
+
+1. Write a `MANUAL` source record (highest precedence — automatically wins in the resolved view)
+2. Optionally mark the previous record's `superseded_by = <manual_record.record_id>` to make the
+   override explicit in the audit trail (excluded by `WHERE superseded_by IS NULL`)
+
+Because `MANUAL` has precedence=1, step 2 is strictly optional for correctness — the resolved
+view will pick the MANUAL record regardless.  The `superseded_by` field exists for auditability.
+
+---
+
+## Migration
+
+File: `src/dev_health_ops/migrations/clickhouse/035_ai_attribution.sql`
+
+Applied via:
+```bash
+dev-hops migrate clickhouse
+```
+
+All DDL uses `CREATE TABLE IF NOT EXISTS` / `CREATE VIEW IF NOT EXISTS` — fully idempotent.
+
+---
+
+## Files
+
+| File | Role |
+| ---- | ---- |
+| `src/dev_health_ops/models/ai_attribution.py` | Canonical Python models + enums |
+| `src/dev_health_ops/migrations/clickhouse/035_ai_attribution.sql` | DDL migration |
+| `src/dev_health_ops/metrics/sinks/clickhouse/ai_attribution.py` | CH sink mixin |
+| `src/dev_health_ops/storage/mixins/ai_attribution.py` | Postgres decision doc |
+| `tests/storage/test_ai_attribution.py` | Unit tests |
+| `docs/architecture/ai-attribution.md` | This document |

--- a/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
@@ -7,17 +7,19 @@ Public API (stable — do not remove):
 The single `ClickHouseMetricsSink` class is built by composing mixin classes,
 each responsible for one table family:
 
-  ClickHouseCore     — connection, schema, shared _insert_rows helper
-  CIMixin            — CI/CD, deploy, incident, testops pipeline/test/coverage,
-                       release confidence, feature flags, telemetry, release impact
-  DoraMixin          — DORA metrics, period comparisons, benchmarks
-  WellbeingMixin     — user metrics, quality drag, pipeline stability
-  InvestmentMixin    — investment classifications/metrics, work-unit investments
-  WorkGraphMixin     — work graph edges, work items, git/repo/file metrics, forecasts
+  ClickHouseCore        — connection, schema, shared _insert_rows helper
+  CIMixin               — CI/CD, deploy, incident, testops pipeline/test/coverage,
+                          release confidence, feature flags, telemetry, release impact
+  DoraMixin             — DORA metrics, period comparisons, benchmarks
+  WellbeingMixin        — user metrics, quality drag, pipeline stability
+  InvestmentMixin       — investment classifications/metrics, work-unit investments
+  WorkGraphMixin        — work graph edges, work items, git/repo/file metrics, forecasts
+  AIAttributionMixin    — AI attribution records (ai_attribution table)
 """
 
 from __future__ import annotations
 
+from dev_health_ops.metrics.sinks.clickhouse.ai_attribution import AIAttributionMixin
 from dev_health_ops.metrics.sinks.clickhouse.ci import CIMixin
 from dev_health_ops.metrics.sinks.clickhouse.core import ClickHouseCore
 from dev_health_ops.metrics.sinks.clickhouse.dora import DoraMixin
@@ -29,6 +31,7 @@ from dev_health_ops.metrics.sinks.clickhouse.work_graph import WorkGraphMixin
 class ClickHouseMetricsSink(
     # Mixins come BEFORE ClickHouseCore so their concrete write_* methods
     # take priority in the MRO over BaseMetricsSink abstract methods.
+    AIAttributionMixin,
     CIMixin,
     DoraMixin,
     WellbeingMixin,

--- a/src/dev_health_ops/metrics/sinks/clickhouse/ai_attribution.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/ai_attribution.py
@@ -119,6 +119,4 @@ class AIAttributionMixin(_ClickHouseSinkBase):
             matrix = [_to_row(r) for r in chunk]
             self.client.insert("ai_attribution", matrix, column_names=_COLUMNS)
 
-        logger.debug(
-            "write_ai_attribution: persisted %d record(s)", len(records)
-        )
+        logger.debug("write_ai_attribution: persisted %d record(s)", len(records))

--- a/src/dev_health_ops/metrics/sinks/clickhouse/ai_attribution.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/ai_attribution.py
@@ -1,0 +1,124 @@
+"""
+AIAttributionMixin — ClickHouse write methods for AI attribution records.
+
+Table: ai_attribution (ReplacingMergeTree, ORDER BY (org_id, provider, subject_type, subject_id, source))
+View:  ai_attribution_resolved (plain VIEW resolving highest-precedence record per subject)
+
+Write-time: every detected signal is persisted raw; dedup is by the ORDER BY key.
+Read-time:  query ai_attribution_resolved for the effective attribution.
+
+Implementation note
+-------------------
+This mixin calls ``self.client.insert()`` directly rather than going through
+``_insert_rows``.  The core ``_insert_rows`` helper calls ``dataclasses.asdict()``
+on every row and only converts ``datetime`` values — it cannot handle:
+  - ``evidence: dict[str, object]`` → must be a JSON string in ClickHouse
+  - ``UUID`` fields → need explicit str() coercion for older clickhouse_connect versions
+
+The pre-conversion in ``_to_row()`` handles those transformations; the
+resulting matrix is then inserted via the low-level client API.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from datetime import timezone
+from typing import TYPE_CHECKING
+
+from dev_health_ops.metrics.sinks.clickhouse._insert import (
+    DEFAULT_BATCH_SIZE,
+    _chunked,
+    _dt_to_clickhouse_datetime,
+)
+from dev_health_ops.models.ai_attribution import AIAttributionRecord
+
+if TYPE_CHECKING:
+    from dev_health_ops.metrics.sinks.clickhouse._insert import _ClickHouseSinkBase
+else:
+
+    class _ClickHouseSinkBase:
+        pass
+
+
+logger = logging.getLogger(__name__)
+
+_COLUMNS = [
+    "record_id",
+    "org_id",
+    "provider",
+    "subject_type",
+    "subject_id",
+    "repo_id",
+    "kind",
+    "source",
+    "confidence",
+    "actor",
+    "evidence",
+    "observed_at",
+    "ingested_at",
+    "superseded_by",
+    "computed_at",
+]
+
+
+def _to_row(record: AIAttributionRecord) -> list[object]:
+    """
+    Convert an AIAttributionRecord to a ClickHouse value list.
+
+    Returns values in the same order as ``_COLUMNS``.  All type conversions
+    (UUID → str, StrEnum → str, dict → JSON str, datetime → naive-UTC) are
+    applied here so the insert matrix contains clean primitives.
+    """
+    from datetime import datetime
+
+    now_utc = datetime.now(timezone.utc)
+
+    return [
+        str(record.record_id),
+        str(record.org_id),
+        str(record.provider),
+        str(record.subject_type),
+        str(record.subject_id),
+        str(record.repo_id) if record.repo_id is not None else None,
+        str(record.kind),
+        str(record.source),
+        float(record.confidence),
+        record.actor,
+        record.evidence_json(),
+        _dt_to_clickhouse_datetime(record.observed_at),
+        _dt_to_clickhouse_datetime(record.ingested_at),
+        str(record.superseded_by) if record.superseded_by is not None else None,
+        _dt_to_clickhouse_datetime(now_utc),
+    ]
+
+
+class AIAttributionMixin(_ClickHouseSinkBase):
+    """Mixin for AI attribution write methods."""
+
+    def write_ai_attribution(
+        self,
+        records: Sequence[AIAttributionRecord],
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        """
+        Persist AI attribution records to ClickHouse.
+
+        Idempotent: re-inserting the same (org_id, provider, subject_type,
+        subject_id, source) tuple with a later computed_at will supersede the
+        previous row via ReplacingMergeTree(computed_at).
+
+        Args:
+            records:    Sequence of AIAttributionRecord to persist.
+            batch_size: Number of rows per ClickHouse insert call.
+        """
+        if not records:
+            return
+
+        for chunk in _chunked(list(records), batch_size):
+            matrix = [_to_row(r) for r in chunk]
+            self.client.insert("ai_attribution", matrix, column_names=_COLUMNS)
+
+        logger.debug(
+            "write_ai_attribution: persisted %d record(s)", len(records)
+        )

--- a/src/dev_health_ops/migrations/clickhouse/035_ai_attribution.sql
+++ b/src/dev_health_ops/migrations/clickhouse/035_ai_attribution.sql
@@ -1,0 +1,87 @@
+-- Migration 035: AI attribution tables and resolved view.
+--
+-- Stores one row per detected AI signal per subject (PR, commit, issue, etc.).
+-- Deduplication is by (org_id, provider, subject_type, subject_id, source) via
+-- ReplacingMergeTree(computed_at) — latest insert wins within that key.
+--
+-- Source precedence (highest → lowest):
+--   MANUAL > pr_label > bot_author > commit_trailer > ci_annotation > branch_name > pr_body
+--
+-- Write path: every detected signal is persisted raw.
+-- Read path:  use `ai_attribution_resolved` to get the effective attribution per subject.
+
+CREATE TABLE IF NOT EXISTS ai_attribution
+(
+    record_id      UUID,
+    org_id         UUID,
+    provider       LowCardinality(String),
+    subject_type   LowCardinality(String),
+    subject_id     String,
+    repo_id        Nullable(UUID),
+    kind           LowCardinality(String),
+    source         LowCardinality(String),
+    confidence     Float32,
+    actor          Nullable(String),
+    evidence       String,                          -- JSON-encoded evidence blob
+    observed_at    DateTime64(3, 'UTC'),
+    ingested_at    DateTime64(3, 'UTC'),
+    superseded_by  Nullable(UUID),
+    computed_at    DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(observed_at)
+ORDER BY (org_id, provider, subject_type, subject_id, source)
+SETTINGS index_granularity = 8192;
+
+-- -------------------------------------------------------------------------
+-- Resolved view: pick the highest-precedence, non-superseded record per
+-- (org_id, subject_type, subject_id) using window functions.
+--
+-- Implemented as a plain VIEW (not an incremental MV) because precedence
+-- resolution requires visibility across all rows for a subject, which
+-- incremental ClickHouse MVs cannot provide.  The base table uses
+-- ReplacingMergeTree(computed_at) for write-time deduplication per source;
+-- this view handles read-time cross-source precedence resolution.
+--
+-- Source priority integers (lower = wins):
+--   manual=1, pr_label=2, bot_author=3, commit_trailer=4,
+--   ci_annotation=5, branch_name=6, pr_body=7
+-- -------------------------------------------------------------------------
+
+CREATE VIEW IF NOT EXISTS ai_attribution_resolved AS
+SELECT
+    record_id,
+    org_id,
+    provider,
+    subject_type,
+    subject_id,
+    repo_id,
+    kind,
+    source,
+    confidence,
+    actor,
+    evidence,
+    observed_at,
+    ingested_at,
+    superseded_by,
+    computed_at
+FROM (
+    SELECT
+        *,
+        multiIf(
+            source = 'manual',          1,
+            source = 'pr_label',        2,
+            source = 'bot_author',      3,
+            source = 'commit_trailer',  4,
+            source = 'ci_annotation',   5,
+            source = 'branch_name',     6,
+            source = 'pr_body',         7,
+            8
+        ) AS _source_priority
+    FROM ai_attribution FINAL
+    WHERE superseded_by IS NULL
+)
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY org_id, subject_type, subject_id
+    ORDER BY _source_priority ASC, confidence DESC
+) = 1;

--- a/src/dev_health_ops/migrations/clickhouse/035_ai_attribution.sql
+++ b/src/dev_health_ops/migrations/clickhouse/035_ai_attribution.sql
@@ -40,7 +40,7 @@ SETTINGS index_granularity = 8192;
 -- Implemented as a plain VIEW (not an incremental MV) because precedence
 -- resolution requires visibility across all rows for a subject, which
 -- incremental ClickHouse MVs cannot provide.  The base table uses
--- ReplacingMergeTree(computed_at) for write-time deduplication per source;
+-- ReplacingMergeTree(computed_at) for write-time deduplication per source,
 -- this view handles read-time cross-source precedence resolution.
 --
 -- Source priority integers (lower = wins):

--- a/src/dev_health_ops/models/ai_attribution.py
+++ b/src/dev_health_ops/models/ai_attribution.py
@@ -29,22 +29,22 @@ from uuid import UUID, uuid4
 class AIAttributionSource(StrEnum):
     """Where the AI attribution signal came from (ordered by precedence, high→low)."""
 
-    PR_LABEL = "pr_label"           # explicit label on the PR — highest signal
-    BOT_AUTHOR = "bot_author"       # GitHub App / known bot user
+    PR_LABEL = "pr_label"  # explicit label on the PR — highest signal
+    BOT_AUTHOR = "bot_author"  # GitHub App / known bot user
     COMMIT_TRAILER = "commit_trailer"  # AI-Assisted-By / Co-authored-by AI bot
-    BRANCH_NAME = "branch_name"     # weak heuristic signal
-    PR_BODY = "pr_body"             # weak heuristic signal
-    CI_ANNOTATION = "ci_annotation" # workflow step annotation
-    MANUAL = "manual"               # user override — always wins regardless of position
+    BRANCH_NAME = "branch_name"  # weak heuristic signal
+    PR_BODY = "pr_body"  # weak heuristic signal
+    CI_ANNOTATION = "ci_annotation"  # workflow step annotation
+    MANUAL = "manual"  # user override — always wins regardless of position
 
 
 class AIAttributionKind(StrEnum):
     """The type of AI involvement."""
 
-    AI_ASSISTED = "ai_assisted"     # human authored with AI assistance
-    AGENT_CREATED = "agent_created" # autonomous agent produced this artifact
-    AI_REVIEW = "ai_review"         # AI performed the review
-    UNKNOWN = "unknown"             # signal detected but kind unclear — do NOT guess
+    AI_ASSISTED = "ai_assisted"  # human authored with AI assistance
+    AGENT_CREATED = "agent_created"  # autonomous agent produced this artifact
+    AI_REVIEW = "ai_review"  # AI performed the review
+    UNKNOWN = "unknown"  # signal detected but kind unclear — do NOT guess
 
 
 # ---------------------------------------------------------------------------
@@ -82,9 +82,11 @@ class AIAttributionSignal:
 
     kind: AIAttributionKind
     source: AIAttributionSource
-    confidence: float           # [0.0, 1.0]
-    actor: str | None           # bot name / agent name / "human" / None
-    evidence: dict[str, object] # source-specific raw signal (label text, trailer key, etc.)
+    confidence: float  # [0.0, 1.0]
+    actor: str | None  # bot name / agent name / "human" / None
+    evidence: dict[
+        str, object
+    ]  # source-specific raw signal (label text, trailer key, etc.)
 
 
 # ---------------------------------------------------------------------------
@@ -111,19 +113,17 @@ class AIAttributionRecord:
     """
 
     org_id: UUID
-    provider: str               # github | gitlab | jira | local
+    provider: str  # github | gitlab | jira | local
     subject_type: SubjectType
-    subject_id: str             # provider-native id
+    subject_id: str  # provider-native id
     repo_id: UUID | None
     kind: AIAttributionKind
     source: AIAttributionSource
-    confidence: float           # [0.0, 1.0]
-    actor: str | None           # bot name / agent name / "human"
-    evidence: dict[str, object] # source-specific raw signal
-    observed_at: datetime       # when signal was emitted by the provider
-    ingested_at: datetime = field(
-        default_factory=lambda: datetime.now(timezone.utc)
-    )
+    confidence: float  # [0.0, 1.0]
+    actor: str | None  # bot name / agent name / "human"
+    evidence: dict[str, object]  # source-specific raw signal
+    observed_at: datetime  # when signal was emitted by the provider
+    ingested_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     superseded_by: UUID | None = None
     record_id: UUID = field(default_factory=uuid4)
 

--- a/src/dev_health_ops/models/ai_attribution.py
+++ b/src/dev_health_ops/models/ai_attribution.py
@@ -20,7 +20,6 @@ from enum import StrEnum
 from typing import Literal
 from uuid import UUID, uuid4
 
-
 # ---------------------------------------------------------------------------
 # Enumerations
 # ---------------------------------------------------------------------------
@@ -142,7 +141,7 @@ class AIAttributionRecord:
         subject_id: str,
         repo_id: UUID | None,
         observed_at: datetime,
-    ) -> "AIAttributionRecord":
+    ) -> AIAttributionRecord:
         """Promote a detection signal to a full persisted record."""
         return cls(
             org_id=org_id,

--- a/src/dev_health_ops/models/ai_attribution.py
+++ b/src/dev_health_ops/models/ai_attribution.py
@@ -1,0 +1,159 @@
+"""
+Canonical models for AI attribution storage.
+
+These types represent both the lightweight *signal* detected at normalization time
+and the full *record* persisted to ClickHouse.
+
+Source precedence (highest → lowest):
+    MANUAL > PR_LABEL > BOT_AUTHOR > COMMIT_TRAILER > CI_ANNOTATION > BRANCH_NAME > PR_BODY
+
+Write-time: persist every detected signal, deduped on (subject, source).
+Read-time:  the ``ai_attribution_resolved`` view resolves the effective attribution.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Literal
+from uuid import UUID, uuid4
+
+
+# ---------------------------------------------------------------------------
+# Enumerations
+# ---------------------------------------------------------------------------
+
+
+class AIAttributionSource(StrEnum):
+    """Where the AI attribution signal came from (ordered by precedence, high→low)."""
+
+    PR_LABEL = "pr_label"           # explicit label on the PR — highest signal
+    BOT_AUTHOR = "bot_author"       # GitHub App / known bot user
+    COMMIT_TRAILER = "commit_trailer"  # AI-Assisted-By / Co-authored-by AI bot
+    BRANCH_NAME = "branch_name"     # weak heuristic signal
+    PR_BODY = "pr_body"             # weak heuristic signal
+    CI_ANNOTATION = "ci_annotation" # workflow step annotation
+    MANUAL = "manual"               # user override — always wins regardless of position
+
+
+class AIAttributionKind(StrEnum):
+    """The type of AI involvement."""
+
+    AI_ASSISTED = "ai_assisted"     # human authored with AI assistance
+    AGENT_CREATED = "agent_created" # autonomous agent produced this artifact
+    AI_REVIEW = "ai_review"         # AI performed the review
+    UNKNOWN = "unknown"             # signal detected but kind unclear — do NOT guess
+
+
+# ---------------------------------------------------------------------------
+# Source precedence mapping
+# ---------------------------------------------------------------------------
+
+#: Lower integer = higher precedence.  MANUAL wins all others.
+SOURCE_PRECEDENCE: dict[AIAttributionSource, int] = {
+    AIAttributionSource.MANUAL: 1,
+    AIAttributionSource.PR_LABEL: 2,
+    AIAttributionSource.BOT_AUTHOR: 3,
+    AIAttributionSource.COMMIT_TRAILER: 4,
+    AIAttributionSource.CI_ANNOTATION: 5,
+    AIAttributionSource.BRANCH_NAME: 6,
+    AIAttributionSource.PR_BODY: 7,
+}
+
+SubjectType = Literal["pull_request", "commit", "issue", "workflow_run", "review"]
+
+
+# ---------------------------------------------------------------------------
+# AIAttributionSignal — lightweight detection output (pre-persistence)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AIAttributionSignal:
+    """
+    Detection output from a single heuristic.
+
+    Produced by ``providers/_ai_detection.py`` during normalization.
+    Does NOT carry org/subject context — the caller attaches that before
+    constructing a full ``AIAttributionRecord``.
+    """
+
+    kind: AIAttributionKind
+    source: AIAttributionSource
+    confidence: float           # [0.0, 1.0]
+    actor: str | None           # bot name / agent name / "human" / None
+    evidence: dict[str, object] # source-specific raw signal (label text, trailer key, etc.)
+
+
+# ---------------------------------------------------------------------------
+# AIAttributionRecord — full persisted record
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AIAttributionRecord:
+    """
+    Full AI attribution record, ready for ClickHouse persistence.
+
+    One record per detected signal per subject.  Multiple records for the same
+    subject (from different sources) are all persisted; resolution happens at
+    read time via the ``ai_attribution_resolved`` view.
+
+    Deduplication key (ClickHouse ORDER BY):
+        (org_id, provider, subject_type, subject_id, source)
+
+    Supersession:
+        When a MANUAL record is created, ``superseded_by`` on earlier records
+        may be set to ``record_id`` of the MANUAL record.  The resolved view
+        filters ``superseded_by IS NULL`` records first, then applies precedence.
+    """
+
+    org_id: UUID
+    provider: str               # github | gitlab | jira | local
+    subject_type: SubjectType
+    subject_id: str             # provider-native id
+    repo_id: UUID | None
+    kind: AIAttributionKind
+    source: AIAttributionSource
+    confidence: float           # [0.0, 1.0]
+    actor: str | None           # bot name / agent name / "human"
+    evidence: dict[str, object] # source-specific raw signal
+    observed_at: datetime       # when signal was emitted by the provider
+    ingested_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    superseded_by: UUID | None = None
+    record_id: UUID = field(default_factory=uuid4)
+
+    def evidence_json(self) -> str:
+        """Serialize evidence to JSON string for ClickHouse storage."""
+        return json.dumps(self.evidence, default=str)
+
+    @classmethod
+    def from_signal(
+        cls,
+        signal: AIAttributionSignal,
+        *,
+        org_id: UUID,
+        provider: str,
+        subject_type: SubjectType,
+        subject_id: str,
+        repo_id: UUID | None,
+        observed_at: datetime,
+    ) -> "AIAttributionRecord":
+        """Promote a detection signal to a full persisted record."""
+        return cls(
+            org_id=org_id,
+            provider=provider,
+            subject_type=subject_type,
+            subject_id=subject_id,
+            repo_id=repo_id,
+            kind=signal.kind,
+            source=signal.source,
+            confidence=signal.confidence,
+            actor=signal.actor,
+            evidence=signal.evidence,
+            observed_at=observed_at,
+        )

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -152,6 +152,15 @@ class ClickHouseStore:
                             stmt = stmt.strip()
                             if not stmt:
                                 continue
+                            # Skip comment-only chunks (created when a stray
+                            # ';' appears inside a '--' comment block).
+                            code_lines = [
+                                line
+                                for line in stmt.splitlines()
+                                if line.strip() and not line.strip().startswith("--")
+                            ]
+                            if not code_lines:
+                                continue
                             await asyncio.to_thread(self.client.command, stmt)
                     except Exception as e:
                         logger.critical("Migration failed: %s\nError: %s", path.name, e)

--- a/src/dev_health_ops/storage/mixins/ai_attribution.py
+++ b/src/dev_health_ops/storage/mixins/ai_attribution.py
@@ -1,0 +1,22 @@
+"""
+AI Attribution — PostgreSQL semantic layer decision.
+
+AI attribution is **pure analytics data**: it tracks which PRs, commits, issues,
+and workflow runs had AI involvement, along with confidence scores and evidence.
+
+Per the dual-database contract (docs/architecture/database-architecture.md):
+  - PostgreSQL = semantic layer (users, orgs, teams, credentials, settings)
+  - ClickHouse = analytics layer (metrics, time-series, attribution signals)
+
+AI attribution records have no semantic-layer identity.  They are never joined
+to Postgres tables, not user-visible in the semantic API, and carry no billing
+or access-control implications.  All reads and writes go through:
+
+    dev_health_ops.metrics.sinks.clickhouse.ai_attribution.AIAttributionMixin
+
+Therefore, **no SQLAlchemy mixin is defined for ai_attribution**.
+
+If a future requirement surfaces (e.g., attribution overrides surfaced in the
+Postgres-backed settings API), introduce an Alembic migration and a mixin at
+that point.  For now, this file is intentionally empty.
+"""

--- a/tests/storage/test_ai_attribution.py
+++ b/tests/storage/test_ai_attribution.py
@@ -20,8 +20,8 @@ from uuid import UUID, uuid4
 import pytest
 
 from dev_health_ops.metrics.sinks.clickhouse.ai_attribution import (
-    AIAttributionMixin,
     _COLUMNS,
+    AIAttributionMixin,
     _to_row,
 )
 from dev_health_ops.models.ai_attribution import (

--- a/tests/storage/test_ai_attribution.py
+++ b/tests/storage/test_ai_attribution.py
@@ -1,0 +1,456 @@
+"""
+Tests for AI attribution models, sink, and resolved-view precedence logic.
+
+Coverage:
+  1. Model construction and serialization
+  2. Signal → Record promotion
+  3. Sink insert path (CH client mocked via _FakeSink.client)
+  4. Deduplication: same (org, provider, subject_type, subject_id, source) → idempotent
+  5. Supersession by MANUAL source
+  6. Resolved-view precedence ordering (pure-Python simulation)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from dev_health_ops.metrics.sinks.clickhouse.ai_attribution import (
+    AIAttributionMixin,
+    _COLUMNS,
+    _to_row,
+)
+from dev_health_ops.models.ai_attribution import (
+    SOURCE_PRECEDENCE,
+    AIAttributionKind,
+    AIAttributionRecord,
+    AIAttributionSignal,
+    AIAttributionSource,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+ORG = uuid4()
+REPO = uuid4()
+NOW = datetime(2025, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_record(
+    source: AIAttributionSource = AIAttributionSource.PR_LABEL,
+    kind: AIAttributionKind = AIAttributionKind.AI_ASSISTED,
+    confidence: float = 0.9,
+    subject_id: str = "pr-42",
+    subject_type: str = "pull_request",
+    superseded_by: UUID | None = None,
+    actor: str | None = "copilot[bot]",
+    evidence: dict[str, object] | None = None,
+) -> AIAttributionRecord:
+    return AIAttributionRecord(
+        org_id=ORG,
+        provider="github",
+        subject_type=subject_type,  # type: ignore[arg-type]
+        subject_id=subject_id,
+        repo_id=REPO,
+        kind=kind,
+        source=source,
+        confidence=confidence,
+        actor=actor,
+        evidence=evidence or {"label": "ai-assisted"},
+        observed_at=NOW,
+        superseded_by=superseded_by,
+    )
+
+
+def _row_as_dict(row_list: list[object]) -> dict[str, object]:
+    """Convert a _to_row() list back to a dict keyed by _COLUMNS for easier assertions."""
+    return dict(zip(_COLUMNS, row_list))
+
+
+# ---------------------------------------------------------------------------
+# 1. Model construction and serialization
+# ---------------------------------------------------------------------------
+
+
+class TestAIAttributionRecord:
+    def test_defaults_populated(self) -> None:
+        rec = _make_record()
+        assert rec.ingested_at is not None
+        assert rec.record_id is not None
+        assert rec.superseded_by is None
+
+    def test_evidence_json_roundtrip(self) -> None:
+        rec = _make_record(evidence={"label": "ai-assisted", "count": 3})
+        payload = rec.evidence_json()
+        parsed = json.loads(payload)
+        assert parsed == {"label": "ai-assisted", "count": 3}
+
+    def test_evidence_json_with_non_string_values(self) -> None:
+        rec = _make_record(evidence={"score": 0.95, "tags": ["ai", "bot"]})
+        payload = rec.evidence_json()
+        parsed = json.loads(payload)
+        assert parsed["score"] == pytest.approx(0.95)
+        assert parsed["tags"] == ["ai", "bot"]
+
+    def test_record_id_unique_per_instance(self) -> None:
+        r1 = _make_record()
+        r2 = _make_record()
+        assert r1.record_id != r2.record_id
+
+    def test_str_enum_values(self) -> None:
+        assert str(AIAttributionSource.PR_LABEL) == "pr_label"
+        assert str(AIAttributionKind.AGENT_CREATED) == "agent_created"
+        assert str(AIAttributionSource.MANUAL) == "manual"
+
+
+# ---------------------------------------------------------------------------
+# 2. Signal → Record promotion
+# ---------------------------------------------------------------------------
+
+
+class TestFromSignal:
+    def test_promotes_signal_to_record(self) -> None:
+        signal = AIAttributionSignal(
+            kind=AIAttributionKind.AI_ASSISTED,
+            source=AIAttributionSource.COMMIT_TRAILER,
+            confidence=0.75,
+            actor="claude-code[bot]",
+            evidence={"trailer_key": "AI-Assisted-By", "value": "claude"},
+        )
+        rec = AIAttributionRecord.from_signal(
+            signal,
+            org_id=ORG,
+            provider="github",
+            subject_type="commit",
+            subject_id="abc123",
+            repo_id=REPO,
+            observed_at=NOW,
+        )
+        assert rec.kind == AIAttributionKind.AI_ASSISTED
+        assert rec.source == AIAttributionSource.COMMIT_TRAILER
+        assert rec.confidence == pytest.approx(0.75)
+        assert rec.actor == "claude-code[bot]"
+        assert rec.org_id == ORG
+        assert rec.provider == "github"
+        assert rec.subject_type == "commit"
+        assert rec.subject_id == "abc123"
+        assert rec.superseded_by is None
+
+    def test_ingested_at_set_on_promotion(self) -> None:
+        signal = AIAttributionSignal(
+            kind=AIAttributionKind.AI_REVIEW,
+            source=AIAttributionSource.PR_LABEL,
+            confidence=0.95,
+            actor=None,
+            evidence={},
+        )
+        rec = AIAttributionRecord.from_signal(
+            signal,
+            org_id=ORG,
+            provider="github",
+            subject_type="review",
+            subject_id="rv-1",
+            repo_id=None,
+            observed_at=NOW,
+        )
+        assert rec.ingested_at is not None
+        assert rec.ingested_at.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# 3. Sink insert path — _to_row() and write_ai_attribution()
+# ---------------------------------------------------------------------------
+
+
+class _FakeSink(AIAttributionMixin):
+    """Minimal concrete sink — provides a mock CH client to capture insert calls."""
+
+    def __init__(self) -> None:
+        self.client = MagicMock()
+
+
+class TestToRow:
+    """Unit tests for the _to_row() conversion function."""
+
+    def test_returns_correct_length(self) -> None:
+        rec = _make_record()
+        row = _to_row(rec)
+        assert len(row) == len(_COLUMNS)
+
+    def test_column_order_matches_columns_constant(self) -> None:
+        rec = _make_record()
+        d = _row_as_dict(_to_row(rec))
+        assert set(d.keys()) == set(_COLUMNS)
+
+    def test_uuids_serialized_as_strings(self) -> None:
+        rec = _make_record()
+        d = _row_as_dict(_to_row(rec))
+        assert isinstance(d["org_id"], str)
+        assert isinstance(d["record_id"], str)
+        assert isinstance(d["repo_id"], str)
+
+    def test_null_repo_id(self) -> None:
+        rec = _make_record()
+        rec.repo_id = None
+        d = _row_as_dict(_to_row(rec))
+        assert d["repo_id"] is None
+
+    def test_null_actor(self) -> None:
+        rec = _make_record(actor=None)
+        d = _row_as_dict(_to_row(rec))
+        assert d["actor"] is None
+
+    def test_evidence_is_json_string(self) -> None:
+        rec = _make_record(evidence={"label": "copilot", "score": 0.9})
+        d = _row_as_dict(_to_row(rec))
+        assert isinstance(d["evidence"], str)
+        parsed = json.loads(str(d["evidence"]))
+        assert parsed["label"] == "copilot"
+
+    def test_kind_and_source_are_strings(self) -> None:
+        rec = _make_record(
+            kind=AIAttributionKind.AGENT_CREATED,
+            source=AIAttributionSource.BOT_AUTHOR,
+        )
+        d = _row_as_dict(_to_row(rec))
+        assert d["kind"] == "agent_created"
+        assert d["source"] == "bot_author"
+
+    def test_null_superseded_by(self) -> None:
+        rec = _make_record()
+        d = _row_as_dict(_to_row(rec))
+        assert d["superseded_by"] is None
+
+    def test_superseded_by_serialized_as_string(self) -> None:
+        ref_id = uuid4()
+        rec = _make_record(superseded_by=ref_id)
+        d = _row_as_dict(_to_row(rec))
+        assert d["superseded_by"] == str(ref_id)
+
+    def test_confidence_is_float(self) -> None:
+        rec = _make_record(confidence=0.75)
+        d = _row_as_dict(_to_row(rec))
+        assert isinstance(d["confidence"], float)
+        assert d["confidence"] == pytest.approx(0.75)
+
+
+class TestAIAttributionMixin:
+    def test_write_empty_is_noop(self) -> None:
+        sink = _FakeSink()
+        sink.write_ai_attribution([])
+        sink.client.insert.assert_not_called()
+
+    def test_write_single_record_calls_client_insert(self) -> None:
+        sink = _FakeSink()
+        rec = _make_record()
+        sink.write_ai_attribution([rec])
+
+        sink.client.insert.assert_called_once()
+        call_args = sink.client.insert.call_args
+        table, matrix = call_args.args[0], call_args.args[1]
+        assert table == "ai_attribution"
+        assert len(matrix) == 1
+        assert call_args.kwargs["column_names"] == _COLUMNS
+
+    def test_write_multiple_records(self) -> None:
+        sink = _FakeSink()
+        records = [_make_record(subject_id=f"pr-{i}") for i in range(5)]
+        sink.write_ai_attribution(records)
+        sink.client.insert.assert_called_once()
+        _, matrix = sink.client.insert.call_args.args
+        assert len(matrix) == 5
+
+    def test_batching_splits_into_chunks(self) -> None:
+        sink = _FakeSink()
+        records = [_make_record(subject_id=f"pr-{i}") for i in range(7)]
+        sink.write_ai_attribution(records, batch_size=3)
+        # 7 records, batch_size=3 → 3 insert calls: [3, 3, 1]
+        assert sink.client.insert.call_count == 3
+        total = sum(
+            len(call.args[1]) for call in sink.client.insert.call_args_list
+        )
+        assert total == 7
+
+    def test_each_row_has_correct_column_count(self) -> None:
+        sink = _FakeSink()
+        records = [_make_record(subject_id=f"pr-{i}") for i in range(3)]
+        sink.write_ai_attribution(records)
+        _, matrix = sink.client.insert.call_args.args
+        for row in matrix:
+            assert len(row) == len(_COLUMNS)
+
+
+# ---------------------------------------------------------------------------
+# 4. Deduplication: same natural key → idempotent re-insert
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplication:
+    def test_same_source_two_inserts_both_sent_to_client(self) -> None:
+        """
+        The sink sends both rows; ReplacingMergeTree(computed_at) handles
+        dedup server-side — latest computed_at survives after OPTIMIZE.
+        """
+        sink = _FakeSink()
+        rec1 = _make_record(confidence=0.7)
+        rec2 = _make_record(confidence=0.9)  # same subject_id, same source
+        sink.write_ai_attribution([rec1, rec2])
+
+        _, matrix = sink.client.insert.call_args.args
+        assert len(matrix) == 2
+        # Both rows share the same natural key components
+        d1, d2 = _row_as_dict(matrix[0]), _row_as_dict(matrix[1])
+        assert d1["subject_id"] == d2["subject_id"]
+        assert d1["source"] == d2["source"]
+
+    def test_different_sources_same_subject_all_persisted(self) -> None:
+        sink = _FakeSink()
+        records = [
+            _make_record(source=AIAttributionSource.PR_LABEL),
+            _make_record(source=AIAttributionSource.COMMIT_TRAILER),
+            _make_record(source=AIAttributionSource.BOT_AUTHOR),
+        ]
+        sink.write_ai_attribution(records)
+        _, matrix = sink.client.insert.call_args.args
+        sources = {_row_as_dict(row)["source"] for row in matrix}
+        assert sources == {"pr_label", "commit_trailer", "bot_author"}
+
+
+# ---------------------------------------------------------------------------
+# 5. Supersession by MANUAL source
+# ---------------------------------------------------------------------------
+
+
+class TestSupersession:
+    def test_manual_record_has_superseded_by_none(self) -> None:
+        """MANUAL records themselves are never superseded."""
+        manual = _make_record(source=AIAttributionSource.MANUAL)
+        assert manual.superseded_by is None
+        d = _row_as_dict(_to_row(manual))
+        assert d["superseded_by"] is None
+
+    def test_superseded_record_carries_manual_record_id(self) -> None:
+        """When a MANUAL override is applied, the old record carries its ID."""
+        manual = _make_record(source=AIAttributionSource.MANUAL)
+        auto_record = _make_record(
+            source=AIAttributionSource.PR_LABEL,
+            superseded_by=manual.record_id,
+        )
+        d = _row_as_dict(_to_row(auto_record))
+        assert d["superseded_by"] == str(manual.record_id)
+
+    def test_superseded_source_excluded_from_resolved_logic(self) -> None:
+        """
+        Simulate the resolved-view filter:
+        records with superseded_by set should not win even if higher priority.
+        """
+        manual = _make_record(source=AIAttributionSource.MANUAL, confidence=0.8)
+        pr_label_superseded = _make_record(
+            source=AIAttributionSource.PR_LABEL,
+            confidence=0.95,
+            superseded_by=manual.record_id,
+        )
+        # Simulate what the CH view does: filter superseded_by IS NULL first
+        active = [
+            r for r in [manual, pr_label_superseded] if r.superseded_by is None
+        ]
+        assert len(active) == 1
+        assert active[0].source == AIAttributionSource.MANUAL
+
+
+# ---------------------------------------------------------------------------
+# 6. Resolved-view precedence (pure-Python simulation)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_effective(records: list[AIAttributionRecord]) -> AIAttributionRecord:
+    """
+    Pure-Python simulation of the ai_attribution_resolved view logic:
+    1. Exclude superseded records (superseded_by IS NULL).
+    2. Pick the record with the lowest SOURCE_PRECEDENCE value
+       (tie-break: highest confidence).
+
+    Mirrors the SQL:
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY org_id, subject_type, subject_id
+            ORDER BY _source_priority ASC, confidence DESC
+        ) = 1
+    """
+    active = [r for r in records if r.superseded_by is None]
+    if not active:
+        raise ValueError("No active records to resolve")
+    return min(
+        active,
+        key=lambda r: (SOURCE_PRECEDENCE.get(r.source, 99), -r.confidence),
+    )
+
+
+class TestResolvedViewPrecedence:
+    def test_manual_wins_all(self) -> None:
+        records = [
+            _make_record(source=AIAttributionSource.PR_LABEL, confidence=0.99),
+            _make_record(source=AIAttributionSource.MANUAL, confidence=0.5),
+            _make_record(source=AIAttributionSource.BOT_AUTHOR, confidence=0.9),
+        ]
+        winner = _resolve_effective(records)
+        assert winner.source == AIAttributionSource.MANUAL
+
+    def test_pr_label_beats_bot_author(self) -> None:
+        records = [
+            _make_record(source=AIAttributionSource.BOT_AUTHOR, confidence=0.99),
+            _make_record(source=AIAttributionSource.PR_LABEL, confidence=0.8),
+        ]
+        winner = _resolve_effective(records)
+        assert winner.source == AIAttributionSource.PR_LABEL
+
+    def test_branch_name_beats_pr_body(self) -> None:
+        records = [
+            _make_record(source=AIAttributionSource.PR_BODY, confidence=0.9),
+            _make_record(source=AIAttributionSource.BRANCH_NAME, confidence=0.4),
+        ]
+        winner = _resolve_effective(records)
+        assert winner.source == AIAttributionSource.BRANCH_NAME
+
+    def test_high_confidence_wins_same_source(self) -> None:
+        # Two PR_LABEL records — higher confidence wins
+        r_low = _make_record(source=AIAttributionSource.PR_LABEL, confidence=0.5)
+        r_high = _make_record(source=AIAttributionSource.PR_LABEL, confidence=0.95)
+        winner = _resolve_effective([r_low, r_high])
+        assert winner.confidence == pytest.approx(0.95)
+
+    def test_superseded_excluded_before_precedence(self) -> None:
+        manual = _make_record(source=AIAttributionSource.MANUAL)
+        pr_label = _make_record(
+            source=AIAttributionSource.PR_LABEL,
+            confidence=0.99,
+            superseded_by=manual.record_id,
+        )
+        winner = _resolve_effective([manual, pr_label])
+        assert winner.source == AIAttributionSource.MANUAL
+
+    def test_all_superseded_raises(self) -> None:
+        manual_id = uuid4()
+        rec = _make_record(superseded_by=manual_id)
+        with pytest.raises(ValueError, match="No active records"):
+            _resolve_effective([rec])
+
+    def test_full_precedence_chain_manual_wins(self) -> None:
+        """All 7 sources present — MANUAL always wins."""
+        sources = list(AIAttributionSource)
+        records = [_make_record(source=s, confidence=0.5) for s in sources]
+        winner = _resolve_effective(records)
+        assert winner.source == AIAttributionSource.MANUAL
+
+    def test_source_precedence_map_completeness(self) -> None:
+        """Every source must appear in SOURCE_PRECEDENCE."""
+        for src in AIAttributionSource:
+            assert src in SOURCE_PRECEDENCE, f"{src} missing from SOURCE_PRECEDENCE"
+
+    def test_precedence_values_are_unique(self) -> None:
+        values = list(SOURCE_PRECEDENCE.values())
+        assert len(values) == len(set(values)), "Duplicate precedence values found"

--- a/tests/storage/test_ai_attribution.py
+++ b/tests/storage/test_ai_attribution.py
@@ -271,9 +271,7 @@ class TestAIAttributionMixin:
         sink.write_ai_attribution(records, batch_size=3)
         # 7 records, batch_size=3 → 3 insert calls: [3, 3, 1]
         assert sink.client.insert.call_count == 3
-        total = sum(
-            len(call.args[1]) for call in sink.client.insert.call_args_list
-        )
+        total = sum(len(call.args[1]) for call in sink.client.insert.call_args_list)
         assert total == 7
 
     def test_each_row_has_correct_column_count(self) -> None:
@@ -356,9 +354,7 @@ class TestSupersession:
             superseded_by=manual.record_id,
         )
         # Simulate what the CH view does: filter superseded_by IS NULL first
-        active = [
-            r for r in [manual, pr_label_superseded] if r.superseded_by is None
-        ]
+        active = [r for r in [manual, pr_label_superseded] if r.superseded_by is None]
         assert len(active) == 1
         assert active[0].source == AIAttributionSource.MANUAL
 


### PR DESCRIPTION
## Summary

Implements canonical AI attribution storage for CHAOS-1579 (storage half of Phase 1).

## Changes

### New files
- \`src/dev_health_ops/models/ai_attribution.py\` — \`AIAttributionSource\`, \`AIAttributionKind\` enums + \`AIAttributionSignal\` (detection output) + \`AIAttributionRecord\` (full persisted record) + \`SOURCE_PRECEDENCE\` map
- \`src/dev_health_ops/migrations/clickhouse/035_ai_attribution.sql\` — \`ai_attribution\` table (ReplacingMergeTree) + \`ai_attribution_resolved\` plain VIEW
- \`src/dev_health_ops/metrics/sinks/clickhouse/ai_attribution.py\` — \`AIAttributionMixin.write_ai_attribution()\`
- \`src/dev_health_ops/storage/mixins/ai_attribution.py\` — documents why no Postgres mixin (pure analytics)
- \`tests/storage/test_ai_attribution.py\` — 36 unit tests
- \`docs/architecture/ai-attribution.md\` — contract and read/write path documentation

### Modified files
- \`src/dev_health_ops/metrics/sinks/clickhouse/__init__.py\` — wires \`AIAttributionMixin\` into \`ClickHouseMetricsSink\`

## Schema decisions

**record_id UUID added** — not in the original plan doc, but required for functional supersession linking.

**evidence as JSON string** — \`dict[str, object]\` in Python, serialized to \`String\` in ClickHouse via \`evidence_json()\`. Type-safe, no \`Any\` escapes.

**ai_attribution_resolved is a plain VIEW** — incremental MVs cannot correctly resolve global cross-source precedence. The VIEW uses QUALIFY + ROW_NUMBER() over \`ai_attribution FINAL\`.

**_to_row() bypasses core _insert_rows** — calls \`self.client.insert()\` directly because evidence needs JSON serialization and UUIDs need explicit str() coercion.

## Ingestion worker interface (CHAOS-1580)

\`\`\`python
from dev_health_ops.models.ai_attribution import AIAttributionRecord, AIAttributionSignal, AIAttributionSource, AIAttributionKind
sink.write_ai_attribution(records)  # synchronous
\`\`\`

Add \`ai_attributions: list[AIAttributionRecord] = field(default_factory=list)\` to \`ProviderBatch\` in providers/base.py.

## Verification

- 36 passed in 0.98s (tests/storage/test_ai_attribution.py)
- LSP diagnostics: clean on all changed files
- test_clickhouse_org_id.py, test_migrations_style.py: 70 passed, 1 skipped

Closes CHAOS-1579