### PR TITLE
fix(sync): restore pending_run_id kwarg on run_sync_config (clobbered by #846)

### DIFF
--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -346,6 +346,7 @@ def run_sync_config(
     config_id: str,
     org_id: str,
     triggered_by: str = "manual",
+    pending_run_id: str | None = None,
 ) -> dict:
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.metrics.job_work_items import run_work_items_sync_job
@@ -459,13 +460,22 @@ def run_sync_config(
 
             job_id = _as_uuid(job.id)
 
-            run = JobRun(
-                job_id=job_id,
-                triggered_by=triggered_by,
-                status=JobRunStatus.PENDING.value,
-            )
-            session.add(run)
-            session.flush()
+            run: JobRun | None = None
+            if pending_run_id is not None:
+                # Reuse the PENDING row created at trigger time.
+                run = (
+                    session.query(JobRun)
+                    .filter(JobRun.id == uuid.UUID(pending_run_id))
+                    .one_or_none()
+                )
+            if run is None:
+                run = JobRun(
+                    job_id=job_id,
+                    triggered_by=triggered_by,
+                    status=JobRunStatus.PENDING.value,
+                )
+                session.add(run)
+                session.flush()
             run_id = _as_uuid(run.id)
 
             setattr(run, "status", JobRunStatus.RUNNING.value)

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -743,6 +743,25 @@ async def test_trigger_passes_pending_run_id_to_task(client):
     assert call_kwargs.get("pending_run_id") == run_id
 
 
+def test_sync_tasks_accept_pending_run_id_kwarg():
+    """The dispatched Celery tasks must accept every kwarg the trigger endpoint
+    passes. Celery validates kwargs against the task signature at .delay() time,
+    so a missing parameter fails the API request itself (regression: PR #846
+    clobbered the pending_run_id parameter that PR #844 added to run_sync_config).
+    """
+    import inspect
+
+    from dev_health_ops.workers.sync_tasks import (
+        dispatch_batch_sync,
+        run_sync_config,
+    )
+
+    for task in (run_sync_config, dispatch_batch_sync):
+        params = inspect.signature(task.run).parameters
+        for kwarg in ("config_id", "org_id", "triggered_by", "pending_run_id"):
+            assert kwarg in params, f"{task.name} is missing kwarg {kwarg!r}"
+
+
 @pytest.mark.asyncio
 async def test_trigger_batch_creates_pending_job_run(client, session_maker):
     """Batch-eligible trigger must also persist a PENDING JobRun."""


### PR DESCRIPTION
## Problem
Every manual **Sync Now** fails with:
`503 Task queue unavailable: run_sync_config() got an unexpected keyword argument 'pending_run_id'`
and leaves an orphaned PENDING JobRun behind (which the web UI renders as a 12/31/1969 start date — companion FE fix: full-chaos/dev-health-web#672).

## Root cause — squash-merge clobber
- #844 (CHAOS-2255) added `pending_run_id: str | None = None` to `run_sync_config` in `workers/sync_runtime.py`, plus logic to reuse the PENDING JobRun persisted at trigger time.
- #846 was branched **before** #844 merged, also touched `sync_runtime.py`, and its squash merge silently reverted those 3 lines — no conflict surfaced.
- The trigger endpoint still passes `pending_run_id=`, and Celery validates kwargs against the task signature at `.delay()` (producer-side `typing=True`), so the API request itself throws.

## Fix
- Restore the kwarg + reuse-PENDING-row logic (flattened, behavior identical to #844), preserving #843's terminal-error handling and #846's credential threading. Verified by diffing the restored file against #844's version: only those two later changes remain.
- Add `test_sync_tasks_accept_pending_run_id_kwarg` — a signature-contract test over `run_sync_config` and `dispatch_batch_sync`. The existing trigger tests mock `.delay()`, so producer/worker signature drift was invisible to CI; this pins both sides.

## Verification
- `pytest tests/api/admin/test_sync_configs.py`: 27 passed
- `mypy --install-types --non-interactive .` (literal CI command): clean, 1011 files
- ruff check/format: clean
- Note: `tests/test_processors_sync.py` has a pre-existing standalone-collection circular-import error, reproduced identically on clean main (86d7a7cd6) — unrelated.