### PR TITLE
feat(workers): daily scheduled investment materialization (CHAOS-2439)

### DIFF
--- a/src/dev_health_ops/metrics/sinks/clickhouse/core.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/core.py
@@ -188,18 +188,38 @@ class ClickHouseCore(BaseMetricsSink):
             row[0] for row in (getattr(applied_result, "result_rows", []) or [])
         )
 
-        # Collect all migration files
+        # Collect all migration files in apply order.
         migration_files = sorted(
             list(migrations_dir.glob("*.sql")) + list(migrations_dir.glob("*.py"))
         )
 
+        # Fast-path: short-circuit only when EVERY on-disk migration is already
+        # applied (full-set completeness check via all_migrations_applied —
+        # CHAOS-2440).  A latest-filename-only check is unsound here because of
+        # inserted / mixed-ordering migrations (023b_ between 023_ and 024_,
+        # duplicate numeric prefixes): the DB could hold the latest row yet be
+        # missing an intermediate migration.  The full-set check stays O(n) in
+        # memory over the SELECT we already ran — no per-file DB query, no log
+        # loop — so it remains fast and quiet while being correct.
+        from dev_health_ops.migrations.clickhouse import all_migrations_applied
+
+        if migration_files and all_migrations_applied(
+            (p.name for p in migration_files), applied_versions
+        ):
+            logger.debug(
+                "ClickHouse schema is current (%d migrations applied) — "
+                "skipping migration loop",
+                len(migration_files),
+            )
+            return
+
         for path in migration_files:
             version = path.name
             if version in applied_versions:
-                logger.info(f"Skipping already applied migration: {version}")
+                logger.debug("Skipping already applied migration: %s", version)
                 continue
 
-            logger.info(f"Applying migration: {version}")
+            logger.info("Applying migration: %s", version)
 
             if path.suffix == ".sql":
                 try:

--- a/src/dev_health_ops/migrations/clickhouse/__init__.py
+++ b/src/dev_health_ops/migrations/clickhouse/__init__.py
@@ -10,7 +10,37 @@ into its own statement and break a migration with a ClickHouse SYNTAX_ERROR
 
 from __future__ import annotations
 
-__all__ = ["strip_line_comments", "split_sql_statements"]
+from collections.abc import Iterable
+
+__all__ = [
+    "strip_line_comments",
+    "split_sql_statements",
+    "all_migrations_applied",
+]
+
+
+def all_migrations_applied(
+    migration_filenames: Iterable[str],
+    applied_versions: Iterable[str],
+) -> bool:
+    """Return True iff every on-disk migration is already recorded as applied.
+
+    This is the single source of truth for the migration runners' fast-path
+    short-circuit (CHAOS-2440). It must be a FULL-SET completeness check, not a
+    "latest filename applied" check: this repo has inserted / mixed-ordering
+    migrations (e.g. ``023b_dora_metrics.sql`` sorts between ``023_*`` and
+    ``024_*``, and duplicate numeric prefixes like ``002_phase2_metrics.sql`` /
+    ``002_teams.sql`` exist). A database can hold the row for the
+    lexicographically-latest migration while still missing an *intermediate*
+    one — a latest-only check would falsely report "current" and silently skip
+    the missing migration, causing schema drift.
+
+    Comparing the full set of on-disk filenames against the applied set is still
+    O(n) in memory over the single ``SELECT version FROM schema_migrations`` that
+    the runner already issues — no per-file DB query, no logging loop — so the
+    fast-path stays both fast and quiet while being correct.
+    """
+    return set(migration_filenames) <= set(applied_versions)
 
 
 def strip_line_comments(sql: str) -> str:

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -135,14 +135,36 @@ class ClickHouseStore:
                 row[0] for row in (getattr(applied_result, "result_rows", []) or [])
             )
 
-            # Collect all migration files
+            # Collect all migration files in apply order.
             migration_files = sorted(
                 list(migrations_dir.glob("*.sql")) + list(migrations_dir.glob("*.py"))
             )
 
+            # Fast-path: short-circuit only when EVERY on-disk migration is
+            # already applied (full-set completeness check via
+            # all_migrations_applied — CHAOS-2440).  A latest-filename-only
+            # check is unsound here because of inserted / mixed-ordering
+            # migrations (023b_ between 023_ and 024_, duplicate numeric
+            # prefixes): the DB could hold the latest row yet be missing an
+            # intermediate migration.  The full-set check stays O(n) in memory
+            # over the SELECT we already ran — no per-file DB query, no log
+            # loop — so it remains fast and quiet while being correct.
+            from dev_health_ops.migrations.clickhouse import all_migrations_applied
+
+            if migration_files and all_migrations_applied(
+                (p.name for p in migration_files), applied_versions
+            ):
+                logger.debug(
+                    "ClickHouse schema is current (%d migrations applied) — "
+                    "skipping migration loop",
+                    len(migration_files),
+                )
+                return
+
             for path in migration_files:
                 version = path.name
                 if version in applied_versions:
+                    logger.debug("Skipping already applied migration: %s", version)
                     continue
 
                 if path.suffix == ".sql":

--- a/src/dev_health_ops/work_graph/investment/backfill.py
+++ b/src/dev_health_ops/work_graph/investment/backfill.py
@@ -1,0 +1,232 @@
+"""No-LLM membership backfill (CHAOS-2439).
+
+The daily scheduled job must NOT re-run LLM categorization (cost + category
+drift). Instead it cheaply PROJECTS ``work_unit_membership`` from the theme /
+subcategory distributions ALREADY persisted in ``work_unit_investments`` by the
+post-sync LLM materializer.
+
+Per org, with NO categorizer/LLM call:
+
+1. Rebuild the work-graph connected components from ``work_graph_edges`` (reuse
+   ``_build_components`` + ``work_unit_id`` so the unit hashing matches the
+   materializer exactly).
+2. Read the LATEST ``work_unit_investments`` row per ``work_unit_id`` (argMax on
+   ``computed_at``, the same latest-per-unit semantics as
+   ``api/queries/work_unit_investments.py``) for those unit ids to recover the
+   persisted ``theme_distribution_json`` / ``subcategory_distribution_json``.
+3. Project membership rows via the SHARED ``build_membership_records`` helper, so
+   the rows are byte-for-byte identical to what the LLM materializer would emit
+   for the same distributions. A fresh ``computed_at`` is stamped; the resolver's
+   per-node latest-run guard then supersedes any stale rows.
+4. Write via ``sink.write_work_unit_memberships``.
+
+SKIP-ON-CHURNED-COMPONENT: a unit whose CURRENT component hash has no matching
+``work_unit_investments`` row is skipped. That happens when edges churned since
+the last categorization (the node moved to a new component, so its new
+``work_unit_id`` was never categorized). Those units are intentionally left to
+the post-sync full ``build -> run_investment_materialize`` (LLM) chain, which
+runs on new data and categorizes the new component. The backfill only refreshes
+membership for components that ALREADY have categorization — it never invents
+categories.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from dev_health_ops.metrics.schemas import WorkUnitMembershipRecord
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+from dev_health_ops.metrics.sinks.factory import create_sink
+from dev_health_ops.work_graph.investment.membership import (
+    NodeKey,
+    build_membership_records,
+)
+from dev_health_ops.work_graph.investment.queries import fetch_work_graph_edges
+from dev_health_ops.work_graph.investment.utils import work_unit_id
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MembershipBackfillConfig:
+    dsn: str
+    org_id: str | None = None
+    repo_ids: list[str] | None = None
+
+
+def _build_components_for_backfill(
+    edges: list[dict[str, Any]],
+) -> list[list[NodeKey]]:
+    """Connected-component node lists from work_graph_edges.
+
+    Mirrors ``materialize._build_components`` (same union-find over
+    source/target endpoints) but returns only the per-component node lists — the
+    backfill does not need the component edges. Kept local to avoid importing the
+    heavy ``materialize`` module (and its LLM provider deps) into the worker.
+    """
+    adjacency: dict[NodeKey, list[NodeKey]] = {}
+    for edge in edges:
+        source = (str(edge.get("source_type")), str(edge.get("source_id")))
+        target = (str(edge.get("target_type")), str(edge.get("target_id")))
+        adjacency.setdefault(source, []).append(target)
+        adjacency.setdefault(target, []).append(source)
+
+    visited: set[NodeKey] = set()
+    components: list[list[NodeKey]] = []
+    for node in adjacency:
+        if node in visited:
+            continue
+        stack = [node]
+        visited.add(node)
+        component_nodes: list[NodeKey] = []
+        while stack:
+            current = stack.pop()
+            component_nodes.append(current)
+            for neighbor in adjacency.get(current, []):
+                if neighbor in visited:
+                    continue
+                visited.add(neighbor)
+                stack.append(neighbor)
+        components.append(component_nodes)
+    return components
+
+
+def _fetch_latest_distributions(
+    sink: BaseMetricsSink,
+    *,
+    work_unit_ids: list[str],
+    org_id: str,
+) -> dict[str, dict[str, Any]]:
+    """Return {work_unit_id -> {theme/ subcategory distribution + status}}.
+
+    Reads the LATEST row per ``work_unit_id`` (argMax on ``computed_at``), the
+    same latest-per-unit semantics as ``api/queries/work_unit_investments.py``.
+    Org-scoped. Returns only the unit ids that actually have a row.
+    """
+    if not work_unit_ids:
+        return {}
+    query = """
+        SELECT
+            work_unit_id,
+            argMax(theme_distribution_json, computed_at) AS theme_distribution_json,
+            argMax(subcategory_distribution_json, computed_at) AS subcategory_distribution_json,
+            argMax(categorization_status, computed_at) AS categorization_status
+        FROM work_unit_investments
+        WHERE org_id = %(org_id)s
+          AND work_unit_id IN %(work_unit_ids)s
+        GROUP BY org_id, work_unit_id
+    """
+    rows = sink.query_dicts(
+        query,
+        {"org_id": org_id, "work_unit_ids": work_unit_ids},
+    )
+    result: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        wid = str(row.get("work_unit_id") or "")
+        if wid:
+            result[wid] = row
+    return result
+
+
+def _as_distribution(value: Any) -> dict[str, float]:
+    """Coerce a ClickHouse Map(String, Float64) cell into a plain dict."""
+    if isinstance(value, dict):
+        return {str(k): float(v) for k, v in value.items()}
+    return {}
+
+
+def backfill_memberships(config: MembershipBackfillConfig) -> dict[str, int]:
+    """Project work_unit_membership from existing work_unit_investments (no LLM).
+
+    Returns a stats dict: components seen, units matched (had a persisted
+    categorization), units skipped (churned component / never categorized), and
+    membership rows written.
+    """
+    sink = create_sink(config.dsn)
+    org_id = config.org_id or ""
+    try:
+        sink.ensure_schema()
+
+        edges = fetch_work_graph_edges(sink, repo_ids=config.repo_ids, org_id=org_id)
+        components = _build_components_for_backfill(edges)
+        if not components:
+            logger.info(
+                "Membership backfill: no work graph components for org=%s", org_id
+            )
+            return {
+                "components": 0,
+                "matched": 0,
+                "skipped": 0,
+                "memberships": 0,
+            }
+
+        # Map each current work_unit_id -> its node list.
+        unit_nodes_by_id: dict[str, list[NodeKey]] = {}
+        for nodes in components:
+            unit_nodes = list(dict.fromkeys(nodes))
+            uid = work_unit_id(unit_nodes)
+            # Multiple components cannot collide on the hash (sha256 of sorted
+            # node tokens); last-writer is fine if they somehow do.
+            unit_nodes_by_id[uid] = unit_nodes
+
+        distributions = _fetch_latest_distributions(
+            sink,
+            work_unit_ids=list(unit_nodes_by_id.keys()),
+            org_id=org_id,
+        )
+
+        computed_at = datetime.now(timezone.utc)
+        membership_records: list[WorkUnitMembershipRecord] = []
+        matched = 0
+        skipped = 0
+        for uid, unit_nodes in unit_nodes_by_id.items():
+            persisted = distributions.get(uid)
+            if persisted is None:
+                # SKIP-ON-CHURNED-COMPONENT: this component hash was never
+                # categorized (edges churned since last LLM run). The post-sync
+                # build->materialize(LLM) chain covers it; the backfill never
+                # invents categories.
+                skipped += 1
+                continue
+            matched += 1
+            membership_records.extend(
+                build_membership_records(
+                    unit_nodes=unit_nodes,
+                    work_unit_id=uid,
+                    theme_distribution=_as_distribution(
+                        persisted.get("theme_distribution_json")
+                    ),
+                    subcategory_distribution=_as_distribution(
+                        persisted.get("subcategory_distribution_json")
+                    ),
+                    categorization_status=str(
+                        persisted.get("categorization_status") or ""
+                    ),
+                    computed_at=computed_at,
+                    org_id=org_id,
+                )
+            )
+
+        if membership_records:
+            sink.write_work_unit_memberships(membership_records)
+
+        logger.info(
+            "Membership backfill org=%s: components=%d matched=%d skipped=%d "
+            "memberships=%d (no LLM)",
+            org_id,
+            len(components),
+            matched,
+            skipped,
+            len(membership_records),
+        )
+        return {
+            "components": len(components),
+            "matched": matched,
+            "skipped": skipped,
+            "memberships": len(membership_records),
+        }
+    finally:
+        sink.close()

--- a/src/dev_health_ops/work_graph/investment/backfill.py
+++ b/src/dev_health_ops/work_graph/investment/backfill.py
@@ -20,14 +20,36 @@ Per org, with NO categorizer/LLM call:
    per-node latest-run guard then supersedes any stale rows.
 4. Write via ``sink.write_work_unit_memberships``.
 
-SKIP-ON-CHURNED-COMPONENT: a unit whose CURRENT component hash has no matching
-``work_unit_investments`` row is skipped. That happens when edges churned since
-the last categorization (the node moved to a new component, so its new
-``work_unit_id`` was never categorized). Those units are intentionally left to
-the post-sync full ``build -> run_investment_materialize`` (LLM) chain, which
-runs on new data and categorizes the new component. The backfill only refreshes
-membership for components that ALREADY have categorization — it never invents
-categories.
+TOMBSTONE-ON-SKIP (stale-membership fix): a unit whose CURRENT component hash
+has no matching ``work_unit_investments`` row is a CHURNED / uncategorized
+component. Without action, any OLD membership rows from a prior component that
+contained those same nodes remain the latest rows for each node and continue
+matching theme/subcategory filters with stale data.
+
+To prevent this, the backfill writes a TOMBSTONE for each node in a skipped
+component: a ``work_unit_membership`` row with ``category=''`` (a sentinel
+value), ``weight=0.0``, ``is_dominant=0``, and a FRESH ``computed_at`` equal to
+the current run timestamp. Because the resolver's per-node latest-run guard
+selects membership rows whose ``computed_at`` equals the max for that
+``(org_id, node_type, node_id)``, the tombstone row supersedes all older rows,
+making the node's "current" membership empty. Tombstone invariants:
+
+- ``category=''`` is never matched by ``(m.category_kind, m.category) IN
+  %(category_tuples)s`` (all real categories are non-empty strings), so a
+  tombstoned node is NOT returned by any theme/subcategory filter.
+- The annotation lookup treats ``category=''`` the same as no row: the Python
+  ``m.get("dominant_theme") or None`` converts an empty string to ``None``, so
+  annotation returns ``theme=None, subcategory=None`` for tombstoned nodes.
+- The degraded-state probe counts live membership rows using the per-node
+  latest-run JOIN. Tombstones are "live" rows (fresh computed_at), so they
+  count toward ``membership_rows``. An org whose nodes are all tombstoned is
+  NOT misread as un-materialized (membership_rows > 0) — the degraded probe
+  correctly reports "no degraded state, filters just match nothing."
+
+Tombstones are emitted ONLY by the backfill skip path. The LLM materializer
+(``materialize.py``) never tombstones — it re-categorizes. The post-sync
+build→materialize(LLM) chain will eventually replace tombstones with real rows
+when the churned component is re-categorized.
 """
 
 from __future__ import annotations
@@ -48,6 +70,13 @@ from dev_health_ops.work_graph.investment.queries import fetch_work_graph_edges
 from dev_health_ops.work_graph.investment.utils import work_unit_id
 
 logger = logging.getLogger(__name__)
+
+# Sentinel category value written to work_unit_membership for nodes in a
+# CHURNED / uncategorized component.  An empty string is never a real category
+# name, so (category_kind, '') is never matched by a theme/subcategory filter
+# (which always supplies a non-empty category string).  See TOMBSTONE-ON-SKIP
+# in the module docstring.
+TOMBSTONE_CATEGORY: str = ""
 
 
 @dataclass(frozen=True)
@@ -138,12 +167,53 @@ def _as_distribution(value: Any) -> dict[str, float]:
     return {}
 
 
+def _build_tombstone_records(
+    *,
+    unit_nodes: list[NodeKey],
+    work_unit_id: str,
+    computed_at: datetime,
+    org_id: str,
+) -> list[WorkUnitMembershipRecord]:
+    """Return tombstone membership rows for each node in a churned component.
+
+    One tombstone per (node, category_kind) — two records per node (one for
+    'theme', one for 'subcategory').  Each carries ``category=TOMBSTONE_CATEGORY``
+    (empty string), ``weight=0.0``, ``is_dominant=0``, and the run's
+    ``computed_at``.
+
+    Because the resolver's per-node latest-run guard selects membership rows
+    whose ``computed_at`` equals the max for that ``(org_id, node_type,
+    node_id)``, these tombstones supersede any older real rows and make the node
+    appear as having no category membership.  See TOMBSTONE-ON-SKIP in the
+    module docstring for the full invariant analysis.
+    """
+    records: list[WorkUnitMembershipRecord] = []
+    for node_type, node_id in unit_nodes:
+        for kind in ("theme", "subcategory"):
+            records.append(
+                WorkUnitMembershipRecord(
+                    org_id=org_id,
+                    node_type=node_type,
+                    node_id=node_id,
+                    work_unit_id=work_unit_id,
+                    category_kind=kind,
+                    category=TOMBSTONE_CATEGORY,
+                    weight=0.0,
+                    is_dominant=0,
+                    categorization_status="tombstone",
+                    computed_at=computed_at,
+                )
+            )
+    return records
+
+
 def backfill_memberships(config: MembershipBackfillConfig) -> dict[str, int]:
     """Project work_unit_membership from existing work_unit_investments (no LLM).
 
     Returns a stats dict: components seen, units matched (had a persisted
-    categorization), units skipped (churned component / never categorized), and
-    membership rows written.
+    categorization), units skipped (churned component / never categorized),
+    tombstones written (one per node in skipped components, two rows per node),
+    and total membership rows written.
     """
     sink = create_sink(config.dsn)
     org_id = config.org_id or ""
