### PR TITLE
fix(credentials): token-wide blank-owner repo discovery + SSRF guard (CHAOS-2449)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -145,11 +145,31 @@ async def list_credential_repos(
                 status_code=401, detail="GitHub App authentication failed"
             ) from exc
         try:
-            repos = github_connector.list_repositories(
-                org_name=effective_owner or None,
-                search=search,
-                max_repos=max_repos,
-            )
+            if not effective_owner and github_credentials.is_app_auth:
+                # GitHub App installation tokens have no user surface.
+                # Enumerate installation repos directly via the REST API,
+                # then apply search as a client-side name filter.
+                repos = await _list_github_app_installation_repos(
+                    github_credentials=github_credentials,
+                    base_url=github_credentials.base_url or "https://api.github.com",
+                    search=search,
+                    max_repos=max_repos,
+                )
+            elif not effective_owner and search:
+                # Blank owner + search: enumerate token-wide repos and filter
+                # client-side via pattern to avoid a global GitHub search.
+                repos = github_connector.list_repositories(
+                    org_name=None,
+                    search=None,
+                    pattern=f"*{search}*",
+                    max_repos=max_repos,
+                )
+            else:
+                repos = github_connector.list_repositories(
+                    org_name=effective_owner or None,
+                    search=search,
+                    max_repos=max_repos,
+                )
         except NotFoundException:
             return DiscoveredReposResponse(provider=provider, repos=[], total=0)
         except AuthenticationException as exc:
@@ -172,11 +192,21 @@ async def list_credential_repos(
         gitlab_connector = GitLabConnector(url=url, private_token=token)
         effective_owner = owner or _string_value(config.get("group"))
         try:
-            repos = gitlab_connector.list_repositories(
-                org_name=effective_owner or None,
-                search=search,
-                max_repos=max_repos,
-            )
+            if not effective_owner and search:
+                # Blank owner + search: enumerate token-scoped projects and
+                # filter client-side to avoid a global public-project search.
+                repos = gitlab_connector.list_repositories(
+                    org_name=None,
+                    search=None,
+                    pattern=f"*{search}*",
+                    max_repos=max_repos,
+                )
+            else:
+                repos = gitlab_connector.list_repositories(
+                    org_name=effective_owner or None,
+                    search=search,
+                    max_repos=max_repos,
+                )
         except NotFoundException:
             return DiscoveredReposResponse(provider=provider, repos=[], total=0)
         except AuthenticationException as exc:
@@ -386,6 +416,83 @@ def _build_safe_url(validated_base: str, path: str) -> str:
         f"{base_path}/{path.lstrip('/')}" if base_path else f"/{path.lstrip('/')}"
     )
     return urlunparse((parsed.scheme, parsed.netloc, safe_path, "", "", ""))
