### PR TITLE
fix(ops): plumb org_id through complexity writers (CHAOS-1744 part 2)

### DIFF
--- a/docs/screenshots/chaos-1744/clickhouse-evidence.md
+++ b/docs/screenshots/chaos-1744/clickhouse-evidence.md
@@ -1,0 +1,71 @@
+# CHAOS-1744 — ClickHouse Evidence: Before vs After
+
+## Before fix (org_id dropped by `_build_snapshots`)
+
+```
+SELECT count() AS total, countIf(compounding_risk IS NOT NULL) AS non_null
+FROM compounding_risk_daily;
+┌─total─┬─non_null─┐
+│     4 │        0 │
+└───────┴──────────┘
+```
+
+Every row `compounding_risk = NULL`, `severity = unknown`. Why:
+
+```
+SELECT org_id, count() FROM repo_complexity_daily GROUP BY org_id;
+┌─org_id─┬─count()─┐
+│        │     720 │   <- empty string, written by buggy _build_snapshots
+└────────┴─────────┘
+```
+
+While the daily job ran with `org_id = ae600a94-...`. The filter
+`WHERE org_id = {org_id:String}` in `load_repo_complexity_delta_30d`
+matched zero rows for every repo → `complexity_delta = None` → all
+required inputs unsatisfied → score = NULL.
+
+## After fix (org_id correctly plumbed through)
+
+After truncating + re-running `dev-hops metrics complexity --backfill 90`
+and `dev-hops metrics daily --backfill 90`:
+
+```
+SELECT
+  count() AS total,
+  countIf(compounding_risk IS NOT NULL) AS non_null,
+  countIf(severity = 'high') AS high,
+  countIf(severity = 'elevated') AS elevated,
+  countIf(severity = 'low') AS low,
+  countIf(severity = 'unknown') AS unknown
+FROM compounding_risk_daily;
+┌─total─┬─non_null─┬─high─┬─elevated─┬─low─┬─unknown─┐
+│   355 │       27 │    0 │       23 │   4 │     328 │
+└───────┴──────────┴──────┴──────────┴─────┴─────────┘
+```
+
+```
+SELECT org_id, count() FROM repo_complexity_daily GROUP BY org_id;
+┌─org_id───────────────────────────────┬─count()─┐
+│ ae600a94-76bc-4166-bf36-051ee4247c73 │     360 │
+└──────────────────────────────────────┴─────────┘
+```
+
+27 real scores computed (23 elevated, 4 low). Remaining 328 rows are
+days where `pr_first_review_p90_hours` is NULL upstream (sparse PR
+review activity) — legitimate data gap, not a bug.
+
+## Sample rows
+
+```
+SELECT day, scope, scope_id, severity, compounding_risk, complexity_delta, review_latency_p90h
+FROM compounding_risk_daily WHERE compounding_risk IS NOT NULL
+ORDER BY day DESC LIMIT 5;
+
+day        | scope | scope_id              | severity | score  | cdelta | rev_p90
+-----------+-------+-----------------------+----------+--------+--------+--------
+2026-05-20 | repo  | 65574b20-1e8d-...     | elevated | 0.4298 |   0    |   23
+2026-05-12 | repo  | 2faf8e66-de78-...     | low      | 0.3433 |   0    |    4.7
+2026-05-11 | repo  | 5b862ba7-ef97-...     | elevated | 0.4458 |   0    |   23.1
+2026-05-11 | repo  | 2faf8e66-de78-...     | elevated | 0.4756 |   0    |   35.3
+2026-05-10 | repo  | 5b862ba7-ef97-...     | elevated | 0.4175 |   0    |   17
+```

--- a/src/dev_health_ops/fixtures/generators/commits.py
+++ b/src/dev_health_ops/fixtures/generators/commits.py
@@ -101,7 +101,9 @@ class CommitsGeneratorMixin(BaseGeneratorMixin):
                 )
         return stats
 
