### PR TITLE
feat(workers): dispatch run_investment_materialize post-sync, org-scoped (CHAOS-2374)

### DIFF
--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -7,6 +7,14 @@ from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 from .client import query_dicts
 
+# NOTE: This CTE MUST stay tenant-scoped. The ReplacingMergeTree dedup key for
+# work_unit_investments is (org_id, work_unit_id) (migration 027), so org_id is
+# part of the row identity. We filter org_id BEFORE aggregating and group by
+# (org_id, work_unit_id); otherwise two tenants sharing a provider-native
+# work_unit_id collapse into a single argMax row and the outer
+# `WHERE org_id = %(org_id)s` drops the losing tenant's data entirely
+# (cross-org leak / undercount — CHAOS-2374). Every consumer of this CTE already
+# supplies the `org_id` query param.
 LATEST_WORK_UNIT_INVESTMENTS_CTE = """
         latest_work_unit_investments AS (
             SELECT
@@ -26,10 +34,11 @@ LATEST_WORK_UNIT_INVESTMENTS_CTE = """
                 argMax(evidence_quality_band, computed_at) AS evidence_quality_band,
                 argMax(categorization_status, computed_at) AS categorization_status,
                 argMax(categorization_run_id, computed_at) AS categorization_run_id,
-                argMax(org_id, computed_at) AS org_id,
+                org_id,
                 max(computed_at) AS computed_at
             FROM work_unit_investments
-            GROUP BY work_unit_id
+            WHERE org_id = %(org_id)s
+            GROUP BY org_id, work_unit_id
         )
 """.rstrip()
 

--- a/src/dev_health_ops/api/queries/work_unit_investments.py
+++ b/src/dev_health_ops/api/queries/work_unit_investments.py
@@ -56,7 +56,7 @@ async def fetch_work_unit_investments(
             max(work_unit_investments.computed_at) AS computed_at
         FROM work_unit_investments
         WHERE {where_sql}
-        GROUP BY work_unit_id
+        GROUP BY org_id, work_unit_id
         ORDER BY effort_value DESC
         LIMIT %(limit)s
     """

--- a/src/dev_health_ops/api/services/investment_mix_explain.py
+++ b/src/dev_health_ops/api/services/investment_mix_explain.py
@@ -167,6 +167,7 @@ async def explain_investment_mix(
     units = await build_work_unit_investments(
         db_url=db_url,
         filters=filters,
+        org_id=org_id,
         limit=200,
         include_text=True,
     )

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -588,6 +588,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
                     categorization_input_hash=bundle.input_hash,
                     categorization_run_id=run_id,
                     computed_at=computed_at,
+                    org_id=config.org_id or "",
                 )
             )
 
@@ -601,6 +602,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
                             source_id=quote.source_id,
                             computed_at=computed_at,
                             categorization_run_id=run_id,
+                            org_id=config.org_id or "",
                         )
                     )
 

