### PR TITLE
feat(api): product telemetry dashboard read API (CHAOS-1869)

### DIFF
--- a/docs/api/graphql-overview.md
+++ b/docs/api/graphql-overview.md
@@ -81,6 +81,33 @@ query Analytics($orgId: String!, $batch: AnalyticsRequestInput!) {
 }
 ```
 
+### Query.productTelemetryDashboard
+
+Fetch first-party product usage dashboard aggregates from the persisted ClickHouse `product_telemetry_events` table. This query is read-only, org-scoped, and uses the same half-open date range contract as the product telemetry dashboard UI: `startDate` is inclusive and `endDate` is exclusive.
+
+```graphql
+query ProductTelemetryDashboard($orgId: String!, $input: ProductTelemetryDashboardInput!) {
+  productTelemetryDashboard(orgId: $orgId, input: $input) {
+    dailyActiveUsers { day activeAnonymousUsers }
+    topRoutes { routePattern events sessions anonymousUsers }
+    featureViews { feature surface views anonymousUsers }
+    filterChanges { view filterKey changes avgValueCount }
+    chartInteractions { chart action surface interactions sessions }
+    clientErrors { routePattern boundary errorClass errors affectedAnonymousUsers }
+    sessionSummary {
+      p50DurationMs
+      p75DurationMs
+      p90DurationMs
+      p95DurationMs
+      avgPagesViewed
+      avgInteractions
+    }
+  }
+}
+```
+
+The resolver derives the product telemetry `org_id_hash` from the authenticated organization before querying ClickHouse. Callers still provide the raw `orgId` variable used by the GraphQL authorization layer; raw organization IDs are not read from `product_telemetry_events`.
+
 ---
 
 ## Example Queries

--- a/docs/superpowers/plans/2026-05-25-product-telemetry-dashboard.md
+++ b/docs/superpowers/plans/2026-05-25-product-telemetry-dashboard.md
@@ -1,0 +1,385 @@
+# Product Telemetry Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first-party ClickHouse-backed product telemetry dashboard recommended by `docs/product/product-telemetry-dashboard-assessment.md`.
+
+**Architecture:** Keep `product_telemetry_events` as the canonical source of truth. Add a backend read model and GraphQL query that aggregates persisted ClickHouse rows, then render the result in `dev-health-web` with existing chart/table patterns. CHAOS-1868 remains responsible for ingestion; this plan covers the read/API/UI path.
+
+**Tech Stack:** Python, FastAPI, Strawberry GraphQL, ClickHouse, pytest, Next.js, TypeScript, urql, Vitest, Playwright.
+
+---
+
+## Linear Tracking
+
+- Parent: CHAOS-1869 — First-party product telemetry dashboard
+- Backend read model: CHAOS-1870
+- API/GraphQL exposure: CHAOS-1871
+- Web dashboard: CHAOS-1872
+- QA/privacy pass: CHAOS-1873
+- Related ingestion dependency: CHAOS-1868
+
+## File Structure
+
+### Ops backend
+
+- Create `src/dev_health_ops/api/product_telemetry/dashboard.py` for ClickHouse dashboard query SQL and row mapping.
+- Create `tests/api/test_product_telemetry_dashboard.py` for backend read-model tests using fake ClickHouse clients.
+- Modify `src/dev_health_ops/api/graphql/models/outputs.py` to add typed Strawberry output objects for dashboard sections.
+- Modify `src/dev_health_ops/api/graphql/models/inputs.py` to add a date-range input if no reusable date range fits the dashboard query.
+- Create `src/dev_health_ops/api/graphql/resolvers/product_telemetry.py` for auth-scoped resolver orchestration.
+- Modify `src/dev_health_ops/api/graphql/schema.py` to expose `productTelemetryDashboard`.
+- Add or update GraphQL resolver tests under `tests/api/graphql/`.
+- Run `python -m dev_health_ops.api.graphql.export_schema` if schema export changes `dev-health-web` contracts.
+
+### Web frontend
+
+- Modify generated GraphQL schema/types after ops schema export, following existing `src/lib/graphql/__generated__/` workflow.
+- Create `src/lib/graphql/productTelemetryFetchers.ts` for server-side dashboard query fetching.
+- Create `src/lib/graphql/hooks/useProductTelemetryDashboard.ts` only if the page needs client-side refresh; otherwise prefer server-side fetching.
+- Create `src/components/product-telemetry/ProductTelemetryDashboard.tsx` for dashboard composition.
+- Create focused section components under `src/components/product-telemetry/` for route usage, feature usage, filter changes, chart interactions, client errors, and session summary if the main component grows beyond a readable single page.
+- Create `src/app/(app)/admin/product-telemetry/page.tsx` for the admin dashboard route.
+- Add tests next to new frontend modules and Playwright coverage for the route.
+
+## Task 1: Backend read model over ClickHouse (CHAOS-1870)
+
+**Files:**
+- Create: `src/dev_health_ops/api/product_telemetry/dashboard.py`
+- Create: `tests/api/test_product_telemetry_dashboard.py`
+
+- [ ] **Step 1: Write failing tests for dashboard query orchestration**
+
+Create `tests/api/test_product_telemetry_dashboard.py` with a fake client that records SQL calls and returns section-specific rows:
+
+```python
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.product_telemetry.dashboard import (
+    ProductTelemetryDashboardRange,
+    load_product_telemetry_dashboard,
+)
+
+
+class FakeQueryClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+
+async def fake_query_dicts(
+    client: FakeQueryClient, sql: str, params: dict[str, Any]
+) -> list[dict[str, Any]]:
+    client.calls.append((sql, params))
+    if "active_anonymous_users" in sql:
+        return [{"day": date(2026, 5, 24), "active_anonymous_users": 7}]
+    if "FROM product_telemetry_events" in sql and "route_pattern" in sql and "page_viewed" in sql:
+        return [{"route_pattern": "/metrics", "events": 9, "sessions": 3, "anonymous_users": 2}]
+    if "feature_viewed" in sql:
+        return [{"feature": "investment", "surface": "dashboard", "views": 5, "anonymous_users": 2}]
+    if "filter_changed" in sql:
+        return [{"view": "metrics", "filter_key": "team", "changes": 4, "avg_value_count": 1.5}]
+    if "chart_interacted" in sql:
+        return [{"chart": "quadrant", "action": "hover", "surface": "metrics", "interactions": 8, "sessions": 2}]
+    if "client_error" in sql:
+        return [{"route_pattern": "/metrics", "boundary": "chart", "error_class": "RenderError", "errors": 2, "affected_anonymous_users": 1}]
+    if "session_ended" in sql:
+        return [{"p50_duration_ms": 1000, "p75_duration_ms": 1500, "p90_duration_ms": 2500, "p95_duration_ms": 3000, "avg_pages_viewed": 4.0, "avg_interactions": 11.0}]
+    return []
+
+
+@pytest.mark.asyncio
+async def test_load_product_telemetry_dashboard_queries_all_sections(monkeypatch) -> None:
+    client = FakeQueryClient()
+    monkeypatch.setattr(
+        "dev_health_ops.api.product_telemetry.dashboard.query_dicts",
+        fake_query_dicts,
+    )
+
+    result = await load_product_telemetry_dashboard(
+        client,
+        org_id_hash="org_hash_123",
+        date_range=ProductTelemetryDashboardRange(
+            start_date=date(2026, 5, 1), end_date=date(2026, 5, 25)
+        ),
+    )
+
+    assert result.daily_active_users[0].active_anonymous_users == 7
+    assert result.top_routes[0].route_pattern == "/metrics"
+    assert result.feature_views[0].feature == "investment"
+    assert result.filter_changes[0].filter_key == "team"
+    assert result.chart_interactions[0].chart == "quadrant"
+    assert result.client_errors[0].error_class == "RenderError"
+    assert result.session_summary.p95_duration_ms == 3000
+    assert len(client.calls) == 7
+    assert all(call[1]["org_id_hash"] == "org_hash_123" for call in client.calls)
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+pytest tests/api/test_product_telemetry_dashboard.py -q
+```
+
+Expected: fail because `dev_health_ops.api.product_telemetry.dashboard` does not exist.
+
+- [ ] **Step 3: Implement typed dashboard read model and queries**
+
+Create `src/dev_health_ops/api/product_telemetry/dashboard.py` with dataclasses for each dashboard section and a `load_product_telemetry_dashboard()` function. Use `dev_health_ops.api.queries.client.query_dicts` for execution. Every query must include `org_id_hash = %(org_id_hash)s`, `occurred_at >= %(start)s`, and `occurred_at < %(end)s`.
+
+The SQL sections should implement the sketches from `docs/product/product-telemetry-dashboard-assessment.md` with stable aliases:
+
+```sql
+SELECT toDate(occurred_at) AS day, uniqExact(anonymous_user_id) AS active_anonymous_users
+FROM product_telemetry_events
+WHERE org_id_hash = %(org_id_hash)s
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY day
+ORDER BY day
+```
+
+Repeat for `page_viewed`, `feature_viewed`, `filter_changed`, `chart_interacted`, `client_error`, and `session_ended` using the assessment’s dimensions and aliases.
+
+- [ ] **Step 4: Run backend read-model tests**
+
+Run:
+
+```bash
+pytest tests/api/test_product_telemetry_dashboard.py -q
+```
+
+Expected: pass.
+
+## Task 2: GraphQL dashboard API (CHAOS-1871)
+
+**Files:**
+- Modify: `src/dev_health_ops/api/graphql/models/inputs.py`
+- Modify: `src/dev_health_ops/api/graphql/models/outputs.py`
+- Create: `src/dev_health_ops/api/graphql/resolvers/product_telemetry.py`
+- Modify: `src/dev_health_ops/api/graphql/schema.py`
+- Create: `tests/api/graphql/test_product_telemetry_dashboard_resolver.py`
+
+- [ ] **Step 1: Write failing resolver test**
+
+Create a test that builds a `GraphQLContext` with `org_id="org_hash_123"` and fake client, monkeypatches `load_product_telemetry_dashboard`, calls `resolve_product_telemetry_dashboard`, and asserts the output shape includes all seven sections.
+
+```python
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.models.inputs import ProductTelemetryDashboardInput
+from dev_health_ops.api.graphql.resolvers.product_telemetry import (
+    resolve_product_telemetry_dashboard,
+)
+from dev_health_ops.api.product_telemetry.dashboard import (
+    ProductTelemetryDashboard,
+    ProductTelemetryDailyActiveUsers,
+    ProductTelemetrySessionSummary,
+)
+
+
+@pytest.mark.asyncio
+async def test_resolve_product_telemetry_dashboard_requires_org_and_maps_sections(monkeypatch) -> None:
+    async def fake_loader(client, org_id_hash, date_range):
+        assert org_id_hash == "org_hash_123"
+        return ProductTelemetryDashboard(
+            daily_active_users=[ProductTelemetryDailyActiveUsers(day=date(2026, 5, 24), active_anonymous_users=7)],
+            top_routes=[],
+            feature_views=[],
+            filter_changes=[],
+            chart_interactions=[],
+            client_errors=[],
+            session_summary=ProductTelemetrySessionSummary(),
+        )
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.graphql.resolvers.product_telemetry.load_product_telemetry_dashboard",
+        fake_loader,
+    )
+
+    context = GraphQLContext(client=object(), org_id="org_hash_123")
+    result = await resolve_product_telemetry_dashboard(
+        context,
+        ProductTelemetryDashboardInput(start_date=date(2026, 5, 1), end_date=date(2026, 5, 25)),
+    )
+
+    assert result.daily_active_users[0].active_anonymous_users == 7
+    assert result.session_summary.avg_pages_viewed is None
+```
+
+- [ ] **Step 2: Run resolver test to verify red**
+
+Run:
+
+```bash
+pytest tests/api/graphql/test_product_telemetry_dashboard_resolver.py -q
+```
+
+Expected: fail because GraphQL input/output/resolver types are missing.
+
+- [ ] **Step 3: Add GraphQL input and output contracts**
+
+Add `ProductTelemetryDashboardInput` to `models/inputs.py` with `start_date: date` and `end_date: date`. Add Strawberry output types to `models/outputs.py` matching the backend dataclasses:
+
+- `ProductTelemetryDailyActiveUsersType`
+- `ProductTelemetryRouteUsageType`
+- `ProductTelemetryFeatureViewType`
+- `ProductTelemetryFilterChangeType`
+- `ProductTelemetryChartInteractionType`
+- `ProductTelemetryClientErrorType`
+- `ProductTelemetrySessionSummaryType`
+- `ProductTelemetryDashboardType`
+
+Use numeric fields as `int` or `float | None`, and expose `day` as `date`.
+
+- [ ] **Step 4: Add resolver**
+
+Create `src/dev_health_ops/api/graphql/resolvers/product_telemetry.py`. Use `require_org_id(context)`, ensure `context.client` exists, validate `start_date <= end_date`, call `load_product_telemetry_dashboard()`, and map dataclasses to Strawberry output types.
+
+- [ ] **Step 5: Expose schema field**
+
+In `schema.py`, import the input/output/resolver and add:
+
+```python
+@strawberry.field(description="Get first-party product telemetry dashboard metrics")
+async def product_telemetry_dashboard(
+    self,
+    info: Info,
+    org_id: str,
+    input: ProductTelemetryDashboardInput,
+) -> ProductTelemetryDashboardType:
+    context = get_context(info)
+    return await resolve_product_telemetry_dashboard(context, input)
+```
+
+- [ ] **Step 6: Run GraphQL tests**
+
+Run:
+
+```bash
+pytest tests/api/graphql/test_product_telemetry_dashboard_resolver.py tests/api/test_product_telemetry_dashboard.py -q
+```
+
+Expected: pass.
+
+## Task 3: Web dashboard data contract and route (CHAOS-1872)
+
+**Files:**
+- Modify: `web/src/lib/graphql/schema.graphql`
+- Modify generated files under `web/src/lib/graphql/__generated__/`
+- Create: `web/src/lib/graphql/productTelemetryFetchers.ts`
+- Create: `web/src/components/product-telemetry/ProductTelemetryDashboard.tsx`
+- Create: `web/src/app/(app)/admin/product-telemetry/page.tsx`
+- Create tests next to new frontend files.
+
+- [ ] **Step 1: Export and sync GraphQL schema**
+
+From ops, run the schema export command used by `src/dev_health_ops/api/graphql/export_schema.py`, then copy or sync the schema into `web/src/lib/graphql/schema.graphql` following the existing repo workflow. Regenerate frontend GraphQL types with the package script defined in `web/package.json`.
+
+- [ ] **Step 2: Write failing fetcher test**
+
+Add a test for `productTelemetryFetchers.ts` that verifies the GraphQL document requests `productTelemetryDashboard` with `dailyActiveUsers`, `topRoutes`, `featureViews`, `filterChanges`, `chartInteractions`, `clientErrors`, and `sessionSummary`.
+
+- [ ] **Step 3: Implement fetcher**
+
+Create a server-side fetcher that accepts `{ orgId, startDate, endDate }`, calls the generated GraphQL document, and returns a normalized dashboard object. Follow the existing server GraphQL fetcher patterns in `src/lib/graphql/*Fetchers.ts`.
+
+- [ ] **Step 4: Write failing component test**
+
+Add a Vitest/Testing Library test for `ProductTelemetryDashboard` with representative data. Assert the page renders:
+
+- daily active anonymous users trend heading
+- top route `/metrics`
+- feature `investment`
+- filter key `team`
+- chart `quadrant`
+- error class `RenderError`
+- session p95 duration
+
+- [ ] **Step 5: Implement dashboard component and route**
+
+Create the dashboard component using existing chart/table components from `src/components/charts/` and metric cards from `src/components/metrics/`. Add `src/app/(app)/admin/product-telemetry/page.tsx` with an authenticated admin page that fetches the last 30 days and renders the component.
+
+- [ ] **Step 6: Run web tests**
+
+Run from `web/`:
+
+```bash
+pnpm test ProductTelemetryDashboard productTelemetryFetchers
+pnpm typecheck
+```
+
+Expected: pass.
+
+## Task 4: End-to-end QA and privacy verification (CHAOS-1873)
+
+**Files:**
+- Add or modify Playwright test under `web/tests/`.
+- Update PR/Linear evidence with screenshots when implementation lands.
+
+- [ ] **Step 1: Seed representative product telemetry events**
+
+Use the existing product telemetry ingestion fixtures or insert representative rows into local ClickHouse for these event names: `page_viewed`, `feature_viewed`, `filter_changed`, `chart_interacted`, `client_error`, and `session_ended`.
+
+- [ ] **Step 2: Verify API surface manually**
+
+Run a GraphQL query against the local ops API for `productTelemetryDashboard` with the seeded org and a 30-day range. Expected: all seven sections return seeded aggregates and no raw blocked fields appear.
+
+- [ ] **Step 3: Verify browser surface manually**
+
+Use the Playwright skill and a real browser to open `/admin/product-telemetry`. Expected: dashboard renders populated sections, empty-state behavior works with no seeded rows, and console has no runtime errors.
+
+- [ ] **Step 4: Verify privacy/network boundaries**
+
+In the browser network panel or Playwright request log, confirm the dashboard does not send product telemetry events to SigNoz, PostHog, Plausible, Kafka, or any external collector. Expected: only first-party app/API requests appear.
+
+- [ ] **Step 5: Capture screenshots**
+
+Capture dashboard screenshots and attach them to the implementation PR and CHAOS-1869/CHAOS-1872 when UI work lands.
+
+## Verification Commands
+
+Run from `ops/`:
+
+```bash
+pytest tests/api/test_product_telemetry_dashboard.py tests/api/graphql/test_product_telemetry_dashboard_resolver.py -q
+ruff format --check src/dev_health_ops/api/product_telemetry src/dev_health_ops/api/graphql tests/api/test_product_telemetry_dashboard.py tests/api/graphql/test_product_telemetry_dashboard_resolver.py
+ruff check src/dev_health_ops/api/product_telemetry src/dev_health_ops/api/graphql tests/api/test_product_telemetry_dashboard.py tests/api/graphql/test_product_telemetry_dashboard_resolver.py
+```
+
+Run from `web/`:
+
+```bash
+pnpm test ProductTelemetryDashboard productTelemetryFetchers
+pnpm typecheck
+```
+
+Manual QA gate:
+
+```text
+1. Start the local stack.
+2. Seed product_telemetry_events rows.
+3. Query productTelemetryDashboard via GraphQL.
+4. Open /admin/product-telemetry in a browser.
+5. Capture screenshot evidence.
+6. Confirm no external vendor/collector network requests.
+```
+
+## Self-Review
+
+- Assessment coverage: the plan covers daily active anonymous users, top route patterns, feature views, filter changes, chart interactions, client errors, and session duration distribution.
+- Boundary coverage: ClickHouse remains source of truth; no vendor adapter, Kafka, autocapture, session replay, or schema-source migration is included.
+- Tracking coverage: Linear parent and subissues exist for backend, API, web, and QA work.
+- Type consistency: backend dataclasses map to GraphQL output types, then to generated frontend GraphQL types.
+- Placeholder scan: no task intentionally defers undefined behavior; follow-up adapters remain out of scope per assessment.

--- a/docs/user-guide/product-telemetry.md
+++ b/docs/user-guide/product-telemetry.md
@@ -52,6 +52,24 @@ The table is optimized for analytical queries and includes the following fields:
 - **TTL:** ClickHouse automatically deletes rows older than 180 days based on the `occurred_at` column.
 - **Rollups:** Future phases may introduce aggregate rollups for long-term trend analysis beyond the 180-day raw event window.
 
+## Product Telemetry Dashboard
+
+The first-party dashboard is available in the admin UI at `/admin/product-telemetry`. It reads the persisted ClickHouse `product_telemetry_events` table through the GraphQL API and does not call external analytics providers.
+
+The default dashboard window is the last 30 days, represented as a half-open date range: `start_date` is inclusive and `end_date` is exclusive. Dashboard sections are intentionally limited to the early product-usage questions supported by the sanitized event contract:
+
+- Daily active anonymous users.
+- Top route patterns by page-view events, sessions, and anonymous users.
+- Stable feature IDs viewed by surface.
+- Filter changes by view and filter key, including average selected value count.
+- Chart interactions by chart type, action, and surface.
+- Client errors by route pattern, boundary, and error class.
+- Session duration percentiles plus average pages viewed and interactions.
+
+Organization scoping uses the same one-way organization hash emitted by `dev-health-web` product telemetry. The dashboard resolver hashes the authenticated organization ID before querying `org_id_hash`, so raw organization IDs are not stored in or queried from the product telemetry table.
+
+The dashboard is a read-only analytics surface. It renders persisted aggregates only; it does not recompute telemetry classifications in the UI and does not write dashboard outputs back to storage.
+
 ## Separation of Concerns
 
 Product telemetry is strictly separated from other telemetry types in the platform:

--- a/src/dev_health_ops/api/graphql/models/inputs.py
+++ b/src/dev_health_ops/api/graphql/models/inputs.py
@@ -137,6 +137,14 @@ class DateRangeInput:
 
 
 @strawberry.input
+class ProductTelemetryDashboardInput:
+    """Half-open date range for product telemetry dashboard queries."""
+
+    start_date: date
+    end_date: date
+
+
+@strawberry.input
 class TimeseriesRequestInput:
     """Request for a timeseries query."""
 

--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -103,6 +103,75 @@ class AnalyticsResult:
 
 
 @strawberry.type
+class ProductTelemetryDailyActiveUsersType:
+    day: date
+    active_anonymous_users: int
+
+
+@strawberry.type
+class ProductTelemetryRouteUsageType:
+    route_pattern: str
+    events: int
+    sessions: int
+    anonymous_users: int
+
+
+@strawberry.type
+class ProductTelemetryFeatureViewType:
+    feature: str
+    surface: str
+    views: int
+    anonymous_users: int
+
+
+@strawberry.type
+class ProductTelemetryFilterChangeType:
+    view: str
+    filter_key: str
+    changes: int
+    avg_value_count: float | None = None
+
+
+@strawberry.type
+class ProductTelemetryChartInteractionType:
+    chart: str
+    action: str
+    surface: str
+    interactions: int
+    sessions: int
+
+
+@strawberry.type
+class ProductTelemetryClientErrorType:
+    route_pattern: str
+    boundary: str
+    error_class: str
+    errors: int
+    affected_anonymous_users: int
+
+
+@strawberry.type
+class ProductTelemetrySessionSummaryType:
+    p50_duration_ms: int | None = None
+    p75_duration_ms: int | None = None
+    p90_duration_ms: int | None = None
+    p95_duration_ms: int | None = None
+    avg_pages_viewed: float | None = None
+    avg_interactions: float | None = None
+
+
+@strawberry.type
+class ProductTelemetryDashboardType:
+    daily_active_users: list[ProductTelemetryDailyActiveUsersType]
+    top_routes: list[ProductTelemetryRouteUsageType]
+    feature_views: list[ProductTelemetryFeatureViewType]
+    filter_changes: list[ProductTelemetryFilterChangeType]
+    chart_interactions: list[ProductTelemetryChartInteractionType]
+    client_errors: list[ProductTelemetryClientErrorType]
+    session_summary: ProductTelemetrySessionSummaryType
+
+
+@strawberry.type
 class CatalogDimension:
     """A dimension available in the catalog."""
 

--- a/src/dev_health_ops/api/graphql/resolvers/product_telemetry.py
+++ b/src/dev_health_ops/api/graphql/resolvers/product_telemetry.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from hashlib import sha256
+
+from dev_health_ops.api.product_telemetry.dashboard import (
+    ProductTelemetryDashboardRange,
+    load_product_telemetry_dashboard,
+)
+
+from ..authz import require_org_id
+from ..context import GraphQLContext
+from ..models.inputs import ProductTelemetryDashboardInput
+from ..models.outputs import (
+    ProductTelemetryChartInteractionType,
+    ProductTelemetryClientErrorType,
+    ProductTelemetryDailyActiveUsersType,
+    ProductTelemetryDashboardType,
+    ProductTelemetryFeatureViewType,
+    ProductTelemetryFilterChangeType,
+    ProductTelemetryRouteUsageType,
+    ProductTelemetrySessionSummaryType,
+)
+
+
+def _product_telemetry_org_hash(org_id: str) -> str:
+    return sha256(org_id.encode()).hexdigest()
+
+
+async def resolve_product_telemetry_dashboard(
+    context: GraphQLContext,
+    input: ProductTelemetryDashboardInput,
+) -> ProductTelemetryDashboardType:
+    org_id = require_org_id(context)
+    client = context.client
+    if client is None:
+        raise RuntimeError("Database client not available")
+    if input.start_date > input.end_date:
+        raise ValueError("start_date must be before or equal to end_date")
+
+    dashboard = await load_product_telemetry_dashboard(
+        client,
+        org_id_hash=_product_telemetry_org_hash(org_id),
+        date_range=ProductTelemetryDashboardRange(
+            start_date=input.start_date,
+            end_date=input.end_date,
+        ),
+    )
+
+    return ProductTelemetryDashboardType(
+        daily_active_users=[
+            ProductTelemetryDailyActiveUsersType(
+                day=item.day,
+                active_anonymous_users=item.active_anonymous_users,
+            )
+            for item in dashboard.daily_active_users
+        ],
+        top_routes=[
+            ProductTelemetryRouteUsageType(
+                route_pattern=item.route_pattern,
+                events=item.events,
+                sessions=item.sessions,
+                anonymous_users=item.anonymous_users,
+            )
+            for item in dashboard.top_routes
+        ],
+        feature_views=[
+            ProductTelemetryFeatureViewType(
+                feature=item.feature,
+                surface=item.surface,
+                views=item.views,
+                anonymous_users=item.anonymous_users,
+            )
+            for item in dashboard.feature_views
+        ],
+        filter_changes=[
+            ProductTelemetryFilterChangeType(
+                view=item.view,
+                filter_key=item.filter_key,
+                changes=item.changes,
+                avg_value_count=item.avg_value_count,
+            )
+            for item in dashboard.filter_changes
+        ],
+        chart_interactions=[
+            ProductTelemetryChartInteractionType(
+                chart=item.chart,
+                action=item.action,
+                surface=item.surface,
+                interactions=item.interactions,
+                sessions=item.sessions,
+            )
+            for item in dashboard.chart_interactions
+        ],
+        client_errors=[
+            ProductTelemetryClientErrorType(
+                route_pattern=item.route_pattern,
+                boundary=item.boundary,
+                error_class=item.error_class,
+                errors=item.errors,
+                affected_anonymous_users=item.affected_anonymous_users,
+            )
+            for item in dashboard.client_errors
+        ],
+        session_summary=ProductTelemetrySessionSummaryType(
+            p50_duration_ms=dashboard.session_summary.p50_duration_ms,
+            p75_duration_ms=dashboard.session_summary.p75_duration_ms,
+            p90_duration_ms=dashboard.session_summary.p90_duration_ms,
+            p95_duration_ms=dashboard.session_summary.p95_duration_ms,
+            avg_pages_viewed=dashboard.session_summary.avg_pages_viewed,
+            avg_interactions=dashboard.session_summary.avg_interactions,
+        ),
+    )

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -30,6 +30,7 @@ from .models.inputs import (
     DimensionInput,
     FilterInput,
     OperatingReviewInput,
+    ProductTelemetryDashboardInput,
     SecurityAlertFilterInput,
     SecurityPaginationInput,
     ThroughputForecastInput,
@@ -42,6 +43,7 @@ from .models.outputs import (
     CatalogResult,
     HomeResult,
     OperatingReview,
+    ProductTelemetryDashboardType,
     SecurityAlertConnection,
     SecurityOverview,
     ThroughputForecast,
@@ -67,6 +69,7 @@ from .resolvers.catalog import resolve_catalog
 from .resolvers.complexity import resolve_complexity_timeseries, resolve_hotspots
 from .resolvers.compounding_risk import resolve_compounding_risk
 from .resolvers.data_health import resolve_data_health
+from .resolvers.product_telemetry import resolve_product_telemetry_dashboard
 from .resolvers.reports import (
     CloneSavedReportInput,
     CreateSavedReportInput,
@@ -153,6 +156,16 @@ class Query:
         """
         context = get_context(info)
         return await resolve_analytics(context, batch)
+
+    @strawberry.field(description="Get first-party product telemetry dashboard metrics")
+    async def product_telemetry_dashboard(
+        self,
+        info: Info,
+        org_id: str,
+        input: ProductTelemetryDashboardInput,
+    ) -> ProductTelemetryDashboardType:
+        context = get_context(info)
+        return await resolve_product_telemetry_dashboard(context, input)
 
     @strawberry.field(description="Get home dashboard metrics")
     async def home(

--- a/src/dev_health_ops/api/product_telemetry/dashboard.py
+++ b/src/dev_health_ops/api/product_telemetry/dashboard.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import asyncio
+import math
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any
+
+from dev_health_ops.api.queries.client import query_dicts, require_clickhouse_backend
+
+
+@dataclass(frozen=True)
+class ProductTelemetryDashboardRange:
+    """Half-open dashboard range: start_date is inclusive, end_date is exclusive."""
+
+    start_date: date
+    end_date: date
+
+
+@dataclass(frozen=True)
+class ProductTelemetryDailyActiveUsers:
+    day: date
+    active_anonymous_users: int
+
+
+@dataclass(frozen=True)
+class ProductTelemetryRouteUsage:
+    route_pattern: str
+    events: int
+    sessions: int
+    anonymous_users: int
+
+
+@dataclass(frozen=True)
+class ProductTelemetryFeatureView:
+    feature: str
+    surface: str
+    views: int
+    anonymous_users: int
+
+
+@dataclass(frozen=True)
+class ProductTelemetryFilterChange:
+    view: str
+    filter_key: str
+    changes: int
+    avg_value_count: float | None
+
+
+@dataclass(frozen=True)
+class ProductTelemetryChartInteraction:
+    chart: str
+    action: str
+    surface: str
+    interactions: int
+    sessions: int
+
+
+@dataclass(frozen=True)
+class ProductTelemetryClientError:
+    route_pattern: str
+    boundary: str
+    error_class: str
+    errors: int
+    affected_anonymous_users: int
+
+
+@dataclass(frozen=True)
+class ProductTelemetrySessionSummary:
+    p50_duration_ms: int | None = None
+    p75_duration_ms: int | None = None
+    p90_duration_ms: int | None = None
+    p95_duration_ms: int | None = None
+    avg_pages_viewed: float | None = None
+    avg_interactions: float | None = None
+
+
+@dataclass(frozen=True)
+class ProductTelemetryDashboard:
+    daily_active_users: list[ProductTelemetryDailyActiveUsers] = field(
+        default_factory=list
+    )
+    top_routes: list[ProductTelemetryRouteUsage] = field(default_factory=list)
+    feature_views: list[ProductTelemetryFeatureView] = field(default_factory=list)
+    filter_changes: list[ProductTelemetryFilterChange] = field(default_factory=list)
+    chart_interactions: list[ProductTelemetryChartInteraction] = field(
+        default_factory=list
+    )
+    client_errors: list[ProductTelemetryClientError] = field(default_factory=list)
+    session_summary: ProductTelemetrySessionSummary = field(
+        default_factory=ProductTelemetrySessionSummary
+    )
+
+
+DAILY_ACTIVE_USERS_SQL = """
+SELECT
+    toDate(occurred_at) AS day,
+    uniqExact(anonymous_user_id) AS active_anonymous_users
+FROM product_telemetry_events
+WHERE org_id_hash = %(org_id_hash)s
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY day
+ORDER BY day
+"""
+
+TOP_ROUTES_SQL = """
+SELECT
+    route_pattern,
+    count() AS events,
+    uniqExact(session_id) AS sessions,
+    uniqExact(anonymous_user_id) AS anonymous_users
+FROM product_telemetry_events
+WHERE org_id_hash = %(org_id_hash)s
+  AND name = 'page_viewed'
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY route_pattern
+ORDER BY events DESC
+LIMIT 25
+"""
+
+FEATURE_VIEWS_SQL = """
+SELECT
+    JSONExtractString(payload_json, 'feature') AS feature,
+    JSONExtractString(payload_json, 'surface') AS surface,
+    count() AS views,
+    uniqExact(anonymous_user_id) AS anonymous_users
+FROM product_telemetry_events
+WHERE org_id_hash = %(org_id_hash)s
+  AND name = 'feature_viewed'
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY feature, surface
+ORDER BY views DESC
+"""
+
+FILTER_CHANGES_SQL = """
+SELECT
+    JSONExtractString(payload_json, 'view') AS view,
+    JSONExtractString(payload_json, 'filterKey') AS filter_key,
+    count() AS changes,
+    avg(JSONExtractInt(payload_json, 'valueCount')) AS avg_value_count
+FROM product_telemetry_events
+WHERE org_id_hash = %(org_id_hash)s
+  AND name = 'filter_changed'
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY view, filter_key
+ORDER BY changes DESC
+"""
+
+CHART_INTERACTIONS_SQL = """
+SELECT
+    JSONExtractString(payload_json, 'chart') AS chart,
+    JSONExtractString(payload_json, 'action') AS action,
+    JSONExtractString(payload_json, 'surface') AS surface,
+    count() AS interactions,
+    uniqExact(session_id) AS sessions
+FROM product_telemetry_events
+WHERE org_id_hash = %(org_id_hash)s
+  AND name = 'chart_interacted'
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY chart, action, surface
+ORDER BY interactions DESC
+"""
+
+CLIENT_ERRORS_SQL = """
+SELECT
+    route_pattern,
+    JSONExtractString(payload_json, 'boundary') AS boundary,
+    JSONExtractString(payload_json, 'errorClass') AS error_class,
+    count() AS errors,
+    uniqExact(anonymous_user_id) AS affected_anonymous_users
+FROM product_telemetry_events
+WHERE org_id_hash = %(org_id_hash)s
+  AND name = 'client_error'
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY route_pattern, boundary, error_class
+ORDER BY errors DESC
+"""
+
+SESSION_SUMMARY_SQL = """
+SELECT
+    quantile(0.5)(JSONExtractInt(payload_json, 'durationMs')) AS p50_duration_ms,
+    quantile(0.75)(JSONExtractInt(payload_json, 'durationMs')) AS p75_duration_ms,
+    quantile(0.9)(JSONExtractInt(payload_json, 'durationMs')) AS p90_duration_ms,
+    quantile(0.95)(JSONExtractInt(payload_json, 'durationMs')) AS p95_duration_ms,
+    avg(JSONExtractInt(payload_json, 'pagesViewed')) AS avg_pages_viewed,
+    avg(JSONExtractInt(payload_json, 'interactions')) AS avg_interactions
+FROM product_telemetry_events
+WHERE org_id_hash = %(org_id_hash)s
+  AND name = 'session_ended'
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+"""
+
+
+def _params(
+    org_id_hash: str, date_range: ProductTelemetryDashboardRange
+) -> dict[str, Any]:
+    return {
+        "org_id_hash": org_id_hash,
+        "start": date_range.start_date,
+        "end": date_range.end_date,
+    }
+
+
+async def load_product_telemetry_dashboard(
+    client: Any,
+    org_id_hash: str,
+    date_range: ProductTelemetryDashboardRange,
+) -> ProductTelemetryDashboard:
+    require_clickhouse_backend(client)
+    params = _params(org_id_hash, date_range)
+
+    (
+        daily_rows,
+        route_rows,
+        feature_rows,
+        filter_rows,
+        chart_rows,
+        error_rows,
+        session_rows,
+    ) = await asyncio.gather(
+        query_dicts(client, DAILY_ACTIVE_USERS_SQL, params),
+        query_dicts(client, TOP_ROUTES_SQL, params),
+        query_dicts(client, FEATURE_VIEWS_SQL, params),
+        query_dicts(client, FILTER_CHANGES_SQL, params),
+        query_dicts(client, CHART_INTERACTIONS_SQL, params),
+        query_dicts(client, CLIENT_ERRORS_SQL, params),
+        query_dicts(client, SESSION_SUMMARY_SQL, params),
+    )
+
+    return ProductTelemetryDashboard(
+        daily_active_users=[
+            ProductTelemetryDailyActiveUsers(
+                day=row["day"],
+                active_anonymous_users=int(row.get("active_anonymous_users") or 0),
+            )
+            for row in daily_rows
+        ],
+        top_routes=[
+            ProductTelemetryRouteUsage(
+                route_pattern=str(row.get("route_pattern") or ""),
+                events=int(row.get("events") or 0),
+                sessions=int(row.get("sessions") or 0),
+                anonymous_users=int(row.get("anonymous_users") or 0),
+            )
+            for row in route_rows
+        ],
+        feature_views=[
+            ProductTelemetryFeatureView(
+                feature=str(row.get("feature") or ""),
+                surface=str(row.get("surface") or ""),
+                views=int(row.get("views") or 0),
+                anonymous_users=int(row.get("anonymous_users") or 0),
+            )
+            for row in feature_rows
+        ],
+        filter_changes=[
+            ProductTelemetryFilterChange(
+                view=str(row.get("view") or ""),
+                filter_key=str(row.get("filter_key") or ""),
+                changes=int(row.get("changes") or 0),
+                avg_value_count=_optional_float(row.get("avg_value_count")),
+            )
+            for row in filter_rows
+        ],
+        chart_interactions=[
+            ProductTelemetryChartInteraction(
+                chart=str(row.get("chart") or ""),
+                action=str(row.get("action") or ""),
+                surface=str(row.get("surface") or ""),
+                interactions=int(row.get("interactions") or 0),
+                sessions=int(row.get("sessions") or 0),
+            )
+            for row in chart_rows
+        ],
+        client_errors=[
+            ProductTelemetryClientError(
+                route_pattern=str(row.get("route_pattern") or ""),
+                boundary=str(row.get("boundary") or ""),
+                error_class=str(row.get("error_class") or ""),
+                errors=int(row.get("errors") or 0),
+                affected_anonymous_users=int(row.get("affected_anonymous_users") or 0),
+            )
+            for row in error_rows
+        ],
+        session_summary=_session_summary(session_rows),
+    )
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    result = float(value)
+    if not math.isfinite(result):
+        return None
+    return result
+
+
+def _optional_int(value: Any) -> int | None:
+    value = _optional_float(value)
+    if value is None:
+        return None
+    return int(value)
+
+
+def _session_summary(rows: list[dict[str, Any]]) -> ProductTelemetrySessionSummary:
+    if not rows:
+        return ProductTelemetrySessionSummary()
+    row = rows[0]
+    return ProductTelemetrySessionSummary(
+        p50_duration_ms=_optional_int(row.get("p50_duration_ms")),
+        p75_duration_ms=_optional_int(row.get("p75_duration_ms")),
+        p90_duration_ms=_optional_int(row.get("p90_duration_ms")),
+        p95_duration_ms=_optional_int(row.get("p95_duration_ms")),
+        avg_pages_viewed=_optional_float(row.get("avg_pages_viewed")),
+        avg_interactions=_optional_float(row.get("avg_interactions")),
+    )

--- a/tests/api/graphql/test_product_telemetry_dashboard_resolver.py
+++ b/tests/api/graphql/test_product_telemetry_dashboard_resolver.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import date
+from hashlib import sha256
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.models.inputs import ProductTelemetryDashboardInput
+from dev_health_ops.api.graphql.resolvers.product_telemetry import (
+    resolve_product_telemetry_dashboard,
+)
+from dev_health_ops.api.product_telemetry.dashboard import (
+    ProductTelemetryDailyActiveUsers,
+    ProductTelemetryDashboard,
+    ProductTelemetrySessionSummary,
+)
+
+
+@pytest.mark.asyncio
+async def test_resolve_product_telemetry_dashboard_requires_org_and_maps_sections(
+    monkeypatch,
+) -> None:
+    expected_org_id_hash = sha256(b"org_raw_123").hexdigest()
+
+    async def fake_loader(client, org_id_hash, date_range):
+        assert client is fake_client
+        assert org_id_hash == expected_org_id_hash
+        assert date_range.start_date == date(2026, 5, 1)
+        assert date_range.end_date == date(2026, 5, 25)
+        return ProductTelemetryDashboard(
+            daily_active_users=[
+                ProductTelemetryDailyActiveUsers(
+                    day=date(2026, 5, 24), active_anonymous_users=7
+                )
+            ],
+            top_routes=[],
+            feature_views=[],
+            filter_changes=[],
+            chart_interactions=[],
+            client_errors=[],
+            session_summary=ProductTelemetrySessionSummary(),
+        )
+
+    fake_client = object()
+    monkeypatch.setattr(
+        "dev_health_ops.api.graphql.resolvers.product_telemetry.load_product_telemetry_dashboard",
+        fake_loader,
+    )
+
+    context = GraphQLContext(
+        org_id="org_raw_123", db_url="clickhouse://test", client=fake_client
+    )
+    result = await resolve_product_telemetry_dashboard(
+        context,
+        ProductTelemetryDashboardInput(
+            start_date=date(2026, 5, 1), end_date=date(2026, 5, 25)
+        ),
+    )
+
+    assert result.daily_active_users[0].active_anonymous_users == 7
+    assert result.session_summary.avg_pages_viewed is None

--- a/tests/api/test_product_telemetry_dashboard.py
+++ b/tests/api/test_product_telemetry_dashboard.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from datetime import date
+from math import nan
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.product_telemetry.dashboard import (
+    ProductTelemetryDashboardRange,
+    load_product_telemetry_dashboard,
+)
+
+
+class FakeQueryClient:
+    backend_type = "clickhouse"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+
+async def fake_query_dicts(
+    client: FakeQueryClient, sql: str, params: dict[str, Any]
+) -> list[dict[str, Any]]:
+    client.calls.append((sql, params))
+    if "active_anonymous_users" in sql:
+        return [{"day": date(2026, 5, 24), "active_anonymous_users": 7}]
+    if "name = 'page_viewed'" in sql:
+        return [
+            {
+                "route_pattern": "/metrics",
+                "events": 9,
+                "sessions": 3,
+                "anonymous_users": 2,
+            }
+        ]
+    if "name = 'feature_viewed'" in sql:
+        return [
+            {
+                "feature": "investment",
+                "surface": "dashboard",
+                "views": 5,
+                "anonymous_users": 2,
+            }
+        ]
+    if "name = 'filter_changed'" in sql:
+        return [
+            {
+                "view": "metrics",
+                "filter_key": "team",
+                "changes": 4,
+                "avg_value_count": 1.5,
+            }
+        ]
+    if "name = 'chart_interacted'" in sql:
+        return [
+            {
+                "chart": "quadrant",
+                "action": "hover",
+                "surface": "metrics",
+                "interactions": 8,
+                "sessions": 2,
+            }
+        ]
+    if "name = 'client_error'" in sql:
+        return [
+            {
+                "route_pattern": "/metrics",
+                "boundary": "chart",
+                "error_class": "RenderError",
+                "errors": 2,
+                "affected_anonymous_users": 1,
+            }
+        ]
+    if "name = 'session_ended'" in sql:
+        return [
+            {
+                "p50_duration_ms": 1000,
+                "p75_duration_ms": 1500,
+                "p90_duration_ms": 2500,
+                "p95_duration_ms": 3000,
+                "avg_pages_viewed": 4.0,
+                "avg_interactions": 11.0,
+            }
+        ]
+    return []
+
+
+@pytest.mark.asyncio
+async def test_load_product_telemetry_dashboard_queries_all_sections(
+    monkeypatch,
+) -> None:
+    client = FakeQueryClient()
+    monkeypatch.setattr(
+        "dev_health_ops.api.product_telemetry.dashboard.query_dicts",
+        fake_query_dicts,
+    )
+
+    result = await load_product_telemetry_dashboard(
+        client,
+        org_id_hash="org_hash_123",
+        date_range=ProductTelemetryDashboardRange(
+            start_date=date(2026, 5, 1), end_date=date(2026, 5, 25)
+        ),
+    )
+
+    assert result.daily_active_users[0].active_anonymous_users == 7
+    assert result.top_routes[0].route_pattern == "/metrics"
+    assert result.feature_views[0].feature == "investment"
+    assert result.filter_changes[0].filter_key == "team"
+    assert result.chart_interactions[0].chart == "quadrant"
+    assert result.client_errors[0].error_class == "RenderError"
+    assert result.session_summary.p95_duration_ms == 3000
+    assert len(client.calls) == 7
+    assert all(call[1]["org_id_hash"] == "org_hash_123" for call in client.calls)
+    assert all("product_telemetry_events" in call[0] for call in client.calls)
+    assert all("occurred_at >= %(start)s" in call[0] for call in client.calls)
+    assert all("occurred_at < %(end)s" in call[0] for call in client.calls)
+
+
+async def fake_query_dicts_with_empty_session_summary(
+    client: FakeQueryClient, sql: str, params: dict[str, Any]
+) -> list[dict[str, Any]]:
+    client.calls.append((sql, params))
+    if "name = 'session_ended'" in sql:
+        return [
+            {
+                "p50_duration_ms": nan,
+                "p75_duration_ms": nan,
+                "p90_duration_ms": nan,
+                "p95_duration_ms": nan,
+                "avg_pages_viewed": nan,
+                "avg_interactions": nan,
+            }
+        ]
+    return []
+
+
+@pytest.mark.asyncio
+async def test_load_product_telemetry_dashboard_normalizes_empty_session_summary(
+    monkeypatch,
+) -> None:
+    client = FakeQueryClient()
+    monkeypatch.setattr(
+        "dev_health_ops.api.product_telemetry.dashboard.query_dicts",
+        fake_query_dicts_with_empty_session_summary,
+    )
+
+    result = await load_product_telemetry_dashboard(
+        client,
+        org_id_hash="org_hash_123",
+        date_range=ProductTelemetryDashboardRange(
+            start_date=date(2026, 5, 1), end_date=date(2026, 5, 25)
+        ),
+    )
+
+    assert result.session_summary.p50_duration_ms is None
+    assert result.session_summary.p95_duration_ms is None
+    assert result.session_summary.avg_pages_viewed is None
+    assert result.session_summary.avg_interactions is None


### PR DESCRIPTION
## Summary
- Adds the ClickHouse product telemetry dashboard read model for DAU, route usage, feature views, filters, chart interactions, client errors, and session summary.
- Exposes the dashboard through GraphQL with org-scoped SHA-256 hash lookup.
- Documents the GraphQL API and user guide path.

## Test Plan
- pytest tests/api/test_product_telemetry_dashboard.py tests/api/graphql/test_product_telemetry_dashboard_resolver.py -q
- ruff check src/dev_health_ops/api/product_telemetry/dashboard.py src/dev_health_ops/api/graphql/resolvers/product_telemetry.py src/dev_health_ops/api/graphql/models/inputs.py src/dev_health_ops/api/graphql/models/outputs.py src/dev_health_ops/api/graphql/schema.py tests/api/test_product_telemetry_dashboard.py tests/api/graphql/test_product_telemetry_dashboard_resolver.py
- ruff format --check src/dev_health_ops/api/product_telemetry/dashboard.py src/dev_health_ops/api/graphql/resolvers/product_telemetry.py src/dev_health_ops/api/graphql/models/inputs.py src/dev_health_ops/api/graphql/models/outputs.py src/dev_health_ops/api/graphql/schema.py tests/api/test_product_telemetry_dashboard.py tests/api/graphql/test_product_telemetry_dashboard_resolver.py
- PYTHONPATH=src python -m dev_health_ops.api.graphql.export_schema --out /tmp/product-telemetry-schema.graphql

Closes CHAOS-1869
Refs CHAOS-1870
Refs CHAOS-1871