### PR TITLE
feat(migrate): add 'migrate clickhouse repair' for stale-tenant orphans (CHAOS-1776)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -53,6 +53,8 @@ dev-hops migrate postgres history          # show migration history
 dev-hops migrate clickhouse
 dev-hops migrate clickhouse upgrade        # same as above
 dev-hops migrate clickhouse status         # show applied/pending migrations
+dev-hops migrate clickhouse repair         # dry-run: find stale-tenant orphan rows in repos
+dev-hops migrate clickhouse repair --apply # actually delete the orphans (see CHAOS-1775/1776)
 ```
 
 > Run both migration commands after setting up a fresh environment, before any sync or metrics commands.

--- a/src/dev_health_ops/migrate.py
+++ b/src/dev_health_ops/migrate.py
@@ -132,6 +132,108 @@ def _run_clickhouse_status(ns: argparse.Namespace) -> int:
     return 0
 
 
+# --- ClickHouse repair (stale-tenant orphan rows in `repos`) ----------------
+
+# Background: ``repos`` is ``ReplacingMergeTree(last_synced)`` ordered by
+# ``(org_id, id)``. Prior to CHAOS-1775, ``ClickHouseStore.insert_repo``
+# short-circuited on existing rows, so re-running ``fixtures generate`` (or any
+# sync) under a different ``--org`` left the table with multiple rows for the
+# same ``id`` under different ``org_id`` values. Those orphan rows are harmless
+# (a non-existent tenant cannot read them) but clutter the table.
+#
+# This repair identifies, per ``id``, the row with the newest ``last_synced``
+# as the *active* tenant row; every other ``(id, org_id)`` row is an orphan.
+
+_REPAIR_DETECT_QUERY = """
+WITH latest AS (
+    SELECT
+        id,
+        argMax(org_id, last_synced) AS active_org_id,
+        max(last_synced) AS active_last_synced
+    FROM repos
+    GROUP BY id
+    HAVING uniqExact(org_id) > 1
+)
+SELECT
+    toString(r.id) AS id,
+    r.repo AS repo,
+    r.org_id AS stale_org_id,
+    l.active_org_id AS active_org_id,
+    r.last_synced AS stale_last_synced,
+    l.active_last_synced AS active_last_synced
+FROM repos r
+INNER JOIN latest l ON r.id = l.id
+WHERE r.org_id != l.active_org_id
+{org_filter}
+ORDER BY r.repo, r.org_id
+"""
+
+
+def _run_clickhouse_repair(ns: argparse.Namespace) -> int:
+    """Find (and optionally delete) stale-tenant orphan rows in ``repos``.
+
+    Dry-run by default. Pass ``--apply`` to issue ``ALTER TABLE repos DELETE``
+    for each orphan. Optional ``--org`` scopes the repair to orphans whose
+    active tenant is that org_id; orphans of other tenants are untouched.
+    """
+    import clickhouse_connect
+
+    uri = resolve_sink_uri(ns)
+    apply = bool(getattr(ns, "apply", False))
+    org_filter_value: str | None = getattr(ns, "org", None)
+
+    if org_filter_value:
+        org_filter_sql = "AND l.active_org_id = {active_org:String}"
+        params: dict[str, str] = {"active_org": org_filter_value}
+    else:
+        org_filter_sql = ""
+        params = {}
+
+    detect_query = _REPAIR_DETECT_QUERY.format(org_filter=org_filter_sql)
+
+    client = clickhouse_connect.get_client(dsn=uri)
+    try:
+        result = client.query(detect_query, parameters=params)
+        orphans = list(result.result_rows or [])
+
+        if not orphans:
+            print("No stale-tenant orphans found in repos.")
+            return 0
+
+        print(f"Found {len(orphans)} stale-tenant orphan row(s) in repos:")
+        print()
+        header = ("repo", "stale_org_id", "active_org_id", "stale_last_synced")
+        print(f"  {header[0]:<40s}  {header[1]:<40s}  {header[2]:<40s}  {header[3]}")
+        for row in orphans:
+            (_id, repo, stale_org, active_org, stale_ts, _active_ts) = row
+            print(
+                f"  {str(repo):<40s}  {str(stale_org):<40s}  "
+                f"{str(active_org):<40s}  {stale_ts}"
+            )
+        print()
+
+        if not apply:
+            print("Dry-run: pass --apply to delete these orphan rows.")
+            return 0
+
+        print("Applying ALTER TABLE repos DELETE per orphan...")
+        deleted = 0
+        for row in orphans:
+            (id_str, _repo, stale_org, _active_org, _stale_ts, _active_ts) = row
+            client.command(
+                "ALTER TABLE repos DELETE "
+                "WHERE id = {id:UUID} AND org_id = {org:String} "
+                "SETTINGS mutations_sync=2",
+                parameters={"id": str(id_str), "org": str(stale_org)},
+            )
+            deleted += 1
+
+        print(f"Deleted {deleted} stale-tenant row(s) from repos.")
+    finally:
+        client.close()
+    return 0
+
+
 # ── CLI registration ───────────────────────────────────────────────
 
 
@@ -171,6 +273,28 @@ def _register_clickhouse_subcommands(
 
     ch_status = sub.add_parser("status", help="Show applied and pending migrations.")
     ch_status.set_defaults(func=_run_clickhouse_status)
+
+    ch_repair = sub.add_parser(
+        "repair",
+        help=(
+            "Find (or with --apply, delete) stale-tenant orphan rows in repos "
+            "(see CHAOS-1775). Dry-run by default."
+        ),
+    )
+    ch_repair.add_argument(
+        "--apply",
+        action="store_true",
+        help="Delete orphan rows. Without this flag, repair is a dry-run.",
+    )
+    ch_repair.add_argument(
+        "--org",
+        default=None,
+        help=(
+            "Scope repair to orphans whose active tenant is this org_id. "
+            "Without this flag, every tenant's orphans are reported/repaired."
+        ),
+    )
+    ch_repair.set_defaults(func=_run_clickhouse_repair)
 
 
 def register_commands(subparsers: argparse._SubParsersAction) -> None:

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -9,6 +9,7 @@ import pytest
 
 from dev_health_ops.cli import build_parser
 from dev_health_ops.migrate import (
+    _run_clickhouse_repair,
     _run_clickhouse_status,
     _run_clickhouse_upgrade,
 )
@@ -47,6 +48,12 @@ class TestMigrateRouting:
             (["migrate", "clickhouse"], "_run_clickhouse_upgrade"),
             (["migrate", "clickhouse", "upgrade"], "_run_clickhouse_upgrade"),
             (["migrate", "clickhouse", "status"], "_run_clickhouse_status"),
+            (["migrate", "clickhouse", "repair"], "_run_clickhouse_repair"),
+            (["migrate", "clickhouse", "repair", "--apply"], "_run_clickhouse_repair"),
+            (
+                ["migrate", "clickhouse", "repair", "--apply", "--org", "org-a"],
+                "_run_clickhouse_repair",
+            ),
             # backward-compat flat aliases
             (["migrate", "upgrade"], "_run_upgrade"),
             (["migrate", "upgrade", "abc123"], "_run_upgrade"),
@@ -266,5 +273,168 @@ class TestClickhouseStatus:
         ):
             with pytest.raises(OSError, match="disk error"):
                 _run_clickhouse_status(_ns())
+
+        mock_client.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _run_clickhouse_repair  (CHAOS-1776)
+# ---------------------------------------------------------------------------
+
+
+class TestClickhouseRepair:
+    def _make_client(self, orphan_rows: list | None = None) -> MagicMock:
+        mock_client = MagicMock()
+        result = MagicMock()
+        result.result_rows = orphan_rows or []
+        mock_client.query.return_value = result
+        return mock_client
+
+    def _ns_repair(self, **kwargs):
+        kwargs.setdefault("apply", False)
+        kwargs.setdefault("org", None)
+        return _ns(**kwargs)
+
+    @patch(
+        "dev_health_ops.migrate.resolve_sink_uri",
+        return_value="clickhouse://fake:8123/test",
+    )
+    def test_no_orphans_prints_clean_message(self, _uri, capsys):
+        mock_client = self._make_client(orphan_rows=[])
+
+        with patch("clickhouse_connect.get_client", return_value=mock_client):
+            result = _run_clickhouse_repair(self._ns_repair())
+
+        assert result == 0
+        assert "No stale-tenant orphans found in repos." in capsys.readouterr().out
+        # Detection-only path — no ALTER TABLE DELETE.
+        mock_client.command.assert_not_called()
+        mock_client.close.assert_called_once()
+
+    @patch(
+        "dev_health_ops.migrate.resolve_sink_uri",
+        return_value="clickhouse://fake:8123/test",
+    )
+    def test_dry_run_does_not_delete(self, _uri, capsys):
+        """Default invocation prints orphans but issues no ALTER TABLE DELETE."""
+        orphan_rows = [
+            (
+                "e50b01bd-47a3-50e7-a9b4-d29a95bfdb07",
+                "acme/demo-app-1",
+                "stale-org",
+                "active-org",
+                datetime(2026, 5, 1),
+                datetime(2026, 5, 22),
+            ),
+        ]
+        mock_client = self._make_client(orphan_rows=orphan_rows)
+
+        with patch("clickhouse_connect.get_client", return_value=mock_client):
+            result = _run_clickhouse_repair(self._ns_repair())
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Found 1 stale-tenant orphan row(s) in repos" in out
+        assert "acme/demo-app-1" in out
+        assert "stale-org" in out
+        assert "active-org" in out
+        assert "Dry-run: pass --apply to delete these orphan rows." in out
+        # No DELETE issued in dry-run.
+        mock_client.command.assert_not_called()
+        mock_client.close.assert_called_once()
+
+    @patch(
+        "dev_health_ops.migrate.resolve_sink_uri",
+        return_value="clickhouse://fake:8123/test",
+    )
+    def test_apply_issues_delete_per_orphan(self, _uri, capsys):
+        orphan_rows = [
+            (
+                "e50b01bd-47a3-50e7-a9b4-d29a95bfdb07",
+                "acme/demo-app-1",
+                "stale-org-a",
+                "active-org",
+                datetime(2026, 5, 1),
+                datetime(2026, 5, 22),
+            ),
+            (
+                "5b862ba7-ef97-59d6-aa06-d1b30de9112b",
+                "acme/demo-app-4",
+                "stale-org-b",
+                "active-org",
+                datetime(2026, 4, 1),
+                datetime(2026, 5, 22),
+            ),
+        ]
+        mock_client = self._make_client(orphan_rows=orphan_rows)
+
+        with patch("clickhouse_connect.get_client", return_value=mock_client):
+            result = _run_clickhouse_repair(self._ns_repair(apply=True))
+
+        assert result == 0
+        assert mock_client.command.call_count == 2
+
+        for call, expected in zip(
+            mock_client.command.call_args_list,
+            [
+                ("e50b01bd-47a3-50e7-a9b4-d29a95bfdb07", "stale-org-a"),
+                ("5b862ba7-ef97-59d6-aa06-d1b30de9112b", "stale-org-b"),
+            ],
+            strict=True,
+        ):
+            args, kwargs = call
+            sql = args[0]
+            assert "ALTER TABLE repos DELETE" in sql
+            assert "mutations_sync=2" in sql
+            assert kwargs["parameters"] == {"id": expected[0], "org": expected[1]}
+
+        out = capsys.readouterr().out
+        assert "Deleted 2 stale-tenant row(s) from repos." in out
+        mock_client.close.assert_called_once()
+
+    @patch(
+        "dev_health_ops.migrate.resolve_sink_uri",
+        return_value="clickhouse://fake:8123/test",
+    )
+    def test_org_filter_passes_param_to_detect_query(self, _uri):
+        mock_client = self._make_client(orphan_rows=[])
+
+        with patch("clickhouse_connect.get_client", return_value=mock_client):
+            _run_clickhouse_repair(self._ns_repair(org="my-org-uuid"))
+
+        assert mock_client.query.call_count == 1
+        args, kwargs = mock_client.query.call_args
+        detect_sql = args[0]
+        # Org filter clause must be injected when --org is given.
+        assert "AND l.active_org_id = {active_org:String}" in detect_sql
+        assert kwargs["parameters"] == {"active_org": "my-org-uuid"}
+
+    @patch(
+        "dev_health_ops.migrate.resolve_sink_uri",
+        return_value="clickhouse://fake:8123/test",
+    )
+    def test_no_org_filter_omits_clause(self, _uri):
+        mock_client = self._make_client(orphan_rows=[])
+
+        with patch("clickhouse_connect.get_client", return_value=mock_client):
+            _run_clickhouse_repair(self._ns_repair())
+
+        args, kwargs = mock_client.query.call_args
+        detect_sql = args[0]
+        # Without --org, the org filter clause must NOT appear.
+        assert "l.active_org_id =" not in detect_sql
+        assert kwargs["parameters"] == {}
+
+    @patch(
+        "dev_health_ops.migrate.resolve_sink_uri",
+        return_value="clickhouse://fake:8123/test",
+    )
+    def test_close_called_even_on_failure(self, _uri):
+        mock_client = self._make_client()
+        mock_client.query.side_effect = RuntimeError("boom")
+
+        with patch("clickhouse_connect.get_client", return_value=mock_client):
+            with pytest.raises(RuntimeError, match="boom"):
+                _run_clickhouse_repair(self._ns_repair())
 
         mock_client.close.assert_called_once()


### PR DESCRIPTION
## Summary

Follow-up to [CHAOS-1775](https://linear.app/fullchaos/issue/CHAOS-1775) / [#775](https://github.com/full-chaos/dev-health-ops/pull/775).

The write-side fix in #775 stopped `insert_repo` from stranding `org_id` on existing rows, but pre-existing deployments still carry the orphan rows that the bug created (same `id`, different `org_id`). They're harmless — a non-existent tenant cannot read them — but they clutter the `repos` table and are confusing during ad-hoc inspection.

This PR adds `dev-hops migrate clickhouse repair` to clean them up.

Closes CHAOS-1776.

## CLI

```bash
# Dry-run (default): print every orphan across all tenants.
dev-hops migrate clickhouse repair

