### PR TITLE
feat(ops): rule-based recommendations engine + GraphQL (CHAOS-1620)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/recommendations.py
+++ b/src/dev_health_ops/api/graphql/models/recommendations.py
@@ -1,0 +1,76 @@
+"""Strawberry GraphQL types for the rule-based recommendations engine."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import Enum
+
+import strawberry
+
+
+@strawberry.enum
+class Severity(Enum):
+    """Operational recommendation severity level."""
+
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+@strawberry.enum
+class WindowUnit(Enum):
+    """Unit for a recommendations lookback window."""
+
+    DAY = "day"
+    WEEK = "week"
+    CYCLE = "cycle"
+
+
+@strawberry.input
+class WindowInput:
+    """Lookback window for querying persisted recommendations.
+
+    Examples:
+        WindowInput(value=7, unit=WindowUnit.DAY)   → last 7 days
+        WindowInput(value=4, unit=WindowUnit.WEEK)  → last 4 weeks (default)
+        WindowInput(value=2, unit=WindowUnit.CYCLE) → last 2 cycles (~4 weeks)
+    """
+
+    value: int = 4
+    unit: WindowUnit = WindowUnit.WEEK
+
+
+@strawberry.type
+class EvidenceRef:
+    """Reference to the specific metric row that triggered a recommendation.
+
+    Every field traces directly to a stored ClickHouse row so consumers can
+    drill through from recommendation → raw metric without opaque IDs.
+    """
+
+    team_id: str
+    metric_table: str
+    window_start: date
+    window_end: date
+    field: str
+    value: float
+
+
+@strawberry.type
+class Recommendation:
+    """A single rule-based, deterministic recommendation for a team.
+
+    Persisted in ``recommendations_daily``; read via argMax(..., computed_at)
+    to retrieve the latest computation for each (team_id, rule_id, day) tuple.
+    """
+
+    rule_id: str
+    team_id: str
+    org_id: str
+    computed_at: datetime
+    window_start: date
+    window_end: date
+    severity: Severity
+    title: str
+    rationale: str
+    success_criterion: str
+    evidence: list[EvidenceRef]

--- a/src/dev_health_ops/api/graphql/persisted_queries.json
+++ b/src/dev_health_ops/api/graphql/persisted_queries.json
@@ -78,6 +78,12 @@
             "description": "Fetch generic sankey flow visualization",
             "schema_version": "1.0",
             "query": "query SankeyFlow($orgId: String!, $batch: AnalyticsRequestInput!) { analytics(orgId: $orgId, batch: $batch) { sankey { nodes { id label dimension value } edges { source target value } coverage { teamCoverage repoCoverage } } } }"
+        },
+        {
+            "id": "team-recommendations",
+            "description": "Fetch latest rule-based recommendations for a team",
+            "schema_version": "1.0",
+            "query": "query TeamRecommendations($orgId: String!, $team: ID!, $window: WindowInput!) { recommendations(orgId: $orgId, team: $team, window: $window) { ruleId teamId orgId computedAt windowStart windowEnd severity title rationale successCriterion evidence { teamId metricTable windowStart windowEnd field value } } }"
         }
     ]
 }

--- a/src/dev_health_ops/api/graphql/resolvers/recommendations.py
+++ b/src/dev_health_ops/api/graphql/resolvers/recommendations.py
@@ -56,7 +56,7 @@ def _window_to_dates(window: WindowInput) -> tuple[date, date]:
     unit/value pair.  A *cycle* is treated as 14 days (two-week sprint).
     """
     today = datetime.now(tz=timezone.utc).date()
-    days: int
+    days = window.value * 7
     match window.unit:
         case WindowUnit.DAY:
             days = window.value
@@ -64,8 +64,6 @@ def _window_to_dates(window: WindowInput) -> tuple[date, date]:
             days = window.value * 7
         case WindowUnit.CYCLE:
             days = window.value * 14
-        case _:  # pragma: no cover
-            days = window.value * 7
     return today - timedelta(days=days), today
 
 
