### PR TITLE
fix(api): resolve opportunity and quadrant labels (CHAOS-2076, CHAOS-2077)

### DIFF
--- a/src/dev_health_ops/api/services/opportunities.py
+++ b/src/dev_health_ops/api/services/opportunities.py
@@ -5,6 +5,54 @@ from ..models.schemas import OpportunitiesResponse, OpportunityCard
 from .cache import TTLCache
 from .home import build_home_response
 
+_DEFAULT_SUGGESTED_EXPERIMENTS = [
+    "Triage the top 10 longest-running work items.",
+    "Introduce a rotating on-call reviewer for stalled PRs.",
+]
+
+_METRIC_SUGGESTED_EXPERIMENTS = {
+    "cycle_time": [
+        "Trace the oldest active items to their current waiting state.",
+        "Split one long-running item into the next reviewable slice.",
+    ],
+    "review_latency": [
+        "Reserve a daily review block for PRs waiting longest for first response.",
+        "Pair authors with likely reviewers before opening complex PRs.",
+    ],
+    "throughput": [
+        "Audit recently completed items for the smallest repeatable delivery pattern.",
+        "Pause new starts until the team finishes the highest-value active work.",
+    ],
+    "deploy_freq": [
+        "Identify the smallest safe release candidate and ship it behind existing controls.",
+        "Review deploy blockers from the last cycle and remove one manual handoff.",
+    ],
+    "churn": [
+        "Review the files with the largest churn increase for unclear ownership or scope.",
+        "Timebox a design checkpoint before the next high-churn change expands.",
+    ],
+    "wip_saturation": [
+        "Set a short-term WIP limit and finish active items before starting more.",
+        "Reassign one blocked item owner to unblock or explicitly park it today.",
+    ],
+    "blocked_work": [
+        "Escalate the top blocked item with the dependency owner and a target unblock date.",
+        "Convert recurring blocked states into explicit dependency tickets.",
+    ],
+    "change_failure_rate": [
+        "Review recent failed changes for the earliest detectable signal before release.",
+        "Add one pre-release check to the riskiest deployment path.",
+    ],
+    "rework_ratio": [
+        "Compare reopened or rewritten work against its original acceptance criteria.",
+        "Add a short pre-implementation alignment review for similar upcoming work.",
+    ],
+    "ci_success": [
+        "Classify the latest CI failures by flaky test, environment, or product defect.",
+        "Fix or quarantine the highest-frequency flaky check before adding new coverage.",
+    ],
+}
+
 
 async def build_opportunities_response(
     *,
@@ -40,10 +88,7 @@ async def build_opportunities_response(
                     f"&range_days={filters.time.range_days}"
                     f"&compare_days={filters.time.compare_days}"
                 ],
-                suggested_experiments=[
-                    "Triage the top 10 longest-running work items.",
-                    "Introduce a rotating on-call reviewer for stalled PRs.",
-                ],
+                suggested_experiments=_suggested_experiments_for(delta.metric),
             )
         )
 
@@ -68,3 +113,7 @@ def _primary_scope_id(filters: MetricFilter) -> str:
     if filters.scope.ids:
         return filters.scope.ids[0]
     return ""
+
+
+def _suggested_experiments_for(metric: str) -> list[str]:
+    return _METRIC_SUGGESTED_EXPERIMENTS.get(metric, _DEFAULT_SUGGESTED_EXPERIMENTS)

--- a/src/dev_health_ops/api/services/quadrant.py
+++ b/src/dev_health_ops/api/services/quadrant.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
-from typing import Any
+from typing import Any, Literal, cast
 
 from fastapi import HTTPException
 
@@ -19,7 +20,7 @@ from ..models.schemas import (
     QuadrantPointTrajectory,
     QuadrantResponse,
 )
-from ..queries.client import clickhouse_client
+from ..queries.client import clickhouse_client, query_dicts
 from ..queries.people import fetch_person_team_id, resolve_person_identity
 from ..queries.quadrant import fetch_quadrant_metric
 from ..utils import build_reverse_alias_map, normalize_alias
@@ -62,6 +63,7 @@ class QuadrantDefinition:
 
 
 TEAM_LABEL = "ifNull(nullIf(m.team_name, ''), m.team_id)"
