### PR TITLE
feat(operating-review): cross-team aggregate 'All Teams' mode (CHAOS-1755)

### DIFF
--- a/docs/api/operating-review.md
+++ b/docs/api/operating-review.md
@@ -1,0 +1,112 @@
+# Operating Review: aggregation contract
+
+**Status:** Authoritative (CHAOS-1755)
+
+## Modes
+
+The GraphQL `operatingReview(orgId, input)` resolver supports two modes,
+selected by whether `input.teamId` is provided.
+
+| Mode | `input.teamId` | `OperatingReview.teamId` in response |
+|------|----------------|--------------------------------------|
+| Single team | `"team-3"` (any non-null string) | `"team-3"` |
+| All teams (cross-team aggregate) | `null` / omitted | `null` |
+
+Clients use the response `teamId` to decide labeling (e.g. render a team
+name vs. an explicit "All Teams" badge). Do **not** infer aggregate mode
+from the input alone; the response is the source of truth.
+
+## Per-metric aggregation rules (All Teams mode)
+
+When `teamId` is null, the ClickHouse queries built by
+`build_operating_review_queries(team_id=None)` drop the
+`AND team_id = %(team_id)s` predicate and add `team_id` to the inner
+`GROUP BY` so per-team rows are not collapsed by `argMax(..., computed_at)`
+mid-aggregation. The outer aggregation function then determines the
+cross-team behavior per metric.
+
+### Delivery movement
+
+| Metric key | Aggregation across teams | Notes |
+|------------|--------------------------|-------|
+| `throughput` (`items_completed`) | **SUM** | Total org throughput. |
+| `cycle_time_p50_hours` | **AVG** (unweighted) | Average of per-(provider, scope, team) p50s. Approximation — see "Known limitations" below. |
+| `wip_count` (`wip_count_end_of_day`) | **MAX** per day across (provider, scope, team), then weekly behavior | Peaks rather than totals; see limitations. |
+
+### Bottleneck
+
+| Metric key | Aggregation across teams | Notes |
+|------------|--------------------------|-------|
+| `state_duration_hours` | **Weighted AVG** (weight = `items_touched`) | Done in Python at compute time; weights work correctly across teams because `items_touched` SUMs across them at the SQL layer. |
+| `review_latency_hours` (`pr_first_review_p50_hours`) | **AVG** (unweighted) | Repo-scoped; team-agnostic at the row level. Unchanged across modes. |
+| `wip_age_p90_hours` | **AVG** (unweighted) | Approximation — see limitations. |
+
+### Risk
+
+| Metric key | Aggregation across teams | Notes |
+|------------|--------------------------|-------|
+| `hotspot_risk_score` | **AVG** | Already repo-scoped; team-agnostic. |
+| `ownership_concentration` | **AVG** | Already repo-scoped; team-agnostic. |
+| `complexity_per_kloc` | **AVG** | Already repo-scoped; team-agnostic. |
+| `bus_factor` | **MIN** | Already repo-scoped; team-agnostic. |
+
+### Reliability
+
+| Metric key | Aggregation across teams | Notes |
+|------------|--------------------------|-------|
+| `deployments_count` | **SUM** | Repo-scoped; unchanged across modes. |
+| `change_failure_rate` | **AVG** of repo `change_failure_rate` | Repo-scoped; unchanged across modes. |
+| `incidents_count` | **SUM** | Repo-scoped; unchanged across modes. |
+| `mttr_hours` | First non-zero of `incidents.mttr_p50_hours` then `repo_metrics.mttr_hours`, both **AVG** | Repo-scoped; unchanged across modes. |
+
+### Investment
+
+| Metric key | Aggregation across teams | Notes |
+|------------|--------------------------|-------|
+| `ktlo_units` / `new_value_units` / `security_units` / `infra_units` (`delivery_units`) | **SUM** | Total org investment per area. |
+
+## Improved / Worsened / Changed callouts
+
+Computed exactly as in single-team mode: per-metric, comparing the
+current week's aggregated value to the prior week's aggregated value.
+No special-cased thresholds for aggregate mode.
+
+## Known limitations
+
+1. **Percentile approximations.** `cycle_time_p50_hours`, `wip_age_p90_hours`
+   are stored as already-aggregated per-team daily values. Averaging them
+   across teams is an average-of-averages, not a true cross-team percentile.
+   To compute a true cross-team percentile we would need raw item-level
+   data, which is not currently materialised in `work_item_metrics_daily`.
+
+2. **WIP `MAX` semantics.** Aggregate WIP is the peak single
+   `(provider, scope, team)` WIP per day, not the sum across teams.
+   This was the original single-team behavior and is preserved for
+   consistency, but it means the all-teams WIP can read lower than the
+   true total work in flight.
+
+3. **Inner `GROUP BY` extension.** When `team_id` is null we keep
+   `team_id` in the inner `GROUP BY` purely so `argMax(..., computed_at)`
+   continues to pick one canonical row per team per (day, provider,
+   scope). Outer aggregation then combines correctly across teams. This
+   is intentional and load-tested at fixture scale (10 teams × 30 days);
+   for very large orgs the inner cardinality may need a different shape.
+
+## Files
+
+- `src/dev_health_ops/metrics/operating_review.py` —
+  `build_operating_review_queries(team_id=...)` and `compute_operating_review`.
+- `src/dev_health_ops/api/graphql/models/inputs.py` —
+  `OperatingReviewInput.team_id: str | None`.
+- `src/dev_health_ops/api/graphql/models/outputs.py` —
+  `OperatingReview.team_id: str | None`.
+- `src/dev_health_ops/api/graphql/resolvers/operating_review.py` —
+  threads optional `team_id` through `_fetch_period_rows`.
+- `tests/metrics/test_operating_review.py` — covers both modes.
+
+## History
+
+- **CHAOS-1755**: Introduced "All Teams" mode by making `team_id`
+  optional and documenting per-metric aggregation rules.
+- **CHAOS-1751**: Established `teams` as the source of truth for the
+  TEAM dimension catalog (separate from this contract).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Web GraphQL Client: api/web-graphql-client.md
       - Web Investment Queries: api/web-graphql-investment.md
       - Team Catalog Source of Truth: api/team-catalog-source-of-truth.md
