### PR TITLE
fix(gitlab): bound repo-tree pagination to prevent infinite loop (CI test-matrix hang)

### DIFF
--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -1049,8 +1049,15 @@ def _iter_gitlab_repo_tree(
 ) -> Iterable[Any]:
     page = 1
     seen = 0
+    # Defensive page cap. GitLab paginates until it returns an empty page, but a
+    # transport/API glitch — or a test double whose ``repository_tree()`` is a
+    # truthy Mock that never yields a falsy page — would otherwise spin forever
+    # (an unbounded REST crawl that hangs the sync; this hung the unit suite to
+    # the CI job timeout). 10k pages at per_page=100 covers ~1M tree entries,
+    # far beyond any real repository.
+    max_pages = 10_000
 
-    while True:
+    while page <= max_pages:
         try:
             page_items = gl_project.repository_tree(
                 ref=ref,
@@ -1067,13 +1074,21 @@ def _iter_gitlab_repo_tree(
                 page=page,
                 all=False,
             )
-        if not page_items:
+        # An empty page marks the end. Check the length explicitly: a real
+        # GitLab response is a list (``[]`` is falsy), but a truthy-but-empty
+        # container — e.g. a test Mock with no configured return — is not caught
+        # by ``not page_items`` alone and would loop until ``max_pages``.
+        try:
+            page_len = len(page_items)
+        except TypeError:
+            page_len = 0
+        if not page_items or page_len == 0:
             break
-        seen += len(page_items)
+        seen += page_len
         logging.debug(
             "GitLab repo tree page %d returned %d items (total: %d)",
             page,
-            len(page_items),
+            page_len,
             seen,
         )
         yield from page_items

--- a/tests/test_processors_gitlab.py
+++ b/tests/test_processors_gitlab.py
@@ -80,6 +80,13 @@ async def test_process_gitlab_project_sync_flags(monkeypatch):
         patch(
             "dev_health_ops.processors.gitlab._fetch_gitlab_blame_sync", return_value=[]
         ),
+        # Backfill paginates the GitLab repo tree; on a Mock store that never
+        # yields an empty page it would loop forever. This test exercises the
+        # sync-flag dispatch, not backfill, so stub it out (hermetic + fast).
+        patch(
+            "dev_health_ops.processors.gitlab._backfill_gitlab_missing_data",
+            new_callable=AsyncMock,
+        ),
     ):
         # Call the function with all sync flags enabled
         await process_gitlab_project(
@@ -139,6 +146,11 @@ async def test_process_gitlab_project_no_sync_flags(monkeypatch):
         patch(
             "dev_health_ops.processors.gitlab._fetch_gitlab_incidents_sync"
         ) as mock_fetch_incidents,
+        # Stub backfill (repo-tree pagination) so a Mock store can't loop forever.
+        patch(
+            "dev_health_ops.processors.gitlab._backfill_gitlab_missing_data",
+            new_callable=AsyncMock,
+        ),
     ):
         # Call with flags False
         await process_gitlab_project(


### PR DESCRIPTION
## Bound GitLab repo-tree pagination — fixes the test-matrix CI hang

**Root cause.** `_iter_gitlab_repo_tree` (processors/gitlab.py, added by the #901 blame backfill) paginates
`gl_project.repository_tree(...)` in a `while True:` loop that only stops on `if not page_items: break`. A real
GitLab response is a list (`[]` is falsy → stops), but a **truthy-but-empty** container does not satisfy
`not page_items`. In `tests/test_processors_gitlab.py` the store/project is a `MagicMock`, so `repository_tree()`
returns a truthy Mock with `len()==0` forever → the loop spins emitting `GitLab repo tree page N returned 0 items`
indefinitely → the unit suite **hangs to the CI job timeout (60 min)**.

This is what made `test-matrix` red on `main` (HEAD `013d95ce8`): the 3.13 cell ran 60 min then timed out; the other
Python cells were `fail-fast`-cancelled. Because it's a hang (version-independent) and pytest runs in random order, a
*different* matrix cell shows the failure each run — which read as "flaky," but it's a deterministic infinite loop.
Every open PR inherits it (they branch off `main`).

**Fix**
- `_iter_gitlab_repo_tree`: terminate on `len(page_items) == 0` (catches a truthy-but-empty page), guard `len()` for
  non-sized returns, and add a defensive `max_pages` cap (10k pages ≈ 1M entries) so a misbehaving API/transport can
  never turn the crawl into an unbounded REST loop. Behaviour is unchanged for real GitLab responses.
- `tests/test_processors_gitlab.py`: stub `_backfill_gitlab_missing_data` in both `process_gitlab_project` tests — they
  exercise sync-flag dispatch, not file backfill, so they shouldn't drive real repo-tree pagination on a Mock.

**Validation (Python 3.13, the version that hung in CI)**
- `tests/test_processors_gitlab.py` → 5 passed in ~2.5s (was: infinite hang).
- Direct check: `_iter_gitlab_repo_tree(MagicMock())` now returns immediately (1 call, 0 items) instead of looping.
- Also green on 3.11. ruff + mypy clean.

No ticket — surfaced while unblocking CHAOS-2393–2400 CI; happy to file one if preferred.
