### PR TITLE
feat(db): PgBouncer transaction-mode connection pooling (CHAOS-2065)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -28,6 +28,34 @@ services:
       retries: 3
       start_period: 30s
 
+  pgbouncer:
+    # CHAOS-2065: transaction-mode connection pooler in front of postgres.
+    # Multiplexes many client connections onto a small server-connection set so
+    # the worker fleet cannot exhaust postgres max_connections. The app runs with
+    # PGBOUNCER_TRANSACTION_MODE=true (disables asyncpg prepared statements).
+    image: edoburu/pgbouncer:latest
+    container_name: pgbouncer
+    restart: unless-stopped
+    environment:
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_NAME: postgres
+      LISTEN_PORT: "6432"
+      POOL_MODE: transaction
+      AUTH_TYPE: scram-sha-256
+      MAX_CLIENT_CONN: "1000"
+      DEFAULT_POOL_SIZE: "25"
+      MIN_POOL_SIZE: "5"
+      RESERVE_POOL_SIZE: "5"
+      ADMIN_USERS: postgres
+    ports:
+      - "6432:6432"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   clickhouse:
     image: clickhouse/clickhouse-server:latest
     container_name: clickhouse
@@ -80,7 +108,11 @@ services:
       SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DEV_HEALTH_OPS: "0.0.0"
       # GraphQL analytics endpoint available at /graphql
       GRAPHQL_QUERY_TIMEOUT: "30"
-      DATABASE_URI: "postgresql+asyncpg://postgres:postgres@postgres:5432/postgres"
+      # CHAOS-2065: runtime DB traffic flows through PgBouncer (transaction mode).
+      # Run schema migrations against postgres:5432 directly -- see
+      # docs/ops/database-connection-pooling.md.
+      DATABASE_URI: "postgresql+asyncpg://postgres:postgres@pgbouncer:6432/postgres"
+      PGBOUNCER_TRANSACTION_MODE: "true"
       CLICKHOUSE_URI: "clickhouse://ch:ch@clickhouse:8123/default"
       REDIS_URL: "redis://valkey:6379/1"
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
@@ -108,6 +140,8 @@ services:
         condition: service_healthy
       valkey:
         condition: service_healthy
+      pgbouncer:
+        condition: service_started
     ports:
       - "8000:8000"
     volumes:
@@ -143,10 +177,12 @@ services:
       - /app/src/dev_health_ops/api
     environment:
       <<: *env
-      POSTGRES_URI: "postgresql+asyncpg://postgres:postgres@postgres:5432/postgres"
+      POSTGRES_URI: "postgresql+asyncpg://postgres:postgres@pgbouncer:6432/postgres"
     depends_on:
       postgres:
         condition: service_healthy
+      pgbouncer:
+        condition: service_started
     ports:
       - "8010:8000"
     volumes:
@@ -181,6 +217,8 @@ services:
         condition: service_healthy
       clickhouse:
         condition: service_healthy
+      pgbouncer:
+        condition: service_started
     volumes:
       - ./:/app
     working_dir: /app

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -109,6 +109,9 @@ services:
       - "8000"
     environment:
       POSTGRES_URI: ${POSTGRES_URI:-}
+      # CHAOS-2065: set true when POSTGRES_URI points at a transaction-mode
+      # pooler (PgBouncer/RDS Proxy/etc). See docs/ops/database-connection-pooling.md.
+      PGBOUNCER_TRANSACTION_MODE: ${PGBOUNCER_TRANSACTION_MODE:-}
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
       STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
       STRIPE_PRICE_ID_TEAM: ${STRIPE_PRICE_ID_TEAM:-}
@@ -173,6 +176,39 @@ services:
         reservations:
           memory: 256M
           cpus: "0.1"