--- a/src/dev_health_ops/work_graph/investment/queries.py
+++ b/src/dev_health_ops/work_graph/investment/queries.py
@@ -126,13 +126,17 @@ def fetch_work_item_active_hours(
     ids = list(dict.fromkeys(work_item_ids))
     if not ids:
         return {}
-    params = {"work_item_ids": ids}
-    query = """
+    params: dict[str, object] = {"work_item_ids": ids}
+    where_sql = "WHERE work_item_id IN %(work_item_ids)s"
+    if org_id:
+        params["org_id"] = org_id
+        where_sql += " AND org_id = %(org_id)s"
+    query = f"""
         SELECT
             work_item_id,
             argMax(active_time_hours, computed_at) AS active_time_hours
         FROM work_item_cycle_times
-        WHERE work_item_id IN %(work_item_ids)s
+        {where_sql}
         GROUP BY work_item_id
     """
     rows = query_dicts(sink, query, params)

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -5,6 +5,8 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
+from celery import chain
+
 from dev_health_ops.credentials.resolver import (
     github_credentials_from_mapping,
     gitlab_credentials_from_mapping,
@@ -315,23 +317,33 @@ def _dispatch_post_sync_tasks(
         )
         dispatched.append("run_complexity_job")
 
-    if has_git and has_work_items:
-        celery_app.send_task(
+    # Work-graph build + investment materialization read org-wide persisted
+    # data (git PRs/commits + work items) that accumulate across separate sync
+    # configs, so they must fire after *either* kind of sync — not only when a
+    # single config carries both. Gating on `has_git and has_work_items` left
+    # work-items-only providers (Jira/Linear) and separately scheduled code vs
+    # work-item syncs with a permanently empty /investment view (CHAOS-2374).
+    if has_git or has_work_items:
+        # Investment distributions depend on the freshly rebuilt work graph.
+        # Enqueueing two independent tasks on the same queue only preserves
+        # publish order, not completion order: with multiple metrics workers
+        # materialization could race ahead of the build and read a stale/empty
+        # graph (CHAOS-2374). Chain them so materialize only starts after the
+        # build *succeeds*. The link is immutable (.si()) so the build's return
+        # value is not injected as a positional arg into materialize.
+        build_sig = celery_app.signature(
             "dev_health_ops.workers.tasks.run_work_graph_build",
             kwargs={"org_id": org_id},
             queue="metrics",
         )
-        dispatched.append("run_work_graph_build")
-
-        # Investment distributions depend on the work-graph build that was
-        # just enqueued; without this the work_unit_investments table is only
-        # ever populated by fixtures/CLI, so live orgs see an empty /investment
-        # view (CHAOS-2374).
-        celery_app.send_task(
+        materialize_sig = celery_app.signature(
             "dev_health_ops.workers.tasks.run_investment_materialize",
             kwargs={"org_id": org_id},
             queue="metrics",
+            immutable=True,
         )
+        chain(build_sig, materialize_sig).apply_async()
+        dispatched.append("run_work_graph_build")
         dispatched.append("run_investment_materialize")
 
     if provider == "gitlab" and has_git:

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -321,6 +321,18 @@ def _dispatch_post_sync_tasks(
             kwargs={"org_id": org_id},
             queue="metrics",
         )
+        dispatched.append("run_work_graph_build")
+
+        # Investment distributions depend on the work-graph build that was
+        # just enqueued; without this the work_unit_investments table is only
+        # ever populated by fixtures/CLI, so live orgs see an empty /investment
+        # view (CHAOS-2374).
+        celery_app.send_task(
+            "dev_health_ops.workers.tasks.run_investment_materialize",
+            kwargs={"org_id": org_id},
+            queue="metrics",
+        )
+        dispatched.append("run_investment_materialize")
 
     if provider == "gitlab" and has_git:
         celery_app.send_task(

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -105,6 +105,7 @@ def run_investment_materialize(
     llm_provider: str = "auto",
     llm_model: str | None = None,
     force: bool = False,
+    org_id: str = "",
 ) -> dict:
     """Materialize investment distributions from work graph.
 
@@ -118,6 +119,7 @@ def run_investment_materialize(
         llm_provider: LLM provider (auto|openai|anthropic)
         llm_model: Optional specific LLM model
         force: Force recomputation even if cached
+        org_id: Organization scope for work-graph/investment queries
 
     Returns:
         dict with materialization status and stats
@@ -170,6 +172,7 @@ def run_investment_materialize(
             llm_model=llm_model,
             team_ids=team_ids,
             force=force,
+            org_id=org_id or None,
         )
         stats = run_async(materialize_investments(config))
         return {"status": "success", "stats": stats}

--- a/tests/api/test_investment_explain_cache.py
+++ b/tests/api/test_investment_explain_cache.py
@@ -155,3 +155,62 @@ async def test_explain_investment_mix_mock_provider_skips_cache():
 
         # Cache should not be accessed for mock provider
         mock_sink_class.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_explain_forwards_org_id_to_work_unit_evidence():
+    """Regression (CHAOS-2374): the explanation path must forward the caller's
+    org_id into build_work_unit_investments.
+
+    work_unit_investments rows are tenant-scoped (org_id is part of the
+    ReplacingMergeTree dedup key, migration 027) and every reader filters
+    ``org_id = %(org_id)s``. If the explain path omits org_id, it defaults to
+    "" and silently drops *all* persisted work-unit evidence for any real org,
+    leaving the LLM/fallback ungrounded (work_unit_count=0, no quotes, no
+    quality stats) despite a non-empty aggregate distribution.
+    """
+    real_org = "org-7c2f1a9e"
+
+    with (
+        patch(
+            "dev_health_ops.api.services.investment_mix_explain.build_investment_response"
+        ) as mock_build,
+        patch(
+            "dev_health_ops.api.services.investment_mix_explain.build_work_unit_investments"
+        ) as mock_units,
+        patch(
+            "dev_health_ops.api.services.investment_mix_explain.get_provider"
+        ) as mock_get_provider,
+    ):
+        mock_investment = MagicMock()
+        mock_investment.theme_distribution = {"feature_delivery": 1.0}
+        mock_investment.subcategory_distribution = {"feature_delivery.customer": 1.0}
+        mock_build.return_value = mock_investment
+
+        mock_units.return_value = []
+
+        mock_provider = MagicMock()
+        mock_provider.complete = AsyncMock(
+            return_value='{"summary": "Test summary", "top_findings": [], "confidence": {"level": "moderate"}, "what_to_check_next": [], "anti_claims": []}'
+        )
+        mock_get_provider.return_value = mock_provider
+
+        class MockFilters:
+            def model_dump(self, mode=None):
+                return {"scope": {"level": "org"}}
+
+        await explain_investment_mix(
+            db_url="clickhouse://localhost:9000/test",
+            filters=MockFilters(),
+            org_id=real_org,
+            llm_provider="mock",
+        )
+
+        build_call = mock_build.await_args
+        units_call = mock_units.await_args
+        assert build_call is not None
+        assert units_call is not None
+        # Aggregate response is org-scoped...
+        assert build_call.kwargs["org_id"] == real_org
+        # ...and so is the work-unit evidence reader (the bug: it defaulted to "").
+        assert units_call.kwargs["org_id"] == real_org

--- a/tests/api/test_investment_latest_row_queries.py
+++ b/tests/api/test_investment_latest_row_queries.py
@@ -42,18 +42,26 @@ async def test_investment_breakdown_aggregates_only_latest_work_unit_row(
     physical_rows: list[dict[str, Any]] = [older, latest]
 
     async def fake_query_dicts(
-        _sink: BaseMetricsSink, sql: str, _params: dict[str, Any]
+        _sink: BaseMetricsSink, sql: str, params: dict[str, Any]
     ) -> list[dict[str, Any]]:
         assert "latest_work_unit_investments AS" in sql
         assert "argMax(effort_value, computed_at) AS effort_value" in sql
-        latest_by_id: dict[str, dict[str, Any]] = {}
+        # The fixed CTE filters by org before aggregating and groups by
+        # (org_id, work_unit_id), so the dedup key is the full tenant identity.
+        assert "WHERE org_id = %(org_id)s" in sql
+        assert "GROUP BY org_id, work_unit_id" in sql
+        scoped_org = params["org_id"]
+        latest_by_key: dict[tuple[str, str], dict[str, Any]] = {}
         for row in physical_rows:
-            current = latest_by_id.get(row["work_unit_id"])
+            if row["org_id"] != scoped_org:
+                continue
+            key = (row["org_id"], row["work_unit_id"])
+            current = latest_by_key.get(key)
             if current is None or row["computed_at"] > current["computed_at"]:
-                latest_by_id[row["work_unit_id"]] = row
+                latest_by_key[key] = row
 
         totals: dict[tuple[str, str], float] = {}
-        for row in latest_by_id.values():
+        for row in latest_by_key.values():
             for subcategory, probability in row["subcategory_distribution_json"]:
                 theme = subcategory.split(".", 1)[0]
                 totals[(subcategory, theme)] = totals.get((subcategory, theme), 0.0) + (
@@ -81,6 +89,110 @@ async def test_investment_breakdown_aggregates_only_latest_work_unit_row(
             "subcategory": "Feature Delivery.product",
             "theme": "Feature Delivery",
             "value": 20.0,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_investment_breakdown_does_not_collapse_across_tenants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two orgs sharing a work_unit_id must each see their own latest row.
+
+    Regression for CHAOS-2374: the shared latest-row CTE used to
+    `GROUP BY work_unit_id` only and then expose `argMax(org_id, computed_at)`.
+    A later materialization for org B with the same (colliding) provider-native
+    work_unit_id would win the argMax, become the single selected row, and the
+    outer `WHERE org_id = %(org_id)s` would then drop org A entirely. The CTE
+    now filters org_id first and groups by (org_id, work_unit_id), so each
+    tenant retains its own row regardless of the other tenant's sync timing.
+    """
+    org_a_row = {
+        "work_unit_id": "ENG-100",  # provider-native id that collides across tenants
+        "org_id": "org-a",
+        "from_ts": datetime(2026, 1, 10, tzinfo=timezone.utc),
+        "to_ts": datetime(2026, 1, 11, tzinfo=timezone.utc),
+        "effort_value": 7.0,
+        "subcategory_distribution_json": [("Feature Delivery.product", 1.0)],
+        # Older computed_at: org-b would win a cross-tenant argMax(org_id).
+        "computed_at": datetime(2026, 1, 12, tzinfo=timezone.utc),
+    }
+    org_b_row = {
+        "work_unit_id": "ENG-100",
+        "org_id": "org-b",
+        "from_ts": datetime(2026, 1, 10, tzinfo=timezone.utc),
+        "to_ts": datetime(2026, 1, 11, tzinfo=timezone.utc),
+        "effort_value": 99.0,
+        "subcategory_distribution_json": [("Keeping the Lights On.ops", 1.0)],
+        # Newer computed_at: this row would win a global argMax and hide org-a.
+        "computed_at": datetime(2026, 1, 20, tzinfo=timezone.utc),
+    }
+    physical_rows: list[dict[str, Any]] = [org_a_row, org_b_row]
+
+    async def fake_query_dicts(
+        _sink: BaseMetricsSink, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        # Faithfully model the fixed CTE: org filter applied BEFORE aggregation,
+        # dedup key = (org_id, work_unit_id).
+        assert "WHERE org_id = %(org_id)s" in sql
+        assert "GROUP BY org_id, work_unit_id" in sql
+        scoped_org = params["org_id"]
+        latest_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+        for row in physical_rows:
+            if row["org_id"] != scoped_org:
+                continue
+            key = (row["org_id"], row["work_unit_id"])
+            current = latest_by_key.get(key)
+            if current is None or row["computed_at"] > current["computed_at"]:
+                latest_by_key[key] = row
+        totals: dict[tuple[str, str], float] = {}
+        for row in latest_by_key.values():
+            for subcategory, probability in row["subcategory_distribution_json"]:
+                theme = subcategory.split(".", 1)[0]
+                totals[(subcategory, theme)] = totals.get((subcategory, theme), 0.0) + (
+                    probability * row["effort_value"]
+                )
+        return [
+            {"subcategory": subcategory, "theme": theme, "value": value}
+            for (subcategory, theme), value in totals.items()
+        ]
+
+    monkeypatch.setattr(investment_queries, "query_dicts", fake_query_dicts)
+
+    start_ts, end_ts = _window()
+
+    # org-a must still see its own row even though org-b has a newer computed_at
+    # on the same work_unit_id.
+    rows_a = await investment_queries.fetch_investment_breakdown(
+        cast(BaseMetricsSink, object()),
+        start_ts=start_ts,
+        end_ts=end_ts,
+        scope_filter="",
+        scope_params={},
+        org_id="org-a",
+    )
+    assert rows_a == [
+        {
+            "subcategory": "Feature Delivery.product",
+            "theme": "Feature Delivery",
+            "value": 7.0,
+        }
+    ]
+
+    # org-b sees only its own row — no bleed from org-a.
+    rows_b = await investment_queries.fetch_investment_breakdown(
+        cast(BaseMetricsSink, object()),
+        start_ts=start_ts,
+        end_ts=end_ts,
+        scope_filter="",
+        scope_params={},
+        org_id="org-b",
+    )
+    assert rows_b == [
+        {
+            "subcategory": "Keeping the Lights On.ops",
+            "theme": "Keeping the Lights On",
+            "value": 99.0,
         }
     ]
 
@@ -132,6 +244,10 @@ async def test_investment_queries_read_latest_work_unit_rows(
     assert "work_unit_investments.from_ts < %(end_ts)s" in sql
     assert "work_unit_investments.to_ts >= %(start_ts)s" in sql
     assert "work_unit_investments.org_id = %(org_id)s" in sql
+    # Tenant-scope the latest-row CTE itself (CHAOS-2374): org filter must be
+    # applied before aggregation and the dedup key must include org_id.
+    assert "WHERE org_id = %(org_id)s" in sql
+    assert "GROUP BY org_id, work_unit_id" in sql
 
 
 @pytest.mark.asyncio

--- a/tests/test_post_sync_investment_dispatch.py
+++ b/tests/test_post_sync_investment_dispatch.py
@@ -1,83 +1,150 @@
 """Unit tests for the post-sync investment-materialize dispatch (CHAOS-2374).
 
-work_unit_investments / work_unit_investment_quotes are written only by
+``work_unit_investments`` / ``work_unit_investment_quotes`` are written only by
 ``materialize_investments`` via the ``run_investment_materialize`` Celery task.
 That task was never dispatched on the live sync path, so real orgs saw an empty
-``/investment`` view. ``_dispatch_post_sync_tasks`` now enqueues it right after
-``run_work_graph_build`` (investment depends on the work-graph build).
+``/investment`` view.
 
-These tests prove the seam without a live ClickHouse: they mock
-``celery_app.send_task`` and assert the dispatch contract.
+``_dispatch_post_sync_tasks`` now enqueues a Celery **chain**:
+``run_work_graph_build`` -> ``run_investment_materialize``. The chain (not two
+independent ``send_task`` calls) guarantees materialization only starts after
+the build *succeeds*, so concurrent metrics workers cannot race materialize
+ahead of the graph it reads. The chain fires after *either* a git or a
+work-item sync (org-wide persisted data accumulates across separate configs),
+not only when one config carries both.
+
+These tests prove the seam without a live ClickHouse: they patch the Celery
+``chain`` / ``signature`` factories and assert the dispatch contract.
 """
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+# Import connectors first to defuse the providers._base <-> connectors circular
+# import that otherwise ERRORs isolated collection (mirrors CHAOS-2370).
+import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.workers.sync_runtime import _dispatch_post_sync_tasks
 
 _INVESTMENT_TASK = "dev_health_ops.workers.tasks.run_investment_materialize"
 _WORK_GRAPH_TASK = "dev_health_ops.workers.tasks.run_work_graph_build"
 
 
-def _sent_task_names(mock_send_task) -> list[str]:
-    return [call.args[0] for call in mock_send_task.call_args_list]
+def _run_dispatch(provider: str, sync_targets: list[str], org_id: str):
+    """Drive _dispatch_post_sync_tasks with chain/signature patched.
 
+    Returns (signature_mock, chain_mock, chain_instance_mock, send_task_mock).
+    """
+    with (
+        patch(
+            "dev_health_ops.workers.sync_runtime.celery_app.signature"
+        ) as mock_signature,
+        patch("dev_health_ops.workers.sync_runtime.chain") as mock_chain,
+        patch(
+            "dev_health_ops.workers.sync_runtime.celery_app.send_task"
+        ) as mock_send_task,
+    ):
+        # Each signature() call returns a distinct marker carrying its args so
+        # we can assert which task each chain position holds.
+        def _make_sig(name, **kwargs):
+            sig = MagicMock(name=f"sig:{name}")
+            sig.task_name = name
+            sig.sig_kwargs = kwargs
+            return sig
 
-def test_investment_materialize_dispatched_with_git_and_work_items() -> None:
-    """git + work-items => run_investment_materialize enqueued, org-scoped."""
-    with patch(
-        "dev_health_ops.workers.sync_runtime.celery_app.send_task"
-    ) as mock_send_task:
+        mock_signature.side_effect = _make_sig
+        chain_instance = MagicMock(name="chain_instance")
+        mock_chain.return_value = chain_instance
         _dispatch_post_sync_tasks(
-            provider="github",
-            sync_targets=["git", "prs", "work-items"],
-            org_id="org-123",
+            provider=provider,
+            sync_targets=sync_targets,
+            org_id=org_id,
         )
+    return mock_signature, mock_chain, chain_instance, mock_send_task
 
-    names = _sent_task_names(mock_send_task)
-    assert _INVESTMENT_TASK in names
-    # Investment must be dispatched AFTER the work-graph build it depends on.
-    assert names.index(_INVESTMENT_TASK) > names.index(_WORK_GRAPH_TASK)
 
-    investment_call = next(
-        call
-        for call in mock_send_task.call_args_list
-        if call.args[0] == _INVESTMENT_TASK
+def test_investment_chain_dispatched_with_git_and_work_items() -> None:
+    """git + work-items => build -> materialize chain, applied async, org-scoped."""
+    mock_signature, mock_chain, chain_instance, _ = _run_dispatch(
+        provider="github",
+        sync_targets=["git", "prs", "work-items"],
+        org_id="org-123",
     )
-    assert investment_call.kwargs["kwargs"] == {"org_id": "org-123"}
-    assert investment_call.kwargs["queue"] == "metrics"
+
+    # The chain must be built with build FIRST, materialize SECOND.
+    assert mock_chain.call_count == 1
+    build_sig, materialize_sig = mock_chain.call_args.args
+    assert build_sig.task_name == _WORK_GRAPH_TASK
+    assert materialize_sig.task_name == _INVESTMENT_TASK
+
+    # Both signatures are org-scoped onto the metrics queue.
+    assert build_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    assert build_sig.sig_kwargs["queue"] == "metrics"
+    assert materialize_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    assert materialize_sig.sig_kwargs["queue"] == "metrics"
+
+    # Materialize is linked IMMUTABLE so the build's return dict is not injected
+    # as a positional arg (which would break run_investment_materialize).
+    assert materialize_sig.sig_kwargs.get("immutable") is True
+    assert build_sig.sig_kwargs.get("immutable") is not True
+
+    # The chain is actually dispatched (not just constructed).
+    chain_instance.apply_async.assert_called_once_with()
 
 
-def test_investment_materialize_not_dispatched_without_work_items() -> None:
-    """git only (no work-items) => investment materialize NOT enqueued."""
-    with patch(
-        "dev_health_ops.workers.sync_runtime.celery_app.send_task"
-    ) as mock_send_task:
-        _dispatch_post_sync_tasks(
-            provider="github",
-            sync_targets=["git", "prs"],
-            org_id="org-123",
-        )
+def test_investment_chain_dispatched_with_git_only() -> None:
+    """git only (no work-items in this config) => chain still fires.
 
-    names = _sent_task_names(mock_send_task)
-    assert _INVESTMENT_TASK not in names
-    # The work-graph build (its dependency) is also gated on work-items.
-    assert _WORK_GRAPH_TASK not in names
+    Work items for the org may have been persisted by a separate sync config;
+    the org-wide build/materialize must not be gated on one config carrying
+    both kinds of data.
+    """
+    _, mock_chain, chain_instance, _ = _run_dispatch(
+        provider="github",
+        sync_targets=["git", "prs"],
+        org_id="org-123",
+    )
+
+    assert mock_chain.call_count == 1
+    build_sig, materialize_sig = mock_chain.call_args.args
+    assert build_sig.task_name == _WORK_GRAPH_TASK
+    assert materialize_sig.task_name == _INVESTMENT_TASK
+    chain_instance.apply_async.assert_called_once_with()
 
 
-def test_investment_materialize_not_dispatched_with_work_items_only() -> None:
-    """work-items only (no git) => investment materialize NOT enqueued."""
-    with patch(
-        "dev_health_ops.workers.sync_runtime.celery_app.send_task"
-    ) as mock_send_task:
-        _dispatch_post_sync_tasks(
-            provider="jira",
-            sync_targets=["work-items"],
-            org_id="org-123",
-        )
+def test_investment_chain_dispatched_with_work_items_only_jira() -> None:
+    """Jira work-items-only sync => chain fires (the major missed live path).
 
-    assert _INVESTMENT_TASK not in _sent_task_names(mock_send_task)
+    Jira/Linear configs only ever carry work-items; gating on git+work-items
+    meant these orgs never enqueued the build/materialize at all (CHAOS-2374).
+    """
+    _, mock_chain, chain_instance, _ = _run_dispatch(
+        provider="jira",
+        sync_targets=["work-items"],
+        org_id="org-123",
+    )
+
+    assert mock_chain.call_count == 1
+    build_sig, materialize_sig = mock_chain.call_args.args
+    assert build_sig.task_name == _WORK_GRAPH_TASK
+    assert materialize_sig.task_name == _INVESTMENT_TASK
+    assert materialize_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    chain_instance.apply_async.assert_called_once_with()
+
+
+def test_no_investment_chain_for_feature_flags_only() -> None:
+    """A sync with neither git nor work-items (e.g. feature-flags) => no chain."""
+    _, mock_chain, _, mock_send_task = _run_dispatch(
+        provider="launchdarkly",
+        sync_targets=["feature-flags"],
+        org_id="org-123",
+    )
+
+    mock_chain.assert_not_called()
+    # And no investment/work-graph send_task either.
+    sent = [call.args[0] for call in mock_send_task.call_args_list]
+    assert _INVESTMENT_TASK not in sent
+    assert _WORK_GRAPH_TASK not in sent
 
 
 def test_run_investment_materialize_forwards_org_id_to_config() -> None:

--- a/tests/test_post_sync_investment_dispatch.py
+++ b/tests/test_post_sync_investment_dispatch.py
@@ -1,0 +1,145 @@
+"""Unit tests for the post-sync investment-materialize dispatch (CHAOS-2374).
+
+work_unit_investments / work_unit_investment_quotes are written only by
+``materialize_investments`` via the ``run_investment_materialize`` Celery task.
+That task was never dispatched on the live sync path, so real orgs saw an empty
+``/investment`` view. ``_dispatch_post_sync_tasks`` now enqueues it right after
+``run_work_graph_build`` (investment depends on the work-graph build).
+
+These tests prove the seam without a live ClickHouse: they mock
+``celery_app.send_task`` and assert the dispatch contract.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from dev_health_ops.workers.sync_runtime import _dispatch_post_sync_tasks
+
+_INVESTMENT_TASK = "dev_health_ops.workers.tasks.run_investment_materialize"
+_WORK_GRAPH_TASK = "dev_health_ops.workers.tasks.run_work_graph_build"
+
+
+def _sent_task_names(mock_send_task) -> list[str]:
+    return [call.args[0] for call in mock_send_task.call_args_list]
+
+
+def test_investment_materialize_dispatched_with_git_and_work_items() -> None:
+    """git + work-items => run_investment_materialize enqueued, org-scoped."""
+    with patch(
+        "dev_health_ops.workers.sync_runtime.celery_app.send_task"
+    ) as mock_send_task:
+        _dispatch_post_sync_tasks(
+            provider="github",
+            sync_targets=["git", "prs", "work-items"],
+            org_id="org-123",
+        )
+
+    names = _sent_task_names(mock_send_task)
+    assert _INVESTMENT_TASK in names
+    # Investment must be dispatched AFTER the work-graph build it depends on.
+    assert names.index(_INVESTMENT_TASK) > names.index(_WORK_GRAPH_TASK)
+
+    investment_call = next(
+        call
+        for call in mock_send_task.call_args_list
+        if call.args[0] == _INVESTMENT_TASK
+    )
+    assert investment_call.kwargs["kwargs"] == {"org_id": "org-123"}
+    assert investment_call.kwargs["queue"] == "metrics"
+
+
+def test_investment_materialize_not_dispatched_without_work_items() -> None:
+    """git only (no work-items) => investment materialize NOT enqueued."""
+    with patch(
+        "dev_health_ops.workers.sync_runtime.celery_app.send_task"
+    ) as mock_send_task:
+        _dispatch_post_sync_tasks(
+            provider="github",
+            sync_targets=["git", "prs"],
+            org_id="org-123",
+        )
+
+    names = _sent_task_names(mock_send_task)
+    assert _INVESTMENT_TASK not in names
+    # The work-graph build (its dependency) is also gated on work-items.
+    assert _WORK_GRAPH_TASK not in names
+
+
+def test_investment_materialize_not_dispatched_with_work_items_only() -> None:
+    """work-items only (no git) => investment materialize NOT enqueued."""
+    with patch(
+        "dev_health_ops.workers.sync_runtime.celery_app.send_task"
+    ) as mock_send_task:
+        _dispatch_post_sync_tasks(
+            provider="jira",
+            sync_targets=["work-items"],
+            org_id="org-123",
+        )
+
+    assert _INVESTMENT_TASK not in _sent_task_names(mock_send_task)
+
+
+def test_run_investment_materialize_forwards_org_id_to_config() -> None:
+    """The task forwards org_id into MaterializeConfig so queries stay scoped."""
+    from typing import Any, cast
+
+    from dev_health_ops.workers.work_graph_tasks import run_investment_materialize
+
+    captured: dict[str, Any] = {}
+
+    class _FakeConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.investment.materialize.MaterializeConfig",
+            _FakeConfig,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.materialize.materialize_investments",
+            return_value=None,
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks.run_async",
+            return_value={"components": 0, "records": 0, "quotes": 0},
+        ),
+    ):
+        task = cast(Any, run_investment_materialize)
+        result = task.run(db_url="clickhouse://x", org_id="org-123")
+
+    assert result["status"] == "success"
+    assert captured["org_id"] == "org-123"
+
+
+def test_run_investment_materialize_empty_org_id_becomes_none() -> None:
+    """An empty org_id collapses to None (no accidental cross-org scan)."""
+    from typing import Any, cast
+
+    from dev_health_ops.workers.work_graph_tasks import run_investment_materialize
+
+    captured: dict[str, Any] = {}
+
+    class _FakeConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.investment.materialize.MaterializeConfig",
+            _FakeConfig,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.materialize.materialize_investments",
+            return_value=None,
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks.run_async",
+            return_value={"components": 0, "records": 0, "quotes": 0},
+        ),
+    ):
+        task = cast(Any, run_investment_materialize)
+        task.run(db_url="clickhouse://x")
+
+    assert captured["org_id"] is None

--- a/tests/work_graph/test_investment_helpers.py
+++ b/tests/work_graph/test_investment_helpers.py
@@ -150,3 +150,58 @@ def test_queries_helpers_build_expected_params(monkeypatch):
     assert repo_ids == ["repo-1", "repo-2"]
 
     assert len(calls) >= 4
+
+
+def test_fetch_work_item_active_hours_scopes_to_requested_org(monkeypatch):
+    """Active-hours effort must not leak another tenant's cycle-time weight.
+
+    Two orgs share the same provider-native work_item_id; an org-scoped
+    materialization must only see its own org's active hours.
+    """
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    # Simulate the ClickHouse backend honoring the org_id predicate: rows for
+    # both tenants exist for work item "W1", but only the requested org's row
+    # is returned when the query filters by org_id.
+    rows_by_org = {
+        "org-a": [{"work_item_id": "W1", "active_time_hours": 5.0}],
+        "org-b": [{"work_item_id": "W1", "active_time_hours": 999.0}],
+    }
+
+    def fake_query_dicts(_sink, query, params):
+        captured.append((query, params))
+        org_id = params.get("org_id")
+        if org_id is None:
+            # No org scope -> backend would return all tenants' rows.
+            return [row for rows in rows_by_org.values() for row in rows]
+        return rows_by_org.get(str(org_id), [])
+
+    monkeypatch.setattr(q, "query_dicts", fake_query_dicts)
+    sink = cast(BaseMetricsSink, object())
+
+    result = q.fetch_work_item_active_hours(sink, work_item_ids=["W1"], org_id="org-a")
+
+    # Only org-a's active hours are used; org-b's 999.0 is excluded.
+    assert result == {"W1": 5.0}
+    query, params = captured[-1]
+    assert "AND org_id = %(org_id)s" in query
+    assert params["org_id"] == "org-a"
+
+
+def test_fetch_work_item_active_hours_omits_org_filter_when_unscoped(monkeypatch):
+    """When no org_id is supplied, the query stays unscoped (back-compat)."""
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    def fake_query_dicts(_sink, query, params):
+        captured.append((query, params))
+        return [{"work_item_id": "W1", "active_time_hours": 3.0}]
+
+    monkeypatch.setattr(q, "query_dicts", fake_query_dicts)
+    sink = cast(BaseMetricsSink, object())
+
+    result = q.fetch_work_item_active_hours(sink, work_item_ids=["W1"])
+
+    assert result == {"W1": 3.0}
+    query, params = captured[-1]
+    assert "org_id" not in query
+    assert "org_id" not in params

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -13,6 +13,7 @@ from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentRecord,
 )
 from dev_health_ops.work_graph.investment.categorize import CategorizationOutcome
