### PR TITLE
fix(investment): scope team attribution joins

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -449,15 +449,19 @@ async def resolve_analytics(
                                 SELECT
                                     work_unit_investments.work_unit_id AS work_unit_id,
                                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
-                                    count() AS cnt
+                                    countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
                                 FROM work_unit_investments
-                                ARRAY JOIN JSONExtract(structural_evidence_json, 'issues', 'Array(String)') AS issue_id
+                                ARRAY JOIN arrayDistinct(arrayConcat(
+                                    JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
+                                    [work_unit_investments.work_unit_id]
+                                )) AS issue_id
                                 LEFT JOIN (
                                     SELECT
                                         work_item_id,
                                         argMax(team_id, computed_at) AS team_id,
                                         argMax(team_name, computed_at) AS team_name
                                     FROM work_item_cycle_times
+                                    WHERE org_id = %(org_id)s
                                     GROUP BY work_item_id
                                 ) AS t ON t.work_item_id = issue_id
                                 GROUP BY work_unit_id, team

--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -136,15 +136,19 @@ def _get_context_params(
                         work_unit_investments.work_unit_id AS work_unit_id,
                         t.team_id AS team_id,
                         ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team_label,
-                        count() AS cnt
+                        countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
                     FROM work_unit_investments
-                    ARRAY JOIN JSONExtract(structural_evidence_json, 'issues', 'Array(String)') AS issue_id
+                    ARRAY JOIN arrayDistinct(arrayConcat(
+                        JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
+                        [work_unit_investments.work_unit_id]
+                    )) AS issue_id
                     LEFT JOIN (
                         SELECT
                             work_item_id,
                             argMax(team_id, computed_at) AS team_id,
                             argMax(team_name, computed_at) AS team_name
                         FROM work_item_cycle_times
+                        WHERE org_id = %(org_id)s
                         GROUP BY work_item_id
                     ) AS t ON t.work_item_id = issue_id
                     GROUP BY work_unit_id, team_id, team_label

--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -148,18 +148,43 @@ async def fetch_investment_team_edges(
         params["subcategories"] = subcategories
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
     query = f"""
+        WITH unit_team AS (
+            SELECT
+                work_unit_id,
+                argMax(team, cnt) AS team
+            FROM (
+                SELECT
+                    work_unit_investments.work_unit_id AS work_unit_id,
+                    ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
+                    countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
+                FROM work_unit_investments
+                ARRAY JOIN arrayDistinct(arrayConcat(
+                    JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
+                    [work_unit_investments.work_unit_id]
+                )) AS issue_id
+                LEFT JOIN (
+                    SELECT
+                        work_item_id,
+                        argMax(team_id, computed_at) AS team_id,
+                        argMax(team_name, computed_at) AS team_name
+                    FROM work_item_cycle_times
+                    WHERE org_id = %(org_id)s
+                    GROUP BY work_item_id
+                ) AS t ON t.work_item_id = issue_id
+                WHERE work_unit_investments.from_ts < %(end_ts)s
+                  AND work_unit_investments.to_ts >= %(start_ts)s
+                  AND work_unit_investments.org_id = %(org_id)s
+                {scope_filter}
+                GROUP BY work_unit_id, team
+            )
+            GROUP BY work_unit_id
+        )
         SELECT
             subcategory_kv.1 AS source,
-            ifNull(team_name, 'unassigned') AS target,
+            ifNull(nullIf(unit_team.team, ''), 'unassigned') AS target,
             sum(subcategory_kv.2 * effort_value) AS value
         FROM work_unit_investments
-        LEFT JOIN (
-            SELECT
-                work_item_id,
-                argMax(team_name, computed_at) AS team_name
-            FROM work_item_cycle_times
-            GROUP BY work_item_id
-        ) AS t ON t.work_item_id = arrayElement(JSONExtract(structural_evidence_json, 'issues', 'Array(String)'), 1)
+        LEFT JOIN unit_team ON unit_team.work_unit_id = work_unit_investments.work_unit_id
         ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
         WHERE work_unit_investments.from_ts < %(end_ts)s
           AND work_unit_investments.to_ts >= %(start_ts)s
@@ -203,15 +228,19 @@ async def fetch_investment_repo_team_edges(
                 SELECT
                     work_unit_investments.work_unit_id AS work_unit_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
-                    count() AS cnt
+                    countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
                 FROM work_unit_investments
-                ARRAY JOIN JSONExtract(structural_evidence_json, 'issues', 'Array(String)') AS issue_id
+                ARRAY JOIN arrayDistinct(arrayConcat(
+                    JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
+                    [work_unit_investments.work_unit_id]
+                )) AS issue_id
                 LEFT JOIN (
                     SELECT
                         work_item_id,
                         argMax(team_id, computed_at) AS team_id,
                         argMax(team_name, computed_at) AS team_name
                     FROM work_item_cycle_times
+                    WHERE org_id = %(org_id)s
                     GROUP BY work_item_id
                 ) AS t ON t.work_item_id = issue_id
                 WHERE work_unit_investments.from_ts < %(end_ts)s
@@ -273,15 +302,19 @@ async def fetch_investment_team_category_repo_edges(
                 SELECT
                     work_unit_investments.work_unit_id AS work_unit_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
-                    count() AS cnt
+                    countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
                 FROM work_unit_investments
-                ARRAY JOIN JSONExtract(structural_evidence_json, 'issues', 'Array(String)') AS issue_id
+                ARRAY JOIN arrayDistinct(arrayConcat(
+                    JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
+                    [work_unit_investments.work_unit_id]
+                )) AS issue_id
                 LEFT JOIN (
                     SELECT
                         work_item_id,
                         argMax(team_id, computed_at) AS team_id,
                         argMax(team_name, computed_at) AS team_name
                     FROM work_item_cycle_times
+                    WHERE org_id = %(org_id)s
                     GROUP BY work_item_id
                 ) AS t ON t.work_item_id = issue_id
                 WHERE work_unit_investments.from_ts < %(end_ts)s
@@ -343,15 +376,19 @@ async def fetch_investment_team_subcategory_repo_edges(
                 SELECT
                     work_unit_investments.work_unit_id AS work_unit_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
-                    count() AS cnt
+                    countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
                 FROM work_unit_investments
-                ARRAY JOIN JSONExtract(structural_evidence_json, 'issues', 'Array(String)') AS issue_id
+                ARRAY JOIN arrayDistinct(arrayConcat(
+                    JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
+                    [work_unit_investments.work_unit_id]
+                )) AS issue_id
                 LEFT JOIN (
                     SELECT
                         work_item_id,
                         argMax(team_id, computed_at) AS team_id,
                         argMax(team_name, computed_at) AS team_name
                     FROM work_item_cycle_times
+                    WHERE org_id = %(org_id)s
                     GROUP BY work_item_id
                 ) AS t ON t.work_item_id = issue_id
                 WHERE work_unit_investments.from_ts < %(end_ts)s
@@ -417,15 +454,19 @@ async def fetch_investment_unassigned_counts(
                 SELECT
                     work_unit_investments.work_unit_id AS work_unit_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
-                    count() AS cnt
+                    countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
                 FROM work_unit_investments
-                ARRAY JOIN JSONExtract(structural_evidence_json, 'issues', 'Array(String)') AS issue_id
+                ARRAY JOIN arrayDistinct(arrayConcat(
+                    JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
+                    [work_unit_investments.work_unit_id]
+                )) AS issue_id
                 LEFT JOIN (
                     SELECT
                         work_item_id,
                         argMax(team_id, computed_at) AS team_id,
                         argMax(team_name, computed_at) AS team_name
                     FROM work_item_cycle_times
+                    WHERE org_id = %(org_id)s
                     GROUP BY work_item_id
                 ) AS t ON t.work_item_id = issue_id
                 WHERE work_unit_investments.from_ts < %(end_ts)s

--- a/tests/api/graphql/test_graphql_investment_team_attribution_sql.py
+++ b/tests/api/graphql/test_graphql_investment_team_attribution_sql.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pytest
+
+import dev_health_ops.api.graphql.resolvers.analytics as analytics_resolver
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.models.inputs import (
+    AnalyticsRequestInput,
+    DateRangeInput,
+    DimensionInput,
+    MeasureInput,
+    SankeyRequestInput,
+)
+from dev_health_ops.api.graphql.sql.compiler import SankeyRequest, compile_sankey
+
+
+def _assert_team_attribution_sql(sql: str) -> None:
+    assert "WHERE org_id = %(org_id)s" in sql
+    assert "arrayDistinct(arrayConcat(" in sql
+    assert "JSONExtract(structural_evidence_json, 'issues', 'Array(String)')" in sql
+    assert "[work_unit_investments.work_unit_id]" in sql
+    assert "t.work_item_id = issue_id" in sql
+
+
+def test_graphql_sankey_team_join_scopes_org_and_uses_work_unit_fallback() -> None:
+    nodes_queries, edges_queries = compile_sankey(
+        SankeyRequest(
+            path=[DimensionInput.THEME.value, DimensionInput.TEAM.value],
+            measure=MeasureInput.COUNT.value,
+            start_date=date(2026, 5, 24),
+            end_date=date(2026, 6, 8),
+            use_investment=True,
+        ),
+        org_id="org-1",
+    )
+
+    compiled_sql = "\n".join(sql for sql, _params in [*nodes_queries, *edges_queries])
+
+    _assert_team_attribution_sql(compiled_sql)
+    assert all(params["org_id"] == "org-1" for _sql, params in nodes_queries)
+    assert all(params["org_id"] == "org-1" for _sql, params in edges_queries)
+
+
+@pytest.mark.asyncio
+async def test_graphql_sankey_coverage_team_join_scopes_org_and_uses_work_unit_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {"sql": "", "params": {}}
+
+    async def fake_execute_sankey_inner(*_args: Any, **_kwargs: Any):
+        return [], []
+
+    async def fake_query_dicts(_client: object, sql: str, params: dict[str, Any]):
+        captured["sql"] = sql
+        captured["params"] = params
+        return [{"total": 2, "assigned_team": 1, "assigned_repo": 2}]
+
+    monkeypatch.setattr(
+        analytics_resolver, "_execute_sankey_inner", fake_execute_sankey_inner
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    result = await analytics_resolver.resolve_analytics(
+        GraphQLContext(org_id="org-1", db_url="clickhouse://test", client=object()),
+        AnalyticsRequestInput(
+            sankey=SankeyRequestInput(
+                path=[DimensionInput.THEME, DimensionInput.TEAM],
+                measure=MeasureInput.COUNT,
+                date_range=DateRangeInput(
+                    start_date=date(2026, 5, 24), end_date=date(2026, 6, 8)
+                ),
+                use_investment=True,
+            ),
+            use_investment=True,
+        ),
+    )
+
+    _assert_team_attribution_sql(str(captured["sql"]))
+    assert captured["params"]["org_id"] == "org-1"
+    assert result.sankey is not None
+    assert result.sankey.coverage is not None
+    assert result.sankey.coverage.team_coverage == 0.5

--- a/tests/api/test_investment_team_attribution_sql.py
+++ b/tests/api/test_investment_team_attribution_sql.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+
+import dev_health_ops.api.queries.investment as investment_queries
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+
+def assert_team_attribution_sql(sql: str) -> None:
+    assert "WHERE org_id = %(org_id)s" in sql
+    assert "arrayDistinct(arrayConcat(" in sql
+    assert "JSONExtract(structural_evidence_json, 'issues', 'Array(String)')" in sql
+    assert "[work_unit_investments.work_unit_id]" in sql
+    assert "t.work_item_id = issue_id" in sql
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fetcher",
+    [
+        investment_queries.fetch_investment_team_edges,
+        investment_queries.fetch_investment_repo_team_edges,
+        investment_queries.fetch_investment_team_category_repo_edges,
+        investment_queries.fetch_investment_team_subcategory_repo_edges,
+        investment_queries.fetch_investment_unassigned_counts,
+    ],
+)
+async def test_investment_team_attribution_sql_scopes_org_and_uses_work_unit_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    fetcher: Any,
+) -> None:
+    captured: dict[str, Any] = {"sql": "", "params": {}}
+
+    async def fake_query_dicts(
+        _sink: BaseMetricsSink, sql: str, params: dict[str, Any]
+    ):
+        captured["sql"] = sql
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(investment_queries, "query_dicts", fake_query_dicts)
+
+    await fetcher(
+        cast(BaseMetricsSink, object()),
+        start_ts=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        end_ts=datetime(2026, 6, 8, tzinfo=timezone.utc),
+        scope_filter="",
+        scope_params={},
+        org_id="org-1",
+    )
+
+    assert_team_attribution_sql(str(captured["sql"]))
+    assert captured["params"]["org_id"] == "org-1"


### PR DESCRIPTION
## Summary
- Scope investment team-attribution joins to `work_item_cycle_times.org_id = %(org_id)s`.
- Resolve team attribution from `arrayDistinct(arrayConcat(JSONExtract(... issues ...), [work_unit_investments.work_unit_id]))` so WorkUnits can match by evidence issue or direct WorkUnit ID.
- Apply the same contract to REST investment edges, GraphQL Sankey SQL, and Sankey coverage SQL.

## ClickHouse verification
- BEFORE current attribution SQL (Meridian 14d, org `900f96be-804c-42fb-9e93-de73c499a22d`): total 163, assigned team 93, unassigned 70.
- AFTER fixed attribution CTE: total 163, assigned team 93, unassigned 70.
- Residual unmapped evidence: fixed unit-team CTE resolves 109 non-empty team labels; coverage remains 93 because 16 resolved records are explicitly `team_id=unassigned` / `team_name=Unassigned`, and 54 in-window WorkUnits have no org-scoped `work_item_cycle_times` direct match.

## Verification
- `docker exec dev-health-clickhouse-1 clickhouse-client --query "<before attribution SQL>"`
- `docker exec dev-health-clickhouse-1 clickhouse-client --query "<fixed attribution CTE>"`
- `uv run ruff format ... && uv run ruff check --fix ...`
- `uv run --extra dev pytest tests/ -k "investment" -q` (65 passed)
- LSP diagnostics clean on changed files.

SCREENSHOT-WAIVER: backend SQL attribution fix; verified via ClickHouse counts + ops tests; live web capture deferred to avoid mutating the shared running stack.