### PR TITLE
perf(sync): scope sync_team_drift sessions to DB ops (CHAOS-2066)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -160,9 +160,9 @@ the matching GraphQL contract.
 ## Part F — Enforcement (so it is adhered to)
 
 - **Definition of Done** (add to the issue template):
-  > Conforms to the Design & Style Framework; uses shared primitives; backing queries return
-  > resolved names (no unresolved ids surfaced); `design-lint` passes; after-screenshot or
-  > visual-regression assertion attached.
+  > Conforms to the Design & Style Framework; uses the shared primitives; 
+  > backing queries return resolved names (no unresolved ids surfaced); `npm run design-lint` passes; 
+  >an after-screenshot or visual-regression assertion is attached.
 - **`design-lint`** (ESLint / custom): ban raw UUID/hash regex in JSX text and label props;
   ban hardcoded hex/px in components; ban non-registry CTA strings; ban `/api/`,
   `api/graphql`, `CHAOS-\d+`, edge-name and detector/telemetry tokens in user-facing strings;

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,173 @@
+# Design & Style Framework — Dev Health Web
+
+> **Status: binding.** Every UI change in `dev-health-web` must conform to this framework.
+> "Done" requires conformance **plus** visual verification (see Part F).
+>
+> This file is the canonical source of truth. It is mirrored in Linear and referenced by
+> the *Market-ready Frontend UX* milestone (CHAOS-2055 interaction/design normalization,
+> CHAOS-2031 style rollout, and the Phase-1 trust issues). When this file and Linear
+> diverge, **this file governs**. Reference it from the repo agent config (`CLAUDE.md` /
+> `AGENTS.md`) so coding agents auto-load it.
+
+## Why this exists
+
+The UI inconsistencies were **not** caused by agents ignoring issues — the issues shipped
+with real PRs. They were caused by *explicit, per-defect* issues producing isolated
+point-fixes with no shared framework to conform to. One chart says "Unattributed", another
+dumps raw JSON; one page resolves names, another shows `#cf3d56b4`; CTAs drift to
+"Re-orient in Cockpit". The fix is systemic: canonical rules + tokens + shared primitives,
+**enforced**, so every change uses them instead of inventing one-offs.
+
+---
+
+## Part A — Interaction & content rules (design)
+
+- **A1 Sidebar** — major product areas only. No one-off metric pages without product approval.
+- **A2 Tabs** — sibling views within one area only (Work: Investment / Flow / Landscape /
+  Heatmap / Capacity / Evidence; AI Workflows: Impact / Attribution / Review Load /
+  Test Gaps / Governance Risk / Evidence). Never style a navigation exit as a tab.
+- **A3 Pills** — filters, scope, status, and segmented view controls only. Never for
+  navigation, back, or primary CTAs.
+- **A4 Buttons** — actions only, drawn from the CTA registry (Part D). Do not invent verbs.
+- **A5 Back links** — one pattern: `Back to Cockpit` or `Back to {parent area}`. Never
+  styled as pills/filters. One return path per screen — remove redundant ones (e.g.
+  `Back to Metrics View` **and** `Back to Cockpit` together).
+- **A6 Page-name agreement** — sidebar label = page title = breadcrumb = route metadata.
+  Normalize: Delivery Risk vs Risk & Quality Drag; AI Workflows vs AI Workflow Intelligence;
+  Coverage vs Coverage Delta.
+- **A7 Identity labels — full-stack contract (not a render-only rule).** Never show a raw
+  ID/hash as a primary user-facing label. The data layer must do the resolving:
+  **GraphQL queries/resolvers must return a resolved display name alongside any id**
+  (e.g. `compoundingRisk` must return `scope { id, displayName }`, not a bare `scope_id`),
+  and the frontend renders it via `EntityLabel`. Fallback order, *only when the server
+  genuinely cannot resolve*: (1) display name → (2) repo/name slug → (3) provider key with
+  prefix → (4) shortened ID with an explicit `Unresolved` badge. A bare `#cf3d56b4` is
+  non-compliant.
+  - **Root-cause example (cockpit conclusion):** "Compounding risk appears elevated for
+    {scope} across {scope}" is driven by `api/graphql?query=compoundingRisk&scope_id=<uuid>`.
+    That query does **not** return a resolved scope display name, and it binds the **same
+    `scope_id` into both the subject and the scope slot** — hence the UUID rendered twice
+    ("for X across X"). The fix lives in the resolver: return `scope.displayName`, and make
+    subject vs scope distinct fields. `EntityLabel` can only render a name the API returns —
+    so this work spans the **GraphQL backend (`dev_health_ops`)** and `dev-health-web`, not
+    the web repo alone. (Tracked: CHAOS-2064.)
+- **A8 No internal/impl leakage** — never render in customer copy: raw IDs, API/GraphQL
+  paths (`/api/v1/...`, `api/graphql?query=...&scope_id=...`), graph edge names (`DEPLOYS`,
+  `LINKED_INCIDENT`), detector/telemetry jargon, version tags (`V1 SPARKLINE`), or Linear
+  IDs (`CHAOS-1757`). Dev-only details go behind debug mode. Remove `Debug Filters` from
+  customer/explore views.
+- **A9 Never render raw data structures** — no JSON/object dumps in user-facing tables. The
+  Evidence Table currently renders `{"repo_id":"…","number":1,…}`; map to typed, labeled
+  fields.
+- **A10 Active navigation** — exactly one selected destination at a time; hover/focus must
+  be visually distinct from selected. No two outlined/selected items at once (observed:
+  Coverage + Delivery Risk both selected; Bottlenecks highlighted on the Coverage page).
+- **A11 Empty / unavailable / error states** — use the `DataState` component with
+  customer-safe copy ("No prior period", "Ownership data not connected yet"), never bare
+  `--`, blank panels, or raw red error blocks (CHAOS-2054). Evidence drawers use the
+  `EvidencePanel` contract or a controlled empty state.
+- **A12 Evidence vs recommendation** — an "Evidence" section contains artifacts
+  (PR / commit / review / pipeline / incident / test / deployment) with a human summary +
+  timestamp; recommendations live in a separate "Recommended next step" slot
+  (EvidencePanel contract).
+
+## Part B — Number, metric & data-integrity rules
+
+- **B1 Formatting** — all numbers via `formatNumber` / `formatPercent`. No raw floats as
+  labels (`74.74071428571429` → `74.7%`). Sensible precision, thousands separators,
+  explicit units.
+- **B2 Signed zero** — never render `-0%`; show `0%` or `No change`.
+- **B3 Extremes** — extreme values (e.g. WIP 939%) must carry a baseline/band or
+  interpretation; if a value looks impossible, validate the computation.
+- **B4 Coherence** — numbers on one page reconcile or state their relationship (Pipelines
+  already does this for success/failure — reuse the pattern).
+- **B5 Distribution / forecast integrity** — percentiles must be monotonic. P50/P75/P90 all
+  reading "4 weeks" is a collapse bug; assert `P50 ≤ P75 ≤ P90`.
+- **B6 Threshold sanity** — default thresholds must be calibrated (Incident load 17.1/wk vs
+  `Threshold 1.0/wk` reads as a wrong default).
+- **B7 Resolver completeness** — a card/conclusion is not "done" if its backing query
+  returns an unresolved id, an empty/flat result, or a missing field that forces a
+  placeholder. The query is part of the deliverable (see A7 root-cause example). If a query
+  is missing or returns nothing, fix the query — do not paper over it with a UUID or
+  "appears flat".
+
+## Part C — Style tokens
+
+Use tokens only. **No hardcoded hex or px in components** — if a value is missing, add a
+token, don't inline.
+
+- **C1 Typography** — one locked scale (size/line-height): `display` 32/40, `h1` 24/32,
+  `h2` 18/26, `h3` 15/22, `body` 14/22, `label-caps` 11/16 (+tracking), `mono` for code/IDs
+  in dev only. Page title = `h1`; section header = `h2`; the uppercase descriptor pattern
+  ("WIP SATURATION") = `label-caps`. Finalize values, then lock; this replaces the ad-hoc
+  per-page sizing.
+- **C2 Color roles** — semantic tokens, not raw hex: `bg`, `surface`, `surface-raised`,
+  `border`, `text-primary`, `text-secondary`, `text-muted`, `accent` (orange), and status
+  `positive` / `caution` / `negative` / `info`. Map status badges consistently
+  (WATCH / ELEVATED → caution / negative; NORMAL → positive).
+- **C3 Spacing** — 4px base scale (4 / 8 / 12 / 16 / 24 / 32 / 48). Standardize card padding
+  and section gaps.
+- **C4 Radius & elevation** — one radius scale (`sm` 6 / `md` 10 / `lg` 16 / `pill` 999) and
+  one elevation set for cards/drawers.
+- **C5 Charts** — one palette + conventions: sequential scale for heatmaps that **must map
+  data variance** (the Churn heatmap renders uniform cyan today), categorical palette for
+  series, consistent axis / gridline / tooltip styling, **styled tooltips** (Pipelines shows
+  a blank white tooltip box), and a `ChartFrame` wrapper exposing title / interpretation /
+  threshold slots.
+- **C6 Density & alignment** — consistent KPI card layout, card heights, and sparkline
+  treatment across TestOps / Work / Coverage.
+
+## Part D — CTA vocabulary registry (typed constants)
+
+Approved actions (add new ones here before use):
+`Open evidence`, `Inspect associations`, `Open artifact`, `Export report`, `Apply filters`,
+`Reset filters`, `Copy`.
+Navigation: `Back to Cockpit`, `Back to {area}`.
+
+Migrations:
+
+| Found | Use |
+| --- | --- |
+| `Re-orient in Cockpit` | `Back to Cockpit` |
+| `Back to Metrics View` | `Back to {area}` |
+| `Open Landscapes` / `Explore Work` | a tab, or `Back to {area}` |
+| `Open Flame` | `Open artifact` (or register `Open flame graph`) |
+| standalone `EVIDENCE` label | `Open evidence` |
+
+## Part E — Shared primitives (build once, use everywhere)
+
+The only sanctioned implementations:
+
+| Primitive | Enforces |
+| --- | --- |
+| `EntityLabel` | A7 |
+| `DataState` | A11 |
+| `EvidencePanel` | A12 |
+| `MetricDelta` | B1 / B2 |
+| `formatNumber` / `formatPercent` | B1 |
+| `BackLink` | A5 |
+| `ModeTabs` | A2 |
+| `FilterPills` | A3 |
+| `ChartFrame` + chart theme | C5 |
+| CTA constants | D |
+
+New surfaces **compose** these — do not re-implement. The `render-safe entity-label helper`
+shipped in PR #555 (CHAOS-2034) is the seed of `EntityLabel`; consolidate everything onto
+it. **Note:** `EntityLabel` can only render a name the API returns — the backing
+query/resolver must supply `displayName` (A7 / B7), so the primitive is incomplete without
+the matching GraphQL contract.
+
+## Part F — Enforcement (so it is adhered to)
+
+- **Definition of Done** (add to the issue template):
+  > Conforms to the Design & Style Framework; uses shared primitives; backing queries return
+  > resolved names (no unresolved ids surfaced); `design-lint` passes; after-screenshot or
+  > visual-regression assertion attached.
+- **`design-lint`** (ESLint / custom): ban raw UUID/hash regex in JSX text and label props;
+  ban hardcoded hex/px in components; ban non-registry CTA strings; ban `/api/`,
+  `api/graphql`, `CHAOS-\d+`, edge-name and detector/telemetry tokens in user-facing strings;
+  require `formatNumber` on chart value labels.
+- **Dev guard** — throw in dev if an unresolved hash reaches a primary label slot.
+- **Visual gate** — tie "Done" to the *Visual User Journey Evidence & UX Acceptance
+  Coverage* milestone: an after-screenshot or visual-regression assertion per fix, so "Done"
+  means *verified*, not just merged.

