### PR TITLE
perf(cli): quiet + fast-path migration ensure (CHAOS-2440)

### DIFF
--- a/src/dev_health_ops/metrics/sinks/clickhouse/core.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/core.py
@@ -188,18 +188,32 @@ class ClickHouseCore(BaseMetricsSink):
             row[0] for row in (getattr(applied_result, "result_rows", []) or [])
         )
 
-        # Collect all migration files
+        # Collect all migration files using the same sort order as the apply loop
+        # so the fast-path "latest" comparison is consistent.
         migration_files = sorted(
             list(migrations_dir.glob("*.sql")) + list(migrations_dir.glob("*.py"))
         )
 
+        # Fast-path: if the DB has already applied every file on disk, skip the
+        # per-file loop entirely.  We compare the last element of the sorted
+        # file list (latest migration on disk) against applied_versions, which
+        # is the single cheapest check possible (O(1) set lookup after the
+        # already-necessary full SELECT).  This avoids ~50 log lines and the
+        # iteration overhead on every CLI invocation when the schema is current.
+        if migration_files and migration_files[-1].name in applied_versions:
+            logger.debug(
+                "ClickHouse schema is current (latest: %s) — skipping migration loop",
+                migration_files[-1].name,
+            )
+            return
+
         for path in migration_files:
             version = path.name
             if version in applied_versions:
-                logger.info(f"Skipping already applied migration: {version}")
+                logger.debug("Skipping already applied migration: %s", version)
                 continue
 
-            logger.info(f"Applying migration: {version}")
+            logger.info("Applying migration: %s", version)
 
             if path.suffix == ".sql":
                 try:

--- a/src/dev_health_ops/metrics/sinks/clickhouse/core.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/core.py
@@ -188,22 +188,28 @@ class ClickHouseCore(BaseMetricsSink):
             row[0] for row in (getattr(applied_result, "result_rows", []) or [])
         )
 
-        # Collect all migration files using the same sort order as the apply loop
-        # so the fast-path "latest" comparison is consistent.
+        # Collect all migration files in apply order.
         migration_files = sorted(
             list(migrations_dir.glob("*.sql")) + list(migrations_dir.glob("*.py"))
         )
 
-        # Fast-path: if the DB has already applied every file on disk, skip the
-        # per-file loop entirely.  We compare the last element of the sorted
-        # file list (latest migration on disk) against applied_versions, which
-        # is the single cheapest check possible (O(1) set lookup after the
-        # already-necessary full SELECT).  This avoids ~50 log lines and the
-        # iteration overhead on every CLI invocation when the schema is current.
-        if migration_files and migration_files[-1].name in applied_versions:
+        # Fast-path: short-circuit only when EVERY on-disk migration is already
+        # applied (full-set completeness check via all_migrations_applied —
+        # CHAOS-2440).  A latest-filename-only check is unsound here because of
+        # inserted / mixed-ordering migrations (023b_ between 023_ and 024_,
+        # duplicate numeric prefixes): the DB could hold the latest row yet be
+        # missing an intermediate migration.  The full-set check stays O(n) in
+        # memory over the SELECT we already ran — no per-file DB query, no log
+        # loop — so it remains fast and quiet while being correct.
+        from dev_health_ops.migrations.clickhouse import all_migrations_applied
+
+        if migration_files and all_migrations_applied(
+            (p.name for p in migration_files), applied_versions
+        ):
             logger.debug(
-                "ClickHouse schema is current (latest: %s) — skipping migration loop",
-                migration_files[-1].name,
+                "ClickHouse schema is current (%d migrations applied) — "
+                "skipping migration loop",
+                len(migration_files),
             )
             return
 

--- a/src/dev_health_ops/migrations/clickhouse/__init__.py
+++ b/src/dev_health_ops/migrations/clickhouse/__init__.py
@@ -10,7 +10,37 @@ into its own statement and break a migration with a ClickHouse SYNTAX_ERROR
 
 from __future__ import annotations
 
