### PR TITLE
feat(api): async product telemetry persistence (CHAOS-450)

### DIFF
--- a/src/dev_health_ops/api/product_telemetry/consumer.py
+++ b/src/dev_health_ops/api/product_telemetry/consumer.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from typing import Any, cast
+
+from pydantic import ValidationError
+
+from .persist import ProductTelemetryPayloadError, persist_product_telemetry_events
+from .schemas import ProductTelemetryEvent
+from .streams import CONSUMER_GROUP, DLQ_STREAM
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 100
+BLOCK_MS = 5000
+
+
+def _ensure_group(redis_client, stream_key: str) -> None:
+    try:
+        redis_client.xgroup_create(stream_key, CONSUMER_GROUP, id="0", mkstream=True)
+    except Exception:
+        pass
+
+
+def _move_to_dlq(redis_client, stream_key: str, entry_id: str, reason: str) -> None:
+    try:
+        redis_client.xadd(
+            DLQ_STREAM,
+            {
+                "original_stream": stream_key,
+                "entry_id": entry_id,
+                "reason": reason,
+                "moved_at": str(time.time()),
+            },
+        )
+    except Exception:
+        logger.exception("Failed to move product telemetry entry %s to DLQ", entry_id)
+
+
+def _events_from_entry(data: dict[str, str]) -> list[ProductTelemetryEvent]:
+    raw_events = json.loads(data.get("events", "[]"))
+    return [ProductTelemetryEvent.model_validate(raw_event) for raw_event in raw_events]
+
+
+def consume_product_telemetry_streams(
+    stream_patterns: list[str] | None = None,
+    max_iterations: int | None = None,
+    consumer_name: str | None = None,
+) -> int:
+    from .streams import get_redis_client
+
+    redis_client = cast(Any, get_redis_client())
+    if not redis_client:
+        logger.warning("Redis unavailable, product telemetry consumer cannot start")
+        return 0
+
+    if consumer_name is None:
+        consumer_name = f"product-telemetry-{uuid.uuid4().hex[:8]}"
+    if stream_patterns is None:
+        stream_patterns = ["product-telemetry:*:events"]
+
+    streams: dict[str, str] = {}
+    for pattern in stream_patterns:
+        if "*" in pattern:
+            for key in redis_client.scan_iter(match=pattern, _type="stream"):
+                streams[key] = ">"
+        else:
+            streams[pattern] = ">"
+
+    if not streams:
+        return 0
+
+    for stream_key in streams:
+        _ensure_group(redis_client, stream_key)
+
+    total_processed = 0
+    iterations = 0
+    while max_iterations is None or iterations < max_iterations:
+        iterations += 1
+        results = redis_client.xreadgroup(
+            CONSUMER_GROUP,
+            consumer_name,
+            streams=streams,
+            count=BATCH_SIZE,
+            block=BLOCK_MS,
+        )
+        if not results:
+            continue
+
+        for stream_key, entries in results:
+            for entry_id, data in entries:
+                try:
+                    events = _events_from_entry(data)
+                    source = data.get("source", "dev-health-web")
+                    persisted = asyncio.run(
+                        persist_product_telemetry_events(events, source)
+                    )
+                    total_processed += persisted
+                except (
+                    json.JSONDecodeError,
+                    ValidationError,
+                    ProductTelemetryPayloadError,
+                ) as exc:
+                    logger.warning(
+                        "Rejecting product telemetry entry %s: %s", entry_id, exc
+                    )
+                    _move_to_dlq(redis_client, stream_key, entry_id, str(exc))
+                except Exception as exc:
+                    logger.exception(
+                        "Failed to persist product telemetry entry %s", entry_id
+                    )
+                    _move_to_dlq(redis_client, stream_key, entry_id, str(exc))
+                finally:
+                    redis_client.xack(stream_key, CONSUMER_GROUP, entry_id)
+
+    return total_processed

--- a/src/dev_health_ops/api/product_telemetry/consumer.py
+++ b/src/dev_health_ops/api/product_telemetry/consumer.py
@@ -22,8 +22,14 @@ BLOCK_MS = 5000
 def _ensure_group(redis_client, stream_key: str) -> None:
     try:
         redis_client.xgroup_create(stream_key, CONSUMER_GROUP, id="0", mkstream=True)
