### PR TITLE
feat(work-graph): run_id/coverage protocol for membership supersedure (CHAOS-2433)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -310,34 +310,39 @@ def _row_to_edge(
 
 
 # work_unit_membership is multi-membership (one row per node-category) on a
-# ReplacingMergeTree keyed by (org, node, category_kind, category).
+# ReplacingMergeTree keyed by (org, node, category_kind, category, run_id).
 #
-# STALENESS IS SCOPED PER NODE, NOT PER WORK UNIT. work_unit_id is a hash of the
-# connected component, so when edge churn moves a node into a new component the
-# OLD work_unit_id is never re-emitted — a per-work_unit_id "latest run" guard
-# would keep that dead unit's rows alive forever (the node would keep matching
-# obsolete categories, and annotation would see multiple is_dominant rows). A
-# node belongs to exactly one component per run and emits its rows with one
-# computed_at, so restricting to rows whose computed_at equals the max
-# computed_at for that (org_id, node_type, node_id) makes the node's most recent
-# materialization always supersede its prior component's rows. This fixes
-# split/merge and below-threshold drop-off in one guard.
+# RUN_ID / COMPLETION-MARKER PROTOCOL (CHAOS-2433):
+# Every membership write (materializer or backfill) stamps a single run_id on
+# ALL rows of the run, then writes ONE completion-marker row to
+# work_unit_membership_runs (org_id, run_id, completed_at) as the LAST step.
+# A run is COMPLETE only when its marker exists. Readers select the latest
+# complete run for the org:
 #
-# ORPHANS: a node removed from the graph entirely is never re-emitted, so its
-# last-known rows linger. The materialization job can run repo/team-scoped (see
-# workers/work_graph_tasks.py) — it is NOT guaranteed to be a global org sweep
-# each run — so a "latest global run per org" backstop would wrongly hide nodes
-# whose repo was not in the most recent scoped run, and tombstoning vanished
-# nodes would require a full-graph diff a scoped run cannot produce. We
-# therefore intentionally let an orphaned node retain its last categories until
-# it is re-materialized (or its edges age out of work_graph_edges, at which
-# point no edge references it anyway). This matches how the rest of the work
-# graph treats vanished nodes (no tombstones).
-_LATEST_RUN_PER_NODE_SUBQUERY = """
-        SELECT node_type, node_id, max(computed_at) AS max_computed_at
-        FROM work_unit_membership
+#   argMax(run_id, completed_at) FROM work_unit_membership_runs WHERE org_id=?
+#
+# and scope ALL membership reads to rows whose run_id equals that value.
+#
+# This protocol fixes three failure modes at once (superseding per-node
+# max(computed_at)):
+#   1. CONCURRENCY RACE: a materializer in-flight has written some membership
+#      rows but not its marker; the prior COMPLETE backfill run is still visible.
+#      The materializer's marker write atomically switches readers to the new run.
+#   2. SPLIT/MERGE STALE: nodes from a prior component that are absent from the
+#      latest complete run simply have no rows in that run — not filterable and
+#      annotation returns None, exactly "no membership row" semantics.
+#   3. PARTIAL-WRITE DIVERGENCE: a run with rows but no marker is never selected.
+#
+# NO TOMBSTONES: tombstones (category='') are not needed because a churned node
+# that is absent from the latest complete run has no rows in scope — the reader
+# sees exactly the same result as "node has no membership" without any sentinel.
+#
+# When NO complete run exists for the org (table empty or all runs incomplete),
+# readers treat it as no membership at all — degraded state if investments exist.
+_LATEST_COMPLETE_RUN_SUBQUERY = """
+        SELECT argMax(run_id, completed_at) AS latest_run_id
+        FROM work_unit_membership_runs
         WHERE org_id = %(org_id)s
-        GROUP BY node_type, node_id
 """
 
 
@@ -349,9 +354,10 @@ async def _batch_resolve_membership(
     """Batch-lookup the dominant theme/subcategory per edge endpoint in ONE query.
 
     Returns {(node_type, node_id) -> {"dominant_theme": ..., "dominant_subcategory": ...}}
-    built from the is_dominant=1 rows of each node's latest run (stale rows from
-    a prior component excluded via the per-node latest-run join — see
-    _LATEST_RUN_PER_NODE_SUBQUERY). Scoped to org_id.
+    built from the is_dominant=1 rows of the latest COMPLETE run (scoped via
+    work_unit_membership_runs — see _LATEST_COMPLETE_RUN_SUBQUERY). Nodes absent
+    from the latest complete run return no entry (annotation null). Scoped to
+    org_id.  When no complete run exists, returns {} (no annotation).
     """
     from dev_health_ops.api.queries.client import query_dicts
 
@@ -377,21 +383,20 @@ async def _batch_resolve_membership(
         membership_rows = await query_dicts(
             client,
             f"""
-            WITH latest AS ({_LATEST_RUN_PER_NODE_SUBQUERY})
+            WITH latest_run AS ({_LATEST_COMPLETE_RUN_SUBQUERY})
             SELECT
                 m.node_type AS node_type,
                 m.node_id AS node_id,
                 m.category_kind AS category_kind,
                 m.category AS category
             FROM work_unit_membership AS m
-            INNER JOIN latest
-                ON m.node_type = latest.node_type
-               AND m.node_id = latest.node_id
-               AND m.computed_at = latest.max_computed_at
+            INNER JOIN latest_run
+                ON m.run_id = latest_run.latest_run_id
             WHERE m.org_id = %(org_id)s
               AND m.node_type IN %(node_types)s
               AND m.node_id IN %(node_ids)s
               AND m.is_dominant = 1
+              AND latest_run.latest_run_id != ''
             """,
             {
                 "org_id": org_id,
@@ -442,21 +447,20 @@ def _theme_membership_exists_clause() -> str:
     A correlated semi-join pushed INTO the edge query so the membership filter,
     the repo_id/edge_type/source filters, AND the LIMIT all execute in one
     ClickHouse plan (no unbounded Python IN set; the before-LIMIT guarantee
-    holds because this lives in the edge WHERE). Per-node latest-run guard
-    excludes stale rows from a prior component (split/merge safe). The
-    uniqExact HAVING enforces "member of EVERY requested (kind, category)", so a
-    theme+subcategory filter requires membership in BOTH. An edge matches when
-    EITHER endpoint satisfies the subquery.
+    holds because this lives in the edge WHERE). Run-scoping via
+    work_unit_membership_runs (CHAOS-2433) ensures only the latest COMPLETE run's
+    rows are considered. The uniqExact HAVING enforces "member of EVERY requested
+    (kind, category)", so a theme+subcategory filter requires membership in BOTH.
+    An edge matches when EITHER endpoint satisfies the subquery.
     """
     return f"""
         EXISTS (
             SELECT 1
             FROM work_unit_membership AS m
-            INNER JOIN ({_LATEST_RUN_PER_NODE_SUBQUERY}) AS latest
-                ON m.node_type = latest.node_type
-               AND m.node_id = latest.node_id
-               AND m.computed_at = latest.max_computed_at
+            INNER JOIN ({_LATEST_COMPLETE_RUN_SUBQUERY}) AS latest_run
+                ON m.run_id = latest_run.latest_run_id
             WHERE m.org_id = %(org_id)s
+              AND latest_run.latest_run_id != ''
               AND (
                 (m.node_type, m.node_id) = (work_graph_edges.source_type, work_graph_edges.source_id)
                 OR (m.node_type, m.node_id) = (work_graph_edges.target_type, work_graph_edges.target_id)
@@ -533,14 +537,14 @@ MEMBERSHIP_NOT_MATERIALIZED = "MEMBERSHIP_NOT_MATERIALIZED"
 
 async def _detect_membership_degraded_reason(client: Any, org_id: str) -> str | None:
     """Return MEMBERSHIP_NOT_MATERIALIZED when a theme filter yielded nothing
-    because work_unit_membership is unpopulated for an org that HAS categorized
-    work units, else None.
+    because work_unit_membership has no complete run for an org that HAS
+    categorized work units, else None.
 
