### PR TITLE
fix(workers): dispatch run_dora_metrics after deployments/cicd/incidents sync (CHAOS-2399)

### DIFF
--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -17,7 +17,6 @@ from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.org_guard import organization_exists_sync
 from dev_health_ops.workers.task_utils import (
-    _DORA_TARGETS,
     _GIT_TARGETS,
     _WORK_ITEM_TARGETS,
     _as_dict,
@@ -34,6 +33,14 @@ from dev_health_ops.workers.task_utils import (
     _normalize_sync_targets,
     _resolve_env_credentials,
 )
+
+# DORA (deployment frequency, lead time, change-failure-rate, MTTR) is computed
+# from synced deployments/CI/incidents in ClickHouse. These targets can be
+# scheduled independently of git/prs (e.g. a deployments-only sync config), so a
+# post-sync DORA recompute must fire on any of them, not only on git (CHAOS-2399
+# — without this a deployments-only sync lagged DORA up to a day until the daily
+# beat). Defined here next to its sole consumer (_dispatch_post_sync_tasks).
+_DORA_TARGETS = {"deployments", "cicd", "incidents"}
 
 logger = logging.getLogger(__name__)
 

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -17,6 +17,7 @@ from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.org_guard import organization_exists_sync
 from dev_health_ops.workers.task_utils import (
+    _DORA_TARGETS,
     _GIT_TARGETS,
     _WORK_ITEM_TARGETS,
     _as_dict,
@@ -300,6 +301,7 @@ def _dispatch_post_sync_tasks(
     target_set = set(sync_targets)
     has_git = bool(target_set & _GIT_TARGETS)
     has_work_items = bool(target_set & _WORK_ITEM_TARGETS)
+    has_dora = bool(target_set & _DORA_TARGETS)
     dispatched: list[str] = []
 
     if has_git:
@@ -346,10 +348,14 @@ def _dispatch_post_sync_tasks(
         dispatched.append("run_work_graph_build")
         dispatched.append("run_investment_materialize")
 
-    if has_git:
+    if has_git or has_dora:
         # CHAOS-2382: DORA is provider-agnostic — computed from synced
         # deployments/incidents in ClickHouse, which both GitHub and GitLab
         # populate. Dispatch for every git-syncing org, not just GitLab.
+        # CHAOS-2399: also dispatch after a deployments/cicd/incidents sync.
+        # Those targets can be scheduled without git (a deployments-only sync
+        # config), and they are exactly the inputs DORA reads — so gating on
+        # git alone left DORA stale until the daily beat after such a sync.
         celery_app.send_task(
             "dev_health_ops.workers.tasks.run_dora_metrics",
             kwargs={"org_id": org_id},

--- a/src/dev_health_ops/workers/task_utils.py
+++ b/src/dev_health_ops/workers/task_utils.py
@@ -197,6 +197,13 @@ def _as_dict(value: object | None) -> dict[str, Any]:
 
 _GIT_TARGETS = {"git", "prs"}
 _WORK_ITEM_TARGETS = {"work-items"}
+# DORA (deployment frequency, lead time, change-failure-rate, MTTR) is computed
+# from synced deployments/CI/incidents in ClickHouse. These targets can be
+# scheduled independently of git/prs (e.g. a deployments-only sync config), so a
+# post-sync DORA recompute must fire on any of them, not only on git (CHAOS-2399
+# — without this a deployments-only sync lagged DORA up to a day until the daily
+# beat).
+_DORA_TARGETS = {"deployments", "cicd", "incidents"}
 _WORK_ITEM_PROVIDERS = {"github", "gitlab", "jira", "linear"}
 
 

--- a/src/dev_health_ops/workers/task_utils.py
+++ b/src/dev_health_ops/workers/task_utils.py
@@ -197,13 +197,6 @@ def _as_dict(value: object | None) -> dict[str, Any]:
 
 _GIT_TARGETS = {"git", "prs"}
 _WORK_ITEM_TARGETS = {"work-items"}
-# DORA (deployment frequency, lead time, change-failure-rate, MTTR) is computed
-# from synced deployments/CI/incidents in ClickHouse. These targets can be
-# scheduled independently of git/prs (e.g. a deployments-only sync config), so a
-# post-sync DORA recompute must fire on any of them, not only on git (CHAOS-2399
-# — without this a deployments-only sync lagged DORA up to a day until the daily
-# beat).
-_DORA_TARGETS = {"deployments", "cicd", "incidents"}
 _WORK_ITEM_PROVIDERS = {"github", "gitlab", "jira", "linear"}
 
 

--- a/tests/test_post_sync_dora_dispatch.py
+++ b/tests/test_post_sync_dora_dispatch.py
@@ -22,9 +22,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-# Import connectors first to defuse the providers._base <-> connectors circular
-# import that otherwise ERRORs isolated collection (mirrors CHAOS-2370).
-import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.workers.sync_runtime import _dispatch_post_sync_tasks
 
 _DORA_TASK = "dev_health_ops.workers.tasks.run_dora_metrics"

--- a/tests/test_post_sync_dora_dispatch.py
+++ b/tests/test_post_sync_dora_dispatch.py
@@ -1,0 +1,140 @@
+"""Unit tests for the post-sync DORA dispatch (CHAOS-2399).
+
+DORA metrics (deployment frequency, lead time, change-fail rate, MTTR) are
+computed by the ``run_dora_metrics`` Celery task from
+deployments/cicd/incidents rows persisted in ClickHouse. Originally
+``_dispatch_post_sync_tasks`` only enqueued ``run_dora_metrics`` after a *git*
+sync (CHAOS-2382). But the DORA inputs — ``deployments``, ``cicd`` and
+``incidents`` — can be carried by sync configs that do **not** also sync git
+(e.g. a deployments-only config). Gating DORA on git alone left those orgs with
+stale DORA until the next daily beat after such a sync.
+
+``_dispatch_post_sync_tasks`` now computes
+``has_dora = target_set & _DORA_TARGETS`` ({"deployments", "cicd",
+"incidents"}) and dispatches ``run_dora_metrics`` when ``has_git or has_dora``.
+
+These tests prove the seam without a live ClickHouse: they patch the same
+Celery ``send_task`` / ``chain`` / ``signature`` factories the sibling
+investment-dispatch test patches and assert the dispatch contract.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+# Import connectors first to defuse the providers._base <-> connectors circular
+# import that otherwise ERRORs isolated collection (mirrors CHAOS-2370).
+import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.workers.sync_runtime import _dispatch_post_sync_tasks
+
+_DORA_TASK = "dev_health_ops.workers.tasks.run_dora_metrics"
+
+
+def _run_dispatch(provider: str, sync_targets: list[str], org_id: str):
+    """Drive _dispatch_post_sync_tasks with chain/signature/send_task patched.
+
+    Returns (signature_mock, chain_mock, chain_instance_mock, send_task_mock).
+    """
+    with (
+        patch(
+            "dev_health_ops.workers.sync_runtime.celery_app.signature"
+        ) as mock_signature,
+        patch("dev_health_ops.workers.sync_runtime.chain") as mock_chain,
+        patch(
+            "dev_health_ops.workers.sync_runtime.celery_app.send_task"
+        ) as mock_send_task,
+    ):
+
+        def _make_sig(name, **kwargs):
+            sig = MagicMock(name=f"sig:{name}")
+            sig.task_name = name
+            sig.sig_kwargs = kwargs
+            return sig
+
+        mock_signature.side_effect = _make_sig
+        chain_instance = MagicMock(name="chain_instance")
+        mock_chain.return_value = chain_instance
+        _dispatch_post_sync_tasks(
+            provider=provider,
+            sync_targets=sync_targets,
+            org_id=org_id,
+        )
+    return mock_signature, mock_chain, chain_instance, mock_send_task
+
+
+def _dora_calls(mock_send_task):
+    """Return the send_task call objects that dispatched run_dora_metrics."""
+    return [
+        call
+        for call in mock_send_task.call_args_list
+        if call.args and call.args[0] == _DORA_TASK
+    ]
+
+
+def test_dora_dispatched_for_deployments_only_no_git() -> None:
+    """deployments-only (no git) => run_dora_metrics sent, org-scoped."""
+    _, _, _, mock_send_task = _run_dispatch(
+        provider="github",
+        sync_targets=["deployments"],
+        org_id="org-123",
+    )
+
+    dora_calls = _dora_calls(mock_send_task)
+    assert len(dora_calls) == 1
+    call = dora_calls[0]
+    assert call.kwargs["kwargs"] == {"org_id": "org-123"}
+    assert call.kwargs["queue"] == "metrics"
+
+
+def test_dora_dispatched_for_cicd_only_no_git() -> None:
+    """cicd-only (no git) => run_dora_metrics sent, org-scoped."""
+    _, _, _, mock_send_task = _run_dispatch(
+        provider="github",
+        sync_targets=["cicd"],
+        org_id="org-456",
+    )
+
+    dora_calls = _dora_calls(mock_send_task)
+    assert len(dora_calls) == 1
+    assert dora_calls[0].kwargs["kwargs"] == {"org_id": "org-456"}
+
+
+def test_dora_dispatched_for_incidents_only_no_git() -> None:
+    """incidents-only (no git) => run_dora_metrics sent, org-scoped."""
+    _, _, _, mock_send_task = _run_dispatch(
+        provider="github",
+        sync_targets=["incidents"],
+        org_id="org-789",
+    )
+
+    dora_calls = _dora_calls(mock_send_task)
+    assert len(dora_calls) == 1
+    assert dora_calls[0].kwargs["kwargs"] == {"org_id": "org-789"}
+
+
+def test_dora_not_dispatched_for_work_items_only() -> None:
+    """work-items-only (no git, no DORA targets) => run_dora_metrics NOT sent.
+
+    A Jira/Linear work-items sync still fires the investment chain, but DORA has
+    no fresh inputs, so it must not be enqueued.
+    """
+    _, _, _, mock_send_task = _run_dispatch(
+        provider="jira",
+        sync_targets=["work-items"],
+        org_id="org-123",
+    )
+
+    assert _dora_calls(mock_send_task) == []
+
+
+def test_dora_dispatched_for_git_only() -> None:
+    """git-only still dispatches run_dora_metrics (CHAOS-2382 unchanged)."""
+    _, _, _, mock_send_task = _run_dispatch(
+        provider="github",
+        sync_targets=["git", "prs"],
+        org_id="org-123",
+    )
+
+    dora_calls = _dora_calls(mock_send_task)
+    assert len(dora_calls) == 1
+    assert dora_calls[0].kwargs["kwargs"] == {"org_id": "org-123"}


### PR DESCRIPTION
## CHAOS-2399 — dispatch run_dora_metrics after deployments/cicd/incidents sync

**Bug (freshness).** Post-sync DORA recompute was gated on `has_git` only. DORA is computed from
synced deployments/CI/incidents, and those targets can be scheduled independently of git (e.g. a
deployments-only sync config), so after such a sync DORA lagged up to a day until the daily beat.

**Fix.** Add `_DORA_TARGETS = {"deployments","cicd","incidents"}` (`task_utils.py`) and dispatch
`run_dora_metrics` when `has_git or has_dora` in `_dispatch_post_sync_tasks`. Single dispatch (no
double-send when both git and dora targets are present); already inside the post-sync success branch.

**Validation.** Unit tests (mirroring the investment-dispatch sibling): deployments-only / cicd-only /
incidents-only each dispatch `run_dora_metrics{org_id}`; work-items-only does not; git-only still does.

Gates: ruff ✓ · mypy ✓ · pytest ✓. Closes CHAOS-2399.
