### PR TITLE
fix(fixtures): enforce metric-coherence Rule 1 in synthetic seed (CHAOS-2040)

### DIFF
--- a/docs/implementation/fixture-metric-coherence.md
+++ b/docs/implementation/fixture-metric-coherence.md
@@ -68,6 +68,15 @@ pending tests, which the UI labels explicitly.
 |---|---|
 | `deletions ≤ additions` (per file per commit) | The synthetic generator models organic change: files that are edited have more added/rewritten content than deleted content. |
 
+### CI pipeline runs
+
+| Invariant | Rationale |
+|---|---|
+| `status` is a known value | Each run belongs to exactly one status bucket (`success`, `failure`/`failed`, `cancelled`/`canceled`, `timeout`, `running`, `queued`, `skipped`). The denominator Rule 1 note applies: `success_rate + failure_rate` need not total 100 % because some runs are `cancelled` — the frontend copy already explains this. The ops contract ensures no run uses an unrecognised status that the UI cannot categorise. |
+| `queued_at ≤ started_at ≤ finished_at` | Timeline order is required for duration and queue-wait calculations to be non-negative. Violated ordering would produce negative latency values on the CI metrics views. |
+
+Note: each pipeline run is allocated a **single** status by construction in the generator, so there is no `sum of buckets = total` check needed. The denominator reconciles trivially — the check validates status validity and time ordering only.
+
 ### Already-enforced invariants (pre-CHAOS-2040)
 
 These were correct before this work; they are documented here for completeness.
@@ -108,9 +117,23 @@ except CoherenceError as exc:
 `validate_all` **collects every violation** before raising, so callers get the
 full picture in one pass rather than stopping at the first problem.
 
-Individual check functions (`check_coverage_snapshots`, `check_test_suite_results`,
-`check_work_item_metrics`, `check_commit_stats`) are also exported for
-targeted use.
+Individual check functions (`check_pipeline_runs`, `check_coverage_snapshots`,
+`check_test_suite_results`, `check_work_item_metrics`, `check_commit_stats`)
+are also exported for targeted use.
+
+### CLI escape hatch
+
+`dev-hops fixtures generate` runs `validate_all` by default after generating
+each repo's data.  To bypass validation (e.g., during profiling or bulk
+historical backfills where you trust the generator):
+
+```bash
+dev-hops fixtures generate --sink $CLICKHOUSE_URI --skip-coherence-validation
+```
+
+The flag is intentionally off by default; it should only be needed when
+generation performance is the bottleneck and you have independent confidence
+in the generator's correctness.
 
 ---
 
@@ -124,12 +147,24 @@ Unit tests live in `tests/fixtures/test_metric_coherence.py`.  They cover:
 3. **Generator regression** — `SyntheticDataGenerator` output passes
    `validate_all` for seeds `[0, 1, 7, 42, 99, 137, 255, 1024]`.
 
+4. **Runner integration** — `run_fixtures_generation` propagates
+   `CoherenceError` when the validator fires; `--skip-coherence-validation`
+   is verified to bypass the gate without calling the validator.
+
 Run with:
 
 ```bash
 cd ops/
 uv run pytest tests/fixtures/test_metric_coherence.py -v
 ```
+
+> **Same-seed determinism note:** the `seed` parameter controls the
+> numeric shape of generated values (counts, percentiles, pass rates) but
+> does not fix wall-clock timestamps — generators call `datetime.now()`
+> internally.  Two runs with the same seed produce coherent data with
+> identical statistical profiles, but with different absolute timestamps.
+> The coherence invariants are timestamp-order invariants, not absolute
+> value invariants, so this does not affect the validation guarantees.
 
 ---
 

--- a/docs/implementation/fixture-metric-coherence.md
+++ b/docs/implementation/fixture-metric-coherence.md
@@ -1,0 +1,148 @@
+# Fixture Metric Coherence (ops-side)
+
+> **Related front-end contract:** `web/docs/metric-coherence.md` — the same
+> Rule 1 principle governs both sides.  This document is the ops-backend
+> mirror: it records which invariants the synthetic fixture generators enforce
+> and how to validate them programmatically.
+
+Implemented as part of **CHAOS-2040**.
+
+---
+
+## Why this exists
+
+The synthetic seed (`dev-hops fixtures generate`) populates the live-backend
+demo with plausible data.  Before CHAOS-2040, the generators produced
+independent random values, which meant the seeded database could contain
+figures that silently contradict each other — for example, coverage snapshots
+where branch coverage exceeded line coverage, or work-item metrics where
+"unassigned completions" exceeded "total completions".
+
+A viewer of the live demo who noticed such a contradiction would reasonably
+assume it was a data bug, not an intended signal.  That erodes trust in the
+product at exactly the moment we want to build it.
+
+The fix is **enforce coherence at generation time**, so invariant-violating
+rows can never be produced in the first place, and add a **validation pass**
+that raises loudly if any violation slips through (e.g., via a future
+refactor).
+
+---
+
+## Invariants by domain
+
+### Coverage snapshots
+
+| Invariant | Rationale |
+|---|---|
+| `branch_coverage_pct ≤ line_coverage_pct` | A branch is only covered if its containing line is covered — branch coverage is a strict subset. |
+| `lines_covered ≤ lines_total` | Covered count cannot exceed the universe. |
+| `branches_covered ≤ branches_total` | Same constraint for branches. |
+
+### Test suite results
+
+| Invariant | Rationale |
+|---|---|
+| `passed + failed + skipped + error_count ≤ total_count` | Sub-counts are shares of the total; they may be *less than* total (quarantined tests appear in no sub-bucket), but never *more than* total. |
+
+Note: the sub-counts share the denominator `total_count`.  A viewer seeing
+"80 passed, 10 failed, 5 skipped, 5 errors out of 100 total" can reconcile
+the numbers (80+10+5+5 = 100).  The remaining capacity is quarantined /
+pending tests, which the UI labels explicitly.
+
+### Work-item metrics (daily)
+
+| Invariant | Rationale |
+|---|---|
+| `items_completed_unassigned ≤ items_completed` | Unassigned completions are a subset of all completions. |
+| `items_started_unassigned ≤ items_started` | Unassigned starts are a subset of all starts. |
+| `wip_unassigned_end_of_day ≤ wip_count_end_of_day` | Unassigned WIP is a subset of total WIP. |
+| `cycle_time_p50_hours ≤ cycle_time_p90_hours` | Percentiles are non-decreasing by definition. |
+| `lead_time_p50_hours ≤ lead_time_p90_hours` | Percentiles are non-decreasing. |
+| `cycle_time_p50_hours ≤ lead_time_p50_hours` | Lead time = queue time + cycle time.  Lead time is always ≥ cycle time. |
+| `wip_age_p50_hours ≤ wip_age_p90_hours` | Percentiles are non-decreasing. |
+
+### Commit stats
+
+| Invariant | Rationale |
+|---|---|
+| `deletions ≤ additions` (per file per commit) | The synthetic generator models organic change: files that are edited have more added/rewritten content than deleted content. |
+
+### Already-enforced invariants (pre-CHAOS-2040)
+
+These were correct before this work; they are documented here for completeness.
+
+| Domain | Invariant |
+|---|---|
+| Coverage | `branch_coverage_pct ≤ line_coverage_pct` (enforced via `min(branch_coverage, line_coverage - 2.0)` in the random walk) |
+| Complexity | `very_high_complexity_functions ≤ high_complexity_functions ≤ functions_count` |
+| Pipeline timing | `queued_at ≤ started_at ≤ finished_at` (derived sequentially) |
+| Deployment timing | `started_at ≤ finished_at ≤ deployed_at` (derived sequentially) |
+| User metrics | `loc_deleted ≤ loc_added` per author-day |
+
+---
+
+## Validation API
+
+```python
+from dev_health_ops.fixtures.coherence import (
+    FixtureBundle,
+    validate_all,
+    CoherenceError,
+)
+
+bundle = FixtureBundle(
+    coverage_snapshots=my_snapshots,      # list[dict]
+    test_suite_results=my_suite_rows,     # list[dict]
+    work_item_metrics=my_wi_rows,         # list[dict]
+    commit_stats=my_stat_rows,            # list[dict]
+)
+
+try:
+    validate_all(bundle)                  # raises CoherenceError if any violation
+except CoherenceError as exc:
+    for v in exc.violations:
+        print(v)
+```
+
+`validate_all` **collects every violation** before raising, so callers get the
+full picture in one pass rather than stopping at the first problem.
+
+Individual check functions (`check_coverage_snapshots`, `check_test_suite_results`,
+`check_work_item_metrics`, `check_commit_stats`) are also exported for
+targeted use.
+
+---
+
+## Testing
+
+Unit tests live in `tests/fixtures/test_metric_coherence.py`.  They cover:
+
+1. **Happy path** — valid rows pass `validate_all`.
+2. **Violation detection** — each invariant category has at least one test
+   that confirms a deliberately-broken row triggers the correct error.
+3. **Generator regression** — `SyntheticDataGenerator` output passes
+   `validate_all` for seeds `[0, 1, 7, 42, 99, 137, 255, 1024]`.
+
+Run with:
+
+```bash
+cd ops/
+uv run pytest tests/fixtures/test_metric_coherence.py -v
+```
+
+---
+
+## Denominator note (Rule 1 alignment)
+
+The front-end contract (Rule 1 in `web/docs/metric-coherence.md`) says:
+
+> If two figures *look* like they should add up but don't, the page MUST
+> either make them reconcile **or explain the denominator**.
+
+The ops generators take the "make them reconcile" path: the values are
+constrained at write time so the page never needs a caveat.  Where a caveat
+*is* appropriate (e.g., success rate + failure rate < 100% because some runs
+are cancelled), the existing frontend copy already explains the denominator —
+the ops seed now produces data that is consistent with that explanation rather
+than contradicting it.

