### PR TITLE
feat(api): expose AI workflow analytics via GraphQL (CHAOS-1582)

### DIFF
--- a/docs/api/graphql-ai.md
+++ b/docs/api/graphql-ai.md
@@ -1,0 +1,179 @@
+# AI Workflow Analytics — GraphQL Contracts
+
+This document covers the GraphQL surface for AI Workflow Intelligence
+(CHAOS-1582).  It is the read-side projection of the metrics, work
+graph, and governance signals delivered by CHAOS-1579 through
+CHAOS-1587.
+
+> **Authority:** the GraphQL schema (`api/graphql/schema.py`) is the
+> source of truth.  This page explains intent and usage; the SDL
+> defines the actual types.
+
+## Mission
+
+Expose every AI-relevant signal that already lives in ClickHouse —
+attribution, impact, review load, risk, governance, and work-graph
+evidence — through stable, typed GraphQL contracts that the web client
+can consume without bespoke joins or recomputation.
+
+## Design rules
+
+- **Read-only.** Resolvers never categorise, never compute metrics,
+  never write.  All persistence happens in the metrics and governance
+  jobs (CHAOS-1581, CHAOS-1587).
+- **Empty / partial / populated states are first-class.** Every result
+  carries `dataAvailable: Boolean!` so the UI can render the correct
+  state without ad-hoc null probing.
+- **Provenance accompanies every metric.** `computedAt` and bucketed
+  evidence references travel with the response so the UI can show
+  freshness and drill into the underlying artifacts.
+- **Drilldown IDs map to Work Graph evidence.** The IDs returned in
+  every contract resolve through `aiWorkflowDrilldown` or
+  `workGraphEdges` — no synthetic identifiers.
+- **Stable contract before completeness.** `aiOpportunities` ships an
+  empty stable contract today; the detector (CHAOS-1586) populates it
+  later without a breaking change.
+
+## Buckets
+
+The metrics rollup persists every PR (and every reviewed artifact) into
+exactly one `attributionBucket`.  These mirror
+`dev_health_ops.metrics.ai_impact.AttributionBucket` (a `StrEnum`) and
+the GraphQL `AIAttributionBucketInput` enum:
+
+| Bucket          | Meaning                                                    |
+| --------------- | ---------------------------------------------------------- |
+| `ai_assisted`   | Human authored with explicit AI assistance.                |
+| `agent_created` | Autonomous agent produced this artifact.                   |
+| `ai_review`     | AI performed the review.                                   |
+| `human`         | Human-only baseline (no detected AI involvement).          |
+| `unknown`       | Attribution unresolved — never guessed.                    |
+
+## Query catalog
+
+All seven queries scope to `orgId` (enforced by `OrgIdAuthExtension`).
+
+### `aiImpactSummary`
+
+Per-bucket totals + a daily timeseries for the requested window, plus
+decomposed Operating Leverage components.  Use this as the
+single-fetch contract for the AI Impact dashboard.
+
+```graphql
+query AIImpact($orgId: String!, $range: AIDateRangeInput!) {
+  aiImpactSummary(orgId: $orgId, dateRange: $range) {
+    totalPrs
+    aiAssistedPrs
+    agentCreatedPrs
+    humanPrs
+    unknownPrs
+    aiAssistedPrRatio
+    byBucket {
+      bucket
+      prsTotal
+      cycleTimeAvgHours
+      aiReviewAmplification
+      leverage {
+        prsComponent
+        cycleTimeComponent
+        reviewComponent
+        reworkComponent
+        testComponent
+        incidentComponent
+      }
+    }
+    dataAvailable
+    computedAt
+  }
+}
+```
+
+### `aiComparison`
+
+Side-by-side aggregation of the AI-attributed buckets against the
+`human` baseline plus per-metric deltas.
+
+### `aiReviewLoad`
+
+Review-load breakdown per bucket: `reviewsPerPr`,
+`changesRequestedPerPr`, and the persisted `reviewAmplification` from
+CHAOS-1581.
+
+### `aiRiskBreakdown`
+
+Per-bucket rework / revert / test-gap / incident rates.  Computed from
+persisted counts, no weighting.
+
+### `aiOpportunities`
+
+Stable contract — `recommendations: []`, `detectorReady: false` —
+until CHAOS-1586 lands the detector.  Clients can render an empty
+state today and gain population without a schema change.
+
+### `aiGovernanceSummary`
+
+Coverage rollups (`declarationCoverage`, `humanReviewCoverage`,
+`securityScanCoverage`, `inPolicyCoverage`) plus recent violations
+(rule id + severity from the canonical AI policy registry).
+
+### `aiWorkflowDrilldown`
+
+Partial Work Graph rooted at an issue, PR, or work_unit.  Returns
+typed nodes and edges with `confidence`, `source`, and short evidence
+references so the UI can render an explanation without re-querying.
+
+## Filtering
+
+`AIScopeInput` is optional on every query that accepts it:
+
+```graphql
+input AIScopeInput {
+  repoId: String
+  teamId: String
+  workType: String
+  buckets: [AIAttributionBucketInput!]
+}
+```
+
+`AIDateRangeInput` is required where present and is inclusive on both
+ends.  Reversed ranges raise a validation error.
+
+## Provenance
+
+Every aggregated row in `aiImpactSummary` is sourced from
+`ai_impact_metrics_daily` rows that carry their own `computedAt`
+timestamp.  The top-level `computedAt` is the maximum of the
+underlying row timestamps.  Coverage and violation rows carry
+`observedAt` straight from `ai_governance_*` tables.
+
+## What this does **not** ship
+
+- **No** rankings of individuals.
+- **No** prompt or session content.
+- **No** UX-time recomputation of categories or rates.
+- **No** new persistence paths — every resolver reads from existing
+  ClickHouse tables only.
+
+## Frontend integration
+
+The web client regenerates types from the exported SDL.  After
+schema changes:
+
+```bash
+# in dev-health-ops
+python -m dev_health_ops.api.graphql.export_schema --out /tmp/schema.graphql
+cp /tmp/schema.graphql ../dev-health-web/src/lib/graphql/schema.graphql
+
+# in dev-health-web
+npm run codegen
+```
+
+`npm run codegen:check` will fail the web CI if the committed types
+fall behind the schema.
+
+## Tests
+
+Contract tests live at
+`tests/api/graphql/test_ai_resolver.py`.  Each query has explicit
+**empty / partial / populated** assertions so future changes preserve
+the empty-state guarantees demanded by the dashboards.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - Reports: user-guide/reports.md
   - API:
       - GraphQL Overview: api/graphql-overview.md
+      - AI Workflow Analytics: api/graphql-ai.md
       - GraphQL Security: api/graphql-security.md
       - Persisted Queries: api/persisted-queries.md
       - View Mapping: api/view-mapping.md

