### PR TITLE
fix(dora): make DORA provider-agnostic; stop GitLab-token crash for GitHub orgs (CHAOS-2382)

### DIFF
--- a/src/dev_health_ops/metrics/compute_dora.py
+++ b/src/dev_health_ops/metrics/compute_dora.py
@@ -1,0 +1,155 @@
+"""Provider-agnostic DORA metric computation from synced ClickHouse rows.
+
+The four DORA metrics are derived from data both the GitHub and GitLab
+processors already write to ClickHouse (``deployments`` and ``incidents``) —
+no live provider API fetch is required (CHAOS-2382). Output rows match the
+``dora_metrics_daily`` contract: one row per ``(repo, metric_name, day)``.
+
+Units mirror the GitLab DORA API so values stay comparable across providers:
+
+* ``deployment_frequency``     — deployment count for the day
+* ``lead_time_for_changes``    — median (deployed_at - merged_at) in seconds
+* ``time_to_restore_service``  — median MTTR (resolved_at - started_at) in seconds
+* ``change_failure_rate``      — failed deployments / total deployments (0..1)
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import date, datetime, time, timedelta, timezone
+from typing import TypedDict
+
+from dev_health_ops.metrics.schemas import (
+    DeploymentRow,
+    DORAMetricsRecord,
+    IncidentRow,
+)
+from dev_health_ops.utils.datetime import to_utc
+
+# Deployment statuses that count as a failed change for change_failure_rate.
+# Mirrors compute_deployments._compute (failed|error|canceled).
+_FAILED_STATUSES = {"failed", "error", "canceled"}
+
+
+class _DeployBucket(TypedDict):
+    deployments: int
+    failed: int
+    lead_times_seconds: list[float]
+
+
+class _IncidentBucket(TypedDict):
+    mttr_seconds: list[float]
+
+
+def _utc_day_window(day: date) -> tuple[datetime, datetime]:
+    start = datetime.combine(day, time.min, tzinfo=timezone.utc)
+    return start, start + timedelta(days=1)
+
+
+def _median(values: Sequence[float]) -> float:
+    sorted_vals = sorted(float(v) for v in values)
+    n = len(sorted_vals)
+    mid = n // 2
+    if n % 2 == 1:
+        return float(sorted_vals[mid])
+    return (sorted_vals[mid - 1] + sorted_vals[mid]) / 2.0
+
+
+def compute_dora_metrics_daily(
+    *,
+    day: date,
+    deployments: Sequence[DeploymentRow],
+    incidents: Sequence[IncidentRow],
+    computed_at: datetime,
+) -> list[DORAMetricsRecord]:
+    """Compute the four DORA metrics per repo for ``day``.
+
+    Returns one ``DORAMetricsRecord`` per (repo, metric) that has data, so a
+    repo with deployments but no incidents still gets deployment_frequency /
+    lead_time / change_failure_rate rows.
+    """
+    start, end = _utc_day_window(day)
+    computed_at_utc = to_utc(computed_at)
+
+    deploy_by_repo: dict[str, _DeployBucket] = {}
+    for deploy_row in deployments:
+        deployed_at = deploy_row.get("deployed_at") or deploy_row.get("started_at")
+        if not isinstance(deployed_at, datetime):
+            continue
+        deployed_at = to_utc(deployed_at)
+        if not (start <= deployed_at < end):
+            continue
+
+        repo_id = str(deploy_row["repo_id"])
+        bucket = deploy_by_repo.get(repo_id)
+        if bucket is None:
+            bucket = {"deployments": 0, "failed": 0, "lead_times_seconds": []}
+            deploy_by_repo[repo_id] = bucket
+
+        bucket["deployments"] += 1
+        status = (deploy_row.get("status") or "").strip().lower()
+        if status in _FAILED_STATUSES:
+            bucket["failed"] += 1
+
+        merged_at = deploy_row.get("merged_at")
+        if isinstance(merged_at, datetime):
+            lead_seconds = (deployed_at - to_utc(merged_at)).total_seconds()
+            if lead_seconds >= 0:
+                bucket["lead_times_seconds"].append(float(lead_seconds))
+
+    incident_by_repo: dict[str, _IncidentBucket] = {}
+    for incident_row in incidents:
+        resolved_at = incident_row.get("resolved_at")
+        if not isinstance(resolved_at, datetime):
+            continue
+        resolved_at = to_utc(resolved_at)
+        if not (start <= resolved_at < end):
+            continue
+
+        started_raw = incident_row.get("started_at")
+        if not isinstance(started_raw, datetime):
+            continue
+        mttr_seconds = (resolved_at - to_utc(started_raw)).total_seconds()
+        if mttr_seconds < 0:
+            continue
+
+        repo_id = str(incident_row["repo_id"])
+        ibucket = incident_by_repo.get(repo_id)
+        if ibucket is None:
+            ibucket = {"mttr_seconds": []}
+            incident_by_repo[repo_id] = ibucket
+        ibucket["mttr_seconds"].append(float(mttr_seconds))
+
+    records: list[DORAMetricsRecord] = []
+
+    def _emit(repo_id: str, metric_name: str, value: float) -> None:
+        records.append(
+            DORAMetricsRecord(
+                repo_id=uuid.UUID(repo_id),
+                day=day,
+                metric_name=metric_name,
+                value=float(value),
+                computed_at=computed_at_utc,
+            )
+        )
+
+    for repo_id, bucket in sorted(deploy_by_repo.items(), key=lambda kv: kv[0]):
+        total = int(bucket["deployments"])
+        _emit(repo_id, "deployment_frequency", float(total))
+        if total > 0:
+            _emit(
+                repo_id,
+                "change_failure_rate",
+                float(bucket["failed"]) / float(total),
+            )
+        lead_times = bucket["lead_times_seconds"]
+        if lead_times:
+            _emit(repo_id, "lead_time_for_changes", _median(lead_times))
+
+    for repo_id, ibucket in sorted(incident_by_repo.items(), key=lambda kv: kv[0]):
+        mttr = ibucket["mttr_seconds"]
+        if mttr:
+            _emit(repo_id, "time_to_restore_service", _median(mttr))
+
+    return records

--- a/src/dev_health_ops/metrics/compute_dora.py
+++ b/src/dev_health_ops/metrics/compute_dora.py
@@ -28,8 +28,18 @@ from dev_health_ops.metrics.schemas import (
 from dev_health_ops.utils.datetime import to_utc
 
 # Deployment statuses that count as a failed change for change_failure_rate.
-# Mirrors compute_deployments._compute (failed|error|canceled).
-_FAILED_STATUSES = {"failed", "error", "canceled"}
+#
+# This must be PROVIDER-AGNOSTIC: deployment rows are persisted from the raw
+# provider status with no normalization (see processors/github.py and
+# processors/gitlab.py -> build_deployment), so both vocabularies coexist in
+# the ``deployments`` table:
+#   * GitHub deployment state  -> 'failure', 'error'   (GitHub Deployment API)
+#   * GitLab deployment status -> 'failed', 'canceled' (GitLab Deployment API)
+# The canonical ClickHouse rollup (026_materialized_views.sql) classifies a
+# failed deployment via ``status = 'failure'``; we include the full union so a
+# GitHub ``status='failure'`` row is not silently counted as a success and
+# driving change_failure_rate toward 0 (CHAOS-2382 round-3).
+_FAILED_STATUSES = {"failure", "failed", "error", "canceled"}
 
 
 class _DeployBucket(TypedDict):

--- a/src/dev_health_ops/metrics/job_dora.py
+++ b/src/dev_health_ops/metrics/job_dora.py
@@ -51,6 +51,35 @@ def _utc_day_window(day: date) -> tuple[datetime, datetime]:
     return start, start + timedelta(days=1)
 
 
+def _repo_filter(
+    params: dict[str, Any],
+    *,
+    org_id: str,
+    repo_id: uuid.UUID | None,
+    repo_name: str | None,
+) -> str:
+    """Build the repo-scoping clause and mutate *params* in place.
+
+    Mirrors the ClickHouseDataLoader pattern: a ``repo_id`` filters directly,
+    while a ``repo_name`` resolves to repo UUIDs via an org-scoped ``repos``
+    subquery. The subquery is org-scoped so a name collision across tenants
+    cannot pull in another org's repo. ``repo_id`` takes precedence when both
+    are supplied.
+    """
+    if repo_id is not None:
+        params["repo_id"] = str(repo_id)
+        return " AND repo_id = {repo_id:UUID}"
+    if repo_name is not None:
+        params["repo_name"] = repo_name
+        return (
+            " AND repo_id IN ("
+            "SELECT id FROM repos"
+            " WHERE repo = {repo_name:String}"
+            " AND org_id = {org_id:String})"
+        )
+    return ""
+
+
 def _load_deployments(
     primary_sink: Any,
     *,
@@ -58,6 +87,7 @@ def _load_deployments(
     start: datetime,
     end: datetime,
     repo_id: uuid.UUID | None,
+    repo_name: str | None = None,
 ) -> list[DeploymentRow]:
     """Read deployments active in the day window from ClickHouse.
 
