### PR TITLE
docs(ai): user-facing interpretation guide for AI Workflow Intelligence views (CHAOS-1588)

### DIFF
--- a/docs/user-guide/views/ai-attribution.md
+++ b/docs/user-guide/views/ai-attribution.md
@@ -1,0 +1,140 @@
+# AI Attribution
+
+This page is the **interpretation reference** for the attribution signals
+that power every AI Workflow Intelligence view. It explains what counts as
+AI-assisted, how confidence is recorded, what stays *unknown*, and — most
+importantly — the explicit guardrails on how this data may and may not be
+used.
+
+> If you read only one page in the AI section, read this one. The
+> dashboards make sense only when the attribution rules are understood.
+
+---
+
+## Buckets
+
+Every PR (and every reviewed artifact) lands in exactly one attribution
+bucket. The buckets are stable across resolvers, metrics, and storage:
+
+| Bucket          | Meaning                                                          |
+| --------------- | ---------------------------------------------------------------- |
+| `ai_assisted`   | Human-authored with explicit AI assistance.                      |
+| `agent_created` | Autonomous agent produced the artifact end-to-end.               |
+| `ai_review`     | AI performed the review.                                         |
+| `human`         | Human-only baseline; no detected AI involvement.                 |
+| `unknown`       | Attribution unresolved. **Never guessed.**                       |
+
+Buckets are mutually exclusive at the artifact level. Aggregates sum to
+the total artifact count on every resolver.
+
+---
+
+## P0 detection sources (CHAOS-1580)
+
+The ingestion path detects assistance from these provider signals, in
+**precedence order**:
+
+1. **Explicit PR labels.** `ai-assisted`, `agent-created`, `ai-review`,
+   and similar canonical labels override every weaker signal.
+2. **Bot / app authors.** Known agent identities (e.g. `app/devin-ai-…`,
+   `bot/copilot-…`) attribute the PR as `agent_created`.
+3. **Commit trailers.** `AI-Assisted-By:` and equivalent trailers attribute
+   the commits (and the PR through commit roll-up).
+4. **Branch naming conventions.** Branch prefixes like `agent/…`,
+   `copilot/…` contribute as a *secondary* signal.
+5. **PR description patterns** and **CI annotations** — secondary signals.
+
+Manual attribution (operator override) is preserved and always wins over
+auto-detection.
+
+---
+
+## Confidence
+
+Every inferred attribution carries a `confidence` value and a `source`
+field describing the strongest signal that produced the classification.
+
+| Source class      | Typical confidence | Interpretation                                       |
+| ----------------- | ------------------ | ---------------------------------------------------- |
+| `explicit_label`  | 1.0                | Operator or org has tagged this artifact directly.   |
+| `bot_author`      | 0.95               | Identified bot/app account is the author.            |
+| `commit_trailer`  | 0.85 – 0.9         | Trailer parsed cleanly from commit message.          |
+| `branch_pattern`  | 0.5 – 0.7          | Branch name matches a known agent prefix.            |
+| `pr_description`  | 0.5                | PR body contains assistance markers.                 |
+| `heuristic`       | 0.3                | Time-window / co-occurrence matching only.           |
+| `manual_override` | 1.0                | Operator set this attribution explicitly.            |
+
+If the strongest signal is weaker than the ingestion threshold, the
+artifact remains in `unknown` — it does **not** get demoted into a "maybe
+AI-assisted" bucket. Unknown is a first-class state, not a guess.
+
+---
+
+## What "unknown" really means
+
+`unknown` is preserved deliberately:
+
+- **In the API**: every resolver exposes the unknown count and ratio.
+- **In the UI**: the AI Impact dashboard surfaces an "Unknown attribution"
+  card so coverage gaps stay visible.
+- **In aggregates**: unknown contributes to denominators where appropriate
+  so AI-share percentages don't silently inflate.
+
+A high unknown rate is a **data-coverage signal first**, a pattern signal
+second. If unknown is climbing, the answer is usually missing labels,
+missing trailers, or a bot account that hasn't been added to the identity
+registry — not a usage trend.
+
+---
+
+## What this attribution model **explicitly does not do**
+
+The product contract (CHAOS-1578) bans the following uses. These bans are
+enforced by what the data model exposes — not just by policy:
+
+- ❌ **No individual surveillance.** There is no per-author AI usage
+  rollup. No resolver returns "AI assistance by login". No filter narrows
+  any AI view to a single person.
+- ❌ **No "AI productivity score" per person.** AI Operating Leverage is
+  org-scoped and decomposable; there is no per-person variant.
+- ❌ **No ranking of developers by AI use, AI-attributed quality, or any
+  AI-derived metric.** Aggregations stop at team granularity.
+- ❌ **No raw prompt or session capture.** Attribution uses only the
+  provider signals listed above. Prompt content is never ingested,
+  rendered, or persisted.
+- ❌ **No invasive IDE telemetry.** This milestone covers PR/commit/issue/
+  workflow-run signals, not editor session data.
+- ❌ **No "did you use AI?" surveys surfaced through this view.**
+  Self-attestation, if added later, will be a separate audited surface.
+
+These limits are encoded in the model — the [AI Governance audit](../../audit/ai_governance/)
+includes a `test_surveillance_posture` test suite that *fails* if a
+per-individual AI usage rollup is ever introduced.
+
+---
+
+## How to use this data well
+
+| ✅ Use for                                                          | ❌ Do not use for                                              |
+| ------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Understanding org-wide adoption trends.                             | Ranking developers by AI use.                                  |
+| Spotting review-load or quality patterns at team / repo scope.      | Performance reviews, calibration, or HR processes.             |
+| Sizing the impact of an agent rollout.                              | Justifying replacing specific individuals.                     |
+| Identifying coverage gaps to improve detection.                     | Naming-and-shaming PRs or contributors.                        |
+| Informing automation opportunity prioritization.                    | Gating individual merges based on AI attribution.              |
+
+If a stakeholder asks for "the list of who is using AI the most", the
+correct answer is to point them at this page and decline. The product
+will keep declining.
+
+---
+
+## Related
+
+- [AI Impact](ai-impact.md) — top-level summary view.
+- [AI Review Load](ai-review-load.md) — review pressure view.
+- [AI Risk](ai-risk.md) — quality risk view.
+- Attribution Storage spec — `docs/product/ai-assisted/Attribution Storage.md`
+- Attribution Ingestion spec — `docs/product/ai-assisted/Attribution Ingestion.md`
+- [AI Workflow Analytics — GraphQL Contracts](../../api/graphql-ai.md)
+- [AI Opportunity Detector computation reference](../../computations/ai-opportunity-detector.md)

