### PR TITLE
fix(api): impersonation middleware must run inner of OrgId so impersonated org wins (CHAOS-2303)

### DIFF
--- a/src/dev_health_ops/api/_middleware.py
+++ b/src/dev_health_ops/api/_middleware.py
@@ -71,8 +71,15 @@ def register_middleware(app: FastAPI) -> None:
     )
 
     app.add_middleware(SlowAPIMiddleware)
-    app.add_middleware(OrgIdMiddleware)
+    # ImpersonationMiddleware is registered BEFORE OrgIdMiddleware so it ends up
+    # INNER on the request path (Starlette wraps last-added as outermost). On the
+    # request path OrgIdMiddleware runs first and sets _current_org_id from the
+    # X-Org-Id header / JWT, then ImpersonationMiddleware runs and overrides it to
+    # the impersonated target org. The inner middleware gets the FINAL write to the
+    # contextvar before the endpoint executes, so impersonation wins (CHAOS-2303).
+    # Do NOT swap these two lines.
     app.add_middleware(ImpersonationMiddleware)
+    app.add_middleware(OrgIdMiddleware)
     app.add_middleware(CorrelationIdMiddleware)
 
 

--- a/src/dev_health_ops/api/graphql/app.py
+++ b/src/dev_health_ops/api/graphql/app.py
@@ -59,6 +59,7 @@ async def get_context(request: Request) -> GraphQLContext:
         extract_token_from_header,
         get_auth_service,
         get_current_org_id,
+        get_impersonation_context,
     )
 
     db_url = os.getenv("CLICKHOUSE_URI") or DEFAULT_CLICKHOUSE_URI
@@ -77,9 +78,19 @@ async def get_context(request: Request) -> GraphQLContext:
     if _graphql_auth_required() and user is None:
         raise HTTPException(status_code=401, detail="Authentication required")
 
-    # --- Resolve org_id (prefer JWT claim, fall back to context/param) -------
+    # --- Resolve org_id ------------------------------------------------------
+    # An active impersonation session takes precedence over the admin's JWT org.
+    # The JWT is never re-issued during impersonation (user.org_id stays the
+    # admin's org), so without this the GraphQL path would scope context, loader
+    # cache keys, and authorization to the admin org while query_dicts overrides
+    # only the raw SQL params to the target org -- inconsistent and a cross-org
+    # cache-poisoning hazard. Precedence: impersonation target > JWT org >
+    # OrgIdMiddleware contextvar > query param. (CHAOS-2303)
     org_id = ""
-    if user and user.org_id:
+    imp_ctx = get_impersonation_context()
+    if imp_ctx is not None and getattr(imp_ctx, "is_active", False):
+        org_id = imp_ctx.target_org_id or ""
+    if not org_id and user and user.org_id:
         org_id = user.org_id
     if not org_id:
         org_id = get_current_org_id() or request.query_params.get("org_id", "") or ""

--- a/src/dev_health_ops/api/graphql/authz.py
+++ b/src/dev_health_ops/api/graphql/authz.py
@@ -172,6 +172,18 @@ def require_platform_admin(context: GraphQLContext) -> None:
     user = context.user
     if user is None:
         raise AuthorizationError("Authentication required")
+    # While an impersonation session is active the effective identity is the
+    # impersonated target user (always a non-superuser -- start_impersonation
+    # rejects superuser targets). Platform-admin, cross-org operations must not be
+    # reachable through impersonation even though the real user is a superuser.
+    # This mirrors has_permission(), which derives permissions from the target
+    # role during impersonation instead of honoring the superuser bypass.
+    # (CHAOS-2303)
+    from dev_health_ops.api.services.auth import get_impersonation_context
+
+    imp_ctx = get_impersonation_context()
+    if imp_ctx is not None and getattr(imp_ctx, "is_active", False):
+        raise AuthorizationError("Platform admin access required")
     if not getattr(user, "is_superuser", False):
         raise AuthorizationError("Platform admin access required")
 

