### PR TITLE
docs(architecture): team-attribution recovery runbook + capture sources

### DIFF
--- a/docs/architecture/team-attribution.md
+++ b/docs/architecture/team-attribution.md
@@ -98,6 +98,26 @@ sequenceDiagram
 `job_daily` (the scheduled recompute) follows the same build → compute path but
 **reads** persisted edges instead of extracting them — see §4.
 
+### Link capture sources & precedence
+
+A PR/MR only inherits a team if an edge to its issue exists. The link is
+captured from where it actually lives, in descending order of authority (PR
+#924 — the primary/secondary sources; #921 added the tertiary):
+
+| Tier | Source | Trust gate | Edge |
+|---|---|---|---|
+| Primary | **Linear issue attachment** (the integration's PR/MR link) | integration `sourceType` **AND** allowlisted host (public SaaS + `LINEAR_TRUSTED_SCM_HOSTS`) | `ghpr:…`/`gitlab:… → linear:KEY` (direct id) |
+| Secondary | **GitHub PR comment** (the Linear bot's linkback) | exact `linear[bot]` actor (`GITHUB_LINEAR_LINKBACK_BOTS`) + `linear.app` URL | `ghpr:… → extkey:KEY` |
+| Tertiary | **PR body / head branch** (the author's own ref) | magic-word / Linear branch convention | `ghpr:… → extkey:KEY` |
+
+The authoritative link runs **Linear → source control** (the issue's attachment
+points at the PR/MR), so the edge is emitted with the PR/MR as the *source* and
+the team-bearing issue as the *target* — fitting the source-inherits-from-target
+resolver unchanged. **Accepted residual:** a trusted org member linking a real
+PR to their own issue drives that PR's attribution — the feature working as
+intended on collaborative data, not a forgery (same-org analytics, not an authz
+boundary).
+
 ---
 
 ## 3. Data flow & relationships (ER)
@@ -214,6 +234,70 @@ flowchart LR
 
 ---
 
+## 5. Recovery / backfill runbook
+
+After deploying the inheritance + capture changes, existing orgs need a
+**recompute** to populate `team_id` on historical rows — there is **no schema
+migration**, only a data replay.
+
+### Why a plain backfill is not enough
+
+The investment **allocation** views derive team at *query time*: the coverage %
+and team-exchange chord read `work_unit_investments` and **LEFT JOIN**
+`work_item_cycle_times` for `argMax(team_id, …)`. So three things must be true,
+and the backfill **runner only re-runs `run_work_items_sync_job` — it does NOT
+fan out** to the work-graph or investment jobs (only the live sync path chains
+those). They must be triggered explicitly.
+
+```mermaid
+flowchart TD
+    DEP["1. Merge + deploy (#921, #923, #924)"] --> SYNC
+    subgraph SYNC ["2. Work-items sync/backfill — ALL providers"]
+        L["Linear (issues + attachment edges)"]
+        G["GitHub / GitLab (PRs/MRs + comment/body edges)"]
+    end
+    SYNC --> CT["work_item_dependencies (extkey/attachment edges)<br/>+ work_item_cycle_times.team_id (inherited)"]
+    CT --> WG["3. work-graph build"]
+    WG --> IM["4. investment materialize (--force)"]
+    IM --> Q["5. allocation coverage % + chord<br/>recover via query-time join to cycle_times"]
+```
+
+### Ordered steps (per affected org)
+
+1. **Merge + deploy** #921 (mechanism), #923 (backfill CLI), #924 (capture).
+2. **Backfill all providers** — Linear **and** GitHub/GitLab. Linear-only does
+   nothing: the PR/MR rows and their edges come from the git providers, and the
+   donor issues come from Linear. A single `--provider all` run (or per-provider
+   with Linear synced so its issues are present) writes the edges and recomputes
+   `work_item_cycle_times.team_id`. The org is derived from the sync config
+   (#923), so `--org` is optional.
+3. **Work-graph build**, then
+4. **Investment materialize (`--force`)** — these rebuild `work_unit_investments`
+   + its `structural_evidence_json.issues` (the coverage join keys); the backfill
+   does not trigger them.
+5. **Verify & recover** — the coverage % and chord recover automatically via the
+   query-time join. Confirm the links were captured:
+
+   ```sql
+   SELECT relationship_type_raw, count()
+   FROM work_item_dependencies FINAL
+   WHERE org_id = {org}
+     AND relationship_type_raw IN
+         ('linear_attachment', 'github_comment_linear_url', 'external_issue_key')
+   GROUP BY relationship_type_raw
+   ```
+
+   Zero `linear_attachment` rows after a Linear backfill means the org's issues
+   carry no integration PR/MR attachments — there is then no link to inherit
+   from, and an empty chord is **correct** (data-driven), not a bug.
+
+> Exact CLI flags vary per command — confirm with `<cmd> --help`. The relevant
+> entry points: `sync work-items` / `backfill run` → `run_work_items_sync_job`;
+> `work-graph build` → `run_work_graph_build`; `investment materialize` →
+> `run_investment_materialize`; `metrics daily` → `run_daily_metrics`.
+
+---
+
 ## Source map
 
 | Concern | Location |
@@ -224,5 +308,8 @@ flowchart LR
 | Sync wiring | `metrics/job_work_items.py` |
 | Scheduled recompute wiring | `metrics/job_daily.py` |
 | Bounded donor/edge loads | `metrics/loaders/clickhouse.py` (`load_work_item_dependencies`, `load_work_item_dependencies_donors`) |
-| extkey capture | `providers/github/normalize.py`, `providers/gitlab/normalize.py` |
-| Tests | `tests/test_linked_issue_team_inheritance.py` |
+| Linear attachment capture (primary) | `providers/linear/normalize.py` (`extract_linear_dependencies`, `_is_scm_attachment`), `providers/linear/client.py` (`get_issue_attachments`) |
+| GitHub comment / body capture | `providers/github/normalize.py` (`extract_github_comment_dependencies`, `extract_github_dependencies`) |
+| GitLab capture | `providers/gitlab/normalize.py` |
+| Recovery runbook | §5 above; backfill `backfill/runner.py`, investment `workers/work_graph_tasks.py` |
+| Tests | `tests/test_linked_issue_team_inheritance.py`, `tests/test_pr_issue_link_capture.py` |


### PR DESCRIPTION
Extends `docs/architecture/team-attribution.md` (added in #921) with the operational runbook and the corrected capture model.

## What's added
- **§5 Recovery / backfill runbook** — the exact replay to recover `team_id` on existing orgs after deploy (no schema migration). Covers:
  - why a plain backfill is insufficient: the allocation coverage % + chord derive team at **query time** (LEFT JOIN `work_unit_investments` → `work_item_cycle_times`), and the backfill **runner only re-runs `run_work_items_sync_job`** — it does **not** fan out to work-graph build / investment materialize;
  - the **all-providers** requirement (Linear-only does nothing — PR/MR rows + edges come from the git providers);
  - the ordered steps, a **verification query** on `work_item_dependencies`, and the job entry points;
  - a flowchart.
- **"Link capture sources & precedence" table** — documents the corrected capture from **#924** (Linear attachment primary → GitHub bot comment → PR body/branch), each with its trust gate, plus the accepted same-org residual.
- Refreshed **source map**.

## Note
The "Link capture sources" table documents **PR #924** (open). The runbook and everything else reflect merged behavior (#921, #923). Docs-link-check passes; 5 mermaid diagrams (sequence/flowchart/ER/component + runbook flowchart) render.