### PR TITLE
fix(teams): set project_keys on Linear team discovery for metrics attribution (CHAOS-2262)

### DIFF
--- a/src/dev_health_ops/api/services/configuration/team_discovery.py
+++ b/src/dev_health_ops/api/services/configuration/team_discovery.py
@@ -80,7 +80,14 @@ class TeamDiscoveryService:
                             provider_team_id=team["key"],
                             name=team["name"],
                             description=team.get("description"),
-                            associations={"provider_org": "linear"},
+                            # Linear work items normalize with
+                            # project_key = team key, so the team key is the
+                            # attribution association (mirrors Jira's
+                            # project_keys / GitHub-GitLab's repo_patterns).
+                            associations={
+                                "project_keys": [team["key"]],
+                                "provider_org": "linear",
+                            },
                         )
                     )
                 return teams

--- a/src/dev_health_ops/metrics/compute_work_items.py
+++ b/src/dev_health_ops/metrics/compute_work_items.py
@@ -213,6 +213,13 @@ def compute_work_item_metrics_daily(
         team_id, team_name = None, None
         if project_key_resolver is not None:
             team_id, team_name = project_key_resolver.resolve(work_scope_id)
+            # Linear: work_scope_id is the project name when the issue sits
+            # in a project, but team mappings carry the TEAM key (the item's
+            # project_key) — retry with it before the membership fallback.
+            if team_id is None and item.project_key:
+                project_key = str(item.project_key)
+                if project_key != work_scope_id:
+                    team_id, team_name = project_key_resolver.resolve(project_key)
         if team_id is None:
             team_id, team_name = _resolve_team(team_resolver, assignee)
         team_id_norm = normalize_team_id(team_id)

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -392,12 +392,21 @@ def run_work_items_sync_job(
 
             def _get_team(wi: Any) -> str:
                 if pk_resolver:
-                    t_id, _ = pk_resolver.resolve(
-                        getattr(wi, "work_scope_id", None)
-                        or getattr(wi, "project_key", None)
-                    )
-                    if t_id:
-                        return t_id
+                    # Try work_scope_id first, then project_key. For Linear
+                    # these differ when the issue sits in a project:
+                    # work_scope_id is the project name while project_key is
+                    # the TEAM key — the attribution key team mappings carry.
+                    # An `or` would hide project_key whenever work_scope_id
+                    # is non-empty but unmatched.
+                    for key in (
+                        getattr(wi, "work_scope_id", None),
+                        getattr(wi, "project_key", None),
+                    ):
+                        if not key:
+                            continue
+                        t_id, _ = pk_resolver.resolve(key)
+                        if t_id:
+                            return t_id
                 if getattr(wi, "assignees", None):
                     t_id, _ = team_resolver.resolve(wi.assignees[0])
                     if t_id:

--- a/src/dev_health_ops/models/work_items.py
+++ b/src/dev_health_ops/models/work_items.py
@@ -89,7 +89,18 @@ class WorkItem:
         Notes:
         - Jira: uses `project_key` when present.
         - GitHub/GitLab: uses `project_id` (e.g. owner/repo, group/project) when present.
+        - Linear: uses `project_id` (the Linear PROJECT name) when the issue
+          sits in a project, else `project_key` (the Linear TEAM key).
         - May be empty when the provider object is not scoped (e.g. GitHub draft project cards).
+
+        IMPORTANT — work scope is NOT the team-attribution key. In Linear,
+        projects and teams are different things: issues always belong to a
+        team (`project_key` = team key) and only sometimes to a project
+        (`project_id`). Team attribution must therefore try `project_key`
+        when a `work_scope_id` lookup misses; see
+        ``ProjectKeyTeamResolver`` callers in ``metrics/compute_work_items.py``
+        and ``metrics/job_work_items.py``. (Jira's project-as-scope is also
+        only a fallback for attribution — teams are membership-based first.)
         """
         if self.provider == "jira" and self.project_key:
             return str(self.project_key)

--- a/src/dev_health_ops/providers/teams.py
+++ b/src/dev_health_ops/providers/teams.py
@@ -69,6 +69,16 @@ class TeamResolver:
 
 @dataclass(frozen=True)
 class ProjectKeyTeamResolver:
+    """Resolves a team from a provider attribution key.
+
+    "Project key" here is the provider's team-attribution key, not
+    necessarily a project: Jira → project key, Linear → TEAM key (Linear
+    projects are a separate concept carried in ``WorkItem.project_id``).
+    Callers should try ``work_scope_id`` first and fall back to
+    ``project_key`` — for Linear issues inside a project the two differ.
+    Membership-based ``TeamResolver`` remains the next fallback.
+    """
+
     project_key_to_team: Mapping[str, tuple[str, str]]
 
     def resolve(self, work_scope_id: str | None) -> tuple[str | None, str | None]:

--- a/tests/test_linear_team_sync.py
+++ b/tests/test_linear_team_sync.py
@@ -380,7 +380,8 @@ class TestDiscoverLinear:
     def test_discover_linear_associations_set(
         self, mock_client_class: MagicMock
     ) -> None:
-        """discover_linear() sets associations with provider_org='linear'."""
+        """discover_linear() sets project_keys (= team key) for work-item
+        attribution, plus provider_org."""
         from dev_health_ops.api.services.configuration import TeamDiscoveryService
 
         mock_client = MagicMock()
@@ -399,7 +400,10 @@ class TestDiscoverLinear:
         result = asyncio.run(service.discover_linear(api_key="test-key"))
 
         assert len(result) == 1
-        assert result[0].associations == {"provider_org": "linear"}
+        assert result[0].associations == {
+            "project_keys": ["ENG"],
+            "provider_org": "linear",
+        }
 
     @patch("dev_health_ops.providers.linear.client.LinearClient")
     def test_discover_linear_client_closed_on_success(

--- a/tests/test_work_item_metrics_compute.py
+++ b/tests/test_work_item_metrics_compute.py
@@ -88,3 +88,50 @@ def test_work_item_cycle_time_percentiles() -> None:
     assert user.user_identity == "alice@example.com"
     assert user.items_completed == 5
     assert user.cycle_time_p50_hours == 4.0
+
+
+def test_linear_item_in_project_attributes_team_via_project_key() -> None:
+    """A Linear issue inside a project has work_scope_id = project name, but
+    team mappings carry the TEAM key (project_key) — attribution must retry
+    with project_key when the work_scope_id lookup misses (CHAOS-2262)."""
+    from dev_health_ops.providers.teams import build_project_key_resolver
+
+    day = date(2025, 2, 1)
+    start = datetime(2025, 2, 1, tzinfo=timezone.utc)
+
+    item = WorkItem(
+        work_item_id="linear:ENG-1",
+        provider="linear",
+        project_key="ENG",  # Linear TEAM key
+        project_id="Q1 Platform Revamp",  # Linear PROJECT name
+        title="In-project issue",
+        type="task",
+        status="done",
+        status_raw="Done",
+        assignees=[],  # no membership fallback available
+        reporter=None,
+        created_at=start - timedelta(days=2),
+        updated_at=start + timedelta(hours=2),
+        started_at=start,
+        completed_at=start + timedelta(hours=2),
+        closed_at=start + timedelta(hours=2),
+        labels=[],
+    )
+
+    resolver = build_project_key_resolver(
+        [{"id": "ENG", "name": "Engineering", "project_keys": ["ENG"]}]
+    )
+
+    group_rows, _, cycle_rows = compute_work_item_metrics_daily(
+        day=day,
+        work_items=[item],
+        transitions=[],
+        computed_at=start,
+        team_resolver=TeamResolver(member_to_team={}),
+        project_key_resolver=resolver,
+    )
+
+    assert group_rows, "expected at least one group row"
+    assert group_rows[0].work_scope_id == "Q1 Platform Revamp"
+    assert group_rows[0].team_id == "ENG"
+    assert cycle_rows[0].team_id == "ENG"


### PR DESCRIPTION
Fixes CHAOS-2262

## Problem

Teams imported from Linear land in Postgres + the ClickHouse `teams` roster (verified live), but with **empty `project_keys` and `repo_patterns`** — so `ProjectKeyTeamResolver` can never attribute work items to them. They show up in the TEAM filter dropdown but never accrue `team_metrics_daily` rows, leaving Landscape → Teams at 'No team data' forever, even after activity sync.

## Important domain note (from review discussion)

**Linear projects ≠ teams**, and attribution is teams-first: the resolver chain is project-key resolver → membership-based `TeamResolver` → unassigned. `WorkItem.project_key` is the provider *attribution* key (Linear → TEAM key; Jira → project key), while the actual Linear project rides separately in `project_id`.

## Fix (two commits)

1. `discover_linear` now sets `project_keys=[team['key']]` — the Linear team key, mirroring Jira's `project_keys` and GitHub/GitLab's `repo_patterns`. Existing imported teams backfill by re-importing with **Merge with existing**.
2. **Attribution fallback**: for Linear issues *inside* a project, `work_scope_id` is the project name, so the team-key lookup missed and fell to membership (empty for UI-imported teams). Both resolver call sites (`compute_work_items.py`, `job_work_items.py`) now retry with the item's `project_key` before the membership fallback. The scope-vs-attribution distinction is now documented on `WorkItem.work_scope_id` and `ProjectKeyTeamResolver`.

## Tests/Gates

- `test_linear_team_sync.py` associations test asserts the new shape
- New `test_linear_item_in_project_attributes_team_via_project_key` — Linear issue in a project, no assignees, attributes to the team via the fallback
- 354 metrics tests pass; full mypy clean (1005 files); ruff check/format clean

Follow-ups: members-on-import parity (separate ticket), Jira first-class Teams discovery (CHAOS-2263).