### PR TITLE
feat(api): platform-admin product telemetry dashboard (CHAOS-1875)

### DIFF
--- a/src/dev_health_ops/api/graphql/authz.py
+++ b/src/dev_health_ops/api/graphql/authz.py
@@ -155,6 +155,27 @@ def require_org_id(context: GraphQLContext) -> str:
     return context.org_id
 
 
+def require_platform_admin(context: GraphQLContext) -> None:
+    """
+    Validate that the authenticated user is a platform-level superuser.
+
+    Platform-admin queries are cross-org by design (e.g., the Super-admin
+    product telemetry dashboard). They must not be reachable by org-scoped
+    users even when ``org_id`` is present in the context.
+
+    Args:
+        context: GraphQL request context.
+
+    Raises:
+        AuthorizationError: If the user is missing or not a superuser.
+    """
+    user = context.user
+    if user is None:
+        raise AuthorizationError("Authentication required")
+    if not getattr(user, "is_superuser", False):
+        raise AuthorizationError("Platform admin access required")
+
+
 def enforce_org_scope(org_id: str, params: dict[str, Any]) -> dict[str, Any]:
     """
     Inject org_id into SQL parameters to enforce org scoping.

--- a/src/dev_health_ops/api/graphql/context.py
+++ b/src/dev_health_ops/api/graphql/context.py
@@ -54,7 +54,11 @@ class GraphQLContext(BaseContext):
     user: AuthenticatedUser | None = None
 
     def __post_init__(self) -> None:
-        if not self.org_id:
+        # Platform/super admins can reach cross-org admin queries without
+        # belonging to a tenant (e.g., the /superadmin/product-telemetry
+        # overview). Per-org resolvers still call ``require_org_id`` so an
+        # org-less context can't be used to query tenant-scoped data.
+        if not self.org_id and not getattr(self.user, "is_superuser", False):
             from .errors import AuthorizationError
 
             raise AuthorizationError("org_id is required")

--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -172,6 +172,51 @@ class ProductTelemetryDashboardType:
 
 
 @strawberry.type
+class ProductTelemetryPlatformTotalsType:
+    """Cross-org totals shown at the top of the Super-admin dashboard."""
+
+    active_orgs: int
+    anonymous_users: int
+    sessions: int
+    events: int
+
+
+@strawberry.type
+class ProductTelemetryTopOrgType:
+    """Per-org rollup row for the Super-admin drilldown table.
+
+    ``org_id`` / ``org_name`` / ``org_slug`` are resolved server-side from
+    Postgres by hashing each known organization's id and matching against
+    ``org_id_hash``. Unknown hashes (e.g., events ingested from orgs that no
+    longer exist) keep those fields ``None`` and the UI falls back to the
+    hash prefix.
+    """
+
+    org_id_hash: str
+    events: int
+    sessions: int
+    anonymous_users: int
+    org_id: str | None = None
+    org_name: str | None = None
+    org_slug: str | None = None
+
+
+@strawberry.type
+class ProductTelemetryPlatformDashboardType:
+    """Platform-admin product telemetry dashboard payload."""
+
+    totals: ProductTelemetryPlatformTotalsType
+    daily_active_users: list[ProductTelemetryDailyActiveUsersType]
+    top_routes: list[ProductTelemetryRouteUsageType]
+    feature_views: list[ProductTelemetryFeatureViewType]
+    filter_changes: list[ProductTelemetryFilterChangeType]
+    chart_interactions: list[ProductTelemetryChartInteractionType]
+    client_errors: list[ProductTelemetryClientErrorType]
+    session_summary: ProductTelemetrySessionSummaryType
+    top_orgs: list[ProductTelemetryTopOrgType]
+
+
+@strawberry.type
 class CatalogDimension:
     """A dimension available in the catalog."""
 

--- a/src/dev_health_ops/api/graphql/resolvers/product_telemetry.py
+++ b/src/dev_health_ops/api/graphql/resolvers/product_telemetry.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 from hashlib import sha256
 
+from sqlalchemy import select
+
 from dev_health_ops.api.product_telemetry.dashboard import (
     ProductTelemetryDashboardRange,
+    ProductTelemetryPlatformDashboard,
+    ProductTelemetryTopOrg,
     load_product_telemetry_dashboard,
+    load_product_telemetry_platform_dashboard,
 )
 
-from ..authz import require_org_id
+from ..authz import require_org_id, require_platform_admin
 from ..context import GraphQLContext
 from ..models.inputs import ProductTelemetryDashboardInput
 from ..models.outputs import (
@@ -17,8 +22,11 @@ from ..models.outputs import (
     ProductTelemetryDashboardType,
     ProductTelemetryFeatureViewType,
     ProductTelemetryFilterChangeType,
+    ProductTelemetryPlatformDashboardType,
+    ProductTelemetryPlatformTotalsType,
     ProductTelemetryRouteUsageType,
     ProductTelemetrySessionSummaryType,
+    ProductTelemetryTopOrgType,
 )
 
 
@@ -110,3 +118,162 @@ async def resolve_product_telemetry_dashboard(
             avg_interactions=dashboard.session_summary.avg_interactions,
         ),
     )
+
+
+async def _load_org_hash_index() -> dict[str, dict[str, str]]:
+    """Build a ``{org_id_hash: {org_id, slug, name}}`` lookup from Postgres.
+
+    Loads every organization row (orgs table is small even for large
+    deployments) and hashes ``str(org.id)`` with the same recipe used by the
+    per-org resolver, so the resulting map can be joined against ClickHouse
+    rollups by hash. Unknown hashes — events ingested from orgs that no
+    longer exist in Postgres — stay unresolved and are surfaced as hash-only
+    rows in the UI.
+    """
+    from dev_health_ops.db import get_postgres_session
+    from dev_health_ops.models.users import Organization
+
+    index: dict[str, dict[str, str]] = {}
+    async with get_postgres_session() as session:
+        result = await session.execute(
+            select(Organization.id, Organization.slug, Organization.name)
+        )
+        for org_id, slug, name in result.all():
+            org_id_str = str(org_id)
+            org_id_hash = _product_telemetry_org_hash(org_id_str)
+            index[org_id_hash] = {
+                "org_id": org_id_str,
+                "slug": str(slug or ""),
+                "name": str(name or ""),
+            }
+    return index
+
+
+def _resolve_top_orgs(
+    top_orgs: list[ProductTelemetryTopOrg],
+    org_index: dict[str, dict[str, str]],
+) -> list[ProductTelemetryTopOrgType]:
+    """Attach Postgres-side org names to ClickHouse top-org rollups by hash.
+
+    Pure function so the merge is unit-testable without touching Postgres.
+    """
+    resolved: list[ProductTelemetryTopOrgType] = []
+    for org in top_orgs:
+        match = org_index.get(org.org_id_hash)
+        resolved.append(
+            ProductTelemetryTopOrgType(
+                org_id_hash=org.org_id_hash,
+                events=org.events,
+                sessions=org.sessions,
+                anonymous_users=org.anonymous_users,
+                org_id=(match or {}).get("org_id"),
+                org_slug=(match or {}).get("slug") or None,
+                org_name=(match or {}).get("name") or None,
+            )
+        )
+    return resolved
+
+
+def _platform_dashboard_to_graphql(
+    dashboard: ProductTelemetryPlatformDashboard,
+    org_index: dict[str, dict[str, str]],
+) -> ProductTelemetryPlatformDashboardType:
+    return ProductTelemetryPlatformDashboardType(
+        totals=ProductTelemetryPlatformTotalsType(
+            active_orgs=dashboard.totals.active_orgs,
+            anonymous_users=dashboard.totals.anonymous_users,
+            sessions=dashboard.totals.sessions,
+            events=dashboard.totals.events,
+        ),
+        daily_active_users=[
+            ProductTelemetryDailyActiveUsersType(
+                day=item.day,
+                active_anonymous_users=item.active_anonymous_users,
+            )
+            for item in dashboard.daily_active_users
+        ],
+        top_routes=[
+            ProductTelemetryRouteUsageType(
+                route_pattern=item.route_pattern,
+                events=item.events,
+                sessions=item.sessions,
+                anonymous_users=item.anonymous_users,
+            )
+            for item in dashboard.top_routes
+        ],
+        feature_views=[
+            ProductTelemetryFeatureViewType(
+                feature=item.feature,
+                surface=item.surface,
+                views=item.views,
+                anonymous_users=item.anonymous_users,
+            )
+            for item in dashboard.feature_views
+        ],
+        filter_changes=[
+            ProductTelemetryFilterChangeType(
+                view=item.view,
+                filter_key=item.filter_key,
+                changes=item.changes,
+                avg_value_count=item.avg_value_count,
+            )
+            for item in dashboard.filter_changes
+        ],
+        chart_interactions=[
+            ProductTelemetryChartInteractionType(
+                chart=item.chart,
+                action=item.action,
+                surface=item.surface,
+                interactions=item.interactions,
+                sessions=item.sessions,
+            )
+            for item in dashboard.chart_interactions
+        ],
+        client_errors=[
+            ProductTelemetryClientErrorType(
+                route_pattern=item.route_pattern,
+                boundary=item.boundary,
+                error_class=item.error_class,
+                errors=item.errors,
+                affected_anonymous_users=item.affected_anonymous_users,
+            )
+            for item in dashboard.client_errors
+        ],
+        session_summary=ProductTelemetrySessionSummaryType(
+            p50_duration_ms=dashboard.session_summary.p50_duration_ms,
+            p75_duration_ms=dashboard.session_summary.p75_duration_ms,
+            p90_duration_ms=dashboard.session_summary.p90_duration_ms,
+            p95_duration_ms=dashboard.session_summary.p95_duration_ms,
+            avg_pages_viewed=dashboard.session_summary.avg_pages_viewed,
+            avg_interactions=dashboard.session_summary.avg_interactions,
+        ),
+        top_orgs=_resolve_top_orgs(dashboard.top_orgs, org_index),
+    )
+
+
+async def resolve_product_telemetry_platform_dashboard(
+    context: GraphQLContext,
+    input: ProductTelemetryDashboardInput,
+) -> ProductTelemetryPlatformDashboardType:
+    """Cross-org product telemetry dashboard for platform/super admins.
+
+    Requires ``context.user.is_superuser``. Aggregates across every tenant
+    and returns a top-orgs roll-up with names resolved from Postgres.
+    """
+    require_platform_admin(context)
+    client = context.client
+    if client is None:
+        raise RuntimeError("Database client not available")
+    if input.start_date > input.end_date:
+        raise ValueError("start_date must be before or equal to end_date")
+
+    dashboard = await load_product_telemetry_platform_dashboard(
+        client,
+        date_range=ProductTelemetryDashboardRange(
+            start_date=input.start_date,
+            end_date=input.end_date,
+        ),
+    )
+
+    org_index = await _load_org_hash_index() if dashboard.top_orgs else {}
+    return _platform_dashboard_to_graphql(dashboard, org_index)

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -44,6 +44,7 @@ from .models.outputs import (
     HomeResult,
     OperatingReview,
     ProductTelemetryDashboardType,
+    ProductTelemetryPlatformDashboardType,
     SecurityAlertConnection,
     SecurityOverview,
     ThroughputForecast,
@@ -69,7 +70,10 @@ from .resolvers.catalog import resolve_catalog
 from .resolvers.complexity import resolve_complexity_timeseries, resolve_hotspots
 from .resolvers.compounding_risk import resolve_compounding_risk
 from .resolvers.data_health import resolve_data_health
-from .resolvers.product_telemetry import resolve_product_telemetry_dashboard
+from .resolvers.product_telemetry import (
+    resolve_product_telemetry_dashboard,
+    resolve_product_telemetry_platform_dashboard,
+)
 from .resolvers.reports import (
     CloneSavedReportInput,
     CreateSavedReportInput,
@@ -166,6 +170,21 @@ class Query:
     ) -> ProductTelemetryDashboardType:
         context = get_context(info)
         return await resolve_product_telemetry_dashboard(context, input)
+
+    @strawberry.field(
+        description=(
+            "Cross-org product telemetry dashboard for platform/super admins. "
+            "Requires is_superuser. Returns global aggregates plus a top-orgs "
+            "rollup with org names resolved from Postgres."
+        )
+    )
+    async def product_telemetry_platform_dashboard(
+        self,
+        info: Info,
+        input: ProductTelemetryDashboardInput,
+    ) -> ProductTelemetryPlatformDashboardType:
+        context = get_context(info)
+        return await resolve_product_telemetry_platform_dashboard(context, input)
 
     @strawberry.field(description="Get home dashboard metrics")
     async def home(

--- a/src/dev_health_ops/api/product_telemetry/dashboard.py
+++ b/src/dev_health_ops/api/product_telemetry/dashboard.py
@@ -92,6 +92,58 @@ class ProductTelemetryDashboard:
     )
 
 
+@dataclass(frozen=True)
+class ProductTelemetryPlatformTotals:
+    """Cross-org aggregate counts for the platform-admin dashboard."""
+
+    active_orgs: int = 0
+    anonymous_users: int = 0
+    sessions: int = 0
+    events: int = 0
+
+
+@dataclass(frozen=True)
+class ProductTelemetryTopOrg:
+    """Per-org rollup row returned by the top-orgs query.
+
+    ``org_id`` / ``org_name`` / ``org_slug`` are filled in by the GraphQL
+    resolver after computing ``sha256(org.id)`` for each known Postgres
+    organization. Unknown hashes (e.g., events ingested from orgs that no
+    longer exist in Postgres) keep the resolved fields ``None``.
+    """
+
+    org_id_hash: str
+    events: int
+    sessions: int
+    anonymous_users: int
+    org_id: str | None = None
+    org_name: str | None = None
+    org_slug: str | None = None
+
+
+@dataclass(frozen=True)
+class ProductTelemetryPlatformDashboard:
+    """Platform-admin dashboard shape: cross-org rollups plus top-org list."""
+
+    totals: ProductTelemetryPlatformTotals = field(
+        default_factory=ProductTelemetryPlatformTotals
+    )
+    daily_active_users: list[ProductTelemetryDailyActiveUsers] = field(
+        default_factory=list
+    )
+    top_routes: list[ProductTelemetryRouteUsage] = field(default_factory=list)
+    feature_views: list[ProductTelemetryFeatureView] = field(default_factory=list)
+    filter_changes: list[ProductTelemetryFilterChange] = field(default_factory=list)
+    chart_interactions: list[ProductTelemetryChartInteraction] = field(
+        default_factory=list
+    )
+    client_errors: list[ProductTelemetryClientError] = field(default_factory=list)
+    session_summary: ProductTelemetrySessionSummary = field(
+        default_factory=ProductTelemetrySessionSummary
+    )
+    top_orgs: list[ProductTelemetryTopOrg] = field(default_factory=list)
+
+
 DAILY_ACTIVE_USERS_SQL = """
 SELECT
     toDate(occurred_at) AS day,
