### PR TITLE
feat(ops): expose busFactor GraphQL field (CHAOS-1736)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/bus_factor.py
+++ b/src/dev_health_ops/api/graphql/resolvers/bus_factor.py
@@ -1,0 +1,201 @@
+"""Bus Factor GraphQL resolver."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections import defaultdict
+from typing import Any, cast
+
+from dev_health_ops.api.queries.client import query_dicts
+from dev_health_ops.metrics.knowledge import compute_bus_factor
+from dev_health_ops.metrics.query_builder import OrgScopedQuery
+from dev_health_ops.metrics.schemas import CommitStatRow
+
+from ..authz import require_org_id
+from ..context import GraphQLContext
+from ..types.bus_factor import (
+    BusFactorMaintainer,
+    BusFactorRepoResult,
+    BusFactorResult,
+    BusFactorScopeInput,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _require_client(context: GraphQLContext) -> Any:
+    if context.client is None:
+        raise RuntimeError("Database client not available for Bus Factor resolver")
+    return context.client
+
+
+def _parse_repo_id(value: str | None) -> uuid.UUID | None:
+    if not value:
+        return None
+    try:
+        return uuid.UUID(value)
+    except (TypeError, ValueError) as exc:
+        logger.debug("Invalid repoId %r in Bus Factor scope: %s", value, exc)
+        return None
+
+
+def _author_identity(row: CommitStatRow) -> str:
+    return row.get("author_email") or row.get("author_name") or "unknown"
+
+
+def _churn(row: CommitStatRow) -> int:
+    return (row.get("additions") or 0) + (row.get("deletions") or 0)
+
+
+def _top_maintainers(
+    rows: list[CommitStatRow], *, limit: int
+) -> list[BusFactorMaintainer]:
+    author_churn: dict[str, int] = defaultdict(int)
+    total_churn = 0
+    for row in rows:
+        churn = _churn(row)
+        if churn <= 0:
+            continue
+        author_churn[_author_identity(row)] += churn
+        total_churn += churn
+
+    if total_churn == 0:
+        return []
+
+    return [
+        BusFactorMaintainer(author=author, share_percent=(churn / total_churn) * 100.0)
+        for author, churn in sorted(
+            author_churn.items(), key=lambda item: item[1], reverse=True
+        )[:limit]
+    ]
+
+
+def _scope_rows(rows: list[CommitStatRow], scope_id: uuid.UUID) -> list[CommitStatRow]:
+    return [cast(CommitStatRow, {**row, "repo_id": scope_id}) for row in rows]
+
+
+def _bus_factor(repo_id: uuid.UUID, rows: list[CommitStatRow]) -> int:
+    return compute_bus_factor(str(repo_id), rows, threshold_percent=0.8)
+
+
+async def _load_commit_ownership_stats(
+    client: Any,
+    *,
+    org_id: str,
+    repo_id: uuid.UUID | None,
+) -> tuple[list[CommitStatRow], dict[uuid.UUID, str]]:
+    scope = OrgScopedQuery(org_id)
+    params: dict[str, Any] = {}
+    filters: list[str] = []
+    if repo_id is not None:
+        params["repo_id"] = str(repo_id)
+        filters.append("gc.repo_id = {repo_id:UUID}")
+
+    params = scope.inject(params)
+    where_clause = f"AND {' AND '.join(filters)}" if filters else ""
+
+    rows = await query_dicts(
+        client,
+        f"""
+        SELECT
+            gc.repo_id AS repo_id,
+            coalesce(r.repo, toString(gc.repo_id)) AS repo_name,
+            gcs.commit_hash AS commit_hash,
+            gc.author_email AS author_email,
+            gc.author_name AS author_name,
+            gc.committer_when AS committer_when,
+            gcs.file_path AS file_path,
+            gcs.additions AS additions,
+            gcs.deletions AS deletions,
+            gcs.old_file_mode AS old_file_mode,
+            gcs.new_file_mode AS new_file_mode
+        FROM git_commit_stats AS gcs
+        INNER JOIN git_commits AS gc
+            ON gc.repo_id = gcs.repo_id
+           AND gc.hash = gcs.commit_hash
+           AND gc.org_id = gcs.org_id
+        LEFT JOIN repos AS r
+            ON r.id = gc.repo_id
+           AND r.org_id = gc.org_id
+        WHERE 1 = 1
+          {scope.filter(alias="gc")}
+          {scope.filter(alias="gcs")}
+          {where_clause}
+        """,
+        params,
+    )
+
+    stats: list[CommitStatRow] = []
+    repo_names: dict[uuid.UUID, str] = {}
+    for row in rows:
+        row_repo_id = row.get("repo_id")
+        if row_repo_id is None:
+            continue
+        parsed_repo_id = uuid.UUID(str(row_repo_id))
+        repo_names[parsed_repo_id] = str(row.get("repo_name") or parsed_repo_id)
+        stats.append(
+            {
+                "repo_id": parsed_repo_id,
+                "commit_hash": str(row.get("commit_hash") or ""),
+                "author_email": row.get("author_email"),
+                "author_name": row.get("author_name"),
+                "committer_when": row["committer_when"],
+                "file_path": row.get("file_path"),
+                "additions": int(row.get("additions") or 0),
+                "deletions": int(row.get("deletions") or 0),
+                "old_file_mode": row.get("old_file_mode"),
+                "new_file_mode": row.get("new_file_mode"),
+            }
+        )
+
+    return stats, repo_names
+
+
+async def resolve_bus_factor(
+    context: GraphQLContext,
+    org_id: str,
+    scope: BusFactorScopeInput | None = None,
+) -> BusFactorResult:
+    """Resolve Bus Factor for an organization or a single repository."""
+
+    authorized_org_id = require_org_id(context)
+    if org_id != authorized_org_id:
+        logger.debug(
+            "Ignoring GraphQL orgId %r in favor of authorized org %r",
+            org_id,
+            authorized_org_id,
+        )
+
+    repo_id = _parse_repo_id(scope.repo_id if scope else None)
+    stats, repo_names = await _load_commit_ownership_stats(
+        _require_client(context), org_id=authorized_org_id, repo_id=repo_id
+    )
+
+    by_repo: dict[uuid.UUID, list[CommitStatRow]] = defaultdict(list)
+    for row in stats:
+        by_repo[row["repo_id"]].append(row)
+
+    per_repo = [
+        BusFactorRepoResult(
+            repo_id=str(current_repo_id),
+            repo_name=repo_names.get(current_repo_id, str(current_repo_id)),
+            value=_bus_factor(current_repo_id, repo_rows),
+            top_maintainers=_top_maintainers(repo_rows, limit=5),
+            evidence_sample_count=len(repo_rows),
+        )
+        for current_repo_id, repo_rows in by_repo.items()
+    ]
+    per_repo.sort(key=lambda item: (item.value, item.repo_name))
+
+    scope_repo_id = repo_id or uuid.uuid5(
+        uuid.NAMESPACE_URL, f"dev-health:bus-factor:{authorized_org_id}:all"
+    )
+    scoped_rows = stats if repo_id else _scope_rows(stats, scope_repo_id)
+
+    return BusFactorResult(
+        scope_value=_bus_factor(scope_repo_id, scoped_rows),
+        top_maintainers=_top_maintainers(stats, limit=5),
+        per_repo=per_repo,
+        evidence_sample_count=len(stats),
+    )

--- a/src/dev_health_ops/api/graphql/resolvers/bus_factor.py
+++ b/src/dev_health_ops/api/graphql/resolvers/bus_factor.py
@@ -94,7 +94,9 @@ async def resolve_bus_factor(
 
     repo_id = _parse_repo_id(scope.repo_id if scope else None)
     team_id = scope.team_id if scope else None
-    loader = OwnershipClickHouseLoader(_require_client(context), org_id=authorized_org_id)
+    loader = OwnershipClickHouseLoader(
+        _require_client(context), org_id=authorized_org_id
+    )
     window = await loader.load_commit_ownership_stats(repo_id=repo_id, team_id=team_id)
 
     by_repo: dict[uuid.UUID, list[CommitStatRow]] = defaultdict(list)
@@ -114,13 +116,16 @@ async def resolve_bus_factor(
     repos.sort(key=lambda item: (item.value, item.repo_name))
 
     scope_repo_id = repo_id or uuid.uuid5(
-        uuid.NAMESPACE_URL, f"dev-health:bus-factor:{authorized_org_id}:{team_id or 'all'}"
+        uuid.NAMESPACE_URL,
+        f"dev-health:bus-factor:{authorized_org_id}:{team_id or 'all'}",
     )
     scoped_rows = window.stats if repo_id else _scope_rows(window.stats, scope_repo_id)
 
     return BusFactor(
         org_id=authorized_org_id,
-        scope=BusFactorScope(repo_id=str(repo_id) if repo_id else None, team_id=team_id),
+        scope=BusFactorScope(
+            repo_id=str(repo_id) if repo_id else None, team_id=team_id
+        ),
         value=_bus_factor(scope_repo_id, scoped_rows),
         top_maintainers=_top_maintainers(window.stats, limit=5),
         repos=repos,

--- a/src/dev_health_ops/api/graphql/resolvers/bus_factor.py
+++ b/src/dev_health_ops/api/graphql/resolvers/bus_factor.py
@@ -7,18 +7,18 @@ import uuid
 from collections import defaultdict
 from typing import Any, cast
 
-from dev_health_ops.api.queries.client import query_dicts
 from dev_health_ops.metrics.knowledge import compute_bus_factor
-from dev_health_ops.metrics.query_builder import OrgScopedQuery
+from dev_health_ops.metrics.loaders.ownership import OwnershipClickHouseLoader
 from dev_health_ops.metrics.schemas import CommitStatRow
 
 from ..authz import require_org_id
 from ..context import GraphQLContext
 from ..types.bus_factor import (
-    BusFactorMaintainer,
-    BusFactorRepoResult,
-    BusFactorResult,
+    BusFactor,
+    BusFactorScope,
     BusFactorScopeInput,
+    MaintainerShare,
+    RepoBusFactor,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,9 +48,7 @@ def _churn(row: CommitStatRow) -> int:
     return (row.get("additions") or 0) + (row.get("deletions") or 0)
 
 
-def _top_maintainers(
-    rows: list[CommitStatRow], *, limit: int
-) -> list[BusFactorMaintainer]:
+def _top_maintainers(rows: list[CommitStatRow], *, limit: int) -> list[MaintainerShare]:
     author_churn: dict[str, int] = defaultdict(int)
     total_churn = 0
     for row in rows:
@@ -64,7 +62,7 @@ def _top_maintainers(
         return []
 
     return [
-        BusFactorMaintainer(author=author, share_percent=(churn / total_churn) * 100.0)
+        MaintainerShare(author=author, share_percent=(churn / total_churn) * 100.0)
         for author, churn in sorted(
             author_churn.items(), key=lambda item: item[1], reverse=True
         )[:limit]
@@ -79,85 +77,12 @@ def _bus_factor(repo_id: uuid.UUID, rows: list[CommitStatRow]) -> int:
     return compute_bus_factor(str(repo_id), rows, threshold_percent=0.8)
 
 
-async def _load_commit_ownership_stats(
-    client: Any,
-    *,
-    org_id: str,
-    repo_id: uuid.UUID | None,
-) -> tuple[list[CommitStatRow], dict[uuid.UUID, str]]:
-    scope = OrgScopedQuery(org_id)
-    params: dict[str, Any] = {}
-    filters: list[str] = []
-    if repo_id is not None:
-        params["repo_id"] = str(repo_id)
-        filters.append("gc.repo_id = {repo_id:UUID}")
-
-    params = scope.inject(params)
-    where_clause = f"AND {' AND '.join(filters)}" if filters else ""
-
-    rows = await query_dicts(
-        client,
-        f"""
-        SELECT
-            gc.repo_id AS repo_id,
-            coalesce(r.repo, toString(gc.repo_id)) AS repo_name,
-            gcs.commit_hash AS commit_hash,
-            gc.author_email AS author_email,
-            gc.author_name AS author_name,
-            gc.committer_when AS committer_when,
-            gcs.file_path AS file_path,
-            gcs.additions AS additions,
-            gcs.deletions AS deletions,
-            gcs.old_file_mode AS old_file_mode,
-            gcs.new_file_mode AS new_file_mode
-        FROM git_commit_stats AS gcs
-        INNER JOIN git_commits AS gc
-            ON gc.repo_id = gcs.repo_id
-           AND gc.hash = gcs.commit_hash
-           AND gc.org_id = gcs.org_id
-        LEFT JOIN repos AS r
-            ON r.id = gc.repo_id
-           AND r.org_id = gc.org_id
-        WHERE 1 = 1
-          {scope.filter(alias="gc")}
-          {scope.filter(alias="gcs")}
-          {where_clause}
-        """,
-        params,
-    )
-
-    stats: list[CommitStatRow] = []
-    repo_names: dict[uuid.UUID, str] = {}
-    for row in rows:
-        row_repo_id = row.get("repo_id")
-        if row_repo_id is None:
-            continue
-        parsed_repo_id = uuid.UUID(str(row_repo_id))
-        repo_names[parsed_repo_id] = str(row.get("repo_name") or parsed_repo_id)
-        stats.append(
-            {
-                "repo_id": parsed_repo_id,
-                "commit_hash": str(row.get("commit_hash") or ""),
-                "author_email": row.get("author_email"),
-                "author_name": row.get("author_name"),
-                "committer_when": row["committer_when"],
-                "file_path": row.get("file_path"),
-                "additions": int(row.get("additions") or 0),
-                "deletions": int(row.get("deletions") or 0),
-                "old_file_mode": row.get("old_file_mode"),
-                "new_file_mode": row.get("new_file_mode"),
-            }
-        )
-
-    return stats, repo_names
-
-
 async def resolve_bus_factor(
     context: GraphQLContext,
     org_id: str,
     scope: BusFactorScopeInput | None = None,
-) -> BusFactorResult:
-    """Resolve Bus Factor for an organization or a single repository."""
+) -> BusFactor:
+    """Resolve Bus Factor for an organization, team, or repository scope."""
 
     authorized_org_id = require_org_id(context)
     if org_id != authorized_org_id:
@@ -168,34 +93,36 @@ async def resolve_bus_factor(
         )
 
     repo_id = _parse_repo_id(scope.repo_id if scope else None)
-    stats, repo_names = await _load_commit_ownership_stats(
-        _require_client(context), org_id=authorized_org_id, repo_id=repo_id
-    )
+    team_id = scope.team_id if scope else None
+    loader = OwnershipClickHouseLoader(_require_client(context), org_id=authorized_org_id)
+    window = await loader.load_commit_ownership_stats(repo_id=repo_id, team_id=team_id)
 
     by_repo: dict[uuid.UUID, list[CommitStatRow]] = defaultdict(list)
-    for row in stats:
+    for row in window.stats:
         by_repo[row["repo_id"]].append(row)
 
-    per_repo = [
-        BusFactorRepoResult(
+    repos = [
+        RepoBusFactor(
             repo_id=str(current_repo_id),
-            repo_name=repo_names.get(current_repo_id, str(current_repo_id)),
+            repo_name=window.repo_names.get(current_repo_id, str(current_repo_id)),
             value=_bus_factor(current_repo_id, repo_rows),
-            top_maintainers=_top_maintainers(repo_rows, limit=5),
+            top_maintainers=_top_maintainers(repo_rows, limit=3),
             evidence_sample_count=len(repo_rows),
         )
         for current_repo_id, repo_rows in by_repo.items()
     ]
-    per_repo.sort(key=lambda item: (item.value, item.repo_name))
+    repos.sort(key=lambda item: (item.value, item.repo_name))
 
     scope_repo_id = repo_id or uuid.uuid5(
-        uuid.NAMESPACE_URL, f"dev-health:bus-factor:{authorized_org_id}:all"
+        uuid.NAMESPACE_URL, f"dev-health:bus-factor:{authorized_org_id}:{team_id or 'all'}"
     )
-    scoped_rows = stats if repo_id else _scope_rows(stats, scope_repo_id)
+    scoped_rows = window.stats if repo_id else _scope_rows(window.stats, scope_repo_id)
 
-    return BusFactorResult(
-        scope_value=_bus_factor(scope_repo_id, scoped_rows),
-        top_maintainers=_top_maintainers(stats, limit=5),
-        per_repo=per_repo,
-        evidence_sample_count=len(stats),
+    return BusFactor(
+        org_id=authorized_org_id,
+        scope=BusFactorScope(repo_id=str(repo_id) if repo_id else None, team_id=team_id),
+        value=_bus_factor(scope_repo_id, scoped_rows),
+        top_maintainers=_top_maintainers(window.stats, limit=5),
+        repos=repos,
+        evidence_sample_count=len(window.stats),
     )

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -46,6 +46,7 @@ from .models.outputs import (
     ThroughputForecast,
     WorkGraphEdgesResult,
 )
+from .types.bus_factor import BusFactorResult, BusFactorScopeInput
 from .models.recommendations import (
     Recommendation,
     WindowInput,
@@ -62,6 +63,7 @@ from .resolvers.ai import (
 from .resolvers.analytics import resolve_analytics
 from .resolvers.catalog import resolve_catalog
 from .resolvers.data_health import resolve_data_health
+from .resolvers.bus_factor import resolve_bus_factor
 from .resolvers.reports import (
     CloneSavedReportInput,
     CreateSavedReportInput,
@@ -303,6 +305,18 @@ class Query:
     ) -> DataHealth:
         context = get_context(info)
         return await resolve_data_health(context, str(team))
+
+    @strawberry.field(
+        description="Repository ownership concentration and bus-factor summary."
+    )
+    async def bus_factor(
+        self,
+        info: Info,
+        org_id: str,
+        scope: BusFactorScopeInput | None = None,
+    ) -> BusFactorResult:
+        context = get_context(info)
+        return await resolve_bus_factor(context, org_id, scope)
 
     @strawberry.field(
         description="Latest rule-based recommendations for a team within a lookback window."

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -46,7 +46,6 @@ from .models.outputs import (
     ThroughputForecast,
     WorkGraphEdgesResult,
 )
-from .types.bus_factor import BusFactorResult, BusFactorScopeInput
 from .models.recommendations import (
     Recommendation,
     WindowInput,
@@ -61,9 +60,9 @@ from .resolvers.ai import (
     resolve_ai_workflow_drilldown,
 )
 from .resolvers.analytics import resolve_analytics
+from .resolvers.bus_factor import resolve_bus_factor
 from .resolvers.catalog import resolve_catalog
 from .resolvers.data_health import resolve_data_health
-from .resolvers.bus_factor import resolve_bus_factor
 from .resolvers.reports import (
     CloneSavedReportInput,
     CreateSavedReportInput,
@@ -82,6 +81,7 @@ from .resolvers.reports import (
     resolve_update_saved_report,
 )
 from .subscriptions import Subscription
+from .types.bus_factor import BusFactor, BusFactorScopeInput
 
 logger = logging.getLogger(__name__)
 
@@ -314,7 +314,7 @@ class Query:
         info: Info,
         org_id: str,
         scope: BusFactorScopeInput | None = None,
-    ) -> BusFactorResult:
+    ) -> BusFactor:
         context = get_context(info)
         return await resolve_bus_factor(context, org_id, scope)
 

--- a/src/dev_health_ops/api/graphql/types/bus_factor.py
+++ b/src/dev_health_ops/api/graphql/types/bus_factor.py
@@ -6,7 +6,7 @@ import strawberry
 
 
 @strawberry.type
-class BusFactorMaintainer:
+class MaintainerShare:
     """A maintainer share within Bus Factor evidence."""
 
     author: str
@@ -14,23 +14,33 @@ class BusFactorMaintainer:
 
 
 @strawberry.type
-class BusFactorRepoResult:
+class RepoBusFactor:
     """Repository-level Bus Factor result."""
 
     repo_id: str = strawberry.field(name="repoId")
     repo_name: str = strawberry.field(name="repoName")
     value: int
-    top_maintainers: list[BusFactorMaintainer] = strawberry.field(name="topMaintainers")
+    top_maintainers: list[MaintainerShare] = strawberry.field(name="topMaintainers")
     evidence_sample_count: int = strawberry.field(name="evidenceSampleCount")
 
 
 @strawberry.type
-class BusFactorResult:
+class BusFactorScope:
+    """Requested Bus Factor scope."""
+
+    repo_id: str | None = strawberry.field(default=None, name="repoId")
+    team_id: str | None = strawberry.field(default=None, name="teamId")
+
+
+@strawberry.type
+class BusFactor:
     """Scope-level Bus Factor result."""
 
-    scope_value: int = strawberry.field(name="scopeValue")
-    top_maintainers: list[BusFactorMaintainer] = strawberry.field(name="topMaintainers")
-    per_repo: list[BusFactorRepoResult] = strawberry.field(name="perRepo")
+    org_id: str = strawberry.field(name="orgId")
+    scope: BusFactorScope
+    value: int
+    top_maintainers: list[MaintainerShare] = strawberry.field(name="topMaintainers")
+    repos: list[RepoBusFactor]
     evidence_sample_count: int = strawberry.field(name="evidenceSampleCount")
 
 
@@ -39,3 +49,4 @@ class BusFactorScopeInput:
     """Optional Bus Factor scope filters."""
 
     repo_id: str | None = strawberry.field(default=None, name="repoId")
+    team_id: str | None = strawberry.field(default=None, name="teamId")

--- a/src/dev_health_ops/api/graphql/types/bus_factor.py
+++ b/src/dev_health_ops/api/graphql/types/bus_factor.py
@@ -1,0 +1,41 @@
+"""GraphQL types for Bus Factor analytics."""
+
+from __future__ import annotations
+
+import strawberry
+
+
+@strawberry.type
+class BusFactorMaintainer:
+    """A maintainer share within Bus Factor evidence."""
+
+    author: str
+    share_percent: float = strawberry.field(name="sharePercent")
+
+
+@strawberry.type
+class BusFactorRepoResult:
+    """Repository-level Bus Factor result."""
+
+    repo_id: str = strawberry.field(name="repoId")
+    repo_name: str = strawberry.field(name="repoName")
+    value: int
+    top_maintainers: list[BusFactorMaintainer] = strawberry.field(name="topMaintainers")
+    evidence_sample_count: int = strawberry.field(name="evidenceSampleCount")
+
+
+@strawberry.type
+class BusFactorResult:
+    """Scope-level Bus Factor result."""
+
+    scope_value: int = strawberry.field(name="scopeValue")
+    top_maintainers: list[BusFactorMaintainer] = strawberry.field(name="topMaintainers")
+    per_repo: list[BusFactorRepoResult] = strawberry.field(name="perRepo")
+    evidence_sample_count: int = strawberry.field(name="evidenceSampleCount")
+
+
+@strawberry.input
+class BusFactorScopeInput:
+    """Optional Bus Factor scope filters."""
+
+    repo_id: str | None = strawberry.field(default=None, name="repoId")

--- a/src/dev_health_ops/metrics/loaders/ownership.py
+++ b/src/dev_health_ops/metrics/loaders/ownership.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from dev_health_ops.api.queries.client import query_dicts
+from dev_health_ops.metrics.query_builder import OrgScopedQuery
+from dev_health_ops.metrics.schemas import CommitStatRow
+
+
+@dataclass(frozen=True)
+class OwnershipWindow:
+    stats: list[CommitStatRow]
+    repo_names: dict[uuid.UUID, str]
+
+
+class OwnershipClickHouseLoader:
+    def __init__(self, client: Any, org_id: str = "") -> None:
+        self.client = client
+        self.org_id = org_id
+        self._scope = OrgScopedQuery(org_id)
+
+    async def _repo_ids_for_team(self, team_id: str) -> list[str]:
+        params = self._scope.inject({"team_id": team_id})
+        rows = await query_dicts(
+            self.client,
+            f"""
+            SELECT DISTINCT repo_id AS repo_id
+            FROM user_metrics_daily
+            WHERE team_id = {{team_id:String}}
+              {self._scope.filter()}
+            """,
+            params,
+        )
+        return [str(row["repo_id"]) for row in rows if row.get("repo_id")]
+
+    async def load_commit_ownership_stats(
+        self,
+        *,
+        repo_id: uuid.UUID | None = None,
+        team_id: str | None = None,
+    ) -> OwnershipWindow:
+        params: dict[str, Any] = {}
+        filters: list[str] = []
+
+        repo_ids: list[str] | None = None
+        if team_id:
+            repo_ids = await self._repo_ids_for_team(team_id)
+            if repo_id is not None:
+                repo_ids = [str(repo_id)] if str(repo_id) in set(repo_ids) else []
+            if not repo_ids:
+                return OwnershipWindow(stats=[], repo_names={})
+
+        if repo_ids is not None:
+            params["repo_ids"] = repo_ids
+            filters.append("gc.repo_id IN {repo_ids:Array(UUID)}")
+        elif repo_id is not None:
+            params["repo_id"] = str(repo_id)
+            filters.append("gc.repo_id = {repo_id:UUID}")
+
+        params = self._scope.inject(params)
+        where_clause = ""
+        if filters:
+            where_clause = "AND " + " AND ".join(filters)
+
+        rows = await query_dicts(
+            self.client,
+            f"""
+            SELECT
+                gc.repo_id AS repo_id,
+                coalesce(r.repo, toString(gc.repo_id)) AS repo_name,
+                gcs.commit_hash AS commit_hash,
+                gc.author_email AS author_email,
+                gc.author_name AS author_name,
+                gc.committer_when AS committer_when,
+                gcs.file_path AS file_path,
+                gcs.additions AS additions,
+                gcs.deletions AS deletions,
+                gcs.old_file_mode AS old_file_mode,
+                gcs.new_file_mode AS new_file_mode
+            FROM git_commit_stats AS gcs
+            INNER JOIN git_commits AS gc
+                ON gc.repo_id = gcs.repo_id
+               AND gc.hash = gcs.commit_hash
+               AND gc.org_id = gcs.org_id
+            LEFT JOIN repos AS r
+                ON r.id = gc.repo_id
+               AND r.org_id = gc.org_id
+            WHERE 1 = 1
+              {self._scope.filter(alias="gc")}
+              {self._scope.filter(alias="gcs")}
+              {where_clause}
+            """,
+            params,
+        )
+
+        stats: list[CommitStatRow] = []
+        repo_names: dict[uuid.UUID, str] = {}
+        for row in rows:
+            row_repo_id = row.get("repo_id")
+            if row_repo_id is None:
+                continue
+            parsed_repo_id = uuid.UUID(str(row_repo_id))
+            repo_names[parsed_repo_id] = str(row.get("repo_name") or parsed_repo_id)
+            stats.append(
+                {
+                    "repo_id": parsed_repo_id,
+                    "commit_hash": str(row.get("commit_hash") or ""),
+                    "author_email": row.get("author_email"),
+                    "author_name": row.get("author_name"),
+                    "committer_when": row["committer_when"],
+                    "file_path": row.get("file_path"),
+                    "additions": int(row.get("additions") or 0),
+                    "deletions": int(row.get("deletions") or 0),
+                    "old_file_mode": row.get("old_file_mode"),
+                    "new_file_mode": row.get("new_file_mode"),
+                }
+            )
+
+        return OwnershipWindow(stats=stats, repo_names=repo_names)

--- a/tests/api/graphql/test_bus_factor.py
+++ b/tests/api/graphql/test_bus_factor.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.resolvers.bus_factor import resolve_bus_factor
+from dev_health_ops.api.graphql.types.bus_factor import BusFactorScopeInput
+from dev_health_ops.metrics.schemas import CommitStatRow
+
+ORG_ID = "org-test"
+REPO_A = UUID("11111111-1111-1111-1111-111111111111")
+REPO_B = UUID("22222222-2222-2222-2222-222222222222")
+NOW = datetime(2026, 5, 20, 12, tzinfo=timezone.utc)
+
+
+def _ctx() -> GraphQLContext:
+    ctx = GraphQLContext(org_id=ORG_ID, db_url="clickhouse://localhost:8123/default")
+    ctx.client = MagicMock()
+    return ctx
+
+
+def _row(repo_id: UUID, commit_hash: str, author: str, churn: int) -> CommitStatRow:
+    return {
+        "repo_id": repo_id,
+        "commit_hash": commit_hash,
+        "author_email": author,
+        "author_name": author.split("@")[0],
+        "committer_when": NOW,
+        "file_path": f"src/{commit_hash}.py",
+        "additions": churn,
+        "deletions": 0,
+        "old_file_mode": None,
+        "new_file_mode": None,
+    }
+
+
+def _db_row(row: CommitStatRow, repo_name: str) -> dict[str, Any]:
+    return {**row, "repo_name": repo_name}
+
+
+def _patch_query(rows: list[dict[str, Any]]) -> Any:
+    return patch(
+        "dev_health_ops.api.graphql.resolvers.bus_factor.query_dicts",
+        new_callable=AsyncMock,
+        return_value=rows,
+    )
+
+
+@pytest.mark.asyncio
+async def test_bus_factor_empty_state_returns_stable_contract():
+    with _patch_query([]):
+        result = await resolve_bus_factor(_ctx(), ORG_ID)
+
+    assert result.scope_value == 0
+    assert result.evidence_sample_count == 0
+    assert result.top_maintainers == []
+    assert result.per_repo == []
+
+
+@pytest.mark.asyncio
+async def test_bus_factor_populates_scope_and_repo_rollups():
+    rows = [
+        _db_row(_row(REPO_A, "a1", "maintainer-a@example.com", 80), "backend"),
+        _db_row(_row(REPO_A, "a2", "maintainer-b@example.com", 20), "backend"),
+        _db_row(_row(REPO_B, "b1", "maintainer-c@example.com", 90), "frontend"),
+        _db_row(_row(REPO_B, "b2", "maintainer-a@example.com", 10), "frontend"),
+    ]
+
+    with _patch_query(rows):
+        result = await resolve_bus_factor(_ctx(), ORG_ID)
+
+    assert result.scope_value == 2
+    assert result.evidence_sample_count == 4
+    assert [share.author for share in result.top_maintainers[:2]] == [
+        "maintainer-a@example.com",
+        "maintainer-c@example.com",
+    ]
+    assert [repo.repo_name for repo in result.per_repo] == ["backend", "frontend"]
+    assert [repo.value for repo in result.per_repo] == [1, 1]
+    assert result.per_repo[0].top_maintainers[0].author == "maintainer-a@example.com"
+    assert result.per_repo[1].top_maintainers[0].author == "maintainer-c@example.com"
+
+
+@pytest.mark.asyncio
+async def test_bus_factor_passes_repo_scope_to_loader():
+    rows = [_db_row(_row(REPO_A, "a1", "maintainer-a@example.com", 100), "backend")]
+
+    with _patch_query(rows) as query:
+        result = await resolve_bus_factor(
+            _ctx(), ORG_ID, BusFactorScopeInput(repo_id=str(REPO_A))
+        )
+
+    params = query.await_args.args[2]
+    assert params["repo_id"] == str(REPO_A)
+    assert result.scope_value == 1

--- a/tests/api/graphql/test_bus_factor.py
+++ b/tests/api/graphql/test_bus_factor.py
@@ -10,6 +10,7 @@ import pytest
 from dev_health_ops.api.graphql.context import GraphQLContext
 from dev_health_ops.api.graphql.resolvers.bus_factor import resolve_bus_factor
 from dev_health_ops.api.graphql.types.bus_factor import BusFactorScopeInput
+from dev_health_ops.metrics.loaders.ownership import OwnershipWindow
 from dev_health_ops.metrics.schemas import CommitStatRow
 
 ORG_ID = "org-test"
@@ -39,62 +40,67 @@ def _row(repo_id: UUID, commit_hash: str, author: str, churn: int) -> CommitStat
     }
 
 
-def _db_row(row: CommitStatRow, repo_name: str) -> dict[str, Any]:
-    return {**row, "repo_name": repo_name}
-
-
-def _patch_query(rows: list[dict[str, Any]]) -> Any:
+def _patch_loader(window: OwnershipWindow) -> Any:
     return patch(
-        "dev_health_ops.api.graphql.resolvers.bus_factor.query_dicts",
+        "dev_health_ops.metrics.loaders.ownership."
+        "OwnershipClickHouseLoader.load_commit_ownership_stats",
         new_callable=AsyncMock,
-        return_value=rows,
+        return_value=window,
     )
 
 
 @pytest.mark.asyncio
 async def test_bus_factor_empty_state_returns_stable_contract():
-    with _patch_query([]):
+    with _patch_loader(OwnershipWindow(stats=[], repo_names={})):
         result = await resolve_bus_factor(_ctx(), ORG_ID)
 
-    assert result.scope_value == 0
+    assert result.org_id == ORG_ID
+    assert result.value == 0
     assert result.evidence_sample_count == 0
     assert result.top_maintainers == []
-    assert result.per_repo == []
+    assert result.repos == []
 
 
 @pytest.mark.asyncio
 async def test_bus_factor_populates_scope_and_repo_rollups():
-    rows = [
-        _db_row(_row(REPO_A, "a1", "maintainer-a@example.com", 80), "backend"),
-        _db_row(_row(REPO_A, "a2", "maintainer-b@example.com", 20), "backend"),
-        _db_row(_row(REPO_B, "b1", "maintainer-c@example.com", 90), "frontend"),
-        _db_row(_row(REPO_B, "b2", "maintainer-a@example.com", 10), "frontend"),
-    ]
+    window = OwnershipWindow(
+        stats=[
+            _row(REPO_A, "a1", "maintainer-a@example.com", 80),
+            _row(REPO_A, "a2", "maintainer-b@example.com", 20),
+            _row(REPO_B, "b1", "maintainer-c@example.com", 90),
+            _row(REPO_B, "b2", "maintainer-a@example.com", 10),
+        ],
+        repo_names={REPO_A: "backend", REPO_B: "frontend"},
+    )
 
-    with _patch_query(rows):
+    with _patch_loader(window):
         result = await resolve_bus_factor(_ctx(), ORG_ID)
 
-    assert result.scope_value == 2
+    assert result.value == 2
     assert result.evidence_sample_count == 4
     assert [share.author for share in result.top_maintainers[:2]] == [
         "maintainer-a@example.com",
         "maintainer-c@example.com",
     ]
-    assert [repo.repo_name for repo in result.per_repo] == ["backend", "frontend"]
-    assert [repo.value for repo in result.per_repo] == [1, 1]
-    assert result.per_repo[0].top_maintainers[0].author == "maintainer-a@example.com"
-    assert result.per_repo[1].top_maintainers[0].author == "maintainer-c@example.com"
+    assert [repo.repo_name for repo in result.repos] == ["backend", "frontend"]
+    assert [repo.value for repo in result.repos] == [1, 1]
+    assert result.repos[0].top_maintainers[0].author == "maintainer-a@example.com"
+    assert result.repos[1].top_maintainers[0].author == "maintainer-c@example.com"
 
 
 @pytest.mark.asyncio
-async def test_bus_factor_passes_repo_scope_to_loader():
-    rows = [_db_row(_row(REPO_A, "a1", "maintainer-a@example.com", 100), "backend")]
+async def test_bus_factor_passes_scope_to_loader():
+    window = OwnershipWindow(
+        stats=[_row(REPO_A, "a1", "maintainer-a@example.com", 100)],
+        repo_names={REPO_A: "backend"},
+    )
 
-    with _patch_query(rows) as query:
+    with _patch_loader(window) as loader:
         result = await resolve_bus_factor(
-            _ctx(), ORG_ID, BusFactorScopeInput(repo_id=str(REPO_A))
+            _ctx(), ORG_ID, BusFactorScopeInput(repo_id=str(REPO_A), team_id="team-a")
         )
 
-    params = query.await_args.args[2]
-    assert params["repo_id"] == str(REPO_A)
-    assert result.scope_value == 1
+    loader.assert_awaited_once_with(repo_id=REPO_A, team_id="team-a")
+    assert result.scope.repo_id == str(REPO_A)
+    assert result.scope.team_id == "team-a"
+    assert result.value == 1


### PR DESCRIPTION
## Summary
- Adds busFactor GraphQL field with BusFactor, RepoBusFactor, MaintainerShare, and BusFactorScopeInput schema types.
- Adds ClickHouse ownership loader over git_commits + git_commit_stats and reuses compute_bus_factor(threshold_percent=0.8).
- Returns scope-wide bus factor plus per-repo bus factor and top maintainer share lists.

## Verification
- pytest tests/api/graphql/test_bus_factor.py -v
- ruff check
- mypy src/dev_health_ops/api/graphql/resolvers/bus_factor.py src/dev_health_ops/metrics/loaders/ownership.py src/dev_health_ops/api/graphql/types/bus_factor.py tests/api/graphql/test_bus_factor.py
- Local uvicorn on :8001 (chosen instead of compose mount swap; compose.yml unchanged) + curl /graphql confirmed fixture org busFactor value=10, evidenceSampleCount=5749, 4 repos.

Refs CHAOS-1736, CHAOS-1733