### PR TITLE
feat(sync): per-provider sync queues + queue depth/age telemetry (CHAOS-2299)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -115,6 +115,11 @@ services:
       PGBOUNCER_TRANSACTION_MODE: "true"
       CLICKHOUSE_URI: "clickhouse://ch:ch@clickhouse:8123/default"
       REDIS_URL: "redis://valkey:6379/1"
+      # CHAOS-2299: route sync dispatch to per-provider queues. Safe to enable
+      # here because the worker -Q lists below consume sync.<provider> in the
+      # SAME change. Bare-image deployments must follow the two-phase rollout
+      # in workers/queues.py: expand consumer -Q lists first, then flip this.
+      PROVIDER_SYNC_QUEUES_ENABLED: "true"
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
       STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
       STRIPE_PRICE_ID_TEAM: ${STRIPE_PRICE_ID_TEAM:-}
@@ -205,6 +210,8 @@ services:
   #                     (per-provider sync queues, CHAOS-2299)
   #   worker-ingest — blocking stream consumers, isolated at concurrency 1
   #   worker-heavy  — long batch jobs: metrics,backfill
+  # `monitoring` (queue-depth telemetry) is consumed by BOTH worker and
+  # worker-heavy so telemetry survives one pool flooding (CHAOS-2299).
   # ---------------------------------------------------------------------------
   worker: &worker-base
     build:
@@ -214,7 +221,7 @@ services:
       args:
         SETUPTOOLS_SCM_PRETEND_VERSION: 0.0.0
     container_name: worker
-    command: celery -A workers.celery_app worker --loglevel=info -Q default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,webhooks,reports --concurrency=${WORKER_CONCURRENCY:-4}
+    command: celery -A workers.celery_app worker --loglevel=info -Q default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,webhooks,reports,monitoring --concurrency=${WORKER_CONCURRENCY:-4}
     environment:
       <<: *env
       CELERY_BROKER_URL: redis://valkey:6379/0
@@ -242,7 +249,9 @@ services:
   worker-heavy:
     <<: *worker-base
     container_name: worker-heavy
-    command: celery -A workers.celery_app worker --loglevel=info -Q metrics,backfill --concurrency=${WORKER_HEAVY_CONCURRENCY:-2}
+    # `monitoring` is consumed here AND by `worker` above: queue telemetry
+    # survives either pool being saturated or down.
+    command: celery -A workers.celery_app worker --loglevel=info -Q metrics,backfill,monitoring --concurrency=${WORKER_HEAVY_CONCURRENCY:-2}
 
   # ---------------------------------------------------------------------------
   # Observability — SigNoz (distributed tracing + metrics)

--- a/compose.yml
+++ b/compose.yml
@@ -201,7 +201,8 @@ services:
   # One shared pool let ~250s blocking stream consumers (ingest) and
   # multi-minute syncs starve latency-sensitive work (Sync Now, webhooks)
   # for hours. Three pools isolate the workload classes:
-  #   worker        — latency-sensitive: default,sync,webhooks,reports
+  #   worker        — latency-sensitive: default,sync,sync.<provider>,webhooks,reports
+  #                     (per-provider sync queues, CHAOS-2299)
   #   worker-ingest — blocking stream consumers, isolated at concurrency 1
   #   worker-heavy  — long batch jobs: metrics,backfill
   # ---------------------------------------------------------------------------
@@ -213,7 +214,7 @@ services:
       args:
         SETUPTOOLS_SCM_PRETEND_VERSION: 0.0.0
     container_name: worker
-    command: celery -A workers.celery_app worker --loglevel=info -Q default,sync,webhooks,reports --concurrency=${WORKER_CONCURRENCY:-4}
+    command: celery -A workers.celery_app worker --loglevel=info -Q default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,webhooks,reports --concurrency=${WORKER_CONCURRENCY:-4}
     environment:
       <<: *env
       CELERY_BROKER_URL: redis://valkey:6379/0

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -32,6 +32,7 @@ from dev_health_ops.models.settings import (
     ScheduledJob,
     SyncConfiguration,
 )
+from dev_health_ops.workers.queues import sync_queue_for_provider
 from dev_health_ops.workers.sync_batch import _is_batch_eligible
 
 from .common import get_session
