### PR TITLE
feat(metrics): compute work_item_state_durations_daily on the live daily job (CHAOS-2377)

### DIFF
--- a/src/dev_health_ops/api/queries/aggregated_flame.py
+++ b/src/dev_health_ops/api/queries/aggregated_flame.py
@@ -42,13 +42,29 @@ async def fetch_cycle_breakdown(
 
     where_clause = " AND ".join(filters)
 
+    # CHAOS-2377: the daily job appends a fresh row per run to this plain
+    # MergeTree, so a re-run/backfill of the same day leaves duplicate rows.
+    # Dedup with argMax(..., computed_at) over the full natural key before
+    # summing, matching the operating_review reader. Summing raw rows would
+    # inflate flow weights and touched counts on every re-run.
     query = f"""
         SELECT
             status,
             sum(duration_hours) AS total_hours,
             sum(items_touched) AS total_items
-        FROM work_item_state_durations_daily
-        WHERE {where_clause}
+        FROM (
+            SELECT
+                day,
+                provider,
+                work_scope_id,
+                team_id,
+                status,
+                argMax(duration_hours, computed_at) AS duration_hours,
+                argMax(items_touched, computed_at) AS items_touched
+            FROM work_item_state_durations_daily
+            WHERE {where_clause}
+            GROUP BY day, provider, work_scope_id, team_id, status
+        )
         GROUP BY status
         ORDER BY total_hours DESC
     """

--- a/src/dev_health_ops/api/queries/explain.py
+++ b/src/dev_health_ops/api/queries/explain.py
@@ -4,6 +4,7 @@ from datetime import date
 from typing import Any
 
 from .client import query_dicts
+from .metrics import _DEDUP_BY_COMPUTED_AT, _metric_from_clause
 
 
 async def fetch_metric_contributors(
@@ -19,7 +20,26 @@ async def fetch_metric_contributors(
     limit: int = 6,
     org_id: str = "",
 ) -> list[dict[str, Any]]:
-    query = f"""
+    if table in _DEDUP_BY_COMPUTED_AT:
+        # CHAOS-2377: dedup re-run/backfill rows to the latest computed_at per
+        # natural key BEFORE the contributor avg(), matching the deduped
+        # /explain headline (fetch_metric_value). Without this the contributor
+        # ranking averages over stale + latest duplicates and misranks owners.
+        # org_id and scope_filter stay in the inner WHERE (see _metric_from_clause).
+        from_clause = _metric_from_clause(
+            table=table, column=column, scope_filter=scope_filter
+        )
+        query = f"""
+        SELECT
+            {group_by} AS id,
+            avg({column}) AS value
+        FROM {from_clause}
+        GROUP BY {group_by}
+        ORDER BY value DESC
+        LIMIT %(limit)s
+    """
+    else:
+        query = f"""
         SELECT
             {group_by} AS id,
             avg({column}) AS value
@@ -52,7 +72,45 @@ async def fetch_metric_driver_delta(
     limit: int = 3,
     org_id: str = "",
 ) -> list[dict[str, Any]]:
-    query = f"""
+    if table in _DEDUP_BY_COMPUTED_AT:
+        # CHAOS-2377: dedup re-run/backfill rows to the latest computed_at per
+        # natural key in BOTH windows before the driver avg()/delta, matching
+        # the deduped /explain headline. The current window reuses the default
+        # start_day/end_day params; the previous CTE binds compare_start/end via
+        # the from-clause param overrides. org_id + scope_filter stay inner.
+        current_from = _metric_from_clause(
+            table=table, column=column, scope_filter=scope_filter
+        )
+        previous_from = _metric_from_clause(
+            table=table,
+            column=column,
+            scope_filter=scope_filter,
+            start_param="compare_start",
+            end_param="compare_end",
+        )
+        query = f"""
+        WITH
+            current AS (
+                SELECT {group_by} AS id, avg({column}) AS value
+                FROM {current_from}
+                GROUP BY {group_by}
+            ),
+            previous AS (
+                SELECT {group_by} AS id, avg({column}) AS value
+                FROM {previous_from}
+                GROUP BY {group_by}
+            )
+        SELECT
+            current.id AS id,
+            current.value AS value,
+            CASE WHEN previous.value = 0 THEN 0 ELSE (current.value - previous.value) / previous.value * 100 END AS delta_pct
+        FROM current
+        LEFT JOIN previous ON current.id = previous.id
+        ORDER BY delta_pct DESC
+        LIMIT %(limit)s
+    """
+    else:
+        query = f"""
         WITH
             current AS (
                 SELECT {group_by} AS id, avg({column}) AS value

--- a/src/dev_health_ops/api/queries/metrics.py
+++ b/src/dev_health_ops/api/queries/metrics.py
@@ -28,7 +28,14 @@ _DEDUP_BY_COMPUTED_AT: dict[str, tuple[str, ...]] = {
 }
 
 
-def _metric_from_clause(*, table: str, column: str, scope_filter: str) -> str:
+def _metric_from_clause(
+    *,
+    table: str,
+    column: str,
+    scope_filter: str,
+    start_param: str = "start_day",
+    end_param: str = "end_day",
+) -> str:
     """Return the FROM source for a metric read.
 
     For most tables this is just the raw table name. For ReplacingMergeTree-by-
@@ -36,6 +43,10 @@ def _metric_from_clause(*, table: str, column: str, scope_filter: str) -> str:
     is wrapped in a subquery that collapses to the latest ``computed_at`` per
     natural key — so a top-level ``sum(column)`` counts each key once instead of
     once per re-run. ``org_id`` stays filtered in the inner ``WHERE``.
+
+    ``start_param`` / ``end_param`` name the bound query params so a single
+    subquery shape can serve both the current and comparison windows (the
+    driver-delta CTE pair reuses this with ``compare_start`` / ``compare_end``).
     """
     natural_key = _DEDUP_BY_COMPUTED_AT.get(table)
     if natural_key is None:
@@ -46,7 +57,7 @@ def _metric_from_clause(*, table: str, column: str, scope_filter: str) -> str:
                 {key_columns},
                 argMax({column}, computed_at) AS {column}
             FROM {table}
-            WHERE day >= %(start_day)s AND day < %(end_day)s
+            WHERE day >= %({start_param})s AND day < %({end_param})s
             {scope_filter}
               AND org_id = %(org_id)s
             GROUP BY {", ".join(natural_key)}

--- a/src/dev_health_ops/api/queries/metrics.py
+++ b/src/dev_health_ops/api/queries/metrics.py
@@ -12,6 +12,47 @@ def _date_params(start_day: date, end_day: date) -> dict[str, Any]:
     return {"start_day": start_day, "end_day": end_day}
 
 
+# CHAOS-2377: tables that the daily job appends to per-run (plain MergeTree, one
+# fresh row per (natural key, computed_at)). Reading them with a top-level
+# sum() double-counts re-runs/backfills, so the table read must be wrapped in a
+# per-key argMax(..., computed_at) dedup subquery before aggregating — matching
+# the operating_review / sankey / aggregated_flame readers on this branch.
+_DEDUP_BY_COMPUTED_AT: dict[str, tuple[str, ...]] = {
+    "work_item_state_durations_daily": (
+        "day",
+        "provider",
+        "work_scope_id",
+        "team_id",
+        "status",
+    ),
+}
+
+
+def _metric_from_clause(*, table: str, column: str, scope_filter: str) -> str:
+    """Return the FROM source for a metric read.
+
+    For most tables this is just the raw table name. For ReplacingMergeTree-by-
+    ``computed_at`` daily tables (those in ``_DEDUP_BY_COMPUTED_AT``) the table
+    is wrapped in a subquery that collapses to the latest ``computed_at`` per
+    natural key — so a top-level ``sum(column)`` counts each key once instead of
+    once per re-run. ``org_id`` stays filtered in the inner ``WHERE``.
+    """
+    natural_key = _DEDUP_BY_COMPUTED_AT.get(table)
+    if natural_key is None:
+        return table
+    key_columns = ",\n                ".join(natural_key)
+    return f"""(
+            SELECT
+                {key_columns},
+                argMax({column}, computed_at) AS {column}
+            FROM {table}
+            WHERE day >= %(start_day)s AND day < %(end_day)s
+            {scope_filter}
+              AND org_id = %(org_id)s
+            GROUP BY {", ".join(natural_key)}
+        )"""
+
+
 async def fetch_metric_series(
     client: Any,
     *,
@@ -27,7 +68,23 @@ async def fetch_metric_series(
     value_expression = _metric_value_expression(
         table=table, column=column, aggregator=aggregator
     )
-    query = f"""
+    if table in _DEDUP_BY_COMPUTED_AT:
+        # Dedup re-run rows under the outer sum() (CHAOS-2377). The subquery
+        # filters day/scope/org_id and emits one row per natural key with the
+        # latest computed_at, so we group only by day on the outer query.
+        from_clause = _metric_from_clause(
+            table=table, column=column, scope_filter=scope_filter
+        )
+        query = f"""
+        SELECT
+            day,
+            {value_expression} AS value
+        FROM {from_clause}
+        GROUP BY day
+        ORDER BY day
+    """
+    else:
+        query = f"""
         SELECT
             day,
             {value_expression} AS value
@@ -59,7 +116,20 @@ async def fetch_metric_value(
     value_expression = _metric_value_expression(
         table=table, column=column, aggregator=aggregator
     )
-    query = f"""
+    if table in _DEDUP_BY_COMPUTED_AT:
+        # Dedup re-run rows under the outer sum() (CHAOS-2377). Without this the
+        # /explain blocked_work headline (current + comparison) inflates by the
+        # number of duplicate daily runs/backfills for the same natural key.
+        from_clause = _metric_from_clause(
+            table=table, column=column, scope_filter=scope_filter
+        )
+        query = f"""
+        SELECT
+            {value_expression} AS value
+        FROM {from_clause}
+    """
+    else:
+        query = f"""
         SELECT
             {value_expression} AS value
         FROM {table}

--- a/src/dev_health_ops/api/queries/metrics.py
+++ b/src/dev_health_ops/api/queries/metrics.py
@@ -92,15 +92,30 @@ async def fetch_blocked_hours(
     scope_params: dict[str, Any],
     org_id: str = "",
 ) -> tuple[float, list[dict[str, Any]]]:
+    # CHAOS-2377: the daily job appends a fresh row per run to this plain
+    # MergeTree, so a re-run/backfill of the same day leaves duplicate rows.
+    # Dedup with argMax(duration_hours, computed_at) over the full natural key
+    # before summing, matching the operating_review reader; summing raw rows
+    # would inflate the blocked-hours panel on every re-run.
     query = f"""
         SELECT
             day,
             sum(duration_hours) AS value
-        FROM work_item_state_durations_daily
-        WHERE day >= %(start_day)s AND day < %(end_day)s
-          AND status = 'blocked'
-        {scope_filter}
-          AND org_id = %(org_id)s
+        FROM (
+            SELECT
+                day,
+                provider,
+                work_scope_id,
+                team_id,
+                status,
+                argMax(duration_hours, computed_at) AS duration_hours
+            FROM work_item_state_durations_daily
+            WHERE day >= %(start_day)s AND day < %(end_day)s
+              AND status = 'blocked'
+            {scope_filter}
+              AND org_id = %(org_id)s
+            GROUP BY day, provider, work_scope_id, team_id, status
+        )
         GROUP BY day
         ORDER BY day
     """

--- a/src/dev_health_ops/api/queries/sankey.py
+++ b/src/dev_health_ops/api/queries/sankey.py
@@ -98,14 +98,29 @@ async def fetch_state_status_counts(
     scope_params: dict[str, Any],
     org_id: str = "",
 ) -> list[dict[str, Any]]:
+    # CHAOS-2377: the daily job appends a fresh row per run to this plain
+    # MergeTree, so a re-run/backfill of the same day leaves duplicate rows.
+    # Dedup with argMax(items_touched, computed_at) over the full natural key
+    # before summing, matching the operating_review reader; summing raw rows
+    # would inflate the Sankey status counts on every re-run.
     query = f"""
         SELECT
             status,
             sum(items_touched) AS items_touched
-        FROM work_item_state_durations_daily
-        WHERE day >= %(start_day)s AND day < %(end_day)s
-          AND org_id = %(org_id)s
-            {scope_filter}
+        FROM (
+            SELECT
+                day,
+                provider,
+                work_scope_id,
+                team_id,
+                status,
+                argMax(items_touched, computed_at) AS items_touched
+            FROM work_item_state_durations_daily
+            WHERE day >= %(start_day)s AND day < %(end_day)s
+              AND org_id = %(org_id)s
+                {scope_filter}
+            GROUP BY day, provider, work_scope_id, team_id, status
+        )
         GROUP BY status
         ORDER BY items_touched DESC
     """

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -62,7 +62,10 @@ from dev_health_ops.metrics.reviews import compute_review_edges_daily
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 from dev_health_ops.metrics.work_items import DiscoveredRepo
 from dev_health_ops.providers.identity import load_identity_resolver
-from dev_health_ops.providers.teams import build_repo_pattern_resolver
+from dev_health_ops.providers.teams import (
+    build_project_key_resolver,
+    build_repo_pattern_resolver,
+)
 from dev_health_ops.storage import detect_db_type
 from dev_health_ops.utils.cli import (
     add_date_range_args,
@@ -508,6 +511,11 @@ async def run_daily_metrics_job(
     team_resolver = get_team_resolver()
     teams_data = await primary_sink.get_all_teams()
     repo_team_resolver = build_repo_pattern_resolver(teams_data)
+    # CHAOS-2377: project-key team attribution for the work-item state-duration
+    # rollup. Mirrors job_work_items: team-owned-by-project-key items that are
+    # unassigned (or assigned to unmapped users) must still land under their
+    # team, not the normalized "unassigned" bucket.
+    project_key_resolver = build_project_key_resolver(teams_data)
     discovered_repos = discover_repos(
         backend=backend,
         primary_sink=primary_sink,
@@ -705,6 +713,7 @@ async def run_daily_metrics_job(
                 transitions=work_item_transitions,
                 computed_at=computed_at,
                 team_resolver=team_resolver,
+                project_key_resolver=project_key_resolver,
             )
 
         review_edges = compute_review_edges_daily(

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -36,6 +36,9 @@ from dev_health_ops.metrics.compute_testops_risk import (
 from dev_health_ops.metrics.compute_wellbeing import (
     compute_team_wellbeing_metrics_daily,
 )
+from dev_health_ops.metrics.compute_work_item_state_durations import (
+    compute_work_item_state_durations_daily,
+)
 from dev_health_ops.metrics.compute_work_items import compute_work_item_metrics_daily
 from dev_health_ops.metrics.dependencies import get_metrics_dependencies
 from dev_health_ops.metrics.hotspots import compute_file_hotspots
@@ -679,6 +682,7 @@ async def run_daily_metrics_job(
         wi_metrics: list[Any] = []
         wi_user_metrics: list[Any] = []
         wi_cycle_times: list[Any] = []
+        wi_state_durations: list[Any] = []
         if work_items:
             wi_metrics, wi_user_metrics, wi_cycle_times = (
                 compute_work_item_metrics_daily(
@@ -688,6 +692,19 @@ async def run_daily_metrics_job(
                     computed_at=computed_at,
                     team_resolver=team_resolver,
                 )
+            )
+            # CHAOS-2377: the state-duration rollup powers /metrics Flow Sankey +
+            # Flame and the Operating Review state-duration panel. The compute
+            # already exists (and is used by the fixtures runner + job_work_items)
+            # but was never invoked in the live scheduled daily job, so the table
+            # stayed empty for real orgs. Reuse the work_items / transitions
+            # already loaded for this day.
+            wi_state_durations = compute_work_item_state_durations_daily(
+                day=d,
+                work_items=work_items,
+                transitions=work_item_transitions,
+                computed_at=computed_at,
+                team_resolver=team_resolver,
             )
 
         review_edges = compute_review_edges_daily(
@@ -880,6 +897,8 @@ async def run_daily_metrics_job(
                 s.write_work_item_user_metrics(wi_user_metrics)
             if wi_cycle_times:
                 s.write_work_item_cycle_times(wi_cycle_times)
+            if wi_state_durations:
+                s.write_work_item_state_durations(wi_state_durations)
             s.write_review_edges(review_edges)
             s.write_cicd_metrics(cicd_metrics)
             s.write_testops_pipeline_metrics(testops_pipeline_metrics)

--- a/tests/api/queries/test_state_durations_dedup.py
+++ b/tests/api/queries/test_state_durations_dedup.py
@@ -1,0 +1,125 @@
+"""CHAOS-2377: state-duration readers must dedup re-run rows before summing.
+
+The scheduled daily job (``run_daily_metrics_job``) now writes
+``work_item_state_durations_daily`` on every run. That table is a plain
+``MergeTree``, so re-running or backfilling the same day appends a *second*
+copy of each (day, provider, work_scope_id, team_id, status) row with a fresh
+``computed_at``. The /metrics Flow Sankey and aggregated Flame readers
+aggregate with ``sum(...)``; without a per-key ``argMax(..., computed_at)``
+dedup they would silently inflate flow weights and touched counts on every
+re-run.
+
+These tests pin the dedup shape on the two readers that previously summed the
+raw table (the Operating Review reader already deduped). They capture the
+emitted SQL and assert it collapses to the latest ``computed_at`` per natural
+key before aggregating — mirroring ``test_clickhouse_computed_at_aliases``.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, cast
+
+import pytest
+
+import dev_health_ops.connectors  # noqa: F401  # break providers<->connectors cycle
+from dev_health_ops.api.queries import aggregated_flame, metrics, sankey
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+_NATURAL_KEY_GROUP_BY = "GROUP BY day, provider, work_scope_id, team_id, status"
+
+
+def _assert_dedup_before_sum(query: str) -> None:
+    # The raw table is read inside an inner subquery that collapses to the
+    # latest computed_at per natural key, and the outer query sums the deduped
+    # rows. A flat ``FROM work_item_state_durations_daily ... GROUP BY status``
+    # with a top-level sum would double-count re-runs.
+    normalized = " ".join(query.split())
+    assert "argMax(items_touched, computed_at)" in normalized
+    assert _NATURAL_KEY_GROUP_BY in normalized
+    # The dedup subquery must sit *under* the outer sum(), i.e. the table is not
+    # summed directly.
+    table_pos = normalized.index("work_item_state_durations_daily")
+    inner_group_pos = normalized.index(_NATURAL_KEY_GROUP_BY)
+    assert inner_group_pos > table_pos, "dedup GROUP BY must follow the table read"
+
+
+@pytest.mark.asyncio
+async def test_sankey_state_status_counts_dedups_reruns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    async def fake_query_dicts(_sink: Any, query: str, _params: Any) -> list[Any]:
+        captured["query"] = query
+        return []
+
+    monkeypatch.setattr(sankey, "query_dicts", fake_query_dicts)
+
+    await sankey.fetch_state_status_counts(
+        cast(BaseMetricsSink, object()),
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        scope_filter=" AND team_id = %(team_id)s",
+        scope_params={"team_id": "core"},
+        org_id="org-a",
+    )
+
+    _assert_dedup_before_sum(captured["query"])
+
+
+@pytest.mark.asyncio
+async def test_aggregated_flame_cycle_breakdown_dedups_reruns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[Any]:
+        captured["query"] = query
+        return []
+
+    monkeypatch.setattr(aggregated_flame, "query_dicts", fake_query_dicts)
+
+    await aggregated_flame.fetch_cycle_breakdown(
+        object(),
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        team_id="core",
+        org_id="org-a",
+    )
+
+    normalized = " ".join(captured["query"].split())
+    assert "argMax(duration_hours, computed_at)" in normalized
+    assert "argMax(items_touched, computed_at)" in normalized
+    assert _NATURAL_KEY_GROUP_BY in normalized
+    table_pos = normalized.index("work_item_state_durations_daily")
+    inner_group_pos = normalized.index(_NATURAL_KEY_GROUP_BY)
+    assert inner_group_pos > table_pos
+
+
+@pytest.mark.asyncio
+async def test_blocked_hours_dedups_reruns(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[Any]:
+        captured["query"] = query
+        return []
+
+    monkeypatch.setattr(metrics, "query_dicts", fake_query_dicts)
+
+    await metrics.fetch_blocked_hours(
+        object(),
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        scope_filter=" AND team_id IN %(team_ids)s",
+        scope_params={"team_ids": ["core"]},
+        org_id="org-a",
+    )
+
+    normalized = " ".join(captured["query"].split())
+    # blocked-hours is the panel Codex flagged for silent inflation.
+    assert "argMax(duration_hours, computed_at)" in normalized
+    assert _NATURAL_KEY_GROUP_BY in normalized
+    table_pos = normalized.index("work_item_state_durations_daily")
+    inner_group_pos = normalized.index(_NATURAL_KEY_GROUP_BY)
+    assert inner_group_pos > table_pos

--- a/tests/api/queries/test_state_durations_dedup.py
+++ b/tests/api/queries/test_state_durations_dedup.py
@@ -23,7 +23,7 @@ from typing import Any, cast
 import pytest
 
 import dev_health_ops.connectors  # noqa: F401  # break providers<->connectors cycle
-from dev_health_ops.api.queries import aggregated_flame, metrics, sankey
+from dev_health_ops.api.queries import aggregated_flame, explain, metrics, sankey
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 _NATURAL_KEY_GROUP_BY = "GROUP BY day, provider, work_scope_id, team_id, status"
@@ -234,3 +234,163 @@ async def test_fetch_metric_value_leaves_other_tables_flat(
     assert "argMax" not in normalized
     assert _NATURAL_KEY_GROUP_BY not in normalized
     assert "FROM work_item_metrics_daily WHERE" in normalized
+
+
+# --- /explain root-cause readers (CHAOS-2377 re-review) ----------------------
+#
+# Codex flagged that build_explain_response ALSO calls fetch_metric_driver_delta
+# and fetch_metric_contributors (and the home summary path calls the driver
+# reader for the top metric). Those SQL builders read FROM {table} directly with
+# no dedup, so after a rerun/backfill the blocked_work drivers/contributors are
+# averaged over stale + latest duplicate rows -> misleading root-cause guidance.
+# These tests pin the same per-key argMax(..., computed_at) dedup on both.
+
+
+def _assert_driver_avg_dedup(query: str) -> None:
+    """Both driver CTEs (current + previous) must dedup before the avg()."""
+    normalized = " ".join(query.split())
+    # Dedup subquery emits the deduped column per natural key.
+    assert "argMax(duration_hours, computed_at)" in normalized
+    # Two dedup subqueries (one per window) -> two natural-key GROUP BYs.
+    assert normalized.count(_NATURAL_KEY_GROUP_BY) == 2, (
+        "both current and previous windows must dedup"
+    )
+    # org_id stays filtered inside each dedup subquery, before the GROUP BY.
+    assert "org_id = %(org_id)s" in normalized
+    first_key_pos = normalized.index(_NATURAL_KEY_GROUP_BY)
+    first_org_pos = normalized.index("org_id = %(org_id)s")
+    assert first_org_pos < first_key_pos, "org_id filter must sit inside the subquery"
+    # The current window binds start_day/end_day; the previous window binds the
+    # compare_start/compare_end params (param-name override on _metric_from_clause).
+    assert "day >= %(start_day)s AND day < %(end_day)s" in normalized
+    assert "day >= %(compare_start)s AND day < %(compare_end)s" in normalized
+    # The outer driver avg() runs over the deduped alias, not the raw table.
+    assert "avg(duration_hours)" in normalized
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_driver_delta_dedups_state_durations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[Any]:
+        captured["query"] = query
+        return []
+
+    monkeypatch.setattr(explain, "query_dicts", fake_query_dicts)
+
+    await explain.fetch_metric_driver_delta(
+        cast(BaseMetricsSink, object()),
+        table="work_item_state_durations_daily",
+        column="duration_hours",
+        group_by="team_id",
+        start_day=date(2026, 5, 8),
+        end_day=date(2026, 5, 15),
+        compare_start=date(2026, 5, 1),
+        compare_end=date(2026, 5, 8),
+        scope_filter=" AND team_id IN %(team_ids)s",
+        scope_params={"team_ids": ["core"]},
+        org_id="org-a",
+    )
+
+    _assert_driver_avg_dedup(captured["query"])
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_contributors_dedups_state_durations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[Any]:
+        captured["query"] = query
+        return []
+
+    monkeypatch.setattr(explain, "query_dicts", fake_query_dicts)
+
+    await explain.fetch_metric_contributors(
+        cast(BaseMetricsSink, object()),
+        table="work_item_state_durations_daily",
+        column="duration_hours",
+        group_by="team_id",
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        scope_filter=" AND team_id IN %(team_ids)s",
+        scope_params={"team_ids": ["core"]},
+        org_id="org-a",
+    )
+
+    normalized = " ".join(captured["query"].split())
+    assert "argMax(duration_hours, computed_at)" in normalized
+    assert _NATURAL_KEY_GROUP_BY in normalized
+    # Table read inside the dedup subquery, contributor avg() over the alias.
+    table_pos = normalized.index("work_item_state_durations_daily")
+    inner_group_pos = normalized.index(_NATURAL_KEY_GROUP_BY)
+    assert inner_group_pos > table_pos, "dedup GROUP BY must follow the table read"
+    org_pos = normalized.index("org_id = %(org_id)s")
+    assert org_pos < inner_group_pos, "org_id filter must sit inside the subquery"
+    assert "avg(duration_hours)" in normalized
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_driver_delta_leaves_other_tables_flat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The driver reader must NOT add argMax dedup for unaffected tables.
+    captured: dict[str, str] = {}
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[Any]:
+        captured["query"] = query
+        return []
+
+    monkeypatch.setattr(explain, "query_dicts", fake_query_dicts)
+
+    await explain.fetch_metric_driver_delta(
+        cast(BaseMetricsSink, object()),
+        table="repo_metrics_daily",
+        column="change_failure_rate",
+        group_by="repo_id",
+        start_day=date(2026, 5, 8),
+        end_day=date(2026, 5, 15),
+        compare_start=date(2026, 5, 1),
+        compare_end=date(2026, 5, 8),
+        scope_filter=" AND repo_id IN %(repo_ids)s",
+        scope_params={"repo_ids": ["r1"]},
+        org_id="org-a",
+    )
+
+    normalized = " ".join(captured["query"].split())
+    assert "argMax" not in normalized
+    assert _NATURAL_KEY_GROUP_BY not in normalized
+    assert "FROM repo_metrics_daily WHERE" in normalized
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_contributors_leaves_other_tables_flat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[Any]:
+        captured["query"] = query
+        return []
+
+    monkeypatch.setattr(explain, "query_dicts", fake_query_dicts)
+
+    await explain.fetch_metric_contributors(
+        cast(BaseMetricsSink, object()),
+        table="repo_metrics_daily",
+        column="change_failure_rate",
+        group_by="repo_id",
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        scope_filter=" AND repo_id IN %(repo_ids)s",
+        scope_params={"repo_ids": ["r1"]},
+        org_id="org-a",
+    )
+
+    normalized = " ".join(captured["query"].split())
+    assert "argMax" not in normalized
+    assert _NATURAL_KEY_GROUP_BY not in normalized
+    assert "FROM repo_metrics_daily WHERE" in normalized

--- a/tests/api/queries/test_state_durations_dedup.py
+++ b/tests/api/queries/test_state_durations_dedup.py
@@ -123,3 +123,114 @@ async def test_blocked_hours_dedups_reruns(monkeypatch: pytest.MonkeyPatch) -> N
     table_pos = normalized.index("work_item_state_durations_daily")
     inner_group_pos = normalized.index(_NATURAL_KEY_GROUP_BY)
     assert inner_group_pos > table_pos
+
+
+def _assert_value_expr_dedup(query: str, *, value_expr: str) -> None:
+    """The /explain & /home generic readers must dedup re-runs for this table.
+
+    Without the per-key argMax(..., computed_at) subquery the outer
+    sum(duration_hours) double-counts every duplicate daily run/backfill, so the
+    blocked_work headline (current AND comparison) inflates by the re-run count.
+    """
+    normalized = " ".join(query.split())
+    assert "argMax(duration_hours, computed_at)" in normalized
+    assert _NATURAL_KEY_GROUP_BY in normalized
+    # The table must be read *inside* the dedup subquery, not summed directly.
+    table_pos = normalized.index("work_item_state_durations_daily")
+    inner_group_pos = normalized.index(_NATURAL_KEY_GROUP_BY)
+    assert inner_group_pos > table_pos, "dedup GROUP BY must follow the table read"
+    # org_id stays filtered in the inner WHERE (before the dedup GROUP BY).
+    org_pos = normalized.index("org_id = %(org_id)s")
+    assert org_pos < inner_group_pos, "org_id filter must sit inside the subquery"
+    # The outer aggregation runs over the deduped alias, not the raw table.
+    assert value_expr in normalized
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_value_dedups_state_durations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # This is the 4th reader path (CHAOS-2377 re-review): /explain blocked_work
+    # current + comparison headline both flow through fetch_metric_value.
+    captured: dict[str, str] = {}
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[Any]:
+        captured["query"] = query
+        return [{"value": 0.0}]
+
+    monkeypatch.setattr(metrics, "query_dicts", fake_query_dicts)
+
+    await metrics.fetch_metric_value(
+        cast(BaseMetricsSink, object()),
+        table="work_item_state_durations_daily",
+        column="duration_hours",
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        scope_filter=" AND team_id IN %(team_ids)s",
+        scope_params={"team_ids": ["core"]},
+        aggregator="sum",
+        org_id="org-a",
+    )
+
+    _assert_value_expr_dedup(captured["query"], value_expr="sum(duration_hours)")
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_series_dedups_state_durations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[Any]:
+        captured["query"] = query
+        return []
+
+    monkeypatch.setattr(metrics, "query_dicts", fake_query_dicts)
+
+    await metrics.fetch_metric_series(
+        cast(BaseMetricsSink, object()),
+        table="work_item_state_durations_daily",
+        column="duration_hours",
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        scope_filter=" AND team_id IN %(team_ids)s",
+        scope_params={"team_ids": ["core"]},
+        aggregator="sum",
+        org_id="org-a",
+    )
+
+    _assert_value_expr_dedup(captured["query"], value_expr="sum(duration_hours)")
+    # The series query still groups the deduped rows by day for the sparkline.
+    normalized = " ".join(captured["query"].split())
+    assert normalized.rstrip().endswith("GROUP BY day ORDER BY day")
+
+
+@pytest.mark.asyncio
+async def test_fetch_metric_value_leaves_other_tables_flat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The generic reader must NOT add argMax dedup for unaffected tables.
+    captured: dict[str, str] = {}
+
+    async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[Any]:
+        captured["query"] = query
+        return [{"value": 0.0}]
+
+    monkeypatch.setattr(metrics, "query_dicts", fake_query_dicts)
+
+    await metrics.fetch_metric_value(
+        cast(BaseMetricsSink, object()),
+        table="work_item_metrics_daily",
+        column="items_completed",
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        scope_filter=" AND team_id IN %(team_ids)s",
+        scope_params={"team_ids": ["core"]},
+        aggregator="sum",
+        org_id="org-a",
+    )
+
+    normalized = " ".join(captured["query"].split())
+    assert "argMax" not in normalized
+    assert _NATURAL_KEY_GROUP_BY not in normalized
+    assert "FROM work_item_metrics_daily WHERE" in normalized

--- a/tests/metrics/test_job_daily_state_durations.py
+++ b/tests/metrics/test_job_daily_state_durations.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import pytest
 
+import dev_health_ops.connectors  # noqa: F401  # break providers<->connectors cycle
 from dev_health_ops.metrics import job_daily
 from dev_health_ops.models.work_items import WorkItem, WorkItemStatusTransition
 
@@ -73,6 +74,7 @@ class _RecordingSink:
     """Captures the work-item state-duration rows the daily job persists."""
 
     org_id = ""
+    teams: list[Any] = []
 
     def __init__(self, db_url: str) -> None:  # mirrors ClickHouseMetricsSink(db_url)
         self.state_durations: list[Any] = []
@@ -81,7 +83,7 @@ class _RecordingSink:
         return None
 
     async def get_all_teams(self) -> list[Any]:
-        return []
+        return list(type(self).teams)
 
     def write_work_item_state_durations(self, rows: list[Any]) -> None:
         self.state_durations.extend(rows)
@@ -122,47 +124,40 @@ class _FakeLoader:
         return self._work_items, self._transitions
 
 
-@pytest.mark.asyncio
-async def test_daily_job_invokes_state_duration_compute_and_persists(
+class _NullResolver:
+    """Membership resolver that never maps an identity to a team."""
+
+    def resolve(self, *a: Any, **k: Any) -> tuple[None, None]:
+        return (None, None)
+
+
+def _neutralize_daily_job(
     monkeypatch: Any,
+    *,
+    sink: _RecordingSink,
+    loader: _FakeLoader,
+    spy_compute: Any,
 ) -> None:
-    work_items, transitions = _sample_work_items()
-    sink = _RecordingSink("clickhouse://test")
-    loader = _FakeLoader(work_items, transitions)
+    """Stub out the surrounding daily-job machinery (ClickHouse / identity /
+    benchmarking) so the test reaches the work-item state-duration block.
 
-    calls: dict[str, Any] = {}
-
-    real_compute = job_daily.compute_work_item_state_durations_daily
-
-    def spy_compute(**kwargs: Any) -> list[Any]:
-        calls["work_items"] = kwargs["work_items"]
-        calls["transitions"] = kwargs["transitions"]
-        calls["day"] = kwargs["day"]
-        rows = real_compute(**kwargs)
-        calls["rows"] = rows
-        return rows
-
-    # Sink + loader seams.
+    The team membership resolver is stubbed to a null resolver — assignee-based
+    attribution is deliberately disabled so that project-key attribution can be
+    exercised in isolation. The *project-key* resolver is left REAL so it is
+    built from the sink's get_all_teams() data, exactly as production does.
+    """
     monkeypatch.setattr(job_daily, "ClickHouseMetricsSink", lambda db_url: sink)
 
     async def fake_get_loader(*a: Any, **k: Any) -> Any:
         return loader
 
     monkeypatch.setattr(job_daily, "_get_loader", fake_get_loader)
-
-    # The state-duration compute under test.
     monkeypatch.setattr(
         job_daily, "compute_work_item_state_durations_daily", spy_compute
     )
 
-    # Neutralize the surrounding daily-job machinery so we reach the work-item
-    # block without a live ClickHouse / identity / benchmarking dependency.
     async def _noop_init_team_resolver(*a: Any, **k: Any) -> None:
         return None
-
-    class _NullResolver:
-        def resolve(self, *a: Any, **k: Any) -> tuple[None, None]:
-            return (None, None)
 
     monkeypatch.setattr(job_daily, "init_team_resolver", _noop_init_team_resolver)
     monkeypatch.setattr(job_daily, "get_team_resolver", lambda: _NullResolver())
@@ -180,6 +175,32 @@ async def test_daily_job_invokes_state_duration_compute_and_persists(
     monkeypatch.setattr(job_daily, "compute_ai_impact_metrics_daily", lambda **k: [])
     monkeypatch.setattr(job_daily, "run_benchmarking_for_day", lambda *a, **k: None)
     monkeypatch.setattr(job_daily, "_write_compounding_risk_for_day", lambda **k: 0)
+
+
+@pytest.mark.asyncio
+async def test_daily_job_invokes_state_duration_compute_and_persists(
+    monkeypatch: Any,
+) -> None:
+    work_items, transitions = _sample_work_items()
+    sink = _RecordingSink("clickhouse://test")
+    _RecordingSink.teams = []
+    loader = _FakeLoader(work_items, transitions)
+
+    calls: dict[str, Any] = {}
+
+    real_compute = job_daily.compute_work_item_state_durations_daily
+
+    def spy_compute(**kwargs: Any) -> list[Any]:
+        calls["work_items"] = kwargs["work_items"]
+        calls["transitions"] = kwargs["transitions"]
+        calls["day"] = kwargs["day"]
+        rows = real_compute(**kwargs)
+        calls["rows"] = rows
+        return rows
+
+    _neutralize_daily_job(
+        monkeypatch, sink=sink, loader=loader, spy_compute=spy_compute
+    )
 
     await job_daily.run_daily_metrics_job(
         db_url="clickhouse://test",
@@ -200,3 +221,65 @@ async def test_daily_job_invokes_state_duration_compute_and_persists(
     assert sink.state_durations == calls["rows"]
     statuses = {r.status for r in sink.state_durations}
     assert "in_progress" in statuses
+
+
+@pytest.mark.asyncio
+async def test_daily_job_state_durations_attribute_unassigned_by_project_key(
+    monkeypatch: Any,
+) -> None:
+    """CHAOS-2377 medium finding: the daily rollup must pass a project-key
+    resolver so a team-owned-by-project-key item that is UNASSIGNED still lands
+    under its team, not the normalized 'unassigned' bucket.
+
+    The sample item has project_key 'ABC' (work_scope_id 'ABC') and an empty
+    assignees list, so identity-based attribution cannot resolve a team. Only a
+    project-key resolver built from teams_data can attribute it. Before the fix
+    the daily job passed team_resolver only and these rows fell to
+    'unassigned'.
+    """
+    work_items, transitions = _sample_work_items()
+    assert work_items[0].assignees == []  # guard: no identity to resolve
+    assert work_items[0].work_scope_id == "ABC"  # jira project_key drives scope
+
+    sink = _RecordingSink("clickhouse://test")
+    # teams_data the daily job feeds to build_project_key_resolver().
+    _RecordingSink.teams = [
+        {"id": "team-platform", "name": "Platform", "project_keys": ["ABC"]}
+    ]
+    loader = _FakeLoader(work_items, transitions)
+
+    real_compute = job_daily.compute_work_item_state_durations_daily
+    seen: dict[str, Any] = {}
+
+    def spy_compute(**kwargs: Any) -> list[Any]:
+        # The daily job must hand the compute a real project_key_resolver.
+        seen["project_key_resolver"] = kwargs.get("project_key_resolver")
+        rows = real_compute(**kwargs)
+        seen["rows"] = rows
+        return rows
+
+    _neutralize_daily_job(
+        monkeypatch, sink=sink, loader=loader, spy_compute=spy_compute
+    )
+
+    await job_daily.run_daily_metrics_job(
+        db_url="clickhouse://test",
+        day=DAY,
+        backfill_days=1,
+        provider="auto",
+        org_id="22222222-2222-2222-2222-222222222222",
+        skip_finalize=True,
+    )
+
+    # A project-key resolver was actually built and passed through.
+    pk_resolver = seen["project_key_resolver"]
+    assert pk_resolver is not None
+    assert pk_resolver.resolve("ABC") == ("team-platform", "Platform")
+
+    # The unassigned item's state-duration rows are attributed to the
+    # project-key team, NOT the 'unassigned' fallback.
+    rows = [r for r in sink.state_durations if r.status == "in_progress"]
+    assert rows, "expected an in_progress state-duration row"
+    assert {r.team_id for r in rows} == {"team-platform"}
+    assert {r.team_name for r in rows} == {"Platform"}
+    assert all(r.team_id != "unassigned" for r in sink.state_durations)

--- a/tests/metrics/test_job_daily_state_durations.py
+++ b/tests/metrics/test_job_daily_state_durations.py
@@ -1,0 +1,202 @@
+"""CHAOS-2377: daily-job work-item state-duration rollup wiring.
+
+``compute_work_item_state_durations_daily`` already existed and was used by the
+fixtures runner and ``job_work_items``, but the *scheduled* daily job
+(``run_daily_metrics_job``) never invoked it. As a result
+``work_item_state_durations_daily`` stayed empty for real orgs and the /metrics
+Flow Sankey + Flame and Operating Review state-duration panel rendered nothing.
+
+These tests pin the seam: the daily job must invoke the state-duration compute
+with the day's already-loaded work_items/transitions and persist the result via
+``sink.write_work_item_state_durations``. The compute's own row-mapping logic is
+covered by ``tests/test_work_item_state_durations_compute.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+
+import pytest
+
+from dev_health_ops.metrics import job_daily
+from dev_health_ops.models.work_items import WorkItem, WorkItemStatusTransition
+
+DAY = date(2025, 12, 18)
+START = datetime(2025, 12, 18, tzinfo=timezone.utc)
+END = datetime(2025, 12, 19, tzinfo=timezone.utc)
+
+
+def _sample_work_items() -> tuple[list[WorkItem], list[WorkItemStatusTransition]]:
+    item = WorkItem(
+        work_item_id="jira:ABC-1",
+        provider="jira",
+        project_key="ABC",
+        project_id="1",
+        title="Test",
+        type="task",
+        status="done",
+        status_raw="Done",
+        assignees=[],
+        reporter=None,
+        created_at=datetime(2025, 12, 17, 20, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2025, 12, 19, 12, 0, tzinfo=timezone.utc),
+        started_at=None,
+        completed_at=None,
+    )
+    transitions = [
+        WorkItemStatusTransition(
+            work_item_id="jira:ABC-1",
+            provider="jira",
+            occurred_at=datetime(2025, 12, 18, 2, 0, tzinfo=timezone.utc),
+            from_status_raw="To Do",
+            to_status_raw="In Progress",
+            from_status="todo",
+            to_status="in_progress",
+            actor=None,
+        ),
+        WorkItemStatusTransition(
+            work_item_id="jira:ABC-1",
+            provider="jira",
+            occurred_at=datetime(2025, 12, 18, 10, 0, tzinfo=timezone.utc),
+            from_status_raw="In Progress",
+            to_status_raw="Done",
+            from_status="in_progress",
+            to_status="done",
+            actor=None,
+        ),
+    ]
+    return [item], transitions
+
+
+class _RecordingSink:
+    """Captures the work-item state-duration rows the daily job persists."""
+
+    org_id = ""
+
+    def __init__(self, db_url: str) -> None:  # mirrors ClickHouseMetricsSink(db_url)
+        self.state_durations: list[Any] = []
+
+    def ensure_tables(self) -> None:
+        return None
+
+    async def get_all_teams(self) -> list[Any]:
+        return []
+
+    def write_work_item_state_durations(self, rows: list[Any]) -> None:
+        self.state_durations.extend(rows)
+
+    # Every other write_* / metric sink method is a no-op for this seam test.
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("write_"):
+            return lambda *a, **k: None
+        raise AttributeError(name)
+
+
+class _FakeLoader:
+    """Returns the day's work items/transitions and empty everything else."""
+
+    def __init__(self, work_items: list[Any], transitions: list[Any]) -> None:
+        self._work_items = work_items
+        self._transitions = transitions
+
+    async def load_git_rows(self, *a: Any, **k: Any) -> tuple[list, list, list]:
+        return [], [], []
+
+    async def load_cicd_data(self, *a: Any, **k: Any) -> tuple[list, list]:
+        return [], []
+
+    async def load_testops_pipeline_data(self, *a: Any, **k: Any) -> tuple[list, list]:
+        return [], []
+
+    async def load_testops_test_data(self, *a: Any, **k: Any) -> tuple[list, list]:
+        return [], []
+
+    async def load_testops_coverage_data(self, *a: Any, **k: Any) -> list:
+        return []
+
+    async def load_incidents(self, *a: Any, **k: Any) -> list:
+        return []
+
+    async def load_work_items(self, *a: Any, **k: Any) -> tuple[list, list]:
+        return self._work_items, self._transitions
+
+
+@pytest.mark.asyncio
+async def test_daily_job_invokes_state_duration_compute_and_persists(
+    monkeypatch: Any,
+) -> None:
+    work_items, transitions = _sample_work_items()
+    sink = _RecordingSink("clickhouse://test")
+    loader = _FakeLoader(work_items, transitions)
+
+    calls: dict[str, Any] = {}
+
+    real_compute = job_daily.compute_work_item_state_durations_daily
+
+    def spy_compute(**kwargs: Any) -> list[Any]:
+        calls["work_items"] = kwargs["work_items"]
+        calls["transitions"] = kwargs["transitions"]
+        calls["day"] = kwargs["day"]
+        rows = real_compute(**kwargs)
+        calls["rows"] = rows
+        return rows
+
+    # Sink + loader seams.
+    monkeypatch.setattr(job_daily, "ClickHouseMetricsSink", lambda db_url: sink)
+
+    async def fake_get_loader(*a: Any, **k: Any) -> Any:
+        return loader
+
+    monkeypatch.setattr(job_daily, "_get_loader", fake_get_loader)
+
+    # The state-duration compute under test.
+    monkeypatch.setattr(
+        job_daily, "compute_work_item_state_durations_daily", spy_compute
+    )
+
+    # Neutralize the surrounding daily-job machinery so we reach the work-item
+    # block without a live ClickHouse / identity / benchmarking dependency.
+    async def _noop_init_team_resolver(*a: Any, **k: Any) -> None:
+        return None
+
+    class _NullResolver:
+        def resolve(self, *a: Any, **k: Any) -> tuple[None, None]:
+            return (None, None)
+
+    monkeypatch.setattr(job_daily, "init_team_resolver", _noop_init_team_resolver)
+    monkeypatch.setattr(job_daily, "get_team_resolver", lambda: _NullResolver())
+    monkeypatch.setattr(
+        job_daily, "build_repo_pattern_resolver", lambda *a, **k: _NullResolver()
+    )
+    monkeypatch.setattr(job_daily, "load_identity_resolver", lambda *a, **k: None)
+    monkeypatch.setattr(job_daily, "discover_repos", lambda **k: [])
+    monkeypatch.setattr(
+        job_daily, "build_governance_rows_for_day", lambda *a, **k: ([], [])
+    )
+    monkeypatch.setattr(
+        job_daily, "_extract_ai_workflow_for_day", lambda **k: ([], [], [], [], [], [])
+    )
+    monkeypatch.setattr(job_daily, "compute_ai_impact_metrics_daily", lambda **k: [])
+    monkeypatch.setattr(job_daily, "run_benchmarking_for_day", lambda *a, **k: None)
+    monkeypatch.setattr(job_daily, "_write_compounding_risk_for_day", lambda **k: 0)
+
+    await job_daily.run_daily_metrics_job(
+        db_url="clickhouse://test",
+        day=DAY,
+        backfill_days=1,
+        provider="auto",
+        org_id="22222222-2222-2222-2222-222222222222",
+        skip_finalize=True,
+    )
+
+    # The compute ran for the day, fed the day's already-loaded rows.
+    assert calls["day"] == DAY
+    assert calls["work_items"] == work_items
+    assert calls["transitions"] == transitions
+
+    # The mapped rows reached the sink via write_work_item_state_durations.
+    assert calls["rows"], "compute produced no rows from the sample transitions"
+    assert sink.state_durations == calls["rows"]
+    statuses = {r.status for r in sink.state_durations}
+    assert "in_progress" in statuses


### PR DESCRIPTION
Computes work_item_state_durations_daily on the scheduled daily job (work_item_transitions were already synced live but never rolled up), so /metrics Flow (Sankey) + Flame and the Operating Review state-duration section populate for real orgs. Writes are deduped via two-stage argMax(...,computed_at) across ALL four reader paths (blocked-hours, sankey, flame, and the /explain + home drivers/contributors) so re-runs/backfills do not inflate.

Part of CHAOS-2372. Closes CHAOS-2377.

Reviewed across multiple adversarial rounds (in-workflow reviewer + Codex). Gates: ruff + full-package mypy + pytest green.
