### PR TITLE
feat(work-graph): derive PR->commit edges live, tenant-scoped (CHAOS-2375)

### DIFF
--- a/src/dev_health_ops/work_graph/builder.py
+++ b/src/dev_health_ops/work_graph/builder.py
@@ -1334,11 +1334,16 @@ class WorkGraphBuilder:
         ``git_pull_requests`` and ``git_commits`` but never populates
         ``work_graph_pr_commit`` (only fixtures did), so the ``CONTAINS`` edges
         built by :meth:`_build_pr_commit_edges_from_fast_path` were empty for real
-        orgs. Here we parse merge/squash commit messages for the PR/MR numbers
-        GitHub and GitLab embed (``Merge pull request #N``, ``(#N)``, ``!N``) and,
-        when the referenced number matches a known PR in the same repo, persist a
-        ``WorkGraphPRCommit`` link. Re-running is idempotent: ``work_graph_pr_commit``
-        is a ReplacingMergeTree keyed on (org_id, repo_id, pr_number, commit_hash).
+        orgs. Here we parse merge commit messages for the PR/MR numbers GitHub and
+        GitLab embed via their explicit merge-keyword conventions
+        (``Merge pull request #N``, ``See merge request grp/proj!N``) and, when the
+        referenced number matches a known PR in the same repo, persist a
+        ``WorkGraphPRCommit`` link. Bare ``#N`` and squash ``(#N)`` forms are
+        deliberately *not* accepted: they are indistinguishable from ordinary issue
+        references and, with no persisted merge metadata to corroborate them, would
+        attach commits to unrelated PRs (see :func:`extract_pr_refs`). Re-running is
+        idempotent: ``work_graph_pr_commit`` is a ReplacingMergeTree keyed on
+        (org_id, repo_id, pr_number, commit_hash).
 
         Returns:
             Number of PR->commit links written.

--- a/src/dev_health_ops/work_graph/builder.py
+++ b/src/dev_health_ops/work_graph/builder.py
@@ -1451,6 +1451,14 @@ class WorkGraphBuilder:
             "Building PR->commit edges from dev_health_ops.work_graph_pr_commit..."
         )
 
+        # Tenant isolation: ``git_commits`` carries an ``org_id`` column
+        # (migration 027) and ``repo_id``/``hash`` values can collide across
+        # tenants (documented in metrics/loaders/ai_impact.py). The commit side
+        # of this join MUST be scoped to the same org as the PR-commit row, or a
+        # tenant-scoped build could satisfy the commit from another org and stamp
+        # a cross-tenant edge into the current org's work_graph_edges. Matching
+        # ``c.org_id = p.org_id`` keeps both sides within one tenant. The
+        # ``p.org_id`` WHERE filter below then pins it to the selected org.
         query = """
         SELECT
             p.repo_id,
@@ -1462,7 +1470,11 @@ class WorkGraphBuilder:
             p.last_synced,
             c.author_when
         FROM work_graph_pr_commit AS p
-        INNER JOIN git_commits AS c ON (toString(p.repo_id) = toString(c.repo_id) AND p.commit_hash = c.hash)
+        INNER JOIN git_commits AS c ON (
+            toString(p.repo_id) = toString(c.repo_id)
+            AND p.commit_hash = c.hash
+            AND toString(p.org_id) = toString(c.org_id)
+        )
         """
         where_parts: list[str] = []
         if self.config.repo_id:

--- a/src/dev_health_ops/work_graph/builder.py
+++ b/src/dev_health_ops/work_graph/builder.py
@@ -15,13 +15,18 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
-from dev_health_ops.metrics.schemas import WorkGraphEdgeRecord, WorkGraphIssuePRRecord
+from dev_health_ops.metrics.schemas import (
+    WorkGraphEdgeRecord,
+    WorkGraphIssuePRRecord,
+    WorkGraphPRCommitRecord,
+)
 from dev_health_ops.metrics.sinks.factory import create_sink
 from dev_health_ops.work_graph.extractors.text_parser import (
     RefType,
     extract_github_issue_refs,
     extract_gitlab_issue_refs,
     extract_jira_keys,
+    extract_pr_refs,
 )
 from dev_health_ops.work_graph.ids import (
     generate_commit_id,
@@ -36,6 +41,7 @@ from dev_health_ops.work_graph.models import (
     Provenance,
     WorkGraphEdge,
     WorkGraphIssuePR,
+    WorkGraphPRCommit,
 )
 
 logger = logging.getLogger(__name__)
@@ -146,6 +152,19 @@ class WorkGraphBuilder:
             org_id=self.config.org_id,
         )
 
+    def _pr_commit_to_record(self, link: WorkGraphPRCommit) -> WorkGraphPRCommitRecord:
+        """Convert WorkGraphPRCommit to WorkGraphPRCommitRecord for sink."""
+        return WorkGraphPRCommitRecord(
+            repo_id=link.repo_id,
+            pr_number=link.pr_number,
+            commit_hash=link.commit_hash,
+            confidence=link.confidence,
+            provenance=link.provenance.value,
+            evidence=link.evidence,
+            last_synced=link.last_synced or self._now,
+            org_id=self.config.org_id,
+        )
+
     def _write_edges(self, edges: list[WorkGraphEdge]) -> int:
         """Write edges via the sink."""
         if not edges:
@@ -160,6 +179,13 @@ class WorkGraphBuilder:
             return
         records = [self._issue_pr_to_record(lnk) for lnk in links]
         self.sink.write_work_graph_issue_pr(records)
+
+    def _write_pr_commit_links(self, links: list[WorkGraphPRCommit]) -> None:
+        """Write PR-commit links via the sink."""
+        if not links:
+            return
+        records = [self._pr_commit_to_record(lnk) for lnk in links]
+        self.sink.write_work_graph_pr_commit(records)
 
     @staticmethod
     def _parse_provenance(value: str | None) -> Provenance:
@@ -363,6 +389,11 @@ class WorkGraphBuilder:
         stats["heuristic_edges"] = self._build_heuristic_issue_pr_edges(
             issue_pr_explicit
         )
+
+        # 4b. Derive PR->commit links from commit messages (fills fast path).
+        # Without this, work_graph_pr_commit is only ever written by fixtures, so
+        # real orgs see no commits under PRs in the /work GraphView.
+        self._derive_pr_commit_links()
 
         # 5. Build PR->commit edges from fast-path table (prerequisite)
         stats["pr_commit_edges"] = self._build_pr_commit_edges_from_fast_path()
@@ -1295,6 +1326,120 @@ class WorkGraphBuilder:
         count = self._write_edges(edges)
         logger.info("Created %d issue->PR edges from fast-path table", count)
         return links, count
+
+    def _derive_pr_commit_links(self) -> int:
+        """Derive PR->commit fast-path links from already-synced git tables.
+
+        Mirrors the issue<->PR self-fill: the live OAuth-provider sync writes raw
+        ``git_pull_requests`` and ``git_commits`` but never populates
+        ``work_graph_pr_commit`` (only fixtures did), so the ``CONTAINS`` edges
+        built by :meth:`_build_pr_commit_edges_from_fast_path` were empty for real
+        orgs. Here we parse merge/squash commit messages for the PR/MR numbers
+        GitHub and GitLab embed (``Merge pull request #N``, ``(#N)``, ``!N``) and,
+        when the referenced number matches a known PR in the same repo, persist a
+        ``WorkGraphPRCommit`` link. Re-running is idempotent: ``work_graph_pr_commit``
+        is a ReplacingMergeTree keyed on (org_id, repo_id, pr_number, commit_hash).
+
+        Returns:
+            Number of PR->commit links written.
+        """
+        logger.info("Deriving PR->commit links from commit messages...")
+
+        # Known PR numbers per repo, so we only link to PRs that actually exist.
+        pr_query = """
+        SELECT
+            repo_id,
+            number
+        FROM git_pull_requests
+        """
+        pr_where: list[str] = []
+        if self.config.repo_id:
+            pr_where.append(f"repo_id = '{self.config.repo_id}'")
+        if self.config.org_id:
+            pr_where.append(f"org_id = '{self.config.org_id}'")
+        if pr_where:
+            pr_query += " WHERE " + " AND ".join(pr_where)
+
+        pr_rows = self.sink.query_dicts(pr_query, {})
+        if not pr_rows:
+            logger.info("No PRs found; skipping PR->commit derivation")
+            return 0
+
+        known_prs: dict[str, set[int]] = {}
+        for pr_row in pr_rows:
+            repo_id = pr_row.get("repo_id")
+            number = pr_row.get("number")
+            if repo_id is None or number is None:
+                continue
+            known_prs.setdefault(str(repo_id), set()).add(int(number))
+
+        commit_query = """
+        SELECT
+            repo_id,
+            hash,
+            message,
+            author_when
+        FROM git_commits
+        WHERE message IS NOT NULL AND message != ''
+        """
+        where_clauses = []
+        if self.config.from_date:
+            where_clauses.append(
+                f"author_when >= '{_format_datetime_for_clickhouse(self.config.from_date)}'"
+            )
+        if self.config.to_date:
+            where_clauses.append(
+                f"author_when <= '{_format_datetime_for_clickhouse(self.config.to_date)}'"
+            )
+        if self.config.repo_id:
+            where_clauses.append(f"repo_id = '{self.config.repo_id}'")
+        if self.config.org_id:
+            where_clauses.append(f"org_id = '{self.config.org_id}'")
+        if where_clauses:
+            commit_query += " AND " + " AND ".join(where_clauses)
+
+        commit_rows = self.sink.query_dicts(commit_query, {})
+        logger.info("Found %d commits to scan for PR refs", len(commit_rows))
+        if not commit_rows:
+            return 0
+
+        links: list[WorkGraphPRCommit] = []
+        seen: set[tuple[str, int, str]] = set()
+        for commit_row in commit_rows:
+            repo_id = commit_row.get("repo_id")
+            commit_hash = commit_row.get("hash")
+            message = commit_row.get("message") or ""
+
+            if not commit_hash or repo_id is None:
+                continue
+
+            repo_id_str = str(repo_id)
+            repo_prs = known_prs.get(repo_id_str)
+            if not repo_prs:
+                continue
+
+            for pr_number in extract_pr_refs(message):
+                if pr_number not in repo_prs:
+                    continue
+                key = (repo_id_str, pr_number, str(commit_hash))
+                if key in seen:
+                    continue
+                seen.add(key)
+                links.append(
+                    WorkGraphPRCommit(
+                        repo_id=uuid.UUID(repo_id_str),
+                        pr_number=pr_number,
+                        commit_hash=str(commit_hash),
+                        confidence=0.9,
+                        provenance=Provenance.EXPLICIT_TEXT,
+                        evidence="commit_message_pr_ref",
+                        last_synced=self._now,
+                    )
+                )
+
+        self._write_pr_commit_links(links)
+        logger.info("Derived %d PR->commit links from commit messages", len(links))
+        return len(links)
 
     def _build_pr_commit_edges_from_fast_path(self) -> int:
         logger.info(

--- a/src/dev_health_ops/work_graph/extractors/text_parser.py
+++ b/src/dev_health_ops/work_graph/extractors/text_parser.py
@@ -54,29 +54,37 @@ GITHUB_PLAIN_REF_PATTERN = re.compile(r"(?<!\w)#(\d+)\b")
 # GitLab uses same patterns but also supports cross-project refs like "group/project#123"
 GITLAB_CROSS_PROJECT_PATTERN = re.compile(r"([\w\-\.]+/[\w\-\.]+)#(\d+)")
 
-# Pull-request references embedded in commit messages by GitHub/GitLab.
-# - Merge commits:  "Merge pull request #123 from ..." / "See merge request grp/proj!45"
-# - Squash commits: "Some change (#123)"
-# - Plain mentions: "#123"
+# Pull-request references embedded in commit messages by GitHub/GitLab when a
+# PR/MR is merged or squashed. These are deliberately PR/MR-specific forms only:
+# a bare "#123" or "!45" is NOT accepted because it overwhelmingly denotes an
+# ordinary issue reference (e.g. "Fixes #7"), not a PR/MR, and treating it as a
+# PR->commit link corrupts the work graph with false high-confidence edges.
+# - Merge commits:  "Merge pull request #123 from ..." (GitHub)
+#                   "See merge request grp/proj!45"     (GitLab)
+# - Squash commits: "Some change (#123)"                (GitHub squash-and-merge)
 GITHUB_MERGE_PR_PATTERN = re.compile(r"merge\s+pull\s+request\s+#(\d+)", re.IGNORECASE)
 GITLAB_MERGE_MR_PATTERN = re.compile(
     r"(?:merge\s+request|see\s+merge\s+request)\b[^!\n]*!(\d+)", re.IGNORECASE
 )
 SQUASH_PR_PATTERN = re.compile(r"\(#(\d+)\)")
-BANG_REF_PATTERN = re.compile(r"(?<![\w/])!(\d+)\b")
 
 
 def extract_pr_refs(text: str) -> list[int]:
     """
     Extract pull/merge-request numbers referenced in a commit message.
 
-    Recognizes the native conventions GitHub and GitLab embed in commit
-    messages when a PR/MR is merged or squashed:
+    Only the native, PR/MR-specific conventions that GitHub and GitLab embed in
+    commit messages when a PR/MR is merged or squashed are recognized:
 
     - "Merge pull request #123 from ..."   (GitHub merge commit)
     - "See merge request group/proj!45"    (GitLab merge commit)
-    - "Implement feature (#123)"            (GitHub/GitLab squash commit)
-    - "#123" / "!45"                        (plain mention)
+    - "Implement feature (#123)"            (GitHub squash-and-merge commit)
+
+    Bare ``#123``/``!45`` mentions are intentionally **not** treated as PR/MR
+    evidence: in commit messages they almost always denote an ordinary issue
+    reference (e.g. "Fixes #7" or "Closes #500"), and promoting them into
+    PR->commit links would persist false high-confidence edges into the work
+    graph and downstream file/AI-impact metrics.
 
     Args:
         text: Commit message to search.
@@ -100,8 +108,6 @@ def extract_pr_refs(text: str) -> list[int]:
         GITHUB_MERGE_PR_PATTERN,
         GITLAB_MERGE_MR_PATTERN,
         SQUASH_PR_PATTERN,
-        GITHUB_PLAIN_REF_PATTERN,
-        BANG_REF_PATTERN,
     ):
         for match in pattern.finditer(text):
             _add(match.group(1))

--- a/src/dev_health_ops/work_graph/extractors/text_parser.py
+++ b/src/dev_health_ops/work_graph/extractors/text_parser.py
@@ -77,6 +77,40 @@ GITLAB_MERGE_MR_PATTERN = re.compile(
     r"(?:merge\s+request|see\s+merge\s+request)\b[^!\n]*!(\d+)", re.IGNORECASE
 )
 
+# Revert commits embed the *original* merge subject verbatim, e.g.
+#   Revert "Merge pull request #42 from team/x"
+#
+#   This reverts commit <sha>.
+# A revert is a *later undo* commit -- it is NOT contained by PR #42, so the
+# merge-keyword number it quotes must never be promoted into a PR->commit link
+# (doing so attributes the revert's changes back to the reverted PR and skews
+# every downstream file/AI-impact metric). We reject the message outright when
+# its subject is a revert or its body carries git's revert marker. Anchored to
+# the start-of-line so an ordinary sentence merely containing the word "revert"
+# (e.g. "Merge pull request #5: revert flag default") is unaffected.
+# CHAOS-2375 round-3.
+REVERT_SUBJECT_PATTERN = re.compile(r"^\s*revert[\s\"']", re.IGNORECASE)
+REVERT_BODY_PATTERN = re.compile(
+    r"^\s*this\s+reverts\s+(?:commit|merge\s+request)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _is_revert_message(text: str) -> bool:
+    """Return True if ``text`` is a revert commit message.
+
+    Recognizes git's canonical revert shapes: a subject line beginning with
+    ``Revert "..."`` and/or a body line ``This reverts commit <sha>.`` (GitLab
+    also emits ``This reverts merge request !N``). Such commits quote the
+    reverted PR/MR's merge subject but are not part of that PR/MR.
+    """
+    if not text:
+        return False
+    first_line = text.lstrip().split("\n", 1)[0]
+    if REVERT_SUBJECT_PATTERN.match(first_line):
+        return True
+    return bool(REVERT_BODY_PATTERN.search(text))
+
 
 def extract_pr_refs(text: str) -> list[int]:
     """
@@ -104,6 +138,11 @@ def extract_pr_refs(text: str) -> list[int]:
       number collides with a real PR number), corrupting the work graph and
       downstream file/AI-impact metrics.
 
+    Revert commits are rejected entirely: ``Revert "Merge pull request #42 ..."``
+    quotes the reverted PR's merge subject but is a *later undo* commit, not a
+    commit contained by PR #42. Linking it would attribute the revert's changes
+    back to the original PR.
+
     Args:
         text: Commit message to search.
 
@@ -111,6 +150,12 @@ def extract_pr_refs(text: str) -> list[int]:
         De-duplicated list of referenced PR/MR numbers, in first-seen order.
     """
     if not text:
+        return []
+
+    # A revert commit quotes the reverted PR/MR's merge subject verbatim but is
+    # not contained by that PR/MR; emitting its number would attribute the undo
+    # back to the original PR. Reject before extracting. CHAOS-2375 round-3.
+    if _is_revert_message(text):
         return []
 
     seen: set[int] = set()

--- a/src/dev_health_ops/work_graph/extractors/text_parser.py
+++ b/src/dev_health_ops/work_graph/extractors/text_parser.py
@@ -54,37 +54,55 @@ GITHUB_PLAIN_REF_PATTERN = re.compile(r"(?<!\w)#(\d+)\b")
 # GitLab uses same patterns but also supports cross-project refs like "group/project#123"
 GITLAB_CROSS_PROJECT_PATTERN = re.compile(r"([\w\-\.]+/[\w\-\.]+)#(\d+)")
 
-# Pull-request references embedded in commit messages by GitHub/GitLab when a
-# PR/MR is merged or squashed. These are deliberately PR/MR-specific forms only:
-# a bare "#123" or "!45" is NOT accepted because it overwhelmingly denotes an
-# ordinary issue reference (e.g. "Fixes #7"), not a PR/MR, and treating it as a
-# PR->commit link corrupts the work graph with false high-confidence edges.
-# - Merge commits:  "Merge pull request #123 from ..." (GitHub)
-#                   "See merge request grp/proj!45"     (GitLab)
-# - Squash commits: "Some change (#123)"                (GitHub squash-and-merge)
+# Pull-request references embedded in commit messages by GitHub/GitLab *only*
+# via their explicit merge-keyword conventions. These forms are PR/MR-specific
+# by construction -- the literal words "pull request" / "merge request" cannot
+# appear in an ordinary issue reference -- so they are safe to promote into
+# PR->commit links:
+# - GitHub merge commit: "Merge pull request #123 from ..."
+# - GitLab merge commit:  "See merge request grp/proj!45"
+#
+# The bare squash form "Some change (#123)" is deliberately NOT recognized.
+# GitHub's squash-and-merge produces "<subject> (#N)", but that is positionally
+# and lexically identical to a hand-authored issue reference such as
+# "Fix parser edge case (#42)". Because git_pull_requests carries no persisted
+# merge_commit_sha (or any merge metadata) to corroborate the link, a bare
+# "(#N)" is indistinguishable from an issue mention. Promoting it would attach a
+# commit to an unrelated PR whenever an issue number happens to collide with a
+# real PR number in the same repo -- durable corruption of work_graph_pr_commit
+# and every downstream file/AI-impact metric that reads it. See CHAOS-2375
+# round-2 review: only unambiguous merge/MR-keyword evidence is accepted.
 GITHUB_MERGE_PR_PATTERN = re.compile(r"merge\s+pull\s+request\s+#(\d+)", re.IGNORECASE)
 GITLAB_MERGE_MR_PATTERN = re.compile(
     r"(?:merge\s+request|see\s+merge\s+request)\b[^!\n]*!(\d+)", re.IGNORECASE
 )
-SQUASH_PR_PATTERN = re.compile(r"\(#(\d+)\)")
 
 
 def extract_pr_refs(text: str) -> list[int]:
     """
     Extract pull/merge-request numbers referenced in a commit message.
 
-    Only the native, PR/MR-specific conventions that GitHub and GitLab embed in
-    commit messages when a PR/MR is merged or squashed are recognized:
+    Only the explicit, unambiguous merge-keyword conventions that GitHub and
+    GitLab embed in *merge* commit messages are recognized:
 
     - "Merge pull request #123 from ..."   (GitHub merge commit)
     - "See merge request group/proj!45"    (GitLab merge commit)
-    - "Implement feature (#123)"            (GitHub squash-and-merge commit)
 
-    Bare ``#123``/``!45`` mentions are intentionally **not** treated as PR/MR
-    evidence: in commit messages they almost always denote an ordinary issue
-    reference (e.g. "Fixes #7" or "Closes #500"), and promoting them into
-    PR->commit links would persist false high-confidence edges into the work
-    graph and downstream file/AI-impact metrics.
+    The literal "pull request" / "merge request" wording guarantees these denote
+    a PR/MR rather than an issue, so the derived ``work_graph_pr_commit`` links
+    are trustworthy.
+
+    Bare forms are intentionally **not** treated as PR/MR evidence:
+
+    - ``#123`` / ``!45``  -- almost always an ordinary issue reference
+      (e.g. "Fixes #7", "Closes #500").
+    - ``(#123)``          -- GitHub's squash-and-merge subject suffix, but it is
+      indistinguishable from a hand-authored parenthetical issue reference like
+      "Fix parser edge case (#42)". With no persisted merge metadata to
+      corroborate it, accepting this would persist false high-confidence
+      PR->commit edges (a commit attached to an unrelated PR whenever an issue
+      number collides with a real PR number), corrupting the work graph and
+      downstream file/AI-impact metrics.
 
     Args:
         text: Commit message to search.
@@ -107,7 +125,6 @@ def extract_pr_refs(text: str) -> list[int]:
     for pattern in (
         GITHUB_MERGE_PR_PATTERN,
         GITLAB_MERGE_MR_PATTERN,
-        SQUASH_PR_PATTERN,
     ):
         for match in pattern.finditer(text):
             _add(match.group(1))

--- a/src/dev_health_ops/work_graph/extractors/text_parser.py
+++ b/src/dev_health_ops/work_graph/extractors/text_parser.py
@@ -54,6 +54,60 @@ GITHUB_PLAIN_REF_PATTERN = re.compile(r"(?<!\w)#(\d+)\b")
 # GitLab uses same patterns but also supports cross-project refs like "group/project#123"
 GITLAB_CROSS_PROJECT_PATTERN = re.compile(r"([\w\-\.]+/[\w\-\.]+)#(\d+)")
 
+# Pull-request references embedded in commit messages by GitHub/GitLab.
+# - Merge commits:  "Merge pull request #123 from ..." / "See merge request grp/proj!45"
+# - Squash commits: "Some change (#123)"
+# - Plain mentions: "#123"
+GITHUB_MERGE_PR_PATTERN = re.compile(r"merge\s+pull\s+request\s+#(\d+)", re.IGNORECASE)
+GITLAB_MERGE_MR_PATTERN = re.compile(
+    r"(?:merge\s+request|see\s+merge\s+request)\b[^!\n]*!(\d+)", re.IGNORECASE
+)
+SQUASH_PR_PATTERN = re.compile(r"\(#(\d+)\)")
+BANG_REF_PATTERN = re.compile(r"(?<![\w/])!(\d+)\b")
+
+
+def extract_pr_refs(text: str) -> list[int]:
+    """
+    Extract pull/merge-request numbers referenced in a commit message.
+
+    Recognizes the native conventions GitHub and GitLab embed in commit
+    messages when a PR/MR is merged or squashed:
+
+    - "Merge pull request #123 from ..."   (GitHub merge commit)
+    - "See merge request group/proj!45"    (GitLab merge commit)
+    - "Implement feature (#123)"            (GitHub/GitLab squash commit)
+    - "#123" / "!45"                        (plain mention)
+
+    Args:
+        text: Commit message to search.
+
+    Returns:
+        De-duplicated list of referenced PR/MR numbers, in first-seen order.
+    """
+    if not text:
+        return []
+
+    seen: set[int] = set()
+    ordered: list[int] = []
+
+    def _add(value: str) -> None:
+        number = int(value)
+        if number not in seen:
+            seen.add(number)
+            ordered.append(number)
+
+    for pattern in (
+        GITHUB_MERGE_PR_PATTERN,
+        GITLAB_MERGE_MR_PATTERN,
+        SQUASH_PR_PATTERN,
+        GITHUB_PLAIN_REF_PATTERN,
+        BANG_REF_PATTERN,
+    ):
+        for match in pattern.finditer(text):
+            _add(match.group(1))
+
+    return ordered
+
 
 def extract_jira_keys(text: str) -> list[ParsedIssueRef]:
     """

--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -60,7 +60,25 @@ def run_work_graph_build(ns: argparse.Namespace) -> int:
     if ns.repo_id:
         repo_id = uuid.UUID(ns.repo_id)
 
-    org_id = getattr(ns, "org", None) or None
+    # Resolve the tenant scope. If --org was supplied it MUST flow into
+    # BuildConfig so every read/write the builder performs is org-scoped:
+    # _derive_pr_commit_links and the *_from_fast_path readers only apply the
+    # org filter (and stamp org_id onto work_graph_pr_commit rows) when
+    # BuildConfig.org_id is set. Dropping it here let `dev-hops work-graph build`
+    # scan all visible PRs/commits and persist derived PR-commit links under the
+    # empty org -- the intended tenant would miss its links while cross-tenant
+    # linkage material accumulated in the empty-org bucket (CHAOS-2375 round-3).
+    org_raw = getattr(ns, "org", None)
+    org_id = org_raw or None
+    if org_raw is not None and not str(org_raw).strip():
+        # An explicit but blank --org is almost certainly a mis-wired tenant
+        # scope; fail closed rather than silently building under the empty org.
+        logging.error(
+            "FAIL: --org was provided but resolved empty; refusing to build an "
+            "unscoped work graph. Pass a concrete org id or omit --org for a "
+            "full rebuild."
+        )
+        return 2
     logging.info("Building work graph for org_id=%s", org_id)
 
     config = BuildConfig(
@@ -70,6 +88,7 @@ def run_work_graph_build(ns: argparse.Namespace) -> int:
         repo_id=repo_id,
         heuristic_days_window=ns.heuristic_window,
         heuristic_confidence=ns.heuristic_confidence,
+        org_id=org_id or "",
     )
 
     logging.info(f"Building work graph from {config.from_date} to {config.to_date}")
@@ -98,6 +117,10 @@ def run_work_graph_build(ns: argparse.Namespace) -> int:
         ]
         if repo_id:
             where_parts.append(f"repo_id = '{repo_id}'")
+        # Verify against THIS tenant's edges only; otherwise a tenant-scoped build
+        # could "pass" on another org's rows while writing nothing of its own.
+        if org_id:
+            where_parts.append(f"org_id = '{org_id}'")
         where_sql = " AND ".join(where_parts)
 
         # Check edge count in DB for verification

--- a/tests/work_graph/test_builder.py
+++ b/tests/work_graph/test_builder.py
@@ -575,6 +575,209 @@ class TestDerivePRCommitLinks:
         assert records[0].commit_hash == "eee555"
 
 
+class TestFastPathTenantIsolation:
+    """Tenant-isolation guards for ``_build_pr_commit_edges_from_fast_path``.
+
+    The fast path materializes PR->commit edges by joining
+    ``work_graph_pr_commit`` to ``git_commits`` on (repo_id, commit_hash).
+    Because ``repo_id``/``commit_hash`` values can collide across tenants
+    (documented in metrics/loaders/ai_impact.py), the commit side MUST be
+    scoped to the same org as the PR-commit row -- otherwise an org-scoped
+    build could pick up another tenant's ``git_commits`` row and stamp a
+    cross-tenant edge into ``work_graph_edges``.
+    """
+
+    def test_join_predicate_scopes_commits_by_org(self):
+        """The fast-path SQL must equate ``c.org_id`` with ``p.org_id``.
+
+        Without this the join only matches on (repo_id, commit_hash) and a
+        colliding commit from another org would satisfy the join.
+        """
+        captured: dict[str, str] = {}
+
+        def mock_query(query, params):
+            if "work_graph_pr_commit AS p" in query:
+                captured["query"] = query
+            return []
+
+        fake_sink = MagicMock()
+        fake_sink.backend_type = "clickhouse"
+        fake_sink.query_dicts.side_effect = mock_query
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default", org_id="org-a")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            builder._build_pr_commit_edges_from_fast_path()
+            builder.close()
+
+        sql = captured["query"]
+        normalized = " ".join(sql.split())
+        # Both join sides must be org-scoped together.
+        assert "toString(p.org_id) = toString(c.org_id)" in normalized
+        # The selected org is still pinned via the WHERE filter.
+        assert "p.org_id = 'org-a'" in normalized
+
+    def test_cross_tenant_commit_collision_is_excluded(self):
+        """Two orgs share repo_id+commit_hash; org A's build must not use B's commit.
+
+        The fake sink simulates the JOIN honoring whatever predicates the
+        builder emits: org A has a PR-commit fast-path row but NO matching
+        ``git_commits`` row of its own; org B owns the colliding commit. With
+        the org-equality predicate present, the join yields zero rows for
+        org A, so no edge is created. (Drop ``c.org_id = p.org_id`` from the
+        builder and this test fails -- the join would match org B's commit.)
+        """
+        shared_repo = uuid.uuid4()
+        shared_hash = "deadbeef"
+        base_time = datetime(2024, 6, 15, tzinfo=timezone.utc)
+
+        # work_graph_pr_commit: org A has a fast-path link row.
+        pr_commit_rows = [
+            {
+                "repo_id": shared_repo,
+                "org_id": "org-a",
+                "pr_number": 1,
+                "commit_hash": shared_hash,
+            },
+        ]
+        # git_commits: ONLY org B owns the colliding commit row.
+        git_commits = [
+            {
+                "repo_id": shared_repo,
+                "org_id": "org-b",
+                "hash": shared_hash,
+                "author_when": base_time,
+            },
+        ]
+
+        def mock_query(query, params):
+            if "work_graph_pr_commit AS p" not in query:
+                return []
+            normalized = " ".join(query.split())
+            # Simulate the INNER JOIN + WHERE org filter the builder emits.
+            org_equijoin = "toString(p.org_id) = toString(c.org_id)" in normalized
+            results = []
+            for p in pr_commit_rows:
+                # WHERE p.org_id = '<selected>'
+                if f"p.org_id = '{p['org_id']}'" not in normalized:
+                    continue
+                for c in git_commits:
+                    if str(p["repo_id"]) != str(c["repo_id"]):
+                        continue
+                    if p["commit_hash"] != c["hash"]:
+                        continue
+                    # The org-equality predicate, when present, excludes the
+                    # cross-tenant commit.
+                    if org_equijoin and str(p["org_id"]) != str(c["org_id"]):
+                        continue
+                    results.append(
+                        {
+                            "repo_id": p["repo_id"],
+                            "pr_number": p["pr_number"],
+                            "commit_hash": p["commit_hash"],
+                            "confidence": 0.9,
+                            "provenance": "explicit_text",
+                            "evidence": "commit_message_pr_ref",
+                            "last_synced": base_time,
+                            "author_when": c["author_when"],
+                        }
+                    )
+            return results
+
+        fake_sink = MagicMock()
+        fake_sink.backend_type = "clickhouse"
+        fake_sink.query_dicts.side_effect = mock_query
+        fake_sink.write_work_graph_edges = MagicMock()
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default", org_id="org-a")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._build_pr_commit_edges_from_fast_path()
+            builder.close()
+
+        # org A has no commit of its own -> the colliding org B commit must be
+        # excluded -> zero edges, no cross-tenant contamination.
+        assert count == 0
+        fake_sink.write_work_graph_edges.assert_not_called()
+
+    def test_same_tenant_commit_still_links(self):
+        """The org-equality predicate must not break the legitimate same-org join."""
+        repo = uuid.uuid4()
+        commit_hash = "cafef00d"
+        base_time = datetime(2024, 6, 15, tzinfo=timezone.utc)
+
+        pr_commit_rows = [
+            {
+                "repo_id": repo,
+                "org_id": "org-a",
+                "pr_number": 7,
+                "commit_hash": commit_hash,
+            },
+        ]
+        git_commits = [
+            {
+                "repo_id": repo,
+                "org_id": "org-a",
+                "hash": commit_hash,
+                "author_when": base_time,
+            },
+        ]
+
+        def mock_query(query, params):
+            if "work_graph_pr_commit AS p" not in query:
+                return []
+            normalized = " ".join(query.split())
+            org_equijoin = "toString(p.org_id) = toString(c.org_id)" in normalized
+            results = []
+            for p in pr_commit_rows:
+                if f"p.org_id = '{p['org_id']}'" not in normalized:
+                    continue
+                for c in git_commits:
+                    if str(p["repo_id"]) != str(c["repo_id"]):
+                        continue
+                    if p["commit_hash"] != c["hash"]:
+                        continue
+                    if org_equijoin and str(p["org_id"]) != str(c["org_id"]):
+                        continue
+                    results.append(
+                        {
+                            "repo_id": p["repo_id"],
+                            "pr_number": p["pr_number"],
+                            "commit_hash": p["commit_hash"],
+                            "confidence": 0.9,
+                            "provenance": "explicit_text",
+                            "evidence": "commit_message_pr_ref",
+                            "last_synced": base_time,
+                            "author_when": c["author_when"],
+                        }
+                    )
+            return results
+
+        fake_sink = MagicMock()
+        fake_sink.backend_type = "clickhouse"
+        fake_sink.query_dicts.side_effect = mock_query
+        fake_sink.write_work_graph_edges = MagicMock(return_value=1)
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default", org_id="org-a")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._build_pr_commit_edges_from_fast_path()
+            builder.close()
+
+        assert count == 1
+        fake_sink.write_work_graph_edges.assert_called_once()
+        edge_records = fake_sink.write_work_graph_edges.call_args[0][0]
+        assert len(edge_records) == 1
+        assert edge_records[0].repo_id == repo
+        assert edge_records[0].org_id == "org-a"
+
+
 class TestWorkGraphBuilderIntegration:
     """Integration tests for WorkGraphBuilder.
 

--- a/tests/work_graph/test_builder.py
+++ b/tests/work_graph/test_builder.py
@@ -277,14 +277,16 @@ class TestDerivePRCommitLinks:
         fake_sink.write_work_graph_pr_commit = MagicMock()
         return fake_sink
 
-    def test_derives_links_from_merge_and_squash_commits(self):
-        """Merge/squash commit messages referencing known PRs yield links."""
+    def test_derives_links_from_merge_keyword_commits(self):
+        """GitHub/GitLab merge-keyword commit messages referencing known PRs yield
+        links; the ambiguous squash ``(#N)`` form does NOT."""
         repo_id = uuid.uuid4()
         base_time = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
 
         pr_rows = [
             {"repo_id": repo_id, "number": 42},
             {"repo_id": repo_id, "number": 7},
+            {"repo_id": repo_id, "number": 45},
         ]
         commit_rows = [
             {
@@ -295,7 +297,15 @@ class TestDerivePRCommitLinks:
             },
             {
                 "repo_id": repo_id,
+                "hash": "ggg777",
+                "message": "See merge request grp/proj!45",
+                "author_when": base_time,
+            },
+            {
+                "repo_id": repo_id,
                 "hash": "bbb222",
+                # Squash form is ambiguous with an issue ref -> must be ignored,
+                # even though PR #7 exists in this repo.
                 "message": "Add retry logic (#7)",
                 "author_when": base_time,
             },
@@ -314,10 +324,11 @@ class TestDerivePRCommitLinks:
         records = fake_sink.write_work_graph_pr_commit.call_args[0][0]
         assert len(records) == 2
         by_commit = {r.commit_hash: r for r in records}
-        # Correct columns + org scoping on the produced records.
+        # Only the two unambiguous merge-keyword commits are linked.
         assert by_commit["aaa111"].pr_number == 42
         assert by_commit["aaa111"].repo_id == repo_id
-        assert by_commit["bbb222"].pr_number == 7
+        assert by_commit["ggg777"].pr_number == 45
+        assert "bbb222" not in by_commit
         for record in records:
             assert record.provenance == "explicit_text"
             assert record.confidence == 0.9
@@ -332,7 +343,7 @@ class TestDerivePRCommitLinks:
             {
                 "repo_id": repo_id,
                 "hash": "ccc333",
-                "message": "Fix flake (#99)",
+                "message": "Merge pull request #99 from fix/flake",
                 "author_when": datetime(2024, 1, 1, tzinfo=timezone.utc),
             },
         ]
@@ -413,6 +424,38 @@ class TestDerivePRCommitLinks:
         assert count == 0
         fake_sink.write_work_graph_pr_commit.assert_not_called()
 
+    def test_squash_paren_ref_colliding_with_pr_number_is_not_linked(self):
+        """A parenthetical ``(#N)`` issue ref must NOT be linked to PR #N.
+
+        Primary CHAOS-2375 round-2 corruption case: "Fix parser edge case (#42)"
+        is a hand-authored issue reference, but the squash convention produces the
+        identical "<subject> (#42)" shape. With PR #42 present in the same repo,
+        the old ``SQUASH_PR_PATTERN`` would have attached this unrelated commit to
+        PR #42. The fix drops the squash form, so no link is written.
+        """
+        repo_id = uuid.uuid4()
+        pr_rows = [{"repo_id": repo_id, "number": 42}]
+        commit_rows = [
+            {
+                "repo_id": repo_id,
+                "hash": "f00d42",
+                "message": "Fix parser edge case (#42)",
+                "author_when": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            },
+        ]
+        fake_sink = self._build_sink(pr_rows, commit_rows)
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._derive_pr_commit_links()
+            builder.close()
+
+        assert count == 0
+        fake_sink.write_work_graph_pr_commit.assert_not_called()
+
     def test_build_invokes_derivation_before_fast_path(self):
         """build() must derive PR->commit links so the fast path is non-empty."""
         repo_id = uuid.uuid4()
@@ -421,7 +464,7 @@ class TestDerivePRCommitLinks:
             {
                 "repo_id": repo_id,
                 "hash": "eee555",
-                "message": "Ship it (#3)",
+                "message": "Merge pull request #3 from team/ship-it",
                 "author_when": datetime(2024, 1, 1, tzinfo=timezone.utc),
             },
         ]

--- a/tests/work_graph/test_builder.py
+++ b/tests/work_graph/test_builder.py
@@ -253,6 +253,164 @@ class TestHeuristicMatching:
         assert count == 0
 
 
+class TestDerivePRCommitLinks:
+    """Tests for live PR->commit derivation from commit messages.
+
+    These prove the seam that wires ``work_graph_pr_commit`` onto the live path:
+    the builder must parse already-synced ``git_commits`` for PR refs and persist
+    ``WorkGraphPRCommit`` rows via ``sink.write_work_graph_pr_commit`` -- previously
+    only fixtures wrote that table, so real orgs saw no commits under PRs.
+    """
+
+    def _build_sink(self, pr_rows, commit_rows):
+        fake_sink = MagicMock()
+        fake_sink.backend_type = "clickhouse"
+
+        def mock_query(query, params):
+            if "git_pull_requests" in query:
+                return pr_rows
+            if "git_commits" in query:
+                return commit_rows
+            return []
+
+        fake_sink.query_dicts.side_effect = mock_query
+        fake_sink.write_work_graph_pr_commit = MagicMock()
+        return fake_sink
+
+    def test_derives_links_from_merge_and_squash_commits(self):
+        """Merge/squash commit messages referencing known PRs yield links."""
+        repo_id = uuid.uuid4()
+        base_time = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        pr_rows = [
+            {"repo_id": repo_id, "number": 42},
+            {"repo_id": repo_id, "number": 7},
+        ]
+        commit_rows = [
+            {
+                "repo_id": repo_id,
+                "hash": "aaa111",
+                "message": "Merge pull request #42 from feature/x",
+                "author_when": base_time,
+            },
+            {
+                "repo_id": repo_id,
+                "hash": "bbb222",
+                "message": "Add retry logic (#7)",
+                "author_when": base_time,
+            },
+        ]
+        fake_sink = self._build_sink(pr_rows, commit_rows)
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._derive_pr_commit_links()
+            builder.close()
+
+        assert count == 2
+        records = fake_sink.write_work_graph_pr_commit.call_args[0][0]
+        assert len(records) == 2
+        by_commit = {r.commit_hash: r for r in records}
+        # Correct columns + org scoping on the produced records.
+        assert by_commit["aaa111"].pr_number == 42
+        assert by_commit["aaa111"].repo_id == repo_id
+        assert by_commit["bbb222"].pr_number == 7
+        for record in records:
+            assert record.provenance == "explicit_text"
+            assert record.confidence == 0.9
+            assert record.evidence == "commit_message_pr_ref"
+            assert record.org_id == ""
+
+    def test_org_id_scoped_onto_records(self):
+        """The configured org_id is stamped onto every derived record."""
+        repo_id = uuid.uuid4()
+        pr_rows = [{"repo_id": repo_id, "number": 99}]
+        commit_rows = [
+            {
+                "repo_id": repo_id,
+                "hash": "ccc333",
+                "message": "Fix flake (#99)",
+                "author_when": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            },
+        ]
+        fake_sink = self._build_sink(pr_rows, commit_rows)
+
+        config = BuildConfig(
+            dsn="clickhouse://localhost:9000/default", org_id="org-abc"
+        )
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._derive_pr_commit_links()
+            builder.close()
+
+        assert count == 1
+        record = fake_sink.write_work_graph_pr_commit.call_args[0][0][0]
+        assert record.org_id == "org-abc"
+        assert record.commit_hash == "ccc333"
+        assert record.pr_number == 99
+
+    def test_ignores_refs_to_unknown_prs(self):
+        """A '#N' that is not a real PR number must not produce a link."""
+        repo_id = uuid.uuid4()
+        pr_rows = [{"repo_id": repo_id, "number": 5}]
+        commit_rows = [
+            {
+                "repo_id": repo_id,
+                "hash": "ddd444",
+                # #500 is not a known PR; should be ignored entirely.
+                "message": "Closes issue #500, unrelated to any PR",
+                "author_when": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            },
+        ]
+        fake_sink = self._build_sink(pr_rows, commit_rows)
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._derive_pr_commit_links()
+            builder.close()
+
+        assert count == 0
+        fake_sink.write_work_graph_pr_commit.assert_not_called()
+
+    def test_build_invokes_derivation_before_fast_path(self):
+        """build() must derive PR->commit links so the fast path is non-empty."""
+        repo_id = uuid.uuid4()
+        pr_rows = [{"repo_id": repo_id, "number": 3}]
+        commit_rows = [
+            {
+                "repo_id": repo_id,
+                "hash": "eee555",
+                "message": "Ship it (#3)",
+                "author_when": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            },
+        ]
+        fake_sink = self._build_sink(pr_rows, commit_rows)
+        fake_sink.write_work_graph_edges = MagicMock()
+        fake_sink.write_work_graph_issue_pr = MagicMock()
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            builder.build()
+            builder.close()
+
+        # The seam: build() persisted PR->commit links via the sink.
+        fake_sink.write_work_graph_pr_commit.assert_called_once()
+        records = fake_sink.write_work_graph_pr_commit.call_args[0][0]
+        assert records[0].pr_number == 3
+        assert records[0].commit_hash == "eee555"
+
+
 class TestWorkGraphBuilderIntegration:
     """Integration tests for WorkGraphBuilder.
 

--- a/tests/work_graph/test_builder.py
+++ b/tests/work_graph/test_builder.py
@@ -380,6 +380,39 @@ class TestDerivePRCommitLinks:
         assert count == 0
         fake_sink.write_work_graph_pr_commit.assert_not_called()
 
+    def test_plain_issue_ref_colliding_with_pr_number_is_not_linked(self):
+        """A plain issue mention (``Fixes #N``) must NOT be linked to PR #N.
+
+        Regression guard for the false-positive corruption flagged in review:
+        an ordinary issue reference whose number happens to equal a real PR
+        number in the same repo must never become a persisted PR->commit edge.
+        """
+        repo_id = uuid.uuid4()
+        # PR #7 exists in this repo...
+        pr_rows = [{"repo_id": repo_id, "number": 7}]
+        commit_rows = [
+            {
+                "repo_id": repo_id,
+                "hash": "fff666",
+                # ...but this commit merely *closes issue* #7; it is unrelated
+                # to PR #7 and must not be promoted into a PR->commit link.
+                "message": "Fixes #7 in the parser",
+                "author_when": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            },
+        ]
+        fake_sink = self._build_sink(pr_rows, commit_rows)
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._derive_pr_commit_links()
+            builder.close()
+
+        assert count == 0
+        fake_sink.write_work_graph_pr_commit.assert_not_called()
+
     def test_build_invokes_derivation_before_fast_path(self):
         """build() must derive PR->commit links so the fast path is non-empty."""
         repo_id = uuid.uuid4()

--- a/tests/work_graph/test_builder.py
+++ b/tests/work_graph/test_builder.py
@@ -456,6 +456,94 @@ class TestDerivePRCommitLinks:
         assert count == 0
         fake_sink.write_work_graph_pr_commit.assert_not_called()
 
+    def test_revert_commit_is_not_linked_to_reverted_pr(self):
+        """A revert of a merge commit must NOT produce a PR->commit link.
+
+        CHAOS-2375 round-3: ``Revert "Merge pull request #42 ..."`` quotes the
+        reverted PR's merge subject but is a later undo commit, not a commit
+        contained by PR #42. Persisting the link would attribute the revert's
+        changes back to the original PR and skew downstream metrics. PR #42
+        exists in this repo, so only the revert guard prevents the bad link.
+        """
+        repo_id = uuid.uuid4()
+        pr_rows = [{"repo_id": repo_id, "number": 42}]
+        commit_rows = [
+            {
+                "repo_id": repo_id,
+                "hash": "rev042",
+                "message": (
+                    'Revert "Merge pull request #42 from team/x"\n\n'
+                    "This reverts commit 0123abcd."
+                ),
+                "author_when": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            },
+        ]
+        fake_sink = self._build_sink(pr_rows, commit_rows)
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._derive_pr_commit_links()
+            builder.close()
+
+        assert count == 0
+        fake_sink.write_work_graph_pr_commit.assert_not_called()
+
+    def test_pr_number_does_not_collide_across_repos(self):
+        """PR #1 in repo A and PR #1 in repo B are distinct.
+
+        Guards id-uniqueness: a commit in repo A merging PR #1 must link only to
+        repo A's PR #1, never repo B's. The derivation keys known PRs by repo_id,
+        so repo B's PR #1 commit (which references no real PR in repo B) is not
+        mis-linked. work_graph_pr_commit rows carry repo_id, keeping the
+        (org, repo, pr_number, commit_hash) identity unique.
+        """
+        repo_a = uuid.uuid4()
+        repo_b = uuid.uuid4()
+        base_time = datetime(2024, 6, 15, tzinfo=timezone.utc)
+        # Both repos have a PR #1.
+        pr_rows = [
+            {"repo_id": repo_a, "number": 1},
+            {"repo_id": repo_b, "number": 1},
+        ]
+        commit_rows = [
+            {
+                "repo_id": repo_a,
+                "hash": "a0001",
+                "message": "Merge pull request #1 from team/a-feature",
+                "author_when": base_time,
+            },
+            {
+                "repo_id": repo_b,
+                "hash": "b0001",
+                "message": "Merge pull request #1 from team/b-feature",
+                "author_when": base_time,
+            },
+        ]
+        fake_sink = self._build_sink(pr_rows, commit_rows)
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._derive_pr_commit_links()
+            builder.close()
+
+        assert count == 2
+        records = fake_sink.write_work_graph_pr_commit.call_args[0][0]
+        by_commit = {r.commit_hash: r for r in records}
+        # Each commit links to its OWN repo's PR #1, never the other repo's.
+        assert by_commit["a0001"].repo_id == repo_a
+        assert by_commit["a0001"].pr_number == 1
+        assert by_commit["b0001"].repo_id == repo_b
+        assert by_commit["b0001"].pr_number == 1
+        # The (repo_id, pr_number, commit_hash) identities are distinct.
+        identities = {(r.repo_id, r.pr_number, r.commit_hash) for r in records}
+        assert len(identities) == 2
+
     def test_build_invokes_derivation_before_fast_path(self):
         """build() must derive PR->commit links so the fast path is non-empty."""
         repo_id = uuid.uuid4()

--- a/tests/work_graph/test_runner.py
+++ b/tests/work_graph/test_runner.py
@@ -1,0 +1,88 @@
+"""Tests for the work-graph CLI runner (``dev-hops work-graph build``).
+
+These guard the org-scope wiring flagged in CHAOS-2375 round-3: the CLI must
+flow ``--org`` into ``BuildConfig.org_id`` so every read/write the builder
+performs is tenant-scoped, and must fail closed when ``--org`` is supplied but
+blank rather than silently building under the empty org.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+# Import connectors first to defuse the providers._base <-> connectors circular
+# import so this module runs in isolation.
+import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.work_graph.runner import run_work_graph_build
+
+
+def _ns(**overrides) -> argparse.Namespace:
+    base = dict(
+        db="clickhouse://localhost:9000/default",
+        from_date="2024-01-01",
+        to_date="2024-02-01",
+        repo_id=None,
+        heuristic_window=7,
+        heuristic_confidence=0.3,
+        check_components=False,
+        allow_degenerate=False,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _patched_builder():
+    """Patch WorkGraphBuilder so build() returns trivially and the verification
+    edge-count query reports a non-empty graph (so run returns 0)."""
+    fake_builder = MagicMock()
+    fake_builder.build.return_value = {"pr_commit_edges": 1}
+    client = MagicMock()
+    client.query.return_value.result_rows = [[1]]
+    fake_builder.client = client
+    return fake_builder
+
+
+def test_org_flows_into_build_config():
+    """``--org X`` must produce ``BuildConfig.org_id == X``."""
+    captured = {}
+
+    def _capture(config):
+        captured["config"] = config
+        return _patched_builder()
+
+    with patch(
+        "dev_health_ops.work_graph.runner.WorkGraphBuilder", side_effect=_capture
+    ):
+        rc = run_work_graph_build(_ns(org="org-abc"))
+
+    assert rc == 0
+    assert captured["config"].org_id == "org-abc"
+
+
+def test_no_org_builds_full_rebuild_with_empty_org():
+    """Omitting ``--org`` is a legitimate full rebuild: org_id is empty, not a
+    failure."""
+    captured = {}
+
+    def _capture(config):
+        captured["config"] = config
+        return _patched_builder()
+
+    with patch(
+        "dev_health_ops.work_graph.runner.WorkGraphBuilder", side_effect=_capture
+    ):
+        rc = run_work_graph_build(_ns(org=None))
+
+    assert rc == 0
+    assert captured["config"].org_id == ""
+
+
+def test_blank_org_fails_closed():
+    """An explicit but blank ``--org`` must fail closed (return 2) and never
+    construct a builder -- otherwise the tenant build silently runs unscoped."""
+    with patch("dev_health_ops.work_graph.runner.WorkGraphBuilder") as builder_cls:
+        rc = run_work_graph_build(_ns(org="   "))
+
+    assert rc == 2
+    builder_cls.assert_not_called()

--- a/tests/work_graph/test_text_parser.py
+++ b/tests/work_graph/test_text_parser.py
@@ -62,6 +62,51 @@ class TestExtractPRRefs:
         )
         assert extract_pr_refs(msg) == [88, 12]
 
+    def test_github_revert_commit_is_not_a_pr_ref(self):
+        """A revert of a GitHub merge commit must yield no PR refs.
+
+        Regression guard for CHAOS-2375 round-3: ``Revert "Merge pull request
+        #42 ..."`` quotes the reverted PR's merge subject verbatim but is a later
+        *undo* commit, not a commit contained by PR #42. Promoting it would
+        attribute the revert's changes back to the original PR.
+        """
+        assert extract_pr_refs('Revert "Merge pull request #42 from team/x"') == []
+        assert (
+            extract_pr_refs(
+                'Revert "Merge pull request #42 from team/x"\n\n'
+                "This reverts commit 0123abcd."
+            )
+            == []
+        )
+
+    def test_gitlab_revert_commit_is_not_a_pr_ref(self):
+        """A revert of a GitLab merge commit must yield no MR refs."""
+        assert extract_pr_refs('Revert "See merge request grp/proj!45"') == []
+        assert (
+            extract_pr_refs("Undo the change\n\nThis reverts merge request !45") == []
+        )
+
+    def test_revert_body_marker_without_revert_subject(self):
+        """A body carrying git's ``This reverts commit`` marker is a revert even
+        if the subject was hand-edited to mention the merge."""
+        msg = (
+            "Roll back flaky feature\n\n"
+            "This reverts commit deadbeef.\n"
+            "Originally landed via Merge pull request #88 from team/feature"
+        )
+        assert extract_pr_refs(msg) == []
+
+    def test_word_revert_inside_merge_subject_still_links(self):
+        """A real merge whose branch/subject merely contains the word 'revert'
+        must still link -- the guard is anchored to revert *commit* shapes, not
+        any occurrence of the word."""
+        assert extract_pr_refs(
+            "Merge pull request #5 from team/revert-flag-default"
+        ) == [5]
+
+    def test_revert_with_leading_whitespace_is_rejected(self):
+        assert extract_pr_refs('   Revert "Merge pull request #42 from team/x"') == []
+
     def test_empty(self):
         assert extract_pr_refs("") == []
         assert extract_pr_refs("no refs here") == []

--- a/tests/work_graph/test_text_parser.py
+++ b/tests/work_graph/test_text_parser.py
@@ -20,11 +20,19 @@ class TestExtractPRRefs:
     def test_github_merge_commit(self):
         assert extract_pr_refs("Merge pull request #123 from feat/x") == [123]
 
-    def test_squash_commit(self):
-        assert extract_pr_refs("Add retry logic (#42)") == [42]
-
     def test_gitlab_merge_request(self):
         assert extract_pr_refs("See merge request group/proj!45") == [45]
+
+    def test_squash_paren_form_is_not_a_pr_ref(self):
+        """GitHub squash ``(#N)`` is indistinguishable from a hand-authored issue
+        reference, so it must NOT be promoted into a PR/MR link.
+
+        Regression guard for CHAOS-2375 round-2: "Fix parser edge case (#42)" is
+        an ordinary parenthetical issue mention; treating it as PR #42 evidence
+        attaches the commit to an unrelated PR and corrupts the work graph.
+        """
+        assert extract_pr_refs("Add retry logic (#42)") == []
+        assert extract_pr_refs("Fix parser edge case (#42)") == []
 
     def test_plain_hash_mention_is_not_a_pr_ref(self):
         """A bare '#N' is an issue reference, not a PR/MR -- must be ignored."""
@@ -38,11 +46,21 @@ class TestExtractPRRefs:
         assert extract_pr_refs("!45 standalone") == []
 
     def test_dedupes_in_first_seen_order(self):
-        # Only PR/MR-specific forms count: "Merge pull request #9" and "(#9)"
-        # both reference PR 9; the trailing bare "#3" is an issue ref and dropped.
+        # Only explicit merge-keyword forms count. "Merge pull request #9"
+        # references PR 9; the squash "(#9)" and trailing bare "#3" are ambiguous
+        # issue-style refs and are dropped.
         assert extract_pr_refs("Merge pull request #9\nfollow-up to (#9) and #3") == [
             9,
         ]
+
+    def test_only_merge_keyword_forms_in_mixed_message(self):
+        """A message mixing a real merge ref with squash/issue noise yields only
+        the merge-keyword PR number."""
+        msg = (
+            "Merge pull request #88 from team/feature\n\n"
+            "Implements thing (#42)\nCloses #7\nSee merge request grp/proj!12"
+        )
+        assert extract_pr_refs(msg) == [88, 12]
 
     def test_empty(self):
         assert extract_pr_refs("") == []

--- a/tests/work_graph/test_text_parser.py
+++ b/tests/work_graph/test_text_parser.py
@@ -10,7 +10,34 @@ from dev_health_ops.work_graph.extractors.text_parser import (
     extract_github_issue_refs,
     extract_gitlab_issue_refs,
     extract_jira_keys,
+    extract_pr_refs,
 )
+
+
+class TestExtractPRRefs:
+    """Tests for PR/MR number extraction from commit messages."""
+
+    def test_github_merge_commit(self):
+        assert extract_pr_refs("Merge pull request #123 from feat/x") == [123]
+
+    def test_squash_commit(self):
+        assert extract_pr_refs("Add retry logic (#42)") == [42]
+
+    def test_gitlab_merge_request(self):
+        assert extract_pr_refs("See merge request group/proj!45") == [45]
+
+    def test_plain_mention(self):
+        assert extract_pr_refs("Relates to #7") == [7]
+
+    def test_dedupes_in_first_seen_order(self):
+        assert extract_pr_refs("Merge pull request #9\nfollow-up to (#9) and #3") == [
+            9,
+            3,
+        ]
+
+    def test_empty(self):
+        assert extract_pr_refs("") == []
+        assert extract_pr_refs("no refs here") == []
 
 
 class TestExtractJiraKeys:

--- a/tests/work_graph/test_text_parser.py
+++ b/tests/work_graph/test_text_parser.py
@@ -26,13 +26,22 @@ class TestExtractPRRefs:
     def test_gitlab_merge_request(self):
         assert extract_pr_refs("See merge request group/proj!45") == [45]
 
-    def test_plain_mention(self):
-        assert extract_pr_refs("Relates to #7") == [7]
+    def test_plain_hash_mention_is_not_a_pr_ref(self):
+        """A bare '#N' is an issue reference, not a PR/MR -- must be ignored."""
+        assert extract_pr_refs("Relates to #7") == []
+        assert extract_pr_refs("Fixes #7") == []
+        assert extract_pr_refs("Closes issue #500, unrelated to any PR") == []
+
+    def test_bare_bang_mention_is_not_a_pr_ref(self):
+        """A bare '!N' without merge-request context must be ignored."""
+        assert extract_pr_refs("yikes! 5 things broke") == []
+        assert extract_pr_refs("!45 standalone") == []
 
     def test_dedupes_in_first_seen_order(self):
+        # Only PR/MR-specific forms count: "Merge pull request #9" and "(#9)"
+        # both reference PR 9; the trailing bare "#3" is an issue ref and dropped.
         assert extract_pr_refs("Merge pull request #9\nfollow-up to (#9) and #3") == [
             9,
-            3,
         ]
 
     def test_empty(self):


### PR DESCRIPTION
Derives PR->commit (CONTAINS) edges on the live work-graph build (previously only fixtures wrote work_graph_pr_commit) so the /work graph shows commits under PRs. The fast-path commit join is tenant-scoped (org equijoin on both sides) so colliding repo_id/commit_hash across orgs cannot stamp a cross-tenant edge; revert commits + parenthesized issue refs are excluded from PR membership.

Part of CHAOS-2372. Closes CHAOS-2375.

> Branch forked at 667dc5b5; origin/main has since advanced. Rebase onto origin/main before merge (3-way merge is safe; a 2-dot diff shows unrelated main commits as spurious deletions). Reviewed across 4 adversarial rounds (in-workflow reviewer + Codex /codex:adversarial-review); tenant-isolation, no-silent-loss and correctness all verified. Gates: ruff + full-package mypy + pytest green.
