### PR TITLE
feat(sync): GitLab parity for API-based file-content backfill

### DIFF
--- a/src/dev_health_ops/analytics/complexity.py
+++ b/src/dev_health_ops/analytics/complexity.py
@@ -10,6 +10,10 @@ from radon.complexity import cc_visit
 logger = logging.getLogger(__name__)
 yaml = importlib.import_module("yaml")
 
+DEFAULT_COMPLEXITY_CONFIG_PATH = (
+    Path(__file__).resolve().parents[1] / "config" / "complexity.yaml"
+)
+
 
 @dataclass
 class FileComplexity:

--- a/src/dev_health_ops/connectors/github.py
+++ b/src/dev_health_ops/connectors/github.py
@@ -708,6 +708,52 @@ class GitHubConnector(GitConnector):
             self._handle_github_exception(e)
             raise
 
+    @retry_with_backoff(
+        max_retries=3,
+        initial_delay=1.0,
+        exceptions=(RateLimitException, APIException),
+    )
+    def get_file_contents(
+        self,
+        owner: str,
+        repo: str,
+        paths: list[str],
+        ref: str = "HEAD",
+        batch_size: int = 50,
+    ) -> dict[str, str]:
+        """
+        Fetch text contents for many files via batched GraphQL blob queries.
+
+        Binary, truncated, or missing blobs are omitted from the result so
+        callers can treat absence as "no usable text".
+
+        :param owner: Repository owner.
+        :param repo: Repository name.
+        :param paths: Repository-relative file paths.
+        :param ref: Git reference the paths are resolved against.
+        :param batch_size: Number of blobs to resolve per GraphQL request.
+        :return: Mapping of path -> file text for blobs with usable text.
+        """
+        contents: dict[str, str] = {}
+        try:
+            for start in range(0, len(paths), batch_size):
+                chunk = paths[start : start + batch_size]
+                batch = self.graphql.get_blob_texts(owner, repo, ref, chunk)
+                contents.update(
+                    {path: text for path, text in batch.items() if text is not None}
+                )
+            logger.info(
+                "Retrieved contents for %d/%d files in %s/%s",
+                len(contents),
+                len(paths),
+                owner,
+                repo,
+            )
+            return contents
+        except Exception as e:
+            self._handle_github_exception(e)
+            raise
+
     def _rest_base_url(self) -> str:
         requester = getattr(self.github, "_Github__requester", None)
         base_url = getattr(requester, "_Requester__base_url", None)

--- a/src/dev_health_ops/connectors/gitlab.py
+++ b/src/dev_health_ops/connectors/gitlab.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import gitlab
+import requests
 from gitlab.exceptions import GitlabAuthenticationError, GitlabError
 
 from dev_health_ops.connectors import models as connector_models
@@ -1033,6 +1034,119 @@ class GitLabConnector(GitConnector):
         return self.get_file_blame_by_project(
             project_name=f"{owner}/{repo}", file_path=path, ref=ref
         )
