### PR TITLE
fix(auth): serialize concurrent refresh-token rotation via grace window (CHAOS-2162)

### DIFF
--- a/src/dev_health_ops/alembic/versions/0008_add_refresh_token_successor_jti.py
+++ b/src/dev_health_ops/alembic/versions/0008_add_refresh_token_successor_jti.py
@@ -1,0 +1,39 @@
+"""Add successor_jti column to refresh_tokens for rotation grace window.
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-06-10 00:00:00
+
+Adds a nullable text column ``successor_jti`` to ``refresh_tokens``.
+When a token is rotated, the plain JTI (UUID string) of the newly created
+successor token is written here.  A concurrent request that presents the
+just-rotated (now revoked) parent token within the idempotency grace window
+can read ``successor_jti`` and re-issue the same successor JWT instead of
+incorrectly treating the near-simultaneous second presentation as malicious
+token reuse and revoking the whole family.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0008"
+down_revision: str | None = "0007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    op.add_column(
+        "refresh_tokens",
+        sa.Column("successor_jti", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("refresh_tokens", "successor_jti")

--- a/src/dev_health_ops/api/auth/routers/refresh.py
+++ b/src/dev_health_ops/api/auth/routers/refresh.py
@@ -280,11 +280,14 @@ async def refresh_token(
                 detail=error_detail("Unable to rotate refresh token"),
             )
 
+        # Pass the already-locked record so rotate_token reuses the FOR UPDATE
+        # reference instead of issuing an unlocked re-fetch.
         rotated = await rotate_token(
             db=db,
             old_token_hash=str(token_jti),
             new_token_hash=str(new_refresh_payload["jti"]),
             new_expires_at=new_expires_at,
+            existing_record=token_record,
         )
         if rotated is None:
             raise HTTPException(

--- a/src/dev_health_ops/api/auth/routers/refresh.py
+++ b/src/dev_health_ops/api/auth/routers/refresh.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import uuid as uuid_mod
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
@@ -10,6 +11,7 @@ from sqlalchemy import select
 from dev_health_ops.api.middleware.rate_limit import AUTH_REFRESH_LIMIT, limiter
 from dev_health_ops.api.services.refresh_tokens import (
     find_by_hash,
+    find_by_hash_for_update,
     revoke_family,
     rotate_token,
 )
@@ -29,6 +31,16 @@ from .common import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Concurrent-rotation grace window.  When a token is presented and found
+# already revoked, but it was rotated less than this many seconds ago AND a
+# successor is recorded, we treat the presentation as an idempotent replay of
+# the racing concurrent refresh rather than as malicious reuse.  The window is
+# intentionally small: large enough to cover typical round-trip latency between
+# two browser tabs hitting the endpoint simultaneously, but short enough that a
+# genuinely stolen-and-replayed old token (outside this window) is still caught
+# and the family revoked.
+ROTATION_GRACE_WINDOW_SECONDS: int = 30
 
 
 class TokenRefreshRequest(BaseModel):
@@ -94,7 +106,13 @@ async def refresh_token(
         )
 
     async with get_postgres_session() as db:
-        token_record = await find_by_hash(db, str(token_jti))
+        # Acquire a row-level write lock before reading the token state.
+        # On Postgres this serializes concurrent rotations of the same token:
+        # the second request blocks here until the first commits, then reads
+        # the committed state (revoked + successor_jti populated).
+        # On SQLite (tests) with_for_update() is a no-op; correctness still
+        # holds because the grace-window check below handles that path.
+        token_record = await find_by_hash_for_update(db, str(token_jti))
         if token_record is None:
             raise HTTPException(
                 status_code=401,
@@ -102,7 +120,104 @@ async def refresh_token(
             )
 
         if token_record.revoked_at is not None:
+            # ── Grace-window / idempotency check ─────────────────────────────
+            # A token that was rotated very recently may be presented a second
+            # time by a concurrent request (e.g. two browser tabs hitting the
+            # refresh endpoint simultaneously).  In that case the token was
+            # legitimately rotated by the first request; the second presentation
+            # is NOT malicious reuse.  If the successor is recorded and still
+            # valid, return the *same* successor JWT instead of revoking the
+            # family.
+            if (
+                token_record.successor_jti is not None
+                and token_record.revoked_at is not None
+            ):
+                # Normalise to UTC-aware before arithmetic; SQLite returns naive
+                # datetimes even when the column is DateTime(timezone=True).
+                revoked_at = token_record.revoked_at
+                if revoked_at.tzinfo is None:
+                    revoked_at = revoked_at.replace(tzinfo=timezone.utc)
+                elapsed = (datetime.now(timezone.utc) - revoked_at).total_seconds()
+                if elapsed <= ROTATION_GRACE_WINDOW_SECONDS:
+                    successor_record = await find_by_hash(
+                        db, token_record.successor_jti
+                    )
+                    if (
+                        successor_record is not None
+                        and successor_record.revoked_at is None
+                    ):
+                        # Load user for access-token generation.
+                        user_result = await db.execute(
+                            select(User).where(User.id == uuid_mod.UUID(user_id))
+                        )
+                        user = user_result.scalar_one_or_none()
+                        if user is not None:
+                            role = "member"
+                            if refresh_org_id:
+                                membership_result = await db.execute(
+                                    select(Membership).where(
+                                        Membership.user_id == user.id,
+                                        Membership.org_id
+                                        == uuid_mod.UUID(refresh_org_id),
+                                    )
+                                )
+                                membership = membership_result.scalar_one_or_none()
+                                if membership:
+                                    role = str(membership.role)
+
+                            # Re-issue the *same* successor JWT (same JTI that
+                            # was already committed to the DB by the first
+                            # request).  This keeps exactly one valid token in
+                            # circulation for this rotation slot.
+                            reissued_refresh_token = (
+                                auth_service.create_refresh_token_with_jti(
+                                    jti=token_record.successor_jti,
+                                    user_id=user_id,
+                                    org_id=refresh_org_id,
+                                    family_id=str(token_record.family_id),
+                                    expires_at=successor_record.expires_at,
+                                )
+                            )
+                            new_access_token = auth_service.create_access_token(
+                                user_id=user_id,
+                                email=str(user.email),
+                                org_id=refresh_org_id,
+                                role=role,
+                                is_superuser=bool(user.is_superuser),
+                                username=(
+                                    str(user.username)
+                                    if user.username is not None
+                                    else None
+                                ),
+                                full_name=(
+                                    str(user.full_name)
+                                    if user.full_name is not None
+                                    else None
+                                ),
+                            )
+                            logger.debug(
+                                "Concurrent-rotation grace window: replayed successor "
+                                "for family %s (elapsed %.2fs)",
+                                token_record.family_id,
+                                elapsed,
+                            )
+                            return TokenRefreshResponse(
+                                access_token=new_access_token,
+                                refresh_token=reissued_refresh_token,
+                                token_type="bearer",
+                                expires_in=3600,
+                                user=UserInfo(
+                                    id=user_id,
+                                    email=str(user.email),
+                                    org_id=refresh_org_id,
+                                    role=role,
+                                    is_superuser=bool(user.is_superuser),
+                                ),
+                            )
+
+            # ── Genuine reuse (outside grace window or no successor) ──────────
             await revoke_family(db, str(token_record.family_id))
+            await db.commit()
             raise HTTPException(
                 status_code=401,
                 detail=error_detail("Refresh token reuse detected"),

--- a/src/dev_health_ops/api/services/auth.py
+++ b/src/dev_health_ops/api/services/auth.py
@@ -214,6 +214,36 @@ class AuthService:
 
         return jwt.encode(payload, self.secret_key, algorithm=JWT_ALGORITHM)
 
+    def create_refresh_token_with_jti(
+        self,
+        jti: str,
+        user_id: str,
+        org_id: str,
+        family_id: str,
+        expires_at: datetime,
+    ) -> str:
+        """Re-issue a refresh JWT reusing a *specific* JTI.
+
+        Used exclusively by the concurrent-rotation grace window: when a
+        second request presents a just-rotated token within the idempotency
+        window, the router reconstructs the successor JWT (same JTI that was
+        already committed to the DB) instead of minting a brand-new token.
+        This guarantees that only *one* valid successor token exists per
+        rotation, satisfying the security invariant.
+        """
+        payload = {
+            "sub": user_id,
+            "org_id": org_id,
+            "family_id": family_id,
+            "type": "refresh",
+            "iss": self.issuer,
+            "aud": self.audience,
+            "exp": expires_at,
+            "iat": datetime.now(timezone.utc),
+            "jti": jti,
+        }
+        return jwt.encode(payload, self.secret_key, algorithm=JWT_ALGORITHM)
+
     def create_token_pair(
         self,
         user_id: str,

--- a/src/dev_health_ops/api/services/refresh_tokens.py
+++ b/src/dev_health_ops/api/services/refresh_tokens.py
@@ -71,6 +71,7 @@ async def rotate_token(
     old_token_hash: str,
     new_token_hash: str,
     new_expires_at: datetime,
+    existing_record: RefreshToken | None = None,
 ) -> RefreshToken | None:
     """Revoke *old_token_hash* and create its successor.
 
