### PR TITLE
fix(api): stabilize GraphQL validation extension wiring (CHAOS-1723)

### DIFF
--- a/src/dev_health_ops/api/graphql/extensions.py
+++ b/src/dev_health_ops/api/graphql/extensions.py
@@ -9,11 +9,19 @@ from __future__ import annotations
 
 import logging
 
-from strawberry.extensions import SchemaExtension
+from strawberry.extensions import AddValidationRules, SchemaExtension
 
 from .errors import AuthorizationError
+from .security import get_graphql_validation_rules
 
 logger = logging.getLogger(__name__)
+
+
+class ConfiguredValidationRules(AddValidationRules):
+    """Strawberry validation rules pre-bound to the dev-health policy."""
+
+    def __init__(self, *, execution_context: object | None = None) -> None:
+        super().__init__(get_graphql_validation_rules())
 
 
 class OrgIdAuthExtension(SchemaExtension):

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import logging
 
 import strawberry
-from strawberry.extensions import AddValidationRules
 from strawberry.types import Info
 
 from .context import GraphQLContext
-from .extensions import OrgIdAuthExtension
+from .extensions import ConfiguredValidationRules, OrgIdAuthExtension
 from .models.ai import (
     AIComparison,
     AIDateRangeInput,
@@ -70,7 +69,6 @@ from .resolvers.reports import (
     resolve_trigger_report,
     resolve_update_saved_report,
 )
-from .security import get_graphql_validation_rules
 from .subscriptions import Subscription
 
 logger = logging.getLogger(__name__)
@@ -423,14 +421,8 @@ schema = strawberry.Schema(
     query=Query,
     mutation=Mutation,
     subscription=Subscription,
-    # AddValidationRules is a SchemaExtension subclass; instantiating it with
-    # configured rules is the documented strawberry pattern. Newer strawberry
-    # stubs narrowed the `extensions` parameter to a
-    # `type[SchemaExtension] | Callable[[], SchemaExtension]` union that
-    # rejects bare instances, while older stubs still accept them. Suppress
-    # both shapes so mypy passes on either stub revision.
     extensions=[
         OrgIdAuthExtension,
-        AddValidationRules(get_graphql_validation_rules()),  # type: ignore[list-item,unused-ignore]
+        ConfiguredValidationRules,
     ],
 )


### PR DESCRIPTION
## Summary
- replace the ignored `AddValidationRules(...)` schema extension instance with a class-based `ConfiguredValidationRules` adapter
- keep Strawberry runtime compatibility by accepting the `execution_context` keyword when the extension class is instantiated
- remove the brittle `# type: ignore[list-item,unused-ignore]` workaround from GraphQL schema wiring

## Verification
- LSP diagnostics clean on changed files
- `python3 -m mypy --install-types --non-interactive .`
- `python3 -m pytest tests/api/graphql/test_graphql_hardening.py::test_introspection_rejected_outside_development tests/api/graphql/test_graphql_hardening.py::test_query_exceeding_depth_limit_rejected tests/api/graphql/test_graphql_hardening.py::test_query_exceeding_alias_limit_rejected -q`
- schema extension smoke test
- `git diff --check`

Closes CHAOS-1723