### PR TITLE
fix(work-graph): per-tab edge_types + server-side flow/artifacts aggregates (CHAOS-2442)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/inputs.py
+++ b/src/dev_health_ops/api/graphql/models/inputs.py
@@ -306,6 +306,13 @@ class WorkGraphEdgeFilterInput:
     source_type: WorkGraphNodeTypeInput | None = None
     target_type: WorkGraphNodeTypeInput | None = None
     edge_type: WorkGraphEdgeTypeInput | None = None
+    # Plural edge-type filter (wire: ``edgeTypes``). Lets a tab fetch its OWN
+    # edge types BEFORE the row cap so a starved category (e.g. the
+    # Dependencies tab's issue↔issue edges) is never hidden behind the LIMIT
+    # by an unrelated dominant edge type (CHAOS-2442). Applied as
+    # ``edge_type IN (...)``. When BOTH ``edge_type`` and ``edge_types`` are
+    # given, they AND (both clauses apply).
+    edge_types: list[WorkGraphEdgeTypeInput] | None = None
     node_id: str | None = None
     theme: str | None = None
     subcategory: str | None = None

--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -571,6 +571,63 @@ class WorkGraphEdgesResult:
     degraded_reason: str | None = None
 
 
+@strawberry.type
+class WorkGraphFlowRow:
+    """Inflow/outflow edge counts for one node type, computed over the FULL
+    edge set (correct at any scale — NOT derived from a capped edge page).
+
+    ``inflow`` counts edges whose TARGET is this node type; ``outflow`` counts
+    edges whose SOURCE is this node type (CHAOS-2442 Inflow/Outflow tab).
+    """
+
+    node_type: WorkGraphNodeType
+    inflow: int
+    outflow: int
+
+
+@strawberry.type
+class WorkGraphFlowResult:
+    """Per-node-type inflow/outflow aggregate over the whole work graph.
+
+    ``degraded_reason`` follows the same contract as ``WorkGraphEdgesResult``:
+    ``"MEMBERSHIP_NOT_MATERIALIZED"`` only when a theme/subcategory filter is
+    active, the aggregate is empty, and the org has investments but no complete
+    membership run yet; ``None`` otherwise (CHAOS-2442).
+    """
+
+    rows: list[WorkGraphFlowRow]
+    degraded_reason: str | None = None
+
+
+@strawberry.type
+class WorkGraphArtifactRow:
+    """A single node ranked by degree (edges touching it as source OR target),
+    computed over the FULL edge set (CHAOS-2442 Artifacts tab).
+
+    ``display_name`` is the A7/A8-resolved label (None → client Unresolved
+    badge, never a raw UUID). ``evidence`` is an opaque sample edge evidence
+    string (or None).
+    """
+
+    node_type: WorkGraphNodeType
+    node_id: str
+    display_name: str | None
+    degree: int
+    evidence: str | None
+
+
+@strawberry.type
+class WorkGraphArtifactsResult:
+    """Top-N nodes by degree across the whole work graph.
+
+    ``degraded_reason`` follows the same contract as ``WorkGraphEdgesResult``
+    (CHAOS-2442).
+    """
+
+    rows: list[WorkGraphArtifactRow]
+    degraded_reason: str | None = None
+
+
 # =============================================================================
 # Capacity Planning types
 # =============================================================================

--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections import defaultdict
 from typing import Any
 
 from dev_health_ops.api.services.identity import looks_like_uuid
@@ -13,9 +14,13 @@ from ..context import GraphQLContext
 from ..models.inputs import WorkGraphEdgeFilterInput
 from ..models.outputs import (
     PageInfo,
+    WorkGraphArtifactRow,
+    WorkGraphArtifactsResult,
     WorkGraphEdgeResult,
     WorkGraphEdgesResult,
     WorkGraphEdgeType,
+    WorkGraphFlowResult,
+    WorkGraphFlowRow,
     WorkGraphNodeType,
     WorkGraphProvenance,
 )
@@ -737,6 +742,99 @@ def _empty_edges_result(degraded_reason: str | None = None) -> WorkGraphEdgesRes
     )
 
 