--- a/src/dev_health_ops/fixtures/coherence.py
+++ b/src/dev_health_ops/fixtures/coherence.py
@@ -1,0 +1,265 @@
+"""Metric-coherence validation for synthetic fixture data.
+
+Mirrors *Rule 1* from ``web/docs/metric-coherence.md``:
+
+    Figures on a surface must reconcile under their stated denominator,
+    or the relationship must be explicitly explained.
+
+Every ``check_*`` function inspects a collection of generated rows and
+raises ``CoherenceError`` if it finds a violation.  The top-level
+``validate_all`` helper calls every registered check in one pass and
+collects every violation before raising, giving callers a complete
+picture rather than stopping at the first problem.
+
+The checks below define the *ops-side coherence contract*; see
+``docs/fixtures/metric-coherence.md`` for the full rationale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Error types
+# ---------------------------------------------------------------------------
+
+
+class CoherenceError(ValueError):
+    """Raised when one or more fixture rows violate a coherence invariant."""
+
+    def __init__(self, violations: list[str]) -> None:
+        self.violations = violations
+        joined = "\n".join(f"  • {v}" for v in violations)
+        super().__init__(f"Fixture coherence violation(s):\n{joined}")
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+
+def check_coverage_snapshots(rows: list[dict[str, Any]]) -> list[str]:
+    """Invariants for coverage snapshot rows.
+
+    1. ``branch_coverage_pct ≤ line_coverage_pct``
+       Branch coverage is a strict subset of line coverage; a branch can
+       only be covered if its containing line is covered.
+
+    2. ``lines_covered ≤ lines_total``
+       Covered count cannot exceed the total.
+
+    3. ``branches_covered ≤ branches_total``
+       Same constraint for branches.
+    """
+    violations: list[str] = []
+    for i, row in enumerate(rows):
+        line_pct = row.get("line_coverage_pct", 0.0)
+        branch_pct = row.get("branch_coverage_pct", 0.0)
+        lines_total = row.get("lines_total", 0)
+        lines_covered = row.get("lines_covered", 0)
+        branches_total = row.get("branches_total", 0)
+        branches_covered = row.get("branches_covered", 0)
+        run_id = row.get("run_id", f"row[{i}]")
+
+        if branch_pct > line_pct:
+            violations.append(
+                f"coverage/{run_id}: branch_coverage_pct ({branch_pct}) "
+                f"> line_coverage_pct ({line_pct}) — "
+                "branch coverage is a subset of line coverage"
+            )
+        if lines_total > 0 and lines_covered > lines_total:
+            violations.append(
+                f"coverage/{run_id}: lines_covered ({lines_covered}) "
+                f"> lines_total ({lines_total})"
+            )
+        if branches_total > 0 and branches_covered > branches_total:
+            violations.append(
+                f"coverage/{run_id}: branches_covered ({branches_covered}) "
+                f"> branches_total ({branches_total})"
+            )
+    return violations
+
+
+def check_test_suite_results(rows: list[dict[str, Any]]) -> list[str]:
+    """Invariants for test suite result rows.
+
+    ``passed_count + failed_count + skipped_count + error_count ≤ total_count``
+
+    The sub-counts are shares of the total.  They may be *less than*
+    total_count (quarantined / pending tests are not in any sub-count),
+    but they must never *exceed* it.
+    """
+    violations: list[str] = []
+    for i, row in enumerate(rows):
+        total = row.get("total_count", 0)
+        passed = row.get("passed_count", 0)
+        failed = row.get("failed_count", 0)
+        skipped = row.get("skipped_count", 0)
+        errors = row.get("error_count", 0)
+        suite_id = row.get("suite_id", f"row[{i}]")
+
+        sub_sum = passed + failed + skipped + errors
+        if sub_sum > total:
+            violations.append(
+                f"test_suite/{suite_id}: "
+                f"passed({passed}) + failed({failed}) + skipped({skipped}) "
+                f"+ error({errors}) = {sub_sum} > total_count({total})"
+            )
+    return violations
+
+
+def check_work_item_metrics(rows: list[dict[str, Any]]) -> list[str]:
+    """Invariants for work_item_metrics_daily rows.
+
+    1. ``items_completed_unassigned ≤ items_completed``
+       Unassigned completions are a subset of all completions.
+
+    2. ``items_started_unassigned ≤ items_started``
+       Unassigned starts are a subset of all starts.
+
+    3. ``wip_unassigned_end_of_day ≤ wip_count_end_of_day``
+       Unassigned WIP is a subset of total WIP.
+
+    4. ``cycle_time_p50_hours ≤ cycle_time_p90_hours``
+       Percentiles must be non-decreasing.
+
+    5. ``lead_time_p50_hours ≤ lead_time_p90_hours``
+       Percentiles must be non-decreasing.
+
+    6. ``cycle_time_p50_hours ≤ lead_time_p50_hours``
+       Lead time = queue + cycle time, so lead time ≥ cycle time.
+
+    7. ``wip_age_p50_hours ≤ wip_age_p90_hours``
+       Percentiles must be non-decreasing.
+    """
+    violations: list[str] = []
+    for i, row in enumerate(rows):
+        label = f"{row.get('work_scope_id', '?')}@{row.get('day', '?')}/{row.get('team_id', f'row[{i}]')}"
+
+        completed = row.get("items_completed", 0) or 0
+        completed_unassigned = row.get("items_completed_unassigned", 0) or 0
+        started = row.get("items_started", 0) or 0
+        started_unassigned = row.get("items_started_unassigned", 0) or 0
+        wip = row.get("wip_count_end_of_day", 0) or 0
+        wip_unassigned = row.get("wip_unassigned_end_of_day", 0) or 0
+
+        ct_p50 = row.get("cycle_time_p50_hours") or 0.0
+        ct_p90 = row.get("cycle_time_p90_hours") or 0.0
+        lt_p50 = row.get("lead_time_p50_hours") or 0.0
+        lt_p90 = row.get("lead_time_p90_hours") or 0.0
+        wip_age_p50 = row.get("wip_age_p50_hours") or 0.0
+        wip_age_p90 = row.get("wip_age_p90_hours") or 0.0
+
+        if completed_unassigned > completed:
+            violations.append(
+                f"work_item_metrics/{label}: "
+                f"items_completed_unassigned({completed_unassigned}) "
+                f"> items_completed({completed})"
+            )
+        if started_unassigned > started:
+            violations.append(
+                f"work_item_metrics/{label}: "
+                f"items_started_unassigned({started_unassigned}) "
+                f"> items_started({started})"
+            )
+        if wip_unassigned > wip:
+            violations.append(
+                f"work_item_metrics/{label}: "
+                f"wip_unassigned_end_of_day({wip_unassigned}) "
+                f"> wip_count_end_of_day({wip})"
+            )
+        if ct_p90 < ct_p50:
+            violations.append(
+                f"work_item_metrics/{label}: "
+                f"cycle_time_p90({ct_p90}) < cycle_time_p50({ct_p50})"
+            )
+        if lt_p90 < lt_p50:
+            violations.append(
+                f"work_item_metrics/{label}: "
+                f"lead_time_p90({lt_p90}) < lead_time_p50({lt_p50})"
+            )
+        if lt_p50 < ct_p50:
+            violations.append(
+                f"work_item_metrics/{label}: "
+                f"lead_time_p50({lt_p50}) < cycle_time_p50({ct_p50}) — "
+                "lead time must be ≥ cycle time (lead = queue + cycle)"
+            )
+        if wip_age_p90 < wip_age_p50:
+            violations.append(
+                f"work_item_metrics/{label}: "
+                f"wip_age_p90({wip_age_p90}) < wip_age_p50({wip_age_p50})"
+            )
+    return violations
+
+
+def check_commit_stats(rows: list[dict[str, Any]]) -> list[str]:
+    """Invariants for commit stat rows.
+
+    ``deletions ≤ additions``
+    A commit stat records what was added and removed in one file.
+    Deletions cannot exceed additions within a single diff hunk
+    (measured as absolute line counts, not net change).
+    """
+    violations: list[str] = []
+    for i, row in enumerate(rows):
+        additions = row.get("additions", 0) or 0
+        deletions = row.get("deletions", 0) or 0
+        commit_hash = row.get("commit_hash", f"row[{i}]")
+        file_path = row.get("file_path", "?")
+
+        if deletions > additions:
+            violations.append(
+                f"commit_stat/{commit_hash}/{file_path}: "
+                f"deletions({deletions}) > additions({additions})"
+            )
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Registry and top-level validator
+# ---------------------------------------------------------------------------
+
+#: Map of domain name → check function for ``validate_all``.
+_CHECKS: dict[str, Any] = {
+    "coverage_snapshots": check_coverage_snapshots,
+    "test_suite_results": check_test_suite_results,
+    "work_item_metrics": check_work_item_metrics,
+    "commit_stats": check_commit_stats,
+}
+
+
+@dataclass
+class FixtureBundle:
+    """A typed container for fixture row collections passed to ``validate_all``.
+
+    Pass only the collections you want to validate; ``None`` values are
+    skipped silently (useful when a caller does not generate every domain).
+    """
+
+    coverage_snapshots: list[dict[str, Any]] | None = None
+    test_suite_results: list[dict[str, Any]] | None = None
+    work_item_metrics: list[dict[str, Any]] | None = None
+    commit_stats: list[dict[str, Any]] | None = None
+
+
+def validate_all(bundle: FixtureBundle) -> None:
+    """Run all registered coherence checks against *bundle*.
+
+    Collects every violation across all domains before raising so callers
+    get the full picture in one pass.
+
+    Raises:
+        CoherenceError: if any invariant is violated.
+    """
+    all_violations: list[str] = []
+
+    for domain, check_fn in _CHECKS.items():
+        collection = getattr(bundle, domain, None)
+        if collection is None:
+            continue
+        violations = check_fn(collection)
+        all_violations.extend(violations)
+
+    if all_violations:
+        raise CoherenceError(all_violations)

--- a/src/dev_health_ops/fixtures/coherence.py
+++ b/src/dev_health_ops/fixtures/coherence.py
@@ -81,14 +81,79 @@ def check_coverage_snapshots(rows: list[dict[str, Any]]) -> list[str]:
     return violations
 
 
+def check_pipeline_runs(rows: list[dict[str, Any]]) -> list[str]:
+    """Invariants for CI pipeline run rows.
+
+    1. ``status`` is a known terminal or in-flight value.
+       The denominator Rule 1 note from ``web/docs/metric-coherence.md``
+       applies here: ``success_rate + failure_rate`` need not equal 100 %
+       because some runs are ``cancelled`` or still ``running``.  The
+       ops-side contract is that *each run is counted in exactly one status
+       bucket* — no run contributes to two categories simultaneously — so
+       the status distribution naturally reconciles without manual clamping.
+
+    2. ``queued_at ≤ started_at ≤ finished_at`` (when all three are present).
+       Timeline order is required for duration and queue-wait calculations
+       to be non-negative.
+    """
+    _VALID_STATUSES = frozenset(
+        {
+            "success",
+            "failure",
+            "failed",
+            "cancelled",
+            "canceled",
+            "timeout",
+            "running",
+            "queued",
+            "skipped",
+        }
+    )
+    violations: list[str] = []
+    for i, row in enumerate(rows):
+        run_id = row.get("run_id", f"row[{i}]")
+        status = row.get("status")
+
+        if status is not None and str(status).lower() not in _VALID_STATUSES:
+            violations.append(
+                f"pipeline_run/{run_id}: unknown status '{status}'; "
+                f"expected one of {sorted(_VALID_STATUSES)}"
+            )
+
+        queued_at = row.get("queued_at")
+        started_at = row.get("started_at")
+        finished_at = row.get("finished_at")
+
+        if queued_at and started_at and started_at < queued_at:
+            violations.append(
+                f"pipeline_run/{run_id}: started_at ({started_at}) "
+                f"< queued_at ({queued_at})"
+            )
+        if started_at and finished_at and finished_at < started_at:
+            violations.append(
+                f"pipeline_run/{run_id}: finished_at ({finished_at}) "
+                f"< started_at ({started_at})"
+            )
+    return violations
+
+
 def check_test_suite_results(rows: list[dict[str, Any]]) -> list[str]:
     """Invariants for test suite result rows.
 
     ``passed_count + failed_count + skipped_count + error_count ≤ total_count``
 
