### PR TITLE
fix(api): key /auth/validate rate limit per-token, not per-IP (CHAOS-2232)

### DIFF
--- a/src/dev_health_ops/api/auth/routers/session.py
+++ b/src/dev_health_ops/api/auth/routers/session.py
@@ -8,7 +8,11 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy import select
 
-from dev_health_ops.api.middleware.rate_limit import AUTH_VALIDATE_LIMIT, limiter
+from dev_health_ops.api.middleware.rate_limit import (
+    AUTH_VALIDATE_LIMIT,
+    get_validate_key,
+    limiter,
+)
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.refresh_tokens import revoke_token
 from dev_health_ops.api.utils.audit import emit_audit_log
@@ -202,7 +206,7 @@ async def switch_org(
 
 
 @router.post("/validate", response_model=TokenValidateResponse)
-@limiter.limit(AUTH_VALIDATE_LIMIT)
+@limiter.limit(AUTH_VALIDATE_LIMIT, key_func=get_validate_key)
 async def validate_token(
     payload: TokenValidateRequest,
     request: Request,

--- a/src/dev_health_ops/api/middleware/rate_limit.py
+++ b/src/dev_health_ops/api/middleware/rate_limit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -84,6 +85,31 @@ def get_forwarded_ip(request: Request) -> str:
     if forwarded and peer in _trusted_proxies():
         return forwarded.split(",")[0].strip()
     return peer
+
+
+def get_validate_key(request: Request) -> str:
+    """Rate-limit key for POST /auth/validate: per-token, not per-IP.
+
+    The web app calls /validate server-side, so every user shares the same
+    TCP peer (the web container). Keying on IP collapses all users into one
+    bucket and the limit becomes a deployment-wide throughput cap (CHAOS-2232).
+    Key on a digest of the submitted token instead — never the raw token,
+    which must not appear in limiter storage or error messages.
+    """
+    body = getattr(request, "_body", None)
+    if isinstance(body, (bytes, bytearray)) and body:
+        try:
+            payload = json.loads(body)
+            if isinstance(payload, dict):
+                token = payload.get("token")
+                if isinstance(token, str) and token:
+                    digest = hashlib.sha256(token.encode("utf-8")).hexdigest()[:32]
+                    return f"validate-token:{digest}"
+        except (UnicodeDecodeError, json.JSONDecodeError, TypeError):
+            logging.getLogger(__name__).debug(
+                "Could not parse request body for validate rate-limit key"
+            )
+    return f"validate-ip:{get_forwarded_ip(request)}"
 
 
 def get_admin_user_key(request: Request) -> str:

--- a/tests/api/test_validate_rate_limit_key.py
+++ b/tests/api/test_validate_rate_limit_key.py
@@ -1,0 +1,95 @@
+"""Per-token rate-limit keying for POST /auth/validate (CHAOS-2232).
+
+The web app calls /validate server-side, so every user shares the same TCP
+peer (the web container). The key must come from the submitted token — as a
+digest, never the raw value — with an IP fallback for tokenless requests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from fastapi import Request
+
+from dev_health_ops.api.middleware.rate_limit import get_validate_key
+
+
+def _make_request(
+    client_host: str = "172.20.0.11",
+    body: bytes | None = None,
+) -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/auth/validate",
+        "headers": [],
+        "client": (client_host, 12345),
+    }
+    request = Request(scope)
+    if body is not None:
+        request._body = body
+    return request
+
+
+def test_token_present_keys_on_digest():
+    token = "eyJhbGciOiJIUzI1NiJ9.payload.sig"
+    req = _make_request(body=json.dumps({"token": token}).encode())
+    expected = hashlib.sha256(token.encode("utf-8")).hexdigest()[:32]
+    assert get_validate_key(req) == f"validate-token:{expected}"
+
+
+def test_raw_token_never_appears_in_key():
+    token = "secret-token-value"
+    req = _make_request(body=json.dumps({"token": token}).encode())
+    assert token not in get_validate_key(req)
+
+
+def test_distinct_tokens_get_distinct_buckets():
+    req_a = _make_request(body=json.dumps({"token": "token-a"}).encode())
+    req_b = _make_request(body=json.dumps({"token": "token-b"}).encode())
+    assert get_validate_key(req_a) != get_validate_key(req_b)
+
+
+def test_same_token_same_bucket_across_requests():
+    body = json.dumps({"token": "token-a"}).encode()
+    assert get_validate_key(_make_request(body=body)) == get_validate_key(
+        _make_request(body=body)
+    )
+
+
+def test_missing_body_falls_back_to_ip():
+    req = _make_request(client_host="172.20.0.11", body=None)
+    assert get_validate_key(req) == "validate-ip:172.20.0.11"
+
+
+def test_malformed_json_falls_back_to_ip():
+    req = _make_request(client_host="172.20.0.11", body=b"not-json{")
+    assert get_validate_key(req) == "validate-ip:172.20.0.11"
+
+
+def test_non_string_token_falls_back_to_ip():
+    req = _make_request(
+        client_host="172.20.0.11", body=json.dumps({"token": 123}).encode()
+    )
+    assert get_validate_key(req) == "validate-ip:172.20.0.11"
+
+
+def test_empty_token_falls_back_to_ip():
+    req = _make_request(
+        client_host="172.20.0.11", body=json.dumps({"token": ""}).encode()
+    )
+    assert get_validate_key(req) == "validate-ip:172.20.0.11"
+
+
+def test_ip_fallback_respects_trusted_proxy(monkeypatch):
+    """The fallback path reuses get_forwarded_ip's trust rules."""
+    monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.1")
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/auth/validate",
+        "headers": [(b"x-forwarded-for", b"203.0.113.1")],
+        "client": ("10.0.0.1", 12345),
+    }
+    assert get_validate_key(Request(scope)) == "validate-ip:203.0.113.1"


### PR DESCRIPTION
## Problem (CHAOS-2232)

Prod logs are flooded with:

```
slowapi: ratelimit 30 per 15 minute (172.20.0.11) exceeded at endpoint: /api/v1/auth/validate
```

`172.20.0.11` is the **web container**, not a user. The NextAuth `jwt` callback calls `POST /api/v1/auth/validate` server-side, so every user's session validation arrives from the same TCP peer. The limiter keys on `get_forwarded_ip` (peer fallback; `TRUSTED_PROXIES` unset and the web fetch sends no `X-Forwarded-For` anyway), so **all users collapse into one 30/15min bucket** — a deployment-wide cap of ~11 active users (each session validates every 5 min), after which validation is 429'd and silently skipped.

## Fix

- New `get_validate_key` in `api/middleware/rate_limit.py`: keys on `sha256(token)[:32]` from the JSON body (`validate-token:<digest>`), falling back to `validate-ip:<forwarded-ip>` when no token is present. Raw token never enters limiter storage, keys, or logs. Modeled on the existing `get_admin_user_key` per-principal pattern.
- `/auth/validate` decorator now uses `@limiter.limit(AUTH_VALIDATE_LIMIT, key_func=get_validate_key)`. The 30/15min figure is unchanged — per token it is generous (legit sessions validate ~3×/15min) while still bounding abuse per stolen/looped token; the tokenless fallback keeps an IP bound for junk traffic.

## Tests

`tests/api/test_validate_rate_limit_key.py` — 9 cases: digest keying, no raw token leakage, distinct/stable buckets, IP fallback for missing body / malformed JSON / non-string / empty token, trusted-proxy XFF handling on the fallback path.

## Gates

- ruff format/check: clean
- mypy `--install-types --non-interactive .`: 1 pre-existing unrelated error (`pandas-stubs` not installable in local sandbox; clean in CI), changed files clean
- unit suite: all failures are local-env only (blocked sockets to local Redis/ClickHouse, OTLP exporter noise in CLI-help assertions); every auth/rate-limit test passes, incl. `tests/test_auth_db_check.py::test_validate_endpoint_rejects_nonexistent_user`

SCREENSHOT-WAIVER: backend rate-limit keying change; no rendered frontend impact.

Linear: CHAOS-2232 (related: CHAOS-2231)