### PR TITLE
fix(investment): stop latest-row CTE alias shadowing argMax ordering column (ILLEGAL_AGGREGATION)

### DIFF
--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -35,7 +35,14 @@ LATEST_WORK_UNIT_INVESTMENTS_CTE = """
                 argMax(categorization_status, computed_at) AS categorization_status,
                 argMax(categorization_run_id, computed_at) AS categorization_run_id,
                 org_id,
-                max(computed_at) AS computed_at
+                -- Alias must NOT be ``computed_at``: that name is the ordering
+                -- column of every ``argMax(col, computed_at)`` above, and on
+                -- ClickHouse 26.5.x an identically-named aggregate alias
+                -- shadows the raw column, turning argMax into
+                -- ``argMax(col, max(computed_at))`` → ILLEGAL_AGGREGATION (184)
+                -- which silently empties the Investment treemap and allocation
+                -- sankey. Keep the distinct name.
+                max(computed_at) AS latest_computed_at
             FROM work_unit_investments
             WHERE org_id = %(org_id)s
             GROUP BY org_id, work_unit_id

--- a/tests/api/test_investment_latest_row_queries.py
+++ b/tests/api/test_investment_latest_row_queries.py
@@ -21,6 +21,25 @@ def _window() -> tuple[datetime, datetime]:
     )
 
 
+def test_latest_row_cte_does_not_shadow_argmax_ordering_column() -> None:
+    """Regression: the aggregate in the latest-row CTE must NOT be aliased to
+    ``computed_at``.
+
+    ``computed_at`` is the ordering column of every ``argMax(col, computed_at)``
+    in the CTE. Aliasing ``max(computed_at) AS computed_at`` makes ClickHouse
+    26.5.x resolve that name to the aggregate alias, turning each argMax into
+    ``argMax(col, max(computed_at))`` — an aggregate inside an aggregate — which
+    fails at analysis time with ``Code: 184 ILLEGAL_AGGREGATION``. Because the
+    GraphQL ``analytics`` breakdown/sankey resolvers reuse this exact CTE, that
+    error silently emptied the Investment treemap and the allocation flows /
+    team-&-repo coverage. The aggregate must keep a distinct alias.
+    """
+    cte = investment_queries.LATEST_WORK_UNIT_INVESTMENTS_CTE
+    assert "argMax(effort_value, computed_at)" in cte  # ordering column is used
+    assert "max(computed_at) AS computed_at" not in cte  # the shadowing alias
+    assert "max(computed_at) AS latest_computed_at" in cte
+
+
 @pytest.mark.asyncio
 async def test_investment_breakdown_aggregates_only_latest_work_unit_row(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Symptom
For org "Int" (`a78c1a6a…`), the **Investment → Overview treemap** renders blank and the **Investment → Allocation** flows / Team-&-Repo coverage show **0%** — even though data exists (the **Evidence** tab, a different REST query, is fully populated).

## Root cause
The `latest_work_unit_investments` CTE — shared by the REST investment queries **and** the GraphQL `analytics` breakdown/sankey resolvers (`compiler.py` imports `LATEST_WORK_UNIT_INVESTMENTS_CTE`) — aliased its dedup aggregate as:

```sql
max(computed_at) AS computed_at
```

`computed_at` is also the **ordering column** of every `argMax(col, computed_at)` in the same SELECT. On **ClickHouse 26.5.x** the identically-named aggregate alias shadows the raw column, so each argMax parses as `argMax(col, max(computed_at))` — an aggregate inside an aggregate — failing at analysis:

```
Code: 184. DB::Exception: Aggregate function max(computed_at) AS computed_at
is found inside another aggregate function in query. (ILLEGAL_AGGREGATION)
```

API logs confirmed both `InvestmentBreakdown` and the investment `Sankey query failed` with code 184. The REST `getWorkUnits` path (Evidence tab) uses a different query and was unaffected — which is why only the GraphQL-backed surfaces went blank.

## Fix
Rename the aggregate alias to **`latest_computed_at`** (the convention already used in `recommendations.py` / `compounding_risk.py`). Nothing references the CTE's `computed_at` output column.

## Verification
- Compiled the GraphQL breakdown SQL via `compile_breakdown(... use_investment=True)` and ran it against the live ClickHouse 26.5.1: **no more code 184**, returns all 5 themes (quality, feature_delivery, maintenance, operational, risk).
- Added a regression test asserting the CTE never re-introduces `max(computed_at) AS computed_at`.
- Restarted the local api (source is bind-mounted) to deploy.

## Gates
ruff check + format ✓ · mypy ✓ · `tests/api/test_investment_latest_row_queries.py` 15 passed ✓

## Note
The companion **Team exchange chord** "No flows" symptom on the same Allocation tab is a *separate* issue (a `flowMatrix` query on `work_item_cycle_times`, not this CTE) being investigated independently.