### PR TITLE
fix(sync): batch child watermarks + typed GitLab credentials (CHAOS-2281, CHAOS-2282)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/teams.py
+++ b/src/dev_health_ops/api/admin/routers/teams.py
@@ -179,6 +179,8 @@ async def discover_teams(
 
     config: dict[str, Any] = getattr(credential, "config") or {}
     discovery_svc = TeamDiscoveryService(session, org_id)
+    truncated = False
+    warnings: list[str] = []
 
     if provider == "github":
         token = decrypted.get("token")
@@ -240,13 +242,14 @@ async def discover_teams(
             )
         discovered_gitlab: list[Any] = []
         for group_path in group_paths:
-            discovered_gitlab.extend(
-                await discovery_svc.discover_gitlab(
-                    token=token,
-                    group_path=group_path,
-                    url=url,
-                )
+            gitlab_result = await discovery_svc.discover_gitlab(
+                token=token,
+                group_path=group_path,
+                url=url,
             )
+            discovered_gitlab.extend(gitlab_result.teams)
+            truncated = truncated or gitlab_result.truncated
+            warnings.extend(gitlab_result.warnings)
         teams = _dedupe_teams(discovered_gitlab)
     elif provider == "linear":
         api_key = decrypted.get("apiKey") or decrypted.get("api_key")
@@ -275,7 +278,13 @@ async def discover_teams(
             url=jira_url,
         )
 
-    return TeamDiscoverResponse(provider=provider, teams=teams, total=len(teams))
+    return TeamDiscoverResponse(
+        provider=provider,
+        teams=teams,
+        total=len(teams),
+        truncated=truncated,
+        warnings=warnings,
+    )
 
 
 @router.post("/teams/import", response_model=TeamImportResponse)

--- a/src/dev_health_ops/api/admin/schemas.py
+++ b/src/dev_health_ops/api/admin/schemas.py
@@ -272,6 +272,10 @@ class TeamDiscoverResponse(BaseModel):
     provider: str
     teams: list[DiscoveredTeam]
     total: int
+    # True when provider-side pagination bounds truncated discovery, i.e.
+    # ``teams`` is a partial view. Optional so existing clients are unaffected.
+    truncated: bool = False
+    warnings: list[str] = Field(default_factory=list)
 
 
 class TeamImportRequest(BaseModel):

--- a/src/dev_health_ops/api/services/configuration/__init__.py
+++ b/src/dev_health_ops/api/services/configuration/__init__.py
@@ -37,7 +37,7 @@ from .integration_credentials import (
 )
 from .jira_activity_inference import JiraActivityInferenceService
 from .sync_configuration import SyncConfigurationService
-from .team_discovery import TeamDiscoveryService
+from .team_discovery import GitLabDiscoveryResult, TeamDiscoveryService
 from .team_drift_sync import TeamDriftSyncService
 from .team_mapping import TeamMappingService
 from .team_membership import TeamMembershipService
@@ -49,6 +49,7 @@ __all__ = [
     "JiraActivityInferenceService",
     "SettingsService",
     "SyncConfigurationService",
+    "GitLabDiscoveryResult",
     "TeamDiscoveryService",
     "TeamDriftSyncService",
     "TeamMappingService",

--- a/src/dev_health_ops/api/services/configuration/team_discovery.py
+++ b/src/dev_health_ops/api/services/configuration/team_discovery.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import itertools
 import logging
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -30,18 +31,45 @@ MAX_GITLAB_DISCOVERY_SUBGROUPS = 500
 MAX_GITLAB_DISCOVERY_PROJECTS = 500
 
 
-def _bounded_list(iterable: Any, limit: int, *, what: str, scope: str) -> list[Any]:
-    """Materialize at most ``limit`` items, logging when results are truncated."""
+def _bounded_list(
+    iterable: Any,
+    limit: int,
+    *,
+    what: str,
+    scope: str,
+    warnings: list[str] | None = None,
+) -> list[Any]:
+    """Materialize at most ``limit`` items, logging when results are truncated.
+
+    When ``warnings`` is provided, a human-readable truncation message is
+    appended to it so callers can surface partial results instead of silently
+    presenting them as complete.
+    """
     items = list(itertools.islice(iter(iterable), limit + 1))
     if len(items) > limit:
-        logger.warning(
-            "GitLab team discovery truncated %s for %s at %d results",
-            what,
-            scope,
-            limit,
+        message = (
+            f"GitLab team discovery truncated {what} for '{scope}' at "
+            f"{limit} results; the import may be incomplete."
         )
+        logger.warning(message)
+        if warnings is not None:
+            warnings.append(message)
         return items[:limit]
     return items
+
+
+@dataclass
+class GitLabDiscoveryResult:
+    """Outcome of a GitLab team discovery walk.
+
+    ``truncated`` is True when any subgroup/project listing hit the discovery
+    pagination bound, meaning ``teams`` (or their ``repo_patterns``) are a
+    partial view; ``warnings`` carries the human-readable details.
+    """
+
+    teams: list[DiscoveredTeam]
+    truncated: bool = False
+    warnings: list[str] = field(default_factory=list)
 
 
 class TeamDiscoveryService:
@@ -123,13 +151,19 @@ class TeamDiscoveryService:
         token: str,
         group_path: str,
         url: str = "https://gitlab.com",
-    ) -> list[DiscoveredTeam]:
-        """Discover groups/subgroups from GitLab."""
+    ) -> GitLabDiscoveryResult:
+        """Discover groups/subgroups from GitLab.
 
-        def _discover() -> list[DiscoveredTeam]:
+        Returns a :class:`GitLabDiscoveryResult`; ``truncated`` is set when
+        the subgroup/project walk hit the discovery pagination bounds, so
+        callers can tell a partial import apart from a complete one.
+        """
+
+        def _discover() -> GitLabDiscoveryResult:
             import gitlab as gl_lib
 
             DiscoveredTeam = _get_discovered_team_cls()
+            warnings: list[str] = []
             gl = gl_lib.Gitlab(url=url, private_token=token)
             root_group = gl.groups.get(group_path)
             groups = [root_group]
@@ -138,6 +172,7 @@ class TeamDiscoveryService:
                 MAX_GITLAB_DISCOVERY_SUBGROUPS,
                 what="subgroups",
                 scope=group_path,
+                warnings=warnings,
             )
             for subgroup in subgroups:
                 groups.append(gl.groups.get(subgroup.id))
@@ -149,6 +184,7 @@ class TeamDiscoveryService:
                     MAX_GITLAB_DISCOVERY_PROJECTS,
                     what="projects",
                     scope=group.full_path,
+                    warnings=warnings,
                 )
                 repo_patterns = [p.path_with_namespace for p in projects]
                 teams.append(
@@ -164,7 +200,11 @@ class TeamDiscoveryService:
                     )
                 )
 
-            return teams
+            return GitLabDiscoveryResult(
+                teams=teams,
+                truncated=bool(warnings),
+                warnings=warnings,
+            )
 
         return await asyncio.to_thread(_discover)
 

--- a/src/dev_health_ops/api/services/configuration/team_discovery.py
+++ b/src/dev_health_ops/api/services/configuration/team_discovery.py
@@ -7,6 +7,8 @@ projects) from external providers and imports them into ``TeamMapping``.
 from __future__ import annotations
 
 import asyncio
+import itertools
+import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -18,6 +20,28 @@ from .team_mapping import TeamMappingService
 
 if TYPE_CHECKING:
     from dev_health_ops.api.admin.schemas import DiscoveredTeam
+
+logger = logging.getLogger(__name__)
+
+# Upper bounds for GitLab discovery pagination. ``get_all=True`` walks every
+# page, which on very large self-hosted instances can mean thousands of API
+# calls; cap the walk and log when results are truncated.
+MAX_GITLAB_DISCOVERY_SUBGROUPS = 500
+MAX_GITLAB_DISCOVERY_PROJECTS = 500
+
+
+def _bounded_list(iterable: Any, limit: int, *, what: str, scope: str) -> list[Any]:
+    """Materialize at most ``limit`` items, logging when results are truncated."""
+    items = list(itertools.islice(iter(iterable), limit + 1))
+    if len(items) > limit:
+        logger.warning(
+            "GitLab team discovery truncated %s for %s at %d results",
+            what,
+            scope,
+            limit,
+        )
+        return items[:limit]
+    return items
 
 
 class TeamDiscoveryService:
@@ -109,12 +133,23 @@ class TeamDiscoveryService:
             gl = gl_lib.Gitlab(url=url, private_token=token)
             root_group = gl.groups.get(group_path)
             groups = [root_group]
-            for subgroup in root_group.subgroups.list(per_page=100, get_all=True):
+            subgroups = _bounded_list(
+                root_group.subgroups.list(per_page=100, iterator=True),
+                MAX_GITLAB_DISCOVERY_SUBGROUPS,
+                what="subgroups",
+                scope=group_path,
+            )
+            for subgroup in subgroups:
                 groups.append(gl.groups.get(subgroup.id))
 
             teams: list[Any] = []
             for group in groups:
-                projects = group.projects.list(per_page=100, get_all=True)
+                projects = _bounded_list(
+                    group.projects.list(per_page=100, iterator=True),
+                    MAX_GITLAB_DISCOVERY_PROJECTS,
+                    what="projects",
+                    scope=group.full_path,
+                )
                 repo_patterns = [p.path_with_namespace for p in projects]
                 teams.append(
                     DiscoveredTeam(

--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -265,6 +265,69 @@ def github_credentials_from_mapping(
         return None
 
 
+def gitlab_credentials_from_mapping(
+    cred_dict: dict[str, Any],
+    *,
+    source: CredentialSource = CredentialSource.DATABASE,
+    credential_name: str = "default",
+) -> GitLabCredentials | None:
+    """Build :class:`GitLabCredentials` from a credentials mapping.
+
+    Accepts a decrypted credentials dict (as persisted in
+    ``integration_credentials`` or assembled from environment variables) and
+    returns a typed credential carrying both the token and the GitLab base
+    URL, so self-hosted instances are honoured everywhere the mapping is
+    consumed. The base URL is resolved from the mapping's ``gitlab_url``,
+    ``url``, or ``base_url`` key (in that order), defaulting to
+    ``https://gitlab.com``.
+
+    Returns ``None`` when the mapping does not contain a ``token``, so
+    callers can surface a clear configuration error.
+    """
+    cred_dict = {k: v for k, v in cred_dict.items() if v is not None}
+    token = str(cred_dict.get("token") or "")
+    if not token:
+        logger.debug("GitLab credentials mapping was incomplete or invalid")
+        return None
+
+    base_url = str(
+        cred_dict.get("gitlab_url")
+        or cred_dict.get("url")
+        or cred_dict.get("base_url")
+        or "https://gitlab.com"
+    )
+
+    try:
+        return GitLabCredentials(
+            token=token,
+            base_url=base_url,
+            source=source,
+            credential_name=credential_name,
+        )
+    except (ValueError, TypeError):
+        # Do not log the exception: it derives from credential construction and
+        # could surface field values. Callers raise a clear config error instead.
+        logger.debug("GitLab credentials mapping was incomplete or invalid")
+        return None
+
+
+def resolve_gitlab_url(
+    sync_options: dict[str, Any],
+    gitlab_credentials: GitLabCredentials | None,
+) -> str:
+    """Resolve the GitLab base URL for a sync/discovery operation.
+
+    Resolution order: ``sync_options['gitlab_url']`` -> credential mapping's
+    URL (``gitlab_url``/``url``/``base_url``) -> ``https://gitlab.com``.
+    """
+    option_url = sync_options.get("gitlab_url")
+    if isinstance(option_url, str) and option_url:
+        return option_url
+    if gitlab_credentials is not None and gitlab_credentials.base_url:
+        return gitlab_credentials.base_url
+    return "https://gitlab.com"
+
+
 def resolve_credentials_sync(
     provider: str,
     org_id: str | None = None,

--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -16,8 +16,15 @@ def discover_repos_for_config(
         # public-only). Authenticated configs pass their token through.
         return discover_github_repos(sync_options, token)
     if provider == "gitlab":
-        token = str(credentials.get("token") or "")
-        return discover_gitlab_repos(sync_options, token)
+        from dev_health_ops.credentials.resolver import (
+            gitlab_credentials_from_mapping,
+            resolve_gitlab_url,
+        )
+
+        gl_credentials = gitlab_credentials_from_mapping(credentials)
+        token = gl_credentials.token if gl_credentials is not None else ""
+        gitlab_url = resolve_gitlab_url(sync_options, gl_credentials)
+        return discover_gitlab_repos(sync_options, token, gitlab_url=gitlab_url)
     return []
 
 
@@ -80,11 +87,14 @@ def discover_github_repos(
 
 
 def discover_gitlab_repos(
-    sync_options: dict[str, Any], token: str
+    sync_options: dict[str, Any],
+    token: str,
+    gitlab_url: str | None = None,
 ) -> list[tuple[str, ...]]:
     import gitlab as gitlab_lib
 
-    gitlab_url = str(sync_options.get("gitlab_url", "https://gitlab.com"))
+    if not gitlab_url:
+        gitlab_url = str(sync_options.get("gitlab_url") or "https://gitlab.com")
     search = sync_options.get("search", "")
     group_path = sync_options.get("group", "")
 

--- a/src/dev_health_ops/workers/sync_backfill.py
+++ b/src/dev_health_ops/workers/sync_backfill.py
@@ -7,7 +7,7 @@ from datetime import date, datetime, timezone
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.task_utils import (
     _as_str,
-    _decrypt_credential_sync,
+    _credential_mapping,
     _extract_provider_token,
     _get_db_url,
     _inject_provider_token,
@@ -68,7 +68,9 @@ def run_backfill(
                     raise ValueError(
                         f"Credential not found for sync configuration: {config.credential_id}"
                     )
-                credentials = _decrypt_credential_sync(credential)
+                # Merge non-sensitive credential.config (e.g. self-hosted
+                # GitLab url) under the decrypted secrets (CHAOS-2282).
+                credentials = _credential_mapping(credential)
             else:
                 credentials = _resolve_env_credentials(provider)
 

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -8,7 +8,11 @@ from typing import Any
 
 from celery import chord, group
 
-from dev_health_ops.credentials.resolver import github_credentials_from_mapping
+from dev_health_ops.credentials.resolver import (
+    github_credentials_from_mapping,
+    gitlab_credentials_from_mapping,
+    resolve_gitlab_url,
+)
 from dev_health_ops.utils.datetime import utc_today
 from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
@@ -509,10 +513,12 @@ def _run_sync_for_repo(
     This is the per-repo worker task dispatched by dispatch_batch_sync.
     It bypasses the DB config lookup and uses the provided options directly.
     """
+    from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.metrics.job_work_items import run_work_items_sync_job
     from dev_health_ops.processors.github import process_github_repo
     from dev_health_ops.processors.gitlab import process_gitlab_project
     from dev_health_ops.storage import resolve_db_type, run_with_store
+    from dev_health_ops.sync.watermarks import get_watermark, set_watermark
 
     db_url = _get_db_url()
     db_type = resolve_db_type(db_url, None)
@@ -538,6 +544,35 @@ def _run_sync_for_repo(
             target for target in sync_targets if target != "work-items"
         ]
 
+        # Incremental sync (CHAOS-2281): mirror run_sync_config's watermark
+        # semantics. Read per-target watermarks and pass since=min(valid) only
+        # when EVERY sync target already has one; otherwise do a full pull.
+        since_dt: datetime | None = None
+        full_resync = bool(sync_options_override.get("full_resync"))
+        repo_id_for_watermark: str | None = None
+
+        if provider == "github" and code_sync_targets:
+            _owner = str(sync_options_override.get("owner", ""))
+            _repo = str(sync_options_override.get("repo", ""))
+            if _owner and _repo:
+                repo_id_for_watermark = f"{_owner}/{_repo}"
+        elif provider == "gitlab":
+            _pid = sync_options_override.get("project_id") or sync_options_override.get(
+                "repo"
+            )
+            if _pid is not None:
+                repo_id_for_watermark = str(_pid)
+
+        if repo_id_for_watermark and not full_resync:
+            with get_postgres_session_sync() as session:
+                watermarks = [
+                    get_watermark(session, org_id, repo_id_for_watermark, t)
+                    for t in sync_targets
+                ]
+                valid = [w for w in watermarks if w is not None]
+                if valid and len(valid) == len(sync_targets):
+                    since_dt = min(valid)
+
         if provider == "github" and code_sync_targets:
             owner = str(sync_options_override.get("owner", ""))
             repo_name = str(sync_options_override.get("repo", ""))
@@ -557,6 +592,7 @@ def _run_sync_for_repo(
                     owner=owner,
                     repo_name=repo_name,
                     token=github_credentials,
+                    since=since_dt,
                     blame_only=merged_flags.get("blame_only", False),
                     sync_git=merged_flags.get("sync_git", False),
                     sync_prs=merged_flags.get("sync_prs", False),
@@ -570,16 +606,16 @@ def _run_sync_for_repo(
 
         elif provider == "gitlab" and code_sync_targets:
             project_id = sync_options_override.get("project_id")
-            token = str(credentials.get("token") or "")
-            gitlab_url = str(
-                sync_options_override.get("gitlab_url", "https://gitlab.com")
-            )
+            gitlab_credentials = gitlab_credentials_from_mapping(credentials)
 
-            if project_id is None or not token:
+            if project_id is None or gitlab_credentials is None:
                 raise ValueError(
                     f"Missing GitLab project_id/token for batch sync: "
                     f"project_id={project_id}"
                 )
+
+            token = gitlab_credentials.token
+            gitlab_url = resolve_gitlab_url(sync_options_override, gitlab_credentials)
 
             gitlab_targets = [
                 target for target in code_sync_targets if target != "work-items"
@@ -592,6 +628,7 @@ def _run_sync_for_repo(
                     project_id=int(project_id),
                     token=token,
                     gitlab_url=gitlab_url,
+                    since=since_dt,
                     blame_only=merged_flags.get("blame_only", False),
                     sync_git=merged_flags.get("sync_git", False),
                     sync_prs=merged_flags.get("sync_prs", False),
@@ -658,6 +695,15 @@ def _run_sync_for_repo(
                 },
             )
             result_payload["work_items_synced"] = True
+
+        # Stamp watermarks on success the same way run_sync_config does:
+        # one row per sync target, anchored at the task's start time so work
+        # arriving mid-sync is re-fetched on the next run.
+        if repo_id_for_watermark:
+            with get_postgres_session_sync() as session:
+                for t in sync_targets:
+                    set_watermark(session, org_id, repo_id_for_watermark, t, started_at)
+                session.flush()
 
         duration = int((datetime.now(timezone.utc) - started_at).total_seconds())
         return {

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -23,7 +23,7 @@ from dev_health_ops.workers.sync_runtime import (
     run_sync_config,
 )
 from dev_health_ops.workers.task_utils import (
-    _decrypt_credential_sync,
+    _credential_mapping,
     _extract_provider_token,
     _get_db_url,
     _inject_provider_token,
@@ -352,7 +352,9 @@ def dispatch_batch_sync(
                     raise _TerminalSyncError(
                         f"Credential not found: {config.credential_id}"
                     )
-                credentials = _decrypt_credential_sync(credential)
+                # Merge non-sensitive credential.config (e.g. self-hosted
+                # GitLab url) under the decrypted secrets (CHAOS-2282).
+                credentials = _credential_mapping(credential)
             else:
                 credentials = _resolve_env_credentials(provider)
 

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -558,7 +558,10 @@ def _run_sync_for_repo(
             _repo = str(sync_options_override.get("repo", ""))
             if _owner and _repo:
                 repo_id_for_watermark = f"{_owner}/{_repo}"
-        elif provider == "gitlab":
+        elif provider == "gitlab" and code_sync_targets:
+            # Gate on code targets like GitHub: work-items windows come from
+            # backfill_days, so a work-items-only child must not stamp a
+            # misleading watermark row.
             _pid = sync_options_override.get("project_id") or sync_options_override.get(
                 "repo"
             )
@@ -653,6 +656,15 @@ def _run_sync_for_repo(
             token = _extract_provider_token(provider, credentials)
             if token:
                 _inject_provider_token(provider, token)
+            if provider == "gitlab":
+                # fetch_gitlab_work_items builds GitLabWorkClient.from_env(),
+                # which reads GITLAB_URL — inject the resolved instance URL so
+                # self-hosted work-items don't fall back to gitlab.com while
+                # code sync above talks to the right host.
+                os.environ["GITLAB_URL"] = resolve_gitlab_url(
+                    sync_options_override,
+                    gitlab_credentials_from_mapping(credentials),
+                )
             backfill_days = int(sync_options_override.get("backfill_days", 1))
             chunk_index = int(sync_options_override.get("chunk_index", 0))
             chunk_since = sync_options_override.get("since")

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -5,7 +5,11 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from dev_health_ops.credentials.resolver import github_credentials_from_mapping
+from dev_health_ops.credentials.resolver import (
+    github_credentials_from_mapping,
+    gitlab_credentials_from_mapping,
+    resolve_gitlab_url,
+)
 from dev_health_ops.utils.datetime import utc_today
 from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
@@ -588,11 +592,12 @@ def run_sync_config(
                 if project_id is None:
                     raise ValueError("Missing GitLab project_id in sync options")
 
-                token = str(credentials.get("token") or "")
-                if not token:
+                gitlab_credentials = gitlab_credentials_from_mapping(credentials)
+                if gitlab_credentials is None:
                     raise ValueError("Missing GitLab token for sync configuration")
 
-                gitlab_url = str(sync_options.get("gitlab_url", "https://gitlab.com"))
+                token = gitlab_credentials.token
+                gitlab_url = resolve_gitlab_url(sync_options, gitlab_credentials)
                 merged_flags = _merge_sync_flags(gitlab_targets)
 
                 async def _gitlab_handler(store):

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -22,7 +22,7 @@ from dev_health_ops.workers.task_utils import (
     _as_str,
     _as_str_list,
     _as_uuid,
-    _decrypt_credential_sync,
+    _credential_mapping,
     _extract_owner_repo,
     _extract_provider_token,
     _get_db_url,
@@ -425,7 +425,9 @@ def run_sync_config(
                         f"Credential not found for sync configuration: {config.credential_id}"
                     )
 
-                credentials = _decrypt_credential_sync(credential)
+                # Merge non-sensitive credential.config (e.g. self-hosted
+                # GitLab url) under the decrypted secrets (CHAOS-2282).
+                credentials = _credential_mapping(credential)
             else:
                 credentials = _resolve_env_credentials(provider)
 

--- a/src/dev_health_ops/workers/sync_team.py
+++ b/src/dev_health_ops/workers/sync_team.py
@@ -103,9 +103,12 @@ async def _discover_and_sync_all(org_id: str | None) -> dict:
                     return {"provider": provider, "skipped": "missing_config"}
                 if not isinstance(url, str) or not url:
                     return {"provider": provider, "skipped": "missing_config"}
-                teams = await discovery_svc.discover_gitlab(
+                gitlab_result = await discovery_svc.discover_gitlab(
                     token=token, group_path=group_path, url=url
                 )
+                # Truncation is logged server-side by the discovery walk;
+                # drift sync only consumes the (possibly partial) teams.
+                teams = gitlab_result.teams
             else:
                 email = decrypted.get("email")
                 api_token = decrypted.get("api_token") or decrypted.get("token")

--- a/src/dev_health_ops/workers/task_utils.py
+++ b/src/dev_health_ops/workers/task_utils.py
@@ -78,6 +78,22 @@ def _decrypt_credential_sync(credential) -> dict[str, Any]:
     return {}
 
 
+def _credential_mapping(credential) -> dict[str, Any]:
+    """Build the full credentials mapping for an ``IntegrationCredential``.
+
+    Merges the credential's non-sensitive ``config`` column (base URLs and
+    other provider options, e.g. a self-hosted GitLab ``url``) underneath the
+    decrypted secret fields, so resolvers such as
+    ``gitlab_credentials_from_mapping`` see both. Decrypted values win on key
+    collisions: ``config`` must never shadow a stored secret.
+    """
+    decrypted = _decrypt_credential_sync(credential)
+    config = getattr(credential, "config", None)
+    if not isinstance(config, dict) or not config:
+        return decrypted
+    return {**config, **decrypted}
+
+
 def _inject_provider_token(provider: str, token: str) -> None:
     env_var = {
         "github": "GITHUB_TOKEN",

--- a/tests/api/admin/test_teams_discover_org_group.py
+++ b/tests/api/admin/test_teams_discover_org_group.py
@@ -18,7 +18,8 @@ import importlib
 import os
 import uuid
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -31,6 +32,7 @@ os.environ.setdefault("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
 from dev_health_ops.api.admin.schemas import DiscoveredTeam
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.configuration import (
+    GitLabDiscoveryResult,
     IntegrationCredentialsService,
     SyncConfigurationService,
 )
@@ -301,7 +303,9 @@ async def test_github_400_when_token_missing(client, session_maker):
 async def test_gitlab_query_param_wins(client, session_maker):
     await _seed_credential(session_maker, "gitlab", config={"group": "config-group"})
 
-    with patch(_GITLAB_DISCOVER, new=AsyncMock(return_value=[])) as mock_discover:
+    with patch(
+        _GITLAB_DISCOVER, new=AsyncMock(return_value=GitLabDiscoveryResult(teams=[]))
+    ) as mock_discover:
         response = await client.get(
             "/api/v1/admin/teams/discover?provider=gitlab&group=param-group"
         )
@@ -310,6 +314,10 @@ async def test_gitlab_query_param_wins(client, session_maker):
     mock_discover.assert_awaited_once_with(
         token="test-token", group_path="param-group", url="https://gitlab.com"
     )
+    # Discovery completed without hitting pagination bounds.
+    data = response.json()
+    assert data["truncated"] is False
+    assert data["warnings"] == []
 
 
 @pytest.mark.asyncio
@@ -320,13 +328,70 @@ async def test_gitlab_derives_group_from_sync_options(client, session_maker):
         session_maker, "gitlab", "my-group/api", {"owner": "my-group"}
     )
 
-    with patch(_GITLAB_DISCOVER, new=AsyncMock(return_value=[])) as mock_discover:
+    with patch(
+        _GITLAB_DISCOVER, new=AsyncMock(return_value=GitLabDiscoveryResult(teams=[]))
+    ) as mock_discover:
         response = await client.get("/api/v1/admin/teams/discover?provider=gitlab")
 
     assert response.status_code == 200, response.text
     mock_discover.assert_awaited_once_with(
         token="test-token", group_path="my-group", url="https://gitlab.com"
     )
+
+
+@pytest.mark.asyncio
+async def test_gitlab_truncated_discovery_surfaces_in_response(client, session_maker):
+    """Partial GitLab walks must be visible to the caller, not silently
+    presented as complete (CHAOS-2281 review follow-up)."""
+    await _seed_credential(session_maker, "gitlab", config={"group": "big-group"})
+
+    warning = (
+        "GitLab team discovery truncated projects for 'big-group' at "
+        "500 results; the import may be incomplete."
+    )
+    result = GitLabDiscoveryResult(
+        teams=[_team("gitlab", "big-group/platform")],
+        truncated=True,
+        warnings=[warning],
+    )
+    with patch(_GITLAB_DISCOVER, new=AsyncMock(return_value=result)):
+        response = await client.get("/api/v1/admin/teams/discover?provider=gitlab")
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["total"] == 1
+    assert data["truncated"] is True
+    assert data["warnings"] == [warning]
+
+
+@pytest.mark.asyncio
+async def test_gitlab_truncation_aggregates_across_groups(client, session_maker):
+    """With multiple derived groups, one truncated walk flags the whole
+    response and all warnings are preserved."""
+    await _seed_credential(session_maker, "gitlab")
+    await _seed_sync_config(session_maker, "gitlab", "grp-a/api", {"owner": "grp-a"})
+    await _seed_sync_config(session_maker, "gitlab", "grp-b/web", {"owner": "grp-b"})
+
+    results = {
+        "grp-a": GitLabDiscoveryResult(teams=[_team("gitlab", "grp-a/x")]),
+        "grp-b": GitLabDiscoveryResult(
+            teams=[_team("gitlab", "grp-b/y")],
+            truncated=True,
+            warnings=["GitLab team discovery truncated subgroups for 'grp-b'"],
+        ),
+    }
+
+    async def _discover(token: str, group_path: str, url: str):
+        return results[group_path]
+
+    with patch(_GITLAB_DISCOVER, new=AsyncMock(side_effect=_discover)):
+        response = await client.get("/api/v1/admin/teams/discover?provider=gitlab")
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["total"] == 2
+    assert data["truncated"] is True
+    assert data["warnings"] == ["GitLab team discovery truncated subgroups for 'grp-b'"]
 
 
 @pytest.mark.asyncio
@@ -360,3 +425,69 @@ async def test_derivation_ignores_other_orgs_sync_configs(client, session_maker)
     response = await client.get("/api/v1/admin/teams/discover?provider=github")
 
     assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GitLab discovery truncation (service level)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discover_gitlab_flags_truncation_when_bound_hit(monkeypatch):
+    """When the project walk exceeds the discovery bound, the result is
+    truncated to the bound and explicitly flagged instead of silently
+    presented as complete."""
+    from dev_health_ops.api.services.configuration import team_discovery as td
+
+    monkeypatch.setattr(td, "MAX_GITLAB_DISCOVERY_PROJECTS", 2)
+
+    root_group = MagicMock()
+    root_group.full_path = "big-group"
+    root_group.name = "Big Group"
+    root_group.description = None
+    root_group.subgroups.list.return_value = iter([])
+    root_group.projects.list.return_value = iter(
+        SimpleNamespace(path_with_namespace=f"big-group/p{i}") for i in range(5)
+    )
+
+    fake_gl = MagicMock()
+    fake_gl.groups.get.return_value = root_group
+
+    with patch("gitlab.Gitlab", return_value=fake_gl):
+        svc = td.TeamDiscoveryService(None, ORG_ID)
+        result = await svc.discover_gitlab(token="t", group_path="big-group")
+
+    assert result.truncated is True
+    assert any("truncated projects" in w for w in result.warnings)
+    assert len(result.teams) == 1
+    assert result.teams[0].associations["repo_patterns"] == [
+        "big-group/p0",
+        "big-group/p1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_discover_gitlab_not_truncated_under_bound(monkeypatch):
+    from dev_health_ops.api.services.configuration import team_discovery as td
+
+    monkeypatch.setattr(td, "MAX_GITLAB_DISCOVERY_PROJECTS", 10)
+
+    root_group = MagicMock()
+    root_group.full_path = "small-group"
+    root_group.name = "Small Group"
+    root_group.description = None
+    root_group.subgroups.list.return_value = iter([])
+    root_group.projects.list.return_value = iter(
+        [SimpleNamespace(path_with_namespace="small-group/only")]
+    )
+
+    fake_gl = MagicMock()
+    fake_gl.groups.get.return_value = root_group
+
+    with patch("gitlab.Gitlab", return_value=fake_gl):
+        svc = td.TeamDiscoveryService(None, ORG_ID)
+        result = await svc.discover_gitlab(token="t", group_path="small-group")
+
+    assert result.truncated is False
+    assert result.warnings == []
+    assert len(result.teams) == 1

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -2014,3 +2014,74 @@ class TestRunSyncConfigGitLabCredentialConfig:
 
         assert result["status"] == "success"
         assert processor.await_args.kwargs["gitlab_url"] == "https://opt.example.com"
+
+
+class TestGitLabWorkItemsUrlInjection:
+    """Self-hosted GitLab work-items must reach the configured instance.
+
+    fetch_gitlab_work_items builds GitLabWorkClient.from_env() (GITLAB_URL), so
+    _run_sync_for_repo injects the resolved URL before the work-items chunk
+    (post-rebase Codex finding on CHAOS-2282).
+    """
+
+    @patch.dict(os.environ, {}, clear=False)
+    @patch("dev_health_ops.metrics.job_work_items.run_work_items_sync_job")
+    @patch("dev_health_ops.workers.sync_batch._get_db_url")
+    def test_gitlab_url_env_injected_from_credentials(
+        self, mock_get_db_url, mock_run_job
+    ):
+        from dev_health_ops.workers.sync_batch import _run_sync_for_repo
+
+        mock_get_db_url.return_value = "clickhouse://ch:ch@clickhouse:8123/default"
+        os.environ.pop("GITLAB_URL", None)
+
+        task = _run_sync_for_repo
+        task.push_request(id="repo-sync-gl-url")
+        try:
+            task(
+                config_id="cfg-1",
+                org_id="org-1",
+                triggered_by="schedule",
+                provider="gitlab",
+                sync_targets=["work-items"],
+                sync_options_override={"project_id": 42},
+                credentials={
+                    "token": "glpat-child",
+                    "url": "https://gitlab.example.com",
+                },
+                config_name="gl-batch",
+            )
+        finally:
+            task.pop_request()
+
+        assert os.environ.get("GITLAB_URL") == "https://gitlab.example.com"
+        assert mock_run_job.call_args.kwargs["provider"] == "gitlab"
+
+    @patch.dict(os.environ, {}, clear=False)
+    @patch("dev_health_ops.sync.watermarks.set_watermark")
+    @patch("dev_health_ops.metrics.job_work_items.run_work_items_sync_job")
+    @patch("dev_health_ops.workers.sync_batch._get_db_url")
+    def test_gitlab_work_items_only_child_stamps_no_watermark(
+        self, mock_get_db_url, mock_run_job, mock_set_watermark
+    ):
+        from dev_health_ops.workers.sync_batch import _run_sync_for_repo
+
+        mock_get_db_url.return_value = "clickhouse://ch:ch@clickhouse:8123/default"
+
+        task = _run_sync_for_repo
+        task.push_request(id="repo-sync-gl-wm")
+        try:
+            task(
+                config_id="cfg-1",
+                org_id="org-1",
+                triggered_by="schedule",
+                provider="gitlab",
+                sync_targets=["work-items"],
+                sync_options_override={"project_id": 42},
+                credentials={"token": "glpat-child"},
+                config_name="gl-batch",
+            )
+        finally:
+            task.pop_request()
+
+        mock_set_watermark.assert_not_called()

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -5,7 +5,7 @@ import sys
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import create_engine
@@ -644,6 +644,475 @@ class TestDispatchBatchSync:
 
         assert result["status"] == "dispatched"
         assert captured_kwargs[0]["sync_options_override"]["search"] == "org/repo-1"
+
+
+class TestGitLabCredentialsFromMapping:
+    def test_token_only_defaults_to_gitlab_com(self):
+        from dev_health_ops.credentials.resolver import gitlab_credentials_from_mapping
+
+        creds = gitlab_credentials_from_mapping({"token": "glpat_secret"})
+        assert creds is not None
+        assert creds.token == "glpat_secret"
+        assert creds.base_url == "https://gitlab.com"
+
+    def test_gitlab_url_key_is_used(self):
+        from dev_health_ops.credentials.resolver import gitlab_credentials_from_mapping
+
+        creds = gitlab_credentials_from_mapping(
+            {"token": "glpat_secret", "gitlab_url": "https://gitlab.example.com"}
+        )
+        assert creds is not None
+        assert creds.base_url == "https://gitlab.example.com"
+
+    def test_url_key_is_used(self):
+        from dev_health_ops.credentials.resolver import gitlab_credentials_from_mapping
+
+        creds = gitlab_credentials_from_mapping(
+            {"token": "glpat_secret", "url": "https://gl.corp.internal"}
+        )
+        assert creds is not None
+        assert creds.base_url == "https://gl.corp.internal"
+
+    def test_base_url_key_is_used(self):
+        from dev_health_ops.credentials.resolver import gitlab_credentials_from_mapping
+
+        creds = gitlab_credentials_from_mapping(
+            {"token": "glpat_secret", "base_url": "https://gl.env.internal"}
+        )
+        assert creds is not None
+        assert creds.base_url == "https://gl.env.internal"
+
+    def test_gitlab_url_takes_precedence_over_url_and_base_url(self):
+        from dev_health_ops.credentials.resolver import gitlab_credentials_from_mapping
+
+        creds = gitlab_credentials_from_mapping(
+            {
+                "token": "glpat_secret",
+                "gitlab_url": "https://first.example.com",
+                "url": "https://second.example.com",
+                "base_url": "https://third.example.com",
+            }
+        )
+        assert creds is not None
+        assert creds.base_url == "https://first.example.com"
+
+    def test_missing_token_returns_none(self):
+        from dev_health_ops.credentials.resolver import gitlab_credentials_from_mapping
+
+        assert gitlab_credentials_from_mapping({}) is None
+        assert (
+            gitlab_credentials_from_mapping({"url": "https://gl.example.com"}) is None
+        )
+        assert gitlab_credentials_from_mapping({"token": None}) is None
+
+
+class TestResolveGitlabUrl:
+    def test_sync_options_take_precedence_over_credentials(self):
+        from dev_health_ops.credentials.resolver import (
+            gitlab_credentials_from_mapping,
+            resolve_gitlab_url,
+        )
+
+        creds = gitlab_credentials_from_mapping(
+            {"token": "t", "url": "https://cred.example.com"}
+        )
+        assert (
+            resolve_gitlab_url({"gitlab_url": "https://opt.example.com"}, creds)
+            == "https://opt.example.com"
+        )
+
+    def test_falls_back_to_credential_url(self):
+        from dev_health_ops.credentials.resolver import (
+            gitlab_credentials_from_mapping,
+            resolve_gitlab_url,
+        )
+
+        creds = gitlab_credentials_from_mapping(
+            {"token": "t", "url": "https://cred.example.com"}
+        )
+        assert resolve_gitlab_url({}, creds) == "https://cred.example.com"
+
+    def test_defaults_to_gitlab_com(self):
+        from dev_health_ops.credentials.resolver import resolve_gitlab_url
+
+        assert resolve_gitlab_url({}, None) == "https://gitlab.com"
+
+
+def _run_child_sync_task(
+    db_session,
+    *,
+    provider: str,
+    sync_options_override: dict,
+    credentials: dict,
+    sync_targets: list[str],
+    processor_path: str,
+):
+    """Execute _run_sync_for_repo with the store/processor layers mocked out.
+
+    Returns (task result, processor AsyncMock) so tests can assert on the
+    kwargs forwarded to process_github_repo / process_gitlab_project.
+    """
+    import uuid as _uuid
+
+    import dev_health_ops.connectors  # noqa: F401  (avoid circular-import on first load)
+    import dev_health_ops.processors.github  # noqa: F401  (make patch targets resolvable)
+    import dev_health_ops.processors.gitlab  # noqa: F401
+    from dev_health_ops.workers.sync_batch import _run_sync_for_repo
+
+    async def _fake_run_with_store(db_url, db_type, handler, org_id=None):
+        await handler(MagicMock())
+
+    processor_mock = AsyncMock()
+    with (
+        patch(
+            "dev_health_ops.workers.sync_batch._get_db_url",
+            return_value="clickhouse://localhost/dev",
+        ),
+        patch("dev_health_ops.storage.resolve_db_type", return_value="clickhouse"),
+        patch("dev_health_ops.storage.run_with_store", new=_fake_run_with_store),
+        patch(processor_path, processor_mock),
+        patch(
+            "dev_health_ops.db.get_postgres_session_sync",
+            side_effect=lambda *a, **k: _fake_session_ctx(db_session),
+        ),
+    ):
+        task = _run_sync_for_repo
+        task.push_request(id=f"child-{_uuid.uuid4()}", retries=0)
+        try:
+            result = task(
+                config_id=str(_uuid.uuid4()),
+                org_id="default",
+                triggered_by="manual",
+                provider=provider,
+                sync_targets=sync_targets,
+                sync_options_override=sync_options_override,
+                credentials=credentials,
+                config_name="batch-config",
+            )
+        finally:
+            task.pop_request()
+    return result, processor_mock
+
+
+def _seed_watermarks(db_session, repo_id: str, targets_to_ts: dict[str, datetime]):
+    from dev_health_ops.models.settings import SyncWatermark
+
+    for target, ts in targets_to_ts.items():
+        db_session.add(
+            SyncWatermark(
+                org_id="default",
+                repo_id=repo_id,
+                target=target,
+                last_synced_at=ts,
+            )
+        )
+    db_session.flush()
+
+
+class TestGitLabDispatchBatchSync:
+    """GitLab batch dispatch mirrors GitHub: child kwargs, gitlab_url threading,
+    watermark read/stamp (CHAOS-2281), and credential URL resolution (CHAOS-2282).
+    """
+
+    @patch("dev_health_ops.workers.sync_batch._run_sync_for_repo")
+    @patch("dev_health_ops.workers.sync_batch.chord")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_dispatches_per_project_children_with_gitlab_url_threading(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_chord,
+        mock_run_for_repo,
+        db_session,
+    ):
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        captured_kwargs = []
+
+        def _capture_signature(**kwargs):
+            captured_kwargs.append(kwargs)
+            return MagicMock()
+
+        mock_run_for_repo.s.side_effect = _capture_signature
+        config = _make_config(
+            provider="gitlab",
+            sync_options={
+                "search": "my-group/*",
+                "gitlab_url": "https://gitlab.example.com",
+            },
+            sync_targets=["git", "prs"],
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        mock_get_session.return_value = _fake_session_ctx(db_session)
+        mock_resolve_creds.return_value = {"token": "glpat_test"}
+        mock_discover.return_value = [("100",), ("200",)]
+        mock_chord.return_value = MagicMock()
+
+        task = dispatch_batch_sync
+        task.push_request(id="gl-batch-dispatch-1")
+        try:
+            result = task(config_id=str(config.id), org_id="default")
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "dispatched"
+        assert result["total_repos"] == 2
+        assert len(captured_kwargs) == 2
+
+        first = captured_kwargs[0]
+        assert first["provider"] == "gitlab"
+        assert first["sync_targets"] == ["git", "prs"]
+        assert first["credentials"] == {"token": "glpat_test"}
+
+        override = first["sync_options_override"]
+        assert override["project_id"] == 100
+        assert override["gitlab_url"] == "https://gitlab.example.com"
+        assert "search" not in override
+        assert "group" not in override
+
+        assert captured_kwargs[1]["sync_options_override"]["project_id"] == 200
+
+    @patch("dev_health_ops.discovery.repos.discover_gitlab_repos")
+    def test_discovery_resolves_gitlab_url_from_credentials(self, mock_gl):
+        from dev_health_ops.discovery.repos import discover_repos_for_config
+
+        mock_gl.return_value = [("100",)]
+        config = _make_config(
+            provider="gitlab",
+            sync_options={"search": "my-group/*"},
+        )
+        result = discover_repos_for_config(
+            config, {"token": "glpat_test", "url": "https://gl.corp.internal"}
+        )
+        assert result == [("100",)]
+        args, kwargs = mock_gl.call_args
+        assert args[1] == "glpat_test"
+        assert kwargs["gitlab_url"] == "https://gl.corp.internal"
+
+    @patch("dev_health_ops.discovery.repos.discover_gitlab_repos")
+    def test_discovery_sync_options_url_beats_credential_url(self, mock_gl):
+        from dev_health_ops.discovery.repos import discover_repos_for_config
+
+        mock_gl.return_value = []
+        config = _make_config(
+            provider="gitlab",
+            sync_options={
+                "search": "my-group/*",
+                "gitlab_url": "https://opt.example.com",
+            },
+        )
+        discover_repos_for_config(
+            config, {"token": "glpat_test", "url": "https://cred.example.com"}
+        )
+        assert mock_gl.call_args.kwargs["gitlab_url"] == "https://opt.example.com"
+
+    def test_batch_eligibility_unchanged_for_gitlab(self):
+        from dev_health_ops.workers.sync_batch import _is_batch_eligible
+
+        eligible = _make_config(
+            provider="gitlab",
+            sync_options={
+                "group": "my-group",
+                "gitlab_url": "https://gitlab.example.com",
+            },
+        )
+        assert _is_batch_eligible(eligible) is True
+
+        single = _make_config(
+            provider="gitlab",
+            sync_options={
+                "group": "my-group",
+                "project_id": 100,
+                "gitlab_url": "https://gitlab.example.com",
+            },
+        )
+        assert _is_batch_eligible(single) is False
+
+
+class TestRunSyncForRepoWatermarks:
+    """Batch children must honour and stamp sync watermarks (CHAOS-2281),
+    mirroring run_sync_config: since=min(watermarks) only when every target
+    has one, no since on partial coverage or full_resync, stamp on success.
+    """
+
+    GITLAB_PROCESSOR = "dev_health_ops.processors.gitlab.process_gitlab_project"
+    GITHUB_PROCESSOR = "dev_health_ops.processors.github.process_github_repo"
+
+    def test_gitlab_child_passes_min_watermark_as_since(self, db_session):
+        older = datetime(2026, 1, 1, 12, 0, 0)
+        newer = datetime(2026, 1, 5, 12, 0, 0)
+        _seed_watermarks(db_session, "100", {"git": newer, "prs": older})
+
+        result, processor = _run_child_sync_task(
+            db_session,
+            provider="gitlab",
+            sync_options_override={"project_id": 100},
+            credentials={"token": "glpat_test"},
+            sync_targets=["git", "prs"],
+            processor_path=self.GITLAB_PROCESSOR,
+        )
+
+        assert result["status"] == "success"
+        since = processor.await_args.kwargs["since"]
+        assert since is not None
+        assert since.replace(tzinfo=None) == older
+
+    def test_gitlab_child_partial_watermarks_means_no_since(self, db_session):
+        _seed_watermarks(db_session, "100", {"git": datetime(2026, 1, 1)})
+
+        result, processor = _run_child_sync_task(
+            db_session,
+            provider="gitlab",
+            sync_options_override={"project_id": 100},
+            credentials={"token": "glpat_test"},
+            sync_targets=["git", "prs"],
+            processor_path=self.GITLAB_PROCESSOR,
+        )
+
+        assert result["status"] == "success"
+        assert processor.await_args.kwargs["since"] is None
+
+    def test_gitlab_child_full_resync_ignores_watermarks(self, db_session):
+        ts = datetime(2026, 1, 1)
+        _seed_watermarks(db_session, "100", {"git": ts, "prs": ts})
+
+        result, processor = _run_child_sync_task(
+            db_session,
+            provider="gitlab",
+            sync_options_override={"project_id": 100, "full_resync": True},
+            credentials={"token": "glpat_test"},
+            sync_targets=["git", "prs"],
+            processor_path=self.GITLAB_PROCESSOR,
+        )
+
+        assert result["status"] == "success"
+        assert processor.await_args.kwargs["since"] is None
+
+    def test_gitlab_child_stamps_watermarks_on_success(self, db_session):
+        from dev_health_ops.models.settings import SyncWatermark
+
+        result, _ = _run_child_sync_task(
+            db_session,
+            provider="gitlab",
+            sync_options_override={"project_id": 100},
+            credentials={"token": "glpat_test"},
+            sync_targets=["git", "prs"],
+            processor_path=self.GITLAB_PROCESSOR,
+        )
+
+        assert result["status"] == "success"
+        rows = (
+            db_session.query(SyncWatermark)
+            .filter(
+                SyncWatermark.org_id == "default",
+                SyncWatermark.repo_id == "100",
+            )
+            .all()
+        )
+        assert {row.target for row in rows} == {"git", "prs"}
+        assert all(row.last_synced_at is not None for row in rows)
+
+    def test_gitlab_child_failure_does_not_stamp_watermarks(self, db_session):
+        import uuid as _uuid
+
+        from dev_health_ops.models.settings import SyncWatermark
+        from dev_health_ops.workers.sync_batch import _run_sync_for_repo
+
+        with (
+            patch(
+                "dev_health_ops.workers.sync_batch._get_db_url",
+                return_value="clickhouse://localhost/dev",
+            ),
+            patch("dev_health_ops.storage.resolve_db_type", return_value="clickhouse"),
+            patch(
+                "dev_health_ops.db.get_postgres_session_sync",
+                side_effect=lambda *a, **k: _fake_session_ctx(db_session),
+            ),
+        ):
+            task = _run_sync_for_repo
+            task.push_request(id=f"child-{_uuid.uuid4()}", retries=0)
+            try:
+                # Missing token => ValueError inside the gitlab branch.
+                with pytest.raises(Exception):
+                    task(
+                        config_id=str(_uuid.uuid4()),
+                        org_id="default",
+                        triggered_by="manual",
+                        provider="gitlab",
+                        sync_targets=["git"],
+                        sync_options_override={"project_id": 100},
+                        credentials={},
+                        config_name="batch-config",
+                    )
+            finally:
+                task.pop_request()
+
+        assert db_session.query(SyncWatermark).count() == 0
+
+    def test_gitlab_child_resolves_url_from_credentials(self, db_session):
+        result, processor = _run_child_sync_task(
+            db_session,
+            provider="gitlab",
+            sync_options_override={"project_id": 100},
+            credentials={"token": "glpat_test", "url": "https://gl.corp.internal"},
+            sync_targets=["git"],
+            processor_path=self.GITLAB_PROCESSOR,
+        )
+
+        assert result["status"] == "success"
+        assert processor.await_args.kwargs["gitlab_url"] == "https://gl.corp.internal"
+        assert result["result"]["gitlab_url"] == "https://gl.corp.internal"
+
+    def test_gitlab_child_sync_options_url_beats_credential_url(self, db_session):
+        result, processor = _run_child_sync_task(
+            db_session,
+            provider="gitlab",
+            sync_options_override={
+                "project_id": 100,
+                "gitlab_url": "https://opt.example.com",
+            },
+            credentials={"token": "glpat_test", "url": "https://cred.example.com"},
+            sync_targets=["git"],
+            processor_path=self.GITLAB_PROCESSOR,
+        )
+
+        assert result["status"] == "success"
+        assert processor.await_args.kwargs["gitlab_url"] == "https://opt.example.com"
+
+    def test_github_child_passes_since_and_stamps_watermarks(self, db_session):
+        from dev_health_ops.models.settings import SyncWatermark
+
+        older = datetime(2026, 2, 1)
+        newer = datetime(2026, 2, 3)
+        _seed_watermarks(db_session, "org/repo-1", {"git": older, "prs": newer})
+
+        result, processor = _run_child_sync_task(
+            db_session,
+            provider="github",
+            sync_options_override={"owner": "org", "repo": "repo-1"},
+            credentials={"token": "ghp_test"},
+            sync_targets=["git", "prs"],
+            processor_path=self.GITHUB_PROCESSOR,
+        )
+
+        assert result["status"] == "success"
+        since = processor.await_args.kwargs["since"]
+        assert since is not None
+        assert since.replace(tzinfo=None) == older
+
+        rows = (
+            db_session.query(SyncWatermark)
+            .filter(SyncWatermark.repo_id == "org/repo-1")
+            .all()
+        )
+        assert {row.target for row in rows} == {"git", "prs"}
+        # Stamped at task start time: strictly newer than the seeded values.
+        assert all(row.last_synced_at.replace(tzinfo=None) > newer for row in rows)
 
 
 class TestBatchSyncCallback:

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -1769,3 +1769,248 @@ class TestRunSyncForRepoCredentials:
             task.pop_request()
 
         assert mock_run_job.call_args.kwargs["credentials"] is None
+
+
+class TestCredentialMapping:
+    """credential.config must be visible to the credential resolvers without
+    ever shadowing decrypted secrets (CHAOS-2282 review follow-up)."""
+
+    def test_config_only_values_are_exposed(self):
+        from dev_health_ops.workers.task_utils import _credential_mapping
+
+        credential = SimpleNamespace(
+            credentials_encrypted=None,
+            config={"url": "https://gitlab.example.com"},
+        )
+        assert _credential_mapping(credential) == {"url": "https://gitlab.example.com"}
+
+    def test_decrypted_wins_on_key_collision(self):
+        from dev_health_ops.workers.task_utils import _credential_mapping
+
+        credential = SimpleNamespace(
+            credentials_encrypted="ciphertext",
+            config={"url": "https://config.example.com", "group": "my-group"},
+        )
+        with patch(
+            "dev_health_ops.workers.task_utils._decrypt_credential_sync",
+            return_value={
+                "token": "glpat_secret",
+                "url": "https://decrypted.example.com",
+            },
+        ):
+            mapping = _credential_mapping(credential)
+
+        assert mapping == {
+            "token": "glpat_secret",
+            "url": "https://decrypted.example.com",
+            "group": "my-group",
+        }
+
+    def test_missing_or_invalid_config_returns_decrypted_only(self):
+        from typing import Any
+
+        from dev_health_ops.workers.task_utils import _credential_mapping
+
+        configs: tuple[Any, ...] = (None, {}, "not-a-dict")
+        for config in configs:
+            credential = SimpleNamespace(credentials_encrypted=None, config=config)
+            assert _credential_mapping(credential) == {}
+
+
+class TestDispatchBatchSyncCredentialConfig:
+    """A self-hosted GitLab url stored on credential.config (not in the
+    encrypted secrets) must reach discovery and the batch children."""
+
+    def _dispatch(self, db_session, *, decrypted: dict, config: dict):
+        import uuid as _uuid
+
+        from dev_health_ops.models.settings import IntegrationCredential
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        credential = IntegrationCredential(
+            org_id="default",
+            provider="gitlab",
+            name="default",
+            credentials_encrypted="ciphertext",
+            config=config,
+        )
+        db_session.add(credential)
+        db_session.flush()
+
+        sync_config = _make_config(
+            provider="gitlab",
+            sync_options={"search": "my-group/*"},
+            sync_targets=["git", "prs"],
+        )
+        sync_config.credential_id = credential.id
+        db_session.add(sync_config)
+        db_session.flush()
+
+        captured_kwargs: list[dict] = []
+
+        def _capture_signature(**kwargs):
+            captured_kwargs.append(kwargs)
+            return MagicMock()
+
+        with (
+            patch(
+                "dev_health_ops.workers.sync_batch._run_sync_for_repo"
+            ) as mock_run_for_repo,
+            patch("dev_health_ops.workers.sync_batch.chord", return_value=MagicMock()),
+            patch(
+                "dev_health_ops.discovery.repos.discover_repos_for_config"
+            ) as mock_discover,
+            patch(
+                "dev_health_ops.workers.task_utils._decrypt_credential_sync",
+                return_value=decrypted,
+            ),
+            patch(
+                "dev_health_ops.db.get_postgres_session_sync",
+                side_effect=lambda *a, **k: _fake_session_ctx(db_session),
+            ),
+        ):
+            mock_run_for_repo.s.side_effect = _capture_signature
+            mock_discover.return_value = [("100",)]
+
+            task = dispatch_batch_sync
+            task.push_request(id=f"gl-cred-config-{_uuid.uuid4()}")
+            try:
+                result = task(config_id=str(sync_config.id), org_id="default")
+            finally:
+                task.pop_request()
+
+        return result, mock_discover, captured_kwargs
+
+    def test_config_url_threads_to_discovery_and_children(self, db_session):
+        result, mock_discover, captured = self._dispatch(
+            db_session,
+            decrypted={"token": "glpat_secret"},
+            config={"url": "https://gitlab.example.com"},
+        )
+
+        assert result["status"] == "dispatched"
+        expected = {"url": "https://gitlab.example.com", "token": "glpat_secret"}
+        # Discovery sees the merged mapping (self-hosted instance honoured).
+        assert mock_discover.call_args.args[1] == expected
+        # Children inherit the merged mapping, so resolve_gitlab_url in the
+        # child resolves the self-hosted url too.
+        assert len(captured) == 1
+        assert captured[0]["credentials"] == expected
+
+    def test_decrypted_url_wins_over_config_url(self, db_session):
+        _, mock_discover, captured = self._dispatch(
+            db_session,
+            decrypted={"token": "glpat_secret", "url": "https://decrypted.example.com"},
+            config={"url": "https://config.example.com"},
+        )
+
+        expected = {"token": "glpat_secret", "url": "https://decrypted.example.com"}
+        assert mock_discover.call_args.args[1] == expected
+        assert captured[0]["credentials"] == expected
+
+
+class TestRunSyncConfigGitLabCredentialConfig:
+    """run_sync_config's gitlab branch must honour credential.config URLs:
+    sync_options.gitlab_url -> decrypted url -> credential.config url ->
+    https://gitlab.com (CHAOS-2282 review follow-up)."""
+
+    GITLAB_PROCESSOR = "dev_health_ops.processors.gitlab.process_gitlab_project"
+
+    def _run(
+        self,
+        db_session,
+        *,
+        decrypted: dict,
+        config: dict,
+        sync_options: dict | None = None,
+    ):
+        import uuid as _uuid
+
+        import dev_health_ops.connectors  # noqa: F401  (avoid circular-import on first load)
+        import dev_health_ops.processors.gitlab  # noqa: F401  (make patch target resolvable)
+        from dev_health_ops.models.settings import IntegrationCredential
+        from dev_health_ops.workers.sync_runtime import run_sync_config
+
+        credential = IntegrationCredential(
+            org_id="default",
+            provider="gitlab",
+            name="default",
+            credentials_encrypted="ciphertext",
+            config=config,
+        )
+        db_session.add(credential)
+        db_session.flush()
+
+        sync_config = _make_config(
+            provider="gitlab",
+            sync_options={"project_id": 100, **(sync_options or {})},
+            sync_targets=["git"],
+        )
+        sync_config.credential_id = credential.id
+        db_session.add(sync_config)
+        db_session.flush()
+
+        async def _fake_run_with_store(db_url, db_type, handler, org_id=None):
+            await handler(MagicMock())
+
+        processor_mock = AsyncMock()
+        with (
+            patch(
+                "dev_health_ops.workers.sync_runtime._get_db_url",
+                return_value="clickhouse://localhost/dev",
+            ),
+            patch("dev_health_ops.storage.resolve_db_type", return_value="clickhouse"),
+            patch("dev_health_ops.storage.run_with_store", new=_fake_run_with_store),
+            patch(self.GITLAB_PROCESSOR, processor_mock),
+            patch("dev_health_ops.workers.sync_runtime._dispatch_post_sync_tasks"),
+            patch(
+                "dev_health_ops.workers.task_utils._decrypt_credential_sync",
+                return_value=decrypted,
+            ),
+            patch(
+                "dev_health_ops.db.get_postgres_session_sync",
+                side_effect=lambda *a, **k: _fake_session_ctx(db_session),
+            ),
+        ):
+            task = run_sync_config
+            task.push_request(id=f"gl-runtime-cred-{_uuid.uuid4()}", retries=0)
+            try:
+                result = task(config_id=str(sync_config.id), org_id="default")
+            finally:
+                task.pop_request()
+        return result, processor_mock
+
+    def test_config_only_url_reaches_connector(self, db_session):
+        result, processor = self._run(
+            db_session,
+            decrypted={"token": "glpat_secret"},
+            config={"url": "https://gitlab.example.com"},
+        )
+
+        assert result["status"] == "success"
+        kwargs = processor.await_args.kwargs
+        assert kwargs["gitlab_url"] == "https://gitlab.example.com"
+        assert kwargs["token"] == "glpat_secret"
+
+    def test_decrypted_url_wins_over_config_url(self, db_session):
+        result, processor = self._run(
+            db_session,
+            decrypted={"token": "glpat_secret", "url": "https://decrypted.example.com"},
+            config={"url": "https://config.example.com"},
+        )
+
+        assert result["status"] == "success"
+        assert (
+            processor.await_args.kwargs["gitlab_url"] == "https://decrypted.example.com"
+        )
+
+    def test_sync_options_url_wins_over_everything(self, db_session):
+        result, processor = self._run(
+            db_session,
+            decrypted={"token": "glpat_secret", "url": "https://decrypted.example.com"},
+            config={"url": "https://config.example.com"},
+            sync_options={"gitlab_url": "https://opt.example.com"},
+        )
+
+        assert result["status"] == "success"
+        assert processor.await_args.kwargs["gitlab_url"] == "https://opt.example.com"

--- a/tests/test_sync_team_parallel.py
+++ b/tests/test_sync_team_parallel.py
@@ -39,9 +39,15 @@ async def test_providers_discovered_concurrently(monkeypatch):
         return_value={"token": "t", "email": "e@x", "api_token": "a"}
     )
 
+    async def slow_discover_gitlab(*args, **kwargs):
+        from dev_health_ops.api.services.configuration import GitLabDiscoveryResult
+
+        teams = await slow_discover(*args, **kwargs)
+        return GitLabDiscoveryResult(teams=teams)
+
     fake_discovery = MagicMock()
     fake_discovery.discover_github = slow_discover
-    fake_discovery.discover_gitlab = slow_discover
+    fake_discovery.discover_gitlab = slow_discover_gitlab
     fake_discovery.discover_jira = slow_discover
 
     fake_drift = MagicMock()


### PR DESCRIPTION
## Summary

Fixes two correctness bugs in the GitLab/GitHub batch sync path, plus a small discovery hardening:

### CHAOS-2281 — batch children skip watermarks (unbounded re-sync)
Watermark read/stamp lived only in `run_sync_config`; the batch child `_run_sync_for_repo` called processors with no `since`, so every batch run re-synced every repo from scratch. The child now mirrors `run_sync_config` semantics exactly:
- reads `get_watermark(session, org_id, repo_id, target)` for each sync target (repo id: `owner/repo` for GitHub, `project_id` for GitLab)
- passes `since=min(valid)` only when **all** targets have watermarks
- honours `full_resync`
- stamps watermarks for every target at task **start** time after child success (so work arriving mid-sync is re-fetched next run)
- applies to both the GitHub and GitLab child handlers

### CHAOS-2282 — gitlab_url never threads through discovery/batch
Self-hosted GitLab was silently broken: discovery and batch children extracted only `credentials['token']` and hardcoded `https://gitlab.com` unless `sync_options.gitlab_url` was set. Adds:
- `gitlab_credentials_from_mapping(mapping) -> GitLabCredentials | None` next to the GitHub mapper, resolving `base_url` from the mapping's `gitlab_url` / `url` / `base_url` keys
- `resolve_gitlab_url(sync_options, creds)` with resolution order `sync_options.gitlab_url` → credential URL → `https://gitlab.com`
- used in `run_sync_config`'s gitlab branch, `_run_sync_for_repo`'s gitlab handler, and `discover_gitlab_repos`
- team discovery (`team_discovery.py`) already receives its URL from credential config (#851) and is behaviourally unchanged

### Also
Bounded the previously unbounded `get_all=True` subgroup/project walks in GitLab team discovery (`MAX_GITLAB_DISCOVERY_SUBGROUPS` / `MAX_GITLAB_DISCOVERY_PROJECTS` = 500, warning logged on truncation).

## Tests
- `TestGitLabDispatchBatchSync`: per-project child kwargs incl. gitlab_url threading, credential-URL discovery resolution, batch eligibility unchanged
- `TestRunSyncForRepoWatermarks`: since=min(watermarks) passed, partial watermarks → no since, full_resync → no since, stamp on success, no stamp on failure, credential/sync_options URL precedence in the child — for both providers
- `TestGitLabCredentialsFromMapping` / `TestResolveGitlabUrl` mapper unit tests

## Gates
- `uv run mypy --install-types --non-interactive .` — clean (1011 files)
- `tests/test_sync_partitioning.py` + `tests/test_worker_github_app_auth.py` — 101 passed
- `./ci/run_tests.sh unit` — only the 4 known-flaky failures (test_org_deletion ×2, TestCoreCache ×2)