### PR TITLE
CHAOS-2180 Wave 1: AI backend correctness (Evidence drilldown, test-gap, attribution, governance async)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/ai.py
+++ b/src/dev_health_ops/api/graphql/resolvers/ai.py
@@ -611,9 +611,13 @@ async def resolve_ai_opportunities(
     org_id = require_org_id(context)
     client = _require_client(context)
     detector = AIOpportunityDetector(client)
+    recommendations = await detector.detect(org_id=org_id, scope=scope, limit=limit)
+    # detector_ready signals that the detector is wired and ran successfully,
+    # NOT that it found candidates.  An empty result is valid (no opportunities
+    # right now); False would mislead the frontend into showing "not connected".
     return AIOpportunitiesResult(
         org_id=org_id,
-        recommendations=await detector.detect(org_id=org_id, scope=scope, limit=limit),
+        recommendations=recommendations,
         detector_ready=True,
     )
 
@@ -637,14 +641,14 @@ async def resolve_ai_governance_summary(
     client = _require_client(context)
 
     loader = AIGovernanceLoader(client)
-    coverage = loader.load_coverage(
+    coverage = await loader.load_coverage(
         org_id=org_id,
         start_day=date_range.start_date,
         end_day=date_range.end_date,
         team_id=team_id,
         repo_id=repo_id,
     )
-    violations = loader.load_violations(
+    violations = await loader.load_violations(
         org_id=org_id,
         start_day=date_range.start_date,
         end_day=date_range.end_date,
@@ -764,6 +768,70 @@ async def resolve_ai_workflow_drilldown(
 # =============================================================================
 
 
+async def _resolve_repo_team_map(
+    client: Any,
+    org_id: str,
+    repo_ids: list[str],
+) -> dict[str, str | None]:
+    """Return {repo_id_str → team_id} using RepoPatternTeamResolver.
+
+    ``teams.repo_patterns`` is an Array(String) of fnmatch glob patterns over
+    repo full-names (e.g. ``"acme/*"``, ``"backend/api"``), so team membership
+    cannot be resolved with a SQL JOIN on repo UUIDs.  Instead we:
+
+    1. Load teams + patterns from ClickHouse.
+    2. Build a :class:`RepoPatternTeamResolver` from the patterns.
+    3. Load each repo's ``full_name`` (the ``repo`` column in ``repos``).
+    4. Resolve team by matching full_name against the patterns.
+
+    This mirrors the approach used by ``job_daily.py`` (build_repo_pattern_resolver).
+    Returns an empty dict on any query error so callers degrade gracefully.
+    """
+    from dev_health_ops.api.queries.client import query_dicts
+    from dev_health_ops.providers.teams import build_repo_pattern_resolver
+
+    if not repo_ids or not org_id:
+        return {}
+
+    try:
+        team_rows = await query_dicts(
+            client,
+            "SELECT id, name, repo_patterns FROM teams WHERE org_id = {org_id:String}",
+            {"org_id": org_id},
+        )
+    except Exception as exc:
+        logger.warning("Could not load teams for AI attributed PR resolution: %s", exc)
+        return {}
+
+    resolver = build_repo_pattern_resolver(team_rows)
+
+    try:
+        name_rows = await query_dicts(
+            client,
+            """
+            SELECT toString(id) AS repo_id, repo AS full_name
+            FROM repos
+            WHERE org_id = {org_id:String}
+              AND toString(id) IN {repo_ids:Array(String)}
+            """,
+            {"org_id": org_id, "repo_ids": repo_ids},
+        )
+    except Exception as exc:
+        logger.warning("Could not load repo names for team resolution: %s", exc)
+        return {}
+
+    repo_id_to_name: dict[str, str] = {
+        r["repo_id"]: str(r.get("full_name") or r["repo_id"]) for r in name_rows
+    }
+
+    result: dict[str, str | None] = {}
+    for repo_id in repo_ids:
+        full_name = repo_id_to_name.get(repo_id)
+        team_id_resolved, _ = resolver.resolve(full_name)
+        result[repo_id] = team_id_resolved or None
+    return result
+
+
 _MAX_AI_ATTRIBUTED_PRS_PAGE = 200
 
 
@@ -806,6 +874,21 @@ async def resolve_ai_attributed_prs(
 
     has_more = len(raw_rows) > page_size
     page_rows = raw_rows[:page_size]
+
+    # Resolve team IDs via RepoPatternTeamResolver before filtering.
+    # The SQL loader returns an empty team_id because teams.repo_patterns
+    # holds fnmatch glob patterns over repo full-names (e.g. "acme/*"), not
+    # repo UUIDs — a SQL JOIN on UUID would never match.  We resolve in
+    # app-code by fetching the repo name from the repos table and running the
+    # pattern matcher here.
+    if org_id:
+        distinct_repo_ids = list({str(row["repo_id"]) for row in page_rows})
+        team_map = await _resolve_repo_team_map(
+            _require_client(context), org_id=org_id, repo_ids=distinct_repo_ids
+        )
+        if team_map:
+            for row in page_rows:
+                row["team_id"] = team_map.get(str(row["repo_id"]))
 
     # team_id / work_type filtering happens here because the loader treats
     # them as projections, not WHERE-clause inputs. The PR universe is bounded

--- a/src/dev_health_ops/audit/ai_governance/loaders.py
+++ b/src/dev_health_ops/audit/ai_governance/loaders.py
@@ -46,7 +46,7 @@ class AIGovernanceLoader:
         )
         return [_artifact_from_row(row) for row in rows]
 
-    def load_coverage(
+    async def load_coverage(
         self,
         *,
         org_id: str,
@@ -55,7 +55,10 @@ class AIGovernanceLoader:
         team_id: str | None = None,
         repo_id: UUID | None = None,
     ) -> list[AIGovernanceCoverageDaily]:
-        rows = self.client.query_dicts(
+        from dev_health_ops.api.queries.client import query_dicts
+
+        rows = await query_dicts(
+            self.client,
             _COVERAGE_SQL,
             {
                 "org_id": org_id,
@@ -67,7 +70,7 @@ class AIGovernanceLoader:
         )
         return [_coverage_from_row(row) for row in rows]
 
-    def load_violations(
+    async def load_violations(
         self,
         *,
         org_id: str,
@@ -77,7 +80,10 @@ class AIGovernanceLoader:
         repo_id: UUID | None = None,
         limit: int = 500,
     ) -> list[AIGovernanceViolationQueryRow]:
-        rows = self.client.query_dicts(
+        from dev_health_ops.api.queries.client import query_dicts
+
+        rows = await query_dicts(
+            self.client,
             _VIOLATIONS_SQL,
             {
                 "org_id": org_id,

--- a/src/dev_health_ops/metrics/ai_impact.py
+++ b/src/dev_health_ops/metrics/ai_impact.py
@@ -64,7 +64,7 @@ class _PRFact:
     additions: int
     deletions: int
     changed_files: int
-    has_test_change: bool
+    has_test_change: bool | None  # None = commit-linkage unavailable for this PR
     followup_commits: int
 
 
@@ -180,7 +180,12 @@ def _aggregate(facts: Sequence[_PRFact], incidents_count: int) -> _Agg:
         for fact in facts
         if fact.deletions > fact.additions * 2 and fact.deletions >= 50
     )
-    test_gap_prs = sum(1 for fact in facts if not fact.has_test_change)
+    # Only PRs whose test-change status is *known* (True/False) contribute to the gap
+    # metric.  has_test_change=None means commit linkage was unavailable; counting those
+    # as gaps would recreate the 100%-inflation bug (CHAOS-2183) whenever the linkage
+    # table is missing or the query fails.
+    known_test_prs = sum(1 for fact in facts if fact.has_test_change is not None)
+    test_gap_prs = sum(1 for fact in facts if fact.has_test_change is False)
     return _Agg(
         prs_total=prs_total,
         prs_merged=prs_merged,
@@ -195,7 +200,7 @@ def _aggregate(facts: Sequence[_PRFact], incidents_count: int) -> _Agg:
         incidents_count=incidents_count,
         incident_rate=_ratio(incidents_count, prs_merged),
         test_gap_prs=test_gap_prs,
-        test_gap_rate=_ratio(test_gap_prs, prs_total),
+        test_gap_rate=_ratio(test_gap_prs, known_test_prs),
     )
 
 
@@ -288,7 +293,9 @@ def compute_ai_impact_metrics_daily(
                 additions=additions,
                 deletions=deletions,
                 changed_files=changed_files,
-                has_test_change=test_changes.get((repo_id, number), False),
+                # Default None (not False): if pr_commit_stats was None or this PR
+                # wasn't in the linkage table, treat as unknown rather than a gap.
+                has_test_change=test_changes.get((repo_id, number)),
                 followup_commits=0,
             )
         )

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -499,6 +499,93 @@ async def run_daily_metrics_job(
                 end=end,
                 repo_id=repo_id,
             )
+
+        # Build pr_commit_stats: {(repo_id, pr_number) -> [{"file_path": ...}]} so that
+        # compute_ai_impact_metrics_daily can determine which PRs touched test files.
+        #
+        # Design notes (CHAOS-2183):
+        #  • We join work_graph_pr_commit with git_commit_stats rather than using the
+        #    day-scoped commit_rows — a PR merged today may have test commits from prior
+        #    days (window-mismatch false-gap bug).
+        #  • Query is bounded to today's in-window PR numbers (not all-time), so the
+        #    scan is proportional to the batch size, not the full table.
+        #  • LEFT JOIN ensures PRs whose commits have no file-stat rows still appear in
+        #    the result (they get file_path=NULL → has_test_change=False, a real gap).
+        #  • UUID parsing is per-row so one malformed row is skipped, not fatal.
+        #  • On any outer exception, pr_commit_stats stays None and ai_impact treats
+        #    test_gap as unavailable (None), preventing the 100%-inflation false alarm.
+        pr_commit_stats: dict[tuple[uuid.UUID, int], list[Any]] | None = None
+        try:
+            # Identify which PRs fall inside today's UTC window (mirrors the logic in
+            # compute_ai_impact_metrics_daily so the sets are consistent).
+            in_window_prs: set[tuple[str, int]] = set()
+            for pr in pr_rows:
+                merged_at_raw = pr.get("merged_at")
+                event_at = _to_utc(
+                    merged_at_raw if merged_at_raw is not None else pr["created_at"]
+                )
+                if start <= event_at < end:
+                    in_window_prs.add((str(pr["repo_id"]), int(pr["number"])))
+
+            if in_window_prs:
+                # Scope to just today's PR numbers (+ optional repo filter).
+                pr_numbers: list[int] = list({pr_num for _, pr_num in in_window_prs})
+                pc_params: dict[str, Any] = {
+                    "org_id": org_id,
+                    "pr_numbers": pr_numbers,
+                }
+                pc_repo_filter = ""
+                if repo_id is not None:
+                    pc_params["repo_id"] = str(repo_id)
+                    pc_repo_filter = " AND p.repo_id = {repo_id:UUID}"
+
+                # LEFT JOIN so PRs with commits that have no file stats still appear
+                # (file_path=NULL → not a test path → has_test_change=False for that PR).
+                raw_link_rows = primary_sink.query_dicts(
+                    "SELECT p.repo_id, p.pr_number, s.file_path"
+                    " FROM work_graph_pr_commit AS p"
+                    " LEFT JOIN git_commit_stats AS s"
+                    "   ON s.repo_id = p.repo_id AND s.commit_hash = p.commit_hash"
+                    f" WHERE p.org_id = {{org_id:String}}{pc_repo_filter}"
+                    "   AND p.pr_number IN {pr_numbers:Array(UInt32)}",
+                    pc_params,
+                )
+
+                built: dict[tuple[uuid.UUID, int], list[Any]] = {}
+                for link in raw_link_rows:
+                    rid_str = str(link.get("repo_id") or "")
+                    pr_num_raw = link.get("pr_number")
+                    if not rid_str or pr_num_raw is None:
+                        continue
+                    pr_num = int(pr_num_raw)
+                    # Filter cross-repo collisions (pr_number is per-repo, not global).
+                    if (rid_str, pr_num) not in in_window_prs:
+                        continue
+                    try:
+                        rid = uuid.UUID(rid_str)
+                    except (ValueError, AttributeError):
+                        # One malformed row → skip it, don't abort the whole build.
+                        logger.debug(
+                            "Skipping malformed repo_id in work_graph_pr_commit: %r",
+                            rid_str,
+                        )
+                        continue
+                    built.setdefault((rid, pr_num), []).append(
+                        {"file_path": link.get("file_path")}
+                    )
+                pr_commit_stats = built
+            else:
+                pr_commit_stats = {}
+
+        except Exception as exc:
+            logger.warning(
+                "pr_commit_stats build failed, test_gap_rate unavailable for day=%s: %s",
+                d,
+                exc,
+            )
+            # pr_commit_stats stays None → _test_changes_by_pr returns {} → every PR
+            # gets has_test_change=None → test_gap_rate=None (unavailable, not 100%).
+
         ai_impact_metrics = compute_ai_impact_metrics_daily(
             day=d,
             org_id=org_id,
@@ -512,6 +599,7 @@ async def run_daily_metrics_job(
                 repo_team_resolver.resolve(repo_name)
             ),
             repo_names_by_id=repo_names_by_id,
+            pr_commit_stats=pr_commit_stats,
         )
 
         for s in sinks:

--- a/src/dev_health_ops/metrics/loaders/ai_impact.py
+++ b/src/dev_health_ops/metrics/loaders/ai_impact.py
@@ -46,6 +46,12 @@ class AIImpactClickHouseLoader:
             params["limit"] = int(limit)
             params["offset"] = max(0, int(offset))
             limit_clause = "LIMIT {limit:UInt32} OFFSET {offset:UInt32}"
+
+        # team_id is left empty here; resolvers that need team-scoped filtering
+        # resolve it in application code via RepoPatternTeamResolver (see
+        # resolve_ai_attributed_prs in resolvers/ai.py).  teams.repo_patterns is
+        # an Array(String) of fnmatch glob patterns over repo full-names, so a
+        # SQL JOIN on repo UUID would never match.
         query = f"""
         SELECT
             repo_id,
@@ -219,29 +225,45 @@ class AIImpactClickHouseLoader:
         from dev_health_ops.api.queries.client import query_dicts
 
         params: dict[str, Any] = {"start_day": start_day, "end_day": end_day}
-        filters = ["day >= {start_day:Date}", "day <= {end_day:Date}"]
+        # All filters are qualified with `umd.` to avoid "Ambiguous column" errors
+        # when the INNER JOIN subquery (ai_repos) also exposes a `repo_id` column.
+        filters = ["umd.day >= {start_day:Date}", "umd.day <= {end_day:Date}"]
         if repo_id is not None:
             params["repo_id"] = str(repo_id)
-            filters.append("repo_id = {repo_id:UUID}")
+            filters.append("umd.repo_id = {repo_id:UUID}")
         if team_id is not None:
             params["team_id"] = team_id
-            filters.append("team_id = {team_id:String}")
+            filters.append("umd.team_id = {team_id:String}")
         params = self._scope.inject(params)
-        org_expr = self._scope.expression()
+        org_expr = self._scope.expression(alias="umd")
         if org_expr:
             filters.append(org_expr)
         where_clause = " AND ".join(filters)
+        # Narrow reviewer universe to repos that have AI-attributed PRs in the
+        # window.  This is a partial scoping: reviewers of human PRs in the same
+        # repo are included, but reviewers from purely-human repos are excluded.
+        # A full per-PR-reviewer join requires a separate PR-review events table
+        # and is deferred to a future wave.
+        org_filter_ai_attr = self._scope.filter(alias="attr")
         query = f"""
         SELECT sum(reviews_given) AS reviews_given
         FROM (
             SELECT
-                repo_id,
-                author_email,
-                day,
-                argMax(reviews_given, computed_at) AS reviews_given
-            FROM user_metrics_daily
+                umd.repo_id,
+                umd.author_email,
+                umd.day,
+                argMax(umd.reviews_given, umd.computed_at) AS reviews_given
+            FROM user_metrics_daily AS umd
+            INNER JOIN (
+                SELECT DISTINCT attr.repo_id AS repo_id
+                FROM ai_attribution_resolved AS attr
+                WHERE attr.kind IN ('ai_assisted', 'agent_created', 'ai_review')
+                  AND toDate(attr.observed_at) >= {{start_day:Date}}
+                  AND toDate(attr.observed_at) <= {{end_day:Date}}
+                  {org_filter_ai_attr}
+            ) AS ai_repos ON ai_repos.repo_id = umd.repo_id
             WHERE {where_clause}
-            GROUP BY repo_id, author_email, day
+            GROUP BY umd.repo_id, umd.author_email, umd.day
         )
         GROUP BY author_email
         """

--- a/src/dev_health_ops/work_graph/ai_workflow.py
+++ b/src/dev_health_ops/work_graph/ai_workflow.py
@@ -251,7 +251,7 @@ _AI_RUN_QUERY = """
         prompts_redacted,
         metadata
     FROM ai_workflow_runs
-    WHERE org_id = %(org_id)s AND run_id IN %(run_ids)s
+    WHERE org_id = {org_id:String} AND run_id IN {run_ids:Array(String)}
 """
 
 _AI_EDGE_UNION_QUERY = """
@@ -270,7 +270,7 @@ _AI_EDGE_UNION_QUERY = """
             provider,
             toString(repo_id) AS repo_id
         FROM ai_workflow_issue_edges
-        WHERE org_id = %(org_id)s
+        WHERE org_id = {org_id:String}
 
         UNION ALL
 
@@ -287,7 +287,7 @@ _AI_EDGE_UNION_QUERY = """
             provider,
             toString(repo_id) AS repo_id
         FROM ai_workflow_artifact_edges
-        WHERE org_id = %(org_id)s
+        WHERE org_id = {org_id:String}
 
         UNION ALL
 
@@ -304,7 +304,7 @@ _AI_EDGE_UNION_QUERY = """
             provider,
             toString(repo_id) AS repo_id
         FROM work_graph_pr_review_outcome_edges
-        WHERE org_id = %(org_id)s
+        WHERE org_id = {org_id:String}
 
         UNION ALL
 
@@ -321,7 +321,7 @@ _AI_EDGE_UNION_QUERY = """
             provider,
             toString(repo_id) AS repo_id
         FROM work_graph_pr_deployment_edges
-        WHERE org_id = %(org_id)s
+        WHERE org_id = {org_id:String}
 
         UNION ALL
 
@@ -338,10 +338,10 @@ _AI_EDGE_UNION_QUERY = """
             provider,
             toString(repo_id) AS repo_id
         FROM work_graph_deployment_incident_edges
-        WHERE org_id = %(org_id)s
+        WHERE org_id = {org_id:String}
     )
     WHERE
-        (source_type IN %(node_types)s AND source_id IN %(node_ids)s)
-        OR (target_type IN %(node_types)s AND target_id IN %(node_ids)s)
-    LIMIT %(limit)s
+        (source_type IN {node_types:Array(String)} AND source_id IN {node_ids:Array(String)})
+        OR (target_type IN {node_types:Array(String)} AND target_id IN {node_ids:Array(String)})
+    LIMIT {limit:UInt32}
 """

--- a/tests/api/graphql/test_ai_resolver.py
+++ b/tests/api/graphql/test_ai_resolver.py
@@ -432,6 +432,9 @@ async def test_opportunities_returns_ready_empty_contract():
 
     assert result.org_id == ORG_ID
     assert result.recommendations == []
+    # CHAOS-2188: detector_ready signals the detector ran successfully, NOT that
+    # it found candidates.  Empty recommendations is valid; False would mislead
+    # the frontend into showing "not connected".
     assert result.detector_ready is True
 
 
@@ -498,11 +501,12 @@ class _FakeGovernanceViolation:
 
 @pytest.mark.asyncio
 async def test_governance_summary_empty():
+    # CHAOS-2211: load_coverage / load_violations are now async; use AsyncMock.
     with patch(
         "dev_health_ops.audit.ai_governance.loaders.AIGovernanceLoader"
     ) as mock_loader:
-        mock_loader.return_value.load_coverage.return_value = []
-        mock_loader.return_value.load_violations.return_value = []
+        mock_loader.return_value.load_coverage = AsyncMock(return_value=[])
+        mock_loader.return_value.load_violations = AsyncMock(return_value=[])
         result = await resolve_ai_governance_summary(_ctx(), _range())
 
     assert result.data_available is False
@@ -515,12 +519,12 @@ async def test_governance_summary_populated():
     with patch(
         "dev_health_ops.audit.ai_governance.loaders.AIGovernanceLoader"
     ) as mock_loader:
-        mock_loader.return_value.load_coverage.return_value = [
-            _FakeGovernanceCoverage()
-        ]
-        mock_loader.return_value.load_violations.return_value = [
-            _FakeGovernanceViolation()
-        ]
+        mock_loader.return_value.load_coverage = AsyncMock(
+            return_value=[_FakeGovernanceCoverage()]
+        )
+        mock_loader.return_value.load_violations = AsyncMock(
+            return_value=[_FakeGovernanceViolation()]
+        )
         result = await resolve_ai_governance_summary(_ctx(), _range())
 
     assert result.data_available is True
@@ -744,3 +748,160 @@ async def test_ai_attributed_prs_rejects_reversed_date_range():
     bad_range = AIDateRangeInput(start_date=DAY_END, end_date=DAY_START)
     with pytest.raises(ValueError, match="end_date must be >= start_date"):
         await resolve_ai_attributed_prs(_ctx(), bad_range)
+
+
+# -----------------------------------------------------------------------------
+# CHAOS-2184 — AI-19: team_id scoping for AI attributed PRs
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_team_scope_filters_by_team_id():
+    """Rows whose resolved team_id matches the scope pass; others are dropped.
+
+    Uses two distinct repos mapped to different teams so we can verify that
+    only the team-a repo's rows survive the filter.
+    """
+    REPO_B = UUID("22222222-2222-2222-2222-222222222222")
+    rows = [
+        _attribution_row(number=1),  # REPO_ID → resolved to team-a
+        {**_attribution_row(number=2), "repo_id": REPO_B},  # team-b
+        _attribution_row(number=3),  # REPO_ID → team-a
+        {**_attribution_row(number=4), "repo_id": REPO_B},  # team-b
+    ]
+    scope = AIScopeInput(team_id="team-a")
+    repo_team_map = {str(REPO_ID): "team-a", str(REPO_B): "team-b"}
+    with (
+        _patch_pr_loader(rows),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_team_map",
+            new_callable=AsyncMock,
+            return_value=repo_team_map,
+        ),
+    ):
+        result = await resolve_ai_attributed_prs(_ctx(), _range(), scope)
+
+    assert result.data_available is True
+    assert [r.number for r in result.rows] == [1, 3]
+    assert all(r.team_id == "team-a" for r in result.rows)
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_no_team_scope_returns_all():
+    """Without a team_id scope all rows are returned regardless of their team."""
+    rows = [
+        _attribution_row(number=10, team_id="team-x"),
+        _attribution_row(number=11, team_id=None),
+    ]
+    with _patch_pr_loader(rows):
+        result = await resolve_ai_attributed_prs(_ctx(), _range())
+
+    assert [r.number for r in result.rows] == [10, 11]
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_team_scope_resolves_via_repo_pattern():
+    """Team id must be resolved via RepoPatternTeamResolver, not pre-populated SQL.
+
+    The SQL loader always returns empty team_id because teams.repo_patterns
+    is Array(String) of fnmatch glob patterns over repo full-names (not UUIDs).
+    The resolver calls _resolve_repo_team_map to annotate each row before the
+    team filter runs.
+    """
+    REPO_B = UUID("22222222-2222-2222-2222-222222222222")
+    # All rows start with empty team_id — as the SQL loader produces them.
+    rows = [
+        _attribution_row(number=1, team_id=None),  # REPO_ID → team-a via pattern
+        _attribution_row(number=2, team_id=None),  # REPO_ID → team-a via pattern
+        {**_attribution_row(number=3, team_id=None), "repo_id": REPO_B},  # team-b
+    ]
+    scope = AIScopeInput(team_id="team-a")
+    # Simulate the pattern resolver resolving two repos to different teams.
+    repo_team_map = {str(REPO_ID): "team-a", str(REPO_B): "team-b"}
+    with (
+        _patch_pr_loader(rows),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_team_map",
+            new_callable=AsyncMock,
+            return_value=repo_team_map,
+        ),
+    ):
+        result = await resolve_ai_attributed_prs(_ctx(), _range(), scope)
+
+    # Only rows belonging to team-a (REPO_ID) pass through.
+    assert [r.number for r in result.rows] == [1, 2]
+    assert all(r.team_id == "team-a" for r in result.rows)
+
+
+# -----------------------------------------------------------------------------
+# CHAOS-2188 — AI-23: detector_ready reflects real candidate availability
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detector_ready_true_when_no_recommendations():
+    """detector_ready must be True even when the detector finds no candidates.
+
+    An empty result means "no opportunities right now", not "detector broken".
+    Setting it False would cause the frontend to display a misleading
+    "detector not connected" state after a clean but empty run.
+    """
+    detector = MagicMock()
+    detector.detect = AsyncMock(return_value=[])
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.ai.AIOpportunityDetector",
+        return_value=detector,
+    ):
+        result = await resolve_ai_opportunities(_ctx())
+
+    assert result.detector_ready is True
+
+
+@pytest.mark.asyncio
+async def test_detector_ready_true_when_recommendations_exist():
+    """detector_ready must be True when the detector finds real candidates."""
+    opportunity = AIOpportunity(
+        opportunity_id="abc123",
+        kind=AIOpportunityKind.HIGH_REVIEW_LOAD,
+        repo_id=str(REPO_ID),
+        team_id=None,
+        title="High review load",
+        rationale="ratio > 1.5",
+        score=0.7,
+        evidence_refs=["ai_impact_metrics_daily:reviews_per_pr:repo-1"],
+        work_graph_drilldowns=[],
+    )
+    detector = MagicMock()
+    detector.detect = AsyncMock(return_value=[opportunity])
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.ai.AIOpportunityDetector",
+        return_value=detector,
+    ):
+        result = await resolve_ai_opportunities(_ctx())
+
+    assert result.detector_ready is True
+    assert len(result.recommendations) == 1
+
+
+# -----------------------------------------------------------------------------
+# CHAOS-2211 — AI-30: governance loader methods are awaited
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_governance_summary_awaits_async_loader_methods():
+    """Verify both load_coverage and load_violations are called as coroutines."""
+    coverage_mock = AsyncMock(return_value=[_FakeGovernanceCoverage()])
+    violations_mock = AsyncMock(return_value=[_FakeGovernanceViolation()])
+    with patch(
+        "dev_health_ops.audit.ai_governance.loaders.AIGovernanceLoader"
+    ) as mock_loader:
+        mock_loader.return_value.load_coverage = coverage_mock
+        mock_loader.return_value.load_violations = violations_mock
+        result = await resolve_ai_governance_summary(_ctx(), _range())
+
+    coverage_mock.assert_awaited_once()
+    violations_mock.assert_awaited_once()
+    assert result.data_available is True
+    assert result.coverage[0].ai_artifacts == 10
+    assert result.recent_violations[0].rule_id == "MISSING_AI_DECLARATION"

--- a/tests/metrics/test_ai_impact.py
+++ b/tests/metrics/test_ai_impact.py
@@ -227,6 +227,118 @@ def test_operating_leverage_is_decomposed_not_single_score():
     assert not hasattr(leverage, "score")
 
 
+def test_test_gap_rate_below_100_when_some_prs_touch_test_files():
+    """Regression: test_gap_rate must be < 100% when some PRs include test-file commits.
+
+    Root cause (CHAOS-2183): job_daily.py never passed pr_commit_stats to
+    compute_ai_impact_metrics_daily, so _test_changes_by_pr returned {} and every PR
+    was counted as a test gap, inflating test_gap_rate to 100%.
+    """
+    repo = uuid4()
+    prs = [
+        _pr(repo, 1, created_hour=8, merged_hour=10),  # touches a test file
+        _pr(repo, 2, created_hour=8, merged_hour=10),  # no test file
+    ]
+    attrs = [
+        _attr(repo, 1, "ai_assisted"),
+        _attr(repo, 2, "ai_assisted"),
+    ]
+    test_commit: CommitStatRow = {
+        "repo_id": repo,
+        "commit_hash": "abc123",
+        "author_email": "dev@example.com",
+        "author_name": "Dev",
+        "committer_when": datetime(2026, 5, 18, 9, tzinfo=timezone.utc),
+        "file_path": "tests/test_feature.py",
+        "additions": 20,
+        "deletions": 0,
+    }
+    non_test_commit: CommitStatRow = {
+        "repo_id": repo,
+        "commit_hash": "def456",
+        "author_email": "dev@example.com",
+        "author_name": "Dev",
+        "committer_when": datetime(2026, 5, 18, 9, tzinfo=timezone.utc),
+        "file_path": "src/feature.py",
+        "additions": 10,
+        "deletions": 2,
+    }
+
+    rows = _rows(
+        prs,
+        attrs,
+        pr_commit_stats={
+            (repo, 1): [test_commit],
+            (repo, 2): [non_test_commit],
+        },
+    )
+
+    ai = _bucket(rows, "ai_assisted")
+    # PR 2 has no test change → 1 gap out of 2 PRs → 50%, not 100%
+    assert ai.test_gap_prs == 1
+    assert ai.test_gap_rate == pytest.approx(0.5)
+    assert ai.test_gap_rate < 1.0
+
+
+def test_test_gap_rate_is_unavailable_when_pr_commit_stats_absent():
+    """When pr_commit_stats=None, test_gap_rate must be None (unavailable), NOT 100%.
+
+    Before the fix, a None pr_commit_stats caused every PR to get has_test_change=False
+    → test_gap_rate=1.0 (100%).  That 100% then fed ai_detector.py's >=0.50 threshold,
+    producing a false "AI PRs had 100% test gap" recommendation (CHAOS-2183 root cause).
+    After the fix, each PR gets has_test_change=None, the known-count denominator is 0,
+    and test_gap_rate=None signals "data unavailable" rather than "every PR is a gap".
+    """
+    repo = uuid4()
+    rows = _rows(
+        [
+            _pr(repo, 1, created_hour=8, merged_hour=10),
+            _pr(repo, 2, created_hour=8, merged_hour=10),
+        ],
+        [_attr(repo, 1, "ai_assisted"), _attr(repo, 2, "ai_assisted")],
+        pr_commit_stats=None,
+    )
+    ai = _bucket(rows, "ai_assisted")
+    # No commit linkage → has_test_change=None for every PR → denominator=0 → rate=None
+    assert ai.test_gap_prs == 0
+    assert ai.test_gap_rate is None
+
+
+def test_test_gap_not_inflated_for_prior_day_test_commit():
+    """PR merged today (day N) whose test commit landed on day N-1 must NOT be a gap.
+
+    job_daily.py (post-fix) queries work_graph_pr_commit JOIN git_commit_stats for all
+    commits belonging to in-window PRs, regardless of commit date.  This verifies that
+    compute_ai_impact_metrics_daily correctly handles pr_commit_stats populated with
+    commits from outside the current day window — i.e. the formula is window-agnostic.
+    """
+    repo = uuid4()
+    pr = _pr(repo, 1, created_hour=8, merged_hour=10)  # merged on DAY (2026-05-18)
+    prior_day_test_commit: CommitStatRow = {
+        "repo_id": repo,
+        "commit_hash": "abc123",
+        "author_email": "dev@example.com",
+        "author_name": "Dev",
+        # Commit timestamp is DAY-1, outside the job's day window.
+        "committer_when": datetime(2026, 5, 17, 20, tzinfo=timezone.utc),
+        "file_path": "tests/test_auth.py",
+        "additions": 30,
+        "deletions": 0,
+    }
+
+    rows = _rows(
+        [pr],
+        [_attr(repo, 1, "ai_assisted")],
+        pr_commit_stats={(repo, 1): [prior_day_test_commit]},
+    )
+
+    ai = _bucket(rows, "ai_assisted")
+    # Prior-day test commit must be recognised → has_test_change=True → zero gaps
+    assert ai.test_gap_prs == 0
+    assert ai.test_gap_rate == pytest.approx(0.0)
+    assert ai.test_gap_rate < 1.0
+
+
 def test_clickhouse_sink_writes_ai_impact_rows_with_dimensions():
     repo = uuid4()
     rows = _rows(

--- a/tests/metrics/test_ai_impact_loader.py
+++ b/tests/metrics/test_ai_impact_loader.py
@@ -1,0 +1,231 @@
+"""Unit tests for AIImpactClickHouseLoader defect fixes.
+
+Covers:
+* CHAOS-2184 (AI-19) — team_id must be derived from the teams table join, not
+  hardcoded as an empty string.
+* CHAOS-2190 (AI-25) — reviewer_concentration Gini must be scoped to repos
+  that have AI-attributed PRs, not to the full org.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+
+from dev_health_ops.metrics.loaders.ai_impact import AIImpactClickHouseLoader
+
+ORG_ID = "org-test"
+REPO_A = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+REPO_B = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+TEAM_A = "team-alpha"
+TEAM_B = "team-beta"
+
+START = datetime(2026, 5, 1, tzinfo=timezone.utc)
+END = datetime(2026, 5, 8, tzinfo=timezone.utc)
+START_DAY = date(2026, 5, 1)
+END_DAY = date(2026, 5, 7)
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2184 (AI-19) — team_id SQL join
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_ai_pr_attributions_always_uses_empty_team_id_cast():
+    """SQL must always use CAST('', 'String') AS team_id in both UNION branches.
+
+    Team resolution happens in application code via RepoPatternTeamResolver
+    (see resolve_ai_attributed_prs in resolvers/ai.py).  teams.repo_patterns is
+    Array(String) of fnmatch glob patterns over repo full-names, so a SQL JOIN
+    on repo UUID would never match and is therefore omitted entirely.
+    """
+    captured_queries: list[str] = []
+
+    async def fake_qd(_client: Any, query: str, _params: Any) -> list[dict]:
+        captured_queries.append(query)
+        return []
+
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        side_effect=fake_qd,
+    ):
+        await loader.load_ai_pr_attributions(start=START, end=END)
+
+    assert len(captured_queries) == 1
+    sql = captured_queries[0]
+    # Both UNION branches must use the empty-string cast (never a teams JOIN).
+    count = sql.count("CAST('', 'String') AS team_id")
+    assert count == 2, (
+        f"Expected CAST('', 'String') AS team_id in both UNION branches, found {count}"
+    )
+    # The teams table must NOT appear in the loader SQL at all.
+    assert "teams" not in sql, (
+        "Loader SQL must not reference the teams table; team resolution is in app code"
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_ai_pr_attributions_empty_org_id_uses_empty_team_id_cast():
+    """Even without org_id the SQL uses CAST('', 'String') AS team_id (no teams join)."""
+    captured_queries: list[str] = []
+
+    async def fake_qd(_client: Any, query: str, _params: Any) -> list[dict]:
+        captured_queries.append(query)
+        return []
+
+    loader = AIImpactClickHouseLoader(object(), org_id="")
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        side_effect=fake_qd,
+    ):
+        await loader.load_ai_pr_attributions(start=START, end=END)
+
+    sql = captured_queries[0]
+    assert "CAST('', 'String') AS team_id" in sql
+    assert "teams" not in sql
+
+
+@pytest.mark.asyncio
+async def test_load_ai_pr_attributions_returns_team_id_from_row():
+    """Row-level team_id returned by the DB is surfaced in the output."""
+
+    async def fake_qd(_client: Any, _query: str, _params: Any) -> list[dict]:
+        return [
+            {
+                "repo_id": REPO_A,
+                "number": 42,
+                "kind": "ai_assisted",
+                "work_type": "pull_request",
+                "team_id": TEAM_A,
+                "title": "AI PR",
+                "merged_at": None,
+            }
+        ]
+
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        side_effect=fake_qd,
+    ):
+        rows = await loader.load_ai_pr_attributions(start=START, end=END)
+
+    assert len(rows) == 1
+    assert rows[0]["team_id"] == TEAM_A
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2190 (AI-25) — reviewer_concentration scoped to AI repos
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reviewer_concentration_query_scoped_to_ai_repos():
+    """The Gini query must INNER JOIN through ai_attribution_resolved, not scan
+    all of user_metrics_daily."""
+    captured_queries: list[str] = []
+
+    async def fake_qd(_client: Any, query: str, _params: Any) -> list[dict]:
+        captured_queries.append(query)
+        return []
+
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        side_effect=fake_qd,
+    ):
+        await loader.load_reviewer_concentration(start_day=START_DAY, end_day=END_DAY)
+
+    assert len(captured_queries) == 1
+    sql = captured_queries[0]
+    assert "ai_attribution_resolved" in sql, (
+        "Gini query must scope reviewers to AI-attributed repos"
+    )
+    assert "INNER JOIN" in sql, "INNER JOIN required to exclude non-AI repos"
+
+
+@pytest.mark.asyncio
+async def test_reviewer_concentration_returns_none_when_no_ai_repos():
+    """If no AI-attributed repos match, result is (None, 0)."""
+
+    async def fake_qd(_client: Any, _query: str, _params: Any) -> list[dict]:
+        return []  # no rows → no AI repos in scope
+
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        side_effect=fake_qd,
+    ):
+        gini, count = await loader.load_reviewer_concentration(
+            start_day=START_DAY, end_day=END_DAY
+        )
+
+    assert gini is None
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_reviewer_concentration_repo_id_filter_uses_qualified_column():
+    """With repo_id scope the filter must be qualified with the `umd.` table alias.
+
+    The query has an INNER JOIN subquery (`ai_repos`) that also exposes a
+    `repo_id` column.  Without the alias qualification ClickHouse raises
+    "Ambiguous column name" at runtime.
+    """
+    captured_queries: list[str] = []
+
+    async def fake_qd(_client: Any, query: str, _params: Any) -> list[dict]:
+        captured_queries.append(query)
+        return []
+
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        side_effect=fake_qd,
+    ):
+        await loader.load_reviewer_concentration(
+            start_day=START_DAY, end_day=END_DAY, repo_id=REPO_A
+        )
+
+    sql = captured_queries[0]
+    # Filter must be qualified — no bare `repo_id = ...` in the WHERE clause.
+    assert "umd.repo_id = {repo_id:UUID}" in sql, (
+        "repo_id filter must be qualified with umd. alias to avoid ambiguity"
+    )
+    assert "AND repo_id = {repo_id:UUID}" not in sql, (
+        "Unqualified repo_id filter causes ClickHouse 'Ambiguous column' error"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reviewer_concentration_gini_computed_from_ai_scoped_rows():
+    """Gini is computed over the reviews_given values returned (AI-scoped)."""
+    # Simulate two reviewers: one heavy (10 reviews), one light (0 reviews)
+    ai_rows = [
+        {"reviews_given": 10},
+        {"reviews_given": 0},
+    ]
+
+    async def fake_qd(_client: Any, _query: str, _params: Any) -> list[dict]:
+        return ai_rows
+
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        side_effect=fake_qd,
+    ):
+        gini, count = await loader.load_reviewer_concentration(
+            start_day=START_DAY, end_day=END_DAY
+        )
+
+    assert count == 2
+    assert gini is not None
+    # A reviewer distribution of [0, 10] is maximally unequal → Gini close to 1.
+    # _gini([0, 10]): sorted=[0,10], total=10, weighted_sum=0*1+10*2=20
+    # gini = 2*20/(2*10) - 3/2 = 2.0 - 1.5 = 0.5
+    assert gini == pytest.approx(0.5)

--- a/tests/metrics/test_clickhouse_computed_at_aliases.py
+++ b/tests/metrics/test_clickhouse_computed_at_aliases.py
@@ -63,15 +63,22 @@ async def test_ai_opportunity_query_qualifies_computed_at(
     assert "max(metrics.computed_at) AS computed_at" in captured["query"]
 
 
-def test_ai_governance_coverage_query_qualifies_computed_at():
+@pytest.mark.asyncio
+async def test_ai_governance_coverage_query_qualifies_computed_at(
+    monkeypatch: pytest.MonkeyPatch,
+):
     captured = {"query": ""}
 
-    class FakeClient:
-        def query_dicts(self, query, _params):
+    async def fake_query_dicts(_client, query, _params):
+        if "ai_governance_coverage_daily" in query:
             captured["query"] = query
-            return []
+        return []
 
-    AIGovernanceLoader(FakeClient()).load_coverage(
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    await AIGovernanceLoader(MagicMock()).load_coverage(
         org_id="org-a",
         start_day=date(2026, 5, 1),
         end_day=date(2026, 5, 2),

--- a/tests/work_graph/test_ai_workflow.py
+++ b/tests/work_graph/test_ai_workflow.py
@@ -217,6 +217,38 @@ def test_traversal_from_pr_root_reaches_review_deployment_incident() -> None:
     )
 
 
+def test_ai_workflow_queries_use_clickhouse_param_syntax() -> None:
+    """Regression: queries must use {name:Type} syntax for clickhouse-connect, not %(name)s.
+
+    clickhouse-connect's query(..., parameters=...) requires the {name:Type} placeholder
+    format.  The old %(name)s style is never substituted — it reaches the DB as a literal
+    string, causing empty result sets or syntax errors (CHAOS-2205).
+    """
+    from dev_health_ops.work_graph.ai_workflow import (
+        _AI_EDGE_UNION_QUERY,
+        _AI_RUN_QUERY,
+    )
+
+    for name, query in [
+        ("_AI_RUN_QUERY", _AI_RUN_QUERY),
+        ("_AI_EDGE_UNION_QUERY", _AI_EDGE_UNION_QUERY),
+    ]:
+        assert "%(org_id)s" not in query, f"{name} still uses %(org_id)s"
+        assert "{org_id:String}" in query, f"{name} missing {{org_id:String}}"
+
+    assert "%(run_ids)s" not in _AI_RUN_QUERY
+    assert "{run_ids:Array(String)}" in _AI_RUN_QUERY
+
+    assert "%(node_types)s" not in _AI_EDGE_UNION_QUERY
+    assert "{node_types:Array(String)}" in _AI_EDGE_UNION_QUERY
+
+    assert "%(node_ids)s" not in _AI_EDGE_UNION_QUERY
+    assert "{node_ids:Array(String)}" in _AI_EDGE_UNION_QUERY
+
+    assert "%(limit)s" not in _AI_EDGE_UNION_QUERY
+    assert "{limit:UInt32}" in _AI_EDGE_UNION_QUERY
+
+
 def test_non_ai_work_graph_edge_record_shape_regression() -> None:
     edge = WorkGraphEdge(
         edge_id="edge-1",


### PR DESCRIPTION
Wave 1 (blocker + decision-free backend slice) of the **CHAOS-2180** AI-area audit. Companion frontend PR: full-chaos/dev-health-web `fix/chaos-2180-ai-frontend`.

## Issues closed
- 🚩 **AI-01 / CHAOS-2205** (blocker) — Evidence drilldown params `%(name)s`→`{name:Type}`; clickhouse-connect never substituted the old style → drilldown always empty
- 🚩 **AI-02 / CHAOS-2183** (blocker) — test-gap accuracy: pass `pr_commit_stats` across **all** of a PR's commits (fixes single-day vs all-time window mismatch); unavailable→`None` (not 100%, which had fed a false detector recommendation); per-row UUID guard; query bounded to in-window PRs
- **AI-19 / CHAOS-2184** — populate attribution `team_id` via `RepoPatternTeamResolver` in app code (`teams.repo_patterns` are fnmatch globs over repo **names**, so a SQL JOIN on repo UUID could never match)
- **AI-23 / CHAOS-2188** — `detector_ready` reflects "detector ran", not "found ≥1 candidate" (a working detector finding 0 no longer reads as "not connected")
- **AI-25 / CHAOS-2190** — scope reviewer-concentration Gini to AI-attributed repos; `umd.`-qualified columns avoid an ambiguous `repo_id`
- **AI-30 / CHAOS-2211** — async governance loaders (no event-loop block)

## Adversarial review caught & fixed
An opus review **BLOCKED** the first pass — tests were green but encoded the bug (AI-19's join was non-functional; AI-23 regressed the empty-state). All findings fixed; tests rewritten to assert correct intent.

## Verification
`ruff` + `ruff-format` clean · full suite **3591 passed**. The **5 failing tests are pre-existing on `main`** (verified by baseline run): `test_org_deletion` ×2, `TestCoreCache` ×2, `test_junit_parser` — all unrelated to AI (live-service / circular-import). Zero net-new failures.

## Known limitation / follow-ups
- Team-scoped attribution pagination is **sparse** (team filter applied post-`LIMIT`); strictly better than the prior always-empty, full server-side filtering deferred to Wave 2.
- Decision-gated AI issues (tab-strips, Test-Gaps/Evidence placement, Automations dup, allowlist source) and the larger data items remain open under **CHAOS-2180**.
