### PR TITLE
feat(admin): add `dev-hops admin users update` CLI command

### DIFF
--- a/src/dev_health_ops/api/admin/cli.py
+++ b/src/dev_health_ops/api/admin/cli.py
@@ -174,6 +174,148 @@ def list_users(ns: argparse.Namespace) -> int:
     return asyncio.run(_list_users_async(ns))
 
 
+async def _update_user_async(ns: argparse.Namespace) -> int:
+    from dev_health_ops.api.services.users import (
+        MembershipService,
+        OrganizationService,
+        UserService,
+    )
+    from dev_health_ops.models.users import MemberRole
+
+    has_profile_change = any(
+        value is not None
+        for value in (
+            ns.new_email,
+            ns.new_username,
+            ns.full_name,
+            ns.active,
+            ns.verified,
+            ns.superuser,
+        )
+    )
+    has_action = (
+        has_profile_change
+        or ns.password is not None
+        or ns.membership_org is not None
+        or ns.remove_from_org is not None
+    )
+    if not has_action:
+        print("Error: No updates specified. Provide at least one field to update.")
+        return 1
+    if ns.role is not None and ns.membership_org is None:
+        print("Error: --role requires --org.")
+        return 1
+
+    session = await _get_session(ns)
+    try:
+        user_svc = UserService(session)
+
+        user = None
+        if ns.id:
+            user = await user_svc.get_by_id(ns.id)
+        elif ns.email:
+            user = await user_svc.get_by_email(ns.email)
+        elif ns.username:
+            user = await user_svc.get_by_username(ns.username)
+        else:
+            print("Error: Identify the user with --id, --email, or --username.")
+            return 1
+
+        if not user:
+            print("Error: User not found.")
+            return 1
+
+        user_id = str(user.id)
+        changes: list[str] = []
+
+        if has_profile_change:
+            await user_svc.update(
+                user_id,
+                email=ns.new_email,
+                username=ns.new_username,
+                full_name=ns.full_name,
+                is_active=ns.active,
+                is_verified=ns.verified,
+                is_superuser=ns.superuser,
+            )
+            if ns.new_email is not None:
+                changes.append(f"email -> {ns.new_email.lower().strip()}")
+            if ns.new_username is not None:
+                changes.append(f"username -> {ns.new_username or '(cleared)'}")
+            if ns.full_name is not None:
+                changes.append("full_name updated")
+            if ns.active is not None:
+                changes.append(f"active -> {ns.active}")
+            if ns.verified is not None:
+                changes.append(f"verified -> {ns.verified}")
+            if ns.superuser is not None:
+                changes.append(f"superuser -> {ns.superuser}")
+
+        if ns.password is not None:
+            await user_svc.set_password(user_id, ns.password)
+            changes.append("password updated (existing sessions revoked)")
+
+        org_svc = OrganizationService(session)
+        membership_svc = MembershipService(session)
+
+        if ns.membership_org is not None:
+            org = await _resolve_org(org_svc, ns.membership_org)
+            if org is None:
+                print(f"Error: Organization '{ns.membership_org}' not found.")
+                await session.rollback()
+                return 1
+            org_id = str(org.id)
+            existing = await membership_svc.get_membership(org_id, user_id)
+            if existing is not None:
+                role = ns.role or str(existing.role)
+                await membership_svc.update_role(org_id, user_id, role)
+                changes.append(f"org '{org.slug}' role -> {role}")
+            else:
+                role = ns.role or MemberRole.MEMBER.value
+                await membership_svc.add_member(
+                    org_id=org_id, user_id=user_id, role=role
+                )
+                changes.append(f"added to org '{org.slug}' as {role}")
+
+        if ns.remove_from_org is not None:
+            org = await _resolve_org(org_svc, ns.remove_from_org)
+            if org is None:
+                print(f"Error: Organization '{ns.remove_from_org}' not found.")
+                await session.rollback()
+                return 1
+            removed = await membership_svc.remove_member(str(org.id), user_id)
+            if removed:
+                changes.append(f"removed from org '{org.slug}'")
+            else:
+                changes.append(f"not a member of org '{org.slug}' (no change)")
+
+        await session.commit()
+        print(f"Updated user: {user.email} (id: {user_id})")
+        for change in changes:
+            print(f"  {change}")
+        return 0
+    except ValueError as e:
+        await session.rollback()
+        print(f"Error: {e}")
+        return 1
+    finally:
+        await session.close()
+
+
+async def _resolve_org(org_svc, identifier: str):
+    org = await org_svc.get_by_slug(identifier)
+    if org is not None:
+        return org
+    try:
+        return await org_svc.get_by_id(identifier)
+    except ValueError:
+        return None
+
+
+def update_user(ns: argparse.Namespace) -> int:
+    return asyncio.run(_update_user_async(ns))
+
+
 async def _list_orgs_async(ns: argparse.Namespace) -> int:
     from dev_health_ops.api.services.users import OrganizationService
 
