### PR TITLE
fix(cli): sync teams exits non-zero on no-op (CHAOS-2391)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,12 @@ CLICKHOUSE_URI="clickhouse://ch:ch@localhost:8123/default" \
 
 # Teams into the semantic database
 POSTGRES_URI="postgresql+asyncpg://postgres:postgres@localhost:5555/postgres" \
-  dev-hops sync teams --provider config --path src/dev_health_ops/config/team_mapping.yaml
+  dev-hops sync teams --provider config --path src/dev_health_ops/config/team_mapping.yaml --allow-empty
 ```
+
+The bundled `team_mapping.yaml` is an empty onboarding sample. `sync teams`
+exits non-zero when no teams are persisted; pass `--allow-empty` only for
+intentional empty/no-op syncs such as validating the sample config.
 
 Provider authentication can come from CLI flags or environment variables such as
 `GITHUB_TOKEN`, `GITLAB_TOKEN`, `JIRA_*`, `ATLASSIAN_*`, and `LINEAR_API_KEY`.

--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -217,7 +217,7 @@ Sync team definitions. Persists to the analytics store, so `CLICKHOUSE_URI` (or 
 
 ```bash
 # From config file
-dev-hops sync teams --path src/dev_health_ops/config/team_mapping.yaml
+dev-hops sync teams --path src/dev_health_ops/config/team_mapping.yaml --allow-empty
 
 # From Jira projects
 dev-hops sync teams --provider jira
