### PR TITLE
fix(work-graph): link squash-merge commits to PRs (CHAOS-2435)

### DIFF
--- a/src/dev_health_ops/work_graph/builder.py
+++ b/src/dev_health_ops/work_graph/builder.py
@@ -12,6 +12,7 @@ import bisect
 import logging
 import sys
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
@@ -27,6 +28,7 @@ from dev_health_ops.work_graph.extractors.text_parser import (
     extract_gitlab_issue_refs,
     extract_jira_keys,
     extract_pr_refs,
+    extract_squash_pr_refs,
 )
 from dev_health_ops.work_graph.ids import (
     generate_commit_id,
@@ -1334,25 +1336,43 @@ class WorkGraphBuilder:
         ``git_pull_requests`` and ``git_commits`` but never populates
         ``work_graph_pr_commit`` (only fixtures did), so the ``CONTAINS`` edges
         built by :meth:`_build_pr_commit_edges_from_fast_path` were empty for real
-        orgs. Here we parse merge commit messages for the PR/MR numbers GitHub and
-        GitLab embed via their explicit merge-keyword conventions
-        (``Merge pull request #N``, ``See merge request grp/proj!N``) and, when the
-        referenced number matches a known PR in the same repo, persist a
-        ``WorkGraphPRCommit`` link. Bare ``#N`` and squash ``(#N)`` forms are
-        deliberately *not* accepted: they are indistinguishable from ordinary issue
-        references and, with no persisted merge metadata to corroborate them, would
-        attach commits to unrelated PRs (see :func:`extract_pr_refs`). Re-running is
-        idempotent: ``work_graph_pr_commit`` is a ReplacingMergeTree keyed on
-        (org_id, repo_id, pr_number, commit_hash).
+        orgs. Here we parse commit messages for PR/MR numbers via two tiers:
+
+        1. **Explicit merge keywords** (``Merge pull request #N``,
+           ``See merge request grp/proj!N``) -- unambiguous, persisted with
+           ``provenance=explicit_text``, ``confidence=0.9`` and
+           ``evidence='commit_message_pr_ref'`` (see :func:`extract_pr_refs`).
+        2. **Squash-merge subject suffix** (``<subject> (#N)``) -- GitHub's
+           *squash and merge* default, which leaves no explicit merge keyword.
+           This form is ambiguous with a hand-authored issue reference, so it is
+           only promoted when ``N`` matches a *known* PR number in the **same
+           (org, repo)**, and is then tagged distinctly:
+           ``provenance=heuristic``, ``confidence=0.6`` and
+           ``evidence='commit_message_squash_pr_ref'`` so downstream consumers
+           can weight or filter it. Without this tier, squash-merge orgs lose
+           nearly all PR->commit edges (CHAOS-2435: live org a78c1a6a had only
+           22 explicit-merge edges while ~3218 squash commits were discarded).
+
+        Bare ``#N`` references are never accepted (indistinguishable from issue
+        mentions). Re-running is idempotent: ``work_graph_pr_commit`` is a
+        ReplacingMergeTree keyed on (org_id, repo_id, pr_number, commit_hash).
+
+        Tenant isolation: known PRs are keyed by ``(org_id, repo_id)`` and a
+        commit is only ever matched against PRs in its *own* org, so a squash
+        ``(#N)`` in org A can never link to org B's PR #N even when ``repo_id``
+        collides across tenants (CHAOS-2189 mirror).
 
         Returns:
             Number of PR->commit links written.
         """
         logger.info("Deriving PR->commit links from commit messages...")
 
-        # Known PR numbers per repo, so we only link to PRs that actually exist.
+        # Known PR numbers per (org, repo), so we only link to PRs that actually
+        # exist *within the same tenant*. ``repo_id`` can collide across orgs, so
+        # org_id MUST be part of the key (tenant isolation).
         pr_query = """
         SELECT
+            org_id,
             repo_id,
             number
         FROM git_pull_requests
@@ -1370,16 +1390,18 @@ class WorkGraphBuilder:
             logger.info("No PRs found; skipping PR->commit derivation")
             return 0
 
-        known_prs: dict[str, set[int]] = {}
+        known_prs: dict[tuple[str, str], set[int]] = {}
         for pr_row in pr_rows:
             repo_id = pr_row.get("repo_id")
             number = pr_row.get("number")
             if repo_id is None or number is None:
                 continue
-            known_prs.setdefault(str(repo_id), set()).add(int(number))
+            org_key = str(pr_row.get("org_id") or "")
+            known_prs.setdefault((org_key, str(repo_id)), set()).add(int(number))
 
         commit_query = """
         SELECT
+            org_id,
             repo_id,
             hash,
             message,
@@ -1408,8 +1430,26 @@ class WorkGraphBuilder:
         if not commit_rows:
             return 0
 
+        # Two extraction tiers, processed in order so the higher-confidence
+        # explicit-merge link wins the (org, repo, pr, hash) dedup over a squash
+        # match for the same pair:
+        #   1. explicit merge keywords  -> explicit_text, 0.9
+        #   2. squash subject "(#N)"    -> heuristic, 0.6 (ambiguous; corroborated
+        #      only against known PRs in the same (org, repo), tagged distinctly)
+        link_tiers: tuple[
+            tuple[Callable[[str], list[int]], float, Provenance, str], ...
+        ] = (
+            (extract_pr_refs, 0.9, Provenance.EXPLICIT_TEXT, "commit_message_pr_ref"),
+            (
+                extract_squash_pr_refs,
+                0.6,
+                Provenance.HEURISTIC,
+                "commit_message_squash_pr_ref",
+            ),
+        )
+
         links: list[WorkGraphPRCommit] = []
-        seen: set[tuple[str, int, str]] = set()
+        seen: set[tuple[str, str, int, str]] = set()
         for commit_row in commit_rows:
             repo_id = commit_row.get("repo_id")
             commit_hash = commit_row.get("hash")
@@ -1419,28 +1459,33 @@ class WorkGraphBuilder:
                 continue
 
             repo_id_str = str(repo_id)
-            repo_prs = known_prs.get(repo_id_str)
+            commit_hash_str = str(commit_hash)
+            org_key = str(commit_row.get("org_id") or "")
+            # Only PRs in this commit's *own* (org, repo) are candidates --
+            # never another tenant's PRs, even on a repo_id collision.
+            repo_prs = known_prs.get((org_key, repo_id_str))
             if not repo_prs:
                 continue
 
-            for pr_number in extract_pr_refs(message):
-                if pr_number not in repo_prs:
-                    continue
-                key = (repo_id_str, pr_number, str(commit_hash))
-                if key in seen:
-                    continue
-                seen.add(key)
-                links.append(
-                    WorkGraphPRCommit(
-                        repo_id=uuid.UUID(repo_id_str),
-                        pr_number=pr_number,
-                        commit_hash=str(commit_hash),
-                        confidence=0.9,
-                        provenance=Provenance.EXPLICIT_TEXT,
-                        evidence="commit_message_pr_ref",
-                        last_synced=self._now,
+            for extractor, confidence, provenance, evidence in link_tiers:
+                for pr_number in extractor(message):
+                    if pr_number not in repo_prs:
+                        continue
+                    key = (org_key, repo_id_str, pr_number, commit_hash_str)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    links.append(
+                        WorkGraphPRCommit(
+                            repo_id=uuid.UUID(repo_id_str),
+                            pr_number=pr_number,
+                            commit_hash=commit_hash_str,
+                            confidence=confidence,
+                            provenance=provenance,
+                            evidence=evidence,
+                            last_synced=self._now,
+                        )
                     )
-                )
 
         self._write_pr_commit_links(links)
         logger.info("Derived %d PR->commit links from commit messages", len(links))

--- a/src/dev_health_ops/work_graph/extractors/text_parser.py
+++ b/src/dev_health_ops/work_graph/extractors/text_parser.py
@@ -62,20 +62,33 @@ GITLAB_CROSS_PROJECT_PATTERN = re.compile(r"([\w\-\.]+/[\w\-\.]+)#(\d+)")
 # - GitHub merge commit: "Merge pull request #123 from ..."
 # - GitLab merge commit:  "See merge request grp/proj!45"
 #
-# The bare squash form "Some change (#123)" is deliberately NOT recognized.
-# GitHub's squash-and-merge produces "<subject> (#N)", but that is positionally
-# and lexically identical to a hand-authored issue reference such as
-# "Fix parser edge case (#42)". Because git_pull_requests carries no persisted
-# merge_commit_sha (or any merge metadata) to corroborate the link, a bare
-# "(#N)" is indistinguishable from an issue mention. Promoting it would attach a
-# commit to an unrelated PR whenever an issue number happens to collide with a
-# real PR number in the same repo -- durable corruption of work_graph_pr_commit
-# and every downstream file/AI-impact metric that reads it. See CHAOS-2375
-# round-2 review: only unambiguous merge/MR-keyword evidence is accepted.
+# The bare squash form "Some change (#123)" is NOT recognized here by
+# :func:`extract_pr_refs`. GitHub's squash-and-merge produces "<subject> (#N)",
+# but that is positionally and lexically identical to a hand-authored issue
+# reference such as "Fix parser edge case (#42)". Because git_pull_requests
+# carries no persisted merge_commit_sha (or any merge metadata) to corroborate
+# the link, a bare "(#N)" is indistinguishable from an issue mention on its own.
+# :func:`extract_pr_refs` therefore stays strict: only unambiguous
+# merge/MR-keyword evidence (CHAOS-2375 round-2). The squash form is instead
+# surfaced separately by :func:`extract_squash_pr_refs`, whose caller
+# corroborates the number against the set of *known* PR numbers in the same
+# (org, repo) before persisting a lower-confidence, distinctly-tagged link
+# (CHAOS-2435 interim recovery -- squash-merge orgs otherwise lose ~all
+# PR->commit edges).
 GITHUB_MERGE_PR_PATTERN = re.compile(r"merge\s+pull\s+request\s+#(\d+)", re.IGNORECASE)
 GITLAB_MERGE_MR_PATTERN = re.compile(
     r"(?:merge\s+request|see\s+merge\s+request)\b[^!\n]*!(\d+)", re.IGNORECASE
 )
+
+# GitHub's squash-and-merge appends the PR number to the *subject line* as a
+# trailing parenthetical: "<subject> (#N)". We anchor to the end of the first
+# line (the subject) so that mid-body parentheticals and hand-authored
+# mid-subject refs are far less likely to match. This form is ambiguous with a
+# hand-authored issue ref, so it is NEVER promoted on its own -- the caller must
+# corroborate N against known PR numbers in the same (org, repo) and tag the
+# resulting link with distinct, lower-confidence evidence. See
+# :func:`extract_squash_pr_refs`.
+GITHUB_SQUASH_PR_PATTERN = re.compile(r"\(#(\d+)\)\s*$")
 
 # Revert commits embed the *original* merge subject verbatim, e.g.
 #   Revert "Merge pull request #42 from team/x"
@@ -133,10 +146,11 @@ def extract_pr_refs(text: str) -> list[int]:
     - ``(#123)``          -- GitHub's squash-and-merge subject suffix, but it is
       indistinguishable from a hand-authored parenthetical issue reference like
       "Fix parser edge case (#42)". With no persisted merge metadata to
-      corroborate it, accepting this would persist false high-confidence
-      PR->commit edges (a commit attached to an unrelated PR whenever an issue
-      number collides with a real PR number), corrupting the work graph and
-      downstream file/AI-impact metrics.
+      corroborate it, accepting it *here* would persist false high-confidence
+      PR->commit edges. The squash form is instead surfaced by
+      :func:`extract_squash_pr_refs` and only linked by the caller after
+      corroborating the number against known PRs in the same (org, repo), with
+      distinct lower-confidence evidence (CHAOS-2435).
 
     Revert commits are rejected entirely: ``Revert "Merge pull request #42 ..."``
     quotes the reverted PR's merge subject but is a *later undo* commit, not a
@@ -175,6 +189,49 @@ def extract_pr_refs(text: str) -> list[int]:
             _add(match.group(1))
 
     return ordered
+
+
+def extract_squash_pr_refs(text: str) -> list[int]:
+    """Extract the PR number from a GitHub squash-merge commit subject.
+
+    GitHub's *squash and merge* writes a single commit whose subject is
+    ``"<PR title> (#N)"`` -- the PR number appended as a trailing parenthetical.
+    Unlike the merge-keyword forms recognized by :func:`extract_pr_refs`, this
+    shape is **ambiguous**: a hand-authored subject like
+    ``"Fix parser edge case (#42)"`` is lexically identical. This function
+    therefore performs *no* corroboration of its own -- it merely surfaces the
+    candidate number. Callers MUST confirm the number against the set of known
+    PR numbers in the same ``(org, repo)`` and persist the link with distinct,
+    lower-confidence evidence (see
+    :meth:`WorkGraphBuilder._derive_pr_commit_links`). On squash-merge orgs this
+    recovers the bulk of PR->commit edges that the strict
+    :func:`extract_pr_refs` necessarily discards (CHAOS-2435).
+
+    Only the trailing parenthetical on the *subject line* (first line) is
+    considered, matching GitHub's convention and avoiding mid-body matches.
+    Revert commits are rejected for the same reason as in
+    :func:`extract_pr_refs`: they quote a prior subject but are a later undo.
+
+    Args:
+        text: Commit message to search.
+
+    Returns:
+        A single-element list ``[N]`` when the subject ends in ``(#N)``, else
+        an empty list.
+    """
+    if not text:
+        return []
+
+    # Reverts quote a prior subject (potentially ending in "(#N)") but are not
+    # contained by that PR -- reject before matching, mirroring extract_pr_refs.
+    if _is_revert_message(text):
+        return []
+
+    subject = text.lstrip().split("\n", 1)[0]
+    match = GITHUB_SQUASH_PR_PATTERN.search(subject)
+    if match is None:
+        return []
+    return [int(match.group(1))]
 
 
 def extract_jira_keys(text: str) -> list[ParsedIssueRef]:

--- a/tests/work_graph/test_builder.py
+++ b/tests/work_graph/test_builder.py
@@ -304,9 +304,10 @@ class TestDerivePRCommitLinks:
             {
                 "repo_id": repo_id,
                 "hash": "bbb222",
-                # Squash form is ambiguous with an issue ref -> must be ignored,
-                # even though PR #7 exists in this repo.
-                "message": "Add retry logic (#7)",
+                # A bare/plain issue mention is ambiguous with an issue ref and
+                # carries no squash suffix -> must be ignored, even though PR #7
+                # exists in this repo.
+                "message": "Add retry logic for #7",
                 "author_when": base_time,
             },
         ]
@@ -424,14 +425,17 @@ class TestDerivePRCommitLinks:
         assert count == 0
         fake_sink.write_work_graph_pr_commit.assert_not_called()
 
-    def test_squash_paren_ref_colliding_with_pr_number_is_not_linked(self):
-        """A parenthetical ``(#N)`` issue ref must NOT be linked to PR #N.
+    def test_squash_paren_ref_to_known_pr_is_linked_with_distinct_evidence(self):
+        """A squash ``(#N)`` matching a KNOWN PR links with lower-confidence,
+        distinctly-tagged evidence (CHAOS-2435 interim recovery).
 
-        Primary CHAOS-2375 round-2 corruption case: "Fix parser edge case (#42)"
-        is a hand-authored issue reference, but the squash convention produces the
-        identical "<subject> (#42)" shape. With PR #42 present in the same repo,
-        the old ``SQUASH_PR_PATTERN`` would have attached this unrelated commit to
-        PR #42. The fix drops the squash form, so no link is written.
+        GitHub's *squash and merge* writes ``"<subject> (#N)"`` with no explicit
+        merge keyword, so the strict :func:`extract_pr_refs` discards it -- which
+        zeroed PR->commit edges for squash-merge orgs. The interim approach
+        promotes the squash suffix when ``N`` is a real PR in the same
+        (org, repo), but tags it ``provenance=heuristic`` / ``confidence=0.6`` /
+        ``evidence='commit_message_squash_pr_ref'`` so downstream consumers can
+        weight or filter the (inherently more ambiguous) link.
         """
         repo_id = uuid.uuid4()
         pr_rows = [{"repo_id": repo_id, "number": 42}]
@@ -453,8 +457,95 @@ class TestDerivePRCommitLinks:
             count = builder._derive_pr_commit_links()
             builder.close()
 
+        assert count == 1
+        record = fake_sink.write_work_graph_pr_commit.call_args[0][0][0]
+        assert record.commit_hash == "f00d42"
+        assert record.pr_number == 42
+        assert record.repo_id == repo_id
+        assert record.provenance == "heuristic"
+        assert record.confidence == 0.6
+        assert record.evidence == "commit_message_squash_pr_ref"
+
+    def test_squash_paren_ref_to_unknown_pr_is_not_linked(self):
+        """A squash ``(#N)`` whose N is NOT a known PR must NOT link.
+
+        The known-PR corroboration is the only guard against attaching a
+        hand-authored parenthetical issue ref to an unrelated PR. If #99 is not
+        a real PR in this (org, repo), no link is written.
+        """
+        repo_id = uuid.uuid4()
+        pr_rows = [{"repo_id": repo_id, "number": 42}]
+        commit_rows = [
+            {
+                "repo_id": repo_id,
+                "hash": "f00d99",
+                "message": "Fix parser edge case (#99)",
+                "author_when": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            },
+        ]
+        fake_sink = self._build_sink(pr_rows, commit_rows)
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._derive_pr_commit_links()
+            builder.close()
+
         assert count == 0
         fake_sink.write_work_graph_pr_commit.assert_not_called()
+
+    def test_squash_paren_ref_does_not_link_across_orgs(self):
+        """A squash ``(#N)`` in org A must NEVER link to org B's PR #N.
+
+        CHAOS-2189 mirror: ``repo_id`` can collide across tenants. Org A owns
+        PR #5 in this repo; org B does not. A squash-merge commit that belongs
+        to **org B** referencing ``(#5)`` must not be corroborated against org
+        A's PR #5 -- known PRs are keyed by (org_id, repo_id) and a commit is
+        only matched against PRs in its own org. Only org A's own commit links.
+        """
+        repo_id = uuid.uuid4()  # shared across both tenants
+        base_time = datetime(2024, 6, 15, tzinfo=timezone.utc)
+        # Only org A owns PR #5 in this repo.
+        pr_rows = [{"org_id": "org-a", "repo_id": repo_id, "number": 5}]
+        commit_rows = [
+            {
+                "org_id": "org-a",
+                "repo_id": repo_id,
+                "hash": "aaa555",
+                "message": "Add caching layer (#5)",
+                "author_when": base_time,
+            },
+            {
+                "org_id": "org-b",
+                "repo_id": repo_id,
+                "hash": "bbb555",
+                # org B has no PR #5 -> this squash ref must NOT cross tenants.
+                "message": "Unrelated change (#5)",
+                "author_when": base_time,
+            },
+        ]
+        fake_sink = self._build_sink(pr_rows, commit_rows)
+
+        # Unscoped build: both orgs' rows are visible, so the per-org keying is
+        # what prevents the cross-tenant link (not a SQL org filter).
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._derive_pr_commit_links()
+            builder.close()
+
+        assert count == 1
+        records = fake_sink.write_work_graph_pr_commit.call_args[0][0]
+        by_commit = {r.commit_hash: r for r in records}
+        # Only org A's own commit links to org A's PR #5.
+        assert "aaa555" in by_commit
+        assert by_commit["aaa555"].pr_number == 5
+        # org B's colliding squash ref is never promoted to org A's PR.
+        assert "bbb555" not in by_commit
 
     def test_revert_commit_is_not_linked_to_reverted_pr(self):
         """A revert of a merge commit must NOT produce a PR->commit link.

--- a/tests/work_graph/test_text_parser.py
+++ b/tests/work_graph/test_text_parser.py
@@ -11,6 +11,7 @@ from dev_health_ops.work_graph.extractors.text_parser import (
     extract_gitlab_issue_refs,
     extract_jira_keys,
     extract_pr_refs,
+    extract_squash_pr_refs,
 )
 
 
@@ -110,6 +111,56 @@ class TestExtractPRRefs:
     def test_empty(self):
         assert extract_pr_refs("") == []
         assert extract_pr_refs("no refs here") == []
+
+
+class TestExtractSquashPRRefs:
+    """Tests for GitHub squash-merge subject extraction (CHAOS-2435).
+
+    ``extract_squash_pr_refs`` only *surfaces* the trailing ``(#N)`` candidate;
+    it performs no corroboration -- the builder confirms N against known PRs in
+    the same (org, repo) before persisting a distinctly-tagged link.
+    """
+
+    def test_trailing_paren_on_subject(self):
+        assert extract_squash_pr_refs("Add retry logic (#42)") == [42]
+        assert extract_squash_pr_refs("Fix parser edge case (#7)") == [7]
+
+    def test_trailing_whitespace_tolerated(self):
+        assert extract_squash_pr_refs("Add retry logic (#42)  ") == [42]
+
+    def test_only_subject_line_considered(self):
+        # A "(#N)" buried in the body is NOT a squash subject suffix.
+        msg = "Refactor module\n\nThis relates to (#99) in the tracker."
+        assert extract_squash_pr_refs(msg) == []
+
+    def test_subject_with_trailing_paren_and_body(self):
+        msg = "Implement feature (#15)\n\nLonger description here (#88)."
+        assert extract_squash_pr_refs(msg) == [15]
+
+    def test_mid_subject_paren_not_matched(self):
+        # Anchored to end-of-subject: a parenthetical that is not the suffix
+        # (e.g. GitHub appends its own number after a hand-authored one) yields
+        # only the trailing number.
+        assert extract_squash_pr_refs("Fix bug (#42) (#100)") == [100]
+
+    def test_merge_keyword_subject_not_matched(self):
+        # Classic merge commits have no trailing "(#N)".
+        assert extract_squash_pr_refs("Merge pull request #123 from feat/x") == []
+
+    def test_plain_hash_not_matched(self):
+        assert extract_squash_pr_refs("Fixes #7") == []
+        assert extract_squash_pr_refs("Relates to #500") == []
+
+    def test_revert_is_rejected(self):
+        assert extract_squash_pr_refs('Revert "Add retry logic (#42)"') == []
+        assert (
+            extract_squash_pr_refs("Undo change (#42)\n\nThis reverts commit 0123abcd.")
+            == []
+        )
+
+    def test_empty(self):
+        assert extract_squash_pr_refs("") == []
+        assert extract_squash_pr_refs("no refs here") == []
 
 
 class TestExtractJiraKeys:


### PR DESCRIPTION
## Problem
`_derive_pr_commit_links` accepted only explicit merge-keyword commits (`Merge pull request #N`, `See merge request grp/proj!N`) and discarded GitHub squash-merge subjects `<subject> (#N)`. On live org `a78c1a6a` this left only **22** `work_graph_pr_commit` edges while ~**3218** squash `(#N)` commits were dropped — zeroing the AI **Test Gap / Hotspot / Complexity** tiles despite full evidence tables.

## Fix (interim, self-contained, backfillable)
- New `extract_squash_pr_refs` surfaces the trailing `(#N)` on the **commit subject line** (anchored to end-of-subject; reverts rejected). It performs no corroboration of its own.
- The builder promotes a squash ref **only when N matches a KNOWN PR in the same (org, repo)**, and tags it distinctly so downstream consumers can weight/filter it:
  - squash: `provenance=heuristic`, `confidence=0.6`, `evidence=commit_message_squash_pr_ref`
  - explicit merge (unchanged): `provenance=explicit_text`, `confidence=0.9`, `evidence=commit_message_pr_ref`
- `extract_pr_refs` stays strict (explicit merges only) — semantics unchanged; existing strict tests remain green.

## Tenant isolation
Known PRs are now keyed by `(org_id, repo_id)` and a commit is matched only against PRs in its **own** org, so a squash `(#N)` in org A can never link to org B's PR #N on a `repo_id` collision. New two-org collision test mirrors CHAOS-2189.

## Gates
- `pytest tests/work_graph/test_text_parser.py tests/work_graph/test_builder.py` → 64 passed, 2 skipped
- `mypy` (changed files + work_graph pkg) → no issues
- `ruff check` / `ruff format --check` → clean

Live-data verification (re-run builder for org a78c1a6a, before/after `work_graph_pr_commit` counts) to follow in a PR comment.

Closes CHAOS-2435