### PR TITLE
fix(api): sanitize rework allocation + add pr_rework_ratio catalog description (CHAOS-2181)

### DIFF
--- a/src/dev_health_ops/api/graphql/loaders/dimension_loader.py
+++ b/src/dev_health_ops/api/graphql/loaders/dimension_loader.py
@@ -84,6 +84,7 @@ def get_measure_descriptions() -> dict[str, str]:
     return {
         Measure.COUNT.value: "Count of work units",
         Measure.CHURN_LOC.value: "Lines of code changed",
+        Measure.PR_REWORK_RATIO.value: "Share of PRs that required multiple review rounds",
         Measure.CYCLE_TIME_HOURS.value: "Average cycle time in hours",
         Measure.THROUGHPUT.value: "Distinct work units completed",
         Measure.PIPELINE_SUCCESS_RATE.value: "CI/CD pipeline success rate",

--- a/src/dev_health_ops/api/services/home.py
+++ b/src/dev_health_ops/api/services/home.py
@@ -957,7 +957,17 @@ async def build_home_response(
             ),
         )
         rework_theme_allocation = [
-            ReworkThemeAllocation(**row) for row in rework_theme_allocation_rows
+            ReworkThemeAllocation(
+                **{
+                    **row,
+                    # Sanitize non-finite floats (NaN/inf) so the JSON response
+                    # stays spec-compliant, matching every other numeric field
+                    # in this payload.
+                    "allocation": safe_float(row.get("allocation")),
+                    "allocation_pct": safe_float(row.get("allocation_pct")),
+                }
+            )
+            for row in rework_theme_allocation_rows
         ]
 
         sources = {

--- a/tests/graphql/test_resolvers.py
+++ b/tests/graphql/test_resolvers.py
@@ -138,9 +138,30 @@ class TestResolveCatalog:
         result = await resolve_catalog(mock_context)
 
         for measure in result.measures:
-            assert measure.description is not None
+            assert measure.description is not None, (
+                f"measure {measure.name!r} has no description"
+            )
             # Description should be meaningful (not empty)
-            assert len(measure.description) > 0
+            assert len(measure.description) > 0, (
+                f"measure {measure.name!r} has an empty description; "
+                f"add it to get_measure_descriptions()"
+            )
+
+    def test_every_measure_enum_member_has_a_description(self):
+        """Guard: get_measure_descriptions() must cover every Measure enum member.
+
+        Prevents the failure mode where a new measure is added to the enum but
+        its description is forgotten (which surfaces as an empty-string
+        description in the catalog).
+        """
+        from dev_health_ops.api.graphql.loaders.dimension_loader import (
+            get_measure_descriptions,
+        )
+        from dev_health_ops.api.graphql.sql.validate import Measure
+
+        descriptions = get_measure_descriptions()
+        missing = [m.value for m in Measure if not descriptions.get(m.value)]
+        assert not missing, f"measures missing descriptions: {missing}"
 
 
 class TestContextOrgIdRequirement:

--- a/tests/test_api_sanitization.py
+++ b/tests/test_api_sanitization.py
@@ -54,6 +54,20 @@ async def test_home_response_sanitizes_non_finite_values(monkeypatch):
     async def _fake_fetch_metric_driver_delta(*_args, **_kwargs):
         return []
 
+    async def _fake_fetch_rework_theme_allocation(*_args, **_kwargs):
+        # Carry a non-finite value through the rework-allocation path to assert
+        # the response sanitizes it (mirrors the other NaN-returning fakes).
+        return [
+            {
+                "theme": "maintenance",
+                "label": "Maintenance",
+                "allocation": float("nan"),
+                "allocation_pct": float("nan"),
+                "prs_merged": 0,
+                "churn_loc": 0,
+            }
+        ]
+
     monkeypatch.setattr(home_service, "clickhouse_client", _fake_clickhouse_client)
     monkeypatch.setattr(
         home_service, "scope_filter_for_metric", _fake_scope_filter_for_metric
@@ -67,6 +81,11 @@ async def test_home_response_sanitizes_non_finite_values(monkeypatch):
     monkeypatch.setattr(home_service, "fetch_coverage", _fake_fetch_coverage)
     monkeypatch.setattr(
         home_service, "fetch_metric_driver_delta", _fake_fetch_metric_driver_delta
+    )
+    monkeypatch.setattr(
+        home_service,
+        "fetch_rework_theme_allocation",
+        _fake_fetch_rework_theme_allocation,
     )
 
     response = await home_service.build_home_response(


### PR DESCRIPTION
## Summary

Two latent failures on the `integration/chaos-market-ready-ux-ops` base, surfaced while greening the operating-review PR (#820). Both bugs were introduced by the CHAOS-2155 rework-signals work merged into that branch.

- **Bug 1 — Missing catalog description:** `get_measure_descriptions()` had no entry for the `PR_REWORK_RATIO` measure (added to the `Measure` enum by the rework-signals work), so the catalog emitted an empty description and `test_catalog_measures_have_descriptions` failed. Added the description and a guard test (`test_every_measure_enum_member_has_a_description`) asserting every `Measure` enum member is covered.

- **Bug 2 — NaN/inf serialization leak (real prod bug):** `build_home_response()` built `ReworkThemeAllocation` rows without running `allocation`/`allocation_pct` through `safe_float`, so a non-finite value (NaN/inf) from ClickHouse would leak into the JSON response and break `json.dumps(allow_nan=False)`. Sanitized both floats, matching every other numeric field in the payload. Extended `test_home_response_sanitizes_non_finite_values` to mock `fetch_rework_theme_allocation` and assert this path is sanitized.

## Files changed (4)

- `src/dev_health_ops/api/graphql/loaders/dimension_loader.py` — added `PR_REWORK_RATIO` description
- `src/dev_health_ops/api/services/home.py` — wrapped `allocation`/`allocation_pct` in `safe_float`
- `tests/graphql/test_resolvers.py` — added `test_every_measure_enum_member_has_a_description` guard
- `tests/test_api_sanitization.py` — extended `test_home_response_sanitizes_non_finite_values` to cover the `ReworkThemeAllocation` path

## Main-latent-bug verdict

**Main is also affected by Bug 2.** `main:src/dev_health_ops/api/services/home.py:960` uses `ReworkThemeAllocation(**row)` without `safe_float` — identical to what was fixed here. Bug 1 is NOT present on main (main already has the `PR_REWORK_RATIO` description at line 87 of `dimension_loader.py`). A separate main-targeted fix is needed for the NaN/inf serialization issue.

## Test plan

- [x] `test_catalog_measures_have_descriptions` — PASSES
- [x] `test_every_measure_enum_member_has_a_description` — PASSES
- [x] `test_home_response_sanitizes_non_finite_values` — PASSES
- [x] `ruff format --check` — clean
- [x] `ruff check` — clean
- [x] `mypy` on touched source files — clean

## SCREENSHOT-WAIVER

These are test/backend-only fixes with no impact on rendered frontend output. No API shape changes, no new/modified GraphQL fields.