### PR TITLE
fix(github): PR work-items sync crashes — PullRequest lacks get_events()

### DIFF
--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -107,7 +107,7 @@ class _GitHubMilestoneLike(Protocol):
     state: object
 
 
-class _GitHubIssueLike(Protocol):
+class _GitHubIssueBaseLike(Protocol):
     number: object
     title: object
     body: object
@@ -122,15 +122,21 @@ class _GitHubIssueLike(Protocol):
     url: object
     pull_request: object
 
-    def get_events(self) -> Iterable[_GitHubEventLike]: ...
-
     def get_comments(self) -> Iterable[_GitHubCommentLike]: ...
 
 
-class _GitHubPullRequestLike(_GitHubIssueLike, Protocol):
+class _GitHubIssueLike(_GitHubIssueBaseLike, Protocol):
+    def get_events(self) -> Iterable[_GitHubEventLike]: ...
+
+
+class _GitHubPullRequestLike(_GitHubIssueBaseLike, Protocol):
     merged: object
     merged_at: object
     draft: object
+
+    # PyGithub's PullRequest exposes the issue-events endpoint as
+    # get_issue_events(); only Issue has get_events().
+    def get_issue_events(self) -> Iterable[_GitHubEventLike]: ...
 
     def get_review_comments(self) -> Iterable[_GitHubCommentLike]: ...
 
@@ -295,12 +301,22 @@ class GitHubWorkClient:
         )
 
     def iter_issue_events(
-        self, issue: _GitHubIssueLike, *, limit: int | None = None
+        self,
+        issue: _GitHubIssueLike | _GitHubPullRequestLike,
+        *,
+        limit: int | None = None,
     ) -> Iterable[_GitHubEventLike]:
         """
         Iterate issue events (labeled/unlabeled/closed/reopened/assigned/...) via REST.
+
+        Accepts both Issues and PullRequests: PyGithub's Issue exposes the
+        endpoint as get_events(), PullRequest as get_issue_events().
         """
