### PR TITLE
feat(ops): complexityTimeseries + hotspots GraphQL resolvers (CHAOS-1756)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/complexity.py
+++ b/src/dev_health_ops/api/graphql/resolvers/complexity.py
@@ -1,0 +1,405 @@
+"""Complexity GraphQL resolvers (CHAOS-1756).
+
+Reads from three append-only ClickHouse tables:
+- ``repo_complexity_daily``      — repo-scope timeseries
+- ``file_complexity_snapshots``  — file-scope timeseries
+- ``file_hotspot_daily``         — hotspot ranking
+
+All reads use ``argMax(<col>, computed_at)`` to surface the latest compute
+pass per ``(org_id, day, scope_key)``.  The resolvers are read-only and never
+recompute any metric — they surface persisted data as-is per the inspectability
+contract.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date as PyDate
+from datetime import timedelta
+from typing import Any
+from urllib.parse import quote
+
+from dev_health_ops.api.queries.client import query_dicts
+
+from ..authz import require_org_id
+from ..context import GraphQLContext
+from ..types.complexity import (
+    ComplexityPoint,
+    ComplexityScope,
+    ComplexityTimeseriesInput,
+    ComplexityTimeseriesResult,
+    HotspotRow,
+    HotspotsInput,
+    HotspotsResult,
+    TimeGranularity,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Hard cap on timeseries rows; protects against pathological scopes.
+MAX_ROWS: int = 1000
+#: Default row limit for timeseries queries.
+DEFAULT_TIMESERIES_LIMIT: int = 500
+#: Default row limit for hotspot queries.
+DEFAULT_HOTSPOTS_LIMIT: int = 50
+#: Hard cap for hotspot rows.
+MAX_HOTSPOTS_ROWS: int = 500
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_client(context: GraphQLContext) -> Any:
+    if context.client is None:
+        raise RuntimeError(
+            "Database client not available for Complexity resolver"
+        )
+    return context.client
+
+
+def _nint(row: dict[str, Any], key: str) -> int | None:
+    """Return ``int(row[key])`` or ``None`` when the value is absent/null."""
+    v = row.get(key)
+    return int(v) if v is not None else None
+
+
+def _nfloat(row: dict[str, Any], key: str) -> float | None:
+    """Return ``float(row[key])`` or ``None`` when the value is absent/null."""
+    v = row.get(key)
+    return float(v) if v is not None else None
+
+
+def _truncate_to_week(day_val: Any) -> Any:
+    """Truncate a ``date`` to the start of its ISO week (Monday).
+
+    Returns the input unchanged when it is not a ``datetime.date``.
+    """
+    if isinstance(day_val, PyDate):
+        return day_val - timedelta(days=day_val.weekday())
+    return day_val
+
+
+async def _load_repo_labels(
+    client: Any, org_id: str, repo_ids: list[str]
+) -> dict[str, str]:
+    """Return ``{repo_id: repo_full_name}`` for the given repo IDs.
+
+    Falls back to the repo_id string when the catalog row is missing so the
+    resolver always returns a non-empty ``scopeName``.
+    """
+    if not repo_ids:
+        return {}
+    rows = await query_dicts(
+        client,
+        """
+        SELECT toString(id) AS repo_id, repo AS full_name
+        FROM repos
+        WHERE org_id = {org_id:String}
+          AND toString(id) IN {repo_ids:Array(String)}
+        """,
+        {"org_id": org_id, "repo_ids": repo_ids},
+    )
+    return {row["repo_id"]: row.get("full_name") or row["repo_id"] for row in rows}
+
+
+# ---------------------------------------------------------------------------
+# ClickHouse fetch helpers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_repo_timeseries(
+    client: Any,
+    *,
+    org_id: str,
+    since_day: str,
+    until_day: str,
+    repo_ids: list[str] | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Latest-compute read from ``repo_complexity_daily`` for the date window.
+
+    ``argMax`` over ``computed_at`` returns the most-recent ingestion for each
+    ``(repo_id, day)`` pair, consistent with the append-only sink contract.
+    """
+    query = """
+        SELECT
+            day,
+            toString(repo_id) AS repo_id,
+            argMax(loc_total,                      computed_at) AS loc_total,
+            argMax(cyclomatic_total,               computed_at) AS cyclomatic_total,
+            argMax(cyclomatic_per_kloc,            computed_at) AS cyclomatic_per_kloc,
+            argMax(high_complexity_functions,      computed_at) AS high_complexity_functions,
+            argMax(very_high_complexity_functions, computed_at) AS very_high_complexity_functions
+        FROM repo_complexity_daily
+        WHERE org_id = {org_id:String}
+          AND day >= {since_day:Date}
+          AND day <= {until_day:Date}
+    """
+    params: dict[str, Any] = {
+        "org_id": org_id,
+        "since_day": since_day,
+        "until_day": until_day,
+    }
+    if repo_ids:
+        bounded = list(repo_ids)[:MAX_ROWS]
+        query += "\n  AND toString(repo_id) IN {repo_ids:Array(String)}"
+        params["repo_ids"] = bounded
+    query += f"\nGROUP BY day, repo_id\nORDER BY day, repo_id\nLIMIT {limit}"
+    return await query_dicts(client, query, params)
+
+
+async def _fetch_file_timeseries(
+    client: Any,
+    *,
+    org_id: str,
+    since_day: str,
+    until_day: str,
+    repo_ids: list[str] | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Latest-compute read from ``file_complexity_snapshots`` for the date window.
+
+    The table uses ``as_of_day`` (not ``day``) as the snapshot column.
+    """
+    query = """
+        SELECT
+            as_of_day AS day,
+            toString(repo_id) AS repo_id,
+            file_path,
+            argMax(cyclomatic_total,               computed_at) AS cyclomatic_total,
+            argMax(cyclomatic_avg,                 computed_at) AS cyclomatic_avg,
+            argMax(high_complexity_functions,      computed_at) AS high_complexity_functions,
+            argMax(very_high_complexity_functions, computed_at) AS very_high_complexity_functions
+        FROM file_complexity_snapshots
+        WHERE org_id = {org_id:String}
+          AND as_of_day >= {since_day:Date}
+          AND as_of_day <= {until_day:Date}
+    """
+    params: dict[str, Any] = {
+        "org_id": org_id,
+        "since_day": since_day,
+        "until_day": until_day,
+    }
+    if repo_ids:
+        bounded = list(repo_ids)[:MAX_ROWS]
+        query += "\n  AND toString(repo_id) IN {repo_ids:Array(String)}"
+        params["repo_ids"] = bounded
+    query += (
+        f"\nGROUP BY as_of_day, repo_id, file_path"
+        f"\nORDER BY as_of_day, repo_id\nLIMIT {limit}"
+    )
+    return await query_dicts(client, query, params)
+
+
+async def _fetch_hotspot_rows(
+    client: Any,
+    *,
+    org_id: str,
+    since_day: str,
+    until_day: str,
+    repo_ids: list[str] | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Latest-compute read from ``file_hotspot_daily``, ranked by risk_score DESC."""
+    query = """
+        SELECT
+            toString(repo_id) AS repo_id,
+            file_path,
+            argMax(churn_loc_30d,       computed_at) AS churn_loc_30d,
+            argMax(churn_commits_30d,   computed_at) AS churn_commits_30d,
+            argMax(cyclomatic_total,    computed_at) AS cyclomatic_total,
+            argMax(cyclomatic_avg,      computed_at) AS cyclomatic_avg,
+            argMax(blame_concentration, computed_at) AS blame_concentration,
+            argMax(risk_score,          computed_at) AS risk_score
+        FROM file_hotspot_daily
+        WHERE org_id = {org_id:String}
+          AND day >= {since_day:Date}
+          AND day <= {until_day:Date}
+    """
+    params: dict[str, Any] = {
+        "org_id": org_id,
+        "since_day": since_day,
+        "until_day": until_day,
+    }
+    if repo_ids:
+        bounded = list(repo_ids)[:MAX_ROWS]
+        query += "\n  AND toString(repo_id) IN {repo_ids:Array(String)}"
+        params["repo_ids"] = bounded
+    query += (
+        f"\nGROUP BY repo_id, file_path"
+        f"\nORDER BY risk_score DESC NULLS LAST\nLIMIT {limit}"
+    )
+    return await query_dicts(client, query, params)
+
+
+# ---------------------------------------------------------------------------
+# Public resolver functions (called from schema.py)
+# ---------------------------------------------------------------------------
+
+
+async def resolve_complexity_timeseries(
+    context: GraphQLContext,
+    input: ComplexityTimeseriesInput,  # noqa: A002
+) -> ComplexityTimeseriesResult:
+    """Serve complexity timeseries from ClickHouse (read-only, append-only reads).
+
+    Org-gate is enforced via ``require_org_id``; any mismatch between the
+    JWT org and the GraphQL ``orgId`` argument is logged and the JWT org wins.
+    """
+    authorized_org_id = require_org_id(context)
+    if input.org_id != authorized_org_id:
+        logger.debug(
+            "Ignoring GraphQL orgId %r in favor of authorized org %r",
+            input.org_id,
+            authorized_org_id,
+        )
+
+    client = _require_client(context)
+
+    raw_limit = input.limit if input.limit is not None else DEFAULT_TIMESERIES_LIMIT
+    effective_limit = max(1, min(raw_limit, MAX_ROWS))
+
+    since_day = input.since_utc.date().isoformat()
+    until_day = input.until_utc.date().isoformat()
+
+    points: list[ComplexityPoint] = []
+
+    if input.scope == ComplexityScope.REPO:
+        rows = await _fetch_repo_timeseries(
+            client,
+            org_id=authorized_org_id,
+            since_day=since_day,
+            until_day=until_day,
+            repo_ids=input.repo_ids,
+            limit=effective_limit,
+        )
+        repo_ids_seen = list({str(r["repo_id"]) for r in rows})
+        labels = await _load_repo_labels(client, authorized_org_id, repo_ids_seen)
+
+        for row in rows:
+            day_val = row["day"]
+            if input.granularity == TimeGranularity.WEEK:
+                day_val = _truncate_to_week(day_val)
+
+            repo_id = str(row["repo_id"])
+            points.append(
+                ComplexityPoint(
+                    point_date=day_val,
+                    scope_id=repo_id,
+                    scope_name=labels.get(repo_id, repo_id),
+                    loc_total=_nint(row, "loc_total"),
+                    cyclomatic_per_kloc=_nfloat(row, "cyclomatic_per_kloc"),
+                    cyclomatic_total=_nint(row, "cyclomatic_total"),
+                    cyclomatic_avg=None,  # not stored per repo row in v1 table
+                    high_complexity_functions=_nint(row, "high_complexity_functions"),
+                    very_high_complexity_functions=_nint(
+                        row, "very_high_complexity_functions"
+                    ),
+                )
+            )
+
+    else:  # FILE scope — reads from file_complexity_snapshots
+        rows = await _fetch_file_timeseries(
+            client,
+            org_id=authorized_org_id,
+            since_day=since_day,
+            until_day=until_day,
+            repo_ids=input.repo_ids,
+            limit=effective_limit,
+        )
+        repo_ids_seen = list({str(r["repo_id"]) for r in rows})
+        labels = await _load_repo_labels(client, authorized_org_id, repo_ids_seen)
+
+        for row in rows:
+            day_val = row["day"]
+            if input.granularity == TimeGranularity.WEEK:
+                day_val = _truncate_to_week(day_val)
+
+            repo_id = str(row["repo_id"])
+            file_path = str(row.get("file_path") or "")
+            # Composite scopeId encodes both repo and file path for uniqueness.
+            scope_id = f"{repo_id}/{file_path}"
+            points.append(
+                ComplexityPoint(
+                    point_date=day_val,
+                    scope_id=scope_id,
+                    scope_name=file_path or scope_id,
+                    loc_total=None,         # not stored per-file in v1 schema
+                    cyclomatic_per_kloc=None,  # not stored per-file in v1 schema
+                    cyclomatic_total=_nint(row, "cyclomatic_total"),
+                    cyclomatic_avg=_nfloat(row, "cyclomatic_avg"),
+                    high_complexity_functions=_nint(row, "high_complexity_functions"),
+                    very_high_complexity_functions=_nint(
+                        row, "very_high_complexity_functions"
+                    ),
+                )
+            )
+
+    total_scope = len({p.scope_id for p in points})
+    return ComplexityTimeseriesResult(points=points, total_scope=total_scope)
+
+
+async def resolve_hotspots(
+    context: GraphQLContext,
+    input: HotspotsInput,  # noqa: A002
+) -> HotspotsResult:
+    """Serve hotspot rows from ClickHouse (read-only, append-only reads).
+
+    Rows are ordered by ``risk_score DESC NULLS LAST`` at the database level.
+    ``evidenceUrl`` is a deterministic deeplink built from ``file_path`` —
+    no external service is queried.
+    """
+    authorized_org_id = require_org_id(context)
+    if input.org_id != authorized_org_id:
+        logger.debug(
+            "Ignoring GraphQL orgId %r in favor of authorized org %r",
+            input.org_id,
+            authorized_org_id,
+        )
+
+    client = _require_client(context)
+
+    raw_limit = input.limit if input.limit is not None else DEFAULT_HOTSPOTS_LIMIT
+    effective_limit = max(1, min(raw_limit, MAX_HOTSPOTS_ROWS))
+
+    since_day = input.since_utc.date().isoformat()
+    until_day = input.until_utc.date().isoformat()
+
+    raw_rows = await _fetch_hotspot_rows(
+        client,
+        org_id=authorized_org_id,
+        since_day=since_day,
+        until_day=until_day,
+        repo_ids=input.repo_ids,
+        limit=effective_limit,
+    )
+
+    repo_ids_seen = list({str(r["repo_id"]) for r in raw_rows})
+    labels = await _load_repo_labels(client, authorized_org_id, repo_ids_seen)
+
+    rows: list[HotspotRow] = []
+    for row in raw_rows:
+        repo_id = str(row["repo_id"])
+        file_path = str(row.get("file_path") or "")
+        blame = row.get("blame_concentration")
+        risk = row.get("risk_score")
+
+        rows.append(
+            HotspotRow(
+                file_path=file_path,
+                repo_id=repo_id,
+                repo_name=labels.get(repo_id, repo_id),
+                churn_loc_30d=int(row.get("churn_loc_30d") or 0),
+                churn_commits_30d=int(row.get("churn_commits_30d") or 0),
+                cyclomatic_total=int(row.get("cyclomatic_total") or 0),
+                cyclomatic_avg=float(row.get("cyclomatic_avg") or 0.0),
+                blame_concentration=float(blame) if blame is not None else None,
+                risk_score=float(risk) if risk is not None else 0.0,
+                # Deterministic deeplink — never calls an external service.
+                evidence_url=f"/code?file={quote(file_path)}" if file_path else None,
+            )
+        )
+
+    return HotspotsResult(rows=rows)

--- a/src/dev_health_ops/api/graphql/resolvers/complexity.py
+++ b/src/dev_health_ops/api/graphql/resolvers/complexity.py
@@ -53,9 +53,7 @@ MAX_HOTSPOTS_ROWS: int = 500
 
 def _require_client(context: GraphQLContext) -> Any:
     if context.client is None:
-        raise RuntimeError(
-            "Database client not available for Complexity resolver"
-        )
+        raise RuntimeError("Database client not available for Complexity resolver")
     return context.client
 
 
@@ -326,7 +324,7 @@ async def resolve_complexity_timeseries(
                     point_date=day_val,
                     scope_id=scope_id,
                     scope_name=file_path or scope_id,
-                    loc_total=None,         # not stored per-file in v1 schema
+                    loc_total=None,  # not stored per-file in v1 schema
                     cyclomatic_per_kloc=None,  # not stored per-file in v1 schema
                     cyclomatic_total=_nint(row, "cyclomatic_total"),
                     cyclomatic_avg=_nfloat(row, "cyclomatic_avg"),

--- a/src/dev_health_ops/api/graphql/resolvers/complexity.py
+++ b/src/dev_health_ops/api/graphql/resolvers/complexity.py
@@ -239,7 +239,7 @@ async def _fetch_hotspot_rows(
 
 async def resolve_complexity_timeseries(
     context: GraphQLContext,
-    input: ComplexityTimeseriesInput,  # noqa: A002
+    input: ComplexityTimeseriesInput,
 ) -> ComplexityTimeseriesResult:
     """Serve complexity timeseries from ClickHouse (read-only, append-only reads).
 
@@ -307,9 +307,7 @@ async def resolve_complexity_timeseries(
             repo_ids=input.repo_ids,
             limit=effective_limit,
         )
-        repo_ids_seen = list({str(r["repo_id"]) for r in rows})
-        labels = await _load_repo_labels(client, authorized_org_id, repo_ids_seen)
-
+        # FILE-scope scopeName is derived from file_path — no repo-label join needed.
         for row in rows:
             day_val = row["day"]
             if input.granularity == TimeGranularity.WEEK:
@@ -341,7 +339,7 @@ async def resolve_complexity_timeseries(
 
 async def resolve_hotspots(
     context: GraphQLContext,
-    input: HotspotsInput,  # noqa: A002
+    input: HotspotsInput,
 ) -> HotspotsResult:
     """Serve hotspot rows from ClickHouse (read-only, append-only reads).
 

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -64,6 +64,7 @@ from .resolvers.ai import (
 from .resolvers.analytics import resolve_analytics
 from .resolvers.bus_factor import resolve_bus_factor
 from .resolvers.catalog import resolve_catalog
+from .resolvers.complexity import resolve_complexity_timeseries, resolve_hotspots
 from .resolvers.compounding_risk import resolve_compounding_risk
 from .resolvers.data_health import resolve_data_health
 from .resolvers.reports import (
@@ -85,6 +86,12 @@ from .resolvers.reports import (
 )
 from .subscriptions import Subscription
 from .types.bus_factor import BusFactor, BusFactorScopeInput
+from .types.complexity import (
+    ComplexityTimeseriesInput,
+    ComplexityTimeseriesResult,
+    HotspotsInput,
+    HotspotsResult,
+)
 from .types.compounding_risk import (
     CompoundingRiskFilterInput,
     CompoundingRiskResult,
@@ -340,6 +347,36 @@ class Query:
     ) -> CompoundingRiskResult:
         context = get_context(info)
         return await resolve_compounding_risk(context, org_id, filter)
+
+    @strawberry.field(
+        description=(
+            "Cyclomatic complexity trend by repo or file. Reads from "
+            "append-only ``repo_complexity_daily`` / ``file_complexity_snapshots`` "
+            "tables — no recomputation, pure surface of persisted data."
+        )
+    )
+    async def complexity_timeseries(
+        self,
+        info: Info,
+        input: ComplexityTimeseriesInput,  # noqa: A002
+    ) -> ComplexityTimeseriesResult:
+        context = get_context(info)
+        return await resolve_complexity_timeseries(context, input)
+
+    @strawberry.field(
+        description=(
+            "Top file hotspots ranked by risk_score (churn x complexity x "
+            "ownership concentration). Reads from the append-only "
+            "``file_hotspot_daily`` table."
+        )
+    )
+    async def hotspots(
+        self,
+        info: Info,
+        input: HotspotsInput,  # noqa: A002
+    ) -> HotspotsResult:
+        context = get_context(info)
+        return await resolve_hotspots(context, input)
 
     @strawberry.field(
         description="Latest rule-based recommendations for a team within a lookback window."

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -358,7 +358,7 @@ class Query:
     async def complexity_timeseries(
         self,
         info: Info,
-        input: ComplexityTimeseriesInput,  # noqa: A002
+        input: ComplexityTimeseriesInput,
     ) -> ComplexityTimeseriesResult:
         context = get_context(info)
         return await resolve_complexity_timeseries(context, input)
@@ -373,7 +373,7 @@ class Query:
     async def hotspots(
         self,
         info: Info,
-        input: HotspotsInput,  # noqa: A002
+        input: HotspotsInput,
     ) -> HotspotsResult:
         context = get_context(info)
         return await resolve_hotspots(context, input)

--- a/src/dev_health_ops/api/graphql/types/complexity.py
+++ b/src/dev_health_ops/api/graphql/types/complexity.py
@@ -1,0 +1,139 @@
+"""GraphQL types for the Complexity surface (CHAOS-1756).
+
+Exposes two read-only queries backed by the existing ClickHouse tables:
+- ``repo_complexity_daily``
+- ``file_complexity_snapshots``
+- ``file_hotspot_daily``
+
+No new tables or ETL are introduced; this is a pure schema addition.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import Enum
+
+import strawberry
+
+
+@strawberry.enum
+class ComplexityScope(Enum):
+    """Scope for complexity timeseries queries.
+
+    ``REPO`` returns one point per repo per day/week.
+    ``FILE`` returns one point per file per snapshot day.
+    """
+
+    REPO = "repo"
+    FILE = "file"
+
+
+@strawberry.enum
+class TimeGranularity(Enum):
+    """Time bucketing granularity for timeseries queries."""
+
+    DAY = "day"
+    WEEK = "week"
+
+
+@strawberry.input
+class ComplexityTimeseriesInput:
+    """Input for the ``complexityTimeseries`` query."""
+
+    org_id: str = strawberry.field(name="orgId")
+    since_utc: datetime = strawberry.field(name="sinceUtc")
+    until_utc: datetime = strawberry.field(name="untilUtc")
+    granularity: TimeGranularity
+    scope: ComplexityScope
+    repo_ids: list[str] | None = strawberry.field(default=None, name="repoIds")
+    team_ids: list[str] | None = strawberry.field(default=None, name="teamIds")
+    #: Row cap; default 500, hard max 1000.
+    limit: int | None = None
+
+
+@strawberry.type
+class ComplexityPoint:
+    """One data point in a complexity timeseries.
+
+    For ``scope=REPO``: ``scopeId`` is the repo UUID, ``scopeName`` is the
+    repo full name.  ``locTotal`` and ``cyclomaticPerKloc`` are populated.
+
+    For ``scope=FILE``: ``scopeId`` is ``<repoId>/<filePath>``,
+    ``scopeName`` is the file path.  ``locTotal`` / ``cyclomaticPerKloc``
+    are ``null`` (not stored per-file in v1 tables).
+    """
+
+    # Using the Python attribute name ``point_date`` to avoid shadowing the
+    # imported ``date`` type; the GraphQL field is aliased to "date".
+    point_date: date = strawberry.field(name="date")
+    scope_id: str = strawberry.field(name="scopeId")
+    scope_name: str = strawberry.field(name="scopeName")
+
+    # Repo-scope only (null for file scope)
+    loc_total: int | None = strawberry.field(default=None, name="locTotal")
+    cyclomatic_per_kloc: float | None = strawberry.field(
+        default=None, name="cyclomaticPerKloc"
+    )
+
+    # Both scopes
+    cyclomatic_total: int | None = strawberry.field(
+        default=None, name="cyclomaticTotal"
+    )
+    cyclomatic_avg: float | None = strawberry.field(
+        default=None, name="cyclomaticAvg"
+    )
+    high_complexity_functions: int | None = strawberry.field(
+        default=None, name="highComplexityFunctions"
+    )
+    very_high_complexity_functions: int | None = strawberry.field(
+        default=None, name="veryHighComplexityFunctions"
+    )
+
+
+@strawberry.type
+class ComplexityTimeseriesResult:
+    """Response for ``complexityTimeseries``."""
+
+    points: list[ComplexityPoint]
+    #: Number of distinct scope IDs (repos or files) present in ``points``.
+    total_scope: int = strawberry.field(name="totalScope")
+
+
+@strawberry.input
+class HotspotsInput:
+    """Input for the ``hotspots`` query."""
+
+    org_id: str = strawberry.field(name="orgId")
+    since_utc: datetime = strawberry.field(name="sinceUtc")
+    until_utc: datetime = strawberry.field(name="untilUtc")
+    repo_ids: list[str] | None = strawberry.field(default=None, name="repoIds")
+    team_ids: list[str] | None = strawberry.field(default=None, name="teamIds")
+    #: Row cap; default 50, hard max 500.
+    limit: int | None = None
+
+
+@strawberry.type
+class HotspotRow:
+    """One file hotspot row from ``file_hotspot_daily``."""
+
+    file_path: str = strawberry.field(name="filePath")
+    repo_id: str = strawberry.field(name="repoId")
+    repo_name: str = strawberry.field(name="repoName")
+    churn_loc_30d: int = strawberry.field(name="churnLoc30d")
+    churn_commits_30d: int = strawberry.field(name="churnCommits30d")
+    cyclomatic_total: int = strawberry.field(name="cyclomaticTotal")
+    cyclomatic_avg: float = strawberry.field(name="cyclomaticAvg")
+    blame_concentration: float | None = strawberry.field(
+        default=None, name="blameConcentration"
+    )
+    #: Hotspot score from ``file_hotspot_daily.risk_score``.
+    risk_score: float = strawberry.field(name="riskScore")
+    #: Deterministic deeplink; built client-side from ``file_path``.
+    evidence_url: str | None = strawberry.field(default=None, name="evidenceUrl")
+
+
+@strawberry.type
+class HotspotsResult:
+    """Response for ``hotspots``."""
+
+    rows: list[HotspotRow]

--- a/src/dev_health_ops/api/graphql/types/complexity.py
+++ b/src/dev_health_ops/api/graphql/types/complexity.py
@@ -79,9 +79,7 @@ class ComplexityPoint:
     cyclomatic_total: int | None = strawberry.field(
         default=None, name="cyclomaticTotal"
     )
-    cyclomatic_avg: float | None = strawberry.field(
-        default=None, name="cyclomaticAvg"
-    )
+    cyclomatic_avg: float | None = strawberry.field(default=None, name="cyclomaticAvg")
     high_complexity_functions: int | None = strawberry.field(
         default=None, name="highComplexityFunctions"
     )

--- a/tests/api/graphql/test_complexity_resolver.py
+++ b/tests/api/graphql/test_complexity_resolver.py
@@ -1,0 +1,587 @@
+"""Resolver tests for Complexity timeseries + hotspots (CHAOS-1756).
+
+These tests exercise the resolvers against a mocked ClickHouse client and
+verify:
+
+* empty state returns ``ComplexityTimeseriesResult(points=[], totalScope=0)``
+  and ``HotspotsResult(rows=[])``,
+* repo-scope timeseries maps all column names correctly,
+* file-scope timeseries uses ``as_of_day`` / ``file_path`` correctly,
+* hotspot rows map ``risk_score``, ``evidenceUrl``, and nullable
+  ``blameConcentration`` correctly,
+* the org-id gate raises ``AuthorizationError`` on mismatch,
+* the row limit is clamped to ``MAX_ROWS`` / ``MAX_HOTSPOTS_ROWS``.
+
+All tests are read-only — no ClickHouse tables are modified.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.resolvers.complexity import (
+    MAX_HOTSPOTS_ROWS,
+    MAX_ROWS,
+    resolve_complexity_timeseries,
+    resolve_hotspots,
+)
+from dev_health_ops.api.graphql.types.complexity import (
+    ComplexityScope,
+    ComplexityTimeseriesInput,
+    HotspotsInput,
+    TimeGranularity,
+)
+
+ORG_ID = "org-complexity-test"
+NOW = datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc)
+DAY = date(2026, 5, 20)
+SINCE = datetime(2026, 5, 1, 0, 0, 0, tzinfo=timezone.utc)
+UNTIL = datetime(2026, 5, 20, 23, 59, 59, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Test infrastructure (mirrors test_compounding_risk_resolver.py)
+# ---------------------------------------------------------------------------
+
+
+def _ctx() -> GraphQLContext:
+    ctx = GraphQLContext(org_id=ORG_ID, db_url="clickhouse://localhost:8123/d")
+    ctx.client = MagicMock(spec=["query"])
+    return ctx
+
+
+def _qresult(columns: list[str], rows: list[list[Any]]) -> Any:
+    """Build a fake clickhouse_connect QueryResult-like object."""
+    result = MagicMock()
+    result.column_names = columns
+    result.result_rows = rows
+    return result
+
+
+def _setup_client(client: Any, responses: list[Any]) -> None:
+    """Make ``client.query`` return ``responses[i]`` on call ``i``."""
+    client.query.side_effect = responses
+
+
+def _timeseries_input(
+    *,
+    scope: ComplexityScope = ComplexityScope.REPO,
+    granularity: TimeGranularity = TimeGranularity.DAY,
+    repo_ids: list[str] | None = None,
+    limit: int | None = None,
+) -> ComplexityTimeseriesInput:
+    return ComplexityTimeseriesInput(
+        org_id=ORG_ID,
+        since_utc=SINCE,
+        until_utc=UNTIL,
+        granularity=granularity,
+        scope=scope,
+        repo_ids=repo_ids,
+        limit=limit,
+    )
+
+
+def _hotspots_input(
+    *,
+    repo_ids: list[str] | None = None,
+    limit: int | None = None,
+) -> HotspotsInput:
+    return HotspotsInput(
+        org_id=ORG_ID,
+        since_utc=SINCE,
+        until_utc=UNTIL,
+        repo_ids=repo_ids,
+        limit=limit,
+    )
+
+
+# ---------------------------------------------------------------------------
+# complexityTimeseries — empty state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeseries_empty_state_repo_scope() -> None:
+    ctx = _ctx()
+    _setup_client(
+        ctx.client,
+        [
+            _qresult([], []),  # repo_complexity_daily → no rows
+            _qresult([], []),  # repo labels lookup
+        ],
+    )
+
+    result = await resolve_complexity_timeseries(ctx, _timeseries_input())
+
+    assert result.points == []
+    assert result.total_scope == 0
+
+
+@pytest.mark.asyncio
+async def test_timeseries_empty_state_file_scope() -> None:
+    ctx = _ctx()
+    _setup_client(
+        ctx.client,
+        [
+            _qresult([], []),  # file_complexity_snapshots → no rows
+            _qresult([], []),  # repo labels lookup
+        ],
+    )
+
+    result = await resolve_complexity_timeseries(
+        ctx, _timeseries_input(scope=ComplexityScope.FILE)
+    )
+
+    assert result.points == []
+    assert result.total_scope == 0
+
+
+# ---------------------------------------------------------------------------
+# complexityTimeseries — repo scope happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeseries_repo_scope_maps_columns_correctly() -> None:
+    ctx = _ctx()
+    columns = [
+        "day",
+        "repo_id",
+        "loc_total",
+        "cyclomatic_total",
+        "cyclomatic_per_kloc",
+        "high_complexity_functions",
+        "very_high_complexity_functions",
+    ]
+    row = [DAY, "repo-abc", 50000, 3200, 64.0, 42, 7]
+
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(columns, [row]),
+            _qresult(["repo_id", "full_name"], [["repo-abc", "acme/backend"]]),
+        ],
+    )
+
+    result = await resolve_complexity_timeseries(ctx, _timeseries_input())
+
+    assert len(result.points) == 1
+    pt = result.points[0]
+    assert pt.point_date == DAY
+    assert pt.scope_id == "repo-abc"
+    assert pt.scope_name == "acme/backend"
+    assert pt.loc_total == 50000
+    assert pt.cyclomatic_per_kloc == pytest.approx(64.0)
+    assert pt.cyclomatic_total == 3200
+    assert pt.cyclomatic_avg is None  # not stored per repo row
+    assert pt.high_complexity_functions == 42
+    assert pt.very_high_complexity_functions == 7
+    assert result.total_scope == 1
+
+
+@pytest.mark.asyncio
+async def test_timeseries_repo_scope_fallback_scope_name_when_label_missing() -> None:
+    ctx = _ctx()
+    columns = [
+        "day",
+        "repo_id",
+        "loc_total",
+        "cyclomatic_total",
+        "cyclomatic_per_kloc",
+        "high_complexity_functions",
+        "very_high_complexity_functions",
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(columns, [[DAY, "repo-xyz", 1000, 80, 80.0, 5, 0]]),
+            _qresult([], []),  # label lookup returns nothing
+        ],
+    )
+
+    result = await resolve_complexity_timeseries(ctx, _timeseries_input())
+
+    # Falls back to repo_id when full_name is not in catalog.
+    assert result.points[0].scope_name == "repo-xyz"
+
+
+@pytest.mark.asyncio
+async def test_timeseries_null_columns_propagate_as_none() -> None:
+    ctx = _ctx()
+    columns = [
+        "day",
+        "repo_id",
+        "loc_total",
+        "cyclomatic_total",
+        "cyclomatic_per_kloc",
+        "high_complexity_functions",
+        "very_high_complexity_functions",
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(columns, [[DAY, "repo-1", None, None, None, None, None]]),
+            _qresult([], []),
+        ],
+    )
+
+    result = await resolve_complexity_timeseries(ctx, _timeseries_input())
+
+    pt = result.points[0]
+    assert pt.loc_total is None
+    assert pt.cyclomatic_total is None
+    assert pt.cyclomatic_per_kloc is None
+    assert pt.high_complexity_functions is None
+    assert pt.very_high_complexity_functions is None
+
+
+@pytest.mark.asyncio
+async def test_timeseries_total_scope_counts_distinct_scope_ids() -> None:
+    ctx = _ctx()
+    columns = [
+        "day",
+        "repo_id",
+        "loc_total",
+        "cyclomatic_total",
+        "cyclomatic_per_kloc",
+        "high_complexity_functions",
+        "very_high_complexity_functions",
+    ]
+    rows = [
+        [DAY, "repo-1", 1000, 80, 80.0, 5, 0],
+        [date(2026, 5, 19), "repo-1", 1000, 79, 79.0, 5, 0],  # same repo, different day
+        [DAY, "repo-2", 2000, 160, 80.0, 10, 1],
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(columns, rows),
+            _qresult([], []),
+        ],
+    )
+
+    result = await resolve_complexity_timeseries(ctx, _timeseries_input())
+
+    assert len(result.points) == 3
+    # Two distinct repos → totalScope == 2
+    assert result.total_scope == 2
+
+
+# ---------------------------------------------------------------------------
+# complexityTimeseries — file scope happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeseries_file_scope_maps_columns_correctly() -> None:
+    ctx = _ctx()
+    columns = [
+        "day",
+        "repo_id",
+        "file_path",
+        "cyclomatic_total",
+        "cyclomatic_avg",
+        "high_complexity_functions",
+        "very_high_complexity_functions",
+    ]
+    row = [DAY, "repo-1", "src/auth/login.py", 120, 6.5, 3, 0]
+
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(columns, [row]),
+            _qresult(["repo_id", "full_name"], [["repo-1", "acme/backend"]]),
+        ],
+    )
+
+    result = await resolve_complexity_timeseries(
+        ctx, _timeseries_input(scope=ComplexityScope.FILE)
+    )
+
+    assert len(result.points) == 1
+    pt = result.points[0]
+    assert pt.point_date == DAY
+    assert pt.scope_id == "repo-1/src/auth/login.py"
+    assert pt.scope_name == "src/auth/login.py"
+    assert pt.loc_total is None       # not in file_complexity_snapshots
+    assert pt.cyclomatic_per_kloc is None  # not in file_complexity_snapshots
+    assert pt.cyclomatic_total == 120
+    assert pt.cyclomatic_avg == pytest.approx(6.5)
+    assert pt.high_complexity_functions == 3
+    assert pt.very_high_complexity_functions == 0
+
+
+# ---------------------------------------------------------------------------
+# complexityTimeseries — WEEK granularity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeseries_week_granularity_truncates_to_monday() -> None:
+    ctx = _ctx()
+    columns = [
+        "day",
+        "repo_id",
+        "loc_total",
+        "cyclomatic_total",
+        "cyclomatic_per_kloc",
+        "high_complexity_functions",
+        "very_high_complexity_functions",
+    ]
+    # 2026-05-20 is a Wednesday; expect truncation to Monday 2026-05-18.
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(columns, [[DAY, "repo-1", 1000, 80, 80.0, 5, 0]]),
+            _qresult([], []),
+        ],
+    )
+
+    result = await resolve_complexity_timeseries(
+        ctx, _timeseries_input(granularity=TimeGranularity.WEEK)
+    )
+
+    assert result.points[0].point_date == date(2026, 5, 18)
+
+
+# ---------------------------------------------------------------------------
+# complexityTimeseries — row limit clamping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeseries_limit_is_clamped_to_max_rows() -> None:
+    ctx = _ctx()
+    _setup_client(ctx.client, [_qresult([], []), _qresult([], [])])
+
+    # A limit far above MAX_ROWS should be clamped silently.
+    result = await resolve_complexity_timeseries(
+        ctx, _timeseries_input(limit=MAX_ROWS + 99999)
+    )
+
+    # The LIMIT clause in the query must be at most MAX_ROWS.
+    first_call_query: str = ctx.client.query.call_args_list[0].args[0]
+    assert f"LIMIT {MAX_ROWS}" in first_call_query
+    assert result.points == []
+
+
+# ---------------------------------------------------------------------------
+# hotspots — empty state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hotspots_empty_state() -> None:
+    ctx = _ctx()
+    _setup_client(
+        ctx.client,
+        [
+            _qresult([], []),  # file_hotspot_daily → no rows
+            _qresult([], []),  # repo labels lookup
+        ],
+    )
+
+    result = await resolve_hotspots(ctx, _hotspots_input())
+
+    assert result.rows == []
+
+
+# ---------------------------------------------------------------------------
+# hotspots — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hotspots_maps_columns_correctly() -> None:
+    ctx = _ctx()
+    columns = [
+        "repo_id",
+        "file_path",
+        "churn_loc_30d",
+        "churn_commits_30d",
+        "cyclomatic_total",
+        "cyclomatic_avg",
+        "blame_concentration",
+        "risk_score",
+    ]
+    row = ["repo-1", "src/core/engine.py", 4200, 38, 95, 9.5, 0.72, 0.88]
+
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(columns, [row]),
+            _qresult(["repo_id", "full_name"], [["repo-1", "acme/core"]]),
+        ],
+    )
+
+    result = await resolve_hotspots(ctx, _hotspots_input())
+
+    assert len(result.rows) == 1
+    r = result.rows[0]
+    assert r.file_path == "src/core/engine.py"
+    assert r.repo_id == "repo-1"
+    assert r.repo_name == "acme/core"
+    assert r.churn_loc_30d == 4200
+    assert r.churn_commits_30d == 38
+    assert r.cyclomatic_total == 95
+    assert r.cyclomatic_avg == pytest.approx(9.5)
+    assert r.blame_concentration == pytest.approx(0.72)
+    assert r.risk_score == pytest.approx(0.88)
+    # urllib.parse.quote keeps '/' safe by default; the path separator is
+    # readable and still valid as a query-string value.
+    assert r.evidence_url == "/code?file=src/core/engine.py"
+
+
+@pytest.mark.asyncio
+async def test_hotspots_null_blame_concentration_propagates_as_none() -> None:
+    ctx = _ctx()
+    columns = [
+        "repo_id",
+        "file_path",
+        "churn_loc_30d",
+        "churn_commits_30d",
+        "cyclomatic_total",
+        "cyclomatic_avg",
+        "blame_concentration",
+        "risk_score",
+    ]
+    row = ["repo-1", "src/main.py", 100, 5, 20, 2.0, None, 0.3]
+
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(columns, [row]),
+            _qresult([], []),
+        ],
+    )
+
+    result = await resolve_hotspots(ctx, _hotspots_input())
+
+    assert result.rows[0].blame_concentration is None
+
+
+@pytest.mark.asyncio
+async def test_hotspots_evidence_url_encodes_special_chars() -> None:
+    ctx = _ctx()
+    columns = [
+        "repo_id",
+        "file_path",
+        "churn_loc_30d",
+        "churn_commits_30d",
+        "cyclomatic_total",
+        "cyclomatic_avg",
+        "blame_concentration",
+        "risk_score",
+    ]
+    row = ["repo-1", "src/module with spaces/file.py", 10, 1, 5, 1.0, None, 0.1]
+
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(columns, [row]),
+            _qresult([], []),
+        ],
+    )
+
+    result = await resolve_hotspots(ctx, _hotspots_input())
+
+    # Spaces must be percent-encoded in the deeplink.
+    assert result.rows[0].evidence_url is not None
+    assert " " not in result.rows[0].evidence_url
+    assert "%20" in result.rows[0].evidence_url
+
+
+@pytest.mark.asyncio
+async def test_hotspots_fallback_repo_name_when_label_missing() -> None:
+    ctx = _ctx()
+    columns = [
+        "repo_id",
+        "file_path",
+        "churn_loc_30d",
+        "churn_commits_30d",
+        "cyclomatic_total",
+        "cyclomatic_avg",
+        "blame_concentration",
+        "risk_score",
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(columns, [["repo-unknown", "src/x.py", 10, 1, 5, 1.0, None, 0.1]]),
+            _qresult([], []),  # no catalog row returned
+        ],
+    )
+
+    result = await resolve_hotspots(ctx, _hotspots_input())
+
+    # Falls back to repo_id when full_name is not in the catalog.
+    assert result.rows[0].repo_name == "repo-unknown"
+
+
+# ---------------------------------------------------------------------------
+# hotspots — row limit clamping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hotspots_limit_is_clamped_to_max_hotspots_rows() -> None:
+    ctx = _ctx()
+    _setup_client(ctx.client, [_qresult([], []), _qresult([], [])])
+
+    result = await resolve_hotspots(ctx, _hotspots_input(limit=MAX_HOTSPOTS_ROWS + 99999))
+
+    first_call_query: str = ctx.client.query.call_args_list[0].args[0]
+    assert f"LIMIT {MAX_HOTSPOTS_ROWS}" in first_call_query
+    assert result.rows == []
+
+
+# ---------------------------------------------------------------------------
+# Org-id gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeseries_org_id_gate_raises_on_missing_context_org() -> None:
+    """``require_org_id`` raises when context.org_id is missing."""
+    from dev_health_ops.api.graphql.errors import AuthorizationError
+
+    # Bypass __post_init__ validation by patching after construction.
+    ctx = _ctx()
+    object.__setattr__(ctx, "org_id", "")
+
+    with pytest.raises(AuthorizationError):
+        await resolve_complexity_timeseries(ctx, _timeseries_input())
+
+
+@pytest.mark.asyncio
+async def test_hotspots_org_id_gate_raises_on_missing_context_org() -> None:
+    """``require_org_id`` raises when context.org_id is missing."""
+    from dev_health_ops.api.graphql.errors import AuthorizationError
+
+    ctx = _ctx()
+    object.__setattr__(ctx, "org_id", "")
+
+    with pytest.raises(AuthorizationError):
+        await resolve_hotspots(ctx, _hotspots_input())
+
+
+# ---------------------------------------------------------------------------
+# Schema surface sanity
+# ---------------------------------------------------------------------------
+
+
+def test_complexity_scope_enum_values() -> None:
+    """ComplexityScope must expose REPO and FILE (no person-level scope)."""
+    values = {s.value for s in ComplexityScope}
+    assert values == {"repo", "file"}
+
+
+def test_time_granularity_enum_values() -> None:
+    """TimeGranularity must expose DAY and WEEK."""
+    values = {g.value for g in TimeGranularity}
+    assert values == {"day", "week"}

