### PR TITLE
feat(governance): AI governance visibility (CHAOS-1587)

### DIFF
--- a/src/dev_health_ops/audit/ai_governance/__init__.py
+++ b/src/dev_health_ops/audit/ai_governance/__init__.py
@@ -1,0 +1,27 @@
+"""Canonical AI governance policy registry and rollups."""
+
+from dev_health_ops.audit.ai_governance.models import (
+    AIGovernanceArtifact,
+    AIGovernanceCoverageDaily,
+    AIGovernanceViolation,
+    AIPolicyRule,
+    AIPolicySeverity,
+    ToolAllowlistStatus,
+)
+from dev_health_ops.audit.ai_governance.policy import (
+    evaluate_artifact,
+    evaluate_artifacts,
+)
+from dev_health_ops.audit.ai_governance.rollup import rollup_coverage_daily
+
+__all__ = [
+    "AIGovernanceArtifact",
+    "AIGovernanceCoverageDaily",
+    "AIGovernanceViolation",
+    "AIPolicyRule",
+    "AIPolicySeverity",
+    "ToolAllowlistStatus",
+    "evaluate_artifact",
+    "evaluate_artifacts",
+    "rollup_coverage_daily",
+]

--- a/src/dev_health_ops/audit/ai_governance/loaders.py
+++ b/src/dev_health_ops/audit/ai_governance/loaders.py
@@ -1,0 +1,304 @@
+"""Typed ClickHouse query helpers for AI governance."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, time, timezone
+from typing import Any
+from uuid import UUID
+
+from dev_health_ops.audit.ai_governance.models import (
+    AIGovernanceArtifact,
+    AIGovernanceCoverageDaily,
+    AIGovernanceViolation,
+    ToolAllowlistStatus,
+)
+
+
+@dataclass(frozen=True)
+class AIGovernanceViolationQueryRow:
+    org_id: str
+    team_id: str | None
+    repo_id: UUID | None
+    rule_id: str
+    severity: str
+    subject_type: str
+    subject_id: str
+    observed_at: datetime
+    evidence: str
+
+
+class AIGovernanceLoader:
+    """Query AI governance inputs and outputs from ClickHouse."""
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    def load_artifacts_for_day(
+        self, *, org_id: str, day: date
+    ) -> list[AIGovernanceArtifact]:
+        start = datetime.combine(day, time.min, tzinfo=timezone.utc)
+        end = datetime.combine(day, time.max, tzinfo=timezone.utc)
+        rows = self.client.query_dicts(
+            _ARTIFACTS_SQL,
+            {"org_id": org_id, "start": start, "end": end},
+        )
+        return [_artifact_from_row(row) for row in rows]
+
+    def load_coverage(
+        self,
+        *,
+        org_id: str,
+        start_day: date,
+        end_day: date,
+        team_id: str | None = None,
+        repo_id: UUID | None = None,
+    ) -> list[AIGovernanceCoverageDaily]:
+        rows = self.client.query_dicts(
+            _COVERAGE_SQL,
+            {
+                "org_id": org_id,
+                "start_day": start_day,
+                "end_day": end_day,
+                "team_id": team_id or "",
+                "repo_id": str(repo_id) if repo_id is not None else "",
+            },
+        )
+        return [_coverage_from_row(row) for row in rows]
+
+    def load_violations(
+        self,
+        *,
+        org_id: str,
+        start_day: date,
+        end_day: date,
+        team_id: str | None = None,
+        repo_id: UUID | None = None,
+        limit: int = 500,
+    ) -> list[AIGovernanceViolationQueryRow]:
+        rows = self.client.query_dicts(
+            _VIOLATIONS_SQL,
+            {
+                "org_id": org_id,
+                "start_day": start_day,
+                "end_day": end_day,
+                "team_id": team_id or "",
+                "repo_id": str(repo_id) if repo_id is not None else "",
+                "limit": limit,
+            },
+        )
+        return [
+            AIGovernanceViolationQueryRow(
+                org_id=str(row["org_id"]),
+                team_id=_optional_str(row.get("team_id")),
+                repo_id=_optional_uuid(row.get("repo_id")),
+                rule_id=str(row["rule_id"]),
+                severity=str(row["severity"]),
+                subject_type=str(row["subject_type"]),
+                subject_id=str(row["subject_id"]),
+                observed_at=_datetime(row["observed_at"]),
+                evidence=str(row.get("evidence") or "{}"),
+            )
+            for row in rows
+        ]
+
+
+def build_governance_rows_for_day(
+    client: Any, *, org_id: str, day: date
+) -> tuple[list[AIGovernanceViolation], list[AIGovernanceCoverageDaily]]:
+    """Load raw artifacts and compute policy events plus coverage rows."""
+    from dev_health_ops.audit.ai_governance.policy import evaluate_artifacts
+    from dev_health_ops.audit.ai_governance.rollup import rollup_coverage_daily
+
+    artifacts = AIGovernanceLoader(client).load_artifacts_for_day(
+        org_id=org_id, day=day
+    )
+    return evaluate_artifacts(artifacts), rollup_coverage_daily(artifacts, day=day)
+
+
+def _artifact_from_row(row: dict[str, Any]) -> AIGovernanceArtifact:
+    tool_name = _optional_str(row.get("tool_name"))
+    return AIGovernanceArtifact(
+        org_id=str(row["org_id"]),
+        team_id=_optional_str(row.get("team_id")),
+        repo_id=_optional_uuid(row.get("repo_id")),
+        subject_type=str(row["subject_type"]),
+        subject_id=str(row["subject_id"]),
+        observed_at=_datetime(row["observed_at"]),
+        ai_detected=bool(row.get("ai_detected", True)),
+        declared_ai=bool(row.get("declared_ai", False)),
+        human_reviewed=_optional_bool(row.get("human_reviewed")),
+        sensitive_repo=bool(row.get("sensitive_repo", False)),
+        repo_allows_ai=bool(row.get("repo_allows_ai", True)),
+        security_scanned=_optional_bool(row.get("security_scanned")),
+        license_or_dependency_finding=bool(
+            row.get("license_or_dependency_finding", False)
+        ),
+        tool_name=tool_name,
+        model_name=_optional_str(row.get("model_name")),
+        tool_allowlist_status=_allowlist_status(row.get("tool_allowlist_status")),
+        evidence={
+            "source": _optional_str(row.get("source")),
+            "kind": _optional_str(row.get("kind")),
+            "confidence": row.get("confidence"),
+            "artifact_url": _optional_str(row.get("artifact_url")),
+        },
+    )
+
+
+def _coverage_from_row(row: dict[str, Any]) -> AIGovernanceCoverageDaily:
+    return AIGovernanceCoverageDaily(
+        org_id=str(row["org_id"]),
+        team_id=_optional_str(row.get("team_id")),
+        repo_id=_optional_uuid(row.get("repo_id")),
+        day=_date(row["day"]),
+        ai_artifacts=int(row.get("ai_artifacts") or 0),
+        declared_artifacts=int(row.get("declared_artifacts") or 0),
+        human_reviewed_prs=int(row.get("human_reviewed_prs") or 0),
+        security_scanned_prs=int(row.get("security_scanned_prs") or 0),
+        in_policy_artifacts=int(row.get("in_policy_artifacts") or 0),
+        computed_at=_datetime(row["computed_at"]),
+    )
+
+
+def _optional_uuid(value: object) -> UUID | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, UUID):
+        return value
+    return UUID(str(value))
+
+
+def _optional_str(value: object) -> str | None:
+    if value in (None, ""):
+        return None
+    return str(value)
+
+
+def _optional_bool(value: object) -> bool | None:
+    if value is None:
+        return None
+    return bool(value)
+
+
+def _allowlist_status(value: object) -> ToolAllowlistStatus:
+    if value in (None, ""):
+        return ToolAllowlistStatus.UNKNOWN
+    try:
+        return ToolAllowlistStatus(str(value))
+    except ValueError:
+        return ToolAllowlistStatus.UNKNOWN
+
+
+def _datetime(value: object) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    return datetime.fromisoformat(str(value))
+
+
+def _date(value: object) -> date:
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    return date.fromisoformat(str(value))
+
+
+_ARTIFACTS_SQL = """
+SELECT
+    toString(a.org_id) AS org_id,
+    CAST(NULL, 'Nullable(String)') AS team_id,
+    a.repo_id AS repo_id,
+    a.subject_type AS subject_type,
+    a.subject_id AS subject_id,
+    a.observed_at AS observed_at,
+    1 AS ai_detected,
+    a.source IN ('manual', 'pr_label', 'commit_trailer') AS declared_ai,
+    if(a.subject_type = 'pull_request', pr.reviews_count > 0, NULL) AS human_reviewed,
+    0 AS sensitive_repo,
+    1 AS repo_allows_ai,
+    if(a.subject_type = 'pull_request', scan.scan_count > 0, NULL) AS security_scanned,
+    finding.finding_count > 0 AS license_or_dependency_finding,
+    JSONExtractString(a.evidence, 'tool_name') AS tool_name,
+    JSONExtractString(a.evidence, 'model_name') AS model_name,
+    coalesce(allow.status, 'unknown') AS tool_allowlist_status,
+    a.source AS source,
+    a.kind AS kind,
+    a.confidence AS confidence,
+    '' AS artifact_url
+FROM ai_attribution_resolved AS a
+LEFT JOIN git_pull_requests AS pr
+    ON a.repo_id = pr.repo_id
+    AND a.subject_type = 'pull_request'
+    AND a.subject_id = toString(pr.number)
+LEFT JOIN (
+    SELECT repo_id, count() AS scan_count
+    FROM ci_pipeline_runs FINAL
+    WHERE lower(coalesce(status, '')) IN ('success', 'passed', 'completed')
+    GROUP BY repo_id
+) AS scan ON a.repo_id = scan.repo_id
+LEFT JOIN (
+    SELECT repo_id, count() AS finding_count
+    FROM security_alerts FINAL
+    WHERE lower(coalesce(source, '')) IN ('dependabot', 'gitlab_dependency', 'dependency_scanning')
+    GROUP BY repo_id
+) AS finding ON a.repo_id = finding.repo_id
+LEFT JOIN ai_tool_allowlist AS allow
+    ON toString(a.org_id) = allow.org_id
+    AND JSONExtractString(a.evidence, 'tool_name') = allow.tool_name
+    AND (allow.model_name IS NULL OR JSONExtractString(a.evidence, 'model_name') = allow.model_name)
+WHERE toString(a.org_id) = {org_id:String}
+  AND a.observed_at >= {start:DateTime64(3, 'UTC')}
+  AND a.observed_at <= {end:DateTime64(3, 'UTC')}
+"""
+
+_COVERAGE_SQL = """
+SELECT
+    org_id,
+    team_id,
+    repo_id,
+    day,
+    argMax(ai_artifacts, computed_at) AS ai_artifacts,
+    argMax(declared_artifacts, computed_at) AS declared_artifacts,
+    argMax(human_reviewed_prs, computed_at) AS human_reviewed_prs,
+    argMax(security_scanned_prs, computed_at) AS security_scanned_prs,
+    argMax(in_policy_artifacts, computed_at) AS in_policy_artifacts,
+    max(computed_at) AS computed_at
+FROM ai_governance_coverage_daily
+WHERE org_id = {org_id:String}
+  AND day >= {start_day:Date}
+  AND day <= {end_day:Date}
+  AND ({team_id:String} = '' OR team_id = {team_id:String})
+  AND ({repo_id:String} = '' OR toString(repo_id) = {repo_id:String})
+GROUP BY org_id, team_id, repo_id, day
+ORDER BY day, team_id, repo_id
+"""
+
+_VIOLATIONS_SQL = """
+SELECT
+    org_id,
+    team_id,
+    repo_id,
+    rule_id,
+    severity,
+    subject_type,
+    subject_id,
+    observed_at,
+    evidence
+FROM ai_policy_events FINAL
+WHERE org_id = {org_id:String}
+  AND toDate(observed_at) >= {start_day:Date}
+  AND toDate(observed_at) <= {end_day:Date}
+  AND ({team_id:String} = '' OR team_id = {team_id:String})
+  AND ({repo_id:String} = '' OR toString(repo_id) = {repo_id:String})
+ORDER BY observed_at DESC
+LIMIT {limit:UInt32}
+"""
+
+
+__all__: Sequence[str] = [
+    "AIGovernanceLoader",
+    "AIGovernanceViolationQueryRow",
+    "build_governance_rows_for_day",
+]

--- a/src/dev_health_ops/audit/ai_governance/models.py
+++ b/src/dev_health_ops/audit/ai_governance/models.py
@@ -1,0 +1,125 @@
+"""Persisted models for AI governance coverage and policy events.
+
+These models intentionally describe artifacts and policy coverage only. They do
+not carry prompt content, IDE telemetry, keystrokes, sessions, transcripts, or
+person-level scores.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from enum import StrEnum
+from uuid import UUID, uuid4
+
+
+class AIPolicyRule(StrEnum):
+    """Canonical, hard-coded AI governance rules."""
+
+    MISSING_AI_DECLARATION = "MISSING_AI_DECLARATION"
+    MISSING_HUMAN_REVIEW = "MISSING_HUMAN_REVIEW"
+    SENSITIVE_REPO_DISALLOWED = "SENSITIVE_REPO_DISALLOWED"
+    DISALLOWED_TOOL = "DISALLOWED_TOOL"
+    MISSING_SECURITY_SCAN = "MISSING_SECURITY_SCAN"
+    NEW_LICENSE_FINDING_FROM_AI_PR = "NEW_LICENSE_FINDING_FROM_AI_PR"
+
+
+class AIPolicySeverity(StrEnum):
+    """Stable severity labels for policy events."""
+
+    INFO = "info"
+    WARNING = "warning"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ToolAllowlistStatus(StrEnum):
+    """Canonical tool/model allowlist statuses."""
+
+    ALLOWED = "allowed"
+    DISALLOWED = "disallowed"
+    DEPRECATED = "deprecated"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class AIGovernanceArtifact:
+    """A policy-evaluation input for an AI-relevant engineering artifact."""
+
+    org_id: str
+    subject_type: str
+    subject_id: str
+    observed_at: datetime
+    team_id: str | None = None
+    repo_id: UUID | None = None
+    ai_detected: bool = False
+    declared_ai: bool = False
+    human_reviewed: bool | None = None
+    sensitive_repo: bool = False
+    repo_allows_ai: bool = True
+    security_scanned: bool | None = None
+    license_or_dependency_finding: bool = False
+    tool_name: str | None = None
+    model_name: str | None = None
+    tool_allowlist_status: ToolAllowlistStatus = ToolAllowlistStatus.UNKNOWN
+    evidence: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AIGovernanceViolation:
+    """A persisted AI policy event linked to an affected artifact."""
+
+    org_id: str
+    rule_id: AIPolicyRule
+    severity: AIPolicySeverity
+    subject_type: str
+    subject_id: str
+    observed_at: datetime
+    event_id: UUID = field(default_factory=uuid4)
+    team_id: str | None = None
+    repo_id: UUID | None = None
+    evidence: dict[str, object] = field(default_factory=dict)
+    computed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def evidence_json(self) -> str:
+        """Serialize artifact references and policy facts for ClickHouse."""
+        return json.dumps(self.evidence, default=str, sort_keys=True)
+
+
+@dataclass(frozen=True)
+class AIGovernanceCoverageDaily:
+    """Daily team/repo AI governance coverage rollup."""
+
+    org_id: str
+    team_id: str | None
+    repo_id: UUID | None
+    day: date
+    ai_artifacts: int
+    declared_artifacts: int
+    human_reviewed_prs: int
+    security_scanned_prs: int
+    in_policy_artifacts: int
+    computed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @property
+    def declaration_coverage(self) -> float:
+        return _ratio(self.declared_artifacts, self.ai_artifacts)
+
+    @property
+    def human_review_coverage(self) -> float:
+        return _ratio(self.human_reviewed_prs, self.ai_artifacts)
+
+    @property
+    def security_scan_coverage(self) -> float:
+        return _ratio(self.security_scanned_prs, self.ai_artifacts)
+
+    @property
+    def in_policy_coverage(self) -> float:
+        return _ratio(self.in_policy_artifacts, self.ai_artifacts)
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 1.0
+    return numerator / denominator

