### PR TITLE
fix(api): TEAM catalog reads from semantic teams table (CHAOS-1751)

### DIFF
--- a/docs/api/team-catalog-source-of-truth.md
+++ b/docs/api/team-catalog-source-of-truth.md
@@ -1,0 +1,106 @@
+# Team-Dimension Catalog: Source of Truth
+
+**Status:** Authoritative (CHAOS-1751)
+
+## Contract
+
+The semantic `teams` ClickHouse table is the **source of truth** for the
+`TEAM` dimension in the GraphQL `catalog` query. Activity counts are
+looked up from an event table via `LEFT JOIN`, so a team with no recorded
+activity in the window still appears in the picker with `count = 0`.
+
+This contract applies to the GraphQL `catalog(orgId, dimension: TEAM)`
+field. Other dimensions (`REPO`, `AUTHOR`, `WORK_TYPE`, `THEME`,
+`SUBCATEGORY`) continue to derive distinct values from the event table
+directly, because their identifiers are not first-class semantic
+entities the same way teams are.
+
+## Why
+
+`investment_metrics_daily.team_id` and other `_metrics_daily.team_id`
+columns are event-time analytics columns. Their values are populated by
+sinks during metric computation and may reflect:
+
+- Resolved team identifiers (`teams.id`) when the resolver matched.
+- The sentinel `"unassigned"` when no team could be resolved.
+- Synthetic literals from fixture generators (e.g. the historical
+  `"alpha"` fallback in `fixtures/generators/investments.py`).
+
+Using these columns as the source of truth for the picker conflates the
+event-time namespace with the semantic roster:
+
+- Active teams with no activity in the window disappear from the picker.
+- Synthetic / sentinel values leak into the UX.
+- The picker silently diverges from any other surface that reads from
+  `teams`.
+
+Surfacing the roster from `teams` and joining counts from an event
+table keeps the two namespaces aligned and makes data gaps observable
+(a real team showing `count = 0` is a fact about activity, not a UX bug).
+
+## Query Shape
+
+The compiled SQL for `catalog(orgId, dimension: TEAM)` is roughly:
+
+```sql
+SELECT
+    t.id AS value,
+    COALESCE(activity.count, 0) AS count
+FROM (
+    SELECT id, name
+    FROM teams FINAL
+    WHERE org_id = %(org_id)s
+      AND is_active = 1
+      AND id != ''
+) AS t
+LEFT JOIN (
+    SELECT toString(team_id) AS team_id, COUNT(*) AS count
+    FROM investment_metrics_daily
+    WHERE team_id IS NOT NULL
+      AND investment_metrics_daily.org_id = %(org_id)s
+      AND toString(team_id) != ''
+    GROUP BY team_id
+) AS activity ON activity.team_id = t.id
+ORDER BY count DESC, t.name ASC
+LIMIT %(limit)s
+```
+
+The count source is determined by the existing source-selection logic
+in `compile_catalog_values` and matches the event table the rest of the
+GraphQL analytics surface reads from for the same query mode
+(investment vs. non-investment).
+
+## Filters
+
+Scope/category filters in `FilterInput` target event-table columns
+(e.g. `team_id`, `repo_id`, `work_unit_type`). They are intentionally
+**not** applied to the team picker query: the picker exposes the full
+active roster regardless of what scope is selected, so users can switch
+scope freely. Activity counts narrow with the count-source query if a
+follow-up surface re-queries with the chosen filters; the catalog
+itself stays roster-complete.
+
+## Divergence with `/api/v1/filters/options`
+
+The legacy REST endpoint `GET /api/v1/filters/options` builds a
+Python-side `UNION ALL` across `teams FINAL`, `user_metrics_daily`, and
+`work_item_user_metrics_daily`. It is **not** the source of truth for
+the GraphQL surface and should be converged onto the same shared helper
+in a follow-up. New consumers should use the GraphQL `catalog` field.
+
+## Files
+
+- `src/dev_health_ops/api/graphql/sql/templates.py` —
+  `catalog_values_team_template()`
+- `src/dev_health_ops/api/graphql/sql/compiler.py` —
+  `compile_catalog_values()` (TEAM branch)
+- `src/dev_health_ops/api/graphql/sql/validate.py` — `Dimension.TEAM`
+- `tests/graphql/test_compiler.py` —
+  `TestCompileCatalogValues::test_team_catalog_uses_teams_table_as_source_of_truth`
+
+## History
+
+- CHAOS-1751: Established `teams` as the source of truth for the TEAM
+  dimension catalog; `LEFT JOIN`-based counts surfaced honestly,
+  including teams with `count = 0`. Fixture runner aligned to use the
+  semantic `teams.id` namespace for event-table writes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
       - View Mapping: api/view-mapping.md
       - Web GraphQL Client: api/web-graphql-client.md
       - Web Investment Queries: api/web-graphql-investment.md
