### PR TITLE
fix(metrics): inject forecast reference date to de-flake capacity test (CHAOS-2400)

### DIFF
--- a/src/dev_health_ops/metrics/compute_capacity.py
+++ b/src/dev_health_ops/metrics/compute_capacity.py
@@ -260,6 +260,7 @@ def forecast_capacity(
     work_scope_id: str | None = None,
     simulations: int = 10000,
     seed: int | None = None,
+    today: date | None = None,
 ) -> ForecastResult:
     """Compute capacity forecast using Monte Carlo simulation.
 
@@ -276,6 +277,12 @@ def forecast_capacity(
         work_scope_id: Work scope identifier (optional).
         simulations: Number of Monte Carlo simulations.
         seed: Random seed for reproducibility.
+        today: Reference date for the forecast horizon (``days_available =
+            target_date - today``). Defaults to the current UTC date. Inject a
+            fixed value for deterministic tests: ``target_date`` derived from a
+            local ``date.today()`` while the horizon is measured against UTC
+            ``now.date()`` makes ``days_available`` (and therefore the
+            quantiles) flip by one near a UTC-midnight boundary (CHAOS-2400).
 
     Returns:
         ForecastResult with percentile estimates.
@@ -291,7 +298,8 @@ def forecast_capacity(
         raise ValueError("Cannot forecast with empty throughput history")
 
     now = datetime.now(timezone.utc)
-    today = now.date()
+    if today is None:
+        today = now.date()
     forecast_id = str(uuid.uuid4())
 
     p50_days: int | None = None

--- a/src/dev_health_ops/metrics/compute_capacity.py
+++ b/src/dev_health_ops/metrics/compute_capacity.py
@@ -279,8 +279,8 @@ def forecast_capacity(
         seed: Random seed for reproducibility.
         today: Reference date for the forecast horizon (``days_available =
             target_date - today``). Defaults to the current UTC date. Inject a
-            fixed value for deterministic tests: ``target_date`` derived from a
-            local ``date.today()`` while the horizon is measured against UTC
+            fixed value for deterministic tests: a ``target_date`` derived from a
+            naive local "today" while the horizon is measured against the UTC
             ``now.date()`` makes ``days_available`` (and therefore the
             quantiles) flip by one near a UTC-midnight boundary (CHAOS-2400).
 

--- a/tests/metrics/test_compute_capacity.py
+++ b/tests/metrics/test_compute_capacity.py
@@ -207,17 +207,27 @@ class TestForecastCapacity:
         samples = _make_samples([5] * 30)
         history = ThroughputHistory(samples)
 
-        target = date.today() + timedelta(days=10)
+        # CHAOS-2400: pin `today` to the SAME reference used to build the target
+        # so days_available is exactly 10. Without injection the target is built
+        # from a naive local date.today() while forecast_capacity measures the
+        # horizon against UTC now.date(); near a UTC-midnight boundary the two
+        # differ by a day, days_available flips 10->9, and the deterministic
+        # quantiles drop 50->45, making this assertion flaky.
+        reference = date.today()
+        target = reference + timedelta(days=10)
         result = forecast_capacity(
             history,
             target_date=target,
             simulations=1000,
             seed=42,
+            today=reference,
         )
 
         assert result.target_date == target
         assert result.target_items is None
 
+        # 30 days of constant throughput == 5 -> every Monte Carlo draw is 5, so
+        # 10 days available yields exactly 50 items at every percentile.
         assert result.p50_items == 50
         assert result.p85_items == 50
         assert result.p95_items == 50
@@ -229,13 +239,15 @@ class TestForecastCapacity:
         samples = _make_samples([5] * 30)
         history = ThroughputHistory(samples)
 
-        target_date = date.today() + timedelta(days=10)
+        reference = date.today()
+        target_date = reference + timedelta(days=10)
         result = forecast_capacity(
             history,
             target_items=50,
             target_date=target_date,
             simulations=1000,
             seed=42,
+            today=reference,
         )
 
         assert result.p50_days is not None
@@ -262,8 +274,11 @@ class TestForecastCapacity:
         samples = _make_samples([5] * 30)
         history = ThroughputHistory(samples)
 
-        past_date = date.today() - timedelta(days=10)
-        result = forecast_capacity(history, target_date=past_date, simulations=100)
+        reference = date.today()
+        past_date = reference - timedelta(days=10)
+        result = forecast_capacity(
+            history, target_date=past_date, simulations=100, today=reference
+        )
 
         assert result.p50_items == 0
         assert result.p85_items == 0


### PR DESCRIPTION
## CHAOS-2400 — de-flake the capacity forecast test (injectable reference date)

**Bug (flaky test).** `forecast_capacity` built the target from a naive local `date.today()` while
measuring the horizon against UTC `now.date()`. Near a UTC-midnight boundary the two differ by a day,
so `days_available` flips 10→9 and the deterministic quantiles drop 50→45, failing
`test_fixed_date_forecast` (and siblings).

**Fix.** Add an injectable `today: date | None = None` parameter to `forecast_capacity`
(`if today is None: today = now.date()` — fully backward compatible; both production callers use
keyword args and never pass it). The three affected tests pin one `reference = date.today()` for both
the target and `today`, making `days_available == 10` deterministic regardless of timezone/midnight.

Confirmed against the real function: `days_available=10 → p50=p85=p95=50`; `=9 → 45` (the observed flake).

Gates: ruff ✓ · mypy ✓ · pytest ✓ (26 capacity tests). Closes CHAOS-2400.