@@ -952,11 +953,16 @@ async def trigger_sync_config(
 
         is_batch = _is_batch_eligible(config)
         task = dispatch_batch_sync if is_batch else run_sync_config
-        result = getattr(task, "delay")(
-            config_id=str(config.id),
-            org_id=str(config.org_id),
-            triggered_by="manual",
-            pending_run_id=pending_run_id,
+        # Per-provider queue routing (CHAOS-2299): an explicit apply_async
+        # queue overrides the task decorator's queue="sync" default.
+        result = getattr(task, "apply_async")(
+            kwargs={
+                "config_id": str(config.id),
+                "org_id": str(config.org_id),
+                "triggered_by": "manual",
+                "pending_run_id": pending_run_id,
+            },
+            queue=sync_queue_for_provider(str(config.provider or "")),
         )
         return {
             "status": "triggered",

--- a/src/dev_health_ops/workers/celery_app.py
+++ b/src/dev_health_ops/workers/celery_app.py
@@ -2,10 +2,11 @@
 
 import logging
 import time
+from datetime import datetime, timezone
 from typing import Any
 
 from celery import Celery
-from celery.signals import task_postrun, task_prerun
+from celery.signals import before_task_publish, task_postrun, task_prerun
 
 from dev_health_ops.logging_config import configure_logging
 from dev_health_ops.sentry import init_sentry
@@ -19,6 +20,18 @@ instrument_celery()
 
 # Per-task start-time registry for duration tracking
 _task_start: dict[str, float] = {}
+
+
+@before_task_publish.connect
+def _stamp_enqueued_at(headers: Any = None, **kwargs: Any) -> None:
+    """Stamp publish time into the message headers (CHAOS-2299).
+
+    Celery's task protocol carries no enqueue timestamp, so the queue-depth
+    monitor (workers.queue_monitor) reads this header off the oldest queued
+    message to report per-queue backlog age.
+    """
+    if isinstance(headers, dict) and "enqueued_at" not in headers:
+        headers["enqueued_at"] = datetime.now(timezone.utc).isoformat()
 
 
 @task_prerun.connect

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -56,6 +56,11 @@ task_queues: dict[str, dict[str, Any]] = {
     "webhooks": {},
     "ingest": {},
     "reports": {},
+    # Dedicated telemetry queue: monitor_queue_depths must not share a queue
+    # with floodable work — if `default` backs up, queue-depth telemetry would
+    # die exactly when it is needed. Consumed by BOTH `worker` and
+    # `worker-heavy` in compose.yml for redundancy.
+    "monitoring": {},
 }
 
 # Beat schedule (periodic tasks)
@@ -116,7 +121,9 @@ beat_schedule = {
     "monitor-queue-depths": {
         "task": "dev_health_ops.workers.tasks.monitor_queue_depths",
         "schedule": 60.0,
-        "options": {"queue": "default"},
+        # Dedicated `monitoring` queue: telemetry must keep flowing even when
+        # `default` floods (that is precisely when it is needed).
+        "options": {"queue": "monitoring"},
     },
 }
 

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -41,7 +41,17 @@ task_default_queue = "default"
 task_queues: dict[str, dict[str, Any]] = {
     "default": {},
     "metrics": {},
+    # Shared sync queue: fallback for unknown providers plus any messages
+    # already in flight at deploy time. Per-provider queues (CHAOS-2299)
+    # make queue depth answer "is <provider> stuck?" with one LLEN and let
+    # operators purge a single provider. Routing lives in
+    # workers.queues.sync_queue_for_provider.
     "sync": {},
+    "sync.github": {},
+    "sync.gitlab": {},
+    "sync.linear": {},
+    "sync.jira": {},
+    "sync.launchdarkly": {},
     "backfill": {},
     "webhooks": {},
     "ingest": {},
@@ -101,6 +111,11 @@ beat_schedule = {
     "dispatch-scheduled-reports": {
         "task": "dev_health_ops.workers.tasks.dispatch_scheduled_reports",
         "schedule": 300.0,
+        "options": {"queue": "default"},
+    },
+    "monitor-queue-depths": {
+        "task": "dev_health_ops.workers.tasks.monitor_queue_depths",
+        "schedule": 60.0,
         "options": {"queue": "default"},
     },
 }

--- a/src/dev_health_ops/workers/queue_monitor.py
+++ b/src/dev_health_ops/workers/queue_monitor.py
@@ -1,0 +1,113 @@
+"""Broker queue depth/age telemetry (CHAOS-2299).
+
+Every live sync incident so far was diagnosed with per-queue ``LLEN`` against
+the broker. This beat task does that automatically: one structured log line
+per non-empty queue (depth + oldest message age) every minute, plus a warning
+when a queue crosses the backlog thresholds, so "is <provider> stuck?" is
+answerable from logs without shelling into the broker.
+
+Age detection relies on the ``enqueued_at`` header stamped by the
+``before_task_publish`` signal in workers.celery_app. Messages published
+before that signal shipped (or by foreign producers) have no header, in which
+case the queue is reported depth-only (``oldest_age_seconds`` is None).
+
+This intentionally writes NO ClickHouse rows — Data Health UI wiring is a
+follow-up.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from dev_health_ops.workers.celery_app import celery_app
+from dev_health_ops.workers.config import task_queues
+
+logger = logging.getLogger(__name__)
+
+# Backlog warning thresholds. Depth: a full batch fan-out of a large org tops
+# out well under this in normal operation. Age: the oldest message waiting
+# longer than 10 minutes means consumers are wedged or starved.
+QUEUE_DEPTH_WARNING_THRESHOLD = 200
+QUEUE_AGE_WARNING_SECONDS = 600
+
+
+def _queue_depth(channel: Any, queue: str) -> int:
+    """Best-effort message count for a queue via the kombu channel.
+
+    Kombu virtual transports (redis/valkey — the deployed broker) implement
+    ``_size``; other transports fall back to a passive queue_declare. A
+    missing queue (redis deletes empty lists) counts as empty.
+    """
+    try:
+        size = getattr(channel, "_size", None)
+        if callable(size):
+            return int(size(queue))
+        return int(channel.queue_declare(queue=queue, passive=True).message_count)
+    except Exception:
+        logger.debug("queue depth probe failed for %s", queue, exc_info=True)
+        return 0
+
+
+def _oldest_age_seconds(channel: Any, queue: str, now: datetime) -> float | None:
+    """Age of the oldest queued message, when cheaply observable.
+
+    Redis transport only: kombu LPUSHes new messages and consumers BRPOP, so
+    the oldest message sits at the tail (``LINDEX queue -1``). Its kombu
+    payload carries the celery headers, including the ``enqueued_at`` stamp
+    from workers.celery_app. Returns None on non-redis transports, unparseable
+    payloads, or messages without the stamp (depth-only reporting).
+    """
+    client = getattr(channel, "client", None)
+    if client is None:  # not a redis-like transport; no cheap peek available
+        return None
+    try:
+        raw = client.lindex(queue, -1)
+        if raw is None:
+            return None
+        payload = json.loads(raw)
+        headers = payload.get("headers") or {}
+        enqueued_at = headers.get("enqueued_at")
+        if not enqueued_at:
+            return None
+        enqueued = datetime.fromisoformat(str(enqueued_at))
+        if enqueued.tzinfo is None:
+            enqueued = enqueued.replace(tzinfo=timezone.utc)
+        return max(0.0, (now - enqueued).total_seconds())
+    except Exception:
+        logger.debug("queue age probe failed for %s", queue, exc_info=True)
+        return None
+
+
+@celery_app.task(
+    bind=True,
+    queue="default",
+    name="dev_health_ops.workers.tasks.monitor_queue_depths",
+)
+def monitor_queue_depths(self) -> dict:
+    """Log depth + oldest-message age for every declared Celery queue."""
+    now = datetime.now(timezone.utc)
+    observed: list[dict[str, Any]] = []
+
+    with celery_app.connection_or_acquire() as connection:
+        channel = connection.default_channel
+        for queue in task_queues:
+            depth = _queue_depth(channel, queue)
+            if depth <= 0:
+                continue
+            oldest_age = _oldest_age_seconds(channel, queue, now)
+            stats = {
+                "queue": queue,
+                "depth": depth,
+                "oldest_age_seconds": oldest_age,
+            }
+            observed.append(stats)
+            logger.info("queue_depth", extra=stats)
+            if depth > QUEUE_DEPTH_WARNING_THRESHOLD or (
+                oldest_age is not None and oldest_age > QUEUE_AGE_WARNING_SECONDS
+            ):
+                logger.warning("queue_backlog", extra=stats)
+
+    return {"queues": observed}

--- a/src/dev_health_ops/workers/queue_monitor.py
+++ b/src/dev_health_ops/workers/queue_monitor.py
@@ -83,7 +83,10 @@ def _oldest_age_seconds(channel: Any, queue: str, now: datetime) -> float | None
 
 @celery_app.task(
     bind=True,
-    queue="default",
+    # Dedicated telemetry queue (consumed by both `worker` and `worker-heavy`
+    # in compose.yml): if `default` floods, this monitor must keep running —
+    # that is exactly the moment its output matters.
+    queue="monitoring",
     name="dev_health_ops.workers.tasks.monitor_queue_depths",
 )
 def monitor_queue_depths(self) -> dict:

--- a/src/dev_health_ops/workers/queues.py
+++ b/src/dev_health_ops/workers/queues.py
@@ -1,0 +1,33 @@
+"""Per-provider sync queue routing (CHAOS-2299).
+
+Live incidents are diagnosed per-queue (``LLEN sync.linear`` answers
+"is Linear stuck?" with one number), and per-provider queues allow targeted
+purges without nuking every provider's in-flight syncs.
+
+NOTE: CHAOS-2284 (SyncDispatchPolicy — designed, not built) will absorb this
+routing decision into a single dispatch policy object. Keep this a free
+function so that migration is a move, not a refactor.
+"""
+
+from __future__ import annotations
+
+# Providers with a dedicated sync queue. Must stay in lockstep with the
+# ``sync.<provider>`` entries in workers.config.task_queues and the -Q lists
+# in compose.yml (guarded by tests/test_compose_config.py).
+SYNC_QUEUE_PROVIDERS = frozenset({"github", "gitlab", "linear", "jira", "launchdarkly"})
+
+# Fallback queue: unknown providers and any messages already in flight on the
+# legacy shared queue at deploy time.
+DEFAULT_SYNC_QUEUE = "sync"
+
+
+def sync_queue_for_provider(provider: str) -> str:
+    """Return the Celery queue name for a provider's sync tasks.
+
+    Known providers get ``sync.<provider>``; anything else falls back to the
+    shared ``sync`` queue, which workers keep consuming for safety.
+    """
+    normalized = (provider or "").strip().lower()
+    if normalized in SYNC_QUEUE_PROVIDERS:
+        return f"sync.{normalized}"
+    return DEFAULT_SYNC_QUEUE

--- a/src/dev_health_ops/workers/queues.py
+++ b/src/dev_health_ops/workers/queues.py
@@ -4,6 +4,18 @@ Live incidents are diagnosed per-queue (``LLEN sync.linear`` answers
 "is Linear stuck?" with one number), and per-provider queues allow targeted
 purges without nuking every provider's in-flight syncs.
 
+Routing is gated by the ``PROVIDER_SYNC_QUEUES_ENABLED`` env flag (default
+OFF) so producers and consumers can move independently. Two-phase rollout:
+
+1. Deploy workers whose ``-Q`` lists include the ``sync.<provider>`` queues
+   (consumers first — they also still consume the shared ``sync`` queue).
+2. Flip ``PROVIDER_SYNC_QUEUES_ENABLED=true`` on producers (API, beat,
+   workers) to start routing to the per-provider queues.
+
+Flipping the flag before step 1 would strand messages on queues nothing
+consumes. The flag is read at call time (not import time) so it can be
+toggled without restart-ordering pain.
+
 NOTE: CHAOS-2284 (SyncDispatchPolicy — designed, not built) will absorb this
 routing decision into a single dispatch policy object. Keep this a free
 function so that migration is a move, not a refactor.
@@ -11,22 +23,39 @@ function so that migration is a move, not a refactor.
 
 from __future__ import annotations
 
+import os
+
 # Providers with a dedicated sync queue. Must stay in lockstep with the
 # ``sync.<provider>`` entries in workers.config.task_queues and the -Q lists
 # in compose.yml (guarded by tests/test_compose_config.py).
 SYNC_QUEUE_PROVIDERS = frozenset({"github", "gitlab", "linear", "jira", "launchdarkly"})
 
-# Fallback queue: unknown providers and any messages already in flight on the
-# legacy shared queue at deploy time.
+# Fallback queue: unknown providers, any messages already in flight on the
+# legacy shared queue at deploy time, and ALL providers while the
+# PROVIDER_SYNC_QUEUES_ENABLED flag is off.
 DEFAULT_SYNC_QUEUE = "sync"
+
+
+def _provider_sync_queues_enabled() -> bool:
+    """Read the rollout flag at call time so ops/tests can flip it live."""
+    return os.getenv("PROVIDER_SYNC_QUEUES_ENABLED", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
 
 
 def sync_queue_for_provider(provider: str) -> str:
     """Return the Celery queue name for a provider's sync tasks.
 
-    Known providers get ``sync.<provider>``; anything else falls back to the
+    With ``PROVIDER_SYNC_QUEUES_ENABLED`` unset/falsy (the default) every
+    provider routes to the shared ``sync`` queue — safe for deployments whose
+    workers have not yet expanded their ``-Q`` lists. With the flag enabled,
+    known providers get ``sync.<provider>``; anything else falls back to the
     shared ``sync`` queue, which workers keep consuming for safety.
     """
+    if not _provider_sync_queues_enabled():
+        return DEFAULT_SYNC_QUEUE
     normalized = (provider or "").strip().lower()
     if normalized in SYNC_QUEUE_PROVIDERS:
         return f"sync.{normalized}"

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -17,6 +17,7 @@ from dev_health_ops.utils.datetime import utc_today
 from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.org_guard import organization_exists_sync
+from dev_health_ops.workers.queues import sync_queue_for_provider
 from dev_health_ops.workers.sync_runtime import (
     _dispatch_post_sync_tasks,
     _TerminalSyncError,
@@ -380,7 +381,7 @@ def dispatch_batch_sync(
                     "triggered_by": triggered_by,
                     "pending_run_id": pending_run_id,
                 },
-                queue="sync",
+                queue=sync_queue_for_provider(provider),
             )
             return {
                 "status": "fallback_single",
@@ -403,6 +404,9 @@ def dispatch_batch_sync(
             return {"status": "no_repos", "total_repos": 0, "batch_count": 0}
 
         batch_size = _get_batch_size(sync_options)
+        # Children inherit the provider's queue (CHAOS-2299): apply_async/
+        # signature options override the task decorator's queue="sync" default.
+        child_queue = sync_queue_for_provider(provider)
         child_tasks = []
 
         for repo_tuple in repos:
@@ -424,18 +428,18 @@ def dispatch_batch_sync(
                 per_repo_options.pop("search", None)
                 per_repo_options.pop("group", None)
 
-            child_tasks.append(
-                getattr(_run_sync_for_repo, "s")(
-                    config_id=config_id,
-                    org_id=org_id,
-                    triggered_by=triggered_by,
-                    provider=provider,
-                    sync_targets=sync_targets,
-                    sync_options_override=per_repo_options,
-                    credentials=credentials,
-                    config_name=config_name,
-                )
+            child_signature = getattr(_run_sync_for_repo, "s")(
+                config_id=config_id,
+                org_id=org_id,
+                triggered_by=triggered_by,
+                provider=provider,
+                sync_targets=sync_targets,
+                sync_options_override=per_repo_options,
+                credentials=credentials,
+                config_name=config_name,
             )
+            child_signature.set(queue=child_queue)
+            child_tasks.append(child_signature)
 
         batches = [
             child_tasks[i : i + batch_size]
@@ -454,16 +458,15 @@ def dispatch_batch_sync(
                 child.set(countdown=batch_index * BATCH_STAGGER_SECONDS)
 
         all_tasks = [task for batch in batches for task in batch]
-        chord(
-            group(all_tasks),
-            getattr(_batch_sync_callback, "s")(
-                provider=provider,
-                sync_targets=sync_targets,
-                org_id=org_id,
-                run_id=pending_run_id,
-                config_id=config_id,
-            ),
-        )()
+        callback_signature = getattr(_batch_sync_callback, "s")(
+            provider=provider,
+            sync_targets=sync_targets,
+            org_id=org_id,
+            run_id=pending_run_id,
+            config_id=config_id,
+        )
+        callback_signature.set(queue=child_queue)
+        chord(group(all_tasks), callback_signature)()
 
         logger.info(
             "dispatch_batch_sync: dispatched %d tasks in %d batches for config %s",

--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.org_guard import organization_exists_sync
+from dev_health_ops.workers.queues import sync_queue_for_provider
 from dev_health_ops.workers.sync_batch import _is_batch_eligible, dispatch_batch_sync
 from dev_health_ops.workers.sync_runtime import run_sync_config
 from dev_health_ops.workers.task_utils import (
@@ -127,6 +128,8 @@ def _maybe_dispatch_config(
     if not next_run <= now:
         return False
 
+    # Per-provider routing (CHAOS-2299): "is Linear stuck?" must be one LLEN.
+    sync_queue = sync_queue_for_provider(_as_str(config.provider))
     if _is_batch_eligible(config):
         dispatch_batch_sync.apply_async(
             kwargs={
@@ -134,7 +137,7 @@ def _maybe_dispatch_config(
                 "org_id": config.org_id,
                 "triggered_by": "schedule",
             },
-            queue="sync",
+            queue=sync_queue,
         )
     else:
         run_sync_config.apply_async(
@@ -143,7 +146,7 @@ def _maybe_dispatch_config(
                 "org_id": config.org_id,
                 "triggered_by": "schedule",
             },
-            queue="sync",
+            queue=sync_queue,
         )
 
     # Stamp the dispatch marker. Create the ScheduledJob row if missing

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -11,6 +11,7 @@ from dev_health_ops.workers.product_tasks import (
     run_capacity_forecast_job,
     sync_teams_to_analytics,
 )
+from dev_health_ops.workers.queue_monitor import monitor_queue_depths
 from dev_health_ops.workers.report_scheduler import dispatch_scheduled_reports
 from dev_health_ops.workers.report_task import execute_saved_report
 from dev_health_ops.workers.sync_batch import (
@@ -67,6 +68,7 @@ __all__ = [
     "dispatch_scheduled_syncs",
     "execute_saved_report",
     "health_check",
+    "monitor_queue_depths",
     "phone_home_heartbeat",
     "process_webhook_event",
     "reconcile_team_members",

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -622,8 +622,9 @@ async def test_delete_nonexistent_sync_config_returns_404(client):
 
 
 @pytest.mark.asyncio
-async def test_trigger_sync_config_returns_202_with_task_id(client):
+async def test_trigger_sync_config_returns_202_with_task_id(client, monkeypatch):
     ac, _ = client
+    monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
 
     create_resp = await _create_sync_config(ac, name="trigger-test")
     assert create_resp.status_code == 201
@@ -646,8 +647,11 @@ async def test_trigger_sync_config_returns_202_with_task_id(client):
 
 
 @pytest.mark.asyncio
-async def test_trigger_sync_config_routes_batch_eligible_to_batch_task(client):
+async def test_trigger_sync_config_routes_batch_eligible_to_batch_task(
+    client, monkeypatch
+):
     ac, _ = client
+    monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
 
     create_resp = await ac.post(
         "/api/v1/admin/sync-configs",
@@ -691,10 +695,13 @@ async def test_trigger_sync_config_routes_batch_eligible_to_batch_task(client):
         ("someday-provider", "sync"),
     ],
 )
-async def test_trigger_routes_to_per_provider_queue(client, provider, expected_queue):
-    """CHAOS-2299: manual triggers land on sync.<provider>; unknown providers
-    fall back to the shared sync queue."""
+async def test_trigger_routes_to_per_provider_queue(
+    client, provider, expected_queue, monkeypatch
+):
+    """CHAOS-2299: with PROVIDER_SYNC_QUEUES_ENABLED, manual triggers land on
+    sync.<provider>; unknown providers fall back to the shared sync queue."""
     ac, _ = client
+    monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
 
     create_resp = await _create_sync_config(
         ac, name=f"queue-route-{provider}", provider=provider
@@ -712,6 +719,30 @@ async def test_trigger_routes_to_per_provider_queue(client, provider, expected_q
     assert resp.status_code == 202
     mock_run.apply_async.assert_called_once()
     assert mock_run.apply_async.call_args.kwargs["queue"] == expected_queue
+
+
+@pytest.mark.asyncio
+async def test_trigger_routes_to_shared_queue_when_flag_off(client, monkeypatch):
+    """CHAOS-2299 rollout safety: with the flag unset (the default), even
+    known providers stay on the legacy shared `sync` queue so workers that
+    have not expanded their -Q lists still consume every dispatch."""
+    ac, _ = client
+    monkeypatch.delenv("PROVIDER_SYNC_QUEUES_ENABLED", raising=False)
+
+    create_resp = await _create_sync_config(ac, name="queue-route-flag-off")
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = create_resp.json()["id"]
+
+    mock_task = MagicMock(id="queue-task-id")
+    mock_run = MagicMock()
+    mock_run.apply_async.return_value = mock_task
+
+    with patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 202
+    mock_run.apply_async.assert_called_once()
+    assert mock_run.apply_async.call_args.kwargs["queue"] == "sync"
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -631,7 +631,7 @@ async def test_trigger_sync_config_returns_202_with_task_id(client):
 
     mock_task = MagicMock(id="fake-task-id")
     mock_run = MagicMock()
-    mock_run.delay.return_value = mock_task
+    mock_run.apply_async.return_value = mock_task
 
     with patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run):
         resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
@@ -641,6 +641,8 @@ async def test_trigger_sync_config_returns_202_with_task_id(client):
     assert data["status"] == "triggered"
     assert data["task_id"] == "fake-task-id"
     assert data["config_id"] == config_id
+    # CHAOS-2299: manual triggers route to the provider's dedicated queue.
+    assert mock_run.apply_async.call_args.kwargs["queue"] == "sync.github"
 
 
 @pytest.mark.asyncio
@@ -661,7 +663,7 @@ async def test_trigger_sync_config_routes_batch_eligible_to_batch_task(client):
 
     mock_task = MagicMock(id="batch-task-id")
     mock_batch = MagicMock()
-    mock_batch.delay.return_value = mock_task
+    mock_batch.apply_async.return_value = mock_task
     mock_run = MagicMock()
 
     with (
@@ -672,8 +674,44 @@ async def test_trigger_sync_config_routes_batch_eligible_to_batch_task(client):
 
     assert resp.status_code == 202
     assert resp.json()["task_id"] == "batch-task-id"
-    mock_batch.delay.assert_called_once()
-    mock_run.delay.assert_not_called()
+    mock_batch.apply_async.assert_called_once()
+    assert mock_batch.apply_async.call_args.kwargs["queue"] == "sync.github"
+    mock_run.apply_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "expected_queue"),
+    [
+        ("github", "sync.github"),
+        ("gitlab", "sync.gitlab"),
+        ("linear", "sync.linear"),
+        ("jira", "sync.jira"),
+        ("launchdarkly", "sync.launchdarkly"),
+        ("someday-provider", "sync"),
+    ],
+)
+async def test_trigger_routes_to_per_provider_queue(client, provider, expected_queue):
+    """CHAOS-2299: manual triggers land on sync.<provider>; unknown providers
+    fall back to the shared sync queue."""
+    ac, _ = client
+
+    create_resp = await _create_sync_config(
+        ac, name=f"queue-route-{provider}", provider=provider
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = create_resp.json()["id"]
+
+    mock_task = MagicMock(id="queue-task-id")
+    mock_run = MagicMock()
+    mock_run.apply_async.return_value = mock_task
+
+    with patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 202
+    mock_run.apply_async.assert_called_once()
+    assert mock_run.apply_async.call_args.kwargs["queue"] == expected_queue
 
 
 @pytest.mark.asyncio
@@ -694,7 +732,7 @@ async def test_trigger_sync_config_celery_unavailable_returns_503(client):
     config_id = create_resp.json()["id"]
 
     mock_run = MagicMock()
-    mock_run.delay.side_effect = Exception("Celery broker connection refused")
+    mock_run.apply_async.side_effect = Exception("Celery broker connection refused")
 
     with patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run):
         resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
@@ -826,7 +864,7 @@ async def test_trigger_creates_pending_job_run(client, session_maker):
 
     mock_task = MagicMock(id="pending-task-id")
     mock_run = MagicMock()
-    mock_run.delay.return_value = mock_task
+    mock_run.apply_async.return_value = mock_task
 
     with patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run):
         resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
@@ -862,7 +900,7 @@ async def test_trigger_passes_pending_run_id_to_task(client):
 
     mock_task = MagicMock(id="threaded-task-id")
     mock_run = MagicMock()
-    mock_run.delay.return_value = mock_task
+    mock_run.apply_async.return_value = mock_task
 
     with patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run):
         resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
@@ -871,13 +909,13 @@ async def test_trigger_passes_pending_run_id_to_task(client):
     run_id = resp.json()["run_id"]
 
     # The task must have been called with pending_run_id matching the returned run_id.
-    call_kwargs = mock_run.delay.call_args.kwargs
+    call_kwargs = mock_run.apply_async.call_args.kwargs["kwargs"]
     assert call_kwargs.get("pending_run_id") == run_id
 
 
 def test_sync_tasks_accept_pending_run_id_kwarg():
     """The dispatched Celery tasks must accept every kwarg the trigger endpoint
-    passes. Celery validates kwargs against the task signature at .delay() time,
+    passes. Celery validates kwargs against the task signature at dispatch time,
     so a missing parameter fails the API request itself (regression: PR #846
     clobbered the pending_run_id parameter that PR #844 added to run_sync_config).
     """
@@ -915,7 +953,7 @@ async def test_trigger_batch_creates_pending_job_run(client, session_maker):
 
     mock_task = MagicMock(id="batch-pending-task-id")
     mock_batch = MagicMock()
-    mock_batch.delay.return_value = mock_task
+    mock_batch.apply_async.return_value = mock_task
     mock_run = MagicMock()
 
     with (
@@ -940,9 +978,9 @@ async def test_trigger_batch_creates_pending_job_run(client, session_maker):
     assert run.status == JobRunStatus.PENDING.value
 
     # Batch task must have been called with pending_run_id.
-    call_kwargs = mock_batch.delay.call_args.kwargs
+    call_kwargs = mock_batch.apply_async.call_args.kwargs["kwargs"]
     assert call_kwargs.get("pending_run_id") == run_id
-    mock_run.delay.assert_not_called()
+    mock_run.apply_async.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_new_user_journey.py
+++ b/tests/api/test_new_user_journey.py
@@ -249,14 +249,14 @@ async def test_full_journey_register_login_create_credential_create_sync_config(
 
     mock_task = MagicMock(id="fake-task-id")
     mock_run = MagicMock()
-    mock_run.delay.return_value = mock_task
+    mock_run.apply_async.return_value = mock_task
 
     with patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run):
         trigger_resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
 
     assert trigger_resp.status_code == 202
     assert trigger_resp.json()["status"] == "triggered"
-    mock_run.delay.assert_called_once()
+    mock_run.apply_async.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -75,13 +75,46 @@ def test_celery_config_has_per_provider_sync_queues() -> None:
 
 
 def test_queue_monitor_beat_entry() -> None:
-    """CHAOS-2299: queue depth/age telemetry runs every minute on `default`."""
+    """CHAOS-2299: queue depth/age telemetry runs every minute on a dedicated
+    `monitoring` queue — not `default`, which can flood (telemetry would die
+    exactly when it is needed)."""
     from dev_health_ops.workers.config import beat_schedule
 
     entry = beat_schedule["monitor-queue-depths"]
     assert entry["task"] == "dev_health_ops.workers.tasks.monitor_queue_depths"
     assert entry["schedule"] == 60.0
-    assert entry["options"] == {"queue": "default"}
+    assert entry["options"] == {"queue": "monitoring"}
+
+
+def test_monitoring_queue_declared_and_consumed_redundantly() -> None:
+    """The `monitoring` queue must exist in task_queues and be consumed by at
+    least two compose worker services so queue telemetry survives one pool
+    being saturated or down."""
+    assert "monitoring" in task_queues
+
+    compose_path = Path(__file__).resolve().parents[1] / "compose.yml"
+    compose_data = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+
+    consumers: list[str] = []
+    for name, service in compose_data["services"].items():
+        command = service.get("command")
+        if command is None:
+            continue
+        command_str = (
+            " ".join(str(part) for part in command)
+            if isinstance(command, list)
+            else str(command)
+        )
+        tokens = command_str.split()
+        if "celery" not in tokens or "worker" not in tokens:
+            continue
+        if "monitoring" in _parse_queues(command_str):
+            consumers.append(name)
+
+    assert len(consumers) >= 2, (
+        f"`monitoring` must be consumed by >=2 worker services for redundancy, "
+        f"found: {sorted(consumers)}"
+    )
 
 
 def test_celery_worker_prefetch_multiplier_is_one() -> None:

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -64,6 +64,26 @@ def test_celery_config_has_backfill_queue() -> None:
     assert "backfill" in task_queues
 
 
+def test_celery_config_has_per_provider_sync_queues() -> None:
+    """CHAOS-2299: each known sync provider has a dedicated queue so queue
+    depth answers "is <provider> stuck?", and the shared `sync` queue stays
+    declared as the fallback for unknown providers and messages already in
+    flight at deploy time."""
+    for provider in ("github", "gitlab", "linear", "jira", "launchdarkly"):
+        assert f"sync.{provider}" in task_queues
+    assert "sync" in task_queues
+
+
+def test_queue_monitor_beat_entry() -> None:
+    """CHAOS-2299: queue depth/age telemetry runs every minute on `default`."""
+    from dev_health_ops.workers.config import beat_schedule
+
+    entry = beat_schedule["monitor-queue-depths"]
+    assert entry["task"] == "dev_health_ops.workers.tasks.monitor_queue_depths"
+    assert entry["schedule"] == 60.0
+    assert entry["options"] == {"queue": "default"}
+
+
 def test_celery_worker_prefetch_multiplier_is_one() -> None:
     """CHAOS-2277: long-running tasks (sync, stream consumers) + default
     prefetch (4) let reserved slow-queue messages fill the QoS window and

--- a/tests/test_queue_monitor.py
+++ b/tests/test_queue_monitor.py
@@ -218,5 +218,6 @@ class TestTaskRegistration:
         assert hasattr(exported, "delay")
         assert exported.name == "dev_health_ops.workers.tasks.monitor_queue_depths"
 
-    def test_monitor_task_runs_on_default_queue(self):
-        assert monitor_queue_depths.queue == "default"
+    def test_monitor_task_runs_on_monitoring_queue(self):
+        """Dedicated queue: a flooded `default` must not starve telemetry."""
+        assert monitor_queue_depths.queue == "monitoring"

--- a/tests/test_queue_monitor.py
+++ b/tests/test_queue_monitor.py
@@ -1,0 +1,222 @@
+"""Queue depth/age telemetry (CHAOS-2299).
+
+monitor_queue_depths reads broker queue depths (and the oldest message's
+enqueue timestamp, stamped by the before_task_publish signal) and emits one
+structured log line per non-empty queue plus a warning above thresholds.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from dev_health_ops.workers import queue_monitor
+from dev_health_ops.workers.queue_monitor import (
+    QUEUE_AGE_WARNING_SECONDS,
+    QUEUE_DEPTH_WARNING_THRESHOLD,
+    monitor_queue_depths,
+)
+
+
+def _kombu_payload(enqueued_at: str | None = None) -> str:
+    """A kombu redis message envelope as it sits on the broker list."""
+    headers = {"task": "dev_health_ops.workers.tasks.run_sync_config", "id": "t-1"}
+    if enqueued_at is not None:
+        headers["enqueued_at"] = enqueued_at
+    return json.dumps(
+        {"body": "", "content-type": "application/json", "headers": headers}
+    )
+
+
+class _FakeRedisClient:
+    def __init__(self, tails: dict[str, str]):
+        self._tails = tails
+
+    def lindex(self, queue: str, index: int):
+        assert index == -1  # oldest message: kombu LPUSHes, consumers BRPOP
+        return self._tails.get(queue)
+
+
+class _FakeRedisChannel:
+    """Mimics the kombu redis virtual channel surface the monitor touches."""
+
+    def __init__(self, depths: dict[str, int], tails: dict[str, str] | None = None):
+        self._depths = depths
+        self.client = _FakeRedisClient(tails or {})
+
+    def _size(self, queue: str) -> int:
+        return self._depths.get(queue, 0)
+
+
+class _FakeAmqpChannel:
+    """A transport without ``_size``/``client``: depth via passive declare."""
+
+    def __init__(self, depths: dict[str, int]):
+        self._depths = depths
+
+    def queue_declare(self, queue: str, passive: bool = False):
+        if queue not in self._depths:
+            raise Exception(f"NOT_FOUND - no queue '{queue}'")
+        return SimpleNamespace(message_count=self._depths[queue])
+
+
+def _run_monitor(monkeypatch, channel, queues: list[str]) -> dict:
+    @contextmanager
+    def _fake_connection():
+        yield SimpleNamespace(default_channel=channel)
+
+    monkeypatch.setattr(queue_monitor, "task_queues", {q: {} for q in queues})
+    monkeypatch.setattr(
+        queue_monitor.celery_app, "connection_or_acquire", _fake_connection
+    )
+
+    task = monitor_queue_depths
+    task.push_request(id="queue-monitor-test")
+    try:
+        return task()
+    finally:
+        task.pop_request()
+
+
+class TestMonitorQueueDepths:
+    def test_empty_queues_emit_nothing(self, monkeypatch, caplog):
+        channel = _FakeRedisChannel(depths={})
+        with caplog.at_level(logging.INFO, logger=queue_monitor.__name__):
+            result = _run_monitor(monkeypatch, channel, ["sync", "sync.github"])
+
+        assert result == {"queues": []}
+        assert not [r for r in caplog.records if r.message == "queue_depth"]
+
+    def test_non_empty_queue_logs_depth_and_age(self, monkeypatch, caplog):
+        enqueued = datetime.now(timezone.utc) - timedelta(seconds=120)
+        channel = _FakeRedisChannel(
+            depths={"sync.linear": 3},
+            tails={"sync.linear": _kombu_payload(enqueued.isoformat())},
+        )
+
+        with caplog.at_level(logging.INFO, logger=queue_monitor.__name__):
+            result = _run_monitor(
+                monkeypatch, channel, ["sync", "sync.linear", "sync.github"]
+            )
+
+        assert len(result["queues"]) == 1
+        stats = result["queues"][0]
+        assert stats["queue"] == "sync.linear"
+        assert stats["depth"] == 3
+        assert 110 <= stats["oldest_age_seconds"] <= 300
+
+        records = [r for r in caplog.records if r.message == "queue_depth"]
+        assert len(records) == 1
+        assert records[0].queue == "sync.linear"
+        assert records[0].depth == 3
+        assert records[0].oldest_age_seconds == stats["oldest_age_seconds"]
+        # Under both thresholds: no warning.
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_depth_warning_above_threshold(self, monkeypatch, caplog):
+        channel = _FakeRedisChannel(
+            depths={"sync.github": QUEUE_DEPTH_WARNING_THRESHOLD + 1}
+        )
+
+        with caplog.at_level(logging.INFO, logger=queue_monitor.__name__):
+            result = _run_monitor(monkeypatch, channel, ["sync.github"])
+
+        warnings = [r for r in caplog.records if r.message == "queue_backlog"]
+        assert len(warnings) == 1
+        assert warnings[0].queue == "sync.github"
+        assert warnings[0].depth == QUEUE_DEPTH_WARNING_THRESHOLD + 1
+        # No enqueued_at header on the tail message: depth-only is acceptable.
+        assert result["queues"][0]["oldest_age_seconds"] is None
+
+    def test_age_warning_above_threshold(self, monkeypatch, caplog):
+        stale = datetime.now(timezone.utc) - timedelta(
+            seconds=QUEUE_AGE_WARNING_SECONDS + 60
+        )
+        channel = _FakeRedisChannel(
+            depths={"sync.jira": 1},
+            tails={"sync.jira": _kombu_payload(stale.isoformat())},
+        )
+
+        with caplog.at_level(logging.INFO, logger=queue_monitor.__name__):
+            _run_monitor(monkeypatch, channel, ["sync.jira"])
+
+        warnings = [r for r in caplog.records if r.message == "queue_backlog"]
+        assert len(warnings) == 1
+        assert warnings[0].oldest_age_seconds > QUEUE_AGE_WARNING_SECONDS
+
+    def test_message_without_enqueued_at_reports_depth_only(self, monkeypatch):
+        """Messages published before the enqueued_at stamp shipped (or by
+        foreign producers) must not break the probe."""
+        channel = _FakeRedisChannel(
+            depths={"sync": 2}, tails={"sync": _kombu_payload(None)}
+        )
+
+        result = _run_monitor(monkeypatch, channel, ["sync"])
+
+        assert result["queues"] == [
+            {"queue": "sync", "depth": 2, "oldest_age_seconds": None}
+        ]
+
+    def test_unparseable_tail_message_reports_depth_only(self, monkeypatch):
+        channel = _FakeRedisChannel(depths={"sync": 1}, tails={"sync": "not-json{"})
+
+        result = _run_monitor(monkeypatch, channel, ["sync"])
+
+        assert result["queues"][0]["depth"] == 1
+        assert result["queues"][0]["oldest_age_seconds"] is None
+
+    def test_non_redis_transport_reports_depth_only(self, monkeypatch):
+        channel = _FakeAmqpChannel(depths={"sync.gitlab": 5})
+
+        result = _run_monitor(monkeypatch, channel, ["sync.gitlab", "metrics"])
+
+        assert result["queues"] == [
+            {"queue": "sync.gitlab", "depth": 5, "oldest_age_seconds": None}
+        ]
+
+    def test_probe_errors_count_queue_as_empty(self, monkeypatch):
+        class _BrokenChannel:
+            def _size(self, queue):
+                raise RuntimeError("broker hiccup")
+
+        result = _run_monitor(monkeypatch, _BrokenChannel(), ["sync"])
+
+        assert result == {"queues": []}
+
+
+class TestEnqueuedAtStamp:
+    def test_before_task_publish_stamps_header(self):
+        from dev_health_ops.workers.celery_app import _stamp_enqueued_at
+
+        headers: dict = {"task": "x"}
+        before = datetime.now(timezone.utc)
+        _stamp_enqueued_at(headers=headers)
+
+        stamped = datetime.fromisoformat(headers["enqueued_at"])
+        assert before <= stamped <= datetime.now(timezone.utc)
+
+    def test_existing_stamp_is_preserved(self):
+        from dev_health_ops.workers.celery_app import _stamp_enqueued_at
+
+        headers = {"enqueued_at": "2026-01-01T00:00:00+00:00"}
+        _stamp_enqueued_at(headers=headers)
+        assert headers["enqueued_at"] == "2026-01-01T00:00:00+00:00"
+
+    def test_non_dict_headers_ignored(self):
+        from dev_health_ops.workers.celery_app import _stamp_enqueued_at
+
+        _stamp_enqueued_at(headers=None)  # must not raise
+
+
+class TestTaskRegistration:
+    def test_monitor_task_is_registered(self):
+        from dev_health_ops.workers.tasks import monitor_queue_depths as exported
+
+        assert hasattr(exported, "delay")
+        assert exported.name == "dev_health_ops.workers.tasks.monitor_queue_depths"
+
+    def test_monitor_task_runs_on_default_queue(self):
+        assert monitor_queue_depths.queue == "default"

--- a/tests/test_sync_manual_trigger_safety.py
+++ b/tests/test_sync_manual_trigger_safety.py
@@ -58,6 +58,7 @@ def test_run_sync_config_unknown_config_is_terminal_without_retry(monkeypatch):
 )
 @pytest.mark.asyncio
 async def test_trigger_sync_config_dispatches_resolved_config_id_and_org(monkeypatch):
+    monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
     request_id = uuid.uuid4()
     resolved_id = uuid.uuid4()
     calls = []

--- a/tests/test_sync_manual_trigger_safety.py
+++ b/tests/test_sync_manual_trigger_safety.py
@@ -77,8 +77,8 @@ async def test_trigger_sync_config_dispatches_resolved_config_id_and_org(monkeyp
             )
 
     class FakeTask:
-        def delay(self, **kwargs):
-            calls.append(kwargs)
+        def apply_async(self, kwargs=None, queue=None, **options):
+            calls.append({"kwargs": kwargs, "queue": queue})
             return SimpleNamespace(id="task-1")
 
     fake_batch_task = FakeTask()
@@ -90,18 +90,16 @@ async def test_trigger_sync_config_dispatches_resolved_config_id_and_org(monkeyp
         str(request_id), session=cast(Any, object()), org_id="org-a"
     )
 
-    assert result == {
-        "status": "triggered",
-        "config_id": str(resolved_id),
-        "task_id": "task-1",
-    }
-    assert calls == [
-        {
-            "config_id": str(resolved_id),
-            "org_id": "org-a",
-            "triggered_by": "manual",
-        }
-    ]
+    assert result["status"] == "triggered"
+    assert result["config_id"] == str(resolved_id)
+    assert result["task_id"] == "task-1"
+    assert len(calls) == 1
+    # CHAOS-2299: manual triggers route to the provider's dedicated queue.
+    assert calls[0]["queue"] == "sync.github"
+    dispatched_kwargs = calls[0]["kwargs"]
+    assert dispatched_kwargs["config_id"] == str(resolved_id)
+    assert dispatched_kwargs["org_id"] == "org-a"
+    assert dispatched_kwargs["triggered_by"] == "manual"
 
 
 @pytest.mark.skip(

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -419,9 +419,11 @@ class TestDispatchBatchSync:
         mock_discover,
         mock_run_sync,
         db_session,
+        monkeypatch,
     ):
         from dev_health_ops.workers.sync_batch import dispatch_batch_sync
 
+        monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
         config = _make_config(
             provider="github",
             sync_options={"search": "org/*"},
@@ -1536,29 +1538,74 @@ class TestTaskRegistration:
 
 
 class TestSyncQueueForProvider:
-    """Per-provider queue routing helper (CHAOS-2299). To be absorbed by
-    SyncDispatchPolicy (CHAOS-2284) when that lands."""
+    """Per-provider queue routing helper (CHAOS-2299), gated by the
+    PROVIDER_SYNC_QUEUES_ENABLED env flag (default OFF) so consumers with
+    expanded -Q lists deploy before producers start routing — a producer on
+    the new code with old-`-Q` workers would otherwise strand syncs on queues
+    nothing consumes. To be absorbed by SyncDispatchPolicy (CHAOS-2284)."""
 
     @pytest.mark.parametrize(
         "provider", ["github", "gitlab", "linear", "jira", "launchdarkly"]
     )
-    def test_known_providers_get_dedicated_queue(self, provider):
+    def test_known_providers_get_dedicated_queue_when_enabled(
+        self, provider, monkeypatch
+    ):
         from dev_health_ops.workers.queues import sync_queue_for_provider
 
+        monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
         assert sync_queue_for_provider(provider) == f"sync.{provider}"
 
-    @pytest.mark.parametrize("provider", ["", "local", "bitbucket", "unknown"])
-    def test_unknown_providers_fall_back_to_shared_queue(self, provider):
+    @pytest.mark.parametrize(
+        "provider", ["github", "gitlab", "linear", "jira", "launchdarkly", "unknown"]
+    )
+    def test_flag_unset_routes_everything_to_shared_queue(self, provider, monkeypatch):
+        """Default-off: mixed deploys (producers upgraded, consumers not yet)
+        must keep every sync on the legacy shared queue."""
         from dev_health_ops.workers.queues import sync_queue_for_provider
 
+        monkeypatch.delenv("PROVIDER_SYNC_QUEUES_ENABLED", raising=False)
         assert sync_queue_for_provider(provider) == "sync"
 
-    def test_normalizes_case_and_whitespace(self):
+    @pytest.mark.parametrize("value", ["false", "0", "no", "", "off", "bogus"])
+    def test_falsy_flag_values_route_to_shared_queue(self, value, monkeypatch):
         from dev_health_ops.workers.queues import sync_queue_for_provider
 
+        monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", value)
+        assert sync_queue_for_provider("github") == "sync"
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "TRUE", " True "])
+    def test_truthy_flag_values_enable_provider_queues(self, value, monkeypatch):
+        from dev_health_ops.workers.queues import sync_queue_for_provider
+
+        monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", value)
+        assert sync_queue_for_provider("github") == "sync.github"
+
+    def test_flag_is_read_at_call_time_not_import_time(self, monkeypatch):
+        """Ops must be able to flip the flag without import-order pain: the
+        same already-imported function changes behavior with the env."""
+        from dev_health_ops.workers.queues import sync_queue_for_provider
+
+        monkeypatch.delenv("PROVIDER_SYNC_QUEUES_ENABLED", raising=False)
+        assert sync_queue_for_provider("linear") == "sync"
+        monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
+        assert sync_queue_for_provider("linear") == "sync.linear"
+        monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "false")
+        assert sync_queue_for_provider("linear") == "sync"
+
+    @pytest.mark.parametrize("provider", ["", "local", "bitbucket", "unknown"])
+    def test_unknown_providers_fall_back_to_shared_queue(self, provider, monkeypatch):
+        from dev_health_ops.workers.queues import sync_queue_for_provider
+
+        monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
+        assert sync_queue_for_provider(provider) == "sync"
+
+    def test_normalizes_case_and_whitespace(self, monkeypatch):
+        from dev_health_ops.workers.queues import sync_queue_for_provider
+
+        monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
         assert sync_queue_for_provider(" GitHub ") == "sync.github"
 
-    def test_every_routable_queue_is_declared_in_task_queues(self):
+    def test_every_routable_queue_is_declared_in_task_queues(self, monkeypatch):
         """Routing to an undeclared queue would strand messages: every queue
         the helper can return must exist in workers.config.task_queues (which
         the compose -Q coverage test then ties to a consumer)."""
@@ -1568,9 +1615,12 @@ class TestSyncQueueForProvider:
             sync_queue_for_provider,
         )
 
+        monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
         for provider in SYNC_QUEUE_PROVIDERS:
             assert sync_queue_for_provider(provider) in task_queues
         assert sync_queue_for_provider("unknown") in task_queues
+        monkeypatch.delenv("PROVIDER_SYNC_QUEUES_ENABLED")
+        assert sync_queue_for_provider("github") in task_queues
 
 
 class TestBatchChildrenQueueRouting:
@@ -1587,9 +1637,11 @@ class TestBatchChildrenQueueRouting:
         mock_discover,
         mock_chord,
         db_session,
+        monkeypatch,
     ):
         from dev_health_ops.workers.sync_batch import dispatch_batch_sync
 
+        monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
         config = _make_config(
             provider="github",
             sync_options={"search": "org/*", "batch_size": 2},
@@ -1629,9 +1681,11 @@ class TestBatchChildrenQueueRouting:
         mock_discover,
         mock_chord,
         db_session,
+        monkeypatch,
     ):
         from dev_health_ops.workers.sync_batch import dispatch_batch_sync
 
+        monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
         config = _make_config(
             provider="gitlab",
             sync_options={"search": "my-group/*"},
@@ -1659,6 +1713,51 @@ class TestBatchChildrenQueueRouting:
             "sync.gitlab"
         ]
         assert callback.options.get("queue") == "sync.gitlab"
+
+    @patch("dev_health_ops.workers.sync_batch.chord")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_flag_off_children_stay_on_shared_queue(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_chord,
+        db_session,
+        monkeypatch,
+    ):
+        """With PROVIDER_SYNC_QUEUES_ENABLED unset (the default) the chord
+        children and callback stay on the legacy shared `sync` queue."""
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        monkeypatch.delenv("PROVIDER_SYNC_QUEUES_ENABLED", raising=False)
+        config = _make_config(
+            provider="github",
+            sync_options={"search": "org/*"},
+            sync_targets=["git"],
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        mock_get_session.return_value = _fake_session_ctx(db_session)
+        mock_resolve_creds.return_value = {"token": "ghp_test"}
+        mock_discover.return_value = [("org", "repo-1")]
+        mock_chord.return_value = MagicMock()
+
+        task = dispatch_batch_sync
+        task.push_request(id="batch-dispatch-flag-off")
+        try:
+            result = task(config_id=str(config.id), org_id="default")
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "dispatched"
+        args, _ = mock_chord.call_args
+        header_group, callback = args[0], args[1]
+        for sig in header_group.tasks:
+            assert sig.options.get("queue") == "sync"
+        assert callback.options.get("queue") == "sync"
 
 
 class TestInjectProviderToken:

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -443,6 +443,8 @@ class TestDispatchBatchSync:
         assert result["status"] == "fallback_single"
         assert "API rate limited" in result["reason"]
         mock_run_sync.apply_async.assert_called_once()
+        # CHAOS-2299: the fallback dispatch stays on the provider's queue.
+        assert mock_run_sync.apply_async.call_args.kwargs["queue"] == "sync.github"
 
     @patch("dev_health_ops.workers.sync_batch.chord")
     @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
@@ -1531,6 +1533,132 @@ class TestTaskRegistration:
         from dev_health_ops.workers.sync_batch import _run_sync_for_repo
 
         assert _run_sync_for_repo.rate_limit == "30/m"
+
+
+class TestSyncQueueForProvider:
+    """Per-provider queue routing helper (CHAOS-2299). To be absorbed by
+    SyncDispatchPolicy (CHAOS-2284) when that lands."""
+
+    @pytest.mark.parametrize(
+        "provider", ["github", "gitlab", "linear", "jira", "launchdarkly"]
+    )
+    def test_known_providers_get_dedicated_queue(self, provider):
+        from dev_health_ops.workers.queues import sync_queue_for_provider
+
+        assert sync_queue_for_provider(provider) == f"sync.{provider}"
+
+    @pytest.mark.parametrize("provider", ["", "local", "bitbucket", "unknown"])
+    def test_unknown_providers_fall_back_to_shared_queue(self, provider):
+        from dev_health_ops.workers.queues import sync_queue_for_provider
+
+        assert sync_queue_for_provider(provider) == "sync"
+
+    def test_normalizes_case_and_whitespace(self):
+        from dev_health_ops.workers.queues import sync_queue_for_provider
+
+        assert sync_queue_for_provider(" GitHub ") == "sync.github"
+
+    def test_every_routable_queue_is_declared_in_task_queues(self):
+        """Routing to an undeclared queue would strand messages: every queue
+        the helper can return must exist in workers.config.task_queues (which
+        the compose -Q coverage test then ties to a consumer)."""
+        from dev_health_ops.workers.config import task_queues
+        from dev_health_ops.workers.queues import (
+            SYNC_QUEUE_PROVIDERS,
+            sync_queue_for_provider,
+        )
+
+        for provider in SYNC_QUEUE_PROVIDERS:
+            assert sync_queue_for_provider(provider) in task_queues
+        assert sync_queue_for_provider("unknown") in task_queues
+
+
+class TestBatchChildrenQueueRouting:
+    """Batch chord children and callback carry the provider queue (CHAOS-2299)."""
+
+    @patch("dev_health_ops.workers.sync_batch.chord")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_children_and_callback_signatures_carry_provider_queue(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_chord,
+        db_session,
+    ):
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        config = _make_config(
+            provider="github",
+            sync_options={"search": "org/*", "batch_size": 2},
+            sync_targets=["git"],
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        mock_get_session.return_value = _fake_session_ctx(db_session)
+        mock_resolve_creds.return_value = {"token": "ghp_test"}
+        mock_discover.return_value = [("org", f"repo-{i}") for i in range(3)]
+        mock_chord.return_value = MagicMock()
+
+        task = dispatch_batch_sync
+        task.push_request(id="batch-dispatch-queue")
+        try:
+            result = task(config_id=str(config.id), org_id="default")
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "dispatched"
+        args, _ = mock_chord.call_args
+        header_group, callback = args[0], args[1]
+
+        for sig in header_group.tasks:
+            assert sig.options.get("queue") == "sync.github"
+        assert callback.options.get("queue") == "sync.github"
+
+    @patch("dev_health_ops.workers.sync_batch.chord")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_gitlab_children_carry_gitlab_queue(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_chord,
+        db_session,
+    ):
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        config = _make_config(
+            provider="gitlab",
+            sync_options={"search": "my-group/*"},
+            sync_targets=["git"],
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        mock_get_session.return_value = _fake_session_ctx(db_session)
+        mock_resolve_creds.return_value = {"token": "glpat_test"}
+        mock_discover.return_value = [("100",)]
+        mock_chord.return_value = MagicMock()
+
+        task = dispatch_batch_sync
+        task.push_request(id="gl-batch-dispatch-queue")
+        try:
+            result = task(config_id=str(config.id), org_id="default")
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "dispatched"
+        args, _ = mock_chord.call_args
+        header_group, callback = args[0], args[1]
+        assert [sig.options.get("queue") for sig in header_group.tasks] == [
+            "sync.gitlab"
+        ]
+        assert callback.options.get("queue") == "sync.gitlab"
 
 
 class TestInjectProviderToken:

--- a/tests/test_sync_scheduler_idempotency.py
+++ b/tests/test_sync_scheduler_idempotency.py
@@ -436,6 +436,7 @@ class TestPerProviderQueueRouting:
     def test_run_sync_config_dispatched_to_provider_queue(
         self, monkeypatch, db_session, provider, expected_queue
     ):
+        monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
         now = datetime.now(timezone.utc)
         config = _make_config(last_sync_at=now - 2 * HOUR, provider=provider)
         job = _make_job(config)
@@ -450,6 +451,7 @@ class TestPerProviderQueueRouting:
         assert run_sync_mock.apply_async.call_args.kwargs["queue"] == expected_queue
 
     def test_batch_dispatch_routed_to_provider_queue(self, monkeypatch, db_session):
+        monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
         now = datetime.now(timezone.utc)
         config = _make_config(
             name="batch-queue-config",
@@ -467,6 +469,25 @@ class TestPerProviderQueueRouting:
         batch_sync_mock.apply_async.assert_called_once()
         assert batch_sync_mock.apply_async.call_args.kwargs["queue"] == "sync.github"
         run_sync_mock.apply_async.assert_not_called()
+
+    def test_flag_off_scheduled_dispatch_stays_on_shared_queue(
+        self, monkeypatch, db_session
+    ):
+        """PROVIDER_SYNC_QUEUES_ENABLED unset (default): scheduled dispatch
+        keeps using the legacy shared queue so old-`-Q` workers consume it."""
+        monkeypatch.delenv("PROVIDER_SYNC_QUEUES_ENABLED", raising=False)
+        now = datetime.now(timezone.utc)
+        config = _make_config(last_sync_at=now - 2 * HOUR, provider="github")
+        job = _make_job(config)
+        db_session.add_all([config, job])
+        db_session.flush()
+
+        task, run_sync_mock, _ = _run_dispatch(monkeypatch, db_session)
+
+        result = _call(task)
+        assert str(config.id) in result["dispatched"]
+        run_sync_mock.apply_async.assert_called_once()
+        assert run_sync_mock.apply_async.call_args.kwargs["queue"] == "sync"
 
 
 class TestManualOnlyConfigsNotDispatched:

--- a/tests/test_sync_scheduler_idempotency.py
+++ b/tests/test_sync_scheduler_idempotency.py
@@ -67,10 +67,11 @@ def _make_config(
     last_sync_at: datetime | None = None,
     sync_options: dict | None = None,
     sync_targets: list | None = None,
+    provider: str = "github",
 ) -> SyncConfiguration:
     config = SyncConfiguration(
         name=name,
-        provider="github",
+        provider=provider,
         org_id="default",
         sync_targets=sync_targets or ["git", "prs"],
         # owner+repo set => not batch eligible; explicit schedule_cron so the
@@ -416,6 +417,56 @@ class TestBatchRoutingStillStampsMarker:
         second = _call(task)
         assert second["dispatched"] == []
         assert batch_sync_mock.apply_async.call_count == 1
+
+
+class TestPerProviderQueueRouting:
+    """Scheduled dispatch routes to per-provider sync queues (CHAOS-2299)."""
+
+    @pytest.mark.parametrize(
+        ("provider", "expected_queue"),
+        [
+            ("github", "sync.github"),
+            ("gitlab", "sync.gitlab"),
+            ("linear", "sync.linear"),
+            ("jira", "sync.jira"),
+            ("launchdarkly", "sync.launchdarkly"),
+            ("mystery-provider", "sync"),
+        ],
+    )
+    def test_run_sync_config_dispatched_to_provider_queue(
+        self, monkeypatch, db_session, provider, expected_queue
+    ):
+        now = datetime.now(timezone.utc)
+        config = _make_config(last_sync_at=now - 2 * HOUR, provider=provider)
+        job = _make_job(config)
+        db_session.add_all([config, job])
+        db_session.flush()
+
+        task, run_sync_mock, _ = _run_dispatch(monkeypatch, db_session)
+
+        result = _call(task)
+        assert str(config.id) in result["dispatched"]
+        run_sync_mock.apply_async.assert_called_once()
+        assert run_sync_mock.apply_async.call_args.kwargs["queue"] == expected_queue
+
+    def test_batch_dispatch_routed_to_provider_queue(self, monkeypatch, db_session):
+        now = datetime.now(timezone.utc)
+        config = _make_config(
+            name="batch-queue-config",
+            last_sync_at=now - 2 * HOUR,
+            sync_options={"search": "org/*", "schedule_cron": "0 * * * *"},
+        )
+        job = _make_job(config)
+        db_session.add_all([config, job])
+        db_session.flush()
+
+        task, run_sync_mock, batch_sync_mock = _run_dispatch(monkeypatch, db_session)
+
+        result = _call(task)
+        assert str(config.id) in result["dispatched"]
+        batch_sync_mock.apply_async.assert_called_once()
+        assert batch_sync_mock.apply_async.call_args.kwargs["queue"] == "sync.github"
+        run_sync_mock.apply_async.assert_not_called()
 
 
 class TestManualOnlyConfigsNotDispatched:


### PR DESCRIPTION
## Summary

Linear CHAOS-2299. Live sync incidents were all diagnosed via per-queue `LLEN`; this makes "is Linear stuck?" one number and enables targeted per-provider purges.

### Per-provider queue routing (gated by `PROVIDER_SYNC_QUEUES_ENABLED`)
- New `workers/queues.py` with `sync_queue_for_provider(provider)` → `sync.<provider>` for `github|gitlab|linear|jira|launchdarkly`, fallback `sync` for anything else. Kept as a free function with a docstring pointing at **CHAOS-2284** (SyncDispatchPolicy), which will absorb it.
- **Routing is OFF by default.** `sync_queue_for_provider` consults the `PROVIDER_SYNC_QUEUES_ENABLED` env flag at call time (truthy: `1`/`true`/`yes`, same convention as `AUTO_RUN_MIGRATIONS`): when unset or falsy, every provider routes to the legacy shared `sync` queue. This prevents the mixed-deploy stranding failure where upgraded producers route to `sync.<provider>` while workers still run the old `-Q ...,sync,...` list and silently never consume those queues.
- `task_queues` gains `sync.github/gitlab/linear/jira/launchdarkly`; the shared `sync` queue **stays declared and consumed** as the fallback for unknown providers, any messages already in flight at deploy time, and all traffic while the flag is off.
- Routed producers (all through the same gated helper):
  - `workers/sync_scheduler.py` — both `run_sync_config.apply_async` and `dispatch_batch_sync.apply_async`
  - `api/admin/routers/sync.py` trigger endpoint — `.delay(...)` → `apply_async(kwargs=..., queue=...)`
  - `workers/sync_batch.py` — chord children (`_run_sync_for_repo` signatures get `.set(queue=...)` alongside the countdown stagger), the chord callback, and the discovery-failure fallback `run_sync_config.apply_async`
  - No other producers of `run_sync_config`/`dispatch_batch_sync`/`_run_sync_for_repo` exist (grepped; `run_backfill` stays on `backfill`, team-drift tasks stay on `sync` — out of scope)
- Task decorators keep `queue="sync"` defaults; apply_async/signature queue overrides them, and Celery retries re-deliver on the original queue via `request.delivery_info` (Celery behavior, not separately tested).

### Rollout procedure (two-phase)
1. **Deploy consumers first**: ship workers whose `-Q` lists include the five `sync.<provider>` queues (they continue consuming the shared `sync` queue too). With the flag still off, all dispatch keeps flowing to `sync` — no behavior change.
2. **Flip the flag**: set `PROVIDER_SYNC_QUEUES_ENABLED=true` on producers (API, beat, workers). The flag is read at call time, so flipping it requires no restart ordering. In-flight messages on `sync` drain normally because workers never stop consuming it.

`compose.yml` in this repo performs both phases atomically: the worker `-Q` expansion and `PROVIDER_SYNC_QUEUES_ENABLED: "true"` (in the shared `&env` anchor) land in the same change, so compose users are always consistent. Bare-image/Helm deployers stay safely on the shared `sync` queue until they opt in following the two phases above (also documented in the `workers/queues.py` module docstring).

### Queue depth/age telemetry
- New beat task `monitor_queue_depths` (every 60s) in `workers/queue_monitor.py`: for every queue in `task_queues`, reads depth via the kombu channel (`_size` on redis/valkey, passive `queue_declare` elsewhere) and the oldest message's age, emitting ONE structured log line per non-empty queue (`queue_depth` with `extra={queue, depth, oldest_age_seconds}`) plus a `queue_backlog` warning above thresholds (depth > 200 or age > 600s, module constants).
- **Dedicated `monitoring` queue**: the monitor task and its beat entry route to a new `monitoring` queue instead of `default` — if `default` floods, telemetry must keep flowing (that is exactly when it is needed). `monitoring` is consumed by **both** `worker` and `worker-heavy` in compose.yml so telemetry survives either pool being saturated or down.
- **Age detection**: Celery's task protocol carries no enqueue timestamp, so a `before_task_publish` signal in `workers/celery_app.py` now stamps `headers["enqueued_at"]`; the monitor peeks the oldest message (`LINDEX queue -1` — kombu LPUSHes, consumers BRPOP) and parses that header. Messages without the stamp (pre-deploy backlog, non-redis transports) degrade gracefully to depth-only (`oldest_age_seconds: null`).
- **No ClickHouse writes in this PR** — Data Health UI wiring is a follow-up.

### Worker consumption
- `compose.yml` worker `-Q` gains the five provider queues plus `monitoring`; `worker-heavy` `-Q` gains `monitoring`; the #856 compose-coverage regression guard (`test_compose_workers_cover_every_celery_queue`) passes, and a new test asserts `monitoring` has ≥2 consumers.

> **Operator note:** the workspace-level compose.yml (not in this repo) needs the same `-Q` additions on its worker services **before** setting `PROVIDER_SYNC_QUEUES_ENABLED=true`:
> `-Q default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,webhooks,reports,monitoring` (and `monitoring` on the heavy pool).

## Tests
- Flag semantics: default-off routes **everything** (including known providers) to `sync`; truthy values enable `sync.<provider>`; falsy values disable; flag read at call time not import time (`test_sync_partitioning.py::TestSyncQueueForProvider`)
- Helper mapping (known/unknown/normalization) + "every routable queue is declared" under both flag states (`test_sync_partitioning.py`)
- Scheduler dispatch asserts the queue kwarg per provider incl. batch + unknown fallback (flag on) and shared-queue routing with flag off (`test_sync_scheduler_idempotency.py`)
- Batch chord children/callback carry the provider queue (flag on) and stay on `sync` (flag off); fallback dispatch queue (`test_sync_partitioning.py`)
- Trigger endpoint queue per provider with the flag on + shared-queue fallback with the flag off; existing `.delay` mocks migrated to `apply_async` (`tests/api/admin/test_sync_configs.py`, `test_new_user_journey.py`, skipped CHAOS-2265 tests updated to the new contract)
- Compose coverage + per-provider queue declarations + beat entry on `monitoring` + `monitoring` consumed by ≥2 workers (`test_compose_config.py`)
- Telemetry unit tests with mocked broker channels: depth/age logging, both warning thresholds, depth-only degradations, broken-probe safety; monitor task registered on the `monitoring` queue (`tests/test_queue_monitor.py`)

## Gates
- `uv run mypy --install-types --non-interactive .` — clean (1018 files)
- Full `./ci/run_tests.sh unit` — only the 4 known pre-existing failures (test_org_deletion ×2, TestCoreCache ×2)
