### PR TITLE
fix(complexity): honor active window in complexity timeseries resolver (CHAOS-2160)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/complexity.py
+++ b/src/dev_health_ops/api/graphql/resolvers/complexity.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 from datetime import date as PyDate
-from datetime import timedelta
+from datetime import timedelta, timezone
 from typing import Any
 from urllib.parse import quote
 
@@ -144,7 +144,26 @@ async def _fetch_repo_timeseries(
         bounded = list(repo_ids)[:MAX_ROWS]
         query += "\n  AND toString(repo_id) IN {repo_ids:Array(String)}"
         params["repo_ids"] = bounded
-    query += f"\nGROUP BY day, repo_id\nORDER BY day, repo_id\nLIMIT {limit}"
+    else:
+        query += """
+          AND toString(repo_id) IN (
+              SELECT repo_id
+              FROM (
+                  SELECT
+                      toString(repo_id) AS repo_id,
+                      argMax(cyclomatic_per_kloc, (day, computed_at)) AS latest_complexity
+                  FROM repo_complexity_daily
+                  WHERE org_id = {org_id:String}
+                    AND day >= {since_day:Date}
+                    AND day <= {until_day:Date}
+                  GROUP BY repo_id
+                  ORDER BY latest_complexity DESC NULLS LAST, repo_id
+                  LIMIT {limit:UInt32}
+              )
+          )
+        """
+        params["limit"] = limit
+    query += "\nGROUP BY day, repo_id\nORDER BY day, repo_id"
     return await query_dicts(client, query, params)
 
 
@@ -259,8 +278,8 @@ async def resolve_complexity_timeseries(
     raw_limit = input.limit if input.limit is not None else DEFAULT_TIMESERIES_LIMIT
     effective_limit = max(1, min(raw_limit, MAX_ROWS))
 
-    since_day = input.since_utc.date().isoformat()
-    until_day = input.until_utc.date().isoformat()
+    since_day = input.since_utc.astimezone(timezone.utc).date().isoformat()
+    until_day = input.until_utc.astimezone(timezone.utc).date().isoformat()
 
     points: list[ComplexityPoint] = []
 

--- a/src/dev_health_ops/api/graphql/resolvers/complexity.py
+++ b/src/dev_health_ops/api/graphql/resolvers/complexity.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 #: Hard cap on timeseries rows; protects against pathological scopes.
 MAX_ROWS: int = 1000
+MAX_TIMESERIES_POINTS: int = 1000
 #: Default row limit for timeseries queries.
 DEFAULT_TIMESERIES_LIMIT: int = 500
 #: Default row limit for hotspot queries.
@@ -69,14 +70,16 @@ def _nfloat(row: dict[str, Any], key: str) -> float | None:
     return float(v) if v is not None else None
 
 
-def _truncate_to_week(day_val: Any) -> Any:
-    """Truncate a ``date`` to the start of its ISO week (Monday).
-
-    Returns the input unchanged when it is not a ``datetime.date``.
-    """
-    if isinstance(day_val, PyDate):
-        return day_val - timedelta(days=day_val.weekday())
-    return day_val
+def _bucket_count(
+    since_day: PyDate, until_day: PyDate, granularity: TimeGranularity
+) -> int:
+    if until_day < since_day:
+        return 1
+    if granularity == TimeGranularity.WEEK:
+        since_bucket = since_day - timedelta(days=since_day.weekday())
+        until_bucket = until_day - timedelta(days=until_day.weekday())
+        return ((until_bucket - since_bucket).days // 7) + 1
+    return (until_day - since_day).days + 1
 
 
 async def _load_repo_labels(
@@ -115,25 +118,30 @@ async def _fetch_repo_timeseries(
     until_day: str,
     repo_ids: list[str] | None,
     limit: int,
+    granularity: TimeGranularity,
 ) -> list[dict[str, Any]]:
     """Latest-compute read from ``repo_complexity_daily`` for the date window.
 
     ``argMax`` over ``computed_at`` returns the most-recent ingestion for each
     ``(repo_id, day)`` pair, consistent with the append-only sink contract.
     """
-    query = """
+    day_expr = "toStartOfWeek(day, 1)" if granularity == TimeGranularity.WEEK else "day"
+    computed_expr = (
+        "(day, computed_at)" if granularity == TimeGranularity.WEEK else "computed_at"
+    )
+    query = f"""
         SELECT
-            day,
+            {day_expr} AS day,
             toString(repo_id) AS repo_id,
-            argMax(loc_total,                      computed_at) AS loc_total,
-            argMax(cyclomatic_total,               computed_at) AS cyclomatic_total,
-            argMax(cyclomatic_per_kloc,            computed_at) AS cyclomatic_per_kloc,
-            argMax(high_complexity_functions,      computed_at) AS high_complexity_functions,
-            argMax(very_high_complexity_functions, computed_at) AS very_high_complexity_functions
+            argMax(loc_total,                      {computed_expr}) AS loc_total,
+            argMax(cyclomatic_total,               {computed_expr}) AS cyclomatic_total,
+            argMax(cyclomatic_per_kloc,            {computed_expr}) AS cyclomatic_per_kloc,
+            argMax(high_complexity_functions,      {computed_expr}) AS high_complexity_functions,
+            argMax(very_high_complexity_functions, {computed_expr}) AS very_high_complexity_functions
         FROM repo_complexity_daily
-        WHERE org_id = {org_id:String}
-          AND day >= {since_day:Date}
-          AND day <= {until_day:Date}
+        WHERE org_id = {{org_id:String}}
+          AND day >= {{since_day:Date}}
+          AND day <= {{until_day:Date}}
     """
     params: dict[str, Any] = {
         "org_id": org_id,
@@ -141,7 +149,7 @@ async def _fetch_repo_timeseries(
         "until_day": until_day,
     }
     if repo_ids:
-        bounded = list(repo_ids)[:MAX_ROWS]
+        bounded = list(repo_ids)[:limit]
         query += "\n  AND toString(repo_id) IN {repo_ids:Array(String)}"
         params["repo_ids"] = bounded
     else:
@@ -175,24 +183,35 @@ async def _fetch_file_timeseries(
     until_day: str,
     repo_ids: list[str] | None,
     limit: int,
+    granularity: TimeGranularity,
 ) -> list[dict[str, Any]]:
     """Latest-compute read from ``file_complexity_snapshots`` for the date window.
 
     The table uses ``as_of_day`` (not ``day``) as the snapshot column.
     """
-    query = """
+    day_expr = (
+        "toStartOfWeek(as_of_day, 1)"
+        if granularity == TimeGranularity.WEEK
+        else "as_of_day"
+    )
+    computed_expr = (
+        "(as_of_day, computed_at)"
+        if granularity == TimeGranularity.WEEK
+        else "computed_at"
+    )
+    query = f"""
         SELECT
-            as_of_day AS day,
+            {day_expr} AS day,
             toString(repo_id) AS repo_id,
             file_path,
-            argMax(cyclomatic_total,               computed_at) AS cyclomatic_total,
-            argMax(cyclomatic_avg,                 computed_at) AS cyclomatic_avg,
-            argMax(high_complexity_functions,      computed_at) AS high_complexity_functions,
-            argMax(very_high_complexity_functions, computed_at) AS very_high_complexity_functions
+            argMax(cyclomatic_total,               {computed_expr}) AS cyclomatic_total,
+            argMax(cyclomatic_avg,                 {computed_expr}) AS cyclomatic_avg,
+            argMax(high_complexity_functions,      {computed_expr}) AS high_complexity_functions,
+            argMax(very_high_complexity_functions, {computed_expr}) AS very_high_complexity_functions
         FROM file_complexity_snapshots
-        WHERE org_id = {org_id:String}
-          AND as_of_day >= {since_day:Date}
-          AND as_of_day <= {until_day:Date}
+        WHERE org_id = {{org_id:String}}
+          AND as_of_day >= {{since_day:Date}}
+          AND as_of_day <= {{until_day:Date}}
     """
     params: dict[str, Any] = {
         "org_id": org_id,
@@ -200,13 +219,10 @@ async def _fetch_file_timeseries(
         "until_day": until_day,
     }
     if repo_ids:
-        bounded = list(repo_ids)[:MAX_ROWS]
+        bounded = list(repo_ids)[:limit]
         query += "\n  AND toString(repo_id) IN {repo_ids:Array(String)}"
         params["repo_ids"] = bounded
-    query += (
-        f"\nGROUP BY as_of_day, repo_id, file_path"
-        f"\nORDER BY as_of_day, repo_id\nLIMIT {limit}"
-    )
+    query += f"\nGROUP BY day, repo_id, file_path\nORDER BY day, repo_id\nLIMIT {limit}"
     return await query_dicts(client, query, params)
 
 
@@ -278,8 +294,14 @@ async def resolve_complexity_timeseries(
     raw_limit = input.limit if input.limit is not None else DEFAULT_TIMESERIES_LIMIT
     effective_limit = max(1, min(raw_limit, MAX_ROWS))
 
-    since_day = input.since_utc.astimezone(timezone.utc).date().isoformat()
-    until_day = input.until_utc.astimezone(timezone.utc).date().isoformat()
+    since_date = input.since_utc.astimezone(timezone.utc).date()
+    until_date = input.until_utc.astimezone(timezone.utc).date()
+    bucket_count = _bucket_count(since_date, until_date, input.granularity)
+    effective_limit = min(
+        effective_limit, max(1, MAX_TIMESERIES_POINTS // bucket_count)
+    )
+    since_day = since_date.isoformat()
+    until_day = until_date.isoformat()
 
     points: list[ComplexityPoint] = []
 
@@ -291,19 +313,16 @@ async def resolve_complexity_timeseries(
             until_day=until_day,
             repo_ids=input.repo_ids,
             limit=effective_limit,
+            granularity=input.granularity,
         )
         repo_ids_seen = list({str(r["repo_id"]) for r in rows})
         labels = await _load_repo_labels(client, authorized_org_id, repo_ids_seen)
 
         for row in rows:
-            day_val = row["day"]
-            if input.granularity == TimeGranularity.WEEK:
-                day_val = _truncate_to_week(day_val)
-
             repo_id = str(row["repo_id"])
             points.append(
                 ComplexityPoint(
-                    point_date=day_val,
+                    point_date=row["day"],
                     scope_id=repo_id,
                     scope_name=labels.get(repo_id, repo_id),
                     loc_total=_nint(row, "loc_total"),
@@ -325,20 +344,17 @@ async def resolve_complexity_timeseries(
             until_day=until_day,
             repo_ids=input.repo_ids,
             limit=effective_limit,
+            granularity=input.granularity,
         )
         # FILE-scope scopeName is derived from file_path — no repo-label join needed.
         for row in rows:
-            day_val = row["day"]
-            if input.granularity == TimeGranularity.WEEK:
-                day_val = _truncate_to_week(day_val)
-
             repo_id = str(row["repo_id"])
             file_path = str(row.get("file_path") or "")
             # Composite scopeId encodes both repo and file path for uniqueness.
             scope_id = f"{repo_id}/{file_path}"
             points.append(
                 ComplexityPoint(
-                    point_date=day_val,
+                    point_date=row["day"],
                     scope_id=scope_id,
                     scope_name=file_path or scope_id,
                     loc_total=None,  # not stored per-file in v1 schema

--- a/src/dev_health_ops/api/graphql/types/complexity.py
+++ b/src/dev_health_ops/api/graphql/types/complexity.py
@@ -47,7 +47,7 @@ class ComplexityTimeseriesInput:
     scope: ComplexityScope
     repo_ids: list[str] | None = strawberry.field(default=None, name="repoIds")
     team_ids: list[str] | None = strawberry.field(default=None, name="teamIds")
-    #: Row cap; default 500, hard max 1000.
+    #: Repo scope cap; default 500, hard max 1000. Returned points remain bounded by scope × bucket safety limits.
     limit: int | None = None
 
 

--- a/tests/api/graphql/test_complexity_resolver.py
+++ b/tests/api/graphql/test_complexity_resolver.py
@@ -403,10 +403,31 @@ async def test_timeseries_limit_is_clamped_to_max_rows() -> None:
         ctx, _timeseries_input(limit=MAX_ROWS + 99999)
     )
 
-    # The LIMIT clause in the query must be at most MAX_ROWS.
     first_call_query: str = ctx.client.query.call_args_list[0].args[0]
-    assert f"LIMIT {MAX_ROWS}" in first_call_query
+    first_call_params: dict[str, Any] = ctx.client.query.call_args_list[0].kwargs[
+        "parameters"
+    ]
+    assert "LIMIT {limit:UInt32}" in first_call_query
+    assert first_call_params["limit"] == MAX_ROWS
     assert result.points == []
+
+
+@pytest.mark.asyncio
+async def test_timeseries_limit_selects_scopes_not_earliest_rows() -> None:
+    ctx = _ctx()
+    _setup_client(ctx.client, [_qresult([], []), _qresult([], [])])
+
+    await resolve_complexity_timeseries(ctx, _timeseries_input(limit=10))
+
+    first_call_query: str = ctx.client.query.call_args_list[0].args[0]
+    first_call_params: dict[str, Any] = ctx.client.query.call_args_list[0].kwargs[
+        "parameters"
+    ]
+    assert "GROUP BY day, repo_id" in first_call_query
+    assert "SELECT repo_id" in first_call_query
+    assert "latest_complexity" in first_call_query
+    assert "ORDER BY day, repo_id\nLIMIT" not in first_call_query
+    assert first_call_params["limit"] == 10
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/graphql/test_complexity_resolver.py
+++ b/tests/api/graphql/test_complexity_resolver.py
@@ -27,6 +27,7 @@ from dev_health_ops.api.graphql.context import GraphQLContext
 from dev_health_ops.api.graphql.resolvers.complexity import (
     MAX_HOTSPOTS_ROWS,
     MAX_ROWS,
+    MAX_TIMESERIES_POINTS,
     resolve_complexity_timeseries,
     resolve_hotspots,
 )
@@ -372,11 +373,13 @@ async def test_timeseries_week_granularity_truncates_to_monday() -> None:
         "high_complexity_functions",
         "very_high_complexity_functions",
     ]
-    # 2026-05-20 is a Wednesday; expect truncation to Monday 2026-05-18.
     _setup_client(
         ctx.client,
         [
-            _qresult(columns, [[DAY, "repo-1", 1000, 80, 80.0, 5, 0]]),
+            _qresult(
+                columns,
+                [[date(2026, 5, 18), "repo-1", 1000, 80, 80.0, 5, 0]],
+            ),
             _qresult([], []),
         ],
     )
@@ -388,17 +391,62 @@ async def test_timeseries_week_granularity_truncates_to_monday() -> None:
     assert result.points[0].point_date == date(2026, 5, 18)
 
 
+@pytest.mark.asyncio
+async def test_timeseries_week_granularity_buckets_in_clickhouse() -> None:
+    ctx = _ctx()
+    _setup_client(ctx.client, [_qresult([], []), _qresult([], [])])
+
+    await resolve_complexity_timeseries(
+        ctx, _timeseries_input(granularity=TimeGranularity.WEEK)
+    )
+
+    first_call_query: str = ctx.client.query.call_args_list[0].args[0]
+    assert "toStartOfWeek(day, 1) AS day" in first_call_query
+    assert (
+        "argMax(cyclomatic_total,               (day, computed_at))" in first_call_query
+    )
+    assert "GROUP BY day, repo_id" in first_call_query
+
+
+@pytest.mark.asyncio
+async def test_timeseries_week_granularity_returns_one_point_per_repo_week() -> None:
+    ctx = _ctx()
+    columns = [
+        "day",
+        "repo_id",
+        "loc_total",
+        "cyclomatic_total",
+        "cyclomatic_per_kloc",
+        "high_complexity_functions",
+        "very_high_complexity_functions",
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(columns, [[date(2026, 5, 18), "repo-1", 1000, 80, 80.0, 5, 0]]),
+            _qresult([], []),
+        ],
+    )
+
+    result = await resolve_complexity_timeseries(
+        ctx, _timeseries_input(granularity=TimeGranularity.WEEK)
+    )
+
+    assert [(p.scope_id, p.point_date) for p in result.points] == [
+        ("repo-1", date(2026, 5, 18))
+    ]
+
+
 # ---------------------------------------------------------------------------
 # complexityTimeseries — row limit clamping
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_timeseries_limit_is_clamped_to_max_rows() -> None:
+async def test_timeseries_limit_is_clamped_by_scope_bucket_point_cap() -> None:
     ctx = _ctx()
     _setup_client(ctx.client, [_qresult([], []), _qresult([], [])])
 
-    # A limit far above MAX_ROWS should be clamped silently.
     result = await resolve_complexity_timeseries(
         ctx, _timeseries_input(limit=MAX_ROWS + 99999)
     )
@@ -407,9 +455,23 @@ async def test_timeseries_limit_is_clamped_to_max_rows() -> None:
     first_call_params: dict[str, Any] = ctx.client.query.call_args_list[0].kwargs[
         "parameters"
     ]
+    expected_scope_limit = MAX_TIMESERIES_POINTS // 20
     assert "LIMIT {limit:UInt32}" in first_call_query
-    assert first_call_params["limit"] == MAX_ROWS
+    assert first_call_params["limit"] == expected_scope_limit
     assert result.points == []
+
+
+@pytest.mark.asyncio
+async def test_timeseries_point_bound_limits_multi_day_multi_repo_window() -> None:
+    ctx = _ctx()
+    _setup_client(ctx.client, [_qresult([], []), _qresult([], [])])
+
+    await resolve_complexity_timeseries(ctx, _timeseries_input(limit=MAX_ROWS))
+
+    first_call_params: dict[str, Any] = ctx.client.query.call_args_list[0].kwargs[
+        "parameters"
+    ]
+    assert first_call_params["limit"] * 20 <= MAX_TIMESERIES_POINTS
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fixes complexity timeseries limiting so `limit` selects top repo scopes, not the earliest rows in the requested window.
- Converts resolver datetime bounds to UTC dates before querying ClickHouse.
- Adds regression coverage that the repo timeseries query returns all days for selected scopes instead of truncating the active window.

## ClickHouse coverage evidence
Leader-confirmed org `900f96be-804c-42fb-9e93-de73c499a22d` has `repo_complexity_daily` coverage from 2026-03-05 through 2026-06-07, with recent daily rows through yesterday. I also confirmed the required query returns recent rows for 2026-06-07 through 2026-05-29.

## Tests
- `uv run --extra dev pytest tests/api/graphql/test_complexity_resolver.py` (21 passed)
- `uv run pytest tests/api/graphql/test_complexity_resolver.py` failed in the fresh uv env because the default install omitted optional `pytest-asyncio`; reran with the repo dev extra.

SCREENSHOT-WAIVER: backend resolver fix only; live UI verification/screenshots are explicitly owned by the leader for CHAOS-2160.

Closes CHAOS-2160