### PR TITLE
fix(clickhouse): add org_id to ReplacingMergeTree dedup keys (CHAOS-2290)

### DIFF
--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -101,6 +101,7 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
         FROM git_commits AS c
         LEFT JOIN git_commit_stats AS s
           ON (s.repo_id = c.repo_id) AND (s.commit_hash = c.hash)
+         AND (s.org_id = c.org_id)
         WHERE c.committer_when >= {{start:DateTime}} AND c.committer_when < {{end:DateTime}}
         {repo_filter}
         {org_filter_c}
@@ -499,6 +500,7 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
         FROM coverage_snapshots AS c
         INNER JOIN ci_pipeline_runs AS p
           ON (p.repo_id = c.repo_id) AND (p.run_id = c.run_id)
+         AND (p.org_id = c.org_id)
         WHERE p.started_at >= {{start:DateTime}} AND p.started_at < {{end:DateTime}}
         {repo_filter}
         {self._org_filter(alias="p")}

--- a/src/dev_health_ops/migrations/clickhouse/042_rmt_org_id_dedup_keys.py
+++ b/src/dev_health_ops/migrations/clickhouse/042_rmt_org_id_dedup_keys.py
@@ -23,20 +23,46 @@ key using the same shadow-table pattern as migration 027 (Altinity pattern):
     1. SHOW CREATE TABLE to get full DDL (preserves settings, indexes, the
        RMT version column, partitioning, etc.)
     2. Modify DDL: rename to ``<table>_new``, prepend org_id to ORDER BY
-    3. INSERT INTO <table>_new SELECT * FROM <table>
-    4. Verify the distinct new-key tuple counts match between original and
+    3. Verify via system.tables that the shadow's sorting key is exactly
+       ``org_id, <old sorting key>`` — abort (and drop the shadow) on any
+       mismatch, so a regex miss on exotic DDL fails closed instead of
+       silently shipping the wrong dedup key
+    4. INSERT INTO <table>_new SELECT * FROM <table> (snapshot copy)
+    5. Verify the distinct new-key tuple counts match between original and
        shadow (raw row counts may legitimately differ: the copy can collapse
        not-yet-merged same-key duplicate versions, which is RMT semantics,
        not data loss)
-    5. EXCHANGE TABLES <table> AND <table>_new (atomic swap)
-    6. DROP TABLE <table>_new (which now holds the old structure)
+    6. EXCHANGE TABLES <table> AND <table>_new (atomic swap)
+    7. CATCH-UP: INSERT INTO <table> SELECT * FROM <table>_new — the shadow
+       now holds the OLD table, including any rows written between the
+       snapshot (step 4) and the swap (step 6). Re-inserting ALL old rows is
+       idempotent under RMT semantics: rows already copied dedup away on the
+       (now org_id-first) key with the newest version winning, while rows
+       that landed after the snapshot survive. This shrinks the write-loss
+       window from the whole copy duration to the EXCHANGE instant, which is
+       atomic.
+    8. DROP TABLE <table>_new — only after the catch-up succeeded.
+
+Residual operational risk: writes that race the EXCHANGE itself can target
+either side of the swap; both sides are preserved (catch-up re-inserts the
+old side), but version ties on the same key resolve arbitrarily. Ops note:
+run this migration during a quiet period / with sync workers stopped.
+
+Crash convergence: if a run crashes after EXCHANGE but before the catch-up
+or DROP, the main table already has the org_id-first key, so a rerun takes
+the idempotency-skip path. That path checks for a leftover ``<table>_new``
+shadow and, if present, performs the catch-up INSERT + DROP before
+declaring the table done — no rows stranded, no shadow left behind. A crash
+*before* EXCHANGE leaves a disposable shadow that the next run drops and
+recreates.
 
 ``work_items`` and ``work_item_transitions`` are included defensively: on
 any database where migration 027 already ran they are skipped by the
 idempotency check (org_id already first in ORDER BY), but a database whose
 027 run was interrupted gets repaired here.
 
-Idempotent: tables already having org_id first in ORDER BY are skipped.
+Idempotent: tables already having org_id first in ORDER BY are skipped
+(after converging any leftover shadow, see above).
 
 NOTE: this file is loaded standalone by the migration runner
 (importlib.util.spec_from_file_location), so it must not import from other
@@ -145,6 +171,42 @@ def _key_columns(new_order_by: str) -> list[str]:
     return [c.strip() for c in new_order_by.strip("() ").split(",") if c.strip()]
 
 
+def _normalize_sorting_key(key: str) -> str:
+    """Normalize a sorting key for string comparison (backticks, spacing)."""
+    return re.sub(r"\s*,\s*", ", ", re.sub(r"\s+", " ", key.replace("`", ""))).strip(
+        " ()"
+    )
+
+
+def _sorting_key(client, table: str) -> str:
+    """Read a table's actual sorting key from system.tables."""
+    res = client.query(
+        "SELECT sorting_key FROM system.tables "
+        "WHERE database = currentDatabase() AND name = {name:String}",
+        parameters={"name": table},
+    )
+    rows = getattr(res, "result_rows", None) or []
+    if not rows or not rows[0]:
+        raise RuntimeError(f"{table}: could not read sorting_key from system.tables")
+    return str(rows[0][0])
+
+
+def _catch_up_and_drop(client, table: str, shadow: str) -> None:
+    """Post-EXCHANGE catch-up: re-insert the old table's rows, then drop it.
+
+    After EXCHANGE TABLES, *shadow* holds the OLD table — including any rows
+    written between the snapshot copy and the swap. Re-inserting ALL of its
+    rows is idempotent under ReplacingMergeTree: rows already present dedup
+    away on the (org_id-first) key with the newest version winning, while
+    late-written rows survive. Only after the catch-up succeeds is the old
+    table dropped; on failure the shadow is left in place so a rerun can
+    converge (see the skip path in _rebuild_table).
+    """
+    log.info(f"  {table}: catch-up copy of post-snapshot writes from `{shadow}`")
+    client.command(f"INSERT INTO `{table}` SELECT * FROM `{shadow}`")
+    client.command(f"DROP TABLE `{shadow}`")
+
+
 def _rebuild_table(client, table: str, new_order_by: str) -> None:
     """Rebuild a single table with org_id prepended to its ORDER BY."""
     shadow = f"{table}_new"
@@ -157,7 +219,19 @@ def _rebuild_table(client, table: str, new_order_by: str) -> None:
     ddl = res.result_rows[0][0]
 
     if _has_org_id_first_in_order_by(ddl):
-        log.info(f"  {table}: org_id already first in ORDER BY, skipping")
+        # Convergence: a previous run may have crashed after EXCHANGE but
+        # before its catch-up/DROP. The leftover shadow then holds the OLD
+        # table (shadows are only created while the main table still lacks
+        # the org_id-first key) — finish the catch-up before skipping so the
+        # post-snapshot writes inside it are not lost.
+        if _table_exists(client, shadow):
+            log.info(
+                f"  {table}: org_id already first in ORDER BY but leftover "
+                f"`{shadow}` found — converging interrupted run"
+            )
+            _catch_up_and_drop(client, table, shadow)
+        else:
+            log.info(f"  {table}: org_id already first in ORDER BY, skipping")
         return
 
     if not _ORG_ID_COL_RE.search(ddl):
