### PR TITLE
fix(sync): org-wide routing + config-contract backend (CHAOS-2250)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -27,6 +27,7 @@ from dev_health_ops.models.settings import (
     ScheduledJob,
     SyncConfiguration,
 )
+from dev_health_ops.workers.sync_batch import _is_batch_eligible
 
 from .common import get_session
 
@@ -134,6 +135,23 @@ NON_REPO_SYNC_PROVIDERS = {"jira", "linear"}
 DEFAULT_SYNC_CRON = "0 * * * *"
 
 
+def _sync_options_with_top_level_fields(
+    sync_options: dict[str, Any] | None,
+    *,
+    schedule_cron: str | None = None,
+    timezone: str | None = None,
+    initial_sync_depth: int | None = None,
+) -> dict[str, Any]:
+    merged = dict(sync_options or {})
+    if schedule_cron is not None:
+        merged["schedule_cron"] = schedule_cron
+    if timezone is not None:
+        merged["timezone"] = timezone
+    if initial_sync_depth is not None:
+        merged["initial_sync_depth"] = initial_sync_depth
+    return merged
+
+
 def _schedule_cron_for_config(config: object) -> str:
     sync_options = dict(getattr(config, "sync_options") or {})
     return str(sync_options.get("schedule_cron") or DEFAULT_SYNC_CRON)
@@ -150,6 +168,13 @@ async def _upsert_scheduled_job(
     )
     result = await session.execute(stmt)
     job = result.scalar_one_or_none()
+    sync_options = dict(getattr(config, "sync_options") or {})
+    provider = str(getattr(config, "provider")).lower()
+    tz = str(sync_options.get("timezone") or "UTC")
+    job_config = {
+        "provider": provider,
+        "sync_config_id": str(sync_config_id),
+    }
     status = (
         JobStatus.ACTIVE.value
         if getattr(config, "is_active")
@@ -162,17 +187,19 @@ async def _upsert_scheduled_job(
                 job_type="sync",
                 schedule_cron=_schedule_cron_for_config(config),
                 org_id=org_id,
-                job_config={
-                    "provider": str(getattr(config, "provider")).lower(),
-                    "sync_config_id": str(sync_config_id),
-                },
+                provider=provider,
+                job_config=job_config,
                 sync_config_id=sync_config_id,
+                tz=tz,
                 status=status,
             )
         )
         return
 
     job.schedule_cron = _schedule_cron_for_config(config)
+    job.provider = provider
+    job.timezone = tz
+    job.job_config = job_config
     job.status = status
 
 
