### PR TITLE
feat(metrics): inherit team attribution from linked issues across providers

### DIFF
--- a/docs/architecture/data-pipeline.md
+++ b/docs/architecture/data-pipeline.md
@@ -139,16 +139,25 @@ canonical target wins (a stable tiebreak, since ClickHouse rows are
 unordered).
 
 The resolver (`build_linked_issue_team_resolver`) is built **once per run**
-and applied identically to both `compute_work_item_metrics_daily`
-(cycle-times) and `compute_work_item_state_durations_daily`, so a PR reads
-with the same team in every work-item table. It must see a **donor-complete**
-set: `job_daily` loads donor work items org-wide (`repo_id=None`) and
-window-independent — a PR can link to an issue that completed long before the
-metrics day, or to a repo-less Linear/Jira issue that a per-repo window would
-exclude. Org-scoped edges come from
-`ClickHouseDataLoader.load_work_item_dependencies`. Because the edges are
-written during a **work-items sync**, a sync (not just a metrics recompute)
-is required for newly-captured links to take effect.
+and applied to *every* work-item metric family — cycle-times
+(`compute_work_item_metrics_daily`), state-durations
+(`compute_work_item_state_durations_daily`), and the issue-type / investment
+rollups (via `_get_team`) — so a PR reads with the same team in every table
+and cross-table joins stay consistent.
+
+It must see a **donor-complete** set, not just the active window:
+
+- `job_daily` loads donor work items org-wide (`repo_id=None`) and
+  window-independent — a PR can link to an issue that completed long before
+  the metrics day, or to a repo-less Linear/Jira issue that a per-repo window
+  would exclude. Dependency edges come from
+  `ClickHouseDataLoader.load_work_item_dependencies` (`FINAL`, latest version).
+- `job_work_items` (the sync) **unions** the freshly-synced items/edges with
+  the persisted ClickHouse superset (`FINAL`), so an incremental run that
+  re-fetches only the PR still finds a donor synced earlier.
+
+Because the edges are written during a **work-items sync**, a sync (not just a
+metrics recompute) is required for newly-captured links to take effect.
 
 > Note: branch-name capture trusts the head branch (the Linear convention),
 > so a contributor could in principle name a branch to force a team

--- a/docs/architecture/data-pipeline.md
+++ b/docs/architecture/data-pipeline.md
@@ -133,7 +133,9 @@ Cross-provider links are captured during sync as provider-neutral
 `extkey:KEY` dependency edges (GitHub: PR body magic-words + head branch;
 GitLab: issue/MR description magic-words; Jira: native `issuelinks`). The
 key is resolved to the real `linear:`/`jira:` work item at inheritance time,
-so over-capturing is harmless — a key with no matching issue never resolves.
+so over-capturing is harmless — a key with no matching issue never resolves,
+and a key that exists in **both** Linear and Jira is treated as ambiguous and
+dropped rather than guessed.
 Only **inheritance-safe relationship types** (`relates_to`, `relates`,
 `duplicates`, `external_issue_key`) transfer a team; blocking links
 (`blocks`/`blocked_by`), which routinely span teams, are ignored. When

--- a/docs/architecture/data-pipeline.md
+++ b/docs/architecture/data-pipeline.md
@@ -111,6 +111,9 @@ async def write_batch(records: List[Model], session: AsyncSession) -> int:
 
 ### Work-item team attribution
 
+> See [Team Attribution](team-attribution.md) for the full architecture with
+> sequence, flowchart, ER, and component diagrams.
+
 Every work item is stamped with a `team_id` at compute time
 (`metrics/compute_work_items.py`). Resolution is a fallback cascade
 (`resolve_base_team` + one inheritance tier), first match wins:

--- a/docs/architecture/data-pipeline.md
+++ b/docs/architecture/data-pipeline.md
@@ -134,9 +134,11 @@ Cross-provider links are captured during sync as provider-neutral
 GitLab: issue/MR description magic-words; Jira: native `issuelinks`). The
 key is resolved to the real `linear:`/`jira:` work item at inheritance time,
 so over-capturing is harmless — a key with no matching issue never resolves.
-When several donors match one source, the lexicographically smallest
-canonical target wins (a stable tiebreak, since ClickHouse rows are
-unordered).
+Only **inheritance-safe relationship types** (`relates_to`, `relates`,
+`duplicates`, `external_issue_key`) transfer a team; blocking links
+(`blocks`/`blocked_by`), which routinely span teams, are ignored. When
+several donors match one source, the lexicographically smallest canonical
+target wins (a stable tiebreak, since ClickHouse rows are unordered).
 
 The resolver (`build_linked_issue_team_resolver`) is built **once per run**
 and applied to *every* work-item metric family — cycle-times
@@ -156,14 +158,21 @@ It must see a **donor-complete** set, not just the active window:
   the persisted ClickHouse superset (`FINAL`), so an incremental run that
   re-fetches only the PR still finds a donor synced earlier.
 
+All donor reads are **tenant-scoped**: the org-wide donor/edge queries run
+only under an explicit `org_id`, so a PR can never inherit a team from another
+organization's issue. An unscoped (dev/CLI) run skips inheritance rather than
+reading across tenants.
+
 Because the edges are written during a **work-items sync**, a sync (not just a
 metrics recompute) is required for newly-captured links to take effect.
 
 > Note: branch-name capture trusts the head branch (the Linear convention),
 > so a contributor could in principle name a branch to force a team
 > inheritance. This is an analytics-attribution signal, not an authorization
-> boundary — the worst case is a self-inflicted mis-attribution of one PR's
-> team — so it is accepted rather than gated.
+> boundary, and it is bounded to the contributor's own org (tenant-scoped
+> donors) and to inheritance-safe relationship types — the worst case is a
+> self-inflicted mis-attribution of one PR's team within the org — so it is
+> accepted rather than gated.
 
 ---
 

--- a/docs/architecture/data-pipeline.md
+++ b/docs/architecture/data-pipeline.md
@@ -155,15 +155,18 @@ by a dependency edge), not the tenant's whole history, and is best-effort (a
 failed donor read degrades to no inheritance rather than aborting the run):
 
 - `job_daily` reads dependency edges
-  (`ClickHouseDataLoader.load_work_item_dependencies`, `FINAL`), collects the
+  (`ClickHouseDataLoader.load_work_item_dependencies`, `FINAL`) **bounded to
+  the source ids evaluated this run** (the run-window work items), collects the
   referenced target ids / external keys, and loads only those donor items via
   `load_work_item_dependencies_donors`. This still spans repos and time (a PR
   can close an issue completed long before the metrics day, or a repo-less
-  Linear/Jira issue) without hydrating the full history.
-- `job_work_items` (the sync) **unions** the freshly-synced items/edges with
-  the persisted ClickHouse edges (`FINAL`) and loads only the referenced donor
-  items, so an incremental run that re-fetches only the PR still finds a donor
-  synced earlier.
+  Linear/Jira issue) without scanning the full graph.
+- `job_work_items` (the sync) treats the **freshly-extracted edges as
+  authoritative** for the items it synced — they are the current
+  source-of-truth, so a link removed from a PR is simply absent and stops
+  granting inheritance — and loads only the referenced donor *items* from
+  ClickHouse (bounded), so an incremental run that re-fetches only the PR still
+  finds a donor synced earlier.
 
 All donor reads are **tenant-scoped**: the org-wide donor/edge queries run
 only under an explicit `org_id`, so a PR can never inherit a team from another
@@ -181,9 +184,14 @@ metrics recompute) is required for newly-captured links to take effect.
 > self-inflicted mis-attribution of one PR's team within the org — so it is
 > accepted rather than gated.
 
----
-
-## 5. Visualization (dev-health-web)
+> Known limitation: `work_item_dependencies` is append-only and has no
+> tombstone, so a *removed* link is not deleted from the table. The **sync**
+> path is unaffected — it re-extracts the PR's current edges, so a removed link
+> stops inheriting immediately. But a standalone **`job_daily` recompute** reads
+> persisted edges and can keep honoring a removed link until the next sync
+> re-stamps the source. A general link-lifecycle/tombstone for
+> `work_item_dependencies` (which also affects the work-graph) is tracked as a
+> follow-up.
 
 **Purpose:** Render persisted data for exploration.
 

--- a/docs/architecture/data-pipeline.md
+++ b/docs/architecture/data-pipeline.md
@@ -147,16 +147,21 @@ and applied to *every* work-item metric family — cycle-times
 rollups (via `_get_team`) — so a PR reads with the same team in every table
 and cross-table joins stay consistent.
 
-It must see a **donor-complete** set, not just the active window:
+It must see a **donor-complete** set, not just the active window — but the
+read is **bounded to the linked surface** (the work items actually referenced
+by a dependency edge), not the tenant's whole history, and is best-effort (a
+failed donor read degrades to no inheritance rather than aborting the run):
 
-- `job_daily` loads donor work items org-wide (`repo_id=None`) and
-  window-independent — a PR can link to an issue that completed long before
-  the metrics day, or to a repo-less Linear/Jira issue that a per-repo window
-  would exclude. Dependency edges come from
-  `ClickHouseDataLoader.load_work_item_dependencies` (`FINAL`, latest version).
+- `job_daily` reads dependency edges
+  (`ClickHouseDataLoader.load_work_item_dependencies`, `FINAL`), collects the
+  referenced target ids / external keys, and loads only those donor items via
+  `load_work_item_dependencies_donors`. This still spans repos and time (a PR
+  can close an issue completed long before the metrics day, or a repo-less
+  Linear/Jira issue) without hydrating the full history.
 - `job_work_items` (the sync) **unions** the freshly-synced items/edges with
-  the persisted ClickHouse superset (`FINAL`), so an incremental run that
-  re-fetches only the PR still finds a donor synced earlier.
+  the persisted ClickHouse edges (`FINAL`) and loads only the referenced donor
+  items, so an incremental run that re-fetches only the PR still finds a donor
+  synced earlier.
 
 All donor reads are **tenant-scoped**: the org-wide donor/edge queries run
 only under an explicit `org_id`, so a PR can never inherit a team from another

--- a/docs/architecture/data-pipeline.md
+++ b/docs/architecture/data-pipeline.md
@@ -109,6 +109,53 @@ async def write_batch(records: List[Model], session: AsyncSession) -> int:
 - Use `argMax(<metric>, computed_at)` to get latest value
 - Re-computation is safe (idempotent via compound keys)
 
+### Work-item team attribution
+
+Every work item is stamped with a `team_id` at compute time
+(`metrics/compute_work_items.py`). Resolution is a fallback cascade
+(`resolve_base_team` + one inheritance tier), first match wins:
+
+1. **Scope key** — `ProjectKeyTeamResolver.resolve(work_scope_id)`: the Jira
+   project key, GitHub/GitLab repo path, or Linear project name.
+2. **Project key** — retry with `WorkItem.project_key` (Linear's TEAM key,
+   which differs from the project name when an issue sits in a project).
+3. **Assignee membership** — `TeamResolver` maps the primary assignee's
+   canonical identity to a team via `IdentityMapping.team_ids`.
+4. **Linked-issue inheritance** — `LinkedIssueTeamResolver`: an item that
+   still resolved to no team borrows the team of an issue it links to via
+   `work_item_dependencies`. This is **provider-agnostic** — a GitHub/GitLab
+   PR inherits the team of the Linear/Jira issue it closes — and is what lets
+   PRs (which match none of tiers 1–3) share a team dimension with the issue
+   trackers in the investment allocation-coverage and team-exchange views.
+5. **`unassigned`** — the normalized sentinel when every tier misses.
+
+Cross-provider links are captured during sync as provider-neutral
+`extkey:KEY` dependency edges (GitHub: PR body magic-words + head branch;
+GitLab: issue/MR description magic-words; Jira: native `issuelinks`). The
+key is resolved to the real `linear:`/`jira:` work item at inheritance time,
+so over-capturing is harmless — a key with no matching issue never resolves.
+When several donors match one source, the lexicographically smallest
+canonical target wins (a stable tiebreak, since ClickHouse rows are
+unordered).
+
+The resolver (`build_linked_issue_team_resolver`) is built **once per run**
+and applied identically to both `compute_work_item_metrics_daily`
+(cycle-times) and `compute_work_item_state_durations_daily`, so a PR reads
+with the same team in every work-item table. It must see a **donor-complete**
+set: `job_daily` loads donor work items org-wide (`repo_id=None`) and
+window-independent — a PR can link to an issue that completed long before the
+metrics day, or to a repo-less Linear/Jira issue that a per-repo window would
+exclude. Org-scoped edges come from
+`ClickHouseDataLoader.load_work_item_dependencies`. Because the edges are
+written during a **work-items sync**, a sync (not just a metrics recompute)
+is required for newly-captured links to take effect.
+
+> Note: branch-name capture trusts the head branch (the Linear convention),
+> so a contributor could in principle name a branch to force a team
+> inheritance. This is an analytics-attribution signal, not an authorization
+> boundary — the worst case is a self-inflicted mis-attribution of one PR's
+> team — so it is accepted rather than gated.
+
 ---
 
 ## 5. Visualization (dev-health-web)

