### PR TITLE
fix(sync): persist PENDING JobRun at Sync Now trigger time (CHAOS-2255)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -23,6 +23,7 @@ from dev_health_ops.api.services.configuration import SyncConfigurationService
 from dev_health_ops.api.services.licensing import TierLimitService
 from dev_health_ops.models.settings import (
     JobRun,
+    JobRunStatus,
     JobStatus,
     ScheduledJob,
     SyncConfiguration,
@@ -647,16 +648,67 @@ async def trigger_sync_config(
             run_sync_config,
         )
 
-        task = dispatch_batch_sync if _is_batch_eligible(config) else run_sync_config
+        # Create a PENDING JobRun synchronously so the UI shows status immediately.
+        # Ensure the ScheduledJob row exists first (worker also does this, but we
+        # need the job_id to create the JobRun).
+        def _create_pending_run(sync_session) -> str:
+            import uuid as _uuid
+
+            config_uuid = _uuid.UUID(str(config.id))
+            job = (
+                sync_session.query(ScheduledJob)
+                .filter(
+                    ScheduledJob.org_id == org_id,
+                    ScheduledJob.sync_config_id == config_uuid,
+                    ScheduledJob.job_type == "sync",
+                )
+                .one_or_none()
+            )
+            if job is None:
+                _sync_options = dict(config.sync_options or {})
+                _provider = str(config.provider or "")
+                job = ScheduledJob(
+                    name=f"sync-config-{config_uuid}",
+                    job_type="sync",
+                    schedule_cron=str(
+                        _sync_options.get("schedule_cron") or "0 * * * *"
+                    ),
+                    org_id=org_id,
+                    provider=_provider,
+                    job_config={
+                        "provider": _provider,
+                        "sync_config_id": str(config_uuid),
+                    },
+                    sync_config_id=config_uuid,
+                    tz=str(_sync_options.get("timezone") or "UTC"),
+                    status=JobStatus.ACTIVE.value,
+                )
+                sync_session.add(job)
+                sync_session.flush()
+            run = JobRun(
+                job_id=_uuid.UUID(str(job.id)),
+                triggered_by="manual",
+                status=JobRunStatus.PENDING.value,
+            )
+            sync_session.add(run)
+            sync_session.flush()
+            return str(run.id)
+
+        pending_run_id: str = await session.run_sync(_create_pending_run)
+
+        is_batch = _is_batch_eligible(config)
+        task = dispatch_batch_sync if is_batch else run_sync_config
         result = getattr(task, "delay")(
             config_id=str(config.id),
             org_id=org_id,
             triggered_by="manual",
+            pending_run_id=pending_run_id,
         )
         return {
             "status": "triggered",
             "config_id": str(config.id),
             "task_id": result.id,
+            "run_id": pending_run_id,
         }
     except Exception as e:
         raise HTTPException(status_code=503, detail=f"Task queue unavailable: {e}")

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -30,6 +30,32 @@ from dev_health_ops.workers.task_utils import (
 logger = logging.getLogger(__name__)
 
 
+def _mark_batch_run_complete(run_id: str, results: list) -> None:
+    """Update the parent JobRun to SUCCESS after all batch children complete."""
+    from dev_health_ops.db import get_postgres_session_sync
+    from dev_health_ops.models.settings import JobRun, JobRunStatus
+
+    try:
+        with get_postgres_session_sync() as session:
+            run_record = (
+                session.query(JobRun)
+                .filter(JobRun.id == uuid.UUID(run_id))
+                .one_or_none()
+            )
+            if run_record is not None:
+                completed_at = datetime.now(timezone.utc)
+                setattr(run_record, "status", JobRunStatus.SUCCESS.value)
+                setattr(run_record, "completed_at", completed_at)
+                setattr(
+                    run_record,
+                    "result",
+                    {"child_results": len(results) if results else 0},
+                )
+                session.flush()
+    except Exception as exc:
+        logger.error("Failed to mark batch run %s complete: %s", run_id, exc)
+
+
 def _is_batch_eligible(config) -> bool:
     """Check if a SyncConfiguration should be dispatched as a batch.
 
@@ -91,6 +117,7 @@ def _batch_sync_callback(
     provider: str,
     sync_targets: list[str],
     org_id: str,
+    run_id: str | None = None,
 ) -> dict:
     """Chord callback: dispatch post-sync tasks after all batch children complete."""
     logger.info(
@@ -102,6 +129,8 @@ def _batch_sync_callback(
         sync_targets=sync_targets,
         org_id=org_id,
     )
+    if run_id is not None:
+        _mark_batch_run_complete(run_id, results)
     return {
         "status": "post_sync_dispatched",
         "child_results": len(results) if results else 0,
@@ -119,6 +148,7 @@ def dispatch_batch_sync(
     config_id: str,
     org_id: str,
     triggered_by: str = "schedule",
+    pending_run_id: str | None = None,
 ) -> dict:
     """Fan out a batch-eligible SyncConfiguration into per-repo Celery tasks.
 
@@ -206,6 +236,7 @@ def dispatch_batch_sync(
                     "config_id": config_id,
                     "org_id": org_id,
                     "triggered_by": triggered_by,
+                    "pending_run_id": pending_run_id,
                 },
                 queue="sync",
             )
@@ -271,6 +302,7 @@ def dispatch_batch_sync(
                 provider=provider,
                 sync_targets=sync_targets,
                 org_id=org_id,
+                run_id=pending_run_id,
             ),
         )()
 

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -338,6 +338,7 @@ def run_sync_config(
     config_id: str,
     org_id: str,
     triggered_by: str = "manual",
+    pending_run_id: str | None = None,
 ) -> dict:
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.metrics.job_work_items import run_work_items_sync_job
@@ -451,13 +452,31 @@ def run_sync_config(
 
             job_id = _as_uuid(job.id)
 
-            run = JobRun(
-                job_id=job_id,
-                triggered_by=triggered_by,
-                status=JobRunStatus.PENDING.value,
-            )
-            session.add(run)
-            session.flush()
+            if pending_run_id is not None:
+                # Reuse the PENDING row created at trigger time.
+                _existing = (
+                    session.query(JobRun)
+                    .filter(JobRun.id == uuid.UUID(pending_run_id))
+                    .one_or_none()
+                )
+                if _existing is not None:
+                    run = _existing
+                else:
+                    run = JobRun(
+                        job_id=job_id,
+                        triggered_by=triggered_by,
+                        status=JobRunStatus.PENDING.value,
+                    )
+                    session.add(run)
+                    session.flush()
+            else:
+                run = JobRun(
+                    job_id=job_id,
+                    triggered_by=triggered_by,
+                    status=JobRunStatus.PENDING.value,
+                )
+                session.add(run)
+                session.flush()
             run_id = _as_uuid(run.id)
 
             setattr(run, "status", JobRunStatus.RUNNING.value)

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -672,3 +672,123 @@ async def test_update_targets_correct_provider(client):
     lin_resp = await ac.get(f"/api/v1/admin/sync-configs/{lin_id}")
     assert lin_resp.status_code == 200
     assert lin_resp.json()["is_active"] is True
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2255: PENDING JobRun created at trigger time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trigger_creates_pending_job_run(client, session_maker):
+    """Trigger must persist a PENDING JobRun before dispatching the Celery task."""
+    from dev_health_ops.models.settings import JobRun, JobRunStatus
+
+    ac, _ = client
+
+    create_resp = await _create_sync_config(
+        ac, name="pending-run-test", provider="github"
+    )
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+
+    mock_task = MagicMock(id="pending-task-id")
+    mock_run = MagicMock()
+    mock_run.delay.return_value = mock_task
+
+    with patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 202
+    data = resp.json()
+    assert data["status"] == "triggered"
+    assert "run_id" in data
+    run_id = data["run_id"]
+
+    # Verify a PENDING JobRun row was persisted.
+    async with session_maker() as session:
+        result = await session.execute(
+            select(JobRun).where(JobRun.id == uuid.UUID(run_id))
+        )
+        run = result.scalar_one_or_none()
+
+    assert run is not None
+    assert run.status == JobRunStatus.PENDING.value
+    assert run.triggered_by == "manual"
+
+
+@pytest.mark.asyncio
+async def test_trigger_passes_pending_run_id_to_task(client):
+    """Trigger must pass pending_run_id kwarg to the dispatched Celery task."""
+    ac, _ = client
+
+    create_resp = await _create_sync_config(
+        ac, name="run-id-thread-test", provider="github"
+    )
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+
+    mock_task = MagicMock(id="threaded-task-id")
+    mock_run = MagicMock()
+    mock_run.delay.return_value = mock_task
+
+    with patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 202
+    run_id = resp.json()["run_id"]
+
+    # The task must have been called with pending_run_id matching the returned run_id.
+    call_kwargs = mock_run.delay.call_args.kwargs
+    assert call_kwargs.get("pending_run_id") == run_id
+
+
+@pytest.mark.asyncio
+async def test_trigger_batch_creates_pending_job_run(client, session_maker):
+    """Batch-eligible trigger must also persist a PENDING JobRun."""
+    from dev_health_ops.models.settings import JobRun, JobRunStatus
+
+    ac, _ = client
+
+    create_resp = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": "batch-pending-run",
+            "provider": "github",
+            "sync_targets": ["git"],
+            "sync_options": {"search": "full-chaos"},
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = create_resp.json()["id"]
+
+    mock_task = MagicMock(id="batch-pending-task-id")
+    mock_batch = MagicMock()
+    mock_batch.delay.return_value = mock_task
+    mock_run = MagicMock()
+
+    with (
+        patch("dev_health_ops.workers.sync_tasks.dispatch_batch_sync", mock_batch),
+        patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run),
+    ):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 202
+    data = resp.json()
+    assert "run_id" in data
+    run_id = data["run_id"]
+
+    # Verify a PENDING JobRun row was persisted for the batch parent.
+    async with session_maker() as session:
+        result = await session.execute(
+            select(JobRun).where(JobRun.id == uuid.UUID(run_id))
+        )
+        run = result.scalar_one_or_none()
+
+    assert run is not None
+    assert run.status == JobRunStatus.PENDING.value
+
+    # Batch task must have been called with pending_run_id.
+    call_kwargs = mock_batch.delay.call_args.kwargs
+    assert call_kwargs.get("pending_run_id") == run_id
+    mock_run.delay.assert_not_called()


