### PR TITLE
fix(api): aggregate throughput forecast across multiple selected teams (CHAOS-1784)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/inputs.py
+++ b/src/dev_health_ops/api/graphql/models/inputs.py
@@ -321,17 +321,18 @@ class CapacityForecastFilterInput:
 class ThroughputForecastInput:
     """Input for throughput-based capacity forecast computation.
 
-    ``team_id`` is optional: when omitted, the forecast aggregates org-wide
-    across all teams (CHAOS-1783). When provided, the forecast is scoped to
-    that single team.
+    ``team_ids`` is optional: when omitted or empty, the forecast aggregates
+    org-wide across all teams. When one or more team ids are supplied, the
+    forecast is scoped to that combined selection — backlog and throughput
+    are summed across the selected teams (CHAOS-1783 multi-team follow-up).
 
     ``backlog_size`` is optional: when omitted, the resolver derives the
     backlog from the latest ``work_item_metrics_daily`` rows that match the
-    same scope (CHAOS-1783). Callers may still pass an explicit value to
-    forecast hypothetical backlogs.
+    same scope. Callers may still pass an explicit value to forecast
+    hypothetical backlogs.
     """
 
-    team_id: str | None = None
+    team_ids: list[str] | None = None
     work_scope_id: str | None = None
     backlog_size: int | None = None
     history_weeks: int = 12

--- a/src/dev_health_ops/api/graphql/resolvers/forecast.py
+++ b/src/dev_health_ops/api/graphql/resolvers/forecast.py
@@ -63,10 +63,30 @@ def _result_to_output(result: ThroughputForecastResult) -> ThroughputForecast:
     )
 
 
+def _team_filter(
+    team_ids: list[str] | None,
+    conditions: list[str],
+    params: dict[str, Any],
+) -> None:
+    """Append a team_id IN / = clause when ``team_ids`` is non-empty.
+
+    Mutates ``conditions`` and ``params`` in place to keep the call sites
+    terse. Empty/None means "no team filter" (org-wide).
+    """
+    if not team_ids:
+        return
+    if len(team_ids) == 1:
+        conditions.append("team_id = {team_id:String}")
+        params["team_id"] = team_ids[0]
+    else:
+        conditions.append("team_id IN {team_ids:Array(String)}")
+        params["team_ids"] = list(team_ids)
+
+
 async def _load_throughput_history(
     context: GraphQLContext,
     *,
-    team_id: str | None,
+    team_ids: list[str] | None,
     work_scope_id: str | None,
     history_weeks: int,
 ) -> ThroughputHistory:
@@ -76,9 +96,7 @@ async def _load_throughput_history(
         "start_date": start_date,
         "org_id": context.org_id,
     }
-    if team_id:
-        conditions.append("team_id = {team_id:String}")
-        params["team_id"] = team_id
+    _team_filter(team_ids, conditions, params)
     if work_scope_id:
         conditions.append("work_scope_id = {work_scope_id:String}")
         params["work_scope_id"] = work_scope_id