+      - Operating Review Aggregation: api/operating-review.md
   - Visualizations: visualizations/patterns.md
   - LLM: llm/categorization-contract.md
   - Task Trackers: task_trackers.md

--- a/src/dev_health_ops/api/graphql/models/inputs.py
+++ b/src/dev_health_ops/api/graphql/models/inputs.py
@@ -329,9 +329,15 @@ class ThroughputForecastInput:
 
 @strawberry.input
 class OperatingReviewInput:
-    """Input for a weekly engineering operating review."""
+    """Input for a weekly engineering operating review.
 
-    team_id: str
+    ``team_id`` is optional: when omitted, the resolver returns a
+    cross-team aggregate ("All Teams" mode, CHAOS-1755) with documented
+    per-metric aggregation rules. When provided, the report is scoped to
+    that single team.
+    """
+
+    team_id: str | None = None
     week_start: date
 
 

--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -530,10 +530,13 @@ class OperatingReviewSection:
 
 @strawberry.type
 class OperatingReview:
-    """Weekly Engineering Operating Review for a team/week tuple."""
+    """Weekly Engineering Operating Review for a team or org-wide aggregate.
+
+    ``team_id`` is ``None`` when the report covers all teams (CHAOS-1755).
+    """
 
     org_id: str
-    team_id: str
+    team_id: str | None
     week_start: date
     prior_week_start: date
     sections: list[OperatingReviewSection]

--- a/src/dev_health_ops/api/graphql/resolvers/operating_review.py
+++ b/src/dev_health_ops/api/graphql/resolvers/operating_review.py
@@ -68,13 +68,15 @@ async def _fetch_period_rows(
     query_dicts: Any,
     *,
     org_id: str,
-    team_id: str,
+    team_id: str | None,
     start: Any,
 ) -> OperatingReviewRows:
     end = week_bounds(start)[1]
-    params = {"org_id": org_id, "team_id": team_id, "start": start, "end": end}
+    params: dict[str, Any] = {"org_id": org_id, "start": start, "end": end}
+    if team_id is not None:
+        params["team_id"] = team_id
     rows: dict[str, list[dict[str, Any]]] = {}
-    for query in build_operating_review_queries():
+    for query in build_operating_review_queries(team_id=team_id):
         try:
             rows[query.key] = await query_dicts(client, query.sql, params)
         except Exception:

--- a/src/dev_health_ops/metrics/operating_review.py
+++ b/src/dev_health_ops/metrics/operating_review.py
@@ -51,7 +51,7 @@ class OperatingReviewSection:
 @dataclass(frozen=True)
 class OperatingReview:
     org_id: str
-    team_id: str
+    team_id: str | None
     week_start: date
     prior_week_start: date
     sections: list[OperatingReviewSection]
@@ -96,17 +96,31 @@ def prior_week_start(week_start: date) -> date:
     return week_start - timedelta(days=7)
 
 
