### PR TITLE
feat(ai): CHAOS-2180 Wave 2 — workflow extractor wiring, allowlist write path, 5 opportunity kinds

### DIFF
--- a/docs/computations/ai-opportunity-detector.md
+++ b/docs/computations/ai-opportunity-detector.md
@@ -15,6 +15,13 @@ CHAOS-1586 uses inline detection in the GraphQL resolver rather than adding a ne
 | `HIGH_REWORK` | AI-assisted PRs have rework rate at least 0.25 and at least +0.10 above the human baseline with at least 10 AI PRs. |
 | `SLOW_CYCLE` | AI-assisted PRs have average cycle time at least 1.25× the human baseline with at least 10 AI PRs. |
 | `UNCOVERED_TEST_AREA` | AI-assisted PRs have `test_gap_rate` at least 0.50 with at least 10 AI PRs. |
+| `TEST_GENERATION` | Human-authored PRs have `test_gap_rate` at least 0.50 with at least 10 human PRs (CHAOS-2189). |
+| `DEPENDENCY_UPDATES` | At least five human-authored, non-bot PRs in the last 30 days have dependency-bump titles (`bump`/`update`/`upgrade` plus dependency vocabulary); AI-attributed PRs are excluded via anti-join (CHAOS-2189). |
+| `MECHANICAL_MIGRATIONS` | At least five human-authored, non-bot PRs in the last 30 days have migration-style titles (`migrat…`, `codemod`, `mass rename`, …); AI-attributed PRs are excluded via anti-join (CHAOS-2189). |
+| `DOCUMENTATION_DRIFT` | At least 20 code commits landed in the last 30 days with zero documentation-file changes (`*.md`, `*.rst`, `*.adoc`, `docs/`) in the same window (CHAOS-2189). |
+| `FLAKY_TEST_TRIAGE` | Case-weighted `flake_rate` from `testops_test_metrics_daily` is at least 0.05 across at least 50 test-case executions in the last 30 days (CHAOS-2189). |
+
+The five CHAOS-2189 rules detect *human/manual* toil or quality gaps where AI should be applied next, so (unlike the AI-bucket rules) they gate on human-authored activity. The SQL-backed CHAOS-2189 rules return nothing under a team-scoped filter, mirroring `REPETITIVE_CHANGE`, because the underlying raw tables carry no team scoping.
 
 ## GraphQL contract
 
@@ -27,7 +34,7 @@ CHAOS-1586 uses inline detection in the GraphQL resolver rather than adding a ne
 Each recommendation includes:
 
 - `opportunityId`: stable hash of `(kind, repo_id, team_id)`.
-- `kind`: one of the five canonical opportunity kinds above.
+- `kind`: one of the ten canonical opportunity kinds above.
 - `repoId` / `teamId`: the scope where the rule fired.
 - `title` and `rationale`: short, numeric explanation of the breach.
 - `score`: 0..1 breach-magnitude ranking score.

--- a/src/dev_health_ops/api/graphql/models/ai.py
+++ b/src/dev_health_ops/api/graphql/models/ai.py
@@ -343,6 +343,13 @@ class AIOpportunityKind(Enum):
     HIGH_REWORK = "high_rework"
     SLOW_CYCLE = "slow_cycle"
     UNCOVERED_TEST_AREA = "uncovered_test_area"
+    # CHAOS-2189: remaining workflow types documented in
+    # docs/product/ai-assisted/AI Opportunity Detection.md.
+    TEST_GENERATION = "test_gen"
+    DEPENDENCY_UPDATES = "dep_updates"
+    MECHANICAL_MIGRATIONS = "migrations"
+    DOCUMENTATION_DRIFT = "doc_drift"
+    FLAKY_TEST_TRIAGE = "flaky_triage"
 
 
 @strawberry.type

--- a/src/dev_health_ops/audit/ai_governance/cli.py
+++ b/src/dev_health_ops/audit/ai_governance/cli.py
@@ -58,13 +58,22 @@ def _sink(ns: argparse.Namespace):
 
 def _cmd_allowlist_set(ns: argparse.Namespace) -> int:
     org_id = _require_org(ns)
