### PR TITLE
feat(ops): throughput-based capacity forecast (CHAOS-1625)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/inputs.py
+++ b/src/dev_health_ops/api/graphql/models/inputs.py
@@ -317,6 +317,16 @@ class CapacityForecastFilterInput:
     limit: int = 10
 
 
+@strawberry.input
+class ThroughputForecastInput:
+    """Input for throughput-based capacity forecast computation."""
+
+    team_id: str
+    work_scope_id: str | None = None
+    backlog_size: int
+    history_weeks: int = 12
+
+
 # =============================================================================
 # Security alert types
 # =============================================================================

--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -451,6 +451,49 @@ class CapacityForecastConnection:
     total_count: int
 
 
+@strawberry.type
+class ThroughputRollingWindow:
+    """Rolling weekly throughput summary for a forecast window."""
+
+    window_weeks: int
+    mean_weekly_throughput: float
+    sample_count: int
+    insufficient_history: bool
+
+
+@strawberry.type
+class ThroughputRiskOverlay:
+    """Risk overlay shown with a throughput forecast."""
+
+    kind: str
+    score: float
+    label: str
+    value: float
+    threshold: float
+    active: bool
+
+
+@strawberry.type
+class ThroughputForecast:
+    """Throughput-based capacity forecast result."""
+
+    forecast_id: str
+    computed_at: str
+    team_id: str
+    work_scope_id: str | None = None
+    backlog_size: int
+    history_weeks: int
+    p50_weeks: int | None
+    p75_weeks: int | None
+    p90_weeks: int | None
+    rolling_windows: list[ThroughputRollingWindow]
+    primary_risk: ThroughputRiskOverlay
+    wip_congestion: ThroughputRiskOverlay
+    review_bottleneck: ThroughputRiskOverlay
+    incident_load: ThroughputRiskOverlay
+    insufficient_history: bool
+
+
 # =============================================================================
 # Security alert output types
 # =============================================================================

