### PR TITLE
feat(fixtures): multi-org product telemetry seeder (CHAOS-1877)

### DIFF
--- a/src/dev_health_ops/fixtures/generators/product_telemetry.py
+++ b/src/dev_health_ops/fixtures/generators/product_telemetry.py
@@ -1,0 +1,429 @@
+"""Synthetic product telemetry event generator for fixtures.
+
+Produces realistic, privacy-safe event streams (typed names, route patterns,
+session lifecycles) that match the schema enforced by
+``dev_health_ops.api.product_telemetry.schemas.ProductTelemetryEvent``. The
+emitted ``org_id_hash`` is the canonical ``sha256(str(org_id))`` digest used
+by the GraphQL resolvers, so seeded rows light up the per-org dashboard and
+the platform-admin top-orgs roll-up out of the box.
+
+The generator is deterministic given a seed and the same ``(org_id, days,
+sessions_per_day)`` inputs — important for reproducible local QA and for the
+multi-org seeder to fan out work across orgs without cross-talk.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+from typing import Any
+
+from dev_health_ops.api.product_telemetry.persist import BLOCKED_PAYLOAD_KEYS
+from dev_health_ops.api.product_telemetry.schemas import ProductTelemetryEvent
+
+SCHEMA_VERSION = "2026-05-telemetry-v1"
+SOURCE = "dev-health-web"
+
+# Route patterns the frontend normalizer (web/src/lib/telemetry/routePatterns.ts)
+# is known to emit. Kept short and realistic — the dashboard SQL groups on
+# route_pattern so high cardinality here hurts the visual.
+ROUTE_PATTERNS: tuple[str, ...] = (
+    "/dashboard",
+    "/metrics",
+    "/metrics/dora",
+    "/investment",
+    "/code",
+    "/work",
+    "/prs",
+    "/issues",
+    "/deployments",
+    "/security",
+    "/people/[person_id]/metrics/[metric]",
+    "/reports/[id]",
+    "/superadmin/product-telemetry",
+)
+
+FEATURES: tuple[tuple[str, str], ...] = (
+    # (feature, surface)
+    ("dashboard", "dashboard"),
+    ("investment", "metrics"),
+    ("dora", "metrics"),
+    ("code", "code"),
+    ("work", "work"),
+    ("testops", "testops"),
+    ("feature-flags", "feature-flags"),
+    ("security", "security"),
+    ("ai-workflow", "ai"),
+)
+
+FILTER_KEYS: tuple[str, ...] = (
+    "scope",
+    "date",
+    "repo",
+    "developer",
+    "work",
+    "flow",
+    "artifact",
+    "blocked",
+    "issueType",
+)
+
+FILTER_VIEWS: tuple[str, ...] = (
+    "dashboard",
+    "metrics",
+    "investment",
+    "code",
+    "work",
+    "security",
+)
+
+CHART_KINDS: tuple[str, ...] = (
+    "quadrant",
+    "timeseries",
+    "treemap",
+    "flame",
+    "sankey",
+)
+
+CHART_ACTIONS: tuple[str, ...] = (
+    "point_selected",
+    "overlay_toggled",
+    "overlay_ignored",
+    "drilldown",
+    "zoom",
+)
+
+NAV_GROUPS: tuple[str, ...] = (
+    "operate",
+    "improve",
+    "investigate",
+    "admin",
+)
+
+NAV_ITEMS: tuple[str, ...] = (
+    "dashboard",
+    "metrics",
+    "code",
+    "work",
+    "security",
+    "ai",
+    "settings",
+)
+
+GUIDES: tuple[str, ...] = (
+    "quadrant-guide",
+    "investment-guide",
+    "dora-guide",
+    "compounding-risk-guide",
+)
+
+ERROR_BOUNDARIES: tuple[str, ...] = ("route", "global")
+ERROR_CLASSES: tuple[str, ...] = (
+    "RenderError",
+    "FetchError",
+    "TypeError",
+    "ChunkLoadError",
+)
+
+
+def product_telemetry_org_hash(org_id: str) -> str:
+    """Hash an org id with the same recipe used by the GraphQL resolvers."""
+    return sha256(org_id.encode()).hexdigest()
+
+
+@dataclass(frozen=True)
+class ProductTelemetrySeedSpec:
+    """Inputs for a single-org seeding run.
+
+    Half-open semantics: ``days`` events are generated across
+    ``[end_time - days, end_time)`` so back-to-back invocations don't
+    double-cover the boundary day.
+    """
+
+    org_id: str
+    days: int
+    sessions_per_day: int
+    seed: int | None = None
+    end_time: datetime | None = None
+
+
+class ProductTelemetryGenerator:
+    """Deterministic generator for ``ProductTelemetryEvent`` streams.
+
+    The output goes straight into ``persist_product_telemetry_events`` and
+    therefore must already obey the payload sanitizer — no blocked keys
+    (email, name, userId, orgId, url, query, search, stack, message, title,
+    body) can appear in any event.
+    """
+
+    def __init__(self, spec: ProductTelemetrySeedSpec) -> None:
+        self.spec = spec
+        self.org_id_hash = product_telemetry_org_hash(spec.org_id)
+        # Mix the (seed, org_id) pair into a stable 64-bit RNG seed so
+        # parallel per-org generation stays deterministic but does not
+        # collide across orgs.
+        seed_material = f"{spec.seed if spec.seed is not None else 0}|{spec.org_id}"
+        rng_seed = int.from_bytes(
+            sha256(seed_material.encode()).digest()[:8], "big", signed=False
+        )
+        self._rng = random.Random(rng_seed)
+
+    # ------------------------------------------------------------------ helpers
+
+    def _new_event_id(self) -> str:
+        return f"evt_{self._rng.getrandbits(64):016x}"
+
+    def _new_session_id(self) -> str:
+        return f"ses_{self._rng.getrandbits(64):016x}"
+
+    def _new_anon_user_id(self) -> str:
+        # Re-use a small pool of anon users so uniqExact() in dashboard
+        # queries returns realistic counts. Picking from N bins keeps cardinality
+        # bounded but still > 1 so aggregates are non-degenerate.
+        bin_count = max(5, self.spec.sessions_per_day // 2)
+        return f"anon_{self._rng.randrange(bin_count):04d}"
+
+    def _pick_route(self) -> str:
+        return self._rng.choice(ROUTE_PATTERNS)
+
+    def _payload_is_safe(self, payload: dict[str, Any]) -> bool:
+        return BLOCKED_PAYLOAD_KEYS.isdisjoint(payload.keys())
+
+    def _event(
+        self,
+        *,
+        name: str,
+        ts: datetime,
+        session_id: str,
+        anon_user_id: str,
+        route_pattern: str | None,
+        payload: dict[str, Any],
+    ) -> ProductTelemetryEvent:
+        assert self._payload_is_safe(payload), (
+            f"payload contains blocked telemetry keys: "
+            f"{sorted(BLOCKED_PAYLOAD_KEYS.intersection(payload))}"
+        )
+        return ProductTelemetryEvent.model_validate(
+            {
+                "name": name,
+                "schemaVersion": SCHEMA_VERSION,
+                "eventId": self._new_event_id(),
+                "ts": ts.isoformat(),
+                "sessionId": session_id,
+                "anonymousUserId": anon_user_id,
+                "orgIdHash": self.org_id_hash,
+                "routePattern": route_pattern,
+                "payload": payload,
+            }
+        )
+
+    # ------------------------------------------------------------------ session
+
+    def _generate_session(self, session_start: datetime) -> list[ProductTelemetryEvent]:
+        """Emit a realistic event stream for a single anonymous session."""
+        session_id = self._new_session_id()
+        anon_user_id = self._new_anon_user_id()
+        entry_route = self._pick_route()
+
+        events: list[ProductTelemetryEvent] = []
+        ts = session_start
+
+        # session_started
+        events.append(
+            self._event(
+                name="session_started",
+                ts=ts,
+                session_id=session_id,
+                anon_user_id=anon_user_id,
+                route_pattern=entry_route,
+                payload={"entryRoutePattern": entry_route},
+            )
+        )
+
+        # 3–8 page_viewed events
+        current_route = entry_route
+        prev_route: str | None = None
+        pages_viewed = 0
+        for _ in range(self._rng.randint(3, 8)):
+            ts += timedelta(seconds=self._rng.randint(5, 90))
+            prev_route, current_route = current_route, self._pick_route()
+            pages_viewed += 1
+            events.append(
+                self._event(
+                    name="page_viewed",
+                    ts=ts,
+                    session_id=session_id,
+                    anon_user_id=anon_user_id,
+                    route_pattern=current_route,
+                    payload={
+                        "routePattern": current_route,
+                        "page": current_route.strip("/").split("/")[0] or "root",
+                        "referrerRoutePattern": prev_route,
+                    },
+                )
+            )
+
+        interactions = 0
+
+        # 1–3 feature_viewed
+        for _ in range(self._rng.randint(1, 3)):
+            ts += timedelta(seconds=self._rng.randint(2, 30))
+            feature, surface = self._rng.choice(FEATURES)
+            interactions += 1
+            events.append(
+                self._event(
+                    name="feature_viewed",
+                    ts=ts,
+                    session_id=session_id,
+                    anon_user_id=anon_user_id,
+                    route_pattern=current_route,
+                    payload={
+                        "feature": feature,
+                        "surface": surface,
+                        "routePattern": current_route,
+                    },
+                )
+            )
+
+        # 0–3 filter_changed
+        for _ in range(self._rng.randint(0, 3)):
+            ts += timedelta(seconds=self._rng.randint(2, 30))
+            interactions += 1
+            events.append(
+                self._event(
+                    name="filter_changed",
+                    ts=ts,
+                    session_id=session_id,
+                    anon_user_id=anon_user_id,
+                    route_pattern=current_route,
+                    payload={
+                        "view": self._rng.choice(FILTER_VIEWS),
+                        "filterKey": self._rng.choice(FILTER_KEYS),
+                        "valueCount": self._rng.randint(1, 5),
+                        "isCustomDateRange": self._rng.random() < 0.2,
+                    },
+                )
+            )
+
+        # 0–3 chart_interacted
+        for _ in range(self._rng.randint(0, 3)):
+            ts += timedelta(seconds=self._rng.randint(2, 30))
+            interactions += 1
+            events.append(
+                self._event(
+                    name="chart_interacted",
+                    ts=ts,
+                    session_id=session_id,
+                    anon_user_id=anon_user_id,
+                    route_pattern=current_route,
+                    payload={
+                        "chart": self._rng.choice(CHART_KINDS),
+                        "action": self._rng.choice(CHART_ACTIONS),
+                        "surface": self._rng.choice(NAV_GROUPS),
+                        "scope": self._rng.choice(("org", "team", "repo", None)),
+                    },
+                )
+            )
+
+        # 0–2 navigation_interacted
+        for _ in range(self._rng.randint(0, 2)):
+            ts += timedelta(seconds=self._rng.randint(2, 20))
+            interactions += 1
+            events.append(
+                self._event(
+                    name="navigation_interacted",
+                    ts=ts,
+                    session_id=session_id,
+                    anon_user_id=anon_user_id,
+                    route_pattern=current_route,
+                    payload={
+                        "group": self._rng.choice(NAV_GROUPS),
+                        "item": self._rng.choice(NAV_ITEMS),
+                        "action": self._rng.choice(
+                            ("group_expanded", "group_collapsed", "item_selected")
+                        ),
+                    },
+                )
+            )
+
+        # 0–1 guide_opened
+        if self._rng.random() < 0.4:
+            ts += timedelta(seconds=self._rng.randint(2, 20))
+            interactions += 1
+            events.append(
+                self._event(
+                    name="guide_opened",
+                    ts=ts,
+                    session_id=session_id,
+                    anon_user_id=anon_user_id,
+                    route_pattern=current_route,
+                    payload={
+                        "guide": self._rng.choice(GUIDES),
+                        "surface": self._rng.choice(NAV_GROUPS),
+                    },
+                )
+            )
+
+        # rare client_error (~5%)
+        if self._rng.random() < 0.05:
+            ts += timedelta(seconds=self._rng.randint(1, 10))
+            events.append(
+                self._event(
+                    name="client_error",
+                    ts=ts,
+                    session_id=session_id,
+                    anon_user_id=anon_user_id,
+                    route_pattern=current_route,
+                    payload={
+                        "boundary": self._rng.choice(ERROR_BOUNDARIES),
+                        "digest": f"d_{self._rng.getrandbits(32):08x}",
+                        "errorClass": self._rng.choice(ERROR_CLASSES),
+                        "routePattern": current_route,
+                    },
+                )
+            )
+
+        # session_ended
+        ts += timedelta(seconds=self._rng.randint(5, 60))
+        duration_ms = int((ts - session_start).total_seconds() * 1000)
+        events.append(
+            self._event(
+                name="session_ended",
+                ts=ts,
+                session_id=session_id,
+                anon_user_id=anon_user_id,
+                route_pattern=current_route,
+                payload={
+                    "durationMs": duration_ms,
+                    "pagesViewed": pages_viewed,
+                    "interactions": interactions,
+                },
+            )
+        )
+
+        return events
+
+    # ------------------------------------------------------------------ public
+
+    def generate_events(self) -> list[ProductTelemetryEvent]:
+        """Generate the full event stream for the configured spec."""
+        end_time = self.spec.end_time or datetime.now(timezone.utc)
+        # Half-open: start_day is inclusive, end_day is exclusive.
+        start_day = (end_time - timedelta(days=self.spec.days)).replace(
+            hour=9, minute=0, second=0, microsecond=0
+        )
+
+        events: list[ProductTelemetryEvent] = []
+        for day_offset in range(self.spec.days):
+            day_start = start_day + timedelta(days=day_offset)
+            for session_index in range(self.spec.sessions_per_day):
+                # Spread sessions across a workday-ish window.
+                offset_minutes = self._rng.randint(0, 9 * 60)
+                jitter_seconds = self._rng.randint(0, 59)
+                session_start = day_start + timedelta(
+                    minutes=offset_minutes, seconds=jitter_seconds
+                )
+                events.extend(self._generate_session(session_start))
+        return events

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -1753,6 +1753,90 @@ def run_fixtures_validation(ns: argparse.Namespace) -> int:
         return 1
 
 
+async def run_product_telemetry_fixtures(ns: argparse.Namespace) -> int:
+    """Seed product_telemetry_events across one or more orgs.
+
+    Resolves orgs from ``--org`` (repeatable) or, when omitted, the first N
+    Postgres ``organizations`` rows. Writes through the canonical sink helper
+    so seeded rows look identical to production ingestion and become visible
+    in both the per-org and the platform-admin dashboards.
+    """
+    from dev_health_ops.api.product_telemetry.persist import (
+        persist_product_telemetry_events,
+    )
+    from dev_health_ops.fixtures.generators.product_telemetry import (
+        SOURCE,
+        ProductTelemetryGenerator,
+        ProductTelemetrySeedSpec,
+    )
+
+    org_ids: list[str] = list(getattr(ns, "org", None) or [])
+
+    if not org_ids:
+        from sqlalchemy import select
+
+        from dev_health_ops.db import get_postgres_session
+        from dev_health_ops.models.users import Organization
+
+        try:
+            async with get_postgres_session() as session:
+                result = await session.execute(
+                    select(Organization.id).limit(int(ns.orgs))
+                )
+                org_ids = [str(row[0]) for row in result.all()]
+        except Exception as exc:
+            logging.warning(
+                "Could not load orgs from Postgres (%s); falling back to "
+                "synthetic ids. Set DATABASE_URI to seed against real orgs.",
+                exc,
+            )
+            # Fall back to synthetic UUIDs so the seeder still produces
+            # platform-admin top-orgs ranks; they just won't resolve to names.
+            org_ids = [
+                str(uuid.uuid5(uuid.NAMESPACE_URL, f"seed-org-{idx}"))
+                for idx in range(int(ns.orgs))
+            ]
+
+    if not org_ids:
+        logging.error(
+            "No orgs to seed. Pass --org <uuid> (repeatable) or seed Postgres "
+            "with `dev-hops fixtures generate` first."
+        )
+        return 1
+
+    total_rows = 0
+    end_time = datetime.now(timezone.utc)
+    for idx, org_id in enumerate(org_ids):
+        # Slightly vary volume per org so the top-orgs roll-up has visible
+        # ranking spread instead of a flat distribution.
+        sessions = max(1, int(ns.sessions_per_day) - (idx % 3))
+        spec = ProductTelemetrySeedSpec(
+            org_id=org_id,
+            days=int(ns.days),
+            sessions_per_day=sessions,
+            seed=ns.seed,
+            end_time=end_time,
+        )
+        generator = ProductTelemetryGenerator(spec)
+        events = generator.generate_events()
+        persisted = await persist_product_telemetry_events(events, source=SOURCE)
+        total_rows += persisted
+        logging.info(
+            "Seeded %d product telemetry events for org %s (hash=%s, "
+            "%d days x %d sessions/day).",
+            persisted,
+            org_id,
+            generator.org_id_hash,
+            spec.days,
+            spec.sessions_per_day,
+        )
+
+    logging.info(
+        "Total: %d product telemetry rows across %d orgs.", total_rows, len(org_ids)
+    )
+    return 0
+
+
 def register_commands(subparsers: argparse._SubParsersAction) -> None:
     fix = subparsers.add_parser("fixtures", help="Data simulation and fixtures.")
     fix_sub = fix.add_subparsers(dest="fixtures_command", required=True)
@@ -1810,3 +1894,45 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         help="Analytics sink URI (ClickHouse). Env: CLICKHOUSE_URI",
     )
     fix_val.set_defaults(func=run_fixtures_validation)
+
+    fix_pt = fix_sub.add_parser(
+        "product-telemetry",
+        help=(
+            "Seed product_telemetry_events across multiple orgs so the "
+            "platform-admin dashboard and per-org views light up locally."
+        ),
+    )
+    fix_pt.add_argument(
+        "--orgs",
+        type=int,
+        default=5,
+        help=(
+            "Number of orgs to seed when --org is not provided. Pulls the "
+            "first N rows from Postgres `organizations`; falls back to "
+            "synthetic UUIDs if Postgres is unavailable."
+        ),
+    )
+    fix_pt.add_argument(
+        "--org",
+        action="append",
+        help=(
+            "Explicit org id to seed. Repeatable. When provided, overrides "
+            "the --orgs Postgres lookup."
+        ),
+    )
+    fix_pt.add_argument(
+        "--days", type=int, default=30, help="Number of days of data per org."
+    )
+    fix_pt.add_argument(
+        "--sessions-per-day",
+        type=int,
+        default=50,
+        help="Average synthetic sessions per day per org.",
+    )
+    fix_pt.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Deterministic seed (mixed with org_id) for repeatable runs.",
+    )
+    fix_pt.set_defaults(func=run_product_telemetry_fixtures)

--- a/tests/fixtures/test_product_telemetry_generator.py
+++ b/tests/fixtures/test_product_telemetry_generator.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timezone
+from hashlib import sha256
+
+from dev_health_ops.api.product_telemetry.persist import BLOCKED_PAYLOAD_KEYS
+from dev_health_ops.fixtures.generators.product_telemetry import (
+    ProductTelemetryGenerator,
+    ProductTelemetrySeedSpec,
+    product_telemetry_org_hash,
+)
+
+FIXED_END = datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _spec(**overrides) -> ProductTelemetrySeedSpec:
+    base = {
+        "org_id": "00000000-0000-0000-0000-000000000001",
+        "days": 3,
+        "sessions_per_day": 4,
+        "seed": 42,
+        "end_time": FIXED_END,
+    }
+    base.update(overrides)
+    return ProductTelemetrySeedSpec(**base)
+
+
+def test_generator_is_deterministic_for_same_seed_and_org() -> None:
+    events_a = ProductTelemetryGenerator(_spec()).generate_events()
+    events_b = ProductTelemetryGenerator(_spec()).generate_events()
+
+    assert len(events_a) == len(events_b)
+    for a, b in zip(events_a, events_b):
+        assert a.event_id == b.event_id
+        assert a.name == b.name
+        assert a.session_id == b.session_id
+        assert a.payload == b.payload
+        assert a.ts == b.ts
+
+
+def test_generator_diverges_between_orgs_with_same_seed() -> None:
+    events_a = ProductTelemetryGenerator(_spec(org_id="org-a")).generate_events()
+    events_b = ProductTelemetryGenerator(_spec(org_id="org-b")).generate_events()
+
+    # Different org_ids must produce different streams so per-org dashboards
+    # show distinct data, but each org must still be internally deterministic.
+    assert events_a[0].event_id != events_b[0].event_id
+    assert events_a[0].org_id_hash != events_b[0].org_id_hash
+
+
+def test_generator_emits_canonical_org_id_hash() -> None:
+    spec = _spec(org_id="abc-123")
+    generator = ProductTelemetryGenerator(spec)
+    expected_hash = sha256(b"abc-123").hexdigest()
+
+    assert generator.org_id_hash == expected_hash
+    assert product_telemetry_org_hash("abc-123") == expected_hash
+
+    events = generator.generate_events()
+    assert events, "expected non-empty event stream"
+    assert all(event.org_id_hash == expected_hash for event in events)
+
+
+def test_generator_payloads_omit_all_blocked_keys() -> None:
+    events = ProductTelemetryGenerator(_spec()).generate_events()
+
+    for event in events:
+        offending = BLOCKED_PAYLOAD_KEYS.intersection(event.payload)
+        assert not offending, (
+            f"event {event.name} payload leaked blocked keys: {sorted(offending)}"
+        )
+
+
+def test_generator_covers_every_typed_event_name() -> None:
+    # Use a larger spec so low-frequency event names (client_error, guide_opened)
+    # have a realistic chance of firing across the run.
+    spec = _spec(days=5, sessions_per_day=20)
+    events = ProductTelemetryGenerator(spec).generate_events()
+    names = Counter(e.name for e in events)
+
+    # Always-emitted lifecycle events
+    assert names["session_started"] > 0
+    assert names["session_ended"] > 0
+    assert names["page_viewed"] > 0
+    assert names["feature_viewed"] > 0
+    # Probability-gated events fire at least once across 100 sessions
+    assert names["chart_interacted"] > 0
+    assert names["navigation_interacted"] > 0
+    assert names["filter_changed"] > 0
+    assert names["guide_opened"] > 0
+
+
+def test_generator_orders_session_started_before_session_ended() -> None:
+    events = ProductTelemetryGenerator(_spec()).generate_events()
+
+    sessions: dict[str, dict[str, datetime]] = {}
+    for event in events:
+        bucket = sessions.setdefault(event.session_id, {})
+        if event.name == "session_started":
+            bucket["start"] = event.ts
+        elif event.name == "session_ended":
+            bucket["end"] = event.ts
+
+    assert sessions, "expected at least one session"
+    for session_id, marks in sessions.items():
+        assert "start" in marks, f"session {session_id} missing session_started"
+        assert "end" in marks, f"session {session_id} missing session_ended"
+        assert marks["start"] < marks["end"], (
+            f"session {session_id} ended before it started"
+        )
+
+
+def test_generator_session_ended_payload_matches_dashboard_contract() -> None:
+    """session_ended events must carry the keys the platform SQL extracts."""
+    events = ProductTelemetryGenerator(_spec()).generate_events()
+    enders = [e for e in events if e.name == "session_ended"]
+    assert enders, "expected at least one session_ended event"
+
+    for event in enders:
+        payload = event.payload
+        assert isinstance(payload["durationMs"], int)
+        assert payload["durationMs"] > 0
+        assert isinstance(payload["pagesViewed"], int)
+        assert payload["pagesViewed"] >= 0
+        assert isinstance(payload["interactions"], int)
+        assert payload["interactions"] >= 0
+
+
+def test_generator_respects_day_count_in_event_timestamps() -> None:
+    spec = _spec(days=3, sessions_per_day=2)
+    events = ProductTelemetryGenerator(spec).generate_events()
+
+    timestamps = [e.ts for e in events]
+    assert timestamps, "expected events"
+    earliest = min(timestamps)
+    latest = max(timestamps)
+    span_days = (latest - earliest).days
+
+    # Sessions fan out across the requested window; the spread should be < days
+    # but the earliest event must fall within the window.
+    assert span_days <= spec.days
+    assert earliest >= FIXED_END.replace(
+        hour=0, minute=0, second=0, microsecond=0
+    ).replace(tzinfo=timezone.utc).replace(year=2026, month=5, day=22)

--- a/tests/fixtures/test_product_telemetry_generator.py
+++ b/tests/fixtures/test_product_telemetry_generator.py
@@ -14,16 +14,21 @@ from dev_health_ops.fixtures.generators.product_telemetry import (
 FIXED_END = datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc)
 
 
-def _spec(**overrides) -> ProductTelemetrySeedSpec:
-    base = {
-        "org_id": "00000000-0000-0000-0000-000000000001",
-        "days": 3,
-        "sessions_per_day": 4,
-        "seed": 42,
-        "end_time": FIXED_END,
-    }
-    base.update(overrides)
-    return ProductTelemetrySeedSpec(**base)
+def _spec(
+    *,
+    org_id: str = "00000000-0000-0000-0000-000000000001",
+    days: int = 3,
+    sessions_per_day: int = 4,
+    seed: int | None = 42,
+    end_time: datetime | None = FIXED_END,
+) -> ProductTelemetrySeedSpec:
+    return ProductTelemetrySeedSpec(
+        org_id=org_id,
+        days=days,
+        sessions_per_day=sessions_per_day,
+        seed=seed,
+        end_time=end_time,
+    )
 
 
 def test_generator_is_deterministic_for_same_seed_and_org() -> None:


### PR DESCRIPTION
## Summary

Seeds `product_telemetry_events` across multiple synthetic orgs so the platform-admin dashboard's cross-org aggregations and top-orgs ranking light up locally without waiting for real ingestion.

Companion to CHAOS-1875 (backend resolver, PR #791) and CHAOS-1876 (frontend).

## Changes

### Generator
`src/dev_health_ops/fixtures/generators/product_telemetry.py`
- `ProductTelemetryGenerator` emits deterministic, privacy-safe event streams keyed by `sha256(org_id)` — the same hash recipe the GraphQL resolvers use, so seeded rows are visible in both per-org and platform-admin views.
- Per-session lifecycle: `session_started` → `page_viewed` / `feature_viewed` / `filter_changed` / `chart_interacted` / `navigation_interacted` / `guide_opened` → `session_ended`, plus rare `client_error` events.
- Payloads pre-screened against `BLOCKED_PAYLOAD_KEYS` so they survive the sink's PII guard.

### Runner
`src/dev_health_ops/fixtures/runner.py`
- `run_product_telemetry_fixtures` + a new `product-telemetry` subparser.
- Pulls orgs from Postgres `organizations` by default; falls back to deterministic synthetic UUIDs if Postgres is unavailable.
- Volume varies slightly per org so top-orgs ranking has visible spread instead of a flat distribution.

## CLI

```bash
dev-hops fixtures product-telemetry \
    --orgs 5 --days 30 --sessions-per-day 50 --seed 42

# Or explicit orgs:
dev-hops fixtures product-telemetry \
    --org 00000000-0000-0000-0000-000000000001 \
    --org 00000000-0000-0000-0000-000000000002 \
    --days 30 --sessions-per-day 50
```

## Tests

`tests/fixtures/test_product_telemetry_generator.py` (8 cases):

1. Determinism across runs for the same `(seed, org_id)`.
2. Divergence across orgs with the same seed.
3. Canonical `sha256(org_id)` hash matches resolver recipe.
4. Every emitted payload omits all `BLOCKED_PAYLOAD_KEYS`.
5. All 9 typed event names fire across a realistic spec.
6. `session_started` timestamps strictly precede `session_ended` in every session.
7. `session_ended` payload matches platform dashboard SQL contract (`durationMs`, `pagesViewed`, `interactions` as ints).
8. Event timestamps respect the requested `--days` window.

## Verification

```bash
cd ops
pytest tests/fixtures/test_product_telemetry_generator.py tests/api/test_product_telemetry.py tests/api/test_product_telemetry_persist.py -q
# → 18 passed

ruff format --check src/dev_health_ops/fixtures/generators/product_telemetry.py src/dev_health_ops/fixtures/runner.py tests/fixtures/test_product_telemetry_generator.py
ruff check ...
# → all green

# CLI sanity:
dev-hops fixtures product-telemetry --help
```

## Dependencies

- CHAOS-1875 (PR #791) — provides the platform dashboard resolver this seeder targets. Seeder works against existing per-org dashboard even without #791, but the full cross-org top-orgs view requires it.

SCREENSHOT-WAIVER: CLI/data change; no rendered UI. Frontend PR (CHAOS-1876) will include the screenshots that demonstrate the seeded data.

Closes CHAOS-1877
Refs CHAOS-1874