### PR TITLE
fix(billing): drop non-UUID org_id instead of retry-looping (poison Stripe TEST webhooks)

### DIFF
--- a/src/dev_health_ops/api/billing/router.py
+++ b/src/dev_health_ops/api/billing/router.py
@@ -380,6 +380,17 @@ async def _handle_invoice_webhook(
     if pending_email:
         email_type, org_str, kwargs = pending_email
         try:
+            uuid.UUID(str(org_str))
+        except ValueError:
+            # Stripe TEST events carry fixture metadata (e.g. org_id="org-abc");
+            # enqueuing them creates poison tasks that can never succeed.
+            logger.warning(
+                "Skipping %s email: webhook org_id=%r is not a UUID",
+                email_type,
+                org_str,
+            )
+            return
+        try:
             send_billing_notification.delay(email_type, org_str, **kwargs)
         except Exception:
             logger.debug(

--- a/src/dev_health_ops/workers/system_ops.py
+++ b/src/dev_health_ops/workers/system_ops.py
@@ -121,6 +121,18 @@ def send_billing_notification(
 
     try:
         org_uuid = uuid.UUID(org_id)
+    except ValueError:
+        # A malformed org_id is permanently bad — retrying can never succeed.
+        # Seen via Stripe TEST webhooks whose metadata carries fixture ids like
+        # "org-abc"; the retry loop just spams the worker.
+        logger.error(
+            "Billing email %s dropped: org_id=%r is not a UUID (non-retryable)",
+            email_type,
+            org_id,
+        )
+        return {"status": "dropped", "reason": "invalid_org_id", "org_id": org_id}
+
+    try:
         run_async(fn(org_uuid))
         return {"status": "sent", "email_type": email_type, "org_id": org_id}
     except Exception as exc:

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1603,3 +1603,29 @@ def test_subscription_billing_plan_fk_has_no_cascade():
             )
             return
     raise AssertionError("billing_plan_id column not found on Subscription model")
+
+
+# ---------------------------------------------------------------------------
+# Poison-message guards: non-UUID org_id must never enqueue or retry
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidOrgIdGuards:
+    def test_task_drops_invalid_org_id_without_retry(self):
+        """A malformed org_id is permanently bad — the task must drop it
+        instead of retry-looping (observed live with Stripe TEST webhook
+        fixture ids like 'org-abc')."""
+        from dev_health_ops.workers.system_ops import send_billing_notification
+
+        task = send_billing_notification
+        task.push_request(id="billing-bad-org", retries=0)
+        try:
+            result = task("subscription_cancelled", "org-abc", tier="team")
+        finally:
+            task.pop_request()
+
+        assert result == {
+            "status": "dropped",
+            "reason": "invalid_org_id",
+            "org_id": "org-abc",
+        }


### PR DESCRIPTION
## Problem
Worker logs showed a permanent retry loop:
```
send_billing_notification ... retry: Retry in 30s: ValueError('badly formed hexadecimal UUID string')  # org_id='org-abc'
```
`org-abc` is a Stripe TEST-event fixture id — local Stripe CLI forwarding delivers test webhooks whose `metadata.org_id` isn't a UUID; the billing router enqueued them and the task retried a permanently-bad input with exponential backoff (worker noise + wasted slots; see also CHAOS-2277 context).

## Fix
- **Task** (`workers/system_ops.py`): validate `org_id` before dispatch; malformed → log error + return `{status: dropped, reason: invalid_org_id}` — non-retryable.
- **Producer** (`api/billing/router.py`): skip enqueueing the notification when webhook metadata org_id isn't a UUID (warning log), so poison tasks are never created.

## Tests
- New `TestInvalidOrgIdGuards::test_task_drops_invalid_org_id_without_retry`
- Full `tests/test_billing.py`: 38/38; mypy clean (1018 files)