### PR TITLE
feat(ai): CHAOS-2180 Wave 2 — review engagement, risk overlaps, impact breakdowns, dense team pagination

### DIFF
--- a/src/dev_health_ops/api/graphql/models/ai.py
+++ b/src/dev_health_ops/api/graphql/models/ai.py
@@ -288,6 +288,11 @@ class AIHotspotOverlapRow:
     ``prs_total`` counts AI-attributed PRs whose changed files could be
     resolved through the work graph (the assessable universe); PRs without
     commit/file linkage are excluded rather than silently diluting the rate.
+
+    ``hotspot_overlap_rate`` is the share of assessable PRs touching
+    **top-decile-risk** files (top 10% of latest ``risk_score`` per repo in
+    the window, minimum one file per repo) — not merely above-average-risk
+    files, which would saturate the rate at ~1.0.
     """
 
     bucket: str

--- a/src/dev_health_ops/api/graphql/models/ai.py
+++ b/src/dev_health_ops/api/graphql/models/ai.py
@@ -140,6 +140,22 @@ class AIImpactBucketTotals:
 
 
 @strawberry.type
+class AIImpactScopeRollupRow:
+    """Per-repo or per-team rollup of AI-attributed PR activity.
+
+    ``scope_id`` is a repo UUID string or a team id; ``scope_label`` is the
+    human-readable name (repo full-name or team name, falling back to the id
+    when the label cannot be resolved).
+    """
+
+    scope_id: str
+    scope_label: str
+    ai_prs_total: int
+    ai_assisted_pr_ratio: float | None
+    rework_rate_delta: float | None
+
+
+@strawberry.type
 class AIImpactSummary:
     """Summary of AI workflow impact across a requested time range."""
 
@@ -154,6 +170,8 @@ class AIImpactSummary:
     ai_assisted_pr_ratio: float | None
     by_bucket: list[AIImpactBucketTotals]
     daily: list[AIImpactBucketRow]
+    repo_breakdown: list[AIImpactScopeRollupRow]
+    team_breakdown: list[AIImpactScopeRollupRow]
     missing_states: list[AIMissingState]
     data_available: bool
     computed_at: datetime | None = None
@@ -201,7 +219,12 @@ class AIComparison:
 
 @strawberry.type
 class AIReviewLoadRow:
-    """Per-bucket review-load row."""
+    """Per-bucket review-load row.
+
+    ``pickup_latency_hours`` and ``review_comments_per_loc`` are computed at
+    query time from ``git_pull_requests`` (CHAOS-2194). ``None`` means the
+    underlying inputs were unavailable for the slice — never a computed zero.
+    """
 
     bucket: str
     prs_total: int
@@ -211,6 +234,8 @@ class AIReviewLoadRow:
     review_amplification: float | None
     post_first_review_pushes_count: int
     post_first_review_pushes_per_pr: float | None
+    pickup_latency_hours: float | None = None
+    review_comments_per_loc: float | None = None
 
 
 @strawberry.type
@@ -257,6 +282,35 @@ class AIRiskBreakdownRow:
 
 
 @strawberry.type
+class AIHotspotOverlapRow:
+    """Per-bucket overlap between AI-attributed PRs and hotspot files.
+
+    ``prs_total`` counts AI-attributed PRs whose changed files could be
+    resolved through the work graph (the assessable universe); PRs without
+    commit/file linkage are excluded rather than silently diluting the rate.
+    """
+
+    bucket: str
+    prs_total: int
+    prs_touching_hotspots: int
+    hotspot_overlap_rate: float | None
+    avg_hotspot_risk_score: float | None
+
+
+@strawberry.type
+class AIComplexityOverlapRow:
+    """Per-bucket overlap between AI-attributed PRs and high-complexity files.
+
+    Same assessable-universe semantics as :class:`AIHotspotOverlapRow`.
+    """
+
+    bucket: str
+    prs_total: int
+    prs_touching_high_complexity: int
+    complexity_overlap_rate: float | None
+
+
+@strawberry.type
 class AIRiskBreakdownResult:
     """Risk breakdown across buckets."""
 
@@ -264,6 +318,8 @@ class AIRiskBreakdownResult:
     start_date: date
     end_date: date
     by_bucket: list[AIRiskBreakdownRow]
+    hotspot_overlap: list[AIHotspotOverlapRow]
+    complexity_overlap: list[AIComplexityOverlapRow]
     missing_states: list[AIMissingState]
     data_available: bool
 

--- a/src/dev_health_ops/api/graphql/resolvers/ai.py
+++ b/src/dev_health_ops/api/graphql/resolvers/ai.py
@@ -40,12 +40,15 @@ from ..models.ai import (
     AIComparison,
     AIComparisonDelta,
     AIComparisonSide,
+    AIComplexityOverlapRow,
     AIDateRangeInput,
     AIGovernanceCoverageRow,
     AIGovernanceSummary,
     AIGovernanceViolationRow,
+    AIHotspotOverlapRow,
     AIImpactBucketRow,
     AIImpactBucketTotals,
+    AIImpactScopeRollupRow,
     AIImpactSummary,
     AILeverageComponents,
     AIMissingState,
@@ -274,6 +277,92 @@ def _aggregate_bucket_totals(rows: list[Any]) -> dict[str, AIImpactBucketTotals]
 # resolve_ai_impact_summary
 # =============================================================================
 
+_SCOPE_BREAKDOWN_LIMIT = 10
+
+
+def _scope_rollups(
+    rows: list[Any],
+    *,
+    key_fn: Any,
+    labels: dict[str, str],
+) -> list[AIImpactScopeRollupRow]:
+    """Aggregate daily records into per-scope AI rollups (CHAOS-2186).
+
+    ``key_fn`` extracts the scope id (repo uuid string or team id) from a
+    record; records with no scope id are skipped. Scopes with zero
+    AI-attributed PRs are dropped — an empty list is the honest "no AI
+    activity ranked" state, not a fabricated zero row.
+    """
+    grouped: dict[str, list[Any]] = defaultdict(list)
+    for row in rows:
+        key = key_fn(row)
+        if not key:
+            continue
+        grouped[str(key)].append(row)
+
+    rollups: list[AIImpactScopeRollupRow] = []
+    for scope_id, scope_rows in grouped.items():
+        ai_rows = [
+            r for r in scope_rows if r.attribution_bucket in AI_ATTRIBUTION_BUCKETS
+        ]
+        human_rows = [r for r in scope_rows if r.attribution_bucket == _BASELINE_BUCKET]
+        ai_prs_total = sum(r.prs_total for r in ai_rows)
+        if ai_prs_total <= 0:
+            continue
+        all_prs_total = sum(r.prs_total for r in scope_rows)
+        ai_rework = _weighted_avg([(r.rework_drag_rate, r.prs_total) for r in ai_rows])
+        human_rework = _weighted_avg(
+            [(r.rework_drag_rate, r.prs_total) for r in human_rows]
+        )
+        rollups.append(
+            AIImpactScopeRollupRow(
+                scope_id=scope_id,
+                scope_label=labels.get(scope_id, scope_id),
+                ai_prs_total=ai_prs_total,
+                ai_assisted_pr_ratio=_ratio(ai_prs_total, all_prs_total),
+                rework_rate_delta=_delta(ai_rework, human_rework),
+            )
+        )
+    rollups.sort(key=lambda r: (-r.ai_prs_total, r.scope_id))
+    return rollups[:_SCOPE_BREAKDOWN_LIMIT]
+
+
+async def _load_scope_breakdowns(
+    context: GraphQLContext,
+    org_id: str,
+    rows: list[Any],
+) -> tuple[list[AIImpactScopeRollupRow], list[AIImpactScopeRollupRow]]:
+    """Build per-repo and per-team rollups with resolved display labels."""
+    if not rows:
+        return [], []
+    loader = AIImpactClickHouseLoader(_require_client(context), org_id=org_id)
+
+    repo_ids = sorted({str(r.repo_id) for r in rows if r.repo_id})
+    try:
+        repo_labels = await loader.load_repo_labels(repo_ids)
+    except Exception as exc:
+        logger.warning("Could not resolve repo labels for AI breakdown: %s", exc)
+        repo_labels = {}
+
+    team_ids = sorted({str(r.team_id) for r in rows if r.team_id})
+    try:
+        team_labels = await loader.load_team_labels(team_ids)
+    except Exception as exc:
+        logger.warning("Could not resolve team labels for AI breakdown: %s", exc)
+        team_labels = {}
+
+    repo_breakdown = _scope_rollups(
+        rows,
+        key_fn=lambda r: str(r.repo_id) if r.repo_id else None,
+        labels=repo_labels,
+    )
+    team_breakdown = _scope_rollups(
+        rows,
+        key_fn=lambda r: r.team_id or None,
+        labels=team_labels,
+    )
+    return repo_breakdown, team_breakdown
+
 
 async def resolve_ai_impact_summary(
     context: GraphQLContext,
@@ -291,6 +380,7 @@ async def resolve_ai_impact_summary(
 
     by_bucket = _aggregate_bucket_totals(rows)
     daily = [_row_to_impact_daily(row) for row in rows]
+    repo_breakdown, team_breakdown = await _load_scope_breakdowns(context, org_id, rows)
 
     total_prs = sum(r.prs_total for r in rows)
     ai_assisted = sum(r.ai_assisted_prs for r in rows)
@@ -304,6 +394,18 @@ async def resolve_ai_impact_summary(
         for state in [_unknown_attribution_missing_state(unknown)]
         if state is not None
     ]
+    if rows and not repo_breakdown and not team_breakdown:
+        missing_states.append(
+            _missing_state(
+                "scope_breakdown",
+                "No repo or team rollups with AI activity",
+                (
+                    "No repos or teams in this scope have AI-attributed PRs "
+                    "in the window, so ranked rollups stay empty. This is a "
+                    "no-data state, not a zero-impact signal."
+                ),
+            )
+        )
 
     return AIImpactSummary(
         org_id=org_id,
@@ -317,6 +419,8 @@ async def resolve_ai_impact_summary(
         ai_assisted_pr_ratio=_ratio(ai_assisted, total_prs),
         by_bucket=sorted(by_bucket.values(), key=lambda r: r.bucket),
         daily=daily,
+        repo_breakdown=repo_breakdown,
+        team_breakdown=team_breakdown,
         missing_states=missing_states,
         data_available=bool(rows),
         computed_at=computed_at,
@@ -437,6 +541,85 @@ async def _load_reviewer_concentration(
     )
 
 
+class _EngagementSlice:
+    """Accumulated engagement inputs for one (bucket, day) or one bucket."""
+
+    __slots__ = ("latency_pairs", "comments_total", "loc_total")
+
+    def __init__(self) -> None:
+        self.latency_pairs: list[tuple[float | None, float]] = []
+        self.comments_total = 0
+        self.loc_total = 0
+
+    def add(self, raw: dict[str, Any]) -> None:
+        latency = raw.get("pickup_latency_hours")
+        weight = float(raw.get("prs_with_first_review") or 0)
+        self.latency_pairs.append(
+            (float(latency) if latency is not None else None, weight)
+        )
+        self.comments_total += int(raw.get("review_comments_total") or 0)
+        self.loc_total += int(raw.get("loc_total") or 0)
+
+    @property
+    def pickup_latency_hours(self) -> float | None:
+        return _weighted_avg(self.latency_pairs)
+
+    @property
+    def review_comments_per_loc(self) -> float | None:
+        if self.loc_total <= 0:
+            return None
+        return self.comments_total / self.loc_total
+
+
+async def _load_engagement_slices(
+    context: GraphQLContext,
+    org_id: str,
+    date_range: AIDateRangeInput,
+    scope: AIScopeInput | None,
+) -> tuple[dict[tuple[str, Any], _EngagementSlice], dict[str, _EngagementSlice]]:
+    """Load CHAOS-2194 engagement metrics keyed by (bucket, day) and bucket.
+
+    A ``work_type`` scope cannot be applied to the raw-PR engagement query
+    (work types live on the linkage path only), so engagement is reported as
+    unavailable rather than silently mis-scoped. Team scopes are translated
+    to repo ids first; an unresolvable team also yields unavailable.
+    """
+    repo_id, team_id, work_type = _normalize_scope(scope)
+    if work_type:
+        return {}, {}
+
+    team_repo_ids: list[uuid.UUID] | None = None
+    if team_id:
+        team_repo_ids = await _resolve_team_repo_ids(
+            _require_client(context), org_id=org_id, team_id=team_id
+        )
+        if team_repo_ids is None or not team_repo_ids:
+            return {}, {}
+
+    start_dt = datetime.combine(date_range.start_date, time.min, tzinfo=timezone.utc)
+    end_dt = datetime.combine(date_range.end_date, time.max, tzinfo=timezone.utc)
+    loader = AIImpactClickHouseLoader(_require_client(context), org_id=org_id)
+    try:
+        raw_rows = await loader.load_review_engagement(
+            start=start_dt,
+            end=end_dt,
+            repo_id=repo_id,
+            repo_ids=team_repo_ids,
+        )
+    except Exception as exc:
+        logger.warning("AI review engagement query failed: %s", exc)
+        return {}, {}
+
+    by_day: dict[tuple[str, Any], _EngagementSlice] = {}
+    by_bucket: dict[str, _EngagementSlice] = {}
+    for raw in raw_rows:
+        bucket = str(raw.get("bucket") or "unknown")
+        day_key = (bucket, raw.get("day"))
+        by_day.setdefault(day_key, _EngagementSlice()).add(raw)
+        by_bucket.setdefault(bucket, _EngagementSlice()).add(raw)
+    return by_day, by_bucket
+
+
 async def resolve_ai_review_load(
     context: GraphQLContext,
     date_range: AIDateRangeInput,
@@ -444,22 +627,34 @@ async def resolve_ai_review_load(
 ) -> AIReviewLoadResult:
     org_id = require_org_id(context)
     rows = await _load_daily_records(context, org_id, date_range, scope)
+    engagement_by_day, engagement_by_bucket = await _load_engagement_slices(
+        context, org_id, date_range, scope
+    )
 
-    daily = [
-        AIReviewLoadRow(
-            bucket=row.attribution_bucket,
-            prs_total=row.prs_total,
-            reviews_total=_review_total_for_row(row),
-            reviews_per_pr=row.reviews_per_pr,
-            changes_requested_per_pr=row.changes_requested_per_pr,
-            review_amplification=row.ai_review_amplification,
-            post_first_review_pushes_count=row.followup_commits_count,
-            post_first_review_pushes_per_pr=_ratio(
-                row.followup_commits_count, row.prs_total
-            ),
+    def _day_engagement(bucket: str, day: Any) -> _EngagementSlice | None:
+        return engagement_by_day.get((bucket, day))
+
+    daily = []
+    for row in rows:
+        slice_ = _day_engagement(row.attribution_bucket, row.day)
+        daily.append(
+            AIReviewLoadRow(
+                bucket=row.attribution_bucket,
+                prs_total=row.prs_total,
+                reviews_total=_review_total_for_row(row),
+                reviews_per_pr=row.reviews_per_pr,
+                changes_requested_per_pr=row.changes_requested_per_pr,
+                review_amplification=row.ai_review_amplification,
+                post_first_review_pushes_count=row.followup_commits_count,
+                post_first_review_pushes_per_pr=_ratio(
+                    row.followup_commits_count, row.prs_total
+                ),
+                pickup_latency_hours=(slice_.pickup_latency_hours if slice_ else None),
+                review_comments_per_loc=(
+                    slice_.review_comments_per_loc if slice_ else None
+                ),
+            )
         )
-        for row in rows
-    ]
 
     by_bucket_acc: dict[str, list[Any]] = defaultdict(list)
     for row in rows:
@@ -470,6 +665,7 @@ async def resolve_ai_review_load(
         prs_total = sum(r.prs_total for r in bucket_rows)
         reviews_total = sum(_review_total_for_row(r) for r in bucket_rows)
         post_first_review_pushes = sum(r.followup_commits_count for r in bucket_rows)
+        bucket_slice = engagement_by_bucket.get(bucket)
         by_bucket.append(
             AIReviewLoadRow(
                 bucket=bucket,
@@ -488,6 +684,12 @@ async def resolve_ai_review_load(
                 post_first_review_pushes_per_pr=_ratio(
                     post_first_review_pushes, prs_total
                 ),
+                pickup_latency_hours=(
+                    bucket_slice.pickup_latency_hours if bucket_slice else None
+                ),
+                review_comments_per_loc=(
+                    bucket_slice.review_comments_per_loc if bucket_slice else None
+                ),
             )
         )
     by_bucket.sort(key=lambda r: r.bucket)
@@ -496,6 +698,20 @@ async def resolve_ai_review_load(
         context, org_id, date_range, scope
     )
     missing_states = []
+    if rows and not engagement_by_bucket:
+        missing_states.append(
+            _missing_state(
+                "review_engagement",
+                "Pickup latency and comment density unavailable",
+                (
+                    "Pickup latency and review comments per changed line could "
+                    "not be computed for this scope — the raw pull-request "
+                    "review timestamps or size fields are missing, or the "
+                    "scope (work type, unresolved team) cannot be applied to "
+                    "raw PR rows. Treat as no-data, not as zero."
+                ),
+            )
+        )
     if not reviewer_concentration.data_available:
         missing_states.append(
             _missing_state(
@@ -561,33 +777,140 @@ async def resolve_ai_risk_breakdown(
         )
     by_bucket.sort(key=lambda r: r.bucket)
 
+    hotspot_overlap, complexity_overlap = await _load_overlap_rows(
+        context, org_id, date_range, scope
+    )
+
+    missing_states: list[AIMissingState] = []
+    if not hotspot_overlap:
+        missing_states.append(
+            _missing_state(
+                "hotspot_overlap",
+                "Hotspot overlap has no assessable AI PRs",
+                (
+                    "No AI-attributed PRs in this window could be joined to "
+                    "hotspot files — either no AI PRs have commit/file "
+                    "linkage yet or no hotspot snapshots exist for the "
+                    "window. Treat missing overlap as no data, not as no "
+                    "risk."
+                ),
+            )
+        )
+    if not complexity_overlap:
+        missing_states.append(
+            _missing_state(
+                "complexity_overlap",
+                "Complexity overlap has no assessable AI PRs",
+                (
+                    "No AI-attributed PRs in this window could be joined to "
+                    "high-complexity files. Drill into PR and Work Graph "
+                    "evidence when available; do not infer person-level "
+                    "quality from this gap."
+                ),
+            )
+        )
+
     return AIRiskBreakdownResult(
         org_id=org_id,
         start_date=date_range.start_date,
         end_date=date_range.end_date,
         by_bucket=by_bucket,
-        missing_states=[
-            _missing_state(
-                "hotspot_overlap",
-                "Hotspot overlap detector not yet wired",
-                (
-                    "AI-attributed PRs are not yet joined to hotspot file "
-                    "overlap. Keep this visible as detector follow-up rather "
-                    "than treating missing overlap as no risk."
-                ),
-            ),
-            _missing_state(
-                "complexity_overlap",
-                "Complexity overlap detector not yet wired",
-                (
-                    "AI-attributed PRs are not yet joined to high-complexity "
-                    "file overlap. Drill into PR and Work Graph evidence when "
-                    "available; do not infer person-level quality from this gap."
-                ),
-            ),
-        ],
+        hotspot_overlap=hotspot_overlap,
+        complexity_overlap=complexity_overlap,
+        missing_states=missing_states,
         data_available=bool(rows),
     )
+
+
+async def _load_overlap_rows(
+    context: GraphQLContext,
+    org_id: str,
+    date_range: AIDateRangeInput,
+    scope: AIScopeInput | None,
+) -> tuple[list[AIHotspotOverlapRow], list[AIComplexityOverlapRow]]:
+    """Load CHAOS-2185 hotspot/complexity overlap rows (best effort).
+
+    Query failures and unresolvable scopes degrade to empty lists, which the
+    caller renders as explicit missing states — never as fabricated zeros.
+    A ``work_type`` scope cannot be applied to the raw-PR join, so overlap
+    is reported unavailable for work-type-scoped requests.
+    """
+    repo_id, team_id, work_type = _normalize_scope(scope)
+    if work_type:
+        return [], []
+
+    team_repo_ids: list[uuid.UUID] | None = None
+    if team_id:
+        team_repo_ids = await _resolve_team_repo_ids(
+            _require_client(context), org_id=org_id, team_id=team_id
+        )
+        if team_repo_ids is None or not team_repo_ids:
+            return [], []
+
+    start_dt = datetime.combine(date_range.start_date, time.min, tzinfo=timezone.utc)
+    end_dt = datetime.combine(date_range.end_date, time.max, tzinfo=timezone.utc)
+    loader = AIImpactClickHouseLoader(_require_client(context), org_id=org_id)
+
+    hotspot_rows: list[AIHotspotOverlapRow] = []
+    try:
+        raw_hotspots = await loader.load_hotspot_overlap(
+            start=start_dt,
+            end=end_dt,
+            start_day=date_range.start_date,
+            end_day=date_range.end_date,
+            repo_id=repo_id,
+            repo_ids=team_repo_ids,
+        )
+    except Exception as exc:
+        logger.warning("AI hotspot overlap query failed: %s", exc)
+        raw_hotspots = []
+    for raw in raw_hotspots:
+        prs_total = int(raw.get("prs_total") or 0)
+        if prs_total <= 0:
+            continue
+        touching = int(raw.get("prs_touching_hotspots") or 0)
+        avg_risk = raw.get("avg_hotspot_risk_score")
+        hotspot_rows.append(
+            AIHotspotOverlapRow(
+                bucket=str(raw.get("bucket") or "unknown"),
+                prs_total=prs_total,
+                prs_touching_hotspots=touching,
+                hotspot_overlap_rate=_ratio(touching, prs_total),
+                avg_hotspot_risk_score=(
+                    float(avg_risk) if avg_risk is not None else None
+                ),
+            )
+        )
+    hotspot_rows.sort(key=lambda r: r.bucket)
+
+    complexity_rows: list[AIComplexityOverlapRow] = []
+    try:
+        raw_complexity = await loader.load_complexity_overlap(
+            start=start_dt,
+            end=end_dt,
+            end_day=date_range.end_date,
+            repo_id=repo_id,
+            repo_ids=team_repo_ids,
+        )
+    except Exception as exc:
+        logger.warning("AI complexity overlap query failed: %s", exc)
+        raw_complexity = []
+    for raw in raw_complexity:
+        prs_total = int(raw.get("prs_total") or 0)
+        if prs_total <= 0:
+            continue
+        touching = int(raw.get("prs_touching_high_complexity") or 0)
+        complexity_rows.append(
+            AIComplexityOverlapRow(
+                bucket=str(raw.get("bucket") or "unknown"),
+                prs_total=prs_total,
+                prs_touching_high_complexity=touching,
+                complexity_overlap_rate=_ratio(touching, prs_total),
+            )
+        )
+    complexity_rows.sort(key=lambda r: r.bucket)
+
+    return hotspot_rows, complexity_rows
 
 
 # =============================================================================
@@ -832,6 +1155,55 @@ async def _resolve_repo_team_map(
     return result
 
 
+async def _resolve_team_repo_ids(
+    client: Any,
+    org_id: str,
+    team_id: str,
+) -> list[uuid.UUID] | None:
+    """Resolve a team id to the repo UUIDs whose names match its patterns.
+
+    Returns the (possibly empty) list of repo UUIDs that
+    ``RepoPatternTeamResolver`` assigns to ``team_id``, or ``None`` when the
+    team/repo catalogs cannot be loaded — callers must then fall back to
+    in-memory filtering rather than treating the team as empty.
+    """
+    from dev_health_ops.api.queries.client import query_dicts
+    from dev_health_ops.providers.teams import build_repo_pattern_resolver
+
+    if not org_id or not team_id:
+        return None
+
+    try:
+        team_rows = await query_dicts(
+            client,
+            "SELECT id, name, repo_patterns FROM teams WHERE org_id = {org_id:String}",
+            {"org_id": org_id},
+        )
+        repo_rows = await query_dicts(
+            client,
+            """
+            SELECT toString(id) AS repo_id, repo AS full_name
+            FROM repos
+            WHERE org_id = {org_id:String}
+            """,
+            {"org_id": org_id},
+        )
+    except Exception as exc:
+        logger.warning("Could not resolve team %r to repo ids: %s", team_id, exc)
+        return None
+
+    resolver = build_repo_pattern_resolver(team_rows)
+    repo_ids: list[uuid.UUID] = []
+    for row in repo_rows:
+        full_name = str(row.get("full_name") or "")
+        resolved_team, _ = resolver.resolve(full_name)
+        if (resolved_team or None) == team_id:
+            parsed = _parse_uuid(str(row.get("repo_id")))
+            if parsed is not None:
+                repo_ids.append(parsed)
+    return repo_ids
+
+
 _MAX_AI_ATTRIBUTED_PRS_PAGE = 200
 
 
@@ -862,12 +1234,34 @@ async def resolve_ai_attributed_prs(
     start_dt = datetime.combine(date_range.start_date, time.min, tzinfo=timezone.utc)
     end_dt = datetime.combine(date_range.end_date, time.max, tzinfo=timezone.utc)
 
+    # Resolve the team scope to repo UUIDs BEFORE the SQL LIMIT so pages stay
+    # dense (CHAOS-2180 Wave 2 — Wave 1 filtered in memory after LIMIT, which
+    # returned sparse pages for team-scoped requests). ``None`` means the
+    # catalogs could not be loaded; fall back to in-memory filtering then.
+    team_repo_ids: list[uuid.UUID] | None = None
+    if team_id:
+        team_repo_ids = await _resolve_team_repo_ids(
+            _require_client(context), org_id=org_id, team_id=team_id
+        )
+        if team_repo_ids is not None and not team_repo_ids:
+            # The team resolves to no repos: honestly empty, not an error.
+            return AiAttributedPrsResult(
+                org_id=org_id,
+                start_date=date_range.start_date,
+                end_date=date_range.end_date,
+                rows=[],
+                total=0,
+                has_more=False,
+                data_available=False,
+            )
+
     loader = AIImpactClickHouseLoader(_require_client(context), org_id=org_id)
     # Fetch one extra row so we can report has_more without a COUNT(*) round-trip.
     raw_rows = await loader.load_ai_pr_attributions(
         start=start_dt,
         end=end_dt,
         repo_id=repo_id,
+        repo_ids=team_repo_ids,
         limit=page_size + 1,
         offset=page_offset,
     )

--- a/src/dev_health_ops/metrics/loaders/ai_impact.py
+++ b/src/dev_health_ops/metrics/loaders/ai_impact.py
@@ -291,7 +291,19 @@ class AIImpactClickHouseLoader:
         Mirrors the two linkage paths used by ``load_ai_pr_attributions``:
         via ``work_graph_issue_pr`` and via direct ``subject_id`` matching
         (``"<number>"`` or ``"<repo_id>#<number>"``). ``any(kind)`` collapses
-        ReplacingMergeTree duplicates and dual-path matches.
+        ReplacingMergeTree duplicates and dual-path matches. Both sides are
+        pinned to the same requested org via the WHERE parameters.
+
+        Join identity: ``work_item_id`` is NOT repo-global — an id reused by
+        another repo in the same org must not cross-link attribution onto
+        unrelated PRs — so the linkage additionally requires
+        ``attr.repo_id = link.repo_id`` whenever the attribution carries a
+        repo. ``attr.repo_id`` is Nullable: a repo-less record is a
+        work-item-level attribution whose stated meaning is "this work
+        item's PR work is AI-attributed", and the work-graph link is its
+        resolution mechanism — it binds to every PR linked to that work item
+        (including multi-repo work items). Only repo-pinned records are
+        constrained to their own repo's links.
         """
         org_filter_attr = self._scope.filter(alias="attr")
         org_filter_link = self._scope.filter(alias="link")
