### PR TITLE
fix(batch): scope GitLab work-items children to project path (CHAOS-2450)

### DIFF
--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -265,7 +265,7 @@ def discover_gitlab_repos(
             ):
                 continue
             if project_id is not None and fnmatch.fnmatch(name, project_pattern):
-                result.append((str(project_id),))
+                result.append((str(project_id), path_with_namespace))
 
         return result
 
@@ -283,6 +283,10 @@ def discover_gitlab_repos(
         name = getattr(group_project, "name", "") or ""
         project_id = getattr(group_project, "id", None)
         if project_id is not None and fnmatch.fnmatch(name, project_pattern):
-            result.append((str(project_id),))
+            path_with_namespace = (
+                getattr(group_project, "path_with_namespace", "")
+                or f"{group_path}/{name}"
+            )
+            result.append((str(project_id), path_with_namespace))
 
     return result

--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -283,10 +283,18 @@ def discover_gitlab_repos(
         name = getattr(group_project, "name", "") or ""
         project_id = getattr(group_project, "id", None)
         if project_id is not None and fnmatch.fnmatch(name, project_pattern):
+            # Prefer the canonical path_with_namespace, then the URL *path*
+            # slug. The display name can differ from the slug stored as the
+            # repo full_name downstream, so it is only a last resort for
+            # objects that expose neither path_with_namespace nor path. Leave
+            # empty if nothing usable is available; dispatch_batch_sync guards
+            # against an empty scope.
             path_with_namespace = (
-                getattr(group_project, "path_with_namespace", "")
-                or f"{group_path}/{name}"
+                getattr(group_project, "path_with_namespace", "") or ""
             )
+            if not path_with_namespace:
+                slug = getattr(group_project, "path", "") or name
+                path_with_namespace = f"{group_path}/{slug}" if slug else ""
             result.append((str(project_id), path_with_namespace))
 
     return result

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -452,7 +452,25 @@ def dispatch_batch_sync(
                 project_id = repo_tuple[0]
                 per_repo_options["project_id"] = int(project_id)
                 if "work-items" in sync_targets:
-                    per_repo_options["search"] = repo_tuple[1]
+                    project_path = repo_tuple[1] if len(repo_tuple) > 1 else ""
+                    if project_path:
+                        per_repo_options["search"] = project_path
+                    else:
+                        # Never pass an empty/all-matching search to a
+                        # work-items child: match_pattern("", ...) treats an
+                        # empty pattern as "match every repo", re-opening the
+                        # org-wide work-items fanout (CHAOS-2450). Scope to a
+                        # sentinel that cannot match any GitLab
+                        # path_with_namespace (which always contains "/") so
+                        # this project's work-items are skipped rather than
+                        # fanning out to all repos.
+                        logger.warning(
+                            "GitLab work-items child for project_id=%s has no "
+                            "project path; skipping work-items scope to avoid "
+                            "org-wide fanout",
+                            project_id,
+                        )
+                        per_repo_options["search"] = f"noscope-{project_id}"
                 else:
                     per_repo_options.pop("search", None)
                 per_repo_options.pop("group", None)

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -451,7 +451,10 @@ def dispatch_batch_sync(
             elif provider == "gitlab":
                 project_id = repo_tuple[0]
                 per_repo_options["project_id"] = int(project_id)
-                per_repo_options.pop("search", None)
+                if "work-items" in sync_targets:
+                    per_repo_options["search"] = repo_tuple[1]
+                else:
+                    per_repo_options.pop("search", None)
                 per_repo_options.pop("group", None)
 
             child_signature = getattr(_run_sync_for_repo, "s")(

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -469,6 +469,23 @@ class TestDiscoverGitlabRepos:
         assert result == [("100", "my-group/api")]
 
     @patch("gitlab.Gitlab")
+    def test_group_project_scope_uses_path_slug_not_display_name(self, mock_gitlab_cls):
+        """CHAOS-2450: when a group project lacks path_with_namespace, the scope
+        must use the URL path slug (canonical, matches the stored repo full_name)
+        not the display name, which can diverge and silently fail work-items
+        scoping.
+        """
+        from dev_health_ops.discovery.repos import discover_gitlab_repos
+
+        proj = SimpleNamespace(name="API Service", path="api-service", id=100)
+        mock_grp = MagicMock()
+        mock_grp.projects.list.return_value = [proj]
+        mock_gitlab_cls.return_value.groups.get.return_value = mock_grp
+
+        result = discover_gitlab_repos({"search": "my-group/*"}, "glpat_token")
+        assert result == [("100", "my-group/api-service")]
+
+    @patch("gitlab.Gitlab")
     def test_bare_group_search_lists_all_group_projects(self, mock_gitlab_cls):
         from dev_health_ops.discovery.repos import discover_gitlab_repos
 

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -1392,6 +1392,71 @@ class TestGitLabDispatchBatchSync:
         assert override["project_id"] == 100
         assert "search" not in override
 
+    @patch("dev_health_ops.workers.sync_batch._run_sync_for_repo")
+    @patch("dev_health_ops.workers.sync_batch.chord")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_gitlab_work_items_child_empty_path_is_not_unscoped(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_chord,
+        mock_run_for_repo,
+        db_session,
+    ):
+        """CHAOS-2450: a GitLab project discovered without a path_with_namespace
+        must NOT produce an empty/all-matching search (match_pattern treats an
+        empty pattern as "match every repo"), which would re-open the org-wide
+        work-items fanout. The child must carry a non-empty, non-wildcard scope
+        that cannot match any path_with_namespace.
+        """
+        from dev_health_ops.utils import match_pattern
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        captured_kwargs = []
+
+        def _capture_signature(**kwargs):
+            captured_kwargs.append(kwargs)
+            return MagicMock()
+
+        mock_run_for_repo.s.side_effect = _capture_signature
+        config = _make_config(
+            provider="gitlab",
+            sync_options={
+                "all_repos": True,
+                "group": "grpA",
+                "gitlab_url": "https://gitlab.example.com",
+            },
+            sync_targets=["git", "work-items"],
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        mock_get_session.return_value = _fake_session_ctx(db_session)
+        mock_resolve_creds.return_value = {"token": "glpat_test"}
+        # Degraded GitLab response: project with no path_with_namespace.
+        mock_discover.return_value = [("300", "")]
+        mock_chord.return_value = MagicMock()
+
+        task = dispatch_batch_sync
+        task.push_request(id="gl-wi-scope-empty")
+        try:
+            result = task(config_id=str(config.id), org_id="default")
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "dispatched"
+        override = captured_kwargs[0]["sync_options_override"]
+        assert override["project_id"] == 300
+        search = override["search"]
+        # Must be a real, non-wildcard scope (not empty, not "*").
+        assert search not in ("", "*")
+        # And it must not match an arbitrary repo path (no org-wide fanout).
+        assert match_pattern("grpA/api", search) is False
+        assert match_pattern("other/repo", search) is False
+
 
 class TestRunSyncForRepoWatermarks:
     """Batch children must honour and stamp sync watermarks (CHAOS-2281),

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -277,13 +277,13 @@ class TestDiscoverReposForConfig:
     def test_gitlab_delegates_to_gitlab_discovery(self, mock_gl):
         from dev_health_ops.discovery.repos import discover_repos_for_config
 
-        mock_gl.return_value = [("123",), ("456",)]
+        mock_gl.return_value = [("123", "grp/proj-a"), ("456", "grp/proj-b")]
         config = _make_config(
             provider="gitlab",
             sync_options={"search": "my-group/*"},
         )
         result = discover_repos_for_config(config, {"token": "glpat_test"})
-        assert result == [("123",), ("456",)]
+        assert result == [("123", "grp/proj-a"), ("456", "grp/proj-b")]
         mock_gl.assert_called_once()
 
     def test_unsupported_provider_returns_empty(self):
@@ -466,7 +466,7 @@ class TestDiscoverGitlabRepos:
         mock_gitlab_cls.return_value.groups.get.return_value = mock_grp
 
         result = discover_gitlab_repos({"search": "my-group/api*"}, "glpat_token")
-        assert result == [("100",)]
+        assert result == [("100", "my-group/api")]
 
     @patch("gitlab.Gitlab")
     def test_bare_group_search_lists_all_group_projects(self, mock_gitlab_cls):
@@ -481,7 +481,7 @@ class TestDiscoverGitlabRepos:
         result = discover_gitlab_repos({"search": "my-group"}, "glpat_token")
 
         mock_gitlab_cls.return_value.groups.get.assert_called_once_with("my-group")
-        assert result == [("100",), ("200",)]
+        assert result == [("100", "my-group/api"), ("200", "my-group/web")]
 
     @patch("gitlab.Gitlab")
     def test_returns_empty_on_group_error(self, mock_gitlab_cls):
@@ -496,8 +496,8 @@ class TestDiscoverGitlabRepos:
         from dev_health_ops.discovery.repos import discover_gitlab_repos
 
         projects = [
-            SimpleNamespace(name="api", id=100),
-            SimpleNamespace(name="web", id=200),
+            SimpleNamespace(name="api", id=100, path_with_namespace="ns/api"),
+            SimpleNamespace(name="web", id=200, path_with_namespace="ns/web"),
         ]
         mock_gitlab_cls.return_value.projects.list.return_value = projects
 
@@ -507,22 +507,24 @@ class TestDiscoverGitlabRepos:
             all=True, membership=True
         )
         mock_gitlab_cls.return_value.groups.get.assert_not_called()
-        assert result == [("100",), ("200",)]
+        assert result == [("100", "ns/api"), ("200", "ns/web")]
 
     @patch("gitlab.Gitlab")
     def test_all_repos_filters_membership_projects(self, mock_gitlab_cls):
         from dev_health_ops.discovery.repos import discover_gitlab_repos
 
         projects = [
-            SimpleNamespace(name="api", id=100),
-            SimpleNamespace(name="web", id=200),
-            SimpleNamespace(name="api-worker", id=300),
+            SimpleNamespace(name="api", id=100, path_with_namespace="ns/api"),
+            SimpleNamespace(name="web", id=200, path_with_namespace="ns/web"),
+            SimpleNamespace(
+                name="api-worker", id=300, path_with_namespace="ns/api-worker"
+            ),
         ]
         mock_gitlab_cls.return_value.projects.list.return_value = projects
 
         result = discover_gitlab_repos({"all_repos": True, "search": "api*"}, "token")
 
-        assert result == [("100",), ("300",)]
+        assert result == [("100", "ns/api"), ("300", "ns/api-worker")]
 
     @patch("gitlab.Gitlab")
     def test_all_repos_group_limits_membership_projects(self, mock_gitlab_cls):
@@ -537,7 +539,7 @@ class TestDiscoverGitlabRepos:
 
         result = discover_gitlab_repos({"all_repos": True, "group": "grpA"}, "token")
 
-        assert result == [("100",), ("200",)]
+        assert result == [("100", "grpA/api"), ("200", "grpA/sub/web")]
 
     @patch("gitlab.Gitlab")
     def test_all_repos_owner_limits_membership_projects(self, mock_gitlab_cls):
@@ -552,7 +554,7 @@ class TestDiscoverGitlabRepos:
 
         result = discover_gitlab_repos({"all_repos": True, "owner": "grpA"}, "token")
 
-        assert result == [("100",), ("200",)]
+        assert result == [("100", "grpA/api"), ("200", "grpA/sub/web")]
 
     @patch("gitlab.Gitlab")
     def test_all_repos_nested_subgroup_search(self, mock_gitlab_cls):
@@ -569,7 +571,7 @@ class TestDiscoverGitlabRepos:
             {"all_repos": True, "search": "grpA/sub/*"}, "token"
         )
 
-        assert result == [("100",)]
+        assert result == [("100", "grpA/sub/api")]
 
     @patch("gitlab.Gitlab")
     def test_all_repos_membership_listing_failure_raises(self, mock_gitlab_cls):
@@ -1176,7 +1178,10 @@ class TestGitLabDispatchBatchSync:
 
         mock_get_session.return_value = _fake_session_ctx(db_session)
         mock_resolve_creds.return_value = {"token": "glpat_test"}
-        mock_discover.return_value = [("100",), ("200",)]
+        mock_discover.return_value = [
+            ("100", "my-group/proj-a"),
+            ("200", "my-group/proj-b"),
+        ]
         mock_chord.return_value = MagicMock()
 
         task = dispatch_batch_sync
@@ -1208,7 +1213,7 @@ class TestGitLabDispatchBatchSync:
     def test_discovery_resolves_gitlab_url_from_credentials(self, mock_gl):
         from dev_health_ops.discovery.repos import discover_repos_for_config
 
-        mock_gl.return_value = [("100",)]
+        mock_gl.return_value = [("100", "my-group/proj-a")]
         config = _make_config(
             provider="gitlab",
             sync_options={"search": "my-group/*"},
@@ -1216,7 +1221,7 @@ class TestGitLabDispatchBatchSync:
         result = discover_repos_for_config(
             config, {"token": "glpat_test", "url": "https://gl.corp.internal"}
         )
-        assert result == [("100",)]
+        assert result == [("100", "my-group/proj-a")]
         args, kwargs = mock_gl.call_args
         assert args[1] == "glpat_test"
         assert kwargs["gitlab_url"] == "https://gl.corp.internal"
@@ -1259,6 +1264,133 @@ class TestGitLabDispatchBatchSync:
             },
         )
         assert _is_batch_eligible(single) is False
+
+    @patch("dev_health_ops.workers.sync_batch._run_sync_for_repo")
+    @patch("dev_health_ops.workers.sync_batch.chord")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_gitlab_work_items_child_search_is_scoped_to_project_path(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_chord,
+        mock_run_for_repo,
+        db_session,
+    ):
+        """CHAOS-2450: GitLab work-items batch children must carry a project-scoped
+        search (path_with_namespace) so run_work_items_sync_job filters to exactly
+        one project instead of syncing every discovered repo.
+        """
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        captured_kwargs = []
+
+        def _capture_signature(**kwargs):
+            captured_kwargs.append(kwargs)
+            return MagicMock()
+
+        mock_run_for_repo.s.side_effect = _capture_signature
+        config = _make_config(
+            provider="gitlab",
+            sync_options={
+                "all_repos": True,
+                "group": "grpA",
+                "gitlab_url": "https://gitlab.example.com",
+            },
+            sync_targets=["git", "work-items"],
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        mock_get_session.return_value = _fake_session_ctx(db_session)
+        mock_resolve_creds.return_value = {"token": "glpat_test"}
+        # Two projects in the group, each with a distinct path_with_namespace.
+        mock_discover.return_value = [
+            ("100", "grpA/api"),
+            ("200", "grpA/sub/worker"),
+        ]
+        mock_chord.return_value = MagicMock()
+
+        task = dispatch_batch_sync
+        task.push_request(id="gl-wi-scope-1")
+        try:
+            result = task(config_id=str(config.id), org_id="default")
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "dispatched"
+        assert len(captured_kwargs) == 2
+
+        # Each child must carry the project-specific path as search so
+        # run_work_items_sync_job scopes to exactly that one project.
+        assert captured_kwargs[0]["sync_options_override"]["search"] == "grpA/api"
+        assert captured_kwargs[0]["sync_options_override"]["project_id"] == 100
+        assert (
+            captured_kwargs[1]["sync_options_override"]["search"] == "grpA/sub/worker"
+        )
+        assert captured_kwargs[1]["sync_options_override"]["project_id"] == 200
+
+        # Batch-level keys must be stripped from every child.
+        for kw in captured_kwargs:
+            assert "all_repos" not in kw["sync_options_override"]
+            assert "group" not in kw["sync_options_override"]
+
+    @patch("dev_health_ops.workers.sync_batch._run_sync_for_repo")
+    @patch("dev_health_ops.workers.sync_batch.chord")
+    @patch("dev_health_ops.discovery.repos.discover_repos_for_config")
+    @patch("dev_health_ops.workers.sync_batch._resolve_env_credentials")
+    @patch("dev_health_ops.db.get_postgres_session_sync")
+    def test_gitlab_no_work_items_child_has_no_search(
+        self,
+        mock_get_session,
+        mock_resolve_creds,
+        mock_discover,
+        mock_chord,
+        mock_run_for_repo,
+        db_session,
+    ):
+        """CHAOS-2450: when work-items is NOT in sync_targets the GitLab child
+        must NOT carry a search key (mirrors existing GitHub behaviour).
+        """
+        from dev_health_ops.workers.sync_batch import dispatch_batch_sync
+
+        captured_kwargs = []
+
+        def _capture_signature(**kwargs):
+            captured_kwargs.append(kwargs)
+            return MagicMock()
+
+        mock_run_for_repo.s.side_effect = _capture_signature
+        config = _make_config(
+            provider="gitlab",
+            sync_options={
+                "all_repos": True,
+                "group": "grpA",
+                "gitlab_url": "https://gitlab.example.com",
+            },
+            sync_targets=["git", "prs"],
+        )
+        db_session.add(config)
+        db_session.flush()
+
+        mock_get_session.return_value = _fake_session_ctx(db_session)
+        mock_resolve_creds.return_value = {"token": "glpat_test"}
+        mock_discover.return_value = [("100", "grpA/api")]
+        mock_chord.return_value = MagicMock()
+
+        task = dispatch_batch_sync
+        task.push_request(id="gl-wi-scope-2")
+        try:
+            result = task(config_id=str(config.id), org_id="default")
+        finally:
+            task.pop_request()
+
+        assert result["status"] == "dispatched"
+        override = captured_kwargs[0]["sync_options_override"]
+        assert override["project_id"] == 100
+        assert "search" not in override
 
 
 class TestRunSyncForRepoWatermarks:
@@ -2023,7 +2155,7 @@ class TestBatchChildrenQueueRouting:
 
         mock_get_session.return_value = _fake_session_ctx(db_session)
         mock_resolve_creds.return_value = {"token": "glpat_test"}
-        mock_discover.return_value = [("100",)]
+        mock_discover.return_value = [("100", "my-group/proj-a")]
         mock_chord.return_value = MagicMock()
 
         task = dispatch_batch_sync
@@ -2430,7 +2562,7 @@ class TestDispatchBatchSyncCredentialConfig:
             ),
         ):
             mock_run_for_repo.s.side_effect = _capture_signature
-            mock_discover.return_value = [("100",)]
+            mock_discover.return_value = [("100", "my-group/proj-a")]
 
             task = dispatch_batch_sync
             task.push_request(id=f"gl-cred-config-{_uuid.uuid4()}")


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug surfaced during the CHAOS-2444 adversarial review: GitLab **work-items** batch children were not scoped to their project, so a GitLab sync config with `work-items` in `sync_targets` re-synced work items for **every** GitLab repo in the org — once per discovered project (duplicate fetches, bypassing namespace narrowing). Git/PR/CI children were already scoped; only the work-items child was not.

## Root cause

- `dispatch_batch_sync` set only `project_id` on GitLab per-repo children (never `repo`/`search`), while the work-items dispatch scopes via `run_work_items_sync_job(repo_name=..., search_pattern=...)`.
- `run_work_items_sync_job` has no `project_id` parameter — it filters `discovered_repos` by `match_pattern(r.full_name, search_pattern)`, where GitLab `full_name` is `path_with_namespace`. With `search_pattern=None`, no filtering happened → all repos synced.

## Fix (mirrors the existing GitHub `owner/repo` scoping)

- `discover_gitlab_repos` now returns `(project_id, path_with_namespace)` 2-tuples (both the `all_repos` and group branches; group branch falls back to `<group>/<name>` if the API object lacks the attribute). GitHub tuple shape unchanged.
- `dispatch_batch_sync` sets `search = path_with_namespace` on GitLab children when `work-items` is in `sync_targets`, so the work-items child scopes to exactly that project.

`match_pattern` uses `fnmatch.fnmatch` (case-insensitive, full-string) — an exact path like `grpA/api` matches only that project and never over-matches a sibling such as `grpA/api-worker`.

## Testing

```bash
PYTHONPATH=src python -m pytest tests/test_sync_partitioning.py -q
# 154 passed
```

- Updated existing GitLab discovery tests for the 2-tuple shape.
- Added regression tests: a GitLab work-items batch child carries a project-scoped `search` (the path); a non-work-items child carries no `search`.

mypy clean, ruff clean on changed files.

Closes CHAOS-2450
