### PR TITLE
fix(admin): fall back to single active credential in discovery endpoints

### DIFF
--- a/src/dev_health_ops/api/admin/routers/identities.py
+++ b/src/dev_health_ops/api/admin/routers/identities.py
@@ -17,6 +17,7 @@ from dev_health_ops.api.admin.schemas import (
     TeamMembersDiscoverResponse,
 )
 from dev_health_ops.api.services.configuration import (
+    AmbiguousCredentialError,
     IdentityMappingService,
     IntegrationCredentialsService,
     JiraActivityInferenceService,
@@ -80,6 +81,8 @@ async def create_or_update_identity(
 async def discover_team_members(
     team_id: str,
     provider: str = Query(..., pattern="^(github|gitlab|jira)$"),
+    credential_id: str | None = Query(None),
+    credential_name: str | None = Query(None),
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> TeamMembersDiscoverResponse:
@@ -89,8 +92,12 @@ async def discover_team_members(
         raise HTTPException(status_code=404, detail="Team not found")
 
     creds_svc = IntegrationCredentialsService(session, org_id)
-    credential = await creds_svc.get(provider, "default")
-    decrypted = await creds_svc.get_decrypted_credentials(provider, "default")
+    try:
+        credential, decrypted = await creds_svc.resolve_with_fallback(
+            provider, name=credential_name, credential_id=credential_id
+        )
+    except AmbiguousCredentialError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
     if credential is None or decrypted is None:
         raise HTTPException(
             status_code=404,
@@ -205,6 +212,8 @@ async def confirm_team_members(
 async def infer_team_members_from_jira_activity(
     team_id: str,
     window_days: int = Query(90, ge=1, le=365),
+    credential_id: str | None = Query(None),
+    credential_name: str | None = Query(None),
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> JiraActivityInferenceResponse:
@@ -226,8 +235,12 @@ async def infer_team_members_from_jira_activity(
         )
 
     creds_svc = IntegrationCredentialsService(session, org_id)
-    credential = await creds_svc.get("jira", "default")
-    decrypted = await creds_svc.get_decrypted_credentials("jira", "default")
+    try:
+        credential, decrypted = await creds_svc.resolve_with_fallback(
+            "jira", name=credential_name, credential_id=credential_id
+        )
+    except AmbiguousCredentialError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
     if credential is None or decrypted is None:
         raise HTTPException(
             status_code=404,

--- a/src/dev_health_ops/api/admin/routers/teams.py
+++ b/src/dev_health_ops/api/admin/routers/teams.py
@@ -15,6 +15,7 @@ from dev_health_ops.api.admin.schemas import (
     TeamMappingUpdate,
 )
 from dev_health_ops.api.services.configuration import (
+    AmbiguousCredentialError,
     IntegrationCredentialsService,
     TeamDiscoveryService,
     TeamMappingService,
@@ -107,12 +108,18 @@ async def delete_team(
 @router.get("/teams/discover", response_model=TeamDiscoverResponse)
 async def discover_teams(
     provider: str = Query(..., pattern="^(github|gitlab|jira|linear)$"),
+    credential_id: str | None = Query(None),
+    credential_name: str | None = Query(None),
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> TeamDiscoverResponse:
     creds_svc = IntegrationCredentialsService(session, org_id)
-    credential = await creds_svc.get(provider, "default")
-    decrypted = await creds_svc.get_decrypted_credentials(provider, "default")
+    try:
+        credential, decrypted = await creds_svc.resolve_with_fallback(
+            provider, name=credential_name, credential_id=credential_id
+        )
+    except AmbiguousCredentialError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
     if credential is None or decrypted is None:
         raise HTTPException(
             status_code=404,

--- a/src/dev_health_ops/api/services/configuration/__init__.py
+++ b/src/dev_health_ops/api/services/configuration/__init__.py
@@ -31,7 +31,10 @@ from ._helpers import (
 )
 from .generic import SettingsService
 from .identity_mapping import IdentityMappingService
-from .integration_credentials import IntegrationCredentialsService
+from .integration_credentials import (
+    AmbiguousCredentialError,
+    IntegrationCredentialsService,
+)
 from .jira_activity_inference import JiraActivityInferenceService
 from .sync_configuration import SyncConfigurationService
 from .team_discovery import TeamDiscoveryService
@@ -40,6 +43,7 @@ from .team_mapping import TeamMappingService
 from .team_membership import TeamMembershipService
 
 __all__ = [
+    "AmbiguousCredentialError",
     "IdentityMappingService",
     "IntegrationCredentialsService",
     "JiraActivityInferenceService",

--- a/src/dev_health_ops/api/services/configuration/integration_credentials.py
+++ b/src/dev_health_ops/api/services/configuration/integration_credentials.py
@@ -22,6 +22,19 @@ from ._helpers import _normalize_credential_keys
 logger = logging.getLogger(__name__)
 
 
+class AmbiguousCredentialError(ValueError):
+    """Raised when a provider has multiple active credentials and no
+    explicit name/id was given to disambiguate."""
+
+    def __init__(self, provider: str, names: list[str]):
+        self.provider = provider
+        self.names = sorted(names)
+        super().__init__(
+            f"Multiple active credentials exist for provider '{provider}' "
+            f"({', '.join(self.names)}); specify credential_name or credential_id"
+        )
+
+
 class IntegrationCredentialsService:
     """Service for managing integration credentials with encryption."""
 
@@ -100,6 +113,55 @@ class IntegrationCredentialsService:
                 sanitize_for_log(name),
             )
             return None
+
+    async def resolve_with_fallback(
+        self,
+        provider: str,
+        name: str | None = None,
+        credential_id: str | None = None,
+    ) -> tuple[IntegrationCredential | None, dict[str, Any] | None]:
+        """Resolve a credential for a provider, falling back when unnamed.
+
+        Resolution order:
+        1. ``credential_id`` (must belong to ``provider``)
+        2. explicit ``name``
+        3. the ``"default"`` name
+        4. the single active credential for the provider
+
+        Returns ``(credential, decrypted_dict)``; both ``None`` when nothing
+        matches. Raises :class:`AmbiguousCredentialError` if step 4 finds more
+        than one active credential.
+        """
+        if credential_id:
+            decrypted, cred = await self.get_decrypted_credentials_by_id(credential_id)
+            if cred is not None and str(getattr(cred, "provider")) != provider:
+                return None, None
+            return cred, decrypted
+
+        if name:
+            cred = await self.get(provider, name)
+            if cred is None:
+                return None, None
+            return cred, await self.get_decrypted_credentials(provider, name)
+
+        cred = await self.get(provider, "default")
+        if cred is not None:
+            return cred, await self.get_decrypted_credentials(provider, "default")
+
+        candidates = [
+            c
+            for c in await self.list_by_provider(provider)
+            if bool(getattr(c, "is_active"))
+        ]
+        if not candidates:
+            return None, None
+        if len(candidates) > 1:
+            raise AmbiguousCredentialError(
+                provider, [str(getattr(c, "name")) for c in candidates]
+            )
+        only = candidates[0]
+        only_name = str(getattr(only, "name"))
+        return only, await self.get_decrypted_credentials(provider, only_name)
 
     async def set(
         self,

--- a/tests/api/admin/test_credential_fallback.py
+++ b/tests/api/admin/test_credential_fallback.py
@@ -1,0 +1,274 @@
+"""Tests for credential resolution fallback in discovery endpoints.
+
+Connections created through the admin UI are stored under a user-chosen
+name (e.g. "chaos"), but the discovery endpoints used to hardcode
+``name="default"`` — making team/member discovery 404 for every provider
+unless a credential happened to be named "default".
+
+Covers ``IntegrationCredentialsService.resolve_with_fallback`` and the
+``GET /teams/discover`` endpoint behaviour built on it.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+os.environ.setdefault("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.services.configuration import (
+    AmbiguousCredentialError,
+    IntegrationCredentialsService,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import IntegrationCredential, TeamMapping
+from dev_health_ops.models.users import Membership, Organization, User
+from tests._helpers import tables_of
+
+admin_router_module = importlib.import_module("dev_health_ops.api.admin")
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+_TABLES = tables_of(User, Organization, Membership, TeamMapping, IntegrationCredential)
+
+ORG_ID = str(uuid.uuid4())
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "cred-fallback.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def _seed_credential(
+    session_maker,
+    provider: str,
+    name: str,
+    is_active: bool = True,
+    credentials: dict | None = None,
+) -> None:
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        await svc.set(
+            provider=provider,
+            credentials=credentials or {"apiKey": "lin_api_test"},
+            name=name,
+            is_active=is_active,
+        )
+        await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Service-level: resolve_with_fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_single_active_credential(session_maker):
+    await _seed_credential(session_maker, "linear", "chaos")
+
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        cred, decrypted = await svc.resolve_with_fallback("linear")
+
+    assert cred is not None
+    assert str(cred.name) == "chaos"
+    assert decrypted == {"api_key": "lin_api_test"}
+
+
+@pytest.mark.asyncio
+async def test_prefers_default_name_when_present(session_maker):
+    await _seed_credential(
+        session_maker, "linear", "default", credentials={"apiKey": "default-key"}
+    )
+    await _seed_credential(
+        session_maker, "linear", "chaos", credentials={"apiKey": "chaos-key"}
+    )
+
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        cred, decrypted = await svc.resolve_with_fallback("linear")
+
+    assert cred is not None
+    assert str(cred.name) == "default"
+    assert decrypted == {"api_key": "default-key"}
+
+
+@pytest.mark.asyncio
+async def test_multiple_active_without_default_is_ambiguous(session_maker):
+    await _seed_credential(session_maker, "linear", "chaos")
+    await _seed_credential(session_maker, "linear", "other")
+
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        with pytest.raises(AmbiguousCredentialError) as exc_info:
+            await svc.resolve_with_fallback("linear")
+
+    assert exc_info.value.names == ["chaos", "other"]
+
+
+@pytest.mark.asyncio
+async def test_inactive_credentials_are_not_fallback_candidates(session_maker):
+    await _seed_credential(session_maker, "linear", "chaos", is_active=False)
+
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        cred, decrypted = await svc.resolve_with_fallback("linear")
+
+    assert cred is None
+    assert decrypted is None
+
+
+@pytest.mark.asyncio
+async def test_explicit_name_lookup(session_maker):
+    await _seed_credential(session_maker, "linear", "chaos")
+    await _seed_credential(session_maker, "linear", "other")
+
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        cred, decrypted = await svc.resolve_with_fallback("linear", name="other")
+
+    assert cred is not None
+    assert str(cred.name) == "other"
+
+
+@pytest.mark.asyncio
+async def test_credential_id_must_match_provider(session_maker):
+    await _seed_credential(session_maker, "github", "chaos", credentials={"token": "x"})
+
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        github_cred = await svc.get("github", "chaos")
+        assert github_cred is not None
+        cred, decrypted = await svc.resolve_with_fallback(
+            "linear", credential_id=str(github_cred.id)
+        )
+
+    assert cred is None
+    assert decrypted is None
+
+
+@pytest.mark.asyncio
+async def test_credential_id_lookup(session_maker):
+    await _seed_credential(session_maker, "linear", "chaos")
+
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        stored = await svc.get("linear", "chaos")
+        assert stored is not None
+        cred, decrypted = await svc.resolve_with_fallback(
+            "linear", credential_id=str(stored.id)
+        )
+
+    assert cred is not None
+    assert decrypted == {"api_key": "lin_api_test"}
+
+
+# ---------------------------------------------------------------------------
+# Endpoint-level: GET /teams/discover
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def client(session_maker):
+    app = FastAPI()
+    app.include_router(admin_router_module.router)
+
+    admin_user = AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        email="admin@example.com",
+        org_id=ORG_ID,
+        role="owner",
+        is_superuser=False,
+    )
+
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+            await session.commit()
+
+    app.dependency_overrides[auth_router_module.get_current_user] = lambda: admin_user
+    app.dependency_overrides[admin_router_module.get_session] = _session_override
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_discover_uses_non_default_credential(client, session_maker):
+    await _seed_credential(session_maker, "linear", "chaos")
+
+    with patch(
+        "dev_health_ops.api.services.configuration.team_discovery."
+        "TeamDiscoveryService.discover_linear",
+        new=AsyncMock(return_value=[]),
+    ) as mock_discover:
+        response = await client.get("/api/v1/admin/teams/discover?provider=linear")
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["provider"] == "linear"
+    assert data["teams"] == []
+    mock_discover.assert_awaited_once_with(api_key="lin_api_test")
+
+
+@pytest.mark.asyncio
+async def test_discover_404_when_no_credentials(client):
+    response = await client.get("/api/v1/admin/teams/discover?provider=linear")
+    assert response.status_code == 404
+    assert "No credentials found for provider 'linear'" in response.text
+
+
+@pytest.mark.asyncio
+async def test_discover_409_when_ambiguous(client, session_maker):
+    await _seed_credential(session_maker, "linear", "chaos")
+    await _seed_credential(session_maker, "linear", "other")
+
+    response = await client.get("/api/v1/admin/teams/discover?provider=linear")
+    assert response.status_code == 409
+    assert "Multiple active credentials" in response.text
+
+
+@pytest.mark.asyncio
+async def test_discover_with_explicit_credential_name(client, session_maker):
+    await _seed_credential(
+        session_maker, "linear", "chaos", credentials={"apiKey": "chaos-key"}
+    )
+    await _seed_credential(
+        session_maker, "linear", "other", credentials={"apiKey": "other-key"}
+    )
+
+    with patch(
+        "dev_health_ops.api.services.configuration.team_discovery."
+        "TeamDiscoveryService.discover_linear",
+        new=AsyncMock(return_value=[]),
+    ) as mock_discover:
+        response = await client.get(
+            "/api/v1/admin/teams/discover?provider=linear&credential_name=other"
+        )
+
+    assert response.status_code == 200, response.text
+    mock_discover.assert_awaited_once_with(api_key="other-key")


### PR DESCRIPTION
Fixes CHAOS-2257

## Problem

**Import Teams fails for every provider** with `No credentials found for provider 'X'` (e.g. `linear`).

The connections UI (`CreateCredentialModal`) requires a user-chosen connection name and stores credentials under it (e.g. `chaos`), but three discovery endpoints hardcode `creds_svc.get(provider, "default")`:

- `GET /teams/discover` (`routers/teams.py`)
- `GET /teams/{id}/discover-members` (`routers/identities.py`)
- `GET /teams/{id}/infer-members` (`routers/identities.py`)

No `default`-named row exists → 404 for all providers. Verified against the live dev DB: both stored credentials (`linear`, `github`) are named `chaos`.

## Fix

New `IntegrationCredentialsService.resolve_with_fallback(provider, name=None, credential_id=None)` with resolution order:

1. `credential_id` (must belong to the provider)
2. explicit `name`
3. `"default"`
4. the **single** active credential for the provider — raises `AmbiguousCredentialError` (→ HTTP 409 listing the names) when several are active, rather than silently picking one

All three endpoints use the resolver and accept optional `credential_id` / `credential_name` query params, so the frontend can later let users pick a connection explicitly (same pattern as `GET /credentials/{id}/repos`).

## Tests

`tests/api/admin/test_credential_fallback.py` — 7 service-level tests (fallback, default-preference, ambiguity, inactive exclusion, name/id lookup, provider mismatch) + 4 endpoint tests including a repro of the reported bug (credential named `chaos`, no `default` → 200).

Gates: `mypy --install-types --non-interactive .` clean, ruff check/format clean, 52 tests across the touched admin suites pass.