@@ -636,6 +778,67 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         "--include-inactive", action="store_true", help="Include inactive users."
     )
     users_list.set_defaults(func=list_users)
+
+    users_update = users_sub.add_parser("update", help="Update an existing user.")
+    users_update.add_argument("--id", help="User ID to update (identifier).")
+    users_update.add_argument(
+        "--email", help="Email of the user to update (identifier)."
+    )
+    users_update.add_argument(
+        "--username", help="Username of the user to update (identifier)."
+    )
+    users_update.add_argument(
+        "--new-email", dest="new_email", help="Set a new email address."
+    )
+    users_update.add_argument(
+        "--new-username",
+        dest="new_username",
+        help="Set a new username (pass an empty string to clear it).",
+    )
+    users_update.add_argument(
+        "--full-name", dest="full_name", help="Set the user's full name."
+    )
+    users_update.add_argument(
+        "--password",
+        help="Set a new password (min 8 chars; revokes existing sessions).",
+    )
+    users_update.add_argument(
+        "--verified",
+        dest="verified",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Set validated/verified status (--verified / --no-verified).",
+    )
+    users_update.add_argument(
+        "--superuser",
+        dest="superuser",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Set superuser (user type) status (--superuser / --no-superuser).",
+    )
+    users_update.add_argument(
+        "--active",
+        dest="active",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Set active status (--active / --no-active).",
+    )
+    users_update.add_argument(
+        "--org",
+        dest="membership_org",
+        help="Org slug or ID: add the user to this org, or update their role.",
+    )
+    users_update.add_argument(
+        "--role",
+        choices=["owner", "admin", "member", "viewer"],
+        help="Membership role to set with --org (default: member when adding).",
+    )
+    users_update.add_argument(
+        "--remove-from-org",
+        dest="remove_from_org",
+        help="Org slug or ID: remove the user's membership from this org.",
+    )
+    users_update.set_defaults(func=update_user)
 
     orgs_parser = admin_sub.add_parser("orgs", help="Organization management.")
     orgs_sub = orgs_parser.add_subparsers(dest="orgs_command", required=True)