--- a/docs/architecture/team-attribution.md
+++ b/docs/architecture/team-attribution.md
@@ -1,0 +1,228 @@
+# Architecture: Work-Item Team Attribution & Linked-Issue Inheritance
+
+**Status:** Authoritative
+**Scope:** dev-health-ops (metrics/compute, sync, loaders, providers)
+**Related:** [data-pipeline.md](data-pipeline.md) (§4 Metrics → Work-item team attribution),
+[investment-data-model.md](investment-data-model.md),
+[team-catalog-source-of-truth.md](../api/team-catalog-source-of-truth.md)
+
+> First slice of the system-wide architecture-documentation epic. Documents how
+> every work item (issue, PR, MR) is stamped with a `team_id`, why PRs used to
+> land as `unassigned`, and how cross-provider linked-issue inheritance recovers
+> team attribution for the investment **allocation-coverage** and
+> **team-exchange chord** views.
+
+## Why this exists
+
+Team resolution historically used three signals — the provider work scope
+(repo / project key), the Linear/Jira project key, and assignee membership.
+**A GitHub/GitLab PR matches none of them**: its repo rarely maps 1:1 to a
+team, it has no project key, and its author often isn't a team member. So PRs
+were stamped `team_id = 'unassigned'` and never shared a team dimension with
+the issue trackers — leaving TEAM COVERAGE at 0% and the team-exchange chord
+empty (no two teams ever co-occur on a work scope).
+
+The fix adds a fourth, **provider-agnostic** tier: a work item with no team of
+its own inherits the team of an issue it links to via `work_item_dependencies`.
+A GitHub PR closing Linear `CHAOS-2400` borrows that issue's `CHAOS` team.
+
+---
+
+## 1. Attribution cascade (decision flow)
+
+`resolve_base_team()` runs tiers 1–3; the linked-issue resolver is tier 4. The
+first match wins and nothing ever overrides a real team.
+
+```mermaid
+flowchart TD
+    A["Work item"] --> B{"Tier 1: ProjectKeyTeamResolver<br/>resolve(work_scope_id)"}
+    B -- match --> T["team_id"]
+    B -- miss --> C{"Tier 2: retry with project_key<br/>(Linear TEAM key)"}
+    C -- match --> T
+    C -- miss --> D{"Tier 3: TeamResolver<br/>assignee in IdentityMapping?"}
+    D -- match --> T
+    D -- miss --> E{"Tier 4: LinkedIssueTeamResolver<br/>linked donor issue has a team?"}
+    E -- match --> T
+    E -- miss --> U["normalize to 'unassigned'"]
+
+    T --> N["normalize_team_id / normalize_team_name"]
+    U --> N
+    N --> R[("stamp team_id on the row")]
+```
+
+**Inheritance is gated**, so it never imports a wrong team:
+- only **inheritance-safe** relationship types transfer a team
+  (`relates_to`, `relates`, `duplicates`, `external_issue_key`); blocking links
+  (`blocks` / `blocked_by`) routinely span teams and are ignored;
+- a cross-provider `extkey:KEY` that exists in **both** Linear and Jira is
+  ambiguous and dropped;
+- multiple donors → the lexicographically smallest canonical target wins
+  (stable, since ClickHouse rows are unordered);
+- per `(source,target)` the **latest** edge by `last_synced` wins, so a flip
+  from `relates_to` to `blocked_by` stops inheriting.
+
+---
+
+## 2. Cross-provider link capture & inheritance (sequence)
+
+Edges are captured during sync; the resolver is built once per run and applied
+to every work-item metric family.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Prov as Provider API (GitHub/GitLab/Jira)
+    participant Norm as Normalizer (providers normalize)
+    participant Job as job_work_items (sync)
+    participant CH as ClickHouse
+    participant Build as build_linked_issue_team_resolver
+    participant Comp as compute_work_item_metrics_daily
+
+    Prov->>Norm: issues / PRs / MRs
+    Norm->>Norm: extract WorkItems + WorkItemDependency edges
+    Note over Norm: PR body magic-words + head branch to extkey:KEY;<br/>keyword sets relationship_type (blocking stays non-inheritable)
+    Norm-->>Job: work_items, dependencies
+    Job->>Job: stamp org_id on items, transitions AND dependencies
+    Job->>CH: write_work_items / write_work_item_dependencies
+    Job->>CH: load donor items for fresh-edge targets (bounded, FINAL, org-scoped)
+    Job->>Build: work_items (synced plus donors), fresh edges
+    Build->>Build: resolve_base_team per item to donor_team map + key_index
+    Build->>Build: collapse edges by source,target latest; apply relationship allowlist
+    Build-->>Job: LinkedIssueTeamResolver
+    loop each day in window
+        Job->>Comp: work_items, transitions, linked_issue_resolver
+        Comp->>CH: write work_item_cycle_times (team_id stamped)
+    end
+```
+
+`job_daily` (the scheduled recompute) follows the same build → compute path but
+**reads** persisted edges instead of extracting them — see §4.
+
+---
+
+## 3. Data flow & relationships (ER)
+
+```mermaid
+erDiagram
+    work_items ||--o{ work_item_dependencies : "source of edges"
+    work_items ||--o{ work_item_cycle_times : "completed to cycle row"
+    work_item_dependencies }o--|| work_items : "target or extkey to donor issue"
+    teams ||--o{ work_item_cycle_times : "team_id"
+    work_item_cycle_times ||--o{ investment_coverage : "team/repo coverage %"
+    work_item_cycle_times ||--o{ team_exchange_chord : "cross-team flows"
+
+    work_items {
+        string work_item_id PK
+        string provider
+        string project_key
+        string project_id
+        uuid   repo_id
+        string org_id
+    }
+    work_item_dependencies {
+        string source_work_item_id
+        string target_work_item_id "id or extkey:KEY"
+        string relationship_type
+        datetime last_synced
+        string org_id
+    }
+    work_item_cycle_times {
+        string work_item_id
+        string team_id "inherited when a PR borrows a donor"
+        string work_scope_id
+        date   day
+        string org_id
+    }
+    teams {
+        string id PK
+        string org_id
+        string project_keys
+    }
+```
+
+The chord and coverage both read `work_item_cycle_times.team_id`. Before
+inheritance, PR rows carried `unassigned`, so they never bridged to the issue
+trackers' teams; after, a PR's row carries the donor issue's team and the two
+providers finally co-occur on a team dimension.
+
+---
+
+## 4. Component & job map (who reads/writes what)
+
+Two jobs build the resolver. Both are **tenant-scoped** (org-wide reads only
+under an explicit `org_id`) and **bounded** (never a full-history scan).
+
+```mermaid
+flowchart LR
+    subgraph providers ["Providers"]
+        GH["github/normalize"]
+        GL["gitlab/normalize"]
+        JI["jira normalize"]
+    end
+
+    subgraph sync ["job_work_items — sync"]
+        S1["extract items + extkey edges"]
+        S2["stamp org_id + write"]
+        S3["load bounded donors<br/>(fresh edges authoritative)"]
+        S4["build resolver"]
+        S5["compute cycle_times + state_durations<br/>+ issue-type/investment via _get_team"]
+    end
+
+    subgraph daily ["job_daily — scheduled recompute"]
+        D1["load run-window work items"]
+        D2["load_work_item_dependencies(source_ids)<br/>bounded + FINAL"]
+        D3["load_work_item_dependencies_donors<br/>by referenced id/key"]
+        D4["build resolver"]
+        D5["compute cycle_times + state_durations"]
+    end
+
+    GH --> S1
+    GL --> S1
+    JI --> S1
+    S1 --> S2 --> S3 --> S4 --> S5
+
+    D1 --> D2 --> D3 --> D4 --> D5
+
+    CH[("ClickHouse:<br/>work_items,<br/>work_item_dependencies,<br/>work_item_cycle_times")]
+    PG[("Postgres:<br/>TeamMapping,<br/>IdentityMapping")]
+
+    S2 -->|write| CH
+    S3 -->|read| CH
+    S5 -->|write| CH
+    D1 -->|read| CH
+    D2 -->|read| CH
+    D3 -->|read| CH
+    D5 -->|write| CH
+    PG -. team resolvers .-> S4
+    PG -. team resolvers .-> D4
+```
+
+**Key boundary differences**
+
+| Aspect | `job_work_items` (sync) | `job_daily` (recompute) |
+|---|---|---|
+| Edge source | freshly extracted (authoritative) | persisted, `FINAL`, bounded by run-window source ids |
+| Removed link | absent on re-extract → stops inheriting | persists until next sync re-stamps (see limitation) |
+| Donor items | bounded to fresh-edge targets | bounded to referenced targets |
+| Tenant scope | reads only when `org_id` set | reads only when `org_id` set |
+
+> **Known limitation.** `work_item_dependencies` is an append-only
+> `ReplacingMergeTree` with no tombstone, so a *removed* link is not deleted. A
+> standalone `job_daily` recompute between syncs can keep honoring it until the
+> next sync re-extracts the source. A link-lifecycle/tombstone (which also
+> affects the work-graph) is a tracked follow-up.
+
+---
+
+## Source map
+
+| Concern | Location |
+|---|---|
+| Attribution cascade + resolver builder | `metrics/compute_work_items.py` (`resolve_base_team`, `build_linked_issue_team_resolver`) |
+| Resolver type | `providers/teams.py` (`LinkedIssueTeamResolver`, `ProjectKeyTeamResolver`, `TeamResolver`) |
+| State-duration parity | `metrics/compute_work_item_state_durations.py` |
+| Sync wiring | `metrics/job_work_items.py` |
+| Scheduled recompute wiring | `metrics/job_daily.py` |
+| Bounded donor/edge loads | `metrics/loaders/clickhouse.py` (`load_work_item_dependencies`, `load_work_item_dependencies_donors`) |
+| extkey capture | `providers/github/normalize.py`, `providers/gitlab/normalize.py` |
+| Tests | `tests/test_linked_issue_team_inheritance.py` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Architecture:
       - Overview: architecture.md
       - Data Pipeline: architecture/data-pipeline.md
+      - Team Attribution: architecture/team-attribution.md
       - Investment Categorization Pipeline: architecture/investment-categorization-pipeline.md
       - Investment Data Model: architecture/investment-data-model.md
       - Repo Layout: architecture/repo-layout.md

--- a/src/dev_health_ops/metrics/compute_work_item_state_durations.py
+++ b/src/dev_health_ops/metrics/compute_work_item_state_durations.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from datetime import date, datetime, time, timedelta, timezone
 
+from dev_health_ops.metrics.compute_work_items import resolve_base_team
 from dev_health_ops.metrics.schemas import WorkItemStateDurationDailyRecord
 from dev_health_ops.models.work_items import (
     WorkItem,
@@ -11,6 +12,7 @@ from dev_health_ops.models.work_items import (
     WorkItemStatusTransition,
 )
 from dev_health_ops.providers.teams import (
+    LinkedIssueTeamResolver,
     ProjectKeyTeamResolver,
     TeamResolver,
     normalize_team_id,
@@ -26,17 +28,21 @@ def _utc_day_window(day: date) -> tuple[datetime, datetime]:
 
 
 def _resolve_team(
+    item: WorkItem,
     team_resolver: TeamResolver | None,
     project_key_resolver: ProjectKeyTeamResolver | None,
-    work_scope_id: str | None,
-    identity: str | None,
+    linked_issue_resolver: LinkedIssueTeamResolver | None,
 ) -> tuple[str, str]:
-    team_id: str | None = None
-    team_name: str | None = None
-    if project_key_resolver is not None:
-        team_id, team_name = project_key_resolver.resolve(work_scope_id)
-    if not team_id and team_resolver is not None:
-        team_id, team_name = team_resolver.resolve(identity)
+    """Resolve an item's team using the same cascade as the cycle-time compute.
+
+    Shares ``resolve_base_team`` (scope key → project_key → assignee) and the
+    linked-issue inheritance fallback so a PR is attributed to the SAME team in
+    state-duration rows as in ``work_item_cycle_times`` — otherwise the same
+    item could read as a donor team in one table and ``unassigned`` in another.
+    """
+    team_id, team_name = resolve_base_team(item, team_resolver, project_key_resolver)
+    if team_id is None and linked_issue_resolver is not None:
+        team_id, team_name = linked_issue_resolver.resolve(item.work_item_id)
     return normalize_team_id(team_id), normalize_team_name(team_name)
 
 
@@ -100,6 +106,7 @@ def compute_work_item_state_durations_daily(
     computed_at: datetime,
     team_resolver: TeamResolver | None = None,
     project_key_resolver: ProjectKeyTeamResolver | None = None,
+    linked_issue_resolver: LinkedIssueTeamResolver | None = None,
 ) -> list[WorkItemStateDurationDailyRecord]:
     """
     Compute per-day time-in-state totals from status transitions.
@@ -130,12 +137,11 @@ def compute_work_item_state_durations_daily(
         if not item_transitions:
             continue
 
-        assignee = item.assignees[0] if item.assignees else None
         team_id, team_name = _resolve_team(
+            item,
             team_resolver,
             project_key_resolver,
-            item.work_scope_id,
-            assignee,
+            linked_issue_resolver,
         )
         work_scope_id = item.work_scope_id or ""
         team_name_by_key[(item.provider, work_scope_id, team_id)] = team_name

--- a/src/dev_health_ops/metrics/compute_work_items.py
+++ b/src/dev_health_ops/metrics/compute_work_items.py
@@ -142,13 +142,40 @@ def build_linked_issue_team_resolver(
             return key_index.get(target_id.split(":", 1)[1].strip().upper())
         return target_id
 
+    def _recency(dep: WorkItemDependency) -> float:
+        last = dep.last_synced
+        try:
+            return last.timestamp() if last is not None else 0.0
+        except (ValueError, OverflowError, OSError):
+            return 0.0
+
+    # Collapse to one edge per (source, target), keeping the latest by
+    # last_synced — so a relationship-type change (e.g. relates_to -> blocked_by)
+    # supersedes the stale row instead of leaving an old inheritable edge alive
+    # alongside the new one. On identical timestamps the lexicographically
+    # smaller relationship_type wins, which deterministically prefers the safer
+    # blocking type (`blocked_by`/`blocks` < `relates_to`) over inheriting.
+    latest_edge: dict[tuple[str, str], WorkItemDependency] = {}
+    for dep in dependencies:
+        pair = (dep.source_work_item_id, dep.target_work_item_id)
+        cur = latest_edge.get(pair)
+        if (
+            cur is None
+            or _recency(dep) > _recency(cur)
+            or (
+                _recency(dep) == _recency(cur)
+                and dep.relationship_type < cur.relationship_type
+            )
+        ):
+            latest_edge[pair] = dep
+
     # Collect every valid donor candidate per source, then pick deterministically
     # so attribution never depends on edge/storage order (ClickHouse rows have no
     # inherent ordering). When a source links several team-attributed issues, the
     # lexicographically smallest canonical target wins — a stable, run-independent
     # tiebreak. The common case is a single donor, where the choice is moot.
     candidates: dict[str, list[tuple[str, tuple[str, str]]]] = {}
-    for dep in dependencies:
+    for dep in latest_edge.values():
         # Only "does-the-work-of"/duplicate links transfer a team; skip blocking
         # and other relationships that routinely span teams.
         if dep.relationship_type not in _INHERITABLE_RELATIONSHIP_TYPES:

--- a/src/dev_health_ops/metrics/compute_work_items.py
+++ b/src/dev_health_ops/metrics/compute_work_items.py
@@ -88,6 +88,17 @@ def resolve_base_team(
     return team_id, team_name
 
 
+# Relationship types that mean "this item does (or duplicates) the work of the
+# linked issue" — the only edges from which it is sound to inherit a team. A
+# blocking relationship (`blocks`/`blocked_by`/`is_blocked_by`) connects items
+# that are frequently owned by *different* teams, so it must NOT drive
+# attribution. `external_issue_key` is the provider-neutral cross-provider edge
+# emitted by the PR parsers (a PR closing a Linear/Jira issue).
+_INHERITABLE_RELATIONSHIP_TYPES = frozenset(
+    {"relates_to", "relates", "duplicates", "external_issue_key"}
+)
+
+
 def build_linked_issue_team_resolver(
     *,
     work_items: Sequence[WorkItem],
@@ -138,6 +149,10 @@ def build_linked_issue_team_resolver(
     # tiebreak. The common case is a single donor, where the choice is moot.
     candidates: dict[str, list[tuple[str, tuple[str, str]]]] = {}
     for dep in dependencies:
+        # Only "does-the-work-of"/duplicate links transfer a team; skip blocking
+        # and other relationships that routinely span teams.
+        if dep.relationship_type not in _INHERITABLE_RELATIONSHIP_TYPES:
+            continue
         source_id = dep.source_work_item_id
         # Only items that resolve to no team of their own need a donor; never
         # override a real attribution. (missing => treat as unresolved.)

--- a/src/dev_health_ops/metrics/compute_work_items.py
+++ b/src/dev_health_ops/metrics/compute_work_items.py
@@ -123,8 +123,12 @@ def build_linked_issue_team_resolver(
     donor_team: dict[str, tuple[str, str]] = {}
     base_resolved: dict[str, str | None] = {}
     # Issue KEY (e.g. CHAOS-2400, PROJ-12) -> work_item_id, for resolving the
-    # provider-neutral ``extkey:`` targets emitted by PR parsers.
+    # provider-neutral ``extkey:`` targets emitted by PR parsers. ``extkey``
+    # carries no provider, so if the SAME key exists in both Linear and Jira it
+    # is genuinely ambiguous — those keys are tracked separately and never
+    # resolve, so an ambiguous link is dropped rather than guessed.
     key_index: dict[str, str] = {}
+    ambiguous_keys: set[str] = set()
 
     for item in work_items:
         wid = item.work_item_id
@@ -135,10 +139,19 @@ def build_linked_issue_team_resolver(
         if team_id:
             donor_team[wid] = (team_id, team_name or team_id)
         if item.provider in ("linear", "jira") and ":" in wid:
-            key_index[wid.split(":", 1)[1].strip().upper()] = wid
+            k = wid.split(":", 1)[1].strip().upper()
+            if k in ambiguous_keys:
+                continue
+            existing = key_index.get(k)
+            if existing is not None and existing != wid:
+                del key_index[k]
+                ambiguous_keys.add(k)  # same key in two providers — ambiguous
+            else:
+                key_index[k] = wid
 
     def _canonical_target(target_id: str) -> str | None:
         if target_id.startswith("extkey:"):
+            # Missing or ambiguous keys both return None → no inheritance.
             return key_index.get(target_id.split(":", 1)[1].strip().upper())
         return target_id
 

--- a/src/dev_health_ops/metrics/compute_work_items.py
+++ b/src/dev_health_ops/metrics/compute_work_items.py
@@ -131,22 +131,29 @@ def build_linked_issue_team_resolver(
             return key_index.get(target_id.split(":", 1)[1].strip().upper())
         return target_id
 
-    inherited: dict[str, tuple[str, str]] = {}
+    # Collect every valid donor candidate per source, then pick deterministically
+    # so attribution never depends on edge/storage order (ClickHouse rows have no
+    # inherent ordering). When a source links several team-attributed issues, the
+    # lexicographically smallest canonical target wins — a stable, run-independent
+    # tiebreak. The common case is a single donor, where the choice is moot.
+    candidates: dict[str, list[tuple[str, tuple[str, str]]]] = {}
     for dep in dependencies:
         source_id = dep.source_work_item_id
         # Only items that resolve to no team of their own need a donor; never
         # override a real attribution. (missing => treat as unresolved.)
         if base_resolved.get(source_id) is not None:
             continue
-        if source_id in inherited:
-            continue  # first donor edge wins, preserving edge order
         target_id = _canonical_target(dep.target_work_item_id)
         if not target_id:
             continue
         donor = donor_team.get(target_id)
         if donor is not None:
-            inherited[source_id] = donor
+            candidates.setdefault(source_id, []).append((target_id, donor))
 
+    inherited: dict[str, tuple[str, str]] = {
+        source_id: min(cands, key=lambda c: c[0])[1]
+        for source_id, cands in candidates.items()
+    }
     return LinkedIssueTeamResolver(_inherited=inherited)
 
 

--- a/src/dev_health_ops/metrics/compute_work_items.py
+++ b/src/dev_health_ops/metrics/compute_work_items.py
@@ -10,8 +10,13 @@ from dev_health_ops.metrics.schemas import (
     WorkItemMetricsDailyRecord,
     WorkItemUserMetricsDailyRecord,
 )
-from dev_health_ops.models.work_items import WorkItem, WorkItemStatusTransition
+from dev_health_ops.models.work_items import (
+    WorkItem,
+    WorkItemDependency,
+    WorkItemStatusTransition,
+)
 from dev_health_ops.providers.teams import (
+    LinkedIssueTeamResolver,
     ProjectKeyTeamResolver,
     TeamResolver,
     normalize_team_id,
@@ -49,6 +54,100 @@ def _resolve_team(
     if team_resolver is None:
         return None, None
     return team_resolver.resolve(identity)
+
+
+def resolve_base_team(
+    item: WorkItem,
+    team_resolver: TeamResolver | None,
+    project_key_resolver: ProjectKeyTeamResolver | None,
+) -> tuple[str | None, str | None]:
+    """Resolve a work item's team via scope key, then project_key, then assignee.
+
+    Returns ``(None, None)`` when no mapping matches (i.e. the item would
+    normalize to ``unassigned``). This is the first three attribution tiers;
+    linked-issue inheritance is layered on top by callers. Shared by the
+    per-day metrics loop and :func:`build_linked_issue_team_resolver` so both
+    apply identical rules — an item only becomes an inheritance donor if it
+    resolves to a real team here.
+    """
+    work_scope_id = item.work_scope_id or ""
+    team_id: str | None = None
+    team_name: str | None = None
+    if project_key_resolver is not None:
+        team_id, team_name = project_key_resolver.resolve(work_scope_id)
+        # Linear: work_scope_id is the project name when the issue sits in a
+        # project, but team mappings carry the TEAM key (the item's
+        # project_key) — retry with it before the membership fallback.
+        if team_id is None and item.project_key:
+            project_key = str(item.project_key)
+            if project_key != work_scope_id:
+                team_id, team_name = project_key_resolver.resolve(project_key)
+    if team_id is None:
+        assignee = item.assignees[0] if item.assignees else None
+        team_id, team_name = _resolve_team(team_resolver, assignee)
+    return team_id, team_name
+
+
+def build_linked_issue_team_resolver(
+    *,
+    work_items: Sequence[WorkItem],
+    dependencies: Sequence[WorkItemDependency],
+    team_resolver: TeamResolver | None = None,
+    project_key_resolver: ProjectKeyTeamResolver | None = None,
+) -> LinkedIssueTeamResolver:
+    """Build the cross-item team-inheritance fallback from dependency edges.
+
+    Any work item that resolves to a real team via :func:`resolve_base_team`
+    becomes an attribution *donor*. A linked work item that resolves to no
+    team inherits the first donor team reachable through a
+    ``work_item_dependencies`` edge where it is the ``source`` (PRs are the
+    source of their ``fixes``/``closes``/``relates_to`` edges).
+
+    ``extkey:KEY`` targets — emitted by the PR parsers for cross-provider
+    references such as a Linear/Jira issue key mentioned in a PR body or
+    branch name — are matched against Linear/Jira work-item keys so a GitHub
+    PR can inherit from the Linear issue it closes even though the two live in
+    different providers.
+    """
+    donor_team: dict[str, tuple[str, str]] = {}
+    base_resolved: dict[str, str | None] = {}
+    # Issue KEY (e.g. CHAOS-2400, PROJ-12) -> work_item_id, for resolving the
+    # provider-neutral ``extkey:`` targets emitted by PR parsers.
+    key_index: dict[str, str] = {}
+
+    for item in work_items:
+        wid = item.work_item_id
+        team_id, team_name = resolve_base_team(
+            item, team_resolver, project_key_resolver
+        )
+        base_resolved[wid] = team_id
+        if team_id:
+            donor_team[wid] = (team_id, team_name or team_id)
+        if item.provider in ("linear", "jira") and ":" in wid:
+            key_index[wid.split(":", 1)[1].strip().upper()] = wid
+
+    def _canonical_target(target_id: str) -> str | None:
+        if target_id.startswith("extkey:"):
+            return key_index.get(target_id.split(":", 1)[1].strip().upper())
+        return target_id
+
+    inherited: dict[str, tuple[str, str]] = {}
+    for dep in dependencies:
+        source_id = dep.source_work_item_id
+        # Only items that resolve to no team of their own need a donor; never
+        # override a real attribution. (missing => treat as unresolved.)
+        if base_resolved.get(source_id) is not None:
+            continue
+        if source_id in inherited:
+            continue  # first donor edge wins, preserving edge order
+        target_id = _canonical_target(dep.target_work_item_id)
+        if not target_id:
+            continue
+        donor = donor_team.get(target_id)
+        if donor is not None:
+            inherited[source_id] = donor
+
+    return LinkedIssueTeamResolver(_inherited=inherited)
 
 
 WAIT_STATUSES = {
@@ -169,6 +268,7 @@ def compute_work_item_metrics_daily(
     computed_at: datetime,
     team_resolver: TeamResolver | None = None,
     project_key_resolver: ProjectKeyTeamResolver | None = None,
+    linked_issue_resolver: LinkedIssueTeamResolver | None = None,
 ) -> tuple[
     list[WorkItemMetricsDailyRecord],
     list[WorkItemUserMetricsDailyRecord],
@@ -210,18 +310,14 @@ def compute_work_item_metrics_daily(
             continue
 
         assignee = item.assignees[0] if item.assignees else None
-        team_id, team_name = None, None
-        if project_key_resolver is not None:
-            team_id, team_name = project_key_resolver.resolve(work_scope_id)
-            # Linear: work_scope_id is the project name when the issue sits
-            # in a project, but team mappings carry the TEAM key (the item's
-            # project_key) — retry with it before the membership fallback.
-            if team_id is None and item.project_key:
-                project_key = str(item.project_key)
-                if project_key != work_scope_id:
-                    team_id, team_name = project_key_resolver.resolve(project_key)
-        if team_id is None:
-            team_id, team_name = _resolve_team(team_resolver, assignee)
+        team_id, team_name = resolve_base_team(
+            item, team_resolver, project_key_resolver
+        )
+        # Final fallback: inherit team from a linked issue (e.g. a PR that
+        # closes a Linear/Jira issue). Provider-agnostic; only fills items
+        # that resolved to no team of their own.
+        if team_id is None and linked_issue_resolver is not None:
+            team_id, team_name = linked_issue_resolver.resolve(item.work_item_id)
         team_id_norm = normalize_team_id(team_id)
         team_name_norm = normalize_team_name(team_name)
 

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -761,26 +761,39 @@ async def run_daily_metrics_job(
     # PR inherit another org's team. Production workers always pass org_id;
     # an unscoped (dev/CLI) run simply skips inheritance.
     if load_work_items_enabled and load_work_items_from_db and days and org_id:
+        # Build the linked-issue inheritance resolver ONCE for the run. The
+        # donor set is bounded to the work items actually referenced by a
+        # dependency edge (not the tenant's whole history) and the read is
+        # best-effort: a failure degrades to no inheritance rather than
+        # aborting the daily job. A PR can reference a donor that completed
+        # before any metrics day, or a repo-less Linear/Jira issue, so the
+        # bounded lookup is org-wide and window-independent.
         _load_deps = getattr(loader, "load_work_item_dependencies", None)
-        if _load_deps is not None:
-            work_item_dependencies = await _load_deps()
-        # Build the resolver ONCE from a donor-complete superset. A PR can link
-        # to an issue that completed before any metrics day, or to a Linear/Jira
-        # issue that has no repo_id — so load org-wide and window-independent
-        # (from the epoch) for donor resolution, NOT the per-day repo-scoped
-        # slice used for the metrics themselves. Reused across every day so a PR
-        # is attributed identically regardless of which day it lands on.
-        donor_start = datetime(1970, 1, 1, tzinfo=timezone.utc)
-        donor_end = _utc_day_window(max(days))[1]
-        donor_items, _ = await loader.load_work_items(
-            donor_start, donor_end, None, None
-        )
-        linked_issue_resolver = build_linked_issue_team_resolver(
-            work_items=donor_items,
-            dependencies=work_item_dependencies,
-            team_resolver=team_resolver,
-            project_key_resolver=project_key_resolver,
-        )
+        _load_donors = getattr(loader, "load_work_item_dependencies_donors", None)
+        if _load_deps is not None and _load_donors is not None:
+            try:
+                work_item_dependencies = await _load_deps()
+                _target_ids: set[str] = set()
+                _issue_keys: set[str] = set()
+                for _dep in work_item_dependencies:
+                    _t = _dep.target_work_item_id
+                    if _t.startswith("extkey:"):
+                        _issue_keys.add(_t.split(":", 1)[1])
+                    elif _t:
+                        _target_ids.add(_t)
+                donor_items = await _load_donors(_target_ids, _issue_keys)
+                linked_issue_resolver = build_linked_issue_team_resolver(
+                    work_items=donor_items,
+                    dependencies=work_item_dependencies,
+                    team_resolver=team_resolver,
+                    project_key_resolver=project_key_resolver,
+                )
+            except Exception:
+                logger.warning(
+                    "Linked-issue donor load failed; skipping inheritance for this run",
+                    exc_info=True,
+                )
+                linked_issue_resolver = None
 
     for d in days:
         logger.info("Computing metrics for day=%s", d.isoformat())

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -40,7 +40,10 @@ from dev_health_ops.metrics.compute_wellbeing import (
 from dev_health_ops.metrics.compute_work_item_state_durations import (
     compute_work_item_state_durations_daily,
 )
-from dev_health_ops.metrics.compute_work_items import compute_work_item_metrics_daily
+from dev_health_ops.metrics.compute_work_items import (
+    build_linked_issue_team_resolver,
+    compute_work_item_metrics_daily,
+)
 from dev_health_ops.metrics.dependencies import get_metrics_dependencies
 from dev_health_ops.metrics.hotspots import (
     compute_file_hotspots,
@@ -745,6 +748,17 @@ async def run_daily_metrics_job(
     # Rolling buffer for pipeline stability (7-day window)
     pipeline_metrics_buffer: list[Any] = []
 
+    # Work-item dependency edges are org-scoped and time-independent (a PR's
+    # link to the issue it closes does not expire), so load them once for the
+    # whole run rather than per day. They power linked-issue team inheritance.
+    # Defensive getattr: loaders without the method (or deployments missing the
+    # table) simply skip inheritance instead of failing the daily job.
+    work_item_dependencies: list[Any] = []
+    if load_work_items_enabled and load_work_items_from_db:
+        _load_deps = getattr(loader, "load_work_item_dependencies", None)
+        if _load_deps is not None:
+            work_item_dependencies = await _load_deps()
+
     for d in days:
         logger.info("Computing metrics for day=%s", d.isoformat())
         start, end = _utc_day_window(d)
@@ -918,6 +932,12 @@ async def run_daily_metrics_job(
         wi_cycle_times: list[Any] = []
         wi_state_durations: list[Any] = []
         if work_items:
+            linked_issue_resolver = build_linked_issue_team_resolver(
+                work_items=work_items,
+                dependencies=work_item_dependencies,
+                team_resolver=team_resolver,
+                project_key_resolver=project_key_resolver,
+            )
             wi_metrics, wi_user_metrics, wi_cycle_times = (
                 compute_work_item_metrics_daily(
                     day=d,
@@ -925,6 +945,8 @@ async def run_daily_metrics_job(
                     transitions=work_item_transitions,
                     computed_at=computed_at,
                     team_resolver=team_resolver,
+                    project_key_resolver=project_key_resolver,
+                    linked_issue_resolver=linked_issue_resolver,
                 )
             )
             # CHAOS-2377: the state-duration rollup powers /metrics Flow Sankey +

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -755,17 +755,21 @@ async def run_daily_metrics_job(
     # table) simply skip inheritance instead of failing the daily job.
     work_item_dependencies: list[Any] = []
     linked_issue_resolver = None
-    if load_work_items_enabled and load_work_items_from_db and days:
+    # Linked-issue inheritance reads org-wide (repo_id=None), so it is only
+    # safe under an explicit tenant scope: without org_id the loader's filter
+    # is empty and the donor/edge queries would span every tenant, letting a
+    # PR inherit another org's team. Production workers always pass org_id;
+    # an unscoped (dev/CLI) run simply skips inheritance.
+    if load_work_items_enabled and load_work_items_from_db and days and org_id:
         _load_deps = getattr(loader, "load_work_item_dependencies", None)
         if _load_deps is not None:
             work_item_dependencies = await _load_deps()
-        # Build the linked-issue team-inheritance resolver ONCE from a
-        # donor-complete superset. A PR can link to an issue that completed
-        # before any metrics day, or to a Linear/Jira issue that has no
-        # repo_id — so load org-wide (repo_id=None) and window-independent
+        # Build the resolver ONCE from a donor-complete superset. A PR can link
+        # to an issue that completed before any metrics day, or to a Linear/Jira
+        # issue that has no repo_id — so load org-wide and window-independent
         # (from the epoch) for donor resolution, NOT the per-day repo-scoped
-        # slice used for the metrics themselves. Reused across every day so a
-        # PR is attributed identically regardless of which day it lands on.
+        # slice used for the metrics themselves. Reused across every day so a PR
+        # is attributed identically regardless of which day it lands on.
         donor_start = datetime(1970, 1, 1, tzinfo=timezone.utc)
         donor_end = _utc_day_window(max(days))[1]
         donor_items, _ = await loader.load_work_items(

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -754,10 +754,29 @@ async def run_daily_metrics_job(
     # Defensive getattr: loaders without the method (or deployments missing the
     # table) simply skip inheritance instead of failing the daily job.
     work_item_dependencies: list[Any] = []
-    if load_work_items_enabled and load_work_items_from_db:
+    linked_issue_resolver = None
+    if load_work_items_enabled and load_work_items_from_db and days:
         _load_deps = getattr(loader, "load_work_item_dependencies", None)
         if _load_deps is not None:
             work_item_dependencies = await _load_deps()
+        # Build the linked-issue team-inheritance resolver ONCE from a
+        # donor-complete superset. A PR can link to an issue that completed
+        # before any metrics day, or to a Linear/Jira issue that has no
+        # repo_id — so load org-wide (repo_id=None) and window-independent
+        # (from the epoch) for donor resolution, NOT the per-day repo-scoped
+        # slice used for the metrics themselves. Reused across every day so a
+        # PR is attributed identically regardless of which day it lands on.
+        donor_start = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        donor_end = _utc_day_window(max(days))[1]
+        donor_items, _ = await loader.load_work_items(
+            donor_start, donor_end, None, None
+        )
+        linked_issue_resolver = build_linked_issue_team_resolver(
+            work_items=donor_items,
+            dependencies=work_item_dependencies,
+            team_resolver=team_resolver,
+            project_key_resolver=project_key_resolver,
+        )
 
     for d in days:
         logger.info("Computing metrics for day=%s", d.isoformat())
@@ -932,12 +951,6 @@ async def run_daily_metrics_job(
         wi_cycle_times: list[Any] = []
         wi_state_durations: list[Any] = []
         if work_items:
-            linked_issue_resolver = build_linked_issue_team_resolver(
-                work_items=work_items,
-                dependencies=work_item_dependencies,
-                team_resolver=team_resolver,
-                project_key_resolver=project_key_resolver,
-            )
             wi_metrics, wi_user_metrics, wi_cycle_times = (
                 compute_work_item_metrics_daily(
                     day=d,
@@ -962,6 +975,7 @@ async def run_daily_metrics_job(
                 computed_at=computed_at,
                 team_resolver=team_resolver,
                 project_key_resolver=project_key_resolver,
+                linked_issue_resolver=linked_issue_resolver,
             )
 
         review_edges = compute_review_edges_daily(

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -772,7 +772,19 @@ async def run_daily_metrics_job(
         _load_donors = getattr(loader, "load_work_item_dependencies_donors", None)
         if _load_deps is not None and _load_donors is not None:
             try:
-                work_item_dependencies = await _load_deps()
+                # Bound the dependency read to edges whose SOURCE is a work item
+                # evaluated this run — load the run-window items once to collect
+                # those source ids — so this is never a full-graph scan on the
+                # critical daily path.
+                run_start = datetime.combine(min(days), time.min, tzinfo=timezone.utc)
+                run_end = _utc_day_window(max(days))[1]
+                run_items, _ = await loader.load_work_items(
+                    run_start, run_end, repo_id, repo_name
+                )
+                source_ids = {wi.work_item_id for wi in run_items}
+                work_item_dependencies = (
+                    await _load_deps(source_ids) if source_ids else []
+                )
                 _target_ids: set[str] = set()
                 _issue_keys: set[str] = set()
                 for _dep in work_item_dependencies:

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -12,7 +12,10 @@ from dev_health_ops.db import resolve_sink_uri
 from dev_health_ops.metrics.compute_work_item_state_durations import (
     compute_work_item_state_durations_daily,
 )
-from dev_health_ops.metrics.compute_work_items import compute_work_item_metrics_daily
+from dev_health_ops.metrics.compute_work_items import (
+    build_linked_issue_team_resolver,
+    compute_work_item_metrics_daily,
+)
 from dev_health_ops.metrics.job_daily import (
     REPO_ROOT,
     _discover_repos,
@@ -296,6 +299,22 @@ def run_work_items_sync_job(
             work_items.extend(items)
             transitions.extend(tr)
             ai_attributions.extend(gl_ai_attributions)
+            # Extract dependency edges (same-provider refs + cross-provider
+            # external keys) from each GitLab work item's description so GitLab
+            # items participate in linked-issue team inheritance like GitHub.
+            # get_attr-based extractor reads WorkItem.description directly.
+            from dev_health_ops.providers.gitlab.normalize import (
+                extract_gitlab_dependencies,
+            )
+
+            for wi in items:
+                dependencies.extend(
+                    extract_gitlab_dependencies(
+                        work_item_id=wi.work_item_id,
+                        issue=wi,
+                        project_full_path=(wi.project_id or wi.project_key or ""),
+                    )
+                )
 
         if "synthetic" in provider_set:
             from dev_health_ops.metrics.work_items import fetch_synthetic_work_items
@@ -410,6 +429,18 @@ def run_work_items_sync_job(
                 )
                 s.write_ai_attribution(ai_attributions)
 
+        # Build the linked-issue team-inheritance fallback once for the whole
+        # window: PRs/MRs that map to no team of their own inherit the team of
+        # an issue they link to (provider-agnostic — e.g. a GitHub PR closing a
+        # Linear issue). Window-wide, so a donor issue completed on a different
+        # day than the borrowing PR still attributes correctly.
+        linked_issue_resolver = build_linked_issue_team_resolver(
+            work_items=work_items,
+            dependencies=dependencies,
+            team_resolver=team_resolver,
+            project_key_resolver=pk_resolver,
+        )
+
         for d in days:
             wi_metrics, wi_user_metrics, wi_cycle_times = (
                 compute_work_item_metrics_daily(
@@ -419,6 +450,7 @@ def run_work_items_sync_job(
                     computed_at=computed_at,
                     team_resolver=team_resolver,
                     project_key_resolver=pk_resolver,
+                    linked_issue_resolver=linked_issue_resolver,
                 )
             )
             wi_state_durations = compute_work_item_state_durations_daily(

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -37,7 +37,6 @@ from dev_health_ops.metrics.work_items import (
 )
 from dev_health_ops.models.work_items import (
     WorkItem,
-    WorkItemDependency,
     WorkItemType,
 )
 from dev_health_ops.providers.identity import load_identity_resolver
@@ -448,55 +447,27 @@ def run_work_items_sync_job(
         # issue they link to (provider-agnostic — e.g. a GitHub PR closing a
         # Linear issue).
         #
-        # The donor set must be COMPLETE, not just this sync window: an
-        # incremental run may re-fetch only the PR while its donor issue was
-        # synced earlier, so union the freshly-synced items/edges with the
-        # persisted superset from ClickHouse. Freshly-synced rows win (newest
-        # attribution); the persisted query uses FINAL to read the latest
-        # ReplacingMergeTree version. Falls back to the in-memory window set if
-        # the sink can't be queried.
+        # Freshly-extracted edges are AUTHORITATIVE for the items synced this
+        # run — they are the current source-of-truth, so a link removed from a
+        # PR is simply absent and stops granting inheritance (no append-only
+        # stale-edge problem on the sync path). We therefore use the fresh edges
+        # only. The donor *items* they point at may have been synced earlier, so
+        # those are loaded from ClickHouse — bounded to the referenced targets,
+        # never a full-history scan — and unioned with the fresh items.
         donor_by_id: dict[str, Any] = {}
         merged_deps: dict[tuple[str, str, str], Any] = {}
-
-        def _dep_key(dep: Any) -> tuple[str, str, str]:
-            return (
-                dep.source_work_item_id,
-                dep.target_work_item_id,
-                dep.relationship_type,
-            )
-
-        # Persisted edges complete the picture when an incremental run re-fetched
-        # only the PR. The read is bounded to edges whose SOURCE is a work item
-        # synced this run — the only items we attribute — so it is never a
-        # full-org graph scan. Only query under an explicit tenant scope (an
-        # unscoped query would read every tenant's edges and let a PR inherit
-        # another org's team) and degrade gracefully on failure.
-        synced_ids = sorted({wi.work_item_id for wi in work_items})
-        if org_id and synced_ids and hasattr(primary_sink, "query_dicts"):
-            try:
-                for r in primary_sink.query_dicts(
-                    "SELECT source_work_item_id, target_work_item_id, "
-                    "relationship_type, relationship_type_raw, last_synced, org_id "
-                    "FROM work_item_dependencies FINAL "
-                    "WHERE org_id = {org_id:String} "
-                    "AND source_work_item_id IN {sources:Array(String)}",
-                    {"org_id": org_id, "sources": synced_ids},
-                ):
-                    dep = to_dataclass(WorkItemDependency, r)
-                    merged_deps[_dep_key(dep)] = dep
-            except Exception:
-                logger.warning(
-                    "Persisted dependency load failed; inheritance limited to "
-                    "the sync window",
-                    exc_info=True,
-                )
-        # Freshly-synced edges win (newest version).
         for dep in dependencies:
-            merged_deps[_dep_key(dep)] = dep
+            merged_deps[
+                (
+                    dep.source_work_item_id,
+                    dep.target_work_item_id,
+                    dep.relationship_type,
+                )
+            ] = dep
 
-        # Load only the donor items referenced by an edge target — bounded to
-        # the linked surface, not the tenant's whole history.
-        if org_id and hasattr(primary_sink, "query_dicts"):
+        # Load only the donor items referenced by a fresh edge target — bounded
+        # to the linked surface, under tenant scope, degrading gracefully.
+        if org_id and merged_deps and hasattr(primary_sink, "query_dicts"):
             _ids: set[str] = set()
             _keys: set[str] = set()
             for dep in merged_deps.values():

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -466,17 +466,21 @@ def run_work_items_sync_job(
             )
 
         # Persisted edges complete the picture when an incremental run re-fetched
-        # only the PR. Only query under an explicit tenant scope — an unscoped
-        # query would read EVERY tenant's edges and let a PR inherit another
-        # org's team — and degrade gracefully on failure.
-        if org_id and hasattr(primary_sink, "query_dicts"):
+        # only the PR. The read is bounded to edges whose SOURCE is a work item
+        # synced this run — the only items we attribute — so it is never a
+        # full-org graph scan. Only query under an explicit tenant scope (an
+        # unscoped query would read every tenant's edges and let a PR inherit
+        # another org's team) and degrade gracefully on failure.
+        synced_ids = sorted({wi.work_item_id for wi in work_items})
+        if org_id and synced_ids and hasattr(primary_sink, "query_dicts"):
             try:
                 for r in primary_sink.query_dicts(
                     "SELECT source_work_item_id, target_work_item_id, "
                     "relationship_type, relationship_type_raw, last_synced, org_id "
                     "FROM work_item_dependencies FINAL "
-                    "WHERE org_id = {org_id:String}",
-                    {"org_id": org_id},
+                    "WHERE org_id = {org_id:String} "
+                    "AND source_work_item_id IN {sources:Array(String)}",
+                    {"org_id": org_id, "sources": synced_ids},
                 ):
                     dep = to_dataclass(WorkItemDependency, r)
                     merged_deps[_dep_key(dep)] = dep

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -460,6 +460,7 @@ def run_work_items_sync_job(
                 computed_at=computed_at,
                 team_resolver=team_resolver,
                 project_key_resolver=pk_resolver,
+                linked_issue_resolver=linked_issue_resolver,
             )
 
             # --- Issue Type Metrics ---

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -393,7 +393,10 @@ def run_work_items_sync_job(
                 "%s: extracted %d sprint records", providers_label, len(sprints)
             )
 
-        # Stamp org_id on work items and transitions before writing to sinks
+        # Stamp org_id on work items, transitions AND dependencies before
+        # writing to sinks. Dependencies must be tagged too: the work_item_dependencies
+        # table is tenant-partitioned and the donor-read path filters by org_id,
+        # so unstamped edges would be invisible to tenant-scoped inheritance.
         if org_id:
             work_items = [
                 replace(wi, org_id=org_id) if hasattr(wi, "org_id") else wi
@@ -402,6 +405,10 @@ def run_work_items_sync_job(
             transitions = [
                 replace(t, org_id=org_id) if hasattr(t, "org_id") else t
                 for t in transitions
+            ]
+            dependencies = [
+                replace(dep, org_id=org_id) if hasattr(dep, "org_id") else dep
+                for dep in dependencies
             ]
 
         # Write raw work items and transitions to sinks

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -450,49 +450,81 @@ def run_work_items_sync_job(
         # the sink can't be queried.
         donor_by_id: dict[str, Any] = {}
         merged_deps: dict[tuple[str, str, str], Any] = {}
-        # Only widen to the persisted superset when scoped to a tenant. Without
-        # org_id the query would read EVERY tenant's work items/edges and a PR
-        # could inherit another org's team, so fall back to this run's freshly-
-        # synced (already tenant-scoped) items/edges instead.
+
+        def _dep_key(dep: Any) -> tuple[str, str, str]:
+            return (
+                dep.source_work_item_id,
+                dep.target_work_item_id,
+                dep.relationship_type,
+            )
+
+        # Persisted edges complete the picture when an incremental run re-fetched
+        # only the PR. Only query under an explicit tenant scope — an unscoped
+        # query would read EVERY tenant's edges and let a PR inherit another
+        # org's team — and degrade gracefully on failure.
         if org_id and hasattr(primary_sink, "query_dicts"):
-            _org_where = " WHERE org_id = {org_id:String}"
-            _org_params = {"org_id": org_id}
             try:
-                for r in primary_sink.query_dicts(
-                    "SELECT * FROM work_items FINAL" + _org_where, _org_params
-                ):
-                    wi = to_dataclass(WorkItem, r)
-                    donor_by_id[wi.work_item_id] = wi
                 for r in primary_sink.query_dicts(
                     "SELECT source_work_item_id, target_work_item_id, "
                     "relationship_type, relationship_type_raw, last_synced, org_id "
-                    "FROM work_item_dependencies FINAL" + _org_where,
-                    _org_params,
+                    "FROM work_item_dependencies FINAL "
+                    "WHERE org_id = {org_id:String}",
+                    {"org_id": org_id},
                 ):
                     dep = to_dataclass(WorkItemDependency, r)
-                    merged_deps[
-                        (
-                            dep.source_work_item_id,
-                            dep.target_work_item_id,
-                            dep.relationship_type,
-                        )
-                    ] = dep
+                    merged_deps[_dep_key(dep)] = dep
             except Exception:
                 logger.warning(
-                    "Donor superset load failed; linked-issue inheritance "
-                    "limited to the sync window",
+                    "Persisted dependency load failed; inheritance limited to "
+                    "the sync window",
                     exc_info=True,
                 )
+        # Freshly-synced edges win (newest version).
+        for dep in dependencies:
+            merged_deps[_dep_key(dep)] = dep
+
+        # Load only the donor items referenced by an edge target — bounded to
+        # the linked surface, not the tenant's whole history.
+        if org_id and hasattr(primary_sink, "query_dicts"):
+            _ids: set[str] = set()
+            _keys: set[str] = set()
+            for dep in merged_deps.values():
+                target = dep.target_work_item_id
+                if target.startswith("extkey:"):
+                    _keys.add(target.split(":", 1)[1].strip().upper())
+                elif target:
+                    _ids.add(target)
+            if _ids or _keys:
+                _clauses: list[str] = []
+                _params: dict[str, Any] = {"org_id": org_id}
+                if _ids:
+                    _params["donor_ids"] = sorted(_ids)
+                    _clauses.append("work_item_id IN {donor_ids:Array(String)}")
+                if _keys:
+                    _params["donor_keys"] = sorted(_keys)
+                    _clauses.append(
+                        "upper(splitByChar(':', work_item_id)[-1]) "
+                        "IN {donor_keys:Array(String)}"
+                    )
+                try:
+                    for r in primary_sink.query_dicts(
+                        "SELECT * FROM work_items FINAL "
+                        "WHERE org_id = {org_id:String} AND ("
+                        + " OR ".join(_clauses)
+                        + ")",
+                        _params,
+                    ):
+                        wi = to_dataclass(WorkItem, r)
+                        donor_by_id[wi.work_item_id] = wi
+                except Exception:
+                    logger.warning(
+                        "Donor item load failed; inheritance limited to the "
+                        "sync window",
+                        exc_info=True,
+                    )
+        # Freshly-synced items win (newest attribution fields).
         for wi in work_items:
             donor_by_id[wi.work_item_id] = wi
-        for dep in dependencies:
-            merged_deps[
-                (
-                    dep.source_work_item_id,
-                    dep.target_work_item_id,
-                    dep.relationship_type,
-                )
-            ] = dep
 
         linked_issue_resolver = build_linked_issue_team_resolver(
             work_items=list(donor_by_id.values()),

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -450,9 +450,13 @@ def run_work_items_sync_job(
         # the sink can't be queried.
         donor_by_id: dict[str, Any] = {}
         merged_deps: dict[tuple[str, str, str], Any] = {}
-        if hasattr(primary_sink, "query_dicts"):
-            _org_where = " WHERE org_id = {org_id:String}" if org_id else ""
-            _org_params = {"org_id": org_id} if org_id else {}
+        # Only widen to the persisted superset when scoped to a tenant. Without
+        # org_id the query would read EVERY tenant's work items/edges and a PR
+        # could inherit another org's team, so fall back to this run's freshly-
+        # synced (already tenant-scoped) items/edges instead.
+        if org_id and hasattr(primary_sink, "query_dicts"):
+            _org_where = " WHERE org_id = {org_id:String}"
+            _org_params = {"org_id": org_id}
             try:
                 for r in primary_sink.query_dicts(
                     "SELECT * FROM work_items FINAL" + _org_where, _org_params

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -15,12 +15,14 @@ from dev_health_ops.metrics.compute_work_item_state_durations import (
 from dev_health_ops.metrics.compute_work_items import (
     build_linked_issue_team_resolver,
     compute_work_item_metrics_daily,
+    resolve_base_team,
 )
 from dev_health_ops.metrics.job_daily import (
     REPO_ROOT,
     _discover_repos,
     _to_utc,
 )
+from dev_health_ops.metrics.loaders.base import to_dataclass
 from dev_health_ops.metrics.schemas import (
     InvestmentClassificationRecord,
     InvestmentMetricsRecord,
@@ -33,12 +35,17 @@ from dev_health_ops.metrics.work_items import (
     fetch_jira_work_items_with_extras,
     parse_github_projects_v2_env,
 )
-from dev_health_ops.models.work_items import WorkItemType
+from dev_health_ops.models.work_items import (
+    WorkItem,
+    WorkItemDependency,
+    WorkItemType,
+)
 from dev_health_ops.providers.identity import load_identity_resolver
 from dev_health_ops.providers.status_mapping import load_status_mapping
 from dev_health_ops.providers.teams import (
     build_project_key_resolver,
     load_team_resolver,
+    normalize_team_id,
 )
 from dev_health_ops.storage import detect_db_type
 from dev_health_ops.utils.cli import (
@@ -430,13 +437,62 @@ def run_work_items_sync_job(
                 s.write_ai_attribution(ai_attributions)
 
         # Build the linked-issue team-inheritance fallback once for the whole
-        # window: PRs/MRs that map to no team of their own inherit the team of
-        # an issue they link to (provider-agnostic — e.g. a GitHub PR closing a
-        # Linear issue). Window-wide, so a donor issue completed on a different
-        # day than the borrowing PR still attributes correctly.
+        # run: PRs/MRs that map to no team of their own inherit the team of an
+        # issue they link to (provider-agnostic — e.g. a GitHub PR closing a
+        # Linear issue).
+        #
+        # The donor set must be COMPLETE, not just this sync window: an
+        # incremental run may re-fetch only the PR while its donor issue was
+        # synced earlier, so union the freshly-synced items/edges with the
+        # persisted superset from ClickHouse. Freshly-synced rows win (newest
+        # attribution); the persisted query uses FINAL to read the latest
+        # ReplacingMergeTree version. Falls back to the in-memory window set if
+        # the sink can't be queried.
+        donor_by_id: dict[str, Any] = {}
+        merged_deps: dict[tuple[str, str, str], Any] = {}
+        if hasattr(primary_sink, "query_dicts"):
+            _org_where = " WHERE org_id = {org_id:String}" if org_id else ""
+            _org_params = {"org_id": org_id} if org_id else {}
+            try:
+                for r in primary_sink.query_dicts(
+                    "SELECT * FROM work_items FINAL" + _org_where, _org_params
+                ):
+                    wi = to_dataclass(WorkItem, r)
+                    donor_by_id[wi.work_item_id] = wi
+                for r in primary_sink.query_dicts(
+                    "SELECT source_work_item_id, target_work_item_id, "
+                    "relationship_type, relationship_type_raw, last_synced, org_id "
+                    "FROM work_item_dependencies FINAL" + _org_where,
+                    _org_params,
+                ):
+                    dep = to_dataclass(WorkItemDependency, r)
+                    merged_deps[
+                        (
+                            dep.source_work_item_id,
+                            dep.target_work_item_id,
+                            dep.relationship_type,
+                        )
+                    ] = dep
+            except Exception:
+                logger.warning(
+                    "Donor superset load failed; linked-issue inheritance "
+                    "limited to the sync window",
+                    exc_info=True,
+                )
+        for wi in work_items:
+            donor_by_id[wi.work_item_id] = wi
+        for dep in dependencies:
+            merged_deps[
+                (
+                    dep.source_work_item_id,
+                    dep.target_work_item_id,
+                    dep.relationship_type,
+                )
+            ] = dep
+
         linked_issue_resolver = build_linked_issue_team_resolver(
-            work_items=work_items,
-            dependencies=dependencies,
+            work_items=list(donor_by_id.values()),
+            dependencies=list(merged_deps.values()),
             team_resolver=team_resolver,
             project_key_resolver=pk_resolver,
         )
@@ -469,18 +525,15 @@ def run_work_items_sync_job(
             ] = {}
 
             def _get_team(wi: Any) -> str:
-                if pk_resolver:
-                    t_id, _ = pk_resolver.resolve(
-                        getattr(wi, "work_scope_id", None)
-                        or getattr(wi, "project_key", None)
+                # Same cascade as cycle-time / state-duration compute, including
+                # the linked-issue inheritance fallback, so issue-type and
+                # investment tables never disagree with the others on a PR's team.
+                team_id, _ = resolve_base_team(wi, team_resolver, pk_resolver)
+                if team_id is None:
+                    team_id, _ = linked_issue_resolver.resolve(
+                        getattr(wi, "work_item_id", None)
                     )
-                    if t_id:
-                        return t_id
-                if getattr(wi, "assignees", None):
-                    t_id, _ = team_resolver.resolve(wi.assignees[0])
-                    if t_id:
-                        return t_id
-                return "unassigned"
+                return normalize_team_id(team_id)
 
             def _normalize_investment_team_id(team_id: str | None) -> str | None:
                 if not team_id or team_id == "unassigned":

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -262,8 +262,11 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
         Edges are org-scoped but otherwise time-independent (a PR's link to the
         issue it closes does not expire), so no date window is applied — the
         whole org graph is needed to attribute a PR to a donor issue that may
-        sit outside the metrics window. Returns an empty list when the table is
-        absent (older deployments) rather than failing the daily job.
+        sit outside the metrics window. ``FINAL`` collapses the
+        ``ReplacingMergeTree(last_synced)`` table to the latest version of each
+        edge so stale/duplicate rows can't drive attribution. Returns an empty
+        list when the table is absent (older deployments) rather than failing
+        the daily job.
         """
         from dev_health_ops.models.work_items import WorkItemDependency
 
@@ -277,7 +280,7 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
             relationship_type_raw,
             last_synced,
             org_id
-        FROM work_item_dependencies
+        FROM work_item_dependencies FINAL
         WHERE 1 = 1
         {org_filter}
         ORDER BY source_work_item_id, target_work_item_id, last_synced

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -299,22 +299,33 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
         rows = await _clickhouse_query_dicts(self.client, query, params)
         return [to_dataclass(WorkItem, r) for r in rows]
 
-    async def load_work_item_dependencies(self) -> list[Any]:
+    async def load_work_item_dependencies(
+        self, source_work_item_ids: Any = None
+    ) -> list[Any]:
         """Load PR/issue dependency edges for linked-issue team inheritance.
 
-        Edges are org-scoped but otherwise time-independent (a PR's link to the
-        issue it closes does not expire), so no date window is applied — the
-        whole org graph is needed to attribute a PR to a donor issue that may
-        sit outside the metrics window. ``FINAL`` collapses the
-        ``ReplacingMergeTree(last_synced)`` table to the latest version of each
-        edge so stale/duplicate rows can't drive attribution. Returns an empty
-        list when the table is absent (older deployments) rather than failing
-        the daily job.
+        ``source_work_item_ids`` bounds the read to edges whose source is a work
+        item that will actually be evaluated this run (the only items we
+        attribute), so the daily path never scans the full org graph; passing
+        ``None`` loads all org edges. Edges are otherwise time-independent (a
+        PR's link to the issue it closes does not expire), so no date window is
+        applied — a PR can still reach a donor issue outside the metrics window.
+        ``FINAL`` collapses the ``ReplacingMergeTree(last_synced)`` table to the
+        latest version of each edge so stale/duplicate rows can't drive
+        attribution. Returns an empty list when the table is absent (older
+        deployments) rather than failing the daily job.
         """
         from dev_health_ops.models.work_items import WorkItemDependency
 
         org_filter = self._org_filter()
         params = self._inject_org_id({})
+        source_filter = ""
+        if source_work_item_ids is not None:
+            ids = sorted({str(i) for i in source_work_item_ids if i})
+            if not ids:
+                return []
+            params["dep_sources"] = ids
+            source_filter = " AND source_work_item_id IN {dep_sources:Array(String)}"
         query = f"""
         SELECT
             source_work_item_id,
@@ -326,6 +337,7 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
         FROM work_item_dependencies FINAL
         WHERE 1 = 1
         {org_filter}
+        {source_filter}
         ORDER BY source_work_item_id, target_work_item_id, last_synced
         """
         try:

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, cast
@@ -34,6 +35,8 @@ from dev_health_ops.models.atlassian_ops import (
     AtlassianOpsSchedule,
 )
 from dev_health_ops.models.teams import JiraProjectOpsTeamLink
+
+logger = logging.getLogger(__name__)
 
 
 async def _clickhouse_query_dicts(
@@ -252,6 +255,42 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
         transitions = [to_dataclass(WorkItemStatusTransition, t) for t in trans_dicts]
 
         return items, transitions
+
+    async def load_work_item_dependencies(self) -> list[Any]:
+        """Load PR/issue dependency edges for linked-issue team inheritance.
+
+        Edges are org-scoped but otherwise time-independent (a PR's link to the
+        issue it closes does not expire), so no date window is applied — the
+        whole org graph is needed to attribute a PR to a donor issue that may
+        sit outside the metrics window. Returns an empty list when the table is
+        absent (older deployments) rather than failing the daily job.
+        """
+        from dev_health_ops.models.work_items import WorkItemDependency
+
+        org_filter = self._org_filter()
+        params = self._inject_org_id({})
+        query = f"""
+        SELECT
+            source_work_item_id,
+            target_work_item_id,
+            relationship_type,
+            relationship_type_raw,
+            last_synced,
+            org_id
+        FROM work_item_dependencies
+        WHERE 1 = 1
+        {org_filter}
+        """
+        try:
+            dep_dicts = await _clickhouse_query_dicts(self.client, query, params)
+        except Exception:
+            logger.warning(
+                "load_work_item_dependencies: query failed; "
+                "skipping linked-issue inheritance",
+                exc_info=True,
+            )
+            return []
+        return [to_dataclass(WorkItemDependency, d) for d in dep_dicts]
 
     async def load_cicd_data(
         self,

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -280,6 +280,7 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
         FROM work_item_dependencies
         WHERE 1 = 1
         {org_filter}
+        ORDER BY source_work_item_id, target_work_item_id, last_synced
         """
         try:
             dep_dicts = await _clickhouse_query_dicts(self.client, query, params)

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -256,6 +256,49 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
 
         return items, transitions
 
+    async def load_work_item_dependencies_donors(
+        self,
+        work_item_ids: Any,
+        issue_keys: Any,
+    ) -> list[Any]:
+        """Load only the donor work items referenced by dependency targets.
+
+        This bounds the linked-issue inheritance donor read to the items
+        actually linked from a dependency edge, instead of hydrating the whole
+        tenant's history. ``work_item_ids`` are full target ids
+        (``gh:…``/``gitlab:…``/``jira:…``/``linear:…``); ``issue_keys`` are the
+        bare keys (e.g. ``CHAOS-2400``) from ``extkey:`` targets, matched against
+        the key suffix of Linear/Jira work-item ids. ``FINAL`` reads the latest
+        version. Returns ``[]`` when nothing is referenced.
+        """
+        from dev_health_ops.models.work_items import WorkItem
+
+        ids = sorted({str(i) for i in work_item_ids if i})
+        keys = sorted({str(k).strip().upper() for k in issue_keys if k})
+        if not ids and not keys:
+            return []
+
+        org_filter = self._org_filter()
+        params = self._inject_org_id({})
+        clauses: list[str] = []
+        if ids:
+            params["donor_ids"] = ids
+            clauses.append("work_item_id IN {donor_ids:Array(String)}")
+        if keys:
+            params["donor_keys"] = keys
+            clauses.append(
+                "upper(splitByChar(':', work_item_id)[-1]) "
+                "IN {donor_keys:Array(String)}"
+            )
+        ref_filter = " OR ".join(clauses)
+        query = f"""
+        SELECT * FROM work_items FINAL
+        WHERE ({ref_filter})
+        {org_filter}
+        """
+        rows = await _clickhouse_query_dicts(self.client, query, params)
+        return [to_dataclass(WorkItem, r) for r in rows]
+
     async def load_work_item_dependencies(self) -> list[Any]:
         """Load PR/issue dependency edges for linked-issue team inheritance.
 

--- a/src/dev_health_ops/providers/github/normalize.py
+++ b/src/dev_health_ops/providers/github/normalize.py
@@ -849,6 +849,21 @@ _GITHUB_ISSUE_REF_PATTERN = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 
+# Cross-provider issue keys (Linear/Jira style, e.g. CHAOS-2400, PROJ-12) that a
+# GitHub PR references when its body closes an issue tracked outside GitHub, or
+# when the head branch follows the Linear/Jira branch convention
+# (``user/chaos-2400-title``). Emitted as provider-neutral ``extkey:`` edges
+# and matched to the actual Linear/Jira work item at team-inheritance time, so
+# the PR can borrow that issue's team. A 2+ letter prefix avoids matching
+# version-ish tokens like ``v1-2``; spurious keys simply never resolve.
+_EXTERNAL_KEY = r"[A-Za-z]{2,}-\d+"
+_EXTERNAL_KEY_BODY_PATTERN = re.compile(
+    r"(?:depends\s+on|blocked\s+by|blocks|fixes|closes|resolves|relates\s+to|"
+    r"part\s+of|see)\s*:?\s*(" + _EXTERNAL_KEY + r")\b",
+    re.IGNORECASE,
+)
+_EXTERNAL_KEY_BRANCH_PATTERN = re.compile("(" + _EXTERNAL_KEY + r")")
+
 
 def extract_github_dependencies(
     *,
@@ -906,6 +921,34 @@ def extract_github_dependencies(
                 target_work_item_id=target_id,
                 relationship_type=dep_type,
                 relationship_type_raw=dep_type,
+                last_synced=datetime.now(timezone.utc),
+            )
+        )
+
+    # Cross-provider links: external issue keys (Linear/Jira) referenced in the
+    # PR body via a magic word, plus any key embedded in the head branch name
+    # (Linear's branch convention). Emitted as ``extkey:KEY`` so a single edge
+    # type carries either provider; resolution to the real work item happens at
+    # inheritance time. De-duplicated against keys already captured.
+    seen_external: set[str] = set()
+    branch_ref = getattr(getattr(issue_or_pr, "head", None), "ref", "")
+    if not isinstance(branch_ref, str):
+        branch_ref = ""  # issues have no head; guard against mocks/None
+    external_candidates = [
+        m.group(1) for m in _EXTERNAL_KEY_BODY_PATTERN.finditer(body)
+    ]
+    external_candidates += _EXTERNAL_KEY_BRANCH_PATTERN.findall(branch_ref)
+    for raw_key in external_candidates:
+        key = raw_key.strip().upper()
+        if not key or key in seen_external:
+            continue
+        seen_external.add(key)
+        dependencies.append(
+            WorkItemDependency(
+                source_work_item_id=work_item_id,
+                target_work_item_id=f"extkey:{key}",
+                relationship_type="relates_to",
+                relationship_type_raw="external_issue_key",
                 last_synced=datetime.now(timezone.utc),
             )
         )

--- a/src/dev_health_ops/providers/github/normalize.py
+++ b/src/dev_health_ops/providers/github/normalize.py
@@ -857,12 +857,28 @@ _GITHUB_ISSUE_REF_PATTERN = re.compile(
 # the PR can borrow that issue's team. A 2+ letter prefix avoids matching
 # version-ish tokens like ``v1-2``; spurious keys simply never resolve.
 _EXTERNAL_KEY = r"[A-Za-z]{2,}-\d+"
+# Capture the keyword so blocking intent is preserved: "blocked by CHAOS-1"
+# must NOT become an inheritable edge (a blocker is often a different team).
 _EXTERNAL_KEY_BODY_PATTERN = re.compile(
-    r"(?:depends\s+on|blocked\s+by|blocks|fixes|closes|resolves|relates\s+to|"
+    r"(depends\s+on|blocked\s+by|blocks|fixes|closes|resolves|relates\s+to|"
     r"part\s+of|see)\s*:?\s*(" + _EXTERNAL_KEY + r")\b",
     re.IGNORECASE,
 )
 _EXTERNAL_KEY_BRANCH_PATTERN = re.compile("(" + _EXTERNAL_KEY + r")")
+
+
+def _external_key_relationship(keyword: str) -> str:
+    """Map an external-key magic word to a dependency relationship type.
+
+    Blocking words yield blocking relationships, which the inheritance resolver
+    excludes from team transfer; closing/relating words yield ``relates_to``.
+    """
+    kw = keyword.strip().lower()
+    if kw == "blocks":
+        return "blocks"
+    if kw in {"blocked by", "depends on"}:
+        return "blocked_by"
+    return "relates_to"
 
 
 def extract_github_dependencies(
@@ -934,11 +950,18 @@ def extract_github_dependencies(
     branch_ref = getattr(getattr(issue_or_pr, "head", None), "ref", "")
     if not isinstance(branch_ref, str):
         branch_ref = ""  # issues have no head; guard against mocks/None
-    external_candidates = [
-        m.group(1) for m in _EXTERNAL_KEY_BODY_PATTERN.finditer(body)
+    # (relationship_type, key) candidates. Body keys carry their keyword's
+    # intent (blocking words stay non-inheritable); branch keys are the Linear
+    # "implements this issue" convention and are inheritance-safe.
+    external_candidates: list[tuple[str, str]] = [
+        (_external_key_relationship(m.group(1)), m.group(2))
+        for m in _EXTERNAL_KEY_BODY_PATTERN.finditer(body)
     ]
-    external_candidates += _EXTERNAL_KEY_BRANCH_PATTERN.findall(branch_ref)
-    for raw_key in external_candidates:
+    external_candidates += [
+        ("external_issue_key", k)
+        for k in _EXTERNAL_KEY_BRANCH_PATTERN.findall(branch_ref)
+    ]
+    for rel_type, raw_key in external_candidates:
         key = raw_key.strip().upper()
         if not key or key in seen_external:
             continue
@@ -947,7 +970,7 @@ def extract_github_dependencies(
             WorkItemDependency(
                 source_work_item_id=work_item_id,
                 target_work_item_id=f"extkey:{key}",
-                relationship_type="relates_to",
+                relationship_type=rel_type,
                 relationship_type_raw="external_issue_key",
                 last_synced=datetime.now(timezone.utc),
             )

--- a/src/dev_health_ops/providers/gitlab/normalize.py
+++ b/src/dev_health_ops/providers/gitlab/normalize.py
@@ -448,10 +448,20 @@ _BLOCKING_KEYWORDS = {"blocks", "blocked by", "is blocked by", "blocking"}
 # Linear/Jira work item at team-inheritance time so the GitLab item can borrow
 # that issue's team — the same cross-provider recovery the GitHub path provides.
 _GITLAB_EXTERNAL_KEY_BODY_PATTERN = re.compile(
-    r"(?:depends\s+on|blocked\s+by|blocks|fixes|closes|resolves|relates\s+to|"
+    r"(depends\s+on|blocked\s+by|blocks|fixes|closes|resolves|relates\s+to|"
     r"part\s+of|see)\s*:?\s*([A-Za-z]{2,}-\d+)\b",
     re.IGNORECASE,
 )
+
+
+def _gitlab_external_key_relationship(keyword: str) -> str:
+    """Blocking words → blocking relationship (non-inheritable); else relates_to."""
+    kw = keyword.strip().lower()
+    if kw == "blocks":
+        return "blocks"
+    if kw in {"blocked by", "depends on"}:
+        return "blocked_by"
+    return "relates_to"
 
 
 def extract_gitlab_dependencies(
@@ -548,7 +558,7 @@ def extract_gitlab_dependencies(
     if description:
         seen_external: set[str] = set()
         for match in _GITLAB_EXTERNAL_KEY_BODY_PATTERN.finditer(str(description)):
-            key = match.group(1).strip().upper()
+            key = match.group(2).strip().upper()
             if not key or key in seen_external:
                 continue
             seen_external.add(key)
@@ -556,7 +566,7 @@ def extract_gitlab_dependencies(
                 WorkItemDependency(
                     source_work_item_id=work_item_id,
                     target_work_item_id=f"extkey:{key}",
-                    relationship_type="relates_to",
+                    relationship_type=_gitlab_external_key_relationship(match.group(1)),
                     relationship_type_raw="external_issue_key",
                 )
             )

--- a/src/dev_health_ops/providers/gitlab/normalize.py
+++ b/src/dev_health_ops/providers/gitlab/normalize.py
@@ -442,6 +442,17 @@ _GITLAB_ISSUE_REF_PATTERN = re.compile(
 )
 _BLOCKING_KEYWORDS = {"blocks", "blocked by", "is blocked by", "blocking"}
 
+# Cross-provider issue keys (Linear/Jira style, e.g. CHAOS-2400, PROJ-12) that a
+# GitLab issue/MR description references when the tracked work lives outside
+# GitLab. Emitted as provider-neutral ``extkey:`` edges and matched to the real
+# Linear/Jira work item at team-inheritance time so the GitLab item can borrow
+# that issue's team — the same cross-provider recovery the GitHub path provides.
+_GITLAB_EXTERNAL_KEY_BODY_PATTERN = re.compile(
+    r"(?:depends\s+on|blocked\s+by|blocks|fixes|closes|resolves|relates\s+to|"
+    r"part\s+of|see)\s*:?\s*([A-Za-z]{2,}-\d+)\b",
+    re.IGNORECASE,
+)
+
 
 def extract_gitlab_dependencies(
     *,
@@ -528,6 +539,25 @@ def extract_gitlab_dependencies(
                     target_work_item_id=target_id,
                     relationship_type=relationship,
                     relationship_type_raw=relationship_raw,
+                )
+            )
+
+    # Cross-provider links: external (Linear/Jira) issue keys referenced via a
+    # magic word in the description. Emitted as ``extkey:KEY`` so a GitLab item
+    # can inherit the team of an issue tracked in another provider.
+    if description:
+        seen_external: set[str] = set()
+        for match in _GITLAB_EXTERNAL_KEY_BODY_PATTERN.finditer(str(description)):
+            key = match.group(1).strip().upper()
+            if not key or key in seen_external:
+                continue
+            seen_external.add(key)
+            dependencies.append(
+                WorkItemDependency(
+                    source_work_item_id=work_item_id,
+                    target_work_item_id=f"extkey:{key}",
+                    relationship_type="relates_to",
+                    relationship_type_raw="external_issue_key",
                 )
             )
 

--- a/src/dev_health_ops/providers/teams.py
+++ b/src/dev_health_ops/providers/teams.py
@@ -112,6 +112,38 @@ class RepoPatternTeamResolver:
         return None, None
 
 
+@dataclass(frozen=True)
+class LinkedIssueTeamResolver:
+    """Inherit team attribution from a linked work item.
+
+    This is the final fallback after scope-key, project-key and membership
+    resolution. A work item that itself resolves to no team — e.g. a
+    GitHub/GitLab PR whose repo maps to no team and whose author is not a
+    team member — borrows the team of an issue it links to via
+    ``work_item_dependencies``.
+
+    The mechanism is provider-agnostic: the donor issue may live in a
+    different provider than the borrowing PR (a GitHub PR inheriting from a
+    Linear or Jira issue it closes). That is exactly the cross-provider
+    recovery the team-exchange chord and allocation-coverage views need,
+    since PRs otherwise always land as ``unassigned`` and never share a team
+    dimension with the issue trackers.
+
+    Instances are cheap dict lookups; the edge walking happens once at build
+    time. Build with
+    :func:`dev_health_ops.metrics.compute_work_items.build_linked_issue_team_resolver`.
+    """
+
+    # source work_item_id -> (team_id, team_name) inherited from a linked,
+    # already-team-attributed target.
+    _inherited: Mapping[str, tuple[str, str]]
+
+    def resolve(self, work_item_id: str | None) -> tuple[str | None, str | None]:
+        if not work_item_id:
+            return None, None
+        return self._inherited.get(work_item_id, (None, None))
+
+
 def _build_member_to_team(teams_data: list) -> dict[str, tuple[str, str]]:
     """Shared helper to build identity map from a list of team-like objects or dicts."""
     member_to_team: dict[str, tuple[str, str]] = {}

--- a/tests/test_linked_issue_team_inheritance.py
+++ b/tests/test_linked_issue_team_inheritance.py
@@ -128,6 +128,29 @@ def test_inheritance_never_overrides_a_real_team() -> None:
     assert resolve_base_team(owned_pr, None, pkr) == ("CHAOS", "Chaos Team")
 
 
+def test_blocking_relationships_do_not_drive_inheritance() -> None:
+    # blocks / blocked_by / is_blocked_by routinely span teams, so they must
+    # NOT transfer a team. Only "does-the-work-of"/duplicate links do.
+    donor = _wi("linear:CHAOS-1", "linear", project_key="CHAOS")
+    pkr = _chaos_resolver()
+    for rel in ("blocks", "blocked_by", "is_blocked_by", "other"):
+        pr = _wi("ghpr:x/y#1", "github", type="pr", project_id="x/y")
+        deps = [WorkItemDependency(pr.work_item_id, donor.work_item_id, rel, rel)]
+        resolver = build_linked_issue_team_resolver(
+            work_items=[donor, pr], dependencies=deps, project_key_resolver=pkr
+        )
+        assert resolver.resolve(pr.work_item_id) == (None, None), rel
+    # ...but a relates/closing edge to the same donor does inherit.
+    pr = _wi("ghpr:x/y#1", "github", type="pr", project_id="x/y")
+    deps = [
+        WorkItemDependency(pr.work_item_id, donor.work_item_id, "relates_to", "fixes")
+    ]
+    resolver = build_linked_issue_team_resolver(
+        work_items=[donor, pr], dependencies=deps, project_key_resolver=pkr
+    )
+    assert resolver.resolve(pr.work_item_id) == ("CHAOS", "Chaos Team")
+
+
 def test_unresolvable_extkey_yields_no_inheritance() -> None:
     pr = _wi("ghpr:x/y#1", "github", type="pr", project_id="x/y")
     deps = [

--- a/tests/test_linked_issue_team_inheritance.py
+++ b/tests/test_linked_issue_team_inheritance.py
@@ -151,6 +151,50 @@ def test_blocking_relationships_do_not_drive_inheritance() -> None:
     assert resolver.resolve(pr.work_item_id) == ("CHAOS", "Chaos Team")
 
 
+def test_newer_blocking_edge_supersedes_stale_inheritable_edge() -> None:
+    # An edge corrected from relates_to -> blocked_by must stop inheriting, even
+    # if the stale relates_to row is still present (different ReplacingMergeTree
+    # version). Latest last_synced per (source,target) wins.
+    donor = _wi("linear:CHAOS-1", "linear", project_key="CHAOS")
+    pr = _wi("ghpr:x/y#1", "github", type="pr", project_id="x/y")
+    old = WorkItemDependency(
+        pr.work_item_id,
+        donor.work_item_id,
+        "relates_to",
+        "fixes",
+        last_synced=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    new = WorkItemDependency(
+        pr.work_item_id,
+        donor.work_item_id,
+        "blocked_by",
+        "blocked by",
+        last_synced=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    # Order-independent: stale relates_to never wins once superseded.
+    for deps in ([old, new], [new, old]):
+        resolver = build_linked_issue_team_resolver(
+            work_items=[donor, pr],
+            dependencies=deps,
+            project_key_resolver=_chaos_resolver(),
+        )
+        assert resolver.resolve(pr.work_item_id) == (None, None)
+    # The reverse correction (blocking -> relates) re-enables inheritance.
+    newer_relates = WorkItemDependency(
+        pr.work_item_id,
+        donor.work_item_id,
+        "relates_to",
+        "fixes",
+        last_synced=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    )
+    resolver = build_linked_issue_team_resolver(
+        work_items=[donor, pr],
+        dependencies=[new, newer_relates],
+        project_key_resolver=_chaos_resolver(),
+    )
+    assert resolver.resolve(pr.work_item_id) == ("CHAOS", "Chaos Team")
+
+
 def test_unresolvable_extkey_yields_no_inheritance() -> None:
     pr = _wi("ghpr:x/y#1", "github", type="pr", project_id="x/y")
     deps = [

--- a/tests/test_linked_issue_team_inheritance.py
+++ b/tests/test_linked_issue_team_inheritance.py
@@ -12,12 +12,19 @@ from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
 
+from dev_health_ops.metrics.compute_work_item_state_durations import (
+    compute_work_item_state_durations_daily,
+)
 from dev_health_ops.metrics.compute_work_items import (
     build_linked_issue_team_resolver,
     compute_work_item_metrics_daily,
     resolve_base_team,
 )
-from dev_health_ops.models.work_items import WorkItem, WorkItemDependency
+from dev_health_ops.models.work_items import (
+    WorkItem,
+    WorkItemDependency,
+    WorkItemStatusTransition,
+)
 from dev_health_ops.providers.github.normalize import extract_github_dependencies
 from dev_health_ops.providers.gitlab.normalize import extract_gitlab_dependencies
 from dev_health_ops.providers.teams import ProjectKeyTeamResolver, TeamResolver
@@ -137,21 +144,52 @@ def test_unresolvable_extkey_yields_no_inheritance() -> None:
     assert resolver.resolve(pr.work_item_id) == (None, None)
 
 
-def test_first_donor_edge_wins() -> None:
+def test_multiple_donors_resolved_deterministically_regardless_of_order() -> None:
+    # ClickHouse rows have no inherent order; multi-donor selection must not
+    # depend on edge order. Smallest canonical target wins, both orderings.
     pr = _wi("ghpr:x/y#1", "github", type="pr", project_id="x/y")
     a = _wi("linear:AAA-1", "linear", project_key="AAA")
     b = _wi("linear:BBB-1", "linear", project_key="BBB")
-    deps = [
-        WorkItemDependency(pr.work_item_id, "extkey:AAA-1", "relates_to", "k"),
-        WorkItemDependency(pr.work_item_id, "extkey:BBB-1", "relates_to", "k"),
-    ]
     pkr = ProjectKeyTeamResolver(
         project_key_to_team={"AAA": ("aaa", "A"), "BBB": ("bbb", "B")}
     )
-    resolver = build_linked_issue_team_resolver(
-        work_items=[pr, a, b], dependencies=deps, project_key_resolver=pkr
+    forward = [
+        WorkItemDependency(pr.work_item_id, "extkey:AAA-1", "relates_to", "k"),
+        WorkItemDependency(pr.work_item_id, "extkey:BBB-1", "relates_to", "k"),
+    ]
+    reverse = list(reversed(forward))
+    r1 = build_linked_issue_team_resolver(
+        work_items=[pr, a, b], dependencies=forward, project_key_resolver=pkr
     )
-    assert resolver.resolve(pr.work_item_id) == ("aaa", "A")
+    r2 = build_linked_issue_team_resolver(
+        work_items=[pr, a, b], dependencies=reverse, project_key_resolver=pkr
+    )
+    # linear:AAA-1 < linear:BBB-1, so 'aaa' wins for both input orders.
+    assert r1.resolve(pr.work_item_id) == ("aaa", "A")
+    assert r2.resolve(pr.work_item_id) == ("aaa", "A")
+
+
+def test_donor_completed_outside_metrics_window_still_attributes() -> None:
+    # Regression for the daily-path donor-completeness fix: the donor issue
+    # completed long before the metrics day. The resolver is built from a
+    # window-independent donor superset, so the PR (computed on a later day)
+    # still inherits. The resolver itself is date-agnostic; this documents the
+    # contract the job relies on by supplying an old donor + a recent PR.
+    old_donor = _wi(
+        "linear:CHAOS-1",
+        "linear",
+        project_key="CHAOS",
+        created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        completed_at=datetime(2025, 1, 2, tzinfo=timezone.utc),
+    )
+    pr = _wi("ghpr:full-chaos/ops#99", "github", type="pr", project_id="full-chaos/ops")
+    deps = [WorkItemDependency(pr.work_item_id, "extkey:CHAOS-1", "relates_to", "k")]
+    resolver = build_linked_issue_team_resolver(
+        work_items=[old_donor, pr],
+        dependencies=deps,
+        project_key_resolver=_chaos_resolver(),
+    )
+    assert resolver.resolve(pr.work_item_id) == ("CHAOS", "Chaos Team")
 
 
 # --------------------------------------------------------------------------- #
@@ -188,6 +226,51 @@ def test_compute_stamps_inherited_team_on_cycle_times() -> None:
     assert by_id[pr.work_item_id].team_id == "CHAOS"
     assert by_id[pr.work_item_id].team_name == "Chaos Team"
     assert by_id[linear.work_item_id].team_id == "CHAOS"
+
+
+def test_cycle_times_and_state_durations_agree_on_inherited_team() -> None:
+    # The same PR must read with the SAME team in both work_item_cycle_times
+    # and work_item_state_durations — otherwise BI rollups that join the two
+    # see contradictory team slices.
+    day = date(2026, 6, 1)
+    linear = _wi("linear:CHAOS-2400", "linear", project_key="CHAOS")
+    pr = _wi("ghpr:full-chaos/ops#12", "github", type="pr", project_id="full-chaos/ops")
+    deps = [WorkItemDependency(pr.work_item_id, "extkey:CHAOS-2400", "relates_to", "k")]
+    pkr = _chaos_resolver()
+    resolver = build_linked_issue_team_resolver(
+        work_items=[linear, pr], dependencies=deps, project_key_resolver=pkr
+    )
+    # state-durations needs a transition to emit a row.
+    transitions = [
+        WorkItemStatusTransition(
+            work_item_id=pr.work_item_id,
+            provider="github",
+            occurred_at=START + timedelta(hours=1),
+            from_status_raw=None,
+            to_status_raw="closed",
+            from_status="in_progress",
+            to_status="done",
+        )
+    ]
+    _, _, cycle_times = compute_work_item_metrics_daily(
+        day=day,
+        work_items=[pr],
+        transitions=transitions,
+        computed_at=START,
+        project_key_resolver=pkr,
+        linked_issue_resolver=resolver,
+    )
+    state_rows = compute_work_item_state_durations_daily(
+        day=day,
+        work_items=[pr],
+        transitions=transitions,
+        computed_at=START + timedelta(hours=6),
+        project_key_resolver=pkr,
+        linked_issue_resolver=resolver,
+    )
+    assert cycle_times[0].team_id == "CHAOS"
+    assert state_rows, "expected at least one state-duration row"
+    assert {r.team_id for r in state_rows} == {"CHAOS"}
 
 
 def test_compute_without_resolver_leaves_pr_unassigned() -> None:

--- a/tests/test_linked_issue_team_inheritance.py
+++ b/tests/test_linked_issue_team_inheritance.py
@@ -371,6 +371,52 @@ def test_github_captures_external_keys_from_body_and_branch() -> None:
     assert "gh:full-chaos/ops#5" in targets  # same-repo ref preserved
 
 
+def test_github_external_key_relationship_type_follows_keyword() -> None:
+    # Blocking intent must produce a non-inheritable relationship; closing /
+    # branch keys must produce inheritable ones.
+    class _Head:
+        ref = "user/eng-7-feature"
+
+    class _PR:
+        body = "Blocked by CHAOS-1. Fixes PROJ-2."
+        head = _Head()
+
+    deps = extract_github_dependencies(
+        work_item_id="ghpr:o/r#1", issue_or_pr=_PR(), repo_full_name="o/r"
+    )
+    rel_by_target = {
+        d.target_work_item_id: d.relationship_type
+        for d in deps
+        if d.target_work_item_id.startswith("extkey:")
+    }
+    assert rel_by_target["extkey:CHAOS-1"] == "blocked_by"  # not inheritable
+    assert rel_by_target["extkey:PROJ-2"] == "relates_to"  # inheritable
+    assert rel_by_target["extkey:ENG-7"] == "external_issue_key"  # branch, inheritable
+
+
+def test_blocked_by_external_key_does_not_drive_inheritance_end_to_end() -> None:
+    # The capture types it blocked_by and the resolver excludes that type, so a
+    # PR that merely says "blocked by CHAOS-1" never inherits the CHAOS team.
+    class _Head:
+        ref = ""
+
+    class _PR:
+        body = "Blocked by CHAOS-1."
+        head = _Head()
+
+    deps = extract_github_dependencies(
+        work_item_id="ghpr:o/r#1", issue_or_pr=_PR(), repo_full_name="o/r"
+    )
+    donor = _wi("linear:CHAOS-1", "linear", project_key="CHAOS")
+    pr = _wi("ghpr:o/r#1", "github", type="pr", project_id="o/r")
+    resolver = build_linked_issue_team_resolver(
+        work_items=[donor, pr],
+        dependencies=deps,
+        project_key_resolver=_chaos_resolver(),
+    )
+    assert resolver.resolve(pr.work_item_id) == (None, None)
+
+
 def test_gitlab_captures_external_key_from_description() -> None:
     wi = _wi(
         "gitlab:grp/proj#7",

--- a/tests/test_linked_issue_team_inheritance.py
+++ b/tests/test_linked_issue_team_inheritance.py
@@ -195,6 +195,23 @@ def test_newer_blocking_edge_supersedes_stale_inheritable_edge() -> None:
     assert resolver.resolve(pr.work_item_id) == ("CHAOS", "Chaos Team")
 
 
+def test_ambiguous_extkey_across_providers_is_dropped() -> None:
+    # extkey carries no provider. If the same key exists in BOTH Linear and
+    # Jira, the link is genuinely ambiguous and must not be guessed.
+    linear = _wi("linear:CHAOS-1", "linear", project_key="CHAOS")
+    jira = _wi("jira:CHAOS-1", "jira", project_key="CHAOS")
+    pr = _wi("ghpr:x/y#1", "github", type="pr", project_id="x/y")
+    deps = [WorkItemDependency(pr.work_item_id, "extkey:CHAOS-1", "relates_to", "k")]
+    pkr = ProjectKeyTeamResolver(project_key_to_team={"CHAOS": ("CHAOS", "Chaos Team")})
+    # Order-independent: ambiguity is detected regardless of which item is seen
+    # first.
+    for items in ([linear, jira, pr], [jira, linear, pr]):
+        resolver = build_linked_issue_team_resolver(
+            work_items=items, dependencies=deps, project_key_resolver=pkr
+        )
+        assert resolver.resolve(pr.work_item_id) == (None, None)
+
+
 def test_unresolvable_extkey_yields_no_inheritance() -> None:
     pr = _wi("ghpr:x/y#1", "github", type="pr", project_id="x/y")
     deps = [

--- a/tests/test_linked_issue_team_inheritance.py
+++ b/tests/test_linked_issue_team_inheritance.py
@@ -1,0 +1,301 @@
+"""Tests for cross-provider linked-issue team inheritance.
+
+A PR/MR that maps to no team of its own inherits the team of an issue it links
+to via ``work_item_dependencies``. The mechanism is provider-agnostic: a GitHub
+PR or GitLab MR can inherit from a Linear or Jira issue (matched through a
+``extkey:KEY`` edge), and same-provider links work too. This is the recovery
+path that lets PRs share a team dimension with the issue trackers in the
+allocation-coverage and team-exchange views.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+from dev_health_ops.metrics.compute_work_items import (
+    build_linked_issue_team_resolver,
+    compute_work_item_metrics_daily,
+    resolve_base_team,
+)
+from dev_health_ops.models.work_items import WorkItem, WorkItemDependency
+from dev_health_ops.providers.github.normalize import extract_github_dependencies
+from dev_health_ops.providers.gitlab.normalize import extract_gitlab_dependencies
+from dev_health_ops.providers.teams import ProjectKeyTeamResolver, TeamResolver
+
+START = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+def _wi(work_item_id: str, provider: str, **kw: object) -> WorkItem:
+    defaults: dict[str, object] = dict(
+        title="t",
+        type="task",
+        status="done",
+        status_raw="Done",
+        created_at=START - timedelta(days=2),
+        updated_at=START + timedelta(hours=2),
+        started_at=START,
+        completed_at=START + timedelta(hours=2),
+        closed_at=START + timedelta(hours=2),
+        labels=[],
+    )
+    defaults.update(kw)
+    return WorkItem(work_item_id=work_item_id, provider=provider, **defaults)  # type: ignore[arg-type]
+
+
+def _chaos_resolver() -> ProjectKeyTeamResolver:
+    return ProjectKeyTeamResolver(
+        project_key_to_team={"CHAOS": ("CHAOS", "Chaos Team")}
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Resolver / builder unit behaviour
+# --------------------------------------------------------------------------- #
+
+
+def test_pr_inherits_team_from_linked_linear_issue_via_extkey() -> None:
+    linear = _wi("linear:CHAOS-2400", "linear", project_key="CHAOS")
+    pr = _wi("ghpr:full-chaos/ops#12", "github", type="pr", project_id="full-chaos/ops")
+    deps = [
+        WorkItemDependency(
+            source_work_item_id=pr.work_item_id,
+            target_work_item_id="extkey:CHAOS-2400",
+            relationship_type="relates_to",
+            relationship_type_raw="external_issue_key",
+        )
+    ]
+    resolver = build_linked_issue_team_resolver(
+        work_items=[linear, pr],
+        dependencies=deps,
+        project_key_resolver=_chaos_resolver(),
+    )
+    assert resolver.resolve(pr.work_item_id) == ("CHAOS", "Chaos Team")
+    # The donor itself resolves to a real team directly, so it needs no
+    # inherited entry.
+    assert resolver.resolve(linear.work_item_id) == (None, None)
+
+
+def test_same_provider_github_pr_to_issue_inheritance() -> None:
+    # GitHub issue mapped to a team by repo-keyed project resolver; the PR lives
+    # in a different, unmapped repo (so it can't self-resolve) and links to it.
+    issue = _wi("gh:team-a/svc#5", "github", project_id="team-a/svc")
+    pr = _wi("ghpr:contrib/forks#9", "github", type="pr", project_id="contrib/forks")
+    pkr = ProjectKeyTeamResolver(
+        project_key_to_team={"team-a/svc": ("team-a", "Team A")}
+    )
+    deps = [
+        WorkItemDependency(
+            source_work_item_id=pr.work_item_id,
+            target_work_item_id=issue.work_item_id,
+            relationship_type="relates_to",
+            relationship_type_raw="relates_to",
+        )
+    ]
+    resolver = build_linked_issue_team_resolver(
+        work_items=[issue, pr], dependencies=deps, project_key_resolver=pkr
+    )
+    assert resolver.resolve(pr.work_item_id) == ("team-a", "Team A")
+
+
+def test_inheritance_never_overrides_a_real_team() -> None:
+    # Source already resolves to its own team; the edge must not change it.
+    owned_pr = _wi("ghpr:x/y#1", "github", project_id="x/y", project_key="CHAOS")
+    other = _wi("linear:OTHER-1", "linear", project_key="OTHER")
+    deps = [
+        WorkItemDependency(
+            source_work_item_id=owned_pr.work_item_id,
+            target_work_item_id="extkey:OTHER-1",
+            relationship_type="relates_to",
+            relationship_type_raw="external_issue_key",
+        )
+    ]
+    pkr = ProjectKeyTeamResolver(
+        project_key_to_team={"CHAOS": ("CHAOS", "Chaos Team"), "OTHER": ("OTHER", "O")}
+    )
+    resolver = build_linked_issue_team_resolver(
+        work_items=[owned_pr, other], dependencies=deps, project_key_resolver=pkr
+    )
+    # resolve_base_team already returns CHAOS, so the source isn't in the
+    # inherited map at all.
+    assert resolver.resolve(owned_pr.work_item_id) == (None, None)
+    assert resolve_base_team(owned_pr, None, pkr) == ("CHAOS", "Chaos Team")
+
+
+def test_unresolvable_extkey_yields_no_inheritance() -> None:
+    pr = _wi("ghpr:x/y#1", "github", type="pr", project_id="x/y")
+    deps = [
+        WorkItemDependency(
+            source_work_item_id=pr.work_item_id,
+            target_work_item_id="extkey:GHOST-9",  # no such issue in the batch
+            relationship_type="relates_to",
+            relationship_type_raw="external_issue_key",
+        )
+    ]
+    resolver = build_linked_issue_team_resolver(
+        work_items=[pr], dependencies=deps, project_key_resolver=_chaos_resolver()
+    )
+    assert resolver.resolve(pr.work_item_id) == (None, None)
+
+
+def test_first_donor_edge_wins() -> None:
+    pr = _wi("ghpr:x/y#1", "github", type="pr", project_id="x/y")
+    a = _wi("linear:AAA-1", "linear", project_key="AAA")
+    b = _wi("linear:BBB-1", "linear", project_key="BBB")
+    deps = [
+        WorkItemDependency(pr.work_item_id, "extkey:AAA-1", "relates_to", "k"),
+        WorkItemDependency(pr.work_item_id, "extkey:BBB-1", "relates_to", "k"),
+    ]
+    pkr = ProjectKeyTeamResolver(
+        project_key_to_team={"AAA": ("aaa", "A"), "BBB": ("bbb", "B")}
+    )
+    resolver = build_linked_issue_team_resolver(
+        work_items=[pr, a, b], dependencies=deps, project_key_resolver=pkr
+    )
+    assert resolver.resolve(pr.work_item_id) == ("aaa", "A")
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end through the per-day metrics compute (the cycle-times producer)
+# --------------------------------------------------------------------------- #
+
+
+def test_compute_stamps_inherited_team_on_cycle_times() -> None:
+    day = date(2026, 6, 1)
+    linear = _wi("linear:CHAOS-2400", "linear", project_key="CHAOS")
+    pr = _wi("ghpr:full-chaos/ops#12", "github", type="pr", project_id="full-chaos/ops")
+    deps = [
+        WorkItemDependency(
+            source_work_item_id=pr.work_item_id,
+            target_work_item_id="extkey:CHAOS-2400",
+            relationship_type="relates_to",
+            relationship_type_raw="external_issue_key",
+        )
+    ]
+    pkr = _chaos_resolver()
+    resolver = build_linked_issue_team_resolver(
+        work_items=[linear, pr], dependencies=deps, project_key_resolver=pkr
+    )
+
+    _, _, cycle_times = compute_work_item_metrics_daily(
+        day=day,
+        work_items=[linear, pr],
+        transitions=[],
+        computed_at=START,
+        project_key_resolver=pkr,
+        linked_issue_resolver=resolver,
+    )
+    by_id = {c.work_item_id: c for c in cycle_times}
+    assert by_id[pr.work_item_id].team_id == "CHAOS"
+    assert by_id[pr.work_item_id].team_name == "Chaos Team"
+    assert by_id[linear.work_item_id].team_id == "CHAOS"
+
+
+def test_compute_without_resolver_leaves_pr_unassigned() -> None:
+    # Regression guard: absent the resolver, the PR is still 'unassigned'
+    # (proves the inheritance — not some other path — is what fixes it).
+    day = date(2026, 6, 1)
+    pr = _wi("ghpr:full-chaos/ops#12", "github", type="pr", project_id="full-chaos/ops")
+    _, _, cycle_times = compute_work_item_metrics_daily(
+        day=day,
+        work_items=[pr],
+        transitions=[],
+        computed_at=START,
+        project_key_resolver=_chaos_resolver(),
+        linked_issue_resolver=None,
+    )
+    assert cycle_times[0].team_id == "unassigned"
+
+
+def test_membership_team_still_wins_over_inheritance() -> None:
+    # A PR whose author is a team member resolves via membership; inheritance
+    # is only a fallback and must not run.
+    day = date(2026, 6, 1)
+    pr = _wi(
+        "ghpr:full-chaos/ops#12",
+        "github",
+        type="pr",
+        project_id="full-chaos/ops",
+        assignees=["bob@example.com"],
+    )
+    other = _wi("linear:OTHER-1", "linear", project_key="OTHER")
+    deps = [WorkItemDependency(pr.work_item_id, "extkey:OTHER-1", "relates_to", "k")]
+    pkr = ProjectKeyTeamResolver(project_key_to_team={"OTHER": ("other", "Other")})
+    team_resolver = TeamResolver(
+        member_to_team={"bob@example.com": ("platform", "Platform")}
+    )
+    resolver = build_linked_issue_team_resolver(
+        work_items=[pr, other],
+        dependencies=deps,
+        team_resolver=team_resolver,
+        project_key_resolver=pkr,
+    )
+    _, _, cycle_times = compute_work_item_metrics_daily(
+        day=day,
+        work_items=[pr],
+        transitions=[],
+        computed_at=START,
+        team_resolver=team_resolver,
+        project_key_resolver=pkr,
+        linked_issue_resolver=resolver,
+    )
+    assert cycle_times[0].team_id == "platform"
+
+
+# --------------------------------------------------------------------------- #
+# Provider link capture emits the edges the mechanism consumes
+# --------------------------------------------------------------------------- #
+
+
+def test_github_captures_external_keys_from_body_and_branch() -> None:
+    class _Head:
+        ref = "chris/chaos-2400-fix"
+
+    class _PR:
+        body = "This PR closes CHAOS-2401 and fixes #5."
+        head = _Head()
+
+    deps = extract_github_dependencies(
+        work_item_id="ghpr:full-chaos/ops#12",
+        issue_or_pr=_PR(),
+        repo_full_name="full-chaos/ops",
+    )
+    targets = {d.target_work_item_id for d in deps}
+    assert "extkey:CHAOS-2400" in targets  # from branch name
+    assert "extkey:CHAOS-2401" in targets  # from body magic word
+    assert "gh:full-chaos/ops#5" in targets  # same-repo ref preserved
+
+
+def test_gitlab_captures_external_key_from_description() -> None:
+    wi = _wi(
+        "gitlab:grp/proj#7",
+        "gitlab",
+        type="issue",
+        description="Depends on PROJ-99 for the backend work",
+    )
+    deps = extract_gitlab_dependencies(
+        work_item_id=wi.work_item_id,
+        issue=wi,
+        project_full_path="grp/proj",
+    )
+    assert any(d.target_work_item_id == "extkey:PROJ-99" for d in deps)
+
+
+def test_jira_native_link_drives_inheritance() -> None:
+    # Jira issues link to each other natively; an unassigned Jira issue inherits
+    # from a linked, team-attributed Jira issue.
+    owned = _wi("jira:CHAOS-1", "jira", project_key="CHAOS")
+    orphan = _wi("jira:LOOSE-9", "jira", project_key="LOOSE")  # no team mapping
+    deps = [
+        WorkItemDependency(
+            source_work_item_id=orphan.work_item_id,
+            target_work_item_id=owned.work_item_id,
+            relationship_type="relates_to",
+            relationship_type_raw="relates",
+        )
+    ]
+    resolver = build_linked_issue_team_resolver(
+        work_items=[owned, orphan],
+        dependencies=deps,
+        project_key_resolver=_chaos_resolver(),
+    )
+    assert resolver.resolve(orphan.work_item_id) == ("CHAOS", "Chaos Team")

--- a/tests/test_linked_issue_team_inheritance.py
+++ b/tests/test_linked_issue_team_inheritance.py
@@ -11,6 +11,7 @@ allocation-coverage and team-exchange views.
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
+from typing import Any, cast
 
 from dev_health_ops.metrics.compute_work_item_state_durations import (
     compute_work_item_state_durations_daily,
@@ -423,7 +424,7 @@ def test_github_captures_external_keys_from_body_and_branch() -> None:
 
     deps = extract_github_dependencies(
         work_item_id="ghpr:full-chaos/ops#12",
-        issue_or_pr=_PR(),
+        issue_or_pr=cast(Any, _PR()),
         repo_full_name="full-chaos/ops",
     )
     targets = {d.target_work_item_id for d in deps}
@@ -443,7 +444,7 @@ def test_github_external_key_relationship_type_follows_keyword() -> None:
         head = _Head()
 
     deps = extract_github_dependencies(
-        work_item_id="ghpr:o/r#1", issue_or_pr=_PR(), repo_full_name="o/r"
+        work_item_id="ghpr:o/r#1", issue_or_pr=cast(Any, _PR()), repo_full_name="o/r"
     )
     rel_by_target = {
         d.target_work_item_id: d.relationship_type
@@ -466,7 +467,7 @@ def test_blocked_by_external_key_does_not_drive_inheritance_end_to_end() -> None
         head = _Head()
 
     deps = extract_github_dependencies(
-        work_item_id="ghpr:o/r#1", issue_or_pr=_PR(), repo_full_name="o/r"
+        work_item_id="ghpr:o/r#1", issue_or_pr=cast(Any, _PR()), repo_full_name="o/r"
     )
     donor = _wi("linear:CHAOS-1", "linear", project_key="CHAOS")
     pr = _wi("ghpr:o/r#1", "github", type="pr", project_id="o/r")


### PR DESCRIPTION
## Problem

In the investment **Allocation** tab, TEAM COVERAGE shows **0% (100% unmapped to a team)** and the **team-exchange chord** shows *"No flows match the current filters."*

Root cause (from the team-mapping investigation): GitHub/GitLab **PRs always land as `team_id='unassigned'`** in `work_item_cycle_times`. Team resolution only consults (1) the repo/project-key scope, (2) the Linear/Jira project key, and (3) assignee membership — none of which attributes a PR to a team. So PRs never share a team dimension with the issue trackers: no two teams ever co-occur on a `(work_scope_id, day)` pair (chord empty), and the coverage join over PR-centric work units only ever yields `unassigned`.

> The separate CTE `ILLEGAL_AGGREGATION` bug (coverage query crashing to a 0% fallback) was already fixed in #920. This PR addresses the underlying **mapping** gap.

## Fix — provider-agnostic linked-issue team inheritance

A fourth attribution tier: a work item that resolves to **no team of its own** inherits the team of an issue it links to via `work_item_dependencies`. Built once per run in `build_linked_issue_team_resolver` and applied as the **final fallback** in `compute_work_item_metrics_daily`, so it never overrides a real attribution.

Cross-provider links are captured as provider-neutral **`extkey:KEY`** edges that resolve to the actual Linear/Jira work item by key at inheritance time:

| Provider | Capture | Recovery |
|---|---|---|
| **GitHub** | PR-body magic words + head branch name (`chris/chaos-2400-…`) | PR → Linear/Jira issue's team |
| **GitLab** | issue/MR description magic words; existing issue edges threaded into the job | MR/issue → linked issue's team |
| **Jira** | native `issuelinks` already flow as edges | issue → linked issue's team |
| **Linear** | native team (donor) | issues are donors |

So a GitHub PR closing `CHAOS-2400` borrows that Linear issue's `CHAOS` team — same recovery for github, gitlab, and jira.

## Applied consistently across every work-item table

The single resolver is used by cycle-times, state-durations, and the issue-type / investment rollups (`_get_team`), so a PR reads with the **same team in every table** and cross-table joins stay consistent. Only inheritance-safe relationship types (`relates_to`, `relates`, `duplicates`, `external_issue_key`) transfer a team — blocking links are excluded.

## Tenant isolation & donor completeness

- Donor reads are **org-scoped**: the org-wide donor/edge queries run only under an explicit `org_id`, so a PR can never inherit another organization's team. Unscoped (dev/CLI) runs skip inheritance rather than read across tenants.
- The donor set is **complete, not window-bound**: `job_daily` loads donors org-wide (`repo_id=None`) and window-independent (a PR can close an issue completed earlier, or a repo-less Linear/Jira issue); `job_work_items` unions the synced window with the persisted ClickHouse superset. `load_work_item_dependencies` uses `FINAL` to read the latest ReplacingMergeTree version, and multi-donor selection is deterministic (smallest canonical target wins).

## Tests
`tests/test_linked_issue_team_inheritance.py` (17 cases): cross-provider extkey, same-provider, never-overrides-real-team, deterministic multi-donor, out-of-window donor, cycle-time/state-duration agreement, blocking-relationship exclusion, membership precedence, unresolvable key, and GitHub/GitLab/Jira capture. Existing provider + work-item compute suites pass (814 in the broader sweep; the only failures are pre-existing `@pytest.mark.clickhouse` live tests needing a seeded DB).

## Adversarial review

Ran `/codex:adversarial-review` across three rounds; each round's findings were fixed:
1. Donor set incomplete in the daily path; state-durations attributed inconsistently; nondeterministic multi-donor selection → donor-complete superset, shared cascade, deterministic tiebreak + `ORDER BY`.
2. Sync-path donor window; issue-type/investment bypassed inheritance; dependency read missed `FINAL` → persisted-superset union, unified `_get_team`, `FINAL` dedup.
3. Cross-tenant donor reads when `org_id` omitted; blocking edges drove inheritance → tenant-scoped donor reads, relationship-type allowlist.

Residual (accepted, documented): branch-name capture is the primary Linear-link signal; tenant scoping + the relationship allowlist bound it to a same-org, self-inflicted mis-attribution — an analytics signal, not an authz boundary.

## Post-deploy recompute
Inheritance needs the new `extkey:` edges in `work_item_dependencies`, written during a **work-items sync** (`run_work_items_sync`). After deploy, run a work-items sync for affected orgs (re-captures edges **and** recomputes with inheritance in one pass) — e.g. org `a78c1a6a-5f85-40c3-8764-5167851d6e7a`.

🤖 Investigated from `/tmp/claude/team-mapping-investigation.md`.