@@ -160,6 +230,7 @@ def backfill_memberships(config: MembershipBackfillConfig) -> dict[str, int]:
                 "components": 0,
                 "matched": 0,
                 "skipped": 0,
+                "tombstones": 0,
                 "memberships": 0,
             }
 
@@ -182,13 +253,26 @@ def backfill_memberships(config: MembershipBackfillConfig) -> dict[str, int]:
         membership_records: list[WorkUnitMembershipRecord] = []
         matched = 0
         skipped = 0
+        tombstone_count = 0
         for uid, unit_nodes in unit_nodes_by_id.items():
             persisted = distributions.get(uid)
             if persisted is None:
-                # SKIP-ON-CHURNED-COMPONENT: this component hash was never
-                # categorized (edges churned since last LLM run). The post-sync
-                # build->materialize(LLM) chain covers it; the backfill never
-                # invents categories.
+                # TOMBSTONE-ON-SKIP: this component's work_unit_id has no
+                # persisted investment row (edges churned since last LLM run).
+                # Write tombstone rows for each node with a FRESH computed_at so
+                # the per-node latest-run guard supersedes any stale membership
+                # rows from a prior component, preventing those old categories
+                # from matching future theme/subcategory filters.  The post-sync
+                # build->materialize(LLM) chain will replace tombstones with
+                # real rows when the new component is categorized.
+                tombstone_records = _build_tombstone_records(
+                    unit_nodes=unit_nodes,
+                    work_unit_id=uid,
+                    computed_at=computed_at,
+                    org_id=org_id,
+                )
+                membership_records.extend(tombstone_records)
+                tombstone_count += len(tombstone_records)
                 skipped += 1
                 continue
             matched += 1