--- a/docs/user-guide/views/ai-impact.md
+++ b/docs/user-guide/views/ai-impact.md
@@ -1,0 +1,121 @@
+# AI Impact
+
+The AI Impact view summarizes how AI-assisted and agent-created work
+**appear** to influence delivery, review pressure, quality, and operational
+drag at the **org level**. It is the top-level dashboard for the AI Workflow
+Intelligence feature (CHAOS-1578).
+
+> **Purpose:** Help leadership see whether AI-assisted workflows are
+> improving flow, shifting work into review or rework, or quietly increasing
+> operational risk. This is a *system-health* lens, not a productivity
+> ranking.
+
+---
+
+## What this view shows
+
+The dashboard renders org-scoped panels with three filter dimensions —
+**team**, **repo**, **work type** — plus a **date range**. All panels share
+the same scope at all times.
+
+### Headline cards
+
+| Card                       | What it answers                                                |
+| -------------------------- | -------------------------------------------------------------- |
+| AI-assisted work share     | What fraction of PRs lean AI-assisted in the selected scope?   |
+| Agent-created work share   | How many fully agent-authored PRs landed?                      |
+| Unknown attribution        | Where attribution remains undetermined and *stays unknown*.    |
+
+### Diagnostic panels
+
+| Panel                              | Reads from                                       |
+| ---------------------------------- | ------------------------------------------------ |
+| AI-assisted work share (donut)     | `aiImpactSummary.byBucket`                       |
+| Agent-created work share (trend)   | `aiImpactSummary.byBucket` + `.daily`            |
+| Net delivery lift                  | `aiImpactSummary.byBucket[AI_ASSISTED].leverage` |
+| Review amplification               | `aiComparison.delta.reviewsPerPrDelta`           |
+| Rework drag                        | `aiComparison.delta.reworkRateDelta`             |
+| Test gap rate                      | `aiComparison.delta.testGapRateDelta`            |
+| Revert + incident drag             | `aiComparison.delta.revertRateDelta` + `incidentRateDelta` |
+| Top affected repos and teams       | Placeholder until repo/team rollups ship         |
+| Best-fit automation opportunities  | `aiOpportunities.recommendations`                |
+
+Net delivery lift is rendered as **decomposable components** (PR volume,
+cycle time, review, rework, test, incident). The aggregate score is never
+shown as a black-box number — see the
+[AI Flow Metrics computation reference](../../computations/ai-opportunity-detector.md)
+and the [GraphQL contract](../../api/graphql-ai.md) for the underlying math.
+
+---
+
+## How to read it
+
+1. **Start with share, not delta.** A 60% AI-assisted share with a small
+   negative delta is a different signal than a 5% share with the same
+   delta.
+2. **Read deltas as direction, not verdict.** Deltas compare AI side to the
+   *human-only baseline* on the same scope and time window. A positive
+   review-amplification delta says "AI-attributed PRs appear to attract
+   more review comments per PR than human PRs *in this scope*", not "AI is
+   bad".
+3. **Keep the unknown bucket in view.** When the unknown count grows, your
+   coverage shrinks. Treat that as a data-quality signal first, a pattern
+   signal second.
+4. **Open the leverage breakdown.** If "Net delivery lift" trends negative,
+   the breakdown tells you whether the drag came from cycle time, review,
+   rework, test gap, or incident drag.
+5. **Filter, then drill.** Use team/repo/work-type filters to localize
+   patterns before clicking through to the underlying PR evidence.
+
+---
+
+## What this view does **not** do
+
+This view is intentionally framed for system observation, not individual
+evaluation. The product contract explicitly **forbids** the following uses:
+
+- ❌ **Individual AI usage surveillance.** No per-author, per-login, or
+  per-developer panels exist. There is no per-user filter and no API path
+  that returns per-individual AI attribution rollups.
+- ❌ **Productivity scoring or rankings.** Leverage is exposed only as
+  decomposable components. There is no "AI productivity score" exposed
+  through any panel or API.
+- ❌ **Cross-person comparison.** Filters cap at team granularity.
+- ❌ **Raw prompt/session capture.** Attribution is inferred from publicly
+  observable provider signals (labels, trailers, bot accounts). Prompt
+  content is never ingested or rendered.
+
+If you are looking for a way to "see which developer uses AI most", **this
+is the wrong tool**, and the design will keep being the wrong tool.
+
+---
+
+## Interpretation guardrails
+
+| Signal                              | Useful framing                                                                | Misuse                                                                 |
+| ----------------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Rising AI-assisted share + rising review amplification | "Are we moving work into review?"                            | "Reviewers are slow."                                                  |
+| Rising AI-assisted share + rising rework drag          | "Are merges incurring more iteration?"                       | "AI is bad" or "Author X is bad."                                      |
+| High unknown attribution            | "Attribution coverage may be missing labels / trailers / bot config."         | Ignore it; treat the dashboard as if unknown didn't exist.             |
+| Negative net delivery lift          | "Drag exceeds delivery on this scope; inspect the breakdown."                 | Treat as a verdict on a team's competence.                             |
+
+---
+
+## Data sources and freshness
+
+- All AI metrics are read from `ai_impact_metrics_daily` (ClickHouse).
+- The resolver is **read-only**; metrics never compute at request time.
+- `computedAt` is surfaced on every response — older `computedAt` means
+  the rollup hasn't refreshed yet, not that the metric is wrong.
+- See [AI Attribution](ai-attribution.md) for what each bucket represents
+  and how confidence is recorded.
+
+---
+
+## Related
+
+- [AI Review Load](ai-review-load.md) — diagnostic view for review pressure.
+- [AI Risk](ai-risk.md) — diagnostic view for quality risk.
+- [AI Attribution](ai-attribution.md) — what counts as AI-assisted, how
+  confidence works, what stays "unknown", and what we will not do with it.
+- [AI Workflow Analytics — GraphQL Contracts](../../api/graphql-ai.md)

