### PR TITLE
docs(agents): rename `linear` CLI references to `linear-cli`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,11 +385,11 @@ If a `dev-health-ops` change affects `dev-health-web` rendering (e.g., API shape
 ### Quick Reference
 
 ```bash
-linear issues create "Task title" --team CHAOS --priority high
-linear issues list
-linear issues get CHAOS-123
-linear issues update CHAOS-123 --state "In Progress"
-linear issues update CHAOS-123 --state "Done"
+linear-cli issues create "Task title" --team CHAOS --priority high
+linear-cli issues list
+linear-cli issues get CHAOS-123
+linear-cli issues update CHAOS-123 --state "In Progress"
+linear-cli issues update CHAOS-123 --state "Done"
 ```
 
 ---

--- a/docs/plans/code-review-action-plan-2026-05-17.md
+++ b/docs/plans/code-review-action-plan-2026-05-17.md
@@ -219,7 +219,7 @@ These were flagged in the review but couldn't be conclusively resolved without l
 
 - **First pass** (Sisyphus direct, grep + Read + LSP): 15 findings → CHAOS-1535 to CHAOS-1549.
 - **Deep dive** (Sisyphus direct, after 4 oracle agent attempts had output lost): 6 NEW findings → CHAOS-1550 to CHAOS-1555.
-- Tickets created via `linear i create` against the `CHAOS` team. All start in `Backlog` state, unassigned.
+- Tickets created via `linear-cli i create` against the `CHAOS` team. All start in `Backlog` state, unassigned.
 - No source files were modified during this review.
 
 ### Where this came from in the codebase


### PR DESCRIPTION
## Summary

The CLI binary is `linear-cli`, not `linear`. Multiple agent-procedural docs assumed a bare `linear` invocation which fails with **"command not found"** on every install. This is the ops-side cleanup; a companion change in `dev-health-web` covers the web-side AGENTS.md and adds a new canonical agent visual-testing procedure.

## Changes

- `AGENTS.md` — 5 task-tracking command examples in the Linear section
- `docs/plans/code-review-action-plan-2026-05-17.md` — 1 procedural mention

```diff
- linear issues create "Task title" --team CHAOS --priority high
+ linear-cli issues create "Task title" --team CHAOS --priority high

- linear issues list
+ linear-cli issues list

# etc.
```

## Preserved (correctly NOT renamed)

- `LINEAR_API_KEY` env var
- `--provider linear` (provider ID, not CLI command)
- `Linear MCP tools` (product name)
- `linear-mcp`, `linear-gradient` (CSS), `/linear` (opencode slash command)
- `task-tracking-github-or-linear` (anchor link in canonical-reference back-pointer)
- Linear-the-product references in prose

## Verification

```bash
# Bare linear-CLI invocations remaining (must be empty):
rg '\blinear\s+(issues|i|skills|attachments|--help)' AGENTS.md docs/plans/code-review-action-plan-2026-05-17.md
# → no output
```

## Type

Documentation only. No behavior changes.

`SCREENSHOT-WAIVER`: documentation-only change, no rendered output affected.
`TEST-WAIVER`: documentation-only change, no code under `src/` touched.