### PR TITLE
fix(auth): reject token refresh for deactivated users (CHAOS-2238)

### DIFF
--- a/src/dev_health_ops/api/auth/routers/refresh.py
+++ b/src/dev_health_ops/api/auth/routers/refresh.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.middleware.rate_limit import AUTH_REFRESH_LIMIT, limiter
 from dev_health_ops.api.services.refresh_tokens import (
@@ -18,6 +19,7 @@ from dev_health_ops.api.services.refresh_tokens import (
 from dev_health_ops.api.utils.audit import emit_audit_log
 from dev_health_ops.api.utils.errors import error_detail
 from dev_health_ops.models.audit import AuditAction, AuditResourceType
+from dev_health_ops.models.refresh_token import RefreshToken
 from dev_health_ops.models.users import Membership, Organization, User
 
 from .common import (
@@ -53,6 +55,47 @@ class TokenRefreshResponse(BaseModel):
     token_type: str = "bearer"
     expires_in: int
     user: UserInfo | None = None
+
+
+async def _reject_if_deactivated(
+    db: AsyncSession,
+    *,
+    user: User,
+    token_record: RefreshToken,
+    refresh_org_id: str,
+    user_id: str,
+    request: Request,
+) -> None:
+    """Revoke the token family and raise 401 when the user is deactivated.
+
+    Deactivation must cut off token issuance, not just API access:
+    get_current_user already blocks deactivated users per-request, but without
+    this check a deactivated user could keep rotating refresh tokens and
+    minting fresh access tokens indefinitely (CHAOS-2238).
+    """
+    if user.is_active:
+        return
+    await revoke_family(db, str(token_record.family_id))
+    parsed_org_id = _parse_uuid(refresh_org_id)
+    if parsed_org_id is not None:
+        emit_audit_log(
+            db,
+            org_id=parsed_org_id,
+            action=AuditAction.LOGIN_FAILED,
+            resource_type=AuditResourceType.SESSION,
+            resource_id=user_id,
+            user_id=_require_uuid(user.id, "user.id"),
+            description="Token refresh failed: user deactivated",
+            request=request,
+            status="failure",
+            error_message="Account is disabled",
+        )
+    await db.commit()
+    logger.warning("Refresh rejected for deactivated user: %s", user_id)
+    raise HTTPException(
+        status_code=401,
+        detail=error_detail("Account is disabled"),
+    )
 
 
 @router.post("/refresh", response_model=TokenRefreshResponse)
@@ -152,6 +195,14 @@ async def refresh_token(
                         )
                         user = user_result.scalar_one_or_none()
                         if user is not None:
+                            await _reject_if_deactivated(
+                                db,
+                                user=user,
+                                token_record=token_record,
+                                refresh_org_id=refresh_org_id,
+                                user_id=user_id,
+                                request=request,
+                            )
                             role = "member"
                             if refresh_org_id:
                                 membership_result = await db.execute(
@@ -246,6 +297,15 @@ async def refresh_token(
                 status_code=401,
                 detail=error_detail("User not found"),
             )
+
+        await _reject_if_deactivated(
+            db,
+            user=user,
+            token_record=token_record,
+            refresh_org_id=refresh_org_id,
+            user_id=user_id,
+            request=request,
+        )
 
         role = "member"
         if refresh_org_id:

--- a/tests/api/auth/test_refresh_deactivated_user.py
+++ b/tests/api/auth/test_refresh_deactivated_user.py
@@ -1,0 +1,310 @@
+"""Deactivated-user refresh rejection tests (CHAOS-2238).
+
+Root cause: /api/v1/auth/refresh loaded the User row but never checked
+``User.is_active``, so a deactivated user could keep rotating refresh tokens
+and minting fresh access tokens indefinitely.  get_current_user blocks API
+use downstream, but token issuance itself must also be cut off.
+
+Tests in this module:
+- deactivated_user_refresh_rejected: deactivated user presents a valid
+  refresh token → 401 "Account is disabled", the token family is revoked,
+  and an audit log entry is recorded.
+- deactivated_user_token_unusable_after_rejection: after the rejection the
+  same token (and family) stays dead — replaying it returns 401.
+- deactivated_user_grace_window_replay_rejected: a token rotated while the
+  user was active cannot be replayed through the concurrent-rotation grace
+  window once the user is deactivated.
+- active_user_refresh_unaffected: regression guard — normal rotation still
+  returns 200 with a usable successor.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+
+import bcrypt
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.middleware.rate_limit import limiter as rate_limiter
+from dev_health_ops.api.services.auth import AuthService
+from dev_health_ops.api.services.refresh_tokens import (
+    create_refresh_token as db_create_refresh_token,
+)
+from dev_health_ops.models.audit import AuditLog
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.refresh_token import RefreshToken
+from dev_health_ops.models.users import LoginAttempt, Membership, Organization, User
+from tests._helpers import tables_of
+
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+JWT_SECRET = "test-secret-key-that-is-long-enough-32+"
+AUTH_SERVICE = AuthService(secret_key=JWT_SECRET)
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "refresh-deactivated.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(
+                    User,
+                    Organization,
+                    Membership,
+                    AuditLog,
+                    LoginAttempt,
+                    RefreshToken,
+                ),
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seed(session_maker):
+    """Create one active user + org + membership in the DB."""
+    password_hash = bcrypt.hashpw(b"Pass123!", bcrypt.gensalt()).decode()
+    user = User(
+        id=uuid.uuid4(),
+        email="deactivated@example.com",
+        username="deactivated",
+        password_hash=password_hash,
+        is_active=True,
+        is_verified=True,
+    )
+    org = Organization(
+        id=uuid.uuid4(), slug="deact-org", name="Deact Org", tier="community"
+    )
+    async with session_maker() as session:
+        session.add_all([user, org])
+        await session.flush()
+        session.add(
+            Membership(
+                user_id=user.id,
+                org_id=org.id,
+                role="owner",
+                joined_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.commit()
+
+    return {
+        "user_id": str(user.id),
+        "email": str(user.email),
+        "org_id": str(org.id),
+    }
+
+
+async def _mint_and_store_token(
+    session_maker, seed: dict, *, family_id: str | None = None
+) -> tuple[str, str]:
+    """Mint a fresh refresh JWT and persist it to the DB.
+
+    Returns (jwt_string, jti_string).
+    """
+    fid = family_id or str(uuid.uuid4())
+    refresh_jwt = AUTH_SERVICE.create_refresh_token(
+        user_id=seed["user_id"],
+        org_id=seed["org_id"],
+        family_id=fid,
+    )
+    payload = AUTH_SERVICE.validate_token(refresh_jwt, token_type="refresh")
+    assert payload is not None
+    jti = str(payload["jti"])
+    exp = datetime.fromtimestamp(float(payload["exp"]), tz=timezone.utc)
+
+    async with session_maker() as session:
+        await db_create_refresh_token(
+            db=session,
+            user_id=seed["user_id"],
+            org_id=seed["org_id"],
+            token_hash=jti,
+            family_id=fid,
+            expires_at=exp,
+        )
+        await session.commit()
+
+    return refresh_jwt, jti
+
+
+async def _deactivate_user(session_maker, seed: dict) -> None:
+    async with session_maker() as session:
+        await session.execute(
+            update(User)
+            .where(User.id == uuid.UUID(seed["user_id"]))
+            .values(is_active=False)
+        )
+        await session.commit()
+
+
+async def _active_token_count(session_maker, family_id: str) -> int:
+    async with session_maker() as session:
+        result = await session.execute(
+            select(func.count())
+            .select_from(RefreshToken)
+            .where(
+                RefreshToken.family_id == uuid.UUID(family_id),
+                RefreshToken.revoked_at.is_(None),
+            )
+        )
+        return int(result.scalar_one())
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch: pytest.MonkeyPatch, session_maker):
+    """FastAPI test client wired to the in-memory SQLite DB."""
+    app = FastAPI()
+    app.include_router(auth_router_module.router)
+
+    app.add_exception_handler(
+        RequestValidationError,
+        lambda req, exc: JSONResponse(
+            status_code=422,
+            content={"detail": {"message": "Validation failed", "errors": []}},
+        ),
+    )
+
+    @asynccontextmanager
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(auth_router_module, "get_postgres_session", _session_override)
+    monkeypatch.setattr(
+        auth_router_module,
+        "get_auth_service",
+        lambda: AUTH_SERVICE,
+    )
+    monkeypatch.setattr(rate_limiter, "enabled", False)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_deactivated_user_refresh_rejected(client, session_maker, seed):
+    """A deactivated user's refresh must 401, revoke the family, and audit."""
+    family_id = str(uuid.uuid4())
+    refresh_jwt, _ = await _mint_and_store_token(
+        session_maker, seed, family_id=family_id
+    )
+    await _deactivate_user(session_maker, seed)
+
+    res = await client.post("/api/v1/auth/refresh", json={"refresh_token": refresh_jwt})
+    assert res.status_code == 401, f"expected 401, got {res.status_code} {res.text}"
+    assert "Account is disabled" in res.text
+
+    assert await _active_token_count(session_maker, family_id) == 0, (
+        "Token family must be fully revoked when a deactivated user refreshes"
+    )
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(AuditLog).where(
+                AuditLog.description == "Token refresh failed: user deactivated"
+            )
+        )
+        assert result.scalars().first() is not None, (
+            "Audit log entry expected for deactivated-user refresh rejection"
+        )
+
+
+@pytest.mark.asyncio
+async def test_deactivated_user_token_unusable_after_rejection(
+    client, session_maker, seed
+):
+    """The revoked family stays dead on subsequent presentations."""
+    family_id = str(uuid.uuid4())
+    refresh_jwt, _ = await _mint_and_store_token(
+        session_maker, seed, family_id=family_id
+    )
+    await _deactivate_user(session_maker, seed)
+
+    first = await client.post(
+        "/api/v1/auth/refresh", json={"refresh_token": refresh_jwt}
+    )
+    assert first.status_code == 401
+
+    replay = await client.post(
+        "/api/v1/auth/refresh", json={"refresh_token": refresh_jwt}
+    )
+    assert replay.status_code == 401, (
+        "Replaying the token after deactivation rejection must stay 401"
+    )
+    assert await _active_token_count(session_maker, family_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_deactivated_user_grace_window_replay_rejected(
+    client, session_maker, seed
+):
+    """The concurrent-rotation grace window must not re-issue tokens to a
+    user deactivated after their last successful rotation."""
+    family_id = str(uuid.uuid4())
+    refresh_jwt, _ = await _mint_and_store_token(
+        session_maker, seed, family_id=family_id
+    )
+
+    # Rotate T1 → T2 while still active.
+    rotated = await client.post(
+        "/api/v1/auth/refresh", json={"refresh_token": refresh_jwt}
+    )
+    assert rotated.status_code == 200, (
+        f"Active-user rotation should succeed: {rotated.status_code} {rotated.text}"
+    )
+
+    await _deactivate_user(session_maker, seed)
+
+    # Present stale T1 within the grace window — must NOT replay the successor.
+    replay = await client.post(
+        "/api/v1/auth/refresh", json={"refresh_token": refresh_jwt}
+    )
+    assert replay.status_code == 401, (
+        "Grace-window replay must be rejected for a deactivated user, got "
+        f"{replay.status_code} {replay.text}"
+    )
+    assert "Account is disabled" in replay.text
+    assert await _active_token_count(session_maker, family_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_active_user_refresh_unaffected(client, session_maker, seed):
+    """Regression guard: active users rotate normally."""
+    family_id = str(uuid.uuid4())
+    refresh_jwt, _ = await _mint_and_store_token(
+        session_maker, seed, family_id=family_id
+    )
+
+    res = await client.post("/api/v1/auth/refresh", json={"refresh_token": refresh_jwt})
+    assert res.status_code == 200, f"{res.status_code} {res.text}"
+    body = res.json()
+    assert body["access_token"]
+    assert body["refresh_token"]
+
+    # Successor is usable.
+    res2 = await client.post(
+        "/api/v1/auth/refresh", json={"refresh_token": body["refresh_token"]}
+    )
+    assert res2.status_code == 200, f"{res2.status_code} {res2.text}"
+    assert await _active_token_count(session_maker, family_id) == 1


### PR DESCRIPTION
## Summary

Fixes [CHAOS-2238](https://linear.app/fullchaos/issue/CHAOS-2238): `POST /api/v1/auth/refresh` loaded the `User` row but never checked `is_active`, so a **deactivated user could keep rotating refresh tokens and minting fresh 60-minute access tokens indefinitely**. `get_current_user` blocks API use downstream, but token issuance itself must be cut off at the refresh choke point.

## Changes

- **`_reject_if_deactivated`** (refresh.py): when the refresh subject is deactivated — revoke the entire token family, emit a `LOGIN_FAILED` audit entry ("Token refresh failed: user deactivated"), and return 401 `Account is disabled` (same message as the `get_current_user` precedent).
- Applied to **both** User loads in the endpoint: the main rotation path and the concurrent-rotation **grace-window replay** path (a successor token must not be re-issued to a user deactivated after their last rotation).
- No changes to rotation/reuse-detection semantics for active users.

## Tests (`tests/api/auth/test_refresh_deactivated_user.py`)

- Deactivated user refresh → 401 + family fully revoked + audit entry recorded
- Post-rejection replay stays 401 (family stays dead)
- Grace-window replay rejected after deactivation (no successor re-issue)
- Active-user rotation regression guard (rotation + successor usable)

## Gates

- ruff format/check: clean
- mypy `--install-types --non-interactive .`: **no issues in 1000 source files**
- Unit suite (CI marker filter): 3825 passed; 4 failures are pre-existing local-env issues (live local ClickHouse/Redis + one collection quirk) — verified identical at `origin/main` in the same environment, untouched by this diff
- New + existing refresh-rotation race suite: 9/9 pass

SCREENSHOT-WAIVER: backend auth behavior only, no rendered frontend change.

Related: #833 (CHAOS-2232 validate rate-limit re-key), dev-health-web#660 (validate 429 backoff).