### PR TITLE
feat(api): product telemetry ingest endpoint (CHAOS-1789)

### DIFF
--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -23,6 +23,7 @@ init_sentry()
 init_tracing()
 
 from dev_health_ops.api.middleware.rate_limit import limiter
+from dev_health_ops.api.product_telemetry import router as product_telemetry_router
 from dev_health_ops.api.telemetry.router import router as telemetry_router
 
 from ._errors import (
@@ -194,6 +195,7 @@ app.include_router(auth_router)
 app.include_router(billing_router)
 app.include_router(licensing_router)
 app.include_router(telemetry_router)
+app.include_router(product_telemetry_router)
 app.include_router(ingest_router)
 app.include_router(orgs_router)
 

--- a/src/dev_health_ops/api/product_telemetry/__init__.py
+++ b/src/dev_health_ops/api/product_telemetry/__init__.py
@@ -1,0 +1,3 @@
+from .router import router
+
+__all__ = ["router"]

--- a/src/dev_health_ops/api/product_telemetry/router.py
+++ b/src/dev_health_ops/api/product_telemetry/router.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from uuid import uuid4
+
+from fastapi import APIRouter, status
+from redis.asyncio import Redis
+
+from .schemas import ProductTelemetryAccepted, ProductTelemetryBatch
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/product-telemetry", tags=["product-telemetry"])
+
+
+def product_telemetry_stream_name(org_id_hash: str | None) -> str:
+    org_key = org_id_hash or "anonymous"
+    return f"product-telemetry:{org_key}:events"
+
+
+async def write_product_telemetry_batch(
+    batch: ProductTelemetryBatch, ingestion_id: str
+) -> str:
+    stream = product_telemetry_stream_name(batch.org_id_hash)
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    client = Redis.from_url(redis_url, decode_responses=True)
+    try:
+        await client.xadd(
+            stream,
+            {
+                "ingestion_id": ingestion_id,
+                "source": batch.source,
+                "org_id_hash": batch.org_id_hash or "",
+                "events": json.dumps(
+                    [
+                        event.model_dump(mode="json", by_alias=True)
+                        for event in batch.events
+                    ]
+                ),
+            },
+        )
+    finally:
+        await client.aclose()
+    return stream
+
+
+@router.post(
+    "/events",
+    response_model=ProductTelemetryAccepted,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def accept_product_telemetry_events(
+    batch: ProductTelemetryBatch,
+) -> ProductTelemetryAccepted:
+    ingestion_id = str(uuid4())
+    try:
+        stream = await write_product_telemetry_batch(batch, ingestion_id)
+    except Exception as exc:  # noqa: BLE001 - ingestion must remain best-effort in local/dev
+        logger.warning("Product telemetry stream unavailable", exc_info=exc)
+        stream = "disabled"
+
+    return ProductTelemetryAccepted(
+        ingestion_id=ingestion_id,
+        items_received=len(batch.events),
+        stream=stream,
+    )

--- a/src/dev_health_ops/api/product_telemetry/schemas.py
+++ b/src/dev_health_ops/api/product_telemetry/schemas.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+TelemetryEventName = Literal[
+    "page_viewed",
+    "feature_viewed",
+    "filter_changed",
+    "chart_interacted",
+    "navigation_interacted",
+    "guide_opened",
+    "session_started",
+    "session_ended",
+    "client_error",
+]
+
+
+class ProductTelemetryEvent(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: TelemetryEventName
+    schema_version: str = Field(alias="schemaVersion")
+    event_id: str = Field(alias="eventId")
+    ts: datetime
+    session_id: str = Field(alias="sessionId")
+    anonymous_user_id: str = Field(alias="anonymousUserId")
+    org_id_hash: str | None = Field(default=None, alias="orgIdHash")
+    route_pattern: str | None = Field(default=None, alias="routePattern")
+    payload: dict[str, str | int | float | bool | None]
+
+
+class ProductTelemetryBatch(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    org_id_hash: str | None = Field(default=None, alias="orgIdHash")
+    source: Literal["dev-health-web"] = "dev-health-web"
+    events: list[ProductTelemetryEvent] = Field(..., min_length=1, max_length=500)
+
+
+class ProductTelemetryAccepted(BaseModel):
+    ingestion_id: str
+    status: Literal["accepted"] = "accepted"
+    items_received: int
+    stream: str

--- a/tests/api/test_product_telemetry.py
+++ b/tests/api/test_product_telemetry.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from dev_health_ops.api.main import app
+
+
+def _event(**overrides: Any) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "name": "chart_interacted",
+        "schemaVersion": "2026-05-telemetry-v1",
+        "eventId": "evt_123",
+        "ts": "2026-05-25T12:00:00Z",
+        "sessionId": "ses_123",
+        "anonymousUserId": "anon_123",
+        "orgIdHash": "org_hash_123",
+        "routePattern": "/metrics",
+        "payload": {
+            "chart": "quadrant",
+            "action": "overlay_toggled",
+            "surface": "metrics",
+            "scope": "org",
+        },
+    }
+    event.update(overrides)
+    return event
+
+
+def _batch(events: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    return {
+        "orgIdHash": "org_hash_123",
+        "source": "dev-health-web",
+        "events": events if events is not None else [_event()],
+    }
+
+
+@pytest.mark.anyio
+async def test_product_telemetry_accepts_valid_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = importlib.import_module("dev_health_ops.api.product_telemetry.router")
+
+    async def write_batch(*args: Any, **kwargs: Any) -> str:
+        return "product-telemetry:org_hash_123:events"
+
+    monkeypatch.setattr(router, "write_product_telemetry_batch", write_batch)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/api/v1/product-telemetry/events",
+            json=_batch([_event(), _event(eventId="evt_456")]),
+        )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["status"] == "accepted"
+    assert body["items_received"] == 2
+    assert body["stream"] == "product-telemetry:org_hash_123:events"
+    assert body["ingestion_id"]
+
+
+@pytest.mark.anyio
+async def test_product_telemetry_rejects_invalid_event_name() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/api/v1/product-telemetry/events",
+            json=_batch([_event(name="quadrant_zone_overlay_toggled")]),
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_product_telemetry_rejects_empty_batch() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/api/v1/product-telemetry/events", json=_batch([])
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_product_telemetry_rejects_batches_larger_than_500() -> None:
+    events = [_event(eventId=f"evt_{index}") for index in range(501)]
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/api/v1/product-telemetry/events", json=_batch(events)
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_product_telemetry_accepts_when_redis_writer_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = importlib.import_module("dev_health_ops.api.product_telemetry.router")
+
+    async def unavailable_writer(*args: Any, **kwargs: Any) -> str:
+        raise ConnectionError("redis unavailable")
+
+    monkeypatch.setattr(router, "write_product_telemetry_batch", unavailable_writer)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/api/v1/product-telemetry/events", json=_batch())
+
+    assert response.status_code == 202
+    assert response.json()["stream"] == "disabled"


### PR DESCRIPTION
## Summary
- Add typed product telemetry Pydantic schemas and /api/v1/product-telemetry/events endpoint
- Register product telemetry router without changing existing /api/v1/telemetry/* voluntary telemetry routes
- Accept valid batches with 202 and return stream=disabled when Redis is unavailable in local/test paths

Refs CHAOS-1789
Plan: docs/superpowers/plans/2026-05-25-product-telemetry-usage-analytics.md

## Verification
- pytest tests/api/test_product_telemetry.py -q -> 5 passed
- ruff format --check src/dev_health_ops/api/product_telemetry tests/api/test_product_telemetry.py -> 4 files already formatted
- ruff check src/dev_health_ops/api/product_telemetry tests/api/test_product_telemetry.py -> All checks passed
- LSP diagnostics: 0 diagnostics for src/dev_health_ops/api/product_telemetry and tests/api/test_product_telemetry.py
- Existing telemetry router tests: none found by tests/api/**/*telemetry*.py beyond new product telemetry tests; existing /api/v1/telemetry/* router code was not modified

SCREENSHOT-WAIVER: backend-only, no rendered UI