--- a/src/dev_health_ops/api/middleware/impersonation.py
+++ b/src/dev_health_ops/api/middleware/impersonation.py
@@ -4,9 +4,15 @@ Checks every incoming request for an active impersonation session. If found,
 overrides _current_org_id and _impersonation_ctx so all downstream code
 (GraphQL, queries, audit) sees the impersonated user's context.
 
-Middleware ordering in main.py:
-  app.add_middleware(OrgIdMiddleware)         # inner - sets org_id from header/JWT
-  app.add_middleware(ImpersonationMiddleware) # outer - overrides it when impersonating
+Middleware registration order in _middleware.py (CHAOS-2303):
+  app.add_middleware(ImpersonationMiddleware)  # inner - runs LAST, overrides org
+  app.add_middleware(OrgIdMiddleware)          # outer - runs FIRST, sets base org
+
+Starlette wraps the last-added middleware as the outermost, so on the request
+path OrgIdMiddleware runs first (sets _current_org_id from header/JWT) and this
+middleware runs after it, getting the final write to _current_org_id. Registering
+ImpersonationMiddleware *after* OrgIdMiddleware would make it outer (run first),
+and OrgIdMiddleware would then clobber the impersonated org back to the admin's.
 """
 
 from __future__ import annotations

--- a/tests/api/graphql/test_context_impersonation.py
+++ b/tests/api/graphql/test_context_impersonation.py
@@ -110,8 +110,9 @@ async def test_get_context_uses_jwt_org_without_impersonation(
 def _superuser_graphql_context(org_id: str = "org-x"):
     """Build a minimal GraphQLContext whose user is a real superuser."""
     from dev_health_ops.api.graphql.context import GraphQLContext
+    from dev_health_ops.api.services.auth import AuthenticatedUser
 
-    user = types.SimpleNamespace(
+    user = AuthenticatedUser(
         user_id="admin-1",
         email="admin@example.com",
         org_id=org_id,

--- a/tests/api/graphql/test_context_impersonation.py
+++ b/tests/api/graphql/test_context_impersonation.py
@@ -1,0 +1,107 @@
+"""Regression tests for GraphQL get_context org resolution under impersonation.
+
+CHAOS-2303: the analytics web UI fetches via GraphQL. During impersonation the
+admin JWT is never re-issued, so `user.org_id` stays the admin's org. get_context
+must prefer the active impersonation target org so that context scoping, loader
+cache keys, and SQL params are all consistently scoped to the impersonated org
+(otherwise query_dicts overrides only the raw SQL params, poisoning loader caches
+keyed by the admin org).
+
+These tests exercise get_context directly with a fake request and a stubbed auth
+service, so no DB or real JWT is required.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from dev_health_ops.api.graphql import app as gql_app
+from dev_health_ops.api.services.auth import (
+    _impersonation_ctx,
+    set_impersonation_context,
+)
+
+
+class _FakeRequest:
+    """Minimal duck-typed stand-in for starlette Request used by get_context."""
+
+    def __init__(
+        self, headers: dict[str, str], query_params: dict[str, str] | None = None
+    ) -> None:
+        self.headers = headers
+        self.query_params = query_params or {}
+
+
+def _stub_admin_auth(monkeypatch: pytest.MonkeyPatch, *, admin_org: str) -> None:
+    """Make get_auth_service() return a superuser admin whose JWT org = admin_org."""
+    fake_admin = types.SimpleNamespace(
+        user_id="admin-1",
+        email="admin@example.com",
+        org_id=admin_org,
+        role="owner",
+        is_superuser=True,
+    )
+    fake_service = types.SimpleNamespace(
+        get_authenticated_user=lambda _token: fake_admin
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.auth.get_auth_service",
+        lambda: fake_service,
+    )
+
+    async def _no_client(_dsn: str) -> None:
+        # Skip ClickHouse client creation; get_context tolerates client=None.
+        return None
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.get_global_client",
+        _no_client,
+    )
+    monkeypatch.setenv("GRAPHQL_AUTH_REQUIRED", "true")
+
+
+@pytest.mark.asyncio
+async def test_get_context_prefers_impersonation_target_org(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An active impersonation session overrides the admin JWT org."""
+    admin_org = "org-admin-gql"
+    target_org = "org-target-gql"
+    _stub_admin_auth(monkeypatch, admin_org=admin_org)
+
+    request = _FakeRequest(headers={"Authorization": "Bearer faketoken"})
+
+    token = set_impersonation_context(
+        target_user_id="target-user",
+        target_org_id=target_org,
+        target_role="member",
+        real_user_id="admin-1",
+    )
+    try:
+        ctx = await gql_app.get_context(request)  # type: ignore[arg-type]
+    finally:
+        _impersonation_ctx.reset(token)
+
+    assert ctx.org_id == target_org, (
+        f"GraphQL context must scope to the impersonated org; "
+        f"expected {target_org!r}, got {ctx.org_id!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_context_uses_jwt_org_without_impersonation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without impersonation, get_context still uses the admin JWT org."""
+    admin_org = "org-admin-gql-2"
+    _stub_admin_auth(monkeypatch, admin_org=admin_org)
+
+    # Ensure no impersonation context leaks in from another test.
+    _impersonation_ctx.set(None)
+
+    request = _FakeRequest(headers={"Authorization": "Bearer faketoken"})
+    ctx = await gql_app.get_context(request)  # type: ignore[arg-type]
+
+    assert ctx.org_id == admin_org

--- a/tests/api/graphql/test_context_impersonation.py
+++ b/tests/api/graphql/test_context_impersonation.py
@@ -105,3 +105,47 @@ async def test_get_context_uses_jwt_org_without_impersonation(
     ctx = await gql_app.get_context(request)  # type: ignore[arg-type]
 
     assert ctx.org_id == admin_org
+
+
+def _superuser_graphql_context(org_id: str = "org-x"):
+    """Build a minimal GraphQLContext whose user is a real superuser."""
+    from dev_health_ops.api.graphql.context import GraphQLContext
+
+    user = types.SimpleNamespace(
+        user_id="admin-1",
+        email="admin@example.com",
+        org_id=org_id,
+        role="owner",
+        is_superuser=True,
+    )
+    return GraphQLContext(org_id=org_id, db_url="", user=user)
+
+
+def test_require_platform_admin_denied_during_impersonation() -> None:
+    """A superuser impersonating a non-platform user cannot reach platform-admin
+    GraphQL operations -- the impersonated identity is not a platform admin."""
+    from dev_health_ops.api.graphql.authz import require_platform_admin
+    from dev_health_ops.api.graphql.errors import AuthorizationError
+
+    ctx = _superuser_graphql_context()
+    token = set_impersonation_context(
+        target_user_id="target-user",
+        target_org_id="org-target",
+        target_role="viewer",
+        real_user_id="admin-1",
+    )
+    try:
+        with pytest.raises(AuthorizationError):
+            require_platform_admin(ctx)
+    finally:
+        _impersonation_ctx.reset(token)
+
+
+def test_require_platform_admin_allowed_for_superuser_without_impersonation() -> None:
+    """Without an active impersonation session a real superuser still passes."""
+    from dev_health_ops.api.graphql.authz import require_platform_admin
+
+    _impersonation_ctx.set(None)
+    ctx = _superuser_graphql_context()
+    # Must not raise.
+    require_platform_admin(ctx)

--- a/tests/api/test_impersonation_middleware.py
+++ b/tests/api/test_impersonation_middleware.py
@@ -416,3 +416,132 @@ async def test_asgi_middleware_passthrough_for_non_superuser():
     assert response.status_code == 200
     assert "x-impersonating" not in response.headers
     mock_session.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 5+6: Integration with OrgIdMiddleware (regression for CHAOS-2303)
+#
+# ImpersonationMiddleware and OrgIdMiddleware BOTH write _current_org_id. In
+# production OrgIdMiddleware must run FIRST (outer) and ImpersonationMiddleware
+# AFTER it (inner), so the impersonated target org is the final value the
+# endpoint sees. The original registration order was inverted, so
+# OrgIdMiddleware clobbered the impersonated org back to the admin's own org and
+# impersonation had no effect on returned data. The earlier tests in this file
+# exercised ImpersonationMiddleware in isolation and therefore never caught it.
+# ---------------------------------------------------------------------------
+
+_ORGID_USER_PATCH = "dev_health_ops.api.middleware.get_authenticated_user_from_headers"
+
+
+def _build_stacked_app(
+    *,
+    impersonation_inner: bool,
+    state_user: Any,
+    captured: dict,
+) -> Any:
+    """Build a stack containing BOTH OrgIdMiddleware and ImpersonationMiddleware.
+
+    ``impersonation_inner=True`` mirrors the production order (OrgId outer,
+    Impersonation inner) so impersonation wins. ``False`` reproduces the original
+    buggy order (Impersonation outer, OrgId inner) where OrgId clobbers the org.
+    """
+    from dev_health_ops.api.middleware import OrgIdMiddleware
+
+    async def _handler(scope: Any, receive: Any, send: Any) -> None:
+        captured["org_id"] = get_current_org_id()
+        captured["imp_ctx"] = get_impersonation_context()
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"{}"})
+
+    if impersonation_inner:
+        app: Any = OrgIdMiddleware(ImpersonationMiddleware(_handler))
+    else:
+        app = ImpersonationMiddleware(OrgIdMiddleware(_handler))
+
+    # _UserStateMiddleware injects the superuser into scope state for
+    # ImpersonationMiddleware._extract_user(); OrgIdMiddleware reads headers.
+    return _UserStateMiddleware(app, state_user)
+
+
+@pytest.mark.asyncio
+async def test_impersonation_overrides_orgid_when_inner():
+    """Production order: Impersonation (inner) overrides OrgId's org_id."""
+    admin_id = "admin-stack-1"
+    admin_org = "org-admin-stack-1"
+    target_org = "org-target-stack-1"
+    target_user = "target-stack-1"
+
+    session = _fake_session(admin_id, target_user, target_org)
+    state_user = _fake_superuser(admin_id)
+    state_user.org_id = admin_org
+
+    captured: dict = {}
+    app = _build_stacked_app(
+        impersonation_inner=True, state_user=state_user, captured=captured
+    )
+
+    with (
+        patch(_PATCH_TARGET, AsyncMock(return_value=session)),
+        patch(_ORGID_USER_PATCH, return_value=state_user),
+    ):
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get("/", headers={"X-Org-Id": admin_org})
+        finally:
+            _current_org_id.set(None)
+            _impersonation_ctx.set(None)
+
+    assert response.status_code == 200
+    assert captured["org_id"] == target_org, (
+        "Impersonation (inner) must override OrgIdMiddleware's org_id; "
+        f"expected {target_org!r}, got {captured['org_id']!r}"
+    )
+    assert response.headers.get("x-impersonating") == "true"
+
+
+@pytest.mark.asyncio
+async def test_orgid_clobbers_impersonation_when_orgid_inner():
+    """Original buggy order: OrgId (inner) clobbers the impersonated org.
+
+    Documents WHY the registration order matters. If the middleware order is
+    re-inverted, the impersonated org is lost and this test fails loudly.
+    """
+    admin_id = "admin-stack-2"
+    admin_org = "org-admin-stack-2"
+    target_org = "org-target-stack-2"
+    target_user = "target-stack-2"
+
+    session = _fake_session(admin_id, target_user, target_org)
+    state_user = _fake_superuser(admin_id)
+    state_user.org_id = admin_org
+
+    captured: dict = {}
+    app = _build_stacked_app(
+        impersonation_inner=False, state_user=state_user, captured=captured
+    )
+
+    with (
+        patch(_PATCH_TARGET, AsyncMock(return_value=session)),
+        patch(_ORGID_USER_PATCH, return_value=state_user),
+    ):
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                response = await client.get("/", headers={"X-Org-Id": admin_org})
+        finally:
+            _current_org_id.set(None)
+            _impersonation_ctx.set(None)
+
+    assert response.status_code == 200
+    assert captured["org_id"] == admin_org