-__all__ = ["strip_line_comments", "split_sql_statements"]
+from collections.abc import Iterable
+
+__all__ = [
+    "strip_line_comments",
+    "split_sql_statements",
+    "all_migrations_applied",
+]
+
+
+def all_migrations_applied(
+    migration_filenames: Iterable[str],
+    applied_versions: Iterable[str],
+) -> bool:
+    """Return True iff every on-disk migration is already recorded as applied.
+
+    This is the single source of truth for the migration runners' fast-path
+    short-circuit (CHAOS-2440). It must be a FULL-SET completeness check, not a
+    "latest filename applied" check: this repo has inserted / mixed-ordering
+    migrations (e.g. ``023b_dora_metrics.sql`` sorts between ``023_*`` and
+    ``024_*``, and duplicate numeric prefixes like ``002_phase2_metrics.sql`` /
+    ``002_teams.sql`` exist). A database can hold the row for the
+    lexicographically-latest migration while still missing an *intermediate*
+    one — a latest-only check would falsely report "current" and silently skip
+    the missing migration, causing schema drift.
+
+    Comparing the full set of on-disk filenames against the applied set is still
+    O(n) in memory over the single ``SELECT version FROM schema_migrations`` that
+    the runner already issues — no per-file DB query, no logging loop — so the
+    fast-path stays both fast and quiet while being correct.
+    """
+    return set(migration_filenames) <= set(applied_versions)
 
 
 def strip_line_comments(sql: str) -> str:

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -135,14 +135,27 @@ class ClickHouseStore:
                 row[0] for row in (getattr(applied_result, "result_rows", []) or [])
             )
 
-            # Collect all migration files
+            # Collect all migration files using the same sort order as the apply
+            # loop so the fast-path "latest" comparison is consistent with it.
             migration_files = sorted(
                 list(migrations_dir.glob("*.sql")) + list(migrations_dir.glob("*.py"))
             )
 
+            # Fast-path: if the last file in the sorted list (latest migration on
+            # disk) is already in applied_versions, the schema is current — skip
+            # the per-file loop entirely.  This avoids iteration and log noise on
+            # every CLI invocation when no migrations are pending.
+            if migration_files and migration_files[-1].name in applied_versions:
+                logger.debug(
+                    "ClickHouse schema is current (latest: %s) — skipping migration loop",
+                    migration_files[-1].name,
+                )
+                return
+
             for path in migration_files:
                 version = path.name
                 if version in applied_versions:
+                    logger.debug("Skipping already applied migration: %s", version)
                     continue
 
                 if path.suffix == ".sql":

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -135,20 +135,29 @@ class ClickHouseStore:
                 row[0] for row in (getattr(applied_result, "result_rows", []) or [])
             )
 
-            # Collect all migration files using the same sort order as the apply
-            # loop so the fast-path "latest" comparison is consistent with it.
+            # Collect all migration files in apply order.
             migration_files = sorted(
                 list(migrations_dir.glob("*.sql")) + list(migrations_dir.glob("*.py"))
             )
 
-            # Fast-path: if the last file in the sorted list (latest migration on
-            # disk) is already in applied_versions, the schema is current — skip
-            # the per-file loop entirely.  This avoids iteration and log noise on
-            # every CLI invocation when no migrations are pending.
-            if migration_files and migration_files[-1].name in applied_versions:
+            # Fast-path: short-circuit only when EVERY on-disk migration is
+            # already applied (full-set completeness check via
+            # all_migrations_applied — CHAOS-2440).  A latest-filename-only
+            # check is unsound here because of inserted / mixed-ordering
+            # migrations (023b_ between 023_ and 024_, duplicate numeric
+            # prefixes): the DB could hold the latest row yet be missing an
+            # intermediate migration.  The full-set check stays O(n) in memory
+            # over the SELECT we already ran — no per-file DB query, no log
+            # loop — so it remains fast and quiet while being correct.
+            from dev_health_ops.migrations.clickhouse import all_migrations_applied
+
+            if migration_files and all_migrations_applied(
+                (p.name for p in migration_files), applied_versions
+            ):
                 logger.debug(
-                    "ClickHouse schema is current (latest: %s) — skipping migration loop",
-                    migration_files[-1].name,
+                    "ClickHouse schema is current (%d migrations applied) — "
+                    "skipping migration loop",
+                    len(migration_files),
                 )
                 return
 

--- a/tests/test_migration_fast_path.py
+++ b/tests/test_migration_fast_path.py
@@ -63,7 +63,9 @@ def _make_store(client: MagicMock) -> ClickHouseStore:
     return store
 
 
