### PR TITLE
feat(improve): wire FlowOpportunityDetector into GraphQL as improveOpportunities (CHAOS-2220)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/improve.py
+++ b/src/dev_health_ops/api/graphql/models/improve.py
@@ -27,7 +27,6 @@ from enum import Enum
 
 import strawberry
 
-
 # ── Experiments (CHAOS-2219) ──────────────────────────────────────────────────
 
 

--- a/src/dev_health_ops/api/graphql/models/improve.py
+++ b/src/dev_health_ops/api/graphql/models/improve.py
@@ -1,12 +1,23 @@
-"""Strawberry GraphQL types for the Improve area — Experiments sub-area.
+"""Strawberry GraphQL types for the Improve area — Experiments + Automations.
 
-v1 design decision: experiments are DERIVED (computed) from the per-opportunity
-``suggested_experiments`` strings already produced by the opportunities service.
-No persistence table is needed for v1 — each ``Experiment`` is assembled at
-query-time from ``OpportunityCard.suggested_experiments``.  The ``status``
-field and the ``opportunity_id`` back-reference keep the schema honest about
-the derivation path so the promotion flow (user assigns owner/metric and saves)
-can be added in v2 without a breaking change.
+This module holds ALL Improve-area types:
+
+- **Experiments** (CHAOS-2219): DERIVED types assembled at query-time from
+  ``OpportunityCard.suggested_experiments``.  No persistence table is needed
+  for v1 — the type contract is stable so persistence can be added in v2
+  without a breaking change.
+
+- **Automations / Flow opportunities** (CHAOS-2220): Non-AI flow opportunity
+  types powering the Improve → Automations surface.  They mirror the domain
+  models in ``dev_health_ops.metrics.opportunities.models`` but carry
+  ``@strawberry`` decorators for direct schema serving.  Defined here (not in
+  ``models/ai.py``) because the Improve opportunity kinds are **non-AI** — the
+  detector fires on flow / cycle / rework signals from ``repo_metrics_daily``
+  and ``work_item_metrics_daily``, not on AI attribution data.
+
+The ``AIScopeInput`` re-use for Automations is intentional: the scope shape
+(optional repo_id, team_id) is the same; introducing a duplicate input type
+would be noise.
 """
 
 from __future__ import annotations
@@ -15,6 +26,9 @@ from datetime import date
 from enum import Enum
 
 import strawberry
+
+
+# ── Experiments (CHAOS-2219) ──────────────────────────────────────────────────
 
 
 @strawberry.enum
@@ -98,3 +112,56 @@ class ExperimentsResult:
 
     items: list[Experiment]
     derived_from_opportunities: bool
+
+
+# ── Automations / Flow opportunities (CHAOS-2220) ─────────────────────────────
+
+
+@strawberry.enum
+class ImproveOpportunityKind(Enum):
+    """Non-AI flow opportunity kinds detected by FlowOpportunityDetector.
+
+    Each value maps to one of the seven threshold rules implemented in
+    ``metrics.opportunities.flow_detector``.
+    """
+
+    HIGH_REVIEW_LATENCY = "high_review_latency"
+    SLOW_CYCLE_TIME = "slow_cycle_time"
+    HIGH_REWORK = "high_rework"
+    HIGH_WIP = "high_wip"
+    LOW_THROUGHPUT = "low_throughput"
+    HIGH_CHURN = "high_churn"
+    HIGH_CHANGE_FAILURE = "high_change_failure"
+
+
+@strawberry.type
+class ImproveOpportunity:
+    """A single scored flow / improve opportunity (non-AI kind)."""
+
+    opportunity_id: str
+    kind: ImproveOpportunityKind
+    entity_type: str
+    entity_id: str
+    title: str
+    rationale: str
+    score: float
+    severity: str
+    evidence_refs: list[str]
+    recommended_action: str
+
+
+@strawberry.type
+class ImproveOpportunitiesResult:
+    """Improve automations surface: non-AI flow opportunity candidates.
+
+    ``detector_ready`` is ``True`` whenever the FlowOpportunityDetector ran
+    without a total failure (it can return an empty list when no thresholds
+    fire — that is a valid "all green" state, not an error).
+    ``detector_ready = False`` means the detector could not connect to
+    ClickHouse or the org scope could not be resolved.
+    """
+
+    org_id: str
+    opportunities: list[ImproveOpportunity]
+    detector_ready: bool
+    total_count: int

--- a/src/dev_health_ops/api/graphql/resolvers/improve.py
+++ b/src/dev_health_ops/api/graphql/resolvers/improve.py
@@ -1,35 +1,59 @@
-"""Resolver for the Improve area — Experiments sub-area.
+"""Resolvers for the Improve area — Experiments (CHAOS-2219) + Automations (CHAOS-2220).
 
-v1 strategy: DERIVED resolver.  Experiments are assembled at query-time from
-``OpportunityCard.suggested_experiments``; no persistence table is required.
+This module holds BOTH Improve-area resolvers:
 
-Each opportunity card holds ``suggested_experiments: list[str]`` (free-text
-hypothesis strings keyed by metric).  The resolver calls
-``build_opportunities_response``, iterates the resulting cards, and promotes
-every suggestion string into a typed ``Experiment`` object whose ``metric``
-traces back to the triggering opportunity metric.  ``status`` is always
-``SUGGESTED`` for these derived experiments.
+- ``resolve_experiments``: DERIVED resolver that assembles experiments at
+  query-time from ``OpportunityCard.suggested_experiments`` (CHAOS-2219).
+  No persistence table is needed for v1 — the resolver contract is stable so
+  persistence can be added in v2 without a schema change.
 
-Promotion path (v2): once a user assigns an owner + stop_condition the record
-can be written to an ``experiments`` table (Postgres semantic / ClickHouse
-analytics) and the resolver switches to reading persisted rows, falling back to
-derived if the table is empty.  The GraphQL contract is unchanged.
+  ID stability: experiment IDs are derived from (metric, suggestion_text)
+  via SHA-256 so the same logical experiment always receives the same ID
+  regardless of the opportunity card's daily rank position.
 
-ID stability note: experiment IDs are derived from (metric, suggestion_text)
-via SHA-256 so the same logical experiment always receives the same ID
-regardless of the opportunity card's daily rank position.  See
-``_stable_experiment_id`` for the derivation.
+- ``resolve_improve_opportunities``: Wires ``FlowOpportunityDetector`` into
+  the GraphQL schema (CHAOS-2220).  Follows the same read-only pattern as
+  ``resolvers/ai.py``.  ``org_id`` is always injected via ``require_org_id``
+  — the resolver never serves cross-org rows.  An optional scope (repo_id /
+  team_id) narrows the ClickHouse queries inside the detector.
+
+Both resolvers share the module-level ``logger`` and the ``GraphQLContext``
+dependency; they are independent and do not call each other.
 """
 
 from __future__ import annotations
 
 import hashlib
 import logging
