### PR TITLE
feat(github): support GitHub App credentials (CHAOS-2276)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,3 +1,4 @@
 f3b6feebaea7953d563207a73c76217f8ec5ccea:tests/test_ingest_api.py:generic-api-key:71
 # CHAOS-1772: false-positive on slowapi rate-limit literal "20/15minutes"
 81d688d029526d14179b71df6db78921b9f09a46:tests/api/auth/test_login_rate_limit.py:generic-api-key:29
+69bb1e2f75882961d9f8d47f99b984b411026865:tests/api/admin/test_credential_repos.py:private-key:193

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -20,6 +20,7 @@ from dev_health_ops.api.admin.schemas import (
     TestConnectionResponse,
 )
 from dev_health_ops.api.services.configuration import IntegrationCredentialsService
+from dev_health_ops.credentials.resolver import github_credentials_from_mapping
 
 from .common import get_session
 
@@ -35,6 +36,27 @@ class _MutableIntegrationCredential(Protocol):
 
 def _string_value(value: object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _github_credentials_or_400(creds: dict[str, Any]):
+    github_credentials = github_credentials_from_mapping(creds)
+    if github_credentials is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "GitHub credentials require either token or "
+                "app_id + private_key + installation_id"
+            ),
+        )
+    return github_credentials
+
+
+def _validated_github_base_url(base_url: str | None) -> str:
+    effective_base_url = base_url or "https://api.github.com"
+    is_valid, error = _validate_external_url(effective_base_url)
+    if not is_valid:
+        raise HTTPException(status_code=400, detail=error)
+    return effective_base_url
 
 
 def _integration_credential_response(
@@ -104,18 +126,26 @@ async def list_credential_repos(
     if provider == "github":
         from dev_health_ops.connectors.github import GitHubConnector
 
-        token = decrypted.get("token")
-        base_url = _string_value(decrypted.get("base_url")) or _string_value(
-            config.get("base_url")
+        github_credentials = _github_credentials_or_400(
+            {
+                **decrypted,
+                "base_url": decrypted.get("base_url") or config.get("base_url"),
+            }
         )
-        if not token:
-            raise HTTPException(
-                status_code=400, detail="GitHub credential missing token"
-            )
-        github_connector = GitHubConnector(token=token, base_url=base_url)
-        effective_owner = owner or _string_value(config.get("org"))
+        _validated_github_base_url(github_credentials.base_url)
+        effective_owner = (
+            owner
+            or _string_value(config.get("org"))
+            or _string_value(decrypted.get("org"))
+        )
         if not effective_owner:
             return DiscoveredReposResponse(provider=provider, repos=[], total=0)
+        try:
+            github_connector = GitHubConnector(credentials=github_credentials)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=401, detail="GitHub App authentication failed"
+            ) from exc
         try:
             repos = github_connector.list_repositories(
                 org_name=effective_owner,
@@ -365,26 +395,56 @@ def _build_safe_url(validated_base: str, path: str) -> str:
 async def _test_github_connection(creds: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
     import httpx
 
-    token = creds.get("token")
+    github_credentials = github_credentials_from_mapping(creds)
+    if github_credentials is None:
+        return False, {
+            "error": "Missing GitHub token or App credentials (app_id, private_key, installation_id)"
+        }
+
+    try:
+        base_url = _validated_github_base_url(github_credentials.base_url)
+    except HTTPException as exc:
+        return False, {"error": exc.detail}
+
+    token = github_credentials.token
+    path = "user"
+    if github_credentials.is_app_auth:
+        from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
+
+        assert github_credentials.app_id is not None
+        assert github_credentials.private_key is not None
+        assert github_credentials.installation_id is not None
+        try:
+            token = GitHubAppTokenProvider(
+                app_id=github_credentials.app_id,
+                private_key=github_credentials.private_key,
+                installation_id=github_credentials.installation_id,
+                api_base_url=base_url,
+            ).get_token()
+        except Exception:
+            return False, {"error": "GitHub App authentication failed"}
+        path = "installation/repositories"
     if not token:
         return False, {"error": "No token provided"}
 
-    base_url = _string_value(creds.get("base_url")) or "https://api.github.com"
-    is_valid, error = _validate_external_url(base_url)
-    if not is_valid:
-        return False, {"error": error}
-
     async with httpx.AsyncClient() as client:
         resp = await client.get(
-            _build_safe_url(base_url, "user"),
+            _build_safe_url(base_url, path),
             headers={
                 "Authorization": f"Bearer {token}",
                 "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
             },
             timeout=10,
         )
         if resp.status_code == 200:
             data = resp.json()
+            if github_credentials.is_app_auth:
+                return True, {
+                    "auth_mode": "github_app",
+                    "installation_id": github_credentials.installation_id,
+                    "repository_count": data.get("total_count"),
+                }
             return True, {"user": data.get("login"), "name": data.get("name")}
         return False, {"status": resp.status_code, "error": resp.text[:200]}
 

--- a/src/dev_health_ops/api/admin/routers/teams.py
+++ b/src/dev_health_ops/api/admin/routers/teams.py
@@ -223,7 +223,12 @@ async def discover_teams(
                     status_code=401, detail="GitHub App authentication failed"
                 ) from exc
         else:
-            token = github_credentials.token
+            token_value = github_credentials.token
+            if not token_value:
+                raise HTTPException(
+                    status_code=400, detail="GitHub credential missing token"
+                )
+            token = token_value
         if not token:
             raise HTTPException(
                 status_code=400, detail="GitHub credential missing token"
@@ -254,14 +259,15 @@ async def discover_teams(
             )
         teams = _dedupe_teams(discovered)
     elif provider == "gitlab":
-        token = decrypted.get("token")
+        token_value = decrypted.get("token")
         url_value = config.get("url", "https://gitlab.com")
         url = url_value if isinstance(url_value, str) else "https://gitlab.com"
-        if not token:
+        if not isinstance(token_value, str) or not token_value:
             raise HTTPException(
                 status_code=400,
                 detail="GitLab credentials require a token",
             )
+        token = token_value
         if group:
             group_paths = [group]
         elif _string_value(config.get("group")):

--- a/src/dev_health_ops/api/admin/routers/teams.py
+++ b/src/dev_health_ops/api/admin/routers/teams.py
@@ -21,6 +21,7 @@ from dev_health_ops.api.services.configuration import (
     TeamDiscoveryService,
     TeamMappingService,
 )
+from dev_health_ops.credentials.resolver import github_credentials_from_mapping
 
 from .common import get_session
 
@@ -29,6 +30,14 @@ router = APIRouter()
 
 def _string_value(value: object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _validate_github_base_url(base_url: str) -> None:
+    from dev_health_ops.api.admin.routers.credentials import _validate_external_url
+
+    is_valid, error = _validate_external_url(base_url)
+    if not is_valid:
+        raise HTTPException(status_code=400, detail=error)
 
 
 async def _derive_owners_from_sync_configs(
@@ -183,11 +192,41 @@ async def discover_teams(
     warnings: list[str] = []
 
     if provider == "github":
-        token = decrypted.get("token")
-        if not token:
+        github_credentials = github_credentials_from_mapping(decrypted)
+        if github_credentials is None:
             raise HTTPException(
                 status_code=400,
-                detail="GitHub credentials require a token",
+                detail=(
+                    "GitHub credentials require either token or "
+                    "app_id + private_key + installation_id"
+                ),
+            )
+        if github_credentials.is_app_auth:
+            from dev_health_ops.connectors.utils.github_app import (
+                GitHubAppTokenProvider,
+            )
+
+            assert github_credentials.app_id is not None
+            assert github_credentials.private_key is not None
+            assert github_credentials.installation_id is not None
+            base_url = github_credentials.base_url or "https://api.github.com"
+            _validate_github_base_url(base_url)
+            try:
+                token = GitHubAppTokenProvider(
+                    app_id=github_credentials.app_id,
+                    private_key=github_credentials.private_key,
+                    installation_id=github_credentials.installation_id,
+                    api_base_url=base_url,
+                ).get_token()
+            except Exception as exc:
+                raise HTTPException(
+                    status_code=401, detail="GitHub App authentication failed"
+                ) from exc
+        else:
+            token = github_credentials.token
+        if not token:
+            raise HTTPException(
+                status_code=400, detail="GitHub credential missing token"
             )
         # Resolution order: explicit query param -> credential config ->
         # owners derived from existing repo sync configurations.

--- a/src/dev_health_ops/api/services/configuration/_helpers.py
+++ b/src/dev_health_ops/api/services/configuration/_helpers.py
@@ -25,7 +25,12 @@ if TYPE_CHECKING:
 _CREDENTIAL_KEY_MAP: dict[str, dict[str, str]] = {
     "linear": {"apiKey": "api_key"},
     "jira": {"apiToken": "api_token", "baseUrl": "base_url"},
-    "github": {"baseUrl": "base_url"},
+    "github": {
+        "appId": "app_id",
+        "baseUrl": "base_url",
+        "installationId": "installation_id",
+        "privateKey": "private_key",
+    },
     "gitlab": {"baseUrl": "base_url"},
     "atlassian": {"apiToken": "api_token", "cloudId": "cloud_id"},
 }

--- a/src/dev_health_ops/connectors/github.py
+++ b/src/dev_health_ops/connectors/github.py
@@ -113,6 +113,7 @@ class GitHubConnector(GitConnector):
                 app_id=credentials.app_id,
                 private_key=credentials.private_key,
                 installation_id=credentials.installation_id,
+                api_base_url=base_url or "https://api.github.com",
             )
             token = self._app_token_provider.get_token()
         elif credentials is not None:

--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -231,25 +231,21 @@ def github_credentials_from_mapping(
 
     Accepts a decrypted credentials dict (as persisted in ``integration_credentials``
     or assembled from environment variables) and returns a typed credential the
-    GitHub connector can consume directly. A ``private_key_path`` is resolved to the
-    ``private_key`` contents when only the path is present.
+    GitHub connector can consume directly.
 
     Returns ``None`` when the mapping contains neither a ``token`` nor a complete
-    App-auth triple (``app_id`` + ``private_key``/``private_key_path`` +
-    ``installation_id``), so callers can surface a clear configuration error.
+    App-auth triple (``app_id`` + ``private_key`` + ``installation_id``), so callers
+    can surface a clear configuration error.
     """
-    cred_dict = {k: v for k, v in cred_dict.items() if v is not None}
+    aliases = {
+        "appId": "app_id",
+        "baseUrl": "base_url",
+        "installationId": "installation_id",
+        "privateKey": "private_key",
+    }
+    cred_dict = {aliases.get(k, k): v for k, v in cred_dict.items() if v is not None}
     if not cred_dict:
         return None
-
-    if "private_key" not in cred_dict:
-        private_key_path = cred_dict.get("private_key_path")
-        if private_key_path:
-            try:
-                with open(str(private_key_path), encoding="utf-8") as key_file:
-                    cred_dict["private_key"] = key_file.read()
-            except OSError as exc:
-                logger.debug("Could not read GitHub App private key path: %s", exc)
 
     allowed = {"token", "app_id", "private_key", "installation_id", "base_url"}
     kwargs = {k: v for k, v in cred_dict.items() if k in allowed}

--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -242,10 +242,21 @@ def github_credentials_from_mapping(
         "baseUrl": "base_url",
         "installationId": "installation_id",
         "privateKey": "private_key",
+        "privateKeyPath": "private_key_path",
     }
     cred_dict = {aliases.get(k, k): v for k, v in cred_dict.items() if v is not None}
     if not cred_dict:
         return None
+
+    if "private_key" not in cred_dict:
+        private_key_path = cred_dict.get("private_key_path")
+        if private_key_path:
+            try:
+                with open(str(private_key_path), encoding="utf-8") as key_file:
+                    cred_dict["private_key"] = key_file.read()
+            except OSError:
+                logger.debug("GitHub private key path could not be read")
+                return None
 
     allowed = {"token", "app_id", "private_key", "installation_id", "base_url"}
     kwargs = {k: v for k, v in cred_dict.items() if k in allowed}

--- a/tests/api/admin/test_credential_repos.py
+++ b/tests/api/admin/test_credential_repos.py
@@ -190,7 +190,7 @@ async def test_list_repos_accepts_github_app_credentials(client):
     ac, state = client
     app_credentials = {
         "app_id": "12345",
-        "private_key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
+        "private_key": "not-a-real-github-app-private-key",
         "installation_id": "67890",
     }
 
@@ -241,7 +241,7 @@ async def test_github_app_test_connection_accepts_camel_case_fields():
         success, details = await credentials_router_module._test_github_connection(
             {
                 "appId": "12345",
-                "privateKey": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
+                "privateKey": "not-a-real-github-app-private-key",
                 "installationId": "67890",
                 "baseUrl": "https://api.github.com",
             }

--- a/tests/api/admin/test_credential_repos.py
+++ b/tests/api/admin/test_credential_repos.py
@@ -35,6 +35,9 @@ from tests._helpers import tables_of
 
 admin_router_module = importlib.import_module("dev_health_ops.api.admin")
 auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+credentials_router_module = importlib.import_module(
+    "dev_health_ops.api.admin.routers.credentials"
+)
 
 _TABLES = tables_of(User, Organization, OrgLicense, IntegrationCredential)
 
@@ -142,14 +145,15 @@ _FAKE_REPOS = [
 
 _DECRYPT_PATCH = "dev_health_ops.api.services.configuration.IntegrationCredentialsService.get_decrypted_credentials_by_id"
 _GH_CONNECTOR = "dev_health_ops.connectors.github.GitHubConnector"
+_GH_APP_PROVIDER = "dev_health_ops.connectors.utils.github_app.GitHubAppTokenProvider"
 
 
-def _mock_credential(provider="github", config=None):
+def _mock_credential(provider="github", config=None, credentials=None):
     """Return a (decrypted_creds, credential_obj) tuple for mocking."""
     cred = MagicMock()
     cred.provider = provider
     cred.config = {"org": "my-org"} if config is None else config
-    return {"token": "ghp_fake123"}, cred
+    return credentials or {"token": "ghp_fake123"}, cred
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +183,77 @@ async def test_list_repos_success(client):
     assert body["total"] == 2
     assert body["repos"][0]["name"] == "api-gateway"
     assert body["repos"][1]["name"] == "web-app"
+
+
+@pytest.mark.asyncio
+async def test_list_repos_accepts_github_app_credentials(client):
+    ac, state = client
+    app_credentials = {
+        "app_id": "12345",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
+        "installation_id": "67890",
+    }
+
+    with (
+        patch(
+            _DECRYPT_PATCH,
+            return_value=_mock_credential(credentials=app_credentials),
+        ),
+        patch(_GH_CONNECTOR) as MockConnector,
+    ):
+        MockConnector.return_value.list_repositories.return_value = _FAKE_REPOS
+
+        resp = await ac.get(
+            f"/api/v1/admin/credentials/{state['cred_id']}/repos",
+            params={"owner": "my-org"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 2
+    _, kwargs = MockConnector.call_args
+    assert kwargs["credentials"].is_app_auth is True
+    assert kwargs["credentials"].installation_id == "67890"
+
+
+@pytest.mark.asyncio
+async def test_github_app_test_connection_accepts_camel_case_fields():
+    class _Response:
+        status_code = 200
+
+        def json(self):
+            return {"total_count": 3}
+
+    class _AsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, *args, **kwargs):
+            return _Response()
+
+    with (
+        patch(_GH_APP_PROVIDER) as MockProvider,
+        patch("httpx.AsyncClient", return_value=_AsyncClient()),
+    ):
+        MockProvider.return_value.get_token.return_value = "ghs_installation"
+        success, details = await credentials_router_module._test_github_connection(
+            {
+                "appId": "12345",
+                "privateKey": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
+                "installationId": "67890",
+                "baseUrl": "https://api.github.com",
+            }
+        )
+
+    assert success is True
+    assert details == {
+        "auth_mode": "github_app",
+        "installation_id": "67890",
+        "repository_count": 3,
+    }
+    MockProvider.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -362,4 +437,4 @@ async def test_missing_token_returns_400(client):
         )
 
     assert resp.status_code == 400
-    assert "missing token" in resp.json()["detail"].lower()
+    assert "require either token" in resp.json()["detail"].lower()

--- a/tests/test_github_app_auth.py
+++ b/tests/test_github_app_auth.py
@@ -91,6 +91,7 @@ def test_github_connector_branches_to_app_token_provider() -> None:
         app_id="12345",
         private_key="synthetic-private-key",
         installation_id="67890",
+        api_base_url="https://api.github.com",
     )
     github_cls.assert_called_once()
     graphql_cls.assert_called_once()


### PR DESCRIPTION
## Summary
- accept GitHub App credential fields from admin configuration, including camelCase UI payloads
- resolve GitHub credentials from either PAT or App installation credentials
- use GitHub App auth for admin repo discovery, credential testing, and team discovery
- preserve GitHub Enterprise base URL through App token exchange

## Verification
- ruff check src/dev_health_ops/api/admin/routers/credentials.py src/dev_health_ops/api/admin/routers/teams.py src/dev_health_ops/api/services/configuration/_helpers.py src/dev_health_ops/connectors/github.py src/dev_health_ops/credentials/resolver.py tests/api/admin/test_credential_repos.py
- PYTHONPATH=src python -m pytest tests/api/admin/test_credential_repos.py

Closes CHAOS-2276
