### PR TITLE
fix(sync): resolve batch sync JobRun state so Sync Now never sticks PENDING (CHAOS-2267)

### DIFF
--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -31,8 +31,52 @@ from dev_health_ops.workers.task_utils import (
 logger = logging.getLogger(__name__)
 
 
-def _mark_batch_run_complete(run_id: str, results: list) -> None:
-    """Update the parent JobRun to SUCCESS after all batch children complete."""
+def _set_run_duration(run_record, completed_at: datetime) -> None:
+    """Compute duration_seconds from started_at when available."""
+    started = getattr(run_record, "started_at", None)
+    if started is None:
+        return
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=timezone.utc)
+    setattr(
+        run_record,
+        "duration_seconds",
+        max(0, int((completed_at - started).total_seconds())),
+    )
+
+
+def _update_config_sync_status(
+    session,
+    config_id: str,
+    org_id: str,
+    *,
+    completed_at: datetime,
+    success: bool,
+    error: str | None = None,
+    stats: dict[str, Any] | None = None,
+) -> None:
+    """Record the terminal sync outcome on the SyncConfiguration."""
+    from dev_health_ops.models.settings import SyncConfiguration
+
+    config_record = (
+        session.query(SyncConfiguration)
+        .filter(
+            SyncConfiguration.id == uuid.UUID(config_id),
+            SyncConfiguration.org_id == org_id,
+        )
+        .one_or_none()
+    )
+    if config_record is None:
+        return
+    setattr(config_record, "last_sync_at", completed_at)
+    setattr(config_record, "last_sync_success", success)
+    setattr(config_record, "last_sync_error", error)
+    if stats is not None:
+        setattr(config_record, "last_sync_stats", stats)
+
+
+def _mark_batch_run_running(run_id: str) -> None:
+    """Transition the pending JobRun to RUNNING when batch dispatch starts."""
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.models.settings import JobRun, JobRunStatus
 
@@ -44,17 +88,95 @@ def _mark_batch_run_complete(run_id: str, results: list) -> None:
                 .one_or_none()
             )
             if run_record is not None:
-                completed_at = datetime.now(timezone.utc)
-                setattr(run_record, "status", JobRunStatus.SUCCESS.value)
-                setattr(run_record, "completed_at", completed_at)
-                setattr(
-                    run_record,
-                    "result",
-                    {"child_results": len(results) if results else 0},
-                )
+                setattr(run_record, "status", JobRunStatus.RUNNING.value)
+                setattr(run_record, "started_at", datetime.now(timezone.utc))
                 session.flush()
     except Exception as exc:
+        logger.error("Failed to mark batch run %s running: %s", run_id, exc)
+
+
+def _mark_batch_run_complete(
+    run_id: str | None,
+    results: list,
+    *,
+    config_id: str | None = None,
+    org_id: str | None = None,
+) -> None:
+    """Update the parent JobRun to SUCCESS after all batch children complete.
+
+    Also stamps last_sync_* on the SyncConfiguration when config_id is given,
+    so the config no longer shows "Never Synced" after a batch run.
+    """
+    from dev_health_ops.db import get_postgres_session_sync
+    from dev_health_ops.models.settings import JobRun, JobRunStatus
+
+    try:
+        with get_postgres_session_sync() as session:
+            completed_at = datetime.now(timezone.utc)
+            stats = {"child_results": len(results) if results else 0}
+            if run_id is not None:
+                run_record = (
+                    session.query(JobRun)
+                    .filter(JobRun.id == uuid.UUID(run_id))
+                    .one_or_none()
+                )
+                if run_record is not None:
+                    setattr(run_record, "status", JobRunStatus.SUCCESS.value)
+                    setattr(run_record, "completed_at", completed_at)
+                    setattr(run_record, "result", stats)
+                    setattr(run_record, "error", None)
+                    _set_run_duration(run_record, completed_at)
+            if config_id is not None and org_id is not None:
+                _update_config_sync_status(
+                    session,
+                    config_id,
+                    org_id,
+                    completed_at=completed_at,
+                    success=True,
+                    stats=stats,
+                )
+            session.flush()
+    except Exception as exc:
         logger.error("Failed to mark batch run %s complete: %s", run_id, exc)