+import uuid
 
+from dev_health_ops.metrics.opportunities.flow_detector import FlowOpportunityDetector
+from dev_health_ops.metrics.opportunities.models import (
+    FlowScopeInput,
+)
+from dev_health_ops.metrics.opportunities.models import (
+    ImproveOpportunity as _DomainOpportunity,
+)
+from dev_health_ops.metrics.opportunities.models import (
+    ImproveOpportunityKind as _DomainKind,
+)
+
+from ..authz import require_org_id
 from ..context import GraphQLContext
-from ..models.improve import Experiment, ExperimentsResult, ExperimentStatus
+from ..models.ai import AIScopeInput
+from ..models.improve import (
+    Experiment,
+    ExperimentsResult,
+    ExperimentStatus,
+    ImproveOpportunitiesResult,
+    ImproveOpportunity,
+    ImproveOpportunityKind,
+)
 
 logger = logging.getLogger(__name__)
+
+
+# ── Experiments (CHAOS-2219) ──────────────────────────────────────────────────
 
 
 def _stable_experiment_id(metric: str, suggestion: str) -> str:
@@ -167,3 +191,98 @@ def _metric_from_card(card: object) -> str:
         label = title.split(" ", 1)[1].lower().replace(" ", "_")
         return label
     return ""
+
+
+# ── Automations / Flow opportunities (CHAOS-2220) ─────────────────────────────
+
+# Map domain enum → Strawberry enum (same string values, but distinct objects).
+_KIND_MAP: dict[_DomainKind, ImproveOpportunityKind] = {
+    _DomainKind.HIGH_REVIEW_LATENCY: ImproveOpportunityKind.HIGH_REVIEW_LATENCY,
+    _DomainKind.SLOW_CYCLE_TIME: ImproveOpportunityKind.SLOW_CYCLE_TIME,
+    _DomainKind.HIGH_REWORK: ImproveOpportunityKind.HIGH_REWORK,
+    _DomainKind.HIGH_WIP: ImproveOpportunityKind.HIGH_WIP,
+    _DomainKind.LOW_THROUGHPUT: ImproveOpportunityKind.LOW_THROUGHPUT,
+    _DomainKind.HIGH_CHURN: ImproveOpportunityKind.HIGH_CHURN,
+    _DomainKind.HIGH_CHANGE_FAILURE: ImproveOpportunityKind.HIGH_CHANGE_FAILURE,
+}
+
+
+def _project(domain: _DomainOpportunity) -> ImproveOpportunity:
+    """Convert a domain ImproveOpportunity to its Strawberry counterpart."""
+    return ImproveOpportunity(
+        opportunity_id=domain.opportunity_id,
+        kind=_KIND_MAP[domain.kind],
+        entity_type=domain.entity_type,
+        entity_id=domain.entity_id,
+        title=domain.title,
+        rationale=domain.rationale,
+        score=domain.score,
+        severity=domain.severity,
+        evidence_refs=list(domain.evidence_refs),
+        recommended_action=domain.recommended_action,
+    )
+
+
+def _parse_scope(scope: AIScopeInput | None) -> FlowScopeInput | None:
+    if scope is None:
+        return None
+    repo_id: uuid.UUID | None = None
+    if scope.repo_id:
+        try:
+            repo_id = uuid.UUID(scope.repo_id)
+        except (TypeError, ValueError):
+            logger.debug(
+                "Invalid repo UUID %r in improve scope, ignoring", scope.repo_id
+            )
+    team_id = scope.team_id or None
+    if repo_id is None and team_id is None:
+        return None
+    return FlowScopeInput(repo_id=repo_id, team_id=team_id)
+
+
+async def resolve_improve_opportunities(
+    context: GraphQLContext,
+    scope: AIScopeInput | None = None,
+    limit: int = 10,
+    window_days: int = 30,
+) -> ImproveOpportunitiesResult:
+    """Return rule-based non-AI flow opportunities for the Improve surface.
+
+    Decision (CHAOS-2220): inline detection — no persisted recommendations.
+    The detector reads pre-computed ClickHouse rows; it never writes.
+    An empty list is the valid "all green" state.
+    """
+    org_id = require_org_id(context)
+
+    if context.client is None:
+        logger.error(
+            "resolve_improve_opportunities: DB client unavailable for org=%s", org_id
+        )
+        return ImproveOpportunitiesResult(
+            org_id=org_id,
+            opportunities=[],
+            detector_ready=False,
+            total_count=0,
+        )
+
+    bounded_limit = max(1, min(int(limit), 100))
+    bounded_window = max(1, min(int(window_days), 365))
+
+    detector = FlowOpportunityDetector(context.client)
+    flow_scope = _parse_scope(scope)
+
+    domain_opps = await detector.detect(
+        org_id=org_id,
+        scope=flow_scope,
+        limit=bounded_limit,
+        window_days=bounded_window,
+    )
+
+    projected = [_project(o) for o in domain_opps]
+
+    return ImproveOpportunitiesResult(
+        org_id=org_id,
+        opportunities=projected,
+        detector_ready=True,
+        total_count=len(projected),
+    )

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -23,7 +23,7 @@ from .models.ai import (
     AIWorkflowRootTypeInput,
 )
 from .models.data_health import DataHealth