-    def generate_complexity_metrics(self, days: int = 30) -> dict[str, list[Any]]:
+    def generate_complexity_metrics(
+        self, days: int = 30, *, org_id: str = ""
+    ) -> dict[str, list[Any]]:
         from dev_health_ops.metrics.schemas import (
             FileComplexitySnapshot,
             RepoComplexityDaily,
@@ -148,6 +150,7 @@ class CommitsGeneratorMixin(BaseGeneratorMixin):
                         high_complexity_functions=high,
                         very_high_complexity_functions=very_high,
                         computed_at=computed_at,
+                        org_id=org_id,
                     )
                 )
 
@@ -168,6 +171,7 @@ class CommitsGeneratorMixin(BaseGeneratorMixin):
                     high_complexity_functions=total_high,
                     very_high_complexity_functions=total_very_high,
                     computed_at=computed_at,
+                    org_id=org_id,
                 )
             )
 

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -729,7 +729,7 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
 
             # 8. Metrics
             if ns.with_metrics and sink:
-                comp_data = generator.generate_complexity_metrics(days=ns.days)
+                comp_data = generator.generate_complexity_metrics(days=ns.days, org_id=org_id)
                 if hasattr(sink, "write_file_complexity_snapshots"):
                     if comp_data["snapshots"]:
                         sink.write_file_complexity_snapshots(comp_data["snapshots"])

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -729,7 +729,9 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
 
             # 8. Metrics
             if ns.with_metrics and sink:
-                comp_data = generator.generate_complexity_metrics(days=ns.days, org_id=org_id)
+                comp_data = generator.generate_complexity_metrics(
+                    days=ns.days, org_id=org_id
+                )
                 if hasattr(sink, "write_file_complexity_snapshots"):
                     if comp_data["snapshots"]:
                         sink.write_file_complexity_snapshots(comp_data["snapshots"])

--- a/src/dev_health_ops/metrics/job_complexity.py
+++ b/src/dev_health_ops/metrics/job_complexity.py
@@ -27,6 +27,7 @@ def run_complexity_scan_job(
     backfill_days: int = 1,
     ref: str = "HEAD",
     sink: Any | None = None,
+    org_id: str = "",
 ) -> None:
     if not db_url and not sink:
         raise ValueError("DB connection string or sink is required.")
@@ -115,6 +116,7 @@ def run_complexity_scan_job(
                         high_complexity_functions=f.high_complexity_functions,
                         very_high_complexity_functions=f.very_high_complexity_functions,
                         computed_at=computed_at,
+                        org_id=org_id,
                     )
                 )
 
@@ -134,6 +136,7 @@ def run_complexity_scan_job(
                 high_complexity_functions=total_high,
                 very_high_complexity_functions=total_very_high,
                 computed_at=computed_at,
+                org_id=org_id,
             )
 
             logger.info(f"Writing {len(snapshots)} file snapshots for {d}...")

--- a/src/dev_health_ops/metrics/job_complexity_db.py
+++ b/src/dev_health_ops/metrics/job_complexity_db.py
@@ -302,7 +302,7 @@ def run_complexity_db_job(
             for d in days:
                 computed_at = datetime.now(timezone.utc)
                 snapshots, repo_daily = _build_snapshots(
-                    repo_uuid, d, ref_value, file_results, computed_at
+                    repo_uuid, d, ref_value, file_results, computed_at, org_id
                 )
 
                 if not snapshots:
@@ -325,6 +325,7 @@ def _build_snapshots(
     ref_value: str,
     file_results: list[FileComplexity],
     computed_at: datetime,
+    org_id: str,
 ) -> tuple[list[FileComplexitySnapshot], RepoComplexityDaily]:
     snapshots: list[FileComplexitySnapshot] = []
     total_loc = 0
@@ -347,6 +348,7 @@ def _build_snapshots(
                 high_complexity_functions=f.high_complexity_functions,
                 very_high_complexity_functions=f.very_high_complexity_functions,
                 computed_at=computed_at,
+                org_id=org_id,
             )
         )
 
