### PR TITLE
ci(docs): add investment anti-drift guards

### DIFF
--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -1,0 +1,84 @@
+name: Docs Guards
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["**"]
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'scripts/check_docs_links.py'
+              - 'scripts/check_investment_docs_drift.py'
+              - 'scripts/gen_taxonomy_docs.py'
+              - 'src/dev_health_ops/investment_taxonomy.py'
+              - 'src/dev_health_ops/work_graph/investment/llm_schema.py'
+              - 'Makefile'
+
+  docs-guards-job:
+    needs: [changes]
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+
+      - name: Check generated taxonomy is up to date
+        run: |
+          make docs:generate-taxonomy
+          git diff --exit-code -- docs/product/investment-taxonomy.md
+
+      - name: Run docs guards
+        run: make docs:check
+
+  docs-guards:
+    name: docs-guards
+    if: always()
+    needs: [docs-guards-job]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate docs guards result
+        env:
+          DOCS_GUARDS_RESULT: ${{ needs.docs-guards-job.result }}
+        run: |
+          echo "docs-guards-job result: ${DOCS_GUARDS_RESULT}"
+          case "${DOCS_GUARDS_RESULT}" in
+            success|skipped)
+              echo "docs guards passed"
+              ;;
+            failure|cancelled|*)
+              echo "docs guards failed"
+              exit 1
+              ;;
+          esac

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,17 @@
-.PHONY: install test\:unit test\:integration test\:e2e test\:live-e2e test\:ci
+.PHONY: docs\:check docs\:check-drift docs\:check-links docs\:generate-taxonomy install test\:unit test\:integration test\:e2e test\:live-e2e test\:ci
+
+docs\:generate-taxonomy:
+	python3 scripts/gen_taxonomy_docs.py
+
+docs\:check-drift:
+	python3 scripts/check_investment_docs_drift.py
+
+docs\:check-links:
+	python3 scripts/check_docs_links.py
+
+docs\:check:
+	python3 scripts/check_investment_docs_drift.py
+	python3 scripts/check_docs_links.py
 
 test\:unit:
 	@./ci/run_tests.sh unit

--- a/docs/product/investment-taxonomy.md
+++ b/docs/product/investment-taxonomy.md
@@ -11,9 +11,8 @@ redefining terms.
   label, and never "unknown". See the
   [Investment Categorization Pipeline](../architecture/investment-categorization-pipeline.md).
 
-> The key list below must match `investment_taxonomy.py` exactly. A CI drift check that
-> enforces this is planned (Anti-Drift milestone); until then, treat the Python registry
-> as authoritative if the two ever disagree.
+> The key list below is generated from `investment_taxonomy.py`; run
+> `make docs:generate-taxonomy` after changing the registry.
 
 ---
 
@@ -81,10 +80,9 @@ dot.
 
 ## Canonical key list
 
-The exact keys, as they appear in `investment_taxonomy.py`. (This block is intended to
-be **generated** from the registry by the Anti-Drift tooling; for now it is maintained by
-hand and must match the code.)
+The exact keys, as they appear in `investment_taxonomy.py`.
 
+<!-- BEGIN GENERATED TAXONOMY -->
 ```text
 # THEMES
 feature_delivery
@@ -109,7 +107,25 @@ quality.reliability
 risk.security
 risk.compliance
 risk.vulnerability
+
+# SUBCATEGORY_TO_THEME
+feature_delivery.customer -> feature_delivery
+feature_delivery.roadmap -> feature_delivery
+feature_delivery.enablement -> feature_delivery
+operational.incident_response -> operational
+operational.on_call -> operational
+operational.support -> operational
+maintenance.refactor -> maintenance
+maintenance.upgrade -> maintenance
+maintenance.debt -> maintenance
+quality.testing -> quality
+quality.bugfix -> quality
+quality.reliability -> quality
+risk.security -> risk
+risk.compliance -> risk
+risk.vulnerability -> risk
 ```
