### PR TITLE
fix(storage): make insert_repo idempotent so org_id refreshes on existing rows (CHAOS-1775)

### DIFF
--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -217,16 +217,30 @@ class ClickHouseStore:
         return bool(getattr(result, "result_rows", None))
 
     async def insert_repo(self, repo: Repo) -> None:
+        """Insert (or refresh) a repo row, idempotently.
+
+        ``repos`` is a ``ReplacingMergeTree(last_synced)`` ordered by
+        ``(org_id, id)``. We *always* write the row and let the engine
+        reconcile by ``last_synced`` for the same ``(org_id, id)`` key.
+
+        Why no existence-check short-circuit (CHAOS-1775):
+          The previous implementation returned early when a row with the
+          same ``id`` already existed, which meant mutable fields —
+          including the auto-injected ``org_id`` set by ``_insert_rows``
+          from ``self.org_id`` — were never refreshed. Re-running ``dev-hops
+          fixtures generate`` (or any sync) with a different ``--org`` then
+          silently stranded ``repos.org_id`` at its first value, which broke
+          every analytics view that scopes via ``r.org_id`` (e.g. the
+          ``/security`` dashboard).
+
+        Stale-tenant rows (same ``id``, prior ``org_id``) remain in the part
+          until merge but no longer mask the active-tenant row, since this
+          method always inserts a fresh row under ``self.org_id``. A
+          dedicated cleanup of stale-tenant orphans is intentionally out of
+          scope for this hot-path sink.
+        """
         assert self.client is not None
         repo_id = self._normalize_uuid(repo.id)
-        async with self._lock:
-            existing = await asyncio.to_thread(
-                self.client.query,
-                "SELECT 1 FROM repos WHERE id = {id:UUID} LIMIT 1",
-                parameters={"id": str(repo_id)},
-            )
-        if getattr(existing, "result_rows", None):
-            return
 
         synced_at = self._normalize_datetime(datetime.now(timezone.utc))
         created_at = (

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -874,6 +874,96 @@ async def test_clickhouse_store_insert_git_file_data_calls_insert():
     ]
 
 
