### PR TITLE
feat(opportunities): CHAOS-2218 Phase 1 — FlowOpportunityDetector backend foundation

### DIFF
--- a/src/dev_health_ops/metrics/opportunities/ai_detector.py
+++ b/src/dev_health_ops/metrics/opportunities/ai_detector.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import uuid
 from dataclasses import dataclass
 from typing import Any
@@ -12,6 +11,12 @@ from dev_health_ops.api.graphql.models.ai import (
 )
 from dev_health_ops.metrics.ai_impact import AI_BUCKETS, AttributionBucket
 from dev_health_ops.metrics.loaders.base import parse_uuid
+from dev_health_ops.metrics.opportunities.scoring import (
+    clamp,
+    score_delta,
+    score_ratio,
+    stable_opportunity_id,
+)
 from dev_health_ops.metrics.query_builder import OrgScopedQuery
 
 _MIN_PRS = 10
@@ -399,8 +404,7 @@ def _work_graph_refs(evidence_refs: list[str]) -> list[AIWorkGraphDrilldownRef]:
 
 
 def _stable_id(kind: AIOpportunityKind, repo_id: str, team_id: str | None) -> str:
-    raw = f"{kind.value}:{repo_id}:{team_id or ''}"
-    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+    return stable_opportunity_id(kind, repo_id, team_id)
 
 
 def _ratio(numerator: float, denominator: float) -> float | None:
@@ -416,19 +420,15 @@ def _float_or_none(value: Any) -> float | None:
 
 
 def _clamp(value: float) -> float:
-    return max(0.0, min(1.0, value))
+    return clamp(value)
 
 
 def _score_ratio(value: float, threshold: float) -> float:
-    if threshold <= 0:
-        return 0.0
-    return _clamp((value / threshold - 1.0) / 2.0 + 0.50)
+    return score_ratio(value, threshold)
 
 
 def _score_delta(value: float, threshold: float) -> float:
-    if threshold <= 0:
-        return 0.0
-    return _clamp((value / threshold - 1.0) / 2.0 + 0.50)
+    return score_delta(value, threshold)
 
 
 def _clamp_limit(limit: int | None) -> int:

