### PR TITLE
feat(workers): schedule RuleEngine recommendations for live orgs (CHAOS-2373)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/recommendations.py
+++ b/src/dev_health_ops/api/graphql/resolvers/recommendations.py
@@ -7,6 +7,8 @@ import logging
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
+from dev_health_ops.utils.datetime import utc_today
+
 from ..authz import require_org_id
 from ..context import GraphQLContext
 from ..models.recommendations import (
@@ -29,8 +31,13 @@ logger = logging.getLogger(__name__)
 #   2. outer: argMax(..., window_end) keeps ONLY the latest window_end (as-of
 #      day) per (org, team, rule). Each scheduled run writes the full rule
 #      state — fired rows AND explicit fired=false tombstones — at
-#      window_end=today, so the most recent as-of dominates and a stale fired
-#      row from an earlier day is superseded instead of lingering in-range.
+#      window_end == as_of_day + 1 (the day AFTER the finalized partition, so
+#      the loader's exclusive `day < window_end` still *reads* that partition),
+#      so the most recent as-of dominates and a stale fired row from an earlier
+#      day is superseded instead of lingering in-range.
+# The read cap below (_window_to_dates) is therefore inclusive of today+1 to
+# match that persisted key, mirroring api/services/filtering.time_window so the
+# home and recommendations() surfaces agree (CHAOS-2373).
 # Final HAVING keeps only currently-fired rules.
 # ---------------------------------------------------------------------------
 _RECOMMENDATIONS_SQL = """\
@@ -77,10 +84,22 @@ ORDER BY latest_window_end DESC, rule_id
 def _window_to_dates(window: WindowInput) -> tuple[date, date]:
     """Convert a WindowInput to (window_start, window_end) date bounds.
 
-    window_end is always today (UTC); window_start is computed from the
-    unit/value pair.  A *cycle* is treated as 14 days (two-week sprint).
+    ``window_end`` is ``utc_today() + 1`` — the EXCLUSIVE-style cap that the
+    scheduled writer persists rows at (it anchors ``window_end == as_of_day + 1``
+    so the loader's exclusive ``day < window_end`` still reads the finalized
+    partition; see workers/recommendations_tasks.py). Capping the read at
+    ``today + 1`` therefore *includes* today's finalized recommendations
+    same-day instead of leaving them one finalize-day stale. This mirrors
+    ``api/services/filtering.time_window`` (``end_day = utc_today() + 1``) so the
+    ``recommendations()`` GraphQL surface and the home surface agree on the
+    convention (CHAOS-2373).
+
+    ``window_start`` is computed from the unit/value pair, anchored to *today*
+    (not the bumped cap) so the lookback span is unchanged. A *cycle* is treated
+    as 14 days (two-week sprint).
     """
-    today = datetime.now(tz=timezone.utc).date()
+    today = utc_today()
+    window_end = today + timedelta(days=1)
     days = window.value * 7
     match window.unit:
         case WindowUnit.DAY:
@@ -89,7 +108,7 @@ def _window_to_dates(window: WindowInput) -> tuple[date, date]:
             days = window.value * 7
         case WindowUnit.CYCLE:
             days = window.value * 14
-    return today - timedelta(days=days), today
+    return today - timedelta(days=days), window_end
 
 
 def _parse_evidence(raw: str | list[Any] | None) -> list[EvidenceRef]:

--- a/src/dev_health_ops/api/graphql/resolvers/recommendations.py
+++ b/src/dev_health_ops/api/graphql/resolvers/recommendations.py
@@ -23,29 +23,54 @@ logger = logging.getLogger(__name__)
 # SQL — argMax reads the latest computed row per (org_id, team_id, rule_id, window_end).
 # These are the ORDER BY columns in migration 039_recommendations.sql.
 # Table: recommendations_daily (ClickHouse, append-only / ReplacingMergeTree).
+#
+# Resolution is two-stage so a *recovered* signal stops showing (CHAOS-2373):
+#   1. inner: argMax(..., computed_at) collapses re-runs of the SAME window_end.
+#   2. outer: argMax(..., window_end) keeps ONLY the latest window_end (as-of
+#      day) per (org, team, rule). Each scheduled run writes the full rule
+#      state — fired rows AND explicit fired=false tombstones — at
+#      window_end=today, so the most recent as-of dominates and a stale fired
+#      row from an earlier day is superseded instead of lingering in-range.
+# Final HAVING keeps only currently-fired rules.
 # ---------------------------------------------------------------------------
 _RECOMMENDATIONS_SQL = """\
-    SELECT
+SELECT
     team_id,
     org_id,
     rule_id,
-    argMax(fired,               computed_at) AS latest_fired,
-    argMax(severity,            computed_at) AS latest_severity,
-    argMax(title,               computed_at) AS latest_title,
-    argMax(rationale,           computed_at) AS latest_rationale,
-    argMax(success_criterion,   computed_at) AS latest_success_criterion,
-    argMax(evidence_json,       computed_at) AS latest_evidence_json,
-    argMax(window_start,        computed_at) AS latest_window_start,
-    argMax(window_end,          computed_at) AS latest_window_end,
-    max(computed_at)                         AS latest_computed_at
-FROM recommendations_daily
-WHERE team_id  = {team_id:String}
-  AND org_id   = {org_id:String}
-  AND window_end >= {window_start:Date}
-  AND window_end <= {window_end:Date}
-GROUP BY org_id, team_id, rule_id, window_end
+    argMax(latest_fired,             window_end) AS latest_fired,
+    argMax(latest_severity,          window_end) AS latest_severity,
+    argMax(latest_title,             window_end) AS latest_title,
+    argMax(latest_rationale,         window_end) AS latest_rationale,
+    argMax(latest_success_criterion, window_end) AS latest_success_criterion,
+    argMax(latest_evidence_json,     window_end) AS latest_evidence_json,
+    argMax(latest_window_start,      window_end) AS latest_window_start,
+    max(window_end)                              AS latest_window_end,
+    argMax(latest_computed_at,       window_end) AS latest_computed_at
+FROM (
+    SELECT
+        team_id,
+        org_id,
+        rule_id,
+        window_end,
+        argMax(fired,               computed_at) AS latest_fired,
+        argMax(severity,            computed_at) AS latest_severity,
+        argMax(title,               computed_at) AS latest_title,
+        argMax(rationale,           computed_at) AS latest_rationale,
+        argMax(success_criterion,   computed_at) AS latest_success_criterion,
+        argMax(evidence_json,       computed_at) AS latest_evidence_json,
+        argMax(window_start,        computed_at) AS latest_window_start,
+        max(computed_at)                         AS latest_computed_at
+    FROM recommendations_daily
+    WHERE team_id  = {team_id:String}
+      AND org_id   = {org_id:String}
+      AND window_end >= {window_start:Date}
+      AND window_end <= {window_end:Date}
+    GROUP BY org_id, team_id, rule_id, window_end
+)
+GROUP BY org_id, team_id, rule_id
 HAVING latest_fired = true
-ORDER BY window_end DESC, rule_id
+ORDER BY latest_window_end DESC, rule_id
 """
 
 

--- a/src/dev_health_ops/api/services/home.py
+++ b/src/dev_health_ops/api/services/home.py
@@ -192,24 +192,53 @@ _LOWER_IS_BETTER = {
     "compounding_risk",
 }
 
+# Two-stage resolution so a *recovered* signal stops showing (CHAOS-2373):
+#   1. inner: argMax(..., computed_at) collapses re-runs of the SAME window_end.
+#   2. outer: argMax(..., window_end) keeps ONLY the latest window_end (as-of
+#      day) per (org, team, rule). The scheduled job writes the full rule state
+#      — fired rows AND explicit fired=false tombstones — at window_end=today,
+#      so the most recent as-of dominates and a stale fired row from an earlier
+#      day is superseded instead of lingering in-range.
+# ``{team_filter}`` is substituted with an extra inner-WHERE predicate.
 _RECOMMENDATIONS_SQL = """
     SELECT
         team_id,
         org_id,
         rule_id,
-        argMax(fired,               computed_at) AS latest_fired,
-        argMax(severity,            computed_at) AS latest_severity,
-        argMax(title,               computed_at) AS latest_title,
-        argMax(rationale,           computed_at) AS latest_rationale,
-        argMax(success_criterion,   computed_at) AS latest_success_criterion,
-        argMax(evidence_json,       computed_at) AS latest_evidence_json,
-        argMax(window_start,        computed_at) AS latest_window_start,
-        argMax(window_end,          computed_at) AS latest_window_end,
-        max(computed_at)                         AS latest_computed_at
-    FROM recommendations_daily
-    WHERE org_id = {org_id:String}
-      AND window_end >= {window_start:Date}
-      AND window_end <= {window_end:Date}
+        argMax(latest_fired,             window_end) AS latest_fired,
+        argMax(latest_severity,          window_end) AS latest_severity,
+        argMax(latest_title,             window_end) AS latest_title,
+        argMax(latest_rationale,         window_end) AS latest_rationale,
+        argMax(latest_success_criterion, window_end) AS latest_success_criterion,
+        argMax(latest_evidence_json,     window_end) AS latest_evidence_json,
+        argMax(latest_window_start,      window_end) AS latest_window_start,
+        max(window_end)                              AS latest_window_end,
+        argMax(latest_computed_at,       window_end) AS latest_computed_at
+    FROM (
+        SELECT
+            team_id,
+            org_id,
+            rule_id,
+            window_end,
+            argMax(fired,               computed_at) AS latest_fired,
+            argMax(severity,            computed_at) AS latest_severity,
+            argMax(title,               computed_at) AS latest_title,
+            argMax(rationale,           computed_at) AS latest_rationale,
+            argMax(success_criterion,   computed_at) AS latest_success_criterion,
+            argMax(evidence_json,       computed_at) AS latest_evidence_json,
+            argMax(window_start,        computed_at) AS latest_window_start,
+            max(computed_at)                         AS latest_computed_at
+        FROM recommendations_daily
+        WHERE org_id = {org_id:String}
+          AND window_end >= {window_start:Date}
+          AND window_end <= {window_end:Date}
+          {team_filter}
+        GROUP BY org_id, team_id, rule_id, window_end
+    )
+    GROUP BY org_id, team_id, rule_id
+    HAVING latest_fired = true
+    ORDER BY latest_window_end DESC, latest_severity DESC, rule_id
+    LIMIT 10
 """
 
 _COMPOUNDING_RISK_SQL = """
@@ -718,20 +747,15 @@ async def _fetch_recommendation_signals(
 ) -> list[HomeSignal]:
     if filters.scope.level != "team" or not filters.scope.ids:
         return []
-    query = _RECOMMENDATIONS_SQL
     params: dict[str, Any] = {
         "org_id": org_id,
         "window_start": start_day,
         "window_end": end_day,
         "team_ids": filters.scope.ids,
     }
-    query += """
-      AND team_id IN {team_ids:Array(String)}
-    GROUP BY org_id, team_id, rule_id, window_end
-    HAVING latest_fired = true
-    ORDER BY window_end DESC, latest_severity DESC, rule_id
-    LIMIT 10
-    """
+    query = _RECOMMENDATIONS_SQL.replace(
+        "{team_filter}", "AND team_id IN {team_ids:Array(String)}"
+    )
     try:
         rows = await query_dicts(sink, query, params)
     except Exception:

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -125,10 +125,7 @@ def _cmd_recommendations_compute(ns: argparse.Namespace) -> int:
     from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
     from dev_health_ops.recommendations import registry as recommendations_registry
     from dev_health_ops.recommendations.engine import RuleEngine
-    from dev_health_ops.recommendations.loader import (
-        ClickHouseMetricsLoader,
-        recommendation_to_record,
-    )
+    from dev_health_ops.recommendations.loader import ClickHouseMetricsLoader
 
     analytics_db = getattr(ns, "analytics_db", None) or os.getenv("CLICKHOUSE_URI", "")
     if not analytics_db:
@@ -157,33 +154,33 @@ def _cmd_recommendations_compute(ns: argparse.Namespace) -> int:
     engine = RuleEngine(registry=recommendations_registry, loader=loader, now=now)
 
     try:
-        recommendations = engine.evaluate_all(
-            team_id=team_id, window=window, org_id=org_id
-        )
+        # Full state: fired recommendations AND explicit fired=False tombstones
+        # so a recovered signal is cleared, not left lingering (CHAOS-2373).
+        records = engine.evaluate_state(team_id=team_id, window=window, org_id=org_id)
     except Exception as exc:
         logging.getLogger(__name__).error(
             "Recommendations evaluation failed for team=%r: %s", team_id, exc
         )
         return 1
 
-    sink.write_recommendations(
-        [recommendation_to_record(rec) for rec in recommendations]
-    )
+    sink.write_recommendations(records)
     sink.close()
 
+    fired = [r for r in records if r.fired]
     log = logging.getLogger(__name__)
     log.info(
-        "recommendations compute: team=%r window=%s fired=%d",
+        "recommendations compute: team=%r window=%s fired=%d rows=%d",
         team_id,
         window,
-        len(recommendations),
+        len(fired),
+        len(records),
     )
     if getattr(ns, "output_json", False):
         import sys
         from dataclasses import asdict
 
         print(
-            json.dumps([asdict(r) for r in recommendations], default=str),
+            json.dumps([asdict(r) for r in fired], default=str),
             file=sys.stdout,
         )
     return 0

--- a/src/dev_health_ops/recommendations/engine.py
+++ b/src/dev_health_ops/recommendations/engine.py
@@ -148,6 +148,84 @@ class RuleEngine:
             window_end=window_end,
         )
 