-    except Exception:
-        pass
+    except Exception as exc:
+        if "BUSYGROUP" in str(exc):
+            return
+        logger.exception(
+            "failed to ensure consumer group",
+            extra={"stream_key": stream_key, "consumer_group": CONSUMER_GROUP},
+        )
+        raise
 
 
 def _move_to_dlq(redis_client, stream_key: str, entry_id: str, reason: str) -> None:

--- a/src/dev_health_ops/api/product_telemetry/persist.py
+++ b/src/dev_health_ops/api/product_telemetry/persist.py
@@ -68,7 +68,7 @@ async def persist_product_telemetry_events(
     for event in events:
         rows.append(
             [
-                event.org_id_hash,
+                event.org_id_hash or "",
                 event.event_id,
                 event.name,
                 event.schema_version,

--- a/src/dev_health_ops/api/product_telemetry/persist.py
+++ b/src/dev_health_ops/api/product_telemetry/persist.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from dev_health_ops.metrics.sinks.factory import create_sink
+
+from .schemas import ProductTelemetryEvent
+
+BLOCKED_PAYLOAD_KEYS = {
+    "email",
+    "name",
+    "userId",
+    "orgId",
+    "url",
+    "query",
+    "search",
+    "stack",
+    "message",
+    "title",
+    "body",
+}
+
+PRODUCT_TELEMETRY_COLUMNS = [
+    "org_id_hash",
+    "event_id",
+    "name",
+    "schema_version",
+    "session_id",
+    "anonymous_user_id",
+    "route_pattern",
+    "payload_json",
+    "occurred_at",
+    "ingested_at",
+    "source",
+]
+
+
+class ProductTelemetryPayloadError(ValueError):
+    pass
+
+
+def _payload_json(payload: dict[str, str | int | float | bool | None]) -> str:
+    blocked = BLOCKED_PAYLOAD_KEYS.intersection(payload)
+    if blocked:
+        blocked_list = ", ".join(sorted(blocked))
+        raise ProductTelemetryPayloadError(
+            f"Blocked product telemetry payload keys: {blocked_list}"
+        )
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _to_utc_naive(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+async def persist_product_telemetry_events(
+    events: list[ProductTelemetryEvent], source: str
+) -> int:
+    if not events:
+        return 0
+    ingested_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    rows: list[list[Any]] = []
+    for event in events:
+        rows.append(
+            [
+                event.org_id_hash,
+                event.event_id,
+                event.name,
+                event.schema_version,
+                event.session_id,
+                event.anonymous_user_id,
+                event.route_pattern,
+                _payload_json(event.payload),
+                _to_utc_naive(event.ts),
+                ingested_at,
+                source,
+            ]
+        )
+
+    sink = create_sink()
+    try:
+        client = cast(Any, sink).client
+        await asyncio.to_thread(
+            client.insert,
+            "product_telemetry_events",
+            rows,
+            column_names=PRODUCT_TELEMETRY_COLUMNS,
+        )
+    finally:
+        sink.close()
+    return len(rows)

--- a/src/dev_health_ops/api/product_telemetry/router.py
+++ b/src/dev_health_ops/api/product_telemetry/router.py
@@ -1,49 +1,16 @@
 from __future__ import annotations
 
-import json
 import logging
-import os
 from uuid import uuid4
 
 from fastapi import APIRouter, status
-from redis.asyncio import Redis
 
 from .schemas import ProductTelemetryAccepted, ProductTelemetryBatch
+from .streams import write_product_telemetry_batch
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/product-telemetry", tags=["product-telemetry"])
-
-
-def product_telemetry_stream_name(org_id_hash: str | None) -> str:
-    org_key = org_id_hash or "anonymous"
-    return f"product-telemetry:{org_key}:events"
-
-
-async def write_product_telemetry_batch(
-    batch: ProductTelemetryBatch, ingestion_id: str
-) -> str:
-    stream = product_telemetry_stream_name(batch.org_id_hash)
-    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
-    client = Redis.from_url(redis_url, decode_responses=True)
-    try:
-        await client.xadd(
-            stream,
-            {
-                "ingestion_id": ingestion_id,
-                "source": batch.source,
-                "org_id_hash": batch.org_id_hash or "",
-                "events": json.dumps(
-                    [
-                        event.model_dump(mode="json", by_alias=True)
-                        for event in batch.events
-                    ]
-                ),
-            },
-        )
-    finally:
-        await client.aclose()
-    return stream
 
 
 @router.post(
@@ -57,7 +24,7 @@ async def accept_product_telemetry_events(
     ingestion_id = str(uuid4())
     try:
         stream = await write_product_telemetry_batch(batch, ingestion_id)
-    except Exception as exc:  # noqa: BLE001 - ingestion must remain best-effort in local/dev
+    except Exception as exc:  # noqa: BLE001 - local/dev accept-and-warn path
         logger.warning("Product telemetry stream unavailable", exc_info=exc)
         stream = "disabled"
 

--- a/src/dev_health_ops/api/product_telemetry/streams.py
+++ b/src/dev_health_ops/api/product_telemetry/streams.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+from .schemas import ProductTelemetryBatch
+
+logger = logging.getLogger(__name__)
+
+CONSUMER_GROUP = "product-telemetry-consumers"
+DLQ_STREAM = "product-telemetry:dlq"
+
+
+def product_telemetry_stream_name(org_id_hash: str | None) -> str:
+    org_key = org_id_hash or "anonymous"
+    return f"product-telemetry:{org_key}:events"
+
+
+def get_redis_client():
+    redis_url = os.getenv("REDIS_URL")
+    if not redis_url:
+        return None
+    try:
+        import valkey as redis
+
+        return redis.from_url(redis_url, decode_responses=True)
+    except Exception:
+        logger.warning("Redis unavailable for product telemetry streams")
+        return None
+
+
+async def write_product_telemetry_batch(
+    batch: ProductTelemetryBatch, ingestion_id: str
+) -> str:
+    stream = product_telemetry_stream_name(batch.org_id_hash)
+    redis_client = get_redis_client()
+    if not redis_client:
+        raise ConnectionError("Redis unavailable for product telemetry streams")
+    redis_client.xadd(
+        stream,
+        {
+            "ingestion_id": ingestion_id,
+            "source": batch.source,
+            "org_id_hash": batch.org_id_hash or "",
+            "events": json.dumps(
+                [event.model_dump(mode="json", by_alias=True) for event in batch.events]
+            ),
+        },
+        maxlen=100000,
+        approximate=True,
+    )
+    return stream

--- a/src/dev_health_ops/migrations/clickhouse/041_product_telemetry_events.sql
+++ b/src/dev_health_ops/migrations/clickhouse/041_product_telemetry_events.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS product_telemetry_events (
+    org_id_hash Nullable(String),
+    event_id String,
+    name LowCardinality(String),
+    schema_version String,
+    session_id String,
+    anonymous_user_id String,
+    route_pattern Nullable(String),
+    payload_json String,
+    occurred_at DateTime64(3, 'UTC'),
+    ingested_at DateTime64(3, 'UTC'),
+    source LowCardinality(String)
+) ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(occurred_at)
+ORDER BY (org_id_hash, name, occurred_at, event_id)
+TTL toDateTime(occurred_at) + INTERVAL 180 DAY DELETE;

--- a/src/dev_health_ops/migrations/clickhouse/041_product_telemetry_events.sql
+++ b/src/dev_health_ops/migrations/clickhouse/041_product_telemetry_events.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS product_telemetry_events (
-    org_id_hash Nullable(String),
+    org_id_hash String DEFAULT '',
     event_id String,
     name LowCardinality(String),
     schema_version String,

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -78,6 +78,12 @@ beat_schedule = {
         "kwargs": {"max_iterations": 50},
         "options": {"queue": "ingest"},
     },
+    "process-product-telemetry-streams": {
+        "task": "dev_health_ops.workers.tasks.run_product_telemetry_consumer",
+        "schedule": 30.0,
+        "kwargs": {"max_iterations": 50},
+        "options": {"queue": "ingest"},
+    },
     "phone-home-heartbeat": {
         "task": "dev_health_ops.workers.tasks.phone_home_heartbeat",
         "schedule": crontab(hour=0, minute=0),

--- a/src/dev_health_ops/workers/system_ops.py
+++ b/src/dev_health_ops/workers/system_ops.py
@@ -23,6 +23,21 @@ def run_ingest_consumer(self, max_iterations: int = 100):
     return {"processed": processed}
 
 
+@celery_app.task(
+    bind=True,
+    queue="ingest",
+    name="dev_health_ops.workers.tasks.run_product_telemetry_consumer",
+)
+def run_product_telemetry_consumer(self, max_iterations: int = 100):
+    """Process buffered product telemetry stream entries."""
+    from dev_health_ops.api.product_telemetry.consumer import (
+        consume_product_telemetry_streams,
+    )
+
+    processed = consume_product_telemetry_streams(max_iterations=max_iterations)
+    return {"processed": processed}
+
+
 @celery_app.task(bind=True, name="dev_health_ops.workers.tasks.health_check")
 def health_check(self) -> dict:
     """Simple health check task to verify worker is running."""

--- a/src/dev_health_ops/workers/system_tasks.py
+++ b/src/dev_health_ops/workers/system_tasks.py
@@ -2,6 +2,7 @@ from dev_health_ops.workers.system_ops import (
     health_check,
     phone_home_heartbeat,
     run_ingest_consumer,
+    run_product_telemetry_consumer,
     send_billing_notification,
 )
 from dev_health_ops.workers.system_webhooks import process_webhook_event
@@ -11,5 +12,6 @@ __all__ = [
     "phone_home_heartbeat",
     "process_webhook_event",
     "run_ingest_consumer",
+    "run_product_telemetry_consumer",
     "send_billing_notification",
 ]

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -36,6 +36,7 @@ from dev_health_ops.workers.system_tasks import (
     phone_home_heartbeat,
     process_webhook_event,
     run_ingest_consumer,
+    run_product_telemetry_consumer,
     send_billing_notification,
 )
 from dev_health_ops.workers.task_utils import (
@@ -78,6 +79,7 @@ __all__ = [
     "run_dora_metrics",
     "run_ingest_consumer",
     "run_investment_materialize",
+    "run_product_telemetry_consumer",
     "run_sync_config",
     "run_work_graph_build",
     "run_work_items_sync",

--- a/tests/api/test_product_telemetry_persist.py
+++ b/tests/api/test_product_telemetry_persist.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Any
 
 from dev_health_ops.api.product_telemetry.consumer import (
+    _ensure_group,
     consume_product_telemetry_streams,
 )
 
@@ -29,8 +30,13 @@ class FakeSink:
 
 
 class FakeRedis:
-    def __init__(self, entries: list[tuple[str, dict[str, str]]]) -> None:
+    def __init__(
+        self,
+        entries: list[tuple[str, dict[str, str]]],
+        xgroup_error: Exception | None = None,
+    ) -> None:
         self.entries = entries
+        self.xgroup_error = xgroup_error
         self.acked: list[tuple[str, str, tuple[str, ...]]] = []
         self.dlq: list[tuple[str, dict[str, str]]] = []
 
@@ -40,6 +46,8 @@ class FakeRedis:
     def xgroup_create(
         self, stream_key: str, group: str, id: str = "0", mkstream: bool = True
     ) -> None:
+        if self.xgroup_error is not None:
+            raise self.xgroup_error
         return None
 
     def xreadgroup(
@@ -192,3 +200,22 @@ def test_product_telemetry_consumer_rejects_blocked_payload_keys_to_dlq(
     assert dlq_stream == "product-telemetry:dlq"
     assert dlq_data["original_stream"] == "product-telemetry:org_hash_123:events"
     assert dlq_data["entry_id"] == "1-0"
+
+
+def test_product_telemetry_consumer_ignores_existing_consumer_group() -> None:
+    redis = FakeRedis(
+        [], xgroup_error=Exception("BUSYGROUP Consumer Group name already exists")
+    )
+
+    _ensure_group(redis, "product-telemetry:org_hash_123:events")
+
+
+def test_product_telemetry_consumer_raises_unexpected_consumer_group_error() -> None:
+    redis = FakeRedis([], xgroup_error=Exception("connection refused"))
+
+    try:
+        _ensure_group(redis, "product-telemetry:org_hash_123:events")
+    except Exception as exc:
+        assert str(exc) == "connection refused"
+    else:
+        raise AssertionError("expected _ensure_group to re-raise unexpected errors")

--- a/tests/api/test_product_telemetry_persist.py
+++ b/tests/api/test_product_telemetry_persist.py
@@ -138,6 +138,30 @@ def test_product_telemetry_consumer_persists_sanitized_payload_json(
     assert isinstance(row["occurred_at"], datetime)
 
 
+def test_product_telemetry_consumer_coerces_missing_org_hash_to_empty_string(
+    monkeypatch,
+) -> None:
+    event = _event()
+    event.pop("orgIdHash")
+    redis = FakeRedis([_entry("1-0", event)])
+    clickhouse = FakeClickHouseClient()
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.product_telemetry.streams.get_redis_client", lambda: redis
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.product_telemetry.persist.create_sink",
+        lambda: FakeSink(clickhouse),
+    )
+
+    processed = consume_product_telemetry_streams(max_iterations=1)
+
+    assert processed == 1
+    _table, rows, columns = clickhouse.inserts[0]
+    row = dict(zip(columns, rows[0]))
+    assert row["org_id_hash"] == ""
+
+
 def test_product_telemetry_consumer_rejects_blocked_payload_keys_to_dlq(
     monkeypatch,
 ) -> None:

--- a/tests/api/test_product_telemetry_persist.py
+++ b/tests/api/test_product_telemetry_persist.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+
+from dev_health_ops.api.product_telemetry.consumer import (
+    consume_product_telemetry_streams,
+)
+
+
+class FakeClickHouseClient:
+    def __init__(self) -> None:
+        self.inserts: list[tuple[str, list[list[Any]], list[str]]] = []
+
+    def insert(
+        self, table: str, rows: list[list[Any]], column_names: list[str]
+    ) -> None:
+        self.inserts.append((table, rows, column_names))
+
+
+class FakeSink:
+    def __init__(self, client: FakeClickHouseClient) -> None:
+        self.client = client
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeRedis:
+    def __init__(self, entries: list[tuple[str, dict[str, str]]]) -> None:
+        self.entries = entries
+        self.acked: list[tuple[str, str, tuple[str, ...]]] = []
+        self.dlq: list[tuple[str, dict[str, str]]] = []
+
+    def scan_iter(self, match: str, _type: str | None = None) -> list[str]:
+        return ["product-telemetry:org_hash_123:events"]
+
+    def xgroup_create(
+        self, stream_key: str, group: str, id: str = "0", mkstream: bool = True
+    ) -> None:
+        return None
+
+    def xreadgroup(
+        self,
+        group: str,
+        consumer: str,
+        streams: dict[str, str],
+        count: int,
+        block: int,
+    ) -> list[tuple[str, list[tuple[str, dict[str, str]]]]]:
+        entries = self.entries
+        self.entries = []
+        if not entries:
+            return []
+        return [("product-telemetry:org_hash_123:events", entries)]
+
+    def xack(self, stream_key: str, group: str, *entry_ids: str) -> None:
+        self.acked.append((stream_key, group, entry_ids))
+
+    def xadd(self, stream_key: str, data: dict[str, str]) -> None:
+        self.dlq.append((stream_key, data))
+
+
+def _event(payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "name": "chart_interacted",
+        "schemaVersion": "2026-05-telemetry-v1",
+        "eventId": "evt_123",
+        "ts": "2026-05-25T12:00:00Z",
+        "sessionId": "ses_123",
+        "anonymousUserId": "anon_123",
+        "orgIdHash": "org_hash_123",
+        "routePattern": "/metrics",
+        "payload": payload
+        or {
+            "chart": "quadrant",
+            "action": "overlay_toggled",
+            "surface": "metrics",
+            "scope": "org",
+        },
+    }
+
+
+def _entry(entry_id: str, event: dict[str, Any]) -> tuple[str, dict[str, str]]:
+    return (
+        entry_id,
+        {
+            "ingestion_id": "ing_123",
+            "source": "dev-health-web",
+            "org_id_hash": "org_hash_123",
+            "events": json.dumps([event]),
+        },
+    )
+
+
+def test_product_telemetry_consumer_persists_sanitized_payload_json(
+    monkeypatch,
+) -> None:
+    redis = FakeRedis([_entry("1-0", _event())])
+    clickhouse = FakeClickHouseClient()
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.product_telemetry.streams.get_redis_client", lambda: redis
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.product_telemetry.persist.create_sink",
+        lambda: FakeSink(clickhouse),
+    )
+
+    processed = consume_product_telemetry_streams(max_iterations=1)
+
+    assert processed == 1
+    assert redis.acked == [
+        (
+            "product-telemetry:org_hash_123:events",
+            "product-telemetry-consumers",
+            ("1-0",),
+        )
+    ]
+    assert redis.dlq == []
+    table, rows, columns = clickhouse.inserts[0]
+    assert table == "product_telemetry_events"
+    row = dict(zip(columns, rows[0]))
+    assert row["org_id_hash"] == "org_hash_123"
+    assert row["event_id"] == "evt_123"
+    assert row["payload_json"] == json.dumps(
+        {
+            "chart": "quadrant",
+            "action": "overlay_toggled",
+            "surface": "metrics",
+            "scope": "org",
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    assert isinstance(row["occurred_at"], datetime)
+
+
+def test_product_telemetry_consumer_rejects_blocked_payload_keys_to_dlq(
+    monkeypatch,
+) -> None:
+    redis = FakeRedis([_entry("1-0", _event({"email": "ada@example.com", "ok": True}))])
+    clickhouse = FakeClickHouseClient()
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.product_telemetry.streams.get_redis_client", lambda: redis
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.product_telemetry.persist.create_sink",
+        lambda: FakeSink(clickhouse),
+    )
+
+    processed = consume_product_telemetry_streams(max_iterations=1)
+
+    assert processed == 0
+    assert clickhouse.inserts == []
+    assert redis.acked == [
+        (
+            "product-telemetry:org_hash_123:events",
+            "product-telemetry-consumers",
+            ("1-0",),
+        )
+    ]
+    assert redis.dlq
+    dlq_stream, dlq_data = redis.dlq[0]
+    assert dlq_stream == "product-telemetry:dlq"
+    assert dlq_data["original_stream"] == "product-telemetry:org_hash_123:events"
+    assert dlq_data["entry_id"] == "1-0"


### PR DESCRIPTION
## Summary
- Add dedicated product telemetry Redis Stream writer using product-telemetry:{orgHashOrAnonymous}:events
- Add product telemetry consumer on the existing ingest queue with validation, ACK, ClickHouse persistence, and product-telemetry:dlq rejection path
- Add ClickHouse migration 041_product_telemetry_events.sql with 180-day TTL and ReplacingMergeTree(ingested_at)

Refs CHAOS-450
Plan: docs/superpowers/plans/2026-05-25-product-telemetry-usage-analytics.md

## Verification
- pytest tests/api/test_product_telemetry.py tests/api/test_product_telemetry_persist.py -q -> 7 passed
- ruff format --check src/dev_health_ops/api/product_telemetry tests/api/test_product_telemetry.py tests/api/test_product_telemetry_persist.py -> 8 files already formatted
- ruff check src/dev_health_ops/api/product_telemetry tests/api/test_product_telemetry.py tests/api/test_product_telemetry_persist.py -> All checks passed
- LSP diagnostics: 0 diagnostics for src/dev_health_ops/api/product_telemetry
- Existing telemetry router tests: none found by tests/api/**/*telemetry*.py beyond new product telemetry tests; existing /api/v1/telemetry/* router code was not modified

SCREENSHOT-WAIVER: backend-only, no rendered UI