@@ -306,7 +318,8 @@ class AIImpactClickHouseLoader:
                 INNER JOIN ai_attribution_resolved AS attr
                     ON attr.subject_type = 'pull_request'
                     AND attr.subject_id = link.work_item_id
-                WHERE 1 = 1 {org_filter_link} {org_filter_attr}
+                WHERE (attr.repo_id IS NULL OR attr.repo_id = link.repo_id)
+                  {org_filter_link} {org_filter_attr}
                 UNION ALL
                 SELECT
                     attr.repo_id AS repo_id,
@@ -373,6 +386,14 @@ class AIImpactClickHouseLoader:
         aggregate read must collapse to ``argMax(..., last_synced)`` first
         (app-code readers like ``load_ai_pr_attributions`` dedupe in Python).
         Org and repo scope filters are applied inside, before the GROUP BY.
+
+        The candidate stage prunes to keys with ANY row version inside the
+        event window so argMax does not aggregate the org's entire PR
+        history. Filtering raw versions directly would be wrong:
+        ``merged_at`` changes between versions (NULL while open, set after
+        merge), so a key's latest version can be in-window while stale
+        versions are not — any-version-qualifies is the safe prefilter, and
+        callers re-apply the window on the deduped values (stage 3).
         """
         scope_filter = self._engagement_scope_filters(params, repo_id, repo_ids)
         org_filter_pr = self._scope.filter(alias="pr")
@@ -390,6 +411,13 @@ class AIImpactClickHouseLoader:
             WHERE 1 = 1
               {scope_filter}
               {org_filter_pr}
+              AND (pr.repo_id, pr.number) IN (
+                  SELECT pr.repo_id, pr.number
+                  FROM git_pull_requests AS pr
+                  WHERE {self._pr_event_window_filter()}
+                    {scope_filter}
+                    {org_filter_pr}
+              )
             GROUP BY pr.repo_id, pr.number
         """
 

