### PR TITLE
fix(org-deletion): stop deleting ClickHouse `teams` table on the Postgres session

### DIFF
--- a/docs/architecture/database-architecture.md
+++ b/docs/architecture/database-architecture.md
@@ -52,7 +52,7 @@ SQLite via `aiosqlite` remains allowed only for test fixtures and local-only eph
 |---------|---------|-------|
 | User management | PostgreSQL | Semantic layer |
 | Organization settings | PostgreSQL | Semantic layer |
-| Team configuration | PostgreSQL | Semantic layer |
+| Team mapping config (`team_mappings`) | PostgreSQL | Semantic layer (the `teams` entity itself is ClickHouse) |
 | Authentication | PostgreSQL | Semantic layer |
 
 ## Environment Variables
@@ -114,6 +114,7 @@ Stores time-series and event data optimized for:
 | `repo_metrics_daily` | Daily repository metrics |
 | `user_metrics_daily` | Daily per-user metrics |
 | `team_metrics_daily` | Daily team aggregates |
+| `teams` | Team entities (members; consumed by metrics & attribution) |
 | `work_item_metrics_daily` | Work item throughput metrics |
 
 ## CLI Command Routing
@@ -131,7 +132,7 @@ Commands automatically use the appropriate database:
 | `sync git` | ClickHouse | Git data ingestion |
 | `sync prs` | ClickHouse | PR data ingestion |
 | `sync work-items` | ClickHouse | Work item ingestion |
-| `sync teams` | PostgreSQL | Team config (semantic) |
+| `sync teams` | Both | Drift/mapping → `team_mappings` (Postgres); team entities → `teams` (ClickHouse) |
 | `metrics daily` | ClickHouse | Metrics computation |
 | `metrics dora` | ClickHouse | DORA metrics |
 | `api` | Both | Serves both layers |

--- a/src/dev_health_ops/api/services/org_deletion.py
+++ b/src/dev_health_ops/api/services/org_deletion.py
@@ -42,7 +42,6 @@ from dev_health_ops.models.settings import (
 )
 from dev_health_ops.models.sso import SSOProvider
 from dev_health_ops.models.subscriptions import Subscription, SubscriptionEvent
-from dev_health_ops.models.teams import Team
 from dev_health_ops.models.users import Membership, Organization
 
 logger = logging.getLogger(__name__)
@@ -267,9 +266,11 @@ def _postgres_targets() -> list[PostgresDeletionTarget]:
             ImpersonationSession,
             lambda org_uuid, _org_id: ImpersonationSession.target_org_id == org_uuid,
         ),
