### PR TITLE
feat: guard managed billing and org-scoped team sync

### DIFF
--- a/docs/architecture/database-architecture.md
+++ b/docs/architecture/database-architecture.md
@@ -132,10 +132,32 @@ Commands automatically use the appropriate database:
 | `sync git` | ClickHouse | Git data ingestion |
 | `sync prs` | ClickHouse | PR data ingestion |
 | `sync work-items` | ClickHouse | Work item ingestion |
-| `sync teams` | Both | Drift/mapping → `team_mappings` (Postgres); team entities → `teams` (ClickHouse) |
+| `sync teams` | Both | **Org-scoped** (`--org`): provider → Postgres `team_mappings` → `bridge_teams_to_clickhouse`; **No-org**: direct ClickHouse write |
 | `metrics daily` | ClickHouse | Metrics computation |
 | `metrics dora` | ClickHouse | DORA metrics |
 | `api` | Both | Serves both layers |
+
+### `sync teams` routing detail
+
+The `sync teams` command has two distinct routing paths depending on whether `--org` is supplied:
+
+| Path | Trigger | Write order | ClickHouse writer |
+|------|---------|-------------|-------------------|
+| **Org-scoped** | `--org <id>` present | 1. `_bridge_teams_to_postgres` (upserts `team_mappings`) → 2. `bridge_teams_to_clickhouse` (reads Postgres, resolves identities, writes `teams`) | `bridge_teams_to_clickhouse` only |
+| **No-org** | `--org` absent | Direct `run_with_store` → ClickHouse `teams` table | `run_with_store` |
+
+**Invariants for the org-scoped path:**
+
+- PostgreSQL `team_mappings` is always the source of truth for org-scoped teams.
+- `bridge_teams_to_clickhouse` is the **sole** ClickHouse writer for org-scoped syncs.
+  It reads `TeamMapping` + `IdentityMapping` from Postgres (both filtered by `org_id`),
+  resolves member identities (email, canonical_id, all provider logins), and writes the
+  enriched payload to the ClickHouse `teams` table.
+- `run_with_store` (direct ClickHouse write from provider data) is **never** called on the
+  org-scoped path.
+- A Postgres bridge failure (`_bridge_teams_to_postgres` returns 0 or raises) causes exit 1.
+- A ClickHouse bridge failure (`bridge_teams_to_clickhouse` raises) is fatal (exit 1) so
+  callers cannot report a successful sync when analytics has not been updated.
 
 ## API Service Routing
 

--- a/src/dev_health_ops/alembic/versions/0011_add_managed_by_to_org_license.py
+++ b/src/dev_health_ops/alembic/versions/0011_add_managed_by_to_org_license.py
@@ -1,0 +1,126 @@
+"""Add managed_by column to org_licenses and organizations for tier-source guard.
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-06-14 00:00:00
+
+Background (CHAOS-2301)
+-----------------------
+Stripe webhooks (customer.subscription.deleted) and the reconciliation
+resolve_mismatch path unconditionally clobber Organization.tier and
+OrgLicense.tier back to 'community' when a subscription is cancelled.
+This breaks manually-granted tiers (e.g. enterprise granted by an admin
+for a self-hosted customer) because Stripe has no subscription for them.
+
+Fix: add a ``managed_by`` column (TEXT, default 'stripe') to both
+``org_licenses`` and ``organizations``.  The webhook revoke path and
+reconciliation only mutate tiers where ``managed_by = 'stripe'``.
+Manual grants set ``managed_by = 'manual'`` and are never touched by
+Stripe events.
+
+Allowed values: 'stripe' | 'manual'
+
+Migration is idempotent: uses _has_column guard so it is a no-op on
+fresh deployments where create_all already materialised the column.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0011"
+down_revision: str | None = "0010"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_COLUMN = "managed_by"
+
+
+def _has_column(conn: sa.Connection, table: str, column: str) -> bool:
+    inspector = sa.inspect(conn)
+    if table not in inspector.get_table_names():
+        return True  # table not yet bootstrapped; create_all will add it
+    return any(col["name"] == column for col in inspector.get_columns(table))
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if not _has_column(conn, "org_licenses", _COLUMN):
+        op.add_column(
+            "org_licenses",
+            sa.Column(
+                _COLUMN,
+                sa.Text(),
+                nullable=False,
+                server_default="stripe",
+                comment=(
+                    "Who manages this tier: 'stripe' (webhook-controlled) "
+                    "or 'manual' (admin-granted, immune to Stripe events)"
+                ),
+            ),
+        )
+    op.execute(
+        """
+        UPDATE org_licenses
+        SET managed_by = 'manual'
+        WHERE managed_by = 'stripe'
+          AND coalesce(tier, 'community') <> 'community'
+          AND coalesce(is_valid, false) = true
+          AND NOT EXISTS (
+            SELECT 1
+            FROM subscriptions
+            WHERE subscriptions.org_id = org_licenses.org_id
+              AND subscriptions.status IN ('active', 'trialing', 'past_due')
+          )
+        """
+    )
+
+    if not _has_column(conn, "organizations", _COLUMN):
+        op.add_column(
+            "organizations",
+            sa.Column(
+                _COLUMN,
+                sa.Text(),
+                nullable=False,
+                server_default="stripe",
+                comment=(
+                    "Who manages this org's tier: 'stripe' or 'manual'. "
+                    "Mirrors org_licenses.managed_by for fast webhook checks."
+                ),
+            ),
+        )
+    op.execute(
+        """
+        UPDATE organizations
+        SET managed_by = 'manual'
+        WHERE managed_by = 'stripe'
+          AND coalesce(tier, 'community') <> 'community'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM subscriptions
+            WHERE subscriptions.org_id = organizations.id
+              AND subscriptions.status IN ('active', 'trialing', 'past_due')
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if "org_licenses" in inspector.get_table_names():
+        if any(col["name"] == _COLUMN for col in inspector.get_columns("org_licenses")):
+            op.drop_column("org_licenses", _COLUMN)
+
+    if "organizations" in inspector.get_table_names():
+        if any(
+            col["name"] == _COLUMN for col in inspector.get_columns("organizations")
+        ):
+            op.drop_column("organizations", _COLUMN)

--- a/src/dev_health_ops/api/billing/router.py
+++ b/src/dev_health_ops/api/billing/router.py
@@ -7,7 +7,7 @@ import logging
 import os
 import uuid
 from datetime import datetime, timezone
-from typing import Annotated, Any
+from typing import Annotated, Any, Protocol, cast
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -57,6 +57,18 @@ except ModuleNotFoundError:
 
 class SignatureVerificationError(Exception):
     """Fallback export when Stripe SDK is unavailable."""
+
+
+class _BillingNotificationTask(Protocol):
+    def delay(self, email_type: str, org_id: str, **kwargs: object) -> object: ...
+
+
+def _enqueue_billing_notification(
+    email_type: str, org_id: str, **kwargs: object
+) -> object:
+    return cast(_BillingNotificationTask, send_billing_notification).delay(
+        email_type, org_id, **kwargs
+    )
 
 
 logger = logging.getLogger(__name__)
@@ -391,7 +403,7 @@ async def _handle_invoice_webhook(
             )
             return
         try:
