### PR TITLE
feat(improve): Experiment GraphQL type + derived resolver (CHAOS-2219)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/improve.py
+++ b/src/dev_health_ops/api/graphql/models/improve.py
@@ -1,0 +1,100 @@
+"""Strawberry GraphQL types for the Improve area — Experiments sub-area.
+
+v1 design decision: experiments are DERIVED (computed) from the per-opportunity
+``suggested_experiments`` strings already produced by the opportunities service.
+No persistence table is needed for v1 — each ``Experiment`` is assembled at
+query-time from ``OpportunityCard.suggested_experiments``.  The ``status``
+field and the ``opportunity_id`` back-reference keep the schema honest about
+the derivation path so the promotion flow (user assigns owner/metric and saves)
+can be added in v2 without a breaking change.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from enum import Enum
+
+import strawberry
+
+
+@strawberry.enum
+class ExperimentStatus(Enum):
+    """Lifecycle state of an experiment.
+
+    ``SUGGESTED`` is the v1 state for experiments that are derived from
+    opportunity cards but have not yet been promoted into a tracked run.
+    """
+
+    SUGGESTED = "suggested"
+    """Derived from an opportunity card — not yet owned or started."""
+
+    ACTIVE = "active"
+    """An owner has claimed the experiment and it is in flight."""
+
+    COMPLETED = "completed"
+    """The experiment has a measured outcome."""
+
+    ABANDONED = "abandoned"
+    """The experiment was dropped before producing an outcome."""
+
+
+@strawberry.type
+class Experiment:
+    """A single process experiment derived from or promoted from an opportunity.
+
+    In v1 every ``Experiment`` is derived from
+    ``OpportunityCard.suggested_experiments`` at query-time.  Fields that
+    belong to a promoted, tracked experiment (``owner``, ``metric``,
+    ``stop_condition``, ``start_date``, ``stop_date``, ``outcome``) are
+    included in the schema now so the GraphQL contract is stable when
+    persistence is added in v2.
+
+    ``opportunity_id`` traces the experiment back to the source opportunity
+    so consumers can navigate opportunity → experiments and vice-versa.
+    """
+
+    id: str
+    """Stable synthetic id of the form ``<opportunity_id>-exp-<index>``."""
+
+    opportunity_id: str
+    """The parent opportunity this experiment was derived from."""
+
+    hypothesis: str
+    """The experiment hypothesis, sourced from the opportunity's suggested text."""
+
+    metric: str
+    """Metric key the experiment is expected to improve (e.g. ``cycle_time``)."""
+
+    owner: str
+    """Team or person running the experiment.  Empty string for SUGGESTED."""
+
+    stop_condition: str
+    """Measurable criterion for concluding the experiment.  Empty for SUGGESTED."""
+
+    status: ExperimentStatus
+    """Current lifecycle state.  Always ``SUGGESTED`` for derived experiments."""
+
+    start_date: date | None
+    """Date the experiment started.  None for SUGGESTED."""
+
+    stop_date: date | None
+    """Date the experiment concluded.  None for SUGGESTED."""
+
+    outcome: str | None
+    """Observed outcome.  None for SUGGESTED."""
+
+
+@strawberry.type
+class ExperimentsResult:
+    """Container for the experiments query response.
+
+    ``items`` is empty when no opportunities are available — the caller should
+    render the appropriate DataState variant (``detector-enabled-no-findings``)
+    rather than inferring data availability from ``len(items) == 0`` alone.
+    The ``derived_from_opportunities`` flag signals whether the list was built
+    from live opportunity data (``True``) or is empty because the opportunities
+    service was unavailable (``False``).
+    """
+
+    items: list[Experiment]
+    derived_from_opportunities: bool

--- a/src/dev_health_ops/api/graphql/resolvers/improve.py
+++ b/src/dev_health_ops/api/graphql/resolvers/improve.py
@@ -14,16 +14,37 @@ Promotion path (v2): once a user assigns an owner + stop_condition the record
 can be written to an ``experiments`` table (Postgres semantic / ClickHouse
 analytics) and the resolver switches to reading persisted rows, falling back to
 derived if the table is empty.  The GraphQL contract is unchanged.