--- a/docs/user-guide/views/ai-review-load.md
+++ b/docs/user-guide/views/ai-review-load.md
@@ -1,0 +1,100 @@
+# AI Review Load
+
+The AI Review Load view is the diagnostic surface for **how AI-attributed
+work shows up in review**. It compares AI-attributed PRs against the
+human-only baseline on the same scope and time window.
+
+> **Purpose:** Surface review pressure that may be created (or absorbed) by
+> AI-assisted workflows. This is a *team flow* lens. It is **not** a per-
+> reviewer scoreboard.
+
+---
+
+## What this view shows
+
+Five metric cards plus one trend, all bucketed by `AI_ASSISTED` vs `HUMAN`:
+
+| Card                       | What it answers                                                             |
+| -------------------------- | --------------------------------------------------------------------------- |
+| Pickup latency             | How long, on average, before review activity begins on a PR. *(Cycle-time proxy until pickup-event ingestion ships.)* |
+| Review comments per PR     | Average review comments per merged PR.                                      |
+| Change request rate        | Average change-request comments per PR.                                     |
+| Approval friction          | Derived: `changesRequestedPerPr / reviewsPerPr` per bucket.                 |
+| Review amplification       | Review volume on AI-attributed PRs vs the baseline.                         |
+| Review amplification trend | Daily series showing whether amplification is trending up or down.          |
+
+### Intentional gaps
+
+Two panels are explicitly **missing** today and rendered as missing-data
+cards so the gap stays visible instead of being silently absent:
+
+| Missing card                         | Why it is missing                                                                                |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| Push iterations after first review   | The schema does not yet expose post-first-review push events.                                    |
+| Reviewer concentration               | **Intentionally deferred** until aggregate-only reviewer distribution ships without per-person ranking. |
+
+Reviewer concentration is the most important of these to call out. The
+*data exists* — we could compute it. We choose **not to ship it as an
+individual-leveled metric**. When it ships, it will land as bucketed
+distribution (top quartile vs the rest), not as a leaderboard with names.
+
+---
+
+## How to read it
+
+1. **Always read deltas against the baseline.** Every card shows the AI-side
+   value with a delta vs the human-only baseline on the same scope.
+2. **Approval friction beats reviews-per-PR alone.** A high reviews-per-PR
+   value with low change-request rate is healthy back-and-forth. A high
+   change-request rate is friction.
+3. **Trends matter more than absolutes.** Look at the amplification trend
+   before reacting to a single day's value.
+4. **Filter first.** The same metric can mean different things in
+   "platform" vs "product" repos. Use team/repo/work-type filters.
+
+---
+
+## What this view does **not** do
+
+- ❌ **No reviewer leaderboards, ever.** No card surfaces "who reviewed
+  the most" or "who approved the fastest". The product contract treats
+  reviewer concentration as a *system-distribution* metric, not an
+  individual rating.
+- ❌ **No author/login surfacing.** PR detail drill-downs surface the PR
+  itself; no per-author rollups exist or are exposed.
+- ❌ **No "AI overhead score".** Friction and amplification are exposed as
+  individual numbers with named definitions, not as a synthetic composite.
+
+If a use case requires "rank reviewers by speed", the answer is the same as
+elsewhere in Dev Health: **don't**. Build a reviewer-load conversation,
+not a reviewer scoreboard.
+
+---
+
+## Interpretation guardrails
+
+| Signal                                              | Useful framing                                                       | Misuse                                                  |
+| --------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------- |
+| AI-side reviews-per-PR clearly above baseline       | "AI-assisted PRs may be triggering more back-and-forth here."        | "AI-assisted authors are sloppy."                       |
+| AI-side change-request rate above baseline          | "Reviewers may be catching more issues on AI-attributed PRs."        | "Reviewer X is too strict."                             |
+| Rising amplification trend                          | "Are AI-assisted PRs adding review load over time?"                  | Treat as a verdict on a single contributor.             |
+| Both cards available but no baseline available      | "Scope likely has no human PRs in the window — broaden the scope."   | Treat AI-side absolute value as comparable to anything. |
+
+---
+
+## Data sources and freshness
+
+- Cards read from `aiReviewLoad` (per-bucket review rollups).
+- Deltas come from `aiComparison` (same scope, same window).
+- Both queries return `dataAvailable: Boolean!` — `false` triggers the
+  missing-data UX rather than a silently empty dashboard.
+- Schema details: [`aiReviewLoad` in graphql-ai.md](../../api/graphql-ai.md).
+
+---
+
+## Related
+
+- [AI Impact](ai-impact.md) — top-level summary view.
+- [AI Risk](ai-risk.md) — diagnostic view for quality risk.
+- [AI Attribution](ai-attribution.md) — how AI-assisted is detected, with
+  full anti-surveillance posture.

