### PR TITLE
fix(fixtures): validate security alert fixtures

### DIFF
--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -359,6 +359,16 @@ dev-hops fixtures generate \
 
 Database type is auto-detected from the sink URI.
 
+Every fixture run also seeds synthetic security alert rows into
+`security_alerts` for each generated repo. These rows include Dependabot,
+code-scanning, advisory, GitLab vulnerability, and GitLab dependency-style
+sources so the security GraphQL resolvers and UI have demo data without a
+separate flag. Verify them with:
+
+```sql
+SELECT count(), countDistinct(severity) FROM security_alerts;
+```
+
 When `--with-metrics` is enabled against ClickHouse, AI workflow intelligence
 tables are also seeded: `ai_attribution`, `ai_workflow_runs`,
 `ai_workflow_artifact_edges`, and `ai_workflow_issue_edges`. The daily metrics
@@ -379,7 +389,8 @@ dev-hops fixtures validate --sink "clickhouse://localhost:8123/default"
 | `--sink` | Analytics sink URI (required, ClickHouse only) |
 
 Checks raw data counts, team mappings, cycle time metrics, work graph edges,
-connected components, AI fixture/rollup tables, and evidence bundle quality.
+connected components, security alert fixture coverage, AI fixture/rollup tables,
+and evidence bundle quality.
 
 ---
 

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -1337,6 +1337,7 @@ def _validate_security_alerts_fixture(client: Any, *, table_exists) -> bool:
     )
     return True
 
+
 def run_fixtures_validation(ns: argparse.Namespace) -> int:
     """Validate that fixture data is sufficient for work graph and investment."""
     import clickhouse_connect

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -1275,7 +1275,7 @@ MIN_SECURITY_ALERTS = 5
 
 
 def _validate_security_alerts_fixture(client: Any, *, table_exists) -> bool:
-    """Verify security_alerts table is present, non-empty, and has realistic distribution.
+    """Verify security_alerts is present, populated, and realistic.
 
     Checks:
     1. Table exists (migration applied).