-        PostgresDeletionTarget(
-            "teams", Team, lambda _org_uuid, org_id: Team.org_id == org_id
-        ),
+        # NOTE: the `teams` entity is a ClickHouse analytics table (used in
+        # metrics), not a Postgres semantic table. It is org-scoped-purged via
+        # `_purge_clickhouse` (migration 024 adds its org_id column). Do NOT add
+        # a `teams` PostgresDeletionTarget here — it lives in a different layer.
+        # The Postgres semantic team config is `team_mappings`, handled below.
         PostgresDeletionTarget(
             "team_mappings",
             TeamMapping,

--- a/tests/api/admin/test_org_deletion.py
+++ b/tests/api/admin/test_org_deletion.py
@@ -13,7 +13,11 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.services.auth import AuthenticatedUser
-from dev_health_ops.api.services.org_deletion import OrganizationDeletionService
+from dev_health_ops.api.services.org_deletion import (
+    OrganizationDeletionService,
+    _clickhouse_tables_from_migrations,
+    _postgres_targets,
+)
 from dev_health_ops.models.audit import AuditLog
 from dev_health_ops.models.backfill import BackfillJob
 from dev_health_ops.models.billing import BillingPlan, BillingPrice
@@ -41,7 +45,6 @@ from dev_health_ops.models.settings import (
 )
 from dev_health_ops.models.sso import SSOProvider
 from dev_health_ops.models.subscriptions import Subscription, SubscriptionEvent
-from dev_health_ops.models.teams import Team
 from dev_health_ops.models.users import Membership, Organization, User
 from tests._helpers import tables_of
 
@@ -71,7 +74,6 @@ _TABLES = tables_of(
     RefreshToken,
     MetricCheckpoint,
     ImpersonationSession,
-    Team,
     Subscription,
     SubscriptionEvent,
     Invoice,
@@ -202,8 +204,6 @@ async def _seed_org_pair(session: AsyncSession) -> tuple[str, str]:
                 protocol="saml",
                 encrypted_secrets={"certificate": "encrypted-cert"},
             ),
-            Team(id="team-one", org_id=str(org1_id), name="Team One"),
-            Team(id="team-two", org_id=str(org2_id), name="Team Two"),
             job1,
             job2,
             JobRun(job_id=job1.id),
@@ -327,7 +327,6 @@ async def test_org_deletion_deletes_only_target_org_and_sanitizes_logs(
         assert (
             await _row_count(session, ScheduledJob, ScheduledJob.org_id == org1_id) == 0
         )
-        assert await _row_count(session, Team, Team.org_id == org1_id) == 0
 
         assert (
             await _row_count(
@@ -345,7 +344,6 @@ async def test_org_deletion_deletes_only_target_org_and_sanitizes_logs(
         assert (
             await _row_count(session, ScheduledJob, ScheduledJob.org_id == org2_id) == 2
         )
-        assert await _row_count(session, Team, Team.org_id == org2_id) == 1
 
     log_output = caplog.text
     assert org1_id in log_output
@@ -518,3 +516,56 @@ async def test_org_deletion_result_counts(session_maker):
 
         assert result.postgres.total >= 0
         assert "organizations" in result.postgres.tables
+
+
+def test_postgres_targets_do_not_overlap_clickhouse_tables():
+    """Guard against cross-layer drift.
+
+    A ClickHouse analytics table must never be registered as a Postgres
+    deletion target. This is exactly the invariant the `teams` regression
+    violated: `teams` is a ClickHouse-only table, so counting it on the
+    Postgres semantic session raised `UndefinedTableError: relation "teams"
+    does not exist`. ClickHouse tables are purged via `_purge_clickhouse`.
+    """
+    pg_tables = {target.table for target in _postgres_targets()}
+    ch_tables = set(_clickhouse_tables_from_migrations())
+    # Sanity-check the catalog itself so a broken migration scan (empty result)
+    # cannot silently turn this guard into a no-op false pass.
+    assert ch_tables, "ClickHouse migration table catalog must not be empty"
+    assert "teams" in ch_tables, "`teams` must be in the ClickHouse purge catalog"
+    overlap = pg_tables & ch_tables
+    assert not overlap, (
+        "Postgres deletion targets must not reference ClickHouse tables "
+        f"(cross-layer drift): {sorted(overlap)}"
+    )
+
+
+def test_org_deletion_does_not_target_teams_in_postgres():
+    """`teams` is a ClickHouse entity (used in metrics) and is purged via the
+    ClickHouse path; it must not be a Postgres deletion target. The Postgres
+    semantic team representation is `team_mappings`, which remains a target.
+    """
+    pg_tables = {target.table for target in _postgres_targets()}
+    assert "teams" not in pg_tables
+    assert "team_mappings" in pg_tables
+
+
+@pytest.mark.asyncio
+async def test_org_deletion_succeeds_without_postgres_teams_table(session_maker):
+    """Regression: production Postgres (Alembic schema) has no `teams` table.
+
+    The `session_maker` fixture mirrors production by omitting `teams` from the
+    created tables, so this reproduces the original failure scenario. Deletion
+    must complete without ever querying `teams` on the Postgres session.
+    """
+    async with session_maker() as session:
+        org1_id, _org2_id = await _seed_org_pair(session)
+
+        service = OrganizationDeletionService(session)
+        # Must not raise UndefinedTableError for the missing `teams` relation.
+        result = await service.delete(org1_id, dry_run=False)
+
+        # `teams` is never counted/deleted on the Postgres session ...
+        assert "teams" not in result.postgres.tables
+        # ... while the Postgres semantic team config still is.
+        assert "team_mappings" in result.postgres.tables


### PR DESCRIPTION
## Summary

Deleting an organization threw:

```
sqlalchemy.exc.ProgrammingError: relation "teams" does not exist
[SQL: SELECT count(*) AS count_1 FROM teams WHERE teams.org_id = $1::VARCHAR]
```

**Root cause:** `org_deletion._postgres_targets()` listed `teams` as a `PostgresDeletionTarget`, so deletion ran `SELECT count(*) FROM teams` against the **Postgres semantic session**. But `teams` is a **ClickHouse analytics table** (used in metrics) — created by ClickHouse migrations `002_teams.sql`/`011_ensure_teams.sql`, with `org_id` added by `024_add_org_id.sql` and sorting key `(org_id, id)` set in `027`. It has **no Alembic migration** and is intentionally absent from the Postgres schema. The Postgres semantic team representation is `team_mappings` (already a correct deletion target).

`teams` is **already** org-scoped-purged by `_purge_clickhouse` (its `org_id` ALTER is matched by the migration-derived catalog), so the Postgres target was both **wrong-layer and redundant**.

This was masked in tests because the SQLite harness created a `teams` table via `Base.metadata.create_all`, which never happens in production Postgres (Alembic-only).

## Changes

- **`org_deletion.py`** — remove the `teams`/`Team` `PostgresDeletionTarget` + unused import; add a comment documenting the layer boundary. `team_mappings` stays.
- **`database-architecture.md`** — correct stale rows: `teams` is ClickHouse (metrics); the Postgres semantic team table is `team_mappings`; `sync teams` touches both layers.
- **`test_org_deletion.py`**
  - Drop `Team` from the test harness so the SQLite schema mirrors production Postgres (no `teams` table) — making **every** existing test a regression guard.
  - Add a **cross-layer invariant guard**: no Postgres deletion target may overlap the ClickHouse migration catalog (catalog asserted non-empty and containing `teams`, so a broken scan can't false-pass).
  - Add an explicit no-`teams`-target test and a regression test that runs deletion against a Postgres schema without a `teams` table.

## ClickHouse cascade (teams + links)

Both `teams` and `jira_project_ops_team_links` carry `org_id` (added by migrations `024`/`027`) and are present in the org-deletion ClickHouse purge catalog, so they **cascade-delete with the org in the same `_purge_clickhouse` sweep**. No additional cleanup path is required.

## Validation

- 13/13 tests pass (`LOG_LEVEL=info`, ClickHouse env unset for a clean signal).
- `ruff format` + `ruff check` clean; pre-commit/commit-msg hooks pass.
- Codex adversarial review: **approve**, no material findings (its hardening nit — assert the CH catalog is non-empty/contains `teams` — is included).

SCREENSHOT-WAIVER: backend-only change (org deletion service + tests + docs); no rendered UI impact.