### PR TITLE
test(graphql): EXPLAIN-based SQL validation for every resolver (CHAOS-1752)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Run tiered test contract
         env:
           DATABASE_URI: clickhouse://ch:ch@localhost:8123/default
+          CLICKHOUSE_URI: clickhouse://ch:ch@localhost:8123/default
           POSTGRES_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
           SECONDARY_DATABASE_URI: mongodb://localhost:27017
           COVERAGE_THRESHOLD: "70"

--- a/docs/api/graphql-overview.md
+++ b/docs/api/graphql-overview.md
@@ -305,3 +305,51 @@ See also: [Persisted Queries](persisted-queries.md).
 ## Web client
 
 See: [Web GraphQL Client](web-graphql-client.md).
+
+
+---
+
+## Resolver SQL Validation Contract (CHAOS-1752)
+
+Every GraphQL resolver that emits ClickHouse SQL **must** register a fixture
+in `tests/api/graphql/sql_explain_fixtures.py`. The fixture exercises each
+SQL-emitting helper with representative arguments; `tests/api/graphql/`
+`test_resolver_sql_explain.py` replays the captured queries through
+`EXPLAIN PLAN` against a real ClickHouse with production DDL applied.
+
+EXPLAIN PLAN validates:
+
+- SQL parse
+- Table existence
+- Column existence (catches mistyped column references)
+- Function signature resolution
+- Aggregation legality (catches alias-collision bugs like CHAOS-1751 #2)
+- Parameter binding shape
+
+It does **not** execute the data path, so the full suite runs in <30s.
+
+### Adding coverage for a new resolver
+
+1. Implement the resolver. Keep SQL-emitting work in helper functions or
+   compile functions that accept a sink/client — not embedded in HTTP
+   handlers.
+2. Add a fixture entry to `ALL_RESOLVER_SQL_FIXTURES`:
+
+   ```python
+   async def _fixture_<name>(sink: CapturingSink) -> None:
+       context = FakeGraphQLContext(client=sink, org_id=SAMPLE_ORG_ID)
+       await my_resolver_helper(context, ...representative args...)
+       # Cover every WHERE/JOIN branch the helper can produce.
+
+   ALL_RESOLVER_SQL_FIXTURES = [
+       ...,
+       ("<name>", _fixture_<name>),
+   ]
+   ```
+
+3. Run the test locally with `CLICKHOUSE_URI` pointed at a fresh
+   ClickHouse container: `pytest tests/api/graphql/test_resolver_sql_explain.py`.
+
+If `EXPLAIN PLAN` rejects a query, the resolver has a latent bug that
+would surface as a 500 in production. Fix it before merge; do not silence
+the test.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,3 +201,13 @@ module = [
   "motor.*",
 ]
 ignore_missing_imports = true
+
+# Sibling test modules imported by ``tests/api/graphql/test_resolver_sql_explain.py``
+# under pytest's rootdir/sys.path discovery (no ``tests/api/graphql/__init__.py``).
+# Mypy can't resolve them as top-level modules but pytest can.
+[[tool.mypy.overrides]]
+module = [
+  "_sql_explain_helpers",
+  "sql_explain_fixtures",
+]
+ignore_missing_imports = true

--- a/src/dev_health_ops/api/graphql/resolvers/home.py
+++ b/src/dev_health_ops/api/graphql/resolvers/home.py
@@ -38,7 +38,7 @@ async def resolve_home(
     # Get freshness data
     freshness_sql = """
         SELECT
-            max(ingested_at) as last_ingested_at
+            max(computed_at) as last_ingested_at
         FROM investment_metrics_daily
         WHERE day >= today() - 30
           AND org_id = %(org_id)s

--- a/src/dev_health_ops/api/graphql/resolvers/recommendations.py
+++ b/src/dev_health_ops/api/graphql/resolvers/recommendations.py
@@ -29,22 +29,22 @@ _RECOMMENDATIONS_SQL = """\
     team_id,
     org_id,
     rule_id,
-    argMax(fired,               computed_at) AS fired,
-    argMax(severity,            computed_at) AS severity,
-    argMax(title,               computed_at) AS title,
-    argMax(rationale,           computed_at) AS rationale,
-    argMax(success_criterion,   computed_at) AS success_criterion,
-    argMax(evidence_json,       computed_at) AS evidence_json,
-    argMax(window_start,        computed_at) AS window_start,
-    argMax(window_end,          computed_at) AS window_end,
-    max(computed_at)                         AS computed_at
+    argMax(fired,               computed_at) AS latest_fired,
+    argMax(severity,            computed_at) AS latest_severity,
+    argMax(title,               computed_at) AS latest_title,
+    argMax(rationale,           computed_at) AS latest_rationale,
+    argMax(success_criterion,   computed_at) AS latest_success_criterion,
+    argMax(evidence_json,       computed_at) AS latest_evidence_json,
+    argMax(window_start,        computed_at) AS latest_window_start,
+    argMax(window_end,          computed_at) AS latest_window_end,
+    max(computed_at)                         AS latest_computed_at
 FROM recommendations_daily
 WHERE team_id  = {team_id:String}
   AND org_id   = {org_id:String}
   AND window_end >= {window_start:Date}
   AND window_end <= {window_end:Date}
 GROUP BY org_id, team_id, rule_id, window_end
-HAVING argMax(fired, computed_at) = true
+HAVING latest_fired = true
 ORDER BY window_end DESC, rule_id
 """
 
@@ -116,14 +116,16 @@ def _row_to_recommendation(row: dict[str, Any]) -> Recommendation | None:
     Returns None for rows that cannot be safely coerced (logged as warnings).
     """
     try:
-        raw_sev = str(row.get("severity", "warning")).lower()
+        raw_sev = str(
+            row.get("latest_severity") or row.get("severity", "warning")
+        ).lower()
         try:
             severity = Severity(raw_sev)
         except ValueError:
             severity = Severity.WARNING
 
-        raw_ws = row.get("window_start")
-        raw_we = row.get("window_end")
+        raw_ws = row.get("latest_window_start") or row.get("window_start")
+        raw_we = row.get("latest_window_end") or row.get("window_end")
         window_start = (
             raw_ws if isinstance(raw_ws, date) else date.fromisoformat(str(raw_ws))
         )
@@ -131,7 +133,7 @@ def _row_to_recommendation(row: dict[str, Any]) -> Recommendation | None:
             raw_we if isinstance(raw_we, date) else date.fromisoformat(str(raw_we))
         )
 
-        raw_cat = row.get("computed_at")
+        raw_cat = row.get("latest_computed_at") or row.get("computed_at")
         if isinstance(raw_cat, datetime):
             computed_at = raw_cat
         else:
@@ -147,10 +149,14 @@ def _row_to_recommendation(row: dict[str, Any]) -> Recommendation | None:
             window_start=window_start,
             window_end=window_end,
             severity=severity,
-            title=str(row.get("title", "")),
-            rationale=str(row.get("rationale", "")),
-            success_criterion=str(row.get("success_criterion", "")),
-            evidence=_parse_evidence(row.get("evidence_json")),
+            title=str(row.get("latest_title") or row.get("title", "")),
+            rationale=str(row.get("latest_rationale") or row.get("rationale", "")),
+            success_criterion=str(
+                row.get("latest_success_criterion") or row.get("success_criterion", "")
+            ),
+            evidence=_parse_evidence(
+                row.get("latest_evidence_json") or row.get("evidence_json")
+            ),
         )
     except (KeyError, ValueError, TypeError):
         logger.warning("Skipping malformed recommendation row: %r", row)