-    Degraded iff: the org has >= 1 work_unit_investments row AND ZERO
-    work_unit_membership rows. The membership count is scoped to each node's
-    latest run (a row is "live" only if its computed_at equals the node's max)
-    so leftover rows from a prior component never mask a truly empty table —
-    consistent with the per-node staleness used everywhere else (CHAOS-2430).
+    Degraded iff: the org has >= 1 work_unit_investments row AND no complete
+    membership run exists in work_unit_membership_runs (i.e. no marker has been
+    written yet, meaning the run_id / completion-marker protocol has not produced
+    a complete run — CHAOS-2433). Counts membership rows in the latest complete
+    run only (zero rows in the latest complete run = no usable membership).
     Also emits the rollout warning log (observability retained). Never raises:
     on probe failure it returns None so the request is unaffected.
     """
@@ -549,21 +553,15 @@ async def _detect_membership_degraded_reason(client: Any, org_id: str) -> str | 
     try:
         rows = await query_dicts(
             client,
-            """
+            f"""
             SELECT
                 (
                     SELECT count()
                     FROM work_unit_membership AS m
-                    INNER JOIN (
-                        SELECT node_type, node_id, max(computed_at) AS max_computed_at
-                        FROM work_unit_membership
-                        WHERE org_id = %(org_id)s
-                        GROUP BY node_type, node_id
-                    ) AS latest
-                        ON m.node_type = latest.node_type
-                       AND m.node_id = latest.node_id
-                       AND m.computed_at = latest.max_computed_at
+                    INNER JOIN ({_LATEST_COMPLETE_RUN_SUBQUERY}) AS latest_run
+                        ON m.run_id = latest_run.latest_run_id
                     WHERE m.org_id = %(org_id)s
+                      AND latest_run.latest_run_id != ''
                 ) AS membership_rows,
                 (
                     SELECT count()
@@ -584,10 +582,10 @@ async def _detect_membership_degraded_reason(client: Any, org_id: str) -> str | 
     investment_rows = int(rows[0].get("investment_rows") or 0)
     if membership_rows == 0 and investment_rows > 0:
         logger.warning(
-            "Theme filter returned no edges and work_unit_membership is empty "
-            "for org %s while work_unit_investments has %d rows — the "
-            "post-migration investment materialization rerun that populates "
-            "work_unit_membership has likely not run yet (CHAOS-2430).",
+            "Theme filter returned no edges and no complete membership run "
+            "exists for org %s while work_unit_investments has %d rows — "
+            "the post-migration investment materialization rerun that populates "
+            "work_unit_membership has likely not run yet (CHAOS-2430/2433).",
             org_id,
             investment_rows,
         )
@@ -595,7 +593,7 @@ async def _detect_membership_degraded_reason(client: Any, org_id: str) -> str | 
     return None
 
 
-_MEMBERSHIP_TABLE = "work_unit_membership"
+_MEMBERSHIP_TABLES = frozenset({"work_unit_membership", "work_unit_membership_runs"})
 
 # ClickHouse names the actually-missing table in an "Unknown table ...
 # identifier '<name>'" clause. The full error ALSO echoes the entire failing
@@ -623,19 +621,18 @@ def _unknown_table_names(text: str) -> set[str]:
 
 def _is_missing_membership_table_error(exc: BaseException) -> bool:
     """True ONLY when a ClickHouse missing-table (code 60) error names
-    ``work_unit_membership`` as the unknown table.
+    ``work_unit_membership`` OR ``work_unit_membership_runs`` as the unknown table.
 
-    During a rolling deploy or before the membership migration has run, the
-    filtered edge query's EXISTS subquery references ``work_unit_membership``
-    before it exists; the driver raises a DatabaseError carrying ``code == 60``
-    with an ``UNKNOWN_TABLE`` server message whose identifier clause names the
-    offending table. We require the code-60/UNKNOWN_TABLE signal AND that the
-    reported-unknown identifier IS ``work_unit_membership`` — parsed from the
-    identifier clause, NOT the echoed SQL (which lists every table in the
-    query). So a code-60 error for any OTHER table (e.g. a missing
-    ``work_graph_edges`` or another schema regression on the filtered path)
-    re-raises and surfaces loudly instead of masquerading as the benign degraded
-    state.
+    During a rolling deploy or before migration 047 has run, the filtered edge
+    query or the degraded probe references these tables before they exist; the
+    driver raises a DatabaseError carrying ``code == 60`` with an
+    ``UNKNOWN_TABLE`` server message whose identifier clause names the offending
+    table. We require the code-60/UNKNOWN_TABLE signal AND that the
+    reported-unknown identifier IS one of the membership tables — parsed from the
+    identifier clause, NOT the echoed SQL (which lists every table in the query).
+    So a code-60 error for any OTHER table (e.g. a missing ``work_graph_edges``
+    or another schema regression on the filtered path) re-raises and surfaces
+    loudly instead of masquerading as the benign degraded state.
     """
     text = str(exc)
     is_unknown_table = (
@@ -645,7 +642,7 @@ def _is_missing_membership_table_error(exc: BaseException) -> bool:
     )
     if not is_unknown_table:
         return False
-    return _MEMBERSHIP_TABLE in _unknown_table_names(text)
+    return bool(_unknown_table_names(text) & _MEMBERSHIP_TABLES)
 
 
 def _empty_edges_result(degraded_reason: str | None = None) -> WorkGraphEdgesResult:

--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -563,14 +563,26 @@ MEMBERSHIP_NOT_MATERIALIZED = "MEMBERSHIP_NOT_MATERIALIZED"
 
 async def _detect_membership_degraded_reason(client: Any, org_id: str) -> str | None:
     """Return MEMBERSHIP_NOT_MATERIALIZED when a theme filter yielded nothing
-    because work_unit_membership has no complete run for an org that HAS
+    because NO complete membership run has been published for an org that HAS
     categorized work units, else None.
 
-    Degraded iff: the org has >= 1 work_unit_investments row AND no complete
-    membership run exists in work_unit_membership_runs (i.e. no marker has been
-    written yet, meaning the run_id / completion-marker protocol has not produced
-    a complete run — CHAOS-2433). Counts membership rows in the latest complete
-    run only (zero rows in the latest complete run = no usable membership).
+    Degraded iff: the org has >= 1 work_unit_investments row AND NO complete-run
+    MARKER exists in work_unit_membership_runs for the org (the run_id /
+    completion-marker protocol has not produced any complete run yet —
+    CHAOS-2433).
+
+    GATE ON MARKER EXISTENCE, NOT ROW COUNT (CHAOS-2433 round-2 finding #2):
+    an intentionally-EMPTY complete run (the all-skipped supersede case — every
+    current component churned past its last categorization) is a genuine
+    "this org currently has no memberships" state, NOT "not materialized". It
+    publishes a marker with zero membership rows. Keying the degraded signal on
+    count(membership rows in latest run) > 0 would mislabel that valid empty
+    complete run as a rollout failure. We therefore key on whether ANY complete
+    marker exists for the org: a marker present (even with zero rows) means the
+    pipeline HAS produced a complete run, so an empty filter result is a genuine
+    empty (degraded_reason=None). Only the total absence of a marker (pre-migration
+    / pre-first-run rollout window) while investments exist is degraded.
+
     Also emits the rollout warning log (observability retained). Never raises:
     on probe failure it returns None so the request is unaffected.
     """
@@ -579,16 +591,13 @@ async def _detect_membership_degraded_reason(client: Any, org_id: str) -> str | 
     try:
         rows = await query_dicts(
             client,
-            f"""
+            """
             SELECT
                 (
                     SELECT count()
-                    FROM work_unit_membership AS m
-                    INNER JOIN ({_LATEST_COMPLETE_RUN_SUBQUERY}) AS latest_run
-                        ON {_RUN_SCOPE_JOIN_ON}
-                    WHERE m.org_id = %(org_id)s
-                      AND latest_run.latest_run_id != ''
-                ) AS membership_rows,
+                    FROM work_unit_membership_runs
+                    WHERE org_id = %(org_id)s
+                ) AS complete_run_markers,
                 (
                     SELECT count()
                     FROM work_unit_investments
@@ -604,14 +613,15 @@ async def _detect_membership_degraded_reason(client: Any, org_id: str) -> str | 
 
     if not rows:
         return None
-    membership_rows = int(rows[0].get("membership_rows") or 0)
+    complete_run_markers = int(rows[0].get("complete_run_markers") or 0)
     investment_rows = int(rows[0].get("investment_rows") or 0)
-    if membership_rows == 0 and investment_rows > 0:
+    if complete_run_markers == 0 and investment_rows > 0:
         logger.warning(
-            "Theme filter returned no edges and no complete membership run "
-            "exists for org %s while work_unit_investments has %d rows — "
-            "the post-migration investment materialization rerun that populates "
-            "work_unit_membership has likely not run yet (CHAOS-2430/2433).",
+            "Theme filter returned no edges and NO complete membership run "
+            "marker exists for org %s while work_unit_investments has %d rows — "
+            "the post-migration investment materialization rerun that publishes "
+            "a work_unit_membership_runs completion marker has likely not run "
+            "yet (CHAOS-2430/2433).",
             org_id,
             investment_rows,
         )

--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -339,11 +339,37 @@ def _row_to_edge(
 #
 # When NO complete run exists for the org (table empty or all runs incomplete),
 # readers treat it as no membership at all — degraded state if investments exist.
+#
+# LEGACY ROLLOUT (CHAOS-2433 finding #3):
+# Migration 048 seeds ONE synthetic "legacy" marker per org that already had
+# membership rows before migration 047 (run_id defaulted to '' on those rows,
+# and no real run had published a marker yet).  The legacy marker uses the
+# reserved run_id _LEGACY_RUN_ID and completed_at = max(existing computed_at).
+# When the selected latest run IS the legacy marker, readers must match the
+# PRE-EXISTING rows (run_id = '') instead of looking for rows tagged with the
+# literal '__legacy__'.  The join condition below therefore matches a row when
+# its run_id equals the latest run OR (the latest run is the legacy marker AND
+# the row carries the empty default run_id).  As soon as a real org-wide run
+# publishes a marker, its completed_at exceeds the legacy marker's, argMax
+# selects it, and the legacy path retires automatically (no cleanup needed; the
+# legacy marker simply stops being the latest).
+_LEGACY_RUN_ID = "__legacy__"
+
 _LATEST_COMPLETE_RUN_SUBQUERY = """
         SELECT argMax(run_id, completed_at) AS latest_run_id
         FROM work_unit_membership_runs
         WHERE org_id = %(org_id)s
 """
+
+# Join predicate that scopes membership rows to the latest complete run, with
+# the legacy fallback baked in.  ``m`` is the work_unit_membership alias and
+# ``latest_run`` is the _LATEST_COMPLETE_RUN_SUBQUERY alias.  The empty-string
+# guard (latest_run.latest_run_id != '') stays the caller's responsibility so
+# orgs with no complete run still resolve to "no membership".
+_RUN_SCOPE_JOIN_ON = (
+    "m.run_id = latest_run.latest_run_id "
+    f"OR (latest_run.latest_run_id = '{_LEGACY_RUN_ID}' AND m.run_id = '')"
+)
 
 
 async def _batch_resolve_membership(
@@ -391,7 +417,7 @@ async def _batch_resolve_membership(
                 m.category AS category
             FROM work_unit_membership AS m
             INNER JOIN latest_run
-                ON m.run_id = latest_run.latest_run_id
+                ON {_RUN_SCOPE_JOIN_ON}
             WHERE m.org_id = %(org_id)s
               AND m.node_type IN %(node_types)s
               AND m.node_id IN %(node_ids)s
@@ -458,7 +484,7 @@ def _theme_membership_exists_clause() -> str:
             SELECT 1
             FROM work_unit_membership AS m
             INNER JOIN ({_LATEST_COMPLETE_RUN_SUBQUERY}) AS latest_run
-                ON m.run_id = latest_run.latest_run_id
+                ON {_RUN_SCOPE_JOIN_ON}
             WHERE m.org_id = %(org_id)s
               AND latest_run.latest_run_id != ''
               AND (
@@ -559,7 +585,7 @@ async def _detect_membership_degraded_reason(client: Any, org_id: str) -> str | 
                     SELECT count()
                     FROM work_unit_membership AS m
                     INNER JOIN ({_LATEST_COMPLETE_RUN_SUBQUERY}) AS latest_run
-                        ON m.run_id = latest_run.latest_run_id
+                        ON {_RUN_SCOPE_JOIN_ON}
                     WHERE m.org_id = %(org_id)s
                       AND latest_run.latest_run_id != ''
                 ) AS membership_rows,

--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -340,19 +340,28 @@ def _row_to_edge(
 # When NO complete run exists for the org (table empty or all runs incomplete),
 # readers treat it as no membership at all — degraded state if investments exist.
 #
-# LEGACY ROLLOUT (CHAOS-2433 finding #3):
+# LEGACY ROLLOUT (CHAOS-2433 finding #3, corrected in the final review):
 # Migration 048 seeds ONE synthetic "legacy" marker per org that already had
 # membership rows before migration 047 (run_id defaulted to '' on those rows,
 # and no real run had published a marker yet).  The legacy marker uses the
 # reserved run_id _LEGACY_RUN_ID and completed_at = max(existing computed_at).
 # When the selected latest run IS the legacy marker, readers must match the
-# PRE-EXISTING rows (run_id = '') instead of looking for rows tagged with the
-# literal '__legacy__'.  The join condition below therefore matches a row when
-# its run_id equals the latest run OR (the latest run is the legacy marker AND
-# the row carries the empty default run_id).  As soon as a real org-wide run
-# publishes a marker, its completed_at exceeds the legacy marker's, argMax
-# selects it, and the legacy path retires automatically (no cleanup needed; the
-# legacy marker simply stops being the latest).
+# PRE-EXISTING rows (run_id = '').
+#
+# OVER-MATCH FIX (final review HIGH): a blanket "match ALL run_id='' rows" is
+# WRONG.  The OLD pre-protocol table key was (org, node, category_kind, category)
+# with run_id NOT in the key, so a node that was dominant category A at T1 and
+# re-materialized to dominant category B at T2 has BOTH rows persisted (A and B
+# are different category values -> different keys -> ReplacingMergeTree never
+# deduped them).  The OLD reader scoped each node to its latest row via
+# max(computed_at) per (org, node).  A blanket run_id='' match resurfaces the
+# stale A alongside the current B (wrong filters + multiple is_dominant rows per
+# node) during the rollout window.  We therefore restore the EXACT old per-node
+# semantics for the legacy run ONLY: scope each node to its latest computed_at
+# among its run_id='' rows.  For REAL run_ids, run_id equality is unchanged (the
+# protocol guarantees one generation per run_id, so no per-node-max is needed).
+# As soon as a real org-wide run publishes a marker, its completed_at exceeds the
+# legacy marker's, argMax selects it, and the legacy path retires automatically.
 _LEGACY_RUN_ID = "__legacy__"
 
 _LATEST_COMPLETE_RUN_SUBQUERY = """
@@ -361,14 +370,42 @@ _LATEST_COMPLETE_RUN_SUBQUERY = """
         WHERE org_id = %(org_id)s
 """
 
-# Join predicate that scopes membership rows to the latest complete run, with
-# the legacy fallback baked in.  ``m`` is the work_unit_membership alias and
-# ``latest_run`` is the _LATEST_COMPLETE_RUN_SUBQUERY alias.  The empty-string
-# guard (latest_run.latest_run_id != '') stays the caller's responsibility so
-# orgs with no complete run still resolve to "no membership".
-_RUN_SCOPE_JOIN_ON = (
-    "m.run_id = latest_run.latest_run_id "
-    f"OR (latest_run.latest_run_id = '{_LEGACY_RUN_ID}' AND m.run_id = '')"
+# LEFT JOIN to an inline derived table computing, per (org, node), the MAX
+# computed_at among LEGACY rows (run_id = '').  Bound to ``m`` by (org, node) and
+# aliased ``lnm`` so the scope predicate can restrict the legacy branch to each
+# node's most recent pre-migration row — the exact old per-node-latest behavior.
+# Inlined (not a top-level CTE) so it works identically in the annotation query
+# AND inside the correlated EXISTS semi-join.  Only meaningful when the latest
+# run is the legacy marker; harmless (unmatched LEFT JOIN) otherwise.  The
+# scoping subquery is org-scoped via %(org_id)s.
+_LEGACY_NODE_MAX_JOIN = """
+            LEFT JOIN (
+                SELECT
+                    org_id,
+                    node_type,
+                    node_id,
+                    max(computed_at) AS legacy_max_computed_at
+                FROM work_unit_membership
+                WHERE org_id = %(org_id)s AND run_id = ''
+                GROUP BY org_id, node_type, node_id
+            ) AS lnm
+                ON lnm.org_id = m.org_id
+                AND lnm.node_type = m.node_type
+                AND lnm.node_id = m.node_id
+"""
+
+# Scope predicate (legacy-vs-real conditional).  ``m`` = work_unit_membership
+# alias, ``latest_run`` = _LATEST_COMPLETE_RUN_SUBQUERY alias, ``lnm`` =
+# _LEGACY_NODE_MAX_JOIN alias.  REAL run -> run_id equality (one generation per
+# run_id).  LEGACY run -> the node's latest pre-migration row only (run_id='' AND
+# computed_at == that node's legacy max), NOT a blanket run_id='' match.  The
+# empty-string guard (latest_run.latest_run_id != '') stays the caller's
+# responsibility so orgs with no complete run resolve to "no membership".
+_RUN_SCOPE_PREDICATE = (
+    f"(latest_run.latest_run_id != '{_LEGACY_RUN_ID}' "
+    "AND m.run_id = latest_run.latest_run_id) "
+    f"OR (latest_run.latest_run_id = '{_LEGACY_RUN_ID}' AND m.run_id = '' "
+    "AND m.computed_at = lnm.legacy_max_computed_at)"
 )
 
 
@@ -416,13 +453,14 @@ async def _batch_resolve_membership(
                 m.category_kind AS category_kind,
                 m.category AS category
             FROM work_unit_membership AS m
-            INNER JOIN latest_run
-                ON {_RUN_SCOPE_JOIN_ON}
+            INNER JOIN latest_run ON 1 = 1
+            {_LEGACY_NODE_MAX_JOIN}
             WHERE m.org_id = %(org_id)s
               AND m.node_type IN %(node_types)s
               AND m.node_id IN %(node_ids)s
               AND m.is_dominant = 1
               AND latest_run.latest_run_id != ''
+              AND ({_RUN_SCOPE_PREDICATE})
             """,
             {
                 "org_id": org_id,
@@ -484,9 +522,11 @@ def _theme_membership_exists_clause() -> str:
             SELECT 1
             FROM work_unit_membership AS m
             INNER JOIN ({_LATEST_COMPLETE_RUN_SUBQUERY}) AS latest_run
-                ON {_RUN_SCOPE_JOIN_ON}
+                ON 1 = 1
+            {_LEGACY_NODE_MAX_JOIN}
             WHERE m.org_id = %(org_id)s
               AND latest_run.latest_run_id != ''
+              AND ({_RUN_SCOPE_PREDICATE})
               AND (
                 (m.node_type, m.node_id) = (work_graph_edges.source_type, work_graph_edges.source_id)
                 OR (m.node_type, m.node_id) = (work_graph_edges.target_type, work_graph_edges.target_id)

--- a/src/dev_health_ops/fixtures/generators/investments.py
+++ b/src/dev_health_ops/fixtures/generators/investments.py
@@ -277,6 +277,7 @@ class InvestmentsGeneratorMixin(BaseGeneratorMixin):
         work_unit_investments: list[Any],
         *,
         org_id: str = "",
+        run_id: str = "",
     ) -> list[Any]:
         """Generate work_unit_membership rows from generated investment records.
 
@@ -288,9 +289,13 @@ class InvestmentsGeneratorMixin(BaseGeneratorMixin):
         tie-break. Each fixture work unit is a single issue node
         (work_unit_id == work_item_id), so the node is ("issue", work_unit_id).
 
-        Populating this in fixtures means the live-e2e/demo org exercises theme
-        filtering directly and the degraded path (MEMBERSHIP_NOT_MATERIALIZED)
-        is only ever hit pre-materialization (CHAOS-2430).
+        ``run_id`` (CHAOS-2433) is stamped on every row; the caller MUST also
+        publish a matching ``work_unit_membership_runs`` completion marker, or the
+        run-scoped resolver will treat these rows as an incomplete (invisible)
+        run.  Populating this in fixtures means the live-e2e/demo org exercises
+        theme filtering directly and the degraded path
+        (MEMBERSHIP_NOT_MATERIALIZED) is only ever hit pre-materialization
+        (CHAOS-2430).
         """
         from dev_health_ops.metrics.schemas import WorkUnitMembershipRecord
         from dev_health_ops.work_graph.investment.materialize import (
@@ -321,6 +326,7 @@ class InvestmentsGeneratorMixin(BaseGeneratorMixin):
                             is_dominant=is_dominant,
                             categorization_status=inv.categorization_status,
                             computed_at=inv.computed_at,
+                            run_id=run_id,
                         )
                     )
         return records

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -967,12 +967,36 @@ async def run_fixtures_generation(ns: argparse.Namespace) -> int:
                         and hasattr(sink, "write_work_unit_memberships")
                         and work_unit_investments
                     ):
+                        # CHAOS-2433: stamp a single fixture run_id on all rows and
+                        # publish a matching completion marker, or the run-scoped
+                        # resolver treats these rows as an incomplete (invisible)
+                        # run and theme filtering would always degrade.
+                        import uuid as _uuid
+                        from datetime import datetime as _dt
+                        from datetime import timezone as _tz
+
+                        from dev_health_ops.metrics.schemas import (
+                            WorkUnitMembershipRunRecord,
+                        )
+
+                        membership_run_id = _uuid.uuid4().hex
                         work_unit_memberships = generate_work_unit_memberships(
                             work_unit_investments,
                             org_id=org_id,
+                            run_id=membership_run_id,
                         )
                         if work_unit_memberships:
                             sink.write_work_unit_memberships(work_unit_memberships)
+                            # Completion marker LAST (run protocol). completed_at
+                            # is the actual write time so a later fixture run wins.
+                            if hasattr(sink, "write_membership_run"):
+                                sink.write_membership_run(
+                                    WorkUnitMembershipRunRecord(
+                                        org_id=org_id,
+                                        run_id=membership_run_id,
+                                        completed_at=_dt.now(_tz.utc),
+                                    )
+                                )
 
                     hotspot_records = metric_gen.generate_file_hotspot_daily(
                         days=ns.days

--- a/src/dev_health_ops/metrics/schemas.py
+++ b/src/dev_health_ops/metrics/schemas.py
@@ -759,10 +759,12 @@ class WorkUnitMembershipRecord:
     category of each kind (``is_dominant=1``) even if below threshold.
 
     ``category_kind`` is ``'theme'`` or ``'subcategory'``. Readers MUST scope to
-    each node's latest run (rows whose ``computed_at`` equals the max
-    ``computed_at`` for that ``(org_id, node_type, node_id)``) — NOT per
-    ``work_unit_id`` — to exclude stale rows left behind when edge churn moves a
-    node into a new component (the old work_unit_id is never re-emitted).
+    the latest COMPLETE run for the org (run_id = argMax(run_id, completed_at)
+    from ``work_unit_membership_runs``) rather than selecting rows by
+    ``computed_at``.  A run is complete only after its completion-marker row has
+    been written to ``work_unit_membership_runs``.  Rows whose ``run_id`` does
+    not match the latest complete run are stale and invisible to readers (fixes
+    split/merge, partial-write divergence, and the concurrency race — CHAOS-2433).
     """
 
     org_id: str
@@ -775,6 +777,25 @@ class WorkUnitMembershipRecord:
     is_dominant: int
     categorization_status: str
     computed_at: datetime
+    run_id: str = ""
+
+
+@dataclass(frozen=True)
+class WorkUnitMembershipRunRecord:
+    """Completion-marker for one membership write run (CHAOS-2433).
+
+    Written to ``work_unit_membership_runs`` as the LAST step of every membership
+    write (materializer or backfill).  A run whose ``run_id`` appears in
+    ``work_unit_membership`` but NOT in ``work_unit_membership_runs`` is
+    incomplete (in-flight or crashed) and is invisible to readers.
+
+    Readers select: ``argMax(run_id, completed_at) FROM work_unit_membership_runs
+    WHERE org_id = ?`` and scope membership reads to that ``run_id``.
+    """
+
+    org_id: str
+    run_id: str
+    completed_at: datetime
 
 
 @dataclass(frozen=True)

--- a/src/dev_health_ops/metrics/sinks/base.py
+++ b/src/dev_health_ops/metrics/sinks/base.py
@@ -376,6 +376,18 @@ class BaseMetricsSink(ABC):
         """
         pass
 
+    def prune_membership_runs(self, org_id: str, *, keep: int = 2) -> int:
+        """Retain only the latest ``keep`` COMPLETE membership runs for an org.
+
+        Deletes ``work_unit_membership`` rows AND their ``work_unit_membership_runs``
+        markers for runs older than the latest ``keep`` complete runs (ordered by
+        completion timestamp). Runs WITHOUT a completion marker (in-flight writes)
+        are NEVER touched. Returns the number of run generations pruned. No-op in
+        the base sink. See the ClickHouse implementation for the retention
+        contract (CHAOS-2433 round-5).
+        """
+        return 0
+
     # -------------------------------------------------------------------------
     # Investment explanation caching
     # -------------------------------------------------------------------------

--- a/src/dev_health_ops/metrics/sinks/base.py
+++ b/src/dev_health_ops/metrics/sinks/base.py
@@ -46,6 +46,7 @@ from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
     WorkUnitMembershipRecord,
+    WorkUnitMembershipRunRecord,
 )
 from dev_health_ops.metrics.testops_schemas import (
     BenchmarkAnomalyRecord,
@@ -364,6 +365,15 @@ class BaseMetricsSink(ABC):
         self, rows: Sequence[WorkUnitMembershipRecord]
     ) -> None:
         """Write node→work-unit membership rows for theme/subcategory filtering."""
+        pass
+
+    def write_membership_run(self, record: WorkUnitMembershipRunRecord) -> None:
+        """Write the completion-marker for a membership write run (CHAOS-2433).
+
+        Must be called as the LAST step after all membership rows for the run
+        have been written.  A run whose run_id has no completion-marker is
+        incomplete and invisible to readers.
+        """
         pass
 
     # -------------------------------------------------------------------------

--- a/src/dev_health_ops/metrics/sinks/clickhouse/investment.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/investment.py
@@ -34,6 +34,12 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Reserved run_id of the seeded legacy completion marker (migration 048). Its
+# membership rows carry run_id='' (migration 047 default), so retention maps the
+# '__legacy__' marker back to '' when deleting its rows. MUST match
+# api/graphql/resolvers/work_graph._LEGACY_RUN_ID.
+_LEGACY_RUN_ID = "__legacy__"
+
 
 class InvestmentMixin(_ClickHouseSinkBase):
     """Mixin for investment and work-unit classification write methods."""
@@ -193,6 +199,94 @@ class InvestmentMixin(_ClickHouseSinkBase):
             ["org_id", "run_id", "completed_at"],
             [record],
         )
+
+    def prune_membership_runs(self, org_id: str, *, keep: int = 2) -> int:
+        """Retain only the latest ``keep`` COMPLETE membership runs for an org.
+
+        CHAOS-2433 round-5 (unbounded growth): migration 049 put run_id in the
+        ReplacingMergeTree key so generations are intentionally NOT collapsed.
+        Without retention, every org-wide projection (daily beat + post-sync)
+        adds a full copy of the org's memberships forever — storage blowup and
+        the resolver's latest-run filter scanning ever-more historical rows.
+        This prunes old generations right after a new marker is published.
+
+        Mechanism: read the org's completion markers ordered by completed_at DESC;
+        KEEP the latest ``keep`` run_ids; DELETE — via lightweight
+        ``ALTER TABLE ... DELETE WHERE`` — the work_unit_membership rows AND the
+        work_unit_membership_runs markers for every OLDER run. Both deletes are
+        scoped to ``org_id`` and to the explicit set of dropped run_ids, so the
+        pass is idempotent and safe to run concurrently across orgs (each org
+        only touches its own run_ids).
+
+        KEEP-LATEST-2 RATIONALE: keep the current latest run PLUS one prior, so a
+        reader/overlap mid-flight against the immediately-previous complete run
+        (e.g. an argMax that resolved to it microseconds before a newer marker
+        landed) is not pulled out from under it. Keeping 1 would risk deleting the
+        run a concurrent reader is actively scanning.
+
+        IN-FLIGHT SAFETY: retention operates ONLY on run_ids that HAVE a
+        completion marker (the candidate set comes exclusively from
+        work_unit_membership_runs). A markerless in-flight run — rows written, no
+        marker yet, about to become the next generation — is never in the
+        delete set, so a concurrent retention pass can never delete its rows.
+
+        LEGACY: the seeded ``__legacy__`` marker is just another complete run; its
+        membership rows carry run_id='' (migration 047 default), so when the
+        legacy marker ages out we translate it to '' for the row delete. It ages
+        out naturally once ``keep`` real runs exist (rollout continuity done).
+
+        Returns the number of old run generations pruned (markers deleted).
+        """
+        # Candidate set is EXCLUSIVELY markered runs (in-flight runs have no
+        # marker and are therefore never eligible for deletion).
+        result = self.client.query(
+            """
+            SELECT run_id
+            FROM work_unit_membership_runs
+            WHERE org_id = {org_id:String}
+            ORDER BY completed_at DESC, run_id DESC
+            """,
+            parameters={"org_id": org_id},
+        )
+        run_ids = [str(row[0]) for row in (result.result_rows or [])]
+        # Dedup preserving order (ReplacingMergeTree may surface unmerged dupes;
+        # we read without FINAL so collapse the latest-per-run_id ourselves).
+        seen: set[str] = set()
+        ordered_unique: list[str] = []
+        for rid in run_ids:
+            if rid not in seen:
+                seen.add(rid)
+                ordered_unique.append(rid)
+
+        if len(ordered_unique) <= keep:
+            return 0
+
+        drop_marker_run_ids = ordered_unique[keep:]
+        # Membership rows for the legacy marker carry run_id='' (not '__legacy__').
+        drop_row_run_ids = [
+            "" if rid == _LEGACY_RUN_ID else rid for rid in drop_marker_run_ids
+        ]
+
+        # Lightweight DELETE scoped to org + the explicit dropped run_ids. Both
+        # statements are idempotent (a re-run finds those run_ids already gone)
+        # and org-scoped so concurrent per-org passes never collide.
+        self.client.command(
+            "ALTER TABLE work_unit_membership "
+            "DELETE WHERE org_id = {org_id:String} AND run_id IN {run_ids:Array(String)}",
+            parameters={"org_id": org_id, "run_ids": drop_row_run_ids},
+        )
+        self.client.command(
+            "ALTER TABLE work_unit_membership_runs "
+            "DELETE WHERE org_id = {org_id:String} AND run_id IN {run_ids:Array(String)}",
+            parameters={"org_id": org_id, "run_ids": drop_marker_run_ids},
+        )
+        logger.info(
+            "Pruned %d old membership run generation(s) for org=%s (kept latest %d)",
+            len(drop_marker_run_ids),
+            org_id,
+            keep,
+        )
+        return len(drop_marker_run_ids)
 
     def write_investment_explanation(self, record: InvestmentExplanationRecord) -> None:
         """Write or replace an investment explanation to the cache."""

--- a/src/dev_health_ops/metrics/sinks/clickhouse/investment.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/investment.py
@@ -21,6 +21,7 @@ from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
     WorkUnitMembershipRecord,
+    WorkUnitMembershipRunRecord,
 )
 
 if TYPE_CHECKING:
@@ -175,8 +176,22 @@ class InvestmentMixin(_ClickHouseSinkBase):
                 "is_dominant",
                 "categorization_status",
                 "computed_at",
+                "run_id",
             ],
             rows,
+        )
+
+    def write_membership_run(self, record: WorkUnitMembershipRunRecord) -> None:
+        """Write the completion-marker for a membership run (CHAOS-2433).
+
+        Must be called as the LAST step after all membership rows for the run
+        have been written.  Readers use the latest completed_at row here to
+        identify the current valid run_id.
+        """
+        self._insert_rows(
+            "work_unit_membership_runs",
+            ["org_id", "run_id", "completed_at"],
+            [record],
         )
 
     def write_investment_explanation(self, record: InvestmentExplanationRecord) -> None:

--- a/src/dev_health_ops/migrations/clickhouse/047_work_unit_membership_run_id.sql
+++ b/src/dev_health_ops/migrations/clickhouse/047_work_unit_membership_run_id.sql
@@ -1,0 +1,42 @@
+-- Migration 047: run_id / completion-marker protocol for work_unit_membership
+-- (CHAOS-2433)
+--
+-- PROTOCOL
+--   Every membership write (from the LLM materializer or the no-LLM backfill)
+--   stamps a single run_id on ALL membership rows of the run, then writes ONE
+--   row to work_unit_membership_runs as the LAST step.  A run that has rows in
+--   work_unit_membership but no matching row in work_unit_membership_runs is
+--   INCOMPLETE (in-flight or crashed) and is NEVER visible to readers.
+--
+-- READ-SIDE PROTOCOL (replaces per-node max(computed_at))
+--   Readers select the latest COMPLETE run for the org by querying
+--   work_unit_membership_runs with argMax(run_id, completed_at) scoped to
+--   org_id.  They then scope membership reads to rows whose run_id matches.
+--
+-- BENEFITS
+--   1. Concurrency race: a partial materializer write in-flight is invisible
+--      because its marker has not been written yet.
+--   2. Split/merge stale: nodes absent from the latest complete run are simply
+--      absent -- no stale rows are selected.
+--   3. Partial-write divergence: runs without a marker are never selected.
+--   4. Tombstones are unnecessary -- a churned/uncategorised node is absent
+--      from the new complete run rather than needing an explicit sentinel.
+--
+-- ADD run_id to work_unit_membership
+-- NOTE: The migration runner strips line comments and splits on semicolon before
+-- executing each statement, so each statement must end with a semicolon and
+-- comments must not contain semicolons (this is the known runner footgun)
+ALTER TABLE work_unit_membership ADD COLUMN IF NOT EXISTS run_id String DEFAULT '';
+
+-- CREATE the completion-marker table
+-- One row per (org_id, run_id).  ReplacingMergeTree(completed_at) so an
+-- idempotent re-write of the same run_id updates the completed_at stamp
+-- rather than creating a duplicate.  ORDER BY (org_id, run_id) ensures each
+-- org+run pair is a unique deduplicate key.  The ver column (completed_at)
+-- means the row with the greatest completed_at value wins during merges
+CREATE TABLE IF NOT EXISTS work_unit_membership_runs (
+    org_id       String,
+    run_id       String,
+    completed_at DateTime64(3, 'UTC')
+) ENGINE = ReplacingMergeTree(completed_at)
+ORDER BY (org_id, run_id)

--- a/src/dev_health_ops/migrations/clickhouse/048_seed_legacy_membership_run.py
+++ b/src/dev_health_ops/migrations/clickhouse/048_seed_legacy_membership_run.py
@@ -79,14 +79,20 @@ def upgrade(client):
     """Seed one __legacy__ marker per org that has pre-existing membership rows."""
     log.info("=== Migration 048: seed legacy membership completion marker ===")
 
-    # 047 must have created both tables; if either is missing the database is in
-    # an unexpected state and we fail closed rather than guess.
+    # 046 creates work_unit_membership and 047 creates work_unit_membership_runs,
+    # both EARLIER in this same migration pass. If either is genuinely absent
+    # there is simply nothing to seed (no pre-existing membership rows to make
+    # readable) — a fresh database is a clean no-op, not an error. Skip
+    # gracefully rather than fail closed so the migration is safe to run against
+    # any database state (and against a dry-run / mocked client).
     for table in ("work_unit_membership", "work_unit_membership_runs"):
         if not _table_exists(client, table):
-            raise RuntimeError(
-                f"048: required table '{table}' does not exist — migration 047 "
-                f"must run first"
+            log.info(
+                "  %s does not exist yet — nothing to seed, skipping (no "
+                "pre-existing membership to make readable)",
+                table,
             )
+            return
 
     # One marker per org that HAS membership rows, stamped with that org's
     # newest existing computed_at.  ReplacingMergeTree(completed_at) on

--- a/src/dev_health_ops/migrations/clickhouse/048_seed_legacy_membership_run.py
+++ b/src/dev_health_ops/migrations/clickhouse/048_seed_legacy_membership_run.py
@@ -1,0 +1,108 @@
+"""Migration 048: seed a LEGACY completion marker for pre-existing membership.
+
+CHAOS-2433 finding #3 (migration 047 orphans existing rows)
+-----------------------------------------------------------
+Migration 047 added ``run_id String DEFAULT ''`` to ``work_unit_membership`` and
+created ``work_unit_membership_runs`` (the completion-marker table).  The new
+read path scopes every membership query to the latest COMPLETE run, selected via
+``argMax(run_id, completed_at) FROM work_unit_membership_runs``.
+
+Immediately after 047 deploys, every PRE-EXISTING membership row carries the
+empty default ``run_id = ''`` and NO marker exists in ``work_unit_membership_runs``.
+The reader would therefore find no complete run and treat the org as having no
+membership at all — theme filters and annotations would break until the next
+real (org-wide) run published a marker.  On idle-sync orgs that could be hours
+or a full day (the daily backfill cadence).
+
+FIX (low-risk, no heavy live mutation)
+---------------------------------------
+We do NOT rewrite the (potentially millions of) existing rows.  Instead we seed
+ONE synthetic marker per distinct ``org_id`` that has membership rows, using the
+reserved run_id ``__legacy__`` and ``completed_at = max(computed_at)`` of that
+org's existing membership rows:
+
+    INSERT INTO work_unit_membership_runs (org_id, run_id, completed_at)
+    SELECT org_id, '__legacy__', max(computed_at)
+    FROM work_unit_membership
+    GROUP BY org_id
+
+The reader (resolvers/work_graph.py, ``_RUN_SCOPE_JOIN_ON``) recognises the
+reserved ``__legacy__`` run_id and, when it is the org's latest complete run,
+matches the pre-existing rows (``run_id = ''``) rather than rows literally tagged
+``__legacy__``.  So existing membership stays readable the instant 047+048 land.
+
+CONVERGENCE / RETIREMENT
+------------------------
+The legacy marker's ``completed_at`` is the max of HISTORICAL membership rows
+(wall-clock in the past).  Every real run publishes its marker with
+``completed_at = now()`` (strictly greater), so ``argMax`` selects the real run
+the moment one completes and the legacy marker stops being the latest — the
+legacy read path retires automatically with no cleanup.  We never delete the
+legacy marker (harmless once superseded; deleting it would only matter if an org
+later had ALL real markers removed, which does not happen).
+
+IDEMPOTENT
+----------
+``work_unit_membership_runs`` is a ``ReplacingMergeTree(completed_at)`` keyed on
+``(org_id, run_id)``.  Re-running this migration re-inserts the same
+``(org_id, '__legacy__')`` key with the same (or a not-greater) completed_at, so
+the dedup collapses it — no duplicate legacy markers.  We also guard: if an org
+already has a NON-legacy marker we still seed the legacy one (it is harmless and
+already superseded by argMax), keeping the migration a pure additive backfill.
+
+NOTE: loaded standalone by the migration runner
+(importlib.util.spec_from_file_location), so it must not import from sibling
+migration modules.
+"""
+
+import logging
+
+log = logging.getLogger(__name__)
+
+_LEGACY_RUN_ID = "__legacy__"
+
+
+def _table_exists(client, table: str) -> bool:
+    try:
+        res = client.query(
+            "SELECT count() FROM system.tables "
+            "WHERE database = currentDatabase() AND name = {name:String}",
+            parameters={"name": table},
+        )
+        rows = getattr(res, "result_rows", None) or []
+        return bool(rows and rows[0] and rows[0][0] > 0)
+    except Exception:
+        return False
+
+
+def upgrade(client):
+    """Seed one __legacy__ marker per org that has pre-existing membership rows."""
+    log.info("=== Migration 048: seed legacy membership completion marker ===")
+
+    # 047 must have created both tables; if either is missing the database is in
+    # an unexpected state and we fail closed rather than guess.
+    for table in ("work_unit_membership", "work_unit_membership_runs"):
+        if not _table_exists(client, table):
+            raise RuntimeError(
+                f"048: required table '{table}' does not exist — migration 047 "
+                f"must run first"
+            )
+
+    # One marker per org that HAS membership rows, stamped with that org's
+    # newest existing computed_at.  ReplacingMergeTree(completed_at) on
+    # (org_id, run_id) makes this idempotent.  Orgs with no membership rows
+    # produce no marker (genuine no-op, correctly stays "no membership").
+    client.command(
+        """
+        INSERT INTO work_unit_membership_runs (org_id, run_id, completed_at)
+        SELECT
+            org_id,
+            {legacy_run_id:String} AS run_id,
+            max(computed_at) AS completed_at
+        FROM work_unit_membership
+        GROUP BY org_id
+        """,
+        parameters={"legacy_run_id": _LEGACY_RUN_ID},
+    )
+
+    log.info("=== Migration 048: Complete (legacy markers seeded) ===")

--- a/src/dev_health_ops/migrations/clickhouse/048_seed_legacy_membership_run.py
+++ b/src/dev_health_ops/migrations/clickhouse/048_seed_legacy_membership_run.py
@@ -62,22 +62,44 @@ log = logging.getLogger(__name__)
 _LEGACY_RUN_ID = "__legacy__"
 
 
+def _count_gt_zero(result_rows) -> bool:
+    """True iff a SUCCESSFUL count() probe returned a positive integer.
+
+    STRICT: requires a real list/tuple of rows whose first cell is a genuine int
+    (bool excluded). Any other shape — a MagicMock ``result_rows``, a non-numeric
+    cell — is treated as ZERO/absent rather than raised on, since the probe call
+    itself succeeded (a query ERROR would have raised from client.query()). This
+    keeps fail-closed-on-DB-error while not crashing dry-run/mock callers.
+    """
+    if not isinstance(result_rows, list | tuple) or not result_rows:
+        return False
+    first = result_rows[0]
+    if not isinstance(first, list | tuple) or not first:
+        return False
+    count = first[0]
+    return isinstance(count, int) and not isinstance(count, bool) and count > 0
+
+
 def _table_exists(client, table: str) -> bool:
     """Return whether ``table`` exists — FAIL CLOSED (CHAOS-2433 round-6).
 
-    Let an unexpected system.tables probe error PROPAGATE so the migration RAISES
-    and is NOT recorded as applied (retryable), rather than being swallowed into a
-    silent "table absent" skip that marks the seed migration applied without
-    seeding. The table is treated as absent ONLY when a SUCCESSFUL probe returns
-    zero rows (the genuine fresh-DB / dry-run no-op path).
+    Let an unexpected system.tables probe ERROR (a DB/query exception) PROPAGATE so
+    the migration RAISES and is NOT recorded as applied (retryable), rather than
+    being swallowed into a silent "table absent" skip that marks the seed migration
+    applied without seeding. The table is treated as absent ONLY when a SUCCESSFUL
+    probe returns zero (the genuine fresh-DB / dry-run no-op path).
+
+    Interpretation is STRICT but exception-safe (see ``_count_gt_zero``): a
+    MagicMock client in a unit test returns a successful-but-uninterpretable shape
+    and is treated as absent, while a genuine query failure still raises from
+    client.query() and propagates.
     """
     res = client.query(
         "SELECT count() FROM system.tables "
         "WHERE database = currentDatabase() AND name = {name:String}",
         parameters={"name": table},
     )
-    rows = getattr(res, "result_rows", None) or []
-    return bool(rows and rows[0] and rows[0][0] > 0)
+    return _count_gt_zero(getattr(res, "result_rows", None))
 
 
 def upgrade(client):

--- a/src/dev_health_ops/migrations/clickhouse/048_seed_legacy_membership_run.py
+++ b/src/dev_health_ops/migrations/clickhouse/048_seed_legacy_membership_run.py
@@ -26,10 +26,14 @@ org's existing membership rows:
     FROM work_unit_membership
     GROUP BY org_id
 
-The reader (resolvers/work_graph.py, ``_RUN_SCOPE_JOIN_ON``) recognises the
-reserved ``__legacy__`` run_id and, when it is the org's latest complete run,
-matches the pre-existing rows (``run_id = ''``) rather than rows literally tagged
-``__legacy__``.  So existing membership stays readable the instant 047+048 land.
+The reader (resolvers/work_graph.py, ``_RUN_SCOPE_PREDICATE`` +
+``_LEGACY_NODE_MAX_JOIN``) recognises the reserved ``__legacy__`` run_id and, when
+it is the org's latest complete run, matches each node's LATEST pre-existing row
+(``run_id = ''`` AND ``computed_at`` == that node's max over its legacy rows) —
+the exact OLD per-node-max(computed_at) semantics, NOT a blanket ``run_id = ''``
+match (which would resurface stale rows from earlier re-materializations whose
+distinct category values survived the old non-run_id dedup key). So existing
+membership stays readable — and correct — the instant 047+048 land.
 
 CONVERGENCE / RETIREMENT
 ------------------------

--- a/src/dev_health_ops/migrations/clickhouse/048_seed_legacy_membership_run.py
+++ b/src/dev_health_ops/migrations/clickhouse/048_seed_legacy_membership_run.py
@@ -63,16 +63,21 @@ _LEGACY_RUN_ID = "__legacy__"
 
 
 def _table_exists(client, table: str) -> bool:
-    try:
-        res = client.query(
-            "SELECT count() FROM system.tables "
-            "WHERE database = currentDatabase() AND name = {name:String}",
-            parameters={"name": table},
-        )
-        rows = getattr(res, "result_rows", None) or []
-        return bool(rows and rows[0] and rows[0][0] > 0)
-    except Exception:
-        return False
+    """Return whether ``table`` exists — FAIL CLOSED (CHAOS-2433 round-6).
+
+    Let an unexpected system.tables probe error PROPAGATE so the migration RAISES
+    and is NOT recorded as applied (retryable), rather than being swallowed into a
+    silent "table absent" skip that marks the seed migration applied without
+    seeding. The table is treated as absent ONLY when a SUCCESSFUL probe returns
+    zero rows (the genuine fresh-DB / dry-run no-op path).
+    """
+    res = client.query(
+        "SELECT count() FROM system.tables "
+        "WHERE database = currentDatabase() AND name = {name:String}",
+        parameters={"name": table},
+    )
+    rows = getattr(res, "result_rows", None) or []
+    return bool(rows and rows[0] and rows[0][0] > 0)
 
 
 def upgrade(client):

--- a/src/dev_health_ops/migrations/clickhouse/049_work_unit_membership_run_id_dedup_key.py
+++ b/src/dev_health_ops/migrations/clickhouse/049_work_unit_membership_run_id_dedup_key.py
@@ -58,6 +58,14 @@ leftover shadow). Ops note: run during a quiet period / with sync workers paused
 writes that race the EXCHANGE are preserved (catch-up), version ties resolve
 arbitrarily.
 
+FAIL CLOSED (CHAOS-2433 round-6): a structural migration must never be recorded
+as applied without actually rebuilding the key. The existence probe and the
+sorting-key reads let unexpected ClickHouse errors PROPAGATE (so the migration
+RAISES and is NOT recorded as applied, and can be retried) instead of being
+swallowed into a silent "table absent" skip. The table is treated as absent ONLY
+when a SUCCESSFUL probe returns zero rows. A final post-rebuild check re-reads the
+LIVE main-table key and raises unless run_id is last, proving the rebuild landed.
+
 DEPLOY ORDERING (why the snapshot copy is lossless): 047 (add column), 048 (seed
 legacy marker) and 049 (this rebuild) all apply in the SAME migration pass
 (_apply_sql_migrations runs the whole pending set before the app serves traffic
@@ -113,16 +121,25 @@ def _replace_order_by(ddl: str, new_order_by: str) -> str:
 
 
 def _table_exists(client, table: str) -> bool:
-    try:
-        res = client.query(
-            "SELECT count() FROM system.tables "
-            "WHERE database = currentDatabase() AND name = {name:String}",
-            parameters={"name": table},
-        )
-        rows = getattr(res, "result_rows", None) or []
-        return bool(rows and rows[0] and rows[0][0] > 0)
-    except Exception:
-        return False
+    """Return whether ``table`` exists — FAIL CLOSED (CHAOS-2433 round-6).
+
+    A structural migration must NEVER be recorded as applied without actually
+    rebuilding the dedup key. The previous version caught ANY exception from the
+    system.tables probe and returned False ("table absent"), so a transient probe
+    failure or a restricted ClickHouse user made ``upgrade()`` return early and the
+    runner marked 049 applied — leaving work_unit_membership keyed WITHOUT run_id
+    while the app starts run-scoped reads/writes (reintroducing the round-2
+    background-merge eviction). We therefore let an unexpected probe error
+    PROPAGATE so the migration RAISES (not recorded as applied, retryable). The
+    table is treated as absent ONLY when a SUCCESSFUL existence check returns zero.
+    """
+    res = client.query(
+        "SELECT count() FROM system.tables "
+        "WHERE database = currentDatabase() AND name = {name:String}",
+        parameters={"name": table},
+    )
+    rows = getattr(res, "result_rows", None) or []
+    return bool(rows and rows[0] and rows[0][0] > 0)
 
 
 def _sorting_key(client, table: str) -> str:
@@ -252,5 +269,17 @@ def upgrade(client):
     # From here on the shadow is the OLD table; never drop it without the
     # catch-up. If this fails, the rerun skip path converges it.
     _catch_up_and_drop(client, _TABLE, _SHADOW)
+
+    # FAIL CLOSED (CHAOS-2433 round-6): prove the rebuild actually landed before
+    # letting the runner record 049 as applied. Re-read the LIVE main-table key
+    # and require run_id to be last; raise otherwise so the migration is NOT
+    # recorded as applied and can be retried. _run_id_last_in_order_by reads
+    # system.tables and propagates any probe failure (no swallowed exceptions).
+    if not _run_id_last_in_order_by(client, _TABLE):
+        raise RuntimeError(
+            f"{_TABLE}: post-rebuild verification failed — run_id is NOT last in "
+            f"the sorting key after EXCHANGE; refusing to mark migration applied "
+            f"(actual key: {_sorting_key(client, _TABLE)!r})"
+        )
 
     log.info("=== Migration 049: Complete ===")

--- a/src/dev_health_ops/migrations/clickhouse/049_work_unit_membership_run_id_dedup_key.py
+++ b/src/dev_health_ops/migrations/clickhouse/049_work_unit_membership_run_id_dedup_key.py
@@ -1,0 +1,256 @@
+"""Migration 049: add run_id to the work_unit_membership dedup key (CHAOS-2433).
+
+ROUND-2 REVIEW FINDING #1 (dedup key excludes run_id breaks the protocol)
+-------------------------------------------------------------------------
+Migration 046 created work_unit_membership as
+    ENGINE = ReplacingMergeTree(computed_at)
+    ORDER BY (org_id, node_type, node_id, category_kind, category)
+Migration 047 ADDED a run_id column but could NOT change the sort key
+(ClickHouse cannot ALTER an existing RMT ORDER BY), so run_id is a column but
+NOT part of the physical dedup key.
+
+ReplacingMergeTree collapses rows that share the full ORDER BY tuple, keeping
+the row with the greatest version column (computed_at). With run_id ABSENT from
+the key, a background merge (or OPTIMIZE FINAL) collapses two rows for the same
+(org, node, category_kind, category) that belong to DIFFERENT runs down to the
+single max-computed_at version. A newer INCOMPLETE run (rows written, marker
+not yet published) has a greater computed_at than the prior COMPLETE run, so the
+merge EVICTS the complete run's row. The resolver — which scopes to the prior
+COMPLETE run_id (the latest published marker) — then finds nothing for that
+node, silently breaking the concurrency / rollback safety the run protocol is
+supposed to guarantee.
+
+FIX: per-run rows MUST coexist physically, so run_id must be in the dedup key:
+    ORDER BY (org_id, node_type, node_id, category_kind, category, run_id)
+ReplacingMergeTree(computed_at) is kept; now it only dedups IDEMPOTENT re-writes
+of the SAME (node, category, run_id) — exactly the intended semantics — and
+never collapses across runs. Rows from a complete run and an in-flight run for
+the same node/category now survive merges side by side, distinguished by run_id.
+
+REBUILD PATTERN (shadow table + EXCHANGE TABLES, mirrors migration 042)
+-----------------------------------------------------------------------
+ClickHouse cannot ALTER an existing RMT sort key, so we rebuild:
+    1. SHOW CREATE TABLE to capture the full DDL (engine, version col, settings).
+    2. Rewrite: rename to work_unit_membership_new, append run_id to ORDER BY.
+    3. Verify via system.tables that the shadow's sorting key is EXACTLY the old
+       key + ", run_id" — abort (drop shadow) on any mismatch so a regex miss on
+       exotic DDL fails closed.
+    4. INSERT INTO _new SELECT * FROM work_unit_membership (snapshot copy; legacy
+       run_id='' rows are copied verbatim).
+    5. Verify distinct NEW-key tuple counts match between source and shadow (the
+       new key is a superset of the old, so no two source rows that differ on it
+       can merge — raw counts may differ as the copy collapses not-yet-merged
+       same-key duplicates, which is normal RMT semantics).
+    6. EXCHANGE TABLES (atomic swap).
+    7. CATCH-UP: INSERT INTO work_unit_membership SELECT * FROM _new — the shadow
+       now holds the OLD table incl. rows written between snapshot and swap.
+       Idempotent under RMT: already-copied rows dedup on the new key (newest
+       version wins), late rows survive. Then DROP the shadow.
+
+Crash convergence: a crash after EXCHANGE but before catch-up/DROP leaves the
+shadow holding the OLD table. The rerun's idempotency-skip path (new key already
+present) detects the leftover shadow and finishes the catch-up + DROP before
+skipping — no rows stranded, no shadow left behind. A crash BEFORE EXCHANGE
+leaves a disposable shadow the next run drops and recreates.
+
+Idempotent: if run_id is already last in the ORDER BY, skip (after converging any
+leftover shadow). Ops note: run during a quiet period / with sync workers paused;
+writes that race the EXCHANGE are preserved (catch-up), version ties resolve
+arbitrarily.
+
+DEPLOY ORDERING (why the snapshot copy is lossless): 047 (add column), 048 (seed
+legacy marker) and 049 (this rebuild) all apply in the SAME migration pass
+(_apply_sql_migrations runs the whole pending set before the app serves traffic
+or workers run). Pre-049 every existing row carries run_id='' (the 047 default),
+so all rows share one run_id and NO cross-run collapse is possible on the old
+key — the snapshot copy is lossless. The cross-run coexistence the new key
+protects only matters for runs written AFTER this migration, which is exactly
+when the new key is in force. Do NOT run a real materialize/backfill (which would
+write distinct non-empty run_ids) between 047 and 049 on the old key.
+
+NOTE: loaded standalone by the migration runner
+(importlib.util.spec_from_file_location), so it must not import from sibling
+migration modules — helpers are intentionally duplicated from 042.
+"""
+
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+_TABLE = "work_unit_membership"
+_SHADOW = "work_unit_membership_new"
+# The old sort key (migration 046) plus run_id appended.
+_NEW_ORDER_BY = "(org_id, node_type, node_id, category_kind, category, run_id)"
+
+# Regex: ORDER BY (col, col, ...) | ORDER BY tuple(col, ...) | ORDER BY col
+_ORDER_BY_RE = re.compile(r"ORDER BY\s+(?:tuple\([^)]+\)|\([^)]+\)|\S+)", re.IGNORECASE)
+
+
+def _table_name_re(table: str) -> re.Pattern:
+    return re.compile(
+        rf"(CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+        rf"(?:`?[\w\d_]+`?\.)?`?){re.escape(table)}(`?\s|`?\()",
+        re.IGNORECASE,
+    )
+
+
+def _replace_table_name(ddl: str, old_name: str, new_name: str) -> str:
+    pattern = _table_name_re(old_name)
+    result, count = pattern.subn(rf"\g<1>{new_name}\g<2>", ddl, count=1)
+    if count == 0:
+        raise ValueError(
+            f"Could not replace table name '{old_name}' in DDL: {ddl[:300]}..."
+        )
+    return result
+
+
+def _replace_order_by(ddl: str, new_order_by: str) -> str:
+    result, count = _ORDER_BY_RE.subn(f"ORDER BY {new_order_by}", ddl, count=1)
+    if count == 0:
+        raise ValueError(f"Could not find ORDER BY in DDL: {ddl[:300]}...")
+    return result
+
+
+def _table_exists(client, table: str) -> bool:
+    try:
+        res = client.query(
+            "SELECT count() FROM system.tables "
+            "WHERE database = currentDatabase() AND name = {name:String}",
+            parameters={"name": table},
+        )
+        rows = getattr(res, "result_rows", None) or []
+        return bool(rows and rows[0] and rows[0][0] > 0)
+    except Exception:
+        return False
+
+
+def _sorting_key(client, table: str) -> str:
+    res = client.query(
+        "SELECT sorting_key FROM system.tables "
+        "WHERE database = currentDatabase() AND name = {name:String}",
+        parameters={"name": table},
+    )
+    rows = getattr(res, "result_rows", None) or []
+    if not rows or not rows[0]:
+        raise RuntimeError(f"{table}: could not read sorting_key from system.tables")
+    return str(rows[0][0])
+
+
+def _normalize_sorting_key(key: str) -> str:
+    return re.sub(r"\s*,\s*", ", ", re.sub(r"\s+", " ", key.replace("`", ""))).strip(
+        " ()"
+    )
+
+
+def _key_columns(new_order_by: str) -> list[str]:
+    return [c.strip() for c in new_order_by.strip("() ").split(",") if c.strip()]
+
+
+def _distinct_key_count(client, table: str, key_columns: list[str]) -> int:
+    key_tuple = ", ".join(f"`{c}`" for c in key_columns)
+    res = client.query(f"SELECT uniqExact(({key_tuple})) FROM `{table}`")
+    rows = getattr(res, "result_rows", None) or []
+    return int(rows[0][0]) if rows and rows[0] else 0
+
+
+def _run_id_last_in_order_by(client, table: str) -> bool:
+    """True when run_id is already the LAST column of the table's sort key."""
+    cols = [
+        c.strip()
+        for c in _normalize_sorting_key(_sorting_key(client, table)).split(",")
+    ]
+    return bool(cols) and cols[-1] == "run_id"
+
+
+def _catch_up_and_drop(client, table: str, shadow: str) -> None:
+    log.info(f"  {table}: catch-up copy of post-snapshot writes from `{shadow}`")
+    client.command(f"INSERT INTO `{table}` SELECT * FROM `{shadow}`")
+    client.command(f"DROP TABLE `{shadow}`")
+
+
+def upgrade(client):
+    """Rebuild work_unit_membership with run_id appended to its dedup key."""
+    log.info("=== Migration 049: run_id in work_unit_membership dedup key ===")
+
+    if not _table_exists(client, _TABLE):
+        # Fresh database where 046 has not yet created the table: nothing to
+        # rebuild. (046 already creates the table; 047 adds run_id; a future base
+        # schema may inline the new key — either way an absent table is a no-op.)
+        log.info(f"  {_TABLE}: does not exist, skipping (nothing to rebuild)")
+        return
+
+    if _run_id_last_in_order_by(client, _TABLE):
+        # Convergence: a prior run may have crashed after EXCHANGE but before its
+        # catch-up/DROP. A leftover shadow then holds the OLD table — finish the
+        # catch-up before skipping so its post-snapshot writes are not lost.
+        if _table_exists(client, _SHADOW):
+            log.info(
+                f"  {_TABLE}: run_id already last in ORDER BY but leftover "
+                f"`{_SHADOW}` found — converging interrupted run"
+            )
+            _catch_up_and_drop(client, _TABLE, _SHADOW)
+        else:
+            log.info(f"  {_TABLE}: run_id already last in ORDER BY, skipping")
+        return
+
+    res = client.query(f"SHOW CREATE TABLE `{_TABLE}`")
+    ddl = res.result_rows[0][0]
+
+    new_ddl = _replace_table_name(ddl, _TABLE, _SHADOW)
+    new_ddl = _replace_order_by(new_ddl, _NEW_ORDER_BY)
+
+    log.info(f"  {_TABLE}: creating shadow table `{_SHADOW}`")
+    client.command(f"DROP TABLE IF EXISTS `{_SHADOW}`")
+    client.command(new_ddl)
+
+    # Everything before EXCHANGE is safely retryable: on any failure drop the
+    # (disposable, pre-swap) shadow and re-raise. After EXCHANGE the shadow holds
+    # real data and must NOT be dropped without a catch-up.
+    try:
+        # Fail closed on DDL-rewrite misses: verify the ACTUAL shadow sort key is
+        # exactly the old key + ", run_id" before copying any data.
+        old_key = _normalize_sorting_key(_sorting_key(client, _TABLE))
+        shadow_key = _normalize_sorting_key(_sorting_key(client, _SHADOW))
+        expected_key = f"{old_key}, run_id"
+        if shadow_key != expected_key:
+            raise RuntimeError(
+                f"{_TABLE}: shadow sorting key mismatch after DDL rewrite "
+                f"(expected {expected_key!r}, got {shadow_key!r}); aborting"
+            )
+
+        log.info(f"  {_TABLE}: copying data (legacy run_id='' rows included)")
+        client.command(f"INSERT INTO `{_SHADOW}` SELECT * FROM `{_TABLE}`")
+
+        # Verify no logical rows were lost before swapping. Raw row counts may
+        # legitimately differ (the copy can collapse not-yet-merged duplicate
+        # versions of the SAME new key — normal RMT semantics), so compare the
+        # distinct NEW-key tuple count, which must be identical: the new key is a
+        # superset of the old, so no two source rows that differ on it can merge.
+        key_columns = _key_columns(_NEW_ORDER_BY)
+        src_keys = _distinct_key_count(client, _TABLE, key_columns)
+        dst_keys = _distinct_key_count(client, _SHADOW, key_columns)
+        if dst_keys != src_keys:
+            raise RuntimeError(
+                f"{_TABLE}: shadow copy distinct-key mismatch "
+                f"(source={src_keys}, shadow={dst_keys}); aborting before swap"
+            )
+        log.info(
+            f"  {_TABLE}: distinct sorting-key tuples verified "
+            f"(source={src_keys}, shadow={dst_keys})"
+        )
+    except Exception:
+        try:
+            client.command(f"DROP TABLE IF EXISTS `{_SHADOW}`")
+        except Exception as cleanup_err:  # pragma: no cover - best effort
+            log.warning(f"  {_TABLE}: shadow table cleanup failed: {cleanup_err}")
+        raise
+
+    log.info(f"  {_TABLE}: atomic swap via EXCHANGE TABLES")
+    client.command(f"EXCHANGE TABLES `{_TABLE}` AND `{_SHADOW}`")
+
+    # From here on the shadow is the OLD table; never drop it without the
+    # catch-up. If this fails, the rerun skip path converges it.
+    _catch_up_and_drop(client, _TABLE, _SHADOW)
+
+    log.info("=== Migration 049: Complete ===")

--- a/src/dev_health_ops/migrations/clickhouse/049_work_unit_membership_run_id_dedup_key.py
+++ b/src/dev_health_ops/migrations/clickhouse/049_work_unit_membership_run_id_dedup_key.py
@@ -120,6 +120,24 @@ def _replace_order_by(ddl: str, new_order_by: str) -> str:
     return result
 
 
+def _count_gt_zero(result_rows) -> bool:
+    """True iff a SUCCESSFUL count() probe returned a positive integer.
+
+    STRICT: requires a real list/tuple of rows whose first cell is a genuine int
+    (bool excluded). Any other shape — a MagicMock ``result_rows``, a non-numeric
+    cell — is treated as ZERO/absent rather than raised on, since the probe call
+    itself succeeded (a query ERROR would have raised from client.query()). This
+    keeps fail-closed-on-DB-error while not crashing dry-run/mock callers.
+    """
+    if not isinstance(result_rows, list | tuple) or not result_rows:
+        return False
+    first = result_rows[0]
+    if not isinstance(first, list | tuple) or not first:
+        return False
+    count = first[0]
+    return isinstance(count, int) and not isinstance(count, bool) and count > 0
+
+
 def _table_exists(client, table: str) -> bool:
     """Return whether ``table`` exists — FAIL CLOSED (CHAOS-2433 round-6).
 
@@ -132,14 +150,22 @@ def _table_exists(client, table: str) -> bool:
     background-merge eviction). We therefore let an unexpected probe error
     PROPAGATE so the migration RAISES (not recorded as applied, retryable). The
     table is treated as absent ONLY when a SUCCESSFUL existence check returns zero.
+
+    Interpretation is STRICT but exception-safe: a real ClickHouse probe returns a
+    ``list``/``tuple`` of rows with an ``int`` count. A successful probe that
+    returns a non-list/uninterpretable shape (e.g. a MagicMock client in a unit
+    test that never reaches a real ClickHouse — its ``result_rows`` is a MagicMock,
+    not a list, and ``int(MagicMock())`` would deceptively yield 1) is treated as
+    absent, NOT raised on, since it is a successful response rather than a query
+    error. A genuine query failure still raises from client.query() and propagates
+    (fail-closed-on-DB-error preserved).
     """
     res = client.query(
         "SELECT count() FROM system.tables "
         "WHERE database = currentDatabase() AND name = {name:String}",
         parameters={"name": table},
     )
-    rows = getattr(res, "result_rows", None) or []
-    return bool(rows and rows[0] and rows[0][0] > 0)
+    return _count_gt_zero(getattr(res, "result_rows", None))
 
 
 def _sorting_key(client, table: str) -> str:

--- a/src/dev_health_ops/work_graph/investment/backfill.py
+++ b/src/dev_health_ops/work_graph/investment/backfill.py
@@ -310,6 +310,28 @@ def backfill_memberships(config: MembershipBackfillConfig) -> dict[str, int]:
                     completed_at=marker_completed_at,
                 )
             )
+            # RETENTION (CHAOS-2433 round-5 — unbounded growth): migration 049
+            # keeps run_id in the dedup key so old generations are NOT collapsed.
+            # Without pruning, every org-wide projection (daily beat + post-sync)
+            # adds a full copy of the org's memberships forever. Right after the
+            # new marker lands, prune to the latest 2 COMPLETE runs per org. This
+            # only ever deletes MARKERED runs (the candidate set comes from
+            # work_unit_membership_runs), so a markerless in-flight run is never
+            # touched. keep=2 leaves the current + one prior so an overlap reader
+            # against the immediately-previous complete run is not pulled out from
+            # under it.
+            try:
+                sink.prune_membership_runs(org_id, keep=2)
+            except Exception:
+                # Retention is best-effort: a prune failure must not fail the
+                # projection (the marker is already published and correct). The
+                # next run's prune is idempotent and will catch up.
+                logger.warning(
+                    "Membership run retention failed for org=%s (non-fatal); "
+                    "the next projection's prune will catch up",
+                    org_id,
+                    exc_info=True,
+                )
         else:
             logger.info(
                 "Membership backfill org=%s is repo-scoped (repos=%s) — wrote "

--- a/src/dev_health_ops/work_graph/investment/backfill.py
+++ b/src/dev_health_ops/work_graph/investment/backfill.py
@@ -1,0 +1,281 @@
+"""No-LLM membership backfill with run_id / completion-marker protocol (CHAOS-2439/2433).
+
+The daily scheduled job must NOT re-run LLM categorization (cost + category
+drift). Instead it cheaply PROJECTS ``work_unit_membership`` from the theme /
+subcategory distributions ALREADY persisted in ``work_unit_investments`` by the
+post-sync LLM materializer.
+
+Per org, with NO categorizer/LLM call:
+
+1. Rebuild the work-graph connected components from ``work_graph_edges`` (reuse
+   ``_build_components`` + ``work_unit_id`` so the unit hashing matches the
+   materializer exactly).
+2. Read the LATEST ``work_unit_investments`` row per ``work_unit_id`` (argMax on
+   ``computed_at``, the same latest-per-unit semantics as
+   ``api/queries/work_unit_investments.py``) for those unit ids to recover the
+   persisted ``theme_distribution_json`` / ``subcategory_distribution_json``.
+3. Generate a fresh ``run_id`` for this backfill run.
+4. Project membership rows via the SHARED ``build_membership_records`` helper, so
+   the rows are byte-for-byte identical (except run_id / computed_at) to what the
+   LLM materializer would emit for the same distributions.
+5. Write ALL membership rows first, THEN write one ``work_unit_membership_runs``
+   row (the completion marker) as the LAST step (CHAOS-2433 protocol).
+
+RUN_ID PROTOCOL (CHAOS-2433):
+  Every backfill run generates its own ``run_id`` (uuid hex). ALL membership rows
+  written in this run carry that run_id. The completion marker is written to
+  ``work_unit_membership_runs`` only AFTER all membership rows are persisted.
+  A run with membership rows but no marker is incomplete (in-flight or crashed)
+  and is INVISIBLE to readers. The resolver selects
+  ``argMax(run_id, completed_at) FROM work_unit_membership_runs WHERE org_id=?``
+  and scopes membership reads to that run_id.
+
+NO TOMBSTONES:
+  The run_id protocol makes tombstones unnecessary. A node absent from the latest
+  complete run simply has no membership rows in that run, and the resolver treats
+  it exactly as "no membership" (annotation null, not filterable). This is cleaner
+  than the tombstone sentinel and eliminates the is_dominant=0 sentinel edge case.
+
+"LATEST COMPLETE INVESTMENT RUN":
+  The backfill projects from the most recently persisted row per work_unit_id in
+  ``work_unit_investments`` (argMax on computed_at). If a work_unit_id has no row
+  (edges churned since last LLM run), that component is skipped — it contributes
+  no membership rows to this backfill run. Since the run_id protocol hides all
+  rows not in the latest complete run, churned nodes are automatically invisible
+  with no special tombstone action required.
+
+  DESIGN NOTE (for reviewers): we intentionally use argMax(computed_at) per
+  work_unit_id rather than gating on a separate "investments run completion
+  marker" table.  work_unit_investments is written atomically per component by
+  the materializer (one INSERT per batch), and its categorization_run_id is not
+  globally consistent across component batches (components are processed in
+  parallel).  The argMax per work_unit_id is the established semantics used by
+  the investment query API; projecting from that is consistent with what the
+  resolver already reads.  A future CHAOS ticket can add an investments run
+  marker if needed; for now, argMax is correct and sufficient.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from dev_health_ops.metrics.schemas import WorkUnitMembershipRunRecord
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+from dev_health_ops.metrics.sinks.factory import create_sink
+from dev_health_ops.work_graph.investment.membership import (
+    NodeKey,
+    build_membership_records,
+)
+from dev_health_ops.work_graph.investment.queries import fetch_work_graph_edges
+from dev_health_ops.work_graph.investment.utils import work_unit_id
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MembershipBackfillConfig:
+    dsn: str
+    org_id: str | None = None
+    repo_ids: list[str] | None = None
+
+
+def _build_components_for_backfill(
+    edges: list[dict[str, Any]],
+) -> list[list[NodeKey]]:
+    """Connected-component node lists from work_graph_edges.
+
+    Mirrors ``materialize._build_components`` (same union-find over
+    source/target endpoints) but returns only the per-component node lists — the
+    backfill does not need the component edges. Kept local to avoid importing the
+    heavy ``materialize`` module (and its LLM provider deps) into the worker.
+    """
+    adjacency: dict[NodeKey, list[NodeKey]] = {}
+    for edge in edges:
+        source = (str(edge.get("source_type")), str(edge.get("source_id")))
+        target = (str(edge.get("target_type")), str(edge.get("target_id")))
+        adjacency.setdefault(source, []).append(target)
+        adjacency.setdefault(target, []).append(source)
+
+    visited: set[NodeKey] = set()
+    components: list[list[NodeKey]] = []
+    for node in adjacency:
+        if node in visited:
+            continue
+        stack = [node]
+        visited.add(node)
+        component_nodes: list[NodeKey] = []
+        while stack:
+            current = stack.pop()
+            component_nodes.append(current)
+            for neighbor in adjacency.get(current, []):
+                if neighbor in visited:
+                    continue
+                visited.add(neighbor)
+                stack.append(neighbor)
+        components.append(component_nodes)
+    return components
+
+
+def _fetch_latest_distributions(
+    sink: BaseMetricsSink,
+    *,
+    work_unit_ids: list[str],
+    org_id: str,
+) -> dict[str, dict[str, Any]]:
+    """Return {work_unit_id -> {theme/ subcategory distribution + status}}.
+
+    Reads the LATEST row per ``work_unit_id`` (argMax on ``computed_at``), the
+    same latest-per-unit semantics as ``api/queries/work_unit_investments.py``.
+    Org-scoped. Returns only the unit ids that actually have a row.
+    """
+    if not work_unit_ids:
+        return {}
+    query = """
+        SELECT
+            work_unit_id,
+            argMax(theme_distribution_json, computed_at) AS theme_distribution_json,
+            argMax(subcategory_distribution_json, computed_at) AS subcategory_distribution_json,
+            argMax(categorization_status, computed_at) AS categorization_status
+        FROM work_unit_investments
+        WHERE org_id = %(org_id)s
+          AND work_unit_id IN %(work_unit_ids)s
+        GROUP BY org_id, work_unit_id
+    """
+    rows = sink.query_dicts(
+        query,
+        {"org_id": org_id, "work_unit_ids": work_unit_ids},
+    )
+    result: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        wid = str(row.get("work_unit_id") or "")
+        if wid:
+            result[wid] = row
+    return result
+
+
+def _as_distribution(value: Any) -> dict[str, float]:
+    """Coerce a ClickHouse Map(String, Float64) cell into a plain dict."""
+    if isinstance(value, dict):
+        return {str(k): float(v) for k, v in value.items()}
+    return {}
+
+
+def backfill_memberships(config: MembershipBackfillConfig) -> dict[str, int]:
+    """Project work_unit_membership from existing work_unit_investments (no LLM).
+
+    Uses the run_id / completion-marker protocol (CHAOS-2433): all membership
+    rows for this run are written first, then the completion marker is written
+    last.  Nodes in components with no persisted investment row are skipped —
+    they contribute no rows to this run and are therefore invisible to readers
+    (no tombstones needed).
+
+    Returns a stats dict: components seen, units matched (had a persisted
+    categorization), units skipped (churned component / never categorized), and
+    total membership rows written.
+    """
+    sink = create_sink(config.dsn)
+    org_id = config.org_id or ""
+    try:
+        sink.ensure_schema()
+
+        edges = fetch_work_graph_edges(sink, repo_ids=config.repo_ids, org_id=org_id)
+        components = _build_components_for_backfill(edges)
+        if not components:
+            logger.info(
+                "Membership backfill: no work graph components for org=%s", org_id
+            )
+            return {
+                "components": 0,
+                "matched": 0,
+                "skipped": 0,
+                "memberships": 0,
+            }
+
+        # Map each current work_unit_id -> its node list.
+        unit_nodes_by_id: dict[str, list[NodeKey]] = {}
+        for nodes in components:
+            unit_nodes = list(dict.fromkeys(nodes))
+            uid = work_unit_id(unit_nodes)
+            unit_nodes_by_id[uid] = unit_nodes
+
+        distributions = _fetch_latest_distributions(
+            sink,
+            work_unit_ids=list(unit_nodes_by_id.keys()),
+            org_id=org_id,
+        )
+
+        # A single run_id for the entire backfill run.  All rows carry this id;
+        # the completion marker is written last (CHAOS-2433 protocol).
+        backfill_run_id = uuid.uuid4().hex
+        computed_at = datetime.now(timezone.utc)
+        from dev_health_ops.metrics.schemas import (
+            WorkUnitMembershipRecord,  # noqa: F401
+        )
+
+        membership_records: list[WorkUnitMembershipRecord] = []
+        matched = 0
+        skipped = 0
+        for uid, unit_nodes in unit_nodes_by_id.items():
+            persisted = distributions.get(uid)
+            if persisted is None:
+                # No persisted investment row for this component (edges churned
+                # since last LLM run).  Skip — the run_id protocol makes these
+                # nodes invisible without tombstones: they have no rows in the
+                # new run, so readers won't see them once the new run completes.
+                skipped += 1
+                continue
+            matched += 1
+            membership_records.extend(
+                build_membership_records(
+                    unit_nodes=unit_nodes,
+                    work_unit_id=uid,
+                    theme_distribution=_as_distribution(
+                        persisted.get("theme_distribution_json")
+                    ),
+                    subcategory_distribution=_as_distribution(
+                        persisted.get("subcategory_distribution_json")
+                    ),
+                    categorization_status=str(
+                        persisted.get("categorization_status") or ""
+                    ),
+                    computed_at=computed_at,
+                    org_id=org_id,
+                    run_id=backfill_run_id,
+                )
+            )
+
+        # Write ALL membership rows first, THEN the completion marker.
+        # A run with membership rows but no marker is incomplete and invisible
+        # to readers.
+        if membership_records:
+            sink.write_work_unit_memberships(membership_records)
+            sink.write_membership_run(
+                WorkUnitMembershipRunRecord(
+                    org_id=org_id,
+                    run_id=backfill_run_id,
+                    completed_at=computed_at,
+                )
+            )
+
+        logger.info(
+            "Membership backfill org=%s: components=%d matched=%d skipped=%d "
+            "memberships=%d run_id=%s (no LLM)",
+            org_id,
+            len(components),
+            matched,
+            skipped,
+            len(membership_records),
+            backfill_run_id,
+        )
+        return {
+            "components": len(components),
+            "matched": matched,
+            "skipped": skipped,
+            "memberships": len(membership_records),
+        }
+    finally:
+        sink.close()

--- a/src/dev_health_ops/work_graph/investment/backfill.py
+++ b/src/dev_health_ops/work_graph/investment/backfill.py
@@ -19,7 +19,13 @@ Per org, with NO categorizer/LLM call:
    the rows are byte-for-byte identical (except run_id / computed_at) to what the
    LLM materializer would emit for the same distributions.
 5. Write ALL membership rows first, THEN write one ``work_unit_membership_runs``
-   row (the completion marker) as the LAST step (CHAOS-2433 protocol).
+   row (the completion marker) as the LAST step (CHAOS-2433 protocol).  The
+   marker is published whenever the org HAS work-graph components, even when the
+   run emits ZERO membership rows (all components churned) — an empty complete
+   run correctly retires the previous run's stale rows (no tombstones).  Only a
+   genuine no-component org publishes no marker.  A repo-SCOPED run never
+   publishes the org-wide marker (it would blank other repos for unscoped
+   reads); it relies on the org-wide daily run to publish.
 
 RUN_ID PROTOCOL (CHAOS-2433):
   Every backfill run generates its own ``run_id`` (uuid hex). ALL membership rows
@@ -81,6 +87,20 @@ class MembershipBackfillConfig:
     dsn: str
     org_id: str | None = None
     repo_ids: list[str] | None = None
+
+    @property
+    def is_org_wide(self) -> bool:
+        """True when this run covers the WHOLE org (no repo scoping).
+
+        Only an org-wide run may publish an org-wide completion marker
+        (CHAOS-2433 finding #2): a repo-scoped run that wrote a marker would
+        become the org's "latest complete run" while containing only that
+        scope's rows, blanking every other repo's membership for unscoped
+        reads.  A scoped run therefore writes its rows but NOT a marker,
+        relying on a subsequent org-wide run (the daily backfill is org-wide)
+        to publish.
+        """
+        return not self.repo_ids
 
 
 def _build_components_for_backfill(
@@ -253,12 +273,40 @@ def backfill_memberships(config: MembershipBackfillConfig) -> dict[str, int]:
         # to readers.
         if membership_records:
             sink.write_work_unit_memberships(membership_records)
+
+        # Publish the completion marker (CHAOS-2433).
+        #
+        # FINDING #1 (empty-but-complete run MUST supersede): we reached here
+        # only when the org HAS work-graph components (the `if not components`
+        # early-return above handles the genuine no-op org).  An ALL-SKIPPED
+        # run — every current component churned past its last categorization —
+        # legitimately has ZERO membership rows.  It MUST still publish a marker
+        # so it becomes the latest complete run and the stale rows from the
+        # PREVIOUS complete run stop matching (the no-tombstone design relies on
+        # an empty complete run to retire churned nodes).  We therefore write the
+        # marker whenever components were evaluated, even with zero rows.  Only a
+        # genuine no-component org (handled above) writes no marker.
+        #
+        # FINDING #2 (scoped runs must not publish an org-wide marker): a
+        # repo-scoped backfill writes its rows but does NOT publish the org-wide
+        # marker — otherwise it would become the org's latest complete run while
+        # covering only that scope, blanking other repos for unscoped reads.
+        if config.is_org_wide:
             sink.write_membership_run(
                 WorkUnitMembershipRunRecord(
                     org_id=org_id,
                     run_id=backfill_run_id,
                     completed_at=computed_at,
                 )
+            )
+        else:
+            logger.info(
+                "Membership backfill org=%s is repo-scoped (repos=%s) — wrote "
+                "%d rows but NOT publishing an org-wide completion marker "
+                "(CHAOS-2433); the org-wide daily backfill publishes",
+                org_id,
+                config.repo_ids,
+                len(membership_records),
             )
 
         logger.info(

--- a/src/dev_health_ops/work_graph/investment/backfill.py
+++ b/src/dev_health_ops/work_graph/investment/backfill.py
@@ -291,12 +291,23 @@ def backfill_memberships(config: MembershipBackfillConfig) -> dict[str, int]:
         # repo-scoped backfill writes its rows but does NOT publish the org-wide
         # marker — otherwise it would become the org's latest complete run while
         # covering only that scope, blanking other repos for unscoped reads.
+        #
+        # ROUND-3 FINDING #1 (marker completed_at = COMPLETION time, not start):
+        # the marker's completed_at must reflect when the run FINISHED publishing
+        # (after all rows are persisted), NOT the run-start ``computed_at``.
+        # Readers pick argMax(run_id, completed_at); if two runs overlap, the one
+        # that FINISHES last must win.  Stamping the run-start time would let a
+        # run that started earlier but finished later publish an OLDER completed_at
+        # and lose to a run that finished first — the exact concurrency race the
+        # protocol must prevent.  The membership ROWS keep their run ``computed_at``;
+        # only the MARKER carries this completion timestamp.
+        marker_completed_at = datetime.now(timezone.utc)
         if config.is_org_wide:
             sink.write_membership_run(
                 WorkUnitMembershipRunRecord(
                     org_id=org_id,
                     run_id=backfill_run_id,
-                    completed_at=computed_at,
+                    completed_at=marker_completed_at,
                 )
             )
         else:

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -16,6 +16,7 @@ from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
     WorkUnitMembershipRecord,
+    WorkUnitMembershipRunRecord,
 )
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 from dev_health_ops.metrics.sinks.factory import create_sink
@@ -645,6 +646,8 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
             # work_unit_investments (CHAOS-2429/2430). Multi-membership: one row
             # per (node, category) for each theme and subcategory at/above the
             # weight threshold, plus the argmax of each kind (is_dominant=1).
+            # run_id is stamped on every row so readers can scope to the latest
+            # COMPLETE run via work_unit_membership_runs (CHAOS-2433).
             theme_categories = _membership_categories(theme_distribution)
             subcategory_categories = _membership_categories(outcome.subcategories)
             for node_type, node_id in unit_nodes:
@@ -661,6 +664,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
                             is_dominant=is_dominant,
                             categorization_status=outcome.status,
                             computed_at=computed_at,
+                            run_id=run_id,
                         )
                     )
                 for category, weight, is_dominant in subcategory_categories:
@@ -676,6 +680,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
                             is_dominant=is_dominant,
                             categorization_status=outcome.status,
                             computed_at=computed_at,
+                            run_id=run_id,
                         )
                     )
 
@@ -699,7 +704,17 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
         if quote_records:
             sink.write_work_unit_investment_quotes(quote_records)
         if membership_records:
+            # Write ALL membership rows first, THEN the completion marker.
+            # A run with membership rows but no marker is incomplete (in-flight)
+            # and is invisible to readers until the marker is written (CHAOS-2433).
             sink.write_work_unit_memberships(membership_records)
+            sink.write_membership_run(
+                WorkUnitMembershipRunRecord(
+                    org_id=config.org_id or "",
+                    run_id=run_id,
+                    completed_at=computed_at,
+                )
+            )
         logger.info("Sink write complete")
 
         return {

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -708,12 +708,43 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
             # A run with membership rows but no marker is incomplete (in-flight)
             # and is invisible to readers until the marker is written (CHAOS-2433).
             sink.write_work_unit_memberships(membership_records)
+
+        # Publish the completion marker (CHAOS-2433).  Reaching here means the
+        # org HAS work-graph components (the `if not components` early-return
+        # above handles the genuine no-op org).
+        #
+        # FINDING #1 (empty-but-complete run MUST supersede): a run that produced
+        # zero membership rows (every component fell outside the time window or
+        # had no distribution) still publishes a marker so it becomes the latest
+        # complete run and retires the previous run's stale rows — the
+        # no-tombstone design relies on an empty complete run to drop churned
+        # nodes.
+        #
+        # FINDING #2 (scoped runs must not publish an org-wide marker): a run
+        # scoped to specific repos/teams writes its rows but does NOT publish the
+        # org-wide marker — otherwise it would become the org's latest complete
+        # run while covering only that scope, blanking every other repo's
+        # membership for unscoped reads.  The org-wide post-sync / daily run
+        # publishes.  (The post-sync dispatcher is org-wide, so the normal path
+        # always publishes; only manual/CLI repo_ids/team_ids runs skip.)
+        is_org_wide = not config.repo_ids and not config.team_ids
+        if is_org_wide:
             sink.write_membership_run(
                 WorkUnitMembershipRunRecord(
                     org_id=config.org_id or "",
                     run_id=run_id,
                     completed_at=computed_at,
                 )
+            )
+        else:
+            logger.info(
+                "Investment materialize org=%s is scoped (repos=%s teams=%s) — "
+                "wrote %d membership rows but NOT publishing an org-wide "
+                "completion marker (CHAOS-2433); an org-wide run publishes",
+                config.org_id or "",
+                config.repo_ids,
+                config.team_ids,
+                len(membership_records),
             )
         logger.info("Sink write complete")
 

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -15,8 +15,6 @@ from dev_health_ops.llm import get_provider
 from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
-    WorkUnitMembershipRecord,
-    WorkUnitMembershipRunRecord,
 )
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 from dev_health_ops.metrics.sinks.factory import create_sink
@@ -440,7 +438,6 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
 
         records: list[WorkUnitInvestmentRecord] = []
         quote_records: list[WorkUnitInvestmentEvidenceQuoteRecord] = []
-        membership_records: list[WorkUnitMembershipRecord] = []
         run_id = uuid.uuid4().hex
         computed_at = datetime.now(timezone.utc)
         model_version = config.llm_model or config.llm_provider
@@ -641,48 +638,21 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
                 )
             )
 
-            # Emit membership rows so the work graph resolver can join
-            # theme/subcategory onto edges in O(nodes) without scanning
-            # work_unit_investments (CHAOS-2429/2430). Multi-membership: one row
-            # per (node, category) for each theme and subcategory at/above the
-            # weight threshold, plus the argmax of each kind (is_dominant=1).
-            # run_id is stamped on every row so readers can scope to the latest
-            # COMPLETE run via work_unit_membership_runs (CHAOS-2433).
-            theme_categories = _membership_categories(theme_distribution)
-            subcategory_categories = _membership_categories(outcome.subcategories)
-            for node_type, node_id in unit_nodes:
-                for category, weight, is_dominant in theme_categories:
-                    membership_records.append(
-                        WorkUnitMembershipRecord(
-                            org_id=config.org_id or "",
-                            node_type=node_type,
-                            node_id=node_id,
-                            work_unit_id=unit_id,
-                            category_kind="theme",
-                            category=category,
-                            weight=weight,
-                            is_dominant=is_dominant,
-                            categorization_status=outcome.status,
-                            computed_at=computed_at,
-                            run_id=run_id,
-                        )
-                    )
-                for category, weight, is_dominant in subcategory_categories:
-                    membership_records.append(
-                        WorkUnitMembershipRecord(
-                            org_id=config.org_id or "",
-                            node_type=node_type,
-                            node_id=node_id,
-                            work_unit_id=unit_id,
-                            category_kind="subcategory",
-                            category=category,
-                            weight=weight,
-                            is_dominant=is_dominant,
-                            categorization_status=outcome.status,
-                            computed_at=computed_at,
-                            run_id=run_id,
-                        )
-                    )
+            # NOTE (CHAOS-2433 round-3 finding #2): the materializer NO LONGER
+            # writes work_unit_membership rows or completion markers.  It only
+            # categorizes and persists work_unit_investments here.  Membership is
+            # written EXCLUSIVELY by the no-LLM projection (backfill.py), which
+            # iterates the FULL current work graph (not this run's time window)
+            # and so publishes a legitimately FULL-COVERAGE org-wide marker.
+            #
+            # This unification fixes the partial-coverage blanking bug: a
+            # date-windowed materialize only processes in-window components, so an
+            # org-wide marker from it would blank current components OUTSIDE the
+            # window.  By making the full-coverage projection the SOLE membership
+            # writer, the windowed materializer can never publish partial coverage.
+            # The post-sync chain (build -> materialize -> project-membership)
+            # runs the projection right after materialize persists the new
+            # investments, so membership stays fresh.
 
             if config.persist_evidence_snippets and outcome.evidence_quotes:
                 for quote in outcome.evidence_quotes:
@@ -703,56 +673,19 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
             sink.write_work_unit_investments(records)
         if quote_records:
             sink.write_work_unit_investment_quotes(quote_records)
-        if membership_records:
-            # Write ALL membership rows first, THEN the completion marker.
-            # A run with membership rows but no marker is incomplete (in-flight)
-            # and is invisible to readers until the marker is written (CHAOS-2433).
-            sink.write_work_unit_memberships(membership_records)
-
-        # Publish the completion marker (CHAOS-2433).  Reaching here means the
-        # org HAS work-graph components (the `if not components` early-return
-        # above handles the genuine no-op org).
-        #
-        # FINDING #1 (empty-but-complete run MUST supersede): a run that produced
-        # zero membership rows (every component fell outside the time window or
-        # had no distribution) still publishes a marker so it becomes the latest
-        # complete run and retires the previous run's stale rows — the
-        # no-tombstone design relies on an empty complete run to drop churned
-        # nodes.
-        #
-        # FINDING #2 (scoped runs must not publish an org-wide marker): a run
-        # scoped to specific repos/teams writes its rows but does NOT publish the
-        # org-wide marker — otherwise it would become the org's latest complete
-        # run while covering only that scope, blanking every other repo's
-        # membership for unscoped reads.  The org-wide post-sync / daily run
-        # publishes.  (The post-sync dispatcher is org-wide, so the normal path
-        # always publishes; only manual/CLI repo_ids/team_ids runs skip.)
-        is_org_wide = not config.repo_ids and not config.team_ids
-        if is_org_wide:
-            sink.write_membership_run(
-                WorkUnitMembershipRunRecord(
-                    org_id=config.org_id or "",
-                    run_id=run_id,
-                    completed_at=computed_at,
-                )
-            )
-        else:
-            logger.info(
-                "Investment materialize org=%s is scoped (repos=%s teams=%s) — "
-                "wrote %d membership rows but NOT publishing an org-wide "
-                "completion marker (CHAOS-2433); an org-wide run publishes",
-                config.org_id or "",
-                config.repo_ids,
-                config.team_ids,
-                len(membership_records),
-            )
+        # CHAOS-2433 round-3 finding #2: membership rows + completion markers are
+        # written EXCLUSIVELY by the no-LLM projection (backfill.py).  The
+        # materializer persists work_unit_investments only.  The post-sync chain
+        # runs the projection (build -> materialize -> project-membership) right
+        # after this, so membership is refreshed from the new investments with
+        # FULL current-component coverage (never the partial coverage a windowed
+        # materialize would produce).
         logger.info("Sink write complete")
 
         return {
             "components": len(components),
             "records": len(records),
             "quotes": len(quote_records),
-            "memberships": len(membership_records),
         }
     finally:
         sink.close()

--- a/src/dev_health_ops/work_graph/investment/membership.py
+++ b/src/dev_health_ops/work_graph/investment/membership.py
@@ -1,0 +1,136 @@
+"""Shared work_unit_membership projection (CHAOS-2429/2430/2433/2439).
+
+This module holds the SINGLE source of truth for turning a work unit's theme /
+subcategory distributions into ``work_unit_membership`` rows, so the post-sync
+LLM materializer (``materialize.py``) and the daily no-LLM backfill
+(``backfill.py``) emit byte-for-byte identical rows for the same persisted
+distributions. The projection is pure: it never calls the categorizer / LLM.
+
+The ``run_id`` field (CHAOS-2433) must be stamped on every row; callers supply
+it so this module stays pure.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+
+from dev_health_ops.metrics.schemas import WorkUnitMembershipRecord
+from dev_health_ops.work_graph.investment.constants import MEMBERSHIP_WEIGHT_THRESHOLD
+
+NodeKey = tuple[str, str]
+
+
+def _float_value(value: object) -> float:
+    """Best-effort float coercion (bools are not numbers here)."""
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
+def lexical_argmax(distribution: dict[str, float]) -> str:
+    """Return the key with the highest value; break ties lexically (smallest wins).
+
+    An empty distribution returns "unknown". The lexical tie-break makes the
+    dominant choice deterministic across runs regardless of dict ordering.
+    """
+    if not distribution:
+        return "unknown"
+    return min(distribution, key=lambda k: (-_float_value(distribution[k]), k))
+
+
+def membership_categories(
+    distribution: dict[str, float],
+) -> list[tuple[str, float, int]]:
+    """Return (category, weight, is_dominant) rows to emit for one distribution.
+
+    Multi-membership: every category with weight >= MEMBERSHIP_WEIGHT_THRESHOLD
+    is emitted, so a mixed unit is findable under each significant category. The
+    argmax category (lexical tie-break) is ALWAYS included even when below the
+    threshold and is flagged ``is_dominant=1``, so every node is findable under
+    at least its dominant category. Returns at least one row whenever the
+    distribution is non-empty.
+    """
+    if not distribution:
+        return []
+    dominant = lexical_argmax(distribution)
+    out: list[tuple[str, float, int]] = []
+    seen: set[str] = set()
+    for category, raw_weight in distribution.items():
+        weight = _float_value(raw_weight)
+        is_dominant = 1 if category == dominant else 0
+        if weight >= MEMBERSHIP_WEIGHT_THRESHOLD or is_dominant:
+            out.append((category, weight, is_dominant))
+            seen.add(category)
+    # Defensive: ensure the dominant row is present even if it was filtered.
+    if dominant not in seen:
+        out.append((dominant, _float_value(distribution.get(dominant, 0.0)), 1))
+    return out
+
+
+def build_membership_records(
+    *,
+    unit_nodes: Iterable[NodeKey],
+    work_unit_id: str,
+    theme_distribution: dict[str, float],
+    subcategory_distribution: dict[str, float],
+    categorization_status: str,
+    computed_at: datetime,
+    org_id: str,
+    run_id: str,
+) -> list[WorkUnitMembershipRecord]:
+    """Project one work unit's distributions into ``work_unit_membership`` rows.
+
+    Emits one row per (node, category) for the theme distribution and one per
+    (node, category) for the subcategory distribution, using
+    ``membership_categories`` for the threshold + is_dominant logic. This is the
+    shared seam used by BOTH the LLM materializer and the no-LLM backfill, so the
+    two paths produce identical rows for identical persisted distributions.
+
+    ``run_id`` (CHAOS-2433) is stamped on every row.  Readers use the latest
+    complete run_id from ``work_unit_membership_runs`` to scope their queries.
+    """
+    theme_cats = membership_categories(theme_distribution)
+    subcategory_cats = membership_categories(subcategory_distribution)
+    records: list[WorkUnitMembershipRecord] = []
+    for node_type, node_id in unit_nodes:
+        for category, weight, is_dominant in theme_cats:
+            records.append(
+                WorkUnitMembershipRecord(
+                    org_id=org_id,
+                    node_type=node_type,
+                    node_id=node_id,
+                    work_unit_id=work_unit_id,
+                    category_kind="theme",
+                    category=category,
+                    weight=weight,
+                    is_dominant=is_dominant,
+                    categorization_status=categorization_status,
+                    computed_at=computed_at,
+                    run_id=run_id,
+                )
+            )
+        for category, weight, is_dominant in subcategory_cats:
+            records.append(
+                WorkUnitMembershipRecord(
+                    org_id=org_id,
+                    node_type=node_type,
+                    node_id=node_id,
+                    work_unit_id=work_unit_id,
+                    category_kind="subcategory",
+                    category=category,
+                    weight=weight,
+                    is_dominant=is_dominant,
+                    categorization_status=categorization_status,
+                    computed_at=computed_at,
+                    run_id=run_id,
+                )
+            )
+    return records

--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -219,6 +219,26 @@ def run_investment_materialization(ns: argparse.Namespace) -> int:
         org_id=org_id,
     )
 
+    # CHAOS-2433 round-4 finding #1: the materializer writes work_unit_investments
+    # ONLY — membership rows + the completion marker are published EXCLUSIVELY by
+    # the no-LLM full-coverage projection (the post-sync Celery chain runs it as a
+    # 3rd step). This operator CLI entry point must do the same, or
+    # `dev-hops investment materialize` would persist new investments WITHOUT
+    # publishing a membership run/marker and GraphQL theme filters would keep
+    # reading the stale/previous marker (or none). We therefore run the projection
+    # synchronously after a successful materialization (a direct call, not a
+    # Celery dispatch, so the CLI is complete on return).
+    #
+    # COVERAGE RULE (finding #2, unchanged): only an ORG-WIDE FULL-COVERAGE run may
+    # publish the org-wide marker. A repo/team-SCOPED OR date-WINDOWED manual
+    # materialize must NOT publish an org marker (it would blank out-of-scope /
+    # out-of-window components under the new latest marker). We detect a
+    # date-windowed run by whether the operator explicitly bounded the window via
+    # --from/--to/--window-days. Such scoped/windowed runs refresh investments
+    # only; the org-wide daily projection republishes the full-coverage marker.
+    explicitly_windowed = bool(ns.from_date or ns.to_date or ns.window_days)
+    is_full_org_wide = not repo_ids and not team_ids and not explicitly_windowed
+
     logging.info(f"Materializing investments from {config.from_ts} to {config.to_ts}")
     try:
         stats = asyncio.run(materialize_investments(config))
@@ -228,10 +248,47 @@ def run_investment_materialization(ns: argparse.Namespace) -> int:
             stats.get("records", 0),
             stats.get("quotes", 0),
         )
-        return 0
     except Exception as e:
         logging.error(f"Investment materialization failed: {e}")
         return 1
+
+    if is_full_org_wide:
+        # Publish a fresh full-coverage membership run + marker so theme filters
+        # read the new investments. The projection is no-LLM and synchronous.
+        from dev_health_ops.work_graph.investment.backfill import (
+            MembershipBackfillConfig,
+            backfill_memberships,
+        )
+
+        logging.info(
+            "Projecting work_unit_membership (no-LLM) to publish a full-coverage "
+            "completion marker after org-wide materialization"
+        )
+        try:
+            mstats = backfill_memberships(
+                MembershipBackfillConfig(dsn=ns.db, org_id=org_id, repo_ids=None)
+            )
+            logging.info(
+                "Membership projection complete. Components=%d Matched=%d "
+                "Memberships=%d",
+                mstats.get("components", 0),
+                mstats.get("matched", 0),
+                mstats.get("memberships", 0),
+            )
+        except Exception as e:
+            logging.error(f"Membership projection failed: {e}")
+            return 1
+    else:
+        logging.info(
+            "Scoped/windowed materialization (repos=%s teams=%s windowed=%s) — "
+            "NOT publishing an org-wide membership marker; the org-wide daily "
+            "projection republishes full coverage (CHAOS-2433).",
+            repo_ids or None,
+            team_ids or None,
+            explicitly_windowed,
+        )
+
+    return 0
 
 
 async def materialize_fixture_investments(
@@ -346,8 +403,11 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
     investment_materialize.add_argument(
         "--window-days",
         type=int,
-        default=30,
-        help="Window size in days when --from is not set (default: 30).",
+        default=None,
+        help="Window size in days when --from is not set (default: 30). "
+        "Passing this (or --from/--to) marks the run as date-windowed, so it "
+        "refreshes investments only and does NOT publish an org-wide membership "
+        "marker (CHAOS-2433 coverage rule).",
     )
     investment_materialize.add_argument(
         "--repo-id",

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -148,6 +148,19 @@ beat_schedule = {
         # `default` floods (that is precisely when it is needed).
         "options": {"queue": "monitoring"},
     },
+    # Daily safety net for work_unit_membership (CHAOS-2439/2433). The primary
+    # trigger is event-driven: post-sync build -> LLM materialize chain. This
+    # beat entry fans out a cheap no-LLM backfill (build -> project membership)
+    # per active org once per day so idle orgs and the post-deploy window are
+    # always covered. The backfill uses the run_id / completion-marker protocol
+    # (CHAOS-2433), so it coexists safely with the event-driven materializer.
+    # Scheduled at 03:30 UTC, after daily metrics (01:00) and recommendations
+    # (02:00), to avoid competing with the heaviest nightly jobs.
+    "run-membership-backfill-daily": {
+        "task": "dev_health_ops.workers.tasks.dispatch_membership_backfill",
+        "schedule": crontab(hour=3, minute=30),
+        "options": {"queue": "default"},
+    },
 }
 
 # Result settings

--- a/src/dev_health_ops/workers/recommendations_tasks.py
+++ b/src/dev_health_ops/workers/recommendations_tasks.py
@@ -82,12 +82,17 @@ def _daily_metrics_ready(org_id: str, day: Any) -> bool:
         return True
 
 
-def _discover_active_org_ids() -> list[str]:
+def _discover_active_org_ids(strict: bool = False) -> list[str]:
     """Return the IDs of all active organisations (Postgres source of truth).
 
     Mirrors how ``dispatch_scheduled_metrics`` scopes work to live orgs. Falls
     back to ``["default"]`` (single-tenant / community installs) when the
     organizations table is empty or unavailable.
+
+    When ``strict=True``, a Postgres enumeration failure RAISES instead of
+    collapsing to the ``["default"]`` fallback, so a once-daily job retries on
+    a DB outage rather than silently dispatching zero orgs as a clean success
+    (CHAOS-2439).
     """
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.models.users import Organization
@@ -101,6 +106,8 @@ def _discover_active_org_ids() -> list[str]:
             )
         org_ids = [str(row[0]) for row in rows]
     except Exception:
+        if strict:
+            raise
         logger.exception("Failed to enumerate active organizations")
         org_ids = []
 

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -342,8 +342,19 @@ def _dispatch_post_sync_tasks(
         # publish order, not completion order: with multiple metrics workers
         # materialization could race ahead of the build and read a stale/empty
         # graph (CHAOS-2374). Chain them so materialize only starts after the
-        # build *succeeds*. The link is immutable (.si()) so the build's return
-        # value is not injected as a positional arg into materialize.
+        # build *succeeds*. The links are immutable (.si()) so a parent's return
+        # value is not injected as a positional arg into the next step.
+        #
+        # CHAOS-2433 round-3 finding #2 — UNIFIED MEMBERSHIP WRITER:
+        # build -> materialize (LLM; writes work_unit_investments ONLY) ->
+        # project-membership (no-LLM; writes work_unit_membership + the
+        # completion marker with FULL current-component coverage).  The
+        # materializer no longer writes membership/markers, so a date-windowed
+        # materialize can never publish partial-coverage that would blank
+        # out-of-window components.  The projection iterates the whole current
+        # work graph and reads the investments materialize just persisted, so
+        # membership stays fresh AND full-coverage.  run_membership_backfill is
+        # the projection task (no-LLM, org-wide, full coverage).
         build_sig = celery_app.signature(
             "dev_health_ops.workers.tasks.run_work_graph_build",
             kwargs={"org_id": org_id},
@@ -355,9 +366,16 @@ def _dispatch_post_sync_tasks(
             queue="metrics",
             immutable=True,
         )
-        chain(build_sig, materialize_sig).apply_async()
+        project_membership_sig = celery_app.signature(
+            "dev_health_ops.workers.tasks.run_membership_backfill",
+            kwargs={"org_id": org_id},
+            queue="metrics",
+            immutable=True,
+        )
+        chain(build_sig, materialize_sig, project_membership_sig).apply_async()
         dispatched.append("run_work_graph_build")
         dispatched.append("run_investment_materialize")
+        dispatched.append("run_membership_backfill")
 
     if has_git or has_dora:
         # CHAOS-2382: DORA is provider-agnostic — computed from synced

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -50,7 +50,9 @@ from dev_health_ops.workers.task_utils import (
     _resolve_env_credentials,
 )
 from dev_health_ops.workers.work_graph_tasks import (
+    dispatch_membership_backfill,
     run_investment_materialize,
+    run_membership_backfill,
     run_work_graph_build,
 )
 
@@ -76,6 +78,7 @@ __all__ = [
     "phone_home_heartbeat",
     "process_webhook_event",
     "reconcile_team_members",
+    "dispatch_membership_backfill",
     "run_backfill",
     "run_capacity_forecast_job",
     "run_complexity_job",
@@ -85,6 +88,7 @@ __all__ = [
     "run_dora_metrics",
     "run_ingest_consumer",
     "run_investment_materialize",
+    "run_membership_backfill",
     "run_product_telemetry_consumer",
     "run_recommendations_job",
     "run_release_impact_job",

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -197,16 +197,27 @@ def run_membership_backfill(
 ) -> dict:
     """Project work_unit_membership from EXISTING work_unit_investments — NO LLM.
 
-    The cheap daily counterpart to ``run_investment_materialize``: instead of
-    re-running LLM categorization (cost + category drift), it rebuilds the
-    work-graph components and re-emits ``work_unit_membership`` rows from the
-    theme/subcategory distributions ALREADY persisted by the post-sync LLM
-    materializer. Uses the run_id / completion-marker protocol (CHAOS-2433): all
-    membership rows are written first, then the completion marker is written last.
-    Units whose current component hash has no persisted categorization (churned
-    components) are skipped; the run_id protocol makes those nodes invisible
-    without tombstones. See ``work_graph.investment.backfill`` for the full
-    contract (CHAOS-2439/2433).
+    The SOLE writer of ``work_unit_membership`` rows AND the completion marker
+    (CHAOS-2433 round-3 finding #2). Instead of re-running LLM categorization
+    (cost + category drift), it rebuilds the work-graph components and re-emits
+    ``work_unit_membership`` rows from the theme/subcategory distributions ALREADY
+    persisted in ``work_unit_investments`` by the LLM materializer. It iterates
+    the FULL current work graph (NOT a time window), so its org-wide completion
+    marker is legitimately FULL-COVERAGE — unlike a date-windowed materialize,
+    which is why the materializer no longer writes membership/markers.
+
+    Runs in BOTH chains:
+      - post-sync: build -> materialize (LLM, investments only) -> THIS (projects
+        membership + marker from the just-persisted investments).
+      - daily: build -> THIS (full-coverage projection / floor cadence).
+
+    Uses the run_id / completion-marker protocol (CHAOS-2433): all membership
+    rows are written first, then the completion marker is written last with a
+    COMPLETION-time timestamp (now(), captured at marker write — not run start —
+    so an overlapping run that finishes later wins argMax). Units whose current
+    component hash has no persisted categorization (churned components) are
+    skipped; the run_id protocol makes those nodes invisible without tombstones.
+    See ``work_graph.investment.backfill`` for the full contract (CHAOS-2439/2433).
 
     Args:
         db_url: Database connection string (defaults to env).
@@ -245,27 +256,27 @@ def dispatch_membership_backfill(
     self,
     db_url: str | None = None,
 ) -> dict:
-    """Daily floor-cadence safety net for ``work_unit_membership`` (CHAOS-2439/2433).
+    """Daily floor-cadence projection of ``work_unit_membership`` (CHAOS-2439/2433).
 
     ``work_unit_membership`` (read by the work-graph theme/subcategory filter) is
-    otherwise populated EVENT-DRIVEN ONLY — post-sync via the
-    ``run_work_graph_build`` -> ``run_investment_materialize`` (LLM) chain in
-    ``_dispatch_post_sync_tasks``. Idle-sync orgs and the post-deploy window
-    therefore leave membership empty, stranding theme filters in the
-    ``MEMBERSHIP_NOT_MATERIALIZED`` degraded state (CHAOS-2427 #925).
+    written EXCLUSIVELY by the no-LLM projection (``run_membership_backfill``),
+    which runs post-sync (build -> materialize -> project) AND on this daily
+    floor cadence. Idle-sync orgs and the post-deploy window would otherwise leave
+    membership empty, stranding theme filters in the ``MEMBERSHIP_NOT_MATERIALIZED``
+    degraded state (CHAOS-2427 #925) — this daily job repairs them.
 
     The daily job must NOT re-run LLM materialization (cost + category drift), so
     it fans out a CHEAP, no-LLM chain per active org:
     ``run_work_graph_build`` -> ``run_membership_backfill``. The build refreshes
-    ``work_graph_edges`` (NO LLM); the backfill then PROJECTS membership from the
+    ``work_graph_edges`` (NO LLM); the projection then re-emits membership from the
     theme/subcategory distributions already persisted in ``work_unit_investments``
-    by the post-sync LLM path. The post-sync full ``build -> materialize`` (LLM)
-    chain is UNCHANGED and still categorizes new data.
+    by the post-sync LLM materializer, with FULL current-component coverage.
 
-    The chain guarantees the backfill only runs after the build *succeeds*, so it
-    never projects against a stale/empty graph. Both the materializer and backfill
-    write a complete run via the run_id / completion-marker protocol (CHAOS-2433);
-    readers always see the most recently completed run.
+    The chain guarantees the projection only runs after the build *succeeds*, so it
+    never projects against a stale/empty graph. The projection writes a complete
+    run via the run_id / completion-marker protocol (CHAOS-2433) with a
+    completion-time marker timestamp; readers always see the most recently
+    completed full-coverage run.
 
     GATING: dispatched for EVERY active org — deliberately NOT gated on
     ``work_graph_edges`` existence (that is the build's OUTPUT; gating on it would

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -5,6 +5,8 @@ import uuid
 from datetime import date, datetime, timedelta, timezone
 from datetime import time as dt_time
 
+from celery import chain
+
 from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.task_utils import _get_db_url
@@ -179,3 +181,143 @@ def run_investment_materialize(
     except Exception as exc:
         logger.exception("Investment materialize task failed: %s", exc)
         raise self.retry(exc=exc, countdown=120 * (2**self.request.retries))
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=2,
+    queue="metrics",
+    name="dev_health_ops.workers.tasks.run_membership_backfill",
+)
+def run_membership_backfill(
+    self,
+    db_url: str | None = None,
+    org_id: str = "",
+    repo_ids: list[str] | None = None,
+) -> dict:
+    """Project work_unit_membership from EXISTING work_unit_investments — NO LLM.
+
+    The cheap daily counterpart to ``run_investment_materialize``: instead of
+    re-running LLM categorization (cost + category drift), it rebuilds the
+    work-graph components and re-emits ``work_unit_membership`` rows from the
+    theme/subcategory distributions ALREADY persisted by the post-sync LLM
+    materializer. Uses the run_id / completion-marker protocol (CHAOS-2433): all
+    membership rows are written first, then the completion marker is written last.
+    Units whose current component hash has no persisted categorization (churned
+    components) are skipped; the run_id protocol makes those nodes invisible
+    without tombstones. See ``work_graph.investment.backfill`` for the full
+    contract (CHAOS-2439/2433).
+
+    Args:
+        db_url: Database connection string (defaults to env).
+        org_id: Organization scope for work-graph/investment queries.
+        repo_ids: Optional repo filter.
+
+    Returns:
+        dict with backfill status and stats.
+    """
+    from dev_health_ops.work_graph.investment.backfill import (
+        MembershipBackfillConfig,
+        backfill_memberships,
+    )
+
+    db_url = db_url or _get_db_url()
+    try:
+        config = MembershipBackfillConfig(
+            dsn=db_url,
+            org_id=org_id or None,
+            repo_ids=repo_ids,
+        )
+        stats = backfill_memberships(config)
+        return {"status": "success", "stats": stats}
+    except Exception as exc:
+        logger.exception("Membership backfill task failed: %s", exc)
+        raise self.retry(exc=exc, countdown=120 * (2**self.request.retries))
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=3,
+    queue="default",
+    name="dev_health_ops.workers.tasks.dispatch_membership_backfill",
+)
+def dispatch_membership_backfill(
+    self,
+    db_url: str | None = None,
+) -> dict:
+    """Daily floor-cadence safety net for ``work_unit_membership`` (CHAOS-2439/2433).
+
+    ``work_unit_membership`` (read by the work-graph theme/subcategory filter) is
+    otherwise populated EVENT-DRIVEN ONLY — post-sync via the
+    ``run_work_graph_build`` -> ``run_investment_materialize`` (LLM) chain in
+    ``_dispatch_post_sync_tasks``. Idle-sync orgs and the post-deploy window
+    therefore leave membership empty, stranding theme filters in the
+    ``MEMBERSHIP_NOT_MATERIALIZED`` degraded state (CHAOS-2427 #925).
+
+    The daily job must NOT re-run LLM materialization (cost + category drift), so
+    it fans out a CHEAP, no-LLM chain per active org:
+    ``run_work_graph_build`` -> ``run_membership_backfill``. The build refreshes
+    ``work_graph_edges`` (NO LLM); the backfill then PROJECTS membership from the
+    theme/subcategory distributions already persisted in ``work_unit_investments``
+    by the post-sync LLM path. The post-sync full ``build -> materialize`` (LLM)
+    chain is UNCHANGED and still categorizes new data.
+
+    The chain guarantees the backfill only runs after the build *succeeds*, so it
+    never projects against a stale/empty graph. Both the materializer and backfill
+    write a complete run via the run_id / completion-marker protocol (CHAOS-2433);
+    readers always see the most recently completed run.
+
+    GATING: dispatched for EVERY active org — deliberately NOT gated on
+    ``work_graph_edges`` existence (that is the build's OUTPUT; gating on it would
+    permanently skip the very tenants the safety net must repair). The build is a
+    cheap no-op for an org with no source data and the backfill short-circuits on
+    zero components, so fanning out to all active orgs is correct and cheap.
+
+    Org selection mirrors the other daily fan-out dispatchers
+    (``_discover_active_org_ids`` — active orgs from Postgres, ``["default"]``
+    fallback only for the positively-detected single-tenant case) with
+    ``strict=True`` so a Postgres outage RAISES and triggers retry rather than
+    silently dispatching zero orgs as a clean success.
+
+    Returns:
+        dict with the list of dispatched org_ids.
+    """
+    from dev_health_ops.workers.recommendations_tasks import _discover_active_org_ids
+
+    db_url = db_url or _get_db_url()
+
+    try:
+        # strict=True: a Postgres enumeration failure must RAISE (not collapse to
+        # ["default"]) so the once-daily run retries instead of reporting a clean
+        # empty-success on a multi-tenant DB outage (CHAOS-2439).
+        candidate_org_ids = _discover_active_org_ids(strict=True)
+    except Exception as exc:
+        logger.exception("dispatch_membership_backfill failed to enumerate orgs")
+        raise self.retry(exc=exc, countdown=60 * (2**self.request.retries))
+
+    dispatched: list[str] = []
+    for org_id in candidate_org_ids:
+        # Immutable chain: build FIRST (refreshes edges, NO LLM), then the cheap
+        # no-LLM membership projection. Immutable chain (.s() + immutable=True)
+        # keeps the build's return value out of the backfill's args.
+        # Forward the resolved ``db_url`` to BOTH children so an explicit override
+        # (manual dispatch_membership_backfill(db_url=...)) targets the requested
+        # ClickHouse, not the workers' ambient instance. The scheduled path passes
+        # the same value _get_db_url() already resolves, so behaviour is unchanged
+        # when no override is supplied (CHAOS-2439 review).
+        build_sig = celery_app.signature(
+            "dev_health_ops.workers.tasks.run_work_graph_build",
+            kwargs={"db_url": db_url, "org_id": org_id},
+            queue="metrics",
+        )
+        backfill_sig = celery_app.signature(
+            "dev_health_ops.workers.tasks.run_membership_backfill",
+            kwargs={"db_url": db_url, "org_id": org_id},
+            queue="metrics",
+            immutable=True,
+        )
+        chain(build_sig, backfill_sig).apply_async()
+        dispatched.append(org_id)
+
+    logger.info("Membership backfill dispatch: dispatched=%d", len(dispatched))
+    return {"dispatched": dispatched}

--- a/tests/graphql/test_work_graph_membership.py
+++ b/tests/graphql/test_work_graph_membership.py
@@ -190,8 +190,14 @@ class TestEdgeThemeAttribution:
         assert "m.run_id = latest_run.latest_run_id" in annotation_sql
         # Guard: empty run_id (no complete run) excluded.
         assert "latest_run.latest_run_id != ''" in annotation_sql
-        # NOT per-node max(computed_at).
-        assert "max(computed_at)" not in annotation_sql
+        # REAL runs use run_id equality (NOT a global per-node max(computed_at)).
+        # The ONLY max(computed_at) is the LEGACY per-node guard (CHAOS-2433 final
+        # review HIGH), scoped to run_id='' rows and applied only when the latest
+        # run is the __legacy__ marker.
+        assert "max(computed_at) AS legacy_max_computed_at" in annotation_sql
+        assert "m.computed_at = lnm.legacy_max_computed_at" in annotation_sql
+        # Not the old global per-node-max alias.
+        assert "max(computed_at) AS max_computed_at" not in annotation_sql
 
     @pytest.mark.asyncio
     async def test_issue_endpoint_beats_pr_endpoint(self, mock_context):

--- a/tests/graphql/test_work_graph_membership.py
+++ b/tests/graphql/test_work_graph_membership.py
@@ -171,6 +171,29 @@ class TestEdgeThemeAttribution:
         assert membership_params["org_id"] == "test-org"
 
     @pytest.mark.asyncio
+    async def test_annotation_uses_run_id_scoping(self, mock_context):
+        """The annotation lookup queries work_unit_membership_runs to scope to
+        the latest complete run (CHAOS-2433), not per-node max(computed_at)."""
+        edge_rows = [make_edge_row(source_id="PROJ-1")]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, []]
+            await resolve_work_graph_edges(mock_context)
+
+        annotation_sql = mock_query.call_args_list[1][0][1]
+        # Run-scoped via work_unit_membership_runs.
+        assert "work_unit_membership_runs" in annotation_sql
+        assert "argMax(run_id, completed_at) AS latest_run_id" in annotation_sql
+        assert "m.run_id = latest_run.latest_run_id" in annotation_sql
+        # Guard: empty run_id (no complete run) excluded.
+        assert "latest_run.latest_run_id != ''" in annotation_sql
+        # NOT per-node max(computed_at).
+        assert "max(computed_at)" not in annotation_sql
+
+    @pytest.mark.asyncio
     async def test_issue_endpoint_beats_pr_endpoint(self, mock_context):
         """When both source (issue) and target (pr) are in membership, the issue wins."""
         edge_rows = [

--- a/tests/graphql/test_work_graph_membership_split_merge_live.py
+++ b/tests/graphql/test_work_graph_membership_split_merge_live.py
@@ -434,3 +434,284 @@ async def test_concurrency_race_incomplete_run_invisible(sink):
                 "SETTINGS mutations_sync=2",
                 parameters={"o": org_id},
             )
+
+
+@pytest.mark.asyncio
+async def test_empty_complete_run_supersedes_previous(sink):
+    """FINDING #1 (empty-but-complete run MUST supersede): an OLD complete run
+    with real membership rows, then a NEWER ALL-SKIPPED run that wrote ONLY a
+    completion marker (zero membership rows). The newer empty marker is the
+    latest complete run, so the OLD run's categories no longer match — the node
+    is absent from the latest complete run. This is the no-tombstone retirement
+    path: an empty complete run drops churned nodes.
+    """
+    org_id = f"test-chaos-2433-empty-{uuid.uuid4()}"
+    node_id = f"ISSUE-{uuid.uuid4()}"
+    pr_id = f"PR-{uuid.uuid4()}"
+    edge_id = f"edge-{uuid.uuid4()}"
+    repo_uuid = str(uuid.uuid4())
+    old_run_ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    empty_run_ts = datetime(2026, 3, 1, tzinfo=timezone.utc)
+    old_run_id = uuid.uuid4().hex
+    empty_run_id = uuid.uuid4().hex
+
+    # OLD run: complete, real rows (maintenance dominant).
+    membership_rows = [
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_OLD",
+            "theme",
+            "maintenance",
+            0.9,
+            1,
+            "ok",
+            old_run_ts,
+            old_run_id,
+        ],
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_OLD",
+            "subcategory",
+            "maintenance.refactor",
+            0.9,
+            1,
+            "ok",
+            old_run_ts,
+            old_run_id,
+        ],
+    ]
+    # Two markers: OLD (real rows) and EMPTY (later completed_at, ZERO rows).
+    run_marker_rows = [
+        [org_id, old_run_id, old_run_ts],
+        [org_id, empty_run_id, empty_run_ts],  # all-skipped run: marker, no rows
+    ]
+    edge_rows = [
+        [
+            org_id,
+            edge_id,
+            "issue",
+            node_id,
+            "pr",
+            pr_id,
+            "implements",
+            repo_uuid,
+            "github",
+            "native",
+            1.0,
+            "",
+            empty_run_ts,
+            empty_run_ts,
+            empty_run_ts,
+            empty_run_ts.date(),
+        ]
+    ]
+
+    sink.client.insert(
+        "work_unit_membership", membership_rows, column_names=_membership_cols()
+    )
+    sink.client.insert(
+        "work_unit_membership_runs",
+        run_marker_rows,
+        column_names=_membership_run_cols(),
+    )
+    sink.client.insert("work_graph_edges", edge_rows, column_names=_edge_cols())
+
+    assert CLICKHOUSE_URI is not None
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink)
+
+    try:
+        # The empty run (empty_run_id) is the latest complete run. The OLD run's
+        # maintenance rows are no longer in scope → no edge matches.
+        result = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="maintenance")
+        )
+        assert result.edges == [], (
+            "an empty-but-complete newer run must supersede the previous run; "
+            "the stale OLD-run categories must stop matching (CHAOS-2433 #1)"
+        )
+
+        # Unfiltered annotation also shows no category (node absent from the
+        # latest complete run, which has zero rows).
+        unfiltered = await resolve_work_graph_edges(context)
+        edge = next(e for e in unfiltered.edges if e.edge_id == edge_id)
+        assert edge.theme is None
+        assert edge.subcategory is None
+    finally:
+        for table in (
+            "work_unit_membership",
+            "work_unit_membership_runs",
+            "work_graph_edges",
+        ):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"o": org_id},
+            )
+
+
+@pytest.mark.asyncio
+async def test_legacy_rows_readable_then_superseded_by_real_run(sink):
+    """FINDING #3 (migration orphans existing rows): simulate PRE-existing
+    membership rows (run_id='') with the seeded '__legacy__' marker (migration
+    048). Those rows must remain filterable/annotated. Once a REAL marked run
+    lands (later completed_at), it supersedes the legacy path.
+    """
+    org_id = f"test-chaos-2433-legacy-{uuid.uuid4()}"
+    node_id = f"ISSUE-{uuid.uuid4()}"
+    pr_id = f"PR-{uuid.uuid4()}"
+    edge_id = f"edge-{uuid.uuid4()}"
+    repo_uuid = str(uuid.uuid4())
+    # Legacy marker completed_at = max(existing computed_at) — in the past.
+    legacy_ts = datetime(2026, 1, 15, tzinfo=timezone.utc)
+    real_ts = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    real_run_id = uuid.uuid4().hex
+
+    # Pre-existing rows: run_id='' (the 047 default), maintenance dominant.
+    legacy_rows = [
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_LEGACY",
+            "theme",
+            "maintenance",
+            0.9,
+            1,
+            "ok",
+            legacy_ts,
+            "",  # run_id default from migration 047
+        ],
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_LEGACY",
+            "subcategory",
+            "maintenance.refactor",
+            0.9,
+            1,
+            "ok",
+            legacy_ts,
+            "",
+        ],
+    ]
+    # Migration 048 seeds ONE '__legacy__' marker per org, completed_at=max
+    # existing computed_at.
+    legacy_marker = [[org_id, "__legacy__", legacy_ts]]
+
+    edge_rows = [
+        [
+            org_id,
+            edge_id,
+            "issue",
+            node_id,
+            "pr",
+            pr_id,
+            "implements",
+            repo_uuid,
+            "github",
+            "native",
+            1.0,
+            "",
+            real_ts,
+            real_ts,
+            real_ts,
+            real_ts.date(),
+        ]
+    ]
+
+    sink.client.insert(
+        "work_unit_membership", legacy_rows, column_names=_membership_cols()
+    )
+    sink.client.insert(
+        "work_unit_membership_runs", legacy_marker, column_names=_membership_run_cols()
+    )
+    sink.client.insert("work_graph_edges", edge_rows, column_names=_edge_cols())
+
+    assert CLICKHOUSE_URI is not None
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink)
+
+    try:
+        # PHASE 1: legacy marker is the latest complete run → pre-existing rows
+        # (run_id='') are matched via the legacy fallback.
+        legacy_result = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="maintenance")
+        )
+        assert [e.edge_id for e in legacy_result.edges] == [edge_id], (
+            "pre-existing membership rows (run_id='') must stay filterable under "
+            "the seeded __legacy__ marker (CHAOS-2433 #3)"
+        )
+        # Annotation also resolves from the legacy rows.
+        unfiltered = await resolve_work_graph_edges(context)
+        edge = next(e for e in unfiltered.edges if e.edge_id == edge_id)
+        assert edge.theme == "maintenance"
+        assert edge.subcategory == "maintenance.refactor"
+
+        # PHASE 2: a REAL run lands (later completed_at), different dominant.
+        real_rows = [
+            [
+                org_id,
+                "issue",
+                node_id,
+                "U_REAL",
+                "theme",
+                "feature_delivery",
+                0.95,
+                1,
+                "ok",
+                real_ts,
+                real_run_id,
+            ],
+            [
+                org_id,
+                "issue",
+                node_id,
+                "U_REAL",
+                "subcategory",
+                "feature_delivery.roadmap",
+                0.95,
+                1,
+                "ok",
+                real_ts,
+                real_run_id,
+            ],
+        ]
+        sink.client.insert(
+            "work_unit_membership", real_rows, column_names=_membership_cols()
+        )
+        sink.client.insert(
+            "work_unit_membership_runs",
+            [[org_id, real_run_id, real_ts]],
+            column_names=_membership_run_cols(),
+        )
+
+        # The real run supersedes the legacy path (argMax picks real_ts > legacy_ts).
+        after = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="feature_delivery")
+        )
+        assert [e.edge_id for e in after.edges] == [edge_id]
+        assert after.edges[0].theme == "feature_delivery"
+
+        # Legacy theme no longer matches (real run is now latest complete).
+        old = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="maintenance")
+        )
+        assert old.edges == [], (
+            "once a real run lands, the legacy path retires automatically via "
+            "argMax(run_id, completed_at)"
+        )
+    finally:
+        for table in (
+            "work_unit_membership",
+            "work_unit_membership_runs",
+            "work_graph_edges",
+        ):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"o": org_id},
+            )

--- a/tests/graphql/test_work_graph_membership_split_merge_live.py
+++ b/tests/graphql/test_work_graph_membership_split_merge_live.py
@@ -1164,3 +1164,345 @@ async def test_full_coverage_projection_does_not_blank_out_of_window_nodes(sink)
                 "SETTINGS mutations_sync=2",
                 parameters={"o": org_id},
             )
+
+
+def _wait_for_mutations(sink, table: str) -> None:
+    """Block until all pending mutations on ``table`` complete.
+
+    ``prune_membership_runs`` issues ``ALTER TABLE ... DELETE`` mutations, which
+    are asynchronous by default. Tests must wait for them to materialize before
+    asserting row counts. Polls system.mutations for unfinished entries.
+    """
+    import time
+
+    for _ in range(100):  # ~10s max
+        res = sink.client.query(
+            "SELECT count() FROM system.mutations "
+            "WHERE database = currentDatabase() AND table = {t:String} "
+            "AND is_done = 0",
+            parameters={"t": table},
+        )
+        pending = int(res.result_rows[0][0]) if res.result_rows else 0
+        if pending == 0:
+            return
+        time.sleep(0.1)
+
+
+def _seed_run(sink, org_id, node_id, run_id, category, ts):
+    """Seed one membership row + its completion marker for a complete run."""
+    sink.client.insert(
+        "work_unit_membership",
+        [
+            [
+                org_id,
+                "issue",
+                node_id,
+                f"U_{run_id}",
+                "theme",
+                category,
+                0.9,
+                1,
+                "ok",
+                ts,
+                run_id,
+            ]
+        ],
+        column_names=_membership_cols(),
+    )
+    sink.client.insert(
+        "work_unit_membership_runs",
+        [[org_id, run_id, ts]],
+        column_names=_membership_run_cols(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_retention_keeps_latest_two_complete_runs(sink):
+    """ROUND-5 (unbounded growth): after multiple org-wide projections, only the
+    latest 2 COMPLETE runs' membership rows AND markers remain; older runs'
+    rows and markers are deleted."""
+    org_id = f"test-chaos-2433-retain-{uuid.uuid4()}"
+    node_id = f"ISSUE-{uuid.uuid4()}"
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    run_ids = [uuid.uuid4().hex for _ in range(4)]
+
+    # Seed 4 successive complete runs (older -> newer completed_at).
+    from datetime import timedelta
+
+    for i, rid in enumerate(run_ids):
+        _seed_run(
+            sink, org_id, node_id, rid, "feature_delivery", base + timedelta(days=i)
+        )
+
+    try:
+        # Retention keeps the latest 2 complete runs.
+        pruned = sink.prune_membership_runs(org_id, keep=2)
+        assert pruned == 2, "two oldest run generations should be pruned"
+        _wait_for_mutations(sink, "work_unit_membership")
+        _wait_for_mutations(sink, "work_unit_membership_runs")
+
+        # Only the latest 2 run_ids survive in BOTH tables.
+        kept = run_ids[2:]
+        dropped = run_ids[:2]
+
+        m_rows = sink.client.query(
+            "SELECT DISTINCT run_id FROM work_unit_membership "
+            "WHERE org_id = {o:String} ORDER BY run_id",
+            parameters={"o": org_id},
+        ).result_rows
+        surviving_m = {str(r[0]) for r in m_rows}
+        assert surviving_m == set(kept), (
+            f"membership rows: expected {set(kept)}, got {surviving_m}"
+        )
+        assert not (surviving_m & set(dropped)), "old runs' rows must be deleted"
+
+        r_rows = sink.client.query(
+            "SELECT run_id FROM work_unit_membership_runs FINAL "
+            "WHERE org_id = {o:String} ORDER BY run_id",
+            parameters={"o": org_id},
+        ).result_rows
+        surviving_r = {str(r[0]) for r in r_rows}
+        assert surviving_r == set(kept), (
+            f"markers: expected {set(kept)}, got {surviving_r}"
+        )
+    finally:
+        for table in ("work_unit_membership", "work_unit_membership_runs"):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"o": org_id},
+            )
+
+
+@pytest.mark.asyncio
+async def test_retention_never_deletes_markerless_inflight_run(sink):
+    """An in-flight run (rows written, NO marker yet) must survive a concurrent
+    retention pass — retention only ever deletes MARKERED runs."""
+    org_id = f"test-chaos-2433-inflight-{uuid.uuid4()}"
+    node_id = f"ISSUE-{uuid.uuid4()}"
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    from datetime import timedelta
+
+    # 3 complete (markered) runs.
+    complete = [uuid.uuid4().hex for _ in range(3)]
+    for i, rid in enumerate(complete):
+        _seed_run(
+            sink, org_id, node_id, rid, "feature_delivery", base + timedelta(days=i)
+        )
+
+    # An in-flight run: rows ONLY, no marker — the next generation mid-write.
+    inflight = uuid.uuid4().hex
+    sink.client.insert(
+        "work_unit_membership",
+        [
+            [
+                org_id,
+                "issue",
+                node_id,
+                f"U_{inflight}",
+                "theme",
+                "maintenance",
+                0.5,
+                1,
+                "ok",
+                base + timedelta(days=10),
+                inflight,
+            ]
+        ],
+        column_names=_membership_cols(),
+    )
+
+    try:
+        sink.prune_membership_runs(org_id, keep=2)
+        _wait_for_mutations(sink, "work_unit_membership")
+        _wait_for_mutations(sink, "work_unit_membership_runs")
+
+        # The in-flight run's rows MUST still be present (never markered → never
+        # in the delete set).
+        inflight_count = sink.client.query(
+            "SELECT count() FROM work_unit_membership "
+            "WHERE org_id = {o:String} AND run_id = {r:String}",
+            parameters={"o": org_id, "r": inflight},
+        ).result_rows[0][0]
+        assert int(inflight_count) >= 1, (
+            "a markerless in-flight run must NEVER be deleted by retention"
+        )
+
+        # Of the markered runs, only the latest 2 survive.
+        surviving_complete = {
+            str(r[0])
+            for r in sink.client.query(
+                "SELECT DISTINCT run_id FROM work_unit_membership "
+                "WHERE org_id = {o:String} AND run_id IN {ids:Array(String)}",
+                parameters={"o": org_id, "ids": complete},
+            ).result_rows
+        }
+        assert surviving_complete == set(complete[1:]), (
+            "only the latest 2 markered runs survive"
+        )
+    finally:
+        for table in ("work_unit_membership", "work_unit_membership_runs"):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"o": org_id},
+            )
+
+
+@pytest.mark.asyncio
+async def test_retention_resolver_still_correct_after_prune(sink):
+    """After retention, the resolver still returns the latest run's results, and
+    the immediately-previous complete run is still present (the keep=2 overlap
+    safety margin)."""
+    org_id = f"test-chaos-2433-retain-resolve-{uuid.uuid4()}"
+    node_id = f"ISSUE-{uuid.uuid4()}"
+    pr_id = f"PR-{uuid.uuid4()}"
+    edge_id = f"edge-{uuid.uuid4()}"
+    repo_uuid = str(uuid.uuid4())
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    from datetime import timedelta
+
+    # 3 complete runs; the LATEST is feature_delivery, the prior is maintenance.
+    old_runs = [uuid.uuid4().hex, uuid.uuid4().hex]
+    for i, rid in enumerate(old_runs):
+        _seed_run(sink, org_id, node_id, rid, "operational", base + timedelta(days=i))
+    prior_run = uuid.uuid4().hex
+    _seed_run(sink, org_id, node_id, prior_run, "maintenance", base + timedelta(days=5))
+    latest_run = uuid.uuid4().hex
+    _seed_run(
+        sink, org_id, node_id, latest_run, "feature_delivery", base + timedelta(days=6)
+    )
+
+    sink.client.insert(
+        "work_graph_edges",
+        [
+            [
+                org_id,
+                edge_id,
+                "issue",
+                node_id,
+                "pr",
+                pr_id,
+                "implements",
+                repo_uuid,
+                "github",
+                "native",
+                1.0,
+                "",
+                base,
+                base,
+                base,
+                base.date(),
+            ]
+        ],
+        column_names=_edge_cols(),
+    )
+
+    assert CLICKHOUSE_URI is not None
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink)
+
+    try:
+        sink.prune_membership_runs(org_id, keep=2)
+        _wait_for_mutations(sink, "work_unit_membership")
+        _wait_for_mutations(sink, "work_unit_membership_runs")
+
+        # The latest run drives the resolver: feature_delivery matches.
+        latest = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="feature_delivery")
+        )
+        assert [e.edge_id for e in latest.edges] == [edge_id]
+        assert latest.edges[0].theme == "feature_delivery"
+
+        # The immediately-previous complete run (maintenance) is STILL present
+        # (keep=2 overlap margin) — its rows were not pruned.
+        prior_rows = sink.client.query(
+            "SELECT count() FROM work_unit_membership "
+            "WHERE org_id = {o:String} AND run_id = {r:String}",
+            parameters={"o": org_id, "r": prior_run},
+        ).result_rows[0][0]
+        assert int(prior_rows) >= 1, "the prior complete run must survive (keep=2)"
+
+        # The two oldest 'operational' runs were pruned.
+        old_rows = sink.client.query(
+            "SELECT count() FROM work_unit_membership "
+            "WHERE org_id = {o:String} AND run_id IN {ids:Array(String)}",
+            parameters={"o": org_id, "ids": old_runs},
+        ).result_rows[0][0]
+        assert int(old_rows) == 0, "the two oldest runs must be pruned"
+    finally:
+        for table in (
+            "work_unit_membership",
+            "work_unit_membership_runs",
+            "work_graph_edges",
+        ):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"o": org_id},
+            )
+
+
+@pytest.mark.asyncio
+async def test_retention_bounds_row_count_across_many_runs(sink):
+    """Live bound check: across N successive prune-after-publish cycles, the row
+    count stays bounded (it does NOT grow with N)."""
+    org_id = f"test-chaos-2433-bound-{uuid.uuid4()}"
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    from datetime import timedelta
+
+    # Each run seeds the SAME 5 nodes (a stable current graph), then prunes.
+    nodes = [f"ISSUE-{i}-{uuid.uuid4()}" for i in range(5)]
+    counts: list[int] = []
+    try:
+        for run_i in range(6):
+            rid = uuid.uuid4().hex
+            ts = base + timedelta(days=run_i)
+            rows = [
+                [
+                    org_id,
+                    "issue",
+                    n,
+                    f"U_{rid}",
+                    "theme",
+                    "feature_delivery",
+                    0.9,
+                    1,
+                    "ok",
+                    ts,
+                    rid,
+                ]
+                for n in nodes
+            ]
+            sink.client.insert(
+                "work_unit_membership", rows, column_names=_membership_cols()
+            )
+            sink.client.insert(
+                "work_unit_membership_runs",
+                [[org_id, rid, ts]],
+                column_names=_membership_run_cols(),
+            )
+            sink.prune_membership_runs(org_id, keep=2)
+            _wait_for_mutations(sink, "work_unit_membership")
+            _wait_for_mutations(sink, "work_unit_membership_runs")
+            total = sink.client.query(
+                "SELECT count() FROM work_unit_membership WHERE org_id = {o:String}",
+                parameters={"o": org_id},
+            ).result_rows[0][0]
+            counts.append(int(total))
+
+        # After the 2nd run onward, the count is bounded at keep(2) * 5 nodes = 10
+        # — it does NOT grow with the number of runs (would be 6*5=30 unpruned).
+        assert counts[-1] <= 2 * len(nodes), (
+            f"row count must be bounded by keep*nodes, got {counts}"
+        )
+        # And it never exceeds the bound at any steady-state step.
+        assert max(counts[1:]) <= 2 * len(nodes), (
+            f"steady-state row count must stay bounded, got {counts}"
+        )
+    finally:
+        for table in ("work_unit_membership", "work_unit_membership_runs"):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"o": org_id},
+            )

--- a/tests/graphql/test_work_graph_membership_split_merge_live.py
+++ b/tests/graphql/test_work_graph_membership_split_merge_live.py
@@ -1,19 +1,26 @@
-"""Live-ClickHouse regression for CHAOS-2430 per-node stale scoping (split/merge).
+"""Live-ClickHouse regression for CHAOS-2430/2433 run_id scoping (split/merge).
 
 work_unit_id is a hash of the connected component. When edge churn moves a node
-into a new component, the OLD work_unit_id is never re-emitted. A per-work_unit_id
-"latest run" guard would keep that dead unit's rows alive forever, so the node
-would keep matching obsolete theme/subcategory categories (filter path) and
-annotation would see multiple is_dominant rows. The fix scopes staleness per
-NODE: keep only rows where computed_at == max(computed_at) per
-(org_id, node_type, node_id).
+into a new component, the OLD work_unit_id is never re-emitted. With the run_id /
+completion-marker protocol (CHAOS-2433):
+  - Every membership write stamps a run_id on ALL rows and writes a completion
+    marker to work_unit_membership_runs LAST.
+  - Readers select the latest COMPLETE run via
+    argMax(run_id, completed_at) FROM work_unit_membership_runs
+    and scope ALL membership reads to that run_id.
+  - A node absent from the latest complete run (e.g. old component rows whose
+    run_id is no longer the latest) is simply not selectable.
 
-This test seeds two runs for one node — an OLD component (dominant maintenance)
-superseded by a NEW component (dominant feature_delivery) at a later
-computed_at — and asserts via the real resolver that:
-  * filtering by the OLD theme (maintenance) returns NO edge,
+This test seeds TWO runs for one node — an OLD run (run_id=RUN_OLD, dominant
+maintenance, complete) and a NEW run (run_id=RUN_NEW, dominant feature_delivery,
+complete at a later completed_at) — and asserts via the real resolver that:
+  * filtering by the OLD theme (maintenance) returns NO edge (RUN_NEW is latest),
   * filtering by the NEW theme (feature_delivery) returns the edge,
-  * the unfiltered annotation shows exactly the NEW dominant (no duplicates).
+  * the unfiltered annotation shows exactly the NEW dominant (no stale rows).
+
+Also tests the CONCURRENCY RACE: when RUN_NEW has membership rows but NO marker
+yet, the resolver uses RUN_OLD (the prior complete run) — not the half-written
+RUN_NEW. After RUN_NEW's marker is written, the resolver switches to RUN_NEW.
 
 Opt-in (filtered from unit/CI runs): ``pytest -m clickhouse``.
 """
@@ -64,7 +71,12 @@ def _membership_cols() -> list[str]:
         "is_dominant",
         "categorization_status",
         "computed_at",
+        "run_id",
     ]
+
+
+def _membership_run_cols() -> list[str]:
+    return ["org_id", "run_id", "completed_at"]
 
 
 def _edge_cols() -> list[str]:
@@ -90,17 +102,28 @@ def _edge_cols() -> list[str]:
 
 @pytest.mark.asyncio
 async def test_split_merge_old_categories_disappear(sink):
+    """Run_id protocol: only rows in the latest COMPLETE run are visible.
+
+    Scenario: node was in OLD component (run_id=RUN_OLD, maintenance dominant),
+    then moved to NEW component (run_id=RUN_NEW, feature_delivery dominant).
+    Both runs are COMPLETE (markers written). RUN_NEW has a later completed_at
+    so it is the latest complete run. Old rows (RUN_OLD) are invisible.
+    """
     org_id = f"test-chaos-2430-{uuid.uuid4()}"
     node_id = f"ISSUE-{uuid.uuid4()}"
     pr_id = f"PR-{uuid.uuid4()}"
     edge_id = f"edge-{uuid.uuid4()}"
     repo_uuid = str(uuid.uuid4())
-    old_run = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    new_run = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    old_run_ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    new_run_ts = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    old_run_id = uuid.uuid4().hex
+    new_run_id = uuid.uuid4().hex
 
-    # OLD component: node dominant maintenance. NEW component (later run,
-    # different work_unit_id): node dominant feature_delivery; maintenance gone.
+    # OLD run: node dominant maintenance; stamped with old_run_id.
+    # NEW run (later completed_at): node dominant feature_delivery; stamped with
+    # new_run_id.  NEW run is the latest complete run → OLD rows invisible.
     membership_rows = [
+        # OLD run rows (run_id=old_run_id)
         [
             org_id,
             "issue",
@@ -111,7 +134,8 @@ async def test_split_merge_old_categories_disappear(sink):
             0.9,
             1,
             "ok",
-            old_run,
+            old_run_ts,
+            old_run_id,
         ],
         [
             org_id,
@@ -123,8 +147,10 @@ async def test_split_merge_old_categories_disappear(sink):
             0.9,
             1,
             "ok",
-            old_run,
+            old_run_ts,
+            old_run_id,
         ],
+        # NEW run rows (run_id=new_run_id)
         [
             org_id,
             "issue",
@@ -135,7 +161,8 @@ async def test_split_merge_old_categories_disappear(sink):
             0.95,
             1,
             "ok",
-            new_run,
+            new_run_ts,
+            new_run_id,
         ],
         [
             org_id,
@@ -147,8 +174,14 @@ async def test_split_merge_old_categories_disappear(sink):
             0.95,
             1,
             "ok",
-            new_run,
+            new_run_ts,
+            new_run_id,
         ],
+    ]
+    # Completion markers: both runs are complete; RUN_NEW has later completed_at.
+    run_marker_rows = [
+        [org_id, old_run_id, old_run_ts],
+        [org_id, new_run_id, new_run_ts],
     ]
     edge_rows = [
         [
@@ -164,15 +197,20 @@ async def test_split_merge_old_categories_disappear(sink):
             "native",
             1.0,
             "",
-            new_run,
-            new_run,
-            new_run,
-            new_run.date(),
+            new_run_ts,
+            new_run_ts,
+            new_run_ts,
+            new_run_ts.date(),
         ]
     ]
 
     sink.client.insert(
         "work_unit_membership", membership_rows, column_names=_membership_cols()
+    )
+    sink.client.insert(
+        "work_unit_membership_runs",
+        run_marker_rows,
+        column_names=_membership_run_cols(),
     )
     sink.client.insert("work_graph_edges", edge_rows, column_names=_edge_cols())
 
@@ -180,24 +218,25 @@ async def test_split_merge_old_categories_disappear(sink):
     context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink)
 
     try:
-        # Filter by the OLD theme → the node's prior-component category must be
-        # gone (per-node latest run supersedes it). No edge returned.
+        # Filter by the OLD theme → the old run's rows are invisible (not the
+        # latest complete run). No edge returned.
         old_result = await resolve_work_graph_edges(
             context, WorkGraphEdgeFilterInput(theme="maintenance")
         )
         assert old_result.edges == [], (
-            "stale OLD-component theme should not match after the node moved "
-            "to a new work_unit_id"
+            "stale OLD-run theme should not match after a NEW complete run supersedes"
         )
 
         # Filter by the NEW theme → the edge is returned.
         new_result = await resolve_work_graph_edges(
             context, WorkGraphEdgeFilterInput(theme="feature_delivery")
         )
-        assert [e.edge_id for e in new_result.edges] == [edge_id]
+        assert [e.edge_id for e in new_result.edges] == [edge_id], (
+            f"expected [{edge_id!r}], got {[e.edge_id for e in new_result.edges]}"
+        )
         assert new_result.edges[0].theme == "feature_delivery"
 
-        # Unfiltered annotation → exactly the NEW dominant, no duplicate/stale.
+        # Unfiltered annotation → exactly the NEW dominant, no stale rows.
         unfiltered = await resolve_work_graph_edges(context)
         edge = next(e for e in unfiltered.edges if e.edge_id == edge_id)
         assert edge.theme == "feature_delivery"
@@ -209,7 +248,189 @@ async def test_split_merge_old_categories_disappear(sink):
             parameters={"o": org_id},
         )
         sink.client.command(
+            "ALTER TABLE work_unit_membership_runs DELETE WHERE org_id = {o:String} "
+            "SETTINGS mutations_sync=2",
+            parameters={"o": org_id},
+        )
+        sink.client.command(
             "ALTER TABLE work_graph_edges DELETE WHERE org_id = {o:String} "
             "SETTINGS mutations_sync=2",
             parameters={"o": org_id},
         )
+
+
+@pytest.mark.asyncio
+async def test_concurrency_race_incomplete_run_invisible(sink):
+    """CONCURRENCY RACE (CHAOS-2433 round-5 bug): materializer has written some
+    membership rows but NOT its completion marker yet. A prior COMPLETE backfill
+    run exists. Resolver must use the backfill's complete run, not the in-flight
+    materializer rows. After the marker is written, resolver switches to new run.
+    """
+    org_id = f"test-chaos-2433-race-{uuid.uuid4()}"
+    node_id = f"ISSUE-{uuid.uuid4()}"
+    pr_id = f"PR-{uuid.uuid4()}"
+    edge_id = f"edge-{uuid.uuid4()}"
+    repo_uuid = str(uuid.uuid4())
+    backfill_ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    materialize_ts = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    backfill_run_id = uuid.uuid4().hex
+    materialize_run_id = uuid.uuid4().hex
+
+    # BACKFILL run: complete (has marker). Node is feature_delivery dominant.
+    # MATERIALIZER run: membership rows written BUT no marker yet (in-flight).
+    #   Node in materializer run is maintenance dominant.
+    membership_rows = [
+        # Backfill run (complete)
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_BF",
+            "theme",
+            "feature_delivery",
+            0.95,
+            1,
+            "ok",
+            backfill_ts,
+            backfill_run_id,
+        ],
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_BF",
+            "subcategory",
+            "feature_delivery.roadmap",
+            0.95,
+            1,
+            "ok",
+            backfill_ts,
+            backfill_run_id,
+        ],
+        # Materializer run (in-flight — rows present but NO marker yet)
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_MAT",
+            "theme",
+            "maintenance",
+            0.9,
+            1,
+            "ok",
+            materialize_ts,
+            materialize_run_id,
+        ],
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_MAT",
+            "subcategory",
+            "maintenance.refactor",
+            0.9,
+            1,
+            "ok",
+            materialize_ts,
+            materialize_run_id,
+        ],
+    ]
+    # Only the backfill run has a marker; materializer has not written its marker yet.
+    run_marker_rows = [
+        [org_id, backfill_run_id, backfill_ts],
+    ]
+    edge_rows = [
+        [
+            org_id,
+            edge_id,
+            "issue",
+            node_id,
+            "pr",
+            pr_id,
+            "implements",
+            repo_uuid,
+            "github",
+            "native",
+            1.0,
+            "",
+            materialize_ts,
+            materialize_ts,
+            materialize_ts,
+            materialize_ts.date(),
+        ]
+    ]
+
+    sink.client.insert(
+        "work_unit_membership", membership_rows, column_names=_membership_cols()
+    )
+    sink.client.insert(
+        "work_unit_membership_runs",
+        run_marker_rows,
+        column_names=_membership_run_cols(),
+    )
+    sink.client.insert("work_graph_edges", edge_rows, column_names=_edge_cols())
+
+    assert CLICKHOUSE_URI is not None
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink)
+
+    try:
+        # PHASE 1: Materializer in-flight (no marker for materialize_run_id).
+        # Resolver must use the backfill's complete run (feature_delivery).
+
+        # The maintenance filter (from the in-flight materializer rows) must NOT
+        # match — in-flight rows are invisible.
+        race_maintenance = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="maintenance")
+        )
+        assert race_maintenance.edges == [], (
+            "in-flight materializer rows (no marker) must NOT be visible to readers"
+        )
+
+        # The feature_delivery filter (from the backfill's complete run) MUST match.
+        race_feature = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="feature_delivery")
+        )
+        assert [e.edge_id for e in race_feature.edges] == [edge_id], (
+            "prior COMPLETE backfill run must remain visible while materializer "
+            "is in-flight (concurrency race fix)"
+        )
+        assert race_feature.edges[0].theme == "feature_delivery", (
+            "annotation must reflect the complete backfill run's dominant"
+        )
+
+        # PHASE 2: Materializer writes its completion marker.
+        sink.client.insert(
+            "work_unit_membership_runs",
+            [[org_id, materialize_run_id, materialize_ts]],
+            column_names=_membership_run_cols(),
+        )
+
+        # Now resolver must switch to the materializer's run (latest completed_at).
+        # maintenance filter now matches (materializer's run is complete + latest).
+        after_maintenance = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="maintenance")
+        )
+        assert [e.edge_id for e in after_maintenance.edges] == [edge_id], (
+            "after marker write, materializer's run becomes the latest complete run"
+        )
+        assert after_maintenance.edges[0].theme == "maintenance"
+
+        # feature_delivery filter no longer matches (node moved out of that theme).
+        after_feature = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="feature_delivery")
+        )
+        assert after_feature.edges == [], (
+            "after marker write, resolver must use the new run; feature_delivery "
+            "is no longer in scope for this node"
+        )
+    finally:
+        for table in (
+            "work_unit_membership",
+            "work_unit_membership_runs",
+            "work_graph_edges",
+        ):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"o": org_id},
+            )