+from dev_health_ops.work_graph.investment.llm_schema import EvidenceQuote
 from dev_health_ops.work_graph.investment.materialize import (
     MaterializeConfig,
     materialize_investments,
@@ -161,6 +162,108 @@ async def test_materialize_invokes_sink(monkeypatch):
     assert json.loads(record.categorization_errors_json) == [
         "probability_sum_renormalized:0.9500"
     ]
+
+
+@pytest.mark.asyncio
+async def test_materialize_writes_records_with_org_id(monkeypatch):
+    """Written rows must carry config.org_id so the org-scoped /investment
+    reader (WHERE org_id = %(org_id)s) can see them (CHAOS-2374).
+
+    The first fix only dispatched the task; rows were still written with the
+    default org_id='' while the reader filtered on the real org id, leaving the
+    view empty. This test exercises record construction end-to-end.
+    """
+    repo_id, edges, work_items, commits = _sample_data()
+    work_items[0]["description"] = "Resolve authentication failures. " * 20
+    sink = FakeSink()
+
+    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
+        return CategorizationOutcome(
+            subcategories={"feature_delivery.roadmap": 1.0},
+            evidence_quotes=[
+                EvidenceQuote(
+                    quote="Resolve authentication failures",
+                    source_type="issue_desc",
+                    source_id="jira:ABC-1",
+                )
+            ],
+            uncertainty="Limited evidence.",
+            status="ok",
+            errors=[],
+        )
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _fake_categorize,
+    )
+
+    now = datetime.now(timezone.utc)
+    config = MaterializeConfig(
+        dsn="clickhouse://localhost:8123/default",
+        from_ts=now - timedelta(days=5),
+        to_ts=now,
+        repo_ids=[repo_id],
+        llm_provider="mock",
+        persist_evidence_snippets=True,
+        llm_model="test-model",
+        org_id="org-real-123",
+    )
+
+    stats = await materialize_investments(config)
+    assert stats["records"] == 1
+    assert sink.investment_rows, "expected at least one investment row"
+    # Every written investment row must carry the real org id.
+    assert all(r.org_id == "org-real-123" for r in sink.investment_rows)
+    # Evidence quotes must be org-tagged too (same reader-scoping concern).
+    assert sink.quote_rows, "expected at least one evidence quote row"
+    assert all(q.org_id == "org-real-123" for q in sink.quote_rows)
+
+
+@pytest.mark.asyncio
+async def test_materialize_records_default_org_id_empty(monkeypatch):
+    """With no org_id configured, rows fall back to '' (not None) so the
+    dataclass/sink column stays a String — and no accidental org is invented.
+    """
+    repo_id, edges, work_items, commits = _sample_data()
+    work_items[0]["description"] = "Resolve authentication failures. " * 20
+    sink = FakeSink()
+
+    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
+        return CategorizationOutcome(
+            subcategories={"feature_delivery.roadmap": 1.0},
+            evidence_quotes=[],
+            uncertainty="Limited evidence.",
+            status="ok",
+            errors=[],
+        )
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _fake_categorize,
+    )
+
+    now = datetime.now(timezone.utc)
+    config = MaterializeConfig(
+        dsn="clickhouse://localhost:8123/default",
+        from_ts=now - timedelta(days=5),
+        to_ts=now,
+        repo_ids=[repo_id],
+        llm_provider="mock",
+        persist_evidence_snippets=False,
+        llm_model="test-model",
+    )
+
+    await materialize_investments(config)
+    assert sink.investment_rows
+    assert all(r.org_id == "" for r in sink.investment_rows)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Dispatches run_investment_materialize on the live post-sync path (it existed but was never dispatched) so work_unit_investments + quotes populate for real orgs and the /investment area renders. Chained immutably after run_work_graph_build; org_id written on every materialized row; the active-hours fallback read is now org-scoped (closes a cross-tenant effort-attribution leak).

Part of CHAOS-2372. Closes CHAOS-2374. Follow-ups: CHAOS-2393 (explain LLM-cache cross-org leak), CHAOS-2394 (investment_segments org_id).

> Branch forked at 667dc5b5; origin/main has since advanced. Rebase onto origin/main before merge (3-way merge is safe; a 2-dot diff shows unrelated main commits as spurious deletions). Reviewed across 4 adversarial rounds (in-workflow reviewer + Codex /codex:adversarial-review); tenant-isolation, no-silent-loss and correctness all verified. Gates: ruff + full-package mypy + pytest green.
