### PR TITLE
feat(gitlab): live MR AI attribution + repo-scoped ai_attribution dedup (CHAOS-2379)

### DIFF
--- a/src/dev_health_ops/metrics/dependencies.py
+++ b/src/dev_health_ops/metrics/dependencies.py
@@ -129,6 +129,14 @@ class GitLabClientProtocol(Protocol):
         updated_after: datetime | None = None,
     ) -> Iterable[Any]: ...
 
+    def iter_project_merge_requests(
+        self,
+        *,
+        project_id_or_path: str,
+        state: str = "all",
+        updated_after: datetime | None = None,
+    ) -> Iterable[Any]: ...
+
 
 class GitLabClientFactory(Protocol):
     def __call__(self) -> GitLabClientProtocol: ...

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -285,15 +285,17 @@ def run_work_items_sync_job(
                 transitions.extend(list(proj_tr or []))
 
         if "gitlab" in provider_set:
-            items, tr = fetch_gitlab_work_items(
+            items, tr, gl_ai_attributions = fetch_gitlab_work_items(
                 repos=discovered_repos,
                 since=since_dt,
                 status_mapping=status_mapping,
                 identity=identity,
                 include_label_events=True,
+                org_id=org_id,
             )
             work_items.extend(items)
             transitions.extend(tr)
+            ai_attributions.extend(gl_ai_attributions)
 
         if "synthetic" in provider_set:
             from dev_health_ops.metrics.work_items import fetch_synthetic_work_items

--- a/src/dev_health_ops/metrics/sinks/clickhouse/ai_attribution.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/ai_attribution.py
@@ -2,7 +2,9 @@
 AIAttributionMixin — ClickHouse write methods for AI attribution records.
 
 Table: ai_attribution (ReplacingMergeTree, ORDER BY (org_id, provider, subject_type, subject_id, source))
-View:  ai_attribution_resolved (plain VIEW resolving highest-precedence record per subject)
+View:  ai_attribution_resolved (plain VIEW resolving highest-precedence record per
+       (org_id, subject_type, repo_id, subject_id) — repo_id is part of the key
+       because PR/MR subject ids are repo-local, see migration 043)
 
 Write-time: every detected signal is persisted raw; dedup is by the ORDER BY key.
 Read-time:  query ai_attribution_resolved for the effective attribution.

--- a/src/dev_health_ops/metrics/sinks/clickhouse/ai_attribution.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/ai_attribution.py
@@ -1,12 +1,14 @@
 """
 AIAttributionMixin — ClickHouse write methods for AI attribution records.
 
-Table: ai_attribution (ReplacingMergeTree, ORDER BY (org_id, provider, subject_type, subject_id, source))
+Table: ai_attribution (ReplacingMergeTree, ORDER BY (org_id, provider, subject_type, repo_id, subject_id, source))
 View:  ai_attribution_resolved (plain VIEW resolving highest-precedence record per
        (org_id, subject_type, repo_id, subject_id) — repo_id is part of the key
-       because PR/MR subject ids are repo-local, see migration 043)
+       because PR/MR subject ids are repo-local, see migrations 043/044)
 
 Write-time: every detected signal is persisted raw; dedup is by the ORDER BY key.
+repo_id sits in the dedup key (migration 044) so two repos in one org that share
+a bare repo-local subject_id (e.g. both have MR !1) never collapse into one row.
 Read-time:  query ai_attribution_resolved for the effective attribution.
 
 Implementation note
@@ -107,8 +109,8 @@ class AIAttributionMixin(_ClickHouseSinkBase):
         Persist AI attribution records to ClickHouse.
 
         Idempotent: re-inserting the same (org_id, provider, subject_type,
-        subject_id, source) tuple with a later computed_at will supersede the
-        previous row via ReplacingMergeTree(computed_at).
+        repo_id, subject_id, source) tuple with a later computed_at will
+        supersede the previous row via ReplacingMergeTree(computed_at).
 
         Args:
             records:    Sequence of AIAttributionRecord to persist.

--- a/src/dev_health_ops/metrics/work_items.py
+++ b/src/dev_health_ops/metrics/work_items.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from dev_health_ops.metrics.dependencies import get_metrics_dependencies
+from dev_health_ops.models.ai_attribution import AIAttributionRecord
 from dev_health_ops.models.work_items import (
     Sprint,
     WorkItem,
@@ -430,17 +431,40 @@ def fetch_gitlab_work_items(
     identity: IdentityResolver,
     include_label_events: bool = True,
     max_label_events: int = 300,
-) -> tuple[list[WorkItem], list[WorkItemStatusTransition]]:
+    org_id: str = "",
+) -> tuple[
+    list[WorkItem],
+    list[WorkItemStatusTransition],
+    list[AIAttributionRecord],
+]:
     """
     Fetch GitLab issues updated since `since` for the given projects and normalize into WorkItems.
 
+    Also scans merge requests updated since `since` for AI attribution signals
+    (labels, bot authors, commit trailers in the description, branch names) and
+    returns them as :class:`AIAttributionRecord` so the work-items sync job can
+    persist GitLab governance coverage through the SAME ``write_ai_attribution``
+    sink path used by GitHub (CHAOS-2379). Attribution detection is the only
+    reason MRs are fetched here; their work items continue to be produced by the
+    provider path, so this scan does not duplicate MR work-item rows.
+
+    Attribution rows are written with the caller's real ``org_id`` and are
+    skipped entirely when ``org_id`` is blank (a CLI-only run with no tenant
+    scope) so a blank-tenant row is never persisted.
+
     Requires `GITLAB_TOKEN` and optional `GITLAB_URL`.
     """
+    from uuid import UUID
+
+    from dev_health_ops.providers.gitlab.normalize import gitlab_mr_ai_attributions
+    from dev_health_ops.providers.utils import env_flag
+
     deps = get_metrics_dependencies()
 
     client = deps.gitlab_client_factory()
     work_items: dict[str, WorkItem] = {}
     transitions: list[WorkItemStatusTransition] = []
+    ai_attributions: list[AIAttributionRecord] = []
 
     since_utc = to_utc(since)
     gitlab_repos = [r for r in repos if r.source == "gitlab"]
@@ -449,6 +473,9 @@ def fetch_gitlab_work_items(
         len(gitlab_repos),
         since_utc.isoformat(),
     )
+    # AI attribution requires a tenant scope and the MR-attribution feature.
+    org_uuid = UUID(org_id) if org_id else None
+    scan_mrs = org_uuid is not None and env_flag("GITLAB_INCLUDE_MRS", True)
     for repo in repos:
         if repo.source != "gitlab":
             continue
@@ -479,9 +506,33 @@ def fetch_gitlab_work_items(
             work_items[wi.work_item_id] = wi
             transitions.extend(list(_transitions or []))
 
+        if scan_mrs:
+            assert org_uuid is not None  # for type checker; guarded by scan_mrs
+            try:
+                for mr in client.iter_project_merge_requests(
+                    project_id_or_path=repo.full_name,
+                    state="all",
+                    updated_after=since_utc,
+                ):
+                    ai_attributions.extend(
+                        gitlab_mr_ai_attributions(
+                            mr=mr,
+                            project_full_path=repo.full_name,
+                            org_id=org_uuid,
+                            repo_id=repo.repo_id,
+                        )
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "GitLab: failed to scan MRs for AI attribution in %s: %s",
+                    repo.full_name,
+                    exc,
+                )
+
     logger.info(
-        "Fetched %d GitLab work items (since %s)",
+        "Fetched %d GitLab work items (since %s); %d AI attribution record(s)",
         len(work_items),
         since_utc.isoformat(),
+        len(ai_attributions),
     )
-    return list(work_items.values()), transitions
+    return list(work_items.values()), transitions, ai_attributions

--- a/src/dev_health_ops/migrations/clickhouse/035_ai_attribution.sql
+++ b/src/dev_health_ops/migrations/clickhouse/035_ai_attribution.sql
@@ -37,6 +37,11 @@ SETTINGS index_granularity = 8192;
 -- Resolved view: pick the highest-precedence, non-superseded record per
 -- (org_id, subject_type, subject_id) using window functions.
 --
+-- NOTE: migration 043 REPLACES this view to add `repo_id` to the partition
+-- key (PR/MR subject ids are repo-local, so two repos sharing PR #1 must each
+-- resolve independently — CHAOS-2379). The definition below is the original
+-- and the live view is whatever 043 last applied.
+--
 -- Implemented as a plain VIEW (not an incremental MV) because precedence
 -- resolution requires visibility across all rows for a subject, which
 -- incremental ClickHouse MVs cannot provide.  The base table uses

--- a/src/dev_health_ops/migrations/clickhouse/043_ai_attribution_resolved_repo_scope.sql
+++ b/src/dev_health_ops/migrations/clickhouse/043_ai_attribution_resolved_repo_scope.sql
@@ -1,0 +1,62 @@
+-- Migration 043: repo-scope the ai_attribution_resolved view (CHAOS-2379).
+--
+-- The view in migration 035 resolved one row per (org_id, subject_type,
+-- subject_id). That key is NOT globally unique: `subject_id` is the bare
+-- provider PR/MR number (`toString(git_pull_requests.number)`), and PR/MR
+-- numbers are only unique WITHIN a repository. GitLab MR `iid` and GitHub PR
+-- `number` both restart at 1 per repo, so two repos in the same org that each
+-- have PR/MR #1 produced two base rows but the view's
+-- `PARTITION BY org_id, subject_type, subject_id` collapsed them to ONE,
+-- keeping a single winning `repo_id`. Every downstream read path
+-- (audit/ai_governance/loaders, metrics/loaders/ai_impact,
+-- metrics/opportunities/ai_detector) joins `attr.repo_id = pr.repo_id`, so the
+-- dropped repo's MR/PR silently disappeared from AI governance coverage and
+-- impact — the second repo's attribution row never matched any PR.
+--
+-- Fix: add `repo_id` to the resolution partition so each repository's PR/MR
+-- attribution resolves independently. Records are still cross-source
+-- precedence-resolved, but now per (org_id, subject_type, repo_id,
+-- subject_id). `repo_id` is Nullable, so repo-less work-item-level
+-- attributions (repo_id IS NULL) form their own partition group and are NOT
+-- collapsed against repo-pinned rows that happen to share a subject_id.
+--
+-- This is a metadata-only view redefinition. The base `ai_attribution` table
+-- is unchanged and no data is rewritten.
+
+CREATE OR REPLACE VIEW ai_attribution_resolved AS
+SELECT
+    record_id,
+    org_id,
+    provider,
+    subject_type,
+    subject_id,
+    repo_id,
+    kind,
+    source,
+    confidence,
+    actor,
+    evidence,
+    observed_at,
+    ingested_at,
+    superseded_by,
+    computed_at
+FROM (
+    SELECT
+        *,
+        multiIf(
+            source = 'manual',          1,
+            source = 'pr_label',        2,
+            source = 'bot_author',      3,
+            source = 'commit_trailer',  4,
+            source = 'ci_annotation',   5,
+            source = 'branch_name',     6,
+            source = 'pr_body',         7,
+            8
+        ) AS _source_priority
+    FROM ai_attribution FINAL
+    WHERE superseded_by IS NULL
+)
+QUALIFY ROW_NUMBER() OVER (
+    PARTITION BY org_id, subject_type, repo_id, subject_id
+    ORDER BY _source_priority ASC, confidence DESC
+) = 1;

--- a/src/dev_health_ops/migrations/clickhouse/044_ai_attribution_repo_id_dedup_key.sql
+++ b/src/dev_health_ops/migrations/clickhouse/044_ai_attribution_repo_id_dedup_key.sql
@@ -1,0 +1,119 @@
+-- Migration 044: add repo_id to the ai_attribution base-table dedup key (CHAOS-2379).
+--
+-- Migration 035 created ai_attribution as
+--   ENGINE = ReplacingMergeTree(computed_at)
+--   ORDER BY (org_id, provider, subject_type, subject_id, source)
+-- The ORDER BY tuple is the ReplacingMergeTree dedup key. repo_id was NOT in it.
+--
+-- subject_id is the bare, repo-local provider PR/MR number
+-- (toString(git_pull_requests.number) == GitLab MR iid == GitHub PR number),
+-- which is only unique WITHIN a repository. This branch is the first live
+-- writer of GitLab MR attributions with subject_id = str(mr.iid). Two GitLab
+-- repos in ONE org that each have MR !1 labeled ai-assisted from the SAME
+-- source therefore produce IDENTICAL dedup keys
+-- (org_id, provider, subject_type, subject_id, source). Under
+-- ReplacingMergeTree FINAL (ai_attribution_resolved reads FROM ai_attribution
+-- FINAL) one repo's row is PERMANENTLY collapsed at the base table BEFORE
+-- migration 043's repo-scoped view ever runs. 043 fixes the read-time view
+-- partition but cannot resurrect a base row that the engine already merged
+-- away. Net: silent cross-repo AI-attribution loss.
+--
+-- Fix: rebuild ai_attribution with repo_id in the ORDER BY, placed BEFORE
+-- subject_id, so each repository's PR/MR attribution dedups independently:
+--   ORDER BY (org_id, provider, subject_type, repo_id, subject_id, source)
+-- The dedup version column (computed_at) is preserved unchanged.
+--
+-- Backward compatibility: GitLab ai_attribution is empty in prod (this branch
+-- is its first writer) and GitHub uses a PREFIXED subject_id
+-- (ghpr:{repo}#{number}), which never collides across repos, so this rebuild
+-- loses no real data. repo_id stays Nullable(UUID) and repo-less
+-- (work-item-level) rows keep repo_id NULL and form their own dedup group.
+--
+-- repo_id is the FIRST Nullable column to appear in this table's ORDER BY
+-- (migration 035's sorting key was all non-Nullable), so the rebuilt table
+-- MUST set allow_nullable_key = 1 or ClickHouse rejects the CREATE with
+-- "Sorting key cannot contain nullable columns" (same pattern as migration
+-- 007's investment_velocity_daily). The setting is harmless and preserves the
+-- NULL-repo dedup group as its own sort-key bucket.
+--
+-- subject_id deliberately stays the bare iid (round-2 pinned this so the
+-- governance loader join a.subject_id = toString(pr.number) keeps working).
+-- The base-table ORDER BY is the correct lever, not the subject_id shape.
+--
+-- Rebuild uses the standard ClickHouse RMT-key-change pattern:
+--   0. DROP any leftover _new table from a prior partial run, so the CREATE
+--      below never silently appends INTO stale data (CREATE IF NOT EXISTS
+--      would otherwise no-op and the INSERT would target the old rows).
+--   1. CREATE the _new table with the corrected ORDER BY.
+--   2. INSERT all rows (explicit column list, exact 035 order).
+--   3. EXCHANGE TABLES (atomic on the Atomic db engine) so readers never see
+--      a missing table, then DROP the old table now parked under _new.
+-- The migration runner (storage/clickhouse.py) splits this file on the
+-- statement separator and skips comment-only chunks. Every statement below is
+-- a single clean separator-terminated statement, and no separator character
+-- appears inside any comment line (a stray one would corrupt the split).
+
+DROP TABLE IF EXISTS ai_attribution_new;
+
+CREATE TABLE IF NOT EXISTS ai_attribution_new
+(
+    record_id      UUID,
+    org_id         UUID,
+    provider       LowCardinality(String),
+    subject_type   LowCardinality(String),
+    subject_id     String,
+    repo_id        Nullable(UUID),
+    kind           LowCardinality(String),
+    source         LowCardinality(String),
+    confidence     Float32,
+    actor          Nullable(String),
+    evidence       String,
+    observed_at    DateTime64(3, 'UTC'),
+    ingested_at    DateTime64(3, 'UTC'),
+    superseded_by  Nullable(UUID),
+    computed_at    DateTime64(3, 'UTC') DEFAULT now64()
+)
+ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(observed_at)
+ORDER BY (org_id, provider, subject_type, repo_id, subject_id, source)
+SETTINGS index_granularity = 8192, allow_nullable_key = 1;
+
+INSERT INTO ai_attribution_new
+(
+    record_id,
+    org_id,
+    provider,
+    subject_type,
+    subject_id,
+    repo_id,
+    kind,
+    source,
+    confidence,
+    actor,
+    evidence,
+    observed_at,
+    ingested_at,
+    superseded_by,
+    computed_at
+)
+SELECT
+    record_id,
+    org_id,
+    provider,
+    subject_type,
+    subject_id,
+    repo_id,
+    kind,
+    source,
+    confidence,
+    actor,
+    evidence,
+    observed_at,
+    ingested_at,
+    superseded_by,
+    computed_at
+FROM ai_attribution;
+
+EXCHANGE TABLES ai_attribution AND ai_attribution_new;
+
+DROP TABLE IF EXISTS ai_attribution_new;

--- a/src/dev_health_ops/models/ai_attribution.py
+++ b/src/dev_health_ops/models/ai_attribution.py
@@ -7,7 +7,7 @@ and the full *record* persisted to ClickHouse.
 Source precedence (highest → lowest):
     MANUAL > PR_LABEL > BOT_AUTHOR > COMMIT_TRAILER > CI_ANNOTATION > BRANCH_NAME > PR_BODY
 
-Write-time: persist every detected signal, deduped on (subject, source).
+Write-time: persist every detected signal, deduped on (repo, subject, source).
 Read-time:  the ``ai_attribution_resolved`` view resolves the effective attribution.
 """
 
@@ -104,7 +104,10 @@ class AIAttributionRecord:
     read time via the ``ai_attribution_resolved`` view.
 
     Deduplication key (ClickHouse ORDER BY):
-        (org_id, provider, subject_type, subject_id, source)
+        (org_id, provider, subject_type, repo_id, subject_id, source)
+        repo_id is part of the key (migration 044) because subject_id is the
+        bare repo-local PR/MR number — two repos in one org sharing a subject_id
+        would otherwise collapse into one row under ReplacingMergeTree.
 
     Supersession:
         When a MANUAL record is created, ``superseded_by`` on earlier records

--- a/src/dev_health_ops/providers/gitlab/normalize.py
+++ b/src/dev_health_ops/providers/gitlab/normalize.py
@@ -873,6 +873,16 @@ def gitlab_mr_ai_attributions(
     high-severity "missing review" governance violations (CHAOS-2379 round-2).
     The synthetic fixtures use the same ``str(pr.number)`` contract.
 
+    GitLab MR ``iid`` (and GitHub PR ``number``) is only unique WITHIN a repo,
+    so two repos in one org can both carry attribution for ``subject_id="1"``.
+    The bare-iid join is safe because EVERY read path additionally constrains
+    ``attr.repo_id = pr.repo_id`` and the ``ai_attribution_resolved`` view
+    resolves per ``(org_id, subject_type, repo_id, subject_id)`` (migration
+    043, CHAOS-2379 round-3) — both repos' rows survive the resolve and each
+    matches only its own repo's PR. ``repo_id`` therefore disambiguates the
+    repo-local id; we do NOT repo-qualify ``subject_id`` itself (that would
+    break the ``toString(pr.number)`` join used by every loader).
+
     ``observed_at`` is a real provider timestamp — never a fabricated
     ingest-time value — derived from the MR's ``created_at``, falling back to
     the MR ``updated_at`` and only then to ``now()`` when the provider omits
@@ -898,6 +908,10 @@ def gitlab_mr_ai_attributions(
     # `git_pull_requests.number = int(mr.iid)`. The subject id MUST therefore be
     # the bare iid string — a prefixed `gitlab:{path}!{iid}` work-item id would
     # never join and would fabricate "missing review" policy failures.
+    # iid is repo-local; cross-repo collisions are disambiguated by repo_id in
+    # every read-path join AND in the ai_attribution_resolved partition
+    # (migration 043), so both repos' rows survive — see this function's
+    # docstring (CHAOS-2379 round-3).
     subject_id = str(iid)
     observed_at = (
         _to_utc(_parse_iso(_get(mr, "created_at")))

--- a/src/dev_health_ops/providers/gitlab/normalize.py
+++ b/src/dev_health_ops/providers/gitlab/normalize.py
@@ -6,6 +6,10 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from uuid import UUID
 
+from dev_health_ops.models.ai_attribution import (
+    AIAttributionRecord,
+    AIAttributionSignal,
+)
 from dev_health_ops.models.work_items import (
     Sprint,
     WorkItem,
@@ -14,6 +18,14 @@ from dev_health_ops.models.work_items import (
     WorkItemReopenEvent,
     WorkItemStatusCategory,
     WorkItemStatusTransition,
+)
+from dev_health_ops.providers._ai_detection import (
+    AuthorInfo,
+    detect_from_author,
+    detect_from_branch_name,
+    detect_from_commit_trailers,
+    detect_from_pr_body,
+    detect_from_pr_labels,
 )
 from dev_health_ops.providers.identity import IdentityResolver
 from dev_health_ops.providers.normalize_common import (
@@ -753,15 +765,6 @@ def build_epic_id_for_issue(
 # ---------------------------------------------------------------------------
 # AI attribution detection — wired into the GitLab normalize path
 # ---------------------------------------------------------------------------
-from dev_health_ops.providers._ai_detection import (  # noqa: E402
-    AIAttributionSignal,
-    AuthorInfo,
-    detect_from_author,
-    detect_from_branch_name,
-    detect_from_commit_trailers,
-    detect_from_pr_body,
-    detect_from_pr_labels,
-)
 
 
 def detect_mr_attributions(
@@ -842,3 +845,61 @@ def detect_mr_attributions(
             signals.append(body_signal)
 
     return signals
+
+
+def gitlab_mr_ai_attributions(
+    *,
+    mr: object,
+    project_full_path: str,
+    org_id: UUID,
+    repo_id: UUID | None,
+) -> list[AIAttributionRecord]:
+    """Promote a GitLab MR's AI attribution signals to persisted records.
+
+    This is the single mapping from a merge request to
+    :class:`AIAttributionRecord` so that BOTH ingestion paths — the live
+    ``metrics.work_items.fetch_gitlab_work_items`` sync entrypoint and
+    :class:`GitLabProvider` — emit byte-identical records into
+    ``ai_governance_coverage_daily`` via ``write_ai_attribution``.
+
+    ``subject_id`` and ``observed_at`` are derived from the SAME canonical
+    formula used by :func:`gitlab_mr_to_work_item` (``gitlab:{path}!{iid}`` and
+    the MR's ``created_at``) so attribution rows join cleanly to MR work items.
+    ``observed_at`` is a real provider timestamp — never a fabricated
+    ingest-time value — falling back to the MR ``updated_at`` and only then to
+    ``now()`` when the provider omits both.
+
+    Args:
+        mr: GitLab merge request object (REST attribute object or dict).
+        project_full_path: Project path used to build the canonical subject id.
+        org_id: Owning organization (tenant scope) — required; records are
+            never written with a blank tenant.
+        repo_id: Repository UUID for this project (may be ``None``).
+
+    Returns:
+        List of :class:`AIAttributionRecord` (may be empty).
+    """
+    signals = detect_mr_attributions(mr=mr)
+    if not signals:
+        return []
+
+    iid = int(_get(mr, "iid") or 0)
+    subject_id = f"gitlab:{project_full_path}!{iid}"  # ! for MRs
+    observed_at = (
+        _to_utc(_parse_iso(_get(mr, "created_at")))
+        or _to_utc(_parse_iso(_get(mr, "updated_at")))
+        or datetime.now(timezone.utc)
+    )
+
+    return [
+        AIAttributionRecord.from_signal(
+            sig,
+            org_id=org_id,
+            provider="gitlab",
+            subject_type="pull_request",
+            subject_id=subject_id,
+            repo_id=repo_id,
+            observed_at=observed_at,
+        )
+        for sig in signals
+    ]

--- a/src/dev_health_ops/providers/gitlab/normalize.py
+++ b/src/dev_health_ops/providers/gitlab/normalize.py
@@ -862,12 +862,21 @@ def gitlab_mr_ai_attributions(
     :class:`GitLabProvider` — emit byte-identical records into
     ``ai_governance_coverage_daily`` via ``write_ai_attribution``.
 
-    ``subject_id`` and ``observed_at`` are derived from the SAME canonical
-    formula used by :func:`gitlab_mr_to_work_item` (``gitlab:{path}!{iid}`` and
-    the MR's ``created_at``) so attribution rows join cleanly to MR work items.
+    ``subject_id`` is the bare MR ``iid`` as a string (``str(iid)``) — the
+    SAME shape the governance/impact read paths join against, where
+    ``ai_attribution.subject_id = toString(git_pull_requests.number)`` and the
+    GitLab processor stores ``git_pull_requests.number = int(mr.iid)`` (see
+    :mod:`dev_health_ops.processors.gitlab` and
+    :mod:`dev_health_ops.audit.ai_governance.loaders`). A prefixed work-item id
+    such as ``gitlab:{path}!{iid}`` would NEVER match that join, leaving
+    ``human_reviewed`` NULL for every GitLab AI MR and fabricating
+    high-severity "missing review" governance violations (CHAOS-2379 round-2).
+    The synthetic fixtures use the same ``str(pr.number)`` contract.
+
     ``observed_at`` is a real provider timestamp — never a fabricated
-    ingest-time value — falling back to the MR ``updated_at`` and only then to
-    ``now()`` when the provider omits both.
+    ingest-time value — derived from the MR's ``created_at``, falling back to
+    the MR ``updated_at`` and only then to ``now()`` when the provider omits
+    both.
 
     Args:
         mr: GitLab merge request object (REST attribute object or dict).
@@ -884,7 +893,12 @@ def gitlab_mr_ai_attributions(
         return []
 
     iid = int(_get(mr, "iid") or 0)
-    subject_id = f"gitlab:{project_full_path}!{iid}"  # ! for MRs
+    # Governance/impact loaders join `ai_attribution.subject_id =
+    # toString(git_pull_requests.number)`, and the GitLab processor stores
+    # `git_pull_requests.number = int(mr.iid)`. The subject id MUST therefore be
+    # the bare iid string — a prefixed `gitlab:{path}!{iid}` work-item id would
+    # never join and would fabricate "missing review" policy failures.
+    subject_id = str(iid)
     observed_at = (
         _to_utc(_parse_iso(_get(mr, "created_at")))
         or _to_utc(_parse_iso(_get(mr, "updated_at")))

--- a/src/dev_health_ops/providers/gitlab/normalize.py
+++ b/src/dev_health_ops/providers/gitlab/normalize.py
@@ -748,3 +748,97 @@ def build_epic_id_for_issue(
 
     epic_group = _get(epic, "group_id") or group_full_path
     return f"gitlab:{epic_group}:epic:{epic_iid}"
+
+
+# ---------------------------------------------------------------------------
+# AI attribution detection — wired into the GitLab normalize path
+# ---------------------------------------------------------------------------
+from dev_health_ops.providers._ai_detection import (  # noqa: E402
+    AIAttributionSignal,
+    AuthorInfo,
+    detect_from_author,
+    detect_from_branch_name,
+    detect_from_commit_trailers,
+    detect_from_pr_body,
+    detect_from_pr_labels,
+)
+
+
+def detect_mr_attributions(
+    *,
+    mr: object,
+) -> list[AIAttributionSignal]:
+    """Detect all AI attribution signals from a GitLab merge request.
+
+    Mirrors :func:`providers.github.normalize.detect_pr_attributions` so the
+    SAME downstream write path (``ProviderBatch.ai_attributions`` →
+    ``write_ai_attribution``) persists GitLab attribution into
+    ``ai_governance_coverage_daily``.
+
+    Runs every provider-agnostic detector and returns the full list of raw
+    signals.  Signals are not collapsed — all are returned for raw
+    persistence; precedence is resolved at read time by the storage layer.
+
+    Sources checked (in precedence order, but all persisted regardless):
+        1. MR labels (highest confidence)
+        2. MR author (bot detection)
+        3. Commit trailers in MR description (squash merges expose them here)
+        4. MR source branch name (weak)
+        5. MR description body (weak)
+
+    Note on commit-level trailers:
+        Full commit message traversal requires an extra API call and is not
+        wired here — the normalize path receives the MR object only.  Squash
+        workflows typically surface commit trailers in the MR description.
+
+    Args:
+        mr: GitLab merge request object (REST attribute object or dict).
+
+    Returns:
+        List of :class:`AIAttributionSignal` objects (may be empty).
+    """
+    signals: list[AIAttributionSignal] = []
+
+    # 1. MR labels (GitLab labels are plain strings)
+    labels = [str(lbl) for lbl in (_get(mr, "labels") or []) if lbl]
+    signals.extend(detect_from_pr_labels(labels))
+
+    # 2. MR author (GitLab user objects expose ``username``/``name``; bots set
+    #    ``bot=True`` rather than GitHub's ``type``/``app_slug``).
+    author_obj = _get(mr, "author")
+    if author_obj is not None:
+        login = str(_get(author_obj, "username") or "")
+        if login:
+            is_bot = bool(_get(author_obj, "bot"))
+            author_signal = detect_from_author(
+                AuthorInfo(
+                    login=login,
+                    user_type="Bot" if is_bot else None,
+                    app_slug=None,
+                )
+            )
+            if author_signal is not None:
+                signals.append(author_signal)
+
+    # 3. Commit trailers from MR description
+    #    Squash/rebase merges often surface commit messages in the description.
+    description = str(_get(mr, "description") or "")
+    signals.extend(detect_from_commit_trailers(description))
+
+    # 4. Source branch name (weak signal)
+    source_branch = _get(mr, "source_branch")
+    if source_branch:
+        branch_signal = detect_from_branch_name(str(source_branch))
+        if branch_signal is not None:
+            signals.append(branch_signal)
+
+    # 5. MR description text (keyword matching — weak signal)
+    #    Only run if a trailer signal hasn't already fired from the same text
+    #    (avoids double-counting the same description body).
+    trailer_fired = any(s.source.value == "commit_trailer" for s in signals)
+    if not trailer_fired and description:
+        body_signal = detect_from_pr_body(description)
+        if body_signal is not None:
+            signals.append(body_signal)
+
+    return signals

--- a/src/dev_health_ops/providers/gitlab/provider.py
+++ b/src/dev_health_ops/providers/gitlab/provider.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import replace
-from datetime import datetime
+from datetime import datetime, timezone
 
+from dev_health_ops.models.ai_attribution import AIAttributionRecord
 from dev_health_ops.models.work_items import (
     Sprint,
     WorkItem,
@@ -84,6 +85,7 @@ class GitLabProvider(ProviderWithClient[GitLabWorkClient]):
         from dev_health_ops.providers.gitlab.normalize import (
             build_epic_id_for_issue,
             detect_gitlab_reopen_events,
+            detect_mr_attributions,
             enrich_work_item_with_priority,
             extract_gitlab_dependencies,
             gitlab_epic_to_work_item,
@@ -103,6 +105,7 @@ class GitLabProvider(ProviderWithClient[GitLabWorkClient]):
         reopen_events: list[WorkItemReopenEvent] = []
         interactions: list[WorkItemInteractionEvent] = []
         sprints: list[Sprint] = []
+        ai_attributions: list[AIAttributionRecord] = []
 
         include_mrs = _env_flag("GITLAB_INCLUDE_MRS", True)
         fetch_notes = _env_flag("GITLAB_FETCH_NOTES", True)
@@ -367,6 +370,36 @@ class GitLabProvider(ProviderWithClient[GitLabWorkClient]):
                         )
                     )
 
+                    # Detect AI attribution signals for this MR.
+                    # Each signal is converted to a full AIAttributionRecord
+                    # so the SAME downstream write path as GitHub persists them.
+                    mr_signals = detect_mr_attributions(mr=mr)
+                    if mr_signals:
+                        if ctx.org_id is None:
+                            raise ValueError(
+                                "GitLab AI attribution requires ctx.org_id"
+                            )
+                        # wi.created_at is already normalized to UTC by
+                        # gitlab_mr_to_work_item.
+                        _observed = wi.created_at or datetime.now(timezone.utc)
+                        for _sig in mr_signals:
+                            ai_attributions.append(
+                                AIAttributionRecord.from_signal(
+                                    _sig,
+                                    org_id=ctx.org_id,
+                                    provider="gitlab",
+                                    subject_type="pull_request",
+                                    subject_id=wi.work_item_id,
+                                    repo_id=ctx.repo_id,
+                                    observed_at=_observed,
+                                )
+                            )
+                        logger.debug(
+                            "GitLab: detected %d AI attribution signal(s) for %s",
+                            len(mr_signals),
+                            wi.work_item_id,
+                        )
+
                     # Get notes for interactions
                     if fetch_notes:
                         try:
@@ -400,6 +433,12 @@ class GitLabProvider(ProviderWithClient[GitLabWorkClient]):
             sum(1 for w in work_items if "!" in w.work_item_id),
             project_path,
         )
+        if ai_attributions:
+            logger.info(
+                "GitLab: emitting %d AI attribution record(s) from %s",
+                len(ai_attributions),
+                project_path,
+            )
 
         return ProviderBatch(
             work_items=work_items,
@@ -408,4 +447,5 @@ class GitLabProvider(ProviderWithClient[GitLabWorkClient]):
             interactions=interactions,
             sprints=sprints,
             reopen_events=reopen_events,
+            ai_attributions=ai_attributions,
         )

--- a/src/dev_health_ops/providers/gitlab/provider.py
+++ b/src/dev_health_ops/providers/gitlab/provider.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import replace
-from datetime import datetime, timezone
+from datetime import datetime
 
 from dev_health_ops.models.ai_attribution import AIAttributionRecord
 from dev_health_ops.models.work_items import (
@@ -85,12 +85,12 @@ class GitLabProvider(ProviderWithClient[GitLabWorkClient]):
         from dev_health_ops.providers.gitlab.normalize import (
             build_epic_id_for_issue,
             detect_gitlab_reopen_events,
-            detect_mr_attributions,
             enrich_work_item_with_priority,
             extract_gitlab_dependencies,
             gitlab_epic_to_work_item,
             gitlab_issue_to_work_item,
             gitlab_milestone_to_sprint,
+            gitlab_mr_ai_attributions,
             gitlab_mr_to_work_item,
             gitlab_note_to_interaction_event,
         )
@@ -370,35 +370,24 @@ class GitLabProvider(ProviderWithClient[GitLabWorkClient]):
                         )
                     )
 
-                    # Detect AI attribution signals for this MR.
-                    # Each signal is converted to a full AIAttributionRecord
-                    # so the SAME downstream write path as GitHub persists them.
-                    mr_signals = detect_mr_attributions(mr=mr)
-                    if mr_signals:
-                        if ctx.org_id is None:
-                            raise ValueError(
-                                "GitLab AI attribution requires ctx.org_id"
-                            )
-                        # wi.created_at is already normalized to UTC by
-                        # gitlab_mr_to_work_item.
-                        _observed = wi.created_at or datetime.now(timezone.utc)
-                        for _sig in mr_signals:
-                            ai_attributions.append(
-                                AIAttributionRecord.from_signal(
-                                    _sig,
-                                    org_id=ctx.org_id,
-                                    provider="gitlab",
-                                    subject_type="pull_request",
-                                    subject_id=wi.work_item_id,
-                                    repo_id=ctx.repo_id,
-                                    observed_at=_observed,
-                                )
-                            )
-                        logger.debug(
-                            "GitLab: detected %d AI attribution signal(s) for %s",
-                            len(mr_signals),
-                            wi.work_item_id,
+                    # Detect AI attribution signals for this MR and promote
+                    # them to records via the shared normalize helper, so this
+                    # provider path and the live fetch_gitlab_work_items sync
+                    # path emit byte-identical records to write_ai_attribution.
+                    if ctx.org_id is not None:
+                        mr_records = gitlab_mr_ai_attributions(
+                            mr=mr,
+                            project_full_path=project_path,
+                            org_id=ctx.org_id,
+                            repo_id=ctx.repo_id,
                         )
+                        if mr_records:
+                            ai_attributions.extend(mr_records)
+                            logger.debug(
+                                "GitLab: detected %d AI attribution signal(s) for %s",
+                                len(mr_records),
+                                wi.work_item_id,
+                            )
 
                     # Get notes for interactions
                     if fetch_notes:

--- a/tests/providers/test_gitlab_ai_attribution.py
+++ b/tests/providers/test_gitlab_ai_attribution.py
@@ -132,8 +132,11 @@ def test_gitlab_mr_ai_attributions_uses_canonical_subject_and_real_timestamp() -
 
     assert records
     rec = records[0]
-    # Subject id matches the canonical gitlab_mr_to_work_item formula ("!" for MRs).
-    assert rec.subject_id == "gitlab:group/widget!42"
+    # Subject id is the bare MR iid string so it joins the governance/impact
+    # read paths (`subject_id = toString(git_pull_requests.number)`), which is
+    # exactly `int(mr.iid)` for GitLab. A prefixed `gitlab:group/widget!42`
+    # would never match and would fabricate "missing review" policy failures.
+    assert rec.subject_id == "42"
     assert rec.org_id == org_id
     assert rec.repo_id == repo_id
     assert rec.provider == "gitlab"
@@ -150,6 +153,50 @@ def test_gitlab_mr_ai_attributions_empty_for_non_ai_mr() -> None:
         repo_id=None,
     )
     assert records == []
+
+
+def test_gitlab_attribution_subject_id_joins_git_pull_requests_number() -> None:
+    """End-to-end JOIN contract (CHAOS-2379 round-2).
+
+    The governance loader (``audit.ai_governance.loaders``) and the impact
+    loader (``metrics.loaders.ai_impact``) resolve ``human_reviewed`` /
+    coverage by joining ``ai_attribution.subject_id = toString(pr.number)``.
+    The GitLab processor stores ``git_pull_requests.number = int(mr["iid"])``.
+    This test reproduces BOTH sides from the SAME merge request and asserts the
+    join equality holds, proving the attribution rows actually match their MR
+    metadata instead of leaving ``human_reviewed`` NULL and fabricating
+    high-severity "missing review" policy violations.
+    """
+    org_id = uuid.uuid4()
+    repo_id = uuid.uuid4()
+    raw_mr: dict[str, Any] = {
+        "iid": 42,
+        "labels": ["ai-assisted"],
+        "author": {"username": "human-author", "name": "human-author"},
+        "description": "normal MR",
+        "source_branch": "feature/human-work",
+        "created_at": "2026-04-17T09:30:00+00:00",
+        "updated_at": "2026-04-17T09:30:00+00:00",
+    }
+
+    # Producer side — exactly what processors.gitlab writes to
+    # git_pull_requests.number for this MR.
+    pr_number = int(raw_mr.get("iid") or 0)
+
+    records = gitlab_mr_ai_attributions(
+        mr=raw_mr,
+        project_full_path="group/widget",
+        org_id=org_id,
+        repo_id=repo_id,
+    )
+
+    assert records
+    # The loader join is `a.subject_id = toString(pr.number)` scoped by repo_id.
+    for rec in records:
+        assert rec.subject_id == str(pr_number)
+        assert rec.repo_id == repo_id  # join is also scoped on a.repo_id = pr.repo_id
+    # Negative guard: the prefixed work-item id shape would NOT join.
+    assert all(rec.subject_id != "gitlab:group/widget!42" for rec in records)
 
 
 # ---------------------------------------------------------------------------
@@ -342,14 +389,10 @@ def test_gitlab_work_items_sync_writes_ai_attribution_with_org_id(
         "bot_author",
         "commit_trailer",
     }
-    # Subject ids use the canonical MR formula.
-    assert any(
-        row.subject_id == "gitlab:group/widget!11" for row in sink.ai_attributions
-    )
+    # Subject ids are the bare MR iid string (joins git_pull_requests.number).
+    assert any(row.subject_id == "11" for row in sink.ai_attributions)
     # The non-AI MR (#14) produced no attribution row.
-    assert not any(
-        row.subject_id == "gitlab:group/widget!14" for row in sink.ai_attributions
-    )
+    assert not any(row.subject_id == "14" for row in sink.ai_attributions)
 
 
 def test_gitlab_work_items_sync_skips_attribution_when_org_blank(

--- a/tests/providers/test_gitlab_ai_attribution.py
+++ b/tests/providers/test_gitlab_ai_attribution.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from dev_health_ops.providers.gitlab.normalize import detect_mr_attributions
+
+
+def _mr(
+    *,
+    labels: list[str] | None = None,
+    author_username: str = "human-author",
+    author_bot: bool = False,
+    description: str = "normal MR",
+    source_branch: str = "feature/human-work",
+) -> SimpleNamespace:
+    """Build a GitLab merge-request-like object for detection tests."""
+    return SimpleNamespace(
+        iid=7,
+        labels=list(labels or []),
+        author=SimpleNamespace(
+            username=author_username,
+            name=author_username,
+            bot=author_bot,
+        ),
+        description=description,
+        source_branch=source_branch,
+    )
+
+
+def test_detect_mr_attributions_from_ai_label() -> None:
+    signals = detect_mr_attributions(mr=_mr(labels=["ai-assisted"]))
+
+    assert any(s.source.value == "pr_label" for s in signals)
+    label_signal = next(s for s in signals if s.source.value == "pr_label")
+    assert label_signal.kind.value == "ai_assisted"
+    assert label_signal.evidence["label"] == "ai-assisted"
+
+
+def test_detect_mr_attributions_from_commit_trailer() -> None:
+    signals = detect_mr_attributions(
+        mr=_mr(description="Implement feature\n\nAI-Assisted-By: Claude Code"),
+    )
+
+    assert any(s.source.value == "commit_trailer" for s in signals)
+    trailer_signal = next(s for s in signals if s.source.value == "commit_trailer")
+    assert trailer_signal.actor == "Claude Code"
+
+
+def test_detect_mr_attributions_from_bot_author() -> None:
+    signals = detect_mr_attributions(
+        mr=_mr(author_username="claude-code[bot]", author_bot=True),
+    )
+
+    assert any(s.source.value == "bot_author" for s in signals)
+    bot_signal = next(s for s in signals if s.source.value == "bot_author")
+    assert bot_signal.kind.value == "agent_created"
+    assert bot_signal.actor == "claude-code[bot]"
+
+
+def test_detect_mr_attributions_from_source_branch() -> None:
+    signals = detect_mr_attributions(
+        mr=_mr(source_branch="copilot/fix-bug"),
+    )
+
+    assert any(s.source.value == "branch_name" for s in signals)
+
+
+def test_detect_mr_attributions_non_ai_mr_emits_none() -> None:
+    signals = detect_mr_attributions(
+        mr=_mr(
+            labels=["bug", "frontend"],
+            author_username="alice",
+            author_bot=False,
+            description="Refactor the widget rendering pipeline.",
+            source_branch="feature/widget-refactor",
+        ),
+    )
+
+    assert signals == []
+
+
+def test_detect_mr_attributions_ci_bot_author_emits_none() -> None:
+    # CI automation bots are explicitly excluded — they are not AI.
+    signals = detect_mr_attributions(
+        mr=_mr(author_username="dependabot[bot]", author_bot=True),
+    )
+
+    assert not any(s.source.value == "bot_author" for s in signals)

--- a/tests/providers/test_gitlab_ai_attribution.py
+++ b/tests/providers/test_gitlab_ai_attribution.py
@@ -1,21 +1,39 @@
 from __future__ import annotations
 
+import dataclasses
+import uuid
+from datetime import date, datetime, timezone
 from types import SimpleNamespace
+from typing import Any
 
-from dev_health_ops.providers.gitlab.normalize import detect_mr_attributions
+import pytest
+
+# Import connectors FIRST to break the providers._base <-> connectors circular
+# import that otherwise ERRORs at collection in isolated runs (see CHAOS-2370).
+import dev_health_ops.connectors  # noqa: F401
+import dev_health_ops.metrics.job_work_items as job
+import dev_health_ops.metrics.work_items as work_items_module
+from dev_health_ops.metrics.work_items import DiscoveredRepo
+from dev_health_ops.models.ai_attribution import AIAttributionRecord
+from dev_health_ops.providers.gitlab.normalize import (
+    detect_mr_attributions,
+    gitlab_mr_ai_attributions,
+)
 
 
 def _mr(
     *,
+    iid: int = 7,
     labels: list[str] | None = None,
     author_username: str = "human-author",
     author_bot: bool = False,
     description: str = "normal MR",
     source_branch: str = "feature/human-work",
+    created_at: datetime | None = None,
 ) -> SimpleNamespace:
     """Build a GitLab merge-request-like object for detection tests."""
     return SimpleNamespace(
-        iid=7,
+        iid=iid,
         labels=list(labels or []),
         author=SimpleNamespace(
             username=author_username,
@@ -24,7 +42,14 @@ def _mr(
         ),
         description=description,
         source_branch=source_branch,
+        created_at=created_at or datetime(2026, 5, 1, 13, tzinfo=timezone.utc),
+        updated_at=created_at or datetime(2026, 5, 1, 13, tzinfo=timezone.utc),
     )
+
+
+# ---------------------------------------------------------------------------
+# Detector unit tests
+# ---------------------------------------------------------------------------
 
 
 def test_detect_mr_attributions_from_ai_label() -> None:
@@ -86,3 +111,266 @@ def test_detect_mr_attributions_ci_bot_author_emits_none() -> None:
     )
 
     assert not any(s.source.value == "bot_author" for s in signals)
+
+
+# ---------------------------------------------------------------------------
+# Record-promotion helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_gitlab_mr_ai_attributions_uses_canonical_subject_and_real_timestamp() -> None:
+    org_id = uuid.uuid4()
+    repo_id = uuid.uuid4()
+    created = datetime(2026, 4, 17, 9, 30, tzinfo=timezone.utc)
+
+    records = gitlab_mr_ai_attributions(
+        mr=_mr(iid=42, labels=["ai-assisted"], created_at=created),
+        project_full_path="group/widget",
+        org_id=org_id,
+        repo_id=repo_id,
+    )
+
+    assert records
+    rec = records[0]
+    # Subject id matches the canonical gitlab_mr_to_work_item formula ("!" for MRs).
+    assert rec.subject_id == "gitlab:group/widget!42"
+    assert rec.org_id == org_id
+    assert rec.repo_id == repo_id
+    assert rec.provider == "gitlab"
+    assert rec.subject_type == "pull_request"
+    # observed_at is the MR's real created_at, never a fabricated ingest time.
+    assert rec.observed_at == created
+
+
+def test_gitlab_mr_ai_attributions_empty_for_non_ai_mr() -> None:
+    records = gitlab_mr_ai_attributions(
+        mr=_mr(),
+        project_full_path="group/widget",
+        org_id=uuid.uuid4(),
+        repo_id=None,
+    )
+    assert records == []
+
+
+# ---------------------------------------------------------------------------
+# Live-path integration test
+#
+# Drives the ACTUAL scheduled work-items sync entrypoint
+# (run_work_items_sync_job -> fetch_gitlab_work_items) with a fake GitLab
+# client and asserts MR-derived AI attribution records reach
+# write_ai_attribution() with the real org_id. This is the seam the prior
+# attempt left broken (records were only emitted from the orphaned
+# GitLabProvider.iter_ingest path, never the legacy GitLab branch).
+# ---------------------------------------------------------------------------
+
+
+class _FakeGitLabClient:
+    """Minimal stand-in for GitLabWorkClient covering the live fetch path."""
+
+    def __init__(self, *, issues: list[Any], mrs: list[Any]) -> None:
+        self._issues = issues
+        self._mrs = mrs
+
+    def iter_project_issues(
+        self, *, project_id_or_path: str, state: str = "all", **_kwargs: Any
+    ) -> list[Any]:
+        return self._issues
+
+    def iter_project_merge_requests(
+        self, *, project_id_or_path: str, state: str = "all", **_kwargs: Any
+    ) -> list[Any]:
+        return self._mrs
+
+
+def _gitlab_issue(iid: int) -> SimpleNamespace:
+    created = datetime(2026, 5, 1, 12, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        iid=iid,
+        title=f"Issue {iid}",
+        description="normal non-AI work",
+        state="opened",
+        created_at=created,
+        updated_at=created,
+        closed_at=None,
+        labels=[],
+        assignees=[],
+        author=SimpleNamespace(username="human", name="human", email=None),
+        web_url=f"https://gitlab.com/group/widget/-/issues/{iid}",
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class _Classification:
+    investment_area: str = "Maintenance / Tech Debt"
+    project_stream: str = ""
+    confidence: float = 1.0
+    rule_id: str = "test"
+
+
+class _Classifier:
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    def classify(self, _payload: object) -> _Classification:
+        return _Classification()
+
+
+class _FakeClickHouseSink:
+    def __init__(self, _dsn: str) -> None:
+        self.org_id = ""
+        self.work_items: list[object] = []
+        self.transitions: list[object] = []
+        self.ai_attributions: list[AIAttributionRecord] = []
+        self.metric_rows: list[object] = []
+
+    def ensure_tables(self) -> None:
+        return None
+
+    def query_dicts(
+        self, _query: str, _params: dict[str, object]
+    ) -> list[dict[str, object]]:
+        return []
+
+    def write_work_items(self, rows: list[object]) -> None:
+        self.work_items.extend(rows)
+
+    def write_work_item_transitions(self, rows: list[object]) -> None:
+        self.transitions.extend(rows)
+
+    def write_ai_attribution(self, rows: list[AIAttributionRecord]) -> None:
+        self.ai_attributions.extend(rows)
+
+    def write_work_item_metrics(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def write_work_item_user_metrics(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def write_work_item_cycle_times(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def write_work_item_state_durations(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def write_issue_type_metrics(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def write_investment_classifications(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def write_investment_metrics(self, rows: list[object]) -> None:
+        self.metric_rows.extend(rows)
+
+    def close(self) -> None:
+        return None
+
+
+def _patch_common(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    sink: _FakeClickHouseSink,
+    repo_id: uuid.UUID,
+    fake_client: _FakeGitLabClient,
+) -> None:
+    monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: sink)
+    monkeypatch.setattr(job, "InvestmentClassifier", _Classifier)
+    monkeypatch.setattr(
+        job, "compute_work_item_metrics_daily", lambda **_kwargs: ([], [], [])
+    )
+    monkeypatch.setattr(
+        job, "compute_work_item_state_durations_daily", lambda **_kwargs: []
+    )
+    monkeypatch.setattr(
+        job,
+        "_discover_repos",
+        lambda **_kwargs: [
+            DiscoveredRepo(
+                repo_id=repo_id,
+                full_name="group/widget",
+                source="gitlab",
+                settings={},
+            )
+        ],
+    )
+
+    # Inject the fake GitLab client at the metrics-dependency seam that
+    # fetch_gitlab_work_items resolves via get_metrics_dependencies().
+    base = work_items_module.get_metrics_dependencies()
+    overridden = dataclasses.replace(base, gitlab_client_factory=lambda: fake_client)
+    monkeypatch.setattr(
+        work_items_module,
+        "get_metrics_dependencies",
+        lambda: overridden,
+    )
+
+
+def test_gitlab_work_items_sync_writes_ai_attribution_with_org_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    org_id = uuid.uuid4()
+    repo_id = uuid.uuid4()
+    sink = _FakeClickHouseSink("clickhouse://test")
+    fake_client = _FakeGitLabClient(
+        issues=[_gitlab_issue(10)],
+        mrs=[
+            _mr(iid=11, labels=["ai-assisted"]),
+            _mr(iid=12, author_username="claude-code[bot]", author_bot=True),
+            _mr(
+                iid=13,
+                description="Implementation details\n\nAI-Assisted-By: Claude Code",
+            ),
+            _mr(iid=14, description="Reviewed and implemented by a human."),
+        ],
+    )
+    _patch_common(monkeypatch, sink=sink, repo_id=repo_id, fake_client=fake_client)
+
+    run_job: Any = job.run_work_items_sync_job
+    run_job(
+        db_url="clickhouse://test",
+        day=date(2026, 5, 2),
+        backfill_days=1,
+        provider="gitlab",
+        org_id=str(org_id),
+    )
+
+    # MR-derived attribution records reached the sink, org-scoped to the real org.
+    assert sink.ai_attributions
+    assert {row.org_id for row in sink.ai_attributions} == {org_id}
+    assert {row.repo_id for row in sink.ai_attributions} == {repo_id}
+    assert {str(row.source) for row in sink.ai_attributions} >= {
+        "pr_label",
+        "bot_author",
+        "commit_trailer",
+    }
+    # Subject ids use the canonical MR formula.
+    assert any(
+        row.subject_id == "gitlab:group/widget!11" for row in sink.ai_attributions
+    )
+    # The non-AI MR (#14) produced no attribution row.
+    assert not any(
+        row.subject_id == "gitlab:group/widget!14" for row in sink.ai_attributions
+    )
+
+
+def test_gitlab_work_items_sync_skips_attribution_when_org_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Without a tenant scope, attribution must NOT be written with a blank org.
+    repo_id = uuid.uuid4()
+    sink = _FakeClickHouseSink("clickhouse://test")
+    fake_client = _FakeGitLabClient(
+        issues=[_gitlab_issue(10)],
+        mrs=[_mr(iid=11, labels=["ai-assisted"])],
+    )
+    _patch_common(monkeypatch, sink=sink, repo_id=repo_id, fake_client=fake_client)
+
+    run_job: Any = job.run_work_items_sync_job
+    run_job(
+        db_url="clickhouse://test",
+        day=date(2026, 5, 2),
+        backfill_days=1,
+        provider="gitlab",
+        org_id="",
+    )
+
+    assert sink.ai_attributions == []

--- a/tests/storage/test_ai_attribution.py
+++ b/tests/storage/test_ai_attribution.py
@@ -373,9 +373,13 @@ def _resolve_effective(records: list[AIAttributionRecord]) -> AIAttributionRecor
 
     Mirrors the SQL:
         QUALIFY ROW_NUMBER() OVER (
-            PARTITION BY org_id, subject_type, subject_id
+            PARTITION BY org_id, subject_type, repo_id, subject_id
             ORDER BY _source_priority ASC, confidence DESC
         ) = 1
+
+    These callers pass records that all share a single resolution partition,
+    so this returns the single winner. Use :func:`_resolve_all` to simulate the
+    full per-partition view output (CHAOS-2379 repo-scope, migration 043).
     """
     active = [r for r in records if r.superseded_by is None]
     if not active:
@@ -384,6 +388,27 @@ def _resolve_effective(records: list[AIAttributionRecord]) -> AIAttributionRecor
         active,
         key=lambda r: (SOURCE_PRECEDENCE.get(r.source, 99), -r.confidence),
     )
+
+
+def _resolve_all(
+    records: list[AIAttributionRecord],
+) -> list[AIAttributionRecord]:
+    """Per-partition resolution mirroring migration 043's view.
+
+    Partition key: (org_id, subject_type, repo_id, subject_id). `repo_id` is
+    part of the key because PR/MR subject ids are repo-local — two repos that
+    share a subject id must each surface their own winning row, never collapse
+    into one.
+    """
+    active = [r for r in records if r.superseded_by is None]
+    partitions: dict[tuple[object, str, object, str], list[AIAttributionRecord]] = {}
+    for r in active:
+        key = (r.org_id, r.subject_type, r.repo_id, r.subject_id)
+        partitions.setdefault(key, []).append(r)
+    return [
+        min(rows, key=lambda r: (SOURCE_PRECEDENCE.get(r.source, 99), -r.confidence))
+        for rows in partitions.values()
+    ]
 
 
 class TestResolvedViewPrecedence:
@@ -450,3 +475,124 @@ class TestResolvedViewPrecedence:
     def test_precedence_values_are_unique(self) -> None:
         values = list(SOURCE_PRECEDENCE.values())
         assert len(values) == len(set(values)), "Duplicate precedence values found"
+
+
+# ---------------------------------------------------------------------------
+# 7. Repo-scoped resolution — cross-repo subject_id collision (CHAOS-2379)
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedViewRepoScope:
+    """Migration 043: PR/MR subject ids are repo-local, so two repos in one org
+    that share the same subject_id (e.g. both have PR/MR #1) must each surface
+    their own resolved row. The pre-043 partition (org, subject_type,
+    subject_id) collapsed them to ONE, silently dropping the second repo's AI
+    MR from governance coverage and impact. This simulates the view's partition
+    key and proves both repos survive.
+    """
+
+    def test_two_repos_same_subject_id_both_survive(self) -> None:
+        repo_a = uuid4()
+        repo_b = uuid4()
+        # Two GitLab repos in the SAME org both have MR !1 attributed as AI.
+        rec_a = AIAttributionRecord(
+            org_id=ORG,
+            provider="gitlab",
+            subject_type="pull_request",
+            subject_id="1",
+            repo_id=repo_a,
+            kind=AIAttributionKind.AI_ASSISTED,
+            source=AIAttributionSource.PR_LABEL,
+            confidence=0.9,
+            actor=None,
+            evidence={"label": "ai-assisted"},
+            observed_at=NOW,
+        )
+        rec_b = AIAttributionRecord(
+            org_id=ORG,
+            provider="gitlab",
+            subject_type="pull_request",
+            subject_id="1",
+            repo_id=repo_b,
+            kind=AIAttributionKind.AGENT_CREATED,
+            source=AIAttributionSource.BOT_AUTHOR,
+            confidence=0.85,
+            actor="claude-code[bot]",
+            evidence={"login": "claude-code[bot]"},
+            observed_at=NOW,
+        )
+        resolved = _resolve_all([rec_a, rec_b])
+        # BOTH repos' attribution rows survive — neither is collapsed away.
+        survivors = {(r.repo_id, r.subject_id) for r in resolved}
+        assert survivors == {(repo_a, "1"), (repo_b, "1")}
+        assert len(resolved) == 2
+
+    def test_same_repo_same_subject_still_resolves_to_one(self) -> None:
+        # Within ONE repo, cross-source precedence still collapses to a single
+        # winner — repo-scoping does NOT weaken intra-repo dedup.
+        repo = uuid4()
+        weak = AIAttributionRecord(
+            org_id=ORG,
+            provider="gitlab",
+            subject_type="pull_request",
+            subject_id="1",
+            repo_id=repo,
+            kind=AIAttributionKind.AI_ASSISTED,
+            source=AIAttributionSource.PR_BODY,
+            confidence=0.95,
+            actor=None,
+            evidence={},
+            observed_at=NOW,
+        )
+        strong = AIAttributionRecord(
+            org_id=ORG,
+            provider="gitlab",
+            subject_type="pull_request",
+            subject_id="1",
+            repo_id=repo,
+            kind=AIAttributionKind.AI_ASSISTED,
+            source=AIAttributionSource.PR_LABEL,
+            confidence=0.5,
+            actor=None,
+            evidence={"label": "ai-assisted"},
+            observed_at=NOW,
+        )
+        resolved = _resolve_all([weak, strong])
+        assert len(resolved) == 1
+        assert resolved[0].source == AIAttributionSource.PR_LABEL
+
+    def test_repo_pinned_and_repo_less_do_not_collapse(self) -> None:
+        # A repo-less (work-item-level) attribution and a repo-pinned one that
+        # share a subject_id are DIFFERENT partitions (repo_id NULL vs a UUID),
+        # so neither suppresses the other.
+        repo = uuid4()
+        pinned = AIAttributionRecord(
+            org_id=ORG,
+            provider="github",
+            subject_type="pull_request",
+            subject_id="1",
+            repo_id=repo,
+            kind=AIAttributionKind.AI_ASSISTED,
+            source=AIAttributionSource.PR_LABEL,
+            confidence=0.9,
+            actor=None,
+            evidence={},
+            observed_at=NOW,
+        )
+        repo_less = AIAttributionRecord(
+            org_id=ORG,
+            provider="github",
+            subject_type="pull_request",
+            subject_id="1",
+            repo_id=None,
+            kind=AIAttributionKind.AI_ASSISTED,
+            source=AIAttributionSource.MANUAL,
+            confidence=0.99,
+            actor=None,
+            evidence={},
+            observed_at=NOW,
+        )
+        resolved = _resolve_all([pinned, repo_less])
+        repo_ids = {r.repo_id for r in resolved}
+        assert repo_ids == {repo, None}
+        assert len(resolved) == 2

--- a/tests/storage/test_ai_attribution.py
+++ b/tests/storage/test_ai_attribution.py
@@ -13,7 +13,9 @@ Coverage:
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
@@ -284,39 +286,97 @@ class TestAIAttributionMixin:
 
 
 # ---------------------------------------------------------------------------
-# 4. Deduplication: same natural key → idempotent re-insert
+# 4. Deduplication: ReplacingMergeTree ORDER-BY (dedup) key
+#
+# The base table is ReplacingMergeTree(computed_at) with ORDER BY
+#   (org_id, provider, subject_type, repo_id, subject_id, source)
+# (migration 044 added repo_id BEFORE subject_id). These tests model the
+# *dedup key* itself — which tuples collapse and which survive — rather than
+# only asserting the sink forwarded rows. A row survives a server-side merge
+# iff it has a UNIQUE dedup tuple. The live counterpart that actually runs
+# OPTIMIZE FINAL is tests/storage/test_ai_attribution_repo_dedup_live.py.
 # ---------------------------------------------------------------------------
 
+#: Column subset that makes up the ReplacingMergeTree ORDER BY (dedup) key.
+_DEDUP_KEY_COLUMNS = (
+    "org_id",
+    "provider",
+    "subject_type",
+    "repo_id",
+    "subject_id",
+    "source",
+)
 
-class TestDeduplication:
-    def test_same_source_two_inserts_both_sent_to_client(self) -> None:
-        """
-        The sink sends both rows; ReplacingMergeTree(computed_at) handles
-        dedup server-side — latest computed_at survives after OPTIMIZE.
-        """
-        sink = _FakeSink()
+
+def _dedup_key(record: AIAttributionRecord) -> tuple[object, ...]:
+    """Project a record onto the ai_attribution ReplacingMergeTree ORDER BY.
+
+    Two records collapse into one under ReplacingMergeTree iff this tuple is
+    equal. Derived from the inserted row (via _to_row) so it stays honest about
+    the actual persisted values, including repo_id.
+    """
+    d = _row_as_dict(_to_row(record))
+    return tuple(d[col] for col in _DEDUP_KEY_COLUMNS)
+
+
+class TestDeduplicationKey:
+    """Model the ReplacingMergeTree dedup key, not just the sink forwarding."""
+
+    def test_same_everything_same_source_collapses(self) -> None:
+        # Identical (org, provider, subject_type, repo, subject_id, source) →
+        # one dedup key → ReplacingMergeTree keeps only the latest row.
         rec1 = _make_record(confidence=0.7)
-        rec2 = _make_record(confidence=0.9)  # same subject_id, same source
-        sink.write_ai_attribution([rec1, rec2])
+        rec2 = _make_record(confidence=0.9)  # only computed_at/confidence differ
+        assert _dedup_key(rec1) == _dedup_key(rec2)
 
-        _, matrix = sink.client.insert.call_args.args
-        assert len(matrix) == 2
-        # Both rows share the same natural key components
-        d1, d2 = _row_as_dict(matrix[0]), _row_as_dict(matrix[1])
-        assert d1["subject_id"] == d2["subject_id"]
-        assert d1["source"] == d2["source"]
+    def test_different_sources_same_subject_are_distinct_keys(self) -> None:
+        # Different source → different dedup key → both rows survive (the view
+        # then resolves cross-source precedence at read time).
+        keys = {
+            _dedup_key(_make_record(source=s))
+            for s in (
+                AIAttributionSource.PR_LABEL,
+                AIAttributionSource.COMMIT_TRAILER,
+                AIAttributionSource.BOT_AUTHOR,
+            )
+        }
+        assert len(keys) == 3
 
-    def test_different_sources_same_subject_all_persisted(self) -> None:
-        sink = _FakeSink()
-        records = [
-            _make_record(source=AIAttributionSource.PR_LABEL),
-            _make_record(source=AIAttributionSource.COMMIT_TRAILER),
-            _make_record(source=AIAttributionSource.BOT_AUTHOR),
-        ]
-        sink.write_ai_attribution(records)
-        _, matrix = sink.client.insert.call_args.args
-        sources = {_row_as_dict(row)["source"] for row in matrix}
-        assert sources == {"pr_label", "commit_trailer", "bot_author"}
+    def test_different_repo_same_subject_same_source_are_distinct_keys(self) -> None:
+        """CHAOS-2379 regression (the exact lossy case), modeled on the key.
+
+        Same org + same bare repo-local subject_id + SAME source, only repo_id
+        differs. BEFORE migration 044 (repo_id absent from ORDER BY) these two
+        rows shared a dedup key and one was permanently collapsed by
+        ReplacingMergeTree, silently dropping one repo's AI attribution. With
+        repo_id in the key, the tuples differ and BOTH survive.
+        """
+        repo_a = uuid4()
+        repo_b = uuid4()
+        rec_a = _make_record(source=AIAttributionSource.PR_LABEL, subject_id="1")
+        rec_a.repo_id = repo_a
+        rec_b = _make_record(source=AIAttributionSource.PR_LABEL, subject_id="1")
+        rec_b.repo_id = repo_b
+
+        key_a, key_b = _dedup_key(rec_a), _dedup_key(rec_b)
+        assert key_a != key_b, (
+            "two repos sharing org+subject_id+source must have DISTINCT dedup "
+            "keys so ReplacingMergeTree keeps both rows (CHAOS-2379)"
+        )
+        # repo_id is the discriminator and it precedes subject_id in the key.
+        assert _DEDUP_KEY_COLUMNS.index("repo_id") < _DEDUP_KEY_COLUMNS.index(
+            "subject_id"
+        )
+
+    def test_repo_pinned_vs_repo_less_are_distinct_keys(self) -> None:
+        # repo_id NULL (work-item-level) vs a concrete repo_id are different
+        # keys, so a repo-less row never collapses a repo-pinned one sharing a
+        # subject_id (and vice versa).
+        pinned = _make_record(source=AIAttributionSource.PR_LABEL, subject_id="1")
+        pinned.repo_id = uuid4()
+        repo_less = _make_record(source=AIAttributionSource.PR_LABEL, subject_id="1")
+        repo_less.repo_id = None
+        assert _dedup_key(pinned) != _dedup_key(repo_less)
 
 
 # ---------------------------------------------------------------------------
@@ -596,3 +656,110 @@ class TestResolvedViewRepoScope:
         repo_ids = {r.repo_id for r in resolved}
         assert repo_ids == {repo, None}
         assert len(resolved) == 2
+
+
+# ---------------------------------------------------------------------------
+# 8. Migration-shape assertions — base-table dedup key (CHAOS-2379, migration 044)
+#
+# These read the actual migration SQL the runner applies and assert the
+# ai_attribution ReplacingMergeTree ORDER BY puts repo_id BEFORE subject_id.
+# Migration 035 keyed only on (org_id, provider, subject_type, subject_id,
+# source); migration 044 must add repo_id so two repos sharing a bare
+# repo-local subject_id do not collapse at the base table.
+# ---------------------------------------------------------------------------
+
+# The runner resolves migrations as parents[1] of storage/clickhouse.py, i.e.
+# src/dev_health_ops/migrations/clickhouse — mirror that here so the test reads
+# the SAME files the runner executes (not a stale top-level copy).
+_MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "dev_health_ops"
+    / "migrations"
+    / "clickhouse"
+)
+
+
+def _strip_sql_comments(sql: str) -> str:
+    """Drop '--' line comments so ORDER BY parsing ignores documentation."""
+    return "\n".join(line.split("--", 1)[0] for line in sql.splitlines())
+
+
+class TestAiAttributionMigrationShape:
+    def test_migration_044_exists(self) -> None:
+        matches = list(_MIGRATIONS_DIR.glob("044_*.sql"))
+        assert matches, (
+            f"expected an 044_*.sql migration in {_MIGRATIONS_DIR} "
+            "(CHAOS-2379 base-table dedup key fix)"
+        )
+
+    def test_order_by_has_repo_id_before_subject_id(self) -> None:
+        matches = list(_MIGRATIONS_DIR.glob("044_*.sql"))
+        assert matches
+        sql = _strip_sql_comments(matches[0].read_text(encoding="utf-8"))
+
+        # The rebuild creates ai_attribution_new with the corrected ORDER BY.
+        m = re.search(r"ORDER BY\s*\(([^)]*)\)", sql, flags=re.IGNORECASE)
+        assert m, "migration 044 must declare an ORDER BY tuple for the rebuild"
+        cols = [c.strip() for c in m.group(1).split(",")]
+
+        assert "repo_id" in cols, f"repo_id missing from ORDER BY: {cols}"
+        assert "subject_id" in cols, f"subject_id missing from ORDER BY: {cols}"
+        assert cols.index("repo_id") < cols.index("subject_id"), (
+            f"repo_id must precede subject_id in the dedup key, got {cols}"
+        )
+        # Full expected key for the rebuilt base table.
+        assert cols == [
+            "org_id",
+            "provider",
+            "subject_type",
+            "repo_id",
+            "subject_id",
+            "source",
+        ], f"unexpected ai_attribution dedup key: {cols}"
+
+    def test_nullable_repo_id_key_requires_allow_nullable_key(self) -> None:
+        # repo_id is Nullable(UUID) and now in the ORDER BY. ClickHouse rejects
+        # a Nullable sorting-key column unless allow_nullable_key = 1, so the
+        # rebuilt CREATE TABLE must set it or the migration fails at apply time.
+        matches = list(_MIGRATIONS_DIR.glob("044_*.sql"))
+        assert matches
+        sql = _strip_sql_comments(matches[0].read_text(encoding="utf-8"))
+        assert re.search(r"allow_nullable_key\s*=\s*1", sql, flags=re.IGNORECASE), (
+            "migration 044 puts Nullable repo_id in the ORDER BY, so the "
+            "rebuilt table MUST set allow_nullable_key = 1 or ClickHouse "
+            "rejects the CREATE"
+        )
+
+    def test_rebuild_swaps_atomically_and_drops_temp(self) -> None:
+        matches = list(_MIGRATIONS_DIR.glob("044_*.sql"))
+        assert matches
+        sql = _strip_sql_comments(matches[0].read_text(encoding="utf-8"))
+        upper = sql.upper()
+        # Atomic swap via EXCHANGE TABLES, then drop the parked old table.
+        assert "EXCHANGE TABLES" in upper, (
+            "migration 044 must swap the rebuilt table in atomically "
+            "(EXCHANGE TABLES) so readers never see a missing ai_attribution"
+        )
+        assert "AI_ATTRIBUTION_NEW" in upper, (
+            "migration 044 should build into a _new table then swap"
+        )
+        assert "DROP TABLE" in upper, (
+            "migration 044 should drop the parked old table after the swap"
+        )
+
+    def test_no_semicolons_inside_comments(self) -> None:
+        # The runner splits on ';'; a ';' inside a '--' comment would create a
+        # spurious statement chunk. Assert every ';' sits outside comments.
+        matches = list(_MIGRATIONS_DIR.glob("044_*.sql"))
+        assert matches
+        raw = matches[0].read_text(encoding="utf-8")
+        for i, line in enumerate(raw.splitlines(), start=1):
+            comment_idx = line.find("--")
+            if comment_idx == -1:
+                continue
+            comment = line[comment_idx:]
+            assert ";" not in comment, (
+                f"semicolon inside a comment on line {i} would break the "
+                f"migration runner's ';' split: {line.strip()!r}"
+            )

--- a/tests/storage/test_ai_attribution_repo_dedup_live.py
+++ b/tests/storage/test_ai_attribution_repo_dedup_live.py
@@ -1,0 +1,159 @@
+"""Live-ClickHouse regression test for the ai_attribution base-table dedup key.
+
+CHAOS-2379. ``ai_attribution`` is a ReplacingMergeTree(computed_at). Migration
+035 keyed it on ``(org_id, provider, subject_type, subject_id, source)`` —
+``repo_id`` was NOT in the ORDER BY. ``subject_id`` is the bare, repo-local
+provider PR/MR number, so two repos in ONE org that each have MR/PR #1 labeled
+ai-assisted from the SAME source produced IDENTICAL dedup keys and one row was
+permanently collapsed on a background merge (the resolved view reads
+``FROM ai_attribution FINAL``). Migration 043's repo-scoped view cannot recover
+a base row the engine already merged away — only the base-table ORDER BY can.
+
+Migration 044 adds ``repo_id`` to the ORDER BY (before ``subject_id``). This
+test exercises the BASE TABLE (not the view's window function) for the exact
+lossy case: same org + same subject_id + SAME source + DIFFERENT repo_id →
+BOTH rows survive ``OPTIMIZE TABLE ... FINAL``.
+
+Opt-in (filtered from unit/CI runs): ``pytest -m clickhouse``.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+# Import connectors FIRST (before any other dev_health_ops import) to break the
+# providers._base <-> connectors circular import that otherwise ERRORs at
+# collection in isolated runs (see CHAOS-2370).
+import dev_health_ops.connectors  # noqa: F401,E402,I001
+from dev_health_ops.models.ai_attribution import (  # noqa: E402
+    AIAttributionKind,
+    AIAttributionRecord,
+    AIAttributionSource,
+)
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/default)",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def sink():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
+    s = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    # Apply pending migrations (including 044) regardless of AUTO_RUN_MIGRATIONS
+    # — the fix under test is a migration.
+    s.ensure_schema(force=True)
+    yield s
+    s.close()
+
+
+def _record(
+    *, org_id: uuid.UUID, repo_id: uuid.UUID, subject_id: str
+) -> AIAttributionRecord:
+    """An AI-attribution record fixed except for repo_id (the discriminator)."""
+    return AIAttributionRecord(
+        org_id=org_id,
+        provider="gitlab",
+        subject_type="pull_request",
+        subject_id=subject_id,
+        repo_id=repo_id,
+        kind=AIAttributionKind.AI_ASSISTED,
+        source=AIAttributionSource.PR_LABEL,  # SAME source for both rows
+        confidence=0.9,
+        actor=None,
+        evidence={"label": "ai-assisted"},
+        observed_at=datetime.now(timezone.utc),
+    )
+
+
+def test_base_table_dedup_keeps_both_repos(sink) -> None:
+    """Same org + subject_id + source, different repo_id → BOTH survive FINAL.
+
+    This is the precise silent-data-loss case. The two records collide on every
+    pre-044 ORDER BY column; only repo_id differs. After OPTIMIZE FINAL both
+    repo_ids must still be present — proving repo_id is part of the dedup key.
+    """
+    org_id = uuid.uuid4()
+    repo_a = uuid.uuid4()
+    repo_b = uuid.uuid4()
+    subject_id = "1"  # bare repo-local MR iid — collides across repos
+
+    try:
+        sink.write_ai_attribution(
+            [
+                _record(org_id=org_id, repo_id=repo_a, subject_id=subject_id),
+                _record(org_id=org_id, repo_id=repo_b, subject_id=subject_id),
+            ]
+        )
+
+        sink.client.command("OPTIMIZE TABLE ai_attribution FINAL")
+        result = sink.client.query(
+            "SELECT DISTINCT repo_id FROM ai_attribution FINAL "
+            "WHERE org_id = {org:UUID} AND subject_id = {sid:String} "
+            "AND source = 'pr_label'",
+            parameters={"org": str(org_id), "sid": subject_id},
+        )
+        survivors = {str(row[0]) for row in (result.result_rows or [])}
+
+        assert survivors == {str(repo_a), str(repo_b)}, (
+            "base-table dedup collapsed a cross-repo ai_attribution row: "
+            f"expected both repos to survive OPTIMIZE FINAL, got {survivors}. "
+            "repo_id must be in the ReplacingMergeTree ORDER BY (migration 044)."
+        )
+    finally:
+        sink.client.command(
+            "ALTER TABLE ai_attribution DELETE WHERE org_id = {org:UUID} "
+            "SETTINGS mutations_sync=2",
+            parameters={"org": str(org_id)},
+        )
+
+
+def test_base_table_dedup_collapses_true_duplicate(sink) -> None:
+    """Same org + repo + subject_id + source → ONE row survives FINAL.
+
+    Confirms migration 044 did not weaken intra-repo dedup: a genuine duplicate
+    (every ORDER BY column equal) still collapses to a single row.
+    """
+    org_id = uuid.uuid4()
+    repo_id = uuid.uuid4()
+    subject_id = "1"
+
+    try:
+        rec1 = _record(org_id=org_id, repo_id=repo_id, subject_id=subject_id)
+        rec2 = _record(org_id=org_id, repo_id=repo_id, subject_id=subject_id)
+        rec2.confidence = 0.5  # differs only on a non-key column
+        sink.write_ai_attribution([rec1, rec2])
+
+        sink.client.command("OPTIMIZE TABLE ai_attribution FINAL")
+        result = sink.client.query(
+            "SELECT count() FROM ai_attribution FINAL "
+            "WHERE org_id = {org:UUID} AND repo_id = {repo:UUID} "
+            "AND subject_id = {sid:String} AND source = 'pr_label'",
+            parameters={
+                "org": str(org_id),
+                "repo": str(repo_id),
+                "sid": subject_id,
+            },
+        )
+        count = (result.result_rows or [[0]])[0][0]
+        assert count == 1, (
+            f"true duplicate must collapse to one row under FINAL, got {count}"
+        )
+    finally:
+        sink.client.command(
+            "ALTER TABLE ai_attribution DELETE WHERE org_id = {org:UUID} "
+            "SETTINGS mutations_sync=2",
+            parameters={"org": str(org_id)},
+        )


### PR DESCRIPTION
Emits GitLab MR AI attribution into the live sync (job_work_items path, not the unused iter_ingest) so ai_governance_coverage_daily populates for GitLab orgs. The ai_attribution base table ORDER BY now includes repo_id (migration 044, allow_nullable_key) so two repos sharing a bare MR iid + source no longer collapse under RMT FINAL; the resolved view is also repo-scoped (043).

Part of CHAOS-2372. Closes CHAOS-2379. Follow-up: CHAOS-2396 (GitHub governance subject_id join mismatch). Note: migration FINAL-survival proven offline + by precedent, not against a live ClickHouse this session.

> Branch forked at 667dc5b5; origin/main has since advanced. Rebase onto origin/main before merge (3-way merge is safe; a 2-dot diff shows unrelated main commits as spurious deletions). Reviewed across 4 adversarial rounds (in-workflow reviewer + Codex /codex:adversarial-review); tenant-isolation, no-silent-loss and correctness all verified. Gates: ruff + full-package mypy + pytest green.