@@ -366,6 +368,7 @@ def _build_snapshots(
         high_complexity_functions=total_high,
         very_high_complexity_functions=total_very_high,
         computed_at=computed_at,
+        org_id=org_id,
     )
 
     return snapshots, repo_daily

--- a/tests/metrics/test_complexity_org_id_propagation.py
+++ b/tests/metrics/test_complexity_org_id_propagation.py
@@ -1,0 +1,194 @@
+"""Regression tests for CHAOS-1744 — complexity rows must carry org_id.
+
+The original CHAOS-1744 fix wired Compounding Risk into the daily job but did
+not catch that ``RepoComplexityDaily`` rows were being persisted with an
+empty-string ``org_id`` because ``_build_snapshots`` dropped the parameter
+before constructing the dataclass. When ``load_repo_complexity_delta_30d``
+later filtered by the running org's UUID, every query returned zero rows,
+``complexity_delta`` was always ``None``, ``has_required_inputs()`` returned
+``False``, and every Compounding Risk row ended up with ``compounding_risk
+= NULL`` and ``severity = 'unknown'``.
+
+These tests assert org_id propagation **without mocking the sink's query
+behaviour**, which was the gap in the original PR #759 test.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+from typing import Any
+
+from dev_health_ops.analytics.complexity import FileComplexity
+from dev_health_ops.fixtures.generator import SyntheticDataGenerator
+from dev_health_ops.metrics.compounding_risk import load_repo_complexity_delta_30d
+from dev_health_ops.metrics.job_complexity_db import _build_snapshots
+
+ORG = "11111111-1111-1111-1111-111111111111"
+OTHER_ORG = "22222222-2222-2222-2222-222222222222"
+DAY = date(2026, 5, 21)
+NOW = datetime(2026, 5, 21, 12, 0, tzinfo=timezone.utc)
+
+
+def _file(path: str = "src/a.py") -> FileComplexity:
+    return FileComplexity(
+        file_path=path,
+        language="python",
+        loc=120,
+        functions_count=10,
+        cyclomatic_total=30,
+        cyclomatic_avg=3.0,
+        high_complexity_functions=1,
+        very_high_complexity_functions=0,
+    )
+
+
+def test_build_snapshots_propagates_org_id_to_repo_daily() -> None:
+    repo_id = uuid.uuid4()
+    snapshots, repo_daily = _build_snapshots(
+        repo_id, DAY, "abc123", [_file()], NOW, ORG
+    )
+    assert repo_daily.org_id == ORG, (
+        f"RepoComplexityDaily.org_id must equal {ORG!r}, "
+        f"got {repo_daily.org_id!r}. This is the CHAOS-1744 bug."
+    )
+
+
+def test_build_snapshots_propagates_org_id_to_file_snapshots() -> None:
+    repo_id = uuid.uuid4()
+    snapshots, _ = _build_snapshots(
+        repo_id, DAY, "abc123", [_file("a.py"), _file("b.py")], NOW, ORG
+    )
+    assert len(snapshots) == 2
+    for snap in snapshots:
+        assert snap.org_id == ORG, (
+            f"FileComplexitySnapshot.org_id must equal {ORG!r}, "
+            f"got {snap.org_id!r}."
+        )
+
+
+def test_fixtures_generator_propagates_org_id() -> None:
+    repo_id = uuid.uuid4()
+    gen = SyntheticDataGenerator(repo_name="acme/demo-app", seed=42)
+    data = gen.generate_complexity_metrics(days=2, org_id=ORG)
+
+    assert data["snapshots"], "fixture generator must produce snapshots"
+    assert data["dailies"], "fixture generator must produce dailies"
+    for snap in data["snapshots"]:
+        assert snap.org_id == ORG
+    for daily in data["dailies"]:
+        assert daily.org_id == ORG
+
+
+# ---------------------------------------------------------------------------
+# Real-world-style fake sink: stores rows AND enforces the same WHERE filters
+# that ClickHouse does. The original PR #759 test mocked query_dicts to
+# return the same dict regardless of params — this is what we are fixing.
+# ---------------------------------------------------------------------------
+
+
+class _OrgFilteringSink:
+    """Fake sink that mimics ClickHouse's WHERE filtering.
+
+    The whole point of this test class is to NOT rubber-stamp every query
+    with a fixed return value (which is what the PR #759 test did). It
+    actually applies the WHERE filters from the parameters, so mismatched
+    org_id behaves exactly the way real ClickHouse does — by returning
+    zero rows.
+    """
+
+    def __init__(self) -> None:
+        # rows is a list of (repo_id_str, day, cpk, org_id) tuples,
+        # the four fields ``load_repo_complexity_delta_30d`` cares about.
+        self.rows: list[tuple[str, date, float, str]] = []
+
+    def add(self, *, repo_id: str, day: date, cpk: float, org_id: str) -> None:
+        self.rows.append((repo_id, day, cpk, org_id))
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        # Apply WHERE filter using the parameters the production query
+        # would set: repo_id, org_id, [start, end] date window with a
+        # midpoint split.
+        repo_id = parameters["repo_id"]
+        start = parameters["start"]
+        end = parameters["end"]
+        mid = parameters["mid"]
+        org_id = parameters["org_id"]
+
+        matched = [
+            (d, cpk)
+            for (rid, d, cpk, oid) in self.rows
+            if rid == repo_id and start <= d <= end and oid == org_id
+        ]
+        if not matched:
+            return []
+
+        first = [cpk for (d, cpk) in matched if d < mid]
+        second = [cpk for (d, cpk) in matched if d >= mid]
+        first_avg = sum(first) / len(first) if first else None
+        second_avg = sum(second) / len(second) if second else None
+        return [{"first_half": first_avg, "second_half": second_avg}]
+
+
+def test_load_complexity_delta_returns_value_when_org_id_matches() -> None:
+    """Demonstrates the happy path that PR #759's test never actually exercised."""
+    sink = _OrgFilteringSink()
+    repo_id = uuid.uuid4()
+
+    # Populate the trailing 30-day window with rising cyclomatic_per_kloc.
+    for i in range(30):
+        d = DAY.fromordinal(DAY.toordinal() - 29 + i)
+        cpk = 100.0 + i * 2.0  # rising trend, second half higher
+        sink.add(repo_id=str(repo_id), day=d, cpk=cpk, org_id=ORG)
+
+    delta = load_repo_complexity_delta_30d(
+        sink, repo_id=str(repo_id), day=DAY, org_id=ORG
+    )
+    assert delta is not None
+    assert delta > 0.0, "rising trend must produce positive delta"
+
+
+def test_load_complexity_delta_returns_none_when_org_id_mismatches() -> None:
+    """The exact CHAOS-1744 bug: rows tagged with the wrong org return None.
+
+    Pre-fix, every existing row had ``org_id=''`` because ``_build_snapshots``
+    dropped the parameter. The running daily job queried with the actual
+    org UUID and matched nothing.
+    """
+    sink = _OrgFilteringSink()
+    repo_id = uuid.uuid4()
+    # Data is stored under empty-string org_id (the pre-fix state).
+    for i in range(30):
+        d = DAY.fromordinal(DAY.toordinal() - 29 + i)
+        cpk = 100.0 + i * 2.0
+        sink.add(repo_id=str(repo_id), day=d, cpk=cpk, org_id="")
+
+    # Query with the real running org_id returns nothing.
+    delta = load_repo_complexity_delta_30d(
+        sink, repo_id=str(repo_id), day=DAY, org_id=ORG
+    )
+    assert delta is None, (
+        "Rows persisted with mismatched org_id must not be discoverable "
+        "by the daily job's org_id-scoped query. This is the failure mode "
+        "PR #759 missed."
+    )
+
+
+def test_load_complexity_delta_isolates_orgs() -> None:
+    """Multi-tenant safety: one org's complexity must not leak into another."""
+    sink = _OrgFilteringSink()
+    repo_id = uuid.uuid4()
+
+    for i in range(30):
+        d = DAY.fromordinal(DAY.toordinal() - 29 + i)
+        sink.add(
+            repo_id=str(repo_id), day=d, cpk=100.0 + i, org_id=ORG
+        )
+
+    # Same data tagged for ORG; another org querying must see nothing.
+    delta_other = load_repo_complexity_delta_30d(
+        sink, repo_id=str(repo_id), day=DAY, org_id=OTHER_ORG
+    )
+    assert delta_other is None

--- a/tests/metrics/test_complexity_org_id_propagation.py
+++ b/tests/metrics/test_complexity_org_id_propagation.py
@@ -62,13 +62,11 @@ def test_build_snapshots_propagates_org_id_to_file_snapshots() -> None:
     assert len(snapshots) == 2
     for snap in snapshots:
         assert snap.org_id == ORG, (
-            f"FileComplexitySnapshot.org_id must equal {ORG!r}, "
-            f"got {snap.org_id!r}."
+            f"FileComplexitySnapshot.org_id must equal {ORG!r}, got {snap.org_id!r}."
         )
 
 
 def test_fixtures_generator_propagates_org_id() -> None:
-    repo_id = uuid.uuid4()
     gen = SyntheticDataGenerator(repo_name="acme/demo-app", seed=42)
     data = gen.generate_complexity_metrics(days=2, org_id=ORG)
 
@@ -183,9 +181,7 @@ def test_load_complexity_delta_isolates_orgs() -> None:
 
     for i in range(30):
         d = DAY.fromordinal(DAY.toordinal() - 29 + i)
-        sink.add(
-            repo_id=str(repo_id), day=d, cpk=100.0 + i, org_id=ORG
-        )
+        sink.add(repo_id=str(repo_id), day=d, cpk=100.0 + i, org_id=ORG)
 
     # Same data tagged for ORG; another org querying must see nothing.
     delta_other = load_repo_complexity_delta_30d(


### PR DESCRIPTION
## TL;DR

CHAOS-1744 part 1 (PR #759) wired Compounding Risk into the daily job, but
the surface was still empty in production. Root cause: `_build_snapshots`
dropped its caller's `org_id`, so every complexity row was persisted with
`org_id=""`. The daily job then queried with the real org UUID, matched
zero rows, and every Compounding Risk score came back NULL.

This PR plumbs `org_id` through all three complexity writers and adds a
regression test that catches the failure mode PR #759 missed.

## Root cause

The chain (each step verified directly against the live ClickHouse stack):

1. `run_complexity_db_job(*, org_id: str, ...)` receives the running org.
2. It calls `_build_snapshots(repo_uuid, d, ref_value, file_results, computed_at)` — **no `org_id`**.
3. `RepoComplexityDaily(org_id: str = "")` and `FileComplexitySnapshot(org_id: str = "")` both default to empty string.
4. All 720 rows in `repo_complexity_daily` had `org_id=''`.
5. Daily job called `load_repo_complexity_delta_30d(..., org_id='ae600a94-...')`.
6. SQL: `WHERE org_id = {org_id:String}` → matched zero rows.
7. `complexity_delta` → `None` → `has_required_inputs()` → `False` → `compounding_risk` → `NULL`.

## Why PR #759 missed it

Its regression test (`tests/metrics/test_job_daily_compounding_risk.py`)
mocked `_Sink.query_dicts` to return a fixed dict regardless of params:

```python
def query_dicts(self, query, parameters):
    return [{"first_half": 100.0, "second_half": 130.0}]
```

So no matter what `org_id` was filtered on, the fake sink returned the
same complexity delta. The actual WHERE-filter behaviour of ClickHouse
was never exercised.

## What this PR changes

- `metrics/job_complexity_db.py::_build_snapshots` — accepts and propagates `org_id`
- `metrics/job_complexity.py::run_complexity_scan_job` — accepts and propagates `org_id`
- `fixtures/generators/commits.py::generate_complexity_metrics` — accepts and propagates `org_id`
- `fixtures/runner.py` — passes the runner's `org_id` to the generator
- `tests/metrics/test_complexity_org_id_propagation.py` — 6 new regression tests using a fake sink that actually enforces WHERE filters

## Verification (live ClickHouse, local stack)

**Before fix** (ops/main at `d7950b8dd`, after running daily metrics):

```
compounding_risk_daily: 4 rows, 0 non-null scores
repo_complexity_daily.org_id: '' (720 rows, empty string)
```

Every Compounding Risk score was `NULL`, every row was `severity='unknown'`.

**After fix** (this branch, truncated + re-ran `metrics complexity --backfill 90` + `metrics daily --backfill 90`):

```
compounding_risk_daily: 355 rows, 27 non-null scores
  severity buckets: 23 elevated, 4 low, 328 unknown
repo_complexity_daily.org_id: 'ae600a94-...' (360 rows, correct UUID)
```

27 real, computed scores. The remaining 328 "unknown" rows are days where
`pr_first_review_p90_hours` is NULL upstream in `repo_metrics_daily` — a
legitimate data gap (sparse PR review activity in synthetic fixtures), not
a Compounding Risk bug.

Full before/after evidence: [`docs/screenshots/chaos-1744/clickhouse-evidence.md`](docs/screenshots/chaos-1744/clickhouse-evidence.md)

### Sample populated rows

| day        | scope_id (truncated) | severity | score   | complexity_delta | review_p90h |
|------------|----------------------|----------|---------|------------------|-------------|
| 2026-05-20 | 65574b20…            | elevated | 0.4298  | 0                | 23.0        |
| 2026-05-12 | 2faf8e66…            | low      | 0.3433  | 0                | 4.7         |
| 2026-05-11 | 5b862ba7…            | elevated | 0.4458  | 0                | 23.1        |
| 2026-05-11 | 2faf8e66…            | elevated | 0.4756  | 0                | 35.3        |
| 2026-05-10 | 5b862ba7…            | elevated | 0.4175  | 0                | 17.0        |

## Tests

```
$ uv run pytest tests/metrics/test_complexity_org_id_propagation.py -v
============================== 6 passed in 4.24s ===============================

$ uv run pytest tests/metrics/test_compounding_risk.py tests/metrics/test_job_daily_compounding_risk.py
============================== 52 passed in 2.8s ===============================
```

Four pre-existing failures in `tests/test_fixtures_runner.py` are
pytest-asyncio environment issues (confirmed identical on `origin/main`)
and unrelated to this PR.

## Migration / operator note

Existing deployments with pre-fix data must re-run complexity metrics to
get rows tagged with the real `org_id`. The column is part of the
ClickHouse table sort key, so `ALTER TABLE … UPDATE org_id` is not
possible (ClickHouse rejects with `CANNOT_UPDATE_COLUMN`). The
recommended sequence:

```bash
# Truncate the affected tables (rows with empty org_id are unusable anyway)
clickhouse-client --query "TRUNCATE TABLE repo_complexity_daily"
clickhouse-client --query "TRUNCATE TABLE file_complexity_snapshots"

# Re-run complexity for the desired backfill window with the right org
dev-hops --org "$ORG_ID" metrics complexity --backfill 90

# Recompute compounding risk
dev-hops --org "$ORG_ID" metrics daily --backfill 90
```

## Screenshot waiver

`SCREENSHOT-WAIVER: backend-only data plumb; visual change relies on already-shipped GraphQL/web code from CHAOS-1642. Backend evidence in clickhouse-evidence.md.`

The GraphQL resolver (`api/graphql/resolvers/compounding_risk.py`) and
the web dashboard (`/risk/compounding` page) are unchanged. Once the
deployed environment runs the migration sequence above, the same UI
code will populate without any frontend change.

## Follow-ups (separate tickets)

- Investigate why `pr_first_review_p90_hours` is NULL for 91% of rows in
  the synthetic fixture set (upstream `repo_metrics_daily` quality issue,
  not Compounding Risk).
- UX polish: when a Compounding Risk surface returns rows but all scores
  are NULL, show a more informative "insufficient inputs for today" message
  instead of rendering rows full of "—".

## Linear

Refs CHAOS-1744
