### PR TITLE
fix(sync): enumerate all token-accessible repos for sync-all (CHAOS-2445/2446/2447)

### DIFF
--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -11,10 +11,22 @@ def discover_repos_for_config(
     sync_options = dict(config.sync_options or {})
 
     if provider == "github":
-        token = _github_token_from_credentials(credentials)
+        from dev_health_ops.credentials.resolver import github_credentials_from_mapping
+
+        gh_credentials = github_credentials_from_mapping(credentials)
+        if (
+            gh_credentials is not None
+            and gh_credentials.is_app_auth
+            and sync_options.get("all_repos") is True
+        ):
+            token = ""
+        else:
+            token = _github_token_from_resolved_credentials(gh_credentials)
         # No token => attempt anonymous public-repo discovery (rate-limited,
         # public-only). Authenticated configs pass their token through.
-        return discover_github_repos(sync_options, token)
+        return discover_github_repos(
+            sync_options, token, github_credentials=gh_credentials
+        )
     if provider == "gitlab":
         from dev_health_ops.credentials.resolver import (
             gitlab_credentials_from_mapping,
@@ -37,6 +49,10 @@ def _github_token_from_credentials(credentials: dict[str, Any]) -> str:
     from dev_health_ops.credentials.resolver import github_credentials_from_mapping
 
     gh_credentials = github_credentials_from_mapping(credentials)
+    return _github_token_from_resolved_credentials(gh_credentials)
+
+
+def _github_token_from_resolved_credentials(gh_credentials: Any | None) -> str:
     if gh_credentials is None:
         return ""
     if gh_credentials.is_app_auth:
@@ -47,7 +63,7 @@ def _github_token_from_credentials(credentials: dict[str, Any]) -> str:
 
 
 def discover_github_repos(
-    sync_options: dict[str, Any], token: str
+    sync_options: dict[str, Any], token: str, github_credentials: Any | None = None
 ) -> list[tuple[str, ...]]:
     from github import Github
 
@@ -74,8 +90,13 @@ def discover_github_repos(
     else:
         repo_pattern = "*"
 
-    g = Github(token) if token else Github()
     if all_repos:
+        if getattr(github_credentials, "is_app_auth", False):
+            return _discover_github_app_installation_repos(
+                github_credentials, namespace=namespace, repo_pattern=repo_pattern
+            )
+
+        g = Github(token) if token else Github()
         try:
             repos = g.get_user().get_repos()
         except Exception:
@@ -101,6 +122,7 @@ def discover_github_repos(
     if not owner:
         return []
 
+    g = Github(token) if token else Github()
     try:
         org = g.get_organization(owner)
         repos = org.get_repos()
@@ -115,6 +137,74 @@ def discover_github_repos(
     for repo in repos:
         if fnmatch.fnmatch(repo.name, repo_pattern):
             result.append((owner, repo.name))
+
+    return result
+
+
+def _discover_github_app_installation_repos(
+    github_credentials: Any, *, namespace: str, repo_pattern: str
+) -> list[tuple[str, ...]]:
+    import requests
+
+    from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
+
+    app_id = getattr(github_credentials, "app_id", None)
+    private_key = getattr(github_credentials, "private_key", None)
+    installation_id = getattr(github_credentials, "installation_id", None)
+    if not app_id or not private_key or not installation_id:
+        raise ValueError(
+            "GitHub App credentials require app_id, private_key, and installation_id"
+        )
+
+    base_url = str(
+        getattr(github_credentials, "base_url", None) or "https://api.github.com"
+    ).rstrip("/")
+    token = GitHubAppTokenProvider(
+        app_id=str(app_id),
+        private_key=str(private_key),
+        installation_id=str(installation_id),
+        api_base_url=base_url,
+    ).get_token()
+
+    result: list[tuple[str, ...]] = []
+    page = 1
+    per_page = 100
+    while True:
+        response = requests.get(
+            f"{base_url}/installation/repositories",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            params={"per_page": per_page, "page": page},
+            timeout=30,
+        )
+        if response.status_code < 200 or response.status_code >= 300:
+            raise RuntimeError(
+                "GitHub App installation repositories request failed: "
+                f"HTTP {response.status_code}"
+            )
+
+        repositories = response.json().get("repositories") or []
+        for repo in repositories:
+            repo_name = str(repo.get("name") or "")
+            if not fnmatch.fnmatch(repo_name, repo_pattern):
+                continue
+            owner = repo.get("owner") or {}
+            repo_owner = str(owner.get("login") or "")
+            if not repo_owner:
+                full_name = str(repo.get("full_name") or "")
+                if "/" in full_name:
+                    repo_owner = full_name.split("/", 1)[0]
+            if namespace and repo_owner.lower() != namespace.lower():
+                continue
+            if repo_owner:
+                result.append((repo_owner, repo_name))
+
+        if len(repositories) < per_page:
+            break
+        page += 1
 
     return result
 

--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -54,10 +54,13 @@ def discover_github_repos(
     search = sync_options.get("search", "")
     owner = sync_options.get("owner", "")
     all_repos = sync_options.get("all_repos") is True
+    namespace = owner.strip() if all_repos and isinstance(owner, str) else ""
 
     if all_repos and isinstance(search, str) and search.strip():
         if "/" in search:
             parts = search.split("/", 1)
+            if not namespace:
+                namespace = parts[0].strip()
             repo_pattern = parts[1]
         else:
             repo_pattern = search.strip()
@@ -88,6 +91,8 @@ def discover_github_repos(
                 full_name = getattr(repo, "full_name", "") or ""
                 if "/" in full_name:
                     repo_owner = full_name.split("/", 1)[0]
+            if namespace and repo_owner.lower() != namespace.lower():
+                continue
             if repo_owner:
                 result.append((repo_owner, repo_name))
 
@@ -125,11 +130,20 @@ def discover_gitlab_repos(
         gitlab_url = str(sync_options.get("gitlab_url") or "https://gitlab.com")
     search = sync_options.get("search", "")
     group_path = sync_options.get("group", "")
+    owner = sync_options.get("owner", "")
     all_repos = sync_options.get("all_repos") is True
+    namespace = ""
+    if all_repos:
+        if isinstance(group_path, str) and group_path.strip():
+            namespace = group_path.strip()
+        elif isinstance(owner, str) and owner.strip():
+            namespace = owner.strip()
 
     if all_repos and isinstance(search, str) and search.strip():
         if "/" in search:
             parts = search.split("/", 1)
+            if not namespace:
+                namespace = parts[0].strip()
             project_pattern = parts[1]
         else:
             project_pattern = search.strip()
@@ -154,6 +168,14 @@ def discover_gitlab_repos(
         for project in projects:
             name = getattr(project, "name", "") or ""
             project_id = getattr(project, "id", None)
+            path_with_namespace = getattr(project, "path_with_namespace", "") or ""
+            normalized_path = path_with_namespace.lower()
+            normalized_namespace = namespace.lower()
+            if normalized_namespace and not (
+                normalized_path == normalized_namespace
+                or normalized_path.startswith(f"{normalized_namespace}/")
+            ):
+                continue
             if project_id is not None and fnmatch.fnmatch(name, project_pattern):
                 result.append((str(project_id),))
 

--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -97,10 +97,7 @@ def discover_github_repos(
             )
 
         g = Github(token) if token else Github()
-        try:
-            repos = g.get_user().get_repos()
-        except Exception:
-            return []
+        repos = g.get_user().get_repos()
 
         result: list[tuple[str, ...]] = []
         for repo in repos:
@@ -249,10 +246,7 @@ def discover_gitlab_repos(
 
     gl = gitlab_lib.Gitlab(gitlab_url, private_token=token)
     if all_repos:
-        try:
-            projects = gl.projects.list(all=True, membership=True)
-        except Exception:
-            return []
+        projects = gl.projects.list(all=True, membership=True)
 
         result: list[tuple[str, ...]] = []
         for project in projects:

--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -53,8 +53,15 @@ def discover_github_repos(
 
     search = sync_options.get("search", "")
     owner = sync_options.get("owner", "")
+    all_repos = sync_options.get("all_repos") is True
 
-    if isinstance(search, str) and "/" in search:
+    if all_repos and isinstance(search, str) and search.strip():
+        if "/" in search:
+            parts = search.split("/", 1)
+            repo_pattern = parts[1]
+        else:
+            repo_pattern = search.strip()
+    elif isinstance(search, str) and "/" in search:
         parts = search.split("/", 1)
         owner = parts[0]
         repo_pattern = parts[1]
@@ -64,10 +71,31 @@ def discover_github_repos(
     else:
         repo_pattern = "*"
 
+    g = Github(token) if token else Github()
+    if all_repos:
+        try:
+            repos = g.get_user().get_repos()
+        except Exception:
+            return []
+
+        result: list[tuple[str, ...]] = []
+        for repo in repos:
+            repo_name = getattr(repo, "name", "") or ""
+            if not fnmatch.fnmatch(repo_name, repo_pattern):
+                continue
+            repo_owner = getattr(getattr(repo, "owner", None), "login", "") or ""
+            if not repo_owner:
+                full_name = getattr(repo, "full_name", "") or ""
+                if "/" in full_name:
+                    repo_owner = full_name.split("/", 1)[0]
+            if repo_owner:
+                result.append((repo_owner, repo_name))
+
+        return result
+
     if not owner:
         return []
 
-    g = Github(token) if token else Github()
     try:
         org = g.get_organization(owner)
         repos = org.get_repos()
@@ -97,8 +125,15 @@ def discover_gitlab_repos(
         gitlab_url = str(sync_options.get("gitlab_url") or "https://gitlab.com")
     search = sync_options.get("search", "")
     group_path = sync_options.get("group", "")
+    all_repos = sync_options.get("all_repos") is True
 
-    if isinstance(search, str) and "/" in search:
+    if all_repos and isinstance(search, str) and search.strip():
+        if "/" in search:
+            parts = search.split("/", 1)
+            project_pattern = parts[1]
+        else:
+            project_pattern = search.strip()
+    elif isinstance(search, str) and "/" in search:
         parts = search.split("/", 1)
         group_path = parts[0]
         project_pattern = parts[1]
@@ -108,10 +143,25 @@ def discover_gitlab_repos(
     else:
         project_pattern = "*"
 
+    gl = gitlab_lib.Gitlab(gitlab_url, private_token=token)
+    if all_repos:
+        try:
+            projects = gl.projects.list(all=True, membership=True)
+        except Exception:
+            return []
+
+        result: list[tuple[str, ...]] = []
+        for project in projects:
+            name = getattr(project, "name", "") or ""
+            project_id = getattr(project, "id", None)
+            if project_id is not None and fnmatch.fnmatch(name, project_pattern):
+                result.append((str(project_id),))
+
+        return result
+
     if not group_path:
         return []
 
-    gl = gitlab_lib.Gitlab(gitlab_url, private_token=token)
     try:
         grp = gl.groups.get(group_path)
         projects = grp.projects.list(all=True)

--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -228,10 +228,14 @@ def discover_gitlab_repos(
 
     if all_repos and isinstance(search, str) and search.strip():
         if "/" in search:
-            parts = search.split("/", 1)
+            # Split on the LAST slash so nested GitLab namespaces (e.g.
+            # "group/subgroup/*") resolve namespace="group/subgroup",
+            # pattern="*" instead of treating "subgroup/*" as a project name
+            # pattern (project names contain no slashes).
+            ns_part, _, pattern_part = search.rpartition("/")
             if not namespace:
-                namespace = parts[0].strip()
-            project_pattern = parts[1]
+                namespace = ns_part.strip()
+            project_pattern = pattern_part
         else:
             project_pattern = search.strip()
     elif isinstance(search, str) and "/" in search:

--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -130,7 +130,7 @@ def discover_github_repos(
         except Exception:
             return []
 
-    result: list[tuple[str, ...]] = []
+    result = []
     for repo in repos:
         if fnmatch.fnmatch(repo.name, repo_pattern):
             result.append((owner, repo.name))
@@ -274,14 +274,14 @@ def discover_gitlab_repos(
 
     try:
         grp = gl.groups.get(group_path)
-        projects = grp.projects.list(all=True)
+        group_projects = grp.projects.list(all=True)
     except Exception:
         return []
 
-    result: list[tuple[str, ...]] = []
-    for project in projects:
-        name = getattr(project, "name", "") or ""
-        project_id = getattr(project, "id", None)
+    result = []
+    for group_project in group_projects:
+        name = getattr(group_project, "name", "") or ""
+        project_id = getattr(group_project, "id", None)
         if project_id is not None and fnmatch.fnmatch(name, project_pattern):
             result.append((str(project_id),))
 

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -197,6 +197,7 @@ def _is_batch_eligible(config) -> bool:
     - sync_options contains a 'search' key with a wildcard pattern (e.g. "org/*")
     - OR sync_options names an org/group without a concrete repo/project
     - OR sync_options contains 'discover: true'
+    - OR sync_options contains 'all_repos: true' for token-wide repository sync
     """
     provider = (config.provider or "").lower()
     if provider not in ("github", "gitlab"):
@@ -205,6 +206,9 @@ def _is_batch_eligible(config) -> bool:
     sync_options = dict(config.sync_options or {})
 
     if sync_options.get("discover") is True:
+        return True
+
+    if sync_options.get("all_repos") is True:
         return True
 
     search = sync_options.get("search")

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -205,6 +205,21 @@ def _is_batch_eligible(config) -> bool:
 
     sync_options = dict(config.sync_options or {})
 
+    if provider == "github":
+        owner = sync_options.get("owner")
+        repo = sync_options.get("repo")
+        if owner and repo:
+            return False
+
+    if provider == "gitlab":
+        project = (
+            sync_options.get("project_id")
+            or sync_options.get("project")
+            or sync_options.get("repo")
+        )
+        if project:
+            return False
+
     if sync_options.get("discover") is True:
         return True
 
@@ -226,7 +241,11 @@ def _is_batch_eligible(config) -> bool:
 
     if provider == "gitlab":
         group = sync_options.get("group")
-        project = sync_options.get("project_id") or sync_options.get("repo")
+        project = (
+            sync_options.get("project_id")
+            or sync_options.get("project")
+            or sync_options.get("repo")
+        )
         if group and not project:
             return True
 
@@ -373,6 +392,8 @@ def dispatch_batch_sync(
         try:
             repos = discover_repos_for_config(config, credentials)
         except Exception as disc_exc:
+            if sync_options.get("all_repos") is True:
+                raise
             logger.warning(
                 "Discovery failed for config %s, falling back to single dispatch: %s",
                 config_id,
@@ -416,6 +437,7 @@ def dispatch_batch_sync(
         for repo_tuple in repos:
             per_repo_options = dict(sync_options)
             per_repo_options.pop("discover", None)
+            per_repo_options.pop("all_repos", None)
             per_repo_options.pop("batch_size", None)
 
             if provider == "github":

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -294,6 +294,42 @@ class TestDiscoverGithubRepos:
         assert result == [("org-a", "api-service"), ("org-c", "api-worker")]
 
     @patch("github.Github")
+    def test_all_repos_search_namespace_limits_authenticated_repos(
+        self, mock_github_cls
+    ):
+        from dev_health_ops.discovery.repos import discover_github_repos
+
+        repos = [
+            SimpleNamespace(name="api", owner=SimpleNamespace(login="orgA")),
+            SimpleNamespace(name="web", owner=SimpleNamespace(login="orgA")),
+            SimpleNamespace(name="api", owner=SimpleNamespace(login="orgB")),
+        ]
+        mock_user = MagicMock()
+        mock_user.get_repos.return_value = repos
+        mock_github_cls.return_value.get_user.return_value = mock_user
+
+        result = discover_github_repos({"all_repos": True, "search": "orgA/*"}, "token")
+
+        assert result == [("orgA", "api"), ("orgA", "web")]
+
+    @patch("github.Github")
+    def test_all_repos_owner_limits_authenticated_repos(self, mock_github_cls):
+        from dev_health_ops.discovery.repos import discover_github_repos
+
+        repos = [
+            SimpleNamespace(name="api", owner=SimpleNamespace(login="orgA")),
+            SimpleNamespace(name="web", owner=SimpleNamespace(login="orgA")),
+            SimpleNamespace(name="api", owner=SimpleNamespace(login="orgB")),
+        ]
+        mock_user = MagicMock()
+        mock_user.get_repos.return_value = repos
+        mock_github_cls.return_value.get_user.return_value = mock_user
+
+        result = discover_github_repos({"all_repos": True, "owner": "orgA"}, "token")
+
+        assert result == [("orgA", "api"), ("orgA", "web")]
+
+    @patch("github.Github")
     def test_returns_empty_on_total_failure(self, mock_github_cls):
         from dev_health_ops.discovery.repos import discover_github_repos
 
@@ -382,6 +418,36 @@ class TestDiscoverGitlabRepos:
         result = discover_gitlab_repos({"all_repos": True, "search": "api*"}, "token")
 
         assert result == [("100",), ("300",)]
+
+    @patch("gitlab.Gitlab")
+    def test_all_repos_group_limits_membership_projects(self, mock_gitlab_cls):
+        from dev_health_ops.discovery.repos import discover_gitlab_repos
+
+        projects = [
+            SimpleNamespace(name="api", id=100, path_with_namespace="grpA/api"),
+            SimpleNamespace(name="web", id=200, path_with_namespace="grpA/sub/web"),
+            SimpleNamespace(name="api", id=300, path_with_namespace="grpB/api"),
+        ]
+        mock_gitlab_cls.return_value.projects.list.return_value = projects
+
+        result = discover_gitlab_repos({"all_repos": True, "group": "grpA"}, "token")
+
+        assert result == [("100",), ("200",)]
+
+    @patch("gitlab.Gitlab")
+    def test_all_repos_owner_limits_membership_projects(self, mock_gitlab_cls):
+        from dev_health_ops.discovery.repos import discover_gitlab_repos
+
+        projects = [
+            SimpleNamespace(name="api", id=100, path_with_namespace="grpA/api"),
+            SimpleNamespace(name="web", id=200, path_with_namespace="grpA/sub/web"),
+            SimpleNamespace(name="api", id=300, path_with_namespace="grpB/api"),
+        ]
+        mock_gitlab_cls.return_value.projects.list.return_value = projects
+
+        result = discover_gitlab_repos({"all_repos": True, "owner": "grpA"}, "token")
+
+        assert result == [("100",), ("200",)]
 
     def test_returns_empty_without_group_when_all_repos_false(self):
         from dev_health_ops.discovery.repos import discover_gitlab_repos

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -555,6 +555,23 @@ class TestDiscoverGitlabRepos:
         assert result == [("100",), ("200",)]
 
     @patch("gitlab.Gitlab")
+    def test_all_repos_nested_subgroup_search(self, mock_gitlab_cls):
+        from dev_health_ops.discovery.repos import discover_gitlab_repos
+
+        projects = [
+            SimpleNamespace(name="api", id=100, path_with_namespace="grpA/sub/api"),
+            SimpleNamespace(name="web", id=200, path_with_namespace="grpA/other/web"),
+            SimpleNamespace(name="db", id=300, path_with_namespace="elsewhere/db"),
+        ]
+        mock_gitlab_cls.return_value.projects.list.return_value = projects
+
+        result = discover_gitlab_repos(
+            {"all_repos": True, "search": "grpA/sub/*"}, "token"
+        )
+
+        assert result == [("100",)]
+
+    @patch("gitlab.Gitlab")
     def test_all_repos_membership_listing_failure_raises(self, mock_gitlab_cls):
         from dev_health_ops.discovery.repos import discover_gitlab_repos
 

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -78,6 +78,15 @@ class TestIsBatchEligible:
         )
         assert _is_batch_eligible(config) is True
 
+    def test_github_with_all_repos_flag(self):
+        from dev_health_ops.workers.sync_batch import _is_batch_eligible
+
+        config = _make_config(
+            provider="github",
+            sync_options={"all_repos": True},
+        )
+        assert _is_batch_eligible(config) is True
+
     def test_github_bare_org_search_is_batch_eligible(self):
         from dev_health_ops.workers.sync_batch import _is_batch_eligible
 
@@ -114,6 +123,15 @@ class TestIsBatchEligible:
         config = _make_config(
             provider="gitlab",
             sync_options={"search": "my-group/*"},
+        )
+        assert _is_batch_eligible(config) is True
+
+    def test_gitlab_with_all_repos_flag(self):
+        from dev_health_ops.workers.sync_batch import _is_batch_eligible
+
+        config = _make_config(
+            provider="gitlab",
+            sync_options={"all_repos": True},
         )
         assert _is_batch_eligible(config) is True
 
@@ -238,6 +256,44 @@ class TestDiscoverGithubRepos:
         assert result == [("user", "my-repo")]
 
     @patch("github.Github")
+    def test_all_repos_lists_authenticated_repos_without_owner(self, mock_github_cls):
+        from dev_health_ops.discovery.repos import discover_github_repos
+
+        repos = [
+            SimpleNamespace(name="api", owner=SimpleNamespace(login="org-a")),
+            SimpleNamespace(name="web", owner=SimpleNamespace(login="org-b")),
+        ]
+        mock_user = MagicMock()
+        mock_user.get_repos.return_value = repos
+        mock_g = mock_github_cls.return_value
+        mock_g.get_user.return_value = mock_user
+
+        result = discover_github_repos({"all_repos": True, "search": ""}, "token")
+
+        mock_g.get_user.assert_called_once_with()
+        mock_g.get_organization.assert_not_called()
+        assert result == [("org-a", "api"), ("org-b", "web")]
+
+    @patch("github.Github")
+    def test_all_repos_filters_and_uses_full_name_owner_fallback(self, mock_github_cls):
+        from dev_health_ops.discovery.repos import discover_github_repos
+
+        repos = [
+            SimpleNamespace(name="api-service", owner=SimpleNamespace(login="org-a")),
+            SimpleNamespace(name="web-app", owner=SimpleNamespace(login="org-b")),
+            SimpleNamespace(
+                name="api-worker", owner=None, full_name="org-c/api-worker"
+            ),
+        ]
+        mock_user = MagicMock()
+        mock_user.get_repos.return_value = repos
+        mock_github_cls.return_value.get_user.return_value = mock_user
+
+        result = discover_github_repos({"all_repos": True, "search": "api-*"}, "token")
+
+        assert result == [("org-a", "api-service"), ("org-c", "api-worker")]
+
+    @patch("github.Github")
     def test_returns_empty_on_total_failure(self, mock_github_cls):
         from dev_health_ops.discovery.repos import discover_github_repos
 
@@ -248,7 +304,7 @@ class TestDiscoverGithubRepos:
         result = discover_github_repos({"search": "org/*"}, "token")
         assert result == []
 
-    def test_returns_empty_without_owner(self):
+    def test_returns_empty_without_owner_when_all_repos_false(self):
         from dev_health_ops.discovery.repos import discover_github_repos
 
         result = discover_github_repos({"search": ""}, "token")
@@ -294,7 +350,40 @@ class TestDiscoverGitlabRepos:
         result = discover_gitlab_repos({"search": "group/*"}, "token")
         assert result == []
 
-    def test_returns_empty_without_group(self):
+    @patch("gitlab.Gitlab")
+    def test_all_repos_lists_membership_projects_without_group(self, mock_gitlab_cls):
+        from dev_health_ops.discovery.repos import discover_gitlab_repos
+
+        projects = [
+            SimpleNamespace(name="api", id=100),
+            SimpleNamespace(name="web", id=200),
+        ]
+        mock_gitlab_cls.return_value.projects.list.return_value = projects
+
+        result = discover_gitlab_repos({"all_repos": True, "search": ""}, "token")
+
+        mock_gitlab_cls.return_value.projects.list.assert_called_once_with(
+            all=True, membership=True
+        )
+        mock_gitlab_cls.return_value.groups.get.assert_not_called()
+        assert result == [("100",), ("200",)]
+
+    @patch("gitlab.Gitlab")
+    def test_all_repos_filters_membership_projects(self, mock_gitlab_cls):
+        from dev_health_ops.discovery.repos import discover_gitlab_repos
+
+        projects = [
+            SimpleNamespace(name="api", id=100),
+            SimpleNamespace(name="web", id=200),
+            SimpleNamespace(name="api-worker", id=300),
+        ]
+        mock_gitlab_cls.return_value.projects.list.return_value = projects
+
+        result = discover_gitlab_repos({"all_repos": True, "search": "api*"}, "token")
+
+        assert result == [("100",), ("300",)]
+
+    def test_returns_empty_without_group_when_all_repos_false(self):
         from dev_health_ops.discovery.repos import discover_gitlab_repos
 
         result = discover_gitlab_repos({"search": ""}, "token")

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -177,6 +177,82 @@ class TestDiscoverReposForConfig:
         assert result == [("my-org", "repo-a"), ("my-org", "repo-b")]
         mock_gh.assert_called_once()
 
+    @patch("requests.get")
+    @patch("dev_health_ops.connectors.utils.github_app.GitHubAppTokenProvider")
+    def test_github_app_all_repos_lists_installation_repositories(
+        self, mock_token_provider_cls, mock_get
+    ):
+        from dev_health_ops.discovery.repos import discover_repos_for_config
+
+        mock_token_provider_cls.return_value.get_token.return_value = (
+            "installation-token"
+        )
+        mock_response = MagicMock(status_code=200)
+        mock_response.json.return_value = {
+            "repositories": [
+                {"name": "api", "owner": {"login": "orgA"}},
+                {"name": "web", "owner": {"login": "orgA"}},
+                {"name": "api-worker", "owner": {"login": "orgA"}},
+                {"name": "api", "owner": {"login": "orgB"}},
+            ]
+        }
+        mock_get.return_value = mock_response
+        config = _make_config(
+            provider="github",
+            sync_options={"all_repos": True, "search": "orgA/api*"},
+        )
+
+        result = discover_repos_for_config(
+            config,
+            {
+                "app_id": "123",
+                "private_key": "private-key",
+                "installation_id": "456",
+                "base_url": "https://api.github.test",
+            },
+        )
+
+        assert result == [("orgA", "api"), ("orgA", "api-worker")]
+        mock_token_provider_cls.assert_called_once_with(
+            app_id="123",
+            private_key="private-key",
+            installation_id="456",
+            api_base_url="https://api.github.test",
+        )
+        mock_get.assert_called_once()
+        assert mock_get.call_args.args[0] == (
+            "https://api.github.test/installation/repositories"
+        )
+        assert mock_get.call_args.kwargs["headers"]["Authorization"] == (
+            "Bearer installation-token"
+        )
+
+    @patch("requests.get")
+    @patch("dev_health_ops.connectors.utils.github_app.GitHubAppTokenProvider")
+    def test_github_app_all_repos_installation_api_failure_raises(
+        self, mock_token_provider_cls, mock_get
+    ):
+        from dev_health_ops.discovery.repos import discover_repos_for_config
+
+        mock_token_provider_cls.return_value.get_token.return_value = (
+            "installation-token"
+        )
+        mock_get.return_value = MagicMock(status_code=401, text="bad credentials")
+        config = _make_config(
+            provider="github",
+            sync_options={"all_repos": True, "search": "orgA/*"},
+        )
+
+        with pytest.raises(RuntimeError, match="HTTP 401"):
+            discover_repos_for_config(
+                config,
+                {
+                    "app_id": "123",
+                    "private_key": "private-key",
+                    "installation_id": "456",
+                },
+            )
+
     @patch("dev_health_ops.discovery.repos.discover_gitlab_repos")
     def test_gitlab_delegates_to_gitlab_discovery(self, mock_gl):
         from dev_health_ops.discovery.repos import discover_repos_for_config

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -87,6 +87,15 @@ class TestIsBatchEligible:
         )
         assert _is_batch_eligible(config) is True
 
+    def test_github_all_repos_with_concrete_repo_not_eligible(self):
+        from dev_health_ops.workers.sync_batch import _is_batch_eligible
+
+        config = _make_config(
+            provider="github",
+            sync_options={"all_repos": True, "owner": "org", "repo": "api"},
+        )
+        assert _is_batch_eligible(config) is False
+
     def test_github_bare_org_search_is_batch_eligible(self):
         from dev_health_ops.workers.sync_batch import _is_batch_eligible
 
@@ -134,6 +143,17 @@ class TestIsBatchEligible:
             sync_options={"all_repos": True},
         )
         assert _is_batch_eligible(config) is True
+
+    def test_gitlab_all_repos_with_concrete_project_not_eligible(self):
+        from dev_health_ops.workers.sync_batch import _is_batch_eligible
+
+        for sync_options in (
+            {"all_repos": True, "project_id": 100},
+            {"all_repos": True, "project": "api"},
+            {"all_repos": True, "repo": "api"},
+        ):
+            config = _make_config(provider="gitlab", sync_options=sync_options)
+            assert _is_batch_eligible(config) is False
 
     def test_jira_never_batch_eligible(self):
         from dev_health_ops.workers.sync_batch import _is_batch_eligible
@@ -406,6 +426,15 @@ class TestDiscoverGithubRepos:
         assert result == [("orgA", "api"), ("orgA", "web")]
 
     @patch("github.Github")
+    def test_all_repos_user_listing_failure_raises(self, mock_github_cls):
+        from dev_health_ops.discovery.repos import discover_github_repos
+
+        mock_github_cls.return_value.get_user.side_effect = RuntimeError("rate limited")
+
+        with pytest.raises(RuntimeError, match="rate limited"):
+            discover_github_repos({"all_repos": True, "search": "orgA/*"}, "token")
+
+    @patch("github.Github")
     def test_returns_empty_on_total_failure(self, mock_github_cls):
         from dev_health_ops.discovery.repos import discover_github_repos
 
@@ -524,6 +553,17 @@ class TestDiscoverGitlabRepos:
         result = discover_gitlab_repos({"all_repos": True, "owner": "grpA"}, "token")
 
         assert result == [("100",), ("200",)]
+
+    @patch("gitlab.Gitlab")
+    def test_all_repos_membership_listing_failure_raises(self, mock_gitlab_cls):
+        from dev_health_ops.discovery.repos import discover_gitlab_repos
+
+        mock_gitlab_cls.return_value.projects.list.side_effect = RuntimeError(
+            "token revoked"
+        )
+
+        with pytest.raises(RuntimeError, match="token revoked"):
+            discover_gitlab_repos({"all_repos": True, "search": "grpA/*"}, "token")
 
     def test_returns_empty_without_group_when_all_repos_false(self):
         from dev_health_ops.discovery.repos import discover_gitlab_repos
@@ -678,6 +718,42 @@ class TestDispatchBatchSync:
         mock_run_sync.apply_async.assert_called_once()
         # CHAOS-2299: the fallback dispatch stays on the provider's queue.
         assert mock_run_sync.apply_async.call_args.kwargs["queue"] == "sync.github"
+
+    @patch("dev_health_ops.workers.sync_batch.run_sync_config")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_all_repos_discovery_failure_marks_error_without_fallback(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_run_sync,
+        db_session,
+    ):
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        config = _make_config(
+            provider="github",
+            sync_options={"all_repos": True, "search": "org/*"},
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        mock_get_session.return_value = _fake_session_ctx(db_session)
+        mock_resolve_creds.return_value = {"token": "ghp_test"}
+        mock_discover.side_effect = RuntimeError("API rate limited")
+
+        task = dispatch_batch_sync
+        task.push_request(id="batch-dispatch-all-repos-failure")
+        try:
+            result = task(config_id=str(config.id), org_id="default")
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "error"
+        assert "API rate limited" in result["error"]
+        mock_run_sync.apply_async.assert_not_called()
 
     @patch("dev_health_ops.workers.sync_batch.chord")
     @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
@@ -855,7 +931,7 @@ class TestDispatchBatchSync:
         mock_run_for_repo.s.side_effect = _capture_signature
         config = _make_config(
             provider="github",
-            sync_options={"search": "org/*"},
+            sync_options={"search": "org/*", "all_repos": True},
             sync_targets=["git", "work-items"],
         )
         db_session.add(config)
@@ -875,6 +951,7 @@ class TestDispatchBatchSync:
 
         assert result["status"] == "dispatched"
         assert captured_kwargs[0]["sync_options_override"]["search"] == "org/repo-1"
+        assert "all_repos" not in captured_kwargs[0]["sync_options_override"]
 
 
 class TestGitLabCredentialsFromMapping:
@@ -1072,6 +1149,7 @@ class TestGitLabDispatchBatchSync:
             provider="gitlab",
             sync_options={
                 "search": "my-group/*",
+                "all_repos": True,
                 "gitlab_url": "https://gitlab.example.com",
             },
             sync_targets=["git", "prs"],
@@ -1103,6 +1181,7 @@ class TestGitLabDispatchBatchSync:
         override = first["sync_options_override"]
         assert override["project_id"] == 100
         assert override["gitlab_url"] == "https://gitlab.example.com"
+        assert "all_repos" not in override
         assert "search" not in override
         assert "group" not in override
 


### PR DESCRIPTION
## Summary

Fixes **"Sync all repositories"** so it enumerates every repository the credential can access, instead of the broken `owner/*` wildcard that returned nothing for a blank owner and only a single org otherwise.

- `sync_options.all_repos` is the token-wide signal. Blank namespace → all accessible repos; owner/group provided → that namespace (including private).
- **GitHub PAT**: authenticated `get_user().get_repos()`. **GitHub App**: `GET /installation/repositories`. **GitLab**: `projects.list(all=True, membership=True)`.
- Namespace narrowing via `repo.owner.login` (GitHub) / `path_with_namespace` (GitLab); nested GitLab subgroups (`group/subgroup/*`) supported.
- Batch eligibility recognizes `all_repos`; concrete-target child configs are excluded and `all_repos` is stripped from generated children to prevent re-discovery feedback loops.
- Discovery auth/API failures now propagate instead of being masked as a successful "0 repos" run.

## Testing

```bash
PYTHONPATH=src python -m pytest tests/test_sync_partitioning.py -q
# 152 passed
```

LSP/ruff clean on changed files.

## Review

Reviewed with codex adversarial review (gpt-5.5) across multiple rounds; findings on namespace over-scoping, GitHub App auth, batch-eligibility feedback loop, discovery-failure masking, and nested GitLab namespaces were all addressed.

Closes CHAOS-2445
Closes CHAOS-2446
Closes CHAOS-2447

Related: CHAOS-2444 (epic), CHAOS-2450 (deferred follow-up — GitLab work-items per-child scoping, pre-existing).