-from .models.improve import ExperimentsResult
+from .models.improve import ExperimentsResult, ImproveOpportunitiesResult
 from .models.inputs import (
     AnalyticsRequestInput,
     CapacityForecastFilterInput,
@@ -72,6 +72,7 @@ from .resolvers.cognitive_load import resolve_cognitive_load
 from .resolvers.complexity import resolve_complexity_timeseries, resolve_hotspots
 from .resolvers.compounding_risk import resolve_compounding_risk
 from .resolvers.data_health import resolve_data_health
+from .resolvers.improve import resolve_improve_opportunities
 from .resolvers.product_telemetry import (
     resolve_product_telemetry_dashboard,
     resolve_product_telemetry_platform_dashboard,
@@ -567,6 +568,26 @@ class Query:
     ) -> AIOpportunitiesResult:
         context = get_context(info)
         return await resolve_ai_opportunities(context, scope, limit)
+
+    @strawberry.field(
+        description=(
+            "Non-AI flow opportunity recommendations for the Improve surface "
+            "(CHAOS-2220). Fires threshold rules over repo and team metrics "
+            "(review latency, cycle time, rework, WIP, throughput, churn, "
+            "change failure) and returns scored candidates. "
+            "An empty list means all metrics are within thresholds — not an error."
+        )
+    )
+    async def improve_opportunities(
+        self,
+        info: Info,
+        org_id: str,
+        scope: AIScopeInput | None = None,
+        limit: int = 10,
+        window_days: int = 30,
+    ) -> ImproveOpportunitiesResult:
+        context = get_context(info)
+        return await resolve_improve_opportunities(context, scope, limit, window_days)
 
     @strawberry.field(
         description="AI governance coverage and recent policy violations."

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -581,7 +581,6 @@ class Query:
     async def improve_opportunities(
         self,
         info: Info,
-        org_id: str,
         scope: AIScopeInput | None = None,
         limit: int = 10,
         window_days: int = 30,

--- a/src/dev_health_ops/metrics/opportunities/flow_detector.py
+++ b/src/dev_health_ops/metrics/opportunities/flow_detector.py
@@ -419,7 +419,7 @@ class FlowOpportunityDetector:
             avg(rework_churn_ratio_30d) AS rework_churn_ratio_30d,
             avg(change_failure_rate) AS change_failure_rate,
             sum(total_loc_touched) AS total_loc_touched
-        FROM repo_metrics_daily
+        FROM repo_metrics_daily FINAL
         WHERE {where_clause}
         GROUP BY repo_id
         HAVING data_days >= {_MIN_DATA_DAYS}
@@ -461,7 +461,7 @@ class FlowOpportunityDetector:
             avg(wip_congestion_ratio) AS wip_congestion_ratio,
             sum(items_completed) AS items_completed,
             avg(defect_intro_rate) AS defect_intro_rate
-        FROM work_item_metrics_daily
+        FROM work_item_metrics_daily FINAL
         WHERE {where_clause}
           AND team_id != ''
         GROUP BY team_id


### PR DESCRIPTION
## Summary

Wires the already-built `FlowOpportunityDetector` (501 lines, 7 rules, 84 tests) into the GraphQL API surface, following the `resolve_ai_opportunities` pattern.

- Adds `ImproveOpportunitiesResult`, `ImproveOpportunity`, and `ImproveOpportunityKind` Strawberry types in `api/graphql/models/improve.py`
- Adds `resolve_improve_opportunities` resolver in `api/graphql/resolvers/improve.py` — instantiates `FlowOpportunityDetector` inline (same pattern as `resolve_ai_opportunities`), enforces org scope via `require_org_id(context)`, projects domain objects to Strawberry types; no `orgId` arg on the field (auth-context scoped)
- Adds `improveOpportunities` field to the GraphQL schema (`schema.py`) — optional `scope: AIScopeInput`, `limit: Int! = 10`, `windowDays: Int! = 30`
- Adds `FINAL` to both `repo_metrics_daily` and `work_item_metrics_daily` ClickHouse queries to prevent unmerged ReplacingMergeTree parts from inflating averages and producing false HIGH_* firings
- Returns all 7 non-AI flow opportunity kinds: `HIGH_REVIEW_LATENCY`, `SLOW_CYCLE_TIME`, `HIGH_REWORK`, `HIGH_WIP`, `LOW_THROUGHPUT`, `HIGH_CHURN`, `HIGH_CHANGE_FAILURE`
- Detector is read-only; no persistence. An empty list means all metrics are within thresholds — not an error.

TEST-EVIDENCE: ci/run_tests.sh unit → exit 0 (all 84 FlowOpportunityDetector tests pass + schema import verified with python -c "from dev_health_ops.api.graphql.schema import Query"). The FINAL keyword and org_id arg removal are structural-only changes to existing query strings; no new code paths requiring new tests. The 84 existing detector tests cover all 7 rule threshold branches. Ruff format + ruff check → clean on pre-push hook.

RISK-NOTES: Read-only inline detection — no writes, no migrations. Blast radius: the new improveOpportunities field is additive to the GraphQL schema; existing queries unaffected. Rollback: revert the 3 commits on this branch; no DB state to undo. The FINAL keyword may increase query latency on large ClickHouse tables — monitor p95 if deployed to high-volume orgs, and consider removing FINAL in favour of argMax dedup if latency degrades. Follow-up: CHAOS-2220 web PR 657 consumes this field.

## Test plan
- [x] ci/run_tests.sh unit → exit 0 (84 tests pass)
- [x] python -c "from dev_health_ops.api.graphql.schema import Query" → no import errors
- [x] Ruff format + check clean (pre-push hook)
- [ ] improveOpportunities field visible in GraphQL introspection (post-deploy)

SCREENSHOT-WAIVER: Backend-only change — no rendered UI.

Closes CHAOS-2220