### PR TITLE
feat(fixtures): seed AI workflow runs/edges and validate AI tables (CHAOS-1724)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,7 +136,10 @@ Notes:
 - `dev-hops` is available after `pip install dev-health-ops` or `pip install -e .`.
 - Synthetic teams are inserted automatically.
 - `--with-metrics` writes the same derived tables as `metrics daily`, plus
-  complexity snapshots and hotspot risk metrics for demo dashboards.
+  complexity snapshots and hotspot risk metrics for demo dashboards. It also
+  seeds AI workflow intelligence (`ai_attribution`, `ai_workflow_runs`,
+  `ai_workflow_artifact_edges`, `ai_workflow_issue_edges`) so the AI impact,
+  governance, and policy-event rollups populate end-to-end.
 
 ## Performance tuning
 

--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -359,6 +359,12 @@ dev-hops fixtures generate \
 
 Database type is auto-detected from the sink URI.
 
+When `--with-metrics` is enabled against ClickHouse, AI workflow intelligence
+tables are also seeded: `ai_attribution`, `ai_workflow_runs`,
+`ai_workflow_artifact_edges`, and `ai_workflow_issue_edges`. The daily metrics
+job then computes `ai_impact_metrics_daily`, `ai_governance_coverage_daily`,
+and `ai_policy_events` from those source rows.
+
 ### `fixtures validate`
 
 Validate that fixture data is sufficient for work graph and investment analysis.
@@ -372,7 +378,8 @@ dev-hops fixtures validate --sink "clickhouse://localhost:8123/default"
 |--------|-------------|
 | `--sink` | Analytics sink URI (required, ClickHouse only) |
 
-Checks raw data counts, team mappings, cycle time metrics, work graph edges, connected components, and evidence bundle quality.
+Checks raw data counts, team mappings, cycle time metrics, work graph edges,
+connected components, AI fixture/rollup tables, and evidence bundle quality.
 
 ---
 