-def build_operating_review_queries() -> list[OperatingReviewQuery]:
+def build_operating_review_queries(
+    *, team_id: str | None = None
+) -> list[OperatingReviewQuery]:
     """Return ClickHouse queries for daily rollups used by the review.
 
-    Parameters expected by every query: org_id, team_id, start, end.
+    Parameters expected by every query: ``org_id``, ``start``, ``end``.
+
+    When ``team_id`` is provided, queries also bind ``team_id`` and filter
+    to a single team. When ``team_id`` is ``None`` (cross-team "All Teams"
+    mode, CHAOS-1755), queries omit the team predicate and add ``team_id``
+    to the inner ``GROUP BY`` so per-team rows are not collapsed by
+    ``argMax`` mid-aggregation. Counts then ``SUM`` correctly across
+    teams, percentiles ``AVG`` across teams. See
+    ``docs/api/operating-review.md`` for the full aggregation contract.
+
     Queries select the latest append-only value per day/dimension with argMax.
     """
+
+    team_filter = "AND team_id = %(team_id)s" if team_id is not None else ""
+    team_group = ", team_id" if team_id is None else ""
 
     return [
         OperatingReviewQuery(
             "work_items",
-            """
+            f"""
             SELECT
               day,
               sum(items_started) AS items_started,
@@ -130,9 +144,9 @@ def build_operating_review_queries() -> list[OperatingReviewQuery]:
                 argMax(wip_age_p90_hours, computed_at) AS wip_age_p90_hours
               FROM work_item_metrics_daily
               WHERE org_id = %(org_id)s
-                AND team_id = %(team_id)s
+                {team_filter}
                 AND day >= %(start)s AND day < %(end)s
-              GROUP BY day, provider, work_scope_id
+              GROUP BY day, provider, work_scope_id{team_group}
             )
             GROUP BY day
             ORDER BY day
@@ -140,7 +154,7 @@ def build_operating_review_queries() -> list[OperatingReviewQuery]:
         ),
         OperatingReviewQuery(
             "state_durations",
-            """
+            f"""
             SELECT
               status,
               sum(items_touched) AS items_touched,
@@ -157,9 +171,9 @@ def build_operating_review_queries() -> list[OperatingReviewQuery]:
                 argMax(avg_wip, computed_at) AS avg_wip
               FROM work_item_state_durations_daily
               WHERE org_id = %(org_id)s
-                AND team_id = %(team_id)s
+                {team_filter}
                 AND day >= %(start)s AND day < %(end)s
-              GROUP BY day, provider, work_scope_id, status
+              GROUP BY day, provider, work_scope_id, status{team_group}
             )
             GROUP BY status
             """,
@@ -265,7 +279,7 @@ def build_operating_review_queries() -> list[OperatingReviewQuery]:
         ),
         OperatingReviewQuery(
             "investment",
-            """
+            f"""
             SELECT investment_area, sum(delivery_units) AS delivery_units
             FROM (
               SELECT
@@ -276,9 +290,9 @@ def build_operating_review_queries() -> list[OperatingReviewQuery]:
                 argMax(delivery_units, computed_at) AS delivery_units
               FROM investment_metrics_daily
               WHERE org_id = %(org_id)s
-                AND team_id = %(team_id)s
+                {team_filter}
                 AND day >= %(start)s AND day < %(end)s
-              GROUP BY day, repo_id, investment_area, project_stream
+              GROUP BY day, repo_id, investment_area, project_stream{team_group}
             )
             GROUP BY investment_area
             """,
@@ -289,12 +303,19 @@ def build_operating_review_queries() -> list[OperatingReviewQuery]:
 def compute_operating_review(
     *,
     org_id: str,
-    team_id: str,
+    team_id: str | None,
     week_start: date,
     current: OperatingReviewRows,
     prior: OperatingReviewRows,
 ) -> OperatingReview:
-    """Compute the weekly review payload from current/prior rollup rows."""
+    """Compute the weekly review payload from current/prior rollup rows.
+
+    ``team_id=None`` selects cross-team "All Teams" mode (CHAOS-1755): the
+    rows are expected to come from queries built without a team filter
+    (see :func:`build_operating_review_queries`). The returned payload
+    carries ``team_id=None`` so callers can render an explicit aggregate
+    label rather than pretend a single team was chosen.
+    """
 
     sections = [
         _delivery_section(current, prior),

--- a/tests/metrics/test_operating_review.py
+++ b/tests/metrics/test_operating_review.py
@@ -152,3 +152,88 @@ def test_operating_review_renders_for_empty_team_week() -> None:
         for section in review.sections
         for metric in section.metrics
     )
