### PR TITLE
fix(ops): spread synthetic PRs evenly across fixture window (CHAOS-1749)

### DIFF
--- a/src/dev_health_ops/fixtures/generators/prs.py
+++ b/src/dev_health_ops/fixtures/generators/prs.py
@@ -24,6 +24,7 @@ class PrsGeneratorMixin(BaseGeneratorMixin):
         self,
         count: int = 20,
         issue_numbers: list[int] | None = None,
+        days: int = 60,
     ) -> list[dict[str, Any]]:
         prs = []
         end_date = datetime.now(timezone.utc)
@@ -53,11 +54,13 @@ class PrsGeneratorMixin(BaseGeneratorMixin):
             "Cleanup Z",
         ]
 
+        fixture_days = max(1, int(days))
+
         for i in range(1, count + 1):
             author_name, author_email = random.choice(self.repo_authors)
-            # PRs created over the last 60 days
+            created_day_offset = (i - 1) % fixture_days
             created_at = end_date - timedelta(
-                days=random.randint(0, 60), hours=random.randint(0, 23)
+                days=created_day_offset, hours=random.randint(0, 23)
             )
             issue_ref = None
             if issue_numbers and random.random() > 0.3:

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -547,7 +547,9 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
 
             # 5. PRs & Reviews
             pr_data = generator.generate_prs(
-                count=ns.pr_count, issue_numbers=issue_numbers
+                count=max(ns.pr_count, ns.days * 2),
+                issue_numbers=issue_numbers,
+                days=ns.days,
             )
             prs = [p["pr"] for p in pr_data]
             await _insert_batches(

--- a/tests/fixtures/test_pr_review_latency_coverage.py
+++ b/tests/fixtures/test_pr_review_latency_coverage.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+
+from dev_health_ops.fixtures.generator import SyntheticDataGenerator
+from dev_health_ops.metrics.compute import compute_daily_metrics
+from dev_health_ops.metrics.schemas import CommitStatRow, PullRequestRow
+
+
+def _pr_row(pr) -> PullRequestRow:
+    return {
+        "repo_id": pr.repo_id,
+        "number": pr.number,
+        "author_email": pr.author_email,
+        "author_name": pr.author_name,
+        "created_at": pr.created_at,
+        "merged_at": pr.merged_at,
+        "first_review_at": pr.first_review_at,
+        "first_comment_at": pr.first_comment_at,
+        "reviews_count": pr.reviews_count,
+        "changes_requested_count": pr.changes_requested_count,
+        "comments_count": pr.comments_count,
+        "additions": pr.additions,
+        "deletions": pr.deletions,
+        "changed_files": pr.changed_files,
+    }
+
+
+def _commit_row(repo_id, day: date) -> CommitStatRow:
+    return {
+        "repo_id": repo_id,
+        "commit_hash": f"commit-{day.isoformat()}",
+        "author_email": "alice@example.com",
+        "author_name": "Alice Smith",
+        "committer_when": datetime.combine(day, time(hour=12), tzinfo=timezone.utc),
+        "file_path": "src/main.py",
+        "additions": 10,
+        "deletions": 2,
+    }
+
+
+def test_synthetic_prs_populate_review_latency_for_most_daily_rows() -> None:
+    days = 90
+    generator = SyntheticDataGenerator(repo_name="acme/demo-app", seed=1749)
+    pr_rows = [
+        _pr_row(item["pr"])
+        for item in generator.generate_prs(count=days * 2, days=days)
+    ]
+    today = datetime.now(timezone.utc).date()
+    start_day = today - timedelta(days=days - 1)
+    non_null_review_days = 0
+
+    for offset in range(days):
+        day = start_day + timedelta(days=offset)
+        window_start = datetime.combine(day, time.min, tzinfo=timezone.utc)
+        window_end = window_start + timedelta(days=1)
+        daily_pr_rows = [
+            pr
+            for pr in pr_rows
+            if window_start <= pr["created_at"] < window_end
+            or (
+                pr["merged_at"] is not None
+                and window_start <= pr["merged_at"] < window_end
+            )
+        ]
+        result = compute_daily_metrics(
+            day=day,
+            commit_stat_rows=[_commit_row(generator.repo_id, day)],
+            pull_request_rows=daily_pr_rows,
+            pull_request_review_rows=[],
+            computed_at=window_end,
+        )
+        repo_metric = result.repo_metrics[0]
+        if repo_metric.pr_first_review_p90_hours is not None:
+            non_null_review_days += 1
+
+    assert non_null_review_days / days >= 0.5


### PR DESCRIPTION
## TL;DR

`pr_first_review_p90_hours` was NULL for ~91% of rows in `repo_metrics_daily` against the synthetic fixture stack, blocking Compounding Risk (CHAOS-1744) from computing scores even when `complexity_delta` was correctly populated. Root cause: the synthetic PR generator distributed all PRs randomly across a 60-day window, so most days had 0 or 1 PR and the p90 of review latency returned NULL.

This PR spreads PRs evenly across the requested fixture window so every day gets at least one PR.

## Root cause

`PrsGeneratorMixin.generate_prs()` (in `src/dev_health_ops/fixtures/generators/prs.py`) placed every synthetic PR within `random.randint(0, 60)` days of "now". With the default `count=20`, that's 20 PRs uniformly distributed across 60 days — roughly one PR every three days. For a 90-day analytics backfill, the vast majority of days had zero or one PR, so the per-day p90 of `first_review_at - created_at` returned NULL (no percentile possible on too-few samples).

The `compounding_risk` composite requires four inputs (`rework_churn`, `complexity_delta`, `ownership concentration`, `review_latency_p90h`), and a missing single one collapses the row to `severity='unknown'`. In the CHAOS-1744 part 2 stack snapshot, 328/355 Compounding Risk rows had `severity='unknown'` purely because review latency was missing.

## Fix

Three small changes:

- `generate_prs()` accepts a new `days` keyword (default 60 for backward compatibility) and assigns `created_day_offset = (i - 1) % days`, distributing PR creation evenly across the window. Guarantees at least `count // days` PRs per day.
- `fixtures/runner.py` passes `days=ns.days` and bumps `count` to `max(ns.pr_count, ns.days * 2)` so the backfill window always has enough PRs to populate review latency at p90.
- New regression test that exercises the **real** generator + real `compute_daily_metrics` (no mocked sink).

## Verification

```
$ uv run pytest tests/fixtures/test_pr_review_latency_coverage.py -v
tests/fixtures/test_pr_review_latency_coverage.py::test_synthetic_prs_populate_review_latency_for_most_daily_rows PASSED
============================== 1 passed in 1.28s ===============================
```

The test runs the actual `SyntheticDataGenerator.generate_prs(count=180, days=90)`, feeds the rows into the real `compute_daily_metrics`, and asserts `>= 50%` of days produce non-null `pr_first_review_p90_hours`. Pre-fix the same test would have produced ~8-10% non-null days.

Full fixture + compounding + complexity suite still green:
```
$ uv run pytest tests/fixtures/ tests/metrics/test_compounding_risk.py tests/metrics/test_complexity_org_id_propagation.py
47 passed in 1.36s
```

## Why this matters for CHAOS-1744

After PR #760 (CHAOS-1744 part 2) shipped, `complexity_delta` was correctly populated but `pr_first_review_p90_hours` was still NULL on most days — so Compounding Risk scores still came back NULL for 328/355 days in the local stack. With this fix, review latency populates densely enough that Compounding Risk scores compute for the majority of days, and the `/risk/compounding` surface populates as designed.

## Test pattern note

Per the AGENTS.md guidance and the lesson from CHAOS-1744 part 1, this test does **not** mock the sink's query behaviour. PR #759 (the original CHAOS-1744 fix) shipped a buggy state because its test stubbed `query_dicts` to return canned values, hiding the org_id filter mismatch. This test uses the real generator + real compute pipeline, so any regression in either layer will fail it.

## Operator note

Existing rows in `repo_metrics_daily` written before this fix retain their NULL review-latency values (no migration needed — review-latency is recomputed on the next daily run from fresh PR data). To pick up the fix:

```bash
clickhouse-client --query "TRUNCATE TABLE prs"
clickhouse-client --query "TRUNCATE TABLE pr_reviews"
dev-hops --org "$ORG_ID" fixtures generate --sink "$CH_URI" --days 90 --with-metrics
dev-hops --org "$ORG_ID" metrics daily --backfill 90
```

## Screenshot waiver

`SCREENSHOT-WAIVER: backend-only fixture/generator change; visual impact is downstream of CHAOS-1744 + this fix, and was already proven via the populated /risk/compounding screenshots in CHAOS-1750 (web PR).`

## Linear

Refs CHAOS-1749
