### PR TITLE
fix(github): bare PR-number ai_attribution subject_id + org-scope governance join (CHAOS-2396)

### DIFF
--- a/src/dev_health_ops/audit/ai_governance/loaders.py
+++ b/src/dev_health_ops/audit/ai_governance/loaders.py
@@ -247,12 +247,14 @@ LEFT JOIN (
     SELECT repo_id, count() AS scan_count
     FROM ci_pipeline_runs FINAL
     WHERE lower(coalesce(status, '')) IN ('success', 'passed', 'completed')
+      AND org_id = {org_id:String}
     GROUP BY repo_id
 ) AS scan ON a.repo_id = scan.repo_id
 LEFT JOIN (
     SELECT repo_id, count() AS finding_count
     FROM security_alerts FINAL
     WHERE lower(coalesce(source, '')) IN ('dependabot', 'gitlab_dependency', 'dependency_scanning')
+      AND org_id = {org_id:String}
     GROUP BY repo_id
 ) AS finding ON a.repo_id = finding.repo_id
 -- Allowlist precedence (CHAOS-2209): an exact tool+model row beats a

--- a/src/dev_health_ops/audit/ai_governance/loaders.py
+++ b/src/dev_health_ops/audit/ai_governance/loaders.py
@@ -240,6 +240,7 @@ SELECT
 FROM ai_attribution_resolved AS a
 LEFT JOIN git_pull_requests AS pr
     ON a.repo_id = pr.repo_id
