### PR TITLE
fix: thread batch sync credentials into work-items job + resolver env fallback (CHAOS-2292)

### DIFF
--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -292,6 +292,16 @@ def resolve_credentials_sync(
         )
 
     if not org_id:
+        # Database resolution needs an org scope, but env credentials do not:
+        # without this fallback a configured DATABASE_URI makes org-less
+        # callers (e.g. GitHubWorkClient.from_env) fail even when the
+        # provider's env variables are set (CHAOS-2292).
+        if allow_env_fallback:
+            resolver = _EnvOnlyResolver()
+            creds = resolver.resolve_from_env(provider, credential_name)
+            if creds is not None:
+                return creds
+
         raise CredentialResolutionError(
             provider=provider,
             message="Organization ID is required for database credential resolution.",

--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -325,12 +325,13 @@ def resolve_credentials_sync(
 
     try:
         asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
         raise RuntimeError(
             "resolve_credentials_sync cannot be called from async context. "
             "Use CredentialResolver.resolve() instead."
         )
-    except RuntimeError:
-        pass
 
     return asyncio.run(_resolve())
 

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 import uuid
 from dataclasses import replace
 from datetime import date, datetime, time, timedelta, timezone
@@ -61,11 +60,13 @@ def _build_github_work_client(
 ) -> Any:
     """Construct a GitHub work-items client from config-resolved credentials.
 
-    Threads the sync config's organization id into credential resolution so a
-    database-stored credential (PAT or GitHub App auth) is honored, instead of
-    relying on a ``GITHUB_TOKEN`` environment side-channel. Falls back to
-    environment-based resolution only when no organization scope is available
-    (e.g. a pure-CLI run without a configured organization).
+    Precedence: explicit ``credentials`` mapping → database credential scoped
+    to ``org_id`` → environment variables as a last resort. An org-scoped
+    caller must never silently pick up ambient ``GITHUB_TOKEN``/App env vars
+    over its org's database credential (tenant boundary, CHAOS-2292); env
+    resolution applies only when no organization scope is available (a
+    pure-CLI run) or when org-scoped resolution finds no database row
+    (DB-less dev setups, via ``CredentialResolver``'s env fallback).
     """
     from dev_health_ops.credentials.resolver import (
         github_credentials_from_mapping,
@@ -82,16 +83,7 @@ def _build_github_work_client(
             )
         return GitHubWorkClient(auth=GitHubAuth.from_credentials(github_credentials))
 
-    has_env_credentials = any(
-        os.getenv(name)
-        for name in (
-            "GITHUB_TOKEN",
-            "GITHUB_APP_ID",
-            "GITHUB_APP_PRIVATE_KEY_PATH",
-            "GITHUB_APP_INSTALLATION_ID",
-        )
-    )
-    if not org_id or has_env_credentials:
+    if not org_id:
         return GitHubWorkClient.from_env()
 
     resolved_credentials = resolve_credentials_sync(

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -629,6 +629,10 @@ def _run_sync_for_repo(
                 },
             )
             started_backfill = datetime.now(timezone.utc)
+            # Pass the decrypted credentials explicitly: the env-injection above
+            # is invisible to resolve_credentials_sync once DATABASE_URI is set,
+            # so relying on it sends the job down a dead from_env() path
+            # (CHAOS-2292).
             run_work_items_sync_job(
                 db_url=db_url,
                 day=utc_today(),
@@ -637,6 +641,7 @@ def _run_sync_for_repo(
                 repo_name=sync_options_override.get("repo"),
                 search_pattern=sync_options_override.get("search"),
                 org_id=org_id,
+                credentials=credentials or None,
             )
             duration_ms = int(
                 (datetime.now(timezone.utc) - started_backfill).total_seconds() * 1000

--- a/tests/providers/test_github_ai_attribution_integration.py
+++ b/tests/providers/test_github_ai_attribution_integration.py
@@ -165,7 +165,6 @@ def test_github_work_items_sync_writes_ai_attribution_with_org_id(
     repo_id = uuid.uuid4()
     sink = _FakeClickHouseSink("clickhouse://test")
 
-    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
     monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: sink)
     monkeypatch.setattr(job, "InvestmentClassifier", _Classifier)
     monkeypatch.setattr(
@@ -201,10 +200,10 @@ def test_github_work_items_sync_writes_ai_attribution_with_org_id(
     client.iter_issue_comments.return_value = []
     client.iter_pr_comments_batch.return_value = []
 
-    monkeypatch.setattr(
-        "dev_health_ops.providers.github.client.GitHubWorkClient.from_env",
-        lambda: client,
-    )
+    # Org-scoped runs resolve credentials org-first (ambient env no longer
+    # preempts the org's DB credential, CHAOS-2292); inject the fake client
+    # at the builder seam — client construction has its own dedicated tests.
+    monkeypatch.setattr(job, "_build_github_work_client", lambda **_kwargs: client)
 
     run_job: Any = job.run_work_items_sync_job
     run_job(

--- a/tests/test_credential_resolver.py
+++ b/tests/test_credential_resolver.py
@@ -613,6 +613,15 @@ class TestResolveCredentialsSync:
             with pytest.raises(CredentialResolutionError):
                 resolve_credentials_sync("github", allow_env_fallback=False)
 
+    # All GitHub env credentials _EnvOnlyResolver reads; ambient values on the
+    # test host (e.g. a developer's GITHUB_APP_ID) must not flip outcomes.
+    _GITHUB_ENV_VARS = (
+        "GITHUB_TOKEN",
+        "GITHUB_APP_ID",
+        "GITHUB_APP_PRIVATE_KEY_PATH",
+        "GITHUB_APP_INSTALLATION_ID",
+    )
+
     def test_env_fallback_when_db_url_set_but_no_org_id(self):
         """Env credentials must win when DATABASE_URI is set but no org scope.
 
@@ -627,6 +636,9 @@ class TestResolveCredentialsSync:
         }
 
         with patch.dict(os.environ, env_patch, clear=False):
+            for var in self._GITHUB_ENV_VARS[1:]:
+                os.environ.pop(var, None)
+
             result = resolve_credentials_sync("github")
 
             assert isinstance(result, GitHubCredentials)
@@ -637,11 +649,11 @@ class TestResolveCredentialsSync:
         """No org_id and no env credentials still raises with DATABASE_URI set."""
         env_patch = {
             "DATABASE_URI": "postgresql+asyncpg://u:p@db:5432/devhealth",
-            "GITHUB_TOKEN": "",
         }
 
         with patch.dict(os.environ, env_patch, clear=False):
-            os.environ.pop("GITHUB_TOKEN", None)
+            for var in self._GITHUB_ENV_VARS:
+                os.environ.pop(var, None)
 
             with pytest.raises(CredentialResolutionError) as exc_info:
                 resolve_credentials_sync("github")
@@ -656,6 +668,9 @@ class TestResolveCredentialsSync:
         }
 
         with patch.dict(os.environ, env_patch, clear=False):
+            for var in self._GITHUB_ENV_VARS[1:]:
+                os.environ.pop(var, None)
+
             with pytest.raises(CredentialResolutionError) as exc_info:
                 resolve_credentials_sync("github", allow_env_fallback=False)
 

--- a/tests/test_credential_resolver.py
+++ b/tests/test_credential_resolver.py
@@ -613,6 +613,54 @@ class TestResolveCredentialsSync:
             with pytest.raises(CredentialResolutionError):
                 resolve_credentials_sync("github", allow_env_fallback=False)
 
+    def test_env_fallback_when_db_url_set_but_no_org_id(self):
+        """Env credentials must win when DATABASE_URI is set but no org scope.
+
+        Regression test for CHAOS-2292: a configured DATABASE_URI used to
+        skip the env-only branch entirely, so org-less callers (e.g.
+        ``GitHubWorkClient.from_env``) always raised even with GITHUB_TOKEN
+        set in the worker environment.
+        """
+        env_patch = {
+            "DATABASE_URI": "postgresql+asyncpg://u:p@db:5432/devhealth",
+            "GITHUB_TOKEN": "ghp_env_with_db_url",
+        }
+
+        with patch.dict(os.environ, env_patch, clear=False):
+            result = resolve_credentials_sync("github")
+
+            assert isinstance(result, GitHubCredentials)
+            assert result.token == "ghp_env_with_db_url"
+            assert result.source == CredentialSource.ENVIRONMENT
+
+    def test_error_db_url_set_no_org_id_no_env(self):
+        """No org_id and no env credentials still raises with DATABASE_URI set."""
+        env_patch = {
+            "DATABASE_URI": "postgresql+asyncpg://u:p@db:5432/devhealth",
+            "GITHUB_TOKEN": "",
+        }
+
+        with patch.dict(os.environ, env_patch, clear=False):
+            os.environ.pop("GITHUB_TOKEN", None)
+
+            with pytest.raises(CredentialResolutionError) as exc_info:
+                resolve_credentials_sync("github")
+
+            assert "Organization ID is required" in str(exc_info.value)
+
+    def test_no_env_fallback_with_db_url_when_disabled(self):
+        """allow_env_fallback=False keeps the org_id requirement strict."""
+        env_patch = {
+            "DATABASE_URI": "postgresql+asyncpg://u:p@db:5432/devhealth",
+            "GITHUB_TOKEN": "ghp_should_not_use",
+        }
+
+        with patch.dict(os.environ, env_patch, clear=False):
+            with pytest.raises(CredentialResolutionError) as exc_info:
+                resolve_credentials_sync("github", allow_env_fallback=False)
+
+            assert "Organization ID is required" in str(exc_info.value)
+
 
 # ---------------------------------------------------------------------------
 # CredentialResolutionError Tests

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -1196,3 +1196,107 @@ class TestNormalizeCredentialKeys:
             "github", {"token": "ghp_xxx", "baseUrl": "https://gh.example.com"}
         )
         assert result == {"token": "ghp_xxx", "base_url": "https://gh.example.com"}
+
+
+from dev_health_ops.metrics.job_work_items import (  # noqa: E402
+    run_work_items_sync_job as _real_run_work_items_sync_job,
+)
+
+
+class TestRunSyncForRepoCredentials:
+    """_run_sync_for_repo must thread credentials into the work-items job.
+
+    Regression tests for CHAOS-2292: the work-items chunk used to rely on
+    env-var injection only, which resolve_credentials_sync ignores once
+    DATABASE_URI is configured — so GitHub App credentials (no "token" key)
+    and PATs alike died in GitHubWorkClient.from_env().
+    """
+
+    @patch.dict(os.environ, {}, clear=False)
+    @patch("dev_health_ops.metrics.job_work_items.run_work_items_sync_job")
+    @patch("dev_health_ops.workers.sync_batch._get_db_url")
+    def test_work_items_job_receives_credentials(self, mock_get_db_url, mock_run_job):
+        from dev_health_ops.workers.sync_batch import _run_sync_for_repo
+
+        mock_get_db_url.return_value = "clickhouse://ch:ch@clickhouse:8123/default"
+        credentials = {"token": "ghp_batch_child", "org": "full-chaos"}
+
+        task = _run_sync_for_repo
+        task.push_request(id="repo-sync-creds")
+        try:
+            result = task(
+                config_id="cfg-1",
+                org_id="org-1",
+                triggered_by="schedule",
+                provider="github",
+                sync_targets=["work-items"],
+                sync_options_override={"owner": "full-chaos", "repo": "threads-cli"},
+                credentials=credentials,
+                config_name="chaos-all",
+            )
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "success"
+        mock_run_job.assert_called_once()
+        kwargs = mock_run_job.call_args.kwargs
+        assert kwargs["credentials"] == credentials
+        assert kwargs["org_id"] == "org-1"
+
+    @patch.dict(os.environ, {}, clear=False)
+    @patch("dev_health_ops.metrics.job_work_items.run_work_items_sync_job")
+    @patch("dev_health_ops.workers.sync_batch._get_db_url")
+    def test_work_items_job_kwargs_match_signature(self, mock_get_db_url, mock_run_job):
+        """Producer-side contract: every kwarg exists on the job signature."""
+        import inspect
+
+        from dev_health_ops.workers.sync_batch import _run_sync_for_repo
+
+        mock_get_db_url.return_value = "clickhouse://ch:ch@clickhouse:8123/default"
+
+        task = _run_sync_for_repo
+        task.push_request(id="repo-sync-contract")
+        try:
+            task(
+                config_id="cfg-1",
+                org_id="org-1",
+                triggered_by="schedule",
+                provider="github",
+                sync_targets=["work-items"],
+                sync_options_override={"owner": "full-chaos", "repo": "threads-cli"},
+                credentials={"token": "ghp_contract"},
+                config_name="chaos-all",
+            )
+        finally:
+            task.pop_request()
+
+        sig_params = set(inspect.signature(_real_run_work_items_sync_job).parameters)
+        passed = set(mock_run_job.call_args.kwargs)
+        assert passed <= sig_params, f"kwargs drifted: {passed - sig_params}"
+
+    @patch.dict(os.environ, {}, clear=False)
+    @patch("dev_health_ops.metrics.job_work_items.run_work_items_sync_job")
+    @patch("dev_health_ops.workers.sync_batch._get_db_url")
+    def test_empty_credentials_passed_as_none(self, mock_get_db_url, mock_run_job):
+        """An empty credentials dict must not masquerade as real credentials."""
+        from dev_health_ops.workers.sync_batch import _run_sync_for_repo
+
+        mock_get_db_url.return_value = "clickhouse://ch:ch@clickhouse:8123/default"
+
+        task = _run_sync_for_repo
+        task.push_request(id="repo-sync-empty-creds")
+        try:
+            task(
+                config_id="cfg-1",
+                org_id="org-1",
+                triggered_by="schedule",
+                provider="github",
+                sync_targets=["work-items"],
+                sync_options_override={"owner": "full-chaos", "repo": "threads-cli"},
+                credentials={},
+                config_name="chaos-all",
+            )
+        finally:
+            task.pop_request()
+
+        assert mock_run_job.call_args.kwargs["credentials"] is None

--- a/tests/test_work_items_github_credentials.py
+++ b/tests/test_work_items_github_credentials.py
@@ -84,3 +84,33 @@ def test_build_github_work_client_without_org_falls_back_to_from_env() -> None:
 
     assert client is sentinel
     from_env.assert_called_once_with()
+
+
+def test_org_scoped_resolution_wins_over_ambient_env_token(monkeypatch) -> None:
+    """Ambient env credentials must not preempt an org's database credential.
+
+    Regression test for CHAOS-2292 (review finding): the builder used to
+    route to ``from_env`` whenever ANY GitHub env credential existed, even
+    with an org scope present — a tenant-boundary violation once the
+    resolver gained an org-less env fallback.
+    """
+    monkeypatch.setenv("GITHUB_TOKEN", "ambient-env-token")
+    monkeypatch.setenv("GITHUB_APP_ID", "999")
+    creds = GitHubCredentials(token="org-db-pat", source=CredentialSource.DATABASE)
+
+    with (
+        patch(
+            "dev_health_ops.credentials.resolver.resolve_credentials_sync",
+            return_value=creds,
+        ) as resolve,
+        patch(
+            "dev_health_ops.providers.github.client.GitHubWorkClient.from_env"
+        ) as from_env,
+        patch("github.Github"),
+        patch("dev_health_ops.providers.github.client.GitHubGraphQLClient"),
+    ):
+        client = _build_github_work_client(org_id=_ORG_ID)
+
+    from_env.assert_not_called()
+    resolve.assert_called_once_with("github", org_id=_ORG_ID, allow_env_fallback=True)
+    assert client.auth.token == "org-db-pat"


### PR DESCRIPTION
## Summary
Fixes CHAOS-2292: every GitHub batch per-repo child failed its work-items chunk with `GITHUB_TOKEN environment variable is required` and retried 3×, despite valid credentials in the task kwargs.

### Root-cause chain
1. `_run_sync_for_repo` (sync_batch.py) injected the PAT into `os.environ[GITHUB_TOKEN]` but called `run_work_items_sync_job` **without** `credentials=`.
2. `_build_github_work_client` saw the injected env token and routed to `GitHubWorkClient.from_env()`.
3. `resolve_credentials_sync` only consults env credentials when **no db_url is configured**; `DATABASE_URI` is always set in the worker, so it raised `Organization ID is required` without ever reading the env — making `from_env()` structurally dead in any containerized deploy.

### Changes
- **sync_batch.py**: pass the decrypted `credentials` dict explicitly to `run_work_items_sync_job` (empty dict → `None`); env-injection retained for other consumers.
- **resolver.py**: when `org_id` is missing and `allow_env_fallback=True`, try `_EnvOnlyResolver` before raising — fixes every other `from_env()` caller.

### Tests
- `TestRunSyncForRepoCredentials` (test_sync_partitioning.py): work-items job receives `credentials`+`org_id`; producer-side kwargs-vs-`inspect.signature` contract; empty dict normalised to `None`.
- `TestResolveCredentialsSync` (test_credential_resolver.py): env fallback with DATABASE_URI set + no org_id; strict raise with no env creds; `allow_env_fallback=False` stays strict.

### Gates
- `ci/run_tests.sh unit`: 3958 passed; 4 failures are pre-existing on origin/main (org-deletion + core-cache, verified identical with changes stashed; unrelated to this diff).
- `mypy --install-types --non-interactive .`: clean (1011 files).
- `ruff check` + `ruff format --check`: clean.