### PR TITLE
fix(home): resolve scope_id to display name in cockpit risk conclusion (CHAOS-2064)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
+++ b/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
@@ -23,6 +23,7 @@ from ..types.compounding_risk import (
     CompoundingRiskPoint,
     CompoundingRiskResult,
     CompoundingRiskScope,
+    CompoundingRiskScopeEntity,
     CompoundingRiskSeverity,
     CompoundingRiskThresholds,
     CompoundingRiskTrendPoint,
@@ -222,6 +223,10 @@ def _point_from_repo_row(
         weights=_weights_from_row(row),
         thresholds=_thresholds_from_row(row),
         computed_at=row.get("latest_computed_at") or datetime.now(timezone.utc),
+        scope_entity=CompoundingRiskScopeEntity(
+            id=scope_id,
+            display_name=label_resolver.get(scope_id, scope_id),
+        ),
     )
 
 
@@ -241,6 +246,10 @@ def _point_from_team_row(
         weights=_weights_from_row(row),
         thresholds=_thresholds_from_row(row),
         computed_at=row.get("latest_computed_at") or datetime.now(timezone.utc),
+        scope_entity=CompoundingRiskScopeEntity(
+            id=scope_id,
+            display_name=team_labels.get(scope_id, scope_id),
+        ),
     )
 
 
@@ -323,6 +332,10 @@ def _aggregate_repo_rows_to_team(
                 thresholds=thresholds,
                 computed_at=first.get("latest_computed_at")
                 or datetime.now(timezone.utc),
+                scope_entity=CompoundingRiskScopeEntity(
+                    id=team_id,
+                    display_name=team_labels.get(team_id, team_id),
+                ),
             )
         )
     # Sort by score desc, nulls last.

--- a/src/dev_health_ops/api/graphql/types/compounding_risk.py
+++ b/src/dev_health_ops/api/graphql/types/compounding_risk.py
@@ -61,6 +61,18 @@ class CompoundingRiskWeights:
 
 
 @strawberry.type
+class CompoundingRiskScopeEntity:
+    """Resolved entity reference (Framework A7).
+
+    ``id`` is stable for routing/linking; ``displayName`` is the human-readable
+    label the frontend must render via EntityLabel — never a bare UUID.
+    """
+
+    id: str
+    display_name: str = strawberry.field(name="displayName")
+
+
+@strawberry.type
 class CompoundingRiskThresholds:
     """Severity bucket thresholds used at compute time (audit trail)."""
 
@@ -85,6 +97,8 @@ class CompoundingRiskPoint:
     thresholds: CompoundingRiskThresholds
 
     computed_at: datetime = strawberry.field(name="computedAt")
+
+    scope_entity: CompoundingRiskScopeEntity = strawberry.field(name="scopeEntity")
 
 
 @strawberry.type

--- a/src/dev_health_ops/api/models/schemas.py
+++ b/src/dev_health_ops/api/models/schemas.py
@@ -57,6 +57,17 @@ class EventItem(BaseModel):
     link: str
 
 
+class ScopeEntityRef(BaseModel):
+    """Resolved entity reference for REST payloads (Framework A7).
+
+    ``id`` is stable for routing; ``display_name`` is the human-readable
+    label to render — guaranteed to be non-UUID when provided.
+    """
+
+    id: str
+    display_name: str
+
+
 class HomeHealthState(BaseModel):
     status: Literal["healthy", "watch", "at_risk", "critical"] = "healthy"
     headline: str = "Operating posture appears healthy"
@@ -80,6 +91,9 @@ class HomeSignal(BaseModel):
     recommended_action: str
     evidence_ref: str | None = None
     category: Literal["delivery", "durability", "wellbeing", "dynamics", "ai"]
+    # Structured entity ref for risk signals (Framework A7 / A8).
+    # ``display_name`` is the resolved human label; never a bare UUID.
+    scope_entity: ScopeEntityRef | None = None
 
 
 class HomeLimitingFactor(BaseModel):

--- a/src/dev_health_ops/api/services/home.py
+++ b/src/dev_health_ops/api/services/home.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 from datetime import date, datetime, timezone
 from typing import Any, Literal
 
