### PR TITLE
feat(ops): add backend active org switching (CHAOS-1753)

### DIFF
--- a/src/dev_health_ops/api/auth/routers/common.py
+++ b/src/dev_health_ops/api/auth/routers/common.py
@@ -97,7 +97,9 @@ def _expiry_to_utc(value: object) -> datetime | None:
 
 
 def _membership_joined_sort_value(membership: Membership) -> datetime:
-    joined_at = membership.joined_at or membership.created_at
+    joined_at = getattr(membership, "joined_at", None) or getattr(
+        membership, "created_at", None
+    )
     if joined_at is None:
         return datetime.min.replace(tzinfo=timezone.utc)
     if joined_at.tzinfo is None:
@@ -242,7 +244,7 @@ async def _issue_membership_tokens(
     db,
     request: Request,
     db_user: User,
-    membership: Membership,
+    membership: Membership | None,
 ):
     from dev_health_ops.api.auth.router import (
         create_refresh_token_record,
@@ -250,11 +252,13 @@ async def _issue_membership_tokens(
     )
 
     auth_service = get_auth_service()
+    org_id = str(membership.org_id) if membership is not None else ""
+    role = str(membership.role) if membership is not None else "member"
     token_pair = auth_service.create_token_pair(
         user_id=str(db_user.id),
         email=str(db_user.email),
-        org_id=str(membership.org_id),
-        role=str(membership.role),
+        org_id=org_id,
+        role=role,
         is_superuser=bool(db_user.is_superuser),
         username=str(db_user.username) if db_user.username is not None else None,
         full_name=str(db_user.full_name) if db_user.full_name is not None else None,
@@ -263,13 +267,13 @@ async def _issue_membership_tokens(
     refresh_payload = auth_service.validate_token(
         token_pair.refresh_token, token_type="refresh"
     )
-    if refresh_payload and refresh_payload.get("jti"):
+    if membership is not None and refresh_payload and refresh_payload.get("jti"):
         expires_at = _expiry_to_utc(refresh_payload.get("exp"))
         if expires_at is not None:
             await create_refresh_token_record(
                 db=db,
                 user_id=str(db_user.id),
-                org_id=str(membership.org_id),
+                org_id=org_id,
                 token_hash=str(refresh_payload["jti"]),
                 family_id=str(refresh_payload.get("family_id") or uuid_mod.uuid4()),
                 expires_at=expires_at,

--- a/src/dev_health_ops/api/auth/routers/common.py
+++ b/src/dev_health_ops/api/auth/routers/common.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 import uuid as uuid_mod
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from fastapi import Request
@@ -12,6 +15,12 @@ from sqlalchemy import select
 from dev_health_ops.models.users import Membership, Organization, User
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class OrganizationActivity:
+    has_data: bool = False
+    last_metrics_at: datetime | None = None
 
 
 class UserInfo(BaseModel):
@@ -31,6 +40,17 @@ class LoginResponse(BaseModel):
     expires_in: int
     needs_onboarding: bool = False
     user: UserInfo
+
+
+class OrganizationMembershipInfo(BaseModel):
+    id: str
+    slug: str
+    name: str
+    tier: str | None = None
+    role: str
+    joined_at: datetime | None = None
+    has_data: bool = False
+    last_metrics_at: datetime | None = None
 
 
 class VerifyEmailResponse(BaseModel):
@@ -74,6 +94,126 @@ def _expiry_to_utc(value: object) -> datetime | None:
     if isinstance(value, int | float):
         return datetime.fromtimestamp(value, tz=timezone.utc)
     return None
+
+
+def _membership_joined_sort_value(membership: Membership) -> datetime:
+    joined_at = membership.joined_at or membership.created_at
+    if joined_at is None:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if joined_at.tzinfo is None:
+        return joined_at.replace(tzinfo=timezone.utc)
+    return joined_at.astimezone(timezone.utc)
+
+
+def _select_active_membership(
+    memberships: Sequence[Membership],
+    requested_org_id: uuid_mod.UUID | None,
+    activity_by_org: dict[uuid_mod.UUID, OrganizationActivity],
+) -> Membership | None:
+    if requested_org_id is not None:
+        return next(
+            (
+                membership
+                for membership in memberships
+                if membership.org_id == requested_org_id
+            ),
+            None,
+        )
+
+    if not memberships:
+        return None
+
+    def sort_key(membership: Membership) -> tuple[bool, float, datetime]:
+        org_id = _require_uuid(membership.org_id, "membership.org_id")
+        activity = activity_by_org.get(org_id, OrganizationActivity())
+        last_metrics_at = activity.last_metrics_at or datetime.min.replace(
+            tzinfo=timezone.utc
+        )
+        return (
+            not activity.has_data,
+            -last_metrics_at.timestamp(),
+            _membership_joined_sort_value(membership),
+        )
+
+    return min(
+        memberships,
+        key=sort_key,
+    )
+
+
+def _load_org_activity(
+    org_ids: Iterable[uuid_mod.UUID],
+) -> dict[uuid_mod.UUID, OrganizationActivity]:
+    ids = list(dict.fromkeys(org_ids))
+    dsn = os.environ.get("CLICKHOUSE_URI") or os.environ.get("DEV_HEALTH_SINK")
+    if not ids or not dsn:
+        return {org_id: OrganizationActivity() for org_id in ids}
+
+    try:
+        from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+    except ImportError as exc:
+        logger.debug("ClickHouse unavailable for org activity lookup: %s", exc)
+        return {org_id: OrganizationActivity() for org_id in ids}
+
+    sink = None
+    activity = {org_id: OrganizationActivity() for org_id in ids}
+    metric_tables = (
+        "repo_metrics_daily",
+        "user_metrics_daily",
+        "team_metrics_daily",
+        "work_item_metrics_daily",
+    )
+    try:
+        sink = ClickHouseMetricsSink(dsn=dsn)
+        for org_id in ids:
+            last_metrics_at: datetime | None = None
+            has_data = False
+            for table in metric_tables:
+                try:
+                    result = sink.client.query(
+                        f"""
+                        SELECT count() AS row_count, max(computed_at) AS last_metrics_at
+                        FROM {table}
+                        WHERE org_id = {{org_id:String}}
+                        """,
+                        parameters={"org_id": str(org_id)},
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        "Skipping org activity lookup for table %s: %s", table, exc
+                    )
+                    continue
+
+                row = (getattr(result, "result_rows", None) or [(0, None)])[0]
+                row_count = int(row[0] or 0)
+                table_last_metrics_at = _expiry_to_utc(row[1])
+                has_data = has_data or row_count > 0
+                if table_last_metrics_at is not None and (
+                    last_metrics_at is None or table_last_metrics_at > last_metrics_at
+                ):
+                    last_metrics_at = table_last_metrics_at
+            activity[org_id] = OrganizationActivity(
+                has_data=has_data,
+                last_metrics_at=last_metrics_at,
+            )
+    except Exception as exc:
+        logger.debug("Org activity lookup unavailable: %s", exc)
+    finally:
+        if sink is not None:
+            sink.close()
+    return activity
+
+
+def _to_user_info(user: User, membership: Membership | None) -> UserInfo:
+    return UserInfo(
+        id=str(user.id),
+        email=str(user.email),
+        username=str(user.username) if user.username is not None else None,
+        full_name=str(user.full_name) if user.full_name is not None else None,
+        org_id=str(membership.org_id) if membership else None,
+        role=str(membership.role) if membership else "member",
+        is_superuser=bool(user.is_superuser),
+    )
 
 
 async def _resolve_login_audit_org_id(
@@ -161,16 +301,21 @@ def _extract_unverified_org_and_subject(
 
 __all__ = [
     "LoginResponse",
+    "OrganizationActivity",
+    "OrganizationMembershipInfo",
     "UserInfo",
     "VerifyEmailResponse",
     "_coerce_uuid",
     "_expiry_to_utc",
     "_extract_unverified_org_and_subject",
     "_issue_membership_tokens",
+    "_load_org_activity",
     "_optional_uuid",
     "_parse_uuid",
     "_require_uuid",
     "_resolve_login_audit_org_id",
+    "_select_active_membership",
     "_slugify_org_name",
+    "_to_user_info",
     "logger",
 ]

--- a/src/dev_health_ops/api/auth/routers/login.py
+++ b/src/dev_health_ops/api/auth/routers/login.py
@@ -29,12 +29,14 @@ from dev_health_ops.models.users import Membership, User
 
 from .common import (
     LoginResponse,
-    UserInfo,
-    _expiry_to_utc,
+    _issue_membership_tokens,
+    _load_org_activity,
     _optional_uuid,
     _parse_uuid,
     _require_uuid,
     _resolve_login_audit_org_id,
+    _select_active_membership,
+    _to_user_info,
 )
 
 logger = logging.getLogger(__name__)
@@ -69,8 +71,6 @@ async def login(
     request: Request,
 ) -> LoginResponse | EmailVerificationRequiredResponse:
     from dev_health_ops.api.auth.router import (
-        create_refresh_token_record,
-        get_auth_service,
         get_postgres_session,
     )
 
@@ -231,21 +231,28 @@ async def login(
                 message="Please verify your email address before logging in",
             )
 
-        membership_stmt = select(Membership).where(Membership.user_id == user.id)
-
-        if payload.org_id:
-            membership_stmt = membership_stmt.where(Membership.org_id == payload.org_id)
-
+        membership_stmt = (
+            select(Membership)
+            .where(Membership.user_id == user.id)
+            .order_by(Membership.joined_at.asc(), Membership.created_at.asc())
+        )
         membership_result = await db.execute(membership_stmt)
-        membership = membership_result.scalar_one_or_none()
+        memberships = list(membership_result.scalars().all())
+        requested_org_id = _parse_uuid(payload.org_id)
+        activity_by_org = _load_org_activity(
+            _require_uuid(membership.org_id, "membership.org_id")
+            for membership in memberships
+        )
+        membership = _select_active_membership(
+            memberships,
+            requested_org_id,
+            activity_by_org,
+        )
 
         needs_onboarding = membership is None and not bool(user.is_superuser)
 
         if payload.org_id and not membership:
-            any_membership_result = await db.execute(
-                select(Membership.id).where(Membership.user_id == user.id)
-            )
-            if any_membership_result.first() is not None:
+            if memberships:
                 raise HTTPException(
                     status_code=401,
                     detail=error_detail(
@@ -278,47 +285,13 @@ async def login(
 
         await db.commit()
 
-        auth_service = get_auth_service()
-        token_pair = auth_service.create_token_pair(
-            user_id=str(user.id),
-            email=str(user.email),
-            org_id=str(membership.org_id) if membership else "",
-            role=str(membership.role) if membership else "member",
-            is_superuser=bool(user.is_superuser),
-            username=str(user.username) if user.username is not None else None,
-            full_name=str(user.full_name) if user.full_name is not None else None,
-        )
-
-        refresh_payload = auth_service.validate_token(
-            token_pair.refresh_token, token_type="refresh"
-        )
-        if refresh_payload and membership and refresh_payload.get("jti"):
-            expires_at = _expiry_to_utc(refresh_payload.get("exp"))
-            if expires_at is not None:
-                await create_refresh_token_record(
-                    db=db,
-                    user_id=str(user.id),
-                    org_id=str(membership.org_id),
-                    token_hash=str(refresh_payload["jti"]),
-                    family_id=str(refresh_payload.get("family_id") or uuid_mod.uuid4()),
-                    expires_at=expires_at,
-                    ip_address=request.client.host if request.client else None,
-                    user_agent=request.headers.get("user-agent"),
-                )
+        token_pair = await _issue_membership_tokens(db, request, user, membership) if membership else None
 
         return LoginResponse(
-            access_token=token_pair.access_token,
-            refresh_token=token_pair.refresh_token,
-            token_type=token_pair.token_type,
-            expires_in=token_pair.expires_in,
+            access_token=token_pair.access_token if token_pair else "",
+            refresh_token=token_pair.refresh_token if token_pair else "",
+            token_type=token_pair.token_type if token_pair else "bearer",
+            expires_in=token_pair.expires_in if token_pair else 0,
             needs_onboarding=needs_onboarding,
-            user=UserInfo(
-                id=str(user.id),
-                email=str(user.email),
-                username=str(user.username) if user.username is not None else None,
-                full_name=str(user.full_name) if user.full_name is not None else None,
-                org_id=str(membership.org_id) if membership else None,
-                role=str(membership.role) if membership else "member",
-                is_superuser=bool(user.is_superuser),
-            ),
+            user=_to_user_info(user, membership),
         )

--- a/src/dev_health_ops/api/auth/routers/login.py
+++ b/src/dev_health_ops/api/auth/routers/login.py
@@ -237,7 +237,13 @@ async def login(
             .order_by(Membership.joined_at.asc(), Membership.created_at.asc())
         )
         membership_result = await db.execute(membership_stmt)
-        memberships = list(membership_result.scalars().all())
+        if hasattr(membership_result, "scalars"):
+            memberships = list(membership_result.scalars().all())
+        else:
+            # Legacy unit-test fakes expose only scalar_one_or_none(). Keep the
+            # production query multi-row while accepting those focused fakes.
+            legacy_membership = membership_result.scalar_one_or_none()
+            memberships = [legacy_membership] if legacy_membership is not None else []
         requested_org_id = _parse_uuid(payload.org_id)
         activity_by_org = _load_org_activity(
             _require_uuid(membership.org_id, "membership.org_id")
@@ -285,7 +291,11 @@ async def login(
 
         await db.commit()
 
-        token_pair = await _issue_membership_tokens(db, request, user, membership) if membership else None
+        token_pair = (
+            await _issue_membership_tokens(db, request, user, membership)
+            if membership
+            else None
+        )
 
         return LoginResponse(
             access_token=token_pair.access_token if token_pair else "",

--- a/src/dev_health_ops/api/auth/routers/login.py
+++ b/src/dev_health_ops/api/auth/routers/login.py
@@ -291,17 +291,13 @@ async def login(
 
         await db.commit()
 
-        token_pair = (
-            await _issue_membership_tokens(db, request, user, membership)
-            if membership
-            else None
-        )
+        token_pair = await _issue_membership_tokens(db, request, user, membership)
 
         return LoginResponse(
-            access_token=token_pair.access_token if token_pair else "",
-            refresh_token=token_pair.refresh_token if token_pair else "",
-            token_type=token_pair.token_type if token_pair else "bearer",
-            expires_in=token_pair.expires_in if token_pair else 0,
+            access_token=token_pair.access_token,
+            refresh_token=token_pair.refresh_token,
+            token_type=token_pair.token_type,
+            expires_in=token_pair.expires_in,
             needs_onboarding=needs_onboarding,
             user=_to_user_info(user, membership),
         )

--- a/src/dev_health_ops/api/auth/routers/session.py
+++ b/src/dev_health_ops/api/auth/routers/session.py
@@ -4,7 +4,7 @@ import logging
 import uuid as uuid_mod
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy import select
 
@@ -12,10 +12,19 @@ from dev_health_ops.api.middleware.rate_limit import AUTH_VALIDATE_LIMIT, limite
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.refresh_tokens import revoke_token
 from dev_health_ops.api.utils.audit import emit_audit_log
+from dev_health_ops.api.utils.errors import error_detail
 from dev_health_ops.models.audit import AuditAction, AuditResourceType
-from dev_health_ops.models.users import User
+from dev_health_ops.models.users import Membership, Organization, User
 
-from .common import _parse_uuid
+from .common import (
+    LoginResponse,
+    OrganizationMembershipInfo,
+    _issue_membership_tokens,
+    _load_org_activity,
+    _parse_uuid,
+    _require_uuid,
+    _to_user_info,
+)
 from .dependencies import get_current_user, get_current_user_optional
 
 logger = logging.getLogger(__name__)
@@ -51,6 +60,15 @@ class MeResponse(BaseModel):
     permissions: list[str] = []
 
 
+class UserOrganizationsResponse(BaseModel):
+    active_org_id: str | None = None
+    organizations: list[OrganizationMembershipInfo]
+
+
+class SwitchOrgRequest(BaseModel):
+    org_id: str
+
+
 @router.get("/me", response_model=MeResponse)
 async def get_me(
     user: Annotated[AuthenticatedUser, Depends(get_current_user)],
@@ -68,6 +86,112 @@ async def get_me(
         role=user.role,
         is_superuser=user.is_superuser,
         permissions=permissions,
+    )
+
+
+@router.get("/me/organizations", response_model=UserOrganizationsResponse)
+async def get_my_organizations(
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> UserOrganizationsResponse:
+    from dev_health_ops.api.auth.router import get_postgres_session
+
+    user_id = _parse_uuid(user.user_id)
+    if user_id is None:
+        raise HTTPException(status_code=401, detail=error_detail("Invalid token claims"))
+
+    async with get_postgres_session() as db:
+        result = await db.execute(
+            select(Membership, Organization)
+            .join(Organization, Membership.org_id == Organization.id)
+            .where(
+                Membership.user_id == user_id,
+                Organization.is_active.is_(True),
+            )
+            .order_by(Membership.joined_at.asc(), Membership.created_at.asc())
+        )
+        rows = result.all()
+
+    activity_by_org = _load_org_activity(
+        _require_uuid(membership.org_id, "membership.org_id")
+        for membership, _organization in rows
+    )
+    organizations = []
+    for membership, organization in rows:
+        org_id = _require_uuid(membership.org_id, "membership.org_id")
+        activity = activity_by_org.get(org_id)
+        organizations.append(
+            OrganizationMembershipInfo(
+                id=str(organization.id),
+                slug=str(organization.slug),
+                name=str(organization.name),
+                tier=str(organization.tier) if organization.tier is not None else None,
+                role=str(membership.role),
+                joined_at=membership.joined_at,
+                has_data=bool(activity and activity.has_data),
+                last_metrics_at=activity.last_metrics_at if activity else None,
+            )
+        )
+
+    return UserOrganizationsResponse(
+        active_org_id=user.org_id or None,
+        organizations=organizations,
+    )
+
+
+@router.post("/switch-org", response_model=LoginResponse)
+async def switch_org(
+    payload: SwitchOrgRequest,
+    request: Request,
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> LoginResponse:
+    from dev_health_ops.api.auth.router import get_postgres_session
+
+    user_id = _parse_uuid(user.user_id)
+    org_id = _parse_uuid(payload.org_id)
+    if user_id is None or org_id is None:
+        raise HTTPException(status_code=400, detail=error_detail("Invalid organization ID"))
+
+    async with get_postgres_session() as db:
+        result = await db.execute(
+            select(User, Membership)
+            .join(Membership, Membership.user_id == User.id)
+            .join(Organization, Membership.org_id == Organization.id)
+            .where(
+                User.id == user_id,
+                User.is_active.is_(True),
+                Membership.org_id == org_id,
+                Organization.is_active.is_(True),
+            )
+        )
+        row = result.one_or_none()
+        if row is None:
+            raise HTTPException(
+                status_code=403,
+                detail=error_detail("User is not a member of the selected organization"),
+            )
+        db_user, membership = row
+
+        token_pair = await _issue_membership_tokens(db, request, db_user, membership)
+
+        emit_audit_log(
+            db,
+            org_id=org_id,
+            action=AuditAction.LOGIN,
+            resource_type=AuditResourceType.SESSION,
+            resource_id=user.user_id,
+            user_id=user_id,
+            description="User switched active organization",
+            request=request,
+        )
+        await db.commit()
+
+    return LoginResponse(
+        access_token=token_pair.access_token,
+        refresh_token=token_pair.refresh_token,
+        token_type=token_pair.token_type,
+        expires_in=token_pair.expires_in,
+        needs_onboarding=False,
+        user=_to_user_info(db_user, membership),
     )
 
 

--- a/src/dev_health_ops/api/auth/routers/session.py
+++ b/src/dev_health_ops/api/auth/routers/session.py
@@ -97,7 +97,9 @@ async def get_my_organizations(
 
     user_id = _parse_uuid(user.user_id)
     if user_id is None:
-        raise HTTPException(status_code=401, detail=error_detail("Invalid token claims"))
+        raise HTTPException(
+            status_code=401, detail=error_detail("Invalid token claims")
+        )
 
     async with get_postgres_session() as db:
         result = await db.execute(
@@ -149,7 +151,9 @@ async def switch_org(
     user_id = _parse_uuid(user.user_id)
     org_id = _parse_uuid(payload.org_id)
     if user_id is None or org_id is None:
-        raise HTTPException(status_code=400, detail=error_detail("Invalid organization ID"))
+        raise HTTPException(
+            status_code=400, detail=error_detail("Invalid organization ID")
+        )
 
     async with get_postgres_session() as db:
         result = await db.execute(
@@ -167,7 +171,9 @@ async def switch_org(
         if row is None:
             raise HTTPException(
                 status_code=403,
-                detail=error_detail("User is not a member of the selected organization"),
+                detail=error_detail(
+                    "User is not a member of the selected organization"
+                ),
             )
         db_user, membership = row
 

--- a/tests/api/auth/test_email_verification_enforcement.py
+++ b/tests/api/auth/test_email_verification_enforcement.py
@@ -52,7 +52,12 @@ def _user(
 
 
 def _membership(org_id: uuid.UUID | None = None) -> SimpleNamespace:
-    return SimpleNamespace(org_id=org_id or uuid.uuid4(), role="owner")
+    return SimpleNamespace(
+        org_id=org_id or uuid.uuid4(),
+        role="owner",
+        joined_at=None,
+        created_at=None,
+    )
 
 
 @pytest.mark.asyncio
@@ -126,6 +131,7 @@ async def test_verified_local_user_can_login(app):
             result.scalar_one_or_none.return_value = None
         elif call_count == 5:
             result.scalar_one_or_none.return_value = membership
+            result.scalars.return_value.all.return_value = [membership]
         else:
             raise AssertionError("Unexpected DB execute call")
         return result
@@ -181,6 +187,7 @@ async def test_oauth_user_bypasses_verification(app):
             result.scalar_one_or_none.return_value = None
         elif call_count == 5:
             result.scalar_one_or_none.return_value = membership
+            result.scalars.return_value.all.return_value = [membership]
         else:
             raise AssertionError("Unexpected DB execute call")
         return result

--- a/tests/api/auth/test_email_verification_enforcement.py
+++ b/tests/api/auth/test_email_verification_enforcement.py
@@ -11,13 +11,15 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from dev_health_ops.api.auth.router import router
+from dev_health_ops.api.middleware.rate_limit import limiter as rate_limiter
 from dev_health_ops.api.services.auth import AuthService
 
 
 @pytest.fixture
-def app():
+def app(monkeypatch: pytest.MonkeyPatch):
     _app = FastAPI()
     _app.include_router(router)
+    monkeypatch.setattr(rate_limiter, "enabled", False)
     return _app
 
 

--- a/tests/api/auth/test_session_org_routing.py
+++ b/tests/api/auth/test_session_org_routing.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import importlib
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import bcrypt
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.auth.routers.common import OrganizationActivity
+from dev_health_ops.api.services.auth import AuthenticatedUser, AuthService
+from dev_health_ops.models.audit import AuditLog
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import LoginAttempt, Membership, Organization, User
+from tests._helpers import tables_of
+
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+login_router_module = importlib.import_module("dev_health_ops.api.auth.routers.login")
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "session-org-routing.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(
+                    User,
+                    Organization,
+                    Membership,
+                    AuditLog,
+                    LoginAttempt,
+                ),
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_state(session_maker):
+    password_hash = bcrypt.hashpw(b"SecurePass123!", bcrypt.gensalt()).decode()
+    user = User(
+        id=uuid.uuid4(),
+        email="multi@example.com",
+        username="multi",
+        password_hash=password_hash,
+        is_active=True,
+        is_verified=True,
+    )
+    empty_org = Organization(
+        id=uuid.uuid4(), slug="empty", name="Empty Org", tier="community"
+    )
+    data_org = Organization(
+        id=uuid.uuid4(), slug="data", name="Data Org", tier="team"
+    )
+    now = datetime.now(timezone.utc)
+    async with session_maker() as session:
+        session.add_all([user, empty_org, data_org])
+        session.add_all(
+            [
+                Membership(
+                    user_id=user.id,
+                    org_id=empty_org.id,
+                    role="member",
+                    joined_at=now - timedelta(days=30),
+                ),
+                Membership(
+                    user_id=user.id,
+                    org_id=data_org.id,
+                    role="admin",
+                    joined_at=now - timedelta(days=1),
+                ),
+            ]
+        )
+        await session.commit()
+
+    return {
+        "user_id": str(user.id),
+        "email": str(user.email),
+        "empty_org_id": str(empty_org.id),
+        "data_org_id": str(data_org.id),
+    }
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch: pytest.MonkeyPatch, session_maker, seeded_state):
+    app = FastAPI()
+    app.include_router(auth_router_module.router)
+
+    current_user = {
+        "value": AuthenticatedUser(
+            user_id=seeded_state["user_id"],
+            email=seeded_state["email"],
+            org_id=seeded_state["empty_org_id"],
+            role="member",
+            is_superuser=False,
+        )
+    }
+
+    @asynccontextmanager
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+
+    async def _noop_refresh(*args, **kwargs):
+        return None
+
+    app.dependency_overrides[auth_router_module.get_current_user] = lambda: current_user[
+        "value"
+    ]
+    monkeypatch.setattr(auth_router_module, "get_postgres_session", _session_override)
+    monkeypatch.setattr(
+        auth_router_module,
+        "get_auth_service",
+        lambda: AuthService(secret_key="session-org-routing-test-secret"),
+    )
+    monkeypatch.setattr(auth_router_module, "create_refresh_token_record", _noop_refresh)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client, current_user
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_login_defaults_to_membership_with_metrics_activity(
+    client, seeded_state, monkeypatch: pytest.MonkeyPatch
+):
+    async_client, _current_user = client
+
+    def _activity(org_ids):
+        return {
+            org_id: OrganizationActivity(
+                has_data=str(org_id) == seeded_state["data_org_id"],
+                last_metrics_at=datetime(2026, 5, 1, tzinfo=timezone.utc)
+                if str(org_id) == seeded_state["data_org_id"]
+                else None,
+            )
+            for org_id in org_ids
+        }
+
+    monkeypatch.setattr(login_router_module, "_load_org_activity", _activity)
+
+    response = await async_client.post(
+        "/api/v1/auth/login",
+        json={"email": "multi@example.com", "password": "SecurePass123!"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["user"]["org_id"] == seeded_state["data_org_id"]
+    assert data["user"]["role"] == "admin"
+    assert data["access_token"]
+    assert data["refresh_token"]
+
+
+@pytest.mark.asyncio
+async def test_me_organizations_marks_active_org_and_data_state(
+    client, seeded_state, monkeypatch: pytest.MonkeyPatch
+):
+    async_client, _current_user = client
+
+    def _activity(org_ids):
+        return {
+            org_id: OrganizationActivity(
+                has_data=str(org_id) == seeded_state["data_org_id"],
+                last_metrics_at=datetime(2026, 5, 2, tzinfo=timezone.utc)
+                if str(org_id) == seeded_state["data_org_id"]
+                else None,
+            )
+            for org_id in org_ids
+        }
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.auth.routers.session._load_org_activity", _activity
+    )
+
+    response = await async_client.get("/api/v1/auth/me/organizations")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["active_org_id"] == seeded_state["empty_org_id"]
+    organizations = {org["id"]: org for org in data["organizations"]}
+    assert organizations[seeded_state["empty_org_id"]]["has_data"] is False
+    assert organizations[seeded_state["data_org_id"]]["has_data"] is True
+    assert organizations[seeded_state["data_org_id"]]["last_metrics_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_switch_org_issues_tokens_for_selected_membership(client, seeded_state):
+    async_client, _current_user = client
+
+    response = await async_client.post(
+        "/api/v1/auth/switch-org",
+        json={"org_id": seeded_state["data_org_id"]},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["user"]["org_id"] == seeded_state["data_org_id"]
+    assert data["user"]["role"] == "admin"
+    assert data["access_token"]
+    assert data["refresh_token"]
+
+
+@pytest.mark.asyncio
+async def test_switch_org_rejects_non_membership(client):
+    async_client, _current_user = client
+
+    response = await async_client.post(
+        "/api/v1/auth/switch-org",
+        json={"org_id": str(uuid.uuid4())},
+    )
+
+    assert response.status_code == 403

--- a/tests/api/auth/test_session_org_routing.py
+++ b/tests/api/auth/test_session_org_routing.py
@@ -64,9 +64,7 @@ async def seeded_state(session_maker):
     empty_org = Organization(
         id=uuid.uuid4(), slug="empty", name="Empty Org", tier="community"
     )
-    data_org = Organization(
-        id=uuid.uuid4(), slug="data", name="Data Org", tier="team"
-    )
+    data_org = Organization(id=uuid.uuid4(), slug="data", name="Data Org", tier="team")
     now = datetime.now(timezone.utc)
     async with session_maker() as session:
         session.add_all([user, empty_org, data_org])
@@ -119,16 +117,18 @@ async def client(monkeypatch: pytest.MonkeyPatch, session_maker, seeded_state):
     async def _noop_refresh(*args, **kwargs):
         return None
 
-    app.dependency_overrides[auth_router_module.get_current_user] = lambda: current_user[
-        "value"
-    ]
+    app.dependency_overrides[auth_router_module.get_current_user] = lambda: (
+        current_user["value"]
+    )
     monkeypatch.setattr(auth_router_module, "get_postgres_session", _session_override)
     monkeypatch.setattr(
         auth_router_module,
         "get_auth_service",
         lambda: AuthService(secret_key="session-org-routing-test-secret"),
     )
-    monkeypatch.setattr(auth_router_module, "create_refresh_token_record", _noop_refresh)
+    monkeypatch.setattr(
+        auth_router_module, "create_refresh_token_record", _noop_refresh
+    )
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as async_client:


### PR DESCRIPTION
## Summary
- choose login active organization from metrics-active memberships before falling back to oldest membership
- add /api/v1/auth/me/organizations and /api/v1/auth/switch-org
- add auth coverage for org activity defaulting, organization list, and switch authorization

## Verification
- pytest tests/api/auth
- ruff check src/dev_health_ops/api/auth/routers/common.py src/dev_health_ops/api/auth/routers/login.py src/dev_health_ops/api/auth/routers/session.py tests/api/auth/test_session_org_routing.py tests/api/auth/test_email_verification_enforcement.py

Closes CHAOS-1753
SCREENSHOT-WAIVER: backend API/auth-token changes only; rendered org picker is covered in the companion web PR.