### PR TITLE
fix(workers): worker_prefetch_multiplier=1 — stop cross-queue head-of-line blocking (CHAOS-2277)

### DIFF
--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -23,6 +23,15 @@ task_track_started = True
 task_time_limit = 3600  # 1 hour max per task
 task_soft_time_limit = 3300  # Soft limit at 55 minutes
 
+# Worker settings
+# Long-running tasks (sync, stream consumers) make prefetching dangerous:
+# with the default multiplier (4) a 2-slot worker reserves up to 8 messages,
+# and once those reservations fill with slow-queue messages the QoS window
+# never opens — newer messages on other queues (e.g. Sync Now on `sync`)
+# are never fetched until a restart releases the unacked reservations.
+# One-at-a-time fetching keeps cross-queue round-robin fair (CHAOS-2277).
+worker_prefetch_multiplier = 1
+
 # Retry settings
 task_default_retry_delay = 60  # 1 minute between retries
 task_max_retries = 3

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -23,3 +23,14 @@ def test_compose_worker_includes_backfill_queue() -> None:
 
 def test_celery_config_has_backfill_queue() -> None:
     assert "backfill" in task_queues
+
+
+def test_celery_worker_prefetch_multiplier_is_one() -> None:
+    """CHAOS-2277: long-running tasks (sync, stream consumers) + default
+    prefetch (4) let reserved slow-queue messages fill the QoS window and
+    block fetching from other queues entirely — Sync Now appeared stuck
+    until a worker restart released the unacked reservations. One-at-a-time
+    fetching keeps cross-queue round-robin fair."""
+    from dev_health_ops.workers.config import worker_prefetch_multiplier
+
+    assert worker_prefetch_multiplier == 1


### PR DESCRIPTION
## Problem
'Sync Now' tasks sat in the `sync` queue while the worker looked idle-ish; **restarting celery made them get picked up immediately** (key clue from Chris).

Mechanism: no `worker_prefetch_multiplier` configured → Celery default 4 → a `--concurrency=2` worker reserves up to 8 messages. The 30s-scheduled stream consumers (`run_ingest_consumer`/`run_product_telemetry_consumer`) hold slots ~250s each and had built a 26k-message `ingest` backlog, so the reservation window filled with ingest messages and the QoS window never opened — messages on `sync` were never fetched. Restart releases unacked reservations → fresh round-robin prefetch → sync runs. Classic head-of-line blocking for mixed-duration workloads.

## Fix
`worker_prefetch_multiplier = 1` in `workers/config.py` (the standard setting for long-running tasks), with a regression test pinning it.

This is the proximate fix; the underlying consumer-task design (overlap-free 30s schedule, ~250s blocking runs, shared pool) is tracked in CHAOS-2277 and worker-topology separation is being discussed separately.

## Tests
- `tests/test_compose_config.py`: new `test_celery_worker_prefetch_multiplier_is_one` (3/3 pass)
- `mypy --install-types --non-interactive .` clean (1014 files)

Linear: CHAOS-2277