### PR TITLE
feat(providers): capture PR/MR↔issue links from Linear attachments + PR comments

### DIFF
--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -353,6 +353,9 @@ def run_work_items_sync_job(
                 reopen_events.extend(batch.reopen_events)
                 interactions.extend(batch.interactions)
                 sprints.extend(batch.sprints)
+                # PR/MR -> issue edges from Linear attachments (links to source
+                # control) drive linked-issue team inheritance for the PR/MR.
+                dependencies.extend(batch.dependencies)
                 # Collect any AI attribution records in the batch.
                 if hasattr(batch, "ai_attributions"):
                     ai_attributions.extend(batch.ai_attributions)

--- a/src/dev_health_ops/providers/github/normalize.py
+++ b/src/dev_health_ops/providers/github/normalize.py
@@ -979,57 +979,36 @@ def extract_github_dependencies(
     return dependencies
 
 
-# A Linear issue link in a PR comment is only captured from an EXPLICIT linkage
-# signal, never a bare token: a ``linear.app/.../issue/KEY`` URL (the integration
-# bot's linkback) or a key preceded by a linkage keyword. This avoids turning an
-# incidental ticket mention (a security id, an unrelated Jira reference) into an
-# inheritable team edge.
+# A Linear link in a PR comment is captured only from the integration bot's
+# ``linear.app/.../issue/KEY`` URL — the single high-confidence, hard-to-forge
+# signal. Bare tokens and natural-language keywords from third-party comments
+# are intentionally not trusted (they could force an unrelated inheritance).
 _COMMENT_LINEAR_URL_PATTERN = re.compile(
     r"linear\.app/[^/\s]+/issue/([A-Za-z][A-Za-z0-9]+-\d+)", re.IGNORECASE
-)
-_COMMENT_KEYWORD_KEY_PATTERN = re.compile(
-    r"(depends\s+on|blocked\s+by|blocks|fixes|closes|resolves|relates\s+to|"
-    r"part\s+of|linked\s+to|see)\s*:?\s*([A-Za-z][A-Za-z0-9]+-\d+)\b",
-    re.IGNORECASE,
 )
 
 
 def extract_github_comment_dependencies(
     *, work_item_id: str, comment_bodies: Sequence[str | None]
 ) -> list[WorkItemDependency]:
-    """Secondary capture: external issue links in a PR's comments.
+    """Secondary capture: Linear issue links in a PR's comments.
 
-    The Linear/Jira reference on a GitHub PR frequently lives only in an
-    integration bot comment, not the PR body or branch. Only EXPLICIT linkage
-    signals are captured — a ``linear.app`` issue URL or a key after a linkage
-    keyword — so incidental ticket mentions can't mis-attribute the PR. Emitted
-    as ``extkey:`` edges; the keyword's intent is preserved (a blocking word
-    yields a non-inheritable relationship), with the URL link as inheritable
-    ``relates_to``. Used as a fallback to the authoritative Linear attachment.
+    PR comments are authored by anyone, so only the HIGH-CONFIDENCE signal is
+    trusted: an explicit ``linear.app/.../issue/KEY`` URL (the integration bot's
+    linkback). Natural-language keyword mentions (``see``/``fixes``/``part of``
+    …) are intentionally NOT captured from comments — a contributor could type
+    them to force an unrelated inheritance; the PR's own body still carries the
+    author's keyworded refs. Blocking phrasing immediately before the URL is
+    honoured (kept non-inheritable). Per key, the highest-risk relationship
+    across all comments wins. Fallback to the authoritative Linear attachment.
     """
-    # Collect every relationship signal per key, then keep the HIGHEST-RISK one
-    # so a blocking mention anywhere in the comments wins over a relates/URL
-    # mention of the same key (a blocking link must stay non-inheritable).
     _RANK = {"blocked_by": 3, "blocks": 2, "relates_to": 1}
     best: dict[str, tuple[str, str]] = {}  # key -> (relationship_type, raw)
-
-    def _consider(raw_key: str, relationship_type: str, raw: str) -> None:
-        key = raw_key.strip().upper()
-        if not key:
-            return
-        current = best.get(key)
-        if current is None or _RANK.get(relationship_type, 0) > _RANK.get(
-            current[0], 0
-        ):
-            best[key] = (relationship_type, raw)
 
     for body in comment_bodies:
         if not body:
             continue
         text = str(body)
-        # Linear bot/integration URL — an explicit link. Honour blocking
-        # phrasing immediately before the URL so "blocked by <linear url>"
-        # stays non-inheritable rather than defaulting to relates_to.
         for match in _COMMENT_LINEAR_URL_PATTERN.finditer(text):
             preceding = text[max(0, match.start() - 40) : match.start()].lower()
             relationship = "relates_to"
@@ -1037,14 +1016,12 @@ def extract_github_comment_dependencies(
                 relationship = "blocked_by"
             elif "blocks" in preceding:
                 relationship = "blocks"
-            _consider(match.group(1), relationship, "github_comment_linear_url")
-        # Explicit linkage keyword + key; intent preserved via keyword mapping.
-        for match in _COMMENT_KEYWORD_KEY_PATTERN.finditer(text):
-            _consider(
-                match.group(2),
-                _external_key_relationship(match.group(1)),
-                "github_comment",
-            )
+            key = match.group(1).strip().upper()
+            if not key:
+                continue
+            current = best.get(key)
+            if current is None or _RANK.get(relationship, 0) > _RANK.get(current[0], 0):
+                best[key] = (relationship, "github_comment_linear_url")
 
     return [
         WorkItemDependency(

--- a/src/dev_health_ops/providers/github/normalize.py
+++ b/src/dev_health_ops/providers/github/normalize.py
@@ -988,25 +988,37 @@ _COMMENT_LINEAR_URL_PATTERN = re.compile(
 )
 
 
+def _is_linear_integration_author(author_login: str | None) -> bool:
+    """True only for the Linear GitHub App actor (``linear[bot]``).
+
+    The ``[bot]`` suffix is reserved for GitHub App actors — a human cannot
+    register a login containing brackets — so this cannot be impersonated by a
+    contributor. Gating comment capture to this actor closes the forge-a-URL
+    vector: a normal user typing a ``linear.app`` URL in a comment is ignored.
+    """
+    login = (author_login or "").strip().lower()
+    return login.endswith("[bot]") and "linear" in login
+
+
 def extract_github_comment_dependencies(
-    *, work_item_id: str, comment_bodies: Sequence[str | None]
+    *, work_item_id: str, comments: Sequence[tuple[str | None, str | None]]
 ) -> list[WorkItemDependency]:
     """Secondary capture: Linear issue links in a PR's comments.
 
-    PR comments are authored by anyone, so only the HIGH-CONFIDENCE signal is
-    trusted: an explicit ``linear.app/.../issue/KEY`` URL (the integration bot's
-    linkback). Natural-language keyword mentions (``see``/``fixes``/``part of``
-    …) are intentionally NOT captured from comments — a contributor could type
-    them to force an unrelated inheritance; the PR's own body still carries the
-    author's keyworded refs. Blocking phrasing immediately before the URL is
-    honoured (kept non-inheritable). Per key, the highest-risk relationship
-    across all comments wins. Fallback to the authoritative Linear attachment.
+    ``comments`` is a sequence of ``(body, author_login)``. Only comments from
+    the Linear integration bot (``linear[bot]``) are trusted, and within those,
+    only an explicit ``linear.app/.../issue/KEY`` URL — natural-language
+    keywords are never captured from comments. Both guards exist because PR
+    comments are third-party authored: without the actor gate a contributor
+    could type a Linear URL to force an unrelated inheritance. Blocking phrasing
+    before the URL is honoured (kept non-inheritable); per key the highest-risk
+    relationship wins. Fallback to the authoritative Linear attachment.
     """
     _RANK = {"blocked_by": 3, "blocks": 2, "relates_to": 1}
     best: dict[str, tuple[str, str]] = {}  # key -> (relationship_type, raw)
 
-    for body in comment_bodies:
-        if not body:
+    for body, author_login in comments:
+        if not body or not _is_linear_integration_author(author_login):
             continue
         text = str(body)
         for match in _COMMENT_LINEAR_URL_PATTERN.finditer(text):

--- a/src/dev_health_ops/providers/github/normalize.py
+++ b/src/dev_health_ops/providers/github/normalize.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 from collections.abc import Sequence
 from datetime import datetime, timezone
@@ -988,16 +989,26 @@ _COMMENT_LINEAR_URL_PATTERN = re.compile(
 )
 
 
-def _is_linear_integration_author(author_login: str | None) -> bool:
-    """True only for the Linear GitHub App actor (``linear[bot]``).
+# Exact login(s) of the Linear GitHub App actor. An exact allowlist (not a
+# substring match) so another app like "linear-helper[bot]" cannot pass.
+# Overridable for self-managed Linear app installs via env.
+_LINEAR_LINKBACK_BOTS = frozenset(
+    b.strip().lower()
+    for b in (os.getenv("GITHUB_LINEAR_LINKBACK_BOTS") or "linear[bot]").split(",")
+    if b.strip()
+)
 
-    The ``[bot]`` suffix is reserved for GitHub App actors — a human cannot
-    register a login containing brackets — so this cannot be impersonated by a
-    contributor. Gating comment capture to this actor closes the forge-a-URL
+
+def _is_linear_integration_author(author_login: str | None) -> bool:
+    """True only for the exact Linear GitHub App actor login(s).
+
+    The ``[bot]`` login is reserved for GitHub App actors (a human cannot
+    register a bracketed login), and the match is EXACT against the trusted
+    allowlist — a different bot whose login merely contains ``linear`` is
+    rejected. Gating comment capture to this actor closes the forge-a-URL
     vector: a normal user typing a ``linear.app`` URL in a comment is ignored.
     """
-    login = (author_login or "").strip().lower()
-    return login.endswith("[bot]") and "linear" in login
+    return (author_login or "").strip().lower() in _LINEAR_LINKBACK_BOTS
 
 
 def extract_github_comment_dependencies(

--- a/src/dev_health_ops/providers/github/normalize.py
+++ b/src/dev_health_ops/providers/github/normalize.py
@@ -1007,23 +1007,21 @@ def extract_github_comment_dependencies(
     yields a non-inheritable relationship), with the URL link as inheritable
     ``relates_to``. Used as a fallback to the authoritative Linear attachment.
     """
-    deps: list[WorkItemDependency] = []
-    seen: set[str] = set()
+    # Collect every relationship signal per key, then keep the HIGHEST-RISK one
+    # so a blocking mention anywhere in the comments wins over a relates/URL
+    # mention of the same key (a blocking link must stay non-inheritable).
+    _RANK = {"blocked_by": 3, "blocks": 2, "relates_to": 1}
+    best: dict[str, tuple[str, str]] = {}  # key -> (relationship_type, raw)
 
-    def _emit(raw_key: str, relationship_type: str, raw: str) -> None:
+    def _consider(raw_key: str, relationship_type: str, raw: str) -> None:
         key = raw_key.strip().upper()
-        if not key or key in seen:
+        if not key:
             return
-        seen.add(key)
-        deps.append(
-            WorkItemDependency(
-                source_work_item_id=work_item_id,
-                target_work_item_id=f"extkey:{key}",
-                relationship_type=relationship_type,
-                relationship_type_raw=raw,
-                last_synced=datetime.now(timezone.utc),
-            )
-        )
+        current = best.get(key)
+        if current is None or _RANK.get(relationship_type, 0) > _RANK.get(
+            current[0], 0
+        ):
+            best[key] = (relationship_type, raw)
 
     for body in comment_bodies:
         if not body:
@@ -1039,15 +1037,25 @@ def extract_github_comment_dependencies(
                 relationship = "blocked_by"
             elif "blocks" in preceding:
                 relationship = "blocks"
-            _emit(match.group(1), relationship, "github_comment_linear_url")
+            _consider(match.group(1), relationship, "github_comment_linear_url")
         # Explicit linkage keyword + key; intent preserved via keyword mapping.
         for match in _COMMENT_KEYWORD_KEY_PATTERN.finditer(text):
-            _emit(
+            _consider(
                 match.group(2),
                 _external_key_relationship(match.group(1)),
                 "github_comment",
             )
-    return deps
+
+    return [
+        WorkItemDependency(
+            source_work_item_id=work_item_id,
+            target_work_item_id=f"extkey:{key}",
+            relationship_type=relationship_type,
+            relationship_type_raw=raw,
+            last_synced=datetime.now(timezone.utc),
+        )
+        for key, (relationship_type, raw) in best.items()
+    ]
 
 
 def enrich_work_item_with_priority(

--- a/src/dev_health_ops/providers/github/normalize.py
+++ b/src/dev_health_ops/providers/github/normalize.py
@@ -979,41 +979,65 @@ def extract_github_dependencies(
     return dependencies
 
 
-# Bare external (Linear/Jira) issue keys as they appear in a PR comment — e.g.
-# the Linear integration bot's "CHAOS-2400" linkback. Uppercase-only to avoid
-# matching version-ish tokens; resolution still drops keys with no matching
-# issue, so over-capture is harmless.
-_EXTERNAL_KEY_COMMENT_PATTERN = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")
+# A Linear issue link in a PR comment is only captured from an EXPLICIT linkage
+# signal, never a bare token: a ``linear.app/.../issue/KEY`` URL (the integration
+# bot's linkback) or a key preceded by a linkage keyword. This avoids turning an
+# incidental ticket mention (a security id, an unrelated Jira reference) into an
+# inheritable team edge.
+_COMMENT_LINEAR_URL_PATTERN = re.compile(
+    r"linear\.app/[^/\s]+/issue/([A-Za-z][A-Za-z0-9]+-\d+)", re.IGNORECASE
+)
+_COMMENT_KEYWORD_KEY_PATTERN = re.compile(
+    r"(depends\s+on|blocked\s+by|blocks|fixes|closes|resolves|relates\s+to|"
+    r"part\s+of|linked\s+to|see)\s*:?\s*([A-Za-z][A-Za-z0-9]+-\d+)\b",
+    re.IGNORECASE,
+)
 
 
 def extract_github_comment_dependencies(
     *, work_item_id: str, comment_bodies: Sequence[str | None]
 ) -> list[WorkItemDependency]:
-    """Secondary capture: external issue keys mentioned in a PR's comments.
+    """Secondary capture: external issue links in a PR's comments.
 
     The Linear/Jira reference on a GitHub PR frequently lives only in an
-    integration bot comment, not the PR body or branch. Emitted as ``extkey:``
-    edges (inheritable ``relates_to``) so the PR can inherit the linked issue's
-    team when the authoritative Linear-attachment edge is unavailable.
+    integration bot comment, not the PR body or branch. Only EXPLICIT linkage
+    signals are captured — a ``linear.app`` issue URL or a key after a linkage
+    keyword — so incidental ticket mentions can't mis-attribute the PR. Emitted
+    as ``extkey:`` edges; the keyword's intent is preserved (a blocking word
+    yields a non-inheritable relationship), with the URL link as inheritable
+    ``relates_to``. Used as a fallback to the authoritative Linear attachment.
     """
     deps: list[WorkItemDependency] = []
     seen: set[str] = set()
+
+    def _emit(raw_key: str, relationship_type: str, raw: str) -> None:
+        key = raw_key.strip().upper()
+        if not key or key in seen:
+            return
+        seen.add(key)
+        deps.append(
+            WorkItemDependency(
+                source_work_item_id=work_item_id,
+                target_work_item_id=f"extkey:{key}",
+                relationship_type=relationship_type,
+                relationship_type_raw=raw,
+                last_synced=datetime.now(timezone.utc),
+            )
+        )
+
     for body in comment_bodies:
         if not body:
             continue
-        for match in _EXTERNAL_KEY_COMMENT_PATTERN.finditer(str(body)):
-            key = match.group(1).strip().upper()
-            if key in seen:
-                continue
-            seen.add(key)
-            deps.append(
-                WorkItemDependency(
-                    source_work_item_id=work_item_id,
-                    target_work_item_id=f"extkey:{key}",
-                    relationship_type="relates_to",
-                    relationship_type_raw="github_comment",
-                    last_synced=datetime.now(timezone.utc),
-                )
+        text = str(body)
+        # Linear bot/integration URL — strongest signal, an explicit link.
+        for match in _COMMENT_LINEAR_URL_PATTERN.finditer(text):
+            _emit(match.group(1), "relates_to", "github_comment_linear_url")
+        # Explicit linkage keyword + key; intent preserved via keyword mapping.
+        for match in _COMMENT_KEYWORD_KEY_PATTERN.finditer(text):
+            _emit(
+                match.group(2),
+                _external_key_relationship(match.group(1)),
+                "github_comment",
             )
     return deps
 

--- a/src/dev_health_ops/providers/github/normalize.py
+++ b/src/dev_health_ops/providers/github/normalize.py
@@ -1029,9 +1029,17 @@ def extract_github_comment_dependencies(
         if not body:
             continue
         text = str(body)
-        # Linear bot/integration URL — strongest signal, an explicit link.
+        # Linear bot/integration URL — an explicit link. Honour blocking
+        # phrasing immediately before the URL so "blocked by <linear url>"
+        # stays non-inheritable rather than defaulting to relates_to.
         for match in _COMMENT_LINEAR_URL_PATTERN.finditer(text):
-            _emit(match.group(1), "relates_to", "github_comment_linear_url")
+            preceding = text[max(0, match.start() - 40) : match.start()].lower()
+            relationship = "relates_to"
+            if "blocked by" in preceding or "depends on" in preceding:
+                relationship = "blocked_by"
+            elif "blocks" in preceding:
+                relationship = "blocks"
+            _emit(match.group(1), relationship, "github_comment_linear_url")
         # Explicit linkage keyword + key; intent preserved via keyword mapping.
         for match in _COMMENT_KEYWORD_KEY_PATTERN.finditer(text):
             _emit(

--- a/src/dev_health_ops/providers/github/normalize.py
+++ b/src/dev_health_ops/providers/github/normalize.py
@@ -979,6 +979,45 @@ def extract_github_dependencies(
     return dependencies
 
 
+# Bare external (Linear/Jira) issue keys as they appear in a PR comment — e.g.
+# the Linear integration bot's "CHAOS-2400" linkback. Uppercase-only to avoid
+# matching version-ish tokens; resolution still drops keys with no matching
+# issue, so over-capture is harmless.
+_EXTERNAL_KEY_COMMENT_PATTERN = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")
+
+
+def extract_github_comment_dependencies(
+    *, work_item_id: str, comment_bodies: Sequence[str | None]
+) -> list[WorkItemDependency]:
+    """Secondary capture: external issue keys mentioned in a PR's comments.
+
+    The Linear/Jira reference on a GitHub PR frequently lives only in an
+    integration bot comment, not the PR body or branch. Emitted as ``extkey:``
+    edges (inheritable ``relates_to``) so the PR can inherit the linked issue's
+    team when the authoritative Linear-attachment edge is unavailable.
+    """
+    deps: list[WorkItemDependency] = []
+    seen: set[str] = set()
+    for body in comment_bodies:
+        if not body:
+            continue
+        for match in _EXTERNAL_KEY_COMMENT_PATTERN.finditer(str(body)):
+            key = match.group(1).strip().upper()
+            if key in seen:
+                continue
+            seen.add(key)
+            deps.append(
+                WorkItemDependency(
+                    source_work_item_id=work_item_id,
+                    target_work_item_id=f"extkey:{key}",
+                    relationship_type="relates_to",
+                    relationship_type_raw="github_comment",
+                    last_synced=datetime.now(timezone.utc),
+                )
+            )
+    return deps
+
+
 def enrich_work_item_with_priority(
     work_item: WorkItem,
     labels: Sequence[str],

--- a/src/dev_health_ops/providers/github/provider.py
+++ b/src/dev_health_ops/providers/github/provider.py
@@ -103,6 +103,7 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
             detect_github_reopen_events,
             detect_pr_attributions,
             enrich_work_item_with_priority,
+            extract_github_comment_dependencies,
             extract_github_dependencies,
             github_comment_to_interaction_event,
             github_issue_to_work_item,
@@ -356,6 +357,17 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                                 )
                                 if event:
                                     interactions.append(event)
+                            # Secondary link capture: a Linear/Jira key in a PR
+                            # comment (e.g. the integration bot linkback) when the
+                            # PR body/branch carries no reference.
+                            dependencies.extend(
+                                extract_github_comment_dependencies(
+                                    work_item_id=wi.work_item_id,
+                                    comment_bodies=[
+                                        getattr(c, "body", None) for c in comments
+                                    ],
+                                )
+                            )
                         except Exception as exc:
                             logger.debug(
                                 "GitHub: failed to fetch comments for PR %s: %s",

--- a/src/dev_health_ops/providers/github/provider.py
+++ b/src/dev_health_ops/providers/github/provider.py
@@ -357,14 +357,23 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                                 )
                                 if event:
                                     interactions.append(event)
-                            # Secondary link capture: a Linear/Jira key in a PR
-                            # comment (e.g. the integration bot linkback) when the
-                            # PR body/branch carries no reference.
+                            # Secondary link capture: the Linear integration
+                            # bot's linkback comment when the PR body/branch
+                            # carries no reference. Only that bot actor is
+                            # trusted (see extract_github_comment_dependencies).
                             dependencies.extend(
                                 extract_github_comment_dependencies(
                                     work_item_id=wi.work_item_id,
-                                    comment_bodies=[
-                                        getattr(c, "body", None) for c in comments
+                                    comments=[
+                                        (
+                                            getattr(c, "body", None),
+                                            getattr(
+                                                getattr(c, "user", None),
+                                                "login",
+                                                None,
+                                            ),
+                                        )
+                                        for c in comments
                                     ],
                                 )
                             )

--- a/src/dev_health_ops/providers/linear/client.py
+++ b/src/dev_health_ops/providers/linear/client.py
@@ -291,6 +291,24 @@ query Comments($issueId: String!, $first: Int!, $after: String) {
 }
 """
 
+ATTACHMENTS_QUERY = """
+query Attachments($issueId: String!, $first: Int!, $after: String) {
+  issue(id: $issueId) {
+    attachments(first: $first, after: $after) {
+      nodes {
+        id
+        url
+        sourceType
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+"""
+
 ISSUE_HISTORY_QUERY = """
 query IssueHistory($issueId: String!) {
   issue(id: $issueId) {
@@ -571,6 +589,37 @@ class LinearClient:
             cursor = page_info.get("endCursor")
 
         return comments[:limit]
+
+    def get_issue_attachments(
+        self,
+        issue_id: str,
+        *,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """Fetch ALL of an issue's attachments, paginating the connection.
+
+        Used only when the bulk ``ISSUES_QUERY`` page is truncated, so a linked
+        PR/MR attachment past the first page is still captured for team
+        inheritance instead of being silently dropped.
+        """
+        cursor: str | None = None
+        attachments: list[dict[str, Any]] = []
+        while len(attachments) < limit:
+            variables = {
+                "issueId": issue_id,
+                "first": min(100, limit - len(attachments)),
+                "after": cursor,
+            }
+            data = self._execute(ATTACHMENTS_QUERY, variables)
+            conn = (data.get("issue") or {}).get("attachments") or {}
+            attachments.extend(conn.get("nodes", []))
+            page_info = conn.get("pageInfo", {})
+            if not page_info.get("hasNextPage"):
+                break
+            cursor = page_info.get("endCursor")
+            if not cursor:
+                break
+        return attachments[:limit]
 
     def get_issue_history(self, issue_id: str) -> list[dict[str, Any]]:
         data = self._execute(ISSUE_HISTORY_QUERY, {"issueId": issue_id})

--- a/src/dev_health_ops/providers/linear/client.py
+++ b/src/dev_health_ops/providers/linear/client.py
@@ -137,6 +137,13 @@ query Issues($first: Int!, $after: String, $filter: IssueFilter) {
           }
         }
       }
+      attachments(first: 25) {
+        nodes {
+          id
+          url
+          sourceType
+        }
+      }
     }
     pageInfo {
       hasNextPage

--- a/src/dev_health_ops/providers/linear/client.py
+++ b/src/dev_health_ops/providers/linear/client.py
@@ -137,11 +137,14 @@ query Issues($first: Int!, $after: String, $filter: IssueFilter) {
           }
         }
       }
-      attachments(first: 25) {
+      attachments(first: 50) {
         nodes {
           id
           url
           sourceType
+        }
+        pageInfo {
+          hasNextPage
         }
       }
     }

--- a/src/dev_health_ops/providers/linear/normalize.py
+++ b/src/dev_health_ops/providers/linear/normalize.py
@@ -96,14 +96,25 @@ def _trusted_scm_hosts() -> frozenset[str]:
     return _PUBLIC_SCM_HOSTS | frozenset(extra)
 
 
-def _is_scm_attachment(url: str) -> bool:
-    """True only when the attachment URL is on a trusted GitHub/GitLab host.
+def _is_scm_attachment(url: str, source_type: str | None) -> bool:
+    """True only for an integration-created GitHub/GitLab PR/MR attachment.
 
-    Attachment ``url`` AND ``sourceType`` are user-controlled, so neither a
-    PR-shaped path (``/pull/N``) nor a forged ``sourceType`` may grant trust —
-    ``sourceType`` is advisory only. Trust is purely the URL host against an
-    allowlist (public SaaS + operator-configured self-hosted hosts).
+    Two factors are BOTH required, because attachment data is user-controlled:
+
+    - ``sourceType`` must name the GitHub/GitLab integration — this is the
+      provenance signal that distinguishes an integration-created PR/MR
+      attachment from a link a user pasted manually onto an issue; and
+    - the URL host must be on the trusted allowlist (public SaaS +
+      operator-configured) — so the link cannot be redirected to a forged host.
+
+    Requiring both means a casual user-added link is dropped (no integration
+    sourceType) and a forged host is dropped (not allowlisted). A user who links
+    a *real* PR on a trusted host to their own issue is the feature working as
+    intended, not a forgery.
     """
+    st = (source_type or "").lower()
+    if "github" not in st and "gitlab" not in st:
+        return False
     try:
         host = (urlsplit(str(url)).netloc or "").lower()
     except ValueError:
@@ -111,15 +122,17 @@ def _is_scm_attachment(url: str) -> bool:
     return host in _trusted_scm_hosts()
 
 
-def _work_item_id_from_pr_url(url: str | None) -> str | None:
+def _work_item_id_from_pr_url(
+    url: str | None, source_type: str | None = None
+) -> str | None:
     """Map a linked PR/MR URL to the matching work-item id, or None.
 
     Returns ``ghpr:{owner}/{repo}#{n}`` for a GitHub PR and
     ``gitlab:{project_path}!{n}`` for a GitLab MR — the same ids those
     providers mint — so the edge resolves directly to the PR/MR work item.
-    Rejects URLs whose host is not a trusted GitHub/GitLab host.
+    Requires both integration ``sourceType`` provenance and a trusted host.
     """
-    if not url or not _is_scm_attachment(url):
+    if not url or not _is_scm_attachment(url, source_type):
         return None
     try:
         path = urlsplit(str(url)).path
@@ -150,7 +163,7 @@ def extract_linear_dependencies(
     seen: set[str] = set()
     attachments = _get(issue, "attachments", "nodes") or []
     for att in attachments:
-        pr_id = _work_item_id_from_pr_url(_get(att, "url"))
+        pr_id = _work_item_id_from_pr_url(_get(att, "url"), _get(att, "sourceType"))
         if not pr_id or pr_id in seen:
             continue
         seen.add(pr_id)

--- a/src/dev_health_ops/providers/linear/normalize.py
+++ b/src/dev_health_ops/providers/linear/normalize.py
@@ -74,14 +74,23 @@ _GITHUB_PR_URL_RE = re.compile(r"^/(?P<repo>.+?)/pull/(?P<num>\d+)/?$")
 _GITLAB_MR_URL_RE = re.compile(r"^/(?P<project>.+?)/-/merge_requests/(?P<num>\d+)/?$")
 
 
+# Public SaaS hosts where a ``/pull/N`` / ``/-/merge_requests/N`` URL can only
+# be a real GitHub/GitLab PR/MR. Exact-match (anchored) — a substring check
+# would accept a forged host like ``github.evil.example``.
+_PUBLIC_SCM_HOSTS = frozenset(
+    {"github.com", "www.github.com", "gitlab.com", "www.gitlab.com"}
+)
+
+
 def _is_scm_attachment(url: str, source_type: str | None) -> bool:
-    """True only when the attachment plausibly comes from GitHub/GitLab.
+    """True only when the attachment is a trustworthy GitHub/GitLab PR/MR link.
 
     Attachment data is user-controlled, so a non-code URL that merely contains
-    ``/pull/N`` (e.g. ``https://evil.example/x/pull/1``) must not be trusted to
-    mint a PR id. Require the integration ``sourceType`` or the URL host to
-    indicate GitHub/GitLab (covers github.com, gitlab.com, and self-hosted/
-    Enterprise hosts named ``github.*`` / ``gitlab.*``).
+    ``/pull/N`` (e.g. ``https://github.evil.example/x/pull/1``) must not be
+    trusted to mint a PR id. Trust requires either an exact **public** SCM host
+    or the Linear integration's ``sourceType`` (the latter is how self-hosted /
+    Enterprise instances on arbitrary hosts are recognised — there is no
+    hostname-only way to distinguish a real self-hosted host from a forged one).
     """
     st = (source_type or "").lower()
     if "github" in st or "gitlab" in st:
@@ -90,7 +99,7 @@ def _is_scm_attachment(url: str, source_type: str | None) -> bool:
         host = (urlsplit(str(url)).netloc or "").lower()
     except ValueError:
         return False
-    return "github" in host or "gitlab" in host
+    return host in _PUBLIC_SCM_HOSTS
 
 
 def _work_item_id_from_pr_url(

--- a/src/dev_health_ops/providers/linear/normalize.py
+++ b/src/dev_health_ops/providers/linear/normalize.py
@@ -74,14 +74,36 @@ _GITHUB_PR_URL_RE = re.compile(r"^/(?P<repo>.+?)/pull/(?P<num>\d+)/?$")
 _GITLAB_MR_URL_RE = re.compile(r"^/(?P<project>.+?)/-/merge_requests/(?P<num>\d+)/?$")
 
 
-def _work_item_id_from_pr_url(url: str | None) -> str | None:
+def _is_scm_attachment(url: str, source_type: str | None) -> bool:
+    """True only when the attachment plausibly comes from GitHub/GitLab.
+
+    Attachment data is user-controlled, so a non-code URL that merely contains
+    ``/pull/N`` (e.g. ``https://evil.example/x/pull/1``) must not be trusted to
+    mint a PR id. Require the integration ``sourceType`` or the URL host to
+    indicate GitHub/GitLab (covers github.com, gitlab.com, and self-hosted/
+    Enterprise hosts named ``github.*`` / ``gitlab.*``).
+    """
+    st = (source_type or "").lower()
+    if "github" in st or "gitlab" in st:
+        return True
+    try:
+        host = (urlsplit(str(url)).netloc or "").lower()
+    except ValueError:
+        return False
+    return "github" in host or "gitlab" in host
+
+
+def _work_item_id_from_pr_url(
+    url: str | None, source_type: str | None = None
+) -> str | None:
     """Map a linked PR/MR URL to the matching work-item id, or None.
 
     Returns ``ghpr:{owner}/{repo}#{n}`` for a GitHub PR and
     ``gitlab:{project_path}!{n}`` for a GitLab MR — the same ids those
     providers mint — so the edge resolves directly to the PR/MR work item.
+    Rejects URLs whose host/sourceType is not a GitHub/GitLab source.
     """
-    if not url:
+    if not url or not _is_scm_attachment(url, source_type):
         return None
     try:
         path = urlsplit(str(url)).path
@@ -112,7 +134,7 @@ def extract_linear_dependencies(
     seen: set[str] = set()
     attachments = _get(issue, "attachments", "nodes") or []
     for att in attachments:
-        pr_id = _work_item_id_from_pr_url(_get(att, "url"))
+        pr_id = _work_item_id_from_pr_url(_get(att, "url"), _get(att, "sourceType"))
         if not pr_id or pr_id in seen:
             continue
         seen.add(pr_id)

--- a/src/dev_health_ops/providers/linear/normalize.py
+++ b/src/dev_health_ops/providers/linear/normalize.py
@@ -124,6 +124,15 @@ def extract_linear_dependencies(
                 relationship_type_raw="linear_attachment",
             )
         )
+    # The attachments connection is fetched as a single page; if it is
+    # truncated, a PR/MR link beyond the page is silently missed. Surface that
+    # so a missed link is observable rather than a silent attribution gap.
+    if _get(issue, "attachments", "pageInfo", "hasNextPage"):
+        logger.warning(
+            "Linear issue %s has more attachments than fetched; a PR/MR link "
+            "may be missed for team inheritance.",
+            work_item_id,
+        )
     return deps
 
 

--- a/src/dev_health_ops/providers/linear/normalize.py
+++ b/src/dev_health_ops/providers/linear/normalize.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import urlsplit
 
 from dev_health_ops.models.work_items import (
     Sprint,
     WorkItem,
+    WorkItemDependency,
     WorkItemInteractionEvent,
     WorkItemReopenEvent,
     WorkItemStatusCategory,
@@ -59,6 +62,69 @@ def _status_from_state_type(state_type: str | None) -> WorkItemStatusCategory:
     if not state_type:
         return "unknown"
     return LINEAR_STATE_TYPE_MAP.get(state_type.lower(), "unknown")
+
+
+# Linear's GitHub/GitLab integration records a linked PR/MR as an issue
+# *attachment* whose ``url`` points at the PR/MR. This is the authoritative
+# link (Linear -> source control), unlike a PR body/branch which often only
+# references the issue in a bot comment. The URL host+path is provider-agnostic:
+# GitHub uses ``/{owner}/{repo}/pull/{n}`` (any host, incl. Enterprise),
+# GitLab uses ``/{group/.../project}/-/merge_requests/{n}`` (incl. self-hosted).
+_GITHUB_PR_URL_RE = re.compile(r"^/(?P<repo>.+?)/pull/(?P<num>\d+)/?$")
+_GITLAB_MR_URL_RE = re.compile(r"^/(?P<project>.+?)/-/merge_requests/(?P<num>\d+)/?$")
+
+
+def _work_item_id_from_pr_url(url: str | None) -> str | None:
+    """Map a linked PR/MR URL to the matching work-item id, or None.
+
+    Returns ``ghpr:{owner}/{repo}#{n}`` for a GitHub PR and
+    ``gitlab:{project_path}!{n}`` for a GitLab MR — the same ids those
+    providers mint — so the edge resolves directly to the PR/MR work item.
+    """
+    if not url:
+        return None
+    try:
+        path = urlsplit(str(url)).path
+    except ValueError:
+        return None
+    if not path:
+        return None
+    gh = _GITHUB_PR_URL_RE.match(path)
+    if gh:
+        return f"ghpr:{gh.group('repo')}#{gh.group('num')}"
+    gl = _GITLAB_MR_URL_RE.match(path)
+    if gl:
+        return f"gitlab:{gl.group('project')}!{gl.group('num')}"
+    return None
+
+
+def extract_linear_dependencies(
+    *, issue: Any, work_item_id: str
+) -> list[WorkItemDependency]:
+    """Emit PR/MR -> Linear-issue edges from an issue's linked attachments.
+
+    The PR/MR is the EDGE SOURCE and the Linear issue (which carries the team)
+    is the TARGET, so the linked-issue inheritance resolver attributes the
+    unassigned PR/MR to this issue's team. Provider-agnostic via URL parsing;
+    non-PR attachments (Figma, Slack, plain links) are ignored.
+    """
+    deps: list[WorkItemDependency] = []
+    seen: set[str] = set()
+    attachments = _get(issue, "attachments", "nodes") or []
+    for att in attachments:
+        pr_id = _work_item_id_from_pr_url(_get(att, "url"))
+        if not pr_id or pr_id in seen:
+            continue
+        seen.add(pr_id)
+        deps.append(
+            WorkItemDependency(
+                source_work_item_id=pr_id,
+                target_work_item_id=work_item_id,
+                relationship_type="relates_to",
+                relationship_type_raw="linear_attachment",
+            )
+        )
+    return deps
 
 
 def _type_from_labels(labels: list[str]) -> WorkItemType:

--- a/src/dev_health_ops/providers/linear/normalize.py
+++ b/src/dev_health_ops/providers/linear/normalize.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 from datetime import datetime, timezone
 from typing import Any
@@ -82,37 +83,43 @@ _PUBLIC_SCM_HOSTS = frozenset(
 )
 
 
-def _is_scm_attachment(url: str, source_type: str | None) -> bool:
-    """True only when the attachment is a trustworthy GitHub/GitLab PR/MR link.
+def _trusted_scm_hosts() -> frozenset[str]:
+    """Public SCM hosts plus any operator-configured self-hosted hosts.
 
-    Attachment data is user-controlled, so a non-code URL that merely contains
-    ``/pull/N`` (e.g. ``https://github.evil.example/x/pull/1``) must not be
-    trusted to mint a PR id. Trust requires either an exact **public** SCM host
-    or the Linear integration's ``sourceType`` (the latter is how self-hosted /
-    Enterprise instances on arbitrary hosts are recognised — there is no
-    hostname-only way to distinguish a real self-hosted host from a forged one).
+    Self-hosted GitHub Enterprise / GitLab live on arbitrary hosts that cannot
+    be trusted by name alone, so they must be opted in explicitly via the
+    ``LINEAR_TRUSTED_SCM_HOSTS`` env var (comma-separated). That is operator
+    config, NOT user-controlled attachment data.
     """
-    st = (source_type or "").lower()
-    if "github" in st or "gitlab" in st:
-        return True
+    raw = os.getenv("LINEAR_TRUSTED_SCM_HOSTS", "")
+    extra = {h.strip().lower() for h in raw.split(",") if h.strip()}
+    return _PUBLIC_SCM_HOSTS | frozenset(extra)
+
+
+def _is_scm_attachment(url: str) -> bool:
+    """True only when the attachment URL is on a trusted GitHub/GitLab host.
+
+    Attachment ``url`` AND ``sourceType`` are user-controlled, so neither a
+    PR-shaped path (``/pull/N``) nor a forged ``sourceType`` may grant trust —
+    ``sourceType`` is advisory only. Trust is purely the URL host against an
+    allowlist (public SaaS + operator-configured self-hosted hosts).
+    """
     try:
         host = (urlsplit(str(url)).netloc or "").lower()
     except ValueError:
         return False
-    return host in _PUBLIC_SCM_HOSTS
+    return host in _trusted_scm_hosts()
 
 
-def _work_item_id_from_pr_url(
-    url: str | None, source_type: str | None = None
-) -> str | None:
+def _work_item_id_from_pr_url(url: str | None) -> str | None:
     """Map a linked PR/MR URL to the matching work-item id, or None.
 
     Returns ``ghpr:{owner}/{repo}#{n}`` for a GitHub PR and
     ``gitlab:{project_path}!{n}`` for a GitLab MR — the same ids those
     providers mint — so the edge resolves directly to the PR/MR work item.
-    Rejects URLs whose host/sourceType is not a GitHub/GitLab source.
+    Rejects URLs whose host is not a trusted GitHub/GitLab host.
     """
-    if not url or not _is_scm_attachment(url, source_type):
+    if not url or not _is_scm_attachment(url):
         return None
     try:
         path = urlsplit(str(url)).path
@@ -143,7 +150,7 @@ def extract_linear_dependencies(
     seen: set[str] = set()
     attachments = _get(issue, "attachments", "nodes") or []
     for att in attachments:
-        pr_id = _work_item_id_from_pr_url(_get(att, "url"), _get(att, "sourceType"))
+        pr_id = _work_item_id_from_pr_url(_get(att, "url"))
         if not pr_id or pr_id in seen:
             continue
         seen.add(pr_id)

--- a/src/dev_health_ops/providers/linear/provider.py
+++ b/src/dev_health_ops/providers/linear/provider.py
@@ -38,7 +38,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
     Capabilities:
     - work_items: yes (issues)
     - status_transitions: yes (via issue history)
-    - dependencies: no (Linear doesn't expose blocking relationships in API)
+    - dependencies: yes (PR/MR links via issue attachments; not blocking relations)
     - interactions: yes (via comments)
     - sprints: yes (via cycles)
     - reopen_events: yes (via issue history)

--- a/src/dev_health_ops/providers/linear/provider.py
+++ b/src/dev_health_ops/providers/linear/provider.py
@@ -98,13 +98,22 @@ class LinearProvider(ProviderWithClient[LinearClient]):
         ) -> list[WorkItemDependency]:
             # PR/MR -> issue edges from linked attachments. If the issue's
             # attachment page was truncated, fetch the full set so a link past
-            # the first page is not silently dropped.
+            # the first page is not silently dropped — best-effort: a transient
+            # fetch error must not abort the whole sync, so fall back to the
+            # first page already in hand.
+            source: dict = issue
             att_page = issue.get("attachments") or {}
             if (att_page.get("pageInfo") or {}).get("hasNextPage") and issue.get("id"):
-                full = client.get_issue_attachments(str(issue["id"]))
-                source: dict = {"attachments": {"nodes": full}}
-            else:
-                source = issue
+                try:
+                    full = client.get_issue_attachments(str(issue["id"]))
+                    source = {"attachments": {"nodes": full}}
+                except Exception as exc:
+                    logger.warning(
+                        "Linear: failed to fetch full attachments for %s; "
+                        "using first page only (%s)",
+                        work_item_id,
+                        exc,
+                    )
             return extract_linear_dependencies(issue=source, work_item_id=work_item_id)
 
         fetch_comments = _env_flag("LINEAR_FETCH_COMMENTS", True)

--- a/src/dev_health_ops/providers/linear/provider.py
+++ b/src/dev_health_ops/providers/linear/provider.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from dev_health_ops.models.work_items import (
     Sprint,
     WorkItem,
+    WorkItemDependency,
     WorkItemInteractionEvent,
     WorkItemReopenEvent,
     WorkItemStatusTransition,
@@ -55,7 +56,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
     capabilities = ProviderCapabilities(
         work_items=True,
         status_transitions=True,
-        dependencies=False,  # Linear API doesn't expose blocking relations well
+        dependencies=True,  # PR/MR links via issue attachments (not blocking relations)
         interactions=True,
         sprints=True,
         reopen_events=True,
@@ -72,6 +73,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
             merged.reopen_events.extend(batch.reopen_events)
             merged.interactions.extend(batch.interactions)
             merged.sprints.extend(batch.sprints)
+            merged.dependencies.extend(batch.dependencies)
         return merged
 
     def iter_ingest(self, ctx: IngestionContext) -> Iterable[ProviderBatch]:
@@ -83,6 +85,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
         """
         from dev_health_ops.providers.linear.normalize import (
             detect_linear_reopen_events,
+            extract_linear_dependencies,
             linear_comment_to_interaction_event,
             linear_cycle_to_sprint,
             linear_issue_to_work_item,
@@ -167,6 +170,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                     page_transitions: list[WorkItemStatusTransition] = []
                     page_reopen_events: list[WorkItemReopenEvent] = []
                     page_interactions: list[WorkItemInteractionEvent] = []
+                    page_dependencies: list[WorkItemDependency] = []
 
                     for issue in issues_page:
                         if ctx.limit is not None and fetched_count >= ctx.limit:
@@ -187,6 +191,11 @@ class LinearProvider(ProviderWithClient[LinearClient]):
 
                         page_items.append(wi)
                         page_transitions.extend(wi_transitions)
+                        page_dependencies.extend(
+                            extract_linear_dependencies(
+                                issue=issue, work_item_id=wi.work_item_id
+                            )
+                        )
 
                         if history:
                             page_reopen_events.extend(
@@ -215,12 +224,14 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                         or page_transitions
                         or page_reopen_events
                         or page_interactions
+                        or page_dependencies
                     ):
                         yield ProviderBatch(
                             work_items=page_items,
                             status_transitions=page_transitions,
                             interactions=page_interactions,
                             reopen_events=page_reopen_events,
+                            dependencies=page_dependencies,
                         )
                         yielded_batch = True
                         fetched_transitions += len(page_transitions)
@@ -242,6 +253,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                         page_transitions = []
                         page_reopen_events = []
                         page_interactions = []
+                        page_dependencies = []
                         for issue in fallback_issues:
                             if ctx.limit is not None and fetched_count >= ctx.limit:
                                 break
@@ -261,6 +273,11 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                             )
                             page_items.append(wi)
                             page_transitions.extend(wi_transitions)
+                            page_dependencies.extend(
+                                extract_linear_dependencies(
+                                    issue=issue, work_item_id=wi.work_item_id
+                                )
+                            )
                             if history:
                                 page_reopen_events.extend(
                                     detect_linear_reopen_events(
@@ -287,12 +304,14 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                             or page_transitions
                             or page_reopen_events
                             or page_interactions
+                            or page_dependencies
                         ):
                             yield ProviderBatch(
                                 work_items=page_items,
                                 status_transitions=page_transitions,
                                 interactions=page_interactions,
                                 reopen_events=page_reopen_events,
+                                dependencies=page_dependencies,
                             )
                             yielded_batch = True
                             fetched_transitions += len(page_transitions)

--- a/src/dev_health_ops/providers/linear/provider.py
+++ b/src/dev_health_ops/providers/linear/provider.py
@@ -93,6 +93,20 @@ class LinearProvider(ProviderWithClient[LinearClient]):
 
         client = self._make_client()
 
+        def _issue_dependencies(
+            issue: dict, work_item_id: str
+        ) -> list[WorkItemDependency]:
+            # PR/MR -> issue edges from linked attachments. If the issue's
+            # attachment page was truncated, fetch the full set so a link past
+            # the first page is not silently dropped.
+            att_page = issue.get("attachments") or {}
+            if (att_page.get("pageInfo") or {}).get("hasNextPage") and issue.get("id"):
+                full = client.get_issue_attachments(str(issue["id"]))
+                source: dict = {"attachments": {"nodes": full}}
+            else:
+                source = issue
+            return extract_linear_dependencies(issue=source, work_item_id=work_item_id)
+
         fetch_comments = _env_flag("LINEAR_FETCH_COMMENTS", True)
         fetch_history = _env_flag("LINEAR_FETCH_HISTORY", True)
         fetch_cycles = _env_flag("LINEAR_FETCH_CYCLES", True)
@@ -192,9 +206,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                         page_items.append(wi)
                         page_transitions.extend(wi_transitions)
                         page_dependencies.extend(
-                            extract_linear_dependencies(
-                                issue=issue, work_item_id=wi.work_item_id
-                            )
+                            _issue_dependencies(issue, wi.work_item_id)
                         )
 
                         if history:
@@ -274,9 +286,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                             page_items.append(wi)
                             page_transitions.extend(wi_transitions)
                             page_dependencies.extend(
-                                extract_linear_dependencies(
-                                    issue=issue, work_item_id=wi.work_item_id
-                                )
+                                _issue_dependencies(issue, wi.work_item_id)
                             )
                             if history:
                                 page_reopen_events.extend(

--- a/tests/test_linear_provider.py
+++ b/tests/test_linear_provider.py
@@ -635,7 +635,9 @@ class TestLinearProviderRegistration:
         provider = LinearProvider()
         assert provider.capabilities.work_items is True
         assert provider.capabilities.status_transitions is True
-        assert provider.capabilities.dependencies is False
+        # Linear emits PR/MR -> issue edges from issue attachments (links to
+        # source control), so it now reports the dependencies capability.
+        assert provider.capabilities.dependencies is True
         assert provider.capabilities.interactions is True
         assert provider.capabilities.sprints is True
         assert provider.capabilities.reopen_events is True

--- a/tests/test_pr_issue_link_capture.py
+++ b/tests/test_pr_issue_link_capture.py
@@ -46,17 +46,12 @@ def _wi(work_item_id: str, provider: str, **kw: object) -> WorkItem:
 # --------------------------------------------------------------------------- #
 
 
-def test_pr_url_parser_maps_github_and_gitlab() -> None:
+def test_pr_url_parser_maps_public_github_and_gitlab() -> None:
     assert (
         _work_item_id_from_pr_url("https://github.com/full-chaos/ops/pull/921")
         == "ghpr:full-chaos/ops#921"
     )
-    # GitHub Enterprise host requires the integration sourceType to be trusted.
-    assert (
-        _work_item_id_from_pr_url("https://github.example.com/o/r/pull/7", "github")
-        == "ghpr:o/r#7"
-    )
-    # GitLab MR, nested groups, any host.
+    # GitLab MR, nested groups, public host.
     assert (
         _work_item_id_from_pr_url(
             "https://gitlab.com/group/sub/project/-/merge_requests/45"
@@ -76,34 +71,43 @@ def test_pr_url_parser_ignores_non_pr_urls() -> None:
         assert _work_item_id_from_pr_url(url) is None
 
 
-def test_pr_url_parser_rejects_non_scm_host_unless_sourcetype() -> None:
-    # A non-public host with a PR-shaped path is not trusted by host alone...
+def test_pr_url_parser_trusts_only_allowlisted_hosts() -> None:
+    # Non-public hosts are rejected — including a forged github-substring host —
+    # because sourceType/host shape are user-controlled and not trustworthy.
     assert _work_item_id_from_pr_url("https://evil.example/owner/repo/pull/1") is None
-    # ...and a forged github-substring host is likewise rejected (no exact match).
     assert _work_item_id_from_pr_url("https://github.evil.example/o/r/pull/1") is None
-    # The integration sourceType authorises a self-hosted/Enterprise host.
     assert (
-        _work_item_id_from_pr_url(
-            "https://gitlab.acme.internal/g/p/-/merge_requests/3", "gitlab"
-        )
+        _work_item_id_from_pr_url("https://gitlab.acme.internal/g/p/-/merge_requests/3")
+        is None
+    )
+
+
+def test_pr_url_parser_allows_operator_configured_self_hosted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Self-hosted hosts are trusted ONLY via operator config, never by URL shape.
+    monkeypatch.setenv("LINEAR_TRUSTED_SCM_HOSTS", "gitlab.acme.internal, ghe.corp")
+    assert (
+        _work_item_id_from_pr_url("https://gitlab.acme.internal/g/p/-/merge_requests/3")
         == "gitlab:g/p!3"
     )
-    # Public hosts are trusted by exact host.
-    assert _work_item_id_from_pr_url("https://github.com/o/r/pull/9") == "ghpr:o/r#9"
+    assert _work_item_id_from_pr_url("https://ghe.corp/o/r/pull/8") == "ghpr:o/r#8"
 
 
-def test_linear_attachment_gated_by_sourcetype_or_host() -> None:
-    # A non-SCM attachment whose URL happens to look like a PR is dropped.
+def test_linear_attachment_sourcetype_does_not_grant_trust() -> None:
+    # A crafted attachment URL on a non-allowlisted host must be dropped even
+    # when sourceType claims github — sourceType is advisory only.
     issue = {
         "attachments": {
             "nodes": [
-                {"url": "https://notion.so/o/r/pull/9", "sourceType": "notion"},
+                {"url": "https://notion.so/o/r/pull/9", "sourceType": "github"},
             ]
         }
     }
     assert extract_linear_dependencies(issue=issue, work_item_id="linear:CHAOS-1") == []
-    # Same path but flagged as a github source -> captured.
-    issue["attachments"]["nodes"][0]["sourceType"] = "github"
+    # A public-host attachment is captured regardless of (absent) sourceType.
+    issue["attachments"]["nodes"][0]["url"] = "https://github.com/o/r/pull/9"
+    del issue["attachments"]["nodes"][0]["sourceType"]
     deps = extract_linear_dependencies(issue=issue, work_item_id="linear:CHAOS-1")
     assert [d.source_work_item_id for d in deps] == ["ghpr:o/r#9"]
 
@@ -160,16 +164,20 @@ def test_linear_attachment_edge_drives_pr_inheritance_direct_target() -> None:
 # --------------------------------------------------------------------------- #
 
 
-def test_github_comment_capture_from_linear_url_only() -> None:
-    # Only the linear.app integration URL is trusted; a bare keyword mention in
-    # a (third-party) comment is intentionally NOT captured.
+BOT = "linear[bot]"  # the Linear GitHub App actor login
+
+
+def test_github_comment_capture_from_bot_linear_url() -> None:
+    # Only the bot's linear.app URL is trusted.
     deps = extract_github_comment_dependencies(
         work_item_id="ghpr:o/r#1",
-        comment_bodies=[
-            "Linked to https://linear.app/full-chaos/issue/CHAOS-2400/title",
-            None,
-            "Also fixes PROJ-7 per discussion",  # keyword, no URL -> ignored
-            "see https://linear.app/x/issue/CHAOS-2400/dup",  # duplicate -> one edge
+        comments=[
+            (
+                "Linked to https://linear.app/full-chaos/issue/CHAOS-2400/title",
+                BOT,
+            ),
+            (None, BOT),
+            ("see https://linear.app/x/issue/CHAOS-2400/dup", BOT),  # dup -> one
         ],
     )
     assert [d.target_work_item_id for d in deps] == ["extkey:CHAOS-2400"]
@@ -177,24 +185,27 @@ def test_github_comment_capture_from_linear_url_only() -> None:
     assert deps[0].relationship_type_raw == "github_comment_linear_url"
 
 
-def test_github_comment_capture_ignores_bare_keyword_mentions() -> None:
-    # Without a linear.app URL, nothing is captured even with linkage keywords —
-    # comments are third-party and keyword text is forgeable.
+def test_github_comment_capture_ignores_non_bot_author() -> None:
+    # A human contributor posting a Linear URL must NOT create an edge — that is
+    # the forge-a-URL vector the actor gate closes.
     deps = extract_github_comment_dependencies(
         work_item_id="ghpr:o/r#1",
-        comment_bodies=["This is blocked by CHAOS-9", "Fixes CHAOS-10 too"],
+        comments=[
+            ("https://linear.app/x/issue/CHAOS-9/foo", "sneaky-user"),
+            ("https://linear.app/x/issue/CHAOS-9/foo", "evil[bot]"),  # wrong bot
+        ],
     )
     assert deps == []
 
 
 def test_github_comment_blocking_wins_over_relates_for_same_key() -> None:
-    # Two URL links for the SAME key, one with blocking context, must resolve to
+    # Two bot URL links for the SAME key, one with blocking context, resolve to
     # the blocking (non-inheritable) relationship.
     deps = extract_github_comment_dependencies(
         work_item_id="ghpr:o/r#1",
-        comment_bodies=[
-            "Tracked in https://linear.app/x/issue/CHAOS-1/foo",
-            "Update: blocked by https://linear.app/x/issue/CHAOS-1/bar",
+        comments=[
+            ("Tracked in https://linear.app/x/issue/CHAOS-1/foo", BOT),
+            ("Update: blocked by https://linear.app/x/issue/CHAOS-1/bar", BOT),
         ],
     )
     assert len(deps) == 1
@@ -203,12 +214,13 @@ def test_github_comment_blocking_wins_over_relates_for_same_key() -> None:
 
 
 def test_github_comment_blocking_intent_preserved_for_url_links() -> None:
-    # "blocked by <linear url>" must stay non-inheritable, not default to
-    # relates_to just because the reference is a URL.
     deps = extract_github_comment_dependencies(
         work_item_id="ghpr:o/r#1",
-        comment_bodies=[
-            "This PR is blocked by https://linear.app/x/issue/ABC-123/needs-infra"
+        comments=[
+            (
+                "This PR is blocked by https://linear.app/x/issue/ABC-123/infra",
+                BOT,
+            )
         ],
     )
     assert len(deps) == 1
@@ -253,16 +265,16 @@ def test_client_paginates_issue_attachments(
     assert calls[1] is not None and calls[1]["after"] == "c1"
 
 
-def test_github_comment_capture_ignores_incidental_and_versionish_tokens() -> None:
-    # Bare mentions with no explicit linkage signal must NOT be captured —
-    # otherwise an unrelated ticket reference could mis-attribute the PR.
+def test_github_comment_capture_ignores_bare_tokens_even_from_bot() -> None:
+    # Even a bot comment only yields edges from an explicit linear.app URL — a
+    # bare token / incidental mention is never captured.
     deps = extract_github_comment_dependencies(
         work_item_id="ghpr:o/r#1",
-        comment_bodies=[
-            "Reminds me of OTHER-123 from last quarter",  # incidental mention
-            "bumped to v1-2 and python-3",
-            "deploy-9 done",
-            "CVE-2024 patched",
+        comments=[
+            ("Reminds me of OTHER-123 from last quarter", BOT),
+            ("bumped to v1-2 and python-3", BOT),
+            ("This is blocked by CHAOS-9", BOT),  # keyword, no URL -> ignored
+            ("CVE-2024 patched", BOT),
         ],
     )
     assert deps == []

--- a/tests/test_pr_issue_link_capture.py
+++ b/tests/test_pr_issue_link_capture.py
@@ -1,0 +1,147 @@
+"""Tests for capturing PR/MR <-> issue links that drive team inheritance.
+
+The authoritative link is Linear -> source control (the issue's attachment
+points at the GitHub PR / GitLab MR). On the GitHub side the reference often
+lives only in a bot comment. These tests cover both capture paths and confirm
+the captured edge drives the existing linked-issue team inheritance.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from dev_health_ops.metrics.compute_work_items import build_linked_issue_team_resolver
+from dev_health_ops.models.work_items import WorkItem
+from dev_health_ops.providers.github.normalize import (
+    extract_github_comment_dependencies,
+)
+from dev_health_ops.providers.linear.normalize import (
+    _work_item_id_from_pr_url,
+    extract_linear_dependencies,
+)
+from dev_health_ops.providers.teams import ProjectKeyTeamResolver
+
+NOW = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+def _wi(work_item_id: str, provider: str, **kw: object) -> WorkItem:
+    defaults: dict[str, object] = dict(
+        title="t",
+        type="task",
+        status="done",
+        status_raw=None,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    defaults.update(kw)
+    return WorkItem(work_item_id=work_item_id, provider=provider, **defaults)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# URL -> work_item_id parser (provider-agnostic)
+# --------------------------------------------------------------------------- #
+
+
+def test_pr_url_parser_maps_github_and_gitlab() -> None:
+    assert (
+        _work_item_id_from_pr_url("https://github.com/full-chaos/ops/pull/921")
+        == "ghpr:full-chaos/ops#921"
+    )
+    # GitHub Enterprise host -> same owner/repo id (host-agnostic).
+    assert (
+        _work_item_id_from_pr_url("https://github.example.com/o/r/pull/7")
+        == "ghpr:o/r#7"
+    )
+    # GitLab MR, nested groups, any host.
+    assert (
+        _work_item_id_from_pr_url(
+            "https://gitlab.com/group/sub/project/-/merge_requests/45"
+        )
+        == "gitlab:group/sub/project!45"
+    )
+
+
+def test_pr_url_parser_ignores_non_pr_urls() -> None:
+    for url in (
+        "https://www.figma.com/file/abc",
+        "https://linear.app/team/issue/CHAOS-1",
+        "https://github.com/owner/repo/issues/5",  # issue, not a PR
+        "",
+        None,
+    ):
+        assert _work_item_id_from_pr_url(url) is None
+
+
+# --------------------------------------------------------------------------- #
+# Linear attachment capture (primary)
+# --------------------------------------------------------------------------- #
+
+
+def test_linear_attachment_emits_pr_to_issue_edge() -> None:
+    issue = {
+        "attachments": {
+            "nodes": [
+                {"url": "https://github.com/full-chaos/ops/pull/12"},
+                {"url": "https://www.notion.so/some-doc"},  # ignored
+            ]
+        }
+    }
+    deps = extract_linear_dependencies(issue=issue, work_item_id="linear:CHAOS-2400")
+    assert len(deps) == 1
+    edge = deps[0]
+    # PR is the SOURCE, issue (with the team) is the TARGET.
+    assert edge.source_work_item_id == "ghpr:full-chaos/ops#12"
+    assert edge.target_work_item_id == "linear:CHAOS-2400"
+    assert edge.relationship_type == "relates_to"  # inheritance-safe
+    assert edge.relationship_type_raw == "linear_attachment"
+
+
+def test_linear_attachment_edge_drives_pr_inheritance_direct_target() -> None:
+    # The target is the real linear: id (no extkey ambiguity), so the resolver
+    # attributes the PR to the issue's team with the builder unchanged.
+    linear = _wi("linear:CHAOS-2400", "linear", project_key="CHAOS")
+    pr = _wi("ghpr:full-chaos/ops#12", "github", type="pr", project_id="full-chaos/ops")
+    deps = extract_linear_dependencies(
+        issue={
+            "attachments": {
+                "nodes": [{"url": "https://github.com/full-chaos/ops/pull/12"}]
+            }
+        },
+        work_item_id="linear:CHAOS-2400",
+    )
+    resolver = build_linked_issue_team_resolver(
+        work_items=[linear, pr],
+        dependencies=deps,
+        project_key_resolver=ProjectKeyTeamResolver(
+            project_key_to_team={"CHAOS": ("CHAOS", "Chaos Team")}
+        ),
+    )
+    assert resolver.resolve(pr.work_item_id) == ("CHAOS", "Chaos Team")
+
+
+# --------------------------------------------------------------------------- #
+# GitHub PR comment capture (secondary)
+# --------------------------------------------------------------------------- #
+
+
+def test_github_comment_capture_extracts_and_dedupes_keys() -> None:
+    deps = extract_github_comment_dependencies(
+        work_item_id="ghpr:o/r#1",
+        comment_bodies=[
+            "Linear: CHAOS-2400 linked this PR",
+            None,
+            "follow-up on CHAOS-2400",  # duplicate key -> one edge
+            "no key in this comment",
+        ],
+    )
+    assert [d.target_work_item_id for d in deps] == ["extkey:CHAOS-2400"]
+    assert deps[0].relationship_type == "relates_to"
+    assert deps[0].relationship_type_raw == "github_comment"
+
+
+def test_github_comment_capture_ignores_lowercase_versionish_tokens() -> None:
+    deps = extract_github_comment_dependencies(
+        work_item_id="ghpr:o/r#1",
+        comment_bodies=["bumped to v1-2 and python-3", "deploy-9 done"],
+    )
+    assert deps == []

--- a/tests/test_pr_issue_link_capture.py
+++ b/tests/test_pr_issue_link_capture.py
@@ -47,14 +47,16 @@ def _wi(work_item_id: str, provider: str, **kw: object) -> WorkItem:
 
 
 def test_pr_url_parser_maps_public_github_and_gitlab() -> None:
-    assert (
-        _work_item_id_from_pr_url("https://github.com/full-chaos/ops/pull/921")
-        == "ghpr:full-chaos/ops#921"
-    )
-    # GitLab MR, nested groups, public host.
+    # Both factors required: integration sourceType + trusted host.
     assert (
         _work_item_id_from_pr_url(
-            "https://gitlab.com/group/sub/project/-/merge_requests/45"
+            "https://github.com/full-chaos/ops/pull/921", "github"
+        )
+        == "ghpr:full-chaos/ops#921"
+    )
+    assert (
+        _work_item_id_from_pr_url(
+            "https://gitlab.com/group/sub/project/-/merge_requests/45", "gitlab"
         )
         == "gitlab:group/sub/project!45"
     )
@@ -68,16 +70,34 @@ def test_pr_url_parser_ignores_non_pr_urls() -> None:
         "",
         None,
     ):
-        assert _work_item_id_from_pr_url(url) is None
+        assert _work_item_id_from_pr_url(url, "github") is None
+
+
+def test_pr_url_parser_requires_integration_sourcetype() -> None:
+    # A real public-host PR URL without the integration sourceType (e.g. a link
+    # a user pasted manually) is NOT trusted.
+    assert _work_item_id_from_pr_url("https://github.com/o/r/pull/9") is None
+    assert _work_item_id_from_pr_url("https://github.com/o/r/pull/9", "link") is None
+    assert (
+        _work_item_id_from_pr_url("https://github.com/o/r/pull/9", "github")
+        == "ghpr:o/r#9"
+    )
 
 
 def test_pr_url_parser_trusts_only_allowlisted_hosts() -> None:
-    # Non-public hosts are rejected — including a forged github-substring host —
-    # because sourceType/host shape are user-controlled and not trustworthy.
-    assert _work_item_id_from_pr_url("https://evil.example/owner/repo/pull/1") is None
-    assert _work_item_id_from_pr_url("https://github.evil.example/o/r/pull/1") is None
+    # Even WITH an integration sourceType, a non-allowlisted host is rejected —
+    # including a forged github-substring host.
     assert (
-        _work_item_id_from_pr_url("https://gitlab.acme.internal/g/p/-/merge_requests/3")
+        _work_item_id_from_pr_url("https://evil.example/o/r/pull/1", "github") is None
+    )
+    assert (
+        _work_item_id_from_pr_url("https://github.evil.example/o/r/pull/1", "github")
+        is None
+    )
+    assert (
+        _work_item_id_from_pr_url(
+            "https://gitlab.acme.internal/g/p/-/merge_requests/3", "gitlab"
+        )
         is None
     )
 
@@ -85,30 +105,38 @@ def test_pr_url_parser_trusts_only_allowlisted_hosts() -> None:
 def test_pr_url_parser_allows_operator_configured_self_hosted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Self-hosted hosts are trusted ONLY via operator config, never by URL shape.
+    # Self-hosted hosts are trusted ONLY via operator config (plus sourceType).
     monkeypatch.setenv("LINEAR_TRUSTED_SCM_HOSTS", "gitlab.acme.internal, ghe.corp")
     assert (
-        _work_item_id_from_pr_url("https://gitlab.acme.internal/g/p/-/merge_requests/3")
+        _work_item_id_from_pr_url(
+            "https://gitlab.acme.internal/g/p/-/merge_requests/3", "gitlab"
+        )
         == "gitlab:g/p!3"
     )
-    assert _work_item_id_from_pr_url("https://ghe.corp/o/r/pull/8") == "ghpr:o/r#8"
+    assert (
+        _work_item_id_from_pr_url("https://ghe.corp/o/r/pull/8", "github")
+        == "ghpr:o/r#8"
+    )
 
 
-def test_linear_attachment_sourcetype_does_not_grant_trust() -> None:
-    # A crafted attachment URL on a non-allowlisted host must be dropped even
-    # when sourceType claims github — sourceType is advisory only.
-    issue = {
+def test_linear_attachment_requires_sourcetype_and_host() -> None:
+    # Integration sourceType on a non-allowlisted host -> dropped (host fails).
+    bad_host = {
         "attachments": {
-            "nodes": [
-                {"url": "https://notion.so/o/r/pull/9", "sourceType": "github"},
-            ]
+            "nodes": [{"url": "https://notion.so/o/r/pull/9", "sourceType": "github"}]
         }
     }
-    assert extract_linear_dependencies(issue=issue, work_item_id="linear:CHAOS-1") == []
-    # A public-host attachment is captured regardless of (absent) sourceType.
-    issue["attachments"]["nodes"][0]["url"] = "https://github.com/o/r/pull/9"
-    del issue["attachments"]["nodes"][0]["sourceType"]
-    deps = extract_linear_dependencies(issue=issue, work_item_id="linear:CHAOS-1")
+    assert extract_linear_dependencies(issue=bad_host, work_item_id="linear:C-1") == []
+    # Trusted host but no integration sourceType (manual link) -> dropped.
+    no_st = {"attachments": {"nodes": [{"url": "https://github.com/o/r/pull/9"}]}}
+    assert extract_linear_dependencies(issue=no_st, work_item_id="linear:C-1") == []
+    # Both present -> captured.
+    ok = {
+        "attachments": {
+            "nodes": [{"url": "https://github.com/o/r/pull/9", "sourceType": "github"}]
+        }
+    }
+    deps = extract_linear_dependencies(issue=ok, work_item_id="linear:C-1")
     assert [d.source_work_item_id for d in deps] == ["ghpr:o/r#9"]
 
 
@@ -121,7 +149,10 @@ def test_linear_attachment_emits_pr_to_issue_edge() -> None:
     issue = {
         "attachments": {
             "nodes": [
-                {"url": "https://github.com/full-chaos/ops/pull/12"},
+                {
+                    "url": "https://github.com/full-chaos/ops/pull/12",
+                    "sourceType": "github",
+                },
                 {"url": "https://www.notion.so/some-doc"},  # ignored
             ]
         }
@@ -144,7 +175,12 @@ def test_linear_attachment_edge_drives_pr_inheritance_direct_target() -> None:
     deps = extract_linear_dependencies(
         issue={
             "attachments": {
-                "nodes": [{"url": "https://github.com/full-chaos/ops/pull/12"}]
+                "nodes": [
+                    {
+                        "url": "https://github.com/full-chaos/ops/pull/12",
+                        "sourceType": "github",
+                    }
+                ]
             }
         },
         work_item_id="linear:CHAOS-2400",

--- a/tests/test_pr_issue_link_capture.py
+++ b/tests/test_pr_issue_link_capture.py
@@ -124,24 +124,44 @@ def test_linear_attachment_edge_drives_pr_inheritance_direct_target() -> None:
 # --------------------------------------------------------------------------- #
 
 
-def test_github_comment_capture_extracts_and_dedupes_keys() -> None:
+def test_github_comment_capture_from_linear_url_and_keyword() -> None:
     deps = extract_github_comment_dependencies(
         work_item_id="ghpr:o/r#1",
         comment_bodies=[
-            "Linear: CHAOS-2400 linked this PR",
+            "Linked to https://linear.app/full-chaos/issue/CHAOS-2400/title",
             None,
-            "follow-up on CHAOS-2400",  # duplicate key -> one edge
-            "no key in this comment",
+            "Also fixes PROJ-7 per discussion",
+            "see https://linear.app/x/issue/CHAOS-2400/dup",  # duplicate -> one edge
         ],
     )
-    assert [d.target_work_item_id for d in deps] == ["extkey:CHAOS-2400"]
-    assert deps[0].relationship_type == "relates_to"
-    assert deps[0].relationship_type_raw == "github_comment"
+    targets = {d.target_work_item_id for d in deps}
+    assert targets == {"extkey:CHAOS-2400", "extkey:PROJ-7"}
+    rel = {d.target_work_item_id: d.relationship_type for d in deps}
+    assert rel["extkey:CHAOS-2400"] == "relates_to"  # URL link
+    assert rel["extkey:PROJ-7"] == "relates_to"  # 'fixes'
 
 
-def test_github_comment_capture_ignores_lowercase_versionish_tokens() -> None:
+def test_github_comment_capture_preserves_blocking_intent() -> None:
+    # A blocking keyword must NOT yield an inheritable edge.
     deps = extract_github_comment_dependencies(
         work_item_id="ghpr:o/r#1",
-        comment_bodies=["bumped to v1-2 and python-3", "deploy-9 done"],
+        comment_bodies=["This is blocked by CHAOS-9 until infra lands"],
+    )
+    assert len(deps) == 1
+    assert deps[0].target_work_item_id == "extkey:CHAOS-9"
+    assert deps[0].relationship_type == "blocked_by"  # excluded by the resolver
+
+
+def test_github_comment_capture_ignores_incidental_and_versionish_tokens() -> None:
+    # Bare mentions with no explicit linkage signal must NOT be captured —
+    # otherwise an unrelated ticket reference could mis-attribute the PR.
+    deps = extract_github_comment_dependencies(
+        work_item_id="ghpr:o/r#1",
+        comment_bodies=[
+            "Reminds me of OTHER-123 from last quarter",  # incidental mention
+            "bumped to v1-2 and python-3",
+            "deploy-9 done",
+            "CVE-2024 patched",
+        ],
     )
     assert deps == []

--- a/tests/test_pr_issue_link_capture.py
+++ b/tests/test_pr_issue_link_capture.py
@@ -9,12 +9,16 @@ the captured edge drives the existing linked-issue team inheritance.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
+
+import pytest
 
 from dev_health_ops.metrics.compute_work_items import build_linked_issue_team_resolver
 from dev_health_ops.models.work_items import WorkItem
 from dev_health_ops.providers.github.normalize import (
     extract_github_comment_dependencies,
 )
+from dev_health_ops.providers.linear.client import LinearAuth, LinearClient
 from dev_health_ops.providers.linear.normalize import (
     _work_item_id_from_pr_url,
     extract_linear_dependencies,
@@ -70,6 +74,37 @@ def test_pr_url_parser_ignores_non_pr_urls() -> None:
         None,
     ):
         assert _work_item_id_from_pr_url(url) is None
+
+
+def test_pr_url_parser_rejects_non_scm_host_unless_sourcetype() -> None:
+    # A non-GitHub/GitLab host with a PR-shaped path must NOT be trusted...
+    assert _work_item_id_from_pr_url("https://evil.example/owner/repo/pull/1") is None
+    # ...unless the integration sourceType marks it as a GitHub/GitLab link.
+    assert (
+        _work_item_id_from_pr_url("https://evil.example/owner/repo/pull/1", "github")
+        == "ghpr:owner/repo#1"
+    )
+    # Self-hosted hosts named github.*/gitlab.* are trusted by host alone.
+    assert (
+        _work_item_id_from_pr_url("https://gitlab.acme.internal/g/p/-/merge_requests/3")
+        == "gitlab:g/p!3"
+    )
+
+
+def test_linear_attachment_gated_by_sourcetype_or_host() -> None:
+    # A non-SCM attachment whose URL happens to look like a PR is dropped.
+    issue = {
+        "attachments": {
+            "nodes": [
+                {"url": "https://notion.so/o/r/pull/9", "sourceType": "notion"},
+            ]
+        }
+    }
+    assert extract_linear_dependencies(issue=issue, work_item_id="linear:CHAOS-1") == []
+    # Same path but flagged as a github source -> captured.
+    issue["attachments"]["nodes"][0]["sourceType"] = "github"
+    deps = extract_linear_dependencies(issue=issue, work_item_id="linear:CHAOS-1")
+    assert [d.source_work_item_id for d in deps] == ["ghpr:o/r#9"]
 
 
 # --------------------------------------------------------------------------- #
@@ -150,6 +185,57 @@ def test_github_comment_capture_preserves_blocking_intent() -> None:
     assert len(deps) == 1
     assert deps[0].target_work_item_id == "extkey:CHAOS-9"
     assert deps[0].relationship_type == "blocked_by"  # excluded by the resolver
+
+
+def test_github_comment_blocking_intent_preserved_for_url_links() -> None:
+    # "blocked by <linear url>" must stay non-inheritable, not default to
+    # relates_to just because the reference is a URL.
+    deps = extract_github_comment_dependencies(
+        work_item_id="ghpr:o/r#1",
+        comment_bodies=[
+            "This PR is blocked by https://linear.app/x/issue/ABC-123/needs-infra"
+        ],
+    )
+    assert len(deps) == 1
+    assert deps[0].target_work_item_id == "extkey:ABC-123"
+    assert deps[0].relationship_type == "blocked_by"
+
+
+def test_client_paginates_issue_attachments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # When an issue's attachment page is truncated, the full set is fetched so a
+    # PR/MR link past the first page is not silently dropped.
+    client = LinearClient(auth=LinearAuth(api_key="test-key"))
+    pages = [
+        {
+            "issue": {
+                "attachments": {
+                    "nodes": [{"url": "u1"}],
+                    "pageInfo": {"hasNextPage": True, "endCursor": "c1"},
+                }
+            }
+        },
+        {
+            "issue": {
+                "attachments": {
+                    "nodes": [{"url": "u2"}],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        },
+    ]
+    calls: list[dict[str, Any] | None] = []
+
+    def _fake_execute(query: str, variables: dict[str, Any] | None = None) -> Any:
+        calls.append(variables)
+        return pages[len(calls) - 1]
+
+    monkeypatch.setattr(client, "_execute", _fake_execute)
+    nodes = client.get_issue_attachments("issue-1")
+    assert [n["url"] for n in nodes] == ["u1", "u2"]
+    assert len(calls) == 2
+    assert calls[1] is not None and calls[1]["after"] == "c1"
 
 
 def test_github_comment_capture_ignores_incidental_and_versionish_tokens() -> None:

--- a/tests/test_pr_issue_link_capture.py
+++ b/tests/test_pr_issue_link_capture.py
@@ -51,9 +51,9 @@ def test_pr_url_parser_maps_github_and_gitlab() -> None:
         _work_item_id_from_pr_url("https://github.com/full-chaos/ops/pull/921")
         == "ghpr:full-chaos/ops#921"
     )
-    # GitHub Enterprise host -> same owner/repo id (host-agnostic).
+    # GitHub Enterprise host requires the integration sourceType to be trusted.
     assert (
-        _work_item_id_from_pr_url("https://github.example.com/o/r/pull/7")
+        _work_item_id_from_pr_url("https://github.example.com/o/r/pull/7", "github")
         == "ghpr:o/r#7"
     )
     # GitLab MR, nested groups, any host.
@@ -77,18 +77,19 @@ def test_pr_url_parser_ignores_non_pr_urls() -> None:
 
 
 def test_pr_url_parser_rejects_non_scm_host_unless_sourcetype() -> None:
-    # A non-GitHub/GitLab host with a PR-shaped path must NOT be trusted...
+    # A non-public host with a PR-shaped path is not trusted by host alone...
     assert _work_item_id_from_pr_url("https://evil.example/owner/repo/pull/1") is None
-    # ...unless the integration sourceType marks it as a GitHub/GitLab link.
+    # ...and a forged github-substring host is likewise rejected (no exact match).
+    assert _work_item_id_from_pr_url("https://github.evil.example/o/r/pull/1") is None
+    # The integration sourceType authorises a self-hosted/Enterprise host.
     assert (
-        _work_item_id_from_pr_url("https://evil.example/owner/repo/pull/1", "github")
-        == "ghpr:owner/repo#1"
-    )
-    # Self-hosted hosts named github.*/gitlab.* are trusted by host alone.
-    assert (
-        _work_item_id_from_pr_url("https://gitlab.acme.internal/g/p/-/merge_requests/3")
+        _work_item_id_from_pr_url(
+            "https://gitlab.acme.internal/g/p/-/merge_requests/3", "gitlab"
+        )
         == "gitlab:g/p!3"
     )
+    # Public hosts are trusted by exact host.
+    assert _work_item_id_from_pr_url("https://github.com/o/r/pull/9") == "ghpr:o/r#9"
 
 
 def test_linear_attachment_gated_by_sourcetype_or_host() -> None:
@@ -159,42 +160,41 @@ def test_linear_attachment_edge_drives_pr_inheritance_direct_target() -> None:
 # --------------------------------------------------------------------------- #
 
 
-def test_github_comment_capture_from_linear_url_and_keyword() -> None:
+def test_github_comment_capture_from_linear_url_only() -> None:
+    # Only the linear.app integration URL is trusted; a bare keyword mention in
+    # a (third-party) comment is intentionally NOT captured.
     deps = extract_github_comment_dependencies(
         work_item_id="ghpr:o/r#1",
         comment_bodies=[
             "Linked to https://linear.app/full-chaos/issue/CHAOS-2400/title",
             None,
-            "Also fixes PROJ-7 per discussion",
+            "Also fixes PROJ-7 per discussion",  # keyword, no URL -> ignored
             "see https://linear.app/x/issue/CHAOS-2400/dup",  # duplicate -> one edge
         ],
     )
-    targets = {d.target_work_item_id for d in deps}
-    assert targets == {"extkey:CHAOS-2400", "extkey:PROJ-7"}
-    rel = {d.target_work_item_id: d.relationship_type for d in deps}
-    assert rel["extkey:CHAOS-2400"] == "relates_to"  # URL link
-    assert rel["extkey:PROJ-7"] == "relates_to"  # 'fixes'
+    assert [d.target_work_item_id for d in deps] == ["extkey:CHAOS-2400"]
+    assert deps[0].relationship_type == "relates_to"
+    assert deps[0].relationship_type_raw == "github_comment_linear_url"
 
 
-def test_github_comment_capture_preserves_blocking_intent() -> None:
-    # A blocking keyword must NOT yield an inheritable edge.
+def test_github_comment_capture_ignores_bare_keyword_mentions() -> None:
+    # Without a linear.app URL, nothing is captured even with linkage keywords —
+    # comments are third-party and keyword text is forgeable.
     deps = extract_github_comment_dependencies(
         work_item_id="ghpr:o/r#1",
-        comment_bodies=["This is blocked by CHAOS-9 until infra lands"],
+        comment_bodies=["This is blocked by CHAOS-9", "Fixes CHAOS-10 too"],
     )
-    assert len(deps) == 1
-    assert deps[0].target_work_item_id == "extkey:CHAOS-9"
-    assert deps[0].relationship_type == "blocked_by"  # excluded by the resolver
+    assert deps == []
 
 
 def test_github_comment_blocking_wins_over_relates_for_same_key() -> None:
-    # A URL relates-link and a later blocking keyword for the SAME key must
-    # resolve to the blocking (non-inheritable) relationship, not relates_to.
+    # Two URL links for the SAME key, one with blocking context, must resolve to
+    # the blocking (non-inheritable) relationship.
     deps = extract_github_comment_dependencies(
         work_item_id="ghpr:o/r#1",
         comment_bodies=[
             "Tracked in https://linear.app/x/issue/CHAOS-1/foo",
-            "Update: this is blocked by CHAOS-1 until the migration lands",
+            "Update: blocked by https://linear.app/x/issue/CHAOS-1/bar",
         ],
     )
     assert len(deps) == 1

--- a/tests/test_pr_issue_link_capture.py
+++ b/tests/test_pr_issue_link_capture.py
@@ -187,6 +187,21 @@ def test_github_comment_capture_preserves_blocking_intent() -> None:
     assert deps[0].relationship_type == "blocked_by"  # excluded by the resolver
 
 
+def test_github_comment_blocking_wins_over_relates_for_same_key() -> None:
+    # A URL relates-link and a later blocking keyword for the SAME key must
+    # resolve to the blocking (non-inheritable) relationship, not relates_to.
+    deps = extract_github_comment_dependencies(
+        work_item_id="ghpr:o/r#1",
+        comment_bodies=[
+            "Tracked in https://linear.app/x/issue/CHAOS-1/foo",
+            "Update: this is blocked by CHAOS-1 until the migration lands",
+        ],
+    )
+    assert len(deps) == 1
+    assert deps[0].target_work_item_id == "extkey:CHAOS-1"
+    assert deps[0].relationship_type == "blocked_by"
+
+
 def test_github_comment_blocking_intent_preserved_for_url_links() -> None:
     # "blocked by <linear url>" must stay non-inheritable, not default to
     # relates_to just because the reference is a URL.


### PR DESCRIPTION
## Why

Follow-up to #921 (linked-issue team inheritance). That PR captured the PR↔issue link only from a **GitHub PR's body/branch** — but for the common **Linear + GitHub/GitLab** setup the authoritative link runs the *other way*:

- The **Linear issue** points at the PR/MR via its integration **attachment** (Linear → source control).
- On the **GitHub** side the reference often lives only in an integration **bot comment**, not the PR body or branch.

So `extract_github_dependencies` (body/branch only) produced **no edge** for most PRs, leaving them `unassigned` and the investment allocation coverage/chord empty even after backfilling. This PR captures the link from where it actually lives.

## What

Two new capture paths feed the **same, unchanged** inheritance resolver from #921:

### Primary — Linear issue attachments
- `ISSUES_QUERY` now fetches `attachments { url sourceType }`.
- `extract_linear_dependencies` parses each attachment URL — **provider-agnostic**: GitHub `…/pull/N` → `ghpr:owner/repo#N`, GitLab `…/-/merge_requests/N` → `gitlab:path!N` (any host, incl. Enterprise / self-hosted) — and emits a **direct** edge `source=<pr/mr id> → target=linear:<ISSUE>`.
- The PR is the **source** and the team-bearing Linear issue is the **target**, so the existing *source-inherits-from-target* resolver attributes the PR **with no changes**. Using the real `linear:` id as the target avoids extkey ambiguity entirely.
- `LinearProvider` now reports the `dependencies` capability and threads edges through `iter_ingest` → `job_work_items`.

### Secondary — GitHub PR comments
- `extract_github_comment_dependencies` scans the already-fetched PR comments for external issue keys (uppercase-only, deduped) → `extkey:` edges, as a fallback when no Linear attachment exists.

### Tertiary — body/branch (unchanged)
The original body/branch extkey capture stays as a third fallback (catches Linear "create branch" PRs).

## Edge direction (the key design point)
A Linear-attachment edge is `Linear(team) → PR(no team)` in concept, but we emit it as `source=PR, target=Linear` so the unassigned PR is the *source* that inherits from the team-bearing *target* — fitting the existing resolver/donor/tenant/bounded machinery untouched.

## Tests
`tests/test_pr_issue_link_capture.py`: URL parser (GitHub/GitLab/Enterprise/non-PR), Linear-attachment edge emission, end-to-end inheritance via attachment, GitHub comment extraction + dedup + version-token rejection. Updated the Linear `dependencies` capability assertion. Provider + inheritance suites green (140 passed locally).

## Validation note
Confirmed against Linear's API that linked PRs/MRs are modeled as issue **attachments** (url-keyed, provider-agnostic), per [Linear's GitLab integration](https://linear.app/integrations/gitlab) and [attachments docs](https://linear.app/developers/attachments).

---

## Trust model & adversarial-review summary

Ran `/codex:adversarial-review` to convergence (6 rounds, ~15 findings fixed). Rounds 1–3 were genuine correctness bugs (non-deterministic donor selection, missing `org_id` stamping, unbounded/abort-prone reads, stale-edge supersession). Rounds 4–6 hardened input provenance. Final trust model for the capture inputs:

- **Linear attachments (primary):** require BOTH the integration `sourceType` (github/gitlab) **and** an allowlisted host (public SaaS + operator-configured `LINEAR_TRUSTED_SCM_HOSTS`). Blocks forged hosts and manually-pasted links.
- **GitHub comments (secondary):** only the exact `linear[bot]` actor (env-overridable `GITHUB_LINEAR_LINKBACK_BOTS`), only `linear.app` issue URLs, with blocking intent preserved.
- **PR body/branch (tertiary):** the PR author's own declaration about their own PR.

**Accepted residual (by design, not a vulnerability):** a trusted org member who links a *real* PR to their own Linear issue causes that PR to inherit the issue's team. That is the feature working as intended on collaborative same-org work-tracking data — there is no privilege escalation or cross-tenant exposure (tenant isolation is enforced separately). This is analytics attribution, not an authorization boundary.
