### PR TITLE
fix(api): sanitize dry_run before logging in org deletion (CodeQL #945)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ dist/
 
 # Mypy report artifact
 index.txt
+.omo/**
+.worktrees/**

--- a/src/dev_health_ops/api/services/org_deletion.py
+++ b/src/dev_health_ops/api/services/org_deletion.py
@@ -342,7 +342,7 @@ class OrganizationDeletionService:
         logger.info(
             "Organization deletion finished org_id=%s dry_run=%s postgres_rows=%s clickhouse_rows=%s",
             org_id_str,
-            dry_run,
+            "True" if dry_run else "False",
             result.postgres.total,
             result.clickhouse.total,
         )

--- a/tests/api/admin/test_org_deletion.py
+++ b/tests/api/admin/test_org_deletion.py
@@ -352,6 +352,11 @@ async def test_org_deletion_deletes_only_target_org_and_sanitizes_logs(
     assert "encrypted-secret-value" not in log_output
     assert "encrypted-token-body" not in log_output
     assert "encrypted-cert" not in log_output
+    # CodeQL py/log-injection (#945): the dry_run query param is logged via a
+    # constant literal selected by the boolean, not the tainted value itself.
+    # Confirm the finished entry renders the expected boolean text on one line.
+    assert "Organization deletion finished" in log_output
+    assert "dry_run=False" in log_output
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Resolves CodeQL **py/log-injection** (CWE-117, medium) alert [#945](https://github.com/full-chaos/dev-health-ops/security/code-scanning/945).

- **Sink:** `src/dev_health_ops/api/services/org_deletion.py:345` — the deletion "finished" log entry.
- **Source:** `dry_run` query parameter in `src/dev_health_ops/api/admin/routers/orgs.py:168`.

`dry_run` is declared `bool` and FastAPI/Pydantic coerces it, but CodeQL's taint tracking still treats the query parameter as remote input flowing into the log call.

## Fix

Sever the taint flow by logging a constant literal selected by the boolean instead of the parameter value:

```diff
-            dry_run,
+            "True" if dry_run else "False",
```

The logged value is now a constant string literal (no data dependency on the tainted input), which CodeQL recognizes as a barrier. Output is **byte-identical** to the previous `%s`-formatted bool (`True`/`False`), so there is no behavioral change.

Note: `org_id_str` in the same/adjacent log lines is already safe — it is sanitized through `uuid.UUID(...)` parsing (`_uuid_org_id`), which is why CodeQL flagged only `dry_run`.

## Verification

- `ruff format --check` + `ruff check` — pass (also enforced by pre-commit/pre-push hooks)
- `lsp_diagnostics` — clean
- `pytest tests/api/admin/test_org_deletion.py` — 10 passed

SCREENSHOT-WAIVER: backend-only logging change with no rendered frontend output.