### PR TITLE
fix(linear): bound 429 retries with shared rate-limit gate (CHAOS-2280)

### DIFF
--- a/src/dev_health_ops/providers/linear/client.py
+++ b/src/dev_health_ops/providers/linear/client.py
@@ -9,11 +9,39 @@ from typing import Any
 
 import httpx
 
+from dev_health_ops.connectors.utils.rate_limit_queue import (
+    RateLimitConfig,
+    RateLimitGate,
+)
+from dev_health_ops.providers._ratelimit import penalize_from_response
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 
 logger = logging.getLogger(__name__)
 
 LINEAR_API_URL = "https://api.linear.app/graphql"
+
+DEFAULT_MAX_ATTEMPTS = 5
+
+
+class LinearGraphQLError(RuntimeError):
+    """Linear returned GraphQL-level errors for a request.
+
+    Subclasses ``RuntimeError`` for backwards compatibility with callers
+    that previously caught the generic error raised here.
+    """
+
+
+class LinearComplexityLimitError(LinearGraphQLError):
+    """Linear rejected the query for exceeding its GraphQL complexity limit.
+
+    Not retryable: the query itself must be restructured (e.g. smaller
+    nested page sizes). See Linear's 10,000-complexity budget.
+    """
+
+
+class LinearRateLimitError(RuntimeError):
+    """Linear kept returning HTTP 429 after exhausting all retry attempts."""
+
 
 ISSUES_QUERY = """
 query Issues($first: Int!, $after: String, $filter: IssueFilter) {
@@ -321,9 +349,13 @@ class LinearClient:
         *,
         auth: LinearAuth,
         per_page: int = 50,
+        gate: RateLimitGate | None = None,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
     ) -> None:
         self.auth = auth
         self.per_page = max(1, min(100, int(per_page)))
+        self.gate = gate or RateLimitGate(RateLimitConfig(initial_backoff_seconds=1.0))
+        self.max_attempts = max(1, int(max_attempts))
         self._rate_limit: RateLimitInfo | None = None
         self._client = httpx.Client(
             headers={
@@ -348,30 +380,74 @@ class LinearClient:
         query: str,
         variables: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        self._wait_for_rate_limit()
-
         payload: dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = variables
 
-        response = self._client.post(LINEAR_API_URL, json=payload)
-        self._update_rate_limit(response)
+        last_delay = 0.0
+        for attempt in range(1, self.max_attempts + 1):
+            self.gate.wait_sync()
+            self._wait_for_rate_limit()
 
-        if response.status_code == 429:
-            retry_after = self._get_retry_after(response)
-            logger.warning("Linear rate limit hit, waiting %ds", retry_after)
-            time.sleep(retry_after)
-            return self._execute(query, variables)
+            response = self._client.post(LINEAR_API_URL, json=payload)
+            self._update_rate_limit(response)
 
-        response.raise_for_status()
-        data = response.json()
+            if response.status_code == 429:
+                # Respect Retry-After when present; otherwise the gate
+                # applies exponential backoff (1s * 2^n, capped at the
+                # gate's max_backoff_seconds).
+                last_delay = penalize_from_response(self.gate, response)
+                logger.warning(
+                    "Linear rate limit hit (attempt %d/%d), backing off %.1fs",
+                    attempt,
+                    self.max_attempts,
+                    last_delay,
+                )
+                continue
 
-        if "errors" in data:
-            errors = data["errors"]
-            error_msg = "; ".join(e.get("message", str(e)) for e in errors)
-            raise RuntimeError(f"Linear GraphQL error: {error_msg}")
+            body = self._parse_body(response)
 
-        return data.get("data", {})
+            # GraphQL-level errors (including complexity-limit rejections,
+            # which Linear returns as HTTP 400) are never retried.
+            errors = body.get("errors") if isinstance(body, dict) else None
+            if errors:
+                self._raise_graphql_errors(errors)
+
+            response.raise_for_status()
+            self.gate.reset()
+            data = body if isinstance(body, dict) else {}
+            return data.get("data") or {}
+
+        raise LinearRateLimitError(
+            f"Linear API rate limited: giving up after {self.max_attempts} "
+            f"attempts (last backoff {last_delay:.1f}s)"
+        )
+
+    @staticmethod
+    def _parse_body(response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _raise_graphql_errors(errors: list[dict[str, Any]]) -> None:
+        error_msg = "; ".join(e.get("message", str(e)) for e in errors)
+        if any(LinearClient._is_complexity_error(e) for e in errors):
+            raise LinearComplexityLimitError(
+                "Linear GraphQL complexity limit exceeded "
+                f"(query must be restructured, not retried): {error_msg}"
+            )
+        raise LinearGraphQLError(f"Linear GraphQL error: {error_msg}")
+
+    @staticmethod
+    def _is_complexity_error(error: dict[str, Any]) -> bool:
+        message = str(error.get("message", "")).lower()
+        if "complexity" in message or "too complex" in message:
+            return True
+        extensions = error.get("extensions") or {}
+        code = str(extensions.get("code", "")).upper()
+        return "COMPLEXITY" in code
 
     def _wait_for_rate_limit(self) -> None:
         if self._rate_limit is None:
@@ -400,15 +476,6 @@ class LinearClient:
                 "Headers: %s",
                 dict(headers),
             )
-
-    def _get_retry_after(self, response: httpx.Response) -> int:
-        try:
-            reset_ms = int(response.headers.get("X-RateLimit-Requests-Reset", 0))
-            now_ms = int(time.time() * 1000)
-            wait_s = max(1, (reset_ms - now_ms) // 1000 + 1)
-            return min(wait_s, 3600)
-        except (ValueError, TypeError):
-            return 60
 
     def iter_issues(
         self,

--- a/tests/test_linear_provider.py
+++ b/tests/test_linear_provider.py
@@ -932,6 +932,201 @@ class TestLinearProviderIngest:
         }
 
 
+class TestLinearClientRetry:
+    """Retry/backoff behaviour of LinearClient._execute (CHAOS-2280)."""
+
+    @staticmethod
+    def _make_client() -> Any:
+        from dev_health_ops.providers.linear.client import LinearAuth, LinearClient
+
+        return LinearClient(auth=LinearAuth(api_key="test-key"))
+
+    @staticmethod
+    def _response(
+        status_code: int,
+        *,
+        json_data: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
+        import httpx
+
+        from dev_health_ops.providers.linear.client import LINEAR_API_URL
+
+        return httpx.Response(
+            status_code,
+            json=json_data if json_data is not None else {},
+            headers=headers,
+            request=httpx.Request("POST", LINEAR_API_URL),
+        )
+
+    @pytest.fixture
+    def sleeps(self, monkeypatch: pytest.MonkeyPatch) -> list[float]:
+        recorded: list[float] = []
+        monkeypatch.setattr(
+            "time.sleep", lambda seconds: recorded.append(float(seconds))
+        )
+        return recorded
+
+    def test_429_retry_after_honored(self, sleeps: list[float]) -> None:
+        client = self._make_client()
+        client._client.post = MagicMock(
+            side_effect=[
+                self._response(429, headers={"Retry-After": "7"}),
+                self._response(200, json_data={"data": {"ok": True}}),
+            ]
+        )
+
+        result = client._execute("query { viewer { id } }")
+
+        assert result == {"ok": True}
+        assert client._client.post.call_count == 2
+        assert sleeps, "expected a backoff sleep after the 429"
+        assert sleeps[0] == pytest.approx(7.0, abs=0.5)
+
+    def test_429_retry_after_clamped_to_max_backoff(self, sleeps: list[float]) -> None:
+        client = self._make_client()
+        client._client.post = MagicMock(
+            side_effect=[
+                self._response(429, headers={"Retry-After": "100000"}),
+                self._response(200, json_data={"data": {}}),
+            ]
+        )
+
+        client._execute("query { viewer { id } }")
+
+        assert sleeps[0] == pytest.approx(300.0, abs=0.5)
+
+    def test_429_retries_bounded(self, sleeps: list[float]) -> None:
+        from dev_health_ops.providers.linear.client import LinearRateLimitError
+
+        client = self._make_client()
+        client._client.post = MagicMock(
+            side_effect=lambda *a, **kw: self._response(429)
+        )
+
+        with pytest.raises(LinearRateLimitError, match="giving up after 5 attempts"):
+            client._execute("query { viewer { id } }")
+
+        assert client._client.post.call_count == 5
+
+    def test_429_backoff_grows_exponentially(self, sleeps: list[float]) -> None:
+        from dev_health_ops.providers.linear.client import LinearRateLimitError
+
+        client = self._make_client()
+        client._client.post = MagicMock(
+            side_effect=lambda *a, **kw: self._response(429)
+        )
+
+        with pytest.raises(LinearRateLimitError):
+            client._execute("query { viewer { id } }")
+
+        # 5 attempts -> 4 backoff sleeps between attempts: ~1s, 2s, 4s, 8s.
+        assert len(sleeps) == 4
+        for expected, actual in zip([1.0, 2.0, 4.0, 8.0], sleeps, strict=True):
+            assert actual == pytest.approx(expected, abs=0.5)
+
+    def test_success_after_retry_resets_backoff(self, sleeps: list[float]) -> None:
+        client = self._make_client()
+        client._client.post = MagicMock(
+            side_effect=[
+                self._response(429),
+                self._response(200, json_data={"data": {"ok": 1}}),
+            ]
+        )
+
+        result = client._execute("query { viewer { id } }")
+
+        assert result == {"ok": 1}
+        # Gate backoff state is reset on success so the next 429 starts
+        # from the initial backoff again, not the escalated one.
+        assert client.gate._current_backoff == pytest.approx(1.0)
+
+    def test_graphql_error_not_retried(self, sleeps: list[float]) -> None:
+        from dev_health_ops.providers.linear.client import LinearGraphQLError
+
+        client = self._make_client()
+        client._client.post = MagicMock(
+            return_value=self._response(
+                200, json_data={"errors": [{"message": "boom"}]}
+            )
+        )
+
+        with pytest.raises(LinearGraphQLError, match="boom"):
+            client._execute("query { viewer { id } }")
+
+        assert client._client.post.call_count == 1
+
+    def test_graphql_error_is_runtime_error_for_back_compat(self) -> None:
+        from dev_health_ops.providers.linear.client import LinearGraphQLError
+
+        assert issubclass(LinearGraphQLError, RuntimeError)
+
+    def test_complexity_error_raises_distinct_type_without_retry(
+        self, sleeps: list[float]
+    ) -> None:
+        from dev_health_ops.providers.linear.client import LinearComplexityLimitError
+
+        client = self._make_client()
+        client._client.post = MagicMock(
+            return_value=self._response(
+                400,
+                json_data={
+                    "errors": [
+                        {
+                            "message": (
+                                "Query too complex to execute. Complexity 13145 "
+                                "exceeds maximum complexity of 10000."
+                            )
+                        }
+                    ]
+                },
+            )
+        )
+
+        with pytest.raises(LinearComplexityLimitError, match="restructured"):
+            client._execute("query { everything }")
+
+        assert client._client.post.call_count == 1
+
+    def test_complexity_error_detected_via_extensions_code(
+        self, sleeps: list[float]
+    ) -> None:
+        from dev_health_ops.providers.linear.client import LinearComplexityLimitError
+
+        client = self._make_client()
+        client._client.post = MagicMock(
+            return_value=self._response(
+                400,
+                json_data={
+                    "errors": [
+                        {
+                            "message": "Request rejected.",
+                            "extensions": {"code": "COMPLEXITY_TOO_HIGH"},
+                        }
+                    ]
+                },
+            )
+        )
+
+        with pytest.raises(LinearComplexityLimitError):
+            client._execute("query { everything }")
+
+        assert client._client.post.call_count == 1
+
+    def test_http_error_without_graphql_errors_raises(
+        self, sleeps: list[float]
+    ) -> None:
+        import httpx
+
+        client = self._make_client()
+        client._client.post = MagicMock(return_value=self._response(500))
+
+        with pytest.raises(httpx.HTTPStatusError):
+            client._execute("query { viewer { id } }")
+
+        assert client._client.post.call_count == 1
+
+
 class TestLinearClientInlineQuery:
     def test_issues_query_includes_inline_history(self) -> None:
         from dev_health_ops.providers.linear.client import ISSUES_QUERY


### PR DESCRIPTION
## Summary

`LinearClient._execute` retried HTTP 429 by **recursing with no depth limit and no exponential backoff** — sustained rate limiting could overflow the stack and hammer the API at a fixed cadence. GraphQL-level errors (including Linear's 10,000-complexity rejections, see 43b6d4977) were raised as bare `RuntimeError` with no categorization.

## Changes

- **Bounded retry loop** (5 attempts, `max_attempts` ctor param) replaces the unbounded recursion. Exhaustion raises `LinearRateLimitError` with attempt count and last backoff.
- **Shared rate-limit infrastructure** (mirrors `JiraClient`): injectable `RateLimitGate` (default `RateLimitConfig(initial_backoff_seconds=1.0)`), `gate.wait_sync()` before each request, `penalize_from_response()` on 429 (honors `Retry-After`, clamped to 300s; otherwise exponential 1s·2ⁿ capped at 300s), `gate.reset()` on success.
- **GraphQL error categorization**: `LinearGraphQLError` (subclasses `RuntimeError` for back-compat) and `LinearComplexityLimitError` for complexity-limit rejections (HTTP 400) — never retried since they require query restructuring.
- Proactive header-based throttling (`X-RateLimit-Requests-*`) preserved unchanged.

## Tests

New `TestLinearClientRetry` (9 tests, mocked httpx responses): Retry-After honored + clamped, retries bounded at 5, exponential backoff growth (1/2/4/8s), success-after-retry resets gate backoff, GraphQL and complexity errors raised without retry, non-429 HTTP errors propagate.

## Gates

- `uv run mypy --install-types --non-interactive .` — clean (1011 files)
- `ci/run_tests.sh unit` — 4000 tests, 4 failures, all known pre-existing (test_org_deletion ×2, TestCoreCache ×2)

Fixes CHAOS-2280