### PR DESCRIPTION
## Summary

Superuser impersonation had **no effect on the data the admin saw** — after starting impersonation, the admin still saw their own org's analytics. Multiple layers were broken; this PR fixes all of them. Findings 2 and 3 were surfaced by `/codex:adversarial-review`.

## Fix 1 — Middleware ordering (REST + contextvar)

`ImpersonationMiddleware` and `OrgIdMiddleware` both write the `_current_org_id` contextvar that `query_dicts()` injects into every ClickHouse query. They were registered with `ImpersonationMiddleware` **after** `OrgIdMiddleware`, which (Starlette wraps last-added as outermost) made Impersonation the **outer** middleware. On the request path Impersonation set the target org first, then `OrgIdMiddleware` ran and **overwrote `_current_org_id` back to the admin's own org**.

- Register `ImpersonationMiddleware` **before** `OrgIdMiddleware` so it becomes **inner** and gets the final write to `_current_org_id` (request path `OrgId → Impersonation → endpoint`).
- Fix the inverted ordering docstring.
- Regression test stacking **both** middlewares (existing tests exercised `ImpersonationMiddleware` in isolation — why this escaped CI):
  - `test_impersonation_overrides_orgid_when_inner` — production order → target org wins.
  - `test_orgid_clobbers_impersonation_when_orgid_inner` — locks the contract; fails loudly if re-inverted.