@@ -320,4 +372,259 @@ def _session_summary(rows: list[dict[str, Any]]) -> ProductTelemetrySessionSumma
         p95_duration_ms=_optional_int(row.get("p95_duration_ms")),
         avg_pages_viewed=_optional_float(row.get("avg_pages_viewed")),
         avg_interactions=_optional_float(row.get("avg_interactions")),
+    )
+
+
+# =============================================================================
+# Platform-admin dashboard (cross-org). Used by the /superadmin/product-telemetry
+# overview page. Reuses the per-section dataclasses where shape matches.
+# =============================================================================
+
+
+PLATFORM_TOTALS_SQL = """
+SELECT
+    uniqExact(org_id_hash) AS active_orgs,
+    uniqExact(anonymous_user_id) AS anonymous_users,
+    uniqExact(session_id) AS sessions,
+    count() AS events
+FROM product_telemetry_events
+WHERE occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+"""
+
+PLATFORM_DAILY_ACTIVE_USERS_SQL = """
+SELECT
+    toDate(occurred_at) AS day,
+    uniqExact(anonymous_user_id) AS active_anonymous_users
+FROM product_telemetry_events
+WHERE occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY day
+ORDER BY day
+"""
+
+PLATFORM_TOP_ROUTES_SQL = """
+SELECT
+    route_pattern,
+    count() AS events,
+    uniqExact(session_id) AS sessions,
+    uniqExact(anonymous_user_id) AS anonymous_users
+FROM product_telemetry_events
+WHERE name = 'page_viewed'
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY route_pattern
+ORDER BY events DESC
+LIMIT 25
+"""
+
+PLATFORM_FEATURE_VIEWS_SQL = """
+SELECT
+    JSONExtractString(payload_json, 'feature') AS feature,
+    JSONExtractString(payload_json, 'surface') AS surface,
+    count() AS views,
+    uniqExact(anonymous_user_id) AS anonymous_users
+FROM product_telemetry_events
+WHERE name = 'feature_viewed'
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY feature, surface
+ORDER BY views DESC
+"""
+
+PLATFORM_FILTER_CHANGES_SQL = """
+SELECT
+    JSONExtractString(payload_json, 'view') AS view,
+    JSONExtractString(payload_json, 'filterKey') AS filter_key,
+    count() AS changes,
+    avg(JSONExtractInt(payload_json, 'valueCount')) AS avg_value_count
+FROM product_telemetry_events
+WHERE name = 'filter_changed'
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY view, filter_key
+ORDER BY changes DESC
+"""
+
+PLATFORM_CHART_INTERACTIONS_SQL = """
+SELECT
+    JSONExtractString(payload_json, 'chart') AS chart,
+    JSONExtractString(payload_json, 'action') AS action,
+    JSONExtractString(payload_json, 'surface') AS surface,
+    count() AS interactions,
+    uniqExact(session_id) AS sessions
+FROM product_telemetry_events
+WHERE name = 'chart_interacted'
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY chart, action, surface
+ORDER BY interactions DESC
+"""
+
+PLATFORM_CLIENT_ERRORS_SQL = """
+SELECT
+    route_pattern,
+    JSONExtractString(payload_json, 'boundary') AS boundary,
+    JSONExtractString(payload_json, 'errorClass') AS error_class,
+    count() AS errors,
+    uniqExact(anonymous_user_id) AS affected_anonymous_users
+FROM product_telemetry_events
+WHERE name = 'client_error'
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY route_pattern, boundary, error_class
+ORDER BY errors DESC
+"""
+
+PLATFORM_SESSION_SUMMARY_SQL = """
+SELECT
+    quantile(0.5)(JSONExtractInt(payload_json, 'durationMs')) AS p50_duration_ms,
+    quantile(0.75)(JSONExtractInt(payload_json, 'durationMs')) AS p75_duration_ms,
+    quantile(0.9)(JSONExtractInt(payload_json, 'durationMs')) AS p90_duration_ms,
+    quantile(0.95)(JSONExtractInt(payload_json, 'durationMs')) AS p95_duration_ms,
+    avg(JSONExtractInt(payload_json, 'pagesViewed')) AS avg_pages_viewed,
+    avg(JSONExtractInt(payload_json, 'interactions')) AS avg_interactions
+FROM product_telemetry_events
+WHERE name = 'session_ended'
+  AND occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+"""
+
+PLATFORM_TOP_ORGS_SQL = """
+SELECT
+    org_id_hash,
+    count() AS events,
+    uniqExact(session_id) AS sessions,
+    uniqExact(anonymous_user_id) AS anonymous_users
+FROM product_telemetry_events
+WHERE occurred_at >= %(start)s
+  AND occurred_at < %(end)s
+GROUP BY org_id_hash
+ORDER BY events DESC
+LIMIT 50
+"""
+
+
+def _platform_params(date_range: ProductTelemetryDashboardRange) -> dict[str, Any]:
+    return {
+        "start": date_range.start_date,
+        "end": date_range.end_date,
+    }
+
+
+def _platform_totals(rows: list[dict[str, Any]]) -> ProductTelemetryPlatformTotals:
+    if not rows:
+        return ProductTelemetryPlatformTotals()
+    row = rows[0]
+    return ProductTelemetryPlatformTotals(
+        active_orgs=int(row.get("active_orgs") or 0),
+        anonymous_users=int(row.get("anonymous_users") or 0),
+        sessions=int(row.get("sessions") or 0),
+        events=int(row.get("events") or 0),
+    )
+
+
+async def load_product_telemetry_platform_dashboard(
+    client: Any,
+    date_range: ProductTelemetryDashboardRange,
+) -> ProductTelemetryPlatformDashboard:
+    """Load cross-org product telemetry rollups for the platform-admin view.
+
+    All queries are run in parallel against the analytics backend. Unlike
+    :func:`load_product_telemetry_dashboard`, none of the queries filter on
+    ``org_id_hash`` — they aggregate across every tenant — and an additional
+    top-orgs query rolls up event volume per ``org_id_hash`` so the resolver
+    can attach Postgres-side org names.
+    """
+    require_clickhouse_backend(client)
+    params = _platform_params(date_range)
+
+    (
+        totals_rows,
+        daily_rows,
+        route_rows,
+        feature_rows,
+        filter_rows,
+        chart_rows,
+        error_rows,
+        session_rows,
+        top_orgs_rows,
+    ) = await asyncio.gather(
+        query_dicts(client, PLATFORM_TOTALS_SQL, params),
+        query_dicts(client, PLATFORM_DAILY_ACTIVE_USERS_SQL, params),
+        query_dicts(client, PLATFORM_TOP_ROUTES_SQL, params),
+        query_dicts(client, PLATFORM_FEATURE_VIEWS_SQL, params),
+        query_dicts(client, PLATFORM_FILTER_CHANGES_SQL, params),
+        query_dicts(client, PLATFORM_CHART_INTERACTIONS_SQL, params),
+        query_dicts(client, PLATFORM_CLIENT_ERRORS_SQL, params),
+        query_dicts(client, PLATFORM_SESSION_SUMMARY_SQL, params),
+        query_dicts(client, PLATFORM_TOP_ORGS_SQL, params),
+    )
+
+    return ProductTelemetryPlatformDashboard(
+        totals=_platform_totals(totals_rows),
+        daily_active_users=[
+            ProductTelemetryDailyActiveUsers(
+                day=row["day"],
+                active_anonymous_users=int(row.get("active_anonymous_users") or 0),
+            )
+            for row in daily_rows
+        ],
+        top_routes=[
+            ProductTelemetryRouteUsage(
+                route_pattern=str(row.get("route_pattern") or ""),
+                events=int(row.get("events") or 0),
+                sessions=int(row.get("sessions") or 0),
+                anonymous_users=int(row.get("anonymous_users") or 0),
+            )
+            for row in route_rows
+        ],
+        feature_views=[
+            ProductTelemetryFeatureView(
+                feature=str(row.get("feature") or ""),
+                surface=str(row.get("surface") or ""),
+                views=int(row.get("views") or 0),
+                anonymous_users=int(row.get("anonymous_users") or 0),
+            )
+            for row in feature_rows
+        ],
+        filter_changes=[
+            ProductTelemetryFilterChange(
+                view=str(row.get("view") or ""),
+                filter_key=str(row.get("filter_key") or ""),
+                changes=int(row.get("changes") or 0),
+                avg_value_count=_optional_float(row.get("avg_value_count")),
+            )
+            for row in filter_rows
+        ],
+        chart_interactions=[
+            ProductTelemetryChartInteraction(
+                chart=str(row.get("chart") or ""),
+                action=str(row.get("action") or ""),
+                surface=str(row.get("surface") or ""),
+                interactions=int(row.get("interactions") or 0),
+                sessions=int(row.get("sessions") or 0),
+            )
+            for row in chart_rows
+        ],
+        client_errors=[
+            ProductTelemetryClientError(
+                route_pattern=str(row.get("route_pattern") or ""),
+                boundary=str(row.get("boundary") or ""),
+                error_class=str(row.get("error_class") or ""),
+                errors=int(row.get("errors") or 0),
+                affected_anonymous_users=int(row.get("affected_anonymous_users") or 0),
+            )
+            for row in error_rows
+        ],
+        session_summary=_session_summary(session_rows),
+        top_orgs=[
+            ProductTelemetryTopOrg(
+                org_id_hash=str(row.get("org_id_hash") or ""),
+                events=int(row.get("events") or 0),
+                sessions=int(row.get("sessions") or 0),
+                anonymous_users=int(row.get("anonymous_users") or 0),
+            )
+            for row in top_orgs_rows
+        ],
     )

