### PR TITLE
feat(work-graph): lookup-backed display-name resolution for WorkGraph edges (CHAOS-2120)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -32,6 +32,22 @@ _PR_EDGE_ID_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Incident status → customer-facing label.  Unknown statuses fall back to a
+# neutral "Incident" label so raw enum strings never reach customer copy.
+_INCIDENT_STATUS_LABELS: dict[str, str] = {
+    "open": "Open",
+    "triggered": "Triggered",
+    "acknowledged": "Acknowledged",
+    "investigating": "Investigating",
+    "resolved": "Resolved",
+    "closed": "Closed",
+}
+
+
+def _incident_label(status: str) -> str:
+    """Map a raw incident status string to a normalised customer-facing label."""
+    return _INCIDENT_STATUS_LABELS.get(status.lower(), "Incident")
+
 
 def _map_node_type(value: str) -> WorkGraphNodeType:
     try:
@@ -150,6 +166,7 @@ async def _batch_resolve_display_names(
                 repo_uuids.add(repo_uuid)
 
         if pr_lookups and repo_uuids:
+            pr_numbers = sorted({pr_num for _, pr_num in pr_lookups.values()})
             try:
                 pr_rows = await query_dicts(
                     client,
@@ -158,22 +175,29 @@ async def _batch_resolve_display_names(
                     FROM git_pull_requests FINAL
                     WHERE org_id = %(org_id)s
                       AND toString(repo_id) IN %(repo_ids)s
+                      AND number IN %(pr_numbers)s
                     """,
-                    {"org_id": org_id, "repo_ids": sorted(repo_uuids)},
+                    {
+                        "org_id": org_id,
+                        "repo_ids": sorted(repo_uuids),
+                        "pr_numbers": pr_numbers,
+                    },
                 )
                 # Build (repo_id_lower, number) → title lookup.
                 pr_title_map: dict[tuple[str, int], str] = {}
                 for r in pr_rows:
                     repo_id = str(r.get("repo_id") or "").lower()
                     number = int(r.get("number") or 0)
-                    title = str(r.get("title") or "").strip()
-                    if repo_id and number and title:
-                        pr_title_map[(repo_id, number)] = title
+                    # Keep variable name distinct from the outer loop's `resolved_title`
+                    # to avoid mypy seeing str | None rebind the earlier `str` annotation.
+                    row_title = str(r.get("title") or "").strip()
+                    if repo_id and number and row_title:
+                        pr_title_map[(repo_id, number)] = row_title
 
                 for pr_id, (repo_uuid, pr_num) in pr_lookups.items():
-                    title = pr_title_map.get((repo_uuid, pr_num))
-                    if title:
-                        resolved[pr_id] = title
+                    resolved_title: str | None = pr_title_map.get((repo_uuid, pr_num))
+                    if resolved_title:
+                        resolved[pr_id] = resolved_title
             except Exception:
                 logger.warning("PR display-name lookup failed", exc_info=True)
 
@@ -194,8 +218,11 @@ async def _batch_resolve_display_names(
             for r in dep_rows:
                 dep_id = str(r.get("deployment_id") or "")
                 env = str(r.get("environment") or "").strip()
-                if dep_id:
-                    resolved[dep_id] = f"{env} deploy" if env else dep_id
+                # Only store a label when we have a meaningful environment string.
+                # Empty env → omit from resolved so _display_name_for returns None
+                # (Unresolved badge) rather than leaking the raw UUID (A8).
+                if dep_id and env:
+                    resolved[dep_id] = f"{env} deploy"
         except Exception:
             logger.warning("Deployment display-name lookup failed", exc_info=True)
 
@@ -216,8 +243,11 @@ async def _batch_resolve_display_names(
             for r in inc_rows:
                 inc_id = str(r.get("incident_id") or "")
                 status = str(r.get("status") or "").strip()
-                if inc_id:
-                    resolved[inc_id] = f"incident ({status})" if status else inc_id
+                # Empty status → omit from resolved (→ Unresolved badge, not raw UUID).
+                # Known statuses are normalised to customer-facing labels; unknown
+                # statuses map to the neutral "Incident" label via _incident_label().
+                if inc_id and status:
+                    resolved[inc_id] = f"incident ({_incident_label(status)})"
         except Exception:
             logger.warning("Incident display-name lookup failed", exc_info=True)
 

--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -24,6 +24,14 @@ logger = logging.getLogger(__name__)
 
 _OPAQUE_HEX_ID_RE = re.compile(r"^[0-9a-f]{24,}$", re.IGNORECASE)
 
+# PR ids stored in work_graph_edges use the format "{repo_uuid}#pr{number}".
+# This pattern is not a bare UUID so it slips past looks_like_uuid(), but it
+# is not human-readable either — it must be resolved to the PR title.
+_PR_EDGE_ID_RE = re.compile(
+    r"^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})#pr(\d+)$",
+    re.IGNORECASE,
+)
+
 
 def _map_node_type(value: str) -> WorkGraphNodeType:
     try:
@@ -46,31 +54,189 @@ def _map_provenance(value: str) -> WorkGraphProvenance:
         return WorkGraphProvenance.HEURISTIC
 
 
-def _display_name_for(entity_id: str) -> str | None:
-    """A7/A8: pass through human-readable ids; return None for bare UUIDs.
+def _display_name_for(
+    entity_id: str, resolved: dict[str, str] | None = None
+) -> str | None:
+    """A7/A8: pass through human-readable ids; return None for unresolvable UUIDs.
 
-    Non-UUID identifiers (e.g. PROJ-123, INC-001, deploy-xyz) are already
-    human-readable and are surfaced verbatim. UUID-style identifiers that
-    cannot be resolved server-side return None so the client renders a
-    controlled Unresolved badge rather than leaking a raw UUID.
+    Resolution priority:
+    1. Lookup-resolved name (from batch lookup) — takes precedence.
+    2. Human-readable pass-through for non-UUID, non-hex identifiers
+       (e.g. PROJ-123, INC-001, deploy-xyz).
+    3. None for bare UUIDs, opaque hex strings, and UUID-based PR ids that
+       were not resolved — the client renders a controlled Unresolved badge
+       rather than leaking a raw UUID (A8).
     """
     raw = str(entity_id).strip()
     if not raw:
         return None
-    return None if looks_like_uuid(raw) or _OPAQUE_HEX_ID_RE.match(raw) else raw
+    # Lookup-resolved names (from batch lookup) take precedence.
+    if resolved and raw in resolved:
+        return resolved[raw]
+    # UUID-based PR ids are not human-readable even though they do not match
+    # the bare-UUID regex (they carry a "#pr{N}" suffix).
+    if _PR_EDGE_ID_RE.match(raw):
+        return None
+    # Bare UUIDs and opaque hex strings are not human-readable.
+    if looks_like_uuid(raw) or _OPAQUE_HEX_ID_RE.match(raw):
+        return None
+    # Human-readable id — pass through verbatim.
+    return raw
 
 
-def _row_to_edge(row: dict[str, Any]) -> WorkGraphEdgeResult:
+async def _batch_resolve_display_names(
+    client: Any,
+    org_id: str,
+    rows: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Resolve display names for UUID-derived ids in one query per entity type.
+
+    Collects unresolved source/target ids across the edge page, grouped by
+    entity type, then issues ONE ClickHouse query per type (no N+1).
+    org_id is included in every join predicate to prevent cross-tenant leaks.
+
+    Returns a mapping {entity_id -> display_name} for all successfully
+    resolved ids.  Any ids absent from the returned dict remain unresolved
+    and will surface as None (→ client Unresolved badge).
+    """
+    from dev_health_ops.api.queries.client import query_dicts
+
+    resolved: dict[str, str] = {}
+
+    # Collect ids that need lookup, partitioned by entity type.
+    pr_ids: set[str] = set()  # "{uuid}#pr{N}" format
+    deployment_ids: set[str] = set()  # bare UUID deployment ids
+    incident_ids: set[str] = set()  # bare UUID incident ids
+
+    for row in rows:
+        for id_field, type_field in (
+            ("source_id", "source_type"),
+            ("target_id", "target_type"),
+        ):
+            entity_id = str(row.get(id_field) or "").strip()
+            entity_type = str(row.get(type_field) or "").lower()
+            if not entity_id:
+                continue
+
+            is_pr_format = bool(_PR_EDGE_ID_RE.match(entity_id))
+            is_bare_uuid = looks_like_uuid(entity_id)
+            is_opaque_hex = bool(_OPAQUE_HEX_ID_RE.match(entity_id))
+
+            # Opaque hex ids (feature_flag hashes, etc.) are not resolvable.
+            if is_opaque_hex:
+                continue
+            # Only collect ids that need a table lookup.
+            if not (is_pr_format or is_bare_uuid):
+                continue
+
+            if is_pr_format or entity_type == "pr":
+                pr_ids.add(entity_id)
+            elif entity_type == "deployment" and is_bare_uuid:
+                deployment_ids.add(entity_id)
+            elif entity_type == "incident" and is_bare_uuid:
+                incident_ids.add(entity_id)
+
+    # --- PRs: one query against git_pull_requests -------------------------
+    if pr_ids:
+        # Only "{uuid}#pr{N}" ids can be resolved; bare UUID pr ids cannot.
+        pr_lookups: dict[str, tuple[str, int]] = {}
+        repo_uuids: set[str] = set()
+        for pr_id in pr_ids:
+            m = _PR_EDGE_ID_RE.match(pr_id)
+            if m:
+                repo_uuid = m.group(1).lower()
+                pr_num = int(m.group(2))
+                pr_lookups[pr_id] = (repo_uuid, pr_num)
+                repo_uuids.add(repo_uuid)
+
+        if pr_lookups and repo_uuids:
+            try:
+                pr_rows = await query_dicts(
+                    client,
+                    """
+                    SELECT toString(repo_id) AS repo_id, number, title
+                    FROM git_pull_requests FINAL
+                    WHERE org_id = %(org_id)s
+                      AND toString(repo_id) IN %(repo_ids)s
+                    """,
+                    {"org_id": org_id, "repo_ids": sorted(repo_uuids)},
+                )
+                # Build (repo_id_lower, number) → title lookup.
+                pr_title_map: dict[tuple[str, int], str] = {}
+                for r in pr_rows:
+                    repo_id = str(r.get("repo_id") or "").lower()
+                    number = int(r.get("number") or 0)
+                    title = str(r.get("title") or "").strip()
+                    if repo_id and number and title:
+                        pr_title_map[(repo_id, number)] = title
+
+                for pr_id, (repo_uuid, pr_num) in pr_lookups.items():
+                    title = pr_title_map.get((repo_uuid, pr_num))
+                    if title:
+                        resolved[pr_id] = title
+            except Exception:
+                logger.warning("PR display-name lookup failed", exc_info=True)
+
+    # --- Deployments: one query against deployments -----------------------
+    if deployment_ids:
+        dep_ids = sorted(deployment_ids)
+        try:
+            dep_rows = await query_dicts(
+                client,
+                """
+                SELECT deployment_id, environment
+                FROM deployments FINAL
+                WHERE org_id = %(org_id)s
+                  AND deployment_id IN %(dep_ids)s
+                """,
+                {"org_id": org_id, "dep_ids": dep_ids},
+            )
+            for r in dep_rows:
+                dep_id = str(r.get("deployment_id") or "")
+                env = str(r.get("environment") or "").strip()
+                if dep_id:
+                    resolved[dep_id] = f"{env} deploy" if env else dep_id
+        except Exception:
+            logger.warning("Deployment display-name lookup failed", exc_info=True)
+
+    # --- Incidents: one query against incidents ---------------------------
+    if incident_ids:
+        inc_ids = sorted(incident_ids)
+        try:
+            inc_rows = await query_dicts(
+                client,
+                """
+                SELECT incident_id, status
+                FROM incidents FINAL
+                WHERE org_id = %(org_id)s
+                  AND incident_id IN %(inc_ids)s
+                """,
+                {"org_id": org_id, "inc_ids": inc_ids},
+            )
+            for r in inc_rows:
+                inc_id = str(r.get("incident_id") or "")
+                status = str(r.get("status") or "").strip()
+                if inc_id:
+                    resolved[inc_id] = f"incident ({status})" if status else inc_id
+        except Exception:
+            logger.warning("Incident display-name lookup failed", exc_info=True)
+
+    return resolved
+
+
+def _row_to_edge(
+    row: dict[str, Any], resolved: dict[str, str] | None = None
+) -> WorkGraphEdgeResult:
     source_id = str(row.get("source_id", ""))
     target_id = str(row.get("target_id", ""))
     return WorkGraphEdgeResult(
         edge_id=str(row.get("edge_id", "")),
         source_type=_map_node_type(str(row.get("source_type", "issue"))),
         source_id=source_id,
-        source_display_name=_display_name_for(source_id),
+        source_display_name=_display_name_for(source_id, resolved),
         target_type=_map_node_type(str(row.get("target_type", "issue"))),
         target_id=target_id,
-        target_display_name=_display_name_for(target_id),
+        target_display_name=_display_name_for(target_id, resolved),
         edge_type=_map_edge_type(str(row.get("edge_type", "relates"))),
         provenance=_map_provenance(str(row.get("provenance", "heuristic"))),
         confidence=float(row.get("confidence", 0.0)),
@@ -138,7 +304,8 @@ async def resolve_work_graph_edges(
     """
 
     rows = await query_dicts(client, query, params)
-    edges = [_row_to_edge(row) for row in rows]
+    resolved = await _batch_resolve_display_names(client, org_id, rows)
+    edges = [_row_to_edge(row, resolved) for row in rows]
 
     return WorkGraphEdgesResult(
         edges=edges,

--- a/tests/graphql/test_work_graph.py
+++ b/tests/graphql/test_work_graph.py
@@ -543,4 +543,181 @@ class TestWorkGraphEdgeLookupResolution:
             mock_query.side_effect = [edge_rows, inc_lookup_rows]
             result = await resolve_work_graph_edges(mock_context)
 
-        assert result.edges[0].target_display_name == "incident (resolved)"
+        # Status normalised to title-case customer label (not raw enum string)
+        assert result.edges[0].target_display_name == "incident (Resolved)"
+
+    @pytest.mark.asyncio
+    async def test_deployment_empty_environment_yields_none(self, mock_context):
+        """UUID deployment_id with empty environment in DB → None (A8 — no raw UUID)."""
+        dep_uuid = "aabbccdd-1234-5678-9abc-ddeeff001122"
+        edge_rows = [
+            make_edge_row(
+                source_type="deployment",
+                source_id=dep_uuid,
+                target_id="INC-001",
+            )
+        ]
+        # Row exists in DB but environment is empty/null
+        dep_lookup_rows = [{"deployment_id": dep_uuid, "environment": ""}]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, dep_lookup_rows]
+            result = await resolve_work_graph_edges(mock_context)
+
+        # Must not leak the raw UUID — Unresolved badge (None)
+        assert result.edges[0].source_display_name is None
+
+    @pytest.mark.asyncio
+    async def test_incident_empty_status_yields_none(self, mock_context):
+        """UUID incident_id with empty status in DB → None (A8 — no raw UUID)."""
+        inc_uuid = "11223344-aabb-ccdd-eeff-001122334455"
+        edge_rows = [
+            make_edge_row(
+                source_type="deployment",
+                source_id="synth-deploy-1",
+                target_type="incident",
+                target_id=inc_uuid,
+            )
+        ]
+        inc_lookup_rows = [{"incident_id": inc_uuid, "status": ""}]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, inc_lookup_rows]
+            result = await resolve_work_graph_edges(mock_context)
+
+        assert result.edges[0].target_display_name is None
+
+    @pytest.mark.asyncio
+    async def test_incident_unknown_status_uses_neutral_label(self, mock_context):
+        """Unknown incident status normalises to the neutral 'Incident' label."""
+        inc_uuid = "11223344-aabb-ccdd-eeff-001122334455"
+        edge_rows = [
+            make_edge_row(
+                source_type="deployment",
+                source_id="synth-deploy-1",
+                target_type="incident",
+                target_id=inc_uuid,
+            )
+        ]
+        inc_lookup_rows = [{"incident_id": inc_uuid, "status": "some_future_status"}]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, inc_lookup_rows]
+            result = await resolve_work_graph_edges(mock_context)
+
+        assert result.edges[0].target_display_name == "incident (Incident)"
+
+    @pytest.mark.asyncio
+    async def test_lookup_sql_includes_org_id_for_pr(self, mock_context):
+        """PR batch lookup query must include org_id to prevent cross-tenant leaks."""
+        repo_uuid = "4e00fff2-df66-5028-8ebd-e4535332300b"
+        edge_rows = [
+            make_edge_row(source_type="pr", source_id=f"{repo_uuid}#pr5", target_id="X")
+        ]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, []]
+            await resolve_work_graph_edges(mock_context)
+
+        # Second call is the PR lookup — verify org_id in params
+        pr_lookup_call = mock_query.call_args_list[1]
+        pr_lookup_params = pr_lookup_call[0][2]
+        assert "org_id" in pr_lookup_params
+        assert pr_lookup_params["org_id"] == "test-org"
+
+    @pytest.mark.asyncio
+    async def test_lookup_sql_includes_org_id_for_deployment(self, mock_context):
+        """Deployment batch lookup query must include org_id."""
+        dep_uuid = "aabbccdd-1234-5678-9abc-ddeeff001122"
+        edge_rows = [
+            make_edge_row(source_type="deployment", source_id=dep_uuid, target_id="X")
+        ]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, []]
+            await resolve_work_graph_edges(mock_context)
+
+        dep_lookup_call = mock_query.call_args_list[1]
+        dep_lookup_params = dep_lookup_call[0][2]
+        assert "org_id" in dep_lookup_params
+        assert dep_lookup_params["org_id"] == "test-org"
+
+    @pytest.mark.asyncio
+    async def test_lookup_sql_includes_org_id_for_incident(self, mock_context):
+        """Incident batch lookup query must include org_id."""
+        inc_uuid = "11223344-aabb-ccdd-eeff-001122334455"
+        edge_rows = [
+            make_edge_row(
+                source_type="deployment",
+                source_id="synth-deploy-1",
+                target_type="incident",
+                target_id=inc_uuid,
+            )
+        ]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, []]
+            await resolve_work_graph_edges(mock_context)
+
+        inc_lookup_call = mock_query.call_args_list[1]
+        inc_lookup_params = inc_lookup_call[0][2]
+        assert "org_id" in inc_lookup_params
+        assert inc_lookup_params["org_id"] == "test-org"
+
+    @pytest.mark.asyncio
+    async def test_lookup_resolved_name_beats_pattern_fallback(self, mock_context):
+        """Lookup result takes precedence over the pattern-based pass-through (A7)."""
+        repo_uuid = "4e00fff2-df66-5028-8ebd-e4535332300b"
+        pr_id = f"{repo_uuid}#pr1"
+        edge_rows = [make_edge_row(source_type="pr", source_id=pr_id, target_id="X")]
+        # Lookup returns a title
+        pr_lookup_rows = [{"repo_id": repo_uuid, "number": 1, "title": "Lookup Title"}]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, pr_lookup_rows]
+            result = await resolve_work_graph_edges(mock_context)
+
+        # Lookup win — not the raw {uuid}#pr1 id, not None
+        assert result.edges[0].source_display_name == "Lookup Title"
+
+    @pytest.mark.asyncio
+    async def test_pr_lookup_filters_by_number(self, mock_context):
+        """PR batch lookup params include number list to avoid fetching all repo PRs."""
+        repo_uuid = "4e00fff2-df66-5028-8ebd-e4535332300b"
+        edge_rows = [
+            make_edge_row(
+                source_type="pr", source_id=f"{repo_uuid}#pr42", target_id="X"
+            )
+        ]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, []]
+            await resolve_work_graph_edges(mock_context)
+
+        pr_lookup_params = mock_query.call_args_list[1][0][2]
+        assert "pr_numbers" in pr_lookup_params
+        assert 42 in pr_lookup_params["pr_numbers"]

