### PR TITLE
fix(api): sanitize ReworkThemeAllocation floats in build_home_response (NaN/inf JSON leak)

### DIFF
--- a/src/dev_health_ops/api/services/home.py
+++ b/src/dev_health_ops/api/services/home.py
@@ -957,7 +957,17 @@ async def build_home_response(
             ),
         )
         rework_theme_allocation = [
-            ReworkThemeAllocation(**row) for row in rework_theme_allocation_rows
+            ReworkThemeAllocation(
+                **{
+                    **row,
+                    # Sanitize non-finite floats (NaN/inf) so the JSON response
+                    # stays spec-compliant, matching every other numeric field
+                    # in this payload.
+                    "allocation": safe_float(row.get("allocation")),
+                    "allocation_pct": safe_float(row.get("allocation_pct")),
+                }
+            )
+            for row in rework_theme_allocation_rows
         ]
 
         sources = {

--- a/tests/test_api_sanitization.py
+++ b/tests/test_api_sanitization.py
@@ -55,7 +55,18 @@ async def test_home_response_sanitizes_non_finite_values(monkeypatch):
         return []
 
     async def _fake_fetch_rework_theme_allocation(*_args, **_kwargs):
-        return []
+        # Carry a non-finite value through the rework-allocation path to assert
+        # the response sanitizes it (mirrors the other NaN-returning fakes).
+        return [
+            {
+                "theme": "maintenance",
+                "label": "Maintenance",
+                "allocation": float("nan"),
+                "allocation_pct": float("nan"),
+                "prs_merged": 0,
+                "churn_loc": 0,
+            }
+        ]
 
     monkeypatch.setattr(home_service, "clickhouse_client", _fake_clickhouse_client)
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

`build_home_response()` builds `ReworkThemeAllocation` rows with `ReworkThemeAllocation(**row)` — without running the float fields through `safe_float`. A non-finite value (NaN/inf) coming from ClickHouse therefore leaks straight into the JSON response and breaks `json.dumps(allow_nan=False)`, which the API relies on for spec-compliant output. Every other numeric field in this payload is already sanitized via `safe_float`; this row type was the one gap.

This is a **real latent production bug on `main`** — surfaced during CHAOS-2181 recon while greening the operating-review work. It is the **companion to #821**, which fixes the identical bug on the `integration/chaos-market-ready-ux-ops` branch (that PR also carries a catalog-description fix that main does not need).

## Fix

`src/dev_health_ops/api/services/home.py` — wrap `allocation` and `allocation_pct` (the only two `float` fields on `ReworkThemeAllocation`; `prs_merged`/`churn_loc` are ints) in `safe_float` when constructing each row.

## Test

`tests/test_api_sanitization.py` — extended `test_home_response_sanitizes_non_finite_values` so its `_fake_fetch_rework_theme_allocation` returns a row carrying `float("nan")` for `allocation`/`allocation_pct` (previously it returned an empty list and never exercised this path). The test asserts `json.dumps(payload, allow_nan=False)` succeeds.

## Test plan

- [x] `test_home_response_sanitizes_non_finite_values` — PASSES
- [x] `ruff format --check` + `ruff check` — clean
- [x] `mypy` on `home.py` — `Success: no issues found`

Diff is 2 files (the `safe_float` wrap + the test extension); no other changes.

## SCREENSHOT-WAIVER

Backend/test-only sanitization fix. No API shape change, no new/modified GraphQL fields, no rendered-frontend impact (a NaN would previously have produced an invalid JSON response / serialization error rather than a different valid render).