### PR TITLE
fix(cli): clean migrate repair help and startup noise (CHAOS-1780, CHAOS-1781, CHAOS-1782)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,6 +42,11 @@ CLICKHOUSE_URI="clickhouse://localhost:8123/default" dev-hops fixtures generate 
 
 ### Migrations
 
+Use `migrate clickhouse repair` when ClickHouse contains duplicate `repos`
+records for the same repository `id` across different `org_id`s (typically
+from running fixtures or syncs under a changed `--org`). The command previews
+by default and only deletes rows when `--apply` is passed.
+
 ```bash
 # PostgreSQL (Alembic) — users, orgs, settings
 dev-hops migrate postgres
@@ -53,8 +58,12 @@ dev-hops migrate postgres history          # show migration history
 dev-hops migrate clickhouse
 dev-hops migrate clickhouse upgrade        # same as above
 dev-hops migrate clickhouse status         # show applied/pending migrations
-dev-hops migrate clickhouse repair         # dry-run: find stale-tenant orphan rows in repos
-dev-hops migrate clickhouse repair --apply # actually delete the orphans (see CHAOS-1775/1776)
+
+# Repair stale duplicate rows in `repos` (different org_id, same id)
+dev-hops migrate clickhouse repair                   # dry-run; no writes
+dev-hops migrate clickhouse repair --org <uuid>      # dry-run scoped to one org
+dev-hops migrate clickhouse repair --apply           # delete the rows shown by dry-run
+dev-hops migrate clickhouse repair --apply --org <uuid>
 ```
 
 > Run both migration commands after setting up a fresh environment, before any sync or metrics commands.

--- a/src/dev_health_ops/api/middleware/rate_limit.py
+++ b/src/dev_health_ops/api/middleware/rate_limit.py
@@ -143,6 +143,19 @@ if Limiter is not None:
         key_func=get_forwarded_ip,
         storage_uri=_storage_uri,
     )
+else:
+    limiter = _NoOpLimiter()
+    LIMITER_BACKEND = "noop"
+
+
+def log_rate_limit_configuration() -> None:
+    """Emit deferred rate-limiter startup messages for real CLI/API runs."""
+    if Limiter is None:
+        _log.warning(
+            "slowapi not installed — rate limiting disabled (NoOp). "
+            "Acceptable for local development only."
+        )
+        return
     if _REDIS_URL:
         _log.info("Rate limiter using Redis storage: %s", _REDIS_URL[:20] + "...")
     else:
@@ -156,13 +169,6 @@ if Limiter is not None:
             "and rate limiting will key on TCP peer address only. "
             "Set TRUSTED_PROXIES (comma-separated IPs/CIDRs) when behind a load balancer."
         )
-else:
-    limiter = _NoOpLimiter()
-    LIMITER_BACKEND = "noop"
-    _log.warning(
-        "slowapi not installed — rate limiting disabled (NoOp). "
-        "Acceptable for local development only."
-    )
 
 
 def verify_rate_limit_config() -> None:

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -3,36 +3,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import inspect
+import io
 import logging
 import os
+import sys
 from pathlib import Path
-
-import dev_health_ops.api.billing.cli as billing_cli
-import dev_health_ops.backfill.cli as backfill_cli
-from dev_health_ops import migrate as migrate_mod
-from dev_health_ops.api import runner as api_runner
-from dev_health_ops.api.admin import cli as admin_cli
-from dev_health_ops.api.services.refresh_tokens import cleanup_expired
-from dev_health_ops.audit import completeness, coverage, perf, schema
-from dev_health_ops.db import get_postgres_session
-from dev_health_ops.fixtures import runner as fixtures_runner
-from dev_health_ops.metrics import (
-    job_capacity,
-    job_complexity_db,
-    job_compounding_risk,
-    job_daily,
-    job_dora,
-    job_ff_validation,
-    job_release_impact,
-    job_work_items,
-)
-
-# Runner and registration modules
-from dev_health_ops.processors import sync as sync_processor
-from dev_health_ops.providers import teams as teams_provider
-from dev_health_ops.work_graph import runner as work_graph_runner
-from dev_health_ops.workers import runner as workers_runner
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -98,6 +75,9 @@ def _resolve_first_org_id(db_url: str | None) -> str | None:
 
 
 async def _run_refresh_token_cleanup() -> int:
+    from dev_health_ops.api.services.refresh_tokens import cleanup_expired
+    from dev_health_ops.db import get_postgres_session
+
     async with get_postgres_session() as db:
         deleted_count = await cleanup_expired(db)
         await db.commit()
@@ -309,7 +289,58 @@ def _propagate_global_args_to_subparsers(parser: argparse.ArgumentParser) -> Non
     walk(parser)
 
 
+def _is_help_invocation(argv: list[str] | None) -> bool:
+    args = sys.argv[1:] if argv is None else argv
+    return any(arg in {"-h", "--help"} for arg in args)
+
+
+@contextlib.contextmanager
+def _suppress_parser_construction_noise():
+    previous_disable_level = logging.root.manager.disable
+    logging.disable(logging.CRITICAL)
+    try:
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            yield
+    finally:
+        logging.disable(previous_disable_level)
+
+
+def _should_resolve_org(ns: argparse.Namespace) -> bool:
+    if getattr(ns, "org", None) is not None:
+        return False
+    return not (
+        getattr(ns, "command", None) == "migrate"
+        and getattr(ns, "migrate_command", None) == "clickhouse"
+        and getattr(ns, "ch_command", None) == "repair"
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
+    import dev_health_ops.api.billing.cli as billing_cli
+    import dev_health_ops.backfill.cli as backfill_cli
+    from dev_health_ops import migrate as migrate_mod
+    from dev_health_ops.api import runner as api_runner
+    from dev_health_ops.api.admin import cli as admin_cli
+    from dev_health_ops.audit import completeness, coverage, perf, schema
+    from dev_health_ops.fixtures import runner as fixtures_runner
+    from dev_health_ops.metrics import (
+        job_capacity,
+        job_complexity_db,
+        job_compounding_risk,
+        job_daily,
+        job_dora,
+        job_ff_validation,
+        job_release_impact,
+        job_work_items,
+    )
+    from dev_health_ops.processors import sync as sync_processor
+    from dev_health_ops.providers import teams as teams_provider
+    from dev_health_ops.work_graph import runner as work_graph_runner
+    from dev_health_ops.workers import runner as workers_runner
+
     parser = argparse.ArgumentParser(
         prog="dev-health-ops",
         description="Sync git data and compute developer health metrics.",
@@ -441,10 +472,14 @@ def main(argv: list[str] | None = None) -> int:
     }:
         _load_dotenv(REPO_ROOT / ".env")
 
-    parser = build_parser()
+    if _is_help_invocation(argv):
+        with _suppress_parser_construction_noise():
+            parser = build_parser()
+    else:
+        parser = build_parser()
     ns = parser.parse_args(argv)
 
-    if getattr(ns, "org", None) is None:
+    if _should_resolve_org(ns):
         ns.org = _resolve_first_org_id(getattr(ns, "db", None))
 
     level_name = str(getattr(ns, "log_level", "") or "INFO").upper()
@@ -452,6 +487,10 @@ def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(
         level=level, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
     )
+
+    from dev_health_ops.api.middleware.rate_limit import log_rate_limit_configuration
+
+    log_rate_limit_configuration()
 
     func = getattr(ns, "func", None)
     if func is None:

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -74,10 +74,21 @@ def _resolve_first_org_id(db_url: str | None) -> str | None:
         return None
 
 
-async def _run_refresh_token_cleanup() -> int:
-    from dev_health_ops.api.services.refresh_tokens import cleanup_expired
-    from dev_health_ops.db import get_postgres_session
+def get_postgres_session():
+    from dev_health_ops.db import get_postgres_session as real_get_postgres_session
 
+    return real_get_postgres_session()
+
+
+async def cleanup_expired(db) -> int:
+    from dev_health_ops.api.services.refresh_tokens import (
+        cleanup_expired as real_cleanup_expired,
+    )
+
+    return await real_cleanup_expired(db)
+
+
+async def _run_refresh_token_cleanup() -> int:
     async with get_postgres_session() as db:
         deleted_count = await cleanup_expired(db)
         await db.commit()

--- a/src/dev_health_ops/migrate.py
+++ b/src/dev_health_ops/migrate.py
@@ -15,9 +15,6 @@ import argparse
 import logging
 from pathlib import Path
 
-from alembic import command
-from alembic.config import Config
-
 from dev_health_ops.db import get_postgres_uri, resolve_sink_uri
 
 logger = logging.getLogger(__name__)
@@ -27,8 +24,10 @@ logger = logging.getLogger(__name__)
 _ALEMBIC_DIR = Path(__file__).resolve().parent / "alembic"
 
 
-def _make_alembic_config(db_url: str | None = None) -> Config:
+def _make_alembic_config(db_url: str | None = None):
     """Build an Alembic ``Config`` programmatically."""
+    from alembic.config import Config
+
     cfg = Config()
     cfg.set_main_option("script_location", str(_ALEMBIC_DIR))
 
@@ -43,30 +42,40 @@ def _make_alembic_config(db_url: str | None = None) -> Config:
 
 
 def _run_upgrade(ns: argparse.Namespace) -> int:
+    from alembic import command
+
     cfg = _make_alembic_config(getattr(ns, "db", None))
     command.upgrade(cfg, ns.revision)
     return 0
 
 
 def _run_downgrade(ns: argparse.Namespace) -> int:
+    from alembic import command
+
     cfg = _make_alembic_config(getattr(ns, "db", None))
     command.downgrade(cfg, ns.revision)
     return 0
 
 
 def _run_current(ns: argparse.Namespace) -> int:
+    from alembic import command
+
     cfg = _make_alembic_config(getattr(ns, "db", None))
     command.current(cfg, verbose=ns.verbose)
     return 0
 
 
 def _run_history(ns: argparse.Namespace) -> int:
+    from alembic import command
+
     cfg = _make_alembic_config(getattr(ns, "db", None))
     command.history(cfg, verbose=ns.verbose)
     return 0
 
 
 def _run_heads(ns: argparse.Namespace) -> int:
+    from alembic import command
+
     cfg = _make_alembic_config(getattr(ns, "db", None))
     command.heads(cfg, verbose=ns.verbose)
     return 0
@@ -132,17 +141,17 @@ def _run_clickhouse_status(ns: argparse.Namespace) -> int:
     return 0
 
 
-# --- ClickHouse repair (stale-tenant orphan rows in `repos`) ----------------
+# --- ClickHouse repair (stale duplicate rows in `repos`) ----------------
 
 # Background: ``repos`` is ``ReplacingMergeTree(last_synced)`` ordered by
-# ``(org_id, id)``. Prior to CHAOS-1775, ``ClickHouseStore.insert_repo``
+# ``(org_id, id)``. Earlier ``ClickHouseStore.insert_repo`` behavior
 # short-circuited on existing rows, so re-running ``fixtures generate`` (or any
 # sync) under a different ``--org`` left the table with multiple rows for the
-# same ``id`` under different ``org_id`` values. Those orphan rows are harmless
-# (a non-existent tenant cannot read them) but clutter the table.
+# same ``id`` under different ``org_id`` values. Older rows are stale duplicates
+# that clutter the table.
 #
 # This repair identifies, per ``id``, the row with the newest ``last_synced``
-# as the *active* tenant row; every other ``(id, org_id)`` row is an orphan.
+# as the newest repository row; every other ``(id, org_id)`` row is stale.
 
 _REPAIR_DETECT_QUERY = """
 WITH latest AS (
@@ -170,11 +179,11 @@ ORDER BY r.repo, r.org_id
 
 
 def _run_clickhouse_repair(ns: argparse.Namespace) -> int:
-    """Find (and optionally delete) stale-tenant orphan rows in ``repos``.
+    """Find (and optionally delete) stale duplicate rows in ``repos``.
 
     Dry-run by default. Pass ``--apply`` to issue ``ALTER TABLE repos DELETE``
-    for each orphan. Optional ``--org`` scopes the repair to orphans whose
-    active tenant is that org_id; orphans of other tenants are untouched.
+    for each stale duplicate row. Optional ``--org`` scopes the repair to
+    duplicate groups whose newest repository row belongs to that org_id.
     """
     import clickhouse_connect
 
@@ -194,17 +203,23 @@ def _run_clickhouse_repair(ns: argparse.Namespace) -> int:
     client = clickhouse_connect.get_client(dsn=uri)
     try:
         result = client.query(detect_query, parameters=params)
-        orphans = list(result.result_rows or [])
+        stale_rows = list(result.result_rows or [])
 
-        if not orphans:
-            print("No stale-tenant orphans found in repos.")
+        if not stale_rows:
+            if org_filter_value:
+                print(
+                    f"No stale duplicate rows found where the newest row "
+                    f"belongs to org {org_filter_value}."
+                )
+            else:
+                print("No stale duplicate rows found in repos.")
             return 0
 
-        print(f"Found {len(orphans)} stale-tenant orphan row(s) in repos:")
+        print(f"Found {len(stale_rows)} stale duplicate row(s) in repos:")
         print()
         header = ("repo", "stale_org_id", "active_org_id", "stale_last_synced")
         print(f"  {header[0]:<40s}  {header[1]:<40s}  {header[2]:<40s}  {header[3]}")
-        for row in orphans:
+        for row in stale_rows:
             (_id, repo, stale_org, active_org, stale_ts, _active_ts) = row
             print(
                 f"  {str(repo):<40s}  {str(stale_org):<40s}  "
@@ -213,12 +228,12 @@ def _run_clickhouse_repair(ns: argparse.Namespace) -> int:
         print()
 
         if not apply:
-            print("Dry-run: pass --apply to delete these orphan rows.")
+            print("Dry-run: pass --apply to delete these stale duplicate rows.")
             return 0
 
-        print("Applying ALTER TABLE repos DELETE per orphan...")
+        print("Applying ALTER TABLE repos DELETE for each stale duplicate row...")
         deleted = 0
-        for row in orphans:
+        for row in stale_rows:
             (id_str, _repo, stale_org, _active_org, _stale_ts, _active_ts) = row
             client.command(
                 "ALTER TABLE repos DELETE "
@@ -228,7 +243,7 @@ def _run_clickhouse_repair(ns: argparse.Namespace) -> int:
             )
             deleted += 1
 
-        print(f"Deleted {deleted} stale-tenant row(s) from repos.")
+        print(f"Deleted {deleted} stale duplicate row(s) from repos.")
     finally:
         client.close()
     return 0
@@ -277,21 +292,20 @@ def _register_clickhouse_subcommands(
     ch_repair = sub.add_parser(
         "repair",
         help=(
-            "Find (or with --apply, delete) stale-tenant orphan rows in repos "
-            "(see CHAOS-1775). Dry-run by default."
+            "Remediate stale duplicate rows in repos. Dry-run unless --apply is passed."
         ),
     )
     ch_repair.add_argument(
         "--apply",
         action="store_true",
-        help="Delete orphan rows. Without this flag, repair is a dry-run.",
+        help="Apply the repair by deleting the stale duplicate rows shown in the dry-run preview.",
     )
     ch_repair.add_argument(
         "--org",
-        default=None,
+        default=argparse.SUPPRESS,
         help=(
-            "Scope repair to orphans whose active tenant is this org_id. "
-            "Without this flag, every tenant's orphans are reported/repaired."
+            "Only include duplicate groups whose newest repository row belongs "
+            "to this org_id. Without this flag, all orgs are checked."
         ),
     )
     ch_repair.set_defaults(func=_run_clickhouse_repair)

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _run_cli_help(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DISABLE_DOTENV"] = "1"
+    env["PYTHONPATH"] = "src"
+    return subprocess.run(
+        [sys.executable, "-m", "dev_health_ops.cli", *args],
+        check=False,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("--help",),
+        ("sync", "--help"),
+        ("metrics", "--help"),
+        ("audit", "--help"),
+        ("fixtures", "--help"),
+        ("api", "--help"),
+        ("billing", "--help"),
+        ("admin", "--help"),
+        ("work-graph", "--help"),
+        ("backfill", "--help"),
+        ("recommendations", "--help"),
+        ("migrate", "--help"),
+        ("migrate", "clickhouse", "repair", "--help"),
+        ("workers", "--help"),
+        ("maintenance", "--help"),
+    ],
+)
+def test_help_has_no_startup_noise_before_usage(args: tuple[str, ...]) -> None:
+    result = _run_cli_help(*args)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert result.stdout.startswith("usage:")
+
+
+def test_rate_limit_import_has_no_startup_noise() -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import dev_health_ops.api.middleware.rate_limit",
+        ],
+        check=False,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -117,7 +117,7 @@ class TestRegisterCommands:
 class TestCommandDispatch:
     """Verify each _run_* function calls the correct alembic.command."""
 
-    @patch("dev_health_ops.migrate.command")
+    @patch("alembic.command")
     def test_run_upgrade(self, mock_cmd):
         ns = argparse.Namespace(db="sqlite:///x.db", revision="head")
         assert _run_upgrade(ns) == 0
@@ -125,7 +125,7 @@ class TestCommandDispatch:
         _cfg, rev = mock_cmd.upgrade.call_args[0]
         assert rev == "head"
 
-    @patch("dev_health_ops.migrate.command")
+    @patch("alembic.command")
     def test_run_downgrade(self, mock_cmd):
         ns = argparse.Namespace(db="sqlite:///x.db", revision="-1")
         assert _run_downgrade(ns) == 0
@@ -133,25 +133,25 @@ class TestCommandDispatch:
         _cfg, rev = mock_cmd.downgrade.call_args[0]
         assert rev == "-1"
 
-    @patch("dev_health_ops.migrate.command")
+    @patch("alembic.command")
     def test_run_current(self, mock_cmd):
         ns = argparse.Namespace(db="sqlite:///x.db", verbose=True)
         assert _run_current(ns) == 0
         mock_cmd.current.assert_called_once()
 
-    @patch("dev_health_ops.migrate.command")
+    @patch("alembic.command")
     def test_run_history(self, mock_cmd):
         ns = argparse.Namespace(db="sqlite:///x.db", verbose=False)
         assert _run_history(ns) == 0
         mock_cmd.history.assert_called_once()
 
-    @patch("dev_health_ops.migrate.command")
+    @patch("alembic.command")
     def test_run_heads(self, mock_cmd):
         ns = argparse.Namespace(db="sqlite:///x.db", verbose=False)
         assert _run_heads(ns) == 0
         mock_cmd.heads.assert_called_once()
 
-    @patch("dev_health_ops.migrate.command")
+    @patch("alembic.command")
     def test_upgrade_uses_db_from_namespace(self, mock_cmd):
         ns = argparse.Namespace(
             db="postgresql+asyncpg://custom@host/mydb", revision="abc123"
@@ -163,7 +163,7 @@ class TestCommandDispatch:
             == "postgresql+asyncpg://custom@host/mydb"
         )
 
-    @patch("dev_health_ops.migrate.command")
+    @patch("alembic.command")
     def test_upgrade_without_db_falls_back_to_env(self, mock_cmd, monkeypatch):
         monkeypatch.delenv("POSTGRES_URI", raising=False)
         monkeypatch.delenv("DATABASE_URL", raising=False)

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from dev_health_ops.cli import build_parser
+from dev_health_ops.cli import _should_resolve_org, build_parser
 from dev_health_ops.migrate import (
     _run_clickhouse_repair,
     _run_clickhouse_status,
@@ -75,6 +75,46 @@ class TestMigrateRouting:
     def test_clickhouse_bare_defaults_to_upgrade(self):
         ns = self.parser.parse_args(["migrate", "clickhouse"])
         assert ns.func.__name__ == "_run_clickhouse_upgrade"
+
+    def test_repair_preserves_root_org_flag(self):
+        ns = self.parser.parse_args(
+            [
+                "--org",
+                "root-org",
+                "migrate",
+                "clickhouse",
+                "repair",
+            ]
+        )
+
+        assert ns.org == "root-org"
+        assert not _should_resolve_org(ns)
+
+    def test_repair_leaf_org_flag_scopes_repair(self):
+        ns = self.parser.parse_args(
+            [
+                "migrate",
+                "clickhouse",
+                "repair",
+                "--org",
+                "leaf-org",
+            ]
+        )
+
+        assert ns.org == "leaf-org"
+        assert not _should_resolve_org(ns)
+
+    def test_repair_without_org_does_not_auto_resolve_first_org(self):
+        ns = self.parser.parse_args(["migrate", "clickhouse", "repair"])
+
+        assert getattr(ns, "org", None) is None
+        assert not _should_resolve_org(ns)
+
+    def test_non_repair_command_without_org_still_auto_resolves(self):
+        ns = self.parser.parse_args(["migrate", "clickhouse", "status"])
+
+        assert getattr(ns, "org", None) is None
+        assert _should_resolve_org(ns)
 
     def test_upgrade_flat_defaults_to_head(self):
         ns = self.parser.parse_args(["migrate", "upgrade"])
@@ -278,15 +318,15 @@ class TestClickhouseStatus:
 
 
 # ---------------------------------------------------------------------------
-# _run_clickhouse_repair  (CHAOS-1776)
+# _run_clickhouse_repair
 # ---------------------------------------------------------------------------
 
 
 class TestClickhouseRepair:
-    def _make_client(self, orphan_rows: list | None = None) -> MagicMock:
+    def _make_client(self, stale_rows: list | None = None) -> MagicMock:
         mock_client = MagicMock()
         result = MagicMock()
-        result.result_rows = orphan_rows or []
+        result.result_rows = stale_rows or []
         mock_client.query.return_value = result
         return mock_client
 
@@ -299,14 +339,14 @@ class TestClickhouseRepair:
         "dev_health_ops.migrate.resolve_sink_uri",
         return_value="clickhouse://fake:8123/test",
     )
-    def test_no_orphans_prints_clean_message(self, _uri, capsys):
-        mock_client = self._make_client(orphan_rows=[])
+    def test_no_stale_duplicates_prints_clean_message(self, _uri, capsys):
+        mock_client = self._make_client(stale_rows=[])
 
         with patch("clickhouse_connect.get_client", return_value=mock_client):
             result = _run_clickhouse_repair(self._ns_repair())
 
         assert result == 0
-        assert "No stale-tenant orphans found in repos." in capsys.readouterr().out
+        assert "No stale duplicate rows found in repos." in capsys.readouterr().out
         # Detection-only path — no ALTER TABLE DELETE.
         mock_client.command.assert_not_called()
         mock_client.close.assert_called_once()
@@ -315,9 +355,25 @@ class TestClickhouseRepair:
         "dev_health_ops.migrate.resolve_sink_uri",
         return_value="clickhouse://fake:8123/test",
     )
+    def test_org_scoped_empty_message_names_scope(self, _uri, capsys):
+        mock_client = self._make_client(stale_rows=[])
+
+        with patch("clickhouse_connect.get_client", return_value=mock_client):
+            result = _run_clickhouse_repair(self._ns_repair(org="my-org-uuid"))
+
+        assert result == 0
+        assert (
+            "No stale duplicate rows found where the newest row belongs to org "
+            "my-org-uuid."
+        ) in capsys.readouterr().out
+
+    @patch(
+        "dev_health_ops.migrate.resolve_sink_uri",
+        return_value="clickhouse://fake:8123/test",
+    )
     def test_dry_run_does_not_delete(self, _uri, capsys):
-        """Default invocation prints orphans but issues no ALTER TABLE DELETE."""
-        orphan_rows = [
+        """Default invocation prints stale duplicate rows but issues no ALTER TABLE DELETE."""
+        stale_rows = [
             (
                 "e50b01bd-47a3-50e7-a9b4-d29a95bfdb07",
                 "acme/demo-app-1",
@@ -327,18 +383,18 @@ class TestClickhouseRepair:
                 datetime(2026, 5, 22),
             ),
         ]
-        mock_client = self._make_client(orphan_rows=orphan_rows)
+        mock_client = self._make_client(stale_rows=stale_rows)
 
         with patch("clickhouse_connect.get_client", return_value=mock_client):
             result = _run_clickhouse_repair(self._ns_repair())
 
         assert result == 0
         out = capsys.readouterr().out
-        assert "Found 1 stale-tenant orphan row(s) in repos" in out
+        assert "Found 1 stale duplicate row(s) in repos" in out
         assert "acme/demo-app-1" in out
         assert "stale-org" in out
         assert "active-org" in out
-        assert "Dry-run: pass --apply to delete these orphan rows." in out
+        assert "Dry-run: pass --apply to delete these stale duplicate rows." in out
         # No DELETE issued in dry-run.
         mock_client.command.assert_not_called()
         mock_client.close.assert_called_once()
@@ -347,8 +403,8 @@ class TestClickhouseRepair:
         "dev_health_ops.migrate.resolve_sink_uri",
         return_value="clickhouse://fake:8123/test",
     )
-    def test_apply_issues_delete_per_orphan(self, _uri, capsys):
-        orphan_rows = [
+    def test_apply_issues_delete_per_stale_row(self, _uri, capsys):
+        stale_rows = [
             (
                 "e50b01bd-47a3-50e7-a9b4-d29a95bfdb07",
                 "acme/demo-app-1",
@@ -366,7 +422,7 @@ class TestClickhouseRepair:
                 datetime(2026, 5, 22),
             ),
         ]
-        mock_client = self._make_client(orphan_rows=orphan_rows)
+        mock_client = self._make_client(stale_rows=stale_rows)
 
         with patch("clickhouse_connect.get_client", return_value=mock_client):
             result = _run_clickhouse_repair(self._ns_repair(apply=True))
@@ -389,7 +445,7 @@ class TestClickhouseRepair:
             assert kwargs["parameters"] == {"id": expected[0], "org": expected[1]}
 
         out = capsys.readouterr().out
-        assert "Deleted 2 stale-tenant row(s) from repos." in out
+        assert "Deleted 2 stale duplicate row(s) from repos." in out
         mock_client.close.assert_called_once()
 
     @patch(
@@ -397,7 +453,7 @@ class TestClickhouseRepair:
         return_value="clickhouse://fake:8123/test",
     )
     def test_org_filter_passes_param_to_detect_query(self, _uri):
-        mock_client = self._make_client(orphan_rows=[])
+        mock_client = self._make_client(stale_rows=[])
 
         with patch("clickhouse_connect.get_client", return_value=mock_client):
             _run_clickhouse_repair(self._ns_repair(org="my-org-uuid"))
@@ -414,7 +470,7 @@ class TestClickhouseRepair:
         return_value="clickhouse://fake:8123/test",
     )
     def test_no_org_filter_omits_clause(self, _uri):
-        mock_client = self._make_client(orphan_rows=[])
+        mock_client = self._make_client(stale_rows=[])
 
         with patch("clickhouse_connect.get_client", return_value=mock_client):
             _run_clickhouse_repair(self._ns_repair())


### PR DESCRIPTION
## Summary
- Rename `migrate clickhouse repair` user-facing wording from stale-tenant/orphan rows to stale duplicate rows.
- Expand the CLI docs with a safe preview/apply runbook and scoped `--org` examples.
- Suppress CLI startup/import noise for help invocations while preserving normal-run operational warnings.
- Defer rate-limit startup warnings out of module import and add help/import smoke tests.
- Preserve explicit repair `--org` flags and avoid implicit first-org scoping for unscoped repair runs.

## Verification
- `PYTHONPATH=src pytest tests/test_migrate_commands.py tests/test_cli_help.py` → 58 passed
- `ruff format . && ruff check .` → clean
- Manual QA: 19 help surfaces start with `usage:` and emit empty stderr
- Manual QA: normal `migrate clickhouse repair` still emits REDIS/TRUSTED_PROXIES warnings and missing ClickHouse URI error

SCREENSHOT-WAIVER: backend/CLI-only changes; no rendered frontend impact.

Closes CHAOS-1780
Closes CHAOS-1781
Closes CHAOS-1782