### PR TITLE
feat(testops): ingest real test results from GitHub/GitLab (CHAOS-2370)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -124,7 +124,15 @@ def _backfill_job_response(job: object):
 # Canonical mapping of provider → supported sync targets.
 # Jira/Linear only support work-items; Git/CI/CD come from code hosts.
 PROVIDER_SYNC_TARGETS: dict[str, list[str]] = {
-    "github": ["git", "prs", "cicd", "deployments", "incidents", "work-items"],
+    "github": [
+        "git",
+        "prs",
+        "cicd",
+        "deployments",
+        "incidents",
+        "work-items",
+        "tests",
+    ],
     "gitlab": [
         "git",
         "prs",
@@ -133,6 +141,7 @@ PROVIDER_SYNC_TARGETS: dict[str, list[str]] = {
         "incidents",
         "work-items",
         "feature-flags",
+        "tests",
     ],
     "jira": ["work-items"],
     "linear": ["work-items"],

--- a/src/dev_health_ops/connectors/github.py
+++ b/src/dev_health_ops/connectors/github.py
@@ -871,6 +871,147 @@ class GitHubConnector(GitConnector):
         initial_delay=1.0,
         exceptions=(RateLimitException, APIException),
     )
+    def list_run_artifacts(
+        self,
+        owner: str,
+        repo: str,
+        run_id: int | str,
+        max_items: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List non-expired artifacts for a workflow run (CHAOS-2370).
+
+        GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts. Returns the
+        ``artifacts`` array (paginated via the Link header). Expired artifacts
+        are skipped because their download endpoint returns 410.
+        """
+        base_url = (
+            f"{self._rest_base_url()}/repos/{owner}/{repo}/actions/runs/"
+            f"{run_id}/artifacts"
+        )
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+        }
+        artifacts: list[dict[str, Any]] = []
+        url: str | None = base_url
+        params: dict[str, Any] | None = {"per_page": 100}
+
+        while url:
+            response = requests.get(url, headers=headers, params=params, timeout=30)
+            params = None
+
+            if response.status_code == 403:
+                if self._is_github_rate_limit_403(response):
+                    retry_after = response.headers.get("Retry-After")
+                    raise RateLimitException(
+                        f"GitHub rate limit (403) listing artifacts: {response.text}",
+                        retry_after_seconds=float(retry_after) if retry_after else None,
+                    )
+                return artifacts
+            if response.status_code == 404:
+                return artifacts
+            if response.status_code == 429:
+                retry_after = response.headers.get("Retry-After")
+                raise RateLimitException(
+                    f"GitHub rate limit listing artifacts: {response.text}",
+                    retry_after_seconds=float(retry_after) if retry_after else None,
+                )
+            if response.status_code >= 400:
+                raise APIException(
+                    f"GitHub artifacts list error: "
+                    f"{response.status_code} {response.text}"
+                )
+
+            payload = response.json()
+            page = payload.get("artifacts", []) if isinstance(payload, dict) else []
+            for artifact in page:
+                if artifact.get("expired"):
+                    continue
+                artifacts.append(artifact)
+                if max_items is not None and len(artifacts) >= max_items:
+                    return artifacts[:max_items]
+
+            url = self._parse_next_link(response.headers.get("Link"))
+
+        return artifacts
+
+    @retry_with_backoff(
+        max_retries=3,
+        initial_delay=1.0,
+        exceptions=(RateLimitException, APIException),
+    )
+    def download_artifact_zip(
+        self,
+        owner: str,
+        repo: str,
+        artifact_id: int | str,
+        max_bytes: int = 100 * 1024 * 1024,
+    ) -> bytes:
+        """Download an Actions artifact ZIP (CHAOS-2370).
+
+        The ``/zip`` endpoint responds 302 with a short-lived pre-signed blob
+        URL. We must NOT forward the GitHub ``Authorization`` header on the
+        redirect — the signed URL carries its own credentials and some storage
+        backends reject the extra header. Returns ``b""`` for expired/removed
+        artifacts (404/410). Streams with a hard byte cap to bound memory.
+        """
+        url = (
+            f"{self._rest_base_url()}/repos/{owner}/{repo}/actions/artifacts/"
+            f"{artifact_id}/zip"
+        )
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+        }
+        response = requests.get(
+            url, headers=headers, timeout=60, allow_redirects=False, stream=True
+        )
+
+        if response.status_code in (404, 410):
+            return b""
+        if response.status_code == 403 and self._is_github_rate_limit_403(response):
+            retry_after = response.headers.get("Retry-After")
+            raise RateLimitException(
+                f"GitHub rate limit downloading artifact {artifact_id}",
+                retry_after_seconds=float(retry_after) if retry_after else None,
+            )
+        if response.status_code in (301, 302, 307, 308):
+            location = response.headers.get("Location")
+            if not location:
+                return b""
+            # Pre-signed URL — deliberately unauthenticated.
+            response = requests.get(location, timeout=120, stream=True)
+
+        if response.status_code in (404, 410):
+            return b""
+        if response.status_code == 429:
+            retry_after = response.headers.get("Retry-After")
+            raise RateLimitException(
+                f"GitHub rate limit downloading artifact {artifact_id}",
+                retry_after_seconds=float(retry_after) if retry_after else None,
+            )
+        if response.status_code >= 400:
+            raise APIException(
+                f"GitHub artifact download error: {response.status_code}"
+            )
+
+        buffer = bytearray()
+        for chunk in response.iter_content(chunk_size=65536):
+            if not chunk:
+                continue
+            buffer.extend(chunk)
+            if len(buffer) > max_bytes:
+                logger.warning(
+                    "Artifact %s exceeds %d byte cap; skipping", artifact_id, max_bytes
+                )
+                return b""
+        return bytes(buffer)
+
+    @retry_with_backoff(
+        max_retries=3,
+        initial_delay=1.0,
+        exceptions=(RateLimitException, APIException),
+    )
     def get_dependabot_alerts(
         self,
         owner: str,

--- a/src/dev_health_ops/connectors/utils/rest.py
+++ b/src/dev_health_ops/connectors/utils/rest.py
@@ -185,6 +185,72 @@ class RESTClient:
         max_delay=60.0,
         exceptions=(RateLimitException, APIException),
     )
+    def get_binary(
+        self,
+        endpoint: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        max_bytes: int = 100 * 1024 * 1024,
+    ) -> bytes:
+        """GET a binary response (e.g. a CI artifact ZIP) with a size cap.
+
+        Returns ``b""`` on 404 (artifacts commonly absent/expired) so callers
+        treat it as "no artifact". Streams with a hard byte cap to bound memory
+        on untrusted downloads (CHAOS-2370).
+        """
+        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        request_headers = {**self.headers, **(headers or {})}
+
+        try:
+            response = requests.get(
+                url,
+                params=params,
+                headers=request_headers,
+                timeout=self.timeout,
+                stream=True,
+            )
+
+            if response.status_code == 401:
+                raise AuthenticationException("Authentication failed")
+            elif response.status_code == 403:
+                raise APIException(f"Forbidden: {response.text}")
+            elif response.status_code == 429:
+                raise RateLimitException(
+                    "API rate limit exceeded",
+                    retry_after_seconds=_parse_retry_after_seconds(response),
+                )
+            elif response.status_code == 404:
+                return b""
+            elif response.status_code != 200:
+                raise APIException(
+                    f"API error: {response.status_code} - {response.text}"
+                )
+
+            buffer = bytearray()
+            for chunk in response.iter_content(chunk_size=65536):
+                if not chunk:
+                    continue
+                buffer.extend(chunk)
+                if len(buffer) > max_bytes:
+                    logger.warning(
+                        "Binary response from %s exceeds %d byte cap; discarding",
+                        endpoint,
+                        max_bytes,
+                    )
+                    return b""
+            return bytes(buffer)
+
+        except requests.exceptions.Timeout as exc:
+            raise APIException("Request timeout") from exc
+        except requests.exceptions.RequestException as exc:
+            raise APIException(f"Request failed: {exc}") from exc
+
+    @retry_with_backoff(
+        max_retries=5,
+        initial_delay=1.0,
+        max_delay=60.0,
+        exceptions=(RateLimitException, APIException),
+    )
     def delete(
         self,
         endpoint: str,
@@ -263,6 +329,32 @@ class GitLabRESTClient(RESTClient):
         # Don't pass token to parent as we're using custom header
         super().__init__(
             base_url=base_url, token=None, timeout=timeout, headers=headers
+        )
+
+    def get_pipeline_test_report(
+        self, project_id: int | str, pipeline_id: int | str
+    ) -> dict[str, Any]:
+        """Fetch GitLab's native parsed JUnit test report for a pipeline.
+
+        GET /projects/{id}/pipelines/{pipeline_id}/test_report returns the
+        already-parsed test suites/cases as JSON, so no artifact download or XML
+        parsing is needed for GitLab pass/fail/duration metrics (CHAOS-2370).
+        Raises APIException on 404 (no report); callers handle best-effort.
+        """
+        return self.get(f"projects/{project_id}/pipelines/{pipeline_id}/test_report")
+
+    def download_job_artifacts(
+        self,
+        project_id: int | str,
+        job_id: int | str,
+        max_bytes: int = 100 * 1024 * 1024,
+    ) -> bytes:
+        """Download a job's artifacts ZIP (for coverage / fallback JUnit).
+
+        Returns ``b""`` when the job has no artifacts or they have expired.
+        """
+        return self.get_binary(
+            f"projects/{project_id}/jobs/{job_id}/artifacts", max_bytes=max_bytes
         )
 
     def get_file_blame(

--- a/src/dev_health_ops/connectors/utils/safe_archive.py
+++ b/src/dev_health_ops/connectors/utils/safe_archive.py
@@ -1,0 +1,124 @@
+"""Bounded, defensive reading of untrusted ZIP archives (CHAOS-2370).
+
+CI test/coverage reports arrive as ZIP artifacts downloaded from GitHub Actions
+and GitLab. ZIPs from external sources are untrusted input and must be handled
+defensively against:
+
+- **Zip-slip / path traversal** — entry names like ``../../etc/passwd`` or
+  absolute paths. We never extract to disk; we read entries in memory and reject
+  dangerous names outright.
+- **Decompression bombs** — a tiny archive that inflates to gigabytes. We cap
+  per-entry uncompressed size, total uncompressed size, entry count, and the
+  per-entry compression ratio.
+
+The reader yields only entries whose names match a caller-supplied predicate
+(e.g. ``*.xml``), so we never inflate files we don't care about.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import zipfile
+from collections.abc import Callable, Iterator
+
+logger = logging.getLogger(__name__)
+
+# Conservative defaults; callers may override per archive.
+DEFAULT_MAX_ENTRIES = 2_000
+DEFAULT_MAX_FILE_BYTES = 64 * 1024 * 1024  # 64 MiB per entry (uncompressed)
+DEFAULT_MAX_TOTAL_BYTES = 256 * 1024 * 1024  # 256 MiB total (uncompressed)
+DEFAULT_MAX_COMPRESSION_RATIO = 200  # uncompressed / compressed per entry
+
+
+def _is_safe_member_name(name: str) -> bool:
+    """Reject absolute paths and parent-directory traversal in entry names."""
+    if not name or name.endswith("/"):
+        return False  # directory entry — nothing to read
+    if name.startswith("/") or name.startswith("\\"):
+        return False
+    # Normalize separators and reject any ``..`` path component.
+    parts = name.replace("\\", "/").split("/")
+    if any(part == ".." for part in parts):
+        return False
+    # Windows drive-absolute (e.g. ``C:\\``).
+    if len(name) >= 2 and name[1] == ":":
+        return False
+    return True
+
+
+def iter_zip_members(
+    data: bytes,
+    *,
+    name_filter: Callable[[str], bool],
+    max_entries: int = DEFAULT_MAX_ENTRIES,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+    max_compression_ratio: int = DEFAULT_MAX_COMPRESSION_RATIO,
+) -> Iterator[tuple[str, bytes]]:
+    """Yield ``(name, content_bytes)`` for matching, in-bounds ZIP members.
+
+    Entries are skipped (with a warning) rather than raising when they fail a
+    safety check, so one hostile entry doesn't abort ingestion of the rest.
+    Raises ``zipfile.BadZipFile`` only when ``data`` is not a valid ZIP — the
+    caller should treat that as "no reports in this artifact".
+    """
+    total_uncompressed = 0
+    processed = 0
+    with zipfile.ZipFile(io.BytesIO(data)) as archive:
+        infos = archive.infolist()
+        if len(infos) > max_entries:
+            logger.warning(
+                "Archive has %d entries (>%d cap); processing first %d only",
+                len(infos),
+                max_entries,
+                max_entries,
+            )
+        for info in infos[:max_entries]:
+            name = info.filename
+            if not _is_safe_member_name(name):
+                logger.warning("Skipping unsafe archive member name: %r", name)
+                continue
+            if not name_filter(name):
+                continue
+            declared = info.file_size
+            if declared > max_file_bytes:
+                logger.warning(
+                    "Skipping oversized archive member %r (%d bytes > %d cap)",
+                    name,
+                    declared,
+                    max_file_bytes,
+                )
+                continue
+            compressed = info.compress_size or 1
+            if declared and declared / compressed > max_compression_ratio:
+                logger.warning(
+                    "Skipping archive member %r: compression ratio %.0f exceeds %d",
+                    name,
+                    declared / compressed,
+                    max_compression_ratio,
+                )
+                continue
+            if total_uncompressed + declared > max_total_bytes:
+                logger.warning(
+                    "Archive total uncompressed size cap (%d) reached; stopping",
+                    max_total_bytes,
+                )
+                break
+            # Read with an explicit byte cap as a second line of defense in case
+            # the declared size in the header understated the real content.
+            with archive.open(info) as member:
+                content = member.read(max_file_bytes + 1)
+            if len(content) > max_file_bytes:
+                logger.warning(
+                    "Skipping archive member %r: actual size exceeds %d cap",
+                    name,
+                    max_file_bytes,
+                )
+                continue
+            total_uncompressed += len(content)
+            processed += 1
+            yield name, content
+    logger.debug(
+        "Read %d member(s) from archive (%d bytes)", processed, total_uncompressed
+    )

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -356,7 +356,7 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
           team_id,
           service_id,
           org_id
-        FROM ci_pipeline_runs
+        FROM ci_pipeline_runs FINAL
         WHERE started_at >= {{start:DateTime}} AND started_at < {{end:DateTime}}
         {repo_filter}
         {org_filter}
@@ -375,8 +375,8 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
           j.runner_type,
           j.retry_attempt,
           j.org_id
-        FROM ci_job_runs AS j
-        INNER JOIN ci_pipeline_runs AS p
+        FROM ci_job_runs AS j FINAL
+        INNER JOIN ci_pipeline_runs AS p FINAL
           ON (p.repo_id = j.repo_id) AND (p.run_id = j.run_id)
          AND (p.org_id = j.org_id)
         WHERE p.started_at >= {{start:DateTime}} AND p.started_at < {{end:DateTime}}
@@ -433,7 +433,7 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
           team_id,
           service_id,
           org_id
-        FROM test_suite_results
+        FROM test_suite_results FINAL
         WHERE coalesce(started_at, finished_at) >= {{start:DateTime}}
           AND coalesce(started_at, finished_at) < {{end:DateTime}}
         {repo_filter}
@@ -455,8 +455,8 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
           c.stack_trace,
           c.is_quarantined,
           c.org_id
-        FROM test_case_results AS c
-        INNER JOIN test_suite_results AS s
+        FROM test_case_results AS c FINAL
+        INNER JOIN test_suite_results AS s FINAL
           ON (s.repo_id = c.repo_id)
          AND (s.run_id = c.run_id)
          AND (s.suite_id = c.suite_id)
@@ -507,8 +507,8 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
           c.team_id,
           c.service_id,
           c.org_id
-        FROM coverage_snapshots AS c
-        INNER JOIN ci_pipeline_runs AS p
+        FROM coverage_snapshots AS c FINAL
+        INNER JOIN ci_pipeline_runs AS p FINAL
           ON (p.repo_id = c.repo_id) AND (p.run_id = c.run_id)
          AND (p.org_id = c.org_id)
         WHERE p.started_at >= {{start:DateTime}} AND p.started_at < {{end:DateTime}}

--- a/src/dev_health_ops/metrics/sinks/ingestion.py
+++ b/src/dev_health_ops/metrics/sinks/ingestion.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from dev_health_ops.metrics.testops_schemas import JobRunRow, PipelineRunExtendedRow
+from dev_health_ops.metrics.testops_schemas import (
+    CoverageSnapshotRow,
+    JobRunRow,
+    PipelineRunExtendedRow,
+    TestCaseResultRow,
+    TestSuiteResultRow,
+)
 from dev_health_ops.models.git import (
     CiPipelineRun,
     Deployment,
@@ -57,6 +63,17 @@ class IngestionSink:
 
     async def insert_testops_job_runs(self, jobs: list[JobRunRow]) -> None:
         await self._store.insert_testops_job_runs(jobs)
+
+    async def insert_test_suite_results(self, suites: list[TestSuiteResultRow]) -> None:
+        await self._store.insert_test_suite_results(suites)
+
+    async def insert_test_case_results(self, cases: list[TestCaseResultRow]) -> None:
+        await self._store.insert_test_case_results(cases)
+
+    async def insert_coverage_snapshots(
+        self, snapshots: list[CoverageSnapshotRow]
+    ) -> None:
+        await self._store.insert_coverage_snapshots(snapshots)
 
     async def insert_deployments(self, deployments: list[Deployment]) -> None:
         await self._store.insert_deployments(deployments)

--- a/src/dev_health_ops/parsers/coverage.py
+++ b/src/dev_health_ops/parsers/coverage.py
@@ -3,7 +3,24 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
-from xml.etree import ElementTree as ET
+from xml.etree import ElementTree as ET  # types only — parsing uses defusedxml
+
+from defusedxml.ElementTree import fromstring as _defused_fromstring
+
+# Coverage XML (cobertura/clover) is downloaded from untrusted CI artifacts;
+# parse with defusedxml and cap document size to block XXE / entity-expansion
+# bombs and memory exhaustion (CHAOS-2370).
+_MAX_XML_BYTES = 64 * 1024 * 1024  # 64 MiB per report
+
+
+def _safe_fromstring(text: str) -> ET.Element:
+    encoded_len = len(text.encode("utf-8", errors="ignore"))
+    if encoded_len > _MAX_XML_BYTES:
+        raise ValueError(
+            f"Coverage XML too large: {encoded_len} bytes exceeds "
+            f"{_MAX_XML_BYTES} byte limit"
+        )
+    return _defused_fromstring(text, forbid_dtd=True)
 
 
 @dataclass(frozen=True)
@@ -147,7 +164,7 @@ def parse_lcov_report(source: str | bytes | Path) -> CoverageReport:
 
 
 def parse_cobertura_xml(source: str | bytes | Path) -> CoverageReport:
-    root = ET.fromstring(_read_text(source))
+    root = _safe_fromstring(_read_text(source))
     files: dict[str, CoverageFileRecord] = {}
 
     for class_element in root.findall(".//class"):

--- a/src/dev_health_ops/parsers/junit.py
+++ b/src/dev_health_ops/parsers/junit.py
@@ -4,9 +4,29 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
-from xml.etree import ElementTree as ET
+from xml.etree import ElementTree as ET  # types only — parsing uses defusedxml
+
+from defusedxml.ElementTree import fromstring as _defused_fromstring
 
 CANONICAL_TEST_STATUSES = {"passed", "failed", "skipped", "error", "quarantined"}
+
+# Untrusted test reports come from external CI artifacts (GitHub Actions /
+# GitLab job artifacts). Parse them with defusedxml (blocks XXE, external
+# entity, and entity-expansion "billion laughs" attacks) and cap the document
+# size so a single pathological report cannot exhaust memory (CHAOS-2370).
+_MAX_XML_BYTES = 64 * 1024 * 1024  # 64 MiB per report
+
+
+def _safe_fromstring(text: str) -> ET.Element:
+    """Parse XML from an untrusted source with entity/DTD attacks disabled."""
+    encoded_len = len(text.encode("utf-8", errors="ignore"))
+    if encoded_len > _MAX_XML_BYTES:
+        raise ValueError(
+            f"XML report too large: {encoded_len} bytes exceeds "
+            f"{_MAX_XML_BYTES} byte limit"
+        )
+    # defusedxml defaults: forbid_entities=True, forbid_external=True.
+    return _defused_fromstring(text, forbid_dtd=True)
 
 
 @dataclass(frozen=True)
@@ -135,7 +155,7 @@ def _infer_framework(suite: ET.Element, cases: list[ParsedTestCase]) -> str | No
 
 
 def parse_junit_xml(source: str | bytes | Path) -> list[ParsedTestSuite]:
-    root = ET.fromstring(_read_text(source))
+    root = _safe_fromstring(_read_text(source))
     suites: list[ParsedTestSuite] = []
 
     candidate_suites: list[ET.Element] = []

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -1028,6 +1028,12 @@ def _is_report_name(name: str) -> bool:
     return lowered.endswith(".xml") or lowered.endswith(".info")
 
 
+def _as_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+
+
 def _fetch_github_test_artifacts_sync(
     connector: Any,
     gh_repo: Any,
@@ -1036,24 +1042,33 @@ def _fetch_github_test_artifacts_sync(
     since: datetime | None,
     default_branch: str | None,
     max_runs: int,
-) -> list[tuple[str, list[tuple[str, bytes]]]]:
+) -> list[tuple[str, list[tuple[str, bytes]], datetime | None, datetime | None]]:
     """Blocking: download + extract JUnit/coverage report files per workflow run.
 
-    Returns ``[(run_id, [(filename, content_bytes), ...]), ...]``. Bounds work
-    by scanning only the default branch and the most recent ``max_runs`` runs in
-    the window (Codex review item D). ``run_id`` is ``str(run.id)`` so the parsed
-    rows join to the pipeline rows the adapter writes.
+    Returns ``[(run_id, members, started_at, finished_at), ...]``. Branch + date
+    filtering is pushed SERVER-SIDE (``get_workflow_runs(branch=, created=)``) so
+    we never paginate deep history of off-branch runs (Codex review item D), and
+    a flat ``max_runs`` cap bounds the scan. ``run_id`` is ``str(run.id)`` and the
+    run timestamps date the suites (which otherwise lack timestamps).
     """
     # Lazy import to avoid a connectors/providers import cycle at module load.
     from dev_health_ops.connectors.utils.safe_archive import iter_zip_members
 
-    results: list[tuple[str, list[tuple[str, bytes]]]] = []
-    since_aware = since
-    if since_aware is not None and since_aware.tzinfo is None:
-        since_aware = since_aware.replace(tzinfo=timezone.utc)
+    results: list[
+        tuple[str, list[tuple[str, bytes]], datetime | None, datetime | None]
+    ] = []
+    since_aware = _as_utc(since)
+
+    list_kwargs: dict[str, Any] = {}
+    if default_branch:
+        list_kwargs["branch"] = default_branch
+    if since_aware is not None:
+        # GitHub's `created` filter is date-granular; the server returns only
+        # runs created on/after this date, so no client-side history walk.
+        list_kwargs["created"] = f">={since_aware.date().isoformat()}"
 
     try:
-        runs = gh_repo.get_workflow_runs()
+        runs = gh_repo.get_workflow_runs(**list_kwargs)
     except Exception as exc:
         logging.warning(
             "Could not list workflow runs for %s/%s: %s", owner, repo_name, exc
@@ -1064,26 +1079,14 @@ def _fetch_github_test_artifacts_sync(
     for run in runs:
         if scanned >= max_runs:
             break
-        head_branch = getattr(run, "head_branch", None)
-        if default_branch and head_branch and head_branch != default_branch:
-            continue
-        created = getattr(run, "created_at", None) or getattr(
-            run, "run_started_at", None
-        )
-        if since_aware is not None and created is not None:
-            created_aware = (
-                created.replace(tzinfo=timezone.utc)
-                if created.tzinfo is None
-                else created
-            )
-            # Workflow runs are returned newest-first; once we pass the window
-            # boundary every subsequent run is older, so stop.
-            if created_aware < since_aware:
-                break
+        scanned += 1
         run_id = getattr(run, "id", None)
         if run_id is None:
             continue
-        scanned += 1
+        run_started = _as_utc(
+            getattr(run, "run_started_at", None) or getattr(run, "created_at", None)
+        )
+        run_finished = _as_utc(getattr(run, "updated_at", None))
         try:
             artifacts = connector.list_run_artifacts(
                 owner, repo_name, run_id, max_items=MAX_ARTIFACTS_PER_RUN
@@ -1109,7 +1112,7 @@ def _fetch_github_test_artifacts_sync(
                 logging.debug("Artifact %s is not a valid zip", artifact_id)
                 continue
         if members:
-            results.append((str(run_id), members))
+            results.append((str(run_id), members, run_started, run_finished))
     return results
 
 
@@ -1186,9 +1189,14 @@ async def _sync_github_test_reports(
     suite_rows: list[Any] = []
     case_rows: list[Any] = []
     coverage_rows: list[Any] = []
-    for run_id_str, members in raw:
+    for run_id_str, members, run_started, run_finished in raw:
         suites, cases, coverage = await ingest_report_members(
-            members, repo_id=repo_id, run_id=run_id_str, org_id=org_id
+            members,
+            repo_id=repo_id,
+            run_id=run_id_str,
+            org_id=org_id,
+            started_at=run_started,
+            finished_at=run_finished,
         )
         suite_rows.extend(suites)
         case_rows.extend(cases)

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import zipfile
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -42,6 +43,11 @@ from dev_health_ops.processors.fetch_utils import (
 )
 from dev_health_ops.processors.release_ref import get_release_ref_enrichment
 from dev_health_ops.processors.storage_protocol import GitSyncStore
+from dev_health_ops.processors.testops_ingest import (
+    MAX_ARTIFACTS_PER_RUN,
+    MAX_RUNS_PER_SYNC,
+    ingest_report_members,
+)
 from dev_health_ops.providers.pr_state import normalize_pr_state
 from dev_health_ops.utils import (
     AGGREGATE_STATS_MARKER,
@@ -1016,6 +1022,194 @@ async def _backfill_github_missing_data(
             )
 
 
+def _is_report_name(name: str) -> bool:
+    """ZIP member filter: JUnit/coverage report files we know how to parse."""
+    lowered = name.lower()
+    return lowered.endswith(".xml") or lowered.endswith(".info")
+
+
+def _fetch_github_test_artifacts_sync(
+    connector: Any,
+    gh_repo: Any,
+    owner: str,
+    repo_name: str,
+    since: datetime | None,
+    default_branch: str | None,
+    max_runs: int,
+) -> list[tuple[str, list[tuple[str, bytes]]]]:
+    """Blocking: download + extract JUnit/coverage report files per workflow run.
+
+    Returns ``[(run_id, [(filename, content_bytes), ...]), ...]``. Bounds work
+    by scanning only the default branch and the most recent ``max_runs`` runs in
+    the window (Codex review item D). ``run_id`` is ``str(run.id)`` so the parsed
+    rows join to the pipeline rows the adapter writes.
+    """
+    # Lazy import to avoid a connectors/providers import cycle at module load.
+    from dev_health_ops.connectors.utils.safe_archive import iter_zip_members
+
+    results: list[tuple[str, list[tuple[str, bytes]]]] = []
+    since_aware = since
+    if since_aware is not None and since_aware.tzinfo is None:
+        since_aware = since_aware.replace(tzinfo=timezone.utc)
+
+    try:
+        runs = gh_repo.get_workflow_runs()
+    except Exception as exc:
+        logging.warning(
+            "Could not list workflow runs for %s/%s: %s", owner, repo_name, exc
+        )
+        return results
+
+    scanned = 0
+    for run in runs:
+        if scanned >= max_runs:
+            break
+        head_branch = getattr(run, "head_branch", None)
+        if default_branch and head_branch and head_branch != default_branch:
+            continue
+        created = getattr(run, "created_at", None) or getattr(
+            run, "run_started_at", None
+        )
+        if since_aware is not None and created is not None:
+            created_aware = (
+                created.replace(tzinfo=timezone.utc)
+                if created.tzinfo is None
+                else created
+            )
+            # Workflow runs are returned newest-first; once we pass the window
+            # boundary every subsequent run is older, so stop.
+            if created_aware < since_aware:
+                break
+        run_id = getattr(run, "id", None)
+        if run_id is None:
+            continue
+        scanned += 1
+        try:
+            artifacts = connector.list_run_artifacts(
+                owner, repo_name, run_id, max_items=MAX_ARTIFACTS_PER_RUN
+            )
+        except Exception as exc:
+            logging.debug("Artifact list failed for run %s: %s", run_id, exc)
+            continue
+        members: list[tuple[str, bytes]] = []
+        for artifact in artifacts:
+            artifact_id = artifact.get("id")
+            if artifact_id is None:
+                continue
+            try:
+                data = connector.download_artifact_zip(owner, repo_name, artifact_id)
+            except Exception as exc:
+                logging.debug("Artifact download failed for %s: %s", artifact_id, exc)
+                continue
+            if not data:
+                continue
+            try:
+                members.extend(iter_zip_members(data, name_filter=_is_report_name))
+            except zipfile.BadZipFile:
+                logging.debug("Artifact %s is not a valid zip", artifact_id)
+                continue
+        if members:
+            results.append((str(run_id), members))
+    return results
+
+
+async def _sync_github_test_reports(
+    *,
+    connector: Any,
+    gh_repo: Any,
+    owner: str,
+    repo_name: str,
+    repo_id: Any,
+    org_id: str,
+    ingestion_sink: IngestionSink,
+    loop: asyncio.AbstractEventLoop,
+    since: datetime | None,
+) -> None:
+    """Ingest TestOps data for one GitHub repo (CHAOS-2370).
+
+    (1) Extended pipeline + job rows via the async adapter (closes the
+    ci_job_runs gap and populates the extended ci_pipeline_runs columns).
+    (2) Test suites/cases + coverage parsed from Actions artifacts.
+    Each stage is independently fault-tolerant so one failure doesn't sink the
+    rest of the sync.
+    """
+    # Lazy imports to avoid a connectors/providers import cycle at module load.
+    from dev_health_ops.processors.testops_pipeline import TestOpsPipelineProcessor
+    from dev_health_ops.providers.github.testops_pipeline import GitHubActionsAdapter
+
+    # (1) Extended pipelines + jobs. Pass the connector's resolved token
+    # explicitly so the adapter never falls back to an ambient env token in a
+    # multi-tenant worker (Codex review item G).
+    try:
+        adapter = GitHubActionsAdapter(
+            base_url=connector._rest_base_url(), token=connector.token
+        )
+        processor = TestOpsPipelineProcessor(ingestion_sink)
+        async with adapter:
+            result = await processor.fetch_and_store(
+                adapter,
+                since_date=since,
+                owner=owner,
+                repo=repo_name,
+                repo_id=repo_id,
+                org_id=org_id,
+            )
+        logging.info(
+            "TestOps GitHub %s/%s: %d pipelines, %d jobs",
+            owner,
+            repo_name,
+            result.pipeline_runs,
+            result.job_runs,
+        )
+    except Exception as exc:
+        logging.warning(
+            "TestOps pipeline/job ingestion failed for %s/%s: %s",
+            owner,
+            repo_name,
+            exc,
+        )
+
+    # (2) JUnit + coverage from artifacts (best-effort; artifacts may be
+    # expired/absent — those repos legitimately show empty test metrics).
+    default_branch = getattr(gh_repo, "default_branch", None)
+    raw = await loop.run_in_executor(
+        None,
+        _fetch_github_test_artifacts_sync,
+        connector,
+        gh_repo,
+        owner,
+        repo_name,
+        since,
+        default_branch,
+        MAX_RUNS_PER_SYNC,
+    )
+    suite_rows: list[Any] = []
+    case_rows: list[Any] = []
+    coverage_rows: list[Any] = []
+    for run_id_str, members in raw:
+        suites, cases, coverage = await ingest_report_members(
+            members, repo_id=repo_id, run_id=run_id_str, org_id=org_id
+        )
+        suite_rows.extend(suites)
+        case_rows.extend(cases)
+        coverage_rows.extend(coverage)
+    if suite_rows:
+        await ingestion_sink.insert_test_suite_results(suite_rows)
+    if case_rows:
+        await ingestion_sink.insert_test_case_results(case_rows)
+    if coverage_rows:
+        await ingestion_sink.insert_coverage_snapshots(coverage_rows)
+    logging.info(
+        "TestOps GitHub %s/%s: %d suites, %d cases, %d coverage from %d runs",
+        owner,
+        repo_name,
+        len(suite_rows),
+        len(case_rows),
+        len(coverage_rows),
+        len(raw),
+    )
+
+
 async def process_github_repo(
     store: GitSyncStore | Any,
     owner: str,
@@ -1030,6 +1224,7 @@ async def process_github_repo(
     sync_deployments: bool = True,
     sync_incidents: bool = True,
     sync_security: bool = True,
+    sync_tests: bool = False,
     backfill_missing: bool = True,
     since: datetime | None = None,
 ) -> None:
@@ -1184,6 +1379,19 @@ async def process_github_repo(
                     await ingestion_sink.insert_ci_pipeline_runs(pipeline_runs)
                     logging.info("Stored %d workflow runs", len(pipeline_runs))
 
+            if sync_tests:
+                await _sync_github_test_reports(
+                    connector=connector,
+                    gh_repo=gh_repo,
+                    owner=owner,
+                    repo_name=repo_name,
+                    repo_id=db_repo.id,
+                    org_id=getattr(store, "org_id", "") or "",
+                    ingestion_sink=ingestion_sink,
+                    loop=loop,
+                    since=since,
+                )
+
             if sync_deployments:
                 logging.info("Fetching deployments from GitHub...")
                 deployments = await loop.run_in_executor(
@@ -1295,6 +1503,7 @@ async def process_github_repos_batch(
     sync_deployments: bool = True,
     sync_incidents: bool = True,
     sync_security: bool = True,
+    sync_tests: bool = False,
     blame_only: bool = False,
     backfill_missing: bool = True,
     since: datetime | None = None,
@@ -1467,6 +1676,29 @@ async def process_github_repos_batch(
             except Exception as e:
                 logging.warning(
                     "Failed to fetch CI/CD runs for GitHub repo %s: %s",
+                    repo_info.full_name,
+                    e,
+                )
+
+        if sync_tests:
+            try:
+                if gh_repo is None:
+                    gh_repo = connector.github.get_repo(repo_info.full_name)
+                batch_owner, _, batch_repo = repo_info.full_name.partition("/")
+                await _sync_github_test_reports(
+                    connector=connector,
+                    gh_repo=gh_repo,
+                    owner=batch_owner,
+                    repo_name=batch_repo,
+                    repo_id=db_repo.id,
+                    org_id=getattr(store, "org_id", "") or "",
+                    ingestion_sink=ingestion_sink,
+                    loop=loop,
+                    since=since,
+                )
+            except Exception as e:
+                logging.warning(
+                    "Failed to sync test reports for GitHub repo %s: %s",
                     repo_info.full_name,
                     e,
                 )

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import zipfile
 from collections.abc import Iterable
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
@@ -37,6 +38,12 @@ from dev_health_ops.processors.fetch_utils import (
 )
 from dev_health_ops.processors.release_ref import get_release_ref_enrichment
 from dev_health_ops.processors.storage_protocol import GitSyncStore
+from dev_health_ops.processors.testops_ingest import (
+    MAX_ARTIFACTS_PER_RUN,
+    MAX_RUNS_PER_SYNC,
+    ingest_report_members,
+)
+from dev_health_ops.processors.testops_tests import process_gitlab_test_report
 from dev_health_ops.providers.pr_state import normalize_pr_state
 from dev_health_ops.utils import (
     AGGREGATE_STATS_MARKER,
@@ -927,6 +934,207 @@ async def _backfill_gitlab_missing_data(
                         await blame_collector.maybe_flush()
 
 
+def _is_report_name(name: str) -> bool:
+    """ZIP member filter: JUnit/coverage report files we know how to parse."""
+    lowered = name.lower()
+    return lowered.endswith(".xml") or lowered.endswith(".info")
+
+
+def _fetch_gitlab_test_reports_sync(
+    connector: Any,
+    gl_project: Any,
+    project_id: int,
+    since: datetime | None,
+    default_branch: str | None,
+    max_pipelines: int,
+) -> tuple[
+    list[tuple[str, dict[str, Any]]],
+    list[tuple[str, list[tuple[str, bytes]]]],
+]:
+    """Blocking: collect native test reports + coverage artifact members.
+
+    Returns ``(test_reports, coverage_members)`` where ``test_reports`` is
+    ``[(run_id, test_report_json), ...]`` (GitLab's parsed JUnit JSON) and
+    ``coverage_members`` is ``[(run_id, [(filename, bytes), ...]), ...]`` from
+    job artifact ZIPs. ``run_id`` is ``str(pipeline.id)`` so rows join to the
+    pipeline. Bounded to the default branch and the most recent
+    ``max_pipelines`` pipelines in the window (Codex review item D).
+    """
+    from dev_health_ops.connectors.utils.safe_archive import iter_zip_members
+
+    test_reports: list[tuple[str, dict[str, Any]]] = []
+    coverage_members: list[tuple[str, list[tuple[str, bytes]]]] = []
+    since_aware = since
+    if since_aware is not None and since_aware.tzinfo is None:
+        since_aware = since_aware.replace(tzinfo=timezone.utc)
+
+    try:
+        raw_pipelines = gl_project.pipelines.list(
+            per_page=100, order_by="updated_at", sort="desc", get_all=False
+        )
+    except Exception as exc:
+        logging.warning(
+            "Could not list pipelines for GitLab project %s: %s", project_id, exc
+        )
+        return test_reports, coverage_members
+
+    count = 0
+    for pipeline in raw_pipelines:
+        if count >= max_pipelines:
+            break
+        ref = getattr(pipeline, "ref", None)
+        if default_branch and ref and ref != default_branch:
+            continue
+        created_at = safe_parse_datetime(getattr(pipeline, "created_at", None))
+        if (
+            since_aware is not None
+            and created_at is not None
+            and created_at.astimezone(timezone.utc) < since_aware
+        ):
+            break
+        pipeline_id = getattr(pipeline, "id", None)
+        if pipeline_id is None:
+            continue
+        count += 1
+        run_id = str(pipeline_id)
+
+        # Native parsed test report (pass/fail/duration) — preferred over XML.
+        try:
+            report = connector.rest_client.get_pipeline_test_report(
+                project_id, pipeline_id
+            )
+            if report and report.get("test_suites"):
+                test_reports.append((run_id, report))
+        except Exception as exc:
+            logging.debug("test_report failed for pipeline %s: %s", pipeline_id, exc)
+
+        # Coverage from job artifacts (best-effort, bounded).
+        try:
+            jobs = connector.rest_client.get_list(
+                f"projects/{project_id}/pipelines/{pipeline_id}/jobs",
+                params={"per_page": 100},
+            )
+        except Exception:
+            jobs = []
+        members: list[tuple[str, bytes]] = []
+        artifact_jobs = 0
+        for job in jobs:
+            if artifact_jobs >= MAX_ARTIFACTS_PER_RUN:
+                break
+            if not (job.get("artifacts_file") or job.get("artifacts")):
+                continue
+            job_id = job.get("id")
+            if job_id is None:
+                continue
+            artifact_jobs += 1
+            try:
+                data = connector.rest_client.download_job_artifacts(project_id, job_id)
+            except Exception as exc:
+                logging.debug("artifact download failed for job %s: %s", job_id, exc)
+                continue
+            if not data:
+                continue
+            try:
+                members.extend(iter_zip_members(data, name_filter=_is_report_name))
+            except zipfile.BadZipFile:
+                continue
+        if members:
+            coverage_members.append((run_id, members))
+
+    return test_reports, coverage_members
+
+
+async def _sync_gitlab_test_reports(
+    *,
+    connector: Any,
+    gl_project: Any,
+    project_id: int,
+    token: str,
+    repo_id: Any,
+    org_id: str,
+    ingestion_sink: IngestionSink,
+    loop: asyncio.AbstractEventLoop,
+    since: datetime | None,
+) -> None:
+    """Ingest TestOps data for one GitLab project (CHAOS-2370).
+
+    (1) Extended pipeline + job rows via the async adapter (closes the
+    ci_job_runs gap). (2) Test suites/cases from GitLab's native test_report
+    JSON. (3) Coverage from job artifacts (test cases from artifacts are
+    discarded — the native report is authoritative — so they aren't
+    double-counted). Each stage is independently fault-tolerant.
+    """
+    from dev_health_ops.processors.testops_pipeline import TestOpsPipelineProcessor
+    from dev_health_ops.providers.gitlab.testops_pipeline import GitLabCIAdapter
+
+    # (1) Extended pipelines + jobs. Explicit token (Codex review item G).
+    try:
+        adapter = GitLabCIAdapter(base_url=connector.rest_client.base_url, token=token)
+        processor = TestOpsPipelineProcessor(ingestion_sink)
+        async with adapter:
+            result = await processor.fetch_and_store(
+                adapter,
+                since_date=since,
+                project_id=project_id,
+                repo_id=repo_id,
+                org_id=org_id,
+            )
+        logging.info(
+            "TestOps GitLab project %s: %d pipelines, %d jobs",
+            project_id,
+            result.pipeline_runs,
+            result.job_runs,
+        )
+    except Exception as exc:
+        logging.warning(
+            "TestOps pipeline/job ingestion failed for GitLab project %s: %s",
+            project_id,
+            exc,
+        )
+
+    default_branch = getattr(gl_project, "default_branch", None)
+    test_reports, coverage_members = await loop.run_in_executor(
+        None,
+        _fetch_gitlab_test_reports_sync,
+        connector,
+        gl_project,
+        project_id,
+        since,
+        default_branch,
+        MAX_RUNS_PER_SYNC,
+    )
+
+    suite_rows: list[Any] = []
+    case_rows: list[Any] = []
+    coverage_rows: list[Any] = []
+    for run_id, report in test_reports:
+        suites, cases = await process_gitlab_test_report(
+            repo_id=repo_id, run_id=run_id, report=report, org_id=org_id
+        )
+        suite_rows.extend(suites)
+        case_rows.extend(cases)
+    for run_id, members in coverage_members:
+        # Keep only coverage rows; suites/cases come from the native report.
+        _, _, coverage = await ingest_report_members(
+            members, repo_id=repo_id, run_id=run_id, org_id=org_id
+        )
+        coverage_rows.extend(coverage)
+
+    if suite_rows:
+        await ingestion_sink.insert_test_suite_results(suite_rows)
+    if case_rows:
+        await ingestion_sink.insert_test_case_results(case_rows)
+    if coverage_rows:
+        await ingestion_sink.insert_coverage_snapshots(coverage_rows)
+    logging.info(
+        "TestOps GitLab project %s: %d suites, %d cases, %d coverage",
+        project_id,
+        len(suite_rows),
+        len(case_rows),
+        len(coverage_rows),
+    )
+
+
 async def process_gitlab_project(
     store: GitSyncStore | Any,
     project_id: int,
@@ -941,6 +1149,7 @@ async def process_gitlab_project(
     sync_deployments: bool = True,
     sync_incidents: bool = True,
     sync_security: bool = True,
+    sync_tests: bool = False,
     backfill_missing: bool = True,
     since: datetime | None = None,
 ) -> None:
@@ -1077,6 +1286,19 @@ async def process_gitlab_project(
                 await ingestion_sink.insert_ci_pipeline_runs(pipeline_runs)
                 logging.info(f"Stored {len(pipeline_runs)} pipeline runs from GitLab")
 
+        if sync_tests:
+            await _sync_gitlab_test_reports(
+                connector=connector,
+                gl_project=gl_project,
+                project_id=project_id,
+                token=token,
+                repo_id=db_repo.id,
+                org_id=getattr(store, "org_id", "") or "",
+                ingestion_sink=ingestion_sink,
+                loop=loop,
+                since=since,
+            )
+
         if sync_deployments:
             logging.info("Fetching deployments from GitLab...")
             deployments = await loop.run_in_executor(
@@ -1197,6 +1419,7 @@ async def process_gitlab_projects_batch(
     sync_deployments: bool = True,
     sync_incidents: bool = True,
     sync_security: bool = True,
+    sync_tests: bool = False,
     blame_only: bool = False,
     backfill_missing: bool = True,
     since: datetime | None = None,
@@ -1360,6 +1583,30 @@ async def process_gitlab_projects_batch(
             except Exception as e:
                 logging.warning(
                     "Failed to fetch CI/CD runs for GitLab project %s: %s",
+                    project_info.full_name,
+                    e,
+                )
+
+        if sync_tests:
+            try:
+                if gl_project is None:
+                    gl_project = await loop.run_in_executor(
+                        None, connector.gitlab.projects.get, project_info.id
+                    )
+                await _sync_gitlab_test_reports(
+                    connector=connector,
+                    gl_project=gl_project,
+                    project_id=project_info.id,
+                    token=token,
+                    repo_id=db_repo.id,
+                    org_id=getattr(store, "org_id", "") or "",
+                    ingestion_sink=ingestion_sink,
+                    loop=loop,
+                    since=since,
+                )
+            except Exception as e:
+                logging.warning(
+                    "Failed to sync test reports for GitLab project %s: %s",
                     project_info.full_name,
                     e,
                 )

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -948,30 +948,44 @@ def _fetch_gitlab_test_reports_sync(
     default_branch: str | None,
     max_pipelines: int,
 ) -> tuple[
-    list[tuple[str, dict[str, Any]]],
+    list[tuple[str, dict[str, Any], datetime | None, datetime | None]],
     list[tuple[str, list[tuple[str, bytes]]]],
 ]:
     """Blocking: collect native test reports + coverage artifact members.
 
     Returns ``(test_reports, coverage_members)`` where ``test_reports`` is
-    ``[(run_id, test_report_json), ...]`` (GitLab's parsed JUnit JSON) and
+    ``[(run_id, test_report_json, started_at, finished_at), ...]`` (GitLab's
+    parsed JUnit JSON + the pipeline timestamps used to date the suites) and
     ``coverage_members`` is ``[(run_id, [(filename, bytes), ...]), ...]`` from
     job artifact ZIPs. ``run_id`` is ``str(pipeline.id)`` so rows join to the
-    pipeline. Bounded to the default branch and the most recent
-    ``max_pipelines`` pipelines in the window (Codex review item D).
+    pipeline. Bounded to the default branch and ``max_pipelines`` pipelines.
     """
     from dev_health_ops.connectors.utils.safe_archive import iter_zip_members
 
-    test_reports: list[tuple[str, dict[str, Any]]] = []
+    test_reports: list[
+        tuple[str, dict[str, Any], datetime | None, datetime | None]
+    ] = []
     coverage_members: list[tuple[str, list[tuple[str, bytes]]]] = []
     since_aware = since
     if since_aware is not None and since_aware.tzinfo is None:
         since_aware = since_aware.replace(tzinfo=timezone.utc)
 
+    # Filter by update time SERVER-SIDE. We must NOT early-`break` on created_at:
+    # the list is ordered by updated_at, and a recently-updated pipeline can be
+    # old by created_at, so breaking would silently skip valid in-window
+    # pipelines (Codex review). The max_pipelines cap bounds the scan instead.
+    list_params: dict[str, Any] = {
+        "per_page": 100,
+        "order_by": "updated_at",
+        "sort": "desc",
+    }
+    if since_aware is not None:
+        list_params["updated_after"] = since_aware.isoformat()
     try:
-        raw_pipelines = gl_project.pipelines.list(
-            per_page=100, order_by="updated_at", sort="desc", get_all=False
-        )
+        if max_pipelines > 100:
+            raw_pipelines = gl_project.pipelines.list(**list_params, as_list=False)
+        else:
+            raw_pipelines = gl_project.pipelines.list(**list_params, get_all=False)
     except Exception as exc:
         logging.warning(
             "Could not list pipelines for GitLab project %s: %s", project_id, exc
@@ -985,18 +999,16 @@ def _fetch_gitlab_test_reports_sync(
         ref = getattr(pipeline, "ref", None)
         if default_branch and ref and ref != default_branch:
             continue
-        created_at = safe_parse_datetime(getattr(pipeline, "created_at", None))
-        if (
-            since_aware is not None
-            and created_at is not None
-            and created_at.astimezone(timezone.utc) < since_aware
-        ):
-            break
         pipeline_id = getattr(pipeline, "id", None)
         if pipeline_id is None:
             continue
         count += 1
         run_id = str(pipeline_id)
+        created_at = safe_parse_datetime(getattr(pipeline, "created_at", None))
+        started_at = (
+            safe_parse_datetime(getattr(pipeline, "started_at", None)) or created_at
+        )
+        finished_at = safe_parse_datetime(getattr(pipeline, "finished_at", None))
 
         # Native parsed test report (pass/fail/duration) — preferred over XML.
         try:
@@ -1004,7 +1016,7 @@ def _fetch_gitlab_test_reports_sync(
                 project_id, pipeline_id
             )
             if report and report.get("test_suites"):
-                test_reports.append((run_id, report))
+                test_reports.append((run_id, report, started_at, finished_at))
         except Exception as exc:
             logging.debug("test_report failed for pipeline %s: %s", pipeline_id, exc)
 
@@ -1107,9 +1119,14 @@ async def _sync_gitlab_test_reports(
     suite_rows: list[Any] = []
     case_rows: list[Any] = []
     coverage_rows: list[Any] = []
-    for run_id, report in test_reports:
+    for run_id, report, started_at, finished_at in test_reports:
         suites, cases = await process_gitlab_test_report(
-            repo_id=repo_id, run_id=run_id, report=report, org_id=org_id
+            repo_id=repo_id,
+            run_id=run_id,
+            report=report,
+            org_id=org_id,
+            started_at=started_at,
+            finished_at=finished_at,
         )
         suite_rows.extend(suites)
         case_rows.extend(cases)

--- a/src/dev_health_ops/processors/sync.py
+++ b/src/dev_health_ops/processors/sync.py
@@ -39,6 +39,7 @@ def _sync_flags_for_target(target: str) -> dict:
         "sync_deployments": target == "deployments",
         "sync_incidents": target == "incidents",
         "sync_security": target == "security",
+        "sync_tests": target == "tests",
         "blame_only": target == "blame",
     }
 
@@ -218,6 +219,7 @@ async def sync_github_target(ns: argparse.Namespace, target: str) -> int:
                 "sync_deployments": flags["sync_deployments"],
                 "sync_incidents": flags["sync_incidents"],
                 "sync_security": flags["sync_security"],
+                "sync_tests": flags["sync_tests"],
                 "blame_only": flags["blame_only"],
                 "backfill_missing": True,
                 "since": since,
@@ -244,6 +246,7 @@ async def sync_github_target(ns: argparse.Namespace, target: str) -> int:
             sync_deployments=flags["sync_deployments"],
             sync_incidents=flags["sync_incidents"],
             sync_security=flags["sync_security"],
+            sync_tests=flags["sync_tests"],
             since=since,
         )
 
@@ -282,6 +285,7 @@ async def sync_gitlab_target(ns: argparse.Namespace, target: str) -> int:
                 "sync_deployments": flags["sync_deployments"],
                 "sync_incidents": flags["sync_incidents"],
                 "sync_security": flags["sync_security"],
+                "sync_tests": flags["sync_tests"],
                 "blame_only": flags["blame_only"],
                 "backfill_missing": True,
                 "since": since,
@@ -308,6 +312,7 @@ async def sync_gitlab_target(ns: argparse.Namespace, target: str) -> int:
             sync_deployments=flags["sync_deployments"],
             sync_incidents=flags["sync_incidents"],
             sync_security=flags["sync_security"],
+            sync_tests=flags["sync_tests"],
             since=since,
         )
 
@@ -377,9 +382,11 @@ def run_sync_target(ns: argparse.Namespace) -> int:
         "deployments",
         "incidents",
         "security",
+        "tests",
     }:
         raise SystemExit(
-            "Sync target must be git, prs, blame, cicd, deployments, incidents, or security."
+            "Sync target must be git, prs, blame, cicd, deployments, incidents, "
+            "security, or tests."
         )
 
     if provider == "local":
@@ -450,6 +457,7 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         "deployments": "Sync deployments.",
         "incidents": "Sync incidents.",
         "security": "Sync security and dependency alerts.",
+        "tests": "Sync CI test results and coverage (TestOps).",
     }
 
     for target, help_text in target_parsers.items():

--- a/src/dev_health_ops/processors/testops_coverage.py
+++ b/src/dev_health_ops/processors/testops_coverage.py
@@ -15,8 +15,14 @@ def _hash_identifier(*parts: str | None) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-def build_snapshot_id(run_id: str, report_format: str | None) -> str:
-    return _hash_identifier(run_id, report_format)
+def build_snapshot_id(
+    run_id: str, report_format: str | None, discriminator: str | None = None
+) -> str:
+    # A run can upload several coverage files of the SAME format (e.g. one per
+    # package). Including a per-file discriminator keeps their snapshot IDs
+    # distinct so they don't collapse to one row under the ReplacingMergeTree
+    # dedup key (org_id, repo_id, run_id, snapshot_id) (CHAOS-2370).
+    return _hash_identifier(run_id, report_format, discriminator)
 
 
 def _coverage_pct(covered: int | None, total: int | None) -> float | None:
@@ -51,6 +57,7 @@ async def process_coverage_report(
     team_id: str | None = None,
     org_id: str = "",
     service_path_prefixes: Mapping[str, str] | None = None,
+    report_path: str | None = None,
 ) -> CoverageSnapshotRow:
     report = parse_coverage_report(source, report_format=report_format)
     lines_total = report.lines_total
@@ -61,7 +68,7 @@ async def process_coverage_report(
     return CoverageSnapshotRow(
         repo_id=repo_id,
         run_id=run_id,
-        snapshot_id=build_snapshot_id(run_id, report.report_format),
+        snapshot_id=build_snapshot_id(run_id, report.report_format, report_path),
         report_format=report.report_format,
         lines_total=lines_total,
         lines_covered=lines_covered,

--- a/src/dev_health_ops/processors/testops_ingest.py
+++ b/src/dev_health_ops/processors/testops_ingest.py
@@ -1,0 +1,158 @@
+"""Shared TestOps report-ingestion helpers (CHAOS-2370).
+
+GitHub and GitLab both end up with a set of in-memory report files (JUnit XML
+and coverage XML) extracted from CI artifacts. This module classifies those
+files and turns them into insert-ready rows, reusing the canonical
+``process_test_report`` / ``process_coverage_report`` builders so both providers
+emit identical row shapes and coherence guarantees.
+
+Volume caps live here (and in ``connectors.utils.safe_archive``) so a single
+sync can't download/parse an unbounded number of artifacts.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Iterable
+
+from dev_health_ops.metrics.testops_schemas import (
+    CoverageSnapshotRow,
+    TestCaseResultRow,
+    TestSuiteResultRow,
+)
+from dev_health_ops.processors.testops_coverage import process_coverage_report
+from dev_health_ops.processors.testops_tests import process_test_report
+
+logger = logging.getLogger(__name__)
+
+# Per-sync volume caps (Codex review item D). Bound how much artifact work a
+# single repo sync performs so we never blow CI-provider rate limits or the
+# sync duration budget. Operators backfill wider windows in separate runs.
+MAX_RUNS_PER_SYNC = 200  # workflow runs / pipelines scanned per repo per sync
+MAX_ARTIFACTS_PER_RUN = 25  # artifact archives downloaded per run
+MAX_REPORTS_PER_RUN = 200  # report files parsed per run
+
+_JUNIT_ROOT_MARKERS = ("<testsuite", "<testsuites")
+_COVERAGE_MARKERS = (
+    "<coverage",
+    "<cobertura",
+    "clover",
+    "<report",
+)  # cobertura/clover/jacoco
+
+
+def classify_report(filename: str, text: str) -> str | None:
+    """Classify a report file as ``"junit"``, ``"coverage"``, or ``None``.
+
+    Content sniffing (not just extension) so a misnamed file still routes
+    correctly. The first KB is enough to find the root element.
+    """
+    head = text[:2048].lower()
+    if any(marker in head for marker in _JUNIT_ROOT_MARKERS):
+        return "junit"
+    lowered_name = filename.lower()
+    if lowered_name.endswith(".info"):
+        return "coverage"  # lcov
+    if any(marker in head for marker in _COVERAGE_MARKERS):
+        return "coverage"
+    return None
+
+
+def _coverage_is_coherent(row: CoverageSnapshotRow) -> bool:
+    """Reject coverage rows with impossible values (Codex review item I).
+
+    Real reports occasionally emit malformed totals; a row where covered >
+    total or a percentage outside [0, 100] would skew the rollup, so we drop it
+    rather than store it. (We do NOT enforce branch<=line — that's a legitimate
+    real-world shape, only a fixture convention.)
+    """
+    lines_total = row.get("lines_total")
+    lines_covered = row.get("lines_covered")
+    if (
+        lines_total is not None
+        and lines_covered is not None
+        and lines_covered > lines_total
+    ):
+        return False
+    for pct in (row.get("line_coverage_pct"), row.get("branch_coverage_pct")):
+        if isinstance(pct, (int, float)) and not (0.0 <= pct <= 100.0):
+            return False
+    return True
+
+
+async def ingest_report_members(
+    members: Iterable[tuple[str, bytes]],
+    *,
+    repo_id: uuid.UUID,
+    run_id: str,
+    org_id: str,
+    team_id: str | None = None,
+) -> tuple[
+    list[TestSuiteResultRow], list[TestCaseResultRow], list[CoverageSnapshotRow]
+]:
+    """Parse extracted artifact members into insert-ready rows.
+
+    ``run_id`` MUST match the pipeline run's id so suite/case/coverage rows join
+    to the pipeline. A single malformed report is skipped (logged) rather than
+    aborting the rest.
+    """
+    suite_rows: list[TestSuiteResultRow] = []
+    case_rows: list[TestCaseResultRow] = []
+    coverage_rows: list[CoverageSnapshotRow] = []
+
+    processed = 0
+    for filename, content in members:
+        if processed >= MAX_REPORTS_PER_RUN:
+            logger.warning(
+                "Hit per-run report cap (%d) for run %s; skipping remainder",
+                MAX_REPORTS_PER_RUN,
+                run_id,
+            )
+            break
+        try:
+            text = content.decode("utf-8", errors="replace")
+        except Exception:  # pragma: no cover - decode is defensive
+            continue
+        kind = classify_report(filename, text)
+        if kind is None:
+            continue
+        processed += 1
+        try:
+            if kind == "junit":
+                suites, cases = await process_test_report(
+                    repo_id=repo_id,
+                    run_id=run_id,
+                    source=text,
+                    team_id=team_id,
+                    org_id=org_id,
+                )
+                suite_rows.extend(suites)
+                case_rows.extend(cases)
+            else:  # coverage
+                coverage = await process_coverage_report(
+                    repo_id=repo_id,
+                    run_id=run_id,
+                    source=text,
+                    team_id=team_id,
+                    org_id=org_id,
+                )
+                if _coverage_is_coherent(coverage):
+                    coverage_rows.append(coverage)
+                else:
+                    logger.warning(
+                        "Dropping incoherent coverage row from %s (run %s)",
+                        filename,
+                        run_id,
+                    )
+        except Exception as exc:
+            logger.warning(
+                "Failed to parse %s report %s (run %s): %s",
+                kind,
+                filename,
+                run_id,
+                exc,
+            )
+            continue
+
+    return suite_rows, case_rows, coverage_rows

--- a/src/dev_health_ops/processors/testops_ingest.py
+++ b/src/dev_health_ops/processors/testops_ingest.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Iterable
+from datetime import datetime
 
 from dev_health_ops.metrics.testops_schemas import (
     CoverageSnapshotRow,
@@ -88,14 +89,17 @@ async def ingest_report_members(
     run_id: str,
     org_id: str,
     team_id: str | None = None,
+    started_at: datetime | None = None,
+    finished_at: datetime | None = None,
 ) -> tuple[
     list[TestSuiteResultRow], list[TestCaseResultRow], list[CoverageSnapshotRow]
 ]:
     """Parse extracted artifact members into insert-ready rows.
 
     ``run_id`` MUST match the pipeline run's id so suite/case/coverage rows join
-    to the pipeline. A single malformed report is skipped (logged) rather than
-    aborting the rest.
+    to the pipeline. ``started_at`` / ``finished_at`` (the CI run's timestamps)
+    date suites whose JUnit XML lacks a ``timestamp`` attribute. A single
+    malformed report is skipped (logged) rather than aborting the rest.
     """
     suite_rows: list[TestSuiteResultRow] = []
     case_rows: list[TestCaseResultRow] = []
@@ -126,6 +130,8 @@ async def ingest_report_members(
                     source=text,
                     team_id=team_id,
                     org_id=org_id,
+                    started_at=started_at,
+                    finished_at=finished_at,
                 )
                 suite_rows.extend(suites)
                 case_rows.extend(cases)
@@ -136,6 +142,7 @@ async def ingest_report_members(
                     source=text,
                     team_id=team_id,
                     org_id=org_id,
+                    report_path=filename,
                 )
                 if _coverage_is_coherent(coverage):
                     coverage_rows.append(coverage)

--- a/src/dev_health_ops/processors/testops_tests.py
+++ b/src/dev_health_ops/processors/testops_tests.py
@@ -3,13 +3,25 @@ from __future__ import annotations
 import hashlib
 import uuid
 from collections.abc import Mapping
+from typing import Any
 
 from dev_health_ops.metrics.testops_schemas import TestCaseResultRow, TestSuiteResultRow
 from dev_health_ops.parsers.junit import (
+    CANONICAL_TEST_STATUSES,
     ParsedTestCase,
     ParsedTestSuite,
     parse_junit_xml,
 )
+
+# GitLab's native test_report API reports case status as one of these strings;
+# map them onto our canonical statuses (notably success → passed) so the
+# GitLab JSON path produces the same vocabulary as the JUnit XML path.
+_GITLAB_STATUS_MAP = {
+    "success": "passed",
+    "failed": "failed",
+    "error": "error",
+    "skipped": "skipped",
+}
 
 
 def _hash_identifier(*parts: str | None) -> str:
@@ -70,18 +82,90 @@ def _suite_file_path(suite: ParsedTestSuite) -> str | None:
     return next((case.file_path for case in suite.cases if case.file_path), None)
 
 
-async def process_test_report(
+def _coerce_float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parsed_suites_from_gitlab_report(
+    report: Mapping[str, Any],
+) -> list[ParsedTestSuite]:
+    """Map GitLab's native pipeline ``test_report`` JSON onto ParsedTestSuite.
+
+    GitLab returns parsed JUnit results as JSON (no XML), so this normalizes the
+    JSON shape into the same intermediate model the XML parser emits. Suite
+    counts are derived from the mapped cases (not GitLab's declared counts) so
+    the coherence invariant ``passed+failed+skipped+error == total`` always
+    holds downstream. Empty suites are dropped, mirroring the XML path.
+    """
+    parsed: list[ParsedTestSuite] = []
+    for suite in report.get("test_suites", []) or []:
+        cases: list[ParsedTestCase] = []
+        for case in suite.get("test_cases", []) or []:
+            raw_status = str(case.get("status") or "").lower()
+            status = _GITLAB_STATUS_MAP.get(raw_status, "error")
+            if status not in CANONICAL_TEST_STATUSES:
+                status = "error"
+            stack_trace = case.get("stack_trace") or case.get("system_output")
+            cases.append(
+                ParsedTestCase(
+                    case_name=case.get("name") or "unnamed",
+                    class_name=case.get("classname"),
+                    duration_seconds=_coerce_float(case.get("execution_time")),
+                    status=status,
+                    failure_message=None,
+                    failure_type=None,
+                    stack_trace=stack_trace,
+                    system_out=case.get("system_output"),
+                    system_err=None,
+                    file_path=None,
+                )
+            )
+        if not cases:
+            continue
+        counts = {status: 0 for status in CANONICAL_TEST_STATUSES}
+        for case_ in cases:
+            counts[case_.status] += 1
+        parsed.append(
+            ParsedTestSuite(
+                suite_name=suite.get("name") or "unnamed",
+                framework="gitlab_ci",
+                duration_seconds=_coerce_float(suite.get("total_time")),
+                started_at=None,
+                finished_at=None,
+                total_count=len(cases),
+                passed_count=counts["passed"],
+                failed_count=counts["failed"],
+                skipped_count=counts["skipped"],
+                error_count=counts["error"],
+                quarantined_count=counts["quarantined"],
+                cases=cases,
+            )
+        )
+    return parsed
+
+
+def _build_rows_from_parsed(
+    parsed_suites: list[ParsedTestSuite],
     *,
     repo_id: uuid.UUID,
     run_id: str,
-    source: str,
     environment: str | None = None,
     framework: str | None = None,
     team_id: str | None = None,
     org_id: str = "",
     service_path_prefixes: Mapping[str, str] | None = None,
 ) -> tuple[list[TestSuiteResultRow], list[TestCaseResultRow]]:
-    parsed_suites = parse_junit_xml(source)
+    """Build insert-ready suite/case rows from parsed suites.
+
+    Shared by the JUnit-XML path (``process_test_report``) and the GitLab-JSON
+    path (``process_gitlab_test_report``) so both emit identical row shapes and
+    coherence guarantees.
+    """
     suite_rows: list[TestSuiteResultRow] = []
     case_rows: list[TestCaseResultRow] = []
 
@@ -136,3 +220,57 @@ async def process_test_report(
             )
 
     return suite_rows, case_rows
+
+
+async def process_test_report(
+    *,
+    repo_id: uuid.UUID,
+    run_id: str,
+    source: str,
+    environment: str | None = None,
+    framework: str | None = None,
+    team_id: str | None = None,
+    org_id: str = "",
+    service_path_prefixes: Mapping[str, str] | None = None,
+) -> tuple[list[TestSuiteResultRow], list[TestCaseResultRow]]:
+    """Parse a JUnit XML report (from a CI artifact) into insert-ready rows."""
+    parsed_suites = parse_junit_xml(source)
+    return _build_rows_from_parsed(
+        parsed_suites,
+        repo_id=repo_id,
+        run_id=run_id,
+        environment=environment,
+        framework=framework,
+        team_id=team_id,
+        org_id=org_id,
+        service_path_prefixes=service_path_prefixes,
+    )
+
+
+async def process_gitlab_test_report(
+    *,
+    repo_id: uuid.UUID,
+    run_id: str,
+    report: Mapping[str, Any],
+    environment: str | None = None,
+    team_id: str | None = None,
+    org_id: str = "",
+    service_path_prefixes: Mapping[str, str] | None = None,
+) -> tuple[list[TestSuiteResultRow], list[TestCaseResultRow]]:
+    """Map GitLab's native pipeline ``test_report`` JSON into insert-ready rows.
+
+    Unlike ``process_test_report`` (JUnit XML), this consumes the parsed JSON
+    GitLab returns from ``GET /projects/:id/pipelines/:id/test_report`` — no XML
+    parsing, so no artifact download is needed for GitLab pass/fail/duration.
+    """
+    parsed_suites = _parsed_suites_from_gitlab_report(report)
+    return _build_rows_from_parsed(
+        parsed_suites,
+        repo_id=repo_id,
+        run_id=run_id,
+        environment=environment,
+        framework="gitlab_ci",
+        team_id=team_id,
+        org_id=org_id,
+        service_path_prefixes=service_path_prefixes,
+    )

--- a/src/dev_health_ops/processors/testops_tests.py
+++ b/src/dev_health_ops/processors/testops_tests.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import uuid
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any
 
 from dev_health_ops.metrics.testops_schemas import TestCaseResultRow, TestSuiteResultRow
@@ -159,12 +160,21 @@ def _build_rows_from_parsed(
     team_id: str | None = None,
     org_id: str = "",
     service_path_prefixes: Mapping[str, str] | None = None,
+    fallback_started_at: datetime | None = None,
+    fallback_finished_at: datetime | None = None,
 ) -> tuple[list[TestSuiteResultRow], list[TestCaseResultRow]]:
     """Build insert-ready suite/case rows from parsed suites.
 
     Shared by the JUnit-XML path (``process_test_report``) and the GitLab-JSON
     path (``process_gitlab_test_report``) so both emit identical row shapes and
     coherence guarantees.
+
+    ``fallback_started_at`` / ``fallback_finished_at`` (typically the CI run's
+    timestamps) are used when a suite carries no timestamps of its own. The
+    daily loader windows suites by ``coalesce(started_at, finished_at)``, so a
+    suite with null timestamps (e.g. every GitLab ``test_report`` suite, or a
+    JUnit file without a ``timestamp`` attribute) would otherwise be invisible
+    to the rollup (CHAOS-2370).
     """
     suite_rows: list[TestSuiteResultRow] = []
     case_rows: list[TestCaseResultRow] = []
@@ -191,8 +201,8 @@ def _build_rows_from_parsed(
                 quarantined_count=suite.quarantined_count,
                 retried_count=0,
                 duration_seconds=suite.duration_seconds,
-                started_at=suite.started_at,
-                finished_at=suite.finished_at,
+                started_at=suite.started_at or fallback_started_at,
+                finished_at=suite.finished_at or fallback_finished_at,
                 team_id=team_id,
                 service_id=service_id,
                 org_id=org_id,
@@ -232,8 +242,14 @@ async def process_test_report(
     team_id: str | None = None,
     org_id: str = "",
     service_path_prefixes: Mapping[str, str] | None = None,
+    started_at: datetime | None = None,
+    finished_at: datetime | None = None,
 ) -> tuple[list[TestSuiteResultRow], list[TestCaseResultRow]]:
-    """Parse a JUnit XML report (from a CI artifact) into insert-ready rows."""
+    """Parse a JUnit XML report (from a CI artifact) into insert-ready rows.
+
+    ``started_at`` / ``finished_at`` are the CI run's timestamps, used to date
+    suites that carry no ``timestamp`` of their own (see _build_rows_from_parsed).
+    """
     parsed_suites = parse_junit_xml(source)
     return _build_rows_from_parsed(
         parsed_suites,
@@ -244,6 +260,8 @@ async def process_test_report(
         team_id=team_id,
         org_id=org_id,
         service_path_prefixes=service_path_prefixes,
+        fallback_started_at=started_at,
+        fallback_finished_at=finished_at,
     )
 
 
@@ -256,12 +274,18 @@ async def process_gitlab_test_report(
     team_id: str | None = None,
     org_id: str = "",
     service_path_prefixes: Mapping[str, str] | None = None,
+    started_at: datetime | None = None,
+    finished_at: datetime | None = None,
 ) -> tuple[list[TestSuiteResultRow], list[TestCaseResultRow]]:
     """Map GitLab's native pipeline ``test_report`` JSON into insert-ready rows.
 
     Unlike ``process_test_report`` (JUnit XML), this consumes the parsed JSON
     GitLab returns from ``GET /projects/:id/pipelines/:id/test_report`` — no XML
     parsing, so no artifact download is needed for GitLab pass/fail/duration.
+
+    GitLab's test_report carries no per-suite timestamps, so ``started_at`` /
+    ``finished_at`` (the pipeline's timestamps) are REQUIRED for the suites to
+    fall inside the daily rollup's window (CHAOS-2370).
     """
     parsed_suites = _parsed_suites_from_gitlab_report(report)
     return _build_rows_from_parsed(
@@ -273,4 +297,6 @@ async def process_gitlab_test_report(
         team_id=team_id,
         org_id=org_id,
         service_path_prefixes=service_path_prefixes,
+        fallback_started_at=started_at,
+        fallback_finished_at=finished_at,
     )

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -607,6 +607,7 @@ def _run_sync_for_repo(
                     sync_cicd=merged_flags.get("sync_cicd", False),
                     sync_deployments=merged_flags.get("sync_deployments", False),
                     sync_incidents=merged_flags.get("sync_incidents", False),
+                    sync_tests=merged_flags.get("sync_tests", False),
                 )
 
             run_async(run_with_store(db_url, db_type, _github_handler, org_id=org_id))
@@ -643,6 +644,7 @@ def _run_sync_for_repo(
                     sync_cicd=merged_flags.get("sync_cicd", False),
                     sync_deployments=merged_flags.get("sync_deployments", False),
                     sync_incidents=merged_flags.get("sync_incidents", False),
+                    sync_tests=merged_flags.get("sync_tests", False),
                 )
 
             run_async(run_with_store(db_url, db_type, _gitlab_handler, org_id=org_id))

--- a/src/dev_health_ops/workers/task_utils.py
+++ b/src/dev_health_ops/workers/task_utils.py
@@ -40,6 +40,7 @@ def _merge_sync_flags(sync_targets: list[str]) -> dict[str, bool]:
         "sync_cicd",
         "sync_deployments",
         "sync_incidents",
+        "sync_tests",
         "blame_only",
     ):
         merged_flags.setdefault(key, False)

--- a/tests/testops/test_2370_ingestion.py
+++ b/tests/testops/test_2370_ingestion.py
@@ -1,0 +1,257 @@
+"""Tests for CHAOS-2370 TestOps ingestion (GitHub/GitLab → real test data).
+
+Covers the pure-logic surface that doesn't need a live provider or ClickHouse:
+- XML hardening (defusedxml: DTD/entity attacks blocked) + size cap
+- safe ZIP reading (zip-slip / oversized members rejected)
+- GitLab native test_report JSON → coherent rows (success→passed)
+- report classification + coverage-coherence guard
+- the new ``tests`` sync-target wiring (flags + admin targets)
+- IngestionSink passthroughs delegate to the store
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from uuid import uuid4
+
+import pytest
+
+from dev_health_ops.connectors.utils.safe_archive import iter_zip_members
+from dev_health_ops.parsers import junit as junit_parser
+from dev_health_ops.parsers.junit import parse_junit_xml
+from dev_health_ops.processors.testops_ingest import (
+    _coverage_is_coherent,
+    classify_report,
+    ingest_report_members,
+)
+from dev_health_ops.processors.testops_tests import process_gitlab_test_report
+
+
+# --------------------------------------------------------------------------- #
+# XML hardening                                                               #
+# --------------------------------------------------------------------------- #
+def test_junit_parses_plain_report() -> None:
+    suites = parse_junit_xml(
+        '<testsuite name="s" time="1.0">'
+        '<testcase name="a" time="0.5"/>'
+        '<testcase name="b" time="0.5"><failure message="x"/></testcase>'
+        "</testsuite>"
+    )
+    assert len(suites) == 1
+    assert suites[0].total_count == 2
+    assert suites[0].passed_count == 1
+    assert suites[0].failed_count == 1
+
+
+def test_junit_rejects_dtd_and_entities() -> None:
+    """An XXE/entity payload must not be parsed (defusedxml, forbid_dtd)."""
+    xxe = (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE t [<!ENTITY x SYSTEM "file:///etc/passwd">]>'
+        '<testsuite name="s"><testcase name="a">&x;</testcase></testsuite>'
+    )
+    with pytest.raises(Exception):
+        parse_junit_xml(xxe)
+
+
+def test_junit_enforces_size_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(junit_parser, "_MAX_XML_BYTES", 16)
+    with pytest.raises(ValueError):
+        parse_junit_xml('<testsuite name="way-too-long-to-fit"/>')
+
+
+# --------------------------------------------------------------------------- #
+# Safe ZIP reading                                                            #
+# --------------------------------------------------------------------------- #
+def _zip(entries: dict[str, str]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name, content in entries.items():
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+def test_zip_reader_rejects_traversal_and_filters() -> None:
+    data = _zip(
+        {
+            "results/report.xml": "<testsuite/>",
+            "../escape.xml": "<evil/>",
+            "/abs.xml": "<evil/>",
+            "notes.txt": "ignore me",
+        }
+    )
+    members = dict(iter_zip_members(data, name_filter=lambda n: n.endswith(".xml")))
+    assert "results/report.xml" in members
+    assert "../escape.xml" not in members
+    assert "/abs.xml" not in members
+    assert "notes.txt" not in members  # filtered by name_filter
+
+
+def test_zip_reader_skips_oversized_members() -> None:
+    data = _zip({"big.xml": "A" * 5000})
+    members = list(
+        iter_zip_members(
+            data, name_filter=lambda n: n.endswith(".xml"), max_file_bytes=100
+        )
+    )
+    assert members == []
+
+
+# --------------------------------------------------------------------------- #
+# GitLab native test_report JSON                                              #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_gitlab_test_report_maps_to_coherent_rows() -> None:
+    report = {
+        "total_count": 3,
+        "test_suites": [
+            {
+                "name": "rspec",
+                "total_time": 1.5,
+                "test_cases": [
+                    {
+                        "name": "p",
+                        "classname": "A",
+                        "execution_time": 0.5,
+                        "status": "success",
+                    },
+                    {
+                        "name": "f",
+                        "classname": "A",
+                        "execution_time": 0.7,
+                        "status": "failed",
+                        "stack_trace": "boom",
+                    },
+                    {
+                        "name": "s",
+                        "classname": "B",
+                        "execution_time": 0.0,
+                        "status": "skipped",
+                    },
+                ],
+            },
+            {"name": "empty", "test_cases": []},  # dropped — no cases
+        ],
+    }
+    repo_id = uuid4()
+    suites, cases = await process_gitlab_test_report(
+        repo_id=repo_id, run_id="999", report=report, org_id="org-1"
+    )
+
+    assert len(suites) == 1, "empty suite is dropped like the XML path"
+    suite = suites[0]
+    # success → passed; counts derived from cases (coherence invariant).
+    assert suite["total_count"] == 3
+    assert suite["passed_count"] == 1
+    assert suite["failed_count"] == 1
+    assert suite["skipped_count"] == 1
+    assert (
+        suite["passed_count"]
+        + suite["failed_count"]
+        + suite["skipped_count"]
+        + suite.get("error_count", 0)
+        == suite["total_count"]
+    )
+    assert suite["framework"] == "gitlab_ci"
+    assert suite["org_id"] == "org-1"
+    # Linkage: every row's run_id matches the pipeline run.
+    assert suite["run_id"] == "999"
+    assert len(cases) == 3
+    assert {c["status"] for c in cases} == {"passed", "failed", "skipped"}
+    assert all(c["run_id"] == "999" for c in cases)
+
+
+# --------------------------------------------------------------------------- #
+# Classification + coverage coherence                                         #
+# --------------------------------------------------------------------------- #
+def test_classify_report() -> None:
+    assert classify_report("junit.xml", "<testsuite name='x'/>") == "junit"
+    assert classify_report("r.xml", "<testsuites><testsuite/></testsuites>") == "junit"
+    assert classify_report("cov.xml", "<coverage line-rate='0.5'/>") == "coverage"
+    assert classify_report("lcov.info", "TN:\nSF:foo.py\n") == "coverage"
+    assert classify_report("readme.txt", "not a report") is None
+
+
+def test_coverage_coherence_guard() -> None:
+    assert _coverage_is_coherent(
+        {"lines_total": 100, "lines_covered": 80, "line_coverage_pct": 80.0}  # type: ignore[typeddict-item]
+    )
+    # covered > total is impossible.
+    assert not _coverage_is_coherent(
+        {"lines_total": 50, "lines_covered": 80, "line_coverage_pct": 160.0}  # type: ignore[typeddict-item]
+    )
+    # percentage out of range.
+    assert not _coverage_is_coherent({"line_coverage_pct": 142.0})  # type: ignore[typeddict-item]
+
+
+@pytest.mark.asyncio
+async def test_ingest_report_members_routes_junit_and_coverage() -> None:
+    members = [
+        ("junit.xml", b'<testsuite name="s"><testcase name="a"/></testsuite>'),
+        ("cov.xml", b'<coverage line-rate="0.5" lines-valid="10" lines-covered="5"/>'),
+        ("noise.txt", b"ignored"),
+    ]
+    suites, cases, coverage = await ingest_report_members(
+        members, repo_id=uuid4(), run_id="42", org_id="org-1"
+    )
+    assert len(suites) == 1
+    assert len(cases) == 1
+    assert cases[0]["run_id"] == "42"
+    assert len(coverage) == 1
+
+
+# --------------------------------------------------------------------------- #
+# `tests` sync-target wiring                                                   #
+# --------------------------------------------------------------------------- #
+def test_tests_target_sets_only_sync_tests_flag() -> None:
+    from dev_health_ops.processors.sync import _sync_flags_for_target
+
+    flags = _sync_flags_for_target("tests")
+    assert flags["sync_tests"] is True
+    assert all(not value for key, value in flags.items() if key != "sync_tests"), (
+        "tests target must not enable any other sync"
+    )
+
+
+def test_merge_sync_flags_defaults_sync_tests_false() -> None:
+    from dev_health_ops.workers.task_utils import _merge_sync_flags
+
+    assert _merge_sync_flags(["tests"])["sync_tests"] is True
+    assert _merge_sync_flags(["git"])["sync_tests"] is False
+    assert _merge_sync_flags(["cicd"])["sync_tests"] is False
+
+
+def test_admin_provider_targets_include_tests() -> None:
+    from dev_health_ops.api.admin.routers.sync import PROVIDER_SYNC_TARGETS
+
+    assert "tests" in PROVIDER_SYNC_TARGETS["github"]
+    assert "tests" in PROVIDER_SYNC_TARGETS["gitlab"]
+
+
+# --------------------------------------------------------------------------- #
+# IngestionSink passthroughs                                                   #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_ingestion_sink_passthroughs_delegate_to_store() -> None:
+    from dev_health_ops.metrics.sinks.ingestion import IngestionSink
+
+    class FakeStore:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, object]] = []
+
+        async def insert_test_suite_results(self, rows: object) -> None:
+            self.calls.append(("suite", rows))
+
+        async def insert_test_case_results(self, rows: object) -> None:
+            self.calls.append(("case", rows))
+
+        async def insert_coverage_snapshots(self, rows: object) -> None:
+            self.calls.append(("coverage", rows))
+
+    store = FakeStore()
+    sink = IngestionSink(store)
+    await sink.insert_test_suite_results([{"a": 1}])  # type: ignore[list-item]
+    await sink.insert_test_case_results([{"b": 2}])  # type: ignore[list-item]
+    await sink.insert_coverage_snapshots([{"c": 3}])  # type: ignore[list-item]
+    assert [name for name, _ in store.calls] == ["suite", "case", "coverage"]

--- a/tests/testops/test_2370_ingestion.py
+++ b/tests/testops/test_2370_ingestion.py
@@ -162,6 +162,32 @@ async def test_gitlab_test_report_maps_to_coherent_rows() -> None:
     assert all(c["run_id"] == "999" for c in cases)
 
 
+@pytest.mark.asyncio
+async def test_gitlab_suites_carry_pipeline_timestamps() -> None:
+    """GitLab suites have no timestamps of their own; without the pipeline
+    fallback they'd be filtered out of the daily rollup (coalesce(started_at,
+    finished_at) window). Regression for the CHAOS-2370 review HIGH-1 finding."""
+    from datetime import datetime, timezone
+
+    started = datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc)
+    finished = datetime(2026, 6, 1, 10, 5, tzinfo=timezone.utc)
+    report = {
+        "test_suites": [
+            {"name": "s", "test_cases": [{"name": "a", "status": "success"}]}
+        ]
+    }
+    suites, _ = await process_gitlab_test_report(
+        repo_id=uuid4(),
+        run_id="7",
+        report=report,
+        org_id="o",
+        started_at=started,
+        finished_at=finished,
+    )
+    assert suites[0]["started_at"] == started
+    assert suites[0]["finished_at"] == finished
+
+
 # --------------------------------------------------------------------------- #
 # Classification + coverage coherence                                         #
 # --------------------------------------------------------------------------- #

--- a/tests/testops/test_2370_ingestion.py
+++ b/tests/testops/test_2370_ingestion.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import io
 import zipfile
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -277,7 +278,12 @@ async def test_ingestion_sink_passthroughs_delegate_to_store() -> None:
 
     store = FakeStore()
     sink = IngestionSink(store)
-    await sink.insert_test_suite_results([{"a": 1}])  # type: ignore[list-item]
-    await sink.insert_test_case_results([{"b": 2}])  # type: ignore[list-item]
-    await sink.insert_coverage_snapshots([{"c": 3}])  # type: ignore[list-item]
+    # Payloads are opaque to the passthrough; type as Any so the TypedDict
+    # element checks don't apply (we only assert delegation, not row shape).
+    suite_rows: list[Any] = [{"a": 1}]
+    case_rows: list[Any] = [{"b": 2}]
+    coverage_rows: list[Any] = [{"c": 3}]
+    await sink.insert_test_suite_results(suite_rows)
+    await sink.insert_test_case_results(case_rows)
+    await sink.insert_coverage_snapshots(coverage_rows)
     assert [name for name, _ in store.calls] == ["suite", "case", "coverage"]


### PR DESCRIPTION
## Problem (CHAOS-2370)

TestOps → **Tests** metrics (Pass/Failure/Flake rate, P95 suite duration) render "Insufficient history / No trend yet" for every real org. Investigation confirmed the raw tables (`test_suite_results`, `test_case_results`, `ci_job_runs`, `coverage_snapshots`) are **populated only by fixtures** — the live GitHub/GitLab sync never invoked the existing `process_test_report` / JUnit parser / TestOps adapters. Real org `a78c1a6a` had 6,119 `ci_pipeline_runs` but **0** of everything else.

## What this does

Adds a new **`tests` sync target** that ingests real test data end-to-end. The daily rollup (`job_daily`) was already wired, so this just makes the raw tables non-empty.

- **GitHub:** download Actions run artifacts (302 → signed URL with auth stripped on redirect; size-capped streaming) → bounded safe-zip reader → JUnit/coverage XML → `process_test_report` / `process_coverage_report`.
- **GitLab:** prefer the **native** `GET /pipelines/:id/test_report` JSON (no zip) via a new `process_gitlab_test_report` mapper; coverage from job-artifact zips (test cases discarded there to avoid double-counting).
- **`ci_job_runs` + extended `ci_pipeline_runs`:** populated via the existing `TestOpsPipelineProcessor` + provider adapters, with the **per-org token passed explicitly** (no env fallback).
- **Wiring:** `tests` target threaded through CLI (`dev-hops sync tests`), admin `PROVIDER_SYNC_TARGETS`, `_sync_flags_for_target`, `_merge_sync_flags`, single + batch processors, and the `sync_batch` worker. Defaults **off**; enabled per-org via `sync_targets`.

## Hardening (from two adversarial review passes)

- **defusedxml** + `forbid_dtd` + 64 MiB cap on all untrusted XML (XXE / entity-expansion bombs).
- **safe_archive**: rejects zip-slip/absolute paths, caps entries/size/total/compression-ratio.
- **RMT read-dedup**: `FINAL` on the test/case/job/pipeline/coverage loaders so re-syncs don't double-count. (A review claim that `FINAL` must precede the alias was **refuted against live ClickHouse** — `AS j FINAL` is the valid form here.)
- **Suite timestamp fallback**: GitLab `test_report` (and timestamp-less JUnit) suites are dated by the CI run's timestamps, so the daily loader's `coalesce(started_at, finished_at)` window doesn't filter them out.
- **Bounded scanning**: GitHub branch+`created` filter pushed server-side; GitLab `updated_after` filter (no non-monotonic early-break); per-sync run/artifact/report caps; coverage `snapshot_id` carries a per-file discriminator.
- Coverage-coherence guard drops impossible rows; all stages are best-effort per repo.

## Verification

- 14 new unit tests (XXE/zip hardening, GitLab JSON→coherent rows, classification, coverage coherence, flags, sink passthroughs, timestamp fallback) + 193 affected-area tests pass.
- `ruff` + `mypy` clean. `dev-hops sync tests` CLI parses.
- Both Understand + adversarial Codex passes applied; ClickHouse claims verified against the running DB.

## Not verified here / follow-ups

- **Real-data e2e against `a78c1a6a` needs live tokens** AND repos that emit JUnit within the **14-day artifact retention** window (GitHub coverage goes to Codecov, not artifacts) — can't run in CI sandbox; needs the live env.
- Flake key is `case_name`-only (not classname) — pre-existing compute semantics, left as a follow-up.
- Base-vs-extended `ci_pipeline_runs` columns degrade on a `cicd`-only re-sync until `tests` runs again (Tests-tab path unaffected; only the Pipelines tab).