--- a/src/dev_health_ops/metrics/loaders/ai_impact.py
+++ b/src/dev_health_ops/metrics/loaders/ai_impact.py
@@ -25,9 +25,16 @@ class AIImpactClickHouseLoader:
         start: datetime,
         end: datetime,
         repo_id: uuid.UUID | None = None,
+        repo_ids: list[uuid.UUID] | None = None,
         limit: int | None = None,
         offset: int = 0,
     ) -> list[AIPullRequestAttributionRow]:
+        """Load AI-attributed PR rows.
+
+        ``repo_ids`` narrows the PR universe in SQL *before* LIMIT/OFFSET so
+        team-scoped pagination stays dense (CHAOS-2180 Wave 2). Resolvers
+        compute it from team repo patterns; ``None`` means no constraint.
+        """
         from dev_health_ops.api.queries.client import query_dicts
 
         params: dict[str, Any] = {
@@ -38,6 +45,11 @@ class AIImpactClickHouseLoader:
         if repo_id is not None:
             params["repo_id"] = str(repo_id)
             repo_filter = "AND pr.repo_id = {repo_id:UUID}"
+        if repo_ids is not None:
+            params["repo_ids"] = [str(r) for r in repo_ids]
+            repo_filter += (
+                "\n              AND toString(pr.repo_id) IN {repo_ids:Array(String)}"
+            )
         params = self._scope.inject(params)
         org_filter_attr = self._scope.filter(alias="attr")
         org_filter_pr = self._scope.filter(alias="pr")
@@ -272,6 +284,318 @@ class AIImpactClickHouseLoader:
         if not review_loads:
             return None, 0
         return _gini(review_loads), len(review_loads)
+
+    def _pr_attribution_subquery(self) -> str:
+        """Deduped (repo_id, number, kind) attribution map subquery.
+
+        Mirrors the two linkage paths used by ``load_ai_pr_attributions``:
+        via ``work_graph_issue_pr`` and via direct ``subject_id`` matching
+        (``"<number>"`` or ``"<repo_id>#<number>"``). ``any(kind)`` collapses
+        ReplacingMergeTree duplicates and dual-path matches.
+        """
+        org_filter_attr = self._scope.filter(alias="attr")
+        return f"""
+            SELECT repo_id, number, any(kind) AS kind
+            FROM (
+                SELECT
+                    link.repo_id AS repo_id,
+                    link.pr_number AS number,
+                    attr.kind AS kind
+                FROM work_graph_issue_pr AS link
+                INNER JOIN ai_attribution_resolved AS attr
+                    ON attr.subject_type = 'pull_request'
+                    AND attr.subject_id = link.work_item_id
+                WHERE 1 = 1 {org_filter_attr}
+                UNION ALL
+                SELECT
+                    attr.repo_id AS repo_id,
+                    toUInt32OrZero(
+                        arrayElement(splitByChar('#', attr.subject_id), -1)
+                    ) AS number,
+                    attr.kind AS kind
+                FROM ai_attribution_resolved AS attr
+                WHERE attr.subject_type = 'pull_request'
+                  AND number > 0
+                  {org_filter_attr}
+            )
+            GROUP BY repo_id, number
+        """
+
+    @staticmethod
+    def _pr_window_filter() -> str:
+        return """((pr.created_at >= {start:DateTime} AND pr.created_at < {end:DateTime})
+                OR (pr.merged_at IS NOT NULL AND pr.merged_at >= {start:DateTime} AND pr.merged_at < {end:DateTime}))"""
+
+    def _engagement_scope_filters(
+        self,
+        params: dict[str, Any],
+        repo_id: uuid.UUID | None,
+        repo_ids: list[uuid.UUID] | None,
+    ) -> str:
+        scope_filter = ""
+        if repo_id is not None:
+            params["repo_id"] = str(repo_id)
+            scope_filter += "\n              AND pr.repo_id = {repo_id:UUID}"
+        if repo_ids is not None:
+            params["repo_ids"] = [str(r) for r in repo_ids]
+            scope_filter += (
+                "\n              AND toString(pr.repo_id) IN {repo_ids:Array(String)}"
+            )
+        return scope_filter
+
+    async def load_review_engagement(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        repo_id: uuid.UUID | None = None,
+        repo_ids: list[uuid.UUID] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Per-(bucket, day) review engagement computed from raw PR rows.
+
+        Returns dicts with ``bucket``, ``day``, ``prs_with_first_review``,
+        ``pickup_latency_hours`` (avg open→first-review, hours),
+        ``review_comments_total`` and ``loc_total`` so the resolver can derive
+        ``review_comments_per_loc`` per slice and per bucket without losing
+        the None-vs-zero distinction (CHAOS-2194).
+
+        Bucket assignment mirrors compute-time ``_safe_bucket``: matched AI
+        kinds keep their kind, ``human`` stays human, anything else —
+        including unattributed PRs — is ``unknown``.
+        """
+        from dev_health_ops.api.queries.client import query_dicts
+
+        params: dict[str, Any] = {
+            "start": start.replace(tzinfo=None),
+            "end": end.replace(tzinfo=None),
+        }
+        scope_filter = self._engagement_scope_filters(params, repo_id, repo_ids)
+        params = self._scope.inject(params)
+        org_filter_pr = self._scope.filter(alias="pr")
+        query = f"""
+        SELECT
+            multiIf(
+                attr_map.kind IN ('ai_assisted', 'agent_created', 'ai_review'),
+                attr_map.kind,
+                attr_map.kind = 'human', 'human',
+                'unknown'
+            ) AS bucket,
+            toDate(pr.created_at) AS day,
+            countIf(
+                pr.first_review_at IS NOT NULL
+                AND pr.first_review_at >= pr.created_at
+            ) AS prs_with_first_review,
+            avgIf(
+                dateDiff('second', pr.created_at, pr.first_review_at) / 3600.0,
+                pr.first_review_at IS NOT NULL
+                AND pr.first_review_at >= pr.created_at
+            ) AS pickup_latency_hours,
+            sum(pr.comments_count) AS review_comments_total,
+            sum(
+                coalesce(pr.additions, 0) + coalesce(pr.deletions, 0)
+            ) AS loc_total
+        FROM git_pull_requests AS pr
+        LEFT JOIN (
+            {self._pr_attribution_subquery()}
+        ) AS attr_map
+            ON attr_map.repo_id = pr.repo_id AND attr_map.number = pr.number
+        WHERE {self._pr_window_filter()}
+          {scope_filter}
+          {org_filter_pr}
+        GROUP BY bucket, day
+        ORDER BY day, bucket
+        """
+        return await query_dicts(self.client, query, params)
+
+    def _ai_pr_files_cte(
+        self,
+        params: dict[str, Any],
+        repo_id: uuid.UUID | None,
+        repo_ids: list[uuid.UUID] | None,
+    ) -> str:
+        """CTE body mapping AI-attributed PRs to their changed file paths.
+
+        Only PRs whose commits are linked through ``work_graph_pr_commit``
+        appear — that is the assessable universe for overlap rates.
+        """
+        scope_filter = self._engagement_scope_filters(params, repo_id, repo_ids)
+        org_filter_pr = self._scope.filter(alias="pr")
+        return f"""
+            SELECT DISTINCT
+                ai.repo_id AS repo_id,
+                ai.number AS number,
+                ai.kind AS bucket,
+                cs.file_path AS file_path
+            FROM (
+                SELECT pr.repo_id AS repo_id, pr.number AS number, attr_map.kind AS kind
+                FROM git_pull_requests AS pr
+                INNER JOIN (
+                    {self._pr_attribution_subquery()}
+                ) AS attr_map
+                    ON attr_map.repo_id = pr.repo_id AND attr_map.number = pr.number
+                WHERE attr_map.kind IN ('ai_assisted', 'agent_created', 'ai_review')
+                  AND {self._pr_window_filter()}
+                  {scope_filter}
+                  {org_filter_pr}
+            ) AS ai
+            INNER JOIN work_graph_pr_commit AS pc
+                ON pc.repo_id = ai.repo_id AND pc.pr_number = ai.number
+            INNER JOIN git_commit_stats AS cs
+                ON cs.repo_id = pc.repo_id AND cs.commit_hash = pc.commit_hash
+        """
+
+    async def load_hotspot_overlap(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        start_day: date,
+        end_day: date,
+        repo_id: uuid.UUID | None = None,
+        repo_ids: list[uuid.UUID] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Per-bucket overlap of AI-attributed PRs with hotspot files.
+
+        Hotspot = latest ``risk_score > 0`` in the window, matching the
+        convention in ``recommendations/loader.py`` and
+        ``metrics/operating_review.py`` (CHAOS-2185).
+        """
+        from dev_health_ops.api.queries.client import query_dicts
+
+        params: dict[str, Any] = {
+            "start": start.replace(tzinfo=None),
+            "end": end.replace(tzinfo=None),
+            "start_day": start_day,
+            "end_day": end_day,
+        }
+        files_cte = self._ai_pr_files_cte(params, repo_id, repo_ids)
+        params = self._scope.inject(params)
+        org_filter_hs = self._scope.filter(alias="hs")
+        query = f"""
+        WITH pr_files AS (
+            {files_cte}
+        ),
+        hotspots AS (
+            SELECT
+                hs.repo_id AS repo_id,
+                hs.file_path AS file_path,
+                argMax(hs.risk_score, hs.computed_at) AS risk_score
+            FROM file_hotspot_daily AS hs
+            WHERE hs.day >= {{start_day:Date}}
+              AND hs.day <= {{end_day:Date}}
+              {org_filter_hs}
+            GROUP BY hs.repo_id, hs.file_path
+            HAVING risk_score > 0
+        )
+        SELECT
+            bucket,
+            uniqExact((pf.repo_id, pf.number)) AS prs_total,
+            uniqExactIf(
+                (pf.repo_id, pf.number), h.file_path != ''
+            ) AS prs_touching_hotspots,
+            avgIf(h.risk_score, h.file_path != '') AS avg_hotspot_risk_score
+        FROM pr_files AS pf
+        LEFT JOIN hotspots AS h
+            ON h.repo_id = pf.repo_id AND h.file_path = pf.file_path
+        GROUP BY bucket
+        ORDER BY bucket
+        """
+        return await query_dicts(self.client, query, params)
+
+    async def load_complexity_overlap(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        end_day: date,
+        repo_id: uuid.UUID | None = None,
+        repo_ids: list[uuid.UUID] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Per-bucket overlap of AI-attributed PRs with high-complexity files.
+
+        High-complexity = latest snapshot (as of ``end_day``) reporting at
+        least one high- or very-high-complexity function (CHAOS-2185).
+        """
+        from dev_health_ops.api.queries.client import query_dicts
+
+        params: dict[str, Any] = {
+            "start": start.replace(tzinfo=None),
+            "end": end.replace(tzinfo=None),
+            "end_day": end_day,
+        }
+        files_cte = self._ai_pr_files_cte(params, repo_id, repo_ids)
+        params = self._scope.inject(params)
+        org_filter_fc = self._scope.filter(alias="fc")
+        query = f"""
+        WITH pr_files AS (
+            {files_cte}
+        ),
+        complex_files AS (
+            SELECT
+                fc.repo_id AS repo_id,
+                fc.file_path AS file_path
+            FROM file_complexity_snapshots AS fc
+            WHERE fc.as_of_day <= {{end_day:Date}}
+              {org_filter_fc}
+            GROUP BY fc.repo_id, fc.file_path
+            HAVING argMax(
+                fc.high_complexity_functions + fc.very_high_complexity_functions,
+                fc.computed_at
+            ) > 0
+        )
+        SELECT
+            bucket,
+            uniqExact((pf.repo_id, pf.number)) AS prs_total,
+            uniqExactIf(
+                (pf.repo_id, pf.number), cf.file_path != ''
+            ) AS prs_touching_high_complexity
+        FROM pr_files AS pf
+        LEFT JOIN complex_files AS cf
+            ON cf.repo_id = pf.repo_id AND cf.file_path = pf.file_path
+        GROUP BY bucket
+        ORDER BY bucket
+        """
+        return await query_dicts(self.client, query, params)
+
+    async def load_repo_labels(self, repo_ids: list[str]) -> dict[str, str]:
+        """Map repo UUID strings to repo full-names (best effort)."""
+        from dev_health_ops.api.queries.client import query_dicts
+
+        if not repo_ids:
+            return {}
+        params: dict[str, Any] = {"repo_ids": repo_ids}
+        params = self._scope.inject(params)
+        org_expr = self._scope.expression()
+        org_filter = f"AND {org_expr}" if org_expr else ""
+        query = f"""
+        SELECT toString(id) AS repo_id, repo AS full_name
+        FROM repos
+        WHERE toString(id) IN {{repo_ids:Array(String)}}
+          {org_filter}
+        """
+        rows = await query_dicts(self.client, query, params)
+        return {
+            str(r["repo_id"]): str(r.get("full_name") or r["repo_id"]) for r in rows
+        }
+
+    async def load_team_labels(self, team_ids: list[str]) -> dict[str, str]:
+        """Map team ids to team display names (best effort)."""
+        from dev_health_ops.api.queries.client import query_dicts
+
+        if not team_ids:
+            return {}
+        params: dict[str, Any] = {"team_ids": team_ids}
+        params = self._scope.inject(params)
+        org_expr = self._scope.expression()
+        org_filter = f"AND {org_expr}" if org_expr else ""
+        query = f"""
+        SELECT toString(id) AS team_id, name
+        FROM teams
+        WHERE toString(id) IN {{team_ids:Array(String)}}
+          {org_filter}
+        """
+        rows = await query_dicts(self.client, query, params)
+        return {str(r["team_id"]): str(r.get("name") or r["team_id"]) for r in rows}
 
 
 def _to_record(raw: dict[str, Any]) -> AIImpactMetricsDailyRecord:

--- a/src/dev_health_ops/metrics/loaders/ai_impact.py
+++ b/src/dev_health_ops/metrics/loaders/ai_impact.py
@@ -294,6 +294,7 @@ class AIImpactClickHouseLoader:
         ReplacingMergeTree duplicates and dual-path matches.
         """
         org_filter_attr = self._scope.filter(alias="attr")
+        org_filter_link = self._scope.filter(alias="link")
         return f"""
             SELECT repo_id, number, any(kind) AS kind
             FROM (
@@ -305,7 +306,7 @@ class AIImpactClickHouseLoader:
                 INNER JOIN ai_attribution_resolved AS attr
                     ON attr.subject_type = 'pull_request'
                     AND attr.subject_id = link.work_item_id
-                WHERE 1 = 1 {org_filter_attr}
+                WHERE 1 = 1 {org_filter_link} {org_filter_attr}
                 UNION ALL
                 SELECT
                     attr.repo_id AS repo_id,
@@ -326,6 +327,20 @@ class AIImpactClickHouseLoader:
         return """((pr.created_at >= {start:DateTime} AND pr.created_at < {end:DateTime})
                 OR (pr.merged_at IS NOT NULL AND pr.merged_at >= {start:DateTime} AND pr.merged_at < {end:DateTime}))"""
 
+    # Event-time expression shared with compute_ai_impact_metrics_daily
+    # (metrics/ai_impact.py: ``event_at = merged_at or created_at`` — a PR
+    # belongs to its merge day when merged, else its creation day). Both
+    # window membership AND the day key must use this expression so
+    # query-time slices line up with ``ai_impact_metrics_daily`` rows.
+    _PR_EVENT_EXPR = "if(pr.merged_at IS NOT NULL, pr.merged_at, pr.created_at)"
+
+    @classmethod
+    def _pr_event_window_filter(cls) -> str:
+        return (
+            f"({cls._PR_EVENT_EXPR} >= {{start:DateTime}} "
+            f"AND {cls._PR_EVENT_EXPR} < {{end:DateTime}})"
+        )
+
     def _engagement_scope_filters(
         self,
         params: dict[str, Any],
@@ -342,6 +357,41 @@ class AIImpactClickHouseLoader:
                 "\n              AND toString(pr.repo_id) IN {repo_ids:Array(String)}"
             )
         return scope_filter
+
+    def _deduped_prs_subquery(
+        self,
+        params: dict[str, Any],
+        repo_id: uuid.UUID | None,
+        repo_ids: list[uuid.UUID] | None,
+    ) -> str:
+        """Latest-version PR rows, collapsed by (repo_id, number).
+
+        ``git_pull_requests`` is a ReplacingMergeTree keyed by
+        ``(repo_id, number)`` with version column ``last_synced``; sync
+        re-runs leave multiple row versions visible until a background merge.
+        Aggregating over the raw table double-counts those versions, so every
+        aggregate read must collapse to ``argMax(..., last_synced)`` first
+        (app-code readers like ``load_ai_pr_attributions`` dedupe in Python).
+        Org and repo scope filters are applied inside, before the GROUP BY.
+        """
+        scope_filter = self._engagement_scope_filters(params, repo_id, repo_ids)
+        org_filter_pr = self._scope.filter(alias="pr")
+        return f"""
+            SELECT
+                pr.repo_id AS repo_id,
+                pr.number AS number,
+                argMax(pr.created_at, pr.last_synced) AS created_at,
+                argMax(pr.merged_at, pr.last_synced) AS merged_at,
+                argMax(pr.first_review_at, pr.last_synced) AS first_review_at,
+                argMax(pr.comments_count, pr.last_synced) AS comments_count,
+                argMax(pr.additions, pr.last_synced) AS additions,
+                argMax(pr.deletions, pr.last_synced) AS deletions
+            FROM git_pull_requests AS pr
+            WHERE 1 = 1
+              {scope_filter}
+              {org_filter_pr}
+            GROUP BY pr.repo_id, pr.number
+        """
 
     async def load_review_engagement(
         self,
@@ -362,6 +412,12 @@ class AIImpactClickHouseLoader:
         Bucket assignment mirrors compute-time ``_safe_bucket``: matched AI
         kinds keep their kind, ``human`` stays human, anything else —
         including unattributed PRs — is ``unknown``.
+
+        Window membership and the ``day`` key both use the event-time
+        expression (merge day when merged, else creation day) so rows merge
+        with ``ai_impact_metrics_daily`` cells — a PR created before the
+        window but merged inside it lands on its merge day, exactly like the
+        compute path.
         """
         from dev_health_ops.api.queries.client import query_dicts
 
@@ -369,9 +425,8 @@ class AIImpactClickHouseLoader:
             "start": start.replace(tzinfo=None),
             "end": end.replace(tzinfo=None),
         }
-        scope_filter = self._engagement_scope_filters(params, repo_id, repo_ids)
+        deduped_prs = self._deduped_prs_subquery(params, repo_id, repo_ids)
         params = self._scope.inject(params)
-        org_filter_pr = self._scope.filter(alias="pr")
         query = f"""
         SELECT
             multiIf(
@@ -380,7 +435,7 @@ class AIImpactClickHouseLoader:
                 attr_map.kind = 'human', 'human',
                 'unknown'
             ) AS bucket,
-            toDate(pr.created_at) AS day,
+            toDate({self._PR_EVENT_EXPR}) AS day,
             countIf(
                 pr.first_review_at IS NOT NULL
                 AND pr.first_review_at >= pr.created_at
@@ -394,14 +449,14 @@ class AIImpactClickHouseLoader:
             sum(
                 coalesce(pr.additions, 0) + coalesce(pr.deletions, 0)
             ) AS loc_total
-        FROM git_pull_requests AS pr
+        FROM (
+            {deduped_prs}
+        ) AS pr
         LEFT JOIN (
             {self._pr_attribution_subquery()}
         ) AS attr_map
             ON attr_map.repo_id = pr.repo_id AND attr_map.number = pr.number
-        WHERE {self._pr_window_filter()}
-          {scope_filter}
-          {org_filter_pr}
+        WHERE {self._pr_event_window_filter()}
         GROUP BY bucket, day
         ORDER BY day, bucket
         """
@@ -416,10 +471,15 @@ class AIImpactClickHouseLoader:
         """CTE body mapping AI-attributed PRs to their changed file paths.
 
         Only PRs whose commits are linked through ``work_graph_pr_commit``
-        appear — that is the assessable universe for overlap rates.
+        appear — that is the assessable universe for overlap rates. The PR
+        universe uses event-time window semantics (merge day when merged) to
+        match ``ai_impact_metrics_daily``. Every joined table is org-scoped:
+        ``work_graph_pr_commit`` and ``git_commit_stats`` both carry
+        ``org_id``, and repo_id/commit_hash values can collide across tenants.
         """
-        scope_filter = self._engagement_scope_filters(params, repo_id, repo_ids)
-        org_filter_pr = self._scope.filter(alias="pr")
+        deduped_prs = self._deduped_prs_subquery(params, repo_id, repo_ids)
+        org_filter_pc = self._scope.filter(alias="pc")
+        org_filter_cs = self._scope.filter(alias="cs")
         return f"""
             SELECT DISTINCT
                 ai.repo_id AS repo_id,
@@ -428,20 +488,22 @@ class AIImpactClickHouseLoader:
                 cs.file_path AS file_path
             FROM (
                 SELECT pr.repo_id AS repo_id, pr.number AS number, attr_map.kind AS kind
-                FROM git_pull_requests AS pr
+                FROM (
+                    {deduped_prs}
+                ) AS pr
                 INNER JOIN (
                     {self._pr_attribution_subquery()}
                 ) AS attr_map
                     ON attr_map.repo_id = pr.repo_id AND attr_map.number = pr.number
                 WHERE attr_map.kind IN ('ai_assisted', 'agent_created', 'ai_review')
-                  AND {self._pr_window_filter()}
-                  {scope_filter}
-                  {org_filter_pr}
+                  AND {self._pr_event_window_filter()}
             ) AS ai
             INNER JOIN work_graph_pr_commit AS pc
                 ON pc.repo_id = ai.repo_id AND pc.pr_number = ai.number
+                {org_filter_pc}
             INNER JOIN git_commit_stats AS cs
                 ON cs.repo_id = pc.repo_id AND cs.commit_hash = pc.commit_hash
+                {org_filter_cs}
         """
 
     async def load_hotspot_overlap(
@@ -454,11 +516,15 @@ class AIImpactClickHouseLoader:
         repo_id: uuid.UUID | None = None,
         repo_ids: list[uuid.UUID] | None = None,
     ) -> list[dict[str, Any]]:
-        """Per-bucket overlap of AI-attributed PRs with hotspot files.
+        """Per-bucket overlap of AI-attributed PRs with top-decile hotspot files.
 
-        Hotspot = latest ``risk_score > 0`` in the window, matching the
-        convention in ``recommendations/loader.py`` and
-        ``metrics/operating_review.py`` (CHAOS-2185).
+        "Hotspot" here means the top decile of latest ``risk_score`` per repo
+        within the window (minimum one file per repo when the decile is
+        degenerate), restricted to ``risk_score > 0``. A bare ``> 0`` cut is
+        NOT discriminating — risk_score is a sum of z-scores, so above-zero
+        means merely above-average and saturates the rate at ~1.0. The
+        reported ``hotspot_overlap_rate`` therefore reads as "share of
+        assessable AI PRs touching top-decile-risk files" (CHAOS-2185).
         """
         from dev_health_ops.api.queries.client import query_dicts
 
@@ -476,16 +542,31 @@ class AIImpactClickHouseLoader:
             {files_cte}
         ),
         hotspots AS (
-            SELECT
-                hs.repo_id AS repo_id,
-                hs.file_path AS file_path,
-                argMax(hs.risk_score, hs.computed_at) AS risk_score
-            FROM file_hotspot_daily AS hs
-            WHERE hs.day >= {{start_day:Date}}
-              AND hs.day <= {{end_day:Date}}
-              {org_filter_hs}
-            GROUP BY hs.repo_id, hs.file_path
-            HAVING risk_score > 0
+            SELECT repo_id, file_path, risk_score
+            FROM (
+                SELECT
+                    repo_id,
+                    file_path,
+                    risk_score,
+                    row_number() OVER (
+                        PARTITION BY repo_id
+                        ORDER BY risk_score DESC, file_path
+                    ) AS risk_rank,
+                    count() OVER (PARTITION BY repo_id) AS repo_file_count
+                FROM (
+                    SELECT
+                        hs.repo_id AS repo_id,
+                        hs.file_path AS file_path,
+                        argMax(hs.risk_score, hs.computed_at) AS risk_score
+                    FROM file_hotspot_daily AS hs
+                    WHERE hs.day >= {{start_day:Date}}
+                      AND hs.day <= {{end_day:Date}}
+                      {org_filter_hs}
+                    GROUP BY hs.repo_id, hs.file_path
+                    HAVING risk_score > 0
+                )
+            )
+            WHERE risk_rank <= greatest(1, toUInt64(ceil(repo_file_count * 0.1)))
         )
         SELECT
             bucket,

--- a/tests/api/graphql/test_ai_resolver.py
+++ b/tests/api/graphql/test_ai_resolver.py
@@ -376,7 +376,12 @@ async def test_review_load_populated_aggregates_by_bucket():
     assert result.reviewer_concentration.data_available is True
     assert result.reviewer_concentration.reviewer_count == 5
     assert result.reviewer_concentration.reviewer_gini == pytest.approx(0.42)
-    assert result.missing_states == []
+    # Engagement loader is not stubbed here, so CHAOS-2194 fields are honestly
+    # unavailable: None values plus an explicit missing state — never zeros.
+    assert [state.key for state in result.missing_states] == ["review_engagement"]
+    ai_bucket = bucket_lookup[AttributionBucket.AI_ASSISTED.value]
+    assert ai_bucket.pickup_latency_hours is None
+    assert ai_bucket.review_comments_per_loc is None
 
 
 # -----------------------------------------------------------------------------
@@ -773,6 +778,14 @@ async def test_ai_attributed_prs_team_scope_filters_by_team_id():
     repo_team_map = {str(REPO_ID): "team-a", str(REPO_B): "team-b"}
     with (
         _patch_pr_loader(rows),
+        # Force the catalogs-unavailable fallback so this test keeps pinning
+        # the Wave-1 in-memory filter; the SQL prefilter path is covered by
+        # test_ai_attributed_prs_team_scope_filters_in_sql_before_limit.
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_team_repo_ids",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
         patch(
             "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_team_map",
             new_callable=AsyncMock,
@@ -820,6 +833,13 @@ async def test_ai_attributed_prs_team_scope_resolves_via_repo_pattern():
     repo_team_map = {str(REPO_ID): "team-a", str(REPO_B): "team-b"}
     with (
         _patch_pr_loader(rows),
+        # Catalogs unavailable → in-memory fallback path (see note in
+        # test_ai_attributed_prs_team_scope_filters_by_team_id).
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_team_repo_ids",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
         patch(
             "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_team_map",
             new_callable=AsyncMock,
@@ -905,3 +925,360 @@ async def test_governance_summary_awaits_async_loader_methods():
     assert result.data_available is True
     assert result.coverage[0].ai_artifacts == 10
     assert result.recent_violations[0].rule_id == "MISSING_AI_DECLARATION"
+
+
+# -----------------------------------------------------------------------------
+# CHAOS-2194 — Review Load pickup latency + review comments per LOC
+# -----------------------------------------------------------------------------
+
+
+def _patch_engagement(rows: list[dict[str, Any]]) -> Any:
+    return patch(
+        "dev_health_ops.metrics.loaders.ai_impact."
+        "AIImpactClickHouseLoader.load_review_engagement",
+        new_callable=AsyncMock,
+        return_value=rows,
+    )
+
+
+def _engagement_row(
+    *,
+    bucket: str,
+    day: date,
+    prs_with_first_review: int = 5,
+    pickup_latency_hours: float | None = 4.0,
+    review_comments_total: int = 20,
+    loc_total: int = 1000,
+) -> dict[str, Any]:
+    return {
+        "bucket": bucket,
+        "day": day,
+        "prs_with_first_review": prs_with_first_review,
+        "pickup_latency_hours": pickup_latency_hours,
+        "review_comments_total": review_comments_total,
+        "loc_total": loc_total,
+    }
+
+
+@pytest.mark.asyncio
+async def test_review_load_merges_engagement_fields():
+    engagement = [
+        _engagement_row(
+            bucket=AttributionBucket.AI_ASSISTED.value,
+            day=DAY_START,
+            pickup_latency_hours=4.0,
+            review_comments_total=20,
+            loc_total=1000,
+        ),
+        _engagement_row(
+            bucket=AttributionBucket.HUMAN.value,
+            day=DAY_START,
+            pickup_latency_hours=8.0,
+            review_comments_total=10,
+            loc_total=500,
+        ),
+    ]
+    with (
+        _patch_loader(_populated_rows()),
+        _patch_reviewer_concentration(0.42, 5),
+        _patch_engagement(engagement),
+    ):
+        result = await resolve_ai_review_load(_ctx(), _range())
+
+    bucket_lookup = {row.bucket: row for row in result.by_bucket}
+    ai_row = bucket_lookup[AttributionBucket.AI_ASSISTED.value]
+    assert ai_row.pickup_latency_hours == pytest.approx(4.0)
+    assert ai_row.review_comments_per_loc == pytest.approx(0.02)
+    human_row = bucket_lookup[AttributionBucket.HUMAN.value]
+    assert human_row.pickup_latency_hours == pytest.approx(8.0)
+    assert human_row.review_comments_per_loc == pytest.approx(0.02)
+    # Buckets without engagement rows stay None (unavailable ≠ zero).
+    unknown_row = bucket_lookup[AttributionBucket.UNKNOWN.value]
+    assert unknown_row.pickup_latency_hours is None
+    assert unknown_row.review_comments_per_loc is None
+    # Daily rows merge by (bucket, day).
+    ai_daily = [
+        r for r in result.daily if r.bucket == AttributionBucket.AI_ASSISTED.value
+    ]
+    assert ai_daily[0].pickup_latency_hours == pytest.approx(4.0)
+    # No engagement missing state when engagement data exists.
+    assert "review_engagement" not in {s.key for s in result.missing_states}
+
+
+@pytest.mark.asyncio
+async def test_review_load_engagement_zero_loc_yields_none_not_zero():
+    engagement = [
+        _engagement_row(
+            bucket=AttributionBucket.AI_ASSISTED.value,
+            day=DAY_START,
+            prs_with_first_review=0,
+            pickup_latency_hours=None,
+            review_comments_total=0,
+            loc_total=0,
+        ),
+    ]
+    with (
+        _patch_loader(_populated_rows()),
+        _patch_reviewer_concentration(0.42, 5),
+        _patch_engagement(engagement),
+    ):
+        result = await resolve_ai_review_load(_ctx(), _range())
+
+    bucket_lookup = {row.bucket: row for row in result.by_bucket}
+    ai_row = bucket_lookup[AttributionBucket.AI_ASSISTED.value]
+    assert ai_row.pickup_latency_hours is None
+    assert ai_row.review_comments_per_loc is None
+
+
+@pytest.mark.asyncio
+async def test_review_load_engagement_skipped_for_work_type_scope():
+    """work_type cannot be applied to raw PR rows — engagement must be
+    reported unavailable rather than silently mis-scoped."""
+    with (
+        _patch_loader(_populated_rows()),
+        _patch_reviewer_concentration(0.42, 5),
+        _patch_engagement([_engagement_row(bucket="ai_assisted", day=DAY_START)]),
+    ):
+        result = await resolve_ai_review_load(
+            _ctx(), _range(), AIScopeInput(work_type="bug")
+        )
+
+    bucket_lookup = {row.bucket: row for row in result.by_bucket}
+    ai_row = bucket_lookup[AttributionBucket.AI_ASSISTED.value]
+    assert ai_row.pickup_latency_hours is None
+    assert "review_engagement" in {s.key for s in result.missing_states}
+
+
+# -----------------------------------------------------------------------------
+# CHAOS-2185 — Hotspot / complexity overlap
+# -----------------------------------------------------------------------------
+
+
+def _patch_hotspot_overlap(rows: list[dict[str, Any]]) -> Any:
+    return patch(
+        "dev_health_ops.metrics.loaders.ai_impact."
+        "AIImpactClickHouseLoader.load_hotspot_overlap",
+        new_callable=AsyncMock,
+        return_value=rows,
+    )
+
+
+def _patch_complexity_overlap(rows: list[dict[str, Any]]) -> Any:
+    return patch(
+        "dev_health_ops.metrics.loaders.ai_impact."
+        "AIImpactClickHouseLoader.load_complexity_overlap",
+        new_callable=AsyncMock,
+        return_value=rows,
+    )
+
+
+@pytest.mark.asyncio
+async def test_risk_breakdown_populated_overlaps_drop_missing_states():
+    hotspot_raw = [
+        {
+            "bucket": "ai_assisted",
+            "prs_total": 10,
+            "prs_touching_hotspots": 4,
+            "avg_hotspot_risk_score": 0.73,
+        }
+    ]
+    complexity_raw = [
+        {
+            "bucket": "ai_assisted",
+            "prs_total": 10,
+            "prs_touching_high_complexity": 2,
+        }
+    ]
+    with (
+        _patch_loader(_populated_rows()),
+        _patch_hotspot_overlap(hotspot_raw),
+        _patch_complexity_overlap(complexity_raw),
+    ):
+        result = await resolve_ai_risk_breakdown(_ctx(), _range())
+
+    assert len(result.hotspot_overlap) == 1
+    hs = result.hotspot_overlap[0]
+    assert hs.bucket == "ai_assisted"
+    assert hs.prs_total == 10
+    assert hs.prs_touching_hotspots == 4
+    assert hs.hotspot_overlap_rate == pytest.approx(0.4)
+    assert hs.avg_hotspot_risk_score == pytest.approx(0.73)
+    cx = result.complexity_overlap[0]
+    assert cx.complexity_overlap_rate == pytest.approx(0.2)
+    # Real data present → missing states must be gone.
+    assert {s.key for s in result.missing_states} == set()
+
+
+@pytest.mark.asyncio
+async def test_risk_breakdown_empty_overlaps_keep_missing_states():
+    with (
+        _patch_loader(_populated_rows()),
+        _patch_hotspot_overlap([]),
+        _patch_complexity_overlap([]),
+    ):
+        result = await resolve_ai_risk_breakdown(_ctx(), _range())
+
+    assert result.hotspot_overlap == []
+    assert result.complexity_overlap == []
+    assert {s.key for s in result.missing_states} == {
+        "hotspot_overlap",
+        "complexity_overlap",
+    }
+
+
+# -----------------------------------------------------------------------------
+# CHAOS-2186 — Impact per-repo / per-team breakdown
+# -----------------------------------------------------------------------------
+
+
+def _patch_repo_labels(labels: dict[str, str]) -> Any:
+    return patch(
+        "dev_health_ops.metrics.loaders.ai_impact."
+        "AIImpactClickHouseLoader.load_repo_labels",
+        new_callable=AsyncMock,
+        return_value=labels,
+    )
+
+
+def _patch_team_labels(labels: dict[str, str]) -> Any:
+    return patch(
+        "dev_health_ops.metrics.loaders.ai_impact."
+        "AIImpactClickHouseLoader.load_team_labels",
+        new_callable=AsyncMock,
+        return_value=labels,
+    )
+
+
+@pytest.mark.asyncio
+async def test_impact_summary_builds_repo_and_team_breakdowns():
+    with (
+        _patch_loader(_populated_rows()),
+        _patch_repo_labels({str(REPO_ID): "acme/api"}),
+        _patch_team_labels({TEAM_ID: "Team A"}),
+    ):
+        result = await resolve_ai_impact_summary(_ctx(), _range())
+
+    assert len(result.repo_breakdown) == 1
+    repo_row = result.repo_breakdown[0]
+    assert repo_row.scope_id == str(REPO_ID)
+    assert repo_row.scope_label == "acme/api"
+    # AI buckets: ai_assisted 20 + agent_created 4 = 24 of 38 total PRs.
+    assert repo_row.ai_prs_total == 24
+    assert repo_row.ai_assisted_pr_ratio == pytest.approx(24 / 38)
+    # AI rework 0.1 (both AI rows) − human rework 0.05 = +0.05.
+    assert repo_row.rework_rate_delta == pytest.approx(0.05)
+    team_row = result.team_breakdown[0]
+    assert team_row.scope_id == TEAM_ID
+    assert team_row.scope_label == "Team A"
+    assert "scope_breakdown" not in {s.key for s in result.missing_states}
+
+
+@pytest.mark.asyncio
+async def test_impact_summary_breakdowns_fall_back_to_ids_and_missing_state():
+    """Label lookups failing must degrade to ids; an all-human window emits
+    the scope_breakdown missing state instead of fabricated zero rows."""
+    human_only = [
+        _record(
+            bucket=AttributionBucket.HUMAN,
+            day=DAY_START,
+            human_prs=12,
+            prs_total=12,
+            prs_merged=11,
+        )
+    ]
+    with (
+        _patch_loader(human_only),
+        _patch_repo_labels({}),
+        _patch_team_labels({}),
+    ):
+        result = await resolve_ai_impact_summary(_ctx(), _range())
+
+    assert result.repo_breakdown == []
+    assert result.team_breakdown == []
+    assert "scope_breakdown" in {s.key for s in result.missing_states}
+
+
+@pytest.mark.asyncio
+async def test_impact_summary_empty_has_empty_breakdowns_without_missing_state():
+    with _patch_loader([]):
+        result = await resolve_ai_impact_summary(_ctx(), _range())
+
+    assert result.repo_breakdown == []
+    assert result.team_breakdown == []
+    assert "scope_breakdown" not in {s.key for s in result.missing_states}
+
+
+# -----------------------------------------------------------------------------
+# CHAOS-2180 Wave 2 — dense team-scoped pagination for attributed PRs
+# -----------------------------------------------------------------------------
+
+
+def _patch_team_repo_ids(value: Any) -> Any:
+    return patch(
+        "dev_health_ops.api.graphql.resolvers.ai._resolve_team_repo_ids",
+        new_callable=AsyncMock,
+        return_value=value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_team_scope_filters_in_sql_before_limit():
+    """Team scope must reach the loader as repo_ids so the SQL LIMIT applies
+    to the already-filtered universe (dense pages)."""
+    rows = [_attribution_row(number=1), _attribution_row(number=2)]
+    scope = AIScopeInput(team_id="team-a")
+    repo_team_map = {str(REPO_ID): "team-a"}
+    with (
+        _patch_pr_loader(rows) as mock_load,
+        _patch_team_repo_ids([REPO_ID]),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_team_map",
+            new_callable=AsyncMock,
+            return_value=repo_team_map,
+        ),
+    ):
+        result = await resolve_ai_attributed_prs(_ctx(), _range(), scope)
+
+    assert mock_load.await_args.kwargs["repo_ids"] == [REPO_ID]
+    assert [r.number for r in result.rows] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_team_with_no_repos_returns_empty():
+    scope = AIScopeInput(team_id="team-empty")
+    with (
+        _patch_pr_loader([_attribution_row(number=1)]) as mock_load,
+        _patch_team_repo_ids([]),
+    ):
+        result = await resolve_ai_attributed_prs(_ctx(), _range(), scope)
+
+    mock_load.assert_not_awaited()
+    assert result.rows == []
+    assert result.data_available is False
+    assert result.has_more is False
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_unresolvable_team_falls_back_to_memory_filter():
+    """When the team catalogs cannot be loaded (None), the resolver keeps the
+    Wave-1 in-memory filter instead of wrongly returning an empty page."""
+    REPO_B = UUID("22222222-2222-2222-2222-222222222222")
+    rows = [
+        _attribution_row(number=1),
+        {**_attribution_row(number=2), "repo_id": REPO_B},
+    ]
+    scope = AIScopeInput(team_id="team-a")
+    repo_team_map = {str(REPO_ID): "team-a", str(REPO_B): "team-b"}
+    with (
+        _patch_pr_loader(rows) as mock_load,
+        _patch_team_repo_ids(None),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_team_map",
+            new_callable=AsyncMock,
+            return_value=repo_team_map,
+        ),
+    ):
+        result = await resolve_ai_attributed_prs(_ctx(), _range(), scope)
+
+    assert mock_load.await_args.kwargs["repo_ids"] is None
+    assert [r.number for r in result.rows] == [1]

--- a/tests/metrics/test_ai_impact_loader.py
+++ b/tests/metrics/test_ai_impact_loader.py
@@ -229,3 +229,131 @@ async def test_reviewer_concentration_gini_computed_from_ai_scoped_rows():
     # _gini([0, 10]): sorted=[0,10], total=10, weighted_sum=0*1+10*2=20
     # gini = 2*20/(2*10) - 3/2 = 2.0 - 1.5 = 0.5
     assert gini == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2180 Wave 2 — repo_ids SQL prefilter for dense team pagination
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_ai_pr_attributions_applies_repo_ids_before_limit():
+    """repo_ids must land in the WHERE clause so LIMIT applies to the
+    already-filtered universe — that is what makes team pages dense."""
+    captured: list[tuple[str, dict]] = []
+
+    async def fake_qd(_client: Any, query: str, params: Any) -> list[dict]:
+        captured.append((query, params))
+        return []
+
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        side_effect=fake_qd,
+    ):
+        await loader.load_ai_pr_attributions(
+            start=START, end=END, repo_ids=[REPO_A, REPO_B], limit=10, offset=0
+        )
+
+    query, params = captured[0]
+    assert "toString(pr.repo_id) IN {repo_ids:Array(String)}" in query
+    assert params["repo_ids"] == [str(REPO_A), str(REPO_B)]
+    # The IN filter must appear before LIMIT (inside the subquery WHERE).
+    assert query.index("repo_ids:Array(String)") < query.index("LIMIT {limit:UInt32}")
+
+
+@pytest.mark.asyncio
+async def test_load_ai_pr_attributions_no_repo_ids_omits_filter():
+    captured: list[str] = []
+
+    async def fake_qd(_client: Any, query: str, _params: Any) -> list[dict]:
+        captured.append(query)
+        return []
+
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        side_effect=fake_qd,
+    ):
+        await loader.load_ai_pr_attributions(start=START, end=END)
+
+    assert "repo_ids" not in captured[0]
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2194 — review engagement query shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_review_engagement_query_shape():
+    """Pickup latency must be guarded against missing/inverted timestamps and
+    bucket fallback must mirror compute-time _safe_bucket semantics."""
+    captured: list[tuple[str, dict]] = []
+
+    async def fake_qd(_client: Any, query: str, params: Any) -> list[dict]:
+        captured.append((query, params))
+        return []
+
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        side_effect=fake_qd,
+    ):
+        await loader.load_review_engagement(start=START, end=END, repo_ids=[REPO_A])
+
+    query, params = captured[0]
+    assert "pr.first_review_at >= pr.created_at" in query
+    assert "'unknown'" in query  # unattributed PRs fall back to unknown
+    assert "coalesce(pr.additions, 0) + coalesce(pr.deletions, 0)" in query
+    assert params["repo_ids"] == [str(REPO_A)]
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2185 — overlap query shapes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_hotspot_overlap_uses_risk_score_convention():
+    captured: list[str] = []
+
+    async def fake_qd(_client: Any, query: str, _params: Any) -> list[dict]:
+        captured.append(query)
+        return []
+
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        side_effect=fake_qd,
+    ):
+        await loader.load_hotspot_overlap(
+            start=START, end=END, start_day=START_DAY, end_day=END_DAY
+        )
+
+    query = captured[0]
+    # Hotspot convention shared with recommendations/operating_review.
+    assert "HAVING risk_score > 0" in query
+    assert "work_graph_pr_commit" in query
+    assert "git_commit_stats" in query
+    assert "uniqExact((pf.repo_id, pf.number))" in query
+
+
+@pytest.mark.asyncio
+async def test_load_complexity_overlap_counts_high_complexity_files():
+    captured: list[str] = []
+
+    async def fake_qd(_client: Any, query: str, _params: Any) -> list[dict]:
+        captured.append(query)
+        return []
+
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        side_effect=fake_qd,
+    ):
+        await loader.load_complexity_overlap(start=START, end=END, end_day=END_DAY)
+
+    query = captured[0]
+    assert "file_complexity_snapshots" in query
+    assert "high_complexity_functions + fc.very_high_complexity_functions" in query

--- a/tests/metrics/test_ai_impact_loader.py
+++ b/tests/metrics/test_ai_impact_loader.py
@@ -332,8 +332,12 @@ async def test_load_hotspot_overlap_uses_risk_score_convention():
         )
 
     query = captured[0]
-    # Hotspot convention shared with recommendations/operating_review.
+    # risk_score > 0 is only a precondition; the discriminating cut is the
+    # per-repo top decile (min one file) — a bare > 0 saturates at ~1.0.
     assert "HAVING risk_score > 0" in query
+    assert "PARTITION BY repo_id" in query
+    assert "repo_file_count * 0.1" in query
+    assert "greatest(1, toUInt64(ceil(repo_file_count * 0.1)))" in query
     assert "work_graph_pr_commit" in query
     assert "git_commit_stats" in query
     assert "uniqExact((pf.repo_id, pf.number))" in query
@@ -357,3 +361,95 @@ async def test_load_complexity_overlap_counts_high_complexity_files():
     query = captured[0]
     assert "file_complexity_snapshots" in query
     assert "high_complexity_functions + fc.very_high_complexity_functions" in query
+
+
+# ---------------------------------------------------------------------------
+# Codex review fixes — org scoping + event-day semantics (CHAOS-2180 Wave 2)
+# ---------------------------------------------------------------------------
+
+
+async def _capture_query(coro_factory) -> tuple[str, dict]:
+    captured: list[tuple[str, dict]] = []
+
+    async def fake_qd(_client: Any, query: str, params: Any) -> list[dict]:
+        captured.append((query, params))
+        return []
+
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        side_effect=fake_qd,
+    ):
+        await coro_factory()
+    return captured[0]
+
+
+@pytest.mark.asyncio
+async def test_hotspot_overlap_org_scopes_every_joined_table():
+    """work_graph_pr_commit, git_commit_stats, work_graph_issue_pr and
+    file_hotspot_daily all carry org_id; repo_id/commit_hash values can
+    collide across tenants, so every join leg must be org-filtered."""
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    query, params = await _capture_query(
+        lambda: loader.load_hotspot_overlap(
+            start=START, end=END, start_day=START_DAY, end_day=END_DAY
+        )
+    )
+    for clause in (
+        "pc.org_id = {org_id:String}",
+        "cs.org_id = {org_id:String}",
+        "link.org_id = {org_id:String}",
+        "hs.org_id = {org_id:String}",
+        "pr.org_id = {org_id:String}",
+        "attr.org_id = {org_id:String}",
+    ):
+        assert clause in query, f"missing org scope: {clause}"
+    assert params["org_id"] == ORG_ID
+
+
+@pytest.mark.asyncio
+async def test_complexity_overlap_org_scopes_every_joined_table():
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    query, _params = await _capture_query(
+        lambda: loader.load_complexity_overlap(start=START, end=END, end_day=END_DAY)
+    )
+    for clause in (
+        "pc.org_id = {org_id:String}",
+        "cs.org_id = {org_id:String}",
+        "link.org_id = {org_id:String}",
+        "fc.org_id = {org_id:String}",
+        "pr.org_id = {org_id:String}",
+        "attr.org_id = {org_id:String}",
+    ):
+        assert clause in query, f"missing org scope: {clause}"
+
+
+@pytest.mark.asyncio
+async def test_review_engagement_org_scoped_and_uses_event_day():
+    """Day key and window must use event time (merged_at when present, else
+    created_at) — the same semantics as compute_ai_impact_metrics_daily — so
+    a PR created before the window but merged inside it lands its engagement
+    on the merge day and merges with the metrics daily row."""
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    query, _params = await _capture_query(
+        lambda: loader.load_review_engagement(start=START, end=END)
+    )
+    event = "if(pr.merged_at IS NOT NULL, pr.merged_at, pr.created_at)"
+    assert f"toDate({event}) AS day" in query
+    assert f"({event} >= {{start:DateTime}} AND {event} < {{end:DateTime}})" in query
+    # The created-OR-merged window form must be gone from this query.
+    assert "pr.created_at >= {start:DateTime} AND pr.created_at <" not in query
+    for clause in (
+        "pr.org_id = {org_id:String}",
+        "attr.org_id = {org_id:String}",
+        "link.org_id = {org_id:String}",
+    ):
+        assert clause in query, f"missing org scope: {clause}"
+
+
+@pytest.mark.asyncio
+async def test_label_lookups_are_org_scoped():
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    repo_query, _ = await _capture_query(lambda: loader.load_repo_labels([str(REPO_A)]))
+    assert "org_id = {org_id:String}" in repo_query
+    team_query, _ = await _capture_query(lambda: loader.load_team_labels([TEAM_A]))
+    assert "org_id = {org_id:String}" in team_query

--- a/tests/metrics/test_ai_impact_loader.py
+++ b/tests/metrics/test_ai_impact_loader.py
@@ -453,3 +453,40 @@ async def test_label_lookups_are_org_scoped():
     assert "org_id = {org_id:String}" in repo_query
     team_query, _ = await _capture_query(lambda: loader.load_team_labels([TEAM_A]))
     assert "org_id = {org_id:String}" in team_query
+
+
+# ---------------------------------------------------------------------------
+# Final review fixes — join identity + windowed candidate prefilter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attribution_join_pins_repo_identity():
+    """work_item_id is not repo-global: the linkage path must constrain
+    repo-pinned attributions to their own repo's links (NULL repo_id =
+    work-item-level attribution, allowed to bind through the link)."""
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    query, _ = await _capture_query(
+        lambda: loader.load_review_engagement(start=START, end=END)
+    )
+    assert "(attr.repo_id IS NULL OR attr.repo_id = link.repo_id)" in query
+
+
+@pytest.mark.asyncio
+async def test_deduped_prs_prefilters_candidates_by_event_window():
+    """argMax must not aggregate the org's entire PR history: the event
+    window must appear INSIDE the candidate selection (any-version-qualifies
+    IN-subquery), and again on deduped values in the outer query."""
+    loader = AIImpactClickHouseLoader(object(), org_id=ORG_ID)
+    query, _ = await _capture_query(
+        lambda: loader.load_review_engagement(start=START, end=END)
+    )
+    event = "if(pr.merged_at IS NOT NULL, pr.merged_at, pr.created_at)"
+    window = f"({event} >= {{start:DateTime}} AND {event} < {{end:DateTime}})"
+    assert "(pr.repo_id, pr.number) IN (" in query
+    # Candidate stage + stage-3 re-check on deduped values = at least twice.
+    assert query.count(window) >= 2
+    # The candidate window predicate must sit before the GROUP BY dedup.
+    in_clause = query.index("(pr.repo_id, pr.number) IN (")
+    candidate_window = query.index(window)
+    assert candidate_window > in_clause or query.index(window, in_clause) > in_clause

--- a/tests/metrics/test_ai_impact_loader_live.py
+++ b/tests/metrics/test_ai_impact_loader_live.py
@@ -1,0 +1,391 @@
+"""Live-ClickHouse fixture-backed tests for CHAOS-2180 Wave 2 loader fixes.
+
+Covers the three Codex-review regressions with controlled, inserted data:
+
+* **Event-day semantics** — a PR created before the window but merged inside
+  it must land its engagement row on the MERGE day (the same
+  ``event_at = merged_at or created_at`` rule as
+  ``compute_ai_impact_metrics_daily``), not on the out-of-window creation day.
+* **Multi-tenant isolation** — rows from a foreign org sharing repo_id and
+  commit_hash values must not leak into this org's overlap counts.
+* **Discriminating hotspot threshold** — with one clear hotspot file among
+  many low-risk files, PRs touching only low-risk files score 0 and mixed
+  populations land strictly between 0 and 1 (a bare ``risk_score > 0`` cut
+  saturates at ~1.0).
+
+Run locally with:
+  CLICKHOUSE_URI=clickhouse://ch:ch@localhost:8123/default \
+  pytest tests/metrics/test_ai_impact_loader_live.py -v
+
+Skips automatically when CLICKHOUSE_URI is unset so it's CI-safe.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date, datetime, timezone
+
+import pytest
+
+from dev_health_ops.metrics.loaders.ai_impact import AIImpactClickHouseLoader
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/default)",
+    ),
+]
+
+# Deterministic ids: reruns overwrite the same ReplacingMergeTree keys.
+ORG = "11110000-c218-0000-0000-00000000aaaa"
+FOREIGN_ORG = "22220000-c218-0000-0000-00000000bbbb"
+REPO = uuid.UUID("33330000-c218-0000-0000-00000000cccc")
+
+START_DAY = date(2026, 5, 1)
+END_DAY = date(2026, 5, 31)
+START = datetime(2026, 5, 1, tzinfo=timezone.utc)
+END = datetime(2026, 5, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+CREATED_BEFORE_WINDOW = datetime(2026, 4, 20, 9, 0, 0)
+MERGED_IN_WINDOW = datetime(2026, 5, 10, 15, 0, 0)
+FIRST_REVIEW = datetime(2026, 4, 20, 13, 0, 0)  # 4h after creation
+NOW = datetime(2026, 5, 31, 12, 0, 0)
+
+
+def _sync_client():
+    import clickhouse_connect
+
+    return clickhouse_connect.get_client(dsn=CLICKHOUSE_URI)
+
+
+def _seed(client) -> None:
+    """Insert the controlled fixture rows (idempotent via ReplacingMergeTree)."""
+    # --- PRs ------------------------------------------------------------
+    # PR 9001: created BEFORE the window, merged INSIDE it (event-day test);
+    #          touches ONLY the hotspot file.
+    # PR 9002: created+merged inside the window; touches ONLY low-risk files.
+    # PR 9003: created+merged inside the window; touches ONLY low-risk files.
+    client.insert(
+        "git_pull_requests",
+        [
+            [
+                str(REPO),
+                9001,
+                "hotspot pr",
+                "open->merge",
+                "merged",
+                "a",
+                "a@x",
+                CREATED_BEFORE_WINDOW,
+                MERGED_IN_WINDOW,
+                MERGED_IN_WINDOW,
+                "f",
+                "main",
+                100,
+                50,
+                1,
+                FIRST_REVIEW,
+                None,
+                0,
+                1,
+                3,
+                NOW,
+                ORG,
+            ],
+            [
+                str(REPO),
+                9002,
+                "cold pr",
+                "",
+                "merged",
+                "a",
+                "a@x",
+                datetime(2026, 5, 5, 9, 0),
+                datetime(2026, 5, 6, 9, 0),
+                datetime(2026, 5, 6, 9, 0),
+                "f",
+                "main",
+                10,
+                5,
+                1,
+                datetime(2026, 5, 5, 11, 0),
+                None,
+                0,
+                1,
+                1,
+                NOW,
+                ORG,
+            ],
+            [
+                str(REPO),
+                9003,
+                "cold pr 2",
+                "",
+                "merged",
+                "a",
+                "a@x",
+                datetime(2026, 5, 7, 9, 0),
+                datetime(2026, 5, 8, 9, 0),
+                datetime(2026, 5, 8, 9, 0),
+                "f",
+                "main",
+                10,
+                5,
+                1,
+                datetime(2026, 5, 7, 11, 0),
+                None,
+                0,
+                1,
+                1,
+                NOW,
+                ORG,
+            ],
+        ],
+        column_names=[
+            "repo_id",
+            "number",
+            "title",
+            "body",
+            "state",
+            "author_name",
+            "author_email",
+            "created_at",
+            "merged_at",
+            "closed_at",
+            "head_branch",
+            "base_branch",
+            "additions",
+            "deletions",
+            "changed_files",
+            "first_review_at",
+            "first_comment_at",
+            "changes_requested_count",
+            "reviews_count",
+            "comments_count",
+            "last_synced",
+            "org_id",
+        ],
+    )
+
+    # --- Attributions (direct subject_id path: "<number>") ---------------
+    attr_cols = [
+        "record_id",
+        "org_id",
+        "provider",
+        "subject_type",
+        "subject_id",
+        "repo_id",
+        "kind",
+        "source",
+        "confidence",
+        "actor",
+        "evidence",
+        "observed_at",
+        "ingested_at",
+        "computed_at",
+    ]
+
+    def _attr(number: int, org: str) -> list:
+        # Deterministic record_id per (org, number) so reruns replace.
+        rid = str(uuid.uuid5(uuid.NAMESPACE_URL, f"c2180-live-{org}-{number}"))
+        return [
+            rid,
+            org,
+            "github",
+            "pull_request",
+            str(number),
+            str(REPO),
+            "ai_assisted",
+            "commit_trailer",
+            0.9,
+            None,
+            "test",
+            NOW,
+            NOW,
+            NOW,
+        ]
+
+    client.insert(
+        "ai_attribution",
+        [_attr(9001, ORG), _attr(9002, ORG), _attr(9003, ORG)],
+        column_names=attr_cols,
+    )
+
+    # --- PR -> commit -> files -------------------------------------------
+    pc_cols = [
+        "repo_id",
+        "pr_number",
+        "commit_hash",
+        "confidence",
+        "provenance",
+        "evidence",
+        "last_synced",
+        "org_id",
+    ]
+    client.insert(
+        "work_graph_pr_commit",
+        [
+            [str(REPO), 9001, "c2180hot", 1.0, "native", "test", NOW, ORG],
+            [str(REPO), 9002, "c2180cold1", 1.0, "native", "test", NOW, ORG],
+            [str(REPO), 9003, "c2180cold2", 1.0, "native", "test", NOW, ORG],
+        ],
+        column_names=pc_cols,
+    )
+    cs_cols = [
+        "repo_id",
+        "commit_hash",
+        "file_path",
+        "additions",
+        "deletions",
+        "old_file_mode",
+        "new_file_mode",
+        "last_synced",
+        "org_id",
+    ]
+    client.insert(
+        "git_commit_stats",
+        [
+            [str(REPO), "c2180hot", "src/hot.py", 100, 50, "", "", NOW, ORG],
+            [str(REPO), "c2180cold1", "src/cold1.py", 10, 5, "", "", NOW, ORG],
+            [str(REPO), "c2180cold2", "src/cold2.py", 10, 5, "", "", NOW, ORG],
+        ],
+        column_names=cs_cols,
+    )
+
+    # --- Hotspot snapshots: 1 hot file among 10 (top decile = exactly 1) --
+    hs_cols = [
+        "repo_id",
+        "day",
+        "file_path",
+        "churn_loc_30d",
+        "churn_commits_30d",
+        "cyclomatic_total",
+        "cyclomatic_avg",
+        "blame_concentration",
+        "risk_score",
+        "computed_at",
+        "org_id",
+    ]
+    hs_rows = [
+        [
+            str(REPO),
+            date(2026, 5, 15),
+            "src/hot.py",
+            500,
+            50,
+            100,
+            10.0,
+            None,
+            5.0,
+            NOW,
+            ORG,
+        ]
+    ]
+    for i in range(1, 10):
+        path = f"src/cold{i}.py" if i <= 2 else f"src/filler{i}.py"
+        hs_rows.append(
+            [str(REPO), date(2026, 5, 15), path, 10, 1, 5, 1.0, None, 0.1, NOW, ORG]
+        )
+    client.insert("file_hotspot_daily", hs_rows, column_names=hs_cols)
+
+    # --- Foreign-org rows with IDENTICAL repo_id + commit hashes ----------
+    # A foreign PR 9002 link pointing its commit at the HOT file: without
+    # org scoping on pc/cs this would flip PR 9002 into a hotspot-toucher.
+    client.insert(
+        "work_graph_pr_commit",
+        [[str(REPO), 9002, "c2180foreign", 1.0, "native", "test", NOW, FOREIGN_ORG]],
+        column_names=pc_cols,
+    )
+    client.insert(
+        "git_commit_stats",
+        [
+            [str(REPO), "c2180foreign", "src/hot.py", 1, 1, "", "", NOW, FOREIGN_ORG],
+            # Foreign stats for an in-org commit hash: org filter on cs must
+            # exclude this row even though pc resolves in-org.
+            [str(REPO), "c2180cold1", "src/hot.py", 1, 1, "", "", NOW, FOREIGN_ORG],
+        ],
+        column_names=cs_cols,
+    )
+
+
+@pytest.fixture(scope="module")
+def seeded() -> None:
+    client = _sync_client()
+    try:
+        _seed(client)
+    finally:
+        client.close()
+
+
+async def _client():
+    from dev_health_ops.api.queries.client import get_global_client
+
+    assert CLICKHOUSE_URI is not None
+    return await get_global_client(CLICKHOUSE_URI)
+
+
+async def test_engagement_daily_lands_on_merge_day(seeded) -> None:
+    """PR 9001 (created 2026-04-20, merged 2026-05-10) must produce its
+    engagement on the merge day — inside the window — not on the creation
+    day, matching compute_ai_impact_metrics_daily's event_at rule."""
+    loader = AIImpactClickHouseLoader(await _client(), org_id=ORG)
+    rows = await loader.load_review_engagement(start=START, end=END, repo_id=REPO)
+    ai_days = {r["day"] for r in rows if r["bucket"] == "ai_assisted"}
+    assert date(2026, 5, 10) in ai_days, f"merge-day cell missing: {rows}"
+    assert date(2026, 4, 20) not in ai_days, "engagement leaked to creation day"
+    merge_day_row = next(
+        r
+        for r in rows
+        if r["bucket"] == "ai_assisted" and r["day"] == date(2026, 5, 10)
+    )
+    # Pickup latency still measures open -> first review (4h), regardless of
+    # which day the PR is bucketed under.
+    assert merge_day_row["prs_with_first_review"] == 1
+    assert float(merge_day_row["pickup_latency_hours"]) == pytest.approx(4.0)
+
+
+async def test_hotspot_overlap_rate_is_fractional_not_saturated(seeded) -> None:
+    """1 of 3 assessable AI PRs touches the single top-decile file → rate
+    must be strictly between 0 and 1 (here 1/3), and the foreign-org rows
+    sharing repo_id/commit_hash must not inflate the count."""
+    loader = AIImpactClickHouseLoader(await _client(), org_id=ORG)
+    rows = await loader.load_hotspot_overlap(
+        start=START,
+        end=END,
+        start_day=START_DAY,
+        end_day=END_DAY,
+        repo_id=REPO,
+    )
+    by_bucket = {r["bucket"]: r for r in rows}
+    ai = by_bucket["ai_assisted"]
+    assert int(ai["prs_total"]) == 3
+    assert int(ai["prs_touching_hotspots"]) == 1, (
+        "expected exactly PR 9001 to touch the top-decile file; foreign-org "
+        f"leakage or threshold saturation? row={ai}"
+    )
+    rate = int(ai["prs_touching_hotspots"]) / int(ai["prs_total"])
+    assert 0.0 < rate < 1.0
+    assert float(ai["avg_hotspot_risk_score"]) == pytest.approx(5.0)
+
+
+async def test_hotspot_overlap_zero_when_only_low_risk_touched(seeded) -> None:
+    """Scoped to a window where only the cold PRs exist (9001 merged on the
+    10th; restrict to the 1st-9th window → only 9002/9003): rate must be a
+    real computed zero."""
+    loader = AIImpactClickHouseLoader(await _client(), org_id=ORG)
+    rows = await loader.load_hotspot_overlap(
+        start=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        end=datetime(2026, 5, 9, tzinfo=timezone.utc),
+        start_day=START_DAY,
+        end_day=END_DAY,
+        repo_id=REPO,
+    )
+    by_bucket = {r["bucket"]: r for r in rows}
+    ai = by_bucket["ai_assisted"]
+    assert int(ai["prs_total"]) == 2
+    assert int(ai["prs_touching_hotspots"]) == 0

--- a/tests/metrics/test_ai_impact_loader_live.py
+++ b/tests/metrics/test_ai_impact_loader_live.py
@@ -45,6 +45,8 @@ pytestmark = [
 ORG = "11110000-c218-0000-0000-00000000aaaa"
 FOREIGN_ORG = "22220000-c218-0000-0000-00000000bbbb"
 REPO = uuid.UUID("33330000-c218-0000-0000-00000000cccc")
+REPO_B = uuid.UUID("44440000-c218-0000-0000-00000000dddd")
+SHARED_WORK_ITEM = "WI-C2180-SHARED"
 
 START_DAY = date(2026, 5, 1)
 END_DAY = date(2026, 5, 31)
@@ -55,6 +57,9 @@ CREATED_BEFORE_WINDOW = datetime(2026, 4, 20, 9, 0, 0)
 MERGED_IN_WINDOW = datetime(2026, 5, 10, 15, 0, 0)
 FIRST_REVIEW = datetime(2026, 4, 20, 13, 0, 0)  # 4h after creation
 NOW = datetime(2026, 5, 31, 12, 0, 0)
+# Later sync version for rows that REPLACE earlier (mis-stamped) fixture
+# versions: argMax(..., last_synced) must pick these over stale inserts.
+NOW_FIXED = datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
 
 
 def _sync_client():
@@ -257,6 +262,131 @@ def _seed(client) -> None:
         column_names=cs_cols,
     )
 
+    # --- Cross-repo work_item_id collision (join-identity fix) ----------
+    # PR 9004 (REPO) and PR 9101 (REPO_B) link the SAME work_item_id; the
+    # only attribution for it is pinned to REPO. Without the
+    # attr.repo_id = link.repo_id constraint, 9101 would be cross-linked.
+    client.insert(
+        "git_pull_requests",
+        [
+            [
+                str(REPO),
+                9004,
+                "wi pr",
+                "",
+                "merged",
+                "a",
+                "a@x",
+                # tz-aware: naive datetimes shift local->UTC on insert and
+                # can move a 17:00 merge onto the next UTC day.
+                datetime(2026, 5, 20, 9, 0, tzinfo=timezone.utc),
+                datetime(2026, 5, 20, 17, 0, tzinfo=timezone.utc),
+                datetime(2026, 5, 20, 17, 0, tzinfo=timezone.utc),
+                "f",
+                "main",
+                20,
+                10,
+                1,
+                datetime(2026, 5, 20, 11, 0, tzinfo=timezone.utc),
+                None,
+                0,
+                1,
+                2,
+                NOW_FIXED,
+                ORG,
+            ],
+            [
+                str(REPO_B),
+                9101,
+                "wi pr other repo",
+                "",
+                "merged",
+                "a",
+                "a@x",
+                datetime(2026, 5, 21, 9, 0, tzinfo=timezone.utc),
+                datetime(2026, 5, 21, 17, 0, tzinfo=timezone.utc),
+                datetime(2026, 5, 21, 17, 0, tzinfo=timezone.utc),
+                "f",
+                "main",
+                20,
+                10,
+                1,
+                datetime(2026, 5, 21, 11, 0, tzinfo=timezone.utc),
+                None,
+                0,
+                1,
+                2,
+                NOW_FIXED,
+                ORG,
+            ],
+        ],
+        column_names=[
+            "repo_id",
+            "number",
+            "title",
+            "body",
+            "state",
+            "author_name",
+            "author_email",
+            "created_at",
+            "merged_at",
+            "closed_at",
+            "head_branch",
+            "base_branch",
+            "additions",
+            "deletions",
+            "changed_files",
+            "first_review_at",
+            "first_comment_at",
+            "changes_requested_count",
+            "reviews_count",
+            "comments_count",
+            "last_synced",
+            "org_id",
+        ],
+    )
+    link_cols = [
+        "repo_id",
+        "work_item_id",
+        "pr_number",
+        "confidence",
+        "provenance",
+        "evidence",
+        "last_synced",
+        "org_id",
+    ]
+    client.insert(
+        "work_graph_issue_pr",
+        [
+            [str(REPO), SHARED_WORK_ITEM, 9004, 1.0, "native", "test", NOW, ORG],
+            [str(REPO_B), SHARED_WORK_ITEM, 9101, 1.0, "native", "test", NOW, ORG],
+        ],
+        column_names=link_cols,
+    )
+    rid = str(uuid.uuid5(uuid.NAMESPACE_URL, f"c2180-live-{ORG}-{SHARED_WORK_ITEM}"))
+    client.insert(
+        "ai_attribution",
+        [
+            [
+                rid,
+                ORG,
+                "github",
+                "pull_request",
+                SHARED_WORK_ITEM,
+                str(REPO),
+                "agent_created",
+                "commit_trailer",
+                0.9,
+                None,
+                "test",
+                NOW,
+                NOW,
+                NOW,
+            ]
+        ],
+        column_names=attr_cols,
+    )
+
     # --- Hotspot snapshots: 1 hot file among 10 (top decile = exactly 1) --
     hs_cols = [
         "repo_id",
@@ -389,3 +519,21 @@ async def test_hotspot_overlap_zero_when_only_low_risk_touched(seeded) -> None:
     ai = by_bucket["ai_assisted"]
     assert int(ai["prs_total"]) == 2
     assert int(ai["prs_touching_hotspots"]) == 0
+
+
+async def test_work_item_attribution_does_not_cross_link_repos(seeded) -> None:
+    """PR 9004 (REPO) and PR 9101 (REPO_B) share a work_item_id; the only
+    attribution for it is pinned to REPO. 9004 must be agent_created and
+    9101 must stay unknown — repo-pinned attributions never cross-link."""
+    loader = AIImpactClickHouseLoader(await _client(), org_id=ORG)
+    rows = await loader.load_review_engagement(start=START, end=END)
+    agent_days = {
+        r["day"]: r["prs_with_first_review"]
+        for r in rows
+        if r["bucket"] == "agent_created"
+    }
+    # Only 9004's merge day carries agent_created engagement.
+    assert agent_days == {date(2026, 5, 20): 1}, f"cross-link leak: {rows}"
+    # 9101 lands in unknown on its own merge day.
+    unknown_days = {r["day"] for r in rows if r["bucket"] == "unknown"}
+    assert date(2026, 5, 21) in unknown_days


### PR DESCRIPTION
## CHAOS-2180 Wave 2 — AI resolvers/loaders

**Tickets:** CHAOS-2194 (pickup latency + review comments/LOC), CHAOS-2185 (real hotspot/complexity overlap), CHAOS-2186 (impact repo/team breakdowns), + Wave-1 known limitation (team-scoped attribution pagination).

### What
- `AIReviewLoadRow.pickupLatencyHours` / `reviewCommentsPerLoc` — query-time from git tables, joined on the same event-day semantics as `ai_impact_metrics_daily` (`merged_at or created_at` for BOTH day bucketing and window membership)
- `AIRiskBreakdownResult.hotspotOverlap` / `complexityOverlap` — real joins (AI PRs → work_graph_pr_commit → git_commit_stats → file_hotspot_daily / file_complexity_snapshots); hotspot = per-repo **top decile** of risk_score (live: 26/44 = 0.59, vs saturated 1.0 under naive >0)
- `AIImpactSummary.repoBreakdown` / `teamBreakdown` — top 10 by AI PR volume, team labels via repo-pattern resolver
- Team-scoped attribution pagination: team→repo_ids resolved BEFORE SQL LIMIT (dense pages)
- argMax(last_synced) dedup for all PR SQL aggregates (RMT row-version double-count); two-stage windowed candidate selection (no full-history argMax on dashboard paths)
- Multi-tenancy: org_id in every JOIN predicate; work-item attribution constrained by repo identity (NULL repo_id = work-item-level, documented)

### Review trail
3 Codex adversarial rounds + orchestrator review; 8 findings fixed (event-day mismatch, org-scoping, saturated metric, cross-repo attribution leak, unbounded dedup scan, +3 self-caught). All SQL live-validated against docker ClickHouse incl. two-org collision fixtures.

### Gates
ruff clean; full pytest 12 failed / 3712 passed — failure list **byte-identical** to clean origin/main baseline (env-dependent live tests; 5 env-independent + 7 with CLICKHOUSE_URI set). Live clickhouse-marked tests 4/4.

### Notes
- **dev-health-web depends on this schema** (PR in dev-health-web targeting chaos-2079-ia-restructure consumes pickupLatencyHours/reviewCommentsPerLoc/repoBreakdown/teamBreakdown/hotspotOverlap/complexityOverlap). Merge/deploy this before the web PR.
- Sibling ops PR (pipeline/CLI) touches disjoint regions of models/ai.py — merge either order, rebase the second if needed.