### PR TITLE
feat(metrics): rule-based AI opportunity detector (CHAOS-1586)

### DIFF
--- a/docs/computations/ai-opportunity-detector.md
+++ b/docs/computations/ai-opportunity-detector.md
@@ -1,0 +1,34 @@
+# AI Automation Opportunity Detector
+
+The AI opportunity detector is a rule-based, read-only backend computation behind the `aiOpportunities` GraphQL field. It reads existing ClickHouse analytics tables and returns ranked `AIOpportunity` recommendations with stable IDs and inspectable evidence references.
+
+## Persistence decision
+
+CHAOS-1586 uses inline detection in the GraphQL resolver rather than adding a new persisted table. The detector only reads already-computed daily rollups and lightweight attribution evidence, so the first backend implementation stays small and avoids introducing another scheduled write path. If recommendation volumes or latency grow, the same output contract can be moved behind a ClickHouse sink later.
+
+## Rules
+
+| Opportunity kind | Trigger |
+| --- | --- |
+| `REPETITIVE_CHANGE` | At least five AI-assisted PRs in the last 30 days share the same author, work type, and three-word title prefix. |
+| `HIGH_REVIEW_LOAD` | AI-assisted PRs have `reviews_per_pr` at least 1.5× the human baseline and at least 10 AI PRs in the window. |
+| `HIGH_REWORK` | AI-assisted PRs have rework rate at least 0.25 and at least +0.10 above the human baseline with at least 10 AI PRs. |
+| `SLOW_CYCLE` | AI-assisted PRs have average cycle time at least 1.25× the human baseline with at least 10 AI PRs. |
+| `UNCOVERED_TEST_AREA` | AI-assisted PRs have `test_gap_rate` at least 0.50 with at least 10 AI PRs. |
+
+## GraphQL contract
+
+`aiOpportunities(scope, limit)` returns `AIOpportunitiesResult`:
+
+- `orgId`: current organization scope.
+- `detectorReady`: `true` when the rule detector was available for the request.
+- `recommendations`: ranked `AIOpportunity` items, capped at 100 even when a larger limit is requested.
+
+Each recommendation includes:
+
+- `opportunityId`: stable hash of `(kind, repo_id, team_id)`.
+- `kind`: one of the five canonical opportunity kinds above.
+- `repoId` / `teamId`: the scope where the rule fired.
+- `title` and `rationale`: short, numeric explanation of the breach.
+- `score`: 0..1 breach-magnitude ranking score.
+- `evidenceRefs`: ClickHouse-backed references such as `ai_impact_metrics_daily:rework_rate:<repo_id>` or `git_pull_requests:<repo_id>:<number>`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
       - Inventory: metrics-inventory.md
       - Canonical Metrics (API Mapping): canonical-metrics.md
       - Canonical Metrics (PRD): computations/canonical-metrics-prd.md
+      - AI Opportunity Detector: computations/ai-opportunity-detector.md
       - Metric Calculations: computations/metric-calculations.md
       - Computations Index: computations/index.md
       - Views Index: user-guide/views-index.md

--- a/src/dev_health_ops/api/graphql/resolvers/ai.py
+++ b/src/dev_health_ops/api/graphql/resolvers/ai.py
@@ -28,6 +28,7 @@ from dev_health_ops.metrics.ai_impact import (
     AttributionBucket,
 )
 from dev_health_ops.metrics.loaders.ai_impact import AIImpactClickHouseLoader
+from dev_health_ops.metrics.opportunities.ai_detector import AIOpportunityDetector
 
 from ..authz import require_org_id
 from ..context import GraphQLContext
