### PR TITLE
CHAOS-2077/2079: cognitiveLoad + reviewEdges queries + churn-quadrant repo-grain fix

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/cognitive_load.py
+++ b/src/dev_health_ops/api/graphql/resolvers/cognitive_load.py
@@ -1,0 +1,244 @@
+"""Cognitive Load GraphQL resolver (CHAOS-2077).
+
+Reads from two append-only ClickHouse tables:
+- ``user_metrics_daily``  — per-developer load signals (SUM across developers)
+- ``team_metrics_daily``  — per-team commit-timing ratios (AVG across teams)
+
+Both tables are plain ``MergeTree`` (NOT ``ReplacingMergeTree``): a recompute /
+backfill appends a NEW row for the same logical key rather than replacing the
+old one. Live data confirms duplicates (user_metrics_daily: 2344 duplicate-key
+rows; team_metrics_daily: 66). We therefore collapse to the latest row per key
+via ``argMax(<col>, computed_at)`` BEFORE aggregating — mirroring the
+established ``resolvers/complexity.py`` convention. Without this, SUM/AVG would
+double-count backfilled rows (naive SUM of pr_interruption_load was 3296 vs the
+correct 1744 in the demo org).
+
+The two result sets are merged on ``day`` (over the UNION of days) in Python
+before being returned. All reads are org-scoped via ``require_org_id`` +
+parametrized ``org_id``. No data is written or recomputed — pure surface of
+persisted metrics.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from dev_health_ops.api.queries.client import query_dicts
+
+from ..authz import require_org_id
+from ..context import GraphQLContext
+from ..types.cognitive_load import (
+    CognitiveLoadInput,
+    CognitiveLoadResult,
+    CognitiveLoadSignal,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _require_client(context: GraphQLContext) -> Any:
+    if context.client is None:
+        raise RuntimeError("Database client not available for CognitiveLoad resolver")
+    return context.client
+
+
+def _nfloat(row: dict[str, Any], key: str) -> float | None:
+    """Return ``float(row[key])`` or ``None`` when absent/null."""
+    v = row.get(key)
+    return float(v) if v is not None else None
+
+
+# ---------------------------------------------------------------------------
+# ClickHouse fetch helpers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_user_metrics(
+    client: Any,
+    *,
+    org_id: str,
+    since_date: str,
+    until_date: str,
+    team_id: str | None,
+) -> list[dict[str, Any]]:
+    """SUM of latest-per-developer cognitive load columns, grouped by day.
+
+    ``user_metrics_daily`` is append-only (plain MergeTree), so a backfill
+    writes a duplicate row for the same ``(org_id, repo_id, author_email, day)``
+    key. The inner subquery selects the latest row per key via
+    ``argMax(<col>, computed_at)``; the outer query SUMs those deduplicated
+    rows by day. This prevents double-counting from re-computation passes.
+
+    Filters by ``org_id`` (always), date range, and optionally ``team_id``.
+    """
+    inner_where = """
+            WHERE org_id = {org_id:String}
+              AND day >= {since_date:Date}
+              AND day <= {until_date:Date}
+    """
+    params: dict[str, Any] = {
+        "org_id": org_id,
+        "since_date": since_date,
+        "until_date": until_date,
+    }
+    if team_id:
+        inner_where += "\n              AND team_id = {team_id:String}"
+        params["team_id"] = team_id
+
+    query = f"""
+        SELECT
+            day,
+            SUM(pr_interruption_load) AS pr_interruption_load,
+            SUM(context_spread_count) AS context_spread_count,
+            SUM(review_request_load)  AS review_request_load
+        FROM (
+            SELECT
+                day,
+                repo_id,
+                author_email,
+                argMax(pr_interruption_load, computed_at) AS pr_interruption_load,
+                argMax(context_spread_count, computed_at) AS context_spread_count,
+                argMax(review_request_load,  computed_at) AS review_request_load
+            FROM user_metrics_daily
+            {inner_where}
+            GROUP BY day, repo_id, author_email
+        )
+        GROUP BY day
+        ORDER BY day
+    """
+    return await query_dicts(client, query, params)
+
+
+async def _fetch_team_metrics(
+    client: Any,
+    *,
+    org_id: str,
+    since_date: str,
+    until_date: str,
+    team_id: str | None,
+) -> list[dict[str, Any]]:
+    """AVG of latest-per-team after-hours / weekend commit ratios, by day.
+
+    ``team_metrics_daily`` is append-only (plain MergeTree) and team-scoped
+    (no repo_id). The inner subquery collapses each
+    ``(org_id, team_id, day)`` key to its latest row via
+    ``argMax(<col>, computed_at)``; the outer query AVGs those deduplicated
+    rows by day. When ``team_id`` is supplied we filter to that team;
+    otherwise we average across all teams to produce an org-wide signal.
+    """
+    inner_where = """
+            WHERE org_id = {org_id:String}
+              AND day >= {since_date:Date}
+              AND day <= {until_date:Date}
+    """
+    params: dict[str, Any] = {
+        "org_id": org_id,
+        "since_date": since_date,
+        "until_date": until_date,
+    }
+    if team_id:
+        inner_where += "\n              AND team_id = {team_id:String}"
+        params["team_id"] = team_id
+
+    query = f"""
+        SELECT
+            day,
+            AVG(after_hours_commit_ratio) AS after_hours_commit_ratio,
+            AVG(weekend_commit_ratio)     AS weekend_commit_ratio
+        FROM (
+            SELECT
+                day,
+                team_id,
+                argMax(after_hours_commit_ratio, computed_at) AS after_hours_commit_ratio,
+                argMax(weekend_commit_ratio,     computed_at) AS weekend_commit_ratio
+            FROM team_metrics_daily
+            {inner_where}
+            GROUP BY day, team_id
+        )
+        GROUP BY day
+        ORDER BY day
+    """
+    return await query_dicts(client, query, params)
+
+
+# ---------------------------------------------------------------------------
+# Public resolver
+# ---------------------------------------------------------------------------
+
+
+async def resolve_cognitive_load(
+    context: GraphQLContext,
+    input: CognitiveLoadInput,
+) -> CognitiveLoadResult:
+    """Serve cognitive-load signals from ClickHouse (read-only).
+
+    Org-gate is enforced via ``require_org_id``; any mismatch between the
+    JWT org and the GraphQL ``orgId`` argument is logged and the JWT org wins.
+
+    The resolver fires two queries (user + team), each of which deduplicates
+    append-only rows via ``argMax(..., computed_at)`` before aggregating, then
+    merges them over the UNION of days. A day present only in
+    ``team_metrics_daily`` (e.g. a weekend with commit-timing data but no
+    per-developer load rows) is still emitted with zero user-side signals.
+    """
+    authorized_org_id = require_org_id(context)
+    if input.org_id != authorized_org_id:
+        logger.debug(
+            "Ignoring GraphQL orgId %r in favor of authorized org %r",
+            input.org_id,
+            authorized_org_id,
+        )
+
+    client = _require_client(context)
+
+    since_date = input.since_date.isoformat()
+    until_date = input.until_date.isoformat()
+
+    # Fire both queries
+    user_rows = await _fetch_user_metrics(
+        client,
+        org_id=authorized_org_id,
+        since_date=since_date,
+        until_date=until_date,
+        team_id=input.team_id,
+    )
+    team_rows = await _fetch_team_metrics(
+        client,
+        org_id=authorized_org_id,
+        since_date=since_date,
+        until_date=until_date,
+        team_id=input.team_id,
+    )
+
+    # Index both result sets by day for an O(1) outer-join merge.
+    user_by_day: dict[Any, dict[str, Any]] = {row["day"]: row for row in user_rows}
+    team_by_day: dict[Any, dict[str, Any]] = {row["day"]: row for row in team_rows}
+
+    # Merge over the UNION of days: a day may appear in team_metrics_daily
+    # without a matching user_metrics_daily row (and vice versa). Sort so the
+    # output is deterministic regardless of dict insertion order.
+    all_days = sorted(set(user_by_day) | set(team_by_day))
+
+    signals: list[CognitiveLoadSignal] = []
+    for day_val in all_days:
+        user_row = user_by_day.get(day_val, {})
+        team_row = team_by_day.get(day_val, {})
+
+        signals.append(
+            CognitiveLoadSignal(
+                day=day_val,
+                pr_interruption_load=float(user_row.get("pr_interruption_load") or 0.0),
+                context_spread_count=float(user_row.get("context_spread_count") or 0.0),
+                review_request_load=float(user_row.get("review_request_load") or 0.0),
+                after_hours_commit_ratio=_nfloat(team_row, "after_hours_commit_ratio"),
+                weekend_commit_ratio=_nfloat(team_row, "weekend_commit_ratio"),
+            )
+        )
+
+    return CognitiveLoadResult(
+        org_id=authorized_org_id,
+        team_id=input.team_id,
+        signals=signals,
+        total_days=len(signals),
+    )

--- a/src/dev_health_ops/api/graphql/resolvers/review_edges.py
+++ b/src/dev_health_ops/api/graphql/resolvers/review_edges.py
@@ -1,0 +1,155 @@
+"""Review Edges GraphQL resolver (CHAOS-2077).
+
+Reads from the append-only ClickHouse table ``review_edges_daily``.
+Returns reviewer-to-author collaboration edges filtered by org, date range,
+and optionally by repo.  All reads are org-scoped via ``require_org_id``.
+No data is written or recomputed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from dev_health_ops.api.queries.client import query_dicts
+
+from ..authz import require_org_id
+from ..context import GraphQLContext
+from ..types.review_edges import (
+    ReviewEdgeRow,
+    ReviewEdgesInput,
+    ReviewEdgesResult,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Hard cap on returned rows to protect against pathological date ranges.
+MAX_REVIEW_EDGES_ROWS: int = 2000
+
+
+def _require_client(context: GraphQLContext) -> Any:
+    if context.client is None:
+        raise RuntimeError("Database client not available for ReviewEdges resolver")
+    return context.client
+
+
+# ---------------------------------------------------------------------------
+# ClickHouse fetch helper
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_review_edges(
+    client: Any,
+    *,
+    org_id: str,
+    since_date: str,
+    until_date: str,
+    repo_ids: list[str] | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Read ``review_edges_daily`` filtered by org + date range.
+
+    ``review_edges_daily`` is append-only (plain MergeTree, NOT
+    ReplacingMergeTree): a recompute / backfill writes a duplicate row for the
+    same ``(org_id, repo_id, reviewer, author, day)`` key (live data shows 49
+    duplicate-key rows). The inner subquery collapses each key to its latest
+    row via ``argMax(reviews_count, computed_at)`` so a backfilled day is not
+    counted twice. Only after deduplication do we ``ORDER BY reviews_count
+    DESC`` (heaviest collaboration pairs first) and apply the row cap.
+
+    An optional ``repo_ids`` filter narrows to specific repositories.
+    ``repo_id`` is stored as a UUID; we cast to String for safe comparison
+    with the input list and for the response payload.
+    """
+    inner_where = """
+            WHERE org_id = {org_id:String}
+              AND day >= {since_date:Date}
+              AND day <= {until_date:Date}
+    """
+    params: dict[str, Any] = {
+        "org_id": org_id,
+        "since_date": since_date,
+        "until_date": until_date,
+    }
+    if repo_ids:
+        inner_where += (
+            "\n              AND toString(repo_id) IN {repo_ids:Array(String)}"
+        )
+        params["repo_ids"] = list(repo_ids)
+
+    query = f"""
+        SELECT
+            reviewer,
+            author,
+            reviews_count,
+            day,
+            toString(repo_id) AS repo_id
+        FROM (
+            SELECT
+                repo_id,
+                reviewer,
+                author,
+                day,
+                argMax(reviews_count, computed_at) AS reviews_count
+            FROM review_edges_daily
+            {inner_where}
+            GROUP BY repo_id, reviewer, author, day
+        )
+        ORDER BY reviews_count DESC
+        LIMIT {limit}
+    """
+    return await query_dicts(client, query, params)
+
+
+# ---------------------------------------------------------------------------
+# Public resolver
+# ---------------------------------------------------------------------------
+
+
+async def resolve_review_edges(
+    context: GraphQLContext,
+    input: ReviewEdgesInput,
+) -> ReviewEdgesResult:
+    """Serve review-edge rows from ClickHouse (read-only).
+
+    Org-gate is enforced via ``require_org_id``; any mismatch between the
+    JWT org and the GraphQL ``orgId`` argument is logged and the JWT org wins.
+    """
+    authorized_org_id = require_org_id(context)
+    if input.org_id != authorized_org_id:
+        logger.debug(
+            "Ignoring GraphQL orgId %r in favor of authorized org %r",
+            input.org_id,
+            authorized_org_id,
+        )
+
+    client = _require_client(context)
+
+    raw_limit = input.limit if input.limit is not None else 500
+    effective_limit = max(1, min(raw_limit, MAX_REVIEW_EDGES_ROWS))
+
+    since_date = input.since_date.isoformat()
+    until_date = input.until_date.isoformat()
+
+    raw_rows = await _fetch_review_edges(
+        client,
+        org_id=authorized_org_id,
+        since_date=since_date,
+        until_date=until_date,
+        repo_ids=input.repo_ids,
+        limit=effective_limit,
+    )
+
+    edges: list[ReviewEdgeRow] = []
+    for row in raw_rows:
+        edges.append(
+            ReviewEdgeRow(
+                reviewer=str(row.get("reviewer") or ""),
+                author=str(row.get("author") or ""),
+                reviews_count=int(row.get("reviews_count") or 0),
+                day=row["day"],
+                repo_id=str(row["repo_id"]) if row.get("repo_id") else None,
+            )
+        )
+
+    return ReviewEdgesResult(edges=edges, total_count=len(edges))

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -67,6 +67,7 @@ from .resolvers.ai import (
 from .resolvers.analytics import resolve_analytics
 from .resolvers.bus_factor import resolve_bus_factor
 from .resolvers.catalog import resolve_catalog
+from .resolvers.cognitive_load import resolve_cognitive_load
 from .resolvers.complexity import resolve_complexity_timeseries, resolve_hotspots
 from .resolvers.compounding_risk import resolve_compounding_risk
 from .resolvers.data_health import resolve_data_health
@@ -91,8 +92,13 @@ from .resolvers.reports import (
     resolve_trigger_report,
     resolve_update_saved_report,
 )
+from .resolvers.review_edges import resolve_review_edges
 from .subscriptions import Subscription
 from .types.bus_factor import BusFactor, BusFactorScopeInput
+from .types.cognitive_load import (
+    CognitiveLoadInput,
+    CognitiveLoadResult,
+)
 from .types.complexity import (
     ComplexityTimeseriesInput,
     ComplexityTimeseriesResult,
@@ -102,6 +108,10 @@ from .types.complexity import (
 from .types.compounding_risk import (
     CompoundingRiskFilterInput,
     CompoundingRiskResult,
+)
+from .types.review_edges import (
+    ReviewEdgesInput,
+    ReviewEdgesResult,
 )
 
 logger = logging.getLogger(__name__)
@@ -409,6 +419,37 @@ class Query:
     ) -> HotspotsResult:
         context = get_context(info)
         return await resolve_hotspots(context, input)
+
+    @strawberry.field(
+        description=(
+            "Daily cognitive-load signals (PR interruption, context spread, "
+            "review request load, after-hours and weekend commit ratios). "
+            "Reads from ``user_metrics_daily`` and ``team_metrics_daily`` — "
+            "no recomputation, pure surface of persisted metrics."
+        )
+    )
+    async def cognitive_load(
+        self,
+        info: Info,
+        input: CognitiveLoadInput,
+    ) -> CognitiveLoadResult:
+        context = get_context(info)
+        return await resolve_cognitive_load(context, input)
+
+    @strawberry.field(
+        description=(
+            "Reviewer-to-author collaboration edges from ``review_edges_daily``. "
+            "Ordered by review count descending.  Use ``repoIds`` to narrow to "
+            "specific repositories.  Org-scoped; no recomputation."
+        )
+    )
+    async def review_edges(
+        self,
+        info: Info,
+        input: ReviewEdgesInput,
+    ) -> ReviewEdgesResult:
+        context = get_context(info)
+        return await resolve_review_edges(context, input)
 
     @strawberry.field(
         description="Latest rule-based recommendations for a team within a lookback window."

--- a/src/dev_health_ops/api/graphql/types/cognitive_load.py
+++ b/src/dev_health_ops/api/graphql/types/cognitive_load.py
@@ -1,0 +1,61 @@
+"""GraphQL types for the Cognitive Load surface (CHAOS-2077).
+
+Exposes two signals merged from existing ClickHouse tables:
+- ``user_metrics_daily``   — per-developer daily load metrics
+- ``team_metrics_daily``   — per-team daily commit-timing ratios
+
+No new tables or ETL are introduced; this is a pure schema addition.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import strawberry
+
+
+@strawberry.input
+class CognitiveLoadInput:
+    """Input for the ``cognitiveLoad`` query."""
+
+    org_id: str = strawberry.field(name="orgId")
+    since_date: date = strawberry.field(name="sinceDate")
+    until_date: date = strawberry.field(name="untilDate")
+    #: Optional filter to a single team.  When absent, data across all teams
+    #: is aggregated.
+    team_id: str | None = strawberry.field(default=None, name="teamId")
+
+
+@strawberry.type
+class CognitiveLoadSignal:
+    """One day's cognitive-load signals, merged from user + team tables.
+
+    ``prInterruptionLoad``, ``contextSpreadCount``, and ``reviewRequestLoad``
+    are summed across all developers in the org (or team when ``teamId`` is
+    supplied).
+
+    ``afterHoursCommitRatio`` and ``weekendCommitRatio`` are team-level averages;
+    they are ``null`` when ``team_metrics_daily`` has no row for the day.
+    """
+
+    day: date
+    pr_interruption_load: float = strawberry.field(name="prInterruptionLoad")
+    context_spread_count: float = strawberry.field(name="contextSpreadCount")
+    review_request_load: float = strawberry.field(name="reviewRequestLoad")
+    after_hours_commit_ratio: float | None = strawberry.field(
+        default=None, name="afterHoursCommitRatio"
+    )
+    weekend_commit_ratio: float | None = strawberry.field(
+        default=None, name="weekendCommitRatio"
+    )
+
+
+@strawberry.type
+class CognitiveLoadResult:
+    """Response for ``cognitiveLoad``."""
+
+    org_id: str = strawberry.field(name="orgId")
+    team_id: str | None = strawberry.field(default=None, name="teamId")
+    signals: list[CognitiveLoadSignal]
+    #: Number of distinct calendar days returned.
+    total_days: int = strawberry.field(name="totalDays")

--- a/src/dev_health_ops/api/graphql/types/review_edges.py
+++ b/src/dev_health_ops/api/graphql/types/review_edges.py
@@ -1,0 +1,48 @@
+"""GraphQL types for the Review Edges surface (CHAOS-2077).
+
+Exposes reviewer-to-author collaboration data from ``review_edges_daily``.
+No new tables or ETL are introduced; this is a pure schema addition.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import strawberry
+
+
+@strawberry.input
+class ReviewEdgesInput:
+    """Input for the ``reviewEdges`` query."""
+
+    org_id: str = strawberry.field(name="orgId")
+    since_date: date = strawberry.field(name="sinceDate")
+    until_date: date = strawberry.field(name="untilDate")
+    #: Optional filter to specific repo UUIDs.  When absent, all repos are
+    #: included.
+    repo_ids: list[str] | None = strawberry.field(default=None, name="repoIds")
+    #: Row cap; default 500, hard max 2000.
+    limit: int = 500
+
+
+@strawberry.type
+class ReviewEdgeRow:
+    """One reviewer-to-author edge for a given day and repo.
+
+    ``repoId`` is the UUID string from ``review_edges_daily.repo_id``.
+    """
+
+    reviewer: str
+    author: str
+    reviews_count: int = strawberry.field(name="reviewsCount")
+    day: date
+    repo_id: str | None = strawberry.field(default=None, name="repoId")
+
+
+@strawberry.type
+class ReviewEdgesResult:
+    """Response for ``reviewEdges``."""
+
+    edges: list[ReviewEdgeRow]
+    #: Total number of rows returned (equals ``len(edges)``).
+    total_count: int = strawberry.field(name="totalCount")

--- a/src/dev_health_ops/api/services/quadrant.py
+++ b/src/dev_health_ops/api/services/quadrant.py
@@ -475,6 +475,16 @@ async def build_quadrant_response(
         raise HTTPException(status_code=404, detail="Unknown quadrant type")
 
     normalized_scope = _normalize_scope(scope_type)
+    # Churn is repo-attributed at ingest; user_metrics_daily.team_id is sparse, so
+    # team/org-grain churn collapses to ~0 and the scatter degenerates onto the y-axis
+    # (CHAOS-2079). For churn_throughput, always enumerate repos regardless of the
+    # caller's filter scope so the quadrant plots real per-repo churn. Person grain
+    # (the individual view) is left intact, and cycle/wip/review quadrants are
+    # unaffected because the branch is gated on the quadrant type. The scope id does
+    # not filter entities at team/repo grain (scope_filter is only set for person
+    # scope below), so an inbound team id here is harmless.
+    if type == "churn_throughput" and normalized_scope in {"org", "team"}:
+        normalized_scope = "repo"
     group_scope = _group_scope(normalized_scope)
     filter_scope = cast(
         Literal["org", "team", "repo", "service", "developer"],

--- a/tests/api/graphql/test_cognitive_load_resolver.py
+++ b/tests/api/graphql/test_cognitive_load_resolver.py
@@ -1,0 +1,429 @@
+"""Resolver tests for cognitiveLoad (CHAOS-2077).
+
+Tests exercise the resolver against a mocked ClickHouse client and verify:
+
+* Empty state returns empty signals list (``totalDays=0``).
+* Signals are built correctly from user_metrics_daily rows.
+* Team metrics (after_hours / weekend ratios) are merged on day.
+* Merge is over the UNION of days: a day present only in team_metrics (and
+  absent from user_metrics) is still emitted, with zero user-side signals and
+  the available team ratios.
+* Days in user_metrics with no matching team_metrics row produce null ratios.
+* Both ClickHouse queries deduplicate append-only rows via
+  ``argMax(<col>, computed_at)`` before aggregating (asserted on SQL text,
+  since the mocked client cannot execute argMax).
+* The org-id gate raises ``AuthorizationError`` when ``context.org_id`` is
+  missing.
+* The ``team_id`` filter passes through to both SQL queries.
+
+All tests are read-only; no ClickHouse tables are modified.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.resolvers.cognitive_load import resolve_cognitive_load
+from dev_health_ops.api.graphql.types.cognitive_load import CognitiveLoadInput
+
+ORG_ID = "org-cogload-test"
+DAY_1 = date(2026, 5, 1)
+DAY_2 = date(2026, 5, 2)
+SINCE = date(2026, 5, 1)
+UNTIL = date(2026, 5, 31)
+
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _ctx() -> GraphQLContext:
+    ctx = GraphQLContext(org_id=ORG_ID, db_url="clickhouse://localhost:8123/d")
+    ctx.client = MagicMock(spec=["query"])
+    return ctx
+
+
+def _qresult(columns: list[str], rows: list[list[Any]]) -> Any:
+    result = MagicMock()
+    result.column_names = columns
+    result.result_rows = rows
+    return result
+
+
+def _setup_client(client: Any, responses: list[Any]) -> None:
+    """Make ``client.query`` return successive responses per call."""
+    client.query.side_effect = responses
+
+
+def _squash_ws(sql: str) -> str:
+    """Collapse runs of whitespace to a single space for robust SQL matching.
+
+    The resolver aligns ``argMax(...)`` columns with padding spaces; this lets
+    assertions match the logical SQL without coupling to exact alignment.
+    """
+    return re.sub(r"\s+", " ", sql)
+
+
+def _input(team_id: str | None = None) -> CognitiveLoadInput:
+    return CognitiveLoadInput(
+        org_id=ORG_ID,
+        since_date=SINCE,
+        until_date=UNTIL,
+        team_id=team_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_empty_state() -> None:
+    """Empty user_metrics returns empty signals (totalDays=0)."""
+    ctx = _ctx()
+    _setup_client(
+        ctx.client,
+        [
+            _qresult([], []),  # user_metrics_daily → no rows
+            _qresult([], []),  # team_metrics_daily → no rows
+        ],
+    )
+
+    result = await resolve_cognitive_load(ctx, _input())
+
+    assert result.org_id == ORG_ID
+    assert result.team_id is None
+    assert result.signals == []
+    assert result.total_days == 0
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: user metrics only (team metrics empty)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_user_metrics_no_team_metrics() -> None:
+    """When team_metrics has no rows, ratios are null for all signals."""
+    ctx = _ctx()
+    user_cols = [
+        "day",
+        "pr_interruption_load",
+        "context_spread_count",
+        "review_request_load",
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(user_cols, [[DAY_1, 12, 45, 3]]),
+            _qresult([], []),  # team_metrics → empty
+        ],
+    )
+
+    result = await resolve_cognitive_load(ctx, _input())
+
+    assert len(result.signals) == 1
+    sig = result.signals[0]
+    assert sig.day == DAY_1
+    assert sig.pr_interruption_load == pytest.approx(12.0)
+    assert sig.context_spread_count == pytest.approx(45.0)
+    assert sig.review_request_load == pytest.approx(3.0)
+    assert sig.after_hours_commit_ratio is None
+    assert sig.weekend_commit_ratio is None
+    assert result.total_days == 1
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: user + team metrics merged on day
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_merges_team_ratios_on_day() -> None:
+    """Team metrics are merged correctly when the day matches."""
+    ctx = _ctx()
+    user_cols = [
+        "day",
+        "pr_interruption_load",
+        "context_spread_count",
+        "review_request_load",
+    ]
+    team_cols = ["day", "after_hours_commit_ratio", "weekend_commit_ratio"]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(user_cols, [[DAY_1, 10, 50, 5], [DAY_2, 8, 30, 2]]),
+            _qresult(team_cols, [[DAY_1, 0.42, 0.31]]),  # only DAY_1 has team row
+        ],
+    )
+
+    result = await resolve_cognitive_load(ctx, _input())
+
+    assert len(result.signals) == 2
+    s1, s2 = result.signals[0], result.signals[1]
+
+    # DAY_1 — team row present
+    assert s1.day == DAY_1
+    assert s1.pr_interruption_load == pytest.approx(10.0)
+    assert s1.after_hours_commit_ratio == pytest.approx(0.42)
+    assert s1.weekend_commit_ratio == pytest.approx(0.31)
+
+    # DAY_2 — no matching team row → null ratios
+    assert s2.day == DAY_2
+    assert s2.pr_interruption_load == pytest.approx(8.0)
+    assert s2.after_hours_commit_ratio is None
+    assert s2.weekend_commit_ratio is None
+
+    assert result.total_days == 2
+
+
+# ---------------------------------------------------------------------------
+# Null / zero tolerance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_null_user_values_default_to_zero() -> None:
+    """Null column values in user_metrics degrade to 0.0 (not crashes)."""
+    ctx = _ctx()
+    user_cols = [
+        "day",
+        "pr_interruption_load",
+        "context_spread_count",
+        "review_request_load",
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(user_cols, [[DAY_1, None, None, None]]),
+            _qresult([], []),
+        ],
+    )
+
+    result = await resolve_cognitive_load(ctx, _input())
+
+    sig = result.signals[0]
+    assert sig.pr_interruption_load == pytest.approx(0.0)
+    assert sig.context_spread_count == pytest.approx(0.0)
+    assert sig.review_request_load == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_null_team_ratios_propagate_as_none() -> None:
+    """Null team ratio values remain null (not coerced to 0)."""
+    ctx = _ctx()
+    user_cols = [
+        "day",
+        "pr_interruption_load",
+        "context_spread_count",
+        "review_request_load",
+    ]
+    team_cols = ["day", "after_hours_commit_ratio", "weekend_commit_ratio"]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(user_cols, [[DAY_1, 5, 20, 1]]),
+            _qresult(team_cols, [[DAY_1, None, None]]),
+        ],
+    )
+
+    result = await resolve_cognitive_load(ctx, _input())
+
+    sig = result.signals[0]
+    assert sig.after_hours_commit_ratio is None
+    assert sig.weekend_commit_ratio is None
+
+
+# ---------------------------------------------------------------------------
+# team_id filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_team_id_reflected_in_result() -> None:
+    """team_id from input is echoed in the result and passed to both queries."""
+    ctx = _ctx()
+    user_cols = [
+        "day",
+        "pr_interruption_load",
+        "context_spread_count",
+        "review_request_load",
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(user_cols, [[DAY_1, 3, 7, 1]]),
+            _qresult([], []),
+        ],
+    )
+
+    result = await resolve_cognitive_load(ctx, _input(team_id="team-alpha"))
+
+    assert result.team_id == "team-alpha"
+    # Both queries must embed the team_id filter — check via call args.
+    assert ctx.client.query.call_count == 2
+    first_query: str = ctx.client.query.call_args_list[0].args[0]
+    second_query: str = ctx.client.query.call_args_list[1].args[0]
+    assert "team_id" in first_query
+    assert "team_id" in second_query
+
+
+# ---------------------------------------------------------------------------
+# Union-of-days merge (finding 3): day only in team_metrics still emitted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_day_only_in_team_metrics_is_emitted() -> None:
+    """A day present in team_metrics but absent from user_metrics is emitted
+    with zero user-side signals + the available team ratios.
+
+    Regression test for finding 3: the merge must span the UNION of days from
+    both result sets, not just the user rows.
+    """
+    ctx = _ctx()
+    user_cols = [
+        "day",
+        "pr_interruption_load",
+        "context_spread_count",
+        "review_request_load",
+    ]
+    team_cols = ["day", "after_hours_commit_ratio", "weekend_commit_ratio"]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(user_cols, [[DAY_1, 10, 50, 5]]),  # only DAY_1
+            _qresult(team_cols, [[DAY_2, 0.40, 0.25]]),  # only DAY_2 (e.g. weekend)
+        ],
+    )
+
+    result = await resolve_cognitive_load(ctx, _input())
+
+    # Union of {DAY_1} and {DAY_2} → both days present, sorted ascending.
+    assert result.total_days == 2
+    by_day = {s.day: s for s in result.signals}
+    assert set(by_day) == {DAY_1, DAY_2}
+
+    # DAY_1 — user signals present, no team row → null ratios
+    assert by_day[DAY_1].pr_interruption_load == pytest.approx(10.0)
+    assert by_day[DAY_1].after_hours_commit_ratio is None
+
+    # DAY_2 — NO user row → zeros, but team ratios present
+    assert by_day[DAY_2].pr_interruption_load == pytest.approx(0.0)
+    assert by_day[DAY_2].context_spread_count == pytest.approx(0.0)
+    assert by_day[DAY_2].review_request_load == pytest.approx(0.0)
+    assert by_day[DAY_2].after_hours_commit_ratio == pytest.approx(0.40)
+    assert by_day[DAY_2].weekend_commit_ratio == pytest.approx(0.25)
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_signals_sorted_by_day() -> None:
+    """Signals are returned in ascending day order even when source rows are
+    interleaved across the two result sets."""
+    ctx = _ctx()
+    user_cols = [
+        "day",
+        "pr_interruption_load",
+        "context_spread_count",
+        "review_request_load",
+    ]
+    team_cols = ["day", "after_hours_commit_ratio", "weekend_commit_ratio"]
+    day_0 = date(2026, 4, 30)
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(user_cols, [[DAY_2, 1, 1, 1]]),  # later day from user side
+            _qresult(team_cols, [[day_0, 0.1, 0.2]]),  # earlier day from team side
+        ],
+    )
+
+    result = await resolve_cognitive_load(ctx, _input())
+
+    assert [s.day for s in result.signals] == [day_0, DAY_2]
+
+
+# ---------------------------------------------------------------------------
+# Dedup: argMax(..., computed_at) before SUM/AVG (finding 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_user_query_dedups_via_argmax_computed_at() -> None:
+    """The user_metrics query must collapse to the latest row per logical key
+    via argMax(<col>, computed_at) before SUMming.
+
+    The mocked client cannot execute argMax, so we assert on the emitted SQL:
+    it must argMax every metric over computed_at and GROUP BY the full key
+    (day, repo_id, author_email) in an inner subquery, then SUM by day.
+    """
+    ctx = _ctx()
+    _setup_client(ctx.client, [_qresult([], []), _qresult([], [])])
+
+    await resolve_cognitive_load(ctx, _input())
+
+    # Column alignment in the SQL may insert extra spaces before ``computed_at``;
+    # normalize runs of whitespace before matching so the assertion is robust.
+    user_query: str = _squash_ws(ctx.client.query.call_args_list[0].args[0])
+    assert "argMax(pr_interruption_load, computed_at)" in user_query
+    assert "argMax(context_spread_count, computed_at)" in user_query
+    assert "argMax(review_request_load, computed_at)" in user_query
+    # Inner grouping on the full append-only key + outer SUM by day.
+    assert "GROUP BY day, repo_id, author_email" in user_query
+    assert "SUM(pr_interruption_load)" in user_query
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_team_query_dedups_via_argmax_computed_at() -> None:
+    """The team_metrics query must collapse to the latest row per
+    (day, team_id) via argMax(<col>, computed_at) before AVGing."""
+    ctx = _ctx()
+    _setup_client(ctx.client, [_qresult([], []), _qresult([], [])])
+
+    await resolve_cognitive_load(ctx, _input())
+
+    team_query: str = _squash_ws(ctx.client.query.call_args_list[1].args[0])
+    assert "argMax(after_hours_commit_ratio, computed_at)" in team_query
+    assert "argMax(weekend_commit_ratio, computed_at)" in team_query
+    assert "GROUP BY day, team_id" in team_query
+    assert "AVG(after_hours_commit_ratio)" in team_query
+
+
+# ---------------------------------------------------------------------------
+# Org-id gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_raises_on_missing_context_org() -> None:
+    """``require_org_id`` raises ``AuthorizationError`` when org_id is absent."""
+    from dev_health_ops.api.graphql.errors import AuthorizationError
+
+    ctx = _ctx()
+    object.__setattr__(ctx, "org_id", "")
+
+    with pytest.raises(AuthorizationError):
+        await resolve_cognitive_load(ctx, _input())
+
+
+# ---------------------------------------------------------------------------
+# Two ClickHouse queries are always fired
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_always_fires_two_queries() -> None:
+    """Resolver always issues exactly 2 ClickHouse queries: user then team."""
+    ctx = _ctx()
+    _setup_client(ctx.client, [_qresult([], []), _qresult([], [])])
+
+    await resolve_cognitive_load(ctx, _input())
+
+    assert ctx.client.query.call_count == 2

