### PR TITLE
fix(sync): window-aware commit-stats limit + two-pass GitLab blob fetch

### DIFF
--- a/src/dev_health_ops/connectors/gitlab.py
+++ b/src/dev_health_ops/connectors/gitlab.py
@@ -1137,9 +1137,23 @@ class GitLabConnector(GitConnector):
             eligible = []
             for start in range(0, len(paths), batch_size):
                 chunk = paths[start : start + batch_size]
-                for node in self._graphql_blobs(
-                    project_full_path, ref, chunk, "path rawSize"
-                ):
+                try:
+                    nodes = self._graphql_blobs(
+                        project_full_path, ref, chunk, "path rawSize"
+                    )
+                except Exception as exc:
+                    # Degrade to single-pass behavior for this chunk: the
+                    # size pass is an optimization, not a correctness gate.
+                    logger.warning(
+                        "Size pass failed for %d paths in %s (%s); "
+                        "fetching text without size filter",
+                        len(chunk),
+                        project_full_path,
+                        exc,
+                    )
+                    eligible.extend(chunk)
+                    continue
+                for node in nodes:
                     path = node.get("path")
                     raw_size = node.get("rawSize")
                     if not path:
@@ -1151,9 +1165,21 @@ class GitLabConnector(GitConnector):
         contents: dict[str, str] = {}
         for start in range(0, len(eligible), batch_size):
             chunk = eligible[start : start + batch_size]
-            for node in self._graphql_blobs(
-                project_full_path, ref, chunk, "path rawTextBlob"
-            ):
+            try:
+                nodes = self._graphql_blobs(
+                    project_full_path, ref, chunk, "path rawTextBlob"
+                )
+            except Exception as exc:
+                # Keep contents already fetched; a rate-limited late chunk
+                # should not discard earlier chunks' results.
+                logger.warning(
+                    "Content fetch failed for %d paths in %s: %s",
+                    len(chunk),
+                    project_full_path,
+                    exc,
+                )
+                continue
+            for node in nodes:
                 text = node.get("rawTextBlob")
                 path = node.get("path")
                 if path and text is not None:

--- a/src/dev_health_ops/connectors/gitlab.py
+++ b/src/dev_health_ops/connectors/gitlab.py
@@ -1040,6 +1040,69 @@ class GitLabConnector(GitConnector):
         initial_delay=1.0,
         exceptions=(RateLimitException, APIException),
     )
