### PR TITLE
fix(api): org-scope investment explanation LLM cache (CHAOS-2393)

### DIFF
--- a/src/dev_health_ops/api/services/investment_mix_explain.py
+++ b/src/dev_health_ops/api/services/investment_mix_explain.py
@@ -65,8 +65,18 @@ def _determine_confidence_level(
     return "low"
 
 
-def _compute_cache_key(filters: Any, theme: str | None, subcategory: str | None) -> str:
-    """Compute a deterministic cache key from filter context."""
+def _compute_cache_key(
+    filters: Any, theme: str | None, subcategory: str | None, org_id: str = ""
+) -> str:
+    """Compute a deterministic cache key from filter context.
+
+    ``org_id`` is part of the key so two tenants with identical
+    filters/theme/subcategory never collide on the same SHA256 and read each
+    other's cached LLM explanation (CHAOS-2393). The read side
+    (``ClickHouseMetricsSink.read_investment_explanation``) additionally filters
+    by ``org_id`` so the tenant boundary holds even if the truncated hash ever
+    collided.
+    """
     # Serialize filters to JSON for hashing
     if hasattr(filters, "model_dump"):
         filter_data = filters.model_dump(mode="json")
@@ -79,6 +89,7 @@ def _compute_cache_key(filters: Any, theme: str | None, subcategory: str | None)
         "filters": filter_data,
         "theme": theme,
         "subcategory": subcategory,
+        "org_id": org_id,
     }
     key_json = json.dumps(key_parts, sort_keys=True, default=str)
     return hashlib.sha256(key_json.encode()).hexdigest()[:32]
@@ -127,13 +138,13 @@ async def explain_investment_mix(
             status="llm_unavailable",
         )
 
-    cache_key = _compute_cache_key(filters, theme, subcategory)
+    cache_key = _compute_cache_key(filters, theme, subcategory, org_id)
 
     if not force_refresh and llm_provider != "mock":
         try:
             ch_sink = ClickHouseMetricsSink(db_url)
             try:
-                cached = ch_sink.read_investment_explanation(cache_key)
+                cached = ch_sink.read_investment_explanation(cache_key, org_id)
                 if cached:
                     logger.info("Cache hit for explanation cache_key=%s", cache_key[:8])
                     cached_data = json.loads(cached.explanation_json)
@@ -405,6 +416,7 @@ async def explain_investment_mix(
                     llm_provider=llm_provider,
                     llm_model=llm_model,
                     computed_at=datetime.now(timezone.utc),
+                    org_id=org_id,
                 )
                 ch_sink.write_investment_explanation(record)
                 logger.info("Cached explanation cache_key=%s", cache_key[:8])

--- a/src/dev_health_ops/metrics/sinks/clickhouse/investment.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/investment.py
@@ -172,13 +172,19 @@ class InvestmentMixin(_ClickHouseSinkBase):
         )
 
     def read_investment_explanation(
-        self, cache_key: str
+        self, cache_key: str, org_id: str = ""
     ) -> InvestmentExplanationRecord | None:
         """
-        Read a cached investment explanation by cache_key.
+        Read a cached investment explanation by cache_key, scoped to ``org_id``.
 
         Uses FINAL to ensure we get the latest version from ReplacingMergeTree.
         Returns None if no cached explanation exists.
+
+        The ``org_id`` predicate is required for tenant isolation: the cache_key
+        is a 32-char SHA256 prefix and two tenants with identical
+        filters/theme/subcategory would otherwise collide and read each other's
+        cached LLM explanation (CHAOS-2393). The cache_key itself also includes
+        org_id (see ``_compute_cache_key``); filtering here is defence in depth.
         """
         result = self.client.query(
             """
@@ -187,12 +193,13 @@ class InvestmentMixin(_ClickHouseSinkBase):
                 explanation_json,
                 llm_provider,
                 llm_model,
-                computed_at
+                computed_at,
+                org_id
             FROM investment_explanations FINAL
-            WHERE cache_key = {cache_key:String}
+            WHERE cache_key = {cache_key:String} AND org_id = {org_id:String}
             LIMIT 1
             """,
-            parameters={"cache_key": cache_key},
+            parameters={"cache_key": cache_key, "org_id": org_id},
         )
         rows = result.result_rows or []
         if not rows:
@@ -206,4 +213,5 @@ class InvestmentMixin(_ClickHouseSinkBase):
             computed_at=row[4]
             if isinstance(row[4], datetime)
             else datetime.now(timezone.utc),