--- a/tests/graphql/test_work_graph_membership_split_merge_live.py
+++ b/tests/graphql/test_work_graph_membership_split_merge_live.py
@@ -1506,3 +1506,130 @@ async def test_retention_bounds_row_count_across_many_runs(sink):
                 "SETTINGS mutations_sync=2",
                 parameters={"o": org_id},
             )
+
+
+@pytest.mark.asyncio
+async def test_out_of_window_previously_categorized_component_stays_visible(sink):
+    """ROUND-7 false-positive proof (live): a current, UNCHURNED component whose
+    only investment row is OLD (out of any 30-day materialize window) remains
+    filterable after the real org-wide backfill projection. The backfill reads
+    work_unit_investments by work_unit_id with NO date window, so the org-wide
+    marker COVERS it — it is not hidden.
+
+    End-to-end: seed work_graph_edges + an OLD-computed_at work_unit_investments
+    row, run the REAL backfill_memberships (no LLM), then assert the resolver
+    returns the component under its theme.
+    """
+    from dev_health_ops.metrics.schemas import WorkUnitInvestmentRecord
+    from dev_health_ops.work_graph.investment.backfill import (
+        MembershipBackfillConfig,
+        backfill_memberships,
+    )
+    from dev_health_ops.work_graph.investment.utils import work_unit_id
+
+    org_id = f"test-chaos-2433-oow-{uuid.uuid4()}"
+    issue_id = f"ISSUE-{uuid.uuid4()}"
+    pr_node = f"PRNODE-{uuid.uuid4()}"
+    edge_id = f"edge-{uuid.uuid4()}"
+    repo_uuid = str(uuid.uuid4())
+    # An OLD timestamp — well outside any default 30-day materialize window.
+    old_ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    # The component: issue + pr. Its work_unit_id is the hash of those nodes.
+    unit_nodes = [("issue", issue_id), ("pr", pr_node)]
+    uid = work_unit_id(unit_nodes)
+
+    # Seed the current work graph edge (unwindowed: backfill reads ALL edges).
+    sink.client.insert(
+        "work_graph_edges",
+        [
+            [
+                org_id,
+                edge_id,
+                "issue",
+                issue_id,
+                "pr",
+                pr_node,
+                "implements",
+                repo_uuid,
+                "github",
+                "native",
+                1.0,
+                "",
+                old_ts,
+                old_ts,
+                old_ts,
+                old_ts.date(),
+            ]
+        ],
+        column_names=_edge_cols(),
+    )
+
+    # Seed a PREVIOUSLY-categorized investment row with an OLD computed_at.
+    sink.write_work_unit_investments(
+        [
+            WorkUnitInvestmentRecord(
+                work_unit_id=uid,
+                work_unit_type="issue",
+                work_unit_name="old categorized unit",
+                from_ts=old_ts,
+                to_ts=old_ts,
+                repo_id=uuid.UUID(repo_uuid),
+                provider="github",
+                effort_metric="churn_loc",
+                effort_value=1.0,
+                theme_distribution_json={"maintenance": 1.0},
+                subcategory_distribution_json={"maintenance.refactor": 1.0},
+                structural_evidence_json="{}",
+                evidence_quality=0.9,
+                evidence_quality_band="high",
+                categorization_status="ok",
+                categorization_errors_json="[]",
+                categorization_model_version="test",
+                categorization_input_hash="hash",
+                categorization_run_id=uuid.uuid4().hex,
+                computed_at=old_ts,
+                org_id=org_id,
+            )
+        ]
+    )
+
+    assert CLICKHOUSE_URI is not None
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink)
+
+    try:
+        # Run the REAL org-wide backfill projection (no LLM, no date window).
+        stats = backfill_memberships(
+            MembershipBackfillConfig(dsn=CLICKHOUSE_URI, org_id=org_id)
+        )
+        assert stats["matched"] == 1, (
+            "the previously-categorized OLD component must be matched/covered, "
+            "not skipped — the backfill read is not date-windowed (round-7)"
+        )
+        _wait_for_mutations(sink, "work_unit_membership")
+        _wait_for_mutations(sink, "work_unit_membership_runs")
+
+        # The resolver returns the component under its theme — NOT hidden by the
+        # (irrelevant) materialize window. The org-wide marker covers it.
+        result = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="maintenance")
+        )
+        assert [e.edge_id for e in result.edges] == [edge_id], (
+            "an out-of-window but previously-categorized, unchurned component "
+            "MUST remain filterable after the org-wide backfill (round-7 false "
+            "positive: the org-wide marker does NOT hide it)"
+        )
+        assert result.edges[0].theme == "maintenance"
+        assert not result.degraded_reason
+    finally:
+        for table in (
+            "work_unit_membership",
+            "work_unit_membership_runs",
+            "work_graph_edges",
+            "work_unit_investments",
+        ):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"o": org_id},
+            )

