### PR TITLE
fix(cli): clean error on invalid DB scheme / provider creds (CHAOS-2390)

### DIFF
--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -369,6 +369,8 @@ _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     ("metrics", "validate-flags"): frozenset({_REQ_CLICKHOUSE}),
     ("metrics", "rebuild"): frozenset({_REQ_CLICKHOUSE}),
     ("metrics", "compounding-risk"): frozenset({_REQ_CLICKHOUSE, _REQ_ORG}),
+    # capacity takes its ClickHouse DSN via its own required --db flag.
+    ("metrics", "capacity"): frozenset({_REQ_SINK_DB}),
     # --- sync (persist to ClickHouse analytics store) ---
     ("sync", "git"): frozenset({_REQ_CLICKHOUSE}),
     ("sync", "prs"): frozenset({_REQ_CLICKHOUSE}),

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -437,6 +437,10 @@ def _clickhouse_present(ns: argparse.Namespace) -> bool:
     return bool(getattr(ns, "analytics_db", None) or os.getenv("CLICKHOUSE_URI"))
 
 
+def _clickhouse_value(ns: argparse.Namespace) -> str | None:
+    return getattr(ns, "analytics_db", None) or os.getenv("CLICKHOUSE_URI")
+
+
 def _postgres_present(ns: argparse.Namespace) -> bool:
     return bool(
         getattr(ns, "db", None)
@@ -452,6 +456,10 @@ def _org_present(ns: argparse.Namespace) -> bool:
 
 def _sink_db_present(ns: argparse.Namespace) -> bool:
     return bool(getattr(ns, "db", None) or os.getenv("CLICKHOUSE_URI"))
+
+
+def _sink_db_value(ns: argparse.Namespace) -> str | None:
+    return getattr(ns, "db", None) or os.getenv("CLICKHOUSE_URI")
 
 
 _REQUIREMENT_PRESENCE = {
@@ -477,10 +485,20 @@ def run_preflight_checks(
 ) -> None:
     """Fast-fail with a usage error if the chosen command's inputs are missing."""
     missing = missing_requirements(ns)
-    if not missing:
-        return
     leaf = getattr(ns, "_leaf_parser", None) or root_parser
-    leaf.error("missing required input(s):\n  - " + "\n  - ".join(missing))
+    if missing:
+        leaf.error("missing required input(s):\n  - " + "\n  - ".join(missing))
+
+    requires = getattr(ns, "_requires", None) or frozenset()
+    from dev_health_ops.db import validate_sink_uri_scheme
+
+    try:
+        if _REQ_CLICKHOUSE in requires and (uri := _clickhouse_value(ns)):
+            validate_sink_uri_scheme(uri)
+        if _REQ_SINK_DB in requires and (uri := _sink_db_value(ns)):
+            validate_sink_uri_scheme(uri)
+    except ValueError as exc:
+        leaf.error(str(exc))
 
 
 def _attach_preflight_metadata(parser: argparse.ArgumentParser) -> None:

--- a/src/dev_health_ops/db.py
+++ b/src/dev_health_ops/db.py
@@ -241,8 +241,23 @@ def resolve_db_uri(ns) -> str:
 def resolve_sink_uri(ns) -> str:
     uri = getattr(ns, "analytics_db", None)
     if uri:
+        _validate_sink_uri(uri, ns)
         return uri
-    return require_clickhouse_uri()
+    uri = require_clickhouse_uri()
+    _validate_sink_uri(uri, ns)
+    return uri
+
+
+def _validate_sink_uri(uri: str, ns) -> None:
+    from dev_health_ops.metrics.sinks.factory import detect_backend
+
+    try:
+        detect_backend(uri)
+    except ValueError as exc:
+        parser = getattr(ns, "_leaf_parser", None)
+        if parser is not None:
+            parser.error(str(exc))
+        raise
 
 
 _postgres_sync_engine: Engine | None = None

--- a/src/dev_health_ops/db.py
+++ b/src/dev_health_ops/db.py
@@ -249,15 +249,19 @@ def resolve_sink_uri(ns) -> str:
 
 
 def _validate_sink_uri(uri: str, ns) -> None:
-    from dev_health_ops.metrics.sinks.factory import detect_backend
-
     try:
-        detect_backend(uri)
+        validate_sink_uri_scheme(uri)
     except ValueError as exc:
         parser = getattr(ns, "_leaf_parser", None)
         if parser is not None:
             parser.error(str(exc))
         raise
+
+
+def validate_sink_uri_scheme(uri: str) -> None:
+    from dev_health_ops.metrics.sinks.factory import detect_backend
+
+    detect_backend(uri)
 
 
 _postgres_sync_engine: Engine | None = None

--- a/src/dev_health_ops/metrics/sinks/clickhouse/core.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/core.py
@@ -25,6 +25,7 @@ from dev_health_ops.metrics.sinks.clickhouse._insert import (
     _chunked,
     _dt_to_clickhouse_datetime,
 )
+from dev_health_ops.metrics.sinks.factory import detect_backend
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +64,7 @@ class ClickHouseCore(BaseMetricsSink):
     def __init__(self, dsn: str, client: Any | None = None) -> None:
         if not dsn:
             raise ValueError("ClickHouse DSN is required")
+        detect_backend(dsn)
         self.dsn = dsn
         if client:
             self.client = client

--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -73,7 +73,14 @@ def run_work_graph_build(ns: argparse.Namespace) -> int:
     )
 
     logging.info(f"Building work graph from {config.from_date} to {config.to_date}")
-    builder = WorkGraphBuilder(config)
+    try:
+        builder = WorkGraphBuilder(config)
+    except ValueError as exc:
+        parser = getattr(ns, "_leaf_parser", None)
+        if parser is not None:
+            parser.error(str(exc))
+        logging.error("Work graph build failed: %s", exc)
+        return 2
     try:
         result = builder.build()
 

--- a/tests/test_cli_preflight.py
+++ b/tests/test_cli_preflight.py
@@ -122,6 +122,22 @@ def test_work_graph_build_rejects_unsupported_db_scheme_cleanly() -> None:
     assert "Only ClickHouse is supported" in result.stderr
 
 
+def test_sync_rejects_unsupported_analytics_scheme_cleanly() -> None:
+    result = _run_cli(
+        "sync",
+        "git",
+        "--provider",
+        "synthetic",
+        "--analytics-db",
+        "sqlite:///x.db",
+    )
+
+    assert result.returncode == 2, result.stderr
+    assert "Traceback" not in result.stderr
+    assert "Unknown or unsupported sink scheme 'sqlite'" in result.stderr
+    assert "Only ClickHouse is supported" in result.stderr
+
+
 def test_help_lists_requirements_in_epilog() -> None:
     result = _run_cli("metrics", "compounding-risk", "--help")
 

--- a/tests/test_cli_preflight.py
+++ b/tests/test_cli_preflight.py
@@ -113,6 +113,15 @@ def test_investment_materialize_accepts_clickhouse_via_db_flag() -> None:
     assert "missing required input" not in result.stderr
 
 
+def test_work_graph_build_rejects_unsupported_db_scheme_cleanly() -> None:
+    result = _run_cli("work-graph", "build", "--db", "sqlite:///x.db")
+
+    assert result.returncode == 2, result.stderr
+    assert "Traceback" not in result.stderr
+    assert "Unknown or unsupported sink scheme 'sqlite'" in result.stderr
+    assert "Only ClickHouse is supported" in result.stderr
+
+
 def test_help_lists_requirements_in_epilog() -> None:
     result = _run_cli("metrics", "compounding-risk", "--help")
 

--- a/tests/test_cli_preflight.py
+++ b/tests/test_cli_preflight.py
@@ -150,6 +150,7 @@ def test_sync_rejects_unsupported_analytics_scheme_cleanly() -> None:
             "sqlite:///x.db",
         ),
         ("investment", "materialize", "--db", "sqlite:///x.db"),
