### PR TITLE
feat(fixtures): curated demo identity replaces fixture-only ids (CHAOS-2037)

### DIFF
--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -331,7 +331,7 @@ dev-hops fixtures generate --days 30
 # Full generation with metrics and work graph
 dev-hops fixtures generate \
   --sink "$CLICKHOUSE_URI" \
-  --repo-name "acme/demo-app" \
+  --repo-name "meridian/web-app" \
   --repo-count 3 \
   --days 60 \
   --commits-per-day 10 \
@@ -346,7 +346,7 @@ dev-hops fixtures generate \
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--sink` | `$CLICKHOUSE_URI` | Analytics sink URI (ClickHouse) |
-| `--repo-name` | `acme/demo-app` | Base repository name |
+| `--repo-name` | `meridian/web-app` | Base repository name |
 | `--repo-count` | `1` | Number of repos to generate |
 | `--days` | `30` | Number of days of historical data |
 | `--commits-per-day` | `5` | Average commits per day |

--- a/src/dev_health_ops/fixtures/demo_identity.py
+++ b/src/dev_health_ops/fixtures/demo_identity.py
@@ -60,3 +60,36 @@ def demo_repo_name(base_name: str, index: int, repo_count: int) -> str:
     if base_name == DEFAULT_DEMO_REPO_NAME and index < len(DEMO_REPO_NAMES):
         return DEMO_REPO_NAMES[index]
     return f"{base_name}-{index + 1}"
+
+
+# Curated, believable team identities (``(team_id, team_name)``). Replaces the
+# generic ``Team 1``/``Alpha Team`` synthetic team names so team pickers, chord
+# diagrams, and repo->team flows render coherent names. Aligned with the
+# dev-health-web sample team names (Core, Platform, Growth, Data, Infra ...).
+DEMO_TEAMS: tuple[tuple[str, str], ...] = (
+    ("core", "Core"),
+    ("platform", "Platform"),
+    ("growth", "Growth"),
+    ("data", "Data"),
+    ("infra", "Infra"),
+    ("mobile", "Mobile"),
+    ("reliability", "Reliability"),
+    ("research", "Research"),
+    ("security", "Security"),
+    ("docs", "Docs"),
+)
+
+# Default team identity used as a single-team fallback when no teams are
+# assigned to a generator (replaces the legacy ``("alpha", "Alpha Team")``).
+DEFAULT_DEMO_TEAM: tuple[str, str] = DEMO_TEAMS[0]
+
+
+def demo_team_identity(index: int) -> tuple[str, str] | None:
+    """Return the curated ``(team_id, team_name)`` for the team at ``index``.
+
+    Returns ``None`` once the curated list is exhausted so callers can fall back
+    to the legacy ``team-{n}`` / ``Team {n}`` scheme for very large team counts.
+    """
+    if 0 <= index < len(DEMO_TEAMS):
+        return DEMO_TEAMS[index]
+    return None

--- a/src/dev_health_ops/fixtures/demo_identity.py
+++ b/src/dev_health_ops/fixtures/demo_identity.py
@@ -1,0 +1,62 @@
+"""Curated, customer-safe demo identity for synthetic fixtures (CHAOS-2037).
+
+The synthetic fixture generator historically emitted fixture-only identifiers
+that leaked onto demo and customer-facing surfaces:
+
+* the org switcher rendered ``Fixture Org (<uuid>)``;
+* churn / coverage views rendered ``acme/demo-app`` and its ``-1``/``-2``
+  numeric suffixes;
+* repository scopes surfaced the bare ``acme/demo-app`` slug.
+
+This module centralizes a small curated set of believable org/repo names so the
+seed produces realistic, coherent labels. Names are intentionally aligned with
+the dev-health-web sample data (``web-app``, ``core-api``, ``auth-service`` …)
+so the two repos stay consistent.
+"""
+
+from __future__ import annotations
+
+# Curated organization brand used for all synthetic/demo seed data. Replaces the
+# legacy ``Fixture Org (<uuid>)`` / ``Default Organization`` display names. The
+# org *slug* remains derived deterministically from the org_id elsewhere; only
+# the human-readable name is sourced here.
+DEMO_ORG_NAME = "Meridian"
+
+# Curated, realistic repository names. The fixture runner assigns these to the
+# generated repos in order; only when the requested repo count exceeds this list
+# does it fall back to the legacy numeric-suffix scheme.
+DEMO_REPO_NAMES: tuple[str, ...] = (
+    "meridian/web-app",
+    "meridian/core-api",
+    "meridian/auth-service",
+    "meridian/billing-service",
+    "meridian/search-service",
+    "meridian/mobile-app",
+    "meridian/data-pipeline",
+    "meridian/infra",
+    "meridian/notifications",
+    "meridian/analytics",
+)
+
+# Default repo name used when no ``--repo-name`` is supplied.
+DEFAULT_DEMO_REPO_NAME = DEMO_REPO_NAMES[0]
+
+
+def demo_repo_name(base_name: str, index: int, repo_count: int) -> str:
+    """Return a believable repo name for the repo at ``index``.
+
+    When the runner generates multiple repos it previously suffixed the base
+    name (``acme/demo-app-1``, ``acme/demo-app-2`` …). For the curated demo seed
+    we instead draw distinct, realistic names from :data:`DEMO_REPO_NAMES` so
+    churn/coverage surfaces never render ``base-1``/``base-2`` scaffolding.
+
+    The curated list is only used when the caller kept the curated default base
+    name; a caller that passes an explicit ``--repo-name`` keeps the legacy
+    numeric-suffix behaviour (and falls back to it once the curated list is
+    exhausted).
+    """
+    if repo_count <= 1:
+        return base_name
+    if base_name == DEFAULT_DEMO_REPO_NAME and index < len(DEMO_REPO_NAMES):
+        return DEMO_REPO_NAMES[index]
+    return f"{base_name}-{index + 1}"

--- a/src/dev_health_ops/fixtures/generator.py
+++ b/src/dev_health_ops/fixtures/generator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import random
 import uuid
 
+from dev_health_ops.fixtures.demo_identity import DEFAULT_DEMO_REPO_NAME
 from dev_health_ops.fixtures.generators import (
     AiWorkflowGeneratorMixin,
     BaseGeneratorMixin,
@@ -42,7 +43,7 @@ class SyntheticDataGenerator(
 ):
     def __init__(
         self,
-        repo_name: str = "acme/demo-app",
+        repo_name: str = DEFAULT_DEMO_REPO_NAME,
         repo_id: uuid.UUID | None = None,
         provider: str = "synthetic",
         seed: int | None = None,

--- a/src/dev_health_ops/fixtures/generators/base.py
+++ b/src/dev_health_ops/fixtures/generators/base.py
@@ -13,6 +13,7 @@ import uuid
 from datetime import date, datetime, timezone
 from typing import Any
 
+from dev_health_ops.fixtures.demo_identity import demo_team_identity
 from dev_health_ops.models.teams import Team
 
 
@@ -96,9 +97,11 @@ class BaseGeneratorMixin:
             team_members = self.authors[start:end]
 
             # Stable IDs
-            if count == 2:
-                team_id = "alpha" if i == 0 else "beta"
-                team_name = "Alpha Team" if i == 0 else "Beta Team"
+            # Curated, believable team identities; falls back to the legacy
+            # team-{n}/Team {n} scheme once the curated list is exhausted.
+            curated_team = demo_team_identity(i)
+            if curated_team is not None:
+                team_id, team_name = curated_team
             else:
                 team_id = f"team-{i + 1}"
                 team_name = f"Team {i + 1}"

--- a/src/dev_health_ops/fixtures/generators/investments.py
+++ b/src/dev_health_ops/fixtures/generators/investments.py
@@ -9,6 +9,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from dev_health_ops.fixtures.demo_identity import DEFAULT_DEMO_TEAM
 from dev_health_ops.fixtures.generators.base import BaseGeneratorMixin
 from dev_health_ops.models.work_items import WorkItem
 
@@ -284,7 +285,7 @@ class InvestmentsGeneratorMixin(BaseGeneratorMixin):
 
         teams_to_use = []
         if self.assigned_teams is None:
-            teams_to_use = [("alpha", "Alpha Team")]
+            teams_to_use = [DEFAULT_DEMO_TEAM]
         elif self.assigned_teams:
             teams_to_use = [(t.id, t.name) for t in self.assigned_teams]
         else:

--- a/src/dev_health_ops/fixtures/generators/teams.py
+++ b/src/dev_health_ops/fixtures/generators/teams.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from dev_health_ops.fixtures.demo_identity import DEMO_ORG_NAME
 from dev_health_ops.fixtures.generators.base import BaseGeneratorMixin
 from dev_health_ops.metrics.schemas import RepoMetricsDailyRecord
 from dev_health_ops.models.git import Repo
@@ -119,11 +120,11 @@ class TeamsGeneratorMixin(BaseGeneratorMixin):
                 _safe = re.sub(r"[^a-z0-9-]+", "-", org_id.lower()).strip("-")
                 _slug_seed = (_safe or f"fixture-{target_org_uuid.hex[:8]}")[:60]
             target_slug = _slug_seed
-            target_name = f"Fixture Org ({org_id})"
+            target_name = DEMO_ORG_NAME
         else:
             target_org_uuid = uuid.uuid5(_DEFAULT_NS, "default-org")
             target_slug = "default-org"
-            target_name = "Default Organization"
+            target_name = DEMO_ORG_NAME
 
         if include_admin:
             admin_user = User(

--- a/src/dev_health_ops/fixtures/generators/work_items.py
+++ b/src/dev_health_ops/fixtures/generators/work_items.py
@@ -6,6 +6,7 @@ import random
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, cast
 
+from dev_health_ops.fixtures.demo_identity import DEFAULT_DEMO_TEAM
 from dev_health_ops.fixtures.generators.base import BaseGeneratorMixin
 from dev_health_ops.metrics.schemas import (
     UserMetricsDailyRecord,
@@ -38,7 +39,7 @@ class WorkItemsGeneratorMixin(BaseGeneratorMixin):
 
         teams_to_use = []
         if self.assigned_teams is None:
-            teams_to_use = [("alpha", "Alpha Team")]
+            teams_to_use = [DEFAULT_DEMO_TEAM]
         elif self.assigned_teams:
             teams_to_use = [(t.id, t.name) for t in self.assigned_teams]
         else:
@@ -95,7 +96,7 @@ class WorkItemsGeneratorMixin(BaseGeneratorMixin):
 
         teams_to_use: list[tuple[str, str]] = []
         if self.assigned_teams is None:
-            teams_to_use = [("alpha", "Alpha Team")]
+            teams_to_use = [DEFAULT_DEMO_TEAM]
         elif self.assigned_teams:
             teams_to_use = [(t.id, t.name) for t in self.assigned_teams]
         else:

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -7,6 +7,10 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
+from dev_health_ops.fixtures.demo_identity import (
+    DEFAULT_DEMO_REPO_NAME,
+    demo_repo_name,
+)
 from dev_health_ops.fixtures.generator import SyntheticDataGenerator
 from dev_health_ops.licensing.gating import LicenseManager
 from dev_health_ops.licensing.generator import TEST_KEYPAIR, generate_test_license
@@ -438,7 +442,7 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
             sink.ensure_tables()
 
         for i in range(repo_count):
-            r_name = base_name if repo_count == 1 else f"{base_name}-{i + 1}"
+            r_name = demo_repo_name(base_name, i, repo_count)
             logging.info(
                 f"Generating fixture data for repo {i + 1}/{repo_count}: {r_name}"
             )
@@ -814,9 +818,7 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                     )
                 )
                 for i in range(_repo_count):
-                    r_name = (
-                        ns.repo_name if _repo_count == 1 else f"{ns.repo_name}-{i + 1}"
-                    )
+                    r_name = demo_repo_name(ns.repo_name, i, _repo_count)
                     seed_value = (int(ns.seed) + i) if ns.seed is not None else None
                     repo_context = cast(
                         dict[str, Any], fixture_data["feature_flag_contexts"][i]
@@ -1850,7 +1852,9 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
     fix_gen.add_argument(
         "--db-type", help="Explicit DB type (postgres, clickhouse, etc)."
     )
-    fix_gen.add_argument("--repo-name", default="acme/demo-app", help="Repo name.")
+    fix_gen.add_argument(
+        "--repo-name", default=DEFAULT_DEMO_REPO_NAME, help="Repo name."
+    )
     fix_gen.add_argument(
         "--repo-count", type=int, default=1, help="Number of repos to generate."
     )

--- a/src/dev_health_ops/processors/sync.py
+++ b/src/dev_health_ops/processors/sync.py
@@ -9,6 +9,7 @@ from dev_health_ops.credentials import (
     resolve_credentials_sync,
 )
 from dev_health_ops.db import resolve_sink_uri
+from dev_health_ops.fixtures.demo_identity import DEFAULT_DEMO_REPO_NAME
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.processors.github import (
     process_github_repo,
@@ -53,7 +54,7 @@ def _resolve_synthetic_repo_name(ns: argparse.Namespace) -> str:
                 "Synthetic provider does not support pattern search; use --repo-name."
             )
         return ns.search
-    return "acme/demo-app"
+    return DEFAULT_DEMO_REPO_NAME
 
 
 def _read_github_app_private_key(path: str) -> str:
@@ -434,7 +435,8 @@ def _add_sync_target_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--use-async", action="store_true")
     parser.add_argument("--max-commits-per-repo", type=int)
     parser.add_argument(
-        "--repo-name", help="Synthetic repo name (default: acme/demo-app)."
+        "--repo-name",
+        help=f"Synthetic repo name (default: {DEFAULT_DEMO_REPO_NAME}).",
     )
     add_date_range_args(parser)
 

--- a/tests/fixtures/test_demo_identity.py
+++ b/tests/fixtures/test_demo_identity.py
@@ -1,0 +1,80 @@
+"""CHAOS-2037: curated demo identity must never leak fixture-only identifiers.
+
+These tests guard the seam where the synthetic fixture generator chooses the
+org display name and repo names that ultimately render on demo / customer
+surfaces (org switcher, churn paths, repo coverage). They assert that:
+
+* the generated organization name is the curated brand, never
+  ``Fixture Org (<uuid>)`` or ``Default Organization``;
+* the default repo name and multi-repo naming draw from curated, believable
+  names rather than ``acme/demo-app`` / ``acme/demo-app-1`` scaffolding.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+from dev_health_ops.fixtures.demo_identity import (
+    DEFAULT_DEMO_REPO_NAME,
+    DEMO_ORG_NAME,
+    DEMO_REPO_NAMES,
+    demo_repo_name,
+)
+from dev_health_ops.fixtures.generator import SyntheticDataGenerator
+
+# Identifiers that must never reach a customer-facing label.
+_FORBIDDEN = ("Fixture Org", "Default Organization", "acme/demo-app")
+_BARE_UUID = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def test_default_repo_name_is_curated_not_fixture():
+    assert DEFAULT_DEMO_REPO_NAME == DEMO_REPO_NAMES[0]
+    assert "acme/demo-app" not in DEFAULT_DEMO_REPO_NAME
+    assert SyntheticDataGenerator().repo_name == DEFAULT_DEMO_REPO_NAME
+
+
+def test_demo_repo_name_single_repo_returns_base():
+    assert demo_repo_name(DEFAULT_DEMO_REPO_NAME, 0, 1) == DEFAULT_DEMO_REPO_NAME
+
+
+def test_demo_repo_name_multi_repo_uses_curated_distinct_names():
+    names = [demo_repo_name(DEFAULT_DEMO_REPO_NAME, i, 4) for i in range(4)]
+    assert names == list(DEMO_REPO_NAMES[:4])
+    # Distinct, believable, and never numeric-suffixed scaffolding.
+    assert len(set(names)) == 4
+    for name in names:
+        assert not re.search(r"-\d+$", name)
+        assert "acme/demo-app" not in name
+
+
+def test_demo_repo_name_falls_back_to_suffix_when_exhausted():
+    over = len(DEMO_REPO_NAMES) + 1
+    last = demo_repo_name(DEFAULT_DEMO_REPO_NAME, over - 1, over)
+    assert last == f"{DEFAULT_DEMO_REPO_NAME}-{over}"
+
+
+def test_demo_repo_name_respects_explicit_base():
+    # An explicit --repo-name keeps the legacy suffix scheme.
+    assert demo_repo_name("custom/repo", 1, 3) == "custom/repo-2"
+
+
+def test_generated_org_name_is_curated_for_uuid_org_id():
+    org_id = str(uuid.uuid4())
+    data = SyntheticDataGenerator(seed=1).generate_users(org_id=org_id)
+    orgs = data["organizations"]
+    assert orgs, "expected at least one seeded organization"
+    for org in orgs:
+        assert org.name == DEMO_ORG_NAME
+        for forbidden in _FORBIDDEN:
+            assert forbidden not in org.name
+        assert not _BARE_UUID.match(org.name)
+
+
+def test_generated_org_name_is_curated_without_org_id():
+    data = SyntheticDataGenerator(seed=1).generate_users(org_id=None)
+    for org in data["organizations"]:
+        assert org.name == DEMO_ORG_NAME

--- a/tests/fixtures/test_demo_identity.py
+++ b/tests/fixtures/test_demo_identity.py
@@ -17,9 +17,12 @@ import uuid
 
 from dev_health_ops.fixtures.demo_identity import (
     DEFAULT_DEMO_REPO_NAME,
+    DEFAULT_DEMO_TEAM,
     DEMO_ORG_NAME,
     DEMO_REPO_NAMES,
+    DEMO_TEAMS,
     demo_repo_name,
+    demo_team_identity,
 )
 from dev_health_ops.fixtures.generator import SyntheticDataGenerator
 
@@ -78,3 +81,31 @@ def test_generated_org_name_is_curated_without_org_id():
     data = SyntheticDataGenerator(seed=1).generate_users(org_id=None)
     for org in data["organizations"]:
         assert org.name == DEMO_ORG_NAME
+
+
+def test_demo_team_identity_is_curated_and_distinct():
+    names = [demo_team_identity(i) for i in range(len(DEMO_TEAMS))]
+    assert names == list(DEMO_TEAMS)
+    ids = [t[0] for t in DEMO_TEAMS]
+    labels = [t[1] for t in DEMO_TEAMS]
+    assert len(set(ids)) == len(ids)
+    assert len(set(labels)) == len(labels)
+    # Never the legacy generic scaffolding.
+    for tid, label in DEMO_TEAMS:
+        assert label not in ("Alpha Team", "Beta Team")
+        assert not label.startswith("Team ")
+        assert tid not in ("alpha", "beta")
+    assert DEFAULT_DEMO_TEAM == DEMO_TEAMS[0]
+
+
+def test_demo_team_identity_falls_back_past_curated_list():
+    assert demo_team_identity(len(DEMO_TEAMS)) is None
+
+
+def test_generated_team_names_are_curated_not_generic():
+    teams = SyntheticDataGenerator(seed=3).generate_teams(count=4)
+    rendered = [(t.id, t.name) for t in teams]
+    assert rendered == list(DEMO_TEAMS[:4])
+    for _, name in rendered:
+        assert name not in ("Alpha Team", "Beta Team")
+        assert not name.startswith("Team ")

--- a/tests/test_fixtures_runner.py
+++ b/tests/test_fixtures_runner.py
@@ -530,7 +530,7 @@ class TestGenerateUsersRespectsOrgId:
 
         assert data["organizations"][0].id == expected
         assert data["organizations"][0].slug == "default-org"
-        assert data["organizations"][0].name == "Default Organization"
+        assert data["organizations"][0].name == "Meridian"
         for m in data["memberships"]:
             assert m.org_id == expected
 

--- a/tests/test_processors_sync.py
+++ b/tests/test_processors_sync.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from dev_health_ops.fixtures.demo_identity import DEFAULT_DEMO_REPO_NAME
 from dev_health_ops.processors import sync as sync_mod
 
 
@@ -75,7 +76,7 @@ def test_resolve_synthetic_repo_name_defaults_and_variants():
         sync_mod._resolve_synthetic_repo_name(
             _ns(repo_name=None, owner=None, repo=None, search=None)
         )
-        == "acme/demo-app"
+        == DEFAULT_DEMO_REPO_NAME
     )
 
 

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -123,12 +123,18 @@ async def test_clickhouse_store_teams():
 
 
 def test_synthetic_teams_generation():
-    """Test synthetic team generation."""
+    """Test synthetic team generation uses curated, believable identities."""
+    from dev_health_ops.fixtures.demo_identity import DEMO_TEAMS
+
     generator = SyntheticDataGenerator()
     teams = generator.generate_teams(count=3)
     assert len(teams) == 3
+    rendered = [(str(getattr(t, "id")), str(getattr(t, "name"))) for t in teams]
+    assert rendered == list(DEMO_TEAMS[:3])
     for team in teams:
-        assert str(getattr(team, "id")).startswith("team-")
+        # Never the legacy generic 'team-N'/'Team N' scaffolding.
+        assert not str(getattr(team, "id")).startswith("team-")
+        assert not str(getattr(team, "name")).startswith("Team ")
         assert len(list(getattr(team, "members") or [])) > 0
 
 


### PR DESCRIPTION
## Summary
Replaces fixture-only identifiers (`Fixture Org`, `acme/demo-app`, `Team 1`) with a curated, realistic demo seed (`Meridian`, `meridian/*`, `Core`/`Platform`/etc) to prevent fixture leaks on customer/demo surfaces.

Refs CHAOS-2037

SCREENSHOT-WAIVER: Backend-only seed changes; names render via live backend.