### PR TITLE
fix(workers): dispatch-time idempotency for sync scheduler (CHAOS-2270)

### DIFF
--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -2,14 +2,170 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.org_guard import organization_exists_sync
 from dev_health_ops.workers.sync_batch import _is_batch_eligible, dispatch_batch_sync
 from dev_health_ops.workers.sync_runtime import run_sync_config
-from dev_health_ops.workers.task_utils import _as_datetime, _as_str
+from dev_health_ops.workers.task_utils import (
+    _as_datetime,
+    _as_datetime_or_none,
+    _as_dict,
+    _as_str,
+    _as_uuid,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from dev_health_ops.models.settings import ScheduledJob, SyncConfiguration
 
 logger = logging.getLogger(__name__)
+
+# Staleness escape for the `is_running` flag: workers crash and queues get
+# purged, so a running marker older than this TTL must not block re-dispatch
+# forever. Generous on purpose -- normal syncs finish well within it.
+STALE_RUNNING_TTL_SECONDS = 2 * 60 * 60  # 2 hours
+
+DEFAULT_SYNC_CRON = "0 * * * *"
+
+
+def _ensure_utc(value: datetime | None) -> datetime | None:
+    """Coerce a DB timestamp to an aware UTC datetime (SQLite returns naive)."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def _running_marker_is_stale(job: ScheduledJob, now: datetime) -> bool:
+    """True when an `is_running` flag is too old to be trusted.
+
+    `last_run_at` is stamped when the worker actually starts the run; fall
+    back to `updated_at` if it was never set. A missing marker is treated as
+    stale so a wedged flag can never block dispatch indefinitely.
+    """
+    marker = _ensure_utc(_as_datetime_or_none(job.last_run_at)) or _ensure_utc(
+        _as_datetime_or_none(job.updated_at)
+    )
+    if marker is None:
+        return True
+    return (now - marker).total_seconds() > STALE_RUNNING_TTL_SECONDS
+
+
+def _maybe_dispatch_config(
+    session: Session, config: SyncConfiguration, now: datetime
+) -> bool:
+    """Dispatch a single sync config if due. Returns True when dispatched.
+
+    Dispatch-time idempotency: `config.last_sync_at` only advances when a run
+    COMPLETES, so due-ness alone re-dispatches the same config every beat tick
+    while its first task sits in the queue (CHAOS-2270). To prevent that, the
+    `ScheduledJob.next_run_at` column is stamped at dispatch time with the next
+    cron occurrence and acts as a "do not re-dispatch before" marker. The
+    marker is self-expiring: if the dispatched task is lost (worker crash,
+    queue purge), the config becomes dispatchable again at the next cron
+    occurrence -- at most one cron interval of delay, no manual cleanup.
+    """
+    from croniter import croniter
+
+    from dev_health_ops.models.settings import ScheduledJob
+
+    if not organization_exists_sync(session, config.org_id):
+        return False
+
+    job = (
+        session.query(ScheduledJob)
+        .filter(
+            ScheduledJob.sync_config_id == config.id,
+            ScheduledJob.org_id == config.org_id,
+            ScheduledJob.job_type == "sync",
+        )
+        .one_or_none()
+    )
+
+    if job is not None and bool(job.is_running):
+        if not _running_marker_is_stale(job, now):
+            return False
+        logger.warning(
+            "Sync job %s for config %s has is_running set for more than %ss; "
+            "treating the marker as stale and re-evaluating dispatch",
+            job.id,
+            config.id,
+            STALE_RUNNING_TTL_SECONDS,
+        )
+
+    # Idempotency gate: a previous tick already dispatched this config and
+    # stamped when it should next be considered.
+    if job is not None:
+        next_allowed = _ensure_utc(_as_datetime_or_none(job.next_run_at))
+        if next_allowed is not None and next_allowed > now:
+            return False
+
+    cron_expr = (
+        _as_str(job.schedule_cron)
+        if job is not None
+        else str(
+            _as_dict(config.sync_options).get("schedule_cron") or DEFAULT_SYNC_CRON
+        )
+    )
+    last_sync = (
+        config.last_sync_at
+        if isinstance(config.last_sync_at, datetime)
+        else _as_datetime(config.created_at)
+    )
+    next_run = croniter(cron_expr, last_sync).get_next(datetime)
+
+    if not next_run <= now:
+        return False
+
+    if _is_batch_eligible(config):
+        dispatch_batch_sync.apply_async(
+            kwargs={
+                "config_id": str(config.id),
+                "org_id": config.org_id,
+                "triggered_by": "schedule",
+            },
+            queue="sync",
+        )
+    else:
+        run_sync_config.apply_async(
+            kwargs={
+                "config_id": str(config.id),
+                "org_id": config.org_id,
+                "triggered_by": "schedule",
+            },
+            queue="sync",
+        )
+
+    # Stamp the dispatch marker. Create the ScheduledJob row if missing
+    # (mirrors run_sync_config, which would otherwise create it on pickup --
+    # too late to dedupe dispatches while the task waits in the queue).
+    if job is None:
+        provider = _as_str(config.provider).lower()
+        job = ScheduledJob(
+            name=f"sync-config-{_as_uuid(config.id)}",
+            job_type="sync",
+            schedule_cron=cron_expr,
+            org_id=_as_str(config.org_id),
+            provider=provider,
+            job_config={
+                "provider": provider,
+                "sync_config_id": str(config.id),
+            },
+            sync_config_id=_as_uuid(config.id),
+            tz=str(_as_dict(config.sync_options).get("timezone") or "UTC"),
+        )
+        session.add(job)
+
+    marker = croniter(cron_expr, now).get_next(datetime)
+    if isinstance(marker, datetime):
+        job.next_run_at = marker
+    session.flush()
+
+    return True
 
 
 @celery_app.task(
@@ -17,17 +173,13 @@ logger = logging.getLogger(__name__)
 )
 def dispatch_scheduled_syncs(self) -> dict:
     """Check active sync configs and dispatch any that are due."""
-    from croniter import croniter
-
     from dev_health_ops.db import get_postgres_session_sync
-    from dev_health_ops.models.settings import (
-        ScheduledJob,
-        SyncConfiguration,
-    )
+    from dev_health_ops.models.settings import SyncConfiguration
 
     now = datetime.now(timezone.utc)
     dispatched: list[str] = []
     skipped = 0
+    errors = 0
 
     try:
         with get_postgres_session_sync() as session:
@@ -38,62 +190,27 @@ def dispatch_scheduled_syncs(self) -> dict:
             )
 
             for config in configs:
-                if not organization_exists_sync(session, config.org_id):
-                    skipped += 1
-                    continue
-
-                job = (
-                    session.query(ScheduledJob)
-                    .filter(
-                        ScheduledJob.sync_config_id == config.id,
-                        ScheduledJob.org_id == config.org_id,
-                        ScheduledJob.job_type == "sync",
-                    )
-                    .one_or_none()
-                )
-
-                if job and job.is_running:
-                    skipped += 1
-                    continue
-
-                cron_expr = _as_str(job.schedule_cron) if job else "0 * * * *"
-                last_sync = (
-                    config.last_sync_at
-                    if isinstance(config.last_sync_at, datetime)
-                    else _as_datetime(config.created_at)
-                )
-                cron = croniter(cron_expr, last_sync)
-                next_run = cron.get_next(datetime)
-
-                if next_run <= now:
-                    if _is_batch_eligible(config):
-                        dispatch_batch_sync.apply_async(
-                            kwargs={
-                                "config_id": str(config.id),
-                                "org_id": config.org_id,
-                                "triggered_by": "schedule",
-                            },
-                            queue="sync",
-                        )
+                try:
+                    if _maybe_dispatch_config(session, config, now):
+                        dispatched.append(str(config.id))
                     else:
-                        run_sync_config.apply_async(
-                            kwargs={
-                                "config_id": str(config.id),
-                                "org_id": config.org_id,
-                                "triggered_by": "schedule",
-                            },
-                            queue="sync",
-                        )
-                    dispatched.append(str(config.id))
-                else:
-                    skipped += 1
+                        skipped += 1
+                except Exception:
+                    # One bad config (e.g. a malformed cron expression) must
+                    # not abort dispatch for the remaining configs.
+                    logger.exception(
+                        "Failed to evaluate sync config %s for dispatch; skipping",
+                        config.id,
+                    )
+                    errors += 1
 
     except Exception:
         logger.exception("dispatch_scheduled_syncs failed")
 
     logger.info(
-        "Scheduled sync dispatch: dispatched=%d skipped=%d",
+        "Scheduled sync dispatch: dispatched=%d skipped=%d errors=%d",
         len(dispatched),
         skipped,
+        errors,
     )
-    return {"dispatched": dispatched, "skipped": skipped}
+    return {"dispatched": dispatched, "skipped": skipped, "errors": errors}

--- a/tests/test_sync_scheduler_idempotency.py
+++ b/tests/test_sync_scheduler_idempotency.py
@@ -1,0 +1,378 @@
+"""Dispatch-time idempotency for the sync scheduler (CHAOS-2270).
+
+`dispatch_scheduled_syncs` runs every beat tick, but `last_sync_at` only
+advances when a run completes, so without a dispatch marker every due config
+was re-enqueued on every tick and flooded the sync queue. These tests cover
+the `ScheduledJob.next_run_at` dispatch marker, the `is_running` staleness
+escape, and per-config error isolation.
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import (
+    JobRunStatus,
+    ScheduledJob,
+    SyncConfiguration,
+)
+
+HOUR = timedelta(hours=1)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@contextmanager
+def _fake_session_ctx(session):
+    yield session
+
+
+def _hourly_croniter_module() -> SimpleNamespace:
+    """Fake croniter module simulating an hourly cron: next = base + 1h."""
+
+    def _croniter(expr: str, base: datetime):
+        if expr == "BAD":
+            raise ValueError(f"malformed cron expression: {expr}")
+
+        class _Iter:
+            def get_next(self, _kind):
+                return base + HOUR
+
+        return _Iter()
+
+    return SimpleNamespace(croniter=_croniter)
+
+
+def _make_config(
+    name: str = "test-config",
+    last_sync_at: datetime | None = None,
+    sync_options: dict | None = None,
+    sync_targets: list | None = None,
+) -> SyncConfiguration:
+    config = SyncConfiguration(
+        name=name,
+        provider="github",
+        org_id="default",
+        sync_targets=sync_targets or ["git", "prs"],
+        # owner+repo set => not batch eligible
+        sync_options=sync_options
+        if sync_options is not None
+        else {"owner": "org", "repo": "repo"},
+        is_active=True,
+    )
+    if last_sync_at is not None:
+        config.last_sync_at = last_sync_at
+    return config
+
+
+def _make_job(
+    config: SyncConfiguration,
+    schedule_cron: str = "0 * * * *",
+    is_running: bool = False,
+    last_run_at: datetime | None = None,
+    next_run_at: datetime | None = None,
+) -> ScheduledJob:
+    job = ScheduledJob(
+        name=f"sync-config-{config.id}",
+        job_type="sync",
+        schedule_cron=schedule_cron,
+        org_id=config.org_id,
+        provider=config.provider,
+        sync_config_id=config.id,
+    )
+    job.is_running = is_running
+    job.last_run_at = last_run_at
+    job.next_run_at = next_run_at
+    return job
+
+
+def _run_dispatch(monkeypatch, db_session) -> tuple[Any, MagicMock, MagicMock]:
+    """Wire mocks and return (task, run_sync_mock, batch_sync_mock)."""
+    from dev_health_ops.workers.sync_scheduler import dispatch_scheduled_syncs
+
+    monkeypatch.setitem(sys.modules, "croniter", _hourly_croniter_module())
+    monkeypatch.setattr(
+        "dev_health_ops.db.get_postgres_session_sync",
+        lambda: _fake_session_ctx(db_session),
+    )
+    run_sync_mock = MagicMock()
+    batch_sync_mock = MagicMock()
+    monkeypatch.setattr(
+        "dev_health_ops.workers.sync_scheduler.run_sync_config", run_sync_mock
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.workers.sync_scheduler.dispatch_batch_sync", batch_sync_mock
+    )
+    return dispatch_scheduled_syncs, run_sync_mock, batch_sync_mock
+
+
+def _call(task) -> dict:
+    task.push_request(id=str(uuid.uuid4()))
+    try:
+        return task()
+    finally:
+        task.pop_request()
+
+
+class TestDispatchIdempotency:
+    def test_due_config_dispatched_once_not_redispatched_on_second_tick(
+        self, monkeypatch, db_session
+    ):
+        now = datetime.now(timezone.utc)
+        config = _make_config(last_sync_at=now - 2 * HOUR)
+        job = _make_job(config)
+        db_session.add_all([config, job])
+        db_session.flush()
+
+        task, run_sync_mock, _ = _run_dispatch(monkeypatch, db_session)
+
+        first = _call(task)
+        assert str(config.id) in first["dispatched"]
+        assert run_sync_mock.apply_async.call_count == 1
+        # The dispatch marker was stamped to the next cron occurrence.
+        assert job.next_run_at is not None
+        assert job.next_run_at > now
+
+        second = _call(task)
+        assert second["dispatched"] == []
+        assert run_sync_mock.apply_async.call_count == 1
+
+    def test_expired_dispatch_marker_allows_redispatch(self, monkeypatch, db_session):
+        now = datetime.now(timezone.utc)
+        config = _make_config(last_sync_at=now - 2 * HOUR)
+        # Marker from a previous dispatch whose task was lost (queue purge,
+        # worker crash) and whose cron occurrence has already passed.
+        job = _make_job(config, next_run_at=now - timedelta(minutes=1))
+        db_session.add_all([config, job])
+        db_session.flush()
+
+        task, run_sync_mock, _ = _run_dispatch(monkeypatch, db_session)
+
+        result = _call(task)
+        assert str(config.id) in result["dispatched"]
+        assert run_sync_mock.apply_async.call_count == 1
+        assert job.next_run_at is not None
+        assert job.next_run_at > now
+
+    def test_fresh_is_running_marker_skips_dispatch(self, monkeypatch, db_session):
+        now = datetime.now(timezone.utc)
+        config = _make_config(last_sync_at=now - 2 * HOUR)
+        job = _make_job(
+            config, is_running=True, last_run_at=now - timedelta(minutes=10)
+        )
+        db_session.add_all([config, job])
+        db_session.flush()
+
+        task, run_sync_mock, _ = _run_dispatch(monkeypatch, db_session)
+
+        result = _call(task)
+        assert result["dispatched"] == []
+        run_sync_mock.apply_async.assert_not_called()
+        assert job.next_run_at is None
+
+    def test_stale_is_running_marker_allows_redispatch(self, monkeypatch, db_session):
+        from dev_health_ops.workers.sync_scheduler import STALE_RUNNING_TTL_SECONDS
+
+        now = datetime.now(timezone.utc)
+        stale = now - timedelta(seconds=STALE_RUNNING_TTL_SECONDS + 60)
+        config = _make_config(last_sync_at=now - 2 * HOUR)
+        # Worker crashed mid-run: is_running was never cleared.
+        job = _make_job(config, is_running=True, last_run_at=stale)
+        db_session.add_all([config, job])
+        db_session.flush()
+
+        task, run_sync_mock, _ = _run_dispatch(monkeypatch, db_session)
+
+        first = _call(task)
+        assert str(config.id) in first["dispatched"]
+        assert run_sync_mock.apply_async.call_count == 1
+
+        # The re-dispatch stamps next_run_at, so even with the flag still
+        # wedged the config is enqueued at most once per cron interval.
+        second = _call(task)
+        assert second["dispatched"] == []
+        assert run_sync_mock.apply_async.call_count == 1
+
+    def test_completed_run_resets_cycle_without_redispatch(
+        self, monkeypatch, db_session
+    ):
+        now = datetime.now(timezone.utc)
+        config = _make_config(last_sync_at=now - 2 * HOUR)
+        job = _make_job(config)
+        db_session.add_all([config, job])
+        db_session.flush()
+
+        task, run_sync_mock, _ = _run_dispatch(monkeypatch, db_session)
+
+        _call(task)
+        assert run_sync_mock.apply_async.call_count == 1
+
+        # Simulate the consumer terminal transition (sync_runtime): the run
+        # completed, is_running cleared, last_sync_at advanced.
+        job.is_running = False
+        config.last_sync_at = now
+        db_session.flush()
+
+        # Still inside the same cron interval: nothing to dispatch.
+        second = _call(task)
+        assert second["dispatched"] == []
+        assert run_sync_mock.apply_async.call_count == 1
+
+        # Next cron interval reached (marker expired AND config due again).
+        job.next_run_at = now - timedelta(seconds=1)
+        config.last_sync_at = now - 2 * HOUR
+        db_session.flush()
+
+        third = _call(task)
+        assert str(config.id) in third["dispatched"]
+        assert run_sync_mock.apply_async.call_count == 2
+
+    def test_creates_scheduled_job_row_when_missing(self, monkeypatch, db_session):
+        now = datetime.now(timezone.utc)
+        config = _make_config(
+            last_sync_at=now - 2 * HOUR,
+            sync_options={"owner": "org", "repo": "repo", "schedule_cron": "0 * * * *"},
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        task, run_sync_mock, _ = _run_dispatch(monkeypatch, db_session)
+
+        first = _call(task)
+        assert str(config.id) in first["dispatched"]
+        assert run_sync_mock.apply_async.call_count == 1
+
+        job = (
+            db_session.query(ScheduledJob)
+            .filter(
+                ScheduledJob.sync_config_id == config.id,
+                ScheduledJob.job_type == "sync",
+            )
+            .one()
+        )
+        assert job.next_run_at is not None
+        assert job.schedule_cron == "0 * * * *"
+        assert job.is_running is False
+
+        second = _call(task)
+        assert second["dispatched"] == []
+        assert run_sync_mock.apply_async.call_count == 1
+
+
+class TestDispatchErrorIsolation:
+    def test_bad_config_does_not_abort_remaining_configs(self, monkeypatch, db_session):
+        now = datetime.now(timezone.utc)
+        bad_config = _make_config(name="bad-config", last_sync_at=now - 2 * HOUR)
+        bad_job = _make_job(bad_config, schedule_cron="BAD")
+        good_config = _make_config(name="good-config", last_sync_at=now - 2 * HOUR)
+        good_job = _make_job(good_config)
+        db_session.add_all([bad_config, bad_job, good_config, good_job])
+        db_session.flush()
+
+        task, run_sync_mock, _ = _run_dispatch(monkeypatch, db_session)
+
+        result = _call(task)
+        assert result["errors"] == 1
+        assert str(good_config.id) in result["dispatched"]
+        assert str(bad_config.id) not in result["dispatched"]
+        assert run_sync_mock.apply_async.call_count == 1
+
+
+class TestConsumerClearsRunningMarker:
+    def test_terminal_failure_clears_is_running(self, monkeypatch, db_session):
+        """run_sync_config must clear is_running on failure, or the scheduler
+        would skip the config until the staleness TTL expires."""
+        from dev_health_ops.workers.sync_runtime import run_sync_config
+
+        config = _make_config(
+            name="no-owner-repo",
+            # github + code targets but no owner/repo anywhere => terminal
+            # ValueError AFTER the job is marked running.
+            sync_options={},
+            sync_targets=["git"],
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        monkeypatch.setattr(
+            "dev_health_ops.db.get_postgres_session_sync",
+            lambda: _fake_session_ctx(db_session),
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_runtime._get_db_url",
+            lambda: "sqlite:///:memory:",
+        )
+
+        task: Any = run_sync_config
+        task.push_request(id=str(uuid.uuid4()), retries=0)
+        try:
+            with pytest.raises(ValueError, match="owner/repo"):
+                task(config_id=str(config.id), org_id="default")
+        finally:
+            task.pop_request()
+
+        job = (
+            db_session.query(ScheduledJob)
+            .filter(
+                ScheduledJob.sync_config_id == config.id,
+                ScheduledJob.job_type == "sync",
+            )
+            .one()
+        )
+        assert job.is_running is False
+        assert job.last_run_status == JobRunStatus.FAILED.value
+
+
+class TestBatchRoutingStillStampsMarker:
+    @patch("dev_health_ops.workers.sync_scheduler.dispatch_batch_sync")
+    @patch("dev_health_ops.workers.sync_scheduler.run_sync_config")
+    def test_batch_config_dispatched_once(
+        self, run_sync_mock, batch_sync_mock, monkeypatch, db_session
+    ):
+        from dev_health_ops.workers.sync_scheduler import dispatch_scheduled_syncs
+
+        now = datetime.now(timezone.utc)
+        config = _make_config(
+            name="batch-config",
+            last_sync_at=now - 2 * HOUR,
+            sync_options={"search": "org/*"},
+        )
+        job = _make_job(config)
+        db_session.add_all([config, job])
+        db_session.flush()
+
+        monkeypatch.setitem(sys.modules, "croniter", _hourly_croniter_module())
+        monkeypatch.setattr(
+            "dev_health_ops.db.get_postgres_session_sync",
+            lambda: _fake_session_ctx(db_session),
+        )
+
+        task: Any = dispatch_scheduled_syncs
+        first = _call(task)
+        assert str(config.id) in first["dispatched"]
+        assert batch_sync_mock.apply_async.call_count == 1
+        run_sync_mock.apply_async.assert_not_called()
+
+        # Batch configs never advance last_sync_at from the scheduler's
+        # perspective; the marker alone must prevent the flood.
+        second = _call(task)
+        assert second["dispatched"] == []
+        assert batch_sync_mock.apply_async.call_count == 1


### PR DESCRIPTION
## Problem (CHAOS-2270)

`dispatch_scheduled_syncs` (beat, every 300s) re-dispatched every due config on every tick: due-ness is `croniter(cron, last_sync_at or created_at).get_next() <= now`, but `last_sync_at` only advances when a run **completes**, and `ScheduledJob.is_running` is checked yet only set when a worker actually picks the task up. With any queue backlog the same configs were enqueued 22-31x each (sync queue hit 500 messages), replayed syncs burned GitHub rate limits (403 secondary-limit, 593s backoffs), which slowed the drain further — a feedback loop.

## Fix: stamp `ScheduledJob.next_run_at` at dispatch time

Chosen mechanism: at dispatch, write the **next cron occurrence** into the existing `next_run_at` column (already indexed, previously unwritten for sync jobs) and gate dispatch on `next_run_at > now`. Why this over setting `is_running` at dispatch:
- **Self-expiring**: nothing needs to clear it. A lost task (worker crash, queue purge) delays the next dispatch by at most one cron interval — no wedged state, no migration.
- `is_running` lifecycle stays owned by `run_sync_config` (set at pickup, cleared on success **and** failure — already implemented); the batch path never touches `ScheduledJob`, so a dispatch-set `is_running` would have wedged batch configs.

Also:
- **Staleness escape** for `is_running` (`STALE_RUNNING_TTL_SECONDS = 2h`): a crashed worker that left the flag set no longer blocks re-dispatch forever; the re-dispatch still stamps `next_run_at`, so even a permanently wedged flag yields at most one dispatch per cron interval.
- **Create the `ScheduledJob` row at dispatch when missing** (mirrors `run_sync_config`'s lazy creation, which happens too late to dedupe while the first task waits in the queue). New rows read `schedule_cron`/`timezone` from `sync_options`, same as the consumer.
- **Per-config error isolation**: the loop body is now wrapped per config; one malformed cron logs + skips instead of aborting dispatch for all remaining configs. Result gains an `errors` counter.

## Known / deferred
- **Timezone is ignored by croniter** (`ScheduledJob.timezone` is stored but the cron is evaluated in UTC). Pre-existing, intentionally not addressed here — separate concern.
- **Conflict risk with #852** (chaos-2267-batch-sync-jobrun-state): this PR deliberately touches **only** `sync_scheduler.py` — no changes to `sync_batch.py` / `sync_runtime.py` hunks #852 modifies. The scheduler's `dispatch_batch_sync.apply_async` kwargs are unchanged (no `pending_run_id`/`config_id` added), so whichever lands second should merge cleanly or with trivial conflicts.

## Tests
`tests/test_sync_scheduler_idempotency.py` (9 tests): due config dispatched once then skipped on the immediate second tick; expired marker re-dispatches; fresh `is_running` skips; stale `is_running` re-dispatches (once per interval); consumer terminal failure clears `is_running` (`run_sync_config` failure path); completed-run cycle; missing job row created + deduped; bad config doesn't kill the loop; batch routing still stamps the marker.

## Gates
- `uv run mypy --install-types --non-interactive .` — clean (1010 files)
- `./ci/run_tests.sh unit` — 3929 passed; only the 5 known pre-existing failures on main (test_org_deletion x2, test_fixed_date_forecast, TestCoreCache x2)
- ruff check + format clean