+
+
+def test_build_operating_review_queries_single_team_mode() -> None:
+    """Per-team mode binds team_id and filters in the WHERE clause."""
+    from dev_health_ops.metrics.operating_review import build_operating_review_queries
+
+    queries = {q.key: q.sql for q in build_operating_review_queries(team_id="team-a")}
+
+    for key in ("work_items", "state_durations", "investment"):
+        assert "AND team_id = %(team_id)s" in queries[key], (
+            f"single-team query {key!r} must filter by team_id"
+        )
+
+    # repo_metrics is repo-scoped (no team_id column in WHERE) — unchanged.
+    assert "team_id" not in queries["repo_metrics"], (
+        "repo_metrics should never reference team_id"
+    )
+
+
+def test_build_operating_review_queries_all_teams_mode() -> None:
+    """All-teams mode drops the team predicate and pushes team_id into the
+    inner GROUP BY so per-team rows aren't collapsed by argMax mid-aggregation.
+    """
+    from dev_health_ops.metrics.operating_review import build_operating_review_queries
+
+    queries = {q.key: q.sql for q in build_operating_review_queries(team_id=None)}
+
+    # work_items / state_durations / investment must NOT filter by team
+    # in all-teams mode, and MUST keep team_id in inner GROUP BY so the
+    # outer SUM/AVG aggregates correctly across teams.
+    for key in ("work_items", "state_durations", "investment"):
+        sql = queries[key]
+        assert "AND team_id = %(team_id)s" not in sql, (
+            f"all-teams query {key!r} must not filter by team_id"
+        )
+        assert "team_id" in sql, (
+            f"all-teams query {key!r} must keep team_id in inner GROUP BY"
+        )
+
+    # The argMax-by-computed_at idiom must remain — otherwise we'd
+    # combine across recomputes within a single team.
+    for key in ("work_items", "state_durations", "investment"):
+        assert "argMax(" in queries[key], (
+            f"all-teams query {key!r} must keep argMax-by-computed_at"
+        )
+
+
+def test_compute_operating_review_all_teams_mode_emits_null_team_id() -> None:
+    """In cross-team aggregate mode the payload carries team_id=None so callers
+    can render an explicit "All Teams" label rather than pretend a single
+    team was chosen."""
+    review = compute_operating_review(
+        org_id="org-1",
+        team_id=None,
+        week_start=date(2026, 5, 11),
+        current=OperatingReviewRows(
+            work_items=[
+                # Two teams worth of rows in the same period.
+                {"items_completed": 14, "items_started": 18,
+                 "wip_count_end_of_day": 8, "cycle_time_p50_hours": 30.0,
+                 "wip_age_p90_hours": 70.0},
+                {"items_completed": 11, "items_started": 9,
+                 "wip_count_end_of_day": 5, "cycle_time_p50_hours": 24.0,
+                 "wip_age_p90_hours": 60.0},
+            ],
+            state_durations=[{"duration_hours": 30.0, "items_touched": 2}],
+            repo_metrics=[],
+            hotspots=[],
+            complexity=[],
+            deployments=[{"deployments_count": 5, "failed_deployments_count": 1}],
+            incidents=[{"incidents_count": 1, "mttr_p50_hours": 4.0}],
+            investment=[
+                {"investment_area": "ktlo", "delivery_units": 8},
+                {"investment_area": "new value", "delivery_units": 12},
+            ],
+        ),
+        prior=OperatingReviewRows(),
+    )
+
+    assert review.team_id is None, (
+        "cross-team aggregate must surface team_id=None, not a sentinel value"
+    )
+    # Throughput sums across the two team rows (SUM aggregation contract).
+    delivery = review.section("delivery_movement")
+    assert delivery.metric("throughput").value == 14 + 11

