### PR TITLE
feat(metrics): compute file_hotspot_daily live + default blame backfill (CHAOS-2376)

### DIFF
--- a/src/dev_health_ops/metrics/hotspots.py
+++ b/src/dev_health_ops/metrics/hotspots.py
@@ -13,6 +13,7 @@ from dev_health_ops.metrics.schemas import (
     FileHotspotDaily,
     FileMetricsRecord,
 )
+from dev_health_ops.utils import AGGREGATE_STATS_MARKER
 
 
 class FileStats(TypedDict):
@@ -57,6 +58,10 @@ def compute_file_hotspots(
 
         path = row.get("file_path")
         if not path:
+            continue
+        # Skip the aggregate-stats sentinel (see compute_file_risk_hotspots):
+        # __AGGREGATE__ is a backfill marker, not a real file.
+        if path == AGGREGATE_STATS_MARKER:
             continue
 
         if path not in file_map:
@@ -128,6 +133,13 @@ def compute_file_risk_hotspots(
             continue
         path = row.get("file_path")
         if not path:
+            continue
+        # GitLab/GitHub backfill stores aggregate-only commit stats with
+        # file_path == AGGREGATE_STATS_MARKER ("__AGGREGATE__"). That sentinel
+        # is not a real file; it must never be ranked/persisted as a hotspot
+        # or it pollutes the risk treemap and hides real files (CHAOS-2376
+        # round-4).
+        if path == AGGREGATE_STATS_MARKER:
             continue
 
         if path not in churn_map:

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -6,6 +6,7 @@ import argparse
 import logging
 import os
 import uuid
+from collections.abc import Iterable
 from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -458,6 +459,23 @@ def _secondary_uri_from_env() -> str:
     return uri
 
 
+def _hotspot_repo_ids(
+    active_repos: set[uuid.UUID],
+    discovered_repo_ids: Iterable[uuid.UUID],
+) -> set[uuid.UUID]:
+    """Repos eligible for the live ``file_hotspot_daily`` risk pass.
+
+    The risk-hotspot computation must NOT be gated on same-day activity:
+    ``compute_file_risk_hotspots`` unions complexity-only files with churned
+    files, so a discovered repo whose risk comes from static complexity (no
+    commits/pipelines/deployments that day) must still produce rows. Returning
+    ``active_repos`` UNION every discovered repo ensures idle complexity-only
+    repos are covered; the compute returns no rows for repos with neither churn
+    nor complexity, so empty repos are never fabricated (CHAOS-2376 round-4).
+    """
+    return set(active_repos) | set(discovered_repo_ids)
+
+
 def _load_complexity_map_for_repo(
     *,
     primary_sink: Any,
@@ -790,11 +808,6 @@ async def run_daily_metrics_job(
         gini_by_repo: dict[uuid.UUID, float] = {}
 
         all_file_metrics = []
-        # file_hotspot_daily (risk treemap + hotspot drilldown on /complexity)
-        # is computed live here by merging the 30d churn window with the latest
-        # complexity snapshot per file, so real OAuth orgs get data instead of
-        # only fixtures (CHAOS-2376).
-        all_file_hotspots = []
         for r_id in active_repos:
             rework_ratio_by_repo[r_id] = compute_rework_churn_ratio(
                 repo_id=str(r_id), window_stats=h_commit_rows
@@ -816,6 +829,25 @@ async def run_daily_metrics_job(
             )
             all_file_metrics.extend(file_metrics)
 
+        # file_hotspot_daily (risk treemap + hotspot drilldown on /complexity)
+        # is computed live here by merging the 30d churn window with the latest
+        # complexity snapshot per file, so real OAuth orgs get data instead of
+        # only fixtures (CHAOS-2376).
+        #
+        # The risk-hotspot pass is NOT gated on active_repos: a repo's risk can
+        # come purely from static complexity (compute_file_risk_hotspots unions
+        # complexity-only files with churned files), and discovered repos can
+        # have complexity snapshots with zero same-day commits/pipelines/
+        # deployments -- common right after onboarding or on quiet-but-risky
+        # repos. Gating on active_repos there left /complexity empty/stale for
+        # those repos. Iterate over active_repos UNION all discovered repos so
+        # idle complexity-only repos still produce rows; compute_file_risk_
+        # hotspots returns [] when a repo has neither churn nor complexity, so
+        # this never fabricates rows for genuinely empty repos (CHAOS-2376
+        # round-4).
+        all_file_hotspots = []
+        hotspot_repos = _hotspot_repo_ids(active_repos, repo_names_by_id)
+        for r_id in hotspot_repos:
             complexity_map = _load_complexity_map_for_repo(
                 primary_sink=primary_sink,
                 org_id=org_id,

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -470,21 +470,27 @@ def _load_complexity_map_for_repo(
 
     ``file_complexity_snapshots`` is written by the separate complexity job
     (``metrics complexity``); this read joins that compute into the daily
-    hotspot/risk computation (CHAOS-2376). Uses ``argMax(*, computed_at)`` per
-    file to dedupe re-computes, mirroring the complexity resolver. Returns an
-    empty map (callers treat complexity as 0) on any query failure so a missing
-    or unmigrated table never aborts the daily job.
+    hotspot/risk computation (CHAOS-2376). Selects, per file, the snapshot with
+    the latest ``as_of_day`` on or before ``day`` (breaking ties by
+    ``computed_at``) via ``argMax(*, (as_of_day, computed_at))``. The temporal
+    key MUST lead with ``as_of_day`` -- keying on ``computed_at`` alone would
+    let an older ``as_of_day`` that was *backfilled/recomputed later* clobber a
+    newer snapshot and persist stale risk_score/cyclomatic into
+    ``file_hotspot_daily`` (CHAOS-2376 round-2). This mirrors the
+    ``max(as_of_day)``-first invariant in ``get_file_complexity_snapshots``.
+    Returns an empty map (callers treat complexity as 0) on any query failure so
+    a missing or unmigrated table never aborts the daily job.
     """
     query = """
         SELECT
             file_path,
-            argMax(language,                       computed_at) AS language,
-            argMax(loc,                            computed_at) AS loc,
-            argMax(functions_count,                computed_at) AS functions_count,
-            argMax(cyclomatic_total,               computed_at) AS cyclomatic_total,
-            argMax(cyclomatic_avg,                 computed_at) AS cyclomatic_avg,
-            argMax(high_complexity_functions,      computed_at) AS high_complexity_functions,
-            argMax(very_high_complexity_functions, computed_at) AS very_high_complexity_functions
+            argMax(language,                       (as_of_day, computed_at)) AS language,
+            argMax(loc,                            (as_of_day, computed_at)) AS loc,
+            argMax(functions_count,                (as_of_day, computed_at)) AS functions_count,
+            argMax(cyclomatic_total,               (as_of_day, computed_at)) AS cyclomatic_total,
+            argMax(cyclomatic_avg,                 (as_of_day, computed_at)) AS cyclomatic_avg,
+            argMax(high_complexity_functions,      (as_of_day, computed_at)) AS high_complexity_functions,
+            argMax(very_high_complexity_functions, (as_of_day, computed_at)) AS very_high_complexity_functions
         FROM file_complexity_snapshots
         WHERE repo_id = {repo_id:UUID}
           AND as_of_day <= {day:Date}
@@ -534,6 +540,7 @@ def _load_complexity_map_for_repo(
 def _load_blame_map_for_repo(
     *,
     primary_sink: Any,
+    org_id: str,
     repo_id: uuid.UUID,
 ) -> dict[str, float]:
     """Load per-file ownership concentration for ``repo_id`` from ``git_blame``.
@@ -545,13 +552,16 @@ def _load_blame_map_for_repo(
     almost all lines (bus-factor risk), near ``0`` means broad ownership.
 
     The aggregation is pushed server-side. ``git_blame`` is
-    ``ReplacingMergeTree(last_synced)`` keyed by ``(repo_id, path, line_no)``,
-    so a per-line ``argMax(author, last_synced)`` collapses re-synced lines to
-    their latest author before the per-file share is computed. Returns an empty
-    map (callers treat concentration as ``NULL``) on any query failure so a
-    missing/unmigrated table never aborts the daily job. ``git_blame`` has no
-    ``org_id`` column; the read is scoped by ``repo_id`` (repos are
-    org-partitioned upstream).
+    ``ReplacingMergeTree(last_synced)`` keyed by ``(org_id, repo_id, path,
+    line_no)`` (migration 027 prepends ``org_id`` to the sorting key and adds
+    the ``org_id`` column), so a per-line ``argMax(author, last_synced)``
+    collapses re-synced lines to their latest author before the per-file share
+    is computed. The read is scoped by BOTH ``org_id`` and ``repo_id``: blame
+    rows are tenant-partitioned, and a stale/default-org row for a reused
+    ``repo_id`` must not contaminate another tenant's ownership data
+    (CHAOS-2376 round-2: cross-org leak). Returns an empty map (callers treat
+    concentration as ``NULL``) on any query failure so a missing/unmigrated
+    table never aborts the daily job.
     """
     query = """
         SELECT
@@ -574,14 +584,18 @@ def _load_blame_map_for_repo(
                     ) AS author
                 FROM git_blame
                 WHERE repo_id = {repo_id:UUID}
-                GROUP BY path, line_no
+    """
+    params: dict[str, Any] = {"repo_id": str(repo_id)}
+    if org_id:
+        query += "                  AND org_id = {org_id:String}\n"
+        params["org_id"] = org_id
+    query += """                GROUP BY path, line_no
             )
             WHERE author != ''
             GROUP BY path, author
         )
         GROUP BY path
     """
-    params: dict[str, Any] = {"repo_id": str(repo_id)}
 
     try:
         rows = primary_sink.query_dicts(query, params)
@@ -813,6 +827,7 @@ async def run_daily_metrics_job(
             # Ownership-risk dimension is non-NULL for real orgs (CHAOS-2376).
             blame_map = _load_blame_map_for_repo(
                 primary_sink=primary_sink,
+                org_id=org_id,
                 repo_id=r_id,
             )
             file_hotspots = compute_file_risk_hotspots(

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -38,7 +38,10 @@ from dev_health_ops.metrics.compute_wellbeing import (
 )
 from dev_health_ops.metrics.compute_work_items import compute_work_item_metrics_daily
 from dev_health_ops.metrics.dependencies import get_metrics_dependencies
-from dev_health_ops.metrics.hotspots import compute_file_hotspots
+from dev_health_ops.metrics.hotspots import (
+    compute_file_hotspots,
+    compute_file_risk_hotspots,
+)
 from dev_health_ops.metrics.identity import (
     get_team_resolver,
     init_team_resolver,
@@ -56,6 +59,7 @@ from dev_health_ops.metrics.quality import (
     compute_single_owner_file_ratio,
 )
 from dev_health_ops.metrics.reviews import compute_review_edges_daily
+from dev_health_ops.metrics.schemas import FileComplexitySnapshot
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 from dev_health_ops.metrics.work_items import DiscoveredRepo
 from dev_health_ops.providers.identity import load_identity_resolver
@@ -454,6 +458,79 @@ def _secondary_uri_from_env() -> str:
     return uri
 
 
+def _load_complexity_map_for_repo(
+    *,
+    primary_sink: Any,
+    org_id: str,
+    repo_id: uuid.UUID,
+    day: date,
+) -> dict[str, FileComplexitySnapshot]:
+    """Load the latest complexity snapshot per file for ``repo_id`` on or before
+    ``day`` from ``file_complexity_snapshots``.
+
+    ``file_complexity_snapshots`` is written by the separate complexity job
+    (``metrics complexity``); this read joins that compute into the daily
+    hotspot/risk computation (CHAOS-2376). Uses ``argMax(*, computed_at)`` per
+    file to dedupe re-computes, mirroring the complexity resolver. Returns an
+    empty map (callers treat complexity as 0) on any query failure so a missing
+    or unmigrated table never aborts the daily job.
+    """
+    query = """
+        SELECT
+            file_path,
+            argMax(language,                       computed_at) AS language,
+            argMax(loc,                            computed_at) AS loc,
+            argMax(functions_count,                computed_at) AS functions_count,
+            argMax(cyclomatic_total,               computed_at) AS cyclomatic_total,
+            argMax(cyclomatic_avg,                 computed_at) AS cyclomatic_avg,
+            argMax(high_complexity_functions,      computed_at) AS high_complexity_functions,
+            argMax(very_high_complexity_functions, computed_at) AS very_high_complexity_functions
+        FROM file_complexity_snapshots
+        WHERE repo_id = {repo_id:UUID}
+          AND as_of_day <= {day:Date}
+    """
+    params: dict[str, Any] = {"repo_id": str(repo_id), "day": day}
+    if org_id:
+        query += "\n          AND org_id = {org_id:String}"
+        params["org_id"] = org_id
+    query += "\n        GROUP BY file_path"
+
+    try:
+        rows = primary_sink.query_dicts(query, params)
+    except Exception as exc:
+        logger.warning(
+            "Complexity snapshot load failed for repo_id=%s day=%s: %s",
+            repo_id,
+            day,
+            exc,
+        )
+        return {}
+
+    complexity_map: dict[str, FileComplexitySnapshot] = {}
+    for row in rows:
+        path = row.get("file_path")
+        if not path:
+            continue
+        complexity_map[path] = FileComplexitySnapshot(
+            repo_id=repo_id,
+            as_of_day=day,
+            ref="",
+            file_path=path,
+            language=row.get("language") or "",
+            loc=int(row.get("loc") or 0),
+            functions_count=int(row.get("functions_count") or 0),
+            cyclomatic_total=int(row.get("cyclomatic_total") or 0),
+            cyclomatic_avg=float(row.get("cyclomatic_avg") or 0.0),
+            high_complexity_functions=int(row.get("high_complexity_functions") or 0),
+            very_high_complexity_functions=int(
+                row.get("very_high_complexity_functions") or 0
+            ),
+            computed_at=datetime.now(timezone.utc),
+            org_id=org_id,
+        )
+    return complexity_map
+
+
 async def run_daily_metrics_job(
     *,
     db_url: str | None = None,
@@ -625,6 +702,11 @@ async def run_daily_metrics_job(
         gini_by_repo: dict[uuid.UUID, float] = {}
 
         all_file_metrics = []
+        # file_hotspot_daily (risk treemap + hotspot drilldown on /complexity)
+        # is computed live here by merging the 30d churn window with the latest
+        # complexity snapshot per file, so real OAuth orgs get data instead of
+        # only fixtures (CHAOS-2376).
+        all_file_hotspots = []
         for r_id in active_repos:
             rework_ratio_by_repo[r_id] = compute_rework_churn_ratio(
                 repo_id=str(r_id), window_stats=h_commit_rows
@@ -645,6 +727,21 @@ async def run_daily_metrics_job(
                 computed_at=computed_at,
             )
             all_file_metrics.extend(file_metrics)
+
+            complexity_map = _load_complexity_map_for_repo(
+                primary_sink=primary_sink,
+                org_id=org_id,
+                repo_id=r_id,
+                day=d,
+            )
+            file_hotspots = compute_file_risk_hotspots(
+                repo_id=r_id,
+                day=d,
+                window_stats=h_commit_rows,
+                complexity_map=complexity_map,
+                computed_at=computed_at,
+            )
+            all_file_hotspots.extend(file_hotspots)
 
         result = compute_daily_metrics(
             day=d,
@@ -915,6 +1012,8 @@ async def run_daily_metrics_job(
                 )
             if all_file_metrics:
                 s.write_file_metrics(all_file_metrics)
+            if all_file_hotspots and hasattr(s, "write_file_hotspot_daily"):
+                s.write_file_hotspot_daily(all_file_hotspots)
 
         _write_compounding_risk_for_day(
             sinks=sinks,

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -531,6 +531,80 @@ def _load_complexity_map_for_repo(
     return complexity_map
 
 
+def _load_blame_map_for_repo(
+    *,
+    primary_sink: Any,
+    repo_id: uuid.UUID,
+) -> dict[str, float]:
+    """Load per-file ownership concentration for ``repo_id`` from ``git_blame``.
+
+    Concentration is the share of currently-blamed lines attributed to the
+    single largest contributor for each file (a max-share / dominant-owner
+    metric in ``[0, 1]``). This surfaces the Ownership/blame dimension of the
+    risk hotspot (CHAOS-2376): a value near ``1.0`` means one author owns
+    almost all lines (bus-factor risk), near ``0`` means broad ownership.
+
+    The aggregation is pushed server-side. ``git_blame`` is
+    ``ReplacingMergeTree(last_synced)`` keyed by ``(repo_id, path, line_no)``,
+    so a per-line ``argMax(author, last_synced)`` collapses re-synced lines to
+    their latest author before the per-file share is computed. Returns an empty
+    map (callers treat concentration as ``NULL``) on any query failure so a
+    missing/unmigrated table never aborts the daily job. ``git_blame`` has no
+    ``org_id`` column; the read is scoped by ``repo_id`` (repos are
+    org-partitioned upstream).
+    """
+    query = """
+        SELECT
+            path,
+            max(author_lines) / sum(author_lines) AS concentration
+        FROM
+        (
+            SELECT
+                path,
+                author,
+                count() AS author_lines
+            FROM
+            (
+                SELECT
+                    path,
+                    line_no,
+                    argMax(
+                        coalesce(author_email, author_name, ''),
+                        last_synced
+                    ) AS author
+                FROM git_blame
+                WHERE repo_id = {repo_id:UUID}
+                GROUP BY path, line_no
+            )
+            WHERE author != ''
+            GROUP BY path, author
+        )
+        GROUP BY path
+    """
+    params: dict[str, Any] = {"repo_id": str(repo_id)}
+
+    try:
+        rows = primary_sink.query_dicts(query, params)
+    except Exception as exc:
+        logger.warning(
+            "Blame map load failed for repo_id=%s: %s",
+            repo_id,
+            exc,
+        )
+        return {}
+
+    blame_map: dict[str, float] = {}
+    for row in rows:
+        path = row.get("path")
+        if not path:
+            continue
+        concentration = row.get("concentration")
+        if concentration is None:
+            continue
+        blame_map[path] = float(concentration)
+    return blame_map
+
+
 async def run_daily_metrics_job(
     *,
     db_url: str | None = None,
@@ -734,11 +808,19 @@ async def run_daily_metrics_job(
                 repo_id=r_id,
                 day=d,
             )
+            # Ownership concentration per file from git_blame (backfilled on
+            # onboarding) feeds blame_concentration so the /complexity
+            # Ownership-risk dimension is non-NULL for real orgs (CHAOS-2376).
+            blame_map = _load_blame_map_for_repo(
+                primary_sink=primary_sink,
+                repo_id=r_id,
+            )
             file_hotspots = compute_file_risk_hotspots(
                 repo_id=r_id,
                 day=d,
                 window_stats=h_commit_rows,
                 complexity_map=complexity_map,
+                blame_map=blame_map,
                 computed_at=computed_at,
             )
             all_file_hotspots.extend(file_hotspots)

--- a/src/dev_health_ops/processors/base_git.py
+++ b/src/dev_health_ops/processors/base_git.py
@@ -379,6 +379,85 @@ async def check_backfill_needs(
     )
 
 
+async def blame_backfill_needed(
+    store: Any,
+    repo_id: Any,
+    *,
+    include_blame: bool,
+    any_row_needs_blame: bool,
+) -> bool:
+    """Decide whether the (capped) blame crawl should run this sync.
+
+    Coverage-aware gate (CHAOS-2376 round-3): the any-row ``has_any_git_blame``
+    check flips false after the first capped batch, which would strand every
+    file past the cap without blame. So when blame already exists, fall through
+    to ``has_unblamed_files`` to keep the crawl alive until coverage is
+    complete. A probe failure must not abort the wider backfill (files / commit
+    stats); on error we leave the any-row decision intact and retry next run.
+    """
+    if not include_blame:
+        return False
+    if any_row_needs_blame:
+        return True
+    if not hasattr(store, "has_unblamed_files"):
+        return False
+    try:
+        return bool(await store.has_unblamed_files(repo_id))
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning(
+            "Failed to probe blame coverage for repo %s; "
+            "deferring blame crawl to next sync: %s",
+            repo_id,
+            e,
+        )
+        return False
+
+
+async def select_unblamed_paths(
+    store: Any,
+    repo_id: Any,
+    file_paths: list[str],
+    max_files: int,
+) -> list[str]:
+    """Return the next bounded batch of paths that still lack blame.
+
+    The onboarding blame crawl is capped at ``max_files`` per sync (one
+    API call per file). Pairing that cap with the any-row ``has_any_git_blame``
+    gate caused silent data loss (CHAOS-2376 round-3): once the first capped
+    batch inserted, the existence gate flipped ``needs_blame`` false and every
+    file past the cap stayed without ``blame_concentration`` forever.
+
+    To make each sync *progress*, diff the live tree (``file_paths``) against
+    the paths already blamed for this repo/org and return only the next
+    unblamed batch. When the store does not expose per-path coverage
+    (``get_blamed_paths``), fall back to the capped prefix of ``file_paths`` so
+    behaviour degrades to the previous bounded crawl rather than failing.
+
+    Returns an empty list when blame coverage is already complete, letting the
+    caller skip the crawl entirely.
+    """
+    if not file_paths:
+        return []
+
+    blamed: set[str] = set()
+    if hasattr(store, "get_blamed_paths"):
+        try:
+            blamed = await store.get_blamed_paths(repo_id)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(
+                "Failed to read blame coverage for repo %s; "
+                "falling back to capped prefix: %s",
+                repo_id,
+                e,
+            )
+            return file_paths[:max_files]
+
+    # Preserve tree order so reruns deterministically advance through the
+    # remaining files instead of reblaming the same prefix.
+    unblamed = [p for p in file_paths if p not in blamed]
+    return unblamed[:max_files]
+
+
 async def backfill_file_records(
     ingestion_sink: Any,
     repo_id: Any,

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -25,6 +25,7 @@ from dev_health_ops.models.git import (
 from dev_health_ops.processors.base_git import (
     BaseGitProcessor,
     backfill_file_records,
+    blame_backfill_needed,
     build_ci_pipeline_run,
     build_connector_pull_request,
     build_deployment,
@@ -32,6 +33,7 @@ from dev_health_ops.processors.base_git import (
     check_backfill_needs,
     resolve_commit_stats_limit,
     resolve_incident_labels,
+    select_unblamed_paths,
 )
 from dev_health_ops.processors.fetch_utils import (
     AsyncBatchCollector,
@@ -881,13 +883,24 @@ async def _backfill_github_missing_data(
     if not needs_files and hasattr(store, "has_any_git_file_contents"):
         needs_files = not await store.has_any_git_file_contents(db_repo.id)
 
-    needs_blame = needs.blame and include_blame
+    # Blame backfill is coverage-aware (CHAOS-2376 round-3). The crawl is capped
+    # at BLAME_BACKFILL_MAX_FILES per sync, so an any-row gate (needs.blame)
+    # would mark the repo "done" after the first capped batch and strand every
+    # file past the cap without blame. Keep the blame branch alive while any
+    # tracked file still lacks blame, so successive syncs advance coverage.
+    needs_blame = await blame_backfill_needed(
+        store,
+        db_repo.id,
+        include_blame=include_blame,
+        any_row_needs_blame=needs.blame,
+    )
     if not (needs_files or needs_blame or needs.commit_stats):
         return
 
     gh_repo = connector.github.get_repo(f"{owner}/{repo_name}")
 
     file_paths: list[str] = []
+    blame_paths: list[str] = []
     if needs_files or needs_blame:
         try:
             branch = gh_repo.get_branch(default_branch)
@@ -978,14 +991,20 @@ async def _backfill_github_missing_data(
     if needs_blame and file_paths:
         # Bound the blame crawl: one GraphQL call per file, so cap the number
         # of files we blame on a single sync to avoid quota exhaustion /
-        # timeouts on large repos (CHAOS-2376).
-        blame_paths = file_paths[:BLAME_BACKFILL_MAX_FILES]
+        # timeouts on large repos (CHAOS-2376). Select the *next* unblamed batch
+        # (diffing the live tree against already-blamed paths) so each rerun
+        # advances coverage instead of reblaming the same capped prefix; the
+        # capped prefix is used only as a fallback when the store lacks per-path
+        # coverage.
+        blame_paths = await select_unblamed_paths(
+            store, db_repo.id, file_paths, BLAME_BACKFILL_MAX_FILES
+        )
+    if needs_blame and blame_paths:
         processed_files = 0
         try:
             logging.info(
-                "Backfilling blame for %d of %d files in %s (cap %d)...",
+                "Backfilling blame for %d unblamed files in %s (cap %d)...",
                 len(blame_paths),
-                len(file_paths),
                 repo_full_name,
                 BLAME_BACKFILL_MAX_FILES,
             )

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -793,6 +793,14 @@ def _split_full_name(full_name: str) -> tuple[str, str]:
 CONTENT_FETCH_MAX_BYTES = 1_000_000
 CONTENT_FETCH_MAX_FILES = 2_000
 
+# Cap on per-file blame fetches during onboarding backfill. Blame costs one
+# GraphQL call per file; without a cap a large repo would turn a normal sync
+# into thousands of calls (quota exhaustion / timeouts). The repo-level
+# has_any_git_blame gate means this is a bounded one-time cost on first
+# onboarding; full coverage remains available via the dedicated blame sync
+# target (CHAOS-2376).
+BLAME_BACKFILL_MAX_FILES = 500
+
 
 async def _fetch_scannable_contents(
     connector: GitHubConnector,
@@ -968,17 +976,23 @@ async def _backfill_github_missing_data(
             )
 
     if needs_blame and file_paths:
+        # Bound the blame crawl: one GraphQL call per file, so cap the number
+        # of files we blame on a single sync to avoid quota exhaustion /
+        # timeouts on large repos (CHAOS-2376).
+        blame_paths = file_paths[:BLAME_BACKFILL_MAX_FILES]
         processed_files = 0
         try:
             logging.info(
-                "Backfilling blame for %d files in %s...",
+                "Backfilling blame for %d of %d files in %s (cap %d)...",
+                len(blame_paths),
                 len(file_paths),
                 repo_full_name,
+                BLAME_BACKFILL_MAX_FILES,
             )
             async with AsyncBatchCollector(
                 ingestion_sink.insert_blame_data
             ) as blame_collector:
-                for path in file_paths:
+                for path in blame_paths:
                     try:
                         blame = connector.get_file_blame(
                             owner=owner,
@@ -1458,9 +1472,12 @@ async def process_github_repo(
             # (e.g. complexity, hotspots, ownership-risk) can run without a
             # local checkout. Gated on sync_git so non-git targets (prs,
             # cicd, ...) stay lean. Blame is included so the /complexity
-            # Ownership-risk tab is populated on normal onboarding; the
-            # backfill is incremental (only fetches blame for files that
-            # lack it) so the per-file GraphQL cost is paid once (CHAOS-2376).
+            # Ownership-risk tab is populated on normal onboarding. The
+            # has_any_git_blame gate is repo-level, so blame is fetched once
+            # per repo on first onboarding (skipped once any blame exists) and
+            # capped at BLAME_BACKFILL_MAX_FILES files per sync so a large repo
+            # cannot turn onboarding into an unbounded GraphQL crawl
+            # (CHAOS-2376).
             if backfill_missing and sync_git:
                 try:
                     await _backfill_github_missing_data(
@@ -1795,9 +1812,10 @@ async def process_github_repos_batch(
         if backfill_missing and sync_git:
             try:
                 # Blame is included so the /complexity Ownership-risk tab is
-                # populated on normal onboarding; the backfill is incremental
-                # (only files lacking blame), so the per-file cost is paid
-                # once (CHAOS-2376).
+                # populated on normal onboarding. The has_any_git_blame gate is
+                # repo-level (fetched once per repo on first onboarding) and the
+                # per-sync crawl is capped at BLAME_BACKFILL_MAX_FILES files so
+                # a large repo cannot exhaust API quota (CHAOS-2376).
                 await _backfill_github_missing_data(
                     store=store,
                     ingestion_sink=ingestion_sink,

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -1455,10 +1455,12 @@ async def process_github_repo(
                 )
 
             # 6. Backfill file records + contents so DB-based metrics
-            # (e.g. complexity) can run without a local checkout. Gated on
-            # sync_git so non-git targets (prs, cicd, ...) stay lean. Blame
-            # is excluded here: it costs one GraphQL call per file and has
-            # its own dedicated sync target.
+            # (e.g. complexity, hotspots, ownership-risk) can run without a
+            # local checkout. Gated on sync_git so non-git targets (prs,
+            # cicd, ...) stay lean. Blame is included so the /complexity
+            # Ownership-risk tab is populated on normal onboarding; the
+            # backfill is incremental (only fetches blame for files that
+            # lack it) so the per-file GraphQL cost is paid once (CHAOS-2376).
             if backfill_missing and sync_git:
                 try:
                     await _backfill_github_missing_data(
@@ -1469,7 +1471,7 @@ async def process_github_repo(
                         repo_full_name=repo_info.full_name,
                         default_branch=repo_info.default_branch,
                         max_commits=max_commits,
-                        include_blame=False,
+                        include_blame=True,
                         include_commit_stats=False,
                     )
                 except Exception as e:
@@ -1792,6 +1794,10 @@ async def process_github_repos_batch(
 
         if backfill_missing and sync_git:
             try:
+                # Blame is included so the /complexity Ownership-risk tab is
+                # populated on normal onboarding; the backfill is incremental
+                # (only files lacking blame), so the per-file cost is paid
+                # once (CHAOS-2376).
                 await _backfill_github_missing_data(
                     store=store,
                     ingestion_sink=ingestion_sink,
@@ -1800,7 +1806,7 @@ async def process_github_repos_batch(
                     repo_full_name=repo_info.full_name,
                     default_branch=repo_info.default_branch,
                     max_commits=max_commits_per_repo,
-                    include_blame=False,
+                    include_blame=True,
                     include_commit_stats=False,
                 )
             except Exception as e:

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -1384,10 +1384,12 @@ async def process_gitlab_project(
                 logging.info(f"Stored {len(blame_batch)} blame records from GitLab")
 
         # 6. Backfill file records + contents so DB-based metrics (e.g.
-        # complexity) can run without a local checkout. Gated on sync_git
-        # so non-git targets (prs, cicd, ...) stay lean. Blame is excluded
-        # here: it costs one REST call per file and has its own dedicated
-        # sync target.
+        # complexity, hotspots, ownership-risk) can run without a local
+        # checkout. Gated on sync_git so non-git targets (prs, cicd, ...)
+        # stay lean. Blame is included so the /complexity Ownership-risk tab
+        # is populated on normal onboarding; the backfill is incremental
+        # (only files lacking blame), so the per-file REST cost is paid once
+        # (CHAOS-2376).
         if backfill_missing and sync_git:
             try:
                 await _backfill_gitlab_missing_data(
@@ -1398,7 +1400,7 @@ async def process_gitlab_project(
                     project_full_name=full_name,
                     default_branch=db_repo.settings.get("default_branch", "main"),
                     max_commits=max_commits,
-                    include_blame=False,
+                    include_blame=True,
                     include_commit_stats=False,
                 )
             except Exception as e:
@@ -1705,6 +1707,10 @@ async def process_gitlab_projects_batch(
 
         if backfill_missing and sync_git:
             try:
+                # Blame is included so the /complexity Ownership-risk tab is
+                # populated on normal onboarding; the backfill is incremental
+                # (only files lacking blame), so the per-file cost is paid
+                # once (CHAOS-2376).
                 await _backfill_gitlab_missing_data(
                     store=store,
                     ingestion_sink=ingestion_sink,
@@ -1713,7 +1719,7 @@ async def process_gitlab_projects_batch(
                     project_full_name=project_info.full_name,
                     default_branch=project_info.default_branch,
                     max_commits=max_commits_per_project,
-                    include_blame=False,
+                    include_blame=True,
                     include_commit_stats=False,
                 )
             except Exception as e:

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -24,6 +24,7 @@ from dev_health_ops.models.git import (
 from dev_health_ops.processors.base_git import (
     BaseGitProcessor,
     backfill_file_records,
+    blame_backfill_needed,
     build_ci_pipeline_run,
     build_connector_pull_request,
     build_deployment,
@@ -31,6 +32,7 @@ from dev_health_ops.processors.base_git import (
     check_backfill_needs,
     resolve_commit_stats_limit,
     resolve_incident_labels,
+    select_unblamed_paths,
 )
 from dev_health_ops.processors.fetch_utils import (
     AsyncBatchCollector,
@@ -814,7 +816,17 @@ async def _backfill_gitlab_missing_data(
     if not needs_files and hasattr(store, "has_any_git_file_contents"):
         needs_files = not await store.has_any_git_file_contents(db_repo.id)
 
-    needs_blame = needs.blame and include_blame
+    # Blame backfill is coverage-aware (CHAOS-2376 round-3). The crawl is capped
+    # at BLAME_BACKFILL_MAX_FILES per sync, so an any-row gate (needs.blame)
+    # would mark the project "done" after the first capped batch and strand
+    # every file past the cap without blame. Keep the blame branch alive while
+    # any tracked file still lacks blame, so successive syncs advance coverage.
+    needs_blame = await blame_backfill_needed(
+        store,
+        db_repo.id,
+        include_blame=include_blame,
+        any_row_needs_blame=needs.blame,
+    )
     if not (needs_files or needs_blame or needs.commit_stats):
         return
 
@@ -825,6 +837,7 @@ async def _backfill_gitlab_missing_data(
         return
 
     file_paths: list[str] = []
+    blame_paths: list[str] = []
     if needs_files or needs_blame:
         try:
             items = _iter_gitlab_repo_tree(
@@ -906,8 +919,25 @@ async def _backfill_gitlab_missing_data(
     if needs_blame and file_paths:
         # Bound the blame crawl: one REST call per file, so cap the number of
         # files we blame on a single sync to avoid rate-limit failures /
-        # timeouts on large projects (CHAOS-2376).
-        blame_paths = file_paths[:BLAME_BACKFILL_MAX_FILES]
+        # timeouts on large projects (CHAOS-2376). Select the *next* unblamed
+        # batch (diffing the live tree against already-blamed paths) so each
+        # rerun advances coverage instead of reblaming the same capped prefix;
+        # the capped prefix is a fallback when the store lacks per-path coverage.
+        blame_paths = await select_unblamed_paths(
+            store, db_repo.id, file_paths, BLAME_BACKFILL_MAX_FILES
+        )
+        if not blame_paths:
+            logging.info(
+                "Blame coverage already complete for %s; skipping crawl",
+                project_full_name,
+            )
+    if needs_blame and blame_paths:
+        logging.info(
+            "Backfilling blame for %d unblamed files in %s (cap %d)...",
+            len(blame_paths),
+            project_full_name,
+            BLAME_BACKFILL_MAX_FILES,
+        )
         async with AsyncBatchCollector(
             ingestion_sink.insert_blame_data
         ) as blame_collector:

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -732,6 +732,14 @@ def _fetch_gitlab_blame_sync(gl_project, connector, project_id, repo_id, limit=5
 CONTENT_FETCH_MAX_BYTES = 1_000_000
 CONTENT_FETCH_MAX_FILES = 2_000
 
+# Cap on per-file blame fetches during onboarding backfill (parity with the
+# GitHub processor). Blame costs one REST call per file; without a cap a large
+# project would turn a normal sync into thousands of calls (rate-limit
+# failures / timeouts). The repo-level has_any_git_blame gate makes this a
+# bounded one-time cost on first onboarding; full coverage remains available
+# via the dedicated blame sync target (CHAOS-2376).
+BLAME_BACKFILL_MAX_FILES = 500
+
 
 async def _fetch_scannable_contents(
     connector: Any,
@@ -896,10 +904,14 @@ async def _backfill_gitlab_missing_data(
                     )
 
     if needs_blame and file_paths:
+        # Bound the blame crawl: one REST call per file, so cap the number of
+        # files we blame on a single sync to avoid rate-limit failures /
+        # timeouts on large projects (CHAOS-2376).
+        blame_paths = file_paths[:BLAME_BACKFILL_MAX_FILES]
         async with AsyncBatchCollector(
             ingestion_sink.insert_blame_data
         ) as blame_collector:
-            for path in file_paths:
+            for path in blame_paths:
                 try:
                     blame_items = connector.rest_client.get_file_blame(
                         project.id,
@@ -1387,9 +1399,11 @@ async def process_gitlab_project(
         # complexity, hotspots, ownership-risk) can run without a local
         # checkout. Gated on sync_git so non-git targets (prs, cicd, ...)
         # stay lean. Blame is included so the /complexity Ownership-risk tab
-        # is populated on normal onboarding; the backfill is incremental
-        # (only files lacking blame), so the per-file REST cost is paid once
-        # (CHAOS-2376).
+        # is populated on normal onboarding. The has_any_git_blame gate is
+        # repo-level, so blame is fetched once per project on first onboarding
+        # (skipped once any blame exists) and capped at BLAME_BACKFILL_MAX_FILES
+        # files per sync so a large project cannot turn onboarding into an
+        # unbounded REST crawl (CHAOS-2376).
         if backfill_missing and sync_git:
             try:
                 await _backfill_gitlab_missing_data(
@@ -1708,9 +1722,10 @@ async def process_gitlab_projects_batch(
         if backfill_missing and sync_git:
             try:
                 # Blame is included so the /complexity Ownership-risk tab is
-                # populated on normal onboarding; the backfill is incremental
-                # (only files lacking blame), so the per-file cost is paid
-                # once (CHAOS-2376).
+                # populated on normal onboarding. The has_any_git_blame gate is
+                # repo-level (fetched once per project on first onboarding) and
+                # the per-sync crawl is capped at BLAME_BACKFILL_MAX_FILES files
+                # so a large project cannot exhaust API quota (CHAOS-2376).
                 await _backfill_gitlab_missing_data(
                     store=store,
                     ingestion_sink=ingestion_sink,

--- a/src/dev_health_ops/processors/storage_protocol.py
+++ b/src/dev_health_ops/processors/storage_protocol.py
@@ -127,8 +127,8 @@ class GitSyncStore(Protocol):
 
     async def get_blamed_paths(self, repo_id: object) -> set[str]:
         """Return the set of file paths that already have blame for the repo."""
-        ...
+        raise NotImplementedError
 
     async def has_unblamed_files(self, repo_id: object) -> bool:
         """Return True if any tracked file still lacks blame for the repo."""
-        ...
+        raise NotImplementedError

--- a/src/dev_health_ops/processors/storage_protocol.py
+++ b/src/dev_health_ops/processors/storage_protocol.py
@@ -124,3 +124,11 @@ class GitSyncStore(Protocol):
     async def has_any_git_blame(self, repo_id: object) -> bool:
         """Return True if any blame records exist for the given repo."""
         ...
+
+    async def get_blamed_paths(self, repo_id: object) -> set[str]:
+        """Return the set of file paths that already have blame for the repo."""
+        ...
+
+    async def has_unblamed_files(self, repo_id: object) -> bool:
+        """Return True if any tracked file still lacks blame for the repo."""
+        ...

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -496,6 +496,66 @@ class ClickHouseStore:
             )
         return bool(getattr(result, "result_rows", None))
 
+    async def get_blamed_paths(self, repo_id) -> set[str]:
+        """Return the set of file paths that already have blame for this repo.
+
+        Used by the onboarding blame backfill to compute the *next* unblamed
+        batch (CHAOS-2376 round-3). The onboarding crawl is capped at
+        ``BLAME_BACKFILL_MAX_FILES`` per sync; without per-path coverage the
+        any-row ``has_any_git_blame`` gate would mark the repo "done" after the
+        first capped insert, permanently leaving files past the cap without
+        ``blame_concentration``. Scoped by ``self.org_id`` because ``git_blame``
+        is org-partitioned (migration 027) and ``repo_id`` is reused across
+        tenants.
+        """
+        assert self.client is not None
+        org_id = getattr(self, "org_id", None) or ""
+        query = "SELECT DISTINCT path FROM git_blame WHERE repo_id = {repo_id:UUID}"
+        params: dict[str, Any] = {"repo_id": str(self._normalize_uuid(repo_id))}
+        if org_id:
+            query += " AND org_id = {org_id:String}"
+            params["org_id"] = org_id
+        async with self._lock:
+            result = await asyncio.to_thread(
+                self.client.query, query, parameters=params
+            )
+        rows = getattr(result, "result_rows", None) or []
+        return {str(row[0]) for row in rows if row and row[0] is not None}
+
+    async def has_unblamed_files(self, repo_id) -> bool:
+        """Whether any tracked file still lacks blame for this repo/org.
+
+        Cheap gate that keeps the blame backfill alive across reruns without
+        walking the provider tree when coverage is already complete
+        (CHAOS-2376 round-3). A file is "unblamed" when a ``git_files`` row
+        exists whose ``path`` has no matching ``git_blame`` row. Both tables are
+        org-partitioned, so the comparison is scoped to ``self.org_id``.
+        Returns False when no files are tracked yet (first onboarding falls
+        back to the ``has_any_git_blame`` any-row gate to start the crawl).
+        """
+        assert self.client is not None
+        org_id = getattr(self, "org_id", None) or ""
+        repo_uuid = str(self._normalize_uuid(repo_id))
+        params: dict[str, Any] = {"repo_id": repo_uuid}
+        files_filter = "repo_id = {repo_id:UUID}"
+        blame_filter = "repo_id = {repo_id:UUID}"
+        if org_id:
+            params["org_id"] = org_id
+            files_filter += " AND org_id = {org_id:String}"
+            blame_filter += " AND org_id = {org_id:String}"
+        query = (
+            "SELECT 1 FROM git_files "
+            f"WHERE {files_filter} "
+            "AND path NOT IN ("
+            f"SELECT path FROM git_blame WHERE {blame_filter}"
+            ") LIMIT 1"
+        )
+        async with self._lock:
+            result = await asyncio.to_thread(
+                self.client.query, query, parameters=params
+            )
+        return bool(getattr(result, "result_rows", None))
+
     async def insert_git_file_data(self, file_data: list[GitFile]) -> None:
         if not file_data:
             return

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -471,7 +471,30 @@ class ClickHouseStore:
         return await self._has_any("git_commit_stats", self._normalize_uuid(repo_id))
 
     async def has_any_git_blame(self, repo_id) -> bool:
-        return await self._has_any("git_blame", self._normalize_uuid(repo_id))
+        """Whether blame exists for this repo *under the current org*.
+
+        Onboarding uses this gate to decide whether to fetch fresh blame
+        (``check_backfill_needs`` -> ``backfill``). ``git_blame`` is
+        ``org_id``-partitioned (migration 027), and ``repo_id`` can be reused
+        across tenants. A repo-only existence check would let a stale/default
+        org's blame row suppress the fresh fetch for a newly-onboarded org,
+        leaving its Ownership-risk tab empty (CHAOS-2376 round-2). Scoping by
+        ``self.org_id`` makes the gate tenant-correct; when ``org_id`` is unset
+        we fall back to the repo-only check.
+        """
+        assert self.client is not None
+        org_id = getattr(self, "org_id", None) or ""
+        query = "SELECT 1 FROM git_blame WHERE repo_id = {repo_id:UUID}"
+        params: dict[str, Any] = {"repo_id": str(self._normalize_uuid(repo_id))}
+        if org_id:
+            query += " AND org_id = {org_id:String}"
+            params["org_id"] = org_id
+        query += " LIMIT 1"
+        async with self._lock:
+            result = await asyncio.to_thread(
+                self.client.query, query, parameters=params
+            )
+        return bool(getattr(result, "result_rows", None))
 
     async def insert_git_file_data(self, file_data: list[GitFile]) -> None:
         if not file_data:

--- a/src/dev_health_ops/storage/mixins/git.py
+++ b/src/dev_health_ops/storage/mixins/git.py
@@ -53,6 +53,40 @@ class GitDataMixin(SQLAlchemyStoreMixinProtocol):
         )
         return (result.scalar() or 0) > 0
 
+    async def get_blamed_paths(self, repo_id) -> set[str]:
+        """Return the set of file paths that already have blame for this repo.
+
+        Drives the coverage-aware onboarding blame backfill (CHAOS-2376
+        round-3): the crawl is capped per sync, so the backfill must diff the
+        live tree against already-blamed paths and process the next unblamed
+        batch instead of stopping once any blame row exists.
+        """
+        assert self.session is not None
+        result = await self.session.execute(
+            select(GitBlame.path).distinct().where(GitBlame.repo_id == repo_id)
+        )
+        return {str(path) for (path,) in result.all() if path is not None}
+
+    async def has_unblamed_files(self, repo_id) -> bool:
+        """Whether any tracked file still lacks blame for this repo.
+
+        Keeps the capped onboarding blame crawl alive across reruns without
+        re-walking the provider tree once coverage is complete (CHAOS-2376
+        round-3). Returns False when no files are tracked yet so first
+        onboarding starts via the ``has_any_git_blame`` any-row gate.
+        """
+        assert self.session is not None
+        blamed_subq = select(GitBlame.path).where(GitBlame.repo_id == repo_id)
+        result = await self.session.execute(
+            select(GitFile.path)
+            .where(
+                GitFile.repo_id == repo_id,
+                GitFile.path.not_in(blamed_subq),
+            )
+            .limit(1)
+        )
+        return result.first() is not None
+
     async def insert_git_file_data(self, file_data: list[GitFile]) -> None:
         if not file_data:
             return

--- a/tests/metrics/test_job_daily_hotspots.py
+++ b/tests/metrics/test_job_daily_hotspots.py
@@ -100,6 +100,55 @@ def test_load_complexity_map_for_repo_maps_rows() -> None:
     assert params["org_id"] == "acme"
     assert "argMax" in query
     assert "file_complexity_snapshots" in query
+    # Latest-by-day selection: the argMax temporal key MUST lead with as_of_day
+    # so a later-recomputed OLDER snapshot cannot clobber a newer one
+    # (CHAOS-2376 round-2). Plain `argMax(field, computed_at)` is the bug.
+    assert "(as_of_day, computed_at)" in query
+    assert "argMax(cyclomatic_total,               computed_at)" not in query
+
+
+def test_load_complexity_map_selects_latest_by_as_of_day() -> None:
+    """The complexity loader must order snapshots by (as_of_day, computed_at),
+    not computed_at alone.
+
+    Regression for CHAOS-2376 round-2: a backfill that recomputes an OLDER
+    ``as_of_day`` *after* a newer snapshot was written would, under a
+    ``argMax(field, computed_at)`` read, surface the stale older values and
+    persist bad risk_score/cyclomatic into ``file_hotspot_daily``. This asserts
+    the query argMaxes on the ``(as_of_day, computed_at)`` tuple so the newest
+    snapshot day always wins regardless of recompute order.
+    """
+    captured: dict[str, str] = {}
+
+    class _CaptureSink:
+        def query_dicts(
+            self, query: str, parameters: dict[str, Any]
+        ) -> list[dict[str, Any]]:
+            captured["query"] = query
+            return []
+
+    job_daily._load_complexity_map_for_repo(
+        primary_sink=_CaptureSink(),
+        org_id="acme",
+        repo_id=uuid.uuid4(),
+        day=DAY,
+    )
+
+    query = captured["query"]
+    # Every projected field must argMax on the (as_of_day, computed_at) tuple.
+    for field in (
+        "language",
+        "loc",
+        "functions_count",
+        "cyclomatic_total",
+        "cyclomatic_avg",
+        "high_complexity_functions",
+        "very_high_complexity_functions",
+    ):
+        assert f"AS {field}" in query
+    assert query.count("(as_of_day, computed_at)") == 7
+    # The buggy single-key form must be gone for every field.
+    assert "computed_at) AS" not in query.replace("(as_of_day, computed_at)", "")
 
 
 def test_load_complexity_map_swallows_query_failure() -> None:
@@ -223,14 +272,18 @@ def test_load_blame_map_for_repo_maps_concentration() -> None:
         ]
     )
 
-    result = job_daily._load_blame_map_for_repo(primary_sink=sink, repo_id=repo_id)
+    result = job_daily._load_blame_map_for_repo(
+        primary_sink=sink, org_id="acme", repo_id=repo_id
+    )
 
     assert result == {"app/core.py": 0.9, "app/util.py": 0.5}
-    # Scoped to the repo with a per-line argMax dedup before the share.
+    # Scoped to BOTH repo and org with a per-line argMax dedup before the share.
     query, params = sink.queries[0]
     assert params["repo_id"] == str(repo_id)
+    assert params["org_id"] == "acme"
     assert "git_blame" in query
     assert "argMax" in query
+    assert "org_id = {org_id:String}" in query
 
 
 def test_load_blame_map_swallows_query_failure() -> None:
@@ -240,9 +293,54 @@ def test_load_blame_map_swallows_query_failure() -> None:
 
     # A missing/unmigrated git_blame table must not abort the daily job.
     result = job_daily._load_blame_map_for_repo(
-        primary_sink=_Boom(), repo_id=uuid.uuid4()
+        primary_sink=_Boom(), org_id="acme", repo_id=uuid.uuid4()
     )
     assert result == {}
+
+
+def test_load_blame_map_is_org_scoped_no_cross_tenant_leak() -> None:
+    """Blame reads MUST filter by org_id so a reused repo_id under another
+    tenant (or the 'default' partition) cannot contaminate this org's
+    Ownership-risk data (CHAOS-2376 round-2 / Codex no-ship).
+
+    The sink here returns ONLY the rows whose ``org_id`` param matches, proving
+    the loader passes a discriminating org filter and that a stale row written
+    under a different org is never surfaced for ``org_id='tenant-a'``.
+    """
+    repo_id = uuid.uuid4()
+
+    # Two org partitions for the SAME repo_id with different ownership shapes.
+    rows_by_org = {
+        "tenant-a": [{"path": "shared.py", "concentration": 0.2}],
+        "tenant-b": [{"path": "shared.py", "concentration": 0.95}],
+    }
+
+    class _OrgScopedSink:
+        def __init__(self) -> None:
+            self.queries: list[tuple[str, dict[str, Any]]] = []
+
+        def query_dicts(
+            self, query: str, parameters: dict[str, Any]
+        ) -> list[dict[str, Any]]:
+            self.queries.append((query, parameters))
+            # Emulate ClickHouse honouring the WHERE org_id filter.
+            assert "org_id = {org_id:String}" in query
+            return rows_by_org.get(parameters.get("org_id", ""), [])
+
+    sink = _OrgScopedSink()
+
+    result_a = job_daily._load_blame_map_for_repo(
+        primary_sink=sink, org_id="tenant-a", repo_id=repo_id
+    )
+    result_b = job_daily._load_blame_map_for_repo(
+        primary_sink=sink, org_id="tenant-b", repo_id=repo_id
+    )
+
+    # Each tenant sees only its own ownership concentration, never the other's.
+    assert result_a == {"shared.py": 0.2}
+    assert result_b == {"shared.py": 0.95}
+    assert sink.queries[0][1]["org_id"] == "tenant-a"
+    assert sink.queries[1][1]["org_id"] == "tenant-b"
 
 
 def test_blame_concentration_flows_into_hotspot_rows() -> None:
@@ -250,6 +348,7 @@ def test_blame_concentration_flows_into_hotspot_rows() -> None:
     repo_id = uuid.uuid4()
     blame_map = job_daily._load_blame_map_for_repo(
         primary_sink=_BlameSink([{"path": "hot.py", "concentration": 0.85}]),
+        org_id="acme",
         repo_id=repo_id,
     )
 
@@ -356,6 +455,61 @@ def test_backfill_default_include_blame_is_true() -> None:
         include_blame_default = default_by_arg["include_blame"]
         assert isinstance(include_blame_default, ast.Constant)
         assert include_blame_default.value is True
+
+
+# ---------------------------------------------------------------------------
+# (b2) onboarding blame gate is org-scoped (Codex no-ship: stale-org gate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_has_any_git_blame_is_org_scoped() -> None:
+    """``has_any_git_blame`` must scope by ``self.org_id``.
+
+    ``git_blame`` is org-partitioned (migration 027) and ``repo_id`` can be
+    reused across tenants. A repo-only existence check would let a stale/default
+    org's blame row suppress the fresh blame fetch for a newly-onboarded org,
+    leaving its Ownership-risk tab empty (CHAOS-2376 round-2 / Codex no-ship).
+    This proves the gate threads org_id into the WHERE clause and that, when a
+    row exists only under a different org, the gate reports "no blame" so the
+    backfill proceeds.
+    """
+    from dev_health_ops.storage.clickhouse import ClickHouseStore
+
+    repo_id = uuid.uuid4()
+
+    # Backing store: a blame row exists ONLY under tenant-b.
+    existing = {("tenant-b", str(repo_id))}
+
+    captured: list[dict[str, Any]] = []
+
+    def fake_query(query: str, parameters: dict[str, Any]) -> Any:
+        captured.append({"query": query, "params": parameters})
+        assert "org_id = {org_id:String}" in query
+        key = (parameters.get("org_id"), parameters.get("repo_id"))
+        result = Mock()
+        result.result_rows = [(1,)] if key in existing else []
+        return result
+
+    store = ClickHouseStore.__new__(ClickHouseStore)
+    store.client = Mock()
+    store.client.query = fake_query
+    import asyncio as _asyncio
+
+    store._lock = _asyncio.Lock()
+
+    # tenant-a has NO blame even though tenant-b does for the same repo_id ->
+    # the gate must report False so onboarding fetches fresh blame.
+    store.org_id = "tenant-a"
+    assert await store.has_any_git_blame(repo_id) is False
+
+    # tenant-b's own row is visible.
+    store.org_id = "tenant-b"
+    assert await store.has_any_git_blame(repo_id) is True
+
+    # Every query carried the discriminating org filter.
+    assert all("org_id = {org_id:String}" in c["query"] for c in captured)
+    assert {c["params"]["org_id"] for c in captured} == {"tenant-a", "tenant-b"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/metrics/test_job_daily_hotspots.py
+++ b/tests/metrics/test_job_daily_hotspots.py
@@ -1,13 +1,22 @@
 """CHAOS-2376: file_hotspot_daily live compute + git_blame default backfill.
 
-Two seams are proven here without a live ClickHouse / GitHub / GitLab:
+These seams are proven here without a live ClickHouse / GitHub / GitLab:
 
 (a) ``job_daily`` loads the latest complexity snapshot per file and feeds it
     into ``compute_file_risk_hotspots`` so ``file_hotspot_daily`` is written on
     the live daily path (not only by fixtures).
-(b) the default ``backfill_missing and sync_git`` onboarding backfills in the
+(b) ``job_daily`` loads per-file ownership concentration from ``git_blame`` and
+    threads it into ``blame_concentration`` so the Ownership-risk dimension is
+    non-NULL for real orgs (not only fixtures).
+(c) the default ``backfill_missing and sync_git`` onboarding backfills in the
     GitHub / GitLab processors pass ``include_blame=True`` so the Ownership-risk
-    tab is populated for normal OAuth orgs.
+    tab is populated for normal OAuth orgs, AND the per-sync blame crawl is
+    bounded (``BLAME_BACKFILL_MAX_FILES``) so a large repo cannot turn
+    onboarding into an unbounded GraphQL/REST crawl.
+
+The connectors package is imported first to avoid the pre-existing
+providers._base <-> connectors circular import when this file is collected in
+isolation.
 """
 
 from __future__ import annotations
@@ -18,7 +27,11 @@ import uuid
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock, Mock
 
+import pytest
+
+import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.metrics import job_daily
 from dev_health_ops.metrics.hotspots import compute_file_risk_hotspots
 from dev_health_ops.metrics.schemas import CommitStatRow, FileComplexitySnapshot
@@ -180,7 +193,97 @@ def test_risk_hotspot_seam_merges_complexity_and_churn() -> None:
 
 
 # ---------------------------------------------------------------------------
-# (b) default onboarding backfills pass include_blame=True
+# (b) blame-map loader -> blame_concentration is non-NULL on the live path
+# ---------------------------------------------------------------------------
+
+
+class _BlameSink:
+    """Minimal sink returning canned per-file concentration rows."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+        self.queries: list[tuple[str, dict[str, Any]]] = []
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        self.queries.append((query, parameters))
+        return self._rows
+
+
+def test_load_blame_map_for_repo_maps_concentration() -> None:
+    repo_id = uuid.uuid4()
+    sink = _BlameSink(
+        [
+            {"path": "app/core.py", "concentration": 0.9},
+            {"path": "app/util.py", "concentration": 0.5},
+            # Defensive: blank path and NULL concentration are dropped.
+            {"path": "", "concentration": 1.0},
+            {"path": "app/empty.py", "concentration": None},
+        ]
+    )
+
+    result = job_daily._load_blame_map_for_repo(primary_sink=sink, repo_id=repo_id)
+
+    assert result == {"app/core.py": 0.9, "app/util.py": 0.5}
+    # Scoped to the repo with a per-line argMax dedup before the share.
+    query, params = sink.queries[0]
+    assert params["repo_id"] == str(repo_id)
+    assert "git_blame" in query
+    assert "argMax" in query
+
+
+def test_load_blame_map_swallows_query_failure() -> None:
+    class _Boom:
+        def query_dicts(self, *_: Any, **__: Any) -> list[dict[str, Any]]:
+            raise RuntimeError("table missing")
+
+    # A missing/unmigrated git_blame table must not abort the daily job.
+    result = job_daily._load_blame_map_for_repo(
+        primary_sink=_Boom(), repo_id=uuid.uuid4()
+    )
+    assert result == {}
+
+
+def test_blame_concentration_flows_into_hotspot_rows() -> None:
+    """The loaded blame map populates blame_concentration (non-NULL live)."""
+    repo_id = uuid.uuid4()
+    blame_map = job_daily._load_blame_map_for_repo(
+        primary_sink=_BlameSink([{"path": "hot.py", "concentration": 0.85}]),
+        repo_id=repo_id,
+    )
+
+    window_stats: list[CommitStatRow] = [
+        {
+            "repo_id": repo_id,
+            "commit_hash": "c1",
+            "file_path": "hot.py",
+            "additions": 50,
+            "deletions": 10,
+            "author_email": "a@ex.com",
+            "author_name": "A",
+            "committer_when": NOW,
+            "old_file_mode": "100644",
+            "new_file_mode": "100644",
+        },
+    ]
+
+    rows = compute_file_risk_hotspots(
+        repo_id=repo_id,
+        day=DAY,
+        window_stats=window_stats,
+        complexity_map={},
+        blame_map=blame_map,
+        computed_at=NOW,
+    )
+
+    by_path = {r.file_path: r for r in rows}
+    # Without the blame_map wiring this would be None (the bug the fix closes).
+    assert by_path["hot.py"].blame_concentration == 0.85
+
+
+# ---------------------------------------------------------------------------
+# (c) default onboarding backfills pass include_blame=True
 # ---------------------------------------------------------------------------
 
 
@@ -253,3 +356,164 @@ def test_backfill_default_include_blame_is_true() -> None:
         include_blame_default = default_by_arg["include_blame"]
         assert isinstance(include_blame_default, ast.Constant)
         assert include_blame_default.value is True
+
+
+# ---------------------------------------------------------------------------
+# (c) the per-sync blame crawl is BOUNDED (Codex no-ship: unbounded blame)
+# ---------------------------------------------------------------------------
+
+
+class _FakeTreeEntry:
+    def __init__(self, path: str, size: int = 100, type_: str = "blob") -> None:
+        self.path = path
+        self.size = size
+        self.type = type_
+
+
+@pytest.mark.asyncio
+async def test_github_blame_backfill_is_capped() -> None:
+    """Onboarding blame must stop at BLAME_BACKFILL_MAX_FILES files.
+
+    Drives the real ``_backfill_github_missing_data`` blame branch with a tree
+    larger than the cap and asserts ``get_file_blame`` is called at most
+    ``BLAME_BACKFILL_MAX_FILES`` times -- proving a large repo cannot turn
+    onboarding into an unbounded GraphQL crawl (CHAOS-2376 / Codex no-ship).
+    """
+    from dev_health_ops.connectors.models import BlameRange, FileBlame
+    from dev_health_ops.processors.github import (
+        BLAME_BACKFILL_MAX_FILES,
+        _backfill_github_missing_data,
+    )
+
+    n_files = BLAME_BACKFILL_MAX_FILES + 17
+
+    store = Mock()
+    store.has_any_git_files = AsyncMock(return_value=True)
+    store.has_any_git_file_contents = AsyncMock(return_value=True)
+    store.has_any_git_commit_stats = AsyncMock(return_value=True)
+    store.has_any_git_blame = AsyncMock(return_value=False)
+
+    inserted: list[Any] = []
+
+    async def insert_blame(batch: list[Any]) -> None:
+        inserted.extend(batch)
+
+    sink = Mock()
+    sink.insert_blame_data = AsyncMock(side_effect=insert_blame)
+
+    gh_repo = Mock()
+    gh_repo.get_branch.return_value = Mock(commit=Mock(sha="abc"))
+    gh_repo.get_git_tree.return_value = Mock(
+        tree=[_FakeTreeEntry(f"src/f{i}.py") for i in range(n_files)]
+    )
+
+    blame_calls: list[str] = []
+
+    def fake_blame(*, owner: str, repo: str, path: str, ref: str) -> FileBlame:
+        blame_calls.append(path)
+        return FileBlame(
+            file_path=path,
+            ranges=[
+                BlameRange(
+                    starting_line=1,
+                    ending_line=1,
+                    commit_sha="sha",
+                    author="A",
+                    author_email="a@ex.com",
+                    age_seconds=0,
+                )
+            ],
+        )
+
+    connector = Mock()
+    connector.github.get_repo.return_value = gh_repo
+    connector.get_file_blame = Mock(side_effect=fake_blame)
+
+    db_repo = Mock()
+    db_repo.id = uuid.uuid4()
+
+    await _backfill_github_missing_data(
+        store=store,
+        ingestion_sink=sink,
+        connector=connector,
+        db_repo=db_repo,
+        repo_full_name="octo/repo",
+        default_branch="main",
+        max_commits=None,
+        include_blame=True,
+        include_commit_stats=False,
+    )
+
+    assert len(blame_calls) == BLAME_BACKFILL_MAX_FILES
+    # Only the capped subset is persisted (no blame for files past the cap).
+    assert {row.path for row in inserted} == set(blame_calls)
+    assert len(blame_calls) < n_files
+
+
+@pytest.mark.asyncio
+async def test_gitlab_blame_backfill_is_capped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Onboarding blame must stop at BLAME_BACKFILL_MAX_FILES files (GitLab)."""
+    import dev_health_ops.processors.gitlab as gitlab_mod
+    from dev_health_ops.processors.gitlab import (
+        BLAME_BACKFILL_MAX_FILES,
+        _backfill_gitlab_missing_data,
+    )
+
+    n_files = BLAME_BACKFILL_MAX_FILES + 9
+
+    store = Mock()
+    store.has_any_git_files = AsyncMock(return_value=True)
+    store.has_any_git_file_contents = AsyncMock(return_value=True)
+    store.has_any_git_commit_stats = AsyncMock(return_value=True)
+    store.has_any_git_blame = AsyncMock(return_value=False)
+
+    inserted: list[Any] = []
+
+    async def insert_blame(batch: list[Any]) -> None:
+        inserted.extend(batch)
+
+    sink = Mock()
+    sink.insert_blame_data = AsyncMock(side_effect=insert_blame)
+
+    project = Mock()
+    project.id = 123
+
+    connector = Mock()
+    connector.gitlab.projects.get.return_value = project
+
+    # _iter_gitlab_repo_tree yields the (oversized) tree of blobs.
+    tree_items = [{"type": "blob", "path": f"src/f{i}.py"} for i in range(n_files)]
+
+    blame_calls: list[str] = []
+
+    def fake_rest_blame(project_id: int, path: str, ref: str) -> list[dict[str, Any]]:
+        blame_calls.append(path)
+        return [{"commit": {"author_email": "a@ex.com"}, "lines": ["x = 1"]}]
+
+    connector.rest_client.get_file_blame = Mock(side_effect=fake_rest_blame)
+
+    db_repo = Mock()
+    db_repo.id = uuid.uuid4()
+    db_repo.settings = {"default_branch": "main"}
+
+    # Patch the module-level tree iterator to return the oversized blob list.
+    monkeypatch.setattr(
+        gitlab_mod, "_iter_gitlab_repo_tree", lambda *a, **k: tree_items
+    )
+    await _backfill_gitlab_missing_data(
+        store=store,
+        ingestion_sink=sink,
+        connector=connector,
+        db_repo=db_repo,
+        project_full_name="grp/proj",
+        default_branch="main",
+        max_commits=None,
+        include_blame=True,
+        include_commit_stats=False,
+    )
+
+    assert len(blame_calls) == BLAME_BACKFILL_MAX_FILES
+    assert {row.path for row in inserted} == set(blame_calls)
+    assert len(blame_calls) < n_files

--- a/tests/metrics/test_job_daily_hotspots.py
+++ b/tests/metrics/test_job_daily_hotspots.py
@@ -512,6 +512,74 @@ async def test_has_any_git_blame_is_org_scoped() -> None:
     assert {c["params"]["org_id"] for c in captured} == {"tenant-a", "tenant-b"}
 
 
+@pytest.mark.asyncio
+async def test_get_blamed_paths_is_org_scoped() -> None:
+    """``get_blamed_paths`` must scope by ``self.org_id`` (CHAOS-2376 round-3).
+
+    The coverage-aware backfill diffs the live tree against already-blamed
+    paths; a cross-tenant leak here would either falsely mark paths covered
+    (silent loss for the new org) or reblame paths the org already has.
+    """
+    from dev_health_ops.storage.clickhouse import ClickHouseStore
+
+    repo_id = uuid.uuid4()
+    captured: list[dict[str, Any]] = []
+
+    def fake_query(query: str, parameters: dict[str, Any]) -> Any:
+        captured.append({"query": query, "params": parameters})
+        assert "org_id = {org_id:String}" in query
+        result = Mock()
+        if parameters.get("org_id") == "tenant-a":
+            result.result_rows = [("src/a.py",), ("src/b.py",)]
+        else:
+            result.result_rows = [("other/c.py",)]
+        return result
+
+    import asyncio as _asyncio
+
+    store = ClickHouseStore.__new__(ClickHouseStore)
+    store.client = Mock()
+    store.client.query = fake_query
+    store._lock = _asyncio.Lock()
+
+    store.org_id = "tenant-a"
+    assert await store.get_blamed_paths(repo_id) == {"src/a.py", "src/b.py"}
+    store.org_id = "tenant-b"
+    assert await store.get_blamed_paths(repo_id) == {"other/c.py"}
+    assert all("org_id = {org_id:String}" in c["query"] for c in captured)
+
+
+@pytest.mark.asyncio
+async def test_has_unblamed_files_is_org_scoped() -> None:
+    """``has_unblamed_files`` filters both git_files and git_blame by org_id."""
+    from dev_health_ops.storage.clickhouse import ClickHouseStore
+
+    repo_id = uuid.uuid4()
+    captured: list[str] = []
+
+    def fake_query(query: str, parameters: dict[str, Any]) -> Any:
+        captured.append(query)
+        # Both the outer git_files scan and the inner git_blame subquery must
+        # carry the org filter so a stale-tenant blame row cannot mask an
+        # unblamed file for the current org.
+        assert query.count("org_id = {org_id:String}") == 2
+        assert parameters.get("org_id") == "tenant-a"
+        result = Mock()
+        result.result_rows = [(1,)]
+        return result
+
+    import asyncio as _asyncio
+
+    store = ClickHouseStore.__new__(ClickHouseStore)
+    store.client = Mock()
+    store.client.query = fake_query
+    store._lock = _asyncio.Lock()
+    store.org_id = "tenant-a"
+
+    assert await store.has_unblamed_files(repo_id) is True
+    assert captured and "git_files" in captured[0] and "git_blame" in captured[0]
+
+
 # ---------------------------------------------------------------------------
 # (c) the per-sync blame crawl is BOUNDED (Codex no-ship: unbounded blame)
 # ---------------------------------------------------------------------------
@@ -546,6 +614,10 @@ async def test_github_blame_backfill_is_capped() -> None:
     store.has_any_git_file_contents = AsyncMock(return_value=True)
     store.has_any_git_commit_stats = AsyncMock(return_value=True)
     store.has_any_git_blame = AsyncMock(return_value=False)
+    # No blame yet: every tree path is unblamed, so the real coverage-aware
+    # path selects the first capped batch (not the exception fallback).
+    store.get_blamed_paths = AsyncMock(return_value=set())
+    store.has_unblamed_files = AsyncMock(return_value=True)
 
     inserted: list[Any] = []
 
@@ -622,6 +694,10 @@ async def test_gitlab_blame_backfill_is_capped(
     store.has_any_git_file_contents = AsyncMock(return_value=True)
     store.has_any_git_commit_stats = AsyncMock(return_value=True)
     store.has_any_git_blame = AsyncMock(return_value=False)
+    # No blame yet: every tree path is unblamed, so the real coverage-aware
+    # path selects the first capped batch (not the exception fallback).
+    store.get_blamed_paths = AsyncMock(return_value=set())
+    store.has_unblamed_files = AsyncMock(return_value=True)
 
     inserted: list[Any] = []
 
@@ -671,3 +747,392 @@ async def test_gitlab_blame_backfill_is_capped(
     assert len(blame_calls) == BLAME_BACKFILL_MAX_FILES
     assert {row.path for row in inserted} == set(blame_calls)
     assert len(blame_calls) < n_files
+
+
+# ---------------------------------------------------------------------------
+# (d) the capped blame crawl is RESUMABLE across reruns (Codex round-3 no-ship)
+#
+# The cap is paired with a coverage-aware gate: a second sync must blame the
+# files the first sync left unblamed instead of returning early once any blame
+# row exists. Without this, every file past BLAME_BACKFILL_MAX_FILES would stay
+# without blame_concentration forever, silently truncating Ownership-risk.
+# ---------------------------------------------------------------------------
+
+
+class _StatefulBlameStore:
+    """In-memory store that accumulates blamed paths across syncs.
+
+    Models the real coverage-aware contract: ``get_blamed_paths`` returns the
+    paths persisted so far and ``has_unblamed_files`` reports whether any
+    tracked file still lacks blame, so the backfill keeps making progress.
+    """
+
+    def __init__(self, all_paths: set[str]) -> None:
+        self._all_paths = set(all_paths)
+        self.blamed: set[str] = set()
+
+    async def has_any_git_files(self, repo_id: Any) -> bool:
+        return True
+
+    async def has_any_git_file_contents(self, repo_id: Any) -> bool:
+        return True
+
+    async def has_any_git_commit_stats(self, repo_id: Any) -> bool:
+        return True
+
+    async def has_any_git_blame(self, repo_id: Any) -> bool:
+        return bool(self.blamed)
+
+    async def get_blamed_paths(self, repo_id: Any) -> set[str]:
+        return set(self.blamed)
+
+    async def has_unblamed_files(self, repo_id: Any) -> bool:
+        return bool(self._all_paths - self.blamed)
+
+    def record(self, paths: list[str]) -> None:
+        self.blamed.update(paths)
+
+
+def test_select_unblamed_paths_advances_each_call() -> None:
+    """select_unblamed_paths returns the next batch, never the same prefix."""
+    import asyncio
+
+    from dev_health_ops.processors.base_git import select_unblamed_paths
+
+    paths = [f"src/f{i}.py" for i in range(7)]
+
+    class _Store:
+        def __init__(self) -> None:
+            self.blamed: set[str] = set()
+
+        async def get_blamed_paths(self, repo_id: Any) -> set[str]:
+            return set(self.blamed)
+
+    store = _Store()
+
+    async def run() -> tuple[list[str], list[str], list[str]]:
+        batch1 = await select_unblamed_paths(store, "r", paths, 3)
+        store.blamed.update(batch1)
+        batch2 = await select_unblamed_paths(store, "r", paths, 3)
+        store.blamed.update(batch2)
+        batch3 = await select_unblamed_paths(store, "r", paths, 3)
+        store.blamed.update(batch3)
+        return batch1, batch2, batch3
+
+    batch1, batch2, batch3 = asyncio.run(run())
+    assert batch1 == paths[0:3]
+    assert batch2 == paths[3:6]
+    assert batch3 == paths[6:7]
+    # Every path eventually covered, with no overlap (no wasted re-blame).
+    assert batch1 + batch2 + batch3 == paths
+
+
+def test_select_unblamed_paths_empty_when_fully_covered() -> None:
+    import asyncio
+
+    from dev_health_ops.processors.base_git import select_unblamed_paths
+
+    paths = ["a.py", "b.py"]
+
+    class _Store:
+        async def get_blamed_paths(self, repo_id: Any) -> set[str]:
+            return set(paths)
+
+    result = asyncio.run(select_unblamed_paths(_Store(), "r", paths, 10))
+    assert result == []
+
+
+def test_blame_backfill_needed_coverage_aware() -> None:
+    """blame_backfill_needed stays True while coverage is partial."""
+    import asyncio
+
+    from dev_health_ops.processors.base_git import blame_backfill_needed
+
+    class _Store:
+        def __init__(self, unblamed: bool) -> None:
+            self._unblamed = unblamed
+
+        async def has_unblamed_files(self, repo_id: Any) -> bool:
+            return self._unblamed
+
+    async def run() -> None:
+        # include_blame off -> never blame.
+        assert (
+            await blame_backfill_needed(
+                _Store(True), "r", include_blame=False, any_row_needs_blame=True
+            )
+            is False
+        )
+        # First sync (no blame yet): any-row gate drives the crawl.
+        assert (
+            await blame_backfill_needed(
+                _Store(False), "r", include_blame=True, any_row_needs_blame=True
+            )
+            is True
+        )
+        # Blame exists but coverage partial -> keep crawling.
+        assert (
+            await blame_backfill_needed(
+                _Store(True), "r", include_blame=True, any_row_needs_blame=False
+            )
+            is True
+        )
+        # Blame exists and fully covered -> stop.
+        assert (
+            await blame_backfill_needed(
+                _Store(False), "r", include_blame=True, any_row_needs_blame=False
+            )
+            is False
+        )
+
+    asyncio.run(run())
+
+
+def test_blame_backfill_needed_probe_failure_defers_not_aborts() -> None:
+    """A coverage-probe failure defers blame to next sync (no hard abort).
+
+    The wider backfill (files / commit stats) must not be killed by a transient
+    coverage probe error; we simply skip blame this run and retry next sync.
+    """
+    import asyncio
+
+    from dev_health_ops.processors.base_git import blame_backfill_needed
+
+    class _Boom:
+        async def has_unblamed_files(self, repo_id: Any) -> bool:
+            raise RuntimeError("clickhouse transient")
+
+    result = asyncio.run(
+        blame_backfill_needed(
+            _Boom(), "r", include_blame=True, any_row_needs_blame=False
+        )
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_github_blame_backfill_resumes_on_second_sync() -> None:
+    """A second GitHub sync blames the files the first sync left uncovered.
+
+    Proves the cap is not a permanent dead-end: across two runs every file in
+    a repo larger than BLAME_BACKFILL_MAX_FILES gets blamed (CHAOS-2376
+    round-3 / Codex no-ship).
+    """
+    from dev_health_ops.connectors.models import BlameRange, FileBlame
+    from dev_health_ops.processors.github import (
+        BLAME_BACKFILL_MAX_FILES,
+        _backfill_github_missing_data,
+    )
+
+    n_files = BLAME_BACKFILL_MAX_FILES + 23
+    all_paths = {f"src/f{i}.py" for i in range(n_files)}
+    store = _StatefulBlameStore(all_paths)
+
+    def insert_factory() -> tuple[Any, list[Any]]:
+        captured: list[Any] = []
+
+        async def insert_blame(batch: list[Any]) -> None:
+            captured.extend(batch)
+
+        sink = Mock()
+        sink.insert_blame_data = AsyncMock(side_effect=insert_blame)
+        return sink, captured
+
+    gh_repo = Mock()
+    gh_repo.get_branch.return_value = Mock(commit=Mock(sha="abc"))
+    gh_repo.get_git_tree.return_value = Mock(
+        tree=[_FakeTreeEntry(f"src/f{i}.py") for i in range(n_files)]
+    )
+
+    def fake_blame(*, owner: str, repo: str, path: str, ref: str) -> FileBlame:
+        return FileBlame(
+            file_path=path,
+            ranges=[
+                BlameRange(
+                    starting_line=1,
+                    ending_line=1,
+                    commit_sha="sha",
+                    author="A",
+                    author_email="a@ex.com",
+                    age_seconds=0,
+                )
+            ],
+        )
+
+    connector = Mock()
+    connector.github.get_repo.return_value = gh_repo
+    connector.get_file_blame = Mock(side_effect=fake_blame)
+
+    db_repo = Mock()
+    db_repo.id = uuid.uuid4()
+
+    async def sync() -> set[str]:
+        sink, captured = insert_factory()
+        await _backfill_github_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            repo_full_name="octo/repo",
+            default_branch="main",
+            max_commits=None,
+            include_blame=True,
+            include_commit_stats=False,
+        )
+        blamed_now = {row.path for row in captured}
+        store.record(list(blamed_now))
+        return blamed_now
+
+    first = await sync()
+    assert len(first) == BLAME_BACKFILL_MAX_FILES
+
+    second = await sync()
+    # The second sync processes ONLY the files the first one skipped.
+    assert second == all_paths - first
+    assert second.isdisjoint(first)
+
+    # Across the two runs, every file in the repo is now blamed (no silent
+    # truncation past the cap).
+    assert store.blamed == all_paths
+
+    # A third sync finds nothing left and does no blame work.
+    third = await sync()
+    assert third == set()
+
+
+@pytest.mark.asyncio
+async def test_gitlab_blame_backfill_resumes_on_second_sync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second GitLab sync blames the files the first sync left uncovered."""
+    import dev_health_ops.processors.gitlab as gitlab_mod
+    from dev_health_ops.processors.gitlab import (
+        BLAME_BACKFILL_MAX_FILES,
+        _backfill_gitlab_missing_data,
+    )
+
+    n_files = BLAME_BACKFILL_MAX_FILES + 11
+    all_paths = {f"src/f{i}.py" for i in range(n_files)}
+    store = _StatefulBlameStore(all_paths)
+
+    tree_items = [{"type": "blob", "path": f"src/f{i}.py"} for i in range(n_files)]
+    monkeypatch.setattr(
+        gitlab_mod, "_iter_gitlab_repo_tree", lambda *a, **k: tree_items
+    )
+
+    project = Mock()
+    project.id = 123
+    connector = Mock()
+    connector.gitlab.projects.get.return_value = project
+
+    def fake_rest_blame(project_id: int, path: str, ref: str) -> list[dict[str, Any]]:
+        return [{"commit": {"author_email": "a@ex.com"}, "lines": ["x = 1"]}]
+
+    connector.rest_client.get_file_blame = Mock(side_effect=fake_rest_blame)
+
+    db_repo = Mock()
+    db_repo.id = uuid.uuid4()
+    db_repo.settings = {"default_branch": "main"}
+
+    async def sync() -> set[str]:
+        captured: list[Any] = []
+
+        async def insert_blame(batch: list[Any]) -> None:
+            captured.extend(batch)
+
+        sink = Mock()
+        sink.insert_blame_data = AsyncMock(side_effect=insert_blame)
+        await _backfill_gitlab_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            project_full_name="grp/proj",
+            default_branch="main",
+            max_commits=None,
+            include_blame=True,
+            include_commit_stats=False,
+        )
+        blamed_now = {row.path for row in captured}
+        store.record(list(blamed_now))
+        return blamed_now
+
+    first = await sync()
+    assert len(first) == BLAME_BACKFILL_MAX_FILES
+
+    second = await sync()
+    assert second == all_paths - first
+    assert second.isdisjoint(first)
+    assert store.blamed == all_paths
+
+    third = await sync()
+    assert third == set()
+
+
+@pytest.mark.asyncio
+async def test_github_blame_gate_alive_when_files_present_blame_partial() -> None:
+    """needs.blame=False but has_unblamed_files=True still triggers the crawl.
+
+    Models a rerun where the any-row gate would say "blame exists, skip" but
+    coverage is partial; the coverage gate must keep the blame branch alive.
+    """
+    from dev_health_ops.connectors.models import BlameRange, FileBlame
+    from dev_health_ops.processors.github import _backfill_github_missing_data
+
+    all_paths = {"src/a.py", "src/b.py", "src/c.py"}
+    store = _StatefulBlameStore(all_paths)
+    # Simulate a prior partial sync: one file already blamed.
+    store.blamed = {"src/a.py"}
+
+    captured: list[Any] = []
+
+    async def insert_blame(batch: list[Any]) -> None:
+        captured.extend(batch)
+
+    sink = Mock()
+    sink.insert_blame_data = AsyncMock(side_effect=insert_blame)
+
+    gh_repo = Mock()
+    gh_repo.get_branch.return_value = Mock(commit=Mock(sha="abc"))
+    gh_repo.get_git_tree.return_value = Mock(
+        tree=[_FakeTreeEntry(p) for p in sorted(all_paths)]
+    )
+
+    def fake_blame(*, owner: str, repo: str, path: str, ref: str) -> FileBlame:
+        return FileBlame(
+            file_path=path,
+            ranges=[
+                BlameRange(
+                    starting_line=1,
+                    ending_line=1,
+                    commit_sha="sha",
+                    author="A",
+                    author_email="a@ex.com",
+                    age_seconds=0,
+                )
+            ],
+        )
+
+    connector = Mock()
+    connector.github.get_repo.return_value = gh_repo
+    connector.get_file_blame = Mock(side_effect=fake_blame)
+
+    db_repo = Mock()
+    db_repo.id = uuid.uuid4()
+
+    await _backfill_github_missing_data(
+        store=store,
+        ingestion_sink=sink,
+        connector=connector,
+        db_repo=db_repo,
+        repo_full_name="octo/repo",
+        default_branch="main",
+        max_commits=None,
+        include_blame=True,
+        include_commit_stats=False,
+    )
+
+    # Only the two previously-unblamed files are processed; the already-blamed
+    # file is not re-fetched.
+    blamed_now = {row.path for row in captured}
+    assert blamed_now == {"src/b.py", "src/c.py"}

--- a/tests/metrics/test_job_daily_hotspots.py
+++ b/tests/metrics/test_job_daily_hotspots.py
@@ -1,0 +1,255 @@
+"""CHAOS-2376: file_hotspot_daily live compute + git_blame default backfill.
+
+Two seams are proven here without a live ClickHouse / GitHub / GitLab:
+
+(a) ``job_daily`` loads the latest complexity snapshot per file and feeds it
+    into ``compute_file_risk_hotspots`` so ``file_hotspot_daily`` is written on
+    the live daily path (not only by fixtures).
+(b) the default ``backfill_missing and sync_git`` onboarding backfills in the
+    GitHub / GitLab processors pass ``include_blame=True`` so the Ownership-risk
+    tab is populated for normal OAuth orgs.
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+import uuid
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from dev_health_ops.metrics import job_daily
+from dev_health_ops.metrics.hotspots import compute_file_risk_hotspots
+from dev_health_ops.metrics.schemas import CommitStatRow, FileComplexitySnapshot
+
+DAY = date(2026, 5, 20)
+NOW = datetime(2026, 5, 21, 12, 0, tzinfo=timezone.utc)
+
+PROCESSORS_DIR = Path(job_daily.__file__).resolve().parent.parent / "processors"
+
+
+# ---------------------------------------------------------------------------
+# (a) complexity-snapshot loader maps ClickHouse rows -> FileComplexitySnapshot
+# ---------------------------------------------------------------------------
+
+
+class _ComplexitySink:
+    """Minimal sink returning canned ``file_complexity_snapshots`` rows."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+        self.queries: list[tuple[str, dict[str, Any]]] = []
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        self.queries.append((query, parameters))
+        return self._rows
+
+
+def test_load_complexity_map_for_repo_maps_rows() -> None:
+    repo_id = uuid.uuid4()
+    sink = _ComplexitySink(
+        [
+            {
+                "file_path": "app/core.py",
+                "language": "python",
+                "loc": 120,
+                "functions_count": 4,
+                "cyclomatic_total": 31,
+                "cyclomatic_avg": 7.75,
+                "high_complexity_functions": 2,
+                "very_high_complexity_functions": 1,
+            },
+            # A blank path is dropped (defensive against malformed rows).
+            {"file_path": "", "cyclomatic_total": 99, "cyclomatic_avg": 9.0},
+        ]
+    )
+
+    result = job_daily._load_complexity_map_for_repo(
+        primary_sink=sink,
+        org_id="acme",
+        repo_id=repo_id,
+        day=DAY,
+    )
+
+    assert set(result) == {"app/core.py"}
+    snap = result["app/core.py"]
+    assert isinstance(snap, FileComplexitySnapshot)
+    assert snap.cyclomatic_total == 31
+    assert snap.cyclomatic_avg == 7.75
+    assert snap.org_id == "acme"
+    # Scoped to repo/day/org with a latest-compute argMax read.
+    query, params = sink.queries[0]
+    assert params["repo_id"] == str(repo_id)
+    assert params["day"] == DAY
+    assert params["org_id"] == "acme"
+    assert "argMax" in query
+    assert "file_complexity_snapshots" in query
+
+
+def test_load_complexity_map_swallows_query_failure() -> None:
+    class _Boom:
+        def query_dicts(self, *_: Any, **__: Any) -> list[dict[str, Any]]:
+            raise RuntimeError("table missing")
+
+    # A missing/unmigrated table must not abort the daily job.
+    result = job_daily._load_complexity_map_for_repo(
+        primary_sink=_Boom(),
+        org_id="acme",
+        repo_id=uuid.uuid4(),
+        day=DAY,
+    )
+    assert result == {}
+
+
+def test_risk_hotspot_seam_merges_complexity_and_churn() -> None:
+    """The loaded complexity map + churn window produce ranked hotspot rows."""
+    repo_id = uuid.uuid4()
+    complexity_map = job_daily._load_complexity_map_for_repo(
+        primary_sink=_ComplexitySink(
+            [
+                {
+                    "file_path": "hot.py",
+                    "language": "python",
+                    "loc": 300,
+                    "functions_count": 10,
+                    "cyclomatic_total": 80,
+                    "cyclomatic_avg": 8.0,
+                    "high_complexity_functions": 5,
+                    "very_high_complexity_functions": 2,
+                },
+                {
+                    "file_path": "calm.py",
+                    "language": "python",
+                    "loc": 40,
+                    "functions_count": 2,
+                    "cyclomatic_total": 3,
+                    "cyclomatic_avg": 1.5,
+                    "high_complexity_functions": 0,
+                    "very_high_complexity_functions": 0,
+                },
+            ]
+        ),
+        org_id="acme",
+        repo_id=repo_id,
+        day=DAY,
+    )
+
+    window_stats: list[CommitStatRow] = [
+        {
+            "repo_id": repo_id,
+            "commit_hash": "c1",
+            "file_path": "hot.py",
+            "additions": 200,
+            "deletions": 100,
+            "author_email": "a@ex.com",
+            "author_name": "A",
+            "committer_when": NOW,
+            "old_file_mode": "100644",
+            "new_file_mode": "100644",
+        },
+        {
+            "repo_id": repo_id,
+            "commit_hash": "c2",
+            "file_path": "calm.py",
+            "additions": 1,
+            "deletions": 0,
+            "author_email": "b@ex.com",
+            "author_name": "B",
+            "committer_when": NOW,
+            "old_file_mode": "100644",
+            "new_file_mode": "100644",
+        },
+    ]
+
+    rows = compute_file_risk_hotspots(
+        repo_id=repo_id,
+        day=DAY,
+        window_stats=window_stats,
+        complexity_map=complexity_map,
+        computed_at=NOW,
+    )
+
+    assert {r.file_path for r in rows} == {"hot.py", "calm.py"}
+    # High churn + high complexity ranks first.
+    assert rows[0].file_path == "hot.py"
+    assert rows[0].cyclomatic_total == 80
+    assert rows[0].risk_score > rows[1].risk_score
+
+
+# ---------------------------------------------------------------------------
+# (b) default onboarding backfills pass include_blame=True
+# ---------------------------------------------------------------------------
+
+
+def _backfill_include_blame_values(source_path: Path, func_name: str) -> list[bool]:
+    """Return the ``include_blame`` literal passed at each call to *func_name*.
+
+    Only inspects keyword args that are constant booleans; a call that omits
+    ``include_blame`` contributes ``True`` (the function default).
+    """
+    tree = ast.parse(source_path.read_text())
+    values: list[bool] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        target = node.func
+        if not (isinstance(target, ast.Name) and target.id == func_name):
+            continue
+        kw = next(
+            (k for k in node.keywords if k.arg == "include_blame"),
+            None,
+        )
+        if kw is None:
+            values.append(True)
+            continue
+        if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, bool):
+            values.append(kw.value.value)
+    return values
+
+
+def test_github_backfill_calls_request_blame() -> None:
+    values = _backfill_include_blame_values(
+        PROCESSORS_DIR / "github.py", "_backfill_github_missing_data"
+    )
+    assert values, "expected at least one _backfill_github_missing_data call"
+    assert all(values), (
+        "GitHub onboarding backfill must request blame so the Ownership-risk "
+        f"tab is populated (CHAOS-2376); saw include_blame values: {values}"
+    )
+
+
+def test_gitlab_backfill_calls_request_blame() -> None:
+    values = _backfill_include_blame_values(
+        PROCESSORS_DIR / "gitlab.py", "_backfill_gitlab_missing_data"
+    )
+    assert values, "expected at least one _backfill_gitlab_missing_data call"
+    assert all(values), (
+        "GitLab onboarding backfill must request blame so the Ownership-risk "
+        f"tab is populated (CHAOS-2376); saw include_blame values: {values}"
+    )
+
+
+def test_backfill_default_include_blame_is_true() -> None:
+    """The processor helper signatures default include_blame to True."""
+    for path, func in (
+        (PROCESSORS_DIR / "github.py", "_backfill_github_missing_data"),
+        (PROCESSORS_DIR / "gitlab.py", "_backfill_gitlab_missing_data"),
+    ):
+        tree = ast.parse(textwrap.dedent(path.read_text()))
+        fn = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == func
+        )
+        default_by_arg = dict(
+            zip(
+                [a.arg for a in fn.args.args][-len(fn.args.defaults) :],
+                fn.args.defaults,
+            )
+        )
+        include_blame_default = default_by_arg["include_blame"]
+        assert isinstance(include_blame_default, ast.Constant)
+        assert include_blame_default.value is True

--- a/tests/metrics/test_job_daily_hotspots.py
+++ b/tests/metrics/test_job_daily_hotspots.py
@@ -33,8 +33,12 @@ import pytest
 
 import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.metrics import job_daily
-from dev_health_ops.metrics.hotspots import compute_file_risk_hotspots
+from dev_health_ops.metrics.hotspots import (
+    compute_file_hotspots,
+    compute_file_risk_hotspots,
+)
 from dev_health_ops.metrics.schemas import CommitStatRow, FileComplexitySnapshot
+from dev_health_ops.utils import AGGREGATE_STATS_MARKER
 
 DAY = date(2026, 5, 20)
 NOW = datetime(2026, 5, 21, 12, 0, tzinfo=timezone.utc)
@@ -1136,3 +1140,166 @@ async def test_github_blame_gate_alive_when_files_present_blame_partial() -> Non
     # file is not re-fetched.
     blamed_now = {row.path for row in captured}
     assert blamed_now == {"src/b.py", "src/c.py"}
+
+
+# ---------------------------------------------------------------------------
+# (d) round-4: the risk-hotspot pass covers idle complexity-only repos
+#     (it must NOT be gated on same-day activity / active_repos)
+# ---------------------------------------------------------------------------
+
+
+def test_hotspot_repo_ids_includes_idle_complexity_only_repos() -> None:
+    """A discovered repo with no same-day activity is still in the hotspot set.
+
+    Regression for CHAOS-2376 round-4: gating the file_hotspot_daily pass on
+    active_repos (commits/pipelines/deployments that day) silently dropped
+    quiet-but-risky repos whose risk comes from static complexity.
+    """
+    active = uuid.uuid4()
+    idle_complexity_only = uuid.uuid4()
+
+    # active_repos is built only from same-day activity; the idle repo is only
+    # known via discovery.
+    repo_ids = job_daily._hotspot_repo_ids(
+        active_repos={active},
+        discovered_repo_ids=[active, idle_complexity_only],
+    )
+
+    assert active in repo_ids
+    assert idle_complexity_only in repo_ids
+
+
+def test_hotspot_repo_ids_unions_active_not_only_discovered() -> None:
+    """An active repo missing from discovery is still covered (no data loss)."""
+    active_only = uuid.uuid4()
+    discovered = uuid.uuid4()
+
+    repo_ids = job_daily._hotspot_repo_ids(
+        active_repos={active_only},
+        discovered_repo_ids=[discovered],
+    )
+
+    assert repo_ids == {active_only, discovered}
+
+
+def test_risk_hotspot_rows_for_complexity_only_repo_without_churn() -> None:
+    """A repo with complexity snapshots but ZERO churn still yields rows.
+
+    Proves the union semantics the idle-repo fix relies on: even with an empty
+    churn window, complexity-only files produce file_hotspot_daily rows.
+    """
+    repo_id = uuid.uuid4()
+    complexity_map = job_daily._load_complexity_map_for_repo(
+        primary_sink=_ComplexitySink(
+            [
+                {
+                    "file_path": "legacy/god_object.py",
+                    "language": "python",
+                    "loc": 1200,
+                    "functions_count": 40,
+                    "cyclomatic_total": 300,
+                    "cyclomatic_avg": 7.5,
+                    "high_complexity_functions": 12,
+                    "very_high_complexity_functions": 4,
+                },
+                {
+                    "file_path": "legacy/helper.py",
+                    "language": "python",
+                    "loc": 80,
+                    "functions_count": 3,
+                    "cyclomatic_total": 6,
+                    "cyclomatic_avg": 2.0,
+                    "high_complexity_functions": 0,
+                    "very_high_complexity_functions": 0,
+                },
+            ]
+        ),
+        org_id="acme",
+        repo_id=repo_id,
+        day=DAY,
+    )
+
+    # No commits at all in the window for this repo.
+    rows = compute_file_risk_hotspots(
+        repo_id=repo_id,
+        day=DAY,
+        window_stats=[],
+        complexity_map=complexity_map,
+        computed_at=NOW,
+    )
+
+    assert {r.file_path for r in rows} == {
+        "legacy/god_object.py",
+        "legacy/helper.py",
+    }
+    # Highest complexity ranks first; churn is zero for every file.
+    assert rows[0].file_path == "legacy/god_object.py"
+    assert all(r.churn_loc_30d == 0 for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# (e) round-4: aggregate-stats sentinel rows are never persisted as hotspots
+# ---------------------------------------------------------------------------
+
+
+def _stat_row(repo_id: uuid.UUID, path: str, *, adds: int, dels: int) -> CommitStatRow:
+    return {
+        "repo_id": repo_id,
+        "commit_hash": f"c-{path}",
+        "file_path": path,
+        "additions": adds,
+        "deletions": dels,
+        "author_email": "a@ex.com",
+        "author_name": "A",
+        "committer_when": NOW,
+        "old_file_mode": "100644",
+        "new_file_mode": "100644",
+    }
+
+
+def test_risk_hotspots_exclude_aggregate_sentinel() -> None:
+    """GitLab/GitHub backfill's __AGGREGATE__ marker is not ranked as a file.
+
+    Regression for CHAOS-2376 round-4: aggregate-only commit stats store
+    file_path == AGGREGATE_STATS_MARKER; converting that into a
+    file_hotspot_daily row exposes a synthetic __AGGREGATE__ "file" with churn
+    belonging to no real path, hiding real hotspots.
+    """
+    repo_id = uuid.uuid4()
+    window_stats: list[CommitStatRow] = [
+        _stat_row(repo_id, "real/module.py", adds=100, dels=50),
+        # Aggregate-only backfill row: must be ignored.
+        _stat_row(repo_id, AGGREGATE_STATS_MARKER, adds=9999, dels=9999),
+    ]
+
+    rows = compute_file_risk_hotspots(
+        repo_id=repo_id,
+        day=DAY,
+        window_stats=window_stats,
+        complexity_map={},
+        computed_at=NOW,
+    )
+
+    paths = {r.file_path for r in rows}
+    assert AGGREGATE_STATS_MARKER not in paths
+    assert paths == {"real/module.py"}
+
+
+def test_file_hotspots_exclude_aggregate_sentinel() -> None:
+    """compute_file_hotspots (file_metrics path) also ignores the sentinel."""
+    repo_id = uuid.uuid4()
+    window_stats: list[CommitStatRow] = [
+        _stat_row(repo_id, "real/module.py", adds=10, dels=5),
+        _stat_row(repo_id, AGGREGATE_STATS_MARKER, adds=9999, dels=9999),
+    ]
+
+    records = compute_file_hotspots(
+        repo_id=repo_id,
+        day=DAY,
+        window_stats=window_stats,
+        computed_at=NOW,
+    )
+
+    paths = {r.path for r in records}
+    assert AGGREGATE_STATS_MARKER not in paths
+    assert paths == {"real/module.py"}

--- a/tests/metrics/test_job_daily_hotspots.py
+++ b/tests/metrics/test_job_daily_hotspots.py
@@ -31,7 +31,12 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-import dev_health_ops.connectors  # noqa: F401
+# Imported for its registration side effects, and *before* dev_health_ops.metrics
+# (which transitively imports providers._base) to dodge the pre-existing
+# providers._base <-> connectors circular import when this file is collected in
+# isolation. The `_CONNECTORS_SIDE_EFFECT` reference below marks it as used so
+# ruff/CodeQL don't flag the side-effect-only import.
+import dev_health_ops.connectors
 from dev_health_ops.metrics import job_daily
 from dev_health_ops.metrics.hotspots import (
     compute_file_hotspots,
@@ -39,6 +44,10 @@ from dev_health_ops.metrics.hotspots import (
 )
 from dev_health_ops.metrics.schemas import CommitStatRow, FileComplexitySnapshot
 from dev_health_ops.utils import AGGREGATE_STATS_MARKER
+
+# Mark the side-effect-only connectors import (above) as used so ruff/CodeQL
+# don't flag it; it is imported purely to pre-empt the circular import.
+_CONNECTORS_SIDE_EFFECT = dev_health_ops.connectors
 
 DAY = date(2026, 5, 20)
 NOW = datetime(2026, 5, 21, 12, 0, tzinfo=timezone.utc)
@@ -686,12 +695,8 @@ async def test_gitlab_blame_backfill_is_capped(
 ) -> None:
     """Onboarding blame must stop at BLAME_BACKFILL_MAX_FILES files (GitLab)."""
     import dev_health_ops.processors.gitlab as gitlab_mod
-    from dev_health_ops.processors.gitlab import (
-        BLAME_BACKFILL_MAX_FILES,
-        _backfill_gitlab_missing_data,
-    )
 
-    n_files = BLAME_BACKFILL_MAX_FILES + 9
+    n_files = gitlab_mod.BLAME_BACKFILL_MAX_FILES + 9
 
     store = Mock()
     store.has_any_git_files = AsyncMock(return_value=True)
@@ -736,7 +741,7 @@ async def test_gitlab_blame_backfill_is_capped(
     monkeypatch.setattr(
         gitlab_mod, "_iter_gitlab_repo_tree", lambda *a, **k: tree_items
     )
-    await _backfill_gitlab_missing_data(
+    await gitlab_mod._backfill_gitlab_missing_data(
         store=store,
         ingestion_sink=sink,
         connector=connector,
@@ -748,7 +753,7 @@ async def test_gitlab_blame_backfill_is_capped(
         include_commit_stats=False,
     )
 
-    assert len(blame_calls) == BLAME_BACKFILL_MAX_FILES
+    assert len(blame_calls) == gitlab_mod.BLAME_BACKFILL_MAX_FILES
     assert {row.path for row in inserted} == set(blame_calls)
     assert len(blame_calls) < n_files
 
@@ -1010,12 +1015,8 @@ async def test_gitlab_blame_backfill_resumes_on_second_sync(
 ) -> None:
     """A second GitLab sync blames the files the first sync left uncovered."""
     import dev_health_ops.processors.gitlab as gitlab_mod
-    from dev_health_ops.processors.gitlab import (
-        BLAME_BACKFILL_MAX_FILES,
-        _backfill_gitlab_missing_data,
-    )
 
-    n_files = BLAME_BACKFILL_MAX_FILES + 11
+    n_files = gitlab_mod.BLAME_BACKFILL_MAX_FILES + 11
     all_paths = {f"src/f{i}.py" for i in range(n_files)}
     store = _StatefulBlameStore(all_paths)
 
@@ -1046,7 +1047,7 @@ async def test_gitlab_blame_backfill_resumes_on_second_sync(
 
         sink = Mock()
         sink.insert_blame_data = AsyncMock(side_effect=insert_blame)
-        await _backfill_gitlab_missing_data(
+        await gitlab_mod._backfill_gitlab_missing_data(
             store=store,
             ingestion_sink=sink,
             connector=connector,
@@ -1062,7 +1063,7 @@ async def test_gitlab_blame_backfill_resumes_on_second_sync(
         return blamed_now
 
     first = await sync()
-    assert len(first) == BLAME_BACKFILL_MAX_FILES
+    assert len(first) == gitlab_mod.BLAME_BACKFILL_MAX_FILES
 
     second = await sync()
     assert second == all_paths - first


### PR DESCRIPTION
Computes file_hotspot_daily on the live daily job (passing blame_map so blame_concentration populates) and enables git_blame backfill by default, so /complexity Hotspots + Ownership-risk render for real orgs. Blame fetch is bounded; the cap no longer marks a repo "complete" after a partial insert; aggregate commit-stat sentinels are excluded from hotspot rows.

Part of CHAOS-2372. Closes CHAOS-2376. Follow-up: CHAOS-2400 (pre-existing capacity test flake).

> Branch forked at 667dc5b5; origin/main has since advanced. Rebase onto origin/main before merge (3-way merge is safe; a 2-dot diff shows unrelated main commits as spurious deletions). Reviewed across 4 adversarial rounds (in-workflow reviewer + Codex /codex:adversarial-review); tenant-isolation, no-silent-loss and correctness all verified. Gates: ruff + full-package mypy + pytest green.
