### PR TITLE
feat(deploy): explicit migrate step in all production stacks (CHAOS-2304)

### DIFF
--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -48,6 +48,40 @@ services:
     networks:
       - dev-health
 
+  # ===========================================================================
+  # Database migrations (one-shot — runs before app services)
+  # ===========================================================================
+  # Applies PostgreSQL (Alembic, when POSTGRES_URI is set) and ClickHouse
+  # schema migrations, then exits 0. App services gate on this completing
+  # successfully via depends_on.condition: service_completed_successfully and
+  # run with AUTO_RUN_MIGRATIONS=false so they never ambient-migrate
+  # (CHAOS-2304 — migration 042+ does shadow-table rebuilds that are not safe
+  # to run concurrently from workers).
+  #
+  # POSTGRES_URI must point DIRECTLY at Postgres (port 5432), never at a
+  # transaction-mode pooler (PgBouncer/RDS Proxy): migrations run raw DDL.
+  # See docs/ops/database-connection-pooling.md.
+  migrate:
+    image: ${DEV_HEALTH_IMAGE:-ghcr.io/your-org/dev-health-ops:latest}
+    container_name: dev-health-migrate
+    restart: "no"
+    entrypoint:
+      - sh
+      - -c
+      - >-
+        if [ -n "$$POSTGRES_URI" ]; then dev-hops migrate postgres; fi
+        && dev-hops migrate clickhouse
+    environment:
+      # Direct Postgres URI (5432), NOT pgbouncer — empty skips the Alembic step.
+      POSTGRES_URI: ${POSTGRES_URI:-}
+      CLICKHOUSE_URI: clickhouse://${CLICKHOUSE_USER:-ch}:${CLICKHOUSE_PASSWORD:-ch}@clickhouse:8123/${CLICKHOUSE_DB:-default}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    networks:
+      - dev-health
+
   api:
     image: ${DEV_HEALTH_IMAGE:-ghcr.io/your-org/dev-health-ops:latest}
     container_name: dev-health-api
@@ -70,6 +104,9 @@ services:
       JIRA_BASE_URL: ${JIRA_BASE_URL:-}
       JIRA_EMAIL: ${JIRA_EMAIL:-}
       JIRA_API_TOKEN: ${JIRA_API_TOKEN:-}
+      # Schema is applied by the one-shot `migrate` service (gated via
+      # depends_on) — the API must never run migrations itself (CHAOS-2304).
+      AUTO_RUN_MIGRATIONS: "false"
     ports:
       - "${API_PORT:-8000}:8000"
     depends_on:
@@ -77,6 +114,8 @@ services:
         condition: service_healthy
       valkey:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 15s
@@ -120,6 +159,9 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
     ports:
       - "${BILLING_EDGE_PORT:-8010}:8000"
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 15s
@@ -161,11 +203,16 @@ services:
       JIRA_BASE_URL: ${JIRA_BASE_URL:-}
       JIRA_EMAIL: ${JIRA_EMAIL:-}
       JIRA_API_TOKEN: ${JIRA_API_TOKEN:-}
+      # Schema is applied by the one-shot `migrate` service (gated via
+      # depends_on) — workers must never run migrations themselves (CHAOS-2304).
+      AUTO_RUN_MIGRATIONS: "false"
     depends_on:
       clickhouse:
         condition: service_healthy
       valkey:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     networks:
       - dev-health
     deploy:

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -61,6 +61,17 @@ services:
   # POSTGRES_URI must point DIRECTLY at Postgres (port 5432), never at a
   # transaction-mode pooler (PgBouncer/RDS Proxy): migrations run raw DDL.
   # See docs/ops/database-connection-pooling.md.
+  #
+  # OPERATOR RECOVERY — failed migrate run: with restart: "no", a failed
+  # migrate is NOT retried, and api/billing-edge/worker stay gated (Created,
+  # never started) until it completes successfully. To inspect and re-run:
+  #
+  #   docker compose -f compose.production.yml logs migrate   # why it failed
+  #   docker compose -f compose.production.yml up migrate     # re-run just migrations
+  #   docker compose -f compose.production.yml up -d          # then start the rest
+  #
+  # `dev-hops migrate clickhouse status` (read-only) shows applied vs pending
+  # migrations; `--check` makes it exit 1 while any migration is pending.
   migrate:
     image: ${DEV_HEALTH_IMAGE:-ghcr.io/your-org/dev-health-ops:latest}
     container_name: dev-health-migrate

--- a/deploy/docker-swarm/README.md
+++ b/deploy/docker-swarm/README.md
@@ -24,6 +24,32 @@ EOF
 docker stack deploy -c stack.yml dev-health
 ```
 
+## Database Migrations (CHAOS-2304)
+
+Schema migrations run as a one-shot `migrate` service
+(`deploy.restart_policy.condition: none`). App services run with
+`AUTO_RUN_MIGRATIONS=false` and never apply migrations themselves.
+
+Swarm has **no** `depends_on` ordering: on first deploy (and after every image
+update) you MUST verify the migrate service completed successfully before
+relying on the stack — api/worker will not create the schema for you:
+
+```bash
+# Wait for the one-shot task to finish, then check it exited 0
+docker service logs dev-health_migrate
+docker service ps dev-health_migrate   # DesiredState=Shutdown, no error
+
+# Re-run migrations manually (e.g. after a failed run)
+docker service update --force dev-health_migrate
+```
+
+Notes:
+
+- `POSTGRES_URI` must point **directly** at Postgres (port 5432), never at a
+  transaction-mode pooler (PgBouncer/RDS Proxy) — migrations run raw DDL. See
+  `docs/ops/database-connection-pooling.md`. The Alembic step is skipped when
+  `POSTGRES_URI` is unset (ClickHouse-only stacks).
+
 ## Scaling Services
 
 ```bash

--- a/deploy/docker-swarm/stack.yml
+++ b/deploy/docker-swarm/stack.yml
@@ -76,6 +76,51 @@ services:
     networks:
       - dev-health-internal
 