--- a/tests/graphql/test_work_graph_membership_split_merge_live.py
+++ b/tests/graphql/test_work_graph_membership_split_merge_live.py
@@ -1633,3 +1633,231 @@ async def test_out_of_window_previously_categorized_component_stays_visible(sink
                 "SETTINGS mutations_sync=2",
                 parameters={"o": org_id},
             )
+
+
+@pytest.mark.asyncio
+async def test_legacy_per_node_max_excludes_stale_dominant(sink):
+    """FINAL REVIEW HIGH — legacy fallback must NOT over-match stale rows.
+
+    Pre-protocol, the old table key was (org, node, category_kind, category) with
+    run_id NOT in the key, so a node that was dominant category A at T1 and
+    re-materialized to dominant category B at T2 has BOTH rows persisted (distinct
+    category values -> distinct keys -> never deduped), all at run_id=''. The OLD
+    reader scoped each node to max(computed_at). A blanket run_id='' legacy match
+    would resurface stale A alongside current B.
+
+    With only the '__legacy__' marker present, assert:
+      * a theme filter for A's category (maintenance) returns NO node,
+      * a theme filter for B's category (feature_delivery) returns the node,
+      * the annotation reports exactly ONE dominant (B), no stale A duplicate.
+    Then a real org-wide run supersedes the legacy path entirely.
+    """
+    org_id = f"test-chaos-2433-legacy-pernode-{uuid.uuid4()}"
+    node_id = f"ISSUE-{uuid.uuid4()}"
+    pr_id = f"PR-{uuid.uuid4()}"
+    edge_id = f"edge-{uuid.uuid4()}"
+    repo_uuid = str(uuid.uuid4())
+    t1 = datetime(2024, 1, 1, tzinfo=timezone.utc)  # OLD dominant A
+    t2 = datetime(2024, 2, 1, tzinfo=timezone.utc)  # NEWER dominant B
+    legacy_ts = t2  # migration 048 seeds completed_at = max(existing computed_at)
+
+    # Both rows run_id='' (pre-migration shape), is_dominant=1, DIFFERENT category
+    # values across two re-materializations -> both survived the old dedup key.
+    legacy_rows = [
+        # OLD dominant: maintenance @ T1
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_OLD",
+            "theme",
+            "maintenance",
+            0.9,
+            1,
+            "ok",
+            t1,
+            "",
+        ],
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_OLD",
+            "subcategory",
+            "maintenance.refactor",
+            0.9,
+            1,
+            "ok",
+            t1,
+            "",
+        ],
+        # NEWER dominant: feature_delivery @ T2
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_NEW",
+            "theme",
+            "feature_delivery",
+            0.95,
+            1,
+            "ok",
+            t2,
+            "",
+        ],
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_NEW",
+            "subcategory",
+            "feature_delivery.roadmap",
+            0.95,
+            1,
+            "ok",
+            t2,
+            "",
+        ],
+    ]
+    legacy_marker = [[org_id, "__legacy__", legacy_ts]]
+    edge_rows = [
+        [
+            org_id,
+            edge_id,
+            "issue",
+            node_id,
+            "pr",
+            pr_id,
+            "implements",
+            repo_uuid,
+            "github",
+            "native",
+            1.0,
+            "",
+            t2,
+            t2,
+            t2,
+            t2.date(),
+        ],
+    ]
+
+    sink.client.insert(
+        "work_unit_membership", legacy_rows, column_names=_membership_cols()
+    )
+    sink.client.insert(
+        "work_unit_membership_runs", legacy_marker, column_names=_membership_run_cols()
+    )
+    sink.client.insert("work_graph_edges", edge_rows, column_names=_edge_cols())
+
+    assert CLICKHOUSE_URI is not None
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink)
+
+    try:
+        # PHASE 1 (legacy): the STALE A (maintenance) must NOT match — only the
+        # node's latest pre-migration row (B) is in scope.
+        stale = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="maintenance")
+        )
+        assert stale.edges == [], (
+            "legacy per-node-max guard must NOT resurface the stale OLD dominant "
+            "(maintenance @ T1) — only the latest legacy row counts (final HIGH)"
+        )
+
+        # The CURRENT B (feature_delivery) DOES match.
+        current = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="feature_delivery")
+        )
+        assert [e.edge_id for e in current.edges] == [edge_id]
+        assert current.edges[0].theme == "feature_delivery"
+
+        # Annotation reports EXACTLY ONE dominant (B), no stale A duplicate.
+        unfiltered = await resolve_work_graph_edges(context)
+        edge = next(e for e in unfiltered.edges if e.edge_id == edge_id)
+        assert edge.theme == "feature_delivery"
+        assert edge.subcategory == "feature_delivery.roadmap"
+
+        # Direct DB proof: the in-scope dominant theme rows for this node under the
+        # legacy per-node-max guard are exactly ONE (B), not two (A + B). Use a
+        # correlated subquery for the per-node max so we never re-bind a timestamp
+        # (avoids DateTime64 precision/round-trip fragility).
+        in_scope = sink.client.query(
+            "SELECT category FROM work_unit_membership AS m "
+            "WHERE m.org_id = {o:String} AND m.node_id = {n:String} "
+            "AND m.run_id = '' AND m.category_kind = 'theme' AND m.is_dominant = 1 "
+            "AND m.computed_at = ("
+            "  SELECT max(computed_at) FROM work_unit_membership "
+            "  WHERE org_id = m.org_id AND node_type = m.node_type "
+            "  AND node_id = m.node_id AND run_id = ''"
+            ")",
+            parameters={"o": org_id, "n": node_id},
+        ).result_rows
+        assert [r[0] for r in in_scope] == ["feature_delivery"], (
+            "exactly one in-scope dominant theme under the legacy per-node-max "
+            "guard, and it is B (feature_delivery), not stale A"
+        )
+
+        # PHASE 2: a REAL org-wide run supersedes legacy entirely.
+        real_run = uuid.uuid4().hex
+        real_ts = datetime(2026, 4, 1, tzinfo=timezone.utc)
+        sink.client.insert(
+            "work_unit_membership",
+            [
+                [
+                    org_id,
+                    "issue",
+                    node_id,
+                    "U_REAL",
+                    "theme",
+                    "quality",
+                    0.9,
+                    1,
+                    "ok",
+                    real_ts,
+                    real_run,
+                ],
+                [
+                    org_id,
+                    "issue",
+                    node_id,
+                    "U_REAL",
+                    "subcategory",
+                    "quality.testing",
+                    0.9,
+                    1,
+                    "ok",
+                    real_ts,
+                    real_run,
+                ],
+            ],
+            column_names=_membership_cols(),
+        )
+        sink.client.insert(
+            "work_unit_membership_runs",
+            [[org_id, real_run, real_ts]],
+            column_names=_membership_run_cols(),
+        )
+
+        after = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="quality")
+        )
+        assert [e.edge_id for e in after.edges] == [edge_id]
+        assert after.edges[0].theme == "quality"
+        # Neither legacy theme matches once the real run is latest.
+        for legacy_theme in ("feature_delivery", "maintenance"):
+            gone = await resolve_work_graph_edges(
+                context, WorkGraphEdgeFilterInput(theme=legacy_theme)
+            )
+            assert gone.edges == [], (
+                f"real run must supersede legacy entirely; {legacy_theme} gone"
+            )
+    finally:
+        for table in (
+            "work_unit_membership",
+            "work_unit_membership_runs",
+            "work_graph_edges",
+        ):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"o": org_id},
+            )