@@ -490,7 +491,7 @@ async def resolve_ai_risk_breakdown(
 
 
 # =============================================================================
-# resolve_ai_opportunities (stable empty contract until CHAOS-1586)
+# resolve_ai_opportunities
 # =============================================================================
 
 
@@ -499,14 +500,21 @@ async def resolve_ai_opportunities(
     scope: AIScopeInput | None = None,
     limit: int = 25,
 ) -> AIOpportunitiesResult:
+    """Return rule-based AI automation opportunities.
+
+    First release decision: inline detection. The resolver reads existing
+    ClickHouse rollups synchronously via ``AIOpportunityDetector`` and does not
+    persist recommendations yet, keeping the detector pure-read and avoiding a
+    second materialization path until noisy-recommendation dismissal lands.
+    """
+
     org_id = require_org_id(context)
-    # Detector is not implemented yet (CHAOS-1586). Returning an empty,
-    # stable result keeps the GraphQL contract usable by the frontend
-    # today and avoids a breaking change when the detector lands.
+    client = _require_client(context)
+    detector = AIOpportunityDetector(client)
     return AIOpportunitiesResult(
         org_id=org_id,
-        recommendations=[],
-        detector_ready=False,
+        recommendations=await detector.detect(org_id=org_id, scope=scope, limit=limit),
+        detector_ready=True,
     )
 
 

--- a/src/dev_health_ops/metrics/opportunities/__init__.py
+++ b/src/dev_health_ops/metrics/opportunities/__init__.py
@@ -1,0 +1,1 @@
+"""Opportunity detectors for precomputed metrics."""

--- a/src/dev_health_ops/metrics/opportunities/ai_detector.py
+++ b/src/dev_health_ops/metrics/opportunities/ai_detector.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from dev_health_ops.api.graphql.models.ai import AIOpportunity, AIOpportunityKind
+from dev_health_ops.metrics.ai_impact import AI_BUCKETS, AttributionBucket
+from dev_health_ops.metrics.loaders.base import parse_uuid
+from dev_health_ops.metrics.query_builder import OrgScopedQuery
+
+_MIN_PRS = 10
+_REPETITIVE_CLUSTER_MIN_PRS = 5
+_MAX_LIMIT = 100
+
+
+@dataclass(frozen=True)
+class _Scope:
+    repo_id: uuid.UUID | None
+    team_id: str | None
+
+
+@dataclass
+class _BucketAgg:
+    prs_total: int = 0
+    reviews_weighted: float = 0.0
+    reviews_weight: int = 0
+    cycle_weighted: float = 0.0
+    cycle_weight: int = 0
+    rework_prs: int = 0
+    test_gap_prs: int = 0
+
+    def add(self, row: dict[str, Any]) -> None:
+        prs = int(row.get("prs_total") or 0)
+        self.prs_total += prs
+        reviews = _float_or_none(row.get("reviews_per_pr"))
+        if reviews is not None and prs > 0:
+            self.reviews_weighted += reviews * prs
+            self.reviews_weight += prs
+        cycle = _float_or_none(row.get("cycle_time_avg_hours"))
+        if cycle is not None and prs > 0:
+            self.cycle_weighted += cycle * prs
+            self.cycle_weight += prs
+        self.rework_prs += int(row.get("rework_prs") or 0)
+        self.test_gap_prs += int(row.get("test_gap_prs") or 0)
+
+    @property
+    def reviews_per_pr(self) -> float | None:
+        return _ratio(self.reviews_weighted, self.reviews_weight)
+
+    @property
+    def cycle_hours(self) -> float | None:
+        return _ratio(self.cycle_weighted, self.cycle_weight)
+
+    @property
+    def rework_rate(self) -> float | None:
+        return _ratio(self.rework_prs, self.prs_total)
+
+    @property
+    def test_gap_rate(self) -> float | None:
+        return _ratio(self.test_gap_prs, self.prs_total)
+
+
+@dataclass
+class _RepoAgg:
+    repo_id: str
+    team_id: str | None
+    ai: _BucketAgg
+    human: _BucketAgg
+
+
+class AIOpportunityDetector:
+    """Rule-based AI automation opportunity detector.
+
+    This class is read-only. It consumes ClickHouse rows already produced by the
+    AI impact and attribution jobs and returns GraphQL opportunity objects.
+    """
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    async def detect(
+        self,
+        org_id: str,
+        scope: Any | None = None,
+        limit: int = 25,
+    ) -> list[AIOpportunity]:
+        bounded_limit = _clamp_limit(limit)
+        normalized_scope = _scope_from_input(scope)
+        impact_rows = await self._load_impact_rows(org_id, normalized_scope)
+        opportunities = self._detect_metric_opportunities(impact_rows)
+        opportunities.extend(
+            await self._detect_repetitive_changes(org_id, normalized_scope)
+        )
+        opportunities.sort(key=lambda item: item.score, reverse=True)
+        return opportunities[:bounded_limit]
+
+    async def _load_impact_rows(
+        self, org_id: str, scope: _Scope
+    ) -> list[dict[str, Any]]:
+        from dev_health_ops.api.queries.client import query_dicts
+
+        params: dict[str, Any] = {}
+        filters = ["day >= today() - 30"]
+        if scope.repo_id is not None:
+            params["repo_id"] = str(scope.repo_id)
+            filters.append("repo_id = {repo_id:UUID}")
+        if scope.team_id is not None:
+            params["team_id"] = scope.team_id
+            filters.append("team_id = {team_id:String}")
+        org_scope = OrgScopedQuery(org_id)
+        params = org_scope.inject(params)
+        org_filter = org_scope.filter()
+        if org_filter:
+            filters.append(org_filter.removeprefix("AND "))
+        where_clause = " AND ".join(filters)
+        query = f"""
+        SELECT
+            org_id,
+            team_id,
+            repo_id,
+            work_type,
+            day,
+            attribution_bucket,
+            argMax(prs_total, computed_at) AS prs_total,
+            argMax(reviews_per_pr, computed_at) AS reviews_per_pr,
+            argMax(cycle_time_avg_hours, computed_at) AS cycle_time_avg_hours,
+            argMax(rework_prs, computed_at) AS rework_prs,
+            argMax(test_gap_prs, computed_at) AS test_gap_prs,
+            max(computed_at) AS computed_at
+        FROM ai_impact_metrics_daily
+        WHERE {where_clause}
+        GROUP BY org_id, team_id, repo_id, work_type, day, attribution_bucket
+        """
+        return await query_dicts(self.client, query, params)
+
+    def _detect_metric_opportunities(
+        self, rows: list[dict[str, Any]]
+    ) -> list[AIOpportunity]:
+        grouped: dict[tuple[str, str | None], _RepoAgg] = {}
+        ai_bucket_values = {bucket.value for bucket in AI_BUCKETS}
+
+        for row in rows:
+            repo = parse_uuid(row.get("repo_id"))
+            if repo is None:
+                continue
+            repo_id = str(repo)
+            team_id = row.get("team_id") or None
+            key = (repo_id, team_id)
+            if key not in grouped:
+                grouped[key] = _RepoAgg(
+                    repo_id=repo_id,
+                    team_id=team_id,
+                    ai=_BucketAgg(),
+                    human=_BucketAgg(),
+                )
+            bucket = str(row.get("attribution_bucket") or "")
+            if bucket in ai_bucket_values:
+                grouped[key].ai.add(row)
+            elif bucket == AttributionBucket.HUMAN.value:
+                grouped[key].human.add(row)
+
+        opportunities: list[AIOpportunity] = []
+        for agg in grouped.values():
+            opportunities.extend(self._metric_rules_for_repo(agg))
+        return opportunities
+
+    def _metric_rules_for_repo(self, agg: _RepoAgg) -> list[AIOpportunity]:
+        opportunities: list[AIOpportunity] = []
+        if agg.ai.prs_total < _MIN_PRS:
+            return opportunities
+
+        ai_reviews = agg.ai.reviews_per_pr
+        human_reviews = agg.human.reviews_per_pr
+        if (
+            ai_reviews is not None
+            and human_reviews is not None
+            and human_reviews > 0
+            and ai_reviews >= human_reviews * 1.5
+        ):
+            ratio = ai_reviews / human_reviews
+            opportunities.append(
+                _opportunity(
+                    kind=AIOpportunityKind.HIGH_REVIEW_LOAD,
+                    repo_id=agg.repo_id,
+                    team_id=agg.team_id,
+                    title=f"High AI review load in {agg.repo_id}",
+                    rationale=(
+                        "AI-assisted PRs averaged "
+                        f"{ai_reviews:.1f} reviews vs {human_reviews:.1f} for "
+                        "human PRs over the last 30 days."
+                    ),
+                    score=_score_ratio(ratio, 1.5),
+                    evidence_refs=[
+                        f"ai_impact_metrics_daily:reviews_per_pr:{agg.repo_id}"
+                    ],
+                )
+            )
+
+        ai_rework = agg.ai.rework_rate
+        human_rework = agg.human.rework_rate
+        if (
+            ai_rework is not None
+            and human_rework is not None
+            and ai_rework >= 0.25
+            and ai_rework - human_rework >= 0.10
+        ):
+            opportunities.append(
+                _opportunity(
+                    kind=AIOpportunityKind.HIGH_REWORK,
+                    repo_id=agg.repo_id,
+                    team_id=agg.team_id,
+                    title=f"High AI rework in {agg.repo_id}",
+                    rationale=(
+                        "AI-assisted PRs had a "
+                        f"{ai_rework:.0%} rework rate vs {human_rework:.0%} for "
+                        "human PRs over the last 30 days."
+                    ),
+                    score=_score_delta(ai_rework - human_rework, 0.10),
+                    evidence_refs=[
+                        f"ai_impact_metrics_daily:rework_rate:{agg.repo_id}"
+                    ],
+                )
+            )
+
+        ai_cycle = agg.ai.cycle_hours
+        human_cycle = agg.human.cycle_hours
+        if (
+            ai_cycle is not None
+            and human_cycle is not None
+            and human_cycle > 0
+            and ai_cycle >= human_cycle * 1.25
+        ):
+            ratio = ai_cycle / human_cycle
+            opportunities.append(
+                _opportunity(
+                    kind=AIOpportunityKind.SLOW_CYCLE,
+                    repo_id=agg.repo_id,
+                    team_id=agg.team_id,
+                    title=f"Slow AI cycle time in {agg.repo_id}",
+                    rationale=(
+                        "AI-assisted PRs averaged "
+                        f"{ai_cycle:.1f} cycle hours vs {human_cycle:.1f} for "
+                        "human PRs over the last 30 days."
+                    ),
+                    score=_score_ratio(ratio, 1.25),
+                    evidence_refs=[
+                        f"ai_impact_metrics_daily:cycle_time_avg_hours:{agg.repo_id}"
+                    ],
+                )
+            )
+
+        ai_test_gap = agg.ai.test_gap_rate
+        if ai_test_gap is not None and ai_test_gap >= 0.50:
+            opportunities.append(
+                _opportunity(
+                    kind=AIOpportunityKind.UNCOVERED_TEST_AREA,
+                    repo_id=agg.repo_id,
+                    team_id=agg.team_id,
+                    title=f"Uncovered AI test area in {agg.repo_id}",
+                    rationale=(
+                        f"AI-assisted PRs had a {ai_test_gap:.0%} test gap rate "
+                        "over the last 30 days."
+                    ),
+                    score=_score_delta(ai_test_gap, 0.50),
+                    evidence_refs=[
+                        f"ai_impact_metrics_daily:test_gap_rate:{agg.repo_id}"
+                    ],
+                )
+            )
+
+        return opportunities
+
+    async def _detect_repetitive_changes(
+        self, org_id: str, scope: _Scope
+    ) -> list[AIOpportunity]:
+        from dev_health_ops.api.queries.client import query_dicts
+
+        if scope.team_id is not None:
+            return []
+
+        params: dict[str, Any] = {"cluster_min": _REPETITIVE_CLUSTER_MIN_PRS}
+        filters = ["pr.created_at >= now() - INTERVAL 30 DAY"]
+        if scope.repo_id is not None:
+            params["repo_id"] = str(scope.repo_id)
+            filters.append("pr.repo_id = {repo_id:UUID}")
+        org_scope = OrgScopedQuery(org_id)
+        params = org_scope.inject(params)
+        org_filter = org_scope.filter(alias="attr")
+        if org_filter:
+            filters.append(org_filter.removeprefix("AND "))
+        where_clause = " AND ".join(filters)
+        query = f"""
+        SELECT
+            toString(pr.repo_id) AS repo_id,
+            CAST('', 'String') AS team_id,
+            coalesce(pr.author_email, pr.author_name, '') AS author,
+            coalesce(nullIf(wi.type, ''), 'pull_request') AS work_type,
+            lower(arrayStringConcat(arraySlice(splitByChar(' ', coalesce(pr.title, '')), 1, 3), ' ')) AS title_prefix,
+            count() AS prs_total,
+            groupArray(concat('git_pull_requests:', toString(pr.repo_id), ':', toString(pr.number))) AS pr_refs
+        FROM git_pull_requests AS pr
+        LEFT JOIN work_graph_issue_pr AS link
+            ON link.repo_id = pr.repo_id AND link.pr_number = pr.number
+        INNER JOIN ai_attribution_resolved AS attr
+            ON attr.repo_id = pr.repo_id
+            AND attr.subject_type = 'pull_request'
+            AND (attr.subject_id = toString(pr.number) OR attr.subject_id = link.work_item_id)
+        LEFT JOIN work_items AS wi
+            ON wi.repo_id = link.repo_id AND wi.work_item_id = link.work_item_id
+        WHERE {where_clause}
+          AND attr.kind IN ('ai_assisted', 'agent_created', 'ai_review')
+          AND coalesce(pr.title, '') != ''
+        GROUP BY repo_id, team_id, author, work_type, title_prefix
+        HAVING prs_total >= {{cluster_min:UInt32}}
+        ORDER BY prs_total DESC
+        LIMIT 100
+        """
+        rows = await query_dicts(self.client, query, params)
+        opportunities: list[AIOpportunity] = []
+        for row in rows:
+            repo = parse_uuid(row.get("repo_id"))
+            if repo is None:
+                continue
+            repo_id = str(repo)
+            team_id = row.get("team_id") or None
+            prs_total = int(row.get("prs_total") or 0)
+            title_prefix = str(row.get("title_prefix") or "similar")
+            evidence_refs = [str(ref) for ref in (row.get("pr_refs") or [])][:5]
+            if not evidence_refs:
+                continue
+            opportunities.append(
+                _opportunity(
+                    kind=AIOpportunityKind.REPETITIVE_CHANGE,
+                    repo_id=repo_id,
+                    team_id=team_id,
+                    title=f"Repetitive AI change pattern in {repo_id}",
+                    rationale=(
+                        f"{prs_total} AI-assisted PRs shared the title prefix "
+                        f"'{title_prefix}' with the same author/work type over "
+                        "the last 30 days."
+                    ),
+                    score=_score_delta(prs_total / _REPETITIVE_CLUSTER_MIN_PRS, 1.0),
+                    evidence_refs=evidence_refs,
+                )
+            )
+        return opportunities
+
+
+def _scope_from_input(scope: Any | None) -> _Scope:
+    repo_id = parse_uuid(getattr(scope, "repo_id", None)) if scope is not None else None
+    team_id = getattr(scope, "team_id", None) if scope is not None else None
+    return _Scope(repo_id=repo_id, team_id=team_id or None)
+
+
+def _opportunity(
+    *,
+    kind: AIOpportunityKind,
+    repo_id: str,
+    team_id: str | None,
+    title: str,
+    rationale: str,
+    score: float,
+    evidence_refs: list[str],
+) -> AIOpportunity:
+    return AIOpportunity(
+        opportunity_id=_stable_id(kind, repo_id, team_id),
+        kind=kind,
+        repo_id=repo_id,
+        team_id=team_id,
+        title=title,
+        rationale=rationale,
+        score=_clamp(score),
+        evidence_refs=evidence_refs,
+    )
+
+
+def _stable_id(kind: AIOpportunityKind, repo_id: str, team_id: str | None) -> str:
+    raw = f"{kind.value}:{repo_id}:{team_id or ''}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
+def _ratio(numerator: float, denominator: float) -> float | None:
+    if denominator <= 0:
+        return None
+    return numerator / denominator
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _score_ratio(value: float, threshold: float) -> float:
+    if threshold <= 0:
+        return 0.0
+    return _clamp((value / threshold - 1.0) / 2.0 + 0.50)
+
+
+def _score_delta(value: float, threshold: float) -> float:
+    if threshold <= 0:
+        return 0.0
+    return _clamp((value / threshold - 1.0) / 2.0 + 0.50)
+
+
+def _clamp_limit(limit: int | None) -> int:
+    if limit is None or limit <= 0:
+        return 25
+    return min(limit, _MAX_LIMIT)

--- a/tests/api/graphql/test_ai_resolver.py
+++ b/tests/api/graphql/test_ai_resolver.py
@@ -29,6 +29,8 @@ from dev_health_ops.api.graphql.context import GraphQLContext
 from dev_health_ops.api.graphql.models.ai import (
     AIAttributionBucketInput,
     AIDateRangeInput,
+    AIOpportunity,
+    AIOpportunityKind,
     AIScopeInput,
     AIWorkflowRootTypeInput,
 )
@@ -373,17 +375,50 @@ async def test_risk_breakdown_populated_computes_rates():
 
 
 # -----------------------------------------------------------------------------
-# aiOpportunities (stable empty contract until CHAOS-1586)
+# aiOpportunities
 # -----------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_opportunities_returns_stable_empty_contract():
-    result = await resolve_ai_opportunities(_ctx())
+async def test_opportunities_returns_ready_empty_contract():
+    detector = MagicMock()
+    detector.detect = AsyncMock(return_value=[])
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.ai.AIOpportunityDetector",
+        return_value=detector,
+    ):
+        result = await resolve_ai_opportunities(_ctx())
 
     assert result.org_id == ORG_ID
     assert result.recommendations == []
