### PR TITLE
fix(models): provider-scoped unique constraint for sync configs (CHAOS-2243)

### DIFF
--- a/src/dev_health_ops/alembic/versions/0009_widen_sync_config_scheduled_job_unique_constraints.py
+++ b/src/dev_health_ops/alembic/versions/0009_widen_sync_config_scheduled_job_unique_constraints.py
@@ -1,0 +1,181 @@
+"""Widen unique constraints on sync_configurations and scheduled_jobs to include provider.
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-06-10 00:00:00
+
+Widens the unique key on sync_configurations from (org_id, name) to
+(org_id, provider, name), and on scheduled_jobs from (org_id, name) to
+(org_id, provider, name).  This mirrors the existing IntegrationCredential
+constraint (uq_credentials_org_provider_name) and allows same-named configs
+across different providers to coexist (e.g. a 'chaos' GitHub config and a
+'chaos' Linear config).
+
+Also adds the provider column to scheduled_jobs (nullable=False, server_default='')
+so the new constraint can reference it.
+
+Dedupe strategy (upgrade):
+  For sync_configurations: when two rows share (org_id, name) but differ on
+  provider, they are already distinct under the new key — no action needed.
+  When two rows share (org_id, name, provider) the newer row (higher created_at)
+  is kept and the older duplicate is deleted.
+
+  Same logic applies to scheduled_jobs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0009"
+down_revision: str | None = "0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. Add provider column to scheduled_jobs (server_default='' so
+    #    existing rows get an empty string, matching non-provider jobs).
+    # ------------------------------------------------------------------
+    op.add_column(
+        "scheduled_jobs",
+        sa.Column(
+            "provider",
+            sa.Text(),
+            nullable=False,
+            server_default="",
+            comment="Provider this job belongs to (empty string for non-provider jobs)",
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # 2. Dedupe sync_configurations: delete older duplicates that share
+    #    (org_id, provider, name).  Rows that only share (org_id, name)
+    #    but differ on provider are already distinct — no action needed.
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        DELETE FROM sync_configurations
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT
+                    id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY org_id, provider, name
+                        ORDER BY created_at DESC
+                    ) AS rn
+                FROM sync_configurations
+            ) ranked
+            WHERE rn > 1
+        )
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # 3. Dedupe scheduled_jobs: same strategy.
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        DELETE FROM scheduled_jobs
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT
+                    id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY org_id, provider, name
+                        ORDER BY created_at DESC
+                    ) AS rn
+                FROM scheduled_jobs
+            ) ranked
+            WHERE rn > 1
+        )
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # 4. Drop old unique constraints.
+    # ------------------------------------------------------------------
+    op.drop_constraint("uq_sync_config_org_name", "sync_configurations", type_="unique")
+    op.drop_constraint("uq_scheduled_job_org_name", "scheduled_jobs", type_="unique")
+
+    # ------------------------------------------------------------------
+    # 5. Create new (org_id, provider, name) unique constraints.
+    # ------------------------------------------------------------------
+    op.create_unique_constraint(
+        "uq_sync_config_org_provider_name",
+        "sync_configurations",
+        ["org_id", "provider", "name"],
+    )
+    op.create_unique_constraint(
+        "uq_scheduled_job_org_provider_name",
+        "scheduled_jobs",
+        ["org_id", "provider", "name"],
+    )
+
+
+def downgrade() -> None:
+    # ------------------------------------------------------------------
+    # Reverse: drop new constraints, restore old ones, drop provider col.
+    # Note: rows that were deduped during upgrade cannot be recovered.
+    # ------------------------------------------------------------------
+    op.drop_constraint(
+        "uq_sync_config_org_provider_name", "sync_configurations", type_="unique"
+    )
+    op.drop_constraint(
+        "uq_scheduled_job_org_provider_name", "scheduled_jobs", type_="unique"
+    )
+
+    # Re-dedupe for the narrower (org_id, name) key before restoring it.
+    op.execute(
+        """
+        DELETE FROM sync_configurations
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT
+                    id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY org_id, name
+                        ORDER BY created_at DESC
+                    ) AS rn
+                FROM sync_configurations
+            ) ranked
+            WHERE rn > 1
+        )
+        """
+    )
+    op.execute(
+        """
+        DELETE FROM scheduled_jobs
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT
+                    id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY org_id, name
+                        ORDER BY created_at DESC
+                    ) AS rn
+                FROM scheduled_jobs
+            ) ranked
+            WHERE rn > 1
+        )
+        """
+    )
+
+    op.create_unique_constraint(
+        "uq_sync_config_org_name",
+        "sync_configurations",
+        ["org_id", "name"],
+    )
+    op.create_unique_constraint(
+        "uq_scheduled_job_org_name",
+        "scheduled_jobs",
+        ["org_id", "name"],
+    )
+
+    op.drop_column("scheduled_jobs", "provider")

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -425,6 +425,7 @@ async def update_sync_config(
 
     updated = await svc.update(
         name=str(getattr(config, "name")),
+        provider=str(getattr(config, "provider")),
         sync_targets=payload.sync_targets,
         sync_options=payload.sync_options,
         is_active=payload.is_active,
@@ -468,7 +469,9 @@ async def delete_sync_config(
     config = await svc.get_by_id(config_id)
     if config is None:
         raise HTTPException(status_code=404, detail="Sync configuration not found")
-    await svc.delete(str(getattr(config, "name")))
+    await svc.delete(
+        str(getattr(config, "name")), provider=str(getattr(config, "provider"))
+    )
 
 
 @router.post("/sync-configs/{config_id}/trigger", status_code=202)

--- a/src/dev_health_ops/api/services/configuration/sync_configuration.py
+++ b/src/dev_health_ops/api/services/configuration/sync_configuration.py
@@ -21,12 +21,16 @@ class SyncConfigurationService:
         self.session = session
         self.org_id = org_id
 
-    async def get(self, name: str) -> SyncConfiguration | None:
-        """Get a sync configuration by name."""
+    async def get(
+        self, name: str, provider: str | None = None
+    ) -> SyncConfiguration | None:
+        """Get a sync configuration by name (and optionally provider)."""
         stmt = select(SyncConfiguration).where(
             SyncConfiguration.org_id == self.org_id,
             SyncConfiguration.name == name,
         )
+        if provider is not None:
+            stmt = stmt.where(SyncConfiguration.provider == provider)
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
 
@@ -71,12 +75,13 @@ class SyncConfigurationService:
     async def update(
         self,
         name: str,
+        provider: str | None = None,
         sync_targets: list[str] | None = None,
         sync_options: dict[str, Any] | None = None,
         is_active: bool | None = None,
     ) -> SyncConfiguration | None:
         """Update a sync configuration."""
-        config: Any | None = await self.get(name)
+        config: Any | None = await self.get(name, provider=provider)
         if config is None:
             return None
 
@@ -100,9 +105,9 @@ class SyncConfigurationService:
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
 
-    async def delete(self, name: str) -> bool:
+    async def delete(self, name: str, provider: str | None = None) -> bool:
         """Delete a sync configuration."""
-        config = await self.get(name)
+        config = await self.get(name, provider=provider)
         if config is None:
             return False
 

--- a/src/dev_health_ops/models/settings.py
+++ b/src/dev_health_ops/models/settings.py
@@ -293,7 +293,9 @@ class SyncConfiguration(Base):
     )
 
     __table_args__ = (
-        UniqueConstraint("org_id", "name", name="uq_sync_config_org_name"),
+        UniqueConstraint(
+            "org_id", "provider", "name", name="uq_sync_config_org_provider_name"
+        ),
         Index("ix_sync_config_org_provider", "org_id", "provider"),
     )
 
@@ -339,6 +341,13 @@ class ScheduledJob(Base):
     )
     job_type: Mapped[str] = mapped_column(
         Text, nullable=False, index=True, comment="Type of job (sync, metrics, etc.)"
+    )
+
+    provider: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        server_default="",
+        comment="Provider this job belongs to (empty string for non-provider jobs)",
     )
 
     schedule_cron: Mapped[str] = mapped_column(
@@ -394,7 +403,9 @@ class ScheduledJob(Base):
     )
 
     __table_args__ = (
-        UniqueConstraint("org_id", "name", name="uq_scheduled_job_org_name"),
+        UniqueConstraint(
+            "org_id", "provider", "name", name="uq_scheduled_job_org_provider_name"
+        ),
         Index("ix_scheduled_job_org_type", "org_id", "job_type"),
         Index("ix_scheduled_job_next_run", "next_run_at"),
     )
@@ -405,6 +416,7 @@ class ScheduledJob(Base):
         job_type: str,
         schedule_cron: str,
         org_id: str | None = None,
+        provider: str = "",
         job_config: dict[str, Any] | None = None,
         sync_config_id: uuid.UUID | None = None,
         tz: str = "UTC",
@@ -414,6 +426,7 @@ class ScheduledJob(Base):
         self.org_id = org_id or ""
         self.name = name
         self.job_type = job_type
+        self.provider = provider
         self.schedule_cron = schedule_cron
         self.timezone = tz
         self.job_config = job_config or {}

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -295,3 +295,92 @@ async def test_list_sync_config_jobs_empty(client):
 
     assert resp.status_code == 200
     assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# Provider-scoped uniqueness tests (CHAOS-2243)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_same_name_different_providers_can_coexist(client):
+    """Two configs with the same name but different providers must both be created."""
+    ac, _ = client
+
+    resp_gh = await _create_sync_config(ac, name="chaos", provider="github")
+    assert resp_gh.status_code == 201, resp_gh.text
+
+    resp_lin = await _create_sync_config(ac, name="chaos", provider="linear")
+    assert resp_lin.status_code == 201, resp_lin.text
+
+    assert resp_gh.json()["id"] != resp_lin.json()["id"]
+
+    list_resp = await ac.get("/api/v1/admin/sync-configs")
+    assert list_resp.status_code == 200
+    names = [c["name"] for c in list_resp.json()]
+    assert names.count("chaos") == 2
+
+
+@pytest.mark.asyncio
+async def test_same_name_same_provider_is_rejected(client):
+    """Two configs with the same (name, provider) must fail with a DB-level error."""
+    from sqlalchemy.exc import IntegrityError
+
+    ac, _ = client
+
+    resp1 = await _create_sync_config(ac, name="dup-config", provider="github")
+    assert resp1.status_code == 201, resp1.text
+
+    # Second create with identical (name, provider) must raise a DB integrity error.
+    # The ASGI test transport propagates the unhandled IntegrityError as an exception
+    # rather than returning an HTTP response, so we catch it here.
+    with pytest.raises((IntegrityError, Exception)) as exc_info:
+        await _create_sync_config(ac, name="dup-config", provider="github")
+    assert "UNIQUE" in str(exc_info.value) or "unique" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_delete_targets_correct_provider(client, session_maker):
+    """Deleting a config by ID removes only the matching provider row."""
+    ac, _ = client
+
+    resp_gh = await _create_sync_config(ac, name="shared-name", provider="github")
+    resp_lin = await _create_sync_config(ac, name="shared-name", provider="linear")
+    assert resp_gh.status_code == 201
+    assert resp_lin.status_code == 201
+
+    gh_id = resp_gh.json()["id"]
+    lin_id = resp_lin.json()["id"]
+
+    del_resp = await ac.delete(f"/api/v1/admin/sync-configs/{gh_id}")
+    assert del_resp.status_code == 204
+
+    # GitHub config gone, Linear config still present.
+    assert (await ac.get(f"/api/v1/admin/sync-configs/{gh_id}")).status_code == 404
+    assert (await ac.get(f"/api/v1/admin/sync-configs/{lin_id}")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_update_targets_correct_provider(client):
+    """Updating a config by ID only modifies the matching provider row."""
+    ac, _ = client
+
+    resp_gh = await _create_sync_config(ac, name="upd-name", provider="github")
+    resp_lin = await _create_sync_config(ac, name="upd-name", provider="linear")
+    assert resp_gh.status_code == 201
+    assert resp_lin.status_code == 201
+
+    gh_id = resp_gh.json()["id"]
+    lin_id = resp_lin.json()["id"]
+
+    patch_resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{gh_id}",
+        json={"is_active": False},
+    )
+    assert patch_resp.status_code == 200
+    assert patch_resp.json()["is_active"] is False
+
+    # Linear config must remain active.
+    lin_resp = await ac.get(f"/api/v1/admin/sync-configs/{lin_id}")
+    assert lin_resp.status_code == 200
+    assert lin_resp.json()["is_active"] is True


### PR DESCRIPTION
## Summary

Widens the unique keys on `sync_configurations` and `scheduled_jobs` from `(org_id, name)` to `(org_id, provider, name)`, mirroring the existing `IntegrationCredential` constraint (`uq_credentials_org_provider_name`).

This fixes the collision where a 'chaos' GitHub config and a 'chaos' Linear config could not coexist in the same org.

## Changes

### Models (`models/settings.py`)
- `SyncConfiguration`: `uq_sync_config_org_name` → `uq_sync_config_org_provider_name` on `(org_id, provider, name)`
- `ScheduledJob`: add `provider` column (`TEXT NOT NULL DEFAULT ''`); `uq_scheduled_job_org_name` → `uq_scheduled_job_org_provider_name` on `(org_id, provider, name)`

### Migration (`alembic/versions/0009`)
- Adds `provider` column to `scheduled_jobs` (server_default=`''`)
- Dedupes any colliding rows (keeps newest by `created_at`) before dropping old constraints
- Drops `uq_sync_config_org_name` and `uq_scheduled_job_org_name`
- Creates `uq_sync_config_org_provider_name` and `uq_scheduled_job_org_provider_name`
- Correct `downgrade()` that reverses all steps

### Service layer (`api/services/configuration/sync_configuration.py`)
- `get()`, `update()`, `delete()` now accept optional `provider` param for provider-scoped lookups

### Router (`api/admin/routers/sync.py`)
- `update_sync_config`: passes `provider` to `svc.update()`
- `delete_sync_config`: passes `provider` to `svc.delete()`

### Tests (`tests/api/admin/test_sync_configs.py`)
- `test_same_name_different_providers_can_coexist`: two configs with same name but different providers both succeed
- `test_same_name_same_provider_is_rejected`: duplicate (name, provider) raises DB integrity error
- `test_delete_targets_correct_provider`: delete by ID removes only the matching provider row
- `test_update_targets_correct_provider`: update by ID modifies only the matching provider row

## Test Results
- 16/16 tests in `test_sync_configs.py` pass
- 152/152 tests in `tests/api/admin/` + `tests/api/auth/` pass
- Pre-existing failure in `test_org_deletion.py` is unrelated (confirmed by checking on base branch)

## Notes
- Does NOT touch sync dispatch/runtime logic (CHAOS-2242 scope)
- `SCREENSHOT-WAIVER`: backend-only change, no rendered frontend output affected

Closes CHAOS-2243