### PR TITLE
fix(metrics): scope deployments reads by org_id, not repos sub-select (CHAOS-2397)

### DIFF
--- a/src/dev_health_ops/api/queries/flame.py
+++ b/src/dev_health_ops/api/queries/flame.py
@@ -12,6 +12,10 @@ async def fetch_pull_request(
     number: int,
     org_id: str = "",
 ) -> dict[str, Any] | None:
+    # CHAOS-2397: scope on git_pull_requests.org_id directly. The previous
+    # `INNER JOIN repos ... WHERE repos.org_id` leaked across tenants because
+    # repos.id is duplicated across orgs, so a shared repo_id crossed the
+    # requester's repos row with another tenant's PR sharing (repo_id, number).
     query = """
         SELECT
             repo_id,
@@ -23,10 +27,9 @@ async def fetch_pull_request(
             merged_at,
             closed_at
         FROM git_pull_requests
-        INNER JOIN repos ON toString(repos.id) = toString(git_pull_requests.repo_id)
-        WHERE repo_id = %(repo_id)s
+        WHERE org_id = %(org_id)s
+          AND repo_id = %(repo_id)s
           AND number = %(number)s
-          AND repos.org_id = %(org_id)s
         LIMIT 1
     """
     rows = await query_dicts(
@@ -44,6 +47,9 @@ async def fetch_pull_request_reviews(
     number: int,
     org_id: str = "",
 ) -> list[dict[str, Any]]:
+    # CHAOS-2397: scope on git_pull_request_reviews.org_id directly (see
+    # fetch_pull_request) — the repos join leaked across tenants for shared
+    # repo_ids.
     query = """
         SELECT
             review_id,
@@ -51,11 +57,10 @@ async def fetch_pull_request_reviews(
             state,
             submitted_at
         FROM git_pull_request_reviews
-        INNER JOIN repos ON toString(repos.id) = toString(git_pull_request_reviews.repo_id)
-        WHERE repo_id = %(repo_id)s
+        WHERE org_id = %(org_id)s
+          AND repo_id = %(repo_id)s
           AND number = %(number)s
           AND submitted_at IS NOT NULL
-          AND repos.org_id = %(org_id)s
         ORDER BY submitted_at
     """
     return await query_dicts(

--- a/src/dev_health_ops/api/queries/flame.py
+++ b/src/dev_health_ops/api/queries/flame.py
@@ -100,6 +100,14 @@ async def fetch_deployment(
     deployment_id: str,
     org_id: str = "",
 ) -> dict[str, Any] | None:
+    # Scope directly on deployments.org_id (added to the table + sort key in
+    # migration 027). The previous `INNER JOIN repos ON repos.id =
+    # deployments.repo_id ... WHERE repos.org_id = %(org_id)s` leaked across
+    # tenants: repos.id is duplicated across orgs, so for a shared repo_id the
+    # join crossed the requester's repos row with ANOTHER org's deployment row
+    # and `LIMIT 1` (no ORDER BY) could return that other tenant's deployment
+    # (CHAOS-2397). ORDER BY last_synced DESC also makes the ReplacingMergeTree
+    # read pick the latest version deterministically.
     query = """
         SELECT
             repo_id,
@@ -111,10 +119,10 @@ async def fetch_deployment(
             deployed_at,
             merged_at
         FROM deployments
-        INNER JOIN repos ON toString(repos.id) = toString(deployments.repo_id)
-        WHERE repo_id = %(repo_id)s
+        WHERE org_id = %(org_id)s
+          AND repo_id = %(repo_id)s
           AND deployment_id = %(deployment_id)s
-          AND repos.org_id = %(org_id)s
+        ORDER BY last_synced DESC
         LIMIT 1
     """
     rows = await query_dicts(

--- a/src/dev_health_ops/metrics/ff_validation.py
+++ b/src/dev_health_ops/metrics/ff_validation.py
@@ -109,7 +109,7 @@ def check_coverage(client: Any, org_id: str, lookback_days: int = 30) -> CheckRe
             SELECT DISTINCT release_ref
             FROM deployments
             WHERE release_ref != ''
-              AND repo_id IN (SELECT id FROM repos WHERE org_id = {org_id:String})
+              AND org_id = {org_id:String}
               AND toDate(coalesce(deployed_at, started_at))
                   >= today() - {lookback:UInt32}
         ),
@@ -386,9 +386,7 @@ def check_join_integrity(
                 SELECT DISTINCT release_ref, environment
                 FROM deployments
                 WHERE release_ref != ''
-                  AND repo_id IN (
-                      SELECT id FROM repos WHERE org_id = {org_id:String}
-                  )
+                  AND org_id = {org_id:String}
             ) AS d
             ON i.release_ref = d.release_ref
                AND i.environment = d.environment

--- a/src/dev_health_ops/metrics/release_impact.py
+++ b/src/dev_health_ops/metrics/release_impact.py
@@ -140,17 +140,19 @@ def _find_release_env_pairs(
 def _count_total_releases(client: Any, org_id: str, day: date) -> int:
     """Count total distinct release_refs deployed on this day.
 
-    Scoped to the current org's repos: ``deployments`` has no ``org_id``
-    column, so we restrict ``repo_id`` to this org's repos (``repos.id``)
-    to avoid mixing other tenants' deployments into the coverage_ratio
-    denominator (CHAOS-2381).
+    Scoped to ``deployments.org_id`` so other tenants' deployments never enter
+    the coverage_ratio denominator (CHAOS-2381). Filtering the org_id column
+    directly (added to deployments + its sort key in migration 027) is also
+    leak-proof against the duplicate-``repos.id``-across-orgs artifact that a
+    ``repo_id IN (SELECT id FROM repos WHERE org_id=...)`` sub-select would
+    match (CHAOS-2397).
     """
     query = """
         SELECT count(DISTINCT release_ref) AS cnt
         FROM deployments
         WHERE release_ref != ''
           AND toDate(coalesce(deployed_at, started_at)) = {day:Date}
-          AND repo_id IN (SELECT id FROM repos WHERE org_id = {org_id:String})
+          AND org_id = {org_id:String}
     """
     params: dict[str, Any] = {"day": str(day), "org_id": org_id}
     rows = _query_dicts(client, query, params)
@@ -164,16 +166,16 @@ def _get_deploy_timestamp(
 ) -> datetime | None:
     """Get the deploy timestamp for a release_ref + environment.
 
-    Scoped to the current org's repos (``repos.id``): ``release_ref`` +
-    ``environment`` is not globally unique, so an unscoped read could pick
-    another tenant's deployment timestamp (CHAOS-2381).
+    Scoped to ``deployments.org_id``: ``release_ref`` + ``environment`` is not
+    globally unique, so an unscoped read could pick another tenant's deployment
+    timestamp (CHAOS-2381 / CHAOS-2397).
     """
     query = """
         SELECT coalesce(deployed_at, started_at) AS deploy_ts
         FROM deployments
         WHERE release_ref = {release_ref:String}
           AND environment = {environment:String}
-          AND repo_id IN (SELECT id FROM repos WHERE org_id = {org_id:String})
+          AND org_id = {org_id:String}
         ORDER BY deploy_ts DESC
         LIMIT 1
     """
@@ -360,9 +362,9 @@ def _concurrent_deploy_count(
 ) -> int:
     """Count other releases in same environment within 24h window.
 
-    Scoped to the current org's repos (``repos.id``) so concurrent-deploy
-    confounding only counts this tenant's deployments, not other orgs that
-    happen to share the same ``environment`` label (CHAOS-2381).
+    Scoped to ``deployments.org_id`` so concurrent-deploy confounding only
+    counts this tenant's deployments, not other orgs that happen to share the
+    same ``environment`` label (CHAOS-2381 / CHAOS-2397).
     """
     window_start = deploy_ts - timedelta(hours=24)
     window_end = deploy_ts + timedelta(hours=24)
@@ -374,7 +376,7 @@ def _concurrent_deploy_count(
           AND release_ref != ''
           AND coalesce(deployed_at, started_at) >= {window_start:DateTime64(3)}
           AND coalesce(deployed_at, started_at) <= {window_end:DateTime64(3)}
-          AND repo_id IN (SELECT id FROM repos WHERE org_id = {org_id:String})
+          AND org_id = {org_id:String}
     """
     rows = _query_dicts(
         client,
@@ -576,17 +578,17 @@ def _get_repo_id_for_release(
 ) -> UUID | None:
     """Look up repo_id from deployments for a release_ref.
 
-    Scoped to the current org's repos (``repos.id``): without this scope an
-    unscoped read could write ANOTHER tenant's ``repo_id`` into this org's
-    surface-readable ``release_impact_daily`` row, since ``release_ref`` +
-    ``environment`` is not globally unique (CHAOS-2381).
+    Scoped to ``deployments.org_id``: without this scope an unscoped read could
+    write ANOTHER tenant's ``repo_id`` into this org's surface-readable
+    ``release_impact_daily`` row, since ``release_ref`` + ``environment`` is not
+    globally unique (CHAOS-2381 / CHAOS-2397).
     """
     query = """
         SELECT repo_id
         FROM deployments
         WHERE release_ref = {release_ref:String}
           AND environment = {environment:String}
-          AND repo_id IN (SELECT id FROM repos WHERE org_id = {org_id:String})
+          AND org_id = {org_id:String}
         ORDER BY coalesce(deployed_at, started_at) DESC
         LIMIT 1
     """

--- a/tests/api/queries/test_flame_deployment_org_scope.py
+++ b/tests/api/queries/test_flame_deployment_org_scope.py
@@ -45,3 +45,44 @@ async def test_fetch_deployment_scopes_on_deployments_org_id(monkeypatch):
         "deployment_id": "d1",
         "org_id": "org-A",
     }
+
+
+@pytest.mark.asyncio
+async def test_fetch_pull_request_scopes_on_git_pull_requests_org_id(monkeypatch):
+    """CHAOS-2397: the same repos-join leak existed in the PR readers."""
+    captured: dict[str, object] = {}
+
+    async def _fake_query_dicts(client, query, params):
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(flame, "query_dicts", _fake_query_dicts)
+    await flame.fetch_pull_request(object(), repo_id="r1", number=7, org_id="org-A")
+
+    query = str(captured["query"])
+    assert "org_id = %(org_id)s" in query
+    assert "INNER JOIN repos" not in query
+    assert "repos.org_id" not in query
+    assert captured["params"] == {"repo_id": "r1", "number": 7, "org_id": "org-A"}  # type: ignore[comparison-overlap]
+
+
+@pytest.mark.asyncio
+async def test_fetch_pull_request_reviews_scopes_on_org_id(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_query_dicts(client, query, params):
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(flame, "query_dicts", _fake_query_dicts)
+    await flame.fetch_pull_request_reviews(
+        object(), repo_id="r1", number=7, org_id="org-A"
+    )
+
+    query = str(captured["query"])
+    assert "org_id = %(org_id)s" in query
+    assert "INNER JOIN repos" not in query
+    assert "repos.org_id" not in query
+    assert captured["params"] == {"repo_id": "r1", "number": 7, "org_id": "org-A"}  # type: ignore[comparison-overlap]

--- a/tests/api/queries/test_flame_deployment_org_scope.py
+++ b/tests/api/queries/test_flame_deployment_org_scope.py
@@ -1,0 +1,47 @@
+"""CHAOS-2397: flame.fetch_deployment must scope on deployments.org_id.
+
+The previous query joined ``repos`` and filtered ``repos.org_id``. Because
+``repos.id`` is duplicated across orgs (a known fixtures/sync artifact), a shared
+``repo_id`` let the join cross the requester's repos row with ANOTHER tenant's
+deployment row, and ``LIMIT 1`` (no ORDER BY) could return that other tenant's
+deployment on an authenticated ``GET /api/v1/flame?entity_type=deployment``.
+The fix filters ``deployments.org_id`` directly (added to the table + sort key
+in migration 027) and orders by ``last_synced`` for a deterministic latest row.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.queries import flame
+
+
+@pytest.mark.asyncio
+async def test_fetch_deployment_scopes_on_deployments_org_id(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_query_dicts(client, query, params):
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(flame, "query_dicts", _fake_query_dicts)
+
+    await flame.fetch_deployment(
+        object(), repo_id="r1", deployment_id="d1", org_id="org-A"
+    )
+
+    query = str(captured["query"])
+    # Scopes directly on the deployments.org_id column (leak-proof against the
+    # duplicate-repos.id-across-orgs artifact)...
+    assert "org_id = %(org_id)s" in query
+    # ...and no longer routes the tenant check through the repos join.
+    assert "INNER JOIN repos" not in query
+    assert "repos.org_id" not in query
+    # Deterministic latest-version read from the ReplacingMergeTree.
+    assert "ORDER BY last_synced DESC" in query
+    assert captured["params"] == {  # type: ignore[comparison-overlap]
+        "repo_id": "r1",
+        "deployment_id": "d1",
+        "org_id": "org-A",
+    }

--- a/tests/api/queries/test_flame_deployment_org_scope.py
+++ b/tests/api/queries/test_flame_deployment_org_scope.py
@@ -40,7 +40,7 @@ async def test_fetch_deployment_scopes_on_deployments_org_id(monkeypatch):
     assert "repos.org_id" not in query
     # Deterministic latest-version read from the ReplacingMergeTree.
     assert "ORDER BY last_synced DESC" in query
-    assert captured["params"] == {  # type: ignore[comparison-overlap]
+    assert captured["params"] == {
         "repo_id": "r1",
         "deployment_id": "d1",
         "org_id": "org-A",
@@ -64,7 +64,7 @@ async def test_fetch_pull_request_scopes_on_git_pull_requests_org_id(monkeypatch
     assert "org_id = %(org_id)s" in query
     assert "INNER JOIN repos" not in query
     assert "repos.org_id" not in query
-    assert captured["params"] == {"repo_id": "r1", "number": 7, "org_id": "org-A"}  # type: ignore[comparison-overlap]
+    assert captured["params"] == {"repo_id": "r1", "number": 7, "org_id": "org-A"}
 
 
 @pytest.mark.asyncio
@@ -85,4 +85,4 @@ async def test_fetch_pull_request_reviews_scopes_on_org_id(monkeypatch):
     assert "org_id = %(org_id)s" in query
     assert "INNER JOIN repos" not in query
     assert "repos.org_id" not in query
-    assert captured["params"] == {"repo_id": "r1", "number": 7, "org_id": "org-A"}  # type: ignore[comparison-overlap]
+    assert captured["params"] == {"repo_id": "r1", "number": 7, "org_id": "org-A"}

--- a/tests/metrics/test_compute_release_impact.py
+++ b/tests/metrics/test_compute_release_impact.py
@@ -499,7 +499,7 @@ class _OrgScopedDeploymentsFakeClient:
     def query(self, query: str, parameters: dict):
         params = parameters or {}
         q = " ".join(query.split())
-        org_id = params.get("org_id")
+        org_id = str(params.get("org_id") or "")
 
         if "FROM deployments" in q:
             self.deployments_queries.append((q, params))

--- a/tests/metrics/test_compute_release_impact.py
+++ b/tests/metrics/test_compute_release_impact.py
@@ -274,14 +274,15 @@ def test_compute_day_isolates_orgs_sharing_release_ref():
     # coverage_ratio would drop to 0.5).
     assert rec.coverage_ratio == pytest.approx(1.0)
 
-    # EVERY deployments read must carry the repo->org scoping predicate and the
-    # correct org_id param (orgA, never orgB).
+    # EVERY deployments read must scope directly on deployments.org_id and carry
+    # the correct org_id param (orgA, never orgB). CHAOS-2397 replaced the old
+    # leaky ``repo_id IN (SELECT id FROM repos WHERE org_id = ...)`` sub-select
+    # (which matched the duplicate-repos.id-across-orgs artifact) with a direct
+    # org_id column filter, so the sub-select must NOT reappear.
     assert client.deployments_queries, "expected at least one deployments read"
-    scoping_predicate = (
-        "repo_id IN (SELECT id FROM repos WHERE org_id = {org_id:String})"
-    )
     for q, params in client.deployments_queries:
-        assert scoping_predicate in q
+        assert "org_id = {org_id:String}" in q
+        assert "repo_id IN (SELECT id FROM repos" not in q
         assert params.get("org_id") == _ORG_A
         assert params.get("org_id") != _ORG_B
 
@@ -436,3 +437,208 @@ def test_two_releases_same_env_get_isolated_telemetry():
     # 5) Per-release completeness differs (24h vs 12h of buckets).
     assert healthy.data_completeness == pytest.approx(1.0)
     assert regressed.data_completeness == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Deployments-read isolation by deployments.org_id (CHAOS-2397)
+#
+# CHAOS-2381 originally scoped deployments reads via a
+# ``repo_id IN (SELECT id FROM repos WHERE org_id = ...)`` sub-select. That
+# sub-select is LEAKY against the real-world artifact where the same
+# ``repos.id`` UUID exists under two different orgs (duplicate-repos.id across
+# tenants): both orgs' rows match the IN-list, so orgA's compute could read
+# orgB's deployment timestamp / repo_id / inflate the release denominator.
+#
+# Migration 027 added ``org_id`` to ``deployments`` (column + sort key), so the
+# fix filters ``AND org_id = {org_id:String}`` DIRECTLY on ``deployments``.
+# That is leak-proof regardless of how repos.id collides across orgs.
+#
+# This fake models the duplicate-repos.id artifact explicitly: orgA and orgB
+# both deployed the SAME release_ref + environment under the SAME repo_id.
+# It resolves deployments reads by the deployments.org_id PARAM only — so if
+# the production query dropped that predicate (or re-introduced the repos
+# sub-select that matches the shared repo_id), orgA would see orgB's row and
+# the assertions below would fail.
+#
+# These are UNIT tests (no live ClickHouse), mirroring the sibling fake-client
+# style above. We also assert on the generated SQL text to lock the fix in:
+# the deployments reads must NOT contain the repos sub-select and MUST contain
+# ``org_id = {org_id:String}``.
+# ---------------------------------------------------------------------------
+
+_ORG_X = "orgX"
+_ORG_Y = "orgY"
+_SHARED_REL_2397 = "v3.0.0"
+_SHARED_ENV_2397 = "production"
+
+
+class _OrgScopedDeploymentsFakeClient:
+    """Fake CH client enforcing deployments.org_id scoping (CHAOS-2397).
+
+    Both orgs share release_ref + environment AND the SAME repo_id (the
+    duplicate-repos.id-across-orgs artifact). Deployment rows are keyed ONLY by
+    the deployments.org_id parameter — never by repo_id — so a query that
+    dropped the org_id predicate would surface the other org's row.
+    """
+
+    def __init__(self, shared_repo_id):
+        self._shared_repo_id = shared_repo_id
+        # deployments rows: org_id -> deploy timestamp. Distinct timestamps so a
+        # cross-tenant read of _get_deploy_timestamp is detectable.
+        self._deploy_ts = {
+            _ORG_X: datetime(2026, 3, 15, 8, 0, tzinfo=timezone.utc),
+            _ORG_Y: datetime(2026, 3, 15, 20, 0, tzinfo=timezone.utc),
+        }
+        # release_refs deployed per org on the day (denominator source).
+        self._releases = {
+            _ORG_X: {_SHARED_REL_2397},
+            _ORG_Y: {_SHARED_REL_2397, "v3.1.0"},  # orgY has an extra release
+        }
+        self.deployments_queries: list[tuple[str, dict]] = []
+
+    def query(self, query: str, parameters: dict):
+        params = parameters or {}
+        q = " ".join(query.split())
+        org_id = params.get("org_id")
+
+        if "FROM deployments" in q:
+            self.deployments_queries.append((q, params))
+            # release-count denominator
+            if "count(DISTINCT release_ref)" in q and "AS cnt" in q:
+                cnt = len(self._releases.get(org_id, set()))
+                return FakeQueryResult(["cnt"], [[cnt]])
+            # repo_id lookup (shared id, but only returned for known orgs)
+            if "SELECT repo_id" in q:
+                if org_id in self._deploy_ts:
+                    return FakeQueryResult(["repo_id"], [[str(self._shared_repo_id)]])
+                return FakeQueryResult(["repo_id"], [])
+            # deploy timestamp — org-specific
+            if "AS deploy_ts" in q:
+                ts = self._deploy_ts.get(org_id)
+                rows: list[list[Any]] = [[ts]] if ts is not None else []
+                return FakeQueryResult(["deploy_ts"], rows)
+            # concurrent deploy count
+            return FakeQueryResult(["cnt"], [[0]])
+
+        if "SELECT DISTINCT release_ref, environment" in q:
+            return FakeQueryResult(
+                ["release_ref", "environment"],
+                [[_SHARED_REL_2397, _SHARED_ENV_2397]],
+            )
+        if "total_signals" in q and "total_sessions" in q:
+            return FakeQueryResult(["total_signals", "total_sessions"], [[5, 400]])
+        if "first_friction_ts" in q:
+            return FakeQueryResult(["first_friction_ts"], [])
+        if "bucket_hours" in q:
+            return FakeQueryResult(["bucket_hours"], [[24]])
+        return FakeQueryResult([], [])
+
+
+def test_count_total_releases_scoped_by_deployments_org_id():
+    """_count_total_releases reads ONLY this org's deployments (CHAOS-2397)."""
+    from dev_health_ops.metrics.release_impact import _count_total_releases
+
+    shared_repo = uuid4()
+    client = _OrgScopedDeploymentsFakeClient(shared_repo)
+    day = date(2026, 3, 15)
+
+    # orgX deployed exactly one release_ref; orgY deployed two. If orgY's
+    # deployments leaked into orgX's denominator the count would be 2.
+    assert _count_total_releases(client, _ORG_X, day) == 1
+    assert _count_total_releases(client, _ORG_Y, day) == 2
+
+    # Every deployments read carried org_id = {org_id:String} directly and never
+    # the leaky repos sub-select.
+    assert client.deployments_queries
+    for q, params in client.deployments_queries:
+        assert "org_id = {org_id:String}" in q
+        assert "repo_id IN (SELECT id FROM repos" not in q
+        assert params.get("org_id") in (_ORG_X, _ORG_Y)
+
+
+def test_get_deploy_timestamp_scoped_by_deployments_org_id():
+    """_get_deploy_timestamp never returns another org's deploy (CHAOS-2397).
+
+    orgX and orgY share release_ref + environment + repo_id (the duplicate-
+    repos.id artifact) but have distinct deploy timestamps. Each org must read
+    only its own.
+    """
+    from dev_health_ops.metrics.release_impact import _get_deploy_timestamp
+
+    shared_repo = uuid4()
+    client = _OrgScopedDeploymentsFakeClient(shared_repo)
+
+    ts_x = _get_deploy_timestamp(client, _ORG_X, _SHARED_REL_2397, _SHARED_ENV_2397)
+    ts_y = _get_deploy_timestamp(client, _ORG_Y, _SHARED_REL_2397, _SHARED_ENV_2397)
+
+    assert ts_x == datetime(2026, 3, 15, 8, 0, tzinfo=timezone.utc)
+    assert ts_y == datetime(2026, 3, 15, 20, 0, tzinfo=timezone.utc)
+    # No cross-tenant bleed: shared release_ref/env/repo_id did not merge them.
+    assert ts_x != ts_y
+
+
+def test_compute_day_orgX_excludes_orgY_sharing_release_and_repo():
+    """End-to-end: orgX compute sees only orgX deployment data (CHAOS-2397)."""
+    shared_repo = uuid4()
+    client = _OrgScopedDeploymentsFakeClient(shared_repo)
+
+    records = _compute_day(
+        client, _ORG_X, date(2026, 3, 15), datetime.now(tz=timezone.utc)
+    )
+
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.org_id == _ORG_X
+    assert rec.repo_id == shared_repo
+    # orgX has 1 covered / 1 total release; orgY's extra release_ref must NOT
+    # inflate the denominator (which would drop coverage_ratio to 0.5).
+    assert rec.coverage_ratio == pytest.approx(1.0)
+
+    # All deployments reads scoped directly on deployments.org_id, no repos
+    # sub-select, and only ever orgX's id.
+    assert client.deployments_queries
+    for q, params in client.deployments_queries:
+        assert "org_id = {org_id:String}" in q
+        assert "repo_id IN (SELECT id FROM repos" not in q
+        assert params.get("org_id") == _ORG_X
+        assert params.get("org_id") != _ORG_Y
+
+
+def test_deployments_queries_have_no_repos_subselect_in_source():
+    """SQL guard: every deployments read in release_impact + ff_validation
+    filters deployments.org_id directly and never the leaky repos sub-select
+    (CHAOS-2397). Inspects the generated query strings via capturing clients.
+    """
+    import dev_health_ops.metrics.ff_validation as ff
+    import dev_health_ops.metrics.release_impact as ri
+
+    captured: list[str] = []
+
+    class _CaptureClient:
+        def query(self, query: str, parameters: dict | None = None):
+            q = " ".join(query.split())
+            if "FROM deployments" in q:
+                captured.append(q)
+            # Return a benign empty-ish result so callers don't crash.
+            return FakeQueryResult([], [])
+
+    client = _CaptureClient()
+    day = date(2026, 3, 15)
+    deploy_ts = datetime(2026, 3, 15, 10, 0, tzinfo=timezone.utc)
+
+    # release_impact.py deployments readers
+    ri._count_total_releases(client, "orgZ", day)
+    ri._get_deploy_timestamp(client, "orgZ", _SHARED_REL_2397, _SHARED_ENV_2397)
+    ri._get_repo_id_for_release(client, "orgZ", _SHARED_REL_2397, _SHARED_ENV_2397)
+    ri._concurrent_deploy_count(
+        client, "orgZ", _SHARED_REL_2397, _SHARED_ENV_2397, deploy_ts
+    )
+
+    # ff_validation.py deployments readers (coverage + join_integrity CTEs)
+    ff.check_coverage(client, "orgZ")
+    ff.check_join_integrity(client, "orgZ")
+
+    assert captured, "expected captured deployments queries"
+    for q in captured:
+        assert "repo_id IN (SELECT id FROM repos" not in q, q
+        assert "org_id = {org_id:String}" in q, q

--- a/tests/metrics/test_compute_release_impact.py
+++ b/tests/metrics/test_compute_release_impact.py
@@ -610,7 +610,12 @@ def test_deployments_queries_have_no_repos_subselect_in_source():
     (CHAOS-2397). Inspects the generated query strings via capturing clients.
     """
     import dev_health_ops.metrics.ff_validation as ff
-    import dev_health_ops.metrics.release_impact as ri
+    from dev_health_ops.metrics.release_impact import (
+        _concurrent_deploy_count,
+        _count_total_releases,
+        _get_deploy_timestamp,
+        _get_repo_id_for_release,
+    )
 
     captured: list[str] = []
 
@@ -627,10 +632,10 @@ def test_deployments_queries_have_no_repos_subselect_in_source():
     deploy_ts = datetime(2026, 3, 15, 10, 0, tzinfo=timezone.utc)
 
     # release_impact.py deployments readers
-    ri._count_total_releases(client, "orgZ", day)
-    ri._get_deploy_timestamp(client, "orgZ", _SHARED_REL_2397, _SHARED_ENV_2397)
-    ri._get_repo_id_for_release(client, "orgZ", _SHARED_REL_2397, _SHARED_ENV_2397)
-    ri._concurrent_deploy_count(
+    _count_total_releases(client, "orgZ", day)
+    _get_deploy_timestamp(client, "orgZ", _SHARED_REL_2397, _SHARED_ENV_2397)
+    _get_repo_id_for_release(client, "orgZ", _SHARED_REL_2397, _SHARED_ENV_2397)
+    _concurrent_deploy_count(
         client, "orgZ", _SHARED_REL_2397, _SHARED_ENV_2397, deploy_ts
     )
 


### PR DESCRIPTION
## CHAOS-2397 — scope deployments reads by org_id (not the leaky repos sub-select)

**Context.** `deployments` already has `org_id` + it is the RMT sort-key prefix (migration 027).
Several reads still scoped tenants via `repo_id IN (SELECT id FROM repos WHERE org_id = …)`, which
**leaks**: `repos.id` is duplicated across orgs (20 ids live), so the sub-select matches another
tenant's repo. On the live org `900f96be` the old sub-select returned **931** release_refs vs **920**
with the direct `org_id` filter — **11 cross-tenant leaks**.

**Fix.** Replace the sub-select with `AND org_id = {org_id:String}` directly on `deployments` in:
- `metrics/release_impact.py` (4 reads) and `metrics/ff_validation.py` (2 reads — one was wrapped
  across lines and missed by a one-line grep).
- `api/queries/flame.py` `fetch_deployment` (authenticated `GET /api/v1/flame?entity_type=deployment`)
  scoped on `repos.org_id` via JOIN; for a shared `repo_id`, `LIMIT 1` (no ORDER BY) could return
  another org's deployment. Rewritten to filter `deployments.org_id` directly with
  `ORDER BY last_synced DESC`. **(Found by adversarial review.)**

No migration needed (027 already added the column + sort key; live `deployments.org_id` is fully
populated with real UUIDs — 0 empty/`default`).

**Validation.** Org-isolation unit tests (shared release_ref+repo_id across two orgs stays isolated);
`fetch_deployment` query asserts direct `org_id` scoping + no `repos` JOIN; read-only live check that
the OLD flame join returned both orgs' rows while the NEW returns only the requester's.

Gates: ruff ✓ · mypy ✓ · pytest ✓. Closes CHAOS-2397.