--- a/tests/api/graphql/test_complexity_resolver.py
+++ b/tests/api/graphql/test_complexity_resolver.py
@@ -129,7 +129,7 @@ async def test_timeseries_empty_state_file_scope() -> None:
         ctx.client,
         [
             _qresult([], []),  # file_complexity_snapshots → no rows
-            _qresult([], []),  # repo labels lookup
+            # FILE-scope skips the repo-labels join — only 1 query fires.
         ],
     )
 
@@ -295,7 +295,7 @@ async def test_timeseries_file_scope_maps_columns_correctly() -> None:
         ctx.client,
         [
             _qresult(columns, [row]),
-            _qresult(["repo_id", "full_name"], [["repo-1", "acme/backend"]]),
+            # FILE-scope skips the repo-labels join — only 1 query fires.
         ],
     )
 
@@ -315,6 +315,40 @@ async def test_timeseries_file_scope_maps_columns_correctly() -> None:
     assert pt.high_complexity_functions == 3
     assert pt.very_high_complexity_functions == 0
 
+
+@pytest.mark.asyncio
+async def test_timeseries_file_scope_skips_repo_label_join() -> None:
+    """FILE-scope must NOT call _load_repo_labels.
+
+    Regression test for the dead-code path flagged by github-code-quality +
+    CodeQL on PR #769: previously FILE-scope built ``repo_ids_seen`` and queried
+    repo labels, but the result was never read (scopeName is derived from
+    file_path). The unused query added a wasted ClickHouse round-trip per call.
+    """
+    ctx = _ctx()
+    columns = [
+        "day", "repo_id", "file_path",
+        "cyclomatic_total", "cyclomatic_avg",
+        "high_complexity_functions", "very_high_complexity_functions",
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(columns, [[DAY, "repo-1", "src/a.py", 10, 2.0, 0, 0]]),
+        ],
+    )
+
+    await resolve_complexity_timeseries(
+        ctx, _timeseries_input(scope=ComplexityScope.FILE)
+    )
+
+    # Exactly one ClickHouse call — the file_complexity_snapshots fetch.
+    # If a future change re-adds the repo-labels join, this assertion fails
+    # and forces the author to justify the extra round-trip.
+    assert ctx.client.query.call_count == 1, (
+        f"FILE-scope made {ctx.client.query.call_count} ClickHouse queries; "
+        "expected 1 (no repo-label join)."
+    )
 
 # ---------------------------------------------------------------------------
 # complexityTimeseries — WEEK granularity