@@ -1284,7 +1284,8 @@ def _validate_security_alerts_fixture(client: Any, *, table_exists) -> bool:
     """
     if not table_exists("security_alerts"):
         logging.error(
-            "FAIL: security_alerts table missing (run fixtures generate — security alerts are emitted automatically)."
+            "FAIL: security_alerts table missing (run fixtures generate — "
+            "security alerts are emitted automatically)."
         )
         return False
 
@@ -1296,7 +1297,8 @@ def _validate_security_alerts_fixture(client: Any, *, table_exists) -> bool:
 
     if count == 0:
         logging.error(
-            "FAIL: security_alerts is empty (regression in fixture generation — check insert_security_alerts path in runner.py)."
+            "FAIL: security_alerts is empty (regression in fixture generation — "
+            "check insert_security_alerts path in runner.py)."
         )
         return False
 
@@ -1321,7 +1323,9 @@ def _validate_security_alerts_fixture(client: Any, *, table_exists) -> bool:
 
     if distinct_severities < 2:
         logging.error(
-            "FAIL: security_alerts severity distribution too narrow (distinct_severities=%d, required>=2). Fixture generation may have produced single-severity data.",
+            "FAIL: security_alerts severity distribution too narrow "
+            "(distinct_severities=%d, required>=2). Fixture generation may "
+            "have produced single-severity data.",
             distinct_severities,
         )
         return False

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -1271,6 +1271,68 @@ def _validate_ai_fixture_tables(client: Any, table_exists) -> bool:
     return True
 
 
+MIN_SECURITY_ALERTS = 5
+
+
+def _validate_security_alerts_fixture(client: Any, *, table_exists) -> bool:
+    """Verify security_alerts table is present, non-empty, and has realistic distribution.
+
+    Checks:
+    1. Table exists (migration applied).
+    2. Row count meets minimum (fixture generation wrote data).
+    3. At least two distinct severity levels present (realistic distribution).
+    """
+    if not table_exists("security_alerts"):
+        logging.error(
+            "FAIL: security_alerts table missing (run fixtures generate — security alerts are emitted automatically)."
+        )
+        return False
+
+    try:
+        count = _query_int(client, "SELECT count() FROM security_alerts")
+    except Exception as exc:
+        logging.error("FAIL: Could not count security_alerts rows: %s", exc)
+        return False
+
+    if count == 0:
+        logging.error(
+            "FAIL: security_alerts is empty (regression in fixture generation — check insert_security_alerts path in runner.py)."
+        )
+        return False
+
+    if count < MIN_SECURITY_ALERTS:
+        logging.error(
+            "FAIL: security_alerts too sparse (count=%d, required>=%d).",
+            count,
+            MIN_SECURITY_ALERTS,
+        )
+        return False
+
+    try:
+        distinct_severities = _query_int(
+            client,
+            "SELECT countDistinct(severity) FROM security_alerts WHERE severity IS NOT NULL",
+        )
+    except Exception as exc:
+        logging.error(
+            "FAIL: Could not validate security_alerts severity distribution: %s", exc
+        )
+        return False
+
+    if distinct_severities < 2:
+        logging.error(
+            "FAIL: security_alerts severity distribution too narrow (distinct_severities=%d, required>=2). Fixture generation may have produced single-severity data.",
+            distinct_severities,
+        )
+        return False
+
+    logging.info(
+        "security_alerts: count=%d, distinct_severities=%d — OK",
+        count,
+        distinct_severities,
+    )
+    return True
+
 def run_fixtures_validation(ns: argparse.Namespace) -> int:
     """Validate that fixture data is sufficient for work graph and investment."""
     import clickhouse_connect
@@ -1575,6 +1637,9 @@ def run_fixtures_validation(ns: argparse.Namespace) -> int:
         return 1
 
     if not _validate_ai_fixture_tables(client, _table_exists):
+        return 1
+
+    if not _validate_security_alerts_fixture(client, table_exists=_table_exists):
         return 1
 
     # 4. Evidence sanity (sample bundles)

--- a/tests/test_fixtures_runner.py
+++ b/tests/test_fixtures_runner.py
@@ -422,7 +422,12 @@ def _security_alerts_table_exists(name: str) -> bool:
 
 def test_validate_security_alerts_fixture_accepts_populated_state():
     client = _SecurityAlertsClient(count=20, distinct_severities=4)
-    assert runner._validate_security_alerts_fixture(client, table_exists=_security_alerts_table_exists) is True
+    assert (
+        runner._validate_security_alerts_fixture(
+            client, table_exists=_security_alerts_table_exists
+        )
+        is True
+    )
 
 
 def test_validate_security_alerts_fixture_rejects_missing_table():
@@ -436,7 +441,9 @@ def test_validate_security_alerts_fixture_rejects_missing_table():
 def test_validate_security_alerts_fixture_rejects_empty_table():
     client = _SecurityAlertsClient(count=0)
     assert (
-        runner._validate_security_alerts_fixture(client, table_exists=_security_alerts_table_exists)
+        runner._validate_security_alerts_fixture(
+            client, table_exists=_security_alerts_table_exists
+        )
         is False
     )
 
@@ -445,7 +452,9 @@ def test_validate_security_alerts_fixture_rejects_sparse_table():
     """count > 0 but below MIN_SECURITY_ALERTS threshold."""
     client = _SecurityAlertsClient(count=runner.MIN_SECURITY_ALERTS - 1)
     assert (
-        runner._validate_security_alerts_fixture(client, table_exists=_security_alerts_table_exists)
+        runner._validate_security_alerts_fixture(
+            client, table_exists=_security_alerts_table_exists
+        )
         is False
     )
 
@@ -454,7 +463,9 @@ def test_validate_security_alerts_fixture_rejects_single_severity():
     """Table has rows but only one distinct severity — distribution is degenerate."""
     client = _SecurityAlertsClient(count=20, distinct_severities=1)
     assert (
-        runner._validate_security_alerts_fixture(client, table_exists=_security_alerts_table_exists)
+        runner._validate_security_alerts_fixture(
+            client, table_exists=_security_alerts_table_exists
+        )
         is False
     )
 

--- a/tests/test_fixtures_runner.py
+++ b/tests/test_fixtures_runner.py
@@ -433,7 +433,9 @@ def test_validate_security_alerts_fixture_accepts_populated_state():
 def test_validate_security_alerts_fixture_rejects_missing_table():
     client = _SecurityAlertsClient()
     assert (
-        runner._validate_security_alerts_fixture(client, table_exists=lambda name: False)
+        runner._validate_security_alerts_fixture(
+            client, table_exists=lambda name: False
+        )
         is False
     )
 
@@ -468,6 +470,7 @@ def test_validate_security_alerts_fixture_rejects_single_severity():
         )
         is False
     )
+
 
 class TestGenerateUsersRespectsOrgId:
     """Regression: ``generate_users(org_id=...)`` MUST stamp the supplied org_id