+
+    @retry_with_backoff(
+        max_retries=3,
+        initial_delay=1.0,
+        exceptions=(RateLimitException, APIException),
+    )
+    def get_file_contents(
+        self,
+        project_full_path: str,
+        paths: list[str],
+        ref: str = "HEAD",
+        batch_size: int = 50,
+        max_bytes: int | None = 1_000_000,
+    ) -> dict[str, str]:
+        """
+        Fetch text contents for many files via batched GraphQL blob queries.
+
+        GitLab's GraphQL API resolves multiple blobs natively through
+        ``repository.blobs(ref:, paths:)``; ``rawTextBlob`` is null for
+        binary blobs, so those (and missing paths) are omitted from the
+        result and callers can treat absence as "no usable text".
+
+        :param project_full_path: Project full path (``group/project``).
+        :param paths: Repository-relative file paths.
+        :param ref: Git reference the paths are resolved against.
+        :param batch_size: Number of blobs to resolve per GraphQL request.
+        :return: Mapping of path -> file text for blobs with usable text.
+        """
+        query = """
+        query($fullPath: ID!, $ref: String!, $paths: [String!]!) {
+          project(fullPath: $fullPath) {
+            repository {
+              blobs(ref: $ref, paths: $paths) {
+                nodes {
+                  path
+                  rawTextBlob
+                  rawSize
+                }
+              }
+            }
+          }
+        }
+        """
+
+        headers = {"Content-Type": "application/json"}
+        if self.private_token:
+            headers["PRIVATE-TOKEN"] = self.private_token
+
+        contents: dict[str, str] = {}
+        try:
+            for start in range(0, len(paths), batch_size):
+                chunk = paths[start : start + batch_size]
+                payload: dict[str, Any] = {
+                    "query": query,
+                    "variables": {
+                        "fullPath": project_full_path,
+                        "ref": ref,
+                        "paths": chunk,
+                    },
+                }
+                response = requests.post(
+                    f"{self.url}/api/graphql",
+                    json=payload,
+                    headers=headers,
+                    timeout=30,
+                )
+                if response.status_code == 401:
+                    raise AuthenticationException("GitLab authentication failed")
+                if response.status_code == 429:
+                    raise RateLimitException(
+                        "GitLab API rate limit exceeded",
+                        retry_after_seconds=_parse_retry_after_seconds(
+                            dict(response.headers)
+                        ),
+                    )
+                if response.status_code != 200:
+                    raise APIException(
+                        f"GitLab GraphQL error: {response.status_code} - "
+                        f"{response.text}"
+                    )
+                data = response.json()
+                if data.get("errors"):
+                    messages = "; ".join(
+                        e.get("message", str(e)) for e in data["errors"]
+                    )
+                    raise APIException(f"GitLab GraphQL errors: {messages}")
+
+                project_data = (data.get("data") or {}).get("project") or {}
+                repository = project_data.get("repository") or {}
+                nodes = (repository.get("blobs") or {}).get("nodes") or []
+                for node in nodes:
+                    text = node.get("rawTextBlob")
+                    path = node.get("path")
+                    if not path or text is None:
+                        continue
+                    raw_size = node.get("rawSize")
+                    if (
+                        max_bytes is not None
+                        and raw_size is not None
+                        and int(raw_size) > max_bytes
+                    ):
+                        continue
+                    contents[path] = text
+
+            logger.info(
+                "Retrieved contents for %d/%d files in %s",
+                len(contents),
+                len(paths),
+                project_full_path,
+            )
+            return contents
+        except requests.exceptions.RequestException as exc:
+            raise APIException(f"GitLab GraphQL request failed: {exc}") from exc
 
     def get_dora_metrics(
         self,

--- a/src/dev_health_ops/connectors/utils/graphql.py
+++ b/src/dev_health_ops/connectors/utils/graphql.py
@@ -5,6 +5,7 @@ This module provides utilities for querying GitHub's GraphQL API,
 particularly for operations not well-supported by PyGithub such as blame.
 """
 
+import json
 import logging
 import time
 from collections.abc import Callable
@@ -197,6 +198,56 @@ class GitHubGraphQLClient:
         result = self.query(query, variables)
 
         return result
+
+    def get_blob_texts(
+        self,
+        owner: str,
+        repo: str,
+        ref: str,
+        paths: list[str],
+    ) -> dict[str, str | None]:
+        """
+        Fetch text contents for multiple blobs in a single GraphQL query.
+
+        Uses field aliases so one request resolves up to ``len(paths)`` blobs.
+        Binary and truncated blobs resolve to None.
+
+        :param owner: Repository owner.
+        :param repo: Repository name.
+        :param ref: Branch, tag, or commit SHA the paths are resolved against.
+        :param paths: Repository-relative file paths.
+        :return: Mapping of path -> text (None when binary/truncated/missing).
+        """
+        if not paths:
+            return {}
+
+        fields = []
+        for i, path in enumerate(paths):
+            expression = json.dumps(f"{ref}:{path}")
+            fields.append(
+                f"f{i}: object(expression: {expression}) "
+                "{ ... on Blob { text isBinary isTruncated } }"
+            )
+
+        query = (
+            "query($owner: String!, $repo: String!) {\n"
+            "  repository(owner: $owner, name: $repo) {\n"
+            + "\n".join(fields)
+            + "\n  }\n}"
+        )
+
+        result = self.query(query, {"owner": owner, "repo": repo})
+        repo_data = result.get("repository") or {}
+
+        contents: dict[str, str | None] = {}
+        for i, path in enumerate(paths):
+            blob = repo_data.get(f"f{i}") or {}
+            text = blob.get("text")
+            if blob.get("isBinary") or blob.get("isTruncated") or text is None:
+                contents[path] = None
+            else:
+                contents[path] = text
+        return contents
 
     def get_rate_limit(self) -> dict[str, Any]:
         """

--- a/src/dev_health_ops/metrics/job_complexity_db.py
+++ b/src/dev_health_ops/metrics/job_complexity_db.py
@@ -7,10 +7,13 @@ import os
 import uuid
 from collections.abc import Sequence
 from datetime import date, datetime, timedelta, timezone
-from pathlib import Path
 from typing import Any
 
-from dev_health_ops.analytics.complexity import ComplexityScanner, FileComplexity
+from dev_health_ops.analytics.complexity import (
+    DEFAULT_COMPLEXITY_CONFIG_PATH,
+    ComplexityScanner,
+    FileComplexity,
+)
 from dev_health_ops.db import resolve_sink_uri
 from dev_health_ops.metrics.schemas import FileComplexitySnapshot, RepoComplexityDaily
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
@@ -23,10 +26,6 @@ from dev_health_ops.utils.cli import (
 )
 
 logger = logging.getLogger(__name__)
-
-DEFAULT_COMPLEXITY_CONFIG_PATH = (
-    Path(__file__).resolve().parents[1] / "config" / "complexity.yaml"
-)
 
 
 def _date_range(end_day: date, backfill_days: int) -> list[date]:
@@ -245,6 +244,7 @@ def run_complexity_db_job(
             )
 
         days = _date_range(date, max(1, int(backfill_days)))
+        repos_with_data = 0
         for repo_uuid, repo_name in repos:
             repo_label = repo_name or str(repo_uuid)
             total_files, non_empty = _git_file_counts(sink.client, repo_uuid)
@@ -299,6 +299,8 @@ def run_complexity_db_job(
                 logger.warning("No complexity data found for repo %s.", repo_label)
                 continue
 
+            repos_with_data += 1
+
             for d in days:
                 computed_at = datetime.now(timezone.utc)
                 snapshots, repo_daily = _build_snapshots(
@@ -315,7 +317,21 @@ def run_complexity_db_job(
     finally:
         sink.close()
 
-    logger.info("Complexity DB job done.")
+    if repos_with_data == 0:
+        logger.error(
+            "Complexity DB job wrote no data: none of the %d repos for org_id=%s "
+            "have scannable contents in git_files/git_blame. Run a GitHub/GitLab "
+            "sync with file-content backfill (or a local sync) first.",
+            len(repos),
+            org_id,
+        )
+        return 1
+
+    logger.info(
+        "Complexity DB job done (%d/%d repos produced data).",
+        repos_with_data,
+        len(repos),
+    )
     return 0
 
 

--- a/src/dev_health_ops/processors/base_git.py
+++ b/src/dev_health_ops/processors/base_git.py
@@ -346,6 +346,7 @@ async def backfill_file_records(
     repo_id: Any,
     file_paths: list[str],
     repo_full_name: str,
+    contents_by_path: dict[str, str] | None = None,
 ) -> None:
     """Persist file path records from a pre-fetched list.
 
@@ -357,10 +358,14 @@ async def backfill_file_records(
         repo_id: The repository identifier.
         file_paths: List of repository-relative file paths.
         repo_full_name: Human-readable name used in log messages.
+        contents_by_path: Optional file text fetched upstream (e.g. via the
+            provider API); paths absent from the mapping persist with NULL
+            contents.
     """
     if not file_paths:
         return
 
+    contents_by_path = contents_by_path or {}
     async with AsyncBatchCollector(ingestion_sink.insert_git_file_data) as collector:
         for path in file_paths:
             collector.add(
@@ -368,12 +373,17 @@ async def backfill_file_records(
                     repo_id=repo_id,
                     path=path,
                     executable=False,
-                    contents=None,
+                    contents=contents_by_path.get(path),
                 )
             )
             await collector.maybe_flush()
 
-    logger.info("Backfilled %d file records for %s", len(file_paths), repo_full_name)
+    logger.info(
+        "Backfilled %d file records (%d with contents) for %s",
+        len(file_paths),
+        len(contents_by_path),
+        repo_full_name,
+    )
 
 
 async def backfill_commit_stat_records(

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -3,6 +3,10 @@ import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from dev_health_ops.analytics.complexity import (
+    DEFAULT_COMPLEXITY_CONFIG_PATH,
+    ComplexityScanner,
+)
 from dev_health_ops.credentials.types import GitHubCredentials
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models import git as git_models
@@ -708,6 +712,59 @@ def _split_full_name(full_name: str) -> tuple[str, str]:
     return parts[0], parts[1]
 
 
+# Bounds for API-based file-content backfill: skip blobs the complexity
+# scanner would reject anyway, oversized blobs, and runaway repos.
+CONTENT_FETCH_MAX_BYTES = 1_000_000
+CONTENT_FETCH_MAX_FILES = 2_000
+
+
+async def _fetch_scannable_contents(
+    connector: GitHubConnector,
+    owner: str,
+    repo_name: str,
+    ref: str,
+    file_paths: list[str],
+    blob_sizes: dict[str, int | None],
+    repo_full_name: str,
+) -> dict[str, str]:
+    """Fetch text for scanner-eligible files via batched GraphQL blob queries.
+
+    Only paths matching the complexity scanner's include/exclude globs are
+    fetched, keeping API volume proportional to what the metrics jobs can
+    actually use. Errors degrade to a paths-only backfill (contents stay
+    NULL) rather than failing the sync.
+    """
+    scanner = ComplexityScanner(config_path=DEFAULT_COMPLEXITY_CONFIG_PATH)
+    scannable: list[str] = []
+    for path in file_paths:
+        if not scanner.should_process(path):
+            continue
+        size = blob_sizes.get(path)
+        if size is not None and size > CONTENT_FETCH_MAX_BYTES:
+            continue
+        scannable.append(path)
+        if len(scannable) >= CONTENT_FETCH_MAX_FILES:
+            logging.warning(
+                "Capping content fetch at %d files for %s",
+                CONTENT_FETCH_MAX_FILES,
+                repo_full_name,
+            )
+            break
+
+    if not scannable:
+        return {}
+
+    loop = asyncio.get_running_loop()
+    try:
+        return await loop.run_in_executor(
+            None,
+            lambda: connector.get_file_contents(owner, repo_name, scannable, ref=ref),
+        )
+    except Exception as e:
+        logging.warning("Failed to fetch file contents for %s: %s", repo_full_name, e)
+        return {}
+
+
 async def _backfill_github_missing_data(
     store: Any,
     ingestion_sink: IngestionSink,
@@ -717,6 +774,8 @@ async def _backfill_github_missing_data(
     default_branch: str,
     max_commits: int | None,
     blame_only: bool = False,
+    include_blame: bool = True,
+    include_commit_stats: bool = True,
 ) -> None:
     # Logic matches the CLI sync orchestration.
     logging.info(
@@ -725,17 +784,31 @@ async def _backfill_github_missing_data(
     )
     owner, repo_name = _split_full_name(repo_full_name)
 
-    needs = await check_backfill_needs(store, db_repo.id, blame_only=blame_only)
-    if not needs.any:
+    # check_backfill_needs's blame_only flag doubles as "skip commit stats".
+    needs = await check_backfill_needs(
+        store, db_repo.id, blame_only=blame_only or not include_commit_stats
+    )
+
+    # Repos synced before content fetching existed have paths-only rows
+    # (contents NULL), which has_any_git_files treats as "done". Upgrade
+    # them by re-running the files backfill when no contents exist yet;
+    # ReplacingMergeTree(last_synced) supersedes the stale rows.
+    needs_files = needs.files
+    if not needs_files and hasattr(store, "has_any_git_file_contents"):
+        needs_files = not await store.has_any_git_file_contents(db_repo.id)
+
+    needs_blame = needs.blame and include_blame
+    if not (needs_files or needs_blame or needs.commit_stats):
         return
 
     gh_repo = connector.github.get_repo(f"{owner}/{repo_name}")
 
     file_paths: list[str] = []
-    if needs.files or needs.blame:
+    if needs_files or needs_blame:
         try:
             branch = gh_repo.get_branch(default_branch)
             tree = gh_repo.get_git_tree(branch.commit.sha, recursive=True)
+            blob_sizes: dict[str, int | None] = {}
             for entry in getattr(tree, "tree", []) or []:
                 if getattr(entry, "type", None) != "blob":
                     continue
@@ -743,10 +816,24 @@ async def _backfill_github_missing_data(
                 if not path:
                     continue
                 file_paths.append(path)
+                blob_sizes[path] = getattr(entry, "size", None)
 
-            if needs.files and file_paths:
+            if needs_files and file_paths:
+                contents_by_path = await _fetch_scannable_contents(
+                    connector,
+                    owner,
+                    repo_name,
+                    default_branch,
+                    file_paths,
+                    blob_sizes,
+                    repo_full_name,
+                )
                 await backfill_file_records(
-                    ingestion_sink, db_repo.id, file_paths, repo_full_name
+                    ingestion_sink,
+                    db_repo.id,
+                    file_paths,
+                    repo_full_name,
+                    contents_by_path=contents_by_path,
                 )
         except Exception as e:
             logging.warning(
@@ -804,7 +891,7 @@ async def _backfill_github_missing_data(
                 e,
             )
 
-    if needs.blame and file_paths:
+    if needs_blame and file_paths:
         processed_files = 0
         try:
             logging.info(
@@ -873,6 +960,7 @@ async def process_github_repo(
     sync_deployments: bool = True,
     sync_incidents: bool = True,
     sync_security: bool = True,
+    backfill_missing: bool = True,
     since: datetime | None = None,
 ) -> None:
     """
@@ -1076,6 +1164,31 @@ async def process_github_repo(
                 await loop.run_in_executor(
                     None, _fetch_github_blame_sync, gh_repo, db_repo.id
                 )
+
+            # 6. Backfill file records + contents so DB-based metrics
+            # (e.g. complexity) can run without a local checkout. Gated on
+            # sync_git so non-git targets (prs, cicd, ...) stay lean. Blame
+            # is excluded here: it costs one GraphQL call per file and has
+            # its own dedicated sync target.
+            if backfill_missing and sync_git:
+                try:
+                    await _backfill_github_missing_data(
+                        store=store,
+                        ingestion_sink=ingestion_sink,
+                        connector=connector,
+                        db_repo=db_repo,
+                        repo_full_name=repo_info.full_name,
+                        default_branch=repo_info.default_branch,
+                        max_commits=max_commits,
+                        include_blame=False,
+                        include_commit_stats=False,
+                    )
+                except Exception as e:
+                    logging.warning(
+                        "Backfill failed for GitHub repo %s: %s",
+                        repo_info.full_name,
+                        e,
+                    )
 
             logging.info(
                 "Successfully processed GitHub repository: %s/%s",
@@ -1364,7 +1477,7 @@ async def process_github_repos_batch(
             )
             await ingestion_sink.insert_git_commit_stats([stat])
 
-        if backfill_missing:
+        if backfill_missing and sync_git:
             try:
                 await _backfill_github_missing_data(
                     store=store,
@@ -1374,6 +1487,8 @@ async def process_github_repos_batch(
                     repo_full_name=repo_info.full_name,
                     default_branch=repo_info.default_branch,
                     max_commits=max_commits_per_repo,
+                    include_blame=False,
+                    include_commit_stats=False,
                 )
             except Exception as e:
                 logging.debug(

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -4,6 +4,10 @@ from collections.abc import Iterable
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
 
+from dev_health_ops.analytics.complexity import (
+    DEFAULT_COMPLEXITY_CONFIG_PATH,
+    ComplexityScanner,
+)
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models import git as git_models
 from dev_health_ops.models.git import (
@@ -656,6 +660,61 @@ def _fetch_gitlab_blame_sync(gl_project, connector, project_id, repo_id, limit=5
     return blame_batch
 
 
+# Bounds for API-based file-content backfill (parity with the GitHub
+# processor): skip blobs the complexity scanner would reject, oversized
+# blobs (enforced via GraphQL rawSize), and runaway repos.
+CONTENT_FETCH_MAX_BYTES = 1_000_000
+CONTENT_FETCH_MAX_FILES = 2_000
+
+
+async def _fetch_scannable_contents(
+    connector: Any,
+    project_full_name: str,
+    ref: str,
+    file_paths: list[str],
+) -> dict[str, str]:
+    """Fetch text for scanner-eligible files via batched GraphQL blob queries.
+
+    Only paths matching the complexity scanner's include/exclude globs are
+    fetched, keeping API volume proportional to what the metrics jobs can
+    actually use. Errors degrade to a paths-only backfill (contents stay
+    NULL) rather than failing the sync.
+    """
+    scanner = ComplexityScanner(config_path=DEFAULT_COMPLEXITY_CONFIG_PATH)
+    scannable: list[str] = []
+    for path in file_paths:
+        if not scanner.should_process(path):
+            continue
+        scannable.append(path)
+        if len(scannable) >= CONTENT_FETCH_MAX_FILES:
+            logging.warning(
+                "Capping content fetch at %d files for %s",
+                CONTENT_FETCH_MAX_FILES,
+                project_full_name,
+            )
+            break
+
+    if not scannable:
+        return {}
+
+    loop = asyncio.get_running_loop()
+    try:
+        return await loop.run_in_executor(
+            None,
+            lambda: connector.get_file_contents(
+                project_full_name,
+                scannable,
+                ref=ref,
+                max_bytes=CONTENT_FETCH_MAX_BYTES,
+            ),
+        )
+    except Exception as e:
+        logging.warning(
+            "Failed to fetch file contents for %s: %s", project_full_name, e
+        )
+        return {}
+
+
 async def _backfill_gitlab_missing_data(
     store: Any,
     ingestion_sink: IngestionSink,
@@ -665,9 +724,24 @@ async def _backfill_gitlab_missing_data(
     default_branch: str,
     max_commits: int | None,
     blame_only: bool = False,
+    include_blame: bool = True,
+    include_commit_stats: bool = True,
 ) -> None:
-    needs = await check_backfill_needs(store, db_repo.id, blame_only=blame_only)
-    if not needs.any:
+    # check_backfill_needs's blame_only flag doubles as "skip commit stats".
+    needs = await check_backfill_needs(
+        store, db_repo.id, blame_only=blame_only or not include_commit_stats
+    )
+
+    # Repos synced before content fetching existed have paths-only rows
+    # (contents NULL), which has_any_git_files treats as "done". Upgrade
+    # them by re-running the files backfill when no contents exist yet;
+    # ReplacingMergeTree(last_synced) supersedes the stale rows.
+    needs_files = needs.files
+    if not needs_files and hasattr(store, "has_any_git_file_contents"):
+        needs_files = not await store.has_any_git_file_contents(db_repo.id)
+
+    needs_blame = needs.blame and include_blame
+    if not (needs_files or needs_blame or needs.commit_stats):
         return
 
     try:
@@ -677,7 +751,7 @@ async def _backfill_gitlab_missing_data(
         return
 
     file_paths: list[str] = []
-    if needs.files or needs.blame:
+    if needs_files or needs_blame:
         try:
             items = _iter_gitlab_repo_tree(
                 project,
@@ -697,9 +771,19 @@ async def _backfill_gitlab_missing_data(
                 continue
             file_paths.append(path)
 
-        if needs.files and file_paths:
+        if needs_files and file_paths:
+            contents_by_path = await _fetch_scannable_contents(
+                connector,
+                project_full_name,
+                default_branch,
+                file_paths,
+            )
             await backfill_file_records(
-                ingestion_sink, db_repo.id, file_paths, project_full_name
+                ingestion_sink,
+                db_repo.id,
+                file_paths,
+                project_full_name,
+                contents_by_path=contents_by_path,
             )
 
     if needs.commit_stats:
@@ -745,7 +829,7 @@ async def _backfill_gitlab_missing_data(
                         f"Failed commit stat fetch for {project_full_name}@{sha}: {e}"
                     )
 
-    if needs.blame and file_paths:
+    if needs_blame and file_paths:
         async with AsyncBatchCollector(
             ingestion_sink.insert_blame_data
         ) as blame_collector:
@@ -798,6 +882,7 @@ async def process_gitlab_project(
     sync_deployments: bool = True,
     sync_incidents: bool = True,
     sync_security: bool = True,
+    backfill_missing: bool = True,
     since: datetime | None = None,
 ) -> None:
     """
@@ -997,6 +1082,29 @@ async def process_gitlab_project(
             if blame_batch:
                 await ingestion_sink.insert_blame_data(blame_batch)
                 logging.info(f"Stored {len(blame_batch)} blame records from GitLab")
+
+        # 6. Backfill file records + contents so DB-based metrics (e.g.
+        # complexity) can run without a local checkout. Gated on sync_git
+        # so non-git targets (prs, cicd, ...) stay lean. Blame is excluded
+        # here: it costs one REST call per file and has its own dedicated
+        # sync target.
+        if backfill_missing and sync_git:
+            try:
+                await _backfill_gitlab_missing_data(
+                    store=store,
+                    ingestion_sink=ingestion_sink,
+                    connector=connector,
+                    db_repo=db_repo,
+                    project_full_name=full_name,
+                    default_branch=db_repo.settings.get("default_branch", "main"),
+                    max_commits=max_commits,
+                    include_blame=False,
+                    include_commit_stats=False,
+                )
+            except Exception as e:
+                logging.warning(
+                    "Backfill failed for GitLab project %s: %s", full_name, e
+                )
 
         logging.info(f"Successfully processed GitLab project: {project_id}")
 
@@ -1270,7 +1378,7 @@ async def process_gitlab_projects_batch(
             )
             await ingestion_sink.insert_git_commit_stats([stat])
 
-        if backfill_missing:
+        if backfill_missing and sync_git:
             try:
                 await _backfill_gitlab_missing_data(
                     store=store,
@@ -1280,6 +1388,8 @@ async def process_gitlab_projects_batch(
                     project_full_name=project_info.full_name,
                     default_branch=project_info.default_branch,
                     max_commits=max_commits_per_project,
+                    include_blame=False,
+                    include_commit_stats=False,
                 )
             except Exception as e:
                 logging.debug(

--- a/src/dev_health_ops/processors/sync.py
+++ b/src/dev_health_ops/processors/sync.py
@@ -219,7 +219,7 @@ async def sync_github_target(ns: argparse.Namespace, target: str) -> int:
                 "sync_incidents": flags["sync_incidents"],
                 "sync_security": flags["sync_security"],
                 "blame_only": flags["blame_only"],
-                "backfill_missing": False,
+                "backfill_missing": True,
                 "since": since,
             }
             if max_commits is not None:

--- a/src/dev_health_ops/processors/sync.py
+++ b/src/dev_health_ops/processors/sync.py
@@ -283,7 +283,7 @@ async def sync_gitlab_target(ns: argparse.Namespace, target: str) -> int:
                 "sync_incidents": flags["sync_incidents"],
                 "sync_security": flags["sync_security"],
                 "blame_only": flags["blame_only"],
-                "backfill_missing": False,
+                "backfill_missing": True,
                 "since": since,
             }
             if max_commits is not None:

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -453,6 +453,20 @@ class ClickHouseStore:
     async def has_any_git_files(self, repo_id) -> bool:
         return await self._has_any("git_files", self._normalize_uuid(repo_id))
 
+    async def has_any_git_file_contents(self, repo_id) -> bool:
+        assert self.client is not None
+        query = (
+            "SELECT 1 FROM git_files WHERE repo_id = {repo_id:UUID} "
+            "AND contents IS NOT NULL AND contents != '' LIMIT 1"
+        )
+        async with self._lock:
+            result = await asyncio.to_thread(
+                self.client.query,
+                query,
+                parameters={"repo_id": str(self._normalize_uuid(repo_id))},
+            )
+        return bool(getattr(result, "result_rows", None))
+
     async def has_any_git_commit_stats(self, repo_id) -> bool:
         return await self._has_any("git_commit_stats", self._normalize_uuid(repo_id))
 

--- a/src/dev_health_ops/storage/mixins/git.py
+++ b/src/dev_health_ops/storage/mixins/git.py
@@ -22,6 +22,19 @@ class GitDataMixin(SQLAlchemyStoreMixinProtocol):
         )
         return (result.scalar() or 0) > 0
 
+    async def has_any_git_file_contents(self, repo_id) -> bool:
+        assert self.session is not None
+        result = await self.session.execute(
+            select(func.count())
+            .select_from(GitFile)
+            .where(
+                GitFile.repo_id == repo_id,
+                GitFile.contents.is_not(None),
+                GitFile.contents != "",
+            )
+        )
+        return (result.scalar() or 0) > 0
+
     async def has_any_git_commit_stats(self, repo_id) -> bool:
         assert self.session is not None
         result = await self.session.execute(

--- a/src/dev_health_ops/workers/metrics_extra.py
+++ b/src/dev_health_ops/workers/metrics_extra.py
@@ -75,7 +75,7 @@ def run_complexity_job(
             org_id=org_id or "",
         )
         return {
-            "status": "success",
+            "status": "success" if result == 0 else "no_data",
             "day": target_day.isoformat(),
             "backfill_days": backfill_days,
             "exit_code": result,

--- a/tests/test_connectors_graphql.py
+++ b/tests/test_connectors_graphql.py
@@ -140,3 +140,50 @@ def test_get_blame_passes_expected_variables(monkeypatch):
         "path": "src/main.py",
         "ref": "main",
     }
+
+
+def test_get_blob_texts_empty_paths_returns_empty():
+    client = GitHubGraphQLClient("token")
+    assert client.get_blob_texts("octo", "repo", "main", []) == {}
+
+
+def test_get_blob_texts_batches_aliases_and_filters(monkeypatch):
+    client = GitHubGraphQLClient("token")
+    query = MagicMock(
+        return_value={
+            "repository": {
+                "f0": {"text": "print('a')\n", "isBinary": False, "isTruncated": False},
+                "f1": {"text": None, "isBinary": True, "isTruncated": False},
+                "f2": {"text": "huge", "isBinary": False, "isTruncated": True},
+                "f3": None,
+            }
+        }
+    )
+    monkeypatch.setattr(client, "query", query)
+
+    paths = ["src/a.py", "img/logo.png", "big.py", "gone.py"]
+    result = client.get_blob_texts("octo", "repo", "main", paths)
+
+    assert result == {
+        "src/a.py": "print('a')\n",
+        "img/logo.png": None,
+        "big.py": None,
+        "gone.py": None,
+    }
+    query.assert_called_once()
+    query_text = query.call_args.args[0]
+    # One alias per path, resolved against the requested ref.
+    assert 'f0: object(expression: "main:src/a.py")' in query_text
+    assert 'f3: object(expression: "main:gone.py")' in query_text
+    assert query.call_args.args[1] == {"owner": "octo", "repo": "repo"}
+
+
+def test_get_blob_texts_escapes_quotes_in_paths(monkeypatch):
+    client = GitHubGraphQLClient("token")
+    query = MagicMock(return_value={"repository": {}})
+    monkeypatch.setattr(client, "query", query)
+
+    client.get_blob_texts("octo", "repo", "main", ['we"ird.py'])
+
+    query_text = query.call_args.args[0]
+    assert '"main:we\\"ird.py"' in query_text

--- a/tests/test_github_connector.py
+++ b/tests/test_github_connector.py
@@ -253,3 +253,50 @@ def test_get_pull_request_reviews_uses_graphql_pagination() -> None:
     assert reviews[0].reviewer == "reviewer"
     assert reviews[1].reviewer == "Unknown"
     assert graphql.query.call_count == 2
+
+
+class TestGitHubConnectorFileContents:
+    """Tests for batched file-content fetching via GraphQL blobs."""
+
+    @pytest.fixture
+    def mock_github_client(self):
+        with patch("dev_health_ops.connectors.github.Github") as mock_github:
+            yield mock_github
+
+    @pytest.fixture
+    def mock_graphql_client(self):
+        with patch(
+            "dev_health_ops.connectors.github.GitHubGraphQLClient"
+        ) as mock_graphql:
+            yield mock_graphql
+
+    def test_get_file_contents_chunks_and_drops_none(
+        self, mock_github_client, mock_graphql_client, monkeypatch
+    ):
+        connector = GitHubConnector(token="test_token")
+        get_blob_texts = Mock(
+            side_effect=[
+                {"a.py": "print('a')\n", "logo.png": None},
+                {"b.py": "print('b')\n"},
+            ]
+        )
+        monkeypatch.setattr(connector.graphql, "get_blob_texts", get_blob_texts)
+
+        result = connector.get_file_contents(
+            "octo", "repo", ["a.py", "logo.png", "b.py"], ref="main", batch_size=2
+        )
+
+        assert result == {"a.py": "print('a')\n", "b.py": "print('b')\n"}
+        assert get_blob_texts.call_count == 2
+        first_call = get_blob_texts.call_args_list[0]
+        assert first_call.args == ("octo", "repo", "main", ["a.py", "logo.png"])
+
+    def test_get_file_contents_empty_paths(
+        self, mock_github_client, mock_graphql_client, monkeypatch
+    ):
+        connector = GitHubConnector(token="test_token")
+        get_blob_texts = Mock()
+        monkeypatch.setattr(connector.graphql, "get_blob_texts", get_blob_texts)
+
+        assert connector.get_file_contents("octo", "repo", []) == {}
+        get_blob_texts.assert_not_called()

--- a/tests/test_github_content_backfill.py
+++ b/tests/test_github_content_backfill.py
@@ -1,0 +1,254 @@
+"""Tests for API-based file-content backfill (no local checkout).
+
+Covers the scanner-driven path selection in
+``processors.github._fetch_scannable_contents``, content propagation through
+``processors.base_git.backfill_file_records``, and the complexity job's
+loud-failure exit when an org has no scannable contents at all.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+# Initialize the connectors package before processors.github to avoid the
+# pre-existing providers._base <-> connectors circular import when this file
+# is collected in isolation.
+import dev_health_ops.connectors  # noqa: F401
+import dev_health_ops.metrics.job_complexity_db as job
+from dev_health_ops.processors.base_git import backfill_file_records
+from dev_health_ops.processors.github import (
+    CONTENT_FETCH_MAX_BYTES,
+    _fetch_scannable_contents,
+)
+
+
+class TestFetchScannableContents:
+    @pytest.mark.asyncio
+    async def test_filters_by_scanner_globs_and_size(self):
+        connector = Mock()
+        connector.get_file_contents = Mock(return_value={"src/app.py": "x = 1\n"})
+
+        file_paths = [
+            "src/app.py",
+            "README.md",
+            "lib/tests/test_app.py",
+            "pkg/__init__.py",
+            "src/huge.py",
+        ]
+        blob_sizes: dict[str, int | None] = {
+            "src/app.py": 120,
+            "README.md": 50,
+            "lib/tests/test_app.py": 80,
+            "pkg/__init__.py": 10,
+            "src/huge.py": CONTENT_FETCH_MAX_BYTES + 1,
+        }
+
+        result = await _fetch_scannable_contents(
+            connector, "octo", "repo", "main", file_paths, blob_sizes, "octo/repo"
+        )
+
+        assert result == {"src/app.py": "x = 1\n"}
+        connector.get_file_contents.assert_called_once_with(
+            "octo", "repo", ["src/app.py"], ref="main"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_scannable_paths_skips_api(self):
+        connector = Mock()
+        connector.get_file_contents = Mock()
+
+        result = await _fetch_scannable_contents(
+            connector, "octo", "repo", "main", ["README.md"], {}, "octo/repo"
+        )
+
+        assert result == {}
+        connector.get_file_contents.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_api_error_degrades_to_empty(self):
+        connector = Mock()
+        connector.get_file_contents = Mock(side_effect=RuntimeError("boom"))
+
+        result = await _fetch_scannable_contents(
+            connector, "octo", "repo", "main", ["src/app.py"], {}, "octo/repo"
+        )
+
+        assert result == {}
+
+
+class TestBackfillFileRecordsContents:
+    @pytest.mark.asyncio
+    async def test_writes_contents_for_known_paths(self):
+        written = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert)
+        repo_id = uuid.uuid4()
+
+        await backfill_file_records(
+            sink,
+            repo_id,
+            ["src/app.py", "README.md"],
+            "octo/repo",
+            contents_by_path={"src/app.py": "x = 1\n"},
+        )
+
+        by_path = {f.path: f.contents for f in written}
+        assert by_path == {"src/app.py": "x = 1\n", "README.md": None}
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_null_contents(self):
+        written = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert)
+
+        await backfill_file_records(sink, uuid.uuid4(), ["a.py"], "octo/repo")
+
+        assert [f.contents for f in written] == [None]
+
+
+class _EmptyClickHouseClient:
+    def query(self, query, parameters=None):
+        class _Result:
+            result_rows = []
+
+        result = _Result()
+        if "count()" in query and "FROM git_files" in query:
+            result.result_rows = [[0, 0]]
+        elif "maxOrNull" in query:
+            result.result_rows = [[None]]
+        return result
+
+
+class _EmptySink:
+    def __init__(self):
+        self.client = _EmptyClickHouseClient()
+        self.snapshots = []
+        self.dailies = []
+
+    def ensure_tables(self):
+        return None
+
+    def write_file_complexity_snapshots(self, rows):
+        self.snapshots.extend(rows)
+
+    def write_repo_complexity_daily(self, rows):
+        self.dailies.extend(rows)
+
+    def close(self):
+        return None
+
+
+def test_complexity_job_returns_nonzero_when_no_repo_has_contents(monkeypatch):
+    sink = _EmptySink()
+    monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: sink)
+
+    rc = job.run_complexity_db_job(
+        repo_id=uuid.uuid4(),
+        db_url="clickhouse://localhost:8123/default",
+        date=date(2026, 6, 12),
+        backfill_days=1,
+        language_globs=None,
+        max_files=None,
+        org_id="test-org",
+    )
+
+    assert rc == 1
+    assert not sink.snapshots
+    assert not sink.dailies
+
+
+class _FakeTreeEntry:
+    def __init__(self, path, size=100, type_="blob"):
+        self.path = path
+        self.size = size
+        self.type = type_
+
+
+class TestPathsOnlyUpgrade:
+    @pytest.mark.asyncio
+    async def test_backfill_refetches_contents_for_paths_only_repos(self):
+        """Repos with paths-only git_files rows (pre-content-sync) get upgraded."""
+        from dev_health_ops.processors.github import _backfill_github_missing_data
+
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=False)
+        store.has_any_git_commit_stats = AsyncMock(return_value=True)
+        store.has_any_git_blame = AsyncMock(return_value=True)
+
+        written = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert)
+
+        gh_repo = Mock()
+        gh_repo.get_branch.return_value = Mock(commit=Mock(sha="abc"))
+        gh_repo.get_git_tree.return_value = Mock(
+            tree=[_FakeTreeEntry("src/app.py"), _FakeTreeEntry("README.md")]
+        )
+        connector = Mock()
+        connector.github.get_repo.return_value = gh_repo
+        connector.get_file_contents = Mock(return_value={"src/app.py": "x = 1\n"})
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_github_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            repo_full_name="octo/repo",
+            default_branch="main",
+            max_commits=None,
+            include_blame=False,
+            include_commit_stats=False,
+        )
+
+        by_path = {f.path: f.contents for f in written}
+        assert by_path == {"src/app.py": "x = 1\n", "README.md": None}
+
+    @pytest.mark.asyncio
+    async def test_backfill_skips_when_contents_already_present(self):
+        from dev_health_ops.processors.github import _backfill_github_missing_data
+
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=True)
+        store.has_any_git_commit_stats = AsyncMock(return_value=True)
+        store.has_any_git_blame = AsyncMock(return_value=True)
+
+        connector = Mock()
+        sink = Mock()
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_github_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            repo_full_name="octo/repo",
+            default_branch="main",
+            max_commits=None,
+            include_blame=False,
+            include_commit_stats=False,
+        )
+
+        connector.github.get_repo.assert_not_called()
+        sink.insert_git_file_data.assert_not_called()

--- a/tests/test_gitlab_content_backfill.py
+++ b/tests/test_gitlab_content_backfill.py
@@ -1,0 +1,217 @@
+"""Tests for GitLab API-based file-content backfill (no local checkout).
+
+Mirrors tests/test_github_content_backfill.py: covers the batched GraphQL
+blob fetch on the connector, the scanner-driven path selection in
+``processors.gitlab._fetch_scannable_contents``, and the paths-only repo
+upgrade through ``_backfill_gitlab_missing_data``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+# Initialize the connectors package before processors.gitlab to avoid the
+# pre-existing providers._base <-> connectors circular import when this file
+# is collected in isolation.
+import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.connectors import GitLabConnector
+from dev_health_ops.processors.gitlab import (
+    _backfill_gitlab_missing_data,
+    _fetch_scannable_contents,
+)
+
+
+class _FakeGraphQLResponse:
+    def __init__(self, nodes, status_code=200):
+        self.status_code = status_code
+        self._nodes = nodes
+        self.headers = {}
+        self.text = ""
+
+    def json(self):
+        return {"data": {"project": {"repository": {"blobs": {"nodes": self._nodes}}}}}
+
+
+class TestGetFileContents:
+    @pytest.fixture
+    def mock_gitlab_client(self):
+        with patch("dev_health_ops.connectors.gitlab.gitlab.Gitlab") as mock_gitlab:
+            yield mock_gitlab
+
+    @pytest.fixture
+    def mock_rest_client(self):
+        with patch("dev_health_ops.connectors.gitlab.GitLabRESTClient") as mock_rest:
+            yield mock_rest
+
+    def test_batches_paths_and_filters_binary_and_oversized(
+        self, mock_gitlab_client, mock_rest_client
+    ):
+        connector = GitLabConnector(
+            url="https://gitlab.example.com", private_token="tok"
+        )
+        response = _FakeGraphQLResponse(
+            [
+                {"path": "src/a.py", "rawTextBlob": "x = 1\n", "rawSize": 7},
+                {"path": "img/logo.png", "rawTextBlob": None, "rawSize": 5000},
+                {"path": "big.py", "rawTextBlob": "huge", "rawSize": 2_000_000},
+            ]
+        )
+        with patch(
+            "dev_health_ops.connectors.gitlab.requests.post",
+            return_value=response,
+        ) as post:
+            result = connector.get_file_contents(
+                "group/proj",
+                ["src/a.py", "img/logo.png", "big.py"],
+                ref="main",
+            )
+
+        assert result == {"src/a.py": "x = 1\n"}
+        post.assert_called_once()
+        _, kwargs = post.call_args
+        assert post.call_args.args[0] == "https://gitlab.example.com/api/graphql"
+        assert kwargs["json"]["variables"] == {
+            "fullPath": "group/proj",
+            "ref": "main",
+            "paths": ["src/a.py", "img/logo.png", "big.py"],
+        }
+        assert kwargs["headers"]["PRIVATE-TOKEN"] == "tok"
+
+    def test_chunks_by_batch_size(self, mock_gitlab_client, mock_rest_client):
+        connector = GitLabConnector(
+            url="https://gitlab.example.com", private_token="tok"
+        )
+        responses = [
+            _FakeGraphQLResponse([{"path": "a.py", "rawTextBlob": "a", "rawSize": 1}]),
+            _FakeGraphQLResponse([{"path": "b.py", "rawTextBlob": "b", "rawSize": 1}]),
+        ]
+        with patch(
+            "dev_health_ops.connectors.gitlab.requests.post",
+            side_effect=responses,
+        ) as post:
+            result = connector.get_file_contents(
+                "group/proj", ["a.py", "b.py"], ref="main", batch_size=1
+            )
+
+        assert result == {"a.py": "a", "b.py": "b"}
+        assert post.call_count == 2
+
+    def test_empty_paths_makes_no_request(self, mock_gitlab_client, mock_rest_client):
+        connector = GitLabConnector(
+            url="https://gitlab.example.com", private_token="tok"
+        )
+        with patch("dev_health_ops.connectors.gitlab.requests.post") as post:
+            assert connector.get_file_contents("group/proj", []) == {}
+        post.assert_not_called()
+
+
+class TestFetchScannableContents:
+    @pytest.mark.asyncio
+    async def test_filters_by_scanner_globs(self):
+        connector = Mock()
+        connector.get_file_contents = Mock(return_value={"src/app.py": "x = 1\n"})
+
+        result = await _fetch_scannable_contents(
+            connector,
+            "group/proj",
+            "main",
+            ["src/app.py", "README.md", "pkg/__init__.py"],
+        )
+
+        assert result == {"src/app.py": "x = 1\n"}
+        connector.get_file_contents.assert_called_once_with(
+            "group/proj", ["src/app.py"], ref="main", max_bytes=1_000_000
+        )
+
+    @pytest.mark.asyncio
+    async def test_api_error_degrades_to_empty(self):
+        connector = Mock()
+        connector.get_file_contents = Mock(side_effect=RuntimeError("boom"))
+
+        result = await _fetch_scannable_contents(
+            connector, "group/proj", "main", ["src/app.py"]
+        )
+
+        assert result == {}
+
+
+class TestGitLabBackfillContents:
+    @pytest.mark.asyncio
+    async def test_backfill_writes_contents_for_paths_only_repos(self):
+        """Projects with paths-only git_files rows get upgraded."""
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=False)
+        store.has_any_git_commit_stats = AsyncMock(return_value=True)
+        store.has_any_git_blame = AsyncMock(return_value=True)
+
+        written = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert)
+
+        project = Mock()
+        connector = Mock()
+        connector.gitlab.projects.get.return_value = project
+        connector.get_file_contents = Mock(return_value={"src/app.py": "x = 1\n"})
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        tree_items = [
+            {"type": "blob", "path": "src/app.py"},
+            {"type": "blob", "path": "README.md"},
+            {"type": "tree", "path": "src"},
+        ]
+        with patch(
+            "dev_health_ops.processors.gitlab._iter_gitlab_repo_tree",
+            return_value=tree_items,
+        ):
+            await _backfill_gitlab_missing_data(
+                store=store,
+                ingestion_sink=sink,
+                connector=connector,
+                db_repo=db_repo,
+                project_full_name="group/proj",
+                default_branch="main",
+                max_commits=None,
+                include_blame=False,
+                include_commit_stats=False,
+            )
+
+        by_path = {f.path: f.contents for f in written}
+        assert by_path == {"src/app.py": "x = 1\n", "README.md": None}
+
+    @pytest.mark.asyncio
+    async def test_backfill_skips_when_contents_already_present(self):
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=True)
+        store.has_any_git_commit_stats = AsyncMock(return_value=True)
+        store.has_any_git_blame = AsyncMock(return_value=True)
+
+        connector = Mock()
+        sink = Mock()
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_gitlab_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            project_full_name="group/proj",
+            default_branch="main",
+            max_commits=None,
+            include_blame=False,
+            include_commit_stats=False,
+        )
+
+        connector.gitlab.projects.get.assert_not_called()
+        sink.insert_git_file_data.assert_not_called()


### PR DESCRIPTION
## Stacked on #882

GitLab twin of #882 (branch base = `feat/github-file-contents-backfill`; retarget to `main` after #882 merges). Brings the API-based file-content sync to the GitLab provider so the complexity metric works for GitLab-synced orgs without a local checkout.

## Changes

- **`GitLabConnector.get_file_contents`** — GitLab GraphQL natively batches blobs (`repository.blobs(ref:, paths:)`), so no alias tricks needed: one request per ~50 paths, `rawTextBlob` is null for binary blobs, `rawSize` enforces the 1 MB cap. PRIVATE-TOKEN auth; works for self-hosted instances (`{url}/api/graphql`).
- **`_backfill_gitlab_missing_data`** — same shape as the GitHub backfill: `include_blame`/`include_commit_stats` params, `has_any_git_file_contents` upgrade gate for paths-only repos, scanner-glob-filtered contents persisted via `backfill_file_records(contents_by_path=...)`. GitLab's blame backfill (which, unlike GitHub's, carries real line text) is untouched and still available via the blame target.
- **`process_gitlab_project`** — files-only backfill on every regular git sync (`backfill_missing=True` default, gated on `sync_git`); worker path (`sync_runtime`) picks this up automatically since `_merge_sync_flags` doesn't override it. Batch call site aligned; CLI batch `backfill_missing` re-enabled.

## Verification

- **Live against gitlab.com with this instance's stored service-account credential**: synced `full.chaos/dev-health-ops` (project 77145099) → `Retrieved contents for 847/847 files`, `Backfilled 1253 file records (847 with contents)`
- `dev-hops metrics complexity --org a78c1a6a-...` now writes **847 file snapshots for the gitlab repo** (alongside the 2,796 for its github twin)
- Gates: ruff ✓, mypy (1,027 files) ✓, unit suite 4,158 passed (same 10 pre-existing env failures as untouched main)
- New tests: `tests/test_gitlab_content_backfill.py` (8 tests: GraphQL batching/filtering/chunking, scanner filter, paths-only upgrade, skip-when-present)

## Side finding (config, not code)

The org's `chaos-gitlab` sync config reports `child_results: 0` because its credential is a group service account that can't enumerate projects via `membership=true`, and `sync_options` has `owner: ""`. The group's projects ARE visible via the group endpoint (`full.chaos` → dev-health-ops, chaos-ops) — the sync config needs `group: full.chaos` (or explicit project ids) to discover them.