### PR TITLE
fix(admin): provider-shaped child sync_options in batch sync-config create (CHAOS-2283)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any, Protocol, cast
 
@@ -34,6 +35,8 @@ from dev_health_ops.models.settings import (
 from dev_health_ops.workers.sync_batch import _is_batch_eligible
 
 from .common import get_session
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -137,6 +140,7 @@ PROVIDER_SYNC_TARGETS: dict[str, list[str]] = {
 
 NON_REPO_SYNC_PROVIDERS = {"jira", "linear"}
 DEFAULT_SYNC_CRON = "0 * * * *"
+DEFAULT_GITLAB_URL = "https://gitlab.com"
 
 
 def _sync_options_with_top_level_fields(
@@ -265,19 +269,31 @@ async def _resolve_gitlab_batch_projects(
     session: AsyncSession,
     org_id: str,
     payload: SyncConfigBatchCreate,
-) -> dict[str, tuple[int, str]]:
+) -> tuple[dict[str, tuple[int, str]], str]:
     """Resolve batch ``repos`` entries to GitLab ``(project_id, child_name)``.
 
-    Numeric entries are treated as project ids directly. Name entries are
-    resolved by listing the group's projects through the stored credential;
-    unknown or ambiguous names raise a 400.
+    Returns the resolved mapping plus the effective ``gitlab_url``, resolved
+    with the same precedence the credential resolver uses:
+    ``sync_options.gitlab_url`` → decrypted credential ``url`` → credential
+    ``config.url`` → ``https://gitlab.com``. The caller persists that URL into
+    parent/child options so children sync against the same instance used for
+    name resolution.
+
+    Name entries are resolved by listing the group's projects through the
+    stored credential; unknown or ambiguous names raise a 400. When a listing
+    is available, numeric entries that match a listed project *name* are
+    treated as names (a project literally named ``007`` must not be coerced
+    to project id 7); numeric entries matching no listed name keep project-id
+    semantics.
     """
     entries = list(dict.fromkeys(payload.repos))
     named = [r for r in entries if not r.strip().isdigit()]
+    numeric = [r for r in entries if r.strip().isdigit()]
     group = _gitlab_group_from_options(payload.sync_options)
 
     resolved: dict[str, tuple[int, str]] = {}
     by_id: dict[int, str] = {}
+    by_key: dict[str, list[tuple[int, str]]] = {}
 
     if named:
         if not payload.credential_id:
@@ -297,6 +313,12 @@ async def _resolve_gitlab_batch_projects(
                 ),
             )
 
+    # Resolve the effective GitLab instance URL up front (even for all-numeric
+    # batches) so self-hosted URLs stored on the credential are not lost.
+    option_url = str(payload.sync_options.get("gitlab_url") or "").strip()
+    gitlab_url = option_url or DEFAULT_GITLAB_URL
+    token: str | None = None
+    if payload.credential_id:
         creds_svc = IntegrationCredentialsService(session, org_id)
         decrypted, credential = await creds_svc.get_decrypted_credentials_by_id(
             payload.credential_id
@@ -304,30 +326,42 @@ async def _resolve_gitlab_batch_projects(
         if credential is None or decrypted is None:
             raise HTTPException(status_code=400, detail="Credential not found")
         token = decrypted.get("token")
-        if not token:
-            raise HTTPException(
-                status_code=400, detail="GitLab credential missing token"
-            )
         cred_config: dict[str, Any] = getattr(credential, "config") or {}
         gitlab_url = str(
-            payload.sync_options.get("gitlab_url")
+            option_url
             or decrypted.get("url")
             or cred_config.get("url")
-            or "https://gitlab.com"
+            or DEFAULT_GITLAB_URL
         )
 
+    if named and not token:
+        raise HTTPException(status_code=400, detail="GitLab credential missing token")
+
+    # List the group's projects when name entries require it, and also
+    # opportunistically when numeric entries could shadow project names.
+    should_list = bool(named) or (bool(numeric) and bool(token) and bool(group))
+    if should_list:
         from dev_health_ops.connectors.gitlab import GitLabConnector
 
         connector = GitLabConnector(url=gitlab_url, private_token=str(token))
         try:
             projects = connector.list_repositories(org_name=group)
         except Exception as exc:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Failed to list GitLab projects for group '{group}': {exc}",
+            if named:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Failed to list GitLab projects for group '{group}': {exc}",
+                )
+            # All-numeric batch: keep historical id semantics when the listing
+            # is unavailable, but log so shadowed names are diagnosable.
+            logger.warning(
+                "GitLab batch create: failed to list projects for group %r to "
+                "cross-check numeric entries; treating them as project ids: %s",
+                group,
+                exc,
             )
+            projects = []
 
-        by_key: dict[str, list[tuple[int, str]]] = {}
         for project in projects:
             entry = (int(project.id), project.full_name or project.name)
             by_id[entry[0]] = entry[1]
@@ -335,8 +369,11 @@ async def _resolve_gitlab_batch_projects(
                 if key:
                     by_key.setdefault(key, []).append(entry)
 
+        # Numeric entries matching a listed project name are names, not ids.
+        named_like = named + [r for r in numeric if r in by_key]
+
         missing = [r for r in named if r not in by_key]
-        ambiguous = [r for r in named if len(by_key.get(r, [])) > 1]
+        ambiguous = [r for r in named_like if len(by_key.get(r, [])) > 1]
         if missing or ambiguous:
             parts = []
             if missing:
@@ -351,7 +388,7 @@ async def _resolve_gitlab_batch_projects(
                 detail=f"Could not resolve GitLab projects — {'; '.join(parts)}",
             )
 
-        for repo in named:
+        for repo in named_like:
             resolved[repo] = by_key[repo][0]
 
     for repo in entries:
@@ -363,7 +400,7 @@ async def _resolve_gitlab_batch_projects(
         )
         resolved[repo] = (project_id, child_name)
 
-    return resolved
+    return resolved, gitlab_url
 
 
 @router.post(
@@ -384,11 +421,21 @@ async def batch_create_sync_configs(
       (and ``gitlab_url`` when present in the parent options), matching what
       the sync runtime expects (``workers/sync_runtime.py`` requires
       ``project_id``). ``payload.repos`` entries may be either numeric GitLab
-      project ids (used as-is) or project names, which are resolved to ids by
-      listing the group's projects via the stored credential. Name entries
-      therefore require ``credential_id`` and a ``group``/``owner`` in
-      ``sync_options``; unknown or ambiguous names are rejected with a 400.
-      Child name is the project's ``path_with_namespace`` when known.
+      project ids or project names, which are resolved to ids by listing the
+      group's projects via the stored credential. Name entries therefore
+      require ``credential_id`` and a ``group``/``owner`` in ``sync_options``;
+      unknown or ambiguous names are rejected with a 400. When a credential
+      and group are available the listing also cross-checks numeric entries:
+      a numeric entry matching a listed project *name* is resolved as a name
+      (so a project literally named ``007`` is not coerced to project id 7),
+      and only entries matching no listed name keep id semantics. Without a
+      credential, an all-numeric ``repos`` list is the escape hatch: entries
+      are used as project ids as-is, with no listing call. The effective
+      ``gitlab_url`` (``sync_options.gitlab_url`` → credential ``url`` →
+      ``https://gitlab.com``) is persisted into parent and child options when
+      it is not the public default, so self-hosted children sync against the
+      same instance used for resolution. Child name is the project's
+      ``path_with_namespace`` when known.
     """
     svc = SyncConfigurationService(session, org_id)
 
@@ -419,6 +466,19 @@ async def batch_create_sync_configs(
         parent_options["timezone"] = payload.timezone
     if payload.initial_sync_depth is not None:
         parent_options["initial_sync_depth"] = payload.initial_sync_depth
+
+    # Resolve GitLab repos (and the effective instance URL) before creating
+    # the parent so a self-hosted gitlab_url derived from the credential is
+    # persisted into both parent and child options — otherwise children with
+    # a valid project_id would later sync against the gitlab.com default.
+    gitlab_projects: dict[str, tuple[int, str]] = {}
+    if provider == "gitlab" and payload.repos:
+        gitlab_projects, effective_gitlab_url = await _resolve_gitlab_batch_projects(
+            session, org_id, payload
+        )
+        if effective_gitlab_url != DEFAULT_GITLAB_URL:
+            parent_options["gitlab_url"] = effective_gitlab_url
+
     parent = SyncConfiguration(
         name=payload.name,
         provider=payload.provider,
@@ -434,10 +494,6 @@ async def batch_create_sync_configs(
     await session.flush()  # need parent.id for children
 
     # Create child configs (one per repo)
-    gitlab_projects: dict[str, tuple[int, str]] = {}
-    if provider == "gitlab" and payload.repos:
-        gitlab_projects = await _resolve_gitlab_batch_projects(session, org_id, payload)
-
     children = []
     for repo_name in payload.repos:
         child_options = dict(parent_options)
@@ -452,8 +508,9 @@ async def batch_create_sync_configs(
             group = _gitlab_group_from_options(payload.sync_options)
             if group:
                 child_options["group"] = group
-            # gitlab_url (if present in parent options) passes through via
-            # the dict(parent_options) copy above.
+            # gitlab_url passes through via the dict(parent_options) copy
+            # above — including the credential-derived URL persisted into
+            # parent_options before parent creation.
         else:
             child_options["repo"] = repo_name
             owner = (

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -19,7 +19,10 @@ from dev_health_ops.api.admin.schemas import (
     SyncConfigResponse,
     SyncConfigUpdate,
 )
-from dev_health_ops.api.services.configuration import SyncConfigurationService
+from dev_health_ops.api.services.configuration import (
+    IntegrationCredentialsService,
+    SyncConfigurationService,
+)
 from dev_health_ops.api.services.licensing import TierLimitService
 from dev_health_ops.models.settings import (
     JobRun,
@@ -248,6 +251,121 @@ async def list_sync_configs(
     return results
 
 
+def _gitlab_group_from_options(sync_options: dict[str, Any]) -> str:
+    """Extract the GitLab group/namespace from batch sync options.
+
+    The web form submits the namespace under ``owner`` (shared field with
+    GitHub); API callers may use ``group`` directly.
+    """
+    group = sync_options.get("group") or sync_options.get("owner") or ""
+    return str(group).strip()
+
+
+async def _resolve_gitlab_batch_projects(
+    session: AsyncSession,
+    org_id: str,
+    payload: SyncConfigBatchCreate,
+) -> dict[str, tuple[int, str]]:
+    """Resolve batch ``repos`` entries to GitLab ``(project_id, child_name)``.
+
+    Numeric entries are treated as project ids directly. Name entries are
+    resolved by listing the group's projects through the stored credential;
+    unknown or ambiguous names raise a 400.
+    """
+    entries = list(dict.fromkeys(payload.repos))
+    named = [r for r in entries if not r.strip().isdigit()]
+    group = _gitlab_group_from_options(payload.sync_options)
+
+    resolved: dict[str, tuple[int, str]] = {}
+    by_id: dict[int, str] = {}
+
+    if named:
+        if not payload.credential_id:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "GitLab batch create requires credential_id to resolve "
+                    "project names to project ids"
+                ),
+            )
+        if not group:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "GitLab batch create requires a group (sync_options.group "
+                    "or sync_options.owner) to resolve project names"
+                ),
+            )
+
+        creds_svc = IntegrationCredentialsService(session, org_id)
+        decrypted, credential = await creds_svc.get_decrypted_credentials_by_id(
+            payload.credential_id
+        )
+        if credential is None or decrypted is None:
+            raise HTTPException(status_code=400, detail="Credential not found")
+        token = decrypted.get("token")
+        if not token:
+            raise HTTPException(
+                status_code=400, detail="GitLab credential missing token"
+            )
+        cred_config: dict[str, Any] = getattr(credential, "config") or {}
+        gitlab_url = str(
+            payload.sync_options.get("gitlab_url")
+            or decrypted.get("url")
+            or cred_config.get("url")
+            or "https://gitlab.com"
+        )
+
+        from dev_health_ops.connectors.gitlab import GitLabConnector
+
+        connector = GitLabConnector(url=gitlab_url, private_token=str(token))
+        try:
+            projects = connector.list_repositories(org_name=group)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Failed to list GitLab projects for group '{group}': {exc}",
+            )
+
+        by_key: dict[str, list[tuple[int, str]]] = {}
+        for project in projects:
+            entry = (int(project.id), project.full_name or project.name)
+            by_id[entry[0]] = entry[1]
+            for key in {project.name, project.full_name}:
+                if key:
+                    by_key.setdefault(key, []).append(entry)
+
+        missing = [r for r in named if r not in by_key]
+        ambiguous = [r for r in named if len(by_key.get(r, [])) > 1]
+        if missing or ambiguous:
+            parts = []
+            if missing:
+                parts.append(f"not found in group '{group}': {', '.join(missing)}")
+            if ambiguous:
+                parts.append(
+                    "ambiguous (multiple projects share this name, use the "
+                    f"full path): {', '.join(ambiguous)}"
+                )
+            raise HTTPException(
+                status_code=400,
+                detail=f"Could not resolve GitLab projects — {'; '.join(parts)}",
+            )
+
+        for repo in named:
+            resolved[repo] = by_key[repo][0]
+
+    for repo in entries:
+        if repo in resolved:
+            continue
+        project_id = int(repo.strip())
+        child_name = by_id.get(
+            project_id, f"{group}/{project_id}" if group else str(project_id)
+        )
+        resolved[repo] = (project_id, child_name)
+
+    return resolved
+
+
 @router.post(
     "/sync-configs/batch", response_model=SyncConfigBatchResponse, status_code=201
 )
@@ -256,7 +374,22 @@ async def batch_create_sync_configs(
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> SyncConfigBatchResponse:
-    """Create a parent sync config + one child per repo."""
+    """Create a parent sync config + one child per repo.
+
+    Child ``sync_options`` are provider-shaped:
+
+    - **github**: each child carries ``repo`` (plus ``owner`` inherited from
+      the parent options); child name is ``{owner}/{repo}``.
+    - **gitlab**: each child carries an integer ``project_id`` plus ``group``
+      (and ``gitlab_url`` when present in the parent options), matching what
+      the sync runtime expects (``workers/sync_runtime.py`` requires
+      ``project_id``). ``payload.repos`` entries may be either numeric GitLab
+      project ids (used as-is) or project names, which are resolved to ids by
+      listing the group's projects via the stored credential. Name entries
+      therefore require ``credential_id`` and a ``group``/``owner`` in
+      ``sync_options``; unknown or ambiguous names are rejected with a 400.
+      Child name is the project's ``path_with_namespace`` when known.
+    """
     svc = SyncConfigurationService(session, org_id)
 
     # Enforce repo limit (existing + new repos)
@@ -301,10 +434,34 @@ async def batch_create_sync_configs(
     await session.flush()  # need parent.id for children
 
     # Create child configs (one per repo)
+    gitlab_projects: dict[str, tuple[int, str]] = {}
+    if provider == "gitlab" and payload.repos:
+        gitlab_projects = await _resolve_gitlab_batch_projects(session, org_id, payload)
+
     children = []
     for repo_name in payload.repos:
         child_options = dict(parent_options)
-        child_options["repo"] = repo_name
+        if provider == "gitlab":
+            project_id, child_name = gitlab_projects[repo_name]
+            # GitLab children are keyed by integer project_id (what the sync
+            # runtime dispatches on), not by GitHub-shaped owner/repo keys.
+            child_options.pop("owner", None)
+            child_options.pop("repo", None)
+            child_options.pop("search", None)
+            child_options["project_id"] = project_id
+            group = _gitlab_group_from_options(payload.sync_options)
+            if group:
+                child_options["group"] = group
+            # gitlab_url (if present in parent options) passes through via
+            # the dict(parent_options) copy above.
+        else:
+            child_options["repo"] = repo_name
+            owner = (
+                payload.sync_options.get("owner")
+                or payload.sync_options.get("group")
+                or payload.name
+            )
+            child_name = f"{owner}/{repo_name}"
         if payload.initial_sync_depth is not None:
             child_options["initial_sync_depth"] = payload.initial_sync_depth
         if payload.schedule_cron is not None:
@@ -312,13 +469,8 @@ async def batch_create_sync_configs(
         if payload.timezone is not None:
             child_options["timezone"] = payload.timezone
 
-        owner = (
-            payload.sync_options.get("owner")
-            or payload.sync_options.get("group")
-            or payload.name
-        )
         child = SyncConfiguration(
-            name=f"{owner}/{repo_name}",
+            name=child_name,
             provider=payload.provider,
             org_id=org_id,
             credential_id=uuid.UUID(payload.credential_id)

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -262,7 +262,9 @@ def _gitlab_group_from_options(sync_options: dict[str, Any]) -> str:
     GitHub); API callers may use ``group`` directly.
     """
     group = sync_options.get("group") or sync_options.get("owner") or ""
-    return str(group).strip()
+    # Strip CR/LF so the user-provided group can't forge log lines when it is
+    # interpolated into warnings (CodeQL: log injection).
+    return str(group).replace("\r", "").replace("\n", "").strip()
 
 
 async def _resolve_gitlab_batch_projects(

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -1015,3 +1015,170 @@ async def test_batch_create_gitlab_names_without_credential_returns_400(client):
 
     assert resp.status_code == 400
     assert "credential_id" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_batch_create_gitlab_credential_url_persisted_into_children(client):
+    """Self-hosted URL from the credential lands in parent + child options.
+
+    Regression: name resolution used the credential's self-hosted URL but
+    children only inherited a gitlab_url already present in parent options,
+    so they later synced against the gitlab.com runtime default.
+    """
+    ac, _ = client
+    credential_id = str(uuid.uuid4())
+
+    mock_creds_svc = MagicMock()
+    mock_creds_svc.get_decrypted_credentials_by_id = AsyncMock(
+        return_value=(
+            {"token": "glpat-test", "url": "https://gitlab.internal.example.com"},
+            MagicMock(config={}),
+        )
+    )
+    mock_connector = MagicMock()
+    mock_connector.list_repositories.return_value = [
+        _gitlab_project(101, "alpha", "acme-group/alpha"),
+    ]
+    mock_connector_cls = MagicMock(return_value=mock_connector)
+
+    with (
+        patch.object(
+            sync_router_module,
+            "IntegrationCredentialsService",
+            return_value=mock_creds_svc,
+        ),
+        patch(
+            "dev_health_ops.connectors.gitlab.GitLabConnector",
+            mock_connector_cls,
+        ),
+    ):
+        resp = await ac.post(
+            "/api/v1/admin/sync-configs/batch",
+            json={
+                "name": "gl-batch-selfhosted",
+                "provider": "gitlab",
+                "credential_id": credential_id,
+                "sync_targets": ["git"],
+                "sync_options": {"owner": "acme-group"},
+                "repos": ["alpha"],
+            },
+        )
+
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+
+    # Resolution used the credential's self-hosted URL...
+    mock_connector_cls.assert_called_once_with(
+        url="https://gitlab.internal.example.com", private_token="glpat-test"
+    )
+    # ...and that URL is persisted into both parent and child options.
+    assert (
+        data["parent"]["sync_options"]["gitlab_url"]
+        == "https://gitlab.internal.example.com"
+    )
+    child = data["children"][0]
+    assert child["sync_options"] == {
+        "gitlab_url": "https://gitlab.internal.example.com",
+        "project_id": 101,
+        "group": "acme-group",
+    }
+
+
+@pytest.mark.asyncio
+async def test_batch_create_gitlab_numeric_entry_matching_name_resolves_as_name(
+    client,
+):
+    """A numeric entry that matches a listed project NAME is a name, not an id."""
+    ac, _ = client
+    credential_id = str(uuid.uuid4())
+
+    mock_creds_svc = MagicMock()
+    mock_creds_svc.get_decrypted_credentials_by_id = AsyncMock(
+        return_value=({"token": "glpat-test"}, MagicMock(config={}))
+    )
+    mock_connector = MagicMock()
+    mock_connector.list_repositories.return_value = [
+        _gitlab_project(7007, "007", "acme-group/007"),
+        _gitlab_project(101, "alpha", "acme-group/alpha"),
+    ]
+
+    with (
+        patch.object(
+            sync_router_module,
+            "IntegrationCredentialsService",
+            return_value=mock_creds_svc,
+        ),
+        patch(
+            "dev_health_ops.connectors.gitlab.GitLabConnector",
+            MagicMock(return_value=mock_connector),
+        ),
+    ):
+        resp = await ac.post(
+            "/api/v1/admin/sync-configs/batch",
+            json={
+                "name": "gl-batch-numeric-name",
+                "provider": "gitlab",
+                "credential_id": credential_id,
+                "sync_targets": ["git"],
+                "sync_options": {"owner": "acme-group"},
+                "repos": ["007"],
+            },
+        )
+
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    mock_connector.list_repositories.assert_called_once_with(org_name="acme-group")
+
+    child = data["children"][0]
+    # Resolved via the listing as the project named "007" — NOT project id 7.
+    assert child["name"] == "acme-group/007"
+    assert child["sync_options"]["project_id"] == 7007
+
+
+@pytest.mark.asyncio
+async def test_batch_create_gitlab_numeric_entry_not_in_listing_used_as_id(client):
+    """A numeric entry matching no listed name keeps project-id semantics."""
+    ac, _ = client
+    credential_id = str(uuid.uuid4())
+
+    mock_creds_svc = MagicMock()
+    mock_creds_svc.get_decrypted_credentials_by_id = AsyncMock(
+        return_value=({"token": "glpat-test"}, MagicMock(config={}))
+    )
+    mock_connector = MagicMock()
+    mock_connector.list_repositories.return_value = [
+        _gitlab_project(101, "alpha", "acme-group/alpha"),
+    ]
+
+    with (
+        patch.object(
+            sync_router_module,
+            "IntegrationCredentialsService",
+            return_value=mock_creds_svc,
+        ),
+        patch(
+            "dev_health_ops.connectors.gitlab.GitLabConnector",
+            MagicMock(return_value=mock_connector),
+        ),
+    ):
+        resp = await ac.post(
+            "/api/v1/admin/sync-configs/batch",
+            json={
+                "name": "gl-batch-numeric-id",
+                "provider": "gitlab",
+                "credential_id": credential_id,
+                "sync_targets": ["git"],
+                "sync_options": {"owner": "acme-group"},
+                "repos": ["12345"],
+            },
+        )
+
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    # The listing WAS consulted (credential + group present)...
+    mock_connector.list_repositories.assert_called_once_with(org_name="acme-group")
+
+    child = data["children"][0]
+    # ...but "12345" matched no listed name, so it stays an id.
+    assert child["sync_options"]["project_id"] == 12345
+    assert child["name"] == "acme-group/12345"

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 import uuid
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -811,3 +811,207 @@ async def test_trigger_batch_creates_pending_job_run(client, session_maker):
     call_kwargs = mock_batch.delay.call_args.kwargs
     assert call_kwargs.get("pending_run_id") == run_id
     mock_run.delay.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Batch create — provider-shaped child sync_options (CHAOS-2283)
+# ---------------------------------------------------------------------------
+
+
+def _gitlab_project(project_id: int, name: str, full_name: str):
+    from dev_health_ops.connectors.models import Repository
+
+    return Repository(
+        id=project_id,
+        name=name,
+        full_name=full_name,
+        default_branch="main",
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_create_github_children_keep_owner_repo_options(client):
+    """Regression: GitHub child options remain owner/repo-shaped, unchanged."""
+    ac, _ = client
+
+    resp = await ac.post(
+        "/api/v1/admin/sync-configs/batch",
+        json={
+            "name": "gh-batch",
+            "provider": "github",
+            "sync_targets": ["git", "prs"],
+            "sync_options": {"owner": "acme"},
+            "repos": ["alpha", "beta"],
+            "schedule_cron": "0 3 * * *",
+        },
+    )
+
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["total_created"] == 2
+    assert [c["name"] for c in data["children"]] == ["acme/alpha", "acme/beta"]
+    for child, repo in zip(data["children"], ["alpha", "beta"]):
+        assert child["sync_options"] == {
+            "owner": "acme",
+            "schedule_cron": "0 3 * * *",
+            "repo": repo,
+        }
+
+
+@pytest.mark.asyncio
+async def test_batch_create_gitlab_children_get_project_id_and_group(client):
+    """GitLab children carry int project_id + group (+ gitlab_url), not repo."""
+    ac, _ = client
+    credential_id = str(uuid.uuid4())
+
+    mock_creds_svc = MagicMock()
+    mock_creds_svc.get_decrypted_credentials_by_id = AsyncMock(
+        return_value=({"token": "glpat-test"}, MagicMock(config={}))
+    )
+    mock_connector = MagicMock()
+    mock_connector.list_repositories.return_value = [
+        _gitlab_project(101, "alpha", "acme-group/alpha"),
+        _gitlab_project(202, "beta", "acme-group/sub/beta"),
+    ]
+    mock_connector_cls = MagicMock(return_value=mock_connector)
+
+    with (
+        patch.object(
+            sync_router_module,
+            "IntegrationCredentialsService",
+            return_value=mock_creds_svc,
+        ),
+        patch(
+            "dev_health_ops.connectors.gitlab.GitLabConnector",
+            mock_connector_cls,
+        ),
+    ):
+        resp = await ac.post(
+            "/api/v1/admin/sync-configs/batch",
+            json={
+                "name": "gl-batch",
+                "provider": "gitlab",
+                "credential_id": credential_id,
+                "sync_targets": ["git", "prs"],
+                "sync_options": {
+                    "owner": "acme-group",
+                    "gitlab_url": "https://gitlab.example.com",
+                },
+                "repos": ["alpha", "beta"],
+                "schedule_cron": "0 3 * * *",
+            },
+        )
+
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["total_created"] == 2
+
+    mock_connector_cls.assert_called_once_with(
+        url="https://gitlab.example.com", private_token="glpat-test"
+    )
+    mock_connector.list_repositories.assert_called_once_with(org_name="acme-group")
+
+    # Child names use path_with_namespace.
+    assert [c["name"] for c in data["children"]] == [
+        "acme-group/alpha",
+        "acme-group/sub/beta",
+    ]
+    for child, project_id in zip(data["children"], [101, 202]):
+        assert child["sync_options"] == {
+            "gitlab_url": "https://gitlab.example.com",
+            "schedule_cron": "0 3 * * *",
+            "project_id": project_id,
+            "group": "acme-group",
+        }
+        assert isinstance(child["sync_options"]["project_id"], int)
+        assert "repo" not in child["sync_options"]
+        assert "owner" not in child["sync_options"]
+
+
+@pytest.mark.asyncio
+async def test_batch_create_gitlab_numeric_ids_skip_resolution(client):
+    """Numeric repos entries are used as project ids without a credential."""
+    ac, _ = client
+
+    resp = await ac.post(
+        "/api/v1/admin/sync-configs/batch",
+        json={
+            "name": "gl-batch-ids",
+            "provider": "gitlab",
+            "sync_targets": ["git"],
+            "sync_options": {"group": "acme-group"},
+            "repos": ["123", "456"],
+        },
+    )
+
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["total_created"] == 2
+    assert [c["name"] for c in data["children"]] == [
+        "acme-group/123",
+        "acme-group/456",
+    ]
+    for child, project_id in zip(data["children"], [123, 456]):
+        assert child["sync_options"] == {
+            "group": "acme-group",
+            "project_id": project_id,
+        }
+
+
+@pytest.mark.asyncio
+async def test_batch_create_gitlab_unknown_project_name_returns_400(client):
+    ac, _ = client
+
+    mock_creds_svc = MagicMock()
+    mock_creds_svc.get_decrypted_credentials_by_id = AsyncMock(
+        return_value=({"token": "glpat-test"}, MagicMock(config={}))
+    )
+    mock_connector = MagicMock()
+    mock_connector.list_repositories.return_value = [
+        _gitlab_project(101, "alpha", "acme-group/alpha"),
+    ]
+
+    with (
+        patch.object(
+            sync_router_module,
+            "IntegrationCredentialsService",
+            return_value=mock_creds_svc,
+        ),
+        patch(
+            "dev_health_ops.connectors.gitlab.GitLabConnector",
+            MagicMock(return_value=mock_connector),
+        ),
+    ):
+        resp = await ac.post(
+            "/api/v1/admin/sync-configs/batch",
+            json={
+                "name": "gl-batch-missing",
+                "provider": "gitlab",
+                "credential_id": str(uuid.uuid4()),
+                "sync_targets": ["git"],
+                "sync_options": {"owner": "acme-group"},
+                "repos": ["ghost"],
+            },
+        )
+
+    assert resp.status_code == 400
+    assert "ghost" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_batch_create_gitlab_names_without_credential_returns_400(client):
+    ac, _ = client
+
+    resp = await ac.post(
+        "/api/v1/admin/sync-configs/batch",
+        json={
+            "name": "gl-batch-nocred",
+            "provider": "gitlab",
+            "sync_targets": ["git"],
+            "sync_options": {"owner": "acme-group"},
+            "repos": ["alpha"],
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "credential_id" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

Fixes CHAOS-2283: `POST /sync-configs/batch` wrote GitHub-shaped child option keys (`repo=<name>`) for **every** provider. GitLab children were therefore created without the integer `project_id` that the sync runtime requires (`sync_runtime.py` raises `Missing GitLab project_id in sync options`; `sync_batch.py` dispatch also keys GitLab children on `int(project_id)`), so they could never sync.

## Changes

- **Provider-conditional child option construction** in `batch_create_sync_configs`:
  - `github`: unchanged (regression-tested) — child carries `repo` plus inherited `owner`; name stays `{owner}/{repo}`.
  - `gitlab`: child carries int `project_id` + `group` (web form sends the namespace as `owner`; API callers may use `group`), with `gitlab_url` passing through from parent options. GitHub-shaped `owner`/`repo`/`search` keys are dropped. Child name uses `path_with_namespace` when known.
- **Payload contract** (documented in the endpoint docstring): `repos` entries may be numeric GitLab project ids (used as-is, no API call) or project names — the web `RepoSelector` sends names from `DiscoveredRepo.name`. Names are resolved to ids by listing the group's projects via the stored credential (same pattern as `GET /credentials/{id}/repos`, which feeds the selector). Unknown/ambiguous names, or name entries without `credential_id`/group, fail fast with 400 instead of persisting children that can never sync.

## Tests

`tests/api/admin/test_sync_configs.py` (+5):
- GitHub regression: exact child `sync_options` dict unchanged (`owner`/`repo`/`schedule_cron` only).
- GitLab: exact child keys (`project_id` int, `group`, `gitlab_url`, no `repo`/`owner`), names from `path_with_namespace`, connector called with credential token + `gitlab_url`.
- GitLab numeric ids: no credential/API call needed.
- GitLab unknown name → 400 naming the repo.
- GitLab names without credential → 400.

## Gates

- `mypy --install-types --non-interactive .` — clean (1011 files)
- `ruff check` / `ruff format` — clean
- `./ci/run_tests.sh unit` — 3957 passed; only failures are the 4 known pre-existing ignores (test_org_deletion ×2, TestCoreCache ×2)