@@ -176,32 +250,57 @@ def _rebuild_table(client, table: str, new_order_by: str) -> None:
     client.command(f"DROP TABLE IF EXISTS `{shadow}`")
     client.command(new_ddl)
 
-    log.info(f"  {table}: copying data")
-    client.command(f"INSERT INTO `{shadow}` SELECT * FROM `{table}`")
+    # Everything before EXCHANGE is safely retryable: on any failure drop
+    # the (disposable, pre-swap) shadow and re-raise. After EXCHANGE the
+    # shadow holds real data and must NOT be dropped without a catch-up.
+    try:
+        # Fail closed on DDL-rewrite misses: the regex rewrite cannot be
+        # trusted on arbitrary DDL (nested expressions like cityHash64(...)
+        # in ORDER BY), so verify the *actual* shadow sorting key is exactly
+        # `org_id, <old key>` before copying any data.
+        old_key = _normalize_sorting_key(_sorting_key(client, table))
+        shadow_key = _normalize_sorting_key(_sorting_key(client, shadow))
+        expected_key = f"org_id, {old_key}"
+        if shadow_key != expected_key:
+            raise RuntimeError(
+                f"{table}: shadow sorting key mismatch after DDL rewrite "
+                f"(expected {expected_key!r}, got {shadow_key!r}); aborting"
+            )
 