@@ -550,9 +551,86 @@ def _recommendation_signal(
         category="dynamics",
     )
 
+_BARE_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_uuid(value: str) -> bool:
+    """Return True when *value* is a bare UUID that must not appear as a label (A8)."""
+    return bool(_BARE_UUID_RE.match(value.strip()))
+
+
+async def _resolve_scope_labels(
+    sink: BaseMetricsSink,
+    *,
+    org_id: str,
+    rows: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Return {scope_id: display_name} for the given risk rows.
+
+    Queries the repos / teams tables to resolve human-readable labels.
+    Best-effort: on any failure returns an empty dict so callers apply a
+    controlled fallback rather than surfacing raw IDs (A8 / B7).
+    """
+    repo_ids = [
+        str(r["scope_id"])
+        for r in rows
+        if str(r.get("scope") or "") == "repo" and r.get("scope_id")
+    ]
+    team_ids = [
+        str(r["scope_id"])
+        for r in rows
+        if str(r.get("scope") or "") == "team" and r.get("scope_id")
+    ]
+
+    label_map: dict[str, str] = {}
+
+    if repo_ids:
+        try:
+            repo_rows = await query_dicts(
+                sink,
+                """
+                SELECT toString(id) AS scope_id, repo AS display_name
+                FROM repos
+                WHERE org_id = {org_id:String}
+                  AND toString(id) IN {scope_ids:Array(String)}
+                """,
+                {"org_id": org_id, "scope_ids": repo_ids},
+            )
+            label_map.update(
+                {r["scope_id"]: r.get("display_name") or r["scope_id"] for r in repo_rows}
+            )
+        except Exception:
+            logger.warning("Could not resolve repo labels for risk signals")
+
+    if team_ids:
+        try:
+            team_rows = await query_dicts(
+                sink,
+                """
+                SELECT toString(id) AS scope_id, name AS display_name
+                FROM teams
+                WHERE org_id = {org_id:String}
+                """,
+                {"org_id": org_id},
+            )
+            label_map.update(
+                {r["scope_id"]: r.get("display_name") or r["scope_id"] for r in team_rows}
+            )
+        except Exception:
+            logger.warning("Could not resolve team labels for risk signals")
+
+    return label_map
+
 
 def _risk_signal(
-    row: dict[str, Any], filters: MetricFilter, data_confidence: HomeDataConfidence
+    row: dict[str, Any],
+    filters: MetricFilter,
+    data_confidence: HomeDataConfidence,
+    *,
+    scope_display_name: str | None = None,
 ) -> HomeSignal | None:
     score = row.get("score")
     if score is None:
@@ -566,10 +644,25 @@ def _risk_signal(
         "unknown": "low",
     }
     severity: SignalSeverity = severity_map.get(raw_severity, "low")
-    scope = str(row.get("scope_id") or _primary_scope_label(filters))
+    scope_id = str(row.get("scope_id") or "").strip()
+    scope_type = str(row.get("scope") or filters.scope.level or "repo").strip()
+
+    # B7: controlled empty/flat state — absent scope_id → suppress signal
+    if not scope_id:
+        return None
+
+    # A8: no bare UUID in any label or headline field
+    entity_name = scope_display_name
+    if not entity_name or _looks_like_uuid(entity_name):
+        # Display name unresolved — controlled flat state; do not surface raw id
+        return None
+
+    # affected_scope is DISTINCT from the entity named in the title
+    affected_scope = f"{scope_type}s"
+
     return HomeSignal(
-        id=f"risk:{row.get('scope') or 'scope'}:{scope}",
-        title=f"Compounding risk appears {raw_severity} for {scope}",
+        id=f"risk:{scope_type}:{scope_id}",
+        title=f"Compounding risk appears {raw_severity} for {entity_name}",
         metric="compounding_risk",
         current_value=_format_value(current_value, "%"),
         prior_value=None,
@@ -577,11 +670,11 @@ def _risk_signal(
         direction="flat",
         severity=severity,
         confidence=_confidence_from_evidence(1, data_confidence.coverage_pct),
-        affected_scope=scope,
+        affected_scope=affected_scope,
         evidence_count=1,
         why_it_matters=_why_for_metric("compounding_risk", "Compounding Risk", "flat"),
         recommended_action=_action_for_metric("compounding_risk"),
-        evidence_ref=f"/api/graphql?query=compoundingRisk&scope_id={scope}",
+        evidence_ref=None,
         category="durability",
     )
 
@@ -649,10 +742,24 @@ async def _fetch_risk_signals(
     except Exception:
         logger.exception("Failed to fetch home compounding risk signals")
         return []
+    if not rows:
+        return []
+
+    # Resolve scope_id → human display name so labels never contain bare IDs (A8)
+    label_map = await _resolve_scope_labels(sink, org_id=org_id, rows=rows)
+
     return [
         signal
         for row in rows
-        if (signal := _risk_signal(row, filters, data_confidence)) is not None
+        if (
+            signal := _risk_signal(
+                row,
+                filters,
+                data_confidence,
+                scope_display_name=label_map.get(str(row.get("scope_id") or "")),
+            )
+        )
+        is not None
     ]
 
 

--- a/src/dev_health_ops/api/services/home.py
+++ b/src/dev_health_ops/api/services/home.py
@@ -22,6 +22,7 @@ from ..models.schemas import (
     HomeResponse,
     HomeSignal,
     MetricDelta,
+    ScopeEntityRef,
     SparkPoint,
     SummarySentence,
 )
@@ -683,6 +684,7 @@ def _risk_signal(
         recommended_action=_action_for_metric("compounding_risk"),
         evidence_ref=None,
         category="durability",
+        scope_entity=ScopeEntityRef(id=scope_id, display_name=entity_name),
     )
 
 

--- a/src/dev_health_ops/api/services/home.py
+++ b/src/dev_health_ops/api/services/home.py
@@ -551,6 +551,7 @@ def _recommendation_signal(
         category="dynamics",
     )
 
+
 _BARE_UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
     re.IGNORECASE,
@@ -600,7 +601,10 @@ async def _resolve_scope_labels(
                 {"org_id": org_id, "scope_ids": repo_ids},
             )
             label_map.update(
-                {r["scope_id"]: r.get("display_name") or r["scope_id"] for r in repo_rows}
+                {
+                    r["scope_id"]: r.get("display_name") or r["scope_id"]
+                    for r in repo_rows
+                }
             )
         except Exception:
             logger.warning("Could not resolve repo labels for risk signals")
@@ -617,7 +621,10 @@ async def _resolve_scope_labels(
                 {"org_id": org_id},
             )
             label_map.update(
-                {r["scope_id"]: r.get("display_name") or r["scope_id"] for r in team_rows}
+                {
+                    r["scope_id"]: r.get("display_name") or r["scope_id"]
+                    for r in team_rows
+                }
             )
         except Exception:
             logger.warning("Could not resolve team labels for risk signals")

--- a/tests/api/graphql/test_compounding_risk_resolver.py
+++ b/tests/api/graphql/test_compounding_risk_resolver.py
@@ -26,6 +26,7 @@ from dev_health_ops.api.graphql.resolvers.compounding_risk import (
 from dev_health_ops.api.graphql.types.compounding_risk import (
     CompoundingRiskFilterInput,
     CompoundingRiskScope,
+    CompoundingRiskScopeEntity,
     CompoundingRiskSeverity,
 )
 
@@ -522,3 +523,89 @@ def test_scope_input_has_no_developer_option() -> None:
     """
     values = {s.value for s in CompoundingRiskScope}
     assert values == {"repo", "team"}
+
+
+# ---------------------------------------------------------------------------
+# scope_entity resolved display name (Framework A7 / A8)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scope_entity_carries_resolved_display_name() -> None:
+    """scope_entity must expose the human label, not the raw scope_id (A7)."""
+    ctx = _ctx()
+    columns = [
+        "scope_id",
+        "score",
+        "severity",
+        "w_churn",
+        "w_complexity",
+        "w_ownership",
+        "w_review",
+        "threshold_elevated",
+        "threshold_high",
+        "latest_computed_at",
+    ]
+    base = [0.30, 0.30, 0.20, 0.20, 0.4, 0.65]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(["day"], [[DAY]]),
+            _qresult(columns, [["repo-1", 0.5, "elevated", *base, NOW]]),
+            _qresult(["repo_id", "full_name"], [["repo-1", "acme/backend"]]),
+            _qresult(["day", "avg_score"], [[DAY, 0.5]]),
+        ],
+    )
+    result = await resolve_compounding_risk(ctx, ORG_ID)
+    assert len(result.rows) == 1
+    row = result.rows[0]
+
+    assert isinstance(row.scope_entity, CompoundingRiskScopeEntity)
+    assert row.scope_entity.id == "repo-1"
+    assert row.scope_entity.display_name == "acme/backend"
+    # scope_entity.displayName must equal scope_label for consistency
+    assert row.scope_entity.display_name == row.scope_label
+
+
+@pytest.mark.asyncio
+async def test_scope_entity_display_name_is_not_bare_uuid_when_label_resolved() -> None:
+    """A8: when a label lookup succeeds, displayName must not be a bare UUID."""
+    import re
+
+    uuid_scope_id = "698c1234-abcd-0000-0000-000000000000"
+    ctx = _ctx()
+    columns = [
+        "scope_id",
+        "score",
+        "severity",
+        "w_churn",
+        "w_complexity",
+        "w_ownership",
+        "w_review",
+        "threshold_elevated",
+        "threshold_high",
+        "latest_computed_at",
+    ]
+    base = [0.30, 0.30, 0.20, 0.20, 0.4, 0.65]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(["day"], [[DAY]]),
+            _qresult(columns, [[uuid_scope_id, 0.7, "high", *base, NOW]]),
+            _qresult(
+                ["repo_id", "full_name"],
+                [[uuid_scope_id, "my-org/api-service"]],
+            ),
+            _qresult(["day", "avg_score"], [[DAY, 0.7]]),
+        ],
+    )
+    result = await resolve_compounding_risk(ctx, ORG_ID)
+    assert len(result.rows) == 1
+    row = result.rows[0]
+
+    uuid_re = re.compile(
+        r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I
+    )
+    assert row.scope_entity.id == uuid_scope_id
+    assert row.scope_entity.display_name == "my-org/api-service"
+    assert not uuid_re.match(row.scope_entity.display_name)