--- a/tests/test_admin_users_update.py
+++ b/tests/test_admin_users_update.py
@@ -1,0 +1,240 @@
+"""Tests for the `dev-hops admin users update` CLI command."""
+
+from __future__ import annotations
+
+import argparse
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.admin.cli import _update_user_async
+from dev_health_ops.api.services.users import UserService, _hash_password
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.refresh_token import RefreshToken
+from dev_health_ops.models.users import Membership, Organization, User
+from tests._helpers import tables_of
+
+
+def _ns(**overrides: object) -> argparse.Namespace:
+    """Build an argparse.Namespace with every `users update` flag defaulted."""
+    defaults: dict[str, object] = {
+        "db": None,
+        "id": None,
+        "email": None,
+        "username": None,
+        "new_email": None,
+        "new_username": None,
+        "full_name": None,
+        "password": None,
+        "verified": None,
+        "superuser": None,
+        "active": None,
+        "membership_org": None,
+        "role": None,
+        "remove_from_org": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "admin-users-update.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(User, Organization, Membership, RefreshToken),
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded(session_maker):
+    user = User(
+        id=uuid.uuid4(),
+        email="alice@example.com",
+        username="alice",
+        full_name="Alice Alpha",
+        password_hash=_hash_password("original-password"),
+        is_active=True,
+        is_verified=False,
+        is_superuser=False,
+    )
+    org_a = Organization(id=uuid.uuid4(), slug="org-a", name="Org A")
+    org_b = Organization(id=uuid.uuid4(), slug="org-b", name="Org B")
+
+    async with session_maker() as session:
+        session.add_all([user, org_a, org_b])
+        # Alice is already a viewer of org-a.
+        session.add(
+            Membership(
+                id=uuid.uuid4(),
+                org_id=org_a.id,
+                user_id=user.id,
+                role="viewer",
+            )
+        )
+        await session.commit()
+
+    return {
+        "user_id": str(user.id),
+        "org_a_id": str(org_a.id),
+        "org_b_id": str(org_b.id),
+    }
+
+
+async def _run(session_maker, ns: argparse.Namespace) -> int:
+    session = session_maker()
+    with patch(
+        "dev_health_ops.api.admin.cli._get_session",
+        return_value=session,
+    ):
+        return await _update_user_async(ns)
+
+
+@pytest.mark.asyncio
+async def test_update_password(session_maker, seeded):
+    rc = await _run(
+        session_maker,
+        _ns(email="alice@example.com", password="brand-new-password"),
+    )
+    assert rc == 0
+
+    async with session_maker() as session:
+        svc = UserService(session)
+        assert await svc.verify_password(seeded["user_id"], "brand-new-password")
+        assert not await svc.verify_password(seeded["user_id"], "original-password")
+
+
+@pytest.mark.asyncio
+async def test_password_too_short_rolls_back(session_maker, seeded):
+    rc = await _run(
+        session_maker,
+        _ns(email="alice@example.com", password="short"),
+    )
+    assert rc == 1
+
+    async with session_maker() as session:
+        svc = UserService(session)
+        # Original password must remain intact after the rollback.
+        assert await svc.verify_password(seeded["user_id"], "original-password")
+
+
+@pytest.mark.asyncio
+async def test_update_validated_and_user_type(session_maker, seeded):
+    rc = await _run(
+        session_maker,
+        _ns(email="alice@example.com", verified=True, superuser=True),
+    )
+    assert rc == 0
+
+    async with session_maker() as session:
+        user = await UserService(session).get_by_id(seeded["user_id"])
+        assert user is not None
+        assert user.is_verified is True
+        assert user.is_superuser is True
+
+
+@pytest.mark.asyncio
+async def test_deactivate_via_no_active(session_maker, seeded):
+    rc = await _run(session_maker, _ns(email="alice@example.com", active=False))
+    assert rc == 0
+
+    async with session_maker() as session:
+        user = await UserService(session).get_by_id(seeded["user_id"])
+        assert user is not None
+        assert user.is_active is False
+
+
+@pytest.mark.asyncio
+async def test_add_to_org_by_slug_with_role(session_maker, seeded):
+    rc = await _run(
+        session_maker,
+        _ns(email="alice@example.com", membership_org="org-b", role="admin"),
+    )
+    assert rc == 0
+
+    async with session_maker() as session:
+        from dev_health_ops.api.services.users import MembershipService
+
+        role = await MembershipService(session).get_user_role(
+            seeded["org_b_id"], seeded["user_id"]
+        )
+        assert role == "admin"
+
+
+@pytest.mark.asyncio
+async def test_update_existing_org_role(session_maker, seeded):
+    rc = await _run(
+        session_maker,
+        _ns(email="alice@example.com", membership_org="org-a", role="owner"),
+    )
+    assert rc == 0
+
+    async with session_maker() as session:
+        from dev_health_ops.api.services.users import MembershipService
+
+        role = await MembershipService(session).get_user_role(
+            seeded["org_a_id"], seeded["user_id"]
+        )
+        assert role == "owner"
+
+
+@pytest.mark.asyncio
+async def test_remove_from_org(session_maker, seeded):
+    rc = await _run(
+        session_maker,
+        _ns(email="alice@example.com", remove_from_org="org-a"),
+    )
+    assert rc == 0
+
+    async with session_maker() as session:
+        from dev_health_ops.api.services.users import MembershipService
+
+        membership = await MembershipService(session).get_membership(
+            seeded["org_a_id"], seeded["user_id"]
+        )
+        assert membership is None
+
+
+@pytest.mark.asyncio
+async def test_no_action_specified_errors(session_maker, seeded):
+    rc = await _run(session_maker, _ns(email="alice@example.com"))
+    assert rc == 1
+
+
+@pytest.mark.asyncio
+async def test_role_without_org_errors(session_maker, seeded):
+    rc = await _run(session_maker, _ns(email="alice@example.com", role="admin"))
+    assert rc == 1
+
+
+@pytest.mark.asyncio
+async def test_user_not_found(session_maker, seeded):
+    rc = await _run(
+        session_maker,
+        _ns(email="nobody@example.com", verified=True),
+    )
+    assert rc == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_org_errors(session_maker, seeded):
+    rc = await _run(
+        session_maker,
+        _ns(email="alice@example.com", membership_org="does-not-exist"),
+    )
+    assert rc == 1


### PR DESCRIPTION
## Summary

Adds a `dev-hops admin users update` CLI command to update an existing user, mirroring the existing `admin users create`/`list` patterns and delegating to the existing `UserService` / `MembershipService` / `OrganizationService` (no logic duplicated, no new persistence path).

Identify the user with `--id` / `--email` / `--username`, then update any of:

| Flag | Effect |
|---|---|
| `--password` | `set_password()` — bcrypt re-hash, revokes refresh tokens, min 8 chars |
| `--verified` / `--no-verified` | `is_verified` (validated status) |
| `--superuser` / `--no-superuser` | `is_superuser` (platform-level "user type") |
| `--active` / `--no-active` | `is_active` |
| `--new-email`, `--new-username`, `--full-name` | profile fields |
| `--org <slug-or-id>` `[--role]` | add membership, or update role if already a member |
| `--remove-from-org <slug-or-id>` | remove the user's membership |

Org is membership-based (no `User.org` column); a user can belong to multiple orgs. Tri-state bool flags use `argparse.BooleanOptionalAction` (default `None` = no change). The command uses a single session, commits once, and rolls back on `ValueError`.

## Design notes

- **`--org` uses `dest=membership_org`** to deliberately shadow the auto-propagated global `--org` scoping flag (which defaults to `$ORG_ID`), so the env value can't silently bleed into membership operations.
- Adversarial review (Codex) flagged that the sole org owner can be demoted/stranded via `update_role` (no last-owner guard, unlike `remove_member`). Per product owner: an org without an owner is **acceptable** (platform/superadmins manage orgs for paying customers), so this is intentionally **not** guarded here. The pre-existing `remove_member` last-owner guard in the shared service is left untouched (out of scope).

## Tests

`tests/test_admin_users_update.py` — 11 integration tests (sqlite+aiosqlite), covering: password change, password-too-short rollback, verified+superuser, deactivate, org add-by-slug with role, existing-role update, remove-from-org, no-action error, role-without-org error, user-not-found, unknown-org.

```
11 passed
```

## Verification

- `lsp_diagnostics` clean (both files)
- `pytest tests/test_admin_users_update.py` → 11 passed
- `ruff format --check` + `ruff check` clean (pre-commit + pre-push hooks passed)

SCREENSHOT-WAIVER: backend-only CLI change, no rendered frontend output.