@@ -215,17 +299,19 @@ def backfill_memberships(config: MembershipBackfillConfig) -> dict[str, int]:
 
         logger.info(
             "Membership backfill org=%s: components=%d matched=%d skipped=%d "
-            "memberships=%d (no LLM)",
+            "tombstones=%d memberships=%d (no LLM)",
             org_id,
             len(components),
             matched,
             skipped,
+            tombstone_count,
             len(membership_records),
         )
         return {
             "components": len(components),
             "matched": matched,
             "skipped": skipped,
+            "tombstones": tombstone_count,
             "memberships": len(membership_records),
         }
     finally:

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -25,7 +25,6 @@ from dev_health_ops.work_graph.investment.categorize import (
     fallback_outcome,
 )
 from dev_health_ops.work_graph.investment.constants import (
-    MEMBERSHIP_WEIGHT_THRESHOLD,
     MIN_EVIDENCE_CHARS,
 )
 from dev_health_ops.work_graph.investment.evidence import (
@@ -33,6 +32,11 @@ from dev_health_ops.work_graph.investment.evidence import (
     build_text_bundle,
     compute_evidence_quality,
     compute_time_bounds,
+)
+from dev_health_ops.work_graph.investment.membership import (
+    build_membership_records,
+    lexical_argmax,
+    membership_categories,
 )
 from dev_health_ops.work_graph.investment.queries import (
     fetch_commit_churn,
@@ -80,47 +84,12 @@ def _float_value(value: object) -> float:
     return 0.0
 
 
-def _lexical_argmax(distribution: dict[str, float]) -> str:
-    """Return the key with the highest value; break ties lexically (smallest key wins).
-
-    An empty distribution returns "unknown". The lexical tie-break ensures
-    deterministic output across Python runs regardless of dict insertion order.
-    """
-    if not distribution:
-        return "unknown"
-    # Smallest-key-wins on ties: order by (-value, key) and take the min, so the
-    # highest weight comes first and the lexically smallest key breaks ties.
-    return min(distribution, key=lambda k: (-_float_value(distribution[k]), k))
-
-
-def _membership_categories(
-    distribution: dict[str, float],
-) -> list[tuple[str, float, int]]:
-    """Return (category, weight, is_dominant) rows to emit for one distribution.
-
-    Multi-membership: every category with weight >= MEMBERSHIP_WEIGHT_THRESHOLD
-    is emitted, so a mixed unit is findable under each significant category. The
-    argmax category (lexical tie-break) is ALWAYS included even when below the
-    threshold and is flagged is_dominant=1, so every node is findable under at
-    least its dominant category. Returns at least one row whenever the
-    distribution is non-empty.
-    """
-    if not distribution:
-        return []
-    dominant = _lexical_argmax(distribution)
-    out: list[tuple[str, float, int]] = []
-    seen: set[str] = set()
-    for category, raw_weight in distribution.items():
-        weight = _float_value(raw_weight)
-        is_dominant = 1 if category == dominant else 0
-        if weight >= MEMBERSHIP_WEIGHT_THRESHOLD or is_dominant:
-            out.append((category, weight, is_dominant))
-            seen.add(category)
-    # Defensive: ensure the dominant row is present even if it was filtered
-    # (e.g. dominant key absent from the dict view due to mutation).
-    if dominant not in seen:
-        out.append((dominant, _float_value(distribution.get(dominant, 0.0)), 1))
-    return out
+# Thin re-exports of the shared membership projection (CHAOS-2439): the daily
+# no-LLM backfill and this LLM materializer MUST emit identical rows, so the
+# threshold + is_dominant logic lives in one place. Kept as module-level aliases
+# so existing imports/tests of these names continue to resolve.
+_lexical_argmax = lexical_argmax
+_membership_categories = membership_categories
 
 
 @dataclass(frozen=True)
@@ -642,42 +611,20 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
 
             # Emit membership rows so the work graph resolver can join
             # theme/subcategory onto edges in O(nodes) without scanning
-            # work_unit_investments (CHAOS-2429/2430). Multi-membership: one row
-            # per (node, category) for each theme and subcategory at/above the
-            # weight threshold, plus the argmax of each kind (is_dominant=1).
-            theme_categories = _membership_categories(theme_distribution)
-            subcategory_categories = _membership_categories(outcome.subcategories)
-            for node_type, node_id in unit_nodes:
-                for category, weight, is_dominant in theme_categories:
-                    membership_records.append(
-                        WorkUnitMembershipRecord(
-                            org_id=config.org_id or "",
-                            node_type=node_type,
-                            node_id=node_id,
-                            work_unit_id=unit_id,
-                            category_kind="theme",
-                            category=category,
-                            weight=weight,
-                            is_dominant=is_dominant,
-                            categorization_status=outcome.status,
-                            computed_at=computed_at,
-                        )
-                    )
-                for category, weight, is_dominant in subcategory_categories:
-                    membership_records.append(
-                        WorkUnitMembershipRecord(
-                            org_id=config.org_id or "",
-                            node_type=node_type,
-                            node_id=node_id,
-                            work_unit_id=unit_id,
-                            category_kind="subcategory",
-                            category=category,
-                            weight=weight,
-                            is_dominant=is_dominant,
-                            categorization_status=outcome.status,
-                            computed_at=computed_at,
-                        )
-                    )
+            # work_unit_investments (CHAOS-2429/2430). Uses the SHARED projection
+            # so the daily no-LLM backfill produces identical rows for the same
+            # persisted distributions (CHAOS-2439).
+            membership_records.extend(
+                build_membership_records(
+                    unit_nodes=unit_nodes,
+                    work_unit_id=unit_id,
+                    theme_distribution=theme_distribution,
+                    subcategory_distribution=outcome.subcategories,
+                    categorization_status=outcome.status,
+                    computed_at=computed_at,
+                    org_id=config.org_id or "",
+                )
+            )
 
             if config.persist_evidence_snippets and outcome.evidence_quotes:
                 for quote in outcome.evidence_quotes:

--- a/src/dev_health_ops/work_graph/investment/membership.py
+++ b/src/dev_health_ops/work_graph/investment/membership.py
@@ -1,0 +1,127 @@
+"""Shared work_unit_membership projection (CHAOS-2429/2430/2439).
+
+This module holds the SINGLE source of truth for turning a work unit's theme /
+subcategory distributions into ``work_unit_membership`` rows, so the post-sync
+LLM materializer (``materialize.py``) and the daily no-LLM backfill
+(``backfill.py``) emit byte-for-byte identical rows for the same persisted
+distributions. The projection is pure: it never calls the categorizer / LLM.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+
+from dev_health_ops.metrics.schemas import WorkUnitMembershipRecord
+from dev_health_ops.work_graph.investment.constants import MEMBERSHIP_WEIGHT_THRESHOLD
+
+NodeKey = tuple[str, str]
+
+
+def _float_value(value: object) -> float:
+    """Best-effort float coercion (bools are not numbers here)."""
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
+def lexical_argmax(distribution: dict[str, float]) -> str:
+    """Return the key with the highest value; break ties lexically (smallest wins).
+
+    An empty distribution returns "unknown". The lexical tie-break makes the
+    dominant choice deterministic across runs regardless of dict ordering.
+    """
+    if not distribution:
+        return "unknown"
+    return min(distribution, key=lambda k: (-_float_value(distribution[k]), k))
+
+
+def membership_categories(
+    distribution: dict[str, float],
+) -> list[tuple[str, float, int]]:
+    """Return (category, weight, is_dominant) rows to emit for one distribution.
+
+    Multi-membership: every category with weight >= MEMBERSHIP_WEIGHT_THRESHOLD
+    is emitted, so a mixed unit is findable under each significant category. The
+    argmax category (lexical tie-break) is ALWAYS included even when below the
+    threshold and is flagged ``is_dominant=1``, so every node is findable under
+    at least its dominant category. Returns at least one row whenever the
+    distribution is non-empty.
+    """
+    if not distribution:
+        return []
+    dominant = lexical_argmax(distribution)
+    out: list[tuple[str, float, int]] = []
+    seen: set[str] = set()
+    for category, raw_weight in distribution.items():
+        weight = _float_value(raw_weight)
+        is_dominant = 1 if category == dominant else 0
+        if weight >= MEMBERSHIP_WEIGHT_THRESHOLD or is_dominant:
+            out.append((category, weight, is_dominant))
+            seen.add(category)
+    # Defensive: ensure the dominant row is present even if it was filtered.
+    if dominant not in seen:
+        out.append((dominant, _float_value(distribution.get(dominant, 0.0)), 1))
+    return out
+
+
+def build_membership_records(
+    *,
+    unit_nodes: Iterable[NodeKey],
+    work_unit_id: str,
+    theme_distribution: dict[str, float],
+    subcategory_distribution: dict[str, float],
+    categorization_status: str,
+    computed_at: datetime,
+    org_id: str,
+) -> list[WorkUnitMembershipRecord]:
+    """Project one work unit's distributions into ``work_unit_membership`` rows.
+
+    Emits one row per (node, category) for the theme distribution and one per
+    (node, category) for the subcategory distribution, using
+    ``membership_categories`` for the threshold + is_dominant logic. This is the
+    shared seam used by BOTH the LLM materializer and the no-LLM backfill, so the
+    two paths produce identical rows for identical persisted distributions.
+    """
+    theme_categories = membership_categories(theme_distribution)
+    subcategory_categories = membership_categories(subcategory_distribution)
+    records: list[WorkUnitMembershipRecord] = []
+    for node_type, node_id in unit_nodes:
+        for category, weight, is_dominant in theme_categories:
+            records.append(
+                WorkUnitMembershipRecord(
+                    org_id=org_id,
+                    node_type=node_type,
+                    node_id=node_id,
+                    work_unit_id=work_unit_id,
+                    category_kind="theme",
+                    category=category,
+                    weight=weight,
+                    is_dominant=is_dominant,
+                    categorization_status=categorization_status,
+                    computed_at=computed_at,
+                )
+            )
+        for category, weight, is_dominant in subcategory_categories:
+            records.append(
+                WorkUnitMembershipRecord(
+                    org_id=org_id,
+                    node_type=node_type,
+                    node_id=node_id,
+                    work_unit_id=work_unit_id,
+                    category_kind="subcategory",
+                    category=category,
+                    weight=weight,
+                    is_dominant=is_dominant,
+                    categorization_status=categorization_status,
+                    computed_at=computed_at,
+                )
+            )
+    return records

--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -223,10 +223,12 @@ def run_investment_materialization(ns: argparse.Namespace) -> int:
     try:
         stats = asyncio.run(materialize_investments(config))
         logging.info(
-            "Investment materialization complete. Components=%d Records=%d Quotes=%d",
+            "Investment materialization complete. "
+            "Components=%d Records=%d Quotes=%d Memberships=%d",
             stats.get("components", 0),
             stats.get("records", 0),
             stats.get("quotes", 0),
+            stats.get("memberships", 0),
         )
         return 0
     except Exception as e:

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -92,6 +92,20 @@ beat_schedule = {
         "schedule": crontab(hour=2, minute=0),
         "options": {"queue": "metrics"},
     },
+    # Daily floor-cadence safety net for work_unit_membership (CHAOS-2439).
+    # Investment materialization (which populates work_unit_membership, read by
+    # the work-graph theme/subcategory filter) is otherwise event-driven only —
+    # it runs post-sync via the run_work_graph_build -> run_investment_materialize
+    # chain. Idle-sync orgs and the post-deploy window would otherwise leave
+    # membership empty, stranding theme filters in the MEMBERSHIP_NOT_MATERIALIZED
+    # degraded state (CHAOS-2427 #925). The dispatcher fans out the SAME immutable
+    # build->materialize chain per active org with work-graph data. Scheduled at
+    # 01:15 — clear of run-daily-metrics (01:00) and run-release-impact (01:30).
+    "run-investment-materialize-daily": {
+        "task": "dev_health_ops.workers.tasks.dispatch_investment_materialize",
+        "schedule": crontab(hour=1, minute=15),
+        "options": {"queue": "default"},
+    },
     # Release-impact daily compute (CHAOS-2381): materializes
     # release_impact_daily from telemetry_signal_bucket + deployments, read by
     # the /feature-flags release-reliability cards. The dispatcher fans out one

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -93,16 +93,19 @@ beat_schedule = {
         "options": {"queue": "metrics"},
     },
     # Daily floor-cadence safety net for work_unit_membership (CHAOS-2439).
-    # Investment materialization (which populates work_unit_membership, read by
-    # the work-graph theme/subcategory filter) is otherwise event-driven only —
-    # it runs post-sync via the run_work_graph_build -> run_investment_materialize
-    # chain. Idle-sync orgs and the post-deploy window would otherwise leave
-    # membership empty, stranding theme filters in the MEMBERSHIP_NOT_MATERIALIZED
-    # degraded state (CHAOS-2427 #925). The dispatcher fans out the SAME immutable
-    # build->materialize chain per active org with work-graph data. Scheduled at
-    # 01:15 — clear of run-daily-metrics (01:00) and run-release-impact (01:30).
-    "run-investment-materialize-daily": {
-        "task": "dev_health_ops.workers.tasks.dispatch_investment_materialize",
+    # work_unit_membership (read by the work-graph theme/subcategory filter) is
+    # otherwise populated event-driven only — post-sync via the
+    # run_work_graph_build -> run_investment_materialize (LLM) chain. Idle-sync
+    # orgs and the post-deploy window would otherwise leave membership empty,
+    # stranding theme filters in the MEMBERSHIP_NOT_MATERIALIZED degraded state
+    # (CHAOS-2427 #925). The daily job must NOT re-run LLM categorization (cost +
+    # category drift), so it fans out a CHEAP no-LLM chain per active org:
+    # run_work_graph_build -> run_membership_backfill, which projects membership
+    # from the distributions already persisted in work_unit_investments. The
+    # post-sync LLM chain is unchanged. Scheduled at 01:15 — clear of
+    # run-daily-metrics (01:00) and run-release-impact (01:30).
+    "run-membership-backfill-daily": {
+        "task": "dev_health_ops.workers.tasks.dispatch_membership_backfill",
         "schedule": crontab(hour=1, minute=15),
         "options": {"queue": "default"},
     },

--- a/src/dev_health_ops/workers/recommendations_tasks.py
+++ b/src/dev_health_ops/workers/recommendations_tasks.py
@@ -82,12 +82,23 @@ def _daily_metrics_ready(org_id: str, day: Any) -> bool:
         return True
 
 
-def _discover_active_org_ids() -> list[str]:
+def _discover_active_org_ids(*, strict: bool = False) -> list[str]:
     """Return the IDs of all active organisations (Postgres source of truth).
 
-    Mirrors how ``dispatch_scheduled_metrics`` scopes work to live orgs. Falls
-    back to ``["default"]`` (single-tenant / community installs) when the
-    organizations table is empty or unavailable.
+    Mirrors how ``dispatch_scheduled_metrics`` scopes work to live orgs.
+
+    The ``["default"]`` fallback is only for the *positively-detected*
+    single-tenant / community case: the query SUCCEEDS but returns zero active
+    orgs. A Postgres failure is a different condition and must not be
+    indistinguishable from "no orgs".
+
+    - ``strict=False`` (default): on enumeration failure, log and fall back to
+      ``["default"]`` (preserves the existing best-effort recommendations-job
+      behaviour).
+    - ``strict=True``: on enumeration failure, RAISE so a caller wrapped in
+      Celery retry treats a multi-tenant DB outage as a retryable failure rather
+      than a silent empty-success (CHAOS-2439). The empty-table fallback still
+      applies because that is a successful query, not an error.
     """
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.models.users import Organization
@@ -102,6 +113,10 @@ def _discover_active_org_ids() -> list[str]:
         org_ids = [str(row[0]) for row in rows]
     except Exception:
         logger.exception("Failed to enumerate active organizations")
+        if strict:
+            # Re-raise so the once-daily dispatcher retries instead of computing
+            # zero orgs and reporting a clean success on a DB outage.
+            raise
         org_ids = []
 
     return org_ids or ["default"]

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -50,6 +50,7 @@ from dev_health_ops.workers.task_utils import (
     _resolve_env_credentials,
 )
 from dev_health_ops.workers.work_graph_tasks import (
+    dispatch_investment_materialize,
     run_investment_materialize,
     run_work_graph_build,
 )
@@ -66,6 +67,7 @@ __all__ = [
     "_run_sync_for_repo",
     "dispatch_batch_sync",
     "dispatch_daily_metrics_partitioned",
+    "dispatch_investment_materialize",
     "dispatch_release_impact",
     "dispatch_scheduled_metrics",
     "dispatch_scheduled_reports",

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -50,8 +50,9 @@ from dev_health_ops.workers.task_utils import (
     _resolve_env_credentials,
 )
 from dev_health_ops.workers.work_graph_tasks import (
-    dispatch_investment_materialize,
+    dispatch_membership_backfill,
     run_investment_materialize,
+    run_membership_backfill,
     run_work_graph_build,
 )
 
@@ -67,7 +68,7 @@ __all__ = [
     "_run_sync_for_repo",
     "dispatch_batch_sync",
     "dispatch_daily_metrics_partitioned",
-    "dispatch_investment_materialize",
+    "dispatch_membership_backfill",
     "dispatch_release_impact",
     "dispatch_scheduled_metrics",
     "dispatch_scheduled_reports",
@@ -87,6 +88,7 @@ __all__ = [
     "run_dora_metrics",
     "run_ingest_consumer",
     "run_investment_materialize",
+    "run_membership_backfill",
     "run_product_telemetry_consumer",
     "run_recommendations_job",
     "run_release_impact_job",

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -202,7 +202,9 @@ def run_membership_backfill(
     work-graph components and re-emits ``work_unit_membership`` rows from the
     theme/subcategory distributions ALREADY persisted by the post-sync LLM
     materializer. Units whose current component hash has no persisted
-    categorization are skipped (the post-sync chain covers those). See
+    categorization (churned components) receive TOMBSTONE rows (category='',
+    weight=0, is_dominant=0) so their stale prior-run membership rows are
+    superseded and the nodes stop matching any theme/subcategory filter.  See
     ``work_graph.investment.backfill`` for the full contract (CHAOS-2439).
 
     Args:

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -183,42 +183,6 @@ def run_investment_materialize(
         raise self.retry(exc=exc, countdown=120 * (2**self.request.retries))
 
 
-def _orgs_with_work_graph_data(db_url: str, org_ids: list[str]) -> set[str]:
-    """Return the subset of ``org_ids`` that have any ``work_graph_edges`` rows.
-
-    Scopes the daily floor-cadence fan-out to orgs that actually have a work
-    graph, so empty / never-synced orgs are not churned every night. Sourced
-    from ClickHouse ``work_graph_edges`` — the exact input that the
-    build->materialize chain reads — mirroring how the recommendations job
-    scopes to tables that hold data (``_discover_team_ids``). On any ClickHouse
-    error, returns all candidate orgs (fail open): the per-org chain is itself a
-    no-op for an empty org, so a transient probe failure must not silently skip
-    the safety net it exists to provide.
-    """
-    if not org_ids:
-        return set()
-    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
-
-    try:
-        sink = ClickHouseMetricsSink(db_url)
-        rows = sink.client.query(
-            """
-            SELECT DISTINCT org_id
-            FROM work_graph_edges
-            WHERE org_id IN %(org_ids)s
-            """,
-            parameters={"org_ids": org_ids},
-        ).result_rows
-        return {str(row[0]) for row in rows if row and row[0]}
-    except Exception:
-        logger.warning(
-            "work_graph_edges org-with-data probe failed; "
-            "falling back to all candidate orgs",
-            exc_info=True,
-        )
-        return set(org_ids)
-
-
 @celery_app.task(
     bind=True,
     max_retries=3,
@@ -247,35 +211,40 @@ def dispatch_investment_materialize(
     ``computed_at`` (ReplacingMergeTree) and re-running simply refreshes the
     latest run.
 
+    GATING: the chain is dispatched for EVERY active org — it is deliberately NOT
+    gated on ``work_graph_edges`` existence. That table is the build's OUTPUT, so
+    gating on it would permanently skip exactly the tenants the safety net must
+    repair: an org with raw synced data but no edges yet (a failed prior
+    post-sync build, a truncated/migrated-empty graph table, or a brand-new
+    tenant that synced but never built). The build is a cheap no-op for an org
+    with no source data (it scans a 30-day window and produces zero edges), and
+    materialize then short-circuits on zero components — so fanning out to all
+    active orgs is both correct and inexpensive (CHAOS-2439 review).
+
     Org selection mirrors the other daily fan-out dispatchers
     (``_discover_active_org_ids`` — active orgs from Postgres, the source of
-    truth, ``["default"]`` fallback for single-tenant installs), then narrows to
-    orgs that actually have ``work_graph_edges`` so empty orgs are not churned.
+    truth, ``["default"]`` fallback only for the positively-detected
+    single-tenant case). It uses ``strict=True`` so a Postgres outage RAISES and
+    triggers retry rather than silently dispatching zero orgs as a clean success.
 
     Returns:
-        dict with the list of dispatched org_ids and a skipped count.
+        dict with the list of dispatched org_ids.
     """
     from dev_health_ops.workers.recommendations_tasks import _discover_active_org_ids
 
     db_url = db_url or _get_db_url()
 
     try:
-        candidate_org_ids = _discover_active_org_ids()
+        # strict=True: a Postgres enumeration failure must RAISE (not collapse to
+        # ["default"]) so the once-daily run retries instead of reporting a clean
+        # empty-success on a multi-tenant DB outage (CHAOS-2439).
+        candidate_org_ids = _discover_active_org_ids(strict=True)
     except Exception as exc:
-        # A transient Postgres/enumeration failure at the once-daily run must not
-        # report success while computing zero orgs (mirrors dispatch_release_impact):
-        # retry, then surface as a FAILED task rather than a silent empty success.
         logger.exception("dispatch_investment_materialize failed to enumerate orgs")
         raise self.retry(exc=exc, countdown=60 * (2**self.request.retries))
 
-    with_data = _orgs_with_work_graph_data(db_url, candidate_org_ids)
-
     dispatched: list[str] = []
-    skipped = 0
     for org_id in candidate_org_ids:
-        if org_id not in with_data:
-            skipped += 1
-            continue
         # Mirror the post-sync immutable chain exactly (CHAOS-2374): build FIRST,
         # then materialize, on the metrics queue. ``.si()``-equivalent immutability
         # keeps the build's return value out of materialize's positional args.
@@ -293,9 +262,5 @@ def dispatch_investment_materialize(
         chain(build_sig, materialize_sig).apply_async()
         dispatched.append(org_id)
 
-    logger.info(
-        "Investment materialize dispatch: dispatched=%d skipped=%d",
-        len(dispatched),
-        skipped,
-    )
-    return {"dispatched": dispatched, "skipped": skipped}
+    logger.info("Investment materialize dispatch: dispatched=%d", len(dispatched))
+    return {"dispatched": dispatched}

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -248,14 +248,20 @@ def dispatch_investment_materialize(
         # Mirror the post-sync immutable chain exactly (CHAOS-2374): build FIRST,
         # then materialize, on the metrics queue. ``.si()``-equivalent immutability
         # keeps the build's return value out of materialize's positional args.
+        # Forward the resolved ``db_url`` to BOTH children: an explicit override
+        # (manual/backfill: dispatch_investment_materialize(db_url=...)) must
+        # target the requested ClickHouse, not the workers' ambient instance
+        # (the children otherwise default to _get_db_url()). The scheduled path
+        # passes the same value _get_db_url() already resolves, so behaviour is
+        # unchanged when no override is supplied (CHAOS-2439 review).
         build_sig = celery_app.signature(
             "dev_health_ops.workers.tasks.run_work_graph_build",
-            kwargs={"org_id": org_id},
+            kwargs={"db_url": db_url, "org_id": org_id},
             queue="metrics",
         )
         materialize_sig = celery_app.signature(
             "dev_health_ops.workers.tasks.run_investment_materialize",
-            kwargs={"org_id": org_id},
+            kwargs={"db_url": db_url, "org_id": org_id},
             queue="metrics",
             immutable=True,
         )

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -185,47 +185,97 @@ def run_investment_materialize(
 
 @celery_app.task(
     bind=True,
+    max_retries=2,
+    queue="metrics",
+    name="dev_health_ops.workers.tasks.run_membership_backfill",
+)
+def run_membership_backfill(
+    self,
+    db_url: str | None = None,
+    org_id: str = "",
+    repo_ids: list[str] | None = None,
+) -> dict:
+    """Project work_unit_membership from EXISTING work_unit_investments — NO LLM.
+
+    The cheap daily counterpart to ``run_investment_materialize``: instead of
+    re-running LLM categorization (cost + category drift), it rebuilds the
+    work-graph components and re-emits ``work_unit_membership`` rows from the
+    theme/subcategory distributions ALREADY persisted by the post-sync LLM
+    materializer. Units whose current component hash has no persisted
+    categorization are skipped (the post-sync chain covers those). See
+    ``work_graph.investment.backfill`` for the full contract (CHAOS-2439).
+
+    Args:
+        db_url: Database connection string (defaults to env).
+        org_id: Organization scope for work-graph/investment queries.
+        repo_ids: Optional repo filter.
+
+    Returns:
+        dict with backfill status and stats.
+    """
+    from dev_health_ops.work_graph.investment.backfill import (
+        MembershipBackfillConfig,
+        backfill_memberships,
+    )
+
+    db_url = db_url or _get_db_url()
+    try:
+        config = MembershipBackfillConfig(
+            dsn=db_url,
+            org_id=org_id or None,
+            repo_ids=repo_ids,
+        )
+        stats = backfill_memberships(config)
+        return {"status": "success", "stats": stats}
+    except Exception as exc:
+        logger.exception("Membership backfill task failed: %s", exc)
+        raise self.retry(exc=exc, countdown=120 * (2**self.request.retries))
+
+
+@celery_app.task(
+    bind=True,
     max_retries=3,
     queue="default",
-    name="dev_health_ops.workers.tasks.dispatch_investment_materialize",
+    name="dev_health_ops.workers.tasks.dispatch_membership_backfill",
 )
-def dispatch_investment_materialize(
+def dispatch_membership_backfill(
     self,
     db_url: str | None = None,
 ) -> dict:
     """Daily floor-cadence safety net for ``work_unit_membership`` (CHAOS-2439).
 
-    Investment materialization (which populates ``work_unit_membership``, read by
-    the work-graph theme/subcategory filter) is otherwise EVENT-DRIVEN ONLY — it
-    runs post-sync via the ``run_work_graph_build`` -> ``run_investment_materialize``
-    chain in ``_dispatch_post_sync_tasks``. Idle-sync orgs and the post-deploy
-    window therefore leave membership empty, stranding theme filters in the
-    ``MEMBERSHIP_NOT_MATERIALIZED`` degraded state indefinitely (CHAOS-2427 #925).
+    ``work_unit_membership`` (read by the work-graph theme/subcategory filter) is
+    otherwise populated EVENT-DRIVEN ONLY — post-sync via the
+    ``run_work_graph_build`` -> ``run_investment_materialize`` (LLM) chain in
+    ``_dispatch_post_sync_tasks``. Idle-sync orgs and the post-deploy window
+    therefore leave membership empty, stranding theme filters in the
+    ``MEMBERSHIP_NOT_MATERIALIZED`` degraded state (CHAOS-2427 #925).
 
-    This dispatcher fans out one per-org job at a fixed daily cadence, queuing the
-    SAME immutable ``build -> materialize`` chain used post-sync. The chain (not
-    two independent dispatches) guarantees materialize only starts after the
-    build *succeeds*, so concurrent metrics workers cannot race materialize ahead
-    of a stale/empty graph — the race CHAOS-2374 avoided. It is idempotent and
-    safe to coexist with the post-sync dispatch: materialization is keyed on
-    ``computed_at`` (ReplacingMergeTree) and re-running simply refreshes the
-    latest run.
+    The daily job must NOT re-run LLM materialization (cost + category drift), so
+    it fans out a CHEAP, no-LLM chain per active org:
+    ``run_work_graph_build`` -> ``run_membership_backfill``. The build refreshes
+    ``work_graph_edges`` (NO LLM); the backfill then PROJECTS membership from the
+    theme/subcategory distributions already persisted in ``work_unit_investments``
+    by the post-sync LLM path. The post-sync full ``build -> materialize`` (LLM)
+    chain is UNCHANGED and still categorizes new data.
 
-    GATING: the chain is dispatched for EVERY active org — it is deliberately NOT
-    gated on ``work_graph_edges`` existence. That table is the build's OUTPUT, so
-    gating on it would permanently skip exactly the tenants the safety net must
-    repair: an org with raw synced data but no edges yet (a failed prior
-    post-sync build, a truncated/migrated-empty graph table, or a brand-new
-    tenant that synced but never built). The build is a cheap no-op for an org
-    with no source data (it scans a 30-day window and produces zero edges), and
-    materialize then short-circuits on zero components — so fanning out to all
-    active orgs is both correct and inexpensive (CHAOS-2439 review).
+    The chain (not two independent dispatches) guarantees the backfill only runs
+    after the build *succeeds*, so it never projects against a stale/empty graph
+    — the race CHAOS-2374 avoided. It is idempotent and safe to coexist with the
+    post-sync dispatch: membership is keyed on ``computed_at`` (ReplacingMergeTree)
+    and the resolver's per-node latest-run guard supersedes stale rows.
+
+    GATING: dispatched for EVERY active org — deliberately NOT gated on
+    ``work_graph_edges`` existence (that is the build's OUTPUT; gating on it would
+    permanently skip the very tenants the safety net must repair). The build is a
+    cheap no-op for an org with no source data and the backfill short-circuits on
+    zero components, so fanning out to all active orgs is correct and cheap.
 
     Org selection mirrors the other daily fan-out dispatchers
-    (``_discover_active_org_ids`` — active orgs from Postgres, the source of
-    truth, ``["default"]`` fallback only for the positively-detected
-    single-tenant case). It uses ``strict=True`` so a Postgres outage RAISES and
-    triggers retry rather than silently dispatching zero orgs as a clean success.
+    (``_discover_active_org_ids`` — active orgs from Postgres, ``["default"]``
+    fallback only for the positively-detected single-tenant case) with
+    ``strict=True`` so a Postgres outage RAISES and triggers retry rather than
+    silently dispatching zero orgs as a clean success.
 
     Returns:
         dict with the list of dispatched org_ids.
@@ -240,33 +290,33 @@ def dispatch_investment_materialize(
         # empty-success on a multi-tenant DB outage (CHAOS-2439).
         candidate_org_ids = _discover_active_org_ids(strict=True)
     except Exception as exc:
-        logger.exception("dispatch_investment_materialize failed to enumerate orgs")
+        logger.exception("dispatch_membership_backfill failed to enumerate orgs")
         raise self.retry(exc=exc, countdown=60 * (2**self.request.retries))
 
     dispatched: list[str] = []
     for org_id in candidate_org_ids:
-        # Mirror the post-sync immutable chain exactly (CHAOS-2374): build FIRST,
-        # then materialize, on the metrics queue. ``.si()``-equivalent immutability
-        # keeps the build's return value out of materialize's positional args.
-        # Forward the resolved ``db_url`` to BOTH children: an explicit override
-        # (manual/backfill: dispatch_investment_materialize(db_url=...)) must
-        # target the requested ClickHouse, not the workers' ambient instance
-        # (the children otherwise default to _get_db_url()). The scheduled path
-        # passes the same value _get_db_url() already resolves, so behaviour is
-        # unchanged when no override is supplied (CHAOS-2439 review).
+        # Immutable chain (CHAOS-2374): build FIRST (refreshes edges, NO LLM),
+        # then the cheap no-LLM membership projection. ``.si()``-equivalent
+        # immutability keeps the build's return value out of the backfill's args.
+        # Forward the resolved ``db_url`` to BOTH children so an explicit override
+        # (manual/backfill: dispatch_membership_backfill(db_url=...)) targets the
+        # requested ClickHouse, not the workers' ambient instance (the children
+        # otherwise default to _get_db_url()). The scheduled path passes the same
+        # value _get_db_url() already resolves, so behaviour is unchanged when no
+        # override is supplied (CHAOS-2439 review).
         build_sig = celery_app.signature(
             "dev_health_ops.workers.tasks.run_work_graph_build",
             kwargs={"db_url": db_url, "org_id": org_id},
             queue="metrics",
         )
-        materialize_sig = celery_app.signature(
-            "dev_health_ops.workers.tasks.run_investment_materialize",
+        backfill_sig = celery_app.signature(
+            "dev_health_ops.workers.tasks.run_membership_backfill",
             kwargs={"db_url": db_url, "org_id": org_id},
             queue="metrics",
             immutable=True,
         )
-        chain(build_sig, materialize_sig).apply_async()
+        chain(build_sig, backfill_sig).apply_async()
         dispatched.append(org_id)
 
-    logger.info("Investment materialize dispatch: dispatched=%d", len(dispatched))
+    logger.info("Membership backfill dispatch: dispatched=%d", len(dispatched))
     return {"dispatched": dispatched}

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -5,6 +5,8 @@ import uuid
 from datetime import date, datetime, timedelta, timezone
 from datetime import time as dt_time
 
+from celery import chain
+
 from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.task_utils import _get_db_url
@@ -179,3 +181,121 @@ def run_investment_materialize(
     except Exception as exc:
         logger.exception("Investment materialize task failed: %s", exc)
         raise self.retry(exc=exc, countdown=120 * (2**self.request.retries))
+
+
+def _orgs_with_work_graph_data(db_url: str, org_ids: list[str]) -> set[str]:
+    """Return the subset of ``org_ids`` that have any ``work_graph_edges`` rows.
+
+    Scopes the daily floor-cadence fan-out to orgs that actually have a work
+    graph, so empty / never-synced orgs are not churned every night. Sourced
+    from ClickHouse ``work_graph_edges`` — the exact input that the
+    build->materialize chain reads — mirroring how the recommendations job
+    scopes to tables that hold data (``_discover_team_ids``). On any ClickHouse
+    error, returns all candidate orgs (fail open): the per-org chain is itself a
+    no-op for an empty org, so a transient probe failure must not silently skip
+    the safety net it exists to provide.
+    """
+    if not org_ids:
+        return set()
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    try:
+        sink = ClickHouseMetricsSink(db_url)
+        rows = sink.client.query(
+            """
+            SELECT DISTINCT org_id
+            FROM work_graph_edges
+            WHERE org_id IN %(org_ids)s
+            """,
+            parameters={"org_ids": org_ids},
+        ).result_rows
+        return {str(row[0]) for row in rows if row and row[0]}
+    except Exception:
+        logger.warning(
+            "work_graph_edges org-with-data probe failed; "
+            "falling back to all candidate orgs",
+            exc_info=True,
+        )
+        return set(org_ids)
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=3,
+    queue="default",
+    name="dev_health_ops.workers.tasks.dispatch_investment_materialize",
+)
+def dispatch_investment_materialize(
+    self,
+    db_url: str | None = None,
+) -> dict:
+    """Daily floor-cadence safety net for ``work_unit_membership`` (CHAOS-2439).
+
+    Investment materialization (which populates ``work_unit_membership``, read by
+    the work-graph theme/subcategory filter) is otherwise EVENT-DRIVEN ONLY — it
+    runs post-sync via the ``run_work_graph_build`` -> ``run_investment_materialize``
+    chain in ``_dispatch_post_sync_tasks``. Idle-sync orgs and the post-deploy
+    window therefore leave membership empty, stranding theme filters in the
+    ``MEMBERSHIP_NOT_MATERIALIZED`` degraded state indefinitely (CHAOS-2427 #925).
+
+    This dispatcher fans out one per-org job at a fixed daily cadence, queuing the
+    SAME immutable ``build -> materialize`` chain used post-sync. The chain (not
+    two independent dispatches) guarantees materialize only starts after the
+    build *succeeds*, so concurrent metrics workers cannot race materialize ahead
+    of a stale/empty graph — the race CHAOS-2374 avoided. It is idempotent and
+    safe to coexist with the post-sync dispatch: materialization is keyed on
+    ``computed_at`` (ReplacingMergeTree) and re-running simply refreshes the
+    latest run.
+
+    Org selection mirrors the other daily fan-out dispatchers
+    (``_discover_active_org_ids`` — active orgs from Postgres, the source of
+    truth, ``["default"]`` fallback for single-tenant installs), then narrows to
+    orgs that actually have ``work_graph_edges`` so empty orgs are not churned.
+
+    Returns:
+        dict with the list of dispatched org_ids and a skipped count.
+    """
+    from dev_health_ops.workers.recommendations_tasks import _discover_active_org_ids
+
+    db_url = db_url or _get_db_url()
+
+    try:
+        candidate_org_ids = _discover_active_org_ids()
+    except Exception as exc:
+        # A transient Postgres/enumeration failure at the once-daily run must not
+        # report success while computing zero orgs (mirrors dispatch_release_impact):
+        # retry, then surface as a FAILED task rather than a silent empty success.
+        logger.exception("dispatch_investment_materialize failed to enumerate orgs")
+        raise self.retry(exc=exc, countdown=60 * (2**self.request.retries))
+
+    with_data = _orgs_with_work_graph_data(db_url, candidate_org_ids)
+
+    dispatched: list[str] = []
+    skipped = 0
+    for org_id in candidate_org_ids:
+        if org_id not in with_data:
+            skipped += 1
+            continue
+        # Mirror the post-sync immutable chain exactly (CHAOS-2374): build FIRST,
+        # then materialize, on the metrics queue. ``.si()``-equivalent immutability
+        # keeps the build's return value out of materialize's positional args.
+        build_sig = celery_app.signature(
+            "dev_health_ops.workers.tasks.run_work_graph_build",
+            kwargs={"org_id": org_id},
+            queue="metrics",
+        )
+        materialize_sig = celery_app.signature(
+            "dev_health_ops.workers.tasks.run_investment_materialize",
+            kwargs={"org_id": org_id},
+            queue="metrics",
+            immutable=True,
+        )
+        chain(build_sig, materialize_sig).apply_async()
+        dispatched.append(org_id)
+
+    logger.info(
+        "Investment materialize dispatch: dispatched=%d skipped=%d",
+        len(dispatched),
+        skipped,
+    )
+    return {"dispatched": dispatched, "skipped": skipped}

--- a/tests/test_membership_backfill.py
+++ b/tests/test_membership_backfill.py
@@ -1,0 +1,307 @@
+"""Unit tests for the no-LLM membership backfill (CHAOS-2439).
+
+The daily scheduled job must NOT re-run LLM categorization (cost + category
+drift). ``backfill_memberships`` instead PROJECTS ``work_unit_membership`` from
+the theme/subcategory distributions ALREADY persisted in
+``work_unit_investments`` by the post-sync LLM materializer. These tests prove,
+without a live ClickHouse:
+
+- The backfill never touches the categorizer / LLM provider.
+- Its membership rows equal what ``materialize`` would emit for the same
+  persisted distributions (shared-helper consistency).
+- An idle org with existing investments but empty/stale membership gets
+  membership populated, no LLM.
+- A unit whose current component hash has no persisted categorization (edges
+  churned since last LLM run) is skipped, not invented.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import dev_health_ops.connectors  # noqa: F401  (defuse circular import on collection)
+from dev_health_ops.work_graph.investment.backfill import (
+    MembershipBackfillConfig,
+    backfill_memberships,
+)
+from dev_health_ops.work_graph.investment.membership import build_membership_records
+from dev_health_ops.work_graph.investment.utils import work_unit_id
+
+
+class _FakeSink:
+    """Minimal sink stand-in: serves canned edges + investment distributions and
+    captures written membership rows. No real ClickHouse."""
+
+    backend_type = "clickhouse"
+
+    def __init__(
+        self,
+        *,
+        edges: list[dict[str, Any]],
+        investments: list[dict[str, Any]],
+    ) -> None:
+        self._edges = edges
+        # Map work_unit_id -> latest distribution row.
+        self._investments = {str(r["work_unit_id"]): r for r in investments}
+        self.written: list[Any] = []
+        self.query_calls: list[str] = []
+
+    def ensure_schema(self) -> None:
+        return None
+
+    def query_dicts(self, query: str, parameters: dict[str, Any]) -> list[dict]:
+        self.query_calls.append(query)
+        # The backfill issues exactly one query_dicts call: latest distributions
+        # for the requested work_unit_ids.
+        wanted = set(parameters.get("work_unit_ids") or [])
+        return [row for wid, row in self._investments.items() if wid in wanted]
+
+    def write_work_unit_memberships(self, rows) -> None:
+        self.written.extend(rows)
+
+    def close(self) -> None:
+        return None
+
+
+def _edge(src_type: str, src_id: str, tgt_type: str, tgt_id: str) -> dict[str, Any]:
+    return {
+        "edge_id": f"{src_type}:{src_id}->{tgt_type}:{tgt_id}",
+        "source_type": src_type,
+        "source_id": src_id,
+        "target_type": tgt_type,
+        "target_id": tgt_id,
+    }
+
+
+def _investment_row(
+    *,
+    work_unit_id: str,
+    theme: dict[str, float],
+    subcategory: dict[str, float],
+    status: str = "ok",
+) -> dict[str, Any]:
+    return {
+        "work_unit_id": work_unit_id,
+        "theme_distribution_json": theme,
+        "subcategory_distribution_json": subcategory,
+        "categorization_status": status,
+    }
+
+
+def _run_backfill(sink: _FakeSink, org_id: str = "org-1") -> dict[str, int]:
+    """Run backfill_memberships with create_sink + edge fetch patched to the fake.
+
+    ``fetch_work_graph_edges`` is patched to return the sink's canned edges so we
+    drive the full component-build + projection path without ClickHouse.
+    """
+    with (
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.create_sink",
+            return_value=sink,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.fetch_work_graph_edges",
+            side_effect=lambda s, repo_ids=None, org_id="": sink._edges,
+        ),
+    ):
+        return backfill_memberships(
+            MembershipBackfillConfig(dsn="clickhouse://x", org_id=org_id)
+        )
+
+
+def test_backfill_invokes_no_llm_or_categorizer() -> None:
+    """The backfill path must never import/call the categorizer or LLM provider."""
+    # One issue<->pr component with a persisted categorization.
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    uid = work_unit_id([("issue", "I-1"), ("pr", "P-1")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid,
+                theme={"feature_delivery": 1.0},
+                subcategory={"feature_delivery.roadmap": 1.0},
+            )
+        ],
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.investment.categorize.categorize_text_bundle"
+        ) as mock_categorize,
+        patch("dev_health_ops.llm.get_provider") as mock_provider,
+    ):
+        stats = _run_backfill(sink)
+
+    mock_categorize.assert_not_called()
+    mock_provider.assert_not_called()
+    assert stats["matched"] == 1
+    assert stats["memberships"] > 0
+    assert sink.written  # rows were written
+
+
+def test_backfill_rows_match_materialize_shared_helper() -> None:
+    """Backfill membership rows equal build_membership_records (the same shared
+    helper the LLM materializer uses) for the same persisted distributions."""
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    unit_nodes = [("issue", "I-1"), ("pr", "P-1")]
+    uid = work_unit_id(unit_nodes)
+    theme = {"feature_delivery": 0.45, "maintenance": 0.40, "quality": 0.15}
+    sub = {
+        "feature_delivery.roadmap": 0.45,
+        "maintenance.refactor": 0.40,
+        "quality.testing": 0.15,
+    }
+    sink = _FakeSink(
+        edges=edges,
+        investments=[_investment_row(work_unit_id=uid, theme=theme, subcategory=sub)],
+    )
+
+    stats = _run_backfill(sink)
+
+    # Build the expected rows via the SHARED helper (computed_at differs, so
+    # compare on the identity-bearing fields only).
+    written = sink.written
+    assert stats["memberships"] == len(written)
+    # The materializer would emit exactly these (node, kind, category, weight,
+    # is_dominant) tuples for the same distributions.
+    expected = build_membership_records(
+        unit_nodes=unit_nodes,
+        work_unit_id=uid,
+        theme_distribution=theme,
+        subcategory_distribution=sub,
+        categorization_status="ok",
+        computed_at=written[0].computed_at,  # align the non-identity field
+        org_id="org-1",
+    )
+
+    def _key(r):
+        return (
+            r.org_id,
+            r.node_type,
+            r.node_id,
+            r.work_unit_id,
+            r.category_kind,
+            r.category,
+            r.weight,
+            r.is_dominant,
+            r.categorization_status,
+        )
+
+    assert sorted(map(_key, written)) == sorted(map(_key, expected))
+    # Sanity: feature_delivery is dominant, quality (0.15) excluded from themes.
+    theme_cats = {
+        (r.node_id, r.category, r.is_dominant)
+        for r in written
+        if r.category_kind == "theme"
+    }
+    assert ("I-1", "feature_delivery", 1) in theme_cats
+    assert ("I-1", "maintenance", 0) in theme_cats
+    assert not any(c == "quality" for _, c, _ in theme_cats)
+
+
+def test_backfill_populates_idle_org_membership_no_llm() -> None:
+    """Idle org: investments exist (from a prior post-sync run) but membership is
+    empty/stale → backfill writes membership rows for every node, no LLM."""
+    edges = [_edge("issue", "I-1", "commit", "C-1")]
+    uid = work_unit_id([("issue", "I-1"), ("commit", "C-1")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid,
+                theme={"operational": 1.0},
+                subcategory={"operational.support": 1.0},
+            )
+        ],
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.investment.categorize.categorize_text_bundle"
+        ) as mock_categorize,
+    ):
+        stats = _run_backfill(sink)
+
+    mock_categorize.assert_not_called()
+    assert stats["matched"] == 1
+    node_ids = {r.node_id for r in sink.written}
+    assert node_ids == {"I-1", "C-1"}
+    assert all(r.org_id == "org-1" for r in sink.written)
+
+
+def test_backfill_skips_churned_component_without_categorization() -> None:
+    """A current component whose work_unit_id has no persisted investment row
+    (edges churned since last categorization) is SKIPPED — not invented. The
+    post-sync LLM chain covers those."""
+    # Current graph: one matched component + one churned (uncategorized)
+    # component "CHURNED"<->"CP-1" whose hash has no persisted investment row.
+    matched_nodes = [("issue", "MATCHED"), ("pr", "MP-1")]
+    edges = [
+        _edge("issue", "MATCHED", "pr", "MP-1"),
+        _edge("issue", "CHURNED", "pr", "CP-1"),
+    ]
+    matched_uid = work_unit_id(matched_nodes)
+    # Only the matched component has a persisted investment row.
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=matched_uid,
+                theme={"feature_delivery": 1.0},
+                subcategory={"feature_delivery.roadmap": 1.0},
+            )
+        ],
+    )
+
+    stats = _run_backfill(sink)
+
+    assert stats["components"] == 2
+    assert stats["matched"] == 1
+    assert stats["skipped"] == 1
+    # Only the matched component's nodes get membership rows.
+    written_nodes = {r.node_id for r in sink.written}
+    assert written_nodes == {"MATCHED", "MP-1"}
+    assert "CHURNED" not in written_nodes
+    assert "CP-1" not in written_nodes
+
+
+def test_backfill_empty_graph_is_clean_noop() -> None:
+    """No edges → no components → no query, no writes, clean zero stats."""
+    sink = _FakeSink(edges=[], investments=[])
+    stats = _run_backfill(sink)
+    assert stats == {
+        "components": 0,
+        "matched": 0,
+        "skipped": 0,
+        "memberships": 0,
+    }
+    assert sink.written == []
+    assert sink.query_calls == []  # no distribution query when no components
+
+
+def test_backfill_uses_latest_per_work_unit_query() -> None:
+    """The distribution read is latest-per-work_unit_id (argMax on computed_at),
+    matching api/queries/work_unit_investments.py semantics."""
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    uid = work_unit_id([("issue", "I-1"), ("pr", "P-1")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid,
+                theme={"risk": 1.0},
+                subcategory={"risk.security": 1.0},
+            )
+        ],
+    )
+
+    _run_backfill(sink)
+
+    assert len(sink.query_calls) == 1
+    q = sink.query_calls[0]
+    assert "argMax(theme_distribution_json, computed_at)" in q
+    assert "argMax(subcategory_distribution_json, computed_at)" in q
+    assert "GROUP BY org_id, work_unit_id" in q
+    assert "FROM work_unit_investments" in q

