### PR TITLE
fix(workers): split Celery worker topology — latency / ingest / heavy pools (CHAOS-2278)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -195,7 +195,17 @@ services:
       retries: 3
       start_period: 30s
 
-  worker:
+  # ---------------------------------------------------------------------------
+  # Celery workers — split topology (CHAOS-2278)
+  #
+  # One shared pool let ~250s blocking stream consumers (ingest) and
+  # multi-minute syncs starve latency-sensitive work (Sync Now, webhooks)
+  # for hours. Three pools isolate the workload classes:
+  #   worker        — latency-sensitive: default,sync,webhooks,reports
+  #   worker-ingest — blocking stream consumers, isolated at concurrency 1
+  #   worker-heavy  — long batch jobs: metrics,backfill
+  # ---------------------------------------------------------------------------
+  worker: &worker-base
     build:
       context: .
       dockerfile: ./docker/Dockerfile
@@ -203,7 +213,7 @@ services:
       args:
         SETUPTOOLS_SCM_PRETEND_VERSION: 0.0.0
     container_name: worker
-    command: celery -A workers.celery_app worker --loglevel=info -Q default,metrics,sync,webhooks,backfill
+    command: celery -A workers.celery_app worker --loglevel=info -Q default,sync,webhooks,reports --concurrency=${WORKER_CONCURRENCY:-4}
     environment:
       <<: *env
       CELERY_BROKER_URL: redis://valkey:6379/0
@@ -222,6 +232,16 @@ services:
     volumes:
       - ./:/app
     working_dir: /app
+
+  worker-ingest:
+    <<: *worker-base
+    container_name: worker-ingest
+    command: celery -A workers.celery_app worker --loglevel=info -Q ingest --concurrency=1
+
+  worker-heavy:
+    <<: *worker-base
+    container_name: worker-heavy
+    command: celery -A workers.celery_app worker --loglevel=info -Q metrics,backfill --concurrency=${WORKER_HEAVY_CONCURRENCY:-2}
 
   # ---------------------------------------------------------------------------
   # Observability — SigNoz (distributed tracing + metrics)

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -7,18 +7,57 @@ import yaml
 from dev_health_ops.workers.config import task_queues
 
 
-def test_compose_worker_includes_backfill_queue() -> None:
+def _parse_queues(command_str: str) -> set[str]:
+    """Extract the -Q/--queues list from a celery worker command string."""
+    queues: set[str] = set()
+    tokens = command_str.split()
+    for i, token in enumerate(tokens):
+        if token in ("-Q", "--queues") and i + 1 < len(tokens):
+            queues.update(q for q in tokens[i + 1].split(",") if q)
+        elif token.startswith("--queues="):
+            queues.update(q for q in token.split("=", 1)[1].split(",") if q)
+        elif token.startswith("-Q") and len(token) > 2:
+            queues.update(q for q in token[2:].split(",") if q)
+    return queues
+
+
+def test_compose_workers_cover_every_celery_queue() -> None:
+    """CHAOS-2278: the union of -Q lists across all compose celery worker
+    services must cover every queue declared in workers.config.task_queues.
+
+    Guards against adding a queue (or a worker topology change) that leaves
+    a queue with no consumer — tasks routed there would silently never run.
+    The previous topology shipped exactly that bug: `ingest` and `reports`
+    existed in task_queues but no compose worker consumed them.
+    """
     compose_path = Path(__file__).resolve().parents[1] / "compose.yml"
     compose_data = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
 
-    worker_command = compose_data["services"]["worker"]["command"]
-    worker_command_str = (
-        " ".join(worker_command)
-        if isinstance(worker_command, list)
-        else str(worker_command)
-    )
+    consumed_queues: set[str] = set()
+    worker_services: list[str] = []
+    for name, service in compose_data["services"].items():
+        command = service.get("command")
+        if command is None:
+            continue
+        command_str = (
+            " ".join(str(part) for part in command)
+            if isinstance(command, list)
+            else str(command)
+        )
+        tokens = command_str.split()
+        if "celery" not in tokens or "worker" not in tokens:
+            continue
+        worker_services.append(name)
+        consumed_queues.update(_parse_queues(command_str))
 
-    assert "backfill" in worker_command_str
+    assert worker_services, "no celery worker services found in compose.yml"
+
+    missing = set(task_queues) - consumed_queues
+    assert not missing, (
+        f"queues declared in workers.config.task_queues but consumed by no "
+        f"compose worker service: {sorted(missing)} "
+        f"(workers: {sorted(worker_services)}, consumed: {sorted(consumed_queues)})"
+    )
 
 
 def test_celery_config_has_backfill_queue() -> None:


### PR DESCRIPTION
## Why

prefetch=1 (#854) fixes cross-queue head-of-line blocking at the message-fetch level, but one small shared pool still serves three incompatible workload classes: ~250s blocking stream consumers (`ingest`), multi-minute batch syncs/metrics, and instant webhooks/Sync Now. Latency variance stays pathological — in a real incident, Sync Now starved for hours behind batch work.

## What

Split the single `worker` service in `compose.yml` into three pools (same image/env/depends_on via YAML anchor):

| Service | Queues (`-Q`) | Concurrency |
|---|---|---|
| `worker` | `default,sync,webhooks,reports` | `${WORKER_CONCURRENCY:-4}` |
| `worker-ingest` | `ingest` | `1` (isolates blocking stream consumers) |
| `worker-heavy` | `metrics,backfill` | `${WORKER_HEAVY_CONCURRENCY:-2}` |

No changes to `workers/config.py` task routing or the beat schedule — this is purely consumer topology.

## Pre-existing gap fixed

The old `-Q default,metrics,sync,webhooks,backfill` omitted **`ingest` and `reports`** entirely, even though both exist in `workers.config.task_queues` — tasks routed to those queues never ran in this stack. The new topology covers them.

## Test

Replaced `test_compose_worker_includes_backfill_queue` with `test_compose_workers_cover_every_celery_queue`: parses every compose service whose command is a `celery … worker`, extracts each `-Q`/`--queues` list, and asserts the **union covers every queue in `workers.config.task_queues`**. Adding a queue without a compose consumer now fails CI. (`test_celery_config_has_backfill_queue` kept; file tail untouched so #854's appended prefetch test merges cleanly.)

## Deploy stacks

The paths `deploy/compose/dev-health-stack.yml` and `deploy/k8s/dev-health-stack/stack.yml` are **not tracked by this repo** (repo `deploy/` contains `docker-compose`, `docker-swarm`, `helm`, `kubernetes`). Those workspace-level stacks were intentionally left untouched; the repo-owned production stacks can get the same split in a follow-up if desired.

Note: `compose.yml` has no AUTO_RUN_MIGRATIONS handling on the worker (post-#850); the new services inherit the identical env block, so behavior parity holds.

## Gates

- `uv run mypy --install-types --non-interactive .` — clean (1011 files)
- `uv run pytest tests/test_compose_config.py -q` — 2 passed
- `./ci/run_tests.sh unit` — 3949 passed; only the 4 known pre-existing failures (test_org_deletion ×2, TestCoreCache ×2)
- `docker compose -f compose.yml config -q` — valid; rendered services verified (anchors + env interpolation resolve correctly)

Closes CHAOS-2278