--- a/docs/user-guide/views/ai-risk.md
+++ b/docs/user-guide/views/ai-risk.md
@@ -1,0 +1,120 @@
+# AI Risk
+
+The AI Risk view is the diagnostic surface for **quality risk associated
+with AI-attributed work**. It compares AI-attributed PRs against the
+human-only baseline on the same scope and time window and surfaces
+governance violations that fire on AI workflows.
+
+> **Purpose:** Surface where AI-assisted work appears to land with lower
+> quality signals (rework, reverts, test gaps, incidents, governance
+> violations). This is a *system-quality* lens. It is **not** a per-
+> author quality grading tool.
+
+---
+
+## What this view shows
+
+Four metric cards comparing AI-side to baseline, three risk-overlap panels,
+one rollup card, and the governance violations list.
+
+### Risk metrics (vs human baseline)
+
+| Card           | What it answers                                                  |
+| -------------- | ---------------------------------------------------------------- |
+| Rework rate    | Share of AI-attributed PRs that appear to require iteration.     |
+| Revert rate    | Share of AI-attributed PRs associated with a subsequent revert.  |
+| Test gap rate  | Share of AI-attributed PRs landing without matching test deltas. |
+| Incident rate  | Share of AI-attributed PRs linked to incident rollups.           |
+
+### Risk overlap panels
+
+Two file-overlap panels render as **missing-data cards** today because the
+underlying detectors do not yet expose per-file overlap with AI-attributed
+PR changed-file sets:
+
+| Missing card                       | What it will show when it lands                                              |
+| ---------------------------------- | ---------------------------------------------------------------------------- |
+| Hotspot file overlap               | AI-attributed PRs that touched detector-flagged hotspot files.               |
+| High-complexity file overlap       | AI-attributed PRs that touched complexity-flagged files.                     |
+
+### Linked incidents
+
+A single rollup card surfacing the count of incidents associated with
+AI-attributed PR edges in the window. PR-level drilldown will arrive when
+a specific PR is selected — the aggregate card does *not* fabricate PR-level
+edges from rollups.
+
+### Governance violations
+
+The AI Governance summary feed is rendered in the same view to make policy
+breaches visible where the quality conversation happens. Each row carries:
+
+- the rule ID
+- severity
+- subject type and subject ID (e.g. `PR pr-7001`)
+- team and repo
+- evidence string
+- observation timestamp
+
+Violations are surfaced by **ruleId + subjectId**, not by author handle.
+
+---
+
+## How to read it
+
+1. **Read deltas, not absolutes.** Every risk card shows the AI-side value
+   alongside the delta vs human-only baseline on the same scope.
+2. **One signal at a time.** A small positive delta on a single metric is
+   noise. Multiple deltas trending the same direction across rework, test
+   gap, and incident is a real pattern.
+3. **Missing-data cards are honest.** When the detector is not yet wired,
+   the card stays present with a "data source needed" note rather than
+   silently disappearing.
+4. **Governance violations are evidence.** Each violation row links to the
+   subject (PR or repo) — drill into the artifact, not the author.
+
+---
+
+## What this view does **not** do
+
+- ❌ **No author quality grading.** No card maps a quality metric to an
+  individual author or reviewer. There is no per-author filter and no
+  resolver path that exposes per-author quality rollups.
+- ❌ **No "AI risk score".** Risk is exposed as named, decomposable
+  metrics, not a synthetic composite.
+- ❌ **No incident attribution to people.** Linked incidents trace to PRs
+  and repos, never to individuals.
+- ❌ **No predictive blocking.** This view explains observed patterns; it
+  does not gate merges, reviews, or deployments.
+
+---
+
+## Interpretation guardrails
+
+| Signal                                                       | Useful framing                                                          | Misuse                                                       |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Rework rate elevated on AI side                              | "Are we landing AI-attributed work that needs follow-up iterations?"    | "Author X writes worse code."                                |
+| Test gap rate elevated on AI side                            | "Is test coverage lagging behind AI-assisted change?"                   | "AI = no tests, ban it."                                     |
+| Incident rate elevated on AI side                            | "Is AI-attributed work clustering near incident-linked PRs?"            | Conclude causality from a single window.                     |
+| Governance violations rising                                 | "Is policy enforcement keeping up with workflow change?"                | Use as a list of contributors to discipline.                 |
+| All cards quiet, missing-data cards loud                     | "Detectors haven't ramped here yet — invest in detection coverage."     | Conclude there is no risk.                                   |
+
+---
+
+## Data sources and freshness
+
+- Risk cards read from `aiRiskBreakdown`.
+- Deltas read from `aiComparison`.
+- Governance violations read from `aiGovernanceSummary.recentViolations`.
+- All three queries return `dataAvailable: Boolean!` — `false` triggers the
+  missing-data UX rather than a silently empty dashboard.
+- Schema details: [graphql-ai.md](../../api/graphql-ai.md).
+
+---
+
+## Related
+
+- [AI Impact](ai-impact.md) — top-level summary view.
+- [AI Review Load](ai-review-load.md) — diagnostic view for review pressure.
+- [AI Attribution](ai-attribution.md) — how AI-assisted is detected and the
+  anti-surveillance posture this view inherits.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,10 @@ nav:
           - Flame Diagrams: user-guide/views/flame-diagrams.md
           - Capacity Planning: user-guide/views/capacity-planning.md
           - Work Graph View: user-guide/views/work-graph.md
