### PR TITLE
fix(sync): Linear/work-items configs never run (CHAOS-2242)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -21,7 +21,12 @@ from dev_health_ops.api.admin.schemas import (
 )
 from dev_health_ops.api.services.configuration import SyncConfigurationService
 from dev_health_ops.api.services.licensing import TierLimitService
-from dev_health_ops.models.settings import JobRun, ScheduledJob, SyncConfiguration
+from dev_health_ops.models.settings import (
+    JobRun,
+    JobStatus,
+    ScheduledJob,
+    SyncConfiguration,
+)
 
 from .common import get_session
 
@@ -125,6 +130,51 @@ PROVIDER_SYNC_TARGETS: dict[str, list[str]] = {
     "launchdarkly": ["feature-flags"],
 }
 
+NON_REPO_SYNC_PROVIDERS = {"jira", "linear"}
+DEFAULT_SYNC_CRON = "0 * * * *"
+
+
+def _schedule_cron_for_config(config: object) -> str:
+    sync_options = dict(getattr(config, "sync_options") or {})
+    return str(sync_options.get("schedule_cron") or DEFAULT_SYNC_CRON)
+
+
+async def _upsert_scheduled_job(
+    session: AsyncSession, config: object, org_id: str
+) -> None:
+    sync_config_id = getattr(config, "id")
+    stmt = select(ScheduledJob).where(
+        ScheduledJob.org_id == org_id,
+        ScheduledJob.sync_config_id == sync_config_id,
+        ScheduledJob.job_type == "sync",
+    )
+    result = await session.execute(stmt)
+    job = result.scalar_one_or_none()
+    status = (
+        JobStatus.ACTIVE.value
+        if getattr(config, "is_active")
+        else JobStatus.PAUSED.value
+    )
+    if job is None:
+        session.add(
+            ScheduledJob(
+                name=f"sync-config-{sync_config_id}",
+                job_type="sync",
+                schedule_cron=_schedule_cron_for_config(config),
+                org_id=org_id,
+                job_config={
+                    "provider": str(getattr(config, "provider")).lower(),
+                    "sync_config_id": str(sync_config_id),
+                },
+                sync_config_id=sync_config_id,
+                status=status,
+            )
+        )
+        return
+
+    job.schedule_cron = _schedule_cron_for_config(config)
+    job.status = status
+
 
 @router.get("/sync-targets")
 async def get_provider_sync_targets() -> dict[str, list[str]]:
@@ -197,9 +247,17 @@ async def batch_create_sync_configs(
             detail=reason or f"Repo limit exceeded (adding {new_count} repos)",
         )
 
-    # Create parent config (template — not synced directly)
+    provider = payload.provider.lower()
+    parent_is_active = provider in NON_REPO_SYNC_PROVIDERS
+
     parent_options = dict(payload.sync_options)
     parent_options.pop("repo", None)  # parent has no single repo