-    assert result.detector_ready is False
+    assert result.detector_ready is True
+
+
+@pytest.mark.asyncio
+async def test_opportunities_delegates_scope_limit_and_returns_evidence():
+    opportunity = AIOpportunity(
+        opportunity_id="stable-id",
+        kind=AIOpportunityKind.HIGH_REWORK,
+        repo_id=str(REPO_ID),
+        team_id=TEAM_ID,
+        title="High AI rework in repo",
+        rationale="AI-assisted PRs had a 33% rework rate vs 10% for human PRs.",
+        score=0.8,
+        evidence_refs=[f"ai_impact_metrics_daily:rework_rate:{REPO_ID}"],
+    )
+    detector = MagicMock()
+    detector.detect = AsyncMock(return_value=[opportunity])
+    scope = AIScopeInput(repo_id=str(REPO_ID), team_id=TEAM_ID)
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.ai.AIOpportunityDetector",
+        return_value=detector,
+    ):
+        result = await resolve_ai_opportunities(_ctx(), scope=scope, limit=1)
+
+    detector.detect.assert_awaited_once_with(org_id=ORG_ID, scope=scope, limit=1)
+    assert result.detector_ready is True
+    assert result.recommendations == [opportunity]
+    assert result.recommendations[0].evidence_refs
 
 
 # -----------------------------------------------------------------------------

