### PR TITLE
fix(ops): wire Compounding Risk into daily metrics (CHAOS-1744)

### DIFF
--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -44,6 +44,7 @@ from dev_health_ops.metrics.identity import (
     init_team_resolver,
     load_team_map,
 )
+from dev_health_ops.metrics.job_compounding_risk import _fetch_repo_metrics_for_day
 from dev_health_ops.metrics.knowledge import (
     compute_bus_factor,
     compute_code_ownership_gini,
@@ -144,6 +145,68 @@ def _date_range(end_day: date, backfill_days: int) -> list[date]:
         return [end_day]
     start_day = end_day - timedelta(days=backfill_days - 1)
     return [start_day + timedelta(days=i) for i in range(backfill_days)]
+
+
+def _repo_to_team_map_for_compounding_risk(
+    *,
+    repo_metrics_rows: list[Any],
+    repo_names_by_id: dict[uuid.UUID, str],
+    repo_team_resolver: Any,
+) -> dict[str, str]:
+    repo_to_team_map: dict[str, str] = {}
+    for row in repo_metrics_rows:
+        row_repo_id = getattr(row, "repo_id", None)
+        if row_repo_id is None:
+            continue
+        full_name = repo_names_by_id.get(row_repo_id)
+        if not full_name:
+            continue
+        team_id, _ = repo_team_resolver.resolve(full_name)
+        if team_id:
+            repo_to_team_map[str(row_repo_id)] = team_id
+    return repo_to_team_map
+
+
+def _write_compounding_risk_for_day(
+    *,
+    sinks: list[Any],
+    primary_sink: Any,
+    day: date,
+    org_id: str,
+    repo_metrics_rows: list[Any],
+    computed_at: datetime,
+    repo_names_by_id: dict[uuid.UUID, str],
+    repo_team_resolver: Any,
+) -> int:
+    rows_for_compounding = list(repo_metrics_rows)
+    if not rows_for_compounding:
+        rows_for_compounding = _fetch_repo_metrics_for_day(primary_sink, org_id, day)
+    if not rows_for_compounding:
+        return 0
+
+    try:
+        repo_to_team_map = _repo_to_team_map_for_compounding_risk(
+            repo_metrics_rows=rows_for_compounding,
+            repo_names_by_id=repo_names_by_id,
+            repo_team_resolver=repo_team_resolver,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("repo_team_resolver failed for compounding risk: %s", exc)
+        repo_to_team_map = {}
+
+    compounding_rows = build_compounding_risk_rows_for_day(
+        sink=primary_sink,
+        day=day,
+        org_id=org_id,
+        repo_metrics_rows=rows_for_compounding,
+        computed_at=computed_at,
+        repo_to_team=repo_to_team_map or None,
+    )
+    if not compounding_rows:
+        return 0
+    for s in sinks:
+        s.write_compounding_risk_daily(compounding_rows)
+    return len(compounding_rows)
 
 
 def _secondary_uri_from_env() -> str:
@@ -477,41 +540,16 @@ async def run_daily_metrics_job(
             if all_file_metrics:
                 s.write_file_metrics(all_file_metrics)
 
-        # Compounding Risk composite (CHAOS-1641). Computed AFTER
-        # ``write_repo_metrics`` so the inputs are persisted, then read
-        # back as needed (complexity delta) by the orchestrator.  Team
-        # rows are aggregated from the repo inputs using the
-        # ``repo_team_resolver`` already in scope.
-        repo_to_team_map: dict[str, str] = {}
-        try:
-            for row in result.repo_metrics:
-                # NOTE: use a distinct name here — the function parameter
-                # ``repo_id`` is reused later in the loop iteration
-                # (e.g. by load_testops_pipeline_data) and must stay None
-                # when the daily job was invoked without a per-repo filter.
-                row_repo_id = getattr(row, "repo_id", None)
-                if row_repo_id is None:
-                    continue
-                full_name = repo_names_by_id.get(row_repo_id)
-                if not full_name:
-                    continue
-                team_id, _ = repo_team_resolver.resolve(full_name)
-                if team_id:
-                    repo_to_team_map[str(row_repo_id)] = team_id
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.warning("repo_team_resolver failed for compounding risk: %s", exc)
-
-        compounding_rows = build_compounding_risk_rows_for_day(
-            sink=primary_sink,
+        _write_compounding_risk_for_day(
+            sinks=sinks,
+            primary_sink=primary_sink,
             day=d,
             org_id=org_id,
             repo_metrics_rows=result.repo_metrics,
             computed_at=computed_at,
-            repo_to_team=repo_to_team_map or None,
+            repo_names_by_id=repo_names_by_id,
+            repo_team_resolver=repo_team_resolver,
         )
-        if compounding_rows:
-            for s in sinks:
-                s.write_compounding_risk_daily(compounding_rows)
 
         # TestOps risk metrics (release confidence, quality drag, pipeline stability)
         release_conf = compute_release_confidence(

--- a/tests/metrics/test_job_daily_compounding_risk.py
+++ b/tests/metrics/test_job_daily_compounding_risk.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Any
+
+from dev_health_ops.metrics import job_daily
+
+DAY = date(2026, 5, 20)
+NOW = datetime(2026, 5, 21, 12, 0, tzinfo=timezone.utc)
+
+
+@dataclass
+class _RepoMetricsRow:
+    repo_id: uuid.UUID
+    rework_churn_ratio_30d: float = 0.15
+    single_owner_file_ratio_30d: float = 0.5
+    code_ownership_gini: float = 0.4
+    bus_factor: int = 2
+    pr_first_review_p90_hours: float = 24.0
+
+
+class _Sink:
+    def __init__(self) -> None:
+        self.written: list[Any] = []
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, float]]:
+        return [{"first_half": 100.0, "second_half": 130.0}]
+
+    def write_compounding_risk_daily(self, rows: list[Any]) -> None:
+        self.written.extend(rows)
+
+
+class _Resolver:
+    def resolve(self, full_name: str) -> tuple[str | None, str | None]:
+        return (
+            ("team-platform", "Platform")
+            if full_name == "acme/backend"
+            else (None, None)
+        )
+
+
+def test_daily_job_writes_compounding_risk_from_persisted_repo_metrics(
+    monkeypatch: Any,
+) -> None:
+    repo_id = uuid.uuid4()
+    persisted_repo_metrics = [_RepoMetricsRow(repo_id=repo_id)]
+    sink = _Sink()
+
+    def fake_fetch_repo_metrics_for_day(
+        primary_sink: Any, org_id: str, day: date
+    ) -> list[_RepoMetricsRow]:
+        assert primary_sink is sink
+        assert org_id == "acme"
+        assert day == DAY
+        return persisted_repo_metrics
+
+    monkeypatch.setattr(
+        job_daily, "_fetch_repo_metrics_for_day", fake_fetch_repo_metrics_for_day
+    )
+
+    written_count = job_daily._write_compounding_risk_for_day(
+        sinks=[sink],
+        primary_sink=sink,
+        day=DAY,
+        org_id="acme",
+        repo_metrics_rows=[],
+        computed_at=NOW,
+        repo_names_by_id={repo_id: "acme/backend"},
+        repo_team_resolver=_Resolver(),
+    )
+
+    assert written_count == 2
+    assert {row.scope for row in sink.written} == {"repo", "team"}
+    repo_row = next(row for row in sink.written if row.scope == "repo")
+    assert repo_row.scope_id == str(repo_id)
+    assert repo_row.org_id == "acme"
+    assert repo_row.compounding_risk is not None
+    assert repo_row.complexity_delta == 0.30


### PR DESCRIPTION
## Summary
- Moves Compounding Risk daily write orchestration into a focused helper called from `dev-hops metrics daily`.
- Falls back to persisted `repo_metrics_daily` rows for the target day before building `compounding_risk_daily` records, matching the standalone Compounding Risk job and GraphQL resolver contract.
- Adds a regression test proving the daily helper fetches persisted repo metrics and writes repo/team rows through `write_compounding_risk_daily`.

## Root cause
The daily metrics job had inline Compounding Risk wiring, but it only used the in-memory `result.repo_metrics` from the current compute pass. When the daily command ran against a seeded analytics DB where repo metrics were already persisted for the day but not present in that in-memory result, no Compounding Risk rows were written, leaving the resolver's `compounding_risk_daily` queries empty. The resolver correctly reads `compounding_risk_daily` (`src/dev_health_ops/api/graphql/resolvers/compounding_risk.py:64-131`); the writer path in daily needed to use the same persisted `repo_metrics_daily` source that the standalone job uses. The fixed path now falls back through `_fetch_repo_metrics_for_day` and writes via the ClickHouse sink at `src/dev_health_ops/metrics/job_daily.py:170-209`, invoked from the daily orchestrator at `src/dev_health_ops/metrics/job_daily.py:543-552`.

## Fix
`run_daily_metrics_job` now delegates Compounding Risk persistence to `_write_compounding_risk_for_day`, which uses current repo metrics when available and otherwise fetches persisted `repo_metrics_daily` rows for the same org/day before computing rows with `build_compounding_risk_rows_for_day` and persisting them via `write_compounding_risk_daily`. Team mapping remains best-effort and still uses the existing repo-team resolver, preserving the metrics/sink boundaries and ClickHouse-only analytics path.

## Manual verification
1. Start a normally seeded analytics stack and run migrations, including ClickHouse migration 040.
2. Seed or sync repo metrics and complexity data for an org/day.
3. Run: `CLICKHOUSE_URI=clickhouse://... dev-hops metrics daily --org <org-id> --before <YYYY-MM-DD+1> --backfill 1`.
4. Confirm rows exist: `SELECT org_id, day, scope, count() FROM compounding_risk_daily WHERE org_id = '<org-id>' GROUP BY org_id, day, scope`.
5. Open `/risk/compounding` and verify the empty state is replaced by populated repo/team data.

## Verification run
- `pytest tests/ -k compounding -x`
- `ruff check src/dev_health_ops/metrics/job_daily.py tests/metrics/test_job_daily_compounding_risk.py`
- LSP diagnostics clean for changed files

SCREENSHOT-WAIVER: backend-only pipeline fix; no GraphQL schema or rendered UI code changed.

Closes CHAOS-1744