--- a/tests/api/graphql/test_product_telemetry_platform_resolver.py
+++ b/tests/api/graphql/test_product_telemetry_platform_resolver.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from datetime import date
+from hashlib import sha256
+from typing import Any, cast
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.errors import AuthorizationError
+from dev_health_ops.api.graphql.models.inputs import ProductTelemetryDashboardInput
+from dev_health_ops.api.graphql.resolvers.product_telemetry import (
+    _resolve_top_orgs,
+    resolve_product_telemetry_platform_dashboard,
+)
+from dev_health_ops.api.product_telemetry.dashboard import (
+    ProductTelemetryPlatformDashboard,
+    ProductTelemetryPlatformTotals,
+    ProductTelemetryRouteUsage,
+    ProductTelemetrySessionSummary,
+    ProductTelemetryTopOrg,
+)
+
+
+class _FakeUser:
+    def __init__(self, is_superuser: bool) -> None:
+        self.is_superuser = is_superuser
+
+
+def _superuser_context() -> GraphQLContext:
+    # Platform admins can have no org_id; the context relaxes the gate for
+    # is_superuser so cross-org queries are reachable.
+    return GraphQLContext(
+        org_id="",
+        db_url="clickhouse://test",
+        client=object(),
+        user=cast(Any, _FakeUser(is_superuser=True)),
+    )
+
+
+def _input() -> ProductTelemetryDashboardInput:
+    return ProductTelemetryDashboardInput(
+        start_date=date(2026, 5, 1), end_date=date(2026, 5, 25)
+    )
+
+
+def test_resolve_top_orgs_attaches_postgres_org_names() -> None:
+    org_a_id = "00000000-0000-0000-0000-000000000001"
+    org_b_id = "00000000-0000-0000-0000-000000000002"
+    hash_a = sha256(org_a_id.encode()).hexdigest()
+    hash_b = sha256(org_b_id.encode()).hexdigest()
+
+    index = {
+        hash_a: {"org_id": org_a_id, "slug": "acme", "name": "Acme Corp"},
+        hash_b: {"org_id": org_b_id, "slug": "globex", "name": "Globex"},
+    }
+
+    rows = [
+        ProductTelemetryTopOrg(
+            org_id_hash=hash_a, events=300, sessions=20, anonymous_users=10
+        ),
+        ProductTelemetryTopOrg(
+            org_id_hash=hash_b, events=200, sessions=12, anonymous_users=8
+        ),
+        ProductTelemetryTopOrg(
+            org_id_hash="unknown_hash", events=50, sessions=3, anonymous_users=2
+        ),
+    ]
+
+    resolved = _resolve_top_orgs(rows, index)
+
+    assert resolved[0].org_id == org_a_id
+    assert resolved[0].org_name == "Acme Corp"
+    assert resolved[0].org_slug == "acme"
+    assert resolved[0].events == 300
+    assert resolved[1].org_id == org_b_id
+    assert resolved[1].org_name == "Globex"
+    # Unknown hash stays hash-only
+    assert resolved[2].org_id_hash == "unknown_hash"
+    assert resolved[2].org_id is None
+    assert resolved[2].org_name is None
+    assert resolved[2].org_slug is None
+
+
+def test_resolve_top_orgs_treats_blank_postgres_name_as_unresolved() -> None:
+    """Empty strings from Postgres should not surface as visible org names."""
+    org_id = "00000000-0000-0000-0000-000000000003"
+    org_hash = sha256(org_id.encode()).hexdigest()
+
+    index = {org_hash: {"org_id": org_id, "slug": "", "name": ""}}
+    rows = [
+        ProductTelemetryTopOrg(
+            org_id_hash=org_hash, events=5, sessions=1, anonymous_users=1
+        )
+    ]
+    resolved = _resolve_top_orgs(rows, index)
+
+    assert resolved[0].org_id == org_id
+    assert resolved[0].org_name is None
+    assert resolved[0].org_slug is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_platform_dashboard_rejects_non_superuser() -> None:
+    context = GraphQLContext(
+        org_id="org_raw_123",
+        db_url="clickhouse://test",
+        client=object(),
+        user=cast(Any, _FakeUser(is_superuser=False)),
+    )
+    with pytest.raises(AuthorizationError):
+        await resolve_product_telemetry_platform_dashboard(context, _input())
+
+
+@pytest.mark.asyncio
+async def test_resolve_platform_dashboard_rejects_unauthenticated() -> None:
+    context = GraphQLContext(
+        org_id="org_raw_123",
+        db_url="clickhouse://test",
+        client=object(),
+        user=None,
+    )
+    with pytest.raises(AuthorizationError):
+        await resolve_product_telemetry_platform_dashboard(context, _input())
+
+
+@pytest.mark.asyncio
+async def test_resolve_platform_dashboard_returns_payload_and_resolves_org_names(
+    monkeypatch,
+) -> None:
+    org_id = "00000000-0000-0000-0000-000000000010"
+    org_hash = sha256(org_id.encode()).hexdigest()
+
+    async def fake_loader(client, date_range):
+        return ProductTelemetryPlatformDashboard(
+            totals=ProductTelemetryPlatformTotals(
+                active_orgs=2,
+                anonymous_users=50,
+                sessions=120,
+                events=900,
+            ),
+            daily_active_users=[],
+            top_routes=[
+                ProductTelemetryRouteUsage(
+                    route_pattern="/metrics",
+                    events=10,
+                    sessions=5,
+                    anonymous_users=4,
+                )
+            ],
+            feature_views=[],
+            filter_changes=[],
+            chart_interactions=[],
+            client_errors=[],
+            session_summary=ProductTelemetrySessionSummary(),
+            top_orgs=[
+                ProductTelemetryTopOrg(
+                    org_id_hash=org_hash,
+                    events=600,
+                    sessions=80,
+                    anonymous_users=30,
+                ),
+                ProductTelemetryTopOrg(
+                    org_id_hash="unknown_hash",
+                    events=300,
+                    sessions=40,
+                    anonymous_users=20,
+                ),
+            ],
+        )
+
+    async def fake_index():
+        return {
+            org_hash: {"org_id": org_id, "slug": "acme", "name": "Acme Corp"},
+        }
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.graphql.resolvers.product_telemetry"
+        ".load_product_telemetry_platform_dashboard",
+        fake_loader,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.graphql.resolvers.product_telemetry._load_org_hash_index",
+        fake_index,
+    )
+
+    result = await resolve_product_telemetry_platform_dashboard(
+        _superuser_context(), _input()
+    )
+
+    assert result.totals.active_orgs == 2
+    assert result.totals.events == 900
+    assert result.top_routes[0].route_pattern == "/metrics"
+    assert len(result.top_orgs) == 2
+    assert result.top_orgs[0].org_id == org_id
+    assert result.top_orgs[0].org_name == "Acme Corp"
+    assert result.top_orgs[0].events == 600
+    assert result.top_orgs[1].org_id is None
+    assert result.top_orgs[1].org_name is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_platform_dashboard_skips_postgres_lookup_when_no_top_orgs(
+    monkeypatch,
+) -> None:
+    """If ClickHouse returns no top-orgs we must not hit Postgres at all."""
+    postgres_called = False
+
+    async def fake_loader(client, date_range):
+        return ProductTelemetryPlatformDashboard(
+            totals=ProductTelemetryPlatformTotals(),
+            top_orgs=[],
+        )
+
+    async def fake_index():
+        nonlocal postgres_called
+        postgres_called = True
+        return {}
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.graphql.resolvers.product_telemetry"
+        ".load_product_telemetry_platform_dashboard",
+        fake_loader,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.graphql.resolvers.product_telemetry._load_org_hash_index",
+        fake_index,
+    )
+
+    result = await resolve_product_telemetry_platform_dashboard(
+        _superuser_context(), _input()
+    )
+
+    assert result.top_orgs == []
+    assert postgres_called is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_platform_dashboard_rejects_inverted_date_range(
+    monkeypatch,
+) -> None:
+    async def fake_loader(client, date_range):  # pragma: no cover - unreachable
+        raise AssertionError("loader should not run for invalid input")
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.graphql.resolvers.product_telemetry"
+        ".load_product_telemetry_platform_dashboard",
+        fake_loader,
+    )
+
+    bad_input = ProductTelemetryDashboardInput(
+        start_date=date(2026, 5, 25), end_date=date(2026, 5, 1)
+    )
+    with pytest.raises(ValueError):
+        await resolve_product_telemetry_platform_dashboard(
+            _superuser_context(), bad_input
+        )