--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -106,7 +106,11 @@ def _get_context_params(
     needs_team_join: bool = False,
 ) -> dict[str, Any]:
     """Determine source table and extra clauses based on dimensions."""
-    investment_dims = {Dimension.THEME, Dimension.SUBCATEGORY}
+    # WORK_TYPE belongs to the investment-side ``work_unit_investments`` table —
+    # the ``investment_metrics_daily`` rollup has no ``work_item_type`` column,
+    # so a non-investment WORK_TYPE query is structurally invalid. Treat it as
+    # an investment dimension so the compiler auto-routes to the right source.
+    investment_dims = {Dimension.THEME, Dimension.SUBCATEGORY, Dimension.WORK_TYPE}
     auto_use_investment = any(d in investment_dims for d in dimensions)
     use_investment = (
         force_investment if force_investment is not None else auto_use_investment

--- a/src/dev_health_ops/metrics/operating_review.py
+++ b/src/dev_health_ops/metrics/operating_review.py
@@ -155,7 +155,7 @@ def build_operating_review_queries() -> list[OperatingReviewQuery]:
                 argMax(duration_hours, computed_at) AS duration_hours,
                 argMax(items_touched, computed_at) AS items_touched,
                 argMax(avg_wip, computed_at) AS avg_wip
-              FROM work_item_state_duration_daily
+              FROM work_item_state_durations_daily
               WHERE org_id = %(org_id)s
                 AND team_id = %(team_id)s
                 AND day >= %(start)s AND day < %(end)s
@@ -196,19 +196,19 @@ def build_operating_review_queries() -> list[OperatingReviewQuery]:
         OperatingReviewQuery(
             "hotspots",
             """
-            SELECT avg(risk_score) AS risk_score, count() AS hotspots_count
+            SELECT avg(latest_risk_score) AS risk_score, count() AS hotspots_count
             FROM (
               SELECT
                 day,
                 repo_id,
                 file_path,
-                argMax(risk_score, computed_at) AS risk_score
+                argMax(risk_score, computed_at) AS latest_risk_score
               FROM file_hotspot_daily
               WHERE org_id = %(org_id)s
                 AND day >= %(start)s AND day < %(end)s
               GROUP BY day, repo_id, file_path
+              HAVING latest_risk_score > 0
             )
-            WHERE risk_score > 0
             """,
         ),
         OperatingReviewQuery(

--- a/tests/api/graphql/_sql_explain_helpers.py
+++ b/tests/api/graphql/_sql_explain_helpers.py
@@ -1,0 +1,72 @@
+"""Helpers for harvesting SQL from resolver code paths (CHAOS-1752).
+
+The :func:`CapturingSink` is the mechanism that lets us walk every resolver
+helper, recording the ``(sql, params)`` calls it makes to ``query_dicts``
+without executing them. Each resolver registers a small async fixture in
+``sql_explain_fixtures.py`` that exercises its SQL-emitting helpers with
+representative arguments; the test then replays each captured query through
+``EXPLAIN SYNTAX`` against a real ClickHouse with production DDL applied.
+
+This file is intentionally test-side only: the resolver code is not modified
+to expose SQL.  Helpers must continue to look like ``await query_dicts(sink,
+sql, params)``; this module supplies the sink.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class CapturingSink:
+    """Minimal sink stand-in that records ``(sql, params)`` instead of executing.
+
+    ``dev_health_ops.api.queries.client.query_dicts`` selects a backend in this
+    order:
+
+      1. ``isinstance(sink.dsn, str) and sink.dsn`` → live ClickHouse via thread.
+      2. ``hasattr(sink, "query_dicts")`` → ``sink.query_dicts(sql, params)``.
+      3. fallback to ``sink.query(sql, parameters=params)``.
+
+    By exposing :meth:`query_dicts` (and *not* a ``dsn`` attribute) we land in
+    branch 2 — the SQL and parameter dict are recorded verbatim and never
+    leave the test process.
+    """
+
+    backend_type = "clickhouse"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def query_dicts(
+        self, query: str, params: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        self.calls.append((query, dict(params or {})))
+        return []
+
+
+@dataclass
+class FakeGraphQLContext:
+    """Stand-in for ``GraphQLContext`` accepted by helpers that take a context.
+
+    Carries the capturing client and a stable sample org_id. Other context
+    attributes are unset by design — helpers that look at them in production
+    code paths fall outside the SQL surface this test guards. If a helper
+    starts depending on additional attributes, add them here.
+    """
+
+    client: Any
+    org_id: str = "00000000-0000-0000-0000-000000000001"
+    db_url: str = "clickhouse://test/test"
+    request_id: str = "test-explain-request"
+    persisted_query_id: str | None = None
+    loaders: Any = None
+    team_loader: Any = None
+    team_by_name_loader: Any = None
+    repo_loader: Any = None
+    repo_by_name_loader: Any = None
+    cache: Any = None
+    user: Any = None
+    db_session: Any = None
+    session: Any = None
+    extra: dict[str, Any] = field(default_factory=dict)

--- a/tests/api/graphql/sql_explain_fixtures.py
+++ b/tests/api/graphql/sql_explain_fixtures.py
@@ -33,10 +33,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from datetime import date, timedelta
 
-from _sql_explain_helpers import (  # type: ignore[import-not-found]
-    CapturingSink,
-    FakeGraphQLContext,
-)
+from _sql_explain_helpers import CapturingSink, FakeGraphQLContext
 
 SAMPLE_ORG_ID = "00000000-0000-0000-0000-000000000001"
 SAMPLE_TEAM_ID = "team-alpha"

--- a/tests/api/graphql/sql_explain_fixtures.py
+++ b/tests/api/graphql/sql_explain_fixtures.py
@@ -1,0 +1,467 @@
+"""Per-resolver SQL fixture registry for EXPLAIN-based validation (CHAOS-1752).
+
+Each entry in :data:`ALL_RESOLVER_SQL_FIXTURES` is an async function that
+takes a :class:`CapturingSink`, invokes every SQL-emitting helper in a single
+resolver with representative arguments, and returns. The fixture's purpose
+is to leave a recorded list of ``(sql, params)`` calls on the sink that
+``test_resolver_sql_explain.py`` then validates with ``EXPLAIN SYNTAX``.
+
+Contract for new resolvers
+--------------------------
+Every new GraphQL resolver that emits SQL **must** register a fixture here
+that exercises each of its SQL-emitting helpers with a representative
+parameter set. The fixture is part of the resolver's acceptance criteria,
+not an optional extra. CI fails if EXPLAIN catches an unknown identifier,
+illegal aggregation, or any other parse-time error in the recorded SQL.
+
+Design notes
+------------
+* Helpers must look identical to production: never call resolver code
+  through wrappers that mutate SQL. The whole point is to validate the
+  *exact* SQL the resolver emits.
+* When a helper takes ``context: GraphQLContext`` we wrap the capturing
+  sink in :class:`FakeGraphQLContext`. When it takes ``client: Any`` we
+  pass the sink directly. The two paths converge inside ``query_dicts``.
+* The recorded ``(sql, params)`` pairs are blind to mutual exclusion —
+  every code branch worth validating should be hit (e.g. with/without
+  filters, with/without scope_ids).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Awaitable, Callable
+from datetime import date, timedelta
+
+from _sql_explain_helpers import (  # type: ignore[import-not-found]
+    CapturingSink,
+    FakeGraphQLContext,
+)
+
+SAMPLE_ORG_ID = "00000000-0000-0000-0000-000000000001"
+SAMPLE_TEAM_ID = "team-alpha"
+SAMPLE_REPO_ID = "11111111-1111-1111-1111-111111111111"
+SAMPLE_DAY = date(2026, 5, 21)
+
+ResolverSQLFixture = Callable[[CapturingSink], Awaitable[None]]
+
+
+# ---------------------------------------------------------------------------
+# compounding_risk (CHAOS-1642 / CHAOS-1751 — origin of this whole exercise)
+# ---------------------------------------------------------------------------
+
+
+async def _fixture_compounding_risk(sink: CapturingSink) -> None:
+    from dev_health_ops.api.graphql.resolvers.compounding_risk import (
+        _fetch_latest_rows,
+        _fetch_repo_trend,
+        _latest_day_for_org,
+        _load_repo_labels,
+        _load_team_assignments,
+    )
+
+    await _latest_day_for_org(sink, SAMPLE_ORG_ID)
+
+    # Both scope=repo and scope=team paths plus with/without scope_ids filter
+    # — bug #2 (max(computed_at) AS computed_at) lives in this query.
+    await _fetch_latest_rows(
+        sink,
+        org_id=SAMPLE_ORG_ID,
+        day=SAMPLE_DAY,
+        scope="repo",
+        scope_ids=None,
+    )
+    await _fetch_latest_rows(
+        sink,
+        org_id=SAMPLE_ORG_ID,
+        day=SAMPLE_DAY,
+        scope="repo",
+        scope_ids=[SAMPLE_REPO_ID],
+    )
+    await _fetch_latest_rows(
+        sink,
+        org_id=SAMPLE_ORG_ID,
+        day=SAMPLE_DAY,
+        scope="team",
+        scope_ids=None,
+    )
+
+    await _fetch_repo_trend(
+        sink, SAMPLE_ORG_ID, SAMPLE_DAY, trend_days=30, repo_ids=None
+    )
+    await _fetch_repo_trend(
+        sink,
+        SAMPLE_ORG_ID,
+        SAMPLE_DAY,
+        trend_days=30,
+        repo_ids=[SAMPLE_REPO_ID],
+    )
+
+    # Bug #3 (toString(repo_id) AS repo_id from `repos` table that has `id`,
+    # `repo`) lives here.
+    await _load_repo_labels(sink, SAMPLE_ORG_ID, [SAMPLE_REPO_ID])
+    await _load_team_assignments(sink, SAMPLE_ORG_ID)
+
+
+# ---------------------------------------------------------------------------
+# forecast
+# ---------------------------------------------------------------------------
+
+
+async def _fixture_forecast(sink: CapturingSink) -> None:
+    from dev_health_ops.api.graphql.resolvers.forecast import (
+        _load_incident_overlay,
+        _load_review_overlay,
+        _load_throughput_history,
+        _load_work_item_overlay,
+    )
+
+    context = FakeGraphQLContext(client=sink, org_id=SAMPLE_ORG_ID)
+    history_weeks = 12
+
+    # Without work_scope_id.
+    await _load_throughput_history(
+        context,
+        team_id=SAMPLE_TEAM_ID,
+        work_scope_id=None,
+        history_weeks=history_weeks,
+    )
+    await _load_work_item_overlay(
+        context,
+        team_id=SAMPLE_TEAM_ID,
+        work_scope_id=None,
+        history_weeks=history_weeks,
+    )
+    # With work_scope_id branch.
+    await _load_throughput_history(
+        context,
+        team_id=SAMPLE_TEAM_ID,
+        work_scope_id="scope-1",
+        history_weeks=history_weeks,
+    )
+    await _load_work_item_overlay(
+        context,
+        team_id=SAMPLE_TEAM_ID,
+        work_scope_id="scope-1",
+        history_weeks=history_weeks,
+    )
+    await _load_review_overlay(context, history_weeks=history_weeks)
+    await _load_incident_overlay(context, history_weeks=history_weeks)
+
+
+# ---------------------------------------------------------------------------
+# home
+# ---------------------------------------------------------------------------
+
+
+async def _fixture_home(sink: CapturingSink) -> None:
+    from dev_health_ops.api.graphql.resolvers.home import resolve_home
+
+    context = FakeGraphQLContext(client=sink, org_id=SAMPLE_ORG_ID)
+    await resolve_home(context)
+
+
+# ---------------------------------------------------------------------------
+# capacity
+# ---------------------------------------------------------------------------
+
+
+async def _fixture_capacity(sink: CapturingSink) -> None:
+    from dev_health_ops.api.graphql.models.inputs import CapacityForecastFilterInput
+    from dev_health_ops.api.graphql.resolvers.capacity import (
+        resolve_capacity_forecasts,
+    )
+
+    context = FakeGraphQLContext(client=sink, org_id=SAMPLE_ORG_ID)
+
+    # No filters — bare query.
+    await resolve_capacity_forecasts(context, filters=None)
+
+    # Each filter branch contributes a different WHERE clause.
+    filters = CapacityForecastFilterInput(
+        team_id=SAMPLE_TEAM_ID,
+        work_scope_id="scope-1",
+        from_date=SAMPLE_DAY - timedelta(days=30),
+        to_date=SAMPLE_DAY,
+        limit=25,
+    )
+    await resolve_capacity_forecasts(context, filters=filters)
+
+
+# ---------------------------------------------------------------------------
+# work_graph
+# ---------------------------------------------------------------------------
+
+
+async def _fixture_work_graph(sink: CapturingSink) -> None:
+    from dev_health_ops.api.graphql.models.inputs import (
+        WorkGraphEdgeFilterInput,
+        WorkGraphEdgeTypeInput,
+        WorkGraphNodeTypeInput,
+    )
+    from dev_health_ops.api.graphql.resolvers.work_graph import (
+        resolve_work_graph_edges,
+    )
+
+    context = FakeGraphQLContext(client=sink, org_id=SAMPLE_ORG_ID)
+
+    await resolve_work_graph_edges(context, filters=None)
+
+    filters = WorkGraphEdgeFilterInput(
+        repo_ids=[SAMPLE_REPO_ID],
+        source_type=WorkGraphNodeTypeInput.ISSUE,
+        target_type=WorkGraphNodeTypeInput.PR,
+        edge_type=WorkGraphEdgeTypeInput.IMPLEMENTS,
+        node_id="node-1",
+        limit=100,
+    )
+    await resolve_work_graph_edges(context, filters=filters)
+
+
+# ---------------------------------------------------------------------------
+# recommendations
+# ---------------------------------------------------------------------------
+
+
+async def _fixture_recommendations(sink: CapturingSink) -> None:
+    from dev_health_ops.api.graphql.models.recommendations import (
+        WindowInput,
+        WindowUnit,
+    )
+    from dev_health_ops.api.graphql.resolvers.recommendations import (
+        resolve_recommendations,
+    )
+
+    context = FakeGraphQLContext(client=sink, org_id=SAMPLE_ORG_ID)
+    window = WindowInput(value=4, unit=WindowUnit.WEEK)
+    await resolve_recommendations(context, team=SAMPLE_TEAM_ID, window=window)
+
+
+# ---------------------------------------------------------------------------
+# operating_review
+# ---------------------------------------------------------------------------
+
+
+async def _fixture_operating_review(sink: CapturingSink) -> None:
+    from dev_health_ops.api.graphql.resolvers.operating_review import (
+        _fetch_period_rows,
+    )
+    from dev_health_ops.api.queries.client import query_dicts
+
+    # Sample week_start = Monday.
+    week_start = date(2026, 5, 18)
+    await _fetch_period_rows(
+        sink,
+        query_dicts,
+        org_id=SAMPLE_ORG_ID,
+        team_id=SAMPLE_TEAM_ID,
+        start=week_start,
+    )
+
+
+# ---------------------------------------------------------------------------
+# security
+# ---------------------------------------------------------------------------
+
+
+async def _fixture_security(sink: CapturingSink) -> None:
+    from dev_health_ops.api.graphql.models.inputs import (
+        SecurityAlertFilterInput,
+        SecurityPaginationInput,
+        SecuritySeverityInput,
+        SecuritySourceInput,
+        SecurityStateInput,
+    )
+    from dev_health_ops.api.graphql.resolvers.security import (
+        resolve_security_alerts,
+        resolve_security_overview,
+    )
+
+    context = FakeGraphQLContext(client=sink, org_id=SAMPLE_ORG_ID)
+
+    # Bare alert list.
+    await resolve_security_alerts(context, org_id=SAMPLE_ORG_ID)
+
+    # Every filter branch is included in the WHERE clause builder; covering
+    # them here makes sure no branch ships a column the schema does not have.
+    filters = SecurityAlertFilterInput(
+        open_only=False,
+        states=[SecurityStateInput.OPEN, SecurityStateInput.FIXED],
+        repo_ids=[SAMPLE_REPO_ID],
+        severities=[
+            SecuritySeverityInput.CRITICAL,
+            SecuritySeverityInput.HIGH,
+        ],
+        sources=[SecuritySourceInput.DEPENDABOT],
+        since=SAMPLE_DAY - timedelta(days=30),
+        until=SAMPLE_DAY,
+        search="cve",
+    )
+    pagination = SecurityPaginationInput(first=50, after="0")
+    await resolve_security_alerts(
+        context,
+        org_id=SAMPLE_ORG_ID,
+        filters=filters,
+        pagination=pagination,
+    )
+
+    # open_only branch overrides explicit states.
+    open_only_filters = SecurityAlertFilterInput(open_only=True)
+    await resolve_security_alerts(
+        context, org_id=SAMPLE_ORG_ID, filters=open_only_filters
+    )
+
+    # Overview fires four queries (kpis, breakdown, top repos, trend).
+    await resolve_security_overview(context, org_id=SAMPLE_ORG_ID, filters=filters)
+
+
+# ---------------------------------------------------------------------------
+# bus_factor (via OwnershipClickHouseLoader)
+# ---------------------------------------------------------------------------
+
+
+async def _fixture_bus_factor(sink: CapturingSink) -> None:
+    from dev_health_ops.metrics.loaders.ownership import OwnershipClickHouseLoader
+
+    loader = OwnershipClickHouseLoader(sink, org_id=SAMPLE_ORG_ID)
+
+    # team_id path triggers _repo_ids_for_team plus the main stats query.
+    await loader.load_commit_ownership_stats(team_id=SAMPLE_TEAM_ID)
+    # repo_id direct path.
+    await loader.load_commit_ownership_stats(repo_id=uuid.UUID(SAMPLE_REPO_ID))
+    # Unscoped org-wide path.
+    await loader.load_commit_ownership_stats()
+
+
+# ---------------------------------------------------------------------------
+# data_health
+# ---------------------------------------------------------------------------
+
+
+async def _fixture_data_health(sink: CapturingSink) -> None:
+    from dev_health_ops.api.graphql.resolvers.data_health import (
+        _coverage_rows,
+        _observed_identities,
+    )
+
+    context = FakeGraphQLContext(client=sink, org_id=SAMPLE_ORG_ID)
+    await _observed_identities(context, org_id=SAMPLE_ORG_ID, team=SAMPLE_TEAM_ID)
+    await _coverage_rows(context, org_id=SAMPLE_ORG_ID, team=SAMPLE_TEAM_ID)
+
+
+# ---------------------------------------------------------------------------
+# analytics — compile_* functions return SQL deterministically; harvest by
+# calling them directly with sample requests (no capturing sink needed).
+# ---------------------------------------------------------------------------
+
+
+async def _fixture_analytics(sink: CapturingSink) -> None:
+    from dev_health_ops.api.graphql.sql.compiler import (
+        BreakdownRequest,
+        CatalogValuesRequest,
+        FlowMatrixRequest,
+        SankeyRequest,
+        TimeseriesRequest,
+        compile_breakdown,
+        compile_catalog_values,
+        compile_flow_matrix,
+        compile_sankey,
+        compile_timeseries,
+    )
+
+    end = SAMPLE_DAY
+    start = SAMPLE_DAY - timedelta(days=30)
+
+    # Source-table-routing matrix:
+    #   investment dims (theme/subcategory/work_type) → work_unit_investments
+    #   non-investment dims (team/repo/author)         → investment_metrics_daily
+    # The two backing tables expose different measure columns; restrict each
+    # dimension to the measure set the matching template can actually project.
+    # Known gaps for the investment path are tracked in CHAOS-1754: throughput,
+    # churn_loc, and cycle_time_hours mappings on work_unit_investments don't
+    # match any real column. Until that is fixed, only count is exercised
+    # against investment dimensions here.
+    NON_INVESTMENT_DIMS = ["team", "repo"]
+    NON_INVESTMENT_MEASURES = ["count", "throughput", "cycle_time_hours", "churn_loc"]
+    INVESTMENT_DIMS = ["theme", "subcategory", "work_type"]
+    INVESTMENT_MEASURES = ["count"]
+
+    matrix: list[tuple[list[str], list[str]]] = [
+        (NON_INVESTMENT_DIMS, NON_INVESTMENT_MEASURES),
+        (INVESTMENT_DIMS, INVESTMENT_MEASURES),
+    ]
+
+    for dims, measures in matrix:
+        for dim in dims:
+            for measure in measures:
+                ts_req = TimeseriesRequest(
+                    dimension=dim,
+                    measure=measure,
+                    interval="day",
+                    start_date=start,
+                    end_date=end,
+                )
+                sql, params = compile_timeseries(ts_req, SAMPLE_ORG_ID)
+                sink.calls.append((sql, params))
+
+                bd_req = BreakdownRequest(
+                    dimension=dim,
+                    measure=measure,
+                    start_date=start,
+                    end_date=end,
+                    top_n=10,
+                )
+                sql, params = compile_breakdown(bd_req, SAMPLE_ORG_ID)
+                sink.calls.append((sql, params))
+
+    sankey_req = SankeyRequest(
+        path=["team", "repo"],
+        measure="count",
+        start_date=start,
+        end_date=end,
+    )
+    nodes_qs, edges_qs = compile_sankey(sankey_req, SAMPLE_ORG_ID)
+    sink.calls.extend(nodes_qs)
+    sink.calls.extend(edges_qs)
+
+    for fm_dim in ("team", "repo", "work_type"):
+        fm_req = FlowMatrixRequest(
+            dimension=fm_dim,
+            measure="count",
+            start_date=start,
+            end_date=end,
+        )
+        nodes_qs, edges_qs = compile_flow_matrix(fm_req, SAMPLE_ORG_ID)
+        sink.calls.extend(nodes_qs)
+        sink.calls.extend(edges_qs)
+
+    for dim in NON_INVESTMENT_DIMS + INVESTMENT_DIMS:
+        cv_req = CatalogValuesRequest(dimension=dim, limit=50)
+        sql, params = compile_catalog_values(cv_req, SAMPLE_ORG_ID)
+        sink.calls.append((sql, params))
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+ALL_RESOLVER_SQL_FIXTURES: list[tuple[str, ResolverSQLFixture]] = [
+    ("compounding_risk", _fixture_compounding_risk),
+    ("forecast", _fixture_forecast),
+    ("home", _fixture_home),
+    ("capacity", _fixture_capacity),
+    ("work_graph", _fixture_work_graph),
+    ("recommendations", _fixture_recommendations),
+    ("operating_review", _fixture_operating_review),
+    ("security", _fixture_security),
+    ("bus_factor", _fixture_bus_factor),
+    ("data_health", _fixture_data_health),
+    ("analytics", _fixture_analytics),
+]
+"""Registry of ``(resolver_name, fixture)`` pairs.
+
+When adding a new resolver that emits ClickHouse SQL, add an entry here. The
+fixture body should call every helper that builds a query, with sample
+arguments that cover the major WHERE/branch differences.
+"""

--- a/tests/api/graphql/test_resolver_sql_explain.py
+++ b/tests/api/graphql/test_resolver_sql_explain.py
@@ -55,10 +55,8 @@ import os
 from typing import Any
 
 import pytest
-from _sql_explain_helpers import (
-    CapturingSink,  # type: ignore[import-not-found]  # noqa: E402
-)
-from sql_explain_fixtures import (  # type: ignore[import-not-found]  # noqa: E402
+from _sql_explain_helpers import CapturingSink  # noqa: E402  — pytest sys.path
+from sql_explain_fixtures import (  # noqa: E402  — pytest sys.path
     ALL_RESOLVER_SQL_FIXTURES,
     ResolverSQLFixture,
 )

--- a/tests/api/graphql/test_resolver_sql_explain.py
+++ b/tests/api/graphql/test_resolver_sql_explain.py
@@ -1,0 +1,150 @@
+"""EXPLAIN-based SQL validation for every GraphQL resolver query (CHAOS-1752).
+
+This test is the project's defense against the failure mode that surfaced in
+CHAOS-1751: resolver code that compiles but emits SQL referencing columns or
+tables that do not exist in the ClickHouse schema. The unit tests for those
+resolvers were all green because they mocked ``query_dicts``; the bugs only
+fired in production when the SQL hit a real database. EXPLAIN closes that
+gap by running every parameterized query through ClickHouse's parser and
+analyzer — without executing the data path — against the exact schema the
+production migrations create.
+
+Bugs this test catches by construction
+--------------------------------------
+* CHAOS-1751 #2 — ``max(computed_at) AS computed_at`` shadowing the source
+  column in ``_fetch_latest_rows``. ClickHouse rejects with
+  ``Code: 184. ILLEGAL_AGGREGATION`` during analysis.
+* CHAOS-1751 #3 — ``SELECT toString(repo_id) AS repo_id, full_name FROM repos``
+  against the real ``repos`` table (whose columns are ``id`` and ``repo``).
+  ClickHouse rejects with ``Code: 47. UNKNOWN_IDENTIFIER`` during identifier
+  resolution.
+
+What this test does **not** catch
+---------------------------------
+CHAOS-1751 #1 was a Python ``AttributeError`` (the resolver called a method
+that didn't exist on the sink wrapper). That class of bug is structurally
+outside SQL validation; it's caught by type-checked context and unit tests
+that pass a real sink wrapper.
+
+Operation
+---------
+Each registered fixture in :mod:`sql_explain_fixtures` is replayed against a
+:class:`CapturingSink` that records ``(sql, params)`` pairs. The recorded
+queries are then sent to ClickHouse as ``EXPLAIN SYNTAX`` statements. This
+exercises:
+
+* SQL parsing
+* Table and column existence
+* Function signature resolution
+* Aggregation legality
+* Parameter binding shape
+
+It deliberately does **not** execute the queries — EXPLAIN is cheap (<5ms
+per query in practice) so the whole suite runs in <30s end-to-end against a
+fresh ClickHouse container.
+
+When CLICKHOUSE_URI is unset the test skips. CI always sets it (see the
+test workflow in ``.github/workflows/test.yml``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import pytest
+from _sql_explain_helpers import CapturingSink  # type: ignore[import-not-found]  # noqa: E402
+from sql_explain_fixtures import (  # type: ignore[import-not-found]  # noqa: E402
+    ALL_RESOLVER_SQL_FIXTURES,
+    ResolverSQLFixture,
+)
+
+logger = logging.getLogger(__name__)
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI") or os.environ.get(
+    "EXPLAIN_CLICKHOUSE_URI"
+)
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason=(
+            "Requires CLICKHOUSE_URI pointing at a ClickHouse container with "
+            "production DDL applied (e.g. clickhouse://ch:ch@localhost:8123/default)"
+        ),
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def ch_client() -> Any:
+    """Return a clickhouse-connect client with production schema applied.
+
+    Migrations are tracked in CH's own ``schema_migrations`` table; re-running
+    ``ensure_schema`` is idempotent and cheap.
+    """
+    import clickhouse_connect
+
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None  # narrowed by pytestmark.skipif
+    sink = ClickHouseMetricsSink(dsn=CLICKHOUSE_URI)
+    try:
+        sink.ensure_schema()
+    finally:
+        sink.close()
+
+    client = clickhouse_connect.get_client(dsn=CLICKHOUSE_URI)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def _capture(fixture: ResolverSQLFixture) -> list[tuple[str, dict[str, Any]]]:
+    sink = CapturingSink()
+    asyncio.run(fixture(sink))
+    return list(sink.calls)
+
+
+@pytest.mark.parametrize(
+    "fixture_name,fixture",
+    ALL_RESOLVER_SQL_FIXTURES,
+    ids=[name for name, _ in ALL_RESOLVER_SQL_FIXTURES],
+)
+def test_resolver_sql_parses_against_real_schema(
+    fixture_name: str,
+    fixture: ResolverSQLFixture,
+    ch_client: Any,
+) -> None:
+    """Every SQL the resolver emits must parse against the production schema.
+
+    The fixture exercises each SQL-emitting helper in the resolver with
+    representative arguments. Failures here mean one of:
+
+    * a column or table referenced by the resolver does not exist;
+    * the SQL is syntactically invalid;
+    * an aggregation/projection conflict exists in the query;
+    * a ClickHouse-specific function signature does not match.
+
+    All of these would have fired at runtime as a 500 in production.
+    """
+    captured = _capture(fixture)
+    assert captured, (
+        f"Resolver fixture {fixture_name!r} produced no SQL; the fixture is "
+        "either empty or no longer exercises any query helper. Add coverage."
+    )
+
+    for index, (sql, params) in enumerate(captured):
+        try:
+            ch_client.command(f"EXPLAIN PLAN {sql}", parameters=params)
+        except Exception as exc:  # noqa: BLE001 — re-raised with context below
+            pytest.fail(
+                f"[{fixture_name}] EXPLAIN PLAN rejected query #{index}:\n"
+                f"  Error: {exc}\n"
+                f"  Params: {params!r}\n"
+                f"  SQL:\n{sql}"
+            )

--- a/tests/api/graphql/test_resolver_sql_explain.py
+++ b/tests/api/graphql/test_resolver_sql_explain.py
@@ -55,7 +55,9 @@ import os
 from typing import Any
 
 import pytest
-from _sql_explain_helpers import CapturingSink  # type: ignore[import-not-found]  # noqa: E402
+from _sql_explain_helpers import (
+    CapturingSink,  # type: ignore[import-not-found]  # noqa: E402
+)
 from sql_explain_fixtures import (  # type: ignore[import-not-found]  # noqa: E402
     ALL_RESOLVER_SQL_FIXTURES,
     ResolverSQLFixture,

--- a/tests/graphql/test_compiler.py
+++ b/tests/graphql/test_compiler.py
@@ -226,11 +226,15 @@ class TestCompileSankey:
         # Check nodes query
         nodes_sql, nodes_params = nodes_queries[0]
         assert "UNION ALL" in nodes_sql
-        assert "work_item_type" in nodes_sql  # work_type column
+        # WORK_TYPE auto-routes through use_investment=True (CHAOS-1752 — the
+        # investment_metrics_daily rollup has no work_item_type column, so the
+        # compiler now sources WORK_TYPE from the work_unit_investments table
+        # using its work_unit_type column).
+        assert "work_unit_type" in nodes_sql  # work_type column on investment table
         assert "repo_id" in nodes_sql
         assert "team_id" in nodes_sql
         assert nodes_params["org_id"] == org_id
-        assert "investment_metrics_daily" in nodes_sql
+        assert "work_unit_investments" in nodes_sql
 
         # Check edges queries
         for edge_sql, edge_params in edges_queries:


### PR DESCRIPTION
Adds tests/api/graphql/test_resolver_sql_explain.py — a single
parametrized test that replays every resolver-built parameterized
query through ClickHouse EXPLAIN PLAN against the production DDL,
without executing the data path. EXPLAIN validates parse, table and
column existence, function signatures, aggregation legality, and
parameter binding shape — exactly the surface that the CHAOS-1751
resolver bugs slipped past.

Bugs the test catches by construction
-------------------------------------
* CHAOS-1751 #2 — argMax aliases shadowing the source column they
  reference (ILLEGAL_AGGREGATION, code 184).
* CHAOS-1751 #3 — column references against a table whose schema
  uses different names (UNKNOWN_IDENTIFIER, code 47).

Validated by `git revert HEAD~3..HEAD` simulation on the
compounding_risk resolver — both bugs fire the test as expected.

Mechanism
---------
* `tests/api/graphql/_sql_explain_helpers.py` — `CapturingSink`
  records `(sql, params)` calls without executing them. Slots in
  via `query_dicts`'s `hasattr(sink, "query_dicts")` path.
* `tests/api/graphql/sql_explain_fixtures.py` — `ALL_RESOLVER_SQL_FIXTURES`
  is a per-resolver registry of async functions that invoke each
  SQL-emitting helper with representative arguments (cover every
  WHERE/branch difference).
* `tests/api/graphql/test_resolver_sql_explain.py` — session-scoped
  fixture connects to ClickHouse (`CLICKHOUSE_URI`), applies the
  production DDL once via `ClickHouseMetricsSink.ensure_schema()`,
  and runs `EXPLAIN PLAN {sql}` for every captured query.

Coverage
--------
11 resolver fixtures: compounding_risk, forecast, home, capacity,
work_graph, recommendations, operating_review, security, bus_factor,
data_health, analytics. Suite runs in ~1.5s locally end-to-end
against a fresh CH container.

Pre-existing bugs surfaced and fixed
------------------------------------
The new test immediately caught several latent runtime bugs in
unrelated resolvers. Fixed in-PR because they are surgical and follow
the CHAOS-1751 pattern:

* `home`: `max(ingested_at)` against `investment_metrics_daily`
  (column doesn't exist; should be `computed_at`).
* `operating_review`:
  - `FROM work_item_state_duration_daily` (table is plural:
    `work_item_state_durations_daily`).
  - `WHERE risk_score > 0` clashing with outer `avg(risk_score) AS
    risk_score`; rename the inner alias to `latest_risk_score` and
    move the predicate into HAVING on the inner aggregate.
* `recommendations`: `argMax(window_end, computed_at) AS window_end`
  (and friends) clashing with source columns referenced in WHERE /
  GROUP BY / HAVING. Rename SELECT aliases to `latest_*` and update
  `_row_to_recommendation` accordingly (with backward-compat fallback
  for any callers that still pass un-aliased rows).
* `analytics`: `Dimension.WORK_TYPE` was not in `investment_dims`,
  so non-forced `use_investment=False` requests routed it against
  `investment_metrics_daily` looking for a non-existent
  `work_item_type` column. WORK_TYPE belongs to the
  `work_unit_investments` rollup; add it to the auto-route set.

Remaining work tracked in CHAOS-1754: the `THROUGHPUT`, `CHURN_LOC`,
and `CYCLE_TIME_HOURS` measure mappings on `work_unit_investments`
reference columns that don't exist on that table. Until that lands,
the analytics fixture matrix is narrowed to `count` against
investment dimensions.

CI
--
`.github/workflows/test.yml`: add `CLICKHOUSE_URI` to the test-matrix
env (in addition to the existing `DATABASE_URI`) so the EXPLAIN
fixture picks up the already-provisioned ClickHouse service.

Contract
--------
Every new GraphQL resolver that emits SQL MUST register a fixture in
`ALL_RESOLVER_SQL_FIXTURES`. Documented in
`docs/api/graphql-overview.md` under "Resolver SQL Validation
Contract (CHAOS-1752)".

SCREENSHOT-WAIVER: backend-only change; no rendered UI surface.

Closes CHAOS-1752