+    def evaluate_state(
+        self,
+        team_id: str,
+        window: int | str = 7,
+        org_id: str = "",
+        rule_version: str = "1.0.0",
+    ) -> list[RecommendationRecord]:
+        """Evaluate every registered rule and return the *full* state as records.
+
+        Unlike :meth:`evaluate_all` (fired-only), this returns one
+        ``RecommendationRecord`` for **every** registered rule:
+
+        * a fired rule yields a ``fired=True`` record carrying its rationale and
+          evidence;
+        * a rule that does **not** fire yields an explicit ``fired=False``
+          tombstone record (from the registry's static ``RuleDef``).
+
+        Persisting the full state is required for correctness: the readers
+        ``argMax(fired, computed_at)`` per ``(org_id, team_id, rule_id,
+        window_end)`` and keep ``HAVING latest_fired = true``. Without a
+        ``fired=False`` row at the new ``window_end``, a rule that fired
+        yesterday but has since recovered would keep surfacing stale guidance
+        (CHAOS-2373). The records all share the same ``computed_at`` and
+        ``window_end`` so one scheduled run replaces the rule state for the
+        team in a single, internally-consistent batch.
+        """
+        from dev_health_ops.recommendations import registry as _registry
+
+        days = _parse_window(window)
+        window_end = self._now.date()
+        window_start = window_end - timedelta(days=days)
+
+        fired = self.evaluate(
+            team_id=team_id,
+            org_id=org_id,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        fired_by_rule = {rec.rule_id: rec for rec in fired}
+
+        from dev_health_ops.recommendations.loader import recommendation_to_record
+
+        records: list[RecommendationRecord] = []
+        for rule_id in self._evaluators:
+            rec = fired_by_rule.get(rule_id)
+            if rec is not None:
+                records.append(recommendation_to_record(rec, rule_version=rule_version))
+                continue
+            # Non-fired: persist an explicit tombstone so the latest state for
+            # this (team, rule, window_end) reads as resolved.
+            try:
+                rule_def = _registry.get_rule(rule_id)
+                title = rule_def.title
+                severity = rule_def.severity
+                success_criterion = rule_def.success_criterion
+            except KeyError:
+                title = ""
+                severity = "warning"
+                success_criterion = ""
+            records.append(
+                RecommendationRecord(
+                    team_id=team_id,
+                    org_id=org_id,
+                    rule_id=rule_id,
+                    rule_version=rule_version,
+                    window_start=window_start,
+                    window_end=window_end,
+                    fired=False,
+                    severity=severity,
+                    title=title,
+                    rationale="",
+                    success_criterion=success_criterion,
+                    evidence_json="[]",
+                    computed_at=self._now,
+                )
+            )
+        return records
+
     def evaluate_one(
         self,
         rule_id: str,

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -80,6 +80,14 @@ beat_schedule = {
         "schedule": crontab(hour=1, minute=0),
         "options": {"queue": "default"},
     },
+    # Runs after run-daily-metrics so recommendations evaluate against the
+    # freshly-computed daily signals (CHAOS-2373). Without this the live path
+    # for recommendations_daily never fires for real orgs.
+    "run-recommendations": {
+        "task": "dev_health_ops.workers.tasks.run_recommendations_job",
+        "schedule": crontab(hour=2, minute=0),
+        "options": {"queue": "metrics"},
+    },
     "sync-team-drift": {
         "task": "dev_health_ops.workers.tasks.sync_team_drift",
         "schedule": crontab(hour=2, minute=30),

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -80,9 +80,13 @@ beat_schedule = {
         "schedule": crontab(hour=1, minute=0),
         "options": {"queue": "default"},
     },
-    # Runs after run-daily-metrics so recommendations evaluate against the
-    # freshly-computed daily signals (CHAOS-2373). Without this the live path
-    # for recommendations_daily never fires for real orgs.
+    # Daily safety net for recommendations_daily (CHAOS-2373). The primary
+    # trigger is completion-gated: run_daily_metrics_finalize_task chains
+    # run_recommendations_job once each (org, day) finalize completes. This beat
+    # entry is a backstop in case a finalize callback was lost; the task itself
+    # skips any org whose daily_finalize checkpoint is still in flight, so it
+    # never reads partial metric tables. Scheduled at 02:00, after the 01:00
+    # run-daily-metrics dispatch.
     "run-recommendations": {
         "task": "dev_health_ops.workers.tasks.run_recommendations_job",
         "schedule": crontab(hour=2, minute=0),

--- a/src/dev_health_ops/workers/metrics_partitioned.py
+++ b/src/dev_health_ops/workers/metrics_partitioned.py
@@ -311,6 +311,30 @@ def run_daily_metrics_finalize_task(
             with get_postgres_session_sync() as session:
                 mark_completed(session, checkpoint_id)
 
+        # Completion-gated trigger: now that daily metrics for this (org, day)
+        # are finalized, evaluate recommendations against fresh tables. The
+        # beat-scheduled run is a daily safety net; this chains off the actual
+        # finalize so recommendations never read partial metrics (CHAOS-2373).
+        # Isolated from finalize success: a broker hiccup enqueueing the
+        # follow-up must NOT retry an already-completed finalize. The daily beat
+        # entry (and tomorrow's finalize) will recover the missed run.
+        try:
+            from dev_health_ops.workers.recommendations_tasks import (
+                run_recommendations_job,
+            )
+
+            run_recommendations_job.apply_async(
+                kwargs={"org_id": org_id, "db_url": db_url, "as_of": day},
+                queue="metrics",
+            )
+        except Exception:
+            logger.exception(
+                "Failed to chain recommendations after finalize for org=%s day=%s; "
+                "beat backstop will retry",
+                org_id,
+                day,
+            )
+
         return {
             "status": "success",
             "day": day,

--- a/src/dev_health_ops/workers/recommendations_tasks.py
+++ b/src/dev_health_ops/workers/recommendations_tasks.py
@@ -1,13 +1,33 @@
 from __future__ import annotations
 
 import logging
-from datetime import date, datetime, time, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.task_utils import _get_db_url
 
 logger = logging.getLogger(__name__)
+
+
+class RecommendationsTeamFailure(Exception):
+    """Raised when one or more teams fail to evaluate during a scheduled run.
+
+    Surfacing this (instead of swallowing the per-team error and returning
+    success) lets Celery retry the job and lets monitoring alert: a silently
+    skipped team writes no ``fired=False`` tombstone, so stale fired guidance
+    would otherwise linger while the task reported success (CHAOS-2373).
+    """
+
+    def __init__(self, org_id: str, failed_teams: list[str], total_teams: int) -> None:
+        self.org_id = org_id
+        self.failed_teams = failed_teams
+        self.total_teams = total_teams
+        super().__init__(
+            f"Recommendations evaluation failed for {len(failed_teams)}/"
+            f"{total_teams} team(s) in org={org_id}: {failed_teams}"
+        )
+
 
 # Checkpoint metric_type written by run_daily_metrics_finalize_task once all
 # daily-metrics batches for an (org, day) have completed. Recommendations gate
@@ -112,6 +132,7 @@ def _compute_recommendations_for_org(
     db_url: str,
     window: int,
     now: datetime,
+    as_of_day: date,
     team_id: str | None = None,
 ) -> int:
     """Run the RuleEngine for every team in ``org_id`` and persist full state.
@@ -119,6 +140,14 @@ def _compute_recommendations_for_org(
     Persists the *complete* rule state per team (fired recommendations **and**
     explicit ``fired=False`` tombstones for rules that no longer fire) so a
     recovered signal is cleared instead of lingering (CHAOS-2373).
+
+    ``now`` is anchored to the *day after* the finalized partition (``as_of_day``)
+    so the engine derives ``window_end == as_of_day + 1`` and — because the
+    ClickHouse loader treats ``window_end`` as **exclusive** (``day < %(end)s``)
+    — the just-finalized ``as_of_day`` partition is actually *read* rather than
+    skipped (CHAOS-2373 round-2). ``as_of_day`` is passed separately so the
+    readiness gate keys on the finalized partition's checkpoint, not on
+    ``now.date()``.
 
     Returns the number of *fired* recommendations written (tombstones excluded).
     """
@@ -128,11 +157,11 @@ def _compute_recommendations_for_org(
     from dev_health_ops.recommendations.loader import ClickHouseMetricsLoader
     from dev_health_ops.recommendations.snapshot import RecommendationRecord
 
-    if not _daily_metrics_ready(org_id, now.date()):
+    if not _daily_metrics_ready(org_id, as_of_day):
         logger.info(
             "Daily metrics not finalized for org=%s day=%s; skipping recommendations",
             org_id,
-            now.date(),
+            as_of_day,
         )
         return 0
 
@@ -148,6 +177,7 @@ def _compute_recommendations_for_org(
 
         records: list[RecommendationRecord] = []
         fired_count = 0
+        failed_teams: list[str] = []
         for tid in team_ids:
             try:
                 team_records = engine.evaluate_state(
@@ -159,21 +189,36 @@ def _compute_recommendations_for_org(
                     org_id,
                     tid,
                 )
+                failed_teams.append(tid)
                 continue
             records.extend(team_records)
             fired_count += sum(1 for r in team_records if r.fired)
 
+        # Persist the state we DID compute before surfacing the failure, so the
+        # teams that evaluated cleanly get fresh tombstones this run.
         if records:
             sink.write_recommendations(records)
 
         logger.info(
-            "recommendations job: org=%s teams=%d fired=%d rows=%d window=%dd",
+            "recommendations job: org=%s teams=%d failed=%d fired=%d rows=%d window=%dd",
             org_id,
             len(team_ids),
+            len(failed_teams),
             fired_count,
             len(records),
             window,
         )
+
+        # Fail loudly on any per-team failure. A swallowed loader/rule error
+        # writes no fired=False tombstone for that team, so stale fired guidance
+        # would linger while the task reported success and monitoring/retries
+        # saw nothing wrong (CHAOS-2373 round-2). Raising marks the job failed so
+        # Celery retries it and operators can alert on the failure.
+        if failed_teams:
+            raise RecommendationsTeamFailure(
+                org_id=org_id, failed_teams=failed_teams, total_teams=len(team_ids)
+            )
+
         return fired_count
     finally:
         sink.close()
@@ -210,24 +255,33 @@ def run_recommendations_job(
             with recent activity for each org from ClickHouse.
         as_of: ISO date (``YYYY-MM-DD``) of the finalized metrics partition the
             run should evaluate against. The finalize callback passes the exact
-            ``day`` it finalized so the readiness gate, ``window_end`` and the
-            written tombstones all key on that partition rather than wall-clock
-            ``today`` — correct across UTC-midnight finalizes and backfills.
-            When ``None`` (beat backstop), today (UTC) is used.
+            ``day`` it finalized so the readiness gate keys on that partition's
+            checkpoint and the engine's exclusive ``window_end`` is set to
+            ``as_of + 1`` — which *includes* the finalized ``as_of`` partition
+            (the loader filters ``day < window_end``). Correct across
+            UTC-midnight finalizes and backfills. When ``None`` (beat backstop),
+            today (UTC) is used and today's not-yet-finalized partition is
+            naturally excluded.
 
     Returns:
         dict with job status and per-org fired counts.
     """
     db_url = db_url or _get_db_url()
     if as_of:
-        # Anchor evaluation to the finalized partition's end-of-day so the
-        # engine derives window_end == as_of (RuleEngine uses now.date()).
+        # The finalized partition is ``as_of_day``; the readiness gate keys on
+        # it. The engine derives its exclusive ``window_end`` from ``now.date()``
+        # and the loader filters ``day < window_end``, so to *include* the
+        # just-finalized ``as_of_day`` partition we anchor ``now`` to the day
+        # AFTER it (CHAOS-2373 round-2). Anchoring to ``as_of_day`` itself made
+        # ``window_end == as_of_day`` and silently excluded the partition the
+        # finalize had just written.
         as_of_day = date.fromisoformat(as_of)
-        now = datetime(
-            as_of_day.year, as_of_day.month, as_of_day.day, tzinfo=timezone.utc
+        now = datetime.combine(
+            as_of_day + timedelta(days=1), time.min, tzinfo=timezone.utc
         )
     else:
         now = datetime.now(timezone.utc)
+        as_of_day = now.date()
 
     org_ids = [org_id] if org_id else _discover_active_org_ids()
 
@@ -240,6 +294,7 @@ def run_recommendations_job(
                 db_url=db_url,
                 window=window,
                 now=now,
+                as_of_day=as_of_day,
                 team_id=team_id,
             )
             results[oid] = fired

--- a/src/dev_health_ops/workers/recommendations_tasks.py
+++ b/src/dev_health_ops/workers/recommendations_tasks.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from dev_health_ops.workers.celery_app import celery_app
+from dev_health_ops.workers.task_utils import _get_db_url
+
+logger = logging.getLogger(__name__)
+
+
+def _discover_active_org_ids() -> list[str]:
+    """Return the IDs of all active organisations (Postgres source of truth).
+
+    Mirrors how ``dispatch_scheduled_metrics`` scopes work to live orgs. Falls
+    back to ``["default"]`` (single-tenant / community installs) when the
+    organizations table is empty or unavailable.
+    """
+    from dev_health_ops.db import get_postgres_session_sync
+    from dev_health_ops.models.users import Organization
+
+    try:
+        with get_postgres_session_sync() as session:
+            rows = (
+                session.query(Organization.id)
+                .filter(Organization.is_active.is_(True))
+                .all()
+            )
+        org_ids = [str(row[0]) for row in rows]
+    except Exception:
+        logger.exception("Failed to enumerate active organizations")
+        org_ids = []
+
+    return org_ids or ["default"]
+
+
+def _discover_team_ids(client: Any, org_id: str) -> list[str]:
+    """Return team IDs with recent activity for ``org_id`` from ClickHouse.
+
+    Sourced from ``work_item_metrics_daily`` — the same table that feeds the
+    recommendation snapshot signals — so we only evaluate teams that have data.
+    """
+    query = """
+        SELECT DISTINCT team_id
+        FROM work_item_metrics_daily
+        WHERE day >= today() - 30
+          AND team_id != ''
+    """
+    params: dict[str, str] = {}
+    if org_id and org_id != "default":
+        query += " AND org_id = %(org_id)s"
+        params["org_id"] = org_id
+
+    result = client.query(query, parameters=params)
+    return [str(row[0]) for row in (result.result_rows or []) if row[0]]
+
+
+def _compute_recommendations_for_org(
+    org_id: str,
+    db_url: str,
+    window: int,
+    now: datetime,
+    team_id: str | None = None,
+) -> int:
+    """Run the RuleEngine for every team in ``org_id`` and persist results.
+
+    Returns the number of fired recommendations written.
+    """
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+    from dev_health_ops.recommendations import registry as recommendations_registry
+    from dev_health_ops.recommendations.engine import RuleEngine
+    from dev_health_ops.recommendations.loader import (
+        ClickHouseMetricsLoader,
+        recommendation_to_record,
+    )
+    from dev_health_ops.recommendations.snapshot import RecommendationRecord
+
+    sink = ClickHouseMetricsSink(dsn=db_url)
+    try:
+        team_ids = [team_id] if team_id else _discover_team_ids(sink.client, org_id)
+        if not team_ids:
+            logger.info("No teams with recent activity for org_id=%s", org_id)
+            return 0
+
+        loader = ClickHouseMetricsLoader(client=sink.client, org_id=org_id)
+        engine = RuleEngine(registry=recommendations_registry, loader=loader, now=now)
+
+        records: list[RecommendationRecord] = []
+        for tid in team_ids:
+            try:
+                recommendations = engine.evaluate_all(
+                    team_id=tid, window=window, org_id=org_id
+                )
+            except Exception:
+                logger.exception(
+                    "Recommendations evaluation failed for org=%s team=%s",
+                    org_id,
+                    tid,
+                )
+                continue
+            records.extend(recommendation_to_record(rec) for rec in recommendations)
+
+        if records:
+            sink.write_recommendations(records)
+
+        logger.info(
+            "recommendations job: org=%s teams=%d fired=%d window=%dd",
+            org_id,
+            len(team_ids),
+            len(records),
+            window,
+        )
+        return len(records)
+    finally:
+        sink.close()
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=3,
+    queue="metrics",
+    name="dev_health_ops.workers.tasks.run_recommendations_job",
+)
+def run_recommendations_job(
+    self,
+    org_id: str | None = None,
+    db_url: str | None = None,
+    window: int = 14,
+    team_id: str | None = None,
+) -> dict:
+    """Compute rule-based recommendations for every active org + team.
+
+    This is the scheduled live path for ``recommendations_daily`` — without it
+    the table is only ever written by the manual ``dev-hops recommendations
+    compute`` CLI, leaving real orgs' home RankedSignals, the
+    ``recommendations(team, window)`` GraphQL query, and the Operating Review
+    empty (CHAOS-2373).
+
+    Args:
+        org_id: Restrict to a single org. When ``None``, enumerate all active
+            organisations from Postgres.
+        db_url: ClickHouse connection string (defaults to CLICKHOUSE_URI env).
+        window: Evaluation window in days (default 14).
+        team_id: Restrict to a single team. When ``None``, discover all teams
+            with recent activity for each org from ClickHouse.
+
+    Returns:
+        dict with job status and per-org fired counts.
+    """
+    db_url = db_url or _get_db_url()
+    now = datetime.now(timezone.utc)
+
+    org_ids = [org_id] if org_id else _discover_active_org_ids()
+
+    results: dict[str, int] = {}
+    total_fired = 0
+    try:
+        for oid in org_ids:
+            fired = _compute_recommendations_for_org(
+                org_id=oid,
+                db_url=db_url,
+                window=window,
+                now=now,
+                team_id=team_id,
+            )
+            results[oid] = fired
+            total_fired += fired
+    except Exception as exc:
+        logger.exception("Recommendations job failed: %s", exc)
+        raise self.retry(exc=exc, countdown=60 * (2**self.request.retries))
+
+    return {
+        "status": "success",
+        "orgs": len(org_ids),
+        "fired": total_fired,
+        "per_org": results,
+    }

--- a/src/dev_health_ops/workers/recommendations_tasks.py
+++ b/src/dev_health_ops/workers/recommendations_tasks.py
@@ -1,13 +1,64 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import date, datetime, time, timezone
 from typing import Any
 
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.task_utils import _get_db_url
 
 logger = logging.getLogger(__name__)
+
+# Checkpoint metric_type written by run_daily_metrics_finalize_task once all
+# daily-metrics batches for an (org, day) have completed. Recommendations gate
+# on this so a premature beat run never evaluates against partial metric tables.
+_FINALIZE_METRIC_TYPE = "daily_finalize"
+
+
+def _daily_metrics_ready(org_id: str, day: Any) -> bool:
+    """Return False only when daily metrics for ``org_id``/``day`` are *in flight*.
+
+    The race the gate guards against: the partitioned daily-metrics chord
+    (``dispatch_daily_metrics_partitioned``) dispatches batch tasks
+    asynchronously and writes a ``daily_finalize`` checkpoint only once every
+    batch has finished. If recommendations evaluate while that finalize is still
+    RUNNING/FAILED, they read partial metric tables and persist misleading rows
+    for today (CHAOS-2373).
+
+    Semantics:
+
+    * A ``daily_finalize`` checkpoint exists for today but is **not COMPLETED**
+      → metrics are demonstrably mid-flight → **skip** (return ``False``).
+    * No checkpoint, or a COMPLETED checkpoint → **proceed**. (Absence means the
+      chord path is not driving this org today; we have no positive evidence of
+      partial data, and the daily run self-corrects via tombstones.)
+    * The ``"default"`` sentinel and any read error → **proceed** (fail open;
+      a checkpoint glitch must never permanently wedge the pipeline).
+    """
+    from dev_health_ops.db import get_postgres_session_sync
+    from dev_health_ops.metrics.checkpoints import get_checkpoint
+    from dev_health_ops.models.checkpoints import CheckpointStatus
+
+    if org_id == "default":
+        return True
+
+    checkpoint_day = datetime.combine(day, time.min, tzinfo=timezone.utc)
+    try:
+        with get_postgres_session_sync() as session:
+            checkpoint = get_checkpoint(
+                session, org_id, None, _FINALIZE_METRIC_TYPE, checkpoint_day
+            )
+            if checkpoint is None:
+                return True
+            return checkpoint.status == CheckpointStatus.COMPLETED
+    except Exception:
+        logger.exception(
+            "Failed to read daily_finalize checkpoint for org=%s day=%s; "
+            "treating as ready",
+            org_id,
+            day,
+        )
+        return True
 
 
 def _discover_active_org_ids() -> list[str]:
@@ -63,18 +114,27 @@ def _compute_recommendations_for_org(
     now: datetime,
     team_id: str | None = None,
 ) -> int:
-    """Run the RuleEngine for every team in ``org_id`` and persist results.
+    """Run the RuleEngine for every team in ``org_id`` and persist full state.
 
-    Returns the number of fired recommendations written.
+    Persists the *complete* rule state per team (fired recommendations **and**
+    explicit ``fired=False`` tombstones for rules that no longer fire) so a
+    recovered signal is cleared instead of lingering (CHAOS-2373).
+
+    Returns the number of *fired* recommendations written (tombstones excluded).
     """
     from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
     from dev_health_ops.recommendations import registry as recommendations_registry
     from dev_health_ops.recommendations.engine import RuleEngine
-    from dev_health_ops.recommendations.loader import (
-        ClickHouseMetricsLoader,
-        recommendation_to_record,
-    )
+    from dev_health_ops.recommendations.loader import ClickHouseMetricsLoader
     from dev_health_ops.recommendations.snapshot import RecommendationRecord
+
+    if not _daily_metrics_ready(org_id, now.date()):
+        logger.info(
+            "Daily metrics not finalized for org=%s day=%s; skipping recommendations",
+            org_id,
+            now.date(),
+        )
+        return 0
 
     sink = ClickHouseMetricsSink(dsn=db_url)
     try:
@@ -87,9 +147,10 @@ def _compute_recommendations_for_org(
         engine = RuleEngine(registry=recommendations_registry, loader=loader, now=now)
 
         records: list[RecommendationRecord] = []
+        fired_count = 0
         for tid in team_ids:
             try:
-                recommendations = engine.evaluate_all(
+                team_records = engine.evaluate_state(
                     team_id=tid, window=window, org_id=org_id
                 )
             except Exception:
@@ -99,19 +160,21 @@ def _compute_recommendations_for_org(
                     tid,
                 )
                 continue
-            records.extend(recommendation_to_record(rec) for rec in recommendations)
+            records.extend(team_records)
+            fired_count += sum(1 for r in team_records if r.fired)
 
         if records:
             sink.write_recommendations(records)
 
         logger.info(
-            "recommendations job: org=%s teams=%d fired=%d window=%dd",
+            "recommendations job: org=%s teams=%d fired=%d rows=%d window=%dd",
             org_id,
             len(team_ids),
+            fired_count,
             len(records),
             window,
         )
-        return len(records)
+        return fired_count
     finally:
         sink.close()
 
@@ -128,6 +191,7 @@ def run_recommendations_job(
     db_url: str | None = None,
     window: int = 14,
     team_id: str | None = None,
+    as_of: str | None = None,
 ) -> dict:
     """Compute rule-based recommendations for every active org + team.
 
@@ -144,12 +208,26 @@ def run_recommendations_job(
         window: Evaluation window in days (default 14).
         team_id: Restrict to a single team. When ``None``, discover all teams
             with recent activity for each org from ClickHouse.
+        as_of: ISO date (``YYYY-MM-DD``) of the finalized metrics partition the
+            run should evaluate against. The finalize callback passes the exact
+            ``day`` it finalized so the readiness gate, ``window_end`` and the
+            written tombstones all key on that partition rather than wall-clock
+            ``today`` — correct across UTC-midnight finalizes and backfills.
+            When ``None`` (beat backstop), today (UTC) is used.
 
     Returns:
         dict with job status and per-org fired counts.
     """
     db_url = db_url or _get_db_url()
-    now = datetime.now(timezone.utc)
+    if as_of:
+        # Anchor evaluation to the finalized partition's end-of-day so the
+        # engine derives window_end == as_of (RuleEngine uses now.date()).
+        as_of_day = date.fromisoformat(as_of)
+        now = datetime(
+            as_of_day.year, as_of_day.month, as_of_day.day, tzinfo=timezone.utc
+        )
+    else:
+        now = datetime.now(timezone.utc)
 
     org_ids = [org_id] if org_id else _discover_active_org_ids()
 

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -12,6 +12,7 @@ from dev_health_ops.workers.product_tasks import (
     sync_teams_to_analytics,
 )
 from dev_health_ops.workers.queue_monitor import monitor_queue_depths
+from dev_health_ops.workers.recommendations_tasks import run_recommendations_job
 from dev_health_ops.workers.report_scheduler import dispatch_scheduled_reports
 from dev_health_ops.workers.report_task import execute_saved_report
 from dev_health_ops.workers.sync_batch import (
@@ -82,6 +83,7 @@ __all__ = [
     "run_ingest_consumer",
     "run_investment_materialize",
     "run_product_telemetry_consumer",
+    "run_recommendations_job",
     "run_sync_config",
     "run_work_graph_build",
     "run_work_items_sync",

--- a/tests/api/graphql/test_recommendations_resolver.py
+++ b/tests/api/graphql/test_recommendations_resolver.py
@@ -288,6 +288,43 @@ async def test_resolve_recommendations_unknown_severity_falls_back(mock_context)
     assert result[0].severity == Severity.WARNING
 
 
+def test_window_to_dates_caps_read_at_today_plus_one(monkeypatch):
+    """Read cap == utc_today()+1 so the writer's today+1 rows are read same-day.
+
+    Regression for the CHAOS-2373 convention mismatch: the scheduled writer
+    persists ``window_end == as_of_day + 1`` (it anchors ``now = as_of_day + 1``
+    so the loader's exclusive ``day < window_end`` still reads the finalized
+    partition). The resolver previously capped at ``today`` and excluded those
+    freshest rows, leaving recommendations() one finalize-day stale. The cap is
+    now inclusive of ``today + 1``, mirroring filtering.time_window's
+    ``end_day = utc_today() + 1`` so this surface agrees with the home surface.
+    """
+    from datetime import date, timedelta
+
+    from dev_health_ops.api.graphql.models.recommendations import (
+        WindowInput,
+        WindowUnit,
+    )
+    from dev_health_ops.api.graphql.resolvers import recommendations as resolver_mod
+    from dev_health_ops.api.graphql.resolvers.recommendations import _window_to_dates
+
+    today = date(2026, 4, 8)
+    monkeypatch.setattr(resolver_mod, "utc_today", lambda: today)
+
+    # window_end is today + 1 (matches the writer + filtering.time_window).
+    ws_week, we_week = _window_to_dates(WindowInput(value=2, unit=WindowUnit.WEEK))
+    assert we_week == today + timedelta(days=1)
+    # window_start is anchored to *today* (not the bumped cap) so the lookback
+    # span is unchanged: 2 weeks == 14 days.
+    assert ws_week == today - timedelta(days=14)
+
+    # Unit math is preserved across day / week / cycle.
+    ws_day, we_day = _window_to_dates(WindowInput(value=7, unit=WindowUnit.DAY))
+    assert (we_day, ws_day) == (today + timedelta(days=1), today - timedelta(days=7))
+    ws_cyc, we_cyc = _window_to_dates(WindowInput(value=2, unit=WindowUnit.CYCLE))
+    assert (we_cyc, ws_cyc) == (today + timedelta(days=1), today - timedelta(days=28))
+
+
 @pytest.mark.anyio
 async def test_resolve_recommendations_raises_without_client(mock_context):
     """RuntimeError is raised when context.client is None (misconfigured server)."""

--- a/tests/test_parallel_metrics.py
+++ b/tests/test_parallel_metrics.py
@@ -221,11 +221,17 @@ class TestRunDailyMetricsBatch:
 
 
 class TestRunDailyMetricsFinalizeTask:
+    @patch("dev_health_ops.workers.recommendations_tasks.run_recommendations_job")
     @patch("dev_health_ops.workers.metrics_partitioned._invalidate_metrics_cache")
     @patch("asyncio.run")
     @patch("dev_health_ops.db.get_postgres_session_sync")
     def test_calls_finalize_and_invalidates_cache(
-        self, mock_get_session, mock_asyncio_run, mock_invalidate, db_session
+        self,
+        mock_get_session,
+        mock_asyncio_run,
+        mock_invalidate,
+        mock_recommendations,
+        db_session,
     ):
         from dev_health_ops.workers.metrics_partitioned import (
             run_daily_metrics_finalize_task,
@@ -249,6 +255,19 @@ class TestRunDailyMetricsFinalizeTask:
         assert result["status"] == "success"
         mock_asyncio_run.assert_called_once()
         mock_invalidate.assert_called_once_with("2025-01-15", "test-org")
+
+        # Completion-gated trigger (CHAOS-2373): once finalize succeeds, the
+        # recommendations job is chained for the same org with the same db_url.
+        mock_recommendations.apply_async.assert_called_once()
+        chained_kwargs = mock_recommendations.apply_async.call_args.kwargs
+        # as_of carries the exact finalized partition day (not wall-clock today)
+        # so the gate + window_end key on the right partition across UTC midnight.
+        assert chained_kwargs["kwargs"] == {
+            "org_id": "test-org",
+            "db_url": "clickhouse://fake",
+            "as_of": "2025-01-15",
+        }
+        assert chained_kwargs["queue"] == "metrics"
 
         checkpoint_day = datetime.combine(
             date(2025, 1, 15), time.min, tzinfo=timezone.utc

--- a/tests/test_recommendations_task.py
+++ b/tests/test_recommendations_task.py
@@ -12,31 +12,46 @@ from __future__ import annotations
 from datetime import date, datetime, timezone
 from unittest.mock import MagicMock, patch
 
-from dev_health_ops.recommendations.schema import EvidenceRef, Recommendation
+from dev_health_ops.recommendations.snapshot import RecommendationRecord
 
 
-def _make_recommendation(team_id: str = "team-1") -> Recommendation:
-    return Recommendation(
-        rule_id="saturation",
+def _fired_record(team_id: str = "team-1") -> RecommendationRecord:
+    """A fired RecommendationRecord (engine.evaluate_state output for a hit)."""
+    return RecommendationRecord(
         team_id=team_id,
         org_id="org-1",
-        computed_at=datetime(2025, 1, 15, tzinfo=timezone.utc),
+        rule_id="saturation",
+        rule_version="1.0.0",
         window_start=date(2025, 1, 1),
         window_end=date(2025, 1, 15),
+        fired=True,
         severity="warning",
         title="WIP saturation rising",
         rationale="WIP per engineer trending up.",
         success_criterion="WIP per engineer < 3",
-        evidence=(
-            EvidenceRef(
-                team_id=team_id,
-                metric_table="work_item_metrics_daily",
-                window_start=date(2025, 1, 1),
-                window_end=date(2025, 1, 15),
-                field="wip_by_day",
-                value=4.0,
-            ),
-        ),
+        evidence_json="[]",
+        computed_at=datetime(2025, 1, 15, tzinfo=timezone.utc),
+    )
+
+
+def _tombstone_record(
+    rule_id: str = "thrash", team_id: str = "team-1"
+) -> RecommendationRecord:
+    """A non-fired RecommendationRecord (tombstone for a recovered/quiet rule)."""
+    return RecommendationRecord(
+        team_id=team_id,
+        org_id="org-1",
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        window_start=date(2025, 1, 1),
+        window_end=date(2025, 1, 15),
+        fired=False,
+        severity="warning",
+        title="",
+        rationale="",
+        success_criterion="resolve",
+        evidence_json="[]",
+        computed_at=datetime(2025, 1, 15, tzinfo=timezone.utc),
     )
 
 
@@ -62,53 +77,111 @@ def test_beat_schedule_entry_exists_on_metrics_queue():
     assert entry["options"]["queue"] == "metrics"
 
 
+@patch("dev_health_ops.workers.recommendations_tasks._daily_metrics_ready")
 @patch("dev_health_ops.workers.recommendations_tasks._get_db_url")
 @patch("dev_health_ops.workers.recommendations_tasks._discover_team_ids")
 @patch("dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink")
 @patch("dev_health_ops.recommendations.loader.ClickHouseMetricsLoader")
 @patch("dev_health_ops.recommendations.engine.RuleEngine")
-def test_task_writes_engine_output_via_sink(
+def test_task_writes_full_state_via_sink(
     mock_engine_cls,
     _mock_loader_cls,
     mock_sink_cls,
     mock_discover_teams,
     mock_get_db_url,
+    mock_ready,
 ):
-    """The engine output for each team must be persisted via write_recommendations."""
+    """Full per-team state (fired + tombstones) must be persisted; only fired counted."""
     from dev_health_ops.workers.recommendations_tasks import run_recommendations_job
 
+    mock_ready.return_value = True
     mock_get_db_url.return_value = "clickhouse://fake"
     mock_discover_teams.return_value = ["team-1", "team-2"]
 
     mock_sink = MagicMock()
     mock_sink_cls.return_value = mock_sink
 
-    rec = _make_recommendation()
+    # Each team: one fired record + one tombstone (the full-state contract).
     mock_engine = MagicMock()
-    mock_engine.evaluate_all.return_value = [rec]
+    mock_engine.evaluate_state.return_value = [
+        _fired_record(),
+        _tombstone_record(),
+    ]
     mock_engine_cls.return_value = mock_engine
 
     result = run_recommendations_job.run(org_id="org-1", window=14)
 
-    # Engine evaluated each discovered team over the requested window.
-    assert mock_engine.evaluate_all.call_count == 2
-    for call in mock_engine.evaluate_all.call_args_list:
+    # Engine evaluated full state for each discovered team over the window.
+    assert mock_engine.evaluate_state.call_count == 2
+    assert mock_engine.evaluate_all.call_count == 0  # no fired-only path anymore
+    for call in mock_engine.evaluate_state.call_args_list:
         assert call.kwargs["window"] == 14
         assert call.kwargs["org_id"] == "org-1"
 
-    # The fired recommendations were written through the sink (the wiring seam).
+    # The full state (fired AND tombstones) was written through the sink.
     mock_sink.write_recommendations.assert_called_once()
     written = mock_sink.write_recommendations.call_args.args[0]
-    # One record per team (2 teams × 1 fired rec each).
-    assert len(written) == 2
-    # Records are RecommendationRecords carrying the engine output's title.
-    assert all(r.title == "WIP saturation rising" for r in written)
-    assert all(r.fired is True for r in written)
+    # 2 teams x (1 fired + 1 tombstone) = 4 rows.
+    assert len(written) == 4
+    assert sum(1 for r in written if r.fired) == 2
+    assert sum(1 for r in written if not r.fired) == 2
+    fired_titles = {r.title for r in written if r.fired}
+    assert fired_titles == {"WIP saturation rising"}
     mock_sink.close.assert_called_once()
 
     assert result["status"] == "success"
+    # Return value counts FIRED only (tombstones are not "fired" recommendations).
     assert result["fired"] == 2
     assert result["per_org"] == {"org-1": 2}
+
+
+@patch("dev_health_ops.workers.recommendations_tasks._compute_recommendations_for_org")
+@patch("dev_health_ops.workers.recommendations_tasks._get_db_url")
+def test_as_of_anchors_evaluation_to_finalized_partition(
+    mock_get_db_url,
+    mock_compute,
+):
+    """as_of pins the engine 'now' (and gate) to the finalized day, not today."""
+    from dev_health_ops.workers.recommendations_tasks import run_recommendations_job
+
+    mock_get_db_url.return_value = "clickhouse://fake"
+    mock_compute.return_value = 0
+
+    run_recommendations_job.run(org_id="org-1", as_of="2025-01-15")
+
+    mock_compute.assert_called_once()
+    passed_now = mock_compute.call_args.kwargs["now"]
+    # now is anchored to the finalized partition day (UTC), so window_end == it.
+    assert passed_now == datetime(2025, 1, 15, tzinfo=timezone.utc)
+    assert passed_now.date() == date(2025, 1, 15)
+
+
+@patch("dev_health_ops.workers.recommendations_tasks._daily_metrics_ready")
+@patch("dev_health_ops.workers.recommendations_tasks._get_db_url")
+@patch("dev_health_ops.workers.recommendations_tasks._discover_team_ids")
+@patch("dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink")
+def test_task_skips_when_daily_metrics_not_ready(
+    mock_sink_cls,
+    mock_discover_teams,
+    mock_get_db_url,
+    mock_ready,
+):
+    """When daily metrics for the org/day are mid-flight, the job must not evaluate."""
+    from dev_health_ops.workers.recommendations_tasks import run_recommendations_job
+
+    mock_ready.return_value = False
+    mock_get_db_url.return_value = "clickhouse://fake"
+    mock_sink = MagicMock()
+    mock_sink_cls.return_value = mock_sink
+
+    result = run_recommendations_job.run(org_id="org-pending", window=14)
+
+    # No teams discovered, no sink opened, nothing written: a clean skip.
+    mock_discover_teams.assert_not_called()
+    mock_sink_cls.assert_not_called()
+    mock_sink.write_recommendations.assert_not_called()
+    assert result["fired"] == 0
+    assert result["per_org"] == {"org-pending": 0}
 
 
 @patch("dev_health_ops.workers.recommendations_tasks._get_db_url")
@@ -135,6 +208,7 @@ def test_task_enumerates_active_orgs_when_org_not_pinned(
     assert result["per_org"] == {"org-a": 3, "org-b": 5}
 
 
+@patch("dev_health_ops.workers.recommendations_tasks._daily_metrics_ready")
 @patch("dev_health_ops.workers.recommendations_tasks._get_db_url")
 @patch("dev_health_ops.workers.recommendations_tasks._discover_team_ids")
 @patch("dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink")
@@ -146,10 +220,12 @@ def test_no_teams_skips_write(
     mock_sink_cls,
     mock_discover_teams,
     mock_get_db_url,
+    mock_ready,
 ):
     """When an org has no active teams, the sink write is skipped (no empty rows)."""
     from dev_health_ops.workers.recommendations_tasks import run_recommendations_job
 
+    mock_ready.return_value = True
     mock_get_db_url.return_value = "clickhouse://fake"
     mock_discover_teams.return_value = []
     mock_sink = MagicMock()
@@ -161,3 +237,69 @@ def test_no_teams_skips_write(
     mock_sink.write_recommendations.assert_not_called()
     mock_sink.close.assert_called_once()
     assert result["fired"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Readiness gate: _daily_metrics_ready semantics
+# ---------------------------------------------------------------------------
+
+
+def test_daily_metrics_ready_default_org_is_always_ready():
+    """The community/single-tenant 'default' sentinel never gates."""
+    from dev_health_ops.workers.recommendations_tasks import _daily_metrics_ready
+
+    assert _daily_metrics_ready("default", date(2026, 4, 8)) is True
+
+
+def test_daily_metrics_ready_proceeds_when_no_checkpoint():
+    """Absent finalize checkpoint -> proceed (chord path not driving this org)."""
+    from dev_health_ops.workers import recommendations_tasks
+
+    with (
+        patch("dev_health_ops.metrics.checkpoints.get_checkpoint", return_value=None),
+        patch("dev_health_ops.db.get_postgres_session_sync") as mock_session,
+    ):
+        mock_session.return_value.__enter__.return_value = MagicMock()
+        ready = recommendations_tasks._daily_metrics_ready("org-x", date(2026, 4, 8))
+
+    assert ready is True
+
+
+def test_daily_metrics_ready_blocks_when_finalize_running():
+    """A RUNNING finalize checkpoint -> metrics mid-flight -> skip."""
+    from dev_health_ops.metrics.checkpoints import CheckpointStatus
+    from dev_health_ops.workers import recommendations_tasks
+
+    checkpoint = MagicMock()
+    checkpoint.status = CheckpointStatus.RUNNING
+
+    with (
+        patch(
+            "dev_health_ops.metrics.checkpoints.get_checkpoint", return_value=checkpoint
+        ),
+        patch("dev_health_ops.db.get_postgres_session_sync") as mock_session,
+    ):
+        mock_session.return_value.__enter__.return_value = MagicMock()
+        ready = recommendations_tasks._daily_metrics_ready("org-x", date(2026, 4, 8))
+
+    assert ready is False
+
+
+def test_daily_metrics_ready_proceeds_when_finalize_completed():
+    """A COMPLETED finalize checkpoint -> metrics fresh -> proceed."""
+    from dev_health_ops.metrics.checkpoints import CheckpointStatus
+    from dev_health_ops.workers import recommendations_tasks
+
+    checkpoint = MagicMock()
+    checkpoint.status = CheckpointStatus.COMPLETED
+
+    with (
+        patch(
+            "dev_health_ops.metrics.checkpoints.get_checkpoint", return_value=checkpoint
+        ),
+        patch("dev_health_ops.db.get_postgres_session_sync") as mock_session,
+    ):
+        mock_session.return_value.__enter__.return_value = MagicMock()
+        ready = recommendations_tasks._daily_metrics_ready("org-x", date(2026, 4, 8))
+
+    assert ready is True

--- a/tests/test_recommendations_task.py
+++ b/tests/test_recommendations_task.py
@@ -137,11 +137,18 @@ def test_task_writes_full_state_via_sink(
 
 @patch("dev_health_ops.workers.recommendations_tasks._compute_recommendations_for_org")
 @patch("dev_health_ops.workers.recommendations_tasks._get_db_url")
-def test_as_of_anchors_evaluation_to_finalized_partition(
+def test_as_of_anchors_window_to_include_finalized_partition(
     mock_get_db_url,
     mock_compute,
 ):
-    """as_of pins the engine 'now' (and gate) to the finalized day, not today."""
+    """as_of must make window_end == as_of + 1 so the finalized day is *read*.
+
+    The ClickHouse loader filters ``day < window_end`` (exclusive end) and the
+    engine derives ``window_end == now.date()``. Anchoring ``now`` to the day
+    AFTER the finalized partition is the only way the just-finalized ``as_of``
+    partition is actually included in the evaluation window (CHAOS-2373 round-2).
+    The readiness gate, however, must still key on the finalized ``as_of`` day.
+    """
     from dev_health_ops.workers.recommendations_tasks import run_recommendations_job
 
     mock_get_db_url.return_value = "clickhouse://fake"
@@ -151,9 +158,73 @@ def test_as_of_anchors_evaluation_to_finalized_partition(
 
     mock_compute.assert_called_once()
     passed_now = mock_compute.call_args.kwargs["now"]
-    # now is anchored to the finalized partition day (UTC), so window_end == it.
-    assert passed_now == datetime(2025, 1, 15, tzinfo=timezone.utc)
-    assert passed_now.date() == date(2025, 1, 15)
+    passed_as_of = mock_compute.call_args.kwargs["as_of_day"]
+
+    # now is the day AFTER the finalized partition, so the engine's exclusive
+    # window_end (= now.date()) is 2025-01-16 and the window [start, 2025-01-16)
+    # INCLUDES the finalized 2025-01-15 partition.
+    assert passed_now == datetime(2025, 1, 16, tzinfo=timezone.utc)
+    assert passed_now.date() == date(2025, 1, 16)
+    # The readiness gate still keys on the finalized partition itself.
+    assert passed_as_of == date(2025, 1, 15)
+
+
+@patch("dev_health_ops.workers.recommendations_tasks._daily_metrics_ready")
+@patch("dev_health_ops.workers.recommendations_tasks._get_db_url")
+@patch("dev_health_ops.workers.recommendations_tasks._discover_team_ids")
+@patch("dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink")
+@patch("dev_health_ops.recommendations.loader.ClickHouseMetricsLoader")
+@patch("dev_health_ops.recommendations.engine.RuleEngine")
+def test_finalized_partition_is_inside_loader_window(
+    mock_engine_cls,
+    _mock_loader_cls,
+    mock_sink_cls,
+    mock_discover_teams,
+    mock_get_db_url,
+    mock_ready,
+):
+    """End-to-end seam: the engine's window_end must exceed the finalized day.
+
+    Drives the real ``_compute_recommendations_for_org`` (via the task) with a
+    fake engine and asserts ``window_end`` (= now.date()) is strictly greater
+    than the finalized ``as_of`` partition. Because the loader treats
+    ``window_end`` as exclusive, ``as_of`` falls *inside* ``[start, window_end)``.
+    """
+    from dev_health_ops.workers import recommendations_tasks
+    from dev_health_ops.workers.recommendations_tasks import run_recommendations_job
+
+    mock_ready.return_value = True
+    mock_get_db_url.return_value = "clickhouse://fake"
+    mock_discover_teams.return_value = ["team-1"]
+    mock_sink_cls.return_value = MagicMock()
+
+    captured: dict = {}
+
+    def _capture_state(*, team_id, window, org_id):
+        # Recreate the engine's window math to assert the contract.
+        from datetime import timedelta
+
+        now = mock_engine_cls.call_args.kwargs["now"]
+        window_end = now.date()
+        window_start = window_end - timedelta(days=window)
+        captured["window_start"] = window_start
+        captured["window_end"] = window_end
+        return []
+
+    mock_engine = MagicMock()
+    mock_engine.evaluate_state.side_effect = _capture_state
+    mock_engine_cls.return_value = mock_engine
+
+    run_recommendations_job.run(org_id="org-1", window=14, as_of="2025-01-15")
+
+    as_of = date(2025, 1, 15)
+    # The finalized partition must be < the exclusive window_end (i.e. inside).
+    assert captured["window_end"] > as_of
+    assert captured["window_start"] <= as_of < captured["window_end"]
+    # And the gate was consulted with the finalized partition, not now.date().
+    assert mock_ready.call_args.args == ("org-1", as_of)
+    # Silence unused-import lint for the module handle used for patching paths.
+    assert recommendations_tasks.run_recommendations_job is run_recommendations_job
 
 
 @patch("dev_health_ops.workers.recommendations_tasks._daily_metrics_ready")
@@ -237,6 +308,98 @@ def test_no_teams_skips_write(
     mock_sink.write_recommendations.assert_not_called()
     mock_sink.close.assert_called_once()
     assert result["fired"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-team failure must surface (fail loudly) — not report success silently
+# ---------------------------------------------------------------------------
+
+
+@patch("dev_health_ops.workers.recommendations_tasks._daily_metrics_ready")
+@patch("dev_health_ops.workers.recommendations_tasks._discover_team_ids")
+@patch("dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink")
+@patch("dev_health_ops.recommendations.loader.ClickHouseMetricsLoader")
+@patch("dev_health_ops.recommendations.engine.RuleEngine")
+def test_per_team_failure_raises_so_job_retries(
+    mock_engine_cls,
+    _mock_loader_cls,
+    mock_sink_cls,
+    mock_discover_teams,
+    mock_ready,
+):
+    """A team that raises must mark the *org* compute as failed, not succeed.
+
+    Previously the per-team exception was swallowed and the task still reported
+    success — leaving the failed team's stale fired rows visible with no
+    tombstone written, invisible to monitoring/retries (CHAOS-2373 round-2).
+    """
+    import pytest
+
+    from dev_health_ops.workers.recommendations_tasks import (
+        RecommendationsTeamFailure,
+        _compute_recommendations_for_org,
+    )
+
+    mock_ready.return_value = True
+    mock_discover_teams.return_value = ["team-ok", "team-bad"]
+    mock_sink = MagicMock()
+    mock_sink_cls.return_value = mock_sink
+
+    mock_engine = MagicMock()
+    # team-ok evaluates cleanly; team-bad raises (transient loader/rule error).
+    mock_engine.evaluate_state.side_effect = [
+        [_fired_record("team-ok"), _tombstone_record(team_id="team-ok")],
+        RuntimeError("clickhouse timeout"),
+    ]
+    mock_engine_cls.return_value = mock_engine
+
+    with pytest.raises(RecommendationsTeamFailure) as excinfo:
+        _compute_recommendations_for_org(
+            org_id="org-1",
+            db_url="clickhouse://fake",
+            window=14,
+            now=datetime(2025, 1, 16, tzinfo=timezone.utc),
+            as_of_day=date(2025, 1, 15),
+        )
+
+    # The failure names the bad team and the org so operators can alert on it.
+    assert excinfo.value.failed_teams == ["team-bad"]
+    assert excinfo.value.org_id == "org-1"
+    assert excinfo.value.total_teams == 2
+    # State for the team that DID evaluate is still persisted before raising.
+    mock_sink.write_recommendations.assert_called_once()
+    written = mock_sink.write_recommendations.call_args.args[0]
+    assert {r.team_id for r in written} == {"team-ok"}
+    # Sink is always closed, even on the failure path.
+    mock_sink.close.assert_called_once()
+
+
+@patch("dev_health_ops.workers.recommendations_tasks._compute_recommendations_for_org")
+@patch("dev_health_ops.workers.recommendations_tasks._get_db_url")
+@patch("dev_health_ops.workers.recommendations_tasks._discover_active_org_ids")
+def test_task_retries_when_an_org_compute_fails(
+    mock_discover_orgs,
+    mock_get_db_url,
+    mock_compute,
+):
+    """A failed org compute must trigger Celery retry, never a 'success' return."""
+    import pytest
+    from celery.exceptions import Retry
+
+    from dev_health_ops.workers.recommendations_tasks import (
+        RecommendationsTeamFailure,
+        run_recommendations_job,
+    )
+
+    mock_get_db_url.return_value = "clickhouse://fake"
+    mock_discover_orgs.return_value = ["org-a"]
+    mock_compute.side_effect = RecommendationsTeamFailure(
+        org_id="org-a", failed_teams=["team-bad"], total_teams=2
+    )
+
+    # eager mode: self.retry raises celery Retry rather than returning success.
+    with pytest.raises(Retry):
+        run_recommendations_job.apply(args=(), kwargs={}, throw=True).get()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recommendations_task.py
+++ b/tests/test_recommendations_task.py
@@ -1,0 +1,163 @@
+"""Unit tests for the scheduled recommendations worker task (CHAOS-2373).
+
+These prove the *seam* that wires the live path for ``recommendations_daily``:
+the task is registered + on the metrics queue + scheduled in beat, and it runs
+the ``RuleEngine`` per active org/team then writes via
+``sink.write_recommendations``. No live ClickHouse / Postgres is touched —
+every collaborator (loader, engine, sink, org/team discovery) is mocked.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from dev_health_ops.recommendations.schema import EvidenceRef, Recommendation
+
+
+def _make_recommendation(team_id: str = "team-1") -> Recommendation:
+    return Recommendation(
+        rule_id="saturation",
+        team_id=team_id,
+        org_id="org-1",
+        computed_at=datetime(2025, 1, 15, tzinfo=timezone.utc),
+        window_start=date(2025, 1, 1),
+        window_end=date(2025, 1, 15),
+        severity="warning",
+        title="WIP saturation rising",
+        rationale="WIP per engineer trending up.",
+        success_criterion="WIP per engineer < 3",
+        evidence=(
+            EvidenceRef(
+                team_id=team_id,
+                metric_table="work_item_metrics_daily",
+                window_start=date(2025, 1, 1),
+                window_end=date(2025, 1, 15),
+                field="wip_by_day",
+                value=4.0,
+            ),
+        ),
+    )
+
+
+def test_task_is_registered_on_metrics_queue():
+    """The task must be importable and registered with Celery (live path exists)."""
+    from dev_health_ops.workers import tasks
+    from dev_health_ops.workers.celery_app import celery_app
+    from dev_health_ops.workers.recommendations_tasks import run_recommendations_job
+
+    assert "run_recommendations_job" in tasks.__all__
+    name = "dev_health_ops.workers.tasks.run_recommendations_job"
+    assert name in celery_app.tasks
+    assert run_recommendations_job.name == name
+    assert run_recommendations_job.queue == "metrics"
+
+
+def test_beat_schedule_entry_exists_on_metrics_queue():
+    """A daily beat entry must exist so real orgs get recommendations."""
+    from dev_health_ops.workers.config import beat_schedule
+
+    entry = beat_schedule["run-recommendations"]
+    assert entry["task"] == "dev_health_ops.workers.tasks.run_recommendations_job"
+    assert entry["options"]["queue"] == "metrics"
+
+
+@patch("dev_health_ops.workers.recommendations_tasks._get_db_url")
+@patch("dev_health_ops.workers.recommendations_tasks._discover_team_ids")
+@patch("dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink")
+@patch("dev_health_ops.recommendations.loader.ClickHouseMetricsLoader")
+@patch("dev_health_ops.recommendations.engine.RuleEngine")
+def test_task_writes_engine_output_via_sink(
+    mock_engine_cls,
+    _mock_loader_cls,
+    mock_sink_cls,
+    mock_discover_teams,
+    mock_get_db_url,
+):
+    """The engine output for each team must be persisted via write_recommendations."""
+    from dev_health_ops.workers.recommendations_tasks import run_recommendations_job
+
+    mock_get_db_url.return_value = "clickhouse://fake"
+    mock_discover_teams.return_value = ["team-1", "team-2"]
+
+    mock_sink = MagicMock()
+    mock_sink_cls.return_value = mock_sink
+
+    rec = _make_recommendation()
+    mock_engine = MagicMock()
+    mock_engine.evaluate_all.return_value = [rec]
+    mock_engine_cls.return_value = mock_engine
+
+    result = run_recommendations_job.run(org_id="org-1", window=14)
+
+    # Engine evaluated each discovered team over the requested window.
+    assert mock_engine.evaluate_all.call_count == 2
+    for call in mock_engine.evaluate_all.call_args_list:
+        assert call.kwargs["window"] == 14
+        assert call.kwargs["org_id"] == "org-1"
+
+    # The fired recommendations were written through the sink (the wiring seam).
+    mock_sink.write_recommendations.assert_called_once()
+    written = mock_sink.write_recommendations.call_args.args[0]
+    # One record per team (2 teams × 1 fired rec each).
+    assert len(written) == 2
+    # Records are RecommendationRecords carrying the engine output's title.
+    assert all(r.title == "WIP saturation rising" for r in written)
+    assert all(r.fired is True for r in written)
+    mock_sink.close.assert_called_once()
+
+    assert result["status"] == "success"
+    assert result["fired"] == 2
+    assert result["per_org"] == {"org-1": 2}
+
+
+@patch("dev_health_ops.workers.recommendations_tasks._get_db_url")
+@patch("dev_health_ops.workers.recommendations_tasks._discover_active_org_ids")
+@patch("dev_health_ops.workers.recommendations_tasks._compute_recommendations_for_org")
+def test_task_enumerates_active_orgs_when_org_not_pinned(
+    mock_compute,
+    mock_discover_orgs,
+    mock_get_db_url,
+):
+    """With no org_id, the task fans out over every active org from Postgres."""
+    from dev_health_ops.workers.recommendations_tasks import run_recommendations_job
+
+    mock_get_db_url.return_value = "clickhouse://fake"
+    mock_discover_orgs.return_value = ["org-a", "org-b"]
+    mock_compute.side_effect = [3, 5]
+
+    result = run_recommendations_job.run()
+
+    mock_discover_orgs.assert_called_once()
+    assert mock_compute.call_count == 2
+    assert result["orgs"] == 2
+    assert result["fired"] == 8
+    assert result["per_org"] == {"org-a": 3, "org-b": 5}
+
+
+@patch("dev_health_ops.workers.recommendations_tasks._get_db_url")
+@patch("dev_health_ops.workers.recommendations_tasks._discover_team_ids")
+@patch("dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink")
+@patch("dev_health_ops.recommendations.loader.ClickHouseMetricsLoader")
+@patch("dev_health_ops.recommendations.engine.RuleEngine")
+def test_no_teams_skips_write(
+    mock_engine_cls,
+    _mock_loader_cls,
+    mock_sink_cls,
+    mock_discover_teams,
+    mock_get_db_url,
+):
+    """When an org has no active teams, the sink write is skipped (no empty rows)."""
+    from dev_health_ops.workers.recommendations_tasks import run_recommendations_job
+
+    mock_get_db_url.return_value = "clickhouse://fake"
+    mock_discover_teams.return_value = []
+    mock_sink = MagicMock()
+    mock_sink_cls.return_value = mock_sink
+
+    result = run_recommendations_job.run(org_id="org-empty")
+
+    mock_engine_cls.assert_not_called()
+    mock_sink.write_recommendations.assert_not_called()
+    mock_sink.close.assert_called_once()
+    assert result["fired"] == 0

--- a/tests/test_recommendations_tombstone.py
+++ b/tests/test_recommendations_tombstone.py
@@ -1,0 +1,260 @@
+"""Tombstone / resolution regression tests for recommendations (CHAOS-2373).
+
+The scheduled recommendations job previously persisted *only* fired
+recommendations. The GraphQL readers ``argMax(fired, computed_at)`` per
+``(org_id, team_id, rule_id, window_end)`` and keep ``HAVING latest_fired =
+true``. Because ``window_end`` is part of the read key and each run writes
+``window_end = today``, a rule that fired yesterday but no longer fires today
+left a stale ``fired=true`` row at yesterday's ``window_end`` that kept
+surfacing resolved guidance until it aged out.
+
+Two layers of fix are exercised here:
+
+* ``RuleEngine.evaluate_state`` returns the *full* rule state — fired rows AND
+  explicit ``fired=False`` tombstones — so a recovered signal is written, not
+  silently omitted (pure unit test, no DB).
+* The reader SQL collapses to the *latest* ``window_end`` per
+  ``(org, team, rule)`` so a newer no-fire as-of supersedes an older fired row
+  (live-ClickHouse test, opt-in via ``pytest -m clickhouse``).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date, datetime, timezone
+
+import pytest
+
+# Import connectors first to break the providers._base <-> connectors circular
+# import that otherwise ERRORs collection of isolated processor/engine imports
+# (matches the CHAOS-2370 guard).
+import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.recommendations.snapshot import (
+    MetricsSnapshot,
+    RecommendationRecord,
+)
+
+# ---------------------------------------------------------------------------
+# Unit: evaluate_state writes a tombstone for every non-firing rule
+# ---------------------------------------------------------------------------
+
+
+class _StubLoader:
+    """MetricsLoader stub returning an all-``None``/empty snapshot (no rule fires)."""
+
+    def __init__(self, snapshot: MetricsSnapshot) -> None:
+        self._snapshot = snapshot
+
+    def load_team_metrics_window(
+        self,
+        team_id: str,
+        org_id: str,
+        window_start: date,
+        window_end: date,
+    ) -> MetricsSnapshot:
+        return self._snapshot
+
+
+def _empty_snapshot(team_id: str, org_id: str, ws: date, we: date) -> MetricsSnapshot:
+    return MetricsSnapshot(
+        team_id=team_id,
+        org_id=org_id,
+        window_start=ws,
+        window_end=we,
+        wip_by_day=[],
+        throughput_by_cycle=[],
+        review_latency_p75_hours=None,
+        reviewer_gini=None,
+        rework_churn_ratio=None,
+        after_hours_ratio=None,
+        cycle_time_by_day=[],
+        hotspot_complexity_delta=None,
+        hotspot_churn_overlap=None,
+    )
+
+
+def test_evaluate_state_emits_tombstone_for_every_rule_when_none_fire():
+    """No rule fires -> one fired=False record per registered rule (no gaps)."""
+    from dev_health_ops.recommendations import registry
+    from dev_health_ops.recommendations.engine import RuleEngine
+    from dev_health_ops.recommendations.rules import RULE_EVALUATORS
+
+    now = datetime(2026, 4, 8, 2, 0, 0, tzinfo=timezone.utc)
+    ws = date(2026, 3, 25)
+    snapshot = _empty_snapshot("team-1", "org-1", ws, now.date())
+    engine = RuleEngine(registry=registry, loader=_StubLoader(snapshot), now=now)
+
+    records = engine.evaluate_state(team_id="team-1", window=14, org_id="org-1")
+
+    # Exactly one record per registered rule, all non-fired tombstones.
+    assert {r.rule_id for r in records} == set(RULE_EVALUATORS)
+    assert len(records) == len(RULE_EVALUATORS)
+    assert all(r.fired is False for r in records)
+    # Tombstones share the run's computed_at + window_end (one consistent batch).
+    assert all(r.computed_at == now for r in records)
+    assert all(r.window_end == now.date() for r in records)
+    # Registry metadata is carried so the row is self-describing.
+    sat = next(r for r in records if r.rule_id == "saturation")
+    assert sat.title == registry.get_rule("saturation").title
+    assert sat.evidence_json == "[]"
+
+
+def test_evaluate_state_mixes_fired_and_tombstones():
+    """A firing rule yields fired=True; the rest yield fired=False, no gaps."""
+    from dev_health_ops.recommendations import registry
+    from dev_health_ops.recommendations.engine import RuleEngine
+    from dev_health_ops.recommendations.rules import RULE_EVALUATORS
+    from dev_health_ops.recommendations.schema import Recommendation
+
+    now = datetime(2026, 4, 8, 2, 0, 0, tzinfo=timezone.utc)
+    ws = date(2026, 3, 25)
+    snapshot = _empty_snapshot("team-1", "org-1", ws, now.date())
+
+    fired_rec = Recommendation(
+        rule_id="saturation",
+        team_id="team-1",
+        org_id="org-1",
+        computed_at=now,
+        window_start=ws,
+        window_end=now.date(),
+        severity="warning",
+        title="WIP saturation rising",
+        rationale="WIP up.",
+        success_criterion="WIP < 3",
+        evidence=(),
+    )
+    # Force only 'saturation' to fire; all other evaluators return None.
+    evaluators = {
+        rid: (lambda s, n: fired_rec) if rid == "saturation" else (lambda s, n: None)
+        for rid in RULE_EVALUATORS
+    }
+    engine = RuleEngine(
+        registry=registry, loader=_StubLoader(snapshot), now=now, evaluators=evaluators
+    )
+
+    records = engine.evaluate_state(team_id="team-1", window=14, org_id="org-1")
+
+    by_rule = {r.rule_id: r for r in records}
+    assert set(by_rule) == set(RULE_EVALUATORS)
+    assert by_rule["saturation"].fired is True
+    assert by_rule["saturation"].title == "WIP saturation rising"
+    assert all(r.fired is False for rid, r in by_rule.items() if rid != "saturation")
+
+
+# ---------------------------------------------------------------------------
+# Live ClickHouse: a newer no-fire as-of supersedes an older fired row
+# ---------------------------------------------------------------------------
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+_live = pytest.mark.skipif(
+    not CLICKHOUSE_URI,
+    reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/default)",
+)
+
+
+def _record(
+    *,
+    team_id: str,
+    org_id: str,
+    rule_id: str,
+    window_end: date,
+    fired: bool,
+    computed_at: datetime,
+) -> RecommendationRecord:
+    return RecommendationRecord(
+        team_id=team_id,
+        org_id=org_id,
+        rule_id=rule_id,
+        rule_version="1.0.0",
+        window_start=window_end,
+        window_end=window_end,
+        fired=fired,
+        severity="warning",
+        title="Saturation" if fired else "",
+        rationale="fired" if fired else "",
+        success_criterion="resolve",
+        evidence_json="[]",
+        computed_at=computed_at,
+    )
+
+
+@pytest.mark.clickhouse
+@_live
+def test_newer_nofire_supersedes_older_fired_row():
+    """A fired row on day1 is cleared once day2 writes a fired=False tombstone.
+
+    Drives the *actual* resolver SQL against live ClickHouse — no mocking of
+    the read path — so the two-stage (latest-window_end) collapse is proven.
+    """
+    from dev_health_ops.api.graphql.resolvers.recommendations import (
+        _RECOMMENDATIONS_SQL,
+    )
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+    org_id = f"test-chaos-2373-{uuid.uuid4()}"
+    team_id = "team-tomb"
+    rule_id = "saturation"
+    day1 = date(2026, 4, 7)
+    day2 = date(2026, 4, 8)
+
+    sink = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    sink.ensure_schema(force=True)
+    try:
+        # Day 1: rule fired (older as-of).
+        sink.write_recommendations(
+            [
+                _record(
+                    team_id=team_id,
+                    org_id=org_id,
+                    rule_id=rule_id,
+                    window_end=day1,
+                    fired=True,
+                    computed_at=datetime(2026, 4, 7, 2, 0, tzinfo=timezone.utc),
+                )
+            ]
+        )
+
+        def _fired_rules(window_end: date) -> set[str]:
+            res = sink.client.query(
+                _RECOMMENDATIONS_SQL,
+                parameters={
+                    "team_id": team_id,
+                    "org_id": org_id,
+                    "window_start": day1.isoformat(),
+                    "window_end": window_end.isoformat(),
+                },
+            )
+            return {row[2] for row in (res.result_rows or [])}  # rule_id col
+
+        # After day 1 the rule is visible (positive control).
+        assert _fired_rules(day1) == {rule_id}
+
+        # Day 2: full-state write -> rule no longer fires (tombstone, newer as-of).
+        sink.write_recommendations(
+            [
+                _record(
+                    team_id=team_id,
+                    org_id=org_id,
+                    rule_id=rule_id,
+                    window_end=day2,
+                    fired=False,
+                    computed_at=datetime(2026, 4, 8, 2, 0, tzinfo=timezone.utc),
+                )
+            ]
+        )
+
+        # The stale day-1 fired row must be superseded by the day-2 tombstone:
+        # the reader collapses to the latest window_end per (org, team, rule).
+        assert _fired_rules(day2) == set(), (
+            "recovered signal still visible: latest-window_end collapse failed"
+        )
+    finally:
+        sink.client.command(
+            "ALTER TABLE recommendations_daily DELETE WHERE org_id = {o:String} "
+            "SETTINGS mutations_sync=2",
+            parameters={"o": org_id},
+        )
+        sink.close()

--- a/tests/test_recommendations_tombstone.py
+++ b/tests/test_recommendations_tombstone.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import os
 import uuid
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
@@ -250,6 +250,133 @@ def test_newer_nofire_supersedes_older_fired_row():
         # the reader collapses to the latest window_end per (org, team, rule).
         assert _fired_rules(day2) == set(), (
             "recovered signal still visible: latest-window_end collapse failed"
+        )
+    finally:
+        sink.client.command(
+            "ALTER TABLE recommendations_daily DELETE WHERE org_id = {o:String} "
+            "SETTINGS mutations_sync=2",
+            parameters={"o": org_id},
+        )
+        sink.close()
+
+
+@pytest.mark.clickhouse
+@_live
+def test_writer_window_end_visible_same_day_via_resolver_cap(monkeypatch):
+    """Writer's ``window_end == today + 1`` is read same-day by recommendations().
+
+    Regression for the CONVENTION MISMATCH (CHAOS-2373): the scheduled writer
+    anchors ``now = as_of_day + 1`` and persists rows at ``window_end ==
+    today + 1`` (so the loader's exclusive ``day < window_end`` still reads the
+    just-finalized ``today`` partition). The GraphQL ``recommendations()``
+    resolver previously capped its read at ``window_end <= today`` and so
+    EXCLUDED those freshest rows — the surface was one finalize-day stale.
+
+    This drives the ACTUAL resolver bounds (``_window_to_dates``, patched so
+    "today" is deterministic) against live ClickHouse and asserts:
+
+    * a rule that fired this finalize cycle (``window_end = today + 1``) APPEARS
+      same-day, and
+    * a recovered rule (fired yesterday, tombstoned this cycle) is CLEARED
+      same-day — not lingering for an extra finalize-day.
+    """
+    from dev_health_ops.api.graphql.models.recommendations import (
+        WindowInput,
+        WindowUnit,
+    )
+    from dev_health_ops.api.graphql.resolvers import recommendations as resolver_mod
+    from dev_health_ops.api.graphql.resolvers.recommendations import (
+        _RECOMMENDATIONS_SQL,
+        _window_to_dates,
+    )
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+
+    # Deterministic "today" so the writer's today+1 and the resolver cap line up.
+    today = date(2026, 4, 8)
+    # Writer convention: window_end == as_of_day + 1 (as_of_day == today).
+    writer_window_end = today + timedelta(days=1)
+    assert writer_window_end == date(2026, 4, 9)  # today + 1
+
+    monkeypatch.setattr(resolver_mod, "utc_today", lambda: today)
+
+    # Sanity: the resolver now caps the read at today + 1 (inclusive), matching
+    # the writer's persisted key. If this regresses to `today`, the freshest
+    # finalized rows fall outside the cap and the asserts below fail.
+    window = WindowInput(value=2, unit=WindowUnit.WEEK)
+    res_start, res_end = _window_to_dates(window)
+    assert res_end == writer_window_end, (
+        "resolver read cap must include the writer's today+1 window_end"
+    )
+
+    org_id = f"test-chaos-2373-cap-{uuid.uuid4()}"
+    team_id = "team-cap"
+    fired_rule = "saturation"
+    recovered_rule = "thrash"
+    computed_at = datetime(2026, 4, 9, 2, 0, tzinfo=timezone.utc)
+
+    sink = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    sink.ensure_schema(force=True)
+    try:
+        # Yesterday's finalize: recovered_rule fired at window_end = today
+        # (yesterday's as_of + 1). The writer convention always bumps by one.
+        sink.write_recommendations(
+            [
+                _record(
+                    team_id=team_id,
+                    org_id=org_id,
+                    rule_id=recovered_rule,
+                    window_end=today,  # yesterday's as_of + 1
+                    fired=True,
+                    computed_at=datetime(2026, 4, 8, 2, 0, tzinfo=timezone.utc),
+                )
+            ]
+        )
+
+        # Today's finalize (as_of = today): full state at window_end = today + 1.
+        #   * fired_rule fires (new signal)
+        #   * recovered_rule tombstoned (no longer fires)
+        sink.write_recommendations(
+            [
+                _record(
+                    team_id=team_id,
+                    org_id=org_id,
+                    rule_id=fired_rule,
+                    window_end=writer_window_end,
+                    fired=True,
+                    computed_at=computed_at,
+                ),
+                _record(
+                    team_id=team_id,
+                    org_id=org_id,
+                    rule_id=recovered_rule,
+                    window_end=writer_window_end,
+                    fired=False,
+                    computed_at=computed_at,
+                ),
+            ]
+        )
+
+        # Read through the resolver's OWN derived bounds (the cap under test).
+        res = sink.client.query(
+            _RECOMMENDATIONS_SQL,
+            parameters={
+                "team_id": team_id,
+                "org_id": org_id,
+                "window_start": res_start.isoformat(),
+                "window_end": res_end.isoformat(),
+            },
+        )
+        fired_now = {row[2] for row in (res.result_rows or [])}  # rule_id col
+
+        # Same-day visibility: today's finalized fired rule APPEARS immediately.
+        assert fired_rule in fired_now, (
+            "today's finalized recommendation excluded by the resolver read cap"
+        )
+        # Same-day clearance: the recovered rule is gone, not stale for a day.
+        assert recovered_rule not in fired_now, (
+            "recovered signal still visible same-day: read cap/convention mismatch"
         )
     finally:
         sink.client.command(


### PR DESCRIPTION
Schedules a per-org/team Celery task (run_recommendations_job) that runs the RuleEngine and writes recommendations_daily, so the dashboard home RankedSignals, the recommendations() GraphQL surface, and Operating Review are no longer empty for real OAuth orgs (previously only the manual `dev-hops recommendations compute` CLI wrote this table). Chained off the daily-metrics finalize (completion-gated) with a daily beat backstop; resolved recommendations are tombstoned; window_end convention unified across writer / resolver / home / CLI.

Part of CHAOS-2372. Closes CHAOS-2373.

Reviewed across 3 adversarial rounds (in-workflow reviewer + Codex /codex:adversarial-review). Gates: ruff + full-package mypy + pytest green.

Tracked follow-up (non-blocking): CHAOS-2398 (re-run computed_at determinism).
