### PR TITLE
chore(ops): commit-msg hook to strip agent-attribution trailers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,9 +423,15 @@ linear-cli issues update CHAOS-123 --state "Done"
 
 ## 11. Pre-commit + pre-push hooks (lefthook + ruff)
 
-Lefthook drives two hooks that together match what CI enforces
-(`ruff format --check .` and `ruff check .`):
+Lefthook drives three hooks:
 
+- **commit-msg** strips agent-attribution trailers from every commit message
+  before the commit lands. Backs the repo-root AGENTS.md rule
+  "Never add contribution attribution for agents in commits." Removes
+  `Ultraworked with [...]`, `Co-authored-by: Sisyphus`,
+  `Co-authored-by: Claude`, and `🤖 Generated with [Claude Code]` lines.
+  Implementation: `scripts/strip_agent_attribution.py`. Tests:
+  `tests/scripts/test_strip_agent_attribution.py`.
 - **pre-commit** auto-fixes formatting and lint on staged `.py` files and
   re-stages the fixes (`stage_fixed: true`). The resulting commit is clean.
 - **pre-push** is a final gate: `ruff format --check` + `ruff check` on the
@@ -459,6 +465,12 @@ lefthook install --force
 If `lefthook install` (without `--force`) warns about `core.hooksPath`, add `--force`.
 
 ### Hook behaviour
+
+**commit-msg** (on every `git commit`, edits the commit message file in place):
+
+| Step | Command | Behaviour |
+|------|---------|-----------|
+| 1 | `python3 scripts/strip_agent_attribution.py {1}` | Removes agent-attribution trailers (`Ultraworked with`, `Co-authored-by: Sisyphus`, `Co-authored-by: Claude`, `🤖 Generated with`). Idempotent. Preserves real human `Co-authored-by`, `Signed-off-by`, `Refs`, `Closes`. |
 
 **pre-commit** (on every `git commit`, for staged `.py` files):
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,6 +14,15 @@
 #
 # Install: `make install` (wires `lefthook install` into the bootstrap).
 
+commit-msg:
+  commands:
+    strip-agent-attribution:
+      # AGENTS.md rule: "Never add contribution attribution for agents in commits."
+      # Sisyphus / oh-my-openagent / Claude Code and similar agents inject
+      # "Ultraworked with ..." and "Co-authored-by: <agent>" trailers despite
+      # the repo rule; this hook strips them before the commit lands.
+      run: python3 scripts/strip_agent_attribution.py {1}
+
 pre-commit:
   parallel: true
   commands:

