### PR TITLE
fix(investment): synthetic evidence handles + validator hardening (CHAOS-2365)

### DIFF
--- a/docs/architecture/investment-categorization-pipeline.md
+++ b/docs/architecture/investment-categorization-pipeline.md
@@ -103,7 +103,7 @@ deterministic.
 
 - top-level keys are exactly `subcategories`, `evidence_quotes`, `uncertainty`;
 - every subcategory key is in the canonical set; each probability in `[0, 1]`;
-- the distribution sums to within `[0.98, 1.02]`;
+- the distribution sums within `[0.9, 1.1]` — a clean `[0.98, 1.02]` sum is accepted as-is, a near-miss is renormalized and flagged `probability_sum_renormalized` in the audit, and `≤ 0` or outside `[0.9, 1.1]` is rejected;
 - each evidence quote is a **literal substring** of the provided source text
   (anti-hallucination), 1–10 quotes, `source ∈ {issue, pr, commit}`;
 - `uncertainty` is non-empty and ≤ 280 chars.

--- a/docs/llm/categorization-contract.md
+++ b/docs/llm/categorization-contract.md
@@ -35,10 +35,11 @@ There are exactly three top-level keys — `subcategories`, `evidence_quotes`,
 
 | Requirement | Details |
 |-------------|---------|
-| `subcategories` | Probabilities over the canonical subcategory keys (see [Investment Taxonomy](../product/investment-taxonomy.md)); each value `0–1`; the values must sum to within `[0.98, 1.02]` |
+| `subcategories` | Probabilities over the canonical subcategory keys (see [Investment Taxonomy](../product/investment-taxonomy.md)); each value `0–1`. A sum in the clean band `[0.98, 1.02]` is accepted as-is; a sum in `[0.9, 1.1]` but outside the clean band is renormalized and flagged with `probability_sum_renormalized:{total}` in `categorization_errors_json`; a sum `≤ 0` or outside `[0.9, 1.1]` is rejected |
 | `evidence_quotes` | A **list** of 1–10 objects, each exactly `{ "quote", "source", "id" }` |
-| `quote` | An **exact substring** of the provided source text (≤ 280 chars) |
+| `quote` | An **extractive substring** of the provided source text (≤ 280 chars). Matching is whitespace-tolerant, but the **exact source span** is what gets persisted |
 | `source` | One of `issue`, `pr`, `commit` |
+| `id` | The **bracketed handle** shown before each evidence block in the prompt (for example `E1`), copied exactly; the validator resolves it back to the real source id |
 | `uncertainty` | Non-empty string, ≤ 280 chars |
 
 ### Example output