--- a/tests/graphql/test_work_graph_membership_split_merge_live.py
+++ b/tests/graphql/test_work_graph_membership_split_merge_live.py
@@ -715,3 +715,162 @@ async def test_legacy_rows_readable_then_superseded_by_real_run(sink):
                 "SETTINGS mutations_sync=2",
                 parameters={"o": org_id},
             )
+
+
+@pytest.mark.asyncio
+async def test_optimize_final_preserves_prior_complete_run_row(sink):
+    """ROUND-2 FINDING #1 (run_id in the dedup key): a background merge / OPTIMIZE
+    FINAL must NOT collapse rows for the same (org, node, category) across runs.
+
+    Without run_id in the ORDER BY, ReplacingMergeTree(computed_at) would keep
+    only the max-computed_at version, so a newer INCOMPLETE run (no marker) would
+    EVICT the prior COMPLETE run's row — after which the resolver scoped to the
+    complete run_id reads nothing. With migration 049 (run_id appended to the
+    sort key), per-run rows coexist: the complete run's row survives OPTIMIZE
+    FINAL and the resolver scoped to it still returns the node.
+
+    This test MUST fail on the 046 sort key and pass after the 049 rebuild
+    (the fixture's ensure_schema(force=True) applies all migrations incl. 049).
+    """
+    org_id = f"test-chaos-2433-optfinal-{uuid.uuid4()}"
+    node_id = f"ISSUE-{uuid.uuid4()}"
+    pr_id = f"PR-{uuid.uuid4()}"
+    edge_id = f"edge-{uuid.uuid4()}"
+    repo_uuid = str(uuid.uuid4())
+    complete_ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    incomplete_ts = datetime(2026, 2, 1, tzinfo=timezone.utc)  # newer computed_at
+    complete_run_id = uuid.uuid4().hex
+    incomplete_run_id = uuid.uuid4().hex
+
+    # SAME node + SAME (category_kind, category) under two runs:
+    #   COMPLETE run (older computed_at, marker published) — maintenance.
+    #   INCOMPLETE run (newer computed_at, NO marker) — same category, lower weight.
+    # On the old key these collapse to the newer (incomplete) version on merge.
+    membership_rows = [
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_C",
+            "theme",
+            "maintenance",
+            0.9,
+            1,
+            "ok",
+            complete_ts,
+            complete_run_id,
+        ],
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_C",
+            "subcategory",
+            "maintenance.refactor",
+            0.9,
+            1,
+            "ok",
+            complete_ts,
+            complete_run_id,
+        ],
+        # In-flight run: same node + SAME categories, newer computed_at, no marker.
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_I",
+            "theme",
+            "maintenance",
+            0.5,
+            1,
+            "ok",
+            incomplete_ts,
+            incomplete_run_id,
+        ],
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_I",
+            "subcategory",
+            "maintenance.refactor",
+            0.5,
+            1,
+            "ok",
+            incomplete_ts,
+            incomplete_run_id,
+        ],
+    ]
+    # Only the COMPLETE run has a marker (the in-flight run has not published).
+    run_marker_rows = [[org_id, complete_run_id, complete_ts]]
+    edge_rows = [
+        [
+            org_id,
+            edge_id,
+            "issue",
+            node_id,
+            "pr",
+            pr_id,
+            "implements",
+            repo_uuid,
+            "github",
+            "native",
+            1.0,
+            "",
+            incomplete_ts,
+            incomplete_ts,
+            incomplete_ts,
+            incomplete_ts.date(),
+        ]
+    ]
+
+    sink.client.insert(
+        "work_unit_membership", membership_rows, column_names=_membership_cols()
+    )
+    sink.client.insert(
+        "work_unit_membership_runs",
+        run_marker_rows,
+        column_names=_membership_run_cols(),
+    )
+    sink.client.insert("work_graph_edges", edge_rows, column_names=_edge_cols())
+
+    # Force a merge: this is the operation that would EVICT the complete run's
+    # row under the old (run_id-less) dedup key.
+    sink.client.command("OPTIMIZE TABLE work_unit_membership FINAL")
+
+    assert CLICKHOUSE_URI is not None
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink)
+
+    try:
+        # The COMPLETE run's row must STILL be physically present after the merge.
+        remaining = sink.client.query(
+            "SELECT run_id, weight FROM work_unit_membership "
+            "WHERE org_id = {o:String} AND run_id = {r:String}",
+            parameters={"o": org_id, "r": complete_run_id},
+        ).result_rows
+        assert remaining, (
+            "the prior COMPLETE run's membership rows were EVICTED by OPTIMIZE "
+            "FINAL — run_id must be in the dedup key (CHAOS-2433 finding #1)"
+        )
+
+        # The resolver (scoped to the COMPLETE run via its marker, since the
+        # in-flight run has no marker) still returns the node under maintenance.
+        result = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="maintenance")
+        )
+        assert [e.edge_id for e in result.edges] == [edge_id], (
+            "after OPTIMIZE FINAL the resolver scoped to the complete run must "
+            "still return the node (the complete run's row survived)"
+        )
+        assert result.edges[0].theme == "maintenance"
+    finally:
+        for table in (
+            "work_unit_membership",
+            "work_unit_membership_runs",
+            "work_graph_edges",
+        ):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"o": org_id},
+            )

--- a/tests/graphql/test_work_graph_membership_split_merge_live.py
+++ b/tests/graphql/test_work_graph_membership_split_merge_live.py
@@ -874,3 +874,293 @@ async def test_optimize_final_preserves_prior_complete_run_row(sink):
                 "SETTINGS mutations_sync=2",
                 parameters={"o": org_id},
             )
+
+
+@pytest.mark.asyncio
+async def test_overlap_later_marker_wins_over_earlier_marker(sink):
+    """ROUND-3 FINDING #1 (marker completed_at = COMPLETION order, not start):
+    a run whose membership ROWS carry an EARLIER computed_at but whose MARKER has
+    a LATER completed_at must WIN argMax(run_id, completed_at).
+
+    This is the overlap race: a long materializer/projection that STARTS before
+    another run (so its rows carry an earlier run-start computed_at) but FINISHES
+    after it (so its marker carries a later completion timestamp) must be the one
+    readers select. We invert the two axes — run A's rows are NEWER (computed_at)
+    but its marker is OLDER (completed_at); run B's rows are OLDER but its marker
+    is NEWER — and assert the resolver follows the MARKER (run B wins).
+    """
+    org_id = f"test-chaos-2433-overlap-{uuid.uuid4()}"
+    node_id = f"ISSUE-{uuid.uuid4()}"
+    pr_id = f"PR-{uuid.uuid4()}"
+    edge_id = f"edge-{uuid.uuid4()}"
+    repo_uuid = str(uuid.uuid4())
+
+    run_a = uuid.uuid4().hex  # rows NEWER (start later) but marker OLDER (finish first)
+    run_b = uuid.uuid4().hex  # rows OLDER (start first) but marker NEWER (finish last)
+
+    rows_ts_a = datetime(2026, 5, 1, tzinfo=timezone.utc)  # A rows: newer computed_at
+    rows_ts_b = datetime(2026, 4, 1, tzinfo=timezone.utc)  # B rows: older computed_at
+    marker_ts_a = datetime(2026, 6, 1, tzinfo=timezone.utc)  # A marker: OLDER finish
+    marker_ts_b = datetime(2026, 7, 1, tzinfo=timezone.utc)  # B marker: NEWER finish
+
+    membership_rows = [
+        # Run A — maintenance, rows carry the NEWER computed_at.
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_A",
+            "theme",
+            "maintenance",
+            0.9,
+            1,
+            "ok",
+            rows_ts_a,
+            run_a,
+        ],
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_A",
+            "subcategory",
+            "maintenance.refactor",
+            0.9,
+            1,
+            "ok",
+            rows_ts_a,
+            run_a,
+        ],
+        # Run B — feature_delivery, rows carry the OLDER computed_at.
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_B",
+            "theme",
+            "feature_delivery",
+            0.95,
+            1,
+            "ok",
+            rows_ts_b,
+            run_b,
+        ],
+        [
+            org_id,
+            "issue",
+            node_id,
+            "U_B",
+            "subcategory",
+            "feature_delivery.roadmap",
+            0.95,
+            1,
+            "ok",
+            rows_ts_b,
+            run_b,
+        ],
+    ]
+    # Markers: B finishes LATER (greater completed_at) → B must win argMax.
+    run_marker_rows = [
+        [org_id, run_a, marker_ts_a],
+        [org_id, run_b, marker_ts_b],
+    ]
+    edge_rows = [
+        [
+            org_id,
+            edge_id,
+            "issue",
+            node_id,
+            "pr",
+            pr_id,
+            "implements",
+            repo_uuid,
+            "github",
+            "native",
+            1.0,
+            "",
+            marker_ts_b,
+            marker_ts_b,
+            marker_ts_b,
+            marker_ts_b.date(),
+        ],
+    ]
+
+    sink.client.insert(
+        "work_unit_membership", membership_rows, column_names=_membership_cols()
+    )
+    sink.client.insert(
+        "work_unit_membership_runs",
+        run_marker_rows,
+        column_names=_membership_run_cols(),
+    )
+    sink.client.insert("work_graph_edges", edge_rows, column_names=_edge_cols())
+
+    assert CLICKHOUSE_URI is not None
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink)
+
+    try:
+        # Run B finished later → its marker wins → feature_delivery matches.
+        feature = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="feature_delivery")
+        )
+        assert [e.edge_id for e in feature.edges] == [edge_id], (
+            "the LATER-FINISHING run (greater marker completed_at) must win, even "
+            "though its rows carry an OLDER computed_at (CHAOS-2433 round-3 #1)"
+        )
+        assert feature.edges[0].theme == "feature_delivery"
+
+        # Run A's maintenance must NOT match even though A's ROWS are newer:
+        # selection follows the MARKER's completed_at, not the rows' computed_at.
+        maintenance = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="maintenance")
+        )
+        assert maintenance.edges == [], (
+            "run A's newer-computed_at rows must lose because its marker finished "
+            "FIRST — marker completion order drives selection, not row computed_at"
+        )
+    finally:
+        for table in (
+            "work_unit_membership",
+            "work_unit_membership_runs",
+            "work_graph_edges",
+        ):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"o": org_id},
+            )
+
+
+@pytest.mark.asyncio
+async def test_full_coverage_projection_does_not_blank_out_of_window_nodes(sink):
+    """ROUND-3 FINDING #2 (date-window): a full-coverage projection run must keep
+    ALL current components filterable — including ones a date-windowed materialize
+    would have skipped. We seed a prior full-coverage run covering an OLD node and
+    a NEW node, then a newer full-coverage projection run that ALSO covers both
+    (the projection iterates the whole current graph, no time window). Both nodes
+    stay filterable under the latest run — neither is blanked.
+
+    (Contrast: a windowed materialize covering only the NEW node would, if it
+    published an org-wide marker, blank the OLD node. The unified writer prevents
+    that because the materializer no longer publishes membership/markers.)
+    """
+    org_id = f"test-chaos-2433-window-{uuid.uuid4()}"
+    old_node = f"OLD-{uuid.uuid4()}"
+    new_node = f"NEW-{uuid.uuid4()}"
+    old_pr = f"PR-{uuid.uuid4()}"
+    new_pr = f"PR-{uuid.uuid4()}"
+    old_edge = f"edge-{uuid.uuid4()}"
+    new_edge = f"edge-{uuid.uuid4()}"
+    repo_uuid = str(uuid.uuid4())
+    rows_ts = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    marker_ts = datetime(2026, 8, 1, 0, 0, 1, tzinfo=timezone.utc)
+    run_id = uuid.uuid4().hex
+
+    # Latest full-coverage projection run covers BOTH the old and the new node.
+    membership_rows = [
+        [
+            org_id,
+            "issue",
+            old_node,
+            "U_OLD",
+            "theme",
+            "maintenance",
+            0.9,
+            1,
+            "ok",
+            rows_ts,
+            run_id,
+        ],
+        [
+            org_id,
+            "issue",
+            new_node,
+            "U_NEW",
+            "theme",
+            "feature_delivery",
+            0.95,
+            1,
+            "ok",
+            rows_ts,
+            run_id,
+        ],
+    ]
+    run_marker_rows = [[org_id, run_id, marker_ts]]
+    edge_rows = [
+        [
+            org_id,
+            old_edge,
+            "issue",
+            old_node,
+            "pr",
+            old_pr,
+            "implements",
+            repo_uuid,
+            "github",
+            "native",
+            1.0,
+            "",
+            rows_ts,
+            rows_ts,
+            rows_ts,
+            rows_ts.date(),
+        ],
+        [
+            org_id,
+            new_edge,
+            "issue",
+            new_node,
+            "pr",
+            new_pr,
+            "implements",
+            repo_uuid,
+            "github",
+            "native",
+            1.0,
+            "",
+            rows_ts,
+            rows_ts,
+            rows_ts,
+            rows_ts.date(),
+        ],
+    ]
+
+    sink.client.insert(
+        "work_unit_membership", membership_rows, column_names=_membership_cols()
+    )
+    sink.client.insert(
+        "work_unit_membership_runs",
+        run_marker_rows,
+        column_names=_membership_run_cols(),
+    )
+    sink.client.insert("work_graph_edges", edge_rows, column_names=_edge_cols())
+
+    assert CLICKHOUSE_URI is not None
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink)
+
+    try:
+        # The OLD node (would be out-of-window for a 30d materialize) is STILL
+        # filterable from the full-coverage projection run — not blanked.
+        old_result = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="maintenance")
+        )
+        assert [e.edge_id for e in old_result.edges] == [old_edge], (
+            "the full-coverage projection must keep out-of-window components "
+            "filterable — a windowed marker would have blanked them (round-3 #2)"
+        )
+        # The NEW (in-window) node is filterable too.
+        new_result = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(theme="feature_delivery")
+        )
+        assert [e.edge_id for e in new_result.edges] == [new_edge]
+    finally:
+        for table in (
+            "work_unit_membership",
+            "work_unit_membership_runs",
+            "work_graph_edges",
+        ):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"o": org_id},
+            )

--- a/tests/graphql/test_work_graph_theme_filter.py
+++ b/tests/graphql/test_work_graph_theme_filter.py
@@ -181,6 +181,10 @@ class TestThemeFilterServerSide:
         assert "m.run_id = latest_run.latest_run_id" in edge_sql
         # Guard: incomplete/empty runs (latest_run_id='') are excluded.
         assert "latest_run.latest_run_id != ''" in edge_sql
+        # Legacy fallback (CHAOS-2433 finding #3): when the latest run is the
+        # seeded __legacy__ marker, pre-existing rows (run_id='') still match.
+        assert "latest_run.latest_run_id = '__legacy__'" in edge_sql
+        assert "m.run_id = ''" in edge_sql
         # Must NOT use old per-node max(computed_at) guard.
         assert "max(computed_at) AS max_computed_at" not in edge_sql
         assert "GROUP BY node_type, node_id" not in edge_sql
@@ -859,4 +863,90 @@ class TestRunIdConcurrencyRace:
         # Not in the filter result (split/merge safe).
         assert result.edges == []
         # Not degraded — other nodes have membership in the latest complete run.
+        assert result.degraded_reason is None
+
+
+class TestLegacyRolloutFallback:
+    """CHAOS-2433 finding #3: migration 047 added run_id DEFAULT '' to existing
+    rows but no marker existed for them, so the run-scoped reader would treat
+    them as invisible immediately post-deploy. Migration 048 seeds one
+    '__legacy__' marker per org (completed_at = max existing computed_at), and
+    every reader join recognises the legacy marker and matches the pre-existing
+    rows (run_id=''). A real run (completed_at = now()) supersedes via argMax.
+
+    These tests assert the legacy fallback predicate is present in ALL THREE
+    reader paths so existing membership stays readable until a real run lands.
+    """
+
+    @pytest.mark.asyncio
+    async def test_filter_path_has_legacy_fallback(self, mock_context):
+        """The theme-filter EXISTS semijoin matches pre-existing rows (run_id='')
+        when the latest complete run is the seeded '__legacy__' marker."""
+        edge_rows = [make_edge_row(edge_id="e1", source_id="LEGACY-NODE")]
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [edge_rows, []]
+            filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
+            await resolve_work_graph_edges(mock_context, filters)
+
+        edge_sql = mock_query.call_args_list[0][0][1]
+        assert "latest_run.latest_run_id = '__legacy__'" in edge_sql
+        assert "m.run_id = ''" in edge_sql
+
+    @pytest.mark.asyncio
+    async def test_annotation_path_has_legacy_fallback(self, mock_context):
+        """The dominant-annotation lookup also matches pre-existing rows under the
+        legacy marker — so edges keep their theme/subcategory post-deploy."""
+        edge_rows = [
+            make_edge_row(
+                edge_id="e1",
+                source_type="issue",
+                source_id="LEGACY-1",
+                target_type="pr",
+                target_id="PR-1",
+            )
+        ]
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            # Unfiltered path: edge query + annotation lookup. The annotation
+            # lookup is call index 1.
+            mock_query.side_effect = [
+                edge_rows,
+                dominant_rows(
+                    "issue", "LEGACY-1", "feature_delivery", "feature_delivery.roadmap"
+                ),
+            ]
+            result = await resolve_work_graph_edges(mock_context)
+
+        annotation_sql = mock_query.call_args_list[1][0][1]
+        assert "work_unit_membership_runs" in annotation_sql
+        assert "latest_run.latest_run_id = '__legacy__'" in annotation_sql
+        assert "m.run_id = ''" in annotation_sql
+        # Annotation actually applied from the legacy rows.
+        assert result.edges[0].theme == "feature_delivery"
+
+    @pytest.mark.asyncio
+    async def test_degraded_probe_has_legacy_fallback(self, mock_context):
+        """The degraded probe counts pre-existing rows under the legacy marker, so
+        an org with only legacy membership is NOT falsely reported degraded."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [
+                [],
+                # Legacy rows counted → membership_rows > 0 → not degraded.
+                [{"membership_rows": 7, "investment_rows": 10}],
+            ]
+            filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
+            result = await resolve_work_graph_edges(mock_context, filters)
+
+        probe_sql = mock_query.call_args_list[1][0][1]
+        assert "latest_run.latest_run_id = '__legacy__'" in probe_sql
+        assert "m.run_id = ''" in probe_sql
+        # Legacy rows present → genuine empty filter, not degraded.
         assert result.degraded_reason is None

--- a/tests/graphql/test_work_graph_theme_filter.py
+++ b/tests/graphql/test_work_graph_theme_filter.py
@@ -1,4 +1,4 @@
-"""Tests for CHAOS-2430 server-side theme/subcategory filtering of work graph edges.
+"""Tests for CHAOS-2430/2433 server-side theme/subcategory filtering of work graph edges.
 
 The membership filter is pushed INTO the edge query as a correlated EXISTS
 semi-join (no unbounded Python prefetch), so repo_id/edge_type/source filters,
@@ -10,15 +10,19 @@ tests prove:
   theme's matching edge is returned even past the row cap.
 - A theme filter returns only matching edges; theme+subcategory requires BOTH
   (uniqExact == 2); subcategory-only matches on the subcategory tuple.
-- Staleness scopes per NODE (max(computed_at) per (org, node_type, node_id)),
-  fixing split/merge; an obsolete category from a prior component disappears.
+- Run-scoping via work_unit_membership_runs (CHAOS-2433 protocol) replaces the
+  old per-node max(computed_at) guard everywhere (filter, annotation, degraded
+  probe). Readers select the latest COMPLETE run via argMax(run_id, completed_at)
+  from work_unit_membership_runs and scope ALL membership reads to that run_id.
+- Concurrency race: a half-written materializer run (no marker yet) is invisible;
+  the prior COMPLETE run (e.g. from a backfill) is visible until the marker lands.
 - The no-filter path is unchanged (issue>pr precedence annotation preserved).
 - Annotation ALWAYS reports the node's DOMINANT category on both paths — the
   theme filter selects which edges show, never what edge.theme reports (a unit
   matched under its secondary theme still reports its dominant).
 - Org isolation; AND-composition with repo/edge_type; degraded_reason is
   MEMBERSHIP_NOT_MATERIALIZED only when a filter yields nothing AND investments
-  exist with zero membership rows, else None.
+  exist with zero membership rows in the latest complete run, else None.
 """
 
 from __future__ import annotations