--- a/src/dev_health_ops/metrics/opportunities/flow_detector.py
+++ b/src/dev_health_ops/metrics/opportunities/flow_detector.py
@@ -1,0 +1,501 @@
+"""Flow / Improve opportunity detector (CHAOS-2218, Phase 1).
+
+This module is **read-only** — it queries precomputed ClickHouse rows and
+returns scored :class:`~.models.ImproveOpportunity` objects.  It never writes
+to storage; persistence is deferred to a future phase.
+
+Architecture
+------------
+- Two ``GROUP BY`` queries run in parallel via :func:`asyncio.gather`:
+  one over ``repo_metrics_daily`` (repo entities),
+  one over ``work_item_metrics_daily`` (team entities).
+- Seven threshold rule functions are applied to the aggregated rows.
+- ``org_id`` is always injected via :class:`OrgScopedQuery` — the detector
+  never mixes rows from different organisations.
+- Per-rule ``try/except`` ensures a single bad row never blanks the result.
+- On total failure the detector logs and returns ``[]``.
+
+Column names are verified against ClickHouse migrations:
+- ``repo_metrics_daily``:  pr_first_review_p50_hours, pr_rework_ratio,
+  rework_churn_ratio_30d, change_failure_rate, total_loc_touched (001, 004)
+- ``work_item_metrics_daily``:  cycle_time_p50_hours, wip_congestion_ratio,
+  items_completed, defect_intro_rate (001, 002)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from dev_health_ops.metrics.opportunities.models import (
+    FlowScopeInput,
+    ImproveOpportunity,
+    ImproveOpportunityKind,
+)
+from dev_health_ops.metrics.opportunities.scoring import (
+    clamp,
+    score_delta,
+    score_ratio,
+    stable_opportunity_id,
+)
+from dev_health_ops.metrics.query_builder import OrgScopedQuery
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Thresholds (blueprint values)
+# ---------------------------------------------------------------------------
+
+_REVIEW_LATENCY_THRESHOLD_HOURS = 24.0  # p50 first-review > 24 h
+_CYCLE_TIME_THRESHOLD_HOURS = 120.0  # p50 cycle > 5 days
+_REWORK_RATIO_THRESHOLD = 0.20  # > 20 % of PRs are rework
+_WIP_CONGESTION_THRESHOLD = 0.40  # congestion ratio > 40 %
+_LOW_THROUGHPUT_THRESHOLD = 2.0  # items_completed < 2 over window
+_HIGH_CHURN_THRESHOLD = 0.30  # rework_churn_ratio_30d > 30 %
+_CHANGE_FAILURE_THRESHOLD = 0.15  # change_failure_rate > 15 %
+
+# Minimum distinct days of data required for a row to be considered
+_MIN_DATA_DAYS = 5
+
+# ---------------------------------------------------------------------------
+# Recommended actions per kind (static map — same strings as
+# _METRIC_SUGGESTED_EXPERIMENTS in services/opportunities.py but tied to a
+# scored entity rather than a metric key).
+# ---------------------------------------------------------------------------
+
+_RECOMMENDED_ACTIONS: dict[ImproveOpportunityKind, str] = {
+    ImproveOpportunityKind.HIGH_REVIEW_LATENCY: (
+        "Reserve a daily review block for PRs waiting longest for first response."
+    ),
+    ImproveOpportunityKind.SLOW_CYCLE_TIME: (
+        "Trace the oldest active items to their current waiting state."
+    ),
+    ImproveOpportunityKind.HIGH_REWORK: (
+        "Compare reopened or rewritten work against its original acceptance criteria."
+    ),
+    ImproveOpportunityKind.HIGH_WIP: (
+        "Set a short-term WIP limit and finish active items before starting more."
+    ),
+    ImproveOpportunityKind.LOW_THROUGHPUT: (
+        "Audit recently completed items for the smallest repeatable delivery pattern."
+    ),
+    ImproveOpportunityKind.HIGH_CHURN: (
+        "Review the files with the largest churn increase for unclear ownership or scope."
+    ),
+    ImproveOpportunityKind.HIGH_CHANGE_FAILURE: (
+        "Review recent failed changes for the earliest detectable signal before release."
+    ),
+}
+
+
+def _severity(score: float) -> str:
+    """Map a normalised score to a severity label."""
+    if score >= 0.75:
+        return "high"
+    if score >= 0.50:
+        return "medium"
+    return "low"
+
+
+def _make_opportunity(
+    *,
+    kind: ImproveOpportunityKind,
+    entity_type: str,
+    entity_id: str,
+    title: str,
+    rationale: str,
+    score: float,
+    evidence_refs: list[str],
+) -> ImproveOpportunity:
+    clamped = clamp(score)
+    return ImproveOpportunity(
+        opportunity_id=stable_opportunity_id(kind, entity_id, None),
+        kind=kind,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        entity_display_name=None,
+        title=title,
+        rationale=rationale,
+        score=clamped,
+        severity=_severity(clamped),
+        evidence_refs=evidence_refs,
+        recommended_action=_RECOMMENDED_ACTIONS[kind],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule functions — each returns an ImproveOpportunity | None
+# ---------------------------------------------------------------------------
+
+
+def _rule_high_review_latency(
+    row: dict[str, Any],
+) -> ImproveOpportunity | None:
+    """Fire when ``pr_first_review_p50_hours > threshold``."""
+    value = _float_or_none(row.get("pr_first_review_p50_hours"))
+    if value is None or value <= _REVIEW_LATENCY_THRESHOLD_HOURS:
+        return None
+    entity_id = str(row["entity_id"])
+    return _make_opportunity(
+        kind=ImproveOpportunityKind.HIGH_REVIEW_LATENCY,
+        entity_type="repo",
+        entity_id=entity_id,
+        title=f"High review latency in {entity_id}",
+        rationale=(
+            f"Median first-review time was {value:.1f} h over the last "
+            f"{row.get('window_days', 30)} days "
+            f"(threshold: {_REVIEW_LATENCY_THRESHOLD_HOURS:.0f} h)."
+        ),
+        score=score_ratio(value, _REVIEW_LATENCY_THRESHOLD_HOURS),
+        evidence_refs=[f"repo_metrics_daily:pr_first_review_p50_hours:{entity_id}"],
+    )
+
+
+def _rule_slow_cycle_time(
+    row: dict[str, Any],
+) -> ImproveOpportunity | None:
+    """Fire when ``cycle_time_p50_hours > threshold``."""
+    value = _float_or_none(row.get("cycle_time_p50_hours"))
+    if value is None or value <= _CYCLE_TIME_THRESHOLD_HOURS:
+        return None
+    entity_id = str(row["entity_id"])
+    return _make_opportunity(
+        kind=ImproveOpportunityKind.SLOW_CYCLE_TIME,
+        entity_type="team",
+        entity_id=entity_id,
+        title=f"Slow cycle time for {entity_id}",
+        rationale=(
+            f"Median cycle time was {value:.1f} h over the last "
+            f"{row.get('window_days', 30)} days "
+            f"(threshold: {_CYCLE_TIME_THRESHOLD_HOURS:.0f} h)."
+        ),
+        score=score_ratio(value, _CYCLE_TIME_THRESHOLD_HOURS),
+        evidence_refs=[f"work_item_metrics_daily:cycle_time_p50_hours:{entity_id}"],
+    )
+
+
+def _rule_high_rework(
+    row: dict[str, Any],
+) -> ImproveOpportunity | None:
+    """Fire when ``pr_rework_ratio > threshold``."""
+    value = _float_or_none(row.get("pr_rework_ratio"))
+    if value is None or value <= _REWORK_RATIO_THRESHOLD:
+        return None
+    entity_id = str(row["entity_id"])
+    return _make_opportunity(
+        kind=ImproveOpportunityKind.HIGH_REWORK,
+        entity_type="repo",
+        entity_id=entity_id,
+        title=f"High rework ratio in {entity_id}",
+        rationale=(
+            f"PR rework ratio was {value:.0%} over the last "
+            f"{row.get('window_days', 30)} days "
+            f"(threshold: {_REWORK_RATIO_THRESHOLD:.0%})."
+        ),
+        score=score_ratio(value, _REWORK_RATIO_THRESHOLD),
+        evidence_refs=[f"repo_metrics_daily:pr_rework_ratio:{entity_id}"],
+    )
+
+
+def _rule_high_wip(
+    row: dict[str, Any],
+) -> ImproveOpportunity | None:
+    """Fire when ``wip_congestion_ratio > threshold``."""
+    value = _float_or_none(row.get("wip_congestion_ratio"))
+    if value is None or value <= _WIP_CONGESTION_THRESHOLD:
+        return None
+    entity_id = str(row["entity_id"])
+    return _make_opportunity(
+        kind=ImproveOpportunityKind.HIGH_WIP,
+        entity_type="team",
+        entity_id=entity_id,
+        title=f"High WIP congestion for {entity_id}",
+        rationale=(
+            f"WIP congestion ratio was {value:.0%} over the last "
+            f"{row.get('window_days', 30)} days "
+            f"(threshold: {_WIP_CONGESTION_THRESHOLD:.0%})."
+        ),
+        score=score_ratio(value, _WIP_CONGESTION_THRESHOLD),
+        evidence_refs=[f"work_item_metrics_daily:wip_congestion_ratio:{entity_id}"],
+    )
+
+
+def _rule_low_throughput(
+    row: dict[str, Any],
+) -> ImproveOpportunity | None:
+    """Fire when ``items_completed < threshold`` (low throughput signal)."""
+    value = _float_or_none(row.get("items_completed"))
+    if value is None or value >= _LOW_THROUGHPUT_THRESHOLD:
+        return None
+    entity_id = str(row["entity_id"])
+    # score: distance below threshold (lower value → higher score)
+    gap = max(0.0, _LOW_THROUGHPUT_THRESHOLD - value)
+    return _make_opportunity(
+        kind=ImproveOpportunityKind.LOW_THROUGHPUT,
+        entity_type="team",
+        entity_id=entity_id,
+        title=f"Low throughput for {entity_id}",
+        rationale=(
+            f"Only {value:.0f} items were completed over the last "
+            f"{row.get('window_days', 30)} days "
+            f"(threshold: {_LOW_THROUGHPUT_THRESHOLD:.0f})."
+        ),
+        score=score_delta(gap, _LOW_THROUGHPUT_THRESHOLD),
+        evidence_refs=[f"work_item_metrics_daily:items_completed:{entity_id}"],
+    )
+
+
+def _rule_high_churn(
+    row: dict[str, Any],
+) -> ImproveOpportunity | None:
+    """Fire when ``rework_churn_ratio_30d > threshold``."""
+    value = _float_or_none(row.get("rework_churn_ratio_30d"))
+    if value is None or value <= _HIGH_CHURN_THRESHOLD:
+        return None
+    entity_id = str(row["entity_id"])
+    return _make_opportunity(
+        kind=ImproveOpportunityKind.HIGH_CHURN,
+        entity_type="repo",
+        entity_id=entity_id,
+        title=f"High rework churn in {entity_id}",
+        rationale=(
+            f"Rework churn ratio was {value:.0%} over the last 30 days "
+            f"(threshold: {_HIGH_CHURN_THRESHOLD:.0%})."
+        ),
+        score=score_ratio(value, _HIGH_CHURN_THRESHOLD),
+        evidence_refs=[f"repo_metrics_daily:rework_churn_ratio_30d:{entity_id}"],
+    )
+
+
+def _rule_high_change_failure(
+    row: dict[str, Any],
+) -> ImproveOpportunity | None:
+    """Fire when ``change_failure_rate > threshold``."""
+    value = _float_or_none(row.get("change_failure_rate"))
+    if value is None or value <= _CHANGE_FAILURE_THRESHOLD:
+        return None
+    entity_id = str(row["entity_id"])
+    return _make_opportunity(
+        kind=ImproveOpportunityKind.HIGH_CHANGE_FAILURE,
+        entity_type="repo",
+        entity_id=entity_id,
+        title=f"High change failure rate in {entity_id}",
+        rationale=(
+            f"Change failure rate was {value:.0%} over the last "
+            f"{row.get('window_days', 30)} days "
+            f"(threshold: {_CHANGE_FAILURE_THRESHOLD:.0%})."
+        ),
+        score=score_ratio(value, _CHANGE_FAILURE_THRESHOLD),
+        evidence_refs=[f"repo_metrics_daily:change_failure_rate:{entity_id}"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule registry — maps to the correct entity_type columns
+# ---------------------------------------------------------------------------
+
+_REPO_RULES = [
+    _rule_high_review_latency,
+    _rule_high_rework,
+    _rule_high_churn,
+    _rule_high_change_failure,
+]
+
+_TEAM_RULES = [
+    _rule_slow_cycle_time,
+    _rule_high_wip,
+    _rule_low_throughput,
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Detector
+# ---------------------------------------------------------------------------
+
+
+class FlowOpportunityDetector:
+    """Rule-based flow / improve opportunity detector.
+
+    This class is **read-only**.  It queries precomputed ClickHouse rows
+    produced by the daily metrics jobs and returns scored
+    :class:`~.models.ImproveOpportunity` objects.
+
+    Parameters
+    ----------
+    client:
+        A ClickHouse-connect (or compatible) client instance.
+    """
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    async def detect(
+        self,
+        org_id: str,
+        scope: FlowScopeInput | None = None,
+        *,
+        limit: int = 10,
+        window_days: int = 30,
+    ) -> list[ImproveOpportunity]:
+        """Detect and score flow opportunities.
+
+        Runs two ClickHouse GROUP BY queries in parallel (repo metrics and
+        team/work-item metrics), applies threshold rules, and returns the
+        top *limit* opportunities sorted by score descending.
+
+        Returns ``[]`` on total failure (individual rule failures are
+        logged and skipped).
+        """
+        bounded_limit = max(1, min(limit, 100))
+        try:
+            repo_rows, team_rows = await asyncio.gather(
+                self._load_repo_rows(org_id, scope, window_days),
+                self._load_team_rows(org_id, scope, window_days),
+            )
+        except Exception:
+            logger.exception(
+                "FlowOpportunityDetector: failed to load metric rows for org=%s",
+                org_id,
+            )
+            return []
+
+        opportunities: list[ImproveOpportunity] = []
+        opportunities.extend(
+            self._apply_rules(repo_rows, _REPO_RULES, window_days=window_days)
+        )
+        opportunities.extend(
+            self._apply_rules(team_rows, _TEAM_RULES, window_days=window_days)
+        )
+        opportunities.sort(key=lambda o: o.score, reverse=True)
+        return opportunities[:bounded_limit]
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+
+    async def _load_repo_rows(
+        self,
+        org_id: str,
+        scope: FlowScopeInput | None,
+        window_days: int,
+    ) -> list[dict[str, Any]]:
+        from dev_health_ops.api.queries.client import query_dicts
+
+        params: dict[str, Any] = {"window_days": window_days}
+        filters: list[str] = ["day >= today() - {window_days:UInt32}"]
+
+        if scope is not None and scope.repo_id is not None:
+            params["repo_id"] = str(scope.repo_id)
+            filters.append("repo_id = {repo_id:UUID}")
+
+        org_scope = OrgScopedQuery(org_id)
+        params = org_scope.inject(params)
+        org_expr = org_scope.expression()
+        if org_expr:
+            filters.append(org_expr)
+
+        where_clause = " AND ".join(filters)
+        query = f"""
+        SELECT
+            toString(repo_id) AS entity_id,
+            uniqExact(day) AS data_days,
+            avg(pr_first_review_p50_hours) AS pr_first_review_p50_hours,
+            avg(pr_rework_ratio) AS pr_rework_ratio,
+            avg(rework_churn_ratio_30d) AS rework_churn_ratio_30d,
+            avg(change_failure_rate) AS change_failure_rate,
+            sum(total_loc_touched) AS total_loc_touched
+        FROM repo_metrics_daily
+        WHERE {where_clause}
+        GROUP BY repo_id
+        HAVING data_days >= {_MIN_DATA_DAYS}
+        ORDER BY data_days DESC
+        LIMIT 500
+        """
+        rows = await query_dicts(self.client, query, params)
+        for row in rows:
+            row["window_days"] = window_days
+        return rows
+
+    async def _load_team_rows(
+        self,
+        org_id: str,
+        scope: FlowScopeInput | None,
+        window_days: int,
+    ) -> list[dict[str, Any]]:
+        from dev_health_ops.api.queries.client import query_dicts
+
+        params: dict[str, Any] = {"window_days": window_days}
+        filters: list[str] = ["day >= today() - {window_days:UInt32}"]
+
+        if scope is not None and scope.team_id is not None:
+            params["team_id"] = scope.team_id
+            filters.append("team_id = {team_id:String}")
+
+        org_scope = OrgScopedQuery(org_id)
+        params = org_scope.inject(params)
+        org_expr = org_scope.expression()
+        if org_expr:
+            filters.append(org_expr)
+
+        where_clause = " AND ".join(filters)
+        query = f"""
+        SELECT
+            team_id AS entity_id,
+            uniqExact(day) AS data_days,
+            avg(cycle_time_p50_hours) AS cycle_time_p50_hours,
+            avg(wip_congestion_ratio) AS wip_congestion_ratio,
+            sum(items_completed) AS items_completed,
+            avg(defect_intro_rate) AS defect_intro_rate
+        FROM work_item_metrics_daily
+        WHERE {where_clause}
+          AND team_id != ''
+        GROUP BY team_id
+        HAVING data_days >= {_MIN_DATA_DAYS}
+        ORDER BY data_days DESC
+        LIMIT 500
+        """
+        rows = await query_dicts(self.client, query, params)
+        for row in rows:
+            row["window_days"] = window_days
+        return rows
+
+    # ------------------------------------------------------------------
+    # Rule application
+    # ------------------------------------------------------------------
+
+    def _apply_rules(
+        self,
+        rows: list[dict[str, Any]],
+        rules: list[Any],
+        *,
+        window_days: int,
+    ) -> list[ImproveOpportunity]:
+        results: list[ImproveOpportunity] = []
+        for row in rows:
+            for rule in rules:
+                try:
+                    opp = rule(row)
+                    if opp is not None:
+                        results.append(opp)
+                except Exception:
+                    logger.exception(
+                        "FlowOpportunityDetector: rule %s failed for row=%r",
+                        getattr(rule, "__name__", rule),
+                        row,
+                    )
+        return results

--- a/src/dev_health_ops/metrics/opportunities/models.py
+++ b/src/dev_health_ops/metrics/opportunities/models.py
@@ -1,0 +1,91 @@
+"""Domain models for the Improve/Flow opportunity engine (CHAOS-2218).
+
+These models are **independent of the GraphQL layer** (no ``strawberry``
+decorators) so they can be used in pure Python tests and by any downstream
+code that does not import the full API stack.
+
+The GraphQL contracts (``schemas.py``, ``OpportunityCard``, etc.) are NOT
+changed in Phase 1 — this module is a foundation only.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class ImproveOpportunityKind(Enum):
+    """Canonical opportunity kinds for the Flow / Improve engine.
+
+    Each value maps to a threshold rule implemented in
+    :class:`~dev_health_ops.metrics.opportunities.flow_detector.FlowOpportunityDetector`.
+    """
+
+    HIGH_REVIEW_LATENCY = "high_review_latency"
+    SLOW_CYCLE_TIME = "slow_cycle_time"
+    HIGH_REWORK = "high_rework"
+    HIGH_WIP = "high_wip"
+    LOW_THROUGHPUT = "low_throughput"
+    HIGH_CHURN = "high_churn"
+    HIGH_CHANGE_FAILURE = "high_change_failure"
+
+
+@dataclass(frozen=True)
+class ImproveOpportunity:
+    """A single scored flow / improve opportunity surfaced by the detector.
+
+    Fields
+    ------
+    opportunity_id
+        Stable 24-hex-char identifier derived deterministically from
+        (kind, entity_type, entity_id).  See :func:`scoring.stable_opportunity_id`.
+    kind
+        The rule that fired (see :class:`ImproveOpportunityKind`).
+    entity_type
+        ``"repo"`` or ``"team"`` — the primary addressable unit.
+    entity_id
+        Opaque string identifier for the entity (repo UUID or team ID string).
+    entity_display_name
+        Human-readable label; ``None`` in Phase 1 (no extra join needed).
+    title
+        Short, actionable title suitable for card headers.
+    rationale
+        One-sentence plain-English explanation referencing the triggering values.
+    score
+        Normalised float in [0, 1].  Higher == more urgent.
+    severity
+        ``"high"``, ``"medium"``, or ``"low"`` derived from score bands.
+    evidence_refs
+        List of opaque ``"table:column:entity_id"`` references that trace back
+        to the ClickHouse row(s) that triggered the rule.
+    recommended_action
+        Prescribed next step drawn from the static action map in
+        :data:`flow_detector._RECOMMENDED_ACTIONS`.
+    """
+
+    opportunity_id: str
+    kind: ImproveOpportunityKind
+    entity_type: str
+    entity_id: str
+    entity_display_name: str | None
+    title: str
+    rationale: str
+    score: float
+    severity: str
+    evidence_refs: list[str]
+    recommended_action: str
+
+
+@dataclass(frozen=True)
+class FlowScopeInput:
+    """Optional scope filter for :class:`FlowOpportunityDetector`.
+
+    Mirrors the ``_Scope`` private dataclass in ``ai_detector.py`` but is
+    exposed as a public, named type so callers do not depend on internals.
+
+    Both fields are optional; omitting them means "whole org".
+    """
+
+    repo_id: uuid.UUID | None = field(default=None)
+    team_id: str | None = field(default=None)