-    # Verify no logical rows were lost before swapping. Raw row counts may
-    # legitimately differ (the copy can collapse not-yet-merged duplicate
-    # versions of the SAME key — normal RMT semantics), so compare the number
-    # of distinct new-key tuples instead, which must be identical: the new
-    # key is a superset of the old one, so no two source rows that differ on
-    # it can ever merge.
-    key_columns = _key_columns(new_order_by)
-    src_keys = _distinct_key_count(client, table, key_columns)
-    dst_keys = _distinct_key_count(client, shadow, key_columns)
-    if dst_keys != src_keys:
-        raise RuntimeError(
-            f"{table}: shadow copy distinct-key mismatch "
-            f"(source={src_keys}, shadow={dst_keys}); aborting before swap"
+        log.info(f"  {table}: copying data")
+        client.command(f"INSERT INTO `{shadow}` SELECT * FROM `{table}`")
+
+        # Verify no logical rows were lost before swapping. Raw row counts
+        # may legitimately differ (the copy can collapse not-yet-merged
+        # duplicate versions of the SAME key — normal RMT semantics), so
+        # compare the number of distinct new-key tuples instead, which must
+        # be identical: the new key is a superset of the old one, so no two
+        # source rows that differ on it can ever merge.
+        key_columns = _key_columns(new_order_by)
+        src_keys = _distinct_key_count(client, table, key_columns)
+        dst_keys = _distinct_key_count(client, shadow, key_columns)
+        if dst_keys != src_keys:
+            raise RuntimeError(
+                f"{table}: shadow copy distinct-key mismatch "
+                f"(source={src_keys}, shadow={dst_keys}); aborting before swap"
+            )
+        log.info(
+            f"  {table}: distinct sorting-key tuples verified "
+            f"(source={src_keys}, shadow={dst_keys})"
         )
-    log.info(
-        f"  {table}: distinct sorting-key tuples verified "
-        f"(source={src_keys}, shadow={dst_keys})"
-    )
+    except Exception:
+        try:
+            client.command(f"DROP TABLE IF EXISTS `{shadow}`")
+        except Exception as cleanup_err:  # pragma: no cover - best effort
+            log.warning(f"  {table}: shadow table cleanup failed: {cleanup_err}")
+        raise
 
     log.info(f"  {table}: atomic swap via EXCHANGE TABLES")
     client.command(f"EXCHANGE TABLES `{table}` AND `{shadow}`")
 
-    client.command(f"DROP TABLE `{shadow}`")
+    # From here on the shadow is the OLD table; never drop it without the
+    # catch-up. If this fails, the rerun skip path converges it.
+    _catch_up_and_drop(client, table, shadow)
 
     log.info(f"  {table}: done")
 
@@ -221,12 +320,12 @@ def upgrade(client):
         try:
             _rebuild_table(client, table, new_order_by)
         except Exception as exc:
+            # No blanket shadow cleanup here: pre-EXCHANGE failures already
+            # dropped their disposable shadow inside _rebuild_table, while a
+            # post-EXCHANGE failure leaves `<table>_new` holding the OLD
+            # table's data — dropping it would lose the catch-up delta. The
+            # rerun skip path converges any such leftover.
             log.error(f"FAILED on {table}: {exc}")
-            # Clean up shadow table on failure
-            try:
-                client.command(f"DROP TABLE IF EXISTS `{table}_new`")
-            except Exception as cleanup_err:
-                log.warning(f"  {table}: shadow table cleanup failed: {cleanup_err}")
             raise
 
     log.info("=== Migration 042: Complete ===")

--- a/src/dev_health_ops/migrations/clickhouse/042_rmt_org_id_dedup_keys.py
+++ b/src/dev_health_ops/migrations/clickhouse/042_rmt_org_id_dedup_keys.py
@@ -1,0 +1,232 @@
+"""Migration 042: Ensure org_id is in every ReplacingMergeTree dedup key (CHAOS-2290).
+
+ReplacingMergeTree deduplicates rows that share the same ORDER BY (sorting
+key) tuple. When org_id is a column but NOT part of the sorting key,
+identical natural keys across two tenants (e.g. the same ``(repo_id,
+work_item_id)`` under two different org_ids) collapse into ONE row on a
+background merge — silent cross-tenant data loss.
+
+Migration 027 fixed this for the tables that existed at the time (including
+``work_items`` / ``work_item_transitions`` from 009_raw_work_items.sql, the
+tables named by CHAOS-2290). However:
+
+* 029_testops_tables.sql created ``ci_job_runs``, ``test_suite_results``,
+  ``test_case_results`` and ``coverage_snapshots`` with org_id as a column
+  but ``ORDER BY`` keyed only on ``(repo_id, ...)``.
+* 032_security_alerts.sql created ``security_alerts`` with
+  ``ORDER BY (repo_id, alert_id)``; 033 added the org_id column but could
+  not fix the sorting key (ClickHouse cannot ALTER an existing RMT key).
+
+This migration rebuilds those tables with org_id prepended to the sorting
+key using the same shadow-table pattern as migration 027 (Altinity pattern):
+
+    1. SHOW CREATE TABLE to get full DDL (preserves settings, indexes, the
+       RMT version column, partitioning, etc.)
+    2. Modify DDL: rename to ``<table>_new``, prepend org_id to ORDER BY
+    3. INSERT INTO <table>_new SELECT * FROM <table>
+    4. Verify the distinct new-key tuple counts match between original and
+       shadow (raw row counts may legitimately differ: the copy can collapse
+       not-yet-merged same-key duplicate versions, which is RMT semantics,
+       not data loss)
+    5. EXCHANGE TABLES <table> AND <table>_new (atomic swap)
+    6. DROP TABLE <table>_new (which now holds the old structure)
+
+``work_items`` and ``work_item_transitions`` are included defensively: on
+any database where migration 027 already ran they are skipped by the
+idempotency check (org_id already first in ORDER BY), but a database whose
+027 run was interrupted gets repaired here.
+
+Idempotent: tables already having org_id first in ORDER BY are skipped.
+
+NOTE: this file is loaded standalone by the migration runner
+(importlib.util.spec_from_file_location), so it must not import from other
+migration modules — helpers are intentionally duplicated from 027.
+"""
+
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Table catalog: table_name -> new ORDER BY with org_id prepended
+# ---------------------------------------------------------------------------
+
+TABLES = {
+    # --- CHAOS-2290 headline tables (009_raw_work_items.sql) ---
+    # Already rebuilt by migration 027 on healthy databases; kept here as an
+    # idempotent safety net.
+    "work_items": "(org_id, repo_id, work_item_id)",
+    "work_item_transitions": "(org_id, repo_id, work_item_id, occurred_at)",
+    # --- TestOps raw tables (029_testops_tables.sql) ---
+    "ci_job_runs": "(org_id, repo_id, run_id, job_id)",
+    "test_suite_results": "(org_id, repo_id, run_id, suite_id)",
+    "test_case_results": "(org_id, repo_id, run_id, suite_id, case_id)",
+    "coverage_snapshots": "(org_id, repo_id, run_id, snapshot_id)",
+    # --- Security alerts (032_security_alerts.sql / 033 org_id column) ---
+    "security_alerts": "(org_id, repo_id, alert_id)",
+}
+
+# ---------------------------------------------------------------------------
+# Helpers (duplicated from migration 027 — see module docstring)
+# ---------------------------------------------------------------------------
+
+# Regex: ORDER BY (col, col, ...) | ORDER BY tuple(col, ...) | ORDER BY col
+_ORDER_BY_RE = re.compile(r"ORDER BY\s+(?:tuple\([^)]+\)|\([^)]+\)|\S+)", re.IGNORECASE)
+
+# Regex: org_id column definition (plain String or LowCardinality(String))
+_ORG_ID_COL_RE = re.compile(
+    r"`?org_id`?\s+(?:LowCardinality\(\s*)?String", re.IGNORECASE
+)
+
+
+def _table_name_re(table: str) -> re.Pattern:
+    """Regex for the table name in a CREATE TABLE statement."""
+    return re.compile(
+        rf"(CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+        rf"(?:`?[\w\d_]+`?\.)?`?){re.escape(table)}(`?\s|`?\()",
+        re.IGNORECASE,
+    )
+
+
+def _has_org_id_first_in_order_by(ddl: str) -> bool:
+    """Check if org_id is already the first column in the ORDER BY clause."""
+    match = _ORDER_BY_RE.search(ddl)
+    if not match:
+        return False
+    order_clause = match.group(0)
+    return bool(
+        re.search(r"ORDER BY\s+(?:tuple)?\(?\s*`?org_id`?", order_clause, re.IGNORECASE)
+    )
+
+
+def _replace_order_by(ddl: str, new_order_by: str) -> str:
+    """Replace the ORDER BY clause in a CREATE TABLE DDL string."""
+    result, count = _ORDER_BY_RE.subn(f"ORDER BY {new_order_by}", ddl, count=1)
+    if count == 0:
+        raise ValueError(f"Could not find ORDER BY in DDL: {ddl[:300]}...")
+    return result
+
+
+def _replace_table_name(ddl: str, old_name: str, new_name: str) -> str:
+    """Replace the table name in a CREATE TABLE DDL string."""
+    pattern = _table_name_re(old_name)
+    result, count = pattern.subn(rf"\g<1>{new_name}\g<2>", ddl, count=1)
+    if count == 0:
+        raise ValueError(
+            f"Could not replace table name '{old_name}' in DDL: {ddl[:300]}..."
+        )
+    return result
+
+
+def _table_exists(client, table: str) -> bool:
+    try:
+        res = client.query(
+            "SELECT count() FROM system.tables "
+            "WHERE database = currentDatabase() AND name = {name:String}",
+            parameters={"name": table},
+        )
+        rows = getattr(res, "result_rows", None) or []
+        return bool(rows and rows[0] and rows[0][0] > 0)
+    except Exception:
+        return False
+
+
+def _distinct_key_count(client, table: str, key_columns: list[str]) -> int:
+    """Count distinct sorting-key tuples (stable under RMT merges)."""
+    key_tuple = ", ".join(f"`{c}`" for c in key_columns)
+    res = client.query(f"SELECT uniqExact(({key_tuple})) FROM `{table}`")
+    rows = getattr(res, "result_rows", None) or []
+    return int(rows[0][0]) if rows and rows[0] else 0
+
+
+def _key_columns(new_order_by: str) -> list[str]:
+    """Parse '(org_id, repo_id, ...)' into its column names."""
+    return [c.strip() for c in new_order_by.strip("() ").split(",") if c.strip()]
+
+
+def _rebuild_table(client, table: str, new_order_by: str) -> None:
+    """Rebuild a single table with org_id prepended to its ORDER BY."""
+    shadow = f"{table}_new"
+
+    if not _table_exists(client, table):
+        log.warning(f"  {table}: table does not exist, skipping")
+        return
+
+    res = client.query(f"SHOW CREATE TABLE `{table}`")
+    ddl = res.result_rows[0][0]
+
+    if _has_org_id_first_in_order_by(ddl):
+        log.info(f"  {table}: org_id already first in ORDER BY, skipping")
+        return
+
+    if not _ORG_ID_COL_RE.search(ddl):
+        # All targeted tables gained org_id in 024/029/033; if it is missing
+        # the database is in an unexpected state — fail loudly rather than
+        # guess a column type.
+        raise ValueError(
+            f"{table}: org_id column not found in DDL; cannot add it to the "
+            f"sorting key. DDL: {ddl[:300]}..."
+        )
+
+    new_ddl = _replace_table_name(ddl, table, shadow)
+    new_ddl = _replace_order_by(new_ddl, new_order_by)
+
+    log.info(f"  {table}: creating shadow table")
+    client.command(f"DROP TABLE IF EXISTS `{shadow}`")
+    client.command(new_ddl)
+
+    log.info(f"  {table}: copying data")
+    client.command(f"INSERT INTO `{shadow}` SELECT * FROM `{table}`")
+
+    # Verify no logical rows were lost before swapping. Raw row counts may
+    # legitimately differ (the copy can collapse not-yet-merged duplicate
+    # versions of the SAME key — normal RMT semantics), so compare the number
+    # of distinct new-key tuples instead, which must be identical: the new
+    # key is a superset of the old one, so no two source rows that differ on
+    # it can ever merge.
+    key_columns = _key_columns(new_order_by)
+    src_keys = _distinct_key_count(client, table, key_columns)
+    dst_keys = _distinct_key_count(client, shadow, key_columns)
+    if dst_keys != src_keys:
+        raise RuntimeError(
+            f"{table}: shadow copy distinct-key mismatch "
+            f"(source={src_keys}, shadow={dst_keys}); aborting before swap"
+        )
+    log.info(
+        f"  {table}: distinct sorting-key tuples verified "
+        f"(source={src_keys}, shadow={dst_keys})"
+    )
+
+    log.info(f"  {table}: atomic swap via EXCHANGE TABLES")
+    client.command(f"EXCHANGE TABLES `{table}` AND `{shadow}`")
+
+    client.command(f"DROP TABLE `{shadow}`")
+
+    log.info(f"  {table}: done")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def upgrade(client):
+    """Rebuild RMT tables whose dedup key is missing org_id (CHAOS-2290)."""
+    log.info("=== Migration 042: org_id in RMT dedup keys (CHAOS-2290) ===")
+
+    total = len(TABLES)
+    for i, (table, new_order_by) in enumerate(TABLES.items(), 1):
+        log.info(f"[{i}/{total}] {table}")
+        try:
+            _rebuild_table(client, table, new_order_by)
+        except Exception as exc:
+            log.error(f"FAILED on {table}: {exc}")
+            # Clean up shadow table on failure
+            try:
+                client.command(f"DROP TABLE IF EXISTS `{table}_new`")
+            except Exception as cleanup_err:
+                log.warning(f"  {table}: shadow table cleanup failed: {cleanup_err}")
+            raise
+
+    log.info("=== Migration 042: Complete ===")

--- a/tests/test_migration_042_rmt_org_id_dedup.py
+++ b/tests/test_migration_042_rmt_org_id_dedup.py
@@ -1,0 +1,157 @@
+"""Static checks for migration 042 (CHAOS-2290).
+
+ReplacingMergeTree deduplicates on the sorting key. If org_id is a column
+but not part of ``ORDER BY``, rows with identical natural keys across two
+tenants collapse into one row on a background merge — cross-tenant data
+loss. These tests guard, at the string/DDL level (no database needed):
+
+1. every rebuild target in migration 042 puts org_id FIRST in the new key;
+2. every ReplacingMergeTree table defined across ALL ClickHouse migrations
+   ends up with org_id in its *effective* sorting key (file DDL, overridden
+   by the 027 / 042 rebuild maps).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+from types import ModuleType
+
+MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "dev_health_ops"
+    / "migrations"
+    / "clickhouse"
+)
+
+MIGRATION_042 = "042_rmt_org_id_dedup_keys.py"
+MIGRATION_027 = "027_add_org_id_to_sorting_keys.py"
+
+
+def _load_migration(filename: str) -> ModuleType:
+    """Load a migration module standalone, exactly like the runner does."""
+    path = MIGRATIONS_DIR / filename
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None, f"cannot load {filename}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# Migration 042 itself
+# ---------------------------------------------------------------------------
+
+
+def test_migration_042_exists_and_has_upgrade() -> None:
+    module = _load_migration(MIGRATION_042)
+    assert callable(getattr(module, "upgrade", None))
+
+
+def test_migration_042_every_new_order_by_starts_with_org_id() -> None:
+    module = _load_migration(MIGRATION_042)
+    assert module.TABLES, "migration 042 must rebuild at least one table"
+    for table, order_by in module.TABLES.items():
+        assert re.match(r"\(\s*org_id\s*,", order_by), (
+            f"{table}: new ORDER BY must start with org_id, got {order_by!r}"
+        )
+
+
+def test_migration_042_covers_known_affected_tables() -> None:
+    """The tables whose live dedup key was missing org_id (CHAOS-2290)."""
+    module = _load_migration(MIGRATION_042)
+    expected = {
+        # CHAOS-2290 headline tables (009_raw_work_items.sql); rebuilt by 027
+        # on healthy databases, kept as an idempotent safety net.
+        "work_items",
+        "work_item_transitions",
+        # 029_testops_tables.sql — created with org_id column but keyed on
+        # (repo_id, ...) only.
+        "ci_job_runs",
+        "test_suite_results",
+        "test_case_results",
+        "coverage_snapshots",
+        # 032_security_alerts.sql / 033 added the column but not the key.
+        "security_alerts",
+    }
+    missing = expected - set(module.TABLES)
+    assert not missing, f"migration 042 missing rebuilds for: {sorted(missing)}"
+
+
+def test_migration_042_runs_after_the_migrations_it_repairs() -> None:
+    """The runner applies files in sorted-filename order."""
+    for prerequisite in (
+        "009_raw_work_items.sql",
+        MIGRATION_027,
+        "029_testops_tables.sql",
+        "033_security_alerts_org_id.sql",
+    ):
+        assert (MIGRATIONS_DIR / prerequisite).exists()
+        assert prerequisite < MIGRATION_042
+
+
+# ---------------------------------------------------------------------------
+# Whole-catalog guard: every RMT table's effective key includes org_id
+# ---------------------------------------------------------------------------
+
+_CREATE_TABLE_RE = re.compile(
+    r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?`?(\w+)`?", re.IGNORECASE
+)
+_ORDER_BY_RE = re.compile(r"ORDER\s+BY\s+(\([^;]*?\)|\S+)\s*(?:;|$|\n)", re.IGNORECASE)
+
+# product_telemetry_events deliberately keys on the privacy-preserving
+# org_id_hash instead of org_id — both are valid tenant keys.
+_TENANT_KEY_RE = re.compile(r"\borg_id(_hash)?\b")
+
+
+def _strip_sql_comments(sql: str) -> str:
+    return "\n".join(line.split("--", 1)[0] for line in sql.splitlines())
+
+
+def _rmt_tables_from_sql_migrations() -> dict[str, tuple[str, str]]:
+    """Map of table -> (defining file, ORDER BY as written in the file)."""
+    tables: dict[str, tuple[str, str]] = {}
+    for sql_file in sorted(MIGRATIONS_DIR.glob("*.sql")):
+        text = _strip_sql_comments(sql_file.read_text(encoding="utf-8"))
+        for stmt in text.split(";"):
+            if "ReplacingMergeTree" not in stmt:
+                continue
+            create = _CREATE_TABLE_RE.search(stmt)
+            if create is None:
+                continue  # e.g. a view referencing an RMT table
+            order_by = _ORDER_BY_RE.search(stmt + ";")
+            assert order_by is not None, (
+                f"{sql_file.name}: ReplacingMergeTree table "
+                f"{create.group(1)} has no ORDER BY"
+            )
+            tables[create.group(1)] = (sql_file.name, order_by.group(1))
+    return tables
+
+
+def test_every_rmt_table_effective_sorting_key_includes_org_id() -> None:
+    """No ReplacingMergeTree table may dedup across tenants.
+
+    The effective sorting key is the table's CREATE TABLE ORDER BY, unless a
+    later rebuild migration (027 or 042) replaced it. A failure here means a
+    migration introduced (or left behind) an RMT table whose dedup key lacks
+    org_id — add the table to a rebuild migration or key it on org_id from
+    the start.
+    """
+    overrides: dict[str, str] = {}
+    overrides.update(_load_migration(MIGRATION_027).TABLES)
+    overrides.update(_load_migration(MIGRATION_042).TABLES)
+
+    offenders: list[str] = []
+    for table, (filename, declared_order_by) in sorted(
+        _rmt_tables_from_sql_migrations().items()
+    ):
+        effective = overrides.get(table, declared_order_by)
+        if not _TENANT_KEY_RE.search(effective):
+            offenders.append(f"{table} ({filename}): ORDER BY {effective}")
+
+    assert not offenders, (
+        "ReplacingMergeTree tables whose effective sorting key is missing "
+        "org_id (cross-tenant dedup, see CHAOS-2290):\n  " + "\n  ".join(offenders)
+    )

--- a/tests/test_migration_042_rmt_org_id_dedup.py
+++ b/tests/test_migration_042_rmt_org_id_dedup.py
@@ -8,7 +8,10 @@ loss. These tests guard, at the string/DDL level (no database needed):
 1. every rebuild target in migration 042 puts org_id FIRST in the new key;
 2. every ReplacingMergeTree table defined across ALL ClickHouse migrations
    ends up with org_id in its *effective* sorting key (file DDL, overridden
-   by the 027 / 042 rebuild maps).
+   by the 027 / 042 rebuild maps);
+3. the rebuild flow itself (against a fake client): post-EXCHANGE catch-up
+   of writes that raced the snapshot copy, crash convergence from a
+   leftover shadow, and the fail-closed sorting-key verification.
 """
 
 from __future__ import annotations
@@ -17,6 +20,8 @@ import importlib.util
 import re
 from pathlib import Path
 from types import ModuleType
+
+import pytest
 
 MIGRATIONS_DIR = (
     Path(__file__).resolve().parents[1]
@@ -155,3 +160,178 @@ def test_every_rmt_table_effective_sorting_key_includes_org_id() -> None:
         "ReplacingMergeTree tables whose effective sorting key is missing "
         "org_id (cross-tenant dedup, see CHAOS-2290):\n  " + "\n  ".join(offenders)
     )
+
+
+# ---------------------------------------------------------------------------
+# Rebuild flow: catch-up, crash convergence, sorting-key verification
+# ---------------------------------------------------------------------------
+
+OLD_KEY = "repo_id, work_item_id"
+NEW_KEY = "org_id, repo_id, work_item_id"
+
+OLD_DDL = (
+    "CREATE TABLE work_items (`repo_id` UUID, `work_item_id` String, "
+    "`org_id` String, `last_synced` DateTime) "
+    "ENGINE = ReplacingMergeTree(last_synced) "
+    "ORDER BY (repo_id, work_item_id) SETTINGS index_granularity = 8192"
+)
+NEW_DDL = OLD_DDL.replace(
+    "ORDER BY (repo_id, work_item_id)",
+    "ORDER BY (org_id, repo_id, work_item_id)",
+)
+
+
+class _FakeResult:
+    def __init__(self, rows: list[list]) -> None:
+        self.result_rows = rows
+
+
+class FakeClient:
+    """Minimal ClickHouse client double tracking executed commands.
+
+    ``tables`` maps table name -> {"ddl": str, "sorting_key": str}. DROP,
+    CREATE and EXCHANGE mutate the catalog; ``created_sorting_key`` is the
+    sorting key assigned to any table CREATEd during the run (lets a test
+    simulate the regex rewrite producing a wrong key). ``fail_on`` injects a
+    failure into the first command containing the substring.
+    """
+
+    def __init__(
+        self,
+        tables: dict[str, dict[str, str]],
+        *,
+        created_sorting_key: str = NEW_KEY,
+        fail_on: str | None = None,
+    ) -> None:
+        self.tables = {name: dict(spec) for name, spec in tables.items()}
+        self.created_sorting_key = created_sorting_key
+        self.fail_on = fail_on
+        self.commands: list[str] = []
+
+    def query(self, query: str, parameters: dict | None = None) -> _FakeResult:
+        if "count() FROM system.tables" in query:
+            assert parameters is not None
+            return _FakeResult([[1 if parameters["name"] in self.tables else 0]])
+        if "sorting_key FROM system.tables" in query:
+            assert parameters is not None
+            spec = self.tables.get(parameters["name"])
+            return _FakeResult([[spec["sorting_key"]]] if spec else [])
+        if query.startswith("SHOW CREATE TABLE"):
+            name = query.split("`")[1]
+            return _FakeResult([[self.tables[name]["ddl"]]])
+        if "uniqExact" in query:
+            return _FakeResult([[5]])
+        raise AssertionError(f"unexpected query: {query}")
+
+    def command(self, cmd: str) -> None:
+        self.commands.append(cmd)
+        if self.fail_on and self.fail_on in cmd:
+            self.fail_on = None  # fail once
+            raise RuntimeError(f"injected failure on: {cmd}")
+        if cmd.startswith("DROP TABLE"):
+            self.tables.pop(cmd.split("`")[1], None)
+        elif cmd.startswith("CREATE TABLE"):
+            name = re.search(r"CREATE TABLE\s+`?(\w+)`?", cmd).group(1)  # type: ignore[union-attr]
+            self.tables[name] = {"ddl": cmd, "sorting_key": self.created_sorting_key}
+        elif cmd.startswith("EXCHANGE TABLES"):
+            a, b = re.findall(r"`(\w+)`", cmd)
+            self.tables[a], self.tables[b] = self.tables[b], self.tables[a]
+
+
+@pytest.fixture()
+def migration() -> ModuleType:
+    return _load_migration(MIGRATION_042)
+
+
+def test_rebuild_runs_catch_up_after_exchange_then_drops_shadow(migration) -> None:
+    """Writes landing between snapshot and EXCHANGE must be re-inserted."""
+    client = FakeClient(
+        {"work_items": {"ddl": OLD_DDL, "sorting_key": OLD_KEY}},
+    )
+    migration._rebuild_table(client, "work_items", f"({NEW_KEY})")
+
+    snapshot = client.commands.index(
+        "INSERT INTO `work_items_new` SELECT * FROM `work_items`"
+    )
+    exchange = client.commands.index(
+        "EXCHANGE TABLES `work_items` AND `work_items_new`"
+    )
+    catch_up = client.commands.index(
+        "INSERT INTO `work_items` SELECT * FROM `work_items_new`"
+    )
+    drop = client.commands.index("DROP TABLE `work_items_new`")
+    assert snapshot < exchange < catch_up < drop, client.commands
+    assert "work_items_new" not in client.tables
+    assert client.tables["work_items"]["sorting_key"] == NEW_KEY
+
+
+def test_rebuild_does_not_drop_shadow_when_catch_up_fails(migration) -> None:
+    """Post-EXCHANGE failure must leave the shadow for rerun convergence."""
+    client = FakeClient(
+        {"work_items": {"ddl": OLD_DDL, "sorting_key": OLD_KEY}},
+        fail_on="INSERT INTO `work_items` SELECT",
+    )
+    with pytest.raises(RuntimeError, match="injected failure"):
+        migration._rebuild_table(client, "work_items", f"({NEW_KEY})")
+
+    # The shadow (now holding the OLD table) must survive the failure.
+    assert "work_items_new" in client.tables
+    assert not any(
+        cmd.startswith("DROP TABLE") and "work_items_new" in cmd
+        for cmd in client.commands[
+            client.commands.index("EXCHANGE TABLES `work_items` AND `work_items_new`") :
+        ]
+    )
+
+
+def test_skip_path_converges_leftover_shadow(migration) -> None:
+    """Rerun after crash-post-EXCHANGE: catch up from the shadow, then drop."""
+    client = FakeClient(
+        {
+            "work_items": {"ddl": NEW_DDL, "sorting_key": NEW_KEY},
+            "work_items_new": {"ddl": OLD_DDL, "sorting_key": OLD_KEY},
+        }
+    )
+    migration._rebuild_table(client, "work_items", f"({NEW_KEY})")
+
+    assert client.commands == [
+        "INSERT INTO `work_items` SELECT * FROM `work_items_new`",
+        "DROP TABLE `work_items_new`",
+    ]
+    assert "work_items_new" not in client.tables
+
+
+def test_skip_path_without_leftover_shadow_is_a_no_op(migration) -> None:
+    client = FakeClient({"work_items": {"ddl": NEW_DDL, "sorting_key": NEW_KEY}})
+    migration._rebuild_table(client, "work_items", f"({NEW_KEY})")
+    assert client.commands == []
+
+
+def test_rebuild_aborts_and_drops_shadow_on_sorting_key_mismatch(migration) -> None:
+    """A regex miss on exotic DDL must fail closed before any data copy."""
+    client = FakeClient(
+        {"work_items": {"ddl": OLD_DDL, "sorting_key": OLD_KEY}},
+        # Simulate the ORDER BY rewrite mangling a nested expression.
+        created_sorting_key="org_id, cityHash64(repo_id)",
+    )
+    with pytest.raises(RuntimeError, match="sorting key mismatch"):
+        migration._rebuild_table(client, "work_items", f"({NEW_KEY})")
+
+    # Shadow dropped, original untouched, no data copied, no swap.
+    assert "work_items_new" not in client.tables
+    assert client.tables["work_items"]["sorting_key"] == OLD_KEY
+    assert not any("INSERT INTO" in cmd for cmd in client.commands)
+    assert not any("EXCHANGE" in cmd for cmd in client.commands)
+
+
+def test_rebuild_drops_shadow_when_snapshot_copy_fails(migration) -> None:
+    """Pre-EXCHANGE failures leave no shadow behind (disposable phase)."""
+    client = FakeClient(
+        {"work_items": {"ddl": OLD_DDL, "sorting_key": OLD_KEY}},
+        fail_on="INSERT INTO `work_items_new`",
+    )
+    with pytest.raises(RuntimeError, match="injected failure"):
+        migration._rebuild_table(client, "work_items", f"({NEW_KEY})")
+
+    assert "work_items_new" not in client.tables
+    assert not any("EXCHANGE" in cmd for cmd in client.commands)

--- a/tests/test_rmt_org_id_dedup_live.py
+++ b/tests/test_rmt_org_id_dedup_live.py
@@ -1,0 +1,217 @@
+"""Live-ClickHouse regression tests for CHAOS-2290.
+
+ReplacingMergeTree deduplicates rows sharing the same sorting-key tuple.
+Before migrations 027/042, several tables keyed only on natural keys like
+``(repo_id, work_item_id)`` — so two tenants whose rows collided on the
+natural key collapsed into ONE row on a background merge.
+
+Each test inserts two rows that are identical except for org_id, forces a
+merge with ``OPTIMIZE TABLE ... FINAL``, and asserts BOTH rows survive.
+
+Opt-in (filtered from unit/CI runs): ``pytest -m clickhouse``.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/default)",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def sink():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
+    s = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    # Apply pending migrations (including 042) regardless of
+    # AUTO_RUN_MIGRATIONS — the fix under test is a migration.
+    s.ensure_schema(force=True)
+    yield s
+    s.close()
+
+
+def _two_orgs() -> tuple[str, str]:
+    return (
+        f"test-chaos-2290-{uuid.uuid4()}",
+        f"test-chaos-2290-{uuid.uuid4()}",
+    )
+
+
+def _surviving_orgs(sink, table: str, where: str, params: dict) -> set[str]:
+    """Force a merge, then return the org_ids still present for the key."""
+    sink.client.command(f"OPTIMIZE TABLE {table} FINAL")
+    result = sink.client.query(
+        f"SELECT DISTINCT org_id FROM {table} WHERE {where}",
+        parameters=params,
+    )
+    return {row[0] for row in (result.result_rows or [])}
+
+
+def _cleanup(sink, table: str, org_a: str, org_b: str) -> None:
+    sink.client.command(
+        f"ALTER TABLE {table} DELETE WHERE org_id IN ({{a:String}}, {{b:String}}) "
+        "SETTINGS mutations_sync=2",
+        parameters={"a": org_a, "b": org_b},
+    )
+
+
+def test_work_items_dedup_does_not_cross_tenants(sink) -> None:
+    """Same (repo_id, work_item_id) under two orgs must survive a merge."""
+    org_a, org_b = _two_orgs()
+    repo_id = uuid.uuid4()
+    work_item_id = f"WI-{uuid.uuid4()}"
+    now = datetime.now(timezone.utc)
+
+    try:
+        sink.client.insert(
+            "work_items",
+            [
+                [repo_id, work_item_id, "linear", f"item of {org}", now, now, now, org]
+                for org in (org_a, org_b)
+            ],
+            column_names=[
+                "repo_id",
+                "work_item_id",
+                "provider",
+                "title",
+                "created_at",
+                "updated_at",
+                "last_synced",
+                "org_id",
+            ],
+        )
+
+        survivors = _surviving_orgs(
+            sink,
+            "work_items",
+            "repo_id = {repo_id:UUID} AND work_item_id = {wid:String}",
+            {"repo_id": str(repo_id), "wid": work_item_id},
+        )
+        assert survivors == {org_a, org_b}, (
+            f"cross-tenant dedup in work_items: expected both orgs to survive "
+            f"OPTIMIZE FINAL, got {survivors}"
+        )
+    finally:
+        _cleanup(sink, "work_items", org_a, org_b)
+
+
+def test_work_item_transitions_dedup_does_not_cross_tenants(sink) -> None:
+    org_a, org_b = _two_orgs()
+    repo_id = uuid.uuid4()
+    work_item_id = f"WI-{uuid.uuid4()}"
+    occurred_at = datetime.now(timezone.utc)
+
+    try:
+        sink.client.insert(
+            "work_item_transitions",
+            [
+                [repo_id, work_item_id, occurred_at, "linear", occurred_at, org]
+                for org in (org_a, org_b)
+            ],
+            column_names=[
+                "repo_id",
+                "work_item_id",
+                "occurred_at",
+                "provider",
+                "last_synced",
+                "org_id",
+            ],
+        )
+
+        survivors = _surviving_orgs(
+            sink,
+            "work_item_transitions",
+            "repo_id = {repo_id:UUID} AND work_item_id = {wid:String}",
+            {"repo_id": str(repo_id), "wid": work_item_id},
+        )
+        assert survivors == {org_a, org_b}
+    finally:
+        _cleanup(sink, "work_item_transitions", org_a, org_b)
+
+
+def test_security_alerts_dedup_does_not_cross_tenants(sink) -> None:
+    """Same (repo_id, alert_id) under two orgs must survive a merge."""
+    org_a, org_b = _two_orgs()
+    repo_id = uuid.uuid4()
+    alert_id = f"GHSA-{uuid.uuid4()}"
+    now = datetime.now(timezone.utc)
+
+    try:
+        sink.client.insert(
+            "security_alerts",
+            [[repo_id, alert_id, "github", now, now, org] for org in (org_a, org_b)],
+            column_names=[
+                "repo_id",
+                "alert_id",
+                "source",
+                "created_at",
+                "last_synced",
+                "org_id",
+            ],
+        )
+
+        survivors = _surviving_orgs(
+            sink,
+            "security_alerts",
+            "repo_id = {repo_id:UUID} AND alert_id = {aid:String}",
+            {"repo_id": str(repo_id), "aid": alert_id},
+        )
+        assert survivors == {org_a, org_b}, (
+            f"cross-tenant dedup in security_alerts: got {survivors}"
+        )
+    finally:
+        _cleanup(sink, "security_alerts", org_a, org_b)
+
+
+def test_test_suite_results_dedup_does_not_cross_tenants(sink) -> None:
+    """Same (repo_id, run_id, suite_id) under two orgs must survive a merge."""
+    org_a, org_b = _two_orgs()
+    repo_id = uuid.uuid4()
+    run_id = f"run-{uuid.uuid4()}"
+    suite_id = "suite-1"
+    now = datetime.now(timezone.utc)
+
+    try:
+        sink.client.insert(
+            "test_suite_results",
+            [
+                [repo_id, run_id, suite_id, "unit", 10, 10, 0, 0, now, org]
+                for org in (org_a, org_b)
+            ],
+            column_names=[
+                "repo_id",
+                "run_id",
+                "suite_id",
+                "suite_name",
+                "total_count",
+                "passed_count",
+                "failed_count",
+                "skipped_count",
+                "last_synced",
+                "org_id",
+            ],
+        )
+
+        survivors = _surviving_orgs(
+            sink,
+            "test_suite_results",
+            "repo_id = {repo_id:UUID} AND run_id = {rid:String} "
+            "AND suite_id = {sid:String}",
+            {"repo_id": str(repo_id), "rid": run_id, "sid": suite_id},
+        )
+        assert survivors == {org_a, org_b}
+    finally:
+        _cleanup(sink, "test_suite_results", org_a, org_b)

--- a/tests/test_rmt_org_id_dedup_live.py
+++ b/tests/test_rmt_org_id_dedup_live.py
@@ -215,3 +215,121 @@ def test_test_suite_results_dedup_does_not_cross_tenants(sink) -> None:
         assert survivors == {org_a, org_b}
     finally:
         _cleanup(sink, "test_suite_results", org_a, org_b)
+
+
+def test_ci_job_runs_dedup_does_not_cross_tenants(sink) -> None:
+    """Same (repo_id, run_id, job_id) under two orgs must survive a merge."""
+    org_a, org_b = _two_orgs()
+    repo_id = uuid.uuid4()
+    run_id = f"run-{uuid.uuid4()}"
+    job_id = "job-1"
+    now = datetime.now(timezone.utc)
+
+    try:
+        sink.client.insert(
+            "ci_job_runs",
+            [[repo_id, run_id, job_id, "build", now, org] for org in (org_a, org_b)],
+            column_names=[
+                "repo_id",
+                "run_id",
+                "job_id",
+                "job_name",
+                "last_synced",
+                "org_id",
+            ],
+        )
+
+        survivors = _surviving_orgs(
+            sink,
+            "ci_job_runs",
+            "repo_id = {repo_id:UUID} AND run_id = {rid:String} "
+            "AND job_id = {jid:String}",
+            {"repo_id": str(repo_id), "rid": run_id, "jid": job_id},
+        )
+        assert survivors == {org_a, org_b}, (
+            f"cross-tenant dedup in ci_job_runs: got {survivors}"
+        )
+    finally:
+        _cleanup(sink, "ci_job_runs", org_a, org_b)
+
+
+def test_test_case_results_dedup_does_not_cross_tenants(sink) -> None:
+    """Same (repo_id, run_id, suite_id, case_id) under two orgs must survive."""
+    org_a, org_b = _two_orgs()
+    repo_id = uuid.uuid4()
+    run_id = f"run-{uuid.uuid4()}"
+    suite_id = "suite-1"
+    case_id = "case-1"
+    now = datetime.now(timezone.utc)
+
+    try:
+        sink.client.insert(
+            "test_case_results",
+            [
+                [repo_id, run_id, suite_id, case_id, "test_case", "passed", now, org]
+                for org in (org_a, org_b)
+            ],
+            column_names=[
+                "repo_id",
+                "run_id",
+                "suite_id",
+                "case_id",
+                "case_name",
+                "status",
+                "last_synced",
+                "org_id",
+            ],
+        )
+
+        survivors = _surviving_orgs(
+            sink,
+            "test_case_results",
+            "repo_id = {repo_id:UUID} AND run_id = {rid:String} "
+            "AND suite_id = {sid:String} AND case_id = {cid:String}",
+            {
+                "repo_id": str(repo_id),
+                "rid": run_id,
+                "sid": suite_id,
+                "cid": case_id,
+            },
+        )
+        assert survivors == {org_a, org_b}, (
+            f"cross-tenant dedup in test_case_results: got {survivors}"
+        )
+    finally:
+        _cleanup(sink, "test_case_results", org_a, org_b)
+
+
+def test_coverage_snapshots_dedup_does_not_cross_tenants(sink) -> None:
+    """Same (repo_id, run_id, snapshot_id) under two orgs must survive."""
+    org_a, org_b = _two_orgs()
+    repo_id = uuid.uuid4()
+    run_id = f"run-{uuid.uuid4()}"
+    snapshot_id = "snap-1"
+    now = datetime.now(timezone.utc)
+
+    try:
+        sink.client.insert(
+            "coverage_snapshots",
+            [[repo_id, run_id, snapshot_id, now, org] for org in (org_a, org_b)],
+            column_names=[
+                "repo_id",
+                "run_id",
+                "snapshot_id",
+                "last_synced",
+                "org_id",
+            ],
+        )
+
+        survivors = _surviving_orgs(
+            sink,
+            "coverage_snapshots",
+            "repo_id = {repo_id:UUID} AND run_id = {rid:String} "
+            "AND snapshot_id = {sid:String}",
+            {"repo_id": str(repo_id), "rid": run_id, "sid": snapshot_id},
+        )
+        assert survivors == {org_a, org_b}, (
+            f"cross-tenant dedup in coverage_snapshots: got {survivors}"
+        )
+    finally:
+        _cleanup(sink, "coverage_snapshots", org_a, org_b)


### PR DESCRIPTION
## Summary

Fixes the CHAOS-2290 tenant-isolation bug class: ReplacingMergeTree tables whose sorting key (dedup key) lacks `org_id`, so identical natural keys across two orgs collapse to one row on a background merge — silent cross-tenant data loss.

### Survey result: the headline table was already fixed

`009_raw_work_items.sql` creates `work_items` / `work_item_transitions` (there is no table literally named `raw_work_items`). Migration `027_add_org_id_to_sorting_keys.py` already rebuilds both with `org_id` first in the key, and the live DB confirms `work_items → (org_id, repo_id, work_item_id)`. **However**, five RMT tables created after 027 repeat the exact same flaw and are broken on live databases:

| Table | Created by | Old key |
|---|---|---|
| `ci_job_runs` | 029_testops_tables.sql | `(repo_id, run_id, job_id)` |
| `test_suite_results` | 029_testops_tables.sql | `(repo_id, run_id, suite_id)` |
| `test_case_results` | 029_testops_tables.sql | `(repo_id, run_id, suite_id, case_id)` |
| `coverage_snapshots` | 029_testops_tables.sql | `(repo_id, run_id, snapshot_id)` |
| `security_alerts` | 032 (033 added the org_id column, but a key cannot be ALTERed) | `(repo_id, alert_id)` |

### Changes

- **`042_rmt_org_id_dedup_keys.py`** — ClickHouse cannot ALTER an existing RMT key, so this reuses 027's shadow-table pattern (`SHOW CREATE TABLE` → create `<table>_new` with `org_id` prepended → `INSERT ... SELECT` → verify → `EXCHANGE TABLES` → drop). It additionally verifies **distinct sorting-key tuple counts** match before the swap (raw row counts can legitimately differ because the copy collapses not-yet-merged same-key duplicate versions — this fired on real local data during verification). `work_items`/`work_item_transitions` are included as idempotent safety nets for any DB whose 027 run was interrupted; the migration skips tables that already have `org_id` first.
- **`tests/test_migration_042_rmt_org_id_dedup.py`** — unit tests (no DB): string-level assertions that every 042 rebuild key starts with `org_id`, plus a whole-catalog guard that parses every `*.sql` migration, applies the 027/042 overrides, and fails if any RMT table's *effective* key lacks a tenant key (`org_id`/`org_id_hash`). This prevents migration 043+ from reintroducing the bug.
- **`tests/test_rmt_org_id_dedup_live.py`** — opt-in `@pytest.mark.clickhouse` regression tests: two rows identical except `org_id`, `OPTIMIZE TABLE ... FINAL`, assert both survive (work_items, work_item_transitions, security_alerts, test_suite_results). Self-cleaning.

### Live verification

Applied against local `dev-health-clickhouse-1` (real data): all 7 tables now report `org_id`-first sorting keys in `system.tables`, `schema_migrations` records `042`, all 4 live tests pass, no shadow/test artifacts left behind.


### Codex-review hardening (second commit)

- **Racing writes (HIGH):** the rebuild no longer drops the old table right after `EXCHANGE`. It first runs a **catch-up pass** — `INSERT INTO <table> SELECT * FROM <table>_new` — re-inserting ALL old rows, which is idempotent under RMT dedup (newest version wins) and preserves any rows written to the source between the snapshot copy and the swap. The old table is dropped only after the catch-up succeeds. **Residual risk:** writes racing the `EXCHANGE` instant itself can land on either side; both sides are preserved, but version ties on the same key resolve arbitrarily. *Ops note: run this migration during a quiet period / with sync workers stopped.*
- **Crash convergence (MEDIUM):** if a run dies after `EXCHANGE` but before catch-up/`DROP`, the rerun's idempotency-skip path now detects the leftover `<table>_new` (which holds the OLD table), runs the catch-up from it, then drops it — no stranded rows, no leftover shadow. Pre-`EXCHANGE` failures still drop their disposable shadow; the old blanket drop-on-any-failure was removed because it would have destroyed the catch-up delta after a post-swap crash.
- **Fail-closed DDL rewrite (MEDIUM):** after creating the shadow, the migration reads `system.tables.sorting_key` for both tables and verifies the shadow's key is exactly `org_id, <old key>` (normalized string compare) **before copying any data** — a regex miss on nested ORDER BY expressions (`cityHash64(...)`, `ifNull(...)`) now aborts and drops the shadow instead of shipping a wrong dedup key.
- **Join predicates (HIGH, data leak):** added `org_id` equality to the `coverage_snapshots ↔ ci_pipeline_runs` and `git_commits ↔ git_commit_stats` joins in `metrics/loaders/clickhouse.py`. The `ci_job_runs ↔ ci_pipeline_runs` and `test_case_results ↔ test_suite_results` joins are fixed in **PR #857 (CHAOS-2293)**, which also reworks the alias filter handling in those exact hunks — deliberately left untouched here; merge order between #857 and #862 doesn't matter.
- **Tests:** live dedup tests now cover all rebuilt TestOps tables (`ci_job_runs`, `test_case_results`, `coverage_snapshots` added; 7 live tests total), plus FakeClient unit tests for catch-up ordering, post-swap-failure shadow retention, crash convergence, fail-closed key verification, and pre-swap cleanup. The full rebuild → catch-up → convergence flow was also exercised end-to-end against the local ClickHouse with a scratch table (cleaned up).

### Reader audit flags (NOT fixed here — follow-up candidates)

Per the org_id-in-every-join-predicate checklist:

- `src/dev_health_ops/audit/completeness.py` — `build_work_items_query` / `build_transitions_query` / `build_git_commits_query` aggregate with **no org_id filter at all** (cross-tenant counts).
- `src/dev_health_ops/api/graphql/resolvers/security.py` — every `security_alerts` query joins `INNER JOIN repos r ON sa.repo_id = r.id` **without** `AND sa.org_id = r.org_id`; org scoping rides solely on `r.org_id`. Now that cross-org alert rows survive dedup (this fix), a colliding `repo_id` would attach another org's alerts to this org's repo row.
- `src/dev_health_ops/work_graph/investment/queries.py` — `fetch_work_items` / `fetch_parent_titles` only filter by org when the optional `org_id=""` arg is set (unscoped fallback).
- `src/dev_health_ops/metrics/compute_capacity.py` — `get_backlog_size` org filter is conditional (unscoped fallback).
- `src/dev_health_ops/work_graph/builder.py` — `WHERE org_id` applied only `if self.config.org_id` (unscoped fallback; also interpolates org_id via f-string).

Non-RMT (plain MergeTree) tables missing org_id in their keys (e.g. `report_provenance`, 030/031 testops daily/benchmark tables) are a perf/index concern, not a dedup-loss one — left out deliberately.

### Gates

- `uv run mypy --install-types --non-interactive .` — clean (1014 files)
- `./ci/run_tests.sh unit` (unsandboxed) — 3963 passed; only the 4 known-flaky ignores failed (test_org_deletion ×2, TestCoreCache ×2)
- `uv run pytest tests/test_migration_042_rmt_org_id_dedup.py -q` — 11 passed
- Live `pytest -m clickhouse tests/test_rmt_org_id_dedup_live.py` — 7 passed

Linear: CHAOS-2290
