### PR TITLE
feat(api): derive backlog + allow org-wide throughput forecast (CHAOS-1783)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/inputs.py
+++ b/src/dev_health_ops/api/graphql/models/inputs.py
@@ -319,11 +319,21 @@ class CapacityForecastFilterInput:
 
 @strawberry.input
 class ThroughputForecastInput:
-    """Input for throughput-based capacity forecast computation."""
+    """Input for throughput-based capacity forecast computation.
 
-    team_id: str
+    ``team_id`` is optional: when omitted, the forecast aggregates org-wide
+    across all teams (CHAOS-1783). When provided, the forecast is scoped to
+    that single team.
+
+    ``backlog_size`` is optional: when omitted, the resolver derives the
+    backlog from the latest ``work_item_metrics_daily`` rows that match the
+    same scope (CHAOS-1783). Callers may still pass an explicit value to
+    forecast hypothetical backlogs.
+    """
+
+    team_id: str | None = None
     work_scope_id: str | None = None
-    backlog_size: int
+    backlog_size: int | None = None
     history_weeks: int = 12
 
 

--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -475,11 +475,15 @@ class ThroughputRiskOverlay:
 
 @strawberry.type
 class ThroughputForecast:
-    """Throughput-based capacity forecast result."""
+    """Throughput-based capacity forecast result.
+
+    ``team_id`` is null when the forecast is computed org-wide (no team
+    scope; CHAOS-1783).
+    """
 
     forecast_id: str
     computed_at: str
-    team_id: str
+    team_id: str | None = None
     work_scope_id: str | None = None
     backlog_size: int
     history_weeks: int

--- a/src/dev_health_ops/api/graphql/resolvers/forecast.py
+++ b/src/dev_health_ops/api/graphql/resolvers/forecast.py
@@ -36,8 +36,6 @@ def _risk_to_output(risk: RiskOverlay) -> ThroughputRiskOverlay:
 
 
 def _result_to_output(result: ThroughputForecastResult) -> ThroughputForecast:
-    if result.team_id is None:
-        raise ValueError("team_id is required for throughput forecasts")
     return ThroughputForecast(
         forecast_id=result.forecast_id,
         computed_at=result.computed_at.isoformat(),
@@ -68,17 +66,19 @@ def _result_to_output(result: ThroughputForecastResult) -> ThroughputForecast:
 async def _load_throughput_history(
     context: GraphQLContext,
     *,
-    team_id: str,
+    team_id: str | None,
     work_scope_id: str | None,
     history_weeks: int,
 ) -> ThroughputHistory:
     start_date = utc_today() - timedelta(weeks=history_weeks)
-    conditions = ["day >= {start_date:Date}", "team_id = {team_id:String}"]
+    conditions = ["day >= {start_date:Date}"]
     params: dict[str, Any] = {
         "start_date": start_date,
-        "team_id": team_id,
         "org_id": context.org_id,
     }
+    if team_id:
+        conditions.append("team_id = {team_id:String}")
+        params["team_id"] = team_id
     if work_scope_id:
         conditions.append("work_scope_id = {work_scope_id:String}")
         params["work_scope_id"] = work_scope_id
@@ -121,17 +121,19 @@ async def _load_throughput_history(
 async def _load_work_item_overlay(
     context: GraphQLContext,
     *,
-    team_id: str,
+    team_id: str | None,
     work_scope_id: str | None,
     history_weeks: int,
 ) -> tuple[float, float]:
     start_date = utc_today() - timedelta(weeks=history_weeks)
-    conditions = ["day >= {start_date:Date}", "team_id = {team_id:String}"]
+    conditions = ["day >= {start_date:Date}"]
     params: dict[str, Any] = {
         "start_date": start_date,
-        "team_id": team_id,
         "org_id": context.org_id,
     }
+    if team_id:
+        conditions.append("team_id = {team_id:String}")
+        params["team_id"] = team_id
     if work_scope_id:
         conditions.append("work_scope_id = {work_scope_id:String}")
         params["work_scope_id"] = work_scope_id
@@ -192,6 +194,53 @@ async def _load_review_overlay(
     return float((rows[0] if rows else {}).get("review_latency_hours") or 0.0)
 
 
+async def _load_backlog(
+    context: GraphQLContext,
+    *,
+    team_id: str | None,
+    work_scope_id: str | None,
+) -> int:
+    """Derive backlog size from latest ``work_item_metrics_daily`` rows.
+
+    Sums ``wip_count_end_of_day`` across the latest day for every team and
+    scope partition that matches the filter. When ``team_id`` is None this
+    yields an org-wide rollup; when set, it yields the team's backlog.
+    Mirrors the contract of ``metrics.job_capacity.get_backlog_from_sink``
+    but corrects its all-teams aggregation (CHAOS-1783).
+    """
+    conditions: list[str] = []
+    params: dict[str, Any] = {"org_id": context.org_id}
+    if team_id:
+        conditions.append("team_id = {team_id:String}")
+        params["team_id"] = team_id
+    if work_scope_id:
+        conditions.append("work_scope_id = {work_scope_id:String}")
+        params["work_scope_id"] = work_scope_id
+    where_sql = (" WHERE " + " AND ".join(conditions)) if conditions else ""
+
+    rows = await query_dicts(
+        context.client,
+        f"""
+        SELECT sum(wip_count_end_of_day) AS backlog
+        FROM (
+            SELECT
+                team_id,
+                work_scope_id,
+                provider,
+                argMax(wip_count_end_of_day, computed_at) AS wip_count_end_of_day
+            FROM work_item_metrics_daily
+            WHERE day = (
+                SELECT max(day) FROM work_item_metrics_daily{where_sql}
+            )
+            {("AND " + " AND ".join(conditions)) if conditions else ""}
+            GROUP BY team_id, work_scope_id, provider
+        )
+        """,
+        params,
+    )
+    return int((rows[0] if rows else {}).get("backlog") or 0)
+
+
 async def _load_incident_overlay(
     context: GraphQLContext,
     *,
@@ -249,9 +298,16 @@ async def resolve_throughput_forecast(
         context,
         history_weeks=input.history_weeks,
     )
+    backlog_size = input.backlog_size
+    if backlog_size is None:
+        backlog_size = await _load_backlog(
+            context,
+            team_id=input.team_id,
+            work_scope_id=input.work_scope_id,
+        )
     result = forecast_throughput_capacity(
         history=history,
-        backlog_size=input.backlog_size,
+        backlog_size=backlog_size,
         team_id=input.team_id,
         work_scope_id=input.work_scope_id,
         history_weeks=input.history_weeks,

--- a/tests/api/graphql/test_throughput_forecast_resolver.py
+++ b/tests/api/graphql/test_throughput_forecast_resolver.py
@@ -1,0 +1,220 @@
+"""Tests for the throughput-forecast GraphQL resolver (CHAOS-1783).
+
+Covers two behaviours added by the capacity-planning UX fix:
+
+* When ``ThroughputForecastInput.team_id`` is ``None`` the resolver
+  aggregates org-wide instead of falling back to sample data.
+* When ``ThroughputForecastInput.backlog_size`` is ``None`` the resolver
+  derives the backlog from the latest ``work_item_metrics_daily`` rows
+  matching the same scope.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dev_health_ops.metrics.compute_capacity import ThroughputHistory, ThroughputSample
+from dev_health_ops.metrics.forecast import (
+    RiskKind,
+    RiskOverlay,
+    RollingWindowThroughput,
+    ThroughputForecastResult,
+)
+
+strawberry = pytest.importorskip("strawberry")
+
+
+def _risk(kind: RiskKind) -> RiskOverlay:
+    return RiskOverlay(
+        kind=kind,
+        score=0.0,
+        label=kind.value,
+        value=0.0,
+        threshold=1.0,
+        active=False,
+    )
+
+
+def _result(team_id: str | None, backlog_size: int) -> ThroughputForecastResult:
+    return ThroughputForecastResult(
+        forecast_id="forecast-123",
+        computed_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+        team_id=team_id,
+        work_scope_id=None,
+        backlog_size=backlog_size,
+        history_weeks=12,
+        p50_weeks=4,
+        p75_weeks=6,
+        p90_weeks=8,
+        rolling_windows=(
+            RollingWindowThroughput(
+                window_weeks=4,
+                mean_weekly_throughput=8.0,
+                samples=(8.0,),
+                insufficient_history=False,
+            ),
+        ),
+        primary_risk=_risk(RiskKind.REVIEW),
+        wip_congestion=_risk(RiskKind.WIP),
+        review_bottleneck=_risk(RiskKind.REVIEW),
+        incident_load=_risk(RiskKind.INCIDENT),
+        insufficient_history=False,
+    )
+
+
+@pytest.fixture
+def ctx():
+    c = MagicMock()
+    c.org_id = "test-org"
+    c.client = MagicMock()
+    return c
+
+
+@pytest.mark.asyncio
+async def test_resolver_aggregates_org_wide_when_team_id_is_none(ctx):
+    """``team_id=None`` must NOT short-circuit to None or sample data."""
+    from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
+    from dev_health_ops.api.graphql.resolvers.forecast import (
+        resolve_throughput_forecast,
+    )
+
+    history = ThroughputHistory(
+        [
+            ThroughputSample(
+                day=date(2026, 5, i + 1),
+                items_completed=5,
+                team_id=None,
+                work_scope_id=None,
+            )
+            for i in range(14)
+        ]
+    )
+
+    fake_result = _result(team_id=None, backlog_size=42)
+
+    with (
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_throughput_history",
+            new_callable=AsyncMock,
+            return_value=history,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_work_item_overlay",
+            new_callable=AsyncMock,
+            return_value=(0.0, 0.0),
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_review_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_incident_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_backlog",
+            new_callable=AsyncMock,
+            return_value=42,
+        ) as load_backlog,
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast.forecast_throughput_capacity",
+            return_value=fake_result,
+        ),
+    ):
+        result = await resolve_throughput_forecast(
+            ctx,
+            ThroughputForecastInput(),  # no team_id, no backlog_size
+        )
+
+    assert result is not None
+    assert result.team_id is None
+    assert result.backlog_size == 42
+    load_backlog.assert_awaited_once_with(ctx, team_id=None, work_scope_id=None)
+
+
+@pytest.mark.asyncio
+async def test_resolver_skips_backlog_query_when_caller_provides_size(ctx):
+    """Explicit ``backlog_size`` must bypass ``_load_backlog``."""
+    from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
+    from dev_health_ops.api.graphql.resolvers.forecast import (
+        resolve_throughput_forecast,
+    )
+
+    history = ThroughputHistory(
+        [
+            ThroughputSample(
+                day=date(2026, 5, i + 1),
+                items_completed=3,
+                team_id="team-a",
+                work_scope_id=None,
+            )
+            for i in range(14)
+        ]
+    )
+
+    fake_result = _result(team_id="team-a", backlog_size=99)
+
+    with (
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_throughput_history",
+            new_callable=AsyncMock,
+            return_value=history,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_work_item_overlay",
+            new_callable=AsyncMock,
+            return_value=(0.0, 0.0),
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_review_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_incident_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_backlog",
+            new_callable=AsyncMock,
+        ) as load_backlog,
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast.forecast_throughput_capacity",
+            return_value=fake_result,
+        ),
+    ):
+        result = await resolve_throughput_forecast(
+            ctx, ThroughputForecastInput(team_id="team-a", backlog_size=99)
+        )
+
+    assert result is not None
+    assert result.team_id == "team-a"
+    assert result.backlog_size == 99
+    load_backlog.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_load_backlog_sums_across_partitions_when_team_id_is_none(ctx):
+    """``_load_backlog`` must aggregate the latest day across all teams."""
+    from dev_health_ops.api.graphql.resolvers.forecast import _load_backlog
+
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.forecast.query_dicts",
+        new_callable=AsyncMock,
+        return_value=[{"backlog": 137}],
+    ) as query:
+        backlog = await _load_backlog(ctx, team_id=None, work_scope_id=None)
+
+    assert backlog == 137
+    # No team_id / work_scope_id should appear in params when both are None.
+    call_args = query.await_args
+    assert call_args is not None
+    params = call_args.args[2]
+    assert "team_id" not in params
+    assert "work_scope_id" not in params


### PR DESCRIPTION
## Why

The `/capacity-planning` GraphQL surface required both `teamId` (non-null) and `backlogSize` (non-null) on `ThroughputForecastInput`. The frontend's default scope is "All Teams" (no team), so the page silently fell back to a hardcoded `SAMPLE_FORECAST` constant with a yellow "Showing sample data" banner. The user was also forced to type a backlog number disconnected from the filter bar (the sibling Monte Carlo resolver already derives backlog via `get_backlog_from_sink`).

## What

- `ThroughputForecastInput.team_id` is now `Optional[str]`; when `None`, the resolver aggregates across all teams.
- `ThroughputForecastInput.backlog_size` is now `Optional[int]`; when `None`, the resolver derives it from the latest `work_item_metrics_daily` rows matching the same scope.
- New `_load_backlog` helper sums `wip_count_end_of_day` across partitions on the latest day — correct for the all-teams case (unlike `metrics.job_capacity.get_backlog_from_sink`, which `LIMIT 1`s and only returns one team's row).
- `_load_throughput_history` and `_load_work_item_overlay` drop the `team_id` `WHERE` clause when `team_id is None`.
- `ThroughputForecast.team_id` is now nullable.
- Drops the unused `team_id is required` guard in `_result_to_output`.

## Test

New `tests/api/graphql/test_throughput_forecast_resolver.py`:

- `test_resolver_aggregates_org_wide_when_team_id_is_none` — covers the All-Teams happy path (`ThroughputForecastInput()` with no args).
- `test_resolver_skips_backlog_query_when_caller_provides_size` — confirms explicit `backlog_size` bypasses derivation.
- `test_load_backlog_sums_across_partitions_when_team_id_is_none` — verifies the `_load_backlog` helper omits team/scope params when None.

```
15 passed, 34 warnings in 1.24s
```

ruff format + ruff check clean on changed files.

Manual end-to-end QA was done against a worktree dev server + worktree api with real fixture data: All-Teams scope rendered backlog = 164 / P50 = 4w; team-1 scope rendered backlog = 40 / P50 = 5w. Screenshots are attached to the companion web PR.

## Linked

- Closes CHAOS-1783
- Companion frontend PR: full-chaos/dev-health-web#540
- Related: CHAOS-1759 (Capacity filter chrome, Done), CHAOS-1761 (Cross-page UX review, Done) — both prior passes addressed chrome, not the IA issues fixed here.

SCREENSHOT-WAIVER: backend-only; visual evidence lives on full-chaos/dev-health-web#540.
