### PR TITLE
feat(api): Valkey-backed shared impersonation cache — multi-replica correctness (CHAOS-2328)

### DIFF
--- a/src/dev_health_ops/api/admin/impersonation.py
+++ b/src/dev_health_ops/api/admin/impersonation.py
@@ -20,7 +20,10 @@ from dev_health_ops.api.admin.schemas import (
 from dev_health_ops.api.auth.router import get_current_user
 from dev_health_ops.api.services.audit import AuditService
 from dev_health_ops.api.services.auth import AuthenticatedUser
-from dev_health_ops.api.services.impersonation_cache import invalidate
+from dev_health_ops.api.services.impersonation_cache import (
+    get_active_session,
+    invalidate,
+)
 from dev_health_ops.db import get_postgres_session
 from dev_health_ops.models.audit import AuditAction, AuditResourceType
 from dev_health_ops.models.impersonation import ImpersonationSession
@@ -137,10 +140,7 @@ async def start_impersonation(
     session.add(new_session)
     await session.flush()
 
-    # Invalidate cache for this admin
-    invalidate(current_user.user_id)
-
-    # Audit log
+    # Audit log — same transaction as the session row, so the two stay atomic
     target_org_uuid = uuid.UUID(str(target_membership.org_id))
     audit_service = AuditService(session)
     await audit_service.log(
@@ -151,6 +151,12 @@ async def start_impersonation(
         resource_id=str(target_user.id),
         user=current_user,
     )
+
+    # COMMIT before invalidating the shared cache: a racing reader between
+    # DEL and commit would re-fill the cache from pre-commit DB state and
+    # poison every replica for up to the cache TTL (CHAOS-2328).
+    await session.commit()
+    await invalidate(current_user.user_id)
 
     return StartImpersonationResponse(
         status="active",
@@ -193,10 +199,7 @@ async def stop_impersonation(
     active_session.ended_at = now
     await session.flush()
 
-    # Invalidate cache
-    invalidate(current_user.user_id)
-
-    # Audit log
+    # Audit log — same transaction as the session update, so the two stay atomic
     target_org_uuid = uuid.UUID(str(active_session.target_org_id))
     audit_service = AuditService(session)
     await audit_service.log(
@@ -208,45 +211,48 @@ async def stop_impersonation(
         user=current_user,
     )
 
+    # COMMIT before invalidating the shared cache — see start_impersonation.
+    await session.commit()
+    await invalidate(current_user.user_id)
+
     return StopImpersonationResponse(status="stopped")
 
 
 @router.get("/impersonate/status", response_model=ImpersonationStatusResponse)
 async def impersonation_status(
     current_user: AuthenticatedUser = Depends(get_current_user),
-    session: AsyncSession = Depends(get_db_session),
 ) -> ImpersonationStatusResponse:
+    """Server-verified impersonation state for the calling admin.
+
+    Reads through the shared Valkey cache (CHAOS-2328): the web frontend
+    polls this per request for superusers, so the hot path must not need a
+    Postgres query. Explicit DEL on start/stop keeps it instantly correct
+    across replicas.
+    """
     if not current_user.is_superuser:
         return ImpersonationStatusResponse(is_impersonating=False)
 
-    admin_user_uuid = _parse_uuid(current_user.user_id, "user_id")
+    # Validates the id format (raises 400 on garbage) — cache keys are keyed
+    # by the canonical string form.
+    _parse_uuid(current_user.user_id, "user_id")
+
+    active = await get_active_session(current_user.user_id)
     now = datetime.now(timezone.utc)
-
-    active_result = await session.execute(
-        select(ImpersonationSession)
-        .where(
-            ImpersonationSession.admin_user_id == admin_user_uuid,
-            ImpersonationSession.ended_at.is_(None),
-            ImpersonationSession.expires_at > now,
-        )
-        .limit(1)
-    )
-    active_session = active_result.scalar_one_or_none()
-
-    if not active_session:
+    if active is None:
         return ImpersonationStatusResponse(is_impersonating=False)
 
-    # Fetch target email for the response
-    target_result = await session.execute(
-        select(User).where(User.id == active_session.target_user_id)
+    expires_at = (
+        active.expires_at.replace(tzinfo=timezone.utc)
+        if active.expires_at.tzinfo is None
+        else active.expires_at
     )
-    target_user = target_result.scalar_one_or_none()
-    target_email = str(target_user.email) if target_user else None
+    if expires_at <= now:
+        return ImpersonationStatusResponse(is_impersonating=False)
 
     return ImpersonationStatusResponse(
         is_impersonating=True,
-        target_user_id=str(active_session.target_user_id),
-        target_email=target_email,
-        target_org_id=str(active_session.target_org_id),
-        expires_at=active_session.expires_at,
+        target_user_id=active.target_user_id,
+        target_email=active.target_email,
+        target_org_id=active.target_org_id,
+        expires_at=active.expires_at,
     )

--- a/src/dev_health_ops/api/admin/impersonation.py
+++ b/src/dev_health_ops/api/admin/impersonation.py
@@ -21,8 +21,9 @@ from dev_health_ops.api.auth.router import get_current_user
 from dev_health_ops.api.services.audit import AuditService
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.impersonation_cache import (
+    CachedImpersonationSession,
     get_active_session,
-    invalidate,
+    set_active_session,
 )
 from dev_health_ops.db import get_postgres_session
 from dev_health_ops.models.audit import AuditAction, AuditResourceType
@@ -152,11 +153,22 @@ async def start_impersonation(
         user=current_user,
     )
 
-    # COMMIT before invalidating the shared cache: a racing reader between
-    # DEL and commit would re-fill the cache from pre-commit DB state and
-    # poison every replica for up to the cache TTL (CHAOS-2328).
+    # COMMIT, then write the authoritative state through to the shared cache
+    # (CHAOS-2328). Ordering matters: a write-through of pre-commit state
+    # would poison every replica for up to the cache TTL.
     await session.commit()
-    await invalidate(current_user.user_id)
+    await set_active_session(
+        current_user.user_id,
+        CachedImpersonationSession(
+            id=str(new_session.id),
+            admin_user_id=str(admin_user_uuid),
+            target_user_id=str(target_user.id),
+            target_org_id=str(target_membership.org_id),
+            target_role=str(target_membership.role),
+            target_email=str(target_user.email),
+            expires_at=expires_at,
+        ),
+    )
 
     return StartImpersonationResponse(
         status="active",
@@ -211,9 +223,9 @@ async def stop_impersonation(
         user=current_user,
     )
 
-    # COMMIT before invalidating the shared cache — see start_impersonation.
+    # COMMIT, then write-through "no active session" — see start_impersonation.
     await session.commit()
-    await invalidate(current_user.user_id)
+    await set_active_session(current_user.user_id, None)
 
     return StopImpersonationResponse(status="stopped")
 

--- a/src/dev_health_ops/api/middleware/impersonation.py
+++ b/src/dev_health_ops/api/middleware/impersonation.py
@@ -173,15 +173,24 @@ def _extract_user(scope: Scope) -> Any | None:
 
 
 async def _expire_session(session: Any, admin_user_id: str) -> None:
-    """Mark a session as ended due to TTL expiry."""
+    """Mark a session as ended due to TTL expiry.
+
+    The cache hands back a plain snapshot (no ORM identity), so end the row
+    via an UPDATE keyed on the session id rather than mutating an instance.
+    """
     try:
+        from sqlalchemy import update as sa_update
+
         from dev_health_ops.db import get_postgres_session
+        from dev_health_ops.models.impersonation import ImpersonationSession
 
         async with get_postgres_session() as db:
-            session.ended_at = datetime.now(timezone.utc)
-            db.add(session)
-            await db.commit()
-        invalidate(admin_user_id)
+            await db.execute(
+                sa_update(ImpersonationSession)
+                .where(ImpersonationSession.id == session.id)
+                .values(ended_at=datetime.now(timezone.utc))
+            )
+        await invalidate(admin_user_id)
     except Exception as exc:
         logger.warning("Failed to expire impersonation session: %s", exc)
 

--- a/src/dev_health_ops/api/middleware/impersonation.py
+++ b/src/dev_health_ops/api/middleware/impersonation.py
@@ -33,7 +33,7 @@ from dev_health_ops.api.services.auth import (
 )
 from dev_health_ops.api.services.impersonation_cache import (
     get_active_session,
-    invalidate,
+    set_active_session,
 )
 
 logger = logging.getLogger(__name__)
@@ -187,10 +187,13 @@ async def _expire_session(session: Any, admin_user_id: str) -> None:
         async with get_postgres_session() as db:
             await db.execute(
                 sa_update(ImpersonationSession)
-                .where(ImpersonationSession.id == session.id)
+                .where(
+                    ImpersonationSession.id == session.id,
+                    ImpersonationSession.ended_at.is_(None),
+                )
                 .values(ended_at=datetime.now(timezone.utc))
             )
-        await invalidate(admin_user_id)
+        await set_active_session(admin_user_id, None)
     except Exception as exc:
         logger.warning("Failed to expire impersonation session: %s", exc)
 

--- a/src/dev_health_ops/api/services/impersonation_cache.py
+++ b/src/dev_health_ops/api/services/impersonation_cache.py
@@ -164,6 +164,12 @@ async def _cache_set(
         _trip_circuit(exc)
 
 
+# Sentinel for "Postgres lookup failed" — must NOT be cached: a transient DB
+# error cached as the negative sentinel would disable an actually active
+# impersonation on every replica for a full TTL.
+_DB_ERROR: Any = object()
+
+
 async def get_active_session(
     admin_user_id: str,
 ) -> CachedImpersonationSession | None:
@@ -171,19 +177,26 @@ async def get_active_session(
 
     Checks the shared Valkey cache first; falls back to Postgres on miss or
     Valkey outage. Returns None when no session is active or both stores are
-    unavailable (fail-open: impersonation does not activate).
+    unavailable (fail-open: impersonation does not activate). Only confirmed
+    DB results are written back to the cache — DB errors are never cached.
     """
     cached = await _cache_get(admin_user_id)
     if cached is not _MISS:
         return cached
 
     session = await _load_from_db(admin_user_id)
+    if session is _DB_ERROR:
+        return None
     await _cache_set(admin_user_id, session)
     return session
 
 
-async def _load_from_db(admin_user_id: str) -> CachedImpersonationSession | None:
-    """Query Postgres for an active impersonation session. Fail-open on error."""
+async def _load_from_db(admin_user_id: str) -> Any:
+    """Query Postgres for an active impersonation session.
+
+    Returns a CachedImpersonationSession, None (confirmed no active session),
+    or _DB_ERROR when the lookup itself failed.
+    """
     try:
         from datetime import timezone
 
@@ -218,19 +231,55 @@ async def _load_from_db(admin_user_id: str) -> CachedImpersonationSession | None
                 expires_at=record.expires_at,
             )
     except Exception:
-        # Fail-open: if DB is unavailable, impersonation doesn't activate
-        return None
+        # Fail-open at the call site, but never cache the failure.
+        logger.warning(
+            "Postgres lookup for impersonation session failed", exc_info=True
+        )
+        return _DB_ERROR
+
+
+async def set_active_session(
+    admin_user_id: str, session: CachedImpersonationSession | None
+) -> None:
+    """Write-through the authoritative state after a committed start/stop.
+
+    Callers must COMMIT first — a write-through of pre-commit state would
+    poison every replica for up to the TTL. Writing the new state (instead of
+    just DEL) also closes most of the load-after-DEL window where a reader
+    that fetched pre-commit DB state re-fills the cache after the DEL; a
+    reader would now have to stay suspended across the entire endpoint
+    transaction AND this write to clobber it, and even then the TTL bounds
+    the damage to ≤ _TTL_SECONDS.
+
+    Deliberately ignores the circuit breaker: this is the one write that
+    keeps replicas correct, so it always attempts Valkey (bounded by the
+    0.5s socket timeouts) even right after a read error.
+    """
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        await client.set(_key(admin_user_id), _serialize(session), ex=_TTL_SECONDS)
+    except Exception as exc:
+        _trip_circuit(exc)
+        logger.error(
+            "Failed to write-through impersonation state for %s — replicas "
+            "may serve stale impersonation context for up to %ss",
+            admin_user_id,
+            _TTL_SECONDS,
+        )
 
 
 async def invalidate(admin_user_id: str) -> None:
-    """Remove the shared cache entry for admin_user_id (call after start/stop).
+    """Remove the shared cache entry for admin_user_id.
 
-    Callers must COMMIT their transaction before invalidating — otherwise a
-    racing reader can re-fill the shared cache from the pre-commit DB state
-    and re-poison every replica for up to the TTL.
+    Prefer set_active_session() after a committed start/stop (write-through
+    leaves no cold-miss window). Like set_active_session, this deliberately
+    ignores the circuit breaker — skipping the DEL because an earlier READ
+    failed would let a stale entry resurface once the circuit closes.
     """
     client = _get_client()
-    if client is None or _circuit_is_open():
+    if client is None:
         return
     try:
         await client.delete(_key(admin_user_id))

--- a/src/dev_health_ops/api/services/impersonation_cache.py
+++ b/src/dev_health_ops/api/services/impersonation_cache.py
@@ -1,74 +1,245 @@
-"""In-process TTL cache for active impersonation sessions.
+"""Valkey-backed shared cache for active impersonation sessions (CHAOS-2328).
 
-Caches active ImpersonationSession lookups to avoid a DB query on every
-request. TTL is 30 seconds — short enough for responsive UX while cutting
-per-request DB cost during impersonation. The cache is unbounded (no
-max-size eviction); entries are evicted only when their TTL expires.
+The previous implementation was a per-process dict with a 30s TTL: stopping
+an impersonation invalidated only the worker that handled the request, so
+every OTHER api replica/worker kept serving the stale impersonation context
+(wrong-org scoping) for up to 30s. Valkey is shared infrastructure for all
+api processes, so an explicit DEL on start/stop is observed by every replica
+on its next request.
+
+Failure policy is fail-correct, not fail-stale: when Valkey is unavailable
+the cache layer is bypassed and every lookup goes straight to Postgres. A
+short circuit breaker bounds the per-request connect cost during an outage.
+Only when Postgres is ALSO unavailable does impersonation silently not
+activate (same as before).
 """
 
 from __future__ import annotations
 
+import json
+import logging
+import os
 import time
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
 
-if TYPE_CHECKING:
-    from dev_health_ops.models.impersonation import ImpersonationSession
+logger = logging.getLogger(__name__)
 
-_TTL_SECONDS: float = 30.0
-# {admin_user_id: (session_or_none, expiry_timestamp)}
-_cache: dict[str, tuple[ImpersonationSession | None, float]] = {}
+# Entries self-expire as a drift bound (e.g. manual DB edits); correctness
+# comes from the explicit DEL in the start/stop endpoints.
+_TTL_SECONDS = 30
+
+_KEY_PREFIX = "impersonation:active:"
+
+# Negative-cache marker: "this admin has no active impersonation session".
+# Caching the absence matters — it is the overwhelmingly common case for
+# superuser traffic and saves a Postgres query per request.
+_NONE_SENTINEL = b"none"
+
+# Sentinel distinguishing "cache miss" from "cached None" in _cache_get.
+_MISS: Any = object()
+
+# Circuit breaker: after a Valkey error, skip the cache for a short window
+# instead of paying the connect timeout on every request.
+_CIRCUIT_SECONDS = 5.0
+_circuit_open_until = 0.0
+
+_client: Any | None = None
 
 
-def _is_expired(expiry: float) -> bool:
-    return time.monotonic() > expiry
+@dataclass(frozen=True)
+class CachedImpersonationSession:
+    """Plain snapshot of an active ImpersonationSession (no ORM identity).
 
-
-async def get_active_session(admin_user_id: str) -> ImpersonationSession | None:
-    """Return the active ImpersonationSession for admin_user_id, or None.
-
-    Checks in-memory cache first; falls back to DB on miss.
-    Returns None if no session is active or DB lookup fails (fail-open).
+    Carried across process boundaries via Valkey, so it must stay a simple
+    serializable value object. ``target_email`` is denormalized here so the
+    status endpoint never needs a Postgres read on the hot path.
     """
-    entry = _cache.get(admin_user_id)
-    if entry is not None:
-        session, expiry = entry
-        if not _is_expired(expiry):
-            return session
-        # Expired — remove from cache and fall through to DB
-        del _cache[admin_user_id]
 
-    # DB lookup
+    id: str
+    admin_user_id: str
+    target_user_id: str
+    target_org_id: str
+    target_role: str
+    target_email: str | None
+    expires_at: datetime
+
+
+def _key(admin_user_id: str) -> str:
+    return f"{_KEY_PREFIX}{admin_user_id}"
+
+
+def _get_client() -> Any | None:
+    """Lazily create the shared Valkey client; None when unconfigured."""
+    global _client
+    if _client is not None:
+        return _client
+    redis_url = os.getenv("REDIS_URL", "")
+    if not redis_url:
+        return None
+    import valkey.asyncio as aioredis
+
+    _client = aioredis.from_url(
+        redis_url,
+        socket_connect_timeout=0.5,
+        socket_timeout=0.5,
+    )
+    return _client
+
+
+def _circuit_is_open() -> bool:
+    return time.monotonic() < _circuit_open_until
+
+
+def _trip_circuit(exc: Exception) -> None:
+    global _circuit_open_until
+    _circuit_open_until = time.monotonic() + _CIRCUIT_SECONDS
+    logger.warning(
+        "Valkey impersonation cache unavailable, bypassing for %.0fs: %s",
+        _CIRCUIT_SECONDS,
+        exc,
+    )
+
+
+def _serialize(session: CachedImpersonationSession | None) -> bytes:
+    if session is None:
+        return _NONE_SENTINEL
+    return json.dumps(
+        {
+            "id": session.id,
+            "admin_user_id": session.admin_user_id,
+            "target_user_id": session.target_user_id,
+            "target_org_id": session.target_org_id,
+            "target_role": session.target_role,
+            "target_email": session.target_email,
+            "expires_at": session.expires_at.isoformat(),
+        }
+    ).encode()
+
+
+def _deserialize(raw: bytes) -> CachedImpersonationSession | None:
+    if raw == _NONE_SENTINEL:
+        return None
+    data = json.loads(raw)
+    return CachedImpersonationSession(
+        id=data["id"],
+        admin_user_id=data["admin_user_id"],
+        target_user_id=data["target_user_id"],
+        target_org_id=data["target_org_id"],
+        target_role=data["target_role"],
+        target_email=data.get("target_email"),
+        expires_at=datetime.fromisoformat(data["expires_at"]),
+    )
+
+
+async def _cache_get(admin_user_id: str) -> Any:
+    """Return the cached value, or _MISS when absent/unavailable."""
+    client = _get_client()
+    if client is None or _circuit_is_open():
+        return _MISS
+    try:
+        raw = await client.get(_key(admin_user_id))
+    except Exception as exc:
+        _trip_circuit(exc)
+        return _MISS
+    if raw is None:
+        return _MISS
+    try:
+        return _deserialize(raw)
+    except Exception:
+        logger.warning("Corrupt impersonation cache entry for %s", admin_user_id)
+        return _MISS
+
+
+async def _cache_set(
+    admin_user_id: str, session: CachedImpersonationSession | None
+) -> None:
+    client = _get_client()
+    if client is None or _circuit_is_open():
+        return
+    try:
+        await client.set(_key(admin_user_id), _serialize(session), ex=_TTL_SECONDS)
+    except Exception as exc:
+        _trip_circuit(exc)
+
+
+async def get_active_session(
+    admin_user_id: str,
+) -> CachedImpersonationSession | None:
+    """Return the active impersonation session for admin_user_id, or None.
+
+    Checks the shared Valkey cache first; falls back to Postgres on miss or
+    Valkey outage. Returns None when no session is active or both stores are
+    unavailable (fail-open: impersonation does not activate).
+    """
+    cached = await _cache_get(admin_user_id)
+    if cached is not _MISS:
+        return cached
+
     session = await _load_from_db(admin_user_id)
-    _cache[admin_user_id] = (session, time.monotonic() + _TTL_SECONDS)
+    await _cache_set(admin_user_id, session)
     return session
 
 
-async def _load_from_db(admin_user_id: str) -> ImpersonationSession | None:
+async def _load_from_db(admin_user_id: str) -> CachedImpersonationSession | None:
     """Query Postgres for an active impersonation session. Fail-open on error."""
     try:
-        from datetime import datetime, timezone
+        from datetime import timezone
 
         from sqlalchemy import select
 
         from dev_health_ops.db import get_postgres_session
         from dev_health_ops.models.impersonation import ImpersonationSession
+        from dev_health_ops.models.users import User
 
         async with get_postgres_session() as session:
             now = datetime.now(timezone.utc)
             stmt = (
-                select(ImpersonationSession)
+                select(ImpersonationSession, User.email)
+                .join(User, User.id == ImpersonationSession.target_user_id)
                 .where(ImpersonationSession.admin_user_id == admin_user_id)
                 .where(ImpersonationSession.ended_at.is_(None))
                 .where(ImpersonationSession.expires_at > now)
                 .limit(1)
             )
             result = await session.execute(stmt)
-            return result.scalar_one_or_none()
+            row = result.first()
+            if row is None:
+                return None
+            record, target_email = row
+            return CachedImpersonationSession(
+                id=str(record.id),
+                admin_user_id=str(record.admin_user_id),
+                target_user_id=str(record.target_user_id),
+                target_org_id=str(record.target_org_id),
+                target_role=str(record.target_role),
+                target_email=str(target_email) if target_email else None,
+                expires_at=record.expires_at,
+            )
     except Exception:
         # Fail-open: if DB is unavailable, impersonation doesn't activate
         return None
 
 
-def invalidate(admin_user_id: str) -> None:
-    """Remove the cached entry for admin_user_id (call after start/stop)."""
-    _cache.pop(admin_user_id, None)
+async def invalidate(admin_user_id: str) -> None:
+    """Remove the shared cache entry for admin_user_id (call after start/stop).
+
+    Callers must COMMIT their transaction before invalidating — otherwise a
+    racing reader can re-fill the shared cache from the pre-commit DB state
+    and re-poison every replica for up to the TTL.
+    """
+    client = _get_client()
+    if client is None or _circuit_is_open():
+        return
+    try:
+        await client.delete(_key(admin_user_id))
+    except Exception as exc:
+        # Stale entries now survive at most _TTL_SECONDS — log loudly.
+        _trip_circuit(exc)
+        logger.error(
+            "Failed to invalidate impersonation cache for %s — replicas may "
+            "serve stale impersonation context for up to %ss",
+            admin_user_id,
+            _TTL_SECONDS,
+        )

--- a/tests/api/admin/test_impersonation_endpoints.py
+++ b/tests/api/admin/test_impersonation_endpoints.py
@@ -24,6 +24,7 @@ from dev_health_ops.api.admin import impersonation as _imp_mod
 from dev_health_ops.api.admin.impersonation import get_db_session, router
 from dev_health_ops.api.auth.router import get_current_user
 from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.services.impersonation_cache import CachedImpersonationSession
 
 # ---------------------------------------------------------------------------
 # Helpers — fake DB row factories
@@ -125,7 +126,8 @@ async def test_client(monkeypatch):
     async def _fake_current_user():
         return admin_state["user"]
 
-    mock_invalidate = MagicMock()
+    # invalidate() is async since the Valkey-backed cache (CHAOS-2328)
+    mock_invalidate = AsyncMock()
     monkeypatch.setattr(_imp_mod, "invalidate", mock_invalidate)
 
     app.dependency_overrides[get_db_session] = _fake_db
@@ -314,6 +316,29 @@ async def test_stop_happy_path_returns_stopped_status(test_client):
 
 
 @pytest.mark.asyncio
+async def test_stop_commits_before_invalidating_cache(test_client):
+    """COMMIT must land before the shared-cache DEL (CHAOS-2328).
+
+    If the DEL ran first, a racing reader could re-fill the Valkey cache from
+    the still-uncommitted DB state (session active) and re-poison every
+    replica for up to the cache TTL.
+    """
+    client, session, admin_state, mock_invalidate = test_client
+    admin_id = uuid.UUID(admin_state["user"].user_id)
+    active = _make_session_row(admin_id, uuid.uuid4(), uuid.uuid4())
+    session.execute.side_effect = [_FakeResult(one=active)]
+
+    order: list[str] = []
+    session.commit.side_effect = lambda: order.append("commit")
+    mock_invalidate.side_effect = lambda *_: order.append("invalidate")
+
+    resp = await client.post("/api/v1/admin/impersonate/stop")
+
+    assert resp.status_code == 200
+    assert order[:2] == ["commit", "invalidate"]
+
+
+@pytest.mark.asyncio
 async def test_stop_no_active_session_returns_400(test_client):
     """Returns 400 when there is no active session to stop."""
     client, session, _, _ = test_client
@@ -346,21 +371,36 @@ async def test_stop_marks_session_ended_at(test_client):
 # ---------------------------------------------------------------------------
 
 
+def _make_cached(
+    admin_id: uuid.UUID,
+    target_id: uuid.UUID,
+    target_org: uuid.UUID,
+    role: str = "member",
+    *,
+    target_email: str | None = "target@example.com",
+    expires_in: timedelta = timedelta(hours=1),
+) -> CachedImpersonationSession:
+    return CachedImpersonationSession(
+        id=str(uuid.uuid4()),
+        admin_user_id=str(admin_id),
+        target_user_id=str(target_id),
+        target_org_id=str(target_org),
+        target_role=role,
+        target_email=target_email,
+        expires_at=datetime.now(timezone.utc) + expires_in,
+    )
+
+
 @pytest.mark.asyncio
-async def test_status_when_impersonating_returns_true(test_client):
-    """Returns is_impersonating=true with target details when session is active."""
+async def test_status_when_impersonating_returns_true(test_client, monkeypatch):
+    """Returns is_impersonating=true with target details from the shared cache."""
     client, session, admin_state, _ = test_client
     admin_id = uuid.UUID(admin_state["user"].user_id)
     target_id = uuid.uuid4()
     target_org = uuid.uuid4()
 
-    active = _make_session_row(admin_id, target_id, target_org, "viewer")
-    target_user = _make_user(target_id, "target@example.com")
-
-    session.execute.side_effect = [
-        _FakeResult(one=active),
-        _FakeResult(one=target_user),
-    ]
+    cached = _make_cached(admin_id, target_id, target_org, "viewer")
+    monkeypatch.setattr(_imp_mod, "get_active_session", AsyncMock(return_value=cached))
 
     resp = await client.get("/api/v1/admin/impersonate/status")
 
@@ -371,13 +411,15 @@ async def test_status_when_impersonating_returns_true(test_client):
     assert body["target_org_id"] == str(target_org)
     assert body["target_email"] == "target@example.com"
     assert body["expires_at"] is not None
+    # The hot path must not touch Postgres (CHAOS-2328)
+    session.execute.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_status_when_not_impersonating_returns_false(test_client):
+async def test_status_when_not_impersonating_returns_false(test_client, monkeypatch):
     """Returns is_impersonating=false when no active session exists."""
     client, session, _, _ = test_client
-    session.execute.side_effect = [_FakeResult(one=None)]
+    monkeypatch.setattr(_imp_mod, "get_active_session", AsyncMock(return_value=None))
 
     resp = await client.get("/api/v1/admin/impersonate/status")
 
@@ -385,6 +427,23 @@ async def test_status_when_not_impersonating_returns_false(test_client):
     body = resp.json()
     assert body["is_impersonating"] is False
     assert body.get("target_user_id") is None
+
+
+@pytest.mark.asyncio
+async def test_status_expired_cached_session_returns_false(test_client, monkeypatch):
+    """A cached session past its expires_at reads as not impersonating."""
+    client, _, admin_state, _ = test_client
+    admin_id = uuid.UUID(admin_state["user"].user_id)
+
+    expired = _make_cached(
+        admin_id, uuid.uuid4(), uuid.uuid4(), expires_in=timedelta(seconds=-5)
+    )
+    monkeypatch.setattr(_imp_mod, "get_active_session", AsyncMock(return_value=expired))
+
+    resp = await client.get("/api/v1/admin/impersonate/status")
+
+    assert resp.status_code == 200
+    assert resp.json()["is_impersonating"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_impersonation_endpoints.py
+++ b/tests/api/admin/test_impersonation_endpoints.py
@@ -126,16 +126,17 @@ async def test_client(monkeypatch):
     async def _fake_current_user():
         return admin_state["user"]
 
-    # invalidate() is async since the Valkey-backed cache (CHAOS-2328)
-    mock_invalidate = AsyncMock()
-    monkeypatch.setattr(_imp_mod, "invalidate", mock_invalidate)
+    # Endpoints write the authoritative state through to the shared Valkey
+    # cache after COMMIT (CHAOS-2328)
+    mock_set_active = AsyncMock()
+    monkeypatch.setattr(_imp_mod, "set_active_session", mock_set_active)
 
     app.dependency_overrides[get_db_session] = _fake_db
     app.dependency_overrides[get_current_user] = _fake_current_user
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        yield client, db_session, admin_state, mock_invalidate
+        yield client, db_session, admin_state, mock_set_active
 
     app.dependency_overrides.clear()
 
@@ -268,9 +269,9 @@ async def test_start_target_no_membership_returns_404(test_client):
 
 
 @pytest.mark.asyncio
-async def test_start_invalidates_cache(test_client):
-    """Cache invalidate() is called with the admin's user_id on success."""
-    client, session, admin_state, mock_invalidate = test_client
+async def test_start_writes_authoritative_state_through_cache(test_client):
+    """set_active_session() receives the new snapshot for this admin on success."""
+    client, session, admin_state, mock_set_active = test_client
     admin_org = uuid.UUID(admin_state["user"].org_id)
     target_id = uuid.uuid4()
 
@@ -286,7 +287,11 @@ async def test_start_invalidates_cache(test_client):
     )
 
     assert resp.status_code == 200
-    mock_invalidate.assert_called_once_with(admin_state["user"].user_id)
+    mock_set_active.assert_called_once()
+    args = mock_set_active.call_args.args
+    assert args[0] == admin_state["user"].user_id
+    assert args[1] is not None
+    assert args[1].target_user_id == str(target_id)
 
 
 # ---------------------------------------------------------------------------
@@ -297,7 +302,7 @@ async def test_start_invalidates_cache(test_client):
 @pytest.mark.asyncio
 async def test_stop_happy_path_returns_stopped_status(test_client):
     """Returns {"status": "stopped"} when an active session exists."""
-    client, session, admin_state, mock_invalidate = test_client
+    client, session, admin_state, mock_set_active = test_client
     admin_id = uuid.UUID(admin_state["user"].user_id)
     target_id = uuid.uuid4()
     target_org = uuid.uuid4()
@@ -312,30 +317,29 @@ async def test_stop_happy_path_returns_stopped_status(test_client):
     assert body["status"] == "stopped"
     # No JWT token emitted
     assert "access_token" not in body
-    mock_invalidate.assert_called_once_with(admin_state["user"].user_id)
+    mock_set_active.assert_called_once_with(admin_state["user"].user_id, None)
 
 
 @pytest.mark.asyncio
-async def test_stop_commits_before_invalidating_cache(test_client):
-    """COMMIT must land before the shared-cache DEL (CHAOS-2328).
+async def test_stop_commits_before_cache_write_through(test_client):
+    """COMMIT must land before the shared-cache write-through (CHAOS-2328).
 
-    If the DEL ran first, a racing reader could re-fill the Valkey cache from
-    the still-uncommitted DB state (session active) and re-poison every
-    replica for up to the cache TTL.
+    Writing pre-commit state (or deleting before commit) would let stale
+    impersonation state reach every replica for up to the cache TTL.
     """
-    client, session, admin_state, mock_invalidate = test_client
+    client, session, admin_state, mock_set_active = test_client
     admin_id = uuid.UUID(admin_state["user"].user_id)
     active = _make_session_row(admin_id, uuid.uuid4(), uuid.uuid4())
     session.execute.side_effect = [_FakeResult(one=active)]
 
     order: list[str] = []
     session.commit.side_effect = lambda: order.append("commit")
-    mock_invalidate.side_effect = lambda *_: order.append("invalidate")
+    mock_set_active.side_effect = lambda *_: order.append("write_through")
 
     resp = await client.post("/api/v1/admin/impersonate/stop")
 
     assert resp.status_code == 200
-    assert order[:2] == ["commit", "invalidate"]
+    assert order[:2] == ["commit", "write_through"]
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_impersonation_cache.py
+++ b/tests/api/test_impersonation_cache.py
@@ -1,0 +1,190 @@
+"""Tests for the Valkey-backed impersonation session cache (CHAOS-2328).
+
+Uses fakeredis (FakeAsyncValkey) so the shared-store semantics — the whole
+point of the migration away from the per-process dict — can be exercised:
+an invalidate issued through ONE client connection must be observed by every
+other client of the same store, which is how api replicas/workers share it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis")
+
+from dev_health_ops.api.services import impersonation_cache as cache  # noqa: E402
+from dev_health_ops.api.services.impersonation_cache import (  # noqa: E402
+    CachedImpersonationSession,
+    get_active_session,
+    invalidate,
+)
+
+
+def _make_cached(admin_id: str | None = None) -> CachedImpersonationSession:
+    return CachedImpersonationSession(
+        id=str(uuid.uuid4()),
+        admin_user_id=admin_id or str(uuid.uuid4()),
+        target_user_id=str(uuid.uuid4()),
+        target_org_id=str(uuid.uuid4()),
+        target_role="member",
+        target_email="target@example.com",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+
+@pytest.fixture
+def shared_server():
+    return fakeredis.FakeServer()
+
+
+@pytest.fixture
+def valkey_client(shared_server, monkeypatch):
+    """Wire the module's client to a fakeredis store and reset the circuit."""
+    client = fakeredis.FakeAsyncValkey(server=shared_server)
+    monkeypatch.setattr(cache, "_client", client)
+    monkeypatch.setattr(cache, "_circuit_open_until", 0.0)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_positive_result_is_cached(valkey_client, monkeypatch):
+    """A DB-loaded session is served from Valkey on subsequent lookups."""
+    session = _make_cached()
+    loader = AsyncMock(return_value=session)
+    monkeypatch.setattr(cache, "_load_from_db", loader)
+
+    first = await get_active_session(session.admin_user_id)
+    second = await get_active_session(session.admin_user_id)
+
+    assert first == session
+    assert second == session
+    loader.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_negative_result_is_cached(valkey_client, monkeypatch):
+    """'No active session' is cached too — the common case for superusers."""
+    loader = AsyncMock(return_value=None)
+    monkeypatch.setattr(cache, "_load_from_db", loader)
+    admin_id = str(uuid.uuid4())
+
+    assert await get_active_session(admin_id) is None
+    assert await get_active_session(admin_id) is None
+    loader.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_invalidate_forces_db_reload(valkey_client, monkeypatch):
+    """After invalidate(), the next lookup goes back to Postgres."""
+    session = _make_cached()
+    loader = AsyncMock(return_value=session)
+    monkeypatch.setattr(cache, "_load_from_db", loader)
+
+    await get_active_session(session.admin_user_id)
+    await invalidate(session.admin_user_id)
+    await get_active_session(session.admin_user_id)
+
+    assert loader.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_invalidate_is_observed_across_clients(
+    shared_server, valkey_client, monkeypatch
+):
+    """A DEL through another client of the same store is seen here.
+
+    This is the CHAOS-2328 regression: with the old per-process dict, a stop
+    handled by one replica left every other replica serving the stale session
+    for up to 30s. With a shared store there is exactly one entry to delete.
+    """
+    session = _make_cached()
+    loader = AsyncMock(return_value=session)
+    monkeypatch.setattr(cache, "_load_from_db", loader)
+
+    # Replica A fills the cache
+    assert await get_active_session(session.admin_user_id) == session
+    loader.assert_awaited_once()
+
+    # "Replica B" (a second connection to the same store) handles the stop
+    other_client = fakeredis.FakeAsyncValkey(server=shared_server)
+    monkeypatch.setattr(cache, "_client", other_client)
+    await invalidate(session.admin_user_id)
+
+    # Replica A's next lookup misses and reloads from Postgres
+    monkeypatch.setattr(cache, "_client", valkey_client)
+    loader.return_value = None
+    assert await get_active_session(session.admin_user_id) is None
+    assert loader.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_valkey_outage_falls_back_to_db_and_trips_circuit(monkeypatch):
+    """Valkey errors bypass the cache (fail-correct) and open the circuit."""
+
+    class _BrokenClient:
+        calls = 0
+
+        async def get(self, *_args):
+            _BrokenClient.calls += 1
+            raise ConnectionError("valkey down")
+
+        async def set(self, *_args, **_kwargs):
+            raise ConnectionError("valkey down")
+
+        async def delete(self, *_args):
+            raise ConnectionError("valkey down")
+
+    monkeypatch.setattr(cache, "_client", _BrokenClient())
+    monkeypatch.setattr(cache, "_circuit_open_until", 0.0)
+    session = _make_cached()
+    loader = AsyncMock(return_value=session)
+    monkeypatch.setattr(cache, "_load_from_db", loader)
+
+    # Both lookups still resolve correctly from Postgres
+    assert await get_active_session(session.admin_user_id) == session
+    assert await get_active_session(session.admin_user_id) == session
+    assert loader.await_count == 2
+
+    # The circuit tripped on the first error: only one client.get attempt
+    assert _BrokenClient.calls == 1
+
+    # invalidate() during the open circuit must not raise
+    await invalidate(session.admin_user_id)
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_valkey_goes_straight_to_db(monkeypatch):
+    """Without REDIS_URL there is no cache — every lookup hits Postgres."""
+    monkeypatch.setattr(cache, "_client", None)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.setattr(cache, "_circuit_open_until", 0.0)
+    session = _make_cached()
+    loader = AsyncMock(return_value=session)
+    monkeypatch.setattr(cache, "_load_from_db", loader)
+
+    assert await get_active_session(session.admin_user_id) == session
+    assert await get_active_session(session.admin_user_id) == session
+    assert loader.await_count == 2
+
+
+def test_serialization_round_trip_preserves_fields():
+    """JSON round-trip keeps every field, tz-aware datetime included."""
+    session = _make_cached()
+    assert cache._deserialize(cache._serialize(session)) == session
+
+    no_email = CachedImpersonationSession(
+        id=session.id,
+        admin_user_id=session.admin_user_id,
+        target_user_id=session.target_user_id,
+        target_org_id=session.target_org_id,
+        target_role=session.target_role,
+        target_email=None,
+        expires_at=session.expires_at,
+    )
+    assert cache._deserialize(cache._serialize(no_email)) == no_email
+
+    assert cache._deserialize(cache._serialize(None)) is None

--- a/tests/api/test_impersonation_cache.py
+++ b/tests/api/test_impersonation_cache.py
@@ -21,6 +21,7 @@ from dev_health_ops.api.services.impersonation_cache import (  # noqa: E402
     CachedImpersonationSession,
     get_active_session,
     invalidate,
+    set_active_session,
 )
 
 
@@ -169,6 +170,71 @@ async def test_unconfigured_valkey_goes_straight_to_db(monkeypatch):
     assert await get_active_session(session.admin_user_id) == session
     assert await get_active_session(session.admin_user_id) == session
     assert loader.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_write_through_serves_new_state_without_db(valkey_client, monkeypatch):
+    """set_active_session() makes the new state readable with zero DB loads."""
+    loader = AsyncMock(return_value=None)
+    monkeypatch.setattr(cache, "_load_from_db", loader)
+    session = _make_cached()
+
+    await set_active_session(session.admin_user_id, session)
+    assert await get_active_session(session.admin_user_id) == session
+
+    await set_active_session(session.admin_user_id, None)
+    assert await get_active_session(session.admin_user_id) is None
+
+    loader.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_db_errors_are_never_cached(valkey_client, monkeypatch):
+    """A transient Postgres failure must not be cached as 'no session'.
+
+    Codex finding: caching the failure as the negative sentinel would
+    disable an actually active impersonation on every replica for a TTL.
+    """
+    session = _make_cached()
+    loader = AsyncMock(side_effect=[cache._DB_ERROR, session])
+    monkeypatch.setattr(cache, "_load_from_db", loader)
+
+    # Failed load → fail-open None, but NOT cached
+    assert await get_active_session(session.admin_user_id) is None
+    # Next lookup retries the DB and succeeds
+    assert await get_active_session(session.admin_user_id) == session
+    assert loader.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_invalidate_and_write_through_ignore_open_circuit(
+    shared_server, valkey_client, monkeypatch
+):
+    """Cache writes that keep replicas correct must not be skipped by the
+    read-path circuit breaker.
+
+    Codex finding: skipping the DEL/SET because an earlier READ failed lets a
+    stale entry resurface once the circuit closes.
+    """
+    session = _make_cached()
+    loader = AsyncMock(return_value=session)
+    monkeypatch.setattr(cache, "_load_from_db", loader)
+
+    # Fill the cache, then trip the circuit as a read error would
+    await get_active_session(session.admin_user_id)
+    monkeypatch.setattr(
+        cache, "_circuit_open_until", __import__("time").monotonic() + 60
+    )
+
+    # The stop's write-through must still reach the shared store
+    await set_active_session(session.admin_user_id, None)
+
+    # A fresh process (closed circuit) must see the new state, not the stale one
+    other = fakeredis.FakeAsyncValkey(server=shared_server)
+    monkeypatch.setattr(cache, "_client", other)
+    monkeypatch.setattr(cache, "_circuit_open_until", 0.0)
+    assert await get_active_session(session.admin_user_id) is None
+    loader.assert_awaited_once()  # only the initial fill
 
 
 def test_serialization_round_trip_preserves_fields():

--- a/tests/api/test_impersonation_middleware.py
+++ b/tests/api/test_impersonation_middleware.py
@@ -7,7 +7,6 @@ tests operate directly on contextvars and the in-memory cache module.
 from __future__ import annotations
 
 import contextvars
-import time
 import types
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -25,7 +24,9 @@ from dev_health_ops.api.services.auth import (
     is_impersonating,
     set_impersonation_context,
 )
-from dev_health_ops.api.services.impersonation_cache import _cache, invalidate
+
+# Cache behaviour (shared Valkey store) is covered in
+# tests/api/test_impersonation_cache.py.
 
 # ---------------------------------------------------------------------------
 # Contextvar: is_impersonating
@@ -154,32 +155,6 @@ def test_impersonation_contextvar_isolation_between_contexts():
         assert ctx_after.target_user_id == "user-main"
     finally:
         _impersonation_ctx.set(None)
-
-
-# ---------------------------------------------------------------------------
-# Cache: invalidate
-# ---------------------------------------------------------------------------
-
-
-def test_invalidate_removes_existing_cache_entry():
-    """invalidate() removes a cached entry for the given admin_user_id."""
-    admin_id = "test-admin-cache-entry"
-    try:
-        _cache[admin_id] = (None, time.monotonic() + 30.0)
-        assert admin_id in _cache
-        invalidate(admin_id)
-        assert admin_id not in _cache
-    finally:
-        _cache.pop(admin_id, None)
-
-
-def test_invalidate_nonexistent_key_is_silent_noop():
-    """invalidate() does not raise when key is absent from cache."""
-    admin_id = "ghost-admin-id"
-    assert admin_id not in _cache
-    # Must not raise
-    invalidate(admin_id)
-    assert admin_id not in _cache
 
 
 def test_is_impersonating_false_after_context_reset():

--- a/tests/test_impersonation.py
+++ b/tests/test_impersonation.py
@@ -104,16 +104,17 @@ async def test_client(monkeypatch):
     async def _override_current_user():
         return current["user"]
 
-    # invalidate() is async since the Valkey-backed cache (CHAOS-2328)
-    mock_invalidate = AsyncMock()
-    monkeypatch.setattr(_imp_mod, "invalidate", mock_invalidate)
+    # Endpoints write the authoritative state through to the shared Valkey
+    # cache after COMMIT (CHAOS-2328)
+    mock_set_active = AsyncMock()
+    monkeypatch.setattr(_imp_mod, "set_active_session", mock_set_active)
 
     app.dependency_overrides[get_db_session] = _override_db_session
     app.dependency_overrides[get_current_user] = _override_current_user
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        yield client, session, current, mock_invalidate
+        yield client, session, current, mock_set_active
 
     app.dependency_overrides.clear()
 
@@ -125,7 +126,7 @@ async def test_client(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_start_impersonation_superuser_can_impersonate_member(test_client):
-    client, session, current, mock_invalidate = test_client
+    client, session, current, mock_set_active = test_client
     admin_org_id = uuid.UUID(current["user"].org_id)
     target_id = uuid.uuid4()
 
@@ -257,8 +258,8 @@ async def test_start_impersonation_no_membership(test_client):
 
 
 @pytest.mark.asyncio
-async def test_start_impersonation_invalidates_cache(test_client):
-    client, session, current, mock_invalidate = test_client
+async def test_start_impersonation_writes_through_cache(test_client):
+    client, session, current, mock_set_active = test_client
     admin_org_id = uuid.UUID(current["user"].org_id)
     target_id = uuid.uuid4()
 
@@ -274,7 +275,11 @@ async def test_start_impersonation_invalidates_cache(test_client):
     )
 
     assert resp.status_code == 200
-    mock_invalidate.assert_called_once_with(current["user"].user_id)
+    mock_set_active.assert_called_once()
+    args = mock_set_active.call_args.args
+    assert args[0] == current["user"].user_id
+    assert args[1] is not None
+    assert args[1].target_user_id == str(target_id)
 
 
 @pytest.mark.asyncio
@@ -306,7 +311,7 @@ async def test_start_impersonation_creates_session_row(test_client):
 
 @pytest.mark.asyncio
 async def test_stop_impersonation_works(test_client):
-    client, session, current, mock_invalidate = test_client
+    client, session, current, mock_set_active = test_client
     admin_id = uuid.UUID(current["user"].user_id)
     target_id = uuid.uuid4()
     target_org_id = uuid.uuid4()
@@ -320,7 +325,7 @@ async def test_stop_impersonation_works(test_client):
     body = resp.json()
     assert body["status"] == "stopped"
     assert "access_token" not in body
-    mock_invalidate.assert_called_once_with(current["user"].user_id)
+    mock_set_active.assert_called_once_with(current["user"].user_id, None)
 
 
 @pytest.mark.asyncio

--- a/tests/test_impersonation.py
+++ b/tests/test_impersonation.py
@@ -14,6 +14,7 @@ from dev_health_ops.api.admin import impersonation as _imp_mod
 from dev_health_ops.api.admin.impersonation import get_db_session, router
 from dev_health_ops.api.auth.router import get_current_user
 from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.services.impersonation_cache import CachedImpersonationSession
 
 
 def _user(
@@ -103,7 +104,8 @@ async def test_client(monkeypatch):
     async def _override_current_user():
         return current["user"]
 
-    mock_invalidate = MagicMock()
+    # invalidate() is async since the Valkey-backed cache (CHAOS-2328)
+    mock_invalidate = AsyncMock()
     monkeypatch.setattr(_imp_mod, "invalidate", mock_invalidate)
 
     app.dependency_overrides[get_db_session] = _override_db_session
@@ -406,19 +408,23 @@ async def test_status_superuser_with_no_active_session(test_client):
 
 
 @pytest.mark.asyncio
-async def test_status_superuser_with_active_session(test_client):
+async def test_status_superuser_with_active_session(test_client, monkeypatch):
     client, session, current, _ = test_client
     admin_id = uuid.UUID(current["user"].user_id)
     target_id = uuid.uuid4()
     target_org_id = uuid.uuid4()
 
-    active = _impersonation_session(admin_id, target_id, target_org_id, "viewer")
-    target = _user(target_id, "target@example.com")
-
-    session.execute.side_effect = [
-        _FakeResult(one=active),
-        _FakeResult(one=target),
-    ]
+    # Status reads through the shared Valkey cache (CHAOS-2328), not the DB.
+    cached = CachedImpersonationSession(
+        id=str(uuid.uuid4()),
+        admin_user_id=str(admin_id),
+        target_user_id=str(target_id),
+        target_org_id=str(target_org_id),
+        target_role="viewer",
+        target_email="target@example.com",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    monkeypatch.setattr(_imp_mod, "get_active_session", AsyncMock(return_value=cached))
 
     resp = await client.get("/api/v1/admin/impersonate/status")
 


### PR DESCRIPTION
Implements CHAOS-2328 (ops half; web PR follows).

## Problem

`impersonation_cache.py` was a **per-process dict** with a 30s TTL. Stop/start invalidated only the worker that handled the request — with multiple api replicas/workers (prod) every other process kept serving the stale impersonation context (wrong-org scoping via `ImpersonationMiddleware`) for up to 30s. Locally invisible (single `--reload` worker); in k8s with replicas it's a correctness bug.

## Change

- **Valkey-backed shared cache** (`REDIS_URL`, already on the api Deployment): plain `CachedImpersonationSession` snapshots (JSON, tz-aware datetimes, denormalized `target_email`), negative caching for the no-session common case, 0.5s socket bounds + 5s circuit breaker on the read path.
- **Write-through after COMMIT**: start/stop commit their transaction (audit row included, atomic as before) and then `SET` the authoritative state — not just `DEL`. Ordering closes the "racing reader re-fills from pre-commit DB state" poison; write-through closes the cold-miss window and shrinks the load-after-DEL race to a reader suspended across the whole endpoint transaction (residual bounded by the 30s TTL).
- **Status endpoint reads through the cache** — zero Postgres on the hot path (the web frontend polls it per superuser request now); expiry double-checked.
- **Fail-correct, never fail-stale**: Valkey outage bypasses the cache straight to Postgres; **DB errors are never cached** (a transient PG error must not read as "not impersonating" replica-wide for a TTL); cache **writes ignore the read circuit breaker** (skipping the SET/DEL because an earlier read failed would let a stale entry resurface).
- Middleware expiry: `UPDATE … WHERE id = :id AND ended_at IS NULL` (cache snapshots have no ORM identity); `invalidate()` is async.

## Codex adversarial review

Initial verdict BLOCK — all four HIGHs addressed in the follow-up commit (DB-error-not-cached, write-ignores-circuit, write-through vs load-after-DEL, audit back inside the transaction). MEDIUMs: status-hot-path wording corrected here (cache *misses* still hit PG by design); circuit-breaker stampede accepted (per-process 0.5s bound at outage onset, superuser-only traffic). Reports: `/tmp/claude/codex-review-ops-valkey-impersonation.md`.

## Verification

- 57 impersonation tests incl. a fakeredis suite: cross-client invalidation (the replica regression), write-through-without-DB, DB-error-not-cached, circuit-ignoring writes, commit-before-write-through ordering, serialization round-trip
- `mypy` clean (1028 files); full unit suite green
- **Live multi-worker proof**: api run with `--workers 2` (compose override) — impersonate → 10× status true; stop → immediately 20× status false and 0/10 stale `x-impersonating` headers across both workers. Valkey key inspected directly: snapshot on start, `none` sentinel on stop.
