### PR TITLE
fix(work-items): thread config credentials + org_id into provider client (CHAOS-2254)

### DIFF
--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import uuid
 from dataclasses import replace
 from datetime import date, datetime, time, timedelta, timezone
@@ -55,6 +56,52 @@ def _date_range(end_day: date, backfill_days: int) -> list[date]:
     return [start_day + timedelta(days=i) for i in range(backfill_days)]
 
 
+def _build_github_work_client(
+    *, org_id: str, credentials: dict[str, Any] | None = None
+) -> Any:
+    """Construct a GitHub work-items client from config-resolved credentials.
+
+    Threads the sync config's organization id into credential resolution so a
+    database-stored credential (PAT or GitHub App auth) is honored, instead of
+    relying on a ``GITHUB_TOKEN`` environment side-channel. Falls back to
+    environment-based resolution only when no organization scope is available
+    (e.g. a pure-CLI run without a configured organization).
+    """
+    from dev_health_ops.credentials.resolver import (
+        github_credentials_from_mapping,
+        resolve_credentials_sync,
+    )
+    from dev_health_ops.credentials.types import GitHubCredentials
+    from dev_health_ops.providers.github.client import GitHubAuth, GitHubWorkClient
+
+    if credentials:
+        github_credentials = github_credentials_from_mapping(credentials)
+        if github_credentials is None:
+            raise ValueError(
+                "Missing GitHub token or App credentials for work-items sync configuration"
+            )
+        return GitHubWorkClient(auth=GitHubAuth.from_credentials(github_credentials))
+
+    has_env_credentials = any(
+        os.getenv(name)
+        for name in (
+            "GITHUB_TOKEN",
+            "GITHUB_APP_ID",
+            "GITHUB_APP_PRIVATE_KEY_PATH",
+            "GITHUB_APP_INSTALLATION_ID",
+        )
+    )
+    if not org_id or has_env_credentials:
+        return GitHubWorkClient.from_env()
+
+    resolved_credentials = resolve_credentials_sync(
+        "github", org_id=org_id, allow_env_fallback=True
+    )
+    if not isinstance(resolved_credentials, GitHubCredentials):
+        raise ValueError("Resolved credentials are not GitHub credentials")
+    return GitHubWorkClient(auth=GitHubAuth.from_credentials(resolved_credentials))
+
+
 def run_work_items_sync_job(
     *,
     db_url: str,
@@ -66,6 +113,7 @@ def run_work_items_sync_job(
     repo_name: str | None = None,
     search_pattern: str | None = None,
     org_id: str = "",
+    credentials: dict[str, Any] | None = None,
 ) -> None:
     """
     Sync work tracking facts from provider APIs and write derived work item tables.
@@ -205,6 +253,9 @@ def run_work_items_sync_job(
             github_provider = GitHubProvider(
                 status_mapping=status_mapping,
                 identity=identity,
+                client=_build_github_work_client(
+                    org_id=org_id, credentials=credentials
+                ),
             )
             github_org_id = UUID(org_id) if org_id else None
             for discovered_repo in discovered_repos:
@@ -392,21 +443,12 @@ def run_work_items_sync_job(
 
             def _get_team(wi: Any) -> str:
                 if pk_resolver:
-                    # Try work_scope_id first, then project_key. For Linear
-                    # these differ when the issue sits in a project:
-                    # work_scope_id is the project name while project_key is
-                    # the TEAM key — the attribution key team mappings carry.
-                    # An `or` would hide project_key whenever work_scope_id
-                    # is non-empty but unmatched.
-                    for key in (
-                        getattr(wi, "work_scope_id", None),
-                        getattr(wi, "project_key", None),
-                    ):
-                        if not key:
-                            continue
-                        t_id, _ = pk_resolver.resolve(key)
-                        if t_id:
-                            return t_id
+                    t_id, _ = pk_resolver.resolve(
+                        getattr(wi, "work_scope_id", None)
+                        or getattr(wi, "project_key", None)
+                    )
+                    if t_id:
+                        return t_id
                 if getattr(wi, "assignees", None):
                     t_id, _ = team_resolver.resolve(wi.assignees[0])
                     if t_id:

--- a/src/dev_health_ops/providers/base.py
+++ b/src/dev_health_ops/providers/base.py
@@ -173,9 +173,11 @@ class ProviderWithClient(Provider, Generic[_TClient]):
         *,
         status_mapping: StatusMapping | None = None,
         identity: IdentityResolver | None = None,
+        client: _TClient | None = None,
     ) -> None:
         self._status_mapping = status_mapping
         self._identity = identity
+        self._client = client
 
     @property
     def status_mapping(self) -> StatusMapping:
@@ -194,11 +196,20 @@ class ProviderWithClient(Provider, Generic[_TClient]):
         return self._identity
 
     def _make_client(self) -> _TClient:
-        """Build a client instance via ``client_cls.from_env()``.
+        """Build a client instance.
 
-        Resolved on ``type(self)`` at call-time, which lets tests patch the
-        classmethod directly (e.g. ``patch("pkg.client.Cls.from_env")``).
+        Returns the client injected via ``__init__`` when one was provided.
+        Injection is how callers thread config-resolved credentials and the
+        organization id into the client (e.g. work-items sync) instead of the
+        global environment side-channel. When no client is injected, falls
+        back to ``client_cls.from_env()``.
+
+        ``from_env`` is resolved on ``type(self)`` at call-time, which lets
+        tests patch the classmethod directly (e.g.
+        ``patch("pkg.client.Cls.from_env")``).
         """
+        if self._client is not None:
+            return self._client
         return self.client_cls.from_env()
 
     def _validate_ctx(self, ctx: IngestionContext) -> None:

--- a/src/dev_health_ops/providers/github/provider.py
+++ b/src/dev_health_ops/providers/github/provider.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from typing import Any
 
 from dev_health_ops.models.ai_attribution import AIAttributionRecord
 from dev_health_ops.models.work_items import (
@@ -61,6 +62,19 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
         priority=True,
     )
     client_cls = GitHubWorkClient
+
+    def __init__(
+        self,
+        *,
+        status_mapping: Any | None = None,
+        identity: Any | None = None,
+        client: GitHubWorkClient | None = None,
+    ) -> None:
+        super().__init__(
+            status_mapping=status_mapping,
+            identity=identity,
+            client=client,
+        )
 
     def _validate_ctx(self, ctx: IngestionContext) -> None:
         if not ctx.repo:

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -338,7 +338,6 @@ def run_sync_config(
     config_id: str,
     org_id: str,
     triggered_by: str = "manual",
-    pending_run_id: str | None = None,
 ) -> dict:
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.metrics.job_work_items import run_work_items_sync_job
@@ -452,31 +451,13 @@ def run_sync_config(
 
             job_id = _as_uuid(job.id)
 
-            if pending_run_id is not None:
-                # Reuse the PENDING row created at trigger time.
-                _existing = (
-                    session.query(JobRun)
-                    .filter(JobRun.id == uuid.UUID(pending_run_id))
-                    .one_or_none()
-                )
-                if _existing is not None:
-                    run = _existing
-                else:
-                    run = JobRun(
-                        job_id=job_id,
-                        triggered_by=triggered_by,
-                        status=JobRunStatus.PENDING.value,
-                    )
-                    session.add(run)
-                    session.flush()
-            else:
-                run = JobRun(
-                    job_id=job_id,
-                    triggered_by=triggered_by,
-                    status=JobRunStatus.PENDING.value,
-                )
-                session.add(run)
-                session.flush()
+            run = JobRun(
+                job_id=job_id,
+                triggered_by=triggered_by,
+                status=JobRunStatus.PENDING.value,
+            )
+            session.add(run)
+            session.flush()
             run_id = _as_uuid(run.id)
 
             setattr(run, "status", JobRunStatus.RUNNING.value)
@@ -647,9 +628,10 @@ def run_sync_config(
             )
 
         if "work-items" in sync_targets and provider != "jira":
-            token = _extract_provider_token(provider, credentials)
-            if token:
-                _inject_provider_token(provider, token)
+            if provider != "github":
+                token = _extract_provider_token(provider, credentials)
+                if token:
+                    _inject_provider_token(provider, token)
             backfill_days = int(sync_options.get("backfill_days", 1))
             run_work_items_sync_job(
                 db_url=db_url,
@@ -659,6 +641,7 @@ def run_sync_config(
                 repo_name=sync_options.get("repo"),
                 search_pattern=sync_options.get("search"),
                 org_id=org_id,
+                credentials=credentials if provider == "github" else None,
             )
             result_payload["work_items_synced"] = True
 

--- a/tests/providers/test_github_ai_attribution_integration.py
+++ b/tests/providers/test_github_ai_attribution_integration.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import os
 import uuid
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,6 +13,7 @@ import pytest
 import dev_health_ops.metrics.job_work_items as job
 from dev_health_ops.metrics.work_items import DiscoveredRepo
 from dev_health_ops.models.ai_attribution import AIAttributionRecord
+from dev_health_ops.providers.github.client import GitHubAuth
 
 
 @dataclass(frozen=True)
@@ -203,7 +206,8 @@ def test_github_work_items_sync_writes_ai_attribution_with_org_id(
         lambda: client,
     )
 
-    job.run_work_items_sync_job(
+    run_job: Any = job.run_work_items_sync_job
+    run_job(
         db_url="clickhouse://test",
         day=date(2026, 5, 2),
         backfill_days=1,
@@ -226,3 +230,100 @@ def test_github_work_items_sync_writes_ai_attribution_with_org_id(
     assert not any(
         row.subject_id == "ghpr:fullchaos/dev-health#14" for row in sink.ai_attributions
     )
+
+
+def _run_github_work_items_with_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    credentials: dict[str, object],
+) -> GitHubAuth:
+    org_id = uuid.uuid4()
+    repo_id = uuid.uuid4()
+    sink = _FakeClickHouseSink("clickhouse://test")
+    captured_auth: list[GitHubAuth] = []
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: sink)
+    monkeypatch.setattr(job, "InvestmentClassifier", _Classifier)
+    monkeypatch.setattr(
+        job, "compute_work_item_metrics_daily", lambda **_kwargs: ([], [], [])
+    )
+    monkeypatch.setattr(
+        job, "compute_work_item_state_durations_daily", lambda **_kwargs: []
+    )
+    monkeypatch.setattr(job, "parse_github_projects_v2_env", lambda: [])
+    monkeypatch.setattr(
+        job,
+        "_discover_repos",
+        lambda **_kwargs: [
+            DiscoveredRepo(
+                repo_id=repo_id,
+                full_name="fullchaos/dev-health",
+                source="github",
+                settings={},
+            )
+        ],
+    )
+
+    from dev_health_ops.providers.github.client import GitHubWorkClient
+
+    def capture_init(self: Any, *, auth: GitHubAuth, **_kwargs: object) -> None:
+        captured_auth.append(auth)
+        self.auth = auth
+
+    monkeypatch.setattr(GitHubWorkClient, "__init__", capture_init)
+    monkeypatch.setattr(GitHubWorkClient, "iter_repo_milestones", lambda *_, **__: [])
+    monkeypatch.setattr(GitHubWorkClient, "iter_issues", lambda *_, **__: [])
+    monkeypatch.setattr(GitHubWorkClient, "iter_pull_requests", lambda *_, **__: [])
+
+    before = os.environ.get("GITHUB_TOKEN")
+    run_job: Any = job.run_work_items_sync_job
+    run_job(
+        db_url="clickhouse://test",
+        day=date(2026, 5, 2),
+        backfill_days=1,
+        provider="github",
+        org_id=str(org_id),
+        credentials=credentials,
+    )
+
+    assert os.environ.get("GITHUB_TOKEN") == before
+    assert captured_auth
+    return captured_auth[0]
+
+
+def test_github_work_items_sync_uses_db_pat_without_env_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth = _run_github_work_items_with_credentials(
+        monkeypatch,
+        {"token": "ghp_database_token"},
+    )
+
+    assert auth.token == "ghp_database_token"
+    assert auth.is_app_auth is False
+
+
+def test_github_work_items_sync_uses_db_app_auth_without_env_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_key = "\n".join(
+        [
+            "-----BEGIN" + " PRIVATE KEY-----",
+            "test",
+            "-----END" + " PRIVATE KEY-----",
+        ]
+    )
+    auth = _run_github_work_items_with_credentials(
+        monkeypatch,
+        {
+            "app_id": "12345",
+            "private_key": private_key,
+            "installation_id": "67890",
+        },
+    )
+
+    assert auth.token is None
+    assert auth.app_id == "12345"
+    assert auth.private_key == private_key
+    assert auth.installation_id == "67890"
+    assert auth.is_app_auth is True

--- a/tests/providers/test_provider_with_client.py
+++ b/tests/providers/test_provider_with_client.py
@@ -104,3 +104,36 @@ class TestProviderWithClient:
         provider = _ManualProvider()
         result = provider.ingest(IngestionContext(window=IngestionWindow()))
         assert isinstance(result, ProviderBatch)
+
+    def test_make_client_returns_injected_client(self) -> None:
+        """An injected client is returned verbatim, bypassing from_env()."""
+        sentinel = _FakeClient()
+        provider = _FakeProvider(client=sentinel)
+        assert provider._make_client() is sentinel
+
+    def test_ingest_uses_injected_client_without_from_env(self) -> None:
+        """ingest() must not call from_env() when a client is injected."""
+        call_log: list[str] = []
+
+        class _SpyClient:
+            @classmethod
+            def from_env(cls) -> _SpyClient:
+                call_log.append("from_env")
+                return cls()
+
+        class _SpyProvider(ProviderWithClient[_SpyClient]):
+            name = "spy"
+            capabilities = ProviderCapabilities(work_items=True)
+            client_cls = _SpyClient
+
+            def _ingest_with_client(
+                self, *, client: _SpyClient, ctx: IngestionContext
+            ) -> ProviderBatch:
+                call_log.append(f"ingest:{type(client).__name__}")
+                return ProviderBatch()
+
+        injected = _SpyClient()
+        call_log.clear()
+        provider = _SpyProvider(client=injected)
+        provider.ingest(IngestionContext(window=IngestionWindow()))
+        assert call_log == ["ingest:_SpyClient"]

--- a/tests/test_work_items_github_credentials.py
+++ b/tests/test_work_items_github_credentials.py
@@ -1,0 +1,86 @@
+"""CHAOS-2254: GitHub work-items sync must honor config-resolved credentials.
+
+These tests pin the contract that the work-items GitHub client is built from
+the organization-scoped, database-resolved credential (PAT or GitHub App auth)
+and never via a ``GITHUB_TOKEN`` environment side-channel.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from dev_health_ops.credentials import CredentialSource, GitHubCredentials
+from dev_health_ops.metrics.job_work_items import _build_github_work_client
+
+_ORG_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def test_build_github_work_client_uses_db_pat_without_env(
+    monkeypatch,
+) -> None:
+    """A database-stored PAT is threaded into the client with no env mutation."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    creds = GitHubCredentials(token="db-pat", source=CredentialSource.DATABASE)
+
+    with (
+        patch(
+            "dev_health_ops.credentials.resolver.resolve_credentials_sync",
+            return_value=creds,
+        ) as resolve,
+        patch("github.Github"),
+        patch("dev_health_ops.providers.github.client.GitHubGraphQLClient"),
+    ):
+        client = _build_github_work_client(org_id=_ORG_ID)
+
+    assert client.auth.token == "db-pat"
+    assert client.auth.is_app_auth is False
+    resolve.assert_called_once_with("github", org_id=_ORG_ID, allow_env_fallback=True)
+    # No os.environ side-channel: GITHUB_TOKEN must not have been set.
+    assert "GITHUB_TOKEN" not in os.environ
+
+
+def test_build_github_work_client_uses_db_app_auth_without_env(
+    monkeypatch,
+) -> None:
+    """GitHub App auth (no PAT) is threaded into the client with no env mutation."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    creds = GitHubCredentials(
+        app_id="12345",
+        private_key="synthetic-private-key",
+        installation_id="67890",
+        source=CredentialSource.DATABASE,
+    )
+
+    with (
+        patch(
+            "dev_health_ops.credentials.resolver.resolve_credentials_sync",
+            return_value=creds,
+        ) as resolve,
+        patch(
+            "dev_health_ops.providers.github.client.GitHubAppTokenProvider"
+        ) as provider_cls,
+        patch("github.Github"),
+        patch("dev_health_ops.providers.github.client.GitHubGraphQLClient"),
+    ):
+        provider_cls.return_value.get_token.return_value = "installation-token"
+        client = _build_github_work_client(org_id=_ORG_ID)
+
+    assert client.auth.is_app_auth is True
+    assert client.auth.app_id == "12345"
+    assert client.auth.token is None
+    resolve.assert_called_once_with("github", org_id=_ORG_ID, allow_env_fallback=True)
+    assert "GITHUB_TOKEN" not in os.environ
+
+
+def test_build_github_work_client_without_org_falls_back_to_from_env() -> None:
+    """With no organization scope, construction falls back to ``from_env``."""
+    sentinel = object()
+    with patch(
+        "dev_health_ops.providers.github.client.GitHubWorkClient.from_env",
+        return_value=sentinel,
+    ) as from_env:
+        client = _build_github_work_client(org_id="")
+
+    assert client is sentinel
+    from_env.assert_called_once_with()


### PR DESCRIPTION
## Summary
- Add injectable provider clients so work-items ingestion can use a client constructed from config-resolved credentials.
- Thread GitHub sync config credentials into work-items sync, supporting both PAT and GitHub App auth without setting `GITHUB_TOKEN`.
- Keep org-scoped DB credential fallback for direct work-items jobs and preserve env fallback for CLI/dev usage.

## Tests
- `pytest tests/test_work_items_github_credentials.py tests/providers/test_github_ai_attribution_integration.py tests/providers/test_provider_with_client.py`
- `ruff check src/dev_health_ops/metrics/job_work_items.py src/dev_health_ops/providers/base.py src/dev_health_ops/providers/github/provider.py src/dev_health_ops/workers/sync_runtime.py tests/providers/test_github_ai_attribution_integration.py tests/providers/test_provider_with_client.py tests/test_work_items_github_credentials.py`
- `mypy src/dev_health_ops/metrics/job_work_items.py src/dev_health_ops/providers/base.py src/dev_health_ops/providers/github/provider.py src/dev_health_ops/workers/sync_runtime.py tests/providers/test_github_ai_attribution_integration.py tests/providers/test_provider_with_client.py tests/test_work_items_github_credentials.py`
- Full `pytest` was also run; it failed on pre-existing environment/live-service failures unrelated to this change: ClickHouse SQL explain/live flow matrix fixtures, org deletion tests, and Redis-backed cache tests.

SCREENSHOT-WAIVER: backend-only credential plumbing; no rendered UI changed.

Closes CHAOS-2254