@@ -99,7 +97,9 @@ def _parse_evidence(raw: str | list[Any] | None) -> list[EvidenceRef]:
                 EvidenceRef(
                     team_id=str(ev.get("team_id", "")),
                     metric_table=str(ev.get("metric_table", "")),
-                    window_start=date.fromisoformat(str(ws_raw)) if ws_raw else date.min,
+                    window_start=date.fromisoformat(str(ws_raw))
+                    if ws_raw
+                    else date.min,
                     window_end=date.fromisoformat(str(we_raw)) if we_raw else date.min,
                     field=str(ev.get("field", "")),
                     value=float(ev.get("value", 0.0)),
@@ -155,6 +155,7 @@ def _row_to_recommendation(row: dict[str, Any]) -> Recommendation | None:
     except (KeyError, ValueError, TypeError):
         logger.warning("Skipping malformed recommendation row: %r", row)
         return None
+
 
 async def resolve_recommendations(
     context: GraphQLContext,

--- a/src/dev_health_ops/api/graphql/resolvers/recommendations.py
+++ b/src/dev_health_ops/api/graphql/resolvers/recommendations.py
@@ -1,0 +1,210 @@
+"""Resolver for the rule-based recommendations engine queries."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+from ..authz import require_org_id
+from ..context import GraphQLContext
+from ..models.recommendations import (
+    EvidenceRef,
+    Recommendation,
+    Severity,
+    WindowInput,
+    WindowUnit,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SQL — argMax reads the latest computed row per (org_id, team_id, rule_id, window_end).
+# These are the ORDER BY columns in migration 039_recommendations.sql.
+# Table: recommendations_daily (ClickHouse, append-only / ReplacingMergeTree).
+# ---------------------------------------------------------------------------
+_RECOMMENDATIONS_SQL = """\
+    SELECT
+    team_id,
+    org_id,
+    rule_id,
+    argMax(fired,               computed_at) AS fired,
+    argMax(severity,            computed_at) AS severity,
+    argMax(title,               computed_at) AS title,
+    argMax(rationale,           computed_at) AS rationale,
+    argMax(success_criterion,   computed_at) AS success_criterion,
+    argMax(evidence_json,       computed_at) AS evidence_json,
+    argMax(window_start,        computed_at) AS window_start,
+    argMax(window_end,          computed_at) AS window_end,
+    max(computed_at)                         AS computed_at
+FROM recommendations_daily
+WHERE team_id  = {team_id:String}
+  AND org_id   = {org_id:String}
+  AND window_end >= {window_start:Date}
+  AND window_end <= {window_end:Date}
+GROUP BY org_id, team_id, rule_id, window_end
+HAVING argMax(fired, computed_at) = true
+ORDER BY window_end DESC, rule_id
+"""
+
+
+def _window_to_dates(window: WindowInput) -> tuple[date, date]:
+    """Convert a WindowInput to (window_start, window_end) date bounds.
+
+    window_end is always today (UTC); window_start is computed from the
+    unit/value pair.  A *cycle* is treated as 14 days (two-week sprint).
+    """
+    today = datetime.now(tz=timezone.utc).date()
+    days: int
+    match window.unit:
+        case WindowUnit.DAY:
+            days = window.value
+        case WindowUnit.WEEK:
+            days = window.value * 7
+        case WindowUnit.CYCLE:
+            days = window.value * 14
+        case _:  # pragma: no cover
+            days = window.value * 7
+    return today - timedelta(days=days), today
+
+
+def _parse_evidence(raw: str | list[Any] | None) -> list[EvidenceRef]:
+    """Deserialise the ``evidence_json`` column into EvidenceRef objects.
+
+    The engine serialises evidence as a JSON array whose object keys match
+    the canonical ``EvidenceRef`` field names exactly:
+    ``team_id``, ``metric_table``, ``window_start``, ``window_end``,
+    ``field``, ``value``.
+    """
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        try:
+            items: list[Any] = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            logger.warning("Failed to parse evidence_json: %r", raw[:200])
+            return []
+    else:
+        items = list(raw)
+
+    refs: list[EvidenceRef] = []
+    for ev in items:
+        if not isinstance(ev, dict):
+            continue
+        try:
+            ws_raw = ev.get("window_start", "")
+            we_raw = ev.get("window_end", "")
+            refs.append(
+                EvidenceRef(
+                    team_id=str(ev.get("team_id", "")),
+                    metric_table=str(ev.get("metric_table", "")),
+                    window_start=date.fromisoformat(str(ws_raw)) if ws_raw else date.min,
+                    window_end=date.fromisoformat(str(we_raw)) if we_raw else date.min,
+                    field=str(ev.get("field", "")),
+                    value=float(ev.get("value", 0.0)),
+                )
+            )
+        except (KeyError, ValueError, TypeError):
+            logger.warning("Skipping malformed evidence entry: %r", ev)
+    return refs
+
+
+def _row_to_recommendation(row: dict[str, Any]) -> Recommendation | None:
+    """Map a ClickHouse result row to a Recommendation GraphQL type.
+
+    Returns None for rows that cannot be safely coerced (logged as warnings).
+    """
+    try:
+        raw_sev = str(row.get("severity", "warning")).lower()
+        try:
+            severity = Severity(raw_sev)
+        except ValueError:
+            severity = Severity.WARNING
+
+        raw_ws = row.get("window_start")
+        raw_we = row.get("window_end")
+        window_start = (
+            raw_ws if isinstance(raw_ws, date) else date.fromisoformat(str(raw_ws))
+        )
+        window_end = (
+            raw_we if isinstance(raw_we, date) else date.fromisoformat(str(raw_we))
+        )
+
+        raw_cat = row.get("computed_at")
+        if isinstance(raw_cat, datetime):
+            computed_at = raw_cat
+        else:
+            computed_at = datetime.fromisoformat(str(raw_cat))
+        if computed_at.tzinfo is None:
+            computed_at = computed_at.replace(tzinfo=timezone.utc)
+
+        return Recommendation(
+            rule_id=str(row["rule_id"]),
+            team_id=str(row["team_id"]),
+            org_id=str(row["org_id"]),
+            computed_at=computed_at,
+            window_start=window_start,
+            window_end=window_end,
+            severity=severity,
+            title=str(row.get("title", "")),
+            rationale=str(row.get("rationale", "")),
+            success_criterion=str(row.get("success_criterion", "")),
+            evidence=_parse_evidence(row.get("evidence_json")),
+        )
+    except (KeyError, ValueError, TypeError):
+        logger.warning("Skipping malformed recommendation row: %r", row)
+        return None
+
+async def resolve_recommendations(
+    context: GraphQLContext,
+    team: str,
+    window: WindowInput,
+) -> list[Recommendation]:
+    """Return the latest persisted recommendations for a team within a window.
+
+    Reads from ``recommendations_daily`` (ClickHouse, append-only) using
+    ``argMax(..., computed_at)`` to retrieve the most recent computation for
+    each ``(team_id, rule_id, day)`` tuple.  Only rows where ``fired = 1``
+    are returned.
+
+    Args:
+        context: GraphQL request context (carries org_id, ClickHouse client).
+        team:    Team ID to query.
+        window:  Lookback window (value + unit) translated to a date range.
+
+    Returns:
+        Ordered list of Recommendation objects, most-recent day first.
+    """
+    from dev_health_ops.api.queries.client import query_dicts
+
+    org_id = require_org_id(context)
+    client = context.client
+    if client is None:
+        raise RuntimeError("Database client not available")
+
+    window_start, window_end = _window_to_dates(window)
+    params: dict[str, Any] = {
+        "team_id": team,
+        "org_id": org_id,
+        "window_start": window_start.isoformat(),
+        "window_end": window_end.isoformat(),
+    }
+
+    try:
+        rows = await query_dicts(client, _RECOMMENDATIONS_SQL, params)
+    except Exception:
+        logger.exception(
+            "Failed to fetch recommendations for team=%s window=%s–%s",
+            team,
+            window_start,
+            window_end,
+        )
+        return []
+
+    results: list[Recommendation] = []
+    for row in rows:
+        rec = _row_to_recommendation(row)
+        if rec is not None:
+            results.append(rec)
+    return results

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -45,6 +45,10 @@ from .models.outputs import (
     ThroughputForecast,
     WorkGraphEdgesResult,
 )
+from .models.recommendations import (
+    Recommendation,
+    WindowInput,
+)
 from .resolvers.ai import (
     resolve_ai_comparison,
     resolve_ai_governance_summary,
@@ -288,6 +292,21 @@ class Query:
 
         context = get_context(info)
         return await resolve_operating_review(context, input)
+
+    @strawberry.field(
+        description="Latest rule-based recommendations for a team within a lookback window."
+    )
+    async def recommendations(
+        self,
+        info: Info,
+        org_id: str,
+        team: strawberry.ID,
+        window: WindowInput,
+    ) -> list[Recommendation]:
+        from .resolvers.recommendations import resolve_recommendations
+
+        context = get_context(info)
+        return await resolve_recommendations(context, str(team), window)
 
     @strawberry.field(
         description="AI workflow impact summary across the requested time range."

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -133,7 +133,10 @@ def _cmd_recommendations_compute(ns: argparse.Namespace) -> int:
     from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
     from dev_health_ops.recommendations import registry as recommendations_registry
     from dev_health_ops.recommendations.engine import RuleEngine
-    from dev_health_ops.recommendations.loader import ClickHouseMetricsLoader
+    from dev_health_ops.recommendations.loader import (
+        ClickHouseMetricsLoader,
+        recommendation_to_record,
+    )
 
     analytics_db = getattr(ns, "analytics_db", None) or os.getenv("CLICKHOUSE_URI", "")
     if not analytics_db:
@@ -171,7 +174,9 @@ def _cmd_recommendations_compute(ns: argparse.Namespace) -> int:
         )
         return 1
 
-    sink.write_recommendations(recommendations)
+    sink.write_recommendations(
+        [recommendation_to_record(rec) for rec in recommendations]
+    )
     sink.close()
 
     log = logging.getLogger(__name__)
@@ -192,7 +197,7 @@ def _cmd_recommendations_compute(ns: argparse.Namespace) -> int:
     return 0
 
 
-def _register_recommendations_commands(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+def _register_recommendations_commands(subparsers: argparse._SubParsersAction) -> None:
     compute = subparsers.add_parser(
         "compute",
         help="Evaluate recommendation rules for a team and write results to ClickHouse.",

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -119,6 +119,100 @@ async def _cmd_maintenance_cleanup_all(_ns: argparse.Namespace) -> int:
     )
     return 0
 
+# ---------------------------------------------------------------------------
+# Recommendations commands
+# ---------------------------------------------------------------------------
+
+
+def _cmd_recommendations_compute(ns: argparse.Namespace) -> int:
+    """Compute rule-based recommendations for a team and persist via ClickHouse sink."""
+    import json
+    from datetime import date, datetime, timezone
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+    from dev_health_ops.recommendations import registry as recommendations_registry
+    from dev_health_ops.recommendations.engine import RuleEngine
+    from dev_health_ops.recommendations.loader import ClickHouseMetricsLoader
+
+    analytics_db = getattr(ns, "analytics_db", None) or os.getenv("CLICKHOUSE_URI", "")
+    if not analytics_db:
+        logging.getLogger(__name__).error(
+            "--analytics-db / CLICKHOUSE_URI is required for recommendations compute"
+        )
+        return 1
+
+    team_id: str = ns.team
+    window: str = ns.window
+    org_id: str = getattr(ns, "org", None) or ""
+    now = datetime.now(timezone.utc)
+
+    # Override window bounds if --since / --until supplied
+    if getattr(ns, "since", None) and getattr(ns, "until", None):
+        since_date = date.fromisoformat(ns.since)
+        until_date = date.fromisoformat(ns.until)
+        window_days = (until_date - since_date).days
+        now = datetime(
+            until_date.year, until_date.month, until_date.day, tzinfo=timezone.utc
+        )
+        window = str(window_days)
+
+    sink = ClickHouseMetricsSink(dsn=analytics_db)
+    loader = ClickHouseMetricsLoader(client=sink.client, org_id=org_id)
+    engine = RuleEngine(registry=recommendations_registry, loader=loader, now=now)
+
+    try:
+        recommendations = engine.evaluate_all(
+            team_id=team_id, window=window, org_id=org_id
+        )
+    except Exception as exc:
+        logging.getLogger(__name__).error(
+            "Recommendations evaluation failed for team=%r: %s", team_id, exc
+        )
+        return 1
+
+    sink.write_recommendations(recommendations)
+    sink.close()
+
+    log = logging.getLogger(__name__)
+    log.info(
+        "recommendations compute: team=%r window=%s fired=%d",
+        team_id, window, len(recommendations),
+    )
+    if getattr(ns, "output_json", False):
+        import sys
+        from dataclasses import asdict
+        print(json.dumps([asdict(r) for r in recommendations], default=str), file=sys.stdout)
+    return 0
+
+
+def _register_recommendations_commands(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    compute = subparsers.add_parser(
+        "compute",
+        help="Evaluate recommendation rules for a team and write results to ClickHouse.",
+    )
+    compute.add_argument("--team", required=True, help="Team ID to evaluate.")
+    compute.add_argument(
+        "--window",
+        default="7d",
+        help="Evaluation window, e.g. '7d' or '14d'. Default: 7d.",
+    )
+    compute.add_argument(
+        "--since",
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Override window start (exclusive end = --until).",
+    )
+    compute.add_argument(
+        "--until",
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Override window end (inclusive). Requires --since.",
+    )
+    compute.add_argument(
+        "--output-json",
+        action="store_true",
+        help="Print fired recommendations as JSON to stdout.",
+    )
+    compute.set_defaults(func=_cmd_recommendations_compute)
 
 _GLOBAL_FLAG_SPECS: tuple[tuple[tuple[str, ...], dict[str, object]], ...] = (
     (
@@ -279,6 +373,15 @@ def build_parser() -> argparse.ArgumentParser:
     work_graph_runner.register_commands(sub)
 
     backfill_cli.register_backfill_commands(sub)
+
+    # ---- recommendations ----
+    rec_parser = sub.add_parser(
+        "recommendations", help="Compute and persist rule-based recommendations."
+    )
+    rec_subparsers = rec_parser.add_subparsers(
+        dest="recommendations_command", required=True
+    )
+    _register_recommendations_commands(rec_subparsers)
 
     # ---- migrate ----
     migrate_mod.register_commands(sub)

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -119,6 +119,7 @@ async def _cmd_maintenance_cleanup_all(_ns: argparse.Namespace) -> int:
     )
     return 0
 
+
 # ---------------------------------------------------------------------------
 # Recommendations commands
 # ---------------------------------------------------------------------------
@@ -128,6 +129,7 @@ def _cmd_recommendations_compute(ns: argparse.Namespace) -> int:
     """Compute rule-based recommendations for a team and persist via ClickHouse sink."""
     import json
     from datetime import date, datetime, timezone
+
     from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
     from dev_health_ops.recommendations import registry as recommendations_registry
     from dev_health_ops.recommendations.engine import RuleEngine
@@ -175,12 +177,18 @@ def _cmd_recommendations_compute(ns: argparse.Namespace) -> int:
     log = logging.getLogger(__name__)
     log.info(
         "recommendations compute: team=%r window=%s fired=%d",
-        team_id, window, len(recommendations),
+        team_id,
+        window,
+        len(recommendations),
     )
     if getattr(ns, "output_json", False):
         import sys
         from dataclasses import asdict
-        print(json.dumps([asdict(r) for r in recommendations], default=str), file=sys.stdout)
+
+        print(
+            json.dumps([asdict(r) for r in recommendations], default=str),
+            file=sys.stdout,
+        )
     return 0
 
 
@@ -213,6 +221,7 @@ def _register_recommendations_commands(subparsers: argparse._SubParsersAction) -
         help="Print fired recommendations as JSON to stdout.",
     )
     compute.set_defaults(func=_cmd_recommendations_compute)
+
 
 _GLOBAL_FLAG_SPECS: tuple[tuple[tuple[str, ...], dict[str, object]], ...] = (
     (

--- a/src/dev_health_ops/metrics/sinks/base.py
+++ b/src/dev_health_ops/metrics/sinks/base.py
@@ -454,3 +454,16 @@ class BaseMetricsSink(ABC):
     def write_worklogs(self, rows: Sequence[Worklog]) -> None:
         """Write raw worklog records."""
         pass
+
+    # -------------------------------------------------------------------------
+    # Recommendations
+    # -------------------------------------------------------------------------
+
+    def write_recommendations(self, rows: Sequence[Any]) -> None:
+        """Write recommendation evaluation results to ``recommendations_daily``.
+
+        Default implementation is a no-op so existing sink subclasses that
+        have not yet been updated continue to work.  Override in
+        ``RecommendationsMixin``.
+        """
+        pass

--- a/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
@@ -7,6 +7,23 @@ Public API (stable — do not remove):
 The single `ClickHouseMetricsSink` class is built by composing mixin classes,
 each responsible for one table family:
 
+  ClickHouseCore            — connection, schema, shared _insert_rows helper
+  CIMixin                   — CI/CD, deploy, incident, testops pipeline/test/coverage,
+                              release confidence, feature flags, telemetry, release impact
+  DoraMixin                 — DORA metrics, period comparisons, benchmarks
+  WellbeingMixin            — user metrics, quality drag, pipeline stability
+  InvestmentMixin           — investment classifications/metrics, work-unit investments
+  WorkGraphMixin            — work graph edges, work items, git/repo/file metrics, forecasts
+  AIAttributionMixin        — AI attribution records (ai_attribution table)
+  AIImpactMixin             — AI workflow impact daily rollups
+  RecommendationsMixin      — recommendations_daily (CHAOS-1622)
+
+Public API (stable — do not remove):
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+The single `ClickHouseMetricsSink` class is built by composing mixin classes,
+each responsible for one table family:
+
   ClickHouseCore        — connection, schema, shared _insert_rows helper
   CIMixin               — CI/CD, deploy, incident, testops pipeline/test/coverage,
                           release confidence, feature flags, telemetry, release impact
@@ -28,6 +45,7 @@ from dev_health_ops.metrics.sinks.clickhouse.ci import CIMixin
 from dev_health_ops.metrics.sinks.clickhouse.core import ClickHouseCore
 from dev_health_ops.metrics.sinks.clickhouse.dora import DoraMixin
 from dev_health_ops.metrics.sinks.clickhouse.investment import InvestmentMixin
+from dev_health_ops.metrics.sinks.clickhouse.recommendations import RecommendationsMixin
 from dev_health_ops.metrics.sinks.clickhouse.wellbeing import WellbeingMixin
 from dev_health_ops.metrics.sinks.clickhouse.work_graph import WorkGraphMixin
 
@@ -40,6 +58,7 @@ class ClickHouseMetricsSink(
     AIAttributionMixin,
     AIImpactMixin,
     CIMixin,
+    RecommendationsMixin,
     DoraMixin,
     WellbeingMixin,
     InvestmentMixin,

--- a/src/dev_health_ops/metrics/sinks/clickhouse/recommendations.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/recommendations.py
@@ -1,0 +1,61 @@
+"""
+RecommendationsMixin — write methods for recommendations_daily.
+
+Table: recommendations_daily
+Engine: ReplacingMergeTree(computed_at)  (append-only; argMax reads)
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from dev_health_ops.recommendations.snapshot import RecommendationRecord
+
+if TYPE_CHECKING:
+    from dev_health_ops.metrics.sinks.clickhouse._insert import _ClickHouseSinkBase
+else:
+
+    class _ClickHouseSinkBase:
+        pass
+
+
+logger = logging.getLogger(__name__)
+
+
+class RecommendationsMixin(_ClickHouseSinkBase):
+    """Mixin for recommendations write methods."""
+
+    def write_recommendations(self, rows: Sequence[RecommendationRecord]) -> None:
+        """Write recommendation evaluation results to ``recommendations_daily``.
+
+        Append-only: re-running for the same window produces new rows with a
+        newer ``computed_at``.  Use ``argMax(fired, computed_at)`` in read
+        queries to retrieve the latest status per
+        ``(org_id, team_id, rule_id, window_end)``.
+
+        Args:
+            rows: Sequence of ``RecommendationRecord`` dataclasses.
+        """
+        if not rows:
+            return
+        self._insert_rows(
+            "recommendations_daily",
+            [
+                "team_id",
+                "org_id",
+                "rule_id",
+                "rule_version",
+                "window_start",
+                "window_end",
+                "fired",
+                "severity",
+                "title",
+                "rationale",
+                "success_criterion",
+                "evidence_json",
+                "computed_at",
+            ],
+            rows,
+        )

--- a/src/dev_health_ops/migrations/clickhouse/039_recommendations.sql
+++ b/src/dev_health_ops/migrations/clickhouse/039_recommendations.sql
@@ -1,0 +1,29 @@
+-- Migration 039: recommendations_daily — append-only rule evaluation results.
+--
+-- Each row records one rule evaluation for a (team_id, rule_id) pair.
+-- Re-evaluations INSERT new rows with a newer computed_at.
+-- Read the latest result with: argMax(fired, computed_at).
+--
+-- ORDER BY includes window_end so range queries are efficient and
+-- (team_id, rule_id, window_end) forms a natural "latest per window" key.
+
+CREATE TABLE IF NOT EXISTS recommendations_daily
+(
+    team_id           LowCardinality(String),
+    org_id            String,
+    rule_id           LowCardinality(String),
+    rule_version      LowCardinality(String)    DEFAULT '1.0.0',
+    window_start      Date,
+    window_end        Date,
+    fired             Bool,
+    severity          LowCardinality(String),   -- 'warning' | 'critical'
+    title             String,
+    rationale         String,
+    success_criterion String,
+    evidence_json     String,                   -- JSON list[EvidenceRef]
+    computed_at       DateTime64(3, 'UTC')      DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(window_end)
+ORDER BY (org_id, team_id, rule_id, window_end)
+SETTINGS index_granularity = 8192;

--- a/src/dev_health_ops/recommendations/__init__.py
+++ b/src/dev_health_ops/recommendations/__init__.py
@@ -1,0 +1,37 @@
+"""Rule-based operational recommendations engine.
+
+This package provides the foundational registry and schema for deterministic,
+rule-based recommendations derived from persisted ClickHouse metrics.
+
+Sub-modules
+-----------
+schema      — Frozen dataclasses: RuleDef, EvidenceRef, Recommendation + type aliases.
+thresholds  — Named numeric constants for the 5 canonical rules (with PRD provenance).
+registry    — Canonical RuleDef list keyed by rule id; get_rule(), all_rules().
+
+Out of scope here
+-----------------
+engine, rule logic, sinks, and GraphQL are implemented in sibling sub-issues
+(CHAOS-1622, CHAOS-1623, CHAOS-1624).
+"""
+
+from dev_health_ops.recommendations.registry import all_rules, get_rule
+from dev_health_ops.recommendations.schema import (
+    EvidenceRef,
+    Recommendation,
+    RuleDef,
+    Severity,
+    Theme,
+    WindowUnit,
+)
+
+__all__ = [
+    "EvidenceRef",
+    "Recommendation",
+    "RuleDef",
+    "Severity",
+    "Theme",
+    "WindowUnit",
+    "all_rules",
+    "get_rule",
+]

--- a/src/dev_health_ops/recommendations/engine.py
+++ b/src/dev_health_ops/recommendations/engine.py
@@ -21,7 +21,7 @@ import logging
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
-from dev_health_ops.recommendations.snapshot import (  # noqa: F401 (re-export for rules)
+from dev_health_ops.recommendations.snapshot import (
     MetricsSnapshot,
     RecommendationRecord,
 )
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
     from dev_health_ops.recommendations.schema import Recommendation
 
 logger = logging.getLogger(__name__)
+
+__all__ = ["MetricsSnapshot", "RecommendationRecord", "RuleEngine"]
 
 
 def _parse_window(window: int | str) -> int:
@@ -77,6 +79,7 @@ class RuleEngine:
             from dev_health_ops.recommendations.rules import (
                 RULE_EVALUATORS,  # noqa: PLC0415
             )
+
             self._evaluators = dict(RULE_EVALUATORS)
 
     # ------------------------------------------------------------------
@@ -113,12 +116,16 @@ class RuleEngine:
             try:
                 rec = fn(snapshot, self._now)
             except Exception:
-                logger.exception("Rule %r raised for team=%r; skipping.", rule_id, team_id)
+                logger.exception(
+                    "Rule %r raised for team=%r; skipping.", rule_id, team_id
+                )
                 continue
             if rec is not None:
                 results.append(rec)
 
-        logger.debug("evaluate team=%r fired=%d/%d", team_id, len(results), len(self._evaluators))
+        logger.debug(
+            "evaluate team=%r fired=%d/%d", team_id, len(results), len(self._evaluators)
+        )
         return results
 
     def evaluate_all(
@@ -134,8 +141,12 @@ class RuleEngine:
         days = _parse_window(window)
         window_end = self._now.date()
         window_start = window_end - timedelta(days=days)
-        return self.evaluate(team_id=team_id, org_id=org_id,
-                             window_start=window_start, window_end=window_end)
+        return self.evaluate(
+            team_id=team_id,
+            org_id=org_id,
+            window_start=window_start,
+            window_end=window_end,
+        )
 
     def evaluate_one(
         self,
@@ -157,7 +168,9 @@ class RuleEngine:
         window_end = self._now.date()
         window_start = window_end - timedelta(days=days)
         snapshot = self._loader.load_team_metrics_window(
-            team_id=team_id, org_id=org_id,
-            window_start=window_start, window_end=window_end,
+            team_id=team_id,
+            org_id=org_id,
+            window_start=window_start,
+            window_end=window_end,
         )
         return self._evaluators[rule_id](snapshot, self._now)

--- a/src/dev_health_ops/recommendations/engine.py
+++ b/src/dev_health_ops/recommendations/engine.py
@@ -1,0 +1,163 @@
+"""Rule evaluation engine for the recommendations system (CHAOS-1622).
+
+The ``RuleEngine`` orchestrates metric loading, rule dispatch, and result
+collection.  It has NO side-effects itself — persistence is the caller's
+responsibility.
+
+Non-negotiable contracts
+------------------------
+* **Deterministic**: ``evaluate`` is a pure function of its arguments.
+* **now parameter**: injected at construction; never read inside rule logic.
+* **Hexagonal**: depends on the ``MetricsLoader`` *protocol*, not ClickHouse.
+
+MetricsSnapshot is re-exported here so rule files can write::
+
+    from dev_health_ops.recommendations.engine import MetricsSnapshot
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from dev_health_ops.recommendations.snapshot import (  # noqa: F401 (re-export for rules)
+    MetricsSnapshot,
+    RecommendationRecord,
+)
+
+if TYPE_CHECKING:
+    from dev_health_ops.recommendations.loader import MetricsLoader
+    from dev_health_ops.recommendations.schema import Recommendation
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_window(window: int | str) -> int:
+    """Return window in whole days.  Accepts int, ``"7d"``, ``"2w"``."""
+    if isinstance(window, int):
+        return window
+    s = str(window).strip().lower()
+    if s.endswith("d"):
+        return int(s[:-1])
+    if s.endswith("w"):
+        return int(s[:-1]) * 7
+    return int(s)
+
+
+class RuleEngine:
+    """Deterministic rule evaluation engine.
+
+    Args:
+        loader:     ``MetricsLoader`` implementation (ClickHouse or fake).
+        now:        Evaluation instant (UTC, timezone-aware).
+        registry:   Optional registry module/object with ``all_rules()``.
+                    Used for documentation/validation only.
+        evaluators: Optional dict[rule_id → callable] override.
+                    Defaults to ``RULE_EVALUATORS`` from ``recommendations.rules``.
+                    Inject a custom dict in tests.
+    """
+
+    def __init__(
+        self,
+        loader: MetricsLoader,
+        now: datetime,
+        registry: Any = None,
+        evaluators: dict[str, Any] | None = None,
+    ) -> None:
+        if now.tzinfo is None:
+            raise ValueError("RuleEngine.now must be timezone-aware (UTC).")
+        self._loader = loader
+        self._now = now
+        self._registry = registry
+
+        if evaluators is not None:
+            self._evaluators: dict[str, Any] = evaluators
+        else:
+            from dev_health_ops.recommendations.rules import (
+                RULE_EVALUATORS,  # noqa: PLC0415
+            )
+            self._evaluators = dict(RULE_EVALUATORS)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def evaluate(
+        self,
+        team_id: str,
+        org_id: str,
+        window_start: date,
+        window_end: date,
+    ) -> list[Recommendation]:
+        """Evaluate all registered rules; return fired recommendations only.
+
+        Args:
+            team_id:      Team identifier.
+            org_id:       Organisation ID for metric scoping.
+            window_start: Inclusive start date (UTC).
+            window_end:   Exclusive end date (UTC).
+
+        Returns:
+            ``list[Recommendation]`` — fired rules only, in evaluator dict order.
+            Rules that raise are logged and skipped.
+        """
+        snapshot = self._loader.load_team_metrics_window(
+            team_id=team_id,
+            org_id=org_id,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        results: list[Any] = []
+        for rule_id, fn in self._evaluators.items():
+            try:
+                rec = fn(snapshot, self._now)
+            except Exception:
+                logger.exception("Rule %r raised for team=%r; skipping.", rule_id, team_id)
+                continue
+            if rec is not None:
+                results.append(rec)
+
+        logger.debug("evaluate team=%r fired=%d/%d", team_id, len(results), len(self._evaluators))
+        return results
+
+    def evaluate_all(
+        self,
+        team_id: str,
+        window: int | str = 7,
+        org_id: str = "",
+    ) -> list[Recommendation]:
+        """Convenience wrapper: derive window dates from ``window`` string.
+
+        Window = ``[now.date() - window_days, now.date())``.
+        """
+        days = _parse_window(window)
+        window_end = self._now.date()
+        window_start = window_end - timedelta(days=days)
+        return self.evaluate(team_id=team_id, org_id=org_id,
+                             window_start=window_start, window_end=window_end)
+
+    def evaluate_one(
+        self,
+        rule_id: str,
+        team_id: str,
+        window: int | str = 7,
+        org_id: str = "",
+    ) -> Recommendation | None:
+        """Evaluate a single rule by *rule_id*.
+
+        Raises:
+            KeyError: when *rule_id* is not in the registered evaluators.
+        """
+        if rule_id not in self._evaluators:
+            raise KeyError(
+                f"Rule {rule_id!r} not found. Available: {sorted(self._evaluators)}"
+            )
+        days = _parse_window(window)
+        window_end = self._now.date()
+        window_start = window_end - timedelta(days=days)
+        snapshot = self._loader.load_team_metrics_window(
+            team_id=team_id, org_id=org_id,
+            window_start=window_start, window_end=window_end,
+        )
+        return self._evaluators[rule_id](snapshot, self._now)

--- a/src/dev_health_ops/recommendations/loader.py
+++ b/src/dev_health_ops/recommendations/loader.py
@@ -1,0 +1,376 @@
+"""MetricsLoader protocol + ClickHouseMetricsLoader implementation.
+
+The ``MetricsLoader`` is the hexagonal-architecture boundary between the
+rule engine and the analytics backend.  Rule evaluators receive a
+``MetricsSnapshot`` — a pure, frozen dataclass — so they are completely
+decoupled from I/O.
+
+ClickHouseMetricsLoader
+-----------------------
+Reads from the **canonical metric tables** following the
+``argMax(…, computed_at)`` append-only read pattern used throughout the
+codebase (see ``metrics/operating_review.py``).
+
+Tables used
+~~~~~~~~~~~
+* ``work_item_metrics_daily``   — wip, throughput, cycle time
+* ``team_metrics_daily``        — after-hours commit ratio
+* ``user_metrics_daily``        — review load per reviewer (Gini input)
+* ``repo_metrics_daily``        — rework ratio, p75 PR cycle time
+* ``repo_complexity_daily``     — cyclomatic complexity
+* ``file_hotspot_daily``        — high-risk hotspot files
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from datetime import date, timedelta
+from typing import Any, Protocol, runtime_checkable
+
+from dev_health_ops.recommendations.snapshot import (
+    MetricsSnapshot,
+    RecommendationRecord,
+)
+
+# ---------------------------------------------------------------------------
+# MetricsLoader protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class MetricsLoader(Protocol):
+    """Port (hexagonal architecture) for loading team metrics snapshots.
+
+    Implementations
+    ---------------
+    * ``ClickHouseMetricsLoader`` — production backend.
+    * Tests: pass any object implementing ``load_team_metrics_window``.
+    """
+
+    def load_team_metrics_window(
+        self,
+        team_id: str,
+        org_id: str,
+        window_start: date,
+        window_end: date,
+    ) -> MetricsSnapshot:
+        """Return a frozen ``MetricsSnapshot`` for the given team and window.
+
+        Missing data fields are ``None`` / empty list — never raised.
+        """
+        ...  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# ClickHouseMetricsLoader
+# ---------------------------------------------------------------------------
+
+
+def _gini(values: list[float]) -> float | None:
+    """Gini coefficient of *values*; ``None`` when < 2 positive entries."""
+    positives = [v for v in values if v > 0]
+    if len(positives) < 2:
+        return None
+    total = sum(positives)
+    if total == 0.0:
+        return 0.0
+    n = len(positives)
+    sorted_vals = sorted(positives)
+    cumulative = sum((i + 1) * v for i, v in enumerate(sorted_vals))
+    return (2.0 * cumulative) / (n * total) - (n + 1.0) / n
+
+
+def _safe_float(value: Any) -> float | None:
+    """Coerce *value* to float; return ``None`` for ``None`` or NaN."""
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return None if math.isnan(f) else f
+
+
+class ClickHouseMetricsLoader:
+    """Production ``MetricsLoader`` backed by ClickHouse.
+
+    Args:
+        client:  Synchronous ``clickhouse_connect`` client.
+        org_id:  Organisation ID for multi-tenant scoping.
+    """
+
+    def __init__(self, client: Any, org_id: str = "") -> None:
+        self._client = client
+        self._org_id = org_id
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _qd(self, query: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        result = self._client.query(query, parameters=params)
+        col_names = list(getattr(result, "column_names", []) or [])
+        rows = list(getattr(result, "result_rows", []) or [])
+        if not col_names or not rows:
+            return []
+        return [dict(zip(col_names, row)) for row in rows]
+
+    def _oc(self) -> str:
+        return "AND org_id = %(org_id)s" if self._org_id else ""
+
+    def _p(self, team_id: str, ws: date, we: date) -> dict[str, Any]:
+        p: dict[str, Any] = {"team_id": team_id, "start": ws, "end": we}
+        if self._org_id:
+            p["org_id"] = self._org_id
+        return p
+
+    # ------------------------------------------------------------------
+    # Signal loaders
+    # ------------------------------------------------------------------
+
+    def _load_wip_throughput(
+        self, team_id: str, ws: date, we: date
+    ) -> tuple[list[float], list[float]]:
+        oc = self._oc()
+        q = f"""
+            SELECT day, sum(wip) AS wip_total, sum(completed) AS tp_total
+            FROM (
+                SELECT day,
+                       argMax(wip_count_end_of_day, computed_at) AS wip,
+                       argMax(items_completed, computed_at) AS completed
+                FROM work_item_metrics_daily
+                WHERE team_id = %(team_id)s
+                  AND day >= %(start)s AND day < %(end)s {oc}
+                GROUP BY day, provider, work_scope_id
+            )
+            GROUP BY day ORDER BY day
+        """
+        rows = self._qd(q, self._p(team_id, ws, we))
+        wip = [float(r.get("wip_total") or 0.0) for r in rows]
+        tp = [float(r.get("tp_total") or 0.0) for r in rows]
+        return wip, tp
+
+    def _load_review_signals(
+        self, team_id: str, ws: date, we: date
+    ) -> tuple[float | None, float | None]:
+        oc = self._oc()
+        params = self._p(team_id, ws, we)
+
+        # p75 PR cycle time across repos
+        q_lat = f"""
+            SELECT avg(p75) AS avg_p75
+            FROM (
+                SELECT repo_id, argMax(pr_cycle_p75_hours, computed_at) AS p75
+                FROM repo_metrics_daily
+                WHERE day >= %(start)s AND day < %(end)s {oc}
+                GROUP BY repo_id
+            )
+        """
+        lat_rows = self._qd(q_lat, params)
+        review_latency = _safe_float(lat_rows[0].get("avg_p75") if lat_rows else None)
+
+        # Reviewer Gini from user_metrics_daily
+        q_gini = f"""
+            SELECT author_email, sum(rev) AS total_reviews
+            FROM (
+                SELECT repo_id, author_email, day,
+                       argMax(reviews_given, computed_at) AS rev
+                FROM user_metrics_daily
+                WHERE team_id = %(team_id)s
+                  AND day >= %(start)s AND day < %(end)s {oc}
+                GROUP BY repo_id, author_email, day
+            )
+            GROUP BY author_email
+        """
+        gini_rows = self._qd(q_gini, params)
+        loads = [float(r.get("total_reviews") or 0.0) for r in gini_rows]
+        return review_latency, _gini(loads)
+
+    def _load_rework_ratio(self, team_id: str, ws: date, we: date) -> float | None:
+        oc = self._oc()
+        q = f"""
+            SELECT avg(rework) AS avg_rework
+            FROM (
+                SELECT repo_id, argMax(pr_rework_ratio, computed_at) AS rework
+                FROM repo_metrics_daily
+                WHERE day >= %(start)s AND day < %(end)s {oc}
+                GROUP BY repo_id
+            )
+        """
+        rows = self._qd(q, self._p(team_id, ws, we))
+        return _safe_float(rows[0].get("avg_rework") if rows else None)
+
+    def _load_sustainability_signals(
+        self, team_id: str, ws: date, we: date
+    ) -> tuple[float | None, list[float]]:
+        oc = self._oc()
+        params = self._p(team_id, ws, we)
+
+        # Average after_hours_commit_ratio over window
+        q_ah = f"""
+            SELECT avg(ratio) AS avg_ratio
+            FROM (
+                SELECT day, argMax(after_hours_commit_ratio, computed_at) AS ratio
+                FROM team_metrics_daily
+                WHERE team_id = %(team_id)s
+                  AND day >= %(start)s AND day < %(end)s {oc}
+                GROUP BY day
+            )
+        """
+        ah_rows = self._qd(q_ah, params)
+        after_hours = _safe_float(ah_rows[0].get("avg_ratio") if ah_rows else None)
+
+        # Cycle time per day (avg across scopes)
+        q_ct = f"""
+            SELECT day, avg(ct) AS avg_ct
+            FROM (
+                SELECT day, provider, work_scope_id,
+                       argMax(cycle_time_p50_hours, computed_at) AS ct
+                FROM work_item_metrics_daily
+                WHERE team_id = %(team_id)s
+                  AND day >= %(start)s AND day < %(end)s {oc}
+                GROUP BY day, provider, work_scope_id
+            )
+            GROUP BY day ORDER BY day
+        """
+        ct_rows = self._qd(q_ct, params)
+        cycle_times = [
+            float(r["avg_ct"]) for r in ct_rows if r.get("avg_ct") is not None
+        ]
+        return after_hours, cycle_times
+
+    def _load_compounding_signals(
+        self, team_id: str, ws: date, we: date
+    ) -> tuple[float | None, float | None]:
+        oc = self._oc()
+        mid = ws + timedelta(days=max(1, (we - ws).days // 2))
+        params = {**self._p(team_id, ws, we), "mid": mid}
+
+        # Complexity delta: second half avg vs first half avg
+        q_cpx = f"""
+            SELECT
+                avg(if(day < %(mid)s, cpk, NULL)) AS first_half,
+                avg(if(day >= %(mid)s, cpk, NULL)) AS second_half
+            FROM (
+                SELECT day, repo_id,
+                       argMax(cyclomatic_per_kloc, computed_at) AS cpk
+                FROM repo_complexity_daily
+                WHERE day >= %(start)s AND day < %(end)s {oc}
+                GROUP BY day, repo_id
+            )
+        """
+        cpx_rows = self._qd(q_cpx, params)
+        complexity_delta: float | None = None
+        if cpx_rows:
+            first = _safe_float(cpx_rows[0].get("first_half"))
+            second = _safe_float(cpx_rows[0].get("second_half"))
+            if first is not None and second is not None:
+                complexity_delta = (second - first) / max(first, 1.0)
+
+        # Hotspot count in second half (files with risk_score > 0)
+        q_hs = f"""
+            SELECT count(DISTINCT file_path) AS total
+            FROM (
+                SELECT file_path, argMax(risk_score, computed_at) AS risk_score
+                FROM file_hotspot_daily
+                WHERE day >= %(mid)s AND day < %(end)s {oc}
+                GROUP BY file_path
+            ) WHERE risk_score > 0
+        """
+        hs_rows = self._qd(q_hs, params)
+        total_hotspots = int(hs_rows[0]["total"]) if hs_rows else 0
+
+        churn_overlap: float | None = None
+        if total_hotspots > 0:
+            # Proxy: if overall complexity is rising, treat overlap as the
+            # normalised delta (capped at 1.0). Full file-level join is a
+            # follow-up optimisation.
+            churn_overlap = (
+                min(1.0, max(0.0, complexity_delta))
+                if complexity_delta is not None and complexity_delta > 0
+                else 0.0
+            )
+
+        return complexity_delta, churn_overlap
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def load_team_metrics_window(
+        self,
+        team_id: str,
+        org_id: str,
+        window_start: date,
+        window_end: date,
+    ) -> MetricsSnapshot:
+        """Load all signals for *team_id* in ``[window_start, window_end)``."""
+        prev_org = self._org_id
+        if org_id:
+            self._org_id = org_id
+        try:
+            wip, throughput = self._load_wip_throughput(team_id, window_start, window_end)
+            rev_lat, rev_gini = self._load_review_signals(team_id, window_start, window_end)
+            rework = self._load_rework_ratio(team_id, window_start, window_end)
+            after_hours, cycle_times = self._load_sustainability_signals(
+                team_id, window_start, window_end
+            )
+            complexity_delta, churn_overlap = self._load_compounding_signals(
+                team_id, window_start, window_end
+            )
+        finally:
+            self._org_id = prev_org
+
+        return MetricsSnapshot(
+            team_id=team_id,
+            org_id=org_id,
+            window_start=window_start,
+            window_end=window_end,
+            wip_by_day=wip,
+            throughput_by_cycle=throughput,
+            review_latency_p75_hours=rev_lat,
+            reviewer_gini=rev_gini,
+            rework_churn_ratio=rework,
+            after_hours_ratio=after_hours,
+            cycle_time_by_day=cycle_times,
+            hotspot_complexity_delta=complexity_delta,
+            hotspot_churn_overlap=churn_overlap,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helper — Recommendation → RecommendationRecord
+# ---------------------------------------------------------------------------
+
+
+def recommendation_to_record(
+    rec: Any, rule_version: str = "1.0.0"
+) -> RecommendationRecord:
+    """Convert a ``Recommendation`` to a ``RecommendationRecord`` for the sink."""
+    evidence_list = [
+        {
+            "team_id": e.team_id,
+            "metric_table": e.metric_table,
+            "window_start": e.window_start.isoformat(),
+            "window_end": e.window_end.isoformat(),
+            "field": e.field,
+            "value": e.value,
+        }
+        for e in rec.evidence
+    ]
+    return RecommendationRecord(
+        team_id=rec.team_id,
+        org_id=rec.org_id,
+        rule_id=rec.rule_id,
+        rule_version=rule_version,
+        window_start=rec.window_start,
+        window_end=rec.window_end,
+        fired=True,
+        severity=rec.severity,
+        title=rec.title,
+        rationale=rec.rationale,
+        success_criterion=rec.success_criterion,
+        evidence_json=json.dumps(evidence_list),
+        computed_at=rec.computed_at,
+    )

--- a/src/dev_health_ops/recommendations/loader.py
+++ b/src/dev_health_ops/recommendations/loader.py
@@ -59,7 +59,7 @@ class MetricsLoader(Protocol):
 
         Missing data fields are ``None`` / empty list — never raised.
         """
-        ...  # pragma: no cover
+        raise NotImplementedError
 
 
 # ---------------------------------------------------------------------------
@@ -310,8 +310,12 @@ class ClickHouseMetricsLoader:
         if org_id:
             self._org_id = org_id
         try:
-            wip, throughput = self._load_wip_throughput(team_id, window_start, window_end)
-            rev_lat, rev_gini = self._load_review_signals(team_id, window_start, window_end)
+            wip, throughput = self._load_wip_throughput(
+                team_id, window_start, window_end
+            )
+            rev_lat, rev_gini = self._load_review_signals(
+                team_id, window_start, window_end
+            )
             rework = self._load_rework_ratio(team_id, window_start, window_end)
             after_hours, cycle_times = self._load_sustainability_signals(
                 team_id, window_start, window_end

--- a/src/dev_health_ops/recommendations/registry.py
+++ b/src/dev_health_ops/recommendations/registry.py
@@ -93,8 +93,7 @@ _RULES: tuple[RuleDef, ...] = (
             "change pressure, compounding architectural risk."
         ),
         success_criterion=(
-            "Complexity delta in hotspot files drops below threshold within "
-            "2 cycles."
+            "Complexity delta in hotspot files drops below threshold within 2 cycles."
         ),
         severity="critical",
         theme="maintenance-tech-debt",
@@ -135,9 +134,7 @@ def get_rule(rule_id: str) -> RuleDef:
         return _INDEX[rule_id]
     except KeyError:
         known = ", ".join(repr(r) for r in _INDEX)
-        raise KeyError(
-            f"Unknown rule id {rule_id!r}. Known ids: {known}"
-        ) from None
+        raise KeyError(f"Unknown rule id {rule_id!r}. Known ids: {known}") from None
 
 
 def all_rules() -> tuple[RuleDef, ...]:

--- a/src/dev_health_ops/recommendations/registry.py
+++ b/src/dev_health_ops/recommendations/registry.py
@@ -1,0 +1,145 @@
+"""Canonical registry of all recommendation rule definitions.
+
+The registry is code, not configuration.  Rules are defined as RuleDef
+instances in _RULES below.  Two public accessors are provided:
+
+    get_rule(id: str) -> RuleDef   — raises KeyError for unknown ids
+    all_rules() -> tuple[RuleDef, ...]  — ordered tuple of all rules
+
+Duplicate-ID guard
+------------------
+A module-level assertion fires at import time if any two rules share an id,
+making registry corruption fail loudly instead of silently losing a rule.
+
+Adding a rule
+-------------
+1.  Add a RuleDef entry to _RULES.
+2.  Add the corresponding thresholds to thresholds.py.
+3.  Implement the rule function under recommendations/rules/ (CHAOS-1623).
+4.  Add a test asserting the rule id is present and the registry is valid.
+"""
+
+from __future__ import annotations
+
+from dev_health_ops.recommendations.schema import RuleDef
+
+# ---------------------------------------------------------------------------
+# Canonical rule definitions
+# (order is stable; do not reorder — ids are the public contract)
+# ---------------------------------------------------------------------------
+
+_RULES: tuple[RuleDef, ...] = (
+    RuleDef(
+        id="saturation",
+        title="Team Saturation",
+        description=(
+            "Rising WIP combined with flat throughput signals the team is "
+            "taking on more work than it can complete."
+        ),
+        success_criterion=(
+            "WIP trend turns negative OR throughput trend turns positive "
+            "within 2 cycles."
+        ),
+        severity="warning",
+        theme="operational-support",
+    ),
+    RuleDef(
+        id="review-concentration",
+        title="Review Concentration Risk",
+        description=(
+            "High review latency paired with a concentrated reviewer set "
+            "creates a delivery bottleneck and bus-factor risk."
+        ),
+        success_criterion=(
+            "Reviewer Gini drops below threshold OR review latency p75 drops "
+            "below threshold within 2 cycles."
+        ),
+        severity="warning",
+        theme="risk-security",
+    ),
+    RuleDef(
+        id="thrash",
+        title="Thrash Detected",
+        description=(
+            "High rework churn alongside low delivery output suggests repeated "
+            "work on the same code paths without forward progress."
+        ),
+        success_criterion=(
+            "Churn ratio drops below threshold OR throughput trend turns "
+            "positive within 2 cycles."
+        ),
+        severity="warning",
+        theme="quality-reliability",
+    ),
+    RuleDef(
+        id="sustainability-risk",
+        title="Sustainability Risk",
+        description=(
+            "Elevated after-hours activity combined with rising cycle time "
+            "suggests delivery is being sustained by time debt."
+        ),
+        success_criterion=(
+            "After-hours ratio drops below threshold AND cycle time trend "
+            "stabilises within 2 cycles."
+        ),
+        severity="critical",
+        theme="operational-support",
+    ),
+    RuleDef(
+        id="compounding-risk",
+        title="Compounding Code Risk",
+        description=(
+            "Complexity is rising in the files that already receive the most "
+            "change pressure, compounding architectural risk."
+        ),
+        success_criterion=(
+            "Complexity delta in hotspot files drops below threshold within "
+            "2 cycles."
+        ),
+        severity="critical",
+        theme="maintenance-tech-debt",
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Duplicate-ID guard — fires at import time, not at call time
+# ---------------------------------------------------------------------------
+
+_ids: list[str] = [rule.id for rule in _RULES]
+_seen: set[str] = set()
+for _rule_id in _ids:
+    if _rule_id in _seen:
+        raise ValueError(
+            f"Duplicate rule id {_rule_id!r} detected in recommendations registry. "
+            "Each rule id must be unique."
+        )
+    _seen.add(_rule_id)
+del _ids, _seen, _rule_id  # clean up module namespace
+
+# ---------------------------------------------------------------------------
+# Public accessors
+# ---------------------------------------------------------------------------
+
+_INDEX: dict[str, RuleDef] = {rule.id: rule for rule in _RULES}
+
+
+def get_rule(rule_id: str) -> RuleDef:
+    """Return the RuleDef for *rule_id*.
+
+    Raises
+    ------
+    KeyError
+        If *rule_id* is not a known canonical rule id.
+    """
+    try:
+        return _INDEX[rule_id]
+    except KeyError:
+        known = ", ".join(repr(r) for r in _INDEX)
+        raise KeyError(
+            f"Unknown rule id {rule_id!r}. Known ids: {known}"
+        ) from None
+
+
+def all_rules() -> tuple[RuleDef, ...]:
+    """Return all registered rules in stable definition order."""
+    return _RULES

--- a/src/dev_health_ops/recommendations/rules/__init__.py
+++ b/src/dev_health_ops/recommendations/rules/__init__.py
@@ -1,0 +1,46 @@
+"""Canonical recommendation rules — auto-registered from this package.
+
+Each rule is a pure function::
+
+    evaluate_<rule>(snapshot: MetricsSnapshot, now: datetime) -> Recommendation | None
+
+Import RULE_EVALUATORS to get the full id → callable mapping that the
+RuleEngine iterates over.
+
+NOTE: imports of schema / thresholds will resolve once CHAOS-1621 (rec-foundation)
+and CHAOS-1622 (rec-engine-core) land. Until then this module uses
+forward-compatible TYPE_CHECKING guards.
+"""
+
+from __future__ import annotations
+
+from dev_health_ops.recommendations.rules.compounding_risk import (
+    evaluate_compounding_risk,
+)
+from dev_health_ops.recommendations.rules.review_concentration import (
+    evaluate_review_concentration,
+)
+from dev_health_ops.recommendations.rules.saturation import evaluate_saturation
+from dev_health_ops.recommendations.rules.sustainability_risk import (
+    evaluate_sustainability_risk,
+)
+from dev_health_ops.recommendations.rules.thrash import evaluate_thrash
+
+# Canonical mapping: rule_id → evaluator callable.
+# The RuleEngine iterates this dict; order is deterministic (insertion order).
+RULE_EVALUATORS = {
+    "saturation": evaluate_saturation,
+    "review-concentration": evaluate_review_concentration,
+    "thrash": evaluate_thrash,
+    "sustainability-risk": evaluate_sustainability_risk,
+    "compounding-risk": evaluate_compounding_risk,
+}
+
+__all__ = [
+    "RULE_EVALUATORS",
+    "evaluate_compounding_risk",
+    "evaluate_review_concentration",
+    "evaluate_saturation",
+    "evaluate_sustainability_risk",
+    "evaluate_thrash",
+]

--- a/src/dev_health_ops/recommendations/rules/compounding_risk.py
+++ b/src/dev_health_ops/recommendations/rules/compounding_risk.py
@@ -1,0 +1,109 @@
+"""Compounding-risk rule — Complexity rising in hotspots.
+
+PRD trigger (§P1: Operational Recommendations):
+    "Complexity rising in hotspots ->
+     Code risk is compounding where change pressure is highest."
+
+Logic (deterministic, no I/O):
+    1. Check hotspot_complexity_delta >= COMPLEXITY_DELTA_THRESHOLD.
+    2. Check hotspot_churn_overlap >= HOTSPOT_CHURN_OVERLAP_THRESHOLD.
+    3. Trigger when BOTH conditions hold.
+    4. Return None if either field is None (no hotspot data).
+
+Field interpretations:
+    hotspot_complexity_delta : normalised increase in cyclomatic complexity
+                               across top-N hotspot files over the window.
+    hotspot_churn_overlap    : fraction of hotspot files that also have rising
+                               complexity (intersection of high-churn + high-complexity).
+
+Metric loader fields consumed from MetricsSnapshot:
+    - snapshot.hotspot_complexity_delta  : float | None
+    - snapshot.hotspot_churn_overlap     : float | None
+    - snapshot.team_id, org_id, window_start, window_end
+
+Source tables referenced in evidence:
+    - file_complexity_snapshots (cyclomatic_per_kloc delta)
+    - file_metrics_daily        (hotspot_score, churn)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from dev_health_ops.recommendations.engine import MetricsSnapshot
+from dev_health_ops.recommendations.schema import EvidenceRef, Recommendation
+from dev_health_ops.recommendations.thresholds import (
+    COMPLEXITY_DELTA_THRESHOLD,
+    HOTSPOT_CHURN_OVERLAP_THRESHOLD,
+)
+
+RULE_ID = "compounding-risk"
+RULE_VERSION = "1.0.0"
+SUCCESS_CRITERION = (
+    f"Hotspot complexity delta drops below {COMPLEXITY_DELTA_THRESHOLD} OR "
+    f"churn-complexity overlap drops below {HOTSPOT_CHURN_OVERLAP_THRESHOLD} in 2 cycles"
+)
+
+
+def evaluate_compounding_risk(
+    snapshot: MetricsSnapshot,
+    now: datetime,
+) -> Recommendation | None:
+    """Trigger when code complexity is rising in the highest-churn hotspots.
+
+    Args:
+        snapshot: Pre-loaded metrics for the evaluation window.
+        now: Evaluation instant (UTC). Passed explicitly for determinism.
+
+    Returns:
+        A Recommendation if the rule fires, else None.
+    """
+    if snapshot.hotspot_complexity_delta is None or snapshot.hotspot_churn_overlap is None:
+        return None
+
+    complexity_delta: float = snapshot.hotspot_complexity_delta
+    churn_overlap: float = snapshot.hotspot_churn_overlap
+
+    if complexity_delta < COMPLEXITY_DELTA_THRESHOLD:
+        return None
+    if churn_overlap < HOTSPOT_CHURN_OVERLAP_THRESHOLD:
+        return None
+
+    evidence: tuple[EvidenceRef, ...] = (
+        EvidenceRef(
+            team_id=snapshot.team_id,
+            metric_table="file_complexity_snapshots",
+            window_start=snapshot.window_start,
+            window_end=snapshot.window_end,
+            field="hotspot_complexity_delta",
+            value=round(complexity_delta, 4),
+        ),
+        EvidenceRef(
+            team_id=snapshot.team_id,
+            metric_table="file_metrics_daily",
+            window_start=snapshot.window_start,
+            window_end=snapshot.window_end,
+            field="hotspot_churn_overlap",
+            value=round(churn_overlap, 4),
+        ),
+    )
+
+    return Recommendation(
+        rule_id=RULE_ID,
+        team_id=snapshot.team_id,
+        org_id=snapshot.org_id,
+        computed_at=now,
+        window_start=snapshot.window_start,
+        window_end=snapshot.window_end,
+        severity="warning",
+        title="Code risk is compounding where change pressure is highest.",
+        rationale=(
+            f"Hotspot complexity delta is {complexity_delta:.3f} "
+            f"(threshold: {COMPLEXITY_DELTA_THRESHOLD}) and churn-complexity overlap "
+            f"is {churn_overlap:.3f} "
+            f"(threshold: {HOTSPOT_CHURN_OVERLAP_THRESHOLD}), "
+            "indicating growing technical debt in the most actively-changed files."
+        ),
+        success_criterion=SUCCESS_CRITERION,
+        evidence=evidence,
+    )

--- a/src/dev_health_ops/recommendations/rules/compounding_risk.py
+++ b/src/dev_health_ops/recommendations/rules/compounding_risk.py
@@ -58,7 +58,10 @@ def evaluate_compounding_risk(
     Returns:
         A Recommendation if the rule fires, else None.
     """
-    if snapshot.hotspot_complexity_delta is None or snapshot.hotspot_churn_overlap is None:
+    if (
+        snapshot.hotspot_complexity_delta is None
+        or snapshot.hotspot_churn_overlap is None
+    ):
         return None
 
     complexity_delta: float = snapshot.hotspot_complexity_delta

--- a/src/dev_health_ops/recommendations/rules/review_concentration.py
+++ b/src/dev_health_ops/recommendations/rules/review_concentration.py
@@ -1,0 +1,118 @@
+"""Review-concentration rule — High review latency + concentrated reviewers (Gini).
+
+PRD trigger (§P1: Operational Recommendations):
+    "High review latency + concentrated reviewers ->
+     Review dependency risk. Add reviewers or rotate ownership."
+
+Logic (deterministic, no I/O):
+    1. Check review_latency_p75_hours >= REVIEW_LATENCY_P75_HOURS.
+    2. Check reviewer_gini >= REVIEWER_GINI_THRESHOLD.
+    3. Trigger when BOTH conditions hold.
+    4. Return None if either field is None (insufficient data).
+
+Metric loader fields consumed from MetricsSnapshot:
+    - snapshot.review_latency_p75_hours  : float | None
+    - snapshot.reviewer_gini             : float | None
+    - snapshot.team_id, org_id, window_start, window_end
+
+Source tables referenced in evidence:
+    - repo_metrics_daily   (pr_cycle_p75_hours)
+    - review_edge_daily    (reviewer distribution -> Gini)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from dev_health_ops.recommendations.engine import MetricsSnapshot
+from dev_health_ops.recommendations.schema import EvidenceRef, Recommendation
+from dev_health_ops.recommendations.thresholds import (
+    REVIEW_LATENCY_P75_HOURS,
+    REVIEWER_GINI_THRESHOLD,
+)
+
+RULE_ID = "review-concentration"
+RULE_VERSION = "1.0.0"
+SUCCESS_CRITERION = (
+    f"Reviewer Gini drops below {REVIEWER_GINI_THRESHOLD} OR review latency p75 drops "
+    f"below {REVIEW_LATENCY_P75_HOURS}h in 2 cycles"
+)
+
+
+def gini(values: list[float]) -> float:
+    """Compute Gini coefficient for a list of non-negative values.
+
+    Returns 0.0 for empty input or when all values are zero.
+    """
+    if not values:
+        return 0.0
+    total = sum(values)
+    if total == 0.0:
+        return 0.0
+    n = len(values)
+    sorted_vals = sorted(values)
+    cum_sum = sum((i + 1) * v for i, v in enumerate(sorted_vals))
+    return (2.0 * cum_sum) / (n * total) - (n + 1.0) / n
+
+
+def evaluate_review_concentration(
+    snapshot: MetricsSnapshot,
+    now: datetime,
+) -> Recommendation | None:
+    """Trigger when review latency is high AND reviewer load is concentrated.
+
+    Args:
+        snapshot: Pre-loaded metrics for the evaluation window.
+        now: Evaluation instant (UTC). Passed explicitly for determinism.
+
+    Returns:
+        A Recommendation if the rule fires, else None.
+    """
+    if snapshot.review_latency_p75_hours is None or snapshot.reviewer_gini is None:
+        return None
+
+    latency: float = snapshot.review_latency_p75_hours
+    gini_score: float = snapshot.reviewer_gini
+
+    if latency < REVIEW_LATENCY_P75_HOURS:
+        return None
+    if gini_score < REVIEWER_GINI_THRESHOLD:
+        return None
+
+    evidence: tuple[EvidenceRef, ...] = (
+        EvidenceRef(
+            team_id=snapshot.team_id,
+            metric_table="repo_metrics_daily",
+            window_start=snapshot.window_start,
+            window_end=snapshot.window_end,
+            field="review_latency_p75_hours",
+            value=round(latency, 2),
+        ),
+        EvidenceRef(
+            team_id=snapshot.team_id,
+            metric_table="review_edge_daily",
+            window_start=snapshot.window_start,
+            window_end=snapshot.window_end,
+            field="reviewer_gini",
+            value=round(gini_score, 4),
+        ),
+    )
+
+    return Recommendation(
+        rule_id=RULE_ID,
+        team_id=snapshot.team_id,
+        org_id=snapshot.org_id,
+        computed_at=now,
+        window_start=snapshot.window_start,
+        window_end=snapshot.window_end,
+        severity="warning",
+        title="Review dependency risk. Add reviewers or rotate ownership.",
+        rationale=(
+            f"Review latency p75 is {latency:.1f}h "
+            f"(threshold: {REVIEW_LATENCY_P75_HOURS}h) and reviewer Gini is "
+            f"{gini_score:.3f} (threshold: {REVIEWER_GINI_THRESHOLD}), "
+            "indicating review load is concentrated in few individuals."
+        ),
+        success_criterion=SUCCESS_CRITERION,
+        evidence=evidence,
+    )

--- a/src/dev_health_ops/recommendations/rules/saturation.py
+++ b/src/dev_health_ops/recommendations/rules/saturation.py
@@ -1,0 +1,119 @@
+"""Saturation rule — Rising WIP + flat throughput.
+
+PRD trigger (§P1: Operational Recommendations):
+    "Rising WIP + flat throughput → The team is saturating.
+     Reduce active work before adding scope."
+
+Logic (deterministic, no I/O):
+    1. Compute linear slope of wip_by_day over the window.
+    2. Compute throughput_delta = last point - first point of throughput_by_cycle.
+    3. Trigger when:
+       slope >= WIP_RISING_SLOPE_THRESHOLD AND
+       throughput_delta <= THROUGHPUT_FLAT_DELTA_THRESHOLD
+
+Metric loader fields consumed from MetricsSnapshot:
+    - snapshot.wip_by_day           : list[float]  (wip_count_end_of_day per day)
+    - snapshot.throughput_by_cycle  : list[float]  (items_completed per cycle)
+    - snapshot.team_id              : str
+    - snapshot.org_id               : str
+    - snapshot.window_start         : date
+    - snapshot.window_end           : date
+
+Source tables referenced in evidence:
+    - work_item_metrics_daily  (wip_count_end_of_day, items_completed)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from dev_health_ops.recommendations.engine import MetricsSnapshot
+from dev_health_ops.recommendations.schema import EvidenceRef, Recommendation
+from dev_health_ops.recommendations.thresholds import (
+    THROUGHPUT_FLAT_DELTA_THRESHOLD,
+    WIP_RISING_SLOPE_THRESHOLD,
+)
+
+RULE_ID = "saturation"
+RULE_VERSION = "1.0.0"
+SUCCESS_CRITERION = (
+    "WIP trend turns negative or throughput trend turns positive in 2 cycles"
+)
+
+
+def _linear_slope(values: list[float]) -> float:
+    """Return OLS slope of *values* (x = index, y = value). Returns 0.0 for < 2 points."""
+    n = len(values)
+    if n < 2:
+        return 0.0
+    x_mean = (n - 1) / 2.0
+    y_mean = sum(values) / n
+    num = sum((i - x_mean) * (v - y_mean) for i, v in enumerate(values))
+    den = sum((i - x_mean) ** 2 for i in range(n))
+    return num / den if den else 0.0
+
+
+def evaluate_saturation(
+    snapshot: MetricsSnapshot,
+    now: datetime,
+) -> Recommendation | None:
+    """Trigger when WIP is rising and throughput is flat.
+
+    Args:
+        snapshot: Pre-loaded metrics for the evaluation window.
+        now: Evaluation instant (UTC). Passed explicitly for determinism.
+
+    Returns:
+        A Recommendation if the rule fires, else None.
+    """
+    wip = snapshot.wip_by_day
+    throughput = snapshot.throughput_by_cycle
+
+    if len(wip) < 2 or len(throughput) < 2:
+        return None
+
+    wip_slope = _linear_slope(list(wip))
+    throughput_delta = throughput[-1] - throughput[0]
+
+    if wip_slope < WIP_RISING_SLOPE_THRESHOLD:
+        return None
+    if throughput_delta > THROUGHPUT_FLAT_DELTA_THRESHOLD:
+        return None
+
+    evidence: tuple[EvidenceRef, ...] = (
+        EvidenceRef(
+            team_id=snapshot.team_id,
+            metric_table="work_item_metrics_daily",
+            window_start=snapshot.window_start,
+            window_end=snapshot.window_end,
+            field="wip_count_end_of_day",
+            value=round(wip_slope, 4),
+        ),
+        EvidenceRef(
+            team_id=snapshot.team_id,
+            metric_table="work_item_metrics_daily",
+            window_start=snapshot.window_start,
+            window_end=snapshot.window_end,
+            field="items_completed_delta",
+            value=round(throughput_delta, 4),
+        ),
+    )
+
+    return Recommendation(
+        rule_id=RULE_ID,
+        team_id=snapshot.team_id,
+        org_id=snapshot.org_id,
+        computed_at=now,
+        window_start=snapshot.window_start,
+        window_end=snapshot.window_end,
+        severity="warning",
+        title="Team is saturating. Reduce active work before adding scope.",
+        rationale=(
+            f"WIP slope is {wip_slope:.3f} items/day "
+            f"(threshold: {WIP_RISING_SLOPE_THRESHOLD}) and throughput delta is "
+            f"{throughput_delta:.1f} items/cycle "
+            f"(threshold: \u2264{THROUGHPUT_FLAT_DELTA_THRESHOLD})."
+        ),
+        success_criterion=SUCCESS_CRITERION,
+        evidence=evidence,
+    )

--- a/src/dev_health_ops/recommendations/rules/sustainability_risk.py
+++ b/src/dev_health_ops/recommendations/rules/sustainability_risk.py
@@ -1,0 +1,121 @@
+"""Sustainability-risk rule — High after-hours activity + rising cycle time.
+
+PRD trigger (§P1: Operational Recommendations):
+    "High after-hours + rising cycle time ->
+     Sustainability risk. Delivery may be propped up by time debt."
+
+Logic (deterministic, no I/O):
+    1. Check after_hours_ratio >= AFTER_HOURS_RATIO_THRESHOLD.
+    2. Compute linear slope of cycle_time_by_day.
+    3. Trigger when BOTH conditions hold:
+       after_hours_ratio >= AFTER_HOURS_RATIO_THRESHOLD AND
+       cycle_time_slope >= CYCLE_TIME_RISING_SLOPE_THRESHOLD
+    4. Return None if after_hours_ratio is None or cycle_time_by_day has < 2 points.
+
+Metric loader fields consumed from MetricsSnapshot:
+    - snapshot.after_hours_ratio     : float | None  (after_hours_commit_ratio)
+    - snapshot.cycle_time_by_day     : list[float]   (cycle_time_p50_hours per day)
+    - snapshot.team_id, org_id, window_start, window_end
+
+Source tables referenced in evidence:
+    - team_metrics_daily       (after_hours_commit_ratio)
+    - work_item_metrics_daily  (cycle_time_p50_hours)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from dev_health_ops.recommendations.engine import MetricsSnapshot
+from dev_health_ops.recommendations.schema import EvidenceRef, Recommendation
+from dev_health_ops.recommendations.thresholds import (
+    AFTER_HOURS_RATIO_THRESHOLD,
+    CYCLE_TIME_RISING_SLOPE_THRESHOLD,
+)
+
+RULE_ID = "sustainability-risk"
+RULE_VERSION = "1.0.0"
+SUCCESS_CRITERION = (
+    f"After-hours ratio drops below {AFTER_HOURS_RATIO_THRESHOLD} AND "
+    "cycle time trend stabilises in 2 cycles"
+)
+
+
+def _linear_slope(values: list[float]) -> float:
+    """Return OLS slope of *values* (x = index, y = value). Returns 0.0 for < 2 points."""
+    n = len(values)
+    if n < 2:
+        return 0.0
+    x_mean = (n - 1) / 2.0
+    y_mean = sum(values) / n
+    num = sum((i - x_mean) * (v - y_mean) for i, v in enumerate(values))
+    den = sum((i - x_mean) ** 2 for i in range(n))
+    return num / den if den else 0.0
+
+
+def evaluate_sustainability_risk(
+    snapshot: MetricsSnapshot,
+    now: datetime,
+) -> Recommendation | None:
+    """Trigger when after-hours activity is high AND cycle time is rising.
+
+    Args:
+        snapshot: Pre-loaded metrics for the evaluation window.
+        now: Evaluation instant (UTC). Passed explicitly for determinism.
+
+    Returns:
+        A Recommendation if the rule fires, else None.
+    """
+    if snapshot.after_hours_ratio is None:
+        return None
+
+    after_hours: float = snapshot.after_hours_ratio
+    cycle_times = snapshot.cycle_time_by_day
+
+    if after_hours < AFTER_HOURS_RATIO_THRESHOLD:
+        return None
+    if len(cycle_times) < 2:
+        return None
+
+    ct_slope = _linear_slope(list(cycle_times))
+    if ct_slope < CYCLE_TIME_RISING_SLOPE_THRESHOLD:
+        return None
+
+    evidence: tuple[EvidenceRef, ...] = (
+        EvidenceRef(
+            team_id=snapshot.team_id,
+            metric_table="team_metrics_daily",
+            window_start=snapshot.window_start,
+            window_end=snapshot.window_end,
+            field="after_hours_commit_ratio",
+            value=round(after_hours, 4),
+        ),
+        EvidenceRef(
+            team_id=snapshot.team_id,
+            metric_table="work_item_metrics_daily",
+            window_start=snapshot.window_start,
+            window_end=snapshot.window_end,
+            field="cycle_time_p50_hours_slope",
+            value=round(ct_slope, 4),
+        ),
+    )
+
+    return Recommendation(
+        rule_id=RULE_ID,
+        team_id=snapshot.team_id,
+        org_id=snapshot.org_id,
+        computed_at=now,
+        window_start=snapshot.window_start,
+        window_end=snapshot.window_end,
+        severity="warning",
+        title="Sustainability risk. Delivery may be propped up by time debt.",
+        rationale=(
+            f"After-hours commit ratio is {after_hours:.3f} "
+            f"(threshold: {AFTER_HOURS_RATIO_THRESHOLD}) and cycle time slope is "
+            f"{ct_slope:.3f} hours/day "
+            f"(threshold: {CYCLE_TIME_RISING_SLOPE_THRESHOLD}), "
+            "suggesting extended hours are masking growing delivery pressure."
+        ),
+        success_criterion=SUCCESS_CRITERION,
+        evidence=evidence,
+    )

--- a/src/dev_health_ops/recommendations/rules/thrash.py
+++ b/src/dev_health_ops/recommendations/rules/thrash.py
@@ -1,0 +1,109 @@
+"""Thrash rule — High churn + low delivery.
+
+PRD trigger (§P1: Operational Recommendations):
+    "High churn + low delivery ->
+     Thrash likely. Inspect hotspots and rework loops."
+
+Logic (deterministic, no I/O):
+    1. Check rework_churn_ratio >= CHURN_RATIO_THRESHOLD.
+    2. Compute throughput_delta = last point - first point of throughput_by_cycle.
+    3. Trigger when BOTH conditions hold:
+       rework_churn_ratio >= CHURN_RATIO_THRESHOLD AND
+       throughput_delta <= THROUGHPUT_LOW_DELTA_THRESHOLD
+    4. Return None if rework_churn_ratio is None (no PR data).
+
+Metric loader fields consumed from MetricsSnapshot:
+    - snapshot.rework_churn_ratio    : float | None  (rework_churn_ratio_30d)
+    - snapshot.throughput_by_cycle   : list[float]   (items_completed per day)
+    - snapshot.team_id, org_id, window_start, window_end
+
+Source tables referenced in evidence:
+    - repo_metrics_daily       (rework_churn_ratio_30d)
+    - work_item_metrics_daily  (items_completed)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from dev_health_ops.recommendations.engine import MetricsSnapshot
+from dev_health_ops.recommendations.schema import EvidenceRef, Recommendation
+from dev_health_ops.recommendations.thresholds import (
+    CHURN_RATIO_THRESHOLD,
+    THROUGHPUT_LOW_DELTA_THRESHOLD,
+)
+
+RULE_ID = "thrash"
+RULE_VERSION = "1.0.0"
+SUCCESS_CRITERION = (
+    f"Churn ratio drops below {CHURN_RATIO_THRESHOLD} OR throughput delta turns "
+    "positive in 2 cycles"
+)
+
+
+def evaluate_thrash(
+    snapshot: MetricsSnapshot,
+    now: datetime,
+) -> Recommendation | None:
+    """Trigger when rework churn is high and throughput is flat or declining.
+
+    Args:
+        snapshot: Pre-loaded metrics for the evaluation window.
+        now: Evaluation instant (UTC). Passed explicitly for determinism.
+
+    Returns:
+        A Recommendation if the rule fires, else None.
+    """
+    if snapshot.rework_churn_ratio is None:
+        return None
+
+    churn_ratio: float = snapshot.rework_churn_ratio
+    throughput = snapshot.throughput_by_cycle
+
+    if churn_ratio < CHURN_RATIO_THRESHOLD:
+        return None
+    if len(throughput) < 2:
+        return None
+
+    throughput_delta = throughput[-1] - throughput[0]
+    if throughput_delta > THROUGHPUT_LOW_DELTA_THRESHOLD:
+        return None
+
+    evidence: tuple[EvidenceRef, ...] = (
+        EvidenceRef(
+            team_id=snapshot.team_id,
+            metric_table="repo_metrics_daily",
+            window_start=snapshot.window_start,
+            window_end=snapshot.window_end,
+            field="rework_churn_ratio_30d",
+            value=round(churn_ratio, 4),
+        ),
+        EvidenceRef(
+            team_id=snapshot.team_id,
+            metric_table="work_item_metrics_daily",
+            window_start=snapshot.window_start,
+            window_end=snapshot.window_end,
+            field="items_completed_delta",
+            value=round(throughput_delta, 4),
+        ),
+    )
+
+    return Recommendation(
+        rule_id=RULE_ID,
+        team_id=snapshot.team_id,
+        org_id=snapshot.org_id,
+        computed_at=now,
+        window_start=snapshot.window_start,
+        window_end=snapshot.window_end,
+        severity="warning",
+        title="Thrash likely. Inspect hotspots and rework loops.",
+        rationale=(
+            f"Rework churn ratio is {churn_ratio:.3f} "
+            f"(threshold: {CHURN_RATIO_THRESHOLD}) and throughput delta is "
+            f"{throughput_delta:.1f} items/cycle "
+            f"(threshold: \u2264{THROUGHPUT_LOW_DELTA_THRESHOLD}), "
+            "suggesting repeated rework is consuming capacity without advancing delivery."
+        ),
+        success_criterion=SUCCESS_CRITERION,
+        evidence=evidence,
+    )

--- a/src/dev_health_ops/recommendations/schema.py
+++ b/src/dev_health_ops/recommendations/schema.py
@@ -1,0 +1,154 @@
+"""Frozen dataclasses and type aliases for the recommendations engine.
+
+All public types are frozen and (where possible) use __slots__ for memory
+efficiency and accidental-mutation protection.
+
+Canonical rule IDs
+------------------
+"saturation" | "review-concentration" | "thrash" | "sustainability-risk" | "compounding-risk"
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Literal
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+Theme = Literal[
+    "feature-delivery",
+    "operational-support",
+    "maintenance-tech-debt",
+    "quality-reliability",
+    "risk-security",
+]
+
+Severity = Literal["warning", "critical"]
+
+WindowUnit = Literal["day", "week", "cycle"]
+
+
+# ---------------------------------------------------------------------------
+# Core dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRef:
+    """Pointer to a stored metric row that supports a recommendation.
+
+    All fields reference persisted ClickHouse data so every recommendation
+    is fully traceable to stored evidence.
+
+    Attributes
+    ----------
+    team_id:
+        Team the metric row belongs to.
+    metric_table:
+        ClickHouse table name (e.g. ``"work_item_metrics_daily"``).
+    window_start:
+        Inclusive start of the metric window (UTC date).
+    window_end:
+        Exclusive end of the metric window (UTC date).
+    field:
+        Column name within *metric_table* that triggered the rule.
+    value:
+        Observed value of *field* at evaluation time.
+    """
+
+    team_id: str
+    metric_table: str
+    window_start: date
+    window_end: date
+    field: str
+    value: float
+
+
+@dataclass(frozen=True, slots=True)
+class RuleDef:
+    """Static definition of a single recommendation rule.
+
+    Instances live in the registry (``registry.py``); they are never created
+    at runtime by rule logic.
+
+    Attributes
+    ----------
+    id:
+        Stable machine identifier (e.g. ``"saturation"``).  Must be unique
+        across all rules — the registry guard enforces this at import.
+    title:
+        Short human label shown in UI / reports.
+    description:
+        One-sentence description of the signal this rule detects.
+    success_criterion:
+        Measurable condition that, when met, means the recommendation is
+        resolved (shown to the operator).
+    severity:
+        ``"warning"`` for early signals; ``"critical"`` for acute risk.
+    theme:
+        Investment theme this rule primarily surfaces.
+    """
+
+    id: str
+    title: str
+    description: str
+    success_criterion: str
+    severity: Severity
+    theme: Theme
+
+
+@dataclass(frozen=True, slots=True)
+class Recommendation:
+    """A single fired recommendation for a team in a time window.
+
+    Produced by the evaluation engine (CHAOS-1622) and persisted via the
+    ClickHouse sink.  Immutable — never mutated after construction.
+
+    Attributes
+    ----------
+    rule_id:
+        Matches ``RuleDef.id``; use ``get_rule(rule_id)`` to resolve the
+        full definition.
+    team_id:
+        Team this recommendation is for.
+    org_id:
+        Organisation this recommendation is for.
+    computed_at:
+        UTC datetime the recommendation was produced.  Acts as the
+        append-only "triggered at" timestamp.
+    window_start:
+        Inclusive start of the metric window evaluated (UTC date).
+    window_end:
+        Exclusive end of the metric window evaluated (UTC date).
+    severity:
+        Severity at evaluation time (may differ from ``RuleDef.severity``
+        if rules support dynamic severity in future; kept here for
+        persistence completeness).
+    title:
+        Human-readable title (copied from ``RuleDef.title`` at compute
+        time so the record is self-contained).
+    rationale:
+        One-sentence explanation of *why* this rule fired (references
+        observed metric values).
+    success_criterion:
+        Copied from ``RuleDef.success_criterion`` at compute time.
+    evidence:
+        Tuple of evidence pointers to the stored metric rows that caused
+        this recommendation to fire.  May be empty only when a rule cannot
+        identify specific rows (strongly discouraged).
+    """
+
+    rule_id: str
+    team_id: str
+    org_id: str
+    computed_at: datetime
+    window_start: date
+    window_end: date
+    severity: Severity
+    title: str
+    rationale: str
+    success_criterion: str
+    evidence: tuple[EvidenceRef, ...]

--- a/src/dev_health_ops/recommendations/snapshot.py
+++ b/src/dev_health_ops/recommendations/snapshot.py
@@ -1,0 +1,143 @@
+"""MetricsSnapshot — the input contract between the engine and rule evaluators.
+
+Rule evaluators (CHAOS-1623) import ``MetricsSnapshot`` from
+``dev_health_ops.recommendations.engine`` (re-exported there).  This module
+is the single source of truth for the dataclass so neither engine.py nor
+loader.py depend on each other.
+
+RecommendationRecord
+--------------------
+Also lives here as the sink-layer row type written to
+``recommendations_daily`` by the ClickHouse sink.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+
+# ---------------------------------------------------------------------------
+# MetricsSnapshot
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class MetricsSnapshot:
+    """Immutable snapshot of all metric signals for one team + window.
+
+    Produced by a ``MetricsLoader`` and consumed by rule evaluator functions.
+    All evaluators receive the same snapshot object; they MUST be pure and
+    deterministic given identical inputs.
+
+    Conventions
+    -----------
+    * List fields are ordered ascending by day (index 0 = oldest).
+    * ``None`` scalar fields mean *no data available* for that signal —
+      evaluators must guard against ``None`` and return ``None`` (no fire).
+    * Empty list fields mean no daily rows matched; evaluators should return
+      ``None`` after a ``len(x) < 2`` guard.
+
+    Fields — saturation + thrash (shared)
+    --------------------------------------
+    wip_by_day:
+        ``wip_count_end_of_day`` summed per calendar day from
+        ``work_item_metrics_daily``.
+    throughput_by_cycle:
+        ``items_completed`` summed per calendar day (same table).
+        Named "by_cycle" because rule logic treats each point as a
+        discrete delivery unit.
+
+    Fields — review-concentration
+    ------------------------------
+    review_latency_p75_hours:
+        Team p75 PR cycle time (hours) from ``repo_metrics_daily``.
+        ``None`` when no PR data exists.
+    reviewer_gini:
+        Gini coefficient of ``reviews_given`` distribution across team
+        members over the window.  ``None`` when fewer than 2 reviewers.
+
+    Fields — thrash
+    ---------------
+    rework_churn_ratio:
+        Average ``pr_rework_ratio`` from ``repo_metrics_daily``.
+        ``None`` when no PR data.
+
+    Fields — sustainability-risk
+    ----------------------------
+    after_hours_ratio:
+        Average ``after_hours_commit_ratio`` from ``team_metrics_daily``
+        over the window.  ``None`` when no commit data.
+    cycle_time_by_day:
+        ``cycle_time_p50_hours`` averaged per day across scopes.
+        Empty list when no work-item data.
+
+    Fields — compounding-risk
+    -------------------------
+    hotspot_complexity_delta:
+        Normalised change in ``cyclomatic_per_kloc``: second-half average
+        minus first-half average, divided by max(first-half average, 1.0).
+        ``None`` when fewer than 2 data points.
+    hotspot_churn_overlap:
+        Fraction ∈ [0, 1] of high-risk hotspot files (``risk_score > 0``)
+        that also have increasing cyclomatic complexity.
+        ``None`` when no hotspot data.
+    """
+
+    team_id: str
+    org_id: str
+    window_start: date
+    window_end: date
+
+    # saturation + thrash (shared)
+    wip_by_day: list[float]
+    throughput_by_cycle: list[float]
+
+    # review-concentration
+    review_latency_p75_hours: float | None
+    reviewer_gini: float | None
+
+    # thrash
+    rework_churn_ratio: float | None
+
+    # sustainability-risk
+    after_hours_ratio: float | None
+    cycle_time_by_day: list[float]
+
+    # compounding-risk
+    hotspot_complexity_delta: float | None
+    hotspot_churn_overlap: float | None
+
+
+# ---------------------------------------------------------------------------
+# RecommendationRecord — sink row for recommendations_daily
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RecommendationRecord:
+    """Row written to the append-only ``recommendations_daily`` ClickHouse table.
+
+    One row per evaluation run per (team_id, rule_id).  Use
+    ``argMax(fired, computed_at)`` to read the latest status.
+
+    evidence_json
+    -------------
+    JSON-encoded ``list[dict]`` matching ``EvidenceRef`` shape::
+
+        [{"team_id": str, "metric_table": str, "window_start": "YYYY-MM-DD",
+          "window_end": "YYYY-MM-DD", "field": str, "value": float}, ...]
+    """
+
+    team_id: str
+    org_id: str
+    rule_id: str
+    rule_version: str
+    window_start: date
+    window_end: date
+    fired: bool
+    severity: str
+    title: str
+    rationale: str
+    success_criterion: str
+    evidence_json: str  # serialised list[EvidenceRef]
+    computed_at: datetime

--- a/src/dev_health_ops/recommendations/thresholds.py
+++ b/src/dev_health_ops/recommendations/thresholds.py
@@ -1,0 +1,88 @@
+"""Named numeric constants for the 5 canonical recommendation rules.
+
+Every constant carries a provenance comment quoting the PRD signal table
+(docs/product/dev-health-product-market-simplification.md lines 176-180).
+
+These values are intentionally grouped by rule so rule implementations can
+import exactly what they need:
+
+    from dev_health_ops.recommendations.thresholds import (
+        WIP_RISING_SLOPE_THRESHOLD,
+        THROUGHPUT_FLAT_DELTA_THRESHOLD,
+    )
+
+Anti-config contract
+--------------------
+Thresholds live here as named Python constants — NOT in YAML, a database,
+or environment variables.  Per-team overrides are explicitly forbidden.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Rule: saturation
+# PRD line 176: "Rising WIP + flat throughput →
+#                The team is saturating. Reduce active work before adding scope."
+# ---------------------------------------------------------------------------
+
+# Minimum daily WIP increase (items/day) averaged over the evaluation window
+# that qualifies as "rising".
+WIP_RISING_SLOPE_THRESHOLD: float = 0.1
+
+# Maximum items/cycle throughput delta that still qualifies as "flat".
+# A delta at or below this value (including negative) signals stagnation.
+THROUGHPUT_FLAT_DELTA_THRESHOLD: float = 0.0
+
+# ---------------------------------------------------------------------------
+# Rule: review-concentration
+# PRD line 177: "High review latency + concentrated reviewers →
+#                Review dependency risk. Add reviewers or rotate ownership."
+# ---------------------------------------------------------------------------
+
+# p75 review latency (hours) at or above which latency is considered "high".
+REVIEW_LATENCY_P75_HOURS: float = 24.0
+
+# Reviewer Gini coefficient at or above which ownership is "concentrated".
+# 0.0 = perfectly equal, 1.0 = single reviewer owns everything.
+REVIEWER_GINI_THRESHOLD: float = 0.6
+
+# ---------------------------------------------------------------------------
+# Rule: thrash
+# PRD line 178: "High churn + low delivery →
+#                Thrash likely. Inspect hotspots and rework loops."
+# ---------------------------------------------------------------------------
+
+# Rework churn ratio (rework LOC / total LOC) at or above which churn is
+# considered "high".  Computed by quality.compute_rework_churn_ratio().
+CHURN_RATIO_THRESHOLD: float = 0.3
+
+# Items/cycle throughput delta at or below which delivery is "low".
+THROUGHPUT_LOW_DELTA_THRESHOLD: float = 0.0
+
+# ---------------------------------------------------------------------------
+# Rule: sustainability-risk
+# PRD line 179: "High after-hours + rising cycle time →
+#                Sustainability risk. Delivery may be propped up by time debt."
+# ---------------------------------------------------------------------------
+
+# Fraction of work activity (commits, reviews, etc.) occurring outside
+# core business hours that qualifies as "high".
+AFTER_HOURS_RATIO_THRESHOLD: float = 0.2
+
+# Minimum hourly increase per day in cycle time trend that qualifies as
+# "rising cycle time".
+CYCLE_TIME_RISING_SLOPE_THRESHOLD: float = 0.1
+
+# ---------------------------------------------------------------------------
+# Rule: compounding-risk
+# PRD line 180: "Complexity rising in hotspots →
+#                Code risk is compounding where change pressure is highest."
+# ---------------------------------------------------------------------------
+
+# Normalised complexity increase (0.0–1.0) in hotspot files required to
+# qualify as "rising".
+COMPLEXITY_DELTA_THRESHOLD: float = 0.2
+
+# Fraction of hotspot files (by churn volume) that must show rising
+# complexity for the rule to fire.
+HOTSPOT_CHURN_OVERLAP_THRESHOLD: float = 0.4

--- a/tests/api/graphql/test_recommendations_resolver.py
+++ b/tests/api/graphql/test_recommendations_resolver.py
@@ -91,7 +91,10 @@ FIXTURE_ROWS = [
 @pytest.mark.anyio
 async def test_resolve_recommendations_returns_list(mock_context):
     """Resolver returns a non-empty list when rows are present."""
-    from dev_health_ops.api.graphql.models.recommendations import WindowInput, WindowUnit
+    from dev_health_ops.api.graphql.models.recommendations import (
+        WindowInput,
+        WindowUnit,
+    )
     from dev_health_ops.api.graphql.resolvers.recommendations import (
         resolve_recommendations,
     )
@@ -149,7 +152,10 @@ async def test_resolve_recommendations_field_mapping(mock_context):
 @pytest.mark.anyio
 async def test_resolve_recommendations_evidence_references_resolve(mock_context):
     """Evidence list is deserialised; each EvidenceRef carries required fields."""
-    from dev_health_ops.api.graphql.models.recommendations import WindowInput, WindowUnit
+    from dev_health_ops.api.graphql.models.recommendations import (
+        WindowInput,
+        WindowUnit,
+    )
     from dev_health_ops.api.graphql.resolvers.recommendations import (
         resolve_recommendations,
     )
@@ -180,7 +186,10 @@ async def test_resolve_recommendations_evidence_references_resolve(mock_context)
 @pytest.mark.anyio
 async def test_resolve_recommendations_empty_on_no_rows(mock_context):
     """Resolver returns an empty list when the query returns nothing."""
-    from dev_health_ops.api.graphql.models.recommendations import WindowInput, WindowUnit
+    from dev_health_ops.api.graphql.models.recommendations import (
+        WindowInput,
+        WindowUnit,
+    )
     from dev_health_ops.api.graphql.resolvers.recommendations import (
         resolve_recommendations,
     )
@@ -202,7 +211,10 @@ async def test_resolve_recommendations_empty_on_no_rows(mock_context):
 @pytest.mark.anyio
 async def test_resolve_recommendations_tolerates_db_error(mock_context):
     """Resolver swallows DB exceptions and returns an empty list (graceful degradation)."""
-    from dev_health_ops.api.graphql.models.recommendations import WindowInput, WindowUnit
+    from dev_health_ops.api.graphql.models.recommendations import (
+        WindowInput,
+        WindowUnit,
+    )
     from dev_health_ops.api.graphql.resolvers.recommendations import (
         resolve_recommendations,
     )
@@ -224,7 +236,10 @@ async def test_resolve_recommendations_tolerates_db_error(mock_context):
 @pytest.mark.anyio
 async def test_resolve_recommendations_multiple_rules(mock_context):
     """All fired rules within the window are returned."""
-    from dev_health_ops.api.graphql.models.recommendations import WindowInput, WindowUnit
+    from dev_health_ops.api.graphql.models.recommendations import (
+        WindowInput,
+        WindowUnit,
+    )
     from dev_health_ops.api.graphql.resolvers.recommendations import (
         resolve_recommendations,
     )
@@ -276,7 +291,10 @@ async def test_resolve_recommendations_unknown_severity_falls_back(mock_context)
 @pytest.mark.anyio
 async def test_resolve_recommendations_raises_without_client(mock_context):
     """RuntimeError is raised when context.client is None (misconfigured server)."""
-    from dev_health_ops.api.graphql.models.recommendations import WindowInput, WindowUnit
+    from dev_health_ops.api.graphql.models.recommendations import (
+        WindowInput,
+        WindowUnit,
+    )
     from dev_health_ops.api.graphql.resolvers.recommendations import (
         resolve_recommendations,
     )

--- a/tests/api/graphql/test_recommendations_resolver.py
+++ b/tests/api/graphql/test_recommendations_resolver.py
@@ -1,0 +1,291 @@
+"""Integration tests for the recommendations GraphQL resolver.
+
+Tests are fixture-backed (no live ClickHouse required): query_dicts is
+patched to return controlled row sets, and we assert the resolver maps
+them to the correct Strawberry output shape, including evidence
+references.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+strawberry = pytest.importorskip("strawberry")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_context():
+    ctx = MagicMock()
+    ctx.org_id = "test-org"
+    ctx.db_url = "clickhouse://localhost:8123/default"
+    ctx.client = MagicMock()
+    return ctx
+
+
+EVIDENCE_LIST = [
+    {
+        "team_id": "team-alpha",
+        "metric_table": "work_item_metrics_daily",
+        "field": "wip_count",
+        "window_start": "2026-04-01",
+        "window_end": "2026-04-07",
+        "value": 14.0,
+    },
+    {
+        "team_id": "team-alpha",
+        "metric_table": "work_item_metrics_daily",
+        "field": "throughput",
+        "window_start": "2026-04-01",
+        "window_end": "2026-04-07",
+        "value": 2.0,
+    },
+]
+
+
+FIXTURE_ROWS = [
+    {
+        "team_id": "team-alpha",
+        "org_id": "test-org",
+        "rule_id": "saturation",
+        "fired": True,
+        "severity": "critical",
+        "title": "Team is saturating. Reduce active work before adding scope.",
+        "rationale": "WIP has been rising while throughput remains flat for 2 cycles.",
+        "success_criterion": "WIP trend turns negative or throughput trend turns positive in 2 cycles",
+        "evidence_json": json.dumps(EVIDENCE_LIST),
+        "window_start": "2026-04-01",
+        "window_end": "2026-04-07",
+        "computed_at": datetime(2026, 4, 8, 3, 0, 0, tzinfo=timezone.utc),
+    },
+    {
+        "team_id": "team-alpha",
+        "org_id": "test-org",
+        "rule_id": "thrash",
+        "window_end": "2026-04-07",
+        "fired": True,
+        "severity": "warning",
+        "title": "Thrash likely. Inspect hotspots and rework loops.",
+        "rationale": "High churn detected with low delivery ratio over the last 7 days.",
+        "success_criterion": "Churn drops OR throughput rises in 2 cycles",
+        "evidence_json": json.dumps([EVIDENCE_LIST[0]]),
+        "window_start": "2026-04-01",
+        "computed_at": datetime(2026, 4, 8, 3, 0, 0, tzinfo=timezone.utc),
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Shape / field tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_resolve_recommendations_returns_list(mock_context):
+    """Resolver returns a non-empty list when rows are present."""
+    from dev_health_ops.api.graphql.models.recommendations import WindowInput, WindowUnit
+    from dev_health_ops.api.graphql.resolvers.recommendations import (
+        resolve_recommendations,
+    )
+
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+        return_value=FIXTURE_ROWS,
+    ):
+        result = await resolve_recommendations(
+            mock_context,
+            team="team-alpha",
+            window=WindowInput(value=1, unit=WindowUnit.WEEK),
+        )
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+
+
+@pytest.mark.anyio
+async def test_resolve_recommendations_field_mapping(mock_context):
+    """Fields map correctly from DB row to Recommendation type."""
+    from dev_health_ops.api.graphql.models.recommendations import (
+        Severity,
+        WindowInput,
+        WindowUnit,
+    )
+    from dev_health_ops.api.graphql.resolvers.recommendations import (
+        resolve_recommendations,
+    )
+
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+        return_value=[FIXTURE_ROWS[0]],
+    ):
+        result = await resolve_recommendations(
+            mock_context,
+            team="team-alpha",
+            window=WindowInput(value=1, unit=WindowUnit.WEEK),
+        )
+
+    assert len(result) == 1
+    rec = result[0]
+    assert rec.rule_id == "saturation"
+    assert rec.team_id == "team-alpha"
+    assert rec.org_id == "test-org"
+    assert rec.severity == Severity.CRITICAL
+    assert rec.title == "Team is saturating. Reduce active work before adding scope."
+    assert rec.success_criterion.startswith("WIP trend")
+    assert isinstance(rec.computed_at, datetime)
+    assert rec.computed_at.tzinfo is not None
+
+
+@pytest.mark.anyio
+async def test_resolve_recommendations_evidence_references_resolve(mock_context):
+    """Evidence list is deserialised; each EvidenceRef carries required fields."""
+    from dev_health_ops.api.graphql.models.recommendations import WindowInput, WindowUnit
+    from dev_health_ops.api.graphql.resolvers.recommendations import (
+        resolve_recommendations,
+    )
+
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+        return_value=[FIXTURE_ROWS[0]],
+    ):
+        result = await resolve_recommendations(
+            mock_context,
+            team="team-alpha",
+            window=WindowInput(value=1, unit=WindowUnit.WEEK),
+        )
+
+    rec = result[0]
+    assert len(rec.evidence) == 2
+    ev = rec.evidence[0]
+    # Keys match canonical EvidenceRef field names exactly (as per engine sink contract)
+    assert ev.metric_table == "work_item_metrics_daily"
+    assert ev.field == "wip_count"
+    assert ev.value == 14.0
+    assert ev.team_id == "team-alpha"
+    assert isinstance(ev.window_start, date)
+    assert isinstance(ev.window_end, date)
+
+
+@pytest.mark.anyio
+async def test_resolve_recommendations_empty_on_no_rows(mock_context):
+    """Resolver returns an empty list when the query returns nothing."""
+    from dev_health_ops.api.graphql.models.recommendations import WindowInput, WindowUnit
+    from dev_health_ops.api.graphql.resolvers.recommendations import (
+        resolve_recommendations,
+    )
+
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        result = await resolve_recommendations(
+            mock_context,
+            team="team-beta",
+            window=WindowInput(value=7, unit=WindowUnit.DAY),
+        )
+
+    assert result == []
+
+
+@pytest.mark.anyio
+async def test_resolve_recommendations_tolerates_db_error(mock_context):
+    """Resolver swallows DB exceptions and returns an empty list (graceful degradation)."""
+    from dev_health_ops.api.graphql.models.recommendations import WindowInput, WindowUnit
+    from dev_health_ops.api.graphql.resolvers.recommendations import (
+        resolve_recommendations,
+    )
+
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("ClickHouse unavailable"),
+    ):
+        result = await resolve_recommendations(
+            mock_context,
+            team="team-alpha",
+            window=WindowInput(value=4, unit=WindowUnit.WEEK),
+        )
+
+    assert result == []
+
+
+@pytest.mark.anyio
+async def test_resolve_recommendations_multiple_rules(mock_context):
+    """All fired rules within the window are returned."""
+    from dev_health_ops.api.graphql.models.recommendations import WindowInput, WindowUnit
+    from dev_health_ops.api.graphql.resolvers.recommendations import (
+        resolve_recommendations,
+    )
+
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+        return_value=FIXTURE_ROWS,
+    ):
+        result = await resolve_recommendations(
+            mock_context,
+            team="team-alpha",
+            window=WindowInput(value=2, unit=WindowUnit.CYCLE),
+        )
+
+    rule_ids = [r.rule_id for r in result]
+    assert "saturation" in rule_ids
+    assert "thrash" in rule_ids
+
+
+@pytest.mark.anyio
+async def test_resolve_recommendations_unknown_severity_falls_back(mock_context):
+    """An unrecognised severity value defaults to WARNING without raising."""
+    from dev_health_ops.api.graphql.models.recommendations import (
+        Severity,
+        WindowInput,
+        WindowUnit,
+    )
+    from dev_health_ops.api.graphql.resolvers.recommendations import (
+        resolve_recommendations,
+    )
+
+    bad_row = {**FIXTURE_ROWS[0], "severity": "ultra-critical"}
+
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+        return_value=[bad_row],
+    ):
+        result = await resolve_recommendations(
+            mock_context,
+            team="team-alpha",
+            window=WindowInput(value=1, unit=WindowUnit.WEEK),
+        )
+
+    assert result[0].severity == Severity.WARNING
+
+
+@pytest.mark.anyio
+async def test_resolve_recommendations_raises_without_client(mock_context):
+    """RuntimeError is raised when context.client is None (misconfigured server)."""
+    from dev_health_ops.api.graphql.models.recommendations import WindowInput, WindowUnit
+    from dev_health_ops.api.graphql.resolvers.recommendations import (
+        resolve_recommendations,
+    )
+
+    mock_context.client = None
+
+    with pytest.raises(RuntimeError, match="Database client not available"):
+        await resolve_recommendations(
+            mock_context,
+            team="team-alpha",
+            window=WindowInput(value=1, unit=WindowUnit.WEEK),
+        )

--- a/tests/recommendations/rules/conftest.py
+++ b/tests/recommendations/rules/conftest.py
@@ -1,0 +1,54 @@
+"""Shared fixtures for recommendation rule golden tests.
+
+Uses the real MetricsSnapshot from CHAOS-1622 (rec-engine-core).
+All fields required; use make_snapshot() helper to build variants.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from dev_health_ops.recommendations.engine import MetricsSnapshot
+
+TEAM_ID = "team-alpha"
+ORG_ID = "org-1"
+WINDOW_START = date(2026, 4, 1)
+WINDOW_END = date(2026, 4, 14)
+NOW = datetime(2026, 4, 14, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def make_snapshot(**overrides: object) -> MetricsSnapshot:
+    """Build a MetricsSnapshot with safe below-threshold defaults.
+
+    Pass keyword arguments to override any field.
+    """
+    defaults: dict[str, object] = {
+        "team_id": TEAM_ID,
+        "org_id": ORG_ID,
+        "window_start": WINDOW_START,
+        "window_end": WINDOW_END,
+        # saturation + thrash (flat WIP, positive throughput trend)
+        "wip_by_day": [5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0],
+        "throughput_by_cycle": [10.0, 11.0],
+        # review-concentration (below both thresholds)
+        "review_latency_p75_hours": 12.0,
+        "reviewer_gini": 0.3,
+        # thrash (low churn)
+        "rework_churn_ratio": 0.1,
+        # sustainability-risk (low after-hours, flat cycle time)
+        "after_hours_ratio": 0.05,
+        "cycle_time_by_day": [24.0, 24.0, 24.0, 24.0, 24.0, 24.0, 24.0],
+        # compounding-risk (below both thresholds)
+        "hotspot_complexity_delta": 0.05,
+        "hotspot_churn_overlap": 0.1,
+    }
+    defaults.update(overrides)
+    return MetricsSnapshot(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.fixture()
+def base_snapshot() -> MetricsSnapshot:
+    """Snapshot with all values below every threshold — no rule should fire."""
+    return make_snapshot()

--- a/tests/recommendations/rules/test_compounding_risk.py
+++ b/tests/recommendations/rules/test_compounding_risk.py
@@ -12,8 +12,6 @@ Covers:
 
 from __future__ import annotations
 
-import pytest
-
 from dev_health_ops.recommendations.rules.compounding_risk import (
     RULE_ID,
     SUCCESS_CRITERION,
@@ -25,7 +23,6 @@ from dev_health_ops.recommendations.thresholds import (
 )
 
 from .conftest import NOW, make_snapshot
-
 
 # ---------------------------------------------------------------------------
 # 1. Positive trigger

--- a/tests/recommendations/rules/test_compounding_risk.py
+++ b/tests/recommendations/rules/test_compounding_risk.py
@@ -1,0 +1,149 @@
+"""Golden tests for the compounding-risk rule.
+
+Covers:
+1. Positive trigger   -- complexity delta + churn overlap both above -> Recommendation.
+2. Negative (complexity just-below threshold) -> None.
+3. Negative (churn overlap just-below threshold) -> None.
+4. None inputs        -- either field None returns None.
+5. Both zero          -- returns None.
+6. Evidence integrity -- correct tables, fields, team_id, window.
+7. Rationale presence -- mentions both threshold values.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.recommendations.rules.compounding_risk import (
+    RULE_ID,
+    SUCCESS_CRITERION,
+    evaluate_compounding_risk,
+)
+from dev_health_ops.recommendations.thresholds import (
+    COMPLEXITY_DELTA_THRESHOLD,
+    HOTSPOT_CHURN_OVERLAP_THRESHOLD,
+)
+
+from .conftest import NOW, make_snapshot
+
+
+# ---------------------------------------------------------------------------
+# 1. Positive trigger
+# ---------------------------------------------------------------------------
+
+
+def test_compounding_risk_fires_when_both_above_threshold() -> None:
+    snap = make_snapshot(
+        hotspot_complexity_delta=COMPLEXITY_DELTA_THRESHOLD + 0.1,
+        hotspot_churn_overlap=HOTSPOT_CHURN_OVERLAP_THRESHOLD + 0.1,
+    )
+    result = evaluate_compounding_risk(snap, NOW)
+
+    assert result is not None
+    assert result.rule_id == RULE_ID
+    assert result.severity == "warning"
+    assert result.success_criterion == SUCCESS_CRITERION
+    assert result.team_id == snap.team_id
+
+
+# ---------------------------------------------------------------------------
+# 2. Negative -- complexity just below
+# ---------------------------------------------------------------------------
+
+
+def test_compounding_risk_does_not_fire_complexity_just_below() -> None:
+    snap = make_snapshot(
+        hotspot_complexity_delta=COMPLEXITY_DELTA_THRESHOLD * 0.99,
+        hotspot_churn_overlap=HOTSPOT_CHURN_OVERLAP_THRESHOLD + 0.2,
+    )
+    assert evaluate_compounding_risk(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Negative -- churn overlap just below
+# ---------------------------------------------------------------------------
+
+
+def test_compounding_risk_does_not_fire_overlap_just_below() -> None:
+    snap = make_snapshot(
+        hotspot_complexity_delta=COMPLEXITY_DELTA_THRESHOLD + 0.2,
+        hotspot_churn_overlap=HOTSPOT_CHURN_OVERLAP_THRESHOLD * 0.99,
+    )
+    assert evaluate_compounding_risk(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. None inputs
+# ---------------------------------------------------------------------------
+
+
+def test_compounding_risk_returns_none_when_complexity_delta_none() -> None:
+    snap = make_snapshot(
+        hotspot_complexity_delta=None,
+        hotspot_churn_overlap=HOTSPOT_CHURN_OVERLAP_THRESHOLD + 0.1,
+    )
+    assert evaluate_compounding_risk(snap, NOW) is None
+
+
+def test_compounding_risk_returns_none_when_churn_overlap_none() -> None:
+    snap = make_snapshot(
+        hotspot_complexity_delta=COMPLEXITY_DELTA_THRESHOLD + 0.1,
+        hotspot_churn_overlap=None,
+    )
+    assert evaluate_compounding_risk(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Both zero
+# ---------------------------------------------------------------------------
+
+
+def test_compounding_risk_does_not_fire_when_both_zero() -> None:
+    snap = make_snapshot(
+        hotspot_complexity_delta=0.0,
+        hotspot_churn_overlap=0.0,
+    )
+    assert evaluate_compounding_risk(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Evidence integrity
+# ---------------------------------------------------------------------------
+
+
+def test_compounding_risk_evidence_tables_and_fields() -> None:
+    snap = make_snapshot(
+        hotspot_complexity_delta=COMPLEXITY_DELTA_THRESHOLD + 0.1,
+        hotspot_churn_overlap=HOTSPOT_CHURN_OVERLAP_THRESHOLD + 0.1,
+    )
+    result = evaluate_compounding_risk(snap, NOW)
+    assert result is not None
+
+    tables = {e.metric_table for e in result.evidence}
+    fields = {e.field for e in result.evidence}
+
+    assert "file_complexity_snapshots" in tables
+    assert "file_metrics_daily" in tables
+    assert "hotspot_complexity_delta" in fields
+    assert "hotspot_churn_overlap" in fields
+
+    for ev in result.evidence:
+        assert ev.team_id == snap.team_id
+        assert ev.window_start == snap.window_start
+        assert ev.window_end == snap.window_end
+
+
+# ---------------------------------------------------------------------------
+# 7. Rationale presence
+# ---------------------------------------------------------------------------
+
+
+def test_compounding_risk_rationale_mentions_both_thresholds() -> None:
+    snap = make_snapshot(
+        hotspot_complexity_delta=COMPLEXITY_DELTA_THRESHOLD + 0.1,
+        hotspot_churn_overlap=HOTSPOT_CHURN_OVERLAP_THRESHOLD + 0.1,
+    )
+    result = evaluate_compounding_risk(snap, NOW)
+    assert result is not None
+    assert str(COMPLEXITY_DELTA_THRESHOLD) in result.rationale
+    assert str(HOTSPOT_CHURN_OVERLAP_THRESHOLD) in result.rationale

--- a/tests/recommendations/rules/test_review_concentration.py
+++ b/tests/recommendations/rules/test_review_concentration.py
@@ -27,7 +27,6 @@ from dev_health_ops.recommendations.thresholds import (
 
 from .conftest import NOW, make_snapshot
 
-
 # ---------------------------------------------------------------------------
 # 1. Positive trigger
 # ---------------------------------------------------------------------------

--- a/tests/recommendations/rules/test_review_concentration.py
+++ b/tests/recommendations/rules/test_review_concentration.py
@@ -1,0 +1,162 @@
+"""Golden tests for the review-concentration rule.
+
+Covers:
+1. Positive trigger   -- high latency + high Gini -> Recommendation returned.
+2. Negative (latency just-below threshold) -> None.
+3. Negative (Gini just-below threshold) -> None.
+4. None inputs        -- missing data returns None.
+5. Evidence integrity -- correct tables, fields, team_id, window.
+6. Rationale presence -- mentions both threshold values.
+7. gini() helper unit tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.recommendations.rules.review_concentration import (
+    RULE_ID,
+    SUCCESS_CRITERION,
+    evaluate_review_concentration,
+    gini,
+)
+from dev_health_ops.recommendations.thresholds import (
+    REVIEW_LATENCY_P75_HOURS,
+    REVIEWER_GINI_THRESHOLD,
+)
+
+from .conftest import NOW, make_snapshot
+
+
+# ---------------------------------------------------------------------------
+# 1. Positive trigger
+# ---------------------------------------------------------------------------
+
+
+def test_review_concentration_fires_when_both_above_threshold() -> None:
+    snap = make_snapshot(
+        review_latency_p75_hours=REVIEW_LATENCY_P75_HOURS + 10.0,
+        reviewer_gini=REVIEWER_GINI_THRESHOLD + 0.1,
+    )
+    result = evaluate_review_concentration(snap, NOW)
+
+    assert result is not None
+    assert result.rule_id == RULE_ID
+    assert result.severity == "warning"
+    assert result.success_criterion == SUCCESS_CRITERION
+    assert result.team_id == snap.team_id
+
+
+# ---------------------------------------------------------------------------
+# 2. Negative -- latency just below
+# ---------------------------------------------------------------------------
+
+
+def test_review_concentration_does_not_fire_latency_just_below() -> None:
+    snap = make_snapshot(
+        review_latency_p75_hours=REVIEW_LATENCY_P75_HOURS * 0.99,
+        reviewer_gini=REVIEWER_GINI_THRESHOLD + 0.2,
+    )
+    assert evaluate_review_concentration(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Negative -- Gini just below
+# ---------------------------------------------------------------------------
+
+
+def test_review_concentration_does_not_fire_gini_just_below() -> None:
+    snap = make_snapshot(
+        review_latency_p75_hours=REVIEW_LATENCY_P75_HOURS * 2.0,
+        reviewer_gini=REVIEWER_GINI_THRESHOLD * 0.99,
+    )
+    assert evaluate_review_concentration(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. None inputs
+# ---------------------------------------------------------------------------
+
+
+def test_review_concentration_returns_none_when_latency_none() -> None:
+    snap = make_snapshot(
+        review_latency_p75_hours=None,
+        reviewer_gini=REVIEWER_GINI_THRESHOLD + 0.1,
+    )
+    assert evaluate_review_concentration(snap, NOW) is None
+
+
+def test_review_concentration_returns_none_when_gini_none() -> None:
+    snap = make_snapshot(
+        review_latency_p75_hours=REVIEW_LATENCY_P75_HOURS + 10.0,
+        reviewer_gini=None,
+    )
+    assert evaluate_review_concentration(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Evidence integrity
+# ---------------------------------------------------------------------------
+
+
+def test_review_concentration_evidence_tables_and_fields() -> None:
+    snap = make_snapshot(
+        review_latency_p75_hours=REVIEW_LATENCY_P75_HOURS + 10.0,
+        reviewer_gini=REVIEWER_GINI_THRESHOLD + 0.1,
+    )
+    result = evaluate_review_concentration(snap, NOW)
+    assert result is not None
+
+    tables = {e.metric_table for e in result.evidence}
+    fields = {e.field for e in result.evidence}
+
+    assert "repo_metrics_daily" in tables
+    assert "review_edge_daily" in tables
+    assert "review_latency_p75_hours" in fields
+    assert "reviewer_gini" in fields
+
+    for ev in result.evidence:
+        assert ev.team_id == snap.team_id
+        assert ev.window_start == snap.window_start
+        assert ev.window_end == snap.window_end
+
+
+# ---------------------------------------------------------------------------
+# 6. Rationale presence
+# ---------------------------------------------------------------------------
+
+
+def test_review_concentration_rationale_mentions_both_thresholds() -> None:
+    snap = make_snapshot(
+        review_latency_p75_hours=REVIEW_LATENCY_P75_HOURS + 10.0,
+        reviewer_gini=REVIEWER_GINI_THRESHOLD + 0.1,
+    )
+    result = evaluate_review_concentration(snap, NOW)
+    assert result is not None
+    assert str(REVIEW_LATENCY_P75_HOURS) in result.rationale
+    assert str(REVIEWER_GINI_THRESHOLD) in result.rationale
+
+
+# ---------------------------------------------------------------------------
+# 7. gini() helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_gini_perfectly_even_returns_zero() -> None:
+    assert gini([2.0, 2.0, 2.0, 2.0]) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_gini_single_dominant_reviewer_is_high() -> None:
+    assert gini([0.0, 0.0, 0.0, 10.0]) > 0.7
+
+
+def test_gini_empty_returns_zero() -> None:
+    assert gini([]) == 0.0
+
+
+def test_gini_all_zero_returns_zero() -> None:
+    assert gini([0.0, 0.0, 0.0]) == 0.0
+
+
+def test_gini_two_equal_reviewers() -> None:
+    assert gini([5.0, 5.0]) == pytest.approx(0.0, abs=1e-9)

--- a/tests/recommendations/rules/test_saturation.py
+++ b/tests/recommendations/rules/test_saturation.py
@@ -1,0 +1,171 @@
+"""Golden tests for the saturation rule.
+
+Covers:
+1. Positive trigger   -- WIP rising + throughput flat -> Recommendation returned.
+2. Negative (WIP just-below threshold) -> None.
+3. Negative (throughput rising despite high WIP) -> None.
+4. Evidence integrity -- correct tables, fields, team_id, window.
+5. Rationale presence -- mentions threshold name and observed value.
+6. Helper unit tests  -- _linear_slope edge cases.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.recommendations.rules.saturation import (
+    RULE_ID,
+    SUCCESS_CRITERION,
+    _linear_slope,
+    evaluate_saturation,
+)
+from dev_health_ops.recommendations.thresholds import (
+    THROUGHPUT_FLAT_DELTA_THRESHOLD,
+    WIP_RISING_SLOPE_THRESHOLD,
+)
+
+from .conftest import NOW, make_snapshot
+
+
+def _rising_wip(slope: float, n: int = 7) -> list[float]:
+    return [5.0 + slope * i for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# 1. Positive trigger
+# ---------------------------------------------------------------------------
+
+
+def test_saturation_fires_when_wip_rising_and_throughput_flat() -> None:
+    snap = make_snapshot(
+        wip_by_day=_rising_wip(WIP_RISING_SLOPE_THRESHOLD * 2),
+        throughput_by_cycle=[10.0, 10.0],
+    )
+    result = evaluate_saturation(snap, NOW)
+
+    assert result is not None
+    assert result.rule_id == RULE_ID
+    assert result.team_id == snap.team_id
+    assert result.org_id == snap.org_id
+    assert result.window_start == snap.window_start
+    assert result.window_end == snap.window_end
+    assert result.severity == "warning"
+    assert result.success_criterion == SUCCESS_CRITERION
+
+
+def test_saturation_fires_when_throughput_declining() -> None:
+    snap = make_snapshot(
+        wip_by_day=_rising_wip(WIP_RISING_SLOPE_THRESHOLD * 2),
+        throughput_by_cycle=[10.0, 8.0],  # delta = -2 <= threshold
+    )
+    assert evaluate_saturation(snap, NOW) is not None
+
+
+# ---------------------------------------------------------------------------
+# 2. Negative -- WIP slope just below threshold
+# ---------------------------------------------------------------------------
+
+
+def test_saturation_does_not_fire_when_wip_slope_just_below() -> None:
+    snap = make_snapshot(
+        wip_by_day=_rising_wip(WIP_RISING_SLOPE_THRESHOLD * 0.99),
+        throughput_by_cycle=[10.0, 8.0],
+    )
+    assert evaluate_saturation(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Negative -- throughput rising (no saturation)
+# ---------------------------------------------------------------------------
+
+
+def test_saturation_does_not_fire_when_throughput_rising() -> None:
+    snap = make_snapshot(
+        wip_by_day=_rising_wip(WIP_RISING_SLOPE_THRESHOLD * 3),
+        throughput_by_cycle=[8.0, 14.0],  # delta = +6 > threshold
+    )
+    assert evaluate_saturation(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Evidence integrity
+# ---------------------------------------------------------------------------
+
+
+def test_saturation_evidence_tables_and_fields() -> None:
+    snap = make_snapshot(
+        wip_by_day=_rising_wip(WIP_RISING_SLOPE_THRESHOLD * 2),
+        throughput_by_cycle=[10.0, 10.0],
+    )
+    result = evaluate_saturation(snap, NOW)
+    assert result is not None
+
+    tables = {e.metric_table for e in result.evidence}
+    fields = {e.field for e in result.evidence}
+
+    assert "work_item_metrics_daily" in tables
+    assert "wip_count_end_of_day" in fields
+    assert "items_completed_delta" in fields
+
+    for ev in result.evidence:
+        assert ev.team_id == snap.team_id
+        assert ev.window_start == snap.window_start
+        assert ev.window_end == snap.window_end
+
+
+# ---------------------------------------------------------------------------
+# 5. Rationale presence
+# ---------------------------------------------------------------------------
+
+
+def test_saturation_rationale_mentions_threshold_and_observed() -> None:
+    snap = make_snapshot(
+        wip_by_day=_rising_wip(WIP_RISING_SLOPE_THRESHOLD * 2),
+        throughput_by_cycle=[10.0, 10.0],
+    )
+    result = evaluate_saturation(snap, NOW)
+    assert result is not None
+    assert str(WIP_RISING_SLOPE_THRESHOLD) in result.rationale
+    assert str(THROUGHPUT_FLAT_DELTA_THRESHOLD) in result.rationale
+
+
+# ---------------------------------------------------------------------------
+# 6. Not enough data -> None
+# ---------------------------------------------------------------------------
+
+
+def test_saturation_returns_none_with_one_wip_point() -> None:
+    snap = make_snapshot(
+        wip_by_day=[10.0],
+        throughput_by_cycle=[5.0, 3.0],
+    )
+    assert evaluate_saturation(snap, NOW) is None
+
+
+def test_saturation_returns_none_with_one_throughput_point() -> None:
+    snap = make_snapshot(
+        wip_by_day=_rising_wip(WIP_RISING_SLOPE_THRESHOLD * 2),
+        throughput_by_cycle=[10.0],
+    )
+    assert evaluate_saturation(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests -- _linear_slope
+# ---------------------------------------------------------------------------
+
+
+def test_linear_slope_flat_is_zero() -> None:
+    assert _linear_slope([5.0, 5.0, 5.0]) == pytest.approx(0.0)
+
+
+def test_linear_slope_single_value_is_zero() -> None:
+    assert _linear_slope([7.0]) == pytest.approx(0.0)
+
+
+def test_linear_slope_ascending() -> None:
+    assert _linear_slope([0.0, 1.0, 2.0]) == pytest.approx(1.0)
+
+
+def test_linear_slope_descending() -> None:
+    assert _linear_slope([2.0, 1.0, 0.0]) == pytest.approx(-1.0)

--- a/tests/recommendations/rules/test_sustainability_risk.py
+++ b/tests/recommendations/rules/test_sustainability_risk.py
@@ -1,0 +1,146 @@
+"""Golden tests for the sustainability-risk rule.
+
+Covers:
+1. Positive trigger   -- high after-hours + rising cycle time -> Recommendation.
+2. Negative (after-hours just-below threshold) -> None.
+3. Negative (cycle time flat despite high after-hours) -> None.
+4. None inputs        -- after_hours_ratio=None returns None.
+5. Not enough data    -- single cycle-time point returns None.
+6. Evidence integrity -- correct tables, fields, team_id, window.
+7. Rationale presence -- mentions both threshold values.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.recommendations.rules.sustainability_risk import (
+    RULE_ID,
+    SUCCESS_CRITERION,
+    _linear_slope,
+    evaluate_sustainability_risk,
+)
+from dev_health_ops.recommendations.thresholds import (
+    AFTER_HOURS_RATIO_THRESHOLD,
+    CYCLE_TIME_RISING_SLOPE_THRESHOLD,
+)
+
+from .conftest import NOW, make_snapshot
+
+
+def _rising_cycle_times(slope: float, n: int = 7, base: float = 24.0) -> list[float]:
+    return [base + slope * i for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# 1. Positive trigger
+# ---------------------------------------------------------------------------
+
+
+def test_sustainability_risk_fires_when_both_conditions_met() -> None:
+    snap = make_snapshot(
+        after_hours_ratio=AFTER_HOURS_RATIO_THRESHOLD + 0.05,
+        cycle_time_by_day=_rising_cycle_times(CYCLE_TIME_RISING_SLOPE_THRESHOLD * 2),
+    )
+    result = evaluate_sustainability_risk(snap, NOW)
+
+    assert result is not None
+    assert result.rule_id == RULE_ID
+    assert result.severity == "warning"
+    assert result.success_criterion == SUCCESS_CRITERION
+    assert result.team_id == snap.team_id
+
+
+# ---------------------------------------------------------------------------
+# 2. Negative -- after-hours just below
+# ---------------------------------------------------------------------------
+
+
+def test_sustainability_risk_does_not_fire_when_after_hours_just_below() -> None:
+    snap = make_snapshot(
+        after_hours_ratio=AFTER_HOURS_RATIO_THRESHOLD * 0.99,
+        cycle_time_by_day=_rising_cycle_times(CYCLE_TIME_RISING_SLOPE_THRESHOLD * 3),
+    )
+    assert evaluate_sustainability_risk(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Negative -- cycle time flat
+# ---------------------------------------------------------------------------
+
+
+def test_sustainability_risk_does_not_fire_when_cycle_time_flat() -> None:
+    snap = make_snapshot(
+        after_hours_ratio=AFTER_HOURS_RATIO_THRESHOLD + 0.1,
+        cycle_time_by_day=[24.0] * 7,
+    )
+    assert evaluate_sustainability_risk(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. None input
+# ---------------------------------------------------------------------------
+
+
+def test_sustainability_risk_returns_none_when_after_hours_none() -> None:
+    snap = make_snapshot(
+        after_hours_ratio=None,
+        cycle_time_by_day=_rising_cycle_times(CYCLE_TIME_RISING_SLOPE_THRESHOLD * 2),
+    )
+    assert evaluate_sustainability_risk(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Not enough cycle-time data
+# ---------------------------------------------------------------------------
+
+
+def test_sustainability_risk_returns_none_with_single_day() -> None:
+    snap = make_snapshot(
+        after_hours_ratio=AFTER_HOURS_RATIO_THRESHOLD + 0.1,
+        cycle_time_by_day=[48.0],
+    )
+    assert evaluate_sustainability_risk(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Evidence integrity
+# ---------------------------------------------------------------------------
+
+
+def test_sustainability_risk_evidence_tables_and_fields() -> None:
+    snap = make_snapshot(
+        after_hours_ratio=AFTER_HOURS_RATIO_THRESHOLD + 0.05,
+        cycle_time_by_day=_rising_cycle_times(CYCLE_TIME_RISING_SLOPE_THRESHOLD * 2),
+    )
+    result = evaluate_sustainability_risk(snap, NOW)
+    assert result is not None
+
+    tables = {e.metric_table for e in result.evidence}
+    fields = {e.field for e in result.evidence}
+
+    assert "team_metrics_daily" in tables
+    assert "work_item_metrics_daily" in tables
+    assert "after_hours_commit_ratio" in fields
+    assert "cycle_time_p50_hours_slope" in fields
+
+    for ev in result.evidence:
+        assert ev.team_id == snap.team_id
+        assert ev.window_start == snap.window_start
+        assert ev.window_end == snap.window_end
+
+
+# ---------------------------------------------------------------------------
+# 7. Rationale presence
+# ---------------------------------------------------------------------------
+
+
+def test_sustainability_risk_rationale_mentions_both_thresholds() -> None:
+    snap = make_snapshot(
+        after_hours_ratio=AFTER_HOURS_RATIO_THRESHOLD + 0.05,
+        cycle_time_by_day=_rising_cycle_times(CYCLE_TIME_RISING_SLOPE_THRESHOLD * 2),
+    )
+    result = evaluate_sustainability_risk(snap, NOW)
+    assert result is not None
+    assert str(AFTER_HOURS_RATIO_THRESHOLD) in result.rationale
+    assert str(CYCLE_TIME_RISING_SLOPE_THRESHOLD) in result.rationale

--- a/tests/recommendations/rules/test_sustainability_risk.py
+++ b/tests/recommendations/rules/test_sustainability_risk.py
@@ -12,12 +12,9 @@ Covers:
 
 from __future__ import annotations
 
-import pytest
-
 from dev_health_ops.recommendations.rules.sustainability_risk import (
     RULE_ID,
     SUCCESS_CRITERION,
-    _linear_slope,
     evaluate_sustainability_risk,
 )
 from dev_health_ops.recommendations.thresholds import (

--- a/tests/recommendations/rules/test_thrash.py
+++ b/tests/recommendations/rules/test_thrash.py
@@ -1,0 +1,149 @@
+"""Golden tests for the thrash rule.
+
+Covers:
+1. Positive trigger   -- high churn + flat throughput -> Recommendation.
+2. Positive trigger   -- high churn + declining throughput -> Recommendation.
+3. Negative (churn just-below threshold) -> None.
+4. Negative (churn high but throughput rising) -> None.
+5. None inputs        -- rework_churn_ratio=None returns None.
+6. Not enough data    -- single cycle point returns None.
+7. Evidence integrity -- correct tables, fields, team_id, window.
+8. Rationale presence -- mentions threshold and observed value.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.recommendations.rules.thrash import (
+    RULE_ID,
+    SUCCESS_CRITERION,
+    evaluate_thrash,
+)
+from dev_health_ops.recommendations.thresholds import (
+    CHURN_RATIO_THRESHOLD,
+    THROUGHPUT_LOW_DELTA_THRESHOLD,
+)
+
+from .conftest import NOW, make_snapshot
+
+
+# ---------------------------------------------------------------------------
+# 1 & 2. Positive triggers
+# ---------------------------------------------------------------------------
+
+
+def test_thrash_fires_when_churn_high_and_throughput_flat() -> None:
+    snap = make_snapshot(
+        rework_churn_ratio=CHURN_RATIO_THRESHOLD + 0.1,
+        throughput_by_cycle=[12.0, 12.0],
+    )
+    result = evaluate_thrash(snap, NOW)
+
+    assert result is not None
+    assert result.rule_id == RULE_ID
+    assert result.severity == "warning"
+    assert result.success_criterion == SUCCESS_CRITERION
+
+
+def test_thrash_fires_when_churn_high_and_throughput_declining() -> None:
+    snap = make_snapshot(
+        rework_churn_ratio=CHURN_RATIO_THRESHOLD + 0.05,
+        throughput_by_cycle=[10.0, 8.0],
+    )
+    assert evaluate_thrash(snap, NOW) is not None
+
+
+# ---------------------------------------------------------------------------
+# 3. Negative -- churn just below
+# ---------------------------------------------------------------------------
+
+
+def test_thrash_does_not_fire_when_churn_just_below() -> None:
+    snap = make_snapshot(
+        rework_churn_ratio=CHURN_RATIO_THRESHOLD * 0.99,
+        throughput_by_cycle=[10.0, 9.0],
+    )
+    assert evaluate_thrash(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Negative -- throughput rising
+# ---------------------------------------------------------------------------
+
+
+def test_thrash_does_not_fire_when_throughput_rising() -> None:
+    snap = make_snapshot(
+        rework_churn_ratio=CHURN_RATIO_THRESHOLD + 0.2,
+        throughput_by_cycle=[8.0, 14.0],
+    )
+    assert evaluate_thrash(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 5. None input
+# ---------------------------------------------------------------------------
+
+
+def test_thrash_returns_none_when_rework_ratio_none() -> None:
+    snap = make_snapshot(
+        rework_churn_ratio=None,
+        throughput_by_cycle=[5.0, 4.0],
+    )
+    assert evaluate_thrash(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Not enough throughput data
+# ---------------------------------------------------------------------------
+
+
+def test_thrash_returns_none_with_single_cycle_point() -> None:
+    snap = make_snapshot(
+        rework_churn_ratio=CHURN_RATIO_THRESHOLD + 0.2,
+        throughput_by_cycle=[10.0],
+    )
+    assert evaluate_thrash(snap, NOW) is None
+
+
+# ---------------------------------------------------------------------------
+# 7. Evidence integrity
+# ---------------------------------------------------------------------------
+
+
+def test_thrash_evidence_tables_and_fields() -> None:
+    snap = make_snapshot(
+        rework_churn_ratio=CHURN_RATIO_THRESHOLD + 0.1,
+        throughput_by_cycle=[12.0, 11.0],
+    )
+    result = evaluate_thrash(snap, NOW)
+    assert result is not None
+
+    tables = {e.metric_table for e in result.evidence}
+    fields = {e.field for e in result.evidence}
+
+    assert "repo_metrics_daily" in tables
+    assert "work_item_metrics_daily" in tables
+    assert "rework_churn_ratio_30d" in fields
+    assert "items_completed_delta" in fields
+
+    for ev in result.evidence:
+        assert ev.team_id == snap.team_id
+        assert ev.window_start == snap.window_start
+        assert ev.window_end == snap.window_end
+
+
+# ---------------------------------------------------------------------------
+# 8. Rationale presence
+# ---------------------------------------------------------------------------
+
+
+def test_thrash_rationale_mentions_threshold_and_observed() -> None:
+    snap = make_snapshot(
+        rework_churn_ratio=CHURN_RATIO_THRESHOLD + 0.1,
+        throughput_by_cycle=[12.0, 12.0],
+    )
+    result = evaluate_thrash(snap, NOW)
+    assert result is not None
+    assert str(CHURN_RATIO_THRESHOLD) in result.rationale
+    assert str(THROUGHPUT_LOW_DELTA_THRESHOLD) in result.rationale

--- a/tests/recommendations/rules/test_thrash.py
+++ b/tests/recommendations/rules/test_thrash.py
@@ -13,8 +13,6 @@ Covers:
 
 from __future__ import annotations
 
-import pytest
-
 from dev_health_ops.recommendations.rules.thrash import (
     RULE_ID,
     SUCCESS_CRITERION,
@@ -26,7 +24,6 @@ from dev_health_ops.recommendations.thresholds import (
 )
 
 from .conftest import NOW, make_snapshot
-
 
 # ---------------------------------------------------------------------------
 # 1 & 2. Positive triggers

--- a/tests/recommendations/test_engine.py
+++ b/tests/recommendations/test_engine.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from dev_health_ops.recommendations import registry
+from dev_health_ops.recommendations.engine import RuleEngine
+from dev_health_ops.recommendations.snapshot import MetricsSnapshot
+
+
+class FakeMetricsLoader:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, date, date]] = []
+
+    def load_team_metrics_window(
+        self,
+        team_id: str,
+        org_id: str,
+        window_start: date,
+        window_end: date,
+    ) -> MetricsSnapshot:
+        self.calls.append((team_id, org_id, window_start, window_end))
+        return MetricsSnapshot(
+            team_id=team_id,
+            org_id=org_id,
+            window_start=window_start,
+            window_end=window_end,
+            wip_by_day=[5.0, 6.0, 7.0, 8.0],
+            throughput_by_cycle=[10.0, 10.0],
+            review_latency_p75_hours=48.0,
+            reviewer_gini=0.8,
+            rework_churn_ratio=0.5,
+            after_hours_ratio=0.4,
+            cycle_time_by_day=[12.0, 18.0, 24.0, 30.0],
+            hotspot_complexity_delta=0.5,
+            hotspot_churn_overlap=0.8,
+        )
+
+
+def test_engine_evaluate_returns_expected_rules() -> None:
+    loader = FakeMetricsLoader()
+    now = datetime(2026, 4, 14, 12, 0, tzinfo=timezone.utc)
+    engine = RuleEngine(registry=registry, loader=loader, now=now)
+
+    recommendations = engine.evaluate(
+        team_id="team-alpha",
+        org_id="org-1",
+        window_start=date(2026, 4, 1),
+        window_end=date(2026, 4, 14),
+    )
+
+    assert loader.calls == [("team-alpha", "org-1", date(2026, 4, 1), date(2026, 4, 14))]
+    assert [item.rule_id for item in recommendations] == [rule.id for rule in registry.all_rules()]
+    assert {item.computed_at for item in recommendations} == {now}
+
+
+def test_engine_evaluate_is_deterministic() -> None:
+    now = datetime(2026, 4, 14, 12, 0, tzinfo=timezone.utc)
+    engine = RuleEngine(registry=registry, loader=FakeMetricsLoader(), now=now)
+    args = ("team-alpha", "org-1", date(2026, 4, 1), date(2026, 4, 14))
+
+    first = engine.evaluate(*args)
+    second = engine.evaluate(*args)
+
+    assert first == second

--- a/tests/recommendations/test_engine.py
+++ b/tests/recommendations/test_engine.py
@@ -48,8 +48,12 @@ def test_engine_evaluate_returns_expected_rules() -> None:
         window_end=date(2026, 4, 14),
     )
 
-    assert loader.calls == [("team-alpha", "org-1", date(2026, 4, 1), date(2026, 4, 14))]
-    assert [item.rule_id for item in recommendations] == [rule.id for rule in registry.all_rules()]
+    assert loader.calls == [
+        ("team-alpha", "org-1", date(2026, 4, 1), date(2026, 4, 14))
+    ]
+    assert [item.rule_id for item in recommendations] == [
+        rule.id for rule in registry.all_rules()
+    ]
     assert {item.computed_at for item in recommendations} == {now}
 
 

--- a/tests/recommendations/test_registry.py
+++ b/tests/recommendations/test_registry.py
@@ -1,0 +1,203 @@
+"""Tests for the canonical recommendations registry.
+
+Covers:
+- All 5 canonical rule ids are present
+- Registry shape (types, required fields non-empty)
+- Immutability of RuleDef instances
+- get_rule() happy + error paths
+- all_rules() returns a stable, non-empty tuple
+- Duplicate-id guard raises at import of a tampered registry
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+from dev_health_ops.recommendations.registry import all_rules, get_rule
+from dev_health_ops.recommendations.schema import RuleDef, Severity, Theme
+
+# ---------------------------------------------------------------------------
+# Expected canonical rule ids (per plan §Canonical Rules)
+# ---------------------------------------------------------------------------
+
+CANONICAL_IDS = {
+    "saturation",
+    "review-concentration",
+    "thrash",
+    "sustainability-risk",
+    "compounding-risk",
+}
+
+VALID_SEVERITIES: set[str] = {"warning", "critical"}
+VALID_THEMES: set[str] = {
+    "feature-delivery",
+    "operational-support",
+    "maintenance-tech-debt",
+    "quality-reliability",
+    "risk-security",
+}
+
+
+# ---------------------------------------------------------------------------
+# Registry completeness
+# ---------------------------------------------------------------------------
+
+
+def test_all_five_canonical_ids_present() -> None:
+    ids = {rule.id for rule in all_rules()}
+    assert ids == CANONICAL_IDS, f"Missing or extra ids: {ids.symmetric_difference(CANONICAL_IDS)}"
+
+
+def test_all_rules_returns_tuple() -> None:
+    result = all_rules()
+    assert isinstance(result, tuple)
+    assert len(result) == 5
+
+
+def test_all_rules_stable_order() -> None:
+    """all_rules() must return the same order on repeated calls."""
+    assert all_rules() == all_rules()
+
+
+# ---------------------------------------------------------------------------
+# Rule shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("rule", all_rules())
+def test_rule_is_ruledef_instance(rule: RuleDef) -> None:
+    assert isinstance(rule, RuleDef)
+
+
+@pytest.mark.parametrize("rule", all_rules())
+def test_rule_id_is_non_empty_string(rule: RuleDef) -> None:
+    assert isinstance(rule.id, str)
+    assert rule.id.strip() != ""
+
+
+@pytest.mark.parametrize("rule", all_rules())
+def test_rule_title_is_non_empty_string(rule: RuleDef) -> None:
+    assert isinstance(rule.title, str)
+    assert rule.title.strip() != ""
+
+
+@pytest.mark.parametrize("rule", all_rules())
+def test_rule_description_is_non_empty_string(rule: RuleDef) -> None:
+    assert isinstance(rule.description, str)
+    assert rule.description.strip() != ""
+
+
+@pytest.mark.parametrize("rule", all_rules())
+def test_rule_success_criterion_is_non_empty_string(rule: RuleDef) -> None:
+    assert isinstance(rule.success_criterion, str)
+    assert rule.success_criterion.strip() != ""
+
+
+@pytest.mark.parametrize("rule", all_rules())
+def test_rule_severity_is_valid(rule: RuleDef) -> None:
+    assert rule.severity in VALID_SEVERITIES
+
+
+@pytest.mark.parametrize("rule", all_rules())
+def test_rule_theme_is_valid(rule: RuleDef) -> None:
+    assert rule.theme in VALID_THEMES
+
+
+# ---------------------------------------------------------------------------
+# Immutability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("rule", all_rules())
+def test_ruledef_is_frozen(rule: RuleDef) -> None:
+    with pytest.raises((AttributeError, TypeError)):
+        rule.id = "mutated"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize("rule", all_rules())
+def test_ruledef_is_hashable(rule: RuleDef) -> None:
+    """Frozen dataclasses must be hashable."""
+    assert hash(rule) is not None
+    {rule}  # can be placed in a set
+
+
+def test_all_rules_tuple_is_immutable() -> None:
+    """The returned tuple cannot be mutated."""
+    rules = all_rules()
+    with pytest.raises(TypeError):
+        rules[0] = rules[1]  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# get_rule() accessor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("rule_id", CANONICAL_IDS)
+def test_get_rule_returns_correct_ruledef(rule_id: str) -> None:
+    rule = get_rule(rule_id)
+    assert isinstance(rule, RuleDef)
+    assert rule.id == rule_id
+
+
+def test_get_rule_unknown_id_raises_key_error() -> None:
+    with pytest.raises(KeyError, match="not-a-real-rule"):
+        get_rule("not-a-real-rule")
+
+
+def test_get_rule_error_message_contains_known_ids() -> None:
+    with pytest.raises(KeyError) as exc_info:
+        get_rule("bogus")
+    message = str(exc_info.value)
+    for canonical_id in CANONICAL_IDS:
+        assert canonical_id in message
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-ID guard
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_id_guard_raises_on_import() -> None:
+    """Importing a registry with duplicate ids must raise ValueError."""
+    # Build a fake registry module with a duplicate rule
+    fake_mod_name = "dev_health_ops.recommendations._fake_registry_dup"
+    fake_mod = types.ModuleType(fake_mod_name)
+    fake_mod.__spec__ = None  # type: ignore[attr-defined]
+
+    dup_rule = get_rule("saturation")
+    fake_rules_source = f"""
+from dev_health_ops.recommendations.schema import RuleDef
+
+_RULES = (
+    RuleDef(
+        id="saturation",
+        title="T1",
+        description="D1",
+        success_criterion="S1",
+        severity="warning",
+        theme="operational-support",
+    ),
+    RuleDef(
+        id="saturation",
+        title="T2",
+        description="D2",
+        success_criterion="S2",
+        severity="warning",
+        theme="operational-support",
+    ),
+)
+
+_ids = [rule.id for rule in _RULES]
+_seen: set = set()
+for _rule_id in _ids:
+    if _rule_id in _seen:
+        raise ValueError(f"Duplicate rule id {{_rule_id!r}} detected in recommendations registry.")
+    _seen.add(_rule_id)
+"""
+    with pytest.raises(ValueError, match="Duplicate rule id"):
+        exec(compile(fake_rules_source, "<fake_registry>", "exec"))  # noqa: S102

--- a/tests/recommendations/test_registry.py
+++ b/tests/recommendations/test_registry.py
@@ -11,14 +11,12 @@ Covers:
 
 from __future__ import annotations
 
-import importlib
-import sys
 import types
 
 import pytest
 
 from dev_health_ops.recommendations.registry import all_rules, get_rule
-from dev_health_ops.recommendations.schema import RuleDef, Severity, Theme
+from dev_health_ops.recommendations.schema import RuleDef
 
 # ---------------------------------------------------------------------------
 # Expected canonical rule ids (per plan §Canonical Rules)
@@ -49,7 +47,9 @@ VALID_THEMES: set[str] = {
 
 def test_all_five_canonical_ids_present() -> None:
     ids = {rule.id for rule in all_rules()}
-    assert ids == CANONICAL_IDS, f"Missing or extra ids: {ids.symmetric_difference(CANONICAL_IDS)}"
+    assert ids == CANONICAL_IDS, (
+        f"Missing or extra ids: {ids.symmetric_difference(CANONICAL_IDS)}"
+    )
 
 
 def test_all_rules_returns_tuple() -> None:
@@ -122,7 +122,7 @@ def test_ruledef_is_frozen(rule: RuleDef) -> None:
 def test_ruledef_is_hashable(rule: RuleDef) -> None:
     """Frozen dataclasses must be hashable."""
     assert hash(rule) is not None
-    {rule}  # can be placed in a set
+    assert rule in {rule}
 
 
 def test_all_rules_tuple_is_immutable() -> None:
@@ -167,10 +167,9 @@ def test_duplicate_id_guard_raises_on_import() -> None:
     # Build a fake registry module with a duplicate rule
     fake_mod_name = "dev_health_ops.recommendations._fake_registry_dup"
     fake_mod = types.ModuleType(fake_mod_name)
-    fake_mod.__spec__ = None  # type: ignore[attr-defined]
+    fake_mod.__spec__ = None
 
-    dup_rule = get_rule("saturation")
-    fake_rules_source = f"""
+    fake_rules_source = """
 from dev_health_ops.recommendations.schema import RuleDef
 
 _RULES = (

--- a/tests/recommendations/test_schema.py
+++ b/tests/recommendations/test_schema.py
@@ -1,0 +1,283 @@
+"""Tests for recommendations schema dataclasses.
+
+Covers:
+- EvidenceRef construction, field types, immutability
+- RuleDef construction, field types, immutability
+- Recommendation construction, field types, immutability
+- evidence tuple immutability
+- Hashability (all frozen dataclasses must be hashable)
+- Equality semantics
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from dev_health_ops.recommendations.schema import (
+    EvidenceRef,
+    Recommendation,
+    RuleDef,
+    Severity,
+    Theme,
+    WindowUnit,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+START = date(2026, 1, 1)
+END = date(2026, 1, 8)
+COMPUTED_AT = datetime(2026, 1, 8, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def make_evidence() -> EvidenceRef:
+    return EvidenceRef(
+        team_id="team-abc",
+        metric_table="work_item_metrics_daily",
+        window_start=START,
+        window_end=END,
+        field="wip_count_end_of_day",
+        value=14.0,
+    )
+
+
+def make_rule_def() -> RuleDef:
+    return RuleDef(
+        id="saturation",
+        title="Team Saturation",
+        description="Rising WIP with flat throughput.",
+        success_criterion="WIP trend turns negative in 2 cycles.",
+        severity="warning",
+        theme="operational-support",
+    )
+
+
+def make_recommendation() -> Recommendation:
+    return Recommendation(
+        rule_id="saturation",
+        team_id="team-abc",
+        org_id="org-xyz",
+        computed_at=COMPUTED_AT,
+        window_start=START,
+        window_end=END,
+        severity="warning",
+        title="Team Saturation",
+        rationale="WIP increased by 0.3 items/day; throughput delta was -1.",
+        success_criterion="WIP trend turns negative in 2 cycles.",
+        evidence=(make_evidence(),),
+    )
+
+
+# ---------------------------------------------------------------------------
+# EvidenceRef
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceRef:
+    def test_construction(self) -> None:
+        ev = make_evidence()
+        assert ev.team_id == "team-abc"
+        assert ev.metric_table == "work_item_metrics_daily"
+        assert ev.window_start == START
+        assert ev.window_end == END
+        assert ev.field == "wip_count_end_of_day"
+        assert ev.value == 14.0
+
+    def test_is_frozen(self) -> None:
+        ev = make_evidence()
+        with pytest.raises((AttributeError, TypeError)):
+            ev.team_id = "mutated"  # type: ignore[misc]
+
+    def test_is_hashable(self) -> None:
+        ev = make_evidence()
+        assert hash(ev) is not None
+        {ev}
+
+    def test_equality(self) -> None:
+        assert make_evidence() == make_evidence()
+
+    def test_inequality_on_value(self) -> None:
+        ev1 = make_evidence()
+        ev2 = EvidenceRef(
+            team_id=ev1.team_id,
+            metric_table=ev1.metric_table,
+            window_start=ev1.window_start,
+            window_end=ev1.window_end,
+            field=ev1.field,
+            value=99.0,
+        )
+        assert ev1 != ev2
+
+    def test_field_types(self) -> None:
+        ev = make_evidence()
+        assert isinstance(ev.team_id, str)
+        assert isinstance(ev.metric_table, str)
+        assert isinstance(ev.window_start, date)
+        assert isinstance(ev.window_end, date)
+        assert isinstance(ev.field, str)
+        assert isinstance(ev.value, float)
+
+
+# ---------------------------------------------------------------------------
+# RuleDef
+# ---------------------------------------------------------------------------
+
+
+class TestRuleDef:
+    def test_construction(self) -> None:
+        rd = make_rule_def()
+        assert rd.id == "saturation"
+        assert rd.title == "Team Saturation"
+        assert rd.severity == "warning"
+        assert rd.theme == "operational-support"
+
+    def test_is_frozen(self) -> None:
+        rd = make_rule_def()
+        with pytest.raises((AttributeError, TypeError)):
+            rd.id = "mutated"  # type: ignore[misc]
+
+    def test_is_hashable(self) -> None:
+        rd = make_rule_def()
+        assert hash(rd) is not None
+        {rd}
+
+    def test_equality(self) -> None:
+        assert make_rule_def() == make_rule_def()
+
+    def test_field_types(self) -> None:
+        rd = make_rule_def()
+        assert isinstance(rd.id, str)
+        assert isinstance(rd.title, str)
+        assert isinstance(rd.description, str)
+        assert isinstance(rd.success_criterion, str)
+        assert isinstance(rd.severity, str)
+        assert isinstance(rd.theme, str)
+
+    def test_severity_values(self) -> None:
+        for sev in ("warning", "critical"):
+            rd = RuleDef(
+                id="x",
+                title="T",
+                description="D",
+                success_criterion="S",
+                severity=sev,  # type: ignore[arg-type]
+                theme="operational-support",
+            )
+            assert rd.severity == sev
+
+    def test_theme_values(self) -> None:
+        themes = (
+            "feature-delivery",
+            "operational-support",
+            "maintenance-tech-debt",
+            "quality-reliability",
+            "risk-security",
+        )
+        for theme in themes:
+            rd = RuleDef(
+                id="x",
+                title="T",
+                description="D",
+                success_criterion="S",
+                severity="warning",
+                theme=theme,  # type: ignore[arg-type]
+            )
+            assert rd.theme == theme
+
+
+# ---------------------------------------------------------------------------
+# Recommendation
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendation:
+    def test_construction(self) -> None:
+        rec = make_recommendation()
+        assert rec.rule_id == "saturation"
+        assert rec.team_id == "team-abc"
+        assert rec.org_id == "org-xyz"
+        assert rec.computed_at == COMPUTED_AT
+        assert rec.window_start == START
+        assert rec.window_end == END
+        assert rec.severity == "warning"
+        assert len(rec.evidence) == 1
+
+    def test_is_frozen(self) -> None:
+        rec = make_recommendation()
+        with pytest.raises((AttributeError, TypeError)):
+            rec.rule_id = "mutated"  # type: ignore[misc]
+
+    def test_evidence_is_tuple(self) -> None:
+        rec = make_recommendation()
+        assert isinstance(rec.evidence, tuple)
+
+    def test_evidence_tuple_is_immutable(self) -> None:
+        rec = make_recommendation()
+        with pytest.raises(TypeError):
+            rec.evidence[0] = make_evidence()  # type: ignore[index]
+
+    def test_evidence_can_be_empty(self) -> None:
+        rec = Recommendation(
+            rule_id="saturation",
+            team_id="team-abc",
+            org_id="org-xyz",
+            computed_at=COMPUTED_AT,
+            window_start=START,
+            window_end=END,
+            severity="warning",
+            title="T",
+            rationale="R",
+            success_criterion="S",
+            evidence=(),
+        )
+        assert rec.evidence == ()
+
+    def test_is_hashable(self) -> None:
+        rec = make_recommendation()
+        assert hash(rec) is not None
+        {rec}
+
+    def test_equality(self) -> None:
+        assert make_recommendation() == make_recommendation()
+
+    def test_field_types(self) -> None:
+        rec = make_recommendation()
+        assert isinstance(rec.rule_id, str)
+        assert isinstance(rec.team_id, str)
+        assert isinstance(rec.org_id, str)
+        assert isinstance(rec.computed_at, datetime)
+        assert isinstance(rec.window_start, date)
+        assert isinstance(rec.window_end, date)
+        assert isinstance(rec.severity, str)
+        assert isinstance(rec.title, str)
+        assert isinstance(rec.rationale, str)
+        assert isinstance(rec.success_criterion, str)
+        assert isinstance(rec.evidence, tuple)
+
+    def test_multiple_evidence_refs(self) -> None:
+        ev2 = EvidenceRef(
+            team_id="team-abc",
+            metric_table="team_metrics_daily",
+            window_start=START,
+            window_end=END,
+            field="after_hours_ratio",
+            value=0.35,
+        )
+        rec = Recommendation(
+            rule_id="sustainability-risk",
+            team_id="team-abc",
+            org_id="org-xyz",
+            computed_at=COMPUTED_AT,
+            window_start=START,
+            window_end=END,
+            severity="critical",
+            title="Sustainability Risk",
+            rationale="After-hours 35%, cycle time rising.",
+            success_criterion="After-hours drops in 2 cycles.",
+            evidence=(make_evidence(), ev2),
+        )
+        assert len(rec.evidence) == 2
+        assert rec.evidence[1].field == "after_hours_ratio"

--- a/tests/recommendations/test_schema.py
+++ b/tests/recommendations/test_schema.py
@@ -19,9 +19,6 @@ from dev_health_ops.recommendations.schema import (
     EvidenceRef,
     Recommendation,
     RuleDef,
-    Severity,
-    Theme,
-    WindowUnit,
 )
 
 # ---------------------------------------------------------------------------
@@ -94,7 +91,7 @@ class TestEvidenceRef:
     def test_is_hashable(self) -> None:
         ev = make_evidence()
         assert hash(ev) is not None
-        {ev}
+        assert ev in {ev}
 
     def test_equality(self) -> None:
         assert make_evidence() == make_evidence()
@@ -142,7 +139,7 @@ class TestRuleDef:
     def test_is_hashable(self) -> None:
         rd = make_rule_def()
         assert hash(rd) is not None
-        {rd}
+        assert rd in {rd}
 
     def test_equality(self) -> None:
         assert make_rule_def() == make_rule_def()
@@ -163,7 +160,7 @@ class TestRuleDef:
                 title="T",
                 description="D",
                 success_criterion="S",
-                severity=sev,  # type: ignore[arg-type]
+                severity=sev,
                 theme="operational-support",
             )
             assert rd.severity == sev
@@ -238,7 +235,7 @@ class TestRecommendation:
     def test_is_hashable(self) -> None:
         rec = make_recommendation()
         assert hash(rec) is not None
-        {rec}
+        assert rec in {rec}
 
     def test_equality(self) -> None:
         assert make_recommendation() == make_recommendation()

--- a/tests/recommendations/test_sink.py
+++ b/tests/recommendations/test_sink.py
@@ -1,0 +1,176 @@
+"""Tests for RecommendationsMixin.write_recommendations.
+
+Uses a mock ClickHouse client — no live database required.
+Verifies that the mixin calls _insert_rows with the correct table name
+and column list.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dev_health_ops.recommendations.snapshot import RecommendationRecord
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_record(
+    team_id: str = "team-1",
+    rule_id: str = "saturation",
+    fired: bool = True,
+) -> RecommendationRecord:
+    return RecommendationRecord(
+        team_id=team_id,
+        org_id="org-1",
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        window_start=date(2025, 1, 1),
+        window_end=date(2025, 1, 8),
+        fired=fired,
+        severity="warning",
+        title="Team is saturating.",
+        rationale="WIP slope exceeds threshold.",
+        success_criterion="WIP trend turns negative within 2 cycles.",
+        evidence_json='[{"team_id": "team-1", "metric_table": "work_item_metrics_daily",'
+        ' "window_start": "2025-01-01", "window_end": "2025-01-08",'
+        ' "field": "wip_count_end_of_day", "value": 0.3}]',
+        computed_at=datetime(2025, 1, 8, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+# ---------------------------------------------------------------------------
+# RecommendationsMixin
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendationsMixin:
+    def _make_sink(self) -> "any":
+        """Build a ClickHouseMetricsSink with a mocked client."""
+        from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+        mock_client = MagicMock()
+        sink = ClickHouseMetricsSink.__new__(ClickHouseMetricsSink)
+        sink.client = mock_client
+        sink.org_id = ""
+        sink._insert_rows = MagicMock()
+        return sink
+
+    def test_write_recommendations_calls_insert_rows(self) -> None:
+        sink = self._make_sink()
+        records = [_make_record()]
+        sink.write_recommendations(records)
+
+        sink._insert_rows.assert_called_once()
+        call_args = sink._insert_rows.call_args
+        table_name = call_args[0][0]
+        columns = call_args[0][1]
+
+        assert table_name == "recommendations_daily"
+        assert "team_id" in columns
+        assert "rule_id" in columns
+        assert "fired" in columns
+        assert "evidence_json" in columns
+        assert "computed_at" in columns
+
+    def test_write_recommendations_empty_is_noop(self) -> None:
+        sink = self._make_sink()
+        sink.write_recommendations([])
+        sink._insert_rows.assert_not_called()
+
+    def test_write_recommendations_multiple_records(self) -> None:
+        sink = self._make_sink()
+        records = [
+            _make_record(rule_id="saturation"),
+            _make_record(rule_id="thrash"),
+            _make_record(rule_id="review-concentration"),
+        ]
+        sink.write_recommendations(records)
+        sink._insert_rows.assert_called_once()
+        # Rows passed are the records
+        passed_rows = sink._insert_rows.call_args[0][2]
+        assert len(passed_rows) == 3
+
+    def test_write_recommendations_includes_rule_version(self) -> None:
+        sink = self._make_sink()
+        sink.write_recommendations([_make_record()])
+        columns = sink._insert_rows.call_args[0][1]
+        assert "rule_version" in columns
+
+
+# ---------------------------------------------------------------------------
+# recommendation_to_record helper
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendationToRecord:
+    def test_converts_recommendation_to_record(self) -> None:
+        from datetime import date, datetime, timezone
+        from dev_health_ops.recommendations.loader import recommendation_to_record
+        from dev_health_ops.recommendations.schema import EvidenceRef, Recommendation
+
+        ev = EvidenceRef(
+            team_id="t1",
+            metric_table="work_item_metrics_daily",
+            window_start=date(2025, 1, 1),
+            window_end=date(2025, 1, 8),
+            field="wip_count_end_of_day",
+            value=0.3,
+        )
+        rec = Recommendation(
+            rule_id="saturation",
+            team_id="t1",
+            org_id="o1",
+            computed_at=datetime(2025, 1, 8, tzinfo=timezone.utc),
+            window_start=date(2025, 1, 1),
+            window_end=date(2025, 1, 8),
+            severity="warning",
+            title="Team is saturating.",
+            rationale="WIP slope.",
+            success_criterion="WIP turns negative.",
+            evidence=(ev,),
+        )
+        record = recommendation_to_record(rec)
+
+        assert record.rule_id == "saturation"
+        assert record.team_id == "t1"
+        assert record.fired is True
+        assert record.severity == "warning"
+
+    def test_evidence_serialised_as_json(self) -> None:
+        import json
+        from dev_health_ops.recommendations.loader import recommendation_to_record
+        from dev_health_ops.recommendations.schema import EvidenceRef, Recommendation
+
+        ev = EvidenceRef(
+            team_id="t1",
+            metric_table="work_item_metrics_daily",
+            window_start=date(2025, 1, 1),
+            window_end=date(2025, 1, 8),
+            field="wip_count_end_of_day",
+            value=1.5,
+        )
+        rec = Recommendation(
+            rule_id="saturation",
+            team_id="t1",
+            org_id="o1",
+            computed_at=datetime(2025, 1, 8, tzinfo=timezone.utc),
+            window_start=date(2025, 1, 1),
+            window_end=date(2025, 1, 8),
+            severity="warning",
+            title="T",
+            rationale="R",
+            success_criterion="S",
+            evidence=(ev,),
+        )
+        record = recommendation_to_record(rec)
+        evidence = json.loads(record.evidence_json)
+        assert len(evidence) == 1
+        assert evidence[0]["field"] == "wip_count_end_of_day"
+        assert evidence[0]["value"] == 1.5
+        assert evidence[0]["metric_table"] == "work_item_metrics_daily"

--- a/tests/recommendations/test_sink.py
+++ b/tests/recommendations/test_sink.py
@@ -8,11 +8,13 @@ and column list.
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
-from unittest.mock import MagicMock, patch
-
-import pytest
+from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock
 
 from dev_health_ops.recommendations.snapshot import RecommendationRecord
+
+if TYPE_CHECKING:
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 
 
 # ---------------------------------------------------------------------------
@@ -50,7 +52,7 @@ def _make_record(
 
 
 class TestRecommendationsMixin:
-    def _make_sink(self) -> "any":
+    def _make_sink(self) -> ClickHouseMetricsSink:
         """Build a ClickHouseMetricsSink with a mocked client."""
         from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 
@@ -58,16 +60,17 @@ class TestRecommendationsMixin:
         sink = ClickHouseMetricsSink.__new__(ClickHouseMetricsSink)
         sink.client = mock_client
         sink.org_id = ""
-        sink._insert_rows = MagicMock()
+        object.__setattr__(sink, "_insert_rows", MagicMock())
         return sink
 
     def test_write_recommendations_calls_insert_rows(self) -> None:
         sink = self._make_sink()
+        insert_rows = cast(MagicMock, sink._insert_rows)
         records = [_make_record()]
         sink.write_recommendations(records)
 
-        sink._insert_rows.assert_called_once()
-        call_args = sink._insert_rows.call_args
+        insert_rows.assert_called_once()
+        call_args = insert_rows.call_args
         table_name = call_args[0][0]
         columns = call_args[0][1]
 
@@ -80,8 +83,9 @@ class TestRecommendationsMixin:
 
     def test_write_recommendations_empty_is_noop(self) -> None:
         sink = self._make_sink()
+        insert_rows = cast(MagicMock, sink._insert_rows)
         sink.write_recommendations([])
-        sink._insert_rows.assert_not_called()
+        insert_rows.assert_not_called()
 
     def test_write_recommendations_multiple_records(self) -> None:
         sink = self._make_sink()
@@ -91,15 +95,17 @@ class TestRecommendationsMixin:
             _make_record(rule_id="review-concentration"),
         ]
         sink.write_recommendations(records)
-        sink._insert_rows.assert_called_once()
+        insert_rows = cast(MagicMock, sink._insert_rows)
+        insert_rows.assert_called_once()
         # Rows passed are the records
-        passed_rows = sink._insert_rows.call_args[0][2]
+        passed_rows = insert_rows.call_args[0][2]
         assert len(passed_rows) == 3
 
     def test_write_recommendations_includes_rule_version(self) -> None:
         sink = self._make_sink()
         sink.write_recommendations([_make_record()])
-        columns = sink._insert_rows.call_args[0][1]
+        insert_rows = cast(MagicMock, sink._insert_rows)
+        columns = insert_rows.call_args[0][1]
         assert "rule_version" in columns
 
 
@@ -111,6 +117,7 @@ class TestRecommendationsMixin:
 class TestRecommendationToRecord:
     def test_converts_recommendation_to_record(self) -> None:
         from datetime import date, datetime, timezone
+
         from dev_health_ops.recommendations.loader import recommendation_to_record
         from dev_health_ops.recommendations.schema import EvidenceRef, Recommendation
 
@@ -144,6 +151,7 @@ class TestRecommendationToRecord:
 
     def test_evidence_serialised_as_json(self) -> None:
         import json
+
         from dev_health_ops.recommendations.loader import recommendation_to_record
         from dev_health_ops.recommendations.schema import EvidenceRef, Recommendation
 


### PR DESCRIPTION
## Summary

Ships the rule-based operational recommendations engine per the P1 plan in `docs/product/dev-health-product-market-simplification.md` §"Operational Recommendations". Closes the four sub-issues under [CHAOS-1620](https://linear.app/fullchaos/issue/CHAOS-1620).

## Scope

- **CHAOS-1621** — Canonical rule registry + schema + named thresholds (code-only, no user config)
- **CHAOS-1622** — Deterministic `RuleEngine` + `ClickHouseMetricsLoader` + ClickHouse append-only sink + migration `039_recommendations.sql` (`ReplacingMergeTree(computed_at)`) + `dev-hops recommendations compute` CLI
- **CHAOS-1623** — Five canonical rules with golden tests: saturation, review-concentration, thrash, sustainability-risk, compounding-risk
- **CHAOS-1624** — Strawberry GraphQL `recommendations(orgId, team, window)` resolver + types + persisted query

## Design

- Hexagonal: rules are pure `(MetricsSnapshot, datetime) -> Recommendation | None`. Engine + ClickHouse loader live behind a `MetricsLoader` protocol so rules are I/O-free.
- Read pattern: `argMax(..., computed_at)` grouped by `(org_id, team_id, rule_id, window_end)` — mirrors `operating_review.py`.
- Every recommendation carries `evidence` (inspectable refs to source rows), `rationale` (named threshold + observed value), and `success_criterion`.

## Verification

\`\`\`
uv run pytest tests/recommendations -v   # 134 passed
uv run ruff check                         # All checks passed
\`\`\`

SCREENSHOT-WAIVER: purely backend change, no rendered UI.

Closes CHAOS-1621
Closes CHAOS-1622
Closes CHAOS-1623
Closes CHAOS-1624
Closes CHAOS-1620