--- a/scripts/strip_agent_attribution.py
+++ b/scripts/strip_agent_attribution.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Strip agent-attribution trailers from a commit message file.
+
+Invoked by the lefthook ``commit-msg`` hook on every ``git commit``.
+
+The repo-root ``AGENTS.md`` rule states: "Never add contribution attribution
+for agents in commits." Sisyphus, oh-my-openagent, Claude Code, and similar
+AI coding agents inject "Ultraworked with [...]" and
+"Co-authored-by: <agent>" trailers into commit messages despite the rule.
+
+This hook removes them before the commit lands so ``main`` stays clean.
+
+Usage::
+
+    python3 scripts/strip_agent_attribution.py <commit-msg-file>
+
+Behaviour:
+* Idempotent: running on a clean message is a no-op.
+* Preserves all other trailers (real ``Co-authored-by`` for humans,
+  ``Signed-off-by``, ``Refs``, ``Closes``, etc.).
+* Collapses runs of blank lines created by removal back to a single blank.
+
+Exit codes:
+* 0 — message rewritten (or unchanged); commit proceeds.
+* non-zero — only if argv is malformed or the file is unreadable.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Patterns that match agent-attribution lines. Match the whole line including
+# trailing newline so the surrounding blank-line collapse stays clean.
+_AGENT_LINE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # "Ultraworked with [Sisyphus](https://...)"
+    re.compile(r"^Ultraworked with \[[^\]]+\]\([^)]*\)\s*$", re.MULTILINE),
+    # "Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>"
+    re.compile(r"^Co-authored-by:\s+Sisyphus\s+<[^>]*>\s*$", re.MULTILINE),
+    # "Co-authored-by: Claude <noreply@anthropic.com>" or similar
+    re.compile(r"^Co-authored-by:\s+Claude\s+<[^>]*>\s*$", re.MULTILINE),
+    # "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+    re.compile(r"^🤖 Generated with \[?[^\]\n]+\]?\([^)]*\)?\s*$", re.MULTILINE),
+)
+
+
+def strip_agent_attribution(message: str) -> str:
+    """Return ``message`` with agent-attribution lines removed."""
+    cleaned = message
+    for pattern in _AGENT_LINE_PATTERNS:
+        cleaned = pattern.sub("", cleaned)
+    # Collapse runs of 3+ blank lines to a single blank line.
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    # Ensure exactly one trailing newline.
+    return cleaned.rstrip() + "\n"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            "usage: strip_agent_attribution.py <commit-msg-file>",
+            file=sys.stderr,
+        )
+        return 2
+    path = Path(argv[1])
+    try:
+        original = path.read_text()
+    except OSError as exc:
+        print(f"strip_agent_attribution: cannot read {path}: {exc}", file=sys.stderr)
+        return 1
+    cleaned = strip_agent_attribution(original)
+    if cleaned != original:
+        path.write_text(cleaned)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_strip_agent_attribution.py
+++ b/tests/scripts/test_strip_agent_attribution.py
@@ -1,0 +1,163 @@
+"""Tests for ``scripts/strip_agent_attribution.py`` (lefthook commit-msg hook)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "strip_agent_attribution.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "strip_agent_attribution", _SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["strip_agent_attribution"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_module = _load_module()
+strip_agent_attribution = _module.strip_agent_attribution
+main = _module.main
+
+
+# ---------------------------------------------------------------------------
+# strip_agent_attribution()
+# ---------------------------------------------------------------------------
+
+
+def test_strips_sisyphus_trailer_pair() -> None:
+    msg = (
+        "feat(api): add product telemetry endpoint (CHAOS-1789)\n"
+        "\n"
+        "Adds POST /api/v1/product-telemetry/events.\n"
+        "\n"
+        "Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)\n"
+        "\n"
+        "Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>\n"
+    )
+    cleaned = strip_agent_attribution(msg)
+    assert "Sisyphus" not in cleaned
+    assert "Ultraworked" not in cleaned
+    assert "clio-agent" not in cleaned
+    assert cleaned == (
+        "feat(api): add product telemetry endpoint (CHAOS-1789)\n"
+        "\n"
+        "Adds POST /api/v1/product-telemetry/events.\n"
+    )
+
+
+def test_strips_claude_code_trailer() -> None:
+    msg = (
+        "fix(db): handle BUSYGROUP on consumer group setup\n"
+        "\n"
+        "🤖 Generated with [Claude Code](https://claude.com/claude-code)\n"
+        "\n"
+        "Co-authored-by: Claude <noreply@anthropic.com>\n"
+    )
+    cleaned = strip_agent_attribution(msg)
+    assert "Claude" not in cleaned
+    assert "🤖" not in cleaned
+    assert cleaned.rstrip() == "fix(db): handle BUSYGROUP on consumer group setup"
+
+
+def test_preserves_real_human_co_author() -> None:
+    msg = (
+        "feat(metrics): wire DORA dashboard tile (CHAOS-1234)\n"
+        "\n"
+        "Co-authored-by: Alex Real-Human <alex@example.com>\n"
+        "Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>\n"
+    )
+    cleaned = strip_agent_attribution(msg)
+    assert "Alex Real-Human <alex@example.com>" in cleaned
+    assert "Sisyphus" not in cleaned
+
+
+def test_preserves_signed_off_by_and_refs() -> None:
+    msg = (
+        "fix(api): drop nullable sort key (CHAOS-450)\n"
+        "\n"
+        "Refs CHAOS-450\n"
+        "Closes CHAOS-786\n"
+        "Signed-off-by: Real Person <real@example.com>\n"
+        "Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)\n"
+        "Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>\n"
+    )
+    cleaned = strip_agent_attribution(msg)
+    assert "Refs CHAOS-450" in cleaned
+    assert "Closes CHAOS-786" in cleaned
+    assert "Signed-off-by: Real Person" in cleaned
+    assert "Sisyphus" not in cleaned
+    assert "Ultraworked" not in cleaned
+
+
+def test_idempotent_on_clean_message() -> None:
+    msg = "chore(deps): bump ruff to 0.6.5\n\nNo behaviour change.\n"
+    assert strip_agent_attribution(msg) == msg
+
+
+def test_collapses_runs_of_blank_lines() -> None:
+    msg = (
+        "subject\n"
+        "\n"
+        "body line\n"
+        "\n"
+        "\n"
+        "\n"
+        "Ultraworked with [Sisyphus](https://example.com/x)\n"
+        "Co-authored-by: Sisyphus <agent@example.com>\n"
+    )
+    cleaned = strip_agent_attribution(msg)
+    assert "\n\n\n" not in cleaned
+    assert cleaned.endswith("body line\n")
+
+
+# ---------------------------------------------------------------------------
+# main() — CLI behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_main_rewrites_file_in_place(tmp_path: Path) -> None:
+    msg_file = tmp_path / "COMMIT_EDITMSG"
+    msg_file.write_text(
+        "feat: thing\n"
+        "\n"
+        "Ultraworked with [Sisyphus](https://example.com/x)\n"
+        "Co-authored-by: Sisyphus <agent@example.com>\n"
+    )
+    rc = main(["strip_agent_attribution.py", str(msg_file)])
+    assert rc == 0
+    assert msg_file.read_text() == "feat: thing\n"
+
+
+def test_main_returns_2_on_bad_argv(tmp_path: Path) -> None:
+    assert main(["strip_agent_attribution.py"]) == 2
+    assert main(["strip_agent_attribution.py", "a", "b"]) == 2
+
+
+def test_main_returns_1_on_unreadable_file(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    rc = main(["strip_agent_attribution.py", str(missing)])
+    assert rc == 1
+
+
+@pytest.mark.parametrize(
+    "agent_line",
+    [
+        "Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>",
+        "Co-authored-by: Sisyphus <other-agent@example.org>",
+        "Co-authored-by: Claude <noreply@anthropic.com>",
+        "Ultraworked with [SomeAgent](https://example.com)",
+    ],
+)
+def test_strips_known_agent_lines_parametrized(agent_line: str) -> None:
+    msg = f"subject\n\nbody\n\n{agent_line}\n"
+    cleaned = strip_agent_attribution(msg)
+    assert agent_line not in cleaned


### PR DESCRIPTION
## Why

Repo-root `AGENTS.md` rule: "Never add contribution attribution for agents in commits."

Sisyphus / oh-my-openagent / Claude Code and similar AI coding agents inject `Ultraworked with [...]` and `Co-authored-by: <agent>` trailers into every commit despite the rule. Five trailer-bearing squash commits already landed in `main` during the CHAOS-450 product-telemetry rollout (web cfb7434, ops bdbeff0, ops e972ad4). Prompt-level instructions are not enough; a repo-level hook is needed.

## What

- `scripts/strip_agent_attribution.py` — commit-msg processor. Strips `Ultraworked with [...]`, `Co-authored-by: Sisyphus`, `Co-authored-by: Claude`, and `🤖 Generated with [Claude Code]` lines. Preserves real human `Co-authored-by`, `Signed-off-by`, `Refs`, `Closes`. Idempotent. Collapses runs of blank lines.
- `tests/scripts/test_strip_agent_attribution.py` — 13 unit tests covering trailer detection, human-author preservation, idempotency, blank-line collapse, and CLI argv handling.
- `lefthook.yml` — new `commit-msg` hook section wires the script.
- `AGENTS.md` §11 — documents the new hook in the existing lefthook table.

## Verification

```
pytest tests/scripts/test_strip_agent_attribution.py -q  # 13 passed
ruff format --check scripts/strip_agent_attribution.py tests/scripts/test_strip_agent_attribution.py  # clean
ruff check scripts/strip_agent_attribution.py tests/scripts/test_strip_agent_attribution.py  # clean
```

End-to-end smoke test: lefthook installed, commit-msg hook fired on a stub commit, trailers stripped, real subject + body preserved. The commit that creates this PR was itself processed by the hook.

## Follow-up (out of scope for this PR)

- `dev-health-web` has no git hook tooling installed. A sibling PR there would need to introduce `lefthook` or equivalent and port this hook over.
- The 3 already-merged squash commits in main retain their trailers. Rewriting main is destructive (blast radius: every developer's checkout, every CI cache, every blame) and is left to the owner's call.

TEST-WAIVER: this PR ships its own tests under `tests/scripts/`.

SCREENSHOT-WAIVER: hook + script only, no rendered UI.