--- a/src/dev_health_ops/fixtures/generator.py
+++ b/src/dev_health_ops/fixtures/generator.py
@@ -12,6 +12,7 @@ import random
 import uuid
 
 from dev_health_ops.fixtures.generators import (
+    AiWorkflowGeneratorMixin,
     BaseGeneratorMixin,
     CommitsGeneratorMixin,
     IncidentsGeneratorMixin,
@@ -28,6 +29,7 @@ __all__ = ["SyntheticDataGenerator"]
 
 
 class SyntheticDataGenerator(
+    AiWorkflowGeneratorMixin,
     CommitsGeneratorMixin,
     PrsGeneratorMixin,
     PipelinesGeneratorMixin,

--- a/src/dev_health_ops/fixtures/generators/__init__.py
+++ b/src/dev_health_ops/fixtures/generators/__init__.py
@@ -5,6 +5,7 @@ into domain-focused mixin classes. The composer in ``generator.py`` inherits
 from all mixins so the public API (``SyntheticDataGenerator``) is unchanged.
 """
 
+from dev_health_ops.fixtures.generators.ai_workflow import AiWorkflowGeneratorMixin
 from dev_health_ops.fixtures.generators.base import BaseGeneratorMixin
 from dev_health_ops.fixtures.generators.commits import CommitsGeneratorMixin
 from dev_health_ops.fixtures.generators.incidents import IncidentsGeneratorMixin
@@ -17,6 +18,7 @@ from dev_health_ops.fixtures.generators.work_items import WorkItemsGeneratorMixi
 
 __all__ = [
     "BaseGeneratorMixin",
+    "AiWorkflowGeneratorMixin",
     "CommitsGeneratorMixin",
     "IncidentsGeneratorMixin",
     "InteractionsGeneratorMixin",

--- a/src/dev_health_ops/fixtures/generators/ai_workflow.py
+++ b/src/dev_health_ops/fixtures/generators/ai_workflow.py
@@ -1,0 +1,318 @@
+"""AI workflow intelligence fixture generators.
+
+Produces synthetic ``ai_workflow_runs`` rows together with the artifact and
+issue edges that connect those runs into the Work Graph. The runs are
+metadata-only by contract: no raw prompts, sessions, transcripts, IDE
+telemetry, or keystrokes are ever fabricated — only prompt *hashes* and
+lengths plus high-level provider/tool/model labels.
+
+Generated data shape:
+
+* One :class:`AIWorkflowRun` per AI-attributed PR (chat-assisted variant) plus
+  a handful of standalone agent-autonomous runs that exercise variety
+  (``status=completed``/``failed``, no PR linkage).
+* For every PR-attached run, one :class:`AIWorkflowArtifactEdge` to the PR
+  (``artifact_type=pull_request``) and, when the PR carries a diff hint, one
+  edge to a synthetic ``diff`` artifact.
+* For every PR-attached run that maps to a referenced issue, one
+  :class:`AIWorkflowIssueEdge` to the issue.
+
+The generator is deterministic when the host
+:class:`SyntheticDataGenerator` is seeded.
+"""
+
+from __future__ import annotations
+
+import random
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from dev_health_ops.fixtures.generators.base import BaseGeneratorMixin
+from dev_health_ops.models.ai_workflow import (
+    AIWorkflowArtifactEdge,
+    AIWorkflowArtifactType,
+    AIWorkflowIssueEdge,
+    AIWorkflowRun,
+    AIWorkflowRunKind,
+    AIWorkflowRunStatus,
+)
+from dev_health_ops.models.git import GitPullRequest
+from dev_health_ops.models.work_items import WorkItem
+
+_TOOL_VARIANTS: tuple[tuple[str, str, AIWorkflowRunKind], ...] = (
+    ("claude-code", "claude-sonnet-4", AIWorkflowRunKind.CHAT_ASSISTED),
+    ("cursor", "claude-3.5-sonnet", AIWorkflowRunKind.CHAT_ASSISTED),
+    ("claude-code-agent", "claude-sonnet-4", AIWorkflowRunKind.AGENT_AUTONOMOUS),
+)
+
+_AUTONOMOUS_STATUSES: tuple[AIWorkflowRunStatus, ...] = (
+    AIWorkflowRunStatus.COMPLETED,
+    AIWorkflowRunStatus.COMPLETED,
+    AIWorkflowRunStatus.FAILED,
+)
+
+
+class AiWorkflowGeneratorMixin(BaseGeneratorMixin):
+    """Generates synthetic AI workflow runs and their typed evidence edges."""
+
+    def generate_ai_workflow_runs(
+        self,
+        prs: list[GitPullRequest],
+        *,
+        org_id: str,
+        autonomous_run_count: int = 3,
+    ) -> list[AIWorkflowRun]:
+        """Generate one workflow run per AI-attributed PR plus a few autonomous runs."""
+        if not prs:
+            return []
+
+        org_uuid = uuid.UUID(str(org_id))
+        runs: list[AIWorkflowRun] = []
+
+        for index, pr in enumerate(prs):
+            if index % 3 == 2:
+                continue
+
+            tool, model, run_kind = _TOOL_VARIANTS[index % len(_TOOL_VARIANTS)]
+            observed_at = pr.merged_at or pr.created_at
+            started_at = observed_at - timedelta(minutes=random.randint(5, 90))
+            run_id = self._workflow_run_id(org_uuid, pr.number, "pr")
+            prompt_seed = f"{org_uuid}:{self.repo_id}:{pr.number}:{tool}:{model}"
+            runs.append(
+                AIWorkflowRun(
+                    run_id=run_id,
+                    org_id=org_uuid,
+                    provider=self.provider,
+                    run_kind=run_kind,
+                    status=AIWorkflowRunStatus.COMPLETED,
+                    tool=tool,
+                    model=model,
+                    actor=self._actor_for_run_kind(run_kind),
+                    repo_id=self.repo_id,
+                    prompts_redacted=True,
+                    prompt_hash=AIWorkflowRun.hash_prompt(prompt_seed),
+                    prompt_length=random.randint(120, 1800),
+                    started_at=started_at,
+                    completed_at=observed_at,
+                    observed_at=observed_at,
+                    metadata={
+                        "source": "synthetic_fixture",
+                        "subject_type": "pull_request",
+                        "subject_id": str(pr.number),
+                    },
+                )
+            )
+
+        if autonomous_run_count > 0:
+            base_time = datetime.now(timezone.utc) - timedelta(days=1)
+            for i in range(autonomous_run_count):
+                started_at = base_time - timedelta(hours=random.randint(1, 48))
+                completed_at = started_at + timedelta(minutes=random.randint(5, 25))
+                status = _AUTONOMOUS_STATUSES[i % len(_AUTONOMOUS_STATUSES)]
+                prompt_seed = f"{org_uuid}:{self.repo_id}:autonomous:{i}"
+                runs.append(
+                    AIWorkflowRun(
+                        run_id=self._workflow_run_id(org_uuid, i, "autonomous"),
+                        org_id=org_uuid,
+                        provider=self.provider,
+                        run_kind=AIWorkflowRunKind.AGENT_AUTONOMOUS,
+                        status=status,
+                        tool="claude-code-agent",
+                        model="claude-sonnet-4",
+                        actor="claude-code[bot]",
+                        repo_id=self.repo_id,
+                        prompts_redacted=True,
+                        prompt_hash=AIWorkflowRun.hash_prompt(prompt_seed),
+                        prompt_length=random.randint(80, 600),
+                        started_at=started_at,
+                        completed_at=completed_at
+                        if status is AIWorkflowRunStatus.COMPLETED
+                        else None,
+                        observed_at=started_at,
+                        metadata={
+                            "source": "synthetic_fixture",
+                            "subject_type": "agent_session",
+                            "subject_id": f"agent-{i}",
+                        },
+                    )
+                )
+
+        return runs
+
+    def generate_ai_workflow_artifact_edges(
+        self,
+        runs: list[AIWorkflowRun],
+        prs: list[GitPullRequest],
+        *,
+        org_id: str,
+    ) -> list[AIWorkflowArtifactEdge]:
+        """Link AI workflow runs to the PR (and a synthetic diff) they produced."""
+        if not runs or not prs:
+            return []
+
+        org_uuid = uuid.UUID(str(org_id))
+        pr_lookup: dict[str, GitPullRequest] = {str(pr.number): pr for pr in prs}
+        edges: list[AIWorkflowArtifactEdge] = []
+
+        for run in runs:
+            subject_type = str(run.metadata.get("subject_type") or "")
+            if subject_type != "pull_request":
+                continue
+            subject_id = str(run.metadata.get("subject_id") or "")
+            pr = pr_lookup.get(subject_id)
+            if pr is None:
+                continue
+
+            evidence_pr = (
+                '{"source":"synthetic_fixture","artifact":"pull_request","number":'
+                f"{pr.number}}}"
+            )
+            edges.append(
+                AIWorkflowArtifactEdge(
+                    edge_id=self._edge_id(
+                        org_uuid, run.run_id, "pull_request", subject_id
+                    ),
+                    org_id=org_uuid,
+                    run_id=run.run_id,
+                    artifact_type=AIWorkflowArtifactType.PULL_REQUEST,
+                    artifact_id=subject_id,
+                    provider=self.provider,
+                    confidence=0.9,
+                    source="synthetic_fixture",
+                    evidence=evidence_pr,
+                    observed_at=run.observed_at,
+                    repo_id=self.repo_id,
+                )
+            )
+
+            # Pair every other run with a synthetic diff artifact so the edge
+            # table exercises more than one artifact_type.
+            if pr.number % 2 == 0:
+                diff_id = f"pr-{pr.number}-diff"
+                evidence_diff = (
+                    '{"source":"synthetic_fixture","artifact":"diff","pr_number":'
+                    f"{pr.number}}}"
+                )
+                edges.append(
+                    AIWorkflowArtifactEdge(
+                        edge_id=self._edge_id(org_uuid, run.run_id, "diff", diff_id),
+                        org_id=org_uuid,
+                        run_id=run.run_id,
+                        artifact_type=AIWorkflowArtifactType.DIFF,
+                        artifact_id=diff_id,
+                        provider=self.provider,
+                        confidence=0.75,
+                        source="synthetic_fixture",
+                        evidence=evidence_diff,
+                        observed_at=run.observed_at,
+                        repo_id=self.repo_id,
+                    )
+                )
+
+        return edges
+
+    def generate_ai_workflow_issue_edges(
+        self,
+        runs: list[AIWorkflowRun],
+        prs: list[GitPullRequest],
+        work_items: list[WorkItem],
+        *,
+        org_id: str,
+    ) -> list[AIWorkflowIssueEdge]:
+        """Link runs to the PR's referenced issue, or to a same-repo issue as fallback."""
+        if not runs or not work_items:
+            return []
+
+        org_uuid = uuid.UUID(str(org_id))
+        pr_lookup: dict[str, GitPullRequest] = {str(pr.number): pr for pr in prs}
+        edges: list[AIWorkflowIssueEdge] = []
+
+        issue_by_repo: dict[uuid.UUID | None, list[str]] = {}
+        for item in work_items:
+            wi_id = str(getattr(item, "work_item_id", "") or "")
+            if not wi_id:
+                continue
+            issue_by_repo.setdefault(getattr(item, "repo_id", None), []).append(wi_id)
+
+        repo_issues = issue_by_repo.get(self.repo_id) or [
+            issue_id for issues in issue_by_repo.values() for issue_id in issues
+        ]
+        if not repo_issues:
+            return []
+
+        for index, run in enumerate(runs):
+            subject_type = str(run.metadata.get("subject_type") or "")
+            if subject_type != "pull_request":
+                continue
+            subject_id = str(run.metadata.get("subject_id") or "")
+            pr = pr_lookup.get(subject_id)
+            if pr is None:
+                continue
+
+            issue_id = self._issue_for_pr(pr, repo_issues, index)
+            if not issue_id:
+                continue
+
+            evidence = (
+                '{"source":"synthetic_fixture","issue_id":"'
+                f'{issue_id}","pr_number":{pr.number}}}'
+            )
+            edges.append(
+                AIWorkflowIssueEdge(
+                    edge_id=self._edge_id(org_uuid, run.run_id, "issue", issue_id),
+                    org_id=org_uuid,
+                    issue_id=issue_id,
+                    run_id=run.run_id,
+                    provider=self.provider,
+                    confidence=0.8,
+                    source="synthetic_fixture",
+                    evidence=evidence,
+                    observed_at=run.observed_at,
+                    repo_id=self.repo_id,
+                )
+            )
+
+        return edges
+
+    def _workflow_run_id(self, org_uuid: uuid.UUID, key: int, scope: str) -> str:
+        return str(
+            uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                f"ai_workflow_run:{org_uuid}:{self.repo_id}:{scope}:{key}",
+            )
+        )
+
+    def _edge_id(
+        self,
+        org_uuid: uuid.UUID,
+        run_id: str,
+        kind: str,
+        target_id: str,
+    ) -> str:
+        return str(
+            uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                f"ai_workflow_edge:{org_uuid}:{run_id}:{kind}:{target_id}",
+            )
+        )
+
+    def _actor_for_run_kind(self, run_kind: AIWorkflowRunKind) -> str:
+        if run_kind is AIWorkflowRunKind.AGENT_AUTONOMOUS:
+            return "claude-code[bot]"
+        if self.repo_authors:
+            name, _email = self.repo_authors[0]
+            return name
+        return "synthetic-author"
+
+    def _issue_for_pr(
+        self,
+        pr: GitPullRequest,
+        repo_issues: list[str],
+        index: int,
+    ) -> str | None:
+        ref = getattr(pr, "issue_id", None) or getattr(pr, "referenced_issue", None)
+        if ref:
+            return str(ref)
+        if not repo_issues:
+            return None
+        return repo_issues[index % len(repo_issues)]

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -578,6 +578,43 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                         r_name,
                     )
 
