### PR TITLE
fix(work-graph): produce PR↔deployment and deployment↔incident edges (CHAOS-2367)

### DIFF
--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -159,13 +159,19 @@ def _extract_ai_workflow_for_day(
     end: datetime,
     repo_id: uuid.UUID | None,
     repo_provider_by_id: dict[str, str],
-) -> tuple[list[Any], list[Any], list[Any], list[Any]]:
+) -> tuple[list[Any], list[Any], list[Any], list[Any], list[Any], list[Any]]:
     """Extract AI workflow runs and Work Graph edges for one UTC day window.
 
-    Returns ``(runs, artifact_edges, issue_edges, review_outcome_edges)``.
-    Returns four empty lists when ``org_id`` is not a UUID — AIWorkflowRun
+    Returns ``(runs, artifact_edges, issue_edges, review_outcome_edges,
+    pr_deployment_edges, deployment_incident_edges)``.
+    Returns six empty lists when ``org_id`` is not a UUID — AIWorkflowRun
     requires a tenant UUID by contract, so extraction without one would
     fabricate attribution (CHAOS-2187).
+
+    Deployment↔incident correlation is day-scoped (CHAOS-2367): an incident
+    links natively when the deployment row carries its PR number, and
+    heuristically (confidence 0.3) to same-repo deployments within the same
+    UTC day otherwise.
     """
     org_uuid: uuid.UUID | None = None
     if org_id:
@@ -175,7 +181,7 @@ def _extract_ai_workflow_for_day(
             org_uuid = None
     if org_uuid is None:
         logger.debug("AI workflow extraction skipped: org_id %r is not a UUID", org_id)
-        return [], [], [], []
+        return [], [], [], [], [], []
 
     wf_params: dict[str, Any] = {"org_id": org_id, "start": start, "end": end}
     wf_repo_filter = ""
@@ -262,19 +268,82 @@ def _extract_ai_workflow_for_day(
     )
     wf_review_rows = _valid_rows(wf_review_rows, "git_pull_request_reviews")
 
-    prs_by_provider: dict[str, list[dict[str, Any]]] = {}
-    for row in wf_pr_rows:
-        row_provider = repo_provider_by_id.get(str(row.get("repo_id") or ""), "unknown")
-        prs_by_provider.setdefault(row_provider, []).append(row)
-    reviews_by_provider: dict[str, list[dict[str, Any]]] = {}
-    for row in wf_review_rows:
-        row_provider = repo_provider_by_id.get(str(row.get("repo_id") or ""), "unknown")
-        reviews_by_provider.setdefault(row_provider, []).append(row)
+    # Deployments/incidents feed the PR→deployment and deployment→incident
+    # Work Graph edges (CHAOS-2367). Their identity is repo_id + an opaque
+    # string id, so they get their own row hygiene instead of _valid_rows
+    # (which requires a PR number).
+    def _valid_id_rows(
+        rows: list[dict[str, Any]], id_key: str, source: str
+    ) -> list[dict[str, Any]]:
+        valid: list[dict[str, Any]] = []
+        dropped = 0
+        for row in rows:
+            try:
+                uuid.UUID(str(row.get("repo_id")))
+            except (ValueError, TypeError, AttributeError):
+                dropped += 1
+                continue
+            if not str(row.get(id_key) or ""):
+                dropped += 1
+                continue
+            valid.append(row)
+        if dropped:
+            logger.warning(
+                "AI workflow extraction dropped %d malformed %s row(s)",
+                dropped,
+                source,
+            )
+        return valid
+
+    wf_deployment_rows = primary_sink.query_dicts(
+        "SELECT repo_id, deployment_id, pull_request_number,"
+        " started_at, finished_at, deployed_at, last_synced"
+        " FROM deployments"
+        " WHERE org_id = {org_id:String}"
+        "   AND coalesce(deployed_at, finished_at, started_at)"
+        "       >= {start:DateTime64(3, 'UTC')}"
+        "   AND coalesce(deployed_at, finished_at, started_at)"
+        "       < {end:DateTime64(3, 'UTC')}"
+        f"{wf_repo_filter}",
+        wf_params,
+    )
+    wf_deployment_rows = _valid_id_rows(
+        wf_deployment_rows, "deployment_id", "deployments"
+    )
+
+    wf_incident_rows = primary_sink.query_dicts(
+        "SELECT repo_id, incident_id, started_at, last_synced"
+        " FROM incidents"
+        " WHERE org_id = {org_id:String}"
+        "   AND started_at >= {start:DateTime64(3, 'UTC')}"
+        "   AND started_at < {end:DateTime64(3, 'UTC')}"
+        f"{wf_repo_filter}",
+        wf_params,
+    )
+    wf_incident_rows = _valid_id_rows(wf_incident_rows, "incident_id", "incidents")
+
+    def _by_provider(
+        rows: list[dict[str, Any]],
+    ) -> dict[str, list[dict[str, Any]]]:
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for row in rows:
+            row_provider = repo_provider_by_id.get(
+                str(row.get("repo_id") or ""), "unknown"
+            )
+            grouped.setdefault(row_provider, []).append(row)
+        return grouped
+
+    prs_by_provider = _by_provider(wf_pr_rows)
+    reviews_by_provider = _by_provider(wf_review_rows)
+    deployments_by_provider = _by_provider(wf_deployment_rows)
+    incidents_by_provider = _by_provider(wf_incident_rows)
 
     runs: list[Any] = []
     artifact_edges: list[Any] = []
     issue_edges: list[Any] = []
     review_outcome_edges: list[Any] = []
+    pr_deployment_edges: list[Any] = []
+    deployment_incident_edges: list[Any] = []
     for wf_provider, provider_prs in prs_by_provider.items():
         extraction = extract_ai_workflow_from_pull_requests(
             provider_prs,
@@ -285,14 +354,30 @@ def _extract_ai_workflow_for_day(
         runs.extend(extraction.runs)
         artifact_edges.extend(extraction.artifact_edges)
         issue_edges.extend(extraction.issue_edges)
-    for wf_provider, provider_reviews in reviews_by_provider.items():
+    edge_providers = (
+        set(reviews_by_provider)
+        | set(deployments_by_provider)
+        | set(incidents_by_provider)
+    )
+    for wf_provider in sorted(edge_providers):
         review_extraction = extract_review_deployment_incident_edges(
             org_id=org_uuid,
             provider=wf_provider,
-            reviews=provider_reviews,
+            reviews=reviews_by_provider.get(wf_provider),
+            deployments=deployments_by_provider.get(wf_provider),
+            incidents=incidents_by_provider.get(wf_provider),
         )
         review_outcome_edges.extend(review_extraction.review_outcome_edges)
-    return runs, artifact_edges, issue_edges, review_outcome_edges
+        pr_deployment_edges.extend(review_extraction.pr_deployment_edges)
+        deployment_incident_edges.extend(review_extraction.deployment_incident_edges)
+    return (
+        runs,
+        artifact_edges,
+        issue_edges,
+        review_outcome_edges,
+        pr_deployment_edges,
+        deployment_incident_edges,
+    )
 
 
 def _repo_to_team_map_for_compounding_risk(
@@ -665,6 +750,8 @@ async def run_daily_metrics_job(
             ai_workflow_artifact_edges,
             ai_workflow_issue_edges,
             ai_review_outcome_edges,
+            ai_pr_deployment_edges,
+            ai_deployment_incident_edges,
         ) = _extract_ai_workflow_for_day(
             primary_sink=primary_sink,
             org_id=org_id,
@@ -811,6 +898,16 @@ async def run_daily_metrics_job(
                 s, "write_work_graph_pr_review_outcome_edges"
             ):
                 s.write_work_graph_pr_review_outcome_edges(ai_review_outcome_edges)
+            if ai_pr_deployment_edges and hasattr(
+                s, "write_work_graph_pr_deployment_edges"
+            ):
+                s.write_work_graph_pr_deployment_edges(ai_pr_deployment_edges)
+            if ai_deployment_incident_edges and hasattr(
+                s, "write_work_graph_deployment_incident_edges"
+            ):
+                s.write_work_graph_deployment_incident_edges(
+                    ai_deployment_incident_edges
+                )
             if all_file_metrics:
                 s.write_file_metrics(all_file_metrics)
 

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -295,14 +295,19 @@ def _extract_ai_workflow_for_day(
             )
         return valid
 
+    # Event time falls back to last_synced (non-nullable) so in-flight
+    # deployments with no timestamps yet still land in a day bucket instead
+    # of silently never matching any window. FINAL: deployments/incidents
+    # are ReplacingMergeTree and may hold pre-merge duplicate rows during
+    # active sync.
     wf_deployment_rows = primary_sink.query_dicts(
         "SELECT repo_id, deployment_id, pull_request_number,"
         " started_at, finished_at, deployed_at, last_synced"
-        " FROM deployments"
+        " FROM deployments FINAL"
         " WHERE org_id = {org_id:String}"
-        "   AND coalesce(deployed_at, finished_at, started_at)"
+        "   AND coalesce(deployed_at, finished_at, started_at, last_synced)"
         "       >= {start:DateTime64(3, 'UTC')}"
-        "   AND coalesce(deployed_at, finished_at, started_at)"
+        "   AND coalesce(deployed_at, finished_at, started_at, last_synced)"
         "       < {end:DateTime64(3, 'UTC')}"
         f"{wf_repo_filter}",
         wf_params,
@@ -313,7 +318,7 @@ def _extract_ai_workflow_for_day(
 
     wf_incident_rows = primary_sink.query_dicts(
         "SELECT repo_id, incident_id, started_at, last_synced"
-        " FROM incidents"
+        " FROM incidents FINAL"
         " WHERE org_id = {org_id:String}"
         "   AND started_at >= {start:DateTime64(3, 'UTC')}"
         "   AND started_at < {end:DateTime64(3, 'UTC')}"

--- a/tests/metrics/test_ai_workflow_live.py
+++ b/tests/metrics/test_ai_workflow_live.py
@@ -196,7 +196,14 @@ async def test_daily_job_rerun_has_no_reader_visible_duplicate_edges() -> None:
     )
 
     def _run_once() -> None:
-        runs, artifacts, issues, reviews = _extract_ai_workflow_for_day(
+        (
+            runs,
+            artifacts,
+            issues,
+            reviews,
+            pr_deploys,
+            deploy_incidents,
+        ) = _extract_ai_workflow_for_day(
             primary_sink=sink,
             org_id=str(org),
             start=day_start,
@@ -209,6 +216,10 @@ async def test_daily_job_rerun_has_no_reader_visible_duplicate_edges() -> None:
         sink.write_ai_workflow_artifact_edges(artifacts)
         sink.write_ai_workflow_issue_edges(issues)
         sink.write_work_graph_pr_review_outcome_edges(reviews)
+        if pr_deploys:
+            sink.write_work_graph_pr_deployment_edges(pr_deploys)
+        if deploy_incidents:
+            sink.write_work_graph_deployment_incident_edges(deploy_incidents)
 
     assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
     client = await get_global_client(CLICKHOUSE_URI)

--- a/tests/metrics/test_job_daily_ai_workflow.py
+++ b/tests/metrics/test_job_daily_ai_workflow.py
@@ -1,10 +1,11 @@
-"""CHAOS-2187: daily-job AI workflow extraction wiring.
+"""CHAOS-2187 + CHAOS-2367: daily-job AI workflow extraction wiring.
 
 Covers ``job_daily._extract_ai_workflow_for_day`` — the helper that turns the
-day's PR/review rows into AI workflow runs and Work Graph edges. The three
-edge tables (``ai_workflow_issue_edges``, ``ai_workflow_artifact_edges``,
-``work_graph_pr_review_outcome_edges``) were previously never populated
-because the extractor had no production call site.
+day's PR/review/deployment/incident rows into AI workflow runs and Work
+Graph edges. These edge tables were previously never populated because the
+extractor had no production call site (CHAOS-2187 for issue/artifact/review
+edges; CHAOS-2367 for pr_deployment and deployment_incident edges, where the
+extractor existed but was called without deployments/incidents rows).
 """
 
 from __future__ import annotations
@@ -76,12 +77,41 @@ class _Sink:
                     "last_synced": START,
                 }
             ]
+        if "FROM deployments" in query:
+            return [
+                {
+                    # Native PR link: produces a confidence-1.0 edge.
+                    "repo_id": REPO_ID,
+                    "deployment_id": "deploy-1",
+                    "pull_request_number": 7,
+                    "started_at": START,
+                    "finished_at": START,
+                    "deployed_at": START,
+                    "last_synced": START,
+                }
+            ]
+        if "FROM incidents" in query:
+            return [
+                {
+                    "repo_id": REPO_ID,
+                    "incident_id": "inc-1",
+                    "started_at": START,
+                    "last_synced": START,
+                }
+            ]
         return []
 
 
-def test_extracts_runs_and_all_three_edge_kinds() -> None:
+def test_extracts_runs_and_all_edge_kinds() -> None:
     sink = _Sink()
-    runs, artifact_edges, issue_edges, review_edges = _extract_ai_workflow_for_day(
+    (
+        runs,
+        artifact_edges,
+        issue_edges,
+        review_edges,
+        pr_deploy_edges,
+        deploy_incident_edges,
+    ) = _extract_ai_workflow_for_day(
         primary_sink=sink,
         org_id=ORG_ID,
         start=START,
@@ -105,10 +135,23 @@ def test_extracts_runs_and_all_three_edge_kinds() -> None:
     assert review_edges[0].review_outcome_id == "rev_7_0"
     assert review_edges[0].outcome == "APPROVED"
 
+    assert len(pr_deploy_edges) == 1
+    assert pr_deploy_edges[0].pr_id == f"{REPO_ID}:7"
+    assert pr_deploy_edges[0].deployment_id == "deploy-1"
+    assert pr_deploy_edges[0].confidence == 1.0
+    assert pr_deploy_edges[0].source == "native"
+
+    assert len(deploy_incident_edges) == 1
+    assert deploy_incident_edges[0].deployment_id == "deploy-1"
+    assert deploy_incident_edges[0].incident_id == "inc-1"
+    # incidents rows carry no deployment_id, so the link is the same-day
+    # same-repo heuristic.
+    assert deploy_incident_edges[0].source == "heuristic"
+
 
 def test_non_uuid_org_skips_extraction_without_queries() -> None:
     sink = _Sink()
-    runs, artifact_edges, issue_edges, review_edges = _extract_ai_workflow_for_day(
+    result = _extract_ai_workflow_for_day(
         primary_sink=sink,
         org_id="not-a-uuid",
         start=START,
@@ -117,19 +160,21 @@ def test_non_uuid_org_skips_extraction_without_queries() -> None:
         repo_provider_by_id={},
     )
 
-    assert (runs, artifact_edges, issue_edges, review_edges) == ([], [], [], [])
+    assert result == ([], [], [], [], [], [])
     assert sink.queries == []
 
 
 def test_unknown_repo_provider_falls_back_to_unknown() -> None:
     sink = _Sink()
-    runs, _artifacts, _issues, _reviews = _extract_ai_workflow_for_day(
-        primary_sink=sink,
-        org_id=ORG_ID,
-        start=START,
-        end=END,
-        repo_id=REPO_ID,
-        repo_provider_by_id={},
+    runs, _artifacts, _issues, _reviews, _deploys, _incidents = (
+        _extract_ai_workflow_for_day(
+            primary_sink=sink,
+            org_id=ORG_ID,
+            start=START,
+            end=END,
+            repo_id=REPO_ID,
+            repo_provider_by_id={},
+        )
     )
 
     assert len(runs) == 1
@@ -172,9 +217,16 @@ def test_malformed_rows_are_dropped_row_locally() -> None:
                 ]
             if "FROM git_pull_request_reviews" in query:
                 rows = rows + [{"repo_id": object(), "number": 3}]
+            if "FROM deployments" in query:
+                rows = rows + [
+                    {"repo_id": "not-a-uuid", "deployment_id": "d-bad"},
+                    {"repo_id": REPO_ID, "deployment_id": ""},
+                ]
+            if "FROM incidents" in query:
+                rows = rows + [{"repo_id": REPO_ID, "incident_id": None}]
             return rows
 
-    runs, artifacts, issues, reviews = _extract_ai_workflow_for_day(
+    runs, artifacts, issues, reviews, deploys, incidents = _extract_ai_workflow_for_day(
         primary_sink=_MalformedRowSink(),
         org_id=ORG_ID,
         start=START,
@@ -188,3 +240,5 @@ def test_malformed_rows_are_dropped_row_locally() -> None:
     assert len(artifacts) == 1
     assert len(issues) == 1
     assert len(reviews) == 1
+    assert len(deploys) == 1
+    assert len(incidents) == 1


### PR DESCRIPTION
## CHAOS-2367

`work_graph_pr_deployment_edges` and `work_graph_deployment_incident_edges` were empty for **every org and provider** — not because anything was missing, but because all three pieces existed without being connected: the sink writers existed, the traversal readers existed, and `extract_review_deployment_incident_edges` even had full deployment/incident logic — the daily job just called it with only `reviews=`. (Same bug class CHAOS-2187 fixed for the review-edge tables.)

## Change

`_extract_ai_workflow_for_day` (metrics/job_daily.py) now:
- queries the day's `deployments` (event time = `coalesce(deployed_at, finished_at, started_at)`) and `incidents`, with the same org/repo scoping and per-row hygiene as the PR/review queries (new `_valid_id_rows` for string-id rows)
- groups by repo provider and passes them through the existing extractor
- returns a 6-tuple; the job writes the two new edge lists via the existing `write_work_graph_pr_deployment_edges` / `write_work_graph_deployment_incident_edges` sink methods (hasattr-guarded like the review edges)

Semantics (all pre-existing extractor behavior, now actually exercised): native PR links via `deployments.pull_request_number` → confidence 1.0/source=native; incidents without a deployment reference → same-repo same-UTC-day heuristic, confidence 0.3/source=heuristic.

## Verification

- Live 30-day daily backfill: fixture org went 0 → **187 pr_deployment edges + 165 deployment_incident edges**; traversal tables now populated
- GitHub-synced org correctly produces 0 for now: its 925 deployments all have `pull_request_number=NULL` and it has 0 incident rows — upstream data gaps noted on the Linear issue (deployment→PR inference via release_ref/merged_at is the follow-up there)
- Tests: `tests/metrics/test_job_daily_ai_workflow.py` extended (deployments/incidents rows, 6-tuple, malformed-row hygiene for string-id rows); live ClickHouse test updated to write the new edges
- ruff ✓, mypy (1,027 files) ✓, unit suite 4,157 passed — 11 local failures = the 10 known env failures + `test_fixed_date_forecast`, a date-rollover flake that fails identically on untouched main (UTC crossed June 13 mid-session)