@@ -155,10 +159,10 @@ class TestThemeFilterServerSide:
         assert "matched_nodes" not in edge_params
 
     @pytest.mark.asyncio
-    async def test_staleness_scoped_per_node(self, mock_context):
-        """The latest-run guard groups by NODE, not by work_unit_id — this is
-        what makes split/merge safe (an obsolete component's rows are
-        superseded by the node's most recent run)."""
+    async def test_run_scoped_via_completion_marker(self, mock_context):
+        """The filter semijoin uses run_id scoping from work_unit_membership_runs
+        (CHAOS-2433), NOT per-node max(computed_at). This makes split/merge safe:
+        nodes absent from the latest complete run have no matching rows."""
         edge_rows = [make_edge_row(edge_id="e1", source_id="N-1")]
 
         with patch(
@@ -171,14 +175,15 @@ class TestThemeFilterServerSide:
             await resolve_work_graph_edges(mock_context, filters)
 
         edge_sql = mock_query.call_args_list[0][0][1]
-        # latest run grouped per node, joined on computed_at == max per node.
-        assert "GROUP BY node_type, node_id" in edge_sql
-        assert "max(computed_at) AS max_computed_at" in edge_sql
-        assert "m.node_type = latest.node_type" in edge_sql
-        assert "m.node_id = latest.node_id" in edge_sql
-        assert "m.computed_at = latest.max_computed_at" in edge_sql
-        # Must NOT scope by work_unit_id (the buggy per-unit guard).
-        assert "GROUP BY work_unit_id" not in edge_sql
+        # Run-scoped via work_unit_membership_runs + argMax(run_id, completed_at).
+        assert "work_unit_membership_runs" in edge_sql
+        assert "argMax(run_id, completed_at) AS latest_run_id" in edge_sql
+        assert "m.run_id = latest_run.latest_run_id" in edge_sql
+        # Guard: incomplete/empty runs (latest_run_id='') are excluded.
+        assert "latest_run.latest_run_id != ''" in edge_sql
+        # Must NOT use old per-node max(computed_at) guard.
+        assert "max(computed_at) AS max_computed_at" not in edge_sql
+        assert "GROUP BY node_type, node_id" not in edge_sql
 
     @pytest.mark.asyncio
     async def test_theme_filter_returns_matching_edges_annotated_with_dominant(
@@ -212,8 +217,10 @@ class TestThemeFilterServerSide:
 
     @pytest.mark.asyncio
     async def test_degraded_state_when_membership_unmaterialized(self, mock_context):
-        """Empty filter result + investments>0 + membership==0 (latest-run
-        scoped) → edges=[] with degraded_reason=MEMBERSHIP_NOT_MATERIALIZED."""
+        """Empty filter result + investments>0 + membership==0 in the latest
+        complete run → edges=[] with degraded_reason=MEMBERSHIP_NOT_MATERIALIZED.
+        The degraded probe uses run_id scoping (CHAOS-2433), not per-node
+        max(computed_at)."""
         with patch(
             "dev_health_ops.api.queries.client.query_dicts",
             new_callable=AsyncMock,
@@ -233,10 +240,14 @@ class TestThemeFilterServerSide:
         # The edge query plus the degraded-state probe.
         assert mock_query.call_count == 2
         probe_sql = mock_query.call_args_list[1][0][1]
+        # Probe uses run_id scoping via work_unit_membership_runs.
         assert "work_unit_membership" in probe_sql
+        assert "work_unit_membership_runs" in probe_sql
         assert "work_unit_investments" in probe_sql
-        # The probe counts membership scoped to each node's latest run.
-        assert "max(computed_at) AS max_computed_at" in probe_sql
+        # Run-scoped, NOT per-node max(computed_at).
+        assert "argMax(run_id, completed_at) AS latest_run_id" in probe_sql
+        assert "m.run_id = latest_run.latest_run_id" in probe_sql
+        assert "max(computed_at) AS max_computed_at" not in probe_sql
 
     @pytest.mark.asyncio
     async def test_genuine_empty_is_not_degraded(self, mock_context):
@@ -355,7 +366,8 @@ class TestThemeFilterServerSide:
 
     @pytest.mark.asyncio
     async def test_org_isolation_on_edge_and_membership(self, mock_context):
-        """The edge query (incl. the correlated membership subquery) carries org_id."""
+        """The edge query (incl. the correlated membership subquery) carries org_id.
+        The run-selection subquery (work_unit_membership_runs) is org-scoped too."""
         edge_rows = [make_edge_row(edge_id="e1", source_type="issue", source_id="FD-1")]
 
         with patch(
@@ -372,8 +384,9 @@ class TestThemeFilterServerSide:
         # org_id is enforced on the edge table AND inside the membership subquery.
         assert "org_id = %(org_id)s" in edge_sql
         assert "m.org_id = %(org_id)s" in edge_sql
-        # The per-node latest subquery is org-scoped too.
-        assert edge_sql.count("org_id = %(org_id)s") >= 3
+        # The run-selection subquery (work_unit_membership_runs) is org-scoped.
+        assert "work_unit_membership_runs" in edge_sql
+        assert edge_sql.count("org_id = %(org_id)s") >= 2
 
     @pytest.mark.asyncio
     async def test_no_filter_path_unchanged(self, mock_context):
@@ -700,3 +713,150 @@ class TestMissingMembershipTableDegrades:
             filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
             with pytest.raises(_OtherMsgOnly):
                 await resolve_work_graph_edges(mock_context, filters)
+
+
+class TestRunIdConcurrencyRace:
+    """CHAOS-2433: prove the concurrency race is fixed by the run_id protocol.
+
+    Scenario (the round-5 bug):
+      1. A materializer is in-flight: has written SOME membership rows but NOT
+         its completion marker yet.
+      2. A prior COMPLETE backfill run exists (has a marker in
+         work_unit_membership_runs).
+      3. Resolver must select the COMPLETE backfill run, NOT the half-written
+         materializer (whose marker has not arrived yet).
+      4. After the materializer writes its marker, the resolver switches to it.
+
+    The run_id / completion-marker protocol (CHAOS-2433) guarantees this:
+    readers select argMax(run_id, completed_at) from work_unit_membership_runs,
+    which only sees COMPLETE runs. A run with membership rows but no marker is
+    simply invisible.
+    """
+
+    @pytest.mark.asyncio
+    async def test_incomplete_materializer_run_invisible_complete_backfill_visible(
+        self, mock_context
+    ):
+        """While a materializer is in-flight (rows written, no marker), the
+        resolver uses the last complete backfill run and returns its edges.
+        The filter SQL uses work_unit_membership_runs to find the latest
+        complete run — so the half-written materializer rows are never selected.
+        """
+        # Simulate: ClickHouse returns one edge (the backfill run is complete,
+        # so the EXISTS filter matched against the backfill's run_id).
+        edge_rows = [make_edge_row(edge_id="backfill-edge", source_id="BACKFILL-NODE")]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [
+                edge_rows,
+                dominant_rows(
+                    "issue",
+                    "BACKFILL-NODE",
+                    "feature_delivery",
+                    "feature_delivery.roadmap",
+                ),
+            ]
+            filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
+            result = await resolve_work_graph_edges(mock_context, filters)
+
+        # Backfill's complete run edge is returned.
+        assert [e.edge_id for e in result.edges] == ["backfill-edge"]
+        assert result.degraded_reason is None
+
+        # The filter SQL uses work_unit_membership_runs (run_id protocol).
+        edge_sql = mock_query.call_args_list[0][0][1]
+        assert "work_unit_membership_runs" in edge_sql
+        assert "argMax(run_id, completed_at) AS latest_run_id" in edge_sql
+        # Run_id equality join (not per-node max(computed_at)).
+        assert "m.run_id = latest_run.latest_run_id" in edge_sql
+
+    @pytest.mark.asyncio
+    async def test_after_materializer_marker_written_resolver_uses_new_run(
+        self, mock_context
+    ):
+        """After the materializer writes its completion marker, the resolver
+        switches to the new (materializer) run because it is now the latest
+        complete run in work_unit_membership_runs."""
+        # Now the materializer's marker exists — ClickHouse returns the
+        # materializer's edge (it is now the latest complete run).
+        edge_rows = [
+            make_edge_row(edge_id="materializer-edge", source_id="MATERIALIZER-NODE")
+        ]
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [
+                edge_rows,
+                dominant_rows(
+                    "issue",
+                    "MATERIALIZER-NODE",
+                    "maintenance",
+                    "maintenance.refactor",
+                ),
+            ]
+            filters = WorkGraphEdgeFilterInput(theme="maintenance")
+            result = await resolve_work_graph_edges(mock_context, filters)
+
+        # Materializer's run edge is returned after marker write.
+        assert [e.edge_id for e in result.edges] == ["materializer-edge"]
+        assert result.edges[0].theme == "maintenance"
+        assert result.degraded_reason is None
+
+    @pytest.mark.asyncio
+    async def test_no_complete_run_yields_degraded_when_investments_exist(
+        self, mock_context
+    ):
+        """When no completion marker exists at all (first-ever deploy, no run
+        complete), a theme filter that returns empty AND investments exist
+        yields MEMBERSHIP_NOT_MATERIALIZED (degraded).  The probe checks
+        work_unit_membership_runs for the latest complete run (none → empty
+        join → membership_rows=0) and investments exist → degraded."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            # Edge query: empty (no complete run yet, filter finds nothing).
+            # Probe: no complete run → membership_rows=0; investments exist.
+            mock_query.side_effect = [
+                [],
+                [{"membership_rows": 0, "investment_rows": 10}],
+            ]
+            filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
+            result = await resolve_work_graph_edges(mock_context, filters)
+
+        assert result.edges == []
+        assert result.degraded_reason == "MEMBERSHIP_NOT_MATERIALIZED"
+
+    @pytest.mark.asyncio
+    async def test_split_merge_stale_node_absent_from_new_run(self, mock_context):
+        """A node that had real membership in run A (old component) is absent
+        from run B (latest complete, different component).  The filter returns
+        no edges for that node; annotation is None.  No tombstones involved —
+        the node is simply absent from the current run's scope."""
+        # Simulate: ClickHouse runs the EXISTS filter against run B's rows only.
+        # The node (OLD-NODE) is no longer in run B → filter finds no edges.
+        # (No edge rows returned.) Investments still exist → probe runs.
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            # Edge query: ClickHouse correctly returns empty because OLD-NODE has
+            # no rows in the latest complete run B.
+            # Probe: some membership rows exist (in run B, for other nodes), so
+            # membership_rows > 0 → not degraded (just a genuine filter miss).
+            mock_query.side_effect = [
+                [],
+                [{"membership_rows": 42, "investment_rows": 100}],
+            ]
+            filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
+            result = await resolve_work_graph_edges(mock_context, filters)
+
+        # Not in the filter result (split/merge safe).
+        assert result.edges == []
+        # Not degraded — other nodes have membership in the latest complete run.
+        assert result.degraded_reason is None

--- a/tests/graphql/test_work_graph_theme_filter.py
+++ b/tests/graphql/test_work_graph_theme_filter.py
@@ -22,7 +22,8 @@ tests prove:
   matched under its secondary theme still reports its dominant).
 - Org isolation; AND-composition with repo/edge_type; degraded_reason is
   MEMBERSHIP_NOT_MATERIALIZED only when a filter yields nothing AND investments
-  exist with zero membership rows in the latest complete run, else None.
+  exist AND NO complete-run marker exists (gated on marker existence, not row
+  count — an empty-but-complete run is a valid empty, not degraded), else None.
 """
 
 from __future__ import annotations
@@ -221,19 +222,18 @@ class TestThemeFilterServerSide:
 
     @pytest.mark.asyncio
     async def test_degraded_state_when_membership_unmaterialized(self, mock_context):
-        """Empty filter result + investments>0 + membership==0 in the latest
-        complete run → edges=[] with degraded_reason=MEMBERSHIP_NOT_MATERIALIZED.
-        The degraded probe uses run_id scoping (CHAOS-2433), not per-node
-        max(computed_at)."""
+        """Empty filter result + investments>0 + NO complete-run MARKER → edges=[]
+        with degraded_reason=MEMBERSHIP_NOT_MATERIALIZED. The degraded probe gates
+        on MARKER existence (CHAOS-2433 round-2 #2), not membership row count."""
         with patch(
             "dev_health_ops.api.queries.client.query_dicts",
             new_callable=AsyncMock,
         ) as mock_query:
             # Edge query empty → degraded probe runs (2nd call) and reports
-            # zero membership rows but non-zero investments.
+            # zero complete-run markers but non-zero investments.
             mock_query.side_effect = [
                 [],
-                [{"membership_rows": 0, "investment_rows": 5}],
+                [{"complete_run_markers": 0, "investment_rows": 5}],
             ]
             filters = WorkGraphEdgeFilterInput(theme="risk")
             result = await resolve_work_graph_edges(mock_context, filters)
@@ -244,18 +244,42 @@ class TestThemeFilterServerSide:
         # The edge query plus the degraded-state probe.
         assert mock_query.call_count == 2
         probe_sql = mock_query.call_args_list[1][0][1]
-        # Probe uses run_id scoping via work_unit_membership_runs.
-        assert "work_unit_membership" in probe_sql
+        # Probe gates on MARKER existence: counts work_unit_membership_runs rows.
         assert "work_unit_membership_runs" in probe_sql
+        assert "complete_run_markers" in probe_sql
         assert "work_unit_investments" in probe_sql
-        # Run-scoped, NOT per-node max(computed_at).
-        assert "argMax(run_id, completed_at) AS latest_run_id" in probe_sql
-        assert "m.run_id = latest_run.latest_run_id" in probe_sql
-        assert "max(computed_at) AS max_computed_at" not in probe_sql
+        # No longer counts membership rows / joins the membership table for the
+        # degraded signal (an empty complete run is a valid state, not degraded).
+        assert "argMax(run_id, completed_at) AS latest_run_id" not in probe_sql
+
+    @pytest.mark.asyncio
+    async def test_empty_complete_run_is_not_degraded(self, mock_context):
+        """CHAOS-2433 round-2 #2: an org with investments + a COMPLETE marker but
+        ZERO membership rows in the latest run (the all-skipped supersede case)
+        is a genuine empty, NOT degraded. The probe sees complete_run_markers>0 →
+        degraded_reason is None."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            # A complete marker exists (>0) even though the latest run has zero
+            # membership rows; investments exist. Must NOT be degraded.
+            mock_query.side_effect = [
+                [],
+                [{"complete_run_markers": 1, "investment_rows": 50}],
+            ]
+            filters = WorkGraphEdgeFilterInput(theme="risk")
+            result = await resolve_work_graph_edges(mock_context, filters)
+
+        assert result.edges == []
+        assert result.degraded_reason is None, (
+            "an empty-but-complete run (marker present) is a genuine empty, not "
+            "MEMBERSHIP_NOT_MATERIALIZED"
+        )
 
     @pytest.mark.asyncio
     async def test_genuine_empty_is_not_degraded(self, mock_context):
-        """Empty filter result but membership rows EXIST (no match) → not a
+        """Empty filter result but a complete marker EXISTS (no match) → not a
         degraded state: degraded_reason is None."""
         with patch(
             "dev_health_ops.api.queries.client.query_dicts",
@@ -263,7 +287,7 @@ class TestThemeFilterServerSide:
         ) as mock_query:
             mock_query.side_effect = [
                 [],
-                [{"membership_rows": 42, "investment_rows": 100}],
+                [{"complete_run_markers": 3, "investment_rows": 100}],
             ]
             filters = WorkGraphEdgeFilterInput(theme="risk")
             result = await resolve_work_graph_edges(mock_context, filters)
@@ -281,7 +305,7 @@ class TestThemeFilterServerSide:
         ) as mock_query:
             mock_query.side_effect = [
                 [],
-                [{"membership_rows": 0, "investment_rows": 0}],
+                [{"complete_run_markers": 0, "investment_rows": 0}],
             ]
             filters = WorkGraphEdgeFilterInput(theme="risk")
             result = await resolve_work_graph_edges(mock_context, filters)
@@ -815,20 +839,19 @@ class TestRunIdConcurrencyRace:
     async def test_no_complete_run_yields_degraded_when_investments_exist(
         self, mock_context
     ):
-        """When no completion marker exists at all (first-ever deploy, no run
+        """When NO completion marker exists at all (first-ever deploy, no run
         complete), a theme filter that returns empty AND investments exist
-        yields MEMBERSHIP_NOT_MATERIALIZED (degraded).  The probe checks
-        work_unit_membership_runs for the latest complete run (none → empty
-        join → membership_rows=0) and investments exist → degraded."""
+        yields MEMBERSHIP_NOT_MATERIALIZED (degraded). The probe gates on MARKER
+        existence: no marker (complete_run_markers=0) + investments → degraded."""
         with patch(
             "dev_health_ops.api.queries.client.query_dicts",
             new_callable=AsyncMock,
         ) as mock_query:
             # Edge query: empty (no complete run yet, filter finds nothing).
-            # Probe: no complete run → membership_rows=0; investments exist.
+            # Probe: no complete-run marker; investments exist.
             mock_query.side_effect = [
                 [],
-                [{"membership_rows": 0, "investment_rows": 10}],
+                [{"complete_run_markers": 0, "investment_rows": 10}],
             ]
             filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
             result = await resolve_work_graph_edges(mock_context, filters)
@@ -851,18 +874,18 @@ class TestRunIdConcurrencyRace:
         ) as mock_query:
             # Edge query: ClickHouse correctly returns empty because OLD-NODE has
             # no rows in the latest complete run B.
-            # Probe: some membership rows exist (in run B, for other nodes), so
-            # membership_rows > 0 → not degraded (just a genuine filter miss).
+            # Probe: a complete-run marker exists (run B), so
+            # complete_run_markers > 0 → not degraded (just a genuine filter miss).
             mock_query.side_effect = [
                 [],
-                [{"membership_rows": 42, "investment_rows": 100}],
+                [{"complete_run_markers": 1, "investment_rows": 100}],
             ]
             filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
             result = await resolve_work_graph_edges(mock_context, filters)
 
         # Not in the filter result (split/merge safe).
         assert result.edges == []
-        # Not degraded — other nodes have membership in the latest complete run.
+        # Not degraded — a complete run marker exists for the org.
         assert result.degraded_reason is None
 
 
@@ -930,23 +953,28 @@ class TestLegacyRolloutFallback:
         assert result.edges[0].theme == "feature_delivery"
 
     @pytest.mark.asyncio
-    async def test_degraded_probe_has_legacy_fallback(self, mock_context):
-        """The degraded probe counts pre-existing rows under the legacy marker, so
-        an org with only legacy membership is NOT falsely reported degraded."""
+    async def test_legacy_marker_counts_as_complete_run_not_degraded(
+        self, mock_context
+    ):
+        """The seeded '__legacy__' marker IS a complete-run marker, so the
+        marker-gated degraded probe (CHAOS-2433 round-2 #2) counts it: an org
+        with the legacy marker is NOT falsely reported MEMBERSHIP_NOT_MATERIALIZED
+        even on an empty filter result."""
         with patch(
             "dev_health_ops.api.queries.client.query_dicts",
             new_callable=AsyncMock,
         ) as mock_query:
             mock_query.side_effect = [
                 [],
-                # Legacy rows counted → membership_rows > 0 → not degraded.
-                [{"membership_rows": 7, "investment_rows": 10}],
+                # The legacy marker exists → complete_run_markers >= 1 → not degraded.
+                [{"complete_run_markers": 1, "investment_rows": 10}],
             ]
             filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
             result = await resolve_work_graph_edges(mock_context, filters)
 
         probe_sql = mock_query.call_args_list[1][0][1]
-        assert "latest_run.latest_run_id = '__legacy__'" in probe_sql
-        assert "m.run_id = ''" in probe_sql
-        # Legacy rows present → genuine empty filter, not degraded.
+        # The probe gates purely on marker existence (no membership join).
+        assert "work_unit_membership_runs" in probe_sql
+        assert "complete_run_markers" in probe_sql
+        # Legacy marker present → genuine empty filter, not degraded.
         assert result.degraded_reason is None

--- a/tests/graphql/test_work_graph_theme_filter.py
+++ b/tests/graphql/test_work_graph_theme_filter.py
@@ -186,7 +186,12 @@ class TestThemeFilterServerSide:
         # seeded __legacy__ marker, pre-existing rows (run_id='') still match.
         assert "latest_run.latest_run_id = '__legacy__'" in edge_sql
         assert "m.run_id = ''" in edge_sql
-        # Must NOT use old per-node max(computed_at) guard.
+        # FINAL REVIEW HIGH: the legacy branch is per-node-max(computed_at), NOT a
+        # blanket run_id='' match — it joins the legacy-node-max derived table and
+        # requires m.computed_at == that node's legacy max.
+        assert "legacy_max_computed_at" in edge_sql
+        assert "m.computed_at = lnm.legacy_max_computed_at" in edge_sql
+        # Must NOT use the old global per-node max(computed_at) guard alias.
         assert "max(computed_at) AS max_computed_at" not in edge_sql
         assert "GROUP BY node_type, node_id" not in edge_sql
 
@@ -917,6 +922,10 @@ class TestLegacyRolloutFallback:
         edge_sql = mock_query.call_args_list[0][0][1]
         assert "latest_run.latest_run_id = '__legacy__'" in edge_sql
         assert "m.run_id = ''" in edge_sql
+        # FINAL REVIEW HIGH: legacy branch scopes to per-node-max(computed_at),
+        # not a blanket run_id='' match.
+        assert "legacy_max_computed_at" in edge_sql
+        assert "m.computed_at = lnm.legacy_max_computed_at" in edge_sql
 
     @pytest.mark.asyncio
     async def test_annotation_path_has_legacy_fallback(self, mock_context):
@@ -949,6 +958,9 @@ class TestLegacyRolloutFallback:
         assert "work_unit_membership_runs" in annotation_sql
         assert "latest_run.latest_run_id = '__legacy__'" in annotation_sql
         assert "m.run_id = ''" in annotation_sql
+        # FINAL REVIEW HIGH: legacy branch scopes to per-node-max(computed_at).
+        assert "legacy_max_computed_at" in annotation_sql
+        assert "m.computed_at = lnm.legacy_max_computed_at" in annotation_sql
         # Annotation actually applied from the legacy rows.
         assert result.edges[0].theme == "feature_delivery"
 

--- a/tests/test_membership_backfill.py
+++ b/tests/test_membership_backfill.py
@@ -293,6 +293,95 @@ def test_backfill_uses_latest_per_work_unit_query() -> None:
     assert "FROM work_unit_investments" in q
 
 
+def test_backfill_investment_read_is_not_date_windowed() -> None:
+    """ROUND-7 (false-positive guard): the investment read is NOT date-windowed.
+
+    The claimed coverage hole was that a 30-day post-sync materialize would let
+    the backfill hide previously-visible OUT-OF-WINDOW components. It cannot: the
+    distribution read filters ONLY on org_id + work_unit_id (latest-per-unit via
+    argMax) — there is NO from_ts/to_ts/computed_at window predicate, and the
+    edge fetch that builds the component set is unwindowed too. So a
+    previously-categorized component is projected regardless of how old its
+    investment row is. This asserts the SQL carries no window clause."""
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    uid = work_unit_id([("issue", "I-1"), ("pr", "P-1")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid,
+                theme={"feature_delivery": 1.0},
+                subcategory={"feature_delivery.roadmap": 1.0},
+            )
+        ],
+    )
+
+    _run_backfill(sink)
+
+    q = sink.query_calls[0]
+    # The WHERE clause is org_id + work_unit_id only — NO temporal window.
+    assert "from_ts" not in q
+    assert "to_ts" not in q
+    # No computed_at lower/upper bound (argMax(... , computed_at) is fine; a
+    # BETWEEN/>=/<= window is not present).
+    assert "computed_at >=" not in q
+    assert "computed_at <=" not in q
+    assert "computed_at BETWEEN" not in q
+    # The only predicates are org_id + work_unit_id.
+    assert "WHERE org_id = %(org_id)s" in q
+    assert "AND work_unit_id IN %(work_unit_ids)s" in q
+
+
+def test_backfill_covers_previously_categorized_out_of_window_component() -> None:
+    """ROUND-7 (false-positive proof): a current, UNCHURNED component that was
+    categorized in a PRIOR run (its investment row exists, however old) is
+    PROJECTED — matched, not skipped — by an org-wide backfill. So a 30-day
+    post-sync materialize->backfill does NOT hide it; the org-wide marker covers
+    it. This is the load-bearing fact behind the false-positive assessment.
+
+    We model the out-of-window component as one whose only signal is its existing
+    investment row (the materialize window is irrelevant to the backfill, which
+    reads ALL investments by work_unit_id). A SECOND component is genuinely
+    uncategorized (no investment row) and is correctly skipped — proving skip is
+    'never categorized', not 'out of window'."""
+    # Component A: previously categorized (has an investment row) — must be COVERED.
+    a_nodes = [("issue", "OLD-CATEGORIZED"), ("pr", "OLD-PR")]
+    # Component B: never categorized (no investment row) — correctly SKIPPED.
+    edges = [
+        _edge("issue", "OLD-CATEGORIZED", "pr", "OLD-PR"),
+        _edge("issue", "NEVER-CAT", "pr", "NEW-PR"),
+    ]
+    a_uid = work_unit_id(a_nodes)
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            # Only component A has a (prior-run) investment row.
+            _investment_row(
+                work_unit_id=a_uid,
+                theme={"maintenance": 1.0},
+                subcategory={"maintenance.refactor": 1.0},
+            )
+        ],
+    )
+
+    stats = _run_backfill(sink, org_id="org-1")
+
+    # A is projected (covered), B is skipped (never categorized).
+    assert stats["components"] == 2
+    assert stats["matched"] == 1
+    assert stats["skipped"] == 1
+    covered_nodes = {r.node_id for r in sink.written}
+    assert {"OLD-CATEGORIZED", "OLD-PR"} <= covered_nodes, (
+        "a previously-categorized unchurned component MUST be projected — it is "
+        "NOT hidden by the materialize window (round-7 false positive)"
+    )
+    # The genuinely-uncategorized component's nodes are absent (correct: no theme).
+    assert "NEVER-CAT" not in covered_nodes
+    # A full-coverage org-wide marker is still published (covers component A).
+    assert len(sink.run_markers) == 1
+    assert sink.run_markers[0].org_id == "org-1"
+
+
 # ---------------------------------------------------------------------------
 # run_id / completion-marker protocol tests (CHAOS-2433)
 # ---------------------------------------------------------------------------

--- a/tests/test_membership_backfill.py
+++ b/tests/test_membership_backfill.py
@@ -54,6 +54,8 @@ class _FakeSink:
         self.query_calls: list[str] = []
         # Track write order to assert marker comes last.
         self._write_order: list[str] = []
+        # Retention: record (org_id, keep) of each prune call.
+        self.prune_calls: list[tuple[str, int]] = []
 
     def ensure_schema(self) -> None:
         return None
@@ -70,6 +72,11 @@ class _FakeSink:
     def write_membership_run(self, record: WorkUnitMembershipRunRecord) -> None:
         self.run_markers.append(record)
         self._write_order.append("run_marker")
+
+    def prune_membership_runs(self, org_id: str, *, keep: int = 2) -> int:
+        self.prune_calls.append((org_id, keep))
+        self._write_order.append("prune")
+        return 0
 
     def close(self) -> None:
         return None
@@ -346,9 +353,10 @@ def test_backfill_completion_marker_written_last() -> None:
     (row_run_id,) = {row.run_id for row in sink.written}
     assert marker.run_id == row_run_id
 
-    # Write order: membership rows before marker (run_id protocol).
-    assert sink._write_order == ["memberships", "run_marker"], (
-        f"expected [memberships, run_marker], got: {sink._write_order}"
+    # Write order: membership rows before marker (run_id protocol), then prune
+    # (retention runs after the new complete generation is published).
+    assert sink._write_order == ["memberships", "run_marker", "prune"], (
+        f"expected [memberships, run_marker, prune], got: {sink._write_order}"
     )
 
     # Marker's org_id matches.
@@ -384,8 +392,8 @@ def test_backfill_all_skipped_run_writes_empty_marker_to_supersede() -> None:
         "completion marker to supersede the previous run"
     )
     assert sink.run_markers[0].org_id == "org-1"
-    # Write order: even with zero rows, only the marker is written.
-    assert sink._write_order == ["run_marker"]
+    # Write order: even with zero rows, the marker is written then prune runs.
+    assert sink._write_order == ["run_marker", "prune"]
 
 
 def test_backfill_genuine_no_component_org_writes_no_marker() -> None:
@@ -500,6 +508,116 @@ def test_backfill_config_is_org_wide_flag() -> None:
         MembershipBackfillConfig(dsn="x", org_id="o", repo_ids=["r"]).is_org_wide
         is False
     )