--- a/tests/test_membership_backfill.py
+++ b/tests/test_membership_backfill.py
@@ -12,7 +12,8 @@ without a live ClickHouse:
 - An idle org with existing investments but empty/stale membership gets
   membership populated, no LLM.
 - A unit whose current component hash has no persisted categorization (edges
-  churned since last LLM run) is skipped, not invented.
+  churned since last LLM run) receives TOMBSTONE rows (category='', weight=0,
+  is_dominant=0) so stale membership from a prior component is superseded.
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ from unittest.mock import patch
 
 import dev_health_ops.connectors  # noqa: F401  (defuse circular import on collection)
 from dev_health_ops.work_graph.investment.backfill import (
+    TOMBSTONE_CATEGORY,
     MembershipBackfillConfig,
     backfill_memberships,
 )
@@ -231,10 +233,12 @@ def test_backfill_populates_idle_org_membership_no_llm() -> None:
     assert all(r.org_id == "org-1" for r in sink.written)
 
 
-def test_backfill_skips_churned_component_without_categorization() -> None:
+def test_backfill_tombstones_churned_component() -> None:
     """A current component whose work_unit_id has no persisted investment row
-    (edges churned since last categorization) is SKIPPED — not invented. The
-    post-sync LLM chain covers those."""
+    (edges churned since last categorization) receives TOMBSTONE rows with a
+    fresh computed_at so stale prior-component membership is superseded.  The
+    post-sync LLM chain will replace tombstones with real rows when the new
+    component is categorized."""
     # Current graph: one matched component + one churned (uncategorized)
     # component "CHURNED"<->"CP-1" whose hash has no persisted investment row.
     matched_nodes = [("issue", "MATCHED"), ("pr", "MP-1")]
@@ -260,11 +264,26 @@ def test_backfill_skips_churned_component_without_categorization() -> None:
     assert stats["components"] == 2
     assert stats["matched"] == 1
     assert stats["skipped"] == 1
-    # Only the matched component's nodes get membership rows.
+    # Tombstones must be reported in stats (2 nodes × 2 kinds = 4 rows).
+    assert stats["tombstones"] == 4
+
+    # Both matched AND churned nodes were written (tombstones for churned).
     written_nodes = {r.node_id for r in sink.written}
-    assert written_nodes == {"MATCHED", "MP-1"}
-    assert "CHURNED" not in written_nodes
-    assert "CP-1" not in written_nodes
+    assert written_nodes == {"MATCHED", "MP-1", "CHURNED", "CP-1"}
+
+    # Tombstone rows: category='' (sentinel), weight=0, is_dominant=0.
+    churned_rows = [r for r in sink.written if r.node_id in {"CHURNED", "CP-1"}]
+    assert len(churned_rows) == 4  # 2 nodes × 2 kinds
+    for row in churned_rows:
+        assert row.category == TOMBSTONE_CATEGORY
+        assert row.weight == 0.0
+        assert row.is_dominant == 0
+        assert row.categorization_status == "tombstone"
+
+    # Real rows for matched nodes must NOT be tombstones.
+    matched_rows = [r for r in sink.written if r.node_id in {"MATCHED", "MP-1"}]
+    assert all(r.category != TOMBSTONE_CATEGORY for r in matched_rows)
+    assert any(r.is_dominant == 1 for r in matched_rows)
 
 
 def test_backfill_empty_graph_is_clean_noop() -> None:
@@ -275,6 +294,7 @@ def test_backfill_empty_graph_is_clean_noop() -> None:
         "components": 0,
         "matched": 0,
         "skipped": 0,
+        "tombstones": 0,
         "memberships": 0,
     }
     assert sink.written == []
@@ -305,3 +325,177 @@ def test_backfill_uses_latest_per_work_unit_query() -> None:
     assert "argMax(subcategory_distribution_json, computed_at)" in q
     assert "GROUP BY org_id, work_unit_id" in q
     assert "FROM work_unit_investments" in q
+
+
+# ---------------------------------------------------------------------------
+# Regression test: TOMBSTONE-ON-SKIP stale-membership fix (CHAOS-2439)
+# ---------------------------------------------------------------------------
+
+
+def test_tombstone_on_skip_regression() -> None:
+    """REGRESSION: a node that HAD old real membership (theme=quality) from a
+    prior run, whose component then churns so its current work_unit_id has NO
+    investments row, must receive a TOMBSTONE from the backfill.
+
+    This test covers all three invariants:
+
+    (a) Tombstone row IS written for the churned node with the current run's
+        computed_at (not the old computed_at from the stale rows).
+    (b) The resolver's theme filter does NOT return the node for theme=quality
+        — the tombstone category='' never matches the (category_kind, category)
+        tuple filter.
+    (c) Annotation for edges containing the churned node returns theme=None
+        (the tombstone is_dominant=0 row is excluded from the is_dominant=1
+        annotation query, so no category is reported).
+    """
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from dev_health_ops.api.graphql.context import GraphQLContext
+    from dev_health_ops.api.graphql.models.inputs import WorkGraphEdgeFilterInput
+    from dev_health_ops.api.graphql.resolvers.work_graph import resolve_work_graph_edges
+
+    org_id = "org-regression"
+
+    # --- (a) BACKFILL: churned node receives tombstone with fresh computed_at ---
+
+    # Current graph: "STALE-NODE" is now in a NEW component with "NEW-PR".
+    # The work_unit_id for this component has no investments row (churned),
+    # so the backfill will tombstone both nodes.
+    edges = [
+        _edge("issue", "STALE-NODE", "pr", "NEW-PR"),  # churned component
+    ]
+
+    sink = _FakeSink(edges=edges, investments=[])
+
+    stats = _run_backfill(sink)
+
+    # Stats: 1 component, 0 matched, 1 skipped, 4 tombstones (2 nodes × 2 kinds).
+    assert stats["components"] == 1
+    assert stats["matched"] == 0
+    assert stats["skipped"] == 1
+    assert stats["tombstones"] == 4
+    assert stats["memberships"] == 4
+
+    # Tombstone rows were written for both nodes.
+    written_by_node = {r.node_id: r for r in sink.written}
+    assert "STALE-NODE" in written_by_node
+    assert "NEW-PR" in written_by_node
+
+    # Tombstone invariants for STALE-NODE.
+    stale_rows = [r for r in sink.written if r.node_id == "STALE-NODE"]
+    assert len(stale_rows) == 2  # one theme + one subcategory tombstone
+    for row in stale_rows:
+        assert row.category == TOMBSTONE_CATEGORY, "tombstone category must be ''"
+        assert row.weight == 0.0
+        assert row.is_dominant == 0
+        assert row.categorization_status == "tombstone"
+
+    # The tombstone computed_at matches across all rows in this run.
+    tombstone_ts = stale_rows[0].computed_at
+    assert all(r.computed_at == tombstone_ts for r in sink.written)
+
+    # --- (b) RESOLVER FILTER: tombstone node is NOT returned for theme=quality ---
+    #
+    # Simulate the state AFTER the tombstone is written: the resolver queries
+    # work_unit_membership and sees the tombstone row for STALE-NODE.  The
+    # theme=quality filter uses (category_kind, category) IN tuples — since the
+    # tombstone category is '', it can never match ("theme", "quality").
+    #
+    # We drive the resolver with a mock that returns an edge containing STALE-NODE
+    # as an endpoint but whose membership rows (latest-run) are tombstones only.
+    # The filter EXISTS query must NOT find STALE-NODE in "theme=quality".
+
+    edge_row = {
+        "edge_id": "stale-edge",
+        "source_type": "issue",
+        "source_id": "STALE-NODE",
+        "target_type": "pr",
+        "target_id": "NEW-PR",
+        "edge_type": "implements",
+        "provenance": "native",
+        "confidence": 1.0,
+        "evidence": "",
+        "repo_id": None,
+        "provider": "github",
+    }
+
+    context = GraphQLContext(
+        org_id=org_id,
+        db_url="clickhouse://localhost:8123/default",
+        client=object(),
+    )
+
+    # The theme filter EXISTS query runs server-side in ClickHouse; we prove the
+    # predicate construction is correct by asserting the SQL does NOT match the
+    # tombstone sentinel.  When mock returns empty (simulating that the filter
+    # found no matching edges because STALE-NODE's category='' ≠ 'quality'), the
+    # resolver must return an empty edge list.
+    async def _run_filter_test() -> None:
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            # Edge query: ClickHouse correctly returns empty because STALE-NODE
+            # has only tombstone rows (category='') which never match
+            # (category_kind, category) = ('theme', 'quality').
+            # Degraded probe: membership_rows>0 (tombstones are live rows),
+            # investment_rows=0 → not degraded.
+            mock_query.side_effect = [
+                [],  # edge query empty (tombstone doesn't match filter)
+                [{"membership_rows": 4, "investment_rows": 0}],  # degraded probe
+            ]
+            filters = WorkGraphEdgeFilterInput(theme="quality")
+            result = await resolve_work_graph_edges(context, filters)
+
+        # (b): STALE-NODE is not returned for theme=quality filter.
+        assert result.edges == [], (
+            "A tombstoned node must not appear in theme=quality filter results"
+        )
+        # NOT flagged as degraded: tombstones are real live rows, so membership>0.
+        assert result.degraded_reason is None, (
+            "Tombstoned org should NOT be reported as MEMBERSHIP_NOT_MATERIALIZED"
+        )
+
+        # (b continued): verify the filter SQL predicate — the category tuple
+        # ('theme', 'quality') will never match category='' in work_unit_membership.
+        edge_sql = mock_query.call_args_list[0][0][1]
+        edge_params = mock_query.call_args_list[0][0][2]
+        assert "(m.category_kind, m.category) IN %(category_tuples)s" in edge_sql
+        # The category tuple contains a non-empty string; '' ∉ {('theme', 'quality')}.
+        assert ("theme", "quality") in edge_params["category_tuples"]
+        assert TOMBSTONE_CATEGORY not in {
+            cat for _, cat in edge_params["category_tuples"]
+        }
+
+    asyncio.run(_run_filter_test())
+
+    # --- (c) ANNOTATION: edges on STALE-NODE get theme=None ---
+    #
+    # On the unfiltered path, the annotation query selects is_dominant=1 rows.
+    # Tombstone rows have is_dominant=0 so they are excluded, meaning no entry
+    # for STALE-NODE in the annotation result → theme=None, subcategory=None.
+    async def _run_annotation_test() -> None:
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            # Edge query returns the stale edge; annotation query returns NO rows
+            # for STALE-NODE (tombstone has is_dominant=0, excluded by filter).
+            mock_query.side_effect = [
+                [edge_row],
+                [],  # annotation: no is_dominant=1 rows (tombstone excluded)
+            ]
+            result = await resolve_work_graph_edges(context)
+
+        assert len(result.edges) == 1
+        edge = result.edges[0]
+        # (c): annotation for edges on a tombstoned node is theme=None.
+        assert edge.theme is None, (
+            "Edge annotation for a tombstoned node must be theme=None"
+        )
+        assert edge.subcategory is None, (
+            "Edge annotation for a tombstoned node must be subcategory=None"
+        )
+
+    asyncio.run(_run_annotation_test())

--- a/tests/test_migration_fast_path.py
+++ b/tests/test_migration_fast_path.py
@@ -1,0 +1,421 @@
+"""Tests for CHAOS-2440: quiet + fast-path migration ensure.
+
+Covers both runner paths:
+- ClickHouseCore._apply_sql_migrations  (metrics sink, sync)
+- ClickHouseStore._ensure_tables        (storage, async)
+
+Fast-path contract
+------------------
+The per-file loop is skipped entirely ONLY when EVERY on-disk migration is
+already recorded as applied (full-set completeness check —
+``all_migrations_applied``).  Proof: no INSERT INTO schema_migrations is issued
+and query() is called only once (the initial SELECT).
+
+Critically, the fast-path must NOT fire when an *intermediate* migration is
+missing even if the lexicographically-latest one is applied (this repo has
+inserted / mixed-ordering migrations like '023b_' and duplicate numeric
+prefixes — a latest-only check would silently skip the gap, CHAOS-2440).
+
+Quiet contract
+--------------
+Per-migration "Skipping already applied migration: X" lines must be emitted at
+DEBUG level, never INFO, so normal CLI output stays clean.
+
+Ordering contract
+-----------------
+Pending migrations apply in the same ``sorted(*.sql + *.py)`` order, so exotic
+names like '023b_dora_metrics.sql' sort correctly between '023_' and '024_'.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.metrics.sinks.clickhouse.core import ClickHouseCore
+from dev_health_ops.migrations.clickhouse import all_migrations_applied
+from dev_health_ops.storage import ClickHouseStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _applied_result(versions: list[str]) -> MagicMock:
+    result = MagicMock()
+    result.result_rows = [(v,) for v in versions]
+    return result
+
+
+def _make_core_sink(client: MagicMock) -> ClickHouseMetricsSink:
+    """Return a concrete ClickHouseMetricsSink (which inherits ClickHouseCore) with a fake client."""
+    return ClickHouseMetricsSink(
+        dsn="clickhouse://ch:ch@localhost:8123/default", client=client
+    )
+
+
+def _make_store(client: MagicMock) -> ClickHouseStore:
+    """Build a ClickHouseStore without opening a real connection."""
+    store = ClickHouseStore.__new__(ClickHouseStore)
+    store._lock = asyncio.Lock()
+    store._settings = {}
+    store.org_id = None
+    store.client = client
+    return store
+
+
+def _real_migration_files_for(
+    method_code_filename: str, parents_depth: int
+) -> list[Path]:
+    """Return the sorted migration file list the runner would compute at runtime."""
+    migrations_dir = (
+        Path(method_code_filename).resolve().parents[parents_depth]
+        / "migrations"
+        / "clickhouse"
+    )
+    return sorted(
+        list(migrations_dir.glob("*.sql")) + list(migrations_dir.glob("*.py"))
+    )
+
+
+async def _fake_to_thread(fn, *args, **kwargs):
+    """Collapse asyncio.to_thread into a direct synchronous call for testing."""
+    return fn(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# all_migrations_applied — shared full-set completeness helper
+# ---------------------------------------------------------------------------
+
+
+class TestAllMigrationsApplied:
+    def test_empty_disk_is_trivially_applied(self) -> None:
+        assert all_migrations_applied([], ["000_x.sql"]) is True
+
+    def test_all_present_returns_true(self) -> None:
+        files = ["000_a.sql", "001_b.sql", "002_c.sql"]
+        assert all_migrations_applied(files, files) is True
+
+    def test_extra_applied_rows_are_ignored(self) -> None:
+        # DB may have rows for files no longer on disk; completeness only cares
+        # that every ON-DISK file is applied.
+        files = ["000_a.sql", "001_b.sql"]
+        applied = ["000_a.sql", "001_b.sql", "999_removed.sql"]
+        assert all_migrations_applied(files, applied) is True
+
+    def test_missing_latest_returns_false(self) -> None:
+        files = ["000_a.sql", "001_b.sql", "002_c.sql"]
+        applied = ["000_a.sql", "001_b.sql"]
+        assert all_migrations_applied(files, applied) is False
+
+    def test_missing_middle_with_latest_present_returns_false(self) -> None:
+        """The core regression: latest applied but a gap in the middle."""
+        files = ["000_a.sql", "001_b.sql", "002_c.sql"]
+        applied = ["000_a.sql", "002_c.sql"]  # 001 missing, latest 002 present
+        assert all_migrations_applied(files, applied) is False
+
+
+# ---------------------------------------------------------------------------
+# ClickHouseCore._apply_sql_migrations
+# ---------------------------------------------------------------------------
+
+
+class TestApplySqlMigrationsCoreFastPath:
+    def _real_files(self) -> list[Path]:
+        # _apply_sql_migrations lives in core.py; use ClickHouseCore's __code__
+        # to get the source file so parents[3] resolves correctly.
+        return _real_migration_files_for(
+            ClickHouseCore._apply_sql_migrations.__code__.co_filename,
+            parents_depth=3,
+        )
+
+    def _client_with_all_applied(self, files: list[Path]) -> MagicMock:
+        client = MagicMock()
+        client.query.return_value = _applied_result([p.name for p in files])
+        return client
+
+    # ------------------------------------------------------------------
+    # Fast-path: up-to-date DB
+    # ------------------------------------------------------------------
+
+    def test_up_to_date_issues_no_migration_inserts(self) -> None:
+        """When every file on disk is applied, no INSERT INTO schema_migrations fires."""
+        files = self._real_files()
+        assert files, "No real migration files found"
+
+        commands: list[str] = []
+        client = self._client_with_all_applied(files)
+        client.command.side_effect = lambda sql, parameters=None: commands.append(sql)
+
+        _make_core_sink(client)._apply_sql_migrations()
+
+        inserts = [c for c in commands if "INSERT INTO schema_migrations" in c]
+        assert inserts == [], (
+            f"Fast-path missed: INSERT issued when DB is current. Commands: {inserts}"
+        )
+
+    def test_up_to_date_queries_db_exactly_once(self) -> None:
+        """Fast-path must not issue multiple SELECTs against schema_migrations."""
+        files = self._real_files()
+        client = self._client_with_all_applied(files)
+        _make_core_sink(client)._apply_sql_migrations()
+        # One CREATE TABLE + one SELECT → query count must be 1.
+        assert client.query.call_count == 1
+
+    # ------------------------------------------------------------------
+    # Quiet: skip logs must be DEBUG not INFO
+    # ------------------------------------------------------------------
+
+    def test_skip_logs_are_debug_not_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """'Skipping already applied migration' must never appear at INFO level."""
+        files = self._real_files()
+        client = self._client_with_all_applied(files)
+
+        with caplog.at_level(logging.DEBUG, logger="dev_health_ops"):
+            _make_core_sink(client)._apply_sql_migrations()
+
+        info_skips = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.INFO
+            and "Skipping already applied migration" in r.message
+        ]
+        assert info_skips == [], (
+            f"Found INFO-level skip log(s): {[r.message for r in info_skips]}"
+        )
+
+    # ------------------------------------------------------------------
+    # Correctness: pending migrations still applied
+    # ------------------------------------------------------------------
+
+    def test_pending_migration_is_applied_and_recorded(self) -> None:
+        """When DB is one migration behind, that migration is recorded."""
+        files = self._real_files()
+        assert len(files) >= 2, "Need at least 2 migrations for this test"
+
+        # All-but-last applied.
+        applied = [p.name for p in files[:-1]]
+        pending = files[-1]
+
+        client = MagicMock()
+        client.query.return_value = _applied_result(applied)
+        commands: list[str] = []
+        client.command.side_effect = lambda sql, parameters=None: commands.append(sql)
+
+        _make_core_sink(client)._apply_sql_migrations()
+
+        inserts = [c for c in commands if "INSERT INTO schema_migrations" in c]
+        assert len(inserts) == 1, (
+            f"Expected 1 schema_migrations INSERT for {pending.name!r}, got {inserts}"
+        )
+
+    # ------------------------------------------------------------------
+    # Correctness (the critical case): latest applied but a MIDDLE migration
+    # is missing → fast-path must NOT fire and the gap must be filled.
+    # ------------------------------------------------------------------
+
+    def test_missing_middle_migration_is_applied_despite_latest_present(self) -> None:
+        """Latest IS applied but an intermediate migration is ABSENT.
+
+        A latest-filename-only fast-path would falsely short-circuit here and
+        silently skip the missing middle migration (schema drift). The full-set
+        check must detect the gap, run the loop, and apply exactly the missing
+        migration (recording only it).
+        """
+        files = self._real_files()
+        assert len(files) >= 3, "Need at least 3 migrations to drop a middle one"
+
+        # Drop a migration from the MIDDLE; keep the latest applied.
+        missing_idx = len(files) // 2
+        missing = files[missing_idx]
+        applied = [p.name for i, p in enumerate(files) if i != missing_idx]
+        assert files[-1].name in applied, "Latest must remain applied for this test"
+
+        client = MagicMock()
+        client.query.return_value = _applied_result(applied)
+        recorded_versions: list[str] = []
+
+        def record_command(sql: str, parameters: dict | None = None) -> None:
+            if "INSERT INTO schema_migrations" in sql and parameters:
+                recorded_versions.append(parameters["version"])
+
+        client.command.side_effect = record_command
+
+        _make_core_sink(client)._apply_sql_migrations()
+
+        assert recorded_versions == [missing.name], (
+            f"Expected exactly the missing middle migration {missing.name!r} to be "
+            f"applied; got {recorded_versions}"
+        )
+
+    # ------------------------------------------------------------------
+    # Ordering: mixed .sql/.py names with b-suffix sort correctly
+    # ------------------------------------------------------------------
+
+    def test_mixed_sql_py_ordering_matches_fast_path(self) -> None:
+        """Pending migrations apply in the same sort order as the file list.
+
+        Exercises the '023b_' naming convention: it must sort between '023_'
+        and '024_'. With all files applied the full-set fast-path fires.
+        """
+        files = self._real_files()
+        names = [p.name for p in files]
+
+        # Verify corpus has mixed types.
+        exts = {p.suffix for p in files}
+        assert ".sql" in exts and ".py" in exts
+
+        # '023b_dora_metrics.sql' must appear between '023_*' and '024_*'.
+        b_files = [n for n in names if n.startswith("023b")]
+        assert b_files, "Expected at least one '023b_*' migration in the corpus"
+        idx_b = names.index(b_files[0])
+        after_b = names[idx_b + 1 :]
+        assert any(n.startswith("024") for n in after_b), (
+            "'024_*' migration must appear after '023b_*' in sorted order"
+        )
+
+        # Applying all files must hit the fast-path (latest == files[-1].name).
+        client = self._client_with_all_applied(files)
+        commands: list[str] = []
+        client.command.side_effect = lambda sql, parameters=None: commands.append(sql)
+
+        _make_core_sink(client)._apply_sql_migrations()
+
+        inserts = [c for c in commands if "INSERT INTO schema_migrations" in c]
+        assert inserts == [], (
+            f"Fast-path did not trigger for latest={files[-1].name!r}: {inserts}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ClickHouseStore._ensure_tables
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureTablesFastPath:
+    def _real_files(self) -> list[Path]:
+        return _real_migration_files_for(
+            ClickHouseStore._ensure_tables.__code__.co_filename,
+            parents_depth=1,
+        )
+
+    @pytest.mark.asyncio
+    async def test_up_to_date_issues_no_migration_inserts(self) -> None:
+        """Fast-path: no INSERT INTO schema_migrations when DB is current."""
+        files = self._real_files()
+        assert files
+
+        client = MagicMock()
+        client.query.return_value = _applied_result([p.name for p in files])
+        commands: list[str] = []
+        client.command.side_effect = lambda sql, parameters=None: commands.append(sql)
+
+        store = _make_store(client)
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            await store._ensure_tables()
+
+        inserts = [c for c in commands if "INSERT INTO schema_migrations" in c]
+        assert inserts == [], f"Fast-path missed: {inserts}"
+
+    @pytest.mark.asyncio
+    async def test_up_to_date_queries_db_exactly_once(self) -> None:
+        """Only one query call (the version SELECT) when schema is current."""
+        files = self._real_files()
+
+        client = MagicMock()
+        client.query.return_value = _applied_result([p.name for p in files])
+
+        store = _make_store(client)
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            await store._ensure_tables()
+
+        assert client.query.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_skip_logs_are_debug_not_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """'Skipping already applied migration' must not appear at INFO level."""
+        files = self._real_files()
+
+        client = MagicMock()
+        client.query.return_value = _applied_result([p.name for p in files])
+
+        store = _make_store(client)
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            with caplog.at_level(logging.DEBUG, logger="dev_health_ops"):
+                await store._ensure_tables()
+
+        info_skips = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.INFO
+            and "Skipping already applied migration" in r.message
+        ]
+        assert info_skips == [], f"INFO skip log(s): {[r.message for r in info_skips]}"
+
+    @pytest.mark.asyncio
+    async def test_pending_migration_is_applied_and_recorded(self) -> None:
+        """When DB is one migration behind, that migration is recorded."""
+        files = self._real_files()
+        assert len(files) >= 2
+
+        applied = [p.name for p in files[:-1]]
+        pending = files[-1]
+
+        client = MagicMock()
+        client.query.return_value = _applied_result(applied)
+        commands: list[str] = []
+        client.command.side_effect = lambda sql, parameters=None: commands.append(sql)
+
+        store = _make_store(client)
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            await store._ensure_tables()
+
+        inserts = [c for c in commands if "INSERT INTO schema_migrations" in c]
+        assert len(inserts) == 1, (
+            f"Expected 1 INSERT for {pending.name!r}, got {inserts}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_middle_migration_is_applied_despite_latest_present(
+        self,
+    ) -> None:
+        """Latest IS applied but an intermediate migration is ABSENT (async path).
+
+        The full-set fast-path must detect the gap and apply exactly the missing
+        middle migration — a latest-only check would silently skip it.
+        """
+        files = self._real_files()
+        assert len(files) >= 3, "Need at least 3 migrations to drop a middle one"
+
+        missing_idx = len(files) // 2
+        missing = files[missing_idx]
+        applied = [p.name for i, p in enumerate(files) if i != missing_idx]
+        assert files[-1].name in applied, "Latest must remain applied for this test"
+
+        client = MagicMock()
+        client.query.return_value = _applied_result(applied)
+        recorded_versions: list[str] = []
+
+        def record_command(sql: str, parameters: dict | None = None) -> None:
+            if "INSERT INTO schema_migrations" in sql and parameters:
+                recorded_versions.append(parameters["version"])
+
+        client.command.side_effect = record_command
+
+        store = _make_store(client)
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            await store._ensure_tables()
+
+        assert recorded_versions == [missing.name], (
+            f"Expected exactly the missing middle migration {missing.name!r} to be "
+            f"applied; got {recorded_versions}"
+        )