+
+  pgbouncer:
+    # CHAOS-2065: optional transaction-mode pooler in front of a managed
+    # Postgres. Disabled unless explicitly enabled:
+    #   docker compose --profile pooler up -d
+    # Then point Postgres consumers at it and flip the app flag:
+    #   POSTGRES_URI=postgresql+asyncpg://USER:PASS@pgbouncer:6432/DB
+    #   PGBOUNCER_TRANSACTION_MODE=true
+    # See docs/ops/database-connection-pooling.md
+    profiles: ["pooler"]
+    image: edoburu/pgbouncer:latest
+    container_name: dev-health-pgbouncer
+    restart: unless-stopped
+    environment:
+      DB_HOST: ${POSTGRES_HOST:?set POSTGRES_HOST}
+      DB_PORT: ${POSTGRES_PORT:-5432}
+      DB_USER: ${POSTGRES_USER:?set POSTGRES_USER}
+      DB_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD}
+      DB_NAME: ${POSTGRES_DB:?set POSTGRES_DB}
+      LISTEN_PORT: "6432"
+      POOL_MODE: transaction
+      AUTH_TYPE: scram-sha-256
+      MAX_CLIENT_CONN: ${PGBOUNCER_MAX_CLIENT_CONN:-1000}
+      DEFAULT_POOL_SIZE: ${PGBOUNCER_DEFAULT_POOL_SIZE:-25}
+    ports:
+      - "${PGBOUNCER_PORT:-6432}:6432"
+    networks:
+      - dev-health
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: "0.5"
 
 volumes:
   clickhouse_data:

--- a/docs/ops/database-connection-pooling.md
+++ b/docs/ops/database-connection-pooling.md
@@ -1,0 +1,131 @@
+# Database connection pooling (PgBouncer)
+
+> **Why this exists (CHAOS-2065).** The semantic Postgres engine opens a
+> SQLAlchemy/asyncpg connection pool **per worker process**. A large Celery
+> fleet (or any horizontally-scaled API/worker tier) multiplies those pools and
+> can exhaust Postgres `max_connections` (default ~100–500) long before the job
+> volume itself is a problem. PgBouncer in **transaction mode** multiplexes many
+> client connections onto a small server-connection set, decoupling fleet size
+> from the Postgres connection ceiling.
+
+## TL;DR
+
+- Put **PgBouncer (transaction pooling)** in front of Postgres.
+- Point the app's `DATABASE_URI` / `POSTGRES_URI` at PgBouncer and set
+  **`PGBOUNCER_TRANSACTION_MODE=true`**.
+- Run **schema migrations against Postgres directly** (bypass PgBouncer).
+
+## The connection-budget math
+
+```
+peak_server_connections  ≈  worker_processes × sessions_per_job × hold_time_fraction
+```
+
+Without a pooler, each process holds up to `pool_size + max_overflow`
+connections (defaults: `20 + 10 = 30`). The binding constraint is:
+
+```
+Σ(per-process SQLAlchemy pools)   <   Postgres max_connections
+```
+
+So ~3–4 fully-busy worker processes already approach a default
+`max_connections=100`. With PgBouncer the budget becomes:
+
+```
+pgbouncer default_pool_size × number_of_(db,user)_pairs × pgbouncer_instances
+        <   Postgres max_connections
+```
+
+Clients connect to PgBouncer (`max_client_conn`, e.g. 1000) and PgBouncer keeps
+only `default_pool_size` (e.g. 25) **server** connections busy per pool. Tune so
+the **server** side stays under `max_connections`; the **client** side can be
+large and cheap.
+
+| Knob | Where | Meaning |
+| --- | --- | --- |
+| `max_client_conn` | PgBouncer | how many app connections may attach |
+| `default_pool_size` | PgBouncer | server connections kept open **per (db,user)** |
+| `POSTGRES_POOL_SIZE` / `POSTGRES_MAX_OVERFLOW` | app env | per-process SQLAlchemy pool (used only on the **direct** path) |
+| `max_connections` | Postgres | hard server ceiling — must exceed the sum of all pooler server pools |
+
+## App configuration
+
+`src/dev_health_ops/db.py` chooses the engine strategy from
+`PGBOUNCER_TRANSACTION_MODE`:
+
+- **`true`** (behind PgBouncer transaction mode): the async engine uses
+  `NullPool` (PgBouncer owns the pool) and disables asyncpg prepared-statement
+  caching/naming via
+  `connect_args={"statement_cache_size": 0, "prepared_statement_name_func": <uuid>}`.
+  The sync engine uses `NullPool`.
+- **unset / `false`** (direct connection): the async/sync engines use a
+  SQLAlchemy `QueuePool` with `pool_pre_ping` and `POSTGRES_POOL_SIZE` /
+  `POSTGRES_MAX_OVERFLOW` (defaults 20 / 10).
+
+### Why prepared statements must be disabled
+
+Transaction pooling hands each client transaction a possibly-different server
+connection. asyncpg (and the SQLAlchemy asyncpg dialect) use **server-side
+prepared statements** by default, which live on one specific server connection —
+so a follow-up that lands on a different connection fails with
+`prepared statement "__asyncpg_stmt_*" does not exist` (or `already exists`).
+Disabling the statement cache and using unique statement names removes the
+cross-connection dependency.
+
+> Requires **SQLAlchemy ≥ 2.0.18** (`prepared_statement_name_func`). The repo
+> pins `sqlalchemy[asyncio]>=2.0.49`.
+
+## Migrations bypass the pooler
+
+Run Alembic/`dev-hops migrate postgres` against Postgres **directly**, not
+through transaction-mode PgBouncer. Migrations can rely on session-scoped
+behavior that transaction pooling does not preserve. Point `POSTGRES_URI` at the
+Postgres host (`postgres:5432`) for the migration step and leave
+`PGBOUNCER_TRANSACTION_MODE` unset for that invocation, e.g.:
+
+```bash
+POSTGRES_URI="postgresql+asyncpg://postgres:postgres@postgres:5432/postgres" \
+  dev-hops migrate postgres
+```
+
+## Local development
+
+`ops/compose.yml` ships a `pgbouncer` service (transaction mode, listening on
+`6432`) in front of `postgres`. The `api`, `billing-edge`, and `worker` services
+route `DATABASE_URI` / `POSTGRES_URI` through `pgbouncer:6432` and set
+`PGBOUNCER_TRANSACTION_MODE=true`.
+
+```bash
+docker compose -f compose.yml up -d postgres pgbouncer
+# inspect pools
+psql -h localhost -p 6432 -U postgres -d pgbouncer -c "SHOW POOLS;"
+```
+
+The same pattern is mirrored in the platform stack (`dev-health/compose.yml`).
+
+## Production topology
+
+Production typically uses a **managed Postgres**; deploy PgBouncer either as a
+sidecar next to each app/worker node or as a small shared tier, in transaction
+mode, in front of it. Required PgBouncer settings:
+
+```ini
+pool_mode = transaction
+max_client_conn = 1000        ; size to fleet
+default_pool_size = 25        ; size so Σ server pools < Postgres max_connections
+auth_type = scram-sha-256
+```
+
+Set the app's `DATABASE_URI` / `POSTGRES_URI` to the PgBouncer endpoint and
+`PGBOUNCER_TRANSACTION_MODE=true`. If the managed provider already offers a
+transaction-mode pooler (e.g. RDS Proxy, Supabase pooler, Neon pooler), point at
+that instead and still set `PGBOUNCER_TRANSACTION_MODE=true` so asyncpg prepared
+statements are disabled.
+
+## Validation
+
+Smoke-validated (CHAOS-2065): 100 concurrent async sessions across two waves
+through transaction-mode PgBouncer using the real `db.py` engine config —
+`NullPool`, zero `prepared statement does not exist` errors, `SHOW POOLS`
+reporting `transaction`. Engine-config invariants are guarded by
+`tests/test_db_pgbouncer.py`.