@@ -103,6 +121,9 @@ async def _load_throughput_history(
         """,
         params,
     )
+    # Result's per-sample team_id is informational only — for multi-team or
+    # all-teams scopes it stays None.
+    sample_team_id = team_ids[0] if team_ids and len(team_ids) == 1 else None
     return ThroughputHistory(
         [
             ThroughputSample(
@@ -110,7 +131,7 @@ async def _load_throughput_history(
                 if isinstance(row["day"], date)
                 else date.fromisoformat(str(row["day"])),
                 items_completed=int(row.get("items_completed") or 0),
-                team_id=team_id,
+                team_id=sample_team_id,
                 work_scope_id=work_scope_id,
             )
             for row in rows
@@ -121,7 +142,7 @@ async def _load_throughput_history(
 async def _load_work_item_overlay(
     context: GraphQLContext,
     *,
-    team_id: str | None,
+    team_ids: list[str] | None,
     work_scope_id: str | None,
     history_weeks: int,
 ) -> tuple[float, float]:
@@ -131,9 +152,7 @@ async def _load_work_item_overlay(
         "start_date": start_date,
         "org_id": context.org_id,
     }
-    if team_id:
-        conditions.append("team_id = {team_id:String}")
-        params["team_id"] = team_id
+    _team_filter(team_ids, conditions, params)
     if work_scope_id:
         conditions.append("work_scope_id = {work_scope_id:String}")
         params["work_scope_id"] = work_scope_id
@@ -197,22 +216,20 @@ async def _load_review_overlay(
 async def _load_backlog(
     context: GraphQLContext,
     *,
-    team_id: str | None,
+    team_ids: list[str] | None,
     work_scope_id: str | None,
 ) -> int:
     """Derive backlog size from latest ``work_item_metrics_daily`` rows.
 
     Sums ``wip_count_end_of_day`` across the latest day for every team and
-    scope partition that matches the filter. When ``team_id`` is None this
-    yields an org-wide rollup; when set, it yields the team's backlog.
-    Mirrors the contract of ``metrics.job_capacity.get_backlog_from_sink``
-    but corrects its all-teams aggregation (CHAOS-1783).
+    scope partition that matches the filter. With no team filter this
+    yields an org-wide rollup; with one team it yields that team's
+    backlog; with multiple teams it sums their backlogs (CHAOS-1783
+    multi-team follow-up).
     """
     conditions: list[str] = []
     params: dict[str, Any] = {"org_id": context.org_id}
-    if team_id:
-        conditions.append("team_id = {team_id:String}")
-        params["team_id"] = team_id
+    _team_filter(team_ids, conditions, params)
     if work_scope_id:
         conditions.append("work_scope_id = {work_scope_id:String}")
         params["work_scope_id"] = work_scope_id
@@ -275,9 +292,15 @@ async def resolve_throughput_forecast(
     if context.client is None:
         raise RuntimeError("Database client not available")
 
+    # Single-team scopes still set team_id on the result so the UI can
+    # display the scope; multi-team and all-teams scopes leave it None.
+    result_team_id = (
+        input.team_ids[0] if input.team_ids and len(input.team_ids) == 1 else None
+    )
+
     history = await _load_throughput_history(
         context,
-        team_id=input.team_id,
+        team_ids=input.team_ids,
         work_scope_id=input.work_scope_id,
         history_weeks=input.history_weeks,
     )
@@ -286,7 +309,7 @@ async def resolve_throughput_forecast(
 
     current_wip, average_wip = await _load_work_item_overlay(
         context,
-        team_id=input.team_id,
+        team_ids=input.team_ids,
         work_scope_id=input.work_scope_id,
         history_weeks=input.history_weeks,
     )
@@ -302,13 +325,13 @@ async def resolve_throughput_forecast(
     if backlog_size is None:
         backlog_size = await _load_backlog(
             context,
-            team_id=input.team_id,
+            team_ids=input.team_ids,
             work_scope_id=input.work_scope_id,
         )
     result = forecast_throughput_capacity(
         history=history,
         backlog_size=backlog_size,
-        team_id=input.team_id,
+        team_id=result_team_id,
         work_scope_id=input.work_scope_id,
         history_weeks=input.history_weeks,
         current_wip=current_wip,

--- a/tests/api/graphql/sql_explain_fixtures.py
+++ b/tests/api/graphql/sql_explain_fixtures.py
@@ -119,26 +119,26 @@ async def _fixture_forecast(sink: CapturingSink) -> None:
     # Without work_scope_id.
     await _load_throughput_history(
         context,
-        team_id=SAMPLE_TEAM_ID,
+        team_ids=[SAMPLE_TEAM_ID],
         work_scope_id=None,
         history_weeks=history_weeks,
     )
     await _load_work_item_overlay(
         context,
-        team_id=SAMPLE_TEAM_ID,
+        team_ids=[SAMPLE_TEAM_ID],
         work_scope_id=None,
         history_weeks=history_weeks,
     )
     # With work_scope_id branch.
     await _load_throughput_history(
         context,
-        team_id=SAMPLE_TEAM_ID,
+        team_ids=[SAMPLE_TEAM_ID],
         work_scope_id="scope-1",
         history_weeks=history_weeks,
     )
     await _load_work_item_overlay(
         context,
-        team_id=SAMPLE_TEAM_ID,
+        team_ids=[SAMPLE_TEAM_ID],
         work_scope_id="scope-1",
         history_weeks=history_weeks,
     )

--- a/tests/api/graphql/test_throughput_forecast_resolver.py
+++ b/tests/api/graphql/test_throughput_forecast_resolver.py
@@ -1,9 +1,12 @@
 """Tests for the throughput-forecast GraphQL resolver (CHAOS-1783).
 
-Covers two behaviours added by the capacity-planning UX fix:
+Covers behaviours added by the capacity-planning UX fix:
 
-* When ``ThroughputForecastInput.team_id`` is ``None`` the resolver
-  aggregates org-wide instead of falling back to sample data.
+* When ``ThroughputForecastInput.team_ids`` is ``None`` or empty the
+  resolver aggregates org-wide instead of falling back to sample data.
+* When ``team_ids`` contains multiple ids the resolver aggregates across
+  the selected teams (single team scopes are a special case of the
+  multi-team path).
 * When ``ThroughputForecastInput.backlog_size`` is ``None`` the resolver
   derives the backlog from the latest ``work_item_metrics_daily`` rows
   matching the same scope.
@@ -65,6 +68,20 @@ def _result(team_id: str | None, backlog_size: int) -> ThroughputForecastResult:
     )
 
 
