### PR TITLE
fix(licensing): resolve org tier via Organization.tier fallback (CHAOS-2256)

### DIFF
--- a/src/dev_health_ops/api/billing/subscription_service.py
+++ b/src/dev_health_ops/api/billing/subscription_service.py
@@ -418,6 +418,23 @@ class SubscriptionService:
             if customer_id:
                 assign_attr(org_license, "customer_id", customer_id)
 
+        # Keep the denormalized Organization.tier column in lockstep so the
+        # tier-resolution fallback (resolve_org_tier) and any direct readers of
+        # Organization.tier never see a value that diverges from OrgLicense.
+        try:
+            from dev_health_ops.models.users import Organization
+
+            org_result = await self.db.execute(
+                select(Organization).where(Organization.id == org_id)
+            )
+            org = org_result.scalar_one_or_none()
+            if org is not None and str(org.tier) != tier_str:
+                assign_attr(org, "tier", tier_str)
+        except OperationalError as exc:
+            logger.warning(
+                "organizations table unavailable; skipping org tier sync (%s)", exc
+            )
+
         # Static literal labels keyed by tier string to break the taint chain
         # entirely (CodeQL py/clear-text-logging-sensitive-data).
         tier_label = {

--- a/src/dev_health_ops/api/services/licensing.py
+++ b/src/dev_health_ops/api/services/licensing.py
@@ -22,6 +22,7 @@ from dev_health_ops.models.licensing import (
     OrgLicense,
     TierLimit,
 )
+from dev_health_ops.models.users import Organization
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -52,6 +53,44 @@ def _coerce_bool_map(value: object) -> dict[str, bool]:
     if not isinstance(value, dict):
         return {}
     return {str(key): bool(enabled) for key, enabled in value.items()}
+
+
+def resolve_org_tier(
+    session: Session,
+    org_id: uuid.UUID,
+    org_license: OrgLicense | None,
+) -> LicenseTier:
+    """Resolve an organization's license tier from an already-fetched OrgLicense.
+
+    Mirrors ``licensing.gating.get_org_entitlements_from_db`` so tier limits and
+    entitlements always agree (CHAOS-2256): ``OrgLicense.tier`` wins when a row
+    exists; otherwise fall back to the ``Organization.tier`` column (set at org
+    creation / by billing webhooks); default to COMMUNITY.
+    """
+    if org_license is not None:
+        try:
+            return LicenseTier(org_license.tier)
+        except ValueError:
+            logger.warning(
+                "Invalid OrgLicense tier=%s for org_id=%s; defaulting to community",
+                org_license.tier,
+                org_id,
+            )
+            return LicenseTier.COMMUNITY
+
+    org_tier = (
+        session.query(Organization.tier).filter(Organization.id == org_id).scalar()
+    )
+    if org_tier is not None:
+        try:
+            return LicenseTier(org_tier)
+        except ValueError:
+            logger.warning(
+                "Invalid Organization tier=%s for org_id=%s; defaulting to community",
+                org_tier,
+                org_id,
+            )
+    return LicenseTier.COMMUNITY
 
 
 def _get_license_public_key() -> str | None:
@@ -300,9 +339,7 @@ class FeatureService:
                     )
 
         org_license = self._get_org_license(org_id)
-        org_tier = (
-            LicenseTier(org_license.tier) if org_license else LicenseTier.COMMUNITY
-        )
+        org_tier = resolve_org_tier(self.session, org_id, org_license)
 
         if org_license and org_license.features_override:
             features_override = _coerce_bool_map(org_license.features_override)
@@ -383,9 +420,7 @@ class TierLimitService:
     def get_limit(self, org_id: uuid.UUID, limit_key: str) -> int | float | None:
         """Get a specific limit for an organization."""
         org_license = self._get_org_license(org_id)
-        org_tier = (
-            LicenseTier(org_license.tier) if org_license else LicenseTier.COMMUNITY
-        )
+        org_tier = resolve_org_tier(self.session, org_id, org_license)
 
         # 1. Per-org override (highest priority)
         if org_license and org_license.limits_override:
@@ -400,9 +435,7 @@ class TierLimitService:
     def get_all_limits(self, org_id: uuid.UUID) -> dict[str, int | float | None]:
         """Get all limits for an organization."""
         org_license = self._get_org_license(org_id)
-        org_tier = (
-            LicenseTier(org_license.tier) if org_license else LicenseTier.COMMUNITY
-        )
+        org_tier = resolve_org_tier(self.session, org_id, org_license)
 
         limits = self._resolve_tier_limits(org_tier)
 

--- a/src/dev_health_ops/api/services/users.py
+++ b/src/dev_health_ops/api/services/users.py
@@ -338,12 +338,41 @@ class OrganizationService:
             org.settings = settings
         if tier is not None:
             org.tier = tier
