### PR TITLE
fix(investment): read latest work unit investment rows (CHAOS-2325)

### DIFF
--- a/docs/api/investment-api.md
+++ b/docs/api/investment-api.md
@@ -22,7 +22,7 @@ SELECT
     subcategory_kv.1 AS subcategory,
     splitByChar('.', subcategory_kv.1)[1] AS theme,
     sum(subcategory_kv.2 * effort_value) AS value
-FROM work_unit_investments
+FROM latest_work_unit_investments AS work_unit_investments
 ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
 WHERE from_ts < %(end_ts)s AND to_ts >= %(start_ts)s AND org_id = %(org_id)s
 GROUP BY subcategory, theme
@@ -92,12 +92,13 @@ never appears in a theme or subcategory distribution. The categorization itself 
 
 ---
 
-## Read-semantics caveat (latest row)
+## Read semantics (latest row)
 
-`work_unit_investments` is `ReplacingMergeTree(computed_at)`, but these queries `sum(...)`
-directly without `FINAL` or `argMax(..., computed_at)`. After a re-materialization,
-duplicate rows for the same `work_unit_id` may be double-counted until ClickHouse merges.
-This is a tracked engineering issue; see the
+`work_unit_investments` is `ReplacingMergeTree(computed_at)`, so duplicate physical rows
+for the same `work_unit_id` can exist until ClickHouse merges them. Investment API reads
+use an explicit latest-row subquery (`argMax(..., computed_at)` grouped by
+`work_unit_id`) before any effort-weighted `sum(...)`. This gives API totals
+latest-row-by-`computed_at` semantics without requiring `FINAL`; see the
 [data model read-semantics note](../architecture/investment-data-model.md#read-semantics-important).
 
 ---

--- a/docs/architecture/investment-data-model.md
+++ b/docs/architecture/investment-data-model.md
@@ -100,15 +100,13 @@ with the same sort key **eventually**, during background merges — not immediat
 
 - `work_unit_investments` is `ORDER BY (work_unit_id)`, so re-materializing a WorkUnit
   produces a new row that *eventually* replaces the old one.
-- The investment API queries currently `sum(...)` directly **without** `FINAL` or
-  `argMax(..., computed_at)`. Between a re-materialization and the next merge, duplicate
-  rows for the same `work_unit_id` can therefore be double-counted in user-visible
-  totals.
+- The investment API does not rely on background merge timing. Read queries first select
+  the latest physical row per `work_unit_id` with an explicit `argMax(..., computed_at)`
+  latest-row subquery, then apply the normal `org_id`, time-window, scope, and category
+  filters before effort-weighted aggregation.
 
-> This is a known correctness caveat, tracked as an engineering issue (review API
-> latest-row semantics). Until resolved, prefer querying with explicit latest-row logic
-> (`argMax`/`FINAL`/a latest subquery) when exact totals matter. See
-> [Investment API](../api/investment-api.md).
+This means user-visible investment totals use latest-row-by-`computed_at` semantics even
+before ClickHouse has compacted older ReplacingMergeTree versions.
 
 ---
 

--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -8,7 +8,10 @@ from collections.abc import Coroutine
 from datetime import date, datetime, time, timezone
 from typing import Any, cast
 
-from dev_health_ops.api.queries.investment import fetch_investment_quality_stats
+from dev_health_ops.api.queries.investment import (
+    LATEST_WORK_UNIT_INVESTMENTS_CTE,
+    fetch_investment_quality_stats,
+)
 
 from ..authz import require_org_id
 from ..context import GraphQLContext
@@ -504,7 +507,7 @@ async def resolve_analytics(
                 )
 
                 table = (
-                    "work_unit_investments"
+                    "latest_work_unit_investments AS work_unit_investments"
                     if request.use_investment
                     else "investment_metrics_daily"
                 )
@@ -527,7 +530,7 @@ async def resolve_analytics(
                                     work_unit_investments.work_unit_id AS work_unit_id,
                                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
                                     countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
-                                FROM work_unit_investments
+                                FROM latest_work_unit_investments AS work_unit_investments
                                 ARRAY JOIN arrayDistinct(arrayConcat(
                                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                                     [work_unit_investments.work_unit_id]
@@ -553,7 +556,17 @@ async def resolve_analytics(
                 if request.use_investment:
                     assigned_repo_expr = f"lower({repo_col}) != 'unassigned'"
 
+                with_clause = (
+                    f"WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}"
+                    if request.use_investment
+                    else ""
+                )
+                source_alias = (
+                    "work_unit_investments" if request.use_investment else table
+                )
+
                 coverage_sql = f"""
+                    {with_clause}
                     SELECT
                         count() as total,
                         countIf({assigned_team_expr}) as assigned_team,
@@ -561,7 +574,7 @@ async def resolve_analytics(
                     FROM {base_table}
                     {joins}
                     WHERE {date_filter}
-                      AND org_id = %(org_id)s
+                      AND {source_alias}.org_id = %(org_id)s
                 """
 
                 cov_params = {

--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -564,6 +564,14 @@ async def resolve_analytics(
                 source_alias = (
                     "work_unit_investments" if request.use_investment else table
                 )
+                # Qualify org_id only on the investment path, which JOINs other
+                # tables (repos/teams) that also carry org_id; the daily-table path
+                # is single-table, so an unqualified column is unambiguous.
+                org_filter = (
+                    f"{source_alias}.org_id = %(org_id)s"
+                    if request.use_investment
+                    else "org_id = %(org_id)s"
+                )
 
                 coverage_sql = f"""
                     {with_clause}
@@ -574,7 +582,7 @@ async def resolve_analytics(
                     FROM {base_table}
                     {joins}
                     WHERE {date_filter}
-                      AND {source_alias}.org_id = %(org_id)s
+                      AND {org_filter}
                 """
 
                 cov_params = {

--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from datetime import date
 from typing import TYPE_CHECKING, Any
 
+from dev_health_ops.api.queries.investment import LATEST_WORK_UNIT_INVESTMENTS_CTE
+
 from ..authz import enforce_org_scope
 from .filter_translation import translate_filters
 from .templates import (
@@ -137,7 +139,7 @@ def _get_context_params(
                         t.team_id AS team_id,
                         ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team_label,
                         countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
-                    FROM work_unit_investments
+                    FROM latest_work_unit_investments AS work_unit_investments
                     ARRAY JOIN arrayDistinct(arrayConcat(
                         JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                         [work_unit_investments.work_unit_id]
@@ -163,9 +165,10 @@ def _get_context_params(
             joins.append("LEFT JOIN repos AS r ON toString(r.id) = toString(repo_id)")
 
         return {
-            "source_table": "work_unit_investments",
+            "source_table": "latest_work_unit_investments AS work_unit_investments",
             "date_filter": "work_unit_investments.from_ts < %(end_date)s AND work_unit_investments.to_ts >= %(start_date)s",
             "extra_clauses": "\n".join(joins),
+            "with_clause": f"WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}",
             "use_investment": True,
         }
 
@@ -173,6 +176,7 @@ def _get_context_params(
         "source_table": "investment_metrics_daily",
         "date_filter": "day >= %(start_date)s AND day <= %(end_date)s",
         "extra_clauses": "",
+        "with_clause": "",
         "use_investment": False,
     }
 

--- a/src/dev_health_ops/api/graphql/sql/templates.py
+++ b/src/dev_health_ops/api/graphql/sql/templates.py
@@ -18,18 +18,21 @@ def timeseries_template(
     source_table: str = "investment_metrics_daily",
     date_filter: str = "day >= %(start_date)s AND day <= %(end_date)s",
     extra_clauses: str = "",
+    with_clause: str = "",
     use_investment: bool = False,
     filter_clause: str = "",  # NEW: scope/category filters
 ) -> str:
     """Generate SQL template for timeseries query."""
     dim_col = Dimension.db_column(dimension, use_investment=use_investment)
     measure_expr = Measure.db_expression(measure, use_investment=use_investment)
+    source_alias = source_table.split(" AS ")[-1]
     trunc_unit = BucketInterval.date_trunc_unit(interval)
 
     # Extract date column from filter for truncating
     date_col = date_filter.split(" ")[0]
 
     return f"""
+{with_clause}
 SELECT
     date_trunc('{trunc_unit}', {date_col}) AS bucket,
     {dim_col} AS dimension_value,
@@ -37,7 +40,7 @@ SELECT
 FROM {source_table}
 {extra_clauses}
 WHERE {date_filter}
-  AND {source_table}.org_id = %(org_id)s
+  AND {source_alias}.org_id = %(org_id)s
 {filter_clause}
 GROUP BY bucket, dimension_value
 ORDER BY bucket ASC, value DESC
@@ -51,21 +54,24 @@ def breakdown_template(
     source_table: str = "investment_metrics_daily",
     date_filter: str = "day >= %(start_date)s AND day <= %(end_date)s",
     extra_clauses: str = "",
+    with_clause: str = "",
     use_investment: bool = False,
     filter_clause: str = "",  # NEW: scope/category filters
 ) -> str:
     """Generate SQL template for breakdown (top-N aggregation) query."""
     dim_col = Dimension.db_column(dimension, use_investment=use_investment)
     measure_expr = Measure.db_expression(measure, use_investment=use_investment)
+    source_alias = source_table.split(" AS ")[-1]
 
     return f"""
+{with_clause}
 SELECT
     {dim_col} AS dimension_value,
     {measure_expr} AS value
 FROM {source_table}
 {extra_clauses}
 WHERE {date_filter}
-  AND {source_table}.org_id = %(org_id)s
+  AND {source_alias}.org_id = %(org_id)s
 {filter_clause}
 GROUP BY dimension_value
 ORDER BY value DESC
@@ -80,11 +86,13 @@ def sankey_nodes_template(
     source_table: str = "investment_metrics_daily",
     date_filter: str = "day >= %(start_date)s AND day <= %(end_date)s",
     extra_clauses: str = "",
+    with_clause: str = "",
     use_investment: bool = False,
     filter_clause: str = "",  # NEW: scope/category filters
 ) -> str:
     """Generate SQL template for Sankey nodes query."""
     measure_expr = Measure.db_expression(measure, use_investment=use_investment)
+    source_alias = source_table.split(" AS ")[-1]
 
     union_parts = []
     for dim in dimensions:
@@ -97,7 +105,7 @@ SELECT
 FROM {source_table}
 {extra_clauses}
 WHERE {date_filter}
-  AND {source_table}.org_id = %(org_id)s
+  AND {source_alias}.org_id = %(org_id)s
 {filter_clause}
 GROUP BY node_id
 ORDER BY value DESC
@@ -107,6 +115,7 @@ LIMIT %(limit_per_dim)s
 
     template = " UNION ALL ".join(union_parts)
     return f"""
+{with_clause}
 {template}
 SETTINGS max_execution_time = %(timeout)s
 """
@@ -119,6 +128,7 @@ def sankey_edges_template(
     source_table: str = "investment_metrics_daily",
     date_filter: str = "day >= %(start_date)s AND day <= %(end_date)s",
     extra_clauses: str = "",
+    with_clause: str = "",
     use_investment: bool = False,
     filter_clause: str = "",  # NEW: scope/category filters
 ) -> str:
@@ -126,8 +136,10 @@ def sankey_edges_template(
     source_col = Dimension.db_column(source_dim, use_investment=use_investment)
     target_col = Dimension.db_column(target_dim, use_investment=use_investment)
     measure_expr = Measure.db_expression(measure, use_investment=use_investment)
+    source_alias = source_table.split(" AS ")[-1]
 
     return f"""
+{with_clause}
 SELECT
     '{source_dim.value.upper()}' AS source_dimension,
     '{target_dim.value.upper()}' AS target_dimension,
@@ -137,7 +149,7 @@ SELECT
 FROM {source_table}
 {extra_clauses}
 WHERE {date_filter}
-  AND {source_table}.org_id = %(org_id)s
+  AND {source_alias}.org_id = %(org_id)s
 {filter_clause}
   AND {source_col} IS NOT NULL
   AND {target_col} IS NOT NULL
@@ -372,21 +384,24 @@ def catalog_values_template(
     dimension: Dimension,
     source_table: str = "investment_metrics_daily",
     extra_clauses: str = "",
+    with_clause: str = "",
     use_investment: bool = False,
     filter_clause: str = "",  # NEW: scope/category filters
     **kwargs: Any,
 ) -> str:
     """Generate SQL template for fetching distinct dimension values."""
     dim_col = Dimension.db_column(dimension, use_investment=use_investment)
+    source_alias = source_table.split(" AS ")[-1]
 
     return f"""
+{with_clause}
 SELECT
     toString({dim_col}) AS value,
     COUNT(*) AS count
 FROM {source_table}
 {extra_clauses}
 WHERE {dim_col} IS NOT NULL
-  AND {source_table}.org_id = %(org_id)s
+  AND {source_alias}.org_id = %(org_id)s
   AND toString({dim_col}) != ''
 {filter_clause}
 GROUP BY value

--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -7,6 +7,32 @@ from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 from .client import query_dicts
 
+LATEST_WORK_UNIT_INVESTMENTS_CTE = """
+        latest_work_unit_investments AS (
+            SELECT
+                work_unit_id,
+                argMax(work_unit_type, computed_at) AS work_unit_type,
+                argMax(work_unit_name, computed_at) AS work_unit_name,
+                argMax(from_ts, computed_at) AS from_ts,
+                argMax(to_ts, computed_at) AS to_ts,
+                argMax(repo_id, computed_at) AS repo_id,
+                argMax(provider, computed_at) AS provider,
+                argMax(effort_metric, computed_at) AS effort_metric,
+                argMax(effort_value, computed_at) AS effort_value,
+                argMax(theme_distribution_json, computed_at) AS theme_distribution_json,
+                argMax(subcategory_distribution_json, computed_at) AS subcategory_distribution_json,
+                argMax(structural_evidence_json, computed_at) AS structural_evidence_json,
+                argMax(evidence_quality, computed_at) AS evidence_quality,
+                argMax(evidence_quality_band, computed_at) AS evidence_quality_band,
+                argMax(categorization_status, computed_at) AS categorization_status,
+                argMax(categorization_run_id, computed_at) AS categorization_run_id,
+                argMax(org_id, computed_at) AS org_id,
+                max(computed_at) AS computed_at
+            FROM work_unit_investments
+            GROUP BY work_unit_id
+        )
+""".rstrip()
+
 
 async def fetch_investment_breakdown(
     sink: BaseMetricsSink,
@@ -31,11 +57,12 @@ async def fetch_investment_breakdown(
         params["subcategories"] = subcategories
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
     query = f"""
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}
         SELECT
             subcategory_kv.1 AS subcategory,
             splitByChar('.', subcategory_kv.1)[1] AS theme,
             sum(subcategory_kv.2 * effort_value) AS value
-        FROM work_unit_investments
+        FROM latest_work_unit_investments AS work_unit_investments
         ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
         WHERE work_unit_investments.from_ts < %(end_ts)s
           AND work_unit_investments.to_ts >= %(start_ts)s
@@ -66,11 +93,12 @@ async def fetch_investment_edges(
         theme_filter = " AND theme_kv.1 IN %(themes)s"
         params["themes"] = themes
     query = f"""
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}
         SELECT
             theme_kv.1 AS source,
             ifNull(r.repo, toString(repo_id)) AS target,
             sum(theme_kv.2 * effort_value) AS value
-        FROM work_unit_investments
+        FROM latest_work_unit_investments AS work_unit_investments
         LEFT JOIN repos AS r ON toString(r.id) = toString(repo_id)
         ARRAY JOIN CAST(theme_distribution_json AS Array(Tuple(String, Float32))) AS theme_kv
         WHERE work_unit_investments.from_ts < %(end_ts)s
@@ -107,11 +135,12 @@ async def fetch_investment_subcategory_edges(
         params["subcategories"] = subcategories
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
     query = f"""
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}
         SELECT
             subcategory_kv.1 AS source,
             ifNull(r.repo, if(repo_id IS NULL, 'unassigned', toString(repo_id))) AS target,
             sum(subcategory_kv.2 * effort_value) AS value
-        FROM work_unit_investments
+        FROM latest_work_unit_investments AS work_unit_investments
         LEFT JOIN repos AS r ON toString(r.id) = toString(repo_id)
         ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
         WHERE work_unit_investments.from_ts < %(end_ts)s
@@ -148,7 +177,8 @@ async def fetch_investment_team_edges(
         params["subcategories"] = subcategories
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
     query = f"""
-        WITH unit_team AS (
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE},
+        unit_team AS (
             SELECT
                 work_unit_id,
                 argMax(team, cnt) AS team
@@ -157,7 +187,7 @@ async def fetch_investment_team_edges(
                     work_unit_investments.work_unit_id AS work_unit_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
                     countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
-                FROM work_unit_investments
+                FROM latest_work_unit_investments AS work_unit_investments
                 ARRAY JOIN arrayDistinct(arrayConcat(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
@@ -183,7 +213,7 @@ async def fetch_investment_team_edges(
             subcategory_kv.1 AS source,
             ifNull(nullIf(unit_team.team, ''), 'unassigned') AS target,
             sum(subcategory_kv.2 * effort_value) AS value
-        FROM work_unit_investments
+        FROM latest_work_unit_investments AS work_unit_investments
         LEFT JOIN unit_team ON unit_team.work_unit_id = work_unit_investments.work_unit_id
         ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
         WHERE work_unit_investments.from_ts < %(end_ts)s
@@ -220,7 +250,8 @@ async def fetch_investment_repo_team_edges(
         params["subcategories"] = subcategories
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
     query = f"""
-        WITH unit_team AS (
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE},
+        unit_team AS (
             SELECT
                 work_unit_id,
                 argMax(team, cnt) AS team
@@ -229,7 +260,7 @@ async def fetch_investment_repo_team_edges(
                     work_unit_investments.work_unit_id AS work_unit_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
                     countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
-                FROM work_unit_investments
+                FROM latest_work_unit_investments AS work_unit_investments
                 ARRAY JOIN arrayDistinct(arrayConcat(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
@@ -256,7 +287,7 @@ async def fetch_investment_repo_team_edges(
             ifNull(r.repo, if(repo_id IS NULL, 'unassigned', toString(repo_id))) AS repo,
             ifNull(nullIf(unit_team.team, ''), 'unassigned') AS team,
             sum(subcategory_kv.2 * effort_value) AS value
-        FROM work_unit_investments
+        FROM latest_work_unit_investments AS work_unit_investments
         LEFT JOIN repos AS r ON toString(r.id) = toString(repo_id)
         LEFT JOIN unit_team ON unit_team.work_unit_id = work_unit_investments.work_unit_id
         ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
@@ -294,7 +325,8 @@ async def fetch_investment_team_category_repo_edges(
         params["subcategories"] = subcategories
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
     query = f"""
-        WITH unit_team AS (
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE},
+        unit_team AS (
             SELECT
                 work_unit_id,
                 argMax(team, cnt) AS team
@@ -303,7 +335,7 @@ async def fetch_investment_team_category_repo_edges(
                     work_unit_investments.work_unit_id AS work_unit_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
                     countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
-                FROM work_unit_investments
+                FROM latest_work_unit_investments AS work_unit_investments
                 ARRAY JOIN arrayDistinct(arrayConcat(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
@@ -330,7 +362,7 @@ async def fetch_investment_team_category_repo_edges(
             splitByChar('.', subcategory_kv.1)[1] AS category,
             ifNull(r.repo, if(repo_id IS NULL, 'unassigned', toString(repo_id))) AS repo,
             sum(subcategory_kv.2 * effort_value) AS value
-        FROM work_unit_investments
+        FROM latest_work_unit_investments AS work_unit_investments
         LEFT JOIN repos AS r ON toString(r.id) = toString(repo_id)
         LEFT JOIN unit_team ON unit_team.work_unit_id = work_unit_investments.work_unit_id
         ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
@@ -368,7 +400,8 @@ async def fetch_investment_team_subcategory_repo_edges(
         params["subcategories"] = subcategories
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
     query = f"""
-        WITH unit_team AS (
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE},
+        unit_team AS (
             SELECT
                 work_unit_id,
                 argMax(team, cnt) AS team
@@ -377,7 +410,7 @@ async def fetch_investment_team_subcategory_repo_edges(
                     work_unit_investments.work_unit_id AS work_unit_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
                     countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
-                FROM work_unit_investments
+                FROM latest_work_unit_investments AS work_unit_investments
                 ARRAY JOIN arrayDistinct(arrayConcat(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
@@ -404,7 +437,7 @@ async def fetch_investment_team_subcategory_repo_edges(
             subcategory_kv.1 AS subcategory,
             ifNull(r.repo, if(repo_id IS NULL, 'unassigned', toString(repo_id))) AS repo,
             sum(subcategory_kv.2 * effort_value) AS value
-        FROM work_unit_investments
+        FROM latest_work_unit_investments AS work_unit_investments
         LEFT JOIN repos AS r ON toString(r.id) = toString(repo_id)
         LEFT JOIN unit_team ON unit_team.work_unit_id = work_unit_investments.work_unit_id
         ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
@@ -446,7 +479,8 @@ async def fetch_investment_unassigned_counts(
         params["subcategories"] = subcategories
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
     query = f"""
-        WITH unit_team AS (
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE},
+        unit_team AS (
             SELECT
                 work_unit_id,
                 argMax(team, cnt) AS team
@@ -455,7 +489,7 @@ async def fetch_investment_unassigned_counts(
                     work_unit_investments.work_unit_id AS work_unit_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
                     countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
-                FROM work_unit_investments
+                FROM latest_work_unit_investments AS work_unit_investments
                 ARRAY JOIN arrayDistinct(arrayConcat(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
@@ -484,7 +518,7 @@ async def fetch_investment_unassigned_counts(
                 work_unit_investments.work_unit_id,
                 ifNull(nullIf(unit_team.team, ''), '') = ''
             ) AS missing_team
-        FROM work_unit_investments
+        FROM latest_work_unit_investments AS work_unit_investments
         LEFT JOIN unit_team ON unit_team.work_unit_id = work_unit_investments.work_unit_id
         WHERE work_unit_investments.from_ts < %(end_ts)s
           AND work_unit_investments.to_ts >= %(start_ts)s
@@ -530,12 +564,13 @@ async def fetch_investment_sunburst(
         params["subcategories"] = subcategories
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
     query = f"""
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}
         SELECT
             subcategory_kv.1 AS subcategory,
             splitByChar('.', subcategory_kv.1)[1] AS theme,
             ifNull(r.repo, toString(repo_id)) AS scope,
             sum(subcategory_kv.2 * effort_value) AS value
-        FROM work_unit_investments
+        FROM latest_work_unit_investments AS work_unit_investments
         LEFT JOIN repos AS r ON toString(r.id) = toString(repo_id)
         ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
         WHERE work_unit_investments.from_ts < %(end_ts)s
@@ -594,7 +629,7 @@ async def fetch_investment_quality_stats(
                     t.team_id AS team_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team_label,
                     countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
-                FROM work_unit_investments
+                FROM latest_work_unit_investments AS work_unit_investments
                 ARRAY JOIN arrayDistinct(arrayConcat(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
@@ -623,6 +658,7 @@ async def fetch_investment_quality_stats(
           )
         """
     query = f"""
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}
         SELECT
             count() AS total,
             countIf(evidence_quality IS NOT NULL) AS quality_known_count,
@@ -633,7 +669,7 @@ async def fetch_investment_quality_stats(
             countIf(evidence_quality_band = 'low') AS low_count,
             countIf(evidence_quality_band = 'very_low') AS very_low_count,
             countIf(evidence_quality IS NULL OR evidence_quality_band = '') AS unknown_count
-        FROM work_unit_investments
+        FROM latest_work_unit_investments AS work_unit_investments
         {team_join}
         WHERE work_unit_investments.from_ts < %(end_ts)s
           AND work_unit_investments.to_ts >= %(start_ts)s

--- a/src/dev_health_ops/api/queries/sankey.py
+++ b/src/dev_health_ops/api/queries/sankey.py
@@ -6,6 +6,7 @@ from typing import Any
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 from .client import query_dicts
+from .investment import LATEST_WORK_UNIT_INVESTMENTS_CTE
 
 
 async def fetch_investment_flow_items(
@@ -19,11 +20,12 @@ async def fetch_investment_flow_items(
     org_id: str = "",
 ) -> list[dict[str, Any]]:
     query = f"""
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}
         SELECT
             theme_kv.1 AS source,
             ifNull(r.repo, toString(repo_id)) AS target,
             sum(theme_kv.2 * effort_value) AS value
-        FROM work_unit_investments
+        FROM latest_work_unit_investments AS work_unit_investments
         LEFT JOIN repos AS r ON toString(r.id) = toString(repo_id)
         ARRAY JOIN CAST(theme_distribution_json AS Array(Tuple(String, Float32))) AS theme_kv
         WHERE from_ts < %(end_ts)s AND to_ts >= %(start_ts)s

--- a/tests/api/test_investment_latest_row_queries.py
+++ b/tests/api/test_investment_latest_row_queries.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+
+import dev_health_ops.api.queries.investment as investment_queries
+import dev_health_ops.api.queries.sankey as sankey_queries
+from dev_health_ops.api.graphql.sql.compiler import (
+    TimeseriesRequest,
+    compile_timeseries,
+)
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+
+def _window() -> tuple[datetime, datetime]:
+    return (
+        datetime(2026, 1, 1, tzinfo=timezone.utc),
+        datetime(2026, 1, 31, tzinfo=timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_investment_breakdown_aggregates_only_latest_work_unit_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    older = {
+        "work_unit_id": "wu-1",
+        "org_id": "org-1",
+        "from_ts": datetime(2026, 1, 10, tzinfo=timezone.utc),
+        "to_ts": datetime(2026, 1, 11, tzinfo=timezone.utc),
+        "effort_value": 10.0,
+        "subcategory_distribution_json": [("Feature Delivery.product", 1.0)],
+        "computed_at": datetime(2026, 1, 12, tzinfo=timezone.utc),
+    }
+    latest = {
+        **older,
+        "effort_value": 20.0,
+        "computed_at": datetime(2026, 1, 13, tzinfo=timezone.utc),
+    }
+    physical_rows = [older, latest]
+
+    async def fake_query_dicts(
+        _sink: BaseMetricsSink, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        assert "latest_work_unit_investments AS" in sql
+        assert "argMax(effort_value, computed_at) AS effort_value" in sql
+        latest_by_id: dict[str, dict[str, Any]] = {}
+        for row in physical_rows:
+            current = latest_by_id.get(row["work_unit_id"])
+            if current is None or row["computed_at"] > current["computed_at"]:
+                latest_by_id[row["work_unit_id"]] = row
+
+        totals: dict[tuple[str, str], float] = {}
+        for row in latest_by_id.values():
+            for subcategory, probability in row["subcategory_distribution_json"]:
+                theme = subcategory.split(".", 1)[0]
+                totals[(subcategory, theme)] = totals.get((subcategory, theme), 0.0) + (
+                    probability * row["effort_value"]
+                )
+        return [
+            {"subcategory": subcategory, "theme": theme, "value": value}
+            for (subcategory, theme), value in totals.items()
+        ]
+
+    monkeypatch.setattr(investment_queries, "query_dicts", fake_query_dicts)
+
+    start_ts, end_ts = _window()
+    rows = await investment_queries.fetch_investment_breakdown(
+        cast(BaseMetricsSink, object()),
+        start_ts=start_ts,
+        end_ts=end_ts,
+        scope_filter="",
+        scope_params={},
+        org_id="org-1",
+    )
+
+    assert rows == [
+        {
+            "subcategory": "Feature Delivery.product",
+            "theme": "Feature Delivery",
+            "value": 20.0,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fetcher",
+    [
+        investment_queries.fetch_investment_breakdown,
+        investment_queries.fetch_investment_edges,
+        investment_queries.fetch_investment_subcategory_edges,
+        investment_queries.fetch_investment_team_edges,
+        investment_queries.fetch_investment_repo_team_edges,
+        investment_queries.fetch_investment_team_category_repo_edges,
+        investment_queries.fetch_investment_team_subcategory_repo_edges,
+        investment_queries.fetch_investment_unassigned_counts,
+        investment_queries.fetch_investment_sunburst,
+        investment_queries.fetch_investment_quality_stats,
+    ],
+)
+async def test_investment_queries_read_latest_work_unit_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    fetcher: Any,
+) -> None:
+    captured: dict[str, str] = {"sql": ""}
+
+    async def fake_query_dicts(
+        _sink: BaseMetricsSink, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        captured["sql"] = sql
+        return []
+
+    monkeypatch.setattr(investment_queries, "query_dicts", fake_query_dicts)
+
+    start_ts, end_ts = _window()
+    await fetcher(
+        cast(BaseMetricsSink, object()),
+        start_ts=start_ts,
+        end_ts=end_ts,
+        scope_filter="",
+        scope_params={},
+        org_id="org-1",
+    )
+
+    sql = captured["sql"]
+    assert "latest_work_unit_investments AS" in sql
+    assert "FROM latest_work_unit_investments AS work_unit_investments" in sql
+    assert "argMax(effort_value, computed_at) AS effort_value" in sql
+    assert "work_unit_investments.from_ts < %(end_ts)s" in sql
+    assert "work_unit_investments.to_ts >= %(start_ts)s" in sql
+    assert "work_unit_investments.org_id = %(org_id)s" in sql
+
+
+@pytest.mark.asyncio
+async def test_sankey_flow_items_read_latest_work_unit_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {"sql": ""}
+
+    async def fake_query_dicts(
+        _sink: BaseMetricsSink, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        captured["sql"] = sql
+        return []
+
+    monkeypatch.setattr(sankey_queries, "query_dicts", fake_query_dicts)
+    start_ts, end_ts = _window()
+
+    await sankey_queries.fetch_investment_flow_items(
+        cast(BaseMetricsSink, object()),
+        start_ts=start_ts,
+        end_ts=end_ts,
+        scope_filter="",
+        scope_params={},
+        limit=10,
+        org_id="org-1",
+    )
+
+    assert "latest_work_unit_investments AS" in captured["sql"]
+    assert (
+        "FROM latest_work_unit_investments AS work_unit_investments" in captured["sql"]
+    )
+
+
+def test_investment_timeseries_compiler_reads_latest_work_unit_rows() -> None:
+    sql, params = compile_timeseries(
+        TimeseriesRequest(
+            dimension="theme",
+            measure="count",
+            interval="day",
+            start_date=datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+            end_date=datetime(2026, 1, 31, tzinfo=timezone.utc).date(),
+        ),
+        org_id="org-1",
+    )
+
+    assert params["org_id"] == "org-1"
+    assert "latest_work_unit_investments AS" in sql
+    assert "FROM latest_work_unit_investments AS work_unit_investments" in sql
+    assert "work_unit_investments.org_id = %(org_id)s" in sql

--- a/tests/api/test_investment_latest_row_queries.py
+++ b/tests/api/test_investment_latest_row_queries.py
@@ -39,7 +39,7 @@ async def test_investment_breakdown_aggregates_only_latest_work_unit_row(
         "effort_value": 20.0,
         "computed_at": datetime(2026, 1, 13, tzinfo=timezone.utc),
     }
-    physical_rows = [older, latest]
+    physical_rows: list[dict[str, Any]] = [older, latest]
 
     async def fake_query_dicts(
         _sink: BaseMetricsSink, sql: str, _params: dict[str, Any]


### PR DESCRIPTION
## Summary
- Add a latest-row-by-computed_at CTE for work_unit_investments reads before effort-weighted aggregation
- Apply the latest-row source to direct investment queries, sankey flow items, and GraphQL investment analytics SQL
- Add regression coverage for duplicate physical rows and update read-semantics docs

## Verification
- python -m pytest tests/api/test_investment_latest_row_queries.py tests/api/test_investment_team_attribution_sql.py tests/api/test_investment_evidence_quality.py tests/api/test_work_unit_investments_query.py tests/graphql/test_compiler.py
- python -m ruff check src/dev_health_ops/api/queries/investment.py src/dev_health_ops/api/queries/sankey.py src/dev_health_ops/api/graphql/sql/compiler.py src/dev_health_ops/api/graphql/sql/templates.py src/dev_health_ops/api/graphql/resolvers/analytics.py tests/api/test_investment_latest_row_queries.py

Refs CHAOS-2325