-    The sub-counts are shares of the total.  They may be *less than*
-    total_count (quarantined / pending tests are not in any sub-count),
-    but they must never *exceed* it.
+    The sub-counts are shares of the total.  They will equal *exactly*
+    ``total_count`` in fixture-generated data (the generator uses sequential
+    slot allocation so passed absorbs all remaining capacity).  They may be
+    *less than* total_count in real-world data where some tests are pending
+    or in an unrecognised state.
+
+    **Quarantined count:** ``quarantined_count`` is a separate *annotation*
+    on tests that may overlap with any status bucket.  A quarantined test
+    is still run and still falls into passed / failed / skipped / error; its
+    quarantine flag only suppresses the result from the build health signal.
+    Quarantined count therefore does NOT participate in the denominator check
+    — it is not a fifth exclusive slot.
     """
     violations: list[str] = []
     for i, row in enumerate(rows):
@@ -222,6 +287,7 @@ def check_commit_stats(rows: list[dict[str, Any]]) -> list[str]:
 
 #: Map of domain name → check function for ``validate_all``.
 _CHECKS: dict[str, Any] = {
+    "pipeline_runs": check_pipeline_runs,
     "coverage_snapshots": check_coverage_snapshots,
     "test_suite_results": check_test_suite_results,
     "work_item_metrics": check_work_item_metrics,
@@ -237,6 +303,7 @@ class FixtureBundle:
     skipped silently (useful when a caller does not generate every domain).
     """
 
