### PR TITLE
feat(investment): expose evidence quality stats

### DIFF
--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -100,6 +100,14 @@ class FlowMatrixResult:
 
 
 @strawberry.type
+class EvidenceQualityStats:
+    mean: float | None = None
+    stddev: float | None = None
+    total: int = 0
+    band_counts: strawberry.scalars.JSON = strawberry.field(default_factory=dict)
+
+
+@strawberry.type
 class AnalyticsResult:
     """Combined result of a batch analytics request."""
 
@@ -107,6 +115,8 @@ class AnalyticsResult:
     breakdowns: list[BreakdownResult]
     sankey: SankeyResult | None = None
     flow_matrix: FlowMatrixResult | None = None
+    evidence_quality_distribution: strawberry.scalars.JSON | None = None
+    evidence_quality_stats: EvidenceQualityStats | None = None
 
 
 @strawberry.type

--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Coroutine
-from datetime import date
-from typing import Any
+from datetime import date, datetime, time, timezone
+from typing import Any, cast
+
+from dev_health_ops.api.queries.investment import fetch_investment_quality_stats
 
 from ..authz import require_org_id
 from ..context import GraphQLContext
@@ -27,6 +29,7 @@ from ..models.outputs import (
     AnalyticsResult,
     BreakdownItem,
     BreakdownResult,
+    EvidenceQualityStats,
     FlowMatrixResult,
     SankeyCoverage,
     SankeyEdge,
@@ -47,6 +50,80 @@ from ..sql.compiler import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _analytics_quality_window(batch: AnalyticsRequestInput) -> tuple[date, date] | None:
+    if batch.breakdowns:
+        date_range = batch.breakdowns[0].date_range
+        return date_range.start_date, date_range.end_date
+    if batch.timeseries:
+        date_range = batch.timeseries[0].date_range
+        return date_range.start_date, date_range.end_date
+    return None
+
+
+async def _resolve_evidence_quality_stats(
+    client: Any,
+    batch: AnalyticsRequestInput,
+    org_id: str,
+) -> EvidenceQualityStats | None:
+    if not bool(batch.use_investment):
+        return None
+    window = _analytics_quality_window(batch)
+    if window is None:
+        return None
+
+    start_date, end_date = window
+    filters = batch.filters
+    scope_filter = ""
+    scope_params: dict[str, Any] = {}
+    team_scope_ids: list[str] | None = None
+    themes: list[str] | None = None
+
+    if filters is not None:
+        if filters.scope is not None and filters.scope.ids:
+            if filters.scope.level.value == "team":
+                team_scope_ids = filters.scope.ids
+            elif filters.scope.level.value == "repo":
+                scope_filter += " AND work_unit_investments.repo_id IN %(scope_ids)s"
+                scope_params["scope_ids"] = filters.scope.ids
+        if filters.what is not None and filters.what.repos:
+            scope_filter += " AND work_unit_investments.repo_id IN %(repo_filter_ids)s"
+            scope_params["repo_filter_ids"] = filters.what.repos
+        if filters.why is not None and filters.why.work_category:
+            themes = filters.why.work_category
+
+    row = await fetch_investment_quality_stats(
+        client,
+        start_ts=datetime.combine(start_date, time.min, tzinfo=timezone.utc),
+        end_ts=datetime.combine(end_date, time.min, tzinfo=timezone.utc),
+        scope_filter=scope_filter,
+        scope_params=scope_params,
+        org_id=org_id,
+        themes=themes,
+        team_scope_ids=team_scope_ids,
+    )
+    if not row:
+        return EvidenceQualityStats()
+
+    band_counts = {
+        "high": int(row.get("high_count") or 0),
+        "moderate": int(row.get("moderate_count") or 0),
+        "low": int(row.get("low_count") or 0),
+        "very_low": int(row.get("very_low_count") or 0),
+        "unknown": int(row.get("unknown_count") or 0),
+    }
+    known_count = int(row.get("quality_known_count") or 0)
+    mean_value = row.get("quality_mean")
+    stddev_value = row.get("quality_stddev")
+    return EvidenceQualityStats(
+        mean=float(mean_value) if mean_value is not None and known_count > 0 else None,
+        stddev=float(stddev_value)
+        if stddev_value is not None and known_count > 0
+        else None,
+        total=int(row.get("total") or 0),
+        band_counts=cast(Any, band_counts),
+    )
 
 
 async def _execute_sankey_inner(
@@ -548,9 +625,20 @@ async def resolve_analytics(
 
         flow_matrix_result = FlowMatrixResult(nodes=fm_nodes, edges=fm_edges)
 
+    evidence_quality_stats = await _resolve_evidence_quality_stats(
+        client, batch, org_id
+    )
+    evidence_quality_distribution = (
+        evidence_quality_stats.band_counts
+        if evidence_quality_stats is not None
+        else None
+    )
+
     return AnalyticsResult(
         timeseries=timeseries_results,
         breakdowns=breakdown_results,
         sankey=sankey_result,
         flow_matrix=flow_matrix_result,
+        evidence_quality_distribution=evidence_quality_distribution,
+        evidence_quality_stats=evidence_quality_stats,
     )

--- a/src/dev_health_ops/api/models/schemas.py
+++ b/src/dev_health_ops/api/models/schemas.py
@@ -313,6 +313,7 @@ class EvidenceQualityStats(BaseModel):
 
     mean: float | None = None
     stddev: float | None = None
+    total: int = 0
     band_counts: dict[str, int] = Field(default_factory=dict)
     quality_drivers: list[str] = Field(default_factory=list)
 

--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -560,6 +560,7 @@ async def fetch_investment_quality_stats(
     org_id: str = "",
     themes: list[str] | None = None,
     subcategories: list[str] | None = None,
+    team_scope_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     """Fetch aggregated evidence quality stats: mean, stddev, band counts."""
     filters: list[str] = []
@@ -577,22 +578,68 @@ async def fetch_investment_quality_stats(
         )
         params["subcategories"] = subcategories
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
+    team_join = ""
+    team_filter = ""
+    if team_scope_ids:
+        params["team_scope_ids"] = team_scope_ids
+        team_join = """
+        LEFT JOIN (
+            SELECT
+                work_unit_id,
+                argMax(team_id, cnt) AS team_id,
+                argMax(team_label, cnt) AS team_label
+            FROM (
+                SELECT
+                    work_unit_investments.work_unit_id AS work_unit_id,
+                    t.team_id AS team_id,
+                    ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team_label,
+                    countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
+                FROM work_unit_investments
+                ARRAY JOIN arrayDistinct(arrayConcat(
+                    JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
+                    [work_unit_investments.work_unit_id]
+                )) AS issue_id
+                LEFT JOIN (
+                    SELECT
+                        work_item_id,
+                        argMax(team_id, computed_at) AS team_id,
+                        argMax(team_name, computed_at) AS team_name
+                    FROM work_item_cycle_times
+                    WHERE org_id = %(org_id)s
+                    GROUP BY work_item_id
+                ) AS t ON t.work_item_id = issue_id
+                WHERE work_unit_investments.from_ts < %(end_ts)s
+                  AND work_unit_investments.to_ts >= %(start_ts)s
+                  AND work_unit_investments.org_id = %(org_id)s
+                GROUP BY work_unit_id, team_id, team_label
+            )
+            GROUP BY work_unit_id
+        ) AS unit_team ON unit_team.work_unit_id = work_unit_investments.work_unit_id
+        """
+        team_filter = """
+          AND (
+              unit_team.team_label IN %(team_scope_ids)s
+              OR unit_team.team_id IN %(team_scope_ids)s
+          )
+        """
     query = f"""
         SELECT
-            sum(effort_value) AS total_effort,
-            sumIf(effort_value, evidence_quality IS NOT NULL) AS quality_known_effort,
-            sumIf(effort_value * evidence_quality, evidence_quality IS NOT NULL) AS quality_weighted,
+            count() AS total,
+            countIf(evidence_quality IS NOT NULL) AS quality_known_count,
+            avgIf(evidence_quality, evidence_quality IS NOT NULL) AS quality_mean,
+            stddevPopIf(evidence_quality, evidence_quality IS NOT NULL) AS quality_stddev,
             countIf(evidence_quality_band = 'high') AS high_count,
             countIf(evidence_quality_band = 'moderate') AS moderate_count,
             countIf(evidence_quality_band = 'low') AS low_count,
             countIf(evidence_quality_band = 'very_low') AS very_low_count,
-            countIf(evidence_quality IS NULL OR evidence_quality_band = '') AS unknown_count,
-            varPopIf(evidence_quality, evidence_quality IS NOT NULL) AS quality_variance
+            countIf(evidence_quality IS NULL OR evidence_quality_band = '') AS unknown_count
         FROM work_unit_investments
+        {team_join}
         WHERE work_unit_investments.from_ts < %(end_ts)s
           AND work_unit_investments.to_ts >= %(start_ts)s
           AND work_unit_investments.org_id = %(org_id)s
         {scope_filter}
+        {team_filter}
         {category_filter}
     """
     rows = await query_dicts(sink, query, params)

--- a/src/dev_health_ops/api/services/investment.py
+++ b/src/dev_health_ops/api/services/investment.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from datetime import datetime, time, timezone
 from typing import Any
 
@@ -90,15 +89,14 @@ def _compute_quality_stats(quality_row: dict[str, Any]) -> EvidenceQualityStats:
     if not quality_row:
         return EvidenceQualityStats()
 
-    total_effort = float(quality_row.get("total_effort") or 0.0)
-    known_effort = float(quality_row.get("quality_known_effort") or 0.0)
-    weighted = float(quality_row.get("quality_weighted") or 0.0)
-    variance = quality_row.get("quality_variance")
-
-    # Compute weighted mean
-    mean = (weighted / known_effort) if known_effort > 0 else None
-    # Compute stddev from variance
-    stddev = math.sqrt(float(variance)) if variance is not None else None
+    total = int(quality_row.get("total") or 0)
+    known_count = int(quality_row.get("quality_known_count") or 0)
+    mean_value = quality_row.get("quality_mean")
+    stddev_value = quality_row.get("quality_stddev")
+    mean = float(mean_value) if mean_value is not None and known_count > 0 else None
+    stddev = (
+        float(stddev_value) if stddev_value is not None and known_count > 0 else None
+    )
 
     band_counts = {
         "high": int(quality_row.get("high_count") or 0),
@@ -111,7 +109,7 @@ def _compute_quality_stats(quality_row: dict[str, Any]) -> EvidenceQualityStats:
     # Determine quality drivers (algorithmic reasons for low quality)
     quality_drivers: list[str] = []
     unknown_count = band_counts.get("unknown", 0)
-    total_count = sum(band_counts.values())
+    total_count = total or sum(band_counts.values())
 
     if total_count > 0 and unknown_count / total_count > 0.3:
         quality_drivers.append("missing_evidence_metadata")
@@ -126,12 +124,13 @@ def _compute_quality_stats(quality_row: dict[str, Any]) -> EvidenceQualityStats:
     if total_count > 0 and low_plus / total_count > 0.5:
         quality_drivers.append("weak_cross_links")
 
-    if known_effort > 0 and total_effort > 0 and known_effort / total_effort < 0.7:
+    if total_count > 0 and known_count / total_count < 0.7:
         quality_drivers.append("thin_component")
 
     return EvidenceQualityStats(
         mean=mean,
         stddev=stddev,
+        total=total,
         band_counts=band_counts,
         quality_drivers=quality_drivers,
     )
@@ -218,6 +217,10 @@ async def build_investment_response(
     return InvestmentResponse(
         theme_distribution=theme_distribution,
         subcategory_distribution=subcategory_distribution,
+        evidence_quality_distribution={
+            band: float(count)
+            for band, count in evidence_quality_stats.band_counts.items()
+        },
         evidence_quality_stats=evidence_quality_stats,
         edges=[],
     )

--- a/tests/api/test_investment_evidence_quality.py
+++ b/tests/api/test_investment_evidence_quality.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any, cast
 
 import pytest
 
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.models.inputs import (
+    AnalyticsRequestInput,
+    BucketIntervalInput,
+    DateRangeInput,
+    DimensionInput,
+    MeasureInput,
+    TimeseriesRequestInput,
+)
+from dev_health_ops.api.graphql.resolvers import analytics as analytics_resolver
 from dev_health_ops.api.queries import investment as investment_queries
 from dev_health_ops.api.services.investment import _compute_quality_stats
 
@@ -81,3 +91,60 @@ def test_compute_quality_stats_exposes_band_counts_mean_stddev_total() -> None:
         "very_low": 0,
         "unknown": 0,
     }
+
+
+@pytest.mark.asyncio
+async def test_graphql_analytics_returns_evidence_quality_stats(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_timeseries(*_args: Any, **_kwargs: Any):
+        return []
+
+    async def fake_quality_stats(*_args: Any, **_kwargs: Any):
+        return {
+            "total": 4,
+            "quality_known_count": 4,
+            "quality_mean": 0.6875,
+            "quality_stddev": 0.147902,
+            "high_count": 1,
+            "moderate_count": 2,
+            "low_count": 1,
+            "very_low_count": 0,
+            "unknown_count": 0,
+        }
+
+    monkeypatch.setattr(
+        analytics_resolver, "_execute_timeseries_query", fake_timeseries
+    )
+    monkeypatch.setattr(
+        analytics_resolver, "fetch_investment_quality_stats", fake_quality_stats
+    )
+
+    result = await analytics_resolver.resolve_analytics(
+        GraphQLContext(org_id="org-1", db_url="clickhouse://test", client=object()),
+        AnalyticsRequestInput(
+            timeseries=[
+                TimeseriesRequestInput(
+                    dimension=DimensionInput.THEME,
+                    measure=MeasureInput.COUNT,
+                    interval=BucketIntervalInput.DAY,
+                    date_range=DateRangeInput(
+                        start_date=date(2026, 5, 26), end_date=date(2026, 6, 9)
+                    ),
+                )
+            ],
+            use_investment=True,
+        ),
+    )
+
+    assert result.evidence_quality_distribution == {
+        "high": 1,
+        "moderate": 2,
+        "low": 1,
+        "very_low": 0,
+        "unknown": 0,
+    }
+    assert result.evidence_quality_stats is not None
+    assert result.evidence_quality_stats.mean == 0.6875
+    assert result.evidence_quality_stats.stddev == 0.147902
+    assert result.evidence_quality_stats.total == 4

--- a/tests/api/test_investment_evidence_quality.py
+++ b/tests/api/test_investment_evidence_quality.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+
+from dev_health_ops.api.queries import investment as investment_queries
+from dev_health_ops.api.services.investment import _compute_quality_stats
+
+
+@pytest.mark.asyncio
+async def test_fetch_investment_quality_stats_reads_persisted_work_unit_bands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {"sql": "", "params": {}}
+
+    async def fake_query_dicts(_sink: object, sql: str, params: dict[str, Any]):
+        captured["sql"] = sql
+        captured["params"] = params
+        return [
+            {
+                "total": 4,
+                "quality_known_count": 4,
+                "quality_mean": 0.6875,
+                "quality_stddev": 0.147902,
+                "high_count": 1,
+                "moderate_count": 2,
+                "low_count": 1,
+                "very_low_count": 0,
+                "unknown_count": 0,
+            }
+        ]
+
+    monkeypatch.setattr(investment_queries, "query_dicts", fake_query_dicts)
+
+    row = await investment_queries.fetch_investment_quality_stats(
+        cast(Any, object()),
+        start_ts=datetime(2026, 5, 26, tzinfo=timezone.utc),
+        end_ts=datetime(2026, 6, 9, tzinfo=timezone.utc),
+        scope_filter=" AND work_unit_investments.repo_id IN %(repo_ids)s",
+        scope_params={"repo_ids": ["repo-1"]},
+        org_id="org-1",
+    )
+
+    sql = str(captured["sql"])
+    assert "FROM work_unit_investments" in sql
+    assert "avgIf(evidence_quality" in sql
+    assert "stddevPopIf(evidence_quality" in sql
+    assert "countIf(evidence_quality_band = 'high')" in sql
+    assert captured["params"]["org_id"] == "org-1"
+    assert captured["params"]["repo_ids"] == ["repo-1"]
+    assert row["high_count"] == 1
+    assert row["moderate_count"] == 2
+    assert row["low_count"] == 1
+    assert row["quality_mean"] == 0.6875
+
+
+def test_compute_quality_stats_exposes_band_counts_mean_stddev_total() -> None:
+    stats = _compute_quality_stats(
+        {
+            "total": 4,
+            "quality_known_count": 4,
+            "quality_mean": 0.6875,
+            "quality_stddev": 0.147902,
+            "high_count": 1,
+            "moderate_count": 2,
+            "low_count": 1,
+            "very_low_count": 0,
+            "unknown_count": 0,
+        }
+    )
+
+    assert stats.total == 4
+    assert stats.mean == 0.6875
+    assert stats.stddev == 0.147902
+    assert stats.band_counts == {
+        "high": 1,
+        "moderate": 2,
+        "low": 1,
+        "very_low": 0,
+        "unknown": 0,
+    }


### PR DESCRIPTION
## Summary
- Aggregates persisted `work_unit_investments.evidence_quality` / `evidence_quality_band` into band counts, mean, stddev, and total.
- Exposes REST `evidence_quality_distribution` plus `evidence_quality_stats`.
- Exposes GraphQL `analytics.evidenceQualityDistribution` plus `analytics.evidenceQualityStats { mean stddev total bandCounts }`.

## Verification
- `uv run ruff format ...`
- `uv run ruff check --fix ...`
- `uv run --extra dev pytest tests/ -k "investment or evidence or quality" -q` → 109 passed, 3522 deselected
- LSP diagnostics clean on changed files
- `uv run --extra dev python -m dev_health_ops.api.graphql.export_schema --out /tmp/schema.graphql`

## ClickHouse verification
Read-only query:
```sql
SELECT evidence_quality_band, count() AS count
FROM work_unit_investments
WHERE org_id = '900f96be-804c-42fb-9e93-de73c499a22d'
  AND from_ts < toDateTime('2026-06-09 00:00:00', 'UTC')
  AND to_ts >= toDateTime('2026-05-26 00:00:00', 'UTC')
GROUP BY evidence_quality_band
ORDER BY evidence_quality_band;

SELECT count() AS total,
       avgIf(evidence_quality, evidence_quality IS NOT NULL) AS mean,
       stddevPopIf(evidence_quality, evidence_quality IS NOT NULL) AS stddev
FROM work_unit_investments
WHERE org_id = '900f96be-804c-42fb-9e93-de73c499a22d'
  AND from_ts < toDateTime('2026-06-09 00:00:00', 'UTC')
  AND to_ts >= toDateTime('2026-05-26 00:00:00', 'UTC');
```

Result:
```
high     51
low      34
moderate 57
total=142 mean=0.7255845070422535 stddev=0.14188694383343048
```

## Exported schema new lines
```graphql
type AnalyticsResult {
  evidenceQualityDistribution: JSON
  evidenceQualityStats: EvidenceQualityStats
}

type EvidenceQualityStats {
  mean: Float
  stddev: Float
  total: Int!
  bandCounts: JSON!
}
```

SCREENSHOT-WAIVER: backend data exposure; verified via ClickHouse + tests; web render is a separate PR.