--- a/tests/api/test_product_telemetry_platform_dashboard.py
+++ b/tests/api/test_product_telemetry_platform_dashboard.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.product_telemetry.dashboard import (
+    ProductTelemetryDashboardRange,
+    load_product_telemetry_platform_dashboard,
+)
+
+
+class FakeQueryClient:
+    backend_type = "clickhouse"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+
+async def fake_query_dicts(
+    client: FakeQueryClient, sql: str, params: dict[str, Any]
+) -> list[dict[str, Any]]:
+    client.calls.append((sql, params))
+    if "active_orgs" in sql:
+        return [
+            {
+                "active_orgs": 4,
+                "anonymous_users": 120,
+                "sessions": 340,
+                "events": 5000,
+            }
+        ]
+    if "active_anonymous_users" in sql:
+        return [{"day": date(2026, 5, 24), "active_anonymous_users": 42}]
+    if "name = 'page_viewed'" in sql:
+        return [
+            {
+                "route_pattern": "/metrics",
+                "events": 90,
+                "sessions": 33,
+                "anonymous_users": 25,
+            }
+        ]
+    if "name = 'feature_viewed'" in sql:
+        return [
+            {
+                "feature": "investment",
+                "surface": "dashboard",
+                "views": 50,
+                "anonymous_users": 30,
+            }
+        ]
+    if "name = 'filter_changed'" in sql:
+        return [
+            {
+                "view": "metrics",
+                "filter_key": "team",
+                "changes": 14,
+                "avg_value_count": 1.7,
+            }
+        ]
+    if "name = 'chart_interacted'" in sql:
+        return [
+            {
+                "chart": "quadrant",
+                "action": "hover",
+                "surface": "metrics",
+                "interactions": 80,
+                "sessions": 20,
+            }
+        ]
+    if "name = 'client_error'" in sql:
+        return [
+            {
+                "route_pattern": "/metrics",
+                "boundary": "chart",
+                "error_class": "RenderError",
+                "errors": 6,
+                "affected_anonymous_users": 3,
+            }
+        ]
+    if "name = 'session_ended'" in sql:
+        return [
+            {
+                "p50_duration_ms": 1100,
+                "p75_duration_ms": 1600,
+                "p90_duration_ms": 2600,
+                "p95_duration_ms": 3100,
+                "avg_pages_viewed": 4.2,
+                "avg_interactions": 11.5,
+            }
+        ]
+    if "GROUP BY org_id_hash" in sql:
+        return [
+            {
+                "org_id_hash": "hash_a",
+                "events": 3000,
+                "sessions": 180,
+                "anonymous_users": 60,
+            },
+            {
+                "org_id_hash": "hash_b",
+                "events": 2000,
+                "sessions": 160,
+                "anonymous_users": 60,
+            },
+        ]
+    return []
+
+
+@pytest.mark.asyncio
+async def test_load_platform_dashboard_runs_all_sections_without_org_filter(
+    monkeypatch,
+) -> None:
+    client = FakeQueryClient()
+    monkeypatch.setattr(
+        "dev_health_ops.api.product_telemetry.dashboard.query_dicts",
+        fake_query_dicts,
+    )
+
+    result = await load_product_telemetry_platform_dashboard(
+        client,
+        date_range=ProductTelemetryDashboardRange(
+            start_date=date(2026, 5, 1), end_date=date(2026, 5, 25)
+        ),
+    )
+
+    # totals roll-up
+    assert result.totals.active_orgs == 4
+    assert result.totals.anonymous_users == 120
+    assert result.totals.sessions == 340
+    assert result.totals.events == 5000
+
+    # section payloads still resolve correctly
+    assert result.daily_active_users[0].active_anonymous_users == 42
+    assert result.top_routes[0].route_pattern == "/metrics"
+    assert result.feature_views[0].feature == "investment"
+    assert result.filter_changes[0].filter_key == "team"
+    assert result.chart_interactions[0].chart == "quadrant"
+    assert result.client_errors[0].error_class == "RenderError"
+    assert result.session_summary.p95_duration_ms == 3100
+
+    # top-orgs rollup is ordered by events desc and stays hash-only at this layer
+    assert [o.org_id_hash for o in result.top_orgs] == ["hash_a", "hash_b"]
+    assert result.top_orgs[0].events == 3000
+    assert result.top_orgs[1].sessions == 160
+    assert result.top_orgs[0].org_id is None
+    assert result.top_orgs[0].org_name is None
+
+    # 9 queries fire: totals + 7 sections + top_orgs
+    assert len(client.calls) == 9
+    for sql, params in client.calls:
+        assert "org_id_hash = %(org_id_hash)s" not in sql, (
+            "platform dashboard must not enforce per-org filter: "
+            f"{sql.strip().splitlines()[0]}"
+        )
+        assert params == {
+            "start": date(2026, 5, 1),
+            "end": date(2026, 5, 25),
+        }
+
+
+@pytest.mark.asyncio
+async def test_load_platform_dashboard_handles_empty_top_orgs(monkeypatch) -> None:
+    async def empty_query_dicts(
+        client: FakeQueryClient, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        client.calls.append((sql, params))
+        return []
+
+    client = FakeQueryClient()
+    monkeypatch.setattr(
+        "dev_health_ops.api.product_telemetry.dashboard.query_dicts",
+        empty_query_dicts,
+    )
+
+    result = await load_product_telemetry_platform_dashboard(
+        client,
+        date_range=ProductTelemetryDashboardRange(
+            start_date=date(2026, 5, 1), end_date=date(2026, 5, 25)
+        ),
+    )
+
+    assert result.totals.active_orgs == 0
+    assert result.totals.events == 0
+    assert result.top_orgs == []
+    assert result.daily_active_users == []
+    assert result.session_summary.p50_duration_ms is None


### PR DESCRIPTION
## Summary

Adds a superuser-gated GraphQL query that aggregates `product_telemetry_events` **across every tenant** and returns a top-orgs roll-up with names resolved from Postgres. Keeps the existing per-org dashboard untouched and reuses the same section dataclasses for cross-org payloads.

This unblocks the `/superadmin/product-telemetry` dashboard, which today is gated by `is_superuser` in `proxy.ts` but the resolver only ever returned the caller's own org data.

## Changes

### Backend
- `dashboard.py`: `ProductTelemetryPlatformDashboard` + 9 new SQL constants (totals, daily active users, top routes, feature views, filter changes, chart interactions, client errors, session summary, top orgs). Top-orgs query `GROUP BY org_id_hash` so the resolver can attach Postgres org names.
- `authz.py`: `require_platform_admin(context)` checks `user.is_superuser`.
- `context.py`: relax `org_id` requirement for `is_superuser` so cross-org admin queries are reachable without belonging to a tenant. Per-org resolvers still call `require_org_id` and reject org-less contexts.
- `resolvers/product_telemetry.py`: `resolve_product_telemetry_platform_dashboard` loads the ClickHouse rollups, then computes `sha256(str(org.id))` for every Postgres organization and merges `org_id` / `name` / `slug` into `top_orgs`. Unknown hashes stay hash-only so the UI can fall back gracefully. Postgres lookup is skipped when ClickHouse returns no top-orgs.
- `models/outputs.py`: `ProductTelemetryPlatformDashboardType`, `ProductTelemetryPlatformTotalsType`, `ProductTelemetryTopOrgType`.
- `schema.py`: `productTelemetryPlatformDashboard` query (no `org_id` arg).

### Tests
- `tests/api/test_product_telemetry_platform_dashboard.py` — SQL smoke: all 9 queries fire, none enforce `org_id` filter, totals + sections + top orgs hydrate correctly, empty result set degrades gracefully.
- `tests/api/graphql/test_product_telemetry_platform_resolver.py` — resolver gating (superuser vs org user vs unauthenticated), pure org-name resolver (`_resolve_top_orgs`), inverted date range rejection, Postgres lookup skipped when there are no top-orgs.

## Verification

```bash
cd ops
pytest tests/api/graphql tests/api/test_product_telemetry*.py -q
# → 138 passed, 11 skipped

ruff format --check src/dev_health_ops/api/product_telemetry src/dev_health_ops/api/graphql tests/api/test_product_telemetry*.py tests/api/graphql/test_product_telemetry*.py
ruff check src/dev_health_ops/api/product_telemetry src/dev_health_ops/api/graphql tests/api/test_product_telemetry*.py tests/api/graphql/test_product_telemetry*.py
# → all green
```

GraphQL schema sanity:
```python
from dev_health_ops.api.graphql.schema import schema
assert 'productTelemetryPlatformDashboard' in str(schema)
assert 'ProductTelemetryPlatformDashboardType' in str(schema)
assert 'ProductTelemetryTopOrgType' in str(schema)
```

## Follow-ups (sibling sub-issues of CHAOS-1874)

- **CHAOS-1876** — Frontend: rewrite `/superadmin/product-telemetry` overview, add `/superadmin/product-telemetry/[orgIdHash]` drilldown.
- **CHAOS-1877** — Fixtures: multi-org product telemetry seeder so the new dashboard lights up locally.

SCREENSHOT-WAIVER: backend-only change; no rendered UI in this PR. Frontend PR (CHAOS-1876) will include screenshots.

Closes CHAOS-1875
Refs CHAOS-1874