+def _history(team_id: str | None = None) -> ThroughputHistory:
+    return ThroughputHistory(
+        [
+            ThroughputSample(
+                day=date(2026, 5, i + 1),
+                items_completed=5,
+                team_id=team_id,
+                work_scope_id=None,
+            )
+            for i in range(14)
+        ]
+    )
+
+
 @pytest.fixture
 def ctx():
     c = MagicMock()
@@ -74,32 +91,18 @@ def ctx():
 
 
 @pytest.mark.asyncio
-async def test_resolver_aggregates_org_wide_when_team_id_is_none(ctx):
-    """``team_id=None`` must NOT short-circuit to None or sample data."""
+async def test_resolver_aggregates_org_wide_when_team_ids_is_none(ctx):
+    """``team_ids=None`` must NOT short-circuit to None or sample data."""
     from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
     from dev_health_ops.api.graphql.resolvers.forecast import (
         resolve_throughput_forecast,
     )
 
-    history = ThroughputHistory(
-        [
-            ThroughputSample(
-                day=date(2026, 5, i + 1),
-                items_completed=5,
-                team_id=None,
-                work_scope_id=None,
-            )
-            for i in range(14)
-        ]
-    )
-
-    fake_result = _result(team_id=None, backlog_size=42)
-
     with (
         patch(
             "dev_health_ops.api.graphql.resolvers.forecast._load_throughput_history",
             new_callable=AsyncMock,
-            return_value=history,
+            return_value=_history(),
         ),
         patch(
             "dev_health_ops.api.graphql.resolvers.forecast._load_work_item_overlay",
@@ -123,18 +126,122 @@ async def test_resolver_aggregates_org_wide_when_team_id_is_none(ctx):
         ) as load_backlog,
         patch(
             "dev_health_ops.api.graphql.resolvers.forecast.forecast_throughput_capacity",
-            return_value=fake_result,
+            return_value=_result(team_id=None, backlog_size=42),
         ),
     ):
-        result = await resolve_throughput_forecast(
-            ctx,
-            ThroughputForecastInput(),  # no team_id, no backlog_size
-        )
+        result = await resolve_throughput_forecast(ctx, ThroughputForecastInput())
 
     assert result is not None
     assert result.team_id is None
     assert result.backlog_size == 42
