### PR TITLE
fix(sync): stop Celery workers auto-running ClickHouse migrations (CHAOS-2268)

### DIFF
--- a/src/dev_health_ops/metrics/sinks/clickhouse/core.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/core.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import uuid
 from dataclasses import asdict
 from datetime import date, datetime, timedelta, timezone
@@ -26,6 +27,14 @@ from dev_health_ops.metrics.sinks.clickhouse._insert import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _auto_run_migrations_enabled() -> bool:
+    return os.getenv("AUTO_RUN_MIGRATIONS", "true").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
 
 
 class ClickHouseCore(BaseMetricsSink):
@@ -221,8 +230,21 @@ class ClickHouseCore(BaseMetricsSink):
                 parameters={"version": version},
             )
 
-    def ensure_schema(self) -> None:
-        """Create ClickHouse tables via SQL migrations."""
+    def ensure_schema(self, *, force: bool = False) -> None:
+        """Create ClickHouse tables via SQL migrations.
+
+        Schema management belongs to the dedicated migration entrypoint
+        (``dev-hops migrate clickhouse`` / the one-shot ``migrate`` compose
+        service), not to task execution. Services that are guaranteed to start
+        after migrations (worker, beat) set ``AUTO_RUN_MIGRATIONS=false`` to
+        turn the ambient ``ensure_tables()`` calls into no-ops; ``force=True``
+        bypasses the flag for the CLI runner.
+        """
+        if not force and not _auto_run_migrations_enabled():
+            logger.debug(
+                "Skipping ClickHouse auto-migration (AUTO_RUN_MIGRATIONS=false)"
+            )
+            return
         self._apply_sql_migrations()
 
     # Alias for backward compatibility

--- a/src/dev_health_ops/migrate.py
+++ b/src/dev_health_ops/migrate.py
@@ -92,7 +92,9 @@ def _run_clickhouse_upgrade(ns: argparse.Namespace) -> int:
     uri = resolve_sink_uri(ns)
     sink = ClickHouseMetricsSink(dsn=uri)
     try:
-        sink.ensure_schema()
+        # The CLI is the canonical migration entrypoint — bypass the
+        # AUTO_RUN_MIGRATIONS opt-out that disables ambient auto-migration.
+        sink.ensure_schema(force=True)
     finally:
         sink.close()
     logger.info("ClickHouse migrations applied successfully.")

--- a/tests/test_worker_auto_migrate_and_sink_cache.py
+++ b/tests/test_worker_auto_migrate_and_sink_cache.py
@@ -1,13 +1,24 @@
-"""Tests for CHAOS-2252: worker migration hook removal.
+"""Tests for CHAOS-2252 / CHAOS-2268: worker migration hook removal.
 
 Issue 4: Workers must NEVER run migrations. The @worker_init migration hook
 has been removed entirely from workers/celery_app.py. Migrations are a
 deploy/init-step concern (dev-hops migrate postgres|clickhouse).
+
+CHAOS-2268: the ClickHouse sink's ambient ``ensure_tables()`` calls (reached
+from Celery tasks via run_work_items_sync_job and friends) also ran SQL
+migrations. ``ensure_schema()`` now honours AUTO_RUN_MIGRATIONS=false (set on
+worker/beat/api in compose, which gate on the one-shot ``migrate`` service);
+the CLI bypasses the flag with ``force=True``.
 """
 
 from __future__ import annotations
 
+from unittest import mock
+
+import pytest
+
 import dev_health_ops.workers.celery_app as celery_module
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 
 
 def test_worker_module_has_no_migration_on_startup_hook() -> None:
@@ -61,3 +72,44 @@ def test_worker_module_has_no_worker_init_migration_receiver() -> None:
         assert "command.upgrade" not in src, (
             f"worker_init receiver {func.__name__!r} must not call command.upgrade"
         )
+
+
+def _sink_with_fake_client() -> ClickHouseMetricsSink:
+    return ClickHouseMetricsSink(
+        dsn="clickhouse://ch:ch@localhost:8123/default", client=mock.MagicMock()
+    )
+
+
+def test_ensure_schema_skips_migrations_when_auto_run_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AUTO_RUN_MIGRATIONS=false turns ambient ensure_schema() into a no-op."""
+    monkeypatch.setenv("AUTO_RUN_MIGRATIONS", "false")
+    sink = _sink_with_fake_client()
+    with mock.patch.object(sink, "_apply_sql_migrations") as apply:
+        sink.ensure_schema()
+        sink.ensure_tables()  # backward-compat alias must honour the flag too
+    apply.assert_not_called()
+
+
+def test_ensure_schema_force_bypasses_auto_run_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """force=True (the dev-hops migrate CLI path) always runs migrations."""
+    monkeypatch.setenv("AUTO_RUN_MIGRATIONS", "false")
+    sink = _sink_with_fake_client()
+    with mock.patch.object(sink, "_apply_sql_migrations") as apply:
+        sink.ensure_schema(force=True)
+    apply.assert_called_once()
+
+
+def test_ensure_schema_runs_migrations_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the env flag, behaviour is unchanged (deploy stacks without a
+    one-shot migrate service still rely on ambient auto-migration)."""
+    monkeypatch.delenv("AUTO_RUN_MIGRATIONS", raising=False)
+    sink = _sink_with_fake_client()
+    with mock.patch.object(sink, "_apply_sql_migrations") as apply:
+        sink.ensure_schema()
+    apply.assert_called_once()


### PR DESCRIPTION
## Problem
Worker logs show SQL migrations executing inside Celery task execution:
```
worker-1  | [2026-06-11 02:29:00,690: INFO/ForkPoolWorker-2] Skipping already applied migration: __init__.py
```
Call chain: `run_sync_config` (Celery) → `run_work_items_sync_job()` → `s.ensure_tables()` (`metrics/job_work_items.py:167`) → `ensure_schema()` → `_apply_sql_migrations()`. The same ambient pattern exists in `job_daily.py`, `job_complexity_db.py`, `job_compounding_risk.py`, and `WorkGraphBuilder.__init__`.

CHAOS-2252 already established the invariant (workers must never run migrations) and removed the Alembic `worker_init` hook — but the ClickHouse path survived.

## Fix
- `ensure_schema()` honours `AUTO_RUN_MIGRATIONS` (default **true** — `deploy/compose` and `deploy/k8s` stacks have no one-shot migrate step and still rely on ambient migration, so default-off would break their first boot)
- `dev-hops migrate clickhouse` passes `force=True` — the CLI remains the canonical migration entrypoint regardless of env
- The workspace `compose.yml` (not in this repo) now sets `AUTO_RUN_MIGRATIONS: "false"` on `worker`/`beat`/`api`, all of which already gate on the one-shot `migrate` service via `service_completed_successfully`

## Tests
- 3 new regression tests in `tests/test_worker_auto_migrate_and_sink_cache.py` (flag off → no-op incl. `ensure_tables` alias; `force=True` bypass; default unchanged)
- `mypy --install-types --non-interactive .` clean (1012 files)
- Unit suite: 3924 passed; 5 failures are pre-existing on main (reproduced identically on `main`: `test_org_deletion` ×2, `test_compute_capacity` fixed-date, `test_core_extraction` cache-timing ×2)

Linear: CHAOS-2268