+            await self._sync_license_tier(uuid.UUID(org_id), tier)
         if is_active is not None:
             org.is_active = is_active
 
         org.updated_at = datetime.now(timezone.utc)
         await self.session.flush()
         return org
+
+    async def _sync_license_tier(self, org_id: uuid.UUID, tier: str) -> None:
+        """Keep an existing OrgLicense row in lockstep with Organization.tier.
+
+        Tier resolution (``resolve_org_tier`` and the entitlements path) gives
+        OrgLicense precedence when a row exists, so an admin tier change must
+        update a pre-existing license row or the org would keep being enforced
+        at the old tier (CHAOS-2256 review). When no row exists, resolution
+        falls back to Organization.tier — nothing to sync.
+        """
+        from sqlalchemy.exc import OperationalError
+
+        from dev_health_ops.models.licensing import OrgLicense
+
+        try:
+            result = await self.session.execute(
+                select(OrgLicense).where(OrgLicense.org_id == org_id)
+            )
+            org_license = result.scalar_one_or_none()
+        except OperationalError:
+            logger.warning(
+                "org_licenses table unavailable; skipping license tier sync for org %s",
+                org_id,
+            )
+            return
+        if org_license is not None and str(org_license.tier) != tier:
+            org_license.tier = tier
+            org_license.updated_at = datetime.now(timezone.utc)
 
     async def delete(self, org_id: str) -> bool:
         org = await self.get_by_id(org_id)

--- a/tests/api/admin/test_tier_limits.py
+++ b/tests/api/admin/test_tier_limits.py
@@ -22,6 +22,7 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.services.auth import AuthenticatedUser
@@ -33,6 +34,7 @@ from dev_health_ops.models.settings import (
     ScheduledJob,
     SyncConfiguration,
 )
+from dev_health_ops.models.subscriptions import Subscription
 from dev_health_ops.models.users import Organization, User
 from tests._helpers import tables_of
 
@@ -48,6 +50,7 @@ _TABLES = tables_of(
     SyncConfiguration,
     ScheduledJob,
     JobRun,
+    Subscription,
 )
 
 
@@ -74,14 +77,19 @@ async def session_maker(tmp_path: Path):
 
 
 async def _seed_org(
-    session_maker, tier: str, *, with_license: bool = True
+    session_maker,
+    tier: str,
+    *,
+    with_license: bool = True,
+    license_tier: str | None = None,
 ) -> dict[str, str]:
     """Create an org + user (+ optionally an OrgLicense) for a given tier.
 
     ``with_license=False`` models the common SaaS state where the org's tier
     lives only on ``Organization.tier`` (set at creation or by an admin) and
     no OrgLicense row exists yet — e.g. a trial before a Stripe plan resolves
-    (CHAOS-2256).
+    (CHAOS-2256). ``license_tier`` seeds an OrgLicense row whose tier diverges
+    from ``Organization.tier`` (legacy stale-row state).
     """
     org_id = uuid.uuid4()
     user_id = uuid.uuid4()
@@ -91,7 +99,7 @@ async def _seed_org(
     user = User(id=user_id, email=f"{tier}@example.com", is_active=True)
     rows: list[object] = [org, user]
     if with_license:
-        rows.append(OrgLicense(org_id=org_id, tier=tier))
+        rows.append(OrgLicense(org_id=org_id, tier=license_tier or tier))
 
     async with session_maker() as session:
         session.add_all(rows)
@@ -386,6 +394,56 @@ async def test_enterprise_without_license_can_set_hourly_schedule(session_maker)
             sync_options={"schedule_cron": "0 * * * *"},
         )
         assert resp.status_code == 201, f"Expected 201: {resp.json()}"
