### PR TITLE
fix(sync): sync-config edits persist + manual-only configs never auto-sync (CHAOS-2295, CHAOS-2297)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -153,6 +153,12 @@ def _sync_options_with_top_level_fields(
     return merged
 
 
+def _config_has_explicit_schedule(config: object) -> bool:
+    """True when the config carries a user-set schedule_cron (not manual-only)."""
+    sync_options = dict(getattr(config, "sync_options") or {})
+    return bool(sync_options.get("schedule_cron"))
+
+
 def _schedule_cron_for_config(config: object) -> str:
     sync_options = dict(getattr(config, "sync_options") or {})
     return str(sync_options.get("schedule_cron") or DEFAULT_SYNC_CRON)
@@ -176,9 +182,12 @@ async def _upsert_scheduled_job(
         "provider": provider,
         "sync_config_id": str(sync_config_id),
     }
+    # Manual-only configs (no explicit schedule_cron) must not auto-sync
+    # (CHAOS-2297). Keep the job row (manual triggers anchor JobRuns to it)
+    # but park it PAUSED; the stored cron is only a non-null placeholder.
     status = (
         JobStatus.ACTIVE.value
-        if getattr(config, "is_active")
+        if getattr(config, "is_active") and _config_has_explicit_schedule(config)
         else JobStatus.PAUSED.value
     )
     if job is None:
@@ -696,12 +705,11 @@ async def trigger_sync_config(
             if job is None:
                 _sync_options = dict(config.sync_options or {})
                 _provider = str(config.provider or "")
+                _explicit_cron = _sync_options.get("schedule_cron")
                 job = ScheduledJob(
                     name=f"sync-config-{config_uuid}",
                     job_type="sync",
-                    schedule_cron=str(
-                        _sync_options.get("schedule_cron") or "0 * * * *"
-                    ),
+                    schedule_cron=str(_explicit_cron or "0 * * * *"),
                     org_id=org_id,
                     provider=_provider,
                     job_config={
@@ -710,7 +718,13 @@ async def trigger_sync_config(
                     },
                     sync_config_id=config_uuid,
                     tz=str(_sync_options.get("timezone") or "UTC"),
-                    status=JobStatus.ACTIVE.value,
+                    # Manual-only configs keep the job row for JobRun anchoring
+                    # but must not be picked up by the scheduler (CHAOS-2297).
+                    status=(
+                        JobStatus.ACTIVE.value
+                        if bool(config.is_active) and _explicit_cron
+                        else JobStatus.PAUSED.value
+                    ),
                 )
                 sync_session.add(job)
                 sync_session.flush()

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -481,13 +481,30 @@ async def update_sync_config(
         raise HTTPException(status_code=404, detail="Sync configuration not found")
 
     # Fix 3 (MEDIUM) & Fix 4 (MEDIUM): Validate schedule_cron when updating sync_options.
-    sync_options = _sync_options_with_top_level_fields(
-        payload.sync_options,
-        schedule_cron=payload.schedule_cron,
-        timezone=payload.timezone,
-        initial_sync_depth=payload.initial_sync_depth,
+    # PATCH semantics for schedule fields: an explicitly provided null clears the
+    # stored value, while an omitted field leaves it untouched. Top-level fields
+    # own these keys and override any (possibly stale) copies nested inside
+    # payload.sync_options, so a stale client payload can never resurrect an old
+    # schedule.
+    provided_fields = payload.model_fields_set
+    top_level_schedule_fields = {
+        "schedule_cron": payload.schedule_cron,
+        "timezone": payload.timezone,
+        "initial_sync_depth": payload.initial_sync_depth,
+    }
+    sync_options = dict(payload.sync_options or {})
+    cleared_keys: set[str] = set()
+    for key, value in top_level_schedule_fields.items():
+        if key not in provided_fields:
+            continue
+        if value is None:
+            cleared_keys.add(key)
+            sync_options.pop(key, None)
+        else:
+            sync_options[key] = value
+    sync_options_provided = payload.sync_options is not None or bool(
+        provided_fields & top_level_schedule_fields.keys()
     )
-    sync_options_provided = bool(sync_options)
 
     schedule_cron = sync_options.get("schedule_cron")
     if schedule_cron:
@@ -536,10 +553,13 @@ async def update_sync_config(
     if payload.sync_targets is not None:
         mutable_config.sync_targets = payload.sync_targets
     if sync_options_provided:
-        mutable_config.sync_options = {
+        merged_options = {
             **dict(getattr(config, "sync_options") or {}),
             **sync_options,
         }
+        for key in cleared_keys:
+            merged_options.pop(key, None)
+        mutable_config.sync_options = merged_options
     if payload.is_active is not None:
         mutable_config.is_active = payload.is_active
     await session.flush()
@@ -562,11 +582,18 @@ async def update_sync_config(
                 mutable_child.is_active = payload.is_active
             # Propagate schedule/timezone/depth from sync_options if provided
             if sync_options_provided:
+                child_sync_options = dict(getattr(child, "sync_options") or {})
+                child_changed = False
                 for key in ("schedule_cron", "timezone", "initial_sync_depth"):
-                    if key in sync_options:
-                        child_sync_options = dict(getattr(child, "sync_options") or {})
+                    if key in cleared_keys:
+                        if key in child_sync_options:
+                            del child_sync_options[key]
+                            child_changed = True
+                    elif key in sync_options:
                         child_sync_options[key] = sync_options[key]
-                        mutable_child.sync_options = child_sync_options
+                        child_changed = True
+                if child_changed:
+                    mutable_child.sync_options = child_sync_options
         if children:
             for child in children:
                 await _upsert_scheduled_job(session, child, org_id)

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -435,10 +435,11 @@ def run_sync_config(
                 .one_or_none()
             )
             if job is None:
+                explicit_cron = sync_options.get("schedule_cron")
                 job = ScheduledJob(
                     name=f"sync-config-{_as_uuid(config.id)}",
                     job_type="sync",
-                    schedule_cron=str(sync_options.get("schedule_cron") or "0 * * * *"),
+                    schedule_cron=str(explicit_cron or "0 * * * *"),
                     org_id=org_id,
                     provider=provider,
                     job_config={
@@ -447,7 +448,14 @@ def run_sync_config(
                     },
                     sync_config_id=_as_uuid(config.id),
                     tz=str(sync_options.get("timezone") or "UTC"),
-                    status=JobStatus.ACTIVE.value,
+                    # Manual-only configs keep the job row for JobRun anchoring
+                    # but must stay PAUSED so the scheduler never picks them up
+                    # (CHAOS-2297).
+                    status=(
+                        JobStatus.ACTIVE.value
+                        if bool(config.is_active) and explicit_cron
+                        else JobStatus.PAUSED.value
+                    ),
                 )
                 session.add(job)
                 session.flush()

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -460,10 +460,17 @@ def run_sync_config(
                 session.add(job)
                 session.flush()
             else:
+                # Reconcile cron AND status with the config (the source of
+                # truth) so out-of-band config changes can't leave the job
+                # parked PAUSED or stale ACTIVE (CHAOS-2297).
+                explicit_cron = sync_options.get("schedule_cron")
+                setattr(job, "schedule_cron", str(explicit_cron or "0 * * * *"))
                 setattr(
                     job,
-                    "schedule_cron",
-                    str(sync_options.get("schedule_cron") or "0 * * * *"),
+                    "status",
+                    JobStatus.ACTIVE.value
+                    if bool(config.is_active) and explicit_cron
+                    else JobStatus.PAUSED.value,
                 )
 
             job_id = _as_uuid(job.id)

--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -71,9 +71,17 @@ def _maybe_dispatch_config(
     """
     from croniter import croniter
 
-    from dev_health_ops.models.settings import ScheduledJob
+    from dev_health_ops.models.settings import JobStatus, ScheduledJob
 
     if not organization_exists_sync(session, config.org_id):
+        return False
+
+    # Manual-only configs (no explicit schedule_cron in sync_options) are
+    # never auto-dispatched (CHAOS-2297). The config is the source of truth:
+    # stored ScheduledJob rows carry DEFAULT_SYNC_CRON as a non-null
+    # placeholder, and legacy rows may still be marked ACTIVE.
+    config_cron = str(_as_dict(config.sync_options).get("schedule_cron") or "")
+    if not config_cron:
         return False
 
     job = (
@@ -85,6 +93,10 @@ def _maybe_dispatch_config(
         )
         .one_or_none()
     )
+
+    # PAUSED/DISABLED jobs (manual-only, org teardown) are never dispatched.
+    if job is not None and int(job.status) != JobStatus.ACTIVE.value:
+        return False
 
     if job is not None and bool(job.is_running):
         if not _running_marker_is_stale(job, now):
@@ -104,13 +116,7 @@ def _maybe_dispatch_config(
         if next_allowed is not None and next_allowed > now:
             return False
 
-    cron_expr = (
-        _as_str(job.schedule_cron)
-        if job is not None
-        else str(
-            _as_dict(config.sync_options).get("schedule_cron") or DEFAULT_SYNC_CRON
-        )
-    )
+    cron_expr = _as_str(job.schedule_cron) if job is not None else config_cron
     last_sync = (
         config.last_sync_at
         if isinstance(config.last_sync_at, datetime)

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -394,6 +394,101 @@ async def test_update_sync_config_merges_top_level_schedule_fields(
 
 
 @pytest.mark.asyncio
+async def test_update_sync_config_explicit_null_clears_schedule(client, session_maker):
+    ac, _ = client
+
+    create_resp = await _create_sync_config(ac, name="clear-schedule")
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+
+    with (
+        patch(
+            "dev_health_ops.licensing.gating._check_org_feature_async",
+            return_value=True,
+        ),
+        patch.object(sync_router_module, "Croniter", _CroniterStub),
+    ):
+        set_resp = await ac.patch(
+            f"/api/v1/admin/sync-configs/{config_id}",
+            json={"schedule_cron": "0 0 * * *", "timezone": "America/Los_Angeles"},
+        )
+    assert set_resp.status_code == 200, set_resp.text
+
+    # Clear the schedule. The payload also carries a stale nested copy of the
+    # old cron (what a stale client sends); it must NOT resurrect the schedule.
+    resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={
+            "schedule_cron": None,
+            "timezone": "America/Los_Angeles",
+            "sync_options": {
+                "owner": "full-chaos",
+                "schedule_cron": "0 0 * * *",
+            },
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert "schedule_cron" not in data["sync_options"]
+    assert data["sync_options"]["owner"] == "full-chaos"
+    assert data["sync_options"]["timezone"] == "America/Los_Angeles"
+    async with session_maker() as session:
+        config = (
+            await session.execute(
+                select(SyncConfiguration).where(
+                    SyncConfiguration.id == uuid.UUID(config_id)
+                )
+            )
+        ).scalar_one()
+    assert "schedule_cron" not in config.sync_options
+    assert config.sync_options["owner"] == "full-chaos"
+
+
+@pytest.mark.asyncio
+async def test_update_sync_config_omitted_schedule_fields_left_unchanged(
+    client, session_maker
+):
+    ac, _ = client
+
+    create_resp = await _create_sync_config(ac, name="omit-schedule")
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+
+    with (
+        patch(
+            "dev_health_ops.licensing.gating._check_org_feature_async",
+            return_value=True,
+        ),
+        patch.object(sync_router_module, "Croniter", _CroniterStub),
+    ):
+        set_resp = await ac.patch(
+            f"/api/v1/admin/sync-configs/{config_id}",
+            json={"schedule_cron": "30 2 * * *", "timezone": "Europe/Berlin"},
+        )
+    assert set_resp.status_code == 200, set_resp.text
+
+    # Omitting schedule fields entirely must leave the stored values untouched.
+    resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={"is_active": False},
+    )
+
+    assert resp.status_code == 200, resp.text
+    async with session_maker() as session:
+        config = (
+            await session.execute(
+                select(SyncConfiguration).where(
+                    SyncConfiguration.id == uuid.UUID(config_id)
+                )
+            )
+        ).scalar_one()
+    assert config.is_active is False
+    assert config.sync_options["schedule_cron"] == "30 2 * * *"
+    assert config.sync_options["timezone"] == "Europe/Berlin"
+
+
+@pytest.mark.asyncio
 async def test_schedule_job_upsert_propagates_schedule_cron(
     client, session_maker, seeded_state
 ):

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -18,6 +18,7 @@ from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import (
     IntegrationCredential,
     JobRun,
+    JobStatus,
     ScheduledJob,
     SyncConfiguration,
 )
@@ -391,6 +392,8 @@ async def test_update_sync_config_merges_top_level_schedule_fields(
     assert job.schedule_cron == "45 3 * * *"
     assert job.provider == "linear"
     assert job.timezone == "Europe/London"
+    # An explicit schedule on an active config keeps the job ACTIVE.
+    assert job.status == JobStatus.ACTIVE.value
 
 
 @pytest.mark.asyncio
@@ -441,8 +444,18 @@ async def test_update_sync_config_explicit_null_clears_schedule(client, session_
                 )
             )
         ).scalar_one()
+        job = (
+            await session.execute(
+                select(ScheduledJob).where(
+                    ScheduledJob.sync_config_id == uuid.UUID(config_id)
+                )
+            )
+        ).scalar_one()
     assert "schedule_cron" not in config.sync_options
     assert config.sync_options["owner"] == "full-chaos"
+    # Clearing the schedule parks the ScheduledJob so the scheduler never
+    # auto-dispatches a manual-only config (CHAOS-2297).
+    assert job.status == JobStatus.PAUSED.value
 
 
 @pytest.mark.asyncio
@@ -486,6 +499,30 @@ async def test_update_sync_config_omitted_schedule_fields_left_unchanged(
     assert config.is_active is False
     assert config.sync_options["schedule_cron"] == "30 2 * * *"
     assert config.sync_options["timezone"] == "Europe/Berlin"
+
+
+@pytest.mark.asyncio
+async def test_create_sync_config_without_schedule_creates_paused_job(
+    client, session_maker
+):
+    ac, _ = client
+
+    create_resp = await _create_sync_config(ac, name="manual-only")
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+
+    async with session_maker() as session:
+        job = (
+            await session.execute(
+                select(ScheduledJob).where(
+                    ScheduledJob.sync_config_id == uuid.UUID(config_id)
+                )
+            )
+        ).scalar_one()
+
+    # Manual-only configs (no schedule_cron) keep a job row for manual-trigger
+    # JobRun anchoring but must stay PAUSED (CHAOS-2297).
+    assert job.status == JobStatus.PAUSED.value
 
 
 @pytest.mark.asyncio

--- a/tests/test_backfill_integration.py
+++ b/tests/test_backfill_integration.py
@@ -359,7 +359,9 @@ def test_dispatch_scheduled_syncs_ignores_backfill_jobs(
             name="sync-integration",
             provider="github",
             sync_targets=[],
-            sync_options={},
+            # CHAOS-2297: scheduled dispatch requires an explicit cron; this
+            # test covers sync-vs-backfill job filtering, not manual-only mode.
+            sync_options={"schedule_cron": "0 * * * *"},
             is_active=True,
         )
         config.id = sync_config_id

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -932,7 +932,7 @@ class TestDispatchScheduledSyncsRouting:
 
         config = _make_config(
             provider="github",
-            sync_options={"search": "org/*"},
+            sync_options={"search": "org/*", "schedule_cron": "0 * * * *"},
             name="batch-config",
         )
         config.last_sync_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
@@ -964,7 +964,11 @@ class TestDispatchScheduledSyncsRouting:
 
         config = _make_config(
             provider="github",
-            sync_options={"owner": "org", "repo": "specific-repo"},
+            sync_options={
+                "owner": "org",
+                "repo": "specific-repo",
+                "schedule_cron": "0 * * * *",
+            },
             name="normal-config",
         )
         config.last_sync_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
@@ -996,14 +1000,18 @@ class TestDispatchScheduledSyncsRouting:
 
         batch_config = _make_config(
             provider="github",
-            sync_options={"search": "org/*"},
+            sync_options={"search": "org/*", "schedule_cron": "0 * * * *"},
             name="batch",
         )
         batch_config.last_sync_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
 
         normal_config = _make_config(
             provider="github",
-            sync_options={"owner": "org", "repo": "repo"},
+            sync_options={
+                "owner": "org",
+                "repo": "repo",
+                "schedule_cron": "0 * * * *",
+            },
             name="normal",
         )
         normal_config.last_sync_at = datetime(2020, 1, 1, tzinfo=timezone.utc)

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -11,10 +11,6 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
-_fake_croniter_mod = MagicMock()
-if "croniter" not in sys.modules:
-    sys.modules["croniter"] = _fake_croniter_mod
-
 from dev_health_ops.models.git import Base  # noqa: E402
 from dev_health_ops.models.settings import (  # noqa: E402
     SyncConfiguration,
@@ -911,11 +907,13 @@ class TestBatchRunStateManagement:
         assert config.last_sync_stats == {"child_results": 2}
 
 
-def _setup_croniter_mock():
+def _setup_croniter_mock(monkeypatch: pytest.MonkeyPatch):
     mock_cron_instance = MagicMock()
     mock_cron_instance.get_next.return_value = datetime(2000, 1, 1, tzinfo=timezone.utc)
     mock_cron_cls = MagicMock(return_value=mock_cron_instance)
-    sys.modules["croniter"].croniter = mock_cron_cls  # type: ignore[attr-defined]
+    monkeypatch.setitem(
+        sys.modules, "croniter", SimpleNamespace(croniter=mock_cron_cls)
+    )
     return mock_cron_cls
 
 
@@ -924,11 +922,11 @@ class TestDispatchScheduledSyncsRouting:
     @patch("dev_health_ops.workers.sync_scheduler.run_sync_config")
     @patch("dev_health_ops.db.get_postgres_session_sync")
     def test_routes_batch_eligible_to_dispatch_batch_sync(
-        self, mock_get_session, mock_run_sync, mock_batch_sync, db_session
+        self, mock_get_session, mock_run_sync, mock_batch_sync, db_session, monkeypatch
     ):
         from dev_health_ops.workers.sync_scheduler import dispatch_scheduled_syncs
 
-        _setup_croniter_mock()
+        _setup_croniter_mock(monkeypatch)
 
         config = _make_config(
             provider="github",
@@ -956,11 +954,11 @@ class TestDispatchScheduledSyncsRouting:
     @patch("dev_health_ops.workers.sync_scheduler.run_sync_config")
     @patch("dev_health_ops.db.get_postgres_session_sync")
     def test_routes_normal_config_to_run_sync_config(
-        self, mock_get_session, mock_run_sync, mock_batch_sync, db_session
+        self, mock_get_session, mock_run_sync, mock_batch_sync, db_session, monkeypatch
     ):
         from dev_health_ops.workers.sync_scheduler import dispatch_scheduled_syncs
 
-        _setup_croniter_mock()
+        _setup_croniter_mock(monkeypatch)
 
         config = _make_config(
             provider="github",
@@ -992,11 +990,11 @@ class TestDispatchScheduledSyncsRouting:
     @patch("dev_health_ops.workers.sync_scheduler.run_sync_config")
     @patch("dev_health_ops.db.get_postgres_session_sync")
     def test_mixed_configs_route_correctly(
-        self, mock_get_session, mock_run_sync, mock_batch_sync, db_session
+        self, mock_get_session, mock_run_sync, mock_batch_sync, db_session, monkeypatch
     ):
         from dev_health_ops.workers.sync_scheduler import dispatch_scheduled_syncs
 
-        _setup_croniter_mock()
+        _setup_croniter_mock(monkeypatch)
 
         batch_config = _make_config(
             provider="github",

--- a/tests/test_sync_scheduler_idempotency.py
+++ b/tests/test_sync_scheduler_idempotency.py
@@ -342,6 +342,44 @@ class TestConsumerClearsRunningMarker:
         assert job.is_running is False
         assert job.last_run_status == JobRunStatus.FAILED.value
 
+    def test_pickup_reconciles_job_status_with_config(self, monkeypatch, db_session):
+        """A job parked PAUSED (manual-only) must be reactivated when the
+        config gained an explicit schedule out-of-band (CHAOS-2297)."""
+        from dev_health_ops.workers.sync_runtime import run_sync_config
+
+        config = _make_config(
+            name="reactivate-me",
+            # Explicit cron, but no owner/repo => terminal ValueError AFTER
+            # the job row is resolved and reconciled.
+            sync_options={"schedule_cron": "0 * * * *"},
+            sync_targets=["git"],
+        )
+        db_session.add(config)
+        db_session.flush()
+        job = _make_job(config)
+        job.status = JobStatus.PAUSED.value
+        db_session.add(job)
+        db_session.flush()
+
+        monkeypatch.setattr(
+            "dev_health_ops.db.get_postgres_session_sync",
+            lambda: _fake_session_ctx(db_session),
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_runtime._get_db_url",
+            lambda: "sqlite:///:memory:",
+        )
+
+        task: Any = run_sync_config
+        task.push_request(id=str(uuid.uuid4()), retries=0)
+        try:
+            with pytest.raises(ValueError, match="owner/repo"):
+                task(config_id=str(config.id), org_id="default")
+        finally:
+            task.pop_request()
+
+        assert job.status == JobStatus.ACTIVE.value
+
 
 class TestBatchRoutingStillStampsMarker:
     @patch("dev_health_ops.workers.sync_scheduler.dispatch_batch_sync")

--- a/tests/test_sync_scheduler_idempotency.py
+++ b/tests/test_sync_scheduler_idempotency.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.settings import (
     JobRunStatus,
+    JobStatus,
     ScheduledJob,
     SyncConfiguration,
 )
@@ -72,10 +73,11 @@ def _make_config(
         provider="github",
         org_id="default",
         sync_targets=sync_targets or ["git", "prs"],
-        # owner+repo set => not batch eligible
+        # owner+repo set => not batch eligible; explicit schedule_cron so the
+        # manual-only gate (CHAOS-2297) doesn't skip dispatch in these tests.
         sync_options=sync_options
         if sync_options is not None
-        else {"owner": "org", "repo": "repo"},
+        else {"owner": "org", "repo": "repo", "schedule_cron": "0 * * * *"},
         is_active=True,
     )
     if last_sync_at is not None:
@@ -353,7 +355,7 @@ class TestBatchRoutingStillStampsMarker:
         config = _make_config(
             name="batch-config",
             last_sync_at=now - 2 * HOUR,
-            sync_options={"search": "org/*"},
+            sync_options={"search": "org/*", "schedule_cron": "0 * * * *"},
         )
         job = _make_job(config)
         db_session.add_all([config, job])
@@ -376,3 +378,42 @@ class TestBatchRoutingStillStampsMarker:
         second = _call(task)
         assert second["dispatched"] == []
         assert batch_sync_mock.apply_async.call_count == 1
+
+
+class TestManualOnlyConfigsNotDispatched:
+    """Manual-only configs (no schedule_cron) must never auto-sync (CHAOS-2297)."""
+
+    def test_config_without_schedule_cron_is_skipped(self, monkeypatch, db_session):
+        now = datetime.now(timezone.utc)
+        config = _make_config(
+            last_sync_at=now - 2 * HOUR,
+            sync_options={"owner": "org", "repo": "repo"},
+        )
+        # Legacy rows: ACTIVE job carrying the default hourly placeholder cron.
+        job = _make_job(config)
+        db_session.add_all([config, job])
+        db_session.flush()
+
+        task, run_sync_mock, batch_sync_mock = _run_dispatch(monkeypatch, db_session)
+
+        result = _call(task)
+        assert result["dispatched"] == []
+        assert result["errors"] == 0
+        run_sync_mock.apply_async.assert_not_called()
+        batch_sync_mock.apply_async.assert_not_called()
+        assert job.next_run_at is None
+
+    def test_paused_job_is_skipped(self, monkeypatch, db_session):
+        now = datetime.now(timezone.utc)
+        config = _make_config(last_sync_at=now - 2 * HOUR)
+        job = _make_job(config)
+        job.status = JobStatus.PAUSED.value
+        db_session.add_all([config, job])
+        db_session.flush()
+
+        task, run_sync_mock, _ = _run_dispatch(monkeypatch, db_session)
+
+        result = _call(task)
+        assert result["dispatched"] == []
+        run_sync_mock.apply_async.assert_not_called()
+        assert job.next_run_at is None


### PR DESCRIPTION
## Summary

Two related fixes to sync configuration behavior:

### 1. Schedule edits now persist (CHAOS-2295)

Sync config edits returned 200 but never persisted schedule changes — clearing a schedule ("Manual only") was impossible, and a stale nested `schedule_cron` in the client payload silently resurrected the old value on every save.

**Root cause:** `PATCH /sync-configs/{config_id}` folded top-level `schedule_cron`/`timezone`/`initial_sync_depth` into `sync_options` only when non-null, then merged the payload's (possibly stale) nested `sync_options` over the stored record. `null` and "omitted" were indistinguishable, so clears were dropped and stale nested copies won.

**Fix** (`update_sync_config`):
- Use `payload.model_fields_set` to distinguish explicitly-provided `null` (clear the key) from omitted fields (leave stored value untouched).
- Top-level schedule fields are now authoritative over any copies nested inside `payload.sync_options`, so stale client payloads can't revert edits.
- The child-config cascade applies the same clear semantics.

### 2. Manual-only configs never auto-sync (CHAOS-2297)

Configs without an explicit `schedule_cron` ("Manual only" in the UI) still synced hourly: every `ScheduledJob` producer stored `DEFAULT_SYNC_CRON` (`0 * * * *`) as a placeholder and marked the job ACTIVE, and the scheduler never checked job status.

**Fix:**
- `sync_scheduler._maybe_dispatch_config`: skip configs whose `sync_options` carry no explicit `schedule_cron` (the config is the source of truth, so legacy ACTIVE rows with the placeholder cron are covered without a migration), and skip non-ACTIVE job rows.
- All three job producers (`_upsert_scheduled_job`, the manual-trigger job-creation path, and `sync_runtime` pickup): status is ACTIVE only when the config is active AND has an explicit `schedule_cron`; otherwise PAUSED. The job row is kept so manual triggers still anchor `JobRun`s to it.

## API contract

PATCH semantics for `schedule_cron`/`timezone`/`initial_sync_depth`: **omit** to preserve, send **explicit null** to clear. A config without `schedule_cron` is manual-only and is never auto-dispatched.

## Tests

- `test_update_sync_config_explicit_null_clears_schedule` — clearing persists even with a stale nested cron in the payload (reproduces the reported curl) and parks the job PAUSED.
- `test_update_sync_config_omitted_schedule_fields_left_unchanged` — PATCH omission semantics.
- `test_create_sync_config_without_schedule_creates_paused_job` — manual-only create.
- `TestManualOnlyConfigsNotDispatched` — scheduler skips cron-less configs (even with legacy ACTIVE+placeholder job rows) and PAUSED jobs.
- Full runs: `test_sync_configs.py` (31), `test_sync_scheduler_idempotency.py` (13), `test_sync_partitioning.py`, `test_sync_manual_trigger_safety.py`, `test_sync_watermarks.py` — all green. `ruff format --check` + `ruff check` clean.
- Note: `test_tier_limits.py` shows 5 failures when run in the same session as `test_sync_partitioning.py` — pre-existing cross-test pollution (`_setup_croniter_mock` mutates `sys.modules` globally), identical on a clean tree.

Counterpart web PR: full-chaos/dev-health-web#674.

Closes CHAOS-2295
Closes CHAOS-2297