+
+
+def _mark_batch_run_failed(
+    run_id: str | None,
+    error: str,
+    *,
+    config_id: str | None = None,
+    org_id: str | None = None,
+) -> None:
+    """Update the parent JobRun to FAILED so it never sticks in PENDING/RUNNING."""
+    from dev_health_ops.db import get_postgres_session_sync
+    from dev_health_ops.models.settings import JobRun, JobRunStatus
+
+    try:
+        with get_postgres_session_sync() as session:
+            completed_at = datetime.now(timezone.utc)
+            if run_id is not None:
+                run_record = (
+                    session.query(JobRun)
+                    .filter(JobRun.id == uuid.UUID(run_id))
+                    .one_or_none()
+                )
+                if run_record is not None:
+                    setattr(run_record, "status", JobRunStatus.FAILED.value)
+                    setattr(run_record, "completed_at", completed_at)
+                    setattr(run_record, "error", error)
+                    _set_run_duration(run_record, completed_at)
+            if config_id is not None and org_id is not None:
+                _update_config_sync_status(
+                    session,
+                    config_id,
+                    org_id,
+                    completed_at=completed_at,
+                    success=False,
+                    error=error,
+                )
+            session.flush()
+    except Exception as exc:
+        logger.error("Failed to mark batch run %s failed: %s", run_id, exc)
 
 
 def _is_batch_eligible(config) -> bool:
@@ -119,6 +241,7 @@ def _batch_sync_callback(
     sync_targets: list[str],
     org_id: str,
     run_id: str | None = None,
+    config_id: str | None = None,
 ) -> dict:
     """Chord callback: dispatch post-sync tasks after all batch children complete."""
     logger.info(
@@ -130,8 +253,8 @@ def _batch_sync_callback(
         sync_targets=sync_targets,
         org_id=org_id,
     )
-    if run_id is not None:
-        _mark_batch_run_complete(run_id, results)
+    if run_id is not None or config_id is not None:
+        _mark_batch_run_complete(run_id, results, config_id=config_id, org_id=org_id)
     return {
         "status": "post_sync_dispatched",
         "child_results": len(results) if results else 0,
@@ -224,6 +347,11 @@ def dispatch_batch_sync(
             else:
                 credentials = _resolve_env_credentials(provider)
 
+        # The pending JobRun was persisted at trigger time (CHAOS-2255); mark it
+        # RUNNING so the UI does not report the sync as "Idle" (CHAOS-2267).
+        if pending_run_id is not None:
+            _mark_batch_run_running(pending_run_id)
+
         from dev_health_ops.discovery.repos import discover_repos_for_config
 
         try:
@@ -254,6 +382,12 @@ def dispatch_batch_sync(
             logger.info(
                 "dispatch_batch_sync: no repos discovered for config %s",
                 config_id,
+            )
+            # Terminal: the chord (and its callback) is never dispatched, so
+            # resolve the run here. Discovery succeeded with zero matches, which
+            # mirrors run_sync_config's semantics of SUCCESS on an empty sync.
+            _mark_batch_run_complete(
+                pending_run_id, [], config_id=config_id, org_id=org_id
             )
             return {"status": "no_repos", "total_repos": 0, "batch_count": 0}
 
@@ -306,6 +440,7 @@ def dispatch_batch_sync(
                 sync_targets=sync_targets,
                 org_id=org_id,
                 run_id=pending_run_id,
+                config_id=config_id,
             ),
         )()
 
@@ -327,6 +462,11 @@ def dispatch_batch_sync(
             "dispatch_batch_sync failed: config_id=%s error=%s",
             config_id,
             exc,
+        )
+        # Terminal: nothing downstream will resolve the run, so fail it here
+        # instead of leaving it stuck PENDING/RUNNING (CHAOS-2267).
+        _mark_batch_run_failed(
+            pending_run_id, str(exc), config_id=config_id, org_id=org_id
         )
         return {"status": "error", "error": str(exc)}
 

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -602,6 +602,245 @@ class TestBatchSyncCallback:
         )
 
 
+class TestBatchRunStateManagement:
+    """dispatch_batch_sync must manage the pending JobRun state (CHAOS-2267).
+
+    A PENDING JobRun is persisted at Sync Now trigger time (CHAOS-2255) and
+    passed via pending_run_id. Every path through dispatch_batch_sync must
+    leave that run in a sensible state instead of stuck PENDING forever.
+    """
+
+    @staticmethod
+    def _make_pending_run(db_session):
+        import uuid as _uuid
+
+        from dev_health_ops.models.settings import JobRun
+
+        run = JobRun(job_id=_uuid.uuid4(), triggered_by="manual")
+        db_session.add(run)
+        db_session.flush()
+        return run
+
+    @staticmethod
+    def _sessions(mock_get_session, db_session):
+        """Each call to get_postgres_session_sync gets a fresh context."""
+        mock_get_session.side_effect = lambda *a, **k: _fake_session_ctx(db_session)
+
+    @patch("dev_health_ops.workers.sync_batch.chord")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_marks_pending_run_running_on_dispatch(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_chord,
+        db_session,
+    ):
+        from dev_health_ops.models.settings import JobRunStatus
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        config = _make_config(provider="github", sync_options={"search": "org/*"})
+        db_session.add(config)
+        run = self._make_pending_run(db_session)
+        self._sessions(mock_get_session, db_session)
+        mock_resolve_creds.return_value = {"token": "ghp_test"}
+        mock_discover.return_value = [("org", "repo-1")]
+        mock_chord.return_value = MagicMock()
+
+        task = dispatch_batch_sync
+        task.push_request(id="batch-run-state-1")
+        try:
+            result = task(
+                config_id=str(config.id),
+                org_id="default",
+                pending_run_id=str(run.id),
+            )
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "dispatched"
+        db_session.refresh(run)
+        assert run.status == JobRunStatus.RUNNING.value
+        assert run.started_at is not None
+
+        # The chord callback must receive both run_id and config_id so it can
+        # resolve the run and stamp the config on success.
+        callback = mock_chord.call_args[0][1]
+        assert callback.kwargs["run_id"] == str(run.id)
+        assert callback.kwargs["config_id"] == str(config.id)
+
+    @patch("dev_health_ops.workers.sync_batch.chord")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_no_repos_resolves_run_success_and_stamps_config(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_chord,
+        db_session,
+    ):
+        from dev_health_ops.models.settings import JobRunStatus
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        config = _make_config(
+            provider="github", sync_options={"search": "org/nonexistent-*"}
+        )
+        db_session.add(config)
+        run = self._make_pending_run(db_session)
+        self._sessions(mock_get_session, db_session)
+        mock_resolve_creds.return_value = {"token": "ghp_test"}
+        mock_discover.return_value = []
+
+        task = dispatch_batch_sync
+        task.push_request(id="batch-run-state-2")
+        try:
+            result = task(
+                config_id=str(config.id),
+                org_id="default",
+                pending_run_id=str(run.id),
+            )
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "no_repos"
+        mock_chord.assert_not_called()
+        db_session.refresh(run)
+        assert run.status == JobRunStatus.SUCCESS.value
+        assert run.completed_at is not None
+        assert run.result == {"child_results": 0}
+        db_session.refresh(config)
+        assert config.last_sync_at is not None
+        assert config.last_sync_success is True
+        assert config.last_sync_error is None
+
+    @patch("dev_health_ops.workers.sync_batch.chord")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_exception_marks_run_failed_and_stamps_config(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_chord,
+        db_session,
+    ):
+        from dev_health_ops.models.settings import JobRunStatus
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        config = _make_config(provider="github", sync_options={"search": "org/*"})
+        db_session.add(config)
+        run = self._make_pending_run(db_session)
+        self._sessions(mock_get_session, db_session)
+        mock_resolve_creds.return_value = {"token": "ghp_test"}
+        mock_discover.return_value = [("org", "repo-1")]
+        mock_chord.side_effect = RuntimeError("broker unavailable")
+
+        task = dispatch_batch_sync
+        task.push_request(id="batch-run-state-3")
+        try:
+            result = task(
+                config_id=str(config.id),
+                org_id="default",
+                pending_run_id=str(run.id),
+            )
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "error"
+        db_session.refresh(run)
+        assert run.status == JobRunStatus.FAILED.value
+        assert run.completed_at is not None
+        assert "broker unavailable" in (run.error or "")
+        db_session.refresh(config)
+        assert config.last_sync_at is not None
+        assert config.last_sync_success is False
+        assert "broker unavailable" in (config.last_sync_error or "")
+
+    @patch("dev_health_ops.workers.sync_batch.run_sync_config")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_fallback_forwards_pending_run_id_without_resolving(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_run_sync,
+        db_session,
+    ):
+        from dev_health_ops.models.settings import JobRunStatus
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        config = _make_config(provider="github", sync_options={"search": "org/*"})
+        db_session.add(config)
+        run = self._make_pending_run(db_session)
+        self._sessions(mock_get_session, db_session)
+        mock_resolve_creds.return_value = {"token": "ghp_test"}
+        mock_discover.side_effect = RuntimeError("API rate limited")
+
+        task = dispatch_batch_sync
+        task.push_request(id="batch-run-state-4")
+        try:
+            result = task(
+                config_id=str(config.id),
+                org_id="default",
+                pending_run_id=str(run.id),
+            )
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "fallback_single"
+        call_kwargs = mock_run_sync.apply_async.call_args.kwargs["kwargs"]
+        assert call_kwargs["pending_run_id"] == str(run.id)
+        # The run must NOT be resolved here: run_sync_config owns it from now
+        # on (it tolerates an already-RUNNING run and re-marks it RUNNING).
+        db_session.refresh(run)
+        assert run.status == JobRunStatus.RUNNING.value
+        assert run.completed_at is None
+
+    @patch("dev_health_ops.workers.sync_batch._dispatch_post_sync_tasks")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_callback_marks_run_success_and_stamps_config(
+        self, mock_get_session, mock_post_sync, db_session
+    ):
+        from dev_health_ops.models.settings import JobRunStatus
+        from dev_health_ops.workers.sync_batch import _batch_sync_callback
+
+        config = _make_config(provider="github", sync_options={"search": "org/*"})
+        db_session.add(config)
+        run = self._make_pending_run(db_session)
+        self._sessions(mock_get_session, db_session)
+
+        task = _batch_sync_callback
+        task.push_request(id="batch-run-state-5")
+        try:
+            result = task(
+                [{"status": "success"}, {"status": "success"}],
+                provider="github",
+                sync_targets=["git"],
+                org_id="default",
+                run_id=str(run.id),
+                config_id=str(config.id),
+            )
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "post_sync_dispatched"
+        db_session.refresh(run)
+        assert run.status == JobRunStatus.SUCCESS.value
+        assert run.completed_at is not None
+        assert run.result == {"child_results": 2}
+        db_session.refresh(config)
+        assert config.last_sync_at is not None
+        assert config.last_sync_success is True
+        assert config.last_sync_stats == {"child_results": 2}
+
+
 def _setup_croniter_mock():
     mock_cron_instance = MagicMock()
     mock_cron_instance.get_next.return_value = datetime(2000, 1, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
## Problem (CHAOS-2267)

Batch-eligible Sync Now runs persisted a PENDING JobRun at trigger time (CHAOS-2255), but `dispatch_batch_sync` never managed its state:

1. Never marked PENDING -> RUNNING at task start (unlike `run_sync_config`), so the UI mapped PENDING -> "Idle".
2. Early-return paths (no repos discovered, discovery-failure fallback, exception handler) never resolved the run, leaving it PENDING forever and the config showing "Never Synced".
3. SUCCESS only happened via `_batch_sync_callback`, which never fires when the chord is never dispatched — and even the callback never stamped `SyncConfiguration.last_sync_*`.

## Fix

- **RUNNING on start**: `_mark_batch_run_running` transitions the pending run (status + `started_at`) once the config is loaded, mirroring `run_sync_config`.
- **No-repos path**: resolves the run **SUCCESS with `child_results: 0`** instead of FAILED — `run_sync_config` marks SUCCESS whenever a sync completes without exception regardless of item count, and zero discovered repos is a valid empty result, not an error. Also stamps `last_sync_at` / `last_sync_success` / `last_sync_stats`.
- **Exception path**: new `_mark_batch_run_failed` (mirrors `_mark_batch_run_complete` style) marks the run FAILED with the error and records `last_sync_success=False` / `last_sync_error` on the config.
- **Fallback path**: keeps forwarding `pending_run_id` to `run_sync_config` (PR #847) and does NOT resolve the run — `run_sync_config` unconditionally re-marks RUNNING (tolerant of the prior transition) and owns the terminal state.
- **Happy path**: `_batch_sync_callback` now receives `config_id` (optional kwarg, backward compatible) so the chord callback also stamps `last_sync_*` on the config — previously even successful batch runs showed "Never Synced".
- `duration_seconds` is now computed on terminal transitions when `started_at` is set.

## Tests

New `TestBatchRunStateManagement` in `tests/test_sync_partitioning.py`:
- RUNNING + `started_at` set on dispatch; chord callback signature carries `run_id` + `config_id`
- no-repos resolves SUCCESS and stamps the config
- exception marks FAILED with error and stamps the config
- fallback forwards `pending_run_id` and leaves the run RUNNING (no double-resolve)
- callback marks SUCCESS and stamps the config

## Gates

- `uv run mypy --install-types --non-interactive .` — clean (1009 files)
- `./ci/run_tests.sh unit` — 3925 passed; only the 5 known pre-existing main failures (test_org_deletion x2, test_compute_capacity fixed_date_forecast, TestCoreCache x2)