### PR TITLE
feat(work-graph): extend Work Graph for AI workflow evidence (CHAOS-1583)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/inputs.py
+++ b/src/dev_health_ops/api/graphql/models/inputs.py
@@ -247,6 +247,11 @@ class WorkGraphNodeTypeInput(Enum):
     FILE = "file"
     RELEASE = "release"
     FEATURE_FLAG = "feature_flag"
+    AI_WORKFLOW_RUN = "ai_workflow_run"
+    DIFF = "diff"
+    REVIEW_OUTCOME = "review_outcome"
+    DEPLOYMENT = "deployment"
+    INCIDENT = "incident"
 
 
 @strawberry.enum
@@ -270,6 +275,11 @@ class WorkGraphEdgeTypeInput(Enum):
     CONFIG_CHANGED_BY = "config_changed_by"
     GUARDS = "guards"
     IMPACTS = "impacts"
+    HAS_AI_WORKFLOW = "has_ai_workflow"
+    GENERATES = "generates"
+    HAS_REVIEW_OUTCOME = "has_review_outcome"
+    DEPLOYS = "deploys"
+    LINKED_INCIDENT = "linked_incident"
 
 
 @strawberry.input

--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -319,6 +319,11 @@ class WorkGraphNodeType(Enum):
     FILE = "file"
     RELEASE = "release"
     FEATURE_FLAG = "feature_flag"
+    AI_WORKFLOW_RUN = "ai_workflow_run"
+    DIFF = "diff"
+    REVIEW_OUTCOME = "review_outcome"
+    DEPLOYMENT = "deployment"
+    INCIDENT = "incident"
 
 
 @strawberry.enum
@@ -355,6 +360,11 @@ class WorkGraphEdgeType(Enum):
 
     # Cross-cutting impact relationships
     IMPACTS = "impacts"
+    HAS_AI_WORKFLOW = "has_ai_workflow"
+    GENERATES = "generates"
+    HAS_REVIEW_OUTCOME = "has_review_outcome"
+    DEPLOYS = "deploys"
+    LINKED_INCIDENT = "linked_incident"
 
 
 @strawberry.enum

--- a/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from dev_health_ops.metrics.sinks.clickhouse.ai_attribution import AIAttributionMixin
 from dev_health_ops.metrics.sinks.clickhouse.ai_governance import AIGovernanceMixin
+from dev_health_ops.metrics.sinks.clickhouse.ai_workflow import AIWorkflowMixin
 from dev_health_ops.metrics.sinks.clickhouse.ci import CIMixin
 from dev_health_ops.metrics.sinks.clickhouse.core import ClickHouseCore
 from dev_health_ops.metrics.sinks.clickhouse.dora import DoraMixin
