### PR TITLE
feat(ops): Compounding Risk composite metric + GraphQL resolver (CHAOS-1641, CHAOS-1642)

### DIFF
--- a/docs/computations/compounding-risk.md
+++ b/docs/computations/compounding-risk.md
@@ -1,0 +1,150 @@
+# Compounding Risk
+
+> _High churn meeting high complexity meeting low ownership meeting slow review._
+
+Compounding Risk is a deterministic, inspectable composite signal that flags
+where change pressure is overlapping with architectural and operational risk.
+It is the canonical "Compounding Risk" wedge from
+[`dev-health-product-market-simplification.md`](../product/dev-health-product-market-simplification.md)
+and is consumed by the `/risk/compounding` web surface (CHAOS-1642).
+
+This document specifies the formula. The implementation lives in
+`src/dev_health_ops/metrics/compounding_risk.py`; the persisted output lives
+in the `compounding_risk_daily` ClickHouse table.
+
+---
+
+## Inputs
+
+For each `(org_id, repo_id, day)` row, four signals are combined:
+
+| Component | Source | Field |
+|---|---|---|
+| Churn | `repo_metrics_daily` | `rework_churn_ratio_30d` |
+| Complexity trend | `repo_complexity_daily` | relative change in `cyclomatic_per_kloc` over the trailing window |
+| Ownership concentration | `repo_metrics_daily` | `max(single_owner_file_ratio_30d, code_ownership_gini)` |
+| Review latency (tail) | `repo_metrics_daily` | `pr_first_review_p90_hours` |
+
+Window: trailing 30 days. The complexity delta uses the first-half-versus-second-half
+average so a recent rise in complexity is captured even when absolute values are small.
+
+If any required input is missing, the score is `NULL` and the severity is `unknown`.
+**Missing data is not zero risk.**
+
+---
+
+## Formula
+
+```
+churn_norm        = clamp01( max(0, rework_churn) / CHURN_REF )           # CHURN_REF = 0.30
+complexity_norm   = clamp01( max(0, complexity_delta) / COMPLEXITY_REF )  # COMPLEXITY_REF = 0.20
+ownership_norm    = clamp01( max(single_owner_ratio, ownership_gini) )    # already in [0, 1]
+review_norm       = clamp01( max(0, review_latency_p90h) / REVIEW_REF )   # REVIEW_REF = 48h
+
+compounding_risk  =
+      W_CHURN      * churn_norm
+    + W_COMPLEXITY * complexity_norm
+    + W_OWNERSHIP  * ownership_norm
+    + W_REVIEW     * review_norm
+```
+
+Default weights (must sum to `1.0`; enforced at construction time):
+
+| Weight | Default |
+|---|---|
+| `W_CHURN` | 0.30 |
+| `W_COMPLEXITY` | 0.30 |
+| `W_OWNERSHIP` | 0.20 |
+| `W_REVIEW` | 0.20 |
+
+The composite is always in `[0, 1]`.
+
+Reference values are intentional saturation thresholds, **not** caps on the
+underlying inputs. They are documented constants in
+`metrics/compounding_risk.py::REFERENCE_VALUES`.
+
+---
+
+## Severity
+
+| Score | Severity |
+|---|---|
+| `score is None` | `unknown` |
+| `score < 0.40` | `low` |
+| `0.40 <= score < 0.65` | `elevated` |
+| `score >= 0.65` | `high` |
+
+Thresholds and weights are persisted with each row. **Historical rows retain
+the bucket they were computed under**, so changes to defaults do not silently
+re-bucket past data.
+
+---
+
+## Persistence
+
+Table: `compounding_risk_daily` (migration `040_compounding_risk_daily.sql`).
+
+Append-only with `computed_at`. Read latest with:
+
+```sql
+SELECT
+  scope_id,
+  argMax(compounding_risk, computed_at)   AS score,
+  argMax(severity, computed_at)            AS severity,
+  argMax(churn_norm, computed_at)          AS churn_norm,
+  argMax(complexity_norm, computed_at)     AS complexity_norm,
+  argMax(ownership_norm, computed_at)      AS ownership_norm,
+  argMax(review_norm, computed_at)         AS review_norm
+FROM compounding_risk_daily
+WHERE org_id = 'demo-org'
+  AND scope = 'repo'
+  AND day = today()
+GROUP BY scope_id
+ORDER BY score DESC NULLS LAST;
+```
+
+Every row carries:
+- the **composite score** and **severity**,
+- the **four normalized components** (so each contribution is visible),
+- the **raw inputs** (so the score can be re-derived by hand),
+- the **weights and thresholds in force at compute time** (audit trail).
+
+This is the inspectability contract — no opaque scoring.
+
+---
+
+## Scope
+
+v1 persists **repo-scope rows only**. Team-scope views are derived at read time
+by aggregating per-repo rows in the GraphQL resolver (CHAOS-1642). Persisting
+team-scope rows is a follow-up optimization; the read-time aggregation already
+honors the inspectability contract.
+
+Per the no-surveillance contract, **there is no per-person scope** for this
+metric, and the web surface explicitly locks the scope picker against it.
+
+---
+
+## Orchestration
+
+Compounding Risk runs as part of `dev-hops metrics daily`:
+
+1. `compute_daily_metrics` writes `repo_metrics_daily` for the day.
+2. `build_compounding_risk_rows_for_day` reads back the just-written
+   `repo_metrics_daily` rows and queries `repo_complexity_daily` for the
+   complexity delta.
+3. The resulting rows are written via `sink.write_compounding_risk_daily(...)`.
+
+No new connector or processor work is required; the pipeline already
+captures every input.
+
+---
+
+## Non-negotiables
+
+- ClickHouse-only persistence.
+- Sink-only writes; no file exports.
+- Deterministic compute; no LLM at compute time.
+- No per-person scope.
+- Score is always inspectable: weights, thresholds, raw inputs, and
+  normalized components are all persisted alongside the score.

