### PR TITLE
fix(workers): support GitHub App auth in sync worker + discovery (CHAOS-2234)

### DIFF
--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -255,8 +255,10 @@ def github_credentials_from_mapping(
 
     try:
         return GitHubCredentials(**kwargs)
-    except (ValueError, TypeError) as exc:
-        logger.debug("Incomplete GitHub credentials mapping: %s", exc)
+    except (ValueError, TypeError):
+        # Do not log the exception: it derives from credential construction and
+        # could surface field values. Callers raise a clear config error instead.
+        logger.debug("GitHub credentials mapping was incomplete or invalid")
         return None
 
 

--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -218,6 +218,48 @@ class CredentialResolver:
         return cred_type(**cred_dict)
 
 
+def github_credentials_from_mapping(
+    cred_dict: dict[str, Any],
+    *,
+    source: CredentialSource = CredentialSource.DATABASE,
+    credential_name: str = "default",
+) -> GitHubCredentials | None:
+    """Build :class:`GitHubCredentials` (PAT or App auth) from a credentials mapping.
+
+    Accepts a decrypted credentials dict (as persisted in ``integration_credentials``
+    or assembled from environment variables) and returns a typed credential the
+    GitHub connector can consume directly. A ``private_key_path`` is resolved to the
+    ``private_key`` contents when only the path is present.
+
+    Returns ``None`` when the mapping contains neither a ``token`` nor a complete
+    App-auth triple (``app_id`` + ``private_key``/``private_key_path`` +
+    ``installation_id``), so callers can surface a clear configuration error.
+    """
+    cred_dict = {k: v for k, v in cred_dict.items() if v is not None}
+    if not cred_dict:
+        return None
+
+    if "private_key" not in cred_dict:
+        private_key_path = cred_dict.get("private_key_path")
+        if private_key_path:
+            try:
+                with open(str(private_key_path), encoding="utf-8") as key_file:
+                    cred_dict["private_key"] = key_file.read()
+            except OSError as exc:
+                logger.debug("Could not read GitHub App private key path: %s", exc)
+
+    allowed = {"token", "app_id", "private_key", "installation_id", "base_url"}
+    kwargs = {k: v for k, v in cred_dict.items() if k in allowed}
+    kwargs["source"] = source
+    kwargs["credential_name"] = credential_name
+
+    try:
+        return GitHubCredentials(**kwargs)
+    except (ValueError, TypeError) as exc:
+        logger.debug("Incomplete GitHub credentials mapping: %s", exc)
+        return None
+
+
 def resolve_credentials_sync(
     provider: str,
     org_id: str | None = None,

--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -9,13 +9,34 @@ def discover_repos_for_config(
 ) -> list[tuple[str, ...]]:
     provider = (config.provider or "").lower()
     sync_options = dict(config.sync_options or {})
-    token = str(credentials.get("token") or "")
 
     if provider == "github":
+        token = _github_token_from_credentials(credentials)
+        if not token:
+            return []
         return discover_github_repos(sync_options, token)
     if provider == "gitlab":
+        token = str(credentials.get("token") or "")
         return discover_gitlab_repos(sync_options, token)
     return []
+
+
+def _github_token_from_credentials(credentials: dict[str, Any]) -> str:
+    """Resolve a usable GitHub token from a credentials mapping.
+
+    Supports both PAT (``token``) and GitHub App auth; for App auth an
+    installation token is minted via the GitHub connector.
+    """
+    from dev_health_ops.credentials.resolver import github_credentials_from_mapping
+
+    gh_credentials = github_credentials_from_mapping(credentials)
+    if gh_credentials is None:
+        return ""
+    if gh_credentials.is_app_auth:
+        from dev_health_ops.connectors.github import GitHubConnector
+
+        return GitHubConnector(credentials=gh_credentials).token
+    return gh_credentials.token or ""
 
 
 def discover_github_repos(

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from celery import chord, group
 
+from dev_health_ops.credentials.resolver import github_credentials_from_mapping
 from dev_health_ops.utils.datetime import utc_today
 from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
@@ -322,11 +323,11 @@ def _run_sync_for_repo(
         if provider == "github":
             owner = str(sync_options_override.get("owner", ""))
             repo_name = str(sync_options_override.get("repo", ""))
-            token = str(credentials.get("token") or "")
+            github_credentials = github_credentials_from_mapping(credentials)
 
-            if not owner or not repo_name or not token:
+            if not owner or not repo_name or github_credentials is None:
                 raise ValueError(
-                    f"Missing GitHub owner/repo/token for batch sync: "
+                    f"Missing GitHub owner/repo/credentials for batch sync: "
                     f"owner={owner}, repo={repo_name}"
                 )
 
@@ -337,7 +338,7 @@ def _run_sync_for_repo(
                     store=store,
                     owner=owner,
                     repo_name=repo_name,
-                    token=token,
+                    token=github_credentials,
                     blame_only=merged_flags.get("blame_only", False),
                     sync_git=merged_flags.get("sync_git", False),
                     sync_prs=merged_flags.get("sync_prs", False),

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
+from dev_health_ops.credentials.resolver import github_credentials_from_mapping
 from dev_health_ops.utils.datetime import utc_today
 from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
@@ -505,9 +506,11 @@ def run_sync_config(
                 )
 
             owner, repo_name = owner_repo
-            token = str(credentials.get("token") or "")
-            if not token:
-                raise ValueError("Missing GitHub token for sync configuration")
+            github_credentials = github_credentials_from_mapping(credentials)
+            if github_credentials is None:
+                raise ValueError(
+                    "Missing GitHub token or App credentials for sync configuration"
+                )
 
             merged_flags = _merge_sync_flags(sync_targets)
 
@@ -516,7 +519,7 @@ def run_sync_config(
                     store=store,
                     owner=owner,
                     repo_name=repo_name,
-                    token=token,
+                    token=github_credentials,
                     since=since_dt,
                     **merged_flags,
                 )

--- a/tests/test_worker_github_app_auth.py
+++ b/tests/test_worker_github_app_auth.py
@@ -1,0 +1,160 @@
+"""Regression tests for GitHub App auth support in the sync worker path.
+
+Background sync previously extracted only the ``token`` key from decrypted
+credentials and raised when it was absent, so GitHub App-auth sync configs
+failed in the Celery worker (CHAOS-2234). These tests lock the fix: the worker
+and repo-discovery paths build a typed :class:`GitHubCredentials` (PAT or App)
+via ``github_credentials_from_mapping`` and mint an installation token for App
+auth.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from dev_health_ops.credentials import CredentialSource
+from dev_health_ops.credentials.resolver import github_credentials_from_mapping
+
+# ---------------------------------------------------------------------------
+# github_credentials_from_mapping
+# ---------------------------------------------------------------------------
+
+
+def test_mapping_builds_pat_credentials() -> None:
+    creds = github_credentials_from_mapping({"token": "ghp_secret"})
+
+    assert creds is not None
+    assert creds.is_app_auth is False
+    assert creds.token == "ghp_secret"
+    assert creds.source == CredentialSource.DATABASE
+
+
+def test_mapping_builds_app_credentials() -> None:
+    creds = github_credentials_from_mapping(
+        {
+            "app_id": "12345",
+            "private_key": "synthetic-private-key",
+            "installation_id": "67890",
+        }
+    )
+
+    assert creds is not None
+    assert creds.is_app_auth is True
+    assert creds.app_id == "12345"
+    assert creds.private_key == "synthetic-private-key"
+    assert creds.installation_id == "67890"
+
+
+def test_mapping_resolves_private_key_path(tmp_path) -> None:
+    key_path = tmp_path / "app.pem"
+    key_path.write_text("pem-contents", encoding="utf-8")
+
+    creds = github_credentials_from_mapping(
+        {
+            "app_id": "12345",
+            "private_key_path": str(key_path),
+            "installation_id": "67890",
+        }
+    )
+
+    assert creds is not None
+    assert creds.is_app_auth is True
+    assert creds.private_key == "pem-contents"
+
+
+def test_mapping_returns_none_when_empty() -> None:
+    assert github_credentials_from_mapping({}) is None
+
+
+def test_mapping_returns_none_when_app_incomplete() -> None:
+    # Missing installation_id => not a complete App triple and no token.
+    assert (
+        github_credentials_from_mapping({"app_id": "12345", "private_key": "k"}) is None
+    )
+
+
+def test_mapping_returns_none_when_token_and_app_conflict() -> None:
+    # token + App fields is rejected by GitHubCredentials validation.
+    assert (
+        github_credentials_from_mapping(
+            {
+                "token": "ghp_secret",
+                "app_id": "12345",
+                "private_key": "k",
+                "installation_id": "67890",
+            }
+        )
+        is None
+    )
+
+
+def test_mapping_ignores_none_values() -> None:
+    creds = github_credentials_from_mapping(
+        {"token": "ghp_secret", "app_id": None, "installation_id": None}
+    )
+
+    assert creds is not None
+    assert creds.is_app_auth is False
+    assert creds.token == "ghp_secret"
+
+
+# ---------------------------------------------------------------------------
+# discover_repos_for_config (repo discovery)
+# ---------------------------------------------------------------------------
+
+
+def _make_config(provider: str, sync_options: dict | None = None):
+    return SimpleNamespace(provider=provider, sync_options=sync_options or {})
+
+
+def test_discover_github_app_auth_mints_token_via_connector() -> None:
+    from dev_health_ops.discovery import repos as repos_mod
+
+    app_credentials = {
+        "app_id": "12345",
+        "private_key": "synthetic-private-key",
+        "installation_id": "67890",
+    }
+    config = _make_config("github", {"search": "my-org/*"})
+
+    with (
+        patch.object(repos_mod, "discover_github_repos") as discover,
+        patch("dev_health_ops.connectors.github.GitHubConnector") as connector_cls,
+    ):
+        connector_cls.return_value = SimpleNamespace(token="installation-token")
+        discover.return_value = [("my-org", "api")]
+
+        result = repos_mod.discover_repos_for_config(config, app_credentials)
+
+    assert result == [("my-org", "api")]
+    # App credentials were converted to a typed credential and the connector
+    # minted an installation token from them.
+    assert connector_cls.call_args.kwargs["credentials"].is_app_auth is True
+    # discover_github_repos receives the minted token string, not raw app fields.
+    assert discover.call_args.args[1] == "installation-token"
+
+
+def test_discover_github_pat_passes_token_through() -> None:
+    from dev_health_ops.discovery import repos as repos_mod
+
+    config = _make_config("github", {"search": "my-org/*"})
+
+    with patch.object(repos_mod, "discover_github_repos") as discover:
+        discover.return_value = [("my-org", "api")]
+        result = repos_mod.discover_repos_for_config(config, {"token": "ghp_x"})
+
+    assert result == [("my-org", "api")]
+    assert discover.call_args.args[1] == "ghp_x"
+
+
+def test_discover_github_returns_empty_without_credentials() -> None:
+    from dev_health_ops.discovery import repos as repos_mod
+
+    config = _make_config("github", {"search": "my-org/*"})
+
+    with patch.object(repos_mod, "discover_github_repos") as discover:
+        result = repos_mod.discover_repos_for_config(config, {})
+
+    assert result == []
+    discover.assert_not_called()


### PR DESCRIPTION
## Summary

Phase 0 of the GitHub App Marketplace + frictionless-install plan (CHAOS-2233). Fixes the prerequisite bug where **background sync ignored GitHub App auth**.

The Celery worker and repo-discovery paths extracted only the `token` key from decrypted credentials and raised `Missing GitHub token ...` when it was absent — so GitHub App-auth sync configs (`app_id` + `private_key` + `installation_id`) failed in the worker even though the connector/processor layer already supports them.

## Change

- **New helper** `github_credentials_from_mapping()` in `credentials/resolver.py` — builds a typed `GitHubCredentials` (PAT **or** App auth) from a decrypted credentials mapping, resolving `private_key_path` → `private_key`, returning `None` for empty/incomplete/conflicting input.
- **`workers/sync_runtime.py`** (`run_sync_config`) — builds `GitHubCredentials` and passes it to `process_github_repo` (which already accepts `str | GitHubCredentials`).
- **`workers/sync_batch.py`** (batch child sync) — same.
- **`discovery/repos.py`** — resolves a usable token for repo discovery, minting an installation token via the connector when App auth is configured. `discover_github_repos(token: str)` signature unchanged.

No DB/schema changes. The processor → `GitHubConnector(credentials=...)` → `GitHubAppTokenProvider` chain was already in place.

## Tests

- New `tests/test_worker_github_app_auth.py` (10 tests): `github_credentials_from_mapping` for PAT / App / `private_key_path` / empty / incomplete / token+app conflict / None-values; discovery mints an install token for App auth, passes PAT through, and returns empty without credentials.
- **159 passed** across new + `test_github_app_auth`, `test_sync_partitioning`, `test_batch_processing`, `test_credential_resolver`. ruff format/check clean.

## Notes

- Pre-existing, unrelated: `tests/test_processors_sync.py` fails collection with a circular import in `providers/_base` — reproduced identically on clean `main`. Not addressed here.

Closes CHAOS-2234

SCREENSHOT-WAIVER: backend-only change, no rendered UI.