### PR TITLE
fix(metrics): unblock ClickHouse AI metrics queries (CHAOS-1716)

### DIFF
--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -423,5 +423,14 @@ schema = strawberry.Schema(
     query=Query,
     mutation=Mutation,
     subscription=Subscription,
-    extensions=[OrgIdAuthExtension, AddValidationRules(get_graphql_validation_rules())],
+    # AddValidationRules is a SchemaExtension subclass; instantiating it with
+    # configured rules is the documented strawberry pattern. Newer strawberry
+    # stubs narrowed the `extensions` parameter to a
+    # `type[SchemaExtension] | Callable[[], SchemaExtension]` union that
+    # rejects bare instances, while older stubs still accept them. Suppress
+    # both shapes so mypy passes on either stub revision.
+    extensions=[
+        OrgIdAuthExtension,
+        AddValidationRules(get_graphql_validation_rules()),  # type: ignore[list-item,unused-ignore]
+    ],
 )

--- a/src/dev_health_ops/metrics/loaders/ai_impact.py
+++ b/src/dev_health_ops/metrics/loaders/ai_impact.py
@@ -117,9 +117,9 @@ class AIImpactClickHouseLoader:
             params["work_type"] = work_type
             filters.append("work_type = {work_type:String}")
         params = self._scope.inject(params)
-        org_filter = self._scope.filter()
-        if org_filter:
-            filters.append(org_filter.removeprefix("AND "))
+        org_expr = self._scope.expression()
+        if org_expr:
+            filters.append(org_expr)
         where_clause = " AND ".join(filters)
         query = f"""
         SELECT

--- a/src/dev_health_ops/metrics/opportunities/ai_detector.py
+++ b/src/dev_health_ops/metrics/opportunities/ai_detector.py
@@ -111,9 +111,9 @@ class AIOpportunityDetector:
             filters.append("team_id = {team_id:String}")
         org_scope = OrgScopedQuery(org_id)
         params = org_scope.inject(params)
-        org_filter = org_scope.filter()
-        if org_filter:
-            filters.append(org_filter.removeprefix("AND "))
+        org_expr = org_scope.expression()
+        if org_expr:
+            filters.append(org_expr)
         where_clause = " AND ".join(filters)
         query = f"""
         SELECT
@@ -287,9 +287,9 @@ class AIOpportunityDetector:
             filters.append("pr.repo_id = {repo_id:UUID}")
         org_scope = OrgScopedQuery(org_id)
         params = org_scope.inject(params)
-        org_filter = org_scope.filter(alias="attr")
-        if org_filter:
-            filters.append(org_filter.removeprefix("AND "))
+        org_expr = org_scope.expression(alias="attr")
+        if org_expr:
+            filters.append(org_expr)
         where_clause = " AND ".join(filters)
         query = f"""
         SELECT

--- a/src/dev_health_ops/metrics/query_builder.py
+++ b/src/dev_health_ops/metrics/query_builder.py
@@ -40,6 +40,26 @@ class OrgScopedQuery:
         col = f"{alias}.org_id" if alias else "org_id"
         return f" AND {col} = {{org_id:String}}"
 
+    def expression(self, *, alias: str = "") -> str:
+        """Return ``"{alias?.}org_id = {org_id:String}"`` or ``""``.
+
+        Companion to :meth:`filter` for callers that build a list of filter
+        clauses and join them with ``" AND "``. Using :meth:`filter` in that
+        context would produce ``"... AND  AND org_id = ..."`` because
+        :meth:`filter` carries the connecting ``" AND "`` prefix.
+
+        Same identifier safety check as :meth:`filter`.
+        """
+        if alias and not alias.isidentifier():
+            raise ValueError(
+                "OrgScopedQuery.expression: alias must be a valid identifier, "
+                f"got {alias!r}"
+            )
+        if not self.org_id:
+            return ""
+        col = f"{alias}.org_id" if alias else "org_id"
+        return f"{col} = {{org_id:String}}"
+
     def inject(self, params: dict[str, Any]) -> dict[str, Any]:
         """Return a new params dict with ``org_id`` added when set.
 

--- a/tests/metrics/test_query_builder.py
+++ b/tests/metrics/test_query_builder.py
@@ -64,3 +64,53 @@ class TestOrgScopedQuery:
         assert (
             q.filter(alias="work_units") == " AND work_units.org_id = {org_id:String}"
         )