-    entry = AIToolAllowlistEntry(
-        org_id=org_id,
-        tool_name=ns.tool,
-        model_name=ns.model,
-        status=ToolAllowlistStatus(ns.status),
-        reason=ns.reason,
-    )
+    try:
+        # AIToolAllowlistEntry normalises blank/whitespace --model to None
+        # (wildcard) and rejects a blank --tool: '' and NULL share the same
+        # ReplacingMergeTree key (ORDER BY ifNull(model_name, '')), so a
+        # blank "exact" row would silently replace the wildcard policy.
+        entry = AIToolAllowlistEntry(
+            org_id=org_id,
+            tool_name=ns.tool,
+            model_name=ns.model,
+            status=ToolAllowlistStatus(ns.status),
+            reason=ns.reason,
+        )
+    except ValueError as exc:
+        raise SystemExit(f"Invalid allowlist entry: {exc}") from exc
+    if ns.model is not None and entry.model_name is None:
+        logger.info("Blank --model treated as wildcard (applies to every model).")
     sink = _sink(ns)
     sink.write_ai_tool_allowlist([entry])
     scope = (

--- a/src/dev_health_ops/audit/ai_governance/cli.py
+++ b/src/dev_health_ops/audit/ai_governance/cli.py
@@ -1,0 +1,145 @@
+"""Admin CLI for the org-level AI tool allowlist (CHAOS-2209).
+
+The allowlist source of truth is admin-seeded: entries are written through
+the ClickHouse sink (sinks-only persistence) and read back with
+latest-version semantics (``ai_tool_allowlist`` is a ReplacingMergeTree
+versioned by ``computed_at``).
+
+Usage::
+
+    dev-hops ai allowlist set --tool claude-code --status allowed \
+        [--model claude] [--reason "Org policy AI-001"]
+    dev-hops ai allowlist list
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+
+from dev_health_ops.audit.ai_governance.models import (
+    AIToolAllowlistEntry,
+    ToolAllowlistStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+_SETTABLE_STATUSES = (
+    ToolAllowlistStatus.ALLOWED.value,
+    ToolAllowlistStatus.DISALLOWED.value,
+    ToolAllowlistStatus.DEPRECATED.value,
+)
+
+
+def _require_org(ns: argparse.Namespace) -> str:
+    org_id = str(getattr(ns, "org", None) or "")
+    if not org_id:
+        raise SystemExit("--org (or ORG_ID) is required for allowlist commands.")
+    return org_id
+
+
+def _require_analytics_db(ns: argparse.Namespace) -> str:
+    db_url = str(getattr(ns, "analytics_db", None) or os.getenv("CLICKHOUSE_URI") or "")
+    if not db_url:
+        raise SystemExit(
+            "--analytics-db (or CLICKHOUSE_URI) is required for allowlist commands."
+        )
+    return db_url
+
+
+def _sink(ns: argparse.Namespace):
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    sink = ClickHouseMetricsSink(_require_analytics_db(ns))
+    sink.ensure_tables()
+    return sink
+
+
+def _cmd_allowlist_set(ns: argparse.Namespace) -> int:
+    org_id = _require_org(ns)
+    entry = AIToolAllowlistEntry(
+        org_id=org_id,
+        tool_name=ns.tool,
+        model_name=ns.model,
+        status=ToolAllowlistStatus(ns.status),
+        reason=ns.reason,
+    )
+    sink = _sink(ns)
+    sink.write_ai_tool_allowlist([entry])
+    scope = (
+        f"{entry.tool_name}/{entry.model_name}" if entry.model_name else entry.tool_name
+    )
+    logger.info("Allowlist updated: org=%s %s -> %s", org_id, scope, entry.status.value)
+    return 0
+
+
+def _cmd_allowlist_list(ns: argparse.Namespace) -> int:
+    org_id = _require_org(ns)
+    sink = _sink(ns)
+    rows = sink.query_dicts(
+        "SELECT tool_name,"
+        " model_name,"
+        " argMax(status, computed_at) AS status,"
+        " argMax(reason, computed_at) AS reason,"
+        " max(updated_at) AS updated_at"
+        " FROM ai_tool_allowlist"
+        " WHERE org_id = {org_id:String}"
+        " GROUP BY tool_name, model_name"
+        " ORDER BY tool_name, model_name",
+        {"org_id": org_id},
+    )
+    if not rows:
+        print(f"No allowlist entries for org {org_id}.")
+        return 0
+    print(f"AI tool allowlist for org {org_id}:")
+    for row in rows:
+        model = row.get("model_name") or "*"
+        reason = row.get("reason") or ""
+        print(
+            f"  {row.get('tool_name')} / {model}: {row.get('status')}"
+            + (f" — {reason}" if reason else "")
+        )
+    return 0
+
+
+def register_commands(subparsers: argparse._SubParsersAction) -> None:
+    """Register the ``ai`` command group (``ai allowlist set|list``)."""
+    ai_parser = subparsers.add_parser(
+        "ai", help="AI governance administration commands."
+    )
+    ai_sub = ai_parser.add_subparsers(dest="ai_command", required=True)
+
+    allowlist_parser = ai_sub.add_parser(
+        "allowlist", help="Manage the org-level AI tool allowlist."
+    )
+    allowlist_sub = allowlist_parser.add_subparsers(
+        dest="allowlist_command", required=True
+    )
+
+    set_parser = allowlist_sub.add_parser(
+        "set", help="Create or update an allowlist entry."
+    )
+    set_parser.add_argument(
+        "--tool", required=True, help="Tool name (e.g. claude-code)."
+    )
+    set_parser.add_argument(
+        "--model",
+        default=None,
+        help="Optional model name. Omit to apply to every model of the tool.",
+    )
+    set_parser.add_argument(
+        "--status",
+        required=True,
+        choices=_SETTABLE_STATUSES,
+        help="Policy status for the tool/model.",
+    )
+    set_parser.add_argument(
+        "--reason", default=None, help="Optional human-readable policy rationale."
+    )
+    set_parser.set_defaults(func=_cmd_allowlist_set)
+
+    list_parser = allowlist_sub.add_parser(
+        "list", help="Show the latest allowlist entries for the org."
+    )
+    list_parser.set_defaults(func=_cmd_allowlist_list)

--- a/src/dev_health_ops/audit/ai_governance/loaders.py
+++ b/src/dev_health_ops/audit/ai_governance/loaders.py
@@ -255,18 +255,24 @@ LEFT JOIN (
     GROUP BY repo_id
 ) AS finding ON a.repo_id = finding.repo_id
 -- Allowlist precedence (CHAOS-2209): an exact tool+model row beats a
--- wildcard (model_name IS NULL) row, and each side is deduplicated to its
--- latest version (argMax over computed_at — the table is a
--- ReplacingMergeTree) AND to one row per join key, so an artifact can never
--- fan out into multiple coverage events from overlapping policy rows.
+-- wildcard row, and each side is deduplicated to its latest version
+-- (argMax over computed_at — the table is a ReplacingMergeTree) AND to one
+-- row per join key, so an artifact can never fan out into multiple
+-- coverage events from overlapping policy rows.
+-- Wildcard means nullIf(model_name, '') IS NULL: legacy '' rows are
+-- wildcard, never exact — JSONExtractString yields '' for missing model
+-- evidence, so a '' "exact" key would phantom-match every artifact that
+-- lacks model evidence. Note migration 038's ORDER BY ifNull(model_name,'')
+-- makes NULL and '' the SAME dedup key (rows can replace each other on
+-- merge); fixing that needs a schema migration — follow-up ticket.
 LEFT JOIN (
     SELECT
         org_id,
         tool_name,
-        ifNull(model_name, '') AS model_key,
+        model_name AS model_key,
         argMax(status, computed_at) AS status
     FROM ai_tool_allowlist
-    WHERE model_name IS NOT NULL
+    WHERE nullIf(model_name, '') IS NOT NULL
     GROUP BY org_id, tool_name, model_key
 ) AS allow_exact
     ON toString(a.org_id) = allow_exact.org_id
@@ -278,7 +284,7 @@ LEFT JOIN (
         tool_name,
         argMax(status, computed_at) AS status
     FROM ai_tool_allowlist
-    WHERE model_name IS NULL
+    WHERE nullIf(model_name, '') IS NULL
     GROUP BY org_id, tool_name
 ) AS allow_wild
     ON toString(a.org_id) = allow_wild.org_id

--- a/src/dev_health_ops/audit/ai_governance/loaders.py
+++ b/src/dev_health_ops/audit/ai_governance/loaders.py
@@ -228,7 +228,11 @@ SELECT
     finding.finding_count > 0 AS license_or_dependency_finding,
     JSONExtractString(a.evidence, 'tool_name') AS tool_name,
     JSONExtractString(a.evidence, 'model_name') AS model_name,
-    coalesce(allow.status, 'unknown') AS tool_allowlist_status,
+    multiIf(
+        allow_exact.status != '', allow_exact.status,
+        allow_wild.status != '', allow_wild.status,
+        'unknown'
+    ) AS tool_allowlist_status,
     a.source AS source,
     a.kind AS kind,
     a.confidence AS confidence,
@@ -250,10 +254,35 @@ LEFT JOIN (
     WHERE lower(coalesce(source, '')) IN ('dependabot', 'gitlab_dependency', 'dependency_scanning')
     GROUP BY repo_id
 ) AS finding ON a.repo_id = finding.repo_id
-LEFT JOIN ai_tool_allowlist AS allow
-    ON toString(a.org_id) = allow.org_id
-    AND JSONExtractString(a.evidence, 'tool_name') = allow.tool_name
-    AND (allow.model_name IS NULL OR JSONExtractString(a.evidence, 'model_name') = allow.model_name)
+-- Allowlist precedence (CHAOS-2209): an exact tool+model row beats a
+-- wildcard (model_name IS NULL) row, and each side is deduplicated to its
+-- latest version (argMax over computed_at — the table is a
+-- ReplacingMergeTree) AND to one row per join key, so an artifact can never
+-- fan out into multiple coverage events from overlapping policy rows.
+LEFT JOIN (
+    SELECT
+        org_id,
+        tool_name,
+        ifNull(model_name, '') AS model_key,
+        argMax(status, computed_at) AS status
+    FROM ai_tool_allowlist
+    WHERE model_name IS NOT NULL
+    GROUP BY org_id, tool_name, model_key
+) AS allow_exact
+    ON toString(a.org_id) = allow_exact.org_id
+    AND JSONExtractString(a.evidence, 'tool_name') = allow_exact.tool_name
+    AND JSONExtractString(a.evidence, 'model_name') = allow_exact.model_key
+LEFT JOIN (
+    SELECT
+        org_id,
+        tool_name,
+        argMax(status, computed_at) AS status
+    FROM ai_tool_allowlist
+    WHERE model_name IS NULL
+    GROUP BY org_id, tool_name
+) AS allow_wild
+    ON toString(a.org_id) = allow_wild.org_id
+    AND JSONExtractString(a.evidence, 'tool_name') = allow_wild.tool_name
 WHERE toString(a.org_id) = {org_id:String}
   AND a.observed_at >= {start:DateTime64(3, 'UTC')}
   AND a.observed_at <= {end:DateTime64(3, 'UTC')}

--- a/src/dev_health_ops/audit/ai_governance/models.py
+++ b/src/dev_health_ops/audit/ai_governance/models.py
@@ -44,6 +44,24 @@ class ToolAllowlistStatus(StrEnum):
 
 
 @dataclass(frozen=True)
+class AIToolAllowlistEntry:
+    """A persisted org-level AI tool/model allowlist policy entry.
+
+    ``model_name=None`` means the policy applies to every model of the tool.
+    Rows are versioned by ``computed_at`` (ReplacingMergeTree), so updating an
+    entry is a plain re-insert with the same (org_id, tool_name, model_name).
+    """
+
+    org_id: str
+    tool_name: str
+    status: ToolAllowlistStatus
+    model_name: str | None = None
+    reason: str | None = None
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    computed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass(frozen=True)
 class AIGovernanceArtifact:
     """A policy-evaluation input for an AI-relevant engineering artifact."""
 

--- a/src/dev_health_ops/audit/ai_governance/models.py
+++ b/src/dev_health_ops/audit/ai_governance/models.py
@@ -50,6 +50,14 @@ class AIToolAllowlistEntry:
     ``model_name=None`` means the policy applies to every model of the tool.
     Rows are versioned by ``computed_at`` (ReplacingMergeTree), so updating an
     entry is a plain re-insert with the same (org_id, tool_name, model_name).
+
+    Empty-string models are normalised to ``None`` at construction: migration
+    038's ORDER BY uses ``ifNull(model_name, '')``, so a NULL wildcard row
+    and a ``''`` "exact" row share the SAME ReplacingMergeTree dedup key and
+    would silently replace each other on background merge. Readers must
+    treat ``''`` as wildcard for the same reason (see the governance
+    loader's ``nullIf`` handling); making the key distinguish them requires
+    a schema migration — flagged as follow-up, out of scope this wave.
     """
 
     org_id: str
@@ -59,6 +67,14 @@ class AIToolAllowlistEntry:
     reason: str | None = None
     updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     computed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def __post_init__(self) -> None:
+        tool = (self.tool_name or "").strip()
+        if not tool:
+            raise ValueError("AIToolAllowlistEntry.tool_name must be non-empty")
+        object.__setattr__(self, "tool_name", tool)
+        model = (self.model_name or "").strip()
+        object.__setattr__(self, "model_name", model or None)
 
 
 @dataclass(frozen=True)

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -336,6 +336,7 @@ def build_parser() -> argparse.ArgumentParser:
     from dev_health_ops.api import runner as api_runner
     from dev_health_ops.api.admin import cli as admin_cli
     from dev_health_ops.audit import completeness, coverage, perf, schema
+    from dev_health_ops.audit.ai_governance import cli as ai_governance_cli
     from dev_health_ops.fixtures import runner as fixtures_runner
     from dev_health_ops.metrics import (
         job_capacity,
@@ -426,6 +427,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     # ---- admin (user/org management) ----
     admin_cli.register_commands(sub)
+
+    # ---- ai governance administration ----
+    ai_governance_cli.register_commands(sub)
 
     # ---- work-graph & investment ----
     work_graph_runner.register_commands(sub)

--- a/src/dev_health_ops/fixtures/generators/__init__.py
+++ b/src/dev_health_ops/fixtures/generators/__init__.py
@@ -5,6 +5,9 @@ into domain-focused mixin classes. The composer in ``generator.py`` inherits
 from all mixins so the public API (``SyntheticDataGenerator``) is unchanged.
 """
 
+from dev_health_ops.fixtures.generators.ai_governance import (
+    generate_ai_tool_allowlist_entries,
+)
 from dev_health_ops.fixtures.generators.ai_workflow import AiWorkflowGeneratorMixin
 from dev_health_ops.fixtures.generators.base import BaseGeneratorMixin
 from dev_health_ops.fixtures.generators.commits import CommitsGeneratorMixin
@@ -19,6 +22,7 @@ from dev_health_ops.fixtures.generators.work_items import WorkItemsGeneratorMixi
 __all__ = [
     "BaseGeneratorMixin",
     "AiWorkflowGeneratorMixin",
+    "generate_ai_tool_allowlist_entries",
     "CommitsGeneratorMixin",
     "IncidentsGeneratorMixin",
     "InteractionsGeneratorMixin",

--- a/src/dev_health_ops/fixtures/generators/ai_governance.py
+++ b/src/dev_health_ops/fixtures/generators/ai_governance.py
@@ -1,0 +1,82 @@
+"""AI governance fixture generators (CHAOS-2209).
+
+Seeds the org-level ``ai_tool_allowlist`` policy table so the governance
+views can render a real allowlist verdict instead of a permanent "unknown".
+The entries are deterministic and deliberately include every status so the
+UI exercises allowed, deprecated, and disallowed renderings.
+
+The ``tool_name``/``model_name`` values intentionally line up with the
+attribution evidence written by
+:meth:`PrGeneratorMixin.generate_ai_attributions` (``tool_name="claude-code"``,
+``model_name="claude"``) so the governance loader's allowlist join produces
+non-"unknown" statuses for fixture data.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from dev_health_ops.audit.ai_governance.models import (
+    AIToolAllowlistEntry,
+    ToolAllowlistStatus,
+)
+
+_ALLOWLIST_SEED: tuple[tuple[str, str | None, ToolAllowlistStatus, str], ...] = (
+    (
+        "claude-code",
+        None,
+        ToolAllowlistStatus.ALLOWED,
+        "Approved engineering assistant (org policy AI-001).",
+    ),
+    (
+        "claude-code",
+        "claude",
+        ToolAllowlistStatus.ALLOWED,
+        "Approved engineering assistant (org policy AI-001).",
+    ),
+    (
+        "cursor",
+        "claude-3.5-sonnet",
+        ToolAllowlistStatus.ALLOWED,
+        "Approved IDE assistant (org policy AI-001).",
+    ),
+    (
+        "claude-code-agent",
+        "claude-sonnet-4",
+        ToolAllowlistStatus.ALLOWED,
+        "Approved autonomous agent with mandatory human review.",
+    ),
+    (
+        "copilot-legacy",
+        None,
+        ToolAllowlistStatus.DEPRECATED,
+        "Superseded; migrate to an approved assistant by Q3.",
+    ),
+    (
+        "shadow-llm",
+        None,
+        ToolAllowlistStatus.DISALLOWED,
+        "Unvetted external service; blocked by security review.",
+    ),
+)
+
+
+def generate_ai_tool_allowlist_entries(
+    org_id: str,
+    *,
+    now: datetime | None = None,
+) -> list[AIToolAllowlistEntry]:
+    """Build the deterministic org-level allowlist seed rows."""
+    stamp = now or datetime.now(timezone.utc)
+    return [
+        AIToolAllowlistEntry(
+            org_id=str(org_id),
+            tool_name=tool_name,
+            model_name=model_name,
+            status=status,
+            reason=reason,
+            updated_at=stamp,
+            computed_at=stamp,
+        )
+        for tool_name, model_name, status, reason in _ALLOWLIST_SEED
+    ]

--- a/src/dev_health_ops/fixtures/generators/ai_governance.py
+++ b/src/dev_health_ops/fixtures/generators/ai_governance.py
@@ -68,7 +68,7 @@ def generate_ai_tool_allowlist_entries(
 ) -> list[AIToolAllowlistEntry]:
     """Build the deterministic org-level allowlist seed rows."""
     stamp = now or datetime.now(timezone.utc)
-    return [
+    entries = [
         AIToolAllowlistEntry(
             org_id=str(org_id),
             tool_name=tool_name,
@@ -80,3 +80,8 @@ def generate_ai_tool_allowlist_entries(
         )
         for tool_name, model_name, status, reason in _ALLOWLIST_SEED
     ]
+    # '' and NULL share the same ReplacingMergeTree key (ORDER BY
+    # ifNull(model_name, '')) — a blank "exact" seed row would replace the
+    # wildcard policy on merge. The dataclass normalises, this asserts.
+    assert all(entry.model_name != "" for entry in entries)
+    return entries

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -441,6 +441,22 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
             sink = ClickHouseMetricsSink(ns.sink)
             sink.ensure_tables()
 
+        # CHAOS-2209: seed the org-level AI tool allowlist so governance
+        # views render real allowlist verdicts (not permanent "unknown").
+        # Org-scoped, so it is written once — not per repo.
+        if sink is not None and hasattr(sink, "write_ai_tool_allowlist"):
+            from dev_health_ops.fixtures.generators.ai_governance import (
+                generate_ai_tool_allowlist_entries,
+            )
+
+            allowlist_entries = generate_ai_tool_allowlist_entries(org_id)
+            sink.write_ai_tool_allowlist(allowlist_entries)
+            logging.info(
+                "Seeded %d ai_tool_allowlist entries for org %s.",
+                len(allowlist_entries),
+                org_id,
+            )
+
         for i in range(repo_count):
             r_name = demo_repo_name(base_name, i, repo_count)
             logging.info(

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -67,6 +67,10 @@ from dev_health_ops.utils.cli import (
     resolve_date_range,
     validate_sink,
 )
+from dev_health_ops.work_graph.extractors.ai_workflow import (
+    extract_ai_workflow_from_pull_requests,
+    extract_review_deployment_incident_edges,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +149,127 @@ def _date_range(end_day: date, backfill_days: int) -> list[date]:
         return [end_day]
     start_day = end_day - timedelta(days=backfill_days - 1)
     return [start_day + timedelta(days=i) for i in range(backfill_days)]
+
+
+def _extract_ai_workflow_for_day(
+    *,
+    primary_sink: Any,
+    org_id: str,
+    start: datetime,
+    end: datetime,
+    repo_id: uuid.UUID | None,
+    repo_provider_by_id: dict[str, str],
+) -> tuple[list[Any], list[Any], list[Any], list[Any]]:
+    """Extract AI workflow runs and Work Graph edges for one UTC day window.
+
+    Returns ``(runs, artifact_edges, issue_edges, review_outcome_edges)``.
+    Returns four empty lists when ``org_id`` is not a UUID — AIWorkflowRun
+    requires a tenant UUID by contract, so extraction without one would
+    fabricate attribution (CHAOS-2187).
+    """
+    org_uuid: uuid.UUID | None = None
+    if org_id:
+        try:
+            org_uuid = uuid.UUID(org_id)
+        except ValueError:
+            org_uuid = None
+    if org_uuid is None:
+        logger.debug("AI workflow extraction skipped: org_id %r is not a UUID", org_id)
+        return [], [], [], []
+
+    wf_params: dict[str, Any] = {"org_id": org_id, "start": start, "end": end}
+    wf_repo_filter = ""
+    if repo_id is not None:
+        wf_params["repo_id"] = str(repo_id)
+        wf_repo_filter = " AND repo_id = {repo_id:UUID}"
+
+    wf_pr_rows = primary_sink.query_dicts(
+        "SELECT repo_id, number, title, body, head_branch,"
+        " author_name, author_email, created_at, merged_at,"
+        " closed_at, last_synced"
+        " FROM git_pull_requests"
+        " WHERE org_id = {org_id:String}"
+        "   AND ((created_at >= {start:DateTime64(3, 'UTC')}"
+        "         AND created_at < {end:DateTime64(3, 'UTC')})"
+        "    OR (merged_at IS NOT NULL"
+        "        AND merged_at >= {start:DateTime64(3, 'UTC')}"
+        "        AND merged_at < {end:DateTime64(3, 'UTC')}))"
+        f"{wf_repo_filter}",
+        wf_params,
+    )
+
+    issue_ids_by_pr: dict[str, list[str]] = {}
+    wf_pr_numbers = sorted(
+        {int(row["number"]) for row in wf_pr_rows if row.get("number") is not None}
+    )
+    if wf_pr_numbers:
+        link_params: dict[str, Any] = {
+            "org_id": org_id,
+            "pr_numbers": wf_pr_numbers,
+        }
+        link_repo_filter = ""
+        if repo_id is not None:
+            link_params["repo_id"] = str(repo_id)
+            link_repo_filter = " AND repo_id = {repo_id:UUID}"
+        link_rows = primary_sink.query_dicts(
+            "SELECT repo_id, pr_number, work_item_id"
+            " FROM work_graph_issue_pr"
+            " WHERE org_id = {org_id:String}"
+            "   AND pr_number IN {pr_numbers:Array(UInt32)}"
+            f"{link_repo_filter}",
+            link_params,
+        )
+        for link in link_rows:
+            wi_id = str(link.get("work_item_id") or "")
+            link_repo = str(link.get("repo_id") or "")
+            link_number = link.get("pr_number")
+            if not wi_id or not link_repo or link_number is None:
+                continue
+            issue_ids_by_pr.setdefault(f"{link_repo}:{int(link_number)}", []).append(
+                wi_id
+            )
+
+    wf_review_rows = primary_sink.query_dicts(
+        "SELECT repo_id, number, review_id, state, submitted_at, last_synced"
+        " FROM git_pull_request_reviews"
+        " WHERE org_id = {org_id:String}"
+        "   AND submitted_at >= {start:DateTime64(3, 'UTC')}"
+        "   AND submitted_at < {end:DateTime64(3, 'UTC')}"
+        f"{wf_repo_filter}",
+        wf_params,
+    )
+
+    prs_by_provider: dict[str, list[dict[str, Any]]] = {}
+    for row in wf_pr_rows:
+        row_provider = repo_provider_by_id.get(str(row.get("repo_id") or ""), "unknown")
+        prs_by_provider.setdefault(row_provider, []).append(row)
+    reviews_by_provider: dict[str, list[dict[str, Any]]] = {}
+    for row in wf_review_rows:
+        row_provider = repo_provider_by_id.get(str(row.get("repo_id") or ""), "unknown")
+        reviews_by_provider.setdefault(row_provider, []).append(row)
+
+    runs: list[Any] = []
+    artifact_edges: list[Any] = []
+    issue_edges: list[Any] = []
+    review_outcome_edges: list[Any] = []
+    for wf_provider, provider_prs in prs_by_provider.items():
+        extraction = extract_ai_workflow_from_pull_requests(
+            provider_prs,
+            org_id=org_uuid,
+            provider=wf_provider,
+            issue_ids_by_pr=issue_ids_by_pr,
+        )
+        runs.extend(extraction.runs)
+        artifact_edges.extend(extraction.artifact_edges)
+        issue_edges.extend(extraction.issue_edges)
+    for wf_provider, provider_reviews in reviews_by_provider.items():
+        review_extraction = extract_review_deployment_incident_edges(
+            org_id=org_uuid,
+            provider=wf_provider,
+            reviews=provider_reviews,
+        )
+        review_outcome_edges.extend(review_extraction.review_outcome_edges)
+    return runs, artifact_edges, issue_edges, review_outcome_edges
 
 
 def _repo_to_team_map_for_compounding_risk(
@@ -267,15 +392,18 @@ async def run_daily_metrics_job(
     team_resolver = get_team_resolver()
     teams_data = await primary_sink.get_all_teams()
     repo_team_resolver = build_repo_pattern_resolver(teams_data)
-    repo_names_by_id = {
-        r.repo_id: r.full_name
-        for r in discover_repos(
-            backend=backend,
-            primary_sink=primary_sink,
-            repo_id=repo_id,
-            repo_name=repo_name,
-            org_id=org_id,
-        )
+    discovered_repos = discover_repos(
+        backend=backend,
+        primary_sink=primary_sink,
+        repo_id=repo_id,
+        repo_name=repo_name,
+        org_id=org_id,
+    )
+    repo_names_by_id = {r.repo_id: r.full_name for r in discovered_repos}
+    # Provider per repo for AI workflow extraction (CHAOS-2187). Falls back to
+    # "unknown" so a missing provider never blocks edge extraction.
+    repo_provider_by_id = {
+        str(r.repo_id): (r.source or "unknown") for r in discovered_repos
     }
 
     loader = await _get_loader(db_url, backend, org_id=org_id)
@@ -500,6 +628,32 @@ async def run_daily_metrics_job(
                 repo_id=repo_id,
             )
 
+        # CHAOS-2187: extract AI workflow runs + Work Graph edges from today's
+        # PRs/reviews so ai_workflow_issue_edges, ai_workflow_artifact_edges,
+        # and work_graph_pr_review_outcome_edges are populated by ingestion.
+        # Extraction is best-effort: any failure degrades to "no edges today"
+        # (mirrors the pr_commit_stats pattern above), never a job abort.
+        try:
+            (
+                ai_workflow_runs,
+                ai_workflow_artifact_edges,
+                ai_workflow_issue_edges,
+                ai_review_outcome_edges,
+            ) = _extract_ai_workflow_for_day(
+                primary_sink=primary_sink,
+                org_id=org_id,
+                start=start,
+                end=end,
+                repo_id=repo_id,
+                repo_provider_by_id=repo_provider_by_id,
+            )
+        except Exception as exc:
+            logger.warning("AI workflow extraction failed for day=%s: %s", d, exc)
+            ai_workflow_runs = []
+            ai_workflow_artifact_edges = []
+            ai_workflow_issue_edges = []
+            ai_review_outcome_edges = []
+
         # Build pr_commit_stats: {(repo_id, pr_number) -> [{"file_path": ...}]} so that
         # compute_ai_impact_metrics_daily can determine which PRs touched test files.
         #
@@ -625,6 +779,18 @@ async def run_daily_metrics_job(
             s.write_ai_governance_coverage_daily(ai_governance_coverage)
             if ai_impact_metrics:
                 s.write_ai_impact_metrics(ai_impact_metrics)
+            if ai_workflow_runs and hasattr(s, "write_ai_workflow_runs"):
+                s.write_ai_workflow_runs(ai_workflow_runs)
+            if ai_workflow_artifact_edges and hasattr(
+                s, "write_ai_workflow_artifact_edges"
+            ):
+                s.write_ai_workflow_artifact_edges(ai_workflow_artifact_edges)
+            if ai_workflow_issue_edges and hasattr(s, "write_ai_workflow_issue_edges"):
+                s.write_ai_workflow_issue_edges(ai_workflow_issue_edges)
+            if ai_review_outcome_edges and hasattr(
+                s, "write_work_graph_pr_review_outcome_edges"
+            ):
+                s.write_work_graph_pr_review_outcome_edges(ai_review_outcome_edges)
             if all_file_metrics:
                 s.write_file_metrics(all_file_metrics)
 

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -198,10 +198,32 @@ def _extract_ai_workflow_for_day(
         wf_params,
     )
 
+    # Row-local hygiene: drop rows whose repo_id/number cannot parse instead
+    # of letting one malformed row abort the whole day (the extractor calls
+    # UUID() on every row). Mirrors the pr_commit_stats per-row handling.
+    def _valid_rows(rows: list[dict[str, Any]], source: str) -> list[dict[str, Any]]:
+        valid: list[dict[str, Any]] = []
+        dropped = 0
+        for row in rows:
+            try:
+                uuid.UUID(str(row.get("repo_id")))
+                int(row.get("number"))  # type: ignore[arg-type]
+            except (ValueError, TypeError, AttributeError):
+                dropped += 1
+                continue
+            valid.append(row)
+        if dropped:
+            logger.warning(
+                "AI workflow extraction dropped %d malformed %s row(s)",
+                dropped,
+                source,
+            )
+        return valid
+
+    wf_pr_rows = _valid_rows(wf_pr_rows, "git_pull_requests")
+
     issue_ids_by_pr: dict[str, list[str]] = {}
-    wf_pr_numbers = sorted(
-        {int(row["number"]) for row in wf_pr_rows if row.get("number") is not None}
-    )
+    wf_pr_numbers = sorted({int(row["number"]) for row in wf_pr_rows})
     if wf_pr_numbers:
         link_params: dict[str, Any] = {
             "org_id": org_id,
@@ -238,6 +260,7 @@ def _extract_ai_workflow_for_day(
         f"{wf_repo_filter}",
         wf_params,
     )
+    wf_review_rows = _valid_rows(wf_review_rows, "git_pull_request_reviews")
 
     prs_by_provider: dict[str, list[dict[str, Any]]] = {}
     for row in wf_pr_rows:
@@ -631,28 +654,25 @@ async def run_daily_metrics_job(
         # CHAOS-2187: extract AI workflow runs + Work Graph edges from today's
         # PRs/reviews so ai_workflow_issue_edges, ai_workflow_artifact_edges,
         # and work_graph_pr_review_outcome_edges are populated by ingestion.
-        # Extraction is best-effort: any failure degrades to "no edges today"
-        # (mirrors the pr_commit_stats pattern above), never a job abort.
-        try:
-            (
-                ai_workflow_runs,
-                ai_workflow_artifact_edges,
-                ai_workflow_issue_edges,
-                ai_review_outcome_edges,
-            ) = _extract_ai_workflow_for_day(
-                primary_sink=primary_sink,
-                org_id=org_id,
-                start=start,
-                end=end,
-                repo_id=repo_id,
-                repo_provider_by_id=repo_provider_by_id,
-            )
-        except Exception as exc:
-            logger.warning("AI workflow extraction failed for day=%s: %s", d, exc)
-            ai_workflow_runs = []
-            ai_workflow_artifact_edges = []
-            ai_workflow_issue_edges = []
-            ai_review_outcome_edges = []
+        # Infrastructure failures (ClickHouse query errors) propagate and fail
+        # the job: there is no persisted job-health table to record a partial
+        # day, and empty edge tables are indistinguishable from "no AI
+        # activity today" — swallowing here would be silent partial data.
+        # Row-local issues (malformed repo ids) are skipped inside the helper,
+        # mirroring the per-row handling in the pr_commit_stats build below.
+        (
+            ai_workflow_runs,
+            ai_workflow_artifact_edges,
+            ai_workflow_issue_edges,
+            ai_review_outcome_edges,
+        ) = _extract_ai_workflow_for_day(
+            primary_sink=primary_sink,
+            org_id=org_id,
+            start=start,
+            end=end,
+            repo_id=repo_id,
+            repo_provider_by_id=repo_provider_by_id,
+        )
 
         # Build pr_commit_stats: {(repo_id, pr_number) -> [{"file_path": ...}]} so that
         # compute_ai_impact_metrics_daily can determine which PRs touched test files.

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -180,14 +180,17 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
                         "merged_at": r.get("merged_at"),
                         "first_review_at": r.get("first_review_at"),
                         "first_comment_at": r.get("first_comment_at"),
+                        # `or 0` (not a .get default): these columns are
+                        # Nullable, so the key is present with value None and
+                        # a plain default would never apply — int(None) crash.
                         "changes_requested_count": int(
-                            r.get("changes_requested_count", 0)
+                            r.get("changes_requested_count") or 0
                         ),
-                        "reviews_count": int(r.get("reviews_count", 0)),
-                        "comments_count": int(r.get("comments_count", 0)),
-                        "additions": int(r.get("additions", 0)),
-                        "deletions": int(r.get("deletions", 0)),
-                        "changed_files": int(r.get("changed_files", 0)),
+                        "reviews_count": int(r.get("reviews_count") or 0),
+                        "comments_count": int(r.get("comments_count") or 0),
+                        "additions": int(r.get("additions") or 0),
+                        "deletions": int(r.get("deletions") or 0),
+                        "changed_files": int(r.get("changed_files") or 0),
                     }
                 )
 

--- a/src/dev_health_ops/metrics/opportunities/ai_detector.py
+++ b/src/dev_health_ops/metrics/opportunities/ai_detector.py
@@ -440,6 +440,16 @@ class AIOpportunityDetector:
             org_expr = org_scope.expression(alias="pr")
             if org_expr:
                 filters.append(org_expr)
+            # Tenant key belongs in the JOIN predicate: an anti-join with an
+            # org filter only on the WHERE (pr) side would let org B's
+            # attribution rows suppress org A's PRs that share a repo_id and
+            # PR number. ai_attribution_resolved.org_id is UUID, hence
+            # toString (same precedent as the governance allowlist join).
+            attr_org_predicate = (
+                "\n                AND toString(attr.org_id) = {org_id:String}"
+                if org_scope
+                else ""
+            )
             where_clause = " AND ".join(filters)
             query = f"""
             SELECT
@@ -451,7 +461,7 @@ class AIOpportunityDetector:
                 ON attr.repo_id = pr.repo_id
                 AND attr.subject_type = 'pull_request'
                 AND attr.subject_id = toString(pr.number)
-                AND attr.kind IN ('ai_assisted', 'agent_created')
+                AND attr.kind IN ('ai_assisted', 'agent_created'){attr_org_predicate}
             WHERE {where_clause}
             GROUP BY repo_id
             HAVING prs_total >= {{min_prs:UInt32}}
@@ -514,7 +524,9 @@ class AIOpportunityDetector:
             countIf({_DOC_FILE_EXPR}) AS doc_changes
         FROM git_commits AS c
         INNER JOIN git_commit_stats AS s
-            ON s.repo_id = c.repo_id AND s.commit_hash = c.hash
+            ON s.repo_id = c.repo_id
+            AND s.commit_hash = c.hash
+            AND s.org_id = c.org_id
         WHERE {where_clause}
         GROUP BY repo_id
         HAVING code_commits >= {{min_commits:UInt32}} AND doc_changes = 0
@@ -574,15 +586,19 @@ class AIOpportunityDetector:
         if org_expr:
             filters.append(org_expr)
         where_clause = " AND ".join(filters)
+        # NB: the output alias must NOT shadow the source column name —
+        # ClickHouse substitutes aliases everywhere, so `AS total_cases`
+        # would turn sum(flake_rate * total_cases) into nested aggregation
+        # (ILLEGAL_AGGREGATION).
         query = f"""
         SELECT
             toString(repo_id) AS repo_id,
-            sum(total_cases) AS total_cases,
+            sum(total_cases) AS cases_total,
             sum(flake_rate * total_cases) / sum(total_cases) AS weighted_flake_rate
         FROM testops_test_metrics_daily
         WHERE {where_clause}
         GROUP BY repo_id
-        HAVING total_cases >= {{min_cases:UInt64}}
+        HAVING cases_total >= {{min_cases:UInt64}}
            AND weighted_flake_rate >= {{flake_threshold:Float64}}
         ORDER BY weighted_flake_rate DESC
         LIMIT 100
@@ -595,7 +611,7 @@ class AIOpportunityDetector:
                 continue
             repo_id = str(repo)
             flake_rate = float(row.get("weighted_flake_rate") or 0.0)
-            total_cases = int(row.get("total_cases") or 0)
+            total_cases = int(row.get("cases_total") or 0)
             opportunities.append(
                 _opportunity(
                     kind=AIOpportunityKind.FLAKY_TEST_TRIAGE,

--- a/src/dev_health_ops/metrics/opportunities/ai_detector.py
+++ b/src/dev_health_ops/metrics/opportunities/ai_detector.py
@@ -23,6 +23,19 @@ _MIN_PRS = 10
 _REPETITIVE_CLUSTER_MIN_PRS = 5
 _MAX_LIMIT = 100
 
+# CHAOS-2189 thresholds for the documented workflow-type rules.
+_TEST_GEN_GAP_THRESHOLD = 0.50
+_DEP_UPDATE_MIN_PRS = 5
+_MIGRATION_MIN_PRS = 5
+_DOC_DRIFT_MIN_CODE_COMMITS = 20
+_FLAKY_MIN_CASES = 50
+_FLAKY_RATE_THRESHOLD = 0.05
+
+_DOC_FILE_EXPR = (
+    "(file_path LIKE '%.md' OR file_path LIKE '%.rst' OR file_path LIKE '%.adoc'"
+    " OR file_path LIKE 'docs/%' OR file_path LIKE '%/docs/%')"
+)
+
 
 @dataclass(frozen=True)
 class _Scope:
@@ -102,6 +115,15 @@ class AIOpportunityDetector:
         opportunities.extend(
             await self._detect_repetitive_changes(org_id, normalized_scope)
         )
+        # CHAOS-2189: documented workflow-type rules (manual toil + quality
+        # signals where AI/agents should be applied next).
+        opportunities.extend(
+            await self._detect_title_pattern_toil(org_id, normalized_scope)
+        )
+        opportunities.extend(await self._detect_doc_drift(org_id, normalized_scope))
+        opportunities.extend(
+            await self._detect_flaky_test_triage(org_id, normalized_scope)
+        )
         opportunities.sort(key=lambda item: item.score, reverse=True)
         return opportunities[:bounded_limit]
 
@@ -177,6 +199,34 @@ class AIOpportunityDetector:
 
     def _metric_rules_for_repo(self, agg: _RepoAgg) -> list[AIOpportunity]:
         opportunities: list[AIOpportunity] = []
+
+        # TEST_GENERATION (CHAOS-2189) gates on the HUMAN bucket: a high
+        # human test-gap rate is the signal that AI test generation is the
+        # next workflow to apply, independent of current AI adoption.
+        human_test_gap = agg.human.test_gap_rate
+        if (
+            agg.human.prs_total >= _MIN_PRS
+            and human_test_gap is not None
+            and human_test_gap >= _TEST_GEN_GAP_THRESHOLD
+        ):
+            opportunities.append(
+                _opportunity(
+                    kind=AIOpportunityKind.TEST_GENERATION,
+                    repo_id=agg.repo_id,
+                    team_id=agg.team_id,
+                    title=f"Test generation candidate in {agg.repo_id}",
+                    rationale=(
+                        "Human-authored PRs had a "
+                        f"{human_test_gap:.0%} test gap rate across "
+                        f"{agg.human.prs_total} PRs over the last 30 days."
+                    ),
+                    score=_score_delta(human_test_gap, _TEST_GEN_GAP_THRESHOLD),
+                    evidence_refs=[
+                        f"ai_impact_metrics_daily:test_gap_rate:{agg.repo_id}"
+                    ],
+                )
+            )
+
         if agg.ai.prs_total < _MIN_PRS:
             return opportunities
 
@@ -355,6 +405,248 @@ class AIOpportunityDetector:
                 )
             )
         return opportunities
+
+    async def _detect_title_pattern_toil(
+        self, org_id: str, scope: _Scope
+    ) -> list[AIOpportunity]:
+        """DEPENDENCY_UPDATES + MECHANICAL_MIGRATIONS (CHAOS-2189).
+
+        Both rules look for clusters of human-authored PRs whose titles match
+        a documented manual-toil pattern. Bot authors are excluded because
+        their work is already automated; AI-attributed PRs are excluded via
+        anti-join for the same reason.
+        """
+        from dev_health_ops.api.queries.client import query_dicts
+
+        if scope.team_id is not None:
+            # git_pull_requests carries no team scoping here; mirror the
+            # repetitive-change rule and stay silent rather than guess.
+            return []
+
+        opportunities: list[AIOpportunity] = []
+        for rule in _TITLE_PATTERN_RULES:
+            params: dict[str, Any] = {"min_prs": rule["min_prs"]}
+            filters = [
+                "pr.created_at >= now() - INTERVAL 30 DAY",
+                str(rule["title_expr"]),
+                "lower(coalesce(pr.author_name, '')) NOT LIKE '%bot%'",
+                "lower(coalesce(pr.author_name, '')) NOT LIKE '%renovate%'",
+            ]
+            if scope.repo_id is not None:
+                params["repo_id"] = str(scope.repo_id)
+                filters.append("pr.repo_id = {repo_id:UUID}")
+            org_scope = OrgScopedQuery(org_id)
+            params = org_scope.inject(params)
+            org_expr = org_scope.expression(alias="pr")
+            if org_expr:
+                filters.append(org_expr)
+            where_clause = " AND ".join(filters)
+            query = f"""
+            SELECT
+                toString(pr.repo_id) AS repo_id,
+                count() AS prs_total,
+                groupArray(concat('git_pull_requests:', toString(pr.repo_id), ':', toString(pr.number))) AS pr_refs
+            FROM git_pull_requests AS pr
+            LEFT ANTI JOIN ai_attribution_resolved AS attr
+                ON attr.repo_id = pr.repo_id
+                AND attr.subject_type = 'pull_request'
+                AND attr.subject_id = toString(pr.number)
+                AND attr.kind IN ('ai_assisted', 'agent_created')
+            WHERE {where_clause}
+            GROUP BY repo_id
+            HAVING prs_total >= {{min_prs:UInt32}}
+            ORDER BY prs_total DESC
+            LIMIT 100
+            """
+            rows = await query_dicts(self.client, query, params)
+            for row in rows:
+                repo = parse_uuid(row.get("repo_id"))
+                if repo is None:
+                    continue
+                repo_id = str(repo)
+                prs_total = int(row.get("prs_total") or 0)
+                evidence_refs = [str(ref) for ref in (row.get("pr_refs") or [])][:5]
+                if not evidence_refs:
+                    continue
+                evidence_refs.append(f"{rule['metric_ref']}:{repo_id}")
+                opportunities.append(
+                    _opportunity(
+                        kind=rule["kind"],
+                        repo_id=repo_id,
+                        team_id=None,
+                        title=str(rule["title"]).format(repo_id=repo_id),
+                        rationale=str(rule["rationale"]).format(prs_total=prs_total),
+                        score=_score_delta(prs_total / float(rule["min_prs"]), 1.0),
+                        evidence_refs=evidence_refs,
+                    )
+                )
+        return opportunities
+
+    async def _detect_doc_drift(
+        self, org_id: str, scope: _Scope
+    ) -> list[AIOpportunity]:
+        """DOCUMENTATION_DRIFT (CHAOS-2189).
+
+        Flags repos with sustained code churn and zero documentation-file
+        changes in the same 30-day window — docs are drifting relative to the
+        code they describe.
+        """
+        from dev_health_ops.api.queries.client import query_dicts
+
+        if scope.team_id is not None:
+            return []
+
+        params: dict[str, Any] = {"min_commits": _DOC_DRIFT_MIN_CODE_COMMITS}
+        filters = ["c.committer_when >= now() - INTERVAL 30 DAY"]
+        if scope.repo_id is not None:
+            params["repo_id"] = str(scope.repo_id)
+            filters.append("c.repo_id = {repo_id:UUID}")
+        org_scope = OrgScopedQuery(org_id)
+        params = org_scope.inject(params)
+        org_expr = org_scope.expression(alias="c")
+        if org_expr:
+            filters.append(org_expr)
+        where_clause = " AND ".join(filters)
+        query = f"""
+        SELECT
+            toString(c.repo_id) AS repo_id,
+            uniqExactIf(c.hash, NOT {_DOC_FILE_EXPR}) AS code_commits,
+            countIf({_DOC_FILE_EXPR}) AS doc_changes
+        FROM git_commits AS c
+        INNER JOIN git_commit_stats AS s
+            ON s.repo_id = c.repo_id AND s.commit_hash = c.hash
+        WHERE {where_clause}
+        GROUP BY repo_id
+        HAVING code_commits >= {{min_commits:UInt32}} AND doc_changes = 0
+        ORDER BY code_commits DESC
+        LIMIT 100
+        """
+        rows = await query_dicts(self.client, query, params)
+        opportunities: list[AIOpportunity] = []
+        for row in rows:
+            repo = parse_uuid(row.get("repo_id"))
+            if repo is None:
+                continue
+            repo_id = str(repo)
+            code_commits = int(row.get("code_commits") or 0)
+            opportunities.append(
+                _opportunity(
+                    kind=AIOpportunityKind.DOCUMENTATION_DRIFT,
+                    repo_id=repo_id,
+                    team_id=None,
+                    title=f"Documentation drift in {repo_id}",
+                    rationale=(
+                        f"{code_commits} code commits landed in the last 30 "
+                        "days with zero documentation-file changes."
+                    ),
+                    score=_score_delta(
+                        code_commits / float(_DOC_DRIFT_MIN_CODE_COMMITS), 1.0
+                    ),
+                    evidence_refs=[f"git_commit_stats:doc_changes:{repo_id}"],
+                )
+            )
+        return opportunities
+
+    async def _detect_flaky_test_triage(
+        self, org_id: str, scope: _Scope
+    ) -> list[AIOpportunity]:
+        """FLAKY_TEST_TRIAGE (CHAOS-2189).
+
+        Reads the persisted TestOps daily rollups: a sustained case-weighted
+        flake rate marks the repo as a flaky-triage automation candidate.
+        """
+        from dev_health_ops.api.queries.client import query_dicts
+
+        if scope.team_id is not None:
+            return []
+
+        params: dict[str, Any] = {
+            "min_cases": _FLAKY_MIN_CASES,
+            "flake_threshold": _FLAKY_RATE_THRESHOLD,
+        }
+        filters = ["day >= today() - 30"]
+        if scope.repo_id is not None:
+            params["repo_id"] = str(scope.repo_id)
+            filters.append("repo_id = {repo_id:UUID}")
+        org_scope = OrgScopedQuery(org_id)
+        params = org_scope.inject(params)
+        org_expr = org_scope.expression()
+        if org_expr:
+            filters.append(org_expr)
+        where_clause = " AND ".join(filters)
+        query = f"""
+        SELECT
+            toString(repo_id) AS repo_id,
+            sum(total_cases) AS total_cases,
+            sum(flake_rate * total_cases) / sum(total_cases) AS weighted_flake_rate
+        FROM testops_test_metrics_daily
+        WHERE {where_clause}
+        GROUP BY repo_id
+        HAVING total_cases >= {{min_cases:UInt64}}
+           AND weighted_flake_rate >= {{flake_threshold:Float64}}
+        ORDER BY weighted_flake_rate DESC
+        LIMIT 100
+        """
+        rows = await query_dicts(self.client, query, params)
+        opportunities: list[AIOpportunity] = []
+        for row in rows:
+            repo = parse_uuid(row.get("repo_id"))
+            if repo is None:
+                continue
+            repo_id = str(repo)
+            flake_rate = float(row.get("weighted_flake_rate") or 0.0)
+            total_cases = int(row.get("total_cases") or 0)
+            opportunities.append(
+                _opportunity(
+                    kind=AIOpportunityKind.FLAKY_TEST_TRIAGE,
+                    repo_id=repo_id,
+                    team_id=None,
+                    title=f"Flaky test triage candidate in {repo_id}",
+                    rationale=(
+                        f"Test cases flaked at {flake_rate:.1%} across "
+                        f"{total_cases} executions over the last 30 days."
+                    ),
+                    score=_score_delta(flake_rate, _FLAKY_RATE_THRESHOLD),
+                    evidence_refs=[f"testops_test_metrics_daily:flake_rate:{repo_id}"],
+                )
+            )
+        return opportunities
+
+
+_TITLE_PATTERN_RULES: tuple[dict[str, Any], ...] = (
+    {
+        "kind": AIOpportunityKind.DEPENDENCY_UPDATES,
+        "min_prs": _DEP_UPDATE_MIN_PRS,
+        "title_expr": (
+            "match(lower(coalesce(pr.title, '')),"
+            " '^(bump|update|upgrade|chore\\\\(deps\\\\)|build\\\\(deps\\\\))')"
+            " AND match(lower(coalesce(pr.title, '')),"
+            " '(depend|deps|version|package|requirement|lockfile| from .* to )')"
+        ),
+        "title": "Manual dependency updates in {repo_id}",
+        "rationale": (
+            "{prs_total} dependency-update PRs were authored by humans in the "
+            "last 30 days; dependency bumps are a documented AI automation "
+            "target."
+        ),
+        "metric_ref": "git_pull_requests:dependency_update_prs",
+    },
+    {
+        "kind": AIOpportunityKind.MECHANICAL_MIGRATIONS,
+        "min_prs": _MIGRATION_MIN_PRS,
+        "title_expr": (
+            "match(lower(coalesce(pr.title, '')),"
+            " '(migrat|mass rename|codemod|deprecat.* api|bulk (rename|move))')"
+        ),
+        "title": "Mechanical migration toil in {repo_id}",
+        "rationale": (
+            "{prs_total} migration-style PRs were authored by humans in the "
+            "last 30 days; mechanical migrations are a documented AI "
+            "automation target."
+        ),
+        "metric_ref": "git_pull_requests:migration_prs",
+    },
+)
 
 
 def _scope_from_input(scope: Any | None) -> _Scope:

--- a/src/dev_health_ops/metrics/sinks/clickhouse/ai_governance.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/ai_governance.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from dev_health_ops.audit.ai_governance.models import (
     AIGovernanceCoverageDaily,
     AIGovernanceViolation,
+    AIToolAllowlistEntry,
 )
 from dev_health_ops.metrics.sinks.clickhouse._insert import (
     DEFAULT_BATCH_SIZE,
@@ -34,6 +35,16 @@ POLICY_EVENT_COLUMNS = [
     "subject_id",
     "observed_at",
     "evidence",
+    "computed_at",
+]
+
+ALLOWLIST_COLUMNS = [
+    "org_id",
+    "tool_name",
+    "model_name",
+    "status",
+    "reason",
+    "updated_at",
     "computed_at",
 ]
 
@@ -64,6 +75,18 @@ def _policy_event_row(event: AIGovernanceViolation) -> list[object]:
         _dt_to_clickhouse_datetime(event.observed_at),
         event.evidence_json(),
         _dt_to_clickhouse_datetime(event.computed_at),
+    ]
+
+
+def _allowlist_row(entry: AIToolAllowlistEntry) -> list[object]:
+    return [
+        entry.org_id,
+        entry.tool_name,
+        entry.model_name,
+        str(entry.status),
+        entry.reason,
+        _dt_to_clickhouse_datetime(entry.updated_at),
+        _dt_to_clickhouse_datetime(entry.computed_at),
     ]
 
 
@@ -111,4 +134,19 @@ class AIGovernanceMixin(_ClickHouseSinkBase):
                 "ai_governance_coverage_daily",
                 [_coverage_row(row) for row in chunk],
                 column_names=COVERAGE_COLUMNS,
+            )
+
+    def write_ai_tool_allowlist(
+        self,
+        entries: Sequence[AIToolAllowlistEntry],
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        """Persist allowlist policy entries (CHAOS-2209 admin-seeded path)."""
+        if not entries:
+            return
+        for chunk in _chunked(list(entries), batch_size):
+            self.client.insert(
+                "ai_tool_allowlist",
+                [_allowlist_row(entry) for entry in chunk],
+                column_names=ALLOWLIST_COLUMNS,
             )

--- a/src/dev_health_ops/work_graph/ai_workflow.py
+++ b/src/dev_health_ops/work_graph/ai_workflow.py
@@ -250,10 +250,15 @@ _AI_RUN_QUERY = """
         toString(repo_id) AS repo_id,
         prompts_redacted,
         metadata
-    FROM ai_workflow_runs
+    FROM ai_workflow_runs FINAL
     WHERE org_id = {org_id:String} AND run_id IN {run_ids:Array(String)}
 """
 
+# Every branch reads its ReplacingMergeTree with FINAL (the repo precedent —
+# see the governance loaders): daily-job reruns insert new computed_at
+# versions of the same deterministic edge ids, and without FINAL those
+# duplicates are query-visible until background merges run. Duplicates would
+# also burn the traversal LIMIT and falsely mark results partial (CHAOS-2187).
 _AI_EDGE_UNION_QUERY = """
     SELECT * FROM
     (
@@ -269,7 +274,7 @@ _AI_EDGE_UNION_QUERY = """
             evidence,
             provider,
             toString(repo_id) AS repo_id
-        FROM ai_workflow_issue_edges
+        FROM ai_workflow_issue_edges FINAL
         WHERE org_id = {org_id:String}
 
         UNION ALL
@@ -286,7 +291,7 @@ _AI_EDGE_UNION_QUERY = """
             evidence,
             provider,
             toString(repo_id) AS repo_id
-        FROM ai_workflow_artifact_edges
+        FROM ai_workflow_artifact_edges FINAL
         WHERE org_id = {org_id:String}
 
         UNION ALL
@@ -303,7 +308,7 @@ _AI_EDGE_UNION_QUERY = """
             evidence,
             provider,
             toString(repo_id) AS repo_id
-        FROM work_graph_pr_review_outcome_edges
+        FROM work_graph_pr_review_outcome_edges FINAL
         WHERE org_id = {org_id:String}
 
         UNION ALL
@@ -320,7 +325,7 @@ _AI_EDGE_UNION_QUERY = """
             evidence,
             provider,
             toString(repo_id) AS repo_id
-        FROM work_graph_pr_deployment_edges
+        FROM work_graph_pr_deployment_edges FINAL
         WHERE org_id = {org_id:String}
 
         UNION ALL
@@ -337,7 +342,7 @@ _AI_EDGE_UNION_QUERY = """
             evidence,
             provider,
             toString(repo_id) AS repo_id
-        FROM work_graph_deployment_incident_edges
+        FROM work_graph_deployment_incident_edges FINAL
         WHERE org_id = {org_id:String}
     )
     WHERE

--- a/src/dev_health_ops/work_graph/ai_workflow.py
+++ b/src/dev_health_ops/work_graph/ai_workflow.py
@@ -137,6 +137,14 @@ async def load_ai_workflow_graph(
 
         node_types = [node_type for node_type, _ in current]
         node_ids = [node_id for _, node_id in current]
+
+        # Role-typed frontier ids: each UNION branch filters on its own key
+        # columns with ONLY the ids that can play that role this hop. Empty
+        # arrays collapse a branch's predicate to constant-false, so branches
+        # with no relevant frontier nodes are pruned before their FINAL pass.
+        def ids_of(*types: str) -> list[str]:
+            return [i for t, i in current if t in types]
+
         rows = await query_dicts(
             client,
             _AI_EDGE_UNION_QUERY,
@@ -144,6 +152,18 @@ async def load_ai_workflow_graph(
                 "org_id": org_id,
                 "node_types": node_types,
                 "node_ids": node_ids,
+                "issue_ids": ids_of("issue"),
+                "run_ids": ids_of("ai_workflow_run"),
+                "pr_ids": ids_of("pr"),
+                "review_outcome_ids": ids_of("review_outcome"),
+                "deployment_ids": ids_of("deployment"),
+                "incident_ids": ids_of("incident"),
+                # Artifact targets carry their own type taxonomy (pr, diff,
+                # ...): superset of every frontier id that is not an
+                # issue/run, so unknown artifact types keep matching.
+                "artifact_ids": [
+                    i for t, i in current if t not in ("issue", "ai_workflow_run")
+                ],
                 "limit": max(limit - len(edges_by_id), 0),
             },
         )
@@ -259,6 +279,19 @@ _AI_RUN_QUERY = """
 # versions of the same deterministic edge ids, and without FINAL those
 # duplicates are query-visible until background merges run. Duplicates would
 # also burn the traversal LIMIT and falsely mark results partial (CHAOS-2187).
+#
+# Each branch ALSO repeats the frontier-id predicate on its own raw key
+# columns (issue_id/run_id/pr_id/... are all in that table's ORDER BY): the
+# key condition then prunes parts/granules BEFORE the FINAL merge, instead
+# of FINAL-merging the org's full history and filtering outside the union.
+# Predicates are role-typed (issue_ids/run_ids/pr_ids/...): an OR across two
+# key columns defeats range pruning, but a role array that is EMPTY for this
+# hop collapses its disjunct to constant-false, so inactive branches prune to
+# zero parts and the active disjunct usually prunes via the (org_id, <id>)
+# key prefix. The arrays are role supersets (artifact_ids = every frontier id
+# that is not an issue/run); the outer WHERE still enforces the exact
+# (type, id) match, so traversal semantics are unchanged and no history
+# window is introduced.
 _AI_EDGE_UNION_QUERY = """
     SELECT * FROM
     (
@@ -276,6 +309,7 @@ _AI_EDGE_UNION_QUERY = """
             toString(repo_id) AS repo_id
         FROM ai_workflow_issue_edges FINAL
         WHERE org_id = {org_id:String}
+          AND (issue_id IN {issue_ids:Array(String)} OR run_id IN {run_ids:Array(String)})
 
         UNION ALL
 
@@ -293,6 +327,7 @@ _AI_EDGE_UNION_QUERY = """
             toString(repo_id) AS repo_id
         FROM ai_workflow_artifact_edges FINAL
         WHERE org_id = {org_id:String}
+          AND (run_id IN {run_ids:Array(String)} OR artifact_id IN {artifact_ids:Array(String)})
 
         UNION ALL
 
@@ -310,6 +345,7 @@ _AI_EDGE_UNION_QUERY = """
             toString(repo_id) AS repo_id
         FROM work_graph_pr_review_outcome_edges FINAL
         WHERE org_id = {org_id:String}
+          AND (pr_id IN {pr_ids:Array(String)} OR review_outcome_id IN {review_outcome_ids:Array(String)})
 
         UNION ALL
 
@@ -327,6 +363,7 @@ _AI_EDGE_UNION_QUERY = """
             toString(repo_id) AS repo_id
         FROM work_graph_pr_deployment_edges FINAL
         WHERE org_id = {org_id:String}
+          AND (pr_id IN {pr_ids:Array(String)} OR deployment_id IN {deployment_ids:Array(String)})
 
         UNION ALL
 
@@ -344,6 +381,7 @@ _AI_EDGE_UNION_QUERY = """
             toString(repo_id) AS repo_id
         FROM work_graph_deployment_incident_edges FINAL
         WHERE org_id = {org_id:String}
+          AND (deployment_id IN {deployment_ids:Array(String)} OR incident_id IN {incident_ids:Array(String)})
     )
     WHERE
         (source_type IN {node_types:Array(String)} AND source_id IN {node_ids:Array(String)})

--- a/tests/audit/ai_governance/test_allowlist.py
+++ b/tests/audit/ai_governance/test_allowlist.py
@@ -1,0 +1,140 @@
+"""CHAOS-2209: ai_tool_allowlist write path (admin-seeded source of truth)."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+from unittest.mock import MagicMock
+
+from dev_health_ops.audit.ai_governance import cli as allowlist_cli
+from dev_health_ops.audit.ai_governance.models import (
+    AIToolAllowlistEntry,
+    ToolAllowlistStatus,
+)
+from dev_health_ops.fixtures.generators.ai_governance import (
+    generate_ai_tool_allowlist_entries,
+)
+from dev_health_ops.metrics.sinks.clickhouse.ai_governance import (
+    ALLOWLIST_COLUMNS,
+    _allowlist_row,
+)
+
+ORG_ID = "33333333-3333-3333-3333-333333333333"
+
+
+def test_fixture_seed_matches_attribution_evidence_tooling() -> None:
+    entries = generate_ai_tool_allowlist_entries(ORG_ID)
+
+    assert entries
+    assert all(entry.org_id == ORG_ID for entry in entries)
+    # The PR fixture generator writes tool_name="claude-code" /
+    # model_name="claude" into attribution evidence; the seed must cover that
+    # pair or the governance join stays "unknown" forever.
+    pairs = {(entry.tool_name, entry.model_name) for entry in entries}
+    assert ("claude-code", None) in pairs
+    assert ("claude-code", "claude") in pairs
+    statuses = {entry.status for entry in entries}
+    assert ToolAllowlistStatus.ALLOWED in statuses
+    assert ToolAllowlistStatus.DISALLOWED in statuses
+    assert ToolAllowlistStatus.DEPRECATED in statuses
+    # Seeding must never write the sentinel "unknown" status.
+    assert ToolAllowlistStatus.UNKNOWN not in statuses
+
+
+def test_allowlist_row_matches_column_order() -> None:
+    entry = AIToolAllowlistEntry(
+        org_id=ORG_ID,
+        tool_name="claude-code",
+        model_name=None,
+        status=ToolAllowlistStatus.ALLOWED,
+        reason="policy",
+    )
+
+    row = _allowlist_row(entry)
+
+    assert len(row) == len(ALLOWLIST_COLUMNS)
+    assert row[ALLOWLIST_COLUMNS.index("org_id")] == ORG_ID
+    assert row[ALLOWLIST_COLUMNS.index("tool_name")] == "claude-code"
+    assert row[ALLOWLIST_COLUMNS.index("model_name")] is None
+    assert row[ALLOWLIST_COLUMNS.index("status")] == "allowed"
+    assert row[ALLOWLIST_COLUMNS.index("reason")] == "policy"
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    allowlist_cli.register_commands(sub)
+    ns = parser.parse_args(argv)
+    ns.org = ORG_ID
+    ns.analytics_db = "clickhouse://test"
+    return ns
+
+
+def test_cli_set_writes_through_sink(monkeypatch: Any) -> None:
+    sink = MagicMock()
+    monkeypatch.setattr(allowlist_cli, "_sink", lambda _ns: sink)
+
+    ns = _parse(
+        [
+            "ai",
+            "allowlist",
+            "set",
+            "--tool",
+            "cursor",
+            "--model",
+            "claude-3.5-sonnet",
+            "--status",
+            "deprecated",
+            "--reason",
+            "superseded",
+        ]
+    )
+    exit_code = ns.func(ns)
+
+    assert exit_code == 0
+    (entries,) = sink.write_ai_tool_allowlist.call_args.args
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.org_id == ORG_ID
+    assert entry.tool_name == "cursor"
+    assert entry.model_name == "claude-3.5-sonnet"
+    assert entry.status is ToolAllowlistStatus.DEPRECATED
+    assert entry.reason == "superseded"
+
+
+def test_cli_set_rejects_unknown_status() -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    allowlist_cli.register_commands(sub)
+
+    try:
+        parser.parse_args(
+            ["ai", "allowlist", "set", "--tool", "x", "--status", "unknown"]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:  # pragma: no cover - argparse must reject the sentinel status
+        raise AssertionError("argparse accepted status=unknown")
+
+
+def test_cli_list_reads_latest_versions(monkeypatch: Any, capsys: Any) -> None:
+    sink = MagicMock()
+    sink.query_dicts.return_value = [
+        {
+            "tool_name": "claude-code",
+            "model_name": None,
+            "status": "allowed",
+            "reason": "policy",
+            "updated_at": None,
+        }
+    ]
+    monkeypatch.setattr(allowlist_cli, "_sink", lambda _ns: sink)
+
+    ns = _parse(["ai", "allowlist", "list"])
+    exit_code = ns.func(ns)
+
+    assert exit_code == 0
+    query = sink.query_dicts.call_args.args[0]
+    assert "argMax(status, computed_at)" in query
+    out = capsys.readouterr().out
+    assert "claude-code / *: allowed" in out

--- a/tests/audit/ai_governance/test_allowlist.py
+++ b/tests/audit/ai_governance/test_allowlist.py
@@ -138,3 +138,63 @@ def test_cli_list_reads_latest_versions(monkeypatch: Any, capsys: Any) -> None:
     assert "argMax(status, computed_at)" in query
     out = capsys.readouterr().out
     assert "claude-code / *: allowed" in out
+
+
+def test_entry_normalizes_blank_model_and_rejects_blank_tool() -> None:
+    """'' and NULL share the same RMT dedup key (ORDER BY ifNull(model_name,
+    '')), so blank models must become wildcard (None) at construction."""
+    entry = AIToolAllowlistEntry(
+        org_id=ORG_ID,
+        tool_name="  cursor  ",
+        model_name="   ",
+        status=ToolAllowlistStatus.ALLOWED,
+    )
+    assert entry.tool_name == "cursor"
+    assert entry.model_name is None
+
+    import pytest
+
+    with pytest.raises(ValueError, match="tool_name"):
+        AIToolAllowlistEntry(
+            org_id=ORG_ID, tool_name="   ", status=ToolAllowlistStatus.ALLOWED
+        )
+
+
+def test_cli_set_blank_model_writes_wildcard(monkeypatch: Any) -> None:
+    sink = MagicMock()
+    monkeypatch.setattr(allowlist_cli, "_sink", lambda _ns: sink)
+
+    ns = _parse(
+        [
+            "ai",
+            "allowlist",
+            "set",
+            "--tool",
+            "cursor",
+            "--model",
+            "",
+            "--status",
+            "allowed",
+        ]
+    )
+    assert ns.func(ns) == 0
+    (entries,) = sink.write_ai_tool_allowlist.call_args.args
+    assert entries[0].model_name is None  # wildcard, not a '' exact policy
+
+
+def test_cli_set_blank_tool_rejected(monkeypatch: Any) -> None:
+    sink = MagicMock()
+    monkeypatch.setattr(allowlist_cli, "_sink", lambda _ns: sink)
+
+    ns = _parse(["ai", "allowlist", "set", "--tool", "  ", "--status", "allowed"])
+    import pytest
+
+    with pytest.raises(SystemExit, match="Invalid allowlist entry"):
+        ns.func(ns)
+    sink.write_ai_tool_allowlist.assert_not_called()
+
+
+def test_fixture_seed_has_no_blank_models() -> None:
+    entries = generate_ai_tool_allowlist_entries(ORG_ID)
+    assert all(entry.model_name != "" for entry in entries)
+    assert all(entry.tool_name for entry in entries)

--- a/tests/metrics/test_ai_opportunity_detector.py
+++ b/tests/metrics/test_ai_opportunity_detector.py
@@ -110,7 +110,9 @@ async def test_detector_honors_scope_and_limit(monkeypatch: pytest.MonkeyPatch):
 @pytest.mark.asyncio
 async def test_detector_emits_repetitive_change(monkeypatch: pytest.MonkeyPatch):
     async def fake_query_dicts(_client, query, _params):
-        if "ai_impact_metrics_daily" in query:
+        # Route by query shape: only the repetitive-change query selects a
+        # title_prefix column (CHAOS-2189 added more git_pull_requests rules).
+        if "title_prefix" not in query:
             return []
         return [
             {
@@ -192,3 +194,170 @@ async def test_detector_empty_data_returns_empty_list(monkeypatch: pytest.Monkey
     result = await AIOpportunityDetector(MagicMock()).detect("org-a", limit=10)
 
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_detector_emits_test_generation_from_human_gap(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """TEST_GENERATION (CHAOS-2189) gates on the human bucket, not AI volume."""
+
+    async def fake_query_dicts(_client, query, _params):
+        if "ai_impact_metrics_daily" not in query:
+            return []
+        return [
+            {
+                "repo_id": REPO_ID,
+                "team_id": "team-a",
+                "attribution_bucket": "human",
+                "prs_total": 20,
+                "reviews_per_pr": 2.0,
+                "cycle_time_avg_hours": 20.0,
+                "rework_prs": 2,
+                "test_gap_prs": 12,
+            },
+            {
+                # AI bucket below the 10-PR minimum: AI rules must stay silent.
+                "repo_id": REPO_ID,
+                "team_id": "team-a",
+                "attribution_bucket": "ai_assisted",
+                "prs_total": 2,
+                "reviews_per_pr": 9.0,
+                "cycle_time_avg_hours": 90.0,
+                "rework_prs": 2,
+                "test_gap_prs": 2,
+            },
+        ]
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    result = await AIOpportunityDetector(MagicMock()).detect(
+        "org-a", AIScopeInput(team_id="team-a"), limit=10
+    )
+
+    assert [item.kind for item in result] == [AIOpportunityKind.TEST_GENERATION]
+    assert "60% test gap rate" in result[0].rationale
+    assert result[0].evidence_refs == [
+        f"ai_impact_metrics_daily:test_gap_rate:{REPO_ID}"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_detector_emits_title_pattern_toil_kinds(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """DEPENDENCY_UPDATES + MECHANICAL_MIGRATIONS fire from title clusters."""
+
+    async def fake_query_dicts(_client, query, _params):
+        if "LEFT ANTI JOIN" not in query:
+            return []
+        if "depend" in query:
+            prs_total = 6
+        elif "migrat" in query:
+            prs_total = 8
+        else:
+            return []
+        return [
+            {
+                "repo_id": REPO_ID,
+                "prs_total": prs_total,
+                "pr_refs": [
+                    f"git_pull_requests:{REPO_ID}:{number}"
+                    for number in range(1, prs_total + 1)
+                ],
+            }
+        ]
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    result = await AIOpportunityDetector(MagicMock()).detect("org-a", limit=10)
+
+    by_kind = {item.kind: item for item in result}
+    assert AIOpportunityKind.DEPENDENCY_UPDATES in by_kind
+    assert AIOpportunityKind.MECHANICAL_MIGRATIONS in by_kind
+    assert (
+        "6 dependency-update PRs"
+        in by_kind[AIOpportunityKind.DEPENDENCY_UPDATES].rationale
+    )
+    assert (
+        "8 migration-style PRs"
+        in by_kind[AIOpportunityKind.MECHANICAL_MIGRATIONS].rationale
+    )
+    deps = by_kind[AIOpportunityKind.DEPENDENCY_UPDATES]
+    assert deps.evidence_refs[0].startswith("git_pull_requests:")
+    assert deps.evidence_refs[-1] == (
+        f"git_pull_requests:dependency_update_prs:{REPO_ID}"
+    )
+    assert deps.work_graph_drilldowns[0].root_type == "pr"
+
+
+@pytest.mark.asyncio
+async def test_detector_emits_doc_drift(monkeypatch: pytest.MonkeyPatch):
+    async def fake_query_dicts(_client, query, _params):
+        if "doc_changes" not in query:
+            return []
+        return [{"repo_id": REPO_ID, "code_commits": 42, "doc_changes": 0}]
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    result = await AIOpportunityDetector(MagicMock()).detect("org-a", limit=10)
+
+    assert [item.kind for item in result] == [AIOpportunityKind.DOCUMENTATION_DRIFT]
+    assert "42 code commits" in result[0].rationale
+    assert result[0].evidence_refs == [f"git_commit_stats:doc_changes:{REPO_ID}"]
+
+
+@pytest.mark.asyncio
+async def test_detector_emits_flaky_test_triage(monkeypatch: pytest.MonkeyPatch):
+    async def fake_query_dicts(_client, query, _params):
+        if "testops_test_metrics_daily" not in query:
+            return []
+        return [
+            {
+                "repo_id": REPO_ID,
+                "total_cases": 400,
+                "weighted_flake_rate": 0.12,
+            }
+        ]
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    result = await AIOpportunityDetector(MagicMock()).detect("org-a", limit=10)
+
+    assert [item.kind for item in result] == [AIOpportunityKind.FLAKY_TEST_TRIAGE]
+    assert "12.0%" in result[0].rationale
+    assert "400 executions" in result[0].rationale
+    assert result[0].evidence_refs == [
+        f"testops_test_metrics_daily:flake_rate:{REPO_ID}"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sql_backed_kinds_skip_team_scope(monkeypatch: pytest.MonkeyPatch):
+    """Team-scoped requests must not run the unscoped raw-table rules."""
+    seen_queries: list[str] = []
+
+    async def fake_query_dicts(_client, query, _params):
+        seen_queries.append(query)
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    result = await AIOpportunityDetector(MagicMock()).detect(
+        "org-a", AIScopeInput(team_id="team-a"), limit=10
+    )
+
+    assert result == []
+    # Only the ai_impact_metrics_daily load runs under a team scope.
+    assert len(seen_queries) == 1
+    assert "ai_impact_metrics_daily" in seen_queries[0]

--- a/tests/metrics/test_ai_opportunity_detector.py
+++ b/tests/metrics/test_ai_opportunity_detector.py
@@ -321,7 +321,7 @@ async def test_detector_emits_flaky_test_triage(monkeypatch: pytest.MonkeyPatch)
         return [
             {
                 "repo_id": REPO_ID,
-                "total_cases": 400,
+                "cases_total": 400,
                 "weighted_flake_rate": 0.12,
             }
         ]

--- a/tests/metrics/test_ai_workflow_live.py
+++ b/tests/metrics/test_ai_workflow_live.py
@@ -1,0 +1,417 @@
+"""Live-ClickHouse verification for the CHAOS-2180 Wave-2 review fixes.
+
+Covers (each against a throwaway random org so runs are isolated):
+
+1. Daily-job rerun produces NO query-visible duplicate AI workflow edges
+   through the real reader path (``load_ai_workflow_graph_for_pr`` — the
+   UNION ALL now reads every ReplacingMergeTree with FINAL).
+2. Detector anti-join and doc-drift join predicates carry the tenant key:
+   org B's rows can no longer suppress or pollute org A's detections even
+   when repo_id / PR number / commit hash collide across orgs.
+3. Governance allowlist precedence: exact tool+model rows beat wildcard
+   rows, latest version wins, and overlapping policy rows never fan an
+   artifact out into duplicates.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import date, datetime, time, timedelta, timezone
+
+import pytest
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/default)",
+    ),
+]
+
+
+def _sink():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    sink = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    sink.ensure_tables()
+    return sink
+
+
+def _insert_prs(sink, org_id: str, repo_id: uuid.UUID, prs: list[dict]) -> None:
+    now = datetime.now(timezone.utc)
+    sink.client.insert(
+        "git_pull_requests",
+        [
+            [
+                repo_id,
+                pr["number"],
+                pr.get("title", ""),
+                pr.get("body", ""),
+                pr.get("author_name", "alice"),
+                pr.get("author_email", "alice@example.com"),
+                pr.get("created_at", now - timedelta(days=2)),
+                pr.get("merged_at"),
+                pr.get("head_branch", "feature/x"),
+                now,
+                org_id,
+            ]
+            for pr in prs
+        ],
+        column_names=[
+            "repo_id",
+            "number",
+            "title",
+            "body",
+            "author_name",
+            "author_email",
+            "created_at",
+            "merged_at",
+            "head_branch",
+            "last_synced",
+            "org_id",
+        ],
+    )
+
+
+def _insert_attributions(
+    sink,
+    org_id: uuid.UUID,
+    repo_id: uuid.UUID,
+    subjects: list[str],
+    *,
+    kind: str = "ai_assisted",
+    evidence: dict | None = None,
+    observed_at: datetime | None = None,
+) -> None:
+    observed = observed_at or (datetime.now(timezone.utc) - timedelta(hours=1))
+    sink.client.insert(
+        "ai_attribution",
+        [
+            [
+                uuid.uuid4(),
+                org_id,
+                "github",
+                "pull_request",
+                subject,
+                repo_id,
+                kind,
+                "pr_label",
+                0.9,
+                json.dumps(evidence or {"label": "ai-assisted"}),
+                observed,
+                observed,
+            ]
+            for subject in subjects
+        ],
+        column_names=[
+            "record_id",
+            "org_id",
+            "provider",
+            "subject_type",
+            "subject_id",
+            "repo_id",
+            "kind",
+            "source",
+            "confidence",
+            "evidence",
+            "observed_at",
+            "ingested_at",
+        ],
+    )
+
+
+async def test_daily_job_rerun_has_no_reader_visible_duplicate_edges() -> None:
+    """Fix 1: write extraction twice, read once — counts must be rerun-stable."""
+    from dev_health_ops.api.queries.client import get_global_client
+    from dev_health_ops.metrics.job_daily import _extract_ai_workflow_for_day
+    from dev_health_ops.work_graph.ai_workflow import load_ai_workflow_graph_for_pr
+
+    sink = _sink()
+    org = uuid.uuid4()
+    repo = uuid.uuid4()
+    day_start = datetime.combine(
+        date.today() - timedelta(days=1), time.min, tzinfo=timezone.utc
+    )
+    day_end = day_start + timedelta(days=1)
+    created = day_start + timedelta(hours=3)
+
+    _insert_prs(
+        sink,
+        str(org),
+        repo,
+        [
+            {
+                "number": 7,
+                "title": "Add caching",
+                "body": "Generated with Claude Code",
+                "created_at": created,
+                "merged_at": created + timedelta(hours=2),
+            }
+        ],
+    )
+    sink.client.insert(
+        "git_pull_request_reviews",
+        [
+            [
+                repo,
+                7,
+                "rev_7_0",
+                "bob@example.com",
+                "APPROVED",
+                created,
+                created,
+                str(org),
+            ]
+        ],
+        column_names=[
+            "repo_id",
+            "number",
+            "review_id",
+            "reviewer",
+            "state",
+            "submitted_at",
+            "last_synced",
+            "org_id",
+        ],
+    )
+    sink.client.insert(
+        "work_graph_issue_pr",
+        [[repo, "jira:ABC-1", 7, 1.0, "native", "test", created, str(org)]],
+        column_names=[
+            "repo_id",
+            "work_item_id",
+            "pr_number",
+            "confidence",
+            "provenance",
+            "evidence",
+            "last_synced",
+            "org_id",
+        ],
+    )
+
+    def _run_once() -> None:
+        runs, artifacts, issues, reviews = _extract_ai_workflow_for_day(
+            primary_sink=sink,
+            org_id=str(org),
+            start=day_start,
+            end=day_end,
+            repo_id=None,
+            repo_provider_by_id={str(repo): "github"},
+        )
+        assert runs and artifacts and issues and reviews
+        sink.write_ai_workflow_runs(runs)
+        sink.write_ai_workflow_artifact_edges(artifacts)
+        sink.write_ai_workflow_issue_edges(issues)
+        sink.write_work_graph_pr_review_outcome_edges(reviews)
+
+    client = await get_global_client(CLICKHOUSE_URI)
+    pr_root = f"{repo}:7"
+
+    _run_once()
+    first = await load_ai_workflow_graph_for_pr(client, str(org), pr_root)
+    assert len(first.edges) == 3  # generates, has_ai_workflow, has_review_outcome
+    assert not first.partial
+
+    _run_once()  # rerun the same day — same deterministic ids, new computed_at
+    second = await load_ai_workflow_graph_for_pr(client, str(org), pr_root)
+    assert len(second.edges) == len(first.edges)
+    assert sorted(e.edge_id for e in second.edges) == sorted(
+        e.edge_id for e in first.edges
+    )
+    assert len(second.nodes) == len(first.nodes)
+    assert not second.partial
+
+
+async def test_dep_update_anti_join_is_tenant_isolated() -> None:
+    """Fix 3: org B attribution rows must not suppress org A's detections."""
+    from dev_health_ops.api.graphql.models.ai import AIOpportunityKind
+    from dev_health_ops.api.queries.client import get_global_client
+    from dev_health_ops.metrics.opportunities.ai_detector import AIOpportunityDetector
+
+    sink = _sink()
+    org_a = uuid.uuid4()
+    org_b = uuid.uuid4()
+    repo = uuid.uuid4()
+    numbers = list(range(1, 7))
+
+    _insert_prs(
+        sink,
+        str(org_a),
+        repo,
+        [
+            {"number": n, "title": f"Bump lodash version from 1.{n} to 2.{n}"}
+            for n in numbers
+        ],
+    )
+    # Same repo_id and PR numbers, but the AI attribution lives in org B.
+    _insert_attributions(sink, org_b, repo, [str(n) for n in numbers])
+
+    client = await get_global_client(CLICKHOUSE_URI)
+    result_a = await AIOpportunityDetector(client).detect(str(org_a), limit=50)
+    kinds_a = {item.kind for item in result_a}
+    assert AIOpportunityKind.DEPENDENCY_UPDATES in kinds_a
+
+    # Org B has attributions but no PRs: nothing should fire there.
+    result_b = await AIOpportunityDetector(client).detect(str(org_b), limit=50)
+    assert AIOpportunityKind.DEPENDENCY_UPDATES not in {i.kind for i in result_b}
+
+
+async def test_doc_drift_join_is_tenant_isolated() -> None:
+    """Fix 3: org B doc-file stats on colliding commit hashes must not hide
+    org A's documentation drift."""
+    from dev_health_ops.api.graphql.models.ai import AIOpportunityKind
+    from dev_health_ops.api.queries.client import get_global_client
+    from dev_health_ops.metrics.opportunities.ai_detector import (
+        _DOC_DRIFT_MIN_CODE_COMMITS,
+        AIOpportunityDetector,
+    )
+
+    sink = _sink()
+    org_a = uuid.uuid4()
+    org_b = uuid.uuid4()
+    repo = uuid.uuid4()
+    when = datetime.now(timezone.utc) - timedelta(days=2)
+    hashes = [
+        f"hash-{org_a.hex[:8]}-{i}" for i in range(_DOC_DRIFT_MIN_CODE_COMMITS + 5)
+    ]
+
+    sink.client.insert(
+        "git_commits",
+        [
+            [repo, h, "alice", "alice@example.com", when, when, when, str(org_a)]
+            for h in hashes
+        ],
+        column_names=[
+            "repo_id",
+            "hash",
+            "author_name",
+            "author_email",
+            "author_when",
+            "committer_when",
+            "last_synced",
+            "org_id",
+        ],
+    )
+    # Org A: pure code churn, zero doc files.
+    sink.client.insert(
+        "git_commit_stats",
+        [
+            [repo, h, f"src/mod_{i}.py", 10, 2, when, str(org_a)]
+            for i, h in enumerate(hashes)
+        ],
+        column_names=[
+            "repo_id",
+            "commit_hash",
+            "file_path",
+            "additions",
+            "deletions",
+            "last_synced",
+            "org_id",
+        ],
+    )
+    # Org B: doc-file stats for the SAME repo/commit hashes. Without the
+    # org key in the join these rows would zero out org A's drift signal.
+    sink.client.insert(
+        "git_commit_stats",
+        [[repo, h, "docs/readme.md", 5, 0, when, str(org_b)] for h in hashes],
+        column_names=[
+            "repo_id",
+            "commit_hash",
+            "file_path",
+            "additions",
+            "deletions",
+            "last_synced",
+            "org_id",
+        ],
+    )
+
+    client = await get_global_client(CLICKHOUSE_URI)
+    result_a = await AIOpportunityDetector(client).detect(str(org_a), limit=50)
+    drift = [i for i in result_a if i.kind is AIOpportunityKind.DOCUMENTATION_DRIFT]
+    assert drift, "org B doc rows leaked into org A's doc-drift join"
+    assert drift[0].repo_id == str(repo)
+
+
+async def test_allowlist_exact_model_beats_wildcard_without_fanout() -> None:
+    """Fix 4: precedence is exact > wildcard, latest version wins, one row
+    per artifact."""
+    from dev_health_ops.audit.ai_governance.loaders import AIGovernanceLoader
+    from dev_health_ops.audit.ai_governance.models import (
+        AIToolAllowlistEntry,
+        ToolAllowlistStatus,
+    )
+
+    sink = _sink()
+    org = uuid.uuid4()
+    repo = uuid.uuid4()
+    day = date.today()
+    observed = datetime.combine(day, time(hour=10), tzinfo=timezone.utc)
+
+    sink.write_ai_tool_allowlist(
+        [
+            AIToolAllowlistEntry(
+                org_id=str(org),
+                tool_name="testtool",
+                model_name=None,
+                status=ToolAllowlistStatus.ALLOWED,
+                reason="wildcard policy",
+            ),
+            AIToolAllowlistEntry(
+                org_id=str(org),
+                tool_name="testtool",
+                model_name="model-y",
+                status=ToolAllowlistStatus.DISALLOWED,
+                reason="exact policy",
+            ),
+        ]
+    )
+    _insert_attributions(
+        sink,
+        org,
+        repo,
+        ["1"],
+        evidence={"tool_name": "testtool", "model_name": "model-y"},
+        observed_at=observed,
+    )
+    _insert_attributions(
+        sink,
+        org,
+        repo,
+        ["2"],
+        evidence={"tool_name": "testtool", "model_name": "model-z"},
+        observed_at=observed,
+    )
+
+    loader = AIGovernanceLoader(sink)
+    artifacts = loader.load_artifacts_for_day(org_id=str(org), day=day)
+    by_subject = {}
+    for artifact in artifacts:
+        # Overlapping wildcard + exact rows must not duplicate artifacts.
+        assert artifact.subject_id not in by_subject, "artifact fan-out"
+        by_subject[artifact.subject_id] = artifact
+
+    assert by_subject["1"].tool_allowlist_status is ToolAllowlistStatus.DISALLOWED
+    assert by_subject["2"].tool_allowlist_status is ToolAllowlistStatus.ALLOWED
+
+    # A newer version of the exact row must win via argMax(computed_at).
+    sink.write_ai_tool_allowlist(
+        [
+            AIToolAllowlistEntry(
+                org_id=str(org),
+                tool_name="testtool",
+                model_name="model-y",
+                status=ToolAllowlistStatus.DEPRECATED,
+                reason="updated exact policy",
+            )
+        ]
+    )
+    refreshed = {
+        a.subject_id: a for a in loader.load_artifacts_for_day(org_id=str(org), day=day)
+    }
+    assert refreshed["1"].tool_allowlist_status is ToolAllowlistStatus.DEPRECATED
+    assert refreshed["2"].tool_allowlist_status is ToolAllowlistStatus.ALLOWED

--- a/tests/metrics/test_ai_workflow_live.py
+++ b/tests/metrics/test_ai_workflow_live.py
@@ -415,3 +415,61 @@ async def test_allowlist_exact_model_beats_wildcard_without_fanout() -> None:
     }
     assert refreshed["1"].tool_allowlist_status is ToolAllowlistStatus.DEPRECATED
     assert refreshed["2"].tool_allowlist_status is ToolAllowlistStatus.ALLOWED
+
+
+async def test_blank_model_rows_resolve_as_wildcard_never_phantom_exact() -> None:
+    """Fix 2 (final pass): a legacy ''-model row (inserted raw, bypassing the
+    normalising dataclass) must behave as wildcard, and an artifact with NO
+    model evidence (JSONExtractString yields '') must resolve via wildcard —
+    never phantom-match a '' "exact" key."""
+    from dev_health_ops.audit.ai_governance.loaders import AIGovernanceLoader
+    from dev_health_ops.audit.ai_governance.models import ToolAllowlistStatus
+
+    sink = _sink()
+    org = uuid.uuid4()
+    repo = uuid.uuid4()
+    day = date.today()
+    observed = datetime.combine(day, time(hour=9), tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+
+    # Legacy '' row written raw (the dataclass would normalise it away).
+    sink.client.insert(
+        "ai_tool_allowlist",
+        [[str(org), "legacytool", "", "disallowed", "legacy blank row", now, now]],
+        column_names=[
+            "org_id",
+            "tool_name",
+            "model_name",
+            "status",
+            "reason",
+            "updated_at",
+            "computed_at",
+        ],
+    )
+    # Artifact with tool evidence but NO model evidence.
+    _insert_attributions(
+        sink,
+        org,
+        repo,
+        ["1"],
+        evidence={"tool_name": "legacytool"},
+        observed_at=observed,
+    )
+    # Artifact WITH a model: must also resolve via the ''-as-wildcard row,
+    # never via a phantom '' exact key.
+    _insert_attributions(
+        sink,
+        org,
+        repo,
+        ["2"],
+        evidence={"tool_name": "legacytool", "model_name": "some-model"},
+        observed_at=observed,
+    )
+
+    loader = AIGovernanceLoader(sink)
+    artifacts = {
+        a.subject_id: a for a in loader.load_artifacts_for_day(org_id=str(org), day=day)
+    }
+    assert len(artifacts) == 2  # no fan-out
+    assert artifacts["1"].tool_allowlist_status is ToolAllowlistStatus.DISALLOWED
+    assert artifacts["2"].tool_allowlist_status is ToolAllowlistStatus.DISALLOWED

--- a/tests/metrics/test_ai_workflow_live.py
+++ b/tests/metrics/test_ai_workflow_live.py
@@ -37,6 +37,7 @@ pytestmark = [
 def _sink():
     from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
     sink = ClickHouseMetricsSink(CLICKHOUSE_URI)
     sink.ensure_tables()
     return sink
@@ -209,6 +210,7 @@ async def test_daily_job_rerun_has_no_reader_visible_duplicate_edges() -> None:
         sink.write_ai_workflow_issue_edges(issues)
         sink.write_work_graph_pr_review_outcome_edges(reviews)
 
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
     client = await get_global_client(CLICKHOUSE_URI)
     pr_root = f"{repo}:7"
 
@@ -251,6 +253,7 @@ async def test_dep_update_anti_join_is_tenant_isolated() -> None:
     # Same repo_id and PR numbers, but the AI attribution lives in org B.
     _insert_attributions(sink, org_b, repo, [str(n) for n in numbers])
 
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
     client = await get_global_client(CLICKHOUSE_URI)
     result_a = await AIOpportunityDetector(client).detect(str(org_a), limit=50)
     kinds_a = {item.kind for item in result_a}
@@ -330,6 +333,7 @@ async def test_doc_drift_join_is_tenant_isolated() -> None:
         ],
     )
 
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
     client = await get_global_client(CLICKHOUSE_URI)
     result_a = await AIOpportunityDetector(client).detect(str(org_a), limit=50)
     drift = [i for i in result_a if i.kind is AIOpportunityKind.DOCUMENTATION_DRIFT]

--- a/tests/metrics/test_job_daily_ai_workflow.py
+++ b/tests/metrics/test_job_daily_ai_workflow.py
@@ -134,3 +134,57 @@ def test_unknown_repo_provider_falls_back_to_unknown() -> None:
 
     assert len(runs) == 1
     assert runs[0].provider == "unknown"
+
+
+def test_infrastructure_errors_propagate() -> None:
+    """Review fix 2: ClickHouse failures must fail the job, not silently
+    produce an empty (= 'no AI activity') day."""
+
+    class _BrokenSink:
+        def query_dicts(self, query: str, parameters: dict[str, Any]) -> list:
+            raise RuntimeError("clickhouse unavailable")
+
+    import pytest
+
+    with pytest.raises(RuntimeError, match="clickhouse unavailable"):
+        _extract_ai_workflow_for_day(
+            primary_sink=_BrokenSink(),
+            org_id=ORG_ID,
+            start=START,
+            end=END,
+            repo_id=None,
+            repo_provider_by_id={},
+        )
+
+
+def test_malformed_rows_are_dropped_row_locally() -> None:
+    """Review fix 2: one garbage row must not abort the day's extraction."""
+
+    class _MalformedRowSink(_Sink):
+        def query_dicts(
+            self, query: str, parameters: dict[str, Any]
+        ) -> list[dict[str, Any]]:
+            rows = super().query_dicts(query, parameters)
+            if "FROM git_pull_requests" in query:
+                rows = rows + [
+                    {"repo_id": "not-a-uuid", "number": 9, "title": "bad"},
+                    {"repo_id": REPO_ID, "number": None, "title": "bad"},
+                ]
+            if "FROM git_pull_request_reviews" in query:
+                rows = rows + [{"repo_id": object(), "number": 3}]
+            return rows
+
+    runs, artifacts, issues, reviews = _extract_ai_workflow_for_day(
+        primary_sink=_MalformedRowSink(),
+        org_id=ORG_ID,
+        start=START,
+        end=END,
+        repo_id=None,
+        repo_provider_by_id={str(REPO_ID): "github"},
+    )
+
+    # The well-formed rows still extract exactly as in the happy-path test.
+    assert len(runs) == 1
+    assert len(artifacts) == 1
+    assert len(issues) == 1
+    assert len(reviews) == 1

--- a/tests/metrics/test_job_daily_ai_workflow.py
+++ b/tests/metrics/test_job_daily_ai_workflow.py
@@ -1,0 +1,136 @@
+"""CHAOS-2187: daily-job AI workflow extraction wiring.
+
+Covers ``job_daily._extract_ai_workflow_for_day`` — the helper that turns the
+day's PR/review rows into AI workflow runs and Work Graph edges. The three
+edge tables (``ai_workflow_issue_edges``, ``ai_workflow_artifact_edges``,
+``work_graph_pr_review_outcome_edges``) were previously never populated
+because the extractor had no production call site.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from dev_health_ops.metrics.job_daily import _extract_ai_workflow_for_day
+
+ORG_ID = "22222222-2222-2222-2222-222222222222"
+REPO_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+START = datetime(2026, 6, 8, tzinfo=timezone.utc)
+END = datetime(2026, 6, 9, tzinfo=timezone.utc)
+
+
+class _Sink:
+    """Routes query_dicts calls by source table."""
+
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        self.queries.append(query)
+        if "FROM git_pull_requests" in query:
+            return [
+                {
+                    "repo_id": REPO_ID,
+                    "number": 7,
+                    "title": "Add caching",
+                    # PR body carries an explicit AI assistance declaration so
+                    # the extractor's body signal fires deterministically.
+                    "body": "Generated with Claude Code",
+                    "head_branch": "feature/cache",
+                    "author_name": "dev-a",
+                    "author_email": "dev-a@example.com",
+                    "created_at": START,
+                    "merged_at": START,
+                    "closed_at": None,
+                    "last_synced": START,
+                },
+                {
+                    # No AI signal: must not produce a run.
+                    "repo_id": REPO_ID,
+                    "number": 8,
+                    "title": "Fix typo",
+                    "body": "",
+                    "head_branch": "fix/typo",
+                    "author_name": "dev-b",
+                    "author_email": "dev-b@example.com",
+                    "created_at": START,
+                    "merged_at": None,
+                    "closed_at": None,
+                    "last_synced": START,
+                },
+            ]
+        if "FROM work_graph_issue_pr" in query:
+            return [{"repo_id": REPO_ID, "pr_number": 7, "work_item_id": "jira:ABC-1"}]
+        if "FROM git_pull_request_reviews" in query:
+            return [
+                {
+                    "repo_id": REPO_ID,
+                    "number": 7,
+                    "review_id": "rev_7_0",
+                    "state": "APPROVED",
+                    "submitted_at": START,
+                    "last_synced": START,
+                }
+            ]
+        return []
+
+
+def test_extracts_runs_and_all_three_edge_kinds() -> None:
+    sink = _Sink()
+    runs, artifact_edges, issue_edges, review_edges = _extract_ai_workflow_for_day(
+        primary_sink=sink,
+        org_id=ORG_ID,
+        start=START,
+        end=END,
+        repo_id=None,
+        repo_provider_by_id={str(REPO_ID): "github"},
+    )
+
+    assert len(runs) == 1
+    assert str(runs[0].org_id) == ORG_ID
+    assert runs[0].provider == "github"
+
+    assert len(artifact_edges) == 1
+    assert artifact_edges[0].artifact_id == f"{REPO_ID}:7"
+
+    assert len(issue_edges) == 1
+    assert issue_edges[0].issue_id == "jira:ABC-1"
+
+    assert len(review_edges) == 1
+    assert review_edges[0].pr_id == f"{REPO_ID}:7"
+    assert review_edges[0].review_outcome_id == "rev_7_0"
+    assert review_edges[0].outcome == "APPROVED"
+
+
+def test_non_uuid_org_skips_extraction_without_queries() -> None:
+    sink = _Sink()
+    runs, artifact_edges, issue_edges, review_edges = _extract_ai_workflow_for_day(
+        primary_sink=sink,
+        org_id="not-a-uuid",
+        start=START,
+        end=END,
+        repo_id=None,
+        repo_provider_by_id={},
+    )
+
+    assert (runs, artifact_edges, issue_edges, review_edges) == ([], [], [], [])
+    assert sink.queries == []
+
+
+def test_unknown_repo_provider_falls_back_to_unknown() -> None:
+    sink = _Sink()
+    runs, _artifacts, _issues, _reviews = _extract_ai_workflow_for_day(
+        primary_sink=sink,
+        org_id=ORG_ID,
+        start=START,
+        end=END,
+        repo_id=REPO_ID,
+        repo_provider_by_id={},
+    )
+
+    assert len(runs) == 1
+    assert runs[0].provider == "unknown"

--- a/tests/work_graph/test_ai_workflow.py
+++ b/tests/work_graph/test_ai_workflow.py
@@ -270,3 +270,75 @@ def test_non_ai_work_graph_edge_record_shape_regression() -> None:
     assert edge.target_type.value == "pr"
     assert edge.edge_type.value == "implements"
     assert edge.evidence == "Closes CHAOS-1"
+
+
+def test_edge_union_pushes_role_typed_predicates_into_each_branch() -> None:
+    """Query-shape regression for the FINAL'd UNION reader (CHAOS-2187 perf).
+
+    Every branch must repeat the frontier-id filter on its OWN key columns
+    (they are in that table's ORDER BY) so part/granule pruning happens
+    BEFORE the FINAL merge. Without these, a single-PR drilldown FINAL-merges
+    the org's entire history in all five edge tables.
+    """
+    from dev_health_ops.work_graph.ai_workflow import _AI_EDGE_UNION_QUERY
+
+    branch_predicates = {
+        "ai_workflow_issue_edges": (
+            "(issue_id IN {issue_ids:Array(String)}"
+            " OR run_id IN {run_ids:Array(String)})"
+        ),
+        "ai_workflow_artifact_edges": (
+            "(run_id IN {run_ids:Array(String)}"
+            " OR artifact_id IN {artifact_ids:Array(String)})"
+        ),
+        "work_graph_pr_review_outcome_edges": (
+            "(pr_id IN {pr_ids:Array(String)}"
+            " OR review_outcome_id IN {review_outcome_ids:Array(String)})"
+        ),
+        "work_graph_pr_deployment_edges": (
+            "(pr_id IN {pr_ids:Array(String)}"
+            " OR deployment_id IN {deployment_ids:Array(String)})"
+        ),
+        "work_graph_deployment_incident_edges": (
+            "(deployment_id IN {deployment_ids:Array(String)}"
+            " OR incident_id IN {incident_ids:Array(String)})"
+        ),
+    }
+    for table, predicate in branch_predicates.items():
+        branch = _AI_EDGE_UNION_QUERY.split(f"FROM {table} FINAL", 1)[1].split(
+            "UNION ALL", 1
+        )[0]
+        assert "org_id = {org_id:String}" in branch, table
+        assert predicate in branch, f"{table} missing pushed-down predicate"
+
+
+def test_traversal_passes_role_typed_frontier_ids() -> None:
+    """The PR-root first hop must send pr_ids=[root] and empty arrays for
+    every role absent from the frontier (empty IN [] prunes that branch)."""
+    captured: list[dict[str, object]] = []
+
+    async def fake_query(_client: object, query: str, params: dict[str, object]):
+        if "FROM ai_workflow_runs" in query:
+            return []
+        captured.append(params)
+        return []
+
+    pr_id = f"{REPO}:42"
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new=AsyncMock(side_effect=fake_query),
+    ):
+        asyncio.run(load_ai_workflow_graph_for_pr(object(), str(ORG), pr_id, depth=1))
+
+    assert len(captured) == 1
+    params = captured[0]
+    assert params["pr_ids"] == [pr_id]
+    assert params["artifact_ids"] == [pr_id]  # superset: pr is an artifact target
+    for empty_role in (
+        "issue_ids",
+        "run_ids",
+        "review_outcome_ids",
+        "deployment_ids",
+        "incident_ids",
+    ):
+        assert params[empty_role] == [], empty_role


### PR DESCRIPTION
## CHAOS-2180 Wave 2 — AI pipeline/CLI

**Tickets:** CHAOS-2187 (wire extract_ai_workflow_from_pull_requests — 3 edge tables were never populated), CHAOS-2209 (admin-seeded ai_tool_allowlist write path, per recorded decision), CHAOS-2189 (5 documented opportunity kinds: TEST_GENERATION, DEPENDENCY_UPDATES, MECHANICAL_MIGRATIONS, DOCUMENTATION_DRIFT, FLAKY_TEST_TRIAGE — all live, evidence-backed).

### What
- Daily job extracts AI workflow runs + issue/artifact/review-outcome edges (rerun-stable: readers use FINAL + role-typed per-branch predicates — EXPLAIN-verified part pruning, 0 parts on inactive branches, ~1 granule single-PR drilldowns)
- Infrastructure failures now FAIL the job (no silent partial edge data); only row-local issues are skipped with counts
- `dev-hops ai allowlist set/list` + fixtures seed (6 entries incl. deliberate wildcard+exact overlap as precedence canary); loader precedence: exact model beats wildcard, ''-normalization at construction/loader (nullIf) — legacy '' rows resolve as wildcard
- Detector SQL: org_id in every JOIN predicate, two-org collision tests; flaky-triage alias-shadowing fix
- Bonus: load_git_rows int(None) crash fix (Nullable count columns)

### Review trail
2 Codex adversarial rounds + orchestrator review; 6 findings fixed (reader-visible replay duplicates — last wave's failure mode, swallowed extraction failures, tenant joins, allowlist double-match, FINAL full-scan shape, ''-vs-NULL ambiguity).

### Gates
ruff clean; full pytest 12 failed / 3712 passed — **byte-identical** to clean origin/main baseline (same-env comparison; 7 of the 12 are CLICKHOUSE_URI-dependent and fail on clean main too). Live e2e: job run twice → deduped edge counts stable (110→110); allowlist coherent.

### Follow-ups filed
CHAOS-2222 (pre-existing org-less joins in _detect_repetitive_changes), CHAOS-2224 (migration 038 ORDER BY collapses NULL/'' model keys — readers are safe, storage key needs a migration).

### Notes
Sibling ops PR #823 touches disjoint regions of models/ai.py — merge either order, rebase the second if needed. The web Wave-2 PR consumes the 5 new AIOpportunityKind enum values.