### PR TITLE
fix(api): thread org_id through build_segment_investment (CHAOS-2394)

### DIFF
--- a/src/dev_health_ops/api/services/investment_segments.py
+++ b/src/dev_health_ops/api/services/investment_segments.py
@@ -77,6 +77,7 @@ async def build_segment_investment(
     theme: str | None,
     subcategory: str | None,
     limit: int = 500,
+    org_id: str = "",
 ) -> WorkUnitInvestment | None:
     start_day, end_day, _, _ = time_window(filters)
     start_ts = datetime.combine(start_day, time.min, tzinfo=timezone.utc)
@@ -84,13 +85,14 @@ async def build_segment_investment(
 
     async with clickhouse_client(db_url) as sink:
         require_clickhouse_backend(sink)
-        repo_ids = await resolve_repo_filter_ids(sink, filters)
+        repo_ids = await resolve_repo_filter_ids(sink, filters, org_id=org_id)
         rows = await fetch_work_unit_investments(
             sink,
             start_ts=start_ts,
             end_ts=end_ts,
             repo_ids=repo_ids or None,
             limit=max(1, int(limit)),
+            org_id=org_id,
         )
 
         if not rows:
@@ -172,7 +174,9 @@ async def build_segment_investment(
             for _, unit_id, run_id in contributions[:5]
             if unit_id and run_id
         ]
-        quote_rows = await fetch_work_unit_investment_quotes(sink, unit_runs=unit_runs)
+        quote_rows = await fetch_work_unit_investment_quotes(
+            sink, unit_runs=unit_runs, org_id=org_id
+        )
 
     textual_evidence: list[dict[str, object]] = []
     for quote in quote_rows or []:

--- a/tests/api/services/test_investment_segments.py
+++ b/tests/api/services/test_investment_segments.py
@@ -1,0 +1,79 @@
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dev_health_ops.api.models.filters import MetricFilter
+from dev_health_ops.api.services.investment_segments import build_segment_investment
+
+
+@pytest.mark.asyncio
+async def test_build_segment_investment_threads_org_id_to_downstream():
+    """org_id passed to build_segment_investment must be forwarded to each
+    downstream ClickHouse query helper (multi-tenant isolation, CHAOS-2394)."""
+    rows = [
+        {
+            "work_unit_id": "wu-1",
+            "categorization_run_id": "run-1",
+            "effort_value": 100.0,
+            "evidence_quality": 0.8,
+            "theme_distribution_json": {"Feature Delivery": 1.0},
+            "subcategory_distribution_json": {"feature_delivery.customer": 1.0},
+        }
+    ]
+
+    filters = MagicMock(spec=MetricFilter)
+
+    resolve_stub = AsyncMock(return_value=["repo-1"])
+    investments_stub = AsyncMock(return_value=rows)
+    quotes_stub = AsyncMock(return_value=[])
+
+    with (
+        patch(
+            "dev_health_ops.api.services.investment_segments.time_window",
+            return_value=(date(2024, 1, 1), date(2024, 1, 31), None, None),
+        ),
+        patch(
+            "dev_health_ops.api.services.investment_segments.clickhouse_client"
+        ) as mock_client_cm,
+        patch(
+            "dev_health_ops.api.services.investment_segments.require_clickhouse_backend"
+        ),
+        patch(
+            "dev_health_ops.api.services.investment_segments.resolve_repo_filter_ids",
+            resolve_stub,
+        ),
+        patch(
+            "dev_health_ops.api.services.investment_segments.fetch_work_unit_investments",
+            investments_stub,
+        ),
+        patch(
+            "dev_health_ops.api.services.investment_segments.fetch_work_unit_investment_quotes",
+            quotes_stub,
+        ),
+    ):
+        mock_client = MagicMock()
+        mock_client.backend_type = "clickhouse"
+        mock_client_cm.return_value.__aenter__.return_value = mock_client
+
+        result = await build_segment_investment(
+            db_url="mock://",
+            filters=filters,
+            theme=None,
+            subcategory=None,
+            org_id="org-xyz",
+        )
+
+    assert result is not None
+
+    # resolve_repo_filter_ids(sink, filters, org_id=...)
+    resolve_stub.assert_awaited_once()
+    assert resolve_stub.await_args.kwargs["org_id"] == "org-xyz"
+
+    # fetch_work_unit_investments(sink, ..., org_id=...)
+    investments_stub.assert_awaited_once()
+    assert investments_stub.await_args.kwargs["org_id"] == "org-xyz"
+
+    # fetch_work_unit_investment_quotes(sink, unit_runs=..., org_id=...)
+    quotes_stub.assert_awaited_once()
+    assert quotes_stub.await_args.kwargs["org_id"] == "org-xyz"

--- a/tests/api/services/test_investment_segments.py
+++ b/tests/api/services/test_investment_segments.py
@@ -68,12 +68,15 @@ async def test_build_segment_investment_threads_org_id_to_downstream():
 
     # resolve_repo_filter_ids(sink, filters, org_id=...)
     resolve_stub.assert_awaited_once()
+    assert resolve_stub.await_args is not None
     assert resolve_stub.await_args.kwargs["org_id"] == "org-xyz"
 
     # fetch_work_unit_investments(sink, ..., org_id=...)
     investments_stub.assert_awaited_once()
+    assert investments_stub.await_args is not None
     assert investments_stub.await_args.kwargs["org_id"] == "org-xyz"
 
     # fetch_work_unit_investment_quotes(sink, unit_runs=..., org_id=...)
     quotes_stub.assert_awaited_once()
+    assert quotes_stub.await_args is not None
     assert quotes_stub.await_args.kwargs["org_id"] == "org-xyz"


### PR DESCRIPTION
## CHAOS-2394 — thread org_id through build_segment_investment

**Bug.** `build_segment_investment` did not accept/forward `org_id`, so its three downstream
ClickHouse helpers (`resolve_repo_filter_ids`, `fetch_work_unit_investments`,
`fetch_work_unit_investment_quotes`) ran with the default `org_id=''` (an equality predicate),
returning **no rows for any real tenant**.

**Fix.** Add `org_id` to the signature and forward it to all three helpers (the one-line
threading pattern from CHAOS-2374). The helpers already hard-filter `org_id = %(org_id)s`.

**Note.** The function is currently unreferenced in `src/` (pre-emptive hardening, sibling of
the CHAOS-2374 fix); the equality predicate means the pre-fix default could only ever return
empty, never leak. A unit test asserts `org_id` is forwarded to all three helpers.

Gates: ruff ✓ · mypy ✓ · pytest ✓. Closes CHAOS-2394.
