### PR TITLE
feat(operating-review): connect AI evidence to weekly review (CHAOS-1722)

### DIFF
--- a/docs/api/graphql-ai.md
+++ b/docs/api/graphql-ai.md
@@ -110,6 +110,12 @@ Stable contract — `recommendations: []`, `detectorReady: false` —
 until CHAOS-1586 lands the detector.  Clients can render an empty
 state today and gain population without a schema change.
 
+Recommendations include metric `evidenceRefs`. When those refs point to PR
+artifacts, the response also includes `workGraphDrilldowns` so clients can
+open `aiWorkflowDrilldown(rootType: PR, rootId: ...)` and inspect the
+underlying Work Graph evidence instead of treating a recommendation as a
+standalone dashboard card.
+
 ### `aiGovernanceSummary`
 
 Coverage rollups (`declarationCoverage`, `humanReviewCoverage`,

--- a/docs/api/operating-review.md
+++ b/docs/api/operating-review.md
@@ -65,6 +65,21 @@ cross-team behavior per metric.
 |------------|--------------------------|-------|
 | `ktlo_units` / `new_value_units` / `security_units` / `infra_units` (`delivery_units`) | **SUM** | Total org investment per area. |
 
+### AI Workflow Intelligence
+
+| Metric key | Aggregation across teams | Notes |
+|------------|--------------------------|-------|
+| `ai_adoption_ratio` | **SUM AI-attributed PRs / SUM total PRs** | Uses persisted AI attribution buckets. Unknown remains in the denominator. |
+| `ai_cycle_time_delta_hours` | **AVG** | AI-attributed cycle-time delta from `ai_impact_metrics_daily`. Negative values mean lower AI-side cycle time. |
+| `ai_review_amplification` | **AVG** | Review-pressure ratio from AI impact rollups. |
+| `ai_risk_drag` | **AVG of available risk rates** | Combines rework, test-gap, and incident drag rates without creating a synthetic person score. |
+| `ai_governance_coverage` | **AVG coverage** | Averages declaration, human-review, security-scan, and in-policy coverage from governance rollups. |
+| `ai_opportunity_signals` | **Rule count** | Counts evidence-backed opportunity conditions for the week; clients should drill into `aiOpportunities` and `aiWorkflowDrilldown` for artifacts. |
+
+The section is a weekly operating cadence for AI adoption: adoption mix,
+delivery impact, review pressure, risk drag, governance, and opportunities.
+It does not recompute attribution or inspect raw prompt/session data.
+
 ## Improved / Worsened / Changed callouts
 
 Computed exactly as in single-team mode: per-metric, comparing the
@@ -108,5 +123,8 @@ No special-cased thresholds for aggregate mode.
 
 - **CHAOS-1755**: Introduced "All Teams" mode by making `team_id`
   optional and documenting per-metric aggregation rules.
+- **CHAOS-1722**: Added the AI Workflow Intelligence section to the weekly
+  operating review and documented evidence handoff to AI recommendations /
+  Work Graph drilldowns.
 - **CHAOS-1751**: Established `teams` as the source of truth for the
   TEAM dimension catalog (separate from this contract).

--- a/src/dev_health_ops/api/graphql/models/ai.py
+++ b/src/dev_health_ops/api/graphql/models/ai.py
@@ -257,6 +257,15 @@ class AIOpportunityKind(Enum):
 
 
 @strawberry.type
+class AIWorkGraphDrilldownRef:
+    """Reference that lets clients open Work Graph evidence for an AI rec."""
+
+    root_type: str
+    root_id: str
+    label: str
+
+
+@strawberry.type
 class AIOpportunity:
     """A single AI automation candidate."""
 
@@ -268,6 +277,7 @@ class AIOpportunity:
     rationale: str
     score: float
     evidence_refs: list[str]
+    work_graph_drilldowns: list[AIWorkGraphDrilldownRef]
 
 
 @strawberry.type

--- a/src/dev_health_ops/api/graphql/resolvers/operating_review.py
+++ b/src/dev_health_ops/api/graphql/resolvers/operating_review.py
@@ -91,6 +91,8 @@ async def _fetch_period_rows(
         deployments=rows.get("deployments", []),
         incidents=rows.get("incidents", []),
         investment=rows.get("investment", []),
+        ai_impact=rows.get("ai_impact", []),
+        ai_governance=rows.get("ai_governance", []),
     )
 
 

--- a/src/dev_health_ops/metrics/operating_review.py
+++ b/src/dev_health_ops/metrics/operating_review.py
@@ -75,6 +75,8 @@ class OperatingReviewRows:
     deployments: Sequence[Mapping[str, Any]] = field(default_factory=list)
     incidents: Sequence[Mapping[str, Any]] = field(default_factory=list)
     investment: Sequence[Mapping[str, Any]] = field(default_factory=list)
+    ai_impact: Sequence[Mapping[str, Any]] = field(default_factory=list)
+    ai_governance: Sequence[Mapping[str, Any]] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -297,6 +299,72 @@ def build_operating_review_queries(
             GROUP BY investment_area
             """,
         ),
+        OperatingReviewQuery(
+            "ai_impact",
+            f"""
+            SELECT
+              attribution_bucket,
+              sum(prs_total) AS prs_total,
+              sum(ai_assisted_prs) AS ai_assisted_prs,
+              sum(agent_created_prs) AS agent_created_prs,
+              sum(human_prs) AS human_prs,
+              sum(unknown_prs) AS unknown_prs,
+              avg(ai_cycle_time_delta_hours) AS ai_cycle_time_delta_hours,
+              avg(ai_review_amplification) AS ai_review_amplification,
+              avg(rework_drag_rate) AS rework_drag_rate,
+              avg(test_gap_rate) AS test_gap_rate,
+              avg(incident_drag_rate) AS incident_drag_rate
+            FROM (
+              SELECT
+                day,
+                repo_id,
+                team_id,
+                work_type,
+                attribution_bucket,
+                argMax(prs_total, computed_at) AS prs_total,
+                argMax(ai_assisted_prs, computed_at) AS ai_assisted_prs,
+                argMax(agent_created_prs, computed_at) AS agent_created_prs,
+                argMax(human_prs, computed_at) AS human_prs,
+                argMax(unknown_prs, computed_at) AS unknown_prs,
+                argMax(ai_cycle_time_delta_hours, computed_at) AS ai_cycle_time_delta_hours,
+                argMax(ai_review_amplification, computed_at) AS ai_review_amplification,
+                argMax(rework_drag_rate, computed_at) AS rework_drag_rate,
+                argMax(test_gap_rate, computed_at) AS test_gap_rate,
+                argMax(incident_drag_rate, computed_at) AS incident_drag_rate
+              FROM ai_impact_metrics_daily
+              WHERE org_id = %(org_id)s
+                {team_filter}
+                AND day >= %(start)s AND day < %(end)s
+              GROUP BY day, repo_id, team_id, work_type, attribution_bucket
+            )
+            GROUP BY attribution_bucket
+            """,
+        ),
+        OperatingReviewQuery(
+            "ai_governance",
+            f"""
+            SELECT
+              avg(declaration_coverage) AS declaration_coverage,
+              avg(human_review_coverage) AS human_review_coverage,
+              avg(security_scan_coverage) AS security_scan_coverage,
+              avg(in_policy_coverage) AS in_policy_coverage
+            FROM (
+              SELECT
+                day,
+                team_id,
+                repo_id,
+                argMax(declaration_coverage, computed_at) AS declaration_coverage,
+                argMax(human_review_coverage, computed_at) AS human_review_coverage,
+                argMax(security_scan_coverage, computed_at) AS security_scan_coverage,
+                argMax(in_policy_coverage, computed_at) AS in_policy_coverage
+              FROM ai_governance_coverage_daily
+              WHERE org_id = %(org_id)s
+                {team_filter}
+                AND day >= %(start)s AND day < %(end)s
+              GROUP BY day, team_id, repo_id
+            )
+            """,
+        ),
     ]
 
 
@@ -323,6 +391,7 @@ def compute_operating_review(
         _risk_section(current, prior),
         _reliability_section(current, prior),
         _investment_section(current, prior),
+        _ai_workflow_section(current, prior),
     ]
     return OperatingReview(
         org_id=org_id,
@@ -544,6 +613,65 @@ def _investment_section(
     )
 
 
+def _ai_workflow_section(
+    current: OperatingReviewRows, prior: OperatingReviewRows
+) -> OperatingReviewSection:
+    return _section(
+        key="ai_workflow_intelligence",
+        title="AI Workflow Intelligence",
+        metrics=[
+            _metric(
+                "ai_adoption_ratio",
+                "AI adoption mix",
+                _ai_adoption_ratio(current.ai_impact),
+                _ai_adoption_ratio(prior.ai_impact),
+                "ratio",
+                NEUTRAL,
+            ),
+            _metric(
+                "ai_cycle_time_delta_hours",
+                "AI delivery impact",
+                _avg(current.ai_impact, "ai_cycle_time_delta_hours"),
+                _avg(prior.ai_impact, "ai_cycle_time_delta_hours"),
+                "hours",
+                LOWER_IS_BETTER,
+            ),
+            _metric(
+                "ai_review_amplification",
+                "AI review pressure",
+                _avg(current.ai_impact, "ai_review_amplification"),
+                _avg(prior.ai_impact, "ai_review_amplification"),
+                "ratio",
+                LOWER_IS_BETTER,
+            ),
+            _metric(
+                "ai_risk_drag",
+                "AI risk drag",
+                _ai_risk_drag(current.ai_impact),
+                _ai_risk_drag(prior.ai_impact),
+                "ratio",
+                LOWER_IS_BETTER,
+            ),
+            _metric(
+                "ai_governance_coverage",
+                "AI governance coverage",
+                _ai_governance_coverage(current.ai_governance),
+                _ai_governance_coverage(prior.ai_governance),
+                "ratio",
+                HIGHER_IS_BETTER,
+            ),
+            _metric(
+                "ai_opportunity_signals",
+                "AI opportunity signals",
+                _ai_opportunity_signals(current.ai_impact, current.ai_governance),
+                _ai_opportunity_signals(prior.ai_impact, prior.ai_governance),
+                "signals",
+                LOWER_IS_BETTER,
+            ),
+        ],
+    )
+
+
 def _section(
     *, key: str, title: str, metrics: list[OperatingReviewMetric]
 ) -> OperatingReviewSection:
@@ -672,6 +800,55 @@ def _change_failure_rate(rows: OperatingReviewRows) -> float:
     if deployments > 0:
         return failed / deployments
     return _avg(rows.repo_metrics, "change_failure_rate")
+
+
+def _ai_adoption_ratio(rows: Iterable[Mapping[str, Any]]) -> float:
+    totals = _sum(rows, "prs_total")
+    if totals == 0:
+        return 0.0
+    ai_prs = _sum(rows, "ai_assisted_prs") + _sum(rows, "agent_created_prs")
+    return ai_prs / totals
+
+
+def _ai_risk_drag(rows: Iterable[Mapping[str, Any]]) -> float:
+    rates = [
+        _avg(rows, "rework_drag_rate"),
+        _avg(rows, "test_gap_rate"),
+        _avg(rows, "incident_drag_rate"),
+    ]
+    present = [rate for rate in rates if rate > 0]
+    if not present:
+        return 0.0
+    return sum(present) / len(present)
+
+
+def _ai_governance_coverage(rows: Iterable[Mapping[str, Any]]) -> float:
+    coverage = [
+        _avg(rows, "declaration_coverage"),
+        _avg(rows, "human_review_coverage"),
+        _avg(rows, "security_scan_coverage"),
+        _avg(rows, "in_policy_coverage"),
+    ]
+    present = [value for value in coverage if value > 0]
+    if not present:
+        return 0.0
+    return sum(present) / len(present)
+
+
+def _ai_opportunity_signals(
+    impact_rows: Iterable[Mapping[str, Any]],
+    governance_rows: Iterable[Mapping[str, Any]],
+) -> float:
+    signals = 0.0
+    if _avg(impact_rows, "ai_review_amplification") >= 1.5:
+        signals += 1.0
+    if _avg(impact_rows, "rework_drag_rate") >= 0.25:
+        signals += 1.0
+    if _avg(impact_rows, "test_gap_rate") >= 0.50:
+        signals += 1.0
+    if 0.0 < _ai_governance_coverage(governance_rows) < 0.80:
+        signals += 1.0
+    return signals
 
 
 def _first_non_zero(*values: float) -> float:

--- a/src/dev_health_ops/metrics/opportunities/ai_detector.py
+++ b/src/dev_health_ops/metrics/opportunities/ai_detector.py
@@ -5,7 +5,11 @@ import uuid
 from dataclasses import dataclass
 from typing import Any
 
-from dev_health_ops.api.graphql.models.ai import AIOpportunity, AIOpportunityKind
+from dev_health_ops.api.graphql.models.ai import (
+    AIOpportunity,
+    AIOpportunityKind,
+    AIWorkGraphDrilldownRef,
+)
 from dev_health_ops.metrics.ai_impact import AI_BUCKETS, AttributionBucket
 from dev_health_ops.metrics.loaders.base import parse_uuid
 from dev_health_ops.metrics.query_builder import OrgScopedQuery
@@ -373,7 +377,25 @@ def _opportunity(
         rationale=rationale,
         score=_clamp(score),
         evidence_refs=evidence_refs,
+        work_graph_drilldowns=_work_graph_refs(evidence_refs),
     )
+
+
+def _work_graph_refs(evidence_refs: list[str]) -> list[AIWorkGraphDrilldownRef]:
+    refs: list[AIWorkGraphDrilldownRef] = []
+    for evidence_ref in evidence_refs:
+        parts = evidence_ref.split(":")
+        if len(parts) != 3 or parts[0] != "git_pull_requests":
+            continue
+        repo_id, number = parts[1], parts[2]
+        refs.append(
+            AIWorkGraphDrilldownRef(
+                root_type="pr",
+                root_id=f"{repo_id}#{number}",
+                label=f"PR {number}",
+            )
+        )
+    return refs
 
 
 def _stable_id(kind: AIOpportunityKind, repo_id: str, team_id: str | None) -> str:

--- a/tests/api/graphql/test_ai_resolver.py
+++ b/tests/api/graphql/test_ai_resolver.py
@@ -406,6 +406,7 @@ async def test_opportunities_delegates_scope_limit_and_returns_evidence():
         rationale="AI-assisted PRs had a 33% rework rate vs 10% for human PRs.",
         score=0.8,
         evidence_refs=[f"ai_impact_metrics_daily:rework_rate:{REPO_ID}"],
+        work_graph_drilldowns=[],
     )
     detector = MagicMock()
     detector.detect = AsyncMock(return_value=[opportunity])

--- a/tests/metrics/test_ai_opportunity_detector.py
+++ b/tests/metrics/test_ai_opportunity_detector.py
@@ -133,6 +133,8 @@ async def test_detector_emits_repetitive_change(monkeypatch: pytest.MonkeyPatch)
     assert len(result) == 1
     assert result[0].kind is AIOpportunityKind.REPETITIVE_CHANGE
     assert result[0].evidence_refs[0].startswith("git_pull_requests:")
+    assert result[0].work_graph_drilldowns[0].root_type == "pr"
+    assert result[0].work_graph_drilldowns[0].root_id == f"{REPO_ID}#1"
 
 
 @pytest.mark.asyncio

--- a/tests/metrics/test_operating_review.py
+++ b/tests/metrics/test_operating_review.py
@@ -54,6 +54,37 @@ def test_operating_review_computes_sections_and_week_over_week_deltas() -> None:
                 {"investment_area": "security", "delivery_units": 2},
                 {"investment_area": "infra", "delivery_units": 3},
             ],
+            ai_impact=[
+                {
+                    "attribution_bucket": "ai_assisted",
+                    "prs_total": 10,
+                    "ai_assisted_prs": 10,
+                    "agent_created_prs": 0,
+                    "human_prs": 0,
+                    "unknown_prs": 0,
+                    "ai_cycle_time_delta_hours": -4.0,
+                    "ai_review_amplification": 1.2,
+                    "rework_drag_rate": 0.12,
+                    "test_gap_rate": 0.20,
+                    "incident_drag_rate": 0.02,
+                },
+                {
+                    "attribution_bucket": "human",
+                    "prs_total": 15,
+                    "ai_assisted_prs": 0,
+                    "agent_created_prs": 0,
+                    "human_prs": 15,
+                    "unknown_prs": 0,
+                },
+            ],
+            ai_governance=[
+                {
+                    "declaration_coverage": 0.9,
+                    "human_review_coverage": 0.8,
+                    "security_scan_coverage": 0.7,
+                    "in_policy_coverage": 0.9,
+                }
+            ],
         ),
         prior=OperatingReviewRows(
             work_items=[
@@ -87,6 +118,30 @@ def test_operating_review_computes_sections_and_week_over_week_deltas() -> None:
                 {"investment_area": "security", "delivery_units": 1},
                 {"investment_area": "infra", "delivery_units": 4},
             ],
+            ai_impact=[
+                {
+                    "attribution_bucket": "ai_assisted",
+                    "prs_total": 6,
+                    "ai_assisted_prs": 6,
+                    "agent_created_prs": 0,
+                    "human_prs": 0,
+                    "unknown_prs": 0,
+                    "ai_cycle_time_delta_hours": 2.0,
+                    "ai_review_amplification": 1.8,
+                    "rework_drag_rate": 0.30,
+                    "test_gap_rate": 0.40,
+                    "incident_drag_rate": 0.04,
+                },
+                {"attribution_bucket": "human", "prs_total": 14, "human_prs": 14},
+            ],
+            ai_governance=[
+                {
+                    "declaration_coverage": 0.7,
+                    "human_review_coverage": 0.6,
+                    "security_scan_coverage": 0.5,
+                    "in_policy_coverage": 0.7,
+                }
+            ],
         ),
     )
 
@@ -98,6 +153,7 @@ def test_operating_review_computes_sections_and_week_over_week_deltas() -> None:
         "risk",
         "reliability",
         "investment",
+        "ai_workflow_intelligence",
     ]
 
     delivery = review.section("delivery_movement")
@@ -126,6 +182,13 @@ def test_operating_review_computes_sections_and_week_over_week_deltas() -> None:
     investment = review.section("investment")
     assert investment.metric("new_value_units").value == 12
     assert investment.metric("ktlo_units").delta.status == "improved"
+
+    ai_workflow = review.section("ai_workflow_intelligence")
+    assert ai_workflow.metric("ai_adoption_ratio").value == pytest.approx(0.4)
+    assert ai_workflow.metric("ai_cycle_time_delta_hours").delta.status == "improved"
+    assert ai_workflow.metric("ai_review_amplification").delta.status == "improved"
+    assert ai_workflow.metric("ai_governance_coverage").value == pytest.approx(0.825)
+    assert ai_workflow.metric("ai_opportunity_signals").value == 0
 
     assert review.recommendations == []
     assert (
@@ -160,7 +223,7 @@ def test_build_operating_review_queries_single_team_mode() -> None:
 
     queries = {q.key: q.sql for q in build_operating_review_queries(team_id="team-a")}
 
-    for key in ("work_items", "state_durations", "investment"):
+    for key in ("work_items", "state_durations", "investment", "ai_impact", "ai_governance"):
         assert "AND team_id = %(team_id)s" in queries[key], (
             f"single-team query {key!r} must filter by team_id"
         )
@@ -182,7 +245,7 @@ def test_build_operating_review_queries_all_teams_mode() -> None:
     # work_items / state_durations / investment must NOT filter by team
     # in all-teams mode, and MUST keep team_id in inner GROUP BY so the
     # outer SUM/AVG aggregates correctly across teams.
-    for key in ("work_items", "state_durations", "investment"):
+    for key in ("work_items", "state_durations", "investment", "ai_impact", "ai_governance"):
         sql = queries[key]
         assert "AND team_id = %(team_id)s" not in sql, (
             f"all-teams query {key!r} must not filter by team_id"

--- a/tests/metrics/test_operating_review.py
+++ b/tests/metrics/test_operating_review.py
@@ -223,7 +223,13 @@ def test_build_operating_review_queries_single_team_mode() -> None:
 
     queries = {q.key: q.sql for q in build_operating_review_queries(team_id="team-a")}
 
-    for key in ("work_items", "state_durations", "investment", "ai_impact", "ai_governance"):
+    for key in (
+        "work_items",
+        "state_durations",
+        "investment",
+        "ai_impact",
+        "ai_governance",
+    ):
         assert "AND team_id = %(team_id)s" in queries[key], (
             f"single-team query {key!r} must filter by team_id"
         )
@@ -245,7 +251,13 @@ def test_build_operating_review_queries_all_teams_mode() -> None:
     # work_items / state_durations / investment must NOT filter by team
     # in all-teams mode, and MUST keep team_id in inner GROUP BY so the
     # outer SUM/AVG aggregates correctly across teams.
-    for key in ("work_items", "state_durations", "investment", "ai_impact", "ai_governance"):
+    for key in (
+        "work_items",
+        "state_durations",
+        "investment",
+        "ai_impact",
+        "ai_governance",
+    ):
         sql = queries[key]
         assert "AND team_id = %(team_id)s" not in sql, (
             f"all-teams query {key!r} must not filter by team_id"


### PR DESCRIPTION
## Summary
- add AI Workflow Intelligence section to Engineering Operating Review
- expose Work Graph drilldown refs for AI opportunities backed by PR evidence
- document weekly review AI metrics and evidence handoff

## Verification
- pytest tests/metrics/test_operating_review.py tests/metrics/test_ai_opportunity_detector.py tests/api/graphql/test_ai_resolver.py
- python -m dev_health_ops.api.graphql.export_schema --out /var/folders/fc/1xbvf93j4t31_5mslw1x6gq40000gn/T/opencode/chaos-1722-schema.graphql
- PYTHONPATH=src operating-review/opportunity QA script

Closes CHAOS-1722
SCREENSHOT-WAIVER: Backend GraphQL/docs contract only; no rendered frontend changes in this branch.