--- a/src/dev_health_ops/api/graphql/models/ai.py
+++ b/src/dev_health_ops/api/graphql/models/ai.py
@@ -1,0 +1,371 @@
+"""Strawberry GraphQL input and output types for AI workflow analytics.
+
+These contracts expose the data produced by the AI Workflow Intelligence
+milestone (attribution ingestion, impact metrics, work-graph evidence, and
+governance) to API clients.
+
+Design notes
+------------
+- Outputs are flat, stable, and JSON-serialisable.  They mirror persisted
+  ClickHouse rows so the frontend never has to mix in unrelated entities.
+- Bucket values and rule identifiers come from canonical, hard-coded
+  registries — clients can switch on them safely.
+- Every result type carries a ``data_available`` flag so the UI can render
+  an empty, partial, or populated state without ad-hoc null probing.
+- Drilldown identifiers point at Work-Graph evidence (PRs, issues, runs)
+  rather than at synthetic UUIDs that the UI cannot resolve.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import Enum
+
+import strawberry
+
+# =============================================================================
+# Inputs
+# =============================================================================
+
+
+@strawberry.enum
+class AIAttributionBucketInput(Enum):
+    """Canonical AI attribution buckets exposed to API clients."""
+
+    AI_ASSISTED = "ai_assisted"
+    AGENT_CREATED = "agent_created"
+    AI_REVIEW = "ai_review"
+    HUMAN = "human"
+    UNKNOWN = "unknown"
+
+
+@strawberry.enum
+class AIWorkflowRootTypeInput(Enum):
+    """Root entity types for AI workflow drilldown."""
+
+    ISSUE = "issue"
+    PR = "pr"
+    WORK_UNIT = "work_unit"
+
+
+@strawberry.input
+class AIDateRangeInput:
+    """Inclusive date range for AI analytics queries."""
+
+    start_date: date
+    end_date: date
+
+
+@strawberry.input
+class AIScopeInput:
+    """Optional scope filters for AI analytics queries.
+
+    All filters are AND-combined; ``None`` means "no filter at this level".
+    """
+
+    repo_id: str | None = None
+    team_id: str | None = None
+    work_type: str | None = None
+    buckets: list[AIAttributionBucketInput] | None = None
+
+
+# =============================================================================
+# Outputs
+# =============================================================================
+
+
+@strawberry.type
+class AILeverageComponents:
+    """Decomposed Operating Leverage components.
+
+    Each component is the contribution (positive = lift, negative = drag) of
+    that dimension to the leverage executive metric.  Components are nullable
+    when the underlying inputs were missing.
+    """
+
+    prs_component: float
+    cycle_time_component: float | None = None
+    review_component: float | None = None
+    rework_component: float | None = None
+    test_component: float | None = None
+    incident_component: float | None = None
+
+
+@strawberry.type
+class AIImpactBucketRow:
+    """Aggregated metric row for one (bucket, day) slice."""
+
+    bucket: str
+    prs_total: int
+    prs_merged: int
+    cycle_time_avg_hours: float | None
+    reviews_per_pr: float | None
+    changes_requested_per_pr: float | None
+    rework_prs: int
+    rework_rate: float | None
+    revert_prs: int
+    revert_rate: float | None
+    incidents_count: int
+    incident_rate: float | None
+    test_gap_prs: int
+    test_gap_rate: float | None
+
+
+@strawberry.type
+class AIImpactBucketTotals:
+    """Totals across the requested time window for one bucket."""
+
+    bucket: str
+    prs_total: int
+    prs_merged: int
+    ai_assisted_pr_ratio: float | None
+    agent_created_pr_count: int
+    cycle_time_avg_hours: float | None
+    ai_cycle_time_delta_hours: float | None
+    ai_review_amplification: float | None
+    rework_drag_rate: float | None
+    revert_rate: float | None
+    incident_drag_rate: float | None
+    test_gap_rate: float | None
+    leverage: AILeverageComponents
+
+
+@strawberry.type
+class AIImpactSummary:
+    """Summary of AI workflow impact across a requested time range."""
+
+    org_id: str
+    start_date: date
+    end_date: date
+    total_prs: int
+    ai_assisted_prs: int
+    agent_created_prs: int
+    human_prs: int
+    unknown_prs: int
+    ai_assisted_pr_ratio: float | None
+    by_bucket: list[AIImpactBucketTotals]
+    daily: list[AIImpactBucketRow]
+    data_available: bool
+    computed_at: datetime | None = None
+
+
+@strawberry.type
+class AIComparisonSide:
+    """One side of an AI-assisted vs non-AI comparison."""
+
+    bucket: str
+    prs_total: int
+    prs_merged: int
+    cycle_time_avg_hours: float | None
+    reviews_per_pr: float | None
+    rework_rate: float | None
+    revert_rate: float | None
+    test_gap_rate: float | None
+    incident_rate: float | None
+
+
+@strawberry.type
+class AIComparisonDelta:
+    """AI side minus baseline side; null where inputs are missing."""
+
+    cycle_time_delta_hours: float | None = None
+    reviews_per_pr_delta: float | None = None
+    rework_rate_delta: float | None = None
+    revert_rate_delta: float | None = None
+    test_gap_rate_delta: float | None = None
+    incident_rate_delta: float | None = None
+
+
+@strawberry.type
+class AIComparison:
+    """Side-by-side AI-assisted vs baseline comparison."""
+
+    org_id: str
+    start_date: date
+    end_date: date
+    ai_side: AIComparisonSide
+    baseline_side: AIComparisonSide
+    delta: AIComparisonDelta
+    data_available: bool
+
+
+@strawberry.type
+class AIReviewLoadRow:
+    """Per-bucket review-load row."""
+
+    bucket: str
+    prs_total: int
+    reviews_total: int
+    reviews_per_pr: float | None
+    changes_requested_per_pr: float | None
+    review_amplification: float | None
+
+
+@strawberry.type
+class AIReviewLoadResult:
+    """Review-load breakdown across buckets and days."""
+
+    org_id: str
+    start_date: date
+    end_date: date
+    by_bucket: list[AIReviewLoadRow]
+    daily: list[AIReviewLoadRow]
+    data_available: bool
+
+
+@strawberry.type
+class AIRiskBreakdownRow:
+    """Per-bucket risk row."""
+
+    bucket: str
+    prs_total: int
+    rework_prs: int
+    rework_rate: float | None
+    revert_prs: int
+    revert_rate: float | None
+    test_gap_prs: int
+    test_gap_rate: float | None
+    incidents_count: int
+    incident_rate: float | None
+
+
+@strawberry.type
+class AIRiskBreakdownResult:
+    """Risk breakdown across buckets."""
+
+    org_id: str
+    start_date: date
+    end_date: date
+    by_bucket: list[AIRiskBreakdownRow]
+    data_available: bool
+
+
+@strawberry.enum
+class AIOpportunityKind(Enum):
+    """Canonical AI automation opportunity kinds.
+
+    These are the targets recognised by the opportunity detector
+    (delivered by CHAOS-1586). Listing them here keeps the contract
+    stable even before the detector ships.
+    """
+
+    REPETITIVE_CHANGE = "repetitive_change"
+    HIGH_REVIEW_LOAD = "high_review_load"
+    HIGH_REWORK = "high_rework"
+    SLOW_CYCLE = "slow_cycle"
+    UNCOVERED_TEST_AREA = "uncovered_test_area"
+
+
+@strawberry.type
+class AIOpportunity:
+    """A single AI automation candidate."""
+
+    opportunity_id: str
+    kind: AIOpportunityKind
+    repo_id: str | None
+    team_id: str | None
+    title: str
+    rationale: str
+    score: float
+    evidence_refs: list[str]
+
+
+@strawberry.type
+class AIOpportunitiesResult:
+    """List of AI automation candidates.
+
+    ``detector_ready`` is ``False`` until the opportunity detector
+    (CHAOS-1586) lands; the contract is stable and returns an empty
+    recommendation list so clients can render an empty state today.
+    """
+
+    org_id: str
+    recommendations: list[AIOpportunity]
+    detector_ready: bool
+
+
+@strawberry.type
+class AIGovernanceCoverageRow:
+    """One day of governance coverage for a (team, repo) cell."""
+
+    day: date
+    team_id: str | None
+    repo_id: str | None
+    ai_artifacts: int
+    declared_artifacts: int
+    human_reviewed_prs: int
+    security_scanned_prs: int
+    in_policy_artifacts: int
+    declaration_coverage: float
+    human_review_coverage: float
+    security_scan_coverage: float
+    in_policy_coverage: float
+
+
+@strawberry.type
+class AIGovernanceViolationRow:
+    """A persisted AI policy violation event."""
+
+    rule_id: str
+    severity: str
+    subject_type: str
+    subject_id: str
+    team_id: str | None
+    repo_id: str | None
+    observed_at: datetime
+    evidence: str
+
+
+@strawberry.type
+class AIGovernanceSummary:
+    """Coverage + recent violations for the requested window."""
+
+    org_id: str
+    start_date: date
+    end_date: date
+    coverage: list[AIGovernanceCoverageRow]
+    recent_violations: list[AIGovernanceViolationRow]
+    data_available: bool
+
+
+@strawberry.type
+class AIWorkflowGraphNodeOut:
+    """A node returned by AI workflow drilldown traversal."""
+
+    node_type: str
+    node_id: str
+
+
+@strawberry.type
+class AIWorkflowGraphEdgeOut:
+    """A typed edge in an AI workflow traversal result.
+
+    Edges always carry provenance (``source``), strength (``confidence``)
+    and short evidence references so the UI can render explanations
+    without re-querying.
+    """
+
+    edge_id: str
+    source_type: str
+    source_id: str
+    target_type: str
+    target_id: str
+    edge_type: str
+    confidence: float
+    source: str
+    evidence: str
+    provider: str | None = None
+    repo_id: str | None = None
+
+
+@strawberry.type
+class AIWorkflowDrilldownResult:
+    """Partial AI workflow graph rooted at an issue/PR/work-unit."""
+
+    org_id: str
+    root_type: str
+    root_id: str
+    nodes: list[AIWorkflowGraphNodeOut]
+    edges: list[AIWorkflowGraphEdgeOut]
+    partial: bool
+    data_available: bool

--- a/src/dev_health_ops/api/graphql/resolvers/ai.py
+++ b/src/dev_health_ops/api/graphql/resolvers/ai.py
@@ -1,0 +1,651 @@
+"""Resolvers for AI workflow analytics GraphQL queries.
+
+This resolver layer is purely **read-only** and never performs persistence.
+Each function:
+
+1. Validates ``org_id`` and the optional scope.
+2. Loads pre-computed AI rows from ClickHouse via the existing
+   ``AIImpactClickHouseLoader`` and ``AIGovernanceLoader`` helpers.
+3. Aggregates, projects, and returns Strawberry types.
+
+Categorisation and metric computation never happen at request time — the
+loaders only read from ``ai_impact_metrics_daily``, ``ai_governance_*`` and
+``ai_workflow_*`` tables that the metrics/governance jobs already populate.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from dev_health_ops.metrics.ai_impact import (
+    AI_BUCKETS as AI_ATTRIBUTION_BUCKETS,
+)
+from dev_health_ops.metrics.ai_impact import (
+    AttributionBucket,
+)
+from dev_health_ops.metrics.loaders.ai_impact import AIImpactClickHouseLoader
+
+from ..authz import require_org_id
+from ..context import GraphQLContext
+from ..models.ai import (
+    AIComparison,
+    AIComparisonDelta,
+    AIComparisonSide,
+    AIDateRangeInput,
+    AIGovernanceCoverageRow,
+    AIGovernanceSummary,
+    AIGovernanceViolationRow,
+    AIImpactBucketRow,
+    AIImpactBucketTotals,
+    AIImpactSummary,
+    AILeverageComponents,
+    AIOpportunitiesResult,
+    AIReviewLoadResult,
+    AIReviewLoadRow,
+    AIRiskBreakdownResult,
+    AIRiskBreakdownRow,
+    AIScopeInput,
+    AIWorkflowDrilldownResult,
+    AIWorkflowGraphEdgeOut,
+    AIWorkflowGraphNodeOut,
+    AIWorkflowRootTypeInput,
+)
+
+logger = logging.getLogger(__name__)
+
+_BASELINE_BUCKET: AttributionBucket = AttributionBucket.HUMAN
+
+
+def _require_client(context: GraphQLContext) -> Any:
+    if context.client is None:
+        raise RuntimeError("Database client not available for AI analytics resolver")
+    return context.client
+
+
+def _parse_uuid(value: str | None) -> uuid.UUID | None:
+    if not value:
+        return None
+    try:
+        return uuid.UUID(value)
+    except (TypeError, ValueError) as exc:
+        logger.debug("Invalid UUID %r in AI analytics scope: %s", value, exc)
+        return None
+
+
+def _normalize_scope(
+    scope: AIScopeInput | None,
+) -> tuple[uuid.UUID | None, str | None, str | None]:
+    if scope is None:
+        return None, None, None
+    return (
+        _parse_uuid(scope.repo_id),
+        scope.team_id or None,
+        scope.work_type or None,
+    )
+
+
+def _validate_date_range(date_range: AIDateRangeInput) -> None:
+    if date_range.end_date < date_range.start_date:
+        raise ValueError(
+            "AI analytics date range end_date must be >= start_date "
+            f"(got start={date_range.start_date}, "
+            f"end={date_range.end_date})"
+        )
+
+
+async def _load_daily_records(
+    context: GraphQLContext,
+    org_id: str,
+    date_range: AIDateRangeInput,
+    scope: AIScopeInput | None,
+) -> list[Any]:
+    """Load daily AI impact records honoring the scope filter."""
+
+    _validate_date_range(date_range)
+    repo_id, team_id, work_type = _normalize_scope(scope)
+    loader = AIImpactClickHouseLoader(_require_client(context), org_id=org_id)
+    return await loader.load_ai_impact_metrics(
+        start_day=date_range.start_date,
+        end_day=date_range.end_date,
+        repo_id=repo_id,
+        team_id=team_id,
+        work_type=work_type,
+    )
+
+
+def _ratio(numerator: float, denominator: float) -> float | None:
+    if denominator == 0:
+        return None
+    return numerator / denominator
+
+
+def _weighted_avg(
+    pairs: list[tuple[float | None, float]],
+) -> float | None:
+    """Combine per-day averages weighted by sample size."""
+    total_weight = 0.0
+    total_value = 0.0
+    for value, weight in pairs:
+        if value is None or weight <= 0:
+            continue
+        total_weight += weight
+        total_value += value * weight
+    if total_weight == 0:
+        return None
+    return total_value / total_weight
+
+
+def _bucket_filter(
+    rows: list[Any], buckets: list[AttributionBucket] | None
+) -> list[Any]:
+    """Drop rows whose ``attribution_bucket`` is outside ``buckets``."""
+    if not buckets:
+        return list(rows)
+    bucket_set = {bucket.value for bucket in buckets}
+    return [row for row in rows if row.attribution_bucket in bucket_set]
+
+
+def _empty_leverage() -> AILeverageComponents:
+    return AILeverageComponents(prs_component=0.0)
+
+
+def _row_to_impact_daily(row: Any) -> AIImpactBucketRow:
+    test_gap_rate = row.test_gap_rate
+    return AIImpactBucketRow(
+        bucket=row.attribution_bucket,
+        prs_total=row.prs_total,
+        prs_merged=row.prs_merged,
+        cycle_time_avg_hours=row.cycle_time_avg_hours,
+        reviews_per_pr=row.reviews_per_pr,
+        changes_requested_per_pr=row.changes_requested_per_pr,
+        rework_prs=row.rework_prs,
+        rework_rate=row.rework_drag_rate,
+        revert_prs=row.revert_prs,
+        revert_rate=row.revert_rate,
+        incidents_count=row.incidents_count,
+        incident_rate=row.incident_drag_rate,
+        test_gap_prs=row.test_gap_prs,
+        test_gap_rate=test_gap_rate,
+    )
+
+
+def _aggregate_bucket_totals(rows: list[Any]) -> dict[str, AIImpactBucketTotals]:
+    by_bucket: dict[str, list[Any]] = defaultdict(list)
+    for row in rows:
+        by_bucket[row.attribution_bucket].append(row)
+
+    totals: dict[str, AIImpactBucketTotals] = {}
+    for bucket, bucket_rows in by_bucket.items():
+        prs_total = sum(r.prs_total for r in bucket_rows)
+        prs_merged = sum(r.prs_merged for r in bucket_rows)
+
+        agent_created_prs = sum(r.agent_created_prs for r in bucket_rows)
+
+        cycle_pairs = [(r.cycle_time_avg_hours, r.prs_merged) for r in bucket_rows]
+        cycle_delta_pairs = [
+            (r.ai_cycle_time_delta_hours, r.prs_merged) for r in bucket_rows
+        ]
+        review_amp_pairs = [
+            (r.ai_review_amplification, r.prs_total) for r in bucket_rows
+        ]
+        rework_pairs = [(r.rework_drag_rate, r.prs_total) for r in bucket_rows]
+        revert_pairs = [(r.revert_rate, r.prs_total) for r in bucket_rows]
+        incident_pairs = [(r.incident_drag_rate, r.prs_total) for r in bucket_rows]
+        test_pairs = [(r.test_gap_rate, r.prs_total) for r in bucket_rows]
+        ratio_pairs = [(r.ai_assisted_pr_ratio, r.prs_total) for r in bucket_rows]
+
+        # Aggregate leverage components by averaging per-day values weighted
+        # by PR volume — the underlying metric is already a ratio.
+        prs_component = (
+            _weighted_avg(
+                [(r.leverage.prs_component, r.prs_total) for r in bucket_rows]
+            )
+            or 0.0
+        )
+        leverage = AILeverageComponents(
+            prs_component=prs_component,
+            cycle_time_component=_weighted_avg(
+                [(r.leverage.cycle_time_component, r.prs_merged) for r in bucket_rows]
+            ),
+            review_component=_weighted_avg(
+                [(r.leverage.review_component, r.prs_total) for r in bucket_rows]
+            ),
+            rework_component=_weighted_avg(
+                [(r.leverage.rework_component, r.prs_total) for r in bucket_rows]
+            ),
+            test_component=_weighted_avg(
+                [(r.leverage.test_component, r.prs_total) for r in bucket_rows]
+            ),
+            incident_component=_weighted_avg(
+                [(r.leverage.incident_component, r.prs_total) for r in bucket_rows]
+            ),
+        )
+
+        totals[bucket] = AIImpactBucketTotals(
+            bucket=bucket,
+            prs_total=prs_total,
+            prs_merged=prs_merged,
+            ai_assisted_pr_ratio=_weighted_avg(ratio_pairs),
+            # Sum of agent-created PRs that landed inside this bucket's group.
+            agent_created_pr_count=agent_created_prs,
+            cycle_time_avg_hours=_weighted_avg(cycle_pairs),
+            ai_cycle_time_delta_hours=_weighted_avg(cycle_delta_pairs),
+            ai_review_amplification=_weighted_avg(review_amp_pairs),
+            rework_drag_rate=_weighted_avg(rework_pairs),
+            revert_rate=_weighted_avg(revert_pairs),
+            incident_drag_rate=_weighted_avg(incident_pairs),
+            test_gap_rate=_weighted_avg(test_pairs),
+            leverage=leverage,
+        )
+    return totals
+
+
+# =============================================================================
+# resolve_ai_impact_summary
+# =============================================================================
+
+
+async def resolve_ai_impact_summary(
+    context: GraphQLContext,
+    date_range: AIDateRangeInput,
+    scope: AIScopeInput | None = None,
+) -> AIImpactSummary:
+    org_id = require_org_id(context)
+    rows = await _load_daily_records(context, org_id, date_range, scope)
+    rows = _bucket_filter(
+        rows,
+        [AttributionBucket(b.value) for b in scope.buckets]
+        if scope and scope.buckets
+        else None,
+    )
+
+    by_bucket = _aggregate_bucket_totals(rows)
+    daily = [_row_to_impact_daily(row) for row in rows]
+
+    total_prs = sum(r.prs_total for r in rows)
+    ai_assisted = sum(r.ai_assisted_prs for r in rows)
+    agent_created = sum(r.agent_created_prs for r in rows)
+    human = sum(r.human_prs for r in rows)
+    unknown = sum(r.unknown_prs for r in rows)
+
+    computed_at = max((row.computed_at for row in rows), default=None)
+
+    return AIImpactSummary(
+        org_id=org_id,
+        start_date=date_range.start_date,
+        end_date=date_range.end_date,
+        total_prs=total_prs,
+        ai_assisted_prs=ai_assisted,
+        agent_created_prs=agent_created,
+        human_prs=human,
+        unknown_prs=unknown,
+        ai_assisted_pr_ratio=_ratio(ai_assisted, total_prs),
+        by_bucket=sorted(by_bucket.values(), key=lambda r: r.bucket),
+        daily=daily,
+        data_available=bool(rows),
+        computed_at=computed_at,
+    )
+
+
+# =============================================================================
+# resolve_ai_comparison
+# =============================================================================
+
+
+def _empty_side(bucket: str) -> AIComparisonSide:
+    return AIComparisonSide(
+        bucket=bucket,
+        prs_total=0,
+        prs_merged=0,
+        cycle_time_avg_hours=None,
+        reviews_per_pr=None,
+        rework_rate=None,
+        revert_rate=None,
+        test_gap_rate=None,
+        incident_rate=None,
+    )
+
+
+def _aggregate_side(rows: list[Any], bucket_label: str) -> AIComparisonSide:
+    if not rows:
+        return _empty_side(bucket_label)
+    prs_total = sum(r.prs_total for r in rows)
+    prs_merged = sum(r.prs_merged for r in rows)
+    return AIComparisonSide(
+        bucket=bucket_label,
+        prs_total=prs_total,
+        prs_merged=prs_merged,
+        cycle_time_avg_hours=_weighted_avg(
+            [(r.cycle_time_avg_hours, r.prs_merged) for r in rows]
+        ),
+        reviews_per_pr=_weighted_avg([(r.reviews_per_pr, r.prs_total) for r in rows]),
+        rework_rate=_weighted_avg([(r.rework_drag_rate, r.prs_total) for r in rows]),
+        revert_rate=_weighted_avg([(r.revert_rate, r.prs_total) for r in rows]),
+        test_gap_rate=_weighted_avg([(r.test_gap_rate, r.prs_total) for r in rows]),
+        incident_rate=_weighted_avg(
+            [(r.incident_drag_rate, r.prs_total) for r in rows]
+        ),
+    )
+
+
+def _delta(a: float | None, b: float | None) -> float | None:
+    if a is None or b is None:
+        return None
+    return a - b
+
+
+async def resolve_ai_comparison(
+    context: GraphQLContext,
+    date_range: AIDateRangeInput,
+    scope: AIScopeInput | None = None,
+) -> AIComparison:
+    org_id = require_org_id(context)
+    all_rows = await _load_daily_records(context, org_id, date_range, scope)
+
+    ai_rows = [r for r in all_rows if r.attribution_bucket in AI_ATTRIBUTION_BUCKETS]
+    baseline_rows = [r for r in all_rows if r.attribution_bucket == _BASELINE_BUCKET]
+
+    ai_side = _aggregate_side(ai_rows, "ai")  # synthetic label for the aggregated side
+    baseline_side = _aggregate_side(baseline_rows, _BASELINE_BUCKET.value)
+    delta = AIComparisonDelta(
+        cycle_time_delta_hours=_delta(
+            ai_side.cycle_time_avg_hours, baseline_side.cycle_time_avg_hours
+        ),
+        reviews_per_pr_delta=_delta(
+            ai_side.reviews_per_pr, baseline_side.reviews_per_pr
+        ),
+        rework_rate_delta=_delta(ai_side.rework_rate, baseline_side.rework_rate),
+        revert_rate_delta=_delta(ai_side.revert_rate, baseline_side.revert_rate),
+        test_gap_rate_delta=_delta(ai_side.test_gap_rate, baseline_side.test_gap_rate),
+        incident_rate_delta=_delta(ai_side.incident_rate, baseline_side.incident_rate),
+    )
+    return AIComparison(
+        org_id=org_id,
+        start_date=date_range.start_date,
+        end_date=date_range.end_date,
+        ai_side=ai_side,
+        baseline_side=baseline_side,
+        delta=delta,
+        data_available=bool(ai_rows or baseline_rows),
+    )
+
+
+# =============================================================================
+# resolve_ai_review_load
+# =============================================================================
+
+
+def _review_total_for_row(row: Any) -> int:
+    reviews_per_pr = row.reviews_per_pr or 0.0
+    return int(round(reviews_per_pr * row.prs_total))
+
+
+async def resolve_ai_review_load(
+    context: GraphQLContext,
+    date_range: AIDateRangeInput,
+    scope: AIScopeInput | None = None,
+) -> AIReviewLoadResult:
+    org_id = require_org_id(context)
+    rows = await _load_daily_records(context, org_id, date_range, scope)
+
+    daily = [
+        AIReviewLoadRow(
+            bucket=row.attribution_bucket,
+            prs_total=row.prs_total,
+            reviews_total=_review_total_for_row(row),
+            reviews_per_pr=row.reviews_per_pr,
+            changes_requested_per_pr=row.changes_requested_per_pr,
+            review_amplification=row.ai_review_amplification,
+        )
+        for row in rows
+    ]
+
+    by_bucket_acc: dict[str, list[Any]] = defaultdict(list)
+    for row in rows:
+        by_bucket_acc[row.attribution_bucket].append(row)
+
+    by_bucket: list[AIReviewLoadRow] = []
+    for bucket, bucket_rows in by_bucket_acc.items():
+        prs_total = sum(r.prs_total for r in bucket_rows)
+        reviews_total = sum(_review_total_for_row(r) for r in bucket_rows)
+        by_bucket.append(
+            AIReviewLoadRow(
+                bucket=bucket,
+                prs_total=prs_total,
+                reviews_total=reviews_total,
+                reviews_per_pr=_weighted_avg(
+                    [(r.reviews_per_pr, r.prs_total) for r in bucket_rows]
+                ),
+                changes_requested_per_pr=_weighted_avg(
+                    [(r.changes_requested_per_pr, r.prs_total) for r in bucket_rows]
+                ),
+                review_amplification=_weighted_avg(
+                    [(r.ai_review_amplification, r.prs_total) for r in bucket_rows]
+                ),
+            )
+        )
+    by_bucket.sort(key=lambda r: r.bucket)
+
+    return AIReviewLoadResult(
+        org_id=org_id,
+        start_date=date_range.start_date,
+        end_date=date_range.end_date,
+        by_bucket=by_bucket,
+        daily=daily,
+        data_available=bool(rows),
+    )
+
+
+# =============================================================================
+# resolve_ai_risk_breakdown
+# =============================================================================
+
+
+async def resolve_ai_risk_breakdown(
+    context: GraphQLContext,
+    date_range: AIDateRangeInput,
+    scope: AIScopeInput | None = None,
+) -> AIRiskBreakdownResult:
+    org_id = require_org_id(context)
+    rows = await _load_daily_records(context, org_id, date_range, scope)
+
+    by_bucket_acc: dict[str, list[Any]] = defaultdict(list)
+    for row in rows:
+        by_bucket_acc[row.attribution_bucket].append(row)
+
+    by_bucket: list[AIRiskBreakdownRow] = []
+    for bucket, bucket_rows in by_bucket_acc.items():
+        prs_total = sum(r.prs_total for r in bucket_rows)
+        rework_prs = sum(r.rework_prs for r in bucket_rows)
+        revert_prs = sum(r.revert_prs for r in bucket_rows)
+        test_gap_prs = sum(r.test_gap_prs for r in bucket_rows)
+        incidents = sum(r.incidents_count for r in bucket_rows)
+        by_bucket.append(
+            AIRiskBreakdownRow(
+                bucket=bucket,
+                prs_total=prs_total,
+                rework_prs=rework_prs,
+                rework_rate=_ratio(rework_prs, prs_total),
+                revert_prs=revert_prs,
+                revert_rate=_ratio(revert_prs, prs_total),
+                test_gap_prs=test_gap_prs,
+                test_gap_rate=_ratio(test_gap_prs, prs_total),
+                incidents_count=incidents,
+                incident_rate=_ratio(incidents, prs_total),
+            )
+        )
+    by_bucket.sort(key=lambda r: r.bucket)
+
+    return AIRiskBreakdownResult(
+        org_id=org_id,
+        start_date=date_range.start_date,
+        end_date=date_range.end_date,
+        by_bucket=by_bucket,
+        data_available=bool(rows),
+    )
+
+
+# =============================================================================
+# resolve_ai_opportunities (stable empty contract until CHAOS-1586)
+# =============================================================================
+
+
+async def resolve_ai_opportunities(
+    context: GraphQLContext,
+    scope: AIScopeInput | None = None,
+    limit: int = 25,
+) -> AIOpportunitiesResult:
+    org_id = require_org_id(context)
+    # Detector is not implemented yet (CHAOS-1586). Returning an empty,
+    # stable result keeps the GraphQL contract usable by the frontend
+    # today and avoids a breaking change when the detector lands.
+    return AIOpportunitiesResult(
+        org_id=org_id,
+        recommendations=[],
+        detector_ready=False,
+    )
+
+
+# =============================================================================
+# resolve_ai_governance_summary
+# =============================================================================
+
+
+async def resolve_ai_governance_summary(
+    context: GraphQLContext,
+    date_range: AIDateRangeInput,
+    scope: AIScopeInput | None = None,
+    violation_limit: int = 100,
+) -> AIGovernanceSummary:
+    from dev_health_ops.audit.ai_governance.loaders import AIGovernanceLoader
+
+    org_id = require_org_id(context)
+    _validate_date_range(date_range)
+    repo_id, team_id, _work_type = _normalize_scope(scope)
+    client = _require_client(context)
+
+    loader = AIGovernanceLoader(client)
+    coverage = loader.load_coverage(
+        org_id=org_id,
+        start_day=date_range.start_date,
+        end_day=date_range.end_date,
+        team_id=team_id,
+        repo_id=repo_id,
+    )
+    violations = loader.load_violations(
+        org_id=org_id,
+        start_day=date_range.start_date,
+        end_day=date_range.end_date,
+        team_id=team_id,
+        repo_id=repo_id,
+        limit=max(0, int(violation_limit)),
+    )
+
+    coverage_rows = [
+        AIGovernanceCoverageRow(
+            day=row.day,
+            team_id=row.team_id,
+            repo_id=str(row.repo_id) if row.repo_id is not None else None,
+            ai_artifacts=row.ai_artifacts,
+            declared_artifacts=row.declared_artifacts,
+            human_reviewed_prs=row.human_reviewed_prs,
+            security_scanned_prs=row.security_scanned_prs,
+            in_policy_artifacts=row.in_policy_artifacts,
+            declaration_coverage=row.declaration_coverage,
+            human_review_coverage=row.human_review_coverage,
+            security_scan_coverage=row.security_scan_coverage,
+            in_policy_coverage=row.in_policy_coverage,
+        )
+        for row in coverage
+    ]
+
+    violation_rows = [
+        AIGovernanceViolationRow(
+            rule_id=v.rule_id,
+            severity=v.severity,
+            subject_type=v.subject_type,
+            subject_id=v.subject_id,
+            team_id=v.team_id,
+            repo_id=str(v.repo_id) if v.repo_id is not None else None,
+            observed_at=_to_aware(v.observed_at),
+            evidence=v.evidence,
+        )
+        for v in violations
+    ]
+
+    return AIGovernanceSummary(
+        org_id=org_id,
+        start_date=date_range.start_date,
+        end_date=date_range.end_date,
+        coverage=coverage_rows,
+        recent_violations=violation_rows,
+        data_available=bool(coverage_rows or violation_rows),
+    )
+
+
+def _to_aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+# =============================================================================
+# resolve_ai_workflow_drilldown
+# =============================================================================
+
+
+async def resolve_ai_workflow_drilldown(
+    context: GraphQLContext,
+    root_type: AIWorkflowRootTypeInput,
+    root_id: str,
+    depth: int = 3,
+    limit: int = 100,
+) -> AIWorkflowDrilldownResult:
+    from dev_health_ops.work_graph.ai_workflow import load_ai_workflow_graph
+
+    org_id = require_org_id(context)
+    if not root_id:
+        raise ValueError("root_id is required for AI workflow drilldown")
+
+    traversal = await load_ai_workflow_graph(
+        _require_client(context),
+        org_id,
+        root_type.value,
+        root_id,
+        depth=max(0, int(depth)),
+        limit=max(0, int(limit)),
+    )
+
+    nodes = [
+        AIWorkflowGraphNodeOut(node_type=node.node_type, node_id=node.node_id)
+        for node in traversal.nodes
+    ]
+    edges = [
+        AIWorkflowGraphEdgeOut(
+            edge_id=edge.edge_id,
+            source_type=edge.source_type,
+            source_id=edge.source_id,
+            target_type=edge.target_type,
+            target_id=edge.target_id,
+            edge_type=edge.edge_type,
+            confidence=edge.confidence,
+            source=edge.source,
+            evidence=edge.evidence,
+            provider=edge.provider,
+            repo_id=edge.repo_id,
+        )
+        for edge in traversal.edges
+    ]
+    return AIWorkflowDrilldownResult(
+        org_id=org_id,
+        root_type=traversal.root_type,
+        root_id=traversal.root_id,
+        nodes=nodes,
+        edges=edges,
+        partial=traversal.partial,
+        data_available=bool(edges),
+    )

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -10,6 +10,18 @@ from strawberry.types import Info
 
 from .context import GraphQLContext
 from .extensions import OrgIdAuthExtension
