### PR TITLE
fix(api): suppress opaque WorkGraph display labels (CHAOS-2089)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -499,13 +499,21 @@ class WorkGraphProvenance(Enum):
 
 @strawberry.type
 class WorkGraphEdgeResult:
-    """A single edge in the work graph."""
+    """A single edge in the work graph.
+
+    source_display_name / target_display_name are A7/A8 resolved labels:
+    a non-UUID id passes through verbatim; a UUID that cannot be looked up
+    is None so the client renders a controlled Unresolved badge (never a
+    bare UUID).
+    """
 
     edge_id: str
     source_type: WorkGraphNodeType
     source_id: str
+    source_display_name: str | None = None
     target_type: WorkGraphNodeType
     target_id: str
+    target_display_name: str | None = None
     edge_type: WorkGraphEdgeType
     provenance: WorkGraphProvenance
     confidence: float

--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from dev_health_ops.api.services.identity import looks_like_uuid
@@ -20,6 +21,8 @@ from ..models.outputs import (
 )
 
 logger = logging.getLogger(__name__)
+
+_OPAQUE_HEX_ID_RE = re.compile(r"^[0-9a-f]{24,}$", re.IGNORECASE)
 
 
 def _map_node_type(value: str) -> WorkGraphNodeType:
@@ -54,7 +57,7 @@ def _display_name_for(entity_id: str) -> str | None:
     raw = str(entity_id).strip()
     if not raw:
         return None
-    return None if looks_like_uuid(raw) else raw
+    return None if looks_like_uuid(raw) or _OPAQUE_HEX_ID_RE.match(raw) else raw
 
 
 def _row_to_edge(row: dict[str, Any]) -> WorkGraphEdgeResult:

--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from dev_health_ops.api.services.identity import looks_like_uuid
+
 from ..authz import require_org_id
 from ..context import GraphQLContext
 from ..models.inputs import WorkGraphEdgeFilterInput
@@ -41,13 +43,31 @@ def _map_provenance(value: str) -> WorkGraphProvenance:
         return WorkGraphProvenance.HEURISTIC
 
 
+def _display_name_for(entity_id: str) -> str | None:
+    """A7/A8: pass through human-readable ids; return None for bare UUIDs.
+
+    Non-UUID identifiers (e.g. PROJ-123, INC-001, deploy-xyz) are already
+    human-readable and are surfaced verbatim. UUID-style identifiers that
+    cannot be resolved server-side return None so the client renders a
+    controlled Unresolved badge rather than leaking a raw UUID.
+    """
+    raw = str(entity_id).strip()
+    if not raw:
+        return None
+    return None if looks_like_uuid(raw) else raw
+
+
 def _row_to_edge(row: dict[str, Any]) -> WorkGraphEdgeResult:
