### PR TITLE
feat(ops): data health GraphQL surface (CHAOS-1630)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/data_health.py
+++ b/src/dev_health_ops/api/graphql/models/data_health.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any
 
 import strawberry
 from strawberry.types import Info
+
+logger = logging.getLogger(__name__)
 
 
 @strawberry.type
@@ -73,6 +77,24 @@ class WindowSpec:
     duration_days: int | None = None
 
 
+METRIC_LINEAGE_REGISTRY: dict[str, tuple[list[str], WindowSpec]] = {
+    "throughput": (["work_item_metrics_daily"], WindowSpec(kind="daily")),
+    "cycle_time": (["work_item_metrics_daily"], WindowSpec(kind="daily")),
+    "lead_time": (["work_item_metrics_daily"], WindowSpec(kind="daily")),
+    "wip": (["work_item_metrics_daily"], WindowSpec(kind="daily")),
+    "review_load": (["repo_metrics_daily"], WindowSpec(kind="daily")),
+    "review_latency": (["repo_metrics_daily"], WindowSpec(kind="daily")),
+    "deployment_frequency": (["repo_metrics_daily"], WindowSpec(kind="daily")),
+    "change_failure_rate": (["repo_metrics_daily"], WindowSpec(kind="daily")),
+    "after_hours_ratio": (["team_metrics_daily"], WindowSpec(kind="daily")),
+    "weekend_ratio": (["team_metrics_daily"], WindowSpec(kind="daily")),
+    "investment_mix": (
+        ["work_unit_investments"],
+        WindowSpec(kind="rolling", duration_days=30),
+    ),
+}
+
+
 @strawberry.type
 class MetricLineage:
     metric_id: strawberry.ID
@@ -80,6 +102,88 @@ class MetricLineage:
     compute_window: WindowSpec
     computed_at: datetime
     row_count: int | None = None
+
+
+async def compute_metric_lineage(
+    context: Any, team: str, metric_id: str
+) -> MetricLineage | None:
+    from dev_health_ops.api.graphql.authz import require_org_id
+
+    org_id = require_org_id(context)
+    registry_entry = METRIC_LINEAGE_REGISTRY.get(metric_id)
+    if registry_entry is None:
+        return None
+    source_tables, window = registry_entry
+    computed_at, row_count = await _lineage_freshness(
+        context, org_id=org_id, team=team, tables=source_tables
+    )
+    if computed_at is None:
+        return None
+    return MetricLineage(
+        metric_id=strawberry.ID(metric_id),
+        source_tables=source_tables,
+        compute_window=window,
+        computed_at=computed_at,
+        row_count=row_count,
+    )
+
+
+async def _lineage_freshness(
+    context: Any, *, org_id: str, team: str, tables: Sequence[str]
+) -> tuple[datetime | None, int | None]:
+    computed_values: list[datetime] = []
+    total_rows = 0
+    for table in tables:
+        if not _safe_table_name(table):
+            continue
+        sql = f"""
+            SELECT argMax(computed_at, computed_at) AS computed_at, count() AS row_count
+            FROM {table}
+            WHERE org_id = %(org_id)s
+        """
+        rows = await _query_dicts(context, sql, {"org_id": org_id, "team": team})
+        if not rows:
+            continue
+        row = rows[0]
+        computed = row.get("computed_at")
+        if isinstance(computed, datetime):
+            computed_values.append(computed)
+        elif computed:
+            try:
+                computed_values.append(datetime.fromisoformat(str(computed)))
+            except ValueError:
+                logger.debug(
+                    "Ignoring unparsable computed_at %r for %s", computed, table
+                )
+        total_rows += _int(row.get("row_count"))
+    if not computed_values:
+        return None, None
+    return max(computed_values), total_rows
+
+
+async def _query_dicts(
+    context: Any, sql: str, params: Mapping[str, Any]
+) -> list[Mapping[str, Any]]:
+    if context.client is None:
+        return []
+    from dev_health_ops.api.queries.client import query_dicts
+
+    try:
+        return list(await query_dicts(context.client, sql, dict(params)))
+    except Exception:
+        logger.exception("Data health query failed")
+        return []
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _safe_table_name(table: str) -> bool:
+    return table.replace("_", "").isalnum()
 
 
 @strawberry.type
@@ -94,9 +198,6 @@ class DataHealth:
     async def metric_lineage(
         self, info: Info, metric_id: strawberry.ID
     ) -> MetricLineage | None:
-        from dev_health_ops.api.graphql.resolvers.data_health import (
-            resolve_metric_lineage,
-        )
-
+        # Keep this resolver with the type to avoid a models<->resolvers import cycle.
         context = info.context if info is not None else self.context
-        return await resolve_metric_lineage(context, self.team, str(metric_id))
+        return await compute_metric_lineage(context, self.team, str(metric_id))