@@ -235,6 +235,11 @@ dev-hops sync teams --provider gitlab \
   --owner my-group/path \
   --auth "$GITLAB_TOKEN"
 ```
+
+The bundled `src/dev_health_ops/config/team_mapping.yaml` is intentionally empty
+for onboarding. By default, `sync teams` exits non-zero when discovery or
+persistence results in zero teams; use `--allow-empty` only when an empty/no-op
+sync is expected.
 
 ---
 

--- a/src/dev_health_ops/providers/teams.py
+++ b/src/dev_health_ops/providers/teams.py
@@ -627,9 +627,14 @@ async def _count_persisted_teams(store: Any, teams_data: list) -> int:
     if not expected_ids or not hasattr(store, "get_all_teams"):
         return 0
 
+    org_id = getattr(store, "org_id", None)
     persisted = await store.get_all_teams()
     persisted_ids = {
-        str(getattr(team, "id", "") or "").strip() for team in persisted
+        str(getattr(team, "id", "") or "").strip()
+        for team in persisted
+        # When the store is org-scoped, only count rows for that org so a
+        # stale/global row from another tenant cannot mask a failed org write.
+        if not org_id or str(getattr(team, "org_id", "") or "") == str(org_id)
     } - {""}
     return len(expected_ids & persisted_ids)
 

--- a/src/dev_health_ops/providers/teams.py
+++ b/src/dev_health_ops/providers/teams.py
@@ -571,7 +571,7 @@ def sync_teams(ns: argparse.Namespace) -> int:
     db_uri = resolve_sink_uri(ns)
     db_type = detect_db_type(db_uri)
 
-    async def _handler(store):
+    async def _handler(store) -> int:
         # Ensure table exists (for SQL stores)
         if hasattr(store, "ensure_tables"):
             await store.ensure_tables()
@@ -583,16 +583,58 @@ def sync_teams(ns: argparse.Namespace) -> int:
                 len(ops_links),
             )
         logging.info(f"Synced {len(teams_data)} teams to DB.")
+        persisted_count = await _count_persisted_teams(store, teams_data)
+        logging.info("Verified %d teams persisted to primary store.", persisted_count)
+        return persisted_count
 
-    asyncio.run(
+    persisted_count = asyncio.run(
         run_with_store(db_uri, db_type, _handler, org_id=getattr(ns, "org", None))
     )
 
-    _bridge_teams_to_postgres(teams_data, ns)
+    org_id = getattr(ns, "org", None)
+    postgres_bridge_count: int | None = None
+    if org_id is not None:
+        try:
+            postgres_bridge_count = _bridge_teams_to_postgres(teams_data, ns)
+        except Exception as e:  # noqa: BLE001 - bridge failures must affect exit code
+            logging.error("Failed to bridge teams to PostgreSQL: %s", e)
+            postgres_bridge_count = 0
+
+    required_counts = [persisted_count]
+    if postgres_bridge_count is not None:
+        required_counts.append(postgres_bridge_count)
+
+    if any(count <= 0 for count in required_counts):
+        message = (
+            "No teams were persisted to all required stores "
+            f"(primary={persisted_count}, postgres_bridge={postgres_bridge_count})."
+        )
+        if getattr(ns, "allow_empty", False):
+            logging.warning(message)
+            return 0
+        logging.error(
+            "%s Pass --allow-empty to exit successfully on an empty sync.", message
+        )
+        return 1
+
     return 0
 
 
-def _bridge_teams_to_postgres(teams_data: list, ns: argparse.Namespace) -> None:
+async def _count_persisted_teams(store: Any, teams_data: list) -> int:
+    expected_ids = {
+        str(getattr(team, "id", "") or "").strip() for team in teams_data
+    } - {""}
+    if not expected_ids or not hasattr(store, "get_all_teams"):
+        return 0
+
+    persisted = await store.get_all_teams()
+    persisted_ids = {
+        str(getattr(team, "id", "") or "").strip() for team in persisted
+    } - {""}
+    return len(expected_ids & persisted_ids)
+
+
+def _bridge_teams_to_postgres(teams_data: list, ns: argparse.Namespace) -> int | None:
     """Upsert Team records into PostgreSQL TeamMapping table for multi-tenant bridge."""
     import logging
 
@@ -603,7 +645,13 @@ def _bridge_teams_to_postgres(teams_data: list, ns: argparse.Namespace) -> None:
 
     org_id = getattr(ns, "org", None)
     if org_id is None:
-        return
+        return None
+
+    expected_ids = {
+        str(getattr(team, "id", "") or "").strip() for team in teams_data
+    } - {""}
+    if not expected_ids:
+        return 0
 
     try:
         with get_postgres_session_sync() as session:
@@ -633,13 +681,24 @@ def _bridge_teams_to_postgres(teams_data: list, ns: argparse.Namespace) -> None:
                             is_active=True,
                         )
                     )
+            session.flush()
+            persisted_ids = set(
+                session.execute(
+                    select(TeamMapping.team_id).where(
+                        TeamMapping.org_id == org_id,
+                        TeamMapping.team_id.in_(expected_ids),
+                    )
+                ).scalars()
+            )
             logging.info(
                 "Bridged %d teams to PostgreSQL TeamMapping (org=%s).",
-                len(teams_data),
+                len(persisted_ids),
                 org_id,
             )
+            return len(persisted_ids)
     except Exception as e:
-        logging.warning("Failed to bridge teams to PostgreSQL (non-fatal): %s", e)
+        logging.error("Failed to bridge teams to PostgreSQL: %s", e)
+        return 0
 
 
 def register_commands(sync_subparsers: argparse._SubParsersAction) -> None:

--- a/src/dev_health_ops/providers/teams.py
+++ b/src/dev_health_ops/providers/teams.py
@@ -558,8 +558,14 @@ def sync_teams(ns: argparse.Namespace) -> int:
         return 1
 
     if not teams_data:
-        logging.warning("No teams found/generated.")
-        return 0
+        message = "No teams found/generated."
+        if getattr(ns, "allow_empty", False):
+            logging.warning(message)
+            return 0
+        logging.error(
+            "%s Pass --allow-empty to exit successfully on an empty sync.", message
+        )
+        return 1
 
     validate_sink(ns)
     db_uri = resolve_sink_uri(ns)
@@ -667,5 +673,10 @@ def register_commands(sync_subparsers: argparse._SubParsersAction) -> None:
     teams.add_argument(
         "--auth",
         help="Provider token override (GitHub/GitLab). Falls back to env vars.",
+    )
+    teams.add_argument(
+        "--allow-empty",
+        action="store_true",
+        help="Exit successfully when no teams are found/generated (default: exit 1).",
     )
     teams.set_defaults(func=sync_teams)

--- a/src/dev_health_ops/storage/__init__.py
+++ b/src/dev_health_ops/storage/__init__.py
@@ -150,7 +150,7 @@ async def run_with_store(
     db_type: str,
     handler: Callable,
     org_id: str | None,
-) -> None:
+) -> Any:
     """
     Helper to create a store and run a handler within its context.
 
@@ -159,7 +159,7 @@ async def run_with_store(
     store: StoreLike = create_store(db_url, db_type)
     store.org_id = org_id
     async with store:
-        await handler(store)
+        return await handler(store)
 
 
 __all__ = [

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -1435,7 +1435,7 @@ class ClickHouseStore:
                         "is_active": int(item.get("is_active", 1)),
                         "updated_at": self._normalize_datetime(item.get("updated_at")),
                         "last_synced": synced_at,
-                        "org_id": item.get("org_id") or "",
+                        "org_id": item.get("org_id") or self.org_id or "",
                     }
                 )
             else:
@@ -1451,7 +1451,7 @@ class ClickHouseStore:
                         "is_active": int(getattr(item, "is_active", 1) or 0),
                         "updated_at": self._normalize_datetime(item.updated_at),
                         "last_synced": synced_at,
-                        "org_id": getattr(item, "org_id", None) or "",
+                        "org_id": getattr(item, "org_id", None) or self.org_id or "",
                     }
                 )
 
@@ -1628,7 +1628,7 @@ class ClickHouseStore:
 
         assert self.client is not None
         # Using FINAL to get the latest version of each team
-        query = "SELECT id, team_uuid, name, description, members, updated_at FROM teams FINAL"
+        query = "SELECT id, org_id, team_uuid, name, description, members, updated_at FROM teams FINAL"
         async with self._lock:
             result = await asyncio.to_thread(self.client.query, query)
 
@@ -1638,11 +1638,12 @@ class ClickHouseStore:
                 teams.append(
                     Team(
                         id=row[0],
-                        team_uuid=row[1],
-                        name=row[2],
-                        description=row[3],
-                        members=row[4],
-                        updated_at=_parse_datetime_value(row[5]),
+                        org_id=row[1],
+                        team_uuid=row[2],
+                        name=row[3],
+                        description=row[4],
+                        members=row[5],
+                        updated_at=_parse_datetime_value(row[6]),
                     )
                 )
         return teams

--- a/tests/providers/jira/test_ops_mapping.py
+++ b/tests/providers/jira/test_ops_mapping.py
@@ -50,6 +50,7 @@ def test_sync_teams_jira_ops():
             "dev_health_ops.providers.teams.detect_db_type", return_value="clickhouse"
         ),
     ):
+        mock_run_store.return_value = 1
         result = sync_teams(ns)
         assert result == 0
         mock_run_store.assert_awaited_once()

--- a/tests/test_linear_team_sync.py
+++ b/tests/test_linear_team_sync.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 def _close_coroutine(coro):
     """Close a coroutine without awaiting it to suppress RuntimeWarning."""
     coro.close()
-    return None
+    return 1
 
 
 # ---------------------------------------------------------------------------
@@ -81,7 +81,7 @@ def _make_ns(
     ns.path = None
     ns.owner = None
     ns.auth = None
-    ns.org = None
+    ns.org = "org-1"
     return ns
 
 
@@ -108,6 +108,7 @@ class TestLinearTeamSync:
         mock_client = MagicMock()
         mock_client_class.from_env.return_value = mock_client
         mock_resolve_sink.return_value = "clickhouse://localhost:8123/default"
+        mock_bridge.return_value = 2
         mock_client.iter_teams.return_value = [
             _mock_linear_team(
                 key="ENG",
@@ -153,6 +154,7 @@ class TestLinearTeamSync:
         mock_client = MagicMock()
         mock_client_class.from_env.return_value = mock_client
         mock_resolve_sink.return_value = "clickhouse://localhost:8123/default"
+        mock_bridge.return_value = 1
         mock_client.iter_teams.return_value = [
             _mock_linear_team(key="ARCH", name="Archived Team", archived=True),
             _mock_linear_team(
@@ -187,6 +189,7 @@ class TestLinearTeamSync:
         mock_client = MagicMock()
         mock_client_class.from_env.return_value = mock_client
         mock_resolve_sink.return_value = "clickhouse://localhost:8123/default"
+        mock_bridge.return_value = 1
         mock_client.iter_teams.return_value = [
             _mock_linear_team(key="EMPTY", name="Empty Team", members=[]),
         ]
@@ -217,6 +220,7 @@ class TestLinearTeamSync:
         mock_client = MagicMock()
         mock_client_class.from_env.return_value = mock_client
         mock_resolve_sink.return_value = "clickhouse://localhost:8123/default"
+        mock_bridge.return_value = 1
 
         # Team with hasNextPage=True — only 1 member in initial nodes
         initial_member = _mock_member(name="Alice", email="alice@example.com")
@@ -278,6 +282,7 @@ class TestLinearTeamSync:
         mock_client = MagicMock()
         mock_client_class.from_env.return_value = mock_client
         mock_resolve_sink.return_value = "clickhouse://localhost:8123/default"
+        mock_bridge.return_value = 1
         mock_client.iter_teams.return_value = [
             _mock_linear_team(
                 key="ENG",

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -193,3 +193,39 @@ async def test_load_team_resolver_from_store_accepts_id_name_dicts():
     team_id, team_name = resolver.resolve("alice@example.com")
     assert team_id == "team-a"
     assert team_name == "Team Alpha"
+
+
+def test_cli_sync_teams_empty_exits_one(tmp_path):
+    """Test that sync_teams exits 1 when no teams are found and allow_empty is False."""
+    import yaml
+
+    from dev_health_ops.providers.teams import sync_teams as _cmd_sync_teams
+
+    config_file = tmp_path / "empty_teams.yaml"
+    config_file.write_text(yaml.dump({"teams": []}))
+
+    ns = MagicMock()
+    ns.provider = "config"
+    ns.path = str(config_file)
+    ns.allow_empty = False
+
+    result = _cmd_sync_teams(ns)
+    assert result == 1
+
+
+def test_cli_sync_teams_empty_allow_empty_exits_zero(tmp_path):
+    """Test that sync_teams exits 0 when no teams are found and allow_empty is True."""
+    import yaml
+
+    from dev_health_ops.providers.teams import sync_teams as _cmd_sync_teams
+
+    config_file = tmp_path / "empty_teams.yaml"
+    config_file.write_text(yaml.dump({"teams": []}))
+
+    ns = MagicMock()
+    ns.provider = "config"
+    ns.path = str(config_file)
+    ns.allow_empty = True
+
+    result = _cmd_sync_teams(ns)
+    assert result == 0

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -96,6 +96,7 @@ async def test_clickhouse_store_teams():
         mock_result.result_rows = [
             (
                 "t1",
+                "org-1",
                 str(uuid.uuid4()),
                 "Team 1",
                 "Desc",
@@ -386,4 +387,65 @@ def test_cli_sync_teams_org_bridge_failure_exits_one(tmp_path):
 
         result = _cmd_sync_teams(ns)
 
+    assert result == 1
+
+
+def test_cli_sync_teams_org_stale_global_row_does_not_mask(tmp_path):
+    """An org-scoped run must not count a stale row from another org as
+    persisted: the org-scoped read-back filters by the store's org_id."""
+    from types import SimpleNamespace
+
+    import yaml
+
+    from dev_health_ops.providers.teams import sync_teams as _cmd_sync_teams
+
+    config_file = tmp_path / "teams.yaml"
+    config_file.write_text(
+        yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+    )
+
+    class FakeStore:
+        # Store is scoped to org-1.
+        org_id = "org-1"
+
+        async def ensure_tables(self):
+            return None
+
+        async def insert_teams(self, teams):
+            # Simulate the org-1 analytics write not landing.
+            return None
+
+        async def get_all_teams(self):
+            # A pre-existing row for the SAME id but a DIFFERENT org.
+            return [SimpleNamespace(id="team-a", org_id="other-org")]
+
+    async def fake_run_with_store(_db_uri, _db_type, handler, org_id=None):
+        assert org_id == "org-1"
+        return await handler(FakeStore())
+
+    with (
+        patch("dev_health_ops.storage.run_with_store", new=fake_run_with_store),
+        patch("dev_health_ops.providers.teams.validate_sink"),
+        patch(
+            "dev_health_ops.providers.teams.resolve_sink_uri",
+            return_value="clickhouse://localhost:8123/default",
+        ),
+        patch(
+            "dev_health_ops.providers.teams.detect_db_type", return_value="clickhouse"
+        ),
+        patch(
+            "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+            return_value=1,
+        ),
+    ):
+        ns = MagicMock()
+        ns.provider = "config"
+        ns.path = str(config_file)
+        ns.org = "org-1"
+        ns.allow_empty = False
+
+        result = _cmd_sync_teams(ns)
+
+    # Stale cross-org row is filtered out -> primary persisted count is 0 -> exit 1,
+    # even though the Postgres bridge succeeded.
     assert result == 1

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -1,4 +1,3 @@
-import asyncio
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
@@ -138,40 +137,54 @@ def test_synthetic_teams_generation():
         assert len(list(getattr(team, "members") or [])) > 0
 
 
-@pytest.mark.asyncio
-async def test_cli_sync_teams_synthetic():
+def test_cli_sync_teams_synthetic():
     """Test CLI sync teams command with synthetic provider."""
     from dev_health_ops.providers.teams import sync_teams as _cmd_sync_teams
 
-    with patch("asyncio.run") as mock_run:
-        with (
-            patch("dev_health_ops.providers.teams.validate_sink") as mock_validate,
-            patch(
-                "dev_health_ops.providers.teams.resolve_sink_uri",
-                return_value="clickhouse://localhost:8123/default",
-            ) as mock_resolve_sink,
-            patch(
-                "dev_health_ops.providers.teams.detect_db_type",
-                return_value="clickhouse",
-            ) as mock_detect,
-        ):
-            ns = MagicMock()
-            ns.db = "sqlite:///:memory:"
-            ns.sink = "clickhouse"
-            ns.analytics_db = None
-            ns.provider = "synthetic"
-            ns.path = None
+    class FakeStore:
+        def __init__(self):
+            self.teams = []
 
-            result = _cmd_sync_teams(ns)
+        async def ensure_tables(self):
+            return None
 
-            assert result == 0
-            assert mock_run.called
-            mock_validate.assert_called_once_with(ns)
-            mock_resolve_sink.assert_called_once_with(ns)
-            mock_detect.assert_called_once_with("clickhouse://localhost:8123/default")
-            coro = mock_run.call_args[0][0]
-            assert asyncio.iscoroutine(coro)
-            coro.close()
+        async def insert_teams(self, teams):
+            self.teams = teams
+
+        async def get_all_teams(self):
+            return self.teams
+
+    async def fake_run_with_store(_db_uri, _db_type, handler, org_id=None):
+        assert org_id is None
+        return await handler(FakeStore())
+
+    with (
+        patch("dev_health_ops.storage.run_with_store", new=fake_run_with_store),
+        patch("dev_health_ops.providers.teams.validate_sink") as mock_validate,
+        patch(
+            "dev_health_ops.providers.teams.resolve_sink_uri",
+            return_value="clickhouse://localhost:8123/default",
+        ) as mock_resolve_sink,
+        patch(
+            "dev_health_ops.providers.teams.detect_db_type",
+            return_value="clickhouse",
+        ) as mock_detect,
+    ):
+        ns = MagicMock()
+        ns.db = "sqlite:///:memory:"
+        ns.sink = "clickhouse"
+        ns.analytics_db = None
+        ns.provider = "synthetic"
+        ns.path = None
+        ns.org = None
+        ns.allow_empty = False
+
+        result = _cmd_sync_teams(ns)
+
+        assert result == 0
+        mock_validate.assert_called_once_with(ns)
+        mock_resolve_sink.assert_called_once_with(ns)
+        mock_detect.assert_called_once_with("clickhouse://localhost:8123/default")
 
 
 @pytest.mark.asyncio
@@ -229,3 +242,148 @@ def test_cli_sync_teams_empty_allow_empty_exits_zero(tmp_path):
 
     result = _cmd_sync_teams(ns)
     assert result == 0
+
+
+def test_cli_sync_teams_non_empty_zero_persisted_exits_one(tmp_path):
+    import yaml
+
+    from dev_health_ops.providers.teams import sync_teams as _cmd_sync_teams
+
+    config_file = tmp_path / "teams.yaml"
+    config_file.write_text(
+        yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+    )
+
+    class FakeStore:
+        async def ensure_tables(self):
+            return None
+
+        async def insert_teams(self, teams):
+            assert len(teams) == 1
+
+        async def get_all_teams(self):
+            return []
+
+    async def fake_run_with_store(_db_uri, _db_type, handler, org_id=None):
+        assert org_id is None
+        return await handler(FakeStore())
+
+    with (
+        patch("dev_health_ops.storage.run_with_store", new=fake_run_with_store),
+        patch("dev_health_ops.providers.teams.validate_sink"),
+        patch(
+            "dev_health_ops.providers.teams.resolve_sink_uri",
+            return_value="clickhouse://localhost:8123/default",
+        ),
+        patch(
+            "dev_health_ops.providers.teams.detect_db_type", return_value="clickhouse"
+        ),
+    ):
+        ns = MagicMock()
+        ns.provider = "config"
+        ns.path = str(config_file)
+        ns.org = None
+        ns.allow_empty = False
+
+        result = _cmd_sync_teams(ns)
+
+    assert result == 1
+
+
+def test_cli_sync_teams_allow_empty_overrides_zero_persisted(tmp_path):
+    import yaml
+
+    from dev_health_ops.providers.teams import sync_teams as _cmd_sync_teams
+
+    config_file = tmp_path / "teams.yaml"
+    config_file.write_text(
+        yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+    )
+
+    class FakeStore:
+        async def ensure_tables(self):
+            return None
+
+        async def insert_teams(self, teams):
+            assert len(teams) == 1
+
+        async def get_all_teams(self):
+            return []
+
+    async def fake_run_with_store(_db_uri, _db_type, handler, org_id=None):
+        assert org_id is None
+        return await handler(FakeStore())
+
+    with (
+        patch("dev_health_ops.storage.run_with_store", new=fake_run_with_store),
+        patch("dev_health_ops.providers.teams.validate_sink"),
+        patch(
+            "dev_health_ops.providers.teams.resolve_sink_uri",
+            return_value="clickhouse://localhost:8123/default",
+        ),
+        patch(
+            "dev_health_ops.providers.teams.detect_db_type", return_value="clickhouse"
+        ),
+    ):
+        ns = MagicMock()
+        ns.provider = "config"
+        ns.path = str(config_file)
+        ns.org = None
+        ns.allow_empty = True
+
+        result = _cmd_sync_teams(ns)
+
+    assert result == 0
+
+
+def test_cli_sync_teams_org_bridge_failure_exits_one(tmp_path):
+    import yaml
+
+    from dev_health_ops.providers.teams import sync_teams as _cmd_sync_teams
+
+    config_file = tmp_path / "teams.yaml"
+    config_file.write_text(
+        yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+    )
+
+    class FakeStore:
+        def __init__(self):
+            self.teams = []
+
+        async def ensure_tables(self):
+            return None
+
+        async def insert_teams(self, teams):
+            self.teams = teams
+
+        async def get_all_teams(self):
+            return self.teams
+
+    async def fake_run_with_store(_db_uri, _db_type, handler, org_id=None):
+        assert org_id == "org-1"
+        return await handler(FakeStore())
+
+    with (
+        patch("dev_health_ops.storage.run_with_store", new=fake_run_with_store),
+        patch("dev_health_ops.providers.teams.validate_sink"),
+        patch(
+            "dev_health_ops.providers.teams.resolve_sink_uri",
+            return_value="clickhouse://localhost:8123/default",
+        ),
+        patch(
+            "dev_health_ops.providers.teams.detect_db_type", return_value="clickhouse"
+        ),
+        patch(
+            "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+            side_effect=RuntimeError("bridge down"),
+        ),
+    ):
+        ns = MagicMock()
+        ns.provider = "config"
+        ns.path = str(config_file)
+        ns.org = "org-1"
+        ns.allow_empty = False
+
+        result = _cmd_sync_teams(ns)
+
+    assert result == 1


### PR DESCRIPTION
## Summary
- `sync teams` now exits 0 **only when at least one team was actually persisted** to the required store(s); a genuine no-op — or a silently-failed org-scoped Postgres bridge — exits non-zero.
- Adds `--allow-empty` to opt back into exit 0 for intentional empty/sample runs.
- Updates the README and CLI reference so the bundled empty-config example uses `--allow-empty` and documents the new exit behaviour.

## Persistence-aware exit contract
- Exit 0 only when every required store persists ≥1 team (read-back: primary store via `get_all_teams()`; org-scoped Postgres bridge via a `TeamMapping` read-back for the org).
- Exit 1 when discovery is empty **or** the persistence read-back is zero (including a swallowed bridge failure under `--org`).
- `--allow-empty` overrides empty/no-op to exit 0.

## Addresses adversarial-review findings
- [high] Exit status was based on discovered objects, not successful persistence — an org-scoped run could persist zero mapping rows yet exit 0. Now validated by reading back persisted counts.
- [medium] The documented empty-config onboarding command would now exit 1; README and CLI reference updated to show `--allow-empty` and note the behaviour change.

## Testing
- Teams suite (11 tests) passes, covering: persisted ≥1 → exit 0; discovered-but-zero-persisted / bridge-failure → non-zero; `--allow-empty` → exit 0.
- `ruff format`/`check` clean.

Closes CHAOS-2391. Based on main.
SCREENSHOT-WAIVER: CLI-only.