### PR TITLE
fix(cli): fast-fail with usage when required DB/org inputs are missing

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -71,3 +71,16 @@ dev-hops migrate clickhouse repair --apply --org <uuid>
 ## Flags and overrides
 
 CLI flags override environment variables. Set `CLICKHOUSE_URI` for analytics and `POSTGRES_URI` for semantic data. Subcommands accept `--sink` for analytics and `--since`/`--before`/`--backfill` for date ranges.
+
+## Input validation
+
+Commands that need a database connection or an organization id are validated **before** they run. If a required input is missing, the command fails fast with a usage error (**exit code 2**) that names exactly what is missing, rather than failing partway through:
+
+```bash
+$ dev-hops metrics compounding-risk        # CLICKHOUSE_URI / org not set
+dev-health-ops metrics compounding-risk: error: missing required input(s):
+  - ClickHouse analytics database — pass --analytics-db or set CLICKHOUSE_URI (...)
+  - organization id — pass --org or set ORG_ID (could not auto-resolve ...)
+```
+
+Every affected command lists its requirements at the bottom of `--help` (a `Requires:` line). See the [CLI Reference requirement matrix](ops/cli-reference.md#input-validation-preflight) for the full per-command list.

--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -25,7 +25,7 @@ The CLI is implemented in `cli.py` and orchestrates:
 
 Subcommands like `metrics daily` also accept `--sink` to select the output backend. Legacy values (`mongo`, `sqlite`, `postgres`, `both`) are rejected immediately with a migration message. ClickHouse is the only supported analytics backend.
 
-> **Caveat:** Some subcommands (e.g., `audit completeness`, `audit coverage`) define their own `--db` flag that accepts an **analytics** (ClickHouse) connection string, overriding the global `--db` meaning for that subcommand. Check individual subcommand docs below for the expected connection type.
+> **Caveat:** Some subcommands (e.g., `audit completeness`, `audit coverage`, `investment materialize`, `work-graph build`) define their own `--db` flag that accepts an **analytics** (ClickHouse) connection string, overriding the global `--db` meaning for that subcommand. Check individual subcommand docs below for the expected connection type.
 
 ### Dual-Database Architecture
 
@@ -44,6 +44,43 @@ See [Database Architecture](../architecture/database-architecture.md) for detail
 |---------|--------|---------|
 | PostgreSQL | `postgresql+asyncpg://` | `postgresql+asyncpg://localhost:5555/postgres` |
 | ClickHouse | `clickhouse://` | `clickhouse://localhost:8123/default` |
+
+---
+
+## Input Validation (Preflight)
+
+Before a subcommand runs, the CLI validates that the inputs it actually needs are present. Commands that require a database connection or an organization id **fail fast** with an argparse usage error (**exit code 2**) that names exactly what is missing — instead of failing deep inside the handler with a logged error or a traceback.
+
+These inputs are supplied through global flags or environment variables (`--analytics-db`/`CLICKHOUSE_URI`, `--db`/`POSTGRES_URI`, `--org`/`ORG_ID`), so they cannot be marked `required` on individual subparsers. The preflight closes that gap centrally.
+
+```bash
+$ dev-hops metrics compounding-risk        # no CLICKHOUSE_URI / org configured
+usage: dev-health-ops metrics compounding-risk [-h] [--day DAY] ...
+dev-health-ops metrics compounding-risk: error: missing required input(s):
+  - ClickHouse analytics database — pass --analytics-db or set CLICKHOUSE_URI (...)
+  - organization id — pass --org or set ORG_ID (could not auto-resolve ...)
+```
+
+Each affected command also lists its requirements at the bottom of `--help`:
+
+```bash
+$ dev-hops metrics compounding-risk --help
+...
+Requires: ClickHouse (--analytics-db / CLICKHOUSE_URI), organization (--org / ORG_ID).
+```
+
+**Requirement matrix:**
+
+| Requirement | Commands |
+|-------------|----------|
+| ClickHouse (`--analytics-db` / `CLICKHOUSE_URI`) | `sync git`, `sync prs`, `sync blame`, `sync cicd`, `sync deployments`, `sync incidents`, `sync security`, `sync tests`, `sync work-items`, `sync teams`; `metrics daily`, `metrics dora`, `metrics complexity`, `metrics release-impact`, `metrics validate-flags`, `metrics rebuild`, `metrics compounding-risk` (+org); `audit perf`, `audit schema`; `recommendations compute`; `ai allowlist list/set` (+org); `migrate clickhouse` (bare + `upgrade`/`status`/`repair`) |
+| ClickHouse via `--db` (`CLICKHOUSE_URI`) | `investment materialize` |
+| PostgreSQL (`--db` / `POSTGRES_URI`) | `billing reconcile`; `migrate postgres` (bare + `upgrade`/`downgrade`/`current`); legacy `migrate upgrade`/`downgrade`/`current` |
+| Organization (`--org` / `ORG_ID`) | `metrics compounding-risk`, `backfill run`, `ai allowlist list/set` |
+
+> The org id auto-resolves from the first organization in PostgreSQL when `--org`/`ORG_ID` are omitted; the preflight only fails when no org can be resolved.
+
+> Read-only Alembic commands that do not open a connection (`migrate [postgres] heads`, `migrate [postgres] history`) are intentionally **not** gated. Commands that declare their own `required=True` flag (e.g. `audit completeness`/`coverage` `--db`, `metrics capacity` `--db`, `fixtures validate` `--sink`) keep using argparse's own required-argument error.
 
 ---
 
@@ -176,7 +213,7 @@ dev-hops sync incidents --provider github \
 
 ### `sync teams`
 
-Sync team definitions.
+Sync team definitions. Persists to the analytics store, so `CLICKHOUSE_URI` (or `--analytics-db`) is required regardless of the `--provider` source (see [Input Validation](#input-validation-preflight)).
 
 ```bash
 # From config file
@@ -718,6 +755,6 @@ dev-hops sync git --provider github \
 |------|---------|
 | 0 | Success |
 | 1 | General error |
-| 2 | Configuration error |
+| 2 | Configuration error — includes argparse usage errors and missing required inputs surfaced by the [preflight](#input-validation-preflight) (e.g. unset `CLICKHOUSE_URI`/`POSTGRES_URI`/`ORG_ID`) |
 | 3 | Authentication error |
 | 4 | Rate limit exceeded |

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -329,6 +329,161 @@ def _should_resolve_org(ns: argparse.Namespace) -> bool:
     )
 
 
+# ---------------------------------------------------------------------------
+# Preflight requirement checks
+# ---------------------------------------------------------------------------
+# Many subcommands need a database connection (ClickHouse and/or PostgreSQL)
+# and/or an organization id that are supplied via *global* flags or env vars
+# (``--analytics-db``/``CLICKHOUSE_URI``, ``--db``/``POSTGRES_URI``,
+# ``--org``/``ORG_ID``). Because these are global+env, individual subparsers
+# cannot mark them ``required=True``. Without a preflight, such commands fail
+# deep inside their handler with a logged error or a raw traceback (exit 1)
+# instead of a fast argparse-style usage error (exit 2).
+#
+# Each leaf command declares the inputs it needs in ``_COMMAND_REQUIREMENTS``;
+# ``run_preflight_checks`` resolves them the same way the handlers do and calls
+# ``parser.error(...)`` so the user gets a usage message naming exactly what is
+# missing. The same requirements are appended to each command's ``--help``.
+_REQ_CLICKHOUSE = "clickhouse"
+_REQ_POSTGRES = "postgres"
+_REQ_ORG = "org"
+
+# Stable display order for messages/epilogs.
+_REQUIREMENT_ORDER: tuple[str, ...] = (_REQ_CLICKHOUSE, _REQ_POSTGRES, _REQ_ORG)
+
+_COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
+    # --- metrics (ClickHouse analytics store) ---
+    ("metrics", "daily"): frozenset({_REQ_CLICKHOUSE}),
+    ("metrics", "dora"): frozenset({_REQ_CLICKHOUSE}),
+    ("metrics", "complexity"): frozenset({_REQ_CLICKHOUSE}),
+    ("metrics", "release-impact"): frozenset({_REQ_CLICKHOUSE}),
+    ("metrics", "validate-flags"): frozenset({_REQ_CLICKHOUSE}),
+    ("metrics", "rebuild"): frozenset({_REQ_CLICKHOUSE}),
+    ("metrics", "compounding-risk"): frozenset({_REQ_CLICKHOUSE, _REQ_ORG}),
+    # --- sync (persist to ClickHouse analytics store) ---
+    ("sync", "git"): frozenset({_REQ_CLICKHOUSE}),
+    ("sync", "prs"): frozenset({_REQ_CLICKHOUSE}),
+    ("sync", "blame"): frozenset({_REQ_CLICKHOUSE}),
+    ("sync", "cicd"): frozenset({_REQ_CLICKHOUSE}),
+    ("sync", "deployments"): frozenset({_REQ_CLICKHOUSE}),
+    ("sync", "incidents"): frozenset({_REQ_CLICKHOUSE}),
+    ("sync", "security"): frozenset({_REQ_CLICKHOUSE}),
+    ("sync", "tests"): frozenset({_REQ_CLICKHOUSE}),
+    ("sync", "work-items"): frozenset({_REQ_CLICKHOUSE}),
+    # --- audit (read ClickHouse analytics store) ---
+    ("audit", "perf"): frozenset({_REQ_CLICKHOUSE}),
+    ("audit", "schema"): frozenset({_REQ_CLICKHOUSE}),
+    # --- other ClickHouse-backed commands ---
+    ("recommendations", "compute"): frozenset({_REQ_CLICKHOUSE}),
+    ("investment", "materialize"): frozenset({_REQ_CLICKHOUSE}),
+    ("ai", "allowlist", "list"): frozenset({_REQ_CLICKHOUSE, _REQ_ORG}),
+    ("ai", "allowlist", "set"): frozenset({_REQ_CLICKHOUSE, _REQ_ORG}),
+    # --- PostgreSQL semantic store ---
+    ("billing", "reconcile"): frozenset({_REQ_POSTGRES}),
+    ("backfill", "run"): frozenset({_REQ_ORG}),
+    # --- migrations that connect to a live database ---
+    ("migrate", "clickhouse", "upgrade"): frozenset({_REQ_CLICKHOUSE}),
+    ("migrate", "clickhouse", "status"): frozenset({_REQ_CLICKHOUSE}),
+    ("migrate", "clickhouse", "repair"): frozenset({_REQ_CLICKHOUSE}),
+    ("migrate", "postgres", "upgrade"): frozenset({_REQ_POSTGRES}),
+    ("migrate", "postgres", "downgrade"): frozenset({_REQ_POSTGRES}),
+    ("migrate", "postgres", "current"): frozenset({_REQ_POSTGRES}),
+    ("migrate", "upgrade"): frozenset({_REQ_POSTGRES}),
+    ("migrate", "downgrade"): frozenset({_REQ_POSTGRES}),
+    ("migrate", "current"): frozenset({_REQ_POSTGRES}),
+}
+
+_REQUIREMENT_MESSAGES: dict[str, str] = {
+    _REQ_CLICKHOUSE: (
+        "ClickHouse analytics database \u2014 pass --analytics-db or set CLICKHOUSE_URI "
+        "(e.g. clickhouse://ch:ch@localhost:8123/default)"
+    ),
+    _REQ_POSTGRES: (
+        "PostgreSQL semantic database \u2014 pass --db or set POSTGRES_URI/DATABASE_URI "
+        "(e.g. postgresql+asyncpg://user:pass@localhost:5432/devhealth)"
+    ),
+    _REQ_ORG: (
+        "organization id \u2014 pass --org or set ORG_ID "
+        "(could not auto-resolve one from the database)"
+    ),
+}
+
+_REQUIREMENT_HELP_LABELS: dict[str, str] = {
+    _REQ_CLICKHOUSE: "ClickHouse (--analytics-db / CLICKHOUSE_URI)",
+    _REQ_POSTGRES: "PostgreSQL (--db / POSTGRES_URI)",
+    _REQ_ORG: "organization (--org / ORG_ID)",
+}
+
+
+def _clickhouse_present(ns: argparse.Namespace) -> bool:
+    return bool(getattr(ns, "analytics_db", None) or os.getenv("CLICKHOUSE_URI"))
+
+
+def _postgres_present(ns: argparse.Namespace) -> bool:
+    return bool(
+        getattr(ns, "db", None)
+        or os.getenv("POSTGRES_URI")
+        or os.getenv("DATABASE_URI")
+        or os.getenv("DATABASE_URL")
+    )
+
+
+def _org_present(ns: argparse.Namespace) -> bool:
+    return bool(getattr(ns, "org", None) or os.getenv("ORG_ID"))
+
+
+_REQUIREMENT_PRESENCE = {
+    _REQ_CLICKHOUSE: _clickhouse_present,
+    _REQ_POSTGRES: _postgres_present,
+    _REQ_ORG: _org_present,
+}
+
+
+def missing_requirements(ns: argparse.Namespace) -> list[str]:
+    """Return human-readable messages for each unmet requirement of ``ns``."""
+    requires = getattr(ns, "_requires", None) or frozenset()
+    missing: list[str] = []
+    for token in _REQUIREMENT_ORDER:
+        if token in requires and not _REQUIREMENT_PRESENCE[token](ns):
+            missing.append(_REQUIREMENT_MESSAGES[token])
+    return missing
+
+
+def run_preflight_checks(
+    root_parser: argparse.ArgumentParser, ns: argparse.Namespace
+) -> None:
+    """Fast-fail with a usage error if the chosen command's inputs are missing."""
+    missing = missing_requirements(ns)
+    if not missing:
+        return
+    leaf = getattr(ns, "_leaf_parser", None) or root_parser
+    leaf.error("missing required input(s):\n  - " + "\n  - ".join(missing))
+
+
+def _attach_preflight_metadata(parser: argparse.ArgumentParser) -> None:
+    """Attach ``_leaf_parser``/``_requires`` defaults and a help epilog per leaf."""
+
+    def walk(p: argparse.ArgumentParser, path: tuple[str, ...]) -> None:
+        sub_actions = [
+            a for a in p._actions if isinstance(a, argparse._SubParsersAction)
+        ]
+        if sub_actions:
+            for sa in sub_actions:
+                for name, child in sa.choices.items():
+                    walk(child, path + (name,))
+            return
+        requires = _COMMAND_REQUIREMENTS.get(path, frozenset())
+        p.set_defaults(_leaf_parser=p, _requires=requires)
+        labels = [
+            _REQUIREMENT_HELP_LABELS[t] for t in _REQUIREMENT_ORDER if t in requires
+        ]
+        if labels:
+            note = "Requires: " + ", ".join(labels) + "."
+            p.epilog = f"{p.epilog}\n\n{note}" if p.epilog else note
+
+    walk(parser, ())
+
+
 def build_parser() -> argparse.ArgumentParser:
     import dev_health_ops.api.billing.cli as billing_cli
     import dev_health_ops.backfill.cli as backfill_cli
@@ -475,6 +630,7 @@ def build_parser() -> argparse.ArgumentParser:
     cleanup_all_parser.set_defaults(func=_cmd_maintenance_cleanup_all)
 
     _propagate_global_args_to_subparsers(parser)
+    _attach_preflight_metadata(parser)
     return parser
 
 
@@ -496,6 +652,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if _should_resolve_org(ns):
         ns.org = _resolve_first_org_id(getattr(ns, "db", None))
+
+    run_preflight_checks(parser, ns)
 
     level_name = str(getattr(ns, "log_level", "") or "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -347,9 +347,18 @@ def _should_resolve_org(ns: argparse.Namespace) -> bool:
 _REQ_CLICKHOUSE = "clickhouse"
 _REQ_POSTGRES = "postgres"
 _REQ_ORG = "org"
+# ClickHouse supplied via a command's own ``--db`` flag (not the global
+# ``--analytics-db``). Used by commands like ``investment materialize`` whose
+# ``--db`` carries the ClickHouse DSN (default: CLICKHOUSE_URI).
+_REQ_SINK_DB = "sink_db"
 
 # Stable display order for messages/epilogs.
-_REQUIREMENT_ORDER: tuple[str, ...] = (_REQ_CLICKHOUSE, _REQ_POSTGRES, _REQ_ORG)
+_REQUIREMENT_ORDER: tuple[str, ...] = (
+    _REQ_CLICKHOUSE,
+    _REQ_POSTGRES,
+    _REQ_ORG,
+    _REQ_SINK_DB,
+)
 
 _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     # --- metrics (ClickHouse analytics store) ---
@@ -370,12 +379,13 @@ _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     ("sync", "security"): frozenset({_REQ_CLICKHOUSE}),
     ("sync", "tests"): frozenset({_REQ_CLICKHOUSE}),
     ("sync", "work-items"): frozenset({_REQ_CLICKHOUSE}),
+    ("sync", "teams"): frozenset({_REQ_CLICKHOUSE}),
     # --- audit (read ClickHouse analytics store) ---
     ("audit", "perf"): frozenset({_REQ_CLICKHOUSE}),
     ("audit", "schema"): frozenset({_REQ_CLICKHOUSE}),
     # --- other ClickHouse-backed commands ---
     ("recommendations", "compute"): frozenset({_REQ_CLICKHOUSE}),
-    ("investment", "materialize"): frozenset({_REQ_CLICKHOUSE}),
+    ("investment", "materialize"): frozenset({_REQ_SINK_DB}),
     ("ai", "allowlist", "list"): frozenset({_REQ_CLICKHOUSE, _REQ_ORG}),
     ("ai", "allowlist", "set"): frozenset({_REQ_CLICKHOUSE, _REQ_ORG}),
     # --- PostgreSQL semantic store ---
@@ -391,6 +401,9 @@ _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     ("migrate", "upgrade"): frozenset({_REQ_POSTGRES}),
     ("migrate", "downgrade"): frozenset({_REQ_POSTGRES}),
     ("migrate", "current"): frozenset({_REQ_POSTGRES}),
+    # Bare ``migrate postgres`` / ``migrate clickhouse`` default to upgrade.
+    ("migrate", "postgres"): frozenset({_REQ_POSTGRES}),
+    ("migrate", "clickhouse"): frozenset({_REQ_CLICKHOUSE}),
 }
 
 _REQUIREMENT_MESSAGES: dict[str, str] = {
@@ -406,12 +419,17 @@ _REQUIREMENT_MESSAGES: dict[str, str] = {
         "organization id \u2014 pass --org or set ORG_ID "
         "(could not auto-resolve one from the database)"
     ),
+    _REQ_SINK_DB: (
+        "ClickHouse analytics database \u2014 pass --db or set CLICKHOUSE_URI "
+        "(e.g. clickhouse://ch:ch@localhost:8123/default)"
+    ),
 }
 
 _REQUIREMENT_HELP_LABELS: dict[str, str] = {
     _REQ_CLICKHOUSE: "ClickHouse (--analytics-db / CLICKHOUSE_URI)",
     _REQ_POSTGRES: "PostgreSQL (--db / POSTGRES_URI)",
     _REQ_ORG: "organization (--org / ORG_ID)",
+    _REQ_SINK_DB: "ClickHouse (--db / CLICKHOUSE_URI)",
 }
 
 
@@ -432,10 +450,15 @@ def _org_present(ns: argparse.Namespace) -> bool:
     return bool(getattr(ns, "org", None) or os.getenv("ORG_ID"))
 
 
+def _sink_db_present(ns: argparse.Namespace) -> bool:
+    return bool(getattr(ns, "db", None) or os.getenv("CLICKHOUSE_URI"))
+
+
 _REQUIREMENT_PRESENCE = {
     _REQ_CLICKHOUSE: _clickhouse_present,
     _REQ_POSTGRES: _postgres_present,
     _REQ_ORG: _org_present,
+    _REQ_SINK_DB: _sink_db_present,
 }
 
 
@@ -464,22 +487,23 @@ def _attach_preflight_metadata(parser: argparse.ArgumentParser) -> None:
     """Attach ``_leaf_parser``/``_requires`` defaults and a help epilog per leaf."""
 
     def walk(p: argparse.ArgumentParser, path: tuple[str, ...]) -> None:
-        sub_actions = [
-            a for a in p._actions if isinstance(a, argparse._SubParsersAction)
-        ]
-        if sub_actions:
-            for sa in sub_actions:
-                for name, child in sa.choices.items():
-                    walk(child, path + (name,))
-            return
-        requires = _COMMAND_REQUIREMENTS.get(path, frozenset())
-        p.set_defaults(_leaf_parser=p, _requires=requires)
-        labels = [
-            _REQUIREMENT_HELP_LABELS[t] for t in _REQUIREMENT_ORDER if t in requires
-        ]
-        if labels:
-            note = "Requires: " + ", ".join(labels) + "."
-            p.epilog = f"{p.epilog}\n\n{note}" if p.epilog else note
+        # Attach to any *dispatchable* parser (one that has a handler). This
+        # includes leaf commands and intermediate parsers that set a default
+        # ``func`` (e.g. bare ``migrate postgres`` -> upgrade), so those forms
+        # are guarded too. Always recurse so more-specific child commands can
+        # override the metadata on the same namespace.
+        if p.get_default("func") is not None:
+            requires = _COMMAND_REQUIREMENTS.get(path, frozenset())
+            p.set_defaults(_leaf_parser=p, _requires=requires)
+            labels = [
+                _REQUIREMENT_HELP_LABELS[t] for t in _REQUIREMENT_ORDER if t in requires
+            ]
+            if labels:
+                note = "Requires: " + ", ".join(labels) + "."
+                p.epilog = f"{p.epilog}\n\n{note}" if p.epilog else note
+        for sa in (a for a in p._actions if isinstance(a, argparse._SubParsersAction)):
+            for name, child in sa.choices.items():
+                walk(child, path + (name,))
 
     walk(parser, ())
 

--- a/tests/test_cli_preflight.py
+++ b/tests/test_cli_preflight.py
@@ -1,0 +1,138 @@
+"""Preflight requirement checks for CLI commands (fast-fail on missing inputs).
+
+Commands that need a database (ClickHouse/PostgreSQL) or an organization id
+supplied via global flags/env vars must fail with an argparse usage error
+(exit 2) naming the missing input, instead of failing deep in the handler with
+a logged error or raw traceback (exit 1). See ``dev_health_ops.cli``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+# Env vars that satisfy preflight requirements; cleared for "missing" cases.
+_CONFIG_ENV = (
+    "CLICKHOUSE_URI",
+    "POSTGRES_URI",
+    "DATABASE_URI",
+    "DATABASE_URL",
+    "ORG_ID",
+)
+
+
+def _run_cli(*args: str, env_overrides: dict[str, str] | None = None):
+    env = os.environ.copy()
+    env["DISABLE_DOTENV"] = "1"
+    env["OTEL_SDK_DISABLED"] = "true"
+    env["PYTHONPATH"] = "src"
+    for key in _CONFIG_ENV:
+        env.pop(key, None)
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, "-m", "dev_health_ops.cli", *args],
+        check=False,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+# Commands that must fast-fail when no database/org is configured, plus the
+# requirement tokens expected to appear in the error message.
+_MISSING_CASES = [
+    (("metrics", "compounding-risk"), ("ClickHouse", "organization")),
+    (("metrics", "daily"), ("ClickHouse",)),
+    (("metrics", "dora"), ("ClickHouse",)),
+    (("metrics", "complexity"), ("ClickHouse",)),
+    (("metrics", "release-impact"), ("ClickHouse",)),
+    (("metrics", "validate-flags"), ("ClickHouse",)),
+    (("metrics", "rebuild"), ("ClickHouse",)),
+    (("sync", "work-items"), ("ClickHouse",)),
+    (("audit", "perf"), ("ClickHouse",)),
+    (("audit", "schema"), ("ClickHouse",)),
+    (("recommendations", "compute", "--team", "t1"), ("ClickHouse",)),
+    (("investment", "materialize"), ("ClickHouse",)),
+    (("billing", "reconcile"), ("PostgreSQL",)),
+    (("migrate", "postgres", "upgrade"), ("PostgreSQL",)),
+    (("migrate", "clickhouse", "status"), ("ClickHouse",)),
+    (("backfill", "run", "--config-id", "x"), ("organization",)),
+]
+
+
+@pytest.mark.parametrize("args,expected", _MISSING_CASES)
+def test_missing_config_fast_fails_with_usage(
+    args: tuple[str, ...], expected: tuple[str, ...]
+) -> None:
+    result = _run_cli(*args)
+
+    # argparse usage error, not a deep handler failure.
+    assert result.returncode == 2, result.stderr
+    assert "Traceback" not in result.stderr
+    assert "missing required input" in result.stderr
+    assert result.stderr.startswith("usage:") or "usage:" in result.stderr
+    for token in expected:
+        assert token in result.stderr
+
+
+def test_configured_command_passes_preflight() -> None:
+    """A configured command gets past preflight (no 'missing required input')."""
+    result = _run_cli(
+        "metrics",
+        "compounding-risk",
+        env_overrides={
+            "CLICKHOUSE_URI": "clickhouse://ch:ch@localhost:9/default",
+            "ORG_ID": "org-test",
+        },
+    )
+
+    # Preflight passed: it may still fail to connect, but not on a missing input.
+    assert "missing required input" not in result.stderr
+
+
+def test_help_lists_requirements_in_epilog() -> None:
+    result = _run_cli("metrics", "compounding-risk", "--help")
+
+    assert result.returncode == 0
+    assert "Requires:" in result.stdout
+    assert "ClickHouse" in result.stdout
+    assert "organization" in result.stdout
+
+
+def test_unrelated_command_has_no_requirements() -> None:
+    """A command with no DB/org need is unaffected by preflight."""
+    result = _run_cli("maintenance", "--help")
+
+    assert result.returncode == 0
+    assert "Requires:" not in result.stdout
+
+
+def test_missing_requirements_unit() -> None:
+    """missing_requirements reflects ns._requires + resolved presence."""
+    from argparse import Namespace
+
+    from dev_health_ops import cli
+
+    ns = Namespace(
+        _requires=frozenset({cli._REQ_CLICKHOUSE, cli._REQ_ORG}),
+        analytics_db=None,
+        db=None,
+        org=None,
+    )
+    for key in _CONFIG_ENV:
+        os.environ.pop(key, None)
+
+    missing = cli.missing_requirements(ns)
+    assert any("ClickHouse" in m for m in missing)
+    assert any("organization" in m for m in missing)
+
+    # Satisfy one requirement via the namespace value.
+    ns.analytics_db = "clickhouse://localhost"
+    missing = cli.missing_requirements(ns)
+    assert not any("ClickHouse" in m for m in missing)
+    assert any("organization" in m for m in missing)

--- a/tests/test_cli_preflight.py
+++ b/tests/test_cli_preflight.py
@@ -62,6 +62,11 @@ _MISSING_CASES = [
     (("migrate", "postgres", "upgrade"), ("PostgreSQL",)),
     (("migrate", "clickhouse", "status"), ("ClickHouse",)),
     (("backfill", "run", "--config-id", "x"), ("organization",)),
+    # Bare migrate forms default to upgrade and must be guarded too.
+    (("migrate", "postgres"), ("PostgreSQL",)),
+    (("migrate", "clickhouse"), ("ClickHouse",)),
+    # sync teams persists to ClickHouse after generating teams.
+    (("sync", "teams", "--provider", "synthetic"), ("ClickHouse",)),
 ]
 
 
@@ -92,6 +97,19 @@ def test_configured_command_passes_preflight() -> None:
     )
 
     # Preflight passed: it may still fail to connect, but not on a missing input.
+    assert "missing required input" not in result.stderr
+
+
+def test_investment_materialize_accepts_clickhouse_via_db_flag() -> None:
+    """`investment materialize` carries its ClickHouse DSN on --db, not
+    --analytics-db; the preflight must accept it and not false-positive."""
+    result = _run_cli(
+        "investment",
+        "materialize",
+        "--db",
+        "clickhouse://ch:ch@localhost:9/default",
+    )
+
     assert "missing required input" not in result.stderr
 
 


### PR DESCRIPTION
## Summary

CLI commands that need ClickHouse/PostgreSQL or an organization id receive them via **global flags with env fallbacks** (`--analytics-db`/`CLICKHOUSE_URI`, `--db`/`POSTGRES_URI`, `--org`/`ORG_ID`). Because these are global+env, individual subparsers cannot mark them `required=True`. As a result ~16 commands (e.g. `dev-hops metrics compounding-risk`) failed **deep in their handler** with a logged error or raw traceback (exit 1), and never surfaced the requirement in `--help`.

This adds a **systemic preflight** (one place, in the CLI entrypoint) so these commands fail fast with an argparse usage error (exit 2) that names exactly what is missing, and lists the requirement in `--help`.

### Before → after (`metrics compounding-risk`, no config)
```
# before: exit 1, buried JSON log line; --help never mentioned --org
# after:
dev-health-ops metrics compounding-risk: error: missing required input(s):
  - ClickHouse analytics database — pass --analytics-db or set CLICKHOUSE_URI (...)
  - organization id — pass --org or set ORG_ID (could not auto-resolve one from the database)
```

## Implementation
- `_COMMAND_REQUIREMENTS` declares each command's needs (`clickhouse` / `postgres` / `org` / `sink_db`).
- `_attach_preflight_metadata()` walks the parser tree once, tagging **every dispatchable parser** (any with a `func` default, including intermediate forms like bare `migrate postgres`) with `_leaf_parser` + `_requires`, and appends a `Requires:` line to its `--help` epilog.
- `run_preflight_checks()` runs in `main()` after org auto-resolution, resolves inputs the **same way handlers do**, and calls `leaf.error(...)` for a usage-level fast fail.

Handler-level guards are intentionally left in place as defense-in-depth.

## Adversarial review (`/codex:adversarial-review`) — findings addressed
- **[high]** `investment materialize` carries its ClickHouse DSN on its own `--db` flag (not `--analytics-db`); the original check false-failed a valid invocation. Added a `_REQ_SINK_DB` token that accepts `--db` / `CLICKHOUSE_URI`.
- **[medium]** Bare `migrate postgres` / `migrate clickhouse` default to upgrade but are intermediate parsers, so they bypassed the leaf-only walk and threw raw tracebacks. The walk now attaches to any parser with a `func` default, and both bare forms are mapped.
- **[medium]** `sync teams` was omitted and still failed deep after generating teams; it now requires ClickHouse.

## Commands covered
metrics: `daily`, `dora`, `complexity`, `release-impact`, `validate-flags`, `rebuild`, `compounding-risk` (+org) · sync: `git/prs/blame/cicd/deployments/incidents/security/tests/work-items/teams` · audit: `perf`, `schema` · `recommendations compute`, `investment materialize` (via `--db`), `ai allowlist {list,set}` (+org) · `billing reconcile` · `backfill run` (org) · migrations that connect (`migrate {postgres,clickhouse}` bare + `upgrade/downgrade/current/status/repair`, legacy `migrate upgrade/downgrade/current`).

Read-only Alembic commands that don't connect (`migrate [postgres] heads/history`) are intentionally **not** gated.

## Documentation
- New **Input Validation (Preflight)** section in the CLI reference with a per-command requirement matrix; clarified exit-code 2; extended the `--db` caveat; noted `sync teams` requires ClickHouse.
- Added an **Input validation** note to the CLI overview linking the matrix.

## Testing
- New preflight test suite (24 tests): fast-fail exit-2 + message for all affected commands incl. bare `migrate postgres/clickhouse` and `sync teams`; **no false positives** when configured; `investment materialize --db ...` passes preflight; `--help` epilog; unit-level requirement resolution.
- Existing help test suite (16) still green. `ruff format`/`check` clean.

## Out of scope (noted for follow-up)
- **Bad-value tracebacks** (not missing-input): invalid `--db` schemes and `metrics dora` GitLab-token paths still raise on *invalid* values — separate value-validation fix.
- **`sync teams` silent no-op** when ClickHouse *is* configured but no teams are found: exits 0 — behavioral change left untouched.
- Admin/`ai`/`billing` CRUD commands hit Postgres but weren't runtime-probed; left out of the map rather than guessed.

SCREENSHOT-WAIVER: CLI-only change, no rendered frontend output.