### PR TITLE
fix(cli): repair metrics rebuild and work-graph verification (CHAOS-2410/CHAOS-2411)

### DIFF
--- a/src/dev_health_ops/metrics/sinks/clickhouse/core.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/core.py
@@ -46,6 +46,9 @@ class ClickHouseCore(BaseMetricsSink):
     `computed_at`. Queries can select the latest version via `argMax`.
     """
 
+    def query(self, query: str, parameters: dict[str, Any] | None = None) -> Any:
+        return self.client.query(query, parameters=parameters or {})
+
     def query_dicts(
         self, query: str, parameters: dict[str, Any]
     ) -> list[dict[str, Any]]:

--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -113,6 +113,8 @@ def run_work_graph_build(ns: argparse.Namespace) -> int:
 
         client = getattr(builder, "client", None)
         if client is None:
+            client = getattr(getattr(builder, "sink", None), "client", None)
+        if client is None:
             logging.error(
                 "FAIL: Work graph builder did not expose a ClickHouse client."
             )

--- a/tests/metrics/test_clickhouse_sink_query.py
+++ b/tests/metrics/test_clickhouse_sink_query.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+
+def test_query_delegates_to_owned_clickhouse_client():
+    client = MagicMock()
+    client.query.return_value.result_rows = [[1]]
+
+    sink = ClickHouseMetricsSink("clickhouse://localhost:9000/default", client=client)
+    result = sink.query("SELECT count() FROM repo_metrics_daily")
+
+    assert result.result_rows == [[1]]
+    client.query.assert_called_once_with(
+        "SELECT count() FROM repo_metrics_daily", parameters={}
+    )
+
+
+def test_query_passes_parameters_to_owned_clickhouse_client():
+    client = MagicMock()
+    client.query.return_value.result_rows = [["repo-1"]]
+
+    sink = ClickHouseMetricsSink("clickhouse://localhost:9000/default", client=client)
+    result = sink.query(
+        "SELECT id FROM repos WHERE org_id = {org_id:String}",
+        parameters={"org_id": "org-abc"},
+    )
+
+    assert result.result_rows == [["repo-1"]]
+    client.query.assert_called_once_with(
+        "SELECT id FROM repos WHERE org_id = {org_id:String}",
+        parameters={"org_id": "org-abc"},
+    )

--- a/tests/work_graph/test_runner.py
+++ b/tests/work_graph/test_runner.py
@@ -86,3 +86,21 @@ def test_blank_org_fails_closed():
 
     assert rc == 2
     builder_cls.assert_not_called()
+
+
+def test_verification_uses_builder_sink_client_when_builder_has_no_client():
+    fake_builder = MagicMock()
+    fake_builder.build.return_value = {"pr_commit_edges": 1}
+    fake_builder.client = None
+    client = MagicMock()
+    client.query.return_value.result_rows = [[1]]
+    fake_builder.sink.client = client
+
+    with patch(
+        "dev_health_ops.work_graph.runner.WorkGraphBuilder",
+        return_value=fake_builder,
+    ):
+        rc = run_work_graph_build(_ns(org="org-abc"))
+
+    assert rc == 0
+    client.query.assert_called_once()


### PR DESCRIPTION
## Summary
- Add a raw `query()` facade to `ClickHouseMetricsSink` so CLI/verification paths that receive the sink wrapper can execute ClickHouse reads.
- Make `dev-hops work-graph build` verify persisted edges through `builder.sink.client` when the builder does not expose a direct `client` attribute.
- Confirm CHAOS-2412/CHAOS-2413 fixes are present on current main and keep their targeted regression tests green.

## Verification
- `PYTHONPATH=src .venv/bin/python -m pytest tests/metrics/test_clickhouse_sink_query.py tests/work_graph/test_runner.py tests/testops/test_junit_parser_read_text.py tests/providers/test_provider_base_import.py`
- `uv run ruff format --check src/dev_health_ops/metrics/sinks/clickhouse/core.py src/dev_health_ops/work_graph/runner.py tests/work_graph/test_runner.py tests/metrics/test_clickhouse_sink_query.py`
- `uv run ruff check src/dev_health_ops/metrics/sinks/clickhouse/core.py src/dev_health_ops/work_graph/runner.py tests/work_graph/test_runner.py tests/metrics/test_clickhouse_sink_query.py`
- CLI smoke: `PYTHONPATH=src .venv/bin/dev-hops work-graph build --help`, `PYTHONPATH=src .venv/bin/dev-hops metrics rebuild --help`
- Runtime seam smoke: sink `query()` delegated to the owned ClickHouse client; work-graph runner returned 0 using `builder.sink.client` fallback.

Closes CHAOS-2410
Closes CHAOS-2411