+def _empty_flow_result(degraded_reason: str | None = None) -> WorkGraphFlowResult:
+    """An empty, well-formed flow aggregate — impossible filters + degraded state."""
+    return WorkGraphFlowResult(rows=[], degraded_reason=degraded_reason)
+
+
+def _empty_artifacts_result(
+    degraded_reason: str | None = None,
+) -> WorkGraphArtifactsResult:
+    """An empty, well-formed artifacts aggregate — impossible filters + degraded."""
+    return WorkGraphArtifactsResult(rows=[], degraded_reason=degraded_reason)
+
+
+def _build_work_graph_where(
+    filters: WorkGraphEdgeFilterInput | None,
+    org_id: str,
+    *,
+    include_edge_filters: bool,
+) -> tuple[str, dict[str, Any]]:
+    """Build the shared WHERE clause + params for the edge list AND aggregates.
+
+    ALWAYS applies the graph-wide filters: org_id (cross-tenant safety),
+    repo_ids, and the theme/subcategory correlated-EXISTS semi-join. These
+    describe the WHOLE graph, so both the capped edge list and the full-set
+    aggregates (flow / artifacts) apply them identically.
+
+    When ``include_edge_filters`` is True, ALSO applies the edge-list-only
+    filters — source_type/target_type/edge_type/edge_types/node_id — which
+    narrow WHICH edges a single view shows. The aggregates describe the whole
+    graph and therefore pass ``include_edge_filters=False``.
+
+    org_id is ALWAYS the first predicate (and lives inside the EXISTS join
+    predicate too — see ``_theme_membership_exists_clause``). Callers MUST
+    screen for ``_theme_subcategory_conflict`` first and short-circuit to an
+    empty result; this builder assumes a non-conflicting theme/subcategory.
+    """
+    params: dict[str, Any] = {"org_id": org_id}
+    where_clauses: list[str] = ["org_id = %(org_id)s"]
+
+    theme_filter = filters.theme if filters else None
+    subcategory_filter = filters.subcategory if filters else None
+
+    if filters:
+        if filters.repo_ids:
+            where_clauses.append("repo_id IN %(repo_ids)s")
+            params["repo_ids"] = filters.repo_ids
+
+        if include_edge_filters:
+            if filters.source_type:
+                where_clauses.append("source_type = %(source_type)s")
+                params["source_type"] = filters.source_type.value
+
+            if filters.target_type:
+                where_clauses.append("target_type = %(target_type)s")
+                params["target_type"] = filters.target_type.value
+
+            if filters.edge_type:
+                where_clauses.append("edge_type = %(edge_type)s")
+                params["edge_type"] = filters.edge_type.value
+
+            # Plural edge_types: fetched BEFORE the cap so a tab's own edge
+            # types can never be starved by an unrelated dominant type
+            # (CHAOS-2442). ANDs with the singular edge_type when both given.
+            if filters.edge_types:
+                where_clauses.append("edge_type IN %(edge_types)s")
+                params["edge_types"] = [e.value for e in filters.edge_types]
+
+            if filters.node_id:
+                where_clauses.append(
+                    "(source_id = %(node_id)s OR target_id = %(node_id)s)"
+                )
+                params["node_id"] = filters.node_id
+
+    # --- Server-side theme/subcategory filter (CHAOS-2430) --------------------
+    # The membership constraint is pushed INTO the query as a correlated EXISTS
+    # semi-join, so repo_id/edge filters AND the membership filter AND any LIMIT
+    # all execute in ONE ClickHouse plan. This keeps the before-LIMIT guarantee
+    # (a sparse theme's edges are never hidden behind the row cap) WITHOUT
+    # round-tripping an unbounded matched-node set through Python. An edge
+    # matches if EITHER endpoint is a member of the requested theme/subcategory
+    # (multi-membership), with the theme+subcategory "both required" semantics
+    # enforced inside the subquery.
+    if theme_filter or subcategory_filter:
+        exists_clause, theme_params = _build_theme_filter(
+            theme_filter, subcategory_filter
+        )
+        if exists_clause:
+            where_clauses.append(exists_clause)
+            params.update(theme_params)
+
+    where_sql = f"WHERE {' AND '.join(where_clauses)}"
+    return where_sql, params
+
+
 async def resolve_work_graph_edges(
     context: GraphQLContext,
     filters: WorkGraphEdgeFilterInput | None = None,
@@ -750,8 +848,6 @@ async def resolve_work_graph_edges(
         raise RuntimeError("Database client not available")
 
     limit = filters.limit if filters else 1000
-    params: dict[str, Any] = {"limit": int(limit), "org_id": org_id}
-    where_clauses: list[str] = ["org_id = %(org_id)s"]
 
     theme_filter = filters.theme if filters else None
     subcategory_filter = filters.subcategory if filters else None
@@ -770,47 +866,39 @@ async def resolve_work_graph_edges(
         )
         return _empty_edges_result()
 
-    if filters:
-        if filters.repo_ids:
-            where_clauses.append("repo_id IN %(repo_ids)s")
-            params["repo_ids"] = filters.repo_ids
+    where_sql, params = _build_work_graph_where(
+        filters, org_id, include_edge_filters=True
+    )
+    params["limit"] = int(limit)
 
-        if filters.source_type:
-            where_clauses.append("source_type = %(source_type)s")
-            params["source_type"] = filters.source_type.value
-
-        if filters.target_type:
-            where_clauses.append("target_type = %(target_type)s")
-            params["target_type"] = filters.target_type.value
-
-        if filters.edge_type:
-            where_clauses.append("edge_type = %(edge_type)s")
-            params["edge_type"] = filters.edge_type.value
-
-        if filters.node_id:
-            where_clauses.append("(source_id = %(node_id)s OR target_id = %(node_id)s)")
-            params["node_id"] = filters.node_id
-
-    # --- Server-side theme/subcategory filter (CHAOS-2430) --------------------
-    # The membership constraint is pushed INTO the edge query as a correlated
-    # EXISTS semi-join, so repo_id/edge_type/source filters AND the membership
-    # filter AND the LIMIT all execute in ONE ClickHouse plan. This keeps the
-    # before-LIMIT guarantee (a sparse theme's edges are never hidden behind the
-    # row cap) WITHOUT round-tripping an unbounded matched-node set through
-    # Python (which could blow param limits / time out at tenant scale and
-    # ignored repo/edge filters). An edge matches if EITHER endpoint is a member
-    # of the requested theme/subcategory (multi-membership), with the
-    # theme+subcategory "both required" semantics enforced inside the subquery.
-    if theme_filter_active:
-        exists_clause, theme_params = _build_theme_filter(
-            theme_filter, subcategory_filter
+    # ORDER BY confidence DESC, edge_id ASC (CHAOS-2442) — GATED on a narrowing
+    # filter being active. The table is sorted by (source_type, source_id,
+    # edge_type, target_type, target_id), NOT confidence, so a GLOBAL relevance
+    # sort would force ClickHouse to read the org's ENTIRE edge set and top-sort
+    # before returning the first page — defeating early-LIMIT termination (a
+    # timeout path for large tenants). We therefore only sort when the candidate
+    # set is ALREADY bounded by a narrowing filter (edge_type(s)/source/target/
+    # node_id/theme/subcategory/repo_ids). For the fully-unfiltered default
+    # overview we emit NO ORDER BY, keeping the cap-bounded hot path — that's
+    # acceptable because the Dependencies tab fetches its own edge_types and the
+    # aggregates (work_graph_flow / work_graph_artifacts) are exact at any scale,
+    # so the broad overview does not need the global sort to be useful.
+    has_narrowing_filter = bool(
+        filters
+        and (
+            filters.repo_ids
+            or filters.source_type
+            or filters.target_type
+            or filters.edge_type
+            or filters.edge_types
+            or filters.node_id
+            or filters.theme
+            or filters.subcategory
         )
-        if exists_clause:
-            where_clauses.append(exists_clause)
-            params.update(theme_params)
-
-    where_sql = f"WHERE {' AND '.join(where_clauses)}"
-
+    )
+    order_by_sql = (
+        "ORDER BY confidence DESC, edge_id ASC" if has_narrowing_filter else ""
+    )
     query = f"""
         SELECT
             edge_id,
@@ -826,6 +914,7 @@ async def resolve_work_graph_edges(
             evidence
         FROM work_graph_edges
         {where_sql}
+        {order_by_sql}
         LIMIT %(limit)s
     """
 
@@ -879,3 +968,216 @@ async def resolve_work_graph_edges(
         ),
         degraded_reason=degraded_reason,
     )
+
+
+async def resolve_work_graph_flow(
+    context: GraphQLContext,
+    filters: WorkGraphEdgeFilterInput | None = None,
+) -> WorkGraphFlowResult:
+    """Per-node-type inflow/outflow counts over the FULL edge set (CHAOS-2442).
+
+    A true server-side aggregate: it GROUPs the whole work graph by
+    (source_type, target_type), so it reflects the REAL direction mix and is
+    correct at any scale — NOT derived from the capped edge page (which, for the
+    demo org, was dominated by `references` and collapsed Inflow/Outflow into a
+    degenerate Issue-in / Commit-out split). Applies ONLY the graph-wide filters
+    (org_id + repo_ids + theme/subcategory); edge-list-only filters do not apply.
+    """
+    from dev_health_ops.api.queries.client import query_dicts
+
+    org_id = require_org_id(context)
+    client = context.client
+
+    if client is None:
+        raise RuntimeError("Database client not available")
+
+    theme_filter = filters.theme if filters else None
+    subcategory_filter = filters.subcategory if filters else None
+    theme_filter_active = bool(theme_filter or subcategory_filter)
+
+    if _theme_subcategory_conflict(theme_filter, subcategory_filter):
+        logger.info(
+            "work_graph_flow theme filter conflict: theme=%r does not own "
+            "subcategory=%r — returning empty result",
+            theme_filter,
+            subcategory_filter,
+        )
+        return _empty_flow_result()
+
+    where_sql, params = _build_work_graph_where(
+        filters, org_id, include_edge_filters=False
+    )
+
+    # uniqExact(edge_id), NOT raw count(): work_graph_edges is a
+    # ReplacingMergeTree(last_synced) whose logical dedup key is edge_id (the
+    # deterministic hash of source_type/source_id/edge_type/target_type/
+    # target_id). Un-merged retry/backfill duplicate physical rows are visible
+    # until a background merge, so count() would inflate the direction mix.
+    # edge_id is unique per logical edge and falls in exactly ONE
+    # (source_type, target_type) group, so uniqExact(edge_id) is exact.
+    query = f"""
+        SELECT source_type, target_type, uniqExact(edge_id) AS cnt
+        FROM work_graph_edges
+        {where_sql}
+        GROUP BY source_type, target_type
+    """
+
+    try:
+        rows = await query_dicts(client, query, params)
+    except Exception as exc:
+        # Same NARROW degraded contract as resolve_work_graph_edges: only a
+        # code-60 missing-membership-table error under an active theme filter is
+        # downgraded; every other error propagates (project rule — no blanket
+        # except/return-default).
+        if theme_filter_active and _is_missing_membership_table_error(exc):
+            logger.warning(
+                "work_unit_membership table missing for org %s during "
+                "work_graph_flow theme filter — returning degraded state "
+                "(CHAOS-2442).",
+                org_id,
+            )
+            return _empty_flow_result(MEMBERSHIP_NOT_MATERIALIZED)
+        raise
+
+    inflow: dict[WorkGraphNodeType, int] = defaultdict(int)
+    outflow: dict[WorkGraphNodeType, int] = defaultdict(int)
+    for row in rows:
+        cnt = int(row.get("cnt") or 0)
+        source_type = _map_node_type(str(row.get("source_type", "")))
+        target_type = _map_node_type(str(row.get("target_type", "")))
+        outflow[source_type] += cnt
+        inflow[target_type] += cnt
+
+    flow_rows = [
+        WorkGraphFlowRow(
+            node_type=node_type,
+            inflow=inflow.get(node_type, 0),
+            outflow=outflow.get(node_type, 0),
+        )
+        for node_type in set(inflow) | set(outflow)
+        if inflow.get(node_type, 0) > 0 or outflow.get(node_type, 0) > 0
+    ]
+    # Sort by total degree desc; node_type value as a deterministic tiebreaker.
+    flow_rows.sort(key=lambda r: (-(r.inflow + r.outflow), r.node_type.value))
+
+    degraded_reason: str | None = None
+    if theme_filter_active and not flow_rows:
+        degraded_reason = await _detect_membership_degraded_reason(client, org_id)
+
+    return WorkGraphFlowResult(rows=flow_rows, degraded_reason=degraded_reason)
+
+
+async def resolve_work_graph_artifacts(
+    context: GraphQLContext,
+    filters: WorkGraphEdgeFilterInput | None = None,
+) -> WorkGraphArtifactsResult:
+    """Top-N nodes by degree over the FULL edge set (CHAOS-2442 Artifacts tab).
+
+    Degree = edges touching a node as SOURCE or TARGET, counted across the whole
+    graph (a UNION ALL of source/target projections), so the ranking is correct
+    at any scale rather than reflecting whatever happened to land in the capped
+    edge page. Applies ONLY the graph-wide filters (org_id + repo_ids +
+    theme/subcategory). ``filters.limit`` is the top-N (the web client passes 50;
+    default 1000). Display names reuse the edge-list batch resolver / A7-A8
+    fallback so a UUID that cannot be resolved surfaces as None (Unresolved
+    badge), never a raw UUID.
+    """
+    from dev_health_ops.api.queries.client import query_dicts
+
+    org_id = require_org_id(context)
+    client = context.client
+
+    if client is None:
+        raise RuntimeError("Database client not available")
+
+    limit = filters.limit if filters else 1000
+
+    theme_filter = filters.theme if filters else None
+    subcategory_filter = filters.subcategory if filters else None
+    theme_filter_active = bool(theme_filter or subcategory_filter)
+
+    if _theme_subcategory_conflict(theme_filter, subcategory_filter):
+        logger.info(
+            "work_graph_artifacts theme filter conflict: theme=%r does not own "
+            "subcategory=%r — returning empty result",
+            theme_filter,
+            subcategory_filter,
+        )
+        return _empty_artifacts_result()
+
+    where_sql, params = _build_work_graph_where(
+        filters, org_id, include_edge_filters=False
+    )
+    params["limit"] = int(limit)
+
+    # The {where} (including the correlated theme EXISTS clause that references
+    # work_graph_edges.{source,target}_{type,id}) appears TWICE — once per UNION
+    # ALL branch. Both branches select FROM work_graph_edges so the correlated
+    # references resolve, and because the param NAMES are identical in both
+    # occurrences, the single params dict serves both.
+    #
+    # degree = uniqExact(edge_id), NOT raw count(): work_graph_edges is a
+    # ReplacingMergeTree(last_synced) keyed logically on edge_id, so un-merged
+    # duplicate physical rows would inflate a count(). uniqExact(edge_id) also
+    # makes a self-loop (source==target, same node) count ONCE — the node's two
+    # UNION ALL projections carry the SAME edge_id, so a self-referential edge
+    # contributes degree 1 (one edge touching the node), not 2.
+    query = f"""
+        SELECT node_type, node_id, uniqExact(edge_id) AS degree, any(evidence) AS evidence
+        FROM (
+            SELECT source_type AS node_type, source_id AS node_id, edge_id, evidence
+            FROM work_graph_edges
+            {where_sql}
+            UNION ALL
+            SELECT target_type AS node_type, target_id AS node_id, edge_id, evidence
+            FROM work_graph_edges
+            {where_sql}
+        )
+        GROUP BY node_type, node_id
+        ORDER BY degree DESC, node_id ASC
+        LIMIT %(limit)s
+    """
+
+    try:
+        rows = await query_dicts(client, query, params)
+    except Exception as exc:
+        if theme_filter_active and _is_missing_membership_table_error(exc):
+            logger.warning(
+                "work_unit_membership table missing for org %s during "
+                "work_graph_artifacts theme filter — returning degraded state "
+                "(CHAOS-2442).",
+                org_id,
+            )
+            return _empty_artifacts_result(MEMBERSHIP_NOT_MATERIALIZED)
+        raise
+
+    # Reuse the edge-list display-name batch resolver by shaping each aggregate
+    # row as a pseudo-edge whose SOURCE endpoint is the node (target endpoint
+    # blank so it is ignored). One query per entity type — no N+1.
+    pseudo_rows = [
+        {
+            "source_id": str(row.get("node_id", "")),
+            "source_type": str(row.get("node_type", "")),
+            "target_id": "",
+            "target_type": "",
+        }
+        for row in rows
+    ]
+    resolved = await _batch_resolve_display_names(client, org_id, pseudo_rows)
+
+    artifact_rows = [
+        WorkGraphArtifactRow(
+            node_type=_map_node_type(str(row.get("node_type", ""))),
+            node_id=str(row.get("node_id", "")),
+            display_name=_display_name_for(str(row.get("node_id", "")), resolved),
+            degree=int(row.get("degree") or 0),
+            evidence=str(row["evidence"]) if row.get("evidence") else None,
+        )
+        for row in rows
+    ]
+
+    degraded_reason: str | None = None
+    if theme_filter_active and not artifact_rows:
+        degraded_reason = await _detect_membership_degraded_reason(client, org_id)
+
+    return WorkGraphArtifactsResult(rows=artifact_rows, degraded_reason=degraded_reason)

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -49,7 +49,9 @@ from .models.outputs import (
     SecurityAlertConnection,
     SecurityOverview,
     ThroughputForecast,
+    WorkGraphArtifactsResult,
     WorkGraphEdgesResult,
+    WorkGraphFlowResult,
 )
 from .models.recommendations import (
     Recommendation,
@@ -263,6 +265,34 @@ class Query:
 
         context = get_context(info)
         return await resolve_work_graph_edges(context, filters)
+
+    @strawberry.field(
+        description="Per-node-type inflow/outflow over the full work graph"
+    )
+    async def work_graph_flow(
+        self,
+        info: Info,
+        org_id: str,
+        filters: WorkGraphEdgeFilterInput | None = None,
+    ) -> WorkGraphFlowResult:
+        from .resolvers.work_graph import resolve_work_graph_flow
+
+        context = get_context(info)
+        return await resolve_work_graph_flow(context, filters)
+
+    @strawberry.field(
+        description="Top-N work graph nodes ranked by degree over the full graph"
+    )
+    async def work_graph_artifacts(
+        self,
+        info: Info,
+        org_id: str,
+        filters: WorkGraphEdgeFilterInput | None = None,
+    ) -> WorkGraphArtifactsResult:
+        from .resolvers.work_graph import resolve_work_graph_artifacts
+
+        context = get_context(info)
+        return await resolve_work_graph_artifacts(context, filters)
 
     @strawberry.field(description="Paginated list of security alerts")
     async def security_alerts(

--- a/tests/graphql/test_work_graph_aggregates.py
+++ b/tests/graphql/test_work_graph_aggregates.py
@@ -1,0 +1,613 @@
+"""Unit tests for CHAOS-2442 work-graph aggregates + plural edge_types filter.
+
+The Dependencies / Inflow-Outflow / Artifacts tabs no longer feed off a single
+``LIMIT 1000`` unordered edge page (which, for the demo org, was dominated by
+``references`` edges and starved every other edge type). Instead:
+
+  * ``edge_types`` (plural) lets a tab fetch its OWN edge types BEFORE the cap,
+    so a sparse category can never be starved.
+  * ``work_graph_flow`` / ``work_graph_artifacts`` are TRUE server-side
+    aggregates computed over the FULL edge set (correct at any scale).
+  * The edge-list query now ``ORDER BY confidence DESC, edge_id ASC`` so the
+    capped overview canvas is no longer pure table-order ``references``.
+
+These tests mock ``query_dicts`` and assert on the captured SQL/params and the
+aggregated Python result (skewed mixes prove the result reflects the TRUE mix,
+not a cap artifact). They also prove the degraded-state contract is identical to
+``resolve_work_graph_edges``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.models.inputs import (
+    WorkGraphEdgeFilterInput,
+    WorkGraphEdgeTypeInput,
+)
+from dev_health_ops.api.graphql.models.outputs import WorkGraphNodeType
+from dev_health_ops.api.graphql.resolvers.work_graph import (
+    resolve_work_graph_artifacts,
+    resolve_work_graph_edges,
+    resolve_work_graph_flow,
+)
+
+
+class MockClient:
+    pass
+
+
+@pytest.fixture
+def mock_context():
+    return GraphQLContext(
+        org_id="test-org",
+        db_url="clickhouse://localhost:8123/default",
+        client=MockClient(),
+    )
+
+
+class _UnknownMembershipTableError(Exception):
+    """code-60 UNKNOWN_TABLE naming work_unit_membership (rolling-deploy state)."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Received ClickHouse exception, code: 60, server response: "
+            "Code: 60. DB::Exception: Unknown table expression identifier "
+            "'work_unit_membership'. (UNKNOWN_TABLE)"
+        )
+        self.code = 60
+
+
+# ---------------------------------------------------------------------------
+# 1. Plural edge_types filter (dependency edges fetched BEFORE the cap)
+# ---------------------------------------------------------------------------
+class TestEdgeTypesFilter:
+    @pytest.mark.asyncio
+    async def test_edge_types_produces_in_clause(self, mock_context):
+        """edge_types=[BLOCKS, RELATES, ...] → `edge_type IN` with those values
+        in params, applied in the edge WHERE (before the LIMIT) so the
+        Dependencies tab's edges can never be starved by the row cap."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = []
+
+            dep_types = [
+                WorkGraphEdgeTypeInput.BLOCKS,
+                WorkGraphEdgeTypeInput.RELATES,
+                WorkGraphEdgeTypeInput.IS_BLOCKED_BY,
+                WorkGraphEdgeTypeInput.PARENT_OF,
+            ]
+            filters = WorkGraphEdgeFilterInput(edge_types=dep_types)
+            await resolve_work_graph_edges(mock_context, filters)
+
+            sql = mock_query.call_args[0][1]
+            params = mock_query.call_args[0][2]
+
+            assert "edge_type IN %(edge_types)s" in sql
+            assert params["edge_types"] == [
+                "blocks",
+                "relates",
+                "is_blocked_by",
+                "parent_of",
+            ]
+            # The IN clause precedes the LIMIT — proof it filters before the cap.
+            assert sql.index("edge_type IN") < sql.index("LIMIT")
+
+    @pytest.mark.asyncio
+    async def test_singular_edge_type_still_works(self, mock_context):
+        """The existing singular edge_type filter is unchanged."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = []
+
+            filters = WorkGraphEdgeFilterInput(
+                edge_type=WorkGraphEdgeTypeInput.IMPLEMENTS
+            )
+            await resolve_work_graph_edges(mock_context, filters)
+
+            sql = mock_query.call_args[0][1]
+            params = mock_query.call_args[0][2]
+
+            assert "edge_type = %(edge_type)s" in sql
+            assert params["edge_type"] == "implements"
+            assert "edge_type IN" not in sql
+
+    @pytest.mark.asyncio
+    async def test_singular_and_plural_are_anded(self, mock_context):
+        """When BOTH edge_type and edge_types are given, both clauses apply (AND)."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = []
+
+            filters = WorkGraphEdgeFilterInput(
+                edge_type=WorkGraphEdgeTypeInput.BLOCKS,
+                edge_types=[
+                    WorkGraphEdgeTypeInput.BLOCKS,
+                    WorkGraphEdgeTypeInput.RELATES,
+                ],
+            )
+            await resolve_work_graph_edges(mock_context, filters)
+
+            sql = mock_query.call_args[0][1]
+            params = mock_query.call_args[0][2]
+
+            assert "edge_type = %(edge_type)s" in sql
+            assert "edge_type IN %(edge_types)s" in sql
+            assert params["edge_type"] == "blocks"
+            assert params["edge_types"] == ["blocks", "relates"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Edge-list ORDER BY — GATED on a narrowing filter (preserves early-LIMIT
+#    termination on the unfiltered hot path; relevance sort only where the
+#    candidate set is already bounded).
+# ---------------------------------------------------------------------------
+class TestEdgeListOrdering:
+    @pytest.mark.asyncio
+    async def test_no_order_by_when_unfiltered(self, mock_context):
+        """Fully-unfiltered default overview must emit NO ORDER BY confidence so
+        ClickHouse keeps early-LIMIT termination (a global sort would read the
+        org's ENTIRE edge set before returning the first page)."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = []
+            await resolve_work_graph_edges(mock_context)
+
+            sql = mock_query.call_args[0][1]
+            assert "ORDER BY" not in sql
+            assert "LIMIT" in sql
+
+    @pytest.mark.asyncio
+    async def test_no_order_by_with_empty_filter_object(self, mock_context):
+        """An empty filters object (no narrowing field set) is still the hot
+        path — no ORDER BY."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = []
+            await resolve_work_graph_edges(mock_context, WorkGraphEdgeFilterInput())
+
+            sql = mock_query.call_args[0][1]
+            assert "ORDER BY" not in sql
+
+    @pytest.mark.asyncio
+    async def test_order_by_when_edge_types_filter_active(self, mock_context):
+        """A narrowing filter bounds the candidate set, so the relevance sort is
+        applied (deterministic, before the cap)."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = []
+            filters = WorkGraphEdgeFilterInput(
+                edge_types=[WorkGraphEdgeTypeInput.BLOCKS]
+            )
+            await resolve_work_graph_edges(mock_context, filters)
+
+            sql = mock_query.call_args[0][1]
+            assert "ORDER BY confidence DESC, edge_id ASC" in sql
+            assert sql.index("ORDER BY") < sql.index("LIMIT")
+
+    @pytest.mark.asyncio
+    async def test_order_by_when_theme_filter_active(self, mock_context):
+        """A theme filter is narrowing → relevance sort applied."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            # edge query empty, then degraded probe.
+            mock_query.side_effect = [
+                [],
+                [{"complete_run_markers": 1, "investment_rows": 5}],
+            ]
+            filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
+            await resolve_work_graph_edges(mock_context, filters)
+
+            sql = mock_query.call_args_list[0][0][1]
+            assert "ORDER BY confidence DESC, edge_id ASC" in sql
+
+    @pytest.mark.asyncio
+    async def test_order_by_when_repo_ids_filter_active(self, mock_context):
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = []
+            filters = WorkGraphEdgeFilterInput(repo_ids=["repo-1"])
+            await resolve_work_graph_edges(mock_context, filters)
+
+            sql = mock_query.call_args[0][1]
+            assert "ORDER BY confidence DESC, edge_id ASC" in sql
+
+
+# ---------------------------------------------------------------------------
+# 2. work_graph_flow aggregates the TRUE direction mix
+# ---------------------------------------------------------------------------
+class TestWorkGraphFlow:
+    @pytest.mark.asyncio
+    async def test_flow_aggregates_inflow_outflow_per_node_type(self, mock_context):
+        """A skewed GROUP-BY result aggregates into correct per-node-type
+        inflow/outflow — reflecting the TRUE mix, not a cap artifact."""
+        group_rows = [
+            # issue -> pr (heavy)
+            {"source_type": "issue", "target_type": "pr", "cnt": 100},
+            # pr -> commit
+            {"source_type": "pr", "target_type": "commit", "cnt": 40},
+            # issue -> issue (dependencies — would be starved in an unordered cap)
+            {"source_type": "issue", "target_type": "issue", "cnt": 10},
+            # commit -> file
+            {"source_type": "commit", "target_type": "file", "cnt": 25},
+        ]
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = group_rows
+            result = await resolve_work_graph_flow(mock_context)
+
+        by_type = {r.node_type: r for r in result.rows}
+
+        # issue: outflow = 100 (->pr) + 10 (->issue); inflow = 10 (issue->issue)
+        assert by_type[WorkGraphNodeType.ISSUE].outflow == 110
+        assert by_type[WorkGraphNodeType.ISSUE].inflow == 10
+        # pr: inflow 100 (issue->pr); outflow 40 (pr->commit)
+        assert by_type[WorkGraphNodeType.PR].inflow == 100
+        assert by_type[WorkGraphNodeType.PR].outflow == 40
+        # commit: inflow 40 (pr->commit); outflow 25 (commit->file)
+        assert by_type[WorkGraphNodeType.COMMIT].inflow == 40
+        assert by_type[WorkGraphNodeType.COMMIT].outflow == 25
+        # file: inflow 25; outflow 0
+        assert by_type[WorkGraphNodeType.FILE].inflow == 25
+        assert by_type[WorkGraphNodeType.FILE].outflow == 0
+
+        # Sorted by total degree desc.
+        totals = [r.inflow + r.outflow for r in result.rows]
+        assert totals == sorted(totals, reverse=True)
+        assert result.degraded_reason is None
+
+    @pytest.mark.asyncio
+    async def test_flow_dedups_by_edge_id_not_raw_count(self, mock_context):
+        """work_graph_edges is a ReplacingMergeTree keyed logically on edge_id;
+        un-merged duplicate physical rows must NOT inflate the direction mix.
+        The flow SQL must aggregate via uniqExact(edge_id), not raw count()."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = []
+            await resolve_work_graph_flow(mock_context)
+
+            sql = mock_query.call_args[0][1]
+            assert "uniqExact(edge_id) AS cnt" in sql
+            assert "count() AS cnt" not in sql
+
+    @pytest.mark.asyncio
+    async def test_flow_aggregation_uses_db_dedup_count(self, mock_context):
+        """The GROUP-BY rows already carry the DB-deduped uniqExact(edge_id)
+        count; Python sums those per direction. Duplicate physical edge versions
+        collapse server-side, so a row's cnt is the LOGICAL edge count."""
+        # Two source/target groups; cnt is the already-deduped uniqExact value.
+        group_rows = [
+            {"source_type": "issue", "target_type": "pr", "cnt": 3},
+            {"source_type": "issue", "target_type": "issue", "cnt": 2},
+        ]
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = group_rows
+            result = await resolve_work_graph_flow(mock_context)
+
+        by_type = {r.node_type: r for r in result.rows}
+        # issue outflow = 3 (->pr) + 2 (->issue); inflow = 2 (issue->issue)
+        assert by_type[WorkGraphNodeType.ISSUE].outflow == 5
+        assert by_type[WorkGraphNodeType.ISSUE].inflow == 2
+        assert by_type[WorkGraphNodeType.PR].inflow == 3
+
+    @pytest.mark.asyncio
+    async def test_flow_uses_group_by_over_full_set_no_limit(self, mock_context):
+        """The flow query is a GROUP BY over the full edge set (no LIMIT) and is
+        org-scoped — it describes the WHOLE graph."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = []
+            await resolve_work_graph_flow(mock_context)
+
+            sql = mock_query.call_args[0][1]
+            params = mock_query.call_args[0][2]
+
+            assert "GROUP BY source_type, target_type" in sql
+            assert "uniqExact(edge_id) AS cnt" in sql
+            assert "LIMIT" not in sql
+            assert "org_id = %(org_id)s" in sql
+            assert params["org_id"] == "test-org"
+
+    @pytest.mark.asyncio
+    async def test_flow_ignores_edge_list_only_filters(self, mock_context):
+        """Aggregates describe the whole graph: edge-list-only filters
+        (edge_type/source_type/node_id) are NOT applied; graph-wide repo_ids IS."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = []
+            filters = WorkGraphEdgeFilterInput(
+                edge_type=WorkGraphEdgeTypeInput.REFERENCES,
+                edge_types=[WorkGraphEdgeTypeInput.BLOCKS],
+                node_id="PROJ-1",
+                repo_ids=["repo-1"],
+            )
+            await resolve_work_graph_flow(mock_context, filters)
+
+            sql = mock_query.call_args[0][1]
+            params = mock_query.call_args[0][2]
+
+            assert "edge_type" not in sql
+            assert "node_id" not in sql
+            assert "repo_id IN %(repo_ids)s" in sql
+            assert params["repo_ids"] == ["repo-1"]
+
+    @pytest.mark.asyncio
+    async def test_flow_degraded_on_missing_membership_table(self, mock_context):
+        """theme filter + missing-membership-table error → MEMBERSHIP_NOT_MATERIALIZED."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = _UnknownMembershipTableError()
+            filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
+            result = await resolve_work_graph_flow(mock_context, filters)
+
+        assert result.rows == []
+        assert result.degraded_reason == "MEMBERSHIP_NOT_MATERIALIZED"
+
+    @pytest.mark.asyncio
+    async def test_flow_other_error_propagates(self, mock_context):
+        """A non-membership error must propagate (no blanket except/return-default)."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = RuntimeError("connection reset")
+            filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
+            with pytest.raises(RuntimeError, match="connection reset"):
+                await resolve_work_graph_flow(mock_context, filters)
+
+    @pytest.mark.asyncio
+    async def test_flow_empty_theme_filter_runs_degraded_probe(self, mock_context):
+        """theme filter + empty aggregate → degraded probe runs (parity with edges)."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            # Aggregate empty, then degraded probe: investments exist, no marker.
+            mock_query.side_effect = [
+                [],
+                [{"complete_run_markers": 0, "investment_rows": 5}],
+            ]
+            filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
+            result = await resolve_work_graph_flow(mock_context, filters)
+
+        assert result.rows == []
+        assert result.degraded_reason == "MEMBERSHIP_NOT_MATERIALIZED"
+        assert mock_query.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# 3. work_graph_artifacts aggregates degree + resolves display names
+# ---------------------------------------------------------------------------
+class TestWorkGraphArtifacts:
+    @pytest.mark.asyncio
+    async def test_artifacts_aggregates_degree_ordered_desc(self, mock_context):
+        """Degree rows map to artifact rows in order, with display-name resolution
+        / fallback (human-readable passes through; UUID → None)."""
+        uuid_id = "4e00fff2-df66-5028-8ebd-e4535332300b"
+        degree_rows = [
+            {
+                "node_type": "issue",
+                "node_id": "PROJ-1",
+                "degree": 12,
+                "evidence": "Closes #1",
+            },
+            {
+                "node_type": "pr",
+                "node_id": uuid_id,
+                "degree": 7,
+                "evidence": None,
+            },
+        ]
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            # degree query, then display-name lookup (PR uuid not resolvable here).
+            mock_query.side_effect = [degree_rows, []]
+            result = await resolve_work_graph_artifacts(mock_context)
+
+        assert [r.node_id for r in result.rows] == ["PROJ-1", uuid_id]
+        assert result.rows[0].degree == 12
+        assert result.rows[1].degree == 7
+        # Degree order preserved (desc).
+        assert result.rows[0].degree >= result.rows[1].degree
+        # Human-readable id passes through; bare UUID (no lookup) → None badge.
+        assert result.rows[0].display_name == "PROJ-1"
+        assert result.rows[1].display_name is None
+        # Evidence passes through (str or None).
+        assert result.rows[0].evidence == "Closes #1"
+        assert result.rows[1].evidence is None
+        assert result.rows[0].node_type == WorkGraphNodeType.ISSUE
+        assert result.rows[1].node_type == WorkGraphNodeType.PR
+        assert result.degraded_reason is None
+
+    @pytest.mark.asyncio
+    async def test_artifacts_degree_sql_union_and_limit(self, mock_context):
+        """The degree SQL UNIONs source+target projections, GROUPs by node, orders
+        by degree desc, and honours filters.limit as the top-N."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [[], []]
+            filters = WorkGraphEdgeFilterInput(limit=50)
+            await resolve_work_graph_artifacts(mock_context, filters)
+
+            sql = mock_query.call_args_list[0][0][1]
+            params = mock_query.call_args_list[0][0][2]
+
+            assert "UNION ALL" in sql
+            assert "source_type AS node_type, source_id AS node_id" in sql
+            assert "target_type AS node_type, target_id AS node_id" in sql
+            assert "GROUP BY node_type, node_id" in sql
+            assert "ORDER BY degree DESC, node_id ASC" in sql
+            assert "LIMIT %(limit)s" in sql
+            assert params["limit"] == 50
+            # org_id appears for cross-tenant safety.
+            assert params["org_id"] == "test-org"
+
+    @pytest.mark.asyncio
+    async def test_artifacts_dedups_degree_by_edge_id(self, mock_context):
+        """Degree must be uniqExact(edge_id) per node (not raw count()), and
+        edge_id must be projected in BOTH UNION ALL legs so the dedup works.
+        This prevents un-merged ReplacingMergeTree duplicate rows from inflating
+        degree."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [[], []]
+            await resolve_work_graph_artifacts(mock_context)
+
+            sql = mock_query.call_args_list[0][0][1]
+            assert "uniqExact(edge_id) AS degree" in sql
+            assert "count() AS degree" not in sql
+            # edge_id carried through BOTH legs of the UNION ALL.
+            assert (
+                "SELECT source_type AS node_type, source_id AS node_id, edge_id" in sql
+            )
+            assert (
+                "SELECT target_type AS node_type, target_id AS node_id, edge_id" in sql
+            )
+
+    @pytest.mark.asyncio
+    async def test_artifacts_self_loop_counts_once(self, mock_context):
+        """A self-referential edge (source==target, same node) appears as TWO
+        UNION ALL rows carrying the SAME edge_id. uniqExact(edge_id) counts it
+        ONCE (one edge touching one node → degree 1, not 2). Assert the SQL
+        shape that guarantees this (query_dicts is mocked)."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [[], []]
+            await resolve_work_graph_artifacts(mock_context)
+
+            sql = mock_query.call_args_list[0][0][1]
+            # Distinct edge_id per node → a self-loop's two rows share one edge_id
+            # and collapse to degree 1.
+            assert "uniqExact(edge_id) AS degree" in sql
+            assert "GROUP BY node_type, node_id" in sql
+
+    @pytest.mark.asyncio
+    async def test_artifacts_resolves_pr_display_name(self, mock_context):
+        """A {uuid}#pr{N} node id resolves to its PR title via the batch resolver."""
+        repo_uuid = "4e00fff2-df66-5028-8ebd-e4535332300b"
+        pr_id = f"{repo_uuid}#pr160"
+        degree_rows = [
+            {"node_type": "pr", "node_id": pr_id, "degree": 5, "evidence": None}
+        ]
+        pr_lookup_rows = [{"repo_id": repo_uuid, "number": 160, "title": "Add X"}]
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [degree_rows, pr_lookup_rows]
+            result = await resolve_work_graph_artifacts(mock_context)
+
+        assert result.rows[0].display_name == "Add X"
+
+    @pytest.mark.asyncio
+    async def test_artifacts_honours_limit_default_when_no_filters(self, mock_context):
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [[], []]
+            await resolve_work_graph_artifacts(mock_context)
+
+            params = mock_query.call_args_list[0][0][2]
+            assert params["limit"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_artifacts_degraded_on_missing_membership_table(self, mock_context):
+        """theme filter + missing-membership-table error → MEMBERSHIP_NOT_MATERIALIZED."""
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = _UnknownMembershipTableError()
+            filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
+            result = await resolve_work_graph_artifacts(mock_context, filters)
+
+        assert result.rows == []
+        assert result.degraded_reason == "MEMBERSHIP_NOT_MATERIALIZED"
+
+    @pytest.mark.asyncio
+    async def test_artifacts_other_error_propagates(self, mock_context):
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = RuntimeError("timeout")
+            filters = WorkGraphEdgeFilterInput(theme="feature_delivery")
+            with pytest.raises(RuntimeError, match="timeout"):
+                await resolve_work_graph_artifacts(mock_context, filters)
+
+
+# ---------------------------------------------------------------------------
+# 5. Theme/subcategory conflict short-circuits both aggregates (rows=[])
+# ---------------------------------------------------------------------------
+class TestAggregateConflictShortCircuit:
+    @pytest.mark.asyncio
+    async def test_flow_conflict_returns_empty_without_query(self, mock_context):
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            # maintenance theme does not own a feature_delivery subcategory.
+            filters = WorkGraphEdgeFilterInput(
+                theme="maintenance", subcategory="feature_delivery.roadmap"
+            )
+            result = await resolve_work_graph_flow(mock_context, filters)
+
+        assert result.rows == []
+        assert result.degraded_reason is None
+        mock_query.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_artifacts_conflict_returns_empty_without_query(self, mock_context):
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            filters = WorkGraphEdgeFilterInput(
+                theme="maintenance", subcategory="feature_delivery.roadmap"
+            )
+            result = await resolve_work_graph_artifacts(mock_context, filters)
+
+        assert result.rows == []
+        assert result.degraded_reason is None
+        mock_query.assert_not_called()

--- a/tests/graphql/test_work_graph_aggregates_live.py
+++ b/tests/graphql/test_work_graph_aggregates_live.py
@@ -1,0 +1,226 @@
+"""Live-ClickHouse acceptance test for CHAOS-2442 work-graph aggregates.
+
+Reproduces the production starvation bug end-to-end: a test org whose edge mix is
+dominated by ``references`` edges (>1000) plus a handful of dependency
+(issue↔issue) edges. On main, a single unordered ``LIMIT 1000`` fetch returns
+almost all ``references`` rows, so:
+  * the Dependencies tab renders empty, and
+  * Inflow/Outflow collapses to a degenerate split.
+
+This test asserts the fix:
+  (a) a dependencies fetch (``edge_types`` = issue↔issue dependency types)
+      returns the dependency edges DIRECTLY — never starved by the cap; and
+  (b) ``work_graph_flow`` / ``work_graph_artifacts``, computed over the FULL
+      edge set, reflect the true mix (not a capped-page artifact).
+
+Opt-in (filtered from unit/CI runs): ``pytest -m clickhouse``.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.models.inputs import (
+    WorkGraphEdgeFilterInput,
+    WorkGraphEdgeTypeInput,
+)
+from dev_health_ops.api.graphql.models.outputs import WorkGraphNodeType
+from dev_health_ops.api.graphql.resolvers.work_graph import (
+    resolve_work_graph_artifacts,
+    resolve_work_graph_edges,
+    resolve_work_graph_flow,
+)
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/default)",
+    ),
+]
+
+# Number of `references` edges to seed — exceeds the default LIMIT 1000 so the
+# unordered cap would, on main, swallow the page and starve dependency edges.
+N_REFERENCES = 1200
+N_DEPENDENCIES = 8
+
+
+@pytest.fixture(scope="module")
+def sink():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+    s = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    s.ensure_schema(force=True)
+    yield s
+    s.close()
+
+
+def _edge_cols() -> list[str]:
+    return [
+        "org_id",
+        "edge_id",
+        "source_type",
+        "source_id",
+        "target_type",
+        "target_id",
+        "edge_type",
+        "repo_id",
+        "provider",
+        "provenance",
+        "confidence",
+        "evidence",
+        "discovered_at",
+        "last_synced",
+        "event_ts",
+        "day",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_aggregates_reflect_full_mix_not_capped_page(sink):
+    org_id = f"test-chaos-2442-{uuid.uuid4()}"
+    repo_uuid = str(uuid.uuid4())
+    ts = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+    edge_rows: list[list[object]] = []
+
+    # >1000 references edges: issue -> commit (dominant mass that, unordered,
+    # fills the entire LIMIT 1000 page on main).
+    for i in range(N_REFERENCES):
+        edge_rows.append(
+            [
+                org_id,
+                f"ref-{i}-{uuid.uuid4()}",
+                "issue",
+                f"ISSUE-REF-{i}",
+                "commit",
+                f"COMMIT-{i}",
+                "references",
+                repo_uuid,
+                "github",
+                "heuristic",
+                0.30,  # low confidence → sorted AFTER dependency edges
+                "",
+                ts,
+                ts,
+                ts,
+                ts.date(),
+            ]
+        )
+
+    # A handful of dependency (issue <-> issue) edges with HIGH confidence.
+    dep_edge_ids: list[str] = []
+    for i in range(N_DEPENDENCIES):
+        eid = f"dep-{i}-{uuid.uuid4()}"
+        dep_edge_ids.append(eid)
+        edge_rows.append(
+            [
+                org_id,
+                eid,
+                "issue",
+                f"ISSUE-A-{i}",
+                "issue",
+                f"ISSUE-B-{i}",
+                "blocks" if i % 2 == 0 else "relates",
+                repo_uuid,
+                "github",
+                "native",
+                0.99,  # high confidence
+                "",
+                ts,
+                ts,
+                ts,
+                ts.date(),
+            ]
+        )
+
+    # A DUPLICATE physical version of the first dependency edge (SAME edge_id,
+    # later last_synced) — simulates an un-merged ReplacingMergeTree retry. The
+    # aggregates dedup via uniqExact(edge_id), so this must NOT inflate counts.
+    dup = list(edge_rows[N_REFERENCES])  # first dependency edge row
+    dup[10] = 0.95  # different confidence (a later version of the same edge)
+    dup[13] = datetime(2026, 6, 2, tzinfo=timezone.utc)  # later last_synced
+    edge_rows.append(dup)
+
+    sink.client.insert("work_graph_edges", edge_rows, column_names=_edge_cols())
+
+    assert CLICKHOUSE_URI is not None  # narrowed by pytestmark.skipif
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink)
+
+    try:
+        # (a) Dependencies fetch via plural edge_types returns the dependency
+        # edges DIRECTLY — they are filtered BEFORE the cap, so the >1000
+        # references can never starve them.
+        dep_result = await resolve_work_graph_edges(
+            context,
+            WorkGraphEdgeFilterInput(
+                edge_types=[
+                    WorkGraphEdgeTypeInput.BLOCKS,
+                    WorkGraphEdgeTypeInput.RELATES,
+                ],
+                limit=1000,
+            ),
+        )
+        returned_dep_ids = {e.edge_id for e in dep_result.edges}
+        assert set(dep_edge_ids) <= returned_dep_ids, (
+            "dependency edges must be fetched directly via edge_types, never "
+            "starved by the >1000 references cap"
+        )
+        assert all(e.edge_type.value in ("blocks", "relates") for e in dep_result.edges)
+
+        # Sanity: with a NARROWING filter active (repo_ids), the candidate set is
+        # bounded so the relevance sort (ORDER BY confidence DESC) applies and the
+        # high-confidence dependency edges surface on the first page. (The
+        # fully-unfiltered overview intentionally emits NO ORDER BY to preserve
+        # early-LIMIT termination — see resolve_work_graph_edges.)
+        overview = await resolve_work_graph_edges(
+            context, WorkGraphEdgeFilterInput(repo_ids=[repo_uuid], limit=1000)
+        )
+        assert any(
+            e.edge_type.value in ("blocks", "relates") for e in overview.edges
+        ), (
+            "with a narrowing filter, ordering by confidence must surface "
+            "dependency edges on the capped overview page"
+        )
+        assert overview.edges[0].edge_type.value in ("blocks", "relates"), (
+            "highest-confidence (dependency) edge should sort first under the "
+            "relevance order"
+        )
+
+        # (b) work_graph_flow reflects the FULL mix (all 1208 edges), not a cap.
+        flow = await resolve_work_graph_flow(context)
+        by_type = {r.node_type: r for r in flow.rows}
+        # issue: outflow = N_REFERENCES (issue->commit) + N_DEPENDENCIES (issue->issue)
+        assert by_type[WorkGraphNodeType.ISSUE].outflow == N_REFERENCES + N_DEPENDENCIES
+        # issue inflow = N_DEPENDENCIES (issue->issue targets)
+        assert by_type[WorkGraphNodeType.ISSUE].inflow == N_DEPENDENCIES
+        # commit inflow = N_REFERENCES; outflow 0
+        assert by_type[WorkGraphNodeType.COMMIT].inflow == N_REFERENCES
+        assert by_type[WorkGraphNodeType.COMMIT].outflow == 0
+        assert flow.degraded_reason is None
+
+        # (b) work_graph_artifacts ranks by degree over the FULL set. The busiest
+        # node types are present and the count is bounded by the limit.
+        artifacts = await resolve_work_graph_artifacts(
+            context, WorkGraphEdgeFilterInput(limit=50)
+        )
+        assert len(artifacts.rows) <= 50
+        assert len(artifacts.rows) > 0
+        # Degrees are non-increasing (ORDER BY degree DESC).
+        degrees = [r.degree for r in artifacts.rows]
+        assert degrees == sorted(degrees, reverse=True)
+        assert artifacts.degraded_reason is None
+    finally:
+        sink.client.command(
+            "ALTER TABLE work_graph_edges DELETE WHERE org_id = {o:String} "
+            "SETTINGS mutations_sync=2",
+            parameters={"o": org_id},
+        )


### PR DESCRIPTION
## CHAOS-2442 — Work Graph 1000-edge cap starvation (backend)

**Pairs with web PR** (dev-health-web `chaos-2442-work-graph-tabs`) — must ship together; this PR adds the GraphQL fields the web PR consumes.

### Problem
The Dependencies / Inflow-Outflow / Artifacts tabs all derived from a single `LIMIT 1000` **unordered** `work_graph_edges` fetch. For reference-heavy orgs (demo org Int: 1618/3038 edges are `references`), the cap is monopolised by `references` (pr→issue / commit→issue), so:
- Dependencies (issue↔issue blocks/relates/etc.) get truncated out → tab renders empty.
- Inflow/Outflow collapses to a degenerate Issue-in / Commit-out split (cap artifact).

Pre-existing unordered-cap starvation, surfaced now that `references` dominate.

### Fix (PMT option 1 + 2 + 3)
- **Plural `edge_types` filter** applied **before** `LIMIT` — a tab fetches its own edge types and can never be starved (singular `edge_type` kept; both AND).
- **True server-side aggregates over the FULL edge set** (correct at any scale, not derived from a capped page):
  - `workGraphFlow` — inflow/outflow per node type.
  - `workGraphArtifacts` — nodes ranked by degree (top-N).
- **`uniqExact(edge_id)` dedup** — `work_graph_edges` is a `ReplacingMergeTree(last_synced)`; raw `count()` would inflate counts/degree on un-merged duplicate rows and double-count self-loops. *(Codex adversarial review finding.)*
- **`ORDER BY confidence` gated to narrowed requests only** — preserves early-LIMIT termination on the unfiltered overview hot path. *(Codex adversarial review finding.)*
- Shared `_build_work_graph_where` keeps org/repo/theme scoping + degraded-state contract identical across all three query paths.

### Tests
- `tests/graphql/test_work_graph_aggregates.py` — unit coverage: edge_types-before-cap, flow/artifacts aggregation of a skewed mix, `uniqExact(edge_id)` dedup + self-loop, ORDER-BY gating, degraded-state parity.
- `tests/graphql/test_work_graph_aggregates_live.py` (`@pytest.mark.clickhouse`) — seeds >1000 `references` + dependency edges; asserts dependencies un-starved and aggregates reflect the full mix.

### Gates
- Targeted + graphql unit lane: pass (87 targeted).
- `mypy --install-types --non-interactive .`: Success (1080 files).
- ruff: clean. Two rounds of `/codex:adversarial-review --model gpt-5.5`; all findings fixed with regression tests.

Note: ops uses a merge queue — not auto-merging.