# Actually delete them.
dev-hops migrate clickhouse repair --apply

# Scope to a specific active tenant (other tenants' orphans untouched).
dev-hops migrate clickhouse repair --apply --org <uuid>
```

## Detection

Per `id`, the row with the newest `last_synced` is the active tenant. Any other `(id, org_id)` row for that same `id` is an orphan:

```sql
WITH latest AS (
    SELECT id,
           argMax(org_id, last_synced) AS active_org_id,
           max(last_synced) AS active_last_synced
    FROM repos
    GROUP BY id
    HAVING uniqExact(org_id) > 1
)
SELECT ... FROM repos r INNER JOIN latest l ON r.id = l.id
WHERE r.org_id != l.active_org_id
```

Apply path issues `ALTER TABLE repos DELETE WHERE id = X AND org_id = stale SETTINGS mutations_sync=2` per orphan so the caller waits for the mutation to land.

## Tests

`tests/test_migrate_commands.py::TestClickhouseRepair` (6 new tests) covers:
- Routing for `repair`, `repair --apply`, `repair --apply --org <x>`
- No-orphans path: clean message, no `DELETE` issued
- Dry-run path: orphans printed, no `DELETE` issued
- Apply path: one `DELETE` per orphan with the right `(id, org_id)` parameters and `mutations_sync=2`
- `--org` filter: detection SQL gets the `AND l.active_org_id = {active_org:String}` clause and the parameter is passed
- Failure path: `client.close()` always called

`pytest tests/test_migrate_commands.py tests/test_migrate.py tests/test_storage.py` → **104 passed**.

`ruff check`, `ruff format --check`, `mypy src/dev_health_ops/migrate.py` all clean.

## Verified end-to-end on the local stack

The 4 stranded `acme/demo-app-*` rows from the CHAOS-1775 investigation were left in place specifically to drive this verification.

```
$ dev-hops migrate clickhouse repair
Found 4 stale-tenant orphan row(s) in repos:

  repo               stale_org_id                          active_org_id                         stale_last_synced
  acme/demo-app-1    ae600a94-76bc-4166-bf36-051ee4247c73  900f96be-804c-42fb-9e93-de73c499a22d  2026-05-21 19:31:02.552
  acme/demo-app-2    ae600a94-76bc-4166-bf36-051ee4247c73  900f96be-804c-42fb-9e93-de73c499a22d  2026-05-21 19:31:12.847
  acme/demo-app-3    ae600a94-76bc-4166-bf36-051ee4247c73  900f96be-804c-42fb-9e93-de73c499a22d  2026-05-21 19:31:23.205
  acme/demo-app-4    ae600a94-76bc-4166-bf36-051ee4247c73  900f96be-804c-42fb-9e93-de73c499a22d  2026-05-21 19:31:33.024

Dry-run: pass --apply to delete these orphan rows.

$ dev-hops migrate clickhouse repair --apply
... Deleted 4 stale-tenant row(s) from repos.

$ dev-hops migrate clickhouse repair
No stale-tenant orphans found in repos.
```

Active-tenant `/security` KPIs unchanged after repair: `open_total=35, critical=2, high=6` (identical to the post-CHAOS-1775 baseline).

## SCREENSHOT-WAIVER

CLI/migrate-only change. No GraphQL schema change, no resolver change, no rendered output in `dev-health-web`.
