### PR TITLE
fix(gitlab): degrade gracefully on feature-flag 403 instead of aborting sync

### DIFF
--- a/docs/connectors/gitlab-permissions.md
+++ b/docs/connectors/gitlab-permissions.md
@@ -1,0 +1,85 @@
+# GitLab Token Permissions & Scopes
+
+This guide explains the GitLab access-token scopes, project roles, and project
+features required for each sync target, and what happens when a permission is
+missing.
+
+> **TL;DR** — A GitLab token that lacks a scope/role (or a project that has a
+> feature disabled) returns **HTTP 403 Forbidden**. As of the GitLab-403
+> graceful-degrade change, an enrichment endpoint returning 403 **no longer
+> aborts the whole sync** — the core git/MR data still syncs and the skipped
+> target is recorded in the sync result. Fix the permission to restore the
+> missing data.
+
+## Token types
+
+Any of the following work, in order of decreasing blast radius:
+
+| Token type | Best for | Notes |
+| --- | --- | --- |
+| **Personal Access Token (PAT)** | A user syncing their own projects | Inherits the user's role on each project. |
+| **Group Access Token** | Syncing many projects under one group | Assign the token a role at the group level. |
+| **Project Access Token** | A single project | Most-scoped; create one per project. |
+
+Set the token via `GITLAB_TOKEN` (env) or `--auth` / the sync-config
+credential. For self-hosted GitLab, also set `--gitlab-url` /
+`credentials.url`.
+
+## Required scopes & roles per sync target
+
+GitLab authorization is **two-dimensional**: the token needs the right **API
+scope** *and* the token's identity needs a high-enough **project role**. Both
+must be satisfied or the API returns 403.
+
+| Sync target | Endpoint(s) | API scope | Min. project role | Project feature that must be enabled | On 403 |
+| --- | --- | --- | --- | --- | --- |
+| `git` (commits, blame) | `/repository/...` | `read_api`, `read_repository` | Reporter | Repository | **Sync fails** — core data |
+| `prs` (merge requests, reviews) | `/merge_requests` | `read_api` | Reporter | Merge requests | **Sync fails** — core data |
+| `cicd` (pipelines) | `/pipelines` | `read_api` | Reporter | CI/CD | Pipeline data skipped |
+| `deployments` | `/deployments`, `/releases` | `read_api` | Reporter | Environments / Releases | **Degrades** — recorded empty, sync continues |
+| `feature-flags` | `/feature_flags` | `api` | **Developer** | Feature Flags | **Degrades** — recorded `skipped: forbidden`, sync continues |
+
+Notes:
+
+- **Feature flags are the strictest.** GitLab's Feature Flags API requires the
+  **Developer** role (not Reporter) and the broader **`api`** scope (not just
+  `read_api`). The Feature Flags project feature must also be enabled
+  (*Settings → General → Visibility, project features → Feature flags*). A
+  read-only `read_api` token, or a Reporter, will get 403 here even if the
+  rest of the sync works.
+- **Deployments** need the project's **Environments** (and optionally
+  **Releases**) features enabled. A project that never deploys through GitLab
+  environments will legitimately return no deployments.
+- `read_api` is sufficient for everything except feature flags; prefer it over
+  the full `api` scope unless feature-flag sync is required.
+
+## How to set permissions
+
+1. **Create/scope the token**
+   - *User/Group/Project* → **Settings → Access Tokens**.
+   - Select scope: `read_api` + `read_repository` for most targets; add `api`
+     if you sync feature flags.
+   - Set the token's **role** to **Developer** if feature-flag sync is needed,
+     otherwise **Reporter** is enough.
+2. **Enable the project features** you sync (Feature Flags, Environments) under
+   *Settings → General → Visibility, project features*.
+3. Re-run the sync. The previously-skipped targets should populate.
+
+## Behavior when a permission is missing
+
+A non-transient GitLab **403** (feature disabled or insufficient role/scope) is
+**not retried** — GitLab signals rate limits with **429**, never 403, so
+retrying a 403 only wastes calls. Instead:
+
+- **`feature-flags`**: the connector raises a non-retryable
+  `AuthenticationException`; the sync runtime records
+  `{"status": "skipped", "reason": "forbidden", "detail": ...}` under
+  `feature_flags` in the sync result and continues.
+- **`deployments`**: already failure-soft — the deployment fetch logs the error
+  and returns an empty list, so the rest of the sync proceeds.
+- **`git` / `prs`**: these are core targets; a 403 there still fails the sync
+  (with the underlying GitLab message) because there is no useful sync without
+  them.
+
+Check the sync result / worker logs for `skipped`/`forbidden` markers to see
+which enrichment data was withheld and why.