+      - Team Catalog Source of Truth: api/team-catalog-source-of-truth.md
   - Visualizations: visualizations/patterns.md
   - LLM: llm/categorization-contract.md
   - Task Trackers: task_trackers.md

--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -13,8 +13,8 @@ from ..authz import enforce_org_scope
 from .filter_translation import translate_filters
 from .templates import (
     breakdown_template,
-    catalog_values_template,
     catalog_values_team_template,
+    catalog_values_template,
     flow_matrix_repo_edges_template,
     flow_matrix_repo_nodes_template,
     flow_matrix_team_edges_template,
@@ -459,9 +459,7 @@ def compile_catalog_values(
         filter_clause, filter_params = translate_filters(
             filters, use_investment=ctx.get("use_investment", False)
         )
-        sql = catalog_values_template(
-            dimension, filter_clause=filter_clause, **ctx
-        )
+        sql = catalog_values_template(dimension, filter_clause=filter_clause, **ctx)
         params.update(filter_params)
 
     params = enforce_org_scope(org_id, params)

--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -14,6 +14,7 @@ from .filter_translation import translate_filters
 from .templates import (
     breakdown_template,
     catalog_values_template,
+    catalog_values_team_template,
     flow_matrix_repo_edges_template,
     flow_matrix_repo_nodes_template,
     flow_matrix_team_edges_template,
@@ -428,6 +429,12 @@ def compile_catalog_values(
 ) -> tuple[str, dict[str, Any]]:
     """
     Compile a catalog values request to parameterized SQL.
+
+    CHAOS-1751: The TEAM dimension uses the semantic ``teams`` table as
+    the source of truth (LEFT JOINed to an event table for activity
+    counts) so the picker reflects the org's actual roster, including
+    teams with zero recorded activity. All other dimensions continue to
+    derive distinct values from the event table directly.
     """
     dimension = validate_dimension(request.dimension)
 
@@ -436,18 +443,27 @@ def compile_catalog_values(
         needs_team_join=_needs_team_join(filters),
     )
 
-    # Translate filters to SQL clause
-    filter_clause, filter_params = translate_filters(
-        filters, use_investment=ctx.get("use_investment", False)
-    )
-
-    sql = catalog_values_template(dimension, filter_clause=filter_clause, **ctx)
-
     params: dict[str, Any] = {
         "limit": request.limit,
         "timeout": timeout,
     }
-    params.update(filter_params)
+
+    if dimension == Dimension.TEAM:
+        # Filter scope/category clauses target event-table columns, which
+        # do not apply when listing teams from the semantic source of
+        # truth. The picker always exposes the full active roster.
+        sql = catalog_values_team_template(
+            count_source_table=ctx["source_table"],
+        )
+    else:
+        filter_clause, filter_params = translate_filters(
+            filters, use_investment=ctx.get("use_investment", False)
+        )
+        sql = catalog_values_template(
+            dimension, filter_clause=filter_clause, **ctx
+        )
+        params.update(filter_params)
+
     params = enforce_org_scope(org_id, params)
 
     return sql, params

--- a/src/dev_health_ops/api/graphql/sql/templates.py
+++ b/src/dev_health_ops/api/graphql/sql/templates.py
@@ -394,3 +394,44 @@ ORDER BY count DESC
 LIMIT %(limit)s
 SETTINGS max_execution_time = %(timeout)s
 """
+
+
+def catalog_values_team_template(
+    count_source_table: str = "investment_metrics_daily",
+    **kwargs: Any,
+) -> str:
+    """Generate SQL template for catalog values of the TEAM dimension.
+
+    CHAOS-1751: The semantic ``teams`` table is the source of truth for
+    the team-dimension catalog. Activity counts are looked up from an
+    event table via LEFT JOIN so teams with zero activity still appear
+    (with ``count = 0``) and the picker reflects the org's actual roster
+    rather than the synthetic event-table namespace.
+
+    See ``docs/api/team-catalog-source-of-truth.md`` for the contract.
+    """
+    return f"""
+SELECT
+    t.id AS value,
+    COALESCE(activity.count, 0) AS count
+FROM (
+    SELECT id, name
+    FROM teams FINAL
+    WHERE org_id = %(org_id)s
+      AND is_active = 1
+      AND id != ''
+) AS t
+LEFT JOIN (
+    SELECT
+        toString(team_id) AS team_id,
+        COUNT(*) AS count
+    FROM {count_source_table}
+    WHERE team_id IS NOT NULL
+      AND {count_source_table}.org_id = %(org_id)s
+      AND toString(team_id) != ''
+    GROUP BY team_id
+) AS activity ON activity.team_id = t.id
+ORDER BY count DESC, t.name ASC
+LIMIT %(limit)s
+SETTINGS max_execution_time = %(timeout)s
+"""

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -822,7 +822,12 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                         dict[str, Any], fixture_data["feature_flag_contexts"][i]
                     )
                     metric_gen = SyntheticDataGenerator(
-                        repo_name=r_name, seed=seed_value
+                        repo_name=r_name,
+                        seed=seed_value,
+                        # CHAOS-1751: align event-table team_ids with the
+                        # semantic teams.id namespace so the catalog
+                        # picker surfaces meaningful counts.
+                        assigned_teams=fixture_data["teams"] or None,
                     )
 
                     dora_records = metric_gen.generate_dora_metrics(days=ns.days)

--- a/tests/graphql/test_compiler.py
+++ b/tests/graphql/test_compiler.py
@@ -256,27 +256,45 @@ class TestCompileSankey:
 class TestCompileCatalogValues:
     """Tests for compile_catalog_values."""
 
-    def test_basic_catalog_values(self):
-        """Test basic catalog values compilation."""
-        request = CatalogValuesRequest(
-            dimension="team",
-            limit=100,
-        )
+    def test_team_catalog_uses_teams_table_as_source_of_truth(self):
+        """CHAOS-1751: TEAM catalog must come from the semantic `teams`
+        table (LEFT JOIN counts from the event table) so the picker
+        surfaces the active roster including teams with count=0."""
+        request = CatalogValuesRequest(dimension="team", limit=100)
         org_id = "test-org"
 
         sql, params = compile_catalog_values(request, org_id)
 
-        # Check SQL structure
+        # Source of truth is `teams FINAL`, not the event table.
+        assert "teams FINAL" in sql
+        assert "is_active = 1" in sql
+        # Activity counts come from the event table via LEFT JOIN.
+        assert "LEFT JOIN" in sql
+        assert "COALESCE(activity.count, 0)" in sql
+        assert "investment_metrics_daily" in sql
+        # Teams with zero activity must still surface honestly.
+        assert "GROUP BY team_id" in sql
+        assert "LIMIT" in sql
+
+        assert params["org_id"] == org_id
+        assert params["limit"] == 100
+
+    def test_non_team_catalog_uses_event_table_directly(self):
+        """REPO and other non-team dimensions retain the original
+        event-table catalog behavior."""
+        request = CatalogValuesRequest(dimension="repo", limit=100)
+        org_id = "test-org"
+
+        sql, _ = compile_catalog_values(request, org_id)
+
         assert "SELECT" in sql
-        assert "team_id" in sql
+        assert "repo_id" in sql
         assert "COUNT(*)" in sql
         assert "GROUP BY" in sql
         assert "investment_metrics_daily" in sql
-        assert "LIMIT" in sql
-
-        # Check params
-        assert params["org_id"] == org_id
-        assert params["limit"] == 100
+        # No teams FINAL or LEFT JOIN for non-team dimensions.
+        assert "teams FINAL" not in sql
+        assert "LEFT JOIN" not in sql
 
     def test_org_id_always_in_params(self):
         """Test that org_id is always included in params."""


### PR DESCRIPTION
## Summary

`/operating-review`'s team picker shows "No teams synced" even when the `teams` table is populated, because the GraphQL `catalog(orgId, dimension: TEAM)` resolver derived distinct values from `investment_metrics_daily.team_id` — an event-time analytics column whose values come from sinks (and, in the synthetic fixture, the literal `"alpha"`).

This PR makes the semantic `teams` ClickHouse table the **source of truth** for the TEAM dimension catalog. Activity counts are looked up from the event table via `LEFT JOIN`, so teams with no recorded activity in the window still appear with `count = 0` instead of disappearing. Other dimensions (`REPO`, `AUTHOR`, `WORK_TYPE`, `THEME`, `SUBCATEGORY`) retain the original event-table catalog behavior.

The PR also fixes the secondary fixture defect that exposed the bug: the per-repo investment generator in `fixtures/runner.py` was constructed without `assigned_teams`, so it fell back to the `"alpha"` literal, leaving `teams.id` (`team-1..team-10`) and `investment_metrics_daily.team_id` (`alpha`) in disjoint namespaces.

## Changes

- **`api/graphql/sql/templates.py`** — new `catalog_values_team_template()`:

  ```sql
  SELECT
      t.id AS value,
      COALESCE(activity.count, 0) AS count
  FROM (SELECT id, name FROM teams FINAL
        WHERE org_id = %(org_id)s AND is_active = 1 AND id != '') AS t
  LEFT JOIN (
      SELECT toString(team_id) AS team_id, COUNT(*) AS count
      FROM <count_source_table>
      WHERE team_id IS NOT NULL
        AND <count_source_table>.org_id = %(org_id)s
        AND toString(team_id) != ''
      GROUP BY team_id
  ) AS activity ON activity.team_id = t.id
  ORDER BY count DESC, t.name ASC
  LIMIT %(limit)s
  ```

- **`api/graphql/sql/compiler.py`** — `compile_catalog_values()` branches on `Dimension.TEAM` to use the new template. Scope/category filters intentionally do not apply to the team picker (the picker always exposes the full active roster regardless of selected scope).

- **`fixtures/runner.py`** — pass `assigned_teams=fixture_data["teams"]` to the per-repo `SyntheticDataGenerator` so synthetic investment metrics use the seeded `teams.id` namespace.

- **`tests/graphql/test_compiler.py`** — `test_team_catalog_uses_teams_table_as_source_of_truth` asserts the new TEAM SQL shape (`teams FINAL`, `LEFT JOIN`, `COALESCE(activity.count, 0)`); `test_non_team_catalog_uses_event_table_directly` asserts unchanged behavior for `REPO`.

- **`docs/api/team-catalog-source-of-truth.md`** — new contract doc describing the source-of-truth rule, the compiled query shape, filter behavior, and the divergence with the legacy `/api/v1/filters/options` REST endpoint (to be converged in a follow-up).

## Acceptance criteria

- [x] `/operating-review` lists all active teams from the `teams` table.
- [x] Teams with no `_metrics_daily.team_id` activity surface with `count = 0` instead of disappearing.
- [x] Contract documented at `docs/api/team-catalog-source-of-truth.md`.

## Testing

```
$ pytest tests/graphql/ tests/api/graphql/ tests/api/ \
    --ignore=tests/graphql/test_flow_matrix_live.py --deselect tests/api/services/test_filtering.py
699 passed, 7 deselected in 20s

$ pytest tests/fixtures/ tests/test_fixtures_runner.py tests/test_fixtures_seed_auth_idempotent.py tests/test_teams.py
41 passed in 4.55s
```

LSP diagnostics clean across all 4 changed files.

## Follow-up

- Converge `/api/v1/filters/options` UNION query onto the shared team-catalog helper.
- Consider whether other catalog dimensions (`REPO`, `AUTHOR`) should also read from semantic tables once those have first-class semantic registries.

SCREENSHOT-WAIVER: backend-only change; the GraphQL response shape is unchanged.

Closes CHAOS-1751