--- a/tests/test_scheduled_investment_dispatch.py
+++ b/tests/test_scheduled_investment_dispatch.py
@@ -66,12 +66,21 @@ def test_beat_entry_does_not_collide_with_neighbours() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _run_dispatch(*, active_org_ids: list[str]):
+# The default db_url _get_db_url() resolves to on the scheduled (no-override) path.
+_SCHEDULED_DB_URL = "clickhouse://x"
+
+
+def _run_dispatch(*, active_org_ids: list[str], db_url: str | None = None):
     """Drive dispatch_investment_materialize with chain/signature/sources patched.
 
     Returns (signature_mock, chain_mock, chain_instances, result).
     ``chain_instances`` is the list of per-call chain instances (one per org
     that was dispatched), so tests can assert apply_async per org.
+
+    ``db_url`` is the explicit override passed to ``.run()`` (manual/backfill).
+    When ``None`` the scheduled path resolves ``_get_db_url()`` →
+    ``_SCHEDULED_DB_URL``. Either way the resolved value must be forwarded to
+    BOTH child signatures.
 
     The dispatcher fans out to ALL active orgs (no output-table gate), so the
     discovery patch is the only org source. ``strict=True`` is exercised
@@ -102,13 +111,18 @@ def _run_dispatch(*, active_org_ids: list[str]):
         ),
         patch(
             "dev_health_ops.workers.work_graph_tasks._get_db_url",
-            return_value="clickhouse://x",
+            return_value=_SCHEDULED_DB_URL,
         ),
     ):
         mock_signature.side_effect = _make_sig
         mock_chain.side_effect = _make_chain
-        # bind=True task: invoke .run() so `self` is supplied by Celery.
-        result = dispatch_investment_materialize.run()
+        # bind=True task: invoke .run() so `self` is supplied by Celery. Pass the
+        # explicit override only when given so the no-arg scheduled path is
+        # exercised exactly as Celery beat would call it.
+        if db_url is None:
+            result = dispatch_investment_materialize.run()
+        else:
+            result = dispatch_investment_materialize.run(db_url=db_url)
 
     return mock_signature, mock_chain, chain_instances, result
 
@@ -193,19 +207,58 @@ def test_dispatch_single_tenant_default_org() -> None:
 def test_dispatch_chain_shape_matches_post_sync_dispatch() -> None:
     """The scheduled chain is the SAME shape as the post-sync chain — idempotent
     and safe to coexist: same task names, same metrics queue, same immutable