--- a/tests/api/graphql/test_review_edges_resolver.py
+++ b/tests/api/graphql/test_review_edges_resolver.py
@@ -1,0 +1,287 @@
+"""Resolver tests for reviewEdges (CHAOS-2077).
+
+Tests exercise the resolver against a mocked ClickHouse client and verify:
+
+* Empty state returns ``ReviewEdgesResult(edges=[], totalCount=0)``.
+* Rows are mapped correctly from ClickHouse column names.
+* The query deduplicates append-only rows via ``argMax(reviews_count,
+  computed_at)`` grouped by the full key BEFORE ordering/limiting (asserted on
+  SQL text, since the mocked client cannot execute argMax).
+* The row limit is clamped to ``MAX_REVIEW_EDGES_ROWS`` and applied AFTER dedup.
+* Optional ``repo_ids`` filter is included in the SQL when supplied.
+* ``repo_id`` is ``None`` when the column value is absent/empty.
+* The org-id gate raises ``AuthorizationError`` when ``context.org_id`` is
+  missing.
+
+All tests are read-only; no ClickHouse tables are modified.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.resolvers.review_edges import (
+    MAX_REVIEW_EDGES_ROWS,
+    resolve_review_edges,
+)
+from dev_health_ops.api.graphql.types.review_edges import ReviewEdgesInput
+
+ORG_ID = "org-review-edges-test"
+DAY = date(2026, 5, 10)
+SINCE = date(2026, 5, 1)
+UNTIL = date(2026, 5, 31)
+
+EDGE_COLS = ["reviewer", "author", "reviews_count", "day", "repo_id"]
+
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+
+def _ctx() -> GraphQLContext:
+    ctx = GraphQLContext(org_id=ORG_ID, db_url="clickhouse://localhost:8123/d")
+    ctx.client = MagicMock(spec=["query"])
+    return ctx
+
+
+def _qresult(columns: list[str], rows: list[list[Any]]) -> Any:
+    result = MagicMock()
+    result.column_names = columns
+    result.result_rows = rows
+    return result
+
+
+def _input(
+    *,
+    repo_ids: list[str] | None = None,
+    limit: int = 500,
+) -> ReviewEdgesInput:
+    return ReviewEdgesInput(
+        org_id=ORG_ID,
+        since_date=SINCE,
+        until_date=UNTIL,
+        repo_ids=repo_ids,
+        limit=limit,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_edges_empty_state() -> None:
+    """Empty table returns stable zero-row contract."""
+    ctx = _ctx()
+    ctx.client.query.return_value = _qresult([], [])
+
+    result = await resolve_review_edges(ctx, _input())
+
+    assert result.edges == []
+    assert result.total_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: column mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_edges_maps_columns_correctly() -> None:
+    """All columns map to the correct GraphQL type fields."""
+    ctx = _ctx()
+    ctx.client.query.return_value = _qresult(
+        EDGE_COLS,
+        [["reviewer@example.com", "author@example.com", 7, DAY, "repo-uuid-abc"]],
+    )
+
+    result = await resolve_review_edges(ctx, _input())
+
+    assert len(result.edges) == 1
+    edge = result.edges[0]
+    assert edge.reviewer == "reviewer@example.com"
+    assert edge.author == "author@example.com"
+    assert edge.reviews_count == 7
+    assert edge.day == DAY
+    assert edge.repo_id == "repo-uuid-abc"
+    assert result.total_count == 1
+
+
+@pytest.mark.asyncio
+async def test_review_edges_multiple_rows_all_returned() -> None:
+    """Multiple edge rows are all included in the result."""
+    ctx = _ctx()
+    ctx.client.query.return_value = _qresult(
+        EDGE_COLS,
+        [
+            ["a@x.com", "b@x.com", 5, DAY, "repo-1"],
+            ["c@x.com", "d@x.com", 3, DAY, "repo-2"],
+            ["a@x.com", "c@x.com", 1, DAY, "repo-1"],
+        ],
+    )
+
+    result = await resolve_review_edges(ctx, _input())
+
+    assert len(result.edges) == 3
+    assert result.total_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Null / missing repo_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_edges_null_repo_id_becomes_none() -> None:
+    """Empty/null repo_id column maps to None in the response."""
+    ctx = _ctx()
+    ctx.client.query.return_value = _qresult(
+        EDGE_COLS,
+        [["r@x.com", "a@x.com", 2, DAY, None]],
+    )
+
+    result = await resolve_review_edges(ctx, _input())
+
+    assert result.edges[0].repo_id is None
+
+
+@pytest.mark.asyncio
+async def test_review_edges_empty_string_repo_id_becomes_none() -> None:
+    """Empty-string repo_id is treated the same as null → None."""
+    ctx = _ctx()
+    ctx.client.query.return_value = _qresult(
+        EDGE_COLS,
+        [["r@x.com", "a@x.com", 2, DAY, ""]],
+    )
+
+    result = await resolve_review_edges(ctx, _input())
+
+    assert result.edges[0].repo_id is None
+
+
+# ---------------------------------------------------------------------------
+# repo_ids filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_edges_repo_ids_filter_appears_in_query() -> None:
+    """When repo_ids are supplied, the SQL includes the IN filter clause."""
+    ctx = _ctx()
+    ctx.client.query.return_value = _qresult([], [])
+
+    await resolve_review_edges(ctx, _input(repo_ids=["repo-a", "repo-b"]))
+
+    query: str = ctx.client.query.call_args.args[0]
+    assert "repo_ids" in query
+
+
+@pytest.mark.asyncio
+async def test_review_edges_no_repo_ids_filter_absent_from_query() -> None:
+    """When repo_ids is None, the IN filter must NOT appear in the SQL."""
+    ctx = _ctx()
+    ctx.client.query.return_value = _qresult([], [])
+
+    await resolve_review_edges(ctx, _input(repo_ids=None))
+
+    query: str = ctx.client.query.call_args.args[0]
+    assert "repo_ids" not in query
+
+
+# ---------------------------------------------------------------------------
+# Dedup: argMax(reviews_count, computed_at) before ORDER/LIMIT (finding 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_edges_dedups_via_argmax_computed_at() -> None:
+    """The query must collapse review_edges_daily to the latest row per
+    (repo_id, reviewer, author, day) via argMax(reviews_count, computed_at)
+    BEFORE ordering and limiting.
+
+    The mocked client cannot execute argMax, so we assert on the emitted SQL:
+    it must argMax reviews_count over computed_at, GROUP BY the full key, and
+    only then ORDER BY reviews_count DESC. Regression test for finding 2:
+    without dedup, a backfilled day's edge would be counted twice.
+    """
+    ctx = _ctx()
+    ctx.client.query.return_value = _qresult([], [])
+
+    await resolve_review_edges(ctx, _input())
+
+    query: str = ctx.client.query.call_args.args[0]
+    assert "argMax(reviews_count, computed_at)" in query
+    assert "GROUP BY repo_id, reviewer, author, day" in query
+    # Dedup subquery must precede the ranking/cap.
+    idx_group = query.index("GROUP BY repo_id, reviewer, author, day")
+    idx_order = query.index("ORDER BY reviews_count DESC")
+    assert idx_group < idx_order, "dedup GROUP BY must come before ORDER BY"
+
+
+# ---------------------------------------------------------------------------
+# Row limit clamping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_edges_limit_clamped_to_max() -> None:
+    """Limits above MAX_REVIEW_EDGES_ROWS are silently clamped."""
+    ctx = _ctx()
+    ctx.client.query.return_value = _qresult([], [])
+
+    await resolve_review_edges(ctx, _input(limit=MAX_REVIEW_EDGES_ROWS + 99999))
+
+    query: str = ctx.client.query.call_args.args[0]
+    assert f"LIMIT {MAX_REVIEW_EDGES_ROWS}" in query
+
+
+@pytest.mark.asyncio
+async def test_review_edges_limit_below_one_clamped_to_one() -> None:
+    """Limits of 0 or negative are clamped to 1."""
+    ctx = _ctx()
+    ctx.client.query.return_value = _qresult([], [])
+
+    await resolve_review_edges(ctx, _input(limit=0))
+
+    query: str = ctx.client.query.call_args.args[0]
+    assert "LIMIT 1" in query
+
+
+# ---------------------------------------------------------------------------
+# Org-id gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_edges_raises_on_missing_context_org() -> None:
+    """``require_org_id`` raises ``AuthorizationError`` when org_id is absent."""
+    from dev_health_ops.api.graphql.errors import AuthorizationError
+
+    ctx = _ctx()
+    object.__setattr__(ctx, "org_id", "")
+
+    with pytest.raises(AuthorizationError):
+        await resolve_review_edges(ctx, _input())
+
+
+# ---------------------------------------------------------------------------
+# Single ClickHouse query per call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_edges_fires_exactly_one_query() -> None:
+    """ReviewEdges resolver issues exactly one ClickHouse query per call."""
+    ctx = _ctx()
+    ctx.client.query.return_value = _qresult([], [])
+
+    await resolve_review_edges(ctx, _input())
+
+    assert ctx.client.query.call_count == 1

--- a/tests/test_quadrant.py
+++ b/tests/test_quadrant.py
@@ -118,6 +118,65 @@ async def test_quadrant_resolves_team_uuid_label_from_team_catalog(monkeypatch):
         raising=False,
     )
 
+    # churn_throughput now forces repo grain (CHAOS-2079), so exercise team-label
+    # resolution through a quadrant that keeps team grain (cycle_throughput).
+    response = await build_quadrant_response(
+        db_url="clickhouse://test",
+        org_id="test-org",
+        type="cycle_throughput",
+        scope_type="team",
+        scope_id="",
+        range_days=30,
+        bucket="week",
+        start_date=date(2024, 1, 1),
+        end_date=date(2024, 1, 8),
+    )
+
+    assert response.points[0].entity_id == team_uuid
+    assert response.points[0].entity_label == "Platform Team"
+
+
+@pytest.mark.asyncio
+async def test_churn_quadrant_forces_repo_grain(monkeypatch):
+    """churn_throughput must enumerate repos even when the caller asks for team/org
+    scope. Churn is repo-attributed at ingest, so team-grain churn collapses to ~0 and
+    the scatter degenerates onto the y-axis (CHAOS-2079). Assert both axes source from
+    repo_metrics_daily and that team-label resolution is skipped."""
+
+    @asynccontextmanager
+    async def _fake_client(_db_url):
+        yield object()
+
+    captured_tables: list[str] = []
+    captured_value_exprs: list[str] = []
+
+    async def _fake_metric(_sink, *, table, value_expr, entity_expr, **_):
+        captured_tables.append(table)
+        captured_value_exprs.append(value_expr)
+        return [
+            {
+                "bucket": date(2024, 1, 1),
+                "entity_id": "checkout-service",
+                "entity_label": "checkout-service",
+                "value": 120.0,
+            }
+        ]
+
+    async def _unexpected_query_dicts(*_args, **_kwargs):
+        raise AssertionError("team-label resolution must not run for repo-grain churn")
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.clickhouse_client", _fake_client
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.fetch_quadrant_metric", _fake_metric
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.query_dicts",
+        _unexpected_query_dicts,
+        raising=False,
+    )
+
     response = await build_quadrant_response(
         db_url="clickhouse://test",
         org_id="test-org",
@@ -130,5 +189,11 @@ async def test_quadrant_resolves_team_uuid_label_from_team_catalog(monkeypatch):
         end_date=date(2024, 1, 8),
     )
 
-    assert response.points[0].entity_id == team_uuid
-    assert response.points[0].entity_label == "Platform Team"
+    # Both axes must source from the repo grain (repo_metrics_daily), not the
+    # team/user tables that produce the degenerate churn≈0 collapse.
+    assert captured_tables, "fetch_quadrant_metric was never called"
+    assert all(table == "repo_metrics_daily AS m" for table in captured_tables)
+    assert any("total_loc_touched" in expr for expr in captured_value_exprs)
+    assert any("prs_merged" in expr for expr in captured_value_exprs)
+    # Repo labels pass through untouched (no team-catalog resolution).
+    assert response.points[0].entity_label == "checkout-service"


### PR DESCRIPTION
## Summary
Backend for the CHAOS-2079 Diagnose remediation.

### cognitiveLoad + reviewEdges GraphQL queries (`b2023552e`)
- New Strawberry resolvers/types exposing `cognitiveLoad` (per-day interruption / context-spread / review-request load + after-hours/weekend ratios) and `reviewEdges` (reviewer->author pairs from `review_edges_daily`).
- Append-only MergeTree tables -> `argMax(col, computed_at)` dedup (adversarial review caught a ~1.9x double-count). 24 resolver tests + 154 graphql-suite pass.

### churn_throughput repo-grain fix (`b5de5d3`)
- The churn x throughput quadrant collapsed at churn~0 under team scope: churn is repo-attributed at ingest (`repo_metrics_daily`), but the team-grain path sums `user_metrics_daily.team_id`, which is sparse. `build_quadrant_response` now forces repo grain for `churn_throughput` when scope is org/team, plotting real per-repo churn vs throughput from the same table. Person grain + cycle/wip/review quadrants are untouched (gated on quadrant type). New `test_churn_quadrant_forces_repo_grain`; team-label test repurposed to `cycle_throughput`.

## Web rendering verification (AGENTS.md)
This backend powers web surfaces; live-verified against the running stack:
- **/metrics?tab=dora** + **/landscape**: churn quadrant now plots **repos** (`meridian/web-app`, `auth-service`, `core-api`, `billing-service`) instead of teams collapsed at churn~0.
- **/cognitive-load** tabs render real `cognitiveLoad` data (Overview KPIs 16/60/2/38%/25%; context-spread trend; load-driver composition; review-wait heatmap).
- **/diagnose/work-graph?tab=review-network** renders the real reviewer->author table from `reviewEdges` (15 reviewers / 52 reviews in the active 14d window).

Screenshots captured locally and available to attach: `dora-quadrant-full.png`, `cl-overview.png`, `cl-context-switching.png`, `cl-focus-pressure.png`, `cl-load-drivers.png`, `cl-heatmap.png`, `diagnose-landing-cards.png`. (gh CLI cannot embed local images; drag-drop into the PR body to attach.)

**Base: `main`.** Paired web PR: full-chaos/dev-health-web#622.