@@ -52,16 +53,18 @@ There are exactly three top-level keys — `subcategories`, `evidence_quotes`,
     "maintenance.refactor": 0.10
   },
   "evidence_quotes": [
-    { "quote": "requested by customer", "source": "issue", "id": "PROJ-123" },
-    { "quote": "hotfix for production outage", "source": "pr", "id": "456" }
+    { "quote": "requested by customer", "source": "issue", "id": "E1" },
+    { "quote": "hotfix for production outage", "source": "pr", "id": "E2" }
   ],
   "uncertainty": "Mixed signals between customer feature work and incident response."
 }
 ```
 
 > The prompt requests a value for **all 15** subcategories. Validation requires every
-> provided key to be canonical and the values to sum to within `[0.98, 1.02]`; the
-> validation step then fills any missing keys with `0` and renormalizes via
+> provided key to be canonical and the values to sum within `[0.9, 1.1]` — a clean sum in
+> `[0.98, 1.02]` is accepted as-is, while a near-miss is renormalized and flagged with
+> `probability_sum_renormalized:{total}`. The validation step then fills any missing keys
+> with `0` and renormalizes via
 > `ensure_full_subcategory_vector`. Keys must match `investment_taxonomy.py` exactly —
 > obsolete keys like `operational.external` or `feature_delivery.platform` are rejected
 > as `unknown_subcategory`.
@@ -87,7 +90,7 @@ repair also fails, a deterministic fallback distribution is applied.
 - non-JSON or non-object payloads;
 - wrong / extra / missing top-level keys;
 - non-canonical subcategory keys (`unknown_subcategory`);
-- probabilities out of range, or a sum outside `[0.98, 1.02]`;
+- probabilities out of range, or a sum `≤ 0` or outside the accepted `[0.9, 1.1]` band (a sum inside `[0.9, 1.1]` but outside the clean `[0.98, 1.02]` band is **accepted** with a `probability_sum_renormalized` audit marker, not a failure);
 - quote count outside 1–10, wrong quote keys, or empty / too-long quotes;
 - a quote that is **not a literal substring** of the source text
   (`evidence_quote_not_substring`);

--- a/docs/llm/categorization-contract.md
+++ b/docs/llm/categorization-contract.md
@@ -167,8 +167,33 @@ When `LLM_PROVIDER` is unset or `auto`, the system checks in order:
 | `LLM_PROVIDER` | Explicit provider selection (see table above) |
 | `LLM_MODEL` | Override the default model for any provider |
 | `OPENAI_BASE_URL` | Custom OpenAI-compatible endpoint |
+| `LOCAL_LLM_BASE_URL` | Generic local OpenAI-compatible endpoint, for example Ollama, vLLM, or LM Studio |
+| `LOCAL_LLM_MODEL` | Model name for `LLM_PROVIDER=local` |
+| `LOCAL_LLM_API_KEY` | API key for local endpoints that require one; defaults to `not-needed` |
+| `OLLAMA_BASE_URL` | Ollama OpenAI-compatible endpoint for `LLM_PROVIDER=ollama`, default `http://localhost:11434/v1` |
+| `OLLAMA_MODEL` | Model name for `LLM_PROVIDER=ollama`, default `llama3.2` |
+| `LMSTUDIO_BASE_URL` | LM Studio OpenAI-compatible endpoint for `LLM_PROVIDER=lmstudio`, default `http://localhost:1234/v1` |
 | `DASHSCOPE_BASE_URL` | Regional DashScope endpoint (default: China; Singapore/US available) |
 | `GEMINI_BASE_URL` | Custom Gemini endpoint |
+
+### Local Endpoint Examples
+
+Use `local` for any OpenAI-compatible server when you want to set the endpoint
+explicitly:
+
+```bash
+export LLM_PROVIDER=local
+export LOCAL_LLM_BASE_URL=http://localhost:8000/v1
+export LOCAL_LLM_MODEL=your-model
+```
+
+Use `ollama` when you want Ollama-specific defaults and environment names:
+
+```bash
+export LLM_PROVIDER=ollama
+export OLLAMA_BASE_URL=http://localhost:11434/v1
+export OLLAMA_MODEL=llama3.2
+```
 
 ### Provider-Specific Notes
 

--- a/docs/ops/investment-materialization.md
+++ b/docs/ops/investment-materialization.md
@@ -71,6 +71,23 @@ dev-hops investment materialize \
 | `--no-persist-evidence-snippets` | off | Skip quote persistence for storage-constrained backfills |
 | `--force` | off | Force re-materialization |
 
+For local OpenAI-compatible servers, set the endpoint before running the command:
+
+```bash
+export LLM_PROVIDER=local
+export LOCAL_LLM_BASE_URL=http://localhost:8000/v1
+export LOCAL_LLM_MODEL=your-model
+
+dev-hops investment materialize \
+  --db "$CLICKHOUSE_URI" \
+  --from 2026-05-01 \
+  --to 2026-06-01
+```
+
+For Ollama-specific configuration, use `LLM_PROVIDER=ollama` with
+`OLLAMA_BASE_URL` and `OLLAMA_MODEL`; the default URL is
+`http://localhost:11434/v1`.
+
 > **Evidence snippets are on by default.** Real materialization runs persist validated
 > extractive quotes to `work_unit_investment_quotes` so evidence drill-downs have the
 > audit trail required by the Investment contract. Use `--no-persist-evidence-snippets`