@@ -340,7 +367,14 @@ async def create_sync_config(
         raise HTTPException(status_code=403, detail=reason or "Repo limit exceeded")
 
     # Fix 5 (LOW): Validate initial_sync_depth against tier limits.
-    initial_sync_depth = payload.sync_options.get("initial_sync_depth")
+    sync_options = _sync_options_with_top_level_fields(
+        payload.sync_options,
+        schedule_cron=payload.schedule_cron,
+        timezone=payload.timezone,
+        initial_sync_depth=payload.initial_sync_depth,
+    )
+
+    initial_sync_depth = sync_options.get("initial_sync_depth")
     if initial_sync_depth is not None:
 
         def _check_backfill_depth(sync_session) -> tuple[bool, str | None]:
@@ -358,7 +392,7 @@ async def create_sync_config(
 
     # Fix 3 (MEDIUM) & Fix 4 (MEDIUM): Validate schedule_cron interval and gate
     # scheduled jobs behind the "scheduled_jobs" feature (Team+ only).
-    schedule_cron = payload.sync_options.get("schedule_cron")
+    schedule_cron = sync_options.get("schedule_cron")
     if schedule_cron:
         # Fix 4: Gate scheduled_jobs feature — Community tier cannot set schedules.
         async def _check_scheduled_jobs_feature(
@@ -412,7 +446,7 @@ async def create_sync_config(
         name=payload.name,
         provider=payload.provider,
         sync_targets=payload.sync_targets,
-        sync_options=payload.sync_options,
+        sync_options=sync_options,
         credential_id=payload.credential_id,
     )
     await _upsert_scheduled_job(session, config, org_id)
@@ -446,7 +480,15 @@ async def update_sync_config(
         raise HTTPException(status_code=404, detail="Sync configuration not found")
 
     # Fix 3 (MEDIUM) & Fix 4 (MEDIUM): Validate schedule_cron when updating sync_options.
-    schedule_cron = (payload.sync_options or {}).get("schedule_cron")
+    sync_options = _sync_options_with_top_level_fields(
+        payload.sync_options,
+        schedule_cron=payload.schedule_cron,
+        timezone=payload.timezone,
+        initial_sync_depth=payload.initial_sync_depth,
+    )
+    sync_options_provided = bool(sync_options)
+
+    schedule_cron = sync_options.get("schedule_cron")
     if schedule_cron:
         # Fix 4: Gate scheduled_jobs feature — Community tier cannot set schedules.
         from dev_health_ops.licensing.gating import _check_org_feature_async
@@ -489,15 +531,18 @@ async def update_sync_config(
                 ),
             )
 
-    updated = await svc.update(
-        name=str(getattr(config, "name")),
-        provider=str(getattr(config, "provider")),
-        sync_targets=payload.sync_targets,
-        sync_options=payload.sync_options,
-        is_active=payload.is_active,
-    )
-    if updated is None:
-        raise HTTPException(status_code=404, detail="Sync configuration not found")
+    mutable_config = cast(_MutableSyncConfiguration, config)
+    if payload.sync_targets is not None:
+        mutable_config.sync_targets = payload.sync_targets
+    if sync_options_provided:
+        mutable_config.sync_options = {
+            **dict(getattr(config, "sync_options") or {}),
+            **sync_options,
+        }
+    if payload.is_active is not None:
+        mutable_config.is_active = payload.is_active
+    await session.flush()
+    updated = config
 
     await _upsert_scheduled_job(session, updated, org_id)
 
@@ -515,11 +560,11 @@ async def update_sync_config(
             if payload.is_active is not None:
                 mutable_child.is_active = payload.is_active
             # Propagate schedule/timezone/depth from sync_options if provided
-            if payload.sync_options:
+            if sync_options_provided:
                 for key in ("schedule_cron", "timezone", "initial_sync_depth"):
-                    if key in payload.sync_options:
+                    if key in sync_options:
                         child_sync_options = dict(getattr(child, "sync_options") or {})
-                        child_sync_options[key] = payload.sync_options[key]
+                        child_sync_options[key] = sync_options[key]
                         mutable_child.sync_options = child_sync_options
         if children:
             for child in children:
@@ -597,9 +642,13 @@ async def trigger_sync_config(
                 pass
 
     try:
-        from dev_health_ops.workers.sync_tasks import run_sync_config
+        from dev_health_ops.workers.sync_tasks import (
+            dispatch_batch_sync,
+            run_sync_config,
+        )
 
-        result = getattr(run_sync_config, "delay")(
+        task = dispatch_batch_sync if _is_batch_eligible(config) else run_sync_config
+        result = getattr(task, "delay")(
             config_id=str(config.id),
             org_id=org_id,
             triggered_by="manual",

--- a/src/dev_health_ops/api/admin/schemas.py
+++ b/src/dev_health_ops/api/admin/schemas.py
@@ -114,6 +114,9 @@ class SyncConfigCreate(BaseModel):
     credential_id: str | None = None
     sync_targets: list[str] = Field(default_factory=list)
     sync_options: dict[str, Any] = Field(default_factory=dict)
+    schedule_cron: str | None = None
+    timezone: str | None = None
+    initial_sync_depth: int | None = None
 
 
 class SyncConfigBatchCreate(BaseModel):
@@ -140,6 +143,9 @@ class SyncConfigUpdate(BaseModel):
     sync_targets: list[str] | None = None
     sync_options: dict[str, Any] | None = None
     is_active: bool | None = None
+    schedule_cron: str | None = None
+    timezone: str | None = None
+    initial_sync_depth: int | None = None
 
 
 class DiscoveredRepo(BaseModel):

--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -51,6 +51,9 @@ def discover_github_repos(
         parts = search.split("/", 1)
         owner = parts[0]
         repo_pattern = parts[1]
+    elif isinstance(search, str) and search.strip() and not owner:
+        owner = search.strip()
+        repo_pattern = "*"
     else:
         repo_pattern = "*"
 
@@ -89,6 +92,9 @@ def discover_gitlab_repos(
         parts = search.split("/", 1)
         group_path = parts[0]
         project_pattern = parts[1]
+    elif isinstance(search, str) and search.strip() and not group_path:
+        group_path = search.strip()
+        project_pattern = "*"
     else:
         project_pattern = "*"
 

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -36,6 +36,7 @@ def _is_batch_eligible(config) -> bool:
     A config is batch-eligible when:
     - Provider is github or gitlab
     - sync_options contains a 'search' key with a wildcard pattern (e.g. "org/*")
+    - OR sync_options names an org/group without a concrete repo/project
     - OR sync_options contains 'discover: true'
     """
     provider = (config.provider or "").lower()
@@ -48,8 +49,23 @@ def _is_batch_eligible(config) -> bool:
         return True
 
     search = sync_options.get("search")
-    if isinstance(search, str) and ("*" in search or "?" in search):
-        return True
+    if isinstance(search, str):
+        if "*" in search or "?" in search:
+            return True
+        if search.strip() and "/" not in search:
+            return True
+
+    if provider == "github":
+        owner = sync_options.get("owner")
+        repo = sync_options.get("repo")
+        if owner and not repo:
+            return True
+
+    if provider == "gitlab":
+        group = sync_options.get("group")
+        project = sync_options.get("project_id") or sync_options.get("repo")
+        if group and not project:
+            return True
 
     return False
 
@@ -219,7 +235,10 @@ def dispatch_batch_sync(
                 owner, repo_name = repo_tuple[0], repo_tuple[1]
                 per_repo_options["owner"] = owner
                 per_repo_options["repo"] = repo_name
-                per_repo_options.pop("search", None)
+                if "work-items" in sync_targets:
+                    per_repo_options["search"] = f"{owner}/{repo_name}"
+                else:
+                    per_repo_options.pop("search", None)
             elif provider == "gitlab":
                 project_id = repo_tuple[0]
                 per_repo_options["project_id"] = int(project_id)

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -431,11 +431,13 @@ def run_sync_config(
                     job_type="sync",
                     schedule_cron=str(sync_options.get("schedule_cron") or "0 * * * *"),
                     org_id=org_id,
+                    provider=provider,
                     job_config={
                         "provider": provider,
                         "sync_config_id": str(_as_uuid(config.id)),
                     },
                     sync_config_id=_as_uuid(config.id),
+                    tz=str(sync_options.get("timezone") or "UTC"),
                     status=JobStatus.ACTIVE.value,
                 )
                 session.add(job)
@@ -509,7 +511,7 @@ def run_sync_config(
                 if valid and len(valid) == len(sync_targets):
                     since_dt = min(valid)
 
-        if provider == "github":
+        if provider == "github" and code_sync_targets:
             owner_repo = _extract_owner_repo(
                 config_name=config_name, sync_options=sync_options
             )

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -39,6 +39,15 @@ _TABLES = tables_of(
 )
 
 
+class _CroniterStub:
+    def __init__(self, *_args, **_kwargs):
+        self._next = 0.0
+
+    def get_next(self, _type):
+        self._next += 86400.0
+        return self._next
+
+
 @pytest_asyncio.fixture
 async def session_maker(tmp_path: Path):
     db_path = tmp_path / "sync-configs.db"
@@ -193,6 +202,54 @@ async def test_create_sync_config_creates_scheduled_job(client, session_maker):
 
 
 @pytest.mark.asyncio
+async def test_create_sync_config_folds_top_level_schedule_fields(
+    client, session_maker
+):
+    ac, _ = client
+
+    with (
+        patch(
+            "dev_health_ops.licensing.gating._check_org_feature_async",
+            return_value=True,
+        ),
+        patch.object(sync_router_module, "Croniter", _CroniterStub),
+    ):
+        resp = await ac.post(
+            "/api/v1/admin/sync-configs",
+            json={
+                "name": "top-level-schedule",
+                "provider": "linear",
+                "sync_targets": ["work-items"],
+                "sync_options": {"backfill_days": 1},
+                "schedule_cron": "30 2 * * *",
+                "timezone": "America/Los_Angeles",
+                "initial_sync_depth": 14,
+            },
+        )
+
+    assert resp.status_code == 201, resp.text
+    config_id = uuid.UUID(resp.json()["id"])
+    async with session_maker() as session:
+        config = (
+            await session.execute(
+                select(SyncConfiguration).where(SyncConfiguration.id == config_id)
+            )
+        ).scalar_one()
+        job = (
+            await session.execute(
+                select(ScheduledJob).where(ScheduledJob.sync_config_id == config_id)
+            )
+        ).scalar_one()
+
+    assert config.sync_options["schedule_cron"] == "30 2 * * *"
+    assert config.sync_options["timezone"] == "America/Los_Angeles"
+    assert config.sync_options["initial_sync_depth"] == 14
+    assert job.provider == "linear"
+    assert job.timezone == "America/Los_Angeles"
+    assert job.job_config == {"provider": "linear", "sync_config_id": str(config_id)}
+
+
+@pytest.mark.asyncio
 async def test_batch_create_linear_without_repos_creates_active_config_and_job(
     client, session_maker
 ):
@@ -277,6 +334,66 @@ async def test_update_sync_config_changes_is_active(client):
 
 
 @pytest.mark.asyncio
+async def test_update_sync_config_merges_top_level_schedule_fields(
+    client, session_maker
+):
+    ac, _ = client
+
+    create_resp = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": "merge-schedule",
+            "provider": "linear",
+            "sync_targets": ["work-items"],
+            "sync_options": {"backfill_days": 7},
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = create_resp.json()["id"]
+
+    with (
+        patch(
+            "dev_health_ops.licensing.gating._check_org_feature_async",
+            return_value=True,
+        ),
+        patch.object(sync_router_module, "Croniter", _CroniterStub),
+    ):
+        resp = await ac.patch(
+            f"/api/v1/admin/sync-configs/{config_id}",
+            json={
+                "schedule_cron": "45 3 * * *",
+                "timezone": "Europe/London",
+                "initial_sync_depth": 21,
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+    async with session_maker() as session:
+        config = (
+            await session.execute(
+                select(SyncConfiguration).where(
+                    SyncConfiguration.id == uuid.UUID(config_id)
+                )
+            )
+        ).scalar_one()
+        job = (
+            await session.execute(
+                select(ScheduledJob).where(
+                    ScheduledJob.sync_config_id == uuid.UUID(config_id)
+                )
+            )
+        ).scalar_one()
+
+    assert config.sync_options["backfill_days"] == 7
+    assert config.sync_options["schedule_cron"] == "45 3 * * *"
+    assert config.sync_options["timezone"] == "Europe/London"
+    assert config.sync_options["initial_sync_depth"] == 21
+    assert job.schedule_cron == "45 3 * * *"
+    assert job.provider == "linear"
+    assert job.timezone == "Europe/London"
+
+
+@pytest.mark.asyncio
 async def test_schedule_job_upsert_propagates_schedule_cron(
     client, session_maker, seeded_state
 ):
@@ -309,6 +426,42 @@ async def test_schedule_job_upsert_propagates_schedule_cron(
 
     assert job is not None
     assert job.schedule_cron == "5 * * * *"
+
+
+@pytest.mark.asyncio
+async def test_schedule_job_upsert_sets_provider_timezone_and_job_config(
+    client, session_maker, seeded_state
+):
+    ac, _ = client
+
+    create_resp = await _create_sync_config(ac, name="schedule-meta", provider="linear")
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+
+    async with session_maker() as session:
+        config = (
+            await session.execute(
+                select(SyncConfiguration).where(
+                    SyncConfiguration.id == uuid.UUID(config_id)
+                )
+            )
+        ).scalar_one()
+        config.sync_options = {"schedule_cron": "10 * * * *", "timezone": "Asia/Tokyo"}
+        await sync_router_module._upsert_scheduled_job(
+            session, config, seeded_state["org_id"]
+        )
+        await session.flush()
+        job = (
+            await session.execute(
+                select(ScheduledJob).where(
+                    ScheduledJob.sync_config_id == uuid.UUID(config_id)
+                )
+            )
+        ).scalar_one()
+
+    assert job.provider == "linear"
+    assert job.timezone == "Asia/Tokyo"
+    assert job.job_config == {"provider": "linear", "sync_config_id": config_id}
 
 
 @pytest.mark.asyncio
@@ -356,6 +509,39 @@ async def test_trigger_sync_config_returns_202_with_task_id(client):
     assert data["status"] == "triggered"
     assert data["task_id"] == "fake-task-id"
     assert data["config_id"] == config_id
+
+
+@pytest.mark.asyncio
+async def test_trigger_sync_config_routes_batch_eligible_to_batch_task(client):
+    ac, _ = client
+
+    create_resp = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": "batch-trigger",
+            "provider": "github",
+            "sync_targets": ["git"],
+            "sync_options": {"search": "full-chaos"},
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = create_resp.json()["id"]
+
+    mock_task = MagicMock(id="batch-task-id")
+    mock_batch = MagicMock()
+    mock_batch.delay.return_value = mock_task
+    mock_run = MagicMock()
+
+    with (
+        patch("dev_health_ops.workers.sync_tasks.dispatch_batch_sync", mock_batch),
+        patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run),
+    ):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 202
+    assert resp.json()["task_id"] == "batch-task-id"
+    mock_batch.delay.assert_called_once()
+    mock_run.delay.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -82,6 +82,27 @@ class TestIsBatchEligible:
         )
         assert _is_batch_eligible(config) is True
 
+    def test_github_bare_org_search_is_batch_eligible(self):
+        from dev_health_ops.workers.sync_batch import _is_batch_eligible
+
+        config = _make_config(provider="github", sync_options={"search": "full-chaos"})
+        assert _is_batch_eligible(config) is True
+
+    def test_github_owner_without_repo_is_batch_eligible(self):
+        from dev_health_ops.workers.sync_batch import _is_batch_eligible
+
+        config = _make_config(provider="github", sync_options={"owner": "full-chaos"})
+        assert _is_batch_eligible(config) is True
+
+    def test_github_owner_repo_remains_single_config(self):
+        from dev_health_ops.workers.sync_batch import _is_batch_eligible
+
+        config = _make_config(
+            provider="github",
+            sync_options={"search": "full-chaos/dev-health"},
+        )
+        assert _is_batch_eligible(config) is False
+
     def test_github_without_wildcard_not_eligible(self):
         from dev_health_ops.workers.sync_batch import _is_batch_eligible
 
@@ -192,6 +213,22 @@ class TestDiscoverGithubRepos:
         assert len(result) == 3
 
     @patch("github.Github")
+    def test_bare_org_search_lists_all_org_repos(self, mock_github_cls):
+        from dev_health_ops.discovery.repos import discover_github_repos
+
+        repos = [SimpleNamespace(name="api"), SimpleNamespace(name="web")]
+        mock_org = MagicMock()
+        mock_org.get_repos.return_value = repos
+        mock_github_cls.return_value.get_organization.return_value = mock_org
+
+        result = discover_github_repos({"search": "full-chaos"}, "token")
+
+        mock_github_cls.return_value.get_organization.assert_called_once_with(
+            "full-chaos"
+        )
+        assert result == [("full-chaos", "api"), ("full-chaos", "web")]
+
+    @patch("github.Github")
     def test_falls_back_to_user_repos_on_org_error(self, mock_github_cls):
         from dev_health_ops.discovery.repos import discover_github_repos
 
@@ -237,6 +274,21 @@ class TestDiscoverGitlabRepos:
 
         result = discover_gitlab_repos({"search": "my-group/api*"}, "glpat_token")
         assert result == [("100",)]
+
+    @patch("gitlab.Gitlab")
+    def test_bare_group_search_lists_all_group_projects(self, mock_gitlab_cls):
+        from dev_health_ops.discovery.repos import discover_gitlab_repos
+
+        proj_a = SimpleNamespace(name="api", id=100)
+        proj_b = SimpleNamespace(name="web", id=200)
+        mock_grp = MagicMock()
+        mock_grp.projects.list.return_value = [proj_a, proj_b]
+        mock_gitlab_cls.return_value.groups.get.return_value = mock_grp
+
+        result = discover_gitlab_repos({"search": "my-group"}, "glpat_token")
+
+        mock_gitlab_cls.return_value.groups.get.assert_called_once_with("my-group")
+        assert result == [("100",), ("200",)]
 
     @patch("gitlab.Gitlab")
     def test_returns_empty_on_group_error(self, mock_gitlab_cls):
@@ -476,6 +528,52 @@ class TestDispatchBatchSync:
 
         assert result["total_repos"] == 7
         assert result["batch_count"] == 4
+
+    @patch("dev_health_ops.workers.sync_batch._run_sync_for_repo")
+    @patch("dev_health_ops.workers.sync_batch.chord")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_github_child_work_items_search_is_scoped_to_repo(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_chord,
+        mock_run_for_repo,
+        db_session,
+    ):
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        captured_kwargs = []
+
+        def _capture_signature(**kwargs):
+            captured_kwargs.append(kwargs)
+            return MagicMock()
+
+        mock_run_for_repo.s.side_effect = _capture_signature
+        config = _make_config(
+            provider="github",
+            sync_options={"search": "org/*"},
+            sync_targets=["git", "work-items"],
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        mock_get_session.return_value = _fake_session_ctx(db_session)
+        mock_resolve_creds.return_value = {"token": "ghp_test"}
+        mock_discover.return_value = [("org", "repo-1")]
+        mock_chord.return_value = MagicMock()
+
+        task = dispatch_batch_sync
+        task.push_request(id="batch-dispatch-work-items")
+        try:
+            result = task(config_id=str(config.id), org_id="default")
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "dispatched"
+        assert captured_kwargs[0]["sync_options_override"]["search"] == "org/repo-1"
 
 
 class TestBatchSyncCallback:

--- a/tests/test_sync_watermarks.py
+++ b/tests/test_sync_watermarks.py
@@ -414,6 +414,43 @@ class TestRunSyncConfigWatermarks:
         assert mock_run_work_items.call_args.kwargs["provider"] == "linear"
 
     @patch("dev_health_ops.metrics.job_work_items.run_work_items_sync_job")
+    @patch("dev_health_ops.workers.sync_runtime._dispatch_post_sync_tasks")
+    @patch(
+        "dev_health_ops.workers.sync_runtime._resolve_env_credentials", return_value={}
+    )
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_github_work_items_only_does_not_require_owner_repo(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_post_sync,
+        mock_run_work_items,
+        db_session,
+    ):
+        from dev_health_ops.workers.sync_runtime import run_sync_config
+
+        config = _make_config(
+            provider="github",
+            sync_options={"search": "full-chaos"},
+            sync_targets=["work-items"],
+            name="github-work-items",
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
+
+        task = cast(Any, run_sync_config)
+        task.push_request(id="github-work-items-only")
+        try:
+            result = task(config_id=str(config.id), org_id=ORG_ID)
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "success"
+        mock_run_work_items.assert_called_once()
+
+    @patch("dev_health_ops.metrics.job_work_items.run_work_items_sync_job")
     def test_batch_child_empty_targets_defaults_to_work_items(
         self, mock_run_work_items
     ):


### PR DESCRIPTION
## Summary
- route org-wide GitHub/GitLab configs through batch sync for scheduled and manual triggers
- normalize bare org/group discovery and per-repo work-item child scoping
- accept and persist top-level schedule_cron/timezone/initial_sync_depth on sync config create/update
- let GitHub work-items-only configs bypass single-repo owner/repo validation

## Verification
- python -m pytest tests/test_sync_partitioning.py tests/test_sync_watermarks.py tests/api/admin/test_sync_configs.py
- python -m ruff format src/dev_health_ops/api/admin/schemas.py src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/api/services/configuration/sync_configuration.py src/dev_health_ops/workers/sync_batch.py src/dev_health_ops/workers/sync_scheduler.py src/dev_health_ops/workers/sync_runtime.py src/dev_health_ops/discovery/repos.py src/dev_health_ops/workers/task_utils.py tests/test_sync_partitioning.py tests/test_sync_watermarks.py tests/api/admin/test_sync_configs.py
- python -m ruff check src/dev_health_ops/api/admin/schemas.py src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/api/services/configuration/sync_configuration.py src/dev_health_ops/workers/sync_batch.py src/dev_health_ops/workers/sync_scheduler.py src/dev_health_ops/workers/sync_runtime.py src/dev_health_ops/discovery/repos.py src/dev_health_ops/workers/task_utils.py tests/test_sync_partitioning.py tests/test_sync_watermarks.py tests/api/admin/test_sync_configs.py
- python -m mypy src/dev_health_ops/api/admin/schemas.py src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/api/services/configuration/sync_configuration.py src/dev_health_ops/workers/sync_batch.py src/dev_health_ops/workers/sync_scheduler.py src/dev_health_ops/workers/sync_runtime.py src/dev_health_ops/discovery/repos.py src/dev_health_ops/workers/task_utils.py
- LSP diagnostics clean on changed source/test files

SCREENSHOT-WAIVER: backend sync/API changes only; no rendered frontend output changed.

Closes CHAOS-2250