+logger = logging.getLogger(__name__)
 
 TEAM_METRICS: dict[str, MetricSpec] = {
     "churn": MetricSpec(
@@ -388,6 +390,35 @@ def _row_entity(
     return person_id, label
 
 
+async def _resolve_team_labels(
+    sink: BaseMetricsSink,
+    *,
+    team_ids: set[str],
+    org_id: str,
+) -> dict[str, str]:
+    if not team_ids:
+        return {}
+    try:
+        rows = await query_dicts(
+            sink,
+            """
+            SELECT toString(id) AS team_id, name AS team_name
+            FROM teams FINAL
+            WHERE org_id = %(org_id)s
+              AND toString(id) IN %(team_ids)s
+            """,
+            {"org_id": org_id, "team_ids": sorted(team_ids)},
+        )
+    except Exception as exc:
+        logger.warning("Could not resolve quadrant team labels: %s", exc)
+        return {}
+    return {
+        str(row.get("team_id") or ""): str(row.get("team_name") or "").strip()
+        for row in rows
+        if row.get("team_id") and str(row.get("team_name") or "").strip()
+    }
+
+
 def _build_axes(definition: QuadrantDefinition) -> QuadrantAxes:
     return QuadrantAxes(
         x=QuadrantAxis(
@@ -445,7 +476,10 @@ async def build_quadrant_response(
 
     normalized_scope = _normalize_scope(scope_type)
     group_scope = _group_scope(normalized_scope)
-    filter_scope = "developer" if normalized_scope == "person" else normalized_scope
+    filter_scope = cast(
+        Literal["org", "team", "repo", "service", "developer"],
+        "developer" if normalized_scope == "person" else normalized_scope,
+    )
     if group_scope == "person" and not scope_id:
         raise HTTPException(
             status_code=400, detail="Individual quadrants require a person id"
@@ -521,6 +555,20 @@ async def build_quadrant_response(
             ),
         )
 
+        team_labels = (
+            await _resolve_team_labels(
+                sink,
+                team_ids={
+                    str(row.get("entity_id") or "").strip()
+                    for row in [*x_rows, *y_rows]
+                    if str(row.get("entity_id") or "").strip()
+                },
+                org_id=org_id,
+            )
+            if group_scope == "team"
+            else {}
+        )
+
     x_map: dict[tuple[str, date], dict[str, Any]] = {}
     for row in x_rows:
         bucket_start = _bucket_start(row.get("bucket"))
@@ -529,6 +577,7 @@ async def build_quadrant_response(
         entity_id, label = _row_entity(row, group_scope=group_scope)
         if not entity_id:
             continue
+        label = team_labels.get(entity_id, label)
         value = x_spec.transform(float(row.get("value") or 0.0))
         x_map[(entity_id, bucket_start)] = {
             "entity_id": entity_id,
@@ -544,6 +593,7 @@ async def build_quadrant_response(
         entity_id, label = _row_entity(row, group_scope=group_scope)
         if not entity_id:
             continue
+        label = team_labels.get(entity_id, label)
         key = (entity_id, bucket_start)
         x_entry = x_map.get(key)
         if not x_entry:

--- a/tests/test_opportunities.py
+++ b/tests/test_opportunities.py
@@ -1,0 +1,88 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from dev_health_ops.api.models.filters import MetricFilter, ScopeFilter, TimeFilter
+from dev_health_ops.api.models.schemas import (
+    ConstraintCard,
+    Coverage,
+    Freshness,
+    HomeResponse,
+    MetricDelta,
+    SparkPoint,
+)
+from dev_health_ops.api.services.cache import TTLCache
+from dev_health_ops.api.services.opportunities import build_opportunities_response
+
+
+def _home_with_deltas(deltas: list[MetricDelta]) -> HomeResponse:
+    return HomeResponse(
+        freshness=Freshness(
+            last_ingested_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            sources={"github": "ok", "gitlab": "ok", "jira": "ok", "ci": "ok"},
+            coverage=Coverage(
+                repos_covered_pct=100.0,
+                prs_linked_to_issues_pct=100.0,
+                issues_with_cycle_states_pct=100.0,
+            ),
+        ),
+        deltas=deltas,
+        summary=[],
+        tiles={},
+        constraint=ConstraintCard(
+            title="Constraint",
+            claim="No constraint",
+            evidence=[],
+            experiments=[],
+        ),
+        events=[],
+    )
+
+
+def _delta(metric: str, label: str, delta_pct: float) -> MetricDelta:
+    return MetricDelta(
+        metric=metric,
+        label=label,
+        value=1.0,
+        unit="items",
+        delta_pct=delta_pct,
+        spark=[SparkPoint(ts=datetime(2024, 1, 1, tzinfo=timezone.utc), value=1.0)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_opportunities_use_metric_specific_experiments(monkeypatch):
+    async def _fake_home(**_):
+        return _home_with_deltas(
+            [
+                _delta("cycle_time", "Cycle Time", 24.0),
+                _delta("review_latency", "Review Latency", 12.0),
+            ]
+        )
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.opportunities.build_home_response", _fake_home
+    )
+
+    result = await build_opportunities_response(
+        db_url="clickhouse://test",
+        filters=MetricFilter(
+            time=TimeFilter(range_days=30, compare_days=30),
+            scope=ScopeFilter(level="team", ids=["team-a"]),
+        ),
+        cache=TTLCache(ttl_seconds=1),
+        org_id="test-org",
+    )
+
+    by_metric = {
+        item.evidence_links[0].split("metric=", 1)[1].split("&", 1)[0]: item
+        for item in result.items
+    }
+    assert by_metric["cycle_time"].suggested_experiments == [
+        "Trace the oldest active items to their current waiting state.",
+        "Split one long-running item into the next reviewable slice.",
+    ]
+    assert by_metric["review_latency"].suggested_experiments == [
+        "Reserve a daily review block for PRs waiting longest for first response.",
+        "Pair authors with likely reviewers before opening complex PRs.",
+    ]

--- a/tests/test_quadrant.py
+++ b/tests/test_quadrant.py
@@ -1,4 +1,7 @@
+from contextlib import asynccontextmanager
 from datetime import date
+
+import pytest
 
 from dev_health_ops.api.models.schemas import (
     QuadrantAnnotation,
@@ -8,7 +11,10 @@ from dev_health_ops.api.models.schemas import (
     QuadrantPointTrajectory,
     QuadrantResponse,
 )
-from dev_health_ops.api.services.quadrant import QUADRANT_DEFINITIONS
+from dev_health_ops.api.services.quadrant import (
+    QUADRANT_DEFINITIONS,
+    build_quadrant_response,
+)
 
 
 def _model_fields(model) -> set[str]:
@@ -65,3 +71,64 @@ def test_quadrant_axis_label_snapshot():
         key: (definition.x.label, definition.y.label)
         for key, definition in QUADRANT_DEFINITIONS.items()
     } == expected
+
+
+@pytest.mark.asyncio
+async def test_quadrant_resolves_team_uuid_label_from_team_catalog(monkeypatch):
+    team_uuid = "4e00fff2-df66-5028-8ebd-e4535332300b"
+
+    @asynccontextmanager
+    async def _fake_client(_db_url):
+        yield object()
+
+    async def _fake_metric(
+        _sink,
+        *,
+        value_expr,
+        start_day,
+        end_day,
+        bucket,
+        entity_expr,
+        label_expr,
+        **_,
+    ):
+        value = 100.0 if "loc_touched" in value_expr else 8.0
+        return [
+            {
+                "bucket": date(2024, 1, 1),
+                "entity_id": team_uuid,
+                "entity_label": team_uuid,
+                "value": value,
+            }
+        ]
+
+    async def _fake_query_dicts(_sink, _query, params):
+        assert params["team_ids"] == [team_uuid]
+        return [{"team_id": team_uuid, "team_name": "Platform Team"}]
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.clickhouse_client", _fake_client
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.fetch_quadrant_metric", _fake_metric
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.query_dicts",
+        _fake_query_dicts,
+        raising=False,
+    )
+
+    response = await build_quadrant_response(
+        db_url="clickhouse://test",
+        org_id="test-org",
+        type="churn_throughput",
+        scope_type="team",
+        scope_id="",
+        range_days=30,
+        bucket="week",
+        start_date=date(2024, 1, 1),
+        end_date=date(2024, 1, 8),
+    )
+
+    assert response.points[0].entity_id == team_uuid
+    assert response.points[0].entity_label == "Platform Team"


### PR DESCRIPTION
## Summary
- Add metric-specific suggested experiments for `/api/v1/opportunities` cards.
- Resolve quadrant team UUID labels through the team catalog before returning `/api/v1/quadrant` payloads.
- Add regression coverage for opportunity recommendations and quadrant team-label resolution.

## Verification
- `ruff check src/dev_health_ops/api/services/opportunities.py src/dev_health_ops/api/services/quadrant.py tests/test_opportunities.py tests/test_quadrant.py`
- `pytest tests/test_opportunities.py tests/test_quadrant.py -q` (`5 passed`)
- Service-level driver verified cycle-time recommendation text and quadrant `Platform Team` label resolution.

SCREENSHOT-WAIVER: Backend-only ops PR; no web code changed. The service-level driver verifies the API payload now emits resolved names for the existing web Landscape path.

Closes CHAOS-2076
Closes CHAOS-2077