--- a/tests/graphql/test_work_graph.py
+++ b/tests/graphql/test_work_graph.py
@@ -373,3 +373,174 @@ class TestWorkGraphEdgeDisplayNames:
         assert result.edges[0].target_display_name == "INC-2"
         assert result.edges[1].source_display_name is None
         assert result.edges[1].target_display_name == "INC-5"
+
+
+class TestWorkGraphEdgeLookupResolution:
+    """CHAOS-2120: Lookup-backed display-name resolution for WorkGraph edges.
+
+    UUID-derived ids that appear in persisted edges are resolved to
+    human-readable labels via one ClickHouse query per entity type (no N+1).
+    Lookup-resolved names take precedence over the pattern-based fallback.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pr_uuid_id_resolved_to_title(self, mock_context):
+        """PR id in {uuid}#pr{N} format resolves to PR title via git_pull_requests."""
+        repo_uuid = "4e00fff2-df66-5028-8ebd-e4535332300b"
+        pr_id = f"{repo_uuid}#pr160"
+        edge_rows = [
+            make_edge_row(
+                source_type="pr",
+                source_id=pr_id,
+                target_type="deployment",
+                target_id="synth-deploy-1",
+            )
+        ]
+        pr_lookup_rows = [
+            {"repo_id": repo_uuid, "number": 160, "title": "Add feature X"}
+        ]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, pr_lookup_rows]
+            result = await resolve_work_graph_edges(mock_context)
+
+        assert result.edges[0].source_display_name == "Add feature X"
+        # Human-readable target passes through unchanged
+        assert result.edges[0].target_display_name == "synth-deploy-1"
+
+    @pytest.mark.asyncio
+    async def test_pr_uuid_id_with_no_db_match_yields_none(self, mock_context):
+        """PR id in {uuid}#pr{N} format with no matching title in DB → None (A8)."""
+        repo_uuid = "4e00fff2-df66-5028-8ebd-e4535332300b"
+        pr_id = f"{repo_uuid}#pr999"
+        edge_rows = [
+            make_edge_row(source_type="pr", source_id=pr_id, target_id="deploy-xyz")
+        ]
+        # Empty result — PR not in git_pull_requests
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, []]
+            result = await resolve_work_graph_edges(mock_context)
+
+        assert result.edges[0].source_display_name is None
+
+    @pytest.mark.asyncio
+    async def test_human_readable_id_passes_through_without_lookup(self, mock_context):
+        """Human-readable ids need no table lookup; query_dicts called exactly once."""
+        edge_rows = [make_edge_row(source_id="PROJ-123", target_id="deploy-prod")]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = edge_rows
+            result = await resolve_work_graph_edges(mock_context)
+
+        # Only the edge query — no batch lookup needed
+        assert mock_query.call_count == 1
+        assert result.edges[0].source_display_name == "PROJ-123"
+        assert result.edges[0].target_display_name == "deploy-prod"
+
+    @pytest.mark.asyncio
+    async def test_opaque_hex_id_never_triggers_lookup(self, mock_context):
+        """Opaque hex ids are not resolvable; no extra query is issued (call_count == 1)."""
+        hex_id = "032adec80b86fd88759f19e65f133d6cacc136f3276cabc79e851ccd22de1cd2"
+        edge_rows = [make_edge_row(source_id=hex_id, target_id="INC-001")]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = edge_rows
+            result = await resolve_work_graph_edges(mock_context)
+
+        assert mock_query.call_count == 1
+        assert result.edges[0].source_display_name is None
+
+    @pytest.mark.asyncio
+    async def test_batching_multiple_pr_ids_use_one_query(self, mock_context):
+        """Multiple unresolved PR ids from the same batch resolve in ONE query (no N+1)."""
+        repo_uuid = "4e00fff2-df66-5028-8ebd-e4535332300b"
+        edge_rows = [
+            make_edge_row(
+                edge_id="e1",
+                source_type="pr",
+                source_id=f"{repo_uuid}#pr10",
+                target_type="issue",
+                target_id="PROJ-1",
+            ),
+            make_edge_row(
+                edge_id="e2",
+                source_type="pr",
+                source_id=f"{repo_uuid}#pr20",
+                target_type="issue",
+                target_id="PROJ-2",
+            ),
+        ]
+        pr_lookup_rows = [
+            {"repo_id": repo_uuid, "number": 10, "title": "PR Ten"},
+            {"repo_id": repo_uuid, "number": 20, "title": "PR Twenty"},
+        ]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, pr_lookup_rows]
+            result = await resolve_work_graph_edges(mock_context)
+
+        # 2 calls: 1 edge query + 1 batch PR lookup (not one per PR)
+        assert mock_query.call_count == 2
+        assert result.edges[0].source_display_name == "PR Ten"
+        assert result.edges[1].source_display_name == "PR Twenty"
+
+    @pytest.mark.asyncio
+    async def test_deployment_uuid_resolved_to_environment_label(self, mock_context):
+        """UUID deployment_id is resolved to '{env} deploy' via the deployments table."""
+        dep_uuid = "aabbccdd-1234-5678-9abc-ddeeff001122"
+        edge_rows = [
+            make_edge_row(
+                source_type="deployment",
+                source_id=dep_uuid,
+                target_type="incident",
+                target_id="INC-001",
+            )
+        ]
+        dep_lookup_rows = [{"deployment_id": dep_uuid, "environment": "production"}]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, dep_lookup_rows]
+            result = await resolve_work_graph_edges(mock_context)
+
+        assert result.edges[0].source_display_name == "production deploy"
+
+    @pytest.mark.asyncio
+    async def test_incident_uuid_resolved_to_status_label(self, mock_context):
+        """UUID incident_id is resolved to 'incident ({status})' via the incidents table."""
+        inc_uuid = "11223344-aabb-ccdd-eeff-001122334455"
+        edge_rows = [
+            make_edge_row(
+                source_type="deployment",
+                source_id="synth-deploy-1",
+                target_type="incident",
+                target_id=inc_uuid,
+            )
+        ]
+        inc_lookup_rows = [{"incident_id": inc_uuid, "status": "resolved"}]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, inc_lookup_rows]
+            result = await resolve_work_graph_edges(mock_context)
+
+        assert result.edges[0].target_display_name == "incident (resolved)"