+
+
+@pytest.mark.asyncio
+async def test_stale_org_license_takes_precedence_and_paths_agree(session_maker):
+    """Documented precedence for a stale/diverged OrgLicense row: the license
+    row wins over Organization.tier, and the limits path and entitlements path
+    agree on it (CHAOS-2256 acceptance: limits resolution == entitlements).
+
+    Divergence is prevented at the write paths (OrganizationService.update and
+    SubscriptionService._sync_org_license keep both in lockstep); this pins the
+    read behavior for pre-existing legacy rows.
+    """
+    from dev_health_ops.licensing.gating import get_org_entitlements_from_db
+
+    state = await _seed_org(session_maker, "enterprise", license_tier="community")
+
+    # Limits path: community license row wins → 24h floor.
+    assert await _get_min_sync_interval(session_maker, state["org_id"]) == 24
+
+    # Entitlements path agrees: tier resolves to community.
+    async with session_maker() as session:
+        entitlements = await get_org_entitlements_from_db(
+            uuid.UUID(state["org_id"]), session
+        )
+    assert entitlements["tier"] == "community"
+
+
+@pytest.mark.asyncio
+async def test_admin_tier_update_heals_stale_org_license(session_maker):
+    """CHAOS-2256 review regression: an admin tier change must update a
+    pre-existing OrgLicense row, otherwise the org keeps being enforced at the
+    stale license tier."""
+    from dev_health_ops.api.services.users import OrganizationService
+
+    state = await _seed_org(session_maker, "community")
+
+    async with session_maker() as session:
+        svc = OrganizationService(session)
+        org = await svc.update(org_id=state["org_id"], tier="enterprise")
+        assert org is not None
+        await session.commit()
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(OrgLicense).filter_by(org_id=uuid.UUID(state["org_id"]))
+        )
+        license_row = result.scalar_one()
+        assert license_row.tier == "enterprise"
+
+    assert await _get_min_sync_interval(session_maker, state["org_id"]) == 0.25
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_tier_limits.py
+++ b/tests/api/admin/test_tier_limits.py
@@ -73,18 +73,28 @@ async def session_maker(tmp_path: Path):
         await engine.dispose()
 
 
-async def _seed_org(session_maker, tier: str) -> dict[str, str]:
-    """Create an org + user + OrgLicense for a given tier."""
+async def _seed_org(
+    session_maker, tier: str, *, with_license: bool = True
+) -> dict[str, str]:
+    """Create an org + user (+ optionally an OrgLicense) for a given tier.
+
+    ``with_license=False`` models the common SaaS state where the org's tier
+    lives only on ``Organization.tier`` (set at creation or by an admin) and
+    no OrgLicense row exists yet — e.g. a trial before a Stripe plan resolves
+    (CHAOS-2256).
+    """
     org_id = uuid.uuid4()
     user_id = uuid.uuid4()
     org = Organization(
         id=org_id, slug=f"{tier}-org", name=f"{tier.title()} Org", tier=tier
     )
     user = User(id=user_id, email=f"{tier}@example.com", is_active=True)
-    license_row = OrgLicense(org_id=org_id, tier=tier)
+    rows: list[object] = [org, user]
+    if with_license:
+        rows.append(OrgLicense(org_id=org_id, tier=tier))
 
     async with session_maker() as session:
-        session.add_all([org, user, license_row])
+        session.add_all(rows)
         await session.commit()
 
     return {"org_id": str(org_id), "user_id": str(user_id)}
@@ -310,6 +320,89 @@ async def test_community_initial_sync_depth_blocked_at_90(session_maker):
             "backfill" in resp.json()["detail"].lower()
             or "limit" in resp.json()["detail"].lower()
         )
+
+
+# ---------------------------------------------------------------------------
+# Enterprise tier resolution (CHAOS-2256)
+# ---------------------------------------------------------------------------
+
+
+async def _get_min_sync_interval(session_maker, org_id: str):
+    from dev_health_ops.api.services.licensing import TierLimitService
+
+    async with session_maker() as session:
+
+        def _get(sync_session):
+            tier_svc = TierLimitService(sync_session)
+            return tier_svc.get_limit(uuid.UUID(org_id), "min_sync_interval_hours")
+
+        return await session.run_sync(_get)
+
+
+@pytest.mark.asyncio
+async def test_enterprise_min_sync_interval_is_quarter_hour(session_maker):
+    """Enterprise org (with OrgLicense): min_sync_interval_hours == 0.25."""
+    state = await _seed_org(session_maker, "enterprise")
+    assert await _get_min_sync_interval(session_maker, state["org_id"]) == 0.25
+
+
+@pytest.mark.asyncio
+async def test_enterprise_tier_resolves_via_organization_fallback(session_maker):
+    """CHAOS-2256: enterprise org WITHOUT an OrgLicense row must resolve via
+    Organization.tier, not silently fall back to community's 24h floor."""
+    state = await _seed_org(session_maker, "enterprise", with_license=False)
+    assert await _get_min_sync_interval(session_maker, state["org_id"]) == 0.25
+
+
+@pytest.mark.asyncio
+async def test_enterprise_can_set_hourly_schedule(session_maker):
+    """Enterprise tier: hourly schedule (1h) accepted (min=0.25h)."""
+    state = await _seed_org(session_maker, "enterprise")
+
+    app = _make_client(session_maker, state)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await _create_config(
+            ac,
+            "hourly-sync",
+            sync_options={"schedule_cron": "0 * * * *"},
+        )
+        assert resp.status_code == 201, f"Expected 201: {resp.json()}"
+
+
+@pytest.mark.asyncio
+async def test_enterprise_without_license_can_set_hourly_schedule(session_maker):
+    """CHAOS-2256 regression: enterprise org with only Organization.tier set
+    (no OrgLicense row) can create a 1h schedule instead of being rejected
+    with the community 24h minimum."""
+    state = await _seed_org(session_maker, "enterprise", with_license=False)
+
+    app = _make_client(session_maker, state)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await _create_config(
+            ac,
+            "hourly-sync",
+            sync_options={"schedule_cron": "0 * * * *"},
+        )
+        assert resp.status_code == 201, f"Expected 201: {resp.json()}"
+
+
+@pytest.mark.asyncio
+async def test_enterprise_below_floor_still_rejected(session_maker):
+    """Enterprise tier floor still applies: a 10-minute cron (< 0.25h) is 403."""
+    state = await _seed_org(session_maker, "enterprise", with_license=False)
+
+    app = _make_client(session_maker, state)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await _create_config(
+            ac,
+            "ten-minute-sync",
+            sync_options={"schedule_cron": "*/10 * * * *"},
+        )
+        assert resp.status_code == 403
+        assert "interval" in resp.json()["detail"].lower()
 
 
 @pytest.mark.asyncio

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1160,6 +1160,15 @@ async def test_subscription_creates_org_license(bridge_db):
         assert features.get("audit_log") is True
         assert features.get("ip_allowlist") is True
 
