### PR TITLE
feat(ai-impact): derive real followup_commits per PR (CHAOS-2437)

### DIFF
--- a/src/dev_health_ops/metrics/ai_impact.py
+++ b/src/dev_health_ops/metrics/ai_impact.py
@@ -165,6 +165,99 @@ def _test_changes_by_pr(
     return result
 
 
+def _first_review_at_by_pr(
+    rows: Sequence[PullRequestReviewRow],
+) -> dict[tuple[uuid.UUID, int], datetime]:
+    """Earliest review timestamp per PR (the feedback boundary for rework)."""
+    result: dict[tuple[uuid.UUID, int], datetime] = {}
+    for row in rows:
+        submitted = row.get("submitted_at")
+        if submitted is None:
+            continue
+        key = (row["repo_id"], int(row["number"]))
+        ts = _to_utc(submitted)
+        current = result.get(key)
+        if current is None or ts < current:
+            result[key] = ts
+    return result
+
+
+# work_graph_pr_commit.evidence values that mark a PR's OWN merge/squash commit
+# (CHAOS-2435). That commit is the merge artifact, not follow-up work, and on a
+# squash-merge repo it is the *only* commit the linkage attaches to the PR --
+# counting it would make every reviewed PR look reworked. Intermediate commits
+# carry other provenance (fixtures/native linkage) and remain eligible.
+_MERGE_ARTIFACT_EVIDENCE: frozenset[str] = frozenset(
+    {"commit_message_pr_ref", "commit_message_squash_pr_ref"}
+)
+
+
+def _followup_commits_by_pr(
+    pr_commit_stats: Mapping[tuple[uuid.UUID, int], Sequence[CommitStatRow]] | None,
+    pr_index: Mapping[tuple[uuid.UUID, int], PullRequestRow],
+    first_review_at: Mapping[tuple[uuid.UUID, int], datetime],
+) -> dict[tuple[uuid.UUID, int], int]:
+    """Count follow-up commits per PR from the PR↔commit linkage.
+
+    A *follow-up* commit is a distinct commit linked to the PR that landed
+    **after** the feedback boundary (boundary = the PR's first review time when
+    it has been reviewed, else its creation time -- "after PR opened").
+
+    Two guards keep the merge artifact itself from being counted as rework, so a
+    squash-merge PR contributes 0 rather than a phantom 1 (the same class of
+    inflation the test-gap None-semantics guard prevents, CHAOS-2183):
+
+    - **evidence** -- commits linked as the PR's own merge/squash commit
+      (``_MERGE_ARTIFACT_EVIDENCE``) are excluded. This is the reliable signal:
+      on a squash-merge repo the squash commit is the only commit CHAOS-2435
+      attaches, and its ``committer_when`` sits just *before* the API-reported
+      ``merged_at``, so a timestamp bound alone misses it.
+    - **merged_at** -- a defensive ``>= merged_at`` cut for any merge commit that
+      reaches here without artifact evidence (e.g. a future linkage source).
+
+    Returns an empty mapping when linkage is unavailable (``pr_commit_stats`` is
+    ``None`` or empty), so :class:`_PRFact` falls back to ``0`` -- never a
+    fabricated count.
+    """
+    if not pr_commit_stats:
+        return {}
+    result: dict[tuple[uuid.UUID, int], int] = {}
+    for key, rows in pr_commit_stats.items():
+        pr = pr_index.get(key)
+        if pr is None:
+            continue
+        boundary = first_review_at.get(key) or _to_utc(pr["created_at"])
+        merged_at_raw = pr.get("merged_at")
+        merged_at = _to_utc(merged_at_raw) if merged_at_raw is not None else None
+
+        # Dedupe the per-file linkage rows down to one timestamp per commit, and
+        # drop any commit ever tagged as the PR's merge/squash artifact.
+        commit_times: dict[str, datetime] = {}
+        artifact_hashes: set[str] = set()
+        for row in rows:
+            commit_hash = row.get("commit_hash")
+            when = row.get("committer_when")
+            if not commit_hash or when is None:
+                continue
+            commit_hash = str(commit_hash)
+            if (row.get("evidence") or "") in _MERGE_ARTIFACT_EVIDENCE:
+                artifact_hashes.add(commit_hash)
+                continue
+            commit_times[commit_hash] = _to_utc(when)
+        for commit_hash in artifact_hashes:
+            commit_times.pop(commit_hash, None)
+
+        count = 0
+        for when in commit_times.values():
+            if when <= boundary:
+                continue
+            if merged_at is not None and when >= merged_at:
+                continue
+            count += 1
+        result[key] = count
+    return result
+
+
 def _aggregate(facts: Sequence[_PRFact], incidents_count: int) -> _Agg:
     cycles = [fact.cycle_hours for fact in facts if fact.cycle_hours is not None]
     prs_total = len(facts)
@@ -240,6 +333,9 @@ def compute_ai_impact_metrics_daily(
     attribution_by_pr = _attribution_index(ai_attribution_rows)
     review_counts = _reviews_by_pr(pull_request_review_rows)
     test_changes = _test_changes_by_pr(commit_stat_rows, pr_commit_stats)
+    first_review_at = _first_review_at_by_pr(pull_request_review_rows)
+    pr_index = {(pr["repo_id"], int(pr["number"])): pr for pr in pull_request_rows}
+    followup_by_pr = _followup_commits_by_pr(pr_commit_stats, pr_index, first_review_at)
     repo_names = repo_names_by_id or {}
     start = datetime.combine(day, datetime.min.time(), tzinfo=timezone.utc)
     end = start + timedelta(days=1)
@@ -296,7 +392,9 @@ def compute_ai_impact_metrics_daily(
                 # Default None (not False): if pr_commit_stats was None or this PR
                 # wasn't in the linkage table, treat as unknown rather than a gap.
                 has_test_change=test_changes.get((repo_id, number)),
-                followup_commits=0,
+                # 0 when linkage is unavailable (never fabricated) -- see
+                # _followup_commits_by_pr.
+                followup_commits=followup_by_pr.get((repo_id, number), 0),
             )
         )
 

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -1124,11 +1124,21 @@ async def run_daily_metrics_job(
 
                 # LEFT JOIN so PRs with commits that have no file stats still appear
                 # (file_path=NULL → not a test path → has_test_change=False for that PR).
+                # commit_hash + committer_when (from git_commits, org-scoped) feed
+                # follow-up-commit derivation (CHAOS-2437); committer_when is
+                # de-duplicated per commit downstream so RMT version rows are
+                # harmless. git_commit_stats carries no org_id column, so its join
+                # stays on (repo_id, commit_hash) -- p is already org-scoped by the
+                # WHERE clause.
                 raw_link_rows = primary_sink.query_dicts(
-                    "SELECT p.repo_id, p.pr_number, s.file_path"
+                    "SELECT p.repo_id, p.pr_number, p.commit_hash, p.evidence,"
+                    " c.committer_when, s.file_path"
                     " FROM work_graph_pr_commit AS p"
                     " LEFT JOIN git_commit_stats AS s"
                     "   ON s.repo_id = p.repo_id AND s.commit_hash = p.commit_hash"
+                    " LEFT JOIN git_commits AS c"
+                    "   ON c.repo_id = p.repo_id AND c.hash = p.commit_hash"
+                    "   AND c.org_id = p.org_id"
                     f" WHERE p.org_id = {{org_id:String}}{pc_repo_filter}"
                     "   AND p.pr_number IN {pr_numbers:Array(UInt32)}",
                     pc_params,
@@ -1154,7 +1164,12 @@ async def run_daily_metrics_job(
                         )
                         continue
                     built.setdefault((rid, pr_num), []).append(
-                        {"file_path": link.get("file_path")}
+                        {
+                            "file_path": link.get("file_path"),
+                            "commit_hash": link.get("commit_hash"),
+                            "committer_when": link.get("committer_when"),
+                            "evidence": link.get("evidence"),
+                        }
                     )
                 pr_commit_stats = built
             else:

--- a/src/dev_health_ops/metrics/schemas.py
+++ b/src/dev_health_ops/metrics/schemas.py
@@ -20,6 +20,10 @@ class CommitStatRow(TypedDict):
     deletions: int
     old_file_mode: NotRequired[str | None]
     new_file_mode: NotRequired[str | None]
+    # PR↔commit linkage provenance (work_graph_pr_commit.evidence), populated
+    # only when these rows come from the PR-commit linkage join (CHAOS-2437).
+    # Distinguishes a PR's merge/squash artifact from intermediate commits.
+    evidence: NotRequired[str | None]
 
 
 class PullRequestRow(TypedDict):

--- a/tests/metrics/test_ai_impact.py
+++ b/tests/metrics/test_ai_impact.py
@@ -214,6 +214,147 @@ def test_ai_test_gap_rate_uses_pr_commit_file_evidence():
     assert ai.leverage.test_component is None
 
 
+def _review(repo_id, number: int, *, hour: int, state: str = "COMMENTED"):
+    return {
+        "repo_id": repo_id,
+        "number": number,
+        "reviewer": "reviewer@example.com",
+        "submitted_at": datetime(2026, 5, 18, hour, tzinfo=timezone.utc),
+        "state": state,
+    }
+
+
+def _commit(
+    repo_id,
+    commit_hash: str,
+    *,
+    hour: int,
+    file_path: str = "src/app.py",
+    evidence: str | None = None,
+):
+    return {
+        "repo_id": repo_id,
+        "commit_hash": commit_hash,
+        "author_email": "dev@example.com",
+        "author_name": "Dev",
+        "committer_when": datetime(2026, 5, 18, hour, tzinfo=timezone.utc),
+        "file_path": file_path,
+        "additions": 4,
+        "deletions": 1,
+        "evidence": evidence,
+    }
+
+
+def test_followup_commits_after_first_review_drive_rework():
+    """A commit pushed after the first review is a follow-up commit and marks
+    the PR as rework -- even with zero changes-requested (CHAOS-2437).
+
+    Exercises the rework path in _aggregate (changes_requested OR
+    followup_commits). Only the post-review commit counts: the commit landed at
+    PR-open time (before the review boundary) must be excluded.
+    """
+    repo = uuid4()
+    pr = _pr(repo, 1, created_hour=8, merged_hour=12)  # changes_requested=0
+    rows = _rows(
+        [pr],
+        [_attr(repo, 1, "ai_assisted")],
+        reviews=[_review(repo, 1, hour=9)],
+        pr_commit_stats={
+            (repo, 1): [
+                _commit(repo, "initial", hour=8),  # before review -> excluded
+                _commit(repo, "followup", hour=10),  # after review -> counted
+            ]
+        },
+    )
+
+    ai = _bucket(rows, "ai_assisted")
+    assert ai.followup_commits_count == 1
+    assert ai.changes_requested_per_pr == pytest.approx(0)
+    assert ai.rework_prs == 1  # rework driven by the follow-up commit alone
+    assert ai.rework_drag_rate == pytest.approx(1)
+
+
+def test_followup_commits_dedupe_per_commit_across_file_rows():
+    """Per-file linkage rows for one commit collapse to a single follow-up."""
+    repo = uuid4()
+    pr = _pr(repo, 1, created_hour=8, merged_hour=12)
+    rows = _rows(
+        [pr],
+        [_attr(repo, 1, "ai_assisted")],
+        reviews=[_review(repo, 1, hour=9)],
+        pr_commit_stats={
+            (repo, 1): [
+                _commit(repo, "follow", hour=10, file_path="src/a.py"),
+                _commit(repo, "follow", hour=10, file_path="src/b.py"),
+            ]
+        },
+    )
+
+    ai = _bucket(rows, "ai_assisted")
+    assert ai.followup_commits_count == 1
+
+
+def test_squash_merge_commit_excluded_by_evidence_not_just_timestamp():
+    """A squash-merge PR's only linked commit is the squash artifact, tagged
+    ``commit_message_squash_pr_ref`` by CHAOS-2435. It must be excluded by its
+    linkage *evidence* -- crucially even though its commit time (11:00) is
+    strictly BEFORE merged_at (12:00), which is exactly the live shape that
+    defeats a timestamp-only bound (org a78c1a6a). No phantom follow-up/rework.
+    """
+    repo = uuid4()
+    pr = _pr(repo, 1, created_hour=8, merged_hour=12)  # no reviews -> boundary=open
+    rows = _rows(
+        [pr],
+        [_attr(repo, 1, "ai_assisted")],
+        pr_commit_stats={
+            (repo, 1): [
+                _commit(
+                    repo, "squash", hour=11, evidence="commit_message_squash_pr_ref"
+                )
+            ]
+        },
+    )
+
+    ai = _bucket(rows, "ai_assisted")
+    assert ai.followup_commits_count == 0
+    assert ai.rework_prs == 0
+
+
+def test_merge_commit_evidence_excluded_from_followup():
+    """An explicit merge commit (``commit_message_pr_ref``) is the merge
+    artifact too, not follow-up work -- excluded regardless of timing."""
+    repo = uuid4()
+    pr = _pr(repo, 1, created_hour=8, merged_hour=12)
+    rows = _rows(
+        [pr],
+        [_attr(repo, 1, "ai_assisted")],
+        reviews=[_review(repo, 1, hour=9)],
+        pr_commit_stats={
+            (repo, 1): [
+                _commit(repo, "merge", hour=11, evidence="commit_message_pr_ref")
+            ]
+        },
+    )
+
+    ai = _bucket(rows, "ai_assisted")
+    assert ai.followup_commits_count == 0
+    assert ai.rework_prs == 0
+
+
+def test_followup_commits_zero_without_linkage():
+    """No PR↔commit linkage -> follow-up count is 0, never fabricated."""
+    repo = uuid4()
+    rows = _rows(
+        [_pr(repo, 1, created_hour=8, merged_hour=12, changes_requested=0)],
+        [_attr(repo, 1, "ai_assisted")],
+        pr_commit_stats=None,
+    )
+
+    ai = _bucket(rows, "ai_assisted")
+    assert ai.followup_commits_count == 0
+    assert ai.rework_prs == 0
+
+
 def test_operating_leverage_is_decomposed_not_single_score():
     repo = uuid4()
     rows = _rows(


### PR DESCRIPTION
## Problem
`_PRFact.followup_commits` was hardcoded `0` (ai_impact.py:299), so the **rework** signal (`rework_prs`, `rework_drag_rate`) only ever reflected `changes_requested` — follow-up commits never contributed.

## Fix
Derive follow-up commits per PR from the PR↔commit linkage that CHAOS-2435 now populates.

A *follow-up commit* = a distinct commit linked to the PR that landed **after** the feedback boundary (first review time, else PR-open) and is **not** the PR's own merge/squash artifact.

- `job_daily`'s `pr_commit_stats` query now also selects `commit_hash`, `committer_when` (from `git_commits`, **org-scoped** join) and the linkage `evidence`.
- `_followup_commits_by_pr` excludes commits tagged `commit_message_pr_ref` / `commit_message_squash_pr_ref` (the merge/squash artifact). This is the **reliable** signal: on a squash-merge repo the squash commit is the *only* commit CHAOS-2435 attaches and its `committer_when` sits just **before** `merged_at`, so a timestamp bound alone misses it. A defensive `>= merged_at` cut remains for any future merge commit lacking artifact evidence.
- Linkage unavailable → `0`, never fabricated (mirrors the test-gap None-semantics guard, CHAOS-2183).
- `CommitStatRow` gains an optional `evidence` field for the linkage rows.

## Why evidence, not timestamp (live finding)
On org `a78c1a6a` a timestamp-only `< merged_at` bound counted **1221 phantom** follow-up commits (one squash artifact per PR, committed just before merge). Evidence-based exclusion brings this to the correct **0**.

## Live verification (org a78c1a6a)
1770 PRs in the linkage table → **0** follow-up commits — every linked row is a merge/squash artifact, correctly excluded (no rework inflation). The metric activates for repos/fixtures whose linkage carries intermediate commits (covered by unit tests).

## Gates
- `pytest tests/metrics -m "not clickhouse" -k "ai_impact or job_daily"` → 72 passed
- new tests: follow-up-after-review drives rework, per-commit dedupe, squash/merge artifact excluded by evidence (even when committed before merge), zero-without-linkage
- `mypy` (ai_impact / job_daily / schemas) → no issues
- `ruff check` / `format --check` → clean

Depends on CHAOS-2435 (PR #929) for live linkage data; code is independent.

Closes CHAOS-2437