@@ -66,10 +96,9 @@ def _load_deployments(
     last_synced for in-flight rows).
     """
     params: dict[str, Any] = {"org_id": org_id, "start": start, "end": end}
-    repo_filter = ""
-    if repo_id is not None:
-        params["repo_id"] = str(repo_id)
-        repo_filter = " AND repo_id = {repo_id:UUID}"
+    repo_filter = _repo_filter(
+        params, org_id=org_id, repo_id=repo_id, repo_name=repo_name
+    )
 
     rows = primary_sink.query_dicts(
         "SELECT repo_id, deployment_id, status, environment,"
@@ -94,13 +123,13 @@ def _load_incidents(
     start: datetime,
     end: datetime,
     repo_id: uuid.UUID | None,
+    repo_name: str | None = None,
 ) -> list[IncidentRow]:
     """Read incidents resolved in the day window from ClickHouse."""
     params: dict[str, Any] = {"org_id": org_id, "start": start, "end": end}
-    repo_filter = ""
-    if repo_id is not None:
-        params["repo_id"] = str(repo_id)
-        repo_filter = " AND repo_id = {repo_id:UUID}"
+    repo_filter = _repo_filter(
+        params, org_id=org_id, repo_id=repo_id, repo_name=repo_name
+    )
 
     rows = primary_sink.query_dicts(
         "SELECT repo_id, incident_id, status, started_at, resolved_at"
@@ -190,6 +219,7 @@ def run_dora_metrics_job(
                 start=start,
                 end=end,
                 repo_id=repo_id,
+                repo_name=repo_name,
             )
             incidents = _load_incidents(
                 primary_sink,
@@ -197,6 +227,7 @@ def run_dora_metrics_job(
                 start=start,
                 end=end,
                 repo_id=repo_id,
+                repo_name=repo_name,
             )
 
             # org_id is auto-injected by the sink from its bound context

--- a/src/dev_health_ops/metrics/job_dora.py
+++ b/src/dev_health_ops/metrics/job_dora.py
@@ -4,18 +4,16 @@ import argparse
 import logging
 import os
 import uuid
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 
-from dev_health_ops.connectors import GitLabConnector
-from dev_health_ops.connectors.exceptions import ConnectorException
 from dev_health_ops.db import resolve_sink_uri
-from dev_health_ops.metrics.job_daily import (
-    _discover_repos,
+from dev_health_ops.metrics.compute_dora import compute_dora_metrics_daily
+from dev_health_ops.metrics.schemas import (
+    DeploymentRow,
+    IncidentRow,
 )
-from dev_health_ops.metrics.schemas import DORAMetricsRecord
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
-from dev_health_ops.metrics.work_items import DiscoveredRepo
 from dev_health_ops.storage import detect_db_type
 from dev_health_ops.utils.cli import (
     add_date_range_args,
@@ -48,16 +46,81 @@ def _parse_metrics(raw_metrics: str | None) -> list[str]:
     return metrics or list(DEFAULT_DORA_METRICS)
 
 
-def _is_gitlab_repo(repo: DiscoveredRepo, allow_unknown: bool) -> bool:
-    source = ""
-    if isinstance(repo.settings, dict):
-        source = str(repo.settings.get("source") or "")
-    if not source:
-        source = str(repo.source or "")
-    source = source.strip().lower()
-    if source == "gitlab":
-        return True
-    return allow_unknown
+def _utc_day_window(day: date) -> tuple[datetime, datetime]:
+    start = datetime.combine(day, time.min, tzinfo=timezone.utc)
+    return start, start + timedelta(days=1)
+
+
+def _load_deployments(
+    primary_sink: Any,
+    *,
+    org_id: str,
+    start: datetime,
+    end: datetime,
+    repo_id: uuid.UUID | None,
+) -> list[DeploymentRow]:
+    """Read deployments active in the day window from ClickHouse.
+
+    ``deployments`` is a ReplacingMergeTree, so FINAL dedups pre-merge
+    duplicates. The window matches the daily job (event time falls back to
+    last_synced for in-flight rows).
+    """
+    params: dict[str, Any] = {"org_id": org_id, "start": start, "end": end}
+    repo_filter = ""
+    if repo_id is not None:
+        params["repo_id"] = str(repo_id)
+        repo_filter = " AND repo_id = {repo_id:UUID}"
+
+    rows = primary_sink.query_dicts(
+        "SELECT repo_id, deployment_id, status, environment,"
+        " started_at, finished_at, deployed_at, merged_at,"
+        " pull_request_number"
+        " FROM deployments FINAL"
+        " WHERE org_id = {org_id:String}"
+        "   AND coalesce(deployed_at, finished_at, started_at, last_synced)"
+        "       >= {start:DateTime64(3, 'UTC')}"
+        "   AND coalesce(deployed_at, finished_at, started_at, last_synced)"
+        "       < {end:DateTime64(3, 'UTC')}"
+        f"{repo_filter}",
+        params,
+    )
+    return [r for r in rows if _has_valid_repo(r)]
+
+
+def _load_incidents(
+    primary_sink: Any,
+    *,
+    org_id: str,
+    start: datetime,
+    end: datetime,
+    repo_id: uuid.UUID | None,
+) -> list[IncidentRow]:
+    """Read incidents resolved in the day window from ClickHouse."""
+    params: dict[str, Any] = {"org_id": org_id, "start": start, "end": end}
+    repo_filter = ""
+    if repo_id is not None:
+        params["repo_id"] = str(repo_id)
+        repo_filter = " AND repo_id = {repo_id:UUID}"
+
+    rows = primary_sink.query_dicts(
+        "SELECT repo_id, incident_id, status, started_at, resolved_at"
+        " FROM incidents FINAL"
+        " WHERE org_id = {org_id:String}"
+        "   AND resolved_at IS NOT NULL"
+        "   AND resolved_at >= {start:DateTime64(3, 'UTC')}"
+        "   AND resolved_at < {end:DateTime64(3, 'UTC')}"
+        f"{repo_filter}",
+        params,
+    )
+    return [r for r in rows if _has_valid_repo(r)]
+
+
+def _has_valid_repo(row: dict[str, Any]) -> bool:
+    try:
+        uuid.UUID(str(row.get("repo_id")))
+    except (ValueError, TypeError, AttributeError):
+        return False
+    return True
 
 
 def run_dora_metrics_job(
@@ -95,28 +158,22 @@ def run_dora_metrics_job(
             f"sink='{sink}' requires db backend '{sink}', got '{backend}'."
         )
 
-    token = (auth or os.getenv("GITLAB_TOKEN") or "").strip()
-    if not token:
-        raise ValueError("GitLab token required (set GITLAB_TOKEN or pass --auth).")
+    # CHAOS-2382: DORA is now provider-agnostic — the four metrics are derived
+    # from already-synced ClickHouse rows (deployments / incidents) that both
+    # the GitHub and GitLab processors write. No live provider fetch and no
+    # GITLAB_TOKEN is required, so GitHub-only orgs no longer crash.
+    del interval, gitlab_url, auth  # legacy GitLab-API knobs, retained for API compat
 
-    gitlab_url = gitlab_url or os.getenv("GITLAB_URL") or "https://gitlab.com"
-    resolved_org_id = org_id or ""
+    resolved_org_id = (org_id or "").strip()
 
     days = _date_range(day, backfill_days)
-    start_date = min(days).isoformat()
-    end_date = max(days).isoformat()
-    metrics_list = _parse_metrics(metrics)
+    metrics_list = set(_parse_metrics(metrics))
     computed_at = datetime.now(timezone.utc)
 
-    primary_sink: Any
-
-    primary_sink = ClickHouseMetricsSink(db_url)
-
+    primary_sink: Any = ClickHouseMetricsSink(db_url)
     sinks: list[Any] = [primary_sink]
     for s in sinks:
         setattr(s, "org_id", resolved_org_id)
-
-    connector = GitLabConnector(url=gitlab_url, private_token=token)
 
     try:
         for s in sinks:
@@ -125,59 +182,46 @@ def run_dora_metrics_job(
             elif hasattr(s, "ensure_indexes"):
                 s.ensure_indexes()
 
-        discovered_repos = _discover_repos(
-            backend=backend,
-            primary_sink=primary_sink,
-            repo_id=repo_id,
-            repo_name=repo_name,
-            org_id=resolved_org_id,
-            provider="gitlab",
-        )
+        for d in days:
+            start, end = _utc_day_window(d)
+            deployments = _load_deployments(
+                primary_sink,
+                org_id=resolved_org_id,
+                start=start,
+                end=end,
+                repo_id=repo_id,
+            )
+            incidents = _load_incidents(
+                primary_sink,
+                org_id=resolved_org_id,
+                start=start,
+                end=end,
+                repo_id=repo_id,
+            )
 
-        allow_unknown = repo_id is not None or repo_name is not None
+            # org_id is auto-injected by the sink from its bound context
+            # (ClickHouseCore._insert_rows), matching the daily-job pattern.
+            rows = [
+                row
+                for row in compute_dora_metrics_daily(
+                    day=d,
+                    deployments=deployments,
+                    incidents=incidents,
+                    computed_at=computed_at,
+                )
+                if row.metric_name in metrics_list
+            ]
 
-        for repo in discovered_repos:
-            if not _is_gitlab_repo(repo, allow_unknown):
-                continue
-
-            rows: list[DORAMetricsRecord] = []
-            for metric in metrics_list:
-                try:
-                    dora_metrics = connector.get_dora_metrics(
-                        repo.full_name,
-                        metric,
-                        start_date=start_date,
-                        end_date=end_date,
-                        interval=interval,
-                    )
-                except ConnectorException as exc:
-                    logger.warning(
-                        "GitLab DORA metric fetch failed for %s (%s): %s",
-                        repo.full_name,
-                        metric,
-                        exc,
-                    )
-                    continue
-
-                for dp in dora_metrics.data_points:
-                    rows.append(
-                        DORAMetricsRecord(
-                            repo_id=repo.repo_id,
-                            day=dp.date.date(),
-                            metric_name=metric,
-                            value=float(dp.value),
-                            computed_at=computed_at,
-                        )
-                    )
-
-            for s in sinks:
-                if rows:
+            if rows:
+                for s in sinks:
                     s.write_dora_metrics(rows)
+                logger.info(
+                    "DORA: wrote %d metric rows for org_id=%s day=%s",
+                    len(rows),
+                    resolved_org_id,
+                    d.isoformat(),
+                )
     finally:
-        try:
-            connector.close()
-        except Exception:
-            logger.exception("Error closing GitLab connector")
         for s in sinks:
             try:
                 s.close()
@@ -188,7 +232,7 @@ def run_dora_metrics_job(
 def register_commands(subparsers: argparse._SubParsersAction) -> None:
     dora = subparsers.add_parser(
         "dora",
-        help="Fetch and persist DORA metrics from GitLab (supplemental).",
+        help="Compute and persist DORA metrics from synced ClickHouse data.",
     )
     add_date_range_args(dora)
     dora.add_argument("--repo-id", type=uuid.UUID)
@@ -196,19 +240,21 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
     add_sink_arg(dora)
     dora.add_argument(
         "--metrics",
-        help="Comma-separated metric names to fetch (default: GitLab DORA set).",
+        help="Comma-separated metric names to compute (default: full DORA set).",
     )
+    # Legacy GitLab-API flags retained for backward compatibility; DORA is now
+    # provider-agnostic and sourced from ClickHouse, so these are ignored.
     dora.add_argument(
         "--interval",
         default="daily",
-        help="DORA interval (default: daily).",
+        help=argparse.SUPPRESS,
     )
     dora.add_argument(
         "--gitlab-url",
         default=os.getenv("GITLAB_URL", "https://gitlab.com"),
-        help="GitLab instance URL.",
+        help=argparse.SUPPRESS,
     )
-    dora.add_argument("--auth", help="GitLab token override.")
+    dora.add_argument("--auth", help=argparse.SUPPRESS)
     dora.set_defaults(func=_cmd_metrics_dora)
 
 

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -322,7 +322,10 @@ def _dispatch_post_sync_tasks(
             queue="metrics",
         )
 
-    if provider == "gitlab" and has_git:
+    if has_git:
+        # CHAOS-2382: DORA is provider-agnostic — computed from synced
+        # deployments/incidents in ClickHouse, which both GitHub and GitLab
+        # populate. Dispatch for every git-syncing org, not just GitLab.
         celery_app.send_task(
             "dev_health_ops.workers.tasks.run_dora_metrics",
             kwargs={"org_id": org_id},

--- a/tests/test_job_dora.py
+++ b/tests/test_job_dora.py
@@ -275,6 +275,120 @@ def test_compute_dora_metrics_daily_seconds_units():
     assert "time_to_restore_service" not in by_metric
 
 
+@pytest.mark.parametrize(
+    "failed_status",
+    ["failure", "failed", "error", "canceled", "FAILURE", " Failed "],
+)
+def test_compute_dora_metrics_daily_counts_failed_status_variants(failed_status):
+    """CHAOS-2382 round-3: every provider's failed-deployment vocabulary must
+    contribute to change_failure_rate. GitHub persists ``status='failure'``
+    (raw GitHub Deployment ``state``); GitLab persists ``status='failed'``.
+    Regression for the no-ship where a GitHub ``status='failure'`` row was
+    counted as a success, driving CFR toward 0 and hiding failed changes."""
+    repo_id = uuid.uuid4()
+    rows = compute_dora_metrics_daily(
+        day=date(2025, 1, 1),
+        deployments=[
+            {
+                "repo_id": repo_id,
+                "deployment_id": "d-ok",
+                "status": "success",
+                "environment": "production",
+                "started_at": datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc),
+                "finished_at": datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc),
+                "deployed_at": datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc),
+                "merged_at": None,
+            },
+            {
+                "repo_id": repo_id,
+                "deployment_id": "d-bad",
+                "status": failed_status,
+                "environment": "production",
+                "started_at": datetime(2025, 1, 1, 11, 0, tzinfo=timezone.utc),
+                "finished_at": datetime(2025, 1, 1, 11, 30, tzinfo=timezone.utc),
+                "deployed_at": datetime(2025, 1, 1, 11, 30, tzinfo=timezone.utc),
+                "merged_at": None,
+            },
+        ],
+        incidents=[],
+        computed_at=datetime(2025, 1, 2, tzinfo=timezone.utc),
+    )
+    by_metric = {row.metric_name: row.value for row in rows}
+    assert by_metric["deployment_frequency"] == 2.0
+    # 1 failed of 2 total -> CFR must be 0.5, never 0.0.
+    assert by_metric["change_failure_rate"] == pytest.approx(0.5)
+
+
+def test_compute_dora_metrics_daily_github_failure_not_counted_as_success():
+    """Pin the exact Codex regression at the compute layer: a single
+    GitHub-style ``status='failure'`` deployment yields CFR == 1.0, not 0.0."""
+    repo_id = uuid.uuid4()
+    rows = compute_dora_metrics_daily(
+        day=date(2025, 1, 1),
+        deployments=[
+            {
+                "repo_id": repo_id,
+                "deployment_id": "gh-1",
+                "status": "failure",  # raw GitHub Deployment state
+                "environment": "production",
+                "started_at": datetime(2025, 1, 1, 11, 0, tzinfo=timezone.utc),
+                "finished_at": None,
+                "deployed_at": datetime(2025, 1, 1, 11, 0, tzinfo=timezone.utc),
+                "merged_at": None,
+            },
+        ],
+        incidents=[],
+        computed_at=datetime(2025, 1, 2, tzinfo=timezone.utc),
+    )
+    by_metric = {row.metric_name: row.value for row in rows}
+    assert by_metric["change_failure_rate"] == pytest.approx(1.0)
+
+
+def test_compute_dora_metrics_daily_mixed_provider_failures_per_repo():
+    """A two-repo mix where one repo's failure uses the GitHub vocabulary
+    ('failure') and the other uses GitLab's ('failed') must classify BOTH as
+    failed — proving the failed-status set is provider-agnostic across repos
+    in a single org-wide run."""
+    gh_repo = uuid.uuid4()
+    gl_repo = uuid.uuid4()
+    started = datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc)
+    finished = datetime(2025, 1, 1, 9, 30, tzinfo=timezone.utc)
+    rows = compute_dora_metrics_daily(
+        day=date(2025, 1, 1),
+        deployments=[
+            {
+                "repo_id": gh_repo,
+                "deployment_id": "gh-1",
+                "status": "failure",  # GitHub vocabulary
+                "environment": "production",
+                "started_at": started,
+                "finished_at": finished,
+                "deployed_at": finished,
+                "merged_at": None,
+            },
+            {
+                "repo_id": gl_repo,
+                "deployment_id": "gl-1",
+                "status": "failed",  # GitLab vocabulary
+                "environment": "production",
+                "started_at": started,
+                "finished_at": finished,
+                "deployed_at": finished,
+                "merged_at": None,
+            },
+        ],
+        incidents=[],
+        computed_at=datetime(2025, 1, 2, tzinfo=timezone.utc),
+    )
+    cfr = {
+        str(row.repo_id): row.value
+        for row in rows
+        if row.metric_name == "change_failure_rate"
+    }
+    assert cfr[str(gh_repo)] == pytest.approx(1.0)
+    assert cfr[str(gl_repo)] == pytest.approx(1.0)
+
+
 def test_compute_dora_metrics_daily_ignores_out_of_window():
     repo_id = uuid.uuid4()
     rows = compute_dora_metrics_daily(

--- a/tests/test_job_dora.py
+++ b/tests/test_job_dora.py
@@ -1,11 +1,13 @@
 import uuid
 from datetime import date, datetime, timezone
-from unittest.mock import MagicMock, patch
 
 import pytest
 
-from dev_health_ops.connectors.models import DORAMetric, DORAMetrics
+# Import connectors first to defuse the providers._base <-> connectors circular
+# import so this module collects/runs in isolation (CHAOS-2370 pattern).
+import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.metrics import job_dora
+from dev_health_ops.metrics.compute_dora import compute_dora_metrics_daily
 
 
 def test_run_dora_metrics_job_rejects_sqlite():
@@ -17,58 +19,192 @@ def test_run_dora_metrics_job_rejects_sqlite():
             backfill_days=1,
             repo_id=uuid.uuid4(),
             repo_name="group/project",
-            auth="token",
             org_id="test-org",
         )
 
 
-def test_run_dora_metrics_job_writes_clickhouse(monkeypatch):
-    class FakeGitLabConnector:
-        def __init__(self, url: str, private_token: str) -> None:
-            self.url = url
-            self.private_token = private_token
+class _FakeClickHouseSink:
+    """Captures DORA writes and serves seeded deployments/incidents.
 