-    load_backlog.assert_awaited_once_with(ctx, team_id=None, work_scope_id=None)
+    load_backlog.assert_awaited_once_with(ctx, team_ids=None, work_scope_id=None)
+
+
+@pytest.mark.asyncio
+async def test_resolver_aggregates_multi_team_selection(ctx):
+    """Multi-team ``team_ids`` must NOT collapse to one team's data."""
+    from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
+    from dev_health_ops.api.graphql.resolvers.forecast import (
+        resolve_throughput_forecast,
+    )
+
+    with (
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_throughput_history",
+            new_callable=AsyncMock,
+            return_value=_history(),
+        ) as load_history,
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_work_item_overlay",
+            new_callable=AsyncMock,
+            return_value=(0.0, 0.0),
+        ) as load_wip,
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_review_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_incident_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_backlog",
+            new_callable=AsyncMock,
+            return_value=84,
+        ) as load_backlog,
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast.forecast_throughput_capacity",
+            return_value=_result(team_id=None, backlog_size=84),
+        ),
+    ):
+        result = await resolve_throughput_forecast(
+            ctx,
+            ThroughputForecastInput(team_ids=["team-1", "team-2"]),
+        )
+
+    assert result is not None
+    # Multi-team scope: result's team_id stays None (aggregated across teams).
+    assert result.team_id is None
+    assert result.backlog_size == 84
+    # Every loader receives the FULL list, not just the first id.
+    load_history.assert_awaited_once_with(
+        ctx, team_ids=["team-1", "team-2"], work_scope_id=None, history_weeks=12
+    )
+    load_wip.assert_awaited_once_with(
+        ctx, team_ids=["team-1", "team-2"], work_scope_id=None, history_weeks=12
+    )
+    load_backlog.assert_awaited_once_with(
+        ctx, team_ids=["team-1", "team-2"], work_scope_id=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolver_single_team_sets_result_team_id(ctx):
+    """Single-team scope echoes the team id back on the result."""
+    from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
+    from dev_health_ops.api.graphql.resolvers.forecast import (
+        resolve_throughput_forecast,
+    )
+
+    with (
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_throughput_history",
+            new_callable=AsyncMock,
+            return_value=_history(team_id="team-a"),
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_work_item_overlay",
+            new_callable=AsyncMock,
+            return_value=(0.0, 0.0),
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_review_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_incident_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_backlog",
+            new_callable=AsyncMock,
+            return_value=40,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast.forecast_throughput_capacity",
+            return_value=_result(team_id="team-a", backlog_size=40),
+        ),
+    ):
+        result = await resolve_throughput_forecast(
+            ctx, ThroughputForecastInput(team_ids=["team-a"])
+        )
+
+    assert result is not None
+    assert result.team_id == "team-a"
 
 
 @pytest.mark.asyncio
@@ -145,25 +252,11 @@ async def test_resolver_skips_backlog_query_when_caller_provides_size(ctx):
         resolve_throughput_forecast,
     )
 
-    history = ThroughputHistory(
-        [
-            ThroughputSample(
-                day=date(2026, 5, i + 1),
-                items_completed=3,
-                team_id="team-a",
-                work_scope_id=None,
-            )
-            for i in range(14)
-        ]
-    )
-
-    fake_result = _result(team_id="team-a", backlog_size=99)
-
     with (
         patch(
             "dev_health_ops.api.graphql.resolvers.forecast._load_throughput_history",
             new_callable=AsyncMock,
-            return_value=history,
+            return_value=_history(team_id="team-a"),
         ),
         patch(
             "dev_health_ops.api.graphql.resolvers.forecast._load_work_item_overlay",
@@ -186,11 +279,11 @@ async def test_resolver_skips_backlog_query_when_caller_provides_size(ctx):
         ) as load_backlog,
         patch(
             "dev_health_ops.api.graphql.resolvers.forecast.forecast_throughput_capacity",
-            return_value=fake_result,
+            return_value=_result(team_id="team-a", backlog_size=99),
         ),
     ):
         result = await resolve_throughput_forecast(
-            ctx, ThroughputForecastInput(team_id="team-a", backlog_size=99)
+            ctx, ThroughputForecastInput(team_ids=["team-a"], backlog_size=99)
         )
 
     assert result is not None
@@ -200,7 +293,7 @@ async def test_resolver_skips_backlog_query_when_caller_provides_size(ctx):
 
 
 @pytest.mark.asyncio
-async def test_load_backlog_sums_across_partitions_when_team_id_is_none(ctx):
+async def test_load_backlog_omits_team_clause_when_team_ids_empty(ctx):
     """``_load_backlog`` must aggregate the latest day across all teams."""
     from dev_health_ops.api.graphql.resolvers.forecast import _load_backlog
 
@@ -209,12 +302,58 @@ async def test_load_backlog_sums_across_partitions_when_team_id_is_none(ctx):
         new_callable=AsyncMock,
         return_value=[{"backlog": 137}],
     ) as query:
-        backlog = await _load_backlog(ctx, team_id=None, work_scope_id=None)
+        backlog = await _load_backlog(ctx, team_ids=None, work_scope_id=None)
 
     assert backlog == 137
