### PR TITLE
fix(security): suppress false-positive logger-credential-disclosure in resolver (CHAOS-2241)

### DIFF
--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -100,7 +100,8 @@ class CredentialResolver:
 
         db_creds = await self._try_database(provider, credential_name)
         if db_creds is not None:
-            logger.info(
+            # Non-secret identifiers only (provider, org id, credential name).
+            logger.info(  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
                 "Resolved %s credentials from database for org=%s name=%s",
                 provider,
                 self.org_id,
@@ -155,7 +156,8 @@ class CredentialResolver:
             )
 
         except Exception as e:
-            logger.warning(
+            # Logs provider + failure reason; never credential values.
+            logger.warning(  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
                 "Failed to fetch %s credentials from database: %s",
                 provider,
                 e,
@@ -190,7 +192,8 @@ class CredentialResolver:
                 credential_name=credential_name,
             )
         except (ValueError, TypeError) as e:
-            logger.debug(
+            # Logs provider + validation error; never credential values.
+            logger.debug(  # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
                 "Incomplete %s credentials from environment: %s",
                 provider,
                 e,


### PR DESCRIPTION
## Summary

Resolves the three pre-existing Semgrep `python-logger-credential-disclosure` (CWE-532) findings in `src/dev_health_ops/credentials/resolver.py`. These surfaced as a false positive adjacent to PR #832 — the bot only commented on the changed line, but the same rule flags three pre-existing `logger.*` calls in this file.

## Why these are false positives

All three log only **non-secret identifiers** — provider name, org id, credential *name* — and resolution exceptions. None log credential values:

- `CredentialResolver.resolve` — `"Resolved %s credentials from database for org=%s name=%s"` (provider, org_id, credential_name)
- `_try_database` — `"Failed to fetch %s credentials from database: %s"` (provider, exception)
- `_try_environment` — `"Incomplete %s credentials from environment: %s"` (provider, validation exception)

## Change

Annotated each with the repo's **established convention** for this exact rule (`# nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure`, already used in `api/auth/routers/login.py` and `password_reset.py`) plus a one-line justification comment.

## Verification

- ruff format/check clean.
- Local Semgrep re-scan: all three findings now report `is_ignored: true` (suppressed).
- Comment-only change — no behavior change, no tests needed.

Closes CHAOS-2241

SCREENSHOT-WAIVER: backend comment-only change, no rendered UI.