+
+ID stability note: experiment IDs are derived from (metric, suggestion_text)
+via SHA-256 so the same logical experiment always receives the same ID
+regardless of the opportunity card's daily rank position.  See
+``_stable_experiment_id`` for the derivation.
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
 
 from ..context import GraphQLContext
 from ..models.improve import Experiment, ExperimentsResult, ExperimentStatus
 
 logger = logging.getLogger(__name__)
+
+
+def _stable_experiment_id(metric: str, suggestion: str) -> str:
+    """Return a 16-hex-char content-stable ID for a derived experiment.
+
+    The ID is derived from (metric, suggestion_text) so it is invariant to
+    daily rank-order shifts of the parent opportunity card.  The same
+    suggestion text for the same metric always produces the same ID, which
+    makes client-side caching and deduplication safe.
+
+    Uses the same SHA-256-prefix approach as
+    ``dev_health_ops.metrics.opportunities.scoring.stable_opportunity_id``.
+    """
+    raw = f"{metric}:{suggestion}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
 
 
 async def resolve_experiments(
@@ -56,8 +77,14 @@ async def resolve_experiments(
             and filters.scope is not None
         ):
             scope_in = filters.scope
+            # ScopeFilterInput.level may be a Strawberry enum (ScopeLevelInput)
+            # whose .value is already the lowercase string, or a plain str.
+            raw_level = getattr(scope_in, "level", "org")
+            level_str = (
+                raw_level.value if hasattr(raw_level, "value") else str(raw_level)
+            ).lower() or "org"
             scope = ScopeFilter(
-                level=getattr(scope_in, "level", "org").lower() or "org",
+                level=level_str,
                 ids=list(getattr(scope_in, "ids", None) or []),
             )
         else:
@@ -87,7 +114,10 @@ async def resolve_experiments(
         )
 
     try:
-        cache = TTLCache()
+        # Re-use the module-level cache injected by the GraphQL app (warm across
+        # requests).  Fall back to a fresh in-memory instance only when running
+        # outside the normal app lifecycle (e.g. tests that don't wire a cache).
+        cache = context.cache or TTLCache(ttl_seconds=60)
         response = await build_opportunities_response(
             db_url=context.db_url,
             filters=metric_filter,
@@ -100,11 +130,11 @@ async def resolve_experiments(
 
     experiments: list[Experiment] = []
     for card in response.items:
-        for idx, suggestion in enumerate(card.suggested_experiments, start=1):
+        for suggestion in card.suggested_experiments:
             metric = _metric_from_card(card)
             experiments.append(
                 Experiment(
-                    id=f"{card.id}-exp-{idx}",
+                    id=_stable_experiment_id(metric, suggestion),
                     opportunity_id=card.id,
                     hypothesis=suggestion,
                     metric=metric,
@@ -123,13 +153,16 @@ async def resolve_experiments(
 def _metric_from_card(card: object) -> str:
     """Infer the metric key from the opportunity card title.
 
-    The opportunities service sets ``title`` as ``"Reduce <metric_label>"``
-    or ``"Recover <metric_label>"``.  For the baseline "Maintain steady flow"
-    card (no specific metric) we return an empty string.  This is intentionally
-    lightweight — a v2 persistence layer can store the metric key explicitly.
+    The opportunities service currently sets ``title`` as ``"Reduce <metric_label>"``.
+    For the baseline "Maintain steady flow" card (no specific metric) we return
+    an empty string.
+
+    NOTE: this title-reversal is intentionally lightweight for v1.  The correct
+    fix for v2 is to thread a ``metric_key`` field onto ``OpportunityCard``
+    directly so callers never need to reverse-engineer it from display text.
     """
     title: str = str(getattr(card, "title", ""))
-    if title.startswith("Reduce ") or title.startswith("Recover "):
+    if title.startswith("Reduce "):
         # Strip the leading verb and normalise to a metric-key-style slug.
         label = title.split(" ", 1)[1].lower().replace(" ", "_")
         return label

--- a/src/dev_health_ops/api/graphql/resolvers/improve.py
+++ b/src/dev_health_ops/api/graphql/resolvers/improve.py
@@ -1,0 +1,136 @@
+"""Resolver for the Improve area — Experiments sub-area.
+
+v1 strategy: DERIVED resolver.  Experiments are assembled at query-time from
+``OpportunityCard.suggested_experiments``; no persistence table is required.
+
+Each opportunity card holds ``suggested_experiments: list[str]`` (free-text
+hypothesis strings keyed by metric).  The resolver calls
+``build_opportunities_response``, iterates the resulting cards, and promotes
+every suggestion string into a typed ``Experiment`` object whose ``metric``
+traces back to the triggering opportunity metric.  ``status`` is always
+``SUGGESTED`` for these derived experiments.
+
+Promotion path (v2): once a user assigns an owner + stop_condition the record
+can be written to an ``experiments`` table (Postgres semantic / ClickHouse
+analytics) and the resolver switches to reading persisted rows, falling back to
+derived if the table is empty.  The GraphQL contract is unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ..context import GraphQLContext
+from ..models.improve import Experiment, ExperimentsResult, ExperimentStatus
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_experiments(
+    context: GraphQLContext,
+    filters: object | None = None,
+) -> ExperimentsResult:
+    """Return derived experiments assembled from opportunity suggested_experiments.
+
+    Calls ``build_opportunities_response`` via the same filter path used by the
+    REST ``/api/v1/opportunities`` endpoint so results are consistent with the
+    Opportunities page.
+
+    Args:
+        context: GraphQL request context (carries org_id, db_url, ClickHouse client).
+        filters:  Optional ``FilterInput``; forwarded to the opportunities service.
+
+    Returns:
+        ``ExperimentsResult`` with ``derived_from_opportunities=True`` when the
+        opportunities service returned data, ``False`` on failure (empty items).
+    """
+    from dev_health_ops.api.models.filters import MetricFilter, ScopeFilter, TimeFilter
+    from dev_health_ops.api.services.cache import TTLCache
+    from dev_health_ops.api.services.opportunities import build_opportunities_response
+
+    # Build a MetricFilter from the GraphQL FilterInput (mirrors the REST path).
+    try:
+        if (
+            filters is not None
+            and hasattr(filters, "scope")
+            and filters.scope is not None
+        ):
+            scope_in = filters.scope
+            scope = ScopeFilter(
+                level=getattr(scope_in, "level", "org").lower() or "org",
+                ids=list(getattr(scope_in, "ids", None) or []),
+            )
+        else:
+            scope = ScopeFilter(level="org", ids=[])
+
+        if (
+            filters is not None
+            and hasattr(filters, "time")
+            and filters.time is not None
+        ):
+            time_in = filters.time
+            time_filter = TimeFilter(
+                range_days=int(getattr(time_in, "range_days", 30)),
+                compare_days=int(getattr(time_in, "compare_days", 30)),
+            )
+        else:
+            time_filter = TimeFilter(range_days=30, compare_days=30)
+
+        metric_filter = MetricFilter(scope=scope, time=time_filter)
+    except Exception:
+        logger.exception(
+            "Failed to build MetricFilter from GraphQL FilterInput; using defaults"
+        )
+        metric_filter = MetricFilter(
+            scope=ScopeFilter(level="org", ids=[]),
+            time=TimeFilter(range_days=30, compare_days=30),
+        )
+
+    try:
+        cache = TTLCache()
+        response = await build_opportunities_response(
+            db_url=context.db_url,
+            filters=metric_filter,
+            cache=cache,
+            org_id=context.org_id,
+        )
+    except Exception:
+        logger.exception("Experiments resolver: opportunities service failed")
+        return ExperimentsResult(items=[], derived_from_opportunities=False)
+
+    experiments: list[Experiment] = []
+    for card in response.items:
+        for idx, suggestion in enumerate(card.suggested_experiments, start=1):
+            metric = _metric_from_card(card)
+            experiments.append(
+                Experiment(
+                    id=f"{card.id}-exp-{idx}",
+                    opportunity_id=card.id,
+                    hypothesis=suggestion,
+                    metric=metric,
+                    owner="",
+                    stop_condition="",
+                    status=ExperimentStatus.SUGGESTED,
+                    start_date=None,
+                    stop_date=None,
+                    outcome=None,
+                )
+            )
+
+    return ExperimentsResult(items=experiments, derived_from_opportunities=True)
+
+
+def _metric_from_card(card: object) -> str:
+    """Infer the metric key from the opportunity card title.
+
+    The opportunities service sets ``title`` as ``"Reduce <metric_label>"``
+    or ``"Recover <metric_label>"``.  For the baseline "Maintain steady flow"
+    card (no specific metric) we return an empty string.  This is intentionally
+    lightweight — a v2 persistence layer can store the metric key explicitly.
+    """
+    title: str = str(getattr(card, "title", ""))
+    if title.startswith("Reduce ") or title.startswith("Recover "):
+        # Strip the leading verb and normalise to a metric-key-style slug.
+        label = title.split(" ", 1)[1].lower().replace(" ", "_")
+        return label
+    return ""

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -23,6 +23,7 @@ from .models.ai import (
     AIWorkflowRootTypeInput,
 )
 from .models.data_health import DataHealth
+from .models.improve import ExperimentsResult
 from .models.inputs import (
     AnalyticsRequestInput,
     CapacityForecastFilterInput,
@@ -476,6 +477,27 @@ class Query:
 
         context = get_context(info)
         return await resolve_recommendations(context, str(team), window)
+
+    @strawberry.field(
+        description=(
+            "Experiments derived from opportunity suggested_experiments (CHAOS-2219). "
+            "v1: computed at query-time — no persistence table. "
+            "Each experiment is a typed promotion of a suggestion string with "
+            "hypothesis / metric / owner / stop_condition. "
+            "``derived_from_opportunities`` is False when the opportunities "
+            "service was unavailable; items will be empty in that case."
+        )
+    )
+    async def experiments(
+        self,
+        info: Info,
+        org_id: str,
+        filters: FilterInput | None = None,
+    ) -> ExperimentsResult:
+        from .resolvers.improve import resolve_experiments
+
+        context = get_context(info)
+        return await resolve_experiments(context, filters)
 
     @strawberry.field(
         description="AI workflow impact summary across the requested time range."

--- a/tests/test_improve_resolver.py
+++ b/tests/test_improve_resolver.py
@@ -1,0 +1,244 @@
+"""Tests for the Improve → Experiments GraphQL resolver (CHAOS-2219).
+
+Covers:
+ - ID stability: same (metric, suggestion) always produces the same id
+   regardless of the parent opportunity card's daily rank position.
+ - Happy path: items are derived with correct fields from OpportunityCard data.
+ - Degraded path: build_opportunities_response failure → empty items,
+   derived_from_opportunities=False.
+ - Filter translation: scope filter is forwarded into MetricFilter correctly.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.resolvers.improve import (
+    _stable_experiment_id,
+    resolve_experiments,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_context(org_id: str = "test-org") -> GraphQLContext:
+    """Build a minimal GraphQLContext sufficient for the experiments resolver."""
+    return GraphQLContext(org_id=org_id, db_url="clickhouse://localhost/test")
+
+
+def _make_card(
+    card_id: str,
+    title: str,
+    suggestions: list[str],
+) -> Any:
+    """Build a lightweight OpportunityCard stand-in."""
+    card = types.SimpleNamespace()
+    card.id = card_id
+    card.title = title
+    card.suggested_experiments = suggestions
+    return card
+
+
+def _make_opportunities_response(cards: list[Any]) -> Any:
+    resp = types.SimpleNamespace()
+    resp.items = cards
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# ID stability
+# ---------------------------------------------------------------------------
+
+
+def test_stable_id_same_inputs_always_equal() -> None:
+    """The same (metric, suggestion) always yields the same ID."""
+    id1 = _stable_experiment_id("cycle_time", "Split long-running items into slices.")
+    id2 = _stable_experiment_id("cycle_time", "Split long-running items into slices.")
+    assert id1 == id2
+
+
+def test_stable_id_invariant_to_card_rank(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ID must not change when the opportunity card's rank (card.id) changes.
+
+    Simulates the daily rank-shift: the same suggestion appearing in
+    card opp-1 today and opp-3 tomorrow should produce the same experiment id.
+    """
+    suggestion = "Reserve a daily review block for PRs waiting longest."
+    metric = "review_latency"
+
+    id_rank1 = _stable_experiment_id(metric, suggestion)
+    id_rank3 = _stable_experiment_id(metric, suggestion)
+
+    # Both calls use (metric, suggestion) — the card rank is NOT in the hash.
+    assert id_rank1 == id_rank3
+    assert len(id_rank1) == 16  # 16-hex-char prefix
+
+
+def test_stable_id_differs_for_different_suggestions() -> None:
+    """Different suggestion texts produce different IDs."""
+    id_a = _stable_experiment_id("cycle_time", "Suggestion A")
+    id_b = _stable_experiment_id("cycle_time", "Suggestion B")
+    assert id_a != id_b
+
+
+def test_stable_id_differs_for_different_metrics() -> None:
+    """Same suggestion text under a different metric produces a different ID."""
+    id_ct = _stable_experiment_id("cycle_time", "Trace oldest active items.")
+    id_rl = _stable_experiment_id("review_latency", "Trace oldest active items.")
+    assert id_ct != id_rl
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_happy_path_returns_correct_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Derived experiments carry the correct hypothesis, metric, and status."""
+    cards = [
+        _make_card(
+            "opp-1",
+            "Reduce Cycle Time",
+            ["Trace oldest active items.", "Split a long-running item."],
+        ),
+        _make_card(
+            "opp-2",
+            "Reduce Review Latency",
+            ["Reserve a daily review block."],
+        ),
+    ]
+    fake_response = _make_opportunities_response(cards)
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.opportunities.build_opportunities_response",
+        AsyncMock(return_value=fake_response),
+    )
+
+    ctx = _make_context()
+    result = await resolve_experiments(ctx)
+
+    assert result.derived_from_opportunities is True
+    assert len(result.items) == 3
+
+    # Map by hypothesis for order-independent assertions.
+    by_hyp = {e.hypothesis: e for e in result.items}
+
+    exp_ct = by_hyp["Trace oldest active items."]
+    assert exp_ct.metric == "cycle_time"
+    assert exp_ct.status.value == "suggested"
+    assert exp_ct.opportunity_id == "opp-1"
+    assert exp_ct.owner == ""
+    assert exp_ct.stop_condition == ""
+    assert exp_ct.start_date is None
+    assert exp_ct.stop_date is None
+    assert exp_ct.outcome is None
+
+    exp_rl = by_hyp["Reserve a daily review block."]
+    assert exp_rl.metric == "review_latency"
+    assert exp_rl.opportunity_id == "opp-2"
+
+
+@pytest.mark.asyncio
+async def test_happy_path_ids_are_content_stable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """IDs must be derivable from (metric, suggestion) alone — not from card rank."""
+    suggestion = "Trace oldest active items."
+    metric_key = "cycle_time"
+
+    # Simulate the card appearing at rank opp-1 today …
+    cards_today = [_make_card("opp-1", "Reduce Cycle Time", [suggestion])]
+    # … and at rank opp-5 tomorrow due to metric fluctuations.
+    cards_tomorrow = [_make_card("opp-5", "Reduce Cycle Time", [suggestion])]
+
+    async def _fake_response(cards):
+        async def _inner(**_kw):
+            return _make_opportunities_response(cards)
+
+        return _inner
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.opportunities.build_opportunities_response",
+        AsyncMock(return_value=_make_opportunities_response(cards_today)),
+    )
+    ctx = _make_context()
+    result_today = await resolve_experiments(ctx)
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.opportunities.build_opportunities_response",
+        AsyncMock(return_value=_make_opportunities_response(cards_tomorrow)),
+    )
+    result_tomorrow = await resolve_experiments(ctx)
+
+    assert result_today.items[0].id == result_tomorrow.items[0].id
+    # ID must also equal the direct helper output.
+    assert result_today.items[0].id == _stable_experiment_id(metric_key, suggestion)
+
+
+# ---------------------------------------------------------------------------
+# Degraded path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_degraded_path_on_service_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When build_opportunities_response raises, return empty + derived_from_opportunities=False."""
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.opportunities.build_opportunities_response",
+        AsyncMock(side_effect=RuntimeError("ClickHouse timeout")),
+    )
+
+    ctx = _make_context()
+    result = await resolve_experiments(ctx)
+
+    assert result.derived_from_opportunities is False
+    assert result.items == []
+
+
+# ---------------------------------------------------------------------------
+# Filter translation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scope_filter_is_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scope filter from GraphQL FilterInput is forwarded to MetricFilter."""
+    from dev_health_ops.api.graphql.models.inputs import (
+        FilterInput,
+        ScopeFilterInput,
+        ScopeLevelInput,
+    )
+
+    captured: dict = {}
+
+    async def _capture_filters(**kwargs: Any):
+        captured["filters"] = kwargs.get("filters")
+        return _make_opportunities_response([])
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.opportunities.build_opportunities_response",
+        _capture_filters,
+    )
+
+    scope_input = ScopeFilterInput(level=ScopeLevelInput.TEAM, ids=["team-alpha"])
+    filters = FilterInput(scope=scope_input)
+
+    ctx = _make_context()
+    await resolve_experiments(ctx, filters=filters)
+
+    assert captured["filters"] is not None
+    mf = captured["filters"]
+    assert mf.scope.level == "team"
+    assert mf.scope.ids == ["team-alpha"]


### PR DESCRIPTION
## Summary

- Adds `Experiment` Strawberry GraphQL type with `hypothesis`, `owner`, `metric`, `stop_condition`, `start_date`, `stop_date`, `outcome`, `status` fields
- Adds `ExperimentStatus` enum (`SUGGESTED`, `ACTIVE`, `COMPLETED`, `ABANDONED`)
- Adds `ExperimentsResult` wrapper with `derived_from_opportunities` flag
- Adds `resolve_experiments` — v1 **derivation-first** resolver: assembles Experiment objects at query-time from `OpportunityCard.suggested_experiments`; no persistence table required
- Wires `experiments(orgId, filters) -> ExperimentsResult` query in `schema.py`
- Experiment IDs are content-stable: `sha256(metric:suggestion)[:16]` — invariant to daily rank-shifts of the parent opportunity card
- Reuses `context.cache` (app-level TTLCache) rather than creating a cold instance per request

## Persistence decision

**Derived/computed (v1)** — no `experiments` table. The resolver calls `build_opportunities_response` (same service as `/api/v1/opportunities`), iterates each `OpportunityCard.suggested_experiments`, and promotes each string into a typed `Experiment` with `status=SUGGESTED`. The GraphQL contract (field names, types) is stable for a v2 persistence layer that adds owner/stop_condition writes without schema changes.

## Known technical debt

`_metric_from_card` reverses the metric key from the opportunity card's `title` field (`"Reduce <metric_label>"` → `"cycle_time"`). This is intentionally lightweight for v1. The correct v2 fix is to add a `metric_key: str` field to `OpportunityCard` directly, so resolvers never need to reverse-engineer it from display text. Tracked in CHAOS-2219 follow-up.

## Test plan

- [x] `uv run python -c "from dev_health_ops.api.graphql.schema import schema"` — schema loads clean
- [x] `uv run pytest tests/test_improve_resolver.py -v` — 8/8 passed (ID stability ×4, happy path ×2, degraded ×1, filter translation ×1)
- [x] `uv run pytest tests/test_utils.py tests/test_migrations_style.py tests/test_cache_mget.py` — 39 passed, 1 skipped
- [x] `uv run ruff format --check .` and `uv run ruff check .` — all clean

Closes CHAOS-2219