### PR TITLE
fix(compose): scope billing-edge reload watcher

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -139,6 +139,8 @@ services:
       - --port
       - "8000"
       - --reload
+      - --reload-dir
+      - /app/src/dev_health_ops/api
     environment:
       <<: *env
       POSTGRES_URI: "postgresql+asyncpg://postgres:postgres@postgres:5432/postgres"


### PR DESCRIPTION
## Summary
- Scope billing-edge Uvicorn reload watching to /app/src/dev_health_ops/api
- Avoid scanning repo-local .worktrees and virtualenv files during local dev reload

## Verification
- lsp_diagnostics clean for compose.yml
- docker compose -f compose.yml config --no-interpolate billing-edge renders --reload-dir /app/src/dev_health_ops/api
- Previously verified from root stack that billing-edge starts and logs: Will watch for changes in these directories: ['/app/src/dev_health_ops/api']
- Previously verified billing-edge /health returns status ok after recreation

SCREENSHOT-WAIVER: Compose-only backend development configuration change; no rendered UI impact.