### PR TITLE
fix(api): resolve contributor + repo identity on Govern surfaces (CHAOS-2089)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -28,10 +28,17 @@ class TimeseriesResult:
 
 @strawberry.type
 class BreakdownItem:
-    """A single item in a breakdown result."""
+    """A single item in a breakdown result.
+
+    ``key`` is the stable dimension value (id or slug). ``label`` is the
+    server-resolved human-readable name (Framework A7); it falls back to a
+    controlled non-UUID token when the entity cannot be resolved (A8) so the
+    client never renders a raw id as the primary label.
+    """
 
     key: str
     value: float
+    label: str | None = None
 
 
 @strawberry.type

--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -158,6 +158,52 @@ async def _execute_timeseries_query(
     ]
 
 
+async def _resolve_breakdown_labels(
+    client: Any,
+    *,
+    dimension: str,
+    org_id: str,
+    keys: list[str],
+) -> dict[str, str]:
+    """Resolve repo/team breakdown keys to display names (Framework A7/A8).
+
+    Only the ``repo`` and ``team`` dimensions carry stable ids that can leak as
+    raw UUIDs; other dimensions (theme, work_type, ...) are already human text.
+    Best-effort: returns an empty map on failure so callers fall back.
+    """
+    from dev_health_ops.api.services.identity import resolve_scope_display_names
+
+    if dimension not in {"repo", "team"}:
+        return {}
+    return await resolve_scope_display_names(
+        client,
+        org_id=org_id,
+        scope="team" if dimension == "team" else "repo",
+        ids=keys,
+    )
+
+
+def _build_breakdown_item(
+    key: str,
+    value: float,
+    label_map: dict[str, str],
+) -> BreakdownItem:
+    from dev_health_ops.api.services.identity import looks_like_uuid
+
+    resolved = label_map.get(key)
+    if resolved and not looks_like_uuid(resolved):
+        label: str | None = resolved
+    elif key and not looks_like_uuid(key):
+        # Already-human key (e.g. investment-path repo slug, theme name).
+        label = key
+    else:
+        # A8: never surface a bare UUID; emit a controlled short token and let
+        # the client render its Unresolved badge.
+        token = key.replace("-", "")[:8]
+        label = f"#{token}" if token else None
+    return BreakdownItem(key=key, value=value, label=label)
+
+
 async def _execute_breakdown_query(
     client: Any,
     bd_req: BreakdownRequestInput,
@@ -184,10 +230,18 @@ async def _execute_breakdown_query(
     sql, params = compile_breakdown(request, org_id, timeout, filters=filters)
 
     rows = await query_dicts(client, sql, params)
+
+    # Resolve repo/team dimension keys to human display names server-side so the
+    # client never renders a raw id as the primary label (Framework A7/A8).
+    keys = [str(row.get("dimension_value", "")) for row in rows]
+    label_map = await _resolve_breakdown_labels(
+        client, dimension=bd_req.dimension.value, org_id=org_id, keys=keys
+    )
     items = [
-        BreakdownItem(
-            key=str(row.get("dimension_value", "")),
-            value=float(row.get("value", 0)),
+        _build_breakdown_item(
+            str(row.get("dimension_value", "")),
+            float(row.get("value", 0)),
+            label_map,
         )
         for row in rows
     ]

--- a/src/dev_health_ops/api/models/schemas.py
+++ b/src/dev_health_ops/api/models/schemas.py
@@ -128,11 +128,20 @@ class HomeResponse(BaseModel):
 
 
 class Contributor(BaseModel):
+    """A metric driver/contributor row (Framework A7).
+
+    ``id`` is stable for routing/drill-down. ``label`` is the human-readable
+    text the UI renders. ``display_name`` carries the resolved name when the
+    server could resolve it (non-UUID, A8); when ``None`` the entity is
+    genuinely unresolved and the client applies its controlled fallback.
+    """
+
     id: str
     label: str
     value: float
     delta_pct: float
     evidence_link: str
+    display_name: str | None = None
 
 
 class ExplainResponse(BaseModel):

--- a/src/dev_health_ops/api/services/explain.py
+++ b/src/dev_health_ops/api/services/explain.py
@@ -188,13 +188,18 @@ async def build_explain_response(
         # Resolve scope ids -> display names server-side so labels never carry
         # a bare UUID (Framework A7/A8). group_by is repo_id or team_id.
         scope_kind = scope_kind_for_group_by(config["group_by"])
-        all_ids = [str(r.get("id") or "") for r in (*drivers, *contributors)]
-        display_names = await resolve_scope_display_names(
-            sink,
-            org_id=org_id,
-            scope=scope_kind,
-            ids=all_ids,
+        all_ids = list(
+            {str(r.get("id") or "") for r in (*drivers, *contributors)} - {""}
         )
+        if scope_kind is not None and all_ids:
+            display_names = await resolve_scope_display_names(
+                sink,
+                org_id=org_id,
+                scope=scope_kind,
+                ids=all_ids,
+            )
+        else:
+            display_names = {}
 
     driver_models: list[Contributor] = [
         _build_contributor(

--- a/src/dev_health_ops/api/services/explain.py
+++ b/src/dev_health_ops/api/services/explain.py
@@ -11,6 +11,11 @@ from ..queries.metrics import fetch_metric_value
 from ..utils import delta_pct, safe_float, safe_transform
 from .cache import TTLCache
 from .filtering import filter_cache_key, scope_filter_for_metric, time_window
+from .identity import (
+    looks_like_uuid,
+    resolve_scope_display_names,
+    scope_kind_for_group_by,
+)
 
 
 class _MetricConfig(TypedDict):
@@ -167,6 +172,7 @@ async def build_explain_response(
             compare_end=compare_end,
             scope_filter=scope_filter,
             scope_params=scope_params,
+            org_id=org_id,
         )
         contributors = await fetch_metric_contributors(
             sink,
@@ -177,42 +183,42 @@ async def build_explain_response(
             end_day=end_day,
             scope_filter=scope_filter,
             scope_params=scope_params,
+            org_id=org_id,
+        )
+        # Resolve scope ids -> display names server-side so labels never carry
+        # a bare UUID (Framework A7/A8). group_by is repo_id or team_id.
+        scope_kind = scope_kind_for_group_by(config["group_by"])
+        all_ids = [str(r.get("id") or "") for r in (*drivers, *contributors)]
+        display_names = await resolve_scope_display_names(
+            sink,
+            org_id=org_id,
+            scope=scope_kind,
+            ids=all_ids,
         )
 
-    driver_models: list[Contributor] = []
-    for row in drivers:
-        raw_value = safe_float(row.get("value"))
-        raw_delta = safe_float(row.get("delta_pct"))
-        driver_models.append(
-            Contributor(
-                id=str(row.get("id") or ""),
-                label=str(row.get("id") or "Unknown"),
-                value=safe_transform(config["transform"], raw_value),
-                delta_pct=raw_delta,
-                evidence_link=(
-                    f"/api/v1/drilldown/prs?metric={metric}"
-                    f"&scope_type={filters.scope.level}"
-                    f"&scope_id={_primary_scope_id(filters)}"
-                ),
-            )
+    driver_models: list[Contributor] = [
+        _build_contributor(
+            row,
+            metric=metric,
+            filters=filters,
+            transform=config["transform"],
+            display_names=display_names,
+            delta_value=safe_float(row.get("delta_pct")),
         )
+        for row in drivers
+    ]
 
-    contributor_models: list[Contributor] = []
-    for row in contributors:
-        raw_value = safe_float(row.get("value"))
-        contributor_models.append(
-            Contributor(
-                id=str(row.get("id") or ""),
-                label=str(row.get("id") or "Unknown"),
-                value=safe_transform(config["transform"], raw_value),
-                delta_pct=0.0,
-                evidence_link=(
-                    f"/api/v1/drilldown/prs?metric={metric}"
-                    f"&scope_type={filters.scope.level}"
-                    f"&scope_id={_primary_scope_id(filters)}"
-                ),
-            )
+    contributor_models: list[Contributor] = [
+        _build_contributor(
+            row,
+            metric=metric,
+            filters=filters,
+            transform=config["transform"],
+            display_names=display_names,
+            delta_value=0.0,
         )
+        for row in contributors
+    ]
 
     response = ExplainResponse(
         metric=metric,
@@ -236,3 +242,48 @@ def _primary_scope_id(filters: MetricFilter) -> str:
     if filters.scope.ids:
         return filters.scope.ids[0]
     return ""
+
+
+def _short_token(scope_id: str) -> str:
+    """Controlled fallback for an unresolved id (never a bare UUID).
+
+    Mirrors the cockpit contract: when the server cannot resolve a human name,
+    surface a short, stable, non-UUID token (e.g. ``#698c0211``) plus the
+    structured ``display_name=None`` so the client renders its Unresolved badge
+    rather than leaking a raw UUID as the primary label (A8).
+    """
+    token = scope_id.replace("-", "")[:8]
+    return f"#{token}" if token else "Unknown"
+
+
+def _build_contributor(
+    row: dict[str, object],
+    *,
+    metric: str,
+    filters: MetricFilter,
+    transform: Callable[[float], float],
+    display_names: dict[str, str],
+    delta_value: float,
+) -> Contributor:
+    scope_id = str(row.get("id") or "")
+    resolved = display_names.get(scope_id)
+    # A8: a bare UUID is never a valid label; fall back to a controlled token.
+    if resolved and not looks_like_uuid(resolved):
+        label = resolved
+        display_name: str | None = resolved
+    else:
+        label = _short_token(scope_id)
+        display_name = None
+    raw_value = safe_float(row.get("value"))
+    return Contributor(
+        id=scope_id,
+        label=label,
+        display_name=display_name,
+        value=safe_transform(transform, raw_value),
+        delta_pct=delta_value,
+        evidence_link=(
+            f"/api/v1/drilldown/prs?metric={metric}"
+            f"&scope_type={filters.scope.level}"
+            f"&scope_id={_primary_scope_id(filters)}"
+        ),
+    )

--- a/src/dev_health_ops/api/services/identity.py
+++ b/src/dev_health_ops/api/services/identity.py
@@ -1,0 +1,104 @@
+"""Shared server-side identity resolution (Framework A7 / A8 / B7).
+
+Resolves stable scope ids (``repo_id`` / ``team_id``) to human-readable
+display names by querying the ``repos`` / ``teams`` analytics tables. This is
+the same resolver contract the cockpit conclusion uses (CHAOS-2064) — extracted
+here so Govern surfaces (Incident Correlation contributors, Change-Failure
+associations, Coverage-by-Repository) can resolve identity server-side instead
+of leaking ``#hex UNRESOLVED`` labels to the client.
+
+Rules:
+- Resolution happens server-side; ids are stable, display names are human.
+- A bare UUID is never a valid display name (A8). Callers must apply a
+  controlled fallback rather than surfacing the raw id.
+- Best-effort: on any query failure an empty map is returned so callers fall
+  back deterministically.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Literal
+
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+from ..queries.client import query_dicts
+
+logger = logging.getLogger(__name__)
+
+ScopeKind = Literal["repo", "team"]
+
+_BARE_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def looks_like_uuid(value: str | None) -> bool:
+    """Return True when *value* is a bare UUID that must not appear as a label (A8)."""
+    if not value:
+        return False
+    return bool(_BARE_UUID_RE.match(value.strip()))
+
+
+async def resolve_scope_display_names(
+    sink: BaseMetricsSink,
+    *,
+    org_id: str,
+    scope: ScopeKind,
+    ids: list[str],
+) -> dict[str, str]:
+    """Return ``{scope_id: display_name}`` for the given ids.
+
+    Queries the ``repos`` (``repo`` slug) or ``teams`` (``name``) table. Only
+    non-UUID display names are kept — a row that would resolve to a bare UUID is
+    omitted so callers apply a controlled fallback rather than surfacing the raw
+    id (A8 / B7). Best-effort: returns an empty dict on any failure.
+    """
+    unique_ids = sorted({str(i) for i in ids if i})
+    if not unique_ids:
+        return {}
+
+    if scope == "repo":
+        sql = """
+            SELECT toString(id) AS scope_id, repo AS display_name
+            FROM repos
+            WHERE org_id = {org_id:String}
+              AND toString(id) IN {scope_ids:Array(String)}
+        """
+        params: dict[str, Any] = {"org_id": org_id, "scope_ids": unique_ids}
+    else:
+        sql = """
+            SELECT toString(id) AS scope_id, name AS display_name
+            FROM teams
+            WHERE org_id = {org_id:String}
+              AND toString(id) IN {scope_ids:Array(String)}
+        """
+        params = {"org_id": org_id, "scope_ids": unique_ids}
+
+    try:
+        rows = await query_dicts(sink, sql, params)
+    except Exception:
+        logger.warning(
+            "Could not resolve %s display names for ids=%s", scope, unique_ids
+        )
+        return {}
+
+    resolved: dict[str, str] = {}
+    for row in rows:
+        scope_id = str(row.get("scope_id") or "")
+        display_name = row.get("display_name")
+        if not scope_id or not display_name:
+            continue
+        display_name = str(display_name).strip()
+        # A8: a bare UUID is not a human label — omit so caller falls back.
+        if not display_name or looks_like_uuid(display_name):
+            continue
+        resolved[scope_id] = display_name
+    return resolved
+
+
+def scope_kind_for_group_by(group_by: str) -> ScopeKind:
+    """Map an explain/driver ``group_by`` column to a resolver scope kind."""
+    return "team" if group_by == "team_id" else "repo"

--- a/src/dev_health_ops/api/services/identity.py
+++ b/src/dev_health_ops/api/services/identity.py
@@ -99,6 +99,13 @@ async def resolve_scope_display_names(
     return resolved
 
 
-def scope_kind_for_group_by(group_by: str) -> ScopeKind:
-    """Map an explain/driver ``group_by`` column to a resolver scope kind."""
-    return "team" if group_by == "team_id" else "repo"
+def scope_kind_for_group_by(group_by: str) -> ScopeKind | None:
+    """Map an explain/driver ``group_by`` column to a resolver scope kind.
+
+    Returns None for unrecognised values; callers must skip resolution.
+    """
+    if group_by == "team_id":
+        return "team"
+    if group_by == "repo_id":
+        return "repo"
+    return None

--- a/tests/api/graphql/test_breakdown_identity.py
+++ b/tests/api/graphql/test_breakdown_identity.py
@@ -1,0 +1,39 @@
+"""Identity resolution contract for Coverage-by-Repository breakdown (CHAOS-2089).
+
+Govern Coverage 'Coverage by Repository' bars are fed by the GraphQL analytics
+breakdown. These tests lock in that ``BreakdownItem.label`` carries a resolved
+display name for repo/team dimensions and never surfaces a bare UUID as the
+primary label (Framework A7/A8).
+"""
+
+from __future__ import annotations
+
+from dev_health_ops.api.graphql.resolvers.analytics import _build_breakdown_item
+
+_REPO_UUID = "4e00fff2-df66-5028-8ebd-e4535332300b"
+
+
+def test_breakdown_item_uses_resolved_label() -> None:
+    item = _build_breakdown_item(
+        _REPO_UUID, 42.0, {_REPO_UUID: "meridian/billing-service"}
+    )
+    assert item.key == _REPO_UUID  # stable id preserved
+    assert item.label == "meridian/billing-service"
+
+
+def test_breakdown_item_unresolved_uuid_falls_back_to_short_token() -> None:
+    item = _build_breakdown_item(_REPO_UUID, 10.0, {})
+    # Primary label must never be the raw UUID (A8).
+    assert "4e00fff2-df66" not in (item.label or "")
+    assert item.label == "#4e00fff2"
+
+
+def test_breakdown_item_human_key_passes_through() -> None:
+    # Investment-path repo slugs / theme names are already human text.
+    item = _build_breakdown_item("acme/web", 7.0, {})
+    assert item.label == "acme/web"
+
+
+def test_breakdown_item_unassigned_passes_through() -> None:
+    item = _build_breakdown_item("unassigned", 3.0, {})
+    assert item.label == "unassigned"

--- a/tests/api/services/test_explain_identity.py
+++ b/tests/api/services/test_explain_identity.py
@@ -36,6 +36,7 @@ def test_looks_like_uuid_matches_bare_uuid() -> None:
 def test_scope_kind_maps_group_by() -> None:
     assert scope_kind_for_group_by("team_id") == "team"
     assert scope_kind_for_group_by("repo_id") == "repo"
+    assert scope_kind_for_group_by("unknown_col") is None
 
 
 def test_short_token_never_returns_bare_uuid() -> None:
@@ -105,34 +106,37 @@ def test_build_explain_response_forwards_org_id_to_fetches() -> None:
     is threaded through so contributor identity can actually be resolved.
     """
     import asyncio
+    from collections.abc import AsyncIterator
     from contextlib import asynccontextmanager
+    from typing import cast
 
     from dev_health_ops.api.services import explain as ex
     from dev_health_ops.api.services.cache import TTLCache
+    from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
     seen: dict[str, str | None] = {}
 
-    async def _fake_contributors(*_a, **kwargs):  # type: ignore[no-untyped-def]
+    async def _fake_contributors(*_a, **kwargs):
         seen["contributors_org"] = kwargs.get("org_id")
         return [{"id": _REPO_UUID, "value": 1.0}]
 
-    async def _fake_drivers(*_a, **kwargs):  # type: ignore[no-untyped-def]
+    async def _fake_drivers(*_a, **kwargs):
         seen["drivers_org"] = kwargs.get("org_id")
         return [{"id": _REPO_UUID, "value": 1.0, "delta_pct": 0.0}]
 
-    async def _fake_value(*_a, **_k):  # type: ignore[no-untyped-def]
+    async def _fake_value(*_a, **_k):
         return 1.0
 
-    async def _fake_scope_filter(*_a, **_k):  # type: ignore[no-untyped-def]
+    async def _fake_scope_filter(*_a, **_k):
         return "", {}
 
-    async def _fake_resolve(*_a, **kwargs):  # type: ignore[no-untyped-def]
+    async def _fake_resolve(*_a, **kwargs):
         seen["resolve_org"] = kwargs.get("org_id")
         return {_REPO_UUID: "meridian/billing-service"}
 
     @asynccontextmanager
-    async def _fake_client(_url):  # type: ignore[no-untyped-def]
-        yield object()
+    async def _fake_client(_url: str) -> AsyncIterator[BaseMetricsSink]:
+        yield cast(BaseMetricsSink, object())
 
     orig = {
         "fetch_metric_contributors": ex.fetch_metric_contributors,
@@ -147,7 +151,7 @@ def test_build_explain_response_forwards_org_id_to_fetches() -> None:
     ex.fetch_metric_value = _fake_value
     ex.scope_filter_for_metric = _fake_scope_filter
     ex.resolve_scope_display_names = _fake_resolve
-    ex.clickhouse_client = _fake_client
+    setattr(ex, "clickhouse_client", _fake_client)
     try:
         response = asyncio.run(
             ex.build_explain_response(

--- a/tests/api/services/test_explain_identity.py
+++ b/tests/api/services/test_explain_identity.py
@@ -1,0 +1,170 @@
+"""Identity resolution contract for explain contributors/drivers (CHAOS-2089).
+
+Govern Incident Correlation + Quality (Reliability Patterns) contributors and
+Change-Failure associations are fed by ``/api/v1/explain``. These tests lock in
+that the backend returns a resolved ``display_name`` alongside the stable id and
+never surfaces a bare UUID as the primary ``label`` (Framework A7/A8).
+"""
+
+from __future__ import annotations
+
+from dev_health_ops.api.models.filters import MetricFilter, ScopeFilter
+from dev_health_ops.api.services.explain import _build_contributor, _short_token
+from dev_health_ops.api.services.identity import (
+    looks_like_uuid,
+    scope_kind_for_group_by,
+)
+
+_REPO_UUID = "698c0211-0000-0000-0000-0000fee29c84"
+
+
+def _filters() -> MetricFilter:
+    return MetricFilter(scope=ScopeFilter(level="repo", ids=["698c0211"]))
+
+
+def _identity(v: float) -> float:
+    return v
+
+
+def test_looks_like_uuid_matches_bare_uuid() -> None:
+    assert looks_like_uuid(_REPO_UUID) is True
+    assert looks_like_uuid("acme/backend") is False
+    assert looks_like_uuid("") is False
+    assert looks_like_uuid(None) is False
+
+
+def test_scope_kind_maps_group_by() -> None:
+    assert scope_kind_for_group_by("team_id") == "team"
+    assert scope_kind_for_group_by("repo_id") == "repo"
+
+
+def test_short_token_never_returns_bare_uuid() -> None:
+    token = _short_token(_REPO_UUID)
+    assert token == "#698c0211"
+    assert not looks_like_uuid(token)
+    assert _short_token("") == "Unknown"
+
+
+def test_build_contributor_uses_resolved_display_name() -> None:
+    row = {"id": _REPO_UUID, "value": 5.0}
+    contributor = _build_contributor(
+        row,
+        metric="change_failure_rate",
+        filters=_filters(),
+        transform=_identity,
+        display_names={_REPO_UUID: "meridian/billing-service"},
+        delta_value=0.0,
+    )
+
+    assert contributor.id == _REPO_UUID  # stable id preserved for drill-down
+    assert contributor.label == "meridian/billing-service"
+    assert contributor.display_name == "meridian/billing-service"
+    assert not looks_like_uuid(contributor.label)
+
+
+def test_build_contributor_unresolved_falls_back_to_short_token() -> None:
+    row = {"id": _REPO_UUID, "value": 3.0}
+    contributor = _build_contributor(
+        row,
+        metric="change_failure_rate",
+        filters=_filters(),
+        transform=_identity,
+        display_names={},  # server could not resolve
+        delta_value=0.0,
+    )
+
+    # Primary label must never be the raw UUID (A8).
+    assert "698c0211-0000" not in contributor.label
+    assert contributor.label == "#698c0211"
+    # display_name is None so the client renders its controlled Unresolved badge.
+    assert contributor.display_name is None
+
+
+def test_build_contributor_rejects_uuid_display_name() -> None:
+    """A resolved value that is itself a UUID must not become the label (A8)."""
+    row = {"id": _REPO_UUID, "value": 1.0}
+    contributor = _build_contributor(
+        row,
+        metric="change_failure_rate",
+        filters=_filters(),
+        transform=_identity,
+        display_names={_REPO_UUID: _REPO_UUID},
+        delta_value=0.0,
+    )
+
+    assert not looks_like_uuid(contributor.label)
+    assert contributor.label == "#698c0211"
+    assert contributor.display_name is None
+
+
+def test_build_explain_response_forwards_org_id_to_fetches() -> None:
+    """Regression: driver/contributor fetches must scope by org_id (CHAOS-2089).
+
+    Without org_id, the explain queries return zero rows for any real org, which
+    is what made the Govern panels render empty/unresolved. Lock in that org_id
+    is threaded through so contributor identity can actually be resolved.
+    """
+    import asyncio
+    from contextlib import asynccontextmanager
+
+    from dev_health_ops.api.services import explain as ex
+    from dev_health_ops.api.services.cache import TTLCache
+
+    seen: dict[str, str | None] = {}
+
+    async def _fake_contributors(*_a, **kwargs):  # type: ignore[no-untyped-def]
+        seen["contributors_org"] = kwargs.get("org_id")
+        return [{"id": _REPO_UUID, "value": 1.0}]
+
+    async def _fake_drivers(*_a, **kwargs):  # type: ignore[no-untyped-def]
+        seen["drivers_org"] = kwargs.get("org_id")
+        return [{"id": _REPO_UUID, "value": 1.0, "delta_pct": 0.0}]
+
+    async def _fake_value(*_a, **_k):  # type: ignore[no-untyped-def]
+        return 1.0
+
+    async def _fake_scope_filter(*_a, **_k):  # type: ignore[no-untyped-def]
+        return "", {}
+
+    async def _fake_resolve(*_a, **kwargs):  # type: ignore[no-untyped-def]
+        seen["resolve_org"] = kwargs.get("org_id")
+        return {_REPO_UUID: "meridian/billing-service"}
+
+    @asynccontextmanager
+    async def _fake_client(_url):  # type: ignore[no-untyped-def]
+        yield object()
+
+    orig = {
+        "fetch_metric_contributors": ex.fetch_metric_contributors,
+        "fetch_metric_driver_delta": ex.fetch_metric_driver_delta,
+        "fetch_metric_value": ex.fetch_metric_value,
+        "scope_filter_for_metric": ex.scope_filter_for_metric,
+        "resolve_scope_display_names": ex.resolve_scope_display_names,
+        "clickhouse_client": ex.clickhouse_client,
+    }
+    ex.fetch_metric_contributors = _fake_contributors
+    ex.fetch_metric_driver_delta = _fake_drivers
+    ex.fetch_metric_value = _fake_value
+    ex.scope_filter_for_metric = _fake_scope_filter
+    ex.resolve_scope_display_names = _fake_resolve
+    ex.clickhouse_client = _fake_client
+    try:
+        response = asyncio.run(
+            ex.build_explain_response(
+                db_url="clickhouse://x",
+                metric="change_failure_rate",
+                filters=_filters(),
+                cache=TTLCache(ttl_seconds=0),
+                org_id="org-meridian",
+            )
+        )
+    finally:
+        for name, fn in orig.items():
+            setattr(ex, name, fn)
+
+    assert seen["contributors_org"] == "org-meridian"
+    assert seen["drivers_org"] == "org-meridian"
+    assert seen["resolve_org"] == "org-meridian"
+    assert response.contributors
+    assert response.contributors[0].display_name == "meridian/billing-service"
+    assert response.contributors[0].label == "meridian/billing-service"


### PR DESCRIPTION
## Summary

Govern → Incident Correlation contributors, Quality (Reliability Patterns) contributors + Change-Failure Associations, and Coverage-by-Repository were rendering raw repo UUIDs as `#hex UNRESOLVED`. This resolves identity **server-side** (Framework A7/A8/B7), reusing the cockpit resolver contract from CHAOS-2064 — the frontend EntityLabel was never the right place to mask this.

## Changes

- **`services/identity.py` (new)** — shared `repo`/`team` id → `display_name` resolver with the A8 bare-UUID guard. Best-effort: omits UUID-only names so callers apply a controlled fallback instead of leaking a raw id.
- **`services/explain.py`** — drivers + contributors now return a resolved `display_name` alongside the stable `id`; `label` falls back to a short non-UUID token (`#abc12345`) only when the server genuinely cannot resolve. **Also forwards `org_id`** to the driver/contributor fetches — they previously queried `org_id=''` and returned zero rows, which is what surfaced the empty/unresolved panels.
- **`graphql/resolvers/analytics.py` + `models/outputs.py`** — `BreakdownItem` gains a server-resolved `label` for `repo`/`team` dimensions so Coverage-by-Repository renders names.
- **Tests** — resolver contract, explain/breakdown label contracts, and an `org_id`-forwarding regression test.

## Verification

- Backend: `153 passed, 11 skipped` (identity + explain + graphql + endpoint suites).
- End-to-end against the live ClickHouse fixture org (Meridian): explain now returns `meridian/web-app`, `meridian/core-api`, `meridian/auth-service`, `meridian/billing-service` with `display_name` populated; breakdown resolves the same repo slugs.

## Screenshots

Cross-repo UI evidence (Incident Correlation / Quality / Coverage showing resolved `meridian/*` names, zero `#hex UNRESOLVED`) is attached to the linked **dev-health-web** PR and to CHAOS-2089.

SCREENSHOT-WAIVER: backend-only repo; rendered UI evidence lives on the paired web PR.

Closes CHAOS-2089