--- a/src/dev_health_ops/api/graphql/resolvers/forecast.py
+++ b/src/dev_health_ops/api/graphql/resolvers/forecast.py
@@ -1,0 +1,263 @@
+"""Resolver for throughput-based capacity forecast queries."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any
+
+from dev_health_ops.api.queries.client import query_dicts
+from dev_health_ops.metrics.compute_capacity import ThroughputHistory, ThroughputSample
+from dev_health_ops.metrics.forecast import (
+    RiskOverlay,
+    ThroughputForecastResult,
+    forecast_throughput_capacity,
+)
+from dev_health_ops.utils.datetime import utc_today
+
+from ..authz import require_org_id
+from ..context import GraphQLContext
+from ..models.inputs import ThroughputForecastInput
+from ..models.outputs import (
+    ThroughputForecast,
+    ThroughputRiskOverlay,
+    ThroughputRollingWindow,
+)
+
+
+def _risk_to_output(risk: RiskOverlay) -> ThroughputRiskOverlay:
+    return ThroughputRiskOverlay(
+        kind=risk.kind.value,
+        score=risk.score,
+        label=risk.label,
+        value=risk.value,
+        threshold=risk.threshold,
+        active=risk.active,
+    )
+
+
+def _result_to_output(result: ThroughputForecastResult) -> ThroughputForecast:
+    if result.team_id is None:
+        raise ValueError("team_id is required for throughput forecasts")
+    return ThroughputForecast(
+        forecast_id=result.forecast_id,
+        computed_at=result.computed_at.isoformat(),
+        team_id=result.team_id,
+        work_scope_id=result.work_scope_id,
+        backlog_size=result.backlog_size,
+        history_weeks=result.history_weeks,
+        p50_weeks=result.p50_weeks,
+        p75_weeks=result.p75_weeks,
+        p90_weeks=result.p90_weeks,
+        rolling_windows=[
+            ThroughputRollingWindow(
+                window_weeks=window.window_weeks,
+                mean_weekly_throughput=window.mean_weekly_throughput,
+                sample_count=len(window.samples),
+                insufficient_history=window.insufficient_history,
+            )
+            for window in result.rolling_windows
+        ],
+        primary_risk=_risk_to_output(result.primary_risk),
+        wip_congestion=_risk_to_output(result.wip_congestion),
+        review_bottleneck=_risk_to_output(result.review_bottleneck),
+        incident_load=_risk_to_output(result.incident_load),
+        insufficient_history=result.insufficient_history,
+    )
+
+
+async def _load_throughput_history(
+    context: GraphQLContext,
+    *,
+    team_id: str,
+    work_scope_id: str | None,
+    history_weeks: int,
+) -> ThroughputHistory:
+    start_date = utc_today() - timedelta(weeks=history_weeks)
+    conditions = ["day >= {start_date:Date}", "team_id = {team_id:String}"]
+    params: dict[str, Any] = {
+        "start_date": start_date,
+        "team_id": team_id,
+        "org_id": context.org_id,
+    }
+    if work_scope_id:
+        conditions.append("work_scope_id = {work_scope_id:String}")
+        params["work_scope_id"] = work_scope_id
+
+    rows = await query_dicts(
+        context.client,
+        f"""
+        SELECT day, sum(items_completed) AS items_completed
+        FROM (
+            SELECT
+                day,
+                provider,
+                work_scope_id,
+                team_id,
+                argMax(items_completed, computed_at) AS items_completed
+            FROM work_item_metrics_daily
+            WHERE {" AND ".join(conditions)}
+            GROUP BY day, provider, work_scope_id, team_id
+        )
+        GROUP BY day
+        ORDER BY day
+        """,
+        params,
+    )
+    return ThroughputHistory(
+        [
+            ThroughputSample(
+                day=row["day"]
+                if isinstance(row["day"], date)
+                else date.fromisoformat(str(row["day"])),
+                items_completed=int(row.get("items_completed") or 0),
+                team_id=team_id,
+                work_scope_id=work_scope_id,
+            )
+            for row in rows
+        ]
+    )
+
+
+async def _load_work_item_overlay(
+    context: GraphQLContext,
+    *,
+    team_id: str,
+    work_scope_id: str | None,
+    history_weeks: int,
+) -> tuple[float, float]:
+    start_date = utc_today() - timedelta(weeks=history_weeks)
+    conditions = ["day >= {start_date:Date}", "team_id = {team_id:String}"]
+    params: dict[str, Any] = {
+        "start_date": start_date,
+        "team_id": team_id,
+        "org_id": context.org_id,
+    }
+    if work_scope_id:
+        conditions.append("work_scope_id = {work_scope_id:String}")
+        params["work_scope_id"] = work_scope_id
+
+    rows = await query_dicts(
+        context.client,
+        f"""
+        SELECT
+            avg(wip_count_end_of_day) AS average_wip,
+            argMax(wip_count_end_of_day, day) AS current_wip
+        FROM (
+            SELECT
+                day,
+                sum(wip_count_end_of_day) AS wip_count_end_of_day
+            FROM (
+                SELECT
+                    day,
+                    provider,
+                    work_scope_id,
+                    team_id,
+                    argMax(wip_count_end_of_day, computed_at) AS wip_count_end_of_day
+                FROM work_item_metrics_daily
+                WHERE {" AND ".join(conditions)}
+                GROUP BY day, provider, work_scope_id, team_id
+            )
+            GROUP BY day
+        )
+        """,
+        params,
+    )
+    row = rows[0] if rows else {}
+    return float(row.get("current_wip") or 0.0), float(row.get("average_wip") or 0.0)
+
+
+async def _load_review_overlay(
+    context: GraphQLContext,
+    *,
+    history_weeks: int,
+) -> float:
+    start_date = utc_today() - timedelta(weeks=history_weeks)
+    rows = await query_dicts(
+        context.client,
+        """
+        SELECT avg(pr_first_review_p50_hours) AS review_latency_hours
+        FROM (
+            SELECT
+                repo_id,
+                day,
+                argMax(pr_first_review_p50_hours, computed_at) AS pr_first_review_p50_hours
+            FROM repo_metrics_daily
+            WHERE day >= {start_date:Date}
+            GROUP BY repo_id, day
+        )
+        WHERE pr_first_review_p50_hours IS NOT NULL
+        """,
+        {"start_date": start_date, "org_id": context.org_id},
+    )
+    return float((rows[0] if rows else {}).get("review_latency_hours") or 0.0)
+
+
+async def _load_incident_overlay(
+    context: GraphQLContext,
+    *,
+    history_weeks: int,
+) -> float:
+    start_date = utc_today() - timedelta(weeks=history_weeks)
+    rows = await query_dicts(
+        context.client,
+        """
+        SELECT sum(incidents_count) / greatest(dateDiff('week', {start_date:Date}, today()), 1) AS incident_count
+        FROM (
+            SELECT
+                repo_id,
+                day,
+                argMax(incidents_count, computed_at) AS incidents_count
+            FROM incident_metrics_daily
+            WHERE day >= {start_date:Date}
+            GROUP BY repo_id, day
+        )
+        """,
+        {"start_date": start_date, "org_id": context.org_id},
+    )
+    return float((rows[0] if rows else {}).get("incident_count") or 0.0)
+
+
+async def resolve_throughput_forecast(
+    context: GraphQLContext,
+    input: ThroughputForecastInput,
+) -> ThroughputForecast | None:
+    """Compute a throughput-based capacity forecast on demand."""
+    require_org_id(context)
+    if context.client is None:
+        raise RuntimeError("Database client not available")
+
+    history = await _load_throughput_history(
+        context,
+        team_id=input.team_id,
+        work_scope_id=input.work_scope_id,
+        history_weeks=input.history_weeks,
+    )
+    if not history.samples:
+        return None
+
+    current_wip, average_wip = await _load_work_item_overlay(
+        context,
+        team_id=input.team_id,
+        work_scope_id=input.work_scope_id,
+        history_weeks=input.history_weeks,
+    )
+    review_latency_hours = await _load_review_overlay(
+        context,
+        history_weeks=input.history_weeks,
+    )
+    incident_count = await _load_incident_overlay(
+        context,
+        history_weeks=input.history_weeks,
+    )
+    result = forecast_throughput_capacity(
+        history=history,
+        backlog_size=input.backlog_size,
+        team_id=input.team_id,
+        work_scope_id=input.work_scope_id,
+        history_weeks=input.history_weeks,
+        current_wip=current_wip,
+        average_wip=average_wip,
+        review_latency_hours=review_latency_hours,
+        incident_count=incident_count,
+    )
+    return _result_to_output(result)

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -29,6 +29,7 @@ from .models.inputs import (
     FilterInput,
     SecurityAlertFilterInput,
     SecurityPaginationInput,
+    ThroughputForecastInput,
     WorkGraphEdgeFilterInput,
 )
 from .models.outputs import (
@@ -39,6 +40,7 @@ from .models.outputs import (
     HomeResult,
     SecurityAlertConnection,
     SecurityOverview,
+    ThroughputForecast,
     WorkGraphEdgesResult,
 )
 from .resolvers.ai import (
@@ -260,6 +262,18 @@ class Query:
 
         context = get_context(info)
         return await resolve_capacity_forecasts(context, filters)
+
+    @strawberry.field(description="Compute throughput-based capacity forecast")
+    async def throughput_forecast(
+        self,
+        info: Info,
+        org_id: str,
+        input: ThroughputForecastInput,
+    ) -> ThroughputForecast | None:
+        from .resolvers.forecast import resolve_throughput_forecast
+
+        context = get_context(info)
+        return await resolve_throughput_forecast(context, input)
 
     @strawberry.field(
         description="AI workflow impact summary across the requested time range."

--- a/src/dev_health_ops/metrics/forecast.py
+++ b/src/dev_health_ops/metrics/forecast.py
@@ -1,0 +1,266 @@
+"""Throughput-based capacity forecasting.
+
+This module intentionally sits beside the existing Monte-Carlo capacity model.
+It uses an empirical rolling-window approach instead of simulation:
+
+* daily completed-item samples are converted into rolling 4/8/12 week mean
+  weekly throughput distributions;
+* the forecast confidence bands are derived from conservative quantiles of the
+  selected rolling distribution: P50 weeks uses the median throughput, P75 uses
+  the 25th percentile throughput, and P90 uses the 10th percentile throughput;
+* weeks-to-complete is ``ceil(backlog_size / weekly_throughput)``.
+
+The P75/P90 outputs are therefore "finish within this many weeks if future
+throughput is no worse than the slowest 25%/10% of comparable historical
+windows". These are planning forecasts, not commitments.
+"""
+
+from __future__ import annotations
+
+import math
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from statistics import fmean
+
+from dev_health_ops.metrics.compute_capacity import ThroughputHistory
+
+MIN_DAYS_PER_WEEK = 7
+ROLLING_WINDOWS_WEEKS = (4, 8, 12)
+WIP_CONGESTION_THRESHOLD = 1.25
+REVIEW_BOTTLENECK_THRESHOLD_HOURS = 48.0
+INCIDENT_LOAD_THRESHOLD = 1.0
+
+
+class RiskKind(str, Enum):
+    """Forecast risk categories exposed to UI surfaces."""
+
+    WIP = "wip"
+    REVIEW = "review"
+    INCIDENT = "incident_load"
+    NONE = "none"
+
+
+@dataclass(frozen=True)
+class RollingWindowThroughput:
+    """Empirical weekly-throughput distribution for one rolling window size."""
+
+    window_weeks: int
+    mean_weekly_throughput: float
+    samples: tuple[float, ...]
+    insufficient_history: bool
+
+
+@dataclass(frozen=True)
+class RiskOverlay:
+    """Risk signal used as a forecast overlay."""
+
+    kind: RiskKind
+    score: float
+    label: str
+    value: float
+    threshold: float
+    active: bool
+
+
+@dataclass(frozen=True)
+class ThroughputForecastResult:
+    """Result of a rolling throughput capacity forecast."""
+
+    forecast_id: str
+    computed_at: datetime
+    team_id: str | None
+    work_scope_id: str | None
+    backlog_size: int
+    history_weeks: int
+    p50_weeks: int | None
+    p75_weeks: int | None
+    p90_weeks: int | None
+    rolling_windows: tuple[RollingWindowThroughput, ...]
+    primary_risk: RiskOverlay
+    wip_congestion: RiskOverlay
+    review_bottleneck: RiskOverlay
+    incident_load: RiskOverlay
+    insufficient_history: bool
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    """Return an interpolated percentile for sorted or unsorted values."""
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * percentile
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return ordered[lower]
+    fraction = rank - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def rolling_weekly_throughput(
+    history: ThroughputHistory,
+    window_weeks: int,
+) -> RollingWindowThroughput:
+    """Compute rolling mean weekly throughput for a window size."""
+    if window_weeks <= 0:
+        raise ValueError("window_weeks must be positive")
+
+    throughputs = [max(0, int(sample.items_completed)) for sample in history.samples]
+    window_days = window_weeks * MIN_DAYS_PER_WEEK
+    if not throughputs:
+        return RollingWindowThroughput(window_weeks, 0.0, (), True)
+
+    if len(throughputs) < window_days:
+        total = sum(throughputs)
+        observed_weeks = max(len(throughputs) / MIN_DAYS_PER_WEEK, 1.0)
+        weekly_mean = total / observed_weeks
+        return RollingWindowThroughput(window_weeks, weekly_mean, (weekly_mean,), True)
+
+    rolling = [
+        sum(throughputs[index : index + window_days]) / window_weeks
+        for index in range(0, len(throughputs) - window_days + 1)
+    ]
+    return RollingWindowThroughput(
+        window_weeks=window_weeks,
+        mean_weekly_throughput=fmean(rolling),
+        samples=tuple(rolling),
+        insufficient_history=False,
+    )
+
+
+def compute_rolling_windows(
+    history: ThroughputHistory,
+    windows_weeks: tuple[int, ...] = ROLLING_WINDOWS_WEEKS,
+) -> tuple[RollingWindowThroughput, ...]:
+    """Compute all requested rolling throughput distributions."""
+    return tuple(rolling_weekly_throughput(history, weeks) for weeks in windows_weeks)
+
+
+def _weeks_to_complete(backlog_size: int, weekly_throughput: float) -> int | None:
+    if backlog_size <= 0:
+        return 0
+    if weekly_throughput <= 0:
+        return None
+    return max(1, math.ceil(backlog_size / weekly_throughput))
+
+
+def _risk_overlay(
+    kind: RiskKind,
+    value: float,
+    threshold: float,
+    label: str,
+) -> RiskOverlay:
+    score = value / threshold if threshold > 0 else 0.0
+    return RiskOverlay(
+        kind=kind,
+        score=score,
+        label=label,
+        value=value,
+        threshold=threshold,
+        active=value >= threshold,
+    )
+
+
+def compute_risk_overlays(
+    *,
+    current_wip: float = 0.0,
+    average_wip: float = 0.0,
+    review_latency_hours: float = 0.0,
+    incident_count: float = 0.0,
+) -> tuple[RiskOverlay, RiskOverlay, RiskOverlay, RiskOverlay]:
+    """Compute WIP, review, incident, and primary risk overlays.
+
+    WIP congestion compares current WIP to recent average WIP. Review
+    bottleneck uses PR review latency in hours. Incident load uses the recent
+    count/rate supplied by the resolver. The highest active normalized score is
+    the primary callout; if none are active, a neutral callout is returned.
+    """
+    wip_ratio = current_wip / average_wip if average_wip > 0 else 0.0
+    wip = _risk_overlay(
+        RiskKind.WIP,
+        wip_ratio,
+        WIP_CONGESTION_THRESHOLD,
+        "WIP congestion",
+    )
+    review = _risk_overlay(
+        RiskKind.REVIEW,
+        review_latency_hours,
+        REVIEW_BOTTLENECK_THRESHOLD_HOURS,
+        "Review bottleneck",
+    )
+    incident = _risk_overlay(
+        RiskKind.INCIDENT,
+        incident_count,
+        INCIDENT_LOAD_THRESHOLD,
+        "Incident load",
+    )
+
+    active = [overlay for overlay in (wip, review, incident) if overlay.active]
+    if active:
+        primary = max(active, key=lambda overlay: overlay.score)
+    else:
+        primary = RiskOverlay(
+            kind=RiskKind.NONE,
+            score=0.0,
+            label="No elevated risk",
+            value=0.0,
+            threshold=0.0,
+            active=False,
+        )
+    return primary, wip, review, incident
+
+
+def forecast_throughput_capacity(
+    *,
+    history: ThroughputHistory,
+    backlog_size: int,
+    team_id: str | None = None,
+    work_scope_id: str | None = None,
+    history_weeks: int = 12,
+    current_wip: float = 0.0,
+    average_wip: float = 0.0,
+    review_latency_hours: float = 0.0,
+    incident_count: float = 0.0,
+) -> ThroughputForecastResult:
+    """Forecast weeks to complete a backlog from rolling throughput history."""
+    if backlog_size < 0:
+        raise ValueError("backlog_size must be non-negative")
+    if history_weeks <= 0:
+        raise ValueError("history_weeks must be positive")
+
+    windows = compute_rolling_windows(history)
+    selected = next(
+        (window for window in windows if window.window_weeks == history_weeks),
+        windows[-1],
+    )
+    distribution = list(selected.samples)
+    p50_throughput = _percentile(distribution, 0.50)
+    p75_throughput = _percentile(distribution, 0.25)
+    p90_throughput = _percentile(distribution, 0.10)
+    primary, wip, review, incident = compute_risk_overlays(
+        current_wip=current_wip,
+        average_wip=average_wip,
+        review_latency_hours=review_latency_hours,
+        incident_count=incident_count,
+    )
+    return ThroughputForecastResult(
+        forecast_id=str(uuid.uuid4()),
+        computed_at=datetime.now(timezone.utc),
+        team_id=team_id,
+        work_scope_id=work_scope_id,
+        backlog_size=backlog_size,
+        history_weeks=history_weeks,
+        p50_weeks=_weeks_to_complete(backlog_size, p50_throughput),
+        p75_weeks=_weeks_to_complete(backlog_size, p75_throughput),
+        p90_weeks=_weeks_to_complete(backlog_size, p90_throughput),
+        rolling_windows=windows,
+        primary_risk=primary,
+        wip_congestion=wip,
+        review_bottleneck=review,
+        incident_load=incident,
+        insufficient_history=any(window.insufficient_history for window in windows),
+    )

--- a/tests/metrics/test_forecast.py
+++ b/tests/metrics/test_forecast.py
@@ -1,0 +1,111 @@
+from datetime import date, timedelta
+
+import pytest
+
+from dev_health_ops.metrics.compute_capacity import ThroughputHistory, ThroughputSample
+from dev_health_ops.metrics.forecast import (
+    RiskKind,
+    compute_risk_overlays,
+    forecast_throughput_capacity,
+    rolling_weekly_throughput,
+)
+
+
+def _history(daily: list[int]) -> ThroughputHistory:
+    start = date(2025, 1, 1)
+    return ThroughputHistory(
+        [
+            ThroughputSample(day=start + timedelta(days=index), items_completed=value)
+            for index, value in enumerate(daily)
+        ]
+    )
+
+
+def test_rolling_forecast_is_deterministic_for_constant_throughput() -> None:
+    history = _history([2] * 84)
+
+    result = forecast_throughput_capacity(
+        history=history,
+        backlog_size=100,
+        team_id="team-1",
+        work_scope_id="scope-1",
+        history_weeks=12,
+    )
+
+    assert result.team_id == "team-1"
+    assert result.work_scope_id == "scope-1"
+    assert result.p50_weeks == 8
+    assert result.p75_weeks == 8
+    assert result.p90_weeks == 8
+    assert [window.window_weeks for window in result.rolling_windows] == [4, 8, 12]
+    assert [window.mean_weekly_throughput for window in result.rolling_windows] == [
+        14.0,
+        14.0,
+        14.0,
+    ]
+    assert not result.insufficient_history
+    assert result.primary_risk.kind is RiskKind.NONE
+
+
+def test_insufficient_history_uses_observed_weekly_rate() -> None:
+    history = _history([3] * 14)
+
+    window = rolling_weekly_throughput(history, 4)
+    result = forecast_throughput_capacity(
+        history=history,
+        backlog_size=42,
+        history_weeks=4,
+    )
+
+    assert window.insufficient_history
+    assert window.mean_weekly_throughput == 21.0
+    assert result.insufficient_history
+    assert result.p50_weeks == 2
+    assert result.p75_weeks == 2
+    assert result.p90_weeks == 2
+
+
+def test_zero_throughput_returns_unknown_completion_weeks() -> None:
+    result = forecast_throughput_capacity(history=_history([0] * 84), backlog_size=10)
+
+    assert result.p50_weeks is None
+    assert result.p75_weeks is None
+    assert result.p90_weeks is None
+
+
+@pytest.mark.parametrize("backlog_size", [-1])
+def test_negative_backlog_rejected(backlog_size: int) -> None:
+    with pytest.raises(ValueError, match="backlog_size"):
+        forecast_throughput_capacity(
+            history=_history([1] * 28), backlog_size=backlog_size
+        )
+
+
+def test_primary_risk_prefers_highest_active_normalized_score() -> None:
+    primary, wip, review, incident = compute_risk_overlays(
+        current_wip=30,
+        average_wip=20,
+        review_latency_hours=120,
+        incident_count=1,
+    )
+
+    assert wip.active
+    assert review.active
+    assert incident.active
+    assert primary.kind is RiskKind.REVIEW
+    assert primary.label == "Review bottleneck"
+
+
+def test_primary_risk_reports_no_elevated_risk_when_below_thresholds() -> None:
+    primary, wip, review, incident = compute_risk_overlays(
+        current_wip=10,
+        average_wip=20,
+        review_latency_hours=8,
+        incident_count=0,
+    )
+
+    assert not wip.active
+    assert not review.active
+    assert not incident.active
+    assert primary.kind is RiskKind.NONE
+    assert primary.label == "No elevated risk"


### PR DESCRIPTION
## Summary
- Add rolling 4/8/12-week throughput forecast model with P50/P75/P90 weeks-to-complete bands
- Add WIP, review, and incident risk overlays with primary risk callout
- Expose separate GraphQL throughputForecast query alongside existing Monte Carlo capacity path

## Verification
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy src/dev_health_ops/metrics/forecast.py src/dev_health_ops/api/graphql/resolvers/forecast.py
- uv run pytest tests/metrics/test_forecast.py -v

Sibling web PR: https://github.com/full-chaos/dev-health-web/pull/490

Closes CHAOS-1625