+    pipeline_runs: list[dict[str, Any]] | None = None
     coverage_snapshots: list[dict[str, Any]] | None = None
     test_suite_results: list[dict[str, Any]] | None = None
     work_item_metrics: list[dict[str, Any]] | None = None

--- a/src/dev_health_ops/fixtures/generators/pipelines.py
+++ b/src/dev_health_ops/fixtures/generators/pipelines.py
@@ -311,20 +311,33 @@ class PipelinesGeneratorMixin(BaseGeneratorMixin):
             else:
                 pass_rate = random.uniform(0.85, 0.98)
 
-            passed = int(total_tests * pass_rate)
             flake_rate = random.uniform(0.02, 0.15)
             flaky_count = max(0, int(total_tests * flake_rate))
-            skipped = random.randint(0, max(1, total_tests // 20))
-            error_count = max(0, int(total_tests * random.uniform(0.02, 0.05)))
             quarantined_count = max(0, int(total_tests * random.uniform(0.01, 0.03)))
-            failed = total_tests - passed - skipped - error_count
-            failed = max(failed, len(persistent_failures))
-            if failed < 0:
-                overflow = -failed
-                failed = 0
-                passed = max(0, passed - overflow)
-            if passed + skipped + failed + error_count > total_tests:
-                passed = max(0, total_tests - skipped - failed - error_count)
+
+            # --- Coherence-safe allocation --------------------------------
+            # Allocate sub-counts so that their sum never exceeds total_count
+            # (Rule 1: figures must reconcile under their stated denominator).
+            # Strategy: fill slots in order — error → skipped → failed → passed.
+            remaining = total_tests
+            error_count = min(
+                max(0, int(total_tests * random.uniform(0.02, 0.05))), remaining
+            )
+            remaining -= error_count
+
+            skipped = min(random.randint(0, max(1, total_tests // 20)), remaining)
+            remaining -= skipped
+
+            # Ensure at least len(persistent_failures) failed tests so that
+            # the per-case generation below can assign them deterministically.
+            min_failed = min(len(persistent_failures), remaining)
+            failed = min(
+                max(min_failed, int(remaining * (1.0 - pass_rate))),
+                remaining,
+            )
+            remaining -= failed
+
+            passed = remaining  # absorbs any rounding residual
 
             suite_duration = random.uniform(30.0, 600.0)
 

--- a/src/dev_health_ops/fixtures/generators/work_items.py
+++ b/src/dev_health_ops/fixtures/generators/work_items.py
@@ -48,6 +48,32 @@ class WorkItemsGeneratorMixin(BaseGeneratorMixin):
         for i in range(days):
             day = end_date - timedelta(days=i)
             for team_id, team_name in teams_to_use:
+                # --- Coherence-safe allocation (Rule 1) -------------------
+                # Unassigned sub-counts must be subsets of their totals.
+                # Lead time must be ≥ cycle time (lead = queue + cycle).
+                # Percentile pairs must be non-decreasing (p50 ≤ p90).
+                items_started = random.randint(2, 8)
+                items_started_unassigned = random.randint(0, items_started)
+                items_completed = random.randint(1, 6)
+                items_completed_unassigned = random.randint(0, items_completed)
+                wip_count = random.randint(5, 15)
+                wip_unassigned = random.randint(0, wip_count)
+
+                # Build cycle / lead times so all four constraints hold:
+                #   ct_p50 ≤ ct_p90, lt_p50 ≤ lt_p90, ct_p50 ≤ lt_p50, ct_p90 ≤ lt_p90
+                # Strategy: generate base cycle-p50, add deltas for p90 and
+                # queue, so every derived value is monotonically larger.
+                ct_p50 = float(random.randint(24, 72))
+                ct_p90 = ct_p50 + float(random.randint(0, 48))
+                queue_p50 = float(random.randint(12, 48))
+                queue_p90 = queue_p50 + float(random.randint(0, 24))
+                lt_p50 = ct_p50 + queue_p50
+                lt_p90 = ct_p90 + queue_p90
+
+                # WIP age: p50 then p90 ≥ p50
+                wip_age_p50 = float(random.randint(12, 48))
+                wip_age_p90 = float(random.randint(48, 168))
+
                 records.append(
                     WorkItemMetricsDailyRecord(
                         day=day,
@@ -55,18 +81,18 @@ class WorkItemsGeneratorMixin(BaseGeneratorMixin):
                         work_scope_id=self.repo_name,
                         team_id=team_id,
                         team_name=team_name,
-                        items_started=random.randint(2, 8),
-                        items_completed=random.randint(1, 6),
-                        items_started_unassigned=random.randint(0, 2),
-                        items_completed_unassigned=random.randint(0, 1),
-                        wip_count_end_of_day=random.randint(5, 15),
-                        wip_unassigned_end_of_day=random.randint(1, 3),
-                        cycle_time_p50_hours=float(random.randint(24, 72)),
-                        cycle_time_p90_hours=float(random.randint(72, 120)),
-                        lead_time_p50_hours=float(random.randint(48, 96)),
-                        lead_time_p90_hours=float(random.randint(96, 240)),
-                        wip_age_p50_hours=float(random.randint(12, 48)),
-                        wip_age_p90_hours=float(random.randint(48, 168)),
+                        items_started=items_started,
+                        items_completed=items_completed,
+                        items_started_unassigned=items_started_unassigned,
+                        items_completed_unassigned=items_completed_unassigned,
+                        wip_count_end_of_day=wip_count,
+                        wip_unassigned_end_of_day=wip_unassigned,
+                        cycle_time_p50_hours=ct_p50,
+                        cycle_time_p90_hours=ct_p90,
+                        lead_time_p50_hours=lt_p50,
+                        lead_time_p90_hours=lt_p90,
+                        wip_age_p50_hours=wip_age_p50,
+                        wip_age_p90_hours=wip_age_p90,
                         bug_completed_ratio=random.uniform(0.1, 0.4),
                         story_points_completed=float(random.randint(10, 50)),
                         # Phase 2 metrics

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
+from dev_health_ops.fixtures.coherence import FixtureBundle, validate_all
 from dev_health_ops.fixtures.demo_identity import (
     DEFAULT_DEMO_REPO_NAME,
     demo_repo_name,
@@ -473,6 +474,13 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                 assigned_teams=assigned_teams,
             )
 
+            # Coherence-bundle accumulators: populated during generation,
+            # validated before the loop advances to the next repo.
+            _coh_commit_stats: list[dict] = []
+            _coh_pipeline_runs: list[dict] = []
+            _coh_suite_results: list[dict] | None = None
+            _coh_coverage: list[dict] | None = None
+
             # 1. Repo
             repo = generator.generate_repo()
             await store.insert_repo(repo)
@@ -493,6 +501,15 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                 allow_parallel=allow_parallel_inserts,
             )
             stats = generator.generate_commit_stats(commits)
+            _coh_commit_stats = [
+                {
+                    "commit_hash": getattr(s, "commit_hash", None),
+                    "file_path": getattr(s, "file_path", None),
+                    "additions": getattr(s, "additions", 0),
+                    "deletions": getattr(s, "deletions", 0),
+                }
+                for s in stats
+            ]
             await _insert_batches(
                 store.insert_git_commit_stats,
                 stats,
@@ -658,6 +675,16 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
             # 6. CI/CD + Deployments + Incidents
             pr_numbers = [pr.number for pr in prs]
             pipeline_runs = generator.generate_ci_pipeline_runs(days=ns.days)
+            _coh_pipeline_runs = [
+                {
+                    "run_id": getattr(r, "run_id", None),
+                    "status": getattr(r, "status", None),
+                    "queued_at": getattr(r, "queued_at", None),
+                    "started_at": getattr(r, "started_at", None),
+                    "finished_at": getattr(r, "finished_at", None),
+                }
+                for r in pipeline_runs
+            ]
             release_refs = ff_release_refs = generator._default_release_refs(ns.days)
             deployments = generator.generate_deployments(
                 days=ns.days, pr_numbers=pr_numbers, release_refs=release_refs
@@ -749,6 +776,7 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                 test_data = generator.generate_test_executions(
                     job_runs, days=ns.days, org_id=org_id
                 )
+                _coh_suite_results = test_data["suite_results"]
                 if hasattr(store, "insert_test_suite_results"):
                     await _insert_batches(
                         store.insert_test_suite_results,
@@ -765,6 +793,7 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                 coverage_snapshots = generator.generate_coverage_snapshots(
                     pipeline_runs, days=ns.days, org_id=org_id
                 )
+                _coh_coverage = coverage_snapshots
                 if hasattr(store, "insert_coverage_snapshots"):
                     await _insert_batches(
                         store.insert_coverage_snapshots,
@@ -779,6 +808,20 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                 blame_data,
                 allow_parallel=allow_parallel_inserts,
             )
+
+            # Coherence gate: validate all generated fixture rows before advancing
+            # to the next repo.  Raises CoherenceError (a ValueError subclass) if
+            # any invariant is violated.  Pass --skip-coherence-validation to
+            # bypass this gate (e.g., during performance-sensitive bulk runs).
+            if not getattr(ns, "skip_coherence_validation", False):
+                validate_all(
+                    FixtureBundle(
+                        pipeline_runs=_coh_pipeline_runs,
+                        commit_stats=_coh_commit_stats,
+                        test_suite_results=_coh_suite_results,
+                        coverage_snapshots=_coh_coverage,
+                    )
+                )
 
             # 8. Metrics
             if ns.with_metrics and sink:
@@ -1935,6 +1978,16 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         type=int,
         default=10,
         help="Number of synthetic teams to create.",
+    )
+    fix_gen.add_argument(
+        "--skip-coherence-validation",
+        action="store_true",
+        dest="skip_coherence_validation",
+        default=False,
+        help=(
+            "Bypass metric-coherence validation after generation. "
+            "Off by default; use only when generation performance is the bottleneck."
+        ),
     )
     fix_gen.set_defaults(func=run_fixtures_generation)
 

--- a/tests/fixtures/test_metric_coherence.py
+++ b/tests/fixtures/test_metric_coherence.py
@@ -371,7 +371,7 @@ class TestGeneratorCoherence:
         gen = _make_gen(seed)
         records = gen.generate_work_item_metrics(days=14)
         # Convert dataclass records to dicts for the validator
-        row_dicts = [r.__dict__ if hasattr(r, "__dict__") else dict(r) for r in records]
+        row_dicts = [vars(r) for r in records]
         bundle = FixtureBundle(work_item_metrics=row_dicts)
         validate_all(bundle)
 
@@ -380,7 +380,7 @@ class TestGeneratorCoherence:
         gen = _make_gen(seed)
         commits = gen.generate_commits(days=14)
         stats = gen.generate_commit_stats(commits)
-        stat_dicts = [s.__dict__ if hasattr(s, "__dict__") else dict(s) for s in stats]
+        stat_dicts = [vars(s) for s in stats]
         bundle = FixtureBundle(commit_stats=stat_dicts)
         validate_all(bundle)
 
@@ -399,12 +399,8 @@ class TestGeneratorCoherence:
         bundle = FixtureBundle(
             coverage_snapshots=snapshots,
             test_suite_results=executions["suite_results"],
-            work_item_metrics=[
-                r.__dict__ if hasattr(r, "__dict__") else dict(r) for r in wi_records
-            ],
-            commit_stats=[
-                s.__dict__ if hasattr(s, "__dict__") else dict(s) for s in stats
-            ],
+            work_item_metrics=[vars(r) for r in wi_records],
+            commit_stats=[vars(s) for s in stats],
         )
         validate_all(bundle)
 

--- a/tests/fixtures/test_metric_coherence.py
+++ b/tests/fixtures/test_metric_coherence.py
@@ -1,0 +1,378 @@
+"""Unit tests for ops fixture metric-coherence (CHAOS-2040).
+
+Guards the invariants defined in ``dev_health_ops/fixtures/coherence.py``
+and the Rule 1 enforcement baked into the generator methods.
+
+Test charter
+============
+1. ``validate_all`` passes on correctly-formed fixture bundles.
+2. ``validate_all`` raises ``CoherenceError`` on every category of known
+   violation, with a descriptive message.
+3. Generator methods produce rows that pass ``validate_all`` across a
+   range of seeds (non-flaky regression surface).
+4. Deliberately broken rows trigger the correct per-check function.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.fixtures.coherence import (
+    CoherenceError,
+    FixtureBundle,
+    check_commit_stats,
+    check_coverage_snapshots,
+    check_test_suite_results,
+    check_work_item_metrics,
+    validate_all,
+)
+from dev_health_ops.fixtures.generator import SyntheticDataGenerator
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_gen(seed: int = 42) -> SyntheticDataGenerator:
+    return SyntheticDataGenerator(repo_name="acme/test-repo", provider="github", seed=seed)
+
+
+def _valid_coverage_row(**overrides) -> dict:
+    base = {
+        "run_id": "run-1",
+        "line_coverage_pct": 80.0,
+        "branch_coverage_pct": 70.0,
+        "lines_total": 10_000,
+        "lines_covered": 8_000,
+        "branches_total": 3_000,
+        "branches_covered": 2_100,
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_suite_row(**overrides) -> dict:
+    base = {
+        "suite_id": "suite-1",
+        "total_count": 100,
+        "passed_count": 80,
+        "failed_count": 10,
+        "skipped_count": 5,
+        "error_count": 5,
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_work_item_row(**overrides) -> dict:
+    base = {
+        "work_scope_id": "repo",
+        "day": "2024-01-01",
+        "team_id": "team-1",
+        "items_started": 5,
+        "items_started_unassigned": 2,
+        "items_completed": 4,
+        "items_completed_unassigned": 1,
+        "wip_count_end_of_day": 10,
+        "wip_unassigned_end_of_day": 3,
+        "cycle_time_p50_hours": 24.0,
+        "cycle_time_p90_hours": 72.0,
+        "lead_time_p50_hours": 48.0,
+        "lead_time_p90_hours": 96.0,
+        "wip_age_p50_hours": 12.0,
+        "wip_age_p90_hours": 48.0,
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_commit_stat_row(**overrides) -> dict:
+    base = {
+        "commit_hash": "abc123",
+        "file_path": "src/foo.py",
+        "additions": 50,
+        "deletions": 20,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# validate_all — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAllHappyPath:
+    def test_empty_bundle_passes(self) -> None:
+        validate_all(FixtureBundle())  # should not raise
+
+    def test_valid_rows_pass(self) -> None:
+        bundle = FixtureBundle(
+            coverage_snapshots=[_valid_coverage_row()],
+            test_suite_results=[_valid_suite_row()],
+            work_item_metrics=[_valid_work_item_row()],
+            commit_stats=[_valid_commit_stat_row()],
+        )
+        validate_all(bundle)  # should not raise
+
+    def test_none_collections_are_skipped(self) -> None:
+        bundle = FixtureBundle(
+            coverage_snapshots=None,
+            test_suite_results=[_valid_suite_row()],
+        )
+        validate_all(bundle)
+
+
+# ---------------------------------------------------------------------------
+# check_coverage_snapshots
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCoverageSnapshots:
+    def test_valid_row_produces_no_violations(self) -> None:
+        assert check_coverage_snapshots([_valid_coverage_row()]) == []
+
+    def test_branch_exceeds_line_pct(self) -> None:
+        row = _valid_coverage_row(line_coverage_pct=70.0, branch_coverage_pct=75.0)
+        violations = check_coverage_snapshots([row])
+        assert len(violations) == 1
+        assert "branch_coverage_pct" in violations[0]
+
+    def test_lines_covered_exceeds_total(self) -> None:
+        row = _valid_coverage_row(lines_covered=10_001, lines_total=10_000)
+        violations = check_coverage_snapshots([row])
+        assert any("lines_covered" in v for v in violations)
+
+    def test_branches_covered_exceeds_total(self) -> None:
+        row = _valid_coverage_row(branches_covered=3_001, branches_total=3_000)
+        violations = check_coverage_snapshots([row])
+        assert any("branches_covered" in v for v in violations)
+
+    def test_equal_branch_and_line_pct_is_valid(self) -> None:
+        row = _valid_coverage_row(line_coverage_pct=80.0, branch_coverage_pct=80.0)
+        assert check_coverage_snapshots([row]) == []
+
+    def test_multiple_violations_reported(self) -> None:
+        row = _valid_coverage_row(
+            line_coverage_pct=60.0,
+            branch_coverage_pct=80.0,
+            lines_covered=11_000,
+            lines_total=10_000,
+        )
+        violations = check_coverage_snapshots([row])
+        assert len(violations) == 2
+
+
+# ---------------------------------------------------------------------------
+# check_test_suite_results
+# ---------------------------------------------------------------------------
+
+
+class TestCheckTestSuiteResults:
+    def test_valid_row_produces_no_violations(self) -> None:
+        assert check_test_suite_results([_valid_suite_row()]) == []
+
+    def test_sum_equals_total_is_valid(self) -> None:
+        row = _valid_suite_row(
+            total_count=100, passed_count=80, failed_count=10,
+            skipped_count=5, error_count=5,
+        )
+        assert check_test_suite_results([row]) == []
+
+    def test_sum_less_than_total_is_valid(self) -> None:
+        # quarantined tests may not appear in any sub-count bucket
+        row = _valid_suite_row(
+            total_count=100, passed_count=70, failed_count=10,
+            skipped_count=5, error_count=5,
+        )
+        assert check_test_suite_results([row]) == []
+
+    def test_sum_exceeds_total_is_violation(self) -> None:
+        row = _valid_suite_row(
+            total_count=100, passed_count=90, failed_count=10,
+            skipped_count=5, error_count=5,
+        )
+        violations = check_test_suite_results([row])
+        assert len(violations) == 1
+        assert "suite_id" not in violations[0] or "suite-1" in violations[0]
+
+    def test_overflow_from_min_failed_floor(self) -> None:
+        """Regression: forcing min failed ≥ N while pass_rate is high used to overflow."""
+        row = _valid_suite_row(
+            total_count=50, passed_count=47, failed_count=10,
+            skipped_count=2, error_count=2,
+        )
+        violations = check_test_suite_results([row])
+        assert violations  # 47+10+2+2=61 > 50
+
+
+# ---------------------------------------------------------------------------
+# check_work_item_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestCheckWorkItemMetrics:
+    def test_valid_row_produces_no_violations(self) -> None:
+        assert check_work_item_metrics([_valid_work_item_row()]) == []
+
+    def test_unassigned_completed_exceeds_completed(self) -> None:
+        row = _valid_work_item_row(items_completed=2, items_completed_unassigned=3)
+        violations = check_work_item_metrics([row])
+        assert any("items_completed_unassigned" in v for v in violations)
+
+    def test_unassigned_started_exceeds_started(self) -> None:
+        row = _valid_work_item_row(items_started=3, items_started_unassigned=5)
+        violations = check_work_item_metrics([row])
+        assert any("items_started_unassigned" in v for v in violations)
+
+    def test_wip_unassigned_exceeds_wip(self) -> None:
+        row = _valid_work_item_row(wip_count_end_of_day=5, wip_unassigned_end_of_day=8)
+        violations = check_work_item_metrics([row])
+        assert any("wip_unassigned" in v for v in violations)
+
+    def test_cycle_time_p90_less_than_p50(self) -> None:
+        row = _valid_work_item_row(cycle_time_p50_hours=80.0, cycle_time_p90_hours=40.0)
+        violations = check_work_item_metrics([row])
+        assert any("cycle_time_p90" in v for v in violations)
+
+    def test_lead_time_less_than_cycle_time(self) -> None:
+        row = _valid_work_item_row(
+            cycle_time_p50_hours=60.0, lead_time_p50_hours=48.0
+        )
+        violations = check_work_item_metrics([row])
+        assert any("lead_time_p50" in v for v in violations)
+
+    def test_lead_time_equals_cycle_time_is_valid(self) -> None:
+        row = _valid_work_item_row(
+            cycle_time_p50_hours=48.0, lead_time_p50_hours=48.0
+        )
+        assert check_work_item_metrics([row]) == []
+
+    def test_wip_age_p90_less_than_p50(self) -> None:
+        row = _valid_work_item_row(wip_age_p50_hours=50.0, wip_age_p90_hours=30.0)
+        violations = check_work_item_metrics([row])
+        assert any("wip_age_p90" in v for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# check_commit_stats
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCommitStats:
+    def test_valid_row_produces_no_violations(self) -> None:
+        assert check_commit_stats([_valid_commit_stat_row()]) == []
+
+    def test_deletions_equal_additions_is_valid(self) -> None:
+        row = _valid_commit_stat_row(additions=30, deletions=30)
+        assert check_commit_stats([row]) == []
+
+    def test_deletions_exceed_additions_is_violation(self) -> None:
+        row = _valid_commit_stat_row(additions=20, deletions=30)
+        violations = check_commit_stats([row])
+        assert len(violations) == 1
+        assert "deletions" in violations[0]
+
+
+# ---------------------------------------------------------------------------
+# validate_all — collects all violations before raising
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAllCollectsViolations:
+    def test_raises_with_all_violations_in_one_error(self) -> None:
+        bundle = FixtureBundle(
+            coverage_snapshots=[
+                _valid_coverage_row(line_coverage_pct=50.0, branch_coverage_pct=80.0)
+            ],
+            test_suite_results=[
+                _valid_suite_row(total_count=10, passed_count=9, failed_count=5,
+                                 skipped_count=0, error_count=0)
+            ],
+        )
+        with pytest.raises(CoherenceError) as exc_info:
+            validate_all(bundle)
+        error = exc_info.value
+        assert len(error.violations) == 2  # one per domain
+
+    def test_error_message_lists_domains(self) -> None:
+        bundle = FixtureBundle(
+            commit_stats=[_valid_commit_stat_row(additions=5, deletions=10)]
+        )
+        with pytest.raises(CoherenceError) as exc_info:
+            validate_all(bundle)
+        assert "commit_stat" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Generator integration — across multiple seeds
+# ---------------------------------------------------------------------------
+
+
+SEEDS = [0, 1, 7, 42, 99, 137, 255, 1024]
+
+
+class TestGeneratorCoherence:
+    """Generated rows must satisfy validate_all for every seed in SEEDS."""
+
+    @pytest.mark.parametrize("seed", SEEDS)
+    def test_coverage_snapshots_are_coherent(self, seed: int) -> None:
+        gen = _make_gen(seed)
+        pipeline_runs = gen.generate_ci_pipeline_runs(days=14)
+        snapshots = gen.generate_coverage_snapshots(pipeline_runs, days=14)
+        bundle = FixtureBundle(coverage_snapshots=snapshots)
+        validate_all(bundle)
+
+    @pytest.mark.parametrize("seed", SEEDS)
+    def test_test_suite_results_are_coherent(self, seed: int) -> None:
+        gen = _make_gen(seed)
+        pipeline_runs = gen.generate_ci_pipeline_runs(days=14)
+        job_runs = gen.generate_ci_job_runs(pipeline_runs)
+        executions = gen.generate_test_executions(job_runs, days=14)
+        bundle = FixtureBundle(
+            test_suite_results=executions["suite_results"],
+        )
+        validate_all(bundle)
+
+    @pytest.mark.parametrize("seed", SEEDS)
+    def test_work_item_metrics_are_coherent(self, seed: int) -> None:
+        gen = _make_gen(seed)
+        records = gen.generate_work_item_metrics(days=14)
+        # Convert dataclass records to dicts for the validator
+        row_dicts = [r.__dict__ if hasattr(r, "__dict__") else dict(r) for r in records]
+        bundle = FixtureBundle(work_item_metrics=row_dicts)
+        validate_all(bundle)
+
+    @pytest.mark.parametrize("seed", SEEDS)
+    def test_commit_stats_are_coherent(self, seed: int) -> None:
+        gen = _make_gen(seed)
+        commits = gen.generate_commits(days=14)
+        stats = gen.generate_commit_stats(commits)
+        stat_dicts = [s.__dict__ if hasattr(s, "__dict__") else dict(s) for s in stats]
+        bundle = FixtureBundle(commit_stats=stat_dicts)
+        validate_all(bundle)
+
+    @pytest.mark.parametrize("seed", SEEDS)
+    def test_full_bundle_is_coherent(self, seed: int) -> None:
+        """All domains together still satisfy validate_all."""
+        gen = _make_gen(seed)
+        pipeline_runs = gen.generate_ci_pipeline_runs(days=14)
+        job_runs = gen.generate_ci_job_runs(pipeline_runs)
+        executions = gen.generate_test_executions(job_runs, days=14)
+        commits = gen.generate_commits(days=14)
+        stats = gen.generate_commit_stats(commits)
+        snapshots = gen.generate_coverage_snapshots(pipeline_runs, days=14)
+        wi_records = gen.generate_work_item_metrics(days=14)
+
+        bundle = FixtureBundle(
+            coverage_snapshots=snapshots,
+            test_suite_results=executions["suite_results"],
+            work_item_metrics=[
+                r.__dict__ if hasattr(r, "__dict__") else dict(r)
+                for r in wi_records
+            ],
+            commit_stats=[
+                s.__dict__ if hasattr(s, "__dict__") else dict(s) for s in stats
+            ],
+        )
+        validate_all(bundle)

--- a/tests/fixtures/test_metric_coherence.py
+++ b/tests/fixtures/test_metric_coherence.py
@@ -34,7 +34,9 @@ from dev_health_ops.fixtures.generator import SyntheticDataGenerator
 
 
 def _make_gen(seed: int = 42) -> SyntheticDataGenerator:
-    return SyntheticDataGenerator(repo_name="acme/test-repo", provider="github", seed=seed)
+    return SyntheticDataGenerator(
+        repo_name="acme/test-repo", provider="github", seed=seed
+    )
 
 
 def _valid_coverage_row(**overrides) -> dict:
@@ -174,23 +176,32 @@ class TestCheckTestSuiteResults:
 
     def test_sum_equals_total_is_valid(self) -> None:
         row = _valid_suite_row(
-            total_count=100, passed_count=80, failed_count=10,
-            skipped_count=5, error_count=5,
+            total_count=100,
+            passed_count=80,
+            failed_count=10,
+            skipped_count=5,
+            error_count=5,
         )
         assert check_test_suite_results([row]) == []
 
     def test_sum_less_than_total_is_valid(self) -> None:
         # quarantined tests may not appear in any sub-count bucket
         row = _valid_suite_row(
-            total_count=100, passed_count=70, failed_count=10,
-            skipped_count=5, error_count=5,
+            total_count=100,
+            passed_count=70,
+            failed_count=10,
+            skipped_count=5,
+            error_count=5,
         )
         assert check_test_suite_results([row]) == []
 
     def test_sum_exceeds_total_is_violation(self) -> None:
         row = _valid_suite_row(
-            total_count=100, passed_count=90, failed_count=10,
-            skipped_count=5, error_count=5,
+            total_count=100,
+            passed_count=90,
+            failed_count=10,
+            skipped_count=5,
+            error_count=5,
         )
         violations = check_test_suite_results([row])
         assert len(violations) == 1
@@ -199,8 +210,11 @@ class TestCheckTestSuiteResults:
     def test_overflow_from_min_failed_floor(self) -> None:
         """Regression: forcing min failed ≥ N while pass_rate is high used to overflow."""
         row = _valid_suite_row(
-            total_count=50, passed_count=47, failed_count=10,
-            skipped_count=2, error_count=2,
+            total_count=50,
+            passed_count=47,
+            failed_count=10,
+            skipped_count=2,
+            error_count=2,
         )
         violations = check_test_suite_results([row])
         assert violations  # 47+10+2+2=61 > 50
@@ -236,16 +250,12 @@ class TestCheckWorkItemMetrics:
         assert any("cycle_time_p90" in v for v in violations)
 
     def test_lead_time_less_than_cycle_time(self) -> None:
-        row = _valid_work_item_row(
-            cycle_time_p50_hours=60.0, lead_time_p50_hours=48.0
-        )
+        row = _valid_work_item_row(cycle_time_p50_hours=60.0, lead_time_p50_hours=48.0)
         violations = check_work_item_metrics([row])
         assert any("lead_time_p50" in v for v in violations)
 
     def test_lead_time_equals_cycle_time_is_valid(self) -> None:
-        row = _valid_work_item_row(
-            cycle_time_p50_hours=48.0, lead_time_p50_hours=48.0
-        )
+        row = _valid_work_item_row(cycle_time_p50_hours=48.0, lead_time_p50_hours=48.0)
         assert check_work_item_metrics([row]) == []
 
     def test_wip_age_p90_less_than_p50(self) -> None:
@@ -286,8 +296,13 @@ class TestValidateAllCollectsViolations:
                 _valid_coverage_row(line_coverage_pct=50.0, branch_coverage_pct=80.0)
             ],
             test_suite_results=[
-                _valid_suite_row(total_count=10, passed_count=9, failed_count=5,
-                                 skipped_count=0, error_count=0)
+                _valid_suite_row(
+                    total_count=10,
+                    passed_count=9,
+                    failed_count=5,
+                    skipped_count=0,
+                    error_count=0,
+                )
             ],
         )
         with pytest.raises(CoherenceError) as exc_info:
@@ -368,8 +383,7 @@ class TestGeneratorCoherence:
             coverage_snapshots=snapshots,
             test_suite_results=executions["suite_results"],
             work_item_metrics=[
-                r.__dict__ if hasattr(r, "__dict__") else dict(r)
-                for r in wi_records
+                r.__dict__ if hasattr(r, "__dict__") else dict(r) for r in wi_records
             ],
             commit_stats=[
                 s.__dict__ if hasattr(s, "__dict__") else dict(s) for s in stats

--- a/tests/fixtures/test_metric_coherence.py
+++ b/tests/fixtures/test_metric_coherence.py
@@ -11,9 +11,13 @@ Test charter
 3. Generator methods produce rows that pass ``validate_all`` across a
    range of seeds (non-flaky regression surface).
 4. Deliberately broken rows trigger the correct per-check function.
+5. ``run_fixtures_generation`` is wired to call ``validate_all``; a
+   deliberately-broken validator raises ``CoherenceError`` to the caller.
 """
 
 from __future__ import annotations
+
+import argparse
 
 import pytest
 
@@ -22,6 +26,7 @@ from dev_health_ops.fixtures.coherence import (
     FixtureBundle,
     check_commit_stats,
     check_coverage_snapshots,
+    check_pipeline_runs,
     check_test_suite_results,
     check_work_item_metrics,
     validate_all,
@@ -94,6 +99,18 @@ def _valid_commit_stat_row(**overrides) -> dict:
         "file_path": "src/foo.py",
         "additions": 50,
         "deletions": 20,
+    }
+    base.update(overrides)
+    return base
+
+
+def _valid_pipeline_run_row(**overrides) -> dict:
+    base = {
+        "run_id": "run-42",
+        "status": "success",
+        "queued_at": "2024-01-01T10:00:00",
+        "started_at": "2024-01-01T10:01:00",
+        "finished_at": "2024-01-01T10:05:00",
     }
     base.update(overrides)
     return base
@@ -390,3 +407,155 @@ class TestGeneratorCoherence:
             ],
         )
         validate_all(bundle)
+
+
+# ---------------------------------------------------------------------------
+# check_pipeline_runs
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPipelineRuns:
+    def test_valid_row_produces_no_violations(self) -> None:
+        assert check_pipeline_runs([_valid_pipeline_run_row()]) == []
+
+    def test_known_statuses_are_valid(self) -> None:
+        for status in (
+            "success",
+            "failure",
+            "failed",
+            "cancelled",
+            "canceled",
+            "timeout",
+            "running",
+            "queued",
+            "skipped",
+        ):
+            row = _valid_pipeline_run_row(status=status)
+            assert check_pipeline_runs([row]) == [], f"Expected {status!r} to be valid"
+
+    def test_unknown_status_is_violation(self) -> None:
+        row = _valid_pipeline_run_row(status="bogus_status")
+        violations = check_pipeline_runs([row])
+        assert len(violations) == 1
+        assert "bogus_status" in violations[0]
+
+    def test_started_before_queued_is_violation(self) -> None:
+        row = _valid_pipeline_run_row(
+            queued_at="2024-01-01T10:05:00",
+            started_at="2024-01-01T10:00:00",
+        )
+        violations = check_pipeline_runs([row])
+        assert any("started_at" in v and "queued_at" in v for v in violations)
+
+    def test_finished_before_started_is_violation(self) -> None:
+        row = _valid_pipeline_run_row(
+            started_at="2024-01-01T10:05:00",
+            finished_at="2024-01-01T10:00:00",
+        )
+        violations = check_pipeline_runs([row])
+        assert any("finished_at" in v and "started_at" in v for v in violations)
+
+    def test_missing_timestamps_are_ignored(self) -> None:
+        """Partial timestamps (e.g. still-running job) should not raise."""
+        row = _valid_pipeline_run_row(started_at=None, finished_at=None)
+        assert check_pipeline_runs([row]) == []
+
+    def test_none_status_is_ignored(self) -> None:
+        """Rows with no status field should not raise (optional field)."""
+        row = _valid_pipeline_run_row(status=None)
+        assert check_pipeline_runs([row]) == []
+
+    @pytest.mark.parametrize("seed", SEEDS)
+    def test_generator_pipeline_runs_are_coherent(self, seed: int) -> None:
+        gen = _make_gen(seed)
+        pipeline_runs = gen.generate_ci_pipeline_runs(days=14)
+        rows = [
+            {
+                "run_id": getattr(r, "run_id", None),
+                "status": getattr(r, "status", None),
+                "queued_at": getattr(r, "queued_at", None),
+                "started_at": getattr(r, "started_at", None),
+                "finished_at": getattr(r, "finished_at", None),
+            }
+            for r in pipeline_runs
+        ]
+        bundle = FixtureBundle(pipeline_runs=rows)
+        validate_all(bundle)
+
+
+# ---------------------------------------------------------------------------
+# Runner integration — validate_all is wired into run_fixtures_generation
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerCoherenceWiring:
+    """Prove that run_fixtures_generation calls validate_all.
+
+    We monkeypatch ``validate_all`` in the runner module to raise
+    ``CoherenceError`` unconditionally, then run a minimal generation
+    against an in-memory SQLite DB and assert the error propagates.
+    """
+
+    @pytest.mark.asyncio
+    async def test_coherence_error_propagates_from_runner(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        import dev_health_ops.fixtures.runner as runner_mod
+
+        def _always_raise(bundle):
+            raise CoherenceError(["deliberate violation injected by test"])
+
+        monkeypatch.setattr(runner_mod, "validate_all", _always_raise)
+
+        db_path = tmp_path / "test_coherence.db"
+        ns = argparse.Namespace(
+            sink=f"sqlite:///{db_path}",
+            db_type=None,
+            days=3,
+            commits_per_day=2,
+            pr_count=5,
+            seed=42,
+            provider="synthetic",
+            with_metrics=False,
+            with_work_graph=False,
+            team_count=2,
+            repo_count=1,
+            skip_coherence_validation=False,
+            repo_name="test/coherence-wire",
+        )
+        with pytest.raises(CoherenceError) as exc_info:
+            await runner_mod.run_fixtures_generation(ns)
+        assert "deliberate violation" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_skip_coherence_validation_bypasses_gate(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """--skip-coherence-validation=True means validate_all is never called."""
+        import dev_health_ops.fixtures.runner as runner_mod
+
+        called = []
+        monkeypatch.setattr(
+            runner_mod,
+            "validate_all",
+            lambda bundle: called.append(bundle),
+        )
+
+        db_path = tmp_path / "test_skip.db"
+        ns = argparse.Namespace(
+            sink=f"sqlite:///{db_path}",
+            db_type=None,
+            days=3,
+            commits_per_day=2,
+            pr_count=5,
+            seed=42,
+            provider="synthetic",
+            with_metrics=False,
+            with_work_graph=False,
+            team_count=2,
+            repo_count=1,
+            skip_coherence_validation=True,
+            repo_name="test/coherence-skip",
+        )
+        await runner_mod.run_fixtures_generation(ns)
+        assert called == [], "validate_all should not be called when skip flag is set"


### PR DESCRIPTION
## Summary

Extends the metric-coherence contract from `web/docs/metric-coherence.md` to the ops-side synthetic fixture generators so the live-backend demo cannot produce figures that silently contradict each other (Rule 1: figures must reconcile under their stated denominator, or the relationship must be explained).

**Invariants audited and enforced at generation time:**

| Domain | Invariant | Status |
|---|---|---|
| Coverage | `branch_coverage_pct ≤ line_coverage_pct` | Existing — documented |
| Coverage | `lines_covered ≤ lines_total`, `branches_covered ≤ branches_total` | Existing — documented |
| Test suites | `passed + failed + skipped + errors ≤ total_count` | **Fixed** — previous allocation overflowed when min-failed floor was applied |
| Work-item metrics | `*_unassigned ≤ parent total` for completed, started, WIP | **Fixed** — all three were independent random values |
| Work-item metrics | `cycle_time_p50 ≤ lead_time_p50` (lead = queue + cycle) | **Fixed** — was independently generated, violated the invariant |
| Work-item metrics | `p50 ≤ p90` for all percentile pairs | **Fixed** — lead_time pair was not monotone |
| Commit stats | `deletions ≤ additions` | Existing — documented |

**New files:**
- `src/dev_health_ops/fixtures/coherence.py` — `FixtureBundle` + `validate_all()` + per-domain `check_*` functions; collects all violations before raising `CoherenceError`
- `tests/fixtures/test_metric_coherence.py` — 67 unit tests: happy-path, per-invariant violation detection, and generator regression across 8 seeds
- `docs/implementation/fixture-metric-coherence.md` — ops-side mirror of `web/docs/metric-coherence.md`

## Test plan

- [x] `uv run pytest tests/fixtures/test_metric_coherence.py -v` — 67/67 pass
- [x] `uv run pytest tests/fixtures/ -v` — 97/97 pass (no regressions)
- [x] `bash ci/run_tests.sh` — full CI suite passes

SCREENSHOT-WAIVER: backend-only change, no rendered output.

Closes CHAOS-2040