@@ -33,6 +34,7 @@ class ClickHouseMetricsSink(
     # Mixins come BEFORE ClickHouseCore so their concrete write_* methods
     # take priority in the MRO over BaseMetricsSink abstract methods.
     AIGovernanceMixin,
+    AIWorkflowMixin,
     AIAttributionMixin,
     CIMixin,
     DoraMixin,

--- a/src/dev_health_ops/metrics/sinks/clickhouse/ai_workflow.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/ai_workflow.py
@@ -1,0 +1,340 @@
+"""ClickHouse write methods for AI workflow Work Graph evidence."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Sequence
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from dev_health_ops.metrics.sinks.clickhouse._insert import (
+    DEFAULT_BATCH_SIZE,
+    _chunked,
+    _dt_to_clickhouse_datetime,
+)
+from dev_health_ops.models.ai_workflow import (
+    AIWorkflowArtifactEdge,
+    AIWorkflowIssueEdge,
+    AIWorkflowRun,
+    WorkGraphDeploymentIncidentEdge,
+    WorkGraphPRDeploymentEdge,
+    WorkGraphPRReviewOutcomeEdge,
+)
+
+if TYPE_CHECKING:
+    from dev_health_ops.metrics.sinks.clickhouse._insert import _ClickHouseSinkBase
+else:
+
+    class _ClickHouseSinkBase:
+        pass
+
+
+logger = logging.getLogger(__name__)
+
+AI_WORKFLOW_RUN_COLUMNS = [
+    "run_id",
+    "org_id",
+    "provider",
+    "run_kind",
+    "status",
+    "tool",
+    "model",
+    "actor",
+    "repo_id",
+    "prompts_redacted",
+    "prompt_hash",
+    "prompt_length",
+    "started_at",
+    "completed_at",
+    "observed_at",
+    "metadata",
+    "computed_at",
+]
+
+AI_WORKFLOW_ARTIFACT_EDGE_COLUMNS = [
+    "edge_id",
+    "org_id",
+    "run_id",
+    "artifact_type",
+    "artifact_id",
+    "provider",
+    "repo_id",
+    "confidence",
+    "source",
+    "evidence",
+    "observed_at",
+    "computed_at",
+]
+
+AI_WORKFLOW_ISSUE_EDGE_COLUMNS = [
+    "edge_id",
+    "org_id",
+    "issue_id",
+    "run_id",
+    "provider",
+    "repo_id",
+    "confidence",
+    "source",
+    "evidence",
+    "observed_at",
+    "computed_at",
+]
+
+PR_REVIEW_OUTCOME_EDGE_COLUMNS = [
+    "edge_id",
+    "org_id",
+    "pr_id",
+    "review_outcome_id",
+    "outcome",
+    "provider",
+    "repo_id",
+    "confidence",
+    "source",
+    "evidence",
+    "observed_at",
+    "computed_at",
+]
+
+PR_DEPLOYMENT_EDGE_COLUMNS = [
+    "edge_id",
+    "org_id",
+    "pr_id",
+    "deployment_id",
+    "provider",
+    "repo_id",
+    "confidence",
+    "source",
+    "evidence",
+    "observed_at",
+    "computed_at",
+]
+
+DEPLOYMENT_INCIDENT_EDGE_COLUMNS = [
+    "edge_id",
+    "org_id",
+    "deployment_id",
+    "incident_id",
+    "provider",
+    "repo_id",
+    "confidence",
+    "source",
+    "evidence",
+    "observed_at",
+    "computed_at",
+]
+
+
+def _computed_at() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _uuid(value: object | None) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _run_to_row(run: AIWorkflowRun) -> list[object]:
+    return [
+        run.run_id,
+        str(run.org_id),
+        run.provider,
+        str(run.run_kind),
+        str(run.status) if run.status is not None else None,
+        run.tool,
+        run.model,
+        run.actor,
+        _uuid(run.repo_id),
+        bool(run.prompts_redacted),
+        run.prompt_hash,
+        run.prompt_length,
+        _dt_to_clickhouse_datetime(run.started_at),
+        _dt_to_clickhouse_datetime(run.completed_at),
+        _dt_to_clickhouse_datetime(run.observed_at),
+        run.metadata_json(),
+        _dt_to_clickhouse_datetime(_computed_at()),
+    ]
+
+
+def _artifact_edge_to_row(edge: AIWorkflowArtifactEdge) -> list[object]:
+    return [
+        edge.edge_id,
+        str(edge.org_id),
+        edge.run_id,
+        str(edge.artifact_type),
+        edge.artifact_id,
+        edge.provider,
+        _uuid(edge.repo_id),
+        float(edge.confidence),
+        edge.source,
+        edge.evidence,
+        _dt_to_clickhouse_datetime(edge.observed_at),
+        _dt_to_clickhouse_datetime(_computed_at()),
+    ]
+
+
+def _issue_edge_to_row(edge: AIWorkflowIssueEdge) -> list[object]:
+    return [
+        edge.edge_id,
+        str(edge.org_id),
+        edge.issue_id,
+        edge.run_id,
+        edge.provider,
+        _uuid(edge.repo_id),
+        float(edge.confidence),
+        edge.source,
+        edge.evidence,
+        _dt_to_clickhouse_datetime(edge.observed_at),
+        _dt_to_clickhouse_datetime(_computed_at()),
+    ]
+
+
+def _review_edge_to_row(edge: WorkGraphPRReviewOutcomeEdge) -> list[object]:
+    return [
+        edge.edge_id,
+        str(edge.org_id),
+        edge.pr_id,
+        edge.review_outcome_id,
+        edge.outcome,
+        edge.provider,
+        _uuid(edge.repo_id),
+        float(edge.confidence),
+        edge.source,
+        edge.evidence,
+        _dt_to_clickhouse_datetime(edge.observed_at),
+        _dt_to_clickhouse_datetime(_computed_at()),
+    ]
+
+
+def _pr_deployment_edge_to_row(edge: WorkGraphPRDeploymentEdge) -> list[object]:
+    return [
+        edge.edge_id,
+        str(edge.org_id),
+        edge.pr_id,
+        edge.deployment_id,
+        edge.provider,
+        _uuid(edge.repo_id),
+        float(edge.confidence),
+        edge.source,
+        edge.evidence,
+        _dt_to_clickhouse_datetime(edge.observed_at),
+        _dt_to_clickhouse_datetime(_computed_at()),
+    ]
+
+
+def _deployment_incident_edge_to_row(
+    edge: WorkGraphDeploymentIncidentEdge,
+) -> list[object]:
+    return [
+        edge.edge_id,
+        str(edge.org_id),
+        edge.deployment_id,
+        edge.incident_id,
+        edge.provider,
+        _uuid(edge.repo_id),
+        float(edge.confidence),
+        edge.source,
+        edge.evidence,
+        _dt_to_clickhouse_datetime(edge.observed_at),
+        _dt_to_clickhouse_datetime(_computed_at()),
+    ]
+
+
+class AIWorkflowMixin(_ClickHouseSinkBase):
+    """Mixin for AI workflow Work Graph persistence."""
+
+    def write_ai_workflow_runs(
+        self,
+        runs: Sequence[AIWorkflowRun],
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        if not runs:
+            return
+        for chunk in _chunked(list(runs), batch_size):
+            self.client.insert(
+                "ai_workflow_runs",
+                [_run_to_row(run) for run in chunk],
+                column_names=AI_WORKFLOW_RUN_COLUMNS,
+            )
+        logger.debug("write_ai_workflow_runs: persisted %d run(s)", len(runs))
+
+    def write_ai_workflow_artifact_edges(
+        self,
+        edges: Sequence[AIWorkflowArtifactEdge],
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        self._write_edges(
+            "ai_workflow_artifact_edges",
+            edges,
+            AI_WORKFLOW_ARTIFACT_EDGE_COLUMNS,
+            _artifact_edge_to_row,
+            batch_size,
+        )
+
+    def write_ai_workflow_issue_edges(
+        self,
+        edges: Sequence[AIWorkflowIssueEdge],
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        self._write_edges(
+            "ai_workflow_issue_edges",
+            edges,
+            AI_WORKFLOW_ISSUE_EDGE_COLUMNS,
+            _issue_edge_to_row,
+            batch_size,
+        )
+
+    def write_work_graph_pr_review_outcome_edges(
+        self,
+        edges: Sequence[WorkGraphPRReviewOutcomeEdge],
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        self._write_edges(
+            "work_graph_pr_review_outcome_edges",
+            edges,
+            PR_REVIEW_OUTCOME_EDGE_COLUMNS,
+            _review_edge_to_row,
+            batch_size,
+        )
+
+    def write_work_graph_pr_deployment_edges(
+        self,
+        edges: Sequence[WorkGraphPRDeploymentEdge],
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        self._write_edges(
+            "work_graph_pr_deployment_edges",
+            edges,
+            PR_DEPLOYMENT_EDGE_COLUMNS,
+            _pr_deployment_edge_to_row,
+            batch_size,
+        )
+
+    def write_work_graph_deployment_incident_edges(
+        self,
+        edges: Sequence[WorkGraphDeploymentIncidentEdge],
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        self._write_edges(
+            "work_graph_deployment_incident_edges",
+            edges,
+            DEPLOYMENT_INCIDENT_EDGE_COLUMNS,
+            _deployment_incident_edge_to_row,
+            batch_size,
+        )
+
+    def _write_edges(
+        self,
+        table: str,
+        edges: Sequence[Any],
+        columns: Sequence[str],
+        row_factory: Callable[[Any], list[object]],
+        batch_size: int,
+    ) -> None:
+        if not edges:
+            return
+        for chunk in _chunked(list(edges), batch_size):
+            self.client.insert(
+                table,
+                [row_factory(edge) for edge in chunk],
+                column_names=list(columns),
+            )
+        logger.debug("%s: persisted %d edge(s)", table, len(edges))

--- a/src/dev_health_ops/migrations/clickhouse/037_ai_workgraph.sql
+++ b/src/dev_health_ops/migrations/clickhouse/037_ai_workgraph.sql
@@ -1,0 +1,127 @@
+-- Migration 037: AI workflow evidence extensions for the Work Graph.
+--
+-- These tables are analytics-only ClickHouse state. They store AI workflow run
+-- metadata and typed evidence edges without raw prompts, sessions, transcripts,
+-- IDE telemetry, or keystroke data.
+
+CREATE TABLE IF NOT EXISTS ai_workflow_runs
+(
+    run_id            String,
+    org_id            UUID,
+    provider          LowCardinality(String),
+    run_kind          LowCardinality(String),
+    status            Nullable(String),
+    tool              Nullable(String),
+    model             Nullable(String),
+    actor             Nullable(String),
+    repo_id           Nullable(UUID),
+    prompts_redacted  Bool,
+    prompt_hash       Nullable(String),
+    prompt_length     Nullable(UInt32),
+    started_at        Nullable(DateTime64(3, 'UTC')),
+    completed_at      Nullable(DateTime64(3, 'UTC')),
+    observed_at       DateTime64(3, 'UTC'),
+    metadata          String,
+    computed_at       DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(observed_at)
+ORDER BY (org_id, provider, run_id)
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS ai_workflow_issue_edges
+(
+    edge_id      String,
+    org_id       UUID,
+    issue_id     String,
+    run_id       String,
+    provider     LowCardinality(String),
+    repo_id      Nullable(UUID),
+    confidence   Float32,
+    source       LowCardinality(String),
+    evidence     String,
+    observed_at  DateTime64(3, 'UTC'),
+    computed_at  DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(observed_at)
+ORDER BY (org_id, issue_id, run_id, source)
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS ai_workflow_artifact_edges
+(
+    edge_id        String,
+    org_id         UUID,
+    run_id         String,
+    artifact_type  LowCardinality(String),
+    artifact_id    String,
+    provider       LowCardinality(String),
+    repo_id        Nullable(UUID),
+    confidence     Float32,
+    source         LowCardinality(String),
+    evidence       String,
+    observed_at    DateTime64(3, 'UTC'),
+    computed_at    DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(observed_at)
+ORDER BY (org_id, run_id, artifact_type, artifact_id, source)
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS work_graph_pr_review_outcome_edges
+(
+    edge_id            String,
+    org_id             UUID,
+    pr_id              String,
+    review_outcome_id  String,
+    outcome            Nullable(String),
+    provider           LowCardinality(String),
+    repo_id            Nullable(UUID),
+    confidence         Float32,
+    source             LowCardinality(String),
+    evidence           String,
+    observed_at        DateTime64(3, 'UTC'),
+    computed_at        DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(observed_at)
+ORDER BY (org_id, pr_id, review_outcome_id, source)
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS work_graph_pr_deployment_edges
+(
+    edge_id        String,
+    org_id         UUID,
+    pr_id          String,
+    deployment_id  String,
+    provider       LowCardinality(String),
+    repo_id        Nullable(UUID),
+    confidence     Float32,
+    source         LowCardinality(String),
+    evidence       String,
+    observed_at    DateTime64(3, 'UTC'),
+    computed_at    DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(observed_at)
+ORDER BY (org_id, pr_id, deployment_id, source)
+SETTINGS index_granularity = 8192;
+
+CREATE TABLE IF NOT EXISTS work_graph_deployment_incident_edges
+(
+    edge_id        String,
+    org_id         UUID,
+    deployment_id  String,
+    incident_id    String,
+    provider       LowCardinality(String),
+    repo_id        Nullable(UUID),
+    confidence     Float32,
+    source         LowCardinality(String),
+    evidence       String,
+    observed_at    DateTime64(3, 'UTC'),
+    computed_at    DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(observed_at)
+ORDER BY (org_id, deployment_id, incident_id, source)
+SETTINGS index_granularity = 8192;

--- a/src/dev_health_ops/models/ai_workflow.py
+++ b/src/dev_health_ops/models/ai_workflow.py
@@ -1,0 +1,140 @@
+"""Typed models for AI workflow evidence in the Work Graph.
+
+The model deliberately stores metadata only. It has no fields for raw prompts,
+sessions, transcripts, IDE telemetry, or keystrokes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import StrEnum
+from uuid import UUID
+
+
+class AIWorkflowRunKind(StrEnum):
+    CHAT_ASSISTED = "chat_assisted"
+    AGENT_AUTONOMOUS = "agent_autonomous"
+    UNKNOWN = "unknown"
+
+
+class AIWorkflowRunStatus(StrEnum):
+    COMPLETED = "completed"
+    FAILED = "failed"
+    RUNNING = "running"
+    UNKNOWN = "unknown"
+
+
+class AIWorkflowArtifactType(StrEnum):
+    PULL_REQUEST = "pull_request"
+    DIFF = "diff"
+
+
+@dataclass(frozen=True)
+class AIWorkflowRun:
+    run_id: str
+    org_id: UUID
+    provider: str
+    run_kind: AIWorkflowRunKind = AIWorkflowRunKind.UNKNOWN
+    status: AIWorkflowRunStatus | str | None = None
+    tool: str | None = None
+    model: str | None = None
+    actor: str | None = None
+    repo_id: UUID | None = None
+    prompts_redacted: bool = True
+    prompt_hash: str | None = None
+    prompt_length: int | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    observed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    @staticmethod
+    def hash_prompt(prompt: str) -> str:
+        return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+    def metadata_json(self) -> str:
+        return json.dumps(self.metadata, sort_keys=True, separators=(",", ":"))
+
+
+@dataclass(frozen=True)
+class AIWorkflowIssueEdge:
+    edge_id: str
+    org_id: UUID
+    issue_id: str
+    run_id: str
+    provider: str
+    confidence: float
+    source: str
+    evidence: str
+    observed_at: datetime
+    repo_id: UUID | None = None
+
+
+@dataclass(frozen=True)
+class AIWorkflowArtifactEdge:
+    edge_id: str
+    org_id: UUID
+    run_id: str
+    artifact_type: AIWorkflowArtifactType
+    artifact_id: str
+    provider: str
+    confidence: float
+    source: str
+    evidence: str
+    observed_at: datetime
+    repo_id: UUID | None = None
+
+
+@dataclass(frozen=True)
+class WorkGraphPRReviewOutcomeEdge:
+    edge_id: str
+    org_id: UUID
+    pr_id: str
+    review_outcome_id: str
+    provider: str
+    confidence: float
+    source: str
+    evidence: str
+    observed_at: datetime
+    outcome: str | None = None
+    repo_id: UUID | None = None
+
+
+@dataclass(frozen=True)
+class WorkGraphPRDeploymentEdge:
+    edge_id: str
+    org_id: UUID
+    pr_id: str
+    deployment_id: str
+    provider: str
+    confidence: float
+    source: str
+    evidence: str
+    observed_at: datetime
+    repo_id: UUID | None = None
+
+
+@dataclass(frozen=True)
+class WorkGraphDeploymentIncidentEdge:
+    edge_id: str
+    org_id: UUID
+    deployment_id: str
+    incident_id: str
+    provider: str
+    confidence: float
+    source: str
+    evidence: str
+    observed_at: datetime
+    repo_id: UUID | None = None
+
+
+AIWorkflowEdge = (
+    AIWorkflowIssueEdge
+    | AIWorkflowArtifactEdge
+    | WorkGraphPRReviewOutcomeEdge
+    | WorkGraphPRDeploymentEdge
+    | WorkGraphDeploymentIncidentEdge
+)

--- a/src/dev_health_ops/work_graph/ai_workflow.py
+++ b/src/dev_health_ops/work_graph/ai_workflow.py
@@ -1,0 +1,347 @@
+"""Typed loaders for AI workflow evidence in the Work Graph."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+AIWorkflowRootType = Literal["issue", "pr", "work_unit"]
+
+
+@dataclass(frozen=True)
+class AIWorkflowGraphNode:
+    """A node returned by AI workflow traversal."""
+
+    node_type: str
+    node_id: str
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AIWorkflowGraphEdge:
+    """A typed edge returned by AI workflow traversal."""
+
+    edge_id: str
+    source_type: str
+    source_id: str
+    target_type: str
+    target_id: str
+    edge_type: str
+    confidence: float
+    source: str
+    evidence: str
+    provider: str | None = None
+    repo_id: str | None = None
+
+
+@dataclass(frozen=True)
+class AIWorkflowTraversalResult:
+    """Partial AI workflow graph rooted at an issue, PR, or WorkUnit."""
+
+    root_type: str
+    root_id: str
+    nodes: list[AIWorkflowGraphNode]
+    edges: list[AIWorkflowGraphEdge]
+    partial: bool = False
+
+
+def _string(value: object | None) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _metadata(value: object | None) -> dict[str, object]:
+    if not value:
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _edge_from_row(row: dict[str, Any]) -> AIWorkflowGraphEdge:
+    return AIWorkflowGraphEdge(
+        edge_id=str(row.get("edge_id") or ""),
+        source_type=str(row.get("source_type") or ""),
+        source_id=str(row.get("source_id") or ""),
+        target_type=str(row.get("target_type") or ""),
+        target_id=str(row.get("target_id") or ""),
+        edge_type=str(row.get("edge_type") or ""),
+        confidence=float(row.get("confidence") or 0.0),
+        source=str(row.get("source") or ""),
+        evidence=str(row.get("evidence") or ""),
+        provider=_string(row.get("provider")),
+        repo_id=_string(row.get("repo_id")),
+    )
+
+
+def _node_key(node_type: str, node_id: str) -> tuple[str, str]:
+    return (node_type, node_id)
+
+
+def _add_node(
+    nodes: dict[tuple[str, str], AIWorkflowGraphNode],
+    node_type: str,
+    node_id: str,
+    metadata: dict[str, object] | None = None,
+) -> None:
+    if not node_id:
+        return
+    key = _node_key(node_type, node_id)
+    if key in nodes:
+        if metadata:
+            merged = {**nodes[key].metadata, **metadata}
+            nodes[key] = AIWorkflowGraphNode(node_type, node_id, merged)
+        return
+    nodes[key] = AIWorkflowGraphNode(node_type, node_id, metadata or {})
+
+
+async def load_ai_workflow_graph(
+    client: object,
+    org_id: str,
+    root_type: AIWorkflowRootType,
+    root_id: str,
+    *,
+    depth: int = 3,
+    limit: int = 100,
+) -> AIWorkflowTraversalResult:
+    """Load AI workflow evidence reachable from an issue, PR, or WorkUnit root.
+
+    The loader is intentionally lenient: missing ``ai_workflow_runs`` metadata does
+    not hide edges, and malformed JSON metadata is ignored rather than raised.
+    """
+
+    from dev_health_ops.api.queries.client import query_dicts
+
+    normalized_root_type = "issue" if root_type == "work_unit" else root_type
+    nodes: dict[tuple[str, str], AIWorkflowGraphNode] = {}
+    edges_by_id: dict[str, AIWorkflowGraphEdge] = {}
+    frontier = {_node_key(normalized_root_type, root_id)}
+    visited: set[tuple[str, str]] = set()
+    partial = False
+
+    _add_node(nodes, normalized_root_type, root_id)
+
+    for _ in range(max(depth, 0)):
+        current = [key for key in frontier if key not in visited]
+        if not current or len(edges_by_id) >= limit:
+            break
+        visited.update(current)
+
+        node_types = [node_type for node_type, _ in current]
+        node_ids = [node_id for _, node_id in current]
+        rows = await query_dicts(
+            client,
+            _AI_EDGE_UNION_QUERY,
+            {
+                "org_id": org_id,
+                "node_types": node_types,
+                "node_ids": node_ids,
+                "limit": max(limit - len(edges_by_id), 0),
+            },
+        )
+        if len(rows) >= max(limit - len(edges_by_id), 0):
+            partial = True
+
+        next_frontier: set[tuple[str, str]] = set()
+        for row in rows:
+            edge = _edge_from_row(row)
+            if not edge.edge_id or edge.edge_id in edges_by_id:
+                continue
+            edges_by_id[edge.edge_id] = edge
+            _add_node(nodes, edge.source_type, edge.source_id)
+            _add_node(nodes, edge.target_type, edge.target_id)
+            for key in (
+                _node_key(edge.source_type, edge.source_id),
+                _node_key(edge.target_type, edge.target_id),
+            ):
+                if key not in visited:
+                    next_frontier.add(key)
+        frontier = next_frontier
+
+    run_ids = [
+        node_id for node_type, node_id in nodes if node_type == "ai_workflow_run"
+    ]
+    if run_ids:
+        run_rows = await query_dicts(
+            client,
+            _AI_RUN_QUERY,
+            {"org_id": org_id, "run_ids": run_ids},
+        )
+        for row in run_rows:
+            run_id = str(row.get("run_id") or "")
+            metadata: dict[str, object] = {
+                "provider": str(row.get("provider") or ""),
+                "run_kind": str(row.get("run_kind") or "unknown"),
+                "status": str(row.get("status") or "unknown"),
+                "tool": str(row.get("tool") or ""),
+                "model": str(row.get("model") or ""),
+                "actor": str(row.get("actor") or ""),
+                "repo_id": str(row.get("repo_id") or ""),
+                "prompts_redacted": bool(row.get("prompts_redacted", True)),
+            }
+            metadata.update(_metadata(row.get("metadata")))
+            _add_node(nodes, "ai_workflow_run", run_id, metadata)
+
+    return AIWorkflowTraversalResult(
+        root_type=root_type,
+        root_id=root_id,
+        nodes=list(nodes.values()),
+        edges=list(edges_by_id.values()),
+        partial=partial,
+    )
+
+
+async def load_ai_workflow_graph_for_issue(
+    client: object,
+    org_id: str,
+    issue_id: str,
+    *,
+    depth: int = 3,
+    limit: int = 100,
+) -> AIWorkflowTraversalResult:
+    return await load_ai_workflow_graph(
+        client, org_id, "issue", issue_id, depth=depth, limit=limit
+    )
+
+
+async def load_ai_workflow_graph_for_pr(
+    client: object,
+    org_id: str,
+    pr_id: str,
+    *,
+    depth: int = 3,
+    limit: int = 100,
+) -> AIWorkflowTraversalResult:
+    return await load_ai_workflow_graph(
+        client, org_id, "pr", pr_id, depth=depth, limit=limit
+    )
+
+
+async def load_ai_workflow_graph_for_work_unit(
+    client: object,
+    org_id: str,
+    work_unit_id: str,
+    *,
+    depth: int = 3,
+    limit: int = 100,
+) -> AIWorkflowTraversalResult:
+    return await load_ai_workflow_graph(
+        client, org_id, "work_unit", work_unit_id, depth=depth, limit=limit
+    )
+
+
+_AI_RUN_QUERY = """
+    SELECT
+        run_id,
+        provider,
+        run_kind,
+        status,
+        tool,
+        model,
+        actor,
+        toString(repo_id) AS repo_id,
+        prompts_redacted,
+        metadata
+    FROM ai_workflow_runs
+    WHERE org_id = %(org_id)s AND run_id IN %(run_ids)s
+"""
+
+_AI_EDGE_UNION_QUERY = """
+    SELECT * FROM
+    (
+        SELECT
+            edge_id,
+            'issue' AS source_type,
+            issue_id AS source_id,
+            'ai_workflow_run' AS target_type,
+            run_id AS target_id,
+            'has_ai_workflow' AS edge_type,
+            confidence,
+            source,
+            evidence,
+            provider,
+            toString(repo_id) AS repo_id
+        FROM ai_workflow_issue_edges
+        WHERE org_id = %(org_id)s
+
+        UNION ALL
+
+        SELECT
+            edge_id,
+            'ai_workflow_run' AS source_type,
+            run_id AS source_id,
+            if(artifact_type = 'pull_request', 'pr', artifact_type) AS target_type,
+            artifact_id AS target_id,
+            'generates' AS edge_type,
+            confidence,
+            source,
+            evidence,
+            provider,
+            toString(repo_id) AS repo_id
+        FROM ai_workflow_artifact_edges
+        WHERE org_id = %(org_id)s
+
+        UNION ALL
+
+        SELECT
+            edge_id,
+            'pr' AS source_type,
+            pr_id AS source_id,
+            'review_outcome' AS target_type,
+            review_outcome_id AS target_id,
+            'has_review_outcome' AS edge_type,
+            confidence,
+            source,
+            evidence,
+            provider,
+            toString(repo_id) AS repo_id
+        FROM work_graph_pr_review_outcome_edges
+        WHERE org_id = %(org_id)s
+
+        UNION ALL
+
+        SELECT
+            edge_id,
+            'pr' AS source_type,
+            pr_id AS source_id,
+            'deployment' AS target_type,
+            deployment_id AS target_id,
+            'deploys' AS edge_type,
+            confidence,
+            source,
+            evidence,
+            provider,
+            toString(repo_id) AS repo_id
+        FROM work_graph_pr_deployment_edges
+        WHERE org_id = %(org_id)s
+
+        UNION ALL
+
+        SELECT
+            edge_id,
+            'deployment' AS source_type,
+            deployment_id AS source_id,
+            'incident' AS target_type,
+            incident_id AS target_id,
+            'linked_incident' AS edge_type,
+            confidence,
+            source,
+            evidence,
+            provider,
+            toString(repo_id) AS repo_id
+        FROM work_graph_deployment_incident_edges
+        WHERE org_id = %(org_id)s
+    )
+    WHERE
+        (source_type IN %(node_types)s AND source_id IN %(node_ids)s)
+        OR (target_type IN %(node_types)s AND target_id IN %(node_ids)s)
+    LIMIT %(limit)s
+"""

--- a/src/dev_health_ops/work_graph/extractors/ai_workflow.py
+++ b/src/dev_health_ops/work_graph/extractors/ai_workflow.py
@@ -1,0 +1,306 @@
+"""Extract AI workflow Work Graph entities from normalized artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+from dev_health_ops.models.ai_attribution import AIAttributionSignal
+from dev_health_ops.models.ai_workflow import (
+    AIWorkflowArtifactEdge,
+    AIWorkflowArtifactType,
+    AIWorkflowIssueEdge,
+    AIWorkflowRun,
+    AIWorkflowRunKind,
+    AIWorkflowRunStatus,
+    WorkGraphDeploymentIncidentEdge,
+    WorkGraphPRDeploymentEdge,
+    WorkGraphPRReviewOutcomeEdge,
+)
+from dev_health_ops.providers._ai_detection import (
+    AuthorInfo,
+    detect_from_author,
+    detect_from_branch_name,
+    detect_from_pr_body,
+    detect_from_pr_labels,
+)
+
+
+@dataclass(frozen=True)
+class AIWorkflowExtractionResult:
+    """AI workflow entities and edges emitted by the extractor."""
+
+    runs: list[AIWorkflowRun] = field(default_factory=list)
+    issue_edges: list[AIWorkflowIssueEdge] = field(default_factory=list)
+    artifact_edges: list[AIWorkflowArtifactEdge] = field(default_factory=list)
+    review_outcome_edges: list[WorkGraphPRReviewOutcomeEdge] = field(
+        default_factory=list
+    )
+    pr_deployment_edges: list[WorkGraphPRDeploymentEdge] = field(default_factory=list)
+    deployment_incident_edges: list[WorkGraphDeploymentIncidentEdge] = field(
+        default_factory=list
+    )
+
+
+def _hash(*parts: object) -> str:
+    canonical = "|".join("" if part is None else str(part) for part in parts)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _str(row: dict[str, Any], key: str, default: str = "") -> str:
+    value = row.get(key)
+    return default if value is None else str(value)
+
+
+def _int_str(row: dict[str, Any], key: str) -> str:
+    value = row.get(key)
+    return (
+        ""
+        if value is None
+        else str(int(value))
+        if isinstance(value, int)
+        else str(value)
+    )
+
+
+def _dt(row: dict[str, Any], *keys: str) -> datetime:
+    for key in keys:
+        value = row.get(key)
+        if isinstance(value, datetime):
+            return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    return _now()
+
+
+def _signals_from_pr(row: dict[str, Any]) -> list[AIAttributionSignal]:
+    signals: list[AIAttributionSignal] = []
+    labels_raw = row.get("labels") or []
+    labels = (
+        [str(label) for label in labels_raw] if isinstance(labels_raw, list) else []
+    )
+    signals.extend(detect_from_pr_labels(labels))
+
+    author_name = _str(row, "author_name") or _str(row, "author_login")
+    if author_name:
+        author_signal = detect_from_author(
+            AuthorInfo(
+                login=author_name,
+                user_type=_str(row, "author_user_type"),
+                app_slug=_str(row, "author_app_slug"),
+            )
+        )
+        if author_signal:
+            signals.append(author_signal)
+
+    branch_signal = detect_from_branch_name(_str(row, "head_branch"))
+    if branch_signal:
+        signals.append(branch_signal)
+
+    body_signal = detect_from_pr_body(_str(row, "body"))
+    if body_signal:
+        signals.append(body_signal)
+
+    return signals
+
+
+def _run_kind(signal: AIAttributionSignal) -> AIWorkflowRunKind:
+    if str(signal.kind) == "agent_created":
+        return AIWorkflowRunKind.AGENT_AUTONOMOUS
+    if str(signal.kind) == "ai_assisted":
+        return AIWorkflowRunKind.CHAT_ASSISTED
+    return AIWorkflowRunKind.UNKNOWN
+
+
+def extract_ai_workflow_from_pull_requests(
+    pull_requests: list[dict[str, Any]],
+    *,
+    org_id: UUID,
+    provider: str,
+    issue_ids_by_pr: dict[str, list[str]] | None = None,
+) -> AIWorkflowExtractionResult:
+    """Create AI workflow runs and issue/PR edges from normalized PR rows.
+
+    Rows may be partial; missing metadata produces fewer fields, not exceptions.
+    ``issue_ids_by_pr`` keys are PR ids in ``repo_id:number`` form.
+    """
+
+    issue_ids_by_pr = issue_ids_by_pr or {}
+    result = AIWorkflowExtractionResult()
+
+    for row in pull_requests:
+        repo_id_raw = row.get("repo_id")
+        if repo_id_raw is None:
+            continue
+        repo_id = UUID(str(repo_id_raw))
+        pr_number = _int_str(row, "number")
+        if not pr_number:
+            continue
+        pr_id = f"{repo_id}:{pr_number}"
+        signals = _signals_from_pr(row)
+        if not signals:
+            continue
+
+        observed_at = _dt(row, "merged_at", "closed_at", "created_at", "last_synced")
+        strongest = max(signals, key=lambda signal: float(signal.confidence))
+        run_id = _hash(org_id, provider, "pull_request", pr_id, strongest.source)
+        result.runs.append(
+            AIWorkflowRun(
+                run_id=run_id,
+                org_id=org_id,
+                provider=provider,
+                run_kind=_run_kind(strongest),
+                status=AIWorkflowRunStatus.COMPLETED,
+                tool=strongest.actor,
+                actor=strongest.actor or _str(row, "author_name") or None,
+                repo_id=repo_id,
+                prompts_redacted=True,
+                started_at=_dt(row, "created_at", "last_synced"),
+                completed_at=_dt(row, "merged_at", "closed_at", "last_synced"),
+                observed_at=observed_at,
+                metadata={
+                    "subject_type": "pull_request",
+                    "subject_id": pr_id,
+                    "signals": [signal.evidence for signal in signals],
+                },
+            )
+        )
+        result.artifact_edges.append(
+            AIWorkflowArtifactEdge(
+                edge_id=_hash("ai_run_pr", org_id, run_id, pr_id),
+                org_id=org_id,
+                run_id=run_id,
+                artifact_type=AIWorkflowArtifactType.PULL_REQUEST,
+                artifact_id=pr_id,
+                provider=provider,
+                repo_id=repo_id,
+                confidence=float(strongest.confidence),
+                source=str(strongest.source),
+                evidence=_json(strongest.evidence),
+                observed_at=observed_at,
+            )
+        )
+        for issue_id in issue_ids_by_pr.get(pr_id, []):
+            result.issue_edges.append(
+                AIWorkflowIssueEdge(
+                    edge_id=_hash("issue_ai_run", org_id, issue_id, run_id),
+                    org_id=org_id,
+                    issue_id=issue_id,
+                    run_id=run_id,
+                    provider=provider,
+                    repo_id=repo_id,
+                    confidence=float(strongest.confidence),
+                    source=str(strongest.source),
+                    evidence=_json({"pr_id": pr_id, "signal": strongest.evidence}),
+                    observed_at=observed_at,
+                )
+            )
+
+    return result
+
+
+def extract_review_deployment_incident_edges(
+    *,
+    org_id: UUID,
+    provider: str,
+    reviews: list[dict[str, Any]] | None = None,
+    deployments: list[dict[str, Any]] | None = None,
+    incidents: list[dict[str, Any]] | None = None,
+) -> AIWorkflowExtractionResult:
+    """Extract PR→review, PR→deployment, and deployment→incident edges."""
+
+    result = AIWorkflowExtractionResult()
+    for row in reviews or []:
+        repo_id_raw = row.get("repo_id")
+        number = _int_str(row, "number")
+        review_id = _str(row, "review_id")
+        if repo_id_raw is None or not number or not review_id:
+            continue
+        repo_id = UUID(str(repo_id_raw))
+        pr_id = f"{repo_id}:{number}"
+        result.review_outcome_edges.append(
+            WorkGraphPRReviewOutcomeEdge(
+                edge_id=_hash("pr_review", org_id, pr_id, review_id),
+                org_id=org_id,
+                pr_id=pr_id,
+                review_outcome_id=review_id,
+                outcome=_str(row, "state") or None,
+                provider=provider,
+                repo_id=repo_id,
+                confidence=1.0,
+                source="native",
+                evidence=_json({"review_id": review_id, "state": row.get("state")}),
+                observed_at=_dt(row, "submitted_at", "last_synced"),
+            )
+        )
+
+    deployments_by_repo: dict[str, list[str]] = {}
+    for row in deployments or []:
+        repo_id_raw = row.get("repo_id")
+        deployment_id = _str(row, "deployment_id")
+        pr_number_value = row.get("pull_request_number")
+        if repo_id_raw is None or not deployment_id:
+            continue
+        repo_id = UUID(str(repo_id_raw))
+        deployments_by_repo.setdefault(str(repo_id), []).append(deployment_id)
+        if pr_number_value is None:
+            continue
+        pr_id = f"{repo_id}:{pr_number_value}"
+        result.pr_deployment_edges.append(
+            WorkGraphPRDeploymentEdge(
+                edge_id=_hash("pr_deployment", org_id, pr_id, deployment_id),
+                org_id=org_id,
+                pr_id=pr_id,
+                deployment_id=deployment_id,
+                provider=provider,
+                repo_id=repo_id,
+                confidence=1.0,
+                source="native",
+                evidence=_json({"deployment_id": deployment_id}),
+                observed_at=_dt(
+                    row, "deployed_at", "finished_at", "started_at", "last_synced"
+                ),
+            )
+        )
+
+    for row in incidents or []:
+        repo_id_raw = row.get("repo_id")
+        incident_id = _str(row, "incident_id")
+        deployment_id = _str(row, "deployment_id")
+        if repo_id_raw is None or not incident_id:
+            continue
+        repo_id = UUID(str(repo_id_raw))
+        linked_deployments = (
+            [deployment_id]
+            if deployment_id
+            else deployments_by_repo.get(str(repo_id), [])
+        )
+        for linked_deployment_id in linked_deployments:
+            result.deployment_incident_edges.append(
+                WorkGraphDeploymentIncidentEdge(
+                    edge_id=_hash(
+                        "deployment_incident", org_id, linked_deployment_id, incident_id
+                    ),
+                    org_id=org_id,
+                    deployment_id=linked_deployment_id,
+                    incident_id=incident_id,
+                    provider=provider,
+                    repo_id=repo_id,
+                    confidence=1.0 if deployment_id else 0.3,
+                    source="native" if deployment_id else "heuristic",
+                    evidence=_json({"incident_id": incident_id}),
+                    observed_at=_dt(row, "started_at", "last_synced"),
+                )
+            )
+
+    return result

--- a/src/dev_health_ops/work_graph/models.py
+++ b/src/dev_health_ops/work_graph/models.py
@@ -19,6 +19,11 @@ class NodeType(str, Enum):
     FILE = "file"
     RELEASE = "release"
     FEATURE_FLAG = "feature_flag"
+    AI_WORKFLOW_RUN = "ai_workflow_run"
+    DIFF = "diff"
+    REVIEW_OUTCOME = "review_outcome"
+    DEPLOYMENT = "deployment"
+    INCIDENT = "incident"
 
 
 class EdgeType(str, Enum):
@@ -54,6 +59,13 @@ class EdgeType(str, Enum):
 
     # Cross-cutting impact relationships
     IMPACTS = "impacts"  # release/flag → telemetry signal
+
+    # AI workflow evidence relationships
+    HAS_AI_WORKFLOW = "has_ai_workflow"  # issue → AI workflow run
+    GENERATES = "generates"  # AI workflow run → diff/PR
+    HAS_REVIEW_OUTCOME = "has_review_outcome"  # PR → review outcome
+    DEPLOYS = "deploys"  # PR → deployment
+    LINKED_INCIDENT = "linked_incident"  # deployment → incident
 
 
 class Provenance(str, Enum):

--- a/tests/storage/test_ai_workflow.py
+++ b/tests/storage/test_ai_workflow.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from dev_health_ops.metrics.sinks.clickhouse.ai_workflow import (
+    AI_WORKFLOW_ARTIFACT_EDGE_COLUMNS,
+    AI_WORKFLOW_ISSUE_EDGE_COLUMNS,
+    AI_WORKFLOW_RUN_COLUMNS,
+    AIWorkflowMixin,
+    _artifact_edge_to_row,
+    _issue_edge_to_row,
+    _run_to_row,
+)
+from dev_health_ops.models.ai_workflow import (
+    AIWorkflowArtifactEdge,
+    AIWorkflowArtifactType,
+    AIWorkflowIssueEdge,
+    AIWorkflowRun,
+    AIWorkflowRunKind,
+)
+
+ORG = uuid4()
+REPO = uuid4()
+NOW = datetime(2026, 5, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class _FakeSink(AIWorkflowMixin):
+    def __init__(self) -> None:
+        self.client = MagicMock()
+
+
+def _row(columns: list[str], values: list[object]) -> dict[str, object]:
+    return dict(zip(columns, values))
+
+
+def test_ai_workflow_run_row_redacts_prompt_content() -> None:
+    run = AIWorkflowRun(
+        run_id="run-1",
+        org_id=ORG,
+        provider="github",
+        run_kind=AIWorkflowRunKind.AGENT_AUTONOMOUS,
+        repo_id=REPO,
+        prompts_redacted=True,
+        prompt_hash=AIWorkflowRun.hash_prompt("secret prompt"),
+        prompt_length=13,
+        observed_at=NOW,
+        metadata={"subject_id": "pr-1"},
+    )
+
+    row = _row(AI_WORKFLOW_RUN_COLUMNS, _run_to_row(run))
+
+    assert row["prompts_redacted"] is True
+    assert row["prompt_hash"] != "secret prompt"
+    assert "secret prompt" not in str(row)
+    forbidden_columns = {"prompt", "session", "transcript", "ide", "keystroke"}
+    assert forbidden_columns.isdisjoint(AI_WORKFLOW_RUN_COLUMNS)
+
+
+def test_ai_workflow_sink_writes_runs_and_edges() -> None:
+    sink = _FakeSink()
+    issue_edge = AIWorkflowIssueEdge(
+        edge_id="edge-issue",
+        org_id=ORG,
+        issue_id="CHAOS-1583",
+        run_id="run-1",
+        provider="github",
+        confidence=0.95,
+        source="pr_label",
+        evidence='{"label":"ai"}',
+        observed_at=NOW,
+        repo_id=REPO,
+    )
+    artifact_edge = AIWorkflowArtifactEdge(
+        edge_id="edge-artifact",
+        org_id=ORG,
+        run_id="run-1",
+        artifact_type=AIWorkflowArtifactType.PULL_REQUEST,
+        artifact_id=f"{REPO}:42",
+        provider="github",
+        confidence=0.95,
+        source="pr_label",
+        evidence='{"label":"ai"}',
+        observed_at=NOW,
+        repo_id=REPO,
+    )
+
+    sink.write_ai_workflow_issue_edges([issue_edge])
+    sink.write_ai_workflow_artifact_edges([artifact_edge])
+
+    first_call = sink.client.insert.call_args_list[0]
+    assert first_call.args[0] == "ai_workflow_issue_edges"
+    assert first_call.kwargs["column_names"] == AI_WORKFLOW_ISSUE_EDGE_COLUMNS
+    assert first_call.args[1][0][:-1] == _issue_edge_to_row(issue_edge)[:-1]
+
+    second_call = sink.client.insert.call_args_list[1]
+    assert second_call.args[0] == "ai_workflow_artifact_edges"
+    assert second_call.kwargs["column_names"] == AI_WORKFLOW_ARTIFACT_EDGE_COLUMNS
+    assert second_call.args[1][0][:-1] == _artifact_edge_to_row(artifact_edge)[:-1]

--- a/tests/work_graph/test_ai_workflow.py
+++ b/tests/work_graph/test_ai_workflow.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from dev_health_ops.work_graph.ai_workflow import (
+    load_ai_workflow_graph_for_issue,
+    load_ai_workflow_graph_for_pr,
+)
+from dev_health_ops.work_graph.extractors.ai_workflow import (
+    extract_ai_workflow_from_pull_requests,
+    extract_review_deployment_incident_edges,
+)
+from dev_health_ops.work_graph.models import (
+    EdgeType,
+    NodeType,
+    Provenance,
+    WorkGraphEdge,
+)
+
+ORG = uuid4()
+REPO = uuid4()
+NOW = datetime(2026, 5, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_extracts_ai_workflow_from_pr_without_raw_prompt_fields() -> None:
+    result = extract_ai_workflow_from_pull_requests(
+        [
+            {
+                "repo_id": REPO,
+                "number": 42,
+                "labels": ["agent-created"],
+                "author_name": "claude[bot]",
+                "author_user_type": "Bot",
+                "head_branch": "claude/chaos-1583",
+                "created_at": NOW,
+                "merged_at": NOW,
+            }
+        ],
+        org_id=ORG,
+        provider="github",
+        issue_ids_by_pr={f"{REPO}:42": ["CHAOS-1583"]},
+    )
+
+    assert len(result.runs) == 1
+    assert len(result.issue_edges) == 1
+    assert len(result.artifact_edges) == 1
+    run = result.runs[0]
+    assert run.prompts_redacted is True
+    serialized_run = str(run)
+    assert "transcript" not in serialized_run
+    assert "keystroke" not in serialized_run
+    assert result.issue_edges[0].issue_id == "CHAOS-1583"
+    assert result.artifact_edges[0].artifact_id == f"{REPO}:42"
+
+
+def test_extracts_pr_review_deployment_incident_edges_with_partial_links() -> None:
+    result = extract_review_deployment_incident_edges(
+        org_id=ORG,
+        provider="github",
+        reviews=[
+            {
+                "repo_id": REPO,
+                "number": 42,
+                "review_id": "review-1",
+                "state": "APPROVED",
+                "submitted_at": NOW,
+            }
+        ],
+        deployments=[
+            {
+                "repo_id": REPO,
+                "deployment_id": "deploy-1",
+                "pull_request_number": 42,
+                "deployed_at": NOW,
+            }
+        ],
+        incidents=[{"repo_id": REPO, "incident_id": "inc-1", "started_at": NOW}],
+    )
+
+    assert result.review_outcome_edges[0].review_outcome_id == "review-1"
+    assert result.pr_deployment_edges[0].deployment_id == "deploy-1"
+    assert result.deployment_incident_edges[0].incident_id == "inc-1"
+    assert result.deployment_incident_edges[0].confidence == 0.3
+
+
+def test_traversal_from_issue_root_loads_partial_ai_metadata() -> None:
+    edge_rows = [
+        {
+            "edge_id": "e1",
+            "source_type": "issue",
+            "source_id": "CHAOS-1583",
+            "target_type": "ai_workflow_run",
+            "target_id": "run-1",
+            "edge_type": "has_ai_workflow",
+            "confidence": 0.95,
+            "source": "pr_label",
+            "evidence": "label",
+            "provider": "github",
+            "repo_id": str(REPO),
+        },
+        {
+            "edge_id": "e2",
+            "source_type": "ai_workflow_run",
+            "source_id": "run-1",
+            "target_type": "pr",
+            "target_id": f"{REPO}:42",
+            "edge_type": "generates",
+            "confidence": 0.95,
+            "source": "pr_label",
+            "evidence": "label",
+            "provider": "github",
+            "repo_id": str(REPO),
+        },
+    ]
+    run_rows = [
+        {
+            "run_id": "run-1",
+            "provider": "github",
+            "run_kind": "agent_autonomous",
+            "status": None,
+            "tool": None,
+            "model": None,
+            "actor": None,
+            "repo_id": str(REPO),
+            "prompts_redacted": True,
+            "metadata": "not-json",
+        }
+    ]
+
+    async def fake_query(_client: object, query: str, _params: dict[str, object]):
+        if "FROM ai_workflow_runs" in query:
+            return run_rows
+        return edge_rows
+
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new=AsyncMock(side_effect=fake_query),
+    ):
+        result = asyncio.run(
+            load_ai_workflow_graph_for_issue(object(), str(ORG), "CHAOS-1583", depth=2)
+        )
+
+    assert {edge.edge_id for edge in result.edges} == {"e1", "e2"}
+    run_node = next(node for node in result.nodes if node.node_id == "run-1")
+    assert run_node.metadata["prompts_redacted"] is True
+    assert run_node.metadata["status"] == "unknown"
+
+
+def test_traversal_from_pr_root_reaches_review_deployment_incident() -> None:
+    pr_id = f"{REPO}:42"
+    edge_rows = [
+        {
+            "edge_id": "review-edge",
+            "source_type": "pr",
+            "source_id": pr_id,
+            "target_type": "review_outcome",
+            "target_id": "review-1",
+            "edge_type": "has_review_outcome",
+            "confidence": 1.0,
+            "source": "native",
+            "evidence": "review",
+            "provider": "github",
+            "repo_id": str(REPO),
+        },
+        {
+            "edge_id": "deploy-edge",
+            "source_type": "pr",
+            "source_id": pr_id,
+            "target_type": "deployment",
+            "target_id": "deploy-1",
+            "edge_type": "deploys",
+            "confidence": 1.0,
+            "source": "native",
+            "evidence": "deployment",
+            "provider": "github",
+            "repo_id": str(REPO),
+        },
+        {
+            "edge_id": "incident-edge",
+            "source_type": "deployment",
+            "source_id": "deploy-1",
+            "target_type": "incident",
+            "target_id": "inc-1",
+            "edge_type": "linked_incident",
+            "confidence": 0.3,
+            "source": "heuristic",
+            "evidence": "incident",
+            "provider": "github",
+            "repo_id": str(REPO),
+        },
+    ]
+
+    async def fake_query(_client: object, query: str, _params: dict[str, object]):
+        if "FROM ai_workflow_runs" in query:
+            return []
+        return edge_rows
+
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new=AsyncMock(side_effect=fake_query),
+    ):
+        result = asyncio.run(
+            load_ai_workflow_graph_for_pr(object(), str(ORG), pr_id, depth=2)
+        )
+
+    assert {edge.edge_type for edge in result.edges} == {
+        "has_review_outcome",
+        "deploys",
+        "linked_incident",
+    }
+    assert any(
+        node.node_type == "incident" and node.node_id == "inc-1"
+        for node in result.nodes
+    )
+
+
+def test_non_ai_work_graph_edge_record_shape_regression() -> None:
+    edge = WorkGraphEdge(
+        edge_id="edge-1",
+        source_type=NodeType.ISSUE,
+        source_id="CHAOS-1",
+        target_type=NodeType.PR,
+        target_id="repo:1",
+        edge_type=EdgeType.IMPLEMENTS,
+        provenance=Provenance.NATIVE,
+        confidence=1.0,
+        evidence="Closes CHAOS-1",
+        discovered_at=NOW,
+        last_synced=NOW,
+        event_ts=NOW,
+        day=NOW.date(),
+    )
+
+    assert edge.source_type.value == "issue"
+    assert edge.target_type.value == "pr"
+    assert edge.edge_type.value == "implements"
+    assert edge.evidence == "Closes CHAOS-1"


### PR DESCRIPTION
## Summary
Extends the Work Graph with AI workflow entities and their relationships so AI Impact views can drill into evidence.

## Entities & edges
- `ai_workflow_runs` (org_id, run_kind, tool/model, started/completed, status, repo_id, prompts_redacted)
- Edges: issue→ai_run, ai_run→pr_or_diff, pr→review_outcome, pr→deployment, deployment→incident
- Edges carry `confidence` + `source`

## Design
- Migration 037_ai_workgraph.sql (ReplacingMergeTree, append-only)
- Extractors emit nodes + edges; sink-only persistence
- Traversal helpers lenient to partial AI metadata
- Non-AI Work Graph paths unchanged (regression guard test included)

## Traversal entry points
- `load_ai_workflow_graph_for_issue(client, org_id, issue_id, depth=..., limit=...)`
- `load_ai_workflow_graph_for_pr(client, org_id, pr_id, depth=..., limit=...)`
- `load_ai_workflow_graph_for_work_unit(client, org_id, work_unit_id, depth=..., limit=...)`

## Non-goals respected
- No raw prompt / session capture
- No invasive IDE telemetry

## Verification
```
uv sync --extra dev && uv run pytest tests/work_graph/ tests/models/ tests/storage/ -x -q
uv run ruff check .
uv run ruff format --check .
uv run mypy src
```

SCREENSHOT-WAIVER: backend-only.

Closes CHAOS-1583