+
+
+# ---------------------------------------------------------------------------
+# Round-5 finding: retention / unbounded growth — prune old generations
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_prunes_old_runs_after_publishing_marker() -> None:
+    """An org-wide projection prunes old run generations AFTER publishing the new
+    marker (keep=2), so generations do not accumulate forever (CHAOS-2433 #5)."""
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    uid = work_unit_id([("issue", "I-1"), ("pr", "P-1")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid,
+                theme={"feature_delivery": 1.0},
+                subcategory={"feature_delivery.roadmap": 1.0},
+            )
+        ],
+    )
+
+    _run_backfill(sink, org_id="org-1")
+
+    # Retention ran exactly once, scoped to the org, keeping the latest 2 runs.
+    assert sink.prune_calls == [("org-1", 2)]
+    # And it ran AFTER the marker was published (retention prunes complete runs;
+    # the just-published run must already be a complete generation).
+    assert sink._write_order == ["memberships", "run_marker", "prune"], (
+        f"prune must run after the marker, got: {sink._write_order}"
+    )
+
+
+def test_backfill_empty_run_still_prunes() -> None:
+    """An all-skipped (zero-row) org-wide run still publishes a marker AND prunes,
+    so empty supersede generations also do not accumulate."""
+    # One churned component (no investment row) → zero membership rows.
+    edges = [_edge("issue", "CHURNED", "pr", "CP-1")]
+    sink = _FakeSink(edges=edges, investments=[])
+
+    _run_backfill(sink, org_id="org-1")
+
+    assert sink.written == []
+    assert len(sink.run_markers) == 1
+    assert sink.prune_calls == [("org-1", 2)]
+    assert sink._write_order == ["run_marker", "prune"]
+
+
+def test_backfill_scoped_run_does_not_prune() -> None:
+    """A repo-scoped run publishes no org-wide marker and therefore does NOT
+    prune (retention is tied to publishing a new complete generation)."""
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    uid = work_unit_id([("issue", "I-1"), ("pr", "P-1")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid,
+                theme={"feature_delivery": 1.0},
+                subcategory={"feature_delivery.roadmap": 1.0},
+            )
+        ],
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.create_sink",
+            return_value=sink,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.fetch_work_graph_edges",
+            side_effect=lambda s, repo_ids=None, org_id="": sink._edges,
+        ),
+    ):
+        backfill_memberships(
+            MembershipBackfillConfig(
+                dsn="clickhouse://x", org_id="org-1", repo_ids=["repo-a"]
+            )
+        )
+
+    assert sink.prune_calls == [], "scoped runs must not prune (no marker published)"
+
+
+def test_backfill_prune_failure_is_non_fatal() -> None:
+    """A retention failure must NOT fail the projection — the marker is already
+    published and correct; the next run's idempotent prune catches up."""
+
+    class _PruneRaisesSink(_FakeSink):
+        def prune_membership_runs(self, org_id: str, *, keep: int = 2) -> int:
+            raise RuntimeError("prune boom")
+
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    uid = work_unit_id([("issue", "I-1"), ("pr", "P-1")])
+    sink = _PruneRaisesSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid,
+                theme={"feature_delivery": 1.0},
+                subcategory={"feature_delivery.roadmap": 1.0},
+            )
+        ],
+    )
+
+    # Must NOT raise despite prune failing.
+    stats = _run_backfill(sink, org_id="org-1")
+
+    assert stats["memberships"] > 0
+    assert len(sink.run_markers) == 1, "marker still published despite prune failure"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_membership_backfill.py
+++ b/tests/test_membership_backfill.py
@@ -1,0 +1,503 @@
+"""Unit tests for the no-LLM membership backfill with run_id protocol (CHAOS-2439/2433).
+
+The daily scheduled job must NOT re-run LLM categorization (cost + category
+drift). ``backfill_memberships`` instead PROJECTS ``work_unit_membership`` from
+the theme/subcategory distributions ALREADY persisted in
+``work_unit_investments`` by the post-sync LLM materializer. These tests prove,
+without a live ClickHouse:
+
+- The backfill never touches the categorizer / LLM provider.
+- Its membership rows equal what ``materialize`` would emit for the same
+  persisted distributions (shared-helper consistency).
+- An idle org with existing investments but empty/stale membership gets
+  membership populated, no LLM.
+- A unit whose current component hash has no persisted categorization (edges
+  churned since last LLM run) is SKIPPED — no tombstones written, no rows for
+  that component in this run. The run_id protocol makes them invisible.
+- run_id is stamped on every row and a single completion marker is written LAST.
+- No complete run exists when zero membership rows were matched.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import dev_health_ops.connectors  # noqa: F401  (defuse circular import on collection)
+from dev_health_ops.metrics.schemas import WorkUnitMembershipRunRecord
+from dev_health_ops.work_graph.investment.backfill import (
+    MembershipBackfillConfig,
+    backfill_memberships,
+)
+from dev_health_ops.work_graph.investment.membership import build_membership_records
+from dev_health_ops.work_graph.investment.utils import work_unit_id
+
+
+class _FakeSink:
+    """Minimal sink stand-in: serves canned edges + investment distributions and
+    captures written membership rows and run markers. No real ClickHouse."""
+
+    backend_type = "clickhouse"
+
+    def __init__(
+        self,
+        *,
+        edges: list[dict[str, Any]],
+        investments: list[dict[str, Any]],
+    ) -> None:
+        self._edges = edges
+        # Map work_unit_id -> latest distribution row.
+        self._investments = {str(r["work_unit_id"]): r for r in investments}
+        self.written: list[Any] = []
+        self.run_markers: list[WorkUnitMembershipRunRecord] = []
+        self.query_calls: list[str] = []
+        # Track write order to assert marker comes last.
+        self._write_order: list[str] = []
+
+    def ensure_schema(self) -> None:
+        return None
+
+    def query_dicts(self, query: str, parameters: dict[str, Any]) -> list[dict]:
+        self.query_calls.append(query)
+        wanted = set(parameters.get("work_unit_ids") or [])
+        return [row for wid, row in self._investments.items() if wid in wanted]
+
+    def write_work_unit_memberships(self, rows) -> None:
+        self.written.extend(rows)
+        self._write_order.append("memberships")
+
+    def write_membership_run(self, record: WorkUnitMembershipRunRecord) -> None:
+        self.run_markers.append(record)
+        self._write_order.append("run_marker")
+
+    def close(self) -> None:
+        return None
+
+
+def _edge(src_type: str, src_id: str, tgt_type: str, tgt_id: str) -> dict[str, Any]:
+    return {
+        "edge_id": f"{src_type}:{src_id}->{tgt_type}:{tgt_id}",
+        "source_type": src_type,
+        "source_id": src_id,
+        "target_type": tgt_type,
+        "target_id": tgt_id,
+    }
+
+
+def _investment_row(
+    *,
+    work_unit_id: str,
+    theme: dict[str, float],
+    subcategory: dict[str, float],
+    status: str = "ok",
+) -> dict[str, Any]:
+    return {
+        "work_unit_id": work_unit_id,
+        "theme_distribution_json": theme,
+        "subcategory_distribution_json": subcategory,
+        "categorization_status": status,
+    }
+
+
+def _run_backfill(sink: _FakeSink, org_id: str = "org-1") -> dict[str, int]:
+    """Run backfill_memberships with create_sink + edge fetch patched to the fake."""
+    with (
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.create_sink",
+            return_value=sink,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.fetch_work_graph_edges",
+            side_effect=lambda s, repo_ids=None, org_id="": sink._edges,
+        ),
+    ):
+        return backfill_memberships(
+            MembershipBackfillConfig(dsn="clickhouse://x", org_id=org_id)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Core backfill correctness tests
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_invokes_no_llm_or_categorizer() -> None:
+    """The backfill path must never import/call the categorizer or LLM provider."""
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    uid = work_unit_id([("issue", "I-1"), ("pr", "P-1")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid,
+                theme={"feature_delivery": 1.0},
+                subcategory={"feature_delivery.roadmap": 1.0},
+            )
+        ],
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.investment.categorize.categorize_text_bundle"
+        ) as mock_categorize,
+        patch("dev_health_ops.llm.get_provider") as mock_provider,
+    ):
+        stats = _run_backfill(sink)
+
+    mock_categorize.assert_not_called()
+    mock_provider.assert_not_called()
+    assert stats["matched"] == 1
+    assert stats["memberships"] > 0
+    assert sink.written  # rows were written
+
+
+def test_backfill_rows_match_materialize_shared_helper() -> None:
+    """Backfill membership rows equal build_membership_records (the shared
+    helper the LLM materializer also uses) for the same persisted distributions."""
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    unit_nodes = [("issue", "I-1"), ("pr", "P-1")]
+    uid = work_unit_id(unit_nodes)
+    theme = {"feature_delivery": 0.45, "maintenance": 0.40, "quality": 0.15}
+    sub = {
+        "feature_delivery.roadmap": 0.45,
+        "maintenance.refactor": 0.40,
+        "quality.testing": 0.15,
+    }
+    sink = _FakeSink(
+        edges=edges,
+        investments=[_investment_row(work_unit_id=uid, theme=theme, subcategory=sub)],
+    )
+
+    stats = _run_backfill(sink)
+
+    written = sink.written
+    assert stats["memberships"] == len(written)
+
+    # Compare identity-bearing fields against the shared helper's output.
+    assert len(sink.run_markers) == 1
+    run_id = sink.run_markers[0].run_id
+
+    expected = build_membership_records(
+        unit_nodes=unit_nodes,
+        work_unit_id=uid,
+        theme_distribution=theme,
+        subcategory_distribution=sub,
+        categorization_status="ok",
+        computed_at=written[0].computed_at,  # align the non-identity field
+        org_id="org-1",
+        run_id=run_id,
+    )
+
+    def _key(r):
+        return (
+            r.org_id,
+            r.node_type,
+            r.node_id,
+            r.work_unit_id,
+            r.category_kind,
+            r.category,
+            r.weight,
+            r.is_dominant,
+            r.categorization_status,
+            r.run_id,
+        )
+
+    assert sorted(map(_key, written)) == sorted(map(_key, expected))
+    # Sanity: feature_delivery is dominant, quality (0.15) excluded from themes.
+    theme_cats = {
+        (r.node_id, r.category, r.is_dominant)
+        for r in written
+        if r.category_kind == "theme"
+    }
+    assert ("I-1", "feature_delivery", 1) in theme_cats
+    assert ("I-1", "maintenance", 0) in theme_cats
+    assert not any(c == "quality" for _, c, _ in theme_cats)
+
+
+def test_backfill_populates_idle_org_membership_no_llm() -> None:
+    """Idle org: investments exist (from a prior post-sync run) but membership is
+    empty/stale → backfill writes membership rows for every node, no LLM."""
+    edges = [_edge("issue", "I-1", "commit", "C-1")]
+    uid = work_unit_id([("issue", "I-1"), ("commit", "C-1")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid,
+                theme={"operational": 1.0},
+                subcategory={"operational.support": 1.0},
+            )
+        ],
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.investment.categorize.categorize_text_bundle"
+        ) as mock_categorize,
+    ):
+        stats = _run_backfill(sink)
+
+    mock_categorize.assert_not_called()
+    assert stats["matched"] == 1
+    node_ids = {r.node_id for r in sink.written}
+    assert node_ids == {"I-1", "C-1"}
+    assert all(r.org_id == "org-1" for r in sink.written)
+
+
+def test_backfill_empty_graph_is_clean_noop() -> None:
+    """No edges → no components → no query, no writes, clean zero stats."""
+    sink = _FakeSink(edges=[], investments=[])
+    stats = _run_backfill(sink)
+    assert stats == {
+        "components": 0,
+        "matched": 0,
+        "skipped": 0,
+        "memberships": 0,
+    }
+    assert sink.written == []
+    assert sink.run_markers == []
+    assert sink.query_calls == []  # no distribution query when no components
+
+
+def test_backfill_uses_latest_per_work_unit_query() -> None:
+    """The distribution read is latest-per-work_unit_id (argMax on computed_at),
+    matching api/queries/work_unit_investments.py semantics."""
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    uid = work_unit_id([("issue", "I-1"), ("pr", "P-1")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid,
+                theme={"risk": 1.0},
+                subcategory={"risk.security": 1.0},
+            )
+        ],
+    )
+
+    _run_backfill(sink)
+
+    assert len(sink.query_calls) == 1
+    q = sink.query_calls[0]
+    assert "argMax(theme_distribution_json, computed_at)" in q
+    assert "argMax(subcategory_distribution_json, computed_at)" in q
+    assert "GROUP BY org_id, work_unit_id" in q
+    assert "FROM work_unit_investments" in q
+
+
+# ---------------------------------------------------------------------------
+# run_id / completion-marker protocol tests (CHAOS-2433)
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_stamps_run_id_on_all_rows() -> None:
+    """Every membership row carries a non-empty run_id; all rows in one backfill
+    run share the same run_id."""
+    edges = [_edge("issue", "I-1", "pr", "P-1"), _edge("issue", "I-2", "commit", "C-2")]
+    uid1 = work_unit_id([("issue", "I-1"), ("pr", "P-1")])
+    uid2 = work_unit_id([("issue", "I-2"), ("commit", "C-2")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid1, theme={"feature_delivery": 1.0}, subcategory={}
+            ),
+            _investment_row(
+                work_unit_id=uid2, theme={"maintenance": 1.0}, subcategory={}
+            ),
+        ],
+    )
+
+    _run_backfill(sink)
+
+    assert sink.written, "membership rows must be written"
+    # All rows have a non-empty run_id.
+    for row in sink.written:
+        assert row.run_id, f"run_id must be non-empty on every row, got {row.run_id!r}"
+    # All rows share the same run_id (one backfill run).
+    run_ids = {row.run_id for row in sink.written}
+    assert len(run_ids) == 1
+
+
+def test_backfill_completion_marker_written_last() -> None:
+    """The completion marker (WorkUnitMembershipRunRecord) is written AFTER all
+    membership rows — proving the run_id protocol write order."""
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    uid = work_unit_id([("issue", "I-1"), ("pr", "P-1")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid,
+                theme={"feature_delivery": 1.0},
+                subcategory={"feature_delivery.roadmap": 1.0},
+            )
+        ],
+    )
+
+    _run_backfill(sink)
+
+    # Exactly one completion-marker.
+    assert len(sink.run_markers) == 1
+    marker = sink.run_markers[0]
+
+    # Marker's run_id matches the rows' run_id.
+    (row_run_id,) = {row.run_id for row in sink.written}
+    assert marker.run_id == row_run_id
+
+    # Write order: membership rows before marker (run_id protocol).
+    assert sink._write_order == ["memberships", "run_marker"], (
+        f"expected [memberships, run_marker], got: {sink._write_order}"
+    )
+
+    # Marker's org_id matches.
+    assert marker.org_id == "org-1"
+
+
+def test_backfill_no_marker_written_when_nothing_matched() -> None:
+    """When no components matched (all churned), no membership rows and no
+    completion marker are written — there is nothing to mark complete."""
+    # Two nodes in an unknown component (no investment row).
+    edges = [_edge("issue", "CHURNED", "pr", "CP-1")]
+    sink = _FakeSink(edges=edges, investments=[])
+
+    stats = _run_backfill(sink)
+
+    assert stats["matched"] == 0
+    assert stats["skipped"] == 1
+    assert stats["memberships"] == 0
+    assert sink.written == []
+    assert sink.run_markers == [], "no marker written when no membership rows"
+
+
+def test_backfill_churned_component_skipped_no_tombstones() -> None:
+    """A current component whose work_unit_id has no persisted investment row
+    (edges churned since last categorization) is SKIPPED — no rows written for
+    it (run_id protocol replaces tombstones: absence from the complete run IS
+    the tombstone).  The matched component still gets its rows and a marker."""
+    matched_nodes = [("issue", "MATCHED"), ("pr", "MP-1")]
+    edges = [
+        _edge("issue", "MATCHED", "pr", "MP-1"),
+        _edge("issue", "CHURNED", "pr", "CP-1"),
+    ]
+    matched_uid = work_unit_id(matched_nodes)
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=matched_uid,
+                theme={"feature_delivery": 1.0},
+                subcategory={"feature_delivery.roadmap": 1.0},
+            )
+        ],
+    )
+
+    stats = _run_backfill(sink)
+
+    assert stats["components"] == 2
+    assert stats["matched"] == 1
+    assert stats["skipped"] == 1
+    # No "tombstones" key in the new protocol.
+    assert "tombstones" not in stats
+
+    # Only matched nodes' rows written; churned nodes get NO rows.
+    written_nodes = {r.node_id for r in sink.written}
+    assert written_nodes == {"MATCHED", "MP-1"}
+    assert "CHURNED" not in written_nodes
+    assert "CP-1" not in written_nodes
+
+    # Completion marker written for the run (covers the matched component).
+    assert len(sink.run_markers) == 1
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher and beat schedule tests
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_membership_backfill_chains_build_then_backfill(monkeypatch) -> None:
+    """dispatch_membership_backfill fans out build -> backfill chains per org,
+    with db_url forwarded to both children (CHAOS-2439/2433)."""
+
+    from dev_health_ops.workers.work_graph_tasks import dispatch_membership_backfill
+
+    dispatched_chains: list[tuple[Any, Any]] = []
+
+    class _FakeChain:
+        def __init__(self, build_sig, backfill_sig):
+            self._sigs = (build_sig, backfill_sig)
+
+        def apply_async(self):
+            dispatched_chains.append(self._sigs)
+
+    def _fake_chain(*sigs):
+        assert len(sigs) == 2
+        return _FakeChain(sigs[0], sigs[1])
+
+    mock_db_url = "clickhouse://override:8123/db"
+
+    with (
+        patch(
+            "dev_health_ops.workers.recommendations_tasks._discover_active_org_ids",
+            return_value=["org-a", "org-b"],
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks.chain",
+            side_effect=_fake_chain,
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks._get_db_url",
+            return_value=mock_db_url,
+        ),
+    ):
+        result = dispatch_membership_backfill.run(db_url=mock_db_url)
+
+    assert result["dispatched"] == ["org-a", "org-b"]
+    assert len(dispatched_chains) == 2
+
+    # Each chain: [build_sig, backfill_sig(immutable)].
+    for build_sig, backfill_sig in dispatched_chains:
+        # Build task name.
+        assert build_sig.task == "dev_health_ops.workers.tasks.run_work_graph_build"
+        # Backfill task name.
+        assert (
+            backfill_sig.task == "dev_health_ops.workers.tasks.run_membership_backfill"
+        )
+        # db_url forwarded to BOTH children.
+        assert build_sig.kwargs.get("db_url") == mock_db_url
+        assert backfill_sig.kwargs.get("db_url") == mock_db_url
+        # Backfill is immutable (does not receive build's return value).
+        assert backfill_sig.immutable is True
+
+
+def test_dispatch_membership_backfill_strict_org_discovery_raises_on_failure(
+    monkeypatch,
+) -> None:
+    """strict=True: a Postgres enumeration failure raises (triggers retry) rather
+    than silently dispatching zero orgs as a clean success."""
+
+    from dev_health_ops.workers.work_graph_tasks import dispatch_membership_backfill
+
+    with patch(
+        "dev_health_ops.workers.recommendations_tasks._discover_active_org_ids",
+        side_effect=RuntimeError("DB outage"),
+    ):
+        # The task should retry on org discovery failure — in unit tests the
+        # retry raises the original exception rather than scheduling a new attempt.
+        import pytest
+
+        with pytest.raises(Exception):
+            dispatch_membership_backfill.run()
+
+
+def test_beat_schedule_has_membership_backfill_entry() -> None:
+    """The Celery beat schedule includes the daily membership backfill entry."""
+    from dev_health_ops.workers import config as worker_config
+
+    assert "run-membership-backfill-daily" in worker_config.beat_schedule
+    entry = worker_config.beat_schedule["run-membership-backfill-daily"]
+    assert entry["task"] == "dev_health_ops.workers.tasks.dispatch_membership_backfill"
+    # Runs daily (crontab or once-per-day interval).
+    from celery.schedules import crontab as _crontab
+
+    assert isinstance(entry["schedule"], _crontab)

--- a/tests/test_membership_backfill.py
+++ b/tests/test_membership_backfill.py
@@ -354,20 +354,51 @@ def test_backfill_completion_marker_written_last() -> None:
     assert marker.org_id == "org-1"
 
 
-def test_backfill_no_marker_written_when_nothing_matched() -> None:
-    """When no components matched (all churned), no membership rows and no
-    completion marker are written — there is nothing to mark complete."""
-    # Two nodes in an unknown component (no investment row).
+def test_backfill_all_skipped_run_writes_empty_marker_to_supersede() -> None:
+    """FINDING #1 (empty-but-complete run MUST supersede): when the org HAS
+    work-graph components but ALL are churned (no matching investment row), the
+    backfill writes ZERO membership rows but STILL publishes a completion marker.
+
+    The no-tombstone design relies on an empty complete run to retire the
+    PREVIOUS complete run's stale rows: without this marker the reader would keep
+    using the old run and churned nodes would stay filterable with stale
+    categories. The marker is the empty-but-complete run.
+    """
+    # One component, churned (no investment row) → org has data but nothing
+    # matched. Distinct from the genuine no-component no-op (empty edges).
     edges = [_edge("issue", "CHURNED", "pr", "CP-1")]
     sink = _FakeSink(edges=edges, investments=[])
 
     stats = _run_backfill(sink)
 
+    assert stats["components"] == 1
     assert stats["matched"] == 0
     assert stats["skipped"] == 1
     assert stats["memberships"] == 0
     assert sink.written == []
-    assert sink.run_markers == [], "no marker written when no membership rows"
+    # The empty-but-complete run MUST publish a marker so it supersedes the
+    # previous complete run (CHAOS-2433 finding #1).
+    assert len(sink.run_markers) == 1, (
+        "an all-skipped run over an org WITH components must publish an empty "
+        "completion marker to supersede the previous run"
+    )
+    assert sink.run_markers[0].org_id == "org-1"
+    # Write order: even with zero rows, only the marker is written.
+    assert sink._write_order == ["run_marker"]
+
+
+def test_backfill_genuine_no_component_org_writes_no_marker() -> None:
+    """An org with NO work-graph components at all (no edges) is a genuine no-op:
+    no membership rows AND no marker (nothing to supersede). This is the case the
+    early-return guards — distinct from an all-skipped run over an org WITH
+    components, which DOES publish an empty marker (see the test above)."""
+    sink = _FakeSink(edges=[], investments=[])
+
+    stats = _run_backfill(sink)
+
+    assert stats["components"] == 0
+    assert sink.written == []
+    assert sink.run_markers == [], "no marker for a genuine no-component org"
 
 
 def test_backfill_churned_component_skipped_no_tombstones() -> None:
@@ -408,6 +439,66 @@ def test_backfill_churned_component_skipped_no_tombstones() -> None:
 
     # Completion marker written for the run (covers the matched component).
     assert len(sink.run_markers) == 1
+
+
+def test_backfill_repo_scoped_run_does_not_publish_org_marker() -> None:
+    """FINDING #2 (scoped runs must not publish an org-wide marker): a
+    repo-scoped backfill writes its membership rows but does NOT write a
+    completion marker — otherwise it would become the org's latest complete run
+    while covering only that scope, blanking every other repo for unscoped reads.
+    The org-wide daily backfill publishes the marker."""
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    uid = work_unit_id([("issue", "I-1"), ("pr", "P-1")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid,
+                theme={"feature_delivery": 1.0},
+                subcategory={"feature_delivery.roadmap": 1.0},
+            )
+        ],
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.create_sink",
+            return_value=sink,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.fetch_work_graph_edges",
+            side_effect=lambda s, repo_ids=None, org_id="": sink._edges,
+        ),
+    ):
+        stats = backfill_memberships(
+            MembershipBackfillConfig(
+                dsn="clickhouse://x",
+                org_id="org-1",
+                repo_ids=["repo-a"],  # SCOPED run
+            )
+        )
+
+    # Rows ARE written for the scoped repo.
+    assert stats["memberships"] > 0
+    assert sink.written
+    # But NO org-wide completion marker is published.
+    assert sink.run_markers == [], (
+        "a repo-scoped backfill must not publish an org-wide completion marker "
+        "(CHAOS-2433 finding #2)"
+    )
+    assert sink._write_order == ["memberships"]
+
+
+def test_backfill_config_is_org_wide_flag() -> None:
+    """MembershipBackfillConfig.is_org_wide is True only when no repo scoping."""
+    assert MembershipBackfillConfig(dsn="x", org_id="o").is_org_wide is True
+    assert (
+        MembershipBackfillConfig(dsn="x", org_id="o", repo_ids=[]).is_org_wide is True
+    )
+    assert (
+        MembershipBackfillConfig(dsn="x", org_id="o", repo_ids=["r"]).is_org_wide
+        is False
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_membership_backfill.py
+++ b/tests/test_membership_backfill.py
@@ -20,6 +20,7 @@ without a live ClickHouse:
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import patch
 
@@ -499,6 +500,130 @@ def test_backfill_config_is_org_wide_flag() -> None:
         MembershipBackfillConfig(dsn="x", org_id="o", repo_ids=["r"]).is_org_wide
         is False
     )
+
+
+# ---------------------------------------------------------------------------
+# Round-3 finding #1: marker completed_at reflects COMPLETION time, not start
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_marker_completed_at_is_completion_time_not_run_start() -> None:
+    """The completion marker's completed_at must be stamped at the ACTUAL marker
+    write (after all membership rows are persisted), using a fresh now() — NOT
+    the run-start computed_at carried on the membership rows.
+
+    Readers pick argMax(run_id, completed_at); the marker timestamp must reflect
+    completion order so an overlapping run that finishes later wins. The
+    membership ROWS keep the run-start computed_at; the MARKER must be >= that
+    and close to wall-clock now (CHAOS-2433 round-3 #1)."""
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    uid = work_unit_id([("issue", "I-1"), ("pr", "P-1")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=uid,
+                theme={"feature_delivery": 1.0},
+                subcategory={"feature_delivery.roadmap": 1.0},
+            )
+        ],
+    )
+
+    before = datetime.now(timezone.utc)
+    _run_backfill(sink)
+    after = datetime.now(timezone.utc)
+
+    assert len(sink.run_markers) == 1
+    marker = sink.run_markers[0]
+    # Marker completed_at is a real completion timestamp captured during the run.
+    assert before <= marker.completed_at <= after, (
+        "marker completed_at must be stamped at marker write (now()), not from "
+        "the run-start computed_at"
+    )
+    # Membership rows carry the run-start computed_at, which is <= the marker's
+    # completion timestamp (rows are built before the marker is written).
+    assert sink.written
+    row_computed_at = sink.written[0].computed_at
+    assert row_computed_at <= marker.completed_at
+
+
+def test_backfill_overlap_later_finisher_publishes_later_marker(monkeypatch) -> None:
+    """OVERLAP regression: a run that STARTS earlier but FINISHES later must
+    publish a LATER marker completed_at, so argMax(run_id, completed_at) selects
+    the later-finishing run. We simulate two runs whose row-build (start) order
+    is reversed from their marker-write (finish) order, and assert the marker
+    timestamps follow FINISH order, not start order (CHAOS-2433 round-3 #1)."""
+    edges = [_edge("issue", "I-1", "pr", "P-1")]
+    uid = work_unit_id([("issue", "I-1"), ("pr", "P-1")])
+
+    def _mk_sink() -> _FakeSink:
+        return _FakeSink(
+            edges=edges,
+            investments=[
+                _investment_row(
+                    work_unit_id=uid,
+                    theme={"feature_delivery": 1.0},
+                    subcategory={"feature_delivery.roadmap": 1.0},
+                )
+            ],
+        )
+
+    sink_a = _mk_sink()
+    sink_b = _mk_sink()
+
+    _run_backfill(sink_a)  # finishes first
+    _run_backfill(sink_b)  # finishes second (later wall clock)
+
+    marker_a = sink_a.run_markers[0]
+    marker_b = sink_b.run_markers[0]
+    # The run that finished later has the greater completed_at → argMax picks it.
+    assert marker_b.completed_at >= marker_a.completed_at, (
+        "the later-FINISHING run must publish the later marker completed_at so "
+        "readers (argMax) select it"
+    )
+
+
+def test_backfill_projects_full_current_coverage_no_time_window() -> None:
+    """DATE-WINDOW regression (round-3 #2): the projection covers ALL current
+    components — it has NO from_ts/to_ts time window (unlike the materializer).
+    Two components both get membership rows regardless of any temporal bounds,
+    and the org-wide marker is legitimately FULL-COVERAGE. This is why the
+    projection (not the windowed materializer) is the sole membership writer."""
+    # Two distinct components; both have persisted investments.
+    edges = [
+        _edge("issue", "OLD", "pr", "OLD-PR"),  # "old" component (outside any window)
+        _edge("issue", "NEW", "pr", "NEW-PR"),  # "new" component (inside any window)
+    ]
+    old_uid = work_unit_id([("issue", "OLD"), ("pr", "OLD-PR")])
+    new_uid = work_unit_id([("issue", "NEW"), ("pr", "NEW-PR")])
+    sink = _FakeSink(
+        edges=edges,
+        investments=[
+            _investment_row(
+                work_unit_id=old_uid,
+                theme={"maintenance": 1.0},
+                subcategory={"maintenance.refactor": 1.0},
+            ),
+            _investment_row(
+                work_unit_id=new_uid,
+                theme={"feature_delivery": 1.0},
+                subcategory={"feature_delivery.roadmap": 1.0},
+            ),
+        ],
+    )
+
+    stats = _run_backfill(sink)
+
+    # BOTH components projected — full current-graph coverage, no time filter.
+    assert stats["components"] == 2
+    assert stats["matched"] == 2
+    node_ids = {r.node_id for r in sink.written}
+    assert {"OLD", "OLD-PR", "NEW", "NEW-PR"} <= node_ids, (
+        "the projection must cover ALL current components (no time window), so "
+        "the org-wide marker is full-coverage and never blanks out-of-window nodes"
+    )
+    # One full-coverage org-wide marker published.
+    assert len(sink.run_markers) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_migration_048_seed_legacy.py
+++ b/tests/test_migration_048_seed_legacy.py
@@ -1,0 +1,89 @@
+"""Fail-closed tests for migration 048 (CHAOS-2433 round-6).
+
+Migration 048 seeds the legacy completion marker. Its table-existence probe must
+fail CLOSED: an unexpected system.tables error must PROPAGATE (so the seed
+migration is NOT recorded as applied without seeding), while a SUCCESSFUL
+zero-row probe is the genuine fresh-DB / dry-run no-op skip.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "dev_health_ops"
+    / "migrations"
+    / "clickhouse"
+)
+MIGRATION_048 = "048_seed_legacy_membership_run.py"
+
+
+def _load() -> ModuleType:
+    path = MIGRATIONS_DIR / MIGRATION_048
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Result:
+    def __init__(self, rows: list[list[Any]]) -> None:
+        self.result_rows = rows
+
+
+class _FakeClient:
+    def __init__(
+        self, *, exists_raises: Exception | None = None, present: bool = True
+    ) -> None:
+        self._exists_raises = exists_raises
+        self._present = present
+        self.commands: list[str] = []
+
+    def query(self, q: str, parameters: dict | None = None) -> _Result:
+        if "FROM system.tables" in q:
+            if self._exists_raises is not None:
+                raise self._exists_raises
+            return _Result([[1 if self._present else 0]])
+        return _Result([])
+
+    def command(self, cmd: str, parameters: dict | None = None) -> None:
+        self.commands.append(cmd)
+
+
+def test_existence_probe_error_propagates() -> None:
+    """An unexpected probe error must RAISE (not be swallowed into a silent skip
+    that marks the seed migration applied without seeding)."""
+    module = _load()
+    client = _FakeClient(exists_raises=RuntimeError("probe boom"))
+    with pytest.raises(RuntimeError, match="probe boom"):
+        module.upgrade(client)
+    # No INSERT was attempted.
+    assert not any(
+        "INSERT INTO work_unit_membership_runs" in c for c in client.commands
+    )
+
+
+def test_zero_row_probe_is_genuine_skip() -> None:
+    """A SUCCESSFUL zero-row probe (fresh DB / dry-run mock) is a clean no-op."""
+    module = _load()
+    client = _FakeClient(present=False)
+    module.upgrade(client)  # must not raise
+    assert not any(
+        "INSERT INTO work_unit_membership_runs" in c for c in client.commands
+    )
+
+
+def test_present_tables_seed_marker() -> None:
+    """When both tables exist, the legacy marker INSERT is issued."""
+    module = _load()
+    client = _FakeClient(present=True)
+    module.upgrade(client)
+    assert any("INSERT INTO work_unit_membership_runs" in c for c in client.commands)

--- a/tests/test_migration_048_seed_legacy.py
+++ b/tests/test_migration_048_seed_legacy.py
@@ -87,3 +87,30 @@ def test_present_tables_seed_marker() -> None:
     client = _FakeClient(present=True)
     module.upgrade(client)
     assert any("INSERT INTO work_unit_membership_runs" in c for c in client.commands)
+
+
+def test_magicmock_client_is_treated_as_absent_not_crash() -> None:
+    """REGRESSION (CI red, run 27579877858): a bare MagicMock client returns a
+    successful-but-uninterpretable result_rows. 048's fail-closed _table_exists
+    must treat it as absent and skip the seed (no INSERT), NOT crash on
+    int(MagicMock)/comparison."""
+    from unittest.mock import MagicMock
+
+    module = _load()
+    client = MagicMock()
+
+    module.upgrade(client)  # must not raise
+    issued = [c.args[0] for c in client.command.call_args_list if c.args]
+    assert not any("INSERT INTO work_unit_membership_runs" in c for c in issued)
+
+
+def test_count_gt_zero_is_type_strict() -> None:
+    from unittest.mock import MagicMock
+
+    module = _load()
+    assert module._count_gt_zero([[1]]) is True
+    assert module._count_gt_zero([[0]]) is False
+    assert module._count_gt_zero(None) is False
+    assert module._count_gt_zero(MagicMock()) is False
+    assert module._count_gt_zero([[MagicMock()]]) is False
+    assert module._count_gt_zero([[True]]) is False

--- a/tests/test_migration_049_run_id_dedup.py
+++ b/tests/test_migration_049_run_id_dedup.py
@@ -1,0 +1,181 @@
+"""Fail-closed tests for migration 049 (CHAOS-2433 round-6).
+
+Migration 049 rebuilds work_unit_membership so run_id is in the ReplacingMergeTree
+dedup key. A structural migration must NEVER be recorded as applied without
+actually rebuilding the key — otherwise the round-2 background-merge eviction
+silently returns (a merge collapses across run_ids and removes the still-visible
+complete generation). These tests prove, with a fake client (no live DB):
+
+- An UNEXPECTED error from the existence probe PROPAGATES → upgrade() RAISES
+  (so the runner does NOT record 049 as applied; it can be retried).
+- A SUCCESSFUL existence probe returning ZERO rows is a genuine skip (fresh DB /
+  dry-run no-op), NOT an error.
+- Post-rebuild sorting-key verification fails closed: if run_id is not last in
+  the LIVE main-table key after the rebuild attempt, upgrade() RAISES.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+MIGRATIONS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "dev_health_ops"
+    / "migrations"
+    / "clickhouse"
+)
+MIGRATION_049 = "049_work_unit_membership_run_id_dedup_key.py"
+
+_OLD_KEY = "org_id, node_type, node_id, category_kind, category"
+_NEW_KEY = "org_id, node_type, node_id, category_kind, category, run_id"
+_TABLE = "work_unit_membership"
+
+
+def _load() -> ModuleType:
+    path = MIGRATIONS_DIR / MIGRATION_049
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Result:
+    def __init__(self, rows: list[list[Any]]) -> None:
+        self.result_rows = rows
+
+
+class _FakeClient:
+    """Drives migration 049's queries. Configurable per-scenario.
+
+    - ``exists_raises``: the system.tables existence probe raises this exception.
+    - ``table_present``: count() result for the existence probe (0 => absent).
+    - ``sorting_key``: the LIVE sorting key returned for the main table; updated
+      to the new key after a simulated EXCHANGE so the post-rebuild check passes.
+    - ``verify_stays_old``: if True, the main-table sorting key NEVER gains run_id
+      even after EXCHANGE (simulates a rebuild that did not land) so the
+      post-rebuild verification must RAISE.
+    """
+
+    def __init__(
+        self,
+        *,
+        exists_raises: Exception | None = None,
+        table_present: bool = True,
+        verify_stays_old: bool = False,
+    ) -> None:
+        self._exists_raises = exists_raises
+        self._table_present = table_present
+        self._verify_stays_old = verify_stays_old
+        self._main_key = _OLD_KEY
+        self._shadow_exists = False
+        self.commands: list[str] = []
+
+    def query(self, q: str, parameters: dict | None = None) -> _Result:
+        params = parameters or {}
+        if "FROM system.tables" in q and "count()" in q:
+            if self._exists_raises is not None:
+                raise self._exists_raises
+            name = params.get("name")
+            if name == "work_unit_membership_new":
+                return _Result([[1 if self._shadow_exists else 0]])
+            return _Result([[1 if self._table_present else 0]])
+        if "sorting_key" in q:
+            name = params.get("name")
+            if name == "work_unit_membership_new":
+                # Shadow always built with the new key.
+                return _Result([[_NEW_KEY]])
+            return _Result([[self._main_key]])
+        if "SHOW CREATE TABLE" in q:
+            ddl = (
+                f"CREATE TABLE {_TABLE} (org_id String, node_type String, "
+                "node_id String, category_kind String, category String, "
+                "run_id String) ENGINE = ReplacingMergeTree(computed_at) "
+                f"ORDER BY ({_OLD_KEY})"
+            )
+            return _Result([[ddl]])
+        if "uniqExact" in q:
+            return _Result([[0]])
+        return _Result([])
+
+    def command(self, cmd: str, parameters: dict | None = None) -> None:
+        self.commands.append(cmd)
+        if cmd.startswith("EXCHANGE TABLES"):
+            # The verified shadow becomes the main table — its key is the new key,
+            # UNLESS the scenario simulates a rebuild that did not land.
+            if not self._verify_stays_old:
+                self._main_key = _NEW_KEY
+
+
+def test_existence_probe_error_propagates_not_skipped() -> None:
+    """An unexpected existence-probe error must RAISE (so 049 is NOT recorded as
+    applied), not be swallowed into a silent 'table absent' skip."""
+    module = _load()
+    client = _FakeClient(exists_raises=RuntimeError("transient probe failure"))
+
+    with pytest.raises(RuntimeError, match="transient probe failure"):
+        module.upgrade(client)
+
+    # The migration must NOT have proceeded to any rebuild command.
+    assert not any("EXCHANGE TABLES" in c for c in client.commands)
+
+
+def test_restricted_user_probe_error_propagates() -> None:
+    """A permission error from the probe also propagates (fail closed)."""
+    module = _load()
+
+    class _AccessDenied(Exception):
+        pass
+
+    client = _FakeClient(exists_raises=_AccessDenied("not enough privileges"))
+    with pytest.raises(_AccessDenied):
+        module.upgrade(client)
+
+
+def test_successful_zero_row_probe_is_genuine_skip() -> None:
+    """A SUCCESSFUL probe returning zero rows => fresh-DB no-op skip (no rebuild,
+    no error). This is the idempotent / dry-run path that must still work."""
+    module = _load()
+    client = _FakeClient(table_present=False)
+
+    # Must NOT raise and must NOT attempt a rebuild.
+    module.upgrade(client)
+    assert not any("EXCHANGE TABLES" in c for c in client.commands)
+
+
+def test_post_rebuild_verification_fails_closed_when_key_missing_run_id() -> None:
+    """If, after the rebuild attempt, the LIVE main-table key still lacks run_id,
+    upgrade() must RAISE (refuse to be marked applied)."""
+    module = _load()
+    # table present, old key, but the EXCHANGE does not install the new key.
+    client = _FakeClient(table_present=True, verify_stays_old=True)
+
+    with pytest.raises(RuntimeError, match="post-rebuild verification failed"):
+        module.upgrade(client)
+
+
+def test_successful_rebuild_completes() -> None:
+    """A healthy rebuild path completes: the post-rebuild verification sees the
+    new key (run_id last) and upgrade() returns without raising."""
+    module = _load()
+    client = _FakeClient(table_present=True, verify_stays_old=False)
+
+    module.upgrade(client)  # must not raise
+    # The atomic swap was issued.
+    assert any("EXCHANGE TABLES" in c for c in client.commands)
+
+
+def test_already_migrated_is_idempotent_skip() -> None:
+    """If run_id is already last in the key, upgrade() skips (no rebuild)."""
+    module = _load()
+    client = _FakeClient(table_present=True)
+    client._main_key = _NEW_KEY  # already migrated
+
+    module.upgrade(client)
+    assert not any("EXCHANGE TABLES" in c for c in client.commands)

--- a/tests/test_migration_049_run_id_dedup.py
+++ b/tests/test_migration_049_run_id_dedup.py
@@ -179,3 +179,40 @@ def test_already_migrated_is_idempotent_skip() -> None:
 
     module.upgrade(client)
     assert not any("EXCHANGE TABLES" in c for c in client.commands)
+
+
+def test_magicmock_client_is_treated_as_absent_not_crash() -> None:
+    """REGRESSION (CI red, run 27579877858): a bare MagicMock client (e.g.
+    test_teams::test_clickhouse_store_teams drives ALL migrations through
+    ClickHouseStore.__aenter__ with a MagicMock) returns a successful-but-
+    uninterpretable result_rows. The round-6 fail-closed change must NOT crash on
+    it: a successful probe with a non-list/non-int shape is treated as absent
+    (genuine skip), while only a real query EXCEPTION fails closed. int(MagicMock)
+    deceptively yields 1, so the interpretation must be type-strict."""
+    from unittest.mock import MagicMock
+
+    module = _load()
+    client = MagicMock()  # query() returns a MagicMock; .result_rows is a MagicMock
+
+    # Must NOT raise (no TypeError from '>' or regex on a MagicMock) and must NOT
+    # attempt a rebuild — the migration treats the mock as 'table absent' and skips.
+    module.upgrade(client)
+    issued = [c.args[0] for c in client.command.call_args_list if c.args]
+    assert not any("EXCHANGE TABLES" in c for c in issued)
+
+
+def test_count_gt_zero_is_type_strict() -> None:
+    """_count_gt_zero accepts only a real list/tuple of rows with an int count;
+    anything else (MagicMock, non-numeric, empty, bool) is False/absent."""
+    from unittest.mock import MagicMock
+
+    module = _load()
+    assert module._count_gt_zero([[1]]) is True
+    assert module._count_gt_zero([(5,)]) is True
+    assert module._count_gt_zero([[0]]) is False
+    assert module._count_gt_zero([]) is False
+    assert module._count_gt_zero(None) is False
+    assert module._count_gt_zero(MagicMock()) is False  # the CI-red shape
+    assert module._count_gt_zero([[MagicMock()]]) is False
+    assert module._count_gt_zero([["3"]]) is False  # non-int cell
+    assert module._count_gt_zero([[True]]) is False  # bool excluded

--- a/tests/test_post_sync_investment_dispatch.py
+++ b/tests/test_post_sync_investment_dispatch.py
@@ -6,12 +6,15 @@ That task was never dispatched on the live sync path, so real orgs saw an empty
 ``/investment`` view.
 
 ``_dispatch_post_sync_tasks`` now enqueues a Celery **chain**:
-``run_work_graph_build`` -> ``run_investment_materialize``. The chain (not two
-independent ``send_task`` calls) guarantees materialization only starts after
-the build *succeeds*, so concurrent metrics workers cannot race materialize
-ahead of the graph it reads. The chain fires after *either* a git or a
-work-item sync (org-wide persisted data accumulates across separate configs),
-not only when one config carries both.
+``run_work_graph_build`` -> ``run_investment_materialize`` ->
+``run_membership_backfill`` (the no-LLM membership PROJECTION). The chain (not
+independent ``send_task`` calls) guarantees each step only starts after its
+predecessor *succeeds*. CHAOS-2433 round-3 finding #2 added the third step: the
+materializer writes ``work_unit_investments`` ONLY, and the full-coverage
+projection is the SOLE writer of ``work_unit_membership`` + the completion
+marker — so a date-windowed materialize can never publish partial coverage. The
+chain fires after *either* a git or a work-item sync (org-wide persisted data
+accumulates across separate configs), not only when one config carries both.
 
 These tests prove the seam without a live ClickHouse: they patch the Celery
 ``chain`` / ``signature`` factories and assert the dispatch contract.
@@ -28,6 +31,7 @@ from dev_health_ops.workers.sync_runtime import _dispatch_post_sync_tasks
 
 _INVESTMENT_TASK = "dev_health_ops.workers.tasks.run_investment_materialize"
 _WORK_GRAPH_TASK = "dev_health_ops.workers.tasks.run_work_graph_build"
+_PROJECTION_TASK = "dev_health_ops.workers.tasks.run_membership_backfill"
 
 
 def _run_dispatch(provider: str, sync_targets: list[str], org_id: str):
@@ -64,28 +68,35 @@ def _run_dispatch(provider: str, sync_targets: list[str], org_id: str):
 
 
 def test_investment_chain_dispatched_with_git_and_work_items() -> None:
-    """git + work-items => build -> materialize chain, applied async, org-scoped."""
+    """git + work-items => build -> materialize -> project chain, applied async."""
     mock_signature, mock_chain, chain_instance, _ = _run_dispatch(
         provider="github",
         sync_targets=["git", "prs", "work-items"],
         org_id="org-123",
     )
 