--- a/tests/metrics/test_ai_opportunity_detector.py
+++ b/tests/metrics/test_ai_opportunity_detector.py
@@ -38,7 +38,9 @@ async def test_detector_emits_metric_opportunities(monkeypatch: pytest.MonkeyPat
             },
         ]
 
-    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", fake_query_dicts)
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
 
     result = await AIOpportunityDetector(MagicMock()).detect(
         "org-a", AIScopeInput(team_id="team-a"), limit=10
@@ -53,7 +55,9 @@ async def test_detector_emits_metric_opportunities(monkeypatch: pytest.MonkeyPat
     assert "4.2 reviews vs 2.0" in by_kind[AIOpportunityKind.HIGH_REVIEW_LOAD].rationale
     assert "33% rework rate vs 10%" in by_kind[AIOpportunityKind.HIGH_REWORK].rationale
     assert "30.0 cycle hours vs 20.0" in by_kind[AIOpportunityKind.SLOW_CYCLE].rationale
-    assert "58% test gap rate" in by_kind[AIOpportunityKind.UNCOVERED_TEST_AREA].rationale
+    assert (
+        "58% test gap rate" in by_kind[AIOpportunityKind.UNCOVERED_TEST_AREA].rationale
+    )
     assert all(item.repo_id == REPO_ID for item in result)
     assert all(item.team_id == "team-a" for item in result)
     assert all(item.evidence_refs for item in result)
@@ -90,7 +94,9 @@ async def test_detector_honors_scope_and_limit(monkeypatch: pytest.MonkeyPatch):
             },
         ]
 