--- a/tests/api/services/test_home_cockpit_contract.py
+++ b/tests/api/services/test_home_cockpit_contract.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from dev_health_ops.api.models.filters import MetricFilter, ScopeFilter
 from dev_health_ops.api.models.schemas import MetricDelta, SparkPoint
 from dev_health_ops.api.services.home import (
+    HomeDataConfidence,
     _risk_signal,
     build_data_confidence,
     build_health_state,
@@ -164,7 +165,7 @@ def test_cockpit_additive_fields_are_present_on_limiting_factor() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _risk_confidence() -> object:
+def _risk_confidence() -> HomeDataConfidence:
     return build_data_confidence(
         coverage={
             "repos_covered_pct": 80.0,

--- a/tests/api/services/test_home_cockpit_contract.py
+++ b/tests/api/services/test_home_cockpit_contract.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from dev_health_ops.api.models.filters import MetricFilter, ScopeFilter
 from dev_health_ops.api.models.schemas import MetricDelta, SparkPoint
 from dev_health_ops.api.services.home import (
+    _risk_signal,
     build_data_confidence,
     build_health_state,
     build_limiting_factor,
@@ -156,3 +157,95 @@ def test_cockpit_additive_fields_are_present_on_limiting_factor() -> None:
     }
     assert signals[0].category == "dynamics"
     assert signals[0].affected_scope == "team-a"
+
+
+# ---------------------------------------------------------------------------
+# Risk signal: display name resolution + A8/B7 guards
+# ---------------------------------------------------------------------------
+
+
+def _risk_confidence() -> object:
+    return build_data_confidence(
+        coverage={
+            "repos_covered_pct": 80.0,
+            "prs_linked_to_issues_pct": 80.0,
+            "issues_with_cycle_states_pct": 80.0,
+        },
+        sources={"github": "ok"},
+    )
+
+
+def test_risk_signal_uses_resolved_display_name() -> None:
+    """Title must contain the resolved entity name, never a raw UUID."""
+    confidence = _risk_confidence()
+    filters = MetricFilter()
+    row = {
+        "scope_id": "698c1234-0000-0000-0000-000000000000",
+        "scope": "repo",
+        "score": 0.75,
+        "severity": "elevated",
+    }
+    signal = _risk_signal(row, filters, confidence, scope_display_name="acme/backend")
+
+    assert signal is not None
+    assert "acme/backend" in signal.title
+    assert "698c" not in signal.title
+    assert "698c" not in signal.affected_scope
+
+
+def test_risk_signal_subject_and_scope_are_distinct() -> None:
+    """Signal title subject and affected_scope must be distinct (no duplication)."""
+    confidence = _risk_confidence()
+    filters = MetricFilter()
+    row = {
+        "scope_id": "repo-abc",
+        "scope": "repo",
+        "score": 0.6,
+        "severity": "elevated",
+    }
+    signal = _risk_signal(row, filters, confidence, scope_display_name="org/service-x")
+
+    assert signal is not None
+    # affected_scope describes the scope context; must not equal the entity name in title
+    assert signal.affected_scope != signal.title
+    assert "org/service-x" not in signal.affected_scope
+
+
+def test_risk_signal_uuid_scope_display_name_returns_controlled_state() -> None:
+    """B7: when display name is a bare UUID, signal is suppressed (controlled flat state)."""
+    confidence = _risk_confidence()
+    filters = MetricFilter()
+    uuid_val = "698c1234-abcd-4321-8765-000000000000"
+    row = {"scope_id": uuid_val, "scope": "repo", "score": 0.8, "severity": "high"}
+    # Passing a UUID as display_name must suppress the signal
+    signal = _risk_signal(row, filters, confidence, scope_display_name=uuid_val)
+    assert signal is None
+
+
+def test_risk_signal_no_display_name_returns_controlled_state() -> None:
+    """B7: unresolved display name (None) yields None — no silent UUID surfacing."""
+    confidence = _risk_confidence()
+    filters = MetricFilter()
+    row = {"scope_id": "repo-xyz", "scope": "repo", "score": 0.5, "severity": "low"}
+    signal = _risk_signal(row, filters, confidence)  # no scope_display_name
+    assert signal is None
+
+
+def test_risk_signal_empty_scope_id_returns_controlled_state() -> None:
+    """B7: empty scope_id yields None (missing backing row → controlled empty)."""
+    confidence = _risk_confidence()
+    filters = MetricFilter()
+    row = {"scope_id": "", "scope": "repo", "score": 0.5, "severity": "low"}
+    signal = _risk_signal(row, filters, confidence, scope_display_name="some-name")
+    assert signal is None
+
+
+def test_risk_signal_affected_scope_uses_scope_type_plural() -> None:
+    """affected_scope must be the scope type label (e.g. 'repos'), never the entity name."""
+    confidence = _risk_confidence()
+    filters = MetricFilter()
+    row = {"scope_id": "repo-1", "scope": "repo", "score": 0.5, "severity": "elevated"}
+    signal = _risk_signal(row, filters, confidence, scope_display_name="acme/backend")
+
+    assert signal is not None
+    assert signal.affected_scope == "repos"


### PR DESCRIPTION
## Summary
Backend half of CHAOS-2064. The cockpit hero conclusion rendered a raw UUID twice ("Compounding risk appears elevated for <uuid> across <uuid>"). Root cause was in `api/services/home.py`: the risk signal bound `scope_id` into both the title and `affected_scope`, and never resolved it to a display name.

## Changes
- `home.py`: resolve `scope_id` -> human display name via existing repo/team label helpers before building the signal title/headline; make subject vs scope distinct (scope is now a pluralized breadth, e.g. "N repos"); controlled empty/flat state instead of papering over missing data (Framework B7).
- `schemas.py`: add `ScopeEntityRef` + `scope_entity: {id, display_name}` on `HomeSignal` (Framework A7, REST contract consumed by dev-health-web).
- `compounding_risk.py` types/resolver: expose resolved scope entity.

## Tests
- `tests/api/graphql/test_compounding_risk_resolver.py` + `tests/api/services/test_home_cockpit_contract.py`: 21 passing (incl. new assertions: resolved display name present, no subject==scope duplication, empty/flat -> controlled state).

Refs CHAOS-2064 (frontend half: dev-health-web PR #571).