### PR DESCRIPTION
## Summary

Clicking 'Sync Now' previously dispatched a Celery task without creating any `JobRun` row, so the UI showed nothing until the worker picked up the task and created its own row (already flipped to RUNNING). For batch-eligible configs, no parent `JobRun` was created at all.

## Root Cause

`trigger_sync_config` called `run_sync_config.delay()` / `dispatch_batch_sync.delay()` without persisting a `JobRun`. The worker created `JobRun(PENDING)` then immediately set it to `RUNNING`, so the PENDING state was never visible.

## Fix

- **`api/admin/routers/sync.py` — `trigger_sync_config`**: Creates a `JobRun(status=PENDING)` synchronously (ensuring `ScheduledJob` exists first), then passes `pending_run_id` to the dispatched task. Returns `run_id` in the 202 response.
- **`workers/sync_runtime.py` — `run_sync_config`**: Accepts optional `pending_run_id`; if provided, reuses the existing PENDING row instead of creating a new one (PENDING → RUNNING → SUCCESS/FAILED). Back-compat preserved (param defaults to `None`).
- **`workers/sync_batch.py` — `dispatch_batch_sync`**: Accepts `pending_run_id` and threads it to the chord callback. Fallback single-dispatch path also threads it.
- **`workers/sync_batch.py` — `_batch_sync_callback`**: Accepts `run_id` and calls `_mark_batch_run_complete` to set terminal SUCCESS status on the parent `JobRun`.
- **`_mark_batch_run_complete`**: New helper that updates the parent batch `JobRun` to SUCCESS after all children complete.

No duplicate `JobRun` rows — the worker updates the existing row.

## Tests

Three new tests in `tests/api/admin/test_sync_configs.py`:
- `test_trigger_creates_pending_job_run` — trigger persists a PENDING row and returns `run_id`
- `test_trigger_passes_pending_run_id_to_task` — `pending_run_id` kwarg is threaded to the task
- `test_trigger_batch_creates_pending_job_run` — batch-eligible trigger also creates a PENDING parent row

All 26 tests pass. Ruff + mypy clean.

SCREENSHOT-WAIVER: backend-only change, no rendered UI output affected.

Closes CHAOS-2255