--- a/src/dev_health_ops/connectors/gitlab.py
+++ b/src/dev_health_ops/connectors/gitlab.py
@@ -359,10 +359,32 @@ class GitLabConnector(GitConnector):
         flags: list[dict[str, Any]] = []
 
         while True:
-            batch = self.rest_client.get_list(
-                endpoint,
-                params={"page": page, "per_page": effective_per_page},
-            )
+            try:
+                batch = self.rest_client.get_list(
+                    endpoint,
+                    params={"page": page, "per_page": effective_per_page},
+                )
+            except APIException as exc:
+                # GitLab returns 403 when the Feature Flags feature is disabled
+                # for the project or the token lacks Developer+ access. Neither
+                # is transient (GitLab rate-limits are 429, never 403), so we
+                # re-raise as a non-retryable AuthenticationException — the
+                # retry decorator only retries RateLimitException/APIException,
+                # so this short-circuits the otherwise-wasteful 3x spin and
+                # gives callers a precise type to degrade on. Mirrors the
+                # GitHub connector's permission-403 handling (CHAOS-2383).
+                if str(exc).startswith("Forbidden:"):
+                    logger.warning(
+                        "GitLab feature flags forbidden (403) for project %s: "
+                        "feature disabled or token lacks Developer access",
+                        project_id_or_path,
+                    )
+                    raise AuthenticationException(
+                        "GitLab feature flags forbidden (403): the Feature "
+                        "Flags feature is disabled for this project or the "
+                        "token lacks the required scope/Developer role."
+                    ) from exc
+                raise
             if not batch:
                 break
             flags.extend(batch)

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -12,6 +12,10 @@ from dev_health_ops.credentials.resolver import (
     gitlab_credentials_from_mapping,
     resolve_gitlab_url,
 )
+from dev_health_ops.exceptions import (
+    AuthenticationException,
+    ConnectorException,
+)
 from dev_health_ops.utils.datetime import utc_today
 from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
@@ -635,12 +639,41 @@ def run_sync_config(
                 if target not in {"feature-flags", "work-items"}
             ]
             if feature_flag_requested:
-                result_payload["feature_flags"] = _sync_gitlab_feature_flags(
-                    db_url=db_url,
-                    org_id=org_id,
-                    credentials=credentials,
-                    sync_options=sync_options,
-                )
+                # Feature flags are optional enrichment. A 403 (feature
+                # disabled or token lacks Developer access) or any other
+                # connector/config failure here must NOT abort the core
+                # git/MR sync — record an observable skip status and continue
+                # (CHAOS: GitLab 403 graceful degrade).
+                try:
+                    result_payload["feature_flags"] = _sync_gitlab_feature_flags(
+                        db_url=db_url,
+                        org_id=org_id,
+                        credentials=credentials,
+                        sync_options=sync_options,
+                    )
+                except AuthenticationException as exc:
+                    logger.warning(
+                        "Skipping GitLab feature-flag sync for org %s: %s",
+                        org_id,
+                        exc,
+                    )
+                    result_payload["feature_flags"] = {
+                        "status": "skipped",
+                        "reason": "forbidden",
+                        "detail": str(exc),
+                    }
+                except (ConnectorException, ValueError) as exc:
+                    logger.warning(
+                        "GitLab feature-flag sync failed for org %s: %s",
+                        org_id,
+                        exc,
+                        exc_info=True,
+                    )
+                    result_payload["feature_flags"] = {
+                        "status": "failed",
+                        "reason": type(exc).__name__,
+                        "detail": str(exc),
+                    }
 
             if not gitlab_targets:
                 pass  # feature-flags-only sync handled above

--- a/tests/test_gitlab_connector.py
+++ b/tests/test_gitlab_connector.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from dev_health_ops.connectors import GitLabConnector
+from dev_health_ops.exceptions import APIException, AuthenticationException
 
 
 class TestGitLabConnectorProjects:
@@ -430,3 +431,57 @@ class TestGitLabConnectorAdapterMethods:
         # Verify project_name was formatted correctly
         mock_gitlab_instance.projects.get.assert_called_once_with("mygroup/myproject")
         assert result.file_path == "path/to/file.py"