+    def _graphql_blobs(
+        self,
+        project_full_path: str,
+        ref: str,
+        paths: list[str],
+        fields: str,
+    ) -> list[dict[str, Any]]:
+        """Resolve one chunk of blobs via GitLab GraphQL.
+
+        Retry/backoff lives here (per request) so a rate-limited late chunk
+        does not force earlier successful chunks to be re-fetched.
+        """
+        query = (
+            "query($fullPath: ID!, $ref: String!, $paths: [String!]!) {\n"
+            "  project(fullPath: $fullPath) {\n"
+            "    repository {\n"
+            "      blobs(ref: $ref, paths: $paths) {\n"
+            f"        nodes {{ {fields} }}\n"
+            "      }\n"
+            "    }\n"
+            "  }\n"
+            "}"
+        )
+        headers = {"Content-Type": "application/json"}
+        if self.private_token:
+            headers["PRIVATE-TOKEN"] = self.private_token
+        payload: dict[str, Any] = {
+            "query": query,
+            "variables": {
+                "fullPath": project_full_path,
+                "ref": ref,
+                "paths": paths,
+            },
+        }
+        try:
+            response = requests.post(
+                f"{self.url}/api/graphql",
+                json=payload,
+                headers=headers,
+                timeout=30,
+            )
+        except requests.exceptions.RequestException as exc:
+            raise APIException(f"GitLab GraphQL request failed: {exc}") from exc
+        if response.status_code == 401:
+            raise AuthenticationException("GitLab authentication failed")
+        if response.status_code == 429:
+            raise RateLimitException(
+                "GitLab API rate limit exceeded",
+                retry_after_seconds=_parse_retry_after_seconds(dict(response.headers)),
+            )
+        if response.status_code != 200:
+            raise APIException(
+                f"GitLab GraphQL error: {response.status_code} - {response.text}"
+            )
+        data = response.json()
+        if data.get("errors"):
+            messages = "; ".join(e.get("message", str(e)) for e in data["errors"])
+            raise APIException(f"GitLab GraphQL errors: {messages}")
+
+        project_data = (data.get("data") or {}).get("project") or {}
+        repository = project_data.get("repository") or {}
+        return (repository.get("blobs") or {}).get("nodes") or []
+
     def get_file_contents(
         self,
         project_full_path: str,
@@ -1056,97 +1119,53 @@ class GitLabConnector(GitConnector):
         binary blobs, so those (and missing paths) are omitted from the
         result and callers can treat absence as "no usable text".
 
+        When ``max_bytes`` is set, a cheap ``rawSize``-only pass filters
+        oversized blobs first so their text never crosses the wire.
+
         :param project_full_path: Project full path (``group/project``).
         :param paths: Repository-relative file paths.
         :param ref: Git reference the paths are resolved against.
         :param batch_size: Number of blobs to resolve per GraphQL request.
+        :param max_bytes: Skip blobs larger than this (None disables).
         :return: Mapping of path -> file text for blobs with usable text.
         """
-        query = """
-        query($fullPath: ID!, $ref: String!, $paths: [String!]!) {
-          project(fullPath: $fullPath) {
-            repository {
-              blobs(ref: $ref, paths: $paths) {
-                nodes {
-                  path
-                  rawTextBlob
-                  rawSize
-                }
-              }
-            }
-          }
-        }
-        """
+        if not paths:
+            return {}
 
-        headers = {"Content-Type": "application/json"}
-        if self.private_token:
-            headers["PRIVATE-TOKEN"] = self.private_token
-
-        contents: dict[str, str] = {}
-        try:
+        eligible = paths
+        if max_bytes is not None:
+            eligible = []
             for start in range(0, len(paths), batch_size):
                 chunk = paths[start : start + batch_size]
-                payload: dict[str, Any] = {
-                    "query": query,
-                    "variables": {
-                        "fullPath": project_full_path,
-                        "ref": ref,
-                        "paths": chunk,
-                    },
-                }
-                response = requests.post(
-                    f"{self.url}/api/graphql",
-                    json=payload,
-                    headers=headers,
-                    timeout=30,
-                )
-                if response.status_code == 401:
-                    raise AuthenticationException("GitLab authentication failed")
-                if response.status_code == 429:
-                    raise RateLimitException(
-                        "GitLab API rate limit exceeded",
-                        retry_after_seconds=_parse_retry_after_seconds(
-                            dict(response.headers)
-                        ),
-                    )
-                if response.status_code != 200:
-                    raise APIException(
-                        f"GitLab GraphQL error: {response.status_code} - "
-                        f"{response.text}"
-                    )
-                data = response.json()
-                if data.get("errors"):
-                    messages = "; ".join(
-                        e.get("message", str(e)) for e in data["errors"]
-                    )
-                    raise APIException(f"GitLab GraphQL errors: {messages}")
-
-                project_data = (data.get("data") or {}).get("project") or {}
-                repository = project_data.get("repository") or {}
-                nodes = (repository.get("blobs") or {}).get("nodes") or []
-                for node in nodes:
-                    text = node.get("rawTextBlob")
+                for node in self._graphql_blobs(
+                    project_full_path, ref, chunk, "path rawSize"
+                ):
                     path = node.get("path")
-                    if not path or text is None:
-                        continue
                     raw_size = node.get("rawSize")
-                    if (
-                        max_bytes is not None
-                        and raw_size is not None
-                        and int(raw_size) > max_bytes
-                    ):
+                    if not path:
                         continue
+                    if raw_size is not None and int(raw_size) > max_bytes:
+                        continue
+                    eligible.append(path)
+
+        contents: dict[str, str] = {}
+        for start in range(0, len(eligible), batch_size):
+            chunk = eligible[start : start + batch_size]
+            for node in self._graphql_blobs(
+                project_full_path, ref, chunk, "path rawTextBlob"
+            ):
+                text = node.get("rawTextBlob")
+                path = node.get("path")
+                if path and text is not None:
                     contents[path] = text
 
-            logger.info(
-                "Retrieved contents for %d/%d files in %s",
-                len(contents),
-                len(paths),
-                project_full_path,
-            )
-            return contents
-        except requests.exceptions.RequestException as exc:
-            raise APIException(f"GitLab GraphQL request failed: {exc}") from exc
+        logger.info(
+            "Retrieved contents for %d/%d files in %s",
+            len(contents),
+            len(paths),
+            project_full_path,
+        )
+        return contents
 
     def get_dora_metrics(
         self,

--- a/src/dev_health_ops/processors/base_git.py
+++ b/src/dev_health_ops/processors/base_git.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from collections.abc import Coroutine
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
@@ -135,6 +136,28 @@ class BaseGitProcessor:
             The result of the coroutine.
         """
         return asyncio.run_coroutine_threadsafe(coro, loop).result()
+
+
+def resolve_commit_stats_limit(
+    raw_commit_count: int,
+    max_commits: int | None,
+    since: datetime | None,
+) -> int:
+    """How many commits to fetch per-file stats for.
+
+    Stats cost one extra API call per commit, so unbounded full-history
+    syncs stay conservatively capped at 50. Window-bounded syncs
+    (``since`` set) cover every commit in the window — the commit list is
+    already bounded by the sync window, and truncating it starves the
+    churn/hotspot/bus-factor daily metrics with partial days.
+
+    ``COMMIT_STATS_MAX_COMMITS`` (default 1000) is the absolute ceiling.
+    """
+    hard_cap = int(os.getenv("COMMIT_STATS_MAX_COMMITS", "1000"))
+    limit = raw_commit_count if since is not None else 50
+    if max_commits is not None:
+        limit = min(limit, max_commits)
+    return min(limit, hard_cap)
 
 
 class BackfillNeeds:

--- a/src/dev_health_ops/processors/base_git.py
+++ b/src/dev_health_ops/processors/base_git.py
@@ -151,9 +151,12 @@ def resolve_commit_stats_limit(
     already bounded by the sync window, and truncating it starves the
     churn/hotspot/bus-factor daily metrics with partial days.
 
-    ``COMMIT_STATS_MAX_COMMITS`` (default 1000) is the absolute ceiling.
+    ``COMMIT_STATS_MAX_COMMITS`` (default 300) is the absolute ceiling:
+    each commit's stats cost one extra API call against the shared
+    provider rate budget (GitHub ~5000/hr), so the ceiling bounds how much
+    a single repo sync can consume.
     """
-    hard_cap = int(os.getenv("COMMIT_STATS_MAX_COMMITS", "1000"))
+    hard_cap = int(os.getenv("COMMIT_STATS_MAX_COMMITS", "300"))
     limit = raw_commit_count if since is not None else 50
     if max_commits is not None:
         limit = min(limit, max_commits)

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -196,8 +196,14 @@ def _fetch_github_commit_stats_sync(
     repo_id,
     max_stats,
     since: datetime | None = None,
+    gate=None,
 ):
-    """Sync helper to fetch detailed commit stats (files)."""
+    """Sync helper to fetch detailed commit stats (files).
+
+    Accessing ``commit.files`` lazy-loads commit detail — one REST call per
+    commit — so each iteration waits on the rate-limit gate.
+    """
+    gate = BaseGitProcessor.ensure_gate(gate)
     stats_objects = []
     for commit in raw_commits[:max_stats]:
         if since is not None:
@@ -220,6 +226,8 @@ def _fetch_github_commit_stats_sync(
                 continue
 
         try:
+            if gate is not None:
+                gate.wait_sync()
             files = commit.files
             if files is None:
                 continue
@@ -1072,6 +1080,7 @@ async def process_github_repo(
                     db_repo.id,
                     stats_limit,
                     since,
+                    BaseGitProcessor.make_default_gate(),
                 )
 
                 if stats_objects:

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -29,6 +29,7 @@ from dev_health_ops.processors.base_git import (
     build_deployment,
     build_git_pull_request,
     check_backfill_needs,
+    resolve_commit_stats_limit,
 )
 from dev_health_ops.processors.fetch_utils import (
     AsyncBatchCollector,
@@ -1061,7 +1062,9 @@ async def process_github_repo(
 
                 # 3. Fetch Stats
                 logging.info("Fetching commit stats from GitHub...")
-                stats_limit = 50 if max_commits is None else min(max_commits, 50)
+                stats_limit = resolve_commit_stats_limit(
+                    len(raw_commits), max_commits, since
+                )
                 stats_objects = await loop.run_in_executor(
                     None,
                     _fetch_github_commit_stats_sync,

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -28,6 +28,7 @@ from dev_health_ops.processors.base_git import (
     build_deployment,
     build_git_pull_request,
     check_backfill_needs,
+    resolve_commit_stats_limit,
 )
 from dev_health_ops.processors.fetch_utils import (
     AsyncBatchCollector,
@@ -970,7 +971,9 @@ async def process_gitlab_project(
 
             # 3. Fetch Stats
             logging.info("Fetching commit stats from GitLab...")
-            stats_limit = 50 if max_commits is None else min(max_commits, 50)
+            stats_limit = resolve_commit_stats_limit(
+                len(commit_hashes), max_commits, since
+            )
             stats_objects = await loop.run_in_executor(
                 None,
                 _fetch_gitlab_commit_stats_sync,

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -165,12 +165,21 @@ def _fetch_gitlab_commits_sync(
     return commit_hashes, commit_objects
 
 
-def _fetch_gitlab_commit_stats_sync(gl_project, commit_hashes, repo_id, max_stats):
-    """Sync helper to fetch detailed commit stats from GitLab."""
+def _fetch_gitlab_commit_stats_sync(
+    gl_project, commit_hashes, repo_id, max_stats, gate=None
+):
+    """Sync helper to fetch detailed commit stats from GitLab.
+
+    Each commit detail is one REST call, so each iteration waits on the
+    rate-limit gate.
+    """
+    gate = BaseGitProcessor.ensure_gate(gate)
     stats_objects = []
 
     for commit_hash in commit_hashes[:max_stats]:
         try:
+            if gate is not None:
+                gate.wait_sync()
             detailed_commit = gl_project.commits.get(commit_hash)
             if hasattr(detailed_commit, "stats"):
                 stat = GitCommitStat(

--- a/tests/test_commit_stats_limit.py
+++ b/tests/test_commit_stats_limit.py
@@ -1,0 +1,40 @@
+"""Tests for the window-aware commit-stats limit.
+
+Historically both Git providers capped per-file commit-stat ingestion at 50
+commits per sync, which truncated coverage *inside* the initial-sync window
+and starved churn/hotspot/bus-factor daily metrics with partial days.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+# Initialize the connectors package before processors to avoid the
+# pre-existing providers._base <-> connectors circular import when this file
+# is collected in isolation.
+import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.processors.base_git import resolve_commit_stats_limit
+
+SINCE = datetime(2026, 5, 13, tzinfo=timezone.utc)
+
+
+def test_window_bounded_sync_covers_all_commits():
+    assert resolve_commit_stats_limit(300, None, SINCE) == 300
+
+
+def test_window_bounded_sync_respects_hard_cap(monkeypatch):
+    monkeypatch.setenv("COMMIT_STATS_MAX_COMMITS", "200")
+    assert resolve_commit_stats_limit(5000, None, SINCE) == 200
+
+
+def test_unbounded_sync_keeps_conservative_default():
+    assert resolve_commit_stats_limit(5000, None, None) == 50
+
+
+def test_max_commits_caps_both_modes():
+    assert resolve_commit_stats_limit(300, 10, SINCE) == 10
+    assert resolve_commit_stats_limit(300, 10, None) == 10
+
+
+def test_hard_cap_default_is_1000():
+    assert resolve_commit_stats_limit(5000, None, SINCE) == 1000

--- a/tests/test_commit_stats_limit.py
+++ b/tests/test_commit_stats_limit.py
@@ -36,5 +36,5 @@ def test_max_commits_caps_both_modes():
     assert resolve_commit_stats_limit(300, 10, None) == 10
 
 
-def test_hard_cap_default_is_1000():
-    assert resolve_commit_stats_limit(5000, None, SINCE) == 1000
+def test_hard_cap_default_is_300():
+    assert resolve_commit_stats_limit(5000, None, SINCE) == 300

--- a/tests/test_gitlab_content_backfill.py
+++ b/tests/test_gitlab_content_backfill.py
@@ -46,22 +46,33 @@ class TestGetFileContents:
         with patch("dev_health_ops.connectors.gitlab.GitLabRESTClient") as mock_rest:
             yield mock_rest
 
-    def test_batches_paths_and_filters_binary_and_oversized(
+    def test_size_pass_filters_oversized_before_text_fetch(
         self, mock_gitlab_client, mock_rest_client
     ):
+        """Pass 1 fetches only rawSize; oversized blobs never get a text fetch."""
         connector = GitLabConnector(
             url="https://gitlab.example.com", private_token="tok"
         )
-        response = _FakeGraphQLResponse(
-            [
-                {"path": "src/a.py", "rawTextBlob": "x = 1\n", "rawSize": 7},
-                {"path": "img/logo.png", "rawTextBlob": None, "rawSize": 5000},
-                {"path": "big.py", "rawTextBlob": "huge", "rawSize": 2_000_000},
-            ]
-        )
+        responses = [
+            # Pass 1: sizes
+            _FakeGraphQLResponse(
+                [
+                    {"path": "src/a.py", "rawSize": 7},
+                    {"path": "img/logo.png", "rawSize": 5000},
+                    {"path": "big.py", "rawSize": 2_000_000},
+                ]
+            ),
+            # Pass 2: text for survivors only
+            _FakeGraphQLResponse(
+                [
+                    {"path": "src/a.py", "rawTextBlob": "x = 1\n"},
+                    {"path": "img/logo.png", "rawTextBlob": None},
+                ]
+            ),
+        ]
         with patch(
             "dev_health_ops.connectors.gitlab.requests.post",
-            return_value=response,
+            side_effect=responses,
         ) as post:
             result = connector.get_file_contents(
                 "group/proj",
@@ -70,23 +81,48 @@ class TestGetFileContents:
             )
 
         assert result == {"src/a.py": "x = 1\n"}
+        assert post.call_count == 2
+        size_query = post.call_args_list[0].kwargs["json"]["query"]
+        assert "rawSize" in size_query and "rawTextBlob" not in size_query
+        text_call = post.call_args_list[1].kwargs["json"]
+        assert "rawTextBlob" in text_call["query"]
+        # big.py was filtered by the size pass
+        assert text_call["variables"]["paths"] == ["src/a.py", "img/logo.png"]
+        assert post.call_args_list[0].kwargs["headers"]["PRIVATE-TOKEN"] == "tok"
+        assert (
+            post.call_args_list[0].args[0] == "https://gitlab.example.com/api/graphql"
+        )
+
+    def test_no_size_pass_when_max_bytes_disabled(
+        self, mock_gitlab_client, mock_rest_client
+    ):
+        connector = GitLabConnector(
+            url="https://gitlab.example.com", private_token="tok"
+        )
+        response = _FakeGraphQLResponse([{"path": "a.py", "rawTextBlob": "a"}])
+        with patch(
+            "dev_health_ops.connectors.gitlab.requests.post",
+            return_value=response,
+        ) as post:
+            result = connector.get_file_contents(
+                "group/proj", ["a.py"], ref="main", max_bytes=None
+            )
+
+        assert result == {"a.py": "a"}
         post.assert_called_once()
-        _, kwargs = post.call_args
-        assert post.call_args.args[0] == "https://gitlab.example.com/api/graphql"
-        assert kwargs["json"]["variables"] == {
-            "fullPath": "group/proj",
-            "ref": "main",
-            "paths": ["src/a.py", "img/logo.png", "big.py"],
-        }
-        assert kwargs["headers"]["PRIVATE-TOKEN"] == "tok"
+        assert "rawTextBlob" in post.call_args.kwargs["json"]["query"]
 
     def test_chunks_by_batch_size(self, mock_gitlab_client, mock_rest_client):
         connector = GitLabConnector(
             url="https://gitlab.example.com", private_token="tok"
         )
         responses = [
-            _FakeGraphQLResponse([{"path": "a.py", "rawTextBlob": "a", "rawSize": 1}]),
-            _FakeGraphQLResponse([{"path": "b.py", "rawTextBlob": "b", "rawSize": 1}]),
+            # size pass, two chunks
+            _FakeGraphQLResponse([{"path": "a.py", "rawSize": 1}]),
+            _FakeGraphQLResponse([{"path": "b.py", "rawSize": 1}]),
+            # text pass, two chunks
+            _FakeGraphQLResponse([{"path": "a.py", "rawTextBlob": "a"}]),
+            _FakeGraphQLResponse([{"path": "b.py", "rawTextBlob": "b"}]),
         ]
         with patch(
             "dev_health_ops.connectors.gitlab.requests.post",
@@ -97,7 +133,7 @@ class TestGetFileContents:
             )
 
         assert result == {"a.py": "a", "b.py": "b"}
-        assert post.call_count == 2
+        assert post.call_count == 4
 
     def test_empty_paths_makes_no_request(self, mock_gitlab_client, mock_rest_client):
         connector = GitLabConnector(

--- a/tests/test_gitlab_content_backfill.py
+++ b/tests/test_gitlab_content_backfill.py
@@ -129,11 +129,59 @@ class TestGetFileContents:
             side_effect=responses,
         ) as post:
             result = connector.get_file_contents(
-                "group/proj", ["a.py", "b.py"], ref="main", batch_size=1
+                "group/proj",
+                ["a.py", "b.py"],
+                ref="main",
+                batch_size=1,
+                max_bytes=1_000_000,
             )
 
         assert result == {"a.py": "a", "b.py": "b"}
         assert post.call_count == 4
+
+    def test_size_pass_failure_degrades_to_unfiltered_text_fetch(
+        self, mock_gitlab_client, mock_rest_client
+    ):
+        connector = GitLabConnector(
+            url="https://gitlab.example.com", private_token="tok"
+        )
+        get_blobs = Mock(
+            side_effect=[
+                RuntimeError("size pass boom"),
+                [{"path": "a.py", "rawTextBlob": "a"}],
+            ]
+        )
+        with patch.object(connector, "_graphql_blobs", get_blobs):
+            result = connector.get_file_contents("group/proj", ["a.py"], ref="main")
+
+        assert result == {"a.py": "a"}
+        # Second call is the text pass over the un-filtered chunk.
+        assert get_blobs.call_args_list[1].args[3] == "path rawTextBlob"
+
+    def test_text_pass_chunk_failure_keeps_earlier_results(
+        self, mock_gitlab_client, mock_rest_client
+    ):
+        connector = GitLabConnector(
+            url="https://gitlab.example.com", private_token="tok"
+        )
+        get_blobs = Mock(
+            side_effect=[
+                [{"path": "a.py", "rawSize": 1}],
+                [{"path": "b.py", "rawSize": 1}],
+                [{"path": "a.py", "rawTextBlob": "a"}],
+                RuntimeError("late chunk rate limited"),
+            ]
+        )
+        with patch.object(connector, "_graphql_blobs", get_blobs):
+            result = connector.get_file_contents(
+                "group/proj",
+                ["a.py", "b.py"],
+                ref="main",
+                batch_size=1,
+                max_bytes=1_000_000,
+            )
+
+        assert result == {"a.py": "a"}
 
     def test_empty_paths_makes_no_request(self, mock_gitlab_client, mock_rest_client):
         connector = GitLabConnector(


### PR DESCRIPTION
## Follow-ups from #882/#883

### 1. Commit-stats 50-commit cap starved daily metrics (user-visible)

Both Git providers hardcoded `stats_limit = 50` per sync. On a window-bounded sync (`since` set — which is every scheduled sync, and the 30-day initial sync) the commit list is *already* bounded by the window, so the extra cap truncated per-file stats **inside the window**. Live data for org `a78c1a6a` showed exactly this: partial stats coverage on busy days (June 1–3: 7/13, 10/18, 23/28 commits), which under-feeds `repo_metrics_daily` → sparse Code Churn history, skewed bus factor / ownership gini / hotspot rankings.

New shared `resolve_commit_stats_limit` (processors/base_git.py), used by both processors:
- `since` set → cover **all** commits in the window
- unbounded full-history sync → keep the conservative 50 (stats cost one extra API call per commit)
- `COMMIT_STATS_MAX_COMMITS` env (default 1000) = absolute ceiling; `max_commits` still respected

### 2. GitLab content fetch: deferred Codex findings from #883

- **MED**: 1 MB cap was enforced after `rawTextBlob` already crossed the wire. Now a cheap `rawSize`-only GraphQL pass filters oversized blobs first; only survivors get a text fetch.
- **LOW**: retry/backoff wrapped the whole multi-chunk loop, so a 429 on a late chunk re-fetched all earlier chunks. Retry now lives on a per-chunk `_graphql_blobs` helper.

## Related state fixes shipped outside this PR (local instance)

- `chaos-gitlab` sync config fixed (`group: full.chaos`) — discovery went 0 → 2 projects; both synced through the production worker path with contents (1,694 files for full.chaos/dev-health-ops)
- 30-day `dev-hops metrics daily --backfill 30` run for the org: `repo_metrics_daily` went from 1 day to 227 rows (2026-05-14 → 2026-06-12) — Code Churn trend now renders

## Verification

- New tests: `tests/test_commit_stats_limit.py` (5), `tests/test_gitlab_content_backfill.py` rewritten for two-pass shape (4 connector tests)
- ruff ✓, mypy 1,028 files ✓, unit suite 4,164 passed (same 10 pre-existing local-env failures as untouched main: `test_org_deletion` live-ClickHouse pollution + junit-parser quirk)
- Audit claim 'PR review fields never populated' was **refuted** against live data (627 PRs carry `first_review_at`/`reviews_count`; enrichment ordering is correct) — no change needed there