### PR TITLE
fix(ops): filter aiAttributedPrs to AI buckets + canonicalize fixture PR ids (CHAOS-1738)

### DIFF
--- a/src/dev_health_ops/fixtures/generators/ai_workflow.py
+++ b/src/dev_health_ops/fixtures/generators/ai_workflow.py
@@ -151,7 +151,9 @@ class AiWorkflowGeneratorMixin(BaseGeneratorMixin):
             return []
 
         org_uuid = uuid.UUID(str(org_id))
-        pr_lookup: dict[str, GitPullRequest] = {f"{self.repo_id}:{pr.number}": pr for pr in prs}
+        pr_lookup: dict[str, GitPullRequest] = {
+            f"{self.repo_id}:{pr.number}": pr for pr in prs
+        }
         edges: list[AIWorkflowArtifactEdge] = []
 
         for run in runs:
@@ -224,7 +226,9 @@ class AiWorkflowGeneratorMixin(BaseGeneratorMixin):
             return []
 
         org_uuid = uuid.UUID(str(org_id))
-        pr_lookup: dict[str, GitPullRequest] = {f"{self.repo_id}:{pr.number}": pr for pr in prs}
+        pr_lookup: dict[str, GitPullRequest] = {
+            f"{self.repo_id}:{pr.number}": pr for pr in prs
+        }
         edges: list[AIWorkflowIssueEdge] = []
 
         issue_by_repo: dict[uuid.UUID | None, list[str]] = {}

--- a/src/dev_health_ops/fixtures/generators/ai_workflow.py
+++ b/src/dev_health_ops/fixtures/generators/ai_workflow.py
@@ -98,7 +98,7 @@ class AiWorkflowGeneratorMixin(BaseGeneratorMixin):
                     metadata={
                         "source": "synthetic_fixture",
                         "subject_type": "pull_request",
-                        "subject_id": str(pr.number),
+                        "subject_id": f"{self.repo_id}:{pr.number}",
                     },
                 )
             )
@@ -151,7 +151,7 @@ class AiWorkflowGeneratorMixin(BaseGeneratorMixin):
             return []
 
         org_uuid = uuid.UUID(str(org_id))
-        pr_lookup: dict[str, GitPullRequest] = {str(pr.number): pr for pr in prs}
+        pr_lookup: dict[str, GitPullRequest] = {f"{self.repo_id}:{pr.number}": pr for pr in prs}
         edges: list[AIWorkflowArtifactEdge] = []
 
         for run in runs:
@@ -224,7 +224,7 @@ class AiWorkflowGeneratorMixin(BaseGeneratorMixin):
             return []
 
         org_uuid = uuid.UUID(str(org_id))
-        pr_lookup: dict[str, GitPullRequest] = {str(pr.number): pr for pr in prs}
+        pr_lookup: dict[str, GitPullRequest] = {f"{self.repo_id}:{pr.number}": pr for pr in prs}
         edges: list[AIWorkflowIssueEdge] = []
 
         issue_by_repo: dict[uuid.UUID | None, list[str]] = {}

--- a/src/dev_health_ops/metrics/loaders/ai_impact.py
+++ b/src/dev_health_ops/metrics/loaders/ai_impact.py
@@ -70,6 +70,7 @@ class AIImpactClickHouseLoader:
             INNER JOIN ai_attribution_resolved AS attr
                 ON attr.subject_type = 'pull_request'
                 AND attr.subject_id = link.work_item_id
+                AND attr.kind IN ('ai_assisted', 'agent_created', 'ai_review')
             LEFT JOIN work_items AS wi
                 ON wi.repo_id = link.repo_id AND wi.work_item_id = link.work_item_id
             WHERE ((pr.created_at >= {{start:DateTime}} AND pr.created_at < {{end:DateTime}})
@@ -91,6 +92,7 @@ class AIImpactClickHouseLoader:
                 ON attr.subject_type = 'pull_request'
                 AND attr.repo_id = pr.repo_id
                 AND (attr.subject_id = toString(pr.number) OR attr.subject_id = concat(toString(pr.repo_id), '#', toString(pr.number)))
+                AND attr.kind IN ('ai_assisted', 'agent_created', 'ai_review')
             WHERE ((pr.created_at >= {{start:DateTime}} AND pr.created_at < {{end:DateTime}})
                 OR (pr.merged_at IS NOT NULL AND pr.merged_at >= {{start:DateTime}} AND pr.merged_at < {{end:DateTime}}))
               {repo_filter}


### PR DESCRIPTION
Two real issues surfaced by the new drilldown UX:

1. The aiAttributedPrs SQL was returning rows for every PR in
   ai_attribution_resolved, including kind='human' and kind='unknown'.
   The field name implies AI-attributed PRs only, so the loader now
   filters to the canonical AI buckets (ai_assisted, agent_created,
   ai_review) on both UNION branches. Matches AI_BUCKETS in
   metrics/ai_impact.py.

2. AI workflow fixtures stored artifact/subject PR ids as bare
   str(pr.number) ('10'). The production extractor and the rest of the
   work graph use f'{repo_id}:{pr_number}' (e.g. 'uuid:10'). That
   inconsistency meant the drilldown could never find edges for a
   selected PR in a fixture-seeded environment.

   The fixture generator now emits the canonical 'repo_id:number'
   format for both AIWorkflowRun.metadata.subject_id and the
   AIWorkflowArtifactEdge.artifact_id derived from it, matching
   work_graph.extractors.ai_workflow. pr_lookup keys are updated in
   step.

   Existing fixture data must be regenerated:

       CLICKHOUSE_URI=... dev-hops fixtures generate --sink "$CLICKHOUSE_URI" --days 30

TEST-EVIDENCE: Local backend checks passed before push: `uv run --extra dev pytest tests/api/graphql/test_ai_resolver.py tests/test_fixtures_runner.py tests/storage/test_ai_workflow.py tests/metrics/test_clickhouse_computed_at_aliases.py` (47 passed), plus CI test matrix green on Python 3.11/3.12/3.13/3.14. Follow-up validation for CI lint/typecheck: `uv run --extra dev ruff format --check .`, `uv run --extra dev ruff check .`, and `uv run --extra dev mypy src/dev_health_ops/metrics/loaders/ai_impact.py src/dev_health_ops/fixtures/generators/ai_workflow.py src/dev_health_ops/api/graphql/resolvers/ai.py`.

RISK-NOTES: Blast radius is limited to the aiAttributedPrs loader filter and fixture-generated canonical PR IDs. Rollback is reverting the follow-up commit; fixture-seeded environments should regenerate fixtures with `dev-hops fixtures generate`. No runtime schema or migration changes.

All 47 related backend tests still pass.
