### PR TITLE
fix(providers): break testops base import cycle (CHAOS-2413)

### DIFF
--- a/src/dev_health_ops/connectors/exceptions.py
+++ b/src/dev_health_ops/connectors/exceptions.py
@@ -1,35 +1,17 @@
-"""
-Exception types for connector operations.
-"""
+from dev_health_ops.exceptions import (
+    APIException,
+    AuthenticationException,
+    ConnectorException,
+    NotFoundException,
+    PaginationException,
+    RateLimitException,
+)
 
-
-class ConnectorException(Exception):
-    """Base exception for all connector errors."""
-
-
-class RateLimitException(ConnectorException):
-    """Raised when API rate limit is exceeded."""
-
-    def __init__(
-        self,
-        message: str = "API rate limit exceeded",
-        retry_after_seconds: float | None = None,
-    ) -> None:
-        super().__init__(message)
-        self.retry_after_seconds = retry_after_seconds
-
-
-class AuthenticationException(ConnectorException):
-    """Raised when authentication fails."""
-
-
-class NotFoundException(ConnectorException):
-    """Raised when a resource is not found."""
-
-
-class PaginationException(ConnectorException):
-    """Raised when pagination fails."""
-
-
-class APIException(ConnectorException):
-    """Raised when API returns an error."""
+__all__ = [
+    "APIException",
+    "AuthenticationException",
+    "ConnectorException",
+    "NotFoundException",
+    "PaginationException",
+    "RateLimitException",
+]

--- a/src/dev_health_ops/exceptions.py
+++ b/src/dev_health_ops/exceptions.py
@@ -1,0 +1,28 @@
+class ConnectorException(Exception):
+    pass
+
+
+class RateLimitException(ConnectorException):
+    def __init__(
+        self,
+        message: str = "API rate limit exceeded",
+        retry_after_seconds: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.retry_after_seconds = retry_after_seconds
+
+
+class AuthenticationException(ConnectorException):
+    pass
+
+
+class NotFoundException(ConnectorException):
+    pass
+
+
+class PaginationException(ConnectorException):
+    pass
+
+
+class APIException(ConnectorException):
+    pass

--- a/src/dev_health_ops/providers/_base.py
+++ b/src/dev_health_ops/providers/_base.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import httpx
 
-from dev_health_ops.connectors.exceptions import APIException, AuthenticationException
+from dev_health_ops.exceptions import APIException, AuthenticationException
 from dev_health_ops.metrics.testops_schemas import JobRunRow, PipelineRunExtendedRow
 
 

--- a/tests/providers/test_provider_base_import.py
+++ b/tests/providers/test_provider_base_import.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_github_testops_pipeline_imports_without_connectors_preload() -> None:
+    module = importlib.import_module("dev_health_ops.providers.github.testops_pipeline")
+
+    assert module.GitHubActionsAdapter.provider == "github_actions"
+
+
+def test_connector_exceptions_keep_shared_identity() -> None:
+    connector_exceptions = importlib.import_module(
+        "dev_health_ops.connectors.exceptions"
+    )
+    shared_exceptions = importlib.import_module("dev_health_ops.exceptions")
+
+    assert connector_exceptions.APIException is shared_exceptions.APIException
+    assert (
+        connector_exceptions.AuthenticationException
+        is shared_exceptions.AuthenticationException
+    )


### PR DESCRIPTION
## Summary
- Move shared connector/provider exception classes to a neutral module
- Re-export those types from connectors.exceptions to preserve legacy import identity
- Switch provider base to the neutral exceptions module and add isolated import regression coverage

## Verification
- PYTHONPATH=src python -c "import dev_health_ops.providers.github.testops_pipeline; import dev_health_ops.providers.gitlab.testops_pipeline"
- PYTHONPATH=src python -m pytest tests/providers/test_provider_base_import.py tests/metrics/test_job_daily_hotspots.py -q
- PYTHONPATH=src python -m ruff format --check src/dev_health_ops/exceptions.py src/dev_health_ops/connectors/exceptions.py src/dev_health_ops/providers/_base.py tests/providers/test_provider_base_import.py
- PYTHONPATH=src python -m ruff check src/dev_health_ops/exceptions.py src/dev_health_ops/connectors/exceptions.py src/dev_health_ops/providers/_base.py tests/providers/test_provider_base_import.py
- Codex adversarial review approved

Closes CHAOS-2413