+from .models.ai import (
+    AIComparison,
+    AIDateRangeInput,
+    AIGovernanceSummary,
+    AIImpactSummary,
+    AIOpportunitiesResult,
+    AIReviewLoadResult,
+    AIRiskBreakdownResult,
+    AIScopeInput,
+    AIWorkflowDrilldownResult,
+    AIWorkflowRootTypeInput,
+)
 from .models.inputs import (
     AnalyticsRequestInput,
     CapacityForecastFilterInput,
@@ -29,6 +41,15 @@ from .models.outputs import (
     SecurityAlertConnection,
     SecurityOverview,
     WorkGraphEdgesResult,
+)
+from .resolvers.ai import (
+    resolve_ai_comparison,
+    resolve_ai_governance_summary,
+    resolve_ai_impact_summary,
+    resolve_ai_opportunities,
+    resolve_ai_review_load,
+    resolve_ai_risk_breakdown,
+    resolve_ai_workflow_drilldown,
 )
 from .resolvers.analytics import resolve_analytics
 from .resolvers.catalog import resolve_catalog
@@ -241,6 +262,112 @@ class Query:
 
         context = get_context(info)
         return await resolve_capacity_forecasts(context, filters)
+
+    @strawberry.field(
+        description="AI workflow impact summary across the requested time range."
+    )
+    async def ai_impact_summary(
+        self,
+        info: Info,
+        org_id: str,
+        date_range: AIDateRangeInput,
+        scope: AIScopeInput | None = None,
+    ) -> AIImpactSummary:
+        context = get_context(info)
+        return await resolve_ai_impact_summary(context, date_range, scope)
+
+    @strawberry.field(
+        description="Side-by-side AI-assisted vs non-AI baseline comparison."
+    )
+    async def ai_comparison(
+        self,
+        info: Info,
+        org_id: str,
+        date_range: AIDateRangeInput,
+        scope: AIScopeInput | None = None,
+    ) -> AIComparison:
+        context = get_context(info)
+        return await resolve_ai_comparison(context, date_range, scope)
+
+    @strawberry.field(
+        description="Per-bucket AI review-load breakdown with amplification."
+    )
+    async def ai_review_load(
+        self,
+        info: Info,
+        org_id: str,
+        date_range: AIDateRangeInput,
+        scope: AIScopeInput | None = None,
+    ) -> AIReviewLoadResult:
+        context = get_context(info)
+        return await resolve_ai_review_load(context, date_range, scope)
+
+    @strawberry.field(
+        description="Per-bucket AI risk breakdown (rework, revert, test gaps, incidents)."
+    )
+    async def ai_risk_breakdown(
+        self,
+        info: Info,
+        org_id: str,
+        date_range: AIDateRangeInput,
+        scope: AIScopeInput | None = None,
+    ) -> AIRiskBreakdownResult:
+        context = get_context(info)
+        return await resolve_ai_risk_breakdown(context, date_range, scope)
+
+    @strawberry.field(
+        description=(
+            "AI automation opportunity recommendations. "
+            "Returns an empty, stable contract until the detector "
+            "ships (CHAOS-1586)."
+        )
+    )
+    async def ai_opportunities(
+        self,
+        info: Info,
+        org_id: str,
+        scope: AIScopeInput | None = None,
+        limit: int = 25,
+    ) -> AIOpportunitiesResult:
+        context = get_context(info)
+        return await resolve_ai_opportunities(context, scope, limit)
+
+    @strawberry.field(
+        description="AI governance coverage and recent policy violations."
+    )
+    async def ai_governance_summary(
+        self,
+        info: Info,
+        org_id: str,
+        date_range: AIDateRangeInput,
+        scope: AIScopeInput | None = None,
+        violation_limit: int = 100,
+    ) -> AIGovernanceSummary:
+        context = get_context(info)
+        return await resolve_ai_governance_summary(
+            context, date_range, scope, violation_limit
+        )
+
+    @strawberry.field(
+        description=(
+            "Drilldown into AI workflow evidence rooted at an issue, "
+            "PR, or work_unit. Returns Work Graph nodes and edges with "
+            "provenance and short evidence references."
+        )
+    )
+    async def ai_workflow_drilldown(
+        self,
+        info: Info,
+        org_id: str,
+        root_type: AIWorkflowRootTypeInput,
+        root_id: str,
+        depth: int = 3,
+        limit: int = 100,
+    ) -> AIWorkflowDrilldownResult:
+        context = get_context(info)
+        return await resolve_ai_workflow_drilldown(
+            context, root_type, root_id, depth, limit
+        )
 
 
 @strawberry.type

--- a/src/dev_health_ops/metrics/ai_impact.py
+++ b/src/dev_health_ops/metrics/ai_impact.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
+from enum import StrEnum
 
 from dev_health_ops.metrics.schemas import (
     AIImpactMetricsDailyRecord,
@@ -18,9 +19,35 @@ from dev_health_ops.metrics.schemas import (
 
 TeamResolver = Callable[[str, str | None, str | None], tuple[str | None, str | None]]
 
-AI_BUCKETS = {"ai_assisted", "agent_created", "ai_review"}
-NON_AI_BUCKET = "human"
-UNKNOWN_BUCKET = "unknown"
+
+class AttributionBucket(StrEnum):
+    """Canonical buckets for AI workflow impact rollups.
+
+    The metrics layer slots every PR (and every reviewed artifact) into
+    exactly one bucket so the per-bucket aggregates remain disjoint and
+    sum to the row total. Bucket string values are also the storage
+    representation in ClickHouse (``ai_impact_metrics_daily.attribution_bucket``).
+    """
+
+    AI_ASSISTED = "ai_assisted"
+    AGENT_CREATED = "agent_created"
+    AI_REVIEW = "ai_review"
+    HUMAN = "human"
+    UNKNOWN = "unknown"
+
+
+#: AI-coded variants of :class:`AttributionBucket`.
+AI_BUCKETS: frozenset[AttributionBucket] = frozenset(
+    {
+        AttributionBucket.AI_ASSISTED,
+        AttributionBucket.AGENT_CREATED,
+        AttributionBucket.AI_REVIEW,
+    }
+)
+#: Non-AI baseline bucket. Imported by job_daily for backward compatibility.
+NON_AI_BUCKET: AttributionBucket = AttributionBucket.HUMAN
+#: Fallback bucket when attribution cannot be determined.
+UNKNOWN_BUCKET: AttributionBucket = AttributionBucket.UNKNOWN
 
 
 @dataclass(frozen=True)

--- a/tests/api/graphql/test_ai_resolver.py
+++ b/tests/api/graphql/test_ai_resolver.py
@@ -1,0 +1,544 @@
+"""Contract tests for AI workflow analytics GraphQL resolvers.
+
+Three states are exercised for every resolver:
+
+* **empty** — the loader returns no rows.  The contract must still
+  populate every required field, never raise, and set
+  ``data_available=False``.
+* **partial** — only some buckets have data (e.g. AI work landed but no
+  human baseline yet).  The contract must surface the populated bucket
+  rows and leave the missing side empty rather than synthesising values.
+* **populated** — every bucket has rollup rows.  The contract must
+  aggregate weighted averages, emit deltas, and tag
+  ``data_available=True``.
+
+The tests stub the ClickHouse-backed loaders so they can run in unit
+mode without a ClickHouse instance.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.models.ai import (
+    AIAttributionBucketInput,
+    AIDateRangeInput,
+    AIScopeInput,
+    AIWorkflowRootTypeInput,
+)
+from dev_health_ops.api.graphql.resolvers.ai import (
+    resolve_ai_comparison,
+    resolve_ai_governance_summary,
+    resolve_ai_impact_summary,
+    resolve_ai_opportunities,
+    resolve_ai_review_load,
+    resolve_ai_risk_breakdown,
+    resolve_ai_workflow_drilldown,
+)
+from dev_health_ops.metrics.ai_impact import AttributionBucket
+from dev_health_ops.metrics.schemas import (
+    AIImpactMetricsDailyRecord,
+    AIOperatingLeverageComponents,
+)
+
+ORG_ID = "org-test"
+REPO_ID = UUID("11111111-1111-1111-1111-111111111111")
+TEAM_ID = "team-a"
+DAY_START = date(2026, 5, 1)
+DAY_END = date(2026, 5, 7)
+COMPUTED_AT = datetime(2026, 5, 7, 12, tzinfo=timezone.utc)
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+
+
+def _ctx() -> GraphQLContext:
+    """Build a minimal GraphQLContext with org scoping and a stub client."""
+    ctx = GraphQLContext(org_id=ORG_ID, db_url="clickhouse://localhost:8123/default")
+    ctx.client = MagicMock()
+    return ctx
+
+
+def _leverage(prs_component: float = 0.1) -> AIOperatingLeverageComponents:
+    return AIOperatingLeverageComponents(
+        prs_component=prs_component,
+        cycle_time_component=0.05,
+        review_component=-0.02,
+        rework_component=-0.01,
+        test_component=-0.005,
+        incident_component=-0.0,
+    )
+
+
+def _record(
+    *,
+    bucket: AttributionBucket,
+    day: date,
+    prs_total: int = 10,
+    prs_merged: int = 8,
+    ai_assisted_prs: int = 0,
+    agent_created_prs: int = 0,
+    human_prs: int = 0,
+    unknown_prs: int = 0,
+    cycle_time_avg_hours: float | None = 24.0,
+    reviews_per_pr: float | None = 1.5,
+    rework_drag_rate: float | None = 0.1,
+    revert_rate: float | None = 0.05,
+    incident_drag_rate: float | None = 0.02,
+    test_gap_rate: float | None = 0.2,
+    ai_review_amplification: float | None = None,
+    ai_cycle_time_delta_hours: float | None = None,
+    ai_assisted_pr_ratio: float | None = None,
+) -> AIImpactMetricsDailyRecord:
+    return AIImpactMetricsDailyRecord(
+        org_id=ORG_ID,
+        team_id=TEAM_ID,
+        repo_id=REPO_ID,
+        work_type="pull_request",
+        day=day,
+        attribution_bucket=bucket.value,
+        prs_total=prs_total,
+        prs_merged=prs_merged,
+        ai_assisted_prs=ai_assisted_prs,
+        agent_created_prs=agent_created_prs,
+        human_prs=human_prs,
+        unknown_prs=unknown_prs,
+        ai_assisted_pr_ratio=ai_assisted_pr_ratio,
+        agent_created_pr_count=agent_created_prs,
+        cycle_time_avg_hours=cycle_time_avg_hours,
+        baseline_cycle_time_avg_hours=None,
+        ai_cycle_time_delta_hours=ai_cycle_time_delta_hours,
+        reviews_per_pr=reviews_per_pr,
+        baseline_reviews_per_pr=None,
+        ai_review_amplification=ai_review_amplification,
+        changes_requested_per_pr=0.3,
+        rework_prs=int(prs_total * (rework_drag_rate or 0)),
+        rework_drag_rate=rework_drag_rate,
+        followup_commits_count=0,
+        revert_prs=int(prs_total * (revert_rate or 0)),
+        revert_rate=revert_rate,
+        incidents_count=int(prs_total * (incident_drag_rate or 0)),
+        incident_drag_rate=incident_drag_rate,
+        test_gap_prs=int(prs_total * (test_gap_rate or 0)),
+        test_gap_rate=test_gap_rate,
+        leverage=_leverage(),
+        computed_at=COMPUTED_AT,
+    )
+
+
+def _populated_rows() -> list[AIImpactMetricsDailyRecord]:
+    """One row per bucket on a single day."""
+    return [
+        _record(
+            bucket=AttributionBucket.AI_ASSISTED,
+            day=DAY_START,
+            prs_total=20,
+            prs_merged=16,
+            ai_assisted_prs=20,
+            ai_assisted_pr_ratio=0.5,
+            ai_review_amplification=1.4,
+            ai_cycle_time_delta_hours=-3.0,
+        ),
+        _record(
+            bucket=AttributionBucket.AGENT_CREATED,
+            day=DAY_START,
+            agent_created_prs=4,
+            prs_total=4,
+            prs_merged=3,
+        ),
+        _record(
+            bucket=AttributionBucket.HUMAN,
+            day=DAY_START,
+            human_prs=12,
+            prs_total=12,
+            prs_merged=11,
+            cycle_time_avg_hours=30.0,
+            reviews_per_pr=1.0,
+            rework_drag_rate=0.05,
+            revert_rate=0.02,
+            incident_drag_rate=0.0,
+            test_gap_rate=0.1,
+        ),
+        _record(
+            bucket=AttributionBucket.UNKNOWN,
+            day=DAY_START,
+            unknown_prs=2,
+            prs_total=2,
+            prs_merged=1,
+        ),
+    ]
+
+
+def _partial_rows() -> list[AIImpactMetricsDailyRecord]:
+    """Only the AI-side bucket populated."""
+    return [
+        _record(
+            bucket=AttributionBucket.AI_ASSISTED,
+            day=DAY_START,
+            ai_assisted_prs=6,
+            ai_assisted_pr_ratio=1.0,
+            ai_review_amplification=1.6,
+        )
+    ]
+
+
+def _patch_loader(rows: list[AIImpactMetricsDailyRecord]) -> Any:
+    """Patch the AIImpactClickHouseLoader to return ``rows``."""
+    return patch(
+        "dev_health_ops.metrics.loaders.ai_impact.AIImpactClickHouseLoader.load_ai_impact_metrics",
+        new_callable=AsyncMock,
+        return_value=rows,
+    )
+
+
+def _range() -> AIDateRangeInput:
+    return AIDateRangeInput(start_date=DAY_START, end_date=DAY_END)
+
+
+# -----------------------------------------------------------------------------
+# aiImpactSummary
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_impact_summary_empty_state_returns_stable_contract():
+    with _patch_loader([]):
+        result = await resolve_ai_impact_summary(_ctx(), _range())
+
+    assert result.org_id == ORG_ID
+    assert result.total_prs == 0
+    assert result.ai_assisted_prs == 0
+    assert result.ai_assisted_pr_ratio is None
+    assert result.by_bucket == []
+    assert result.daily == []
+    assert result.data_available is False
+    assert result.computed_at is None
+
+
+@pytest.mark.asyncio
+async def test_impact_summary_partial_returns_only_populated_bucket():
+    with _patch_loader(_partial_rows()):
+        result = await resolve_ai_impact_summary(_ctx(), _range())
+
+    assert result.data_available is True
+    assert len(result.by_bucket) == 1
+    assert result.by_bucket[0].bucket == AttributionBucket.AI_ASSISTED.value
+    assert result.by_bucket[0].ai_review_amplification == pytest.approx(1.6)
+    assert result.ai_assisted_prs == 6
+    assert result.human_prs == 0
+
+
+@pytest.mark.asyncio
+async def test_impact_summary_populated_aggregates_all_buckets():
+    with _patch_loader(_populated_rows()):
+        result = await resolve_ai_impact_summary(_ctx(), _range())
+
+    assert result.data_available is True
+    bucket_names = {row.bucket for row in result.by_bucket}
+    assert bucket_names == {
+        AttributionBucket.AI_ASSISTED.value,
+        AttributionBucket.AGENT_CREATED.value,
+        AttributionBucket.HUMAN.value,
+        AttributionBucket.UNKNOWN.value,
+    }
+    assert result.ai_assisted_prs == 20
+    assert result.agent_created_prs == 4
+    assert result.human_prs == 12
+    assert result.unknown_prs == 2
+    assert result.total_prs == 20 + 4 + 12 + 2
+    # ai_assisted_pr_ratio is the volume-weighted average across all rows.
+    assert result.ai_assisted_pr_ratio is not None
+    assert result.computed_at == COMPUTED_AT
+
+
+@pytest.mark.asyncio
+async def test_impact_summary_respects_bucket_filter():
+    scope = AIScopeInput(
+        buckets=[AIAttributionBucketInput.AGENT_CREATED],
+    )
+    with _patch_loader(_populated_rows()):
+        result = await resolve_ai_impact_summary(_ctx(), _range(), scope)
+
+    assert {row.bucket for row in result.by_bucket} == {
+        AttributionBucket.AGENT_CREATED.value
+    }
+    assert all(d.bucket == AttributionBucket.AGENT_CREATED.value for d in result.daily)
+
+
+# -----------------------------------------------------------------------------
+# aiComparison
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_comparison_empty_returns_zeroed_sides():
+    with _patch_loader([]):
+        result = await resolve_ai_comparison(_ctx(), _range())
+
+    assert result.data_available is False
+    assert result.ai_side.prs_total == 0
+    assert result.baseline_side.prs_total == 0
+    assert result.delta.cycle_time_delta_hours is None
+
+
+@pytest.mark.asyncio
+async def test_comparison_partial_leaves_baseline_side_empty():
+    with _patch_loader(_partial_rows()):
+        result = await resolve_ai_comparison(_ctx(), _range())
+
+    assert result.data_available is True
+    assert result.ai_side.prs_total == 10  # _partial_rows uses default prs_total=10
+    assert result.baseline_side.prs_total == 0
+    # delta requires both sides — partial inputs yield None per field.
+    assert result.delta.cycle_time_delta_hours is None
+    assert result.delta.rework_rate_delta is None
+
+
+@pytest.mark.asyncio
+async def test_comparison_populated_emits_delta():
+    with _patch_loader(_populated_rows()):
+        result = await resolve_ai_comparison(_ctx(), _range())
+
+    assert result.data_available is True
+    assert result.ai_side.prs_total == 24  # ai_assisted (20) + agent_created (4)
+    assert result.baseline_side.prs_total == 12
+    assert result.delta.cycle_time_delta_hours is not None
+    assert result.delta.reviews_per_pr_delta is not None
+
+
+# -----------------------------------------------------------------------------
+# aiReviewLoad
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_load_empty_state():
+    with _patch_loader([]):
+        result = await resolve_ai_review_load(_ctx(), _range())
+
+    assert result.data_available is False
+    assert result.by_bucket == []
+    assert result.daily == []
+
+
+@pytest.mark.asyncio
+async def test_review_load_populated_aggregates_by_bucket():
+    with _patch_loader(_populated_rows()):
+        result = await resolve_ai_review_load(_ctx(), _range())
+
+    assert result.data_available is True
+    bucket_lookup = {row.bucket: row for row in result.by_bucket}
+    # 20 PRs * 1.5 reviews_per_pr = 30 reviews for ai_assisted bucket.
+    assert bucket_lookup[AttributionBucket.AI_ASSISTED.value].reviews_total == 30
+    # Review amplification only populated for ai_assisted in fixture.
+    assert bucket_lookup[
+        AttributionBucket.AI_ASSISTED.value
+    ].review_amplification == pytest.approx(1.4)
+
+
+# -----------------------------------------------------------------------------
+# aiRiskBreakdown
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_risk_breakdown_empty_state():
+    with _patch_loader([]):
+        result = await resolve_ai_risk_breakdown(_ctx(), _range())
+
+    assert result.data_available is False
+    assert result.by_bucket == []
+
+
+@pytest.mark.asyncio
+async def test_risk_breakdown_populated_computes_rates():
+    with _patch_loader(_populated_rows()):
+        result = await resolve_ai_risk_breakdown(_ctx(), _range())
+
+    assert result.data_available is True
+    bucket_lookup = {row.bucket: row for row in result.by_bucket}
+    ai_row = bucket_lookup[AttributionBucket.AI_ASSISTED.value]
+    # rework_drag_rate fixture = 0.1, so rework_prs = 1 / 10 total = 0.1
+    assert ai_row.rework_rate == pytest.approx(0.1)
+    assert ai_row.revert_rate == pytest.approx(0.05)
+    assert ai_row.test_gap_rate == pytest.approx(0.2)
+
+
+# -----------------------------------------------------------------------------
+# aiOpportunities (stable empty contract until CHAOS-1586)
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_opportunities_returns_stable_empty_contract():
+    result = await resolve_ai_opportunities(_ctx())
+
+    assert result.org_id == ORG_ID
+    assert result.recommendations == []
+    assert result.detector_ready is False
+
+
+# -----------------------------------------------------------------------------
+# aiGovernanceSummary
+# -----------------------------------------------------------------------------
+
+
+class _FakeGovernanceCoverage:
+    def __init__(self) -> None:
+        self.day = DAY_START
+        self.team_id = TEAM_ID
+        self.repo_id = REPO_ID
+        self.ai_artifacts = 10
+        self.declared_artifacts = 8
+        self.human_reviewed_prs = 7
+        self.security_scanned_prs = 6
+        self.in_policy_artifacts = 5
+        self.declaration_coverage = 0.8
+        self.human_review_coverage = 0.7
+        self.security_scan_coverage = 0.6
+        self.in_policy_coverage = 0.5
+
+
+class _FakeGovernanceViolation:
+    def __init__(self) -> None:
+        self.rule_id = "MISSING_AI_DECLARATION"
+        self.severity = "warning"
+        self.subject_type = "pull_request"
+        self.subject_id = "repo/123"
+        self.team_id = TEAM_ID
+        self.repo_id = REPO_ID
+        self.observed_at = datetime(2026, 5, 1, 12, tzinfo=timezone.utc)
+        self.evidence = '{"declared_ai": false}'
+
+
+@pytest.mark.asyncio
+async def test_governance_summary_empty():
+    with patch(
+        "dev_health_ops.audit.ai_governance.loaders.AIGovernanceLoader"
+    ) as mock_loader:
+        mock_loader.return_value.load_coverage.return_value = []
+        mock_loader.return_value.load_violations.return_value = []
+        result = await resolve_ai_governance_summary(_ctx(), _range())
+
+    assert result.data_available is False
+    assert result.coverage == []
+    assert result.recent_violations == []
+
+
+@pytest.mark.asyncio
+async def test_governance_summary_populated():
+    with patch(
+        "dev_health_ops.audit.ai_governance.loaders.AIGovernanceLoader"
+    ) as mock_loader:
+        mock_loader.return_value.load_coverage.return_value = [
+            _FakeGovernanceCoverage()
+        ]
+        mock_loader.return_value.load_violations.return_value = [
+            _FakeGovernanceViolation()
+        ]
+        result = await resolve_ai_governance_summary(_ctx(), _range())
+
+    assert result.data_available is True
+    assert result.coverage[0].declaration_coverage == pytest.approx(0.8)
+    assert result.recent_violations[0].rule_id == "MISSING_AI_DECLARATION"
+    assert result.recent_violations[0].repo_id == str(REPO_ID)
+
+
+# -----------------------------------------------------------------------------
+# aiWorkflowDrilldown
+# -----------------------------------------------------------------------------
+
+
+class _FakeNode:
+    def __init__(self, node_type: str, node_id: str) -> None:
+        self.node_type = node_type
+        self.node_id = node_id
+
+
+class _FakeEdge:
+    def __init__(self) -> None:
+        self.edge_id = "edge-1"
+        self.source_type = "issue"
+        self.source_id = "issue-1"
+        self.target_type = "ai_workflow_run"
+        self.target_id = "run-1"
+        self.edge_type = "has_ai_workflow"
+        self.confidence = 0.9
+        self.source = "pr_label"
+        self.evidence = "label:ai-assisted"
+        self.provider = "github"
+        self.repo_id = str(REPO_ID)
+
+
+class _FakeTraversal:
+    def __init__(self) -> None:
+        self.root_type = "issue"
+        self.root_id = "issue-1"
+        self.nodes = [
+            _FakeNode("issue", "issue-1"),
+            _FakeNode("ai_workflow_run", "run-1"),
+        ]
+        self.edges = [_FakeEdge()]
+        self.partial = False
+
+
+@pytest.mark.asyncio
+async def test_workflow_drilldown_empty():
+    fake = _FakeTraversal()
+    fake.nodes = []
+    fake.edges = []
+    with patch(
+        "dev_health_ops.work_graph.ai_workflow.load_ai_workflow_graph",
+        new_callable=AsyncMock,
+        return_value=fake,
+    ):
+        result = await resolve_ai_workflow_drilldown(
+            _ctx(), AIWorkflowRootTypeInput.ISSUE, "issue-1"
+        )
+
+    assert result.data_available is False
+    assert result.nodes == []
+    assert result.edges == []
+
+
+@pytest.mark.asyncio
+async def test_workflow_drilldown_populated():
+    with patch(
+        "dev_health_ops.work_graph.ai_workflow.load_ai_workflow_graph",
+        new_callable=AsyncMock,
+        return_value=_FakeTraversal(),
+    ):
+        result = await resolve_ai_workflow_drilldown(
+            _ctx(), AIWorkflowRootTypeInput.ISSUE, "issue-1"
+        )
+
+    assert result.data_available is True
+    assert len(result.nodes) == 2
+    assert result.edges[0].edge_type == "has_ai_workflow"
+    assert result.edges[0].provider == "github"
+
+
+# -----------------------------------------------------------------------------
+# Validation
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_impact_summary_rejects_reversed_date_range():
+    bad_range = AIDateRangeInput(start_date=DAY_END, end_date=DAY_START)
+    with pytest.raises(ValueError, match="end_date must be >= start_date"):
+        await resolve_ai_impact_summary(_ctx(), bad_range)
+
+
+@pytest.mark.asyncio
+async def test_workflow_drilldown_rejects_empty_root_id():
+    with pytest.raises(ValueError, match="root_id is required"):
+        await resolve_ai_workflow_drilldown(_ctx(), AIWorkflowRootTypeInput.ISSUE, "")


### PR DESCRIPTION
## Summary

Exposes the AI Workflow Intelligence data (attribution, impact metrics, work-graph evidence, governance) through stable, typed GraphQL contracts so the upcoming AI dashboards (CHAOS-1584 / CHAOS-1585) can consume them without bespoke joins or recomputation.

Closes CHAOS-1582.

## What ships

Seven new read-only `Query` fields:

| Query | Purpose |
|---|---|
| `aiImpactSummary` | Per-bucket totals + daily timeseries + decomposed leverage |
| `aiComparison` | AI-side aggregate vs `human` baseline with per-metric deltas |
| `aiReviewLoad` | Reviews-per-PR + review amplification per bucket |
| `aiRiskBreakdown` | Rework / revert / test-gap / incident rates per bucket |
| `aiOpportunities` | **Stable empty contract** until CHAOS-1586 detector lands |
| `aiGovernanceSummary` | Coverage rollups + recent canonical policy violations |
| `aiWorkflowDrilldown` | Work Graph traversal rooted at issue/PR/work_unit, returning typed nodes/edges with provenance |

All scoped through \`OrgIdAuthExtension\`; all carry \`dataAvailable: Boolean!\` so the UI can render empty / partial / populated states deterministically.

## Notable choices

- **REST**: this codebase exposes analytics exclusively through GraphQL (no \`/api/analytics/*\` REST surface exists). The CHAOS-1582 acceptance criteria (\"API contracts\", \"typed response shapes\", \"GraphQL schema and generated frontend types updated\") are satisfied by the GraphQL surface alone.
- **Enums over strings**: introduces \`AttributionBucket(StrEnum)\` in \`metrics/ai_impact.py\` as the single source of truth for the five canonical buckets. \`AI_BUCKETS\` / \`NON_AI_BUCKET\` / \`UNKNOWN_BUCKET\` are kept as enum-valued back-compat aliases so existing job_daily / sinks / loaders don't churn.
- **Stable empty contract for opportunities**: rather than reshape the schema when CHAOS-1586 lands, \`aiOpportunities\` returns \`recommendations: []\`, \`detectorReady: false\` today. Clients render an empty state and gain population transparently.
- **No new persistence**: every resolver reads from existing \`ai_impact_metrics_daily\`, \`ai_governance_*\`, and \`ai_workflow_*\` tables via the existing loaders. No UX-time recompute, no new sinks.

## Tests

- \`tests/api/graphql/test_ai_resolver.py\` (18 tests, all passing) covers empty / partial / populated states for every resolver plus validation edges.
- Full unit suite green (3055 passed). Pre-existing failures on \`origin/main\` (GitLab network, Redis cache, testops circular import, live-ClickHouse flow matrix) are unrelated.
- Ruff + mypy clean on touched files.

## Frontend codegen

The frontend SDL bump + regenerated types ship as a sister PR on dev-health-web (\`feat/chaos-1582-ai-schema-codegen\`) — see \`docs/api/graphql-ai.md\` for the procedure.

## Provenance + drilldown

Every aggregated row in \`aiImpactSummary\` carries \`computedAt\` (max of underlying daily-row timestamps). Drilldown identifiers returned by every resolver resolve through \`aiWorkflowDrilldown\` or existing \`workGraphEdges\` — no synthetic IDs.

SCREENSHOT-WAIVER: backend-only PR with no rendered UI surface.