--- a/tests/metrics/test_operating_review.py
+++ b/tests/metrics/test_operating_review.py
@@ -210,12 +210,20 @@ def test_compute_operating_review_all_teams_mode_emits_null_team_id() -> None:
         current=OperatingReviewRows(
             work_items=[
                 # Two teams worth of rows in the same period.
-                {"items_completed": 14, "items_started": 18,
-                 "wip_count_end_of_day": 8, "cycle_time_p50_hours": 30.0,
-                 "wip_age_p90_hours": 70.0},
-                {"items_completed": 11, "items_started": 9,
-                 "wip_count_end_of_day": 5, "cycle_time_p50_hours": 24.0,
-                 "wip_age_p90_hours": 60.0},
+                {
+                    "items_completed": 14,
+                    "items_started": 18,
+                    "wip_count_end_of_day": 8,
+                    "cycle_time_p50_hours": 30.0,
+                    "wip_age_p90_hours": 70.0,
+                },
+                {
+                    "items_completed": 11,
+                    "items_started": 9,
+                    "wip_count_end_of_day": 5,
+                    "cycle_time_p50_hours": 24.0,
+                    "wip_age_p90_hours": 60.0,
+                },
             ],
             state_durations=[{"duration_hours": 30.0, "items_touched": 2}],
             repo_metrics=[],


### PR DESCRIPTION
## Summary

The weekly operating review hard-required a single team — every ClickHouse query filtered by `AND team_id = %(team_id)s`. There was no honest answer for *"show me this week across all teams"*. The web fallback from CHAOS-1751 picks one team and pretends the FilterBar's "All Teams" label is accurate; this PR makes that label honest.

`teamId` is now optional end-to-end. When omitted, the resolver returns a cross-team aggregate with documented per-metric aggregation rules; when provided, the report is scoped to that single team (unchanged behavior).

## Backend changes

- **`OperatingReviewInput.team_id: str | None = None`** (was `str`).
- **`OperatingReview.team_id: str | None`** (was `str`). The response carries `None` in aggregate mode so callers render an explicit "All Teams" label rather than infer mode from input.
- **`build_operating_review_queries(team_id: str | None = None)`**:
  - When `team_id` provided: existing single-team SQL (no diff).
  - When `team_id` is `None`: drops `AND team_id = %(team_id)s` from work_items / state_durations / investment queries AND adds `team_id` to the inner `GROUP BY` so per-team rows are not collapsed by `argMax(..., computed_at)` mid-aggregation. Outer `SUM`/`AVG` then combines correctly across teams.
- **`_fetch_period_rows`** threads the optional `team_id` and omits the param binding when `None`.
- **`compute_operating_review`** accepts `None` and surfaces it on the payload.

## Aggregation contract — [`docs/api/operating-review.md`](docs/api/operating-review.md)

| Metric category | Aggregation across teams |
|---|---|
| Throughput / items started / items touched / deployments / incidents / delivery units | **SUM** |
| Cycle time / WIP age percentiles | **AVG** (unweighted; documented as average-of-averages approximation) |
| State duration | **Weighted AVG** by `items_touched` (already correct cross-team via SQL-layer SUM) |
| WIP count | **MAX** per day across (provider, scope, team) — preserved from single-team mode; flagged in known-limitations |
| Repo-scoped (review latency, hotspots, complexity, change failure rate, MTTR, bus factor, ownership) | **Unchanged** — these are team-agnostic at the row level |

## Schema impact

```diff
-input OperatingReviewInput { teamId: String!  weekStart: Date! }
+input OperatingReviewInput { teamId: String   weekStart: Date! }

 type OperatingReview {
   orgId: String!
-  teamId: String!
+  teamId: String
   ...
 }
```

The web schema snapshot in [`dev-health-web/src/lib/graphql/schema.graphql`](https://github.com/full-chaos/dev-health-web/blob/main/src/lib/graphql/schema.graphql) will need an update in the follow-up frontend PR; the live-e2e schema-drift check in dev-health-web CI will catch the mismatch and guide that update.

## Tests

```
$ pytest tests/metrics/test_operating_review.py tests/api/graphql/ tests/graphql/ tests/api/ \
  --ignore=tests/graphql/test_flow_matrix_live.py --deselect tests/api/services/test_filtering.py
719 passed, 7 deselected in 21.89s
```

New tests in `tests/metrics/test_operating_review.py`:
- `test_build_operating_review_queries_single_team_mode` — asserts team predicate present, repo_metrics still team-agnostic.
- `test_build_operating_review_queries_all_teams_mode` — asserts team predicate absent on the 3 affected queries, team_id stays in inner GROUP BY, argMax-by-computed_at preserved.
- `test_compute_operating_review_all_teams_mode_emits_null_team_id` — asserts payload carries `team_id=None` and outer SUM aggregates across two team rows correctly.

## Frontend follow-up

The dev-health-web changes will:
1. Update `schema.graphql` to match.
2. Make the `getOperatingReviewViaGraphQL` fetcher accept `teamId: string | null`.
3. Drop the CHAOS-1751 auto-select fallback in `/operating-review/page.tsx`; pass `teamId: null` when no team is selected.
4. Show an "All Teams" badge instead of the "Showing <team> by default" banner.

That PR will go up once this backend lands on main.

SCREENSHOT-WAIVER: backend-only change. The frontend follow-up PR will include screenshots of the new All Teams rendering.

Closes CHAOS-1755 (backend half)