--- a/src/dev_health_ops/work_graph/investment/categorize.py
+++ b/src/dev_health_ops/work_graph/investment/categorize.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from dev_health_ops.llm import LLMProvider, get_provider
 from dev_health_ops.work_graph.investment.llm_schema import (
@@ -81,6 +81,7 @@ class CategorizationOutcome:
     uncertainty: str
     status: str
     errors: list[str]
+    warnings: list[str] = field(default_factory=list)
 
 
 def _fallback_distribution() -> dict[str, float]:
@@ -156,6 +157,7 @@ async def categorize_text_bundle(
             uncertainty=validation.uncertainty,
             status="ok",
             errors=[],
+            warnings=validation.warnings,
         )
 
     repair_prompt = _build_repair_prompt(validation.errors, bundle.source_block)
@@ -183,6 +185,7 @@ async def categorize_text_bundle(
             uncertainty=validation.uncertainty,
             status="repaired",
             errors=[],
+            warnings=validation.warnings,
         )
 
     logger.warning(
@@ -196,4 +199,5 @@ async def categorize_text_bundle(
         uncertainty="Insufficient validated evidence to assign a confident subcategory mix.",
         status="invalid_llm_output",
         errors=validation.errors,
+        warnings=validation.warnings,
     )

--- a/src/dev_health_ops/work_graph/investment/categorize.py
+++ b/src/dev_health_ops/work_graph/investment/categorize.py
@@ -27,6 +27,7 @@ Rules:
 - Provide a probability distribution across all subcategories (values 0-1, sum to 1).
 - Provide evidence_quotes as 1-10 items with exact substrings from the source text.
 - evidence_quotes items must have: quote, source (issue|pr|commit), id.
+- evidence_quotes id MUST be the bracketed handle shown before an evidence block (for example "E1"), copied exactly.
 - Provide uncertainty as a short string (1-280 chars).
 - No extra keys.
 
@@ -50,7 +51,7 @@ Output schema:
     "risk.vulnerability": 0.0
   }},
   "evidence_quotes": [
-    {{ "quote": "...", "source": "issue", "id": "..." }}
+    {{ "quote": "...", "source": "issue", "id": "E1" }}
   ],
   "uncertainty": "..."
 }}
@@ -144,7 +145,9 @@ async def categorize_text_bundle(
             uncertainty="",
         )
     else:
