### PR TITLE
fix(fixtures): idempotent _seed_auth_data via membership upsert (CHAOS-1717)

### DIFF
--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -423,5 +423,14 @@ schema = strawberry.Schema(
     query=Query,
     mutation=Mutation,
     subscription=Subscription,
-    extensions=[OrgIdAuthExtension, AddValidationRules(get_graphql_validation_rules())],
+    # AddValidationRules is a SchemaExtension subclass; instantiating it with
+    # configured rules is the documented strawberry pattern. Newer strawberry
+    # stubs narrowed the `extensions` parameter to a
+    # `type[SchemaExtension] | Callable[[], SchemaExtension]` union that
+    # rejects bare instances, while older stubs still accept them. Suppress
+    # both shapes so mypy passes on either stub revision.
+    extensions=[
+        OrgIdAuthExtension,
+        AddValidationRules(get_graphql_validation_rules()),  # type: ignore[list-item,unused-ignore]
+    ],
 )

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -243,21 +243,77 @@ def validate_work_unit_investment_density_and_coverage(
 
 
 async def _seed_auth_data(session, user_data: dict) -> None:
-    """Merge users, organizations, memberships, and licenses into PostgreSQL."""
+    """Merge orgs/users, upsert memberships, replace licenses into Postgres.
+
+    Idempotent against re-runs. Memberships use an explicit
+    ``INSERT ... ON CONFLICT (user_id, org_id) DO NOTHING`` because
+    ``session.merge(membership)`` interacts badly with the
+    ``cascade='all, delete-orphan'`` declared on
+    :attr:`User.memberships` / :attr:`Organization.memberships` and the
+    ``uq_membership_user_org`` constraint: SQLAlchemy autoflushes a
+    pending INSERT inside the merge's SELECT, which races the constraint
+    even though the merging row has a deterministic id (CHAOS-1717).
+    Existing licenses already use a delete + add idempotency dance for
+    similar reasons.
+    """
+    from sqlalchemy import delete
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+    from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+    from dev_health_ops.models.licensing import OrgLicense
+    from dev_health_ops.models.users import Membership
+
+    bind = await session.connection()
+    dialect = bind.dialect.name
+
     for org in user_data["organizations"]:
         await session.merge(org)
     await session.commit()
+
     for user in user_data["users"]:
         await session.merge(user)
     await session.commit()
-    for membership in user_data["memberships"]:
-        await session.merge(membership)
+
+    memberships = user_data.get("memberships") or []
+    if memberships:
+        rows = [
+            {
+                "id": m.id,
+                "user_id": m.user_id,
+                "org_id": m.org_id,
+                "role": m.role,
+                "invited_by_id": getattr(m, "invited_by_id", None),
+                "joined_at": m.joined_at,
+            }
+            for m in memberships
+        ]
+        # Execute the dialect-specific upsert inside each branch — the
+        # postgresql and sqlite ``insert`` builders return incompatible
+        # ``Insert`` subclasses, so sharing a single ``stmt`` variable
+        # confuses mypy's type narrowing (CHAOS-1717).
+        if dialect == "sqlite":
+            await session.execute(
+                sqlite_insert(Membership)
+                .values(rows)
+                .on_conflict_do_nothing(
+                    index_elements=["user_id", "org_id"],
+                )
+            )
+        elif dialect in ("postgres", "postgresql"):
+            await session.execute(
+                pg_insert(Membership)
+                .values(rows)
+                .on_conflict_do_nothing(
+                    index_elements=["user_id", "org_id"],
+                )
+            )
+        else:
+            raise RuntimeError(
+                f"_seed_auth_data: unsupported SQL dialect for upsert: {dialect!r}"
+            )
     await session.commit()
+
     for org_license in user_data.get("licenses", []):
-        from sqlalchemy import delete
-
-        from dev_health_ops.models.licensing import OrgLicense
-
         await session.execute(
             delete(OrgLicense).where(OrgLicense.org_id == org_license.org_id)
         )

--- a/tests/test_fixtures_seed_auth_idempotent.py
+++ b/tests/test_fixtures_seed_auth_idempotent.py
@@ -1,0 +1,225 @@
+"""Regression test for CHAOS-1717: re-running ``_seed_auth_data`` must not crash.
+
+Before this fix, a second call would raise
+``UniqueViolationError: uq_membership_user_org`` because
+``session.merge(membership)`` autoflushed a pending INSERT before the
+merge's SELECT resolved, even though the row already existed with a
+deterministic primary key.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.fixtures.runner import _seed_auth_data
+from dev_health_ops.licensing.types import LicenseTier
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.licensing import OrgLicense
+from dev_health_ops.models.users import Membership, Organization, User
+from tests._helpers import tables_of
+
+_NS = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "seed-auth-idempotent.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(User, Organization, Membership, OrgLicense),
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+def _build_user_data() -> dict:
+    """Build the same user_data shape the fixtures generator produces.
+
+    Two users (admin + alice) bound to one org, one license. Deterministic
+    UUIDs so a second invocation lands on identical PKs.
+    """
+    target_org_id = uuid.UUID("ae600a94-76bc-4166-bf36-051ee4247c73")
+
+    admin = User(
+        id=uuid.uuid5(_NS, "admin@devhealth.example"),
+        email="admin@devhealth.example",
+        username="admin",
+        password_hash="$2b$12$dummy",
+        full_name="Admin",
+        auth_provider="local",
+        is_active=True,
+        is_verified=True,
+        is_superuser=True,
+    )
+    alice = User(
+        id=uuid.uuid5(_NS, "alice@example.com"),
+        email="alice@example.com",
+        username="alice",
+        password_hash="$2b$12$dummy",
+        full_name="Alice",
+        auth_provider="local",
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
+    org = Organization(
+        id=target_org_id,
+        slug="fixture-ae600a94",
+        name="Fixture Org",
+        tier="enterprise",
+        is_active=True,
+    )
+    now = datetime.now(timezone.utc)
+    admin_membership = Membership(
+        id=uuid.uuid5(admin.id, str(org.id)),
+        user_id=admin.id,
+        org_id=org.id,
+        role="owner",
+        joined_at=now,
+    )
+    alice_membership = Membership(
+        id=uuid.uuid5(alice.id, str(org.id)),
+        user_id=alice.id,
+        org_id=org.id,
+        role="member",
+        joined_at=now,
+    )
+    license_row = OrgLicense(
+        org_id=org.id,
+        tier=LicenseTier.ENTERPRISE.value,
+        license_type="saas",
+        licensed_users=None,
+        licensed_repos=None,
+        issued_at=now,
+    )
+    license_row.id = uuid.uuid5(org.id, "org-license")
+    return {
+        "organizations": [org],
+        "users": [admin, alice],
+        "memberships": [admin_membership, alice_membership],
+        "licenses": [license_row],
+    }
+
+
+@pytest.mark.asyncio
+async def test_seed_auth_data_is_idempotent_on_rerun(session_maker):
+    """Second invocation must not raise UniqueViolationError."""
+
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    # Second invocation: deterministic PKs collide with existing rows. The
+    # pre-fix code raised UniqueViolationError here. Post-fix must succeed.
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    # And a third for paranoia.
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    # Final state: exactly the expected row counts, no duplicates.
+    async with session_maker() as session:
+        orgs = (await session.execute(select(Organization))).scalars().all()
+        users = (await session.execute(select(User))).scalars().all()
+        memberships = (await session.execute(select(Membership))).scalars().all()
+        licenses = (await session.execute(select(OrgLicense))).scalars().all()
+
+    assert len(orgs) == 1
+    assert len(users) == 2
+    assert len(memberships) == 2
+    assert {m.role for m in memberships} == {"owner", "member"}
+    assert len(licenses) == 1
+
+
+@pytest.mark.asyncio
+async def test_seed_auth_data_first_invocation_writes_everything(session_maker):
+    """Sanity: the first call still seeds the expected rows."""
+
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    async with session_maker() as session:
+        memberships = (await session.execute(select(Membership))).scalars().all()
+
+    assert len(memberships) == 2
+    user_org_pairs = {(m.user_id, m.org_id) for m in memberships}
+    assert len(user_org_pairs) == 2  # no accidental collision
+
+
+@pytest.mark.asyncio
+async def test_seed_auth_data_handles_empty_memberships(session_maker):
+    """An empty membership list must not break the upsert path."""
+
+    data = _build_user_data()
+    data["memberships"] = []
+    async with session_maker() as session:
+        await _seed_auth_data(session, data)
+
+    async with session_maker() as session:
+        memberships = (await session.execute(select(Membership))).scalars().all()
+    assert memberships == []
+
+
+@pytest.mark.asyncio
+async def test_seed_auth_data_uses_upsert_for_memberships(tmp_path):
+    """Guard against accidental revert to ``session.merge(membership)``.
+
+    The SQLite-backed idempotency tests above only catch part of the bug:
+    SQLite's constraint-check timing differs from Postgres + asyncpg, so a
+    naive ``session.merge(membership)`` flow can still pass on SQLite while
+    crashing in production. This test inspects the actual SQL emitted by
+    ``_seed_auth_data`` and asserts the membership statement carries the
+    ``ON CONFLICT ... DO NOTHING`` clause that makes the seed truly
+    idempotent on Postgres.
+    """
+    from sqlalchemy import event
+
+    db_path = tmp_path / "upsert-capture.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(User, Organization, Membership, OrgLicense),
+            )
+        )
+
+    captured_sql: list[str] = []
+
+    def _record(conn, cursor, statement, parameters, context, executemany):  # noqa: ARG001
+        captured_sql.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _record)
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        async with maker() as session:
+            await _seed_auth_data(session, _build_user_data())
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _record)
+        await engine.dispose()
+
+    membership_inserts = [sql for sql in captured_sql if "INTO memberships" in sql]
+    assert membership_inserts, (
+        "expected at least one INSERT INTO memberships statement; "
+        f"captured {len(captured_sql)} statements: {captured_sql}"
+    )
+    assert any(
+        "ON CONFLICT" in sql and "DO NOTHING" in sql for sql in membership_inserts
+    ), (
+        "membership INSERT must use ON CONFLICT DO NOTHING for idempotency; "
+        f"got: {membership_inserts}"
+    )


### PR DESCRIPTION
## Summary

Running `dev-hops fixtures generate` (or `python -m dev_health_ops.cli fixtures generate`) a second time against the same `--org` crashed:

```
sqlalchemy.exc.IntegrityError (raised as a result of Query-invoked autoflush)
asyncpg.exceptions.UniqueViolationError
duplicate key value violates unique constraint "uq_membership_user_org"
```

The user expectation — "re-running fixtures to add more data shouldn't fail" — was not met. This PR makes `_seed_auth_data` truly idempotent.

## Root cause

`_seed_auth_data` relied on `session.merge(membership)` for idempotency. Memberships have deterministic UUIDs (`uuid5(user_id, org_id)`) so `merge()` *should* find the existing row by PK and update.

In practice, the `cascade="all, delete-orphan"` declarations on `User.memberships` and `Organization.memberships`, combined with asyncpg's eager constraint surfacing, cause SQLAlchemy to autoflush a pending Membership INSERT *inside* the merge's SELECT — racing the `uq_membership_user_org` unique constraint even though the row's PK is already in the DB.

Sibling code already worked around the same class of bug for `OrgLicense` (original L256-264) via delete + add. Memberships need the analogous treatment but as upsert, since memberships are FK targets and shouldn't be DELETEd between runs.

## Fix

`_seed_auth_data` now:

1. **Probes the dialect** (`session.connection().dialect.name`) and picks `postgresql.insert` or `sqlite.insert` accordingly — same pattern as `storage/sqlalchemy.py::_insert_for_dialect`.

2. **Emits one bulk upsert** for the entire membership batch:

   ```sql
   INSERT INTO memberships (...) VALUES (...)
   ON CONFLICT (user_id, org_id) DO NOTHING
   ```

   The conflict target matches the `uq_membership_user_org` unique constraint exactly, so re-runs become no-ops at the row level. (DO NOTHING is correct here — fixture seed data isn't authoritative; production memberships are owned by the invite/register flows.)

3. **Keeps `session.merge`** for organizations and users (those tolerate re-merge by PK without cascade interaction), and **keeps the existing delete+add dance** for licenses (unchanged).

## Tests

New `tests/test_fixtures_seed_auth_idempotent.py` — 4 tests, 225 lines:

| Test | What it asserts |
|---|---|
| `test_seed_auth_data_is_idempotent_on_rerun` | Three sequential `_seed_auth_data` calls against an in-memory async SQLite DB succeed and the final row counts are exactly 1 org / 2 users / 2 memberships / 1 license. |
| `test_seed_auth_data_first_invocation_writes_everything` | Smoke test that the upsert path still seeds correctly on the first call. |
| `test_seed_auth_data_handles_empty_memberships` | Edge case: empty membership list does not break the upsert. |
| `test_seed_auth_data_uses_upsert_for_memberships` | Captures every SQL statement via SQLAlchemy's `before_cursor_execute` engine event and asserts the membership INSERT carries `ON CONFLICT ... DO NOTHING`. **Catches accidental reverts to `session.merge(membership)` that would slip past SQLite idempotency tests** (SQLite's constraint-check timing differs from Postgres + asyncpg). |

The SQL-capture test was verified to **FAIL** on the unpatched runner and **PASS** with the fix — so it's a real regression guard, not just a happy-path test.

Full fixtures-suite run:

```
pytest tests/test_fixtures_runner.py tests/test_fixtures_complexity_blame.py \
       tests/test_fixtures_security_alerts.py tests/test_fixtures_feature_flags.py \
       tests/test_fixtures_testops.py tests/test_fixtures_seed_auth_idempotent.py
68 passed
```

`lsp_diagnostics` clean.

## Caveats / known limits

- The first three tests run on **SQLite**, which doesn't faithfully reproduce the production race (Postgres + asyncpg cascade timing). The 4th SQL-capture test is what actually guards against the regression.
- Repo has no Postgres test infrastructure (`testcontainers`, `pytest-postgresql`, etc.). A real Postgres-backed end-to-end test for `_seed_auth_data` is out of scope here but would be a useful follow-up.

## Closes / refs

Closes CHAOS-1717.