--- a/src/dev_health_ops/audit/ai_governance/policy.py
+++ b/src/dev_health_ops/audit/ai_governance/policy.py
@@ -1,0 +1,82 @@
+"""Canonical AI governance rule evaluators."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from dev_health_ops.audit.ai_governance.models import (
+    AIGovernanceArtifact,
+    AIGovernanceViolation,
+    AIPolicyRule,
+    AIPolicySeverity,
+    ToolAllowlistStatus,
+)
+
+RULE_SEVERITY: dict[AIPolicyRule, AIPolicySeverity] = {
+    AIPolicyRule.MISSING_AI_DECLARATION: AIPolicySeverity.WARNING,
+    AIPolicyRule.MISSING_HUMAN_REVIEW: AIPolicySeverity.HIGH,
+    AIPolicyRule.SENSITIVE_REPO_DISALLOWED: AIPolicySeverity.CRITICAL,
+    AIPolicyRule.DISALLOWED_TOOL: AIPolicySeverity.HIGH,
+    AIPolicyRule.MISSING_SECURITY_SCAN: AIPolicySeverity.HIGH,
+    AIPolicyRule.NEW_LICENSE_FINDING_FROM_AI_PR: AIPolicySeverity.HIGH,
+}
+
+
+def evaluate_artifact(artifact: AIGovernanceArtifact) -> list[AIGovernanceViolation]:
+    """Evaluate one artifact against the canonical AI governance registry."""
+    if not artifact.ai_detected:
+        return []
+
+    violations: list[AIGovernanceViolation] = []
+    if not artifact.declared_ai:
+        violations.append(_violation(artifact, AIPolicyRule.MISSING_AI_DECLARATION))
+    if artifact.subject_type == "pull_request" and artifact.human_reviewed is not True:
+        violations.append(_violation(artifact, AIPolicyRule.MISSING_HUMAN_REVIEW))
+    if artifact.sensitive_repo and not artifact.repo_allows_ai:
+        violations.append(_violation(artifact, AIPolicyRule.SENSITIVE_REPO_DISALLOWED))
+    if artifact.tool_allowlist_status == ToolAllowlistStatus.DISALLOWED:
+        violations.append(_violation(artifact, AIPolicyRule.DISALLOWED_TOOL))
+    if (
+        artifact.subject_type == "pull_request"
+        and artifact.security_scanned is not True
+    ):
+        violations.append(_violation(artifact, AIPolicyRule.MISSING_SECURITY_SCAN))
+    if artifact.license_or_dependency_finding:
+        violations.append(
+            _violation(artifact, AIPolicyRule.NEW_LICENSE_FINDING_FROM_AI_PR)
+        )
+    return violations
+
+
+def evaluate_artifacts(
+    artifacts: Iterable[AIGovernanceArtifact],
+) -> list[AIGovernanceViolation]:
+    """Evaluate multiple artifacts and flatten policy events."""
+    violations: list[AIGovernanceViolation] = []
+    for artifact in artifacts:
+        violations.extend(evaluate_artifact(artifact))
+    return violations
+
+
+def _violation(
+    artifact: AIGovernanceArtifact, rule_id: AIPolicyRule
+) -> AIGovernanceViolation:
+    evidence: dict[str, object] = {
+        "subject_type": artifact.subject_type,
+        "subject_id": artifact.subject_id,
+        "tool_name": artifact.tool_name,
+        "model_name": artifact.model_name,
+        "tool_allowlist_status": str(artifact.tool_allowlist_status),
+        "artifact_evidence": artifact.evidence,
+    }
+    return AIGovernanceViolation(
+        org_id=artifact.org_id,
+        team_id=artifact.team_id,
+        repo_id=artifact.repo_id,
+        rule_id=rule_id,
+        severity=RULE_SEVERITY[rule_id],
+        subject_type=artifact.subject_type,
+        subject_id=artifact.subject_id,
+        observed_at=artifact.observed_at,
+        evidence=evidence,
+    )

--- a/src/dev_health_ops/audit/ai_governance/rollup.py
+++ b/src/dev_health_ops/audit/ai_governance/rollup.py
@@ -1,0 +1,58 @@
+"""Daily coverage rollups for AI governance."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import date, datetime, timezone
+from uuid import UUID
+
+from dev_health_ops.audit.ai_governance.models import (
+    AIGovernanceArtifact,
+    AIGovernanceCoverageDaily,
+)
+from dev_health_ops.audit.ai_governance.policy import evaluate_artifact
+
+
+def rollup_coverage_daily(
+    artifacts: Iterable[AIGovernanceArtifact],
+    *,
+    day: date,
+    computed_at: datetime | None = None,
+) -> list[AIGovernanceCoverageDaily]:
+    """Produce team/repo coverage rows for AI governance."""
+    grouped: dict[tuple[str, str | None, UUID | None], list[AIGovernanceArtifact]] = {}
+    for artifact in artifacts:
+        if not artifact.ai_detected or artifact.observed_at.date() != day:
+            continue
+        key = (artifact.org_id, artifact.team_id, artifact.repo_id)
+        grouped.setdefault(key, []).append(artifact)
+
+    rows: list[AIGovernanceCoverageDaily] = []
+    row_computed_at = computed_at or datetime.now(timezone.utc)
+    for (org_id, team_id, repo_id), group in sorted(
+        grouped.items(),
+        key=lambda item: (item[0][0], item[0][1] or "", str(item[0][2])),
+    ):
+        rows.append(
+            AIGovernanceCoverageDaily(
+                org_id=org_id,
+                team_id=team_id,
+                repo_id=repo_id,
+                day=day,
+                ai_artifacts=len(group),
+                declared_artifacts=sum(1 for a in group if a.declared_ai),
+                human_reviewed_prs=sum(
+                    1
+                    for a in group
+                    if a.subject_type == "pull_request" and a.human_reviewed is True
+                ),
+                security_scanned_prs=sum(
+                    1
+                    for a in group
+                    if a.subject_type == "pull_request" and a.security_scanned is True
+                ),
+                in_policy_artifacts=sum(1 for a in group if not evaluate_artifact(a)),
+                computed_at=row_computed_at,
+            )
+        )
+    return rows

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -10,6 +10,7 @@ from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from dev_health_ops.audit.ai_governance.loaders import build_governance_rows_for_day
 from dev_health_ops.db import resolve_sink_uri
 from dev_health_ops.metrics.benchmarking.runner import run_benchmarking_for_day
 from dev_health_ops.metrics.compute import compute_daily_metrics