--- a/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
+++ b/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
@@ -1,0 +1,476 @@
+"""Compounding Risk GraphQL resolver (CHAOS-1642).
+
+Reads from the append-only ``compounding_risk_daily`` table populated by the
+daily metrics job (CHAOS-1641). The resolver is read-only and never
+recomputes the composite — it surfaces persisted distributions exactly as
+they were computed, honoring the inspectability contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+from ..authz import require_org_id
+from ..context import GraphQLContext
+from ..types.compounding_risk import (
+    CompoundingRiskComponents,
+    CompoundingRiskFilterInput,
+    CompoundingRiskPoint,
+    CompoundingRiskResult,
+    CompoundingRiskScope,
+    CompoundingRiskSeverity,
+    CompoundingRiskThresholds,
+    CompoundingRiskTrendPoint,
+    CompoundingRiskWeights,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Hard limit on rows returned; protects against pathological scopes.
+MAX_ROWS: int = 500
+#: Hard limit on trend window in days.
+MAX_TREND_DAYS: int = 365
+
+
+def _require_client(context: GraphQLContext) -> Any:
+    if context.client is None:
+        raise RuntimeError(
+            "Database client not available for Compounding Risk resolver"
+        )
+    return context.client
+
+
+def _severity_from_str(value: Any) -> CompoundingRiskSeverity:
+    raw = str(value or "unknown").lower()
+    try:
+        return CompoundingRiskSeverity(raw)
+    except ValueError:
+        return CompoundingRiskSeverity.UNKNOWN
+
+
+def _query_dicts(client: Any, query: str, params: dict) -> list[dict[str, Any]]:
+    """Run a parameterized ClickHouse query and return list-of-dicts."""
+    result = client.query(query, parameters=params)
+    columns = list(getattr(result, "column_names", []) or [])
+    rows = list(getattr(result, "result_rows", []) or [])
+    if not columns or not rows:
+        return []
+    return [dict(zip(columns, row)) for row in rows]
+
+
+def _latest_day_for_org(client: Any, org_id: str) -> date | None:
+    rows = _query_dicts(
+        client,
+        """
+        SELECT max(day) AS day
+        FROM compounding_risk_daily
+        WHERE org_id = {org_id:String}
+        """,
+        {"org_id": org_id},
+    )
+    if not rows:
+        return None
+    value = rows[0].get("day")
+    if isinstance(value, date):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    return None
+
+
+def _fetch_latest_rows(
+    client: Any,
+    *,
+    org_id: str,
+    day: date,
+    scope: str,
+    scope_ids: list[str] | None,
+) -> list[dict[str, Any]]:
+    """Latest per-(scope_id) row at the given day, for one scope value.
+
+    ``argMax`` over ``computed_at`` returns the most-recent compute for each
+    scope_id on that day. All audit-trail fields are passed through so the
+    UI can show the score's full provenance without a second roundtrip.
+    """
+    query = """
+        SELECT
+            scope_id,
+            argMax(compounding_risk,    computed_at) AS score,
+            argMax(severity,            computed_at) AS severity,
+            argMax(churn_norm,          computed_at) AS churn_norm,
+            argMax(complexity_norm,     computed_at) AS complexity_norm,
+            argMax(ownership_norm,      computed_at) AS ownership_norm,
+            argMax(review_norm,         computed_at) AS review_norm,
+            argMax(rework_churn,        computed_at) AS rework_churn,
+            argMax(complexity_delta,    computed_at) AS complexity_delta,
+            argMax(bus_factor,          computed_at) AS bus_factor,
+            argMax(ownership_gini,      computed_at) AS ownership_gini,
+            argMax(single_owner_ratio,  computed_at) AS single_owner_ratio,
+            argMax(review_latency_p90h, computed_at) AS review_latency_p90h,
+            argMax(w_churn,             computed_at) AS w_churn,
+            argMax(w_complexity,        computed_at) AS w_complexity,
+            argMax(w_ownership,         computed_at) AS w_ownership,
+            argMax(w_review,            computed_at) AS w_review,
+            argMax(threshold_elevated,  computed_at) AS threshold_elevated,
+            argMax(threshold_high,      computed_at) AS threshold_high,
+            max(computed_at)                          AS computed_at
+        FROM compounding_risk_daily
+        WHERE org_id = {org_id:String}
+          AND scope = {scope:String}
+          AND day = {day:Date}
+    """
+    params: dict[str, Any] = {"org_id": org_id, "day": day, "scope": scope}
+    if scope_ids:
+        bounded = list(scope_ids)[:MAX_ROWS]
+        query += "\n  AND scope_id IN {scope_ids:Array(String)}"
+        params["scope_ids"] = bounded
+    query += f"\nGROUP BY scope_id\nORDER BY score DESC NULLS LAST\nLIMIT {MAX_ROWS}"
+    return _query_dicts(client, query, params)
+
+
+def _fetch_repo_trend(
+    client: Any,
+    org_id: str,
+    end_day: date,
+    trend_days: int,
+    repo_ids: list[str] | None,
+) -> list[dict[str, Any]]:
+    start_day = end_day - timedelta(days=max(0, trend_days - 1))
+    query = """
+        SELECT day,
+               avg(score) AS avg_score
+        FROM (
+            SELECT
+                day,
+                scope_id,
+                argMax(compounding_risk, computed_at) AS score
+            FROM compounding_risk_daily
+            WHERE org_id = {org_id:String}
+              AND scope = 'repo'
+              AND day >= {start:Date} AND day <= {end:Date}
+    """
+    params: dict[str, Any] = {
+        "org_id": org_id,
+        "start": start_day,
+        "end": end_day,
+    }
+    if repo_ids:
+        bounded = list(repo_ids)[:MAX_ROWS]
+        query += "\n              AND scope_id IN {repo_ids:Array(String)}"
+        params["repo_ids"] = bounded
+    query += """
+            GROUP BY day, scope_id
+        )
+        GROUP BY day ORDER BY day
+    """
+    return _query_dicts(client, query, params)
+
+
+def _components_from_row(row: dict[str, Any]) -> CompoundingRiskComponents:
+    def _nf(key: str) -> float | None:
+        v = row.get(key)
+        return float(v) if v is not None else None
+
+    return CompoundingRiskComponents(
+        churn_norm=_nf("churn_norm"),
+        complexity_norm=_nf("complexity_norm"),
+        ownership_norm=_nf("ownership_norm"),
+        review_norm=_nf("review_norm"),
+        rework_churn=_nf("rework_churn"),
+        complexity_delta=_nf("complexity_delta"),
+        bus_factor=_nf("bus_factor"),
+        ownership_gini=_nf("ownership_gini"),
+        single_owner_ratio=_nf("single_owner_ratio"),
+        review_latency_p90h=_nf("review_latency_p90h"),
+    )
+
+
+def _weights_from_row(row: dict[str, Any]) -> CompoundingRiskWeights:
+    return CompoundingRiskWeights(
+        churn=float(row.get("w_churn") or 0.0),
+        complexity=float(row.get("w_complexity") or 0.0),
+        ownership=float(row.get("w_ownership") or 0.0),
+        review=float(row.get("w_review") or 0.0),
+    )
+
+
+def _thresholds_from_row(row: dict[str, Any]) -> CompoundingRiskThresholds:
+    return CompoundingRiskThresholds(
+        elevated=float(row.get("threshold_elevated") or 0.0),
+        high=float(row.get("threshold_high") or 0.0),
+    )
+
+
+def _point_from_repo_row(
+    row: dict[str, Any], day: date, label_resolver: dict[str, str]
+) -> CompoundingRiskPoint:
+    scope_id = str(row["scope_id"])
+    score_val = row.get("score")
+    return CompoundingRiskPoint(
+        day=day,
+        scope=CompoundingRiskScope.REPO,
+        scope_id=scope_id,
+        scope_label=label_resolver.get(scope_id, scope_id),
+        score=float(score_val) if score_val is not None else None,
+        severity=_severity_from_str(row.get("severity")),
+        components=_components_from_row(row),
+        weights=_weights_from_row(row),
+        thresholds=_thresholds_from_row(row),
+        computed_at=row.get("computed_at") or datetime.now(timezone.utc),
+    )
+
+
+def _point_from_team_row(
+    row: dict[str, Any], day: date, team_labels: dict[str, str]
+) -> CompoundingRiskPoint:
+    scope_id = str(row["scope_id"])
+    score_val = row.get("score")
+    return CompoundingRiskPoint(
+        day=day,
+        scope=CompoundingRiskScope.TEAM,
+        scope_id=scope_id,
+        scope_label=team_labels.get(scope_id, scope_id),
+        score=float(score_val) if score_val is not None else None,
+        severity=_severity_from_str(row.get("severity")),
+        components=_components_from_row(row),
+        weights=_weights_from_row(row),
+        thresholds=_thresholds_from_row(row),
+        computed_at=row.get("computed_at") or datetime.now(timezone.utc),
+    )
+
+
+def _aggregate_repo_rows_to_team(
+    repo_rows: list[dict[str, Any]],
+    *,
+    repo_to_team: dict[str, str],
+    team_labels: dict[str, str],
+    team_id_filter: list[str] | None,
+    day: date,
+) -> list[CompoundingRiskPoint]:
+    """Read-time aggregation of repo-scope rows into team-scope points.
+
+    v1 strategy: unweighted mean of repo scores per team. Component values
+    are similarly averaged. Audit fields (weights, thresholds) carry from
+    the first repo in the team — these are constant across repos in the
+    same compute pass so the mean is a no-op.
+
+    Team-scope persistence is a follow-up optimisation (see plan).
+    """
+    by_team: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in repo_rows:
+        team = repo_to_team.get(str(row["scope_id"]))
+        if not team:
+            continue
+        if team_id_filter and team not in team_id_filter:
+            continue
+        by_team[team].append(row)
+
+    out: list[CompoundingRiskPoint] = []
+    for team_id, rows in by_team.items():
+        scores = [r.get("score") for r in rows if r.get("score") is not None]
+        avg_score: float | None = (
+            sum(float(s) for s in scores) / len(scores) if scores else None
+        )
+        # Average each component independently — missing values skipped.
+
+        def _avg(key: str) -> float | None:
+            vals = [r.get(key) for r in rows if r.get(key) is not None]
+            return sum(float(v) for v in vals) / len(vals) if vals else None
+
+        first = rows[0]
+        components = CompoundingRiskComponents(
+            churn_norm=_avg("churn_norm"),
+            complexity_norm=_avg("complexity_norm"),
+            ownership_norm=_avg("ownership_norm"),
+            review_norm=_avg("review_norm"),
+            rework_churn=_avg("rework_churn"),
+            complexity_delta=_avg("complexity_delta"),
+            bus_factor=_avg("bus_factor"),
+            ownership_gini=_avg("ownership_gini"),
+            single_owner_ratio=_avg("single_owner_ratio"),
+            review_latency_p90h=_avg("review_latency_p90h"),
+        )
+        # Severity is recomputed from the averaged score using the same
+        # thresholds the underlying rows were computed with.
+        thresholds = _thresholds_from_row(first)
+        if avg_score is None:
+            severity = CompoundingRiskSeverity.UNKNOWN
+        elif avg_score >= thresholds.high:
+            severity = CompoundingRiskSeverity.HIGH
+        elif avg_score >= thresholds.elevated:
+            severity = CompoundingRiskSeverity.ELEVATED
+        else:
+            severity = CompoundingRiskSeverity.LOW
+
+        out.append(
+            CompoundingRiskPoint(
+                day=day,
+                scope=CompoundingRiskScope.TEAM,
+                scope_id=team_id,
+                scope_label=team_labels.get(team_id, team_id),
+                score=avg_score,
+                severity=severity,
+                components=components,
+                weights=_weights_from_row(first),
+                thresholds=thresholds,
+                computed_at=first.get("computed_at")
+                or datetime.now(timezone.utc),
+            )
+        )
+    # Sort by score desc, nulls last.
+    out.sort(key=lambda p: (p.score is None, -(p.score or 0.0)))
+    return out
+
+
+async def _load_repo_labels(
+    client: Any, org_id: str, repo_ids: list[str]
+) -> dict[str, str]:
+    if not repo_ids:
+        return {}
+    rows = _query_dicts(
+        client,
+        """
+        SELECT toString(repo_id) AS repo_id, full_name
+        FROM repos
+        WHERE org_id = {org_id:String}
+          AND toString(repo_id) IN {repo_ids:Array(String)}
+        """,
+        {"org_id": org_id, "repo_ids": repo_ids},
+    )
+    return {row["repo_id"]: row.get("full_name") or row["repo_id"] for row in rows}
+
+
+async def _load_team_assignments(
+    client: Any, org_id: str
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Return ``(repo_id → team_id, team_id → team_name)`` mappings.
+
+    The mapping is best-effort. If the ``teams`` table cannot be reached,
+    the resolver simply returns no team rows rather than erroring.
+    """
+    try:
+        team_rows = _query_dicts(
+            client,
+            """
+            SELECT id, name, repo_patterns
+            FROM teams
+            WHERE org_id = {org_id:String}
+            """,
+            {"org_id": org_id},
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Could not load teams for compounding risk: %s", exc)
+        return {}, {}
+
+    repo_to_team: dict[str, str] = {}
+    team_labels: dict[str, str] = {}
+    for row in team_rows:
+        team_id = str(row["id"])
+        team_labels[team_id] = row.get("name") or team_id
+        for repo_id in row.get("repo_patterns") or []:
+            repo_to_team[str(repo_id)] = team_id
+    return repo_to_team, team_labels
+
+
+async def resolve_compounding_risk(
+    context: GraphQLContext,
+    org_id: str,
+    filter: CompoundingRiskFilterInput | None = None,  # noqa: A002
+) -> CompoundingRiskResult:
+    """Read latest Compounding Risk rows for the org, with optional breakout."""
+    authorized_org_id = require_org_id(context)
+    if org_id != authorized_org_id:
+        logger.debug(
+            "Ignoring GraphQL orgId %r in favor of authorized org %r",
+            org_id,
+            authorized_org_id,
+        )
+
+    client = _require_client(context)
+    filt = filter or CompoundingRiskFilterInput()
+    breakout = filt.breakout
+    trend_days = max(1, min(filt.trend_days, MAX_TREND_DAYS))
+
+    day = filt.day or _latest_day_for_org(client, authorized_org_id)
+    if day is None:
+        return CompoundingRiskResult(
+            org_id=authorized_org_id,
+            breakout=breakout,
+            rows=[],
+            trend=[],
+            generated_at=datetime.now(timezone.utc),
+        )
+
+    points: list[CompoundingRiskPoint]
+    if breakout == CompoundingRiskScope.REPO:
+        repo_rows = _fetch_latest_rows(
+            client,
+            org_id=authorized_org_id,
+            day=day,
+            scope="repo",
+            scope_ids=filt.repo_ids,
+        )
+        repo_ids = [str(r["scope_id"]) for r in repo_rows]
+        labels = await _load_repo_labels(client, authorized_org_id, repo_ids)
+        points = [_point_from_repo_row(r, day, labels) for r in repo_rows]
+    else:
+        # Prefer persisted team-scope rows. Fall back to read-time
+        # aggregation only when the team rows are missing (back-compat
+        # with deployments that haven't yet caught up to the orchestrator
+        # change).
+        team_rows = _fetch_latest_rows(
+            client,
+            org_id=authorized_org_id,
+            day=day,
+            scope="team",
+            scope_ids=filt.team_ids,
+        )
+        if team_rows:
+            _, team_labels = await _load_team_assignments(
+                client, authorized_org_id
+            )
+            points = [
+                _point_from_team_row(r, day, team_labels) for r in team_rows
+            ]
+        else:
+            # Fallback path: aggregate from the repo rows.
+            repo_rows = _fetch_latest_rows(
+                client,
+                org_id=authorized_org_id,
+                day=day,
+                scope="repo",
+                scope_ids=filt.repo_ids,
+            )
+            repo_to_team, team_labels = await _load_team_assignments(
+                client, authorized_org_id
+            )
+            points = _aggregate_repo_rows_to_team(
+                repo_rows,
+                repo_to_team=repo_to_team,
+                team_labels=team_labels,
+                team_id_filter=filt.team_ids,
+                day=day,
+            )
+
+    trend_rows = _fetch_repo_trend(
+        client, authorized_org_id, day, trend_days, filt.repo_ids
+    )
+    trend = [
+        CompoundingRiskTrendPoint(
+            day=row["day"],
+            score=float(row["avg_score"]) if row.get("avg_score") is not None else None,
+            severity=_severity_from_str(None),  # severity not aggregated for trend
+        )
+        for row in trend_rows
+    ]
+
+    return CompoundingRiskResult(
+        org_id=authorized_org_id,
+        breakout=breakout,
+        rows=points,
+        trend=trend,
+        generated_at=datetime.now(timezone.utc),
+    )

--- a/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
+++ b/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
@@ -270,15 +270,18 @@ def _aggregate_repo_rows_to_team(
 
     out: list[CompoundingRiskPoint] = []
     for team_id, rows in by_team.items():
-        scores = [r.get("score") for r in rows if r.get("score") is not None]
+        score_values: list[float] = [
+            float(r["score"]) for r in rows if r.get("score") is not None
+        ]
         avg_score: float | None = (
-            sum(float(s) for s in scores) / len(scores) if scores else None
+            sum(score_values) / len(score_values) if score_values else None
         )
-        # Average each component independently — missing values skipped.
 
-        def _avg(key: str) -> float | None:
-            vals = [r.get(key) for r in rows if r.get(key) is not None]
-            return sum(float(v) for v in vals) / len(vals) if vals else None
+        def _avg(key: str, source_rows: list[dict[str, Any]] = rows) -> float | None:
+            vals: list[float] = [
+                float(r[key]) for r in source_rows if r.get(key) is not None
+            ]
+            return sum(vals) / len(vals) if vals else None
 
         first = rows[0]
         components = CompoundingRiskComponents(
@@ -316,8 +319,7 @@ def _aggregate_repo_rows_to_team(
                 components=components,
                 weights=_weights_from_row(first),
                 thresholds=thresholds,
-                computed_at=first.get("computed_at")
-                or datetime.now(timezone.utc),
+                computed_at=first.get("computed_at") or datetime.now(timezone.utc),
             )
         )
     # Sort by score desc, nulls last.
@@ -429,12 +431,8 @@ async def resolve_compounding_risk(
             scope_ids=filt.team_ids,
         )
         if team_rows:
-            _, team_labels = await _load_team_assignments(
-                client, authorized_org_id
-            )
-            points = [
-                _point_from_team_row(r, day, team_labels) for r in team_rows
-            ]
+            _, team_labels = await _load_team_assignments(client, authorized_org_id)
+            points = [_point_from_team_row(r, day, team_labels) for r in team_rows]
         else:
             # Fallback path: aggregate from the repo rows.
             repo_rows = _fetch_latest_rows(

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -64,6 +64,7 @@ from .resolvers.ai import (
 from .resolvers.analytics import resolve_analytics
 from .resolvers.bus_factor import resolve_bus_factor
 from .resolvers.catalog import resolve_catalog
+from .resolvers.compounding_risk import resolve_compounding_risk
 from .resolvers.data_health import resolve_data_health
 from .resolvers.reports import (
     CloneSavedReportInput,
@@ -84,6 +85,10 @@ from .resolvers.reports import (
 )
 from .subscriptions import Subscription
 from .types.bus_factor import BusFactor, BusFactorScopeInput
+from .types.compounding_risk import (
+    CompoundingRiskFilterInput,
+    CompoundingRiskResult,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -319,6 +324,22 @@ class Query:
     ) -> BusFactor:
         context = get_context(info)
         return await resolve_bus_factor(context, org_id, scope)
+
+    @strawberry.field(
+        description=(
+            "Compounding Risk composite: churn × complexity × ownership "
+            "× review-latency. Inspectable score with persisted weights, "
+            "thresholds, raw inputs, and normalized components."
+        )
+    )
+    async def compounding_risk(
+        self,
+        info: Info,
+        org_id: str,
+        filter: CompoundingRiskFilterInput | None = None,  # noqa: A002
+    ) -> CompoundingRiskResult:
+        context = get_context(info)
+        return await resolve_compounding_risk(context, org_id, filter)
 
     @strawberry.field(
         description="Latest rule-based recommendations for a team within a lookback window."

--- a/src/dev_health_ops/api/graphql/types/compounding_risk.py
+++ b/src/dev_health_ops/api/graphql/types/compounding_risk.py
@@ -1,0 +1,129 @@
+"""GraphQL types for the Compounding Risk surface (CHAOS-1642)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import Enum
+
+import strawberry
+
+
+@strawberry.enum
+class CompoundingRiskScope(Enum):
+    """Breakout scope for Compounding Risk queries.
+
+    Per the no-surveillance contract, ``DEVELOPER`` is intentionally absent.
+    """
+
+    REPO = "repo"
+    TEAM = "team"
+
+
+@strawberry.enum
+class CompoundingRiskSeverity(Enum):
+    """Severity bucket persisted alongside the composite score."""
+
+    UNKNOWN = "unknown"
+    LOW = "low"
+    ELEVATED = "elevated"
+    HIGH = "high"
+
+
+@strawberry.type
+class CompoundingRiskComponents:
+    """Per-component normalized values and the raw inputs they came from.
+
+    All fields are nullable — a missing input propagates as ``None`` rather
+    than zero (data unavailable is not "no risk").
+    """
+
+    churn_norm: float | None = strawberry.field(name="churnNorm")
+    complexity_norm: float | None = strawberry.field(name="complexityNorm")
+    ownership_norm: float | None = strawberry.field(name="ownershipNorm")
+    review_norm: float | None = strawberry.field(name="reviewNorm")
+
+    rework_churn: float | None = strawberry.field(name="reworkChurn")
+    complexity_delta: float | None = strawberry.field(name="complexityDelta")
+    bus_factor: float | None = strawberry.field(name="busFactor")
+    ownership_gini: float | None = strawberry.field(name="ownershipGini")
+    single_owner_ratio: float | None = strawberry.field(name="singleOwnerRatio")
+    review_latency_p90h: float | None = strawberry.field(name="reviewLatencyP90h")
+
+
+@strawberry.type
+class CompoundingRiskWeights:
+    """Weights used at compute time (audit trail; sums to 1.0)."""
+
+    churn: float
+    complexity: float
+    ownership: float
+    review: float
+
+
+@strawberry.type
+class CompoundingRiskThresholds:
+    """Severity bucket thresholds used at compute time (audit trail)."""
+
+    elevated: float
+    high: float
+
+
+@strawberry.type
+class CompoundingRiskPoint:
+    """One Compounding Risk row (latest ``computed_at`` per scope/day)."""
+
+    day: date
+    scope: CompoundingRiskScope
+    scope_id: str = strawberry.field(name="scopeId")
+    scope_label: str = strawberry.field(name="scopeLabel")
+
+    score: float | None  # nullable when any required input is missing
+    severity: CompoundingRiskSeverity
+
+    components: CompoundingRiskComponents
+    weights: CompoundingRiskWeights
+    thresholds: CompoundingRiskThresholds
+
+    computed_at: datetime = strawberry.field(name="computedAt")
+
+
+@strawberry.type
+class CompoundingRiskTrendPoint:
+    """One day in a per-scope trend series."""
+
+    day: date
+    score: float | None
+    severity: CompoundingRiskSeverity
+
+
+@strawberry.type
+class CompoundingRiskResult:
+    """Top-level Compounding Risk response.
+
+    ``rows`` contains the latest per-scope record sorted by score descending
+    (nulls last). ``trend`` is the per-day series for the selected scope (or
+    the aggregate trend when no scope is selected).
+    """
+
+    org_id: str = strawberry.field(name="orgId")
+    breakout: CompoundingRiskScope
+    rows: list[CompoundingRiskPoint]
+    trend: list[CompoundingRiskTrendPoint]
+    generated_at: datetime = strawberry.field(name="generatedAt")
+
+
+@strawberry.input
+class CompoundingRiskFilterInput:
+    """Filter for the Compounding Risk query.
+
+    Per the no-surveillance contract, this input intentionally does not
+    accept a person/developer scope. ``breakout`` chooses repo vs team
+    aggregation; specific ``repoIds`` or ``teamIds`` narrow the result set
+    further.
+    """
+
+    day: date | None = None  # default: latest available day
+    breakout: CompoundingRiskScope = CompoundingRiskScope.REPO
+    repo_ids: list[str] | None = strawberry.field(default=None, name="repoIds")
+    team_ids: list[str] | None = strawberry.field(default=None, name="teamIds")
+    trend_days: int = strawberry.field(default=30, name="trendDays")

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -365,11 +365,6 @@ def build_parser() -> argparse.ArgumentParser:
     job_ff_validation.register_commands(metrics_subparsers)
     job_compounding_risk.register_commands(metrics_subparsers)
 
-
-
-
-
-
     # ---- audit ----
     audit_parser = sub.add_parser("audit", help="Run diagnostic audits.")
     audit_subparsers = audit_parser.add_subparsers(dest="audit_command", required=True)

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -20,6 +20,7 @@ from dev_health_ops.fixtures import runner as fixtures_runner
 from dev_health_ops.metrics import (
     job_capacity,
     job_complexity_db,
+    job_compounding_risk,
     job_daily,
     job_dora,
     job_ff_validation,
@@ -362,6 +363,12 @@ def build_parser() -> argparse.ArgumentParser:
     job_capacity.register_commands(metrics_subparsers)
     job_release_impact.register_commands(metrics_subparsers)
     job_ff_validation.register_commands(metrics_subparsers)
+    job_compounding_risk.register_commands(metrics_subparsers)
+
+
+
+
+
 
     # ---- audit ----
     audit_parser = sub.add_parser("audit", help="Run diagnostic audits.")

--- a/src/dev_health_ops/metrics/compounding_risk.py
+++ b/src/dev_health_ops/metrics/compounding_risk.py
@@ -1,0 +1,530 @@
+"""Compounding Risk composite metric (CHAOS-1641).
+
+Deterministic, inspectable composite that combines four signals already
+computed elsewhere in the metrics pipeline:
+
+    churn       — rework churn ratio over the trailing window
+    complexity  — repo complexity trend (cyclomatic_per_kloc delta)
+    ownership   — concentration (max of single-owner ratio and gini)
+    review      — review-latency p90 in hours (pr_first_review_p90_hours)
+
+Each input is normalized into [0, 1] against a reference value, then
+combined via a weighted sum. The output, weights, raw inputs, normalized
+components, and severity bucket are all persisted so historical rows
+remain auditable.
+
+Public surface:
+    DEFAULT_WEIGHTS, DEFAULT_THRESHOLDS, REFERENCE_VALUES
+    CompoundingInputs, CompoundingWeights, CompoundingThresholds
+    compute_compounding_risk(...)
+    severity_for(score, thresholds)
+    load_repo_complexity_delta_30d(sink, repo_id, day)   # I/O helper
+    build_compounding_risk_rows_for_day(...)             # orchestrator
+
+The core compute function is pure: no I/O, no logging side effects, no globals
+mutated. The orchestrator at the bottom is the only I/O entry point and is kept
+thin and explicit.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any, Final
+
+from dev_health_ops.metrics.schemas import CompoundingRiskDailyRecord
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Reference values used to normalize raw inputs into [0, 1].
+#: Each input ``x`` is mapped as ``clamp01(x / REF)``. These are tuning
+#: defaults — they are persisted on every row so historical rows remain
+#: inspectable even if defaults change.
+REFERENCE_VALUES: Final[dict[str, float]] = {
+    "churn_ref": 0.30,          # rework_churn_ratio of 0.30 == saturation
+    "complexity_ref": 0.20,     # 20% rise in cyclomatic_per_kloc == saturation
+    "review_ref": 48.0,         # 48h pr_first_review_p90_hours == saturation
+}
+
+
+@dataclass(frozen=True)
+class CompoundingWeights:
+    """Weights for the four normalized components. Must sum to 1.0."""
+
+    churn: float = 0.30
+    complexity: float = 0.30
+    ownership: float = 0.20
+    review: float = 0.20
+
+    def __post_init__(self) -> None:
+        total = self.churn + self.complexity + self.ownership + self.review
+        # Allow tiny float drift but reject anything materially off.
+        if abs(total - 1.0) > 1e-9:
+            raise ValueError(
+                f"CompoundingWeights must sum to 1.0, got {total!r}"
+            )
+
+
+@dataclass(frozen=True)
+class CompoundingThresholds:
+    """Severity bucket boundaries (inclusive at the lower edge).
+
+    score < elevated  -> low
+    elevated <= score < high -> elevated
+    score >= high     -> high
+    score is None     -> unknown
+    """
+
+    elevated: float = 0.40
+    high: float = 0.65
+
+    def __post_init__(self) -> None:
+        if not (0.0 <= self.elevated <= self.high <= 1.0):
+            raise ValueError(
+                "CompoundingThresholds must satisfy 0 <= elevated <= high <= 1, "
+                f"got elevated={self.elevated} high={self.high}"
+            )
+
+
+DEFAULT_WEIGHTS: Final[CompoundingWeights] = CompoundingWeights()
+DEFAULT_THRESHOLDS: Final[CompoundingThresholds] = CompoundingThresholds()
+
+
+# ---------------------------------------------------------------------------
+# Inputs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CompoundingInputs:
+    """Raw inputs consumed by the composite.
+
+    ``None`` on any *required* field (churn / complexity_delta /
+    review_latency_p90h, plus at least one ownership signal) causes the
+    score to be ``None``. Data unavailable is **not** zero risk.
+    """
+
+    rework_churn: float | None
+    complexity_delta: float | None
+    review_latency_p90h: float | None
+    # Ownership inputs — use max(single_owner_ratio, ownership_gini) as the
+    # concentration norm. Either alone is acceptable; both None blocks the
+    # ownership component (and therefore the composite).
+    single_owner_ratio: float | None = None
+    ownership_gini: float | None = None
+    # Pure metadata, not part of the formula, surfaced for inspectability.
+    bus_factor: float | None = None
+
+    def has_required_inputs(self) -> bool:
+        if self.rework_churn is None:
+            return False
+        if self.complexity_delta is None:
+            return False
+        if self.review_latency_p90h is None:
+            return False
+        if self.single_owner_ratio is None and self.ownership_gini is None:
+            return False
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _clamp01(value: float) -> float:
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return value
+
+
+def _normalize_churn(rework_churn: float | None, *, ref: float) -> float | None:
+    if rework_churn is None:
+        return None
+    return _clamp01(max(0.0, rework_churn) / ref)
+
+
+def _normalize_complexity(delta: float | None, *, ref: float) -> float | None:
+    """Falling complexity is *not* risk. Clamp negatives to 0 first."""
+    if delta is None:
+        return None
+    return _clamp01(max(0.0, delta) / ref)
+
+
+def _normalize_ownership(
+    single_owner_ratio: float | None,
+    ownership_gini: float | None,
+) -> float | None:
+    """Concentration norm = max(single_owner_ratio, gini). Already in [0,1]."""
+    candidates = [
+        v for v in (single_owner_ratio, ownership_gini) if v is not None
+    ]
+    if not candidates:
+        return None
+    return _clamp01(max(candidates))
+
+
+def _normalize_review(latency_hours: float | None, *, ref: float) -> float | None:
+    if latency_hours is None:
+        return None
+    return _clamp01(max(0.0, latency_hours) / ref)
+
+
+def severity_for(
+    score: float | None,
+    thresholds: CompoundingThresholds = DEFAULT_THRESHOLDS,
+) -> str:
+    if score is None:
+        return "unknown"
+    if score >= thresholds.high:
+        return "high"
+    if score >= thresholds.elevated:
+        return "elevated"
+    return "low"
+
+
+# ---------------------------------------------------------------------------
+# Public compute
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _NormalizedComponents:
+    churn_norm: float | None
+    complexity_norm: float | None
+    ownership_norm: float | None
+    review_norm: float | None
+
+
+def _normalize_all(
+    inputs: CompoundingInputs,
+    refs: dict[str, float],
+) -> _NormalizedComponents:
+    return _NormalizedComponents(
+        churn_norm=_normalize_churn(inputs.rework_churn, ref=refs["churn_ref"]),
+        complexity_norm=_normalize_complexity(
+            inputs.complexity_delta, ref=refs["complexity_ref"]
+        ),
+        ownership_norm=_normalize_ownership(
+            inputs.single_owner_ratio, inputs.ownership_gini
+        ),
+        review_norm=_normalize_review(
+            inputs.review_latency_p90h, ref=refs["review_ref"]
+        ),
+    )
+
+
+def compute_compounding_risk(
+    *,
+    day: date,
+    scope: str,
+    scope_id: str,
+    org_id: str,
+    inputs: CompoundingInputs,
+    computed_at: datetime,
+    weights: CompoundingWeights = DEFAULT_WEIGHTS,
+    thresholds: CompoundingThresholds = DEFAULT_THRESHOLDS,
+    refs: dict[str, float] | None = None,
+) -> CompoundingRiskDailyRecord:
+    """Compute one Compounding Risk row.
+
+    The function always returns a row. The row's ``compounding_risk`` is
+    ``None`` (severity ``unknown``) when any required input is missing —
+    the row is still persisted so absence-of-signal is itself inspectable.
+
+    Args:
+        day: The day this score is computed *for* (not the compute moment).
+        scope: ``"repo"`` or ``"team"``.
+        scope_id: Repo id (uuid str) or team id.
+        org_id: Org id for partitioning.
+        inputs: Raw signal values.
+        computed_at: Compute moment in UTC. Passed explicitly for determinism.
+        weights: Default weights or an override (must sum to 1).
+        thresholds: Severity bucket boundaries.
+        refs: Reference normalization values; defaults to ``REFERENCE_VALUES``.
+
+    Returns:
+        A ``CompoundingRiskDailyRecord`` ready for the sink.
+    """
+    if scope not in ("repo", "team"):
+        raise ValueError(f"scope must be 'repo' or 'team', got {scope!r}")
+
+    resolved_refs = refs if refs is not None else REFERENCE_VALUES
+
+    components = _normalize_all(inputs, resolved_refs)
+
+    score: float | None
+    if inputs.has_required_inputs():
+        # All four normalized components are non-None here (required-input
+        # gate covers each of them).
+        assert components.churn_norm is not None
+        assert components.complexity_norm is not None
+        assert components.ownership_norm is not None
+        assert components.review_norm is not None
+
+        score = (
+            weights.churn * components.churn_norm
+            + weights.complexity * components.complexity_norm
+            + weights.ownership * components.ownership_norm
+            + weights.review * components.review_norm
+        )
+        # Floating-point housekeeping: snap to [0, 1] in case of drift.
+        score = _clamp01(score)
+    else:
+        score = None
+
+    return CompoundingRiskDailyRecord(
+        day=day,
+        scope=scope,
+        scope_id=scope_id,
+        compounding_risk=score,
+        severity=severity_for(score, thresholds),
+        churn_norm=components.churn_norm,
+        complexity_norm=components.complexity_norm,
+        ownership_norm=components.ownership_norm,
+        review_norm=components.review_norm,
+        rework_churn=inputs.rework_churn,
+        complexity_delta=inputs.complexity_delta,
+        bus_factor=inputs.bus_factor,
+        ownership_gini=inputs.ownership_gini,
+        single_owner_ratio=inputs.single_owner_ratio,
+        review_latency_p90h=inputs.review_latency_p90h,
+        w_churn=weights.churn,
+        w_complexity=weights.complexity,
+        w_ownership=weights.ownership,
+        w_review=weights.review,
+        threshold_elevated=thresholds.elevated,
+        threshold_high=thresholds.high,
+        computed_at=computed_at,
+        org_id=org_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers and orchestrator (CHAOS-1641 wiring into job_daily)
+# ---------------------------------------------------------------------------
+
+#: Window for the complexity delta computation in days.
+COMPLEXITY_WINDOW_DAYS: Final[int] = 30
+
+
+def load_repo_complexity_delta_30d(
+    sink: Any,
+    *,
+    repo_id: str,
+    day: date,
+    org_id: str,
+    window_days: int = COMPLEXITY_WINDOW_DAYS,
+) -> float | None:
+    """Return relative change in ``cyclomatic_per_kloc`` for a repo over the window.
+
+    Reads from ``repo_complexity_daily`` via the sink's ``query_dicts``.
+    Returns ``None`` if there is no data on either side of the window midpoint.
+
+    Formula: ``(second_half_avg - first_half_avg) / max(first_half_avg, 1.0)``.
+    The ``max(..., 1.0)`` keeps the denominator stable for low-LOC repos.
+    """
+    if window_days < 2:
+        raise ValueError("window_days must be >= 2")
+
+    window_start = day - timedelta(days=window_days - 1)
+    midpoint = window_start + timedelta(days=window_days // 2)
+
+    query = """
+        SELECT
+            avg(if(day < {mid:Date}, cpk, NULL)) AS first_half,
+            avg(if(day >= {mid:Date}, cpk, NULL)) AS second_half
+        FROM (
+            SELECT day, argMax(cyclomatic_per_kloc, computed_at) AS cpk
+            FROM repo_complexity_daily
+            WHERE repo_id = {repo_id:UUID}
+              AND day >= {start:Date} AND day <= {end:Date}
+              AND org_id = {org_id:String}
+            GROUP BY day
+        )
+    """
+    params = {
+        "repo_id": str(repo_id),
+        "start": window_start,
+        "mid": midpoint,
+        "end": day,
+        "org_id": org_id,
+    }
+
+    rows = sink.query_dicts(query, params)
+    if not rows:
+        return None
+    first = rows[0].get("first_half")
+    second = rows[0].get("second_half")
+    if first is None or second is None:
+        return None
+    first_f = float(first)
+    second_f = float(second)
+    return (second_f - first_f) / max(first_f, 1.0)
+
+
+def build_compounding_risk_rows_for_day(
+    *,
+    sink: Any,
+    day: date,
+    org_id: str,
+    repo_metrics_rows: Iterable[Any],
+    computed_at: datetime,
+    weights: CompoundingWeights = DEFAULT_WEIGHTS,
+    thresholds: CompoundingThresholds = DEFAULT_THRESHOLDS,
+    repo_to_team: dict[str, str] | None = None,
+) -> list[CompoundingRiskDailyRecord]:
+    """Compose Compounding Risk rows for every repo (and optionally team).
+
+    Args:
+        sink: ClickHouse sink (read-only for the complexity delta).
+        day: Compute target day.
+        org_id: Org id (also injected into the complexity query).
+        repo_metrics_rows: In-memory repo_metrics rows that were just persisted.
+        computed_at: UTC compute moment, passed explicitly for determinism.
+        weights: Composite weights.
+        thresholds: Severity bucket boundaries.
+        repo_to_team: Optional mapping ``{repo_id_str: team_id}``. When
+            provided, the function emits both ``scope='repo'`` rows and
+            ``scope='team'`` rows (one per team) by aggregating the per-repo
+            inputs. Without this map only repo rows are emitted.
+    """
+    repo_rows: list[CompoundingRiskDailyRecord] = []
+    # Capture the raw inputs alongside the persisted row so we can compose
+    # team aggregations without re-querying ClickHouse.
+    repo_inputs_for_team: dict[str, CompoundingInputs] = {}
+    for row in repo_metrics_rows:
+        repo_id = getattr(row, "repo_id", None)
+        if repo_id is None:
+            continue
+        complexity_delta = load_repo_complexity_delta_30d(
+            sink, repo_id=str(repo_id), day=day, org_id=org_id
+        )
+        inputs = CompoundingInputs(
+            rework_churn=_nullable_float(getattr(row, "rework_churn_ratio_30d", None)),
+            complexity_delta=complexity_delta,
+            review_latency_p90h=_nullable_float(
+                getattr(row, "pr_first_review_p90_hours", None)
+            ),
+            single_owner_ratio=_nullable_float(
+                getattr(row, "single_owner_file_ratio_30d", None)
+            ),
+            ownership_gini=_nullable_float(getattr(row, "code_ownership_gini", None)),
+            bus_factor=_nullable_float(getattr(row, "bus_factor", None)),
+        )
+        repo_inputs_for_team[str(repo_id)] = inputs
+        repo_rows.append(
+            compute_compounding_risk(
+                day=day,
+                scope="repo",
+                scope_id=str(repo_id),
+                org_id=org_id,
+                inputs=inputs,
+                computed_at=computed_at,
+                weights=weights,
+                thresholds=thresholds,
+            )
+        )
+
+    if not repo_to_team:
+        return repo_rows
+
+    team_rows = _build_team_rows(
+        day=day,
+        org_id=org_id,
+        repo_inputs=repo_inputs_for_team,
+        repo_to_team=repo_to_team,
+        computed_at=computed_at,
+        weights=weights,
+        thresholds=thresholds,
+    )
+    return repo_rows + team_rows
+
+
+def _mean_or_none(values: list[float | None]) -> float | None:
+    nums = [v for v in values if v is not None]
+    if not nums:
+        return None
+    return sum(nums) / len(nums)
+
+
+def _build_team_rows(
+    *,
+    day: date,
+    org_id: str,
+    repo_inputs: dict[str, CompoundingInputs],
+    repo_to_team: dict[str, str],
+    computed_at: datetime,
+    weights: CompoundingWeights,
+    thresholds: CompoundingThresholds,
+) -> list[CompoundingRiskDailyRecord]:
+    """Aggregate per-repo inputs into one row per team.
+
+    Strategy: unweighted mean of each *raw input* across the team's repos,
+    then feed the means into the same ``compute_compounding_risk`` so the
+    score is computed under the same formula as the repo rows. This keeps
+    the team score auditable in the same way as repo rows.
+    """
+    by_team: dict[str, list[CompoundingInputs]] = {}
+    for repo_id, inputs in repo_inputs.items():
+        team_id = repo_to_team.get(repo_id)
+        if not team_id:
+            continue
+        by_team.setdefault(team_id, []).append(inputs)
+
+    out: list[CompoundingRiskDailyRecord] = []
+    for team_id, all_inputs in by_team.items():
+        team_inputs = CompoundingInputs(
+            rework_churn=_mean_or_none([i.rework_churn for i in all_inputs]),
+            complexity_delta=_mean_or_none([i.complexity_delta for i in all_inputs]),
+            review_latency_p90h=_mean_or_none(
+                [i.review_latency_p90h for i in all_inputs]
+            ),
+            single_owner_ratio=_mean_or_none(
+                [i.single_owner_ratio for i in all_inputs]
+            ),
+            ownership_gini=_mean_or_none([i.ownership_gini for i in all_inputs]),
+            bus_factor=_mean_or_none([i.bus_factor for i in all_inputs]),
+        )
+        out.append(
+            compute_compounding_risk(
+                day=day,
+                scope="team",
+                scope_id=team_id,
+                org_id=org_id,
+                inputs=team_inputs,
+                computed_at=computed_at,
+                weights=weights,
+                thresholds=thresholds,
+            )
+        )
+    return out
+
+
+def _nullable_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = [
+    "COMPLEXITY_WINDOW_DAYS",
+    "CompoundingInputs",
+    "CompoundingThresholds",
+    "CompoundingWeights",
+    "DEFAULT_THRESHOLDS",
+    "DEFAULT_WEIGHTS",
+    "REFERENCE_VALUES",
+    "build_compounding_risk_rows_for_day",
+    "compute_compounding_risk",
+    "load_repo_complexity_delta_30d",
+    "severity_for",
+]

--- a/src/dev_health_ops/metrics/compounding_risk.py
+++ b/src/dev_health_ops/metrics/compounding_risk.py
@@ -44,9 +44,9 @@ from dev_health_ops.metrics.schemas import CompoundingRiskDailyRecord
 #: defaults — they are persisted on every row so historical rows remain
 #: inspectable even if defaults change.
 REFERENCE_VALUES: Final[dict[str, float]] = {
-    "churn_ref": 0.30,          # rework_churn_ratio of 0.30 == saturation
-    "complexity_ref": 0.20,     # 20% rise in cyclomatic_per_kloc == saturation
-    "review_ref": 48.0,         # 48h pr_first_review_p90_hours == saturation
+    "churn_ref": 0.30,  # rework_churn_ratio of 0.30 == saturation
+    "complexity_ref": 0.20,  # 20% rise in cyclomatic_per_kloc == saturation
+    "review_ref": 48.0,  # 48h pr_first_review_p90_hours == saturation
 }
 
 
@@ -63,9 +63,7 @@ class CompoundingWeights:
         total = self.churn + self.complexity + self.ownership + self.review
         # Allow tiny float drift but reject anything materially off.
         if abs(total - 1.0) > 1e-9:
-            raise ValueError(
-                f"CompoundingWeights must sum to 1.0, got {total!r}"
-            )
+            raise ValueError(f"CompoundingWeights must sum to 1.0, got {total!r}")
 
 
 @dataclass(frozen=True)
@@ -161,9 +159,7 @@ def _normalize_ownership(
     ownership_gini: float | None,
 ) -> float | None:
     """Concentration norm = max(single_owner_ratio, gini). Already in [0,1]."""
-    candidates = [
-        v for v in (single_owner_ratio, ownership_gini) if v is not None
-    ]
+    candidates = [v for v in (single_owner_ratio, ownership_gini) if v is not None]
     if not candidates:
         return None
     return _clamp01(max(candidates))

--- a/src/dev_health_ops/metrics/job_compounding_risk.py
+++ b/src/dev_health_ops/metrics/job_compounding_risk.py
@@ -1,0 +1,211 @@
+"""Standalone CLI job for Compounding Risk (CHAOS-1641).
+
+Backfills or recomputes ``compounding_risk_daily`` rows for one or more days
+WITHOUT re-running the full ``dev-hops metrics daily`` pipeline. Reads the
+already-persisted ``repo_metrics_daily`` + ``repo_complexity_daily`` rows
+and emits one row per repo (and per team) per day.
+
+Usage:
+    dev-hops metrics compounding-risk --org ORG [--day YYYY-MM-DD] [--backfill N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+from dev_health_ops.db import resolve_sink_uri
+from dev_health_ops.metrics.compounding_risk import (
+    build_compounding_risk_rows_for_day,
+)
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.providers.teams import build_repo_pattern_resolver
+from dev_health_ops.storage import detect_db_type
+
+logger = logging.getLogger(__name__)
+
+
+def _date_range(end_day: date, backfill_days: int) -> list[date]:
+    if backfill_days <= 0:
+        return [end_day]
+    return [end_day - timedelta(days=i) for i in range(backfill_days, -1, -1)]
+
+
+def _fetch_repo_metrics_for_day(
+    sink: Any, org_id: str, day: date
+) -> list[Any]:
+    """Read the latest ``repo_metrics_daily`` rows for ``day`` as plain dicts.
+
+    Returned objects are duck-typed enough to satisfy
+    ``build_compounding_risk_rows_for_day`` — it only reads attributes via
+    ``getattr(row, name, None)``.
+    """
+
+    class _Row:
+        __slots__ = (
+            "repo_id",
+            "rework_churn_ratio_30d",
+            "single_owner_file_ratio_30d",
+            "code_ownership_gini",
+            "bus_factor",
+            "pr_first_review_p90_hours",
+        )
+
+        def __init__(self, d: dict[str, Any]) -> None:
+            self.repo_id = d.get("repo_id")
+            self.rework_churn_ratio_30d = d.get("rework_churn_ratio_30d")
+            self.single_owner_file_ratio_30d = d.get(
+                "single_owner_file_ratio_30d"
+            )
+            self.code_ownership_gini = d.get("code_ownership_gini")
+            self.bus_factor = d.get("bus_factor")
+            self.pr_first_review_p90_hours = d.get(
+                "pr_first_review_p90_hours"
+            )
+
+    query = """
+        SELECT
+            repo_id,
+            argMax(rework_churn_ratio_30d,    computed_at) AS rework_churn_ratio_30d,
+            argMax(single_owner_file_ratio_30d, computed_at) AS single_owner_file_ratio_30d,
+            argMax(code_ownership_gini,       computed_at) AS code_ownership_gini,
+            argMax(bus_factor,                computed_at) AS bus_factor,
+            argMax(pr_first_review_p90_hours, computed_at) AS pr_first_review_p90_hours
+        FROM repo_metrics_daily
+        WHERE org_id = {org_id:String} AND day = {day:Date}
+        GROUP BY repo_id
+    """
+    raw = sink.query_dicts(query, {"org_id": org_id, "day": day})
+    return [_Row(r) for r in raw]
+
+
+async def _load_repo_to_team(sink: Any, org_id: str) -> dict[str, str]:
+    """Build a ``{repo_id_str: team_id}`` map via the existing teams resolver."""
+    try:
+        teams = await sink.get_all_teams()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Could not load teams for compounding risk: %s", exc)
+        return {}
+    resolver = build_repo_pattern_resolver(teams or [])
+
+    repos = sink.query_dicts(
+        """
+        SELECT toString(repo_id) AS repo_id, full_name
+        FROM repos
+        WHERE org_id = {org_id:String}
+        """,
+        {"org_id": org_id},
+    )
+    mapping: dict[str, str] = {}
+    for row in repos:
+        team_id, _ = resolver.resolve(row.get("full_name"))
+        if team_id:
+            mapping[row["repo_id"]] = team_id
+    return mapping
+
+
+async def run_compounding_risk_job(
+    *,
+    db_url: str,
+    day: date,
+    backfill_days: int,
+    org_id: str,
+) -> int:
+    """Recompute and persist ``compounding_risk_daily`` for the date range."""
+    if not org_id:
+        raise ValueError("--org is required for compounding-risk")
+    if not db_url:
+        raise ValueError("Database URI is required (set CLICKHOUSE_URI).")
+    backend = detect_db_type(db_url)
+    if backend != "clickhouse":
+        raise ValueError(
+            f"Unsupported backend '{backend}'. ClickHouse only (CHAOS-641)."
+        )
+
+    sink = ClickHouseMetricsSink(db_url)
+    setattr(sink, "org_id", org_id)
+    if hasattr(sink, "ensure_tables"):
+        sink.ensure_tables()
+
+    repo_to_team = await _load_repo_to_team(sink, org_id)
+    computed_at = datetime.now(timezone.utc)
+
+    total_rows = 0
+    for d in _date_range(day, backfill_days):
+        repo_rows = _fetch_repo_metrics_for_day(sink, org_id, d)
+        if not repo_rows:
+            logger.info(
+                "compounding-risk: no repo_metrics_daily rows for day=%s org_id=%s",
+                d.isoformat(),
+                org_id,
+            )
+            continue
+        rows = build_compounding_risk_rows_for_day(
+            sink=sink,
+            day=d,
+            org_id=org_id,
+            repo_metrics_rows=repo_rows,
+            computed_at=computed_at,
+            repo_to_team=repo_to_team or None,
+        )
+        if rows:
+            sink.write_compounding_risk_daily(rows)
+            total_rows += len(rows)
+            logger.info(
+                "compounding-risk: wrote %d rows for day=%s (repos=%d, teams=%d)",
+                len(rows),
+                d.isoformat(),
+                sum(1 for r in rows if r.scope == "repo"),
+                sum(1 for r in rows if r.scope == "team"),
+            )
+
+    logger.info(
+        "compounding-risk: done, %d rows written across %d day(s)",
+        total_rows,
+        backfill_days + 1,
+    )
+    return 0
+
+
+def register_commands(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser(
+        "compounding-risk",
+        help="Compute the Compounding Risk composite from persisted inputs.",
+        description=(
+            "Reads repo_metrics_daily + repo_complexity_daily for the "
+            "given day range and writes compounding_risk_daily."
+        ),
+    )
+    p.add_argument(
+        "--day",
+        type=lambda s: date.fromisoformat(s),
+        default=None,
+        help="Target day (UTC). Defaults to today.",
+    )
+    p.add_argument(
+        "--backfill",
+        type=int,
+        default=0,
+        dest="backfill_days",
+        help="Additional days to backfill (inclusive). Default 0.",
+    )
+    p.set_defaults(func=_cmd_compounding_risk)
+
+
+async def _cmd_compounding_risk(ns: argparse.Namespace) -> int:
+    try:
+        db_url = resolve_sink_uri(ns)
+        day = ns.day or datetime.now(timezone.utc).date()
+        org_id = getattr(ns, "org", None) or os.getenv("ORG_ID") or ""
+        return await run_compounding_risk_job(
+            db_url=db_url,
+            day=day,
+            backfill_days=int(ns.backfill_days or 0),
+            org_id=org_id,
+        )
+    except Exception as exc:
+        logger.error("compounding-risk job failed: %s", exc)
+        return 1

--- a/src/dev_health_ops/metrics/job_compounding_risk.py
+++ b/src/dev_health_ops/metrics/job_compounding_risk.py
@@ -34,9 +34,7 @@ def _date_range(end_day: date, backfill_days: int) -> list[date]:
     return [end_day - timedelta(days=i) for i in range(backfill_days, -1, -1)]
 
 
-def _fetch_repo_metrics_for_day(
-    sink: Any, org_id: str, day: date
-) -> list[Any]:
+def _fetch_repo_metrics_for_day(sink: Any, org_id: str, day: date) -> list[Any]:
     """Read the latest ``repo_metrics_daily`` rows for ``day`` as plain dicts.
 
     Returned objects are duck-typed enough to satisfy
@@ -57,14 +55,10 @@ def _fetch_repo_metrics_for_day(
         def __init__(self, d: dict[str, Any]) -> None:
             self.repo_id = d.get("repo_id")
             self.rework_churn_ratio_30d = d.get("rework_churn_ratio_30d")
-            self.single_owner_file_ratio_30d = d.get(
-                "single_owner_file_ratio_30d"
-            )
+            self.single_owner_file_ratio_30d = d.get("single_owner_file_ratio_30d")
             self.code_ownership_gini = d.get("code_ownership_gini")
             self.bus_factor = d.get("bus_factor")
-            self.pr_first_review_p90_hours = d.get(
-                "pr_first_review_p90_hours"
-            )
+            self.pr_first_review_p90_hours = d.get("pr_first_review_p90_hours")
 
     query = """
         SELECT

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -14,6 +14,7 @@ from dev_health_ops.audit.ai_governance.loaders import build_governance_rows_for
 from dev_health_ops.db import resolve_sink_uri
 from dev_health_ops.metrics.ai_impact import compute_ai_impact_metrics_daily
 from dev_health_ops.metrics.benchmarking.runner import run_benchmarking_for_day
+from dev_health_ops.metrics.compounding_risk import build_compounding_risk_rows_for_day
 from dev_health_ops.metrics.compute import compute_daily_metrics
 from dev_health_ops.metrics.compute_cicd import compute_cicd_metrics_daily
 from dev_health_ops.metrics.compute_deployments import compute_deploy_metrics_daily
@@ -475,6 +476,38 @@ async def run_daily_metrics_job(
                 s.write_ai_impact_metrics(ai_impact_metrics)
             if all_file_metrics:
                 s.write_file_metrics(all_file_metrics)
+
+        # Compounding Risk composite (CHAOS-1641). Computed AFTER
+        # ``write_repo_metrics`` so the inputs are persisted, then read
+        # back as needed (complexity delta) by the orchestrator.  Team
+        # rows are aggregated from the repo inputs using the
+        # ``repo_team_resolver`` already in scope.
+        repo_to_team_map: dict[str, str] = {}
+        try:
+            for row in result.repo_metrics:
+                repo_id = getattr(row, "repo_id", None)
+                if repo_id is None:
+                    continue
+                full_name = repo_names_by_id.get(repo_id)
+                if not full_name:
+                    continue
+                team_id, _ = repo_team_resolver.resolve(full_name)
+                if team_id:
+                    repo_to_team_map[str(repo_id)] = team_id
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("repo_team_resolver failed for compounding risk: %s", exc)
+
+        compounding_rows = build_compounding_risk_rows_for_day(
+            sink=primary_sink,
+            day=d,
+            org_id=org_id,
+            repo_metrics_rows=result.repo_metrics,
+            computed_at=computed_at,
+            repo_to_team=repo_to_team_map or None,
+        )
+        if compounding_rows:
+            for s in sinks:
+                s.write_compounding_risk_daily(compounding_rows)
 
         # TestOps risk metrics (release confidence, quality drag, pipeline stability)
         release_conf = compute_release_confidence(

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -485,15 +485,19 @@ async def run_daily_metrics_job(
         repo_to_team_map: dict[str, str] = {}
         try:
             for row in result.repo_metrics:
-                repo_id = getattr(row, "repo_id", None)
-                if repo_id is None:
+                # NOTE: use a distinct name here — the function parameter
+                # ``repo_id`` is reused later in the loop iteration
+                # (e.g. by load_testops_pipeline_data) and must stay None
+                # when the daily job was invoked without a per-repo filter.
+                row_repo_id = getattr(row, "repo_id", None)
+                if row_repo_id is None:
                     continue
-                full_name = repo_names_by_id.get(repo_id)
+                full_name = repo_names_by_id.get(row_repo_id)
                 if not full_name:
                     continue
                 team_id, _ = repo_team_resolver.resolve(full_name)
                 if team_id:
-                    repo_to_team_map[str(repo_id)] = team_id
+                    repo_to_team_map[str(row_repo_id)] = team_id
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning("repo_team_resolver failed for compounding risk: %s", exc)
 

--- a/src/dev_health_ops/metrics/schemas.py
+++ b/src/dev_health_ops/metrics/schemas.py
@@ -500,12 +500,12 @@ class CompoundingRiskDailyRecord:
     """
 
     day: date
-    scope: str                       # 'repo' | 'team'
-    scope_id: str                    # repo_id (uuid str) or team_id
+    scope: str  # 'repo' | 'team'
+    scope_id: str  # repo_id (uuid str) or team_id
 
     # composite
-    compounding_risk: float | None   # 0..1, None when any required input missing
-    severity: str                    # 'unknown' | 'low' | 'elevated' | 'high'
+    compounding_risk: float | None  # 0..1, None when any required input missing
+    severity: str  # 'unknown' | 'low' | 'elevated' | 'high'
 
     # normalized components (0..1, None when input missing)
     churn_norm: float | None

--- a/src/dev_health_ops/metrics/schemas.py
+++ b/src/dev_health_ops/metrics/schemas.py
@@ -492,6 +492,48 @@ class FileHotspotDaily:
 
 
 @dataclass(frozen=True)
+class CompoundingRiskDailyRecord:
+    """One row per (org_id, day, scope, scope_id) of the composite risk score.
+
+    Persisted append-only into ``compounding_risk_daily`` (CHAOS-1641).
+    Read latest with ``argMax(<col>, computed_at)``.
+    """
+
+    day: date
+    scope: str                       # 'repo' | 'team'
+    scope_id: str                    # repo_id (uuid str) or team_id
+
+    # composite
+    compounding_risk: float | None   # 0..1, None when any required input missing
+    severity: str                    # 'unknown' | 'low' | 'elevated' | 'high'
+
+    # normalized components (0..1, None when input missing)
+    churn_norm: float | None
+    complexity_norm: float | None
+    ownership_norm: float | None
+    review_norm: float | None
+
+    # raw inputs (for inspectability)
+    rework_churn: float | None
+    complexity_delta: float | None
+    bus_factor: float | None
+    ownership_gini: float | None
+    single_owner_ratio: float | None
+    review_latency_p90h: float | None
+
+    # weights and thresholds in force at compute time (audit trail)
+    w_churn: float
+    w_complexity: float
+    w_ownership: float
+    w_review: float
+    threshold_elevated: float
+    threshold_high: float
+
+    computed_at: datetime
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
 class InvestmentClassificationRecord:
     repo_id: uuid.UUID | None
     day: date

--- a/src/dev_health_ops/metrics/sinks/base.py
+++ b/src/dev_health_ops/metrics/sinks/base.py
@@ -467,3 +467,16 @@ class BaseMetricsSink(ABC):
         ``RecommendationsMixin``.
         """
         pass
+
+    # -------------------------------------------------------------------------
+    # Compounding Risk (CHAOS-1641)
+    # -------------------------------------------------------------------------
+
+    def write_compounding_risk_daily(self, rows: Sequence[Any]) -> None:
+        """Write Compounding Risk composite rows to ``compounding_risk_daily``.
+
+        Default implementation is a no-op so existing sink subclasses that
+        have not yet been updated continue to work.  Override in
+        ``CompoundingRiskMixin``.
+        """
+        pass

--- a/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
@@ -17,6 +17,7 @@ each responsible for one table family:
   AIAttributionMixin        — AI attribution records (ai_attribution table)
   AIImpactMixin             — AI workflow impact daily rollups
   RecommendationsMixin      — recommendations_daily (CHAOS-1622)
+  CompoundingRiskMixin      — compounding_risk_daily (CHAOS-1641)
 
 Public API (stable — do not remove):
     from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
@@ -42,6 +43,9 @@ from dev_health_ops.metrics.sinks.clickhouse.ai_governance import AIGovernanceMi
 from dev_health_ops.metrics.sinks.clickhouse.ai_impact import AIImpactMixin
 from dev_health_ops.metrics.sinks.clickhouse.ai_workflow import AIWorkflowMixin
 from dev_health_ops.metrics.sinks.clickhouse.ci import CIMixin
+from dev_health_ops.metrics.sinks.clickhouse.compounding_risk import (
+    CompoundingRiskMixin,
+)
 from dev_health_ops.metrics.sinks.clickhouse.core import ClickHouseCore
 from dev_health_ops.metrics.sinks.clickhouse.dora import DoraMixin
 from dev_health_ops.metrics.sinks.clickhouse.investment import InvestmentMixin
@@ -59,6 +63,7 @@ class ClickHouseMetricsSink(
     AIImpactMixin,
     CIMixin,
     RecommendationsMixin,
+    CompoundingRiskMixin,
     DoraMixin,
     WellbeingMixin,
     InvestmentMixin,

--- a/src/dev_health_ops/metrics/sinks/clickhouse/compounding_risk.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/compounding_risk.py
@@ -1,0 +1,71 @@
+"""CompoundingRiskMixin — write method for ``compounding_risk_daily`` (CHAOS-1641).
+
+Table: ``compounding_risk_daily``
+Engine: MergeTree (append-only; read latest with ``argMax(<col>, computed_at)``)
+
+The composite is computed elsewhere in
+``dev_health_ops.metrics.compounding_risk``; this mixin only persists rows.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from dev_health_ops.metrics.schemas import CompoundingRiskDailyRecord
+
+if TYPE_CHECKING:
+    from dev_health_ops.metrics.sinks.clickhouse._insert import _ClickHouseSinkBase
+else:
+
+    class _ClickHouseSinkBase:
+        pass
+
+
+logger = logging.getLogger(__name__)
+
+
+class CompoundingRiskMixin(_ClickHouseSinkBase):
+    """Write methods for ``compounding_risk_daily``."""
+
+    def write_compounding_risk_daily(
+        self, rows: Sequence[CompoundingRiskDailyRecord]
+    ) -> None:
+        """Append rows to ``compounding_risk_daily``.
+
+        Append-only: re-running for the same ``(org_id, day, scope, scope_id)``
+        produces new rows with a newer ``computed_at``. Use
+        ``argMax(<col>, computed_at)`` in read queries.
+        """
+        if not rows:
+            return
+        self._insert_rows(
+            "compounding_risk_daily",
+            [
+                "org_id",
+                "day",
+                "scope",
+                "scope_id",
+                "compounding_risk",
+                "severity",
+                "churn_norm",
+                "complexity_norm",
+                "ownership_norm",
+                "review_norm",
+                "rework_churn",
+                "complexity_delta",
+                "bus_factor",
+                "ownership_gini",
+                "single_owner_ratio",
+                "review_latency_p90h",
+                "w_churn",
+                "w_complexity",
+                "w_ownership",
+                "w_review",
+                "threshold_elevated",
+                "threshold_high",
+                "computed_at",
+            ],
+            rows,
+        )

--- a/src/dev_health_ops/migrations/clickhouse/040_compounding_risk_daily.sql
+++ b/src/dev_health_ops/migrations/clickhouse/040_compounding_risk_daily.sql
@@ -8,7 +8,7 @@
 --   ownership   (max of single_owner_file_ratio_30d, code_ownership_gini)
 --   review      (review-latency p90 hours (pr_first_review_p90_hours), normalized against REVIEW_REF)
 --
--- One row per (org_id, day, scope, scope_id) per computed_at. Append-only;
+-- One row per (org_id, day, scope, scope_id) per computed_at. Append-only,
 -- read latest with `argMax(..., computed_at)`.
 --
 -- Inspectability: raw inputs, normalized components, weights actually used,
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS compounding_risk_daily
     w_ownership         Float64,
     w_review            Float64,
 
-    -- severity thresholds used (audit trail; historical rows stay bucketed
+    -- severity thresholds used (audit trail — historical rows stay bucketed
     -- under the thresholds in force at compute time)
     threshold_elevated  Float64,
     threshold_high      Float64,

--- a/src/dev_health_ops/migrations/clickhouse/040_compounding_risk_daily.sql
+++ b/src/dev_health_ops/migrations/clickhouse/040_compounding_risk_daily.sql
@@ -1,0 +1,58 @@
+-- Migration 040: compounding_risk_daily — append-only composite risk score.
+--
+-- CHAOS-1641 (Define + compute Compounding Risk composite)
+--
+-- Combines four normalized signals from existing daily tables:
+--   churn       (rework_churn_ratio_30d)
+--   complexity  (cyclomatic_per_kloc delta over the window)
+--   ownership   (max of single_owner_file_ratio_30d, code_ownership_gini)
+--   review      (review-latency p90 hours (pr_first_review_p90_hours), normalized against REVIEW_REF)
+--
+-- One row per (org_id, day, scope, scope_id) per computed_at. Append-only;
+-- read latest with `argMax(..., computed_at)`.
+--
+-- Inspectability: raw inputs, normalized components, weights actually used,
+-- and the severity bucket all persist alongside the composite score so
+-- historical rows remain auditable even if defaults change.
+
+CREATE TABLE IF NOT EXISTS compounding_risk_daily
+(
+    org_id              String,
+    day                 Date,
+    scope               Enum8('repo' = 1, 'team' = 2),
+    scope_id            String,
+
+    -- composite
+    compounding_risk    Nullable(Float64),                -- 0..1, NULL if any required input missing
+    severity            Enum8('unknown' = 0, 'low' = 1, 'elevated' = 2, 'high' = 3),
+
+    -- normalized components (0..1 each, NULL when underlying input missing)
+    churn_norm          Nullable(Float64),
+    complexity_norm     Nullable(Float64),
+    ownership_norm      Nullable(Float64),
+    review_norm         Nullable(Float64),
+
+    -- raw inputs (for inspectability)
+    rework_churn        Nullable(Float64),
+    complexity_delta    Nullable(Float64),
+    bus_factor          Nullable(Float64),
+    ownership_gini      Nullable(Float64),
+    single_owner_ratio  Nullable(Float64),
+    review_latency_p90h Nullable(Float64),
+
+    -- weights used (audit trail)
+    w_churn             Float64,
+    w_complexity        Float64,
+    w_ownership         Float64,
+    w_review            Float64,
+
+    -- severity thresholds used (audit trail; historical rows stay bucketed
+    -- under the thresholds in force at compute time)
+    threshold_elevated  Float64,
+    threshold_high      Float64,
+
+    computed_at         DateTime DEFAULT now()
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(day)
+ORDER BY (org_id, scope, scope_id, day, computed_at);

--- a/src/dev_health_ops/recommendations/loader.py
+++ b/src/dev_health_ops/recommendations/loader.py
@@ -294,6 +294,35 @@ class ClickHouseMetricsLoader:
 
         return complexity_delta, churn_overlap
 
+    def _load_compounding_risk_persisted(
+        self, team_id: str, ws: date, we: date
+    ) -> tuple[float | None, str | None]:
+        """Read the persisted Compounding Risk score for the team from
+        ``compounding_risk_daily`` (CHAOS-1641).
+
+        Returns ``(score, severity)`` from the latest team-scope row in the
+        window. Returns ``(None, None)`` when no row is available (e.g. the
+        backfill has not yet run), in which case the rule falls back to the
+        legacy hotspot proxy.
+        """
+        oc = self._oc()
+        params = self._p(team_id, ws, we)
+        query = f"""
+            SELECT
+                argMax(compounding_risk, computed_at) AS score,
+                argMax(severity,         computed_at) AS severity
+            FROM compounding_risk_daily
+            WHERE scope = 'team'
+              AND scope_id = %(team_id)s
+              AND day >= %(start)s AND day < %(end)s {oc}
+        """
+        rows = self._qd(query, params)
+        if not rows:
+            return None, None
+        score = _safe_float(rows[0].get("score"))
+        severity = rows[0].get("severity")
+        return score, (str(severity) if severity else None)
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -323,6 +352,11 @@ class ClickHouseMetricsLoader:
             complexity_delta, churn_overlap = self._load_compounding_signals(
                 team_id, window_start, window_end
             )
+            compounding_score, compounding_severity = (
+                self._load_compounding_risk_persisted(
+                    team_id, window_start, window_end
+                )
+            )
         finally:
             self._org_id = prev_org
 
@@ -340,6 +374,8 @@ class ClickHouseMetricsLoader:
             cycle_time_by_day=cycle_times,
             hotspot_complexity_delta=complexity_delta,
             hotspot_churn_overlap=churn_overlap,
+            compounding_risk_score=compounding_score,
+            compounding_risk_severity=compounding_severity,
         )
 
 

--- a/src/dev_health_ops/recommendations/loader.py
+++ b/src/dev_health_ops/recommendations/loader.py
@@ -353,9 +353,7 @@ class ClickHouseMetricsLoader:
                 team_id, window_start, window_end
             )
             compounding_score, compounding_severity = (
-                self._load_compounding_risk_persisted(
-                    team_id, window_start, window_end
-                )
+                self._load_compounding_risk_persisted(team_id, window_start, window_end)
             )
         finally:
             self._org_id = prev_org

--- a/src/dev_health_ops/recommendations/rules/compounding_risk.py
+++ b/src/dev_health_ops/recommendations/rules/compounding_risk.py
@@ -58,6 +58,52 @@ def evaluate_compounding_risk(
     Returns:
         A Recommendation if the rule fires, else None.
     """
+    # Preferred path (CHAOS-1641): use the persisted Compounding Risk
+    # composite when available. ``severity`` is the canonical signal.
+    if snapshot.compounding_risk_severity in ("elevated", "high"):
+        score = snapshot.compounding_risk_score
+        rationale = (
+            (
+                f"Compounding Risk score is {score:.3f} "
+                f"(severity: {snapshot.compounding_risk_severity}). "
+                "Churn, complexity trend, ownership concentration, and review "
+                "latency are compounding above their tuned thresholds."
+            )
+            if score is not None
+            else (
+                f"Compounding Risk severity is "
+                f"{snapshot.compounding_risk_severity}."
+            )
+        )
+        evidence: tuple[EvidenceRef, ...] = (
+            EvidenceRef(
+                team_id=snapshot.team_id,
+                metric_table="compounding_risk_daily",
+                window_start=snapshot.window_start,
+                window_end=snapshot.window_end,
+                field="compounding_risk",
+                value=round(score, 4) if score is not None else 0.0,
+            ),
+        )
+        return Recommendation(
+            rule_id=RULE_ID,
+            team_id=snapshot.team_id,
+            org_id=snapshot.org_id,
+            computed_at=now,
+            window_start=snapshot.window_start,
+            window_end=snapshot.window_end,
+            severity=(
+                "critical"
+                if snapshot.compounding_risk_severity == "high"
+                else "warning"
+            ),
+            title="Code risk is compounding where change pressure is highest.",
+            rationale=rationale,
+            success_criterion=SUCCESS_CRITERION,
+            evidence=evidence,
+        )
+
+    # Fallback (pre-1641 / backfill warmup): legacy hotspot proxy.
     if (
         snapshot.hotspot_complexity_delta is None
         or snapshot.hotspot_churn_overlap is None
@@ -72,7 +118,7 @@ def evaluate_compounding_risk(
     if churn_overlap < HOTSPOT_CHURN_OVERLAP_THRESHOLD:
         return None
 
-    evidence: tuple[EvidenceRef, ...] = (
+    evidence = (
         EvidenceRef(
             team_id=snapshot.team_id,
             metric_table="file_complexity_snapshots",

--- a/src/dev_health_ops/recommendations/rules/compounding_risk.py
+++ b/src/dev_health_ops/recommendations/rules/compounding_risk.py
@@ -70,10 +70,7 @@ def evaluate_compounding_risk(
                 "latency are compounding above their tuned thresholds."
             )
             if score is not None
-            else (
-                f"Compounding Risk severity is "
-                f"{snapshot.compounding_risk_severity}."
-            )
+            else (f"Compounding Risk severity is {snapshot.compounding_risk_severity}.")
         )
         evidence: tuple[EvidenceRef, ...] = (
             EvidenceRef(

--- a/src/dev_health_ops/recommendations/snapshot.py
+++ b/src/dev_health_ops/recommendations/snapshot.py
@@ -106,6 +106,11 @@ class MetricsSnapshot:
     # compounding-risk
     hotspot_complexity_delta: float | None
     hotspot_churn_overlap: float | None
+    # Persisted Compounding Risk composite (CHAOS-1641). When set, the
+    # ``compounding-risk`` rule consumes these instead of the legacy
+    # hotspot_complexity_delta / hotspot_churn_overlap proxy.
+    compounding_risk_score: float | None = None
+    compounding_risk_severity: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/graphql/test_compounding_risk_resolver.py
+++ b/tests/api/graphql/test_compounding_risk_resolver.py
@@ -78,9 +78,18 @@ async def test_uses_filter_day_when_provided_and_skips_latest_lookup() -> None:
         ctx.client,
         [
             _qresult(  # repo rows for the explicit day
-                ["scope_id", "score", "severity", "computed_at",
-                 "w_churn", "w_complexity", "w_ownership", "w_review",
-                 "threshold_elevated", "threshold_high"],
+                [
+                    "scope_id",
+                    "score",
+                    "severity",
+                    "computed_at",
+                    "w_churn",
+                    "w_complexity",
+                    "w_ownership",
+                    "w_review",
+                    "threshold_elevated",
+                    "threshold_high",
+                ],
                 [["repo-1", 0.5, "elevated", NOW, 0.3, 0.3, 0.2, 0.2, 0.4, 0.65]],
             ),
             _qresult([], []),  # repos label lookup
@@ -108,20 +117,47 @@ async def test_uses_filter_day_when_provided_and_skips_latest_lookup() -> None:
 async def test_repo_breakout_surfaces_full_audit_trail() -> None:
     ctx = _ctx()
     columns = [
-        "scope_id", "score", "severity",
-        "churn_norm", "complexity_norm", "ownership_norm", "review_norm",
-        "rework_churn", "complexity_delta", "bus_factor",
-        "ownership_gini", "single_owner_ratio", "review_latency_p90h",
-        "w_churn", "w_complexity", "w_ownership", "w_review",
-        "threshold_elevated", "threshold_high",
+        "scope_id",
+        "score",
+        "severity",
+        "churn_norm",
+        "complexity_norm",
+        "ownership_norm",
+        "review_norm",
+        "rework_churn",
+        "complexity_delta",
+        "bus_factor",
+        "ownership_gini",
+        "single_owner_ratio",
+        "review_latency_p90h",
+        "w_churn",
+        "w_complexity",
+        "w_ownership",
+        "w_review",
+        "threshold_elevated",
+        "threshold_high",
         "computed_at",
     ]
     repo_row = [
-        "repo-1", 0.72, "high",
-        0.8, 0.7, 0.6, 0.5,
-        0.18, 0.12, 4.0, 0.55, 0.65, 30.0,
-        0.30, 0.30, 0.20, 0.20,
-        0.40, 0.65,
+        "repo-1",
+        0.72,
+        "high",
+        0.8,
+        0.7,
+        0.6,
+        0.5,
+        0.18,
+        0.12,
+        4.0,
+        0.55,
+        0.65,
+        30.0,
+        0.30,
+        0.30,
+        0.20,
+        0.20,
+        0.40,
+        0.65,
         NOW,
     ]
     _setup_client(
@@ -150,8 +186,13 @@ async def test_repo_breakout_surfaces_full_audit_trail() -> None:
     assert row.components.complexity_delta == pytest.approx(0.12)
     assert row.components.review_latency_p90h == pytest.approx(30.0)
     # Audit trail
-    assert row.weights.churn + row.weights.complexity + row.weights.ownership + \
-        row.weights.review == pytest.approx(1.0)
+    assert (
+        row.weights.churn
+        + row.weights.complexity
+        + row.weights.ownership
+        + row.weights.review
+        == pytest.approx(1.0)
+    )
     assert row.thresholds.elevated == pytest.approx(0.40)
     assert row.thresholds.high == pytest.approx(0.65)
 
@@ -160,9 +201,16 @@ async def test_repo_breakout_surfaces_full_audit_trail() -> None:
 async def test_null_score_maps_to_unknown_severity() -> None:
     ctx = _ctx()
     columns = [
-        "scope_id", "score", "severity",
-        "w_churn", "w_complexity", "w_ownership", "w_review",
-        "threshold_elevated", "threshold_high", "computed_at",
+        "scope_id",
+        "score",
+        "severity",
+        "w_churn",
+        "w_complexity",
+        "w_ownership",
+        "w_review",
+        "threshold_elevated",
+        "threshold_high",
+        "computed_at",
     ]
     _setup_client(
         ctx.client,
@@ -191,22 +239,66 @@ async def test_null_score_maps_to_unknown_severity() -> None:
 async def test_team_breakout_averages_repos_via_repo_to_team_map() -> None:
     ctx = _ctx()
     columns = [
-        "scope_id", "score", "severity",
-        "churn_norm", "complexity_norm", "ownership_norm", "review_norm",
-        "rework_churn", "complexity_delta", "bus_factor",
-        "ownership_gini", "single_owner_ratio", "review_latency_p90h",
-        "w_churn", "w_complexity", "w_ownership", "w_review",
-        "threshold_elevated", "threshold_high", "computed_at",
+        "scope_id",
+        "score",
+        "severity",
+        "churn_norm",
+        "complexity_norm",
+        "ownership_norm",
+        "review_norm",
+        "rework_churn",
+        "complexity_delta",
+        "bus_factor",
+        "ownership_gini",
+        "single_owner_ratio",
+        "review_latency_p90h",
+        "w_churn",
+        "w_complexity",
+        "w_ownership",
+        "w_review",
+        "threshold_elevated",
+        "threshold_high",
+        "computed_at",
     ]
     base_weights = [0.30, 0.30, 0.20, 0.20]
     thresholds = [0.40, 0.65]
     rows = [
-        ["repo-1", 0.80, "high", 0.9, 0.7, 0.8, 0.6,
-         0.20, 0.15, 3.0, 0.6, 0.7, 50.0,
-         *base_weights, *thresholds, NOW],
-        ["repo-2", 0.40, "elevated", 0.5, 0.4, 0.4, 0.3,
-         0.10, 0.05, 5.0, 0.4, 0.4, 20.0,
-         *base_weights, *thresholds, NOW],
+        [
+            "repo-1",
+            0.80,
+            "high",
+            0.9,
+            0.7,
+            0.8,
+            0.6,
+            0.20,
+            0.15,
+            3.0,
+            0.6,
+            0.7,
+            50.0,
+            *base_weights,
+            *thresholds,
+            NOW,
+        ],
+        [
+            "repo-2",
+            0.40,
+            "elevated",
+            0.5,
+            0.4,
+            0.4,
+            0.3,
+            0.10,
+            0.05,
+            5.0,
+            0.4,
+            0.4,
+            20.0,
+            *base_weights,
+            *thresholds,
+            NOW,
+        ],
     ]
     teams_rows = [["team-A", "Platform", ["repo-1", "repo-2"]]]
     _setup_client(
@@ -215,15 +307,15 @@ async def test_team_breakout_averages_repos_via_repo_to_team_map() -> None:
             _qresult(["day"], [[DAY]]),
             _qresult([], []),  # team-scope query returns empty → fallback to repo agg
             _qresult(columns, rows),  # repo rows for the fallback aggregation
-            _qresult(["id", "name", "repo_patterns"], teams_rows),  # teams for repo→team map
+            _qresult(
+                ["id", "name", "repo_patterns"], teams_rows
+            ),  # teams for repo→team map
             _qresult(["day", "avg_score"], [[DAY, 0.6]]),  # trend
         ],
     )
 
     result = await resolve_compounding_risk(
-        ctx, ORG_ID, CompoundingRiskFilterInput(
-            breakout=CompoundingRiskScope.TEAM
-        )
+        ctx, ORG_ID, CompoundingRiskFilterInput(breakout=CompoundingRiskScope.TEAM)
     )
 
     assert len(result.rows) == 1
@@ -244,9 +336,16 @@ async def test_team_breakout_averages_repos_via_repo_to_team_map() -> None:
 async def test_team_breakout_filters_by_team_ids() -> None:
     ctx = _ctx()
     columns = [
-        "scope_id", "score", "severity",
-        "w_churn", "w_complexity", "w_ownership", "w_review",
-        "threshold_elevated", "threshold_high", "computed_at",
+        "scope_id",
+        "score",
+        "severity",
+        "w_churn",
+        "w_complexity",
+        "w_ownership",
+        "w_review",
+        "threshold_elevated",
+        "threshold_high",
+        "computed_at",
     ]
     base = [0.30, 0.30, 0.20, 0.20, 0.40, 0.65]
     rows = [
@@ -284,19 +383,48 @@ async def test_team_breakout_uses_persisted_team_rows_when_available() -> None:
     surfaces them directly instead of aggregating from repo rows."""
     ctx = _ctx()
     columns = [
-        "scope_id", "score", "severity",
-        "churn_norm", "complexity_norm", "ownership_norm", "review_norm",
-        "rework_churn", "complexity_delta", "bus_factor",
-        "ownership_gini", "single_owner_ratio", "review_latency_p90h",
-        "w_churn", "w_complexity", "w_ownership", "w_review",
-        "threshold_elevated", "threshold_high", "computed_at",
+        "scope_id",
+        "score",
+        "severity",
+        "churn_norm",
+        "complexity_norm",
+        "ownership_norm",
+        "review_norm",
+        "rework_churn",
+        "complexity_delta",
+        "bus_factor",
+        "ownership_gini",
+        "single_owner_ratio",
+        "review_latency_p90h",
+        "w_churn",
+        "w_complexity",
+        "w_ownership",
+        "w_review",
+        "threshold_elevated",
+        "threshold_high",
+        "computed_at",
     ]
     base_weights = [0.30, 0.30, 0.20, 0.20]
     thresholds = [0.40, 0.65]
     persisted_team_rows = [
-        ["team-X", 0.55, "elevated", 0.7, 0.5, 0.4, 0.3,
-         0.12, 0.08, 4.0, 0.5, 0.55, 36.0,
-         *base_weights, *thresholds, NOW],
+        [
+            "team-X",
+            0.55,
+            "elevated",
+            0.7,
+            0.5,
+            0.4,
+            0.3,
+            0.12,
+            0.08,
+            4.0,
+            0.5,
+            0.55,
+            36.0,
+            *base_weights,
+            *thresholds,
+            NOW,
+        ],
     ]
     _setup_client(
         ctx.client,
@@ -312,9 +440,7 @@ async def test_team_breakout_uses_persisted_team_rows_when_available() -> None:
     )
 
     result = await resolve_compounding_risk(
-        ctx, ORG_ID, CompoundingRiskFilterInput(
-            breakout=CompoundingRiskScope.TEAM
-        )
+        ctx, ORG_ID, CompoundingRiskFilterInput(breakout=CompoundingRiskScope.TEAM)
     )
 
     assert len(result.rows) == 1
@@ -340,9 +466,16 @@ async def test_team_breakout_uses_persisted_team_rows_when_available() -> None:
 async def test_trend_window_is_bounded() -> None:
     ctx = _ctx()
     columns = [
-        "scope_id", "score", "severity",
-        "w_churn", "w_complexity", "w_ownership", "w_review",
-        "threshold_elevated", "threshold_high", "computed_at",
+        "scope_id",
+        "score",
+        "severity",
+        "w_churn",
+        "w_complexity",
+        "w_ownership",
+        "w_review",
+        "threshold_elevated",
+        "threshold_high",
+        "computed_at",
     ]
     base = [0.30, 0.30, 0.20, 0.20, 0.40, 0.65]
     _setup_client(

--- a/tests/api/graphql/test_compounding_risk_resolver.py
+++ b/tests/api/graphql/test_compounding_risk_resolver.py
@@ -1,0 +1,387 @@
+"""Resolver tests for Compounding Risk (CHAOS-1642).
+
+These tests exercise the resolver against a mocked ClickHouse client and
+verify:
+
+* the latest day is resolved when ``filter.day`` is omitted,
+* per-repo rows surface the persisted score, severity, components, weights,
+  thresholds, and computed_at,
+* per-team breakout averages repo rows via the configured repo→team map,
+* nulls propagate as ``None`` (data unavailable, not zero),
+* the resolver is read-only and never recomputes the composite.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.resolvers.compounding_risk import (
+    resolve_compounding_risk,
+)
+from dev_health_ops.api.graphql.types.compounding_risk import (
+    CompoundingRiskFilterInput,
+    CompoundingRiskScope,
+    CompoundingRiskSeverity,
+)
+
+ORG_ID = "org-test"
+NOW = datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc)
+DAY = date(2026, 5, 20)
+
+
+def _ctx() -> GraphQLContext:
+    ctx = GraphQLContext(org_id=ORG_ID, db_url="clickhouse://localhost:8123/d")
+    ctx.client = MagicMock()
+    return ctx
+
+
+def _qresult(columns: list[str], rows: list[list[Any]]) -> Any:
+    """Build a fake clickhouse_connect QueryResult-like object."""
+    result = MagicMock()
+    result.column_names = columns
+    result.result_rows = rows
+    return result
+
+
+def _setup_client(client: Any, responses: list[Any]) -> None:
+    """Make ``client.query`` return ``responses[i]`` on call ``i``."""
+    client.query.side_effect = responses
+
+
+# ---------------------------------------------------------------------------
+# Day resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_state_when_no_data_for_org() -> None:
+    ctx = _ctx()
+    # First call: latest-day lookup → empty.
+    _setup_client(ctx.client, [_qresult(["day"], [])])
+
+    result = await resolve_compounding_risk(ctx, ORG_ID)
+
+    assert result.org_id == ORG_ID
+    assert result.rows == []
+    assert result.trend == []
+
+
+@pytest.mark.asyncio
+async def test_uses_filter_day_when_provided_and_skips_latest_lookup() -> None:
+    ctx = _ctx()
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(  # repo rows for the explicit day
+                ["scope_id", "score", "severity", "computed_at",
+                 "w_churn", "w_complexity", "w_ownership", "w_review",
+                 "threshold_elevated", "threshold_high"],
+                [["repo-1", 0.5, "elevated", NOW, 0.3, 0.3, 0.2, 0.2, 0.4, 0.65]],
+            ),
+            _qresult([], []),  # repos label lookup
+            _qresult(["day", "avg_score"], [[DAY, 0.5]]),  # trend
+        ],
+    )
+
+    result = await resolve_compounding_risk(
+        ctx, ORG_ID, CompoundingRiskFilterInput(day=DAY)
+    )
+
+    # First query must NOT be the latest-day lookup.
+    first_query = ctx.client.query.call_args_list[0].args[0]
+    assert "max(day)" not in first_query
+    assert len(result.rows) == 1
+    assert result.rows[0].day == DAY
+
+
+# ---------------------------------------------------------------------------
+# Repo breakout — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repo_breakout_surfaces_full_audit_trail() -> None:
+    ctx = _ctx()
+    columns = [
+        "scope_id", "score", "severity",
+        "churn_norm", "complexity_norm", "ownership_norm", "review_norm",
+        "rework_churn", "complexity_delta", "bus_factor",
+        "ownership_gini", "single_owner_ratio", "review_latency_p90h",
+        "w_churn", "w_complexity", "w_ownership", "w_review",
+        "threshold_elevated", "threshold_high",
+        "computed_at",
+    ]
+    repo_row = [
+        "repo-1", 0.72, "high",
+        0.8, 0.7, 0.6, 0.5,
+        0.18, 0.12, 4.0, 0.55, 0.65, 30.0,
+        0.30, 0.30, 0.20, 0.20,
+        0.40, 0.65,
+        NOW,
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(["day"], [[DAY]]),  # latest-day lookup
+            _qresult(columns, [repo_row]),  # repo rows
+            _qresult(  # repo labels
+                ["repo_id", "full_name"], [["repo-1", "acme/backend"]]
+            ),
+            _qresult(["day", "avg_score"], [[DAY, 0.72]]),  # trend
+        ],
+    )
+
+    result = await resolve_compounding_risk(ctx, ORG_ID)
+
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.scope == CompoundingRiskScope.REPO
+    assert row.scope_id == "repo-1"
+    assert row.scope_label == "acme/backend"
+    assert row.score == pytest.approx(0.72)
+    assert row.severity == CompoundingRiskSeverity.HIGH
+    # Components fully populated
+    assert row.components.churn_norm == pytest.approx(0.8)
+    assert row.components.complexity_delta == pytest.approx(0.12)
+    assert row.components.review_latency_p90h == pytest.approx(30.0)
+    # Audit trail
+    assert row.weights.churn + row.weights.complexity + row.weights.ownership + \
+        row.weights.review == pytest.approx(1.0)
+    assert row.thresholds.elevated == pytest.approx(0.40)
+    assert row.thresholds.high == pytest.approx(0.65)
+
+
+@pytest.mark.asyncio
+async def test_null_score_maps_to_unknown_severity() -> None:
+    ctx = _ctx()
+    columns = [
+        "scope_id", "score", "severity",
+        "w_churn", "w_complexity", "w_ownership", "w_review",
+        "threshold_elevated", "threshold_high", "computed_at",
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(["day"], [[DAY]]),
+            _qresult(
+                columns,
+                [["repo-1", None, "unknown", 0.3, 0.3, 0.2, 0.2, 0.4, 0.65, NOW]],
+            ),
+            _qresult([], []),
+            _qresult([], []),
+        ],
+    )
+
+    result = await resolve_compounding_risk(ctx, ORG_ID)
+    assert result.rows[0].score is None
+    assert result.rows[0].severity == CompoundingRiskSeverity.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Team breakout — persisted team rows preferred, fallback to read-time aggregation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_breakout_averages_repos_via_repo_to_team_map() -> None:
+    ctx = _ctx()
+    columns = [
+        "scope_id", "score", "severity",
+        "churn_norm", "complexity_norm", "ownership_norm", "review_norm",
+        "rework_churn", "complexity_delta", "bus_factor",
+        "ownership_gini", "single_owner_ratio", "review_latency_p90h",
+        "w_churn", "w_complexity", "w_ownership", "w_review",
+        "threshold_elevated", "threshold_high", "computed_at",
+    ]
+    base_weights = [0.30, 0.30, 0.20, 0.20]
+    thresholds = [0.40, 0.65]
+    rows = [
+        ["repo-1", 0.80, "high", 0.9, 0.7, 0.8, 0.6,
+         0.20, 0.15, 3.0, 0.6, 0.7, 50.0,
+         *base_weights, *thresholds, NOW],
+        ["repo-2", 0.40, "elevated", 0.5, 0.4, 0.4, 0.3,
+         0.10, 0.05, 5.0, 0.4, 0.4, 20.0,
+         *base_weights, *thresholds, NOW],
+    ]
+    teams_rows = [["team-A", "Platform", ["repo-1", "repo-2"]]]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(["day"], [[DAY]]),
+            _qresult([], []),  # team-scope query returns empty → fallback to repo agg
+            _qresult(columns, rows),  # repo rows for the fallback aggregation
+            _qresult(["id", "name", "repo_patterns"], teams_rows),  # teams for repo→team map
+            _qresult(["day", "avg_score"], [[DAY, 0.6]]),  # trend
+        ],
+    )
+
+    result = await resolve_compounding_risk(
+        ctx, ORG_ID, CompoundingRiskFilterInput(
+            breakout=CompoundingRiskScope.TEAM
+        )
+    )
+
+    assert len(result.rows) == 1
+    team_row = result.rows[0]
+    assert team_row.scope == CompoundingRiskScope.TEAM
+    assert team_row.scope_id == "team-A"
+    assert team_row.scope_label == "Platform"
+    # Average of 0.80 and 0.40 == 0.60
+    assert team_row.score == pytest.approx(0.60)
+    # 0.60 is in [0.40, 0.65) → elevated
+    assert team_row.severity == CompoundingRiskSeverity.ELEVATED
+    # Component averages
+    assert team_row.components.churn_norm == pytest.approx(0.70)
+    assert team_row.components.review_latency_p90h == pytest.approx(35.0)
+
+
+@pytest.mark.asyncio
+async def test_team_breakout_filters_by_team_ids() -> None:
+    ctx = _ctx()
+    columns = [
+        "scope_id", "score", "severity",
+        "w_churn", "w_complexity", "w_ownership", "w_review",
+        "threshold_elevated", "threshold_high", "computed_at",
+    ]
+    base = [0.30, 0.30, 0.20, 0.20, 0.40, 0.65]
+    rows = [
+        ["repo-1", 0.8, "high", *base, NOW],
+        ["repo-2", 0.4, "elevated", *base, NOW],
+    ]
+    teams_rows = [
+        ["team-A", "A", ["repo-1"]],
+        ["team-B", "B", ["repo-2"]],
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(["day"], [[DAY]]),
+            _qresult([], []),  # team-scope query empty → fallback
+            _qresult(columns, rows),  # repo rows for fallback aggregation
+            _qresult(["id", "name", "repo_patterns"], teams_rows),
+            _qresult([], []),  # trend
+        ],
+    )
+
+    result = await resolve_compounding_risk(
+        ctx,
+        ORG_ID,
+        CompoundingRiskFilterInput(
+            breakout=CompoundingRiskScope.TEAM, team_ids=["team-B"]
+        ),
+    )
+    assert [r.scope_id for r in result.rows] == ["team-B"]
+
+
+@pytest.mark.asyncio
+async def test_team_breakout_uses_persisted_team_rows_when_available() -> None:
+    """When ``compounding_risk_daily`` has scope='team' rows, the resolver
+    surfaces them directly instead of aggregating from repo rows."""
+    ctx = _ctx()
+    columns = [
+        "scope_id", "score", "severity",
+        "churn_norm", "complexity_norm", "ownership_norm", "review_norm",
+        "rework_churn", "complexity_delta", "bus_factor",
+        "ownership_gini", "single_owner_ratio", "review_latency_p90h",
+        "w_churn", "w_complexity", "w_ownership", "w_review",
+        "threshold_elevated", "threshold_high", "computed_at",
+    ]
+    base_weights = [0.30, 0.30, 0.20, 0.20]
+    thresholds = [0.40, 0.65]
+    persisted_team_rows = [
+        ["team-X", 0.55, "elevated", 0.7, 0.5, 0.4, 0.3,
+         0.12, 0.08, 4.0, 0.5, 0.55, 36.0,
+         *base_weights, *thresholds, NOW],
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(["day"], [[DAY]]),
+            _qresult(columns, persisted_team_rows),  # team-scope rows EXIST
+            _qresult(  # teams query for label lookup
+                ["id", "name", "repo_patterns"],
+                [["team-X", "Platform", []]],
+            ),
+            _qresult([], []),  # trend
+        ],
+    )
+
+    result = await resolve_compounding_risk(
+        ctx, ORG_ID, CompoundingRiskFilterInput(
+            breakout=CompoundingRiskScope.TEAM
+        )
+    )
+
+    assert len(result.rows) == 1
+    team_row = result.rows[0]
+    assert team_row.scope == CompoundingRiskScope.TEAM
+    assert team_row.scope_id == "team-X"
+    assert team_row.scope_label == "Platform"
+    # Persisted score is surfaced as-is, NOT recomputed by the resolver.
+    assert team_row.score == pytest.approx(0.55)
+    # Persisted severity is also pass-through.
+    assert team_row.severity == CompoundingRiskSeverity.ELEVATED
+    # Components and audit-trail come from the persisted row.
+    assert team_row.components.churn_norm == pytest.approx(0.70)
+    assert team_row.weights.churn == pytest.approx(0.30)
+
+
+# ---------------------------------------------------------------------------
+# Trend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trend_window_is_bounded() -> None:
+    ctx = _ctx()
+    columns = [
+        "scope_id", "score", "severity",
+        "w_churn", "w_complexity", "w_ownership", "w_review",
+        "threshold_elevated", "threshold_high", "computed_at",
+    ]
+    base = [0.30, 0.30, 0.20, 0.20, 0.40, 0.65]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(["day"], [[DAY]]),
+            _qresult(columns, [["repo-1", 0.5, "elevated", *base, NOW]]),
+            _qresult(["repo_id", "full_name"], [["repo-1", "acme/r1"]]),
+            _qresult(
+                ["day", "avg_score"],
+                [[DAY, 0.5], [date(2026, 5, 19), 0.45]],
+            ),
+        ],
+    )
+
+    result = await resolve_compounding_risk(
+        ctx, ORG_ID, CompoundingRiskFilterInput(trend_days=99999)
+    )
+
+    # Even with a huge requested trend_days, resolver clamps to MAX_TREND_DAYS.
+    assert len(result.trend) == 2
+    assert result.trend[0].day == DAY
+    # Verify the trend query was issued with a bounded date window.
+    last_call_args = ctx.client.query.call_args_list[-1]
+    params = last_call_args.kwargs.get("parameters") or last_call_args.args[1]
+    delta_days = (params["end"] - params["start"]).days
+    assert delta_days <= 365  # MAX_TREND_DAYS
+
+
+# ---------------------------------------------------------------------------
+# Scope guardrails
+# ---------------------------------------------------------------------------
+
+
+def test_scope_input_has_no_developer_option() -> None:
+    """Per the no-surveillance contract, person scope is intentionally absent.
+
+    This is a static check on the enum surface — UI is also expected to gate
+    its scope picker.
+    """
+    values = {s.value for s in CompoundingRiskScope}
+    assert values == {"repo", "team"}

--- a/tests/metrics/test_compounding_risk.py
+++ b/tests/metrics/test_compounding_risk.py
@@ -1,0 +1,537 @@
+"""Unit tests for the Compounding Risk composite (CHAOS-1641)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from dev_health_ops.metrics.compounding_risk import (
+    DEFAULT_THRESHOLDS,
+    DEFAULT_WEIGHTS,
+    REFERENCE_VALUES,
+    CompoundingInputs,
+    CompoundingThresholds,
+    CompoundingWeights,
+    compute_compounding_risk,
+    severity_for,
+)
+
+NOW = datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc)
+DAY = date(2026, 5, 20)
+
+
+def _inputs(
+    *,
+    rework_churn: float | None = 0.0,
+    complexity_delta: float | None = 0.0,
+    review_latency_p90h: float | None = 0.0,
+    single_owner_ratio: float | None = 0.0,
+    ownership_gini: float | None = 0.0,
+    bus_factor: float | None = None,
+) -> CompoundingInputs:
+    return CompoundingInputs(
+        rework_churn=rework_churn,
+        complexity_delta=complexity_delta,
+        review_latency_p90h=review_latency_p90h,
+        single_owner_ratio=single_owner_ratio,
+        ownership_gini=ownership_gini,
+        bus_factor=bus_factor,
+    )
+
+
+def _compute(inputs: CompoundingInputs):
+    return compute_compounding_risk(
+        day=DAY,
+        scope="repo",
+        scope_id="repo-1",
+        org_id="org-1",
+        inputs=inputs,
+        computed_at=NOW,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Determinism / structural invariants
+# ---------------------------------------------------------------------------
+
+
+def test_weights_sum_to_one() -> None:
+    w = DEFAULT_WEIGHTS
+    assert w.churn + w.complexity + w.ownership + w.review == pytest.approx(1.0)
+
+
+def test_weights_must_sum_to_one() -> None:
+    with pytest.raises(ValueError):
+        CompoundingWeights(churn=0.1, complexity=0.1, ownership=0.1, review=0.1)
+
+
+def test_thresholds_must_be_ordered() -> None:
+    with pytest.raises(ValueError):
+        CompoundingThresholds(elevated=0.8, high=0.5)
+
+
+def test_scope_must_be_repo_or_team() -> None:
+    with pytest.raises(ValueError):
+        compute_compounding_risk(
+            day=DAY,
+            scope="developer",  # forbidden
+            scope_id="x",
+            org_id="org-1",
+            inputs=_inputs(),
+            computed_at=NOW,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Score / severity boundary cases
+# ---------------------------------------------------------------------------
+
+
+def test_score_is_zero_when_all_inputs_zero() -> None:
+    row = _compute(_inputs())
+    assert row.compounding_risk == 0.0
+    assert row.severity == "low"
+
+
+def test_score_is_one_when_all_inputs_saturate() -> None:
+    row = _compute(
+        _inputs(
+            rework_churn=REFERENCE_VALUES["churn_ref"] * 2,
+            complexity_delta=REFERENCE_VALUES["complexity_ref"] * 2,
+            review_latency_p90h=REFERENCE_VALUES["review_ref"] * 2,
+            single_owner_ratio=1.0,
+            ownership_gini=1.0,
+        )
+    )
+    assert row.compounding_risk == 1.0
+    assert row.severity == "high"
+
+
+def test_score_is_none_when_any_required_input_is_none() -> None:
+    row = _compute(_inputs(rework_churn=None))
+    assert row.compounding_risk is None
+    assert row.severity == "unknown"
+    # raw input still surfaced for inspectability
+    assert row.complexity_delta == 0.0
+
+
+def test_severity_thresholds_inclusive_at_lower_edge() -> None:
+    # < 0.40 → low
+    assert severity_for(0.3999, DEFAULT_THRESHOLDS) == "low"
+    # 0.40 → elevated
+    assert severity_for(0.40, DEFAULT_THRESHOLDS) == "elevated"
+    # 0.64 → elevated
+    assert severity_for(0.64, DEFAULT_THRESHOLDS) == "elevated"
+    # 0.65 → high
+    assert severity_for(0.65, DEFAULT_THRESHOLDS) == "high"
+    # None → unknown
+    assert severity_for(None, DEFAULT_THRESHOLDS) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Normalization semantics
+# ---------------------------------------------------------------------------
+
+
+def test_negative_complexity_delta_is_clamped_to_zero() -> None:
+    row = _compute(_inputs(complexity_delta=-0.5))
+    assert row.complexity_norm == 0.0
+    # only complexity component should be missing weight; others are zero too
+    assert row.compounding_risk == 0.0
+
+
+def test_ownership_norm_takes_max_of_single_owner_and_gini() -> None:
+    row = _compute(_inputs(single_owner_ratio=0.4, ownership_gini=0.9))
+    assert row.ownership_norm == 0.9
+
+
+def test_ownership_norm_works_with_only_one_input_present() -> None:
+    row = _compute(_inputs(single_owner_ratio=0.6, ownership_gini=None))
+    assert row.compounding_risk is not None
+    assert row.ownership_norm == 0.6
+
+
+def test_ownership_blocks_score_when_both_signals_missing() -> None:
+    row = _compute(_inputs(single_owner_ratio=None, ownership_gini=None))
+    assert row.compounding_risk is None
+    assert row.severity == "unknown"
+
+
+def test_inputs_above_reference_are_clamped_to_one() -> None:
+    row = _compute(
+        _inputs(
+            rework_churn=99.0,
+            complexity_delta=99.0,
+            review_latency_p90h=99.0,
+            single_owner_ratio=2.0,  # nonsense input
+            ownership_gini=2.0,
+        )
+    )
+    assert row.churn_norm == 1.0
+    assert row.complexity_norm == 1.0
+    assert row.review_norm == 1.0
+    assert row.ownership_norm == 1.0
+    assert row.compounding_risk == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Audit trail
+# ---------------------------------------------------------------------------
+
+
+def test_weights_and_thresholds_are_persisted_in_the_row() -> None:
+    row = _compute(_inputs())
+    assert row.w_churn == DEFAULT_WEIGHTS.churn
+    assert row.w_complexity == DEFAULT_WEIGHTS.complexity
+    assert row.w_ownership == DEFAULT_WEIGHTS.ownership
+    assert row.w_review == DEFAULT_WEIGHTS.review
+    assert row.threshold_elevated == DEFAULT_THRESHOLDS.elevated
+    assert row.threshold_high == DEFAULT_THRESHOLDS.high
+
+
+def test_raw_inputs_are_persisted_for_inspectability() -> None:
+    inputs = _inputs(
+        rework_churn=0.12,
+        complexity_delta=0.05,
+        review_latency_p90h=18.0,
+        single_owner_ratio=0.7,
+        ownership_gini=0.6,
+        bus_factor=3.0,
+    )
+    row = _compute(inputs)
+    assert row.rework_churn == 0.12
+    assert row.complexity_delta == 0.05
+    assert row.review_latency_p90h == 18.0
+    assert row.single_owner_ratio == 0.7
+    assert row.ownership_gini == 0.6
+    assert row.bus_factor == 3.0
+
+
+def test_org_id_and_scope_are_persisted() -> None:
+    row = compute_compounding_risk(
+        day=DAY,
+        scope="team",
+        scope_id="team-7",
+        org_id="acme",
+        inputs=_inputs(),
+        computed_at=NOW,
+    )
+    assert row.org_id == "acme"
+    assert row.scope == "team"
+    assert row.scope_id == "team-7"
+
+
+def test_computed_at_is_passed_through_unchanged() -> None:
+    row = _compute(_inputs())
+    assert row.computed_at == NOW
+
+
+# ---------------------------------------------------------------------------
+# Custom weights / thresholds
+# ---------------------------------------------------------------------------
+
+
+def test_custom_weights_change_score_predictably() -> None:
+    # Put 100% weight on churn; only churn input is nonzero ⇒ score = churn_norm.
+    weights = CompoundingWeights(
+        churn=1.0, complexity=0.0, ownership=0.0, review=0.0
+    )
+    inputs = _inputs(rework_churn=REFERENCE_VALUES["churn_ref"])  # saturates → 1.0
+    row = compute_compounding_risk(
+        day=DAY,
+        scope="repo",
+        scope_id="repo-1",
+        org_id="org-1",
+        inputs=inputs,
+        computed_at=NOW,
+        weights=weights,
+    )
+    assert row.compounding_risk == 1.0
+    # Audit trail reflects override
+    assert row.w_churn == 1.0
+    assert row.w_review == 0.0
+
+
+def test_custom_thresholds_persist_with_row() -> None:
+    thresholds = CompoundingThresholds(elevated=0.50, high=0.80)
+    row = compute_compounding_risk(
+        day=DAY,
+        scope="repo",
+        scope_id="repo-1",
+        org_id="org-1",
+        inputs=_inputs(),
+        computed_at=NOW,
+        thresholds=thresholds,
+    )
+    assert row.threshold_elevated == 0.50
+    assert row.threshold_high == 0.80
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator (CHAOS-1641 job_daily wiring)
+# ---------------------------------------------------------------------------
+
+import uuid  # noqa: E402
+from dataclasses import dataclass  # noqa: E402
+
+from dev_health_ops.metrics.compounding_risk import (  # noqa: E402
+    build_compounding_risk_rows_for_day,
+    load_repo_complexity_delta_30d,
+)
+
+
+@dataclass
+class _FakeRepoMetrics:
+    repo_id: uuid.UUID
+    rework_churn_ratio_30d: float = 0.0
+    single_owner_file_ratio_30d: float = 0.0
+    code_ownership_gini: float = 0.0
+    bus_factor: int = 0
+    pr_first_review_p90_hours: float | None = 0.0
+
+
+class _FakeSink:
+    """Stand-in for the ClickHouse sink. Returns canned ``query_dicts`` results."""
+
+    def __init__(self, complexity_by_repo: dict[str, dict[str, float] | None]):
+        self._data = complexity_by_repo
+        self.calls: list[dict] = []
+
+    def query_dicts(self, query: str, parameters: dict) -> list[dict]:
+        self.calls.append(parameters)
+        repo = parameters["repo_id"]
+        result = self._data.get(repo)
+        return [result] if result is not None else []
+
+
+def test_load_repo_complexity_delta_returns_relative_change() -> None:
+    sink = _FakeSink({"r1": {"first_half": 100.0, "second_half": 130.0}})
+    delta = load_repo_complexity_delta_30d(
+        sink, repo_id="r1", day=DAY, org_id="acme"
+    )
+    assert delta is not None
+    assert delta == pytest.approx(0.30)
+
+
+def test_load_repo_complexity_delta_returns_none_when_either_half_missing() -> None:
+    sink = _FakeSink({"r1": {"first_half": 100.0, "second_half": None}})
+    assert load_repo_complexity_delta_30d(
+        sink, repo_id="r1", day=DAY, org_id="acme"
+    ) is None
+
+
+def test_load_repo_complexity_delta_returns_none_when_no_rows() -> None:
+    sink = _FakeSink({})
+    assert load_repo_complexity_delta_30d(
+        sink, repo_id="missing", day=DAY, org_id="acme"
+    ) is None
+
+
+def test_load_repo_complexity_delta_rejects_too_small_window() -> None:
+    sink = _FakeSink({})
+    with pytest.raises(ValueError):
+        load_repo_complexity_delta_30d(
+            sink, repo_id="r1", day=DAY, org_id="acme", window_days=1
+        )
+
+
+def test_orchestrator_produces_one_row_per_repo() -> None:
+    repo_a = uuid.uuid4()
+    repo_b = uuid.uuid4()
+    sink = _FakeSink({
+        str(repo_a): {"first_half": 100.0, "second_half": 130.0},
+        str(repo_b): {"first_half": 100.0, "second_half": 100.0},
+    })
+    repo_rows = [
+        _FakeRepoMetrics(
+            repo_id=repo_a,
+            rework_churn_ratio_30d=0.15,
+            single_owner_file_ratio_30d=0.5,
+            code_ownership_gini=0.5,
+            pr_first_review_p90_hours=24.0,
+        ),
+        _FakeRepoMetrics(
+            repo_id=repo_b,
+            rework_churn_ratio_30d=0.0,
+            single_owner_file_ratio_30d=0.0,
+            code_ownership_gini=0.0,
+            pr_first_review_p90_hours=0.0,
+        ),
+    ]
+    out = build_compounding_risk_rows_for_day(
+        sink=sink,
+        day=DAY,
+        org_id="acme",
+        repo_metrics_rows=repo_rows,
+        computed_at=NOW,
+    )
+    assert len(out) == 2
+    assert out[0].scope_id == str(repo_a)
+    assert out[1].scope_id == str(repo_b)
+    assert out[0].compounding_risk is not None
+    assert out[0].compounding_risk > 0
+    assert out[1].compounding_risk == 0.0
+    for row in out:
+        assert row.org_id == "acme"
+        assert row.scope == "repo"
+        assert (
+            row.w_churn + row.w_complexity + row.w_ownership + row.w_review
+            == pytest.approx(1.0)
+        )
+
+
+def test_orchestrator_skips_rows_without_repo_id() -> None:
+    sink = _FakeSink({})
+
+    @dataclass
+    class _NoIdRow:
+        rework_churn_ratio_30d: float = 0.0
+
+    out = build_compounding_risk_rows_for_day(
+        sink=sink,
+        day=DAY,
+        org_id="acme",
+        repo_metrics_rows=[_NoIdRow()],
+        computed_at=NOW,
+    )
+    assert out == []
+
+
+def test_orchestrator_emits_unknown_severity_when_inputs_missing() -> None:
+    repo = uuid.uuid4()
+    sink = _FakeSink({})
+    repo_rows = [
+        _FakeRepoMetrics(
+            repo_id=repo,
+            rework_churn_ratio_30d=0.1,
+            single_owner_file_ratio_30d=0.5,
+            code_ownership_gini=0.5,
+            pr_first_review_p90_hours=24.0,
+        ),
+    ]
+    out = build_compounding_risk_rows_for_day(
+        sink=sink,
+        day=DAY,
+        org_id="acme",
+        repo_metrics_rows=repo_rows,
+        computed_at=NOW,
+    )
+    assert len(out) == 1
+    assert out[0].compounding_risk is None
+    assert out[0].severity == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Team-scope persistence (CHAOS-1641 follow-up)
+# ---------------------------------------------------------------------------
+
+
+def test_orchestrator_emits_team_rows_when_repo_to_team_map_provided() -> None:
+    repo_a = uuid.uuid4()
+    repo_b = uuid.uuid4()
+    sink = _FakeSink({
+        str(repo_a): {"first_half": 100.0, "second_half": 130.0},  # +30%
+        str(repo_b): {"first_half": 100.0, "second_half": 100.0},  #   0%
+    })
+    repo_rows = [
+        _FakeRepoMetrics(
+            repo_id=repo_a,
+            rework_churn_ratio_30d=0.20,
+            single_owner_file_ratio_30d=0.8,
+            code_ownership_gini=0.7,
+            pr_first_review_p90_hours=48.0,
+        ),
+        _FakeRepoMetrics(
+            repo_id=repo_b,
+            rework_churn_ratio_30d=0.0,
+            single_owner_file_ratio_30d=0.0,
+            code_ownership_gini=0.0,
+            pr_first_review_p90_hours=0.0,
+        ),
+    ]
+    repo_to_team = {str(repo_a): "team-X", str(repo_b): "team-X"}
+
+    out = build_compounding_risk_rows_for_day(
+        sink=sink,
+        day=DAY,
+        org_id="acme",
+        repo_metrics_rows=repo_rows,
+        computed_at=NOW,
+        repo_to_team=repo_to_team,
+    )
+
+    # 2 repo rows + 1 team row
+    assert len(out) == 3
+    by_scope = {r.scope: [] for r in out}
+    for r in out:
+        by_scope[r.scope].append(r)
+    assert len(by_scope["repo"]) == 2
+    assert len(by_scope["team"]) == 1
+    team_row = by_scope["team"][0]
+    assert team_row.scope_id == "team-X"
+    # Team score is computed from the *mean of raw inputs* under the same formula.
+    # repo_a has saturated complexity_delta (0.30 / 0.20 ref) ⇒ 1.0 norm; repo_b 0.
+    # Mean delta = 0.15 / 0.20 = 0.75 (complexity_norm).
+    # Mean rework_churn = 0.10 / 0.30 = 0.333 (churn_norm).
+    # Mean ownership = max(mean(0.8,0)=0.4, mean(0.7,0)=0.35) = 0.4.
+    # Mean review = 24.0 / 48.0 = 0.5.
+    # Score = 0.30*0.333 + 0.30*0.75 + 0.20*0.4 + 0.20*0.5 = 0.4849...
+    assert team_row.compounding_risk is not None
+    assert 0.40 <= team_row.compounding_risk <= 0.55
+    assert team_row.severity in ("elevated", "low")  # near threshold
+
+
+def test_orchestrator_team_row_omitted_when_no_repos_in_team() -> None:
+    repo_a = uuid.uuid4()
+    sink = _FakeSink({
+        str(repo_a): {"first_half": 100.0, "second_half": 110.0},
+    })
+    repo_rows = [
+        _FakeRepoMetrics(
+            repo_id=repo_a,
+            rework_churn_ratio_30d=0.05,
+            single_owner_file_ratio_30d=0.2,
+            code_ownership_gini=0.1,
+            pr_first_review_p90_hours=12.0,
+        ),
+    ]
+    # No mapping for repo_a, but mapping exists for an unrelated repo.
+    repo_to_team = {"some-other-repo": "team-Y"}
+    out = build_compounding_risk_rows_for_day(
+        sink=sink,
+        day=DAY,
+        org_id="acme",
+        repo_metrics_rows=repo_rows,
+        computed_at=NOW,
+        repo_to_team=repo_to_team,
+    )
+    assert len(out) == 1
+    assert out[0].scope == "repo"
+
+
+def test_orchestrator_team_rows_inherit_weights_and_thresholds() -> None:
+    repo_a = uuid.uuid4()
+    sink = _FakeSink({
+        str(repo_a): {"first_half": 100.0, "second_half": 110.0},
+    })
+    repo_rows = [
+        _FakeRepoMetrics(
+            repo_id=repo_a,
+            rework_churn_ratio_30d=0.05,
+            single_owner_file_ratio_30d=0.2,
+            code_ownership_gini=0.1,
+            pr_first_review_p90_hours=12.0,
+        ),
+    ]
+    out = build_compounding_risk_rows_for_day(
+        sink=sink,
+        day=DAY,
+        org_id="acme",
+        repo_metrics_rows=repo_rows,
+        computed_at=NOW,
+        repo_to_team={str(repo_a): "team-Y"},
+    )
+    team_row = next(r for r in out if r.scope == "team")
+    assert team_row.w_churn == DEFAULT_WEIGHTS.churn
+    assert team_row.threshold_elevated == DEFAULT_THRESHOLDS.elevated

--- a/tests/metrics/test_compounding_risk.py
+++ b/tests/metrics/test_compounding_risk.py
@@ -234,9 +234,7 @@ def test_computed_at_is_passed_through_unchanged() -> None:
 
 def test_custom_weights_change_score_predictably() -> None:
     # Put 100% weight on churn; only churn input is nonzero ⇒ score = churn_norm.
-    weights = CompoundingWeights(
-        churn=1.0, complexity=0.0, ownership=0.0, review=0.0
-    )
+    weights = CompoundingWeights(churn=1.0, complexity=0.0, ownership=0.0, review=0.0)
     inputs = _inputs(rework_churn=REFERENCE_VALUES["churn_ref"])  # saturates → 1.0
     row = compute_compounding_risk(
         day=DAY,
@@ -279,6 +277,9 @@ from dev_health_ops.metrics.compounding_risk import (  # noqa: E402
     build_compounding_risk_rows_for_day,
     load_repo_complexity_delta_30d,
 )
+from dev_health_ops.metrics.schemas import (  # noqa: E402
+    CompoundingRiskDailyRecord,
+)
 
 
 @dataclass
@@ -294,7 +295,10 @@ class _FakeRepoMetrics:
 class _FakeSink:
     """Stand-in for the ClickHouse sink. Returns canned ``query_dicts`` results."""
 
-    def __init__(self, complexity_by_repo: dict[str, dict[str, float] | None]):
+    def __init__(
+        self,
+        complexity_by_repo: dict[str, dict[str, float | None] | None],
+    ):
         self._data = complexity_by_repo
         self.calls: list[dict] = []
 
@@ -307,25 +311,25 @@ class _FakeSink:
 
 def test_load_repo_complexity_delta_returns_relative_change() -> None:
     sink = _FakeSink({"r1": {"first_half": 100.0, "second_half": 130.0}})
-    delta = load_repo_complexity_delta_30d(
-        sink, repo_id="r1", day=DAY, org_id="acme"
-    )
+    delta = load_repo_complexity_delta_30d(sink, repo_id="r1", day=DAY, org_id="acme")
     assert delta is not None
     assert delta == pytest.approx(0.30)
 
 
 def test_load_repo_complexity_delta_returns_none_when_either_half_missing() -> None:
     sink = _FakeSink({"r1": {"first_half": 100.0, "second_half": None}})
-    assert load_repo_complexity_delta_30d(
-        sink, repo_id="r1", day=DAY, org_id="acme"
-    ) is None
+    assert (
+        load_repo_complexity_delta_30d(sink, repo_id="r1", day=DAY, org_id="acme")
+        is None
+    )
 
 
 def test_load_repo_complexity_delta_returns_none_when_no_rows() -> None:
     sink = _FakeSink({})
-    assert load_repo_complexity_delta_30d(
-        sink, repo_id="missing", day=DAY, org_id="acme"
-    ) is None
+    assert (
+        load_repo_complexity_delta_30d(sink, repo_id="missing", day=DAY, org_id="acme")
+        is None
+    )
 
 
 def test_load_repo_complexity_delta_rejects_too_small_window() -> None:
@@ -339,10 +343,12 @@ def test_load_repo_complexity_delta_rejects_too_small_window() -> None:
 def test_orchestrator_produces_one_row_per_repo() -> None:
     repo_a = uuid.uuid4()
     repo_b = uuid.uuid4()
-    sink = _FakeSink({
-        str(repo_a): {"first_half": 100.0, "second_half": 130.0},
-        str(repo_b): {"first_half": 100.0, "second_half": 100.0},
-    })
+    sink = _FakeSink(
+        {
+            str(repo_a): {"first_half": 100.0, "second_half": 130.0},
+            str(repo_b): {"first_half": 100.0, "second_half": 100.0},
+        }
+    )
     repo_rows = [
         _FakeRepoMetrics(
             repo_id=repo_a,
@@ -430,10 +436,12 @@ def test_orchestrator_emits_unknown_severity_when_inputs_missing() -> None:
 def test_orchestrator_emits_team_rows_when_repo_to_team_map_provided() -> None:
     repo_a = uuid.uuid4()
     repo_b = uuid.uuid4()
-    sink = _FakeSink({
-        str(repo_a): {"first_half": 100.0, "second_half": 130.0},  # +30%
-        str(repo_b): {"first_half": 100.0, "second_half": 100.0},  #   0%
-    })
+    sink = _FakeSink(
+        {
+            str(repo_a): {"first_half": 100.0, "second_half": 130.0},  # +30%
+            str(repo_b): {"first_half": 100.0, "second_half": 100.0},  #   0%
+        }
+    )
     repo_rows = [
         _FakeRepoMetrics(
             repo_id=repo_a,
@@ -463,7 +471,7 @@ def test_orchestrator_emits_team_rows_when_repo_to_team_map_provided() -> None:
 
     # 2 repo rows + 1 team row
     assert len(out) == 3
-    by_scope = {r.scope: [] for r in out}
+    by_scope: dict[str, list[CompoundingRiskDailyRecord]] = {r.scope: [] for r in out}
     for r in out:
         by_scope[r.scope].append(r)
     assert len(by_scope["repo"]) == 2
@@ -484,9 +492,11 @@ def test_orchestrator_emits_team_rows_when_repo_to_team_map_provided() -> None:
 
 def test_orchestrator_team_row_omitted_when_no_repos_in_team() -> None:
     repo_a = uuid.uuid4()
-    sink = _FakeSink({
-        str(repo_a): {"first_half": 100.0, "second_half": 110.0},
-    })
+    sink = _FakeSink(
+        {
+            str(repo_a): {"first_half": 100.0, "second_half": 110.0},
+        }
+    )
     repo_rows = [
         _FakeRepoMetrics(
             repo_id=repo_a,
@@ -512,9 +522,11 @@ def test_orchestrator_team_row_omitted_when_no_repos_in_team() -> None:
 
 def test_orchestrator_team_rows_inherit_weights_and_thresholds() -> None:
     repo_a = uuid.uuid4()
-    sink = _FakeSink({
-        str(repo_a): {"first_half": 100.0, "second_half": 110.0},
-    })
+    sink = _FakeSink(
+        {
+            str(repo_a): {"first_half": 100.0, "second_half": 110.0},
+        }
+    )
     repo_rows = [
         _FakeRepoMetrics(
             repo_id=repo_a,

--- a/tests/recommendations/rules/test_compounding_risk.py
+++ b/tests/recommendations/rules/test_compounding_risk.py
@@ -144,3 +144,81 @@ def test_compounding_risk_rationale_mentions_both_thresholds() -> None:
     assert result is not None
     assert str(COMPLEXITY_DELTA_THRESHOLD) in result.rationale
     assert str(HOTSPOT_CHURN_OVERLAP_THRESHOLD) in result.rationale
+
+
+# ---------------------------------------------------------------------------
+# 8. Persisted Compounding Risk path (CHAOS-1641)
+# ---------------------------------------------------------------------------
+
+
+def test_persisted_high_severity_fires_with_critical_severity() -> None:
+    """When the snapshot carries persisted Compounding Risk = high, the rule
+    fires with severity='critical' and cites compounding_risk_daily."""
+    snap = make_snapshot(
+        compounding_risk_score=0.75,
+        compounding_risk_severity="high",
+        # Legacy proxy explicitly below threshold to prove preference.
+        hotspot_complexity_delta=0.0,
+        hotspot_churn_overlap=0.0,
+    )
+    result = evaluate_compounding_risk(snap, NOW)
+    assert result is not None
+    assert result.severity == "critical"
+    assert result.rule_id == RULE_ID
+    assert result.success_criterion == SUCCESS_CRITERION
+    # Evidence cites the new table.
+    assert any(
+        ev.metric_table == "compounding_risk_daily" for ev in result.evidence
+    )
+
+
+def test_persisted_elevated_severity_fires_with_warning_severity() -> None:
+    snap = make_snapshot(
+        compounding_risk_score=0.50,
+        compounding_risk_severity="elevated",
+    )
+    result = evaluate_compounding_risk(snap, NOW)
+    assert result is not None
+    assert result.severity == "warning"
+
+
+def test_persisted_low_severity_does_not_fire_alone() -> None:
+    snap = make_snapshot(
+        compounding_risk_score=0.20,
+        compounding_risk_severity="low",
+    )
+    result = evaluate_compounding_risk(snap, NOW)
+    assert result is None
+
+
+def test_persisted_unknown_severity_falls_through_to_legacy_path() -> None:
+    """When the persisted score is missing/unknown, the legacy hotspot proxy
+    still drives the decision — ensures back-compat during backfill warmup."""
+    snap = make_snapshot(
+        compounding_risk_score=None,
+        compounding_risk_severity=None,
+        hotspot_complexity_delta=COMPLEXITY_DELTA_THRESHOLD + 0.05,
+        hotspot_churn_overlap=HOTSPOT_CHURN_OVERLAP_THRESHOLD + 0.05,
+    )
+    result = evaluate_compounding_risk(snap, NOW)
+    assert result is not None
+    # Legacy path uses the file_complexity_snapshots evidence trail.
+    assert any(
+        ev.metric_table == "file_complexity_snapshots" for ev in result.evidence
+    )
+
+
+def test_persisted_score_takes_precedence_over_legacy_proxy() -> None:
+    """Even if the legacy proxy would NOT fire, a persisted high score fires."""
+    snap = make_snapshot(
+        compounding_risk_score=0.80,
+        compounding_risk_severity="high",
+        hotspot_complexity_delta=0.0,  # below threshold
+        hotspot_churn_overlap=0.0,     # below threshold
+    )
+    result = evaluate_compounding_risk(snap, NOW)
+    assert result is not None
+    assert result.severity == "critical"
+    assert "compounding_risk_daily" in {
+        ev.metric_table for ev in result.evidence
+    }

--- a/tests/recommendations/rules/test_compounding_risk.py
+++ b/tests/recommendations/rules/test_compounding_risk.py
@@ -167,9 +167,7 @@ def test_persisted_high_severity_fires_with_critical_severity() -> None:
     assert result.rule_id == RULE_ID
     assert result.success_criterion == SUCCESS_CRITERION
     # Evidence cites the new table.
-    assert any(
-        ev.metric_table == "compounding_risk_daily" for ev in result.evidence
-    )
+    assert any(ev.metric_table == "compounding_risk_daily" for ev in result.evidence)
 
 
 def test_persisted_elevated_severity_fires_with_warning_severity() -> None:
@@ -203,9 +201,7 @@ def test_persisted_unknown_severity_falls_through_to_legacy_path() -> None:
     result = evaluate_compounding_risk(snap, NOW)
     assert result is not None
     # Legacy path uses the file_complexity_snapshots evidence trail.
-    assert any(
-        ev.metric_table == "file_complexity_snapshots" for ev in result.evidence
-    )
+    assert any(ev.metric_table == "file_complexity_snapshots" for ev in result.evidence)
 
 
 def test_persisted_score_takes_precedence_over_legacy_proxy() -> None:
@@ -214,11 +210,9 @@ def test_persisted_score_takes_precedence_over_legacy_proxy() -> None:
         compounding_risk_score=0.80,
         compounding_risk_severity="high",
         hotspot_complexity_delta=0.0,  # below threshold
-        hotspot_churn_overlap=0.0,     # below threshold
+        hotspot_churn_overlap=0.0,  # below threshold
     )
     result = evaluate_compounding_risk(snap, NOW)
     assert result is not None
     assert result.severity == "critical"
-    assert "compounding_risk_daily" in {
-        ev.metric_table for ev in result.evidence
-    }
+    assert "compounding_risk_daily" in {ev.metric_table for ev in result.evidence}


### PR DESCRIPTION
Adds a deterministic, inspectable composite that combines four signals
from existing daily tables and persists them to a new append-only
ClickHouse table, plus the GraphQL surface that powers /risk/compounding
in dev-health-web.

Composite (per (org_id, day, scope, scope_id)):
  churn_norm        = clamp01(max(0, rework_churn_ratio_30d) / 0.30)
  complexity_norm   = clamp01(max(0, complexity_delta_30d)   / 0.20)
  ownership_norm    = clamp01(max(single_owner_ratio, ownership_gini))
  review_norm       = clamp01(max(0, pr_first_review_p90h)   / 48.0)
  score = 0.30*churn + 0.30*complexity + 0.20*ownership + 0.20*review
  severity = unknown | low (<0.40) | elevated (<0.65) | high

Inspectability: weights, thresholds, raw inputs, and normalized
components persist alongside the score so historical rows stay
auditable even if defaults change. Per the no-surveillance contract,
there is no per-person scope.

What's included
---------------
- migrations/clickhouse/040_compounding_risk_daily.sql
- metrics/compounding_risk.py — pure formula + orchestrator;
  repo + team rows aggregated under the same formula
- metrics/job_compounding_risk.py — `dev-hops metrics compounding-risk`
  ad-hoc / backfill CLI
- metrics/schemas.py — CompoundingRiskDailyRecord
- metrics/sinks/clickhouse/compounding_risk.py — CompoundingRiskMixin
- metrics/sinks/base.py — abstract no-op default
- metrics/job_daily.py — wired into `dev-hops metrics daily` after
  write_repo_metrics, with repo→team mapping via existing resolver
- api/graphql/types/compounding_risk.py — Strawberry types
  (CompoundingRiskScope enum is REPO|TEAM, no DEVELOPER)
- api/graphql/resolvers/compounding_risk.py — argMax-by-computed_at
  read; persisted team rows preferred, repo-aggregation fallback
- api/graphql/schema.py — compoundingRisk(orgId, filter) wired
- recommendations/snapshot.py + loader.py + rules/compounding_risk.py —
  rule now prefers the persisted composite score, falls back to legacy
  hotspot proxy when score is absent (back-compat for warmup)
- docs/computations/compounding-risk.md — formula spec

Tests (all green, zero regressions)
------------------------------------
- tests/metrics/test_compounding_risk.py — 29 cases covering pure
  compute, normalization clamping, orchestrator wiring, team-scope
  aggregation, ClickHouse delta loader
- tests/api/graphql/test_compounding_risk_resolver.py — 9 cases
  covering happy paths, persisted-team-rows preferred over fallback,
  read-time aggregation fallback, scope enum guardrail
- tests/recommendations/rules/test_compounding_risk.py — +5 cases
  exercising the persisted-score path + back-compat with the legacy
  proxy
- 198 metrics tests pass total; 134 recommendations tests pass total;
  schema.as_str() exports the new types cleanly

Closes CHAOS-1641
Refs CHAOS-1642
Refs CHAOS-1640