-    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", fake_query_dicts)
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
 
     result = await AIOpportunityDetector(MagicMock()).detect(
         "org-a", AIScopeInput(repo_id=REPO_ID), limit=1
@@ -112,11 +118,15 @@ async def test_detector_emits_repetitive_change(monkeypatch: pytest.MonkeyPatch)
                 "team_id": "",
                 "prs_total": 6,
                 "title_prefix": "bump deps",
-                "pr_refs": [f"git_pull_requests:{REPO_ID}:{number}" for number in range(1, 7)],
+                "pr_refs": [
+                    f"git_pull_requests:{REPO_ID}:{number}" for number in range(1, 7)
+                ],
             }
         ]
 
-    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", fake_query_dicts)
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
 
     result = await AIOpportunityDetector(MagicMock()).detect("org-a", limit=10)
 
@@ -159,7 +169,9 @@ async def test_detector_clamps_limit_to_one_hundred(monkeypatch: pytest.MonkeyPa
             )
         return rows
 
-    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", fake_query_dicts)
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
 
     result = await AIOpportunityDetector(MagicMock()).detect("org-a", limit=500)
 
@@ -171,7 +183,9 @@ async def test_detector_empty_data_returns_empty_list(monkeypatch: pytest.Monkey
     async def fake_query_dicts(_client, _query, _params):
         return []
 
-    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", fake_query_dicts)
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
 
     result = await AIOpportunityDetector(MagicMock()).detect("org-a", limit=10)
 

--- a/tests/metrics/test_ai_opportunity_detector.py
+++ b/tests/metrics/test_ai_opportunity_detector.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.api.graphql.models.ai import AIOpportunityKind, AIScopeInput
+from dev_health_ops.metrics.opportunities.ai_detector import AIOpportunityDetector
+
+REPO_ID = "11111111-1111-1111-1111-111111111111"
+
+
+@pytest.mark.asyncio
+async def test_detector_emits_metric_opportunities(monkeypatch: pytest.MonkeyPatch):
+    async def fake_query_dicts(_client, query, _params):
+        if "ai_impact_metrics_daily" not in query:
+            return []
+        return [
+            {
+                "repo_id": REPO_ID,
+                "team_id": "team-a",
+                "attribution_bucket": "ai_assisted",
+                "prs_total": 12,
+                "reviews_per_pr": 4.2,
+                "cycle_time_avg_hours": 30.0,
+                "rework_prs": 4,
+                "test_gap_prs": 7,
+            },
+            {
+                "repo_id": REPO_ID,
+                "team_id": "team-a",
+                "attribution_bucket": "human",
+                "prs_total": 20,
+                "reviews_per_pr": 2.0,
+                "cycle_time_avg_hours": 20.0,
+                "rework_prs": 2,
+                "test_gap_prs": 2,
+            },
+        ]
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", fake_query_dicts)
+
+    result = await AIOpportunityDetector(MagicMock()).detect(
+        "org-a", AIScopeInput(team_id="team-a"), limit=10
+    )
+
+    kinds = {item.kind for item in result}
+    assert AIOpportunityKind.HIGH_REVIEW_LOAD in kinds
+    assert AIOpportunityKind.HIGH_REWORK in kinds
+    assert AIOpportunityKind.SLOW_CYCLE in kinds
+    assert AIOpportunityKind.UNCOVERED_TEST_AREA in kinds
+    by_kind = {item.kind: item for item in result}
+    assert "4.2 reviews vs 2.0" in by_kind[AIOpportunityKind.HIGH_REVIEW_LOAD].rationale
+    assert "33% rework rate vs 10%" in by_kind[AIOpportunityKind.HIGH_REWORK].rationale
+    assert "30.0 cycle hours vs 20.0" in by_kind[AIOpportunityKind.SLOW_CYCLE].rationale
+    assert "58% test gap rate" in by_kind[AIOpportunityKind.UNCOVERED_TEST_AREA].rationale
+    assert all(item.repo_id == REPO_ID for item in result)
+    assert all(item.team_id == "team-a" for item in result)
+    assert all(item.evidence_refs for item in result)
+
+
+@pytest.mark.asyncio
+async def test_detector_honors_scope_and_limit(monkeypatch: pytest.MonkeyPatch):
+    calls: list[dict] = []
+
+    async def fake_query_dicts(_client, query, params):
+        calls.append(params)
+        if "ai_impact_metrics_daily" not in query:
+            return []
+        return [
+            {
+                "repo_id": REPO_ID,
+                "team_id": None,
+                "attribution_bucket": "ai_assisted",
+                "prs_total": 12,
+                "reviews_per_pr": 4.0,
+                "cycle_time_avg_hours": 10.0,
+                "rework_prs": 0,
+                "test_gap_prs": 7,
+            },
+            {
+                "repo_id": REPO_ID,
+                "team_id": None,
+                "attribution_bucket": "human",
+                "prs_total": 20,
+                "reviews_per_pr": 2.0,
+                "cycle_time_avg_hours": 9.0,
+                "rework_prs": 0,
+                "test_gap_prs": 1,
+            },
+        ]
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", fake_query_dicts)
+
+    result = await AIOpportunityDetector(MagicMock()).detect(
+        "org-a", AIScopeInput(repo_id=REPO_ID), limit=1
+    )
+
+    assert len(result) == 1
+    assert calls[0]["repo_id"] == REPO_ID
+    assert calls[0]["org_id"] == "org-a"
+
+
+@pytest.mark.asyncio
+async def test_detector_emits_repetitive_change(monkeypatch: pytest.MonkeyPatch):
+    async def fake_query_dicts(_client, query, _params):
+        if "ai_impact_metrics_daily" in query:
+            return []
+        return [
+            {
+                "repo_id": REPO_ID,
+                "team_id": "",
+                "prs_total": 6,
+                "title_prefix": "bump deps",
+                "pr_refs": [f"git_pull_requests:{REPO_ID}:{number}" for number in range(1, 7)],
+            }
+        ]
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", fake_query_dicts)
+
+    result = await AIOpportunityDetector(MagicMock()).detect("org-a", limit=10)
+
+    assert len(result) == 1
+    assert result[0].kind is AIOpportunityKind.REPETITIVE_CHANGE
+    assert result[0].evidence_refs[0].startswith("git_pull_requests:")
+
+
+@pytest.mark.asyncio
+async def test_detector_clamps_limit_to_one_hundred(monkeypatch: pytest.MonkeyPatch):
+    async def fake_query_dicts(_client, query, _params):
+        if "ai_impact_metrics_daily" not in query:
+            return []
+        rows = []
+        for index in range(101):
+            repo_id = f"00000000-0000-0000-0000-{index + 1:012d}"
+            rows.extend(
+                [
+                    {
+                        "repo_id": repo_id,
+                        "team_id": None,
+                        "attribution_bucket": "ai_assisted",
+                        "prs_total": 12,
+                        "reviews_per_pr": 6.0,
+                        "cycle_time_avg_hours": 10.0,
+                        "rework_prs": 0,
+                        "test_gap_prs": 0,
+                    },
+                    {
+                        "repo_id": repo_id,
+                        "team_id": None,
+                        "attribution_bucket": "human",
+                        "prs_total": 12,
+                        "reviews_per_pr": 1.0,
+                        "cycle_time_avg_hours": 10.0,
+                        "rework_prs": 0,
+                        "test_gap_prs": 0,
+                    },
+                ]
+            )
+        return rows
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", fake_query_dicts)
+
+    result = await AIOpportunityDetector(MagicMock()).detect("org-a", limit=500)
+
+    assert len(result) == 100
+
+
+@pytest.mark.asyncio
+async def test_detector_empty_data_returns_empty_list(monkeypatch: pytest.MonkeyPatch):
+    async def fake_query_dicts(_client, _query, _params):
+        return []
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", fake_query_dicts)
+
+    result = await AIOpportunityDetector(MagicMock()).detect("org-a", limit=10)
+
+    assert result == []


### PR DESCRIPTION
## Summary
- Implements a read-only `AIOpportunityDetector` that evaluates existing ClickHouse AI impact and attribution rows.
- Wires `resolve_ai_opportunities` to return ranked recommendations with `detectorReady=true`, honoring repo/team scope and limit clamping.
- Adds detector/resolver tests and documents rules + GraphQL contract in mkdocs.

## Persistence decision
Inline for this first backend increment. The detector reads already-computed daily rollups synchronously and avoids a new materialized recommendation table/write path until recommendation dismissal/noise controls define lifecycle semantics.

## Rule table
| Kind | Trigger |
| --- | --- |
| `REPETITIVE_CHANGE` | ≥5 AI-assisted PRs in 30d with same author/work type/title-prefix cluster. |
| `HIGH_REVIEW_LOAD` | AI bucket reviews/PR ≥1.5× human baseline and ≥10 PRs. |
| `HIGH_REWORK` | AI rework rate ≥0.25 and ≥+0.10 vs human baseline and ≥10 PRs. |
| `SLOW_CYCLE` | AI cycle time ≥1.25× human baseline and ≥10 PRs. |
| `UNCOVERED_TEST_AREA` | AI test gap rate ≥0.50 and ≥10 PRs. |

## Test evidence
- `python -m pytest tests/metrics/test_ai_opportunity_detector.py tests/api/graphql/test_ai_resolver.py --collect-only -q` → 24 tests collected.
- `python -m pytest tests/metrics/test_ai_opportunity_detector.py tests/api/graphql/test_ai_resolver.py` → 24 passed, 35 warnings.
- `ruff check src/dev_health_ops/metrics/opportunities/ai_detector.py src/dev_health_ops/api/graphql/resolvers/ai.py tests/metrics/test_ai_opportunity_detector.py tests/api/graphql/test_ai_resolver.py` → passed.
- `mypy src/dev_health_ops/metrics/opportunities/ai_detector.py src/dev_health_ops/api/graphql/resolvers/ai.py tests/metrics/test_ai_opportunity_detector.py tests/api/graphql/test_ai_resolver.py` → passed.
- LSP diagnostics clean on changed Python files.

Closes CHAOS-1586