### PR TITLE
CHAOS-2165: Govern backend fixes — TestOps analytics null-safety + pipeline fixture attribution

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -68,7 +68,7 @@ async def _execute_sankey_inner(
             for row in rows:
                 dim = str(row.get("dimension", ""))
                 node_id = str(row.get("node_id", ""))
-                value = float(row.get("value", 0))
+                value = float(row.get("value") or 0)
                 out.append(
                     SankeyNode(
                         id=f"{dim}:{node_id}",
@@ -92,7 +92,7 @@ async def _execute_sankey_inner(
                 target_dim = str(row.get("target_dimension", ""))
                 source = str(row.get("source", ""))
                 target = str(row.get("target", ""))
-                value = float(row.get("value", 0))
+                value = float(row.get("value") or 0)
                 out.append(
                     SankeyEdge(
                         source=f"{source_dim}:{source}",
@@ -139,7 +139,7 @@ async def _execute_timeseries_query(
     for row in rows:
         dim_val = str(row.get("dimension_value", ""))
         bucket_date = row.get("bucket")
-        value = float(row.get("value", 0))
+        value = float(row.get("value") or 0)
 
         if dim_val not in grouped:
             grouped[dim_val] = []
@@ -240,7 +240,7 @@ async def _execute_breakdown_query(
     items = [
         _build_breakdown_item(
             str(row.get("dimension_value", "")),
-            float(row.get("value", 0)),
+            float(row.get("value") or 0),
             label_map,
         )
         for row in rows

--- a/src/dev_health_ops/fixtures/generators/pipelines.py
+++ b/src/dev_health_ops/fixtures/generators/pipelines.py
@@ -7,6 +7,7 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 from dev_health_ops.fixtures.generators.base import BaseGeneratorMixin
+from dev_health_ops.metrics.testops_schemas import PipelineRunExtendedRow
 from dev_health_ops.models.git import CiPipelineRun, Deployment
 
 
@@ -46,6 +47,96 @@ class PipelinesGeneratorMixin(BaseGeneratorMixin):
                 )
             current_date += timedelta(days=1)
         return runs
+
+    def generate_pipeline_run_extended_rows(
+        self,
+        pipeline_runs: list[CiPipelineRun] | None = None,
+        days: int = 30,
+        runs_per_day: int = 3,
+        *,
+        org_id: str = "",
+    ) -> list[PipelineRunExtendedRow]:
+        """Generate CI pipeline run dicts for ClickHouse with retry_count and team_id.
+
+        Unlike generate_ci_pipeline_runs (which produces SQLAlchemy objects for
+        Postgres), this method returns PipelineRunExtendedRow dicts suitable for
+        the ClickHouse ci_pipeline_runs table and compute_pipeline_metrics_daily.
+
+        When *pipeline_runs* is provided the extended rows are derived from those
+        existing objects, guaranteeing that run_id values match the Postgres-side
+        rows.  This is the mode used by the fixture runner so that both inserts
+        share the same primary key.
+
+        When *pipeline_runs* is None the method generates rows from scratch
+        (standalone / test mode) — backward-compatible with callers that do not
+        yet have a pre-generated list.
+
+        Approximately 10% of runs have retry_count > 0 so that rerun_rate is
+        non-zero in daily metric aggregates.  Each run is attributed to a team
+        via _pick_assigned_team_id, mirroring the pattern used for job/suite rows.
+        """
+        service_id = self._get_service_id()
+        rows: list[PipelineRunExtendedRow] = []
+
+        if pipeline_runs is not None:
+            # Derive extended rows from already-generated CiPipelineRun objects.
+            # This keeps run_ids aligned between Postgres and ClickHouse.
+            for run in pipeline_runs:
+                retry_count = random.randint(1, 3) if random.random() < 0.10 else 0
+                team_id = self._pick_assigned_team_id(run.run_id)
+                row: PipelineRunExtendedRow = {
+                    "repo_id": self.repo_id,
+                    "run_id": run.run_id,
+                    "provider": "github_actions",
+                    "status": run.status or "success",
+                    "queued_at": run.queued_at or run.started_at,
+                    "started_at": run.started_at,
+                    "finished_at": run.finished_at or run.started_at,
+                    "retry_count": retry_count,
+                    "team_id": team_id,
+                    "service_id": service_id,
+                    "org_id": org_id,
+                }
+                rows.append(row)
+            return rows
+
+        # Standalone generation (backward-compatible path used in unit tests).
+        end_date = datetime.now(timezone.utc)
+        start_date = end_date - timedelta(days=days)
+        run_index = 0
+        current_date = start_date
+        while current_date <= end_date:
+            daily_count = random.randint(1, max(1, runs_per_day * 2))
+            for _ in range(daily_count):
+                queued_at = current_date + timedelta(minutes=random.randint(0, 60 * 12))
+                started_at = queued_at + timedelta(minutes=random.randint(1, 30))
+                duration_minutes = random.randint(5, 60)
+                finished_at = started_at + timedelta(minutes=duration_minutes)
+                status = random.choices(
+                    ["success", "failure", "cancelled"],
+                    weights=[0.7, 0.2, 0.1],
+                    k=1,
+                )[0]
+                run_index += 1
+                run_id = f"synth-run-{run_index}"
+                retry_count = random.randint(1, 3) if random.random() < 0.10 else 0
+                team_id = self._pick_assigned_team_id(run_id)
+                row = {
+                    "repo_id": self.repo_id,
+                    "run_id": run_id,
+                    "provider": "github_actions",
+                    "status": status,
+                    "queued_at": queued_at,
+                    "started_at": started_at,
+                    "finished_at": finished_at,
+                    "retry_count": retry_count,
+                    "team_id": team_id,
+                    "service_id": service_id,
+                    "org_id": org_id,
+                }
+                rows.append(row)
+            current_date += timedelta(days=1)
+        return rows
 
     def generate_ci_job_runs(
         self, pipeline_runs: list[CiPipelineRun], *, org_id: str = ""

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -647,11 +647,42 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                 days=ns.days, pr_numbers=pr_numbers, release_refs=release_refs
             )
             incidents = generator.generate_incidents(days=ns.days)
-            await _insert_batches(
-                store.insert_ci_pipeline_runs,
-                pipeline_runs,
-                allow_parallel=allow_parallel_inserts,
+            # Pipeline-run insert — ONE path to keep the ci_daily_rollup_mv from
+            # seeing the same (repo_id, run_id) twice.
+            #
+            # ClickHouseStore: insert_testops_pipeline_runs carries ALL fields
+            #   (retry_count, team_id, …) in a single INSERT statement so the MV
+            #   fires exactly once per run.  insert_ci_pipeline_runs is intentionally
+            #   skipped here — calling both would produce two MV events and inflate
+            #   synthetic daily totals even though ReplacingMergeTree eventually
+            #   deduplicates the source table.
+            #
+            # SQLAlchemyStore (Postgres/SQLite): insert_ci_pipeline_runs is the
+            #   standard ORM path.  There is no MV concern, and the Postgres schema
+            #   does not carry retry_count/team_id in ci_pipeline_runs.
+            _ch_pipeline_insert = (
+                getattr(store, "insert_testops_pipeline_runs", None)
+                if not isinstance(store, SQLAlchemyStore)
+                else None
             )
+            if _ch_pipeline_insert is not None:
+                # ClickHouse path: single enriched insert — MV sees each run_id once.
+                extended_pipeline_rows = generator.generate_pipeline_run_extended_rows(
+                    pipeline_runs=pipeline_runs, org_id=org_id
+                )
+                await _insert_batches(
+                    _ch_pipeline_insert,
+                    extended_pipeline_rows,
+                    allow_parallel=allow_parallel_inserts,
+                )
+            else:
+                # Postgres/SQLite path: ORM-backed insert (basic fields only).
+                await _insert_batches(
+                    store.insert_ci_pipeline_runs,
+                    pipeline_runs,
+                    allow_parallel=allow_parallel_inserts,
+                )
+
             await _insert_batches(
                 store.insert_deployments,
                 deployments,

--- a/tests/graphql/test_resolvers.py
+++ b/tests/graphql/test_resolvers.py
@@ -289,3 +289,116 @@ class TestResolveAnalytics:
         assert len(captured_sql) == 1
         assert "AND org_id = %(org_id)s" in captured_sql[0]
         assert captured_params[0]["org_id"] == "tenant-123"
+
+    @pytest.mark.asyncio
+    async def test_timeseries_null_value_does_not_raise(self, monkeypatch):
+        """CHAOS-2172: NULL AVG from ClickHouse (value=None) must coerce to 0.0, not TypeError."""
+        from datetime import date as date_
+
+        from dev_health_ops.api.graphql.models.inputs import (
+            BucketIntervalInput,
+            DateRangeInput,
+            DimensionInput,
+            MeasureInput,
+            TimeseriesRequestInput,
+        )
+        from dev_health_ops.api.graphql.resolvers.analytics import (
+            _execute_timeseries_query,
+        )
+
+        async def fake_query_dicts(_client, _sql, _params):
+            # Simulate ClickHouse returning NULL for AVG on an empty bucket.
+            return [
+                {
+                    "dimension_value": "team-a",
+                    "bucket": date_(2025, 6, 1),
+                    "value": None,
+                },
+                {
+                    "dimension_value": "team-a",
+                    "bucket": date_(2025, 6, 2),
+                    "value": 3.5,
+                },
+            ]
+
+        def fake_compile_ts(_request, _org_id, _timeout, filters=None):
+            return "SELECT 1", {}
+
+        monkeypatch.setattr(
+            "dev_health_ops.api.queries.client.query_dicts",
+            fake_query_dicts,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.api.graphql.resolvers.analytics.compile_timeseries",
+            fake_compile_ts,
+        )
+
+        ts_req = TimeseriesRequestInput(
+            dimension=DimensionInput.TEAM,
+            measure=MeasureInput.COUNT,
+            interval=BucketIntervalInput.DAY,
+            date_range=DateRangeInput(
+                start_date=date_(2025, 6, 1),
+                end_date=date_(2025, 6, 7),
+            ),
+        )
+        # Must not raise TypeError.
+        results = await _execute_timeseries_query(
+            MockClient(), ts_req, "org-x", 30, False, None
+        )
+        assert len(results) == 1
+        buckets = results[0].buckets
+        assert len(buckets) == 2
+        assert buckets[0].value == 0.0  # NULL → 0.0
+        assert buckets[1].value == 3.5
+
+    @pytest.mark.asyncio
+    async def test_breakdown_null_value_does_not_raise(self, monkeypatch):
+        """CHAOS-2172: NULL value in breakdown rows must coerce to 0.0, not TypeError."""
+        from datetime import date as date_
+
+        from dev_health_ops.api.graphql.models.inputs import (
+            BreakdownRequestInput,
+            DateRangeInput,
+            DimensionInput,
+            MeasureInput,
+        )
+        from dev_health_ops.api.graphql.resolvers.analytics import (
+            _execute_breakdown_query,
+        )
+
+        async def fake_query_dicts(_client, _sql, _params):
+            return [
+                {"dimension_value": "auth-service", "value": None},
+                {"dimension_value": "api-gateway", "value": 7.2},
+            ]
+
+        def fake_compile_bd(_request, _org_id, _timeout, filters=None):
+            return "SELECT 1", {}
+
+        monkeypatch.setattr(
+            "dev_health_ops.api.queries.client.query_dicts",
+            fake_query_dicts,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.api.graphql.resolvers.analytics.compile_breakdown",
+            fake_compile_bd,
+        )
+
+        bd_req = BreakdownRequestInput(
+            dimension=DimensionInput.TEAM,
+            measure=MeasureInput.COUNT,
+            date_range=DateRangeInput(
+                start_date=date_(2025, 6, 1),
+                end_date=date_(2025, 6, 7),
+            ),
+        )
+        # Must not raise TypeError.
+        result = await _execute_breakdown_query(
+            MockClient(), bd_req, "org-x", 30, False, None
+        )
+        assert len(result.items) == 2
+        null_item = next(i for i in result.items if i.key == "auth-service")
+        assert null_item.value == 0.0  # NULL → 0.0
+        normal_item = next(i for i in result.items if i.key == "api-gateway")
+        assert normal_item.value == 7.2

--- a/tests/test_fixtures_runner.py
+++ b/tests/test_fixtures_runner.py
@@ -472,6 +472,139 @@ def test_validate_security_alerts_fixture_rejects_single_severity():
     )
 
 
+class TestRunnerWiresExtendedPipelineRows:
+    """CHAOS-2173: pipeline-run insert must be a single call per (repo_id, run_id)
+    so ci_daily_rollup_mv counts each run exactly once."""
+
+    @pytest.mark.asyncio
+    async def test_sqlite_path_no_double_insert(self, tmp_path, monkeypatch):
+        """On SQLite/Postgres (SQLAlchemyStore), the runner must call
+        insert_ci_pipeline_runs and must NOT call insert_testops_pipeline_runs
+        — preventing a double-insert that would inflate any MV counts."""
+        from dev_health_ops.storage import SQLAlchemyStore
+
+        ci_run_ids: list[str] = []
+        testops_run_ids: list[str] = []
+
+        original_ci = SQLAlchemyStore.insert_ci_pipeline_runs
+
+        async def spy_ci(self_store, batch):
+            ci_run_ids.extend(r.run_id for r in batch)
+            return await original_ci(self_store, batch)
+
+        async def spy_testops(self_store, batch):
+            testops_run_ids.extend(r.get("run_id", "") for r in batch)
+
+        monkeypatch.setattr(SQLAlchemyStore, "insert_ci_pipeline_runs", spy_ci)
+        monkeypatch.setattr(
+            SQLAlchemyStore, "insert_testops_pipeline_runs", spy_testops
+        )
+
+        db_file = tmp_path / "test_no_double.db"
+        ns = argparse.Namespace(
+            sink=f"sqlite:///{db_file}",
+            db_type="sqlite",
+            org_id="test-org",
+            repo_name="test/no-double",
+            repo_count=1,
+            days=3,
+            commits_per_day=2,
+            pr_count=2,
+            seed=42,
+            provider="synthetic",
+            with_work_graph=False,
+            with_metrics=False,
+            team_count=2,
+        )
+
+        result = await run_fixtures_generation(ns)
+        assert result == 0
+
+        # Postgres/SQLite path: basic insert was used.
+        assert ci_run_ids, "insert_ci_pipeline_runs must be called on SQLite path"
+
+        # No testops insert on the SQLite path — this prevents double-insert.
+        assert not testops_run_ids, (
+            "insert_testops_pipeline_runs must NOT be called on SQLite/Postgres — "
+            "calling both would insert each run_id twice, inflating MV counts. "
+            f"Got run_ids: {testops_run_ids[:5]}"
+        )
+
+        # Every run_id appears exactly once.
+        assert len(ci_run_ids) == len(set(ci_run_ids)), (
+            "each run_id must appear in insert_ci_pipeline_runs exactly once"
+        )
+
+    def test_clickhouse_store_takes_extended_branch(self):
+        """The branching condition must route non-SQLAlchemy stores with
+        insert_testops_pipeline_runs to the single-insert (extended) path,
+        and SQLAlchemyStore to the basic-insert path.
+
+        This directly exercises the condition in runner._handler without
+        needing a full end-to-end run against a live ClickHouse."""
+        from dev_health_ops.storage import SQLAlchemyStore
+
+        # Simulate ClickHouseStore: not SQLAlchemy, has insert_testops_pipeline_runs.
+        class _FakeCHStore:
+            async def insert_ci_pipeline_runs(self, batch):
+                pass
+
+            async def insert_testops_pipeline_runs(self, batch):
+                pass
+
+        ch_store = _FakeCHStore()
+        sq_store = SQLAlchemyStore.__new__(SQLAlchemyStore)
+
+        # Replicate the branching condition from runner.py.
+        def _pick_pipeline_insert(store):
+            return (
+                getattr(store, "insert_testops_pipeline_runs", None)
+                if not isinstance(store, SQLAlchemyStore)
+                else None
+            )
+
+        # ClickHouse-like store → extended insert path.
+        ch_insert = _pick_pipeline_insert(ch_store)
+        assert ch_insert is not None, (
+            "ClickHouseStore-like stores must use insert_testops_pipeline_runs"
+        )
+        # Bound methods compare equal by __func__ + __self__ even if not identical objects.
+        assert ch_insert.__func__ is _FakeCHStore.insert_testops_pipeline_runs, (
+            "must resolve to insert_testops_pipeline_runs, not insert_ci_pipeline_runs"
+        )
+
+        # SQLAlchemyStore → None → falls through to insert_ci_pipeline_runs.
+        sq_insert = _pick_pipeline_insert(sq_store)
+        assert sq_insert is None, (
+            "SQLAlchemyStore must NOT use insert_testops_pipeline_runs "
+            "(would double-insert into Postgres/SQLite)"
+        )
+
+    def test_generator_derives_extended_rows_from_pipeline_runs(self):
+        """When pipeline_runs is supplied, extended rows must use the same run_ids
+        as those SQLAlchemy objects (key alignment for ReplacingMergeTree dedup)."""
+        gen = SyntheticDataGenerator(repo_name="test/key-align", seed=42)
+        pipeline_runs = gen.generate_ci_pipeline_runs(days=5, runs_per_day=3)
+
+        extended = gen.generate_pipeline_run_extended_rows(
+            pipeline_runs=pipeline_runs, org_id="test-org"
+        )
+
+        assert len(extended) == len(pipeline_runs), (
+            "extended rows count must match pipeline_runs count"
+        )
+        expected_run_ids = {r.run_id for r in pipeline_runs}
+        actual_run_ids = {r["run_id"] for r in extended}
+        assert actual_run_ids == expected_run_ids, (
+            "extended row run_ids must match pipeline_run run_ids exactly"
+        )
+        # Every extended row must carry the required TestOps-only fields.
+        for row in extended:
+            assert "retry_count" in row
+            assert "team_id" in row
+            assert row.get("org_id") == "test-org"
+
+
 class TestGenerateUsersRespectsOrgId:
     """Regression: ``generate_users(org_id=...)`` MUST stamp the supplied org_id
     onto the Organization row and every Membership/license, so that synthetic

--- a/tests/test_fixtures_testops.py
+++ b/tests/test_fixtures_testops.py
@@ -206,3 +206,107 @@ class TestGenerateCoverageSnapshots:
 
     def test_empty_pipeline_list(self, generator: SyntheticDataGenerator) -> None:
         assert generator.generate_coverage_snapshots([], days=7) == []
+
+
+class TestGeneratePipelineRunExtendedRows:
+    """CHAOS-2173: pipeline extended rows must carry retry_count and team_id."""
+
+    def test_returns_nonempty(self, generator: SyntheticDataGenerator) -> None:
+        rows = generator.generate_pipeline_run_extended_rows(days=7, runs_per_day=3)
+        assert len(rows) > 0
+
+    def test_required_fields_present(self, generator: SyntheticDataGenerator) -> None:
+        rows = generator.generate_pipeline_run_extended_rows(days=7, runs_per_day=3)
+        required = {
+            "repo_id",
+            "run_id",
+            "provider",
+            "status",
+            "started_at",
+            "finished_at",
+        }
+        for row in rows[:10]:
+            assert required.issubset(row.keys()), f"Missing: {required - row.keys()}"
+
+    def test_retry_count_varies(self, generator: SyntheticDataGenerator) -> None:
+        """At least one run should have retry_count > 0 across 30 days (~10% rate)."""
+        rows = generator.generate_pipeline_run_extended_rows(days=30, runs_per_day=5)
+        retry_counts = [row.get("retry_count", 0) for row in rows]
+        assert any(c > 0 for c in retry_counts), (
+            "Expected some runs with retry_count > 0 (approx 10% rate)"
+        )
+
+    def test_team_id_populated_when_teams_assigned(self) -> None:
+        """team_id must be set on rows when the generator has assigned_teams."""
+        from dev_health_ops.models.teams import Team
+
+        teams = [
+            Team(id="t-alpha", name="Alpha", members=["alice@example.com"]),
+            Team(id="t-beta", name="Beta", members=["bob@example.com"]),
+        ]
+        gen = SyntheticDataGenerator(
+            repo_name="acme/demo-app", seed=42, assigned_teams=teams
+        )
+        rows = gen.generate_pipeline_run_extended_rows(days=7, runs_per_day=3)
+        team_ids = [row.get("team_id") for row in rows]
+        assert any(t is not None for t in team_ids), (
+            "Expected at least some runs to have non-NULL team_id"
+        )
+        # All assigned team IDs must come from the known list.
+        valid_ids = {"t-alpha", "t-beta", None}
+        for tid in team_ids:
+            assert tid in valid_ids, f"Unexpected team_id: {tid}"
+
+    def test_compute_gives_nonzero_rerun_rate(self) -> None:
+        """CHAOS-2173: compute_pipeline_metrics_daily must report rerun_rate > 0."""
+        from datetime import date, datetime, timezone
+        from typing import cast
+
+        from dev_health_ops.metrics.compute_testops import (
+            compute_pipeline_metrics_daily,
+        )
+        from dev_health_ops.metrics.testops_schemas import PipelineRunExtendedRow
+        from dev_health_ops.models.teams import Team
+
+        teams = [Team(id="t-alpha", name="Alpha", members=[])]
+        gen = SyntheticDataGenerator(
+            repo_name="acme/metrics-test", seed=7, assigned_teams=teams
+        )
+        target_day = date(2025, 6, 15)
+        # Build synthetic PipelineRunExtendedRow dicts for a controlled single day.
+        rows = [
+            {
+                "repo_id": gen.repo_id,
+                "run_id": "r-001",
+                "provider": "github_actions",
+                "status": "success",
+                "queued_at": datetime(2025, 6, 15, 8, 0, tzinfo=timezone.utc),
+                "started_at": datetime(2025, 6, 15, 8, 5, tzinfo=timezone.utc),
+                "finished_at": datetime(2025, 6, 15, 8, 20, tzinfo=timezone.utc),
+                "retry_count": 0,
+                "team_id": "t-alpha",
+                "org_id": "org-test",
+            },
+            {
+                "repo_id": gen.repo_id,
+                "run_id": "r-002",
+                "provider": "github_actions",
+                "status": "success",
+                "queued_at": datetime(2025, 6, 15, 9, 0, tzinfo=timezone.utc),
+                "started_at": datetime(2025, 6, 15, 9, 5, tzinfo=timezone.utc),
+                "finished_at": datetime(2025, 6, 15, 9, 25, tzinfo=timezone.utc),
+                "retry_count": 2,  # This run was retried.
+                "team_id": "t-alpha",
+                "org_id": "org-test",
+            },
+        ]
+        records = compute_pipeline_metrics_daily(
+            day=target_day,
+            pipeline_runs=cast(list[PipelineRunExtendedRow], rows),
+            job_runs=[],
+            computed_at=datetime(2025, 6, 15, 12, 0, tzinfo=timezone.utc),
+        )
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.rerun_rate == pytest.approx(0.5)  # 1 of 2 runs has retry_count > 0
+        assert rec.team_id == "t-alpha"  # non-NULL team attribution


### PR DESCRIPTION
## Summary

Backend half of the **Govern IA audit** ([CHAOS-2165](https://linear.app/fullchaos/issue/CHAOS-2165)) — the dev-health-ops fixes behind the TestOps surfaces, hardened by a **codex adversarial review**.

## Issues addressed
- **CHAOS-2172** — null-safe `float()` coercion on a NULL ClickHouse `AVG()` in the analytics resolver (the "1 issue" runtime error on `/testops/tests`). `float(row.get("value") or 0)` at the timeseries + breakdown coercion sites.
- **CHAOS-2173** — fixtures now populate pipeline `retry_count` (~10% of runs) + `team_id`, so `rerun_rate` and the pipeline failure-breakdown team attribution are non-zero (no more constant 0% rerun / single "Unattributed" bar). Wired via a **single store-branched `ci_pipeline_runs` insert**: ClickHouse takes the extended-row insert (full record + `retry_count`/`team_id`), Postgres takes the ORM insert.

## Investigation
- **CHAOS-2170** (`change_failure_rate` = 0% across Quality + Incident Correlation): traced compute + org/repo scoping end-to-end — **correct**. The 0% is **stale demo data**; remedy is a `dev-hops fixtures generate --with-metrics` reseed, not code.

## Adversarial-review fix (codex, P2)
- The first 2173 wiring did a *second* ClickHouse insert of the same `(repo_id, run_id)` rows → `ci_daily_rollup_mv` double-counted (the MV fires per insert; ReplacingMergeTree only dedups the table). Replaced with the single branched insert. **MV-source topology verified:** `clickhouse_insert_testops_pipeline_runs` writes the full record to `ci_pipeline_runs` — the exact table `ci_daily_rollup_mv` reads `FROM` — so the MV sees each run once (no double-count, no starvation).

## Verification
**pytest 289 pass** (`-m "not clickhouse"`) · ruff-format clean.

Related: CHAOS-2165 (epic) · CHAOS-2172 / 2173 · CHAOS-2170 · the dev-health-web PR (frontend half).

> Note: the visible effect of 2173 (and 2170) requires a fixtures reseed with `--with-metrics`.
