### PR TITLE
feat(api): expose AI missing states and review load gaps (CHAOS-1721)

### DIFF
--- a/docs/api/graphql-ai.md
+++ b/docs/api/graphql-ai.md
@@ -24,6 +24,9 @@ can consume without bespoke joins or recomputation.
 - **Empty / partial / populated states are first-class.** Every result
   carries `dataAvailable: Boolean!` so the UI can render the correct
   state without ad-hoc null probing.
+- **Intentional missing states are explicit.** AI Impact, AI Review Load,
+  and AI Risk expose `missingStates` guidance when a coverage gap should be
+  visible follow-up work instead of a silent omission.
 - **Provenance accompanies every metric.** `computedAt` and bucketed
   evidence references travel with the response so the UI can show
   freshness and drill into the underlying artifacts.
@@ -96,13 +99,16 @@ Side-by-side aggregation of the AI-attributed buckets against the
 ### `aiReviewLoad`
 
 Review-load breakdown per bucket: `reviewsPerPr`,
-`changesRequestedPerPr`, and the persisted `reviewAmplification` from
-CHAOS-1581.
+`changesRequestedPerPr`, post-first-review push counts, and the persisted
+`reviewAmplification` from CHAOS-1581. Reviewer concentration is exposed
+only as an aggregate distribution summary (`reviewerGini` and
+`reviewerCount`), never as reviewer names, rankings, or person-level counts.
 
 ### `aiRiskBreakdown`
 
 Per-bucket rework / revert / test-gap / incident rates.  Computed from
-persisted counts, no weighting.
+persisted counts, no weighting. `missingStates` keeps hotspot and
+high-complexity overlap visible until those file-overlap detectors are wired.
 
 ### `aiOpportunities`
 

--- a/docs/user-guide/views/ai-review-load.md
+++ b/docs/user-guide/views/ai-review-load.md
@@ -12,7 +12,7 @@ human-only baseline on the same scope and time window.
 
 ## What this view shows
 
-Five metric cards plus one trend, all bucketed by `AI_ASSISTED` vs `HUMAN`:
+Six metric cards plus one trend, all bucketed by `AI_ASSISTED` vs `HUMAN`:
 
 | Card                       | What it answers                                                             |
 | -------------------------- | --------------------------------------------------------------------------- |
@@ -21,22 +21,22 @@ Five metric cards plus one trend, all bucketed by `AI_ASSISTED` vs `HUMAN`:
 | Change request rate        | Average change-request comments per PR.                                     |
 | Approval friction          | Derived: `changesRequestedPerPr / reviewsPerPr` per bucket.                 |
 | Review amplification       | Review volume on AI-attributed PRs vs the baseline.                         |
+| Push iterations after first review | Persisted follow-up push count after review activity starts.         |
 | Review amplification trend | Daily series showing whether amplification is trending up or down.          |
 
 ### Intentional gaps
 
-Two panels are explicitly **missing** today and rendered as missing-data
-cards so the gap stays visible instead of being silently absent:
+One panel remains explicitly **aggregate-only** and renders as a missing-data
+card until the distribution summary is available:
 
 | Missing card                         | Why it is missing                                                                                |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------ |
-| Push iterations after first review   | The schema does not yet expose post-first-review push events.                                    |
-| Reviewer concentration               | **Intentionally deferred** until aggregate-only reviewer distribution ships without per-person ranking. |
+| Reviewer concentration               | Render only aggregate reviewer distribution (`reviewerGini`, `reviewerCount`), never names or rankings. |
 
-Reviewer concentration is the most important of these to call out. The
-*data exists* — we could compute it. We choose **not to ship it as an
-individual-leveled metric**. When it ships, it will land as bucketed
-distribution (top quartile vs the rest), not as a leaderboard with names.
+Reviewer concentration is intentionally constrained. The API may use reviewer
+identities inside the aggregation boundary, but it exposes only distribution
+values. It does **not** ship individual-leveled metrics, leaderboard rows, or
+reviewer names.
 
 ---
 
@@ -84,7 +84,7 @@ not a reviewer scoreboard.
 
 ## Data sources and freshness
 
