### PR TITLE
feat(ops): expose aiAttributedPrs GraphQL field (CHAOS-1738)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/ai.py
+++ b/src/dev_health_ops/api/graphql/models/ai.py
@@ -369,3 +369,34 @@ class AIWorkflowDrilldownResult:
     edges: list[AIWorkflowGraphEdgeOut]
     partial: bool
     data_available: bool
+
+
+@strawberry.type
+class AiAttributedPr:
+    """A single AI-attributed pull request candidate for drilldown selection.
+
+    Rows are sourced directly from ``ai_attribution_resolved`` joined to
+    ``git_pull_requests``. No aggregation, no fabrication — just the PRs that
+    have an AI attribution signal in the requested window.
+    """
+
+    repo_id: strawberry.ID
+    number: int
+    title: str | None = None
+    kind: str | None = None
+    work_type: str | None = None
+    team_id: str | None = None
+    merged_at: datetime | None = None
+
+
+@strawberry.type
+class AiAttributedPrsResult:
+    """Paginated list of AI-attributed PRs in the requested window."""
+
+    org_id: str
+    start_date: date
+    end_date: date
+    rows: list[AiAttributedPr]
+    total: int
+    has_more: bool
+    data_available: bool

--- a/src/dev_health_ops/api/graphql/resolvers/ai.py
+++ b/src/dev_health_ops/api/graphql/resolvers/ai.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 import logging
 import uuid
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, time, timezone
 from typing import Any