+    if payload.schedule_cron is not None:
+        parent_options["schedule_cron"] = payload.schedule_cron
+    if payload.timezone is not None:
+        parent_options["timezone"] = payload.timezone
+    if payload.initial_sync_depth is not None:
+        parent_options["initial_sync_depth"] = payload.initial_sync_depth
     parent = SyncConfiguration(
         name=payload.name,
         provider=payload.provider,
@@ -209,7 +267,7 @@ async def batch_create_sync_configs(
         else None,
         sync_targets=payload.sync_targets,
         sync_options=parent_options,
-        is_active=False,  # parent is a template, children are the active jobs
+        is_active=parent_is_active,
     )
     session.add(parent)
     await session.flush()  # need parent.id for children
@@ -246,6 +304,12 @@ async def batch_create_sync_configs(
         children.append(child)
 
     session.add_all(children)
+    await session.flush()
+
+    if parent_is_active:
+        await _upsert_scheduled_job(session, parent, org_id)
+    for child in children:
+        await _upsert_scheduled_job(session, child, org_id)
     await session.flush()
 
     return SyncConfigBatchResponse(
@@ -351,6 +415,8 @@ async def create_sync_config(
         sync_options=payload.sync_options,
         credential_id=payload.credential_id,
     )
+    await _upsert_scheduled_job(session, config, org_id)
+    await session.flush()
     return _sync_config_to_response(config)
 
 
@@ -432,6 +498,8 @@ async def update_sync_config(
     if updated is None:
         raise HTTPException(status_code=404, detail="Sync configuration not found")
 
+    await _upsert_scheduled_job(session, updated, org_id)
+
     # Cascade shared settings to children when updating a parent config
     if getattr(updated, "parent_id") is None:
         stmt = select(SyncConfiguration).where(
@@ -453,6 +521,8 @@ async def update_sync_config(
                         child_sync_options[key] = payload.sync_options[key]
                         mutable_child.sync_options = child_sync_options
         if children:
+            for child in children:
+                await _upsert_scheduled_job(session, child, org_id)
             await session.flush()
 
     return _sync_config_to_response(updated)

--- a/src/dev_health_ops/api/admin/schemas.py
+++ b/src/dev_health_ops/api/admin/schemas.py
@@ -124,7 +124,7 @@ class SyncConfigBatchCreate(BaseModel):
     credential_id: str | None = None
     sync_targets: list[str] = Field(default_factory=list)
     sync_options: dict[str, Any] = Field(default_factory=dict)
-    repos: list[str] = Field(..., min_length=1, description="Repo names to sync")
+    repos: list[str] = Field(default_factory=list, description="Repo names to sync")
     schedule_cron: str | None = None
     timezone: str | None = None
     initial_sync_depth: int | None = None

--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -12,6 +12,8 @@ def discover_repos_for_config(
 
     if provider == "github":
         token = _github_token_from_credentials(credentials)
+        if not token:
+            return []
         return discover_github_repos(sync_options, token)
     if provider == "gitlab":
         token = str(credentials.get("token") or "")
@@ -55,7 +57,7 @@ def discover_github_repos(
     if not owner:
         return []
 
-    g = Github(token) if token else Github()
+    g = Github(token)
     try:
         org = g.get_organization(owner)
         repos = org.get_repos()

--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -12,8 +12,6 @@ def discover_repos_for_config(
 
     if provider == "github":
         token = _github_token_from_credentials(credentials)
-        if not token:
-            return []
         return discover_github_repos(sync_options, token)
     if provider == "gitlab":
         token = str(credentials.get("token") or "")
@@ -57,7 +55,7 @@ def discover_github_repos(
     if not owner:
         return []
 
-    g = Github(token)
+    g = Github(token) if token else Github()
     try:
         org = g.get_organization(owner)
         repos = org.get_repos()

--- a/src/dev_health_ops/workers/org_guard.py
+++ b/src/dev_health_ops/workers/org_guard.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any
 
 from sqlalchemy.exc import SQLAlchemyError
 
 from dev_health_ops.models.users import Organization
+
+logger = logging.getLogger(__name__)
 
 
 def organization_exists_sync(session: Any, org_id: str | None) -> bool:
@@ -16,12 +19,15 @@ def organization_exists_sync(session: Any, org_id: str | None) -> bool:
     except ValueError:
         return True
     try:
-        return (
+        exists = (
             session.query(Organization.id)
             .filter(Organization.id == org_uuid)
             .one_or_none()
             is not None
         )
+        if not exists:
+            logger.warning("Skipping sync for missing organization org_id=%s", org_id)
+        return exists
     except SQLAlchemyError:
         # Fail open: this guard only skips work for already-deleted orgs. If
         # existence cannot be verified (DB error, or a narrow test/migration

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -23,6 +23,7 @@ from dev_health_ops.workers.task_utils import (
     _get_db_url,
     _inject_provider_token,
     _merge_sync_flags,
+    _normalize_sync_targets,
     _resolve_env_credentials,
 )
 
@@ -152,7 +153,9 @@ def dispatch_batch_sync(
                 raise ValueError(f"Sync configuration not found: {config_id}")
 
             provider = (config.provider or "").lower()
-            sync_targets = list(config.sync_targets or [])
+            sync_targets = _normalize_sync_targets(
+                provider, list(config.sync_targets or [])
+            )
             sync_options = dict(config.sync_options or {})
             config_name = config.name
 
@@ -182,7 +185,7 @@ def dispatch_batch_sync(
                 config_id,
                 disc_exc,
             )
-            run_sync_config.apply_async(
+            getattr(run_sync_config, "apply_async")(
                 kwargs={
                     "config_id": config_id,
                     "org_id": org_id,
@@ -224,7 +227,7 @@ def dispatch_batch_sync(
                 per_repo_options.pop("group", None)
 
             child_tasks.append(
-                _run_sync_for_repo.s(
+                getattr(_run_sync_for_repo, "s")(
                     config_id=config_id,
                     org_id=org_id,
                     triggered_by=triggered_by,
@@ -245,7 +248,7 @@ def dispatch_batch_sync(
         all_tasks = [task for batch in batches for task in batch]
         chord(
             group(all_tasks),
-            _batch_sync_callback.s(
+            getattr(_batch_sync_callback, "s")(
                 provider=provider,
                 sync_targets=sync_targets,
                 org_id=org_id,
@@ -313,6 +316,7 @@ def _run_sync_for_repo(
     )
 
     try:
+        sync_targets = _normalize_sync_targets(provider, list(sync_targets or []))
         result_payload: dict[str, Any] = {
             "provider": provider,
             "config_id": config_id,
@@ -320,7 +324,11 @@ def _run_sync_for_repo(
             "triggered_by": triggered_by,
         }
 
-        if provider == "github":
+        code_sync_targets = [
+            target for target in sync_targets if target != "work-items"
+        ]
+
+        if provider == "github" and code_sync_targets:
             owner = str(sync_options_override.get("owner", ""))
             repo_name = str(sync_options_override.get("repo", ""))
             github_credentials = github_credentials_from_mapping(credentials)
@@ -331,7 +339,7 @@ def _run_sync_for_repo(
                     f"owner={owner}, repo={repo_name}"
                 )
 
-            merged_flags = _merge_sync_flags(sync_targets)
+            merged_flags = _merge_sync_flags(code_sync_targets)
 
             async def _github_handler(store):
                 await process_github_repo(
@@ -350,7 +358,7 @@ def _run_sync_for_repo(
             run_async(run_with_store(db_url, db_type, _github_handler, org_id=org_id))
             result_payload.update({"owner": owner, "repo": repo_name})
 
-        elif provider == "gitlab":
+        elif provider == "gitlab" and code_sync_targets:
             project_id = sync_options_override.get("project_id")
             token = str(credentials.get("token") or "")
             gitlab_url = str(
@@ -363,7 +371,10 @@ def _run_sync_for_repo(
                     f"project_id={project_id}"
                 )
 
-            merged_flags = _merge_sync_flags(sync_targets)
+            gitlab_targets = [
+                target for target in code_sync_targets if target != "work-items"
+            ]
+            merged_flags = _merge_sync_flags(gitlab_targets)
 
             async def _gitlab_handler(store):
                 await process_gitlab_project(
@@ -382,6 +393,11 @@ def _run_sync_for_repo(
             run_async(run_with_store(db_url, db_type, _gitlab_handler, org_id=org_id))
             result_payload.update(
                 {"project_id": int(project_id), "gitlab_url": gitlab_url}
+            )
+
+        elif provider not in {"github", "gitlab"} and "work-items" not in sync_targets:
+            raise ValueError(
+                f"Unsupported batch sync provider/targets: provider={provider} targets={sync_targets}"
             )
 
         if "work-items" in sync_targets:

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -24,6 +24,7 @@ from dev_health_ops.workers.task_utils import (
     _get_db_url,
     _inject_provider_token,
     _merge_sync_flags,
+    _normalize_sync_targets,
     _resolve_env_credentials,
 )
 
@@ -392,7 +393,9 @@ def run_sync_config(
 
             provider = _as_str(config.provider).lower()
             config_name = _as_str(config.name)
-            sync_targets = _as_str_list(config.sync_targets)
+            sync_targets = _normalize_sync_targets(
+                provider, _as_str_list(config.sync_targets)
+            )
             sync_options = _as_dict(config.sync_options)
 
             if config.credential_id:
@@ -426,7 +429,7 @@ def run_sync_config(
                 job = ScheduledJob(
                     name=f"sync-config-{_as_uuid(config.id)}",
                     job_type="sync",
-                    schedule_cron="0 * * * *",
+                    schedule_cron=str(sync_options.get("schedule_cron") or "0 * * * *"),
                     org_id=org_id,
                     job_config={
                         "provider": provider,
@@ -437,6 +440,12 @@ def run_sync_config(
                 )
                 session.add(job)
                 session.flush()
+            else:
+                setattr(
+                    job,
+                    "schedule_cron",
+                    str(sync_options.get("schedule_cron") or "0 * * * *"),
+                )
 
             job_id = _as_uuid(job.id)
 
@@ -466,7 +475,11 @@ def run_sync_config(
         full_resync = bool(sync_options.get("full_resync"))
         repo_id_for_watermark: str | None = None
 
-        if provider == "github":
+        code_sync_targets = [
+            target for target in sync_targets if target != "work-items"
+        ]
+
+        if provider == "github" and code_sync_targets:
             _owr = _extract_owner_repo(
                 config_name=config_name, sync_options=sync_options
             )
@@ -512,7 +525,7 @@ def run_sync_config(
                     "Missing GitHub token or App credentials for sync configuration"
                 )
 
-            merged_flags = _merge_sync_flags(sync_targets)
+            merged_flags = _merge_sync_flags(code_sync_targets)
 
             async def _github_handler(store):
                 await process_github_repo(
@@ -533,10 +546,12 @@ def run_sync_config(
                 }
             )
 
-        elif provider == "gitlab":
-            feature_flag_requested = "feature-flags" in sync_targets
+        elif provider == "gitlab" and code_sync_targets:
+            feature_flag_requested = "feature-flags" in code_sync_targets
             gitlab_targets = [
-                target for target in sync_targets if target != "feature-flags"
+                target
+                for target in code_sync_targets
+                if target not in {"feature-flags", "work-items"}
             ]
             if feature_flag_requested:
                 result_payload["feature_flags"] = _sync_gitlab_feature_flags(
@@ -604,6 +619,11 @@ def run_sync_config(
                 org_id=org_id,
             )
             result_payload["backfill_days"] = backfill_days
+
+        elif provider not in {"github", "gitlab"} and "work-items" not in sync_targets:
+            raise ValueError(
+                f"Unsupported sync provider/targets: provider={provider} targets={sync_targets}"
+            )
 
         if "work-items" in sync_targets and provider != "jira":
             token = _extract_provider_token(provider, credentials)

--- a/src/dev_health_ops/workers/task_utils.py
+++ b/src/dev_health_ops/workers/task_utils.py
@@ -180,6 +180,20 @@ def _as_dict(value: object | None) -> dict[str, Any]:
 
 _GIT_TARGETS = {"git", "prs"}
 _WORK_ITEM_TARGETS = {"work-items"}
+_WORK_ITEM_PROVIDERS = {"github", "gitlab", "jira", "linear"}
+
+
+def _normalize_sync_targets(provider: str, sync_targets: list[str]) -> list[str]:
+    provider = provider.lower()
+    if sync_targets:
+        return sync_targets
+    if provider in _WORK_ITEM_PROVIDERS:
+        logger.warning(
+            "Sync configuration for provider=%s has no sync targets; defaulting to work-items",
+            provider,
+        )
+        return ["work-items"]
+    raise ValueError(f"Sync configuration for provider={provider} has no sync targets")
 
 
 def _invalidate_metrics_cache(day: str, org_id: str) -> None:

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -26,6 +26,7 @@ from tests._helpers import tables_of
 
 admin_router_module = importlib.import_module("dev_health_ops.api.admin")
 auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+sync_router_module = importlib.import_module("dev_health_ops.api.admin.routers.sync")
 
 _TABLES = tables_of(
     User,
@@ -166,6 +167,72 @@ async def test_create_sync_config_persists_to_db(client, session_maker):
 
 
 @pytest.mark.asyncio
+async def test_create_sync_config_creates_scheduled_job(client, session_maker):
+    ac, _ = client
+
+    resp = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": "scheduled-linear",
+            "provider": "linear",
+            "sync_targets": ["work-items"],
+            "sync_options": {},
+        },
+    )
+
+    assert resp.status_code == 201
+    config_id = uuid.UUID(resp.json()["id"])
+    async with session_maker() as session:
+        result = await session.execute(
+            select(ScheduledJob).where(ScheduledJob.sync_config_id == config_id)
+        )
+        job = result.scalar_one_or_none()
+
+    assert job is not None
+    assert job.schedule_cron == "0 * * * *"
+
+
+@pytest.mark.asyncio
+async def test_batch_create_linear_without_repos_creates_active_config_and_job(
+    client, session_maker
+):
+    ac, _ = client
+
+    resp = await ac.post(
+        "/api/v1/admin/sync-configs/batch",
+        json={
+            "name": "linear-work-items",
+            "provider": "linear",
+            "sync_targets": ["work-items"],
+            "sync_options": {},
+            "repos": [],
+            "schedule_cron": "15 * * * *",
+        },
+    )
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["children"] == []
+    assert data["parent"]["is_active"] is True
+    config_id = uuid.UUID(data["parent"]["id"])
+    async with session_maker() as session:
+        config_result = await session.execute(
+            select(SyncConfiguration).where(SyncConfiguration.id == config_id)
+        )
+        config = config_result.scalar_one_or_none()
+        job_result = await session.execute(
+            select(ScheduledJob).where(ScheduledJob.sync_config_id == config_id)
+        )
+        job = job_result.scalar_one_or_none()
+
+    assert config is not None
+    assert config.is_active is True
+    assert config.sync_options["schedule_cron"] == "15 * * * *"
+    assert job is not None
+    assert job.schedule_cron == "15 * * * *"
+
+
+@pytest.mark.asyncio
 async def test_get_sync_config_by_id(client):
     ac, _ = client
 
@@ -207,6 +274,41 @@ async def test_update_sync_config_changes_is_active(client):
     data = resp.json()
     assert data["is_active"] is False
     assert data["id"] == config_id
+
+
+@pytest.mark.asyncio
+async def test_schedule_job_upsert_propagates_schedule_cron(
+    client, session_maker, seeded_state
+):
+    ac, _ = client
+
+    create_resp = await _create_sync_config(
+        ac, name="schedule-update", provider="linear"
+    )
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+
+    async with session_maker() as session:
+        config_result = await session.execute(
+            select(SyncConfiguration).where(
+                SyncConfiguration.id == uuid.UUID(config_id)
+            )
+        )
+        config = config_result.scalar_one()
+        config.sync_options = {"schedule_cron": "5 * * * *"}
+        await sync_router_module._upsert_scheduled_job(
+            session, config, seeded_state["org_id"]
+        )
+        await session.flush()
+        result = await session.execute(
+            select(ScheduledJob).where(
+                ScheduledJob.sync_config_id == uuid.UUID(config_id)
+            )
+        )
+        job = result.scalar_one_or_none()
+
+    assert job is not None
+    assert job.schedule_cron == "5 * * * *"
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync_watermarks.py
+++ b/tests/test_sync_watermarks.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import sys
+import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -51,7 +53,7 @@ def _make_config(
         name=name,
         provider=provider,
         org_id=org_id,
-        sync_targets=sync_targets or ["git", "prs"],
+        sync_targets=["git", "prs"] if sync_targets is None else sync_targets,
         sync_options=sync_options or {},
         is_active=is_active,
     )
@@ -197,7 +199,7 @@ class TestRunSyncConfigWatermarks:
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
         mock_run_with_store.return_value = None
 
-        task = run_sync_config
+        task = cast(Any, run_sync_config)
         task.push_request(id="watermark-test-1")
         try:
             result = task(config_id=str(config.id), org_id=ORG_ID)
@@ -246,7 +248,7 @@ class TestRunSyncConfigWatermarks:
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
         mock_run_with_store.return_value = None
 
-        task = run_sync_config
+        task = cast(Any, run_sync_config)
         task.push_request(id="watermark-test-2")
         try:
             result = task(config_id=str(config.id), org_id=ORG_ID)
@@ -283,7 +285,7 @@ class TestRunSyncConfigWatermarks:
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
         mock_run_with_store.return_value = None
 
-        task = run_sync_config
+        task = cast(Any, run_sync_config)
         task.push_request(id="watermark-test-3")
         try:
             result = task(config_id=str(config.id), org_id=ORG_ID)
@@ -322,7 +324,7 @@ class TestRunSyncConfigWatermarks:
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
         mock_run_with_store.side_effect = RuntimeError("API failure")
 
-        task = run_sync_config
+        task = cast(Any, run_sync_config)
         task.push_request(id="watermark-test-4")
         try:
             with pytest.raises((Retry, RuntimeError)):
@@ -360,7 +362,7 @@ class TestRunSyncConfigWatermarks:
 
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
 
-        task = run_sync_config
+        task = cast(Any, run_sync_config)
         task.push_request(id="watermark-test-5")
         try:
             result = task(config_id=str(config.id), org_id=ORG_ID)
@@ -370,6 +372,73 @@ class TestRunSyncConfigWatermarks:
         assert result["status"] == "success"
         count = db_session.query(SyncWatermark).count()
         assert count == 0
+
+    @patch("dev_health_ops.metrics.job_work_items.run_work_items_sync_job")
+    @patch("dev_health_ops.workers.sync_runtime._dispatch_post_sync_tasks")
+    @patch(
+        "dev_health_ops.workers.sync_runtime._resolve_env_credentials",
+        return_value={"api_key": "lin_test"},
+    )
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_linear_empty_targets_defaults_to_work_items(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_post_sync,
+        mock_run_work_items,
+        db_session,
+    ):
+        from dev_health_ops.workers.sync_runtime import run_sync_config
+
+        config = _make_config(
+            provider="linear",
+            sync_options={"backfill_days": 2},
+            sync_targets=[],
+            name="linear-config",
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
+
+        task = cast(Any, run_sync_config)
+        task.push_request(id="linear-work-items-test")
+        try:
+            result = task(config_id=str(config.id), org_id=ORG_ID)
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "success"
+        assert result["result"]["sync_targets"] == ["work-items"]
+        mock_run_work_items.assert_called_once()
+        assert mock_run_work_items.call_args.kwargs["provider"] == "linear"
+
+    @patch("dev_health_ops.metrics.job_work_items.run_work_items_sync_job")
+    def test_batch_child_empty_targets_defaults_to_work_items(
+        self, mock_run_work_items
+    ):
+        from dev_health_ops.workers.sync_batch import _run_sync_for_repo
+
+        task = cast(Any, _run_sync_for_repo)
+        task.push_request(id="batch-linear-work-items-test")
+        try:
+            result = task(
+                config_id=str(uuid.uuid4()),
+                org_id=ORG_ID,
+                triggered_by="manual",
+                provider="linear",
+                sync_targets=[],
+                sync_options_override={"backfill_days": 3},
+                credentials={"api_key": "lin_test"},
+                config_name="linear-config",
+            )
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "success"
+        assert result["result"]["sync_targets"] == ["work-items"]
+        mock_run_work_items.assert_called_once()
+        assert mock_run_work_items.call_args.kwargs["provider"] == "linear"
 
     @patch("dev_health_ops.storage.run_with_store")
     @patch("dev_health_ops.workers.sync_runtime._dispatch_post_sync_tasks")
@@ -402,7 +471,7 @@ class TestRunSyncConfigWatermarks:
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
         mock_run_with_store.return_value = None
 
-        task = run_sync_config
+        task = cast(Any, run_sync_config)
         task.push_request(id="watermark-test-6")
         try:
             result = task(config_id=str(config.id), org_id=ORG_ID)
@@ -447,7 +516,7 @@ class TestRunSyncConfigWatermarks:
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
         mock_run_with_store.return_value = None
 
-        task = run_sync_config
+        task = cast(Any, run_sync_config)
         task.push_request(id="watermark-test-7")
         try:
             result = task(config_id=str(config.id), org_id=ORG_ID)


### PR DESCRIPTION
## Summary
- Default empty sync targets to `work-items` for work-item providers and route Linear/GitHub/GitLab/Jira through `run_work_items_sync_job` instead of silently succeeding.
- Create active non-repo batch configs for Linear/Jira and persist/update `ScheduledJob.schedule_cron` from sync options.
- Add a missing-org warning to the org guard while keeping fail-open DB-error behavior.
- Restore anonymous public GitHub repo discovery by allowing PyGithub unauthenticated clients when no token is configured.

## Verification
- `pytest tests/test_sync_watermarks.py tests/api/admin/test_sync_configs.py tests/test_admin_sync_targets.py`
- `ruff format --check src/dev_health_ops/workers/sync_runtime.py src/dev_health_ops/workers/sync_batch.py src/dev_health_ops/workers/task_utils.py src/dev_health_ops/workers/org_guard.py src/dev_health_ops/discovery/repos.py src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/api/admin/schemas.py tests/test_sync_watermarks.py tests/api/admin/test_sync_configs.py`
- `ruff check src/dev_health_ops/workers/sync_runtime.py src/dev_health_ops/workers/sync_batch.py src/dev_health_ops/workers/task_utils.py src/dev_health_ops/workers/org_guard.py src/dev_health_ops/discovery/repos.py src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/api/admin/schemas.py tests/test_sync_watermarks.py tests/api/admin/test_sync_configs.py`
- `mypy src/dev_health_ops/workers/sync_runtime.py src/dev_health_ops/workers/sync_batch.py src/dev_health_ops/workers/task_utils.py src/dev_health_ops/workers/org_guard.py src/dev_health_ops/discovery/repos.py src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/api/admin/schemas.py tests/test_sync_watermarks.py tests/api/admin/test_sync_configs.py`
- LSP diagnostics clean on touched files

## Notes
- PR #832 regression decision: kept GitHub App/PAT token support, but removed the early empty-token return so anonymous public-repo discovery works again via `Github()`.
- SCREENSHOT-WAIVER: backend sync/runtime/API behavior only; no rendered frontend output changed.

Closes CHAOS-2242