### PR TITLE
feat(metrics): compute AI workflow impact metrics (CHAOS-1581)

### DIFF
--- a/src/dev_health_ops/metrics/ai_impact.py
+++ b/src/dev_health_ops/metrics/ai_impact.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+
+from dev_health_ops.metrics.schemas import (
+    AIImpactMetricsDailyRecord,
+    AIOperatingLeverageComponents,
+    AIPullRequestAttributionRow,
+    CommitStatRow,
+    IncidentRow,
+    PullRequestReviewRow,
+    PullRequestRow,
+)
+
+TeamResolver = Callable[[str, str | None, str | None], tuple[str | None, str | None]]
+
+AI_BUCKETS = {"ai_assisted", "agent_created", "ai_review"}
+NON_AI_BUCKET = "human"
+UNKNOWN_BUCKET = "unknown"
+
+
+@dataclass(frozen=True)
+class _PRFact:
+    repo_id: uuid.UUID
+    number: int
+    bucket: str
+    work_type: str
+    team_id: str | None
+    merged: bool
+    cycle_hours: float | None
+    reviews: int
+    changes_requested: int
+    additions: int
+    deletions: int
+    changed_files: int
+    has_test_change: bool
+    followup_commits: int
+
+
+@dataclass(frozen=True)
+class _Agg:
+    prs_total: int
+    prs_merged: int
+    cycle_avg: float | None
+    reviews_per_pr: float | None
+    changes_requested_per_pr: float | None
+    rework_prs: int
+    rework_rate: float | None
+    followup_commits: int
+    revert_prs: int
+    revert_rate: float | None
+    incidents_count: int
+    incident_rate: float | None
+    test_gap_prs: int
+    test_gap_rate: float | None
+
+
+def _to_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _avg(values: Sequence[float]) -> float | None:
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _ratio(numerator: int | float, denominator: int | float) -> float | None:
+    if denominator == 0:
+        return None
+    return float(numerator) / float(denominator)
+
+
+def _safe_bucket(kind: str | None) -> str:
+    if kind is None or kind == "":
+        return UNKNOWN_BUCKET
+    normalized = kind.strip().lower().replace("-", "_")
+    if normalized in AI_BUCKETS or normalized == NON_AI_BUCKET:
+        return normalized
+    return UNKNOWN_BUCKET
+
+
+def _is_test_path(path: str | None) -> bool:
+    if not path:
+        return False
+    lower = path.lower()
+    return (
+        "/test/" in lower
+        or "/tests/" in lower
+        or lower.startswith("test/")
+        or lower.startswith("tests/")
+        or lower.endswith("_test.py")
+        or lower.endswith(".test.ts")
+        or lower.endswith(".test.tsx")
+        or lower.endswith(".spec.ts")
+        or lower.endswith(".spec.tsx")
+    )
+
+
+def _attribution_index(
+    rows: Sequence[AIPullRequestAttributionRow],
+) -> dict[tuple[uuid.UUID, int], AIPullRequestAttributionRow]:
+    indexed: dict[tuple[uuid.UUID, int], AIPullRequestAttributionRow] = {}
+    for row in rows:
+        indexed[(row["repo_id"], int(row["number"]))] = row
+    return indexed
+
+
+def _reviews_by_pr(
+    rows: Sequence[PullRequestReviewRow],
+) -> dict[tuple[uuid.UUID, int], tuple[int, int]]:
+    counts: dict[tuple[uuid.UUID, int], list[int]] = defaultdict(lambda: [0, 0])
+    for row in rows:
+        key = (row["repo_id"], int(row["number"]))
+        counts[key][0] += 1
+        if str(row.get("state") or "").upper() == "CHANGES_REQUESTED":
+            counts[key][1] += 1
+    return {key: (value[0], value[1]) for key, value in counts.items()}
+
+
+def _test_changes_by_pr(
+    commit_rows: Sequence[CommitStatRow],
+    pr_commit_stats: Mapping[tuple[uuid.UUID, int], Sequence[CommitStatRow]] | None,
+) -> dict[tuple[uuid.UUID, int], bool]:
+    if pr_commit_stats is None:
+        # Without PR↔commit linkage, preserve null-as-unavailable semantics by
+        # not manufacturing test coverage evidence from repo-level commits.
+        return {}
+    result: dict[tuple[uuid.UUID, int], bool] = {}
+    for key, rows in pr_commit_stats.items():
+        result[key] = any(_is_test_path(row.get("file_path")) for row in rows)
+    return result
+
+
+def _aggregate(facts: Sequence[_PRFact], incidents_count: int) -> _Agg:
+    cycles = [fact.cycle_hours for fact in facts if fact.cycle_hours is not None]
+    prs_total = len(facts)
+    prs_merged = sum(1 for fact in facts if fact.merged)
+    reviews = sum(fact.reviews for fact in facts)
+    changes_requested = sum(fact.changes_requested for fact in facts)
+    rework_prs = sum(
+        1 for fact in facts if fact.changes_requested > 0 or fact.followup_commits > 0
+    )
+    followup_commits = sum(fact.followup_commits for fact in facts)
+    revert_prs = sum(
+        1
+        for fact in facts
+        if fact.deletions > fact.additions * 2 and fact.deletions >= 50
+    )
+    test_gap_prs = sum(1 for fact in facts if not fact.has_test_change)
+    return _Agg(
+        prs_total=prs_total,
+        prs_merged=prs_merged,
+        cycle_avg=_avg(cycles),
+        reviews_per_pr=_ratio(reviews, prs_total),
+        changes_requested_per_pr=_ratio(changes_requested, prs_total),
+        rework_prs=rework_prs,
+        rework_rate=_ratio(rework_prs, prs_total),
+        followup_commits=followup_commits,
+        revert_prs=revert_prs,
+        revert_rate=_ratio(revert_prs, prs_total),
+        incidents_count=incidents_count,
+        incident_rate=_ratio(incidents_count, prs_merged),
+        test_gap_prs=test_gap_prs,
+        test_gap_rate=_ratio(test_gap_prs, prs_total),
+    )
+
+
+def _component_delta(
+    value: float | None,
+    baseline: float | None,
+    *,
+    lower_is_better: bool,
+) -> float | None:
+    if value is None or baseline is None or baseline == 0:
+        return None
+    ratio = value / baseline
+    return (1.0 - ratio) if lower_is_better else (ratio - 1.0)
+
+
+def compute_ai_impact_metrics_daily(
+    *,
+    day: date,
+    org_id: str,
+    pull_request_rows: Sequence[PullRequestRow],
+    pull_request_review_rows: Sequence[PullRequestReviewRow],
+    ai_attribution_rows: Sequence[AIPullRequestAttributionRow],
+    incident_rows: Sequence[IncidentRow] = (),
+    commit_stat_rows: Sequence[CommitStatRow] = (),
+    computed_at: datetime,
+    team_resolver: TeamResolver | None = None,
+    repo_names_by_id: Mapping[uuid.UUID, str] | None = None,
+    pr_commit_stats: Mapping[tuple[uuid.UUID, int], Sequence[CommitStatRow]]
+    | None = None,
+) -> list[AIImpactMetricsDailyRecord]:
+    """Compute decomposable AI workflow impact metrics for one UTC day.
+
+    Missing attribution is represented as ``unknown``.  It is never folded into
+    the human baseline, keeping AI vs non-AI comparisons uncontaminated.
+    """
+
+    attribution_by_pr = _attribution_index(ai_attribution_rows)
+    review_counts = _reviews_by_pr(pull_request_review_rows)
+    test_changes = _test_changes_by_pr(commit_stat_rows, pr_commit_stats)
+    repo_names = repo_names_by_id or {}
+    start = datetime.combine(day, datetime.min.time(), tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+
+    facts: list[_PRFact] = []
+    for pr in pull_request_rows:
+        created_at = _to_utc(pr["created_at"])
+        merged_at_raw = pr.get("merged_at")
+        merged_at = _to_utc(merged_at_raw) if merged_at_raw is not None else None
+        event_at = merged_at or created_at
+        if not (start <= event_at < end):
+            continue
+
+        repo_id = pr["repo_id"]
+        number = int(pr["number"])
+        attr = attribution_by_pr.get((repo_id, number))
+        bucket = _safe_bucket(attr.get("kind") if attr else None)
+        work_type = (
+            str(attr.get("work_type") or "pull_request") if attr else "pull_request"
+        )
+        team_id = attr.get("team_id") if attr else None
+        if team_id is None and team_resolver is not None:
+            team_id, _ = team_resolver(str(repo_id), repo_names.get(repo_id), None)
+
+        reviews, changes_requested_from_reviews = review_counts.get(
+            (repo_id, number), (0, 0)
+        )
+        reviews = int(pr.get("reviews_count", reviews) or reviews)
+        changes_requested = int(
+            pr.get("changes_requested_count", changes_requested_from_reviews)
+            or changes_requested_from_reviews
+        )
+        cycle_hours = None
+        if merged_at is not None:
+            cycle_hours = (merged_at - created_at).total_seconds() / 3600.0
+
+        additions = int(pr.get("additions", 0) or 0)
+        deletions = int(pr.get("deletions", 0) or 0)
+        changed_files = int(pr.get("changed_files", 0) or 0)
+        facts.append(
+            _PRFact(
+                repo_id=repo_id,
+                number=number,
+                bucket=bucket,
+                work_type=work_type,
+                team_id=team_id,
+                merged=merged_at is not None,
+                cycle_hours=cycle_hours,
+                reviews=reviews,
+                changes_requested=changes_requested,
+                additions=additions,
+                deletions=deletions,
+                changed_files=changed_files,
+                has_test_change=test_changes.get((repo_id, number), False),
+                followup_commits=0,
+            )
+        )
+
+    incidents_by_repo: dict[uuid.UUID, int] = defaultdict(int)
+    for incident in incident_rows:
+        started_at = _to_utc(incident["started_at"])
+        if start <= started_at < end:
+            incidents_by_repo[incident["repo_id"]] += 1
+
+    grouped: dict[tuple[str | None, uuid.UUID, str], list[_PRFact]] = defaultdict(list)
+    for fact in facts:
+        grouped[(fact.team_id, fact.repo_id, fact.work_type)].append(fact)
+
+    rows: list[AIImpactMetricsDailyRecord] = []
+    for (team_id, repo_id, work_type), group_facts in grouped.items():
+        baseline = _aggregate(
+            [fact for fact in group_facts if fact.bucket == NON_AI_BUCKET], 0
+        )
+        group_total = len(group_facts)
+        for bucket in (*sorted(AI_BUCKETS), NON_AI_BUCKET, UNKNOWN_BUCKET):
+            bucket_facts = [fact for fact in group_facts if fact.bucket == bucket]
+            if not bucket_facts and bucket != UNKNOWN_BUCKET:
+                continue
+            agg = _aggregate(
+                bucket_facts,
+                incidents_by_repo.get(repo_id, 0) if bucket in AI_BUCKETS else 0,
+            )
+            ai_count = sum(1 for fact in group_facts if fact.bucket in AI_BUCKETS)
+            ai_assisted_count = sum(
+                1 for fact in group_facts if fact.bucket == "ai_assisted"
+            )
+            agent_created_count = sum(
+                1 for fact in group_facts if fact.bucket == "agent_created"
+            )
+            human_count = sum(1 for fact in group_facts if fact.bucket == NON_AI_BUCKET)
+            unknown_count = sum(
+                1 for fact in group_facts if fact.bucket == UNKNOWN_BUCKET
+            )
+            cycle_delta = (
+                agg.cycle_avg - baseline.cycle_avg
+                if agg.cycle_avg is not None and baseline.cycle_avg is not None
+                else None
+            )
+            review_amplification = _component_delta(
+                agg.reviews_per_pr, baseline.reviews_per_pr, lower_is_better=False
+            )
+            leverage = AIOperatingLeverageComponents(
+                prs_component=float(ai_count),
+                cycle_time_component=_component_delta(
+                    agg.cycle_avg, baseline.cycle_avg, lower_is_better=True
+                ),
+                review_component=review_amplification,
+                rework_component=_component_delta(
+                    agg.rework_rate, baseline.rework_rate, lower_is_better=True
+                ),
+                test_component=_component_delta(
+                    agg.test_gap_rate, baseline.test_gap_rate, lower_is_better=True
+                ),
+                incident_component=_component_delta(
+                    agg.incident_rate, baseline.incident_rate, lower_is_better=True
+                ),
+            )
+            rows.append(
+                AIImpactMetricsDailyRecord(
+                    org_id=org_id,
+                    team_id=team_id,
+                    repo_id=repo_id,
+                    work_type=work_type,
+                    day=day,
+                    attribution_bucket=bucket,
+                    prs_total=agg.prs_total,
+                    prs_merged=agg.prs_merged,
+                    ai_assisted_prs=ai_assisted_count,
+                    agent_created_prs=agent_created_count,
+                    human_prs=human_count,
+                    unknown_prs=unknown_count,
+                    ai_assisted_pr_ratio=_ratio(ai_assisted_count, group_total),
+                    agent_created_pr_count=agent_created_count,
+                    cycle_time_avg_hours=agg.cycle_avg,
+                    baseline_cycle_time_avg_hours=baseline.cycle_avg,
+                    ai_cycle_time_delta_hours=cycle_delta,
+                    reviews_per_pr=agg.reviews_per_pr,
+                    baseline_reviews_per_pr=baseline.reviews_per_pr,
+                    ai_review_amplification=review_amplification,
+                    changes_requested_per_pr=agg.changes_requested_per_pr,
+                    rework_prs=agg.rework_prs,
+                    rework_drag_rate=agg.rework_rate,
+                    followup_commits_count=agg.followup_commits,
+                    revert_prs=agg.revert_prs,
+                    revert_rate=agg.revert_rate,
+                    incidents_count=agg.incidents_count,
+                    incident_drag_rate=agg.incident_rate,
+                    test_gap_prs=agg.test_gap_prs,
+                    test_gap_rate=agg.test_gap_rate,
+                    leverage=leverage,
+                    computed_at=computed_at,
+                )
+            )
+    return rows

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from dev_health_ops.audit.ai_governance.loaders import build_governance_rows_for_day
 from dev_health_ops.db import resolve_sink_uri
+from dev_health_ops.metrics.ai_impact import compute_ai_impact_metrics_daily
 from dev_health_ops.metrics.benchmarking.runner import run_benchmarking_for_day
 from dev_health_ops.metrics.compute import compute_daily_metrics
 from dev_health_ops.metrics.compute_cicd import compute_cicd_metrics_daily
@@ -426,6 +427,26 @@ async def run_daily_metrics_job(
         ai_policy_events, ai_governance_coverage = build_governance_rows_for_day(
             primary_sink, org_id=org_id, day=d
         )
+        ai_attribution_rows = []
+        ai_loader: Any = loader
+        if hasattr(ai_loader, "load_ai_pr_attributions"):
+            ai_attribution_rows = await ai_loader.load_ai_pr_attributions(
+                start=start,
+                end=end,
+                repo_id=repo_id,
+            )
+        ai_impact_metrics = compute_ai_impact_metrics_daily(
+            day=d,
+            org_id=org_id,
+            pull_request_rows=pr_rows,
+            pull_request_review_rows=review_rows,
+            ai_attribution_rows=ai_attribution_rows,
+            incident_rows=incident_rows,
+            commit_stat_rows=commit_rows,
+            computed_at=computed_at,
+            team_resolver=team_resolver,
+            repo_names_by_id=repo_names_by_id,
+        )
 
         for s in sinks:
             s.write_repo_metrics(result.repo_metrics)
@@ -448,6 +469,8 @@ async def run_daily_metrics_job(
             s.write_incident_metrics(incident_metrics)
             s.write_ai_policy_events(ai_policy_events)
             s.write_ai_governance_coverage_daily(ai_governance_coverage)
+            if ai_impact_metrics:
+                s.write_ai_impact_metrics(ai_impact_metrics)
             if all_file_metrics:
                 s.write_file_metrics(all_file_metrics)
 

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -444,7 +444,9 @@ async def run_daily_metrics_job(
             incident_rows=incident_rows,
             commit_stat_rows=commit_rows,
             computed_at=computed_at,
-            team_resolver=team_resolver,
+            team_resolver=lambda _repo_id, repo_name, _identity: (
+                repo_team_resolver.resolve(repo_name)
+            ),
             repo_names_by_id=repo_names_by_id,
         )
 

--- a/src/dev_health_ops/metrics/loaders/ai_impact.py
+++ b/src/dev_health_ops/metrics/loaders/ai_impact.py
@@ -45,7 +45,7 @@ class AIImpactClickHouseLoader:
             pr.number AS number,
             attr.kind AS kind,
             coalesce(nullIf(wi.type, ''), 'pull_request') AS work_type,
-            CAST(NULL, 'Nullable(String)') AS team_id
+            CAST('', 'String') AS team_id
         FROM git_pull_requests AS pr
         INNER JOIN work_graph_issue_pr AS link
             ON link.repo_id = pr.repo_id AND link.pr_number = pr.number
@@ -65,12 +65,12 @@ class AIImpactClickHouseLoader:
             pr.number AS number,
             attr.kind AS kind,
             'pull_request' AS work_type,
-            CAST(NULL, 'Nullable(String)') AS team_id
+            CAST('', 'String') AS team_id
         FROM git_pull_requests AS pr
         INNER JOIN ai_attribution_resolved AS attr
             ON attr.subject_type = 'pull_request'
             AND attr.repo_id = pr.repo_id
-            AND attr.subject_id IN (toString(pr.number), concat(toString(pr.repo_id), '#', toString(pr.number)))
+            AND (attr.subject_id = toString(pr.number) OR attr.subject_id = concat(toString(pr.repo_id), '#', toString(pr.number)))
         WHERE ((pr.created_at >= {{start:DateTime}} AND pr.created_at < {{end:DateTime}})
             OR (pr.merged_at IS NOT NULL AND pr.merged_at >= {{start:DateTime}} AND pr.merged_at < {{end:DateTime}}))
           {repo_filter}
@@ -89,7 +89,7 @@ class AIImpactClickHouseLoader:
                     "number": int(raw.get("number") or 0),
                     "kind": raw.get("kind"),
                     "work_type": raw.get("work_type"),
-                    "team_id": raw.get("team_id"),
+                    "team_id": raw.get("team_id") or None,
                 }
             )
         return rows
@@ -175,7 +175,7 @@ def _to_record(raw: dict[str, Any]) -> AIImpactMetricsDailyRecord:
         raise ValueError("ai_impact_metrics_daily row has invalid repo_id")
     return AIImpactMetricsDailyRecord(
         org_id=str(raw.get("org_id") or ""),
-        team_id=raw.get("team_id"),
+        team_id=raw.get("team_id") or None,
         repo_id=repo_id,
         work_type=str(raw.get("work_type") or "pull_request"),
         day=raw["day"],

--- a/src/dev_health_ops/metrics/loaders/ai_impact.py
+++ b/src/dev_health_ops/metrics/loaders/ai_impact.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from typing import Any
+
+from dev_health_ops.metrics.loaders.base import parse_uuid
+from dev_health_ops.metrics.query_builder import OrgScopedQuery
+from dev_health_ops.metrics.schemas import (
+    AIImpactMetricsDailyRecord,
+    AIOperatingLeverageComponents,
+    AIPullRequestAttributionRow,
+)
+
+
+class AIImpactClickHouseLoader:
+    def __init__(self, client: Any, org_id: str = "") -> None:
+        self.client = client
+        self.org_id = org_id
+        self._scope = OrgScopedQuery(org_id)
+
+    async def load_ai_pr_attributions(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        repo_id: uuid.UUID | None = None,
+    ) -> list[AIPullRequestAttributionRow]:
+        from dev_health_ops.api.queries.client import query_dicts
+
+        params: dict[str, Any] = {
+            "start": start.replace(tzinfo=None),
+            "end": end.replace(tzinfo=None),
+        }
+        repo_filter = ""
+        if repo_id is not None:
+            params["repo_id"] = str(repo_id)
+            repo_filter = "AND pr.repo_id = {repo_id:UUID}"
+        params = self._scope.inject(params)
+        org_filter_attr = self._scope.filter(alias="attr")
+        org_filter_pr = self._scope.filter(alias="pr")
+        query = f"""
+        SELECT
+            pr.repo_id AS repo_id,
+            pr.number AS number,
+            attr.kind AS kind,
+            coalesce(nullIf(wi.type, ''), 'pull_request') AS work_type,
+            CAST(NULL, 'Nullable(String)') AS team_id
+        FROM git_pull_requests AS pr
+        INNER JOIN work_graph_issue_pr AS link
+            ON link.repo_id = pr.repo_id AND link.pr_number = pr.number
+        INNER JOIN ai_attribution_resolved AS attr
+            ON attr.subject_type = 'pull_request'
+            AND attr.subject_id = link.work_item_id
+        LEFT JOIN work_items AS wi
+            ON wi.repo_id = link.repo_id AND wi.work_item_id = link.work_item_id
+        WHERE ((pr.created_at >= {{start:DateTime}} AND pr.created_at < {{end:DateTime}})
+            OR (pr.merged_at IS NOT NULL AND pr.merged_at >= {{start:DateTime}} AND pr.merged_at < {{end:DateTime}}))
+          {repo_filter}
+          {org_filter_pr}
+          {org_filter_attr}
+        UNION ALL
+        SELECT
+            pr.repo_id AS repo_id,
+            pr.number AS number,
+            attr.kind AS kind,
+            'pull_request' AS work_type,
+            CAST(NULL, 'Nullable(String)') AS team_id
+        FROM git_pull_requests AS pr
+        INNER JOIN ai_attribution_resolved AS attr
+            ON attr.subject_type = 'pull_request'
+            AND attr.repo_id = pr.repo_id
+            AND attr.subject_id IN (toString(pr.number), concat(toString(pr.repo_id), '#', toString(pr.number)))
+        WHERE ((pr.created_at >= {{start:DateTime}} AND pr.created_at < {{end:DateTime}})
+            OR (pr.merged_at IS NOT NULL AND pr.merged_at >= {{start:DateTime}} AND pr.merged_at < {{end:DateTime}}))
+          {repo_filter}
+          {org_filter_pr}
+          {org_filter_attr}
+        """
+        raw_rows = await query_dicts(self.client, query, params)
+        rows: list[AIPullRequestAttributionRow] = []
+        for raw in raw_rows:
+            parsed_repo_id = parse_uuid(raw.get("repo_id"))
+            if parsed_repo_id is None:
+                continue
+            rows.append(
+                {
+                    "repo_id": parsed_repo_id,
+                    "number": int(raw.get("number") or 0),
+                    "kind": raw.get("kind"),
+                    "work_type": raw.get("work_type"),
+                    "team_id": raw.get("team_id"),
+                }
+            )
+        return rows
+
+    async def load_ai_impact_metrics(
+        self,
+        *,
+        start_day: date,
+        end_day: date,
+        repo_id: uuid.UUID | None = None,
+        team_id: str | None = None,
+        work_type: str | None = None,
+    ) -> list[AIImpactMetricsDailyRecord]:
+        from dev_health_ops.api.queries.client import query_dicts
+
+        params: dict[str, Any] = {"start_day": start_day, "end_day": end_day}
+        filters = ["day >= {start_day:Date}", "day <= {end_day:Date}"]
+        if repo_id is not None:
+            params["repo_id"] = str(repo_id)
+            filters.append("repo_id = {repo_id:UUID}")
+        if team_id is not None:
+            params["team_id"] = team_id
+            filters.append("team_id = {team_id:String}")
+        if work_type is not None:
+            params["work_type"] = work_type
+            filters.append("work_type = {work_type:String}")
+        params = self._scope.inject(params)
+        org_filter = self._scope.filter()
+        if org_filter:
+            filters.append(org_filter.removeprefix("AND "))
+        where_clause = " AND ".join(filters)
+        query = f"""
+        SELECT
+            org_id,
+            team_id,
+            repo_id,
+            work_type,
+            day,
+            attribution_bucket,
+            argMax(prs_total, computed_at) AS prs_total,
+            argMax(prs_merged, computed_at) AS prs_merged,
+            argMax(ai_assisted_prs, computed_at) AS ai_assisted_prs,
+            argMax(agent_created_prs, computed_at) AS agent_created_prs,
+            argMax(human_prs, computed_at) AS human_prs,
+            argMax(unknown_prs, computed_at) AS unknown_prs,
+            argMax(ai_assisted_pr_ratio, computed_at) AS ai_assisted_pr_ratio,
+            argMax(agent_created_pr_count, computed_at) AS agent_created_pr_count,
+            argMax(cycle_time_avg_hours, computed_at) AS cycle_time_avg_hours,
+            argMax(baseline_cycle_time_avg_hours, computed_at) AS baseline_cycle_time_avg_hours,
+            argMax(ai_cycle_time_delta_hours, computed_at) AS ai_cycle_time_delta_hours,
+            argMax(reviews_per_pr, computed_at) AS reviews_per_pr,
+            argMax(baseline_reviews_per_pr, computed_at) AS baseline_reviews_per_pr,
+            argMax(ai_review_amplification, computed_at) AS ai_review_amplification,
+            argMax(changes_requested_per_pr, computed_at) AS changes_requested_per_pr,
+            argMax(rework_prs, computed_at) AS rework_prs,
+            argMax(rework_drag_rate, computed_at) AS rework_drag_rate,
+            argMax(followup_commits_count, computed_at) AS followup_commits_count,
+            argMax(revert_prs, computed_at) AS revert_prs,
+            argMax(revert_rate, computed_at) AS revert_rate,
+            argMax(incidents_count, computed_at) AS incidents_count,
+            argMax(incident_drag_rate, computed_at) AS incident_drag_rate,
+            argMax(test_gap_prs, computed_at) AS test_gap_prs,
+            argMax(test_gap_rate, computed_at) AS test_gap_rate,
+            argMax(leverage_prs_component, computed_at) AS leverage_prs_component,
+            argMax(leverage_cycle_time_component, computed_at) AS leverage_cycle_time_component,
+            argMax(leverage_review_component, computed_at) AS leverage_review_component,
+            argMax(leverage_rework_component, computed_at) AS leverage_rework_component,
+            argMax(leverage_test_component, computed_at) AS leverage_test_component,
+            argMax(leverage_incident_component, computed_at) AS leverage_incident_component,
+            max(computed_at) AS computed_at
+        FROM ai_impact_metrics_daily
+        WHERE {where_clause}
+        GROUP BY org_id, team_id, repo_id, work_type, day, attribution_bucket
+        ORDER BY day, repo_id, work_type, attribution_bucket
+        """
+        raw_rows = await query_dicts(self.client, query, params)
+        return [_to_record(raw) for raw in raw_rows]
+
+
+def _to_record(raw: dict[str, Any]) -> AIImpactMetricsDailyRecord:
+    repo_id = parse_uuid(raw.get("repo_id"))
+    if repo_id is None:
+        raise ValueError("ai_impact_metrics_daily row has invalid repo_id")
+    return AIImpactMetricsDailyRecord(
+        org_id=str(raw.get("org_id") or ""),
+        team_id=raw.get("team_id"),
+        repo_id=repo_id,
+        work_type=str(raw.get("work_type") or "pull_request"),
+        day=raw["day"],
+        attribution_bucket=str(raw.get("attribution_bucket") or "unknown"),
+        prs_total=int(raw.get("prs_total") or 0),
+        prs_merged=int(raw.get("prs_merged") or 0),
+        ai_assisted_prs=int(raw.get("ai_assisted_prs") or 0),
+        agent_created_prs=int(raw.get("agent_created_prs") or 0),
+        human_prs=int(raw.get("human_prs") or 0),
+        unknown_prs=int(raw.get("unknown_prs") or 0),
+        ai_assisted_pr_ratio=raw.get("ai_assisted_pr_ratio"),
+        agent_created_pr_count=int(raw.get("agent_created_pr_count") or 0),
+        cycle_time_avg_hours=raw.get("cycle_time_avg_hours"),
+        baseline_cycle_time_avg_hours=raw.get("baseline_cycle_time_avg_hours"),
+        ai_cycle_time_delta_hours=raw.get("ai_cycle_time_delta_hours"),
+        reviews_per_pr=raw.get("reviews_per_pr"),
+        baseline_reviews_per_pr=raw.get("baseline_reviews_per_pr"),
+        ai_review_amplification=raw.get("ai_review_amplification"),
+        changes_requested_per_pr=raw.get("changes_requested_per_pr"),
+        rework_prs=int(raw.get("rework_prs") or 0),
+        rework_drag_rate=raw.get("rework_drag_rate"),
+        followup_commits_count=int(raw.get("followup_commits_count") or 0),
+        revert_prs=int(raw.get("revert_prs") or 0),
+        revert_rate=raw.get("revert_rate"),
+        incidents_count=int(raw.get("incidents_count") or 0),
+        incident_drag_rate=raw.get("incident_drag_rate"),
+        test_gap_prs=int(raw.get("test_gap_prs") or 0),
+        test_gap_rate=raw.get("test_gap_rate"),
+        leverage=AIOperatingLeverageComponents(
+            prs_component=float(raw.get("leverage_prs_component") or 0.0),
+            cycle_time_component=raw.get("leverage_cycle_time_component"),
+            review_component=raw.get("leverage_review_component"),
+            rework_component=raw.get("leverage_rework_component"),
+            test_component=raw.get("leverage_test_component"),
+            incident_component=raw.get("leverage_incident_component"),
+        ),
+        computed_at=raw["computed_at"],
+    )

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -13,7 +13,6 @@ from dev_health_ops.metrics.loaders.base import (
     parse_uuid,
     to_dataclass,
 )
-from dev_health_ops.metrics.query_builder import OrgScopedQuery
 from dev_health_ops.metrics.schemas import (
     CommitStatRow,
     DeploymentRow,
@@ -55,9 +54,7 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
     """
 
     def __init__(self, client: Any, org_id: str = "") -> None:
-        self.client = client
-        self.org_id = org_id
-        self._scope = OrgScopedQuery(org_id)
+        super().__init__(client, org_id=org_id)
 
     def _org_filter(self, *, alias: str = "") -> str:
         """Return an ``AND org_id = …`` clause when *org_id* is set."""

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, cast
 
+from dev_health_ops.metrics.loaders.ai_impact import AIImpactClickHouseLoader
 from dev_health_ops.metrics.loaders.base import (
     DataLoader,
     naive_utc,
@@ -44,7 +45,7 @@ async def _clickhouse_query_dicts(
     return await query_dicts(client, query, params)
 
 
-class ClickHouseDataLoader(DataLoader):
+class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
     """DataLoader implementation for ClickHouse backend.
 
     Args:

--- a/src/dev_health_ops/metrics/schemas.py
+++ b/src/dev_health_ops/metrics/schemas.py
@@ -49,11 +49,65 @@ class PullRequestReviewRow(TypedDict):
     state: str  # APPROVED|CHANGES_REQUESTED|COMMENTED|DISMISSED|...
 
 
+class AIPullRequestAttributionRow(TypedDict):
+    repo_id: uuid.UUID
+    number: int
+    kind: str | None
+    work_type: str | None
+    team_id: str | None
+
+
 class PullRequestCommentRow(TypedDict):
     repo_id: uuid.UUID
     number: int
     commenter: str
     created_at: datetime
+
+
+@dataclass(frozen=True)
+class AIOperatingLeverageComponents:
+    prs_component: float
+    cycle_time_component: float | None
+    review_component: float | None
+    rework_component: float | None
+    test_component: float | None
+    incident_component: float | None
+
+
+@dataclass(frozen=True)
+class AIImpactMetricsDailyRecord:
+    org_id: str
+    team_id: str | None
+    repo_id: uuid.UUID
+    work_type: str
+    day: date
+    attribution_bucket: str
+    prs_total: int
+    prs_merged: int
+    ai_assisted_prs: int
+    agent_created_prs: int
+    human_prs: int
+    unknown_prs: int
+    ai_assisted_pr_ratio: float | None
+    agent_created_pr_count: int
+    cycle_time_avg_hours: float | None
+    baseline_cycle_time_avg_hours: float | None
+    ai_cycle_time_delta_hours: float | None
+    reviews_per_pr: float | None
+    baseline_reviews_per_pr: float | None
+    ai_review_amplification: float | None
+    changes_requested_per_pr: float | None
+    rework_prs: int
+    rework_drag_rate: float | None
+    followup_commits_count: int
+    revert_prs: int
+    revert_rate: float | None
+    incidents_count: int
+    incident_drag_rate: float | None
+    test_gap_prs: int
+    test_gap_rate: float | None
+    leverage: AIOperatingLeverageComponents
+    computed_at: datetime
 
 
 class PipelineRunRow(TypedDict):

--- a/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
@@ -15,12 +15,14 @@ each responsible for one table family:
   InvestmentMixin       — investment classifications/metrics, work-unit investments
   WorkGraphMixin        — work graph edges, work items, git/repo/file metrics, forecasts
   AIAttributionMixin    — AI attribution records (ai_attribution table)
+  AIImpactMixin         — AI workflow impact daily rollups
 """
 
 from __future__ import annotations
 
 from dev_health_ops.metrics.sinks.clickhouse.ai_attribution import AIAttributionMixin
 from dev_health_ops.metrics.sinks.clickhouse.ai_governance import AIGovernanceMixin
+from dev_health_ops.metrics.sinks.clickhouse.ai_impact import AIImpactMixin
 from dev_health_ops.metrics.sinks.clickhouse.ai_workflow import AIWorkflowMixin
 from dev_health_ops.metrics.sinks.clickhouse.ci import CIMixin
 from dev_health_ops.metrics.sinks.clickhouse.core import ClickHouseCore
@@ -36,6 +38,7 @@ class ClickHouseMetricsSink(
     AIGovernanceMixin,
     AIWorkflowMixin,
     AIAttributionMixin,
+    AIImpactMixin,
     CIMixin,
     DoraMixin,
     WellbeingMixin,

--- a/src/dev_health_ops/metrics/sinks/clickhouse/ai_impact.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/ai_impact.py
@@ -64,7 +64,7 @@ class AIImpactMixin(_ClickHouseSinkBase):
         class _RowAdapter:
             def __init__(self, row: AIImpactMetricsDailyRecord) -> None:
                 self.org_id = row.org_id
-                self.team_id = row.team_id
+                self.team_id = row.team_id or ""
                 self.repo_id = row.repo_id
                 self.work_type = row.work_type
                 self.day = row.day

--- a/src/dev_health_ops/metrics/sinks/clickhouse/ai_impact.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/ai_impact.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from dev_health_ops.metrics.schemas import AIImpactMetricsDailyRecord
+
+if TYPE_CHECKING:
+    from dev_health_ops.metrics.sinks.clickhouse._insert import _ClickHouseSinkBase
+else:
+
+    class _ClickHouseSinkBase:
+        pass
+
+
+_COLUMNS = [
+    "org_id",
+    "team_id",
+    "repo_id",
+    "work_type",
+    "day",
+    "attribution_bucket",
+    "prs_total",
+    "prs_merged",
+    "ai_assisted_prs",
+    "agent_created_prs",
+    "human_prs",
+    "unknown_prs",
+    "ai_assisted_pr_ratio",
+    "agent_created_pr_count",
+    "cycle_time_avg_hours",
+    "baseline_cycle_time_avg_hours",
+    "ai_cycle_time_delta_hours",
+    "reviews_per_pr",
+    "baseline_reviews_per_pr",
+    "ai_review_amplification",
+    "changes_requested_per_pr",
+    "rework_prs",
+    "rework_drag_rate",
+    "followup_commits_count",
+    "revert_prs",
+    "revert_rate",
+    "incidents_count",
+    "incident_drag_rate",
+    "test_gap_prs",
+    "test_gap_rate",
+    "leverage_prs_component",
+    "leverage_cycle_time_component",
+    "leverage_review_component",
+    "leverage_rework_component",
+    "leverage_test_component",
+    "leverage_incident_component",
+    "computed_at",
+]
+
+
+class AIImpactMixin(_ClickHouseSinkBase):
+    def write_ai_impact_metrics(
+        self, rows: Sequence[AIImpactMetricsDailyRecord]
+    ) -> None:
+        if not rows:
+            return
+
+        class _RowAdapter:
+            def __init__(self, row: AIImpactMetricsDailyRecord) -> None:
+                self.org_id = row.org_id
+                self.team_id = row.team_id
+                self.repo_id = row.repo_id
+                self.work_type = row.work_type
+                self.day = row.day
+                self.attribution_bucket = row.attribution_bucket
+                self.prs_total = row.prs_total
+                self.prs_merged = row.prs_merged
+                self.ai_assisted_prs = row.ai_assisted_prs
+                self.agent_created_prs = row.agent_created_prs
+                self.human_prs = row.human_prs
+                self.unknown_prs = row.unknown_prs
+                self.ai_assisted_pr_ratio = row.ai_assisted_pr_ratio
+                self.agent_created_pr_count = row.agent_created_pr_count
+                self.cycle_time_avg_hours = row.cycle_time_avg_hours
+                self.baseline_cycle_time_avg_hours = row.baseline_cycle_time_avg_hours
+                self.ai_cycle_time_delta_hours = row.ai_cycle_time_delta_hours
+                self.reviews_per_pr = row.reviews_per_pr
+                self.baseline_reviews_per_pr = row.baseline_reviews_per_pr
+                self.ai_review_amplification = row.ai_review_amplification
+                self.changes_requested_per_pr = row.changes_requested_per_pr
+                self.rework_prs = row.rework_prs
+                self.rework_drag_rate = row.rework_drag_rate
+                self.followup_commits_count = row.followup_commits_count
+                self.revert_prs = row.revert_prs
+                self.revert_rate = row.revert_rate
+                self.incidents_count = row.incidents_count
+                self.incident_drag_rate = row.incident_drag_rate
+                self.test_gap_prs = row.test_gap_prs
+                self.test_gap_rate = row.test_gap_rate
+                self.leverage_prs_component = row.leverage.prs_component
+                self.leverage_cycle_time_component = row.leverage.cycle_time_component
+                self.leverage_review_component = row.leverage.review_component
+                self.leverage_rework_component = row.leverage.rework_component
+                self.leverage_test_component = row.leverage.test_component
+                self.leverage_incident_component = row.leverage.incident_component
+                self.computed_at = row.computed_at
+
+        # _insert_rows expects dataclasses, so build explicit dictionaries here.
+        matrix = []
+        for row in rows:
+            adapter = _RowAdapter(row)
+            matrix.append([getattr(adapter, column) for column in _COLUMNS])
+        self.client.insert("ai_impact_metrics_daily", matrix, column_names=_COLUMNS)

--- a/src/dev_health_ops/migrations/clickhouse/036_ai_metrics.sql
+++ b/src/dev_health_ops/migrations/clickhouse/036_ai_metrics.sql
@@ -1,0 +1,57 @@
+-- Migration 036: AI workflow impact metric rollups.
+--
+-- Append-only daily rollups computed from ai_attribution_resolved and PR facts.
+-- Read latest values with argMax(..., computed_at).  Null attribution is kept
+-- as attribution_bucket='unknown' and is never folded into human baselines.
+
+CREATE TABLE IF NOT EXISTS ai_impact_metrics_daily
+(
+    org_id String,
+    team_id Nullable(String),
+    repo_id UUID,
+    work_type LowCardinality(String),
+    day Date,
+    attribution_bucket LowCardinality(String), -- ai_assisted|agent_created|ai_review|human|unknown
+
+    prs_total UInt32,
+    prs_merged UInt32,
+    ai_assisted_prs UInt32,
+    agent_created_prs UInt32,
+    human_prs UInt32,
+    unknown_prs UInt32,
+    ai_assisted_pr_ratio Nullable(Float64),
+    agent_created_pr_count UInt32,
+
+    cycle_time_avg_hours Nullable(Float64),
+    baseline_cycle_time_avg_hours Nullable(Float64),
+    ai_cycle_time_delta_hours Nullable(Float64),
+
+    reviews_per_pr Nullable(Float64),
+    baseline_reviews_per_pr Nullable(Float64),
+    ai_review_amplification Nullable(Float64),
+    changes_requested_per_pr Nullable(Float64),
+
+    rework_prs UInt32,
+    rework_drag_rate Nullable(Float64),
+    followup_commits_count UInt32,
+    revert_prs UInt32,
+    revert_rate Nullable(Float64),
+    incidents_count UInt32,
+    incident_drag_rate Nullable(Float64),
+
+    test_gap_prs UInt32,
+    test_gap_rate Nullable(Float64),
+
+    leverage_prs_component Float64,
+    leverage_cycle_time_component Nullable(Float64),
+    leverage_review_component Nullable(Float64),
+    leverage_rework_component Nullable(Float64),
+    leverage_test_component Nullable(Float64),
+    leverage_incident_component Nullable(Float64),
+
+    computed_at DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(day)
+ORDER BY (org_id, team_id, repo_id, work_type, day, attribution_bucket)
+SETTINGS index_granularity = 8192;

--- a/src/dev_health_ops/migrations/clickhouse/036_ai_metrics.sql
+++ b/src/dev_health_ops/migrations/clickhouse/036_ai_metrics.sql
@@ -7,7 +7,7 @@
 CREATE TABLE IF NOT EXISTS ai_impact_metrics_daily
 (
     org_id String,
-    team_id Nullable(String),
+    team_id String,                  -- empty string sentinel for no team association. Sorting key cannot be Nullable without allow_nullable_key.
     repo_id UUID,
     work_type LowCardinality(String),
     day Date,

--- a/tests/metrics/test_ai_impact.py
+++ b/tests/metrics/test_ai_impact.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from dev_health_ops.metrics.ai_impact import compute_ai_impact_metrics_daily
+from dev_health_ops.metrics.schemas import (
+    AIPullRequestAttributionRow,
+    CommitStatRow,
+    IncidentRow,
+    PullRequestReviewRow,
+    PullRequestRow,
+)
+from dev_health_ops.metrics.sinks.clickhouse.ai_impact import AIImpactMixin
+
+DAY = date(2026, 5, 18)
+COMPUTED_AT = datetime(2026, 5, 18, 12, tzinfo=timezone.utc)
+
+
+def _pr(
+    repo_id,
+    number: int,
+    *,
+    created_hour: int,
+    merged_hour: int | None,
+    reviews: int = 0,
+    changes_requested: int = 0,
+    additions: int = 10,
+    deletions: int = 5,
+) -> PullRequestRow:
+    return {
+        "repo_id": repo_id,
+        "number": number,
+        "author_email": "dev@example.com",
+        "author_name": "Dev",
+        "created_at": datetime(2026, 5, 18, created_hour, tzinfo=timezone.utc),
+        "merged_at": (
+            datetime(2026, 5, 18, merged_hour, tzinfo=timezone.utc)
+            if merged_hour is not None
+            else None
+        ),
+        "reviews_count": reviews,
+        "changes_requested_count": changes_requested,
+        "comments_count": 0,
+        "additions": additions,
+        "deletions": deletions,
+        "changed_files": 2,
+    }
+
+
+def _attr(
+    repo_id, number: int, kind: str, work_type: str = "pull_request"
+) -> AIPullRequestAttributionRow:
+    return {
+        "repo_id": repo_id,
+        "number": number,
+        "kind": kind,
+        "work_type": work_type,
+        "team_id": None,
+    }
+
+
+def _rows(
+    prs: list[PullRequestRow],
+    attrs: list[AIPullRequestAttributionRow],
+    *,
+    reviews: list[PullRequestReviewRow] | None = None,
+    incidents: list[IncidentRow] | None = None,
+    commit_stats: list[CommitStatRow] | None = None,
+    pr_commit_stats: dict | None = None,
+):
+    return compute_ai_impact_metrics_daily(
+        day=DAY,
+        org_id="org-a",
+        pull_request_rows=prs,
+        pull_request_review_rows=reviews or [],
+        ai_attribution_rows=attrs,
+        incident_rows=incidents or [],
+        commit_stat_rows=commit_stats or [],
+        computed_at=COMPUTED_AT,
+        pr_commit_stats=pr_commit_stats,
+    )
+
+
+def _bucket(rows, bucket: str):
+    return next(row for row in rows if row.attribution_bucket == bucket)
+
+
+def test_ai_assisted_pr_ratio_keeps_unknown_out_of_human_baseline():
+    repo = uuid4()
+    rows = _rows(
+        [
+            _pr(repo, 1, created_hour=9, merged_hour=10),
+            _pr(repo, 2, created_hour=9, merged_hour=11),
+        ],
+        [_attr(repo, 1, "ai_assisted")],
+    )
+
+    ai = _bucket(rows, "ai_assisted")
+    unknown = _bucket(rows, "unknown")
+
+    assert ai.ai_assisted_pr_ratio == pytest.approx(0.5)
+    assert ai.human_prs == 0
+    assert ai.unknown_prs == 1
+    assert unknown.prs_total == 1
+
+
+def test_agent_created_pr_count_is_reported():
+    repo = uuid4()
+    rows = _rows(
+        [_pr(repo, 7, created_hour=9, merged_hour=10)],
+        [_attr(repo, 7, "agent_created")],
+    )
+
+    assert _bucket(rows, "agent_created").agent_created_pr_count == 1
+
+
+def test_ai_cycle_time_delta_uses_human_baseline_only():
+    repo = uuid4()
+    rows = _rows(
+        [
+            _pr(repo, 1, created_hour=8, merged_hour=10),
+            _pr(repo, 2, created_hour=8, merged_hour=13),
+        ],
+        [_attr(repo, 1, "ai_assisted"), _attr(repo, 2, "human")],
+    )
+
+    ai = _bucket(rows, "ai_assisted")
+    assert ai.cycle_time_avg_hours == pytest.approx(2)
+    assert ai.baseline_cycle_time_avg_hours == pytest.approx(5)
+    assert ai.ai_cycle_time_delta_hours == pytest.approx(-3)
+    assert ai.leverage.cycle_time_component == pytest.approx(0.6)
+
+
+def test_ai_review_amplification_is_decomposed():
+    repo = uuid4()
+    rows = _rows(
+        [
+            _pr(repo, 1, created_hour=8, merged_hour=10, reviews=4),
+            _pr(repo, 2, created_hour=8, merged_hour=10, reviews=2),
+        ],
+        [_attr(repo, 1, "ai_assisted"), _attr(repo, 2, "human")],
+    )
+
+    ai = _bucket(rows, "ai_assisted")
+    assert ai.reviews_per_pr == pytest.approx(4)
+    assert ai.baseline_reviews_per_pr == pytest.approx(2)
+    assert ai.ai_review_amplification == pytest.approx(1)
+    assert ai.leverage.review_component == pytest.approx(1)
+
+
+def test_ai_rework_drag_counts_changes_requested():
+    repo = uuid4()
+    rows = _rows(
+        [_pr(repo, 1, created_hour=8, merged_hour=10, changes_requested=1)],
+        [_attr(repo, 1, "ai_assisted")],
+    )
+
+    ai = _bucket(rows, "ai_assisted")
+    assert ai.rework_prs == 1
+    assert ai.rework_drag_rate == pytest.approx(1)
+
+
+def test_ai_revert_and_incident_drag_are_separate_fields():
+    repo = uuid4()
+    rows = _rows(
+        [_pr(repo, 1, created_hour=8, merged_hour=10, additions=10, deletions=100)],
+        [_attr(repo, 1, "ai_assisted")],
+        incidents=[
+            {
+                "repo_id": repo,
+                "incident_id": "inc-1",
+                "status": "resolved",
+                "started_at": datetime(2026, 5, 18, 11, tzinfo=timezone.utc),
+                "resolved_at": None,
+            }
+        ],
+    )
+
+    ai = _bucket(rows, "ai_assisted")
+    assert ai.revert_prs == 1
+    assert ai.revert_rate == pytest.approx(1)
+    assert ai.incidents_count == 1
+    assert ai.incident_drag_rate == pytest.approx(1)
+
+
+def test_ai_test_gap_rate_uses_pr_commit_file_evidence():
+    repo = uuid4()
+    pr = _pr(repo, 1, created_hour=8, merged_hour=10)
+    rows = _rows(
+        [pr],
+        [_attr(repo, 1, "ai_assisted")],
+        pr_commit_stats={
+            (repo, 1): [
+                {
+                    "repo_id": repo,
+                    "commit_hash": "abc",
+                    "author_email": "dev@example.com",
+                    "author_name": "Dev",
+                    "committer_when": datetime(2026, 5, 18, 9, tzinfo=timezone.utc),
+                    "file_path": "src/app.py",
+                    "additions": 4,
+                    "deletions": 1,
+                }
+            ]
+        },
+    )
+
+    ai = _bucket(rows, "ai_assisted")
+    assert ai.test_gap_prs == 1
+    assert ai.test_gap_rate == pytest.approx(1)
+    assert ai.leverage.test_component is None
+
+
+def test_operating_leverage_is_decomposed_not_single_score():
+    repo = uuid4()
+    rows = _rows(
+        [_pr(repo, 1, created_hour=8, merged_hour=10)], [_attr(repo, 1, "ai_assisted")]
+    )
+
+    leverage = _bucket(rows, "ai_assisted").leverage
+    assert leverage.prs_component == 1
+    assert hasattr(leverage, "cycle_time_component")
+    assert hasattr(leverage, "review_component")
+    assert not hasattr(leverage, "score")
+
+
+def test_clickhouse_sink_writes_ai_impact_rows_with_dimensions():
+    repo = uuid4()
+    rows = _rows(
+        [_pr(repo, 1, created_hour=8, merged_hour=10)], [_attr(repo, 1, "ai_assisted")]
+    )
+
+    class Client:
+        def __init__(self):
+            self.calls = []
+
+        def insert(self, table, matrix, column_names):
+            self.calls.append((table, matrix, column_names))
+
+    class Sink(AIImpactMixin):
+        def __init__(self):
+            self.client = Client()
+
+    sink = Sink()
+    sink.write_ai_impact_metrics(rows)
+
+    table, matrix, columns = sink.client.calls[0]
+    assert table == "ai_impact_metrics_daily"
+    assert "org_id" in columns
+    assert "team_id" in columns
+    assert "repo_id" in columns
+    assert "work_type" in columns
+    assert matrix[0][columns.index("attribution_bucket")] == "ai_assisted"


### PR DESCRIPTION
## Summary
Adds AI workflow impact metrics computed from `ai_attribution` (CHAOS-1579/1580). Queryable by team, repo, time range, work type. AI vs non-AI baselines tracked separately. Null/unknown attribution is a distinct bucket — never silently treated as human.

## Metrics
- AI-assisted PR ratio
- Agent-created PR count
- AI cycle-time delta
- AI review amplification
- AI rework drag
- AI revert + incident drag
- AI test gap rate
- AI Operating Leverage (decomposed — exposes its components)

## Design
- Migration 036_ai_metrics.sql (ReplacingMergeTree; dims org_id, team_id, repo_id, work_type, date)
- Compute jobs registered into `dev-hops metrics daily`
- Read path uses `ai_attribution_resolved`
- Unknown attribution kept as a separate bucket

## Verification
```
uv run pytest tests/metrics/test_ai_impact*
uv run ruff check
uv run mypy src
```

SCREENSHOT-WAIVER: backend-only.

Closes CHAOS-1581