+            if sink is not None and hasattr(sink, "write_ai_workflow_runs"):
+                ai_workflow_runs = generator.generate_ai_workflow_runs(
+                    prs,
+                    org_id=org_id,
+                )
+                if ai_workflow_runs:
+                    sink.write_ai_workflow_runs(ai_workflow_runs)
+                    logging.info(
+                        "Wrote %d synthetic AI workflow runs for repo %s.",
+                        len(ai_workflow_runs),
+                        r_name,
+                    )
+
+                    if hasattr(sink, "write_ai_workflow_artifact_edges"):
+                        artifact_edges = generator.generate_ai_workflow_artifact_edges(
+                            ai_workflow_runs, prs, org_id=org_id
+                        )
+                        if artifact_edges:
+                            sink.write_ai_workflow_artifact_edges(artifact_edges)
+                            logging.info(
+                                "Wrote %d AI workflow artifact edges for repo %s.",
+                                len(artifact_edges),
+                                r_name,
+                            )
+
+                    if hasattr(sink, "write_ai_workflow_issue_edges"):
+                        issue_edges = generator.generate_ai_workflow_issue_edges(
+                            ai_workflow_runs, prs, work_items, org_id=org_id
+                        )
+                        if issue_edges:
+                            sink.write_ai_workflow_issue_edges(issue_edges)
+                            logging.info(
+                                "Wrote %d AI workflow issue edges for repo %s.",
+                                len(issue_edges),
+                                r_name,
+                            )
+
             pr_commit_links = generator.generate_pr_commits(prs, commits, org_id=org_id)
             if hasattr(store, "insert_work_graph_pr_commit"):
                 await _insert_batches(
@@ -1167,6 +1204,64 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
     return 0
 
 
+AI_FIXTURE_TABLES: tuple[str, ...] = (
+    "ai_attribution",
+    "ai_workflow_runs",
+    "ai_workflow_artifact_edges",
+    "ai_workflow_issue_edges",
+    "ai_impact_metrics_daily",
+    "ai_governance_coverage_daily",
+    "ai_policy_events",
+)
+
+
+def _validate_ai_fixture_tables(client: Any, table_exists) -> bool:
+    """Verify every AI fixture/rollup table is present and non-empty."""
+    counts: dict[str, int] = {}
+    for table in AI_FIXTURE_TABLES:
+        if not table_exists(table):
+            logging.error(
+                "FAIL: AI fixture table %s missing (run fixtures with --with-metrics).",
+                table,
+            )
+            return False
+        try:
+            counts[table] = _query_int(client, f"SELECT count() FROM {table}")
+        except Exception as exc:
+            logging.error("FAIL: Could not count %s rows: %s", table, exc)
+            return False
+        if counts[table] == 0:
+            logging.error(
+                "FAIL: AI fixture table %s is empty (regression in --with-metrics).",
+                table,
+            )
+            return False
+
+    try:
+        linked_runs = _query_int(
+            client,
+            """
+            SELECT count(DISTINCT r.run_id)
+            FROM ai_workflow_runs r
+            INNER JOIN ai_workflow_artifact_edges a USING (org_id, run_id)
+            """,
+        )
+    except Exception as exc:
+        logging.error("FAIL: Could not validate workflow run linkage: %s", exc)
+        return False
+    if linked_runs == 0:
+        logging.error(
+            "FAIL: ai_workflow_runs has no rows linked via ai_workflow_artifact_edges."
+        )
+        return False
+
+    logging.info(
+        "AI fixture tables: "
+        + ", ".join(f"{name}={counts[name]}" for name in AI_FIXTURE_TABLES)
+    )
+    return True
+
+
 def run_fixtures_validation(ns: argparse.Namespace) -> int:
     """Validate that fixture data is sufficient for work graph and investment."""
     import clickhouse_connect
@@ -1468,6 +1563,9 @@ def run_fixtures_validation(ns: argparse.Namespace) -> int:
 
     except Exception as e:
         logging.error(f"FAIL: Could not validate work graph investment coverage: {e}")
+        return 1
+
+    if not _validate_ai_fixture_tables(client, _table_exists):
         return 1
 
     # 4. Evidence sanity (sample bundles)

--- a/tests/test_fixtures_runner.py
+++ b/tests/test_fixtures_runner.py
@@ -10,6 +10,11 @@ from dev_health_ops.fixtures.runner import (
     run_fixtures_generation,
 )
 from dev_health_ops.models.ai_attribution import AIAttributionKind
+from dev_health_ops.models.ai_workflow import (
+    AIWorkflowArtifactType,
+    AIWorkflowRunKind,
+    AIWorkflowRunStatus,
+)
 from dev_health_ops.storage import SQLAlchemyStore
 
 
@@ -91,6 +96,55 @@ def test_pr_fixture_generator_emits_ai_attribution_records():
         AIAttributionKind.AI_ASSISTED,
         AIAttributionKind.AGENT_CREATED,
     }
