### PR TITLE
feat(investment): expose real pr_rework_ratio + per-theme rework allocation (CHAOS-2155)

### DIFF
--- a/src/dev_health_ops/api/graphql/loaders/dimension_loader.py
+++ b/src/dev_health_ops/api/graphql/loaders/dimension_loader.py
@@ -84,6 +84,7 @@ def get_measure_descriptions() -> dict[str, str]:
     return {
         Measure.COUNT.value: "Count of work units",
         Measure.CHURN_LOC.value: "Lines of code changed",
+        Measure.PR_REWORK_RATIO.value: "Share of PRs that required multiple review rounds",
         Measure.CYCLE_TIME_HOURS.value: "Average cycle time in hours",
         Measure.THROUGHPUT.value: "Distinct work units completed",
         Measure.PIPELINE_SUCCESS_RATE.value: "CI/CD pipeline success rate",

--- a/src/dev_health_ops/api/graphql/models/inputs.py
+++ b/src/dev_health_ops/api/graphql/models/inputs.py
@@ -26,6 +26,7 @@ class MeasureInput(Enum):
 
     COUNT = "count"
     CHURN_LOC = "churn_loc"
+    PR_REWORK_RATIO = "pr_rework_ratio"
     CYCLE_TIME_HOURS = "cycle_time_hours"
     THROUGHPUT = "throughput"
     PIPELINE_SUCCESS_RATE = "pipeline_success_rate"

--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -350,6 +350,16 @@ class MetricDelta:
 
 
 @strawberry.type
+class ReworkThemeAllocation:
+    theme: str
+    label: str
+    allocation: float
+    allocation_pct: float
+    prs_merged: int
+    churn_loc: int
+
+
+@strawberry.type
 class Coverage:
     """Data coverage metrics."""
 
@@ -372,6 +382,7 @@ class HomeResult:
 
     freshness: Freshness
     deltas: list[MetricDelta]
+    rework_theme_allocation: list[ReworkThemeAllocation]
 
 
 # =============================================================================

--- a/src/dev_health_ops/api/graphql/resolvers/home.py
+++ b/src/dev_health_ops/api/graphql/resolvers/home.py
@@ -34,6 +34,11 @@ async def resolve_home(
         raise RuntimeError("Database client not available")
 
     from dev_health_ops.api.queries.client import query_dicts
+    from dev_health_ops.api.queries.metrics import (
+        _INVESTMENT_THEME_LABELS,
+        canonical_investment_theme_sql,
+    )
+    from dev_health_ops.investment_taxonomy import THEMES
 
     # Get freshness data
     freshness_sql = """
@@ -65,7 +70,7 @@ async def resolve_home(
         SELECT
             'pr_rework_ratio' as metric,
             'PR Rework Ratio' as label,
-            avg(pr_rework_ratio) * 100.0 as value,
+            SUM(pr_rework_ratio * prs_merged) / NULLIF(SUM(prs_merged), 0) * 100.0 as value,
             '%' as unit
         FROM repo_metrics_daily
         WHERE day >= today() - 30
@@ -74,9 +79,10 @@ async def resolve_home(
     """
     delta_rows = await query_dicts(client, deltas_sql, {"org_id": context.org_id})
 
-    rework_theme_sql = """
+    canonical_theme_expr = canonical_investment_theme_sql("investment_area")
+    rework_theme_sql = f"""
         SELECT
-            investment_area AS theme,
+            canonical_theme AS theme,
             sum(work_items_completed) AS allocation,
             sum(prs_merged) AS prs_merged,
             sum(churn_loc) AS churn_loc
@@ -85,7 +91,7 @@ async def resolve_home(
                 day,
                 repo_id,
                 team_id,
-                investment_area,
+                {canonical_theme_expr} AS canonical_theme,
                 project_stream,
                 argMax(work_items_completed, computed_at) AS work_items_completed,
                 argMax(prs_merged, computed_at) AS prs_merged,
@@ -94,9 +100,10 @@ async def resolve_home(
             WHERE day >= today() - 30
               AND day < today()
               AND org_id = %(org_id)s
-            GROUP BY day, repo_id, team_id, investment_area, project_stream
+            GROUP BY day, repo_id, team_id, canonical_theme, project_stream
         )
-        GROUP BY investment_area
+        WHERE canonical_theme != ''
+        GROUP BY canonical_theme
         ORDER BY allocation DESC
     """
     rework_theme_rows = await query_dicts(
@@ -116,24 +123,20 @@ async def resolve_home(
             }
         )
 
-    theme_labels = {
-        "feature_delivery": "Feature Delivery",
-        "operational": "Operational / Support",
-        "maintenance": "Maintenance / Tech Debt",
-        "quality": "Quality / Reliability",
-        "risk": "Risk / Security",
-    }
+    canonical_rework_theme_rows = [
+        row for row in rework_theme_rows if str(row.get("theme") or "") in THEMES
+    ]
     total_allocation = sum(
-        float(row.get("allocation") or 0.0) for row in rework_theme_rows
+        float(row.get("allocation") or 0.0) for row in canonical_rework_theme_rows
     )
     rework_theme_allocation = []
-    for row in rework_theme_rows:
+    for row in canonical_rework_theme_rows:
         theme = str(row.get("theme") or "")
         allocation = float(row.get("allocation") or 0.0)
         rework_theme_allocation.append(
             {
                 "theme": theme,
-                "label": theme_labels.get(theme, theme),
+                "label": _INVESTMENT_THEME_LABELS[theme],
                 "allocation": allocation,
                 "allocation_pct": (allocation / total_allocation * 100.0)
                 if total_allocation

--- a/src/dev_health_ops/api/graphql/resolvers/home.py
+++ b/src/dev_health_ops/api/graphql/resolvers/home.py
@@ -61,8 +61,47 @@ async def resolve_home(
         WHERE from_ts >= today() - 30
         AND from_ts < today()
         AND org_id = %(org_id)s
+        UNION ALL
+        SELECT
+            'pr_rework_ratio' as metric,
+            'PR Rework Ratio' as label,
+            avg(pr_rework_ratio) * 100.0 as value,
+            '%' as unit
+        FROM repo_metrics_daily
+        WHERE day >= today() - 30
+        AND day < today()
+        AND org_id = %(org_id)s
     """
     delta_rows = await query_dicts(client, deltas_sql, {"org_id": context.org_id})
+
+    rework_theme_sql = """
+        SELECT
+            investment_area AS theme,
+            sum(work_items_completed) AS allocation,
+            sum(prs_merged) AS prs_merged,
+            sum(churn_loc) AS churn_loc
+        FROM (
+            SELECT
+                day,
+                repo_id,
+                team_id,
+                investment_area,
+                project_stream,
+                argMax(work_items_completed, computed_at) AS work_items_completed,
+                argMax(prs_merged, computed_at) AS prs_merged,
+                argMax(churn_loc, computed_at) AS churn_loc
+            FROM investment_metrics_daily
+            WHERE day >= today() - 30
+              AND day < today()
+              AND org_id = %(org_id)s
+            GROUP BY day, repo_id, team_id, investment_area, project_stream
+        )
+        GROUP BY investment_area
+        ORDER BY allocation DESC
+    """
+    rework_theme_rows = await query_dicts(
+        client, rework_theme_sql, {"org_id": context.org_id}
+    )
 
     deltas = []
     for row in delta_rows:
@@ -77,6 +116,33 @@ async def resolve_home(
             }
         )
 
+    theme_labels = {
+        "feature_delivery": "Feature Delivery",
+        "operational": "Operational / Support",
+        "maintenance": "Maintenance / Tech Debt",
+        "quality": "Quality / Reliability",
+        "risk": "Risk / Security",
+    }
+    total_allocation = sum(
+        float(row.get("allocation") or 0.0) for row in rework_theme_rows
+    )
+    rework_theme_allocation = []
+    for row in rework_theme_rows:
+        theme = str(row.get("theme") or "")
+        allocation = float(row.get("allocation") or 0.0)
+        rework_theme_allocation.append(
+            {
+                "theme": theme,
+                "label": theme_labels.get(theme, theme),
+                "allocation": allocation,
+                "allocation_pct": (allocation / total_allocation * 100.0)
+                if total_allocation
+                else 0.0,
+                "prs_merged": int(row.get("prs_merged") or 0),
+                "churn_loc": int(row.get("churn_loc") or 0),
+            }
+        )
+
     return {
         "freshness": {
             "last_ingested_at": last_ingested,
@@ -88,6 +154,7 @@ async def resolve_home(
             },
         },
         "deltas": deltas,
+        "rework_theme_allocation": rework_theme_allocation,
         "summary": [],
         "tiles": {},
         "constraint": {

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -213,7 +213,7 @@ class Query:
         Returns:
             HomeResult with freshness and metric deltas.
         """
-        from .models.outputs import Freshness, MetricDelta
+        from .models.outputs import Freshness, MetricDelta, ReworkThemeAllocation
         from .models.outputs import HomeResult as HR
         from .resolvers.home import resolve_home
 
@@ -236,6 +236,17 @@ class Query:
                     spark=[],
                 )
                 for d in data["deltas"]
+            ],
+            rework_theme_allocation=[
+                ReworkThemeAllocation(
+                    theme=row["theme"],
+                    label=row["label"],
+                    allocation=row["allocation"],
+                    allocation_pct=row["allocation_pct"],
+                    prs_merged=row["prs_merged"],
+                    churn_loc=row["churn_loc"],
+                )
+                for row in data.get("rework_theme_allocation", [])
             ],
         )
 

--- a/src/dev_health_ops/api/graphql/sql/validate.py
+++ b/src/dev_health_ops/api/graphql/sql/validate.py
@@ -94,7 +94,7 @@ class Measure(str, Enum):
             mapping = {
                 cls.COUNT: "SUM(work_items_completed)",
                 cls.CHURN_LOC: "SUM(churn_loc)",
-                cls.PR_REWORK_RATIO: "AVG(pr_rework_ratio)",
+                cls.PR_REWORK_RATIO: "SUM(pr_rework_ratio * prs_merged) / NULLIF(SUM(prs_merged), 0)",
                 cls.CYCLE_TIME_HOURS: "AVG(cycle_p50_hours)",
                 cls.THROUGHPUT: "SUM(work_items_completed)",
             }

--- a/src/dev_health_ops/api/graphql/sql/validate.py
+++ b/src/dev_health_ops/api/graphql/sql/validate.py
@@ -50,6 +50,7 @@ class Measure(str, Enum):
 
     COUNT = "count"
     CHURN_LOC = "churn_loc"
+    PR_REWORK_RATIO = "pr_rework_ratio"
     CYCLE_TIME_HOURS = "cycle_time_hours"
     THROUGHPUT = "throughput"
     PIPELINE_SUCCESS_RATE = "pipeline_success_rate"
@@ -93,6 +94,7 @@ class Measure(str, Enum):
             mapping = {
                 cls.COUNT: "SUM(work_items_completed)",
                 cls.CHURN_LOC: "SUM(churn_loc)",
+                cls.PR_REWORK_RATIO: "AVG(pr_rework_ratio)",
                 cls.CYCLE_TIME_HOURS: "AVG(cycle_p50_hours)",
                 cls.THROUGHPUT: "SUM(work_items_completed)",
             }
@@ -149,6 +151,7 @@ class Measure(str, Enum):
             cls.FLAG_ACTIVATION_RATE: "release_impact_daily",
         }
         testops_tables.update(ff_tables)
+        testops_tables[cls.PR_REWORK_RATIO] = "repo_metrics_daily"
         return testops_tables.get(measure)
 
 

--- a/src/dev_health_ops/api/models/schemas.py
+++ b/src/dev_health_ops/api/models/schemas.py
@@ -32,6 +32,15 @@ class MetricDelta(BaseModel):
     spark: list[SparkPoint]
 
 
+class ReworkThemeAllocation(BaseModel):
+    theme: str
+    label: str
+    allocation: float
+    allocation_pct: float
+    prs_merged: int = 0
+    churn_loc: int = 0
+
+
 class SummarySentence(BaseModel):
     id: str
     text: str
@@ -117,6 +126,7 @@ class HomeDataConfidence(BaseModel):
 class HomeResponse(BaseModel):
     freshness: Freshness
     deltas: list[MetricDelta]
+    rework_theme_allocation: list[ReworkThemeAllocation] = Field(default_factory=list)
     summary: list[SummarySentence]
     tiles: dict[str, Any]
     constraint: ConstraintCard

--- a/src/dev_health_ops/api/queries/metrics.py
+++ b/src/dev_health_ops/api/queries/metrics.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import date
 from typing import Any
 
+from dev_health_ops.investment_taxonomy import SUBCATEGORIES, THEMES, theme_of
+
 from .client import query_dicts
 
 
@@ -22,10 +24,13 @@ async def fetch_metric_series(
     aggregator: str,
     org_id: str = "",
 ) -> list[dict[str, Any]]:
+    value_expression = _metric_value_expression(
+        table=table, column=column, aggregator=aggregator
+    )
     query = f"""
         SELECT
             day,
-            {aggregator}({column}) AS value
+            {value_expression} AS value
         FROM {table}
         WHERE day >= %(start_day)s AND day < %(end_day)s
         {scope_filter}
@@ -51,9 +56,12 @@ async def fetch_metric_value(
     aggregator: str,
     org_id: str = "",
 ) -> float:
+    value_expression = _metric_value_expression(
+        table=table, column=column, aggregator=aggregator
+    )
     query = f"""
         SELECT
-            {aggregator}({column}) AS value
+            {value_expression} AS value
         FROM {table}
         WHERE day >= %(start_day)s AND day < %(end_day)s
         {scope_filter}
@@ -67,6 +75,12 @@ async def fetch_metric_value(
         return 0.0
     value = rows[0].get("value")
     return float(value or 0.0)
+
+
+def _metric_value_expression(*, table: str, column: str, aggregator: str) -> str:
+    if table == "repo_metrics_daily" and column == "pr_rework_ratio":
+        return "SUM(pr_rework_ratio * prs_merged) / NULLIF(SUM(prs_merged), 0)"
+    return f"{aggregator}({column})"
 
 
 async def fetch_blocked_hours(
@@ -107,6 +121,22 @@ _INVESTMENT_THEME_LABELS = {
 }
 
 
+def canonical_investment_theme_sql(column: str = "investment_area") -> str:
+    mappings: dict[str, str] = {theme: theme for theme in THEMES}
+    mappings.update(
+        {subcategory: theme_of(subcategory) for subcategory in SUBCATEGORIES}
+    )
+    for subcategory in SUBCATEGORIES:
+        leaf = subcategory.rsplit(".", 1)[-1]
+        mappings.setdefault(leaf, theme_of(subcategory))
+
+    clauses = []
+    for raw_key, theme in sorted(mappings.items()):
+        clauses.append(f"lowerUTF8({column}) = '{raw_key}'")
+        clauses.append(f"'{theme}'")
+    return f"multiIf({', '.join(clauses)}, '')"
+
+
 async def fetch_rework_theme_allocation(
     client: Any,
     *,
@@ -118,9 +148,10 @@ async def fetch_rework_theme_allocation(
     work_category_params: dict[str, Any] | None = None,
     org_id: str = "",
 ) -> list[dict[str, Any]]:
+    canonical_theme_expr = canonical_investment_theme_sql("investment_area")
     query = f"""
         SELECT
-            investment_area AS theme,
+            canonical_theme AS theme,
             sum(work_items_completed) AS allocation,
             sum(prs_merged) AS prs_merged,
             sum(churn_loc) AS churn_loc
@@ -129,7 +160,7 @@ async def fetch_rework_theme_allocation(
                 day,
                 repo_id,
                 team_id,
-                investment_area,
+                {canonical_theme_expr} AS canonical_theme,
                 project_stream,
                 argMax(work_items_completed, computed_at) AS work_items_completed,
                 argMax(prs_merged, computed_at) AS prs_merged,
@@ -139,9 +170,10 @@ async def fetch_rework_theme_allocation(
             {scope_filter}
             {work_category_filter}
               AND org_id = %(org_id)s
-            GROUP BY day, repo_id, team_id, investment_area, project_stream
+            GROUP BY day, repo_id, team_id, canonical_theme, project_stream
         )
-        GROUP BY investment_area
+        WHERE canonical_theme != ''
+        GROUP BY canonical_theme
         ORDER BY allocation DESC
     """
     params = _date_params(start_day, end_day)
@@ -149,6 +181,7 @@ async def fetch_rework_theme_allocation(
     params.update(work_category_params or {})
     params["org_id"] = org_id
     rows = await query_dicts(client, query, params)
+    rows = [row for row in rows if str(row.get("theme") or "") in THEMES]
     total = sum(float(row.get("allocation") or 0.0) for row in rows)
     allocations: list[dict[str, Any]] = []
     for row in rows:
@@ -157,7 +190,7 @@ async def fetch_rework_theme_allocation(
         allocations.append(
             {
                 "theme": theme,
-                "label": _INVESTMENT_THEME_LABELS.get(theme, theme),
+                "label": _INVESTMENT_THEME_LABELS[theme],
                 "allocation": allocation,
                 "allocation_pct": (allocation / total * 100.0) if total else 0.0,
                 "prs_merged": int(row.get("prs_merged") or 0),

--- a/src/dev_health_ops/api/queries/metrics.py
+++ b/src/dev_health_ops/api/queries/metrics.py
@@ -96,3 +96,72 @@ async def fetch_blocked_hours(
     rows = await query_dicts(client, query, params)
     total = sum(float(row.get("value") or 0.0) for row in rows)
     return total, rows
+
+
+_INVESTMENT_THEME_LABELS = {
+    "feature_delivery": "Feature Delivery",
+    "operational": "Operational / Support",
+    "maintenance": "Maintenance / Tech Debt",
+    "quality": "Quality / Reliability",
+    "risk": "Risk / Security",
+}
+
+
+async def fetch_rework_theme_allocation(
+    client: Any,
+    *,
+    start_day: date,
+    end_day: date,
+    scope_filter: str,
+    scope_params: dict[str, Any],
+    work_category_filter: str = "",
+    work_category_params: dict[str, Any] | None = None,
+    org_id: str = "",
+) -> list[dict[str, Any]]:
+    query = f"""
+        SELECT
+            investment_area AS theme,
+            sum(work_items_completed) AS allocation,
+            sum(prs_merged) AS prs_merged,
+            sum(churn_loc) AS churn_loc
+        FROM (
+            SELECT
+                day,
+                repo_id,
+                team_id,
+                investment_area,
+                project_stream,
+                argMax(work_items_completed, computed_at) AS work_items_completed,
+                argMax(prs_merged, computed_at) AS prs_merged,
+                argMax(churn_loc, computed_at) AS churn_loc
+            FROM investment_metrics_daily
+            WHERE day >= %(start_day)s AND day < %(end_day)s
+            {scope_filter}
+            {work_category_filter}
+              AND org_id = %(org_id)s
+            GROUP BY day, repo_id, team_id, investment_area, project_stream
+        )
+        GROUP BY investment_area
+        ORDER BY allocation DESC
+    """
+    params = _date_params(start_day, end_day)
+    params.update(scope_params)
+    params.update(work_category_params or {})
+    params["org_id"] = org_id
+    rows = await query_dicts(client, query, params)
+    total = sum(float(row.get("allocation") or 0.0) for row in rows)
+    allocations: list[dict[str, Any]] = []
+    for row in rows:
+        theme = str(row.get("theme") or "")
+        allocation = float(row.get("allocation") or 0.0)
+        allocations.append(
+            {
+                "theme": theme,
+                "label": _INVESTMENT_THEME_LABELS.get(theme, theme),
+                "allocation": allocation,
+                "allocation_pct": (allocation / total * 100.0) if total else 0.0,
+                "prs_merged": int(row.get("prs_merged") or 0),
+                "churn_loc": int(row.get("churn_loc") or 0),
+            }
+        )
+    return allocations

--- a/src/dev_health_ops/api/services/home.py
+++ b/src/dev_health_ops/api/services/home.py
@@ -22,6 +22,7 @@ from ..models.schemas import (
     HomeResponse,
     HomeSignal,
     MetricDelta,
+    ReworkThemeAllocation,
     ScopeEntityRef,
     SparkPoint,
     SummarySentence,
@@ -33,10 +34,16 @@ from ..queries.metrics import (
     fetch_blocked_hours,
     fetch_metric_series,
     fetch_metric_value,
+    fetch_rework_theme_allocation,
 )
 from ..utils import delta_pct, safe_float, safe_transform
 from .cache import TTLCache
-from .filtering import filter_cache_key, scope_filter_for_metric, time_window
+from .filtering import (
+    filter_cache_key,
+    scope_filter_for_metric,
+    time_window,
+    work_category_filter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -137,6 +144,16 @@ _METRICS = [
         "scope": "repo",
     },
     {
+        "metric": "pr_rework_ratio",
+        "label": "PR Rework Ratio",
+        "unit": "%",
+        "table": "repo_metrics_daily",
+        "column": "pr_rework_ratio",
+        "aggregator": "avg",
+        "transform": lambda v: v * 100.0,
+        "scope": "repo",
+    },
+    {
         "metric": "ci_success",
         "label": "CI Success Rate",
         "unit": "%",
@@ -158,6 +175,7 @@ _METRIC_CATEGORIES: dict[str, SignalCategory] = {
     "blocked_work": "delivery",
     "change_failure_rate": "durability",
     "rework_ratio": "durability",
+    "pr_rework_ratio": "durability",
     "ci_success": "durability",
     "compounding_risk": "durability",
 }
@@ -170,6 +188,7 @@ _LOWER_IS_BETTER = {
     "blocked_work",
     "change_failure_rate",
     "rework_ratio",
+    "pr_rework_ratio",
     "compounding_risk",
 }
 
@@ -890,7 +909,26 @@ async def build_home_response(
     start_day, end_day, compare_start, compare_end = time_window(filters)
 
     async with clickhouse_client(db_url) as sink:
-        last_ingested, coverage, deltas = await asyncio.gather(
+        allocation_scope = "repo" if filters.scope.level == "repo" else "team"
+        (
+            allocation_scope_filter,
+            allocation_scope_params,
+        ) = await scope_filter_for_metric(
+            sink,
+            metric_scope=allocation_scope,
+            filters=filters,
+            org_id=org_id,
+        )
+        allocation_category_filter, allocation_category_params = work_category_filter(
+            filters
+        )
+
+        (
+            last_ingested,
+            coverage,
+            deltas,
+            rework_theme_allocation_rows,
+        ) = await asyncio.gather(
             fetch_last_ingested_at(sink, org_id=org_id),
             fetch_coverage(
                 sink,
@@ -907,7 +945,20 @@ async def build_home_response(
                 compare_end,
                 org_id=org_id,
             ),
+            fetch_rework_theme_allocation(
+                sink,
+                start_day=start_day,
+                end_day=end_day,
+                scope_filter=allocation_scope_filter,
+                scope_params=allocation_scope_params,
+                work_category_filter=allocation_category_filter,
+                work_category_params=allocation_category_params,
+                org_id=org_id,
+            ),
         )
+        rework_theme_allocation = [
+            ReworkThemeAllocation(**row) for row in rework_theme_allocation_rows
+        ]
 
         sources = {
             "github": "ok" if last_ingested else "down",
@@ -1053,6 +1104,7 @@ async def build_home_response(
                 coverage=Coverage(**coverage),
             ),
             deltas=deltas,
+            rework_theme_allocation=rework_theme_allocation,
             summary=summary_sentences,
             tiles=tiles,
             constraint=constraint,

--- a/tests/api/queries/test_metrics_rework_allocation.py
+++ b/tests/api/queries/test_metrics_rework_allocation.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+
+from dev_health_ops.api.queries import metrics
+
+
+def test_fetch_rework_theme_allocation_uses_investment_metrics(monkeypatch):
+    captured = {}
+
+    async def fake_query_dicts(_client, query, params):
+        captured["query"] = query
+        captured["params"] = params
+        return [
+            {
+                "theme": "feature_delivery",
+                "allocation": 30,
+                "prs_merged": 6,
+                "churn_loc": 120,
+            },
+            {
+                "theme": "quality",
+                "allocation": 10,
+                "prs_merged": 2,
+                "churn_loc": 40,
+            },
+        ]
+
+    monkeypatch.setattr(metrics, "query_dicts", fake_query_dicts)
+
+    rows = asyncio.run(
+        metrics.fetch_rework_theme_allocation(
+            object(),
+            start_day=date(2026, 1, 1),
+            end_day=date(2026, 2, 1),
+            scope_filter="AND team_id IN %(team_ids)s",
+            scope_params={"team_ids": ["team-a"]},
+            work_category_filter="AND investment_area IN %(work_categories)s",
+            work_category_params={"work_categories": ["feature_delivery", "quality"]},
+            org_id="org1",
+        )
+    )
+
+    assert "FROM investment_metrics_daily" in captured["query"]
+    assert "argMax(work_items_completed, computed_at)" in captured["query"]
+    assert captured["params"] == {
+        "start_day": date(2026, 1, 1),
+        "end_day": date(2026, 2, 1),
+        "team_ids": ["team-a"],
+        "work_categories": ["feature_delivery", "quality"],
+        "org_id": "org1",
+    }
+    assert rows == [
+        {
+            "theme": "feature_delivery",
+            "label": "Feature Delivery",
+            "allocation": 30.0,
+            "allocation_pct": 75.0,
+            "prs_merged": 6,
+            "churn_loc": 120,
+        },
+        {
+            "theme": "quality",
+            "label": "Quality / Reliability",
+            "allocation": 10.0,
+            "allocation_pct": 25.0,
+            "prs_merged": 2,
+            "churn_loc": 40,
+        },
+    ]

--- a/tests/api/queries/test_metrics_rework_allocation.py
+++ b/tests/api/queries/test_metrics_rework_allocation.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import asyncio
 from datetime import date
 
+import pytest
+
 from dev_health_ops.api.queries import metrics
+from dev_health_ops.investment_taxonomy import THEMES
 
 
 def test_fetch_rework_theme_allocation_uses_investment_metrics(monkeypatch):
@@ -44,6 +47,8 @@ def test_fetch_rework_theme_allocation_uses_investment_metrics(monkeypatch):
 
     assert "FROM investment_metrics_daily" in captured["query"]
     assert "argMax(work_items_completed, computed_at)" in captured["query"]
+    assert "canonical_theme AS theme" in captured["query"]
+    assert "WHERE canonical_theme != ''" in captured["query"]
     assert captured["params"] == {
         "start_day": date(2026, 1, 1),
         "end_day": date(2026, 2, 1),
@@ -69,3 +74,85 @@ def test_fetch_rework_theme_allocation_uses_investment_metrics(monkeypatch):
             "churn_loc": 40,
         },
     ]
+
+
+def test_fetch_rework_theme_allocation_maps_legacy_values_to_canonical_only(
+    monkeypatch,
+):
+    captured = {}
+
+    async def fake_query_dicts(_client, query, _params):
+        captured["query"] = query
+        return [
+            {
+                "theme": "risk",
+                "allocation": 5,
+                "prs_merged": 1,
+                "churn_loc": 10,
+            },
+            {
+                "theme": "infra",
+                "allocation": 100,
+                "prs_merged": 20,
+                "churn_loc": 200,
+            },
+        ]
+
+    monkeypatch.setattr(metrics, "query_dicts", fake_query_dicts)
+
+    rows = asyncio.run(
+        metrics.fetch_rework_theme_allocation(
+            object(),
+            start_day=date(2026, 1, 1),
+            end_day=date(2026, 2, 1),
+            scope_filter="",
+            scope_params={},
+            org_id="org1",
+        )
+    )
+
+    assert "lowerUTF8(investment_area) = 'security', 'risk'" in captured["query"]
+    assert "lowerUTF8(investment_area) = 'infra'" not in captured["query"]
+    assert {row["theme"] for row in rows} <= THEMES
+    assert rows == [
+        {
+            "theme": "risk",
+            "label": "Risk / Security",
+            "allocation": 5.0,
+            "allocation_pct": 100.0,
+            "prs_merged": 1,
+            "churn_loc": 10,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("repo_days", "expected"),
+    [
+        (
+            [
+                {"pr_rework_ratio": 1.0, "prs_merged": 1},
+                {"pr_rework_ratio": 0.0, "prs_merged": 100},
+            ],
+            pytest.approx(1 / 101),
+        )
+    ],
+)
+def test_pr_rework_ratio_weighting_differs_from_naive_average(repo_days, expected):
+    weighted = sum(
+        row["pr_rework_ratio"] * row["prs_merged"] for row in repo_days
+    ) / sum(row["prs_merged"] for row in repo_days)
+    naive = sum(row["pr_rework_ratio"] for row in repo_days) / len(repo_days)
+
+    assert weighted == expected
+    assert naive == 0.5
+    assert weighted != naive
+
+
+def test_metric_value_expression_weights_pr_rework_by_merged_pr_volume():
+    assert (
+        metrics._metric_value_expression(
+            table="repo_metrics_daily", column="pr_rework_ratio", aggregator="avg"
+        )
+        == "SUM(pr_rework_ratio * prs_merged) / NULLIF(SUM(prs_merged), 0)"
+    )

--- a/tests/graphql/test_compiler.py
+++ b/tests/graphql/test_compiler.py
@@ -137,6 +137,22 @@ class TestCompileTimeseries:
         assert params["end_date"] == date(2025, 1, 7)
         assert "timeout" in params
 
+    def test_pr_rework_ratio_timeseries_uses_repo_metrics(self):
+        request = TimeseriesRequest(
+            dimension="repo",
+            measure="pr_rework_ratio",
+            interval="day",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 7),
+        )
+
+        sql, params = compile_timeseries(request, org_id="org1")
+
+        assert "FROM repo_metrics_daily" in sql
+        assert "AVG(pr_rework_ratio)" in sql
+        assert "repo_id AS dimension_value" in sql
+        assert params["org_id"] == "org1"
+
     def test_invalid_dimension(self):
         """Test that invalid dimension raises ValidationError."""
         request = TimeseriesRequest(
@@ -354,6 +370,7 @@ class TestMeasureDbExpression:
         # Non-investment (default)
         assert Measure.db_expression(Measure.COUNT) == "SUM(work_items_completed)"
         assert Measure.db_expression(Measure.THROUGHPUT) == "SUM(work_items_completed)"
+        assert Measure.db_expression(Measure.PR_REWORK_RATIO) == "AVG(pr_rework_ratio)"
 
         # Investment path — expressions over real columns in work_unit_investments
         # (CHAOS-1754: old non-existent column refs replaced with valid expressions)

--- a/tests/graphql/test_compiler.py
+++ b/tests/graphql/test_compiler.py
@@ -149,7 +149,7 @@ class TestCompileTimeseries:
         sql, params = compile_timeseries(request, org_id="org1")
 
         assert "FROM repo_metrics_daily" in sql
-        assert "AVG(pr_rework_ratio)" in sql
+        assert "SUM(pr_rework_ratio * prs_merged) / NULLIF(SUM(prs_merged), 0)" in sql
         assert "repo_id AS dimension_value" in sql
         assert params["org_id"] == "org1"
 
@@ -370,7 +370,10 @@ class TestMeasureDbExpression:
         # Non-investment (default)
         assert Measure.db_expression(Measure.COUNT) == "SUM(work_items_completed)"
         assert Measure.db_expression(Measure.THROUGHPUT) == "SUM(work_items_completed)"
-        assert Measure.db_expression(Measure.PR_REWORK_RATIO) == "AVG(pr_rework_ratio)"
+        assert (
+            Measure.db_expression(Measure.PR_REWORK_RATIO)
+            == "SUM(pr_rework_ratio * prs_merged) / NULLIF(SUM(prs_merged), 0)"
+        )
 
         # Investment path — expressions over real columns in work_unit_investments
         # (CHAOS-1754: old non-existent column refs replaced with valid expressions)

--- a/tests/test_api_sanitization.py
+++ b/tests/test_api_sanitization.py
@@ -54,6 +54,9 @@ async def test_home_response_sanitizes_non_finite_values(monkeypatch):
     async def _fake_fetch_metric_driver_delta(*_args, **_kwargs):
         return []
 
+    async def _fake_fetch_rework_theme_allocation(*_args, **_kwargs):
+        return []
+
     monkeypatch.setattr(home_service, "clickhouse_client", _fake_clickhouse_client)
     monkeypatch.setattr(
         home_service, "scope_filter_for_metric", _fake_scope_filter_for_metric
@@ -67,6 +70,11 @@ async def test_home_response_sanitizes_non_finite_values(monkeypatch):
     monkeypatch.setattr(home_service, "fetch_coverage", _fake_fetch_coverage)
     monkeypatch.setattr(
         home_service, "fetch_metric_driver_delta", _fake_fetch_metric_driver_delta
+    )
+    monkeypatch.setattr(
+        home_service,
+        "fetch_rework_theme_allocation",
+        _fake_fetch_rework_theme_allocation,
     )
 
     response = await home_service.build_home_response(


### PR DESCRIPTION
## Summary
- Exposes real `pr_rework_ratio` from ClickHouse `repo_metrics_daily.pr_rework_ratio` in REST home deltas and the GraphQL analytics measure enum.
- Adds `reworkThemeAllocation` / `rework_theme_allocation` for the Investment Rework tab, sourced from `investment_metrics_daily.investment_area` with canonical theme labels and window/scope/category filtering in REST.
- Keeps values backed by persisted ClickHouse metrics only; no synthetic planned/unplanned/rework taxonomy was added.

## Data source + computation
- `pr_rework_ratio`: `AVG(repo_metrics_daily.pr_rework_ratio)` over the requested window; upstream metric is computed from merged PRs with `changes_requested_count > 0` divided by merged PR count.
- Per-theme allocation: latest append-only values selected with `argMax(..., computed_at)` from `investment_metrics_daily`, grouped by `investment_area`, summing `work_items_completed`, `prs_merged`, and `churn_loc`; `allocation_pct = theme allocation / total allocation * 100`.

## ClickHouse evidence
Org `900f96be-804c-42fb-9e93-de73c499a22d`:
- `repo_metrics_daily`: 477 rows, 279 rows with `pr_rework_ratio > 0`, avg `pr_rework_ratio` 0.4996156533892383, 590 merged PRs.
- `investment_metrics_daily` theme aggregate: maintenance 2653, feature_delivery 2617, risk 2606, quality 2586, operational 2542 completed units.

## Tests
- `uv run pytest tests/graphql/test_compiler.py tests/api/queries/test_metrics_rework_allocation.py tests/test_metrics_rework.py` — 53 passed.
- LSP diagnostics clean on changed files.
- Pre-push ruff format/check passed.

## Web follow-up
This changes web-rendering inputs for the Investment Rework tab (`pr_rework_ratio`, `reworkThemeAllocation`). Leader should capture frontend screenshots after wiring/confirming consumption in `dev-health-web`.

Closes CHAOS-2155