--- a/src/dev_health_ops/db.py
+++ b/src/dev_health_ops/db.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import os
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
+from typing import Any
+from uuid import uuid4
 
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
@@ -25,9 +27,64 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import NullPool
 
 _postgres_engine: AsyncEngine | None = None
 _clickhouse_engine: AsyncEngine | None = None
+
+
+def _is_truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _pgbouncer_transaction_mode() -> bool:
+    """True when the semantic DB is reached through PgBouncer in transaction mode.
+
+    Transaction pooling multiplexes a small set of server connections across many
+    clients, which breaks server-side prepared statements. When enabled we let
+    PgBouncer own the pool (NullPool) and stop asyncpg from caching/naming
+    prepared statements. See docs/ops/database-connection-pooling.md.
+    """
+    return _is_truthy(os.getenv("PGBOUNCER_TRANSACTION_MODE"))
+
+
+def _pg_pool_size() -> tuple[int, int]:
+    """(pool_size, max_overflow) for the direct-connection path, env-overridable."""
+
+    def _int_env(name: str, default: int) -> int:
+        raw = os.getenv(name)
+        if not raw:
+            return default
+        try:
+            return int(raw)
+        except ValueError:
+            return default
+
+    return _int_env("POSTGRES_POOL_SIZE", 20), _int_env("POSTGRES_MAX_OVERFLOW", 10)
+
+
+def _async_postgres_engine_kwargs(uri: str) -> dict[str, Any]:
+    """Build create_async_engine kwargs for the semantic Postgres engine.
+
+    Behind PgBouncer transaction mode: NullPool + disabled asyncpg statement
+    cache + unique prepared-statement names (requires SQLAlchemy >= 2.0.18).
+    Otherwise: a SQLAlchemy QueuePool with pre-ping and env-tunable sizing.
+    """
+    is_postgres = uri.startswith("postgresql+")
+    if is_postgres and _pgbouncer_transaction_mode():
+        return {
+            "poolclass": NullPool,
+            "connect_args": {
+                "statement_cache_size": 0,
+                "prepared_statement_name_func": lambda: f"__asyncpg_{uuid4()}__",
+            },
+        }
+    kwargs: dict[str, Any] = {"pool_pre_ping": True}
+    if is_postgres:
+        pool_size, max_overflow = _pg_pool_size()
+        kwargs["pool_size"] = pool_size
+        kwargs["max_overflow"] = max_overflow
+    return kwargs
 
 
 def get_postgres_uri() -> str | None:
@@ -66,11 +123,9 @@ def get_postgres_engine() -> AsyncEngine:
             raise RuntimeError(
                 "PostgreSQL URI not configured. Set POSTGRES_URI environment variable."
             )
-        engine_kwargs: dict[str, bool | int] = {"pool_pre_ping": True}
-        if uri.startswith("postgresql+"):
-            engine_kwargs["pool_size"] = 20
-            engine_kwargs["max_overflow"] = 10
-        _postgres_engine = create_async_engine(uri, **engine_kwargs)
+        _postgres_engine = create_async_engine(
+            uri, **_async_postgres_engine_kwargs(uri)
+        )
     return _postgres_engine
 
 
@@ -217,12 +272,18 @@ def get_postgres_sync_engine() -> Engine:
             raise RuntimeError(
                 "PostgreSQL URI not configured. Set POSTGRES_URI environment variable."
             )
-        _postgres_sync_engine = create_engine(
-            uri,
-            pool_pre_ping=True,
-            pool_size=20,
-            max_overflow=10,
-        )
+        if _pgbouncer_transaction_mode():
+            # PgBouncer owns the pool; psycopg keeps no server-side prepared
+            # statements by default, so only the pool class needs to change.
+            _postgres_sync_engine = create_engine(uri, poolclass=NullPool)
+        else:
+            pool_size, max_overflow = _pg_pool_size()
+            _postgres_sync_engine = create_engine(
+                uri,
+                pool_pre_ping=True,
+                pool_size=pool_size,
+                max_overflow=max_overflow,
+            )
     return _postgres_sync_engine
 
 