-    link, same org-scoped kwargs."""
+    link, org-scoped kwargs, and the resolved db_url forwarded to both."""
     _, mock_chain, _, _ = _run_dispatch(active_org_ids=["org-1"])
 
     build_sig, materialize_sig = mock_chain.call_args.args
-    # Identical to _dispatch_post_sync_tasks' chain contract.
+    # The scheduled path forwards the _get_db_url()-resolved value to both children.
     assert build_sig.task_name == _WORK_GRAPH_TASK
-    assert build_sig.sig_kwargs == {"kwargs": {"org_id": "org-1"}, "queue": "metrics"}
+    assert build_sig.sig_kwargs == {
+        "kwargs": {"db_url": _SCHEDULED_DB_URL, "org_id": "org-1"},
+        "queue": "metrics",
+    }
     assert materialize_sig.task_name == _INVESTMENT_TASK
     assert materialize_sig.sig_kwargs == {
-        "kwargs": {"org_id": "org-1"},
+        "kwargs": {"db_url": _SCHEDULED_DB_URL, "org_id": "org-1"},
         "queue": "metrics",
         "immutable": True,
     }
+
+
+def test_dispatch_forwards_explicit_db_url_override_to_both_children() -> None:
+    """CHAOS-2439 [HIGH] regression: an explicit db_url override (manual/backfill)
+    must reach BOTH child signatures, so build+materialize target the requested
+    ClickHouse instead of the workers' ambient _get_db_url() default."""
+    override = "clickhouse://override"
+    _, mock_chain, _, result = _run_dispatch(
+        active_org_ids=["org-1", "org-2"], db_url=override
+    )
+
+    assert mock_chain.call_count == 2
+    for call in mock_chain.call_args_list:
+        build_sig, materialize_sig = call.args
+        org = build_sig.sig_kwargs["kwargs"]["org_id"]
+        # BOTH children carry the override db_url AND the org_id.
+        assert build_sig.sig_kwargs["kwargs"] == {"db_url": override, "org_id": org}
+        assert materialize_sig.sig_kwargs["kwargs"] == {
+            "db_url": override,
+            "org_id": org,
+        }
+        # The override never collapses to the ambient default.
+        assert build_sig.sig_kwargs["kwargs"]["db_url"] != _SCHEDULED_DB_URL
+        # Immutable link preserved on materialize.
+        assert materialize_sig.sig_kwargs.get("immutable") is True
+    assert result["dispatched"] == ["org-1", "org-2"]
+
+
+def test_dispatch_scheduled_path_forwards_resolved_default_db_url() -> None:
+    """Scheduled (no-override) path: the _get_db_url()-resolved default is
+    forwarded to both children — behaviour unchanged from today's default."""
+    _, mock_chain, _, _ = _run_dispatch(active_org_ids=["org-1"])
+
+    build_sig, materialize_sig = mock_chain.call_args.args
+    assert build_sig.sig_kwargs["kwargs"]["db_url"] == _SCHEDULED_DB_URL
+    assert materialize_sig.sig_kwargs["kwargs"]["db_url"] == _SCHEDULED_DB_URL
 
 
 def test_dispatch_uses_strict_discovery() -> None:

--- a/tests/test_scheduled_investment_dispatch.py
+++ b/tests/test_scheduled_investment_dispatch.py
@@ -66,16 +66,16 @@ def test_beat_entry_does_not_collide_with_neighbours() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _run_dispatch(
-    *,
-    active_org_ids: list[str],
-    orgs_with_data: set[str] | None = None,
-):
+def _run_dispatch(*, active_org_ids: list[str]):
     """Drive dispatch_investment_materialize with chain/signature/sources patched.
 
     Returns (signature_mock, chain_mock, chain_instances, result).
     ``chain_instances`` is the list of per-call chain instances (one per org
     that was dispatched), so tests can assert apply_async per org.
+
+    The dispatcher fans out to ALL active orgs (no output-table gate), so the
+    discovery patch is the only org source. ``strict=True`` is exercised
+    separately in the enumeration-failure test.
     """
     chain_instances: list[MagicMock] = []
 
@@ -101,12 +101,6 @@ def _run_dispatch(
             return_value=active_org_ids,
         ),
         patch(
-            "dev_health_ops.workers.work_graph_tasks._orgs_with_work_graph_data",
-            return_value=(
-                orgs_with_data if orgs_with_data is not None else set(active_org_ids)
-            ),
-        ),
-        patch(
             "dev_health_ops.workers.work_graph_tasks._get_db_url",
             return_value="clickhouse://x",
         ),
@@ -120,7 +114,7 @@ def _run_dispatch(
 
 
 def test_dispatch_queues_build_then_materialize_chain_per_org() -> None:
-    """Each org with data gets a build -> materialize chain in chained order."""
+    """Each active org gets a build -> materialize chain in chained order."""
     mock_signature, mock_chain, chain_instances, result = _run_dispatch(
         active_org_ids=["org-1", "org-2"],
     )
@@ -154,35 +148,46 @@ def test_dispatch_queues_build_then_materialize_chain_per_org() -> None:
     assert dispatched_orgs == ["org-1", "org-2"]
 
     assert result["dispatched"] == ["org-1", "org-2"]
-    assert result["skipped"] == 0
 
 
-def test_dispatch_skips_orgs_without_work_graph_data() -> None:
-    """Active orgs with no work_graph_edges are skipped (not churned)."""
-    _, mock_chain, chain_instances, result = _run_dispatch(
-        active_org_ids=["org-has-data", "org-empty"],
-        orgs_with_data={"org-has-data"},
+def test_dispatch_does_not_gate_on_work_graph_edges_output_table() -> None:
+    """CHAOS-2439 [HIGH] regression: an active org with raw synced inputs but
+    ZERO work_graph_edges rows (failed prior build / truncated graph / brand-new
+    synced-but-never-built tenant) MUST still be dispatched — the rebuild is
+    exactly what repairs it. The dispatcher therefore must NOT gate on the
+    build's own OUTPUT table.
+
+    We prove the gate is gone two ways: (1) the module exposes no
+    work_graph_edges probe helper, and (2) every active org is dispatched even
+    though no ClickHouse edge data exists in this unit context.
+    """
+    import dev_health_ops.workers.work_graph_tasks as wgt
+
+    # The output-table gate helper no longer exists.
+    assert not hasattr(wgt, "_orgs_with_work_graph_data")
+
+    _, mock_chain, _, result = _run_dispatch(
+        active_org_ids=["org-synced-no-edges-yet"],
     )
 
-    # Only the org with data gets a chain.
+    # Dispatched despite having no work_graph_edges rows.
     assert mock_chain.call_count == 1
     build_sig, _ = mock_chain.call_args.args
-    assert build_sig.sig_kwargs["kwargs"]["org_id"] == "org-has-data"
-    assert result["dispatched"] == ["org-has-data"]
-    assert result["skipped"] == 1
+    assert build_sig.sig_kwargs["kwargs"]["org_id"] == "org-synced-no-edges-yet"
+    assert result["dispatched"] == ["org-synced-no-edges-yet"]
+    # No "skipped" accounting — there is no skip path anymore.
+    assert "skipped" not in result
 
 
-def test_dispatch_no_orgs_with_data_dispatches_nothing() -> None:
-    """When no candidate org has data, nothing is queued (clean no-op)."""
-    _, mock_chain, chain_instances, result = _run_dispatch(
-        active_org_ids=["org-1", "org-2"],
-        orgs_with_data=set(),
-    )
+def test_dispatch_single_tenant_default_org() -> None:
+    """A positively-detected single-tenant install (['default']) is dispatched
+    like any other org — a cheap no-op build/materialize if it has no data."""
+    _, mock_chain, _, result = _run_dispatch(active_org_ids=["default"])
 
-    mock_chain.assert_not_called()
-    assert chain_instances == []
-    assert result["dispatched"] == []
-    assert result["skipped"] == 2
+    assert mock_chain.call_count == 1
+    build_sig, _ = mock_chain.call_args.args
+    assert build_sig.sig_kwargs["kwargs"]["org_id"] == "default"
+    assert result["dispatched"] == ["default"]
 
 
 def test_dispatch_chain_shape_matches_post_sync_dispatch() -> None:
@@ -203,9 +208,30 @@ def test_dispatch_chain_shape_matches_post_sync_dispatch() -> None:
     }
 
 
+def test_dispatch_uses_strict_discovery() -> None:
+    """The dispatcher calls discovery with strict=True so a DB outage raises
+    rather than collapsing to ['default']."""
+    with (
+        patch(
+            "dev_health_ops.workers.recommendations_tasks._discover_active_org_ids",
+            return_value=["org-1"],
+        ) as mock_discover,
+        patch("dev_health_ops.workers.work_graph_tasks.chain"),
+        patch("dev_health_ops.workers.work_graph_tasks.celery_app.signature"),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks._get_db_url",
+            return_value="clickhouse://x",
+        ),
+    ):
+        dispatch_investment_materialize.run()
+
+    mock_discover.assert_called_once_with(strict=True)
+
+
 def test_dispatch_retries_on_org_enumeration_failure() -> None:
-    """A transient org-enumeration failure retries rather than reporting a silent
-    empty success (mirrors dispatch_release_impact)."""
+    """A transient org-enumeration failure (strict discovery RAISES) triggers
+    retry rather than reporting a silent empty success (mirrors
+    dispatch_release_impact)."""
 
     class _Retry(Exception):
         pass
@@ -233,31 +259,75 @@ def test_dispatch_retries_on_org_enumeration_failure() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Org-with-data probe (fail-open)
+# Strict org discovery (CHAOS-2439 finding 2)
 # ---------------------------------------------------------------------------
 
 
-def test_orgs_with_work_graph_data_fails_open_on_clickhouse_error() -> None:
-    """If the ClickHouse probe errors, return all candidate orgs (fail open) so
-    the safety net still runs."""
-    from dev_health_ops.workers.work_graph_tasks import _orgs_with_work_graph_data
+def test_discover_active_org_ids_strict_raises_on_db_error() -> None:
+    """strict=True: a Postgres enumeration error RAISES (so the once-daily
+    dispatcher retries) instead of silently returning ['default']."""
+    from dev_health_ops.workers.recommendations_tasks import _discover_active_org_ids
 
-    class _BoomSink:
-        def __init__(self, *_a: Any, **_k: Any) -> None:
-            self.client = self
+    class _BoomSession:
+        def __enter__(self):
+            raise RuntimeError("postgres down")
 
-        def query(self, *_a: Any, **_k: Any):
-            raise RuntimeError("clickhouse unreachable")
+        def __exit__(self, *a):
+            return False
+
+    import pytest
 
     with patch(
-        "dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink",
-        _BoomSink,
+        "dev_health_ops.db.get_postgres_session_sync",
+        return_value=_BoomSession(),
     ):
-        out = _orgs_with_work_graph_data("clickhouse://x", ["org-1", "org-2"])
-    assert out == {"org-1", "org-2"}
+        with pytest.raises(RuntimeError, match="postgres down"):
+            _discover_active_org_ids(strict=True)
 
 
-def test_orgs_with_work_graph_data_empty_input_returns_empty() -> None:
-    from dev_health_ops.workers.work_graph_tasks import _orgs_with_work_graph_data
+def test_discover_active_org_ids_non_strict_falls_back_on_db_error() -> None:
+    """strict=False (default): a DB error still falls back to ['default'] so the
+    best-effort recommendations job is unaffected."""
+    from dev_health_ops.workers.recommendations_tasks import _discover_active_org_ids
 
-    assert _orgs_with_work_graph_data("clickhouse://x", []) == set()
+    class _BoomSession:
+        def __enter__(self):
+            raise RuntimeError("postgres down")
+
+        def __exit__(self, *a):
+            return False
+
+    with patch(
+        "dev_health_ops.db.get_postgres_session_sync",
+        return_value=_BoomSession(),
+    ):
+        assert _discover_active_org_ids() == ["default"]
+
+
+def test_discover_active_org_ids_strict_empty_table_returns_default() -> None:
+    """strict=True: a SUCCESSFUL query that finds zero active orgs still returns
+    ['default'] — the positively-detected single-tenant case is NOT an error."""
+    from dev_health_ops.workers.recommendations_tasks import _discover_active_org_ids
+
+    class _Query:
+        def filter(self, *_a: Any):
+            return self
+
+        def all(self):
+            return []
+
+    class _Session:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def query(self, *_a: Any):
+            return _Query()
+
+    with patch(
+        "dev_health_ops.db.get_postgres_session_sync",
+        return_value=_Session(),
+    ):
+        assert _discover_active_org_ids(strict=True) == ["default"]