## Fix 2 — GraphQL context org resolution

The web UI fetches analytics via **GraphQL**, and `graphql/app.py:get_context` resolved `org_id` from the admin JWT (`user.org_id`) **first**. During impersonation the JWT is never re-issued, so GraphQL stayed scoped to the admin org. Worse: `query_dicts` overrides only the raw SQL params from the contextvar (target org) while GraphQL **loader cache keys** and `context.org_id` use the JWT org — a correctness bug *and* a **cross-org cache-poisoning hazard**.

- `get_context` now prefers an active impersonation target org. Precedence: **impersonation target → JWT org → OrgIdMiddleware contextvar → query param** — keeping context scoping, loader cache keys, and SQL params consistent.
- Verified the web sends no `org_id` GraphQL variable, so `OrgIdAuthExtension` does not raise a cross-org error after the change.
- Tests: `test_get_context_prefers_impersonation_target_org`, `test_get_context_uses_jwt_org_without_impersonation`.

## Fix 3 — Platform-admin authorization during impersonation

`require_platform_admin` honored the raw superuser bypass (`context.user.is_superuser`), unlike `has_permission()` which already downgrades to the impersonated target role. So while impersonating a viewer/member, a superadmin could still reach cross-org platform dashboards (e.g. `productTelemetryPlatformDashboard`), violating the impersonated permission boundary.

- Deny platform-admin GraphQL operations whenever an active impersonation context is present, mirroring the permission service.
- Tests: `test_require_platform_admin_denied_during_impersonation`, `test_require_platform_admin_allowed_for_superuser_without_impersonation`.

## Testing

- `pytest tests/api/test_impersonation_middleware.py tests/api/graphql/test_context_impersonation.py` → 19 passed.
- `pytest tests/test_impersonation.py tests/api/test_impersonation_audit.py tests/api/admin/test_impersonation_endpoints.py tests/graphql/test_security.py` → 58 passed.
- `ruff format --check` + `ruff check` clean on changed files.

## Notes

Frontend gating of the Impersonate button (superuser-only) ships in dev-health-web PR #675 (same Linear issue).

SCREENSHOT-WAIVER: backend-only change; no API shape or rendered-output changes.

Closes CHAOS-2303
