### PR TITLE
fix(ops): correct THROUGHPUT/CHURN_LOC/CYCLE_TIME_HOURS mappings for work_unit_investments (CHAOS-1754)

### DIFF
--- a/src/dev_health_ops/api/graphql/sql/validate.py
+++ b/src/dev_health_ops/api/graphql/sql/validate.py
@@ -78,9 +78,16 @@ class Measure(str, Enum):
         if use_investment:
             mapping: dict[Measure, str] = {
                 cls.COUNT: "SUM(subcategory_kv.2 * effort_value)",
-                cls.CHURN_LOC: "SUM(churn_loc)",
-                cls.CYCLE_TIME_HOURS: "AVG(cycle_p50_hours)",
-                cls.THROUGHPUT: "SUM(throughput)",
+                # THROUGHPUT: each work unit's subcategory probabilities sum to
+                # ~1.0, so summing them gives the weighted count of work units.
+                cls.THROUGHPUT: "SUM(subcategory_kv.2)",
+                # CHURN_LOC: effort_value stores the actual churn LOC for work
+                # units whose effort_metric = 'churn_loc'; weight by subcategory
+                # probability to apportion across the ARRAY JOIN fan-out.
+                cls.CHURN_LOC: "SUM(if(effort_metric = 'churn_loc', subcategory_kv.2 * effort_value, 0))",
+                # CYCLE_TIME_HOURS: derived from the stored timestamps (from_ts,
+                # to_ts) as the per-work-unit cycle duration in hours.
+                cls.CYCLE_TIME_HOURS: "AVG(dateDiff('hour', from_ts, to_ts))",
             }
         else:
             mapping = {

--- a/tests/api/graphql/sql_explain_fixtures.py
+++ b/tests/api/graphql/sql_explain_fixtures.py
@@ -370,8 +370,8 @@ async def _fixture_analytics(sink: CapturingSink) -> None:
     start = SAMPLE_DAY - timedelta(days=30)
 
     # Source-table-routing matrix:
-#   investment dims (theme/subcategory/work_type) → work_unit_investments
-#   non-investment dims (team/repo/author)         → investment_metrics_daily
+    #   investment dims (theme/subcategory/work_type) → work_unit_investments
+    #   non-investment dims (team/repo/author)         → investment_metrics_daily
     # The two backing tables expose different column sets; the investment path
     # uses derived expressions over real columns in work_unit_investments:
     #   THROUGHPUT      → SUM(subcategory_kv.2)  (weighted work-unit count)

--- a/tests/api/graphql/sql_explain_fixtures.py
+++ b/tests/api/graphql/sql_explain_fixtures.py
@@ -370,18 +370,18 @@ async def _fixture_analytics(sink: CapturingSink) -> None:
     start = SAMPLE_DAY - timedelta(days=30)
 
     # Source-table-routing matrix:
-    #   investment dims (theme/subcategory/work_type) → work_unit_investments
-    #   non-investment dims (team/repo/author)         → investment_metrics_daily
-    # The two backing tables expose different measure columns; restrict each
-    # dimension to the measure set the matching template can actually project.
-    # Known gaps for the investment path are tracked in CHAOS-1754: throughput,
-    # churn_loc, and cycle_time_hours mappings on work_unit_investments don't
-    # match any real column. Until that is fixed, only count is exercised
-    # against investment dimensions here.
+#   investment dims (theme/subcategory/work_type) → work_unit_investments
+#   non-investment dims (team/repo/author)         → investment_metrics_daily
+    # The two backing tables expose different column sets; the investment path
+    # uses derived expressions over real columns in work_unit_investments:
+    #   THROUGHPUT      → SUM(subcategory_kv.2)  (weighted work-unit count)
+    #   CHURN_LOC       → SUM(if(effort_metric='churn_loc', subcategory_kv.2*effort_value, 0))
+    #   CYCLE_TIME_HOURS→ AVG(dateDiff('hour', from_ts, to_ts))
+    # Fixed in CHAOS-1754; all four measures are now exercised.
     NON_INVESTMENT_DIMS = ["team", "repo"]
     NON_INVESTMENT_MEASURES = ["count", "throughput", "cycle_time_hours", "churn_loc"]
     INVESTMENT_DIMS = ["theme", "subcategory", "work_type"]
-    INVESTMENT_MEASURES = ["count"]
+    INVESTMENT_MEASURES = ["count", "throughput", "churn_loc", "cycle_time_hours"]
 
     matrix: list[tuple[list[str], list[str]]] = [
         (NON_INVESTMENT_DIMS, NON_INVESTMENT_MEASURES),

--- a/tests/graphql/test_compiler.py
+++ b/tests/graphql/test_compiler.py
@@ -355,12 +355,21 @@ class TestMeasureDbExpression:
         assert Measure.db_expression(Measure.COUNT) == "SUM(work_items_completed)"
         assert Measure.db_expression(Measure.THROUGHPUT) == "SUM(work_items_completed)"
 
-        # Investment
+        # Investment path — expressions over real columns in work_unit_investments
+        # (CHAOS-1754: old non-existent column refs replaced with valid expressions)
         assert (
             Measure.db_expression(Measure.COUNT, use_investment=True)
             == "SUM(subcategory_kv.2 * effort_value)"
         )
         assert (
             Measure.db_expression(Measure.THROUGHPUT, use_investment=True)
-            == "SUM(throughput)"
+            == "SUM(subcategory_kv.2)"
+        )
+        assert (
+            Measure.db_expression(Measure.CHURN_LOC, use_investment=True)
+            == "SUM(if(effort_metric = 'churn_loc', subcategory_kv.2 * effort_value, 0))"
+        )
+        assert (
+            Measure.db_expression(Measure.CYCLE_TIME_HOURS, use_investment=True)
+            == "AVG(dateDiff('hour', from_ts, to_ts))"
         )


### PR DESCRIPTION
## Summary

Fix the measure→column mapping for `work_unit_investments` so THROUGHPUT, CHURN_LOC, and CYCLE_TIME_HOURS resolve to real columns when `use_investment=True` in `compile_timeseries` / `compile_breakdown`.

Previously these measures mapped to non-existent columns causing ClickHouse Code 47 UNKNOWN_IDENTIFIER errors on any GraphQL query for INVESTMENT_DIMS × those measures.

## Column Mapping Chosen

| Measure | Old (broken) expression | New (correct) expression | Column source |
|---|---|---|---|
| THROUGHPUT | `SUM(throughput)` | `SUM(subcategory_kv.2)` | subcategory probabilities sum to ~1.0 per work unit (ARRAY JOIN alias) |
| CHURN_LOC | `SUM(churn_loc)` | `SUM(if(effort_metric = 'churn_loc', subcategory_kv.2 * effort_value, 0))` | `effort_value` stores LOC churn when `effort_metric='churn_loc'` |
| CYCLE_TIME_HOURS | `AVG(cycle_p50_hours)` | `AVG(dateDiff('hour', from_ts, to_ts))` | `from_ts`/`to_ts` stored per work unit |

All expressions reference only columns that exist in `work_unit_investments` (verified via migrations 017, 019, 024).

## Files Touched

- `src/dev_health_ops/api/graphql/sql/validate.py` — fixed `Measure.db_expression()` investment path
- `tests/api/graphql/sql_explain_fixtures.py` — widened INVESTMENT_MEASURES from `["count"]` to `["count", "throughput", "churn_loc", "cycle_time_hours"]`
- `tests/graphql/test_compiler.py` — updated assertions for new correct expressions

## Test Evidence

```
python -m pytest tests/graphql/ tests/api/graphql/ -x -v
279 passed, 17 skipped in 1.96s
```

ruff: All checks passed
mypy: Success: no issues found in 1 source file

## Notes

- The EXPLAIN-based SQL tests (test_resolver_sql_explain.py) skip without a live ClickHouse; they run in CI.
- Non-investment path (`use_investment=False`, querying `investment_metrics_daily`) is unchanged.

SCREENSHOT-WAIVER: API-only change; no rendered frontend output affected.

Closes CHAOS-1754