--- a/src/dev_health_ops/api/services/configuration/team_discovery.py
+++ b/src/dev_health_ops/api/services/configuration/team_discovery.py
@@ -23,7 +23,11 @@ if TYPE_CHECKING:
 class TeamDiscoveryService:
     """Service for discovering teams from external providers."""
 
-    def __init__(self, session: AsyncSession, org_id: str):
+    def __init__(self, session: AsyncSession | None, org_id: str):
+        # ``session`` is optional: the discover_* methods perform external
+        # network I/O only and never touch the DB, so callers that only need
+        # discovery (e.g. the worker fan-out) can pass ``None`` and avoid
+        # holding a connection idle-in-transaction. import_teams requires one.
         self.session = session
         self.org_id = org_id
 
@@ -171,6 +175,8 @@ class TeamDiscoveryService:
         on_conflict: str = "skip",
     ) -> dict[str, Any]:
         """Import discovered teams into TeamMapping."""
+        if self.session is None:
+            raise RuntimeError("import_teams requires a database session")
         team_mapping_svc = TeamMappingService(self.session, self.org_id)
         imported = 0
         skipped = 0

--- a/src/dev_health_ops/workers/sync_team.py
+++ b/src/dev_health_ops/workers/sync_team.py
@@ -32,12 +32,18 @@ def _string_or_none(value: object | None) -> str | None:
 
 
 async def _discover_and_sync_all(org_id: str | None) -> dict:
-    """Discover teams from every configured provider concurrently and run drift sync.
+    """Discover teams from every configured provider and run drift sync.
 
-    Each provider (github, gitlab, jira) gets its own coroutine that performs the
-    credential lookup, discovery call, and drift-sync call. ``asyncio.gather``
-    fans them out so the wall-time equals max(per-provider-time) rather than the
-    sum.
+    Connections are scoped tightly to the DB work so a Postgres connection is
+    never held idle-in-transaction across the slow external discovery calls:
+
+    * Phase 1 (one short session): read + decrypt credentials for all providers.
+    * Phase 2 (no session held): discover teams from each provider concurrently
+      via ``asyncio.gather`` -- pure external network I/O, zero DB connections.
+    * Phase 3 (one short session): persist drift sequentially.
+
+    Peak demand is one connection per job, held only for the millisecond-scale
+    reads/writes, while the slow per-provider network calls still overlap.
     """
     from dev_health_ops.api.services.configuration import (
         IntegrationCredentialsService,
@@ -47,72 +53,106 @@ async def _discover_and_sync_all(org_id: str | None) -> dict:
     from dev_health_ops.db import get_postgres_session
 
     effective_org_id = org_id or ""
+    providers = ("github", "gitlab", "jira")
 
+    # Phase 1: read + decrypt credentials in one short-lived session. These are
+    # fast local reads; the connection is released before any network I/O.
+    prepared: dict[str, tuple[dict[str, Any], dict[str, Any]]] = {}
+    skipped: dict[str, dict[str, Any]] = {}
     async with get_postgres_session() as session:
         creds_svc = IntegrationCredentialsService(session, effective_org_id)
-        discovery_svc = TeamDiscoveryService(session, effective_org_id)
-        drift_svc = TeamDriftSyncService(session, effective_org_id)
-
-        async def _run_one(provider: str) -> dict:
+        for provider in providers:
             credential = await creds_svc.get(provider, "default")
             if credential is None:
-                return {"provider": provider, "skipped": "no_credential"}
+                skipped[provider] = {"provider": provider, "skipped": "no_credential"}
+                continue
             decrypted = await creds_svc.get_decrypted_credentials(provider, "default")
             if decrypted is None:
-                return {"provider": provider, "skipped": "no_decrypted"}
+                skipped[provider] = {"provider": provider, "skipped": "no_decrypted"}
+                continue
             config: dict[str, Any] = (
                 credential.config if isinstance(credential.config, dict) else {}
             )
+            prepared[provider] = (decrypted, config)
+
+    # Phase 2: discover teams concurrently WITHOUT holding a DB connection.
+    # discover_* perform external network I/O only, so a sessionless service is
+    # safe and keeps the connection pool free during the slow calls.
+    discovery_svc = TeamDiscoveryService(None, effective_org_id)
+
+    async def _discover(provider: str) -> dict:
+        decrypted, config = prepared[provider]
+        try:
+            if provider == "github":
+                token = decrypted.get("token")
+                org_name = config.get("org")
+                if not isinstance(token, str) or not token:
+                    return {"provider": provider, "skipped": "missing_config"}
+                if not isinstance(org_name, str) or not org_name:
+                    return {"provider": provider, "skipped": "missing_config"}
+                teams = await discovery_svc.discover_github(
+                    token=token, org_name=org_name
+                )
+            elif provider == "gitlab":
+                token = decrypted.get("token")
+                group_path = config.get("group")
+                url = config.get("url", "https://gitlab.com")
+                if not isinstance(token, str) or not token:
+                    return {"provider": provider, "skipped": "missing_config"}
+                if not isinstance(group_path, str) or not group_path:
+                    return {"provider": provider, "skipped": "missing_config"}
+                if not isinstance(url, str) or not url:
+                    return {"provider": provider, "skipped": "missing_config"}
+                teams = await discovery_svc.discover_gitlab(
+                    token=token, group_path=group_path, url=url
+                )
+            else:
+                email = decrypted.get("email")
+                api_token = decrypted.get("api_token") or decrypted.get("token")
+                jira_url = config.get("url") or decrypted.get("url")
+                if not isinstance(email, str) or not email:
+                    return {"provider": provider, "skipped": "missing_config"}
+                if not isinstance(api_token, str) or not api_token:
+                    return {"provider": provider, "skipped": "missing_config"}
+                if not isinstance(jira_url, str) or not jira_url:
+                    return {"provider": provider, "skipped": "missing_config"}
+                teams = await discovery_svc.discover_jira(
+                    email=email, api_token=api_token, url=jira_url
+                )
+            return {"provider": provider, "teams": teams}
+        except Exception as exc:
+            logger.warning("Team discovery failed for provider %s: %s", provider, exc)
+            return {"provider": provider, "error": str(exc)}
+
+    discovered = await asyncio.gather(*(_discover(p) for p in prepared))
+    discovered_by_provider = {item["provider"]: item for item in discovered}
+
+    # Phase 3: persist drift in one short-lived session, sequentially. Each
+    # run_drift_sync is a fast local read + write + flush.
+    results: list[dict[str, Any]] = []
+    async with get_postgres_session() as session:
+        drift_svc = TeamDriftSyncService(session, effective_org_id)
+        for provider in providers:
+            if provider in skipped:
+                results.append(skipped[provider])
+                continue
+            outcome = discovered_by_provider.get(provider)
+            if outcome is None:
+                continue
+            if "teams" not in outcome:
+                # discovery skipped or errored -- surface as-is, no DB work
+                results.append(outcome)
+                continue
             try:
-                if provider == "github":
-                    token = decrypted.get("token")
-                    org_name = config.get("org")
-                    if not isinstance(token, str) or not token:
-                        return {"provider": provider, "skipped": "missing_config"}
-                    if not isinstance(org_name, str) or not org_name:
-                        return {"provider": provider, "skipped": "missing_config"}
-                    teams = await discovery_svc.discover_github(
-                        token=token, org_name=org_name
-                    )
-                elif provider == "gitlab":
-                    token = decrypted.get("token")
-                    group_path = config.get("group")
-                    url = config.get("url", "https://gitlab.com")
-                    if not isinstance(token, str) or not token:
-                        return {"provider": provider, "skipped": "missing_config"}
-                    if not isinstance(group_path, str) or not group_path:
-                        return {"provider": provider, "skipped": "missing_config"}
-                    if not isinstance(url, str) or not url:
-                        return {"provider": provider, "skipped": "missing_config"}
-                    teams = await discovery_svc.discover_gitlab(
-                        token=token, group_path=group_path, url=url
-                    )
-                else:
-                    email = decrypted.get("email")
-                    api_token = decrypted.get("api_token") or decrypted.get("token")
-                    jira_url = config.get("url") or decrypted.get("url")
-                    if not isinstance(email, str) or not email:
-                        return {"provider": provider, "skipped": "missing_config"}
-                    if not isinstance(api_token, str) or not api_token:
-                        return {"provider": provider, "skipped": "missing_config"}
-                    if not isinstance(jira_url, str) or not jira_url:
-                        return {"provider": provider, "skipped": "missing_config"}
-                    teams = await discovery_svc.discover_jira(
-                        email=email, api_token=api_token, url=jira_url
-                    )
-                return await drift_svc.run_drift_sync(provider, teams)
+                results.append(
+                    await drift_svc.run_drift_sync(provider, outcome["teams"])
+                )
             except Exception as exc:
                 logger.warning(
                     "Team drift sync failed for provider %s: %s", provider, exc
                 )
-                return {"provider": provider, "error": str(exc)}
+                results.append({"provider": provider, "error": str(exc)})
 
-        results = await asyncio.gather(
-            _run_one("github"),
-            _run_one("gitlab"),
-            _run_one("jira"),
-        )
-        await session.commit()
     return {"status": "success", "results": list(results)}
 
 

--- a/tests/test_sync_team_parallel.py
+++ b/tests/test_sync_team_parallel.py
@@ -14,11 +14,17 @@ async def test_providers_discovered_concurrently(monkeypatch):
 
     active = 0
     peak = 0
+    # Tracks live DB sessions opened via get_postgres_session.
+    sessions = {"open": 0, "peak_open": 0}
+    open_during_discovery = 0
 
     async def slow_discover(*_args, **_kwargs):
-        nonlocal active, peak
+        nonlocal active, peak, open_during_discovery
         active += 1
         peak = max(peak, active)
+        # CHAOS-2066 invariant: no DB connection may be held while the slow
+        # external discovery call is in flight.
+        open_during_discovery = max(open_during_discovery, sessions["open"])
         try:
             await asyncio.sleep(0.05)
             return []
@@ -43,9 +49,12 @@ async def test_providers_discovered_concurrently(monkeypatch):
 
     class _FakeSession:
         async def __aenter__(self):
+            sessions["open"] += 1
+            sessions["peak_open"] = max(sessions["peak_open"], sessions["open"])
             return MagicMock(commit=AsyncMock())
 
         async def __aexit__(self, *a):
+            sessions["open"] -= 1
             return False
 
         async def commit(self):
@@ -66,8 +75,16 @@ async def test_providers_discovered_concurrently(monkeypatch):
         ),
         patch("dev_health_ops.db.get_postgres_session", lambda: _FakeSession()),
     ):
-        # Call the async body directly via the helper we'll add
         result = await mod._discover_and_sync_all(org_id="org-1")
 
     assert peak >= 3, f"Expected 3 concurrent providers, observed peak={peak}"
     assert len(result["results"]) == 3
+    # CHAOS-2066: the connection is scoped to DB ops only -- never held during
+    # discovery, and never more than one open at a time per job.
+    assert open_during_discovery == 0, (
+        f"DB connection held during discovery (open={open_during_discovery})"
+    )
+    assert sessions["peak_open"] <= 1, (
+        f"More than one session open at once (peak={sessions['peak_open']})"
+    )
+    assert sessions["open"] == 0, "Session leaked (not closed)"


### PR DESCRIPTION
## Summary

Restructures `_discover_and_sync_all` so a Postgres connection is **never held idle-in-transaction** across the slow external provider discovery calls, and resolves the `IllegalStateChangeError` regression from CHAOS-1256.

Three phases:
1. **Phase 1** (one short session): read + decrypt all providers' credentials → connection released
2. **Phase 2** (no session held): `asyncio.gather` the external `discover_*` network calls — zero DB connections during the slow part
3. **Phase 3** (one short session): persist drift sequentially

`TeamDiscoveryService.session` is now optional (the `discover_*` methods never touch it); `import_teams` raises if called without one. Admin-router callers pass real sessions and are unaffected.

## Why

`discover_github/gitlab/jira` perform external network I/O only and never touch the DB, yet the prior code held a session open for their full (seconds-long, N+1) duration. The earlier correctness fix for CHAOS-1256 (per-coroutine sessions) made this 3 connections held idle-in-tx per job.

| | per-job connections | hold-time |
|---|---|---|
| Before (shared session) | 1 (but broken — `IllegalStateChangeError`) | seconds |
| Prior fix (per-coroutine) | 3 | seconds |
| **This PR** | **1** | **ms** |

Network parallelism across providers is preserved. The infra-level lever (PgBouncer transaction pooling) remains tracked in **CHAOS-2065**.

## Tests

`tests/test_sync_team_parallel.py` now asserts the invariants:
- no DB connection open during discovery (`open_during_discovery == 0`)
- ≤1 session open at any instant (`peak_open <= 1`)
- no session leak
- existing `peak >= 3` discovery concurrency

Verification: `ruff format --check` + `ruff check` + `mypy` clean; `pytest tests/test_sync_team_parallel.py tests/test_teams.py tests/test_linear_team_sync.py tests/api/admin/test_teams.py` → 28 passed.

## Also included

- `docs/design-system.md` — canonical Design & Style Framework for dev-health-web (binding doc referenced by design-lint and the Market-ready Frontend UX milestone).

Refs CHAOS-2066, CHAOS-1256

SCREENSHOT-WAIVER: backend worker + docs only; no rendered UI output.