-        def get_dora_metrics(
-            self,
-            project_name: str,
-            metric: str,
-            start_date: str | None = None,
-            end_date: str | None = None,
-            interval: str = "daily",
-        ) -> DORAMetrics:
-            return DORAMetrics(
-                metric_name=metric,
-                data_points=[
-                    DORAMetric(
-                        date=datetime(2025, 1, 1, tzinfo=timezone.utc),
-                        value=1.25,
-                    )
-                ],
-            )
+    Mirrors the real ClickHouse sink surface used by run_dora_metrics_job:
+    query_dicts(), ensure_tables(), write_dora_metrics(), close().
+    """
 
-        def close(self) -> None:
-            return
+    def __init__(self, deployments=None, incidents=None):
+        self._deployments = deployments or []
+        self._incidents = incidents or []
+        self.org_id = ""
+        self.written = []
 
-    monkeypatch.setattr(job_dora, "GitLabConnector", FakeGitLabConnector)
+    def query_dicts(self, query, parameters):
+        if "FROM deployments" in query:
+            return self._deployments
+        if "FROM incidents" in query:
+            return self._incidents
+        raise AssertionError(f"Unexpected query: {query}")
 
-    mock_sink = MagicMock()
-    mock_sink.client = MagicMock()
+    def ensure_tables(self):
+        return None
+
+    def write_dora_metrics(self, rows):
+        self.written.extend(rows)
+
+    def close(self):
+        return None
+
+
+def test_run_dora_metrics_job_github_org_no_gitlab_token(monkeypatch):
+    """CHAOS-2382: a GitHub-only org (no GITLAB_TOKEN) must NOT raise and must
+    compute DORA rows from already-synced ClickHouse deployments."""
+    monkeypatch.delenv("GITLAB_TOKEN", raising=False)
 
     repo_id = uuid.uuid4()
+    deployments = [
+        {
+            "repo_id": repo_id,
+            "deployment_id": "d1",
+            "status": "success",
+            "environment": "production",
+            "started_at": datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc),
+            "finished_at": datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc),
+            "deployed_at": datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc),
+            "merged_at": datetime(2025, 1, 1, 8, 0, tzinfo=timezone.utc),
+            "pull_request_number": 42,
+        },
+        {
+            "repo_id": repo_id,
+            "deployment_id": "d2",
+            "status": "failed",
+            "environment": "production",
+            "started_at": datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc),
+            "finished_at": datetime(2025, 1, 1, 12, 30, tzinfo=timezone.utc),
+            "deployed_at": datetime(2025, 1, 1, 12, 30, tzinfo=timezone.utc),
+            "merged_at": None,
+            "pull_request_number": None,
+        },
+    ]
+    incidents = [
+        {
+            "repo_id": repo_id,
+            "incident_id": "i1",
+            "status": "resolved",
+            "started_at": datetime(2025, 1, 1, 13, 0, tzinfo=timezone.utc),
+            "resolved_at": datetime(2025, 1, 1, 14, 0, tzinfo=timezone.utc),
+        },
+    ]
 
-    with patch(
-        "dev_health_ops.metrics.job_dora.ClickHouseMetricsSink",
-        return_value=mock_sink,
-    ):
-        job_dora.run_dora_metrics_job(
-            db_url="clickhouse://localhost:8123/default",
-            day=date(2025, 1, 1),
-            backfill_days=1,
-            repo_id=repo_id,
-            repo_name="group/project",
-            auth="token",
-            org_id="test-org",
-        )
+    sink = _FakeClickHouseSink(deployments=deployments, incidents=incidents)
+    monkeypatch.setattr(job_dora, "ClickHouseMetricsSink", lambda db_url: sink)
 
-    # Verify the sink's write method was called
-    assert mock_sink.write_dora_metrics.called
+    # No auth / GITLAB_TOKEN passed: must not raise.
+    job_dora.run_dora_metrics_job(
+        db_url="clickhouse://localhost:8123/default",
+        day=date(2025, 1, 1),
+        backfill_days=1,
+        org_id="a78c1a6a-0000-0000-0000-000000000000",
+    )
+
+    by_metric = {row.metric_name: row.value for row in sink.written}
+    assert by_metric["deployment_frequency"] == 2.0
+    # 1 failed of 2 deployments
+    assert by_metric["change_failure_rate"] == pytest.approx(0.5)
+    # lead time: deployed 10:00 - merged 08:00 = 2h = 7200s (only d1 has merged_at)
+    assert by_metric["lead_time_for_changes"] == pytest.approx(7200.0)
+    # MTTR: resolved 14:00 - started 13:00 = 1h = 3600s
+    assert by_metric["time_to_restore_service"] == pytest.approx(3600.0)
+
+
+def test_run_dora_metrics_job_no_deployments_writes_nothing(monkeypatch):
+    monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+    sink = _FakeClickHouseSink(deployments=[], incidents=[])
+    monkeypatch.setattr(job_dora, "ClickHouseMetricsSink", lambda db_url: sink)
+
+    job_dora.run_dora_metrics_job(
+        db_url="clickhouse://localhost:8123/default",
+        day=date(2025, 1, 1),
+        backfill_days=1,
+        org_id="test-org",
+    )
+
+    assert sink.written == []
+
+
+def test_run_dora_metrics_job_filters_to_requested_metrics(monkeypatch):
+    monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+    repo_id = uuid.uuid4()
+    deployments = [
+        {
+            "repo_id": repo_id,
+            "deployment_id": "d1",
+            "status": "success",
+            "environment": "production",
+            "started_at": datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc),
+            "finished_at": datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc),
+            "deployed_at": datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc),
+            "merged_at": None,
+            "pull_request_number": None,
+        },
+    ]
+    sink = _FakeClickHouseSink(deployments=deployments, incidents=[])
+    monkeypatch.setattr(job_dora, "ClickHouseMetricsSink", lambda db_url: sink)
+
+    job_dora.run_dora_metrics_job(
+        db_url="clickhouse://localhost:8123/default",
+        day=date(2025, 1, 1),
+        backfill_days=1,
+        metrics="deployment_frequency",
+        org_id="test-org",
+    )
+
+    assert {row.metric_name for row in sink.written} == {"deployment_frequency"}
+
+
+def test_compute_dora_metrics_daily_seconds_units():
+    """Lead time and MTTR are emitted in seconds (GitLab-API parity)."""
+    repo_id = uuid.uuid4()
+    computed_at = datetime(2025, 1, 2, tzinfo=timezone.utc)
+    rows = compute_dora_metrics_daily(
+        day=date(2025, 1, 1),
+        deployments=[
+            {
+                "repo_id": repo_id,
+                "deployment_id": "d1",
+                "status": "success",
+                "environment": "production",
+                "started_at": datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc),
+                "finished_at": datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc),
+                "deployed_at": datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc),
+                "merged_at": datetime(2025, 1, 1, 7, 0, tzinfo=timezone.utc),
+            },
+        ],
+        incidents=[],
+        computed_at=computed_at,
+    )
+    by_metric = {row.metric_name: row.value for row in rows}
+    # 10:00 - 07:00 = 3h = 10800s
+    assert by_metric["lead_time_for_changes"] == pytest.approx(10800.0)
+    assert by_metric["deployment_frequency"] == 1.0
+    assert by_metric["change_failure_rate"] == 0.0
+    assert "time_to_restore_service" not in by_metric
+
+
+def test_compute_dora_metrics_daily_ignores_out_of_window():
+    repo_id = uuid.uuid4()
+    rows = compute_dora_metrics_daily(
+        day=date(2025, 1, 1),
+        deployments=[
+            {
+                "repo_id": repo_id,
+                "deployment_id": "d1",
+                "status": "success",
+                "environment": "production",
+                "started_at": None,
+                "finished_at": None,
+                "deployed_at": datetime(2025, 1, 2, 10, 0, tzinfo=timezone.utc),
+                "merged_at": None,
+            },
+        ],
+        incidents=[],
+        computed_at=datetime(2025, 1, 2, tzinfo=timezone.utc),
+    )
+    assert rows == []

--- a/tests/test_job_dora.py
+++ b/tests/test_job_dora.py
@@ -159,6 +159,93 @@ def test_run_dora_metrics_job_filters_to_requested_metrics(monkeypatch):
     assert {row.metric_name for row in sink.written} == {"deployment_frequency"}
 
 
+class _CapturingClickHouseSink(_FakeClickHouseSink):
+    """Records every query + params so repo scoping can be asserted."""
+
+    def __init__(self, deployments=None, incidents=None):
+        super().__init__(deployments=deployments, incidents=incidents)
+        self.queries: list[tuple[str, dict]] = []
+
+    def query_dicts(self, query, parameters):
+        self.queries.append((query, dict(parameters)))
+        return super().query_dicts(query, parameters)
+
+
+def test_run_dora_metrics_job_repo_name_scopes_both_queries(monkeypatch):
+    """CHAOS-2382 round-2: a ``repo_name``-only run must constrain BOTH the
+    deployment and incident ClickHouse queries via an org-scoped ``repos``
+    subquery. Regression for the no-ship where ``--repo-name`` was accepted but
+    silently dropped, letting a scoped run write DORA rows for every repo."""
+    monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+    sink = _CapturingClickHouseSink(deployments=[], incidents=[])
+    monkeypatch.setattr(job_dora, "ClickHouseMetricsSink", lambda db_url: sink)
+
+    org_id = "a78c1a6a-0000-0000-0000-000000000000"
+    job_dora.run_dora_metrics_job(
+        db_url="clickhouse://localhost:8123/default",
+        day=date(2025, 1, 1),
+        backfill_days=1,
+        repo_name="owner/repo",
+        org_id=org_id,
+    )
+
+    dep_q = next((q, p) for q, p in sink.queries if "FROM deployments" in q)
+    inc_q = next((q, p) for q, p in sink.queries if "FROM incidents" in q)
+    for query, params in (dep_q, inc_q):
+        # The repo-name subquery filter must be present and org-scoped so a
+        # cross-tenant name collision cannot leak another org's repo.
+        assert "repo_id IN (" in query
+        assert "FROM repos" in query
+        assert "repo = {repo_name:String}" in query
+        assert "org_id = {org_id:String}" in query
+        assert params["repo_name"] == "owner/repo"
+        assert params["org_id"] == org_id
+
+
+def test_run_dora_metrics_job_repo_id_takes_precedence(monkeypatch):
+    """When both repo_id and repo_name are passed, repo_id wins (direct filter)
+    and no unscoped repos subquery is emitted."""
+    monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+    sink = _CapturingClickHouseSink(deployments=[], incidents=[])
+    monkeypatch.setattr(job_dora, "ClickHouseMetricsSink", lambda db_url: sink)
+
+    repo_id = uuid.uuid4()
+    job_dora.run_dora_metrics_job(
+        db_url="clickhouse://localhost:8123/default",
+        day=date(2025, 1, 1),
+        backfill_days=1,
+        repo_id=repo_id,
+        repo_name="owner/repo",
+        org_id="test-org",
+    )
+
+    for query, params in sink.queries:
+        assert "repo_id = {repo_id:UUID}" in query
+        assert "FROM repos" not in query
+        assert params["repo_id"] == str(repo_id)
+        assert "repo_name" not in params
+
+
+def test_run_dora_metrics_job_no_repo_scope_omits_filter(monkeypatch):
+    """An unscoped (org-wide) run must not emit any repo filter clause."""
+    monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+    sink = _CapturingClickHouseSink(deployments=[], incidents=[])
+    monkeypatch.setattr(job_dora, "ClickHouseMetricsSink", lambda db_url: sink)
+
+    job_dora.run_dora_metrics_job(
+        db_url="clickhouse://localhost:8123/default",
+        day=date(2025, 1, 1),
+        backfill_days=1,
+        org_id="test-org",
+    )
+
+    for query, params in sink.queries:
+        assert "repo_id =" not in query
+        assert "FROM repos" not in query
+        assert "repo_id" not in params
+        assert "repo_name" not in params
+
+
 def test_compute_dora_metrics_daily_seconds_units():
     """Lead time and MTTR are emitted in seconds (GitLab-API parity)."""
     repo_id = uuid.uuid4()


### PR DESCRIPTION
Makes DORA provider-agnostic so the scheduled run_dora_metrics no longer crashes for GitHub-only orgs (it previously required GITLAB_TOKEN unconditionally and raised "GitLab token required" for every non-GitLab org). DORA now computes from already-synced ClickHouse deployments/incidents rather than a live GitLab fetch; failed-deployment classification corrected for CFR.

Part of CHAOS-2372. Closes CHAOS-2382.

Reviewed across adversarial rounds (in-workflow reviewer + Codex). Gates: ruff + full-package mypy + pytest green.

Tracked follow-ups (non-blocking): CHAOS-2395 (failed-deploy undercount in MV), CHAOS-2399 (post-sync DORA dispatch freshness).
