### PR TITLE
feat(sync): deployment→PR inference + configurable incident labels (CHAOS-2368/2369)

### DIFF
--- a/src/dev_health_ops/connectors/utils/rest.py
+++ b/src/dev_health_ops/connectors/utils/rest.py
@@ -362,6 +362,32 @@ class GitLabRESTClient(RESTClient):
             params["sort"] = sort
         return self.get_list(endpoint, params=params)
 
+    def get_issues(
+        self,
+        project_id: int,
+        labels: str | None = None,
+        state: str | None = None,
+        page: int = 1,
+        per_page: int = 100,
+        order_by: str | None = None,
+        sort: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List project issues; ``labels`` is GitLab's comma-separated filter."""
+        endpoint = f"projects/{project_id}/issues"
+        params: dict[str, Any] = {
+            "page": page,
+            "per_page": per_page,
+        }
+        if labels:
+            params["labels"] = labels
+        if state:
+            params["state"] = state
+        if order_by:
+            params["order_by"] = order_by
+        if sort:
+            params["sort"] = sort
+        return self.get_list(endpoint, params=params)
+
     def get_releases(
         self,
         project_id: int,

--- a/src/dev_health_ops/processors/base_git.py
+++ b/src/dev_health_ops/processors/base_git.py
@@ -138,6 +138,18 @@ class BaseGitProcessor:
         return asyncio.run_coroutine_threadsafe(coro, loop).result()
 
 
+def resolve_incident_labels() -> list[str]:
+    """Issue labels that mark an incident, for the provider incident syncs.
+
+    ``INCIDENT_LABELS`` is a comma-separated list (default ``incident``).
+    Providers query one label at a time (GitHub's multi-label filter is
+    AND-semantics) and dedupe across labels.
+    """
+    raw = os.getenv("INCIDENT_LABELS", "incident")
+    labels = [token.strip() for token in raw.split(",") if token.strip()]
+    return labels or ["incident"]
+
+
 def resolve_commit_stats_limit(
     raw_commit_count: int,
     max_commits: int | None,

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -30,6 +30,7 @@ from dev_health_ops.processors.base_git import (
     build_git_pull_request,
     check_backfill_needs,
     resolve_commit_stats_limit,
+    resolve_incident_labels,
 )
 from dev_health_ops.processors.fetch_utils import (
     AsyncBatchCollector,
@@ -314,7 +315,34 @@ def _fetch_github_workflow_runs_sync(gh_repo, repo_id, max_runs, since):
     return runs
 
 
-def _fetch_github_deployments_sync(gh_repo, repo_id, max_deployments, since):
+def _resolve_github_deployment_pr(gh_repo, sha, gate):
+    """Resolve the merged PR for a deployed commit via /commits/{sha}/pulls.
+
+    Costs up to two gated API calls per deployment. Failure-soft: any
+    lookup error leaves the deployment without PR attribution rather than
+    failing the sync.
+    """
+    if not sha:
+        return None, None
+    try:
+        if gate is not None:
+            gate.wait_sync()
+        commit = gh_repo.get_commit(sha)
+        if gate is not None:
+            gate.wait_sync()
+        pulls = list(commit.get_pulls()[:10])
+    except Exception as exc:
+        logging.debug("Failed PR lookup for deployed commit %s: %s", sha, exc)
+        return None, None
+    merged = [pr for pr in pulls if getattr(pr, "merged_at", None) is not None]
+    chosen = merged[0] if merged else (pulls[0] if pulls else None)
+    if chosen is None:
+        return None, None
+    return getattr(chosen, "number", None), getattr(chosen, "merged_at", None)
+
+
+def _fetch_github_deployments_sync(gh_repo, repo_id, max_deployments, since, gate=None):
+    gate = BaseGitProcessor.ensure_gate(gate)
     deployments: list[Deployment] = []
     if not hasattr(gh_repo, "get_deployments"):
         return deployments
@@ -341,6 +369,9 @@ def _fetch_github_deployments_sync(gh_repo, repo_id, max_deployments, since):
             "github",
             releases=release_objects,
         )
+        pr_number, pr_merged_at = _resolve_github_deployment_pr(
+            gh_repo, getattr(dep, "sha", None), gate
+        )
         deployments.append(
             build_deployment(
                 repo_id=repo_id,
@@ -350,6 +381,8 @@ def _fetch_github_deployments_sync(gh_repo, repo_id, max_deployments, since):
                 started_at=created_at,
                 finished_at=None,
                 deployed_at=created_at,
+                merged_at=pr_merged_at,
+                pull_request_number=pr_number,
                 release_ref=enrichment.release_ref,
                 release_ref_confidence=enrichment.confidence,
             )
@@ -361,13 +394,30 @@ def _fetch_github_incidents_sync(gh_repo, repo_id, max_issues, since):
     incidents: list[Incident] = []
     if not hasattr(gh_repo, "get_issues"):
         return incidents
-    try:
-        raw_issues = list(
-            gh_repo.get_issues(state="all", labels=["incident"])[:max_issues]
-        )
-    except Exception as exc:
-        logging.debug("Failed to fetch incident issues: %s", exc)
-        return incidents
+    labels = resolve_incident_labels()
+    raw_issues = []
+    seen_issue_ids: set = set()
+    for label in labels:
+        try:
+            label_issues = list(
+                gh_repo.get_issues(state="all", labels=[label])[:max_issues]
+            )
+        except Exception as exc:
+            logging.debug(
+                "Failed to fetch incident issues for label %r: %s", label, exc
+            )
+            continue
+        for issue in label_issues:
+            issue_id = getattr(issue, "id", None)
+            if issue_id in seen_issue_ids:
+                continue
+            seen_issue_ids.add(issue_id)
+            raw_issues.append(issue)
+    logging.info(
+        "Fetched %d incident issue(s) (labels searched: %s)",
+        len(raw_issues),
+        ", ".join(labels),
+    )
 
     for issue in raw_issues:
         created_at = getattr(issue, "created_at", None)

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -335,7 +335,14 @@ def _resolve_github_deployment_pr(gh_repo, sha, gate):
         logging.debug("Failed PR lookup for deployed commit %s: %s", sha, exc)
         return None, None
     merged = [pr for pr in pulls if getattr(pr, "merged_at", None) is not None]
-    chosen = merged[0] if merged else (pulls[0] if pulls else None)
+    # Prefer the PR that directly merged this commit: get_pulls() also
+    # returns PRs that merely contain the SHA (e.g. stacked merges).
+    direct = [pr for pr in merged if getattr(pr, "merge_commit_sha", None) == sha]
+    chosen = (
+        direct[0]
+        if direct
+        else (merged[0] if merged else (pulls[0] if pulls else None))
+    )
     if chosen is None:
         return None, None
     return getattr(chosen, "number", None), getattr(chosen, "merged_at", None)
@@ -408,6 +415,10 @@ def _fetch_github_incidents_sync(gh_repo, repo_id, max_issues, since):
             )
             continue
         for issue in label_issues:
+            # The GitHub issues API returns PRs alongside issues; a PR
+            # carrying an incident label is not an incident.
+            if getattr(issue, "pull_request", None) is not None:
+                continue
             issue_id = getattr(issue, "id", None)
             if issue_id in seen_issue_ids:
                 continue

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -434,8 +434,11 @@ def _resolve_gitlab_deployment_mr(connector, project_id, sha):
     if not chosen:
         return None, None
     merged_at = safe_parse_datetime(chosen.get("merged_at") or "")
-    iid = chosen.get("iid")
-    return (int(iid) if iid is not None else None), merged_at
+    try:
+        iid = int(chosen.get("iid"))
+    except (TypeError, ValueError):
+        iid = None
+    return iid, merged_at
 
 
 def _fetch_gitlab_deployments_sync(

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -29,6 +29,7 @@ from dev_health_ops.processors.base_git import (
     build_git_pull_request,
     check_backfill_needs,
     resolve_commit_stats_limit,
+    resolve_incident_labels,
 )
 from dev_health_ops.processors.fetch_utils import (
     AsyncBatchCollector,
@@ -413,6 +414,30 @@ def _fetch_gitlab_pipelines_sync(gl_project, repo_id, max_pipelines, since):
     return pipelines
 
 
+def _resolve_gitlab_deployment_mr(connector, project_id, sha):
+    """Resolve the merged MR for a deployed commit via the commits API.
+
+    Failure-soft: any lookup error leaves the deployment without MR
+    attribution rather than failing the sync.
+    """
+    if not sha:
+        return None, None
+    try:
+        mrs = connector.rest_client.get_list(
+            f"projects/{project_id}/repository/commits/{sha}/merge_requests"
+        )
+    except Exception as exc:
+        logging.debug("Failed MR lookup for deployed commit %s: %s", sha, exc)
+        return None, None
+    merged = [mr for mr in mrs or [] if mr.get("state") == "merged"]
+    chosen = merged[0] if merged else (mrs[0] if mrs else None)
+    if not chosen:
+        return None, None
+    merged_at = safe_parse_datetime(chosen.get("merged_at") or "")
+    iid = chosen.get("iid")
+    return (int(iid) if iid is not None else None), merged_at
+
+
 def _fetch_gitlab_deployments_sync(
     connector, project_id, repo_id, max_deployments, since
 ):
@@ -466,6 +491,9 @@ def _fetch_gitlab_deployments_sync(
             releases=release_objects,
         )
 
+        mr_number, mr_merged_at = _resolve_gitlab_deployment_mr(
+            connector, project_id, dep.get("sha")
+        )
         deployments.append(
             build_deployment(
                 repo_id=repo_id,
@@ -477,6 +505,8 @@ def _fetch_gitlab_deployments_sync(
                 started_at=created_at,
                 finished_at=finished_at,
                 deployed_at=created_at,
+                merged_at=mr_merged_at,
+                pull_request_number=mr_number,
                 release_ref=enrichment.release_ref,
                 release_ref_confidence=enrichment.confidence,
             )
@@ -486,20 +516,36 @@ def _fetch_gitlab_deployments_sync(
 
 
 def _fetch_gitlab_incidents_sync(connector, project_id, repo_id, max_issues, since):
-    """Sync helper to fetch GitLab incidents (issues labeled 'incident')."""
+    """Sync helper to fetch GitLab incidents (configurable incident labels)."""
     incidents: list[Incident] = []
-    try:
-        raw_issues = connector.rest_client.get_issues(
-            project_id=project_id,
-            labels="incident",
-            per_page=min(max_issues, 100),
-            order_by="updated_at",
-            sort="desc",
-        )
-    except Exception as exc:
-        logging.debug("Failed to fetch incident issues: %s", exc)
-        return incidents
-
+    labels = resolve_incident_labels()
+    raw_issues: list = []
+    seen_issue_ids: set = set()
+    for label in labels:
+        try:
+            label_issues = connector.rest_client.get_issues(
+                project_id=project_id,
+                labels=label,
+                per_page=min(max_issues, 100),
+                order_by="updated_at",
+                sort="desc",
+            )
+        except Exception as exc:
+            logging.debug(
+                "Failed to fetch incident issues for label %r: %s", label, exc
+            )
+            continue
+        for issue in label_issues or []:
+            issue_id = issue.get("id")
+            if issue_id in seen_issue_ids:
+                continue
+            seen_issue_ids.add(issue_id)
+            raw_issues.append(issue)
+    logging.info(
+        "Fetched %d GitLab incident issue(s) (labels searched: %s)",
+        len(raw_issues),
+        ", ".join(labels),
+    )
     for issue in raw_issues[:max_issues]:
         created_at_str = issue.get("created_at")
         if not created_at_str:

--- a/tests/test_deployment_pr_inference.py
+++ b/tests/test_deployment_pr_inference.py
@@ -16,6 +16,7 @@ from unittest.mock import Mock
 # pre-existing providers._base <-> connectors circular import when this file
 # is collected in isolation.
 import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.connectors.utils.rest import GitLabRESTClient
 from dev_health_ops.processors.base_git import resolve_incident_labels
 from dev_health_ops.processors.github import (
     _fetch_github_deployments_sync,
@@ -41,7 +42,7 @@ class _NoWaitGate:
 
 class TestGitHubDeploymentPRInference:
     def test_resolves_merged_pr(self) -> None:
-        merged_pr = Mock(number=42, merged_at=NOW)
+        merged_pr = Mock(number=42, merged_at=NOW, merge_commit_sha="abc123")
         open_pr = Mock(number=43, merged_at=None)
         commit = Mock()
         commit.get_pulls.return_value = [open_pr, merged_pr]
@@ -54,6 +55,20 @@ class TestGitHubDeploymentPRInference:
         assert (number, merged_at) == (42, NOW)
         gh_repo.get_commit.assert_called_once_with("abc123")
         assert gate.waits == 2
+
+    def test_prefers_pr_that_directly_merged_the_sha(self) -> None:
+        """get_pulls() also returns PRs that merely contain the SHA
+        (stacked merges); the direct merger must win regardless of order."""
+        containing_pr = Mock(number=100, merged_at=NOW, merge_commit_sha="other")
+        direct_pr = Mock(number=42, merged_at=NOW, merge_commit_sha="abc123")
+        commit = Mock()
+        commit.get_pulls.return_value = [containing_pr, direct_pr]
+        gh_repo = Mock()
+        gh_repo.get_commit.return_value = commit
+
+        number, _ = _resolve_github_deployment_pr(gh_repo, "abc123", _NoWaitGate())
+
+        assert number == 42
 
     def test_falls_back_to_first_pr_when_none_merged(self) -> None:
         open_pr = Mock(number=7, merged_at=None)
@@ -126,6 +141,15 @@ class TestGitLabDeploymentMRInference:
         connector.rest_client.get_list.side_effect = RuntimeError("boom")
         assert _resolve_gitlab_deployment_mr(connector, 123, "abc") == (None, None)
 
+    def test_non_numeric_iid_is_soft(self) -> None:
+        connector = Mock()
+        connector.rest_client.get_list.return_value = [
+            {"iid": "abc", "state": "merged", "merged_at": "2026-06-12T00:00:00Z"}
+        ]
+        number, merged_at = _resolve_gitlab_deployment_mr(connector, 123, "abc")
+        assert number is None
+        assert merged_at is not None
+
 
 class TestIncidentLabels:
     def test_default_label(self, monkeypatch) -> None:
@@ -143,7 +167,9 @@ class TestIncidentLabels:
     def test_github_queries_each_label_and_dedupes(self, monkeypatch) -> None:
         monkeypatch.setenv("INCIDENT_LABELS", "incident,outage")
         shared = Mock(id=1, state="closed", created_at=NOW, closed_at=NOW)
+        shared.pull_request = None
         outage_only = Mock(id=2, state="open", created_at=NOW, closed_at=None)
+        outage_only.pull_request = None
         gh_repo = Mock()
         gh_repo.get_issues.side_effect = [[shared], [shared, outage_only]]
 
@@ -156,14 +182,32 @@ class TestIncidentLabels:
         ]
         assert labels_queried == [["incident"], ["outage"]]
 
+    def test_github_filters_prs_carrying_incident_label(self, monkeypatch) -> None:
+        monkeypatch.delenv("INCIDENT_LABELS", raising=False)
+        real_issue = Mock(id=1, state="closed", created_at=NOW, closed_at=NOW)
+        real_issue.pull_request = None
+        labeled_pr = Mock(id=2, state="open", created_at=NOW, closed_at=None)
+        labeled_pr.pull_request = Mock()  # the issues API includes PRs
+        gh_repo = Mock()
+        gh_repo.get_issues.return_value = [real_issue, labeled_pr]
+
+        incidents = _fetch_github_incidents_sync(gh_repo, REPO_ID, 10, None)
+
+        assert [i.incident_id for i in incidents] == ["1"]
+
     def test_gitlab_queries_each_label_and_dedupes(self, monkeypatch) -> None:
+        """rest_client is spec'd to the real GitLabRESTClient so a missing
+        method (the original silent-no-op bug) fails loudly here."""
         monkeypatch.setenv("INCIDENT_LABELS", "incident,outage")
         shared = {"id": 1, "state": "closed", "created_at": "2026-06-12T00:00:00Z"}
         outage_only = {"id": 2, "state": "opened", "created_at": "2026-06-12T01:00:00Z"}
         connector = Mock()
+        connector.rest_client = Mock(spec=GitLabRESTClient)
         connector.rest_client.get_issues.side_effect = [[shared], [shared, outage_only]]
 
         incidents = _fetch_gitlab_incidents_sync(connector, 123, REPO_ID, 10, None)
 
         assert {i.incident_id for i in incidents} == {"1", "2"}
         assert connector.rest_client.get_issues.call_count == 2
+        first_call = connector.rest_client.get_issues.call_args_list[0]
+        assert first_call.kwargs["labels"] == "incident"

--- a/tests/test_deployment_pr_inference.py
+++ b/tests/test_deployment_pr_inference.py
@@ -1,0 +1,169 @@
+"""CHAOS-2368/CHAOS-2369: deployment→PR inference + configurable incident labels.
+
+Deployment syncs previously ignored the deployed commit SHA, leaving
+``deployments.pull_request_number`` NULL everywhere — so the PR↔deployment
+work-graph edges (#886) had no native source data. Incident syncs hardcoded
+the exact label ``incident`` with no diagnosability.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+# Initialize the connectors package before processors to avoid the
+# pre-existing providers._base <-> connectors circular import when this file
+# is collected in isolation.
+import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.processors.base_git import resolve_incident_labels
+from dev_health_ops.processors.github import (
+    _fetch_github_deployments_sync,
+    _fetch_github_incidents_sync,
+    _resolve_github_deployment_pr,
+)
+from dev_health_ops.processors.gitlab import (
+    _fetch_gitlab_incidents_sync,
+    _resolve_gitlab_deployment_mr,
+)
+
+REPO_ID = uuid.uuid4()
+NOW = datetime(2026, 6, 12, tzinfo=timezone.utc)
+
+
+class _NoWaitGate:
+    def __init__(self) -> None:
+        self.waits = 0
+
+    def wait_sync(self) -> None:
+        self.waits += 1
+
+
+class TestGitHubDeploymentPRInference:
+    def test_resolves_merged_pr(self) -> None:
+        merged_pr = Mock(number=42, merged_at=NOW)
+        open_pr = Mock(number=43, merged_at=None)
+        commit = Mock()
+        commit.get_pulls.return_value = [open_pr, merged_pr]
+        gh_repo = Mock()
+        gh_repo.get_commit.return_value = commit
+        gate = _NoWaitGate()
+
+        number, merged_at = _resolve_github_deployment_pr(gh_repo, "abc123", gate)
+
+        assert (number, merged_at) == (42, NOW)
+        gh_repo.get_commit.assert_called_once_with("abc123")
+        assert gate.waits == 2
+
+    def test_falls_back_to_first_pr_when_none_merged(self) -> None:
+        open_pr = Mock(number=7, merged_at=None)
+        commit = Mock()
+        commit.get_pulls.return_value = [open_pr]
+        gh_repo = Mock()
+        gh_repo.get_commit.return_value = commit
+
+        number, merged_at = _resolve_github_deployment_pr(
+            gh_repo, "abc123", _NoWaitGate()
+        )
+
+        assert (number, merged_at) == (7, None)
+
+    def test_no_sha_skips_lookup(self) -> None:
+        gh_repo = Mock()
+        assert _resolve_github_deployment_pr(gh_repo, None, _NoWaitGate()) == (
+            None,
+            None,
+        )
+        gh_repo.get_commit.assert_not_called()
+
+    def test_lookup_failure_is_soft(self) -> None:
+        gh_repo = Mock()
+        gh_repo.get_commit.side_effect = RuntimeError("boom")
+        assert _resolve_github_deployment_pr(gh_repo, "abc", _NoWaitGate()) == (
+            None,
+            None,
+        )
+
+    def test_deployments_carry_pr_attribution(self) -> None:
+        dep = Mock(id=99, state="success", environment="prod", created_at=NOW)
+        dep.sha = "abc123"
+        merged_pr = Mock(number=42, merged_at=NOW)
+        commit = Mock()
+        commit.get_pulls.return_value = [merged_pr]
+        gh_repo = Mock()
+        gh_repo.get_deployments.return_value = [dep]
+        gh_repo.get_releases.return_value = []
+        gh_repo.get_commit.return_value = commit
+
+        deployments = _fetch_github_deployments_sync(
+            gh_repo, REPO_ID, 10, None, _NoWaitGate()
+        )
+
+        assert len(deployments) == 1
+        assert deployments[0].pull_request_number == 42
+        assert deployments[0].merged_at == NOW
+
+
+class TestGitLabDeploymentMRInference:
+    def test_resolves_merged_mr(self) -> None:
+        connector = Mock()
+        connector.rest_client.get_list.return_value = [
+            {"iid": 5, "state": "opened", "merged_at": None},
+            {"iid": 6, "state": "merged", "merged_at": "2026-06-12T00:00:00Z"},
+        ]
+
+        number, merged_at = _resolve_gitlab_deployment_mr(connector, 123, "abc")
+
+        assert number == 6
+        assert merged_at is not None
+        connector.rest_client.get_list.assert_called_once_with(
+            "projects/123/repository/commits/abc/merge_requests"
+        )
+
+    def test_no_sha_or_failure_is_soft(self) -> None:
+        connector = Mock()
+        assert _resolve_gitlab_deployment_mr(connector, 123, None) == (None, None)
+        connector.rest_client.get_list.side_effect = RuntimeError("boom")
+        assert _resolve_gitlab_deployment_mr(connector, 123, "abc") == (None, None)
+
+
+class TestIncidentLabels:
+    def test_default_label(self, monkeypatch) -> None:
+        monkeypatch.delenv("INCIDENT_LABELS", raising=False)
+        assert resolve_incident_labels() == ["incident"]
+
+    def test_env_override_and_whitespace(self, monkeypatch) -> None:
+        monkeypatch.setenv("INCIDENT_LABELS", " incident , outage ,sev1,")
+        assert resolve_incident_labels() == ["incident", "outage", "sev1"]
+
+    def test_empty_env_falls_back(self, monkeypatch) -> None:
+        monkeypatch.setenv("INCIDENT_LABELS", " , ")
+        assert resolve_incident_labels() == ["incident"]
+
+    def test_github_queries_each_label_and_dedupes(self, monkeypatch) -> None:
+        monkeypatch.setenv("INCIDENT_LABELS", "incident,outage")
+        shared = Mock(id=1, state="closed", created_at=NOW, closed_at=NOW)
+        outage_only = Mock(id=2, state="open", created_at=NOW, closed_at=None)
+        gh_repo = Mock()
+        gh_repo.get_issues.side_effect = [[shared], [shared, outage_only]]
+
+        incidents = _fetch_github_incidents_sync(gh_repo, REPO_ID, 10, None)
+
+        assert {i.incident_id for i in incidents} == {"1", "2"}
+        assert gh_repo.get_issues.call_count == 2
+        labels_queried = [
+            call.kwargs["labels"] for call in gh_repo.get_issues.call_args_list
+        ]
+        assert labels_queried == [["incident"], ["outage"]]
+
+    def test_gitlab_queries_each_label_and_dedupes(self, monkeypatch) -> None:
+        monkeypatch.setenv("INCIDENT_LABELS", "incident,outage")
+        shared = {"id": 1, "state": "closed", "created_at": "2026-06-12T00:00:00Z"}
+        outage_only = {"id": 2, "state": "opened", "created_at": "2026-06-12T01:00:00Z"}
+        connector = Mock()
+        connector.rest_client.get_issues.side_effect = [[shared], [shared, outage_only]]
+
+        incidents = _fetch_gitlab_incidents_sync(connector, 123, REPO_ID, 10, None)
+
+        assert {i.incident_id for i in incidents} == {"1", "2"}
+        assert connector.rest_client.get_issues.call_count == 2


### PR DESCRIPTION
## CHAOS-2367 sub-issues — feeds the work-graph edges shipped in #886

### CHAOS-2368: deployment→PR inference

Both deployment syncs ignored the deployed commit SHA (GitHub `Deployment.sha`, GitLab payload `sha`), so `deployments.pull_request_number` was NULL for every API-synced org (a78c1a6a: 925/925) and the PR↔deployment edges had no native source.

- **GitHub** `_resolve_github_deployment_pr`: `GET /commits/{sha}/pulls` via PyGithub (`get_commit` + `get_pulls`, two rate-limit-gated calls per deployment, failure-soft per deployment); prefers the merged PR, falls back to the first associated PR; sets `pull_request_number` + `merged_at`
- **GitLab** `_resolve_gitlab_deployment_mr`: `GET /projects/{id}/repository/commits/{sha}/merge_requests`; prefers `state=merged`; sets MR iid + parsed `merged_at`
- Bounded by the existing `max_deployments`/`since` window — incremental syncs only pay for new deployments

### CHAOS-2369: configurable incident labels

Incident syncs hardcoded the exact label `incident`; org a78c1a6a has 0 incidents because none of its repos define that label, and the empty result was silent.

- `resolve_incident_labels()` (shared, base_git): `INCIDENT_LABELS` env, comma-separated, default `incident`
- Both providers query one label at a time (GitHub's multi-label filter is AND-semantics), dedupe by issue id, and log labels searched + match count so empty results are diagnosable

## Verification

- Live: re-synced `full-chaos/dev-health-ops` deployments through the new code → **25/47 deployments now carry `pull_request_number` + `merged_at`** (rest are direct-push deploys); daily job over that window produced the org's **first 25 `work_graph_pr_deployment_edges`** (was 0 since inception)
- New tests: `tests/test_deployment_pr_inference.py` (12: merged-PR preference, fallback, no-sha skip, failure-soft, gate usage, end-to-end deployment build, label env parsing, per-label query + dedupe both providers)
- ruff ✓, mypy (1,030 files) ✓, unit suite 4,188 passed (11 known local flakes: org-deletion live-ClickHouse pollution ×9, junit parser, date-rollover forecast — all fail identically on main)