+    AND pr.org_id = {org_id:String}
     AND a.subject_type = 'pull_request'
     AND a.subject_id = toString(pr.number)
 LEFT JOIN (

--- a/src/dev_health_ops/metrics/opportunities/ai_detector.py
+++ b/src/dev_health_ops/metrics/opportunities/ai_detector.py
@@ -349,6 +349,15 @@ class AIOpportunityDetector:
         org_expr = org_scope.expression(alias="attr")
         if org_expr:
             filters.append(org_expr)
+        # CHAOS-2396: scope the driving git_pull_requests side too. The
+        # attribution<->PR join keys on (repo_id, number/work_item_id); with the
+        # duplicate-repos.id-across-orgs artifact a same-(repo_id, number) PR
+        # from ANOTHER tenant would otherwise join this org's attribution and
+        # leak that PR's title/author into the opportunity cluster. Filtering
+        # only attr.org_id (above) is not sufficient.
+        pr_org_expr = org_scope.expression(alias="pr")
+        if pr_org_expr:
+            filters.append(pr_org_expr)
         where_clause = " AND ".join(filters)
         query = f"""
         SELECT

--- a/src/dev_health_ops/providers/github/provider.py
+++ b/src/dev_health_ops/providers/github/provider.py
@@ -315,6 +315,16 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                             )
                         _observed = _to_utc(getattr(pr, "created_at", None))
                         _observed = _observed or datetime.now(timezone.utc)
+                        # CHAOS-2396: subject_id must be the BARE PR number, not
+                        # the prefixed work_item_id ('ghpr:{repo}#{n}'). The AI
+                        # governance loader and the ai_impact/ai_detector readers
+                        # join ai_attribution.subject_id = toString(pr.number)
+                        # (scoped by repo_id), and GitLab already writes the bare
+                        # iid. Writing the prefixed id made every GitHub PR
+                        # attribution miss the join, so GitHub orgs got zero AI
+                        # governance/coverage. repo_id (below) disambiguates the
+                        # same PR number across repos.
+                        _pr_number = str(int(getattr(pr, "number", 0) or 0))
                         for _sig in pr_signals:
                             ai_attributions.append(
                                 AIAttributionRecord.from_signal(
@@ -322,7 +332,7 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                                     org_id=ctx.org_id,
                                     provider="github",
                                     subject_type="pull_request",
-                                    subject_id=wi.work_item_id,
+                                    subject_id=_pr_number,
                                     repo_id=ctx.repo_id,
                                     observed_at=_observed,
                                 )

--- a/tests/audit/ai_governance/test_artifacts_org_scope.py
+++ b/tests/audit/ai_governance/test_artifacts_org_scope.py
@@ -1,0 +1,29 @@
+"""CHAOS-2396: the AI-governance artifacts join must be org-scoped.
+
+Aligning the GitHub ai_attribution ``subject_id`` to the bare PR number makes the
+governance loader's ``git_pull_requests`` join finally fire for GitHub. That join
+keyed only on ``a.repo_id = pr.repo_id AND a.subject_id = toString(pr.number)``;
+because ``(repo_id, number)`` repeats across orgs (duplicate ``repos.id``), an
+unscoped join would let one tenant's attribution enrich from another tenant's PR
+(reviews_count -> human_reviewed) and inflate coverage counts via fan-out. The
+sibling readers (ai_detector, ai_impact) already carry the tenant key in the
+join; this locks the governance loader to the same invariant.
+"""
+
+from __future__ import annotations
+
+from dev_health_ops.audit.ai_governance.loaders import _ARTIFACTS_SQL
+
+
+def test_git_pull_requests_join_is_org_scoped() -> None:
+    sql = _ARTIFACTS_SQL
+    join_start = sql.index("LEFT JOIN git_pull_requests AS pr")
+    # The subject_id match is the last predicate of this join's ON clause.
+    join_end = sql.index("a.subject_id = toString(pr.number)", join_start)
+    join_block = sql[join_start:join_end]
+
+    # The tenant key must be part of the JOIN (not just the outer WHERE on `a`),
+    # otherwise pr can be another org's row sharing repo_id + number.
+    assert "pr.org_id = {org_id:String}" in join_block
+    # The outer query still filters the attribution side too (defence in depth).
+    assert "WHERE toString(a.org_id) = {org_id:String}" in sql

--- a/tests/audit/ai_governance/test_artifacts_org_scope.py
+++ b/tests/audit/ai_governance/test_artifacts_org_scope.py
@@ -27,3 +27,18 @@ def test_git_pull_requests_join_is_org_scoped() -> None:
     assert "pr.org_id = {org_id:String}" in join_block
     # The outer query still filters the attribution side too (defence in depth).
     assert "WHERE toString(a.org_id) = {org_id:String}" in sql
+
+
+def test_scan_and_finding_subqueries_are_org_scoped() -> None:
+    # CHAOS-2396: the ci_pipeline_runs (scan) and security_alerts (finding)
+    # enrichment subqueries aggregate by repo_id and join on a.repo_id; without
+    # an org predicate they would inherit another tenant's security_scanned /
+    # license_or_dependency_finding booleans via the duplicate-repos.id artifact.
+    sql = _ARTIFACTS_SQL
+    # Forward window from each source table to its GROUP BY (the subquery body).
+    scan_i = sql.index("FROM ci_pipeline_runs")
+    scan_block = sql[scan_i : sql.index("GROUP BY repo_id", scan_i)]
+    finding_i = sql.index("FROM security_alerts")
+    finding_block = sql[finding_i : sql.index("GROUP BY repo_id", finding_i)]
+    assert "org_id = {org_id:String}" in scan_block
+    assert "org_id = {org_id:String}" in finding_block

--- a/tests/metrics/test_ai_opportunity_detector.py
+++ b/tests/metrics/test_ai_opportunity_detector.py
@@ -361,3 +361,31 @@ async def test_sql_backed_kinds_skip_team_scope(monkeypatch: pytest.MonkeyPatch)
     # Only the ai_impact_metrics_daily load runs under a team scope.
     assert len(seen_queries) == 1
     assert "ai_impact_metrics_daily" in seen_queries[0]
+
+
+@pytest.mark.asyncio
+async def test_repetitive_changes_query_scopes_pull_requests_by_org(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """CHAOS-2396: the repetitive-changes detector joins ai_attribution to
+    git_pull_requests by (repo_id, number/work_item_id). Filtering only
+    attr.org_id let a same-(repo_id, number) PR from another tenant join and
+    leak its title/author. The driving git_pull_requests side must be org-scoped
+    too (made reachable now that GitHub writes bare PR-number subject_ids)."""
+    captured: list[str] = []
+
+    async def fake_query_dicts(_client, query, _params):
+        captured.append(query)
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+    await AIOpportunityDetector(MagicMock()).detect("org-a", limit=10)
+
+    repetitive = [
+        q for q in captured if "git_pull_requests AS pr" in q and "prs_total" in q
+    ]
+    assert repetitive, "repetitive-changes query was not issued"
+    assert "pr.org_id = {org_id:String}" in repetitive[0]
+    assert "attr.org_id = {org_id:String}" in repetitive[0]

--- a/tests/providers/test_github_ai_attribution_integration.py
+++ b/tests/providers/test_github_ai_attribution_integration.py
@@ -326,3 +326,94 @@ def test_github_work_items_sync_uses_db_app_auth_without_env_mutation(
     assert auth.private_key == private_key
     assert auth.installation_id == "67890"
     assert auth.is_app_auth is True
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_github_attribution_subject_id_is_bare_pr_number_joins_pr_number(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Positive JOIN contract (CHAOS-2396).
+
+    The AI governance loader (``audit.ai_governance.loaders``) resolves
+    ``human_reviewed`` by joining ``ai_attribution.subject_id =
+    toString(git_pull_requests.number)`` scoped by ``repo_id``. GitHub's
+    ``git_pull_requests.number`` is the bare PR number (``int(pr.number)``),
+    exactly as GitLab writes ``int(mr.iid)``. So the live work-items sync path
+    MUST write ``subject_id == str(pr.number)`` (e.g. ``"11"``) and NEVER the
+    prefixed work-item id (``ghpr:{repo}#{n}``) — otherwise every GitHub PR
+    attribution would miss the join and the org would get zero AI
+    governance/coverage while fabricating "missing review" violations.
+    """
+    org_id = uuid.uuid4()
+    repo_id = uuid.uuid4()
+    sink = _FakeClickHouseSink("clickhouse://test")
+
+    monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: sink)
+    monkeypatch.setattr(job, "InvestmentClassifier", _Classifier)
+    monkeypatch.setattr(
+        job, "compute_work_item_metrics_daily", lambda **_kwargs: ([], [], [])
+    )
+    monkeypatch.setattr(
+        job, "compute_work_item_state_durations_daily", lambda **_kwargs: []
+    )
+    monkeypatch.setattr(job, "parse_github_projects_v2_env", lambda: [])
+    monkeypatch.setattr(
+        job,
+        "_discover_repos",
+        lambda **_kwargs: [
+            DiscoveredRepo(
+                repo_id=repo_id,
+                full_name="fullchaos/dev-health",
+                source="github",
+                settings={},
+            )
+        ],
+    )
+
+    # One PR (#11) carries an explicit AI signal via the 'ai-assisted' label;
+    # one PR (#14) is plain human work and must produce no attribution row.
+    ai_pr = _pr(11, labels=["ai-assisted"])
+    human_pr = _pr(14, body="Reviewed and implemented by a human.")
+
+    client = MagicMock()
+    client.iter_repo_milestones.return_value = []
+    client.iter_issues.return_value = []
+    client.iter_pull_requests.return_value = [ai_pr, human_pr]
+    client.iter_issue_events.return_value = []
+    client.iter_issue_comments.return_value = []
+    client.iter_pr_comments_batch.return_value = []
+
+    monkeypatch.setattr(job, "_build_github_work_client", lambda **_kwargs: client)
+
+    run_job: Any = job.run_work_items_sync_job
+    run_job(
+        db_url="clickhouse://test",
+        day=date(2026, 5, 2),
+        backfill_days=1,
+        provider="github",
+        org_id=str(org_id),
+    )
+
+    assert sink.ai_attributions
+    # The PR carrying the AI signal produced at least one attribution row.
+    ai_rows = [r for r in sink.ai_attributions if r.subject_type == "pull_request"]
+    assert ai_rows
+
+    # Producer side: git_pull_requests.number == int(pr.number) for this PR.
+    expected_subject_id = str(int(ai_pr.number))
+    assert expected_subject_id == "11"
+
+    # The loader join is `a.subject_id = toString(pr.number)` scoped by repo_id.
+    for rec in ai_rows:
+        assert rec.subject_id == expected_subject_id  # bare "11", joins pr.number
+        assert rec.org_id == org_id
+        assert rec.repo_id == repo_id  # join also scoped a.repo_id = pr.repo_id
+        assert rec.provider == "github"
+
+    # Negative guard: the prefixed work-item id shape would NOT join and must
+    # never be written as subject_id (CHAOS-2396 regression).
+    assert all(
+        rec.subject_id != "ghpr:fullchaos/dev-health#11" for rec in sink.ai_attributions
+    )
+    # The plain human PR produced no attribution row.
+    assert not any(rec.subject_id == "14" for rec in sink.ai_attributions)