--- a/tests/test_fixtures_runner.py
+++ b/tests/test_fixtures_runner.py
@@ -400,6 +400,64 @@ def test_validate_ai_fixture_tables_rejects_unlinked_runs():
     assert runner._validate_ai_fixture_tables(client, _all_ai_tables_exist) is False
 
 
+class _SecurityAlertsClient:
+    """Stub ClickHouse client for security_alerts validation tests."""
+
+    def __init__(self, *, count: int = 20, distinct_severities: int = 4):
+        self.count = count
+        self.distinct_severities = distinct_severities
+
+    def query(self, sql: str):
+        normalized = " ".join(sql.split())
+        if "countDistinct(severity)" in normalized:
+            return _QueryResult(self.distinct_severities)
+        if "FROM security_alerts" in normalized:
+            return _QueryResult(self.count)
+        raise AssertionError(f"Unexpected query: {normalized}")
+
+
+def _security_alerts_table_exists(name: str) -> bool:
+    return name == "security_alerts"
+
+
+def test_validate_security_alerts_fixture_accepts_populated_state():
+    client = _SecurityAlertsClient(count=20, distinct_severities=4)
+    assert runner._validate_security_alerts_fixture(client, table_exists=_security_alerts_table_exists) is True
+
+
+def test_validate_security_alerts_fixture_rejects_missing_table():
+    client = _SecurityAlertsClient()
+    assert (
+        runner._validate_security_alerts_fixture(client, table_exists=lambda name: False)
+        is False
+    )
+
+
+def test_validate_security_alerts_fixture_rejects_empty_table():
+    client = _SecurityAlertsClient(count=0)
+    assert (
+        runner._validate_security_alerts_fixture(client, table_exists=_security_alerts_table_exists)
+        is False
+    )
+
+
+def test_validate_security_alerts_fixture_rejects_sparse_table():
+    """count > 0 but below MIN_SECURITY_ALERTS threshold."""
+    client = _SecurityAlertsClient(count=runner.MIN_SECURITY_ALERTS - 1)
+    assert (
+        runner._validate_security_alerts_fixture(client, table_exists=_security_alerts_table_exists)
+        is False
+    )
+
+
+def test_validate_security_alerts_fixture_rejects_single_severity():
+    """Table has rows but only one distinct severity — distribution is degenerate."""
+    client = _SecurityAlertsClient(count=20, distinct_severities=1)
+    assert (
+        runner._validate_security_alerts_fixture(client, table_exists=_security_alerts_table_exists)
+        is False
+    )
+
 class TestGenerateUsersRespectsOrgId:
     """Regression: ``generate_users(org_id=...)`` MUST stamp the supplied org_id
     onto the Organization row and every Membership/license, so that synthetic


### PR DESCRIPTION
## Summary
- add fixtures validate coverage for security_alerts table presence, volume, and severity diversity
- document security_alert fixture generation and verification query
- add regression tests for security alert validation cases

## Verification
- uv run --with pytest-asyncio pytest tests/test_fixtures_runner.py tests/test_fixtures_security_alerts.py -q
- uv run --with pytest-asyncio pytest tests/graphql/test_security.py -q
- uv run ruff check src/dev_health_ops/fixtures/runner.py tests/test_fixtures_runner.py
- CLI fixture generation against ClickHouse produced 15 security alerts with 3 distinct severities

SCREENSHOT-WAIVER: backend/docs-only fixture validation change; no rendered frontend output changed.