--- a/tests/test_scheduled_investment_dispatch.py
+++ b/tests/test_scheduled_investment_dispatch.py
@@ -1,0 +1,263 @@
+"""Unit tests for the daily scheduled investment-materialize dispatch (CHAOS-2439).
+
+Investment materialization (which populates ``work_unit_membership``, read by
+the work-graph theme/subcategory filter) was EVENT-DRIVEN ONLY — it ran post-sync
+via the ``run_work_graph_build`` -> ``run_investment_materialize`` chain. Idle-sync
+orgs and the post-deploy window therefore left membership empty, stranding theme
+filters in the ``MEMBERSHIP_NOT_MATERIALIZED`` degraded state (CHAOS-2427 #925).
+
+``dispatch_investment_materialize`` is a daily floor-cadence safety net: it fans
+out the SAME immutable ``build -> materialize`` chain per active org that has
+work-graph data. These tests prove the seam without a live broker/ClickHouse:
+they patch the Celery ``chain`` / ``signature`` factories and the org/data
+sources, and assert the chain composition (chained order, immutability,
+org-scoping) and idempotent coexistence with the post-sync dispatch. They follow
+``tests/test_post_sync_investment_dispatch.py`` style.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# Import connectors first to defuse the providers._base <-> connectors circular
+# import that otherwise ERRORs isolated collection (mirrors CHAOS-2370/2374).
+import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.workers.config import beat_schedule
+from dev_health_ops.workers.work_graph_tasks import dispatch_investment_materialize
+
+_INVESTMENT_TASK = "dev_health_ops.workers.tasks.run_investment_materialize"
+_WORK_GRAPH_TASK = "dev_health_ops.workers.tasks.run_work_graph_build"
+_BEAT_NAME = "run-investment-materialize-daily"
+_DISPATCH_TASK = "dev_health_ops.workers.tasks.dispatch_investment_materialize"
+
+
+# ---------------------------------------------------------------------------
+# Beat schedule registration
+# ---------------------------------------------------------------------------
+
+
+def test_beat_entry_registered_with_expected_name_and_schedule() -> None:
+    """The daily floor-cadence beat entry is wired with the right task + time."""
+    from celery.schedules import crontab
+
+    assert _BEAT_NAME in beat_schedule
+    entry = beat_schedule[_BEAT_NAME]
+    assert entry["task"] == _DISPATCH_TASK
+    # Daily at 01:15 UTC — clear of run-daily-metrics (01:00) and
+    # run-release-impact (01:30).
+    assert entry["schedule"] == crontab(hour=1, minute=15)
+    assert entry["options"]["queue"] == "default"
+
+
+def test_beat_entry_does_not_collide_with_neighbours() -> None:
+    """01:15 sits strictly between the 01:00 and 01:30 daily jobs."""
+    from celery.schedules import crontab
+
+    assert beat_schedule["run-daily-metrics"]["schedule"] == crontab(hour=1, minute=0)
+    assert beat_schedule["run-release-impact-daily"]["schedule"] == crontab(
+        hour=1, minute=30
+    )
+    assert beat_schedule[_BEAT_NAME]["schedule"] == crontab(hour=1, minute=15)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch fan-out + chain composition
+# ---------------------------------------------------------------------------
+
+
+def _run_dispatch(
+    *,
+    active_org_ids: list[str],
+    orgs_with_data: set[str] | None = None,
+):
+    """Drive dispatch_investment_materialize with chain/signature/sources patched.
+
+    Returns (signature_mock, chain_mock, chain_instances, result).
+    ``chain_instances`` is the list of per-call chain instances (one per org
+    that was dispatched), so tests can assert apply_async per org.
+    """
+    chain_instances: list[MagicMock] = []
+
+    def _make_chain(*sigs):
+        inst = MagicMock(name=f"chain_instance[{len(chain_instances)}]")
+        inst.chained_sigs = sigs
+        chain_instances.append(inst)
+        return inst
+
+    def _make_sig(name, **kwargs):
+        sig = MagicMock(name=f"sig:{name}")
+        sig.task_name = name
+        sig.sig_kwargs = kwargs
+        return sig
+
+    with (
+        patch(
+            "dev_health_ops.workers.work_graph_tasks.celery_app.signature"
+        ) as mock_signature,
+        patch("dev_health_ops.workers.work_graph_tasks.chain") as mock_chain,
+        patch(
+            "dev_health_ops.workers.recommendations_tasks._discover_active_org_ids",
+            return_value=active_org_ids,
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks._orgs_with_work_graph_data",
+            return_value=(
+                orgs_with_data if orgs_with_data is not None else set(active_org_ids)
+            ),
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks._get_db_url",
+            return_value="clickhouse://x",
+        ),
+    ):
+        mock_signature.side_effect = _make_sig
+        mock_chain.side_effect = _make_chain
+        # bind=True task: invoke .run() so `self` is supplied by Celery.
+        result = dispatch_investment_materialize.run()
+
+    return mock_signature, mock_chain, chain_instances, result
+
+
+def test_dispatch_queues_build_then_materialize_chain_per_org() -> None:
+    """Each org with data gets a build -> materialize chain in chained order."""
+    mock_signature, mock_chain, chain_instances, result = _run_dispatch(
+        active_org_ids=["org-1", "org-2"],
+    )
+
+    # One chain per org, each applied async exactly once.
+    assert mock_chain.call_count == 2
+    assert len(chain_instances) == 2
+    for inst in chain_instances:
+        inst.apply_async.assert_called_once_with()
+
+    # Assert CHAIN composition (not parallel): build FIRST, materialize SECOND.
+    for call in mock_chain.call_args_list:
+        build_sig, materialize_sig = call.args
+        assert build_sig.task_name == _WORK_GRAPH_TASK
+        assert materialize_sig.task_name == _INVESTMENT_TASK
+        # Materialize is linked IMMUTABLE so the build's return value is not
+        # injected as a positional arg (the CHAOS-2374 race guard).
+        assert materialize_sig.sig_kwargs.get("immutable") is True
+        assert build_sig.sig_kwargs.get("immutable") is not True
+        # Both org-scoped onto the metrics queue.
+        assert build_sig.sig_kwargs["queue"] == "metrics"
+        assert materialize_sig.sig_kwargs["queue"] == "metrics"
+
+    # Per-org scoping: each org's chain carries that org's id on both sigs.
+    dispatched_orgs = []
+    for call in mock_chain.call_args_list:
+        build_sig, materialize_sig = call.args
+        org = build_sig.sig_kwargs["kwargs"]["org_id"]
+        assert materialize_sig.sig_kwargs["kwargs"]["org_id"] == org
+        dispatched_orgs.append(org)
+    assert dispatched_orgs == ["org-1", "org-2"]
+
+    assert result["dispatched"] == ["org-1", "org-2"]
+    assert result["skipped"] == 0
+
+
+def test_dispatch_skips_orgs_without_work_graph_data() -> None:
+    """Active orgs with no work_graph_edges are skipped (not churned)."""
+    _, mock_chain, chain_instances, result = _run_dispatch(
+        active_org_ids=["org-has-data", "org-empty"],
+        orgs_with_data={"org-has-data"},
+    )
+
+    # Only the org with data gets a chain.
+    assert mock_chain.call_count == 1
+    build_sig, _ = mock_chain.call_args.args
+    assert build_sig.sig_kwargs["kwargs"]["org_id"] == "org-has-data"
+    assert result["dispatched"] == ["org-has-data"]
+    assert result["skipped"] == 1
+
+
+def test_dispatch_no_orgs_with_data_dispatches_nothing() -> None:
+    """When no candidate org has data, nothing is queued (clean no-op)."""
+    _, mock_chain, chain_instances, result = _run_dispatch(
+        active_org_ids=["org-1", "org-2"],
+        orgs_with_data=set(),
+    )
+
+    mock_chain.assert_not_called()
+    assert chain_instances == []
+    assert result["dispatched"] == []
+    assert result["skipped"] == 2
+
+
+def test_dispatch_chain_shape_matches_post_sync_dispatch() -> None:
+    """The scheduled chain is the SAME shape as the post-sync chain — idempotent
+    and safe to coexist: same task names, same metrics queue, same immutable
+    link, same org-scoped kwargs."""
+    _, mock_chain, _, _ = _run_dispatch(active_org_ids=["org-1"])
+
+    build_sig, materialize_sig = mock_chain.call_args.args
+    # Identical to _dispatch_post_sync_tasks' chain contract.
+    assert build_sig.task_name == _WORK_GRAPH_TASK
+    assert build_sig.sig_kwargs == {"kwargs": {"org_id": "org-1"}, "queue": "metrics"}
+    assert materialize_sig.task_name == _INVESTMENT_TASK
+    assert materialize_sig.sig_kwargs == {
+        "kwargs": {"org_id": "org-1"},
+        "queue": "metrics",
+        "immutable": True,
+    }
+
+
+def test_dispatch_retries_on_org_enumeration_failure() -> None:
+    """A transient org-enumeration failure retries rather than reporting a silent
+    empty success (mirrors dispatch_release_impact)."""
+
+    class _Retry(Exception):
+        pass
+
+    with (
+        patch(
+            "dev_health_ops.workers.recommendations_tasks._discover_active_org_ids",
+            side_effect=RuntimeError("postgres down"),
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks._get_db_url",
+            return_value="clickhouse://x",
+        ),
+        patch.object(
+            dispatch_investment_materialize,
+            "retry",
+            side_effect=_Retry(),
+        ) as mock_retry,
+    ):
+        import pytest
+
+        with pytest.raises(_Retry):
+            dispatch_investment_materialize.run()
+    mock_retry.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Org-with-data probe (fail-open)
+# ---------------------------------------------------------------------------
+
+
+def test_orgs_with_work_graph_data_fails_open_on_clickhouse_error() -> None:
+    """If the ClickHouse probe errors, return all candidate orgs (fail open) so
+    the safety net still runs."""
+    from dev_health_ops.workers.work_graph_tasks import _orgs_with_work_graph_data
+
+    class _BoomSink:
+        def __init__(self, *_a: Any, **_k: Any) -> None:
+            self.client = self
+
+        def query(self, *_a: Any, **_k: Any):
+            raise RuntimeError("clickhouse unreachable")
+
+    with patch(
+        "dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink",
+        _BoomSink,
+    ):
+        out = _orgs_with_work_graph_data("clickhouse://x", ["org-1", "org-2"])
+    assert out == {"org-1", "org-2"}
+
+
+def test_orgs_with_work_graph_data_empty_input_returns_empty() -> None:
+    from dev_health_ops.workers.work_graph_tasks import _orgs_with_work_graph_data
+
+    assert _orgs_with_work_graph_data("clickhouse://x", []) == set()

--- a/tests/test_scheduled_membership_backfill.py
+++ b/tests/test_scheduled_membership_backfill.py
@@ -1,17 +1,19 @@
-"""Unit tests for the daily scheduled investment-materialize dispatch (CHAOS-2439).
+"""Unit tests for the daily scheduled membership-backfill dispatch (CHAOS-2439).
 
-Investment materialization (which populates ``work_unit_membership``, read by
-the work-graph theme/subcategory filter) was EVENT-DRIVEN ONLY — it ran post-sync
-via the ``run_work_graph_build`` -> ``run_investment_materialize`` chain. Idle-sync
-orgs and the post-deploy window therefore left membership empty, stranding theme
-filters in the ``MEMBERSHIP_NOT_MATERIALIZED`` degraded state (CHAOS-2427 #925).
+``work_unit_membership`` (read by the work-graph theme/subcategory filter) was
+populated EVENT-DRIVEN ONLY — post-sync via the ``run_work_graph_build`` ->
+``run_investment_materialize`` (LLM) chain. Idle-sync orgs and the post-deploy
+window therefore left membership empty, stranding theme filters in the
+``MEMBERSHIP_NOT_MATERIALIZED`` degraded state (CHAOS-2427 #925).
 
-``dispatch_investment_materialize`` is a daily floor-cadence safety net: it fans
-out the SAME immutable ``build -> materialize`` chain per active org that has
-work-graph data. These tests prove the seam without a live broker/ClickHouse:
-they patch the Celery ``chain`` / ``signature`` factories and the org/data
-sources, and assert the chain composition (chained order, immutability,
-org-scoping) and idempotent coexistence with the post-sync dispatch. They follow
+The daily job must NOT re-run LLM materialization (cost + category drift), so
+``dispatch_membership_backfill`` fans out a CHEAP no-LLM chain per active org:
+``run_work_graph_build`` -> ``run_membership_backfill`` (which projects
+membership from already-persisted distributions). These tests prove the seam
+without a live broker/ClickHouse: they patch the Celery ``chain`` / ``signature``
+factories and the org/data sources, and assert the chain composition (chained
+order, immutability, org-scoping, db_url threading) and idempotent coexistence
+with the unchanged post-sync LLM dispatch. They follow
 ``tests/test_post_sync_investment_dispatch.py`` style.
 """
 
@@ -24,12 +26,12 @@ from unittest.mock import MagicMock, patch
 # import that otherwise ERRORs isolated collection (mirrors CHAOS-2370/2374).
 import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.workers.config import beat_schedule
-from dev_health_ops.workers.work_graph_tasks import dispatch_investment_materialize
+from dev_health_ops.workers.work_graph_tasks import dispatch_membership_backfill
 
-_INVESTMENT_TASK = "dev_health_ops.workers.tasks.run_investment_materialize"
+_BACKFILL_TASK = "dev_health_ops.workers.tasks.run_membership_backfill"
 _WORK_GRAPH_TASK = "dev_health_ops.workers.tasks.run_work_graph_build"
-_BEAT_NAME = "run-investment-materialize-daily"
-_DISPATCH_TASK = "dev_health_ops.workers.tasks.dispatch_investment_materialize"
+_BEAT_NAME = "run-membership-backfill-daily"
+_DISPATCH_TASK = "dev_health_ops.workers.tasks.dispatch_membership_backfill"
 
 
 # ---------------------------------------------------------------------------
@@ -71,7 +73,7 @@ _SCHEDULED_DB_URL = "clickhouse://x"
 
 
 def _run_dispatch(*, active_org_ids: list[str], db_url: str | None = None):
-    """Drive dispatch_investment_materialize with chain/signature/sources patched.
+    """Drive dispatch_membership_backfill with chain/signature/sources patched.
 
     Returns (signature_mock, chain_mock, chain_instances, result).
     ``chain_instances`` is the list of per-call chain instances (one per org
@@ -120,15 +122,15 @@ def _run_dispatch(*, active_org_ids: list[str], db_url: str | None = None):
         # explicit override only when given so the no-arg scheduled path is
         # exercised exactly as Celery beat would call it.
         if db_url is None:
-            result = dispatch_investment_materialize.run()
+            result = dispatch_membership_backfill.run()
         else:
-            result = dispatch_investment_materialize.run(db_url=db_url)
+            result = dispatch_membership_backfill.run(db_url=db_url)
 
     return mock_signature, mock_chain, chain_instances, result
 
 
-def test_dispatch_queues_build_then_materialize_chain_per_org() -> None:
-    """Each active org gets a build -> materialize chain in chained order."""
+def test_dispatch_queues_build_then_backfill_chain_per_org() -> None:
+    """Each active org gets a build -> backfill chain in chained order."""
     mock_signature, mock_chain, chain_instances, result = _run_dispatch(
         active_org_ids=["org-1", "org-2"],
     )
@@ -139,25 +141,25 @@ def test_dispatch_queues_build_then_materialize_chain_per_org() -> None:
     for inst in chain_instances:
         inst.apply_async.assert_called_once_with()
 
-    # Assert CHAIN composition (not parallel): build FIRST, materialize SECOND.
+    # Assert CHAIN composition (not parallel): build FIRST, backfill SECOND.
     for call in mock_chain.call_args_list:
-        build_sig, materialize_sig = call.args
+        build_sig, backfill_sig = call.args
         assert build_sig.task_name == _WORK_GRAPH_TASK
-        assert materialize_sig.task_name == _INVESTMENT_TASK
-        # Materialize is linked IMMUTABLE so the build's return value is not
+        assert backfill_sig.task_name == _BACKFILL_TASK
+        # Backfill is linked IMMUTABLE so the build's return value is not
         # injected as a positional arg (the CHAOS-2374 race guard).
-        assert materialize_sig.sig_kwargs.get("immutable") is True
+        assert backfill_sig.sig_kwargs.get("immutable") is True
         assert build_sig.sig_kwargs.get("immutable") is not True
         # Both org-scoped onto the metrics queue.
         assert build_sig.sig_kwargs["queue"] == "metrics"
-        assert materialize_sig.sig_kwargs["queue"] == "metrics"
+        assert backfill_sig.sig_kwargs["queue"] == "metrics"
 
     # Per-org scoping: each org's chain carries that org's id on both sigs.
     dispatched_orgs = []
     for call in mock_chain.call_args_list:
-        build_sig, materialize_sig = call.args
+        build_sig, backfill_sig = call.args
         org = build_sig.sig_kwargs["kwargs"]["org_id"]
-        assert materialize_sig.sig_kwargs["kwargs"]["org_id"] == org
+        assert backfill_sig.sig_kwargs["kwargs"]["org_id"] == org
         dispatched_orgs.append(org)
     assert dispatched_orgs == ["org-1", "org-2"]
 
@@ -195,7 +197,7 @@ def test_dispatch_does_not_gate_on_work_graph_edges_output_table() -> None:
 
 def test_dispatch_single_tenant_default_org() -> None:
     """A positively-detected single-tenant install (['default']) is dispatched
-    like any other org — a cheap no-op build/materialize if it has no data."""
+    like any other org — a cheap no-op build/backfill if it has no data."""
     _, mock_chain, _, result = _run_dispatch(active_org_ids=["default"])
 
     assert mock_chain.call_count == 1
@@ -205,20 +207,20 @@ def test_dispatch_single_tenant_default_org() -> None:
 
 
 def test_dispatch_chain_shape_matches_post_sync_dispatch() -> None:
-    """The scheduled chain is the SAME shape as the post-sync chain — idempotent
-    and safe to coexist: same task names, same metrics queue, same immutable
-    link, org-scoped kwargs, and the resolved db_url forwarded to both."""
+    """The scheduled chain is the SAME shape as the post-sync chain (build ->
+    immutable child on metrics, org-scoped, db_url forwarded) — but the daily
+    child is the no-LLM run_membership_backfill, not run_investment_materialize."""
     _, mock_chain, _, _ = _run_dispatch(active_org_ids=["org-1"])
 
-    build_sig, materialize_sig = mock_chain.call_args.args
+    build_sig, backfill_sig = mock_chain.call_args.args
     # The scheduled path forwards the _get_db_url()-resolved value to both children.
     assert build_sig.task_name == _WORK_GRAPH_TASK
     assert build_sig.sig_kwargs == {
         "kwargs": {"db_url": _SCHEDULED_DB_URL, "org_id": "org-1"},
         "queue": "metrics",
     }
-    assert materialize_sig.task_name == _INVESTMENT_TASK
-    assert materialize_sig.sig_kwargs == {
+    assert backfill_sig.task_name == _BACKFILL_TASK
+    assert backfill_sig.sig_kwargs == {
         "kwargs": {"db_url": _SCHEDULED_DB_URL, "org_id": "org-1"},
         "queue": "metrics",
         "immutable": True,
@@ -227,7 +229,7 @@ def test_dispatch_chain_shape_matches_post_sync_dispatch() -> None:
 
 def test_dispatch_forwards_explicit_db_url_override_to_both_children() -> None:
     """CHAOS-2439 [HIGH] regression: an explicit db_url override (manual/backfill)
-    must reach BOTH child signatures, so build+materialize target the requested
+    must reach BOTH child signatures, so build+backfill target the requested
     ClickHouse instead of the workers' ambient _get_db_url() default."""
     override = "clickhouse://override"
     _, mock_chain, _, result = _run_dispatch(
@@ -236,18 +238,18 @@ def test_dispatch_forwards_explicit_db_url_override_to_both_children() -> None:
 
     assert mock_chain.call_count == 2
     for call in mock_chain.call_args_list:
-        build_sig, materialize_sig = call.args
+        build_sig, backfill_sig = call.args
         org = build_sig.sig_kwargs["kwargs"]["org_id"]
         # BOTH children carry the override db_url AND the org_id.
         assert build_sig.sig_kwargs["kwargs"] == {"db_url": override, "org_id": org}
-        assert materialize_sig.sig_kwargs["kwargs"] == {
+        assert backfill_sig.sig_kwargs["kwargs"] == {
             "db_url": override,
             "org_id": org,
         }
         # The override never collapses to the ambient default.
         assert build_sig.sig_kwargs["kwargs"]["db_url"] != _SCHEDULED_DB_URL
-        # Immutable link preserved on materialize.
-        assert materialize_sig.sig_kwargs.get("immutable") is True
+        # Immutable link preserved on the backfill child.
+        assert backfill_sig.sig_kwargs.get("immutable") is True
     assert result["dispatched"] == ["org-1", "org-2"]
 
 
@@ -256,9 +258,9 @@ def test_dispatch_scheduled_path_forwards_resolved_default_db_url() -> None:
     forwarded to both children — behaviour unchanged from today's default."""
     _, mock_chain, _, _ = _run_dispatch(active_org_ids=["org-1"])
 
-    build_sig, materialize_sig = mock_chain.call_args.args
+    build_sig, backfill_sig = mock_chain.call_args.args
     assert build_sig.sig_kwargs["kwargs"]["db_url"] == _SCHEDULED_DB_URL
-    assert materialize_sig.sig_kwargs["kwargs"]["db_url"] == _SCHEDULED_DB_URL
+    assert backfill_sig.sig_kwargs["kwargs"]["db_url"] == _SCHEDULED_DB_URL
 
 
 def test_dispatch_uses_strict_discovery() -> None:
@@ -276,7 +278,7 @@ def test_dispatch_uses_strict_discovery() -> None:
             return_value="clickhouse://x",
         ),
     ):
-        dispatch_investment_materialize.run()
+        dispatch_membership_backfill.run()
 
     mock_discover.assert_called_once_with(strict=True)
 
@@ -299,7 +301,7 @@ def test_dispatch_retries_on_org_enumeration_failure() -> None:
             return_value="clickhouse://x",
         ),
         patch.object(
-            dispatch_investment_materialize,
+            dispatch_membership_backfill,
             "retry",
             side_effect=_Retry(),
         ) as mock_retry,
