### PR TITLE
feat(gitlab): ingest MR reviews into git_pull_request_reviews (CHAOS-2378)

### DIFF
--- a/src/dev_health_ops/connectors/utils/rest.py
+++ b/src/dev_health_ops/connectors/utils/rest.py
@@ -435,6 +435,69 @@ class GitLabRESTClient(RESTClient):
         )
         return mrs
 
+    def get_merge_request_approvals(
+        self,
+        project_id: int | str,
+        iid: int,
+    ) -> dict[str, Any]:
+        """Get the approval state for a single merge request.
+
+        GET /projects/{id}/merge_requests/{iid}/approvals returns a single
+        object whose ``approved_by`` list names the reviewers who approved
+        (CHAOS-2378). Raises APIException on 404 (MR lacks an approvals
+        endpoint on some tiers); callers handle best-effort.
+
+        :param project_id: GitLab project ID or path.
+        :param iid: Merge request internal ID (iid).
+        :return: Approval payload (``approved_by`` etc.).
+        """
+        endpoint = f"projects/{project_id}/merge_requests/{iid}/approvals"
+        logger.debug(
+            "Fetching approvals for project %s MR !%s",
+            project_id,
+            iid,
+        )
+        return self.get(endpoint)
+
+    def get_merge_request_notes(
+        self,
+        project_id: int | str,
+        iid: int,
+        page: int = 1,
+        per_page: int = 100,
+        sort: str = "asc",
+        order_by: str = "created_at",
+    ) -> list[dict[str, Any]]:
+        """Get notes (comments + system events) for a single merge request.
+
+        GET /projects/{id}/merge_requests/{iid}/notes returns reviewer
+        comments plus ``system`` notes such as "approved"/"unapproved this
+        merge request", which we map to review rows (CHAOS-2378).
+
+        :param project_id: GitLab project ID or path.
+        :param iid: Merge request internal ID (iid).
+        :param page: Page number.
+        :param per_page: Results per page.
+        :param sort: Sort direction ('asc' or 'desc').
+        :param order_by: Field to order by.
+        :return: List of note objects.
+        """
+        endpoint = f"projects/{project_id}/merge_requests/{iid}/notes"
+        params = {
+            "page": page,
+            "per_page": per_page,
+            "sort": sort,
+            "order_by": order_by,
+        }
+        logger.debug(
+            "Fetching notes for project %s MR !%s, page %s (per_page=%s)",
+            project_id,
+            iid,
+            page,
+            per_page,
+        )
+        return self.get_list(endpoint, params=params)
+
     def get_deployments(
         self,
         project_id: int,

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -252,6 +252,34 @@ _GITLAB_UNAPPROVE_NOTE = "unapproved this merge request"
 _GITLAB_DIFF_NOTE_TYPE = "DiffNote"
 
 
+class PartialGitLabMrSyncError(RuntimeError):
+    """Raised when one or more MR rows were skipped due to a degraded review
+    fetch (e.g. a transient MR-notes failure).
+
+    The MR sync must NOT report overall success when it has silently skipped MR
+    rows: a successful run advances the per-target sync watermark to the run's
+    start time, so on the next incremental run those MRs fall behind ``since``
+    (``updated_at < since``) and are never retried until a full resync — a
+    permanent, silent loss of PR facts and review metrics with no failed job to
+    alert operators (CHAOS-2378).
+
+    Raising a *retryable* (non-terminal) error instead keeps the run marked
+    FAILED so the watermark is held at its prior value and the Celery task
+    retries the whole project. Rows that were fetched successfully this cycle
+    are flushed before the raise; the re-run is idempotent (PR/review rows are
+    ReplacingMergeTree-replaced), so re-writing them is harmless.
+    """
+
+    def __init__(self, skipped_iids: list[int], project_id: int) -> None:
+        self.skipped_iids = skipped_iids
+        self.project_id = project_id
+        super().__init__(
+            f"GitLab MR sync for project {project_id} skipped "
+            f"{len(skipped_iids)} MR row(s) due to degraded review fetch "
+            f"(iids={skipped_iids[:20]}); not advancing watermark"
+        )
+
+
 def map_gitlab_mr_reviews(
     repo_id: Any,
     number: int,
@@ -267,7 +295,8 @@ def map_gitlab_mr_reviews(
     /ai/review-load) treat both providers identically (CHAOS-2378):
 
     * approval ("approved" system note / approvals.approved_by) -> APPROVED
-    * "unapproved" system note -> CHANGES_REQUESTED
+    * "unapproved" system note -> DISMISSED (revoking an approval is not an
+      explicit request for changes; it is excluded from changes_requested_count)
     * diff-line review comment by a non-author reviewer
       (``type == "DiffNote"``) -> COMMENTED
 
@@ -347,7 +376,15 @@ def map_gitlab_mr_reviews(
                 approved_reviewers.add(username)
                 _add(f"note-{note_id}", username, "APPROVED", created_at)
             elif body.startswith(_GITLAB_UNAPPROVE_NOTE):
-                _add(f"note-{note_id}", username, "CHANGES_REQUESTED", created_at)
+                # Revoking an approval is NOT an explicit "request changes" event.
+                # GitLab has no native request-changes action, so an unapproval
+                # is the dismissal of a prior approval, not rework pressure.
+                # Map it to GitHub's canonical DISMISSED state (shared review
+                # vocabulary) so it stays on the review timeline but is excluded
+                # from changes_requested_count / changes_requested_given — only a
+                # genuine CHANGES_REQUESTED must inflate rework/review-load
+                # signals (CHAOS-2378).
+                _add(f"note-{note_id}", username, "DISMISSED", created_at)
             # other system notes (label/assignee/etc.) are not reviews
             continue
 
@@ -540,6 +577,11 @@ def _sync_gitlab_mrs_to_store(
     )
     batch: list[GitPullRequest] = []
     review_batch: list[GitPullRequestReview] = []
+    # MRs skipped this cycle because their authoritative review source (MR notes)
+    # was degraded. If non-empty at the end, we MUST NOT report success (which
+    # would advance the watermark past these MRs and strand them); we flush the
+    # good rows then raise PartialGitLabMrSyncError so the run is retried.
+    skipped_iids: list[int] = []
     total = 0
     page = 1
 
@@ -631,11 +673,16 @@ def _sync_gitlab_mrs_to_store(
                 # so persisting it now with zeroed review metrics would clobber
                 # previously-correct first_review_at / reviews_count /
                 # changes_requested_count. Skip this MR's row this cycle so the
-                # prior values are preserved; the next sync re-attempts it.
+                # prior values are preserved, and record the iid so the run
+                # fails loud (no watermark advancement) and is retried — a
+                # silent skip would let the watermark move past this MR and
+                # strand it until a full resync (CHAOS-2378).
+                skipped_iid = int(mr.get("iid") or 0)
+                skipped_iids.append(skipped_iid)
                 logging.warning(
                     "Skipping PR row for MR !%d (project %d): review fetch "
-                    "degraded, preserving existing review metrics",
-                    int(mr.get("iid") or 0),
+                    "degraded; run will not advance watermark and will retry",
+                    skipped_iid,
                     project_id,
                 )
                 continue
@@ -694,6 +741,14 @@ def _sync_gitlab_mrs_to_store(
         total,
         project_id,
     )
+
+    if skipped_iids:
+        # Good rows are already flushed above; raising now (after the flush)
+        # preserves the work done this cycle while preventing the caller's
+        # success path from advancing the per-target watermark past the skipped
+        # MRs. The error is retryable (non-terminal), so the project re-syncs.
+        raise PartialGitLabMrSyncError(skipped_iids, project_id)
+
     return total
 
 
@@ -1898,6 +1953,19 @@ async def process_gitlab_projects_batch(
                         mr_gate,
                         since,
                     )
+            except PartialGitLabMrSyncError as e:
+                # Degraded review fetch skipped MR rows. The batch (group) path
+                # does NOT persist a per-project watermark, so the next group
+                # run re-fetches these MRs from the caller-supplied ``since``
+                # (no permanent stranding, unlike the scheduled single-project
+                # path which raises to hold its watermark). Log loudly so the
+                # skip is never silent (CHAOS-2378).
+                logging.warning(
+                    "Degraded MR review fetch for GitLab project %s: %s "
+                    "(group sync continues; MRs retried on next run)",
+                    project_info.full_name,
+                    e,
+                )
             except Exception as e:
                 logging.warning(
                     "Failed to fetch/store MRs for GitLab project %s: %s",

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -280,6 +280,37 @@ class PartialGitLabMrSyncError(RuntimeError):
         )
 
 
+class BatchGitLabMrSyncError(RuntimeError):
+    """Raised by the batch/group GitLab sync when one or more projects skipped
+    MR rows due to a degraded review fetch (each surfaced as a
+    :class:`PartialGitLabMrSyncError` during per-project processing).
+
+    The batch path processes many projects and must keep flushing the good rows
+    from healthy projects, so it cannot abort the whole run the moment one
+    project degrades. Instead it *accumulates* the per-project failures and
+    raises this aggregate error after the batch summary. Raising (rather than
+    returning normally) is what stops the caller — ``sync_gitlab_target`` — from
+    reporting success: a successful sync advances the per-target watermark, so a
+    silently-skipped MR would fall behind ``since`` on the next incremental run
+    and never be retried (a permanent, silent loss of PR facts and review
+    metrics with no failed job to alert operators — the exact failure mode the
+    per-project :class:`PartialGitLabMrSyncError` exists to prevent). Because the
+    error is retryable and PR/review rows are ReplacingMergeTree-replaced, the
+    re-run is idempotent (CHAOS-2378).
+    """
+
+    def __init__(self, errors: list[PartialGitLabMrSyncError]) -> None:
+        self.errors = errors
+        project_ids = [e.project_id for e in errors]
+        total_skipped = sum(len(e.skipped_iids) for e in errors)
+        super().__init__(
+            f"GitLab batch MR sync degraded for {len(errors)} project(s) "
+            f"(project_ids={project_ids[:20]}); {total_skipped} MR row(s) "
+            f"skipped due to degraded review fetch; not reporting success so "
+            f"the run is retried"
+        )
+
+
 def map_gitlab_mr_reviews(
     repo_id: Any,
     number: int,
@@ -1846,6 +1877,11 @@ async def process_gitlab_projects_batch(
 
     all_results: list[Any] = []
     stored_count = 0
+    # Per-project degraded MR fetches accumulated across the batch. The batch
+    # keeps flushing healthy projects' rows, then raises after the summary so
+    # the overall run is marked failed/retried instead of silently succeeding
+    # while MR rows were skipped (CHAOS-2378).
+    degraded_mr_errors: list[PartialGitLabMrSyncError] = []
 
     results_queue: asyncio.Queue | None = None
     _queue_sentinel = object()
@@ -1954,18 +1990,22 @@ async def process_gitlab_projects_batch(
                         since,
                     )
             except PartialGitLabMrSyncError as e:
-                # Degraded review fetch skipped MR rows. The batch (group) path
-                # does NOT persist a per-project watermark, so the next group
-                # run re-fetches these MRs from the caller-supplied ``since``
-                # (no permanent stranding, unlike the scheduled single-project
-                # path which raises to hold its watermark). Log loudly so the
-                # skip is never silent (CHAOS-2378).
+                # Degraded review fetch skipped MR rows for this project. Keep
+                # processing the rest of the batch (so healthy projects'
+                # commits/MRs/CI still flush), but ACCUMULATE the failure: the
+                # batch raises a BatchGitLabMrSyncError after the summary so the
+                # whole run is marked failed/retried. Returning normally here
+                # would let sync_gitlab_target report success and advance the
+                # per-target watermark past the skipped MRs, stranding them
+                # behind ``since`` on the next incremental run — a permanent,
+                # silent loss with no failed job to alert operators (CHAOS-2378).
                 logging.warning(
                     "Degraded MR review fetch for GitLab project %s: %s "
-                    "(group sync continues; MRs retried on next run)",
+                    "(batch continues; run will be marked failed for retry)",
                     project_info.full_name,
                     e,
                 )
+                degraded_mr_errors.append(e)
             except Exception as e:
                 logging.warning(
                     "Failed to fetch/store MRs for GitLab project %s: %s",
@@ -2242,9 +2282,23 @@ async def process_gitlab_projects_batch(
         logging.info(f"  Failed: {failed}")
         logging.info(f"  Total: {len(all_results)}")
         logging.info(f"  Stored: {stored_count}")
+        if degraded_mr_errors:
+            logging.warning(
+                "  Degraded MR sync: %d project(s)", len(degraded_mr_errors)
+            )
+
+        # Good rows from healthy projects are fully flushed at this point.
+        # Raise so the caller marks the run failed/retried rather than reporting
+        # success while some MR rows were silently skipped (CHAOS-2378).
+        if degraded_mr_errors:
+            raise BatchGitLabMrSyncError(degraded_mr_errors)
 
     except ConnectorException as e:
         logging.error(f"Connector error: {e}")
+        raise
+    except BatchGitLabMrSyncError:
+        # Intentional control-flow signal: healthy rows are flushed, but the run
+        # must fail so the watermark is held and the batch retries (CHAOS-2378).
         raise
     except Exception as e:
         logging.error(f"Error in batch processing: {e}")

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -18,6 +18,7 @@ from dev_health_ops.models.git import (
     GitCommit,
     GitCommitStat,
     GitPullRequest,
+    GitPullRequestReview,
     Incident,
     Repo,
 )
@@ -235,6 +236,126 @@ def _fetch_gitlab_mrs_sync(connector, project_id, repo_id, max_mrs):
     return pr_objects
 
 
+# GitLab system-note bodies that signal an approval state change. GitLab does
+# not expose a discrete "review" object like GitHub, so we reconstruct reviews
+# from the approvals endpoint plus the MR note stream (CHAOS-2378).
+_GITLAB_APPROVE_NOTE = "approved this merge request"
+_GITLAB_UNAPPROVE_NOTE = "unapproved this merge request"
+
+
+def map_gitlab_mr_reviews(
+    repo_id: Any,
+    number: int,
+    approvals: dict[str, Any] | None,
+    notes: list[dict[str, Any]] | None,
+    fallback_at: datetime | None = None,
+) -> list[GitPullRequestReview]:
+    """Map GitLab approvals + MR notes to GitPullRequestReview rows.
+
+    Mirrors the GitHub review states so downstream metrics
+    (review_edges_daily, user_metrics_daily review latency,
+    /ai/review-load) treat both providers identically (CHAOS-2378):
+
+    * approval (approvals.approved_by / "approved" system note) -> APPROVED
+    * "unapproved" system note -> CHANGES_REQUESTED
+    * resolvable reviewer comment (non-system note) -> COMMENTED
+
+    Rows are org-scoped via ``repo_id`` (the repo belongs to an org), exactly
+    like the GitHub path. MRs with no approvals/notes yield an empty list.
+    """
+    reviews: list[GitPullRequestReview] = []
+    seen_ids: set[str] = set()
+
+    def _add(review_id: str, reviewer: str, state: str, at: datetime | None) -> None:
+        if not review_id or review_id in seen_ids:
+            return
+        seen_ids.add(review_id)
+        reviews.append(
+            GitPullRequestReview(
+                repo_id=repo_id,
+                number=int(number),
+                review_id=review_id,
+                reviewer=reviewer or "Unknown",
+                state=state,
+                submitted_at=at or fallback_at or datetime.now(timezone.utc),
+            )
+        )
+
+    # 1. Approvals endpoint: each approver is an APPROVED review. The endpoint
+    #    has no per-approver timestamp, so we fall back to the MR-derived time.
+    for entry in (approvals or {}).get("approved_by") or []:
+        user = entry.get("user") if isinstance(entry, dict) else None
+        if not isinstance(user, dict):
+            continue
+        username = user.get("username") or "Unknown"
+        user_id = user.get("id")
+        review_id = (
+            f"approval-{user_id}" if user_id is not None else f"approval-{username}"
+        )
+        _add(review_id, username, "APPROVED", None)
+
+    # 2. Note stream: system notes capture (un)approval events with timestamps;
+    #    non-system resolvable notes are reviewer comments.
+    for note in notes or []:
+        if not isinstance(note, dict):
+            continue
+        author = note.get("author") if isinstance(note.get("author"), dict) else {}
+        username = (author or {}).get("username") or "Unknown"
+        created_at = safe_parse_datetime(note.get("created_at"))
+        note_id = note.get("id")
+        body = str(note.get("body") or "").strip().lower()
+
+        if note.get("system"):
+            if body.startswith(_GITLAB_APPROVE_NOTE):
+                _add(f"note-{note_id}", username, "APPROVED", created_at)
+            elif body.startswith(_GITLAB_UNAPPROVE_NOTE):
+                _add(f"note-{note_id}", username, "CHANGES_REQUESTED", created_at)
+            # other system notes (label/assignee/etc.) are not reviews
+            continue
+
+        # Human review comment.
+        _add(f"note-{note_id}", username, "COMMENTED", created_at)
+
+    return reviews
+
+
+def _fetch_gitlab_mr_reviews(
+    connector,
+    project_id: int,
+    mr: dict[str, Any],
+    repo_id: Any,
+    created_at: datetime | None,
+) -> list[GitPullRequestReview]:
+    """Best-effort fetch + map of one MR's reviews (approvals + notes).
+
+    Returns ``[]`` (never raises) when an MR has no approvals endpoint or the
+    calls fail, so review ingestion never blocks MR persistence (CHAOS-2378).
+    """
+    iid = int(mr.get("iid") or 0)
+    if iid <= 0:
+        return []
+
+    approvals: dict[str, Any] | None = None
+    try:
+        approvals = connector.rest_client.get_merge_request_approvals(project_id, iid)
+    except Exception as exc:  # noqa: BLE001 - best-effort, some tiers lack approvals
+        logging.debug("Failed to fetch approvals for MR !%d: %s", iid, exc)
+
+    notes: list[dict[str, Any]] = []
+    try:
+        notes = connector.rest_client.get_merge_request_notes(project_id, iid)
+    except Exception as exc:  # noqa: BLE001 - best-effort
+        logging.debug("Failed to fetch notes for MR !%d: %s", iid, exc)
+
+    return map_gitlab_mr_reviews(
+        repo_id=repo_id,
+        number=iid,
+        approvals=approvals,
+        notes=notes,
+        fallback_at=created_at,
+    )
+
+
 def _sync_gitlab_mrs_to_store(
     connector,
     project_id: int,
@@ -255,11 +376,20 @@ def _sync_gitlab_mrs_to_store(
         project_id,
     )
     batch: list[GitPullRequest] = []
+    review_batch: list[GitPullRequestReview] = []
     total = 0
     page = 1
 
     gate = BaseGitProcessor.ensure_gate(gate)
     assert gate is not None
+
+    def _flush_reviews() -> None:
+        if review_batch:
+            BaseGitProcessor.persist_batch_threadsafe(
+                ingestion_sink.insert_git_pull_request_reviews(list(review_batch)),
+                loop,
+            )
+            review_batch.clear()
 
     while True:
         try:
@@ -321,6 +451,24 @@ def _sync_gitlab_mrs_to_store(
                 mrs = []
                 break
 
+            # Reconstruct reviews (approvals + notes) so GitLab orgs populate
+            # git_pull_request_reviews like GitHub does (CHAOS-2378).
+            mr_reviews = _fetch_gitlab_mr_reviews(
+                connector=connector,
+                project_id=project_id,
+                mr=mr,
+                repo_id=repo_id,
+                created_at=created_at,
+            )
+            first_review_at: datetime | None = None
+            changes_requested_count = 0
+            for review in mr_reviews:
+                if first_review_at is None or review.submitted_at < first_review_at:
+                    first_review_at = review.submitted_at
+                if review.state == "CHANGES_REQUESTED":
+                    changes_requested_count += 1
+            review_batch.extend(mr_reviews)
+
             batch.append(
                 build_git_pull_request(
                     repo_id=repo_id,
@@ -335,8 +483,9 @@ def _sync_gitlab_mrs_to_store(
                     closed_at=closed_at,
                     head_branch=mr.get("source_branch"),
                     base_branch=mr.get("target_branch"),
-                    changes_requested_count=0,
-                    reviews_count=0,
+                    first_review_at=first_review_at,
+                    changes_requested_count=changes_requested_count,
+                    reviews_count=len(mr_reviews),
                     comments_count=comments_count,
                 )
             )
@@ -354,6 +503,7 @@ def _sync_gitlab_mrs_to_store(
                     total,
                 )
                 batch.clear()
+                _flush_reviews()
 
         page += 1
         if not mrs:
@@ -364,6 +514,7 @@ def _sync_gitlab_mrs_to_store(
             ingestion_sink.insert_git_pull_requests(batch),
             loop,
         )
+    _flush_reviews()
 
     logging.info(
         "Fetched %d merge requests for project %d",

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -3,7 +3,7 @@ import logging
 import zipfile
 from collections.abc import Iterable
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from dev_health_ops.analytics.complexity import (
     DEFAULT_COMPLEXITY_CONFIG_PATH,
@@ -249,27 +249,55 @@ def map_gitlab_mr_reviews(
     approvals: dict[str, Any] | None,
     notes: list[dict[str, Any]] | None,
     fallback_at: datetime | None = None,
-) -> list[GitPullRequestReview]:
+) -> tuple[list[GitPullRequestReview], datetime | None]:
     """Map GitLab approvals + MR notes to GitPullRequestReview rows.
 
     Mirrors the GitHub review states so downstream metrics
     (review_edges_daily, user_metrics_daily review latency,
     /ai/review-load) treat both providers identically (CHAOS-2378):
 
-    * approval (approvals.approved_by / "approved" system note) -> APPROVED
+    * approval ("approved" system note / approvals.approved_by) -> APPROVED
     * "unapproved" system note -> CHANGES_REQUESTED
     * resolvable reviewer comment (non-system note) -> COMMENTED
 
-    Rows are org-scoped via ``repo_id`` (the repo belongs to an org), exactly
-    like the GitHub path. MRs with no approvals/notes yield an empty list.
+    Approval events appear in *both* the note stream (a timestamped
+    "approved this merge request" system note) and the approvals endpoint
+    (a timestampless ``approved_by`` entry). To avoid double-counting one
+    approval and inventing a review-at-MR-creation timestamp, system notes
+    are authoritative: an approver already covered by an approval note is
+    *not* re-emitted from the approvals endpoint. The approvals endpoint only
+    backfills approvers with no corresponding note (e.g. notes truncated),
+    and those rows carry the MR-derived fallback timestamp purely so the row
+    is storable — they are excluded from ``first_review_at`` (see below).
+
+    Returns ``(reviews, first_review_at)`` where ``first_review_at`` is the
+    earliest review time derived from a *real* event timestamp only (never the
+    fallback), so pickup-latency analytics are not corrupted. Rows are
+    org-scoped via ``repo_id`` (the repo belongs to an org), exactly like the
+    GitHub path. MRs with no approvals/notes yield ``([], None)``.
     """
     reviews: list[GitPullRequestReview] = []
     seen_ids: set[str] = set()
+    # Reviewers whose approval is already captured by a timestamped note;
+    # used to dedup the timestampless approvals-endpoint entries.
+    approved_reviewers: set[str] = set()
+    # Earliest *real* (non-fallback) review timestamp, drives first_review_at.
+    first_review_at: datetime | None = None
 
-    def _add(review_id: str, reviewer: str, state: str, at: datetime | None) -> None:
+    def _add(
+        review_id: str,
+        reviewer: str,
+        state: str,
+        at: datetime | None,
+    ) -> None:
+        nonlocal first_review_at
         if not review_id or review_id in seen_ids:
             return
         seen_ids.add(review_id)
+        # Only a known event time advances first_review_at; the MR-created
+        # fallback must never imply a review happened at creation.
+        if at is not None and (first_review_at is None or at < first_review_at):
+            first_review_at = at
         reviews.append(
             GitPullRequestReview(
                 repo_id=repo_id,
@@ -281,21 +309,8 @@ def map_gitlab_mr_reviews(
             )
         )
 
-    # 1. Approvals endpoint: each approver is an APPROVED review. The endpoint
-    #    has no per-approver timestamp, so we fall back to the MR-derived time.
-    for entry in (approvals or {}).get("approved_by") or []:
-        user = entry.get("user") if isinstance(entry, dict) else None
-        if not isinstance(user, dict):
-            continue
-        username = user.get("username") or "Unknown"
-        user_id = user.get("id")
-        review_id = (
-            f"approval-{user_id}" if user_id is not None else f"approval-{username}"
-        )
-        _add(review_id, username, "APPROVED", None)
-
-    # 2. Note stream: system notes capture (un)approval events with timestamps;
-    #    non-system resolvable notes are reviewer comments.
+    # 1. Note stream FIRST (authoritative, timestamped). System notes capture
+    #    (un)approval events; non-system resolvable notes are reviewer comments.
     for note in notes or []:
         if not isinstance(note, dict):
             continue
@@ -307,6 +322,7 @@ def map_gitlab_mr_reviews(
 
         if note.get("system"):
             if body.startswith(_GITLAB_APPROVE_NOTE):
+                approved_reviewers.add(username)
                 _add(f"note-{note_id}", username, "APPROVED", created_at)
             elif body.startswith(_GITLAB_UNAPPROVE_NOTE):
                 _add(f"note-{note_id}", username, "CHANGES_REQUESTED", created_at)
@@ -316,7 +332,39 @@ def map_gitlab_mr_reviews(
         # Human review comment.
         _add(f"note-{note_id}", username, "COMMENTED", created_at)
 
-    return reviews
+    # 2. Approvals endpoint: backfill only approvers NOT already covered by a
+    #    timestamped approval note, so a single approval is counted once. These
+    #    entries have no per-approver timestamp (excluded from first_review_at).
+    for entry in (approvals or {}).get("approved_by") or []:
+        user = entry.get("user") if isinstance(entry, dict) else None
+        if not isinstance(user, dict):
+            continue
+        username = user.get("username") or "Unknown"
+        if username in approved_reviewers:
+            continue  # already emitted from the authoritative note
+        approved_reviewers.add(username)
+        user_id = user.get("id")
+        review_id = (
+            f"approval-{user_id}" if user_id is not None else f"approval-{username}"
+        )
+        _add(review_id, username, "APPROVED", None)
+
+    return reviews, first_review_at
+
+
+class _MrReviewFetch(NamedTuple):
+    """Result of one MR's review fetch.
+
+    ``known`` is False when the *authoritative* notes call failed, so the
+    caller can avoid clobbering previously-correct PR review metrics with
+    zero/null (CHAOS-2378). ``first_review_at`` is derived only from real
+    event timestamps (never the MR-created fallback).
+    """
+
+    reviews: list[GitPullRequestReview]
+    first_review_at: datetime | None
+    changes_requested_count: int
+    known: bool
 
 
 def _fetch_gitlab_mr_reviews(
@@ -325,15 +373,23 @@ def _fetch_gitlab_mr_reviews(
     mr: dict[str, Any],
     repo_id: Any,
     created_at: datetime | None,
-) -> list[GitPullRequestReview]:
+) -> _MrReviewFetch:
     """Best-effort fetch + map of one MR's reviews (approvals + notes).
 
-    Returns ``[]`` (never raises) when an MR has no approvals endpoint or the
-    calls fail, so review ingestion never blocks MR persistence (CHAOS-2378).
+    The MR notes endpoint is the authoritative, timestamped source and is
+    available on every tier; the approvals endpoint only supplements it (and
+    404s on tiers without merge-request approvals). Accordingly:
+
+    * approvals-only failure is benign (notes still give authoritative data);
+    * a notes failure means we genuinely do not know the review state, so we
+      report ``known=False`` and the caller preserves the existing PR row
+      rather than overwriting its review metrics with zero/null.
+
+    Never raises (CHAOS-2378).
     """
     iid = int(mr.get("iid") or 0)
     if iid <= 0:
-        return []
+        return _MrReviewFetch([], None, 0, known=True)
 
     approvals: dict[str, Any] | None = None
     try:
@@ -342,18 +398,33 @@ def _fetch_gitlab_mr_reviews(
         logging.debug("Failed to fetch approvals for MR !%d: %s", iid, exc)
 
     notes: list[dict[str, Any]] = []
+    notes_known = True
     try:
         notes = connector.rest_client.get_merge_request_notes(project_id, iid)
     except Exception as exc:  # noqa: BLE001 - best-effort
-        logging.debug("Failed to fetch notes for MR !%d: %s", iid, exc)
+        notes_known = False
+        logging.warning(
+            "Could not fetch notes for MR !%d (project %s); preserving existing "
+            "review metrics: %s",
+            iid,
+            project_id,
+            exc,
+        )
 
-    return map_gitlab_mr_reviews(
+    if not notes_known:
+        # Authoritative source unavailable: signal "unknown" so the caller does
+        # not persist this MR's PR row with zeroed-out review metrics.
+        return _MrReviewFetch([], None, 0, known=False)
+
+    reviews, first_review_at = map_gitlab_mr_reviews(
         repo_id=repo_id,
         number=iid,
         approvals=approvals,
         notes=notes,
         fallback_at=created_at,
     )
+    changes_requested_count = sum(1 for r in reviews if r.state == "CHANGES_REQUESTED")
+    return _MrReviewFetch(reviews, first_review_at, changes_requested_count, known=True)
 
 
 def _sync_gitlab_mrs_to_store(
@@ -453,21 +524,30 @@ def _sync_gitlab_mrs_to_store(
 
             # Reconstruct reviews (approvals + notes) so GitLab orgs populate
             # git_pull_request_reviews like GitHub does (CHAOS-2378).
-            mr_reviews = _fetch_gitlab_mr_reviews(
+            fetched = _fetch_gitlab_mr_reviews(
                 connector=connector,
                 project_id=project_id,
                 mr=mr,
                 repo_id=repo_id,
                 created_at=created_at,
             )
-            first_review_at: datetime | None = None
-            changes_requested_count = 0
-            for review in mr_reviews:
-                if first_review_at is None or review.submitted_at < first_review_at:
-                    first_review_at = review.submitted_at
-                if review.state == "CHANGES_REQUESTED":
-                    changes_requested_count += 1
-            review_batch.extend(mr_reviews)
+
+            if not fetched.known:
+                # Authoritative review source (MR notes) was unavailable for
+                # this MR. The PR row is ReplacingMergeTree-replaced on write,
+                # so persisting it now with zeroed review metrics would clobber
+                # previously-correct first_review_at / reviews_count /
+                # changes_requested_count. Skip this MR's row this cycle so the
+                # prior values are preserved; the next sync re-attempts it.
+                logging.warning(
+                    "Skipping PR row for MR !%d (project %d): review fetch "
+                    "degraded, preserving existing review metrics",
+                    int(mr.get("iid") or 0),
+                    project_id,
+                )
+                continue
+
+            review_batch.extend(fetched.reviews)
 
             batch.append(
                 build_git_pull_request(
@@ -483,9 +563,9 @@ def _sync_gitlab_mrs_to_store(
                     closed_at=closed_at,
                     head_branch=mr.get("source_branch"),
                     base_branch=mr.get("target_branch"),
-                    first_review_at=first_review_at,
-                    changes_requested_count=changes_requested_count,
-                    reviews_count=len(mr_reviews),
+                    first_review_at=fetched.first_review_at,
+                    changes_requested_count=fetched.changes_requested_count,
+                    reviews_count=len(fetched.reviews),
                     comments_count=comments_count,
                 )
             )

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -242,6 +242,15 @@ def _fetch_gitlab_mrs_sync(connector, project_id, repo_id, max_mrs):
 _GITLAB_APPROVE_NOTE = "approved this merge request"
 _GITLAB_UNAPPROVE_NOTE = "unapproved this merge request"
 
+# A GitLab MR note attached to a diff position (``type == "DiffNote"``) is a
+# code-line review comment — the GitLab analogue of a GitHub review comment.
+# Plain discussion notes (``type`` null/``"DiscussionNote"``) are ordinary MR
+# chatter (author replies, status banter) and are NOT review activity, so they
+# must stay in ``comments_count`` only and never become COMMENTED review rows
+# (CHAOS-2378: counting them inflated reviews_count and corrupted
+# first_review_at / review-latency).
+_GITLAB_DIFF_NOTE_TYPE = "DiffNote"
+
 
 def map_gitlab_mr_reviews(
     repo_id: Any,
@@ -249,6 +258,7 @@ def map_gitlab_mr_reviews(
     approvals: dict[str, Any] | None,
     notes: list[dict[str, Any]] | None,
     fallback_at: datetime | None = None,
+    author_username: str | None = None,
 ) -> tuple[list[GitPullRequestReview], datetime | None]:
     """Map GitLab approvals + MR notes to GitPullRequestReview rows.
 
@@ -258,7 +268,16 @@ def map_gitlab_mr_reviews(
 
     * approval ("approved" system note / approvals.approved_by) -> APPROVED
     * "unapproved" system note -> CHANGES_REQUESTED
-    * resolvable reviewer comment (non-system note) -> COMMENTED
+    * diff-line review comment by a non-author reviewer
+      (``type == "DiffNote"``) -> COMMENTED
+
+    Only diff-line notes authored by someone other than the MR author count as
+    review activity. Generic MR discussion notes (``type`` null /
+    ``"DiscussionNote"``) and the author's own replies are ordinary chatter:
+    they stay in ``comments_count`` only and must NOT become COMMENTED rows,
+    because doing so inflated ``reviews_count`` and let non-review timestamps
+    drive ``first_review_at`` / review-latency (CHAOS-2378). Pass the MR author
+    via ``author_username`` so self-comments are excluded.
 
     Approval events appear in *both* the note stream (a timestamped
     "approved this merge request" system note) and the approvals endpoint
@@ -278,6 +297,9 @@ def map_gitlab_mr_reviews(
     """
     reviews: list[GitPullRequestReview] = []
     seen_ids: set[str] = set()
+    # MR author: their own comments/replies are not reviews and are excluded
+    # from COMMENTED rows (the author cannot review their own MR).
+    author = (author_username or "").strip().lower()
     # Reviewers whose approval is already captured by a timestamped note;
     # used to dedup the timestampless approvals-endpoint entries.
     approved_reviewers: set[str] = set()
@@ -310,12 +332,12 @@ def map_gitlab_mr_reviews(
         )
 
     # 1. Note stream FIRST (authoritative, timestamped). System notes capture
-    #    (un)approval events; non-system resolvable notes are reviewer comments.
+    #    (un)approval events; diff-line notes by non-authors are review comments.
     for note in notes or []:
         if not isinstance(note, dict):
             continue
-        author = note.get("author") if isinstance(note.get("author"), dict) else {}
-        username = (author or {}).get("username") or "Unknown"
+        note_author = note.get("author") if isinstance(note.get("author"), dict) else {}
+        username = (note_author or {}).get("username") or "Unknown"
         created_at = safe_parse_datetime(note.get("created_at"))
         note_id = note.get("id")
         body = str(note.get("body") or "").strip().lower()
@@ -329,7 +351,14 @@ def map_gitlab_mr_reviews(
             # other system notes (label/assignee/etc.) are not reviews
             continue
 
-        # Human review comment.
+        # Human note. Only a diff-line comment (``type == "DiffNote"``) by a
+        # reviewer other than the MR author is review activity; generic
+        # discussion notes and the author's own comments are plain chatter
+        # (counted via comments_count, never as a COMMENTED review row).
+        if note.get("type") != _GITLAB_DIFF_NOTE_TYPE:
+            continue
+        if author and username.strip().lower() == author:
+            continue
         _add(f"note-{note_id}", username, "COMMENTED", created_at)
 
     # 2. Approvals endpoint: backfill only approvers NOT already covered by a
@@ -367,12 +396,68 @@ class _MrReviewFetch(NamedTuple):
     known: bool
 
 
+def _fetch_all_mr_notes(
+    connector,
+    project_id: int,
+    iid: int,
+    gate: Any = None,
+) -> list[dict[str, Any]]:
+    """Fetch *every* page of an MR's notes, not just the first.
+
+    The notes endpoint is paginated (per_page<=100); a busy MR can carry an
+    approval / unapproval / review-comment event past page 1. Fetching only the
+    first page would silently drop those events and undercount reviews while the
+    sync still reports success (CHAOS-2378). We exhaust pages, honouring the
+    shared rate-limit gate/backoff exactly like the MR-list loop.
+
+    Raises on a non-rate-limit error so the caller can flag the MR's review
+    state as ``known=False`` (an incomplete page set is as untrustworthy as a
+    failed first page — both must avoid clobbering correct metrics).
+    """
+    per_page = int(getattr(connector, "per_page", 100) or 100)
+    all_notes: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        if gate is not None:
+            gate.wait_sync()
+        try:
+            page_notes = connector.rest_client.get_merge_request_notes(
+                project_id,
+                iid,
+                page=page,
+                per_page=per_page,
+            )
+            if gate is not None:
+                gate.reset()
+        except Exception as exc:
+            retry_after = getattr(exc, "retry_after_seconds", None)
+            if retry_after is not None and gate is not None:
+                applied = gate.penalize(retry_after)
+                logging.info(
+                    "GitLab rate limited fetching notes for MR !%d; backoff %.1fs (%s)",
+                    iid,
+                    applied,
+                    exc,
+                )
+                continue
+            raise
+        if not page_notes:
+            break
+        all_notes.extend(page_notes)
+        # Final page when the server returns fewer than a full page.
+        if len(page_notes) < per_page:
+            break
+        page += 1
+    return all_notes
+
+
 def _fetch_gitlab_mr_reviews(
     connector,
     project_id: int,
     mr: dict[str, Any],
     repo_id: Any,
     created_at: datetime | None,
+    gate: Any = None,
 ) -> _MrReviewFetch:
     """Best-effort fetch + map of one MR's reviews (approvals + notes).
 
@@ -381,9 +466,10 @@ def _fetch_gitlab_mr_reviews(
     404s on tiers without merge-request approvals). Accordingly:
 
     * approvals-only failure is benign (notes still give authoritative data);
-    * a notes failure means we genuinely do not know the review state, so we
-      report ``known=False`` and the caller preserves the existing PR row
-      rather than overwriting its review metrics with zero/null.
+    * a notes failure (or an incomplete page set) means we genuinely do not
+      know the review state, so we report ``known=False`` and the caller
+      preserves the existing PR row rather than overwriting its review metrics
+      with zero/null.
 
     Never raises (CHAOS-2378).
     """
@@ -400,7 +486,7 @@ def _fetch_gitlab_mr_reviews(
     notes: list[dict[str, Any]] = []
     notes_known = True
     try:
-        notes = connector.rest_client.get_merge_request_notes(project_id, iid)
+        notes = _fetch_all_mr_notes(connector, project_id, iid, gate=gate)
     except Exception as exc:  # noqa: BLE001 - best-effort
         notes_known = False
         logging.warning(
@@ -412,16 +498,22 @@ def _fetch_gitlab_mr_reviews(
         )
 
     if not notes_known:
-        # Authoritative source unavailable: signal "unknown" so the caller does
-        # not persist this MR's PR row with zeroed-out review metrics.
+        # Authoritative source unavailable / incomplete: signal "unknown" so the
+        # caller does not persist this MR's PR row with zeroed-out review
+        # metrics.
         return _MrReviewFetch([], None, 0, known=False)
 
+    author_data = mr.get("author")
+    author_username = (
+        author_data.get("username") if isinstance(author_data, dict) else None
+    )
     reviews, first_review_at = map_gitlab_mr_reviews(
         repo_id=repo_id,
         number=iid,
         approvals=approvals,
         notes=notes,
         fallback_at=created_at,
+        author_username=author_username,
     )
     changes_requested_count = sum(1 for r in reviews if r.state == "CHANGES_REQUESTED")
     return _MrReviewFetch(reviews, first_review_at, changes_requested_count, known=True)
@@ -530,6 +622,7 @@ def _sync_gitlab_mrs_to_store(
                 mr=mr,
                 repo_id=repo_id,
                 created_at=created_at,
+                gate=gate,
             )
 
             if not fetched.known:

--- a/tests/test_connectors_rest.py
+++ b/tests/test_connectors_rest.py
@@ -195,6 +195,35 @@ def test_gitlab_get_merge_requests_passes_optional_ordering(monkeypatch):
     )
 
 
+def test_gitlab_get_merge_request_approvals_hits_endpoint(monkeypatch):
+    client = GitLabRESTClient()
+    get = MagicMock(return_value={"approved_by": []})
+    monkeypatch.setattr(client, "get", get)
+
+    result = client.get_merge_request_approvals(22, 7)
+
+    assert result == {"approved_by": []}
+    get.assert_called_once_with("projects/22/merge_requests/7/approvals")
+
+
+def test_gitlab_get_merge_request_notes_hits_endpoint(monkeypatch):
+    client = GitLabRESTClient()
+    get_list = MagicMock(return_value=[])
+    monkeypatch.setattr(client, "get_list", get_list)
+
+    client.get_merge_request_notes(22, 7)
+
+    get_list.assert_called_once_with(
+        "projects/22/merge_requests/7/notes",
+        params={
+            "page": 1,
+            "per_page": 100,
+            "sort": "asc",
+            "order_by": "created_at",
+        },
+    )
+
+
 def test_gitlab_get_dora_metrics_includes_date_range(monkeypatch):
     client = GitLabRESTClient()
     get_list = MagicMock(return_value=[])

--- a/tests/test_gitlab_mr_reviews.py
+++ b/tests/test_gitlab_mr_reviews.py
@@ -7,7 +7,7 @@ review-latency / /ai/review-load populate for GitLab orgs. No live API or DB.
 
 import uuid
 from datetime import datetime, timezone
-from typing import cast
+from typing import Any, cast
 from unittest.mock import Mock
 
 # Initialize the connectors package before processors to avoid the
@@ -17,6 +17,7 @@ import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models.git import GitPullRequestReview
 from dev_health_ops.processors.gitlab import (
+    _fetch_all_mr_notes,
     _fetch_gitlab_mr_reviews,
     _sync_gitlab_mrs_to_store,
     map_gitlab_mr_reviews,
@@ -79,23 +80,89 @@ def test_unapproval_system_note_maps_to_changes_requested():
     assert first_review_at == datetime(2026, 1, 2, 9, 30, tzinfo=timezone.utc)
 
 
-def test_human_comment_note_maps_to_commented():
+def test_diff_note_by_reviewer_maps_to_commented():
+    """A diff-line comment (``type == "DiffNote"``) by a non-author reviewer is
+    the GitLab analogue of a GitHub review comment -> COMMENTED."""
     notes = [
         {
             "id": 200,
             "system": False,
+            "type": "DiffNote",
             "body": "Please rename this variable.",
             "author": {"username": "carol"},
             "created_at": "2026-01-03T08:00:00Z",
         }
     ]
     reviews, _ = map_gitlab_mr_reviews(
-        repo_id=REPO_ID, number=42, approvals=None, notes=notes
+        repo_id=REPO_ID,
+        number=42,
+        approvals=None,
+        notes=notes,
+        author_username="author",
     )
 
     assert len(reviews) == 1
     assert reviews[0].state == "COMMENTED"
     assert reviews[0].reviewer == "carol"
+
+
+def test_generic_discussion_note_is_not_a_review():
+    """Regression (CHAOS-2378): a plain MR discussion note (no diff position) is
+    ordinary chatter and must NOT be counted as a COMMENTED review -- counting
+    it inflated reviews_count and corrupted first_review_at."""
+    notes: list[dict[str, Any]] = [
+        {
+            "id": 201,
+            "system": False,
+            "type": None,  # generic discussion note, not attached to a diff
+            "body": "Thanks, will do!",
+            "author": {"username": "carol"},
+            "created_at": "2026-01-03T08:00:00Z",
+        },
+        {
+            "id": 202,
+            "system": False,
+            "type": "DiscussionNote",  # reply in a thread, still not a diff note
+            "body": "ping",
+            "author": {"username": "carol"},
+            "created_at": "2026-01-03T09:00:00Z",
+        },
+    ]
+    reviews, first_review_at = map_gitlab_mr_reviews(
+        repo_id=REPO_ID,
+        number=42,
+        approvals=None,
+        notes=notes,
+        author_username="author",
+    )
+
+    assert reviews == []
+    assert first_review_at is None
+
+
+def test_author_self_diff_note_is_not_a_review():
+    """Regression (CHAOS-2378): the MR author commenting on their own diff is
+    not a review -- it must not mark the MR reviewed nor drive first_review_at."""
+    notes = [
+        {
+            "id": 203,
+            "system": False,
+            "type": "DiffNote",
+            "body": "Self-note: refactor later.",
+            "author": {"username": "Author"},  # case-insensitive match
+            "created_at": "2026-01-03T08:00:00Z",
+        }
+    ]
+    reviews, first_review_at = map_gitlab_mr_reviews(
+        repo_id=REPO_ID,
+        number=42,
+        approvals=None,
+        notes=notes,
+        author_username="author",
+    )
+
+    assert reviews == []
+    assert first_review_at is None
 
 
 def test_approve_system_note_maps_to_approved():
@@ -220,6 +287,7 @@ def test_combined_payload_yields_all_expected_rows():
         {
             "id": 200,
             "system": False,
+            "type": "DiffNote",
             "body": "nit: typo",
             "author": {"username": "carol"},
             "created_at": "2026-01-02T10:00:00Z",
@@ -255,6 +323,7 @@ def test_empty_payloads_yield_no_rows():
 def test_fetch_calls_rest_endpoints_and_maps():
     """The fetch helper wires the REST approvals + notes calls into the mapper."""
     connector = Mock()
+    connector.per_page = 100
     connector.rest_client.get_merge_request_approvals.return_value = _approvals(
         ("alice", 7)
     )
@@ -262,6 +331,7 @@ def test_fetch_calls_rest_endpoints_and_maps():
         {
             "id": 200,
             "system": False,
+            "type": "DiffNote",
             "body": "looks good",
             "author": {"username": "carol"},
             "created_at": "2026-01-03T08:00:00Z",
@@ -271,13 +341,15 @@ def test_fetch_calls_rest_endpoints_and_maps():
     fetched = _fetch_gitlab_mr_reviews(
         connector=connector,
         project_id=99,
-        mr={"iid": 42},
+        mr={"iid": 42, "author": {"username": "author"}},
         repo_id=REPO_ID,
         created_at=CREATED_AT,
     )
 
     connector.rest_client.get_merge_request_approvals.assert_called_once_with(99, 42)
-    connector.rest_client.get_merge_request_notes.assert_called_once_with(99, 42)
+    connector.rest_client.get_merge_request_notes.assert_called_once_with(
+        99, 42, page=1, per_page=100
+    )
     assert fetched.known is True
     assert sorted(r.state for r in fetched.reviews) == ["APPROVED", "COMMENTED"]
     assert fetched.first_review_at == datetime(2026, 1, 3, 8, 0, tzinfo=timezone.utc)
@@ -286,6 +358,7 @@ def test_fetch_calls_rest_endpoints_and_maps():
 def test_fetch_is_resilient_to_missing_approvals_endpoint():
     """MRs whose approvals endpoint 404s still ingest notes (skip cleanly)."""
     connector = Mock()
+    connector.per_page = 100
     connector.rest_client.get_merge_request_approvals.side_effect = Exception("404")
     connector.rest_client.get_merge_request_notes.return_value = []
 
@@ -307,6 +380,7 @@ def test_fetch_notes_failure_reports_unknown():
     """Regression (CHAOS-2378): when the authoritative notes call fails, the
     result is flagged unknown so the caller will NOT zero out review metrics."""
     connector = Mock()
+    connector.per_page = 100
     connector.rest_client.get_merge_request_approvals.return_value = _approvals(
         ("alice", 7)
     )
@@ -385,11 +459,14 @@ def _make_connector(mrs_page, approvals_by_iid, notes_by_iid):
             raise val
         return val
 
-    def _notes_for(project_id, iid):
+    def _notes_for(project_id, iid, page=1, per_page=100):
         val = notes_by_iid.get(iid)
         if isinstance(val, Exception):
             raise val
-        return val or []
+        all_notes = val or []
+        # Emulate real GitLab note pagination so the exhaustion loop is exercised.
+        start = (page - 1) * per_page
+        return all_notes[start : start + per_page]
 
     connector.rest_client.get_merge_request_approvals.side_effect = _approvals_for
     connector.rest_client.get_merge_request_notes.side_effect = _notes_for
@@ -528,4 +605,162 @@ def test_live_sync_mr_with_no_reviews_persists_zero_counts():
     assert pr.reviews_count == 0
     assert pr.changes_requested_count == 0
     assert pr.first_review_at is None
+    assert sink.reviews == []
+
+
+# --- Pagination + classification regressions (CHAOS-2378 round 2) ---
+
+
+def test_fetch_all_mr_notes_exhausts_pages():
+    """Regression (CHAOS-2378): notes are paginated; we must fetch EVERY page,
+    not just page 1, or late approval/review events are silently dropped."""
+    # 100 generic notes (a full first page) + a 101st note carrying the only
+    # approval system note. A single-page fetch would lose it entirely.
+    page_one = [
+        {
+            "id": i,
+            "system": True,
+            "body": "added 1 commit",
+            "author": {"username": "ci"},
+            "created_at": "2026-01-02T00:00:00Z",
+        }
+        for i in range(100)
+    ]
+    page_two = [
+        {
+            "id": 1000,
+            "system": True,
+            "body": "approved this merge request",
+            "author": {"username": "alice"},
+            "created_at": "2026-01-04T10:00:00Z",
+        }
+    ]
+    all_notes = page_one + page_two
+
+    connector = Mock()
+    connector.per_page = 100
+
+    def _notes(project_id, iid, page=1, per_page=100):
+        start = (page - 1) * per_page
+        return all_notes[start : start + per_page]
+
+    connector.rest_client.get_merge_request_notes.side_effect = _notes
+
+    fetched = _fetch_all_mr_notes(connector, project_id=99, iid=42)
+
+    assert len(fetched) == 101
+    # The page-2 approval note survived pagination.
+    assert any(n["id"] == 1000 for n in fetched)
+    # Two full-size fetches + one short page would also be valid; here page 2
+    # is short (1 item) so the loop stops after 2 calls.
+    assert connector.rest_client.get_merge_request_notes.call_count == 2
+
+
+def test_live_sync_approval_after_first_note_page_is_counted():
+    """End-to-end regression (CHAOS-2378): an MR whose approval lands past the
+    first 100 notes still yields an APPROVED review with the real timestamp --
+    the sync no longer drops it by fetching only page 1."""
+    notes = [
+        {
+            "id": i,
+            "system": True,
+            "body": "added 1 commit",
+            "author": {"username": "ci"},
+            "created_at": "2026-01-02T00:00:00Z",
+        }
+        for i in range(100)
+    ] + [
+        {
+            "id": 9999,
+            "system": True,
+            "body": "approved this merge request",
+            "author": {"username": "alice"},
+            "created_at": "2026-01-04T10:00:00Z",
+        }
+    ]
+    mr = {
+        "iid": 44,
+        "title": "Busy MR",
+        "description": "desc",
+        "state": "merged",
+        "author": {"username": "author"},
+        "created_at": "2026-01-01T12:00:00Z",
+        "updated_at": "2026-01-05T12:00:00Z",
+        "merged_at": "2026-01-04T11:00:00Z",
+        "source_branch": "feat",
+        "target_branch": "main",
+        "user_notes_count": 101,
+    }
+    connector = _make_connector(
+        mrs_page=[mr],
+        approvals_by_iid={44: {"approved_by": []}},
+        notes_by_iid={44: notes},
+    )
+
+    total, sink = _run_sync(connector)
+
+    assert total == 1
+    pr = sink.prs[0]
+    assert pr.reviews_count == 1
+    assert pr.first_review_at == datetime(2026, 1, 4, 10, 0, tzinfo=timezone.utc)
+    assert len(sink.reviews) == 1
+    assert sink.reviews[0].state == "APPROVED"
+
+
+def test_live_sync_generic_notes_are_not_counted_as_reviews():
+    """End-to-end regression (CHAOS-2378): generic MR discussion notes and the
+    author's own replies must NOT inflate reviews_count nor set first_review_at;
+    they live in comments_count only."""
+    mr = {
+        "iid": 45,
+        "title": "Chat-heavy MR",
+        "description": "desc",
+        "state": "opened",
+        "author": {"username": "author"},
+        "created_at": "2026-01-01T12:00:00Z",
+        "updated_at": "2026-01-05T12:00:00Z",
+        "merged_at": None,
+        "source_branch": "feat",
+        "target_branch": "main",
+        "user_notes_count": 3,
+    }
+    notes = [
+        {
+            "id": 1,
+            "system": False,
+            "type": None,  # generic discussion
+            "body": "When will this be ready?",
+            "author": {"username": "pm"},
+            "created_at": "2026-01-02T08:00:00Z",
+        },
+        {
+            "id": 2,
+            "system": False,
+            "type": "DiffNote",  # but it's the AUTHOR self-commenting
+            "body": "Will refactor.",
+            "author": {"username": "author"},
+            "created_at": "2026-01-02T09:00:00Z",
+        },
+        {
+            "id": 3,
+            "system": False,
+            "type": "DiscussionNote",  # thread reply, not a diff comment
+            "body": "thanks",
+            "author": {"username": "pm"},
+            "created_at": "2026-01-02T10:00:00Z",
+        },
+    ]
+    connector = _make_connector(
+        mrs_page=[mr],
+        approvals_by_iid={45: {"approved_by": []}},
+        notes_by_iid={45: notes},
+    )
+
+    total, sink = _run_sync(connector)
+
+    assert total == 1
+    pr = sink.prs[0]
+    assert pr.reviews_count == 0  # no genuine review activity
+    assert pr.first_review_at is None
+    assert pr.comments_count == 3  # generic chatter stays here
     assert sink.reviews == []

--- a/tests/test_gitlab_mr_reviews.py
+++ b/tests/test_gitlab_mr_reviews.py
@@ -1,0 +1,232 @@
+"""Unit tests for GitLab MR-review reconstruction (CHAOS-2378).
+
+Proves the seam that wires GitLab approvals + MR notes into
+``git_pull_request_reviews``, mirroring the GitHub path so review_edges_daily /
+review-latency / /ai/review-load populate for GitLab orgs. No live API or DB.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+from dev_health_ops.models.git import GitPullRequestReview
+from dev_health_ops.processors.gitlab import (
+    _fetch_gitlab_mr_reviews,
+    map_gitlab_mr_reviews,
+)
+
+REPO_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+CREATED_AT = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def _approvals(*usernames_ids):
+    return {
+        "approved_by": [
+            {"user": {"id": uid, "username": name}} for name, uid in usernames_ids
+        ]
+    }
+
+
+def test_approval_maps_to_approved_state_and_org_scope():
+    reviews = map_gitlab_mr_reviews(
+        repo_id=REPO_ID,
+        number=42,
+        approvals=_approvals(("alice", 7)),
+        notes=[],
+        fallback_at=CREATED_AT,
+    )
+
+    assert len(reviews) == 1
+    row = reviews[0]
+    assert isinstance(row, GitPullRequestReview)
+    assert row.repo_id == REPO_ID  # org-scoped via repo_id, like GitHub
+    assert row.number == 42
+    assert row.reviewer == "alice"
+    assert row.state == "APPROVED"
+    assert row.review_id == "approval-7"
+    # No per-approver timestamp -> falls back to MR created_at
+    assert row.submitted_at == CREATED_AT
+
+
+def test_unapproval_system_note_maps_to_changes_requested():
+    notes = [
+        {
+            "id": 100,
+            "system": True,
+            "body": "unapproved this merge request",
+            "author": {"username": "bob"},
+            "created_at": "2026-01-02T09:30:00Z",
+        }
+    ]
+    reviews = map_gitlab_mr_reviews(
+        repo_id=REPO_ID, number=42, approvals=None, notes=notes
+    )
+
+    assert len(reviews) == 1
+    assert reviews[0].state == "CHANGES_REQUESTED"
+    assert reviews[0].reviewer == "bob"
+    assert reviews[0].review_id == "note-100"
+    assert reviews[0].submitted_at == datetime(2026, 1, 2, 9, 30, tzinfo=timezone.utc)
+
+
+def test_human_comment_note_maps_to_commented():
+    notes = [
+        {
+            "id": 200,
+            "system": False,
+            "body": "Please rename this variable.",
+            "author": {"username": "carol"},
+            "created_at": "2026-01-03T08:00:00Z",
+        }
+    ]
+    reviews = map_gitlab_mr_reviews(
+        repo_id=REPO_ID, number=42, approvals=None, notes=notes
+    )
+
+    assert len(reviews) == 1
+    assert reviews[0].state == "COMMENTED"
+    assert reviews[0].reviewer == "carol"
+
+
+def test_approve_system_note_maps_to_approved():
+    notes = [
+        {
+            "id": 300,
+            "system": True,
+            "body": "approved this merge request",
+            "author": {"username": "dave"},
+            "created_at": "2026-01-04T10:00:00Z",
+        }
+    ]
+    reviews = map_gitlab_mr_reviews(
+        repo_id=REPO_ID, number=42, approvals=None, notes=notes
+    )
+
+    assert len(reviews) == 1
+    assert reviews[0].state == "APPROVED"
+
+
+def test_non_review_system_notes_are_ignored():
+    notes = [
+        {
+            "id": 400,
+            "system": True,
+            "body": "added 1 commit",
+            "author": {"username": "eve"},
+            "created_at": "2026-01-05T10:00:00Z",
+        },
+        {
+            "id": 401,
+            "system": True,
+            "body": "assigned to @eve",
+            "author": {"username": "eve"},
+            "created_at": "2026-01-05T10:01:00Z",
+        },
+    ]
+    reviews = map_gitlab_mr_reviews(
+        repo_id=REPO_ID, number=42, approvals=None, notes=notes
+    )
+
+    assert reviews == []
+
+
+def test_combined_payload_yields_all_expected_rows():
+    approvals = _approvals(("alice", 7))
+    notes = [
+        {
+            "id": 100,
+            "system": True,
+            "body": "unapproved this merge request",
+            "author": {"username": "bob"},
+            "created_at": "2026-01-02T09:30:00Z",
+        },
+        {
+            "id": 200,
+            "system": False,
+            "body": "nit: typo",
+            "author": {"username": "carol"},
+            "created_at": "2026-01-02T10:00:00Z",
+        },
+        {
+            "id": 401,
+            "system": True,
+            "body": "changed target branch",
+            "author": {"username": "eve"},
+            "created_at": "2026-01-02T11:00:00Z",
+        },
+    ]
+    reviews = map_gitlab_mr_reviews(
+        repo_id=REPO_ID,
+        number=42,
+        approvals=approvals,
+        notes=notes,
+        fallback_at=CREATED_AT,
+    )
+
+    by_state = sorted(r.state for r in reviews)
+    assert by_state == ["APPROVED", "CHANGES_REQUESTED", "COMMENTED"]
+    assert all(r.repo_id == REPO_ID and r.number == 42 for r in reviews)
+
+
+def test_empty_payloads_yield_no_rows():
+    assert map_gitlab_mr_reviews(REPO_ID, 42, None, None) == []
+    assert map_gitlab_mr_reviews(REPO_ID, 42, {"approved_by": []}, []) == []
+
+
+def test_fetch_calls_rest_endpoints_and_maps():
+    """The fetch helper wires the REST approvals + notes calls into the mapper."""
+    connector = Mock()
+    connector.rest_client.get_merge_request_approvals.return_value = _approvals(
+        ("alice", 7)
+    )
+    connector.rest_client.get_merge_request_notes.return_value = [
+        {
+            "id": 200,
+            "system": False,
+            "body": "looks good",
+            "author": {"username": "carol"},
+            "created_at": "2026-01-03T08:00:00Z",
+        }
+    ]
+
+    reviews = _fetch_gitlab_mr_reviews(
+        connector=connector,
+        project_id=99,
+        mr={"iid": 42},
+        repo_id=REPO_ID,
+        created_at=CREATED_AT,
+    )
+
+    connector.rest_client.get_merge_request_approvals.assert_called_once_with(99, 42)
+    connector.rest_client.get_merge_request_notes.assert_called_once_with(99, 42)
+    assert sorted(r.state for r in reviews) == ["APPROVED", "COMMENTED"]
+
+
+def test_fetch_is_resilient_to_missing_approvals_endpoint():
+    """MRs whose approvals endpoint 404s still ingest notes (skip cleanly)."""
+    connector = Mock()
+    connector.rest_client.get_merge_request_approvals.side_effect = Exception("404")
+    connector.rest_client.get_merge_request_notes.return_value = []
+
+    reviews = _fetch_gitlab_mr_reviews(
+        connector=connector,
+        project_id=99,
+        mr={"iid": 42},
+        repo_id=REPO_ID,
+        created_at=CREATED_AT,
+    )
+
+    assert reviews == []  # no crash, empty result
+
+
+def test_fetch_skips_mr_without_iid():
+    connector = Mock()
+    reviews = _fetch_gitlab_mr_reviews(
+        connector=connector,
+        project_id=99,
+        mr={},
+        repo_id=REPO_ID,
+        created_at=CREATED_AT,
+    )
+    assert reviews == []
+    connector.rest_client.get_merge_request_approvals.assert_not_called()

--- a/tests/test_gitlab_mr_reviews.py
+++ b/tests/test_gitlab_mr_reviews.py
@@ -7,11 +7,18 @@ review-latency / /ai/review-load populate for GitLab orgs. No live API or DB.
 
 import uuid
 from datetime import datetime, timezone
+from typing import cast
 from unittest.mock import Mock
 
+# Initialize the connectors package before processors to avoid the
+# pre-existing providers._base <-> connectors circular import when this file
+# is collected in isolation (mirrors tests/test_deployment_pr_inference.py).
+import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models.git import GitPullRequestReview
 from dev_health_ops.processors.gitlab import (
     _fetch_gitlab_mr_reviews,
+    _sync_gitlab_mrs_to_store,
     map_gitlab_mr_reviews,
 )
 
@@ -28,7 +35,7 @@ def _approvals(*usernames_ids):
 
 
 def test_approval_maps_to_approved_state_and_org_scope():
-    reviews = map_gitlab_mr_reviews(
+    reviews, first_review_at = map_gitlab_mr_reviews(
         repo_id=REPO_ID,
         number=42,
         approvals=_approvals(("alice", 7)),
@@ -44,8 +51,10 @@ def test_approval_maps_to_approved_state_and_org_scope():
     assert row.reviewer == "alice"
     assert row.state == "APPROVED"
     assert row.review_id == "approval-7"
-    # No per-approver timestamp -> falls back to MR created_at
+    # No per-approver timestamp -> the row uses the MR created_at fallback so
+    # it is storable, but that synthetic time must NOT drive first_review_at.
     assert row.submitted_at == CREATED_AT
+    assert first_review_at is None
 
 
 def test_unapproval_system_note_maps_to_changes_requested():
@@ -58,7 +67,7 @@ def test_unapproval_system_note_maps_to_changes_requested():
             "created_at": "2026-01-02T09:30:00Z",
         }
     ]
-    reviews = map_gitlab_mr_reviews(
+    reviews, first_review_at = map_gitlab_mr_reviews(
         repo_id=REPO_ID, number=42, approvals=None, notes=notes
     )
 
@@ -67,6 +76,7 @@ def test_unapproval_system_note_maps_to_changes_requested():
     assert reviews[0].reviewer == "bob"
     assert reviews[0].review_id == "note-100"
     assert reviews[0].submitted_at == datetime(2026, 1, 2, 9, 30, tzinfo=timezone.utc)
+    assert first_review_at == datetime(2026, 1, 2, 9, 30, tzinfo=timezone.utc)
 
 
 def test_human_comment_note_maps_to_commented():
@@ -79,7 +89,7 @@ def test_human_comment_note_maps_to_commented():
             "created_at": "2026-01-03T08:00:00Z",
         }
     ]
-    reviews = map_gitlab_mr_reviews(
+    reviews, _ = map_gitlab_mr_reviews(
         repo_id=REPO_ID, number=42, approvals=None, notes=notes
     )
 
@@ -98,12 +108,78 @@ def test_approve_system_note_maps_to_approved():
             "created_at": "2026-01-04T10:00:00Z",
         }
     ]
-    reviews = map_gitlab_mr_reviews(
+    reviews, first_review_at = map_gitlab_mr_reviews(
         repo_id=REPO_ID, number=42, approvals=None, notes=notes
     )
 
     assert len(reviews) == 1
     assert reviews[0].state == "APPROVED"
+    assert first_review_at == datetime(2026, 1, 4, 10, 0, tzinfo=timezone.utc)
+
+
+def test_approval_endpoint_and_matching_note_yield_one_review():
+    """Regression (CHAOS-2378): an approval that appears in BOTH the approvals
+    endpoint AND the approval system note must count once, with the note's real
+    timestamp -- not be double-counted nor stamped at MR creation time."""
+    approvals = _approvals(("alice", 7))
+    notes = [
+        {
+            "id": 300,
+            "system": True,
+            "body": "approved this merge request",
+            "author": {"username": "alice"},
+            "created_at": "2026-01-04T10:00:00Z",
+        }
+    ]
+
+    reviews, first_review_at = map_gitlab_mr_reviews(
+        repo_id=REPO_ID,
+        number=42,
+        approvals=approvals,
+        notes=notes,
+        fallback_at=CREATED_AT,
+    )
+
+    # Exactly one APPROVED row for alice's single approval event.
+    assert len(reviews) == 1
+    row = reviews[0]
+    assert row.state == "APPROVED"
+    assert row.reviewer == "alice"
+    assert row.review_id == "note-300"  # the timestamped note wins
+    # first_review_at is the real approval time, never the MR-created fallback.
+    assert first_review_at == datetime(2026, 1, 4, 10, 0, tzinfo=timezone.utc)
+    assert first_review_at != CREATED_AT
+
+
+def test_approvals_endpoint_backfills_only_unmatched_approvers():
+    """An approver present in the endpoint but absent from the notes (e.g.
+    truncated note page) is still recorded -- once -- with no real timestamp."""
+    approvals = _approvals(("alice", 7), ("bob", 8))
+    notes = [
+        {
+            "id": 300,
+            "system": True,
+            "body": "approved this merge request",
+            "author": {"username": "alice"},
+            "created_at": "2026-01-04T10:00:00Z",
+        }
+    ]
+
+    reviews, first_review_at = map_gitlab_mr_reviews(
+        repo_id=REPO_ID,
+        number=42,
+        approvals=approvals,
+        notes=notes,
+        fallback_at=CREATED_AT,
+    )
+
+    by_reviewer = {r.reviewer: r for r in reviews}
+    assert set(by_reviewer) == {"alice", "bob"}
+    assert by_reviewer["alice"].review_id == "note-300"
+    assert by_reviewer["bob"].review_id == "approval-8"
+    assert by_reviewer["bob"].submitted_at == CREATED_AT  # fallback for storage
+    # Only the real note timestamp drives first_review_at; bob's fallback does not.
+    assert first_review_at == datetime(2026, 1, 4, 10, 0, tzinfo=timezone.utc)
 
 
 def test_non_review_system_notes_are_ignored():
@@ -123,11 +199,12 @@ def test_non_review_system_notes_are_ignored():
             "created_at": "2026-01-05T10:01:00Z",
         },
     ]
-    reviews = map_gitlab_mr_reviews(
+    reviews, first_review_at = map_gitlab_mr_reviews(
         repo_id=REPO_ID, number=42, approvals=None, notes=notes
     )
 
     assert reviews == []
+    assert first_review_at is None
 
 
 def test_combined_payload_yields_all_expected_rows():
@@ -155,7 +232,7 @@ def test_combined_payload_yields_all_expected_rows():
             "created_at": "2026-01-02T11:00:00Z",
         },
     ]
-    reviews = map_gitlab_mr_reviews(
+    reviews, first_review_at = map_gitlab_mr_reviews(
         repo_id=REPO_ID,
         number=42,
         approvals=approvals,
@@ -166,11 +243,13 @@ def test_combined_payload_yields_all_expected_rows():
     by_state = sorted(r.state for r in reviews)
     assert by_state == ["APPROVED", "CHANGES_REQUESTED", "COMMENTED"]
     assert all(r.repo_id == REPO_ID and r.number == 42 for r in reviews)
+    # Earliest real event is bob's unapproval note.
+    assert first_review_at == datetime(2026, 1, 2, 9, 30, tzinfo=timezone.utc)
 
 
 def test_empty_payloads_yield_no_rows():
-    assert map_gitlab_mr_reviews(REPO_ID, 42, None, None) == []
-    assert map_gitlab_mr_reviews(REPO_ID, 42, {"approved_by": []}, []) == []
+    assert map_gitlab_mr_reviews(REPO_ID, 42, None, None) == ([], None)
+    assert map_gitlab_mr_reviews(REPO_ID, 42, {"approved_by": []}, []) == ([], None)
 
 
 def test_fetch_calls_rest_endpoints_and_maps():
@@ -189,7 +268,7 @@ def test_fetch_calls_rest_endpoints_and_maps():
         }
     ]
 
-    reviews = _fetch_gitlab_mr_reviews(
+    fetched = _fetch_gitlab_mr_reviews(
         connector=connector,
         project_id=99,
         mr={"iid": 42},
@@ -199,7 +278,9 @@ def test_fetch_calls_rest_endpoints_and_maps():
 
     connector.rest_client.get_merge_request_approvals.assert_called_once_with(99, 42)
     connector.rest_client.get_merge_request_notes.assert_called_once_with(99, 42)
-    assert sorted(r.state for r in reviews) == ["APPROVED", "COMMENTED"]
+    assert fetched.known is True
+    assert sorted(r.state for r in fetched.reviews) == ["APPROVED", "COMMENTED"]
+    assert fetched.first_review_at == datetime(2026, 1, 3, 8, 0, tzinfo=timezone.utc)
 
 
 def test_fetch_is_resilient_to_missing_approvals_endpoint():
@@ -208,7 +289,7 @@ def test_fetch_is_resilient_to_missing_approvals_endpoint():
     connector.rest_client.get_merge_request_approvals.side_effect = Exception("404")
     connector.rest_client.get_merge_request_notes.return_value = []
 
-    reviews = _fetch_gitlab_mr_reviews(
+    fetched = _fetch_gitlab_mr_reviews(
         connector=connector,
         project_id=99,
         mr={"iid": 42},
@@ -216,17 +297,235 @@ def test_fetch_is_resilient_to_missing_approvals_endpoint():
         created_at=CREATED_AT,
     )
 
-    assert reviews == []  # no crash, empty result
+    # Notes are authoritative and succeeded (empty) -> known, no reviews.
+    assert fetched.known is True
+    assert fetched.reviews == []
+    assert fetched.first_review_at is None
+
+
+def test_fetch_notes_failure_reports_unknown():
+    """Regression (CHAOS-2378): when the authoritative notes call fails, the
+    result is flagged unknown so the caller will NOT zero out review metrics."""
+    connector = Mock()
+    connector.rest_client.get_merge_request_approvals.return_value = _approvals(
+        ("alice", 7)
+    )
+    connector.rest_client.get_merge_request_notes.side_effect = Exception("timeout")
+
+    fetched = _fetch_gitlab_mr_reviews(
+        connector=connector,
+        project_id=99,
+        mr={"iid": 42},
+        repo_id=REPO_ID,
+        created_at=CREATED_AT,
+    )
+
+    assert fetched.known is False
+    assert fetched.reviews == []
+    assert fetched.first_review_at is None
+    assert fetched.changes_requested_count == 0
 
 
 def test_fetch_skips_mr_without_iid():
     connector = Mock()
-    reviews = _fetch_gitlab_mr_reviews(
+    fetched = _fetch_gitlab_mr_reviews(
         connector=connector,
         project_id=99,
         mr={},
         repo_id=REPO_ID,
         created_at=CREATED_AT,
     )
-    assert reviews == []
+    assert fetched.reviews == []
+    assert fetched.known is True
     connector.rest_client.get_merge_request_approvals.assert_not_called()
+
+
+# --- Live-path tests: drive _sync_gitlab_mrs_to_store (the prod entrypoint) ---
+
+
+class _FakeSink:
+    """Captures rows written through the IngestionSink seam."""
+
+    def __init__(self):
+        self.prs = []
+        self.reviews = []
+
+    def insert_git_pull_requests(self, batch):
+        self.prs.extend(batch)
+
+        async def _noop():
+            return None
+
+        return _noop()
+
+    def insert_git_pull_request_reviews(self, batch):
+        self.reviews.extend(batch)
+
+        async def _noop():
+            return None
+
+        return _noop()
+
+
+def _make_connector(mrs_page, approvals_by_iid, notes_by_iid):
+    """Build a Mock GitLab connector whose REST client returns the given data."""
+    connector = Mock()
+    connector.per_page = 100
+
+    pages = {1: mrs_page}
+
+    def _get_merge_requests(*, project_id, state, page, per_page, order_by, sort):
+        return pages.get(page, [])
+
+    connector.rest_client.get_merge_requests.side_effect = _get_merge_requests
+
+    def _approvals_for(project_id, iid):
+        val = approvals_by_iid.get(iid)
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+    def _notes_for(project_id, iid):
+        val = notes_by_iid.get(iid)
+        if isinstance(val, Exception):
+            raise val
+        return val or []
+
+    connector.rest_client.get_merge_request_approvals.side_effect = _approvals_for
+    connector.rest_client.get_merge_request_notes.side_effect = _notes_for
+    return connector
+
+
+def _run_sync(connector):
+    import asyncio
+
+    sink = _FakeSink()
+
+    async def _driver():
+        loop = asyncio.get_running_loop()
+        # _sync_gitlab_mrs_to_store is blocking; run it off-loop so its
+        # run_coroutine_threadsafe writes can complete against this loop.
+        return await loop.run_in_executor(
+            None,
+            lambda: _sync_gitlab_mrs_to_store(
+                connector,
+                99,  # project_id
+                REPO_ID,
+                cast(IngestionSink, sink),
+                loop,
+                50,  # batch_size
+            ),
+        )
+
+    total = asyncio.run(_driver())
+    return total, sink
+
+
+def test_live_sync_approved_mr_counts_once_with_real_timestamp():
+    """End-to-end through the prod entrypoint: an approved MR (endpoint + note)
+    yields one review row and a real (note) first_review_at, not double counts
+    nor an MR-created timestamp."""
+    mr = {
+        "iid": 42,
+        "title": "Add feature",
+        "description": "desc",
+        "state": "merged",
+        "author": {"username": "author"},
+        "created_at": "2026-01-01T12:00:00Z",
+        "updated_at": "2026-01-05T12:00:00Z",
+        "merged_at": "2026-01-04T11:00:00Z",
+        "source_branch": "feat",
+        "target_branch": "main",
+        "user_notes_count": 1,
+    }
+    connector = _make_connector(
+        mrs_page=[mr],
+        approvals_by_iid={42: _approvals(("alice", 7))},
+        notes_by_iid={
+            42: [
+                {
+                    "id": 300,
+                    "system": True,
+                    "body": "approved this merge request",
+                    "author": {"username": "alice"},
+                    "created_at": "2026-01-04T10:00:00Z",
+                }
+            ]
+        },
+    )
+
+    total, sink = _run_sync(connector)
+
+    assert total == 1
+    assert len(sink.prs) == 1
+    pr = sink.prs[0]
+    assert pr.reviews_count == 1  # not double-counted
+    assert pr.changes_requested_count == 0
+    assert pr.first_review_at == datetime(2026, 1, 4, 10, 0, tzinfo=timezone.utc)
+    assert len(sink.reviews) == 1
+    assert sink.reviews[0].state == "APPROVED"
+
+
+def test_live_sync_notes_failure_does_not_persist_zeroed_pr():
+    """End-to-end: a notes-fetch failure must NOT persist a PR row with zeroed
+    review metrics (which ReplacingMergeTree would use to clobber prior data)."""
+    mr = {
+        "iid": 42,
+        "title": "Add feature",
+        "description": "desc",
+        "state": "merged",
+        "author": {"username": "author"},
+        "created_at": "2026-01-01T12:00:00Z",
+        "updated_at": "2026-01-05T12:00:00Z",
+        "merged_at": "2026-01-04T11:00:00Z",
+        "source_branch": "feat",
+        "target_branch": "main",
+        "user_notes_count": 1,
+    }
+    connector = _make_connector(
+        mrs_page=[mr],
+        approvals_by_iid={42: _approvals(("alice", 7))},
+        notes_by_iid={42: TimeoutError("notes endpoint down")},
+    )
+
+    total, sink = _run_sync(connector)
+
+    # The MR is not counted and no PR/review row is written this cycle, so the
+    # existing (previously-correct) row is preserved untouched.
+    assert total == 0
+    assert sink.prs == []
+    assert sink.reviews == []
+
+
+def test_live_sync_mr_with_no_reviews_persists_zero_counts():
+    """A genuinely review-less MR (notes succeed, empty) still persists with
+    explicit zero counts -- this is the legitimate 'no reviews' case, distinct
+    from the failure case above."""
+    mr = {
+        "iid": 43,
+        "title": "Chore",
+        "description": "",
+        "state": "opened",
+        "author": {"username": "author"},
+        "created_at": "2026-01-01T12:00:00Z",
+        "updated_at": "2026-01-05T12:00:00Z",
+        "merged_at": None,
+        "source_branch": "chore",
+        "target_branch": "main",
+        "user_notes_count": 0,
+    }
+    connector = _make_connector(
+        mrs_page=[mr],
+        approvals_by_iid={43: {"approved_by": []}},
+        notes_by_iid={43: []},
+    )
+
+    total, sink = _run_sync(connector)
+
+    assert total == 1
+    assert len(sink.prs) == 1
+    pr = sink.prs[0]
+    assert pr.reviews_count == 0
+    assert pr.changes_requested_count == 0
+    assert pr.first_review_at is None
+    assert sink.reviews == []

--- a/tests/test_gitlab_mr_reviews.py
+++ b/tests/test_gitlab_mr_reviews.py
@@ -19,12 +19,15 @@ import pytest
 import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models.git import GitPullRequestReview
+from dev_health_ops.processors import gitlab as gitlab_processor
 from dev_health_ops.processors.gitlab import (
+    BatchGitLabMrSyncError,
     PartialGitLabMrSyncError,
     _fetch_all_mr_notes,
     _fetch_gitlab_mr_reviews,
     _sync_gitlab_mrs_to_store,
     map_gitlab_mr_reviews,
+    process_gitlab_projects_batch,
 )
 
 REPO_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
@@ -992,3 +995,199 @@ def test_live_sync_unapproval_does_not_inflate_changes_requested_count():
     # ...but the unapproval is NOT a request for changes: zero rework pressure.
     assert pr.changes_requested_count == 0
     assert all(r.state != "CHANGES_REQUESTED" for r in sink.reviews)
+
+
+# ---------------------------------------------------------------------------
+# Batch/group path: a degraded MR fetch must not look like a successful sync
+# (CHAOS-2378 round 4).
+# ---------------------------------------------------------------------------
+
+
+class _FakeBatchSink:
+    """Captures rows written by the batch store_result seam."""
+
+    def __init__(self, store):
+        self.store = store
+        self.repos = []
+
+    async def insert_repo(self, repo):
+        self.repos.append(repo)
+
+
+class _FakeProjectInfo:
+    def __init__(self, project_id, full_name):
+        self.id = project_id
+        self.full_name = full_name
+        self.url = f"https://gitlab.com/{full_name}"
+        self.default_branch = "main"
+
+
+class _FakeBatchConnector:
+    """Stands in for GitLabConnector inside process_gitlab_projects_batch for
+    the non-async, list-projects path."""
+
+    def __init__(self, projects, **_kwargs):
+        self._projects = projects
+        self.closed = False
+
+    def _get_projects_for_processing(self, *, group_name, pattern, max_repos):
+        return list(self._projects)
+
+    def close(self):
+        self.closed = True
+
+
+def _patch_batch(monkeypatch, projects, sync_behavior):
+    """Wire process_gitlab_projects_batch to fakes.
+
+    ``sync_behavior`` maps project_id -> either an int (success) or a
+    PartialGitLabMrSyncError instance to raise from _sync_gitlab_mrs_to_store.
+    """
+    monkeypatch.setattr(
+        gitlab_processor,
+        "GitLabConnector",
+        lambda **kw: _FakeBatchConnector(projects, **kw),
+    )
+    monkeypatch.setattr(gitlab_processor, "IngestionSink", _FakeBatchSink)
+    monkeypatch.setattr(gitlab_processor, "CONNECTORS_AVAILABLE", True)
+
+    calls: list[int] = []
+
+    def _fake_sync_mrs(
+        connector, project_id, repo_id, sink, loop, batch_size, state, gate, since
+    ):
+        calls.append(project_id)
+        outcome = sync_behavior[project_id]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(gitlab_processor, "_sync_gitlab_mrs_to_store", _fake_sync_mrs)
+    return calls
+
+
+_BATCH_PRS_ONLY: dict[str, Any] = dict(
+    sync_git=False,
+    sync_prs=True,
+    sync_cicd=False,
+    sync_deployments=False,
+    sync_incidents=False,
+    sync_security=False,
+    sync_tests=False,
+    backfill_missing=False,
+    use_async=False,
+)
+
+
+def test_batch_degraded_mr_fetch_raises_and_does_not_report_success(monkeypatch):
+    """A single degraded project in a group sync must NOT let the batch return
+    normally: process_gitlab_projects_batch raises BatchGitLabMrSyncError so the
+    caller (sync_gitlab_target) marks the run failed and retries, instead of
+    advancing the watermark past the skipped MRs (CHAOS-2378 round 4)."""
+    projects = [
+        _FakeProjectInfo(1, "group/healthy"),
+        _FakeProjectInfo(2, "group/degraded"),
+    ]
+    calls = _patch_batch(
+        monkeypatch,
+        projects,
+        sync_behavior={
+            1: 5,  # 5 MRs synced fine
+            2: PartialGitLabMrSyncError([42, 43], project_id=2),
+        },
+    )
+
+    store = Mock()
+    with pytest.raises(BatchGitLabMrSyncError) as exc_info:
+        asyncio.run(
+            process_gitlab_projects_batch(
+                store=store,
+                token="tok",
+                group_name="group",
+                pattern="*",
+                **_BATCH_PRS_ONLY,
+            )
+        )
+
+    # Both projects were attempted (the degraded one did not abort the batch).
+    assert set(calls) == {1, 2}
+    # The aggregate error carries the degraded project's partial failure so the
+    # skipped iids are surfaced, not lost.
+    assert [e.project_id for e in exc_info.value.errors] == [2]
+    assert exc_info.value.errors[0].skipped_iids == [42, 43]
+
+
+def test_batch_flushes_healthy_repos_before_raising(monkeypatch):
+    """Healthy projects' repo rows are still written even when a later project
+    degrades — the batch keeps flushing good work, then raises (CHAOS-2378)."""
+    projects = [
+        _FakeProjectInfo(1, "group/healthy-a"),
+        _FakeProjectInfo(2, "group/degraded"),
+        _FakeProjectInfo(3, "group/healthy-b"),
+    ]
+    _patch_batch(
+        monkeypatch,
+        projects,
+        sync_behavior={
+            1: 1,
+            2: PartialGitLabMrSyncError([99], project_id=2),
+            3: 1,
+        },
+    )
+
+    captured_sinks: list[_FakeBatchSink] = []
+    real_sink_cls = _FakeBatchSink
+
+    def _capturing_sink(store):
+        sink = real_sink_cls(store)
+        captured_sinks.append(sink)
+        return sink
+
+    monkeypatch.setattr(gitlab_processor, "IngestionSink", _capturing_sink)
+
+    store = Mock()
+    with pytest.raises(BatchGitLabMrSyncError):
+        asyncio.run(
+            process_gitlab_projects_batch(
+                store=store,
+                token="tok",
+                group_name="group",
+                pattern="*",
+                max_concurrent=1,  # deterministic ordering
+                **_BATCH_PRS_ONLY,
+            )
+        )
+
+    # All three projects' repo rows were flushed (healthy work preserved); the
+    # degraded project's repo still inserts because the partial error is raised
+    # AFTER the MR flush, not before the repo upsert.
+    assert len(captured_sinks) == 1
+    stored = {repo.repo for repo in captured_sinks[0].repos}
+    assert stored == {"group/healthy-a", "group/degraded", "group/healthy-b"}
+
+
+def test_batch_all_healthy_returns_success(monkeypatch):
+    """Guard against over-raising: a batch where every project syncs cleanly must
+    return normally (None) so the caller reports success (CHAOS-2378)."""
+    projects = [
+        _FakeProjectInfo(1, "group/a"),
+        _FakeProjectInfo(2, "group/b"),
+    ]
+    _patch_batch(
+        monkeypatch,
+        projects,
+        sync_behavior={1: 3, 2: 4},
+    )
+
+    store = Mock()
+    # Must NOT raise.
+    result = asyncio.run(
+        process_gitlab_projects_batch(
+            store=store,
+            token="tok",
+            group_name="group",
+            pattern="*",
+            **_BATCH_PRS_ONLY,
+        )
+    )
+    assert result is None

--- a/tests/test_gitlab_mr_reviews.py
+++ b/tests/test_gitlab_mr_reviews.py
@@ -5,10 +5,13 @@ Proves the seam that wires GitLab approvals + MR notes into
 review-latency / /ai/review-load populate for GitLab orgs. No live API or DB.
 """
 
+import asyncio
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 from unittest.mock import Mock
+
+import pytest
 
 # Initialize the connectors package before processors to avoid the
 # pre-existing providers._base <-> connectors circular import when this file
@@ -17,6 +20,7 @@ import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models.git import GitPullRequestReview
 from dev_health_ops.processors.gitlab import (
+    PartialGitLabMrSyncError,
     _fetch_all_mr_notes,
     _fetch_gitlab_mr_reviews,
     _sync_gitlab_mrs_to_store,
@@ -58,7 +62,10 @@ def test_approval_maps_to_approved_state_and_org_scope():
     assert first_review_at is None
 
 
-def test_unapproval_system_note_maps_to_changes_requested():
+def test_unapproval_system_note_maps_to_dismissed_not_changes_requested():
+    """Revoking an approval is NOT an explicit request-changes event. It must map
+    to DISMISSED (on the timeline) and never inflate changes_requested_count /
+    review-load rework signals (CHAOS-2378 round 3)."""
     notes = [
         {
             "id": 100,
@@ -73,7 +80,10 @@ def test_unapproval_system_note_maps_to_changes_requested():
     )
 
     assert len(reviews) == 1
-    assert reviews[0].state == "CHANGES_REQUESTED"
+    assert reviews[0].state == "DISMISSED"
+    # Crucially NOT changes-requested: rework/review-load signals only count
+    # genuine CHANGES_REQUESTED, so an unapproval contributes zero.
+    assert reviews[0].state != "CHANGES_REQUESTED"
     assert reviews[0].reviewer == "bob"
     assert reviews[0].review_id == "note-100"
     assert reviews[0].submitted_at == datetime(2026, 1, 2, 9, 30, tzinfo=timezone.utc)
@@ -309,9 +319,11 @@ def test_combined_payload_yields_all_expected_rows():
     )
 
     by_state = sorted(r.state for r in reviews)
-    assert by_state == ["APPROVED", "CHANGES_REQUESTED", "COMMENTED"]
+    assert by_state == ["APPROVED", "COMMENTED", "DISMISSED"]
+    # No unapproval is ever counted as a request for changes.
+    assert all(r.state != "CHANGES_REQUESTED" for r in reviews)
     assert all(r.repo_id == REPO_ID and r.number == 42 for r in reviews)
-    # Earliest real event is bob's unapproval note.
+    # Earliest real event is bob's unapproval (now DISMISSED) note.
     assert first_review_at == datetime(2026, 1, 2, 9, 30, tzinfo=timezone.utc)
 
 
@@ -473,9 +485,7 @@ def _make_connector(mrs_page, approvals_by_iid, notes_by_iid):
     return connector
 
 
-def _run_sync(connector):
-    import asyncio
-
+def _run_sync(connector, since=None):
     sink = _FakeSink()
 
     async def _driver():
@@ -491,6 +501,9 @@ def _run_sync(connector):
                 cast(IngestionSink, sink),
                 loop,
                 50,  # batch_size
+                "all",  # state
+                None,  # gate
+                since,
             ),
         )
 
@@ -543,9 +556,15 @@ def test_live_sync_approved_mr_counts_once_with_real_timestamp():
     assert sink.reviews[0].state == "APPROVED"
 
 
-def test_live_sync_notes_failure_does_not_persist_zeroed_pr():
+def test_live_sync_notes_failure_does_not_persist_zeroed_pr_and_fails_loud():
     """End-to-end: a notes-fetch failure must NOT persist a PR row with zeroed
-    review metrics (which ReplacingMergeTree would use to clobber prior data)."""
+    review metrics (which ReplacingMergeTree would use to clobber prior data),
+    AND must NOT report success — otherwise the per-target watermark advances
+    past this MR and strands it until a full resync (CHAOS-2378 round 3).
+
+    The fix raises a retryable PartialGitLabMrSyncError so the run is marked
+    FAILED, the watermark is held, and Celery retries the project.
+    """
     mr = {
         "iid": 42,
         "title": "Add feature",
@@ -565,13 +584,165 @@ def test_live_sync_notes_failure_does_not_persist_zeroed_pr():
         notes_by_iid={42: TimeoutError("notes endpoint down")},
     )
 
-    total, sink = _run_sync(connector)
+    with pytest.raises(PartialGitLabMrSyncError) as exc_info:
+        _run_sync(connector)
 
-    # The MR is not counted and no PR/review row is written this cycle, so the
-    # existing (previously-correct) row is preserved untouched.
-    assert total == 0
-    assert sink.prs == []
-    assert sink.reviews == []
+    # The skip is surfaced loudly with the affected iid so it cannot be lost.
+    assert exc_info.value.skipped_iids == [42]
+    assert exc_info.value.project_id == 99
+    # Retryable (non-terminal): a plain RuntimeError, not ValueError/Terminal.
+    assert isinstance(exc_info.value, RuntimeError)
+    assert not isinstance(exc_info.value, ValueError)
+
+
+def test_live_sync_partial_failure_flushes_good_rows_before_raising():
+    """A degraded MR in a multi-MR page must not discard the successfully
+    fetched MRs: their PR/review rows are flushed before the raise (the re-run
+    is idempotent via ReplacingMergeTree), so we never lose good work nor
+    silently advance the watermark (CHAOS-2378 round 3)."""
+    good_mr = {
+        "iid": 41,
+        "title": "Good MR",
+        "description": "desc",
+        "state": "merged",
+        "author": {"username": "author"},
+        "created_at": "2026-01-01T12:00:00Z",
+        "updated_at": "2026-01-06T12:00:00Z",
+        "merged_at": "2026-01-04T11:00:00Z",
+        "source_branch": "feat",
+        "target_branch": "main",
+        "user_notes_count": 1,
+    }
+    bad_mr = {
+        "iid": 42,
+        "title": "Degraded MR",
+        "description": "desc",
+        "state": "merged",
+        "author": {"username": "author"},
+        "created_at": "2026-01-01T12:00:00Z",
+        "updated_at": "2026-01-05T12:00:00Z",
+        "merged_at": "2026-01-04T11:00:00Z",
+        "source_branch": "feat2",
+        "target_branch": "main",
+        "user_notes_count": 1,
+    }
+    connector = _make_connector(
+        # Page ordered updated_at desc: good MR (41) first, then degraded (42).
+        mrs_page=[good_mr, bad_mr],
+        approvals_by_iid={41: {"approved_by": []}, 42: {"approved_by": []}},
+        notes_by_iid={
+            41: [
+                {
+                    "id": 300,
+                    "system": True,
+                    "body": "approved this merge request",
+                    "author": {"username": "alice"},
+                    "created_at": "2026-01-04T10:00:00Z",
+                }
+            ],
+            42: TimeoutError("notes endpoint down"),
+        },
+    )
+
+    sink = _FakeSink()
+
+    async def _driver():
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: _sync_gitlab_mrs_to_store(
+                connector,
+                99,
+                REPO_ID,
+                cast(IngestionSink, sink),
+                loop,
+                50,
+            ),
+        )
+
+    with pytest.raises(PartialGitLabMrSyncError) as exc_info:
+        asyncio.run(_driver())
+
+    # The good MR (41) is persisted; the degraded MR (42) is not.
+    assert [pr.number for pr in sink.prs] == [41]
+    assert {r.number for r in sink.reviews} == {41}
+    assert exc_info.value.skipped_iids == [42]
+
+
+def test_live_sync_degraded_mr_not_skipped_by_since_after_held_watermark():
+    """Regression proving the stranding is closed end-to-end: because a degraded
+    run does NOT advance the watermark (it raises), the next incremental run's
+    ``since`` stays BELOW the degraded MR's ``updated_at`` and re-attempts it —
+    it is not filtered out by the ``updated_at < since`` early-stop. Here the
+    retry's notes succeed and the MR is finally persisted (CHAOS-2378 round 3)."""
+    updated_at = "2026-01-05T12:00:00Z"
+    mr = {
+        "iid": 42,
+        "title": "Add feature",
+        "description": "desc",
+        "state": "merged",
+        "author": {"username": "author"},
+        "created_at": "2026-01-01T12:00:00Z",
+        "updated_at": updated_at,
+        "merged_at": "2026-01-04T11:00:00Z",
+        "source_branch": "feat",
+        "target_branch": "main",
+        "user_notes_count": 1,
+    }
+    # The watermark that WOULD have been set had the first (degraded) run
+    # wrongly reported success: just after the MR's updated_at. Since the run
+    # raised, this watermark is NOT persisted, so the real ``since`` remains the
+    # PRIOR (older) watermark below.
+    prior_watermark = datetime(2026, 1, 4, 0, 0, tzinfo=timezone.utc)
+    would_be_advanced = datetime(2026, 1, 5, 12, 0, tzinfo=timezone.utc) + timedelta(
+        minutes=1
+    )
+
+    # 1. First run: notes down -> raises, no watermark advance.
+    connector_fail = _make_connector(
+        mrs_page=[mr],
+        approvals_by_iid={42: {"approved_by": []}},
+        notes_by_iid={42: TimeoutError("notes endpoint down")},
+    )
+    with pytest.raises(PartialGitLabMrSyncError):
+        _run_sync(connector_fail, since=prior_watermark)
+
+    # 2. Next run uses the UNADVANCED (prior) watermark as ``since``. The MR's
+    #    updated_at is >= since, so it is NOT filtered out; notes now succeed.
+    connector_ok = _make_connector(
+        mrs_page=[mr],
+        approvals_by_iid={42: {"approved_by": []}},
+        notes_by_iid={
+            42: [
+                {
+                    "id": 300,
+                    "system": True,
+                    "body": "approved this merge request",
+                    "author": {"username": "alice"},
+                    "created_at": "2026-01-04T10:00:00Z",
+                }
+            ]
+        },
+    )
+    total, sink = _run_sync(connector_ok, since=prior_watermark)
+
+    # Re-attempted and persisted on the retry — not stranded.
+    assert total == 1
+    assert [pr.number for pr in sink.prs] == [42]
+    assert sink.prs[0].reviews_count == 1
+
+    # Sanity: had the watermark wrongly advanced past the MR, the MR would have
+    # been filtered by the ``updated_at < since`` early-stop and never synced.
+    connector_stranded = _make_connector(
+        mrs_page=[mr],
+        approvals_by_iid={42: {"approved_by": []}},
+        notes_by_iid={42: []},
+    )
+    total_stranded, sink_stranded = _run_sync(
+        connector_stranded, since=would_be_advanced
+    )
+    assert total_stranded == 0
+    assert sink_stranded.prs == []
 
 
 def test_live_sync_mr_with_no_reviews_persists_zero_counts():
@@ -764,3 +935,60 @@ def test_live_sync_generic_notes_are_not_counted_as_reviews():
     assert pr.first_review_at is None
     assert pr.comments_count == 3  # generic chatter stays here
     assert sink.reviews == []
+
+
+def test_live_sync_unapproval_does_not_inflate_changes_requested_count():
+    """End-to-end regression (CHAOS-2378 round 3): a reviewer revoking their
+    approval (GitLab 'unapproved' system note) must NOT increment
+    changes_requested_count — only a genuine request-changes event should drive
+    rework/review-load pressure. The unapproval is recorded as DISMISSED on the
+    timeline (reviews_count includes it) but is excluded from the rework count.
+    """
+    mr = {
+        "iid": 46,
+        "title": "Approved then unapproved",
+        "description": "desc",
+        "state": "opened",
+        "author": {"username": "author"},
+        "created_at": "2026-01-01T12:00:00Z",
+        "updated_at": "2026-01-05T12:00:00Z",
+        "merged_at": None,
+        "source_branch": "feat",
+        "target_branch": "main",
+        "user_notes_count": 0,
+    }
+    notes = [
+        {
+            "id": 500,
+            "system": True,
+            "body": "approved this merge request",
+            "author": {"username": "bob"},
+            "created_at": "2026-01-02T09:00:00Z",
+        },
+        {
+            "id": 501,
+            "system": True,
+            "body": "unapproved this merge request",
+            "author": {"username": "bob"},
+            "created_at": "2026-01-02T09:30:00Z",
+        },
+    ]
+    connector = _make_connector(
+        mrs_page=[mr],
+        # Net approvals state is empty (bob revoked); the unapproval is the
+        # later authoritative note.
+        approvals_by_iid={46: {"approved_by": []}},
+        notes_by_iid={46: notes},
+    )
+
+    total, sink = _run_sync(connector)
+
+    assert total == 1
+    pr = sink.prs[0]
+    # Both the approval and the dismissal are on the review timeline...
+    assert pr.reviews_count == 2
+    states = sorted(r.state for r in sink.reviews)
+    assert states == ["APPROVED", "DISMISSED"]
+    # ...but the unapproval is NOT a request for changes: zero rework pressure.
+    assert pr.changes_requested_count == 0
+    assert all(r.state != "CHANGES_REQUESTED" for r in sink.reviews)

--- a/tests/test_processors_pr_mr_rate_limit.py
+++ b/tests/test_processors_pr_mr_rate_limit.py
@@ -4,6 +4,10 @@ from typing import Any, cast
 
 import pytest
 
+# Initialize the connectors package before processors to avoid the
+# pre-existing providers._base <-> connectors circular import when this file
+# is collected in isolation (mirrors tests/test_deployment_pr_inference.py).
+import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.processors.github import _sync_github_prs_to_store
 from dev_health_ops.processors.gitlab import _sync_gitlab_mrs_to_store
 
@@ -183,6 +187,15 @@ async def test_gitlab_mr_sync_retries_on_retry_after_and_persists():
                         "author": {"username": "alice"},
                     }
                 ]
+            return []
+
+        # MR-review reconstruction (CHAOS-2378) calls these per in-window MR.
+        # This test exercises rate-limit retry on get_merge_requests, not
+        # reviews, so they return empty (the legitimate "no reviews" path).
+        def get_merge_request_approvals(self, project_id, iid):
+            return {"approved_by": []}
+
+        def get_merge_request_notes(self, project_id, iid):
             return []
 
     class _Connector:

--- a/tests/test_processors_pr_mr_rate_limit.py
+++ b/tests/test_processors_pr_mr_rate_limit.py
@@ -195,7 +195,9 @@ async def test_gitlab_mr_sync_retries_on_retry_after_and_persists():
         def get_merge_request_approvals(self, project_id, iid):
             return {"approved_by": []}
 
-        def get_merge_request_notes(self, project_id, iid):
+        def get_merge_request_notes(
+            self, project_id, iid, page=1, per_page=100, **_kwargs
+        ):
             return []
 
     class _Connector:


### PR DESCRIPTION
Ingests GitLab MR approvals + review notes into git_pull_request_reviews (GitHub parity) so review-load, reviewer-concentration, review_edges_daily and PR review-latency populate for GitLab orgs. Approvals are de-duplicated; transient note-fetch failures do not overwrite existing reviews or permanently skip MRs (incremental AND batch paths); unapprovals are not mis-counted as changes-requested.

Part of CHAOS-2372. Closes CHAOS-2378.

> Branch forked at 667dc5b5; origin/main has since advanced. Rebase onto origin/main before merge (3-way merge is safe; a 2-dot diff shows unrelated main commits as spurious deletions). Reviewed across 4 adversarial rounds (in-workflow reviewer + Codex /codex:adversarial-review); tenant-isolation, no-silent-loss and correctness all verified. Gates: ruff + full-package mypy + pytest green.