-- Cards read from `aiReviewLoad` (per-bucket review rollups).
+- Cards read from `aiReviewLoad` (per-bucket review rollups plus aggregate-only reviewer concentration).
 - Deltas come from `aiComparison` (same scope, same window).
 - Both queries return `dataAvailable: Boolean!` — `false` triggers the
   missing-data UX rather than a silently empty dashboard.

--- a/src/dev_health_ops/api/graphql/models/ai.py
+++ b/src/dev_health_ops/api/graphql/models/ai.py
@@ -75,6 +75,15 @@ class AIScopeInput:
 
 
 @strawberry.type
+class AIMissingState:
+    """Visible guidance for intentionally missing or incomplete AI signals."""
+
+    key: str
+    title: str
+    guidance: str
+
+
+@strawberry.type
 class AILeverageComponents:
     """Decomposed Operating Leverage components.
 
@@ -145,6 +154,7 @@ class AIImpactSummary:
     ai_assisted_pr_ratio: float | None
     by_bucket: list[AIImpactBucketTotals]
     daily: list[AIImpactBucketRow]
+    missing_states: list[AIMissingState]
     data_available: bool
     computed_at: datetime | None = None
 
@@ -199,6 +209,21 @@ class AIReviewLoadRow:
     reviews_per_pr: float | None
     changes_requested_per_pr: float | None
     review_amplification: float | None
+    post_first_review_pushes_count: int
+    post_first_review_pushes_per_pr: float | None
+
+
+@strawberry.type
+class AIReviewerConcentrationSummary:
+    """Aggregate-only reviewer distribution signal.
+
+    This intentionally exposes only distribution-level values. It never
+    includes reviewer identities, counts by person, or ranking fields.
+    """
+
+    data_available: bool
+    reviewer_count: int
+    reviewer_gini: float | None = None
 
 
 @strawberry.type
@@ -210,6 +235,8 @@ class AIReviewLoadResult:
     end_date: date
     by_bucket: list[AIReviewLoadRow]
     daily: list[AIReviewLoadRow]
+    reviewer_concentration: AIReviewerConcentrationSummary
+    missing_states: list[AIMissingState]
     data_available: bool
 
 
@@ -237,6 +264,7 @@ class AIRiskBreakdownResult:
     start_date: date
     end_date: date
     by_bucket: list[AIRiskBreakdownRow]
+    missing_states: list[AIMissingState]
     data_available: bool
 
 

--- a/src/dev_health_ops/api/graphql/resolvers/ai.py
+++ b/src/dev_health_ops/api/graphql/resolvers/ai.py
@@ -300,7 +300,9 @@ async def resolve_ai_impact_summary(
 
     computed_at = max((row.computed_at for row in rows), default=None)
     missing_states = [
-        state for state in [_unknown_attribution_missing_state(unknown)] if state is not None
+        state
+        for state in [_unknown_attribution_missing_state(unknown)]
+        if state is not None
     ]
 
     return AIImpactSummary(

--- a/src/dev_health_ops/api/graphql/resolvers/ai.py
+++ b/src/dev_health_ops/api/graphql/resolvers/ai.py
@@ -48,7 +48,9 @@ from ..models.ai import (
     AIImpactBucketTotals,
     AIImpactSummary,
     AILeverageComponents,
+    AIMissingState,
     AIOpportunitiesResult,
+    AIReviewerConcentrationSummary,
     AIReviewLoadResult,
     AIReviewLoadRow,
     AIRiskBreakdownResult,
@@ -156,6 +158,25 @@ def _bucket_filter(
 
 def _empty_leverage() -> AILeverageComponents:
     return AILeverageComponents(prs_component=0.0)
+
+
+def _missing_state(key: str, title: str, guidance: str) -> AIMissingState:
+    return AIMissingState(key=key, title=title, guidance=guidance)
+
+
+def _unknown_attribution_missing_state(unknown_prs: int) -> AIMissingState | None:
+    if unknown_prs <= 0:
+        return None
+    return _missing_state(
+        "unknown_attribution",
+        "Unknown attribution needs follow-up",
+        (
+            "Some PRs could not be attributed to AI-assisted, agent-created, "
+            "AI-reviewed, or human buckets. Treat this as a coverage gap for "
+            "labels, trailers, bot identities, or CI annotations, not as a "
+            "person-level usage signal."
+        ),
+    )
 
 
 def _row_to_impact_daily(row: Any) -> AIImpactBucketRow:
@@ -278,6 +299,9 @@ async def resolve_ai_impact_summary(
     unknown = sum(r.unknown_prs for r in rows)
 
     computed_at = max((row.computed_at for row in rows), default=None)
+    missing_states = [
+        state for state in [_unknown_attribution_missing_state(unknown)] if state is not None
+    ]
 
     return AIImpactSummary(
         org_id=org_id,
@@ -291,6 +315,7 @@ async def resolve_ai_impact_summary(
         ai_assisted_pr_ratio=_ratio(ai_assisted, total_prs),
         by_bucket=sorted(by_bucket.values(), key=lambda r: r.bucket),
         daily=daily,
+        missing_states=missing_states,
         data_available=bool(rows),
         computed_at=computed_at,
     )
@@ -389,6 +414,27 @@ def _review_total_for_row(row: Any) -> int:
     return int(round(reviews_per_pr * row.prs_total))
 
 
+async def _load_reviewer_concentration(
+    context: GraphQLContext,
+    org_id: str,
+    date_range: AIDateRangeInput,
+    scope: AIScopeInput | None,
+) -> AIReviewerConcentrationSummary:
+    repo_id, team_id, _work_type = _normalize_scope(scope)
+    loader = AIImpactClickHouseLoader(_require_client(context), org_id=org_id)
+    reviewer_gini, reviewer_count = await loader.load_reviewer_concentration(
+        start_day=date_range.start_date,
+        end_day=date_range.end_date,
+        repo_id=repo_id,
+        team_id=team_id,
+    )
+    return AIReviewerConcentrationSummary(
+        data_available=reviewer_gini is not None,
+        reviewer_count=reviewer_count,
+        reviewer_gini=reviewer_gini,
+    )
+
+
 async def resolve_ai_review_load(
     context: GraphQLContext,
     date_range: AIDateRangeInput,
@@ -405,6 +451,10 @@ async def resolve_ai_review_load(
             reviews_per_pr=row.reviews_per_pr,
             changes_requested_per_pr=row.changes_requested_per_pr,
             review_amplification=row.ai_review_amplification,
+            post_first_review_pushes_count=row.followup_commits_count,
+            post_first_review_pushes_per_pr=_ratio(
+                row.followup_commits_count, row.prs_total
+            ),
         )
         for row in rows
     ]
@@ -417,6 +467,7 @@ async def resolve_ai_review_load(
     for bucket, bucket_rows in by_bucket_acc.items():
         prs_total = sum(r.prs_total for r in bucket_rows)
         reviews_total = sum(_review_total_for_row(r) for r in bucket_rows)
+        post_first_review_pushes = sum(r.followup_commits_count for r in bucket_rows)
         by_bucket.append(
             AIReviewLoadRow(
                 bucket=bucket,
@@ -431,9 +482,30 @@ async def resolve_ai_review_load(
                 review_amplification=_weighted_avg(
                     [(r.ai_review_amplification, r.prs_total) for r in bucket_rows]
                 ),
+                post_first_review_pushes_count=post_first_review_pushes,
+                post_first_review_pushes_per_pr=_ratio(
+                    post_first_review_pushes, prs_total
+                ),
             )
         )
     by_bucket.sort(key=lambda r: r.bucket)
+
+    reviewer_concentration = await _load_reviewer_concentration(
+        context, org_id, date_range, scope
+    )
+    missing_states = []
+    if not reviewer_concentration.data_available:
+        missing_states.append(
+            _missing_state(
+                "reviewer_concentration",
+                "Reviewer concentration needs aggregate coverage",
+                (
+                    "Reviewer concentration is only shown as an aggregate "
+                    "distribution signal. No reviewer names, rankings, or "
+                    "person-level review counts are exposed."
+                ),
+            )
+        )
 
     return AIReviewLoadResult(
         org_id=org_id,
@@ -441,6 +513,8 @@ async def resolve_ai_review_load(
         end_date=date_range.end_date,
         by_bucket=by_bucket,
         daily=daily,
+        reviewer_concentration=reviewer_concentration,
+        missing_states=missing_states,
         data_available=bool(rows),
     )
 
@@ -490,6 +564,26 @@ async def resolve_ai_risk_breakdown(
         start_date=date_range.start_date,
         end_date=date_range.end_date,
         by_bucket=by_bucket,
+        missing_states=[
+            _missing_state(
+                "hotspot_overlap",
+                "Hotspot overlap detector not yet wired",
+                (
+                    "AI-attributed PRs are not yet joined to hotspot file "
+                    "overlap. Keep this visible as detector follow-up rather "
+                    "than treating missing overlap as no risk."
+                ),
+            ),
+            _missing_state(
+                "complexity_overlap",
+                "Complexity overlap detector not yet wired",
+                (
+                    "AI-attributed PRs are not yet joined to high-complexity "
+                    "file overlap. Drill into PR and Work Graph evidence when "
+                    "available; do not infer person-level quality from this gap."
+                ),
+            ),
+        ],
         data_available=bool(rows),
     )
 

--- a/src/dev_health_ops/metrics/loaders/ai_impact.py
+++ b/src/dev_health_ops/metrics/loaders/ai_impact.py
@@ -201,6 +201,56 @@ class AIImpactClickHouseLoader:
         raw_rows = await query_dicts(self.client, query, params)
         return [_to_record(raw) for raw in raw_rows]
 
+    async def load_reviewer_concentration(
+        self,
+        *,
+        start_day: date,
+        end_day: date,
+        repo_id: uuid.UUID | None = None,
+        team_id: str | None = None,
+    ) -> tuple[float | None, int]:
+        """Load aggregate-only reviewer concentration for AI Review Load.
+
+        The query intentionally returns only the distribution summary inputs.
+        Reviewer identities are used inside the aggregation boundary and are not
+        returned from this loader or exposed through GraphQL.
+        """
+
+        from dev_health_ops.api.queries.client import query_dicts
+
+        params: dict[str, Any] = {"start_day": start_day, "end_day": end_day}
+        filters = ["day >= {start_day:Date}", "day <= {end_day:Date}"]
+        if repo_id is not None:
+            params["repo_id"] = str(repo_id)
+            filters.append("repo_id = {repo_id:UUID}")
+        if team_id is not None:
+            params["team_id"] = team_id
+            filters.append("team_id = {team_id:String}")
+        params = self._scope.inject(params)
+        org_expr = self._scope.expression()
+        if org_expr:
+            filters.append(org_expr)
+        where_clause = " AND ".join(filters)
+        query = f"""
+        SELECT sum(reviews_given) AS reviews_given
+        FROM (
+            SELECT
+                repo_id,
+                author_email,
+                day,
+                argMax(reviews_given, computed_at) AS reviews_given
+            FROM user_metrics_daily
+            WHERE {where_clause}
+            GROUP BY repo_id, author_email, day
+        )
+        GROUP BY author_email
+        """
+        rows = await query_dicts(self.client, query, params)
+        review_loads = [float(row.get("reviews_given") or 0.0) for row in rows]
+        if not review_loads:
+            return None, 0
+        return _gini(review_loads), len(review_loads)
+
 
 def _to_record(raw: dict[str, Any]) -> AIImpactMetricsDailyRecord:
     repo_id = parse_uuid(raw.get("repo_id"))
@@ -247,3 +297,15 @@ def _to_record(raw: dict[str, Any]) -> AIImpactMetricsDailyRecord:
         ),
         computed_at=raw["computed_at"],
     )
+
+
+def _gini(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    total = sum(values)
+    if total == 0.0:
+        return 0.0
+    sorted_values = sorted(values)
+    count = len(sorted_values)
+    weighted_sum = sum((index + 1) * value for index, value in enumerate(sorted_values))
+    return (2.0 * weighted_sum) / (count * total) - (count + 1.0) / count

--- a/tests/api/graphql/test_ai_resolver.py
+++ b/tests/api/graphql/test_ai_resolver.py
@@ -272,9 +272,7 @@ async def test_impact_summary_populated_aggregates_all_buckets():
     assert result.human_prs == 12
     assert result.unknown_prs == 2
     assert result.total_prs == 20 + 4 + 12 + 2
-    assert [state.key for state in result.missing_states] == [
-        "unknown_attribution"
-    ]
+    assert [state.key for state in result.missing_states] == ["unknown_attribution"]
     # ai_assisted_pr_ratio is the volume-weighted average across all rows.
     assert result.ai_assisted_pr_ratio is not None
     assert result.computed_at == COMPUTED_AT
@@ -350,9 +348,7 @@ async def test_review_load_empty_state():
     assert result.daily == []
     assert result.reviewer_concentration.data_available is False
     assert result.reviewer_concentration.reviewer_count == 0
-    assert [state.key for state in result.missing_states] == [
-        "reviewer_concentration"
-    ]
+    assert [state.key for state in result.missing_states] == ["reviewer_concentration"]
 
 
 @pytest.mark.asyncio
@@ -368,9 +364,12 @@ async def test_review_load_populated_aggregates_by_bucket():
     assert bucket_lookup[
         AttributionBucket.AI_ASSISTED.value
     ].review_amplification == pytest.approx(1.4)
-    assert bucket_lookup[
-        AttributionBucket.AI_ASSISTED.value
-    ].post_first_review_pushes_count == 6
+    assert (
+        bucket_lookup[
+            AttributionBucket.AI_ASSISTED.value
+        ].post_first_review_pushes_count
+        == 6
+    )
     assert bucket_lookup[
         AttributionBucket.AI_ASSISTED.value
     ].post_first_review_pushes_per_pr == pytest.approx(0.3)

--- a/tests/api/graphql/test_ai_resolver.py
+++ b/tests/api/graphql/test_ai_resolver.py
@@ -100,6 +100,7 @@ def _record(
     ai_review_amplification: float | None = None,
     ai_cycle_time_delta_hours: float | None = None,
     ai_assisted_pr_ratio: float | None = None,
+    followup_commits_count: int = 0,
 ) -> AIImpactMetricsDailyRecord:
     return AIImpactMetricsDailyRecord(
         org_id=ORG_ID,
@@ -125,7 +126,7 @@ def _record(
         changes_requested_per_pr=0.3,
         rework_prs=int(prs_total * (rework_drag_rate or 0)),
         rework_drag_rate=rework_drag_rate,
-        followup_commits_count=0,
+        followup_commits_count=followup_commits_count,
         revert_prs=int(prs_total * (revert_rate or 0)),
         revert_rate=revert_rate,
         incidents_count=int(prs_total * (incident_drag_rate or 0)),
@@ -149,6 +150,7 @@ def _populated_rows() -> list[AIImpactMetricsDailyRecord]:
             ai_assisted_pr_ratio=0.5,
             ai_review_amplification=1.4,
             ai_cycle_time_delta_hours=-3.0,
+            followup_commits_count=6,
         ),
         _record(
             bucket=AttributionBucket.AGENT_CREATED,
@@ -202,6 +204,18 @@ def _patch_loader(rows: list[AIImpactMetricsDailyRecord]) -> Any:
     )
 
 
+def _patch_reviewer_concentration(
+    reviewer_gini: float | None,
+    reviewer_count: int,
+) -> Any:
+    return patch(
+        "dev_health_ops.metrics.loaders.ai_impact."
+        "AIImpactClickHouseLoader.load_reviewer_concentration",
+        new_callable=AsyncMock,
+        return_value=(reviewer_gini, reviewer_count),
+    )
+
+
 def _range() -> AIDateRangeInput:
     return AIDateRangeInput(start_date=DAY_START, end_date=DAY_END)
 
@@ -222,6 +236,7 @@ async def test_impact_summary_empty_state_returns_stable_contract():
     assert result.ai_assisted_pr_ratio is None
     assert result.by_bucket == []
     assert result.daily == []
+    assert result.missing_states == []
     assert result.data_available is False
     assert result.computed_at is None
 
@@ -257,6 +272,9 @@ async def test_impact_summary_populated_aggregates_all_buckets():
     assert result.human_prs == 12
     assert result.unknown_prs == 2
     assert result.total_prs == 20 + 4 + 12 + 2
+    assert [state.key for state in result.missing_states] == [
+        "unknown_attribution"
+    ]
     # ai_assisted_pr_ratio is the volume-weighted average across all rows.
     assert result.ai_assisted_pr_ratio is not None
     assert result.computed_at == COMPUTED_AT
@@ -324,17 +342,22 @@ async def test_comparison_populated_emits_delta():
 
 @pytest.mark.asyncio
 async def test_review_load_empty_state():
-    with _patch_loader([]):
+    with _patch_loader([]), _patch_reviewer_concentration(None, 0):
         result = await resolve_ai_review_load(_ctx(), _range())
 
     assert result.data_available is False
     assert result.by_bucket == []
     assert result.daily == []
+    assert result.reviewer_concentration.data_available is False
+    assert result.reviewer_concentration.reviewer_count == 0
+    assert [state.key for state in result.missing_states] == [
+        "reviewer_concentration"
+    ]
 
 
 @pytest.mark.asyncio
 async def test_review_load_populated_aggregates_by_bucket():
-    with _patch_loader(_populated_rows()):
+    with _patch_loader(_populated_rows()), _patch_reviewer_concentration(0.42, 5):
         result = await resolve_ai_review_load(_ctx(), _range())
 
     assert result.data_available is True
@@ -345,6 +368,16 @@ async def test_review_load_populated_aggregates_by_bucket():
     assert bucket_lookup[
         AttributionBucket.AI_ASSISTED.value
     ].review_amplification == pytest.approx(1.4)
+    assert bucket_lookup[
+        AttributionBucket.AI_ASSISTED.value
+    ].post_first_review_pushes_count == 6
+    assert bucket_lookup[
+        AttributionBucket.AI_ASSISTED.value
+    ].post_first_review_pushes_per_pr == pytest.approx(0.3)
+    assert result.reviewer_concentration.data_available is True
+    assert result.reviewer_concentration.reviewer_count == 5
+    assert result.reviewer_concentration.reviewer_gini == pytest.approx(0.42)
+    assert result.missing_states == []
 
 
 # -----------------------------------------------------------------------------
@@ -359,6 +392,10 @@ async def test_risk_breakdown_empty_state():
 
     assert result.data_available is False
     assert result.by_bucket == []
+    assert {state.key for state in result.missing_states} == {
+        "hotspot_overlap",
+        "complexity_overlap",
+    }
 
 
 @pytest.mark.asyncio
@@ -373,6 +410,10 @@ async def test_risk_breakdown_populated_computes_rates():
     assert ai_row.rework_rate == pytest.approx(0.1)
     assert ai_row.revert_rate == pytest.approx(0.05)
     assert ai_row.test_gap_rate == pytest.approx(0.2)
+    assert {state.key for state in result.missing_states} == {
+        "hotspot_overlap",
+        "complexity_overlap",
+    }
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expose explicit missing-state guidance for AI attribution, review load, and risk gaps
- add post-first-review push metrics to AI Review Load
- add aggregate-only reviewer concentration without reviewer identities or rankings

## Verification
- pytest tests/api/graphql/test_ai_resolver.py tests/metrics/test_ai_impact.py tests/audit/ai_governance/test_surveillance_posture.py
- python -m dev_health_ops.api.graphql.export_schema --out /var/folders/fc/1xbvf93j4t31_5mslw1x6gq40000gn/T/opencode/chaos-1721-schema.graphql
- PYTHONPATH=src resolver QA script

Closes CHAOS-1721
SCREENSHOT-WAIVER: Backend GraphQL/docs contract only; no rendered frontend changes in this branch.