+            org_id=str(row[5]) if row[5] else "",
         )

--- a/tests/api/test_investment_explain_cache.py
+++ b/tests/api/test_investment_explain_cache.py
@@ -101,6 +101,86 @@ def test_compute_cache_key_with_string_fallback():
     assert len(key) == 32
 
 
+def test_compute_cache_key_different_org_ids():
+    """Regression (CHAOS-2393): cross-tenant cache keys must diverge.
+
+    Two tenants with identical filters/theme/subcategory must NOT produce the
+    same SHA256 cache key, otherwise org B reads org A's cached LLM
+    explanation from the shared ``investment_explanations`` table. ``org_id``
+    is now hashed into the key so the keys differ.
+    """
+
+    class MockFilters:
+        def model_dump(self, mode=None):
+            return {
+                "scope": {"level": "org", "ids": []},
+                "time_range": {"range_days": 14, "compare_days": 14},
+            }
+
+    filters = MockFilters()
+
+    key_org_a = _compute_cache_key(
+        filters, theme="feature_delivery", subcategory=None, org_id="orgA"
+    )
+    key_org_b = _compute_cache_key(
+        filters, theme="feature_delivery", subcategory=None, org_id="orgB"
+    )
+
+    assert key_org_a != key_org_b
+    # Still a well-formed key.
+    assert len(key_org_a) == 32
+    assert len(key_org_b) == 32
+
+
+def test_compute_cache_key_same_org_id_is_stable():
+    """Same org_id (and other args) must yield the same key (cache hits work).
+
+    The org_id scoping must not break determinism: identical inputs including
+    org_id always hash to the same cache key, so a tenant's repeated request
+    hits its own cached explanation.
+    """
+
+    class MockFilters:
+        def model_dump(self, mode=None):
+            return {
+                "scope": {"level": "org", "ids": []},
+                "time_range": {"range_days": 14, "compare_days": 14},
+            }
+
+    filters = MockFilters()
+
+    key1 = _compute_cache_key(
+        filters, theme="feature_delivery", subcategory=None, org_id="orgA"
+    )
+    key2 = _compute_cache_key(
+        filters, theme="feature_delivery", subcategory=None, org_id="orgA"
+    )
+
+    assert key1 == key2
+    assert len(key1) == 32
+
+
+def test_compute_cache_key_org_id_changes_default_key():
+    """Supplying a non-default org_id must differ from the empty-default key.
+
+    The default ``org_id=""`` (legacy/global cache slot) must not collide with
+    a real tenant's key, confirming org_id genuinely participates in the hash.
+    """
+
+    class MockFilters:
+        def model_dump(self, mode=None):
+            return {"scope": {"level": "org"}}
+
+    filters = MockFilters()
+
+    key_default = _compute_cache_key(filters, theme=None, subcategory=None)
+    key_tenant = _compute_cache_key(
+        filters, theme=None, subcategory=None, org_id="org-7c2f1a9e"
+    )
+
+    assert key_default != key_tenant
+
+
 @pytest.mark.asyncio
 async def test_explain_investment_mix_mock_provider_skips_cache():
     """Test that mock provider does not use cache."""


### PR DESCRIPTION
## CHAOS-2393 — org-scope the investment explanation LLM cache

**Bug (tenant isolation).** The investment-mix LLM explanation cache was not org-scoped:
`_compute_cache_key` omitted `org_id`, the cache record was written with the default empty
`org_id`, and `read_investment_explanation` filtered only on `cache_key`. Two tenants with
identical filters/theme/subcategory collide on the 32-char SHA256 `cache_key`, so one org
could read the other's cached LLM explanation.

**Fix**
- `_compute_cache_key(filters, theme, subcategory, org_id)` now folds `org_id` into the hash.
- The cached `InvestmentExplanationRecord` is written with the real `org_id` (the column +
  RMT sort-key prefix already exist from migration 027; `_insert_rows` persists `record.org_id`).
- `read_investment_explanation(cache_key, org_id)` filters `WHERE cache_key = … AND org_id = …`
  (defence-in-depth even against a truncated-hash collision).

**Validation**
- Unit tests: distinct org_ids ⇒ distinct keys; same org_id stable; org_id participates in the hash.
- Read-only live check: the new `WHERE cache_key=… AND org_id=…` parses against `investment_explanations`.

Gates: ruff ✓ · mypy ✓ · pytest ✓. Closes CHAOS-2393.