+        # CHAOS-2256 review: Organization.tier must be kept in lockstep so the
+        # resolve_org_tier fallback never sees a stale value.
+        from dev_health_ops.models.users import Organization
+
+        org_row = (
+            await session.execute(select(Organization).where(Organization.id == org_id))
+        ).scalar_one()
+        assert org_row.tier == "enterprise"
+
 
 @pytest.mark.asyncio
 async def test_subscription_update_does_not_duplicate_license(bridge_db):


### PR DESCRIPTION
## Summary
Fixes [CHAOS-2256](https://linear.app/fullchaos/issue/CHAOS-2256): an Enterprise org setting a 1h sync interval was rejected with the **community** 24h floor because `TierLimitService` (and `FeatureService`) resolved tier from the `OrgLicense` table only, silently defaulting to COMMUNITY when no row exists.

An org can legitimately be Enterprise with no `OrgLicense` row: tier set on `Organization.tier` at creation / by an admin (`OrganizationService.update`), or a trial before the Stripe plan resolves (`_sync_org_license` returns early when `billing_plan_id` is None). The entitlements path (`gating.get_org_entitlements_from_db`, `_check_org_feature_async`) already falls back to `Organization.tier` — the limits path didn't.

## Change
- New `resolve_org_tier(session, org_id, org_license)` in `api/services/licensing.py`: `OrgLicense.tier` wins when a row exists; else fall back to `Organization.tier`; default COMMUNITY. Mirrors the entitlements path exactly (including invalid-tier warning behavior).
- Used by `TierLimitService.get_limit` / `get_all_limits` and `FeatureService.check_feature_access` — fixes all 7 tier-limit gates in `admin/routers/sync.py` (max_repos, backfill_days, min_sync_interval_hours ×2, max_work_items, backfill trigger) in one place.

## Feature-gate inventory (audit performed for this fix)
- **7 TierLimitService call sites** (all in `admin/routers/sync.py`) — were BUGGY, all fixed by this change.
- **31 `@require_feature` decorators** (SSO, IP allowlist, retention, audit logs) — all async → already get the per-org `_check_org_feature_async` fallback → OK.
- **Entitlements endpoints** (`/api/v1/licensing/entitlements`, `/api/v1/billing/entitlements`) — already fall back to `Organization.tier` → OK.
- **GraphQL `authz.py` `has_feature`** — instance-level JWT (self-hosted LICENSE_KEY), per-deployment by design.
- No unsafe ad-hoc tier checks found elsewhere.

## Tests
- `test_enterprise_min_sync_interval_is_quarter_hour` — with OrgLicense → 0.25
- `test_enterprise_tier_resolves_via_organization_fallback` — **no OrgLicense row** → 0.25 (fails pre-fix)
- `test_enterprise_without_license_can_set_hourly_schedule` — 1h cron → 201 (fails pre-fix with the exact CHAOS-2256 error)
- `test_enterprise_can_set_hourly_schedule`, `test_enterprise_below_floor_still_rejected` (10-min cron → 403)

## Gates
- `ruff format --check` / `ruff check` clean
- `mypy --install-types --non-interactive .` — 0 issues, 1008 files
- `tests/api/admin/test_tier_limits.py` 14 passed; `tests/test_licensing.py` 95 passed; `tests/test_backfill_integration.py` 14 passed