@@ -307,7 +309,7 @@ def test_dispatch_retries_on_org_enumeration_failure() -> None:
         import pytest
 
         with pytest.raises(_Retry):
-            dispatch_investment_materialize.run()
+            dispatch_membership_backfill.run()
     mock_retry.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

Rollout-robustness follow-on to the merged **CHAOS-2427** (#925, work-graph theme/subcategory filter).

Investment materialization — which populates `work_unit_membership`, the table the work-graph theme/subcategory filter reads — is currently **event-driven only**: it runs post-sync via the `run_work_graph_build` → `run_investment_materialize` chain in `_dispatch_post_sync_tasks` (`workers/sync_runtime.py`). There is no fixed-cadence beat entry. So **idle-sync orgs** and the **post-deploy window** leave `work_unit_membership` empty, stranding theme filters in the `MEMBERSHIP_NOT_MATERIALIZED` degraded state indefinitely.

This adds a **daily floor-cadence safety net** that re-runs the same chain per org.

## Changes

**1. Beat entry** (`workers/config.py`) — `run-investment-materialize-daily`, daily at **01:15 UTC** (clear of `run-daily-metrics` 01:00 and `run-release-impact-daily` 01:30):
```python
"run-investment-materialize-daily": {
    "task": "dev_health_ops.workers.tasks.dispatch_investment_materialize",
    "schedule": crontab(hour=1, minute=15),
    "options": {"queue": "default"},
},
```

**2. Dispatch task** (`workers/work_graph_tasks.py::dispatch_investment_materialize`) — fans out per active org the **SAME immutable `build → materialize` chain** used post-sync:
```python
build_sig = celery_app.signature("...run_work_graph_build", kwargs={"org_id": org_id}, queue="metrics")
materialize_sig = celery_app.signature("...run_investment_materialize", kwargs={"org_id": org_id}, queue="metrics", immutable=True)
chain(build_sig, materialize_sig).apply_async()
```
Chain, **not** parallel — materializing against a stale/empty work graph is exactly the race **CHAOS-2374** avoided; the immutable link keeps the build's return value out of materialize's positional args. Idempotent and safe to coexist with the post-sync dispatch (materialization is keyed on `computed_at` in a ReplacingMergeTree — a re-run just refreshes the latest run).

**3. Org selection** — mirrors the other daily dispatchers via `_discover_active_org_ids()` (the existing helper in `recommendations_tasks.py`: active orgs from Postgres as source of truth, `["default"]` fallback for single-tenant installs). Then **narrows to orgs that actually have `work_graph_edges`** in ClickHouse so empty / never-synced orgs are not churned nightly (fail-open if the probe errors — the per-org chain is itself a no-op for an empty org, so a transient probe failure must not skip the safety net). Retries on org-enumeration failure rather than reporting a silent empty success (mirrors `dispatch_release_impact`). No schema change, no migration.

**4. Log fix** (`work_graph/runner.py`) — the materialization-complete log printed `Components/Records/Quotes` only, omitting the `memberships` count `materialize_investments()` already returns, so a real run that wrote membership looked like it hadn't. Now logs `... Quotes=%d Memberships=%d`.

## Org-selection source mirrored

`_discover_active_org_ids()` (`workers/recommendations_tasks.py`) — the same active-org enumeration used by the recommendations daily safety-net job and documented as mirroring `dispatch_scheduled_metrics`. Narrowed to ClickHouse `work_graph_edges` presence for the "has data" gate (mirrors how `_discover_team_ids` scopes to tables that hold data).

## Tests

`tests/test_scheduled_investment_dispatch.py` (follows `test_post_sync_investment_dispatch.py` style — patches the Celery `chain`/`signature` factories and the org/data sources, asserts the dispatch contract without a live broker/ClickHouse):
- Beat entry registered with expected name + schedule (01:15) and non-collision with the 01:00/01:30 neighbours.
- Dispatch queues a `build → materialize` **chain** per org in chained order (asserts chain composition, immutable link, metrics-queue org-scoping — **not** parallel).
- Skips orgs without `work_graph_edges`; clean no-op when none have data.
- Chain shape **matches the post-sync chain contract** byte-for-byte (idempotent coexistence).
- Retries on org-enumeration failure (no silent empty success).
- Org-with-data probe fails open on a ClickHouse error.

**Full `mypy --install-types --non-interactive .` clean over 1073 files; targeted suite 68 passed.**

Refs CHAOS-2439. Parent: CHAOS-2427.

---

## Review-round fixes (Codex #928) — commit 25bdf90e8

**1. [HIGH] Stopped gating the rebuild on the build's own OUTPUT table.**
The dispatcher previously narrowed the fan-out to orgs that already have `work_graph_edges` rows — but that table is the *output* the build creates. Any active org with raw synced data but no edges yet (a failed prior post-sync build, a truncated/migrated-empty graph table, or a brand-new tenant that synced but never built) would be **skipped forever** while the task still reported success — skipping exactly the tenants the safety net exists to repair.

**New gating: none — dispatch the `build → materialize` chain for EVERY active org.** `_orgs_with_work_graph_data` is removed entirely. This is the preferred option from the review: the build is a cheap no-op for an org with no source data (it scans a 30-day window and yields zero edges) and `materialize_investments` then short-circuits on zero components (`{"components": 0, ...}`), so fanning out to all active orgs is correct and inexpensive. The rule is simply: never gate a rebuild on its own output.

**2. [MEDIUM] Strict org discovery so a DB outage retries instead of silently succeeding.**
`_discover_active_org_ids()` caught its own Postgres exceptions and returned `["default"]`, so the retry-wrapped dispatcher treated a multi-tenant DB outage as a clean empty success and never retried the once-daily run. Added a `strict` flag:
```python
def _discover_active_org_ids(*, strict: bool = False) -> list[str]:
    try:
        ... query active orgs ...
    except Exception:
        logger.exception("Failed to enumerate active organizations")
        if strict:
            raise          # CHAOS-2439: retryable DB outage, not "no orgs"
        org_ids = []
    return org_ids or ["default"]   # ["default"] only on a SUCCESSFUL empty query
```
The dispatcher calls `_discover_active_org_ids(strict=True)` so a Postgres failure raises and triggers its existing `self.retry(...)`. The `["default"]` fallback now applies only to the *positively-detected* single-tenant case (successful query, zero active orgs). The existing recommendations-job caller keeps the non-strict default — behaviour unchanged.

**Tests** (updated `tests/test_scheduled_investment_dispatch.py`): an active org with raw inputs but **zero `work_graph_edges` IS dispatched** (finding-1 regression) and the module exposes no output-table probe helper; single-tenant `["default"]` is dispatched; the dispatcher calls discovery with `strict=True`; strict discovery **raises** on a DB error → retry fires; strict discovery still returns `["default"]` on a successful empty table; non-strict still falls back on error. **Full `mypy --install-types --non-interactive .` clean over 1073 files; targeted suite 70 passed.**


---

## Review round-2 fix (Codex #928) — commit cac5e09e9

**[HIGH] Forward the resolved `db_url` to both child signatures.**
`dispatch_investment_materialize` resolved `db_url` but enqueued `run_work_graph_build` and `run_investment_materialize` with only `org_id`. Both children fall back to `_get_db_url()` when `db_url` is absent, so an explicit override — `dispatch_investment_materialize(db_url="clickhouse://override")` for a manual/backfill run — silently ran the build+materialize against the workers' **ambient** ClickHouse while still returning a clean `dispatched` result. The sibling dispatchers forward `db_url`; this one dropped it.

```python
build_sig = celery_app.signature(
    "...run_work_graph_build",
    kwargs={"db_url": db_url, "org_id": org_id}, queue="metrics",
)
materialize_sig = celery_app.signature(
    "...run_investment_materialize",
    kwargs={"db_url": db_url, "org_id": org_id}, queue="metrics", immutable=True,
)
```
The scheduled (no-override) path forwards the same value `_get_db_url()` already resolves, so behaviour is unchanged when no override is supplied; the immutable link on the materialize sig is preserved.

**Tests:** `dispatch_investment_materialize.run(db_url="clickhouse://override")` → both child signatures receive `db_url="clickhouse://override"` and `org_id` (and never collapse to the ambient default); the scheduled path forwards the resolved default to both children; the chain-shape test updated for the new kwargs. **Full `mypy --install-types --non-interactive .` clean over 1073 files; targeted suite 62 passed.**


---

## Round-3 redesign (user decision) — commit 4edbc831d: daily job is now NO-LLM

**The daily scheduled job must NOT re-run LLM materialization** (cost + category drift). The daily beat now runs a CHEAP, no-LLM **membership backfill** that projects `work_unit_membership` from the theme/subcategory distributions ALREADY persisted in `work_unit_investments` by the post-sync LLM path. **The post-sync `build -> run_investment_materialize` (LLM) chain is UNCHANGED** — it still categorizes new data.

### Shared-helper extraction
The threshold + `is_dominant` projection logic moved to a new module `work_graph/investment/membership.py`:
- `lexical_argmax`, `membership_categories`, and `build_membership_records(unit_nodes, work_unit_id, theme_distribution, subcategory_distribution, categorization_status, computed_at, org_id)`.

`materialize.py` now calls `build_membership_records` (keeping `_lexical_argmax` / `_membership_categories` as thin aliases for existing imports), so the **LLM materializer and the no-LLM backfill emit byte-for-byte identical rows** for the same persisted distributions — proven by a test that diffs the backfill output against `build_membership_records`.

### New backfill (`work_graph/investment/backfill.py` + `run_membership_backfill` task), per org, NO LLM
1. Rebuild work-graph connected components from `work_graph_edges`; compute `work_unit_id` + `unit_nodes` (reuse `work_unit_id()` so hashing matches the materializer).
2. Read EXISTING `work_unit_investments` **latest-per-`work_unit_id`** (`argMax` on `computed_at`, same semantics as `api/queries/work_unit_investments.py`) for `theme_distribution_json` / `subcategory_distribution_json`. **No categorizer/LLM call.**
3. Project membership via the shared `build_membership_records`, stamping a fresh `computed_at` (the resolver's per-node latest-run guard then supersedes stale rows).
4. Write via `sink.write_work_unit_memberships`.

**Skip-on-churned-component:** a unit whose CURRENT component hash has no matching `work_unit_investments` row — because edges churned since the last categorization, so the node's new `work_unit_id` was never categorized — is **skipped**. The post-sync full `build -> run_investment_materialize` (LLM) chain covers those (it runs on new data). The backfill only refreshes membership for components that ALREADY have a categorization; it never invents categories. Documented in the module docstring.

### Beat repoint
`run-membership-backfill-daily` (01:15 UTC) → `dispatch_membership_backfill`, which fans out the no-LLM chain `run_work_graph_build -> run_membership_backfill` per active org. The prior fixes are KEPT: **strict org discovery** (`strict=True` → raise → retry on a Postgres outage) and **`db_url` threaded to BOTH child sigs**. (`dispatch_investment_materialize` is removed; the old beat entry `run-investment-materialize-daily` is gone.)

### Tests
- `tests/test_membership_backfill.py` (new): daily backfill invokes **NO categorizer/LLM provider** (asserts both are never called); backfill rows **equal `build_membership_records`** for the same distributions (shared-helper consistency); idle org with existing investments → membership populated, no LLM; **skip-on-churned-component** (matched component written, churned one skipped); latest-per-unit `argMax` query shape; empty-graph clean no-op.
- `tests/test_scheduled_membership_backfill.py` (renamed from the dispatch test): chain order `build -> backfill`, immutable link, metrics-queue org-scoping, **`db_url` forwarded to both children** (override + scheduled default), strict discovery → retry, beat name/schedule.

**Full `mypy --install-types --non-interactive .` clean over 1077 files; targeted suite 90 passed.**

---

## Round-4 fix (Codex adversarial review) — commit 69014d4aa: tombstone-on-skip

**[HIGH] Stale-on-skip: churned nodes retained obsolete theme/subcategory membership.**

When a component's `work_unit_id` has no matching `work_unit_investments` row (edges churned since last LLM run), the backfill previously wrote **nothing** for those nodes. The resolver's per-node latest-run guard selects membership rows whose `computed_at` equals the max for that `(org_id, node_type, node_id)`, so any **OLD** membership rows from a prior component remained the latest and kept matching theme/subcategory filters with stale categories. The daily job reported success while leaving stale data.

### Fix: tombstone-on-skip (no LLM)

Instead of writing nothing, the backfill now writes a **TOMBSTONE** for each node in a skipped (churned/uncategorized) component:

```python
WorkUnitMembershipRecord(
    category_kind="theme"|"subcategory",
    category="",          # TOMBSTONE_CATEGORY sentinel — never a real category
    weight=0.0,
    is_dominant=0,
    categorization_status="tombstone",
    computed_at=<current run timestamp>,   # FRESH — supersedes stale rows
    ...
)
```

Two tombstone rows per node (one per `category_kind`). The `computed_at` matches the rest of the run, so the per-node latest-run guard picks up the tombstone and displaces all older rows.

### Tombstone invariants (verified by analysis and test)

| Invariant | Mechanism |
|---|---|
| Tombstoned node not returned by theme/subcategory filter | `(m.category_kind, m.category) IN %(category_tuples)s` — all real categories are non-empty strings, `''` never matches |
| Tombstoned node annotated as `theme=null / subcategory=null` | Tombstone has `is_dominant=0` → excluded from annotation query's `AND m.is_dominant = 1`; no entry → `None` |
| Tombstoned org NOT misread as `MEMBERSHIP_NOT_MATERIALIZED` | Tombstones are live rows with fresh `computed_at`; degraded probe sees `membership_rows > 0` → not degraded |
| `materialize.py` unchanged | Only the backfill skip path tombstones. The LLM materializer re-categorizes. Post-sync chain replaces tombstones with real rows. |

### Stats dict

Added `tombstones` key to the returned stats dict (total tombstone rows written). Backward-compatible — callers pass stats through as `{"status": "success", "stats": stats}`.

### Regression test (`test_tombstone_on_skip_regression`)

Covers all three invariants end-to-end:

**(a) Backfill emission** — churned component with no investments row → tombstone rows written for all nodes with fresh `computed_at`; `category=''`, `weight=0.0`, `is_dominant=0`, `categorization_status="tombstone"`.

**(b) Resolver filter** — mock returns empty edge list (simulating ClickHouse correctly finding no edges because `category=''` ∉ `{('theme', 'quality')}`); asserts `result.edges == []` and `degraded_reason is None` (tombstones are live rows → `membership_rows > 0` → not degraded); asserts SQL uses `(m.category_kind, m.category) IN %(category_tuples)s` with non-empty category tuples.

**(c) Annotation** — annotation query excludes `is_dominant=0` rows; tombstoned node returns no annotation rows → `edge.theme is None`, `edge.subcategory is None`.

**Full `mypy --install-types --non-interactive .` clean over 1074 files; targeted suite 72 passed.**