-def _real_migration_files_for(method_code_filename: str, parents_depth: int) -> list[Path]:
+def _real_migration_files_for(
+    method_code_filename: str, parents_depth: int
+) -> list[Path]:
     """Return the sorted migration file list the runner would compute at runtime."""
     migrations_dir = (
         Path(method_code_filename).resolve().parents[parents_depth]
@@ -86,7 +88,6 @@ async def _fake_to_thread(fn, *args, **kwargs):
 
 
 class TestApplySqlMigrationsCoreFastPath:
-
     def _real_files(self) -> list[Path]:
         # _apply_sql_migrations lives in core.py; use ClickHouseCore's __code__
         # to get the source file so parents[3] resolves correctly.
@@ -199,7 +200,7 @@ class TestApplySqlMigrationsCoreFastPath:
         b_files = [n for n in names if n.startswith("023b")]
         assert b_files, "Expected at least one '023b_*' migration in the corpus"
         idx_b = names.index(b_files[0])
-        after_b = names[idx_b + 1:]
+        after_b = names[idx_b + 1 :]
         assert any(n.startswith("024") for n in after_b), (
             "'024_*' migration must appear after '023b_*' in sorted order"
         )
@@ -223,7 +224,6 @@ class TestApplySqlMigrationsCoreFastPath:
 
 
 class TestEnsureTablesFastPath:
-
     def _real_files(self) -> list[Path]:
         return _real_migration_files_for(
             ClickHouseStore._ensure_tables.__code__.co_filename,

--- a/tests/test_migration_fast_path.py
+++ b/tests/test_migration_fast_path.py
@@ -6,9 +6,15 @@ Covers both runner paths:
 
 Fast-path contract
 ------------------
-When the last entry in sorted(*.sql + *.py) is already in applied_versions,
-the per-file loop is skipped entirely.  Proof: no INSERT INTO schema_migrations
-is issued and query() is called only once (the initial SELECT).
+The per-file loop is skipped entirely ONLY when EVERY on-disk migration is
+already recorded as applied (full-set completeness check —
+``all_migrations_applied``).  Proof: no INSERT INTO schema_migrations is issued
+and query() is called only once (the initial SELECT).
+
+Critically, the fast-path must NOT fire when an *intermediate* migration is
+missing even if the lexicographically-latest one is applied (this repo has
+inserted / mixed-ordering migrations like '023b_' and duplicate numeric
+prefixes — a latest-only check would silently skip the gap, CHAOS-2440).
 
 Quiet contract
 --------------
@@ -17,9 +23,8 @@ DEBUG level, never INFO, so normal CLI output stays clean.
 
 Ordering contract
 -----------------
-The fast-path comparison uses the same ``sorted(*.sql + *.py)`` key as the
-apply loop, so exotic names like '023b_dora_metrics.sql' sort correctly between
-'023_' and '024_'.
+Pending migrations apply in the same ``sorted(*.sql + *.py)`` order, so exotic
+names like '023b_dora_metrics.sql' sort correctly between '023_' and '024_'.
 """
 
 from __future__ import annotations
@@ -33,6 +38,7 @@ import pytest
 
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 from dev_health_ops.metrics.sinks.clickhouse.core import ClickHouseCore
+from dev_health_ops.migrations.clickhouse import all_migrations_applied
 from dev_health_ops.storage import ClickHouseStore
 
 # ---------------------------------------------------------------------------
@@ -80,6 +86,38 @@ def _real_migration_files_for(
 async def _fake_to_thread(fn, *args, **kwargs):
     """Collapse asyncio.to_thread into a direct synchronous call for testing."""
     return fn(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# all_migrations_applied — shared full-set completeness helper
+# ---------------------------------------------------------------------------
+
+
+class TestAllMigrationsApplied:
+    def test_empty_disk_is_trivially_applied(self) -> None:
+        assert all_migrations_applied([], ["000_x.sql"]) is True
+
+    def test_all_present_returns_true(self) -> None:
+        files = ["000_a.sql", "001_b.sql", "002_c.sql"]
+        assert all_migrations_applied(files, files) is True
+
+    def test_extra_applied_rows_are_ignored(self) -> None:
+        # DB may have rows for files no longer on disk; completeness only cares
+        # that every ON-DISK file is applied.
+        files = ["000_a.sql", "001_b.sql"]
+        applied = ["000_a.sql", "001_b.sql", "999_removed.sql"]
+        assert all_migrations_applied(files, applied) is True
+
+    def test_missing_latest_returns_false(self) -> None:
+        files = ["000_a.sql", "001_b.sql", "002_c.sql"]
+        applied = ["000_a.sql", "001_b.sql"]
+        assert all_migrations_applied(files, applied) is False
+
+    def test_missing_middle_with_latest_present_returns_false(self) -> None:
+        """The core regression: latest applied but a gap in the middle."""
+        files = ["000_a.sql", "001_b.sql", "002_c.sql"]
+        applied = ["000_a.sql", "002_c.sql"]  # 001 missing, latest 002 present
+        assert all_migrations_applied(files, applied) is False
 
 
 # ---------------------------------------------------------------------------
@@ -179,15 +217,53 @@ class TestApplySqlMigrationsCoreFastPath:
         )
 
     # ------------------------------------------------------------------
+    # Correctness (the critical case): latest applied but a MIDDLE migration
+    # is missing → fast-path must NOT fire and the gap must be filled.
+    # ------------------------------------------------------------------
+
+    def test_missing_middle_migration_is_applied_despite_latest_present(self) -> None:
+        """Latest IS applied but an intermediate migration is ABSENT.
+
+        A latest-filename-only fast-path would falsely short-circuit here and
+        silently skip the missing middle migration (schema drift). The full-set
+        check must detect the gap, run the loop, and apply exactly the missing
+        migration (recording only it).
+        """
+        files = self._real_files()
+        assert len(files) >= 3, "Need at least 3 migrations to drop a middle one"
+
+        # Drop a migration from the MIDDLE; keep the latest applied.
+        missing_idx = len(files) // 2
+        missing = files[missing_idx]
+        applied = [p.name for i, p in enumerate(files) if i != missing_idx]
+        assert files[-1].name in applied, "Latest must remain applied for this test"
+
+        client = MagicMock()
+        client.query.return_value = _applied_result(applied)
+        recorded_versions: list[str] = []
+
+        def record_command(sql: str, parameters: dict | None = None) -> None:
+            if "INSERT INTO schema_migrations" in sql and parameters:
+                recorded_versions.append(parameters["version"])
+
+        client.command.side_effect = record_command
+
+        _make_core_sink(client)._apply_sql_migrations()
+
+        assert recorded_versions == [missing.name], (
+            f"Expected exactly the missing middle migration {missing.name!r} to be "
+            f"applied; got {recorded_versions}"
+        )
+
+    # ------------------------------------------------------------------
     # Ordering: mixed .sql/.py names with b-suffix sort correctly
     # ------------------------------------------------------------------
 
     def test_mixed_sql_py_ordering_matches_fast_path(self) -> None:
-        """Fast-path 'latest' comparison uses the same sort as the apply loop.
+        """Pending migrations apply in the same sort order as the file list.
 
         Exercises the '023b_' naming convention: it must sort between '023_'
-        and '024_', and the fast-path must agree with the loop on which file is
-        "latest on disk".
+        and '024_'. With all files applied the full-set fast-path fires.
         """
         files = self._real_files()
         names = [p.name for p in files]
@@ -306,4 +382,40 @@ class TestEnsureTablesFastPath:
         inserts = [c for c in commands if "INSERT INTO schema_migrations" in c]
         assert len(inserts) == 1, (
             f"Expected 1 INSERT for {pending.name!r}, got {inserts}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_middle_migration_is_applied_despite_latest_present(
+        self,
+    ) -> None:
+        """Latest IS applied but an intermediate migration is ABSENT (async path).
+
+        The full-set fast-path must detect the gap and apply exactly the missing
+        middle migration — a latest-only check would silently skip it.
+        """
+        files = self._real_files()
+        assert len(files) >= 3, "Need at least 3 migrations to drop a middle one"
+
+        missing_idx = len(files) // 2
+        missing = files[missing_idx]
+        applied = [p.name for i, p in enumerate(files) if i != missing_idx]
+        assert files[-1].name in applied, "Latest must remain applied for this test"
+
+        client = MagicMock()
+        client.query.return_value = _applied_result(applied)
+        recorded_versions: list[str] = []
+
+        def record_command(sql: str, parameters: dict | None = None) -> None:
+            if "INSERT INTO schema_migrations" in sql and parameters:
+                recorded_versions.append(parameters["version"])
+
+        client.command.side_effect = record_command
+
+        store = _make_store(client)
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            await store._ensure_tables()
+
+        assert recorded_versions == [missing.name], (
+            f"Expected exactly the missing middle migration {missing.name!r} to be "
+            f"applied; got {recorded_versions}"
         )

--- a/tests/test_migration_fast_path.py
+++ b/tests/test_migration_fast_path.py
@@ -1,0 +1,309 @@
+"""Tests for CHAOS-2440: quiet + fast-path migration ensure.
+
+Covers both runner paths:
+- ClickHouseCore._apply_sql_migrations  (metrics sink, sync)
+- ClickHouseStore._ensure_tables        (storage, async)
+
+Fast-path contract
+------------------
+When the last entry in sorted(*.sql + *.py) is already in applied_versions,
+the per-file loop is skipped entirely.  Proof: no INSERT INTO schema_migrations
+is issued and query() is called only once (the initial SELECT).
+
+Quiet contract
+--------------
+Per-migration "Skipping already applied migration: X" lines must be emitted at
+DEBUG level, never INFO, so normal CLI output stays clean.
+
+Ordering contract
+-----------------
+The fast-path comparison uses the same ``sorted(*.sql + *.py)`` key as the
+apply loop, so exotic names like '023b_dora_metrics.sql' sort correctly between
+'023_' and '024_'.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.metrics.sinks.clickhouse.core import ClickHouseCore
+from dev_health_ops.storage import ClickHouseStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _applied_result(versions: list[str]) -> MagicMock:
+    result = MagicMock()
+    result.result_rows = [(v,) for v in versions]
+    return result
+
+
+def _make_core_sink(client: MagicMock) -> ClickHouseMetricsSink:
+    """Return a concrete ClickHouseMetricsSink (which inherits ClickHouseCore) with a fake client."""
+    return ClickHouseMetricsSink(
+        dsn="clickhouse://ch:ch@localhost:8123/default", client=client
+    )
+
+
+def _make_store(client: MagicMock) -> ClickHouseStore:
+    """Build a ClickHouseStore without opening a real connection."""
+    store = ClickHouseStore.__new__(ClickHouseStore)
+    store._lock = asyncio.Lock()
+    store._settings = {}
+    store.org_id = None
+    store.client = client
+    return store
+
+
+def _real_migration_files_for(method_code_filename: str, parents_depth: int) -> list[Path]:
+    """Return the sorted migration file list the runner would compute at runtime."""
+    migrations_dir = (
+        Path(method_code_filename).resolve().parents[parents_depth]
+        / "migrations"
+        / "clickhouse"
+    )
+    return sorted(
+        list(migrations_dir.glob("*.sql")) + list(migrations_dir.glob("*.py"))
+    )
+
+
+async def _fake_to_thread(fn, *args, **kwargs):
+    """Collapse asyncio.to_thread into a direct synchronous call for testing."""
+    return fn(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# ClickHouseCore._apply_sql_migrations
+# ---------------------------------------------------------------------------
+
+
+class TestApplySqlMigrationsCoreFastPath:
+
+    def _real_files(self) -> list[Path]:
+        # _apply_sql_migrations lives in core.py; use ClickHouseCore's __code__
+        # to get the source file so parents[3] resolves correctly.
+        return _real_migration_files_for(
+            ClickHouseCore._apply_sql_migrations.__code__.co_filename,
+            parents_depth=3,
+        )
+
+    def _client_with_all_applied(self, files: list[Path]) -> MagicMock:
+        client = MagicMock()
+        client.query.return_value = _applied_result([p.name for p in files])
+        return client
+
+    # ------------------------------------------------------------------
+    # Fast-path: up-to-date DB
+    # ------------------------------------------------------------------
+
+    def test_up_to_date_issues_no_migration_inserts(self) -> None:
+        """When every file on disk is applied, no INSERT INTO schema_migrations fires."""
+        files = self._real_files()
+        assert files, "No real migration files found"
+
+        commands: list[str] = []
+        client = self._client_with_all_applied(files)
+        client.command.side_effect = lambda sql, parameters=None: commands.append(sql)
+
+        _make_core_sink(client)._apply_sql_migrations()
+
+        inserts = [c for c in commands if "INSERT INTO schema_migrations" in c]
+        assert inserts == [], (
+            f"Fast-path missed: INSERT issued when DB is current. Commands: {inserts}"
+        )
+
+    def test_up_to_date_queries_db_exactly_once(self) -> None:
+        """Fast-path must not issue multiple SELECTs against schema_migrations."""
+        files = self._real_files()
+        client = self._client_with_all_applied(files)
+        _make_core_sink(client)._apply_sql_migrations()
+        # One CREATE TABLE + one SELECT → query count must be 1.
+        assert client.query.call_count == 1
+
+    # ------------------------------------------------------------------
+    # Quiet: skip logs must be DEBUG not INFO
+    # ------------------------------------------------------------------
+
+    def test_skip_logs_are_debug_not_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """'Skipping already applied migration' must never appear at INFO level."""
+        files = self._real_files()
+        client = self._client_with_all_applied(files)
+
+        with caplog.at_level(logging.DEBUG, logger="dev_health_ops"):
+            _make_core_sink(client)._apply_sql_migrations()
+
+        info_skips = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.INFO
+            and "Skipping already applied migration" in r.message
+        ]
+        assert info_skips == [], (
+            f"Found INFO-level skip log(s): {[r.message for r in info_skips]}"
+        )
+
+    # ------------------------------------------------------------------
+    # Correctness: pending migrations still applied
+    # ------------------------------------------------------------------
+
+    def test_pending_migration_is_applied_and_recorded(self) -> None:
+        """When DB is one migration behind, that migration is recorded."""
+        files = self._real_files()
+        assert len(files) >= 2, "Need at least 2 migrations for this test"
+
+        # All-but-last applied.
+        applied = [p.name for p in files[:-1]]
+        pending = files[-1]
+
+        client = MagicMock()
+        client.query.return_value = _applied_result(applied)
+        commands: list[str] = []
+        client.command.side_effect = lambda sql, parameters=None: commands.append(sql)
+
+        _make_core_sink(client)._apply_sql_migrations()
+
+        inserts = [c for c in commands if "INSERT INTO schema_migrations" in c]
+        assert len(inserts) == 1, (
+            f"Expected 1 schema_migrations INSERT for {pending.name!r}, got {inserts}"
+        )
+
+    # ------------------------------------------------------------------
+    # Ordering: mixed .sql/.py names with b-suffix sort correctly
+    # ------------------------------------------------------------------
+
+    def test_mixed_sql_py_ordering_matches_fast_path(self) -> None:
+        """Fast-path 'latest' comparison uses the same sort as the apply loop.
+
+        Exercises the '023b_' naming convention: it must sort between '023_'
+        and '024_', and the fast-path must agree with the loop on which file is
+        "latest on disk".
+        """
+        files = self._real_files()
+        names = [p.name for p in files]
+
+        # Verify corpus has mixed types.
+        exts = {p.suffix for p in files}
+        assert ".sql" in exts and ".py" in exts
+
+        # '023b_dora_metrics.sql' must appear between '023_*' and '024_*'.
+        b_files = [n for n in names if n.startswith("023b")]
+        assert b_files, "Expected at least one '023b_*' migration in the corpus"
+        idx_b = names.index(b_files[0])
+        after_b = names[idx_b + 1:]
+        assert any(n.startswith("024") for n in after_b), (
+            "'024_*' migration must appear after '023b_*' in sorted order"
+        )
+
+        # Applying all files must hit the fast-path (latest == files[-1].name).
+        client = self._client_with_all_applied(files)
+        commands: list[str] = []
+        client.command.side_effect = lambda sql, parameters=None: commands.append(sql)
+
+        _make_core_sink(client)._apply_sql_migrations()
+
+        inserts = [c for c in commands if "INSERT INTO schema_migrations" in c]
+        assert inserts == [], (
+            f"Fast-path did not trigger for latest={files[-1].name!r}: {inserts}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ClickHouseStore._ensure_tables
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureTablesFastPath:
+
+    def _real_files(self) -> list[Path]:
+        return _real_migration_files_for(
+            ClickHouseStore._ensure_tables.__code__.co_filename,
+            parents_depth=1,
+        )
+
+    @pytest.mark.asyncio
+    async def test_up_to_date_issues_no_migration_inserts(self) -> None:
+        """Fast-path: no INSERT INTO schema_migrations when DB is current."""
+        files = self._real_files()
+        assert files
+
+        client = MagicMock()
+        client.query.return_value = _applied_result([p.name for p in files])
+        commands: list[str] = []
+        client.command.side_effect = lambda sql, parameters=None: commands.append(sql)
+
+        store = _make_store(client)
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            await store._ensure_tables()
+
+        inserts = [c for c in commands if "INSERT INTO schema_migrations" in c]
+        assert inserts == [], f"Fast-path missed: {inserts}"
+
+    @pytest.mark.asyncio
+    async def test_up_to_date_queries_db_exactly_once(self) -> None:
+        """Only one query call (the version SELECT) when schema is current."""
+        files = self._real_files()
+
+        client = MagicMock()
+        client.query.return_value = _applied_result([p.name for p in files])
+
+        store = _make_store(client)
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            await store._ensure_tables()
+
+        assert client.query.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_skip_logs_are_debug_not_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """'Skipping already applied migration' must not appear at INFO level."""
+        files = self._real_files()
+
+        client = MagicMock()
+        client.query.return_value = _applied_result([p.name for p in files])
+
+        store = _make_store(client)
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            with caplog.at_level(logging.DEBUG, logger="dev_health_ops"):
+                await store._ensure_tables()
+
+        info_skips = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.INFO
+            and "Skipping already applied migration" in r.message
+        ]
+        assert info_skips == [], f"INFO skip log(s): {[r.message for r in info_skips]}"
+
+    @pytest.mark.asyncio
+    async def test_pending_migration_is_applied_and_recorded(self) -> None:
+        """When DB is one migration behind, that migration is recorded."""
+        files = self._real_files()
+        assert len(files) >= 2
+
+        applied = [p.name for p in files[:-1]]
+        pending = files[-1]
+
+        client = MagicMock()
+        client.query.return_value = _applied_result(applied)
+        commands: list[str] = []
+        client.command.side_effect = lambda sql, parameters=None: commands.append(sql)
+
+        store = _make_store(client)
+        with patch("asyncio.to_thread", side_effect=_fake_to_thread):
+            await store._ensure_tables()
+
+        inserts = [c for c in commands if "INSERT INTO schema_migrations" in c]
+        assert len(inserts) == 1, (
+            f"Expected 1 INSERT for {pending.name!r}, got {inserts}"
+        )


### PR DESCRIPTION
## Summary

Fixes CHAOS-2440. Every CLI command that opens a ClickHouse sink was running the full migration pass and logging ~50 `Skipping already applied migration: X` lines per invocation.

- **Fast-path short-circuit**: after the single cheap `SELECT version FROM schema_migrations` that was already required, check `sorted(*.sql + *.py)[-1].name in applied_versions`. If the latest file on disk is already applied, return immediately — skip the per-file loop entirely. The check reuses the exact same `sorted(*.sql + *.py)` ordering as the apply loop, so exotic names like `023b_dora_metrics.sql` sort correctly between `023_*` and `024_*`.
- **Quiet**: the per-migration `"Skipping already applied migration: X"` log lines are lowered from `INFO` → `DEBUG` in `core.py`, and a new `DEBUG`-level skip log is added to `storage/clickhouse.py` (previously silent but still iterated). Genuinely-applying and error logs remain at `INFO`/`ERROR`.

## Files changed

- `src/dev_health_ops/metrics/sinks/clickhouse/core.py` — `_apply_sql_migrations`: fast-path + lower skip log + fix f-string logging to `%` format
- `src/dev_health_ops/storage/clickhouse.py` — `_ensure_tables`: fast-path + debug-level skip log

## Tests

9 new unit tests in `tests/test_migration_fast_path.py` covering both runners:
- Up-to-date DB → fast-path fires, no `INSERT INTO schema_migrations`, `query()` called once, no INFO-level skip logs
- DB one migration behind → pending migration is applied and recorded, in order
- Mixed `.sql`/`.py` sort order validated against real migration corpus (`023b_` naming confirmed)

## Reviewer notes

- The fast-path key is `migration_files[-1].name` where `migration_files = sorted(*.sql + *.py)`. This is **byte-lexicographic on the full filename** (Python default sort on `Path`). Since all files share the same directory, this is effectively filename sort — identical to what the apply loop iterates. No new ordering logic introduced.
- The `_run_clickhouse_upgrade` CLI path calls `ensure_schema(force=True)` which calls `_apply_sql_migrations` directly — the fast-path applies there too (correct: fresh run of `dev-hops migrate clickhouse` on an already-current DB is now silent).
- `AUTO_RUN_MIGRATIONS=false` still gates before `_apply_sql_migrations` is called at all — no change to that behavior.
- The live-e2e migration path (`dev-hops migrate clickhouse upgrade`) is unchanged in correctness: when migrations ARE pending, all pending files still apply in sorted order.