### PR TITLE
docs: GitHub App auth nav link + Marketplace/install plan

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
   - Connectors:
       - Usage: connectors/usage.md
       - Private Repos: connectors/private-repo-testing.md
+      - GitHub App Auth: user-guide/github-app-auth.md
   - Metrics:
       - Overview: metrics.md
       - Inventory: metrics-inventory.md


### PR DESCRIPTION
## Summary

Two docs-only changes for the GitHub App workstream:

1. **Link the orphaned GitHub App Auth guide** — `docs/user-guide/github-app-auth.md` existed but was not in `mkdocs.yml` nav (rendered to the published site but invisible in navigation). Now linked under **Connectors**.
2. **Add the Marketplace + frictionless-install plan** — new `docs/plans/github-app-marketplace.md` (linked under **Plans**) capturing the research-backed implementation plan for one-click GitHub App install and Marketplace listing.

## Plan doc highlights

- Current-state audit: token minting, credential model, encrypted storage, webhook router, and admin APIs **already exist**.
- Gaps: (0) Celery worker ignores App auth, (1) no installation persistence/callback, (2) no install/marketplace webhooks, (3) no web "Connect App" path.
- Phased plan: P0 worker fix -> P1 install capture (ops+web) -> P2 Marketplace listing (flagged for a follow-up GitHub-docs verification pass) -> P3 optional self-hosted App Manifest helper.

Tracked in Linear (CHAOS) as a parent + per-phase sub-issues.

## Notes

- Docs-only; no code, no rendered frontend output.
- web/ has no MkDocs/gh-pages docs site, so no equivalent change there.

SCREENSHOT-WAIVER: docs nav + planning markdown only, no rendered UI in this repo.