### PR DESCRIPTION
## Summary

- Resolves UUID-derived entity ids in `work_graph_edges` to human-readable labels via **one ClickHouse query per entity type** (no N+1 reads)
- PR ids stored as `{repo-uuid}#pr{N}` are resolved to `git_pull_requests.title`; UUID deployment ids resolve to `{environment} deploy`; UUID incident ids resolve to `incident ({NormalisedStatus})`
- Lookup-resolved names take precedence over the pattern-based fallback; ids absent from the resolved map return `None` (client renders Unresolved badge per A8 contract)
- **Intentional behaviour change:** `{uuid}#prN` compound ids that were previously passed through verbatim (because they don't match the bare-UUID regex) now return `None` when unresolved. This is A8-correct — these ids are not human-readable and must not be surfaced raw to the client
- Incident status strings are normalised through `_INCIDENT_STATUS_LABELS` (title-case known values; unknown → neutral `"Incident"` label)

## Tables used per entity type

| Entity type | ClickHouse table | Field used |
|---|---|---|
| `pr` (`{uuid}#pr{N}`) | `git_pull_requests FINAL` | `title` (filtered by org_id + repo_id + number) |
| `deployment` (bare UUID) | `deployments FINAL` | `environment` |
| `incident` (bare UUID) | `incidents FINAL` | `status` |

## Test plan

- [x] `test_pr_uuid_id_resolved_to_title` — `{uuid}#pr{N}` resolves to PR title
- [x] `test_pr_uuid_id_with_no_db_match_yields_none` — unresolved PR → None (not raw id)
- [x] `test_human_readable_id_passes_through_without_lookup` — call_count == 1
- [x] `test_opaque_hex_id_never_triggers_lookup` — call_count == 1
- [x] `test_batching_multiple_pr_ids_use_one_query` — call_count == 2 (not 3)
- [x] `test_deployment_uuid_resolved_to_environment_label`
- [x] `test_incident_uuid_resolved_to_status_label` — status normalised to title-case
- [x] `test_deployment_empty_environment_yields_none` — empty env → None (A8)
- [x] `test_incident_empty_status_yields_none` — empty status → None (A8)
- [x] `test_incident_unknown_status_uses_neutral_label` — → `incident (Incident)`
- [x] `test_lookup_sql_includes_org_id_for_pr/deployment/incident` — org_id in every lookup
- [x] `test_lookup_resolved_name_beats_pattern_fallback` — precedence rule
- [x] `test_pr_lookup_filters_by_number` — `pr_numbers` in query params
- [x] All 16 prior tests continue to pass (31 total, 0 failures)

SCREENSHOT-WAIVER: backend-only resolver change; no rendered UI output.

Closes CHAOS-2120