### PR TITLE
chore(investment): cleanup legacy defaults and materialization docs

### DIFF
--- a/docs/api/investment-api.md
+++ b/docs/api/investment-api.md
@@ -86,9 +86,10 @@ never appears in a theme or subcategory distribution. The categorization itself 
 "unknown" (see the [pipeline guarantees](../architecture/investment-categorization-pipeline.md#guarantees)).
 
 > Do not confuse this with the legacy rule-based classifier in
-> `analytics/investment.py`, which uses `unassigned` as a *category* fallback. That path
-> is legacy and is being deprecated/isolated; it is not part of the canonical Investment
-> View.
+> `analytics/investment.py`. That path is explicitly deprecated/isolated to the
+> pre-WorkUnit daily `investment_*` metric tables; it is not part of the canonical
+> Investment View and now falls back to the legacy `product/general` bucket rather
+> than an `unassigned` category.
 
 ---
 

--- a/docs/architecture/adr/002-investment-period-components.md
+++ b/docs/architecture/adr/002-investment-period-components.md
@@ -1,0 +1,57 @@
+# ADR-002: Investment WorkUnit Component Scope for Period Views
+
+**Status**: RECOMMENDED - NEEDS PRODUCT SIGN-OFF  
+**Created**: 2026-06-11  
+**Parent Issues**: CHAOS-2326
+
+## Context
+
+`dev-hops investment materialize` currently forms connected components from all fetched
+`work_graph_edges` for the selected repo/team scope, then filters the resulting WorkUnits
+by component time bounds (`from_ts`/`to_ts`). The `--from`/`--to` window therefore decides
+which WorkUnits are written, not which edges are allowed to connect into a WorkUnit.
+
+This preserves stable WorkUnit identities across repeated materializations, but long-lived
+issue/PR/commit chains can keep accumulating historical edges. For period-scoped
+Investment View reads, that can make components historically sticky and larger than the
+period a user is inspecting.
+
+## Question
+
+Should period-scoped Investment View materialization build components only from edges in
+the requested period, or keep using cross-period components and filter after component
+formation?
+
+## Options
+
+| Option | Description | Pros | Cons |
+| ------ | ----------- | ---- | ---- |
+| A: Cross-period components (current) | Build components from all fetched edges, then filter by component bounds. | Stable WorkUnit IDs; complete provenance for long-lived work; no accidental fragmentation. | Components can grow large; period views may include historical context outside the visible window. |
+| B: Period-bounded components | Filter edges/nodes to the period before component construction. | Period views are strictly local; bounds component growth. | Same real-world work can split across periods; WorkUnit IDs churn; explanations lose older evidence. |
+| C: Hybrid with explicit lookback | Build from period edges plus a bounded lookback window. | Caps growth while retaining near-period context. | Adds a product/config decision; IDs may still change when lookback changes. |
+
+## Recommendation
+
+Keep **Option A** as the safe default for now and document it as intentional until Product
+chooses a stricter period semantics model. Do **not** implement bounding in CHAOS-2326
+because the correct behavior is a product decision: stable cross-period WorkUnits and
+strict period-local WorkUnits optimize for different user expectations.
+
+If Product wants strictly period-local Investment View semantics, implement **Option C**
+first rather than jumping directly to Option B. A bounded lookback should be explicit in
+the UI/docs and included in the WorkUnit ID strategy so users understand why a component's
+evidence set can differ by reporting window.
+
+## Decision
+
+> **PENDING PRODUCT SIGN-OFF** - Engineering recommends preserving current cross-period
+> component formation for now, with an explicit follow-up decision on whether period views
+> should trade stable WorkUnit identity for strict period locality.
+
+## Implementation Notes
+
+- No materializer code changes are included with this ADR.
+- Existing docs should continue to state that `--from`/`--to` bound materialization output,
+  not component formation.
+- If bounding is later approved, add tests that compare WorkUnit IDs and evidence contents
+  across adjacent windows before changing `materialize.py`.

--- a/docs/architecture/investment-categorization-pipeline.md
+++ b/docs/architecture/investment-categorization-pipeline.md
@@ -160,8 +160,9 @@ effort metric/value, and audit fields (`categorization_status`,
 `categorization_model_version`, `categorization_input_hash`, `categorization_run_id`,
 `computed_at`).
 
-Evidence quotes are written to `work_unit_investment_quotes` **only when**
-`--persist-evidence-snippets` is enabled (default off). See
+Evidence quotes are written to `work_unit_investment_quotes` by default for CLI and
+worker materialization runs. They can be skipped with
+`--no-persist-evidence-snippets` for storage-constrained backfills. See
 [Investment Data Model](investment-data-model.md) for table schemas and read semantics.
 
 ---

--- a/docs/architecture/investment-data-model.md
+++ b/docs/architecture/investment-data-model.md
@@ -49,7 +49,7 @@ One row per WorkUnit per materialization run. Created in
 > The header comment also says work units are "(PR/Issue)" — in fact a WorkUnit can also
 > contain **commit** nodes.
 
-### `work_unit_investment_quotes` (optional evidence)
+### `work_unit_investment_quotes` (evidence quotes)
 
 Extractive evidence quotes, one row per quote. Created in
 `017_investment_materialize_tables.sql`.
@@ -64,10 +64,11 @@ Extractive evidence quotes, one row per quote. Created in
 | `categorization_run_id` | `String` | Run UUID |
 | `org_id` | `String` | Tenant (added in 024) |
 
-> **Quotes are written only when explicitly enabled.** The materializer writes quote
-> rows **only** when `--persist-evidence-snippets` is passed (default off; fixtures force
-> it on). UX and docs must treat evidence quotes as *may be available*, not *always
-> present*. See [Investment Materialization](../ops/investment-materialization.md).
+> **Quotes are written by default for materialization runs.** The CLI and worker
+> materializer default to persisting validated extractive quotes; `--no-persist-evidence-snippets`
+> can deliberately skip them for storage-constrained backfills. UX should still tolerate
+> missing quotes because fallback WorkUnits and historical runs may have none. See
+> [Investment Materialization](../ops/investment-materialization.md).
 
 ### `investment_explanations` (UX-time cache)
 

--- a/docs/computations/metric-calculations.md
+++ b/docs/computations/metric-calculations.md
@@ -201,7 +201,12 @@ Computed via `radon` scanning historical git references.
 
 ---
 
-## Investment Metrics
+## Investment Metrics (legacy daily rollups)
+
+These `investment_*` daily tables predate the canonical WorkUnit Investment View.
+They are retained for compatibility only; new investment analytics should read the
+WorkUnit distribution tables documented in
+[Investment Data Model](../architecture/investment-data-model.md).
 
 ### Daily Investment (`investment_metrics_daily`)
 
@@ -218,7 +223,8 @@ Categorizes effort into investment areas via rule-based classifier.
 | `delivery_units` | Story points or item count |
 | `churn_loc` | LOC associated with area |
 
-**Configuration:** `config/investment_areas.yaml`
+**Configuration:** `config/investment_areas.yaml` (legacy only; unmatched items fall
+back to `product/general`, not `unassigned`).
 
 ---
 

--- a/docs/metrics-inventory.md
+++ b/docs/metrics-inventory.md
@@ -40,7 +40,7 @@ Work item metrics assume provider data has been synced via `dev-hops sync work-i
 
 | Metric                | Status | Source/Implementation                                                                                        |
 | :-------------------- | :----: | :----------------------------------------------------------------------------------------------------------- |
-| Investment Allocation |  [x]   | Classified via `InvestmentClassifier` in `analytics/investment.py`. Rules in `config/investment_areas.yaml`. |
+| Investment Allocation |  [x]   | **Legacy daily rollup** classified via `InvestmentClassifier` in `analytics/investment.py`. Rules in `config/investment_areas.yaml`; not the canonical WorkUnit Investment View. |
 | Project Stream Churn  |  [x]   | LOC churn aggregated by project stream and investment area.                                                  |
 | Strategic vs KTLO %   |  [x]   | Derived from Investment Allocation daily rollups.                                                            |
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -353,9 +353,9 @@ Complexity metrics are computed by scanning local git clones at specific histori
   - `very_high_complexity_functions`: Count of functions with CC > 25.
 - **Backfilling**: Uses `git checkout` (via `GitPython`) to analyze historical state.
 
-## Investment Metrics (`investment_metrics_daily`)
+## Investment Metrics (`investment_metrics_daily`, legacy)
 
-Categorizes engineering effort into investment areas (e.g., "New Value", "Security", "Infrastructure") using a rule-based classifier.
+Legacy daily rollups categorize engineering effort into investment areas (e.g., "Product", "Security", "Infrastructure") using a rule-based classifier. This is not the canonical Investment View; new investment analytics should use the WorkUnit distribution tables documented in [Investment Data Model](architecture/investment-data-model.md).
 
 - **Artifacts Classified**:
   - **Work Items**: Based on labels, components, and title keywords.
@@ -365,7 +365,7 @@ Categorizes engineering effort into investment areas (e.g., "New Value", "Securi
   - `project_stream`: A secondary grouping (e.g., "Project Phoenix").
   - `delivery_units`: Story points or count of work items completed.
   - `churn_loc`: Sum of additions + deletions associated with the area.
-- **Configuration**: `config/investment_areas.yaml` defines the matching rules and priorities.
+- **Configuration**: `config/investment_areas.yaml` defines the legacy matching rules and priorities. Missing or unmatched rules fall back to the legacy `product/general` bucket, never `unassigned`.
 
 ## TestOps Metrics
 

--- a/docs/ops/investment-materialization.md
+++ b/docs/ops/investment-materialization.md
@@ -54,8 +54,7 @@ reads these edges.
 dev-hops investment materialize \
   --db "$CLICKHOUSE_URI" \
   --from 2026-05-01 \
-  --to 2026-06-01 \
-  --persist-evidence-snippets
+  --to 2026-06-01
 ```
 
 | Flag | Default | Purpose |
@@ -68,14 +67,15 @@ dev-hops investment materialize \
 | `--team-id` | all | Team identifier; repeatable |
 | `--llm-provider` | `auto` | LLM provider (`openai`, `anthropic`, `mock`, …) |
 | `--model` | provider default | Override the model |
-| `--persist-evidence-snippets` | **off** | Persist extractive evidence quotes to `work_unit_investment_quotes` |
+| `--persist-evidence-snippets` | **on** | Persist extractive evidence quotes to `work_unit_investment_quotes` |
+| `--no-persist-evidence-snippets` | off | Skip quote persistence for storage-constrained backfills |
 | `--force` | off | Force re-materialization |
 
-> **`--persist-evidence-snippets` is off by default.** Without it, no rows land in
-> `work_unit_investment_quotes`, so evidence drill-downs are empty: validated LLM quotes
-> are not persisted, and fallback WorkUnits have no quotes to begin with. Enable it for any
-> run whose evidence you want to surface in the UI. (Whether this default should change is
-> tracked as an engineering issue.)
+> **Evidence snippets are on by default.** Real materialization runs persist validated
+> extractive quotes to `work_unit_investment_quotes` so evidence drill-downs have the
+> audit trail required by the Investment contract. Use `--no-persist-evidence-snippets`
+> only for deliberate storage-constrained backfills; fallback WorkUnits may still have no
+> quotes because no validated LLM quote exists.
 
 ### Time window behavior
 
@@ -87,14 +87,14 @@ full edge set first, then filtered. See the
 ### Output
 
 On success the command logs `Components=… Records=… Quotes=…` and returns exit code `0`.
-`Records` is the number of `work_unit_investments` rows written; `Quotes` is `0` unless
-`--persist-evidence-snippets` was set.
+`Records` is the number of `work_unit_investments` rows written; `Quotes` is the number
+of persisted evidence quote rows (unless quote persistence was explicitly disabled).
 
 ---
 
 ## Fixtures (mock LLM)
 
-Synthetic/demo data uses the mock provider and forces evidence persistence on, via
+Synthetic/demo data uses the mock provider and keeps evidence persistence on, via
 `materialize_fixture_investments` in `runner.py`. Use the fixtures flow
 (`dev-hops fixtures …`) rather than calling this directly for demo environments.
 

--- a/src/dev_health_ops/analytics/investment.py
+++ b/src/dev_health_ops/analytics/investment.py
@@ -1,3 +1,12 @@
+"""Deprecated rule-based investment classifier.
+
+This module powers the legacy daily ``investment_*`` metrics path only. The
+canonical Investment View is WorkUnit-based and lives under
+``dev_health_ops.work_graph.investment``; it persists subcategory/theme
+distributions to ``work_unit_investments``. Do not import this module from the
+canonical WorkUnit materializer or API path.
+"""
+
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -6,6 +15,9 @@ from typing import Any
 import yaml
 
 logger = logging.getLogger(__name__)
+
+LEGACY_DEFAULT_INVESTMENT_AREA = "product"
+LEGACY_DEFAULT_PROJECT_STREAM = "general"
 
 
 @dataclass
@@ -17,6 +29,13 @@ class InvestmentClassification:
 
 
 class InvestmentClassifier:
+    """Legacy classifier for pre-WorkUnit daily investment rollups.
+
+    This intentionally does not participate in the canonical Investment View.
+    Its fallback is a legacy ``product/general`` bucket rather than
+    ``unassigned`` so this path cannot emit an unknown-like category.
+    """
+
     def __init__(self, config_path: Path):
         self.rules = self._load_rules(config_path)
 
@@ -44,17 +63,21 @@ class InvestmentClassifier:
 
             if self._matches(match, artifact):
                 return InvestmentClassification(
-                    investment_area=output.get("investment_area", "unassigned"),
-                    project_stream=output.get("project_stream"),
+                    investment_area=output.get(
+                        "investment_area", LEGACY_DEFAULT_INVESTMENT_AREA
+                    ),
+                    project_stream=output.get(
+                        "project_stream", LEGACY_DEFAULT_PROJECT_STREAM
+                    ),
                     confidence=1.0,
-                    rule_id=rule.get("id", "unassigned"),
+                    rule_id=rule.get("id", "legacy_rule"),
                 )
 
         return InvestmentClassification(
-            investment_area="unassigned",
-            project_stream=None,
+            investment_area=LEGACY_DEFAULT_INVESTMENT_AREA,
+            project_stream=LEGACY_DEFAULT_PROJECT_STREAM,
             confidence=0.0,
-            rule_id="unassigned",
+            rule_id="legacy_default",
         )
 
     def _matches(self, match_criteria: dict, artifact: dict) -> bool:

--- a/src/dev_health_ops/config/investment_areas.yaml
+++ b/src/dev_health_ops/config/investment_areas.yaml
@@ -1,3 +1,9 @@
+# Deprecated legacy rule set for src/dev_health_ops/analytics/investment.py.
+# This config feeds only the pre-WorkUnit daily investment_* metric tables.
+# The canonical Investment View uses work_graph/investment materialization and
+# the fixed subcategory/theme taxonomy; do not use this file for canonical
+# WorkUnit categorization.
+
 rules:
   # --- Synthetic Data Mappings (Specific Labels -> Project Streams) ---
 

--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -180,7 +180,7 @@ def run_investment_materialization(ns: argparse.Namespace) -> int:
         to_ts=to_ts,
         repo_ids=repo_ids or None,
         llm_provider=getattr(ns, "llm_provider", "auto") or "auto",
-        persist_evidence_snippets=getattr(ns, "persist_evidence_snippets", False),
+        persist_evidence_snippets=getattr(ns, "persist_evidence_snippets", True),
         llm_model=getattr(ns, "model", None),
         team_ids=team_ids or None,
         force=getattr(ns, "force", False),
@@ -334,8 +334,16 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
     add_llm_arguments(investment_materialize)
     investment_materialize.add_argument(
         "--persist-evidence-snippets",
+        dest="persist_evidence_snippets",
         action="store_true",
+        default=True,
         help="Persist extractive evidence quotes for work units.",
+    )
+    investment_materialize.add_argument(
+        "--no-persist-evidence-snippets",
+        dest="persist_evidence_snippets",
+        action="store_false",
+        help="Skip persisting extractive evidence quotes for work units.",
     )
     investment_materialize.add_argument(
         "--force", action="store_true", help="Force re-materialization."

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -166,7 +166,7 @@ def run_investment_materialize(
             to_ts=parsed_to,
             repo_ids=repo_ids,
             llm_provider=llm_provider,
-            persist_evidence_snippets=False,
+            persist_evidence_snippets=True,
             llm_model=llm_model,
             team_ids=team_ids,
             force=force,

--- a/tests/analytics/test_investment_classifier.py
+++ b/tests/analytics/test_investment_classifier.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from dev_health_ops.analytics.investment import InvestmentClassifier
+
+
+def test_legacy_investment_classifier_fallback_is_assigned(tmp_path: Path) -> None:
+    classifier = InvestmentClassifier(tmp_path / "missing-investment-areas.yaml")
+
+    classification = classifier.classify({"labels": [], "component": "", "title": ""})
+
+    assert classification.investment_area == "product"
+    assert classification.project_stream == "general"
+    assert classification.rule_id == "legacy_default"
+    assert classification.confidence == 0.0


### PR DESCRIPTION
## Summary
- Marked the legacy rule-based investment classifier/config as deprecated and isolated to the pre-WorkUnit daily metrics path; its fallback is now legacy `product/general` instead of `unassigned`.
- Made evidence quote persistence default-on for CLI and worker materialization, with `--no-persist-evidence-snippets` as an explicit opt-out; updated M1 docs accordingly.
- Added ADR-002 documenting current cross-period component behavior for period-scoped Investment View and recommending no runtime bounding until Product signs off.

## Product sign-off flags
- CHAOS-2324: This PR changes real materialization defaults to persist evidence quotes by default. Product/ops should sign off on the storage-vs-audit tradeoff; an explicit opt-out is included.
- CHAOS-2326: ADR recommends preserving cross-period component formation for now. Product must decide whether strict period-local WorkUnits are worth WorkUnit ID churn/evidence fragmentation. No bounding code was added.

## Verification
- Grep usages/imports before changing legacy classifier: only `metrics/job_work_items.py` imports `InvestmentClassifier`; canonical `work_graph/investment` path does not.
- `mcp_Ast_grep_search`/AST grep attempted for imports; tool returned `Not connected`, so grep results were used as the available verification source.
- `lsp_diagnostics` clean on changed Python files.
- `pytest tests/analytics/test_investment_classifier.py`
- `ruff format --check src/dev_health_ops/analytics/investment.py src/dev_health_ops/work_graph/runner.py src/dev_health_ops/workers/work_graph_tasks.py tests/analytics/test_investment_classifier.py`
- `ruff check src/dev_health_ops/analytics/investment.py src/dev_health_ops/work_graph/runner.py src/dev_health_ops/workers/work_graph_tasks.py tests/analytics/test_investment_classifier.py`
- Pre-push hook: ruff format/check passed.
- Codex adversarial review: approved, no material findings.

SCREENSHOT-WAIVER: backend/docs-only cleanup; no rendered frontend output changed.

Refs CHAOS-2323 CHAOS-2324 CHAOS-2326