--- a/src/dev_health_ops/metrics/opportunities/scoring.py
+++ b/src/dev_health_ops/metrics/opportunities/scoring.py
@@ -1,0 +1,81 @@
+"""Pure scoring math shared by all flow-opportunity detectors.
+
+Extracted from ai_detector.py so the same primitives can be reused by the
+FlowOpportunityDetector (CHAOS-2218) and any future detector without
+importing the AI-specific module.
+
+All functions are side-effect-free and fully deterministic.  Tests live in
+``tests/metrics/opportunities/test_scoring.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+
+def clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    """Clamp *value* to the closed interval [lo, hi].
+
+    >>> clamp(1.5)
+    1.0
+    >>> clamp(-0.1)
+    0.0
+    >>> clamp(0.5)
+    0.5
+    """
+    return max(lo, min(hi, value))
+
+
+def score_ratio(value: float, threshold: float) -> float:
+    """Score a ratio relative to *threshold*.
+
+    Returns a value in [0, 1] where 0.5 corresponds to *value* == *threshold*
+    and the score increases as *value* grows above the threshold.
+
+    >>> score_ratio(2.0, 1.0)  # twice the threshold → 1.0
+    1.0
+    >>> score_ratio(1.0, 1.0)  # exactly at threshold → 0.5
+    0.5
+    >>> score_ratio(0.0, 1.0)  # below threshold → 0.0
+    0.0
+    """
+    if threshold <= 0:
+        return 0.0
+    return clamp((value / threshold - 1.0) / 2.0 + 0.50)
+
+
+def score_delta(value: float, threshold: float) -> float:
+    """Score an absolute delta relative to *threshold*.
+
+    Identical semantics to :func:`score_ratio` — the name communicates intent
+    to callers that deal with absolute differences rather than multipliers.
+
+    >>> score_delta(0.2, 0.1)  # twice the threshold → 1.0
+    1.0
+    >>> score_delta(0.1, 0.1)  # exactly at threshold → 0.5
+    0.5
+    """
+    if threshold <= 0:
+        return 0.0
+    return clamp((value / threshold - 1.0) / 2.0 + 0.50)
+
+
+def stable_opportunity_id(kind: Any, entity_id: str, secondary_id: str | None) -> str:
+    """Return a stable, deterministic 24-hex-char SHA-256 prefix.
+
+    The identifier is derived from ``kind.value`` (or ``str(kind)``),
+    *entity_id*, and *secondary_id*.  The output is stable across process
+    restarts and deterministic for the same inputs, making it safe to use
+    as a deduplication key in the API.
+
+    >>> id1 = stable_opportunity_id("HIGH_REVIEW_LATENCY", "repo-abc", None)
+    >>> id2 = stable_opportunity_id("HIGH_REVIEW_LATENCY", "repo-abc", None)
+    >>> id1 == id2
+    True
+    >>> len(id1)
+    24
+    """
+    kind_str = kind.value if hasattr(kind, "value") else str(kind)
+    raw = f"{kind_str}:{entity_id}:{secondary_id or ''}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]

--- a/tests/metrics/opportunities/test_flow_detector.py
+++ b/tests/metrics/opportunities/test_flow_detector.py
@@ -1,0 +1,570 @@
+"""Unit tests for FlowOpportunityDetector (CHAOS-2218, Phase 1).
+
+Uses a fake ClickHouse client that returns synthetic list[dict] rows.
+All tests are pure unit tests — no live ClickHouse, no @pytest.mark.clickhouse.
+
+Test coverage:
+- Each of the 7 rule functions: fires above threshold, skips below, score monotonicity
+- Deterministic opportunity_id for the same (kind, entity_id)
+- Org-scoping (org_id injected in params)
+- asyncio.gather parallelism (both queries called)
+- Total failure → [] (no exception raised to caller)
+- Rule exception isolation (bad row doesn't blank result)
+- Limit capping
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.metrics.opportunities.flow_detector import (
+    _CHANGE_FAILURE_THRESHOLD,
+    _CYCLE_TIME_THRESHOLD_HOURS,
+    _HIGH_CHURN_THRESHOLD,
+    _LOW_THROUGHPUT_THRESHOLD,
+    _MIN_DATA_DAYS,
+    _REVIEW_LATENCY_THRESHOLD_HOURS,
+    _REWORK_RATIO_THRESHOLD,
+    _WIP_CONGESTION_THRESHOLD,
+    FlowOpportunityDetector,
+    _rule_high_change_failure,
+    _rule_high_churn,
+    _rule_high_review_latency,
+    _rule_high_rework,
+    _rule_high_wip,
+    _rule_low_throughput,
+    _rule_slow_cycle_time,
+)
+from dev_health_ops.metrics.opportunities.models import (
+    FlowScopeInput,
+    ImproveOpportunityKind,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+REPO_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+TEAM_ID = "team-alpha"
+ORG_ID = "org-test"
+
+
+def _repo_row(**kwargs: Any) -> dict[str, Any]:
+    """Build a synthetic repo_metrics_daily aggregate row above all thresholds."""
+    defaults: dict[str, Any] = {
+        "entity_id": REPO_ID,
+        "data_days": _MIN_DATA_DAYS + 1,
+        "pr_first_review_p50_hours": _REVIEW_LATENCY_THRESHOLD_HOURS * 2,
+        "pr_rework_ratio": _REWORK_RATIO_THRESHOLD * 2,
+        "rework_churn_ratio_30d": _HIGH_CHURN_THRESHOLD * 2,
+        "change_failure_rate": _CHANGE_FAILURE_THRESHOLD * 2,
+        "total_loc_touched": 10000,
+        "window_days": 30,
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+def _team_row(**kwargs: Any) -> dict[str, Any]:
+    """Build a synthetic work_item_metrics_daily aggregate row above all thresholds."""
+    defaults: dict[str, Any] = {
+        "entity_id": TEAM_ID,
+        "data_days": _MIN_DATA_DAYS + 1,
+        "cycle_time_p50_hours": _CYCLE_TIME_THRESHOLD_HOURS * 2,
+        "wip_congestion_ratio": _WIP_CONGESTION_THRESHOLD * 2,
+        "items_completed": _LOW_THROUGHPUT_THRESHOLD / 2,  # below threshold
+        "defect_intro_rate": 0.05,
+        "window_days": 30,
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+# ---------------------------------------------------------------------------
+# Rule unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRuleHighReviewLatency:
+    def test_fires_above_threshold(self) -> None:
+        row = _repo_row(pr_first_review_p50_hours=_REVIEW_LATENCY_THRESHOLD_HOURS * 2)
+        opp = _rule_high_review_latency(row)
+        assert opp is not None
+        assert opp.kind is ImproveOpportunityKind.HIGH_REVIEW_LATENCY
+
+    def test_skips_at_threshold(self) -> None:
+        row = _repo_row(pr_first_review_p50_hours=_REVIEW_LATENCY_THRESHOLD_HOURS)
+        assert _rule_high_review_latency(row) is None
+
+    def test_skips_below_threshold(self) -> None:
+        row = _repo_row(pr_first_review_p50_hours=1.0)
+        assert _rule_high_review_latency(row) is None
+
+    def test_skips_none_value(self) -> None:
+        row = _repo_row(pr_first_review_p50_hours=None)
+        assert _rule_high_review_latency(row) is None
+
+    def test_score_monotone_increasing(self) -> None:
+        values = [
+            _REVIEW_LATENCY_THRESHOLD_HOURS * m for m in (1.1, 1.5, 2.0, 3.0, 5.0)
+        ]
+        scores = [
+            _rule_high_review_latency(_repo_row(pr_first_review_p50_hours=v)).score  # type: ignore[union-attr]
+            for v in values
+        ]
+        assert scores == sorted(scores)
+
+    def test_evidence_refs_format(self) -> None:
+        opp = _rule_high_review_latency(
+            _repo_row(pr_first_review_p50_hours=_REVIEW_LATENCY_THRESHOLD_HOURS * 2)
+        )
+        assert opp is not None
+        assert opp.evidence_refs[0].startswith(
+            "repo_metrics_daily:pr_first_review_p50_hours:"
+        )
+
+
+class TestRuleHighRework:
+    def test_fires_above_threshold(self) -> None:
+        row = _repo_row(pr_rework_ratio=_REWORK_RATIO_THRESHOLD * 2)
+        opp = _rule_high_rework(row)
+        assert opp is not None
+        assert opp.kind is ImproveOpportunityKind.HIGH_REWORK
+
+    def test_skips_at_threshold(self) -> None:
+        assert (
+            _rule_high_rework(_repo_row(pr_rework_ratio=_REWORK_RATIO_THRESHOLD))
+            is None
+        )
+
+    def test_skips_below_threshold(self) -> None:
+        assert _rule_high_rework(_repo_row(pr_rework_ratio=0.0)) is None
+
+    def test_score_monotone_increasing(self) -> None:
+        values = [_REWORK_RATIO_THRESHOLD * m for m in (1.1, 1.5, 2.0, 3.0)]
+        scores = [
+            _rule_high_rework(_repo_row(pr_rework_ratio=v)).score  # type: ignore[union-attr]
+            for v in values
+        ]
+        assert scores == sorted(scores)
+
+
+class TestRuleHighChurn:
+    def test_fires_above_threshold(self) -> None:
+        opp = _rule_high_churn(
+            _repo_row(rework_churn_ratio_30d=_HIGH_CHURN_THRESHOLD * 2)
+        )
+        assert opp is not None
+        assert opp.kind is ImproveOpportunityKind.HIGH_CHURN
+
+    def test_skips_at_threshold(self) -> None:
+        assert (
+            _rule_high_churn(_repo_row(rework_churn_ratio_30d=_HIGH_CHURN_THRESHOLD))
+            is None
+        )
+
+    def test_skips_below_threshold(self) -> None:
+        assert _rule_high_churn(_repo_row(rework_churn_ratio_30d=0.0)) is None
+
+    def test_score_monotone_increasing(self) -> None:
+        values = [_HIGH_CHURN_THRESHOLD * m for m in (1.1, 1.5, 2.0, 3.0)]
+        scores = [
+            _rule_high_churn(_repo_row(rework_churn_ratio_30d=v)).score  # type: ignore[union-attr]
+            for v in values
+        ]
+        assert scores == sorted(scores)
+
+
+class TestRuleHighChangeFailure:
+    def test_fires_above_threshold(self) -> None:
+        opp = _rule_high_change_failure(
+            _repo_row(change_failure_rate=_CHANGE_FAILURE_THRESHOLD * 2)
+        )
+        assert opp is not None
+        assert opp.kind is ImproveOpportunityKind.HIGH_CHANGE_FAILURE
+
+    def test_skips_at_threshold(self) -> None:
+        assert (
+            _rule_high_change_failure(
+                _repo_row(change_failure_rate=_CHANGE_FAILURE_THRESHOLD)
+            )
+            is None
+        )
+
+    def test_skips_below_threshold(self) -> None:
+        assert _rule_high_change_failure(_repo_row(change_failure_rate=0.0)) is None
+
+    def test_score_monotone_increasing(self) -> None:
+        values = [_CHANGE_FAILURE_THRESHOLD * m for m in (1.1, 1.5, 2.0, 3.0)]
+        scores = [
+            _rule_high_change_failure(_repo_row(change_failure_rate=v)).score  # type: ignore[union-attr]
+            for v in values
+        ]
+        assert scores == sorted(scores)
+
+
+class TestRuleSlowCycleTime:
+    def test_fires_above_threshold(self) -> None:
+        opp = _rule_slow_cycle_time(
+            _team_row(cycle_time_p50_hours=_CYCLE_TIME_THRESHOLD_HOURS * 2)
+        )
+        assert opp is not None
+        assert opp.kind is ImproveOpportunityKind.SLOW_CYCLE_TIME
+
+    def test_skips_at_threshold(self) -> None:
+        assert (
+            _rule_slow_cycle_time(
+                _team_row(cycle_time_p50_hours=_CYCLE_TIME_THRESHOLD_HOURS)
+            )
+            is None
+        )
+
+    def test_skips_below_threshold(self) -> None:
+        assert _rule_slow_cycle_time(_team_row(cycle_time_p50_hours=10.0)) is None
+
+    def test_skips_none(self) -> None:
+        assert _rule_slow_cycle_time(_team_row(cycle_time_p50_hours=None)) is None
+
+    def test_score_monotone_increasing(self) -> None:
+        values = [_CYCLE_TIME_THRESHOLD_HOURS * m for m in (1.1, 1.5, 2.0, 3.0)]
+        scores = [
+            _rule_slow_cycle_time(_team_row(cycle_time_p50_hours=v)).score  # type: ignore[union-attr]
+            for v in values
+        ]
+        assert scores == sorted(scores)
+
+
+class TestRuleHighWip:
+    def test_fires_above_threshold(self) -> None:
+        opp = _rule_high_wip(
+            _team_row(wip_congestion_ratio=_WIP_CONGESTION_THRESHOLD * 2)
+        )
+        assert opp is not None
+        assert opp.kind is ImproveOpportunityKind.HIGH_WIP
+
+    def test_skips_at_threshold(self) -> None:
+        assert (
+            _rule_high_wip(_team_row(wip_congestion_ratio=_WIP_CONGESTION_THRESHOLD))
+            is None
+        )
+
+    def test_skips_below_threshold(self) -> None:
+        assert _rule_high_wip(_team_row(wip_congestion_ratio=0.0)) is None
+
+    def test_score_monotone_increasing(self) -> None:
+        values = [_WIP_CONGESTION_THRESHOLD * m for m in (1.1, 1.5, 2.0, 3.0)]
+        scores = [
+            _rule_high_wip(_team_row(wip_congestion_ratio=v)).score  # type: ignore[union-attr]
+            for v in values
+        ]
+        assert scores == sorted(scores)
+
+
+class TestRuleLowThroughput:
+    def test_fires_below_threshold(self) -> None:
+        opp = _rule_low_throughput(
+            _team_row(items_completed=_LOW_THROUGHPUT_THRESHOLD / 2)
+        )
+        assert opp is not None
+        assert opp.kind is ImproveOpportunityKind.LOW_THROUGHPUT
+
+    def test_skips_at_threshold(self) -> None:
+        assert (
+            _rule_low_throughput(_team_row(items_completed=_LOW_THROUGHPUT_THRESHOLD))
+            is None
+        )
+
+    def test_skips_above_threshold(self) -> None:
+        assert (
+            _rule_low_throughput(
+                _team_row(items_completed=_LOW_THROUGHPUT_THRESHOLD * 2)
+            )
+            is None
+        )
+
+    def test_skips_none(self) -> None:
+        assert _rule_low_throughput(_team_row(items_completed=None)) is None
+
+    def test_score_present(self) -> None:
+        opp = _rule_low_throughput(_team_row(items_completed=0.0))
+        assert opp is not None
+        assert 0.0 <= opp.score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Deterministic ID tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicIds:
+    def test_same_inputs_produce_same_id(self) -> None:
+        row = _repo_row(
+            entity_id=REPO_ID,
+            pr_first_review_p50_hours=_REVIEW_LATENCY_THRESHOLD_HOURS * 2,
+        )
+        opp1 = _rule_high_review_latency(row)
+        opp2 = _rule_high_review_latency(row)
+        assert opp1 is not None and opp2 is not None
+        assert opp1.opportunity_id == opp2.opportunity_id
+
+    def test_different_entities_produce_different_ids(self) -> None:
+        row1 = _repo_row(
+            entity_id="repo-1",
+            pr_first_review_p50_hours=_REVIEW_LATENCY_THRESHOLD_HOURS * 2,
+        )
+        row2 = _repo_row(
+            entity_id="repo-2",
+            pr_first_review_p50_hours=_REVIEW_LATENCY_THRESHOLD_HOURS * 2,
+        )
+        opp1 = _rule_high_review_latency(row1)
+        opp2 = _rule_high_review_latency(row2)
+        assert opp1 is not None and opp2 is not None
+        assert opp1.opportunity_id != opp2.opportunity_id
+
+
+# ---------------------------------------------------------------------------
+# Detector integration tests (with fake query_dicts)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detector_returns_opportunities_for_valid_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detector surfaces findings when rows are above thresholds."""
+    repo_rows = [_repo_row()]
+    team_rows = [_team_row()]
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[dict]:
+        if "repo_metrics_daily" in query:
+            return repo_rows
+        return team_rows
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    result = await FlowOpportunityDetector(MagicMock()).detect(ORG_ID, limit=20)
+    assert len(result) > 0
+    kinds = {o.kind for o in result}
+    # Repo rules should fire (review latency, rework, churn, change failure)
+    assert ImproveOpportunityKind.HIGH_REVIEW_LATENCY in kinds
+    assert ImproveOpportunityKind.HIGH_REWORK in kinds
+    # Team rules should fire (slow cycle, wip, low throughput)
+    assert ImproveOpportunityKind.SLOW_CYCLE_TIME in kinds
+    assert ImproveOpportunityKind.LOW_THROUGHPUT in kinds
+
+
+@pytest.mark.asyncio
+async def test_detector_empty_rows_returns_empty_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_query_dicts(_client: Any, _query: str, _params: Any) -> list[dict]:
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    result = await FlowOpportunityDetector(MagicMock()).detect(ORG_ID)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_detector_respects_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Detector never returns more than limit items."""
+    # Generate many repo rows all above every threshold
+    many_rows = [_repo_row(entity_id=f"repo-{i}") for i in range(50)]
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[dict]:
+        if "repo_metrics_daily" in query:
+            return many_rows
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    result = await FlowOpportunityDetector(MagicMock()).detect(ORG_ID, limit=5)
+    assert len(result) == 5
+
+
+@pytest.mark.asyncio
+async def test_detector_injects_org_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """org_id is injected into the params dict for both queries."""
+    captured_params: list[dict] = []
+
+    async def fake_query_dicts(_client: Any, _query: str, params: Any) -> list[dict]:
+        captured_params.append(dict(params))
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    await FlowOpportunityDetector(MagicMock()).detect("my-org-id")
+
+    assert len(captured_params) == 2, "Expected exactly two queries (repo + team)"
+    for params in captured_params:
+        assert params.get("org_id") == "my-org-id"
+
+
+@pytest.mark.asyncio
+async def test_detector_both_queries_called(monkeypatch: pytest.MonkeyPatch) -> None:
+    """asyncio.gather causes both repo and team queries to be called."""
+    queries_seen: list[str] = []
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[dict]:
+        queries_seen.append(query)
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    await FlowOpportunityDetector(MagicMock()).detect(ORG_ID)
+
+    assert any("repo_metrics_daily" in q for q in queries_seen)
+    assert any("work_item_metrics_daily" in q for q in queries_seen)
+    assert len(queries_seen) == 2
+
+
+@pytest.mark.asyncio
+async def test_detector_total_failure_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If both queries raise, detect() returns [] rather than propagating."""
+
+    async def fake_query_dicts(_client: Any, _query: str, _params: Any) -> list[dict]:
+        raise RuntimeError("ClickHouse is unavailable")
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    result = await FlowOpportunityDetector(MagicMock()).detect(ORG_ID)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_detector_bad_row_skipped_others_returned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row that causes a rule exception doesn't blank the whole result."""
+    bad_row = {"entity_id": "bad-repo", "pr_first_review_p50_hours": object()}
+    good_row = _repo_row(entity_id="good-repo")
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[dict]:
+        if "repo_metrics_daily" in query:
+            return [bad_row, good_row]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    result = await FlowOpportunityDetector(MagicMock()).detect(ORG_ID)
+    entity_ids = {o.entity_id for o in result}
+    assert "good-repo" in entity_ids
+
+
+@pytest.mark.asyncio
+async def test_detector_sorted_by_score_descending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Results are sorted highest-score-first."""
+    # Create rows that produce different scores
+    rows = [
+        _repo_row(
+            entity_id=f"repo-{i}",
+            pr_first_review_p50_hours=_REVIEW_LATENCY_THRESHOLD_HOURS * (i + 2),
+        )
+        for i in range(5)
+    ]
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[dict]:
+        if "repo_metrics_daily" in query:
+            return rows
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    result = await FlowOpportunityDetector(MagicMock()).detect(ORG_ID, limit=20)
+    review_latency_opps = [
+        o for o in result if o.kind is ImproveOpportunityKind.HIGH_REVIEW_LATENCY
+    ]
+    scores = [o.score for o in review_latency_opps]
+    assert scores == sorted(scores, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_detector_scope_filters_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """repo_id scope is passed as a query param."""
+    import uuid as _uuid
+
+    captured: list[dict] = []
+
+    async def fake_query_dicts(_client: Any, _query: str, params: Any) -> list[dict]:
+        captured.append(dict(params))
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    repo_id = _uuid.UUID(REPO_ID)
+    scope = FlowScopeInput(repo_id=repo_id)
+    await FlowOpportunityDetector(MagicMock()).detect(ORG_ID, scope=scope)
+
+    repo_params = [p for p in captured if "repo_id" in p]
+    assert repo_params, "repo_id should be in the repo query params"
+    assert repo_params[0]["repo_id"] == str(repo_id)
+
+
+@pytest.mark.asyncio
+async def test_detector_scope_filters_team(monkeypatch: pytest.MonkeyPatch) -> None:
+    """team_id scope is passed as a query param."""
+    captured: list[dict] = []
+
+    async def fake_query_dicts(_client: Any, _query: str, params: Any) -> list[dict]:
+        captured.append(dict(params))
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    scope = FlowScopeInput(team_id=TEAM_ID)
+    await FlowOpportunityDetector(MagicMock()).detect(ORG_ID, scope=scope)
+
+    team_params = [p for p in captured if "team_id" in p]
+    assert team_params, "team_id should be in the team query params"
+    assert team_params[0]["team_id"] == TEAM_ID
+
+
+@pytest.mark.asyncio
+async def test_detector_parallelism(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both queries are launched concurrently via asyncio.gather."""
+    started: list[str] = []
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[dict]:
+        if "repo_metrics_daily" in query:
+            started.append("repo")
+        elif "work_item_metrics_daily" in query:
+            started.append("team")
+        await asyncio.sleep(0)  # yield so both can start
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    await FlowOpportunityDetector(MagicMock()).detect(ORG_ID)
+    assert "repo" in started
+    assert "team" in started

--- a/tests/metrics/opportunities/test_models.py
+++ b/tests/metrics/opportunities/test_models.py
@@ -1,0 +1,100 @@
+"""Unit tests for dev_health_ops.metrics.opportunities.models.
+
+Tests cover:
+- ImproveOpportunityKind enum values are stable strings
+- ImproveOpportunity is frozen (immutable)
+- FlowScopeInput fields default to None
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from dev_health_ops.metrics.opportunities.models import (
+    FlowScopeInput,
+    ImproveOpportunity,
+    ImproveOpportunityKind,
+)
+
+
+class TestImproveOpportunityKind:
+    def test_all_kinds_have_string_values(self) -> None:
+        for kind in ImproveOpportunityKind:
+            assert isinstance(kind.value, str)
+            assert kind.value  # non-empty
+
+    def test_expected_kinds_present(self) -> None:
+        values = {k.value for k in ImproveOpportunityKind}
+        for expected in (
+            "high_review_latency",
+            "slow_cycle_time",
+            "high_rework",
+            "high_wip",
+            "low_throughput",
+            "high_churn",
+            "high_change_failure",
+        ):
+            assert expected in values
+
+    def test_seven_kinds(self) -> None:
+        assert len(ImproveOpportunityKind) == 7
+
+
+class TestImproveOpportunity:
+    def _make(self, **overrides: object) -> ImproveOpportunity:
+        defaults: dict[str, object] = {
+            "opportunity_id": "abc123",
+            "kind": ImproveOpportunityKind.HIGH_REVIEW_LATENCY,
+            "entity_type": "repo",
+            "entity_id": "repo-1",
+            "entity_display_name": None,
+            "title": "High review latency",
+            "rationale": "p50 first-review was 48 h",
+            "score": 0.7,
+            "severity": "medium",
+            "evidence_refs": ["repo_metrics_daily:pr_first_review_p50_hours:repo-1"],
+            "recommended_action": "Reserve a daily review block.",
+        }
+        defaults.update(overrides)
+        return ImproveOpportunity(**defaults)  # type: ignore[arg-type]
+
+    def test_construction(self) -> None:
+        opp = self._make()
+        assert opp.opportunity_id == "abc123"
+        assert opp.kind is ImproveOpportunityKind.HIGH_REVIEW_LATENCY
+
+    def test_frozen(self) -> None:
+        opp = self._make()
+        with pytest.raises(AttributeError):
+            opp.score = 0.9  # type: ignore[misc]
+
+    def test_entity_display_name_defaults_to_none(self) -> None:
+        opp = self._make()
+        assert opp.entity_display_name is None
+
+    def test_evidence_refs_is_list(self) -> None:
+        opp = self._make()
+        assert isinstance(opp.evidence_refs, list)
+
+
+class TestFlowScopeInput:
+    def test_both_none_by_default(self) -> None:
+        scope = FlowScopeInput()
+        assert scope.repo_id is None
+        assert scope.team_id is None
+
+    def test_repo_id_accepted(self) -> None:
+        uid = uuid.UUID("11111111-1111-1111-1111-111111111111")
+        scope = FlowScopeInput(repo_id=uid)
+        assert scope.repo_id == uid
+
+    def test_team_id_accepted(self) -> None:
+        scope = FlowScopeInput(team_id="team-alpha")
+        assert scope.team_id == "team-alpha"
+
+    def test_frozen(self) -> None:
+        scope = FlowScopeInput(team_id="x")
+        with pytest.raises(AttributeError):
+            scope.team_id = "y"  # type: ignore[misc]

--- a/tests/metrics/opportunities/test_scoring.py
+++ b/tests/metrics/opportunities/test_scoring.py
@@ -1,0 +1,142 @@
+"""Unit tests for dev_health_ops.metrics.opportunities.scoring.
+
+Tests cover:
+- clamp boundary and interior values
+- score_ratio at/above/below threshold, monotonicity
+- score_delta at/above/below threshold, monotonicity
+- stable_opportunity_id determinism, length, uniqueness
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.metrics.opportunities.scoring import (
+    clamp,
+    score_delta,
+    score_ratio,
+    stable_opportunity_id,
+)
+
+
+class TestClamp:
+    def test_below_lo_returns_lo(self) -> None:
+        assert clamp(-1.0) == 0.0
+
+    def test_above_hi_returns_hi(self) -> None:
+        assert clamp(2.0) == 1.0
+
+    def test_at_lo_boundary(self) -> None:
+        assert clamp(0.0) == 0.0
+
+    def test_at_hi_boundary(self) -> None:
+        assert clamp(1.0) == 1.0
+
+    def test_interior_unchanged(self) -> None:
+        assert clamp(0.5) == pytest.approx(0.5)
+
+    def test_custom_bounds(self) -> None:
+        assert clamp(5.0, lo=2.0, hi=4.0) == pytest.approx(4.0)
+        assert clamp(1.0, lo=2.0, hi=4.0) == pytest.approx(2.0)
+        assert clamp(3.0, lo=2.0, hi=4.0) == pytest.approx(3.0)
+
+
+class TestScoreRatio:
+    def test_at_threshold_returns_half(self) -> None:
+        assert score_ratio(1.0, 1.0) == pytest.approx(0.5)
+
+    def test_double_threshold_returns_one(self) -> None:
+        assert score_ratio(2.0, 1.0) == pytest.approx(1.0)
+
+    def test_below_threshold_returns_below_half(self) -> None:
+        assert score_ratio(0.5, 1.0) < 0.5
+
+    def test_zero_threshold_returns_zero(self) -> None:
+        assert score_ratio(10.0, 0.0) == 0.0
+
+    def test_negative_threshold_returns_zero(self) -> None:
+        assert score_ratio(10.0, -1.0) == 0.0
+
+    def test_result_clamped_to_unit_interval(self) -> None:
+        result = score_ratio(1000.0, 1.0)
+        assert 0.0 <= result <= 1.0
+
+    def test_monotone_increasing(self) -> None:
+        """Higher ratio → higher score."""
+        threshold = 24.0
+        values = [12.0, 24.0, 36.0, 48.0, 96.0]
+        scores = [score_ratio(v, threshold) for v in values]
+        assert scores == sorted(scores), "score_ratio must be monotone non-decreasing"
+
+
+class TestScoreDelta:
+    def test_at_threshold_returns_half(self) -> None:
+        assert score_delta(0.10, 0.10) == pytest.approx(0.5)
+
+    def test_double_threshold_returns_one(self) -> None:
+        assert score_delta(0.20, 0.10) == pytest.approx(1.0)
+
+    def test_below_threshold_returns_below_half(self) -> None:
+        assert score_delta(0.05, 0.10) < 0.5
+
+    def test_zero_threshold_returns_zero(self) -> None:
+        assert score_delta(0.5, 0.0) == 0.0
+
+    def test_negative_threshold_returns_zero(self) -> None:
+        assert score_delta(0.5, -0.1) == 0.0
+
+    def test_result_clamped_to_unit_interval(self) -> None:
+        result = score_delta(999.0, 0.1)
+        assert 0.0 <= result <= 1.0
+
+    def test_monotone_increasing(self) -> None:
+        threshold = 0.10
+        values = [0.0, 0.05, 0.10, 0.15, 0.30]
+        scores = [score_delta(v, threshold) for v in values]
+        assert scores == sorted(scores), "score_delta must be monotone non-decreasing"
+
+
+class TestStableOpportunityId:
+    def test_deterministic_same_inputs(self) -> None:
+        id1 = stable_opportunity_id("HIGH_REVIEW_LATENCY", "repo-abc", None)
+        id2 = stable_opportunity_id("HIGH_REVIEW_LATENCY", "repo-abc", None)
+        assert id1 == id2
+
+    def test_length_is_24(self) -> None:
+        result = stable_opportunity_id("HIGH_REWORK", "team-x", "secondary")
+        assert len(result) == 24
+
+    def test_hexadecimal_only(self) -> None:
+        result = stable_opportunity_id("HIGH_WIP", "team-y", None)
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_unique_for_different_kinds(self) -> None:
+        id1 = stable_opportunity_id("HIGH_WIP", "repo-1", None)
+        id2 = stable_opportunity_id("HIGH_REWORK", "repo-1", None)
+        assert id1 != id2
+
+    def test_unique_for_different_entities(self) -> None:
+        id1 = stable_opportunity_id("SLOW_CYCLE_TIME", "repo-1", None)
+        id2 = stable_opportunity_id("SLOW_CYCLE_TIME", "repo-2", None)
+        assert id1 != id2
+
+    def test_unique_for_different_secondary(self) -> None:
+        id1 = stable_opportunity_id("HIGH_CHURN", "repo-1", "a")
+        id2 = stable_opportunity_id("HIGH_CHURN", "repo-1", "b")
+        assert id1 != id2
+
+    def test_none_and_empty_secondary_equivalent(self) -> None:
+        """None secondary_id is treated the same as empty string."""
+        id1 = stable_opportunity_id("HIGH_CHURN", "repo-1", None)
+        id2 = stable_opportunity_id("HIGH_CHURN", "repo-1", "")
+        assert id1 == id2
+
+    def test_uses_enum_value(self) -> None:
+        """Objects with a .value attribute use that value, not repr()."""
+        from dev_health_ops.metrics.opportunities.models import ImproveOpportunityKind
+
+        id_via_enum = stable_opportunity_id(
+            ImproveOpportunityKind.HIGH_REVIEW_LATENCY, "repo-1", None
+        )
+        id_via_string = stable_opportunity_id("high_review_latency", "repo-1", None)
+        assert id_via_enum == id_via_string


### PR DESCRIPTION
## Summary

Phase 1 of the CHAOS-2218 Opportunities engine — backend foundation only. No GraphQL/API contract changes, no new routes, no frontend.

- **scoring.py** — extracts pure scoring math from ai_detector.py (score_ratio, score_delta, clamp, stable_opportunity_id) as public functions; ai_detector.py now imports from here (pure refactor, all existing tests pass)
- **models.py** — ImproveOpportunity (frozen dataclass), ImproveOpportunityKind enum (7 kinds), FlowScopeInput
- **flow_detector.py** — FlowOpportunityDetector(client).detect(): two parallel asyncio.gather GROUP BY queries (repo_metrics_daily + work_item_metrics_daily), HAVING data_days >= 5, org_id via OrgScopedQuery, per-rule try/except, returns [] on total failure
- **84 new unit tests** — scoring primitives, model invariants, all 7 rule functions (fires/skips at/above/below threshold, score monotonicity), detector integration (org-scoping, parallelism, limit, failure isolation)

## ClickHouse column verification

All queried columns confirmed present in live dev ClickHouse:
- repo_metrics_daily: pr_first_review_p50_hours, pr_rework_ratio, rework_churn_ratio_30d, change_failure_rate, total_loc_touched (512 non-null rows)
- work_item_metrics_daily: cycle_time_p50_hours, wip_congestion_ratio, items_completed, defect_intro_rate (882 non-null rows)

## Test plan

- [x] 84 new unit tests pass
- [x] 5 pre-existing ai_detector tests still pass (behavior-identical refactor)
- [x] ruff check + ruff format clean
- [x] mypy no issues on new module
- [x] Full unit suite: 3637 passed, 43 pre-existing infrastructure failures (redis/org-deletion, identical on main)

## SCREENSHOT-WAIVER

Backend-only change. No rendered UI output.

Closes CHAOS-2218 (Phase 1 only)