### PR TITLE
fix(operating-review): generate recommendations from worsened metrics (CHAOS-2181)

### DIFF
--- a/src/dev_health_ops/metrics/operating_review.py
+++ b/src/dev_health_ops/metrics/operating_review.py
@@ -393,14 +393,15 @@ def compute_operating_review(
         _investment_section(current, prior),
         _ai_workflow_section(current, prior),
     ]
+    recommendations = _recommendations_from_sections(sections)
     return OperatingReview(
         org_id=org_id,
         team_id=team_id,
         week_start=week_start,
         prior_week_start=prior_week_start(week_start),
         sections=sections,
-        recommendations=[],
-        recommendations_empty_state="No operating review rules are configured.",
+        recommendations=recommendations,
+        recommendations_empty_state="No signals worsened this week.",
     )
 
 
@@ -742,6 +743,27 @@ def _delta_summary(metric: OperatingReviewMetric) -> str:
         "unchanged": "did not change",
     }[metric.delta.status]
     return f"{metric.label} {direction} by {metric.delta.absolute:+.1f} {metric.unit}"
+
+
+def _recommendations_from_sections(
+    sections: list[OperatingReviewSection],
+) -> list[str]:
+    """Derive plain-language recommendations from worsened metrics.
+
+    For each metric whose delta status is ``"worsened"`` across all sections,
+    emit one recommendation sentence: "Review {label}: worsened by {absolute:+.1f}
+    {unit} week-over-week."  This is a pure pass over already-computed section
+    data — no re-querying or extra computation.
+    """
+    recommendations: list[str] = []
+    for section in sections:
+        for metric in section.metrics:
+            if metric.delta.status == "worsened":
+                recommendations.append(
+                    f"Review {metric.label}: worsened by "
+                    f"{metric.delta.absolute:+.1f} {metric.unit} week-over-week."
+                )
+    return recommendations
 
 
 def _value(row: Mapping[str, Any], key: str) -> float | None:

--- a/tests/metrics/test_operating_review.py
+++ b/tests/metrics/test_operating_review.py
@@ -190,11 +190,14 @@ def test_operating_review_computes_sections_and_week_over_week_deltas() -> None:
     assert ai_workflow.metric("ai_governance_coverage").value == pytest.approx(0.825)
     assert ai_workflow.metric("ai_opportunity_signals").value == 0
 
-    assert review.recommendations == []
-    assert (
-        review.recommendations_empty_state
-        == "No operating review rules are configured."
-    )
+    # WIP count max(8,12)=12 vs prior 9 → worsened (lower is better).
+    # All other delivery/risk/reliability/investment/ai metrics improved or changed.
+    assert len(review.recommendations) == 1
+    wip_rec = review.recommendations[0]
+    assert "WIP" in wip_rec
+    assert "worsened by" in wip_rec
+    assert "week-over-week" in wip_rec
+    assert review.recommendations_empty_state == "No signals worsened this week."
 
 
 def test_operating_review_renders_for_empty_team_week() -> None:
@@ -320,3 +323,70 @@ def test_compute_operating_review_all_teams_mode_emits_null_team_id() -> None:
     # Throughput sums across the two team rows (SUM aggregation contract).
     delivery = review.section("delivery_movement")
     assert delivery.metric("throughput").value == 14 + 11
+
+
+def test_recommendations_populated_from_worsened_metrics() -> None:
+    """Worsened metrics produce recommendation sentences; no worsened → empty list."""
+    # Prior week was better on throughput (higher is better: 20→10 = worsened)
+    # and cycle time got worse (lower is better: 30→48 = worsened).
+    review_with_worsened = compute_operating_review(
+        org_id="org-1",
+        team_id="team-a",
+        week_start=date(2026, 5, 18),
+        current=OperatingReviewRows(
+            work_items=[
+                {
+                    "items_completed": 10,
+                    "items_started": 8,
+                    "wip_count_end_of_day": 5,
+                    "cycle_time_p50_hours": 48.0,
+                    "wip_age_p90_hours": 60.0,
+                }
+            ],
+        ),
+        prior=OperatingReviewRows(
+            work_items=[
+                {
+                    "items_completed": 20,
+                    "items_started": 15,
+                    "wip_count_end_of_day": 8,
+                    "cycle_time_p50_hours": 30.0,
+                    "wip_age_p90_hours": 40.0,
+                }
+            ],
+        ),
+    )
+
+    recs = review_with_worsened.recommendations
+    assert len(recs) > 0, "Expected at least one recommendation for worsened metrics"
+    # Each recommendation mentions the metric label and "week-over-week".
+    for rec in recs:
+        assert "worsened by" in rec
+        assert "week-over-week" in rec
+    # Throughput is worsened (20→10, higher is better).
+    throughput_rec = next((r for r in recs if "Throughput" in r), None)
+    assert throughput_rec is not None
+    assert "+10" not in throughput_rec  # absolute is -10 for worsened
+    assert (
+        "-10" in throughput_rec or "−10" in throughput_rec or "-10.0" in throughput_rec
+    )
+
+    # Empty state is updated message.
+    assert (
+        review_with_worsened.recommendations_empty_state
+        == "No signals worsened this week."
+    )
+
+    # Review with no worsened signals has empty recommendations.
+    review_no_worsened = compute_operating_review(
+        org_id="org-1",
+        team_id="team-a",
+        week_start=date(2026, 5, 18),
+        current=OperatingReviewRows(),
+        prior=OperatingReviewRows(),
+    )
+    assert review_no_worsened.recommendations == []
+    assert (
+        review_no_worsened.recommendations_empty_state
+        == "No signals worsened this week."
+    )


### PR DESCRIPTION
## Summary

- Replace hardwired `recommendations=[]` in `compute_operating_review` with a pure-Python pass over computed sections
- For each metric with `delta.status=="worsened"`, emit: `"Review {label}: worsened by {absolute:+.1f} {unit} week-over-week."`
- Update `recommendations_empty_state` copy from `"No operating review rules are configured."` → `"No signals worsened this week."`
- Add `test_recommendations_populated_from_worsened_metrics` unit test covering both the populated and empty cases

## Test plan

- [x] `pytest tests/metrics/test_operating_review.py` — 6/6 pass
- [x] `mypy src/dev_health_ops/metrics/operating_review.py` — clean
- [x] `ruff check` + `ruff format --check` — clean

SCREENSHOT-WAIVER: backend-only change, no rendered frontend output in this repo

Closes CHAOS-2181 (ops sub-task)