-        validation = validate_llm_payload(payload or {}, bundle.source_texts)
+        validation = validate_llm_payload(
+            payload or {}, bundle.source_texts, bundle.handle_map
+        )
 
     if validation.ok:
         return CategorizationOutcome(
@@ -169,7 +172,9 @@ async def categorize_text_bundle(
             uncertainty="",
         )
     else:
-        validation = validate_llm_payload(payload or {}, bundle.source_texts)
+        validation = validate_llm_payload(
+            payload or {}, bundle.source_texts, bundle.handle_map
+        )
 
     if validation.ok:
         return CategorizationOutcome(

--- a/src/dev_health_ops/work_graph/investment/evidence.py
+++ b/src/dev_health_ops/work_graph/investment/evidence.py
@@ -230,11 +230,16 @@ def build_text_bundle(
             )
 
     source_block_lines: list[str] = []
+    handle_map: dict[str, tuple[str, str]] = {}
+    next_handle = 1
     for source_type in ("issue", "pr", "commit"):
         for source_id, text in source_texts[source_type].items():
             if not text:
                 continue
-            source_block_lines.append(f"[{source_type}] {source_id}")
+            handle = f"E{next_handle}"
+            next_handle += 1
+            handle_map[handle] = (source_type, source_id)
+            source_block_lines.append(f"[{source_type}] {handle}")
             source_block_lines.append(text)
             source_block_lines.append("")
 
@@ -256,6 +261,7 @@ def build_text_bundle(
     return TextBundle(
         source_block=source_block,
         source_texts=source_texts,
+        handle_map=handle_map,
         input_hash=input_hash,
         text_source_count=text_source_count,
         text_char_count=text_char_count,

--- a/src/dev_health_ops/work_graph/investment/llm_schema.py
+++ b/src/dev_health_ops/work_graph/investment/llm_schema.py
@@ -13,8 +13,8 @@ ALLOWED_TOP_LEVEL_KEYS = {"subcategories", "evidence_quotes", "uncertainty"}
 ALLOWED_QUOTE_KEYS = {"quote", "source", "id"}
 ALLOWED_SOURCES = {"issue", "pr", "commit"}
 
-MIN_SUM = 0.98
-MAX_SUM = 1.02
+MIN_ACCEPTABLE_SUM = 0.9
+MAX_ACCEPTABLE_SUM = 1.1
 MAX_UNCERTAINTY_LEN = 280
 MAX_QUOTE_LEN = 280
 MIN_QUOTES = 1
@@ -50,6 +50,7 @@ def parse_llm_json(raw_text: str) -> tuple[dict[str, object] | None, list[str]]:
 def validate_llm_payload(
     payload: dict[str, object],
     source_texts: dict[str, dict[str, str]],
+    handle_map: dict[str, tuple[str, str]],
 ) -> LLMValidationResult:
     errors: list[str] = []
 
@@ -83,8 +84,10 @@ def validate_llm_payload(
         cleaned[key] = numeric
 
     total = sum(cleaned.values())
-    if total < MIN_SUM or total > MAX_SUM:
+    if total <= 0.0 or total < MIN_ACCEPTABLE_SUM or total > MAX_ACCEPTABLE_SUM:
         errors.append(f"probability_sum_out_of_range:{total:.4f}")
+    else:
+        cleaned = {key: value / total for key, value in cleaned.items()}
 
     evidence_quotes_raw = payload.get("evidence_quotes")
     evidence_quotes: list[EvidenceQuote] = []
@@ -128,19 +131,26 @@ def validate_llm_payload(
             if not source_id:
                 errors.append(f"evidence_quote_missing_id:{idx}")
                 continue
-            source_map = source_texts.get(source_type) or {}
-            source_text = source_map.get(source_id, "")
+            resolved = handle_map.get(source_id)
+            if resolved is None:
+                errors.append(f"evidence_quote_unknown_source:{idx}")
+                continue
+            real_source_type, real_source_id = resolved
+            source_map = source_texts.get(real_source_type) or {}
+            source_text = source_map.get(real_source_id, "")
             if not source_text:
                 errors.append(f"evidence_quote_unknown_source:{idx}")
                 continue
-            if quote not in source_text:
+            normalized_quote = " ".join(quote.split())
+            normalized_source_text = " ".join(source_text.split())
+            if normalized_quote not in normalized_source_text:
                 errors.append(f"evidence_quote_not_substring:{idx}")
                 continue
             evidence_quotes.append(
                 EvidenceQuote(
                     quote=quote,
-                    source_type=source_type,
-                    source_id=source_id,
+                    source_type=real_source_type,
+                    source_id=real_source_id,
                 )
             )
 

--- a/src/dev_health_ops/work_graph/investment/llm_schema.py
+++ b/src/dev_health_ops/work_graph/investment/llm_schema.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import json
 import math
-from dataclasses import dataclass
+import re
+from dataclasses import dataclass, field
 
 from dev_health_ops.work_graph.investment.taxonomy import SUBCATEGORIES
 from dev_health_ops.work_graph.investment.utils import ensure_full_subcategory_vector
@@ -13,6 +14,8 @@ ALLOWED_TOP_LEVEL_KEYS = {"subcategories", "evidence_quotes", "uncertainty"}
 ALLOWED_QUOTE_KEYS = {"quote", "source", "id"}
 ALLOWED_SOURCES = {"issue", "pr", "commit"}
 
+MIN_STRICT_SUM = 0.98
+MAX_STRICT_SUM = 1.02
 MIN_ACCEPTABLE_SUM = 0.9
 MAX_ACCEPTABLE_SUM = 1.1
 MAX_UNCERTAINTY_LEN = 280
@@ -35,6 +38,18 @@ class LLMValidationResult:
     subcategories: dict[str, float]
     evidence_quotes: list[EvidenceQuote]
     uncertainty: str
+    warnings: list[str] = field(default_factory=list)
+
+
+def _recover_quote_span(quote: str, source_text: str) -> str | None:
+    tokens = quote.split()
+    if not tokens:
+        return None
+    pattern = r"\s+".join(re.escape(token) for token in tokens)
+    match = re.search(pattern, source_text)
+    if match is None:
+        return None
+    return match.group(0)
 
 
 def parse_llm_json(raw_text: str) -> tuple[dict[str, object] | None, list[str]]:
@@ -53,6 +68,7 @@ def validate_llm_payload(
     handle_map: dict[str, tuple[str, str]],
 ) -> LLMValidationResult:
     errors: list[str] = []
+    warnings: list[str] = []
 
     keys = set(payload.keys())
     if keys != ALLOWED_TOP_LEVEL_KEYS:
@@ -87,6 +103,8 @@ def validate_llm_payload(
     if total <= 0.0 or total < MIN_ACCEPTABLE_SUM or total > MAX_ACCEPTABLE_SUM:
         errors.append(f"probability_sum_out_of_range:{total:.4f}")
     else:
+        if total < MIN_STRICT_SUM or total > MAX_STRICT_SUM:
+            warnings.append(f"probability_sum_renormalized:{total:.4f}")
         cleaned = {key: value / total for key, value in cleaned.items()}
 
     evidence_quotes_raw = payload.get("evidence_quotes")
@@ -141,14 +159,13 @@ def validate_llm_payload(
             if not source_text:
                 errors.append(f"evidence_quote_unknown_source:{idx}")
                 continue
-            normalized_quote = " ".join(quote.split())
-            normalized_source_text = " ".join(source_text.split())
-            if normalized_quote not in normalized_source_text:
+            recovered_quote = _recover_quote_span(quote, source_text)
+            if recovered_quote is None:
                 errors.append(f"evidence_quote_not_substring:{idx}")
                 continue
             evidence_quotes.append(
                 EvidenceQuote(
-                    quote=quote,
+                    quote=recovered_quote,
                     source_type=real_source_type,
                     source_id=real_source_id,
                 )
@@ -168,6 +185,7 @@ def validate_llm_payload(
             subcategories={},
             evidence_quotes=[],
             uncertainty=uncertainty,
+            warnings=warnings,
         )
 
     normalized = ensure_full_subcategory_vector(cleaned)
@@ -177,4 +195,5 @@ def validate_llm_payload(
         subcategories=normalized,
         evidence_quotes=evidence_quotes,
         uncertainty=uncertainty,
+        warnings=warnings,
     )

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -527,6 +527,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
             if outcome.status == "invalid_llm_output":
                 evidence_quality_value = min(float(evidence_quality_value), 0.3)
             evidence_band = evidence_quality_band(float(evidence_quality_value))
+            categorization_audit = [*outcome.errors, *outcome.warnings]
 
             effort_metric, effort_value = _effort_from_work_unit(
                 issue_ids=issue_node_ids,
@@ -582,7 +583,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
                     evidence_quality=evidence_quality_value,
                     evidence_quality_band=evidence_band,
                     categorization_status=outcome.status,
-                    categorization_errors_json=json.dumps(outcome.errors),
+                    categorization_errors_json=json.dumps(categorization_audit),
                     categorization_model_version=model_version,
                     categorization_input_hash=bundle.input_hash,
                     categorization_run_id=run_id,

--- a/src/dev_health_ops/work_graph/investment/types.py
+++ b/src/dev_health_ops/work_graph/investment/types.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 class TextBundle:
     source_block: str
     source_texts: dict[str, dict[str, str]]
+    handle_map: dict[str, tuple[str, str]]
     input_hash: str
     text_source_count: int
     text_char_count: int

--- a/tests/work_graph/test_investment_categorize.py
+++ b/tests/work_graph/test_investment_categorize.py
@@ -25,8 +25,9 @@ def _bundle() -> TextBundle:
         "commit": {},
     }
     return TextBundle(
-        source_block="[issue] jira:ABC-1\nFix login outage for auth service",
+        source_block="[issue] E1\nFix login outage for auth service",
         source_texts=source_texts,
+        handle_map={"E1": ("issue", "jira:ABC-1")},
         input_hash="hash",
         text_source_count=1,
         text_char_count=40,
@@ -54,7 +55,7 @@ def test_repaired_status(monkeypatch):
                 "feature_delivery.roadmap": 1.0
               },
               "evidence_quotes": [
-                { "quote": "Fix login outage", "source": "issue", "id": "jira:ABC-1" }
+                { "quote": "Fix login outage", "source": "issue", "id": "E1" }
               ],
               "uncertainty": "Some uncertainty remains."
             }""",

--- a/tests/work_graph/test_investment_categorize.py
+++ b/tests/work_graph/test_investment_categorize.py
@@ -52,7 +52,8 @@ def test_repaired_status(monkeypatch):
             "not json",
             """{
               "subcategories": {
-                "feature_delivery.roadmap": 1.0
+                "feature_delivery.roadmap": 0.55,
+                "quality.bugfix": 0.40
               },
               "evidence_quotes": [
                 { "quote": "Fix login outage", "source": "issue", "id": "E1" }
@@ -69,3 +70,4 @@ def test_repaired_status(monkeypatch):
     assert provider.calls == 2
     assert "Output schema" in provider.prompts[1]
     assert outcome.status == "repaired"
+    assert outcome.warnings == ["probability_sum_renormalized:0.9500"]

--- a/tests/work_graph/test_investment_helpers.py
+++ b/tests/work_graph/test_investment_helpers.py
@@ -80,9 +80,14 @@ def test_build_text_bundle_and_quality_score():
         work_unit_id="WU-1",
     )
 
-    assert "[issue] ISS-1" in bundle.source_block
-    assert "[pr] PR-1" in bundle.source_block
-    assert "[commit] abc123" in bundle.source_block
+    assert "[issue] E1" in bundle.source_block
+    assert "[pr] E2" in bundle.source_block
+    assert "[commit] E3" in bundle.source_block
+    assert bundle.handle_map == {
+        "E1": ("issue", "ISS-1"),
+        "E2": ("pr", "PR-1"),
+        "E3": ("commit", "abc123"),
+    }
     assert bundle.text_source_count == 3
     assert bundle.text_char_count > 0
 

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+import json
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -118,6 +119,7 @@ def _patch_queries(monkeypatch, edges, work_items, commits):
 @pytest.mark.asyncio
 async def test_materialize_invokes_sink(monkeypatch):
     repo_id, edges, work_items, commits = _sample_data()
+    work_items[0]["description"] = "Resolve authentication failures. " * 20
     sink = FakeSink()
 
     async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
@@ -127,6 +129,7 @@ async def test_materialize_invokes_sink(monkeypatch):
             uncertainty="Limited evidence.",
             status="ok",
             errors=[],
+            warnings=["probability_sum_renormalized:0.9500"],
         )
 
     monkeypatch.setattr(
@@ -155,6 +158,9 @@ async def test_materialize_invokes_sink(monkeypatch):
     record = sink.investment_rows[0]
     assert record.work_unit_type == "incident"
     assert record.work_unit_name == "Fix login outage"
+    assert json.loads(record.categorization_errors_json) == [
+        "probability_sum_renormalized:0.9500"
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/work_graph/test_llm_schema.py
+++ b/tests/work_graph/test_llm_schema.py
@@ -57,6 +57,7 @@ def test_probabilities_normalize_to_one():
     }
     result = validate_llm_payload(payload, _source_texts(), _handle_map())
     assert result.ok
+    assert result.warnings == []
     total = sum(result.subcategories.values())
     assert abs(total - 1.0) < 1e-6
 
@@ -97,7 +98,7 @@ def test_evidence_handle_not_in_map_is_unknown_source():
     assert "evidence_quote_unknown_source:0" in result.errors
 
 
-def test_probabilities_within_loose_band_are_renormalized_and_accepted():
+def test_probabilities_within_loose_band_are_renormalized_with_warning():
     payload: dict[str, object] = {
         "subcategories": {
             "feature_delivery.roadmap": 0.55,
@@ -110,6 +111,7 @@ def test_probabilities_within_loose_band_are_renormalized_and_accepted():
     }
     result = validate_llm_payload(payload, _source_texts(), _handle_map())
     assert result.ok
+    assert result.warnings == ["probability_sum_renormalized:0.9500"]
     assert abs(sum(result.subcategories.values()) - 1.0) < 1e-6
     assert result.subcategories["feature_delivery.roadmap"] == 0.55 / 0.95
 
@@ -128,6 +130,7 @@ def test_degenerate_probability_sum_still_rejected():
 
 
 def test_evidence_quote_substring_check_normalizes_whitespace():
+    source_text = _source_texts()["commit"]["repo@abc"]
     payload: dict[str, object] = {
         "subcategories": {"quality.bugfix": 1.0},
         "evidence_quotes": [
@@ -137,6 +140,8 @@ def test_evidence_quote_substring_check_normalizes_whitespace():
     }
     result = validate_llm_payload(payload, _source_texts(), _handle_map())
     assert result.ok
+    assert result.evidence_quotes[0].quote == "Handle\n token   refresh"
+    assert result.evidence_quotes[0].quote in source_text
 
 
 def test_parse_llm_json_strict():

--- a/tests/work_graph/test_llm_schema.py
+++ b/tests/work_graph/test_llm_schema.py
@@ -11,7 +11,15 @@ def _source_texts() -> dict[str, dict[str, str]]:
     return {
         "issue": {"jira:ABC-1": "Fix login outage for auth service"},
         "pr": {"repo#pr1": "Add auth retry handling"},
-        "commit": {"repo@abc": "Handle token refresh"},
+        "commit": {"repo@abc": "Handle\n token   refresh"},
+    }
+
+
+def _handle_map() -> dict[str, tuple[str, str]]:
+    return {
+        "E1": ("issue", "jira:ABC-1"),
+        "E2": ("pr", "repo#pr1"),
+        "E3": ("commit", "repo@abc"),
     }
 
 
@@ -22,14 +30,14 @@ def test_rejects_unknown_keys_and_extra_keys():
             {
                 "quote": "Fix login outage",
                 "source": "issue",
-                "id": "jira:ABC-1",
+                "id": "E1",
                 "extra": "x",
             }
         ],
         "uncertainty": "Limited evidence.",
         "extra": "nope",
     }
-    result = validate_llm_payload(payload, _source_texts())
+    result = validate_llm_payload(payload, _source_texts(), _handle_map())
     assert not result.ok
     assert any("unexpected_top_level_keys" in err for err in result.errors)
     assert any("unknown_subcategory" in err for err in result.errors)
@@ -43,11 +51,11 @@ def test_probabilities_normalize_to_one():
     payload: dict[str, object] = {
         "subcategories": subcategories,
         "evidence_quotes": [
-            {"quote": "Fix login outage", "source": "issue", "id": "jira:ABC-1"}
+            {"quote": "Fix login outage", "source": "issue", "id": "E1"}
         ],
         "uncertainty": "Reasonable confidence based on evidence.",
     }
-    result = validate_llm_payload(payload, _source_texts())
+    result = validate_llm_payload(payload, _source_texts(), _handle_map())
     assert result.ok
     total = sum(result.subcategories.values())
     assert abs(total - 1.0) < 1e-6
@@ -56,14 +64,79 @@ def test_probabilities_normalize_to_one():
 def test_evidence_quote_must_be_substring():
     payload: dict[str, object] = {
         "subcategories": {"feature_delivery.roadmap": 1.0},
-        "evidence_quotes": [
-            {"quote": "Not in text", "source": "issue", "id": "jira:ABC-1"}
-        ],
+        "evidence_quotes": [{"quote": "Not in text", "source": "issue", "id": "E1"}],
         "uncertainty": "Limited evidence.",
     }
-    result = validate_llm_payload(payload, _source_texts())
+    result = validate_llm_payload(payload, _source_texts(), _handle_map())
     assert not result.ok
     assert any("evidence_quote_not_substring" in err for err in result.errors)
+
+
+def test_evidence_handle_round_trips_to_real_source_id_despite_source_mismatch():
+    payload: dict[str, object] = {
+        "subcategories": {"quality.bugfix": 1.0},
+        "evidence_quotes": [{"quote": "Fix login outage", "source": "pr", "id": "E1"}],
+        "uncertainty": "Reasonable confidence based on evidence.",
+    }
+    result = validate_llm_payload(payload, _source_texts(), _handle_map())
+    assert result.ok
+    assert result.evidence_quotes[0].source_type == "issue"
+    assert result.evidence_quotes[0].source_id == "jira:ABC-1"
+
+
+def test_evidence_handle_not_in_map_is_unknown_source():
+    payload: dict[str, object] = {
+        "subcategories": {"quality.bugfix": 1.0},
+        "evidence_quotes": [
+            {"quote": "Fix login outage", "source": "issue", "id": "E99"}
+        ],
+        "uncertainty": "Reasonable confidence based on evidence.",
+    }
+    result = validate_llm_payload(payload, _source_texts(), _handle_map())
+    assert not result.ok
+    assert "evidence_quote_unknown_source:0" in result.errors
+
+
+def test_probabilities_within_loose_band_are_renormalized_and_accepted():
+    payload: dict[str, object] = {
+        "subcategories": {
+            "feature_delivery.roadmap": 0.55,
+            "quality.bugfix": 0.40,
+        },
+        "evidence_quotes": [
+            {"quote": "Fix login outage", "source": "issue", "id": "E1"}
+        ],
+        "uncertainty": "Reasonable confidence based on evidence.",
+    }
+    result = validate_llm_payload(payload, _source_texts(), _handle_map())
+    assert result.ok
+    assert abs(sum(result.subcategories.values()) - 1.0) < 1e-6
+    assert result.subcategories["feature_delivery.roadmap"] == 0.55 / 0.95
+
+
+def test_degenerate_probability_sum_still_rejected():
+    payload: dict[str, object] = {
+        "subcategories": {"quality.bugfix": 0.5},
+        "evidence_quotes": [
+            {"quote": "Fix login outage", "source": "issue", "id": "E1"}
+        ],
+        "uncertainty": "Reasonable confidence based on evidence.",
+    }
+    result = validate_llm_payload(payload, _source_texts(), _handle_map())
+    assert not result.ok
+    assert any("probability_sum_out_of_range:0.5000" in err for err in result.errors)
+
+
+def test_evidence_quote_substring_check_normalizes_whitespace():
+    payload: dict[str, object] = {
+        "subcategories": {"quality.bugfix": 1.0},
+        "evidence_quotes": [
+            {"quote": "Handle token refresh", "source": "commit", "id": "E3"}
+        ],
+        "uncertainty": "Reasonable confidence based on evidence.",
+    }
+    result = validate_llm_payload(payload, _source_texts(), _handle_map())
+    assert result.ok
 
 
 def test_parse_llm_json_strict():


### PR DESCRIPTION
## Summary

Fixes compute-time investment categorization that failed `evidence_quote_unknown_source` on **every** work unit when run against weak local LLMs (e.g. `google/gemma-4-e4b`), falling back to the deterministic prior each time.

**Root cause (A/B confirmed):** `validate_llm_payload()` required the model to echo opaque provider IDs verbatim (e.g. `ghpr:full-chaos/dev-health-ops#825`, `<uuid>@<sha>`) and bind them to the correct `[issue]/[pr]/[commit]` tag. A 4B local model can't; `gpt-5-mini` passes ~92% and never hits `unknown_source`. Same org, same prompt, same validator — only the model differs.

## Changes

1. **Synthetic evidence handles** (`evidence.py`, `types.py`, `llm_schema.py`, `categorize.py`)
   - The prompt now presents each evidence item with a short stable handle (`E1`, `E2`, …) instead of opaque provider IDs. A new `TextBundle.handle_map` resolves the model's echoed handle back to the **real** `(source_type, source_id)`. `EvidenceQuote` still carries real ids, so persistence is unchanged.
   - Also neutralizes a contradictory signal: GitHub PRs ingested as work-items land in the `issue` bucket tagged `[issue]` while their text says `Type: pr`.

2. **Observable probability renormalization** (`llm_schema.py`, `categorize.py`, `materialize.py`)
   - Clean band `[0.98, 1.02]` accepted as-is; near-miss in `[0.9, 1.1]` is renormalized **and** flagged with `probability_sum_renormalized:{total}` persisted to `categorization_errors_json`; `≤ 0` or outside `[0.9, 1.1]` rejected. No more silent acceptance of off-sum distributions.

3. **Extractive span recovery** (`llm_schema.py`)
   - `_recover_quote_span()` uses a whitespace-tolerant (`\s+`) bounded regex to locate the quote in the original source text and persists the **exact source substring**, restoring the extractive-substring guarantee while tolerating weak-model whitespace drift.

4. **Docs** — aligned `categorization-contract.md` + `investment-categorization-pipeline.md` band/handle semantics with the shipped validator; documented local provider URL overrides.

## Adversarial review (Codex)

- Round 1 → `needs-attention`: 2 MEDIUM (silent prob renormalize, weakened substring guarantee)
- Round 2 → both code findings **cleared**; flagged only doc drift
- Round 3 fix → docs aligned

## Test evidence

- `tests/work_graph/`: **102 passed / 2 skipped**
- `ruff format --check` + `ruff check`: clean
- New tests: handle round-trip + source-mismatch tolerance, handle-not-in-map → `unknown_source`, near-miss renormalization warning, degenerate sum rejected, whitespace-tolerant span recovery persists exact substring.

## Notes

- Persistence boundary intact: `EvidenceQuote.source_type/source_id` remain real provider ids; only the persisted `quote` text becomes the recovered exact source span.
- No taxonomy/theme/roll-up changes; sink-only persistence preserved.

SCREENSHOT-WAIVER: Backend-only change (work_graph/investment validator + prompt + docs). No GraphQL schema or rendered UI output changed.

Closes CHAOS-2365