+    source_id = str(row.get("source_id", ""))
+    target_id = str(row.get("target_id", ""))
     return WorkGraphEdgeResult(
         edge_id=str(row.get("edge_id", "")),
         source_type=_map_node_type(str(row.get("source_type", "issue"))),
-        source_id=str(row.get("source_id", "")),
+        source_id=source_id,
+        source_display_name=_display_name_for(source_id),
         target_type=_map_node_type(str(row.get("target_type", "issue"))),
-        target_id=str(row.get("target_id", "")),
+        target_id=target_id,
+        target_display_name=_display_name_for(target_id),
         edge_type=_map_edge_type(str(row.get("edge_type", "relates"))),
         provenance=_map_provenance(str(row.get("provenance", "heuristic"))),
         confidence=float(row.get("confidence", 0.0)),

--- a/tests/graphql/test_work_graph.py
+++ b/tests/graphql/test_work_graph.py
@@ -335,6 +335,21 @@ class TestWorkGraphEdgeDisplayNames:
         assert result.edges[0].target_display_name is None
 
     @pytest.mark.asyncio
+    async def test_hash_like_ids_yield_none_display_name(self, mock_context):
+        hash_id = "4e00fff2df6650288ebde4535332300b"
+        rows = [
+            make_edge_row(source_id=hash_id, target_id="INC-001"),
+        ]
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = rows
+            result = await resolve_work_graph_edges(mock_context)
+
+        assert result.edges[0].source_display_name is None
+
+    @pytest.mark.asyncio
     async def test_display_names_present_on_every_edge(self, mock_context):
         """Every edge result carries source/target display name fields (may be None)."""
         rows = [

--- a/tests/graphql/test_work_graph.py
+++ b/tests/graphql/test_work_graph.py
@@ -262,3 +262,99 @@ class TestResolveWorkGraphEdges:
 
         with pytest.raises(RuntimeError, match="Database client not available"):
             await resolve_work_graph_edges(context)
+
+
+class TestWorkGraphEdgeDisplayNames:
+    """CHAOS-2089: WorkGraphEdgeResult carries server-resolved display names.
+
+    A7/A8 contract: human-readable source/target IDs pass through as
+    display names; UUID-style IDs that cannot be looked up return None so
+    the client renders a controlled Unresolved badge rather than a bare UUID.
+    """
+
+    @pytest.mark.asyncio
+    async def test_human_readable_source_id_becomes_display_name(self, mock_context):
+        """Non-UUID source_id (e.g. PROJ-123) passes through as source_display_name."""
+        rows = [
+            make_edge_row(source_id="PROJ-123", target_id="dep-abc"),
+        ]
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = rows
+            result = await resolve_work_graph_edges(mock_context)
+
+        assert result.edges[0].source_display_name == "PROJ-123"
+
+    @pytest.mark.asyncio
+    async def test_human_readable_target_id_becomes_display_name(self, mock_context):
+        """Non-UUID target_id (e.g. INC-001) passes through as target_display_name."""
+        rows = [
+            make_edge_row(source_id="deploy-xyz", target_id="INC-001"),
+        ]
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = rows
+            result = await resolve_work_graph_edges(mock_context)
+
+        assert result.edges[0].target_display_name == "INC-001"
+
+    @pytest.mark.asyncio
+    async def test_uuid_source_id_yields_none_display_name(self, mock_context):
+        """UUID source_id without a resolvable name -> source_display_name is None (A8)."""
+        uuid_id = "4e00fff2-df66-5028-8ebd-e4535332300b"
+        rows = [
+            make_edge_row(source_id=uuid_id, target_id="INC-001"),
+        ]
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = rows
+            result = await resolve_work_graph_edges(mock_context)
+
+        assert result.edges[0].source_display_name is None
+
+    @pytest.mark.asyncio
+    async def test_uuid_target_id_yields_none_display_name(self, mock_context):
+        """UUID target_id without a resolvable name -> target_display_name is None (A8)."""
+        uuid_id = "698c0211-e29b-41d4-a716-446655440000"
+        rows = [
+            make_edge_row(source_id="dep-xyz", target_id=uuid_id),
+        ]
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = rows
+            result = await resolve_work_graph_edges(mock_context)
+
+        assert result.edges[0].target_display_name is None
+
+    @pytest.mark.asyncio
+    async def test_display_names_present_on_every_edge(self, mock_context):
+        """Every edge result carries source/target display name fields (may be None)."""
+        rows = [
+            make_edge_row(edge_id="e1", source_id="PROJ-1", target_id="INC-2"),
+            make_edge_row(
+                edge_id="e2",
+                source_id="4e00fff2-df66-5028-8ebd-e4535332300b",
+                target_id="INC-5",
+            ),
+        ]
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = rows
+            result = await resolve_work_graph_edges(mock_context)
+
+        assert hasattr(result.edges[0], "source_display_name")
+        assert hasattr(result.edges[0], "target_display_name")
+        assert result.edges[0].source_display_name == "PROJ-1"
+        assert result.edges[0].target_display_name == "INC-2"
+        assert result.edges[1].source_display_name is None
+        assert result.edges[1].target_display_name == "INC-5"


### PR DESCRIPTION
## Summary
- Treat long hex Work Graph IDs as opaque and return null display names for them
- Preserve human-readable IDs such as incident keys
- Add GraphQL regression coverage for hash-like IDs

## Verification
- pytest tests/graphql/test_work_graph.py
- ruff format --check src/dev_health_ops/api/graphql/resolvers/work_graph.py tests/graphql/test_work_graph.py
- ruff check src/dev_health_ops/api/graphql/resolvers/work_graph.py tests/graphql/test_work_graph.py
- PYTHONPATH=src python -c 'from dev_health_ops.api.graphql.resolvers.work_graph import _display_name_for; values={"uuid": _display_name_for("4e00fff2-df66-5028-8ebd-e4535332300b"), "hex": _display_name_for("4e00fff2df6650288ebde4535332300b"), "human": _display_name_for("INC-2025-404")}; assert values == {"uuid": None, "hex": None, "human": "INC-2025-404"}, values; print(values)'

SCREENSHOT-WAIVER: API-only label fallback hardening; frontend behavior is covered in the companion web PR.

Closes CHAOS-2089