### PR TITLE
fix(admin): resolve org/group for team discovery from params, config, or repo sync (CHAOS-2266)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/teams.py
+++ b/src/dev_health_ops/api/admin/routers/teams.py
@@ -17,6 +17,7 @@ from dev_health_ops.api.admin.schemas import (
 from dev_health_ops.api.services.configuration import (
     AmbiguousCredentialError,
     IntegrationCredentialsService,
+    SyncConfigurationService,
     TeamDiscoveryService,
     TeamMappingService,
 )
@@ -24,6 +25,50 @@ from dev_health_ops.api.services.configuration import (
 from .common import get_session
 
 router = APIRouter()
+
+
+def _string_value(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+async def _derive_owners_from_sync_configs(
+    session: AsyncSession,
+    org_id: str,
+    provider: str,
+    option_keys: tuple[str, ...],
+) -> list[str]:
+    """Derive distinct owner/group values from the org's sync configurations.
+
+    Repo sync stores the GitHub org / GitLab group in
+    ``SyncConfiguration.sync_options`` (key ``owner``, see the sync-config
+    batch endpoint), so orgs with a working repo sync can discover teams
+    without any extra configuration.
+    """
+    svc = SyncConfigurationService(session, org_id)
+    configs = await svc.list_all(active_only=True)
+    owners: list[str] = []
+    for config in configs:
+        if str(getattr(config, "provider", "")).lower() != provider:
+            continue
+        options: dict[str, Any] = dict(getattr(config, "sync_options") or {})
+        for key in option_keys:
+            value = _string_value(options.get(key))
+            if value and value not in owners:
+                owners.append(value)
+    return owners
+
+
+def _dedupe_teams(teams: list[Any]) -> list[Any]:
+    """Dedupe discovered teams by provider team key/slug."""
+    seen: set[str] = set()
+    unique: list[Any] = []
+    for team in teams:
+        key = str(getattr(team, "provider_team_id"))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(team)
+    return unique
 
 
 class _MutableTeamMapping(Protocol):
@@ -110,6 +155,12 @@ async def discover_teams(
     provider: str = Query(..., pattern="^(github|gitlab|jira|linear)$"),
     credential_id: str | None = Query(None),
     credential_name: str | None = Query(None),
+    org: str | None = Query(
+        None, description="GitHub organization to discover teams from"
+    ),
+    group: str | None = Query(
+        None, description="GitLab group path to discover teams from"
+    ),
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> TeamDiscoverResponse:
@@ -131,30 +182,72 @@ async def discover_teams(
 
     if provider == "github":
         token = decrypted.get("token")
-        org_name_value = config.get("org")
-        org_name = org_name_value if isinstance(org_name_value, str) else None
-        if not token or not org_name:
+        if not token:
             raise HTTPException(
                 status_code=400,
-                detail="GitHub credentials require token and config.org",
+                detail="GitHub credentials require a token",
             )
-        teams = await discovery_svc.discover_github(token=token, org_name=org_name)
+        # Resolution order: explicit query param -> credential config ->
+        # owners derived from existing repo sync configurations.
+        if org:
+            org_names = [org]
+        elif _string_value(config.get("org")):
+            org_names = [cast(str, _string_value(config.get("org")))]
+        else:
+            org_names = await _derive_owners_from_sync_configs(
+                session, org_id, "github", ("owner", "org")
+            )
+        if not org_names:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Could not determine a GitHub organization for team "
+                    "discovery. Pass ?org=<org-name>, set config.org on the "
+                    "credential, or configure a GitHub repository sync first."
+                ),
+            )
+        discovered: list[Any] = []
+        for org_name in org_names:
+            discovered.extend(
+                await discovery_svc.discover_github(token=token, org_name=org_name)
+            )
+        teams = _dedupe_teams(discovered)
     elif provider == "gitlab":
         token = decrypted.get("token")
-        group_path_value = config.get("group")
-        group_path = group_path_value if isinstance(group_path_value, str) else None
         url_value = config.get("url", "https://gitlab.com")
         url = url_value if isinstance(url_value, str) else "https://gitlab.com"
-        if not token or not group_path:
+        if not token:
             raise HTTPException(
                 status_code=400,
-                detail="GitLab credentials require token and config.group",
+                detail="GitLab credentials require a token",
             )
-        teams = await discovery_svc.discover_gitlab(
-            token=token,
-            group_path=group_path,
-            url=url,
-        )
+        if group:
+            group_paths = [group]
+        elif _string_value(config.get("group")):
+            group_paths = [cast(str, _string_value(config.get("group")))]
+        else:
+            group_paths = await _derive_owners_from_sync_configs(
+                session, org_id, "gitlab", ("group", "owner")
+            )
+        if not group_paths:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Could not determine a GitLab group for team discovery. "
+                    "Pass ?group=<group-path>, set config.group on the "
+                    "credential, or configure a GitLab repository sync first."
+                ),
+            )
+        discovered_gitlab: list[Any] = []
+        for group_path in group_paths:
+            discovered_gitlab.extend(
+                await discovery_svc.discover_gitlab(
+                    token=token,
+                    group_path=group_path,
+                    url=url,
+                )
+            )
+        teams = _dedupe_teams(discovered_gitlab)
     elif provider == "linear":
         api_key = decrypted.get("apiKey") or decrypted.get("api_key")
         if not api_key:

--- a/tests/api/admin/test_teams_discover_org_group.py
+++ b/tests/api/admin/test_teams_discover_org_group.py
@@ -1,0 +1,362 @@
+"""Tests for org/group resolution in ``GET /teams/discover`` (CHAOS-2266).
+
+Team import from GitHub/GitLab used to hard-require ``config.org`` /
+``config.group`` on the stored credential, but nothing ever populated those
+fields — the endpoint 400'd for every org. Discovery now resolves the
+effective org/group in order:
+
+1. explicit ``org`` / ``group`` query parameter,
+2. ``credential.config`` (legacy behaviour),
+3. distinct owner/group values derived from the org's active
+   ``SyncConfiguration.sync_options`` for the same provider (zero-config
+   path — repo sync already knows the owner).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+os.environ.setdefault("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+
+from dev_health_ops.api.admin.schemas import DiscoveredTeam
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.services.configuration import (
+    IntegrationCredentialsService,
+    SyncConfigurationService,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import (
+    IntegrationCredential,
+    SyncConfiguration,
+    TeamMapping,
+)
+from dev_health_ops.models.users import Membership, Organization, User
+from tests._helpers import tables_of
+
+admin_router_module = importlib.import_module("dev_health_ops.api.admin")
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+_TABLES = tables_of(
+    User,
+    Organization,
+    Membership,
+    TeamMapping,
+    IntegrationCredential,
+    SyncConfiguration,
+)
+
+ORG_ID = str(uuid.uuid4())
+
+_GITHUB_DISCOVER = (
+    "dev_health_ops.api.services.configuration.team_discovery."
+    "TeamDiscoveryService.discover_github"
+)
+_GITLAB_DISCOVER = (
+    "dev_health_ops.api.services.configuration.team_discovery."
+    "TeamDiscoveryService.discover_gitlab"
+)
+
+
+def _team(provider_type: str, team_id: str, name: str | None = None) -> DiscoveredTeam:
+    return DiscoveredTeam(
+        provider_type=provider_type,
+        provider_team_id=team_id,
+        name=name or team_id,
+    )
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "teams-discover.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def _seed_credential(
+    session_maker,
+    provider: str,
+    credentials: dict | None = None,
+    config: dict | None = None,
+) -> None:
+    async with session_maker() as session:
+        svc = IntegrationCredentialsService(session, ORG_ID)
+        await svc.set(
+            provider=provider,
+            credentials=credentials or {"token": "test-token"},
+            name="default",
+            config=config,
+        )
+        await session.commit()
+
+
+async def _seed_sync_config(
+    session_maker,
+    provider: str,
+    name: str,
+    sync_options: dict,
+    is_active: bool = True,
+    org_id: str = ORG_ID,
+) -> None:
+    async with session_maker() as session:
+        svc = SyncConfigurationService(session, org_id)
+        config = await svc.create(
+            name=name,
+            provider=provider,
+            sync_targets=["git"],
+            sync_options=sync_options,
+        )
+        if not is_active:
+            config.is_active = False
+        await session.commit()
+
+
+@pytest_asyncio.fixture
+async def client(session_maker):
+    app = FastAPI()
+    app.include_router(admin_router_module.router)
+
+    admin_user = AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        email="admin@example.com",
+        org_id=ORG_ID,
+        role="owner",
+        is_superuser=False,
+    )
+
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+            await session.commit()
+
+    app.dependency_overrides[auth_router_module.get_current_user] = lambda: admin_user
+    app.dependency_overrides[admin_router_module.get_session] = _session_override
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GitHub
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_github_query_param_wins_over_config(client, session_maker):
+    await _seed_credential(session_maker, "github", config={"org": "config-org"})
+    await _seed_sync_config(
+        session_maker, "github", "derived-org/repo", {"owner": "derived-org"}
+    )
+
+    with patch(_GITHUB_DISCOVER, new=AsyncMock(return_value=[])) as mock_discover:
+        response = await client.get(
+            "/api/v1/admin/teams/discover?provider=github&org=param-org"
+        )
+
+    assert response.status_code == 200, response.text
+    mock_discover.assert_awaited_once_with(token="test-token", org_name="param-org")
+
+
+@pytest.mark.asyncio
+async def test_github_falls_back_to_credential_config(client, session_maker):
+    await _seed_credential(session_maker, "github", config={"org": "config-org"})
+    await _seed_sync_config(
+        session_maker, "github", "derived-org/repo", {"owner": "derived-org"}
+    )
+
+    with patch(_GITHUB_DISCOVER, new=AsyncMock(return_value=[])) as mock_discover:
+        response = await client.get("/api/v1/admin/teams/discover?provider=github")
+
+    assert response.status_code == 200, response.text
+    mock_discover.assert_awaited_once_with(token="test-token", org_name="config-org")
+
+
+@pytest.mark.asyncio
+async def test_github_derives_org_from_sync_options(client, session_maker):
+    """No query param and no config.org — the existing frontend call shape."""
+    await _seed_credential(session_maker, "github")
+    await _seed_sync_config(
+        session_maker, "github", "acme/api", {"owner": "acme", "repo": "api"}
+    )
+    await _seed_sync_config(
+        session_maker, "github", "acme/web", {"owner": "acme", "repo": "web"}
+    )
+
+    teams = [_team("github", "platform")]
+    with patch(_GITHUB_DISCOVER, new=AsyncMock(return_value=teams)) as mock_discover:
+        response = await client.get("/api/v1/admin/teams/discover?provider=github")
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["total"] == 1
+    assert data["teams"][0]["provider_team_id"] == "platform"
+    # Distinct owners only: two configs with the same owner -> one call.
+    mock_discover.assert_awaited_once_with(token="test-token", org_name="acme")
+
+
+@pytest.mark.asyncio
+async def test_github_derivation_skips_other_provider_and_inactive(
+    client, session_maker
+):
+    await _seed_credential(session_maker, "github")
+    await _seed_sync_config(
+        session_maker, "gitlab", "glgroup/repo", {"owner": "glgroup"}
+    )
+    await _seed_sync_config(
+        session_maker,
+        "github",
+        "inactive/repo",
+        {"owner": "inactive-org"},
+        is_active=False,
+    )
+    await _seed_sync_config(session_maker, "github", "acme/api", {"owner": "acme"})
+
+    with patch(_GITHUB_DISCOVER, new=AsyncMock(return_value=[])) as mock_discover:
+        response = await client.get("/api/v1/admin/teams/discover?provider=github")
+
+    assert response.status_code == 200, response.text
+    mock_discover.assert_awaited_once_with(token="test-token", org_name="acme")
+
+
+@pytest.mark.asyncio
+async def test_github_multi_owner_merge_dedupes_by_slug(client, session_maker):
+    await _seed_credential(session_maker, "github")
+    await _seed_sync_config(session_maker, "github", "org-a/api", {"owner": "org-a"})
+    await _seed_sync_config(session_maker, "github", "org-b/web", {"owner": "org-b"})
+
+    results = {
+        "org-a": [_team("github", "platform"), _team("github", "shared")],
+        "org-b": [_team("github", "shared"), _team("github", "mobile")],
+    }
+
+    async def _discover(token: str, org_name: str):
+        return results[org_name]
+
+    with patch(_GITHUB_DISCOVER, new=AsyncMock(side_effect=_discover)) as mock_discover:
+        response = await client.get("/api/v1/admin/teams/discover?provider=github")
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert mock_discover.await_count == 2
+    called_orgs = {call.kwargs["org_name"] for call in mock_discover.await_args_list}
+    assert called_orgs == {"org-a", "org-b"}
+    assert data["total"] == 3
+    assert [t["provider_team_id"] for t in data["teams"]] == [
+        "platform",
+        "shared",
+        "mobile",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_github_400_when_nothing_resolves(client, session_maker):
+    await _seed_credential(session_maker, "github")
+
+    response = await client.get("/api/v1/admin/teams/discover?provider=github")
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "?org=" in detail
+    assert "repository sync" in detail
+
+
+@pytest.mark.asyncio
+async def test_github_400_when_token_missing(client, session_maker):
+    await _seed_credential(session_maker, "github", credentials={"other": "x"})
+
+    response = await client.get("/api/v1/admin/teams/discover?provider=github&org=acme")
+
+    assert response.status_code == 400
+    assert "token" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# GitLab
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gitlab_query_param_wins(client, session_maker):
+    await _seed_credential(session_maker, "gitlab", config={"group": "config-group"})
+
+    with patch(_GITLAB_DISCOVER, new=AsyncMock(return_value=[])) as mock_discover:
+        response = await client.get(
+            "/api/v1/admin/teams/discover?provider=gitlab&group=param-group"
+        )
+
+    assert response.status_code == 200, response.text
+    mock_discover.assert_awaited_once_with(
+        token="test-token", group_path="param-group", url="https://gitlab.com"
+    )
+
+
+@pytest.mark.asyncio
+async def test_gitlab_derives_group_from_sync_options(client, session_maker):
+    await _seed_credential(session_maker, "gitlab")
+    # The sync-config UI stores the GitLab group under ``owner``.
+    await _seed_sync_config(
+        session_maker, "gitlab", "my-group/api", {"owner": "my-group"}
+    )
+
+    with patch(_GITLAB_DISCOVER, new=AsyncMock(return_value=[])) as mock_discover:
+        response = await client.get("/api/v1/admin/teams/discover?provider=gitlab")
+
+    assert response.status_code == 200, response.text
+    mock_discover.assert_awaited_once_with(
+        token="test-token", group_path="my-group", url="https://gitlab.com"
+    )
+
+
+@pytest.mark.asyncio
+async def test_gitlab_400_when_nothing_resolves(client, session_maker):
+    await _seed_credential(session_maker, "gitlab")
+
+    response = await client.get("/api/v1/admin/teams/discover?provider=gitlab")
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "?group=" in detail
+    assert "repository sync" in detail
+
+
+# ---------------------------------------------------------------------------
+# Org isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_derivation_ignores_other_orgs_sync_configs(client, session_maker):
+    await _seed_credential(session_maker, "github")
+    await _seed_sync_config(
+        session_maker,
+        "github",
+        "other/repo",
+        {"owner": "other-tenant-org"},
+        org_id=str(uuid.uuid4()),
+    )
+
+    response = await client.get("/api/v1/admin/teams/discover?provider=github")
+
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
Fixes [CHAOS-2266](https://linear.app/full-chaos/issue/CHAOS-2266): team import from GitHub/GitLab always failed with "GitHub credentials require token and config.org" / "GitLab credentials require token and config.group" because nothing ever populates `config.org` / `config.group` on `IntegrationCredential` — the frontend has no UI for them and the endpoint had no override.

## Changes
`GET /api/v1/admin/teams/discover` now resolves the effective GitHub org / GitLab group in order:
1. **Explicit query param** — new optional `org` (GitHub) / `group` (GitLab) parameters, mirroring the `owner` override on repo discovery (`/credentials/{id}/repos`).
2. **Credential config** — `credential.config.org` / `.group` (legacy behaviour, unchanged).
3. **Derived from repo sync** — distinct `owner`/`group`/`org` values in active `SyncConfiguration.sync_options` for the same provider. This is the zero-config path: any org with a working repo sync (the sync-config UI stores the owner there) gets team import working with the existing parameterless frontend call.

When multiple distinct owners are derived, discovery runs across all of them and results are deduped by provider team slug (consistent with `import_teams`' `gh:<slug>` keying). If nothing resolves, the 400 now tells the user exactly what to do instead of pointing at a config field that cannot be set.

Route signature stays backward compatible — `web/src/lib/admin/api/teams.ts` calls `/teams/discover?provider=...` with no extra params and now succeeds via derivation. No web changes needed.

## Tests
New `tests/api/admin/test_teams_discover_org_group.py` (11 tests, style of `test_credential_fallback.py`): query param precedence, config fallback, sync_options derivation (incl. distinct-owner collapse, provider/active filtering, org isolation), multi-owner merge + slug dedupe, missing-token 400, and actionable nothing-found 400 for both providers.

## Gates
- `uv run mypy --install-types --non-interactive .` — clean (1010 files)
- `./ci/run_tests.sh unit` — 3931 passed; only the 5 known pre-existing failures on main (org_deletion x2, fixed_date_forecast, TestCoreCache x2)
- ruff check/format via lefthook — clean