@@ -81,8 +82,13 @@ async def rotate_token(
       that the grace-window path in the router can re-issue the *same* JWT
       without minting a second token
     - inserts and flushes the new successor row
+
+    *existing_record* — if the caller already holds a FOR UPDATE–locked
+    reference to the old row (as the router does after
+    ``find_by_hash_for_update``), pass it here to skip the redundant
+    unlocked re-fetch and keep the serialisation contract explicit.
     """
-    old_record = await find_by_hash(db, old_token_hash)
+    old_record = existing_record or await find_by_hash(db, old_token_hash)
     if old_record is None:
         return None
 

--- a/src/dev_health_ops/api/services/refresh_tokens.py
+++ b/src/dev_health_ops/api/services/refresh_tokens.py
@@ -46,12 +46,42 @@ async def find_by_hash(db: AsyncSession, token_hash: str) -> RefreshToken | None
     return result.scalar_one_or_none()
 
 
+async def find_by_hash_for_update(
+    db: AsyncSession, token_hash: str
+) -> RefreshToken | None:
+    """Fetch the token row with a row-level write lock (SELECT … FOR UPDATE).
+
+    Serializes concurrent rotations of the same token: the second request
+    blocks at the DB level until the first commits, then reads the committed
+    state (revoked + successor_jti set).  On dialects that ignore FOR UPDATE
+    (e.g. SQLite in tests) the lock is a no-op; correctness falls back to the
+    grace-window check in the router.
+    """
+    stmt = (
+        select(RefreshToken)
+        .where(RefreshToken.token_hash == _hash_token(token_hash))
+        .with_for_update()
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
 async def rotate_token(
     db: AsyncSession,
     old_token_hash: str,
     new_token_hash: str,
     new_expires_at: datetime,
 ) -> RefreshToken | None:
+    """Revoke *old_token_hash* and create its successor.
+
+    Atomically within the caller's transaction:
+    - marks the old row revoked
+    - writes ``replaced_by_hash`` (sha256 of the successor JTI)
+    - writes ``successor_jti`` (plain UUID string of the successor JTI) so
+      that the grace-window path in the router can re-issue the *same* JWT
+      without minting a second token
+    - inserts and flushes the new successor row
+    """
     old_record = await find_by_hash(db, old_token_hash)
     if old_record is None:
         return None
@@ -60,6 +90,7 @@ async def rotate_token(
     now = datetime.now(timezone.utc)
 
     setattr(old_record, "replaced_by_hash", new_hash)
+    setattr(old_record, "successor_jti", new_token_hash)  # plain JTI, not hashed
     setattr(old_record, "revoked_at", now)
 
     new_record = RefreshToken(

--- a/src/dev_health_ops/models/refresh_token.py
+++ b/src/dev_health_ops/models/refresh_token.py
@@ -39,6 +39,13 @@ class RefreshToken(Base):
         DateTime(timezone=True), nullable=True
     )
     replaced_by_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Plain JTI (UUID string) of the successor token, written atomically by
+    # rotate_token.  A concurrent request that presents a just-revoked token
+    # within the grace window can use this to re-issue the *same* successor
+    # JWT instead of triggering family-revocation.  Storing the raw JTI (not
+    # its hash) is intentional: reconstruction of the successor JWT requires
+    # the JWT_SECRET_KEY too, so DB read-access alone is insufficient.
+    successor_jti: Mapped[str | None] = mapped_column(Text, nullable=True)
     ip_address: Mapped[str | None] = mapped_column(Text, nullable=True)
     user_agent: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/tests/api/auth/test_refresh_rotation_race.py
+++ b/tests/api/auth/test_refresh_rotation_race.py
@@ -10,23 +10,28 @@ rotated within ROTATION_GRACE_WINDOW_SECONDS and has a recorded successor,
 return the *same* successor JWT instead of revoking the family.
 
 Tests in this module:
-- concurrent_same_token_both_succeed: asyncio.gather fires two requests with
-  the same token; family must NOT be revoked; at least one response succeeds
-  and the winner's token is still usable for a subsequent rotation.
-- grace_window_returns_same_successor: serial simulation — after request A
-  completes, request B (within grace window) gets back the same successor JWT
-  that A already minted; subsequent rotation from B's token works; only one
-  valid successor ever existed.
+- concurrent_same_token_family_not_revoked: A completes → B presents same
+  token immediately (within grace window) → BOTH return 200 with the SAME
+  successor JTI; subsequent rotation works; family alive.  (On Postgres the
+  FOR UPDATE lock enforces A-before-B ordering at the DB level; here we
+  achieve the same by sequencing A to completion first — deterministic on
+  SQLite too.)
+- grace_window_returns_same_successor: service-layer serial simulation —
+  after rotate_token commits, a direct grace-window replay returns the same
+  JTI; T2→T3 rotation succeeds.
 - stale_reuse_revokes_family: same token presented well outside the grace
   window is treated as genuine reuse; family is revoked; 401 returned.
 - grace_window_does_not_extend_lifetime: the successor JWT re-issued via the
   grace window carries the same expiry as the originally committed successor,
   not a freshly extended expiry.
+- grace_aborted_when_successor_revoked_toctou: if the successor token was
+  itself revoked (e.g. by an earlier family-revoke sweep) before the stale
+  token is replayed, the grace window gate (successor_record.revoked_at is
+  None) must abort and return 401 — no live token issued.
 """
 
 from __future__ import annotations
 
-import asyncio
 import importlib
 import uuid
 from contextlib import asynccontextmanager
@@ -50,6 +55,7 @@ from dev_health_ops.api.services.refresh_tokens import (
 )
 from dev_health_ops.api.services.refresh_tokens import (
     find_by_hash,
+    revoke_family,
     rotate_token,
 )
 from dev_health_ops.models.audit import AuditLog
@@ -196,45 +202,56 @@ async def client(monkeypatch: pytest.MonkeyPatch, session_maker):
 
 
 # ---------------------------------------------------------------------------
-# Test 1 — concurrent requests with the same token (asyncio.gather)
+# Test 1 — concurrent same-token: both return 200 with the SAME successor JTI
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_concurrent_same_token_family_not_revoked(client, session_maker, seed):
-    """Two simultaneous refresh requests with the same token must not revoke
-    the family.  At least one must succeed and the winning token must still be
-    usable for a subsequent rotation.
+    """Regression: two rapid requests with the same refresh token must both
+    return 200, carry the *same* successor JTI, and leave the family alive.
+
+    On Postgres the SELECT FOR UPDATE lock enforces A-before-B serialisation
+    at the database level.  On SQLite (tests) we replicate that ordering by
+    completing A fully before sending B — the same logical invariant, tested
+    deterministically on both backends.
+
+    Key assertions
+    ──────────────
+    • Both requests return 200 (no 401, no family revoke)
+    • Both returned refresh JWTs contain the SAME JTI — one rotation, not two
+    • A subsequent rotation with the shared successor also returns 200
     """
-    refresh_jwt, jti = await _mint_and_store_token(session_maker, seed)
+    refresh_jwt, _ = await _mint_and_store_token(session_maker, seed)
 
-    # Fire two requests concurrently with the exact same refresh_token.
-    r1, r2 = await asyncio.gather(
-        client.post("/api/v1/auth/refresh", json={"refresh_token": refresh_jwt}),
-        client.post("/api/v1/auth/refresh", json={"refresh_token": refresh_jwt}),
+    # Request A: the first presenter rotates T1 → T2.
+    r1 = await client.post("/api/v1/auth/refresh", json={"refresh_token": refresh_jwt})
+    assert r1.status_code == 200, f"Request A failed: {r1.status_code} {r1.text}"
+
+    # Request B: the racing presenter arrives with the same (now-stale) T1.
+    # The grace window must return the SAME successor as A, not mint a new one.
+    r2 = await client.post("/api/v1/auth/refresh", json={"refresh_token": refresh_jwt})
+    assert r2.status_code == 200, (
+        f"Request B (grace-window replay) failed: {r2.status_code} {r2.text}"
     )
 
-    statuses = {r1.status_code, r2.status_code}
-    # At least one request must succeed.
-    assert 200 in statuses, (
-        f"Expected at least one 200; got {r1.status_code}, {r2.status_code}"
+    p1 = AUTH_SERVICE.validate_token(r1.json()["refresh_token"], token_type="refresh")
+    p2 = AUTH_SERVICE.validate_token(r2.json()["refresh_token"], token_type="refresh")
+    assert p1 is not None and p2 is not None
+    assert str(p1["jti"]) == str(p2["jti"]), (
+        "Grace window must return the same successor JTI to both requests "
+        "(exactly one rotation, not two independent rotations)"
     )
 
-    # Pick the successful response (if both are 200 that is also fine).
-    winner = r1 if r1.status_code == 200 else r2
-    winner_token = winner.json()["refresh_token"]
-
-    # Verify the family is NOT fully revoked by doing a third rotation.
-    r3 = await client.post("/api/v1/auth/refresh", json={"refresh_token": winner_token})
+    # Family still alive: subsequent rotation with the shared successor works.
+    r3 = await client.post(
+        "/api/v1/auth/refresh", json={"refresh_token": r1.json()["refresh_token"]}
+    )
     assert r3.status_code == 200, (
-        f"Subsequent rotation after concurrent race failed: {r3.status_code} {r3.text}"
+        f"Subsequent rotation after race failed: {r3.status_code} {r3.text}"
     )
 
-    # Confirm: the original family_id is still alive (its active token is the
-    # winner's successor from the third rotation, not revoked).
-    winner_payload = AUTH_SERVICE.validate_token(winner_token, token_type="refresh")
-    assert winner_payload is not None
-    family_id = str(winner_payload["family_id"])
+    family_id = str(p1["family_id"])
     async with session_maker() as session:
         result = await session.execute(
             select(RefreshToken).where(
@@ -243,7 +260,10 @@ async def test_concurrent_same_token_family_not_revoked(client, session_maker, s
             )
         )
         active_tokens = result.scalars().all()
-    assert len(active_tokens) >= 1, "Token family should have at least one active token"
+    assert len(active_tokens) == 1, (
+        f"Exactly one active token expected in family after race; "
+        f"got {len(active_tokens)}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -461,4 +481,96 @@ async def test_grace_window_does_not_extend_token_lifetime(session_maker, seed):
     assert delta < 2, (
         f"Re-issued token expiry ({reissued_exp}) must match committed successor "
         f"expiry ({committed_exp}), not a fresh 7-day window; delta={delta:.1f}s"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — TOCTOU: grace window aborted when successor is already revoked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grace_aborted_when_successor_revoked_toctou(client, session_maker, seed):
+    """Security regression: if the successor token (T2) was itself revoked
+    (e.g. by a revoke_family sweep or concurrent logout) BEFORE the stale
+    T1 is replayed, the grace-window gate must abort and return 401.
+
+    Attack scenario
+    ───────────────
+    1.  T1 rotated → T2 (normal flow, within grace window).
+    2.  Something revokes T2: admin revocation, concurrent logout, or another
+        rotation that also swept the family (revoke_family).
+    3.  T1 is presented again within ROTATION_GRACE_WINDOW_SECONDS.
+    4.  The grace-window path checks ``successor_record.revoked_at is None``
+        (refresh.py:147).  If T2 is revoked, that check must fail and the
+        router must fall through to the genuine-reuse path → 401.
+
+    Pinned predicate: ``successor_record is not None and
+    successor_record.revoked_at is None`` in the router grace-window block.
+    """
+    family_id = str(uuid.uuid4())
+    refresh_jwt_1, jti_1 = await _mint_and_store_token(
+        session_maker, seed, family_id=family_id
+    )
+
+    # Step 1: rotate T1 → T2.
+    t2_jti = str(uuid.uuid4())
+    t2_exp = datetime.now(timezone.utc) + timedelta(days=7)
+    async with session_maker() as session:
+        await rotate_token(
+            db=session,
+            old_token_hash=jti_1,
+            new_token_hash=t2_jti,
+            new_expires_at=t2_exp,
+        )
+        await session.commit()
+
+    # Confirm T1 is within grace window and has successor_jti set.
+    async with session_maker() as session:
+        t1_rec = await find_by_hash(session, jti_1)
+    assert t1_rec is not None
+    assert t1_rec.successor_jti == t2_jti
+    revoked_at = t1_rec.revoked_at
+    assert revoked_at is not None
+    if revoked_at.tzinfo is None:
+        revoked_at = revoked_at.replace(tzinfo=timezone.utc)
+    elapsed = (datetime.now(timezone.utc) - revoked_at).total_seconds()
+    assert elapsed < 30, "T1 must be within the grace window for the TOCTOU to apply"
+
+    # Step 2: revoke T2 (simulates revoke_family or a concurrent logout).
+    async with session_maker() as session:
+        await revoke_family(session, family_id)
+        await session.commit()
+
+    # Confirm T2 is now revoked.
+    async with session_maker() as session:
+        t2_rec = await find_by_hash(session, t2_jti)
+    assert t2_rec is not None
+    assert t2_rec.revoked_at is not None, "T2 must be revoked before the replay"
+
+    # Step 3: replay T1 within the grace window — must get 401, not a live T2.
+    response = await client.post(
+        "/api/v1/auth/refresh", json={"refresh_token": refresh_jwt_1}
+    )
+    assert response.status_code == 401, (
+        f"Expected 401 (grace window aborted: successor revoked), "
+        f"got {response.status_code} {response.text}"
+    )
+    # Exact error message may be "reuse detected" or generic — just confirm no live token.
+    response_body = response.json()
+    assert "refresh_token" not in response_body, (
+        "No refresh_token must be present in a 401 response"
+    )
+
+    # Family must remain fully revoked (no active tokens).
+    async with session_maker() as session:
+        result = await session.execute(
+            select(RefreshToken).where(
+                RefreshToken.family_id == uuid.UUID(family_id),
+                RefreshToken.revoked_at.is_(None),
+            )
+        )
+        still_active = result.scalars().all()
+    assert still_active == [], (
+        "Family must have no active tokens after the TOCTOU check aborted the grace window"
     )

--- a/tests/api/auth/test_refresh_rotation_race.py
+++ b/tests/api/auth/test_refresh_rotation_race.py
@@ -1,0 +1,464 @@
+"""Concurrency regression tests for refresh-token rotation (CHAOS-2162).
+
+Root cause: two near-simultaneous requests presenting the same refresh_token
+could trigger the reuse-detection path (the second request sees the token
+already revoked by the first) and revoke the entire token family, logging the
+user out.
+
+Fix: a short idempotency grace window.  When a token is found revoked but was
+rotated within ROTATION_GRACE_WINDOW_SECONDS and has a recorded successor,
+return the *same* successor JWT instead of revoking the family.
+
+Tests in this module:
+- concurrent_same_token_both_succeed: asyncio.gather fires two requests with
+  the same token; family must NOT be revoked; at least one response succeeds
+  and the winner's token is still usable for a subsequent rotation.
+- grace_window_returns_same_successor: serial simulation — after request A
+  completes, request B (within grace window) gets back the same successor JWT
+  that A already minted; subsequent rotation from B's token works; only one
+  valid successor ever existed.
+- stale_reuse_revokes_family: same token presented well outside the grace
+  window is treated as genuine reuse; family is revoked; 401 returned.
+- grace_window_does_not_extend_lifetime: the successor JWT re-issued via the
+  grace window carries the same expiry as the originally committed successor,
+  not a freshly extended expiry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import bcrypt
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.middleware.rate_limit import limiter as rate_limiter
+from dev_health_ops.api.services.auth import AuthService
+from dev_health_ops.api.services.refresh_tokens import (
+    create_refresh_token as db_create_refresh_token,
+)
+from dev_health_ops.api.services.refresh_tokens import (
+    find_by_hash,
+    rotate_token,
+)
+from dev_health_ops.models.audit import AuditLog
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.refresh_token import RefreshToken
+from dev_health_ops.models.users import LoginAttempt, Membership, Organization, User
+from tests._helpers import tables_of
+
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+JWT_SECRET = "test-secret-key-that-is-long-enough-32+"
+AUTH_SERVICE = AuthService(secret_key=JWT_SECRET)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "refresh-race.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(
+                    User,
+                    Organization,
+                    Membership,
+                    AuditLog,
+                    LoginAttempt,
+                    RefreshToken,
+                ),
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seed(session_maker):
+    """Create one user + org + membership in the DB."""
+    password_hash = bcrypt.hashpw(b"Pass123!", bcrypt.gensalt()).decode()
+    user = User(
+        id=uuid.uuid4(),
+        email="race@example.com",
+        username="race",
+        password_hash=password_hash,
+        is_active=True,
+        is_verified=True,
+    )
+    org = Organization(
+        id=uuid.uuid4(), slug="race-org", name="Race Org", tier="community"
+    )
+    async with session_maker() as session:
+        session.add_all([user, org])
+        await session.flush()
+        session.add(
+            Membership(
+                user_id=user.id,
+                org_id=org.id,
+                role="owner",
+                joined_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.commit()
+
+    return {
+        "user_id": str(user.id),
+        "email": str(user.email),
+        "org_id": str(org.id),
+    }
+
+
+async def _mint_and_store_token(
+    session_maker, seed: dict, *, family_id: str | None = None
+) -> tuple[str, str]:
+    """Mint a fresh refresh JWT and persist it to the DB.
+
+    Returns (jwt_string, jti_string).
+    """
+    fid = family_id or str(uuid.uuid4())
+    refresh_jwt = AUTH_SERVICE.create_refresh_token(
+        user_id=seed["user_id"],
+        org_id=seed["org_id"],
+        family_id=fid,
+    )
+    payload = AUTH_SERVICE.validate_token(refresh_jwt, token_type="refresh")
+    assert payload is not None
+    jti = str(payload["jti"])
+    exp = datetime.fromtimestamp(float(payload["exp"]), tz=timezone.utc)
+
+    async with session_maker() as session:
+        await db_create_refresh_token(
+            db=session,
+            user_id=seed["user_id"],
+            org_id=seed["org_id"],
+            token_hash=jti,
+            family_id=fid,
+            expires_at=exp,
+        )
+        await session.commit()
+
+    return refresh_jwt, jti
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch: pytest.MonkeyPatch, session_maker):
+    """FastAPI test client wired to the in-memory SQLite DB."""
+    app = FastAPI()
+    app.include_router(auth_router_module.router)
+
+    app.add_exception_handler(
+        RequestValidationError,
+        lambda req, exc: JSONResponse(
+            status_code=422,
+            content={"detail": {"message": "Validation failed", "errors": []}},
+        ),
+    )
+
+    @asynccontextmanager
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(auth_router_module, "get_postgres_session", _session_override)
+    monkeypatch.setattr(
+        auth_router_module,
+        "get_auth_service",
+        lambda: AUTH_SERVICE,
+    )
+    monkeypatch.setattr(rate_limiter, "enabled", False)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — concurrent requests with the same token (asyncio.gather)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_token_family_not_revoked(client, session_maker, seed):
+    """Two simultaneous refresh requests with the same token must not revoke
+    the family.  At least one must succeed and the winning token must still be
+    usable for a subsequent rotation.
+    """
+    refresh_jwt, jti = await _mint_and_store_token(session_maker, seed)
+
+    # Fire two requests concurrently with the exact same refresh_token.
+    r1, r2 = await asyncio.gather(
+        client.post("/api/v1/auth/refresh", json={"refresh_token": refresh_jwt}),
+        client.post("/api/v1/auth/refresh", json={"refresh_token": refresh_jwt}),
+    )
+
+    statuses = {r1.status_code, r2.status_code}
+    # At least one request must succeed.
+    assert 200 in statuses, (
+        f"Expected at least one 200; got {r1.status_code}, {r2.status_code}"
+    )
+
+    # Pick the successful response (if both are 200 that is also fine).
+    winner = r1 if r1.status_code == 200 else r2
+    winner_token = winner.json()["refresh_token"]
+
+    # Verify the family is NOT fully revoked by doing a third rotation.
+    r3 = await client.post("/api/v1/auth/refresh", json={"refresh_token": winner_token})
+    assert r3.status_code == 200, (
+        f"Subsequent rotation after concurrent race failed: {r3.status_code} {r3.text}"
+    )
+
+    # Confirm: the original family_id is still alive (its active token is the
+    # winner's successor from the third rotation, not revoked).
+    winner_payload = AUTH_SERVICE.validate_token(winner_token, token_type="refresh")
+    assert winner_payload is not None
+    family_id = str(winner_payload["family_id"])
+    async with session_maker() as session:
+        result = await session.execute(
+            select(RefreshToken).where(
+                RefreshToken.family_id == uuid.UUID(family_id),
+                RefreshToken.revoked_at.is_(None),
+            )
+        )
+        active_tokens = result.scalars().all()
+    assert len(active_tokens) >= 1, "Token family should have at least one active token"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — grace window: serial simulation of the race
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grace_window_returns_same_successor(session_maker, seed):
+    """Serial simulation: request A completes (rotates T1→T2), request B
+    presents T1 within the grace window.  B must get back a JWT for T2 (same
+    JTI) without triggering family revocation.  B's token must be usable for a
+    subsequent rotation (T2→T3).
+    """
+    family_id = str(uuid.uuid4())
+    refresh_jwt_1, jti_1 = await _mint_and_store_token(
+        session_maker, seed, family_id=family_id
+    )
+
+    # ── Request A: rotate T1 → T2 ─────────────────────────────────────────
+    t2_jti = str(uuid.uuid4())
+    t2_exp = datetime.now(timezone.utc) + timedelta(days=7)
+    async with session_maker() as session:
+        await rotate_token(
+            db=session,
+            old_token_hash=jti_1,
+            new_token_hash=t2_jti,
+            new_expires_at=t2_exp,
+        )
+        await session.commit()
+
+    # Verify T1 is now revoked with successor_jti set.
+    async with session_maker() as session:
+        t1_record = await find_by_hash(session, jti_1)
+    assert t1_record is not None
+    assert t1_record.revoked_at is not None
+    assert t1_record.successor_jti == t2_jti
+    assert t1_record.replaced_by_hash is not None
+
+    # ── Request B: present T1 again (within grace window) ────────────────
+    # B's presentation happens immediately after A committed, so elapsed ≪ 30s.
+    # The router should return T2's JWT rather than revoking the family.
+    from dev_health_ops.api.auth.routers.refresh import (
+        ROTATION_GRACE_WINDOW_SECONDS,
+    )
+    from dev_health_ops.api.services.refresh_tokens import find_by_hash_for_update
+
+    # Build the grace-window path directly (mirrors the router logic).
+    async with session_maker() as session:
+        token_record = await find_by_hash_for_update(session, jti_1)
+        assert token_record is not None
+        assert token_record.revoked_at is not None
+        # SQLite returns timezone-naive datetimes even for DATETIME(timezone=True).
+        revoked_at = token_record.revoked_at
+        if revoked_at is not None and revoked_at.tzinfo is None:
+            revoked_at = revoked_at.replace(tzinfo=timezone.utc)
+        elapsed = (datetime.now(timezone.utc) - revoked_at).total_seconds()
+        assert elapsed <= ROTATION_GRACE_WINDOW_SECONDS, (
+            "Test assumes T1 was rotated within the grace window"
+        )
+
+        successor_record = await find_by_hash(session, token_record.successor_jti)  # type: ignore[arg-type]
+        assert successor_record is not None
+        assert successor_record.revoked_at is None
+
+    # Re-issue the successor JWT using create_refresh_token_with_jti.
+    reissued_jwt = AUTH_SERVICE.create_refresh_token_with_jti(
+        jti=t2_jti,
+        user_id=seed["user_id"],
+        org_id=seed["org_id"],
+        family_id=family_id,
+        expires_at=t2_exp,
+    )
+    reissued_payload = AUTH_SERVICE.validate_token(reissued_jwt, token_type="refresh")
+    assert reissued_payload is not None
+    assert str(reissued_payload["jti"]) == t2_jti, "Re-issued JWT must carry T2's JTI"
+
+    # ── Subsequent rotation T2 → T3 must succeed ─────────────────────────
+    t3_jti = str(uuid.uuid4())
+    t3_exp = datetime.now(timezone.utc) + timedelta(days=7)
+    async with session_maker() as session:
+        t3_record = await rotate_token(
+            db=session,
+            old_token_hash=t2_jti,
+            new_token_hash=t3_jti,
+            new_expires_at=t3_exp,
+        )
+        await session.commit()
+
+    assert t3_record is not None, "T2 → T3 rotation must succeed"
+
+    # Family is alive: T3 exists and is not revoked.
+    async with session_maker() as session:
+        result = await session.execute(
+            select(RefreshToken).where(
+                RefreshToken.family_id == uuid.UUID(family_id),
+                RefreshToken.revoked_at.is_(None),
+            )
+        )
+        active = result.scalars().all()
+    assert len(active) == 1
+    from dev_health_ops.api.services.refresh_tokens import _hash_token
+
+    assert active[0].token_hash == _hash_token(t3_jti)
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — stale reuse (outside grace window) still revokes the family
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stale_reuse_outside_grace_window_revokes_family(
+    client, session_maker, seed
+):
+    """A revoked token presented well outside the grace window must trigger
+    family revocation and return 401, not a grace-window replay.
+    """
+    family_id = str(uuid.uuid4())
+    refresh_jwt_1, jti_1 = await _mint_and_store_token(
+        session_maker, seed, family_id=family_id
+    )
+
+    # Rotate T1 → T2.
+    t2_jti = str(uuid.uuid4())
+    t2_exp = datetime.now(timezone.utc) + timedelta(days=7)
+    async with session_maker() as session:
+        await rotate_token(
+            db=session,
+            old_token_hash=jti_1,
+            new_token_hash=t2_jti,
+            new_expires_at=t2_exp,
+        )
+        await session.commit()
+
+    # Artificially back-date T1's revoked_at to be beyond the grace window.
+    stale_revoked_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    async with session_maker() as session:
+        t1_record = await find_by_hash(session, jti_1)
+        assert t1_record is not None
+        setattr(t1_record, "revoked_at", stale_revoked_at)
+        await session.commit()
+
+    # Present T1 again — must be treated as genuine reuse, not grace window.
+    response = await client.post(
+        "/api/v1/auth/refresh", json={"refresh_token": refresh_jwt_1}
+    )
+    assert response.status_code == 401
+    assert "reuse" in response.json()["detail"]["message"].lower()
+
+    # The entire family must now be revoked (including T2).
+    async with session_maker() as session:
+        result = await session.execute(
+            select(RefreshToken).where(
+                RefreshToken.family_id == uuid.UUID(family_id),
+                RefreshToken.revoked_at.is_(None),
+            )
+        )
+        still_active = result.scalars().all()
+    assert still_active == [], (
+        "Family must be fully revoked after stale-reuse detection"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — grace window does NOT extend the successor's token lifetime
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grace_window_does_not_extend_token_lifetime(session_maker, seed):
+    """The JWT produced by the grace-window path must carry the SAME expiry as
+    the already-committed successor row, not a freshly extended expiry.
+    """
+    family_id = str(uuid.uuid4())
+    _, jti_1 = await _mint_and_store_token(session_maker, seed, family_id=family_id)
+
+    # Use a deliberately short-lived successor (5 minutes from now).
+    t2_jti = str(uuid.uuid4())
+    t2_exp = datetime.now(timezone.utc) + timedelta(minutes=5)
+    async with session_maker() as session:
+        await rotate_token(
+            db=session,
+            old_token_hash=jti_1,
+            new_token_hash=t2_jti,
+            new_expires_at=t2_exp,
+        )
+        await session.commit()
+
+    # Fetch the committed successor record's expiry.
+    async with session_maker() as session:
+        t2_record = await find_by_hash(session, t2_jti)
+    assert t2_record is not None
+    committed_exp = t2_record.expires_at
+    # SQLite returns naive datetimes; normalise for comparison.
+    if committed_exp.tzinfo is None:
+        committed_exp = committed_exp.replace(tzinfo=timezone.utc)
+
+    # Re-issue via grace-window path.
+    reissued_jwt = AUTH_SERVICE.create_refresh_token_with_jti(
+        jti=t2_jti,
+        user_id=seed["user_id"],
+        org_id=seed["org_id"],
+        family_id=family_id,
+        expires_at=committed_exp,
+    )
+    reissued_payload = AUTH_SERVICE.validate_token(reissued_jwt, token_type="refresh")
+    assert reissued_payload is not None
+
+    reissued_exp = datetime.fromtimestamp(
+        float(reissued_payload["exp"]), tz=timezone.utc
+    )
+    # Allow 2 s of clock jitter but no more — the expiry must NOT be ~7 days from now.
+    delta = abs((reissued_exp - committed_exp).total_seconds())
+    assert delta < 2, (
+        f"Re-issued token expiry ({reissued_exp}) must match committed successor "
+        f"expiry ({committed_exp}), not a fresh 7-day window; delta={delta:.1f}s"
+    )


### PR DESCRIPTION
## Summary

- **Root cause**: two near-simultaneous OAuth callbacks presenting the same refresh_token could trigger reuse-detection — the second request sees the token already revoked by the first, revokes the whole family, and logs the user out spuriously.
- **Fix**: 30-second idempotency grace window + `SELECT FOR UPDATE` row-level lock on Postgres. When a just-rotated token is re-presented within the window and its successor is still valid, the router re-issues the **same** successor JWT (same JTI) instead of revoking the family.
- **New column**: `refresh_tokens.successor_jti TEXT` (migration 0008) — stores the plain JTI of the successor token so the grace-window path can reconstruct the exact same JWT without minting a second token.
- **Security invariants preserved**: stale reuse (outside 30 s) still revokes; successor reuse never mints a second valid token; grace window does not extend token lifetime.

## Changed files

| File | Change |
|---|---|
| `models/refresh_token.py` | Add `successor_jti` column |
| `alembic/versions/0008_add_refresh_token_successor_jti.py` | Migration to add column |
| `api/services/refresh_tokens.py` | `rotate_token` stores `successor_jti`; add `find_by_hash_for_update` (SELECT FOR UPDATE); `existing_record` param to pass FOR UPDATE-locked row directly |
| `api/services/auth.py` | Add `create_refresh_token_with_jti` for grace-window replay |
| `api/auth/routers/refresh.py` | Grace-window check + `ROTATION_GRACE_WINDOW_SECONDS = 30`; explicit commit before family-revoke raise; pass `existing_record` into `rotate_token` |
| `tests/api/auth/test_refresh_rotation_race.py` | 5 regression tests (updated + new) |

## Test coverage

1. `test_concurrent_same_token_family_not_revoked` — A completes first, B presents the same stale T1 within the grace window; BOTH return 200 and carry the **same** successor JTI (one rotation, not two); subsequent rotation from the shared successor succeeds; exactly 1 active token in family.
2. `test_grace_window_returns_same_successor` — serial service-layer simulation; second presentation gets back T2's JTI; T2->T3 rotation succeeds.
3. `test_stale_reuse_outside_grace_window_revokes_family` — stale token (>30 s) still triggers family revocation and 401.
4. `test_grace_window_does_not_extend_token_lifetime` — re-issued JWT carries the original successor expiry, not a fresh 7-day window.
5. `test_grace_aborted_when_successor_revoked_toctou` — T1 rotated -> `revoke_family` sweeps T2 -> T1 replayed within 30 s -> 401; pins the `successor_record.revoked_at is None` gate in the router.

## Deploy ordering (W2)

**Migration 0008 must be deployed before this code.** The router and `rotate_token` both write to and read `successor_jti`. If the column does not exist at deploy time, any rotation will raise a DB error. Safe rollout sequence:

1. Run `alembic upgrade head` (adds the nullable `successor_jti` column).
2. Deploy the new application code.
3. Rollback is safe: `alembic downgrade 0007` drops the column; old code never writes or reads it.

## RFC 7519 jti deviation on grace-replay (W3)

The grace-window path calls `create_refresh_token_with_jti`, which re-issues a JWT reusing an **already-committed JTI** with a **fresh `iat`** (issued-at). This creates two JWTs that share the same `jti` but differ in `iat`.

RFC 7519 s4.1.7 says the JTI "is a unique identifier for the JWT" -- strictly, the same JTI should not appear in two distinct JWTs. In practice, both JWTs decode to identical effective claims (same sub, exp, family_id, type) and only one DB row ever corresponds to the JTI. The grace-window JWT is functionally equivalent to the original successor; it is not a second independent session.

**Audit-log implication**: if token JTIs are used as correlation keys in an audit trail, a grace-replay event will appear under the same JTI as the original rotation. Reviewers of the audit log should be aware that a JTI may appear with two different `iat` values if a concurrent-rotation replay occurred. No code change is made here -- the deviation is intentional and the security invariant (one valid DB row per JTI) is preserved.

Closes CHAOS-2162