@@ -422,6 +423,9 @@ async def run_daily_metrics_job(
         incident_metrics = compute_incident_metrics_daily(
             day=d, incidents=incident_rows, computed_at=computed_at
         )
+        ai_policy_events, ai_governance_coverage = build_governance_rows_for_day(
+            primary_sink, org_id=org_id, day=d
+        )
 
         for s in sinks:
             s.write_repo_metrics(result.repo_metrics)
@@ -442,6 +446,8 @@ async def run_daily_metrics_job(
             s.write_testops_coverage_metrics(testops_coverage_metrics)
             s.write_deploy_metrics(deploy_metrics)
             s.write_incident_metrics(incident_metrics)
+            s.write_ai_policy_events(ai_policy_events)
+            s.write_ai_governance_coverage_daily(ai_governance_coverage)
             if all_file_metrics:
                 s.write_file_metrics(all_file_metrics)
 

--- a/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
@@ -20,6 +20,7 @@ each responsible for one table family:
 from __future__ import annotations
 
 from dev_health_ops.metrics.sinks.clickhouse.ai_attribution import AIAttributionMixin
+from dev_health_ops.metrics.sinks.clickhouse.ai_governance import AIGovernanceMixin
 from dev_health_ops.metrics.sinks.clickhouse.ci import CIMixin
 from dev_health_ops.metrics.sinks.clickhouse.core import ClickHouseCore
 from dev_health_ops.metrics.sinks.clickhouse.dora import DoraMixin
@@ -31,6 +32,7 @@ from dev_health_ops.metrics.sinks.clickhouse.work_graph import WorkGraphMixin
 class ClickHouseMetricsSink(
     # Mixins come BEFORE ClickHouseCore so their concrete write_* methods
     # take priority in the MRO over BaseMetricsSink abstract methods.
+    AIGovernanceMixin,
     AIAttributionMixin,
     CIMixin,
     DoraMixin,

--- a/src/dev_health_ops/metrics/sinks/clickhouse/ai_governance.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/ai_governance.py
@@ -1,0 +1,114 @@
+"""ClickHouse sink methods for AI governance records."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from dev_health_ops.audit.ai_governance.models import (
+    AIGovernanceCoverageDaily,
+    AIGovernanceViolation,
+)
+from dev_health_ops.metrics.sinks.clickhouse._insert import (
+    DEFAULT_BATCH_SIZE,
+    _chunked,
+    _dt_to_clickhouse_datetime,
+)
+
+if TYPE_CHECKING:
+    from dev_health_ops.metrics.sinks.clickhouse._insert import _ClickHouseSinkBase
+else:
+
+    class _ClickHouseSinkBase:
+        pass
+
+
+POLICY_EVENT_COLUMNS = [
+    "event_id",
+    "org_id",
+    "team_id",
+    "repo_id",
+    "rule_id",
+    "severity",
+    "subject_type",
+    "subject_id",
+    "observed_at",
+    "evidence",
+    "computed_at",
+]
+
+COVERAGE_COLUMNS = [
+    "org_id",
+    "team_id",
+    "repo_id",
+    "day",
+    "ai_artifacts",
+    "declared_artifacts",
+    "human_reviewed_prs",
+    "security_scanned_prs",
+    "in_policy_artifacts",
+    "computed_at",
+]
+
+
+def _policy_event_row(event: AIGovernanceViolation) -> list[object]:
+    return [
+        str(event.event_id),
+        event.org_id,
+        event.team_id,
+        str(event.repo_id) if event.repo_id is not None else None,
+        str(event.rule_id),
+        str(event.severity),
+        event.subject_type,
+        event.subject_id,
+        _dt_to_clickhouse_datetime(event.observed_at),
+        event.evidence_json(),
+        _dt_to_clickhouse_datetime(event.computed_at),
+    ]
+
+
+def _coverage_row(row: AIGovernanceCoverageDaily) -> list[object]:
+    return [
+        row.org_id,
+        row.team_id,
+        str(row.repo_id) if row.repo_id is not None else None,
+        row.day,
+        row.ai_artifacts,
+        row.declared_artifacts,
+        row.human_reviewed_prs,
+        row.security_scanned_prs,
+        row.in_policy_artifacts,
+        _dt_to_clickhouse_datetime(row.computed_at),
+    ]
+
+
+class AIGovernanceMixin(_ClickHouseSinkBase):
+    """Mixin for AI governance policy events and coverage rows."""
+
+    def write_ai_policy_events(
+        self,
+        events: Sequence[AIGovernanceViolation],
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        if not events:
+            return
+        for chunk in _chunked(list(events), batch_size):
+            self.client.insert(
+                "ai_policy_events",
+                [_policy_event_row(event) for event in chunk],
+                column_names=POLICY_EVENT_COLUMNS,
+            )
+
+    def write_ai_governance_coverage_daily(
+        self,
+        rows: Sequence[AIGovernanceCoverageDaily],
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        if not rows:
+            return
+        for chunk in _chunked(list(rows), batch_size):
+            self.client.insert(
+                "ai_governance_coverage_daily",
+                [_coverage_row(row) for row in chunk],
+                column_names=COVERAGE_COLUMNS,
+            )

--- a/src/dev_health_ops/migrations/clickhouse/038_ai_governance.sql
+++ b/src/dev_health_ops/migrations/clickhouse/038_ai_governance.sql
@@ -1,0 +1,56 @@
+-- Migration 038: AI governance policy events and coverage rollups.
+--
+-- Governance is coverage-oriented, not surveillance-oriented: events reference
+-- work artifact ids and JSON evidence metadata only.  No prompt/session/IDE
+-- telemetry is captured.
+
+CREATE TABLE IF NOT EXISTS ai_policy_events
+(
+    event_id     UUID,
+    org_id       String,
+    team_id      Nullable(String),
+    repo_id      Nullable(UUID),
+    rule_id      LowCardinality(String),
+    severity     LowCardinality(String),
+    subject_type LowCardinality(String),
+    subject_id   String,
+    observed_at  DateTime64(3, 'UTC'),
+    evidence     String,                         -- JSON-encoded artifact references only
+    computed_at  DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(observed_at)
+ORDER BY (org_id, ifNull(team_id, ''), ifNull(repo_id, toUUID('00000000-0000-0000-0000-000000000000')), rule_id, subject_type, subject_id, observed_at, event_id)
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS ai_governance_coverage_daily
+(
+    org_id              String,
+    team_id             Nullable(String),
+    repo_id             Nullable(UUID),
+    day                 Date,
+    ai_artifacts        UInt64,
+    declared_artifacts  UInt64,
+    human_reviewed_prs  UInt64,
+    security_scanned_prs UInt64,
+    in_policy_artifacts UInt64,
+    computed_at         DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(day)
+ORDER BY (org_id, ifNull(team_id, ''), ifNull(repo_id, toUUID('00000000-0000-0000-0000-000000000000')), day)
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS ai_tool_allowlist
+(
+    org_id      String,
+    tool_name   String,
+    model_name  Nullable(String),
+    status      LowCardinality(String),           -- allowed | disallowed | deprecated
+    reason      Nullable(String),
+    updated_at  DateTime64(3, 'UTC'),
+    computed_at DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(computed_at)
+ORDER BY (org_id, tool_name, ifNull(model_name, ''))
+SETTINGS index_granularity = 8192;

--- a/tests/audit/ai_governance/test_policy.py
+++ b/tests/audit/ai_governance/test_policy.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from dev_health_ops.audit.ai_governance import (
+    AIGovernanceArtifact,
+    AIPolicyRule,
+    ToolAllowlistStatus,
+    evaluate_artifact,
+)
+
+NOW = datetime(2026, 5, 18, 12, 0, tzinfo=timezone.utc)
+
+
+def _artifact(**overrides: object) -> AIGovernanceArtifact:
+    values: dict[str, Any] = {
+        "org_id": "org-1",
+        "team_id": "team-1",
+        "repo_id": uuid4(),
+        "subject_type": "pull_request",
+        "subject_id": "42",
+        "observed_at": NOW,
+        "ai_detected": True,
+        "declared_ai": True,
+        "human_reviewed": True,
+        "sensitive_repo": False,
+        "repo_allows_ai": True,
+        "security_scanned": True,
+        "license_or_dependency_finding": False,
+        "tool_allowlist_status": ToolAllowlistStatus.ALLOWED,
+    }
+    values.update(overrides)
+    return AIGovernanceArtifact(**values)
+
+
+def _rules(artifact: AIGovernanceArtifact) -> set[AIPolicyRule]:
+    return {violation.rule_id for violation in evaluate_artifact(artifact)}
+
+
+def test_clean_artifact_has_no_violations() -> None:
+    assert evaluate_artifact(_artifact()) == []
+
+
+def test_missing_data_for_non_ai_artifact_is_clean() -> None:
+    assert evaluate_artifact(_artifact(ai_detected=False, human_reviewed=None)) == []
+
+
+def test_missing_ai_declaration_trips() -> None:
+    assert _rules(_artifact(declared_ai=False)) == {AIPolicyRule.MISSING_AI_DECLARATION}
+
+
+def test_missing_ai_declaration_clean() -> None:
+    assert AIPolicyRule.MISSING_AI_DECLARATION not in _rules(
+        _artifact(declared_ai=True)
+    )
+
+
+def test_missing_ai_declaration_missing_data() -> None:
+    assert AIPolicyRule.MISSING_AI_DECLARATION in _rules(_artifact(declared_ai=False))
+
+
+def test_missing_human_review_trips() -> None:
+    assert AIPolicyRule.MISSING_HUMAN_REVIEW in _rules(_artifact(human_reviewed=False))
+
+
+def test_missing_human_review_clean() -> None:
+    assert AIPolicyRule.MISSING_HUMAN_REVIEW not in _rules(
+        _artifact(human_reviewed=True)
+    )
+
+
+def test_missing_human_review_missing_data() -> None:
+    assert AIPolicyRule.MISSING_HUMAN_REVIEW in _rules(_artifact(human_reviewed=None))
+
+
+def test_sensitive_repo_disallowed_trips() -> None:
+    assert AIPolicyRule.SENSITIVE_REPO_DISALLOWED in _rules(
+        _artifact(sensitive_repo=True, repo_allows_ai=False)
+    )
+
+
+def test_sensitive_repo_disallowed_clean() -> None:
+    assert AIPolicyRule.SENSITIVE_REPO_DISALLOWED not in _rules(
+        _artifact(sensitive_repo=True, repo_allows_ai=True)
+    )
+
+
+def test_sensitive_repo_disallowed_missing_data() -> None:
+    assert AIPolicyRule.SENSITIVE_REPO_DISALLOWED not in _rules(
+        _artifact(sensitive_repo=False, repo_allows_ai=False)
+    )
+
+
+def test_disallowed_tool_trips() -> None:
+    assert AIPolicyRule.DISALLOWED_TOOL in _rules(
+        _artifact(tool_allowlist_status=ToolAllowlistStatus.DISALLOWED)
+    )
+
+
+def test_disallowed_tool_clean() -> None:
+    assert AIPolicyRule.DISALLOWED_TOOL not in _rules(
+        _artifact(tool_allowlist_status=ToolAllowlistStatus.ALLOWED)
+    )
+
+
+def test_disallowed_tool_missing_data() -> None:
+    assert AIPolicyRule.DISALLOWED_TOOL not in _rules(
+        _artifact(tool_allowlist_status=ToolAllowlistStatus.UNKNOWN)
+    )
+
+
+def test_missing_security_scan_trips() -> None:
+    assert AIPolicyRule.MISSING_SECURITY_SCAN in _rules(
+        _artifact(security_scanned=False)
+    )
+
+
+def test_missing_security_scan_clean() -> None:
+    assert AIPolicyRule.MISSING_SECURITY_SCAN not in _rules(
+        _artifact(security_scanned=True)
+    )
+
+
+def test_missing_security_scan_missing_data() -> None:
+    assert AIPolicyRule.MISSING_SECURITY_SCAN in _rules(
+        _artifact(security_scanned=None)
+    )
+
+
+def test_license_or_dependency_finding_trips() -> None:
+    assert AIPolicyRule.NEW_LICENSE_FINDING_FROM_AI_PR in _rules(
+        _artifact(license_or_dependency_finding=True)
+    )
+
+
+def test_license_or_dependency_finding_clean() -> None:
+    assert AIPolicyRule.NEW_LICENSE_FINDING_FROM_AI_PR not in _rules(
+        _artifact(license_or_dependency_finding=False)
+    )
+
+
+def test_license_or_dependency_finding_missing_data() -> None:
+    assert AIPolicyRule.NEW_LICENSE_FINDING_FROM_AI_PR not in _rules(
+        _artifact(license_or_dependency_finding=False)
+    )

--- a/tests/audit/ai_governance/test_rollup.py
+++ b/tests/audit/ai_governance/test_rollup.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from uuid import UUID
+
+from dev_health_ops.audit.ai_governance import (
+    AIGovernanceArtifact,
+    rollup_coverage_daily,
+)
+
+DAY = date(2026, 5, 18)
+NOW = datetime(2026, 5, 18, 12, 0, tzinfo=timezone.utc)
+REPO = UUID("11111111-1111-1111-1111-111111111111")
+
+
+def test_rollup_coverage_counts_team_and_repo_scope() -> None:
+    rows = rollup_coverage_daily(
+        [
+            AIGovernanceArtifact(
+                org_id="org-1",
+                team_id="team-1",
+                repo_id=REPO,
+                subject_type="pull_request",
+                subject_id="1",
+                observed_at=NOW,
+                ai_detected=True,
+                declared_ai=True,
+                human_reviewed=True,
+                security_scanned=True,
+            ),
+            AIGovernanceArtifact(
+                org_id="org-1",
+                team_id="team-1",
+                repo_id=REPO,
+                subject_type="pull_request",
+                subject_id="2",
+                observed_at=NOW,
+                ai_detected=True,
+                declared_ai=False,
+                human_reviewed=False,
+                security_scanned=False,
+            ),
+            AIGovernanceArtifact(
+                org_id="org-1",
+                team_id="team-1",
+                repo_id=REPO,
+                subject_type="commit",
+                subject_id="abc",
+                observed_at=NOW,
+                ai_detected=False,
+            ),
+        ],
+        day=DAY,
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.org_id == "org-1"
+    assert row.team_id == "team-1"
+    assert row.repo_id == REPO
+    assert row.ai_artifacts == 2
+    assert row.declared_artifacts == 1
+    assert row.human_reviewed_prs == 1
+    assert row.security_scanned_prs == 1
+    assert row.in_policy_artifacts == 1
+    assert row.declaration_coverage == 0.5
+    assert row.in_policy_coverage == 0.5

--- a/tests/audit/ai_governance/test_surveillance_posture.py
+++ b/tests/audit/ai_governance/test_surveillance_posture.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import fields
+
+from dev_health_ops.audit.ai_governance.models import (
+    AIGovernanceArtifact,
+    AIGovernanceCoverageDaily,
+    AIGovernanceViolation,
+)
+from dev_health_ops.metrics.sinks.clickhouse.ai_governance import (
+    COVERAGE_COLUMNS,
+    POLICY_EVENT_COLUMNS,
+)
+
+FORBIDDEN_FIELD_NAMES = {"prompt", "session", "transcript", "ide", "user_keystroke"}
+
+
+def test_persisted_governance_models_do_not_store_surveillance_fields() -> None:
+    persisted_names = set(POLICY_EVENT_COLUMNS) | set(COVERAGE_COLUMNS)
+    for model in (
+        AIGovernanceArtifact,
+        AIGovernanceCoverageDaily,
+        AIGovernanceViolation,
+    ):
+        persisted_names.update(field.name for field in fields(model))
+
+    assert persisted_names.isdisjoint(FORBIDDEN_FIELD_NAMES)


### PR DESCRIPTION
## Summary
Enterprise AI governance visibility — policy coverage at team and repo scope, canonical rule registry, violation events linking back to artifacts, daily coverage rollup. No-surveillance posture preserved.

## Canonical rules
- MISSING_AI_DECLARATION
- MISSING_HUMAN_REVIEW
- SENSITIVE_REPO_DISALLOWED
- DISALLOWED_TOOL
- MISSING_SECURITY_SCAN
- NEW_LICENSE_FINDING_FROM_AI_PR

## Design
- Migration 038_ai_governance.sql (policy_events + coverage_daily)
- Allowlist storage: ClickHouse analytics (`ai_tool_allowlist`) so daily governance joins remain ClickHouse-only and append-friendly with `computed_at`.
- Evaluators run daily through `dev-hops metrics daily`; outputs append-only with computed_at
- Surveillance-posture guard test asserts persisted records carry no prompt/session/IDE fields

## Verification
```bash
uv run pytest tests/audit/ -x -q
uv run ruff check .
uv run ruff format --check .
uv run mypy src
```

SCREENSHOT-WAIVER: backend-only.

Closes CHAOS-1587