### PR TITLE
fix(metrics): normalize deployment failure status across providers (CHAOS-2395)

### DIFF
--- a/src/dev_health_ops/metrics/compute_deployments.py
+++ b/src/dev_health_ops/metrics/compute_deployments.py
@@ -8,6 +8,17 @@ from typing import TypedDict
 from dev_health_ops.metrics.schemas import DeploymentRow, DeployMetricsDailyRecord
 from dev_health_ops.utils.datetime import to_utc
 
+# Deployment statuses that count as a FAILED change. Must be PROVIDER-AGNOSTIC:
+# deployment rows are persisted from the raw provider status with no
+# normalization, so both vocabularies coexist in the ``deployments`` table:
+#   * GitHub deployment state  -> 'failure', 'error'   (GitHub Deployment API)
+#   * GitLab deployment status -> 'failed', 'canceled' (GitLab Deployment API)
+# Counting only 'failure' (or only {failed,error,canceled}) silently drops one
+# provider's failures and biases DORA change-failure-rate toward 0. This is the
+# single source of truth shared with ``compute_dora`` and the ClickHouse
+# ``deployment_daily_rollup`` MV (CHAOS-2382 / CHAOS-2395).
+DEPLOYMENT_FAILURE_STATUSES = {"failure", "failed", "error", "canceled"}
+
 
 class DeploymentBucket(TypedDict):
     deployments: int
