### PR TITLE
docs(ops): correct gh pr create PR-creation flow — --head does NOT auto-push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,19 +32,17 @@ This file is intentionally short. The canonical instructions live in the MkDocs 
 ## GitHub PR workflow override
 
 - Use the `github-gh` skill for GitHub operations.
-- Prefer `gh pr create --fill` or `gh pct --fill` for unpublished branches; `--fill` lets GitHub CLI derive the title/body from commits and push the branch as part of PR creation.
-- If you need a custom title/body, use `--fill` first and then edit the PR with `gh pr edit` rather than omitting `--fill` on an unpublished branch.
-- If PR creation still reports that the branch must be pushed first, push with an explicit refspec and retry with `--head`:
+- **Push the branch first, then create the PR with `--head <branch>`.** In non-interactive contexts (agents, CI) `gh pr create` will NOT push the branch for you. `--head` does NOT auto-push either — per the gh docs, it "explicitly skip[s] any forking or pushing behavior." The error message `you must first push the current branch to a remote, or use the --head flag` is misleading; `--head` only suppresses the interactive push prompt and still requires the branch to be on remote.
+- Canonical sequence:
 
   ```bash
-  gh pct --fill --base main
-
-  # Fallback only when --fill still cannot publish the branch:
   GIT_MASTER=1 git push origin <branch>:<branch>
-  gh pct "<title>" --base main --head <branch> --body "..."
+  gh pr create --head <branch> --title "<title>" --body "<body>" --base main
   ```
 
-- Never use a bare `git push` from a worktree; worktree upstreams can point at `main` and trigger branch-protection failures.
+  - `--fill` (derives title/body from commits) is independent of pushing — still push first: `git push origin <branch>:<branch> && gh pr create --head <branch> --fill --base main`.
+- Prefer `gh pr create ...` over the `gh pct` alias in agent contexts. `pct` resolves to `gh pr create -t`, which then collides on argument parsing when you also pass `--head` or `--title` after it.
+- Never use a bare `git push` from a worktree; worktree upstreams can point at `main` and trigger branch-protection failures. The explicit refspec form (`git push origin <branch>:<branch>`) bypasses this.
 
 ## Provider boundary
 - New provider integrations live under `src/dev_health_ops/providers/<provider>/`.


### PR DESCRIPTION
## Summary

Corrects the `GitHub PR workflow override` section of `ops/AGENTS.md`. An earlier draft of this PR (and a transient suggestion that triggered this change) claimed `--head <branch>` makes `gh pr create` auto-push the branch. **That is empirically false.**

Per gh's own help text:

> "Use `--head` to explicitly skip any forking or pushing behavior."

`--head` only silences the interactive push prompt that gh shows in a TTY when the branch isn't on remote, and lets you name the head branch explicitly. It still requires the branch to be on remote.

## Empirical verification while shipping this PR

| Attempt | Result |
|---|---|
| `gh pr create --head docs/gh-pct-head-flag --title … --body …` (branch not pushed) | ❌ `pull request create failed: GraphQL: Head sha can't be blank, Base sha can't be blank, No commits between main and docs/gh-pct-head-flag, Head ref must be a branch` |
| `git push origin docs/gh-pct-head-flag:docs/gh-pct-head-flag` | ✅ branch published |
| `gh pr create --head docs/gh-pct-head-flag --title … --body …` (branch on remote) | ✅ PR created (this one) |

The misleading gh error message `you must first push the current branch to a remote, or use the --head flag` is what made the false claim plausible. It reads as if `--head` is an alternative to pushing — it isn't.

## Changes to `ops/AGENTS.md`

- Lead with **"Push the branch first, then create the PR with `--head <branch>`"** as the canonical sequence.
- Quote the gh docs directly so future readers don't repeat the same misunderstanding.
- Add a note about the `gh pct` alias gotcha: `pct` resolves to `gh pr create -t`, which collides on argument parsing when followed by `--head` or `--title`. Prefer `gh pr create ...` in agent contexts.
- Keep the worktree warning and explicit-refspec rationale intact.

## Companion changes (not in this PR — agent-local docs, not in any git repo)

- `/Users/chris/projects/full-chaos/dev-health/AGENTS.md` — updated to match.
- `/Users/chris/projects/full-chaos/dev-health/CLAUDE.md` — updated to match.

TEST-WAIVER: Docs-only change, no code or test surface modified.