-    # No team_id / work_scope_id should appear in params when both are None.
     call_args = query.await_args
     assert call_args is not None
     params = call_args.args[2]
     assert "team_id" not in params
+    assert "team_ids" not in params
     assert "work_scope_id" not in params
+
+
+@pytest.mark.asyncio
+async def test_load_backlog_uses_in_clause_for_multiple_teams(ctx):
+    """Multi-team scope must produce an ``IN`` clause with an Array param."""
+    from dev_health_ops.api.graphql.resolvers.forecast import _load_backlog
+
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.forecast.query_dicts",
+        new_callable=AsyncMock,
+        return_value=[{"backlog": 84}],
+    ) as query:
+        backlog = await _load_backlog(
+            ctx, team_ids=["team-1", "team-2"], work_scope_id=None
+        )
+
+    assert backlog == 84
+    call_args = query.await_args
+    assert call_args is not None
+    sql = call_args.args[1]
+    params = call_args.args[2]
+    assert "team_id IN {team_ids:Array(String)}" in sql
+    assert params["team_ids"] == ["team-1", "team-2"]
+    assert "team_id" not in params
+
+
+@pytest.mark.asyncio
+async def test_load_backlog_uses_equality_for_single_team(ctx):
+    """Single-team scope must still use ``team_id =``, not ``IN``."""
+    from dev_health_ops.api.graphql.resolvers.forecast import _load_backlog
+
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.forecast.query_dicts",
+        new_callable=AsyncMock,
+        return_value=[{"backlog": 40}],
+    ) as query:
+        backlog = await _load_backlog(ctx, team_ids=["team-a"], work_scope_id=None)
+
+    assert backlog == 40
+    call_args = query.await_args
+    assert call_args is not None
+    sql = call_args.args[1]
+    params = call_args.args[2]
+    assert "team_id = {team_id:String}" in sql
+    assert params["team_id"] == "team-a"
+    assert "team_ids" not in params


### PR DESCRIPTION
## Why

CHAOS-1783 exposed `ThroughputForecastInput.team_id` as `Optional[str]`. The web filter bar scope-locked to "team" supports multi-select, but only one team was ever sent. Selecting `team-1 + team-2` produced an identical forecast to `team-2` alone — backlog and throughput didn't aggregate across the selection.

## What

- Rename `team_id: Optional[str]` → `team_ids: Optional[list[str]]` on `ThroughputForecastInput`. Empty / null still means "all teams".
- New `_team_filter` helper builds either `team_id = {team_id:String}` (one team) or `team_id IN {team_ids:Array(String)}` (multiple). All three loaders share it: `_load_throughput_history`, `_load_work_item_overlay`, `_load_backlog`.
- Result's `team_id` stays `Optional[str]`: set when exactly one team is selected, `None` for multi-team or all-teams scopes.

## Test

`tests/api/graphql/test_throughput_forecast_resolver.py`:
- `test_resolver_aggregates_multi_team_selection` — full pipeline gets the whole list; `result.team_id` is `None`.
- `test_resolver_single_team_sets_result_team_id` — single-team path still echoes the id.
- `test_load_backlog_uses_in_clause_for_multiple_teams` — verifies the SQL contains `IN {team_ids:Array(String)}`.
- `test_load_backlog_uses_equality_for_single_team` — single team still uses `team_id =`.

```
7 passed in 1.71s
```

ruff format + ruff check clean on changed files.

## End-to-end manual QA

Against a worktree dev server + worktree api with fixture data:

| Scope | Backlog | P50 | WIP |
|---|---|---|---|
| `team-1` alone | 40 | 5w | 1.66× |
| `team-2` alone | 44 | 7w | 1.56× |
| `team-1` + `team-2` | **84** | **6w** | **1.61×** |

Backlog sums (40 + 44 = 84). P50 and WIP fall between the singletons — combined throughput against combined backlog. Screenshots on the companion web PR.

## Linked

- Closes CHAOS-1784
- Companion frontend PR: full-chaos/dev-health-web#TBD
- Related: CHAOS-1783 (the partial fix that shipped multi-team-broken)

SCREENSHOT-WAIVER: backend-only; visual evidence on the companion web PR.