@@ -74,7 +85,7 @@ def compute_deploy_metrics_daily(
 
         bucket["deployments"] = int(bucket["deployments"]) + 1
         status = (row.get("status") or "").strip().lower()
-        if status in {"failed", "error", "canceled"}:
+        if status in DEPLOYMENT_FAILURE_STATUSES:
             bucket["failed"] = int(bucket["failed"]) + 1
 
         started_at = row.get("started_at")

--- a/src/dev_health_ops/metrics/compute_dora.py
+++ b/src/dev_health_ops/metrics/compute_dora.py
@@ -20,6 +20,7 @@ from collections.abc import Sequence
 from datetime import date, datetime, time, timedelta, timezone
 from typing import TypedDict
 
+from dev_health_ops.metrics.compute_deployments import DEPLOYMENT_FAILURE_STATUSES
 from dev_health_ops.metrics.schemas import (
     DeploymentRow,
     DORAMetricsRecord,
@@ -28,18 +29,10 @@ from dev_health_ops.metrics.schemas import (
 from dev_health_ops.utils.datetime import to_utc
 
 # Deployment statuses that count as a failed change for change_failure_rate.
-#
-# This must be PROVIDER-AGNOSTIC: deployment rows are persisted from the raw
-# provider status with no normalization (see processors/github.py and
-# processors/gitlab.py -> build_deployment), so both vocabularies coexist in
-# the ``deployments`` table:
-#   * GitHub deployment state  -> 'failure', 'error'   (GitHub Deployment API)
-#   * GitLab deployment status -> 'failed', 'canceled' (GitLab Deployment API)
-# The canonical ClickHouse rollup (026_materialized_views.sql) classifies a
-# failed deployment via ``status = 'failure'``; we include the full union so a
-# GitHub ``status='failure'`` row is not silently counted as a success and
-# driving change_failure_rate toward 0 (CHAOS-2382 round-3).
-_FAILED_STATUSES = {"failure", "failed", "error", "canceled"}
+# Single source of truth lives in ``compute_deployments`` so the daily deploy
+# metrics, DORA change-failure-rate, and the ClickHouse deployment_daily_rollup
+# MV all classify failures identically across providers (CHAOS-2382 / 2395).
+_FAILED_STATUSES = DEPLOYMENT_FAILURE_STATUSES
 
 
 class _DeployBucket(TypedDict):

--- a/src/dev_health_ops/migrations/clickhouse/026_materialized_views.sql
+++ b/src/dev_health_ops/migrations/clickhouse/026_materialized_views.sql
@@ -92,6 +92,6 @@ AS SELECT
     toDate(coalesce(deployed_at, started_at)) AS day,
     toUInt64(count()) AS total_deployments,
     toUInt64(countIf(status = 'success')) AS success_deployments,
-    toUInt64(countIf(status = 'failure')) AS failure_deployments
+    toUInt64(countIf(status IN ('failure', 'failed', 'error', 'canceled'))) AS failure_deployments
 FROM deployments
 GROUP BY repo_id, toDate(coalesce(deployed_at, started_at));

--- a/src/dev_health_ops/migrations/clickhouse/027_add_org_id_to_sorting_keys.py
+++ b/src/dev_health_ops/migrations/clickhouse/027_add_org_id_to_sorting_keys.py
@@ -161,7 +161,7 @@ AS SELECT
     toDate(coalesce(deployed_at, started_at)) AS day,
     toUInt64(count()) AS total_deployments,
     toUInt64(countIf(status = 'success')) AS success_deployments,
-    toUInt64(countIf(status = 'failure')) AS failure_deployments
+    toUInt64(countIf(status IN ('failure', 'failed', 'error', 'canceled'))) AS failure_deployments
 FROM deployments
 GROUP BY org_id, repo_id, toDate(coalesce(deployed_at, started_at))""",
 ]

--- a/src/dev_health_ops/migrations/clickhouse/045_deployment_rollup_failure_status.sql
+++ b/src/dev_health_ops/migrations/clickhouse/045_deployment_rollup_failure_status.sql
@@ -1,0 +1,33 @@
+-- Migration 045: normalize deployment-failure classification in the canonical
+-- deployment_daily_rollup materialized view (CHAOS-2395).
+--
+-- The MV (026_materialized_views.sql, rebuilt in 027_add_org_id_to_sorting_keys)
+-- classified failures with countIf(status = 'failure') ONLY. That counts
+-- GitHub's deployment state 'failure' but silently drops GitLab's deployment
+-- status 'failed'/'canceled' (and 'error'), so deployment_daily_rollup
+-- .failure_deployments undercounted failed deployments for GitLab orgs and any
+-- DORA change-failure-rate derived from the rollup was biased toward 0. This
+-- recreates the MV with the provider-agnostic failure union that
+-- compute_deployments.DEPLOYMENT_FAILURE_STATUSES / compute_dora use, so the
+-- rollup classifies failures identically to the Python daily-metrics path.
+--
+-- A ClickHouse materialized view only transforms rows at INSERT time, so
+-- recreating it makes every future deployment sync correct. Historical
+-- deployment_daily_rollup rows are intentionally left untouched: no in-app
+-- reader consumes that rollup today (DORA computes change-failure-rate in
+-- Python directly from the deployments table), and the next sync repopulates
+-- current partitions. The MV definition below is byte-for-byte the org-scoped
+-- 027 definition with only the failure countIf widened.
+DROP VIEW IF EXISTS deployment_daily_rollup_mv;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS deployment_daily_rollup_mv
+TO deployment_daily_rollup
+AS SELECT
+    org_id,
+    repo_id,
+    toDate(coalesce(deployed_at, started_at)) AS day,
+    toUInt64(count()) AS total_deployments,
+    toUInt64(countIf(status = 'success')) AS success_deployments,
+    toUInt64(countIf(status IN ('failure', 'failed', 'error', 'canceled'))) AS failure_deployments
+FROM deployments
+GROUP BY org_id, repo_id, toDate(coalesce(deployed_at, started_at));

--- a/tests/metrics/test_compute_deployments.py
+++ b/tests/metrics/test_compute_deployments.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from uuid import uuid4
+
+from dev_health_ops.metrics.compute_deployments import (
+    DEPLOYMENT_FAILURE_STATUSES,
+    compute_deploy_metrics_daily,
+)
+from dev_health_ops.metrics.schemas import DeploymentRow
+
+
+def test_failure_status_normalization_counts_every_provider_vocab():
+    """CHAOS-2395: failed_deployments_count must count BOTH GitHub
+    ('failure', 'error') and GitLab ('failed', 'canceled') failure vocab.
+
+    Deployment rows are persisted with the raw provider status (no
+    normalization), so both vocabularies coexist in the ``deployments`` table.
+    Counting only one provider's vocabulary silently drops the other's
+    failures and biases DORA change-failure-rate toward 0.
+    """
+    day = date(2026, 2, 18)
+    repo_id = uuid4()
+    computed_at = datetime(2026, 2, 18, 15, 0, tzinfo=timezone.utc)
+    deployed_at = datetime(2026, 2, 18, 12, 0, tzinfo=timezone.utc)
+
+    # Single repo + single day. One 'success' (excluded) and the full
+    # cross-provider failure vocabulary (all 4 counted).
+    deployments: list[DeploymentRow] = [
+        {
+            "repo_id": repo_id,
+            "deployment_id": f"d-{status}",
+            "status": status,
+            "environment": "prod",
+            "started_at": deployed_at,
+            "finished_at": None,
+            "deployed_at": deployed_at,
+        }
+        for status in ["success", "failure", "failed", "error", "canceled"]
+    ]
+
+    records = compute_deploy_metrics_daily(
+        day=day,
+        deployments=deployments,
+        computed_at=computed_at,
+    )
+
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.repo_id == repo_id
+    assert rec.day == day
+    # All 5 deployments occurred on the day -> counted.
+    assert rec.deployments_count == 5
+    # 'success' excluded; every provider failure vocab counted.
+    assert rec.failed_deployments_count == 4
+
+
+def test_github_failure_status_is_counted():
+    """Guards the original omission: 'failure' (GitHub deployment vocab) must
+    be classified as a failure. Counting only {failed,error,canceled} would
+    silently drop GitHub failures.
+    """
+    # The shared source-of-truth set must include the GitHub-specific token.
+    assert "failure" in DEPLOYMENT_FAILURE_STATUSES
+
+    day = date(2026, 2, 18)
+    repo_id = uuid4()
+    computed_at = datetime(2026, 2, 18, 15, 0, tzinfo=timezone.utc)
+    deployed_at = datetime(2026, 2, 18, 12, 0, tzinfo=timezone.utc)
+
+    deployments: list[DeploymentRow] = [
+        {
+            "repo_id": repo_id,
+            "deployment_id": "gh-1",
+            "status": "failure",
+            "environment": "prod",
+            "started_at": deployed_at,
+            "finished_at": None,
+            "deployed_at": deployed_at,
+        }
+    ]
+
+    records = compute_deploy_metrics_daily(
+        day=day,
+        deployments=deployments,
+        computed_at=computed_at,
+    )
+
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.deployments_count == 1
+    assert rec.failed_deployments_count == 1


### PR DESCRIPTION
## CHAOS-2395 — normalize deployment failure status across providers

**Bug (data correctness).** Deployment-failure classification was provider-biased:
- `compute_deployments.py` counted only `{failed, error, canceled}`, omitting GitHub's `failure`.
- The `deployment_daily_rollup_mv` (026/027) used `countIf(status = 'failure')` only, dropping
  GitLab's `failed`/`canceled` and `error`.

**Real-data impact.** On the live dev org `900f96be` (Meridian), `deployments` has **143** rows
with `failed`/`canceled`/`error` and **0** with `failure` — so the old MV reported **0** failed
deployments where the truth is **143**.

**Fix**
- Single source of truth `DEPLOYMENT_FAILURE_STATUSES = {"failure","failed","error","canceled"}`
  in `compute_deployments.py`; `compute_dora` imports it (was a private duplicate). No import cycle.
- MV `countIf` widened to `status IN (…)` in `026`/`027` source (fresh installs) **and** in a new
  forward migration `045_deployment_rollup_failure_status.sql` (DROP+CREATE the MV) for already-migrated DBs.

**Notes.** `compute_dora`'s Python change-failure-rate was already correct (it owned the canonical
set). No in-app reader consumes `deployment_daily_rollup` today, so the MV recreate is go-forward
only (historical rollup rows left as-is; no backfill needed).

Gates: ruff ✓ · mypy ✓ · pytest ✓ (unit: all four failure vocabularies counted). Closes CHAOS-2395.