+  # ===========================================================================
+  # Database migrations (one-shot — CHAOS-2304)
+  # ===========================================================================
+  # Swarm has no depends_on/completion conditions: this service runs once
+  # (restart_policy.condition: none) and operators MUST verify it completed
+  # successfully before relying on the stack — see README.md:
+  #   docker service logs dev-health_migrate
+  # App services run with AUTO_RUN_MIGRATIONS=false and never ambient-migrate.
+  #
+  # POSTGRES_URI must point DIRECTLY at Postgres (port 5432), never at a
+  # transaction-mode pooler (PgBouncer/RDS Proxy): migrations run raw DDL.
+  # The Alembic step is skipped when POSTGRES_URI is unset (ClickHouse-only
+  # stacks).
+  migrate:
+    image: ghcr.io/your-org/dev-health-ops:latest
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    entrypoint:
+      - sh
+      - -c
+      - >-
+        if [ -n "$$POSTGRES_URI" ]; then dev-hops migrate postgres; fi
+        && dev-hops migrate clickhouse
+    environment:
+      POSTGRES_URI: ${POSTGRES_URI:-}
+      CLICKHOUSE_URI: clickhouse://ch:ch@clickhouse:8123/default
+      LOG_LEVEL: INFO
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        condition: none
+      resources:
+        limits:
+          memory: 1G
+          cpus: "0.5"
+        reservations:
+          memory: 128M
+          cpus: "0.1"
+    networks:
+      - dev-health-internal
+
   api:
     image: ghcr.io/your-org/dev-health-ops:latest
     command:
@@ -90,6 +135,9 @@ services:
       CELERY_RESULT_BACKEND: redis://valkey:6379/0
       GRAPHQL_QUERY_TIMEOUT: "30"
       LOG_LEVEL: INFO
+      # Schema is applied by the one-shot `migrate` service — the API must
+      # never run migrations itself (CHAOS-2304).
+      AUTO_RUN_MIGRATIONS: "false"
     secrets:
       - github_token
       - gitlab_token
@@ -148,6 +196,9 @@ services:
       CELERY_BROKER_URL: redis://valkey:6379/0
       CELERY_RESULT_BACKEND: redis://valkey:6379/0
       LOG_LEVEL: INFO
+      # Schema is applied by the one-shot `migrate` service — workers must
+      # never run migrations themselves (CHAOS-2304).
+      AUTO_RUN_MIGRATIONS: "false"
     secrets:
       - github_token
       - gitlab_token

--- a/deploy/helm/dev-health/templates/_helpers.tpl
+++ b/deploy/helm/dev-health/templates/_helpers.tpl
@@ -139,6 +139,49 @@ imagePullSecrets:
 {{- end }}
 
 {{/*
+Shared non-secret config data — used by the main ConfigMap and the migration
+hook ConfigMap (the latter exists because pre-install hooks run before the
+chart's regular resources are created).
+*/}}
+{{- define "dev-health.configData" -}}
+{{- $redisAuto := and .Values.valkey.enabled (not .Values.config.CELERY_BROKER_URL) }}
+{{- $redisKeys := list "CELERY_BROKER_URL" "CELERY_RESULT_BACKEND" "REDIS_URL" }}
+{{- range $key, $value := .Values.config }}
+{{- if or $value (not (and $redisAuto (has $key $redisKeys))) }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- if $redisAuto }}
+CELERY_BROKER_URL: {{ include "dev-health.redisURL" . | quote }}
+CELERY_RESULT_BACKEND: {{ include "dev-health.redisURL" . | quote }}
+REDIS_URL: {{ include "dev-health.redisURL" . | quote }}
+{{- end }}
+{{- if not (hasKey .Values.config "AUTO_RUN_MIGRATIONS") }}
+{{- /* CHAOS-2304: when the migration hook owns schema changes, app pods must
+   never ambient-migrate. Set config.AUTO_RUN_MIGRATIONS to override. */}}
+AUTO_RUN_MIGRATIONS: {{ ternary "false" "true" .Values.migrations.hook.enabled | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Shared secret stringData — used by the main Secret and the migration hook
+Secret.
+*/}}
+{{- define "dev-health.secretData" -}}
+{{- range $key, $value := .Values.secrets.data }}
+{{- if $value }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- if and .Values.clickhouse.enabled (not (index .Values.secrets.data "CLICKHOUSE_URI")) }}
+CLICKHOUSE_URI: {{ include "dev-health.clickhouseURI" . | quote }}
+{{- end }}
+{{- if and .Values.postgresql.enabled (not (index .Values.secrets.data "DATABASE_URI")) }}
+DATABASE_URI: {{ include "dev-health.postgresURI" . | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
 Component labels helper — call with (dict "component" "api" "context" $)
 */}}
 {{- define "dev-health.componentLabels" -}}

--- a/deploy/helm/dev-health/templates/configmap.yaml
+++ b/deploy/helm/dev-health/templates/configmap.yaml
@@ -6,15 +6,4 @@ metadata:
   labels:
     {{- include "dev-health.labels" . | nindent 4 }}
 data:
-  {{- $redisAuto := and $.Values.valkey.enabled (not $.Values.config.CELERY_BROKER_URL) }}
-  {{- $redisKeys := list "CELERY_BROKER_URL" "CELERY_RESULT_BACKEND" "REDIS_URL" }}
-  {{- range $key, $value := .Values.config }}
-  {{- if or $value (not (and $redisAuto (has $key $redisKeys))) }}
-  {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}
-  {{- if $redisAuto }}
-  CELERY_BROKER_URL: {{ include "dev-health.redisURL" . | quote }}
-  CELERY_RESULT_BACKEND: {{ include "dev-health.redisURL" . | quote }}
-  REDIS_URL: {{ include "dev-health.redisURL" . | quote }}
-  {{- end }}
+  {{- include "dev-health.configData" . | trim | nindent 2 }}