-            send_billing_notification.delay(email_type, org_str, **kwargs)
+            _enqueue_billing_notification(email_type, org_str, **kwargs)
         except Exception:
             logger.debug(
                 "Failed to enqueue %s email for org_id=%s", email_type, org_str
@@ -490,12 +502,12 @@ async def _handle_subscription_updated(subscription: object) -> None:
         logger.exception("Failed to regenerate license for org_id=%s", org_id)
         return
 
-    await _persist_license(org_id, tier, license_key, customer_id)
+    persisted = await _persist_license(org_id, tier, license_key, customer_id)
 
     # Send subscription changed email if tier actually changed.
-    if old_tier is not None and old_tier != str(tier.value):
+    if persisted and old_tier is not None and old_tier != str(tier.value):
         try:
-            send_billing_notification.delay(
+            _enqueue_billing_notification(
                 "subscription_changed",
                 org_id,
                 old_tier=old_tier,
@@ -541,7 +553,7 @@ async def _handle_subscription_deleted(subscription: object) -> None:
         await _revoke_license(org_id)
 
         try:
-            send_billing_notification.delay(
+            _enqueue_billing_notification(
                 "subscription_cancelled",
                 org_id,
                 tier=current_tier,
@@ -592,7 +604,7 @@ async def _handle_trial_will_end(subscription: object) -> None:
     trial_end_iso = trial_end_dt.date().isoformat()
 
     try:
-        send_billing_notification.delay(
+        _enqueue_billing_notification(
             "trial_expiring",
             org_id,
             days_remaining=days_remaining,
@@ -646,7 +658,7 @@ async def _persist_license(
     tier: LicenseTier,
     license_key: str,
     customer_id: str | None,
-) -> None:
+) -> bool:
     """Persist license to OrgLicense and update Organization tier."""
     try:
         from datetime import datetime, timezone
@@ -664,19 +676,34 @@ async def _persist_license(
                 org_uuid = uuid_mod.UUID(org_id)
             except ValueError:
                 logger.warning("Invalid org_id UUID: %s", org_id)
-                return
+                return False
 
             result = await session.execute(
                 select(Organization).where(Organization.id == org_uuid)
             )
             org = result.scalar_one_or_none()
-            if org:
-                assign_attr(org, "tier", str(tier.value))
 
             license_result = await session.execute(
                 select(OrgLicense).where(OrgLicense.org_id == org_uuid)
             )
             org_license = license_result.scalar_one_or_none()
+
+            org_managed_by = getattr(org, "managed_by", "stripe") if org else "stripe"
+            lic_managed_by = (
+                getattr(org_license, "managed_by", "stripe")
+                if org_license
+                else "stripe"
+            )
+            if org_managed_by == "manual" or lic_managed_by == "manual":
+                logger.info(
+                    "Stripe license persist ignored for manually-managed org %s "
+                    "(managed_by='manual'); tier preserved.",
+                    org_id,
+                )
+                return False
+
+            if org:
+                assign_attr(org, "tier", str(tier.value))
 
             if org_license is None:
                 org_license = OrgLicense(
@@ -696,13 +723,19 @@ async def _persist_license(
             org_license.last_validated_at = datetime.now(timezone.utc)
 
             await session.commit()
+            return True
 
     except Exception:
         logger.exception("Failed to persist license for org_id=%s", org_id)
+        return False
 
 
 async def _revoke_license(org_id: str) -> None:
-    """Mark org license as invalid (subscription cancelled)."""
+    """Mark org license as invalid (subscription cancelled).
+
+    Skips orgs where managed_by='manual' — those tiers are admin-granted
+    and must not be clobbered by Stripe webhook events.
+    """
     try:
         from sqlalchemy import select
 
@@ -722,13 +755,30 @@ async def _revoke_license(org_id: str) -> None:
                 select(Organization).where(Organization.id == org_uuid)
             )
             org = result.scalar_one_or_none()
+
+            result_lic = await session.execute(
+                select(OrgLicense).where(OrgLicense.org_id == org_uuid)
+            )
+            org_license = result_lic.scalar_one_or_none()
+
+            # Guard: skip if this org's tier is manually managed.
+            org_managed_by = getattr(org, "managed_by", "stripe") if org else "stripe"
+            lic_managed_by = (
+                getattr(org_license, "managed_by", "stripe")
+                if org_license
+                else "stripe"
+            )
+            if org_managed_by == "manual" or lic_managed_by == "manual":
+                logger.info(
+                    "Stripe subscription.deleted ignored for manually-managed org %s "
+                    "(managed_by='manual'); tier preserved.",
+                    org_id,
+                )
+                return
+
             if org:
                 assign_attr(org, "tier", str(LicenseTier.COMMUNITY.value))
 
-            result = await session.execute(
-                select(OrgLicense).where(OrgLicense.org_id == org_uuid)
-            )
-            org_license = result.scalar_one_or_none()
             if org_license:
                 assign_attr(org_license, "is_valid", False)
                 assign_attr(org_license, "tier", str(LicenseTier.COMMUNITY.value))

--- a/src/dev_health_ops/api/billing/subscription_service.py
+++ b/src/dev_health_ops/api/billing/subscription_service.py
@@ -399,6 +399,30 @@ class SubscriptionService:
 
         customer_id = str(getattr(subscription, "stripe_customer_id", "") or "")
 
+        org = None
+        try:
+            from dev_health_ops.models.users import Organization
+
+            org_result = await self.db.execute(
+                select(Organization).where(Organization.id == org_id)
+            )
+            org = org_result.scalar_one_or_none()
+        except OperationalError as exc:
+            logger.warning(
+                "organizations table unavailable; skipping org tier sync (%s)", exc
+            )
+
+        org_managed_by = getattr(org, "managed_by", "stripe") if org else "stripe"
+        lic_managed_by = (
+            getattr(org_license, "managed_by", "stripe") if org_license else "stripe"
+        )
+        if org_managed_by == "manual" or lic_managed_by == "manual":
+            logger.info(
+                "Skipping Stripe org-license sync for manually-managed org_id=%s",
+                org_id,
+            )
+            return
+
         if org_license is None:
             org_license = OrgLicense(
                 org_id=org_id,
@@ -418,22 +442,8 @@ class SubscriptionService:
             if customer_id:
                 assign_attr(org_license, "customer_id", customer_id)
 
-        # Keep the denormalized Organization.tier column in lockstep so the
-        # tier-resolution fallback (resolve_org_tier) and any direct readers of
-        # Organization.tier never see a value that diverges from OrgLicense.
-        try:
-            from dev_health_ops.models.users import Organization
-
-            org_result = await self.db.execute(
-                select(Organization).where(Organization.id == org_id)
-            )
-            org = org_result.scalar_one_or_none()
-            if org is not None and str(org.tier) != tier_str:
-                assign_attr(org, "tier", tier_str)
-        except OperationalError as exc:
-            logger.warning(
-                "organizations table unavailable; skipping org tier sync (%s)", exc
-            )
+        if org is not None and str(org.tier) != tier_str:
+            assign_attr(org, "tier", tier_str)
 
         # Static literal labels keyed by tier string to break the taint chain
         # entirely (CodeQL py/clear-text-logging-sensitive-data).

--- a/src/dev_health_ops/api/services/configuration/team_discovery.py
+++ b/src/dev_health_ops/api/services/configuration/team_discovery.py
@@ -251,6 +251,44 @@ class TeamDiscoveryService:
 
         return await asyncio.to_thread(_discover)
 
+    async def discover_ms_teams(
+        self,
+        tenant_id: str,
+        client_id: str,
+        client_secret: str,
+    ) -> list[DiscoveredTeam]:
+        """Discover teams from Microsoft Teams (Microsoft Graph API)."""
+
+        async def _discover() -> list[DiscoveredTeam]:
+            from dev_health_ops.connectors.teams import TeamsConnector
+
+            DiscoveredTeam = _get_discovered_team_cls()
+            connector = TeamsConnector(
+                tenant_id=tenant_id,
+                client_id=client_id,
+                client_secret=client_secret,
+            )
+            try:
+                ms_teams = await connector.list_teams()
+                teams: list[Any] = []
+                for t in ms_teams:
+                    teams.append(
+                        DiscoveredTeam(
+                            provider_type="ms-teams",
+                            provider_team_id=t.id,
+                            name=t.display_name,
+                            description=t.description,
+                            associations={
+                                "provider_org": tenant_id,
+                            },
+                        )
+                    )
+                return teams
+            finally:
+                await connector.close()
+
+        return await _discover()
+
     async def import_teams(
         self,
         teams: list[DiscoveredTeam],
@@ -270,6 +308,8 @@ class TeamDiscoveryService:
                 team_id = f"gh:{team.provider_team_id}"
             elif team.provider_type == "gitlab":
                 team_id = f"gl:{team.provider_team_id}"
+            elif team.provider_type == "ms-teams":
+                team_id = f"ms-teams:{team.provider_team_id}"
             else:
                 team_id = team.provider_team_id
 

--- a/src/dev_health_ops/api/services/users.py
+++ b/src/dev_health_ops/api/services/users.py
@@ -300,6 +300,7 @@ class OrganizationService:
             description=description,
             settings=settings or {},
             tier=tier,
+            managed_by="manual" if tier != "community" else "stripe",
             is_active=True,
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),
@@ -337,8 +338,10 @@ class OrganizationService:
         if settings is not None:
             org.settings = settings
         if tier is not None:
-            org.tier = tier
-            await self._sync_license_tier(uuid.UUID(org_id), tier)
+            if str(org.tier) != tier:
+                org.tier = tier
+                org.managed_by = "manual" if tier != "community" else "stripe"
+                await self._sync_license_tier(uuid.UUID(org_id), tier)
         if is_active is not None:
             org.is_active = is_active
 
@@ -354,6 +357,10 @@ class OrganizationService:
         update a pre-existing license row or the org would keep being enforced
         at the old tier (CHAOS-2256 review). When no row exists, resolution
         falls back to Organization.tier — nothing to sync.
+
+        Paid admin grants are marked managed_by='manual' so Stripe webhook
+        events cannot clobber them. Admin downgrades to community remain
+        Stripe-manageable so a later checkout can restore paid entitlements.
         """
         from sqlalchemy.exc import OperationalError
 
@@ -370,8 +377,10 @@ class OrganizationService:
                 org_id,
             )
             return
-        if org_license is not None and str(org_license.tier) != tier:
-            org_license.tier = tier
+        if org_license is not None:
+            if str(org_license.tier) != tier:
+                org_license.tier = tier
+            org_license.managed_by = "manual" if tier != "community" else "stripe"
             org_license.updated_at = datetime.now(timezone.utc)
 
     async def delete(self, org_id: str) -> bool:

--- a/src/dev_health_ops/db.py
+++ b/src/dev_health_ops/db.py
@@ -283,8 +283,29 @@ def _get_sync_postgres_uri() -> str | None:
     return None
 
 
-def get_postgres_sync_engine() -> Engine:
+def _ensure_sync_postgres(uri: str) -> str:
+    if uri.startswith("postgresql+asyncpg://"):
+        return uri.replace("postgresql+asyncpg://", "postgresql://", 1)
+    if uri.startswith("sqlite+aiosqlite://"):
+        return uri.replace("sqlite+aiosqlite://", "sqlite://", 1)
+    return uri
+
+
+def get_postgres_sync_engine(uri: str | None = None) -> Engine:
     global _postgres_sync_engine
+    if uri is not None:
+        sync_uri = _ensure_sync_postgres(uri)
+        if _pgbouncer_transaction_mode():
+            return create_engine(sync_uri, poolclass=NullPool)
+        if not sync_uri.startswith("postgresql"):
+            return create_engine(sync_uri)
+        pool_size, max_overflow = _pg_pool_size()
+        return create_engine(
+            sync_uri,
+            pool_pre_ping=True,
+            pool_size=pool_size,
+            max_overflow=max_overflow,
+        )
     if _postgres_sync_engine is None:
         uri = _get_sync_postgres_uri()
         if not uri:
@@ -319,3 +340,19 @@ def get_postgres_session_sync() -> Generator[Session, None, None]:
         raise
     finally:
         session.close()
+
+
+@contextmanager
+def get_postgres_session_sync_for_uri(uri: str) -> Generator[Session, None, None]:
+    engine = get_postgres_sync_engine(uri)
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+        engine.dispose()

--- a/src/dev_health_ops/models/licensing.py
+++ b/src/dev_health_ops/models/licensing.py
@@ -337,6 +337,13 @@ class OrgLicense(Base):
         nullable=True,
         comment="External customer ID (Stripe, etc.)",
     )
+    managed_by: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="stripe",
+        server_default="stripe",
+        comment="Who manages this tier: 'stripe' (webhook-controlled) or 'manual' (admin-granted, immune to Stripe events)",
+    )
     features_override: Mapped[dict[str, Any] | None] = mapped_column(
         JSON,
         nullable=True,
@@ -375,6 +382,7 @@ class OrgLicense(Base):
         expires_at: datetime | None = None,
         license_type: str = "saas",
         customer_id: str | None = None,
+        managed_by: str = "stripe",
         features_override: dict[str, Any] | None = None,
         limits_override: dict[str, Any] | None = None,
     ) -> None:
@@ -389,6 +397,7 @@ class OrgLicense(Base):
         self.is_valid = True
         self.license_type = license_type
         self.customer_id = customer_id
+        self.managed_by = managed_by
         self.features_override = features_override or {}
         self.limits_override = limits_override or {}
         self.created_at = datetime.now(timezone.utc)

--- a/src/dev_health_ops/models/users.py
+++ b/src/dev_health_ops/models/users.py
@@ -171,7 +171,13 @@ class Organization(Base):
     # Billing/tier info (for SaaS)
     tier: Mapped[str | None] = mapped_column(Text, default="community", nullable=False)
     stripe_customer_id: Mapped[str | None] = mapped_column(Text, nullable=True)
-
+    managed_by: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="stripe",
+        server_default="stripe",
+        comment="Who manages this org's tier: 'stripe' or 'manual'. Mirrors org_licenses.managed_by.",
+    )
     # Status
     is_active: Mapped[bool | None] = mapped_column(
         Boolean, default=True, nullable=False

--- a/src/dev_health_ops/providers/team_bridge.py
+++ b/src/dev_health_ops/providers/team_bridge.py
@@ -8,7 +8,10 @@ from typing import Any
 
 from sqlalchemy import select
 
-from dev_health_ops.db import get_postgres_session_sync
+from dev_health_ops.db import (
+    get_postgres_session_sync,
+    get_postgres_session_sync_for_uri,
+)
 from dev_health_ops.models.settings import IdentityMapping, TeamMapping
 from dev_health_ops.storage.clickhouse import ClickHouseStore
 
@@ -68,21 +71,28 @@ def _parse_json_array(value: Any) -> list[str]:
     return []
 
 
-def _clickhouse_uri() -> str:
-    uri = (
-        os.getenv("CLICKHOUSE_URI")
-        or os.getenv("DATABASE_URI")
-        or os.getenv("DATABASE_URL")
-    )
+def _clickhouse_uri(db_url: str | None = None) -> str:
+    if db_url:
+        return db_url
+    uri = os.getenv("CLICKHOUSE_URI")
     if not uri:
-        raise RuntimeError("Missing CLICKHOUSE_URI or DATABASE_URI for team bridge")
+        raise RuntimeError("Missing CLICKHOUSE_URI for team bridge")
     return uri
 
 
-def bridge_teams_to_clickhouse(org_id: str | None = None) -> int:
+def bridge_teams_to_clickhouse(
+    org_id: str | None = None,
+    db_url: str | None = None,
+    postgres_db_url: str | None = None,
+) -> int:
     teams_payload: list[dict[str, Any]] = []
 
-    with get_postgres_session_sync() as session:
+    session_context = (
+        get_postgres_session_sync_for_uri(postgres_db_url)
+        if postgres_db_url
+        else get_postgres_session_sync()
+    )
+    with session_context as session:
         mappings = (
             session.execute(
                 select(TeamMapping).where(
@@ -128,7 +138,7 @@ def bridge_teams_to_clickhouse(org_id: str | None = None) -> int:
             )
 
     async def _run() -> None:
-        async with ClickHouseStore(_clickhouse_uri()) as store:
+        async with ClickHouseStore(_clickhouse_uri(db_url)) as store:
             await store.insert_teams(teams_payload)
 
     asyncio.run(_run())

--- a/src/dev_health_ops/providers/teams.py
+++ b/src/dev_health_ops/providers/teams.py
@@ -5,10 +5,18 @@ import importlib
 import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from dev_health_ops.db import resolve_sink_uri
+from sqlalchemy import select
+
+from dev_health_ops.db import (
+    get_postgres_session_sync_for_uri,
+    resolve_db_uri,
+    resolve_sink_uri,
+)
+from dev_health_ops.models.settings import IdentityMapping, TeamMapping
 from dev_health_ops.models.teams import Team
 from dev_health_ops.storage import detect_db_type
 from dev_health_ops.utils.cli import add_sink_arg, validate_sink
@@ -279,6 +287,17 @@ def sync_teams(ns: argparse.Namespace) -> int:
                         members=[str(m) for m in members],
                     )
                 )
+                setattr(
+                    teams_data[-1],
+                    "project_keys",
+                    [str(k) for k in entry.get("project_keys", []) if k],
+                )
+                setattr(
+                    teams_data[-1],
+                    "repo_patterns",
+                    [str(p) for p in entry.get("repo_patterns", []) if p],
+                )
+                setattr(teams_data[-1], "members_complete", True)
 
     elif provider == "jira":
         from dev_health_ops.providers.jira.client import JiraClient
@@ -312,6 +331,7 @@ def sync_teams(ns: argparse.Namespace) -> int:
                             members=members,
                         )
                     )
+                    setattr(teams_data[-1], "members_complete", False)
             logging.info(f"Fetched {len(teams_data)} projects from Jira.")
         except Exception as e:
             logging.error(f"Failed to fetch Jira projects: {e}")
@@ -354,6 +374,7 @@ def sync_teams(ns: argparse.Namespace) -> int:
                             description=f"Atlassian Ops team linked to Jira {project.project.key}",
                             members=[],
                         )
+                        setattr(ops_team_cache[team_id], "members_complete", False)
                     ops_links.append(
                         JiraProjectOpsTeamLink(
                             project_key=project.project.key,
@@ -380,6 +401,8 @@ def sync_teams(ns: argparse.Namespace) -> int:
 
         generator = SyntheticDataGenerator()
         teams_data = generator.generate_teams(count=8)
+        for team in teams_data:
+            setattr(team, "members_complete", True)
         logging.info(f"Generated {len(teams_data)} synthetic teams.")
 
     elif provider == "github":
@@ -412,6 +435,7 @@ def sync_teams(ns: argparse.Namespace) -> int:
                         members=members,
                     )
                 )
+                setattr(teams_data[-1], "members_complete", True)
             gh.close()
             logging.info(f"Fetched {len(teams_data)} teams from GitHub.")
         except Exception as e:
@@ -446,6 +470,7 @@ def sync_teams(ns: argparse.Namespace) -> int:
                     members=[m.username for m in members_list],
                 )
             )
+            setattr(teams_data[-1], "members_complete", True)
             # Also fetch subgroups as separate teams
             for subgroup in group.subgroups.list(per_page=100, get_all=True):
                 full_sg = gl.groups.get(subgroup.id)
@@ -459,6 +484,7 @@ def sync_teams(ns: argparse.Namespace) -> int:
                         members=[m.username for m in sg_members],
                     )
                 )
+                setattr(teams_data[-1], "members_complete", True)
             logging.info(f"Fetched {len(teams_data)} teams from GitLab.")
         except Exception as e:
             logging.error(f"Failed to fetch GitLab teams: {e}")
@@ -485,6 +511,7 @@ def sync_teams(ns: argparse.Namespace) -> int:
                 description = t.get("description")
                 description_text = str(description) if description else None
                 members_nodes = (t.get("members", {}) or {}).get("nodes", [])
+                members_complete = True
                 if t.get("members", {}).get("pageInfo", {}).get("hasNextPage"):
                     try:
                         full_members = linear_client.get_team_members(
@@ -492,6 +519,7 @@ def sync_teams(ns: argparse.Namespace) -> int:
                         )
                     except Exception:
                         full_members = members_nodes
+                        members_complete = False
                     members_source = full_members
                 else:
                     members_source = members_nodes
@@ -499,14 +527,14 @@ def sync_teams(ns: argparse.Namespace) -> int:
                     (m.get("email") or m.get("name", "")) for m in members_source
                 ]
                 members = [m for m in members if m]
-                teams_data.append(
-                    Team(
-                        id=team_id,
-                        name=name,
-                        description=description_text,
-                        members=members,
-                    )
+                team = Team(
+                    id=team_id,
+                    name=name,
+                    description=description_text,
+                    members=members,
                 )
+                setattr(team, "members_complete", members_complete)
+                teams_data.append(team)
             logging.info(f"Fetched {len(teams_data)} teams from Linear.")
         except Exception as e:
             logging.error(f"Failed to fetch Linear teams: {e}")
@@ -548,6 +576,7 @@ def sync_teams(ns: argparse.Namespace) -> int:
                         members=member_ids,
                     )
                 )
+                setattr(teams_data[-1], "members_complete", True)
             logging.info(f"Fetched {len(teams_data)} teams from Microsoft Teams.")
         except Exception as e:
             logging.error(f"Failed to fetch Microsoft Teams: {e}")
@@ -567,6 +596,73 @@ def sync_teams(ns: argparse.Namespace) -> int:
         )
         return 1
 
+    org_id = getattr(ns, "org", None)
+
+    if org_id is not None:
+        # Org-scoped path: provider -> Postgres TeamMapping -> bridge_teams_to_clickhouse.
+        # Never write ClickHouse directly; the bridge reads from Postgres so the
+        # semantic layer is always the source of truth for org-scoped teams.
+        validate_sink(ns)
+        db_uri = resolve_sink_uri(ns)
+        postgres_db_uri = resolve_db_uri(ns)
+        postgres_bridge_count: int = 0
+        try:
+            result = _bridge_teams_to_postgres(teams_data, ns)
+            postgres_bridge_count = result if result is not None else 0
+        except Exception as e:  # noqa: BLE001 - bridge failures must affect exit code
+            logging.error("Failed to bridge teams to PostgreSQL: %s", e)
+            postgres_bridge_count = 0
+
+        if postgres_bridge_count <= 0:
+            message = (
+                "No teams were persisted to PostgreSQL TeamMapping "
+                f"(org={org_id}, count={postgres_bridge_count})."
+            )
+            if getattr(ns, "allow_empty", False):
+                logging.warning(message)
+                return 0
+            logging.error(
+                "%s Pass --allow-empty to exit successfully on an empty sync.", message
+            )
+            return 1
+
+        # Bridge Postgres TeamMapping -> ClickHouse.
+        try:
+            from dev_health_ops.providers.team_bridge import bridge_teams_to_clickhouse
+
+            bridge_teams_to_clickhouse(
+                org_id=org_id,
+                db_url=db_uri,
+                postgres_db_url=postgres_db_uri,
+            )
+            logging.info(
+                "Bridged %d teams from PostgreSQL to ClickHouse (org=%s).",
+                postgres_bridge_count,
+                org_id,
+            )
+            if ops_links:
+                import asyncio
+
+                from dev_health_ops.storage.clickhouse import ClickHouseStore
+
+                async def _insert_ops_links() -> None:
+                    async with ClickHouseStore(db_uri) as store:
+                        store.org_id = str(org_id)
+                        await store.insert_jira_project_ops_team_links(ops_links)
+
+                asyncio.run(_insert_ops_links())
+                logging.info(
+                    "Synced %d jira project ops team links to ClickHouse (org=%s).",
+                    len(ops_links),
+                    org_id,
+                )
+        except Exception as e:  # noqa: BLE001 - bridge failures must affect exit code
+            logging.error("bridge_teams_to_clickhouse failed (org=%s): %s", org_id, e)
+            return 1
+
+        return 0
+
+    # No-org path: write directly to ClickHouse (unchanged).
     validate_sink(ns)
     db_uri = resolve_sink_uri(ns)
     db_type = detect_db_type(db_uri)
@@ -588,27 +684,11 @@ def sync_teams(ns: argparse.Namespace) -> int:
         return persisted_count
 
     persisted_count = asyncio.run(
-        run_with_store(db_uri, db_type, _handler, org_id=getattr(ns, "org", None))
+        run_with_store(db_uri, db_type, _handler, org_id=None)
     )
 
-    org_id = getattr(ns, "org", None)
-    postgres_bridge_count: int | None = None
-    if org_id is not None:
-        try:
-            postgres_bridge_count = _bridge_teams_to_postgres(teams_data, ns)
-        except Exception as e:  # noqa: BLE001 - bridge failures must affect exit code
-            logging.error("Failed to bridge teams to PostgreSQL: %s", e)
-            postgres_bridge_count = 0
-
-    required_counts = [persisted_count]
-    if postgres_bridge_count is not None:
-        required_counts.append(postgres_bridge_count)
-
-    if any(count <= 0 for count in required_counts):
-        message = (
-            "No teams were persisted to all required stores "
-            f"(primary={persisted_count}, postgres_bridge={postgres_bridge_count})."
-        )
+    if persisted_count <= 0:
+        message = "No teams were persisted to ClickHouse."
         if getattr(ns, "allow_empty", False):
             logging.warning(message)
             return 0
@@ -639,18 +719,146 @@ async def _count_persisted_teams(store: Any, teams_data: list) -> int:
     return len(expected_ids & persisted_ids)
 
 
+def _team_string_list(team: Any, field: str) -> list[str]:
+    value = team.get(field) if isinstance(team, dict) else getattr(team, field, [])
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if item]
+
+
+def _provider_team_id(team_id: str, provider: str) -> str:
+    if provider == "github" and team_id.startswith("gh:"):
+        return team_id.removeprefix("gh:")
+    if provider == "gitlab" and team_id.startswith("gl:"):
+        return team_id.removeprefix("gl:")
+    if provider == "linear" and team_id.startswith("linear:"):
+        return team_id.removeprefix("linear:")
+    if provider == "ms-teams" and team_id.startswith("ms-teams:"):
+        return team_id.removeprefix("ms-teams:")
+    return team_id
+
+
+def _project_keys_for_team(team_id: str, provider: str, team: Any) -> list[str]:
+    configured = _team_string_list(team, "project_keys")
+    if configured:
+        return configured
+    if provider == "jira":
+        return [team_id]
+    if provider == "linear" and team_id.startswith("linear:"):
+        return [team_id.removeprefix("linear:")]
+    return []
+
+
+def _team_members(team: Any) -> list[str]:
+    return [
+        str(member).strip()
+        for member in (getattr(team, "members", None) or [])
+        if str(member).strip()
+    ]
+
+
+def _team_members_complete(team: Any) -> bool:
+    return bool(getattr(team, "members_complete", False))
+
+
+def _identity_member_values(identity: Any) -> set[str]:
+    values: set[str] = set()
+    email = getattr(identity, "email", None)
+    if email:
+        values.add(str(email))
+    canonical_id = getattr(identity, "canonical_id", None)
+    if canonical_id:
+        values.add(str(canonical_id))
+    for provider_values in (
+        getattr(identity, "provider_identities", None) or {}
+    ).values():
+        if isinstance(provider_values, list):
+            values.update(str(value) for value in provider_values if value)
+        elif provider_values:
+            values.add(str(provider_values))
+    return values
+
+
+def _reconcile_team_member_identities(
+    session: Any,
+    *,
+    org_id: str,
+    team_id: str,
+    provider: str,
+    members: list[str],
+    members_complete: bool,
+) -> None:
+    desired_members = set(members)
+    if members_complete:
+        existing_identities = (
+            session.execute(
+                select(IdentityMapping).where(
+                    IdentityMapping.org_id == org_id,
+                    IdentityMapping.is_active.is_(True),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for identity in existing_identities:
+            provider_identities = dict(
+                getattr(identity, "provider_identities", {}) or {}
+            )
+            if provider not in provider_identities:
+                continue
+            team_ids = list(getattr(identity, "team_ids", []) or [])
+            if team_id not in team_ids:
+                continue
+            if _identity_member_values(identity) & desired_members:
+                continue
+            team_ids = [
+                existing_team_id
+                for existing_team_id in team_ids
+                if existing_team_id != team_id
+            ]
+            setattr(identity, "team_ids", team_ids)
+
+    for member in members:
+        existing = session.execute(
+            select(IdentityMapping).filter_by(org_id=org_id, canonical_id=member)
+        ).scalar_one_or_none()
+        if existing is None:
+            session.add(
+                IdentityMapping(
+                    org_id=org_id,
+                    canonical_id=member,
+                    email=member if "@" in member else None,
+                    display_name=None if "@" in member else member,
+                    provider_identities={provider: [member]},
+                    team_ids=[team_id],
+                    is_active=True,
+                )
+            )
+            continue
+
+        provider_identities = dict(getattr(existing, "provider_identities", {}) or {})
+        provider_members = list(provider_identities.get(provider) or [])
+        if member not in provider_members:
+            provider_members.append(member)
+        provider_identities[provider] = provider_members
+
+        team_ids = list(getattr(existing, "team_ids", []) or [])
+        if team_id not in team_ids:
+            team_ids.append(team_id)
+
+        setattr(existing, "provider_identities", provider_identities)
+        setattr(existing, "team_ids", team_ids)
+        setattr(existing, "is_active", True)
+
+
 def _bridge_teams_to_postgres(teams_data: list, ns: argparse.Namespace) -> int | None:
-    """Upsert Team records into PostgreSQL TeamMapping table for multi-tenant bridge."""
+    """Upsert provider-discovered teams into the org-scoped TeamMapping layer."""
     import logging
-
-    from sqlalchemy import select
-
-    from dev_health_ops.db import get_postgres_session_sync
-    from dev_health_ops.models.settings import TeamMapping
 
     org_id = getattr(ns, "org", None)
     if org_id is None:
         return None
+    provider = str(getattr(ns, "provider", "config") or "config").lower()
 
     expected_ids = {
         str(getattr(team, "id", "") or "").strip() for team in teams_data
@@ -659,7 +867,7 @@ def _bridge_teams_to_postgres(teams_data: list, ns: argparse.Namespace) -> int |
         return 0
 
     try:
-        with get_postgres_session_sync() as session:
+        with get_postgres_session_sync_for_uri(resolve_db_uri(ns)) as session:
             for team in teams_data:
                 team_id = str(getattr(team, "id", "")).strip()
                 if not team_id:
@@ -671,11 +879,37 @@ def _bridge_teams_to_postgres(teams_data: list, ns: argparse.Namespace) -> int |
 
                 team_name = str(getattr(team, "name", team_id) or team_id)
                 team_description = getattr(team, "description", None)
+                repo_patterns = _team_string_list(team, "repo_patterns")
+                project_keys = _project_keys_for_team(team_id, provider, team)
+                members = _team_members(team)
+                members_complete = _team_members_complete(team)
+                extra_data = dict(getattr(existing, "extra_data", {}) or {})
+                extra_data.update(
+                    {
+                        "provider_type": provider,
+                        "provider_team_id": _provider_team_id(team_id, provider),
+                        "last_discovered_at": datetime.now(timezone.utc).isoformat(),
+                        "sync_source": "cli-sync-teams",
+                    }
+                )
 
                 if existing:
-                    setattr(existing, "name", team_name)
-                    setattr(existing, "description", team_description)
+                    managed_fields = set(getattr(existing, "managed_fields", []) or [])
+                    if getattr(existing, "sync_policy", 1) == 0:
+                        if "name" in managed_fields:
+                            setattr(existing, "name", team_name)
+                        if (
+                            "description" in managed_fields
+                            and team_description is not None
+                        ):
+                            setattr(existing, "description", team_description)
+                        if "repo_patterns" in managed_fields:
+                            setattr(existing, "repo_patterns", repo_patterns)
+                        if "project_keys" in managed_fields:
+                            setattr(existing, "project_keys", project_keys)
                     setattr(existing, "is_active", True)
+                    setattr(existing, "extra_data", extra_data)
+                    setattr(existing, "last_drift_sync_at", datetime.now(timezone.utc))
                 else:
                     session.add(
                         TeamMapping(
@@ -683,9 +917,20 @@ def _bridge_teams_to_postgres(teams_data: list, ns: argparse.Namespace) -> int |
                             name=team_name,
                             org_id=org_id,
                             description=team_description,
+                            repo_patterns=repo_patterns,
+                            project_keys=project_keys,
+                            extra_data=extra_data,
                             is_active=True,
                         )
                     )
+                _reconcile_team_member_identities(
+                    session,
+                    org_id=org_id,
+                    team_id=team_id,
+                    provider=provider,
+                    members=members,
+                    members_complete=members_complete,
+                )
             session.flush()
             persisted_ids = set(
                 session.execute(

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -1577,6 +1577,7 @@ class ClickHouseStore:
                         "ops_team_name": item.get("ops_team_name"),
                         "updated_at": self._normalize_datetime(item.get("updated_at")),
                         "last_synced": synced_at,
+                        "org_id": item.get("org_id") or self.org_id or "",
                     }
                 )
             else:
@@ -1588,6 +1589,7 @@ class ClickHouseStore:
                         "ops_team_name": item.ops_team_name,
                         "updated_at": self._normalize_datetime(item.updated_at),
                         "last_synced": synced_at,
+                        "org_id": getattr(item, "org_id", None) or self.org_id or "",
                     }
                 )
 
@@ -1600,6 +1602,7 @@ class ClickHouseStore:
                 "ops_team_name",
                 "updated_at",
                 "last_synced",
+                "org_id",
             ],
             rows,
         )

--- a/src/dev_health_ops/workers/product_tasks.py
+++ b/src/dev_health_ops/workers/product_tasks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import date
 
+from dev_health_ops.db import require_clickhouse_uri
 from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.task_utils import _get_db_url
@@ -20,7 +21,9 @@ def sync_teams_to_analytics(self, org_id: str | None = None) -> dict:
     from dev_health_ops.providers.team_bridge import bridge_teams_to_clickhouse
 
     try:
-        count = bridge_teams_to_clickhouse(org_id=org_id)
+        count = bridge_teams_to_clickhouse(
+            org_id=org_id, db_url=require_clickhouse_uri()
+        )
         return {"status": "success", "teams_synced": count}
     except Exception as exc:
         logger.exception("sync_teams_to_analytics failed: %s", exc)

--- a/src/dev_health_ops/workers/sync_team.py
+++ b/src/dev_health_ops/workers/sync_team.py
@@ -6,9 +6,9 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
+from dev_health_ops.db import require_clickhouse_uri
 from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
-from dev_health_ops.workers.task_utils import _get_db_url
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,13 @@ async def _discover_and_sync_all(org_id: str | None) -> dict:
     from dev_health_ops.db import get_postgres_session
 
     effective_org_id = org_id or ""
-    providers = ("github", "gitlab", "jira")
+
+    # Capability registry: all org-scoped providers that support drift discovery.
+    # Entries are ordered; the set is the single source of truth for which
+    # providers the worker covers. Adding a provider here is sufficient to
+    # include it in Phase 1 credential lookup, Phase 2 concurrent discovery,
+    # and Phase 3 drift persistence.
+    providers = ("github", "gitlab", "jira", "linear", "ms-teams")
 
     # Phase 1: read + decrypt credentials in one short-lived session. These are
     # fast local reads; the connection is released before any network I/O.
@@ -109,6 +115,26 @@ async def _discover_and_sync_all(org_id: str | None) -> dict:
                 # Truncation is logged server-side by the discovery walk;
                 # drift sync only consumes the (possibly partial) teams.
                 teams = gitlab_result.teams
+            elif provider == "linear":
+                api_key = decrypted.get("api_key") or decrypted.get("token")
+                if not isinstance(api_key, str) or not api_key:
+                    return {"provider": provider, "skipped": "missing_config"}
+                teams = await discovery_svc.discover_linear(api_key=api_key)
+            elif provider == "ms-teams":
+                tenant_id = decrypted.get("tenant_id")
+                client_id_val = decrypted.get("client_id")
+                client_secret = decrypted.get("client_secret")
+                if not isinstance(tenant_id, str) or not tenant_id:
+                    return {"provider": provider, "skipped": "missing_config"}
+                if not isinstance(client_id_val, str) or not client_id_val:
+                    return {"provider": provider, "skipped": "missing_config"}
+                if not isinstance(client_secret, str) or not client_secret:
+                    return {"provider": provider, "skipped": "missing_config"}
+                teams = await discovery_svc.discover_ms_teams(
+                    tenant_id=tenant_id,
+                    client_id=client_id_val,
+                    client_secret=client_secret,
+                )
             else:
                 email = decrypted.get("email")
                 api_token = decrypted.get("api_token") or decrypted.get("token")
@@ -202,14 +228,14 @@ def reconcile_team_members(self, org_id: str | None = None) -> dict:
         from dev_health_ops.models.teams import Team
         from dev_health_ops.storage.clickhouse import ClickHouseStore
 
-        db_url = _get_db_url()
-        if not db_url:
-            raise ValueError(
-                "Missing CLICKHOUSE_URI or DATABASE_URI for reconciliation"
-            )
-
-        async with ClickHouseStore(db_url) as store:
+        async with ClickHouseStore(require_clickhouse_uri()) as store:
             teams = await store.get_all_teams()
+            if org_id is not None:
+                teams = [
+                    team
+                    for team in teams
+                    if str(getattr(team, "org_id", "") or "") == str(org_id)
+                ]
             now = datetime.now(timezone.utc)
             updated_teams = [
                 Team(
@@ -219,6 +245,7 @@ def reconcile_team_members(self, org_id: str | None = None) -> dict:
                     description=_string_or_none(team.description),
                     members=sorted(team_members.get(str(team.id), set())),
                     updated_at=now,
+                    org_id=str(getattr(team, "org_id", "") or ""),
                 )
                 for team in teams
             ]

--- a/tests/api/billing/test_managed_by_guard.py
+++ b/tests/api/billing/test_managed_by_guard.py
@@ -1,0 +1,525 @@
+"""Tests for CHAOS-2301: managed_by guard prevents Stripe from clobbering manual tiers.
+
+Covers:
+- _revoke_license skips orgs where org.managed_by='manual'
+- _revoke_license skips orgs where org_license.managed_by='manual'
+- _revoke_license proceeds normally for stripe-managed orgs
+- OrganizationService.update sets managed_by='manual' on org and license
+- OrganizationService._sync_license_tier sets managed_by='manual' on license
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_org(
+    org_id: uuid.UUID,
+    tier: str = "enterprise",
+    managed_by: str = "manual",
+) -> SimpleNamespace:
+    return SimpleNamespace(id=org_id, tier=tier, managed_by=managed_by)
+
+
+def _make_license(
+    org_id: uuid.UUID,
+    tier: str = "enterprise",
+    managed_by: str = "manual",
+    is_valid: bool = True,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        org_id=org_id,
+        tier=tier,
+        managed_by=managed_by,
+        is_valid=is_valid,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _revoke_license guard tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revoke_license_skips_manual_org_managed_by():
+    """_revoke_license must not downgrade org when org.managed_by='manual'."""
+    org_id = uuid.uuid4()
+    org = _make_org(org_id, tier="enterprise", managed_by="manual")
+    org_license = _make_license(org_id, tier="enterprise", managed_by="stripe")
+
+    mock_session = AsyncMock()
+    # First execute → Organization, second → OrgLicense
+    mock_session.execute.side_effect = [
+        MagicMock(scalar_one_or_none=MagicMock(return_value=org)),
+        MagicMock(scalar_one_or_none=MagicMock(return_value=org_license)),
+    ]
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "dev_health_ops.db.get_postgres_session",
+        return_value=mock_ctx,
+    ):
+        from dev_health_ops.api.billing.router import _revoke_license
+
+        await _revoke_license(str(org_id))
+
+    # commit must NOT have been called — we returned early
+    mock_session.commit.assert_not_called()
+    # tier must be unchanged
+    assert org.tier == "enterprise"
+    assert org_license.tier == "enterprise"
+
+
+@pytest.mark.asyncio
+async def test_revoke_license_skips_manual_license_managed_by():
+    """_revoke_license must not downgrade when org_license.managed_by='manual'."""
+    org_id = uuid.uuid4()
+    org = _make_org(org_id, tier="enterprise", managed_by="stripe")
+    org_license = _make_license(org_id, tier="enterprise", managed_by="manual")
+
+    mock_session = AsyncMock()
+    mock_session.execute.side_effect = [
+        MagicMock(scalar_one_or_none=MagicMock(return_value=org)),
+        MagicMock(scalar_one_or_none=MagicMock(return_value=org_license)),
+    ]
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "dev_health_ops.db.get_postgres_session",
+        return_value=mock_ctx,
+    ):
+        from dev_health_ops.api.billing.router import _revoke_license
+
+        await _revoke_license(str(org_id))
+
+    mock_session.commit.assert_not_called()
+    assert org.tier == "enterprise"
+    assert org_license.tier == "enterprise"
+    assert org_license.is_valid is True
+
+
+@pytest.mark.asyncio
+async def test_revoke_license_proceeds_for_stripe_managed_org():
+    """_revoke_license must downgrade stripe-managed orgs normally."""
+    org_id = uuid.uuid4()
+    org = _make_org(org_id, tier="team", managed_by="stripe")
+    org_license = _make_license(org_id, tier="team", managed_by="stripe", is_valid=True)
+
+    mock_session = AsyncMock()
+    mock_session.execute.side_effect = [
+        MagicMock(scalar_one_or_none=MagicMock(return_value=org)),
+        MagicMock(scalar_one_or_none=MagicMock(return_value=org_license)),
+    ]
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "dev_health_ops.db.get_postgres_session",
+        return_value=mock_ctx,
+    ):
+        from dev_health_ops.api.billing.router import _revoke_license
+
+        await _revoke_license(str(org_id))
+
+    mock_session.commit.assert_called_once()
+    assert org.tier == "community"
+    assert org_license.tier == "community"
+    assert org_license.is_valid is False
+
+
+@pytest.mark.asyncio
+async def test_revoke_license_proceeds_when_no_org_or_license():
+    """_revoke_license with no DB rows should commit without error."""
+    org_id = uuid.uuid4()
+
+    mock_session = AsyncMock()
+    mock_session.execute.side_effect = [
+        MagicMock(scalar_one_or_none=MagicMock(return_value=None)),
+        MagicMock(scalar_one_or_none=MagicMock(return_value=None)),
+    ]
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "dev_health_ops.db.get_postgres_session",
+        return_value=mock_ctx,
+    ):
+        from dev_health_ops.api.billing.router import _revoke_license
+
+        await _revoke_license(str(org_id))
+
+    # No org/license rows → nothing to guard, commit still called
+    mock_session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_persist_license_skips_manual_org_managed_by():
+    from dev_health_ops.api.billing.router import _persist_license
+    from dev_health_ops.licensing.types import LicenseTier
+
+    org_id = uuid.uuid4()
+    org = _make_org(org_id, tier="enterprise", managed_by="manual")
+    org_license = _make_license(org_id, tier="enterprise", managed_by="stripe")
+
+    mock_session = AsyncMock()
+    mock_session.execute.side_effect = [
+        MagicMock(scalar_one_or_none=MagicMock(return_value=org)),
+        MagicMock(scalar_one_or_none=MagicMock(return_value=org_license)),
+    ]
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("dev_health_ops.db.get_postgres_session", return_value=mock_ctx):
+        persisted = await _persist_license(
+            str(org_id), LicenseTier.TEAM, "stripe-license", "cus_123"
+        )
+
+    assert persisted is False
+    mock_session.commit.assert_not_called()
+    assert org.tier == "enterprise"
+    assert org_license.tier == "enterprise"
+
+
+@pytest.mark.asyncio
+async def test_persist_license_skips_manual_license_managed_by():
+    from dev_health_ops.api.billing.router import _persist_license
+    from dev_health_ops.licensing.types import LicenseTier
+
+    org_id = uuid.uuid4()
+    org = _make_org(org_id, tier="enterprise", managed_by="stripe")
+    org_license = _make_license(org_id, tier="enterprise", managed_by="manual")
+
+    mock_session = AsyncMock()
+    mock_session.execute.side_effect = [
+        MagicMock(scalar_one_or_none=MagicMock(return_value=org)),
+        MagicMock(scalar_one_or_none=MagicMock(return_value=org_license)),
+    ]
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("dev_health_ops.db.get_postgres_session", return_value=mock_ctx):
+        persisted = await _persist_license(
+            str(org_id), LicenseTier.TEAM, "stripe-license", "cus_123"
+        )
+
+    assert persisted is False
+    mock_session.commit.assert_not_called()
+    assert org.tier == "enterprise"
+    assert org_license.tier == "enterprise"
+
+
+@pytest.mark.asyncio
+async def test_persist_license_updates_stripe_managed_rows():
+    from dev_health_ops.api.billing.router import _persist_license
+    from dev_health_ops.licensing.types import LicenseTier
+
+    org_id = uuid.uuid4()
+    org = _make_org(org_id, tier="community", managed_by="stripe")
+    org_license = _make_license(org_id, tier="community", managed_by="stripe")
+
+    mock_session = AsyncMock()
+    mock_session.execute.side_effect = [
+        MagicMock(scalar_one_or_none=MagicMock(return_value=org)),
+        MagicMock(scalar_one_or_none=MagicMock(return_value=org_license)),
+    ]
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("dev_health_ops.db.get_postgres_session", return_value=mock_ctx):
+        persisted = await _persist_license(
+            str(org_id), LicenseTier.TEAM, "stripe-license", "cus_123"
+        )
+
+    assert persisted is True
+    mock_session.commit.assert_called_once()
+    assert org.tier == "team"
+    assert org_license.tier == "team"
+    assert org_license.license_key == "stripe-license"
+    assert org_license.customer_id == "cus_123"
+
+
+# ---------------------------------------------------------------------------
+# OrganizationService.update sets managed_by='manual'
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_org_service_update_sets_managed_by_manual_on_org():
+    """OrganizationService.update must set org.managed_by='manual' when tier changes."""
+    from dev_health_ops.api.services.users import OrganizationService
+
+    org_id = uuid.uuid4()
+    org = SimpleNamespace(
+        id=org_id,
+        slug="test-org",
+        name="Test Org",
+        description=None,
+        tier="community",
+        managed_by="stripe",
+        is_active=True,
+        settings={},
+        updated_at=None,
+    )
+
+    mock_session = AsyncMock()
+
+    async def _get_by_id(_id: str):
+        return org
+
+    svc = OrganizationService(mock_session)
+    svc.get_by_id = _get_by_id  # type: ignore[method-assign]
+
+    # Stub _sync_license_tier to avoid DB calls
+    svc._sync_license_tier = AsyncMock()  # type: ignore[method-assign]
+
+    result = await svc.update(str(org_id), tier="enterprise")
+
+    assert result is org
+    assert org.tier == "enterprise"
+    assert org.managed_by == "manual"
+    svc._sync_license_tier.assert_awaited_once_with(org_id, "enterprise")
+
+
+@pytest.mark.asyncio
+async def test_org_service_create_sets_managed_by_manual_for_paid_tier():
+    from dev_health_ops.api.services.users import OrganizationService
+
+    mock_session = AsyncMock()
+    mock_session.add = MagicMock()
+    mock_session.execute.return_value = MagicMock(
+        scalar_one_or_none=MagicMock(return_value=None)
+    )
+
+    svc = OrganizationService(mock_session)
+    org = await svc.create(name="Enterprise Org", tier="enterprise")
+
+    assert org.tier == "enterprise"
+    assert org.managed_by == "manual"
+
+
+@pytest.mark.asyncio
+async def test_org_service_create_leaves_community_stripe_managed():
+    from dev_health_ops.api.services.users import OrganizationService
+
+    mock_session = AsyncMock()
+    mock_session.add = MagicMock()
+    mock_session.execute.return_value = MagicMock(
+        scalar_one_or_none=MagicMock(return_value=None)
+    )
+
+    svc = OrganizationService(mock_session)
+    org = await svc.create(name="Community Org")
+
+    assert org.tier == "community"
+    assert org.managed_by == "stripe"
+
+
+@pytest.mark.asyncio
+async def test_org_service_update_no_tier_does_not_set_managed_by():
+    """OrganizationService.update must NOT set managed_by when tier is not changed."""
+    from dev_health_ops.api.services.users import OrganizationService
+
+    org_id = uuid.uuid4()
+    org = SimpleNamespace(
+        id=org_id,
+        slug="test-org",
+        name="Test Org",
+        description=None,
+        tier="team",
+        managed_by="stripe",
+        is_active=True,
+        settings={},
+        updated_at=None,
+    )
+
+    mock_session = AsyncMock()
+
+    async def _get_by_id(_id: str):
+        return org
+
+    svc = OrganizationService(mock_session)
+    svc.get_by_id = _get_by_id  # type: ignore[method-assign]
+    svc._sync_license_tier = AsyncMock()  # type: ignore[method-assign]
+
+    await svc.update(str(org_id), name="New Name")
+
+    # managed_by must remain unchanged
+    assert org.managed_by == "stripe"
+    svc._sync_license_tier.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_org_service_update_same_tier_preserves_managed_by():
+    from dev_health_ops.api.services.users import OrganizationService
+
+    org_id = uuid.uuid4()
+    org = SimpleNamespace(
+        id=org_id,
+        slug="test-org",
+        name="Test Org",
+        description=None,
+        tier="team",
+        managed_by="stripe",
+        is_active=True,
+        settings={},
+        updated_at=None,
+    )
+
+    mock_session = AsyncMock()
+
+    async def _get_by_id(_id: str):
+        return org
+
+    svc = OrganizationService(mock_session)
+    svc.get_by_id = _get_by_id  # type: ignore[method-assign]
+    svc._sync_license_tier = AsyncMock()  # type: ignore[method-assign]
+
+    await svc.update(str(org_id), name="New Name", tier="team")
+
+    assert org.managed_by == "stripe"
+    svc._sync_license_tier.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_org_service_update_community_keeps_stripe_manageable():
+    from dev_health_ops.api.services.users import OrganizationService
+
+    org_id = uuid.uuid4()
+    org = SimpleNamespace(
+        id=org_id,
+        slug="test-org",
+        name="Test Org",
+        description=None,
+        tier="enterprise",
+        managed_by="manual",
+        is_active=True,
+        settings={},
+        updated_at=None,
+    )
+
+    mock_session = AsyncMock()
+
+    async def _get_by_id(_id: str):
+        return org
+
+    svc = OrganizationService(mock_session)
+    svc.get_by_id = _get_by_id  # type: ignore[method-assign]
+    svc._sync_license_tier = AsyncMock()  # type: ignore[method-assign]
+
+    await svc.update(str(org_id), tier="community")
+
+    assert org.tier == "community"
+    assert org.managed_by == "stripe"
+    svc._sync_license_tier.assert_awaited_once_with(org_id, "community")
+
+
+# ---------------------------------------------------------------------------
+# _sync_license_tier sets managed_by='manual' on OrgLicense
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_license_tier_sets_managed_by_manual():
+    """_sync_license_tier must set org_license.managed_by='manual'."""
+    from dev_health_ops.api.services.users import OrganizationService
+
+    org_id = uuid.uuid4()
+    org_license = SimpleNamespace(
+        org_id=org_id,
+        tier="community",
+        managed_by="stripe",
+        updated_at=None,
+    )
+
+    mock_session = AsyncMock()
+    mock_session.execute.return_value = MagicMock(
+        scalar_one_or_none=MagicMock(return_value=org_license)
+    )
+
+    svc = OrganizationService(mock_session)
+    await svc._sync_license_tier(org_id, "enterprise")
+
+    assert org_license.tier == "enterprise"
+    assert org_license.managed_by == "manual"
+
+
+@pytest.mark.asyncio
+async def test_sync_license_tier_no_license_row_is_noop():
+    """_sync_license_tier with no OrgLicense row must not raise."""
+    from dev_health_ops.api.services.users import OrganizationService
+
+    org_id = uuid.uuid4()
+
+    mock_session = AsyncMock()
+    mock_session.execute.return_value = MagicMock(
+        scalar_one_or_none=MagicMock(return_value=None)
+    )
+
+    svc = OrganizationService(mock_session)
+    # Should not raise
+    await svc._sync_license_tier(org_id, "enterprise")
+
+
+@pytest.mark.asyncio
+async def test_sync_license_tier_community_keeps_license_stripe_manageable():
+    from dev_health_ops.api.services.users import OrganizationService
+
+    org_id = uuid.uuid4()
+    org_license = SimpleNamespace(
+        org_id=org_id,
+        tier="enterprise",
+        managed_by="manual",
+        updated_at=None,
+    )
+
+    mock_session = AsyncMock()
+    mock_session.execute.return_value = MagicMock(
+        scalar_one_or_none=MagicMock(return_value=org_license)
+    )
+
+    svc = OrganizationService(mock_session)
+    await svc._sync_license_tier(org_id, "community")
+
+    assert org_license.tier == "community"
+    assert org_license.managed_by == "stripe"
+
+
+def test_managed_by_migration_backfills_likely_manual_rows():
+    migration = (
+        "src/dev_health_ops/alembic/versions/0011_add_managed_by_to_org_license.py"
+    )
+    source = __import__("pathlib").Path(migration).read_text()
+
+    assert "UPDATE org_licenses" in source
+    assert "coalesce(tier, 'community') <> 'community'" in source
+    assert "coalesce(is_valid, false) = true" in source
+    assert "FROM subscriptions" in source
+    assert "subscriptions.status IN ('active', 'trialing', 'past_due')" in source
+    assert "NOT EXISTS" in source
+    assert "org_licenses.license_type" not in source
+    assert "stripe_customer_id IS NULL" not in source
+    assert "UPDATE organizations" in source

--- a/tests/api/billing/test_managed_by_guard.py
+++ b/tests/api/billing/test_managed_by_guard.py
@@ -268,7 +268,9 @@ async def test_persist_license_updates_stripe_managed_rows():
 
 
 @pytest.mark.asyncio
-async def test_org_service_update_sets_managed_by_manual_on_org():
+async def test_org_service_update_sets_managed_by_manual_on_org(
+    monkeypatch: pytest.MonkeyPatch,
+):
     """OrganizationService.update must set org.managed_by='manual' when tier changes."""
     from dev_health_ops.api.services.users import OrganizationService
 
@@ -291,17 +293,18 @@ async def test_org_service_update_sets_managed_by_manual_on_org():
         return org
 
     svc = OrganizationService(mock_session)
-    svc.get_by_id = _get_by_id  # type: ignore[method-assign]
+    monkeypatch.setattr(svc, "get_by_id", _get_by_id)
 
     # Stub _sync_license_tier to avoid DB calls
-    svc._sync_license_tier = AsyncMock()  # type: ignore[method-assign]
+    sync_license_tier = AsyncMock()
+    monkeypatch.setattr(svc, "_sync_license_tier", sync_license_tier)
 
     result = await svc.update(str(org_id), tier="enterprise")
 
     assert result is org
     assert org.tier == "enterprise"
     assert org.managed_by == "manual"
-    svc._sync_license_tier.assert_awaited_once_with(org_id, "enterprise")
+    sync_license_tier.assert_awaited_once_with(org_id, "enterprise")
 
 
 @pytest.mark.asyncio
@@ -339,7 +342,9 @@ async def test_org_service_create_leaves_community_stripe_managed():
 
 
 @pytest.mark.asyncio
-async def test_org_service_update_no_tier_does_not_set_managed_by():
+async def test_org_service_update_no_tier_does_not_set_managed_by(
+    monkeypatch: pytest.MonkeyPatch,
+):
     """OrganizationService.update must NOT set managed_by when tier is not changed."""
     from dev_health_ops.api.services.users import OrganizationService
 
@@ -362,18 +367,21 @@ async def test_org_service_update_no_tier_does_not_set_managed_by():
         return org
 
     svc = OrganizationService(mock_session)
-    svc.get_by_id = _get_by_id  # type: ignore[method-assign]
-    svc._sync_license_tier = AsyncMock()  # type: ignore[method-assign]
+    monkeypatch.setattr(svc, "get_by_id", _get_by_id)
+    sync_license_tier = AsyncMock()
+    monkeypatch.setattr(svc, "_sync_license_tier", sync_license_tier)
 
     await svc.update(str(org_id), name="New Name")
 
     # managed_by must remain unchanged
     assert org.managed_by == "stripe"
-    svc._sync_license_tier.assert_not_awaited()
+    sync_license_tier.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_org_service_update_same_tier_preserves_managed_by():
+async def test_org_service_update_same_tier_preserves_managed_by(
+    monkeypatch: pytest.MonkeyPatch,
+):
     from dev_health_ops.api.services.users import OrganizationService
 
     org_id = uuid.uuid4()
@@ -395,17 +403,20 @@ async def test_org_service_update_same_tier_preserves_managed_by():
         return org
 
     svc = OrganizationService(mock_session)
-    svc.get_by_id = _get_by_id  # type: ignore[method-assign]
-    svc._sync_license_tier = AsyncMock()  # type: ignore[method-assign]
+    monkeypatch.setattr(svc, "get_by_id", _get_by_id)
+    sync_license_tier = AsyncMock()
+    monkeypatch.setattr(svc, "_sync_license_tier", sync_license_tier)
 
     await svc.update(str(org_id), name="New Name", tier="team")
 
     assert org.managed_by == "stripe"
-    svc._sync_license_tier.assert_not_awaited()
+    sync_license_tier.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_org_service_update_community_keeps_stripe_manageable():
+async def test_org_service_update_community_keeps_stripe_manageable(
+    monkeypatch: pytest.MonkeyPatch,
+):
     from dev_health_ops.api.services.users import OrganizationService
 
     org_id = uuid.uuid4()
@@ -427,14 +438,15 @@ async def test_org_service_update_community_keeps_stripe_manageable():
         return org
 
     svc = OrganizationService(mock_session)
-    svc.get_by_id = _get_by_id  # type: ignore[method-assign]
-    svc._sync_license_tier = AsyncMock()  # type: ignore[method-assign]
+    monkeypatch.setattr(svc, "get_by_id", _get_by_id)
+    sync_license_tier = AsyncMock()
+    monkeypatch.setattr(svc, "_sync_license_tier", sync_license_tier)
 
     await svc.update(str(org_id), tier="community")
 
     assert org.tier == "community"
     assert org.managed_by == "stripe"
-    svc._sync_license_tier.assert_awaited_once_with(org_id, "community")
+    sync_license_tier.assert_awaited_once_with(org_id, "community")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/jira/test_ops_mapping.py
+++ b/tests/providers/jira/test_ops_mapping.py
@@ -19,6 +19,7 @@ def test_sync_teams_jira_ops():
     ns.analytics_db = None
     ns.provider = "jira-ops"
     ns.path = None
+    ns.org = None
 
     # Mock data from library
     mock_project = CanonicalProjectWithOpsgenieTeams(

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any, Protocol, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -13,6 +14,12 @@ from httpx import ASGITransport, AsyncClient
 from dev_health_ops.api.billing.router import SignatureVerificationError, router
 from dev_health_ops.api.billing.stripe_client import reset_price_tier_map
 from tests._helpers import tables_of
+
+
+class _CallableCeleryTask(Protocol):
+    def __call__(self, email_type: str, org_id: str, **kwargs: Any) -> dict: ...
+    def push_request(self, **kwargs: Any) -> None: ...
+    def pop_request(self) -> None: ...
 
 
 @pytest.fixture(autouse=True)
@@ -1239,6 +1246,74 @@ async def test_subscription_update_does_not_duplicate_license(bridge_db):
 
 
 @pytest.mark.asyncio
+async def test_subscription_sync_preserves_manually_managed_license(bridge_db):
+    import uuid
+
+    from sqlalchemy import select
+
+    from dev_health_ops.api.billing.subscription_service import SubscriptionService
+    from dev_health_ops.models.licensing import OrgLicense
+    from dev_health_ops.models.users import Organization
+
+    org_id = uuid.uuid4()
+    plan_id = uuid.uuid4()
+    price_id = uuid.uuid4()
+    bundle_id = uuid.uuid4()
+    stripe_price_id = "price_manual_guard"
+
+    async with bridge_db() as session:
+        from sqlalchemy import select as sa_select
+
+        from dev_health_ops.models.billing import BillingPrice
+
+        await _seed_enterprise_plan(session, plan_id, price_id, bundle_id)
+        price_row = (
+            await session.execute(
+                sa_select(BillingPrice).where(BillingPrice.id == price_id)
+            )
+        ).scalar_one()
+        price_row.stripe_price_id = stripe_price_id
+
+        org = Organization(
+            id=org_id, slug=f"manual-org-{org_id.hex[:8]}", name="Manual Org"
+        )
+        org.tier = "enterprise"
+        org.managed_by = "manual"
+        session.add(org)
+        session.add(
+            OrgLicense(
+                org_id=org_id,
+                tier="enterprise",
+                license_type="saas",
+                managed_by="manual",
+                customer_id="cus_manual",
+            )
+        )
+        await session.commit()
+
+    stripe_sub = _make_stripe_sub("sub_manual_guard", stripe_price_id, org_id)
+
+    async with bridge_db() as session:
+        svc = SubscriptionService(session)
+        await svc.upsert_from_stripe(stripe_sub, org_id)
+        await session.commit()
+
+    async with bridge_db() as session:
+        org_row = (
+            await session.execute(select(Organization).where(Organization.id == org_id))
+        ).scalar_one()
+        lic = (
+            await session.execute(select(OrgLicense).where(OrgLicense.org_id == org_id))
+        ).scalar_one()
+
+    assert org_row.tier == "enterprise"
+    assert org_row.managed_by == "manual"
+    assert lic.tier == "enterprise"
+    assert lic.managed_by == "manual"
+    assert lic.customer_id == "cus_manual"
+
+
+@pytest.mark.asyncio
 async def test_subscription_cancellation_downgrades_license(bridge_db):
     """Cancelled subscription downgrades OrgLicense to community; row survives."""
     import uuid
@@ -1617,7 +1692,7 @@ class TestInvalidOrgIdGuards:
         fixture ids like 'org-abc')."""
         from dev_health_ops.workers.system_ops import send_billing_notification
 
-        task = send_billing_notification
+        task = cast(_CallableCeleryTask, send_billing_notification)
         task.push_request(id="billing-bad-org", retries=0)
         try:
             result = task("subscription_cancelled", "org-abc", tier="team")

--- a/tests/test_linear_team_sync.py
+++ b/tests/test_linear_team_sync.py
@@ -77,7 +77,7 @@ def _make_ns(
     ns.provider = provider
     ns.db = db
     ns.sink = "clickhouse"
-    ns.analytics_db = None
+    ns.analytics_db = "clickhouse://example.test:8123/default"
     ns.path = None
     ns.owner = None
     ns.auth = None
@@ -94,20 +94,22 @@ class TestLinearTeamSync:
     """Tests for the linear branch inside sync_teams()."""
 
     @patch("dev_health_ops.providers.teams._bridge_teams_to_postgres")
-    @patch("dev_health_ops.providers.teams.resolve_sink_uri")
     @patch("dev_health_ops.providers.linear.client.LinearClient")
     def test_happy_path_two_teams(
         self,
         mock_client_class: MagicMock,
-        mock_resolve_sink: MagicMock,
         mock_bridge: MagicMock,
     ) -> None:
-        """Happy path: two active teams with members → two Team objects created."""
+        """Happy path: two active teams with members → two Team objects created.
+
+        Org-scoped path (ns.org set): _bridge_teams_to_postgres is called directly;
+        asyncio.run is NOT called for the ClickHouse write (bridge_teams_to_clickhouse
+        handles that internally).
+        """
         from dev_health_ops.providers.teams import sync_teams
 
         mock_client = MagicMock()
         mock_client_class.from_env.return_value = mock_client
-        mock_resolve_sink.return_value = "clickhouse://localhost:8123/default"
         mock_bridge.return_value = 2
         mock_client.iter_teams.return_value = [
             _mock_linear_team(
@@ -123,14 +125,14 @@ class TestLinearTeamSync:
         ]
 
         ns = _make_ns()
-        with patch("asyncio.run") as mock_run:
-            mock_run.side_effect = _close_coroutine
+        with patch(
+            "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+            return_value=2,
+        ):
             result = sync_teams(ns)
 
         assert result == 0
-        # asyncio.run was called (to persist teams)
-        mock_run.assert_called_once()
-        # bridge was called
+        # bridge was called with the provider-built teams list
         mock_bridge.assert_called_once()
         # Verify the teams list passed to bridge has 2 items with correct IDs
         teams_arg = mock_bridge.call_args[0][0]
@@ -165,7 +167,13 @@ class TestLinearTeamSync:
         ]
 
         ns = _make_ns()
-        with patch("asyncio.run") as mock_run:
+        with (
+            patch("asyncio.run") as mock_run,
+            patch(
+                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+                return_value=1,
+            ),
+        ):
             mock_run.side_effect = _close_coroutine
             result = sync_teams(ns)
 
@@ -195,7 +203,13 @@ class TestLinearTeamSync:
         ]
 
         ns = _make_ns()
-        with patch("asyncio.run") as mock_run:
+        with (
+            patch("asyncio.run") as mock_run,
+            patch(
+                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+                return_value=1,
+            ),
+        ):
             mock_run.side_effect = _close_coroutine
             result = sync_teams(ns)
 
@@ -239,7 +253,13 @@ class TestLinearTeamSync:
         mock_client.get_team_members.return_value = [initial_member, extra_member]
 
         ns = _make_ns()
-        with patch("asyncio.run") as mock_run:
+        with (
+            patch("asyncio.run") as mock_run,
+            patch(
+                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+                return_value=1,
+            ),
+        ):
             mock_run.side_effect = _close_coroutine
             result = sync_teams(ns)
 
@@ -251,6 +271,49 @@ class TestLinearTeamSync:
         # Both members should be present
         assert "alice@example.com" in teams_arg[0].members
         assert "bob@example.com" in teams_arg[0].members
+
+    @patch("dev_health_ops.providers.teams._bridge_teams_to_postgres")
+    @patch("dev_health_ops.providers.teams.resolve_sink_uri")
+    @patch("dev_health_ops.providers.linear.client.LinearClient")
+    def test_partial_member_pagination_is_marked_incomplete(
+        self,
+        mock_client_class: MagicMock,
+        mock_resolve_sink: MagicMock,
+        mock_bridge: MagicMock,
+    ) -> None:
+        from dev_health_ops.providers.teams import sync_teams
+
+        mock_client = MagicMock()
+        mock_client_class.from_env.return_value = mock_client
+        mock_resolve_sink.return_value = "clickhouse://localhost:8123/default"
+        mock_bridge.return_value = 1
+        initial_member = _mock_member(name="Alice", email="alice@example.com")
+        mock_client.iter_teams.return_value = [
+            _mock_linear_team(
+                key="BIG",
+                name="Big Team",
+                team_id="team-big",
+                members=[initial_member],
+                has_next_page=True,
+            ),
+        ]
+        mock_client.get_team_members.side_effect = RuntimeError("linear timeout")
+
+        ns = _make_ns()
+        with (
+            patch("asyncio.run") as mock_run,
+            patch(
+                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+                return_value=1,
+            ),
+        ):
+            mock_run.side_effect = _close_coroutine
+            result = sync_teams(ns)
+
+        assert result == 0
+        teams_arg = mock_bridge.call_args[0][0]
+        assert teams_arg[0].members == ["alice@example.com"]
+        assert getattr(teams_arg[0], "members_complete") is False
 
     @patch("dev_health_ops.providers.linear.client.LinearClient")
     def test_linear_config_error_returns_1(
@@ -311,7 +374,13 @@ class TestLinearTeamSync:
         ]
 
         ns = _make_ns()
-        with patch("asyncio.run") as mock_run:
+        with (
+            patch("asyncio.run") as mock_run,
+            patch(
+                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+                return_value=1,
+            ),
+        ):
             mock_run.side_effect = _close_coroutine
             result = sync_teams(ns)
 

--- a/tests/test_sync_team_parallel.py
+++ b/tests/test_sync_team_parallel.py
@@ -1,4 +1,7 @@
-"""Assert sync_team_drift dispatches provider discovery concurrently."""
+"""Assert sync_team_drift dispatches provider discovery concurrently.
+
+Covers the full capability registry: github, gitlab, jira, linear, ms-teams.
+"""
 
 from __future__ import annotations
 
@@ -33,10 +36,24 @@ async def test_providers_discovered_concurrently(monkeypatch):
 
     fake_creds = MagicMock()
     fake_creds.get = AsyncMock(
-        return_value=MagicMock(config={"org": "o", "group": "g", "url": "https://j"})
+        return_value=MagicMock(
+            config={
+                "org": "o",
+                "group": "g",
+                "url": "https://j",
+            }
+        )
     )
     fake_creds.get_decrypted_credentials = AsyncMock(
-        return_value={"token": "t", "email": "e@x", "api_token": "a"}
+        return_value={
+            "token": "t",
+            "email": "e@x",
+            "api_token": "a",
+            "api_key": "lk",
+            "tenant_id": "tid",
+            "client_id": "cid",
+            "client_secret": "csec",
+        }
     )
 
     async def slow_discover_gitlab(*args, **kwargs):
@@ -49,6 +66,8 @@ async def test_providers_discovered_concurrently(monkeypatch):
     fake_discovery.discover_github = slow_discover
     fake_discovery.discover_gitlab = slow_discover_gitlab
     fake_discovery.discover_jira = slow_discover
+    fake_discovery.discover_linear = slow_discover
+    fake_discovery.discover_ms_teams = slow_discover
 
     fake_drift = MagicMock()
     fake_drift.run_drift_sync = AsyncMock(return_value={"provider": "x"})
@@ -83,8 +102,8 @@ async def test_providers_discovered_concurrently(monkeypatch):
     ):
         result = await mod._discover_and_sync_all(org_id="org-1")
 
-    assert peak >= 3, f"Expected 3 concurrent providers, observed peak={peak}"
-    assert len(result["results"]) == 3
+    assert peak >= 5, f"Expected 5 concurrent providers, observed peak={peak}"
+    assert len(result["results"]) == 5
     # CHAOS-2066: the connection is scoped to DB ops only -- never held during
     # discovery, and never more than one open at a time per job.
     assert open_during_discovery == 0, (
@@ -94,3 +113,32 @@ async def test_providers_discovered_concurrently(monkeypatch):
         f"More than one session open at once (peak={sessions['peak_open']})"
     )
     assert sessions["open"] == 0, "Session leaked (not closed)"
+
+
+@pytest.mark.asyncio
+async def test_capability_registry_covers_all_supported_providers():
+    """The capability registry in _discover_and_sync_all must cover all 5 org-scoped providers.
+
+    This test is a static invariant: if a provider is added to providers/teams.py
+    sync_teams() but not to the worker registry, this test catches the drift.
+    """
+    import inspect
+
+    from dev_health_ops.workers import sync_team as mod
+
+    source = inspect.getsource(mod._discover_and_sync_all)
+    for provider in ("github", "gitlab", "jira", "linear", "ms-teams"):
+        assert provider in source, (
+            f"Provider '{provider}' missing from _discover_and_sync_all capability registry"
+        )
+
+
+def test_reconcile_team_members_uses_clickhouse_uri_and_preserves_org_scope():
+    import inspect
+
+    from dev_health_ops.workers import sync_team as mod
+
+    source = inspect.getsource(mod.reconcile_team_members)
+    assert "require_clickhouse_uri()" in source
+    assert "_get_db_url" not in source
+    assert 'org_id=str(getattr(team, "org_id"' in source

--- a/tests/test_sync_teams_routing_invariants.py
+++ b/tests/test_sync_teams_routing_invariants.py
@@ -1,0 +1,779 @@
+"""Invariant tests for sync_teams routing (CHAOS-2401).
+
+Pins the two routing paths introduced by CHAOS-2401:
+
+Org-scoped path (``--org <id>`` present):
+    provider → _bridge_teams_to_postgres → bridge_teams_to_clickhouse
+    - run_with_store is NOT called (no direct ClickHouse write from provider data)
+    - _bridge_teams_to_postgres IS called and its count gates the exit code
+    - bridge_teams_to_clickhouse IS called with the correct org_id
+    - bridge_teams_to_clickhouse failure is fatal after PostgreSQL succeeds
+
+No-org path (``--org`` absent):
+    provider → run_with_store (direct ClickHouse write)
+    - _bridge_teams_to_postgres is NOT called
+    - bridge_teams_to_clickhouse is NOT called
+    - run_with_store IS called with org_id=None
+
+Membership invariants (bridge_teams_to_clickhouse):
+    - Reads TeamMapping + IdentityMapping from Postgres (org-scoped)
+    - Emits identity-resolved members (email, canonical_id, provider logins)
+    - Does not read from provider-supplied teams_data directly
+"""
+
+from __future__ import annotations
+
+import argparse
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ns(
+    *,
+    provider: str = "config",
+    org: str | None = None,
+    allow_empty: bool = False,
+    path: str | None = None,
+) -> argparse.Namespace:
+    ns = argparse.Namespace()
+    ns.provider = provider
+    ns.org = org
+    ns.allow_empty = allow_empty
+    ns.path = path
+    ns.db = "sqlite+aiosqlite:///:memory:"
+    ns.sink = "clickhouse"
+    ns.analytics_db = "clickhouse://example.test:8123/default"
+    ns.owner = None
+    ns.auth = None
+    return ns
+
+
+# ---------------------------------------------------------------------------
+# Org-scoped routing invariants
+# ---------------------------------------------------------------------------
+
+
+class TestOrgScopedRouting:
+    """Org-scoped sync must go through Postgres-first path."""
+
+    def test_org_scoped_does_not_call_run_with_store(self, tmp_path: Any) -> None:
+        """run_with_store must NOT be called for org-scoped syncs.
+
+        The org-scoped path is: _bridge_teams_to_postgres → bridge_teams_to_clickhouse.
+        run_with_store (direct ClickHouse write from provider data) must be bypassed.
+        """
+        import yaml
+
+        from dev_health_ops.providers.teams import sync_teams
+
+        config_file = tmp_path / "teams.yaml"
+        config_file.write_text(
+            yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+        )
+
+        run_with_store_called = []
+
+        async def _spy_run_with_store(
+            _db_uri: str, _db_type: str, handler: Any, org_id: Any = None
+        ) -> int:
+            run_with_store_called.append(org_id)
+            return 1
+
+        with (
+            patch(
+                "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+                return_value=1,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+                return_value=1,
+            ),
+            patch(
+                "dev_health_ops.storage.run_with_store",
+                side_effect=_spy_run_with_store,
+            ),
+        ):
+            ns = _make_ns(org="org-1", path=str(config_file))
+            result = sync_teams(ns)
+
+        assert result == 0
+        assert run_with_store_called == [], (
+            "run_with_store must not be called on the org-scoped path"
+        )
+
+    def test_org_scoped_calls_bridge_to_postgres(self, tmp_path: Any) -> None:
+        """_bridge_teams_to_postgres must be called for org-scoped syncs."""
+        import yaml
+
+        from dev_health_ops.providers.teams import sync_teams
+
+        config_file = tmp_path / "teams.yaml"
+        config_file.write_text(
+            yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+        )
+
+        pg_calls: list[Any] = []
+
+        def _spy_pg(teams_data: list, ns: Any) -> int:
+            pg_calls.append((teams_data, ns))
+            return len(teams_data)
+
+        with (
+            patch(
+                "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+                side_effect=_spy_pg,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+                return_value=1,
+            ),
+        ):
+            ns = _make_ns(org="org-1", path=str(config_file))
+            result = sync_teams(ns)
+
+        assert result == 0
+        assert len(pg_calls) == 1, "_bridge_teams_to_postgres must be called once"
+
+    def test_org_scoped_calls_bridge_to_clickhouse_with_org_id_and_db_url(
+        self, tmp_path: Any
+    ) -> None:
+        """bridge_teams_to_clickhouse must receive org_id and requested DB URL."""
+        import yaml
+
+        from dev_health_ops.providers.teams import sync_teams
+
+        config_file = tmp_path / "teams.yaml"
+        config_file.write_text(
+            yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+        )
+
+        captured_calls: list[tuple[str | None, str | None, str | None]] = []
+
+        def _spy_ch(
+            org_id: str | None = None,
+            db_url: str | None = None,
+            postgres_db_url: str | None = None,
+        ) -> int:
+            captured_calls.append((org_id, db_url, postgres_db_url))
+            return 1
+
+        with (
+            patch(
+                "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+                return_value=1,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+                side_effect=_spy_ch,
+            ),
+        ):
+            ns = _make_ns(org="org-42", path=str(config_file))
+            result = sync_teams(ns)
+
+        assert result == 0
+        assert captured_calls == [
+            (
+                "org-42",
+                "clickhouse://example.test:8123/default",
+                "sqlite+aiosqlite:///:memory:",
+            )
+        ], "bridge_teams_to_clickhouse must receive the org_id and requested db URL"
+
+    def test_org_scoped_postgres_bridge_failure_exits_one(self, tmp_path: Any) -> None:
+        """If _bridge_teams_to_postgres raises, exit code must be 1."""
+        import yaml
+
+        from dev_health_ops.providers.teams import sync_teams
+
+        config_file = tmp_path / "teams.yaml"
+        config_file.write_text(
+            yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+        )
+
+        with patch(
+            "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+            side_effect=RuntimeError("pg down"),
+        ):
+            ns = _make_ns(org="org-1", path=str(config_file))
+            result = sync_teams(ns)
+
+        assert result == 1
+
+    def test_org_scoped_postgres_bridge_zero_count_exits_one(
+        self, tmp_path: Any
+    ) -> None:
+        """If _bridge_teams_to_postgres returns 0, exit code must be 1."""
+        import yaml
+
+        from dev_health_ops.providers.teams import sync_teams
+
+        config_file = tmp_path / "teams.yaml"
+        config_file.write_text(
+            yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+        )
+
+        with patch(
+            "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+            return_value=0,
+        ):
+            ns = _make_ns(org="org-1", path=str(config_file))
+            result = sync_teams(ns)
+
+        assert result == 1
+
+    def test_org_scoped_clickhouse_bridge_failure_exits_one(
+        self, tmp_path: Any
+    ) -> None:
+        import yaml
+
+        from dev_health_ops.providers.teams import sync_teams
+
+        config_file = tmp_path / "teams.yaml"
+        config_file.write_text(
+            yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+        )
+
+        with (
+            patch(
+                "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+                return_value=1,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+                side_effect=RuntimeError("ch down"),
+            ),
+        ):
+            ns = _make_ns(org="org-1", path=str(config_file))
+            result = sync_teams(ns)
+
+        assert result == 1
+
+    def test_org_scoped_postgres_bridge_receives_provider_teams(
+        self, tmp_path: Any
+    ) -> None:
+        """_bridge_teams_to_postgres must receive the provider-built teams list."""
+        import yaml
+
+        from dev_health_ops.providers.teams import sync_teams
+
+        config_file = tmp_path / "teams.yaml"
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "teams": [
+                        {"team_id": "eng", "team_name": "Engineering"},
+                        {"team_id": "ops", "team_name": "Operations"},
+                    ]
+                }
+            )
+        )
+
+        captured: list[Any] = []
+
+        def _spy_pg(teams_data: list, ns: Any) -> int:
+            captured.extend(teams_data)
+            return len(teams_data)
+
+        with (
+            patch(
+                "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+                side_effect=_spy_pg,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+                return_value=2,
+            ),
+        ):
+            ns = _make_ns(org="org-1", path=str(config_file))
+            sync_teams(ns)
+
+        team_ids = {getattr(t, "id", None) for t in captured}
+        assert "eng" in team_ids
+        assert "ops" in team_ids
+
+
+# ---------------------------------------------------------------------------
+# No-org routing invariants
+# ---------------------------------------------------------------------------
+
+
+class TestNoOrgRouting:
+    """No-org sync must write directly to ClickHouse via run_with_store."""
+
+    def test_no_org_does_not_call_postgres_bridge(self, tmp_path: Any) -> None:
+        """_bridge_teams_to_postgres must NOT be called when org is absent."""
+        import yaml
+
+        from dev_health_ops.providers.teams import sync_teams
+
+        config_file = tmp_path / "teams.yaml"
+        config_file.write_text(
+            yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+        )
+
+        async def _fake_run_with_store(
+            _db_uri: str, _db_type: str, handler: Any, org_id: Any = None
+        ) -> int:
+            class _FakeStore:
+                async def ensure_tables(self) -> None:
+                    pass
+
+                async def insert_teams(self, teams: list) -> None:
+                    pass
+
+                async def get_all_teams(self) -> list:
+                    return [SimpleNamespace(id="team-a", org_id=None)]
+
+            return await handler(_FakeStore())
+
+        with (
+            patch(
+                "dev_health_ops.providers.teams._bridge_teams_to_postgres"
+            ) as mock_pg,
+            patch(
+                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse"
+            ) as mock_ch,
+            patch(
+                "dev_health_ops.storage.run_with_store",
+                side_effect=_fake_run_with_store,
+            ),
+            patch("dev_health_ops.providers.teams.validate_sink"),
+            patch(
+                "dev_health_ops.providers.teams.resolve_sink_uri",
+                return_value="clickhouse://localhost:8123/default",
+            ),
+            patch(
+                "dev_health_ops.providers.teams.detect_db_type",
+                return_value="clickhouse",
+            ),
+        ):
+            ns = _make_ns(org=None, path=str(config_file))
+            result = sync_teams(ns)
+
+        assert result == 0
+        mock_pg.assert_not_called()
+        mock_ch.assert_not_called()
+
+    def test_no_org_run_with_store_receives_org_id_none(self, tmp_path: Any) -> None:
+        """run_with_store must be called with org_id=None on the no-org path."""
+        import yaml
+
+        from dev_health_ops.providers.teams import sync_teams
+
+        config_file = tmp_path / "teams.yaml"
+        config_file.write_text(
+            yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+        )
+
+        captured_org_ids: list[Any] = []
+
+        async def _spy_run_with_store(
+            _db_uri: str, _db_type: str, handler: Any, org_id: Any = None
+        ) -> int:
+            captured_org_ids.append(org_id)
+
+            class _FakeStore:
+                async def ensure_tables(self) -> None:
+                    pass
+
+                async def insert_teams(self, teams: list) -> None:
+                    pass
+
+                async def get_all_teams(self) -> list:
+                    return [SimpleNamespace(id="team-a", org_id=None)]
+
+            return await handler(_FakeStore())
+
+        with (
+            patch(
+                "dev_health_ops.storage.run_with_store",
+                side_effect=_spy_run_with_store,
+            ),
+            patch("dev_health_ops.providers.teams.validate_sink"),
+            patch(
+                "dev_health_ops.providers.teams.resolve_sink_uri",
+                return_value="clickhouse://localhost:8123/default",
+            ),
+            patch(
+                "dev_health_ops.providers.teams.detect_db_type",
+                return_value="clickhouse",
+            ),
+            patch("dev_health_ops.providers.teams._bridge_teams_to_postgres"),
+        ):
+            ns = _make_ns(org=None, path=str(config_file))
+            sync_teams(ns)
+
+        assert captured_org_ids == [None], (
+            "run_with_store must be called with org_id=None on the no-org path"
+        )
+
+
+# ---------------------------------------------------------------------------
+# bridge_teams_to_clickhouse membership invariants
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeTeamsToClickhouseMembership:
+    """bridge_teams_to_clickhouse must read from Postgres and resolve identities."""
+
+    def _make_team_mapping(
+        self,
+        team_id: str = "eng",
+        name: str = "Engineering",
+        org_id: str = "org-1",
+        is_active: bool = True,
+        project_keys: Any = None,
+        repo_patterns: Any = None,
+        description: str | None = None,
+        updated_at: Any = None,
+    ) -> SimpleNamespace:
+        from datetime import datetime, timezone
+
+        return SimpleNamespace(
+            team_id=team_id,
+            name=name,
+            org_id=org_id,
+            is_active=is_active,
+            project_keys=project_keys,
+            repo_patterns=repo_patterns,
+            description=description,
+            updated_at=updated_at or datetime.now(timezone.utc),
+        )
+
+    def _make_identity_mapping(
+        self,
+        email: str | None = None,
+        canonical_id: str | None = None,
+        display_name: str | None = None,
+        provider_identities: dict | None = None,
+        team_ids: list | None = None,
+        is_active: bool = True,
+        org_id: str = "org-1",
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            email=email,
+            canonical_id=canonical_id,
+            display_name=display_name,
+            provider_identities=provider_identities or {},
+            team_ids=team_ids or [],
+            is_active=is_active,
+            org_id=org_id,
+        )
+
+    def _make_fake_session(
+        self,
+        team_mappings: list,
+        identity_mappings: list,
+    ) -> Any:
+        """Build a fake synchronous Postgres session context manager."""
+        call_count = [0]
+
+        class _FakeResult:
+            def __init__(self, rows: list) -> None:
+                self._rows = rows
+
+            def scalars(self) -> _FakeScalars:
+                return _FakeScalars(self._rows)
+
+        class _FakeScalars:
+            def __init__(self, rows: list) -> None:
+                self._rows = rows
+
+            def all(self) -> list:
+                return self._rows
+
+        class _FakeSession:
+            def __enter__(self) -> _FakeSession:
+                return self
+
+            def __exit__(self, *args: Any) -> None:
+                pass
+
+            def execute(self, stmt: Any) -> _FakeResult:
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    return _FakeResult(team_mappings)
+                return _FakeResult(identity_mappings)
+
+        return _FakeSession()
+
+    def _make_fake_ch_store(self) -> tuple[Any, list]:
+        """Return (mock ClickHouseStore class, captured_payloads list)."""
+        captured: list[Any] = []
+
+        class _FakeStore:
+            async def __aenter__(self) -> _FakeStore:
+                return self
+
+            async def __aexit__(self, *args: Any) -> None:
+                pass
+
+            async def insert_teams(self, payload: list) -> None:
+                captured.extend(payload)
+
+        class _FakeStoreClass:
+            def __init__(self, uri: str) -> None:
+                pass
+
+            def __new__(cls, uri: str) -> _FakeStore:  # type: ignore[misc]
+                return _FakeStore()
+
+        return _FakeStoreClass, captured
+
+    def test_bridge_calls_clickhouse_insert(self) -> None:
+        """bridge_teams_to_clickhouse must call ClickHouseStore.insert_teams."""
+        from dev_health_ops.providers.team_bridge import bridge_teams_to_clickhouse
+
+        team_mapping = self._make_team_mapping(team_id="eng", org_id="org-1")
+        fake_session = self._make_fake_session([team_mapping], [])
+        fake_store_cls, captured = self._make_fake_ch_store()
+
+        with (
+            patch(
+                "dev_health_ops.providers.team_bridge.get_postgres_session_sync",
+                return_value=fake_session,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge.ClickHouseStore",
+                fake_store_cls,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge._clickhouse_uri",
+                return_value="clickhouse://localhost:8123/default",
+            ),
+        ):
+            count = bridge_teams_to_clickhouse(org_id="org-1")
+
+        assert count == 1
+        assert len(captured) == 1
+        assert captured[0]["id"] == "eng"
+        assert captured[0]["org_id"] == "org-1"
+
+    def test_bridge_uses_requested_postgres_db_url(self) -> None:
+        from dev_health_ops.providers.team_bridge import bridge_teams_to_clickhouse
+
+        fake_session = self._make_fake_session([], [])
+        fake_store_cls, _captured = self._make_fake_ch_store()
+
+        with (
+            patch(
+                "dev_health_ops.providers.team_bridge.get_postgres_session_sync_for_uri",
+                return_value=fake_session,
+            ) as mock_session_for_uri,
+            patch(
+                "dev_health_ops.providers.team_bridge.ClickHouseStore",
+                fake_store_cls,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge._clickhouse_uri",
+                return_value="clickhouse://localhost:8123/default",
+            ),
+        ):
+            bridge_teams_to_clickhouse(
+                org_id="org-1",
+                postgres_db_url="sqlite:///semantic.db",
+            )
+
+        mock_session_for_uri.assert_called_once_with("sqlite:///semantic.db")
+
+    def test_bridge_requires_clickhouse_uri_not_database_uri(
+        self, monkeypatch: Any
+    ) -> None:
+        from dev_health_ops.providers.team_bridge import _clickhouse_uri
+
+        monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+        monkeypatch.setenv("DATABASE_URI", "postgresql://semantic.example/devhealth")
+
+        try:
+            _clickhouse_uri()
+        except RuntimeError as exc:
+            assert "CLICKHOUSE_URI" in str(exc)
+        else:
+            raise AssertionError("_clickhouse_uri must not use DATABASE_URI fallback")
+
+    def test_sync_teams_to_analytics_passes_clickhouse_uri(
+        self, monkeypatch: Any
+    ) -> None:
+        from dev_health_ops.workers.product_tasks import sync_teams_to_analytics
+
+        captured: dict[str, str | None] = {}
+
+        def _bridge(org_id: str | None = None, db_url: str | None = None) -> int:
+            captured["org_id"] = org_id
+            captured["db_url"] = db_url
+            return 3
+
+        monkeypatch.setenv("CLICKHOUSE_URI", "clickhouse://analytics.example/default")
+        monkeypatch.setenv("DATABASE_URI", "postgresql://semantic.example/devhealth")
+
+        with patch(
+            "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+            side_effect=_bridge,
+        ):
+            result = getattr(sync_teams_to_analytics, "run")(org_id="org-1")
+
+        assert result == {"status": "success", "teams_synced": 3}
+        assert captured == {
+            "org_id": "org-1",
+            "db_url": "clickhouse://analytics.example/default",
+        }
+
+    def test_bridge_emits_identity_resolved_members(self) -> None:
+        """bridge_teams_to_clickhouse must include email + provider logins in members."""
+        from dev_health_ops.providers.team_bridge import bridge_teams_to_clickhouse
+
+        team_mapping = self._make_team_mapping(team_id="eng", org_id="org-1")
+        identity = self._make_identity_mapping(
+            email="alice@example.com",
+            canonical_id="alice@example.com",
+            provider_identities={"github": ["alice-gh"], "linear": ["alice-lin"]},
+            team_ids=["eng"],
+            org_id="org-1",
+        )
+        fake_session = self._make_fake_session([team_mapping], [identity])
+        fake_store_cls, captured = self._make_fake_ch_store()
+
+        with (
+            patch(
+                "dev_health_ops.providers.team_bridge.get_postgres_session_sync",
+                return_value=fake_session,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge.ClickHouseStore",
+                fake_store_cls,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge._clickhouse_uri",
+                return_value="clickhouse://localhost:8123/default",
+            ),
+        ):
+            bridge_teams_to_clickhouse(org_id="org-1")
+
+        assert len(captured) == 1
+        members = captured[0]["members"]
+        assert "alice@example.com" in members, "email must be in members"
+        assert "alice-gh" in members, "github login must be in members"
+        assert "alice-lin" in members, "linear login must be in members"
+
+    def test_bridge_org_id_scopes_output(self) -> None:
+        """bridge_teams_to_clickhouse output rows must carry the correct org_id."""
+        from dev_health_ops.providers.team_bridge import bridge_teams_to_clickhouse
+
+        team_mapping = self._make_team_mapping(team_id="eng", org_id="org-99")
+        fake_session = self._make_fake_session([team_mapping], [])
+        fake_store_cls, captured = self._make_fake_ch_store()
+
+        with (
+            patch(
+                "dev_health_ops.providers.team_bridge.get_postgres_session_sync",
+                return_value=fake_session,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge.ClickHouseStore",
+                fake_store_cls,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge._clickhouse_uri",
+                return_value="clickhouse://localhost:8123/default",
+            ),
+        ):
+            bridge_teams_to_clickhouse(org_id="org-99")
+
+        assert captured[0]["org_id"] == "org-99"
+
+    def test_bridge_empty_team_mapping_returns_zero(self) -> None:
+        """bridge_teams_to_clickhouse returns 0 when no active TeamMappings exist."""
+        from dev_health_ops.providers.team_bridge import bridge_teams_to_clickhouse
+
+        fake_session = self._make_fake_session([], [])
+        fake_store_cls, captured = self._make_fake_ch_store()
+
+        with (
+            patch(
+                "dev_health_ops.providers.team_bridge.get_postgres_session_sync",
+                return_value=fake_session,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge.ClickHouseStore",
+                fake_store_cls,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge._clickhouse_uri",
+                return_value="clickhouse://localhost:8123/default",
+            ),
+        ):
+            count = bridge_teams_to_clickhouse(org_id="org-1")
+
+        assert count == 0
+        assert captured == [], "insert_teams must be called with empty list"
+
+    def test_bridge_member_without_email_uses_display_name(self) -> None:
+        """Identity with no email falls back to display_name in members."""
+        from dev_health_ops.providers.team_bridge import bridge_teams_to_clickhouse
+
+        team_mapping = self._make_team_mapping(team_id="eng", org_id="org-1")
+        identity = self._make_identity_mapping(
+            email=None,
+            display_name="Dave",
+            team_ids=["eng"],
+            org_id="org-1",
+        )
+        fake_session = self._make_fake_session([team_mapping], [identity])
+        fake_store_cls, captured = self._make_fake_ch_store()
+
+        with (
+            patch(
+                "dev_health_ops.providers.team_bridge.get_postgres_session_sync",
+                return_value=fake_session,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge.ClickHouseStore",
+                fake_store_cls,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge._clickhouse_uri",
+                return_value="clickhouse://localhost:8123/default",
+            ),
+        ):
+            bridge_teams_to_clickhouse(org_id="org-1")
+
+        assert "Dave" in captured[0]["members"]
+
+    def test_bridge_identity_with_email_does_not_use_display_name(self) -> None:
+        """Identity with email must NOT include display_name in members."""
+        from dev_health_ops.providers.team_bridge import bridge_teams_to_clickhouse
+
+        team_mapping = self._make_team_mapping(team_id="eng", org_id="org-1")
+        identity = self._make_identity_mapping(
+            email="carol@example.com",
+            display_name="Carol",
+            team_ids=["eng"],
+            org_id="org-1",
+        )
+        fake_session = self._make_fake_session([team_mapping], [identity])
+        fake_store_cls, captured = self._make_fake_ch_store()
+
+        with (
+            patch(
+                "dev_health_ops.providers.team_bridge.get_postgres_session_sync",
+                return_value=fake_session,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge.ClickHouseStore",
+                fake_store_cls,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge._clickhouse_uri",
+                return_value="clickhouse://localhost:8123/default",
+            ),
+        ):
+            bridge_teams_to_clickhouse(org_id="org-1")
+
+        members = captured[0]["members"]
+        assert "carol@example.com" in members
+        assert "Carol" not in members, "display_name must not appear when email is set"

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.fixtures.generator import SyntheticDataGenerator
 from dev_health_ops.models.teams import JiraProjectOpsTeamLink, Team
@@ -347,54 +348,29 @@ def test_cli_sync_teams_org_bridge_failure_exits_one(tmp_path):
         yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
     )
 
-    class FakeStore:
-        def __init__(self):
-            self.teams = []
-
-        async def ensure_tables(self):
-            return None
-
-        async def insert_teams(self, teams):
-            self.teams = teams
-
-        async def get_all_teams(self):
-            return self.teams
-
-    async def fake_run_with_store(_db_uri, _db_type, handler, org_id=None):
-        assert org_id == "org-1"
-        return await handler(FakeStore())
-
-    with (
-        patch("dev_health_ops.storage.run_with_store", new=fake_run_with_store),
-        patch("dev_health_ops.providers.teams.validate_sink"),
-        patch(
-            "dev_health_ops.providers.teams.resolve_sink_uri",
-            return_value="clickhouse://localhost:8123/default",
-        ),
-        patch(
-            "dev_health_ops.providers.teams.detect_db_type", return_value="clickhouse"
-        ),
-        patch(
-            "dev_health_ops.providers.teams._bridge_teams_to_postgres",
-            side_effect=RuntimeError("bridge down"),
-        ),
+    with patch(
+        "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+        side_effect=RuntimeError("bridge down"),
     ):
         ns = MagicMock()
         ns.provider = "config"
         ns.path = str(config_file)
         ns.org = "org-1"
+        ns.db = "sqlite:///semantic.db"
         ns.allow_empty = False
+        ns.sink = "clickhouse"
+        ns.analytics_db = "clickhouse://example.test:8123/default"
 
         result = _cmd_sync_teams(ns)
 
     assert result == 1
 
 
-def test_cli_sync_teams_org_stale_global_row_does_not_mask(tmp_path):
-    """An org-scoped run must not count a stale row from another org as
-    persisted: the org-scoped read-back filters by the store's org_id."""
-    from types import SimpleNamespace
+def test_cli_sync_teams_org_scoped_routes_through_postgres_then_clickhouse(tmp_path):
+    """Org-scoped sync must write Postgres first, then bridge to ClickHouse.
 
+    Direct ClickHouse write (run_with_store) must NOT be called for org-scoped runs.
+    """
     import yaml
 
     from dev_health_ops.providers.teams import sync_teams as _cmd_sync_teams
@@ -404,48 +380,553 @@ def test_cli_sync_teams_org_stale_global_row_does_not_mask(tmp_path):
         yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
     )
 
-    class FakeStore:
-        # Store is scoped to org-1.
-        org_id = "org-1"
-
-        async def ensure_tables(self):
-            return None
-
-        async def insert_teams(self, teams):
-            # Simulate the org-1 analytics write not landing.
-            return None
-
-        async def get_all_teams(self):
-            # A pre-existing row for the SAME id but a DIFFERENT org.
-            return [SimpleNamespace(id="team-a", org_id="other-org")]
-
-    async def fake_run_with_store(_db_uri, _db_type, handler, org_id=None):
-        assert org_id == "org-1"
-        return await handler(FakeStore())
-
     with (
-        patch("dev_health_ops.storage.run_with_store", new=fake_run_with_store),
-        patch("dev_health_ops.providers.teams.validate_sink"),
-        patch(
-            "dev_health_ops.providers.teams.resolve_sink_uri",
-            return_value="clickhouse://localhost:8123/default",
-        ),
-        patch(
-            "dev_health_ops.providers.teams.detect_db_type", return_value="clickhouse"
-        ),
         patch(
             "dev_health_ops.providers.teams._bridge_teams_to_postgres",
             return_value=1,
+        ) as mock_pg_bridge,
+        patch(
+            "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+        ) as mock_ch_bridge,
+        patch("dev_health_ops.storage.run_with_store") as mock_run_with_store,
+    ):
+        ns = MagicMock()
+        ns.provider = "config"
+        ns.path = str(config_file)
+        ns.org = "org-1"
+        ns.db = "sqlite:///semantic.db"
+        ns.allow_empty = False
+        ns.sink = "clickhouse"
+        ns.analytics_db = "clickhouse://example.test:8123/default"
+
+        result = _cmd_sync_teams(ns)
+
+    assert result == 0
+    mock_pg_bridge.assert_called_once()
+    mock_ch_bridge.assert_called_once_with(
+        org_id="org-1",
+        db_url=ns.analytics_db,
+        postgres_db_url="sqlite+aiosqlite:///semantic.db",
+    )
+    # Direct ClickHouse write must NOT be called for org-scoped runs.
+    mock_run_with_store.assert_not_called()
+
+
+def test_bridge_teams_to_postgres_creates_full_mapping_metadata():
+    from argparse import Namespace
+
+    from dev_health_ops.models.settings import TeamMapping
+    from dev_health_ops.models.teams import Team
+    from dev_health_ops.providers.teams import _bridge_teams_to_postgres
+
+    added: list[TeamMapping] = []
+
+    class FakeScalarResult:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def scalar_one_or_none(self):
+            return self._rows[0] if self._rows else None
+
+        def scalars(self):
+            return self
+
+        def __iter__(self):
+            return iter(self._rows)
+
+        def all(self):
+            return self._rows
+
+    class FakeSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def execute(self, _stmt):
+            if added:
+                return FakeScalarResult([team.team_id for team in added])
+            return FakeScalarResult([])
+
+        def add(self, item):
+            added.append(item)
+
+        def flush(self):
+            return None
+
+    team = Team(id="linear:ENG", name="Engineering", description="Eng team")
+    ns = Namespace(org="org-1", provider="linear")
+
+    with patch(
+        "dev_health_ops.providers.teams.get_postgres_session_sync_for_uri",
+        return_value=FakeSession(),
+    ):
+        count = _bridge_teams_to_postgres([team], ns)
+
+    assert count == 1
+    assert added[0].project_keys == ["ENG"]
+    added_extra = added[0].extra_data or {}
+    assert added_extra["provider_type"] == "linear"
+    assert added_extra["provider_team_id"] == "ENG"
+
+
+def test_bridge_teams_to_postgres_persists_provider_members_as_identities():
+    from argparse import Namespace
+
+    from dev_health_ops.models.settings import IdentityMapping, TeamMapping
+    from dev_health_ops.models.teams import Team
+    from dev_health_ops.providers.teams import _bridge_teams_to_postgres
+
+    added = []
+
+    class FakeScalarResult:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def scalar_one_or_none(self):
+            return self._rows[0] if self._rows else None
+
+        def scalars(self):
+            return self
+
+        def __iter__(self):
+            return iter(self._rows)
+
+        def all(self):
+            return self._rows
+
+    class FakeSession:
+        def __init__(self):
+            self.calls = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def execute(self, _stmt):
+            self.calls += 1
+            if self.calls in (1, 2):
+                return FakeScalarResult([])
+            return FakeScalarResult(["linear:ENG"])
+
+        def add(self, item):
+            added.append(item)
+
+        def flush(self):
+            return None
+
+    team = Team(
+        id="linear:ENG",
+        name="Engineering",
+        description="Eng team",
+        members=["alice@example.com"],
+    )
+    ns = Namespace(org="org-1", provider="linear")
+
+    with patch(
+        "dev_health_ops.providers.teams.get_postgres_session_sync_for_uri",
+        return_value=FakeSession(),
+    ):
+        count = _bridge_teams_to_postgres([team], ns)
+
+    assert count == 1
+    identity = next(item for item in added if isinstance(item, IdentityMapping))
+    assert any(isinstance(item, TeamMapping) for item in added)
+    assert identity.org_id == "org-1"
+    assert identity.canonical_id == "alice@example.com"
+    assert identity.email == "alice@example.com"
+    assert identity.provider_identities == {"linear": ["alice@example.com"]}
+    assert identity.team_ids == ["linear:ENG"]
+
+
+def test_bridge_teams_to_postgres_removes_absent_provider_members():
+    from argparse import Namespace
+
+    from dev_health_ops.models.settings import IdentityMapping, TeamMapping
+    from dev_health_ops.models.teams import Team
+    from dev_health_ops.providers.teams import _bridge_teams_to_postgres
+
+    existing_mapping = TeamMapping(
+        team_id="linear:ENG",
+        name="Engineering",
+        org_id="org-1",
+        extra_data={"provider_type": "linear"},
+    )
+    existing_identity = IdentityMapping(
+        org_id="org-1",
+        canonical_id="alice@example.com",
+        email="alice@example.com",
+        provider_identities={"linear": ["alice@example.com"]},
+        team_ids=["linear:ENG"],
+    )
+
+    class FakeScalarResult:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def scalar_one_or_none(self):
+            return self._rows[0] if self._rows else None
+
+        def scalars(self):
+            return self
+
+        def __iter__(self):
+            return iter(self._rows)
+
+        def all(self):
+            return self._rows
+
+    class FakeSession:
+        def __init__(self):
+            self.calls = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def execute(self, _stmt):
+            self.calls += 1
+            if self.calls == 1:
+                return FakeScalarResult([existing_mapping])
+            if self.calls == 2:
+                return FakeScalarResult([existing_identity])
+            return FakeScalarResult(["linear:ENG"])
+
+        def flush(self):
+            return None
+
+    team = Team(id="linear:ENG", name="Engineering", members=[])
+    setattr(team, "members_complete", True)
+    ns = Namespace(org="org-1", provider="linear")
+
+    with patch(
+        "dev_health_ops.providers.teams.get_postgres_session_sync_for_uri",
+        return_value=FakeSession(),
+    ):
+        count = _bridge_teams_to_postgres([team], ns)
+
+    assert count == 1
+    assert existing_identity.team_ids == []
+
+
+def test_bridge_teams_to_postgres_preserves_members_for_incomplete_snapshot():
+    from argparse import Namespace
+
+    from dev_health_ops.models.settings import IdentityMapping, TeamMapping
+    from dev_health_ops.models.teams import Team
+    from dev_health_ops.providers.teams import _bridge_teams_to_postgres
+
+    existing_mapping = TeamMapping(team_id="OPS", name="Ops", org_id="org-1")
+    existing_identity = IdentityMapping(
+        org_id="org-1",
+        canonical_id="alice@example.com",
+        email="alice@example.com",
+        provider_identities={"jira": ["alice-account"]},
+        team_ids=["OPS"],
+    )
+
+    class FakeScalarResult:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def scalar_one_or_none(self):
+            return self._rows[0] if self._rows else None
+
+        def scalars(self):
+            return self
+
+        def __iter__(self):
+            return iter(self._rows)
+
+        def all(self):
+            return self._rows
+
+    class FakeSession:
+        def __init__(self):
+            self.calls = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def execute(self, _stmt):
+            self.calls += 1
+            if self.calls == 1:
+                return FakeScalarResult([existing_mapping])
+            return FakeScalarResult(["OPS"])
+
+        def flush(self):
+            return None
+
+    team = Team(id="OPS", name="Ops", members=[])
+    ns = Namespace(org="org-1", provider="jira")
+
+    with patch(
+        "dev_health_ops.providers.teams.get_postgres_session_sync_for_uri",
+        return_value=FakeSession(),
+    ):
+        count = _bridge_teams_to_postgres([team], ns)
+
+    assert count == 1
+    assert existing_identity.team_ids == ["OPS"]
+
+
+def test_bridge_teams_to_postgres_preserves_curated_mapping_fields():
+    from argparse import Namespace
+
+    from dev_health_ops.models.settings import TeamMapping
+    from dev_health_ops.models.teams import Team
+    from dev_health_ops.providers.teams import _bridge_teams_to_postgres
+
+    existing = TeamMapping(
+        team_id="linear:ENG",
+        name="Curated Engineering",
+        org_id="org-1",
+        description="Curated description",
+        project_keys=["KEEP"],
+        repo_patterns=["full-chaos/*"],
+        extra_data={"owner": "admin"},
+        sync_policy=1,
+    )
+
+    class FakeScalarResult:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def scalar_one_or_none(self):
+            return self._rows[0] if self._rows else None
+
+        def scalars(self):
+            return self
+
+        def __iter__(self):
+            return iter(self._rows)
+
+        def all(self):
+            return self._rows
+
+    class FakeSession:
+        def __init__(self):
+            self.calls = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def execute(self, _stmt):
+            self.calls += 1
+            if self.calls == 1:
+                return FakeScalarResult([existing])
+            return FakeScalarResult([existing.team_id])
+
+        def flush(self):
+            return None
+
+    team = Team(
+        id="linear:ENG", name="Provider Engineering", description="Provider desc"
+    )
+    ns = Namespace(org="org-1", provider="linear")
+
+    with patch(
+        "dev_health_ops.providers.teams.get_postgres_session_sync_for_uri",
+        return_value=FakeSession(),
+    ):
+        count = _bridge_teams_to_postgres([team], ns)
+
+    assert count == 1
+    assert existing.name == "Curated Engineering"
+    assert existing.description == "Curated description"
+    assert existing.project_keys == ["KEEP"]
+    assert existing.repo_patterns == ["full-chaos/*"]
+    existing_extra = existing.extra_data or {}
+    assert existing_extra["owner"] == "admin"
+    assert existing_extra["provider_type"] == "linear"
+
+
+def test_cli_sync_teams_org_scoped_ch_bridge_failure_exits_one(tmp_path):
+    import yaml
+
+    from dev_health_ops.providers.teams import sync_teams as _cmd_sync_teams
+
+    config_file = tmp_path / "teams.yaml"
+    config_file.write_text(
+        yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+    )
+
+    with (
+        patch(
+            "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+            return_value=1,
+        ),
+        patch(
+            "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+            side_effect=RuntimeError("ch unavailable"),
         ),
     ):
         ns = MagicMock()
         ns.provider = "config"
         ns.path = str(config_file)
         ns.org = "org-1"
+        ns.db = "sqlite:///semantic.db"
         ns.allow_empty = False
+        ns.sink = "clickhouse"
+        ns.analytics_db = "clickhouse://example.test:8123/default"
 
         result = _cmd_sync_teams(ns)
 
-    # Stale cross-org row is filtered out -> primary persisted count is 0 -> exit 1,
-    # even though the Postgres bridge succeeded.
     assert result == 1
+
+
+def test_cli_sync_teams_org_scoped_jira_ops_links_written_after_bridge():
+    from atlassian.canonical_models import (
+        CanonicalProjectWithOpsgenieTeams,
+        JiraProject,
+        OpsgenieTeamRef,
+    )
+
+    from dev_health_ops.models.teams import JiraProjectOpsTeamLink
+    from dev_health_ops.providers.teams import sync_teams as _cmd_sync_teams
+
+    project = CanonicalProjectWithOpsgenieTeams(
+        project=JiraProject(cloud_id="cloud-1", key="OPS", name="Ops Project"),
+        opsgenie_teams=[OpsgenieTeamRef(id="team-1", name="Ops Team")],
+    )
+    captured: list[JiraProjectOpsTeamLink] = []
+
+    class FakeClickHouseStore:
+        org_id = None
+
+        def __init__(self, db_uri):
+            self.db_uri = db_uri
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def insert_jira_project_ops_team_links(self, links):
+            captured.extend(links)
+
+    with (
+        patch(
+            "dev_health_ops.providers.jira.atlassian_compat.get_atlassian_cloud_id",
+            return_value="cloud-1",
+        ),
+        patch(
+            "dev_health_ops.providers.jira.atlassian_compat.build_atlassian_graphql_client"
+        ),
+        patch(
+            "atlassian.graph.api.jira_projects.iter_projects_with_opsgenie_linkable_teams",
+            return_value=iter([project]),
+        ),
+        patch(
+            "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+            return_value=1,
+        ),
+        patch(
+            "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+            return_value=1,
+        ),
+        patch(
+            "dev_health_ops.storage.clickhouse.ClickHouseStore",
+            FakeClickHouseStore,
+        ),
+    ):
+        ns = MagicMock()
+        ns.provider = "jira-ops"
+        ns.path = None
+        ns.org = "org-1"
+        ns.db = "sqlite:///semantic.db"
+        ns.allow_empty = False
+        ns.sink = "clickhouse"
+        ns.analytics_db = "clickhouse://example.test:8123/default"
+
+        result = _cmd_sync_teams(ns)
+
+    assert result == 0
+    assert len(captured) == 1
+    assert captured[0].project_key == "OPS"
+    assert captured[0].ops_team_id == "team-1"
+
+
+def test_bridge_teams_to_postgres_uses_requested_semantic_db_url():
+    from argparse import Namespace
+
+    from dev_health_ops.models.teams import Team
+    from dev_health_ops.providers.teams import _bridge_teams_to_postgres
+
+    class FakeSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def execute(self, _stmt):
+            raise AssertionError("session should not be used in this routing test")
+
+    with patch(
+        "dev_health_ops.providers.teams.get_postgres_session_sync_for_uri",
+        return_value=FakeSession(),
+    ) as mock_session_for_uri:
+        _bridge_teams_to_postgres(
+            [Team(id="team-a", name="Team A")],
+            Namespace(
+                org="org-1",
+                provider="config",
+                db="sqlite:///semantic.db",
+                analytics_db="clickhouse://analytics.example/default",
+            ),
+        )
+
+    mock_session_for_uri.assert_called_once_with("sqlite+aiosqlite:///semantic.db")
+
+
+@pytest.mark.asyncio
+async def test_import_ms_teams_uses_prefixed_team_id():
+    from dev_health_ops.api.admin.schemas import DiscoveredTeam
+    from dev_health_ops.api.services.configuration.team_discovery import (
+        TeamDiscoveryService,
+    )
+
+    captured: dict = {}
+
+    class FakeTeamMappingService:
+        def __init__(self, _session, _org_id):
+            pass
+
+        async def get(self, _team_id):
+            return None
+
+        async def create_or_update(self, **kwargs):
+            captured.update(kwargs)
+
+    with patch(
+        "dev_health_ops.api.services.configuration.team_discovery.TeamMappingService",
+        FakeTeamMappingService,
+    ):
+        result = await TeamDiscoveryService(
+            MagicMock(spec=AsyncSession), "org-1"
+        ).import_teams(
+            [
+                DiscoveredTeam(
+                    provider_type="ms-teams",
+                    provider_team_id="graph-team-id",
+                    name="Platform Team",
+                )
+            ]
+        )
+
+    assert result["imported"] == 1
+    assert captured["team_id"] == "ms-teams:graph-team-id"
+    assert captured["extra_data"]["provider_team_id"] == "graph-team-id"


### PR DESCRIPTION
## Summary
- add managed_by ownership for org tiers/licenses so Stripe paths skip manual paid grants while community downgrades stay Stripe-manageable
- route org-scoped team sync through PostgreSQL TeamMapping/IdentityMapping before ClickHouse analytics bridging
- preserve provider membership authority, handle partial Linear reads, scope Jira ops links and worker reconciliation by org

## Verification
- python -m pytest tests/test_teams.py tests/test_sync_teams_routing_invariants.py tests/api/billing/test_managed_by_guard.py tests/test_billing.py tests/test_linear_team_sync.py tests/test_sync_team_parallel.py tests/test_migration_042_rmt_org_id_dedup.py tests/providers/jira/test_ops_mapping.py -q
- python -m ruff format --check src/dev_health_ops/api/services/users.py src/dev_health_ops/providers/teams.py src/dev_health_ops/workers/sync_team.py src/dev_health_ops/alembic/versions/0011_add_managed_by_to_org_license.py tests/test_teams.py tests/test_sync_teams_routing_invariants.py tests/api/billing/test_managed_by_guard.py tests/test_linear_team_sync.py tests/test_sync_team_parallel.py src/dev_health_ops/workers/product_tasks.py src/dev_health_ops/providers/team_bridge.py
- python -m ruff check src/dev_health_ops/api/services/users.py src/dev_health_ops/providers/teams.py src/dev_health_ops/workers/sync_team.py src/dev_health_ops/alembic/versions/0011_add_managed_by_to_org_license.py tests/test_teams.py tests/test_sync_teams_routing_invariants.py tests/api/billing/test_managed_by_guard.py tests/test_linear_team_sync.py tests/test_sync_team_parallel.py src/dev_health_ops/workers/product_tasks.py src/dev_health_ops/providers/team_bridge.py
- PYTHONPATH=src python -m dev_health_ops.cli sync teams --help
- PYTHONPATH=src python -m dev_health_ops.cli sync teams --provider not-a-provider

SCREENSHOT-WAIVER: backend/API/CLI and persistence behavior only; no rendered dev-health-web UI changes.