### PR TITLE
fix(sync): stagger batch sync fan-out to avoid GitHub secondary rate limits (CHAOS-2272)

### DIFF
--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -30,6 +30,11 @@ from dev_health_ops.workers.task_utils import (
 
 logger = logging.getLogger(__name__)
 
+# Seconds between the start of consecutive batches when fanning out per-repo
+# sync tasks. Staggering avoids hammering the provider API with every repo at
+# once (GitHub secondary rate limits, CHAOS-2272). Batch 0 starts immediately.
+BATCH_STAGGER_SECONDS = 60
+
 
 def _set_run_duration(run_record, completed_at: datetime) -> None:
     """Compute duration_seconds from started_at when available."""
@@ -432,6 +437,16 @@ def dispatch_batch_sync(
         ]
         total_batches = len(batches)
 
+        # Stagger batches so all repos don't sync concurrently: tasks in
+        # batch N start ~N*BATCH_STAGGER_SECONDS after dispatch. The single
+        # chord over all tasks is preserved so the callback still fires
+        # exactly once after every child completes.
+        for batch_index, batch in enumerate(batches):
+            if batch_index == 0:
+                continue
+            for child in batch:
+                child.set(countdown=batch_index * BATCH_STAGGER_SECONDS)
+
         all_tasks = [task for batch in batches for task in batch]
         chord(
             group(all_tasks),
@@ -475,6 +490,7 @@ def dispatch_batch_sync(
     bind=True,
     max_retries=3,
     queue="sync",
+    rate_limit="30/m",
     name="dev_health_ops.workers.tasks._run_sync_for_repo",
 )
 def _run_sync_for_repo(

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -529,6 +529,74 @@ class TestDispatchBatchSync:
         assert result["total_repos"] == 7
         assert result["batch_count"] == 4
 
+    @patch("dev_health_ops.workers.sync_batch.chord")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_staggers_batches_with_countdown(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_chord,
+        db_session,
+    ):
+        from dev_health_ops.workers.sync_batch import (
+            BATCH_STAGGER_SECONDS,
+            _batch_sync_callback,
+            dispatch_batch_sync,
+        )
+
+        config = _make_config(
+            provider="github",
+            sync_options={"search": "org/*", "batch_size": 2},
+            sync_targets=["git"],
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        mock_get_session.return_value = _fake_session_ctx(db_session)
+        mock_resolve_creds.return_value = {"token": "ghp_test"}
+        mock_discover.return_value = [("org", f"repo-{i}") for i in range(5)]
+        mock_chord.return_value = MagicMock()
+
+        task = dispatch_batch_sync
+        task.push_request(id="batch-dispatch-stagger")
+        try:
+            result = task(config_id=str(config.id), org_id="default")
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "dispatched"
+        assert result["batch_count"] == 3
+
+        args, _ = mock_chord.call_args
+        header_group, callback = args[0], args[1]
+        signatures = list(header_group.tasks)
+
+        # Total dispatched count unchanged: one task per repo.
+        assert len(signatures) == 5
+
+        # Batch 0 starts immediately (no countdown); batch N is staggered.
+        expected_countdowns = [
+            None,
+            None,
+            BATCH_STAGGER_SECONDS,
+            BATCH_STAGGER_SECONDS,
+            2 * BATCH_STAGGER_SECONDS,
+        ]
+        actual_countdowns = [sig.options.get("countdown") for sig in signatures]
+        assert actual_countdowns == expected_countdowns
+
+        # Chord callback still attached with unchanged kwargs.
+        assert callback.task == _batch_sync_callback.name
+        assert callback.kwargs == {
+            "provider": "github",
+            "sync_targets": ["git"],
+            "org_id": "default",
+            "run_id": None,
+        }
+
     @patch("dev_health_ops.workers.sync_batch._run_sync_for_repo")
     @patch("dev_health_ops.workers.sync_batch.chord")
     @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
@@ -981,6 +1049,11 @@ class TestTaskRegistration:
         from dev_health_ops.workers.sync_batch import _run_sync_for_repo
 
         assert _run_sync_for_repo.queue == "sync"
+
+    def test_run_sync_for_repo_rate_limit(self):
+        from dev_health_ops.workers.sync_batch import _run_sync_for_repo
+
+        assert _run_sync_for_repo.rate_limit == "30/m"
 
 
 class TestInjectProviderToken:

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -588,13 +588,15 @@ class TestDispatchBatchSync:
         actual_countdowns = [sig.options.get("countdown") for sig in signatures]
         assert actual_countdowns == expected_countdowns
 
-        # Chord callback still attached with unchanged kwargs.
+        # Chord callback still attached with unchanged kwargs (config_id
+        # added by CHAOS-2267/#852 so the callback can stamp last_sync_*).
         assert callback.task == _batch_sync_callback.name
         assert callback.kwargs == {
             "provider": "github",
             "sync_targets": ["git"],
             "org_id": "default",
             "run_id": None,
+            "config_id": str(config.id),
         }
 
     @patch("dev_health_ops.workers.sync_batch._run_sync_for_repo")


### PR DESCRIPTION
Fixes CHAOS-2272.

## Problem

`dispatch_batch_sync` chunked `child_tasks` into batches of `batch_size`, then immediately flattened them (`all_tasks = [task for batch in batches for task in batch]`) and dispatched a single `chord(group(all_tasks), ...)`. Batching was computed and thrown away — every per-repo task was enqueued simultaneously. A 20-repo "Sync Now" meant 20 concurrent GitHub syncs, tripping secondary rate limits (observed 403s with ~600s backoffs) and starving the sync queue.

## Fix

- **Stagger batch starts**: tasks in batch N get `countdown=N * BATCH_STAGGER_SECONDS` (new module constant, 60s) via `Signature.set()` before the chord header is built. Batch 0 starts immediately. The same `_get_batch_size` chunks (sync_options `batch_size` → `SYNC_BATCH_SIZE` env → default 5) drive the stagger.
- **Chord semantics preserved**: still one chord over all tasks, so `_batch_sync_callback` fires exactly once after all children complete, with unchanged kwargs. Verified against Celery 5.6.3: `group._apply_tasks` applies each header signature with its own merged options, so the countdown publishes as a message `eta`; confirmed empirically with an in-memory broker (batch-0 messages have `eta=None`, batch-N messages have a future eta). Chord completion counting is backend-side and ETA-agnostic.
- **`rate_limit="30/m"` on `_run_sync_for_repo`** so scheduler-triggered replays are throttled per worker too.

## Tests

New `test_staggers_batches_with_countdown` (batch_size=2, 5 repos): batch 0 signatures carry no countdown, batch 1 gets 60s, batch 2 gets 120s; callback is `_batch_sync_callback` with unchanged kwargs; total dispatched count unchanged. Plus a `rate_limit` registration assert.

- `uv run mypy --install-types --non-interactive .` — clean (1009 files)
- `tests/test_sync_partitioning.py` — 63 passed
- `./ci/run_tests.sh unit` — 3923 passed; only the 4 known pre-existing failures (test_org_deletion ×2, TestCoreCache ×2)

## Merge-conflict note

PR #852 (`chaos-2267-batch-sync-jobrun-state`) also touches `sync_batch.py` (JobRun state helpers, `config_id` kwarg on `_batch_sync_callback`). This diff is kept tight to the chord-dispatch hunk (insertion between the `batches` computation and `all_tasks`) plus the `_run_sync_for_repo` decorator; whichever PR merges second may need a trivial rebase.