+@pytest.mark.asyncio
+async def test_clickhouse_store_insert_repo_refreshes_org_id_on_existing_row():
+    """Regression for CHAOS-1775.
+
+    Re-inserting the same repo while ``self.org_id`` has changed must write
+    a fresh row tagged with the new ``org_id`` (so the analytics views, which
+    JOIN on ``repos.org_id``, see the active tenant). The previous
+    implementation short-circuited on existence and stranded ``org_id`` at
+    its first value.
+    """
+    test_repo_id = uuid.uuid4()
+    test_repo = Repo(id=test_repo_id, repo="owner/repo")
+
+    mock_client = MagicMock()
+    mock_client.command = MagicMock()
+    mock_client.insert = MagicMock()
+    # ``query`` is only invoked during migration init (SHOW TABLES, etc.).
+    # The post-fix ``insert_repo`` no longer performs an existence query.
+    mock_client.query = MagicMock(return_value=MagicMock(result_rows=[]))
+    mock_client.close = MagicMock()
+
+    import sys
+    from types import SimpleNamespace
+
+    get_client = MagicMock(return_value=mock_client)
+    fake_clickhouse_connect = SimpleNamespace(get_client=get_client)
+
+    with patch.dict(sys.modules, {"clickhouse_connect": fake_clickhouse_connect}):
+        store = ClickHouseStore("clickhouse://localhost:8123/default")
+        async with store:
+            # First insert under org A.
+            store.org_id = "org-a"
+            await store.insert_repo(test_repo)
+            # Re-insert under org B. The fix must NOT short-circuit; it must
+            # write a new row tagged with org B.
+            store.org_id = "org-b"
+            await store.insert_repo(test_repo)
+
+    # Two inserts must have happened.
+    assert mock_client.insert.call_count == 2, (
+        "insert_repo short-circuited on existing row — CHAOS-1775 regressed"
+    )
+
+    for call_idx, expected_org in enumerate(("org-a", "org-b")):
+        args, kwargs = mock_client.insert.call_args_list[call_idx]
+        assert args[0] == "repos"
+        column_names = kwargs["column_names"]
+        assert "org_id" in column_names, (
+            f"call {call_idx}: org_id missing from column_names"
+        )
+        matrix = args[1]
+        org_id_idx = list(column_names).index("org_id")
+        assert matrix[0][org_id_idx] == expected_org, (
+            f"call {call_idx}: expected org_id={expected_org!r}, "
+            f"got {matrix[0][org_id_idx]!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_clickhouse_store_insert_repo_writes_under_self_org_id():
+    """Fresh insert path: org_id auto-injection from ``self.org_id`` works."""
+    test_repo = Repo(id=uuid.uuid4(), repo="owner/repo")
+
+    mock_client = MagicMock()
+    mock_client.command = MagicMock()
+    mock_client.insert = MagicMock()
+    mock_client.query = MagicMock(return_value=MagicMock(result_rows=[]))
+    mock_client.close = MagicMock()
+
+    import sys
+    from types import SimpleNamespace
+
+    get_client = MagicMock(return_value=mock_client)
+    fake_clickhouse_connect = SimpleNamespace(get_client=get_client)
+
+    with patch.dict(sys.modules, {"clickhouse_connect": fake_clickhouse_connect}):
+        store = ClickHouseStore("clickhouse://localhost:8123/default")
+        async with store:
+            store.org_id = "acme-corp"
+            await store.insert_repo(test_repo)
+
+    args, kwargs = mock_client.insert.call_args
+    assert args[0] == "repos"
+    column_names = kwargs["column_names"]
+    assert "org_id" in column_names
+    matrix = args[1]
+    org_id_idx = list(column_names).index("org_id")
+    assert matrix[0][org_id_idx] == "acme-corp"
+
+
 # SQLite-specific Tests
 
 


### PR DESCRIPTION
## Summary

`ClickHouseStore.insert_repo()` short-circuited when a repo row with the same `id` already existed and never refreshed mutable fields — most importantly the `org_id` auto-injected by `_insert_rows`. Re-running `dev-hops fixtures generate` (or any sync) with a different `--org` silently stranded `repos.org_id` at its first value, which broke every analytics view that scopes via `r.org_id` (e.g. the entire `/security` dashboard — KPIs, alerts list, severity breakdown, top repos, trend).

Closes CHAOS-1775.

## Root cause

[`src/dev_health_ops/storage/clickhouse.py:222-229`](https://github.com/.../storage/clickhouse.py#L222-L229) (before this PR):

```python
existing = await asyncio.to_thread(
    self.client.query,
    "SELECT 1 FROM repos WHERE id = {id:UUID} LIMIT 1",
    parameters={"id": str(repo_id)},
)
if getattr(existing, "result_rows", None):
    return  # ← never updated org_id (or any mutable field)
```

`_insert_rows` auto-injects `org_id` from `self.org_id` only for actual inserts — so the existence-check + early-return path bypassed it entirely.

Concrete impact observed locally:
```
sa.org_id                            | r.org_id                              | n
900f96be-804c-42fb-9e93-de73c499a22d | ae600a94-76bc-4166-bf36-051ee4247c73 | 60   ← orphaned
```
`security_alerts` correctly tagged with the active org; `repos` stuck on the prior org. `SecurityResolver`'s `INNER JOIN repos r ON sa.repo_id = r.id WHERE r.org_id = …` dropped every row → empty dashboard.

## Fix

Drop the existence-check early-return; always write through `_insert_rows`. The `repos` table is `ReplacingMergeTree(last_synced)` ordered by `(org_id, id)`, so the engine reconciles within `(org_id, id)` by `last_synced` as designed. Stale-tenant rows survive as harmless orphans until merge but no longer mask the active tenant's row.

Audited every other `insert_*` in `ClickHouseStore` — none use this pattern. They all rely on ReplacingMergeTree dedup directly.

## Tests

Two new regression tests in `tests/test_storage.py`:
- `test_clickhouse_store_insert_repo_refreshes_org_id_on_existing_row` — calls `insert_repo` twice with two different `self.org_id` values and asserts that **both** inserts occur with the correct `org_id` per call (this is exactly the CHAOS-1775 scenario).
- `test_clickhouse_store_insert_repo_writes_under_self_org_id` — verifies the auto-injection path on a fresh insert.

`pytest tests/test_storage.py tests/test_clickhouse_org_id.py tests/test_storage_mixins.py tests/test_fixtures_security_alerts.py` → **124 passed**.

`ruff check` and `ruff format --check` clean.

## Verified end-to-end

After this fix + a one-time repair INSERT to re-tag the 4 stranded `acme/demo-app-*` repos under the active fixture org, the exact resolver KPI query returns the expected non-zero data:

```
open_total | critical | high
35         | 2        | 6
```

## SCREENSHOT-WAIVER

Pure backend storage-sink fix. No GraphQL schema change, no resolver change, no rendered-output change in `dev-health-web`. The user-visible recovery is purely "dashboard that was empty now has data".

## Follow-up (not in this PR)

Stale-tenant orphan rows (same `id`, prior `org_id`) survive until ClickHouse merges. Active cleanup belongs in a `dev-hops migrate repair` command or similar — out of scope for this hot-path sink fix.