+
+
+async def _list_github_app_installation_repos(
+    github_credentials: Any,
+    base_url: str,
+    search: str | None,
+    max_repos: int,
+) -> list[Any]:
+    """Enumerate repos accessible to a GitHub App installation.
+
+    Uses the installation/repositories REST endpoint (paginated) so that
+    blank-owner discovery works for App auth, which has no user surface.
+    Applies search as a client-side name filter (fnmatch) to avoid a global
+    GitHub search.
+    """
+    import fnmatch
+    import httpx
+
+    from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
+    from dev_health_ops.connectors.models import Repository
+
+    assert github_credentials.app_id is not None
+    assert github_credentials.private_key is not None
+    assert github_credentials.installation_id is not None
+
+    token = GitHubAppTokenProvider(
+        app_id=github_credentials.app_id,
+        private_key=github_credentials.private_key,
+        installation_id=github_credentials.installation_id,
+        api_base_url=base_url,
+    ).get_token()
+
+    pattern = f"*{search}*" if search else None
+    repos: list[Any] = []
+    page = 1
+    per_page = 100
+
+    async with httpx.AsyncClient() as client:
+        while True:
+            resp = await client.get(
+                _build_safe_url(base_url, "installation/repositories"),
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+                params={"per_page": per_page, "page": page},
+                timeout=10,
+            )
+            if resp.status_code != 200:
+                break
+            data = resp.json()
+            page_repos = data.get("repositories", [])
+            if not page_repos:
+                break
+            for r in page_repos:
+                if pattern and not fnmatch.fnmatch(
+                    (r.get("full_name") or "").lower(), pattern.lower()
+                ):
+                    continue
+                repos.append(
+                    Repository(
+                        id=r["id"],
+                        name=r["name"],
+                        full_name=r["full_name"],
+                        default_branch=r.get("default_branch") or "main",
+                        description=r.get("description"),
+                        url=r.get("html_url") or "",
+                    )
+                )
+                if len(repos) >= max_repos:
+                    return repos
+            if len(page_repos) < per_page:
+                break
+            page += 1
+
+    return repos
 
 
 async def _test_github_connection(creds: dict[str, Any]) -> tuple[bool, dict[str, Any]]:

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -192,18 +192,20 @@ async def list_credential_repos(
         gitlab_connector = GitLabConnector(url=url, private_token=token)
         effective_owner = owner or _string_value(config.get("group"))
         try:
-            if not effective_owner and search:
-                # Blank owner + search: enumerate token-scoped projects and
-                # filter client-side to avoid a global public-project search.
-                repos = gitlab_connector.list_repositories(
-                    org_name=None,
-                    search=None,
-                    pattern=f"*{search}*",
+            if not effective_owner:
+                # Blank owner: enumerate only membership-scoped projects to
+                # avoid returning globally-visible public projects the token
+                # is not a member of. Bypass the connector (frozen) and call
+                # python-gitlab directly with membership=True.
+                repos = _list_gitlab_membership_repos(
+                    url=url,
+                    token=token,
+                    search=search,
                     max_repos=max_repos,
                 )
             else:
                 repos = gitlab_connector.list_repositories(
-                    org_name=effective_owner or None,
+                    org_name=effective_owner,
                     search=search,
                     max_repos=max_repos,
                 )
@@ -466,8 +468,36 @@ async def _list_github_app_installation_repos(
                 params={"per_page": per_page, "page": page},
                 timeout=10,
             )
+            if resp.status_code == 401 or (
+                resp.status_code == 403
+                and "rate limit" not in resp.text.lower()
+                and "x-ratelimit-remaining" not in resp.headers
+            ):
+                raise HTTPException(
+                    status_code=401,
+                    detail="GitHub App authentication failed",
+                )
+            if resp.status_code == 429 or (
+                resp.status_code == 403
+                and (
+                    "rate limit" in resp.text.lower()
+                    or "x-ratelimit-remaining" in resp.headers
+                )
+            ):
+                raise HTTPException(
+                    status_code=429,
+                    detail="GitHub API rate limit exceeded",
+                )
+            if resp.status_code >= 500:
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"GitHub API error: {resp.status_code}",
+                )
             if resp.status_code != 200:
-                break
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"GitHub API error: {resp.status_code}",
+                )
             data = resp.json()
             page_repos = data.get("repositories", [])
             if not page_repos:
@@ -492,6 +522,76 @@ async def _list_github_app_installation_repos(
             if len(page_repos) < per_page:
                 break
             page += 1
+
+    return repos
+
+
+def _list_gitlab_membership_repos(
+    url: str,
+    token: str,
+    search: str | None,
+    max_repos: int,
+) -> list[Any]:
+    """Enumerate GitLab projects the token is a member of (membership=True).
+
+    Bypasses the frozen connector to call python-gitlab directly with
+    membership=True, ensuring only credential-accessible projects are returned.
+    Applies search as a client-side fnmatch filter to avoid a global search.
+    """
+    import fnmatch
+
+    import gitlab
+    from gitlab.exceptions import GitlabAuthenticationError, GitlabError
+
+    from dev_health_ops.connectors.exceptions import (
+        AuthenticationException,
+        RateLimitException,
+    )
+    from dev_health_ops.connectors.models import Repository
+
+    gl = gitlab.Gitlab(url=url, private_token=token)
+    pattern = f"*{search}*" if search else None
+    repos: list[Any] = []
+    page = 1
+    per_page = 100
+
+    try:
+        while True:
+            gl_projects = gl.projects.list(
+                membership=True,
+                per_page=per_page,
+                page=page,
+            )
+            if not gl_projects:
+                break
+            for p in gl_projects:
+                full_name = getattr(p, "path_with_namespace", None) or getattr(
+                    p, "name", ""
+                )
+                if pattern and not fnmatch.fnmatch(full_name.lower(), pattern.lower()):
+                    continue
+                repos.append(
+                    Repository(
+                        id=p.id,
+                        name=p.name,
+                        full_name=full_name,
+                        default_branch=getattr(p, "default_branch", None) or "main",
+                        description=getattr(p, "description", None),
+                        url=getattr(p, "web_url", "") or "",
+                    )
+                )
+                if len(repos) >= max_repos:
+                    return repos
+            if len(gl_projects) < per_page:
+                break
+            page += 1
+    except GitlabAuthenticationError as exc:
+        raise AuthenticationException(str(exc)) from exc
+    except GitlabError as exc:
+        msg = str(exc).lower()
+        if "rate" in msg or "429" in msg:
+            raise RateLimitException(str(exc)) from exc
+        raise
 
     return repos
 

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -182,7 +182,9 @@ async def list_credential_repos(
         token = decrypted.get("token")
         url = (
             _string_value(decrypted.get("url"))
+            or _string_value(decrypted.get("base_url"))
             or _string_value(config.get("url"))
+            or _string_value(config.get("base_url"))
             or "https://gitlab.com"
         )
         if not token:

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -580,8 +580,10 @@ def _list_gitlab_membership_repos(
             if not gl_projects:
                 break
             for p in gl_projects:
-                full_name = getattr(p, "path_with_namespace", None) or getattr(
-                    p, "name", ""
+                full_name = str(
+                    getattr(p, "path_with_namespace", None)
+                    or getattr(p, "name", "")
+                    or ""
                 )
                 if pattern and not fnmatch.fnmatch(full_name.lower(), pattern.lower()):
                     continue

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -191,6 +191,9 @@ async def list_credential_repos(
             raise HTTPException(
                 status_code=400, detail="GitLab credential missing token"
             )
+        is_valid, url_error = _validate_external_url(url)
+        if not is_valid:
+            raise HTTPException(status_code=400, detail=url_error)
         gitlab_connector = GitLabConnector(url=url, private_token=token)
         effective_owner = owner or _string_value(config.get("group"))
         try:
@@ -470,22 +473,32 @@ async def _list_github_app_installation_repos(
                 params={"per_page": per_page, "page": page},
                 timeout=10,
             )
-            if resp.status_code == 401 or (
-                resp.status_code == 403
-                and "rate limit" not in resp.text.lower()
-                and "x-ratelimit-remaining" not in resp.headers
-            ):
+            if resp.status_code == 401:
                 raise HTTPException(
                     status_code=401,
                     detail="GitHub App authentication failed",
                 )
-            if resp.status_code == 429 or (
-                resp.status_code == 403
-                and (
-                    "rate limit" in resp.text.lower()
-                    or "x-ratelimit-remaining" in resp.headers
+            if resp.status_code == 403:
+                body_lower = resp.text.lower()
+                remaining = resp.headers.get("x-ratelimit-remaining")
+                retry_after = resp.headers.get("retry-after")
+                is_rate_limit = (
+                    remaining == "0"
+                    or retry_after is not None
+                    or "rate limit" in body_lower
+                    or "abuse" in body_lower
+                    or "secondary" in body_lower
                 )
-            ):
+                if is_rate_limit:
+                    raise HTTPException(
+                        status_code=429,
+                        detail="GitHub API rate limit exceeded",
+                    )
+                raise HTTPException(
+                    status_code=403,
+                    detail="GitHub App permission denied",
+                )
+            if resp.status_code == 429:
                 raise HTTPException(
                     status_code=429,
                     detail="GitHub API rate limit exceeded",

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -432,10 +432,11 @@ async def _list_github_app_installation_repos(
     GitHub search.
     """
     import fnmatch
+
     import httpx
 
-    from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
     from dev_health_ops.connectors.models import Repository
+    from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
 
     assert github_credentials.app_id is not None
     assert github_credentials.private_key is not None

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -138,8 +138,6 @@ async def list_credential_repos(
             or _string_value(config.get("org"))
             or _string_value(decrypted.get("org"))
         )
-        if not effective_owner:
-            return DiscoveredReposResponse(provider=provider, repos=[], total=0)
         try:
             github_connector = GitHubConnector(credentials=github_credentials)
         except Exception as exc:
@@ -148,7 +146,7 @@ async def list_credential_repos(
             ) from exc
         try:
             repos = github_connector.list_repositories(
-                org_name=effective_owner,
+                org_name=effective_owner or None,
                 search=search,
                 max_repos=max_repos,
             )
@@ -173,11 +171,9 @@ async def list_credential_repos(
             )
         gitlab_connector = GitLabConnector(url=url, private_token=token)
         effective_owner = owner or _string_value(config.get("group"))
-        if not effective_owner:
-            return DiscoveredReposResponse(provider=provider, repos=[], total=0)
         try:
             repos = gitlab_connector.list_repositories(
-                org_name=effective_owner,
+                org_name=effective_owner or None,
                 search=search,
                 max_repos=max_repos,
             )

--- a/tests/api/admin/test_credential_repos.py
+++ b/tests/api/admin/test_credential_repos.py
@@ -145,6 +145,7 @@ _FAKE_REPOS = [
 
 _DECRYPT_PATCH = "dev_health_ops.api.services.configuration.IntegrationCredentialsService.get_decrypted_credentials_by_id"
 _GH_CONNECTOR = "dev_health_ops.connectors.github.GitHubConnector"
+_GL_CONNECTOR = "dev_health_ops.connectors.gitlab.GitLabConnector"
 _GH_APP_PROVIDER = "dev_health_ops.connectors.utils.github_app.GitHubAppTokenProvider"
 
 
@@ -336,8 +337,11 @@ async def test_rate_limit_returns_429(client):
 
 
 @pytest.mark.asyncio
-async def test_no_owner_returns_empty_without_calling_connector(client):
-    """No owner param and no config.org → 200 empty, connector never called."""
+async def test_no_owner_github_enumerates_token_wide(client):
+    """Blank owner + no config.org → connector called without org_name (token-wide).
+
+    CHAOS-2449: previously returned empty list; now enumerates all accessible repos.
+    """
     ac, state = client
 
     with (
@@ -347,6 +351,7 @@ async def test_no_owner_returns_empty_without_calling_connector(client):
         ) as _,
         patch(_GH_CONNECTOR) as MockConnector,
     ):
+        MockConnector.return_value.list_repositories.return_value = _FAKE_REPOS
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
             # no owner query param
@@ -354,10 +359,12 @@ async def test_no_owner_returns_empty_without_calling_connector(client):
 
     assert resp.status_code == 200
     body = resp.json()
-    assert body["repos"] == []
-    assert body["total"] == 0
-    # Connector should never have been instantiated for the list call
-    MockConnector.return_value.list_repositories.assert_not_called()
+    assert body["total"] == 2
+    assert body["repos"][0]["name"] == "api-gateway"
+    # Connector must be called without org_name (None → token-wide)
+    MockConnector.return_value.list_repositories.assert_called_once_with(
+        org_name=None, search=None, max_repos=100
+    )
 
 
 @pytest.mark.asyncio
@@ -380,6 +387,53 @@ async def test_owner_falls_back_to_config_org(client):
     assert resp.json()["total"] == 2
     MockConnector.return_value.list_repositories.assert_called_once_with(
         org_name="my-org", search=None, max_repos=100
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_owner_gitlab_enumerates_token_wide(client):
+    """Blank owner + no config.group → GitLab connector called without org_name (token-wide).
+
+    CHAOS-2449: previously returned empty list; now enumerates all accessible projects.
+    """
+    ac, state = client
+
+    gl_repos = [
+        Repository(
+            id=10,
+            name="infra",
+            full_name="mygroup/infra",
+            default_branch="main",
+            description="Infrastructure repo",
+            url="https://gitlab.com/mygroup/infra",
+        ),
+    ]
+
+    with (
+        patch(
+            _DECRYPT_PATCH,
+            return_value=_mock_credential(
+                provider="gitlab",
+                config={},  # no group in config
+                credentials={"token": "glpat_fake"},
+            ),
+        ) as _,
+        patch(_GL_CONNECTOR) as MockGLConnector,
+    ):
+        MockGLConnector.return_value.list_repositories.return_value = gl_repos
+        resp = await ac.get(
+            f"/api/v1/admin/credentials/{state['cred_id']}/repos",
+            # no owner query param
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["provider"] == "gitlab"
+    assert body["total"] == 1
+    assert body["repos"][0]["name"] == "infra"
+    # Connector must be called without org_name (None → token-wide)
+    MockGLConnector.return_value.list_repositories.assert_called_once_with(
+        org_name=None, search=None, max_repos=100
     )
 
 

--- a/tests/api/admin/test_credential_repos.py
+++ b/tests/api/admin/test_credential_repos.py
@@ -641,6 +641,10 @@ async def test_gitlab_base_url_key_used_for_self_hosted(client):
         ) as _,
         patch(_GL_CONNECTOR) as MockGLConnector,
         patch(_GL_MEMBERSHIP_HELPER, return_value=gl_repos) as MockMembership,
+        patch(
+            "dev_health_ops.api.admin.routers.credentials.socket.getaddrinfo",
+            return_value=[(2, 1, 6, "", ("8.8.8.8", 0))],
+        ),
     ):
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
@@ -857,3 +861,107 @@ async def test_missing_token_returns_400(client):
 
     assert resp.status_code == 400
     assert "require either token" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests — Security / correctness fixes (review round 4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gitlab_internal_url_rejected_ssrf(client):
+    """GitLab credential with an internal/private base_url → HTTP 400 (SSRF guard).
+
+    CHAOS-2449 review round 4 (FINDING 1 HIGH): the GitLab branch of
+    list_credential_repos must validate the resolved URL with _validate_external_url
+    before constructing GitLabConnector or calling _list_gitlab_membership_repos,
+    so a tenant-controlled base_url cannot be used to exfiltrate the GitLab token
+    to an internal host.
+    """
+    ac, state = client
+
+    for internal_url in (
+        "http://localhost",
+        "http://169.254.169.254",
+        "http://192.168.1.1",
+    ):
+        with (
+            patch(
+                _DECRYPT_PATCH,
+                return_value=_mock_credential(
+                    provider="gitlab",
+                    config={},
+                    credentials={"token": "glpat_fake", "url": internal_url},
+                ),
+            ) as _,
+            patch(_GL_CONNECTOR) as MockGLConnector,
+            patch(_GL_MEMBERSHIP_HELPER) as MockMembership,
+        ):
+            resp = await ac.get(
+                f"/api/v1/admin/credentials/{state['cred_id']}/repos",
+            )
+
+        assert resp.status_code == 400, (
+            f"Expected 400 for {internal_url}, got {resp.status_code}"
+        )
+        # Connector and membership helper must NOT have been called
+        MockGLConnector.assert_not_called()
+        MockMembership.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_github_app_403_permission_not_rate_limit(client):
+    """App installation helper: 403 with x-ratelimit-remaining=4999 and a
+    permission-error body → auth/permission error (HTTP 403), NOT 429.
+
+    CHAOS-2449 review round 4 (FINDING 2 MEDIUM): the previous logic treated any
+    403 carrying an x-ratelimit-remaining header as a rate limit, causing admins
+    to be wrongly told to wait when the real problem is a missing permission or
+    SSO requirement.  A 403 is only a rate limit when remaining==0, Retry-After
+    is present, or the body explicitly mentions rate/abuse/secondary limiting.
+    """
+    ac, state = client
+    app_credentials = {
+        "app_id": "12345",
+        "private_key": "not-a-real-github-app-private-key",
+        "installation_id": "67890",
+    }
+
+    class _FakeResp:
+        status_code = 403
+        text = "Resource not accessible by integration"
+        headers = {"x-ratelimit-remaining": "4999"}
+
+        def json(self):
+            return {"message": "Resource not accessible by integration"}
+
+    class _FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, *args, **kwargs):
+            return _FakeResp()
+
+    with (
+        patch(
+            _DECRYPT_PATCH,
+            return_value=_mock_credential(config={}, credentials=app_credentials),
+        ) as _,
+        patch(_GH_CONNECTOR),
+        patch(_GH_APP_PROVIDER) as MockProvider,
+        patch("httpx.AsyncClient", return_value=_FakeAsyncClient()),
+    ):
+        MockProvider.return_value.get_token.return_value = "ghs_token"
+        resp = await ac.get(
+            f"/api/v1/admin/credentials/{state['cred_id']}/repos",
+        )
+
+    # Must NOT be 429 — remaining=4999 means quota is not exhausted
+    assert resp.status_code != 429, (
+        "Permission 403 must not be misreported as rate limit"
+    )
+    # Must be a client-side auth/permission error
+    assert resp.status_code in (401, 403)

--- a/tests/api/admin/test_credential_repos.py
+++ b/tests/api/admin/test_credential_repos.py
@@ -438,6 +438,162 @@ async def test_no_owner_gitlab_enumerates_token_wide(client):
 
 
 # ---------------------------------------------------------------------------
+# Tests — Blank-owner search safety (review findings)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_owner_github_search_uses_pattern_not_global_search(client):
+    """Blank owner + search → client-side pattern filter, NOT global search_repositories.
+
+    Finding 1 (HIGH): passing search= to the connector with no owner triggers a
+    global GitHub search that returns repos the credential cannot access.
+    Fix: enumerate token-wide repos and apply search as a pattern filter.
+    """
+    ac, state = client
+
+    with (
+        patch(
+            _DECRYPT_PATCH,
+            return_value=_mock_credential(config={}),  # no org in config
+        ) as _,
+        patch(_GH_CONNECTOR) as MockConnector,
+    ):
+        MockConnector.return_value.list_repositories.return_value = _FAKE_REPOS
+        resp = await ac.get(
+            f"/api/v1/admin/credentials/{state['cred_id']}/repos",
+            params={"search": "api"},  # search but no owner
+        )
+
+    assert resp.status_code == 200
+    # Must NOT have called search_repositories (global search)
+    MockConnector.return_value.search_repositories = MagicMock()
+    MockConnector.return_value.search_repositories.assert_not_called()
+    # Must have called list_repositories with pattern= (client-side filter), search=None
+    call_kwargs = MockConnector.return_value.list_repositories.call_args
+    assert call_kwargs is not None
+    assert call_kwargs.kwargs.get("search") is None or call_kwargs.args[1:2] == ()
+    assert call_kwargs.kwargs.get("pattern") == "*api*"
+    assert call_kwargs.kwargs.get("org_name") is None
+
+
+@pytest.mark.asyncio
+async def test_no_owner_github_app_uses_installation_repos(client):
+    """Blank owner + GitHub App auth → installation/repositories endpoint.
+
+    Finding 2 (MEDIUM): get_user().get_repos() fails for App installation tokens
+    because App tokens have no user surface. Fix: enumerate via the
+    installation/repositories REST API.
+    """
+    ac, state = client
+    app_credentials = {
+        "app_id": "12345",
+        "private_key": "not-a-real-github-app-private-key",
+        "installation_id": "67890",
+    }
+
+    class _FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {
+                "repositories": [
+                    {
+                        "id": 1,
+                        "name": "install-repo",
+                        "full_name": "org/install-repo",
+                        "default_branch": "main",
+                        "description": "Installation repo",
+                        "html_url": "https://github.com/org/install-repo",
+                    }
+                ],
+                "total_count": 1,
+            }
+
+    class _FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, *args, **kwargs):
+            return _FakeResp()
+
+    with (
+        patch(
+            _DECRYPT_PATCH,
+            return_value=_mock_credential(config={}, credentials=app_credentials),
+        ) as _,
+        patch(_GH_CONNECTOR) as MockConnector,
+        patch(_GH_APP_PROVIDER) as MockProvider,
+        patch("httpx.AsyncClient", return_value=_FakeAsyncClient()),
+    ):
+        MockProvider.return_value.get_token.return_value = "ghs_installation_token"
+        resp = await ac.get(
+            f"/api/v1/admin/credentials/{state['cred_id']}/repos",
+            # no owner — App auth blank-owner path
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["repos"][0]["name"] == "install-repo"
+    # The connector's list_repositories must NOT have been called
+    # (we bypass it for App auth + blank owner)
+    MockConnector.return_value.list_repositories.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_no_owner_gitlab_search_uses_pattern_not_global_search(client):
+    """Blank owner + search → GitLab uses client-side pattern, not global search.
+
+    GitLab's list_projects passes search= to the API which can return public
+    projects beyond the token's membership scope. Fix: enumerate token-scoped
+    projects (search=None) and apply search as a client-side pattern filter.
+    """
+    ac, state = client
+
+    gl_repos = [
+        Repository(
+            id=10,
+            name="infra-api",
+            full_name="mygroup/infra-api",
+            default_branch="main",
+            description="Infrastructure API",
+            url="https://gitlab.com/mygroup/infra-api",
+        ),
+    ]
+
+    with (
+        patch(
+            _DECRYPT_PATCH,
+            return_value=_mock_credential(
+                provider="gitlab",
+                config={},  # no group in config
+                credentials={"token": "glpat_fake"},
+            ),
+        ) as _,
+        patch(_GL_CONNECTOR) as MockGLConnector,
+    ):
+        MockGLConnector.return_value.list_repositories.return_value = gl_repos
+        resp = await ac.get(
+            f"/api/v1/admin/credentials/{state['cred_id']}/repos",
+            params={"search": "api"},  # search but no owner
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["provider"] == "gitlab"
+    # Must have called list_repositories with pattern= (client-side), search=None
+    call_kwargs = MockGLConnector.return_value.list_repositories.call_args
+    assert call_kwargs is not None
+    assert call_kwargs.kwargs.get("search") is None
+    assert call_kwargs.kwargs.get("pattern") == "*api*"
+    assert call_kwargs.kwargs.get("org_name") is None
+
+
+# ---------------------------------------------------------------------------
 # Tests — Edge cases
 # ---------------------------------------------------------------------------
 

--- a/tests/api/admin/test_credential_repos.py
+++ b/tests/api/admin/test_credential_repos.py
@@ -147,6 +147,9 @@ _DECRYPT_PATCH = "dev_health_ops.api.services.configuration.IntegrationCredentia
 _GH_CONNECTOR = "dev_health_ops.connectors.github.GitHubConnector"
 _GL_CONNECTOR = "dev_health_ops.connectors.gitlab.GitLabConnector"
 _GH_APP_PROVIDER = "dev_health_ops.connectors.utils.github_app.GitHubAppTokenProvider"
+_GL_MEMBERSHIP_HELPER = (
+    "dev_health_ops.api.admin.routers.credentials._list_gitlab_membership_repos"
+)
 
 
 def _mock_credential(provider="github", config=None, credentials=None):
@@ -391,10 +394,11 @@ async def test_owner_falls_back_to_config_org(client):
 
 
 @pytest.mark.asyncio
-async def test_no_owner_gitlab_enumerates_token_wide(client):
-    """Blank owner + no config.group → GitLab connector called without org_name (token-wide).
+async def test_no_owner_gitlab_enumerates_membership_scoped(client):
+    """Blank owner + no config.group → membership-scoped enumeration (not global).
 
-    CHAOS-2449: previously returned empty list; now enumerates all accessible projects.
+    CHAOS-2449 review finding 2: blank-owner GitLab must use membership=True
+    to avoid returning globally-visible public projects.
     """
     ac, state = client
 
@@ -419,8 +423,8 @@ async def test_no_owner_gitlab_enumerates_token_wide(client):
             ),
         ) as _,
         patch(_GL_CONNECTOR) as MockGLConnector,
+        patch(_GL_MEMBERSHIP_HELPER, return_value=gl_repos) as MockMembership,
     ):
-        MockGLConnector.return_value.list_repositories.return_value = gl_repos
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
             # no owner query param
@@ -431,10 +435,9 @@ async def test_no_owner_gitlab_enumerates_token_wide(client):
     assert body["provider"] == "gitlab"
     assert body["total"] == 1
     assert body["repos"][0]["name"] == "infra"
-    # Connector must be called without org_name (None → token-wide)
-    MockGLConnector.return_value.list_repositories.assert_called_once_with(
-        org_name=None, search=None, max_repos=100
-    )
+    # Must use membership-scoped helper, NOT the connector's unscoped list
+    MockMembership.assert_called_once()
+    MockGLConnector.return_value.list_repositories.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -545,12 +548,12 @@ async def test_no_owner_github_app_uses_installation_repos(client):
 
 
 @pytest.mark.asyncio
-async def test_no_owner_gitlab_search_uses_pattern_not_global_search(client):
-    """Blank owner + search → GitLab uses client-side pattern, not global search.
+async def test_no_owner_gitlab_search_uses_membership_scoped_with_pattern(client):
+    """Blank owner + search → membership-scoped enumeration with client-side pattern.
 
-    GitLab's list_projects passes search= to the API which can return public
-    projects beyond the token's membership scope. Fix: enumerate token-scoped
-    projects (search=None) and apply search as a client-side pattern filter.
+    CHAOS-2449 review finding 2: blank-owner GitLab must use membership=True
+    (via _list_gitlab_membership_repos) and apply search as a client-side
+    pattern filter, never a global public-project search.
     """
     ac, state = client
 
@@ -575,8 +578,8 @@ async def test_no_owner_gitlab_search_uses_pattern_not_global_search(client):
             ),
         ) as _,
         patch(_GL_CONNECTOR) as MockGLConnector,
+        patch(_GL_MEMBERSHIP_HELPER, return_value=gl_repos) as MockMembership,
     ):
-        MockGLConnector.return_value.list_repositories.return_value = gl_repos
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
             params={"search": "api"},  # search but no owner
@@ -585,12 +588,158 @@ async def test_no_owner_gitlab_search_uses_pattern_not_global_search(client):
     assert resp.status_code == 200
     body = resp.json()
     assert body["provider"] == "gitlab"
-    # Must have called list_repositories with pattern= (client-side), search=None
-    call_kwargs = MockGLConnector.return_value.list_repositories.call_args
-    assert call_kwargs is not None
-    assert call_kwargs.kwargs.get("search") is None
-    assert call_kwargs.kwargs.get("pattern") == "*api*"
-    assert call_kwargs.kwargs.get("org_name") is None
+    assert body["repos"][0]["name"] == "infra-api"
+    # Must use membership-scoped helper with search forwarded for client-side filtering
+    MockMembership.assert_called_once_with(
+        url="https://gitlab.com",
+        token="glpat_fake",
+        search="api",
+        max_repos=100,
+    )
+    # Must NOT have called the connector's unscoped list
+    MockGLConnector.return_value.list_repositories.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests — App installation helper error handling (review finding 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_github_app_installation_401_raises_auth_error(client):
+    """App installation helper: 401 response → HTTP 401, not a silent empty list."""
+    ac, state = client
+    app_credentials = {
+        "app_id": "12345",
+        "private_key": "not-a-real-github-app-private-key",
+        "installation_id": "67890",
+    }
+
+    class _FakeResp:
+        status_code = 401
+        text = "Bad credentials"
+        headers: dict = {}
+
+        def json(self):
+            return {"message": "Bad credentials"}
+
+    class _FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, *args, **kwargs):
+            return _FakeResp()
+
+    with (
+        patch(
+            _DECRYPT_PATCH,
+            return_value=_mock_credential(config={}, credentials=app_credentials),
+        ) as _,
+        patch(_GH_CONNECTOR),
+        patch(_GH_APP_PROVIDER) as MockProvider,
+        patch("httpx.AsyncClient", return_value=_FakeAsyncClient()),
+    ):
+        MockProvider.return_value.get_token.return_value = "ghs_bad_token"
+        resp = await ac.get(
+            f"/api/v1/admin/credentials/{state['cred_id']}/repos",
+        )
+
+    assert resp.status_code == 401
+    assert "authentication" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_github_app_installation_429_raises_rate_limit(client):
+    """App installation helper: 429 response → HTTP 429, not a silent empty list."""
+    ac, state = client
+    app_credentials = {
+        "app_id": "12345",
+        "private_key": "not-a-real-github-app-private-key",
+        "installation_id": "67890",
+    }
+
+    class _FakeResp:
+        status_code = 429
+        text = "rate limit exceeded"
+        headers: dict = {}
+
+        def json(self):
+            return {"message": "rate limit exceeded"}
+
+    class _FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, *args, **kwargs):
+            return _FakeResp()
+
+    with (
+        patch(
+            _DECRYPT_PATCH,
+            return_value=_mock_credential(config={}, credentials=app_credentials),
+        ) as _,
+        patch(_GH_CONNECTOR),
+        patch(_GH_APP_PROVIDER) as MockProvider,
+        patch("httpx.AsyncClient", return_value=_FakeAsyncClient()),
+    ):
+        MockProvider.return_value.get_token.return_value = "ghs_token"
+        resp = await ac.get(
+            f"/api/v1/admin/credentials/{state['cred_id']}/repos",
+        )
+
+    assert resp.status_code == 429
+    assert "rate limit" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_github_app_installation_5xx_raises_502(client):
+    """App installation helper: 5xx response → HTTP 502, not a silent empty list."""
+    ac, state = client
+    app_credentials = {
+        "app_id": "12345",
+        "private_key": "not-a-real-github-app-private-key",
+        "installation_id": "67890",
+    }
+
+    class _FakeResp:
+        status_code = 503
+        text = "Service Unavailable"
+        headers: dict = {}
+
+        def json(self):
+            return {}
+
+    class _FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, *args, **kwargs):
+            return _FakeResp()
+
+    with (
+        patch(
+            _DECRYPT_PATCH,
+            return_value=_mock_credential(config={}, credentials=app_credentials),
+        ) as _,
+        patch(_GH_CONNECTOR),
+        patch(_GH_APP_PROVIDER) as MockProvider,
+        patch("httpx.AsyncClient", return_value=_FakeAsyncClient()),
+    ):
+        MockProvider.return_value.get_token.return_value = "ghs_token"
+        resp = await ac.get(
+            f"/api/v1/admin/credentials/{state['cred_id']}/repos",
+        )
+
+    assert resp.status_code == 502
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/admin/test_credential_repos.py
+++ b/tests/api/admin/test_credential_repos.py
@@ -601,6 +601,66 @@ async def test_no_owner_gitlab_search_uses_membership_scoped_with_pattern(client
 
 
 # ---------------------------------------------------------------------------
+# Tests — GitLab base_url key fallback (review round 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gitlab_base_url_key_used_for_self_hosted(client):
+    """Credential with only base_url (no url) → discovery uses that host, not gitlab.com.
+
+    CHAOS-2449 review round 3: the GitLab url resolution previously only checked
+    decrypted['url'] and config['url'], so a self-hosted credential stored with
+    base_url would silently fall back to gitlab.com, disclosing the token to the
+    wrong host.
+    """
+    ac, state = client
+
+    gl_repos = [
+        Repository(
+            id=20,
+            name="self-hosted-repo",
+            full_name="mygroup/self-hosted-repo",
+            default_branch="main",
+            description=None,
+            url="https://gitlab.example.com/mygroup/self-hosted-repo",
+        ),
+    ]
+
+    with (
+        patch(
+            _DECRYPT_PATCH,
+            return_value=_mock_credential(
+                provider="gitlab",
+                config={},
+                credentials={
+                    "token": "glpat_selfhosted",
+                    "base_url": "https://gitlab.example.com",  # only base_url, no url
+                },
+            ),
+        ) as _,
+        patch(_GL_CONNECTOR) as MockGLConnector,
+        patch(_GL_MEMBERSHIP_HELPER, return_value=gl_repos) as MockMembership,
+    ):
+        resp = await ac.get(
+            f"/api/v1/admin/credentials/{state['cred_id']}/repos",
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["repos"][0]["name"] == "self-hosted-repo"
+    # Membership helper must be called with the self-hosted URL, NOT gitlab.com
+    MockMembership.assert_called_once_with(
+        url="https://gitlab.example.com",
+        token="glpat_selfhosted",
+        search=None,
+        max_repos=100,
+    )
+    MockGLConnector.return_value.list_repositories.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Tests — App installation helper error handling (review finding 1)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes the admin repo-browser endpoint `GET /credentials/{credential_id}/repos` so a **blank owner** lists credential-accessible repositories instead of returning an empty list.

- **Blank owner**: GitHub enumerates token-wide (or installation repositories for GitHub App credentials); GitLab uses a membership-scoped listing. Search is applied client-side, never via a global GitHub search.
- **GitLab URL** is resolved from `url`/`base_url` and validated with `_validate_external_url` before any client is constructed — prevents SSRF / token disclosure to internal or attacker-controlled hosts (mirrors `_test_gitlab_connection`).
- **GitHub App** installation API errors are classified correctly: 401 / 403 permission vs 429 rate-limit (only on `x-ratelimit-remaining == 0`, `Retry-After`, or abuse/secondary wording) vs 502.

## Testing

```bash
PYTHONPATH=src python -m pytest tests/api/admin/test_credential_repos.py -q
# 21 passed
```

LSP/ruff clean on changed files.

## Review

Reviewed with codex adversarial review (gpt-5.5) across multiple rounds; global-search over-scope, GitHub App auth path, GitLab membership scoping, `base_url` resolution, SSRF validation, and 403 classification findings were all addressed.

Closes CHAOS-2449