+
+import strawberry
 
 from dev_health_ops.metrics.ai_impact import (
     AI_BUCKETS as AI_ATTRIBUTION_BUCKETS,
@@ -33,6 +35,8 @@ from dev_health_ops.metrics.opportunities.ai_detector import AIOpportunityDetect
 from ..authz import require_org_id
 from ..context import GraphQLContext
 from ..models.ai import (
+    AiAttributedPr,
+    AiAttributedPrsResult,
     AIComparison,
     AIComparisonDelta,
     AIComparisonSide,
@@ -656,4 +660,84 @@ async def resolve_ai_workflow_drilldown(
         edges=edges,
         partial=traversal.partial,
         data_available=bool(edges),
+    )
+
+
+# =============================================================================
+# resolve_ai_attributed_prs
+# =============================================================================
+
+
+_MAX_AI_ATTRIBUTED_PRS_PAGE = 200
+
+
+async def resolve_ai_attributed_prs(
+    context: GraphQLContext,
+    date_range: AIDateRangeInput,
+    scope: AIScopeInput | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> AiAttributedPrsResult:
+    """List AI-attributed pull requests for drilldown selection.
+
+    Reads ``ai_attribution_resolved`` joined to ``git_pull_requests`` and
+    returns the unaggregated PRs that drive the AI Review Load and AI Risk
+    dashboards. The UI passes a chosen ``(repo_id, number)`` to
+    ``aiWorkflowDrilldown`` to retrieve evidence graphs.
+
+    No fabrication: every returned row corresponds to a persisted attribution.
+    """
+
+    org_id = require_org_id(context)
+    _validate_date_range(date_range)
+    repo_id, team_id, work_type = _normalize_scope(scope)
+
+    page_size = max(1, min(int(limit), _MAX_AI_ATTRIBUTED_PRS_PAGE))
+    page_offset = max(0, int(offset))
+
+    start_dt = datetime.combine(date_range.start_date, time.min, tzinfo=timezone.utc)
+    end_dt = datetime.combine(date_range.end_date, time.max, tzinfo=timezone.utc)
+
+    loader = AIImpactClickHouseLoader(_require_client(context), org_id=org_id)
+    # Fetch one extra row so we can report has_more without a COUNT(*) round-trip.
+    raw_rows = await loader.load_ai_pr_attributions(
+        start=start_dt,
+        end=end_dt,
+        repo_id=repo_id,
+        limit=page_size + 1,
+        offset=page_offset,
+    )
+
+    has_more = len(raw_rows) > page_size
+    page_rows = raw_rows[:page_size]
+
+    # team_id / work_type filtering happens here because the loader treats
+    # them as projections, not WHERE-clause inputs. The PR universe is bounded
+    # by date_range + repo_id so in-memory filtering is safe at this scale.
+    if team_id:
+        page_rows = [row for row in page_rows if (row.get("team_id") or "") == team_id]
+    if work_type:
+        page_rows = [row for row in page_rows if (row.get("work_type") or "") == work_type]
+
+    rows = [
+        AiAttributedPr(
+            repo_id=strawberry.ID(str(row["repo_id"])),
+            number=int(row["number"]),
+            title=row.get("title"),
+            kind=row.get("kind"),
+            work_type=row.get("work_type"),
+            team_id=row.get("team_id") or None,
+            merged_at=_to_aware(row["merged_at"]) if row.get("merged_at") else None,
+        )
+        for row in page_rows
+    ]
+
+    return AiAttributedPrsResult(
+        org_id=org_id,
+        start_date=date_range.start_date,
+        end_date=date_range.end_date,
+        rows=rows,
+        total=len(rows),
+        has_more=has_more,
+        data_available=bool(rows),
     )

--- a/src/dev_health_ops/api/graphql/resolvers/ai.py
+++ b/src/dev_health_ops/api/graphql/resolvers/ai.py
@@ -717,7 +717,9 @@ async def resolve_ai_attributed_prs(
     if team_id:
         page_rows = [row for row in page_rows if (row.get("team_id") or "") == team_id]
     if work_type:
-        page_rows = [row for row in page_rows if (row.get("work_type") or "") == work_type]
+        page_rows = [
+            row for row in page_rows if (row.get("work_type") or "") == work_type
+        ]
 
     rows = [
         AiAttributedPr(

--- a/src/dev_health_ops/api/graphql/resolvers/ai.py
+++ b/src/dev_health_ops/api/graphql/resolvers/ai.py
@@ -721,18 +721,20 @@ async def resolve_ai_attributed_prs(
             row for row in page_rows if (row.get("work_type") or "") == work_type
         ]
 
-    rows = [
-        AiAttributedPr(
-            repo_id=strawberry.ID(str(row["repo_id"])),
-            number=int(row["number"]),
-            title=row.get("title"),
-            kind=row.get("kind"),
-            work_type=row.get("work_type"),
-            team_id=row.get("team_id") or None,
-            merged_at=_to_aware(row["merged_at"]) if row.get("merged_at") else None,
+    rows: list[AiAttributedPr] = []
+    for row in page_rows:
+        merged_at_raw = row.get("merged_at")
+        rows.append(
+            AiAttributedPr(
+                repo_id=strawberry.ID(str(row["repo_id"])),
+                number=int(row["number"]),
+                title=row.get("title"),
+                kind=row.get("kind"),
+                work_type=row.get("work_type"),
+                team_id=row.get("team_id") or None,
+                merged_at=_to_aware(merged_at_raw) if merged_at_raw else None,
+            )
         )
-        for row in page_rows
-    ]
 
     return AiAttributedPrsResult(
         org_id=org_id,

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -10,6 +10,7 @@ from strawberry.types import Info
 from .context import GraphQLContext
 from .extensions import ConfiguredValidationRules, OrgIdAuthExtension
 from .models.ai import (
+    AiAttributedPrsResult,
     AIComparison,
     AIDateRangeInput,
     AIGovernanceSummary,
@@ -51,6 +52,7 @@ from .models.recommendations import (
     WindowInput,
 )
 from .resolvers.ai import (
+    resolve_ai_attributed_prs,
     resolve_ai_comparison,
     resolve_ai_governance_summary,
     resolve_ai_impact_summary,
@@ -437,6 +439,28 @@ class Query:
         context = get_context(info)
         return await resolve_ai_workflow_drilldown(
             context, root_type, root_id, depth, limit
+        )
+
+    @strawberry.field(
+        description=(
+            "List AI-attributed pull requests in the requested window so "
+            "the UI can offer a concrete drilldown selector. Rows come "
+            "from ai_attribution_resolved joined to git_pull_requests; "
+            "no aggregation, no fabrication."
+        )
+    )
+    async def ai_attributed_prs(
+        self,
+        info: Info,
+        org_id: str,
+        date_range: AIDateRangeInput,
+        scope: AIScopeInput | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> AiAttributedPrsResult:
+        context = get_context(info)
+        return await resolve_ai_attributed_prs(
+            context, date_range, scope, limit, offset
         )
 
 

--- a/src/dev_health_ops/metrics/loaders/ai_impact.py
+++ b/src/dev_health_ops/metrics/loaders/ai_impact.py
@@ -25,6 +25,8 @@ class AIImpactClickHouseLoader:
         start: datetime,
         end: datetime,
         repo_id: uuid.UUID | None = None,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[AIPullRequestAttributionRow]:
         from dev_health_ops.api.queries.client import query_dicts
 
@@ -39,57 +41,86 @@ class AIImpactClickHouseLoader:
         params = self._scope.inject(params)
         org_filter_attr = self._scope.filter(alias="attr")
         org_filter_pr = self._scope.filter(alias="pr")
+        limit_clause = ""
+        if limit is not None and int(limit) > 0:
+            params["limit"] = int(limit)
+            params["offset"] = max(0, int(offset))
+            limit_clause = "LIMIT {limit:UInt32} OFFSET {offset:UInt32}"
         query = f"""
         SELECT
-            pr.repo_id AS repo_id,
-            pr.number AS number,
-            attr.kind AS kind,
-            coalesce(nullIf(wi.type, ''), 'pull_request') AS work_type,
-            CAST('', 'String') AS team_id
-        FROM git_pull_requests AS pr
-        INNER JOIN work_graph_issue_pr AS link
-            ON link.repo_id = pr.repo_id AND link.pr_number = pr.number
-        INNER JOIN ai_attribution_resolved AS attr
-            ON attr.subject_type = 'pull_request'
-            AND attr.subject_id = link.work_item_id
-        LEFT JOIN work_items AS wi
-            ON wi.repo_id = link.repo_id AND wi.work_item_id = link.work_item_id
-        WHERE ((pr.created_at >= {{start:DateTime}} AND pr.created_at < {{end:DateTime}})
-            OR (pr.merged_at IS NOT NULL AND pr.merged_at >= {{start:DateTime}} AND pr.merged_at < {{end:DateTime}}))
-          {repo_filter}
-          {org_filter_pr}
-          {org_filter_attr}
-        UNION ALL
-        SELECT
-            pr.repo_id AS repo_id,
-            pr.number AS number,
-            attr.kind AS kind,
-            'pull_request' AS work_type,
-            CAST('', 'String') AS team_id
-        FROM git_pull_requests AS pr
-        INNER JOIN ai_attribution_resolved AS attr
-            ON attr.subject_type = 'pull_request'
-            AND attr.repo_id = pr.repo_id
-            AND (attr.subject_id = toString(pr.number) OR attr.subject_id = concat(toString(pr.repo_id), '#', toString(pr.number)))
-        WHERE ((pr.created_at >= {{start:DateTime}} AND pr.created_at < {{end:DateTime}})
-            OR (pr.merged_at IS NOT NULL AND pr.merged_at >= {{start:DateTime}} AND pr.merged_at < {{end:DateTime}}))
-          {repo_filter}
-          {org_filter_pr}
-          {org_filter_attr}
+            repo_id,
+            number,
+            kind,
+            work_type,
+            team_id,
+            title,
+            merged_at
+        FROM (
+            SELECT
+                pr.repo_id AS repo_id,
+                pr.number AS number,
+                attr.kind AS kind,
+                coalesce(nullIf(wi.type, ''), 'pull_request') AS work_type,
+                CAST('', 'String') AS team_id,
+                pr.title AS title,
+                pr.merged_at AS merged_at
+            FROM git_pull_requests AS pr
+            INNER JOIN work_graph_issue_pr AS link
+                ON link.repo_id = pr.repo_id AND link.pr_number = pr.number
+            INNER JOIN ai_attribution_resolved AS attr
+                ON attr.subject_type = 'pull_request'
+                AND attr.subject_id = link.work_item_id
+            LEFT JOIN work_items AS wi
+                ON wi.repo_id = link.repo_id AND wi.work_item_id = link.work_item_id
+            WHERE ((pr.created_at >= {{start:DateTime}} AND pr.created_at < {{end:DateTime}})
+                OR (pr.merged_at IS NOT NULL AND pr.merged_at >= {{start:DateTime}} AND pr.merged_at < {{end:DateTime}}))
+              {repo_filter}
+              {org_filter_pr}
+              {org_filter_attr}
+            UNION ALL
+            SELECT
+                pr.repo_id AS repo_id,
+                pr.number AS number,
+                attr.kind AS kind,
+                'pull_request' AS work_type,
+                CAST('', 'String') AS team_id,
+                pr.title AS title,
+                pr.merged_at AS merged_at
+            FROM git_pull_requests AS pr
+            INNER JOIN ai_attribution_resolved AS attr
+                ON attr.subject_type = 'pull_request'
+                AND attr.repo_id = pr.repo_id
+                AND (attr.subject_id = toString(pr.number) OR attr.subject_id = concat(toString(pr.repo_id), '#', toString(pr.number)))
+            WHERE ((pr.created_at >= {{start:DateTime}} AND pr.created_at < {{end:DateTime}})
+                OR (pr.merged_at IS NOT NULL AND pr.merged_at >= {{start:DateTime}} AND pr.merged_at < {{end:DateTime}}))
+              {repo_filter}
+              {org_filter_pr}
+              {org_filter_attr}
+        )
+        ORDER BY merged_at DESC NULLS LAST, repo_id, number DESC
+        {limit_clause}
         """
         raw_rows = await query_dicts(self.client, query, params)
         rows: list[AIPullRequestAttributionRow] = []
+        seen: set[tuple[str, int]] = set()
         for raw in raw_rows:
             parsed_repo_id = parse_uuid(raw.get("repo_id"))
             if parsed_repo_id is None:
                 continue
+            number = int(raw.get("number") or 0)
+            dedupe_key = (str(parsed_repo_id), number)
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
             rows.append(
                 {
                     "repo_id": parsed_repo_id,
-                    "number": int(raw.get("number") or 0),
+                    "number": number,
                     "kind": raw.get("kind"),
                     "work_type": raw.get("work_type"),
                     "team_id": raw.get("team_id") or None,
+                    "title": raw.get("title"),
+                    "merged_at": raw.get("merged_at"),
                 }
             )
         return rows

--- a/src/dev_health_ops/metrics/schemas.py
+++ b/src/dev_health_ops/metrics/schemas.py
@@ -55,6 +55,8 @@ class AIPullRequestAttributionRow(TypedDict):
     kind: str | None
     work_type: str | None
     team_id: str | None
+    title: NotRequired[str | None]
+    merged_at: NotRequired[datetime | None]
 
 
 class PullRequestCommentRow(TypedDict):

--- a/tests/api/graphql/test_ai_resolver.py
+++ b/tests/api/graphql/test_ai_resolver.py
@@ -656,9 +656,7 @@ async def test_ai_attributed_prs_reports_has_more_and_pages():
     # Loader returns limit+1 rows to signal more pages.
     rows = [_attribution_row(number=200 + i) for i in range(51)]
     with _patch_pr_loader(rows) as mock_load:
-        result = await resolve_ai_attributed_prs(
-            _ctx(), _range(), limit=50, offset=0
-        )
+        result = await resolve_ai_attributed_prs(_ctx(), _range(), limit=50, offset=0)
 
     assert mock_load.await_args.kwargs["limit"] == 51
     assert mock_load.await_args.kwargs["offset"] == 0

--- a/tests/api/graphql/test_ai_resolver.py
+++ b/tests/api/graphql/test_ai_resolver.py
@@ -35,6 +35,7 @@ from dev_health_ops.api.graphql.models.ai import (
     AIWorkflowRootTypeInput,
 )
 from dev_health_ops.api.graphql.resolvers.ai import (
+    resolve_ai_attributed_prs,
     resolve_ai_comparison,
     resolve_ai_governance_summary,
     resolve_ai_impact_summary,
@@ -577,3 +578,130 @@ async def test_impact_summary_rejects_reversed_date_range():
 async def test_workflow_drilldown_rejects_empty_root_id():
     with pytest.raises(ValueError, match="root_id is required"):
         await resolve_ai_workflow_drilldown(_ctx(), AIWorkflowRootTypeInput.ISSUE, "")
+
+
+# -----------------------------------------------------------------------------
+# aiAttributedPrs
+# -----------------------------------------------------------------------------
+
+
+def _attribution_row(
+    *,
+    number: int,
+    kind: str = "copilot",
+    work_type: str = "pull_request",
+    team_id: str | None = None,
+    title: str | None = None,
+    merged_at: datetime | None = None,
+):
+    return {
+        "repo_id": REPO_ID,
+        "number": number,
+        "kind": kind,
+        "work_type": work_type,
+        "team_id": team_id,
+        "title": title,
+        "merged_at": merged_at,
+    }
+
+
+def _patch_pr_loader(rows: list[dict[str, Any]]) -> Any:
+    return patch(
+        "dev_health_ops.metrics.loaders.ai_impact.AIImpactClickHouseLoader.load_ai_pr_attributions",
+        new_callable=AsyncMock,
+        return_value=rows,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_empty_state():
+    with _patch_pr_loader([]):
+        result = await resolve_ai_attributed_prs(_ctx(), _range())
+
+    assert result.org_id == ORG_ID
+    assert result.rows == []
+    assert result.total == 0
+    assert result.has_more is False
+    assert result.data_available is False
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_populated_maps_fields():
+    merged = datetime(2026, 5, 4, 9, tzinfo=timezone.utc)
+    rows = [
+        _attribution_row(
+            number=101,
+            kind="copilot",
+            title="Add feature flag",
+            merged_at=merged,
+        ),
+        _attribution_row(number=102, kind="cursor", title="Refactor auth"),
+    ]
+    with _patch_pr_loader(rows):
+        result = await resolve_ai_attributed_prs(_ctx(), _range())
+
+    assert result.data_available is True
+    assert result.has_more is False
+    assert result.total == 2
+    assert [r.number for r in result.rows] == [101, 102]
+    assert result.rows[0].repo_id == str(REPO_ID)
+    assert result.rows[0].title == "Add feature flag"
+    assert result.rows[0].kind == "copilot"
+    assert result.rows[0].merged_at == merged
+    assert result.rows[1].merged_at is None
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_reports_has_more_and_pages():
+    # Loader returns limit+1 rows to signal more pages.
+    rows = [_attribution_row(number=200 + i) for i in range(51)]
+    with _patch_pr_loader(rows) as mock_load:
+        result = await resolve_ai_attributed_prs(
+            _ctx(), _range(), limit=50, offset=0
+        )
+
+    assert mock_load.await_args.kwargs["limit"] == 51
+    assert mock_load.await_args.kwargs["offset"] == 0
+    assert len(result.rows) == 50
+    assert result.has_more is True
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_passes_repo_scope_to_loader():
+    scope = AIScopeInput(repo_id=str(REPO_ID))
+    with _patch_pr_loader([]) as mock_load:
+        await resolve_ai_attributed_prs(_ctx(), _range(), scope)
+
+    assert mock_load.await_args.kwargs["repo_id"] == REPO_ID
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_filters_by_work_type_in_memory():
+    rows = [
+        _attribution_row(number=1, work_type="bug"),
+        _attribution_row(number=2, work_type="feature"),
+        _attribution_row(number=3, work_type="bug"),
+    ]
+    scope = AIScopeInput(work_type="bug")
+    with _patch_pr_loader(rows):
+        result = await resolve_ai_attributed_prs(_ctx(), _range(), scope)
+
+    assert [r.number for r in result.rows] == [1, 3]
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_clamps_oversize_limit():
+    rows = [_attribution_row(number=i) for i in range(10)]
+    with _patch_pr_loader(rows) as mock_load:
+        await resolve_ai_attributed_prs(_ctx(), _range(), limit=5000, offset=-5)
+
+    # Limit is clamped to _MAX_AI_ATTRIBUTED_PRS_PAGE (200) plus 1 for has_more probe.
+    assert mock_load.await_args.kwargs["limit"] == 201
+    assert mock_load.await_args.kwargs["offset"] == 0
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_rejects_reversed_date_range():
+    bad_range = AIDateRangeInput(start_date=DAY_END, end_date=DAY_START)
+    with pytest.raises(ValueError, match="end_date must be >= start_date"):
+        await resolve_ai_attributed_prs(_ctx(), bad_range)


### PR DESCRIPTION
Adds a new Query field aiAttributedPrs that returns the AI-attributed
pull requests inside a given window so the dev-health-web Drilldown
modal can offer a real PR selector (CHAOS-1739).

* New Strawberry types AiAttributedPr / AiAttributedPrsResult.
* New resolver resolve_ai_attributed_prs wraps the existing
  load_ai_pr_attributions() loader; date range + repo scope come from
  AIScopeInput; team_id / work_type filtering happens in-memory because
  the loader projects them rather than filtering server-side.
* load_ai_pr_attributions() now also projects pr.title and pr.merged_at
  and supports LIMIT/OFFSET. Existing callers (job_daily) unaffected.
* SELECT branches are unioned, deduped, and ordered by merged_at DESC.
* 6 new contract tests cover empty state, populated mapping, has_more,
  scope passthrough, in-memory work_type filter, oversize-limit clamp,
  and reversed-date-range rejection. Full AI resolver suite green
  (26/26).

No persistence path changes; no fabrication. The new field returns the
same evidence already aggregated into the existing AI dashboards,
unaggregated, so the UI can pick a specific PR before calling
aiWorkflowDrilldown(rootType=PR, rootId=...).

Closes CHAOS-1738