--- a/tests/api/graphql/test_complexity_resolver.py
+++ b/tests/api/graphql/test_complexity_resolver.py
@@ -327,9 +327,13 @@ async def test_timeseries_file_scope_skips_repo_label_join() -> None:
     """
     ctx = _ctx()
     columns = [
-        "day", "repo_id", "file_path",
-        "cyclomatic_total", "cyclomatic_avg",
-        "high_complexity_functions", "very_high_complexity_functions",
+        "day",
+        "repo_id",
+        "file_path",
+        "cyclomatic_total",
+        "cyclomatic_avg",
+        "high_complexity_functions",
+        "very_high_complexity_functions",
     ]
     _setup_client(
         ctx.client,
@@ -349,6 +353,7 @@ async def test_timeseries_file_scope_skips_repo_label_join() -> None:
         f"FILE-scope made {ctx.client.query.call_count} ClickHouse queries; "
         "expected 1 (no repo-label join)."
     )
+
 
 # ---------------------------------------------------------------------------
 # complexityTimeseries — WEEK granularity

--- a/tests/api/graphql/test_complexity_resolver.py
+++ b/tests/api/graphql/test_complexity_resolver.py
@@ -308,7 +308,7 @@ async def test_timeseries_file_scope_maps_columns_correctly() -> None:
     assert pt.point_date == DAY
     assert pt.scope_id == "repo-1/src/auth/login.py"
     assert pt.scope_name == "src/auth/login.py"
-    assert pt.loc_total is None       # not in file_complexity_snapshots
+    assert pt.loc_total is None  # not in file_complexity_snapshots
     assert pt.cyclomatic_per_kloc is None  # not in file_complexity_snapshots
     assert pt.cyclomatic_total == 120
     assert pt.cyclomatic_avg == pytest.approx(6.5)
@@ -533,7 +533,9 @@ async def test_hotspots_limit_is_clamped_to_max_hotspots_rows() -> None:
     ctx = _ctx()
     _setup_client(ctx.client, [_qresult([], []), _qresult([], [])])
 
-    result = await resolve_hotspots(ctx, _hotspots_input(limit=MAX_HOTSPOTS_ROWS + 99999))
+    result = await resolve_hotspots(
+        ctx, _hotspots_input(limit=MAX_HOTSPOTS_ROWS + 99999)
+    )
 
     first_call_query: str = ctx.client.query.call_args_list[0].args[0]
     assert f"LIMIT {MAX_HOTSPOTS_ROWS}" in first_call_query


### PR DESCRIPTION
## Summary

Exposes two read-only GraphQL queries backed by **existing** ClickHouse analytics tables. Pure schema + resolver work — no new tables, no ETL, no migrations.

### New queries

```graphql
extend type Query {
  complexityTimeseries(input: ComplexityTimeseriesInput!): ComplexityTimeseriesResult!
  hotspots(input: HotspotsInput!): HotspotsResult!
}
```

**`complexityTimeseries`** — cyclomatic complexity trend by repo or file, backed by `repo_complexity_daily` (REPO scope) and `file_complexity_snapshots` (FILE scope). Supports DAY/WEEK granularity bucketing.

**`hotspots`** — top files ranked by `risk_score DESC` from `file_hotspot_daily`, with deterministic `evidenceUrl` deeplinks.

### Files changed

| File | Purpose |
|------|---------|
| `src/dev_health_ops/api/graphql/types/complexity.py` | Strawberry types: `ComplexityScope`, `TimeGranularity`, `ComplexityTimeseriesInput/Result`, `ComplexityPoint`, `HotspotsInput/Result`, `HotspotRow` |
| `src/dev_health_ops/api/graphql/resolvers/complexity.py` | Resolvers: org-gate via `require_org_id`, `argMax(col, computed_at)` reads, MAX\_ROWS guard, repo-label join |
| `src/dev_health_ops/api/graphql/schema.py` | Wires both resolvers into the `Query` class |
| `tests/api/graphql/test_complexity_resolver.py` | 19 unit tests covering empty state, column mapping, null propagation, WEEK truncation, limit clamping, org-gate |

### Implementation notes

- Mirrors `compounding_risk.py` idioms throughout (\_require\_client, require\_org\_id, query\_dicts, argMax)
- `cyclomaticAvg` is null for REPO scope (not stored in `repo_complexity_daily`); populated for FILE scope from `file_complexity_snapshots.cyclomatic_avg`
- `evidenceUrl` is a deterministic deeplink built via `urllib.parse.quote` — no external service called
- `teamIds` input accepted for future use; v1 filters on `repoIds` only (no ClickHouse team→repo join table exists)

### Verification

- [x] `uv sync` → 0
- [x] `ruff check src tests` → 0
- [x] `mypy src/.../resolvers/complexity.py src/.../types/complexity.py` → 0
- [x] `pytest tests/api/graphql/test_complexity_resolver.py -v` → **19/19 passed**
- [x] `python -m dev_health_ops.api.graphql.export_schema` → new fields visible in SDL

SCREENSHOT-WAIVER: backend-only PR; no rendered UI output in this repo.

Closes CHAOS-1756
Unblocks CHAOS-1745 (frontend complexity page — separate agent picks up after this merges)