+
+
+def test_ai_workflow_generator_emits_runs_and_edges():
+    org_id = str(uuid.uuid4())
+    generator = SyntheticDataGenerator(repo_name="test/ai-workflow", seed=7)
+    pr_data = generator.generate_prs(count=6, issue_numbers=[101, 202])
+    prs = [item["pr"] for item in pr_data]
+    work_items = generator.generate_work_items(days=2)
+
+    runs = generator.generate_ai_workflow_runs(prs, org_id=org_id)
+    assert runs, "expected at least one synthetic AI workflow run"
+    assert {run.org_id for run in runs} == {uuid.UUID(org_id)}
+    assert all(run.prompts_redacted for run in runs)
+    assert all(run.prompt_hash and len(run.prompt_hash) == 64 for run in runs)
+    assert {run.run_kind for run in runs} >= {
+        AIWorkflowRunKind.CHAT_ASSISTED,
+        AIWorkflowRunKind.AGENT_AUTONOMOUS,
+    }
+    pr_runs = [
+        run for run in runs if run.metadata.get("subject_type") == "pull_request"
+    ]
+    assert pr_runs, "expected at least one PR-linked run"
+    autonomous_runs = [
+        run for run in runs if run.run_kind is AIWorkflowRunKind.AGENT_AUTONOMOUS
+    ]
+    assert any(run.status is AIWorkflowRunStatus.FAILED for run in autonomous_runs)
+
+    artifact_edges = generator.generate_ai_workflow_artifact_edges(
+        runs, prs, org_id=org_id
+    )
+    assert artifact_edges, "expected artifact edges linking runs to PRs"
+    edge_run_ids = {edge.run_id for edge in artifact_edges}
+    pr_run_ids = {run.run_id for run in pr_runs}
+    assert edge_run_ids.issubset({run.run_id for run in runs})
+    assert edge_run_ids & pr_run_ids, "artifact edges must reference PR runs"
+    assert {edge.artifact_type for edge in artifact_edges} >= {
+        AIWorkflowArtifactType.PULL_REQUEST,
+    }
+    assert all(edge.repo_id == generator.repo_id for edge in artifact_edges)
+
+    issue_edges = generator.generate_ai_workflow_issue_edges(
+        runs, prs, work_items, org_id=org_id
+    )
+    assert issue_edges, "expected issue edges to be generated"
+    assert {edge.run_id for edge in issue_edges}.issubset(
+        {run.run_id for run in pr_runs}
+    )
+    assert all(edge.issue_id for edge in issue_edges)
+    assert all(edge.confidence > 0 for edge in issue_edges)
 
 
 @pytest.mark.asyncio
