### PR TITLE
fix(connectors): diagnosable + classified GitHub 403s (CHAOS-2383)

### DIFF
--- a/src/dev_health_ops/connectors/github.py
+++ b/src/dev_health_ops/connectors/github.py
@@ -22,7 +22,11 @@ from dev_health_ops.connectors.base import (
 from dev_health_ops.connectors.exceptions import (
     APIException,
     AuthenticationException,
+    ConnectorException,
     NotFoundException,
+)
+from dev_health_ops.connectors.exceptions import (
+    RateLimitException as ExceptionsRateLimitException,
 )
 from dev_health_ops.connectors.models import (
     Author,
@@ -141,6 +145,25 @@ class GitHubConnector(GitConnector):
         :param e: Exception from GitHub API.
         :raises: Appropriate connector exception.
         """
+        # Already-classified connector exceptions (raised by the GraphQL client
+        # in ``GitHubGraphQLClient.query``) must keep their retry semantics.
+        # Re-wrapping them in the generic ``else`` branch below converts a
+        # deliberately NON-retryable permission/SSO ``AuthenticationException``
+        # into a retryable ``APIException`` ("Unexpected error"), so the outer
+        # ``@retry_with_backoff`` decorator spins five times on an unfixable
+        # permission error with the root cause hidden. Pass these through.
+        #
+        # NB: the retry decorators on the wrappers use
+        # ``connectors.base.RateLimitException`` (imported as
+        # ``RateLimitException`` here), which is a DISTINCT class from
+        # ``connectors.exceptions.RateLimitException`` raised by the GraphQL
+        # client. Normalise the latter to the former so a rate-limit 403 stays
+        # RETRYABLE (it is the ``exceptions=`` tuple member the decorator
+        # catches), while preserving the ``retry_after_seconds`` wait.
+        if isinstance(e, ExceptionsRateLimitException):
+            raise RateLimitException(str(e), retry_after_seconds=e.retry_after_seconds)
+        if isinstance(e, ConnectorException):
+            raise e
         if isinstance(e, RateLimitExceededException):
             record_github_api_request(endpoint="unknown", status_code="429")
             raise RateLimitException(

--- a/src/dev_health_ops/connectors/github.py
+++ b/src/dev_health_ops/connectors/github.py
@@ -40,6 +40,7 @@ from dev_health_ops.connectors.utils import (
     GitHubGraphQLClient,
     match_repo_pattern,
     retry_with_backoff,
+    safe_github_headers,
 )
 from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
 from dev_health_ops.metrics.prometheus import (
@@ -49,8 +50,25 @@ from dev_health_ops.metrics.prometheus import (
 
 logger = logging.getLogger(__name__)
 
+# GitHub response headers worth logging to attribute a 403 (never the token).
+_DIAGNOSTIC_HEADER_NAMES = (
+    "x-ratelimit-remaining",
+    "x-ratelimit-reset",
+    "retry-after",
+    "x-github-request-id",
+    "x-accepted-github-permissions",
+)
+
 if TYPE_CHECKING:
     from dev_health_ops.credentials.types import GitHubCredentials
+
+
+def _diagnostic_headers(headers: dict[str, Any] | None) -> dict[str, str]:
+    """Filter a header mapping down to the diagnostic allow-list (no token)."""
+    if not headers:
+        return {}
+    lowered = {str(k).lower(): str(v) for k, v in headers.items()}
+    return {name: lowered[name] for name in _DIAGNOSTIC_HEADER_NAMES if name in lowered}
 
 
 class GitHubConnector(GitConnector):
@@ -140,11 +158,52 @@ class GitHubConnector(GitConnector):
                     "(fine-grained PAT / GitHub App tokens can 404). "
                     f"Details: {e}"
                 )
+            elif e.status == 403:
+                self._raise_github_403(e)
             else:
                 raise APIException(f"GitHub API error: {e}")
         else:
             record_github_api_request(endpoint="unknown", status_code="500")
             raise APIException(f"Unexpected error: {e}")
+
+    def _raise_github_403(self, e: GithubException) -> None:
+        """Classify a PyGithub 403 and raise an attributable exception.
+
+        Logs the diagnostic GitHub headers (never the token), then:
+        - x-ratelimit-remaining == 0 -> retryable RateLimitException (reset wait).
+        - Retry-After present -> retryable RateLimitException (secondary/abuse).
+        - permission/SSO/other -> NON-retryable AuthenticationException so the
+          retry decorator does not spin on an unfixable permission error.
+        """
+        headers = getattr(e, "headers", None)
+        diag = _diagnostic_headers(headers if isinstance(headers, dict) else None)
+        body = getattr(e, "data", None)
+        # (a) primary rate limit.
+        if diag.get("x-ratelimit-remaining") == "0":
+            logger.warning("GitHub primary rate limit (403) headers=%s", diag)
+            raise RateLimitException(
+                f"GitHub rate limit (403) (headers={diag})",
+                retry_after_seconds=self._rate_limit_reset_delay_seconds(),
+            )
+        # (b) secondary/abuse limit.
+        retry_after = diag.get("retry-after")
+        if retry_after is not None:
+            logger.warning("GitHub secondary/abuse rate limit (403) headers=%s", diag)
+            try:
+                retry_after_seconds: float | None = float(retry_after)
+            except ValueError:
+                retry_after_seconds = None
+            raise RateLimitException(
+                f"GitHub secondary/abuse rate limit (403) (headers={diag})",
+                retry_after_seconds=retry_after_seconds,
+            )
+        # (c) permission/SSO/other 403 -> non-retryable.
+        logger.warning("GitHub 403 (permission/SSO) headers=%s body=%s", diag, body)
+        raise AuthenticationException(
+            "GitHub 403 (permission/SSO): token likely lacks a required "
+            "scope/permission or the org requires SAML SSO authorization for "
+            f"this token (headers={diag}). Details: {e}"
+        )
 
     @retry_with_backoff(
         max_retries=3,
@@ -771,8 +830,61 @@ class GitHubConnector(GitConnector):
             return None
 
     def _is_github_rate_limit_403(self, response: requests.Response) -> bool:
+        # Primary rate limit advertises x-ratelimit-remaining: 0; secondary/
+        # abuse limits advertise Retry-After. Fall back to the body wording for
+        # older responses that omit the headers.
+        diag = safe_github_headers(response)
+        if diag.get("x-ratelimit-remaining") == "0" or "retry-after" in diag:
+            return True
         body = response.text.lower()
         return "rate limit" in body or "abuse" in body or "secondary" in body
+
+    def _classify_github_403(
+        self, response: requests.Response, method: str, endpoint: str
+    ) -> RateLimitException | None:
+        """Classify a 403 and log diagnostic headers (never the token).
+
+        Returns a ``RateLimitException`` (with the appropriate wait) for primary
+        or secondary/abuse rate limits, or ``None`` for a permission/SSO/other
+        403. In all cases the endpoint, HTTP method and key GitHub response
+        headers are logged so the failure is attributable.
+        """
+        diag = safe_github_headers(response)
+        retry_after = diag.get("retry-after")
+        # (a) primary rate limit -> wait for the reset window.
+        if diag.get("x-ratelimit-remaining") == "0":
+            logger.warning(
+                "GitHub primary rate limit (403) on %s %s headers=%s",
+                method,
+                endpoint,
+                diag,
+            )
+            return RateLimitException(
+                f"GitHub rate limit (403) on {method} {endpoint} (headers={diag})",
+                retry_after_seconds=(float(retry_after) if retry_after else None),
+            )
+        # (b) secondary/abuse limit -> backoff per Retry-After / body wording.
+        if retry_after is not None or self._is_github_rate_limit_403(response):
+            logger.warning(
+                "GitHub secondary/abuse rate limit (403) on %s %s headers=%s",
+                method,
+                endpoint,
+                diag,
+            )
+            return RateLimitException(
+                f"GitHub secondary/abuse rate limit (403) on {method} {endpoint} "
+                f"(headers={diag})",
+                retry_after_seconds=(float(retry_after) if retry_after else None),
+            )
+        # (c) permission/SSO/other 403 -> not a rate limit.
+        logger.warning(
+            "GitHub 403 (permission/SSO) on %s %s headers=%s body=%s",
+            method,
+            endpoint,
+            diag,
+            response.text,
+        )
+        return None
 
     def _get_security_alert_page(
         self,
@@ -799,18 +911,14 @@ class GitHubConnector(GitConnector):
             )
 
             if response.status_code == 403:
-                if self._is_github_rate_limit_403(response):
-                    retry_after = response.headers.get("Retry-After")
-                    raise RateLimitException(
-                        f"GitHub rate limit (403) for {endpoint}: {response.text}",
-                        retry_after_seconds=float(retry_after) if retry_after else None,
-                    )
-                logger.debug(
-                    "GitHub security endpoint unavailable for %s/%s (%s): 403",
-                    owner,
-                    repo,
-                    endpoint,
+                rate_limit = self._classify_github_403(
+                    response, "GET", f"/repos/{owner}/{repo}/{endpoint}"
                 )
+                if rate_limit is not None:
+                    raise rate_limit
+                # Permission/SSO 403 on an optional security endpoint: the
+                # feature is likely disabled or the token lacks the scope.
+                # Treat as "no data" (the diagnostic 403 was already logged).
                 return []
 
             if response.status_code == 404:
@@ -901,12 +1009,13 @@ class GitHubConnector(GitConnector):
             params = None
 
             if response.status_code == 403:
-                if self._is_github_rate_limit_403(response):
-                    retry_after = response.headers.get("Retry-After")
-                    raise RateLimitException(
-                        f"GitHub rate limit (403) listing artifacts: {response.text}",
-                        retry_after_seconds=float(retry_after) if retry_after else None,
-                    )
+                rate_limit = self._classify_github_403(
+                    response,
+                    "GET",
+                    f"/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
+                )
+                if rate_limit is not None:
+                    raise rate_limit
                 return artifacts
             if response.status_code == 404:
                 return artifacts
@@ -969,12 +1078,14 @@ class GitHubConnector(GitConnector):
 
         if response.status_code in (404, 410):
             return b""
-        if response.status_code == 403 and self._is_github_rate_limit_403(response):
-            retry_after = response.headers.get("Retry-After")
-            raise RateLimitException(
-                f"GitHub rate limit downloading artifact {artifact_id}",
-                retry_after_seconds=float(retry_after) if retry_after else None,
+        if response.status_code == 403:
+            rate_limit = self._classify_github_403(
+                response,
+                "GET",
+                f"/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip",
             )
+            if rate_limit is not None:
+                raise rate_limit
         if response.status_code in (301, 302, 307, 308):
             location = response.headers.get("Location")
             if not location:

--- a/src/dev_health_ops/connectors/utils/__init__.py
+++ b/src/dev_health_ops/connectors/utils/__init__.py
@@ -7,7 +7,7 @@ from .github_app import (
     GitHubAppTokenProvider,
     create_github_app_jwt,
 )
-from .graphql import GitHubGraphQLClient
+from .graphql import GitHubGraphQLClient, safe_github_headers
 from .pagination import AsyncPaginationHandler, PaginationHandler
 from .patterns import match_name_pattern, match_project_pattern, match_repo_pattern
 from .rate_limit_queue import (
@@ -22,6 +22,7 @@ from .token_pool import TokenPool, create_token_pool
 
 __all__ = [
     "GitHubGraphQLClient",
+    "safe_github_headers",
     "GitHubAppAuthError",
     "GitHubAppTokenProvider",
     "create_github_app_jwt",

--- a/src/dev_health_ops/connectors/utils/graphql.py
+++ b/src/dev_health_ops/connectors/utils/graphql.py
@@ -23,6 +23,18 @@ from dev_health_ops.connectors.utils.retry import retry_with_backoff
 logger = logging.getLogger(__name__)
 
 
+# GitHub response headers that explain a 403/rate-limit without leaking the
+# token. Logged verbatim so an operator can attribute a failure to a permission,
+# SSO, or rate-limit cause.
+_DIAGNOSTIC_HEADERS = (
+    "x-ratelimit-remaining",
+    "x-ratelimit-reset",
+    "retry-after",
+    "x-github-request-id",
+    "x-accepted-github-permissions",
+)
+
+
 def _github_reset_delay_seconds(
     response: requests.Response,
 ) -> float | None:
@@ -35,6 +47,18 @@ def _github_reset_delay_seconds(
         return None
 
     return max(0.0, reset_epoch - time.time())
+
+
+def safe_github_headers(response: requests.Response) -> dict[str, str]:
+    """Extract diagnostic GitHub headers, never the credential.
+
+    Returns only the allow-listed ``_DIAGNOSTIC_HEADERS`` so logs and error
+    messages can attribute a 403 (rate-limit vs permission/SSO) without ever
+    echoing ``Authorization``. Header lookup is case-insensitive (HTTP headers
+    are case-insensitive; ``requests`` uses a ``CaseInsensitiveDict``).
+    """
+    lowered = {str(k).lower(): str(v) for k, v in response.headers.items()}
+    return {name: lowered[name] for name in _DIAGNOSTIC_HEADERS if name in lowered}
 
 
 class GitHubGraphQLClient:
@@ -112,14 +136,43 @@ class GitHubGraphQLClient:
             if response.status_code == 401:
                 raise AuthenticationException("GitHub authentication failed")
             elif response.status_code == 403:
-                # Could be rate limit or other forbidden error
-                rate_limit_remaining = response.headers.get("X-RateLimit-Remaining")
-                if rate_limit_remaining == "0":
+                diag = safe_github_headers(response)
+                logger.warning(
+                    "GitHub 403 on POST %s headers=%s body=%s",
+                    self.GRAPHQL_ENDPOINT,
+                    diag,
+                    response.text,
+                )
+                # (a) primary rate limit: remaining quota exhausted -> retry
+                # after the reset window.
+                if diag.get("x-ratelimit-remaining") == "0":
                     raise RateLimitException(
-                        "GitHub API rate limit exceeded",
+                        f"GitHub API rate limit exceeded on POST "
+                        f"{self.GRAPHQL_ENDPOINT} (headers={diag})",
                         retry_after_seconds=_github_reset_delay_seconds(response),
                     )
-                raise APIException(f"GitHub API forbidden: {response.text}")
+                # (b) secondary/abuse limit: Retry-After present -> backoff.
+                retry_after = diag.get("retry-after")
+                if retry_after is not None:
+                    try:
+                        retry_after_seconds: float | None = float(retry_after)
+                    except ValueError:
+                        retry_after_seconds = None
+                    raise RateLimitException(
+                        f"GitHub secondary/abuse rate limit on POST "
+                        f"{self.GRAPHQL_ENDPOINT} (headers={diag})",
+                        retry_after_seconds=retry_after_seconds,
+                    )
+                # (c) permission/SSO/other 403: NOT a transient condition.
+                # Raise a non-retryable AuthenticationException so the retry
+                # decorator (which only retries RateLimitException/APIException)
+                # does not blindly spin on an unfixable permission error.
+                raise AuthenticationException(
+                    f"GitHub 403 (permission/SSO) on POST {self.GRAPHQL_ENDPOINT}: "
+                    "token likely lacks a required scope/permission or the org "
+                    "requires SAML SSO authorization for this token "
+                    f"(headers={diag}). Body: {response.text}"
+                )
             elif response.status_code != 200:
                 raise APIException(
                     f"GitHub API error: {response.status_code} - {response.text}"

--- a/src/dev_health_ops/connectors/utils/graphql.py
+++ b/src/dev_health_ops/connectors/utils/graphql.py
@@ -151,13 +151,27 @@ class GitHubGraphQLClient:
                         f"{self.GRAPHQL_ENDPOINT} (headers={diag})",
                         retry_after_seconds=_github_reset_delay_seconds(response),
                     )
-                # (b) secondary/abuse limit: Retry-After present -> backoff.
+                # (b) secondary/abuse limit: Retry-After present, OR the body
+                # carries GitHub's documented secondary/abuse wording even with
+                # no Retry-After header (a DOCUMENTED case). Mirrors the REST
+                # path's ``_is_github_rate_limit_403`` body-wording fallback so
+                # both transports back off + retry instead of raising a
+                # non-retryable auth error on the file-contents/blame hot path.
                 retry_after = diag.get("retry-after")
-                if retry_after is not None:
-                    try:
-                        retry_after_seconds: float | None = float(retry_after)
-                    except ValueError:
-                        retry_after_seconds = None
+                body = response.text.lower()
+                body_indicates_rate_limit = (
+                    "rate limit" in body or "abuse" in body or "secondary" in body
+                )
+                if retry_after is not None or body_indicates_rate_limit:
+                    if retry_after is not None:
+                        try:
+                            retry_after_seconds: float | None = float(retry_after)
+                        except ValueError:
+                            retry_after_seconds = None
+                    else:
+                        # Body-only secondary/abuse 403 with no Retry-After:
+                        # back off a sane default before the decorator retries.
+                        retry_after_seconds = 60.0
                     raise RateLimitException(
                         f"GitHub secondary/abuse rate limit on POST "
                         f"{self.GRAPHQL_ENDPOINT} (headers={diag})",

--- a/src/dev_health_ops/connectors/utils/retry.py
+++ b/src/dev_health_ops/connectors/utils/retry.py
@@ -102,6 +102,8 @@ def retry_with_backoff(
     """
 
     def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        op_name = getattr(func, "__qualname__", getattr(func, "__name__", repr(func)))
+
         @wraps(func)
         async def async_wrapper(*args: Any, **kwargs: Any) -> T:
             rate_limiter = RateLimiter(
@@ -122,7 +124,8 @@ def retry_with_backoff(
                     if attempt < max_retries - 1:
                         retry_after = _get_retry_after_seconds(e)
                         logger.warning(
-                            "Attempt %s/%s failed: %s. Retrying...",
+                            "%s attempt %s/%s failed: %s. Retrying...",
+                            op_name,
                             attempt + 1,
                             max_retries,
                             e,
@@ -137,7 +140,8 @@ def retry_with_backoff(
                             await rate_limiter.wait()
                     else:
                         logger.error(
-                            "All %s attempts failed. Giving up.",
+                            "%s: all %s attempts failed. Giving up.",
+                            op_name,
                             max_retries,
                         )
 
@@ -166,7 +170,8 @@ def retry_with_backoff(
                     if attempt < max_retries - 1:
                         retry_after = _get_retry_after_seconds(e)
                         logger.warning(
-                            "Attempt %s/%s failed: %s. Retrying...",
+                            "%s attempt %s/%s failed: %s. Retrying...",
+                            op_name,
                             attempt + 1,
                             max_retries,
                             e,
@@ -181,7 +186,8 @@ def retry_with_backoff(
                             rate_limiter.wait_sync()
                     else:
                         logger.error(
-                            "All %s attempts failed. Giving up.",
+                            "%s: all %s attempts failed. Giving up.",
+                            op_name,
                             max_retries,
                         )
 

--- a/tests/test_github_403_observability.py
+++ b/tests/test_github_403_observability.py
@@ -279,6 +279,106 @@ def test_pygithub_primary_rate_limit_403_raises_rate_limit(monkeypatch):
 
 
 # --------------------------------------------------------------------------
+# _handle_github_exception — already-classified connector exceptions pass
+# through UNCHANGED (the permission/SSO 403 -> retry-spin regression).
+# --------------------------------------------------------------------------
+
+
+def test_handle_github_exception_passes_through_authentication_exception():
+    # A non-retryable AuthenticationException (raised by the GraphQL client for
+    # a permission/SSO 403) must NOT be re-wrapped into a retryable APIException.
+    auth_exc = AuthenticationException("GitHub 403 (permission/SSO): ...")
+    with GitHubConnector(token="t") as connector:
+        with pytest.raises(AuthenticationException) as exc_info:
+            connector._handle_github_exception(auth_exc)
+
+    # Same object, unchanged type — not reclassified to APIException.
+    assert exc_info.value is auth_exc
+    assert not isinstance(exc_info.value, APIException)
+
+
+def test_handle_github_exception_normalises_graphql_rate_limit_to_retryable():
+    # A GraphQL-originated exceptions.RateLimitException is normalised to the
+    # base.RateLimitException the wrapper retry decorator catches (preserving the
+    # wait), NOT collapsed into the generic APIException ("Unexpected error")
+    # branch. This keeps a rate-limit 403 RETRYABLE on the file-content/blame
+    # hot path while a permission/SSO 403 stays non-retryable.
+    rl_exc = ExcRateLimitException(
+        "secondary/abuse rate limit", retry_after_seconds=42.0
+    )
+    with GitHubConnector(token="t") as connector:
+        with pytest.raises(RateLimitException) as exc_info:
+            connector._handle_github_exception(rl_exc)
+
+    assert exc_info.value.retry_after_seconds == pytest.approx(42.0)
+    assert "secondary/abuse rate limit" in str(exc_info.value)
+
+
+# --------------------------------------------------------------------------
+# File-content / blame wrappers — a permission/SSO 403 from the GraphQL layer
+# must NOT be retried 5x nor reclassified to APIException by the outer
+# @retry_with_backoff(exceptions=(RateLimitException, APIException)) decorator.
+# --------------------------------------------------------------------------
+
+
+def test_get_file_contents_permission_403_not_retried(monkeypatch):
+    monkeypatch.setattr(
+        "dev_health_ops.connectors.utils.retry.time.sleep", lambda *_: None
+    )
+    auth_exc = AuthenticationException(
+        "GitHub 403 (permission/SSO) on POST https://api.github.com/graphql: ..."
+    )
+    with GitHubConnector(token="t") as connector:
+        connector.graphql.get_blob_texts = MagicMock(side_effect=auth_exc)
+        with pytest.raises(AuthenticationException) as exc_info:
+            connector.get_file_contents("o", "r", ["a.py"])
+
+    # Exactly ONE GraphQL call: the decorator did not spin on a non-retryable
+    # permission failure, and the error was not reclassified to APIException.
+    assert connector.graphql.get_blob_texts.call_count == 1
+    assert not isinstance(exc_info.value, APIException)
+    assert "permission" in str(exc_info.value) or "SSO" in str(exc_info.value)
+
+
+def test_get_file_blame_permission_403_not_retried(monkeypatch):
+    monkeypatch.setattr(
+        "dev_health_ops.connectors.utils.retry.time.sleep", lambda *_: None
+    )
+    auth_exc = AuthenticationException(
+        "GitHub 403 (permission/SSO) on POST https://api.github.com/graphql: ..."
+    )
+    with GitHubConnector(token="t") as connector:
+        connector.graphql.get_blame = MagicMock(side_effect=auth_exc)
+        with pytest.raises(AuthenticationException) as exc_info:
+            connector.get_file_blame("o", "r", "a.py")
+
+    assert connector.graphql.get_blame.call_count == 1
+    assert not isinstance(exc_info.value, APIException)
+
+
+def test_get_file_contents_rate_limit_403_is_still_retried(monkeypatch):
+    # A rate-limit 403 surfaces from the GraphQL client as
+    # ``exceptions.RateLimitException``, a DISTINCT class from the
+    # ``base.RateLimitException`` the wrapper's retry decorator catches.
+    # ``_handle_github_exception`` normalises it to ``base.RateLimitException``
+    # (preserving the wait) so it STILL retries — a permission 403 must not be
+    # made retryable, but a rate-limit 403 must remain so.
+    monkeypatch.setattr(
+        "dev_health_ops.connectors.utils.retry.time.sleep", lambda *_: None
+    )
+    rl_exc = ExcRateLimitException("rate limit 403", retry_after_seconds=0.0)
+    with GitHubConnector(token="t") as connector:
+        connector.graphql.get_blob_texts = MagicMock(side_effect=rl_exc)
+        with pytest.raises(RateLimitException) as exc_info:
+            connector.get_file_contents("o", "r", ["a.py"])
+
+    # max_retries=3 on get_file_contents -> exhausts all 3 attempts.
+    assert connector.graphql.get_blob_texts.call_count == 3
+    # Normalised to the retryable base RateLimitException, wait preserved.
+    assert exc_info.value.retry_after_seconds == pytest.approx(0.0)
+
+
+# --------------------------------------------------------------------------
 # retry_with_backoff — operation name is now in the log line
 # --------------------------------------------------------------------------
 

--- a/tests/test_github_403_observability.py
+++ b/tests/test_github_403_observability.py
@@ -146,6 +146,30 @@ def test_graphql_secondary_abuse_403_raises_rate_limit_with_wait(monkeypatch):
     assert GitHubGraphQLClient.GRAPHQL_ENDPOINT in str(exc_info.value)
 
 
+def test_graphql_body_only_secondary_403_is_retryable_without_retry_after(monkeypatch):
+    # GitHub-documented case: a secondary/abuse 403 whose body carries the
+    # wording but with NO Retry-After header and NO x-ratelimit-remaining:0.
+    # The body-wording fallback (mirroring the REST path) must classify it as a
+    # RETRYABLE RateLimitException, not a non-retryable AuthenticationException,
+    # so the file-contents/blame hot path backs off and retries.
+    response = _FakeResponse(
+        status_code=403,
+        headers={"X-GitHub-Request-Id": "REQ:11"},
+        text="You have exceeded a secondary rate limit. Please wait a few minutes.",
+    )
+    _patch_post(monkeypatch, response)
+
+    client = GitHubGraphQLClient("token")
+    with pytest.raises(ExcRateLimitException) as exc_info:
+        client.query("query { viewer { login } }")
+
+    # Retryable rate-limit error (not AuthenticationException) with a sane
+    # default wait since no Retry-After header was present.
+    assert not isinstance(exc_info.value, AuthenticationException)
+    assert exc_info.value.retry_after_seconds == pytest.approx(60.0)
+    assert GitHubGraphQLClient.GRAPHQL_ENDPOINT in str(exc_info.value)
+
+
 def test_graphql_primary_rate_limit_403_names_endpoint_and_headers(monkeypatch):
     response = _FakeResponse(
         status_code=403,

--- a/tests/test_github_403_observability.py
+++ b/tests/test_github_403_observability.py
@@ -1,0 +1,281 @@
+"""Diagnosability of GitHub connector 403s (CHAOS-2383).
+
+A real permission/SSO 403 used to surface only as
+``Attempt 2/5 failed: Forbidden`` with no endpoint/headers, and the generic
+retry decorator spun on it five times. These tests assert that:
+
+- a bare/permission 403 raises a NON-retryable error naming the endpoint and
+  the captured GitHub headers (so the retry decorator does not spin),
+- rate-limit headers (primary) and Retry-After (secondary/abuse) raise
+  ``RateLimitException`` with the correct wait,
+- the error/log message includes the endpoint and the diagnostic headers,
+- the retry wrapper labels its warnings with the wrapped operation name.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# Initialize the connectors package first to avoid the pre-existing
+# providers._base <-> connectors circular import on isolated collection.
+import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.connectors.base import RateLimitException
+from dev_health_ops.connectors.exceptions import (
+    APIException,
+    AuthenticationException,
+)
+from dev_health_ops.connectors.exceptions import (
+    RateLimitException as ExcRateLimitException,
+)
+from dev_health_ops.connectors.github import GitHubConnector
+from dev_health_ops.connectors.utils.graphql import (
+    GitHubGraphQLClient,
+    safe_github_headers,
+)
+from dev_health_ops.connectors.utils.retry import retry_with_backoff
+
+
+class _FakeResponse:
+    """Minimal stand-in for ``requests.Response`` with case-insensitive-ish
+    headers fed as a plain dict (the production helper lowercases keys)."""
+
+    def __init__(
+        self,
+        status_code: int,
+        headers: dict[str, str] | None = None,
+        text: str = "",
+    ) -> None:
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = text
+
+    def json(self) -> dict[str, Any]:
+        return {}
+
+
+# --------------------------------------------------------------------------
+# safe_github_headers — never leaks the token, captures the diagnostic set
+# --------------------------------------------------------------------------
+
+
+def test_safe_github_headers_filters_to_allowlist_and_drops_token():
+    response = _FakeResponse(
+        status_code=403,
+        headers={
+            "Authorization": "Bearer ghs_secret",
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "12345",
+            "Retry-After": "30",
+            "X-GitHub-Request-Id": "ABCD:1234",
+            "X-Accepted-GitHub-Permissions": "contents=read",
+        },
+    )
+    diag = safe_github_headers(response)  # type: ignore[arg-type]
+
+    assert "authorization" not in {k.lower() for k in diag}
+    assert diag["x-ratelimit-remaining"] == "0"
+    assert diag["x-ratelimit-reset"] == "12345"
+    assert diag["retry-after"] == "30"
+    assert diag["x-github-request-id"] == "ABCD:1234"
+    assert diag["x-accepted-github-permissions"] == "contents=read"
+
+
+# --------------------------------------------------------------------------
+# GraphQL query() — the max_retries=5 path that spun on bare 403s
+# --------------------------------------------------------------------------
+
+
+def _patch_post(monkeypatch, response):
+    monkeypatch.setattr(
+        "dev_health_ops.connectors.utils.graphql.requests.post",
+        MagicMock(return_value=response),
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.connectors.utils.retry.time.sleep", lambda *_: None
+    )
+
+
+def test_graphql_permission_403_is_nonretryable_and_names_endpoint(monkeypatch):
+    post = MagicMock(
+        return_value=_FakeResponse(
+            status_code=403,
+            headers={
+                "X-GitHub-Request-Id": "REQ:9",
+                "X-Accepted-GitHub-Permissions": "contents=read",
+            },
+            text="Resource protected by organization SAML enforcement.",
+        )
+    )
+    monkeypatch.setattr("dev_health_ops.connectors.utils.graphql.requests.post", post)
+    monkeypatch.setattr(
+        "dev_health_ops.connectors.utils.retry.time.sleep", lambda *_: None
+    )
+
+    client = GitHubGraphQLClient("token")
+    with pytest.raises(AuthenticationException) as exc_info:
+        client.query("query { viewer { login } }")
+
+    message = str(exc_info.value)
+    # Non-retryable: AuthenticationException is not in the retry tuple, so the
+    # decorator must NOT have retried -> exactly one HTTP call.
+    assert post.call_count == 1
+    # Error names the endpoint and surfaces the diagnostic headers.
+    assert GitHubGraphQLClient.GRAPHQL_ENDPOINT in message
+    assert "x-github-request-id" in message
+    assert "REQ:9" in message
+    assert "SSO" in message or "permission" in message
+
+
+def test_graphql_secondary_abuse_403_raises_rate_limit_with_wait(monkeypatch):
+    response = _FakeResponse(
+        status_code=403,
+        headers={"Retry-After": "42", "X-GitHub-Request-Id": "REQ:7"},
+        text="You have exceeded a secondary rate limit.",
+    )
+    _patch_post(monkeypatch, response)
+
+    client = GitHubGraphQLClient("token")
+    with pytest.raises(ExcRateLimitException) as exc_info:
+        client.query("query { viewer { login } }")
+
+    assert exc_info.value.retry_after_seconds == pytest.approx(42.0)
+    assert GitHubGraphQLClient.GRAPHQL_ENDPOINT in str(exc_info.value)
+
+
+def test_graphql_primary_rate_limit_403_names_endpoint_and_headers(monkeypatch):
+    response = _FakeResponse(
+        status_code=403,
+        headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "105"},
+        text="API rate limit exceeded",
+    )
+    _patch_post(monkeypatch, response)
+    monkeypatch.setattr(
+        "dev_health_ops.connectors.utils.graphql.time.time", lambda: 100
+    )
+
+    client = GitHubGraphQLClient("token")
+    with pytest.raises(ExcRateLimitException) as exc_info:
+        client.query("query { viewer { login } }")
+
+    assert exc_info.value.retry_after_seconds == pytest.approx(5.0)
+    message = str(exc_info.value)
+    assert GitHubGraphQLClient.GRAPHQL_ENDPOINT in message
+    assert "x-ratelimit-remaining" in message
+
+
+# --------------------------------------------------------------------------
+# GitHubConnector._classify_github_403 — REST 403 paths
+# --------------------------------------------------------------------------
+
+
+def test_rest_classify_permission_403_returns_none_and_logs_endpoint(caplog):
+    with GitHubConnector(token="t") as connector:
+        response = _FakeResponse(
+            status_code=403,
+            headers={"X-GitHub-Request-Id": "REQ:1"},
+            text="Resource not accessible by integration",
+        )
+        with caplog.at_level(logging.WARNING):
+            result = connector._classify_github_403(
+                response,
+                "GET",
+                "/repos/o/r/dependabot/alerts",
+            )
+
+    # Permission 403 -> not a rate limit -> caller falls back to "no data".
+    assert result is None
+    log_text = caplog.text
+    assert "/repos/o/r/dependabot/alerts" in log_text
+    assert "GET" in log_text
+    assert "REQ:1" in log_text
+    assert "permission" in log_text.lower() or "sso" in log_text.lower()
+
+
+def test_rest_classify_primary_rate_limit_returns_rate_limit(monkeypatch):
+    with GitHubConnector(token="t") as connector:
+        response = _FakeResponse(
+            status_code=403,
+            headers={"X-RateLimit-Remaining": "0", "Retry-After": "17"},
+            text="API rate limit exceeded",
+        )
+        result = connector._classify_github_403(
+            response,
+            "GET",
+            "/repos/o/r/actions/runs/9/artifacts",
+        )
+
+    assert isinstance(result, RateLimitException)
+    assert result.retry_after_seconds == pytest.approx(17.0)
+    assert "/repos/o/r/actions/runs/9/artifacts" in str(result)
+
+
+# --------------------------------------------------------------------------
+# GitHubConnector._raise_github_403 — PyGithub exception path
+# --------------------------------------------------------------------------
+
+
+def test_pygithub_permission_403_is_nonretryable_auth_error(caplog):
+    from github.GithubException import GithubException
+
+    with GitHubConnector(token="t") as connector:
+        exc = GithubException(
+            403,
+            {"message": "Resource protected by organization SAML enforcement."},
+            {"x-github-request-id": "REQ:42"},
+        )
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(AuthenticationException) as exc_info:
+                connector._handle_github_exception(exc)
+
+    message = str(exc_info.value)
+    assert "REQ:42" in message
+    assert "SSO" in message or "permission" in message
+    assert "REQ:42" in caplog.text
+
+
+def test_pygithub_primary_rate_limit_403_raises_rate_limit(monkeypatch):
+    from github.GithubException import GithubException
+
+    with GitHubConnector(token="t") as connector:
+        monkeypatch.setattr(connector, "_rate_limit_reset_delay_seconds", lambda: 99.0)
+        exc = GithubException(
+            403,
+            {"message": "API rate limit exceeded"},
+            {"x-ratelimit-remaining": "0", "x-github-request-id": "REQ:5"},
+        )
+        with pytest.raises(RateLimitException) as exc_info:
+            connector._handle_github_exception(exc)
+
+    assert exc_info.value.retry_after_seconds == pytest.approx(99.0)
+    assert "REQ:5" in str(exc_info.value)
+
+
+# --------------------------------------------------------------------------
+# retry_with_backoff — operation name is now in the log line
+# --------------------------------------------------------------------------
+
+
+def test_retry_logs_include_operation_name(caplog):
+    calls = {"n": 0}
+
+    @retry_with_backoff(
+        max_retries=2,
+        initial_delay=0.0,
+        max_delay=0.0,
+        exceptions=(APIException,),
+    )
+    def flaky_operation() -> str:
+        calls["n"] += 1
+        raise APIException("boom")
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(APIException):
+            flaky_operation()
+
+    assert calls["n"] == 2
+    # The wrapped function's qualname must appear in the retry warning.
+    assert "flaky_operation" in caplog.text


### PR DESCRIPTION
Makes GitHub connector 403s diagnosable and correctly classified: the retry wrapper + connector now log endpoint, method, org, and the relevant GitHub response headers (x-ratelimit-remaining/reset, retry-after, x-github-request-id), and 403s are split into primary rate-limit (wait to reset), secondary/abuse (backoff, incl. body-only with no Retry-After), and permission/SSO (non-retryable, surfaced clearly instead of being blind-retried 5x and hidden behind "Unexpected error"). Connector exception types are preserved through the file-content/blame wrappers so a permission 403 is not reclassified into a retryable APIException.

Part of CHAOS-2372. Closes CHAOS-2383.

Reviewed across adversarial rounds (in-workflow reviewer + Codex: approve). Gates: ruff + full-package mypy + pytest green.
