### PR TITLE
fix(discovery): restore anonymous GitHub public-repo discovery (CHAOS-2246)

### DIFF
--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -12,8 +12,8 @@ def discover_repos_for_config(
 
     if provider == "github":
         token = _github_token_from_credentials(credentials)
-        if not token:
-            return []
+        # No token => attempt anonymous public-repo discovery (rate-limited,
+        # public-only). Authenticated configs pass their token through.
         return discover_github_repos(sync_options, token)
     if provider == "gitlab":
         token = str(credentials.get("token") or "")
@@ -57,7 +57,7 @@ def discover_github_repos(
     if not owner:
         return []
 
-    g = Github(token)
+    g = Github(token) if token else Github()
     try:
         org = g.get_organization(owner)
         repos = org.get_repos()

--- a/tests/test_worker_github_app_auth.py
+++ b/tests/test_worker_github_app_auth.py
@@ -148,13 +148,47 @@ def test_discover_github_pat_passes_token_through() -> None:
     assert discover.call_args.args[1] == "ghp_x"
 
 
-def test_discover_github_returns_empty_without_credentials() -> None:
+def test_discover_github_attempts_anonymous_without_credentials() -> None:
+    """Without credentials we still attempt anonymous public-repo discovery.
+
+    Regression guard for CHAOS-2246: a credential-less GitHub config must not
+    short-circuit to ``[]`` before discovery; it should attempt anonymous
+    public-repo discovery with an empty token.
+    """
     from dev_health_ops.discovery import repos as repos_mod
 
     config = _make_config("github", {"search": "my-org/*"})
 
     with patch.object(repos_mod, "discover_github_repos") as discover:
+        discover.return_value = [("my-org", "public-api")]
         result = repos_mod.discover_repos_for_config(config, {})
 
-    assert result == []
-    discover.assert_not_called()
+    assert result == [("my-org", "public-api")]
+    discover.assert_called_once()
+    # Empty token signals the anonymous discovery path.
+    assert discover.call_args.args[1] == ""
+
+
+def test_discover_github_repos_uses_anonymous_client_without_token() -> None:
+    """``discover_github_repos`` uses an unauthenticated client when token is empty."""
+    from dev_health_ops.discovery import repos as repos_mod
+
+    with patch("github.Github") as github_cls:
+        client = github_cls.return_value
+        client.get_organization.return_value.get_repos.return_value = []
+        repos_mod.discover_github_repos({"search": "my-org/*"}, "")
+
+    # No token => anonymous client constructed with no arguments.
+    github_cls.assert_called_once_with()
+
+
+def test_discover_github_repos_uses_token_client_when_present() -> None:
+    """``discover_github_repos`` passes the token to the client when present."""
+    from dev_health_ops.discovery import repos as repos_mod
+
+    with patch("github.Github") as github_cls:
+        client = github_cls.return_value
+        client.get_organization.return_value.get_repos.return_value = []
+        repos_mod.discover_github_repos({"search": "my-org/*"}, "ghp_x")
+
+    github_cls.assert_called_once_with("ghp_x")


### PR DESCRIPTION
## Summary
Restores anonymous GitHub public-repo discovery that was regressed by PR #832 (CHAOS-2234, GitHub App auth).

PR #832 added an early `return []` in `discover_repos_for_config` when no GitHub token is present, and constructed `Github(token)` with a possibly-empty token. This broke discovery for credential-less GitHub configs targeting public orgs.

This is the proper home for the fix that was reverted out of PR #836 (CHAOS-2242) to keep that PR scoped to Linear/work-items sync.

## Changes
- `discovery/repos.py`: remove the no-token short-circuit so GitHub discovery is attempted anonymously; use `Github(token) if token else Github()` for the unauthenticated client.
- `tests/test_worker_github_app_auth.py`: update the contract — without credentials, anonymous public-repo discovery is attempted (empty-token path). Added coverage asserting anonymous (`Github()`) vs token (`Github("ghp_x")`) client construction.

## Tradeoff (documented)
Unauthenticated GitHub API is public-repo-only and rate-limited (~60 req/hr). This restores prior intended behavior for public orgs; authenticated configs are unaffected.

## Verification
- `pytest tests/test_worker_github_app_auth.py` — 12 passed.
- `ruff format --check`, `ruff check`, `mypy` on changed files — clean.

SCREENSHOT-WAIVER: backend-only change (repo discovery logic); no rendered frontend output.

Closes CHAOS-2246