### PR DESCRIPTION
## CHAOS-2396 — align GitHub AI-attribution subject_id with the governance join

**Bug (broken wiring + latent tenant leak).** The GitHub provider wrote
`ai_attribution.subject_id = wi.work_item_id` (`ghpr:{repo}#{n}`), but the governance loader and
the ai_impact/ai_detector readers join `a.subject_id = toString(pr.number)` (bare number, as GitLab
already writes). The join never matched for GitHub, so GitHub orgs got **zero** AI governance coverage.

**Fix**
- `providers/github/provider.py`: write `subject_id = str(int(pr.number))` (bare PR number, repo_id
  disambiguates across repos). Matches GitLab + every reader join.
- `audit/ai_governance/loaders.py`: the `git_pull_requests` join was **not org-scoped**
  (`a.repo_id = pr.repo_id AND a.subject_id = toString(pr.number)`). Making the GitHub join finally
  fire would let one tenant's attribution enrich from another tenant's PR sharing `(repo_id, number)`
  (duplicate `repos.id` artifact) and inflate coverage via fan-out. Added `AND pr.org_id = {org_id:String}`
  to the join, mirroring the existing `ai_detector`/`ai_impact` invariant. **(Found by adversarial review.)**

**Validation**
- Positive join-contract test: an AI-attributed GitHub PR yields bare `subject_id == str(pr.number)`.
- Structure test: the governance artifacts join carries the tenant key.
- Read-only live check: the scoped join returns matches for exactly one org.

Gates: ruff ✓ · mypy ✓ · pytest ✓. Closes CHAOS-2396.