--- a/tests/test_db_pgbouncer.py
+++ b/tests/test_db_pgbouncer.py
@@ -1,0 +1,86 @@
+"""Engine configuration for PgBouncer transaction-mode pooling (CHAOS-2065).
+
+These guard the contract that, behind PgBouncer in transaction mode, the async
+Postgres engine uses NullPool and disables asyncpg prepared-statement caching /
+naming -- otherwise pooled server connections raise
+``prepared statement "__asyncpg_stmt_*" does not exist``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.pool import NullPool
+
+from dev_health_ops import db
+
+
+@pytest.fixture(autouse=True)
+def _clear_pool_env(monkeypatch):
+    for var in (
+        "PGBOUNCER_TRANSACTION_MODE",
+        "POSTGRES_POOL_SIZE",
+        "POSTGRES_MAX_OVERFLOW",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestPgbouncerTransactionModeFlag:
+    def test_disabled_by_default(self):
+        assert db._pgbouncer_transaction_mode() is False
+
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "Yes", "on"])
+    def test_truthy_values_enable(self, monkeypatch, val):
+        monkeypatch.setenv("PGBOUNCER_TRANSACTION_MODE", val)
+        assert db._pgbouncer_transaction_mode() is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "", "off", "  "])
+    def test_falsy_values_disable(self, monkeypatch, val):
+        monkeypatch.setenv("PGBOUNCER_TRANSACTION_MODE", val)
+        assert db._pgbouncer_transaction_mode() is False
+
+
+class TestAsyncEngineKwargs:
+    def test_direct_postgres_uses_queue_pool(self):
+        kw = db._async_postgres_engine_kwargs("postgresql+asyncpg://u:p@h:5432/d")
+        assert kw == {"pool_pre_ping": True, "pool_size": 20, "max_overflow": 10}
+        assert "poolclass" not in kw
+
+    def test_pgbouncer_uses_nullpool_and_disables_prepared_statements(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("PGBOUNCER_TRANSACTION_MODE", "true")
+        kw = db._async_postgres_engine_kwargs("postgresql+asyncpg://u:p@h:6432/d")
+
+        assert kw["poolclass"] is NullPool
+        # PgBouncer owns the pool -- SQLAlchemy must not also size one.
+        assert "pool_size" not in kw and "max_overflow" not in kw
+
+        connect_args = kw["connect_args"]
+        assert connect_args["statement_cache_size"] == 0
+        name_func = connect_args["prepared_statement_name_func"]
+        # Unique per call so names never collide across multiplexed server conns.
+        assert name_func() != name_func()
+        assert name_func().startswith("__asyncpg_")
+
+    def test_pgbouncer_flag_ignored_for_non_postgres(self, monkeypatch):
+        monkeypatch.setenv("PGBOUNCER_TRANSACTION_MODE", "true")
+        kw = db._async_postgres_engine_kwargs("sqlite+aiosqlite:///:memory:")
+        assert kw == {"pool_pre_ping": True}
+        assert "poolclass" not in kw
+
+    def test_pool_size_env_overridable(self, monkeypatch):
+        monkeypatch.setenv("POSTGRES_POOL_SIZE", "50")
+        monkeypatch.setenv("POSTGRES_MAX_OVERFLOW", "25")
+        kw = db._async_postgres_engine_kwargs("postgresql+asyncpg://u:p@h/d")
+        assert kw["pool_size"] == 50
+        assert kw["max_overflow"] == 25
+
+
+class TestPoolSizeParsing:
+    def test_defaults(self):
+        assert db._pg_pool_size() == (20, 10)
+
+    def test_invalid_values_fall_back_to_defaults(self, monkeypatch):
+        monkeypatch.setenv("POSTGRES_POOL_SIZE", "not-an-int")
+        monkeypatch.setenv("POSTGRES_MAX_OVERFLOW", "")
+        assert db._pg_pool_size() == (20, 10)


### PR DESCRIPTION
## Summary

Adds a transaction-mode connection-pooling path so a horizontally-scaled worker/API fleet cannot exhaust Postgres `max_connections`. This is the infra lever flagged while fixing CHAOS-2066 (the per-job session count is bounded; the real ceiling is `processes × pool_size` against Postgres).

## Changes

**`db.py` (the core change).** When `PGBOUNCER_TRANSACTION_MODE=true`:
- async engine uses `NullPool` (PgBouncer owns the pool)
- disables asyncpg prepared-statement caching/naming — `connect_args={statement_cache_size: 0, prepared_statement_name_func: <uuid>}` (requires SQLAlchemy ≥ 2.0.18; repo pins 2.0.49) — so multiplexed server connections never raise `prepared statement "__asyncpg_stmt_*" does not exist`
- sync engine uses `NullPool`

The direct-connection path keeps `QueuePool` + `pool_pre_ping` and is now env-tunable via `POSTGRES_POOL_SIZE` / `POSTGRES_MAX_OVERFLOW`.

**`compose.yml`** — `pgbouncer` service (transaction mode, `:6432`) in front of `postgres`; `api`/`billing-edge`/`worker` route through it with the flag.

**`compose.production.yml`** — optional `--profile pooler` PgBouncer fronting a managed Postgres + the env flag on the Postgres consumer.

**`docs/ops/database-connection-pooling.md`** — connection-budget math, asyncpg transaction-mode caveats, migration-bypass guidance, prod topology.

## Why prepared statements must be disabled

Transaction pooling hands each transaction a possibly-different server connection; asyncpg's default server-side prepared statements live on one connection, so a follow-up on another connection fails. Disabling the cache + unique statement names removes the cross-connection dependency.

## Migrations

Run schema migrations against Postgres **directly** (bypass transaction-mode PgBouncer) — documented in the new doc.

## Validation

Smoke-tested against a live transaction-mode PgBouncer using the real `db.py` engine: **100 concurrent async sessions across two waves** → `NullPool`, **zero** prepared-statement errors, `SHOW POOLS` reporting `transaction`. Engine-config invariants guarded by `tests/test_db_pgbouncer.py` (18 tests). Full gate: ruff format/check + mypy clean, 37 tests pass.

Refs CHAOS-2065

SCREENSHOT-WAIVER: backend/infra + docs only; no rendered UI output.