+          - AI Impact: user-guide/views/ai-impact.md
+          - AI Review Load: user-guide/views/ai-review-load.md
+          - AI Risk: user-guide/views/ai-risk.md
+          - AI Attribution: user-guide/views/ai-attribution.md
       - Work Graph: user-guide/work-graph.md
       - Reports: user-guide/reports.md
   - API:


### PR DESCRIPTION
## Summary

Adds the **user-facing documentation** half of CHAOS-1588: four new MkDocs pages that interpret the AI Workflow Intelligence dashboards (CHAOS-1584 + CHAOS-1585), document attribution confidence, and explicitly warn against individual ranking and surveillance use.

## What's in here

- **`docs/user-guide/views/ai-impact.md`** — Top-level summary view. Documents every spec panel from CHAOS-1584, how to read share vs. delta, how the decomposable leverage breakdown is structured, and an explicit guardrails section banning individual surveillance, productivity scoring, cross-person comparison, and raw prompt capture as supported uses.
- **`docs/user-guide/views/ai-review-load.md`** — Diagnostic view for review pressure (CHAOS-1585). Documents pickup latency, review comments per PR, change-request rate, approval friction, review amplification, and the two intentionally deferred missing-data panels (push iterations, reviewer concentration). Reviewer concentration's deferral is called out as a product decision, not a data gap.
- **`docs/user-guide/views/ai-risk.md`** — Quality-risk diagnostic view (CHAOS-1585). Documents the four risk metric cards (rework / revert / test gap / incident), the file-overlap stubs, the linked-incidents rollup, and the governance violations feed, including the fact that violations are surfaced by `ruleId`/`subjectId` and never by author handle.
- **`docs/user-guide/views/ai-attribution.md`** — Interpretation reference for the attribution model. Documents the five buckets, the P0 detection sources, confidence levels, what "unknown" really means, and a complete enumeration of what the attribution model deliberately will not do (no per-person surveillance, no productivity scoring, no cross-person ranking, no prompt capture, no invasive IDE telemetry). Notes that the audit/ai_governance/test_surveillance_posture suite is the enforcement layer for these limits.
- **`mkdocs.yml`** — registers the four new pages under User Guide > Views.

## Scope notes

- The API contract is already documented at `docs/api/graphql-ai.md` (shipped with CHAOS-1582). These new pages are the user-facing interpretation layer the CHAOS-1588 acceptance criteria called for:
  - "Docs explain attribution confidence and limitations"
  - "Docs explicitly warn against individual ranking or surveillance use"
- The web E2E + MSW fixtures half of CHAOS-1588 ships separately as `feat/chaos-1588-ai-e2e-and-mocks` on dev-health-web.

## Verification

- `mkdocs build --strict` exits 0 (after pruning two cross-doc links to untracked spec files outside the nav).
- All four pages explicitly include surveillance / ranking warnings.

## Closes / refs

Refs CHAOS-1588 (Add tests, fixtures, and docs for AI Workflow Intelligence) — paired with `feat/chaos-1588-ai-e2e-and-mocks` on dev-health-web which closes the test/fixtures half.