+<!-- END GENERATED TAXONOMY -->
 
 ---
 

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Check relative markdown links and anchors under docs/."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS_ROOT = ROOT / "docs"
+
+INLINE_LINK_RE = re.compile(r"(?<!!)\[[^\]\n]+\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+REFERENCE_DEF_RE = re.compile(r"^\[[^\]]+\]:\s+(\S+)", re.MULTILINE)
+HTML_ID_RE = re.compile(r"\bid=[\"']([^\"']+)[\"']")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
+
+
+def slugify(heading: str) -> str:
+    heading = re.sub(r"<[^>]+>", "", heading)
+    heading = re.sub(r"`([^`]*)`", r"\1", heading)
+    heading = heading.strip().lower()
+    heading = re.sub(r"[^\w\s-]", "", heading)
+    heading = re.sub(r"[\s_-]+", "-", heading).strip("-")
+    return heading
+
+
+def anchors_for(path: Path) -> set[str]:
+    anchors = {""}
+    text = path.read_text(encoding="utf-8")
+    counts: dict[str, int] = {}
+    for line in text.splitlines():
+        match = HEADING_RE.match(line)
+        if not match:
+            continue
+        base = slugify(match.group(2))
+        if not base:
+            continue
+        count = counts.get(base, 0)
+        counts[base] = count + 1
+        anchors.add(base if count == 0 else f"{base}-{count}")
+    anchors.update(HTML_ID_RE.findall(text))
+    return anchors
+
+
+def iter_links(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    return [*INLINE_LINK_RE.findall(text), *REFERENCE_DEF_RE.findall(text)]
+
+
+def should_skip(target: str) -> bool:
+    if not target or target.startswith(("http://", "https://", "mailto:", "tel:")):
+        return True
+    if target.startswith("#"):
+        return False
+    parsed = urlsplit(target)
+    return bool(parsed.scheme or parsed.netloc) or target.startswith("/")
+
+
+def check_link(
+    source: Path, raw_target: str, anchor_cache: dict[Path, set[str]]
+) -> str | None:
+    if should_skip(raw_target):
+        return None
+    parsed = urlsplit(raw_target)
+    target_path = unquote(parsed.path)
+    anchor = unquote(parsed.fragment)
+
+    if target_path and not target_path.endswith(".md"):
+        return None
+
+    destination = source if not target_path else (source.parent / target_path).resolve()
+    try:
+        destination.relative_to(DOCS_ROOT)
+    except ValueError:
+        return None
+
+    if not destination.exists():
+        return f"{source.relative_to(ROOT)} -> {raw_target}: missing file"
+    if destination.suffix != ".md":
+        return None
+
+    if anchor:
+        anchors = anchor_cache.setdefault(destination, anchors_for(destination))
+        if anchor not in anchors:
+            return f"{source.relative_to(ROOT)} -> {raw_target}: missing anchor"
+    return None
+
+
+def main() -> int:
+    errors: list[str] = []
+    anchor_cache: dict[Path, set[str]] = {}
+    for path in sorted(DOCS_ROOT.rglob("*.md")):
+        for target in iter_links(path):
+            error = check_link(path, target, anchor_cache)
+            if error:
+                errors.append(error)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print("Docs link check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_investment_docs_drift.py
+++ b/scripts/check_investment_docs_drift.py
@@ -32,7 +32,7 @@ def _literal_set(path: Path, name: str) -> set[str]:
                 for target in node.targets
             )
             value = node.value
-        elif isinstance(node, ast.AnnAssign):
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
             target_matches = (
                 isinstance(node.target, ast.Name) and node.target.id == name
             )

--- a/scripts/check_investment_docs_drift.py
+++ b/scripts/check_investment_docs_drift.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Fail on factual drift between investment docs and canonical Python registries."""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TAXONOMY_PATH = ROOT / "src" / "dev_health_ops" / "investment_taxonomy.py"
+LLM_SCHEMA_PATH = (
+    ROOT / "src" / "dev_health_ops" / "work_graph" / "investment" / "llm_schema.py"
+)
+TAXONOMY_DOC = ROOT / "docs" / "product" / "investment-taxonomy.md"
+LLM_CONTRACT_DOC = ROOT / "docs" / "llm" / "categorization-contract.md"
+
+BEGIN = "<!-- BEGIN GENERATED TAXONOMY -->"
+END = "<!-- END GENERATED TAXONOMY -->"
+KEY_RE = re.compile(r"`([a-z][a-z_]*(?:\.[a-z][a-z_]*)?)`")
+JSON_BLOCK_RE = re.compile(r"```json\s*(.*?)\s*```", re.DOTALL)
+DOC_KEY_PLACEHOLDERS = {"theme.subcategory"}
+
+
+def _literal_set(path: Path, name: str) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            target_matches = any(
+                isinstance(target, ast.Name) and target.id == name
+                for target in node.targets
+            )
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            target_matches = (
+                isinstance(node.target, ast.Name) and node.target.id == name
+            )
+            value = node.value
+        else:
+            continue
+        if not target_matches:
+            continue
+        if not isinstance(value, ast.Set):
+            raise ValueError(f"{name} is not a set literal in {path}")
+        values: set[str] = set()
+        for element in value.elts:
+            if not isinstance(element, ast.Constant) or not isinstance(
+                element.value, str
+            ):
+                raise ValueError(f"{name} contains a non-string literal")
+            values.add(element.value)
+        return values
+    raise ValueError(f"{name} not found in {path}")
+
+
+def _generated_block(doc: str) -> str:
+    start = doc.find(BEGIN)
+    stop = doc.find(END)
+    if start == -1 or stop == -1 or stop < start:
+        raise ValueError(f"generated taxonomy markers missing in {TAXONOMY_DOC}")
+    return doc[start + len(BEGIN) : stop]
+
+
+def _keys_from_generated_block(block: str) -> tuple[set[str], set[str], dict[str, str]]:
+    themes: set[str] = set()
+    subcategories: set[str] = set()
+    mapping: dict[str, str] = {}
+    section = ""
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line or line == "```text" or line == "```":
+            continue
+        if line.startswith("# "):
+            section = line.removeprefix("# ")
+            continue
+        if section == "THEMES":
+            themes.add(line)
+        elif section == "SUBCATEGORIES (theme.subcategory)":
+            subcategories.add(line)
+        elif section == "SUBCATEGORY_TO_THEME":
+            subcategory, separator, theme = line.partition(" -> ")
+            if not separator:
+                raise ValueError(f"bad mapping line in generated block: {line}")
+            mapping[subcategory] = theme
+    return themes, subcategories, mapping
+
+
+def check_taxonomy_doc() -> list[str]:
+    errors: list[str] = []
+    canonical_themes = _literal_set(TAXONOMY_PATH, "THEMES")
+    canonical_subcategories = _literal_set(TAXONOMY_PATH, "SUBCATEGORIES")
+    canonical_mapping = {
+        subcategory: subcategory.split(".", 1)[0]
+        for subcategory in canonical_subcategories
+    }
+
+    doc = TAXONOMY_DOC.read_text(encoding="utf-8")
+    block_themes, block_subcategories, block_mapping = _keys_from_generated_block(
+        _generated_block(doc)
+    )
+    if block_themes != canonical_themes:
+        errors.append(
+            f"generated theme keys drift: expected {sorted(canonical_themes)}, "
+            f"found {sorted(block_themes)}"
+        )
+    if block_subcategories != canonical_subcategories:
+        errors.append(
+            "generated subcategory keys drift: "
+            f"expected {sorted(canonical_subcategories)}, found {sorted(block_subcategories)}"
+        )
+    if block_mapping != canonical_mapping:
+        errors.append(
+            f"generated subcategory mapping drift: expected {canonical_mapping}, "
+            f"found {block_mapping}"
+        )
+
+    documented = set(KEY_RE.findall(doc))
+    documented_themes = {
+        key for key in documented if "." not in key and key in canonical_themes
+    }
+    documented_subcategories = {
+        key
+        for key in documented
+        if "." in key and not key.endswith(".py") and key not in DOC_KEY_PLACEHOLDERS
+    }
+    unknown_subcategories = documented_subcategories - canonical_subcategories
+    if unknown_subcategories:
+        errors.append(
+            f"documented unknown subcategory keys: {sorted(unknown_subcategories)}"
+        )
+    if documented_themes != canonical_themes:
+        errors.append(
+            f"documented theme keys drift: expected {sorted(canonical_themes)}, "
+            f"found {sorted(documented_themes)}"
+        )
+    if not canonical_subcategories.issubset(documented_subcategories):
+        errors.append(
+            "documented subcategory keys missing: "
+            f"{sorted(canonical_subcategories - documented_subcategories)}"
+        )
+    return errors
+
+
+def check_llm_schema_examples() -> list[str]:
+    errors: list[str] = []
+    allowed = _literal_set(LLM_SCHEMA_PATH, "ALLOWED_TOP_LEVEL_KEYS")
+    doc = LLM_CONTRACT_DOC.read_text(encoding="utf-8")
+    for index, raw_json in enumerate(JSON_BLOCK_RE.findall(doc), start=1):
+        try:
+            payload = json.loads(raw_json)
+        except json.JSONDecodeError as exc:
+            errors.append(f"json example #{index} is invalid JSON: {exc}")
+            continue
+        if not isinstance(payload, dict):
+            continue
+        keys = set(payload)
+        if keys != allowed:
+            errors.append(
+                f"json example #{index} top-level keys drift: "
+                f"expected {sorted(allowed)}, found {sorted(keys)}"
+            )
+    return errors
+
+
+def main() -> int:
+    errors = [*check_taxonomy_doc(), *check_llm_schema_examples()]
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print("Investment docs drift check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen_taxonomy_docs.py
+++ b/scripts/gen_taxonomy_docs.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Render the generated taxonomy key block in investment docs."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TAXONOMY_PATH = ROOT / "src" / "dev_health_ops" / "investment_taxonomy.py"
+DOC_PATH = ROOT / "docs" / "product" / "investment-taxonomy.md"
+
+BEGIN = "<!-- BEGIN GENERATED TAXONOMY -->"
+END = "<!-- END GENERATED TAXONOMY -->"
+
+
+def _literal_set_order(source: str, name: str) -> list[str]:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            target_matches = any(
+                isinstance(target, ast.Name) and target.id == name
+                for target in node.targets
+            )
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            target_matches = (
+                isinstance(node.target, ast.Name) and node.target.id == name
+            )
+            value = node.value
+        else:
+            continue
+        if not target_matches:
+            continue
+        if not isinstance(value, ast.Set):
+            raise ValueError(f"{name} is not a set literal in {TAXONOMY_PATH}")
+        values: list[str] = []
+        for element in value.elts:
+            if not isinstance(element, ast.Constant) or not isinstance(
+                element.value, str
+            ):
+                raise ValueError(f"{name} contains a non-string literal")
+            values.append(element.value)
+        return values
+    raise ValueError(f"{name} not found in {TAXONOMY_PATH}")
+
+
+def load_taxonomy() -> tuple[list[str], list[str], dict[str, str]]:
+    source = TAXONOMY_PATH.read_text(encoding="utf-8")
+    themes = _literal_set_order(source, "THEMES")
+    subcategories = _literal_set_order(source, "SUBCATEGORIES")
+    theme_set = set(themes)
+
+    mapping: dict[str, str] = {}
+    for subcategory in subcategories:
+        theme, separator, _ = subcategory.partition(".")
+        if not separator:
+            raise ValueError(f"subcategory key lacks theme prefix: {subcategory}")
+        if theme not in theme_set:
+            raise ValueError(
+                f"subcategory {subcategory} maps to unknown theme prefix {theme}"
+            )
+        mapping[subcategory] = theme
+    return themes, subcategories, mapping
+
+
+def render_block(
+    themes: list[str], subcategories: list[str], mapping: dict[str, str]
+) -> str:
+    lines = [
+        BEGIN,
+        "```text",
+        "# THEMES",
+        *themes,
+        "",
+        "# SUBCATEGORIES (theme.subcategory)",
+        *subcategories,
+        "",
+        "# SUBCATEGORY_TO_THEME",
+    ]
+    lines.extend(
+        f"{subcategory} -> {mapping[subcategory]}" for subcategory in subcategories
+    )
+    lines.extend(["```", END])
+    return "\n".join(lines)
+
+
+def update_doc() -> None:
+    themes, subcategories, mapping = load_taxonomy()
+    rendered = render_block(themes, subcategories, mapping)
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    start = doc.find(BEGIN)
+    stop = doc.find(END)
+    if start == -1 or stop == -1 or stop < start:
+        raise SystemExit(f"Generated taxonomy markers not found in {DOC_PATH}")
+    stop += len(END)
+    updated = f"{doc[:start]}{rendered}{doc[stop:]}"
+    DOC_PATH.write_text(updated, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    update_doc()

--- a/scripts/gen_taxonomy_docs.py
+++ b/scripts/gen_taxonomy_docs.py
@@ -23,7 +23,7 @@ def _literal_set_order(source: str, name: str) -> list[str]:
                 for target in node.targets
             )
             value = node.value
-        elif isinstance(node, ast.AnnAssign):
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
             target_matches = (
                 isinstance(node.target, ast.Name) and node.target.id == name
             )


### PR DESCRIPTION
## Summary
- Generate the canonical taxonomy key block in docs/product/investment-taxonomy.md from src/dev_health_ops/investment_taxonomy.py.
- Add runnable docs drift checks for taxonomy facts and LLM schema JSON examples.
- Add an internal docs markdown link/anchor checker and wire the docs guards into CI.

## Validation
- make docs:generate-taxonomy
- make docs:check
- ruff format --check scripts/gen_taxonomy_docs.py scripts/check_investment_docs_drift.py scripts/check_docs_links.py
- ruff check scripts/gen_taxonomy_docs.py scripts/check_investment_docs_drift.py scripts/check_docs_links.py
- lsp_diagnostics clean on changed Python scripts

## Notes
- Root /AGENTS.md is unversioned and out of scope for the docs link checker.
- SCREENSHOT-WAIVER: docs/CI-only ops change; no rendered frontend output changed.

Refs CHAOS-2320 CHAOS-2321 CHAOS-2322