--- a/deploy/helm/dev-health/templates/migrate-job.yaml
+++ b/deploy/helm/dev-health/templates/migrate-job.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.migrations.hook.enabled }}
+{{- /*
+Database migration hook (CHAOS-2304).
+
+Runs PostgreSQL (Alembic) + ClickHouse migrations as a pre-install/pre-upgrade
+hook so schema changes complete before any workload from the release is
+(re)deployed. App pods run with AUTO_RUN_MIGRATIONS=false (see configmap.yaml)
+and never ambient-migrate — shadow-table rebuild migrations are not safe to
+run concurrently from workers.
+
+The hook ships its own ConfigMap/Secret copies: pre-install hooks run before
+the chart's regular resources exist, so the Job cannot reference them on a
+fresh install. When secrets.create is false the external secret is referenced
+directly (it exists independently of the release).
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "dev-health.fullname" . }}-migrate-config
+  namespace: {{ include "dev-health.namespace" . }}
+  labels:
+    {{- include "dev-health.componentLabels" (dict "component" "migrate" "context" $) | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+data:
+  {{- include "dev-health.configData" . | trim | nindent 2 }}
+{{- if .Values.secrets.create }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "dev-health.fullname" . }}-migrate-secrets
+  namespace: {{ include "dev-health.namespace" . }}
+  labels:
+    {{- include "dev-health.componentLabels" (dict "component" "migrate" "context" $) | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+type: Opaque
+stringData:
+  {{- include "dev-health.secretData" . | trim | nindent 2 }}
+{{- end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "dev-health.fullname" . }}-migrate
+  namespace: {{ include "dev-health.namespace" . }}
+  labels:
+    {{- include "dev-health.componentLabels" (dict "component" "migrate" "context" $) | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.migrations.hook.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.migrations.hook.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "dev-health.componentSelectorLabels" (dict "component" "migrate" "context" $) | nindent 8 }}
+    spec:
+      {{- include "dev-health.imagePullSecrets" . | nindent 6 }}
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: migrate
+          image: {{ include "dev-health.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          # POSTGRES_URI / DATABASE_URI must point DIRECTLY at Postgres (5432),
+          # never at a transaction-mode pooler (PgBouncer/RDS Proxy) —
+          # migrations run raw DDL. See docs/ops/database-connection-pooling.md.
+          # The Alembic step is skipped when no Postgres URI is configured.
+          command:
+            - sh
+            - -c
+            - >-
+              if [ -n "$POSTGRES_URI" ] || [ -n "$DATABASE_URI" ];
+              then dev-hops migrate postgres; fi
+              && dev-hops migrate clickhouse
+          envFrom:
+            - configMapRef:
+                name: {{ include "dev-health.fullname" . }}-migrate-config
+            - secretRef:
+                {{- if .Values.secrets.create }}
+                name: {{ include "dev-health.fullname" . }}-migrate-secrets
+                {{- else }}
+                name: {{ include "dev-health.secretName" . }}
+                {{- end }}
+          {{- with .Values.migrations.hook.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.migrations.hook.resources | nindent 12 }}
+{{- end }}

--- a/deploy/helm/dev-health/templates/secret.yaml
+++ b/deploy/helm/dev-health/templates/secret.yaml
@@ -8,15 +8,5 @@ metadata:
     {{- include "dev-health.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{- range $key, $value := .Values.secrets.data }}
-  {{- if $value }}
-  {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}
-  {{- if and .Values.clickhouse.enabled (not (index .Values.secrets.data "CLICKHOUSE_URI")) }}
-  CLICKHOUSE_URI: {{ include "dev-health.clickhouseURI" . | quote }}
-  {{- end }}
-  {{- if and .Values.postgresql.enabled (not (index .Values.secrets.data "DATABASE_URI")) }}
-  DATABASE_URI: {{ include "dev-health.postgresURI" . | quote }}
-  {{- end }}
+  {{- include "dev-health.secretData" . | trim | nindent 2 }}
 {{- end }}

--- a/deploy/helm/dev-health/values.yaml
+++ b/deploy/helm/dev-health/values.yaml
@@ -183,6 +183,34 @@ web:
   extraEnv: []
 
 # =============================================================================
+# Database migrations (CHAOS-2304)
+# =============================================================================
+# When enabled, a pre-install/pre-upgrade Helm hook Job applies PostgreSQL
+# (Alembic) + ClickHouse migrations before the release's workloads are
+# (re)deployed, and the shared ConfigMap sets AUTO_RUN_MIGRATIONS=false so
+# api/worker/beat never ambient-migrate. Set config.AUTO_RUN_MIGRATIONS
+# explicitly to override the computed value.
+#
+# The Postgres URI used for migrations must point DIRECTLY at Postgres
+# (port 5432), never at a transaction-mode pooler (PgBouncer/RDS Proxy) —
+# migrations run raw DDL. See docs/ops/database-connection-pooling.md.
+migrations:
+  hook:
+    enabled: true
+    backoffLimit: 2
+    activeDeadlineSeconds: 1800
+    resources:
+      requests:
+        memory: "256Mi"
+        cpu: "100m"
+      limits:
+        memory: "1Gi"
+        cpu: "500m"
+    # -- Extra environment variables for the migration Job (e.g. a direct
+    #    POSTGRES_URI when the app's DATABASE_URI points at a pooler)
+    extraEnv: []
+
+# =============================================================================
 # CronJobs
 # =============================================================================
 cronjobs:

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,0 +1,44 @@
+# Kubernetes Deployment
+
+Raw manifests managed via Kustomize:
+
+```bash
+kubectl apply -k deploy/kubernetes/
+```
+
+## Database migrations (required ordering)
+
+Schema migrations run as a one-shot Job (`migrate-job.yaml`), and all app pods
+run with `AUTO_RUN_MIGRATIONS=false` (set in `configmap.yaml`) so api/worker
+never ambient-migrate (CHAOS-2304 — shadow-table rebuild migrations are not
+safe to run concurrently from workers).
+
+**Kubernetes Jobs do not gate Deployments.** The migrate Job must complete
+before rolling out new api/worker images:
+
+```bash
+# Jobs are immutable — delete the previous run first
+kubectl -n dev-health delete job dev-health-migrate --ignore-not-found
+
+kubectl apply -k deploy/kubernetes/
+
+kubectl -n dev-health wait --for=condition=complete --timeout=600s \
+  job/dev-health-migrate
+
+# Only then roll the app workloads onto the new image
+kubectl -n dev-health rollout restart deployment/dev-health-api deployment/dev-health-worker
+```
+
+If the Job fails, inspect it before retrying:
+
+```bash
+kubectl -n dev-health logs job/dev-health-migrate
+```
+
+Notes:
+
+- `POSTGRES_URI` (in `dev-health-secrets`) must point **directly** at Postgres
+  (port 5432), never at a transaction-mode pooler (PgBouncer/RDS Proxy) —
+  migrations run raw DDL. See `docs/ops/database-connection-pooling.md`.
+- The Alembic step is skipped automatically when `POSTGRES_URI` is unset;
+  ClickHouse migrations always run.

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -35,8 +35,31 @@ If the Job fails, inspect it before retrying:
 kubectl -n dev-health logs job/dev-health-migrate
 ```
 
+### Safety net: `wait-for-migrations` initContainers
+
+The explicit `kubectl wait` flow above is the recommended path, but a naive
+`kubectl apply -k deploy/kubernetes/` is also safe: the api and worker
+Deployments carry a `wait-for-migrations` initContainer that blocks app start
+until `dev-hops migrate clickhouse status --check` reports the schema current.
+
+- The check is strictly **read-only** (it lists applied vs pending migrations
+  and exits 1 while any are pending) — it never runs DDL, so multiple replicas
+  polling concurrently cannot race. The migrate Job remains the only thing
+  that applies schema.
+- Each initContainer run polls every 5s for up to ~5 minutes, then exits
+  nonzero and relies on the kubelet's restart backoff as the overall timeout.
+  Pods stuck in `Init:...` mean the migrate Job has not completed — check
+  `kubectl -n dev-health logs job/dev-health-migrate`.
+- The check covers **ClickHouse only**. Postgres is external/optional in this
+  stack (the Alembic step is skipped when `POSTGRES_URI` is unset) and Alembic
+  has no equally cheap read-only pending-check wired into `dev-hops`; if you
+  run Postgres, use the explicit `kubectl wait` flow above for full ordering.
+
 Notes:
 
+- `CLICKHOUSE_URI` (in `dev-health-secrets`) is the DSN that
+  `dev-hops migrate clickhouse` and `status --check` resolve — keep it in sync
+  with `DATABASE_URI` (the app connection string).
 - `POSTGRES_URI` (in `dev-health-secrets`) must point **directly** at Postgres
   (port 5432), never at a transaction-mode pooler (PgBouncer/RDS Proxy) —
   migrations run raw DDL. See `docs/ops/database-connection-pooling.md`.

--- a/deploy/kubernetes/api.yaml
+++ b/deploy/kubernetes/api.yaml
@@ -19,10 +19,54 @@ spec:
       labels:
         app.kubernetes.io/name: dev-health-api
     spec:
+      securityContext:
+        runAsNonRoot: true
+      # CHAOS-2304 safety net: a naive `kubectl apply -k deploy/kubernetes/`
+      # rolls Deployments without waiting for the migrate Job. This
+      # initContainer blocks app start until all ClickHouse migrations are
+      # applied. It is strictly READ-ONLY (`status --check` — exit 0 when
+      # current, 1 when pending); the one-shot Job (migrate-job.yaml) remains
+      # the only thing that runs DDL. After 60 pending checks (~5 min) it
+      # exits 1 and relies on kubelet restart backoff as the overall timeout.
+      # The recommended deploy flow (README.md: `kubectl wait` on the Job)
+      # still applies — this is the safety net, not the primary ordering.
+      initContainers:
+        - name: wait-for-migrations
+          image: ghcr.io/your-org/dev-health-ops:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+          command:
+            - sh
+            - -c
+            - |
+              attempts=0
+              until dev-hops migrate clickhouse status --check; do
+                attempts=$((attempts + 1))
+                if [ "$attempts" -ge 60 ]; then
+                  echo "ClickHouse migrations still pending after $attempts checks; exiting for restart backoff" >&2
+                  exit 1
+                fi
+                echo "ClickHouse migrations pending; re-checking in 5s (attempt $attempts/60)"
+                sleep 5
+              done
+          envFrom:
+            - configMapRef:
+                name: dev-health-config
+            - secretRef:
+                name: dev-health-secrets
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "512Mi"
+              cpu: "250m"
       containers:
         - name: api
           image: ghcr.io/your-org/dev-health-ops:latest
           # Or use: your-registry/dev-health-ops:latest
+          securityContext:
+            allowPrivilegeEscalation: false
           args:
             - "--host"
             - "0.0.0.0"

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -35,3 +35,7 @@ data:
   
   # Logging
   LOG_LEVEL: "INFO"
+
+  # Migrations (CHAOS-2304): schema is applied by the one-shot migrate Job
+  # (migrate-job.yaml) — api/worker pods must never run migrations themselves.
+  AUTO_RUN_MIGRATIONS: "false"

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -12,6 +12,9 @@ resources:
   - redis.yaml
   # NOTE (CHAOS-2304): Jobs do not gate Deployments. The migrate Job must
   # complete before api/worker roll out — see migrate-job.yaml and README.md.
+  # Safety net: api/worker carry a read-only `wait-for-migrations`
+  # initContainer that blocks app start until the schema is current, so a
+  # naive `kubectl apply -k` cannot serve against an unmigrated schema.
   - migrate-job.yaml
   - api.yaml
   - worker.yaml

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
   - secrets.yaml
   - clickhouse.yaml
   - redis.yaml
+  # NOTE (CHAOS-2304): Jobs do not gate Deployments. The migrate Job must
+  # complete before api/worker roll out — see migrate-job.yaml and README.md.
+  - migrate-job.yaml
   - api.yaml
   - worker.yaml
   - cronjobs.yaml

--- a/deploy/kubernetes/migrate-job.yaml
+++ b/deploy/kubernetes/migrate-job.yaml
@@ -1,0 +1,67 @@
+---
+# Database migration Job (CHAOS-2304)
+#
+# Applies PostgreSQL (Alembic, when POSTGRES_URI is set) and ClickHouse schema
+# migrations, then exits. App pods run with AUTO_RUN_MIGRATIONS=false (see
+# configmap.yaml) so they never ambient-migrate — migration 042+ does
+# shadow-table rebuilds that are not safe to run concurrently from workers.
+#
+# IMPORTANT — ordering: Kubernetes Jobs do NOT gate Deployments. This Job must
+# complete BEFORE rolling out new api/worker images. Recommended sequence:
+#
+#   kubectl -n dev-health delete job dev-health-migrate --ignore-not-found
+#   kubectl apply -k deploy/kubernetes/   # or apply this file alone
+#   kubectl -n dev-health wait --for=condition=complete --timeout=600s \
+#     job/dev-health-migrate
+#   # ...then roll out the app Deployments (kubectl rollout restart ...)
+#
+# A Job is used (not an initContainer on the api Deployment) because api/worker
+# run multiple replicas under HPAs — per-pod initContainers would run the same
+# DDL concurrently, which is exactly the race this Job removes.
+#
+# POSTGRES_URI must point DIRECTLY at Postgres (port 5432), never at a
+# transaction-mode pooler (PgBouncer/RDS Proxy): migrations run raw DDL.
+# See docs/ops/database-connection-pooling.md.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dev-health-migrate
+  namespace: dev-health
+  labels:
+    app.kubernetes.io/name: dev-health-migrate
+    app.kubernetes.io/component: migrate
+    app.kubernetes.io/part-of: dev-health-ops
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 1800
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dev-health-migrate
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: migrate
+          image: ghcr.io/your-org/dev-health-ops:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+          command:
+            - sh
+            - -c
+            - >-
+              if [ -n "$POSTGRES_URI" ]; then dev-hops migrate postgres; fi
+              && dev-hops migrate clickhouse
+          envFrom:
+            - configMapRef:
+                name: dev-health-config
+            - secretRef:
+                name: dev-health-secrets
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"

--- a/deploy/kubernetes/migrate-job.yaml
+++ b/deploy/kubernetes/migrate-job.yaml
@@ -15,9 +15,12 @@
 #     job/dev-health-migrate
 #   # ...then roll out the app Deployments (kubectl rollout restart ...)
 #
-# A Job is used (not an initContainer on the api Deployment) because api/worker
-# run multiple replicas under HPAs — per-pod initContainers would run the same
-# DDL concurrently, which is exactly the race this Job removes.
+# A Job is used (not a migrating initContainer on the api Deployment) because
+# api/worker run multiple replicas under HPAs — per-pod initContainers would
+# run the same DDL concurrently, which is exactly the race this Job removes.
+# The api/worker `wait-for-migrations` initContainers are NOT that: they only
+# poll the read-only `dev-hops migrate clickhouse status --check` (no DDL)
+# until this Job has brought the schema current.
 #
 # POSTGRES_URI must point DIRECTLY at Postgres (port 5432), never at a
 # transaction-mode pooler (PgBouncer/RDS Proxy): migrations run raw DDL.

--- a/deploy/kubernetes/secrets.yaml
+++ b/deploy/kubernetes/secrets.yaml
@@ -15,6 +15,11 @@ stringData:
   # Database credentials
   # Replace with your actual values
   DATABASE_URI: "clickhouse://ch:ch@clickhouse:8123/default"
+  # CLICKHOUSE_URI is what `dev-hops migrate clickhouse` (the migrate Job) and
+  # `dev-hops migrate clickhouse status --check` (the wait-for-migrations
+  # initContainers) resolve — DATABASE_URI is NOT consulted by those commands.
+  # Keep both in sync; they should point at the same ClickHouse DSN.
+  CLICKHOUSE_URI: "clickhouse://ch:ch@clickhouse:8123/default"
   SECONDARY_DATABASE_URI: ""
   
   # Provider tokens

--- a/deploy/kubernetes/worker.yaml
+++ b/deploy/kubernetes/worker.yaml
@@ -19,9 +19,47 @@ spec:
       labels:
         app.kubernetes.io/name: dev-health-worker
     spec:
+      securityContext:
+        runAsNonRoot: true
+      # CHAOS-2304 safety net: see api.yaml — blocks worker start until all
+      # ClickHouse migrations are applied. Read-only `status --check` loop,
+      # no DDL; the migrate Job is the only migration runner.
+      initContainers:
+        - name: wait-for-migrations
+          image: ghcr.io/your-org/dev-health-ops:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+          command:
+            - sh
+            - -c
+            - |
+              attempts=0
+              until dev-hops migrate clickhouse status --check; do
+                attempts=$((attempts + 1))
+                if [ "$attempts" -ge 60 ]; then
+                  echo "ClickHouse migrations still pending after $attempts checks; exiting for restart backoff" >&2
+                  exit 1
+                fi
+                echo "ClickHouse migrations pending; re-checking in 5s (attempt $attempts/60)"
+                sleep 5
+              done
+          envFrom:
+            - configMapRef:
+                name: dev-health-config
+            - secretRef:
+                name: dev-health-secrets
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "512Mi"
+              cpu: "250m"
       containers:
         - name: worker
           image: ghcr.io/your-org/dev-health-ops:latest
+          securityContext:
+            allowPrivilegeEscalation: false
           command:
             - celery
             - -A

--- a/src/dev_health_ops/migrate.py
+++ b/src/dev_health_ops/migrate.py
@@ -102,8 +102,16 @@ def _run_clickhouse_upgrade(ns: argparse.Namespace) -> int:
 
 
 def _run_clickhouse_status(ns: argparse.Namespace) -> int:
+    """Show applied/pending ClickHouse migrations (read-only — no DDL).
+
+    With ``--check``, exit 1 when any migration is pending and 0 when the
+    schema is current. This gives deploy tooling (e.g. the Kubernetes
+    ``wait-for-migrations`` initContainers) a clean read-only wait primitive
+    that can never race the canonical ``migrate clickhouse`` upgrade path.
+    """
     import clickhouse_connect
 
+    check = bool(getattr(ns, "check", False))
     uri = resolve_sink_uri(ns)
     client = clickhouse_connect.get_client(dsn=uri)
     try:
@@ -113,6 +121,7 @@ def _run_clickhouse_status(ns: argparse.Namespace) -> int:
             )
             applied = {row[0]: row[1] for row in (result.result_rows or [])}
         except Exception:
+            # No schema_migrations table yet — nothing has been applied.
             applied = {}
 
         available = sorted(
@@ -138,6 +147,9 @@ def _run_clickhouse_status(ns: argparse.Namespace) -> int:
         print(
             f"{len(applied)} applied, {pending_count} pending, {len(available)} total"
         )
+
+        if check and pending_count:
+            return 1
     finally:
         client.close()
     return 0
@@ -289,6 +301,15 @@ def _register_clickhouse_subcommands(
     ch_up.set_defaults(func=_run_clickhouse_upgrade)
 
     ch_status = sub.add_parser("status", help="Show applied and pending migrations.")
+    ch_status.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Exit 1 if any migration is pending, 0 if the schema is current. "
+            "Read-only — never applies DDL. Used as a wait primitive by "
+            "deploy tooling (e.g. Kubernetes initContainers)."
+        ),
+    )
     ch_status.set_defaults(func=_run_clickhouse_status)
 
     ch_repair = sub.add_parser(

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -117,6 +117,102 @@ def test_monitoring_queue_declared_and_consumed_redundantly() -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# CHAOS-2304: production deploy stacks must run migrations as an explicit
+# one-shot step — app services never ambient-migrate (AUTO_RUN_MIGRATIONS=false).
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PROD_COMPOSE = _REPO_ROOT / "deploy" / "docker-compose" / "compose.production.yml"
+_SWARM_STACK = _REPO_ROOT / "deploy" / "docker-swarm" / "stack.yml"
+_K8S_DIR = _REPO_ROOT / "deploy" / "kubernetes"
+_HELM_DIR = _REPO_ROOT / "deploy" / "helm" / "dev-health"
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_production_compose_has_one_shot_migrate_service() -> None:
+    services = _load_yaml(_PROD_COMPOSE)["services"]
+    migrate = services.get("migrate")
+    assert migrate is not None, "compose.production.yml must define a migrate service"
+    assert migrate.get("restart") == "no"
+    entrypoint = " ".join(str(p) for p in migrate["entrypoint"])
+    assert "dev-hops migrate clickhouse" in entrypoint
+    assert "dev-hops migrate postgres" in entrypoint
+
+
+def test_production_compose_app_services_gate_on_migrate() -> None:
+    services = _load_yaml(_PROD_COMPOSE)["services"]
+    for name in ("api", "billing-edge", "worker"):
+        deps = services[name].get("depends_on") or {}
+        assert (
+            deps.get("migrate", {}).get("condition") == "service_completed_successfully"
+        ), f"{name} must gate on migrate completing successfully"
+
+
+def test_production_compose_disables_ambient_migrations() -> None:
+    services = _load_yaml(_PROD_COMPOSE)["services"]
+    for name in ("api", "worker"):
+        env = services[name].get("environment") or {}
+        assert env.get("AUTO_RUN_MIGRATIONS") == "false", (
+            f"{name} must set AUTO_RUN_MIGRATIONS=false — schema is applied by "
+            f"the one-shot migrate service"
+        )
+
+
+def test_swarm_stack_has_migrate_service_and_disables_ambient_migrations() -> None:
+    services = _load_yaml(_SWARM_STACK)["services"]
+    migrate = services.get("migrate")
+    assert migrate is not None, "stack.yml must define a migrate service"
+    restart = migrate["deploy"]["restart_policy"]["condition"]
+    assert restart == "none", "swarm migrate must be one-shot (restart: none)"
+    entrypoint = " ".join(str(p) for p in migrate["entrypoint"])
+    assert "dev-hops migrate clickhouse" in entrypoint
+    for name in ("api", "worker"):
+        env = services[name].get("environment") or {}
+        assert env.get("AUTO_RUN_MIGRATIONS") == "false"
+
+
+def test_kubernetes_manifests_run_migrations_as_job() -> None:
+    job_docs = [
+        d
+        for d in yaml.safe_load_all(
+            (_K8S_DIR / "migrate-job.yaml").read_text(encoding="utf-8")
+        )
+        if d
+    ]
+    jobs = [d for d in job_docs if d.get("kind") == "Job"]
+    assert len(jobs) == 1
+    pod_spec = jobs[0]["spec"]["template"]["spec"]
+    assert pod_spec["restartPolicy"] == "Never"
+    command = " ".join(pod_spec["containers"][0]["command"])
+    assert "dev-hops migrate clickhouse" in command
+
+    config = _load_yaml(_K8S_DIR / "configmap.yaml")
+    assert config["data"]["AUTO_RUN_MIGRATIONS"] == "false"
+
+    kustomization = _load_yaml(_K8S_DIR / "kustomization.yaml")
+    assert "migrate-job.yaml" in kustomization["resources"]
+
+
+def test_helm_chart_runs_migrations_as_pre_upgrade_hook() -> None:
+    # Helm templates are Go-templated, so assert on text rather than YAML.
+    template = (_HELM_DIR / "templates" / "migrate-job.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "helm.sh/hook: pre-install,pre-upgrade" in template
+    assert "helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded" in template
+    assert "dev-hops migrate clickhouse" in template
+
+    helpers = (_HELM_DIR / "templates" / "_helpers.tpl").read_text(encoding="utf-8")
+    assert "AUTO_RUN_MIGRATIONS" in helpers
+
+    values = _load_yaml(_HELM_DIR / "values.yaml")
+    assert values["migrations"]["hook"]["enabled"] is True
+
+
 def test_celery_worker_prefetch_multiplier_is_one() -> None:
     """CHAOS-2277: long-running tasks (sync, stream consumers) + default
     prefetch (4) let reserved slow-queue messages fill the QoS window and

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
 
+import pytest
 import yaml
 
 from dev_health_ops.workers.config import task_queues
@@ -195,6 +197,84 @@ def test_kubernetes_manifests_run_migrations_as_job() -> None:
 
     kustomization = _load_yaml(_K8S_DIR / "kustomization.yaml")
     assert "migrate-job.yaml" in kustomization["resources"]
+
+
+def _k8s_docs(filename: str) -> list[dict]:
+    return [
+        d
+        for d in yaml.safe_load_all((_K8S_DIR / filename).read_text(encoding="utf-8"))
+        if d
+    ]
+
+
+def test_kubernetes_secret_exposes_clickhouse_uri_for_migrate(monkeypatch) -> None:
+    """`dev-hops migrate clickhouse` (the Job) and `status --check` (the
+    wait-for-migrations initContainers) resolve CLICKHOUSE_URI via
+    resolve_sink_uri — they do NOT read DATABASE_URI. Without CLICKHOUSE_URI
+    in the secret the migrate Job fails on first boot."""
+    from dev_health_ops.db import resolve_sink_uri
+
+    secret = next(
+        d
+        for d in _k8s_docs("secrets.yaml")
+        if d.get("kind") == "Secret" and d["metadata"]["name"] == "dev-health-secrets"
+    )
+    uri = secret["stringData"].get("CLICKHOUSE_URI")
+    assert uri, "dev-health-secrets must define CLICKHOUSE_URI"
+    assert uri.startswith("clickhouse://")
+
+    # The value must be resolvable exactly the way the migrate CLI resolves it.
+    monkeypatch.setenv("CLICKHOUSE_URI", uri)
+    assert resolve_sink_uri(argparse.Namespace(analytics_db=None)) == uri
+
+    # ...and the Job must actually see the secret (envFrom).
+    job = next(d for d in _k8s_docs("migrate-job.yaml") if d.get("kind") == "Job")
+    container = job["spec"]["template"]["spec"]["containers"][0]
+    secret_refs = {
+        ref["secretRef"]["name"]
+        for ref in container.get("envFrom", [])
+        if "secretRef" in ref
+    }
+    assert "dev-health-secrets" in secret_refs
+
+
+@pytest.mark.parametrize("manifest", ["api.yaml", "worker.yaml"])
+def test_kubernetes_app_deployments_wait_for_migrations(manifest: str) -> None:
+    """CHAOS-2304 safety net: a naive `kubectl apply -k` rolls Deployments
+    without waiting for the migrate Job. api/worker must carry a read-only
+    wait-for-migrations initContainer that blocks until the schema is
+    current (`dev-hops migrate clickhouse status --check`) and never runs
+    DDL itself."""
+    deployment = next(d for d in _k8s_docs(manifest) if d.get("kind") == "Deployment")
+    pod_spec = deployment["spec"]["template"]["spec"]
+    waiter = next(
+        (
+            c
+            for c in pod_spec.get("initContainers") or []
+            if c["name"] == "wait-for-migrations"
+        ),
+        None,
+    )
+    assert waiter is not None, (
+        f"{manifest} must define a wait-for-migrations initContainer"
+    )
+
+    command = " ".join(waiter["command"])
+    assert "dev-hops migrate clickhouse status --check" in command
+    # Read-only contract: every dev-hops invocation in the waiter is the
+    # status --check probe — it must never run the upgrade (DDL) path.
+    assert command.count("dev-hops") == command.count(
+        "dev-hops migrate clickhouse status --check"
+    )
+
+    secret_refs = {
+        ref["secretRef"]["name"]
+        for ref in waiter.get("envFrom", [])
+        if "secretRef" in ref
+    }
+    assert "dev-health-secrets" in secret_refs, (
+        "waiter needs the secret env (CLICKHOUSE_URI) to resolve the DSN"
+    )
 
 
 def test_helm_chart_runs_migrations_as_pre_upgrade_hook() -> None:

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -48,6 +48,7 @@ class TestMigrateRouting:
             (["migrate", "clickhouse"], "_run_clickhouse_upgrade"),
             (["migrate", "clickhouse", "upgrade"], "_run_clickhouse_upgrade"),
             (["migrate", "clickhouse", "status"], "_run_clickhouse_status"),
+            (["migrate", "clickhouse", "status", "--check"], "_run_clickhouse_status"),
             (["migrate", "clickhouse", "repair"], "_run_clickhouse_repair"),
             (["migrate", "clickhouse", "repair", "--apply"], "_run_clickhouse_repair"),
             (
@@ -75,6 +76,15 @@ class TestMigrateRouting:
     def test_clickhouse_bare_defaults_to_upgrade(self):
         ns = self.parser.parse_args(["migrate", "clickhouse"])
         assert ns.func.__name__ == "_run_clickhouse_upgrade"
+
+    def test_status_check_flag_parses(self):
+        ns = self.parser.parse_args(["migrate", "clickhouse", "status", "--check"])
+        assert ns.func.__name__ == "_run_clickhouse_status"
+        assert ns.check is True
+
+    def test_status_check_flag_defaults_false(self):
+        ns = self.parser.parse_args(["migrate", "clickhouse", "status"])
+        assert ns.check is False
 
     def test_repair_preserves_root_org_flag(self):
         ns = self.parser.parse_args(
@@ -315,6 +325,122 @@ class TestClickhouseStatus:
                 _run_clickhouse_status(_ns())
 
         mock_client.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _run_clickhouse_status --check (CHAOS-2304 k8s wait primitive)
+# ---------------------------------------------------------------------------
+
+
+class TestClickhouseStatusCheck:
+    """`status --check` is the read-only wait primitive used by the
+    Kubernetes wait-for-migrations initContainers: exit 1 while any
+    migration is pending, 0 once the schema is current. It must never
+    apply DDL."""
+
+    def _make_mock_client(self, applied_rows: list | None = None):
+        mock_client = MagicMock()
+        result = MagicMock()
+        result.result_rows = applied_rows or []
+        mock_client.query.return_value = result
+        return mock_client
+
+    @patch(
+        "dev_health_ops.migrate.resolve_sink_uri",
+        return_value="clickhouse://fake:8123/test",
+    )
+    def test_exits_nonzero_when_pending(self, _mock_uri, tmp_path, capsys):
+        (tmp_path / "000_init.sql").write_text("SELECT 1")
+        (tmp_path / "001_add_col.sql").write_text("SELECT 1")
+
+        applied_rows = [("000_init.sql", datetime(2026, 6, 1))]
+        mock_client = self._make_mock_client(applied_rows)
+
+        with (
+            patch("dev_health_ops.migrate._CH_MIGRATIONS_DIR", tmp_path),
+            patch("clickhouse_connect.get_client", return_value=mock_client),
+        ):
+            result = _run_clickhouse_status(_ns(check=True))
+
+        assert result == 1
+        assert "1 applied, 1 pending, 2 total" in capsys.readouterr().out
+        # Read-only contract: no DDL/commands issued, only the SELECT query.
+        mock_client.command.assert_not_called()
+        mock_client.close.assert_called_once()
+
+    @patch(
+        "dev_health_ops.migrate.resolve_sink_uri",
+        return_value="clickhouse://fake:8123/test",
+    )
+    def test_exits_zero_when_current(self, _mock_uri, tmp_path):
+        (tmp_path / "000_init.sql").write_text("SELECT 1")
+
+        applied_rows = [("000_init.sql", datetime(2026, 6, 1))]
+        mock_client = self._make_mock_client(applied_rows)
+
+        with (
+            patch("dev_health_ops.migrate._CH_MIGRATIONS_DIR", tmp_path),
+            patch("clickhouse_connect.get_client", return_value=mock_client),
+        ):
+            result = _run_clickhouse_status(_ns(check=True))
+
+        assert result == 0
+        mock_client.close.assert_called_once()
+
+    @patch(
+        "dev_health_ops.migrate.resolve_sink_uri",
+        return_value="clickhouse://fake:8123/test",
+    )
+    def test_exits_nonzero_on_fresh_database(self, _mock_uri, tmp_path):
+        """First boot: no schema_migrations table yet — everything is
+        pending, so --check must fail (this is exactly the state the
+        initContainer waits out while the migrate Job runs)."""
+        (tmp_path / "000_init.sql").write_text("SELECT 1")
+
+        mock_client = MagicMock()
+        mock_client.query.side_effect = Exception("Unknown table")
+
+        with (
+            patch("dev_health_ops.migrate._CH_MIGRATIONS_DIR", tmp_path),
+            patch("clickhouse_connect.get_client", return_value=mock_client),
+        ):
+            result = _run_clickhouse_status(_ns(check=True))
+
+        assert result == 1
+        mock_client.close.assert_called_once()
+
+    @patch(
+        "dev_health_ops.migrate.resolve_sink_uri",
+        return_value="clickhouse://fake:8123/test",
+    )
+    def test_exits_zero_when_no_migration_files(self, _mock_uri, tmp_path):
+        mock_client = self._make_mock_client()
+
+        with (
+            patch("dev_health_ops.migrate._CH_MIGRATIONS_DIR", tmp_path),
+            patch("clickhouse_connect.get_client", return_value=mock_client),
+        ):
+            result = _run_clickhouse_status(_ns(check=True))
+
+        assert result == 0
+
+    @patch(
+        "dev_health_ops.migrate.resolve_sink_uri",
+        return_value="clickhouse://fake:8123/test",
+    )
+    def test_without_check_pending_still_exits_zero(self, _mock_uri, tmp_path):
+        """Plain `status` keeps its informational exit-0 behavior."""
+        (tmp_path / "000_init.sql").write_text("SELECT 1")
+
+        mock_client = self._make_mock_client()
+
+        with (
+            patch("dev_health_ops.migrate._CH_MIGRATIONS_DIR", tmp_path),
+            patch("clickhouse_connect.get_client", return_value=mock_client),
+        ):
+            result = _run_clickhouse_status(_ns(check=False))
+
+        assert result == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

CHAOS-2268/#850 gated ClickHouse auto-migration behind `AUTO_RUN_MIGRATIONS` (default `true`), but no production deploy stack shipped a migrate step — api/workers all still ambient-migrated on boot. Migration 042 (#862) does shadow-table rebuilds, so concurrent worker-driven migration in prod is race-prone. This PR ends worker-driven ambient migration in every production stack by adding an explicit one-shot migrate step (reference pattern: workspace `compose.yml`) and setting `AUTO_RUN_MIGRATIONS=false` on app services.

## Per-stack approach

### docker-compose (`deploy/docker-compose/compose.production.yml`)
- One-shot `migrate` service (same image): `dev-hops migrate postgres && dev-hops migrate clickhouse`; Alembic step auto-skips when `POSTGRES_URI` is unset (this stack's Postgres is external/optional).
- `api`/`billing-edge`/`worker` gate via `depends_on.condition: service_completed_successfully`; `AUTO_RUN_MIGRATIONS: "false"` on api/worker.
- `POSTGRES_URI` documented as direct-to-5432, never a transaction-mode pooler (DDL — see `docs/ops/database-connection-pooling.md`).

### kubernetes (`deploy/kubernetes/`)
- New `migrate-job.yaml` Job (`restartPolicy: Never`, `backoffLimit: 2`, same image + `envFrom` configmap/secret as api), added to `kustomization.yaml`.
- **Job, not initContainer**: api/worker run multiple replicas under HPAs — per-pod initContainers would run the same DDL concurrently, recreating the race. Jobs don't gate Deployments natively, so the required `kubectl wait --for=condition=complete` ordering is documented in the manifest comment and a new `deploy/kubernetes/README.md`.
- `AUTO_RUN_MIGRATIONS: "false"` added to the shared configmap (covers api + worker via `envFrom`).

### helm (`deploy/helm/dev-health`)
- `templates/migrate-job.yaml`: `pre-install,pre-upgrade` hook Job, `hook-delete-policy: before-hook-creation,hook-succeeded`, toggle `migrations.hook.enabled` (default `true`).
- Hook ships its own ConfigMap/Secret copies (hook-weight -5): pre-install hooks run **before** the chart's regular resources exist, so the Job can't reference them on a fresh install. With `secrets.create=false` the external secret is referenced directly. Config/secret data factored into `dev-health.configData`/`dev-health.secretData` helpers — rendered output verified byte-identical to main except the intended new key.
- Shared configmap computes `AUTO_RUN_MIGRATIONS` from the toggle (`false` when hook enabled, `true` when disabled), overridable via `config.AUTO_RUN_MIGRATIONS`.

### docker-swarm (`deploy/docker-swarm/stack.yml`)
- `migrate` service with `deploy.restart_policy.condition: none` (one-shot), hardened (`no-new-privileges`, `read_only` + tmpfs); `AUTO_RUN_MIGRATIONS: "false"` on api/worker.
- Swarm has no `depends_on` ordering: README documents that operators must verify `docker service logs <stack>_migrate` before first deploy / after image updates, and how to re-run via `docker service update --force`.

## Validation
- `docker compose -f deploy/docker-compose/compose.production.yml config -q` (dummy env) — OK; verified the interpolated `migrate` service entrypoint.
- `docker compose -f deploy/docker-swarm/stack.yml config -q` — OK (pre-existing obsolete-`version` warning only).
- `kubectl kustomize deploy/kubernetes/` — OK.
- `helm template` (default + `migrations.hook.enabled=false` + values-quickstart) and `helm lint` — OK; configmap/secret render-diffed against main.

## Tests
- `tests/test_compose_config.py`: new assertions for all four stacks (migrate step exists, compose gating wired, `AUTO_RUN_MIGRATIONS=false` present, helm hook annotations, kustomization wiring) — 9 passed.
- `mypy --install-types --non-interactive .` — clean (1015 files).
- `./ci/run_tests.sh unit` — 4039 passed; only the 4 known-ignorable failures (test_org_deletion ×2, TestCoreCache ×2).