+
+    def test_expression_empty_org(self) -> None:
+        q = OrgScopedQuery("")
+        assert q.expression() == ""
+        assert q.expression(alias="c") == ""
+
+    def test_expression_with_org(self) -> None:
+        q = OrgScopedQuery("acme")
+        assert q.expression() == "org_id = {org_id:String}"
+
+    def test_expression_with_alias(self) -> None:
+        q = OrgScopedQuery("acme")
+        assert q.expression(alias="attr") == "attr.org_id = {org_id:String}"
+
+    @pytest.mark.parametrize(
+        "bad_alias",
+        ["c; DROP TABLE users--", "c OR 1=1", "c.d", "1c", "c-d", "'; --"],
+    )
+    def test_expression_rejects_non_identifier_alias(self, bad_alias: str) -> None:
+        q = OrgScopedQuery("acme")
+        with pytest.raises(ValueError, match="valid identifier"):
+            q.expression(alias=bad_alias)
+
+    def test_expression_composes_cleanly_in_filter_list(self) -> None:
+        """Regression for CHAOS-1716: callers that build a filter LIST and
+        join with ``" AND "`` must use :meth:`expression`, not
+        :meth:`filter`. Using :meth:`filter` produces a double-AND that
+        ClickHouse rejects with SYNTAX_ERROR."""
+        q = OrgScopedQuery("acme")
+        filters = [
+            "day >= {start_day:Date}",
+            "day <= {end_day:Date}",
+        ]
+        org_expr = q.expression()
+        if org_expr:
+            filters.append(org_expr)
+        where_clause = " AND ".join(filters)
+        assert where_clause == (
+            "day >= {start_day:Date} AND day <= {end_day:Date} "
+            "AND org_id = {org_id:String}"
+        )
+        assert " AND  AND " not in where_clause
+
+    def test_filter_still_useful_for_concatenation_callers(self) -> None:
+        """Confirm :meth:`filter` stays the right tool when the caller is
+        appending onto a finished WHERE clause via string concatenation,
+        which is how every non-AI loader uses it."""
+        q = OrgScopedQuery("acme")
+        sql = "SELECT 1 FROM t WHERE foo = 1" + q.filter()
+        assert sql == "SELECT 1 FROM t WHERE foo = 1 AND org_id = {org_id:String}"


### PR DESCRIPTION
## Summary

After running `dev-hops migrate clickhouse`, every GraphQL AI workflow resolver and the AI opportunity detector raises:

```
Code: 62. DB::Exception: Syntax error: failed at position 2573 (org_id) (line 41, col 74):
org_id = {org_id:String} GROUP BY org_id, team_id, repo_id, work_type, day, attribution_bucket
```

## Root cause

`OrgScopedQuery.filter()` returns the connecting-AND form (`" AND col = {org_id:String}"`, leading space) so callers can string-concatenate onto a finished WHERE clause. That's the canonical usage and stays unchanged.

The AI loaders, however, build a filter **list** and join with `" AND "`:

```python
filters = ["day >= {start_day:Date}", "day <= {end_day:Date}"]
filters.append(org_filter.removeprefix("AND "))   # buggy
where_clause = " AND ".join(filters)
```

`removeprefix("AND ")` does **not** match (`filter()` actually starts with `" AND "` — leading space), so the string is appended unchanged. After joining, the WHERE clause contains `... AND  AND org_id = ...` — double AND — which ClickHouse rejects with `SYNTAX_ERROR`.

The bug shipped with CHAOS-1581 (`ai_impact` loader) and CHAOS-1586 (`ai_opportunity_detector`). Existing tests mock the loaders and never exercise the SQL string.

## Fix

- New `OrgScopedQuery.expression(alias="")` returns bare `"col = {org_id:String}"` for filter-list contexts. Inherits the SQL-injection-safe alias check from `.filter()`.
- Migrate the three buggy call sites:
  - `src/dev_health_ops/metrics/loaders/ai_impact.py:120`
  - `src/dev_health_ops/metrics/opportunities/ai_detector.py:114`
  - `src/dev_health_ops/metrics/opportunities/ai_detector.py:290`

`.filter()` stays available unchanged for the canonical string-concatenation callers (the non-AI loaders in `metrics/loaders/clickhouse.py` etc.).

## Tests

`tests/metrics/test_query_builder.py` grows from 16 → 25 tests:
- `expression()` empty / with-org / with-alias / rejects-bad-alias parametrized
- **Regression**: `test_expression_composes_cleanly_in_filter_list` builds the exact filter-list pattern from the loaders and asserts no `" AND  AND "` substring
- Smoke check that `.filter()` still works for the string-concatenation pattern

```
pytest tests/metrics/test_query_builder.py \
       tests/metrics/test_ai_impact.py \
       tests/metrics/test_ai_opportunity_detector.py \
       tests/api/graphql/test_ai_resolver.py
58 passed
```

`lsp_diagnostics` clean on all touched files.

## Closes / refs

Closes CHAOS-1716.