+
+
+class TestGitLabFeatureFlags403:
+    """get_feature_flags must treat a 403 as a non-retryable permission error."""
+
+    @pytest.fixture
+    def mock_gitlab_client(self):
+        with patch("dev_health_ops.connectors.gitlab.gitlab.Gitlab") as mock_gitlab:
+            yield mock_gitlab
+
+    @pytest.fixture
+    def mock_rest_client(self):
+        with patch("dev_health_ops.connectors.gitlab.GitLabRESTClient") as mock_rest:
+            yield mock_rest
+
+    def test_forbidden_raises_non_retryable_authentication_exception(
+        self, mock_gitlab_client, mock_rest_client
+    ):
+        """A 403 (feature disabled / token lacks access) is re-raised as a
+        non-retryable AuthenticationException so the sync can degrade and the
+        retry decorator does not spin on an unfixable permission error."""
+        mock_rest_instance = mock_rest_client.return_value
+        mock_rest_instance.get_list.side_effect = APIException(
+            'Forbidden: {"message":"403 Forbidden"}'
+        )
+
+        connector = GitLabConnector(
+            url="https://gitlab.com", private_token="test_token"
+        )
+
+        with pytest.raises(AuthenticationException, match="forbidden"):
+            connector.get_feature_flags("mygroup/myproject")
+
+        # Non-retryable: get_list is invoked once per inner attempt only, never
+        # multiplied by the outer get_feature_flags retry decorator.
+        assert mock_rest_instance.get_list.call_count == 1
+
+    def test_non_forbidden_api_error_is_not_swallowed(
+        self, mock_gitlab_client, mock_rest_client
+    ):
+        """A non-403 APIException (e.g. 500) must still propagate as-is so the
+        retry/normal error path is unaffected."""
+        mock_rest_instance = mock_rest_client.return_value
+        mock_rest_instance.get_list.side_effect = APIException("API error: 500 - boom")
+
+        connector = GitLabConnector(
+            url="https://gitlab.com", private_token="test_token"
+        )
+
+        # Patch sleep so the (correct) retry behaviour for real APIExceptions
+        # doesn't slow the test down.
+        with patch("dev_health_ops.connectors.utils.retry.time.sleep"):
+            with pytest.raises(APIException, match="API error"):
+                connector.get_feature_flags("mygroup/myproject")


### PR DESCRIPTION
## Problem

A GitLab **403** on the feature-flags endpoint (Feature Flags feature disabled, or token lacking Developer/`api` access) propagated past the sync call site and **aborted the entire `run_sync_config` run** — taking commits/MRs down with it. Reported from a live worker:

```
dev_health_ops.exceptions.APIException: Forbidden: {"message":"403 Forbidden"}
  ... sync_runtime.py:228 _sync_gitlab_feature_flags -> get_feature_flags
```

GitLab signals rate limits with **429**, never 403, so a 403 is never transient — yet `rest.py` classifies every 403 as a *retryable* `APIException`, so each one spun 5×(inner)×3×(outer) before failing.

## Fix (GitLab-scoped — shared `rest.py` left untouched since Jira uses it)

- **`connectors/gitlab.py`** — `get_feature_flags` converts a `Forbidden:` 403 into a **non-retryable** `AuthenticationException` (fail-fast + precise type), mirroring the GitHub permission-403 handling (CHAOS-2383).
- **`workers/sync_runtime.py`** — feature-flag call site now **skips + records + continues**:
  - `AuthenticationException` → `result_payload["feature_flags"] = {"status":"skipped","reason":"forbidden", ...}`
  - other `ConnectorException`/`ValueError` → `{"status":"failed","reason":<type>, ...}` (logged with traceback)
  - core git/MR sync proceeds regardless.
- **`tests/test_gitlab_connector.py`** — 403 is non-retryable (asserts single `get_list` call); non-403 `APIException` still propagates.
- **`docs/connectors/gitlab-permissions.md`** — token scope/role/feature reference + 403 degradation behavior.

> Deployments were already failure-soft (`_fetch_gitlab_deployments_sync` returns empty on error) — those log lines were retry noise, not a crash.

## Behavior change

| Endpoint | Before | After |
|---|---|---|
| `feature-flags` 403 | crashes whole sync | skipped + recorded, sync continues |
| `git`/`prs` 403 | fails | fails (core data — unchanged) |

## Gates
- ruff check + format ✓
- mypy (src + tests) ✓
- 23 related tests ✓ (`test_gitlab_connector`, `test_gitlab_feature_flags`, `test_processors_gitlab`, `test_admin_sync_targets`)

## Operational note
Workers run the baked image, so this takes effect after a `--build`. Immediate live mitigation: give the token `api` scope + **Developer** role and enable the project's Feature Flags feature (see the new doc).