@@ -276,6 +330,56 @@ def test_work_unit_investment_validation_rejects_low_repo_or_team_coverage():
         )
         is False
     )
+
+
+class _AiValidationClient:
+    """Stub ClickHouse client that returns canned counts for AI fixture tables."""
+
+    def __init__(self, counts: dict[str, int], linked_runs: int = 5):
+        self.counts = counts
+        self.linked_runs = linked_runs
+
+    def query(self, sql: str):
+        normalized = " ".join(sql.split())
+        for table, value in self.counts.items():
+            if f"FROM {table}" in normalized and "ai_workflow_runs r" not in normalized:
+                return _QueryResult(value)
+        if "ai_workflow_runs r" in normalized:
+            return _QueryResult(self.linked_runs)
+        raise AssertionError(f"Unexpected query: {normalized}")
+
+
+def _all_ai_tables_exist(name: str) -> bool:
+    return name in set(runner.AI_FIXTURE_TABLES)
+
+
+def test_validate_ai_fixture_tables_accepts_populated_state():
+    counts = {table: 42 for table in runner.AI_FIXTURE_TABLES}
+    client = _AiValidationClient(counts)
+    assert runner._validate_ai_fixture_tables(client, _all_ai_tables_exist) is True
+
+
+def test_validate_ai_fixture_tables_rejects_empty_table():
+    counts = {table: 10 for table in runner.AI_FIXTURE_TABLES}
+    counts["ai_workflow_runs"] = 0
+    client = _AiValidationClient(counts)
+    assert runner._validate_ai_fixture_tables(client, _all_ai_tables_exist) is False
+
+
+def test_validate_ai_fixture_tables_rejects_missing_table():
+    counts = {table: 10 for table in runner.AI_FIXTURE_TABLES}
+    client = _AiValidationClient(counts)
+    present = set(runner.AI_FIXTURE_TABLES) - {"ai_workflow_artifact_edges"}
+    assert (
+        runner._validate_ai_fixture_tables(client, lambda name: name in present)
+        is False
+    )
+
+
+def test_validate_ai_fixture_tables_rejects_unlinked_runs():
+    counts = {table: 10 for table in runner.AI_FIXTURE_TABLES}
+    client = _AiValidationClient(counts, linked_runs=0)
+    assert runner._validate_ai_fixture_tables(client, _all_ai_tables_exist) is False
 
 
 class TestGenerateUsersRespectsOrgId:


### PR DESCRIPTION
## Summary

Extends `dev-hops fixtures generate --with-metrics` so the AI fixture surface is complete end-to-end, not just PR-level `ai_attribution`.

- New **`AiWorkflowGeneratorMixin`** produces metadata-only `AIWorkflowRun` rows (no prompts, sessions, transcripts, IDE telemetry, or keystrokes — only prompt *hashes* and lengths) plus typed `AIWorkflowArtifactEdge` and `AIWorkflowIssueEdge` rows, so the Work Graph AI evidence tables (`ai_workflow_runs`, `ai_workflow_artifact_edges`, `ai_workflow_issue_edges`) are populated and internally linked.
- The existing daily metrics job already rolls up to `ai_impact_metrics_daily`, `ai_governance_coverage_daily`, and `ai_policy_events` from these source rows, so all six AI fixture tables called out in the ticket now populate.
- Adds an AI fixture validation step to `dev-hops fixtures validate` that fails if any of the AI source/rollup tables regresses to empty or to having no PR-linked artifact edges.
- Adds regression tests at both the generator level (PR-linked + autonomous runs, both artifact types, populated issue edges) and the validation level (rejects missing/empty/unlinked).

## Tables touched by --with-metrics

| Table | Source |
| ----- | ------ |
| `ai_attribution` | PR-level synthetic signals (already wired in #747) |
| `ai_workflow_runs` | **NEW** – one run per AI-attributed PR + autonomous runs |
| `ai_workflow_artifact_edges` | **NEW** – runs ↔ PRs and runs ↔ diff artifacts |
| `ai_workflow_issue_edges` | **NEW** – runs ↔ referenced or same-repo issues |
| `ai_impact_metrics_daily` | rollup (computed from attribution + PR facts) |
| `ai_governance_coverage_daily` | rollup (via `build_governance_rows_for_day`) |
| `ai_policy_events` | rollup (via `build_governance_rows_for_day`) |

## Guardrails preserved

- Sink-only persistence; no new output files.
- Workflow runs are metadata-only (`prompts_redacted=True`; only `prompt_hash` and `prompt_length` are stored).
- Deterministic when the host `SyntheticDataGenerator` is seeded.

## Verification

- `pytest tests/test_fixtures_runner.py tests/metrics/test_ai_impact.py tests/metrics/test_ai_opportunity_detector.py tests/metrics/test_clickhouse_computed_at_aliases.py tests/work_graph/test_ai_workflow.py tests/storage/test_ai_attribution.py tests/api/graphql/test_ai_resolver.py tests/providers/test_ai_detection.py tests/providers/test_github_ai_attribution_integration.py -q` → **175 passed**
- `mypy src/dev_health_ops/fixtures/generators/ai_workflow.py src/dev_health_ops/fixtures/generators/__init__.py src/dev_health_ops/fixtures/generator.py src/dev_health_ops/fixtures/runner.py tests/test_fixtures_runner.py` → **Success: no issues found in 5 source files**
- `ruff check src/dev_health_ops/fixtures/ tests/test_fixtures_runner.py` → clean
- `ruff format --check ...` → clean

End-to-end smoke (10 PRs, seed=7):

```
AI workflow runs: 10  (chat_assisted + agent_autonomous, statuses: completed + failed)
  PR-linked: 7
  autonomous: 3
AI workflow artifact edges: 11  (pull_request + diff)
AI workflow issue edges: 7
AI attributions: 7   (ai_assisted + agent_created)
all runs have hashed prompts: True
```

SCREENSHOT-WAIVER: backend-only fixture/generator/validator changes; no rendered UI changed.

Closes CHAOS-1724