### PR TITLE
fix(backfill): derive org from sync config id instead of requiring --org

### DIFF
--- a/src/dev_health_ops/backfill/cli.py
+++ b/src/dev_health_ops/backfill/cli.py
@@ -27,7 +27,9 @@ def register_backfill_commands(subparsers: argparse._SubParsersAction) -> None:
 
     run_parser = backfill_subparsers.add_parser("run", help="Run historical backfill.")
     run_parser.add_argument(
-        "--config-id", required=True, help="Sync configuration UUID"
+        "--config-id",
+        required=True,
+        help="Sync configuration UUID (its organization is used; --org is optional)",
     )
     add_date_range_args(run_parser)
     add_sink_arg(run_parser)
@@ -40,9 +42,9 @@ def _cmd_backfill_run(ns: argparse.Namespace) -> int:
         end_day, backfill_days = resolve_date_range(ns)
         since = end_day - timedelta(days=backfill_days - 1)
         before = end_day
-        org_id = str(getattr(ns, "org", "") or "")
-        if not org_id:
-            raise ValueError("Organization ID is required")
+        # org is derived from the sync configuration (--config-id); --org is an
+        # optional assertion validated inside run_backfill_for_config.
+        org_id = str(getattr(ns, "org", "") or "") or None
 
         def _progress(index: int, total: int, window_since, window_before) -> None:
             print(

--- a/src/dev_health_ops/backfill/runner.py
+++ b/src/dev_health_ops/backfill/runner.py
@@ -18,7 +18,7 @@ def run_backfill_for_config(
     *,
     db_url: str,
     sync_config_id: str,
-    org_id: str,
+    org_id: str | None = None,
     since: date,
     before: date,
     sink: str = "clickhouse",
@@ -27,16 +27,26 @@ def run_backfill_for_config(
 ) -> dict[str, Any]:
     config_uuid = uuid.UUID(sync_config_id)
     with get_postgres_session_sync() as session:
+        # The sync configuration owns its tenant, so the org is derived from the
+        # config id — callers do not need to pass --org. When an org_id IS given
+        # it is treated as an assertion: a mismatch is an explicit error rather
+        # than a silent "not found" (the previous behaviour filtered on both id
+        # AND org_id, so a wrong/empty --org just looked like a missing config).
         config = (
             session.query(SyncConfiguration)
-            .filter(
-                SyncConfiguration.id == config_uuid,
-                SyncConfiguration.org_id == org_id,
-            )
+            .filter(SyncConfiguration.id == config_uuid)
             .one_or_none()
         )
         if config is None:
             raise ValueError(f"Sync configuration not found: {sync_config_id}")
+
+        resolved_org_id = str(config.org_id)
+        if org_id and org_id != resolved_org_id:
+            raise ValueError(
+                f"Org mismatch: --org {org_id} does not own sync config "
+                f"{sync_config_id} (owned by {resolved_org_id})"
+            )
+        org_id = resolved_org_id
 
         provider = str(config.provider or "").strip().lower()
         sync_options = dict(config.sync_options or {})
@@ -63,6 +73,7 @@ def run_backfill_for_config(
         "status": "success",
         "provider": provider,
         "sync_config_id": sync_config_id,
+        "org_id": org_id,
         "window_count": len(windows),
         "since": since.isoformat(),
         "before": before.isoformat(),

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -404,7 +404,7 @@ _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     ("admin", "bundles", "assign-plan"): frozenset({_REQ_POSTGRES}),
     ("admin", "bundles", "assign-org"): frozenset({_REQ_POSTGRES}),
     ("billing", "reconcile"): frozenset({_REQ_POSTGRES}),
-    ("backfill", "run"): frozenset({_REQ_ORG}),
+    ("backfill", "run"): frozenset({_REQ_POSTGRES}),
     # --- migrations that connect to a live database ---
     ("migrate", "clickhouse", "upgrade"): frozenset({_REQ_CLICKHOUSE}),
     ("migrate", "clickhouse", "status"): frozenset({_REQ_CLICKHOUSE}),

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -109,3 +109,85 @@ def test_run_backfill_for_config_raises_when_config_missing(
             since=date(2026, 1, 1),
             before=date(2026, 1, 10),
         )
+
+
+class _FakeConfig:
+    def __init__(self, org_id: str) -> None:
+        self.id = org_id
+        self.org_id = org_id
+        self.provider = "github"
+        self.sync_options: dict[str, object] = {}
+
+
+def _patch_session_with_config(monkeypatch: pytest.MonkeyPatch, config: object) -> None:
+    class _Query:
+        def filter(self, *args, **kwargs):
+            return self
+
+        def one_or_none(self):
+            return config
+
+    class _Session:
+        def query(self, *args, **kwargs):
+            return _Query()
+
+    class _Ctx:
+        def __enter__(self):
+            return _Session()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(
+        "dev_health_ops.backfill.runner.get_postgres_session_sync",
+        lambda: _Ctx(),
+    )
+
+
+def test_run_backfill_derives_org_from_config_when_org_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_org = "55555555-5555-5555-5555-555555555555"
+    _patch_session_with_config(monkeypatch, _FakeConfig(config_org))
+
+    captured: dict[str, object] = {}
+
+    def _fake_sync_job(*args, **kwargs):
+        captured["org_id"] = kwargs.get("org_id")
+
+    monkeypatch.setattr(
+        "dev_health_ops.backfill.runner.run_work_items_sync_job",
+        _fake_sync_job,
+    )
+
+    result = run_backfill_for_config(
+        db_url="clickhouse://local",
+        sync_config_id="66666666-6666-6666-6666-666666666666",
+        org_id=None,
+        since=date(2026, 1, 1),
+        before=date(2026, 1, 3),
+    )
+
+    assert result["org_id"] == config_org
+    assert captured["org_id"] == config_org
+
+
+def test_run_backfill_raises_on_org_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_org = "77777777-7777-7777-7777-777777777777"
+    _patch_session_with_config(monkeypatch, _FakeConfig(config_org))
+
+    monkeypatch.setattr(
+        "dev_health_ops.backfill.runner.run_work_items_sync_job",
+        lambda *args, **kwargs: None,
+    )
+
+    with pytest.raises(ValueError, match="Org mismatch"):
+        run_backfill_for_config(
+            db_url="clickhouse://local",
+            sync_config_id="88888888-8888-8888-8888-888888888888",
+            org_id="99999999-9999-9999-9999-999999999999",
+            since=date(2026, 1, 1),
+            before=date(2026, 1, 3),
+        )

--- a/tests/test_cli_preflight.py
+++ b/tests/test_cli_preflight.py
@@ -128,7 +128,9 @@ _MISSING_CASES = [
     (("billing", "reconcile"), ("PostgreSQL",)),
     (("migrate", "postgres", "upgrade"), ("PostgreSQL",)),
     (("migrate", "clickhouse", "status"), ("ClickHouse",)),
-    (("backfill", "run", "--config-id", "x"), ("organization",)),
+    # backfill run reads the SyncConfiguration from Postgres; the org is
+    # derived from --config-id, so the missing input is PostgreSQL, not --org.
+    (("backfill", "run", "--config-id", "x"), ("PostgreSQL",)),
     # Bare migrate forms default to upgrade and must be guarded too.
     (("migrate", "postgres"), ("PostgreSQL",)),
     (("migrate", "clickhouse"), ("ClickHouse",)),


### PR DESCRIPTION
## Problem

The `backfill run` CLI command (`python -m dev_health_ops.cli backfill run --config-id <uuid> ...`) redundantly **required** `--org`, even though the `SyncConfiguration` looked up by `--config-id` already owns `org_id`.

This was a footgun: because the runner filtered the config query on **both** `id` AND `org_id`, passing a wrong or empty `--org` silently surfaced as `"Sync configuration not found"` — pointing the operator at the wrong problem (a missing config) when the real issue was a mismatched/absent org.

## Fix

- `run_backfill_for_config` now queries the `SyncConfiguration` by `id` only and derives `org_id` from `config.org_id`.
- A supplied `org_id` is treated as an **optional assertion**: a mismatch raises an explicit `"Org mismatch"` error instead of a misleading "not found".
- The CLI makes `--org` optional (derived in the runner) and updates the `--config-id` help text.
- The requirements/preflight map switches `backfill run` from requiring an organization to requiring **PostgreSQL** (it reads the config from Postgres). `backfill run --help` now shows `Requires: PostgreSQL` and no organization line.

## Tests

- New unit tests: omitting `org_id` derives it from the config; a mismatched `org_id` raises (following the existing monkeypatched fake-session pattern).
- Updated the preflight parametrized case to expect PostgreSQL instead of organization for the new contract.
- `pytest -k backfill`: all green. ruff + mypy clean on changed files.

Note: one pre-existing, unrelated preflight failure (`test_admin_license_create_is_not_a_postgres_preflight_false_positive`, depends on a license key env) is present on main and untouched by this PR.