### PR TITLE
fix(teams): propagate confirmed members to analytics + Linear member discovery (CHAOS-2264)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/identities.py
+++ b/src/dev_health_ops/api/admin/routers/identities.py
@@ -80,7 +80,7 @@ async def create_or_update_identity(
 )
 async def discover_team_members(
     team_id: str,
-    provider: str = Query(..., pattern="^(github|gitlab|jira)$"),
+    provider: str = Query(..., pattern="^(github|gitlab|jira|linear)$"),
     credential_id: str | None = Query(None),
     credential_name: str | None = Query(None),
     session: AsyncSession = Depends(get_session),
@@ -138,6 +138,17 @@ async def discover_team_members(
             token=token,
             group_path=group_path,
             url=url,
+        )
+    elif provider == "linear":
+        api_key = decrypted.get("apiKey") or decrypted.get("api_key")
+        if not api_key:
+            raise HTTPException(
+                status_code=400,
+                detail="Linear credentials require apiKey",
+            )
+        members = await membership_svc.discover_members_linear(
+            api_key=api_key,
+            team_key=provider_team_id,
         )
     else:
         email = decrypted.get("email")

--- a/src/dev_health_ops/api/services/configuration/team_membership.py
+++ b/src/dev_health_ops/api/services/configuration/team_membership.py
@@ -95,6 +95,52 @@ class TeamMembershipService:
 
         return await asyncio.to_thread(_discover)
 
+    async def discover_members_linear(
+        self,
+        api_key: str,
+        team_key: str,
+    ) -> list[DiscoveredMember]:
+        """Discover members of a Linear team by its key (e.g. "ENG").
+
+        Linear assignees normalize to emails, so the member email doubles as
+        the provider identity (falling back to the user id when absent).
+        """
+
+        def _discover() -> list[DiscoveredMember]:
+            from dev_health_ops.providers.linear.client import LinearAuth, LinearClient
+
+            DiscoveredMember = _get_discovered_member_cls()
+            normalized_key = team_key.removeprefix("linear:")
+            with LinearClient(auth=LinearAuth(api_key=api_key)) as client:
+                for team in client.iter_teams():
+                    if team.get("key") != normalized_key:
+                        continue
+                    members_page = team.get("members") or {}
+                    nodes = list(members_page.get("nodes") or [])
+                    if (members_page.get("pageInfo") or {}).get("hasNextPage"):
+                        nodes = client.get_team_members(str(team.get("id") or ""))
+                    members: list[Any] = []
+                    for node in nodes:
+                        if node.get("active") is False:
+                            continue
+                        member_email = node.get("email")
+                        provider_identity = member_email or node.get("id")
+                        if not provider_identity:
+                            continue
+                        members.append(
+                            DiscoveredMember(
+                                provider_type="linear",
+                                provider_identity=str(provider_identity),
+                                display_name=node.get("name"),
+                                email=member_email,
+                                role=None,
+                            )
+                        )
+                    return members
+            return []
+
+        return await asyncio.to_thread(_discover)
+
     async def discover_members_jira(
         self,
         email: str,

--- a/src/dev_health_ops/providers/team_bridge.py
+++ b/src/dev_health_ops/providers/team_bridge.py
@@ -9,8 +9,45 @@ from typing import Any
 from sqlalchemy import select
 
 from dev_health_ops.db import get_postgres_session_sync
-from dev_health_ops.models.settings import TeamMapping
+from dev_health_ops.models.settings import IdentityMapping, TeamMapping
 from dev_health_ops.storage.clickhouse import ClickHouseStore
+
+
+def _members_by_team(identity_mappings: Any) -> dict[str, set[str]]:
+    """Collect member identities per team from confirmed identity mappings.
+
+    The membership-based ``TeamResolver`` matches work-item assignees
+    (emails, provider logins/account ids) against ``teams.members`` in
+    ClickHouse, so every confirmed identity facet is included: email,
+    canonical_id, and all provider identities. ``display_name`` is used
+    only when no email exists (mirrors the worker ``sync_teams`` path and
+    avoids false-positive matches on common names).
+    """
+    members: dict[str, set[str]] = {}
+    for ident in identity_mappings:
+        identities: set[str] = set()
+        email = getattr(ident, "email", None)
+        if email:
+            identities.add(str(email))
+        canonical_id = getattr(ident, "canonical_id", None)
+        if canonical_id:
+            identities.add(str(canonical_id))
+        for values in (getattr(ident, "provider_identities", None) or {}).values():
+            if isinstance(values, list):
+                identities.update(str(v) for v in values if v)
+            elif values:
+                identities.add(str(values))
+        if not email:
+            display_name = getattr(ident, "display_name", None)
+            if display_name:
+                identities.add(str(display_name))
+        if not identities:
+            continue
+        for team_id in getattr(ident, "team_ids", None) or []:
+            key = str(team_id).strip()
+            if key:
+                members.setdefault(key, set()).update(identities)
+    return members
 
 
 def _parse_json_array(value: Any) -> list[str]:
@@ -57,6 +94,18 @@ def bridge_teams_to_clickhouse(org_id: str | None = None) -> int:
             .all()
         )
 
+        identity_mappings = (
+            session.execute(
+                select(IdentityMapping).where(
+                    IdentityMapping.org_id == org_id,
+                    IdentityMapping.is_active.is_(True),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        members_by_team = _members_by_team(identity_mappings)
+
         for mapping in mappings:
             team_id = str(mapping.team_id or "").strip()
             if not team_id:
@@ -71,7 +120,7 @@ def bridge_teams_to_clickhouse(org_id: str | None = None) -> int:
                     "description": mapping.description,
                     "project_keys": _parse_json_array(mapping.project_keys),
                     "repo_patterns": _parse_json_array(mapping.repo_patterns),
-                    "members": [],
+                    "members": sorted(members_by_team.get(team_id, ())),
                     "is_active": 1,
                     "org_id": org_id,
                     "updated_at": mapping.updated_at,

--- a/tests/test_team_members_bridge.py
+++ b/tests/test_team_members_bridge.py
@@ -1,0 +1,189 @@
+"""Tests for team member propagation (CHAOS-2264).
+
+Covers:
+- ``_members_by_team`` — confirmed identity mappings → ClickHouse ``teams.members``
+  (previously the analytics bridge hardcoded ``members: []``, discarding
+  confirmed memberships and breaking the membership-based attribution fallback
+  for UI-imported teams)
+- ``TeamMembershipService.discover_members_linear`` — Linear team member
+  discovery for the existing discover→confirm flow
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from dev_health_ops.providers.team_bridge import _members_by_team
+
+# ---------------------------------------------------------------------------
+# _members_by_team
+# ---------------------------------------------------------------------------
+
+
+def _identity(**kwargs: Any) -> SimpleNamespace:
+    defaults: dict[str, Any] = {
+        "canonical_id": None,
+        "display_name": None,
+        "email": None,
+        "provider_identities": {},
+        "team_ids": [],
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+class TestMembersByTeam:
+    def test_collects_all_identity_facets_per_team(self) -> None:
+        mappings = [
+            _identity(
+                canonical_id="alice@example.com",
+                email="alice@example.com",
+                provider_identities={"github": ["alice-gh"], "linear": ["alice-lin"]},
+                team_ids=["CHAOS"],
+            )
+        ]
+        result = _members_by_team(mappings)
+        assert result == {
+            "CHAOS": {"alice@example.com", "alice-gh", "alice-lin"},
+        }
+
+    def test_identity_in_multiple_teams(self) -> None:
+        mappings = [
+            _identity(email="bob@example.com", team_ids=["CHAOS", "gh:platform"])
+        ]
+        result = _members_by_team(mappings)
+        assert result["CHAOS"] == {"bob@example.com"}
+        assert result["gh:platform"] == {"bob@example.com"}
+
+    def test_display_name_only_used_without_email(self) -> None:
+        with_email = _identity(
+            email="carol@example.com", display_name="Carol", team_ids=["t1"]
+        )
+        without_email = _identity(display_name="Dave", team_ids=["t1"])
+        result = _members_by_team([with_email, without_email])
+        assert "Carol" not in result["t1"]
+        assert "Dave" in result["t1"]
+        assert "carol@example.com" in result["t1"]
+
+    def test_no_team_ids_or_no_identities_skipped(self) -> None:
+        mappings = [
+            _identity(email="erin@example.com", team_ids=[]),
+            _identity(team_ids=["t1"]),
+        ]
+        assert _members_by_team(mappings) == {}
+
+
+# ---------------------------------------------------------------------------
+# discover_members_linear
+# ---------------------------------------------------------------------------
+
+
+def _linear_team(
+    *,
+    key: str = "ENG",
+    members: list[dict[str, Any]] | None = None,
+    has_next_page: bool = False,
+) -> dict[str, Any]:
+    return {
+        "id": f"team-{key.lower()}",
+        "key": key,
+        "name": key.title(),
+        "members": {
+            "nodes": members or [],
+            "pageInfo": {"hasNextPage": has_next_page},
+        },
+    }
+
+
+class TestDiscoverMembersLinear:
+    @patch("dev_health_ops.providers.linear.client.LinearClient")
+    def test_happy_path_filters_inactive_and_uses_email(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        from dev_health_ops.api.services.configuration import TeamMembershipService
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.__enter__.return_value = mock_client
+        mock_client.iter_teams.return_value = [
+            _linear_team(
+                key="ENG",
+                members=[
+                    {
+                        "id": "u1",
+                        "name": "Alice",
+                        "email": "alice@x.io",
+                        "active": True,
+                    },
+                    {"id": "u2", "name": "Bob", "email": None, "active": True},
+                    {"id": "u3", "name": "Gone", "email": "gone@x.io", "active": False},
+                ],
+            ),
+        ]
+
+        service = TeamMembershipService.__new__(TeamMembershipService)
+        members = asyncio.run(
+            service.discover_members_linear(api_key="k", team_key="ENG")
+        )
+
+        assert [m.provider_identity for m in members] == ["alice@x.io", "u2"]
+        assert members[0].provider_type == "linear"
+        assert members[0].email == "alice@x.io"
+        assert members[1].display_name == "Bob"
+
+    @patch("dev_health_ops.providers.linear.client.LinearClient")
+    def test_paginates_when_first_page_incomplete(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        from dev_health_ops.api.services.configuration import TeamMembershipService
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.__enter__.return_value = mock_client
+        mock_client.iter_teams.return_value = [
+            _linear_team(key="ENG", members=[], has_next_page=True),
+        ]
+        mock_client.get_team_members.return_value = [
+            {"id": "u9", "name": "Zoe", "email": "zoe@x.io", "active": True},
+        ]
+
+        service = TeamMembershipService.__new__(TeamMembershipService)
+        members = asyncio.run(
+            service.discover_members_linear(api_key="k", team_key="ENG")
+        )
+
+        mock_client.get_team_members.assert_called_once_with("team-eng")
+        assert [m.provider_identity for m in members] == ["zoe@x.io"]
+
+    @patch("dev_health_ops.providers.linear.client.LinearClient")
+    def test_strips_linear_prefix_and_unknown_team_returns_empty(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        from dev_health_ops.api.services.configuration import TeamMembershipService
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.__enter__.return_value = mock_client
+        mock_client.iter_teams.return_value = [
+            _linear_team(
+                key="ENG",
+                members=[
+                    {"id": "u1", "name": "Alice", "email": "alice@x.io", "active": True}
+                ],
+            ),
+        ]
+
+        service = TeamMembershipService.__new__(TeamMembershipService)
+
+        prefixed = asyncio.run(
+            service.discover_members_linear(api_key="k", team_key="linear:ENG")
+        )
+        assert [m.provider_identity for m in prefixed] == ["alice@x.io"]
+
+        missing = asyncio.run(
+            service.discover_members_linear(api_key="k", team_key="NOPE")
+        )
+        assert missing == []


### PR DESCRIPTION
Fixes CHAOS-2264

## Problem

Team attribution is teams-first: project-key resolver → **membership-based TeamResolver** → unassigned. But the membership fallback never worked for UI-managed teams because the analytics bridge (`sync_teams_to_analytics` → `bridge_teams_to_clickhouse`) hardcoded `members: []` — even though the confirm-members endpoint dispatches that very sync after confirming. Confirmed memberships were being thrown away on the way to ClickHouse.

Additionally, the discover-members endpoint only supported `github|gitlab|jira`, so Linear teams (CHAOS-2262) had no member-discovery path in the API at all.

## Fix

1. **Bridge** (`providers/team_bridge.py`): derive `teams.members` from active Postgres `identity_mappings` — email, canonical_id, and all provider identities per team (`display_name` only when no email exists, mirroring the worker `sync_teams` path and avoiding false-positive name matches). Provider-agnostic: fixes the existing confirm flow for GitHub/GitLab/Jira teams too.
2. **Linear member discovery**: new `TeamMembershipService.discover_members_linear` (uses `iter_teams`' embedded member page, paginating via `get_team_members` for >100-member teams; filters inactive; member email doubles as provider identity since Linear assignees normalize to emails) + `linear` branch on `GET /teams/{id}/discover-members` with the same credential fallback as CHAOS-2257.

End-to-end flow now: import teams → discover members (incl. Linear) → confirm → members land in ClickHouse → assignee-based attribution works.

Note: the web UI doesn't call discover-members yet — this is backend capability the UI can adopt; the bridge fix benefits any flow that writes identity mappings.

## Tests/Gates

New `tests/test_team_members_bridge.py`: 4 `_members_by_team` tests (facet collection, multi-team, display-name guard, skip-empty) + 3 `discover_members_linear` tests (inactive filter + email identity, pagination, prefix-strip/unknown team). 23 tests pass across touched suites; full mypy clean (1006 files); ruff clean.