-        yield from self._iter_with_limit(issue.get_events(), limit=limit)
+        if hasattr(issue, "get_events"):
+            events = issue.get_events()
+        else:
+            events = issue.get_issue_events()
+        yield from self._iter_with_limit(events, limit=limit)
 
     def iter_pull_requests(
         self,
@@ -320,7 +336,7 @@ class GitHubWorkClient:
         yield from self._iter_with_limit(pulls, limit=limit)
 
     def iter_issue_comments(
-        self, issue: _GitHubIssueLike, *, limit: int | None = None
+        self, issue: _GitHubIssueBaseLike, *, limit: int | None = None
     ) -> Iterable[_GitHubCommentLike]:
         """
         Iterate comments on an issue via REST.

--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -126,7 +126,8 @@ class _GitHubIssueBaseLike(Protocol):
 
 
 class _GitHubIssueLike(_GitHubIssueBaseLike, Protocol):
-    def get_events(self) -> Iterable[_GitHubEventLike]: ...
+    def get_events(self) -> Iterable[_GitHubEventLike]:
+        pass
 
 
 class _GitHubPullRequestLike(_GitHubIssueBaseLike, Protocol):
@@ -136,7 +137,8 @@ class _GitHubPullRequestLike(_GitHubIssueBaseLike, Protocol):
 
     # PyGithub's PullRequest exposes the issue-events endpoint as
     # get_issue_events(); only Issue has get_events().
-    def get_issue_events(self) -> Iterable[_GitHubEventLike]: ...
+    def get_issue_events(self) -> Iterable[_GitHubEventLike]:
+        raise NotImplementedError
 
     def get_review_comments(self) -> Iterable[_GitHubCommentLike]: ...
 

--- a/tests/providers/test_github_iter_issue_events.py
+++ b/tests/providers/test_github_iter_issue_events.py
@@ -1,0 +1,70 @@
+"""Test GitHubWorkClient.iter_issue_events against real PyGithub vocabulary.
+
+Regression: PyGithub's PullRequest has no get_events() — only Issue does;
+PullRequest exposes the same endpoint as get_issue_events(). The fakes here
+deliberately mirror that asymmetry (no MagicMock, which would auto-create
+any attribute and hide the bug).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from dev_health_ops.providers.github.client import GitHubAuth, GitHubWorkClient
+
+
+@pytest.fixture
+def client() -> GitHubWorkClient:
+    with (
+        patch("github.Github"),
+        patch("dev_health_ops.providers.github.client.GitHubGraphQLClient"),
+    ):
+        return GitHubWorkClient(auth=GitHubAuth(token="fake"))
+
+
+class _FakeEvent:
+    created_at = None
+    event = "closed"
+    label = None
+    actor = None
+
+
+class _FakeIssue:
+    """Mirrors github.Issue.Issue: has get_events, no get_issue_events."""
+
+    def get_events(self) -> list[_FakeEvent]:
+        return [_FakeEvent(), _FakeEvent()]
+
+
+class _FakePullRequest:
+    """Mirrors github.PullRequest.PullRequest: has get_issue_events ONLY."""
+
+    def get_issue_events(self) -> list[_FakeEvent]:
+        return [_FakeEvent(), _FakeEvent(), _FakeEvent()]
+
+
+class TestIterIssueEvents:
+    def test_issue_uses_get_events(self, client: GitHubWorkClient) -> None:
+        events = list(client.iter_issue_events(_FakeIssue(), limit=None))  # type: ignore[arg-type]
+        assert len(events) == 2
+
+    def test_pull_request_uses_get_issue_events(self, client: GitHubWorkClient) -> None:
+        # Must not raise AttributeError: 'PullRequest' object has no
+        # attribute 'get_events'.
+        events = list(client.iter_issue_events(_FakePullRequest(), limit=None))  # type: ignore[arg-type]
+        assert len(events) == 3
+
+    def test_pull_request_respects_limit(self, client: GitHubWorkClient) -> None:
+        events = list(client.iter_issue_events(_FakePullRequest(), limit=1))  # type: ignore[arg-type]
+        assert len(events) == 1
+
+    def test_pygithub_vocabulary_unchanged(self) -> None:
+        """Pin the upstream contract the dispatch in iter_issue_events relies on."""
+        from github.Issue import Issue
+        from github.PullRequest import PullRequest
+
+        assert hasattr(Issue, "get_events")
+        assert not hasattr(PullRequest, "get_events")
+        assert hasattr(PullRequest, "get_issue_events")


### PR DESCRIPTION
## Problem
Worker logs on every PR-bearing repo during work-items sync:
`GitHub: failed to fetch PRs from full-chaos/container-compose: 'PullRequest' object has no attribute 'get_events'`

## Root cause
`provider.py:272` passes PRs into `client.iter_issue_events()`, which called `issue.get_events()`. PyGithub (v2.9.1, verified) exposes the issue-events endpoint as `Issue.get_events()` but `PullRequest.get_issue_events()` — PRs have no `get_events`. The local `_GitHubPullRequestLike` protocol inherited `get_events()` from `_GitHubIssueLike`, so both mypy and the MagicMock-based tests encoded the wrong contract and CI stayed green (same failure mode as CHAOS-2225: mocks must mirror real vocabulary).

## Fix
- Split protocols: shared `_GitHubIssueBaseLike`; `_GitHubIssueLike` adds `get_events()`; `_GitHubPullRequestLike` declares `get_issue_events()` — matching real PyGithub
- `iter_issue_events` accepts both and dispatches via `hasattr` (protocols aren't runtime-checkable)
- `iter_issue_comments` narrowed to the base protocol (mypy caught `iter_pr_comments` passing PRs into it after the split)
- New regression tests use plain-class fakes (not MagicMock) that mirror real PyGithub vocabulary — a fake PR deliberately lacking `get_events` — plus `test_pygithub_vocabulary_unchanged` pinning the upstream contract against PyGithub upgrades

## Call-site audit
`provider.py:175` and `metrics/work_items.py:345` pass genuine Issues from `iter_issues` (which skips PRs) — unaffected.

## Verification
- 59 tests across 6 GitHub-related files: pass
- `mypy --install-types --non-interactive .`: clean (1009 files)
- ruff check/format: clean