### PR TITLE
feat(attribution): wire AI attribution through production GitHub sync (CHAOS-1714)

### DIFF
--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -26,7 +26,6 @@ from dev_health_ops.metrics.schemas import (
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 from dev_health_ops.metrics.work_items import (
     fetch_github_project_v2_items,
-    fetch_github_work_items,
     fetch_gitlab_work_items,
     fetch_jira_work_items_with_extras,
     parse_github_projects_v2_env,
@@ -174,10 +173,6 @@ def run_work_items_sync_job(
         # AI attribution records collected across all provider batches.
         # Populated when providers emit attribution signals (GitHub PRs).
         # Written to sink via write_ai_attribution() at end of sync loop.
-        # NOTE: The legacy fetch_github_work_items() path used below for GitHub
-        # does not yet return attribution records. Full attribution flow for GitHub
-        # requires refactoring the GitHub sync to use GitHubProvider.iter_ingest()
-        # per discovered repo. See CHAOS-1580 follow-up.
         ai_attributions: list[Any] = []
 
         if "jira" in provider_set:
@@ -202,15 +197,36 @@ def run_work_items_sync_job(
             sprints.extend(sprint_rows)
 
         if "github" in provider_set:
-            items, tr = fetch_github_work_items(
-                repos=discovered_repos,
-                since=since_dt,
+            from uuid import UUID
+
+            from dev_health_ops.providers.base import IngestionContext, IngestionWindow
+            from dev_health_ops.providers.github.provider import GitHubProvider
+
+            github_provider = GitHubProvider(
                 status_mapping=status_mapping,
                 identity=identity,
-                include_issue_events=True,
             )
-            work_items.extend(items)
-            transitions.extend(tr)
+            github_org_id = UUID(org_id) if org_id else None
+            for discovered_repo in discovered_repos:
+                if discovered_repo.source != "github":
+                    continue
+                ctx = IngestionContext(
+                    window=IngestionWindow(
+                        updated_since=since_dt,
+                        active_until=until_dt,
+                    ),
+                    repo=discovered_repo.full_name,
+                    repo_id=discovered_repo.repo_id,
+                    org_id=github_org_id,
+                )
+                for batch in github_provider.iter_ingest(ctx):
+                    work_items.extend(batch.work_items)
+                    transitions.extend(batch.status_transitions)
+                    dependencies.extend(batch.dependencies)
+                    reopen_events.extend(batch.reopen_events)
+                    interactions.extend(batch.interactions)
+                    sprints.extend(batch.sprints)
+                    ai_attributions.extend(batch.ai_attributions)
 
             projects = parse_github_projects_v2_env()
             if projects:
@@ -256,6 +272,7 @@ def run_work_items_sync_job(
             ctx = IngestionContext(
                 window=IngestionWindow(updated_since=since_dt, active_until=until_dt),
                 repo=None,
+                org_id=uuid.UUID(org_id) if org_id else None,
             )
             fetched_items = 0
             fetched_transitions = 0

--- a/src/dev_health_ops/providers/base.py
+++ b/src/dev_health_ops/providers/base.py
@@ -12,6 +12,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Protocol, TypeVar
+from uuid import UUID
 
 if TYPE_CHECKING:
     from dev_health_ops.models.ai_attribution import AIAttributionRecord
@@ -64,6 +65,8 @@ class IngestionContext:
     - window: time bounds for incremental sync
     - project_key: Jira project key (e.g. "ABC")
     - repo: GitHub/GitLab repo identifier (e.g. "owner/repo")
+    - repo_id: internal repository UUID for persisted analytics rows
+    - org_id: organization UUID for scoped analytics rows
     - group: GitLab group path
     - limit: optional max items to fetch (for testing)
     """
@@ -71,6 +74,8 @@ class IngestionContext:
     window: IngestionWindow
     project_key: str | None = None  # jira
     repo: str | None = None  # github/gitlab
+    repo_id: UUID | None = None
+    org_id: UUID | None = None
     group: str | None = None  # gitlab
     limit: int | None = None
 

--- a/src/dev_health_ops/providers/github/provider.py
+++ b/src/dev_health_ops/providers/github/provider.py
@@ -163,7 +163,7 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                 wi, wi_transitions = github_issue_to_work_item(
                     issue=issue,
                     repo_full_name=repo_full_name,
-                    repo_id=None,
+                    repo_id=ctx.repo_id,
                     status_mapping=self.status_mapping,
                     identity=self.identity,
                     events=events,
@@ -260,7 +260,7 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                     wi, wi_transitions = github_pr_to_work_item(
                         pr=pr,
                         repo_full_name=repo_full_name,
-                        repo_id=None,
+                        repo_id=ctx.repo_id,
                         status_mapping=self.status_mapping,
                         identity=self.identity,
                         events=events,
@@ -293,27 +293,23 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                     # Detect AI attribution signals for this PR.
                     # Each signal is converted to a full AIAttributionRecord
                     # using subject context from this ingestion pass.
-                    # org_id is not yet available in the provider layer;
-                    # use a sentinel nil UUID — the orchestrator / sink
-                    # should override with the real org_id before persisting.
-                    # TODO (CHAOS-1580 follow-up): thread org_id through
-                    # IngestionContext so we can set it correctly here.
-                    from uuid import UUID as _UUID
-
-                    _nil_org = _UUID(int=0)
                     pr_signals = detect_pr_attributions(pr=pr)
                     if pr_signals:
+                        if ctx.org_id is None:
+                            raise ValueError(
+                                "GitHub AI attribution requires ctx.org_id"
+                            )
                         _observed = _to_utc(getattr(pr, "created_at", None))
                         _observed = _observed or datetime.now(timezone.utc)
                         for _sig in pr_signals:
                             ai_attributions.append(
                                 AIAttributionRecord.from_signal(
                                     _sig,
-                                    org_id=_nil_org,
+                                    org_id=ctx.org_id,
                                     provider="github",
                                     subject_type="pull_request",
                                     subject_id=wi.work_item_id,
-                                    repo_id=None,
+                                    repo_id=ctx.repo_id,
                                     observed_at=_observed,
                                 )
                             )

--- a/tests/providers/test_github_ai_attribution_integration.py
+++ b/tests/providers/test_github_ai_attribution_integration.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import dev_health_ops.metrics.job_work_items as job
+from dev_health_ops.metrics.work_items import DiscoveredRepo
+from dev_health_ops.models.ai_attribution import AIAttributionRecord
+
+
+@dataclass(frozen=True)
+class _Classification:
+    investment_area: str = "Maintenance / Tech Debt"
+    project_stream: str = ""
+    confidence: float = 1.0
+    rule_id: str = "test"
+
+
+class _Classifier:
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    def classify(self, _payload: object) -> _Classification:
+        return _Classification()
+
+
+class _FakeClickHouseSink:
+    def __init__(self, _dsn: str) -> None:
+        self.org_id = ""
+        self.work_items: list[object] = []
+        self.transitions: list[object] = []
+        self.dependencies: list[object] = []
+        self.reopen_events: list[object] = []
+        self.interactions: list[object] = []
+        self.sprints: list[object] = []
+        self.ai_attributions: list[AIAttributionRecord] = []
+        self.metric_rows: list[object] = []
+
+    def ensure_tables(self) -> None:
+        return None
+
+    def query_dicts(
+        self, _query: str, _params: dict[str, object]
+    ) -> list[dict[str, object]]:
+        return []
+
+    def write_work_items(self, rows: list[object]) -> None:
+        self.work_items.extend(rows)
+
+    def write_work_item_transitions(self, rows: list[object]) -> None:
+        self.transitions.extend(rows)
+
+    def write_work_item_dependencies(self, rows: list[object]) -> None:
+        self.dependencies.extend(rows)
+
+    def write_work_item_reopen_events(self, rows: list[object]) -> None:
+        self.reopen_events.extend(rows)
+
+    def write_work_item_interactions(self, rows: list[object]) -> None:
+        self.interactions.extend(rows)
+
+    def write_sprints(self, rows: list[object]) -> None:
+        self.sprints.extend(rows)
+
+    def write_ai_attribution(self, rows: list[AIAttributionRecord]) -> None:
+        self.ai_attributions.extend(rows)
+
+    def write_work_item_metrics(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def write_work_item_user_metrics(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def write_work_item_cycle_times(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def write_work_item_state_durations(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def write_issue_type_metrics(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def write_investment_classifications(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def write_investment_metrics(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def close(self) -> None:
+        return None
+
+
+def _label(name: str) -> SimpleNamespace:
+    return SimpleNamespace(name=name)
+
+
+def _user(login: str, *, user_type: str = "User") -> SimpleNamespace:
+    return SimpleNamespace(
+        login=login,
+        email=f"{login}@example.com",
+        name=login,
+        type=user_type,
+        app_slug=None,
+    )
+
+
+def _issue(number: int) -> SimpleNamespace:
+    created = datetime(2026, 5, 1, 12, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        number=number,
+        title=f"Issue {number}",
+        state="open",
+        body="normal non-AI work",
+        created_at=created,
+        updated_at=created,
+        closed_at=None,
+        html_url=f"https://github.com/fullchaos/dev-health/issues/{number}",
+        pull_request=None,
+        labels=[],
+        assignees=[],
+        user=_user("human-author"),
+    )
+
+
+def _pr(
+    number: int,
+    *,
+    labels: list[str] | None = None,
+    author: str = "human-author",
+    body: str = "normal PR",
+) -> SimpleNamespace:
+    created = datetime(2026, 5, 1, 13, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        number=number,
+        title=f"PR {number}",
+        state="open",
+        merged=False,
+        draft=False,
+        body=body,
+        created_at=created,
+        updated_at=created,
+        closed_at=None,
+        merged_at=None,
+        html_url=f"https://github.com/fullchaos/dev-health/pull/{number}",
+        labels=[_label(name) for name in labels or []],
+        assignees=[],
+        user=_user(author, user_type="Bot" if author.endswith("[bot]") else "User"),
+        head=SimpleNamespace(ref="feature/human-work"),
+    )
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_github_work_items_sync_writes_ai_attribution_with_org_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    repo_id = uuid.uuid4()
+    sink = _FakeClickHouseSink("clickhouse://test")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: sink)
+    monkeypatch.setattr(job, "InvestmentClassifier", _Classifier)
+    monkeypatch.setattr(
+        job, "compute_work_item_metrics_daily", lambda **_kwargs: ([], [], [])
+    )
+    monkeypatch.setattr(
+        job, "compute_work_item_state_durations_daily", lambda **_kwargs: []
+    )
+    monkeypatch.setattr(job, "parse_github_projects_v2_env", lambda: [])
+    monkeypatch.setattr(
+        job,
+        "_discover_repos",
+        lambda **_kwargs: [
+            DiscoveredRepo(
+                repo_id=repo_id,
+                full_name="fullchaos/dev-health",
+                source="github",
+                settings={},
+            )
+        ],
+    )
+
+    client = MagicMock()
+    client.iter_repo_milestones.return_value = []
+    client.iter_issues.return_value = [_issue(10)]
+    client.iter_pull_requests.return_value = [
+        _pr(11, labels=["ai-assisted"]),
+        _pr(12, author="claude-code[bot]"),
+        _pr(13, body="Implementation details\n\nAI-Assisted-By: Claude Code"),
+        _pr(14, body="Reviewed and implemented by a human."),
+    ]
+    client.iter_issue_events.return_value = []
+    client.iter_issue_comments.return_value = []
+    client.iter_pr_comments_batch.return_value = []
+
+    monkeypatch.setattr(
+        "dev_health_ops.providers.github.client.GitHubWorkClient.from_env",
+        lambda: client,
+    )
+
+    job.run_work_items_sync_job(
+        db_url="clickhouse://test",
+        day=date(2026, 5, 2),
+        backfill_days=1,
+        provider="github",
+        org_id=str(org_id),
+    )
+
+    assert sink.ai_attributions
+    assert {row.org_id for row in sink.ai_attributions} == {org_id}
+    assert {row.repo_id for row in sink.ai_attributions} == {repo_id}
+    assert {str(row.source) for row in sink.ai_attributions} >= {
+        "pr_label",
+        "bot_author",
+        "commit_trailer",
+    }
+
+    work_item_ids = {getattr(row, "work_item_id", "") for row in sink.work_items}
+    assert "gh:fullchaos/dev-health#10" in work_item_ids
+    assert "ghpr:fullchaos/dev-health#14" in work_item_ids
+    assert not any(
+        row.subject_id == "ghpr:fullchaos/dev-health#14" for row in sink.ai_attributions
+    )


### PR DESCRIPTION
## Summary
Wires AI attribution detection through the production sync orchestrator so detected
AI signals actually land in the ClickHouse `ai_attribution` table during real GitHub syncs.
Follow-up to CHAOS-1580 (PR #734).

## Changes
- Migrated the production GitHub work-items sync path from legacy `fetch_github_work_items()` to `GitHubProvider.iter_ingest()` so provider-emitted attribution records are collected and written
- Plumb `org_id` through `IngestionContext`; remove nil-UUID sentinels
- Integration test asserts `ai_attribution` rows land in CH during a synthetic sync

## Verification
```
uv run pytest tests/providers/ tests/storage/ -x -q
uv run ruff check .
uv run ruff format --check .
uv run mypy src
```

SCREENSHOT-WAIVER: backend-only change.

Closes CHAOS-1714