--- a/src/dev_health_ops/api/graphql/models/data_health.py
+++ b/src/dev_health_ops/api/graphql/models/data_health.py
@@ -1,0 +1,102 @@
+"""Strawberry GraphQL types for the data-health surface."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import strawberry
+from strawberry.types import Info
+
+
+@strawberry.type
+class ConnectorFailure:
+    occurred_at: datetime
+    message: str
+    stage: str | None = None
+
+
+@strawberry.type
+class ConnectorStatus:
+    provider: str
+    scope: str
+    last_sync_at: datetime | None = None
+    rows_ingested: int = 0
+    last_failure: ConnectorFailure | None = None
+
+
+@strawberry.type
+class UnmappedIdentity:
+    provider: str
+    email: str | None = None
+    display_name: str | None = None
+    observed_count: int | None = None
+
+
+@strawberry.type
+class AliasSuggestion:
+    unmapped_identity: UnmappedIdentity
+    suggested_canonical_id: str
+    confidence: float
+
+
+@strawberry.type
+class IdentityMappingHealth:
+    unmapped_count: int
+    unmapped_identities: list[UnmappedIdentity]
+    suggested_aliases: list[AliasSuggestion]
+
+
+@strawberry.type
+class MissingMapping:
+    repo_name: str
+    reason: str
+
+
+@strawberry.type
+class CoverageStat:
+    total_repos: int
+    covered_repos: int
+    coverage_pct: float
+    missing: list[MissingMapping]
+
+
+@strawberry.type
+class MappingCoverage:
+    deployments: CoverageStat
+    work_items: CoverageStat
+
+
+@strawberry.type
+class WindowSpec:
+    kind: str
+    duration_days: int | None = None
+
+
+@strawberry.type
+class MetricLineage:
+    metric_id: strawberry.ID
+    source_tables: list[str]
+    compute_window: WindowSpec
+    computed_at: datetime
+    row_count: int | None = None
+
+
+@strawberry.type
+class DataHealth:
+    connectors: list[ConnectorStatus]
+    identity_mapping: IdentityMappingHealth
+    mapping_coverage: MappingCoverage
+    team: strawberry.Private[str]
+    context: strawberry.Private[Any]
+
+    @strawberry.field
+    async def metric_lineage(
+        self, info: Info, metric_id: strawberry.ID
+    ) -> MetricLineage | None:
+        from dev_health_ops.api.graphql.resolvers.data_health import (
+            resolve_metric_lineage,
+        )
+
+        context = info.context if info is not None else self.context
+        return await resolve_metric_lineage(context, self.team, str(metric_id))

--- a/src/dev_health_ops/api/graphql/resolvers/data_health.py
+++ b/src/dev_health_ops/api/graphql/resolvers/data_health.py
@@ -1,0 +1,452 @@
+"""Resolvers for the operator-facing data-health GraphQL surface."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+import strawberry
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from dev_health_ops.models.settings import (
+    IdentityMapping,
+    JobRun,
+    JobRunStatus,
+    ScheduledJob,
+    SyncConfiguration,
+)
+
+from ..authz import require_org_id
+from ..context import GraphQLContext
+from ..errors import AuthorizationError
+from ..models.data_health import (
+    AliasSuggestion,
+    ConnectorFailure,
+    ConnectorStatus,
+    CoverageStat,
+    DataHealth,
+    IdentityMappingHealth,
+    MappingCoverage,
+    MetricLineage,
+    MissingMapping,
+    UnmappedIdentity,
+    WindowSpec,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_UNMAPPED_IDENTITIES = 25
+MAX_ALIAS_SUGGESTIONS = 25
+
+# TODO(CHAOS-1631): promote sync_configurations/job_runs into a dedicated
+# sync-run read model with rows-ingested/stage fields for connector health.
+
+METRIC_LINEAGE_REGISTRY: dict[str, tuple[list[str], WindowSpec]] = {
+    "throughput": (["work_item_metrics_daily"], WindowSpec(kind="daily")),
+    "cycle_time": (["work_item_metrics_daily"], WindowSpec(kind="daily")),
+    "lead_time": (["work_item_metrics_daily"], WindowSpec(kind="daily")),
+    "wip": (["work_item_metrics_daily"], WindowSpec(kind="daily")),
+    "review_load": (["repo_metrics_daily"], WindowSpec(kind="daily")),
+    "review_latency": (["repo_metrics_daily"], WindowSpec(kind="daily")),
+    "deployment_frequency": (["repo_metrics_daily"], WindowSpec(kind="daily")),
+    "change_failure_rate": (["repo_metrics_daily"], WindowSpec(kind="daily")),
+    "after_hours_ratio": (["team_metrics_daily"], WindowSpec(kind="daily")),
+    "weekend_ratio": (["team_metrics_daily"], WindowSpec(kind="daily")),
+    "investment_mix": (["work_unit_investments"], WindowSpec(kind="rolling", duration_days=30)),
+}
+
+
+async def resolve_data_health(context: GraphQLContext, team: str) -> DataHealth:
+    """Return connector, identity, mapping, and lineage health for a team."""
+
+    _require_operator(context)
+    require_org_id(context)
+    connectors = await resolve_connectors(context)
+    identity_mapping = await resolve_identity_mapping(context, team)
+    mapping_coverage = await resolve_mapping_coverage(context, team)
+    return DataHealth(
+        connectors=connectors,
+        identity_mapping=identity_mapping,
+        mapping_coverage=mapping_coverage,
+        team=team,
+        context=context,
+    )
+
+
+def _require_operator(context: GraphQLContext) -> None:
+    user = context.user
+    if user is None:
+        raise AuthorizationError("Authentication required")
+    role = str(getattr(user, "role", "") or "").lower()
+    if getattr(user, "is_superuser", False) or role in {"admin", "owner", "operator"}:
+        return
+    raise AuthorizationError("Data health requires operator access")
+
+
+async def resolve_connectors(context: GraphQLContext) -> list[ConnectorStatus]:
+    """Read connector status from existing sync configuration/job-run tables."""
+
+    org_id = require_org_id(context)
+    session = _db_session(context)
+    if session is None:
+        return []
+
+    stmt = (
+        select(SyncConfiguration)
+        .where(SyncConfiguration.org_id == org_id, SyncConfiguration.is_active.is_(True))
+        .options(selectinload(SyncConfiguration.children))
+        .order_by(SyncConfiguration.provider, SyncConfiguration.name)
+    )
+    configs = list((await session.execute(stmt)).scalars().all())
+    statuses: list[ConnectorStatus] = []
+    for config in configs:
+        latest_run = await _latest_job_run(session, config.id)
+        stats = _as_mapping(config.last_sync_stats) or _as_mapping(
+            getattr(latest_run, "result", None)
+        )
+        rows_ingested = _rows_ingested(stats)
+        last_sync_at = config.last_sync_at or getattr(latest_run, "completed_at", None)
+        failure = _connector_failure(config, latest_run)
+        statuses.append(
+            ConnectorStatus(
+                provider=str(config.provider),
+                scope=_connector_scope(config),
+                last_sync_at=last_sync_at,
+                rows_ingested=rows_ingested,
+                last_failure=failure,
+            )
+        )
+    return statuses
+
+
+async def _latest_job_run(session: Any, sync_config_id: Any) -> JobRun | None:
+    stmt = (
+        select(JobRun)
+        .join(ScheduledJob, ScheduledJob.id == JobRun.job_id)
+        .where(ScheduledJob.sync_config_id == sync_config_id)
+        .order_by(JobRun.created_at.desc())
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalars().first()
+
+
+def _connector_scope(config: SyncConfiguration) -> str:
+    targets = config.sync_targets or []
+    if targets:
+        return ", ".join(str(target) for target in targets[:3])
+    return str(config.name)
+
+
+def _connector_failure(
+    config: SyncConfiguration, latest_run: JobRun | None
+) -> ConnectorFailure | None:
+    message = config.last_sync_error or getattr(latest_run, "error", None)
+    failed_run = latest_run is not None and getattr(latest_run, "status", None) in {
+        JobRunStatus.FAILED.value,
+        JobRunStatus.CANCELLED.value,
+    }
+    if not message and config.last_sync_success is not False and not failed_run:
+        return None
+    occurred_at = (
+        getattr(latest_run, "completed_at", None)
+        or getattr(latest_run, "started_at", None)
+        or config.last_sync_at
+        or config.updated_at
+        or datetime.now(UTC)
+    )
+    result = _as_mapping(getattr(latest_run, "result", None))
+    return ConnectorFailure(
+        occurred_at=occurred_at,
+        message=str(message or "Last sync failed"),
+        stage=str(result.get("stage")) if result and result.get("stage") else None,
+    )
+
+
+async def resolve_identity_mapping(
+    context: GraphQLContext, team: str
+) -> IdentityMappingHealth:
+    org_id = require_org_id(context)
+    observed = await _observed_identities(context, org_id=org_id, team=team)
+    mapped = await _mapped_identities(context, org_id=org_id, team=team)
+    mapped_keys = _identity_keys(mapped)
+
+    unmapped: list[UnmappedIdentity] = []
+    for row in observed:
+        identity = _unmapped_identity(row)
+        if not _is_mapped(identity, mapped_keys):
+            unmapped.append(identity)
+
+    unmapped.sort(key=lambda item: item.observed_count or 0, reverse=True)
+    suggestions = _alias_suggestions(unmapped, mapped)[:MAX_ALIAS_SUGGESTIONS]
+    return IdentityMappingHealth(
+        unmapped_count=len(unmapped),
+        unmapped_identities=unmapped[:MAX_UNMAPPED_IDENTITIES],
+        suggested_aliases=suggestions,
+    )
+
+
+async def _observed_identities(
+    context: GraphQLContext, *, org_id: str, team: str
+) -> list[Mapping[str, Any]]:
+    client = context.client
+    if client is None:
+        return []
+    sql = """
+        SELECT provider, identity, display_name, sum(observed_count) AS observed_count
+        FROM (
+            SELECT 'git' AS provider, lower(author_email) AS identity,
+                   any(author_name) AS display_name, count() AS observed_count
+            FROM git_commits
+            WHERE org_id = %(org_id)s AND lower(author_email) != ''
+            GROUP BY identity
+            UNION ALL
+            SELECT provider, arrayJoin(assignees) AS identity,
+                   identity AS display_name, count() AS observed_count
+            FROM work_items
+            WHERE org_id = %(org_id)s AND has(assignees, '') = 0
+            GROUP BY provider, identity
+        )
+        GROUP BY provider, identity, display_name
+        ORDER BY observed_count DESC
+        LIMIT 100
+    """
+    return await _query_dicts(context, sql, {"org_id": org_id, "team": team})
+
+
+async def _mapped_identities(
+    context: GraphQLContext, *, org_id: str, team: str
+) -> list[IdentityMapping]:
+    session = _db_session(context)
+    if session is None:
+        return []
+    stmt = select(IdentityMapping).where(
+        IdentityMapping.org_id == org_id,
+        IdentityMapping.is_active.is_(True),
+    )
+    rows = list((await session.execute(stmt)).scalars().all())
+    if not team:
+        return rows
+    return [row for row in rows if not row.team_ids or team in row.team_ids]
+
+
+def _unmapped_identity(row: Mapping[str, Any]) -> UnmappedIdentity:
+    identity = str(row.get("identity") or "")
+    email = identity if "@" in identity else None
+    return UnmappedIdentity(
+        provider=str(row.get("provider") or "unknown"),
+        email=email,
+        display_name=str(row.get("display_name") or identity) or None,
+        observed_count=_int(row.get("observed_count")),
+    )
+
+
+def _identity_keys(mapped: Sequence[IdentityMapping]) -> set[str]:
+    keys: set[str] = set()
+    for row in mapped:
+        for value in [row.canonical_id, row.email, row.display_name]:
+            if value:
+                keys.add(_norm(value))
+        for values in (row.provider_identities or {}).values():
+            keys.update(_norm(str(value)) for value in values if value)
+    return keys
+
+
+def _is_mapped(identity: UnmappedIdentity, mapped_keys: set[str]) -> bool:
+    values = [identity.email, identity.display_name]
+    return any(value and _norm(value) in mapped_keys for value in values)
+
+
+def _alias_suggestions(
+    unmapped: Sequence[UnmappedIdentity], mapped: Sequence[IdentityMapping]
+) -> list[AliasSuggestion]:
+    by_local: dict[str, IdentityMapping] = {}
+    for row in mapped:
+        for value in [row.email, row.canonical_id]:
+            local = _email_local(value)
+            if local:
+                by_local.setdefault(local, row)
+
+    suggestions: list[AliasSuggestion] = []
+    for identity in unmapped:
+        local = _email_local(identity.email) or _email_local(identity.display_name)
+        if not local or local not in by_local:
+            continue
+        target = by_local[local]
+        suggestions.append(
+            AliasSuggestion(
+                unmapped_identity=identity,
+                suggested_canonical_id=target.canonical_id,
+                confidence=0.82,
+            )
+        )
+    return suggestions
+
+
+async def resolve_mapping_coverage(
+    context: GraphQLContext, team: str
+) -> MappingCoverage:
+    org_id = require_org_id(context)
+    deployments, work_items = await _coverage_rows(context, org_id=org_id, team=team)
+    return MappingCoverage(
+        deployments=_coverage_stat(deployments, "No deployment-to-release/PR mapping"),
+        work_items=_coverage_stat(work_items, "No work-item project/provider mapping"),
+    )
+
+
+async def _coverage_rows(
+    context: GraphQLContext, *, org_id: str, team: str
+) -> tuple[list[Mapping[str, Any]], list[Mapping[str, Any]]]:
+    deployments_sql = """
+        SELECT coalesce(nullIf(r.repo, ''), toString(d.repo_id)) AS repo_name,
+               count() AS total,
+               countIf(d.pull_request_number IS NOT NULL OR d.release_ref != '') AS covered
+        FROM deployments d
+        LEFT JOIN repos r ON r.id = d.repo_id
+        WHERE d.org_id = %(org_id)s
+        GROUP BY repo_name
+        ORDER BY repo_name
+    """
+    work_items_sql = """
+        SELECT coalesce(nullIf(r.repo, ''), toString(w.repo_id)) AS repo_name,
+               count() AS total,
+               countIf(w.provider != '' AND w.project_key != '') AS covered
+        FROM work_items w
+        LEFT JOIN repos r ON r.id = w.repo_id
+        WHERE w.org_id = %(org_id)s
+        GROUP BY repo_name
+        ORDER BY repo_name
+    """
+    deployments = await _query_dicts(
+        context, deployments_sql, {"org_id": org_id, "team": team}
+    )
+    work_items = await _query_dicts(context, work_items_sql, {"org_id": org_id, "team": team})
+    return deployments, work_items
+
+
+def _coverage_stat(rows: Iterable[Mapping[str, Any]], reason: str) -> CoverageStat:
+    materialized = list(rows)
+    total = len(materialized)
+    covered = sum(1 for row in materialized if _int(row.get("covered")) > 0)
+    missing = [
+        MissingMapping(repo_name=str(row.get("repo_name") or "unknown"), reason=reason)
+        for row in materialized
+        if _int(row.get("covered")) <= 0
+    ]
+    pct = (covered / total * 100.0) if total else 100.0
+    return CoverageStat(
+        total_repos=total,
+        covered_repos=covered,
+        coverage_pct=pct,
+        missing=missing,
+    )
+
+
+async def resolve_metric_lineage(
+    context: GraphQLContext, team: str, metric_id: str
+) -> MetricLineage | None:
+    org_id = require_org_id(context)
+    registry_entry = METRIC_LINEAGE_REGISTRY.get(metric_id)
+    if registry_entry is None:
+        return None
+    source_tables, window = registry_entry
+    computed_at, row_count = await _lineage_freshness(
+        context, org_id=org_id, team=team, tables=source_tables
+    )
+    if computed_at is None:
+        return None
+    return MetricLineage(
+        metric_id=strawberry.ID(metric_id),
+        source_tables=source_tables,
+        compute_window=window,
+        computed_at=computed_at,
+        row_count=row_count,
+    )
+
+
+async def _lineage_freshness(
+    context: GraphQLContext, *, org_id: str, team: str, tables: Sequence[str]
+) -> tuple[datetime | None, int | None]:
+    computed_values: list[datetime] = []
+    total_rows = 0
+    for table in tables:
+        if not _safe_table_name(table):
+            continue
+        sql = f"""
+            SELECT argMax(computed_at, computed_at) AS computed_at, count() AS row_count
+            FROM {table}
+            WHERE org_id = %(org_id)s
+        """
+        rows = await _query_dicts(context, sql, {"org_id": org_id, "team": team})
+        if not rows:
+            continue
+        row = rows[0]
+        computed = row.get("computed_at")
+        if isinstance(computed, datetime):
+            computed_values.append(computed)
+        elif computed:
+            try:
+                computed_values.append(datetime.fromisoformat(str(computed)))
+            except ValueError:
+                logger.debug("Ignoring unparsable computed_at %r for %s", computed, table)
+        total_rows += _int(row.get("row_count"))
+    if not computed_values:
+        return None, None
+    return max(computed_values), total_rows
+
+
+async def _query_dicts(
+    context: GraphQLContext, sql: str, params: Mapping[str, Any]
+) -> list[Mapping[str, Any]]:
+    if context.client is None:
+        return []
+    from dev_health_ops.api.queries.client import query_dicts
+
+    try:
+        return list(await query_dicts(context.client, sql, dict(params)))
+    except Exception:
+        logger.exception("Data health query failed")
+        return []
+
+
+def _db_session(context: GraphQLContext) -> Any | None:
+    return getattr(context, "db_session", None) or getattr(context, "session", None)
+
+
+def _rows_ingested(stats: Mapping[str, Any] | None) -> int:
+    if not stats:
+        return 0
+    for key in ("rows_ingested", "rows", "items_synced", "items", "count"):
+        if key in stats:
+            return _int(stats.get(key))
+    return 0
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _norm(value: str) -> str:
+    return " ".join(value.strip().lower().split())
+
+
+def _email_local(value: str | None) -> str | None:
+    if not value:
+        return None
+    normalized = _norm(value)
+    if "@" in normalized:
+        return normalized.split("@", 1)[0]
+    return normalized or None
+
+
+def _safe_table_name(table: str) -> bool:
+    return table.replace("_", "").isalnum()

--- a/src/dev_health_ops/api/graphql/resolvers/data_health.py
+++ b/src/dev_health_ops/api/graphql/resolvers/data_health.py
@@ -7,7 +7,6 @@ from collections.abc import Iterable, Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any
 
-import strawberry
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
@@ -33,7 +32,7 @@ from ..models.data_health import (
     MetricLineage,
     MissingMapping,
     UnmappedIdentity,
-    WindowSpec,
+    compute_metric_lineage,
 )
 
 logger = logging.getLogger(__name__)
@@ -43,20 +42,6 @@ MAX_ALIAS_SUGGESTIONS = 25
 
 # TODO(CHAOS-1631): promote sync_configurations/job_runs into a dedicated
 # sync-run read model with rows-ingested/stage fields for connector health.
-
-METRIC_LINEAGE_REGISTRY: dict[str, tuple[list[str], WindowSpec]] = {
-    "throughput": (["work_item_metrics_daily"], WindowSpec(kind="daily")),
-    "cycle_time": (["work_item_metrics_daily"], WindowSpec(kind="daily")),
-    "lead_time": (["work_item_metrics_daily"], WindowSpec(kind="daily")),
-    "wip": (["work_item_metrics_daily"], WindowSpec(kind="daily")),
-    "review_load": (["repo_metrics_daily"], WindowSpec(kind="daily")),
-    "review_latency": (["repo_metrics_daily"], WindowSpec(kind="daily")),
-    "deployment_frequency": (["repo_metrics_daily"], WindowSpec(kind="daily")),
-    "change_failure_rate": (["repo_metrics_daily"], WindowSpec(kind="daily")),
-    "after_hours_ratio": (["team_metrics_daily"], WindowSpec(kind="daily")),
-    "weekend_ratio": (["team_metrics_daily"], WindowSpec(kind="daily")),
-    "investment_mix": (["work_unit_investments"], WindowSpec(kind="rolling", duration_days=30)),
-}
 
 
 async def resolve_data_health(context: GraphQLContext, team: str) -> DataHealth:
@@ -96,7 +81,9 @@ async def resolve_connectors(context: GraphQLContext) -> list[ConnectorStatus]:
 
     stmt = (
         select(SyncConfiguration)
-        .where(SyncConfiguration.org_id == org_id, SyncConfiguration.is_active.is_(True))
+        .where(
+            SyncConfiguration.org_id == org_id, SyncConfiguration.is_active.is_(True)
+        )
         .options(selectinload(SyncConfiguration.children))
         .order_by(SyncConfiguration.provider, SyncConfiguration.name)
     )
@@ -322,7 +309,9 @@ async def _coverage_rows(
     deployments = await _query_dicts(
         context, deployments_sql, {"org_id": org_id, "team": team}
     )
-    work_items = await _query_dicts(context, work_items_sql, {"org_id": org_id, "team": team})
+    work_items = await _query_dicts(
+        context, work_items_sql, {"org_id": org_id, "team": team}
+    )
     return deployments, work_items
 
 
@@ -347,54 +336,7 @@ def _coverage_stat(rows: Iterable[Mapping[str, Any]], reason: str) -> CoverageSt
 async def resolve_metric_lineage(
     context: GraphQLContext, team: str, metric_id: str
 ) -> MetricLineage | None:
-    org_id = require_org_id(context)
-    registry_entry = METRIC_LINEAGE_REGISTRY.get(metric_id)
-    if registry_entry is None:
-        return None
-    source_tables, window = registry_entry
-    computed_at, row_count = await _lineage_freshness(
-        context, org_id=org_id, team=team, tables=source_tables
-    )
-    if computed_at is None:
-        return None
-    return MetricLineage(
-        metric_id=strawberry.ID(metric_id),
-        source_tables=source_tables,
-        compute_window=window,
-        computed_at=computed_at,
-        row_count=row_count,
-    )
-
-
-async def _lineage_freshness(
-    context: GraphQLContext, *, org_id: str, team: str, tables: Sequence[str]
-) -> tuple[datetime | None, int | None]:
-    computed_values: list[datetime] = []
-    total_rows = 0
-    for table in tables:
-        if not _safe_table_name(table):
-            continue
-        sql = f"""
-            SELECT argMax(computed_at, computed_at) AS computed_at, count() AS row_count
-            FROM {table}
-            WHERE org_id = %(org_id)s
-        """
-        rows = await _query_dicts(context, sql, {"org_id": org_id, "team": team})
-        if not rows:
-            continue
-        row = rows[0]
-        computed = row.get("computed_at")
-        if isinstance(computed, datetime):
-            computed_values.append(computed)
-        elif computed:
-            try:
-                computed_values.append(datetime.fromisoformat(str(computed)))
-            except ValueError:
-                logger.debug("Ignoring unparsable computed_at %r for %s", computed, table)
-        total_rows += _int(row.get("row_count"))
-    if not computed_values:
-        return None, None
-    return max(computed_values), total_rows
+    return await compute_metric_lineage(context, team, metric_id)
 
 
 async def _query_dicts(
@@ -446,7 +388,3 @@ def _email_local(value: str | None) -> str | None:
     if "@" in normalized:
         return normalized.split("@", 1)[0]
     return normalized or None
-
-
-def _safe_table_name(table: str) -> bool:
-    return table.replace("_", "").isalnum()

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -21,6 +21,7 @@ from .models.ai import (
     AIWorkflowDrilldownResult,
     AIWorkflowRootTypeInput,
 )
+from .models.data_health import DataHealth
 from .models.inputs import (
     AnalyticsRequestInput,
     CapacityForecastFilterInput,
@@ -56,6 +57,7 @@ from .resolvers.ai import (
 )
 from .resolvers.analytics import resolve_analytics
 from .resolvers.catalog import resolve_catalog
+from .resolvers.data_health import resolve_data_health
 from .resolvers.reports import (
     CloneSavedReportInput,
     CreateSavedReportInput,
@@ -288,6 +290,15 @@ class Query:
 
         context = get_context(info)
         return await resolve_operating_review(context, input)
+
+    @strawberry.field(description="Operator data-health and trust surface")
+    async def data_health(
+        self,
+        info: Info,
+        team: strawberry.ID,
+    ) -> DataHealth:
+        context = get_context(info)
+        return await resolve_data_health(context, str(team))
 
     @strawberry.field(
         description="AI workflow impact summary across the requested time range."

--- a/tests/api/graphql/test_data_health.py
+++ b/tests/api/graphql/test_data_health.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any, cast
+from uuid import UUID
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.resolvers import data_health
+from dev_health_ops.models.settings import IdentityMapping, JobRun, SyncConfiguration
+
+pytestmark = pytest.mark.anyio
+
+
+class _ScalarResult:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+    def first(self) -> Any | None:
+        return self._rows[0] if self._rows else None
+
+
+class _ExecuteResult:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def scalars(self) -> _ScalarResult:
+        return _ScalarResult(self._rows)
+
+
+class _Session:
+    def __init__(self, rows: list[Any]) -> None:
+        self.rows = rows
+
+    async def execute(self, _stmt: Any) -> _ExecuteResult:
+        return _ExecuteResult(self.rows)
+
+
+def _context(**kwargs: Any) -> GraphQLContext:
+    ctx = GraphQLContext(
+        org_id="org-1",
+        db_url="clickhouse://localhost/default",
+        client=kwargs.pop("client", object()),
+        user=cast(Any, SimpleNamespace(role="admin", is_superuser=False)),
+    )
+    for key, value in kwargs.items():
+        setattr(ctx, key, value)
+    return ctx
+
+
+async def test_connectors_reads_existing_sync_history(monkeypatch: pytest.MonkeyPatch):
+    config = SyncConfiguration(
+        name="GitHub Main",
+        provider="github",
+        org_id="org-1",
+        sync_targets=["acme/app"],
+    )
+    config.last_sync_at = datetime(2026, 5, 20, tzinfo=UTC)
+    config.last_sync_success = False
+    config.last_sync_error = "rate limited"
+    config.last_sync_stats = {"rows_ingested": 42}
+
+    run = JobRun(job_id=UUID("00000000-0000-0000-0000-000000000001"))
+    run.completed_at = datetime(2026, 5, 20, 1, tzinfo=UTC)
+    run.result = {"stage": "fetch"}
+    monkeypatch.setattr(data_health, "_latest_job_run", lambda *_args: _async_value(run))
+
+    result = await data_health.resolve_connectors(_context(db_session=_Session([config])))
+
+    assert len(result) == 1
+    assert result[0].provider == "github"
+    assert result[0].scope == "acme/app"
+    assert result[0].rows_ingested == 42
+    assert result[0].last_failure is not None
+    assert result[0].last_failure.message == "rate limited"
+    assert result[0].last_failure.stage == "fetch"
+
+
+async def test_identity_mapping_surfaces_unmapped_and_alias_suggestions(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fake_query_dicts(_context: GraphQLContext, _sql: str, _params: dict[str, Any]):
+        return [
+            {
+                "provider": "git",
+                "identity": "sam@example.com",
+                "display_name": "Sam",
+                "observed_count": 7,
+            },
+            {
+                "provider": "git",
+                "identity": "alex@example.com",
+                "display_name": "Alex",
+                "observed_count": 3,
+            },
+        ]
+
+    mapped = [
+        IdentityMapping(
+            canonical_id="sam@corp.test",
+            org_id="org-1",
+            email="sam@corp.test",
+            provider_identities={"git": ["sam@corp.test"]},
+            team_ids=["team-a"],
+        )
+    ]
+
+    monkeypatch.setattr(data_health, "_query_dicts", fake_query_dicts)
+    monkeypatch.setattr(data_health, "_mapped_identities", lambda *_args, **_kw: _async_value(mapped))
+
+    result = await data_health.resolve_identity_mapping(_context(), "team-a")
+
+    assert result.unmapped_count == 2
+    assert [item.email for item in result.unmapped_identities] == [
+        "sam@example.com",
+        "alex@example.com",
+    ]
+    assert result.suggested_aliases[0].suggested_canonical_id == "sam@corp.test"
+
+
+async def test_mapping_coverage_reports_missing_repositories(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fake_coverage_rows(_context: GraphQLContext, *, org_id: str, team: str):
+        assert org_id == "org-1"
+        assert team == "team-a"
+        return (
+            [
+                {"repo_name": "api", "total": 2, "covered": 2},
+                {"repo_name": "web", "total": 1, "covered": 0},
+            ],
+            [{"repo_name": "api", "total": 4, "covered": 4}],
+        )
+
+    monkeypatch.setattr(data_health, "_coverage_rows", fake_coverage_rows)
+
+    result = await data_health.resolve_mapping_coverage(_context(), "team-a")
+
+    assert result.deployments.total_repos == 2
+    assert result.deployments.covered_repos == 1
+    assert result.deployments.coverage_pct == 50.0
+    assert result.deployments.missing[0].repo_name == "web"
+    assert result.work_items.coverage_pct == 100.0
+
+
+async def test_metric_lineage_uses_registry_and_argmax(monkeypatch: pytest.MonkeyPatch):
+    captured_sql: list[str] = []
+
+    async def fake_query_dicts(_client: Any, sql: str, params: dict[str, Any]):
+        captured_sql.append(sql)
+        assert params["org_id"] == "org-1"
+        return [{"computed_at": datetime(2026, 5, 20, 2, tzinfo=UTC), "row_count": 9}]
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", fake_query_dicts)
+
+    result = await data_health.resolve_metric_lineage(_context(), "team-a", "throughput")
+
+    assert result is not None
+    assert result.metric_id == "throughput"
+    assert result.source_tables == ["work_item_metrics_daily"]
+    assert result.compute_window.kind == "daily"
+    assert result.row_count == 9
+    assert "argMax(computed_at, computed_at)" in captured_sql[0]
+
+
+async def _async_value(value: Any) -> Any:
+    return value

--- a/tests/api/graphql/test_data_health.py
+++ b/tests/api/graphql/test_data_health.py
@@ -68,9 +68,13 @@ async def test_connectors_reads_existing_sync_history(monkeypatch: pytest.Monkey
     run = JobRun(job_id=UUID("00000000-0000-0000-0000-000000000001"))
     run.completed_at = datetime(2026, 5, 20, 1, tzinfo=UTC)
     run.result = {"stage": "fetch"}
-    monkeypatch.setattr(data_health, "_latest_job_run", lambda *_args: _async_value(run))
+    monkeypatch.setattr(
+        data_health, "_latest_job_run", lambda *_args: _async_value(run)
+    )
 
-    result = await data_health.resolve_connectors(_context(db_session=_Session([config])))
+    result = await data_health.resolve_connectors(
+        _context(db_session=_Session([config]))
+    )
 
     assert len(result) == 1
     assert result[0].provider == "github"
@@ -84,7 +88,9 @@ async def test_connectors_reads_existing_sync_history(monkeypatch: pytest.Monkey
 async def test_identity_mapping_surfaces_unmapped_and_alias_suggestions(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    async def fake_query_dicts(_context: GraphQLContext, _sql: str, _params: dict[str, Any]):
+    async def fake_query_dicts(
+        _context: GraphQLContext, _sql: str, _params: dict[str, Any]
+    ):
         return [
             {
                 "provider": "git",
@@ -111,7 +117,9 @@ async def test_identity_mapping_surfaces_unmapped_and_alias_suggestions(
     ]
 
     monkeypatch.setattr(data_health, "_query_dicts", fake_query_dicts)
-    monkeypatch.setattr(data_health, "_mapped_identities", lambda *_args, **_kw: _async_value(mapped))
+    monkeypatch.setattr(
+        data_health, "_mapped_identities", lambda *_args, **_kw: _async_value(mapped)
+    )
 
     result = await data_health.resolve_identity_mapping(_context(), "team-a")
 
@@ -156,9 +164,13 @@ async def test_metric_lineage_uses_registry_and_argmax(monkeypatch: pytest.Monke
         assert params["org_id"] == "org-1"
         return [{"computed_at": datetime(2026, 5, 20, 2, tzinfo=UTC), "row_count": 9}]
 
-    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", fake_query_dicts)
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
 
-    result = await data_health.resolve_metric_lineage(_context(), "team-a", "throughput")
+    result = await data_health.resolve_metric_lineage(
+        _context(), "team-a", "throughput"
+    )
 
     assert result is not None
     assert result.metric_id == "throughput"


### PR DESCRIPTION
## Summary

Backend half of [CHAOS-1630](https://linear.app/fullchaos/issue/CHAOS-1630) — exposes a single `dataHealth(team: ID!)` GraphQL field aggregating connector freshness, identity-mapping gaps, deployment/work-item mapping coverage, and metric lineage. Operator-only, read-only.

## Scope

- `api/graphql/models/data_health.py` — Strawberry types: `DataHealth`, `ConnectorStatus`, `ConnectorFailure`, `IdentityMappingHealth`, `UnmappedIdentity`, `AliasSuggestion`, `MappingCoverage`, `CoverageStat`, `MissingMapping`, `MetricLineage`, `WindowSpec`
- `api/graphql/resolvers/data_health.py` — four sub-resolvers reading existing state only; in-code `# TODO` markers where sync-history instrumentation is missing (no inventing of schema, per the plan)
- Wired into `api/graphql/schema.py`
- Tests: `tests/api/graphql/test_data_health.py` (4/4 passing)

## Companion PR

Frontend `/data-health` route lives in the dev-health-web companion PR on `feat/chaos-1630-data-health-ui`. Both must land together.

## Verification

\`\`\`
uv run pytest tests/api/graphql/test_data_health.py -v   # 4 passed
uv run ruff check src/dev_health_ops/api/graphql/resolvers/data_health.py \
                  src/dev_health_ops/api/graphql/models/data_health.py   # clean
\`\`\`

SCREENSHOT-WAIVER: purely backend change, no rendered UI.

Refs CHAOS-1631 CHAOS-1632 CHAOS-1633 CHAOS-1634