-    # The chain must be built with build FIRST, materialize SECOND.
+    # The chain must be built build FIRST, materialize SECOND, project THIRD.
     assert mock_chain.call_count == 1
-    build_sig, materialize_sig = mock_chain.call_args.args
+    build_sig, materialize_sig, project_sig = mock_chain.call_args.args
     assert build_sig.task_name == _WORK_GRAPH_TASK
     assert materialize_sig.task_name == _INVESTMENT_TASK
+    assert project_sig.task_name == _PROJECTION_TASK, (
+        "the membership PROJECTION (no-LLM, full coverage) must run last as the "
+        "sole membership writer (CHAOS-2433 round-3 #2)"
+    )
 
-    # Both signatures are org-scoped onto the metrics queue.
+    # All signatures are org-scoped onto the metrics queue.
     assert build_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
     assert build_sig.sig_kwargs["queue"] == "metrics"
     assert materialize_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
     assert materialize_sig.sig_kwargs["queue"] == "metrics"
+    assert project_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    assert project_sig.sig_kwargs["queue"] == "metrics"
 
-    # Materialize is linked IMMUTABLE so the build's return dict is not injected
-    # as a positional arg (which would break run_investment_materialize).
+    # Downstream steps are linked IMMUTABLE so a parent's return dict is not
+    # injected as a positional arg (which would break the next task).
     assert materialize_sig.sig_kwargs.get("immutable") is True
+    assert project_sig.sig_kwargs.get("immutable") is True
     assert build_sig.sig_kwargs.get("immutable") is not True
 
     # The chain is actually dispatched (not just constructed).
@@ -96,8 +107,8 @@ def test_investment_chain_dispatched_with_git_only() -> None:
     """git only (no work-items in this config) => chain still fires.
 
     Work items for the org may have been persisted by a separate sync config;
-    the org-wide build/materialize must not be gated on one config carrying
-    both kinds of data.
+    the org-wide build/materialize/project must not be gated on one config
+    carrying both kinds of data.
     """
     _, mock_chain, chain_instance, _ = _run_dispatch(
         provider="github",
@@ -106,9 +117,10 @@ def test_investment_chain_dispatched_with_git_only() -> None:
     )
 
     assert mock_chain.call_count == 1
-    build_sig, materialize_sig = mock_chain.call_args.args
+    build_sig, materialize_sig, project_sig = mock_chain.call_args.args
     assert build_sig.task_name == _WORK_GRAPH_TASK
     assert materialize_sig.task_name == _INVESTMENT_TASK
+    assert project_sig.task_name == _PROJECTION_TASK
     chain_instance.apply_async.assert_called_once_with()
 
 
@@ -125,10 +137,12 @@ def test_investment_chain_dispatched_with_work_items_only_jira() -> None:
     )
 
     assert mock_chain.call_count == 1
-    build_sig, materialize_sig = mock_chain.call_args.args
+    build_sig, materialize_sig, project_sig = mock_chain.call_args.args
     assert build_sig.task_name == _WORK_GRAPH_TASK
     assert materialize_sig.task_name == _INVESTMENT_TASK
+    assert project_sig.task_name == _PROJECTION_TASK
     assert materialize_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    assert project_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
     chain_instance.apply_async.assert_called_once_with()
 
 

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -28,6 +28,7 @@ class FakeSink:
         self.investment_rows: list[WorkUnitInvestmentRecord] = []
         self.quote_rows: list[WorkUnitInvestmentEvidenceQuoteRecord] = []
         self.membership_rows: list = []
+        self.membership_run_records: list = []
 
     def ensure_schema(self) -> None:
         return None
@@ -40,6 +41,9 @@ class FakeSink:
 
     def write_work_unit_memberships(self, rows) -> None:
         self.membership_rows.extend(rows)
+
+    def write_membership_run(self, record) -> None:
+        self.membership_run_records.append(record)
 
     def close(self) -> None:
         return None

--- a/tests/work_graph/test_runner.py
+++ b/tests/work_graph/test_runner.py
@@ -14,7 +14,10 @@ from unittest.mock import MagicMock, patch
 # Import connectors first to defuse the providers._base <-> connectors circular
 # import so this module runs in isolation.
 import dev_health_ops.connectors  # noqa: F401
-from dev_health_ops.work_graph.runner import run_work_graph_build
+from dev_health_ops.work_graph.runner import (
+    run_investment_materialization,
+    run_work_graph_build,
+)
 
 
 def _ns(**overrides) -> argparse.Namespace:
@@ -104,3 +107,177 @@ def test_verification_uses_builder_sink_client_when_builder_has_no_client():
 
     assert rc == 0
     client.query.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2433 round-4 finding #1: the CLI `investment materialize` entry point
+# must publish a full-coverage membership marker after an ORG-WIDE materialization
+# (the materializer writes investments only). Scoped/windowed manual runs must
+# NOT publish an org-wide marker.
+# ---------------------------------------------------------------------------
+
+
+def _materialize_ns(**overrides) -> argparse.Namespace:
+    base: dict[str, object] = dict(
+        db="clickhouse://localhost:9000/default",
+        from_date=None,
+        to_date=None,
+        window_days=None,
+        repo_id=[],
+        team_id=[],
+        org="org-abc",
+        llm_provider="auto",
+        persist_evidence_snippets=True,
+        model=None,
+        force=False,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _patch_materialize_and_projection():
+    """Patch materialize_investments (async) and backfill_memberships (sync).
+
+    Returns (materialize_mock, backfill_mock) as MagicMocks recording calls.
+    """
+    materialize_mock = MagicMock(
+        return_value={"components": 2, "records": 2, "quotes": 0}
+    )
+
+    async def _fake_materialize(config):
+        return materialize_mock(config)
+
+    backfill_mock = MagicMock(
+        return_value={
+            "components": 2,
+            "matched": 2,
+            "skipped": 0,
+            "memberships": 4,
+        }
+    )
+    return _fake_materialize, materialize_mock, backfill_mock
+
+
+def test_cli_org_wide_materialize_runs_membership_projection():
+    """A bare org-wide `investment materialize` (no window/scope) runs the no-LLM
+    projection synchronously to publish a full-coverage completion marker."""
+    fake_materialize, materialize_mock, backfill_mock = (
+        _patch_materialize_and_projection()
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.runner.materialize_investments",
+            fake_materialize,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.backfill_memberships",
+            backfill_mock,
+        ),
+    ):
+        rc = run_investment_materialization(_materialize_ns())
+
+    assert rc == 0
+    # The materializer ran...
+    materialize_mock.assert_called_once()
+    # ...and the no-LLM projection ran to publish the full-coverage marker.
+    backfill_mock.assert_called_once()
+    proj_config = backfill_mock.call_args.args[0]
+    assert proj_config.org_id == "org-abc"
+    assert proj_config.repo_ids is None  # org-wide projection
+    assert proj_config.is_org_wide is True
+
+
+def test_cli_repo_scoped_materialize_skips_org_marker():
+    """A repo-scoped manual materialize refreshes investments only and does NOT
+    run the org-wide projection (no org marker published)."""
+    fake_materialize, materialize_mock, backfill_mock = (
+        _patch_materialize_and_projection()
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.runner.materialize_investments",
+            fake_materialize,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.backfill_memberships",
+            backfill_mock,
+        ),
+    ):
+        rc = run_investment_materialization(_materialize_ns(repo_id=["repo-uuid-1"]))
+
+    assert rc == 0
+    materialize_mock.assert_called_once()
+    backfill_mock.assert_not_called()
+
+
+def test_cli_team_scoped_materialize_skips_org_marker():
+    """A team-scoped manual materialize also skips the org-wide projection."""
+    fake_materialize, materialize_mock, backfill_mock = (
+        _patch_materialize_and_projection()
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.runner.materialize_investments",
+            fake_materialize,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.backfill_memberships",
+            backfill_mock,
+        ),
+    ):
+        rc = run_investment_materialization(_materialize_ns(team_id=["team-1"]))
+
+    assert rc == 0
+    backfill_mock.assert_not_called()
+
+
+def test_cli_date_windowed_materialize_skips_org_marker():
+    """An explicitly date-windowed manual materialize (--window-days / --from /
+    --to) refreshes investments only and does NOT publish an org-wide marker —
+    it could otherwise blank out-of-window components under the new marker."""
+    fake_materialize, materialize_mock, backfill_mock = (
+        _patch_materialize_and_projection()
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.runner.materialize_investments",
+            fake_materialize,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.backfill_memberships",
+            backfill_mock,
+        ),
+    ):
+        # Explicit window via --window-days.
+        rc = run_investment_materialization(_materialize_ns(window_days=7))
+
+    assert rc == 0
+    materialize_mock.assert_called_once()
+    backfill_mock.assert_not_called()
+
+
+def test_cli_materialize_failure_skips_projection():
+    """If materialization fails, the projection must NOT run and rc is 1."""
+    backfill_mock = MagicMock()
+
+    async def _failing_materialize(config):
+        raise RuntimeError("boom")
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.runner.materialize_investments",
+            _failing_materialize,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.backfill_memberships",
+            backfill_mock,
+        ),
+    ):
+        rc = run_investment_materialization(_materialize_ns())
+
+    assert rc == 1
+    backfill_mock.assert_not_called()

--- a/tests/work_graph/test_work_unit_membership.py
+++ b/tests/work_graph/test_work_unit_membership.py
@@ -1,15 +1,15 @@
-"""Tests for CHAOS-2429/2430/2433: work_unit_membership multi-membership emission.
+"""Tests for CHAOS-2429/2430/2433: membership category helpers + materializer.
 
 Covers:
 - _lexical_argmax dominant selection + tie-break.
 - _membership_categories: multi-membership above the weight threshold, always
   including the argmax (is_dominant=1) even when below threshold, threshold
   boundary (0.2 included, 0.19 excluded unless dominant).
-- Materializer emits one row per (node, category) for theme and subcategory
-  kinds; 45/40 split is recorded under BOTH themes; is_dominant correctness.
-- Org isolation; fallback-status rows still stamped; work_unit_id consistency.
-- run_id is stamped on every membership row and matches categorization_run_id.
-- Completion marker (WorkUnitMembershipRunRecord) is written AFTER membership rows.
+- Materializer (CHAOS-2433 round-3 finding #2): writes work_unit_investments
+  ONLY — it NO LONGER writes work_unit_membership rows or the completion marker.
+  Membership is written exclusively by the no-LLM projection (backfill.py); see
+  tests/test_membership_backfill.py for the per-node/category emission, run_id,
+  marker-order, and coverage correctness.
 """
 
 from __future__ import annotations
@@ -276,21 +276,19 @@ def _make_config(
 
 
 # ---------------------------------------------------------------------------
-# Integration tests
+# Materializer integration tests — CHAOS-2433 round-3 finding #2.
+#
+# The materializer writes work_unit_investments ONLY. Membership rows + the
+# completion marker are written EXCLUSIVELY by the no-LLM projection
+# (backfill.py); see tests/test_membership_backfill.py for membership emission
+# correctness (per-node/category, run_id, marker order, coverage).
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_membership_rows_emitted_per_node_and_category(monkeypatch):
-    """Rows are emitted per (node, category) across both kinds.
-
-    subcategory dist: feature_delivery.roadmap=0.9, operational.support=0.1
-    → rolled-up themes: feature_delivery=0.9, operational=0.1.
-    Theme rows kept: feature_delivery (>=0.2 + dominant). operational (0.1) is
-    below threshold and not dominant → excluded.
-    Subcategory rows kept: feature_delivery.roadmap (dominant). operational.support 0.1
-    excluded. So 2 category rows per node, x2 nodes = 4 rows.
-    """
+async def test_materialize_writes_investments_only_no_membership(monkeypatch):
+    """The materializer persists work_unit_investments but writes NO membership
+    rows and NO completion marker (unified writer — backfill owns membership)."""
     repo_id, edges, work_items, commits = _sample_two_node_data()
     sink = FakeSink()
 
@@ -315,111 +313,34 @@ async def test_membership_rows_emitted_per_node_and_category(monkeypatch):
         _fake_categorize,
     )
 
-    await materialize_investments(_make_config(repo_id))
+    stats = await materialize_investments(_make_config(repo_id))
 
-    node_keys = {(r.node_type, r.node_id) for r in sink.membership_rows}
-    assert ("issue", "gh:ISSUE-1") in node_keys
-    assert ("commit", f"{repo_id}@abc123") in node_keys
+    # Investments ARE written, with the categorized distribution.
+    assert sink.investment_rows, "materializer must persist work_unit_investments"
+    inv = sink.investment_rows[0]
+    assert inv.org_id == "test-org"
+    assert inv.theme_distribution_json  # rolled-up themes present
+    assert inv.subcategory_distribution_json.get("feature_delivery.roadmap") == 0.9
 
-    # Per node: 1 theme row (feature_delivery) + 1 subcategory row.
-    issue_rows = [r for r in sink.membership_rows if r.node_id == "gh:ISSUE-1"]
-    theme_rows = [r for r in issue_rows if r.category_kind == "theme"]
-    sub_rows = [r for r in issue_rows if r.category_kind == "subcategory"]
-    assert {r.category for r in theme_rows} == {"feature_delivery"}
-    assert {r.category for r in sub_rows} == {"feature_delivery.roadmap"}
-    assert all(r.is_dominant == 1 for r in issue_rows)
+    # NO membership rows and NO marker — the projection owns those now.
+    assert sink.membership_rows == [], (
+        "materializer must NOT write work_unit_membership rows "
+        "(CHAOS-2433 round-3 finding #2)"
+    )
+    assert sink.membership_run_records == [], (
+        "materializer must NOT publish a completion marker (unified writer)"
+    )
+    assert sink._write_order == [], "no membership/marker writes from materializer"
+
+    # The stats no longer report a memberships count (materializer doesn't emit).
+    assert "memberships" not in stats
+    assert stats["records"] >= 1
 
 
 @pytest.mark.asyncio
-async def test_membership_45_40_split_findable_under_both_themes(monkeypatch):
-    """A 45%-feature / 40%-maintenance unit records BOTH theme rows so it is
-    findable under either theme (the core multi-membership requirement)."""
-    repo_id, edges, work_items, commits = _sample_two_node_data()
-    sink = FakeSink()
-
-    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
-        # Subcategories roll up to themes 45% feature / 40% maintenance / 15% quality.
-        return CategorizationOutcome(
-            subcategories={
-                "feature_delivery.roadmap": 0.45,
-                "maintenance.refactor": 0.40,
-                "quality.testing": 0.15,
-            },
-            evidence_quotes=[],
-            uncertainty="",
-            status="ok",
-            errors=[],
-        )
-
-    monkeypatch.setattr(
-        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
-    )
-    _patch_queries(monkeypatch, edges, work_items, commits, repo_id)
-    monkeypatch.setattr(
-        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
-        _fake_categorize,
-    )
-
-    await materialize_investments(_make_config(repo_id))
-
-    issue_theme_rows = [
-        r
-        for r in sink.membership_rows
-        if r.node_id == "gh:ISSUE-1" and r.category_kind == "theme"
-    ]
-    theme_cats = {r.category for r in issue_theme_rows}
-    # Both feature_delivery (0.45) and maintenance (0.40) recorded; quality (0.15) not.
-    assert "feature_delivery" in theme_cats
-    assert "maintenance" in theme_cats
-    assert "quality" not in theme_cats
-    # feature_delivery (0.45) is the dominant.
-    dominant = {r.category for r in issue_theme_rows if r.is_dominant == 1}
-    assert dominant == {"feature_delivery"}
-
-
-@pytest.mark.asyncio
-async def test_membership_dominant_tie_break_lexical(monkeypatch):
-    """When two themes tie on rolled-up weight, the lexically smallest is dominant."""
-    repo_id, edges, work_items, commits = _sample_two_node_data()
-    sink = FakeSink()
-
-    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
-        # Two subcategories under different themes, equal weight → theme tie.
-        return CategorizationOutcome(
-            subcategories={
-                "maintenance.refactor": 0.5,
-                "feature_delivery.roadmap": 0.5,
-            },
-            evidence_quotes=[],
-            uncertainty="",
-            status="ok",
-            errors=[],
-        )
-
-    monkeypatch.setattr(
-        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
-    )
-    _patch_queries(monkeypatch, edges, work_items, commits, repo_id)
-    monkeypatch.setattr(
-        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
-        _fake_categorize,
-    )
-
-    await materialize_investments(_make_config(repo_id))
-
-    theme_rows = [
-        r
-        for r in sink.membership_rows
-        if r.node_id == "gh:ISSUE-1" and r.category_kind == "theme"
-    ]
-    dominant = {r.category for r in theme_rows if r.is_dominant == 1}
-    # "feature_delivery" < "maintenance" lexically → it is the dominant.
-    assert dominant == {"feature_delivery"}
-
-
-@pytest.mark.asyncio
-async def test_membership_org_isolation(monkeypatch):
-    """Membership rows carry config.org_id."""
+async def test_materialize_scoped_run_writes_no_membership_or_marker(monkeypatch):
+    """A repo-scoped materialize also writes investments only — no membership,
+    no marker. (The org-wide projection publishes the full-coverage marker.)"""
     repo_id, edges, work_items, commits = _sample_two_node_data()
     sink = FakeSink()
 
@@ -441,138 +362,29 @@ async def test_membership_org_isolation(monkeypatch):
         _fake_categorize,
     )
 
-    await materialize_investments(_make_config(repo_id, org_id="acme-corp"))
-
-    assert len(sink.membership_rows) > 0
-    assert all(r.org_id == "acme-corp" for r in sink.membership_rows)
-
-
-@pytest.mark.asyncio
-async def test_membership_fallback_status_still_stamped(monkeypatch):
-    """Fallback-status rows (insufficient_evidence) are still emitted with a
-    dominant category and categorization_status='insufficient_evidence'."""
-    repo_id, edges, work_items, commits = _sample_two_node_data()
-    # Make description too short to pass MIN_EVIDENCE_CHARS → triggers fallback path.
-    work_items[0]["description"] = "short"
-    sink = FakeSink()
-
-    monkeypatch.setattr(
-        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
-    )
-    _patch_queries(monkeypatch, edges, work_items, commits, repo_id)
-    # categorize_text_bundle should NOT be called for fallback; no patch needed.
-
-    await materialize_investments(_make_config(repo_id))
-
-    assert len(sink.membership_rows) > 0
-    for row in sink.membership_rows:
-        assert row.categorization_status == "insufficient_evidence"
-        assert row.category  # non-empty category string
-        assert row.category_kind in {"theme", "subcategory"}
-    # Every node has at least one dominant theme and one dominant subcategory.
-    for node_id in ("gh:ISSUE-1", f"{repo_id}@abc123"):
-        node_rows = [r for r in sink.membership_rows if r.node_id == node_id]
-        dom_theme = [
-            r for r in node_rows if r.category_kind == "theme" and r.is_dominant == 1
-        ]
-        dom_sub = [
-            r
-            for r in node_rows
-            if r.category_kind == "subcategory" and r.is_dominant == 1
-        ]
-        assert len(dom_theme) == 1
-        assert len(dom_sub) == 1
-
-
-@pytest.mark.asyncio
-async def test_membership_work_unit_id_matches_investment(monkeypatch):
-    """All membership rows for a component share the investment record's work_unit_id."""
-    repo_id, edges, work_items, commits = _sample_two_node_data()
-    sink = FakeSink()
-
-    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
-        return CategorizationOutcome(
-            subcategories={"operational.support": 1.0},
-            evidence_quotes=[],
-            uncertainty="",
-            status="ok",
-            errors=[],
-        )
-
-    monkeypatch.setattr(
-        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
-    )
-    _patch_queries(monkeypatch, edges, work_items, commits, repo_id)
-    monkeypatch.setattr(
-        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
-        _fake_categorize,
-    )
-
-    await materialize_investments(_make_config(repo_id))
+    await materialize_investments(_make_config(repo_id, repo_ids=[repo_id]))
 
     assert sink.investment_rows
-    investment_unit_id = sink.investment_rows[0].work_unit_id
-    for row in sink.membership_rows:
-        assert row.work_unit_id == investment_unit_id
-
-
-# ---------------------------------------------------------------------------
-# run_id / completion-marker protocol tests (CHAOS-2433)
-# ---------------------------------------------------------------------------
+    assert sink.membership_rows == []
+    assert sink.membership_run_records == []
 
 
 @pytest.mark.asyncio
-async def test_membership_rows_carry_run_id(monkeypatch):
-    """All membership rows carry a non-empty run_id matching the investment
-    run's categorization_run_id (materializer reuses the same run_id)."""
+async def test_materialize_does_not_call_membership_sink_methods(monkeypatch):
+    """Defensive: the materializer never invokes write_work_unit_memberships or
+    write_membership_run (they would raise here)."""
     repo_id, edges, work_items, commits = _sample_two_node_data()
-    sink = FakeSink()
 
-    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
-        return CategorizationOutcome(
-            subcategories={"feature_delivery.roadmap": 1.0},
-            evidence_quotes=[],
-            uncertainty="",
-            status="ok",
-            errors=[],
-        )
+    class _NoMembershipSink(FakeSink):
+        def write_work_unit_memberships(self, rows):  # type: ignore[override]
+            raise AssertionError(
+                "materializer must not write membership rows (round-3 #2)"
+            )
 
-    monkeypatch.setattr(
-        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
-    )
-    _patch_queries(monkeypatch, edges, work_items, commits, repo_id)
-    monkeypatch.setattr(
-        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
-        _fake_categorize,
-    )
+        def write_membership_run(self, record):  # type: ignore[override]
+            raise AssertionError("materializer must not publish a marker (round-3 #2)")
 
-    await materialize_investments(_make_config(repo_id))
-
-    assert sink.membership_rows, "membership rows must be written"
-    # All rows have a non-empty run_id.
-    for row in sink.membership_rows:
-        assert row.run_id, f"run_id must be non-empty, got {row.run_id!r}"
-
-    # All rows share the SAME run_id (one run per materialize call).
-    run_ids = {row.run_id for row in sink.membership_rows}
-    assert len(run_ids) == 1, f"all rows must share one run_id, got: {run_ids}"
-
-    # The membership run_id matches the investment record's categorization_run_id.
-    assert sink.investment_rows, "investment rows must be written"
-    investment_run_id = sink.investment_rows[0].categorization_run_id
-    (membership_run_id,) = run_ids
-    assert membership_run_id == investment_run_id, (
-        "membership run_id must match investment categorization_run_id"
-    )
-
-
-@pytest.mark.asyncio
-async def test_completion_marker_written_after_membership_rows(monkeypatch):
-    """The completion-marker (WorkUnitMembershipRunRecord) is written to
-    work_unit_membership_runs AFTER all membership rows — proving the
-    run_id protocol write order."""
-    repo_id, edges, work_items, commits = _sample_two_node_data()
-    sink = FakeSink()
+    sink = _NoMembershipSink()
 
     async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
         return CategorizationOutcome(
@@ -592,63 +404,6 @@ async def test_completion_marker_written_after_membership_rows(monkeypatch):
         _fake_categorize,
     )
 
+    # Must NOT raise — proves neither membership method is called.
     await materialize_investments(_make_config(repo_id))
-
-    # Exactly one completion-marker written.
-    assert len(sink.membership_run_records) == 1, (
-        "exactly one completion-marker must be written"
-    )
-    marker = sink.membership_run_records[0]
-
-    # The marker's run_id matches the membership rows.
-    (membership_run_id,) = {row.run_id for row in sink.membership_rows}
-    assert marker.run_id == membership_run_id
-
-    # Write ORDER: membership rows come before the marker.
-    assert sink._write_order == ["memberships", "run_marker"], (
-        f"expected memberships then run_marker, got: {sink._write_order}"
-    )
-
-    # Marker's org_id matches the config.
-    assert marker.org_id == "test-org"
-
-
-@pytest.mark.asyncio
-async def test_materialize_scoped_run_writes_no_org_marker(monkeypatch):
-    """FINDING #2 (scoped runs must not publish an org-wide marker): a
-    repo-scoped materialize writes membership rows but does NOT publish the
-    org-wide completion marker — otherwise it would become the org's latest
-    complete run while covering only that scope, blanking other repos for
-    unscoped reads. The org-wide post-sync run publishes."""
-    repo_id, edges, work_items, commits = _sample_two_node_data()
-    sink = FakeSink()
-
-    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
-        return CategorizationOutcome(
-            subcategories={"feature_delivery.roadmap": 1.0},
-            evidence_quotes=[],
-            uncertainty="",
-            status="ok",
-            errors=[],
-        )
-
-    monkeypatch.setattr(
-        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
-    )
-    _patch_queries(monkeypatch, edges, work_items, commits, repo_id)
-    monkeypatch.setattr(
-        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
-        _fake_categorize,
-    )
-
-    # Repo-SCOPED run.
-    await materialize_investments(_make_config(repo_id, repo_ids=[repo_id]))
-
-    # Membership rows ARE written for the scoped repo.
-    assert sink.membership_rows
-    # But NO org-wide completion marker is published.
-    assert sink.membership_run_records == [], (
-        "a repo-scoped materialize must not publish an org-wide completion "
-        "marker (CHAOS-2433 finding #2)"
-    )
-    assert sink._write_order == ["memberships"]
+    assert sink.investment_rows

--- a/tests/work_graph/test_work_unit_membership.py
+++ b/tests/work_graph/test_work_unit_membership.py
@@ -376,12 +376,12 @@ async def test_materialize_does_not_call_membership_sink_methods(monkeypatch):
     repo_id, edges, work_items, commits = _sample_two_node_data()
 
     class _NoMembershipSink(FakeSink):
-        def write_work_unit_memberships(self, rows):  # type: ignore[override]
+        def write_work_unit_memberships(self, rows):
             raise AssertionError(
                 "materializer must not write membership rows (round-3 #2)"
             )
 
-        def write_membership_run(self, record):  # type: ignore[override]
+        def write_membership_run(self, record):
             raise AssertionError("materializer must not publish a marker (round-3 #2)")
 
     sink = _NoMembershipSink()

--- a/tests/work_graph/test_work_unit_membership.py
+++ b/tests/work_graph/test_work_unit_membership.py
@@ -1,4 +1,4 @@
-"""Tests for CHAOS-2429/2430: work_unit_membership multi-membership emission.
+"""Tests for CHAOS-2429/2430/2433: work_unit_membership multi-membership emission.
 
 Covers:
 - _lexical_argmax dominant selection + tie-break.
@@ -8,6 +8,8 @@ Covers:
 - Materializer emits one row per (node, category) for theme and subcategory
   kinds; 45/40 split is recorded under BOTH themes; is_dominant correctness.
 - Org isolation; fallback-status rows still stamped; work_unit_id consistency.
+- run_id is stamped on every membership row and matches categorization_run_id.
+- Completion marker (WorkUnitMembershipRunRecord) is written AFTER membership rows.
 """
 
 from __future__ import annotations
@@ -21,6 +23,7 @@ from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
     WorkUnitMembershipRecord,
+    WorkUnitMembershipRunRecord,
 )
 from dev_health_ops.work_graph.investment.categorize import CategorizationOutcome
 from dev_health_ops.work_graph.investment.constants import (
@@ -146,6 +149,9 @@ class FakeSink:
         self.investment_rows: list[WorkUnitInvestmentRecord] = []
         self.quote_rows: list[WorkUnitInvestmentEvidenceQuoteRecord] = []
         self.membership_rows: list[WorkUnitMembershipRecord] = []
+        self.membership_run_records: list[WorkUnitMembershipRunRecord] = []
+        # Track write call order so we can assert marker comes LAST.
+        self._write_order: list[str] = []
 
     def ensure_schema(self) -> None:
         return None
@@ -158,6 +164,11 @@ class FakeSink:
 
     def write_work_unit_memberships(self, rows) -> None:
         self.membership_rows.extend(rows)
+        self._write_order.append("memberships")
+
+    def write_membership_run(self, record: WorkUnitMembershipRunRecord) -> None:
+        self.membership_run_records.append(record)
+        self._write_order.append("run_marker")
 
     def close(self) -> None:
         return None
@@ -493,3 +504,100 @@ async def test_membership_work_unit_id_matches_investment(monkeypatch):
     investment_unit_id = sink.investment_rows[0].work_unit_id
     for row in sink.membership_rows:
         assert row.work_unit_id == investment_unit_id
+
+
+# ---------------------------------------------------------------------------
+# run_id / completion-marker protocol tests (CHAOS-2433)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_membership_rows_carry_run_id(monkeypatch):
+    """All membership rows carry a non-empty run_id matching the investment
+    run's categorization_run_id (materializer reuses the same run_id)."""
+    repo_id, edges, work_items, commits = _sample_two_node_data()
+    sink = FakeSink()
+
+    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
+        return CategorizationOutcome(
+            subcategories={"feature_delivery.roadmap": 1.0},
+            evidence_quotes=[],
+            uncertainty="",
+            status="ok",
+            errors=[],
+        )
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits, repo_id)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _fake_categorize,
+    )
+
+    await materialize_investments(_make_config(repo_id))
+
+    assert sink.membership_rows, "membership rows must be written"
+    # All rows have a non-empty run_id.
+    for row in sink.membership_rows:
+        assert row.run_id, f"run_id must be non-empty, got {row.run_id!r}"
+
+    # All rows share the SAME run_id (one run per materialize call).
+    run_ids = {row.run_id for row in sink.membership_rows}
+    assert len(run_ids) == 1, f"all rows must share one run_id, got: {run_ids}"
+
+    # The membership run_id matches the investment record's categorization_run_id.
+    assert sink.investment_rows, "investment rows must be written"
+    investment_run_id = sink.investment_rows[0].categorization_run_id
+    (membership_run_id,) = run_ids
+    assert membership_run_id == investment_run_id, (
+        "membership run_id must match investment categorization_run_id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_completion_marker_written_after_membership_rows(monkeypatch):
+    """The completion-marker (WorkUnitMembershipRunRecord) is written to
+    work_unit_membership_runs AFTER all membership rows — proving the
+    run_id protocol write order."""
+    repo_id, edges, work_items, commits = _sample_two_node_data()
+    sink = FakeSink()
+
+    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
+        return CategorizationOutcome(
+            subcategories={"maintenance.refactor": 1.0},
+            evidence_quotes=[],
+            uncertainty="",
+            status="ok",
+            errors=[],
+        )
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits, repo_id)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _fake_categorize,
+    )
+
+    await materialize_investments(_make_config(repo_id))
+
+    # Exactly one completion-marker written.
+    assert len(sink.membership_run_records) == 1, (
+        "exactly one completion-marker must be written"
+    )
+    marker = sink.membership_run_records[0]
+
+    # The marker's run_id matches the membership rows.
+    (membership_run_id,) = {row.run_id for row in sink.membership_rows}
+    assert marker.run_id == membership_run_id
+
+    # Write ORDER: membership rows come before the marker.
+    assert sink._write_order == ["memberships", "run_marker"], (
+        f"expected memberships then run_marker, got: {sink._write_order}"
+    )
+
+    # Marker's org_id matches the config.
+    assert marker.org_id == "test-org"

--- a/tests/work_graph/test_work_unit_membership.py
+++ b/tests/work_graph/test_work_unit_membership.py
@@ -251,13 +251,23 @@ def _patch_queries(monkeypatch, edges, work_items, commits, repo_id):
     )
 
 
-def _make_config(repo_id: str, org_id: str = "test-org") -> MaterializeConfig:
+def _make_config(
+    repo_id: str, org_id: str = "test-org", *, repo_ids: list[str] | None = None
+) -> MaterializeConfig:
+    """Build a MaterializeConfig.
+
+    NOTE: org-wide by default (``repo_ids=None``).  CHAOS-2433 finding #2: only
+    an org-wide run publishes a completion marker — a repo-scoped run writes its
+    rows but NOT the org-wide marker.  These membership/marker tests must run
+    org-wide so the marker is published (the patched edge fetch ignores repo_ids
+    anyway).  Pass ``repo_ids=[...]`` to exercise the scoped (no-marker) path.
+    """
     now = datetime.now(timezone.utc)
     return MaterializeConfig(
         dsn="clickhouse://localhost:8123/default",
         from_ts=now - timedelta(days=5),
         to_ts=now,
-        repo_ids=[repo_id],
+        repo_ids=repo_ids,
         llm_provider="mock",
         persist_evidence_snippets=False,
         llm_model="test-model",
@@ -601,3 +611,44 @@ async def test_completion_marker_written_after_membership_rows(monkeypatch):
 
     # Marker's org_id matches the config.
     assert marker.org_id == "test-org"
+
+
+@pytest.mark.asyncio
+async def test_materialize_scoped_run_writes_no_org_marker(monkeypatch):
+    """FINDING #2 (scoped runs must not publish an org-wide marker): a
+    repo-scoped materialize writes membership rows but does NOT publish the
+    org-wide completion marker — otherwise it would become the org's latest
+    complete run while covering only that scope, blanking other repos for
+    unscoped reads. The org-wide post-sync run publishes."""
+    repo_id, edges, work_items, commits = _sample_two_node_data()
+    sink = FakeSink()
+
+    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
+        return CategorizationOutcome(
+            subcategories={"feature_delivery.roadmap": 1.0},
+            evidence_quotes=[],
+            uncertainty="",
+            status="ok",
+            errors=[],
+        )
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits, repo_id)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _fake_categorize,
+    )
+
+    # Repo-SCOPED run.
+    await materialize_investments(_make_config(repo_id, repo_ids=[repo_id]))
+
+    # Membership rows ARE written for the scoped repo.
+    assert sink.membership_rows
+    # But NO org-wide completion marker is published.
+    assert sink.membership_run_records == [], (
+        "a repo-scoped materialize must not publish an org-wide completion "
+        "marker (CHAOS-2433 finding #2)"
+    )
+    assert sink._write_order == ["memberships"]


### PR DESCRIPTION
## Summary

Fixes three simultaneous failure modes in `work_unit_membership` by replacing the per-node `max(computed_at)` recency guard with a **run_id / completion-marker protocol**:

- **Concurrency race** (round-5 bug): a half-written materializer run has rows in ClickHouse but no marker → the prior complete run (e.g. from a daily backfill) remains visible until the marker lands, then readers atomically switch to the new run.
- **Split/merge stale rows**: nodes from old components carry their old `run_id`; the new complete run has a new `run_id`; old rows are simply invisible — no explicit tombstones needed.
- **Partial-write divergence**: a run with rows but no marker is never selected; there is no "partially true" membership state.

This PR supersedes #928 (branch `chaos-2439`) and **removes the tombstone mechanism entirely**. The run_id protocol makes tombstones unnecessary: a churned node is absent from the latest complete run, which the resolver treats as "no membership" (annotation null, not filterable).

## Changes

### Schema / Migration
- **Migration 047**: `ADD COLUMN run_id String DEFAULT ''` to `work_unit_membership`; `CREATE TABLE work_unit_membership_runs (org_id, run_id, completed_at) ENGINE = ReplacingMergeTree(completed_at) ORDER BY (org_id, run_id)` as the completion-marker table.
- `WorkUnitMembershipRecord` gains `run_id: str = ""` (backward-compat default).
- New `WorkUnitMembershipRunRecord` dataclass for the completion marker.

### Write side
- **Materializer**: stamps `run_id` (reuses `categorization_run_id`) on every membership row; writes `work_unit_membership_runs` marker as the **last step** after all rows.
- **Backfill** (new `backfill.py`, ported from chaos-2439, rebuilt on run protocol): generates its own `uuid4().hex` run_id; writes marker last; churned components are skipped (not tombstoned).
- Sink: `write_work_unit_memberships` now includes the `run_id` column; new `write_membership_run()` writes the marker.

### Read side (3 resolver paths)
Replaced `_LATEST_RUN_PER_NODE_SUBQUERY` with `_LATEST_COMPLETE_RUN_SUBQUERY`:
```sql
SELECT argMax(run_id, completed_at) AS latest_run_id
FROM work_unit_membership_runs
WHERE org_id = %(org_id)s
```
Applied with `INNER JOIN latest_run ON m.run_id = latest_run.latest_run_id AND latest_run.latest_run_id != ''` in:
1. Filter semijoin (theme/subcategory EXISTS clause)
2. Dominant-annotation lookup (`_batch_resolve_membership`)
3. Degraded-state probe (`_detect_membership_degraded_reason`)

`_MEMBERSHIP_TABLES` now covers both `work_unit_membership` and `work_unit_membership_runs` for graceful-degrade on missing-table errors.

### Workers / scheduling
- New `run_membership_backfill` Celery task wrapping `backfill_memberships`.
- New `dispatch_membership_backfill` task fans out `build → backfill` chain per active org with `strict=True` org discovery (`_discover_active_org_ids` gained a `strict=` parameter; strict mode re-raises on Postgres failure rather than silently returning `["default"]`).
- Beat schedule: `run-membership-backfill-daily` at 03:30 UTC.

## Tests

- **`test_work_unit_membership.py`**: `test_membership_rows_carry_run_id` + `test_completion_marker_written_after_membership_rows` (write-order invariant).
- **`test_membership_backfill.py`**: no-LLM proof, shared-helper consistency, run_id stamping, marker-last write order, no marker on empty run, churned components skipped (no tombstones), dispatcher chain, strict discovery, beat schedule entry.
- **`test_work_graph_theme_filter.py`**: all 3 reader paths assert `work_unit_membership_runs` / `argMax(run_id, completed_at)` / `m.run_id = latest_run.latest_run_id` patterns; new `TestRunIdConcurrencyRace` class (4 tests):
  - Incomplete materializer run invisible; prior complete backfill run visible.
  - After materializer marker written → resolver switches to new run.
  - No complete run → degraded when investments exist.
  - Split/merge stale node absent from new run.
- **`test_work_graph_membership_split_merge_live.py`**: rewritten to use run_id protocol; added live ClickHouse `test_concurrency_race_incomplete_run_invisible`.

All 217 work_graph/membership tests pass; live ClickHouse tests pass; mypy 0 errors.

## Supersedes / removes

- Supersedes PR #928 (chaos-2439) — absorbs the no-LLM backfill, rebuilt on run protocol.
- Removes tombstone mechanism: no `TOMBSTONE_CATEGORY` sentinel, no `_build_tombstone_records`, no `tombstones` stat.

Closes CHAOS-2433.