+        ("metrics", "capacity", "--db", "sqlite:///x.db"),
     ],
 )
 def test_clickhouse_commands_reject_unsupported_analytics_scheme_cleanly(

--- a/tests/test_cli_preflight.py
+++ b/tests/test_cli_preflight.py
@@ -138,6 +138,45 @@ def test_sync_rejects_unsupported_analytics_scheme_cleanly() -> None:
     assert "Only ClickHouse is supported" in result.stderr
 
 
+@pytest.mark.parametrize(
+    "args",
+    [
+        (
+            "recommendations",
+            "compute",
+            "--team",
+            "t1",
+            "--analytics-db",
+            "sqlite:///x.db",
+        ),
+        ("investment", "materialize", "--db", "sqlite:///x.db"),
+    ],
+)
+def test_clickhouse_commands_reject_unsupported_analytics_scheme_cleanly(
+    args: tuple[str, ...],
+) -> None:
+    result = _run_cli(*args)
+
+    assert result.returncode == 2, result.stderr
+    assert "Traceback" not in result.stderr
+    assert "Unknown or unsupported sink scheme 'sqlite'" in result.stderr
+    assert "Only ClickHouse is supported" in result.stderr
+
+
+def test_recommendations_compute_accepts_clickhouse_scheme_preflight() -> None:
+    result = _run_cli(
+        "recommendations",
+        "compute",
+        "--team",
+        "t1",
+        "--analytics-db",
+        "clickhouse://ch:ch@localhost:9/default",
+    )
+
+    assert "missing required input" not in result.stderr
+    assert "Unknown or unsupported sink scheme" not in result.stderr
+
+
 def test_help_lists_requirements_in_epilog() -> None:
     result = _run_cli("metrics", "compounding-risk", "--help")
 

--- a/tests/test_stores_contract.py
+++ b/tests/test_stores_contract.py
@@ -22,11 +22,16 @@ class TestBackendDetection:
 
     def test_clickhouse_detection(self):
         assert detect_backend("clickhouse://localhost:8123") == SinkBackend.CLICKHOUSE
+        assert (
+            detect_backend("clickhouse://localhost:8443/default?secure=true")
+            == SinkBackend.CLICKHOUSE
+        )
         assert detect_backend("clickhouse+http://localhost") == SinkBackend.CLICKHOUSE
         assert (
             detect_backend("clickhouse+https://localhost:8123")
             == SinkBackend.CLICKHOUSE
         )
+        assert detect_backend("clickhouse+native://localhost") == SinkBackend.CLICKHOUSE
 
     def test_removed_backends_raise_value_error(self):
         """Backends removed in CHAOS-641 should raise ValueError."""
@@ -60,6 +65,16 @@ class TestSinkFactory:
     def test_rejects_sqlite_sink(self):
         with pytest.raises(ValueError, match="Only ClickHouse is supported"):
             create_sink("sqlite:///./test_sinks.db")
+
+    def test_clickhouse_sink_rejects_invalid_scheme_before_client_creation(self):
+        from unittest.mock import MagicMock
+
+        from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+        with pytest.raises(
+            ValueError, match="Unknown or unsupported sink scheme 'sqlite'"
+        ):
+            ClickHouseMetricsSink("sqlite:///./test_sinks.db", client=MagicMock())
 
     def test_requires_dsn_or_env_var(self, monkeypatch):
         # Clear all env vars that create_sink() checks


### PR DESCRIPTION
## Summary
- Validate the analytics DSN **scheme** for every ClickHouse-backed command, not just `sync`/`work-graph`. A non-ClickHouse scheme (e.g. `sqlite:///x.db`) now produces a clean argparse usage error (exit 2) instead of a raw traceback or an unintended connection.
- Scheme validation is enforced in the CLI preflight when the analytics value is present, so `recommendations compute`, `investment materialize`, `sync *`, `metrics *`, `audit perf/schema`, and `migrate clickhouse` are covered uniformly.
- Defense-in-depth: the ClickHouse sink constructor now rejects an unsupported scheme before any client is created.

## Behaviour
- `work-graph build --db sqlite:///x.db` → exit 2, clean message naming the scheme, no traceback.
- `recommendations compute --analytics-db sqlite:///x.db` → exit 2 (previously under-rejected).
- `investment materialize --db sqlite:///x.db` → exit 2 (previously under-rejected).
- Valid schemes still pass: `clickhouse://`, `clickhouse://...?secure=true`, `clickhouse+http://`, `clickhouse+https://`, `clickhouse+native://`.

## Addresses adversarial-review finding
[medium] Scheme validation previously lived only in the shared sink-URI resolver; commands that build the ClickHouse sink directly bypassed it. Now centralized in the preflight and enforced at the sink boundary.

## Testing
- Preflight regression suite (29 tests) and store-contract suite (9 tests) pass; new cases cover both CLI commands, a valid-scheme pass, and a sink-boundary rejection.
- `ruff format`/`check` clean.

Closes CHAOS-2390. Based on main.
SCREENSHOT-WAIVER: CLI-only.