### PR TITLE
docs(investment): accurate developer docs for investment categorization (M1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 If available locally:
 
 **Canonical Reference:** See [`/AGENTS.md`](../AGENTS.md) for the unified Dev Health platform agent briefing.
-**Deep Dives:** See [`/docs/agent-instructions/`](../docs/agent-instructions/) for detailed topic documentation.
+**Deep Dives:** See the MkDocs site under [`docs/`](docs/index.md) — e.g. the [Investment Categorization Pipeline](docs/architecture/investment-categorization-pipeline.md), [Investment Data Model](docs/architecture/investment-data-model.md), and [LLM Categorization Contract](docs/llm/categorization-contract.md).
 
 
 # AGENTS — Briefing and pointers (dev-health-ops)

--- a/docs/api/investment-api.md
+++ b/docs/api/investment-api.md
@@ -56,7 +56,7 @@ though it still has a valid distribution.
 | `fetch_investment_breakdown` | subcategory + theme → value | `subcategory_prob * effort_value` |
 | `fetch_investment_edges` | theme → repo/scope → value | `theme_prob * effort_value` |
 | `fetch_investment_subcategory_edges` | subcategory → repo/scope → value | `subcategory_prob * effort_value` |
-| `fetch_investment_team_edges` | theme → team → value | `theme_prob * effort_value` |
+| `fetch_investment_team_edges` | subcategory → team → value | `subcategory_prob * effort_value` |
 
 All of them `ARRAY JOIN` the stored `Map` distribution into rows, filter by the time
 window (`from_ts < end_ts AND to_ts >= start_ts`) and `org_id`, then group.
@@ -69,16 +69,21 @@ compute time — the API never re-categorizes.
 
 ## `unassigned` means missing scope, not a category
 
-In edge queries the target is computed as, e.g.:
+Some edge queries surface an `unassigned` **scope label** for WorkUnits with no resolved
+repo or team. The exact expression varies by query, e.g.:
 
 ```sql
+-- fetch_investment_subcategory_edges: missing repo
 ifNull(r.repo, if(repo_id IS NULL, 'unassigned', toString(repo_id))) AS target
+-- fetch_investment_team_edges: missing team
+ifNull(nullIf(unit_team.team, ''), 'unassigned') AS target
 ```
 
-Here `unassigned` is a **scope/grouping label** for a WorkUnit with no resolved
-repo/team — it is **not** an investment category and never appears in a theme or
-subcategory distribution. The categorization itself never returns "unknown"
-(see the [pipeline guarantees](../architecture/investment-categorization-pipeline.md#guarantees)).
+(`fetch_investment_edges` and the sunburst query instead use `ifNull(r.repo, toString(repo_id))`,
+which can fall back to the raw `repo_id`.) In every case `unassigned` is a **scope/grouping
+label** for a WorkUnit with no resolved repo/team — it is **not** an investment category and
+never appears in a theme or subcategory distribution. The categorization itself never returns
+"unknown" (see the [pipeline guarantees](../architecture/investment-categorization-pipeline.md#guarantees)).
 
 > Do not confuse this with the legacy rule-based classifier in
 > `analytics/investment.py`, which uses `unassigned` as a *category* fallback. That path

--- a/docs/api/investment-api.md
+++ b/docs/api/investment-api.md
@@ -1,0 +1,113 @@
+# Investment API (Aggregation & Effort Weighting)
+
+How persisted investment distributions become the numbers shown in the product. This is
+the read side of the [Investment Categorization Pipeline](../architecture/investment-categorization-pipeline.md);
+the tables it reads are described in the
+[Investment Data Model](../architecture/investment-data-model.md).
+
+Query code lives in `src/dev_health_ops/api/queries/investment.py`; the user-facing
+response builder is in `src/dev_health_ops/api/services/investment.py`.
+
+---
+
+## The one thing to understand: values are effort-weighted
+
+A WorkUnit stores a **probability** per theme/subcategory. The API does **not** report
+those probabilities directly — it multiplies each probability by the WorkUnit's
+`effort_value` and sums across WorkUnits:
+
+```sql
+-- fetch_investment_breakdown (simplified)
+SELECT
+    subcategory_kv.1 AS subcategory,
+    splitByChar('.', subcategory_kv.1)[1] AS theme,
+    sum(subcategory_kv.2 * effort_value) AS value
+FROM work_unit_investments
+ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
+WHERE from_ts < %(end_ts)s AND to_ts >= %(start_ts)s AND org_id = %(org_id)s
+GROUP BY subcategory, theme
+ORDER BY value DESC
+```
+
+So **"60% Feature Delivery" means 60% of weighted effort**, not 60% of tickets and not
+the average probability. A WorkUnit with a large `effort_value` moves the distribution
+far more than a tiny one.
+
+### What `effort_value` is
+
+Computed at materialization time by `_effort_from_work_unit`, with this precedence:
+
+| Priority | Source | `effort_metric` |
+| -------- | ------ | --------------- |
+| 1 | Commit churn (additions + deletions) | `churn_loc` |
+| 2 | PR churn (additions + deletions) | `churn_loc` |
+| 3 | Issue active hours | `active_hours` |
+| 4 | none → `0.0` | `churn_loc` |
+
+A WorkUnit with `effort_value == 0` contributes nothing to weighted aggregates even
+though it still has a valid distribution.
+
+---
+
+## Query surfaces
+
+| Function | Shape | Weighting |
+| -------- | ----- | --------- |
+| `fetch_investment_breakdown` | subcategory + theme → value | `subcategory_prob * effort_value` |
+| `fetch_investment_edges` | theme → repo/scope → value | `theme_prob * effort_value` |
+| `fetch_investment_subcategory_edges` | subcategory → repo/scope → value | `subcategory_prob * effort_value` |
+| `fetch_investment_team_edges` | theme → team → value | `theme_prob * effort_value` |
+
+All of them `ARRAY JOIN` the stored `Map` distribution into rows, filter by the time
+window (`from_ts < end_ts AND to_ts >= start_ts`) and `org_id`, then group.
+
+Themes are derived in SQL from the subcategory prefix
+(`splitByChar('.', subcategory)[1]`), mirroring the deterministic roll-up done at
+compute time — the API never re-categorizes.
+
+---
+
+## `unassigned` means missing scope, not a category
+
+In edge queries the target is computed as, e.g.:
+
+```sql
+ifNull(r.repo, if(repo_id IS NULL, 'unassigned', toString(repo_id))) AS target
+```
+
+Here `unassigned` is a **scope/grouping label** for a WorkUnit with no resolved
+repo/team — it is **not** an investment category and never appears in a theme or
+subcategory distribution. The categorization itself never returns "unknown"
+(see the [pipeline guarantees](../architecture/investment-categorization-pipeline.md#guarantees)).
+
+> Do not confuse this with the legacy rule-based classifier in
+> `analytics/investment.py`, which uses `unassigned` as a *category* fallback. That path
+> is legacy and is being deprecated/isolated; it is not part of the canonical Investment
+> View.
+
+---
+
+## Read-semantics caveat (latest row)
+
+`work_unit_investments` is `ReplacingMergeTree(computed_at)`, but these queries `sum(...)`
+directly without `FINAL` or `argMax(..., computed_at)`. After a re-materialization,
+duplicate rows for the same `work_unit_id` may be double-counted until ClickHouse merges.
+This is a tracked engineering issue; see the
+[data model read-semantics note](../architecture/investment-data-model.md#read-semantics-important).
+
+---
+
+## Evidence quality stats
+
+`api/services/investment.py` also surfaces evidence-quality statistics (the `0–1` score
+and its band) alongside distributions, and guards for missing tables/columns. Use these
+to convey confidence in the UI — a distribution dominated by low-quality or fallback
+WorkUnits should be presented with appropriate uncertainty (see the
+[LLM Categorization Contract](../llm/categorization-contract.md#ux-time-explanation)).
+
+## Related
+
+- [Investment Categorization Pipeline](../architecture/investment-categorization-pipeline.md)
+- [Investment Data Model](../architecture/investment-data-model.md)
+- [Web Investment Queries](web-graphql-investment.md)
+- [View Mapping](view-mapping.md)

--- a/docs/architecture/investment-categorization-pipeline.md
+++ b/docs/architecture/investment-categorization-pipeline.md
@@ -1,0 +1,184 @@
+# Investment Categorization Pipeline
+
+How a piece of work is assigned an investment categorization, end to end.
+
+This is the **compute-time** pipeline. It runs during `dev-hops investment materialize`
+(see [Investment Materialization](../ops/investment-materialization.md)), persists
+distributions to ClickHouse (see [Investment Data Model](investment-data-model.md)),
+and is read back — **effort-weighted** — by the API
+(see [Investment API](../api/investment-api.md)).
+
+For the strict LLM input/output schema, see the
+[LLM Categorization Contract](../llm/categorization-contract.md). For the canonical
+themes and subcategories, see the [Investment Taxonomy](../product/investment-taxonomy.md).
+
+> **Mental model.** An individual issue, PR, or commit is **never** tagged with a
+> category. The unit of categorization is a **WorkUnit** (a cluster of related items),
+> and the output is a **probability distribution** over a fixed taxonomy — not a single
+> label. Themes are a deterministic roll-up of subcategory probabilities; the LLM never
+> picks a theme directly.
+
+Code lives in `src/dev_health_ops/work_graph/investment/`.
+
+---
+
+## Pipeline at a glance
+
+```mermaid
+flowchart TD
+    A[work_graph_edges] --> B[Build connected components]
+    B --> C[Per component: build text evidence bundle]
+    C --> D{Enough evidence?}
+    D -- no --> F[Deterministic fallback prior]
+    D -- yes --> E[LLM -> 15-subcategory distribution]
+    E --> V{Strict validation}
+    V -- ok --> G[Normalize subcategory vector]
+    V -- fail --> R[One repair re-prompt]
+    R -- ok --> G
+    R -- fail --> F
+    F --> G
+    G --> H[Deterministic roll-up to 5 themes]
+    H --> I[Compute evidence quality + effort value]
+    I --> J[(Persist: work_unit_investments + quotes)]
+```
+
+---
+
+## Step 1 — Form the WorkUnit
+
+`materialize_investments` reads typed edges from `work_graph_edges` via
+`fetch_work_graph_edges` and builds **connected components** with `_build_components`.
+Each component is one **WorkUnit**: a set of linked `issue` / `pr` / `commit` nodes.
+The WorkUnit id is a stable SHA-256 of its sorted node tokens (`work_unit_id`).
+
+Categorization therefore happens on the **cluster**, not on the individual item.
+
+> **Correction — components are not window-bounded.** `fetch_work_graph_edges`
+> filters by repo / org only, **not** by time. Components are built from the **full**
+> edge set, and the requested time window (`--from` / `--to`) is applied **afterward**:
+> a component is skipped only if its node time-bounds (`compute_time_bounds`) fall
+> entirely outside the window. Do not describe components as "built from edges inside
+> the window" — a long-lived component can span many periods. (Whether that is the
+> desired product behavior is tracked separately as an engineering question.)
+
+## Step 2 — Build the text evidence bundle
+
+For each WorkUnit, `build_text_bundle` (in `evidence.py`) gathers bounded text:
+
+| Source  | Max items | Fields used |
+| ------- | --------- | ----------- |
+| Issues  | 6         | title, description, type, labels, parent title, epic title |
+| PRs     | 6         | title, body |
+| Commits | 12        | subject line (first non-empty line) |
+
+Each field is truncated to **280** chars and each source to **900** chars. The result
+is a `source_block` (the text shown to the LLM) plus a per-source map (`source_texts`)
+used later to verify quotes, and an `input_hash` (SHA-256 of the serialized sources)
+persisted for audit.
+
+## Step 3 — Gate: LLM vs deterministic fallback
+
+Before any LLM call, `materialize_investments` decides per component:
+
+- `text_char_count < MIN_EVIDENCE_CHARS` → fallback (`insufficient_evidence`)
+- `text_source_count == 0` → fallback (`no_text_sources`)
+- otherwise → send to the LLM
+
+This keeps cost down and avoids asking the model to categorize empty clusters.
+
+## Step 4 — LLM assigns subcategory probabilities
+
+`categorize_text_bundle` (in `categorize.py`) sends the canonical prompt and expects a
+**probability distribution across all 15 subcategories** (summing to 1), plus 1–10
+**extractive evidence quotes** and a short `uncertainty` string. The 15 subcategories
+are the fixed registry in `investment_taxonomy.py`
+(see [Investment Taxonomy](../product/investment-taxonomy.md)).
+
+**This is the step that makes the determination.** Everything downstream is
+deterministic.
+
+## Step 5 — Strict validation, one repair, deterministic fallback
+
+`validate_llm_payload` (in `llm_schema.py`) enforces:
+
+- top-level keys are exactly `subcategories`, `evidence_quotes`, `uncertainty`;
+- every subcategory key is in the canonical set; each probability in `[0, 1]`;
+- the distribution sums to within `[0.98, 1.02]`;
+- each evidence quote is a **literal substring** of the provided source text
+  (anti-hallucination), 1–10 quotes, `source ∈ {issue, pr, commit}`;
+- `uncertainty` is non-empty and ≤ 280 chars.
+
+On failure, exactly **one repair re-prompt** is attempted (the validation errors are
+fed back). If it still fails, a deterministic fallback distribution is applied with
+status `invalid_llm_output`.
+
+> **The fallback is a neutral prior, not "unknown."** `FALLBACK_PRIOR` spreads weight
+> evenly across one representative subcategory per theme (and zeroes the rest). It
+> satisfies the "never unknown" contract, but semantically it means *"insufficient
+> validated evidence to assign a confident mix,"* **not** a meaningful estimate. Treat
+> low `evidence_quality` and a fallback `categorization_status` as low-confidence
+> signals in any UX.
+
+Possible `categorization_status` values: `ok`, `repaired`, `invalid_llm_output`,
+`insufficient_evidence`, `no_text_sources`.
+
+## Step 6 — Deterministic theme roll-up
+
+Themes are **never** chosen by the LLM. `rollup_subcategories_to_themes` sums
+subcategory probabilities by their prefix (`operational.on_call` → `operational`) and
+normalizes across the 5 themes. The subcategory vector is first filled out to all 15
+keys and normalized via `ensure_full_subcategory_vector`. Pure arithmetic — no model
+involved. This is what prevents category drift.
+
+## Step 7 — Evidence quality and effort value
+
+`compute_evidence_quality` (in `evidence.py`) emits a `0–1` score:
+
+```
+0.4 * text_score + 0.3 * source_agreement + 0.3 * structural_density
+```
+
+where `text_score` reflects how much text was available, `source_agreement` rewards
+having more than one source type (issue/pr/commit), and `structural_density` combines
+graph density with average edge confidence. It is banded into
+`high` / `moderate` / `low` / `very_low`.
+
+Separately, `_effort_from_work_unit` computes the **effort value** used later for
+weighting (see [Investment API](../api/investment-api.md)). Precedence:
+
+1. commit churn (additions + deletions) → metric `churn_loc`
+2. else PR churn → metric `churn_loc`
+3. else issue active hours → metric `active_hours`
+4. else `0.0`
+
+## Step 8 — Persist
+
+A `WorkUnitInvestmentRecord` is written per WorkUnit to `work_unit_investments` with the
+theme distribution, subcategory distribution, structural evidence, evidence quality,
+effort metric/value, and audit fields (`categorization_status`,
+`categorization_model_version`, `categorization_input_hash`, `categorization_run_id`,
+`computed_at`).
+
+Evidence quotes are written to `work_unit_investment_quotes` **only when**
+`--persist-evidence-snippets` is enabled (default off). See
+[Investment Data Model](investment-data-model.md) for table schemas and read semantics.
+
+---
+
+## Guarantees
+
+For every WorkUnit:
+
+- theme probabilities sum to ~1.0;
+- subcategory probabilities sum to the theme probabilities;
+- evidence arrays exist (may be empty);
+- evidence quality is always emitted;
+- categorization never returns "unknown".
+
+## What this pipeline does **not** do
+
+- It does not tag individual issues/PRs/commits.
+- It does not let the LLM choose themes or invent categories.
+- It does not recompute anything at UX-time — explanations read persisted data only
+  (see the [LLM Categorization Contract](../llm/categorization-contract.md)).
+- It does not apply effort weighting here; weighting happens at read time in the API.

--- a/docs/architecture/investment-categorization-pipeline.md
+++ b/docs/architecture/investment-categorization-pipeline.md
@@ -120,7 +120,8 @@ status `invalid_llm_output`.
 > signals in any UX.
 
 Possible `categorization_status` values: `ok`, `repaired`, `invalid_llm_output`,
-`insufficient_evidence`, `no_text_sources`.
+`insufficient_evidence`, `no_text_sources`, and `llm_task_failed` (the async LLM task
+raised before an outcome was recorded).
 
 ## Step 6 — Deterministic theme roll-up
 

--- a/docs/architecture/investment-data-model.md
+++ b/docs/architecture/investment-data-model.md
@@ -1,0 +1,119 @@
+# Investment Data Model
+
+Where investment categorization is persisted, and how to read it correctly.
+
+Investment analytics are **ClickHouse-only**. PostgreSQL holds none of this data — it is
+the semantic/admin layer only. Tables are written by the materializer (see
+[Investment Categorization Pipeline](investment-categorization-pipeline.md)) and read,
+**effort-weighted**, by the API (see [Investment API](../api/investment-api.md)).
+
+Migrations live in `src/dev_health_ops/migrations/clickhouse/`.
+
+---
+
+## Tables
+
+### `work_unit_investments` (canonical)
+
+One row per WorkUnit per materialization run. Created in
+`017_investment_materialize_tables.sql`; label columns added in
+`019_work_unit_investment_labels.sql`; `org_id` added in `024_add_org_id.sql`.
+
+| Column | Type | Notes |
+| ------ | ---- | ----- |
+| `work_unit_id` | `String` | Stable SHA-256 of the component's sorted nodes |
+| `work_unit_type` | `Nullable(String)` | Label (added in 019) |
+| `work_unit_name` | `Nullable(String)` | Label (added in 019) |
+| `from_ts` / `to_ts` | `DateTime64(3,'UTC')` | Component time bounds (min/max node times) |
+| `repo_id` | `Nullable(UUID)` | Null → surfaces as `unassigned` scope in the API |
+| `provider` | `Nullable(String)` | Source provider |
+| `effort_metric` | `String` | **Runtime values: `churn_loc` or `active_hours`** |
+| `effort_value` | `Float64` | Weight used by the API (see below) |
+| `theme_distribution_json` | `Map(String, Float64)` | 5 themes → probability (~sums to 1) |
+| `subcategory_distribution_json` | `Map(String, Float64)` | 15 subcategories → probability |
+| `structural_evidence_json` | `String` | Serialized structural signals |
+| `evidence_quality` | `Float64` | `0.0–1.0` |
+| `evidence_quality_band` | `String` | **Runtime values: `high` / `moderate` / `low` / `very_low`** |
+| `categorization_status` | `String` | **Runtime values: `ok`, `repaired`, `invalid_llm_output`, `insufficient_evidence`, `no_text_sources`** |
+| `categorization_errors_json` | `String` | Serialized validation errors (if any) |
+| `categorization_model_version` | `String` | Model id (or provider name) |
+| `categorization_input_hash` | `String` | SHA-256 of the serialized evidence bundle |
+| `categorization_run_id` | `String` | Per-run UUID |
+| `computed_at` | `DateTime64(3,'UTC')` | Run timestamp; **the ReplacingMergeTree version** |
+| `org_id` | `String` | Tenant (added in 024) |
+
+> **Heads-up: the SQL comments are stale.** The DDL comments name example values that
+> the code no longer emits (e.g. `effort_metric` comment says `'fte_days', 'story_points'`;
+> `evidence_quality_band` says `'high','medium','low'`; `categorization_status` says
+> `'success','error','partial'`). The **runtime** values are the ones in the table above.
+> The header comment also says work units are "(PR/Issue)" — in fact a WorkUnit can also
+> contain **commit** nodes.
+
+### `work_unit_investment_quotes` (optional evidence)
+
+Extractive evidence quotes, one row per quote. Created in
+`017_investment_materialize_tables.sql`.
+
+| Column | Type | Notes |
+| ------ | ---- | ----- |
+| `work_unit_id` | `String` | FK to the WorkUnit |
+| `quote` | `String` | A literal substring of the source text |
+| `source_type` | `String` | **Runtime values: `issue`, `pr`, `commit`** (the DDL comment is stale) |
+| `source_id` | `String` | Source item id |
+| `computed_at` | `DateTime64(3,'UTC')` | ReplacingMergeTree version |
+| `categorization_run_id` | `String` | Run UUID |
+| `org_id` | `String` | Tenant (added in 024) |
+
+> **Quotes are written only when explicitly enabled.** The materializer writes quote
+> rows **only** when `--persist-evidence-snippets` is passed (default off; fixtures force
+> it on). UX and docs must treat evidence quotes as *may be available*, not *always
+> present*. See [Investment Materialization](../ops/investment-materialization.md).
+
+### `investment_explanations` (UX-time cache)
+
+Caches AI-generated **explanations** of already-persisted categorizations. Created in
+`018_investment_explanations.sql`. Explanations are read-only narrative; they **never**
+alter persisted distributions (see the
+[LLM Categorization Contract](../llm/categorization-contract.md)).
+
+| Column | Type | Notes |
+| ------ | ---- | ----- |
+| `cache_key` | `String` | Explanation cache key |
+| `explanation_json` | `String` | Serialized explanation |
+| `llm_provider` / `llm_model` | `String` / `Nullable(String)` | Provider used |
+| `computed_at` | `DateTime64(3,'UTC')` | ReplacingMergeTree version |
+
+### Legacy daily tables (not the canonical path)
+
+`007_complexity_investment_issues.sql` defines `investment_classifications_daily`,
+`investment_metrics_daily`, and `issue_type_metrics_daily`. These predate the WorkUnit
+model and are **not** the canonical distribution path. Prefer `work_unit_investments`
+for all new work.
+
+---
+
+## Read semantics — important
+
+All four tables use `ENGINE = ReplacingMergeTree(computed_at)`. ClickHouse replaces rows
+with the same sort key **eventually**, during background merges — not immediately.
+
+- `work_unit_investments` is `ORDER BY (work_unit_id)`, so re-materializing a WorkUnit
+  produces a new row that *eventually* replaces the old one.
+- The investment API queries currently `sum(...)` directly **without** `FINAL` or
+  `argMax(..., computed_at)`. Between a re-materialization and the next merge, duplicate
+  rows for the same `work_unit_id` can therefore be double-counted in user-visible
+  totals.
+
+> This is a known correctness caveat, tracked as an engineering issue (review API
+> latest-row semantics). Until resolved, prefer querying with explicit latest-row logic
+> (`argMax`/`FINAL`/a latest subquery) when exact totals matter. See
+> [Investment API](../api/investment-api.md).
+
+---
+
+## Related
+
+- [Investment Categorization Pipeline](investment-categorization-pipeline.md) — how rows are produced
+- [Investment API](../api/investment-api.md) — how rows are aggregated and weighted
+- [Investment Materialization](../ops/investment-materialization.md) — the CLI that writes these tables
+- [Database Architecture](database-architecture.md) — dual-database (semantic vs analytics) contract

--- a/docs/architecture/investment-data-model.md
+++ b/docs/architecture/investment-data-model.md
@@ -34,7 +34,7 @@ One row per WorkUnit per materialization run. Created in
 | `structural_evidence_json` | `String` | Serialized structural signals |
 | `evidence_quality` | `Float64` | `0.0–1.0` |
 | `evidence_quality_band` | `String` | **Runtime values: `high` / `moderate` / `low` / `very_low`** |
-| `categorization_status` | `String` | **Runtime values: `ok`, `repaired`, `invalid_llm_output`, `insufficient_evidence`, `no_text_sources`** |
+| `categorization_status` | `String` | **Runtime values: `ok`, `repaired`, `invalid_llm_output`, `insufficient_evidence`, `no_text_sources`, `llm_task_failed`** |
 | `categorization_errors_json` | `String` | Serialized validation errors (if any) |
 | `categorization_model_version` | `String` | Model id (or provider name) |
 | `categorization_input_hash` | `String` | SHA-256 of the serialized evidence bundle |
@@ -82,6 +82,7 @@ alter persisted distributions (see the
 | `explanation_json` | `String` | Serialized explanation |
 | `llm_provider` / `llm_model` | `String` / `Nullable(String)` | Provider used |
 | `computed_at` | `DateTime64(3,'UTC')` | ReplacingMergeTree version |
+| `org_id` | `String` | Tenant (added in 024) |
 
 ### Legacy daily tables (not the canonical path)
 
@@ -94,7 +95,7 @@ for all new work.
 
 ## Read semantics — important
 
-All four tables use `ENGINE = ReplacingMergeTree(computed_at)`. ClickHouse replaces rows
+The three canonical investment tables (`work_unit_investments`, `work_unit_investment_quotes`, `investment_explanations`) use `ENGINE = ReplacingMergeTree(computed_at)`. ClickHouse replaces rows
 with the same sort key **eventually**, during background merges — not immediately.
 
 - `work_unit_investments` is `ORDER BY (work_unit_id)`, so re-materializing a WorkUnit

--- a/docs/llm/categorization-contract.md
+++ b/docs/llm/categorization-contract.md
@@ -2,6 +2,10 @@
 
 Rules and specifications for LLM usage in the Dev Health platform.
 
+> For the end-to-end compute flow this contract sits inside, see the
+> [Investment Categorization Pipeline](../architecture/investment-categorization-pipeline.md).
+> For the canonical keys, see the [Investment Taxonomy](../product/investment-taxonomy.md).
+
 ---
 
 ## Overview
@@ -21,91 +25,108 @@ LLMs are used in two contexts:
 
 Map messy human text to canonical investment categories with subcategory distributions.
 
-### Schema Compliance
+### Strict schema
 
-Output **MUST** be strict JSON matching:
-```
-work_graph/investment/llm_schema.py
-```
+Output **MUST** be strict JSON validated by `work_graph/investment/llm_schema.py`.
+There are exactly three top-level keys — `subcategories`, `evidence_quotes`,
+`uncertainty` — and no others.
 
-### Output Requirements
+### Output requirements
 
 | Requirement | Details |
 |-------------|---------|
-| Keys | From canonical subcategory registry only |
-| Probabilities | Valid (0–1), normalized |
-| Evidence | **Extractive substrings** from input text |
-| Theme roll-up | Computed deterministically from subcategories |
+| `subcategories` | Probabilities over the canonical subcategory keys (see [Investment Taxonomy](../product/investment-taxonomy.md)); each value `0–1`; the values must sum to within `[0.98, 1.02]` |
+| `evidence_quotes` | A **list** of 1–10 objects, each exactly `{ "quote", "source", "id" }` |
+| `quote` | An **exact substring** of the provided source text (≤ 280 chars) |
+| `source` | One of `issue`, `pr`, `commit` |
+| `uncertainty` | Non-empty string, ≤ 280 chars |
 
-### Example Output
+### Example output
 
 ```json
 {
   "subcategories": {
-    "operational.external": 0.45,
-    "operational.incident": 0.25,
-    "feature_delivery.customer": 0.20,
+    "feature_delivery.customer": 0.45,
+    "operational.incident_response": 0.25,
+    "quality.bugfix": 0.20,
     "maintenance.refactor": 0.10
   },
-  "evidence": {
-    "operational.external": ["customer-facing issue", "support ticket"],
-    "operational.incident": ["incident response", "outage window"],
-    "feature_delivery.customer": ["requested by customer"],
-    "maintenance.refactor": ["cleanup", "technical debt"]
-  },
-  "uncertainty": "moderate"
+  "evidence_quotes": [
+    { "quote": "requested by customer", "source": "issue", "id": "PROJ-123" },
+    { "quote": "hotfix for production outage", "source": "pr", "id": "456" }
+  ],
+  "uncertainty": "Mixed signals between customer feature work and incident response."
 }
 ```
 
-### Two-Stage Process
+> The prompt requests a value for **all 15** subcategories. Validation requires every
+> provided key to be canonical and the values to sum to within `[0.98, 1.02]`; the
+> materializer then fills any missing keys with `0` and renormalizes via
+> `ensure_full_subcategory_vector`. Keys must match `investment_taxonomy.py` exactly —
+> obsolete keys like `operational.external` or `feature_delivery.platform` are rejected
+> as `unknown_subcategory`.
 
-1. **LLM Stage:** Map text → subcategory distribution
-2. **Deterministic Stage:** Roll subcategories → themes (no LLM)
+### Two-stage process
 
-This separation prevents category drift.
+1. **LLM stage:** map text → subcategory distribution.
+2. **Deterministic stage:** roll subcategories → themes (no LLM).
+
+This separation prevents category drift. The full flow is documented in the
+[Investment Categorization Pipeline](../architecture/investment-categorization-pipeline.md).
 
 ---
 
-## Retry Policy
+## Validation, repair, and fallback
 
-### When to Retry
+Each response is validated by `validate_llm_payload`. On failure the categorizer makes
+**exactly one** repair attempt, re-prompting with the specific validation errors. If the
+repair also fails, a deterministic fallback distribution is applied.
 
-- Whitespace/empty response
-- Truncated response (`finish_reason=length`)
-- Invalid JSON structure
-- Missing required keys
+### Validation failures include
 
-### Retry Strategy
+- non-JSON or non-object payloads;
+- wrong / extra / missing top-level keys;
+- non-canonical subcategory keys (`unknown_subcategory`);
+- probabilities out of range, or a sum outside `[0.98, 1.02]`;
+- quote count outside 1–10, wrong quote keys, or empty / too-long quotes;
+- a quote that is **not a literal substring** of the source text
+  (`evidence_quote_not_substring`);
+- invalid `source` (not `issue` / `pr` / `commit`) or unknown source id;
+- missing / too-long `uncertainty`.
 
-1. **First attempt:** Standard prompt, standard tokens
-2. **Retry attempt:**
-   - Double `max_completion_tokens` (minimum 512)
-   - Simplify and harden JSON prompt
-   - Add explicit JSON instruction in system AND user message
+### Outcome status
 
-### Failure Handling
+Every run records a `categorization_status`:
 
-After one retry failure:
-1. Mark categorization as invalid
-2. Apply deterministic fallback
-3. Persist with `fallback_applied=true`
+| Status | Meaning |
+|--------|---------|
+| `ok` | Validated on the first attempt |
+| `repaired` | Validated after the single repair re-prompt |
+| `invalid_llm_output` | Still invalid after repair → deterministic fallback applied |
+| `insufficient_evidence` | Too little text to call the LLM → fallback |
+| `no_text_sources` | No usable source text → fallback |
+
+> The fallback is a **neutral prior** (`FALLBACK_PRIOR`), not "unknown". It preserves the
+> never-unknown guarantee but means *"insufficient validated evidence"* — pair it with a
+> low `evidence_quality` reading in any UX.
 
 ---
 
 ## Audit Fields
 
-Every categorization run must persist:
+Every WorkUnit row in `work_unit_investments` persists:
 
 | Field | Description |
 |-------|-------------|
-| `categorized_at` | Timestamp |
-| `model_version` | LLM model identifier |
-| `prompt_hash` | Hash of prompt template |
-| `raw_response` | Original LLM output |
-| `fallback_applied` | Boolean |
-| `retry_count` | Number of retries |
-| `finish_reason` | OpenAI finish reason |
-| `token_usage` | Tokens consumed |
+| `categorization_status` | Outcome status (table above) |
+| `categorization_errors_json` | Serialized validation errors (if any) |
+| `categorization_model_version` | Model id, or provider name when no model is set |
+| `categorization_input_hash` | SHA-256 of the serialized evidence bundle |
+| `categorization_run_id` | Per-run UUID |
+| `computed_at` | Run timestamp (also the ReplacingMergeTree version) |
+
+See the [Investment Data Model](../architecture/investment-data-model.md) for the full
+schema and read semantics.
 
 ---
 

--- a/docs/llm/categorization-contract.md
+++ b/docs/llm/categorization-contract.md
@@ -61,7 +61,7 @@ There are exactly three top-level keys — `subcategories`, `evidence_quotes`,
 
 > The prompt requests a value for **all 15** subcategories. Validation requires every
 > provided key to be canonical and the values to sum to within `[0.98, 1.02]`; the
-> materializer then fills any missing keys with `0` and renormalizes via
+> validation step then fills any missing keys with `0` and renormalizes via
 > `ensure_full_subcategory_vector`. Keys must match `investment_taxonomy.py` exactly —
 > obsolete keys like `operational.external` or `feature_delivery.platform` are rejected
 > as `unknown_subcategory`.
@@ -105,6 +105,7 @@ Every run records a `categorization_status`:
 | `invalid_llm_output` | Still invalid after repair → deterministic fallback applied |
 | `insufficient_evidence` | Too little text to call the LLM → fallback |
 | `no_text_sources` | No usable source text → fallback |
+| `llm_task_failed` | The async LLM task raised before an outcome was recorded → fallback |
 
 > The fallback is a **neutral prior** (`FALLBACK_PRIOR`), not "unknown". It preserves the
 > never-unknown guarantee but means *"insufficient validated evidence"* — pair it with a
@@ -136,7 +137,7 @@ The system supports multiple LLM backends. Set `LLM_PROVIDER` or let auto-detect
 
 ### Provider Configuration
 
-| Provider | Env Var for Selection | Required Env Vars | Default Model |
+| Provider | Env Var for Selection | Key Env Vars (selection / override) | Default Model |
 |----------|----------------------|-------------------|---------------|
 | **OpenAI** | `LLM_PROVIDER=openai` | `OPENAI_API_KEY` | `gpt-5-mini` |
 | **Anthropic** | `LLM_PROVIDER=anthropic` | `ANTHROPIC_API_KEY` | `claude-3-haiku-20240307` |

--- a/docs/ops/investment-materialization.md
+++ b/docs/ops/investment-materialization.md
@@ -72,10 +72,10 @@ dev-hops investment materialize \
 | `--force` | off | Force re-materialization |
 
 > **`--persist-evidence-snippets` is off by default.** Without it, no rows land in
-> `work_unit_investment_quotes`, so evidence drill-downs will be empty even though the
-> LLM produced (and validated) quotes. Enable it for any run whose evidence you want to
-> surface in the UI. (Whether this default should change is tracked as an engineering
-> issue.)
+> `work_unit_investment_quotes`, so evidence drill-downs are empty: validated LLM quotes
+> are not persisted, and fallback WorkUnits have no quotes to begin with. Enable it for any
+> run whose evidence you want to surface in the UI. (Whether this default should change is
+> tracked as an engineering issue.)
 
 ### Time window behavior
 

--- a/docs/ops/investment-materialization.md
+++ b/docs/ops/investment-materialization.md
@@ -1,0 +1,106 @@
+# Investment Materialization (CLI)
+
+How to build the Work Graph and materialize investment categorization from the command
+line. These commands write to ClickHouse only.
+
+- Pipeline internals: [Investment Categorization Pipeline](../architecture/investment-categorization-pipeline.md)
+- Tables produced: [Investment Data Model](../architecture/investment-data-model.md)
+- LLM schema/behavior: [LLM Categorization Contract](../llm/categorization-contract.md)
+
+Commands are registered in `src/dev_health_ops/work_graph/runner.py`.
+
+---
+
+## Prerequisites
+
+1. ClickHouse migrations applied: `dev-hops migrate clickhouse`.
+2. Raw provider data already synced (git, PRs, work items) — see
+   [Getting Started](../getting-started.md).
+3. An LLM provider configured (or use `--llm-provider mock` for deterministic output).
+   See the provider table in the
+   [LLM Categorization Contract](../llm/categorization-contract.md#llm-provider-options).
+
+The two commands run in order: **`work-graph build`** produces the edges that
+**`investment materialize`** clusters into WorkUnits.
+
+---
+
+## Step 1 — Build the Work Graph
+
+```bash
+dev-hops work-graph build \
+  --db "$CLICKHOUSE_URI" \
+  --from 2026-05-01 \
+  --to 2026-06-01
+```
+
+| Flag | Default | Purpose |
+| ---- | ------- | ------- |
+| `--db` | *(required)* | ClickHouse DSN (`clickhouse://user:pass@host:port/db`) |
+| `--from` | 30 days ago | Start date `YYYY-MM-DD` |
+| `--to` | today | End date `YYYY-MM-DD` |
+| `--repo-id` | all | Restrict to a repository UUID |
+| `--heuristic-window` | `7` | Days window for heuristic issue→PR matching |
+| `--heuristic-confidence` | `0.3` | Confidence score assigned to heuristic matches |
+| `--allow-degenerate` | off | Allow a single connected-component graph (otherwise fail) |
+| `--check-components` | on | Perform component analysis |
+
+This writes typed rows to `work_graph_edges` (and helper tables). The investment step
+reads these edges.
+
+## Step 2 — Materialize investments
+
+```bash
+dev-hops investment materialize \
+  --db "$CLICKHOUSE_URI" \
+  --from 2026-05-01 \
+  --to 2026-06-01 \
+  --persist-evidence-snippets
+```
+
+| Flag | Default | Purpose |
+| ---- | ------- | ------- |
+| `--db` | `$CLICKHOUSE_URI` | ClickHouse DSN (falls back to env var) |
+| `--from` | `--window-days` before `--to` | Start date `YYYY-MM-DD` |
+| `--to` | now | End date `YYYY-MM-DD` |
+| `--window-days` | `30` | Window size when `--from` is omitted |
+| `--repo-id` | all | Repository UUID; repeatable |
+| `--team-id` | all | Team identifier; repeatable |
+| `--llm-provider` | `auto` | LLM provider (`openai`, `anthropic`, `mock`, …) |
+| `--model` | provider default | Override the model |
+| `--persist-evidence-snippets` | **off** | Persist extractive evidence quotes to `work_unit_investment_quotes` |
+| `--force` | off | Force re-materialization |
+
+> **`--persist-evidence-snippets` is off by default.** Without it, no rows land in
+> `work_unit_investment_quotes`, so evidence drill-downs will be empty even though the
+> LLM produced (and validated) quotes. Enable it for any run whose evidence you want to
+> surface in the UI. (Whether this default should change is tracked as an engineering
+> issue.)
+
+### Time window behavior
+
+`--from`/`--to` bound which WorkUnits are **materialized** (by their node time-bounds),
+but they do **not** bound how components are **formed** — components are built from the
+full edge set first, then filtered. See the
+[pipeline doc](../architecture/investment-categorization-pipeline.md#step-1-form-the-workunit).
+
+### Output
+
+On success the command logs `Components=… Records=… Quotes=…` and returns exit code `0`.
+`Records` is the number of `work_unit_investments` rows written; `Quotes` is `0` unless
+`--persist-evidence-snippets` was set.
+
+---
+
+## Fixtures (mock LLM)
+
+Synthetic/demo data uses the mock provider and forces evidence persistence on, via
+`materialize_fixture_investments` in `runner.py`. Use the fixtures flow
+(`dev-hops fixtures …`) rather than calling this directly for demo environments.
+
+## Re-running
+
+Re-materializing the same window writes new rows (new `categorization_run_id` /
+`computed_at`). Because the tables are `ReplacingMergeTree(computed_at)`, old rows are
+replaced only after a background merge — see the read-semantics note in the
+[Investment Data Model](../architecture/investment-data-model.md#read-semantics-important).

--- a/docs/product/investment-taxonomy.md
+++ b/docs/product/investment-taxonomy.md
@@ -1,31 +1,127 @@
 # Investment Taxonomy
 
-Source of truth: `dev-health-ops/investment_taxonomy.py`
+The canonical, fixed vocabulary for the Investment View. This page is the **shared
+semantic source** — both user-facing and developer docs link here instead of
+redefining terms.
 
-## Themes
-- `feature_delivery"`
-- `maintenance"`
-- `operational"`
-- `quality"`
-- `risk"`
+- **Source of truth:** `src/dev_health_ops/investment_taxonomy.py`
+  (`THEMES`, `SUBCATEGORIES`, `SUBCATEGORY_TO_THEME`).
+- The taxonomy is **fixed**: no synonyms, no overrides, no per-team configuration.
+- Every WorkUnit gets a probability distribution over these keys — never a single hard
+  label, and never "unknown". See the
+  [Investment Categorization Pipeline](../architecture/investment-categorization-pipeline.md).
 
-## Subcategories (by theme)
-### `feature_delivery"`
+> The key list below must match `investment_taxonomy.py` exactly. A CI drift check that
+> enforces this is planned (Anti-Drift milestone); until then, treat the Python registry
+> as authoritative if the two ever disagree.
 
+---
 
-### `maintenance"`
+## Themes (5, fixed)
 
+| Key | Display name | What it captures |
+| --- | ------------ | ---------------- |
+| `feature_delivery` | Feature Delivery | Building new capability and shipping value to users. |
+| `operational` | Operational / Support | Keeping the lights on — incidents, on-call, and supporting users. |
+| `maintenance` | Maintenance / Tech Debt | Keeping the codebase healthy — refactors, upgrades, paying down debt. |
+| `quality` | Quality / Reliability | Making the product correct and dependable — testing, bug fixes, reliability. |
+| `risk` | Risk / Security | Protecting the product and the business — security, compliance, vulnerabilities. |
 
-### `operational"`
+Theme probabilities are a **deterministic roll-up** of the subcategory probabilities
+below (sum of subcategories sharing the same prefix), normalized across the 5 themes.
 
+---
 
-### `quality"`
+## Subcategories (15, fixed)
 
+Each subcategory key is `theme.subcategory`. The theme is always the prefix before the
+dot.
 
-### `risk"`
+### Feature Delivery
 
+| Key | Plain-language meaning |
+| --- | ---------------------- |
+| `feature_delivery.customer` | Work driven by a specific customer ask or commitment. |
+| `feature_delivery.roadmap` | Planned roadmap features and enhancements. |
+| `feature_delivery.enablement` | Platform/tooling that enables others to build (internal enablement, SDKs, APIs). |
 
+### Operational / Support
+
+| Key | Plain-language meaning |
+| --- | ---------------------- |
+| `operational.incident_response` | Responding to and resolving active incidents/outages. |
+| `operational.on_call` | On-call duties and operational toil outside named incidents. |
+| `operational.support` | Helping users — support tickets, questions, troubleshooting. |
+
+### Maintenance / Tech Debt
+
+| Key | Plain-language meaning |
+| --- | ---------------------- |
+| `maintenance.refactor` | Restructuring existing code without changing behavior. |
+| `maintenance.upgrade` | Dependency/runtime/platform upgrades and migrations. |
+| `maintenance.debt` | Paying down accumulated technical debt. |
+
+### Quality / Reliability
+
+| Key | Plain-language meaning |
+| --- | ---------------------- |
+| `quality.testing` | Adding or improving tests and test infrastructure. |
+| `quality.bugfix` | Fixing defects in delivered functionality. |
+| `quality.reliability` | Reliability, resilience, and stability improvements. |
+
+### Risk / Security
+
+| Key | Plain-language meaning |
+| --- | ---------------------- |
+| `risk.security` | Proactive security hardening and controls. |
+| `risk.compliance` | Meeting compliance, regulatory, or audit requirements. |
+| `risk.vulnerability` | Remediating specific known vulnerabilities. |
+
+---
+
+## Canonical key list
+
+The exact keys, as they appear in `investment_taxonomy.py`. (This block is intended to
+be **generated** from the registry by the Anti-Drift tooling; for now it is maintained by
+hand and must match the code.)
+
+```text
+# THEMES
+feature_delivery
+operational
+maintenance
+quality
+risk
+
+# SUBCATEGORIES (theme.subcategory)
+feature_delivery.customer
+feature_delivery.roadmap
+feature_delivery.enablement
+operational.incident_response
+operational.on_call
+operational.support
+maintenance.refactor
+maintenance.upgrade
+maintenance.debt
+quality.testing
+quality.bugfix
+quality.reliability
+risk.security
+risk.compliance
+risk.vulnerability
+```
+
+---
 
 ## Guarantees
-- Subcategory keys are canonical and fixed.
+
+- Subcategory keys are canonical and fixed; provider-native labels are inputs only and
+  are normalized away.
 - Theme roll-up is deterministic via `theme_of(subcategory)`.
+- Categorization always produces a distribution — it never returns "unknown".
+
+## Related
+
+- [Investment View](../user-guide/investment-view.md) — how to read the distribution (user-facing)
+- [Investment Categorization Pipeline](../architecture/investment-categorization-pipeline.md) — how it is computed
+- [LLM Categorization Contract](../llm/categorization-contract.md) — the strict LLM schema

--- a/docs/user-guide/investment-view.md
+++ b/docs/user-guide/investment-view.md
@@ -10,10 +10,10 @@ This page is the leadership-facing definition of the canonical investment lens.
 ## Core mechanics
 - A WorkUnit receives a compute-time distribution over subcategories.
 - Subcategories roll up deterministically to themes.
-- Aggregations are probability-weighted.
+- Aggregations are **effort-weighted**: each probability is multiplied by the WorkUnit's effort value before summing (see [Investment API](../api/investment-api.md)).
 
 ## Taxonomy (canonical keys)
-See: `docs/00-overview/04-investment-taxonomy.md`.
+See the [Investment Taxonomy](../product/investment-taxonomy.md).
 
 ## Non-negotiables
 - No WorkUnit-as-category.
@@ -21,5 +21,9 @@ See: `docs/00-overview/04-investment-taxonomy.md`.
 - No “unknown” output.
 
 ## Related docs
-- LLM categorization contract
-- Work graph (relationships and materialization)
+- [Investment Categorization Pipeline](../architecture/investment-categorization-pipeline.md) — how the distribution is computed
+- [Investment Data Model](../architecture/investment-data-model.md) — how it is persisted
+- [Investment API](../api/investment-api.md) — how it is aggregated and effort-weighted
+- [Investment Materialization](../ops/investment-materialization.md) — the CLI that produces it
+- [LLM Categorization Contract](../llm/categorization-contract.md)
+- [Work Graph](work-graph.md) — relationships and materialization

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,8 @@ nav:
   - Architecture:
       - Overview: architecture.md
       - Data Pipeline: architecture/data-pipeline.md
+      - Investment Categorization Pipeline: architecture/investment-categorization-pipeline.md
+      - Investment Data Model: architecture/investment-data-model.md
       - Repo Layout: architecture/repo-layout.md
       - Frontend Architecture: architecture/frontend-architecture.md
       - Middleware Impersonation: architecture/middleware-impersonation.md
@@ -56,6 +58,7 @@ nav:
       - Workers: ops/workers.md
       - SLOs: slos.md
       - Customer Offboarding: ops/customer-offboarding.md
+      - Investment Materialization: ops/investment-materialization.md
   - CLI:
       - Overview: cli.md
       - Reference: ops/cli-reference.md
@@ -93,6 +96,7 @@ nav:
       - Product Telemetry Dashboard Assessment: product/product-telemetry-dashboard-assessment.md
   - API:
       - GraphQL Overview: api/graphql-overview.md
+      - Investment API: api/investment-api.md
       - AI Workflow Analytics: api/graphql-ai.md
       - GraphQL Security: api/graphql-security.md
       - Persisted Queries: api/persisted-queries.md


### PR DESCRIPTION
## Summary

**M1** of the [Investment View Documentation](https://linear.app/fullchaos/project/investment-view-documentation-845e591e3cb6) initiative. Brings the developer docs in line with the shipped compute pipeline and fixes the code/docs drift surfaced in the documentation audit (and confirmed by an Oracle review).

## Changes

- **Rewrite** `docs/llm/categorization-contract.md` to the real LLM contract: top-level keys `subcategories`/`evidence_quotes`/`uncertainty`, literal-substring quote rule, probability sum `[0.98, 1.02]`, **one** repair re-prompt then deterministic fallback, real `categorization_status` values and audit fields. Removes obsolete keys (`operational.external`, `feature_delivery.platform`) and the old `evidence` map.
- **New** `docs/architecture/investment-categorization-pipeline.md` — the 8-step compute flow with a diagram. Includes the corrections: components are built from all edges then time-filtered; the fallback is an "insufficient validated evidence" prior, not "unknown"; effort-weighting happens downstream.
- **New** `docs/architecture/investment-data-model.md` — exact ClickHouse DDLs, **real runtime enum values** (the SQL comments are stale), optional quote persistence, and the `ReplacingMergeTree(computed_at)` latest-row read caveat.
- **New** `docs/ops/investment-materialization.md` — `work-graph build` + `investment materialize` CLI reference (`--persist-evidence-snippets` is default-off).
- **New** `docs/api/investment-api.md` — effort-weighted aggregation (`probability * effort_value`, churn → PR churn → active hours → 0); `unassigned` documented as a missing-scope label, not a category.
- **Fix dead links**: `ops/AGENTS.md` deep-dives pointer; `docs/user-guide/investment-view.md` taxonomy link + corrected "probability-weighted" → "effort-weighted"; new pages wired into `mkdocs.yml` nav.

## Verification

- All internal `.md` links in changed/new docs resolve.
- New pages present in MkDocs nav.
- Docs-only change (no code/tests touched).

## Note

The platform-root `AGENTS.md` (which also had phantom `docs/agent-instructions/` links) is **not under version control**, so its fix is local-only and not part of this PR. Bringing it under version control is a recommended follow-up.

Refs CHAOS-2310, CHAOS-2311, CHAOS-2312, CHAOS-2313, CHAOS-2314, CHAOS-2315