### PR TITLE
feat(auth): invalidate access tokens on credential change via token_version (CHAOS-2458)

### DIFF
--- a/src/dev_health_ops/alembic/versions/0012_add_user_token_version.py
+++ b/src/dev_health_ops/alembic/versions/0012_add_user_token_version.py
@@ -1,0 +1,58 @@
+"""Add token_version to users for JWT credential invalidation.
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-06-16 00:00:00
+
+Access JWTs embed the user's current integer token_version. Credential changes
+increment the value, immediately invalidating already-issued access tokens whose
+claim no longer matches the persisted anchor.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0012"
+down_revision: str | None = "0011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_TABLE = "users"
+_COLUMN = "token_version"
+
+
+def _has_column(conn: sa.Connection, table: str, column: str) -> bool:
+    inspector = sa.inspect(conn)
+    if table not in inspector.get_table_names():
+        return True
+    return any(col["name"] == column for col in inspector.get_columns(table))
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if _has_column(conn, _TABLE, _COLUMN):
+        return
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            _COLUMN,
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if _TABLE not in inspector.get_table_names():
+        return
+    if any(col["name"] == _COLUMN for col in inspector.get_columns(_TABLE)):
+        op.drop_column(_TABLE, _COLUMN)

--- a/src/dev_health_ops/api/auth/routers/common.py
+++ b/src/dev_health_ops/api/auth/routers/common.py
@@ -262,6 +262,7 @@ async def _issue_membership_tokens(
         is_superuser=bool(db_user.is_superuser),
         username=str(db_user.username) if db_user.username is not None else None,
         full_name=str(db_user.full_name) if db_user.full_name is not None else None,
+        token_version=int(getattr(db_user, "token_version", 0) or 0),
     )
 
     refresh_payload = auth_service.validate_token(

--- a/src/dev_health_ops/api/auth/routers/dependencies.py
+++ b/src/dev_health_ops/api/auth/routers/dependencies.py
@@ -58,7 +58,9 @@ async def get_current_user(
 
     async with get_postgres_session() as db:
         result = await db.execute(
-            select(User.id, User.is_active).where(User.id == user_uuid)
+            select(User.id, User.is_active, User.token_version).where(
+                User.id == user_uuid
+            )
         )
         db_user = result.one_or_none()
 
@@ -75,6 +77,14 @@ async def get_current_user(
         raise HTTPException(
             status_code=401,
             detail=error_detail("Account is disabled"),
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if user.token_version != int(db_user.token_version or 0):
+        logger.warning("JWT token version mismatch for user: %s", user.user_id)
+        raise HTTPException(
+            status_code=401,
+            detail=error_detail("Invalid or expired token"),
             headers={"WWW-Authenticate": "Bearer"},
         )
 
@@ -105,11 +115,15 @@ async def get_current_user_optional(
 
     async with get_postgres_session() as db:
         result = await db.execute(
-            select(User.id, User.is_active).where(User.id == user_uuid)
+            select(User.id, User.is_active, User.token_version).where(
+                User.id == user_uuid
+            )
         )
         db_user = result.one_or_none()
 
     if not db_user or not db_user.is_active:
+        return None
+    if user.token_version != int(db_user.token_version or 0):
         return None
 
     return user

--- a/src/dev_health_ops/api/auth/routers/dependencies.py
+++ b/src/dev_health_ops/api/auth/routers/dependencies.py
@@ -1,20 +1,14 @@
 from __future__ import annotations
 
-import logging
-import uuid as uuid_mod
 from typing import Annotated
 
 from fastapi import Header, HTTPException
-from sqlalchemy import select
 
 from dev_health_ops.api.services.auth import (
     AuthenticatedUser,
     extract_token_from_header,
 )
 from dev_health_ops.api.utils.errors import error_detail
-from dev_health_ops.models.users import User
-
-logger = logging.getLogger(__name__)
 
 
 async def get_current_user(
@@ -38,50 +32,10 @@ async def get_current_user(
         )
 
     auth_service = get_auth_service()
-    user = auth_service.get_authenticated_user(token)
+    async with get_postgres_session() as db:
+        user = await auth_service.authenticate_access_token(token, db)
 
     if not user:
-        raise HTTPException(
-            status_code=401,
-            detail=error_detail("Invalid or expired token"),
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    try:
-        user_uuid = uuid_mod.UUID(user.user_id)
-    except ValueError:
-        raise HTTPException(
-            status_code=401,
-            detail=error_detail("Invalid token claims"),
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    async with get_postgres_session() as db:
-        result = await db.execute(
-            select(User.id, User.is_active, User.token_version).where(
-                User.id == user_uuid
-            )
-        )
-        db_user = result.one_or_none()
-
-    if db_user is None:
-        logger.warning("JWT valid but user not found in DB: %s", user.user_id)
-        raise HTTPException(
-            status_code=401,
-            detail=error_detail("User no longer exists"),
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    if not db_user.is_active:
-        logger.warning("JWT valid but user is deactivated: %s", user.user_id)
-        raise HTTPException(
-            status_code=401,
-            detail=error_detail("Account is disabled"),
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    if user.token_version != int(db_user.token_version or 0):
-        logger.warning("JWT token version mismatch for user: %s", user.user_id)
         raise HTTPException(
             status_code=401,
             detail=error_detail("Invalid or expired token"),
@@ -104,29 +58,8 @@ async def get_current_user_optional(
         return None
 
     auth_service = get_auth_service()
-    user = auth_service.get_authenticated_user(token)
-    if not user:
-        return None
-
-    try:
-        user_uuid = uuid_mod.UUID(user.user_id)
-    except ValueError:
-        return None
-
     async with get_postgres_session() as db:
-        result = await db.execute(
-            select(User.id, User.is_active, User.token_version).where(
-                User.id == user_uuid
-            )
-        )
-        db_user = result.one_or_none()
-
-    if not db_user or not db_user.is_active:
-        return None
-    if user.token_version != int(db_user.token_version or 0):
-        return None
-
-    return user
+        return await auth_service.authenticate_access_token(token, db)
 
 
 __all__ = ["get_current_user", "get_current_user_optional"]

--- a/src/dev_health_ops/api/auth/routers/oauth.py
+++ b/src/dev_health_ops/api/auth/routers/oauth.py
@@ -168,6 +168,7 @@ async def social_login(
             is_superuser=bool(user.is_superuser),
             username=str(user.username) if user.username is not None else None,
             full_name=str(user.full_name) if user.full_name is not None else None,
+            token_version=int(getattr(user, "token_version", 0) or 0),
         )
 
         refresh_payload = auth_service.validate_token(

--- a/src/dev_health_ops/api/auth/routers/password_reset.py
+++ b/src/dev_health_ops/api/auth/routers/password_reset.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 import importlib
 import logging
+import uuid
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy import func, select
 
 from dev_health_ops.api.middleware.rate_limit import get_auth_key, limiter
+from dev_health_ops.api.utils.audit import emit_audit_log
 from dev_health_ops.api.utils.errors import error_detail
 from dev_health_ops.api.utils.logging import sanitize_for_log
-from dev_health_ops.models.users import User
+from dev_health_ops.models.audit import AuditAction, AuditResourceType
+from dev_health_ops.models.users import Membership, User
 
 from .common import VerifyEmailResponse
 
@@ -75,7 +78,10 @@ async def forgot_password(
 
 
 @router.post("/reset-password", response_model=VerifyEmailResponse)
-async def reset_password(payload: ResetPasswordRequest) -> VerifyEmailResponse:
+async def reset_password(
+    payload: ResetPasswordRequest,
+    request: Request,
+) -> VerifyEmailResponse:
     from dev_health_ops.api.auth.router import get_postgres_session
 
     password_reset_service = importlib.import_module(
@@ -89,6 +95,21 @@ async def reset_password(payload: ResetPasswordRequest) -> VerifyEmailResponse:
             raise HTTPException(
                 status_code=400,
                 detail=error_detail("Invalid or expired token"),
+            )
+        membership_result = await db.execute(
+            select(Membership.org_id).where(Membership.user_id == user.id).limit(1)
+        )
+        audit_org_id = membership_result.scalar_one_or_none()
+        if audit_org_id is not None:
+            emit_audit_log(
+                db,
+                org_id=audit_org_id,
+                action=AuditAction.PASSWORD_RESET,
+                resource_type=AuditResourceType.USER,
+                resource_id=str(user.id),
+                user_id=uuid.UUID(str(user.id)),
+                description="User reset password",
+                request=request,
             )
         await db.commit()
 

--- a/src/dev_health_ops/api/auth/routers/refresh.py
+++ b/src/dev_health_ops/api/auth/routers/refresh.py
@@ -245,6 +245,9 @@ async def refresh_token(
                                     if user.full_name is not None
                                     else None
                                 ),
+                                token_version=int(
+                                    getattr(user, "token_version", 0) or 0
+                                ),
                             )
                             logger.debug(
                                 "Concurrent-rotation grace window: replayed successor "
@@ -378,6 +381,7 @@ async def refresh_token(
             is_superuser=bool(user.is_superuser),
             username=str(user.username) if user.username is not None else None,
             full_name=str(user.full_name) if user.full_name is not None else None,
+            token_version=int(getattr(user, "token_version", 0) or 0),
         )
 
     return TokenRefreshResponse(

--- a/src/dev_health_ops/api/auth/routers/session.py
+++ b/src/dev_health_ops/api/auth/routers/session.py
@@ -226,11 +226,15 @@ async def validate_token(
 
     async with get_postgres_session() as db:
         result = await db.execute(
-            select(User.id, User.is_active).where(User.id == user_uuid)
+            select(User.id, User.is_active, User.token_version).where(
+                User.id == user_uuid
+            )
         )
         db_user = result.one_or_none()
 
     if not db_user or not db_user.is_active:
+        return TokenValidateResponse(valid=False)
+    if user.token_version != int(db_user.token_version or 0):
         return TokenValidateResponse(valid=False)
 
     return TokenValidateResponse(

--- a/src/dev_health_ops/api/auth/routers/session.py
+++ b/src/dev_health_ops/api/auth/routers/session.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import uuid as uuid_mod
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -214,27 +213,10 @@ async def validate_token(
     from dev_health_ops.api.auth.router import get_auth_service, get_postgres_session
 
     auth_service = get_auth_service()
-    user = auth_service.get_authenticated_user(payload.token)
+    async with get_postgres_session() as db:
+        user = await auth_service.authenticate_access_token(payload.token, db)
 
     if not user:
-        return TokenValidateResponse(valid=False)
-
-    try:
-        user_uuid = uuid_mod.UUID(user.user_id)
-    except ValueError:
-        return TokenValidateResponse(valid=False)
-
-    async with get_postgres_session() as db:
-        result = await db.execute(
-            select(User.id, User.is_active, User.token_version).where(
-                User.id == user_uuid
-            )
-        )
-        db_user = result.one_or_none()
-
-    if not db_user or not db_user.is_active:
-        return TokenValidateResponse(valid=False)
-    if user.token_version != int(db_user.token_version or 0):
         return TokenValidateResponse(valid=False)
 
     return TokenValidateResponse(

--- a/src/dev_health_ops/api/auth/sso/router.py
+++ b/src/dev_health_ops/api/auth/sso/router.py
@@ -663,6 +663,7 @@ async def saml_acs_callback(
             is_superuser=bool(user.is_superuser),
             username=_present_str(user.username, "user.username"),
             full_name=_present_str(user.full_name, "user.full_name"),
+            token_version=int(getattr(user, "token_version", 0) or 0),
         )
 
         return SSOLoginResponse(
@@ -859,6 +860,7 @@ async def oidc_callback(
             is_superuser=bool(user.is_superuser),
             username=_present_str(user.username, "user.username"),
             full_name=_present_str(user.full_name, "user.full_name"),
+            token_version=int(getattr(user, "token_version", 0) or 0),
         )
 
         return SSOLoginResponse(
@@ -1290,6 +1292,7 @@ async def oauth_callback(
             is_superuser=bool(user.is_superuser),
             username=_present_str(user.username, "user.username"),
             full_name=_present_str(user.full_name, "user.full_name"),
+            token_version=int(getattr(user, "token_version", 0) or 0),
         )
 
         return SSOLoginResponse(

--- a/src/dev_health_ops/api/graphql/app.py
+++ b/src/dev_health_ops/api/graphql/app.py
@@ -61,6 +61,7 @@ async def get_context(request: Request) -> GraphQLContext:
         get_current_org_id,
         get_impersonation_context,
     )
+    from dev_health_ops.db import get_postgres_session
 
     db_url = os.getenv("CLICKHOUSE_URI") or DEFAULT_CLICKHOUSE_URI
     persisted_query_id = request.headers.get("X-Persisted-Query-Id")
@@ -72,7 +73,8 @@ async def get_context(request: Request) -> GraphQLContext:
         token = extract_token_from_header(auth_header)
         if token:
             auth_service = get_auth_service()
-            user = auth_service.get_authenticated_user(token)
+            async with get_postgres_session() as db:
+                user = await auth_service.authenticate_access_token(token, db)
             logger.debug("Authenticated user: %s", user.email if user else None)
 
     if _graphql_auth_required() and user is None:

--- a/src/dev_health_ops/api/middleware/__init__.py
+++ b/src/dev_health_ops/api/middleware/__init__.py
@@ -33,7 +33,7 @@ from dev_health_ops.api.services.auth import (
 logger = logging.getLogger(__name__)
 
 
-def get_authenticated_user_from_headers(
+async def get_authenticated_user_from_headers(
     headers: Iterable[tuple[bytes, bytes]],
 ) -> AuthenticatedUser | None:
     for key, value in headers:
@@ -41,7 +41,12 @@ def get_authenticated_user_from_headers(
             token = extract_token_from_header(value.decode("latin-1"))
             if not token:
                 return None
-            return get_auth_service().get_authenticated_user(token)
+            from dev_health_ops.db import get_postgres_session
+
+            async with get_postgres_session() as session:
+                return await get_auth_service().authenticate_access_token(
+                    token, session
+                )
     return None
 
 
@@ -84,7 +89,7 @@ class OrgIdMiddleware:
                 header_org_id = value.decode("latin-1").strip() or None
                 break
 
-        user = get_authenticated_user_from_headers(headers)
+        user = await get_authenticated_user_from_headers(headers)
 
         resolved_org_id: str | None = None
         if header_org_id and user is not None:

--- a/src/dev_health_ops/api/middleware/impersonation.py
+++ b/src/dev_health_ops/api/middleware/impersonation.py
@@ -57,7 +57,7 @@ class ImpersonationMiddleware:
             await self.app(scope, receive, send)
             return
 
-        real_user = _extract_user(scope)
+        real_user = await _extract_user(scope)
         if real_user is None or not getattr(real_user, "is_superuser", False):
             await self.app(scope, receive, send)
             return
@@ -148,7 +148,7 @@ def _may_be_superuser(scope: Scope) -> bool:
         return False
 
 
-def _extract_user(scope: Scope) -> Any | None:
+async def _extract_user(scope: Scope) -> Any | None:
     """Extract authenticated user from scope state or authorization header."""
     state = scope.get("state")
     if state is not None:
@@ -169,7 +169,10 @@ def _extract_user(scope: Scope) -> Any | None:
     token = extract_token_from_header(auth_header)
     if not token:
         return None
-    return get_auth_service().get_authenticated_user(token)
+    from dev_health_ops.db import get_postgres_session
+
+    async with get_postgres_session() as db:
+        return await get_auth_service().authenticate_access_token(token, db)
 
 
 async def _expire_session(session: Any, admin_user_id: str) -> None:

--- a/src/dev_health_ops/api/services/auth.py
+++ b/src/dev_health_ops/api/services/auth.py
@@ -388,13 +388,14 @@ class AuthService:
             token_version = 0 if user.token_version is None else int(user.token_version)
         except (TypeError, ValueError):
             logger.warning(
-                "JWT token version claim is invalid for user: %s", user.user_id
+                "Access denied: stale-session check unreadable for user %s",
+                user.user_id,
             )
             return None
 
         current_token_version = int(db_user.token_version or 0)
         if token_version != current_token_version:
-            logger.warning("JWT token version mismatch for user: %s", user.user_id)
+            logger.warning("Access denied: stale session for user %s", user.user_id)
             return None
 
         user.token_version = token_version

--- a/src/dev_health_ops/api/services/auth.py
+++ b/src/dev_health_ops/api/services/auth.py
@@ -116,6 +116,7 @@ class AuthenticatedUser:
     username: str | None = None
     full_name: str | None = None
     impersonated_by: str | None = None
+    token_version: int | None = None
 
     @property
     def is_admin(self) -> bool:
@@ -158,6 +159,7 @@ class AuthService:
         is_superuser: bool = False,
         username: str | None = None,
         full_name: str | None = None,
+        token_version: int = 0,
         impersonating_user_id: str | None = None,
         expires_delta: timedelta | None = None,
     ) -> str:
@@ -178,6 +180,7 @@ class AuthService:
             "exp": expire,
             "iat": datetime.now(timezone.utc),
             "jti": str(uuid.uuid4()),
+            "tv": token_version,
         }
         if username:
             payload["username"] = username
@@ -253,6 +256,7 @@ class AuthService:
         is_superuser: bool = False,
         username: str | None = None,
         full_name: str | None = None,
+        token_version: int = 0,
     ) -> TokenPair:
         """Create both access and refresh tokens."""
         access_token = self.create_access_token(
@@ -263,6 +267,7 @@ class AuthService:
             is_superuser=is_superuser,
             username=username,
             full_name=full_name,
+            token_version=token_version,
         )
         refresh_token = self.create_refresh_token(user_id=user_id, org_id=org_id)
         return TokenPair(access_token=access_token, refresh_token=refresh_token)
@@ -337,6 +342,7 @@ class AuthService:
             username=payload.get("username"),
             full_name=payload.get("full_name"),
             impersonated_by=payload.get("impersonating_user_id"),
+            token_version=payload.get("tv"),
         )
 
     def refresh_access_token(
@@ -347,6 +353,7 @@ class AuthService:
         is_superuser: bool = False,
         username: str | None = None,
         full_name: str | None = None,
+        token_version: int = 0,
     ) -> str | None:
         """Create a new access token from a valid refresh token."""
         payload = self.validate_token(refresh_token, token_type="refresh")
@@ -361,6 +368,7 @@ class AuthService:
             is_superuser=is_superuser,
             username=username,
             full_name=full_name,
+            token_version=token_version,
         )
 
 

--- a/src/dev_health_ops/api/services/auth.py
+++ b/src/dev_health_ops/api/services/auth.py
@@ -16,6 +16,10 @@ from typing import Any
 
 import jwt
 from jwt.exceptions import InvalidTokenError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.models.users import User
 
 logger = logging.getLogger(__name__)
 
@@ -344,6 +348,57 @@ class AuthService:
             impersonated_by=payload.get("impersonating_user_id"),
             token_version=payload.get("tv"),
         )
+
+    async def authenticate_access_token(
+        self,
+        token: str,
+        db: AsyncSession,
+    ) -> AuthenticatedUser | None:
+        """Validate an access JWT against the database-backed user state.
+
+        Missing legacy ``tv`` claims are treated as version 0 so access tokens
+        issued before token-version rollout remain valid for users whose
+        persisted token_version is still the backfilled default. Present claims
+        must match the current database value exactly.
+        """
+        user = self.get_authenticated_user(token)
+        if not user:
+            return None
+
+        try:
+            user_uuid = uuid.UUID(user.user_id)
+        except ValueError:
+            logger.warning("JWT contains invalid user id claim: %s", user.user_id)
+            return None
+
+        result = await db.execute(
+            select(User.id, User.is_active, User.token_version).where(
+                User.id == user_uuid
+            )
+        )
+        db_user = result.one_or_none()
+        if db_user is None:
+            logger.warning("JWT valid but user not found in DB: %s", user.user_id)
+            return None
+        if not db_user.is_active:
+            logger.warning("JWT valid but user is deactivated: %s", user.user_id)
+            return None
+
+        try:
+            token_version = 0 if user.token_version is None else int(user.token_version)
+        except (TypeError, ValueError):
+            logger.warning(
+                "JWT token version claim is invalid for user: %s", user.user_id
+            )
+            return None
+
+        current_token_version = int(db_user.token_version or 0)
+        if token_version != current_token_version:
+            logger.warning("JWT token version mismatch for user: %s", user.user_id)
+            return None
+
+        user.token_version = token_version
+        return user
 
     def refresh_access_token(
         self,

--- a/src/dev_health_ops/api/services/password_reset.py
+++ b/src/dev_health_ops/api/services/password_reset.py
@@ -118,6 +118,7 @@ async def reset_password_with_token(
         bcrypt.gensalt(),
     ).decode("utf-8")
     user.password_hash = password_hash
+    user.token_version = int(user.token_version or 0) + 1
     user.updated_at = now
 
     revoke_all_for_user = importlib.import_module(

--- a/src/dev_health_ops/api/services/users.py
+++ b/src/dev_health_ops/api/services/users.py
@@ -134,7 +134,7 @@ class UserService:
             raise ValueError(f"User with username {username} already exists")
 
         password_hash = None
-        if password:
+        if password is not None:
             if len(password) < PASSWORD_MIN_LENGTH:
                 raise ValueError(
                     f"Password must be at least {PASSWORD_MIN_LENGTH} characters"
@@ -211,6 +211,7 @@ class UserService:
                 f"Password must be at least {PASSWORD_MIN_LENGTH} characters"
             )
         user.password_hash = _hash_password(password)
+        user.token_version = int(user.token_version or 0) + 1
         user.updated_at = datetime.now(timezone.utc)
         await revoke_all_for_user(self.session, user_id)
         await self.session.flush()

--- a/src/dev_health_ops/models/users.py
+++ b/src/dev_health_ops/models/users.py
@@ -84,6 +84,9 @@ class User(Base):
     is_superuser: Mapped[bool | None] = mapped_column(
         Boolean, default=False, nullable=False
     )
+    token_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
 
     # Timestamps
     last_login_at: Mapped[datetime | None] = mapped_column(

--- a/tests/api/auth/test_password_reset.py
+++ b/tests/api/auth/test_password_reset.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from dev_health_ops.api.middleware.rate_limit import limiter as rate_limiter
 from dev_health_ops.api.services.password_reset import create_password_reset_token
-from dev_health_ops.models.audit import AuditLog
+from dev_health_ops.models.audit import AuditAction, AuditLog
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.password_reset_token import PasswordResetToken
 from dev_health_ops.models.refresh_token import RefreshToken
@@ -71,8 +71,10 @@ async def seeded_user(session_maker):
         is_active=True,
         is_verified=True,
     )
+    org = Organization(id=uuid.uuid4(), slug="reset-org", name="Reset Org")
+    membership = Membership(user_id=user.id, org_id=org.id, role="member")
     async with session_maker() as session:
-        session.add(user)
+        session.add_all([user, org, membership])
         await session.commit()
     return user
 
@@ -189,6 +191,50 @@ async def test_reset_password_valid_token_updates_password_hash(
         new_password.encode("utf-8"),
         updated_user.password_hash.encode("utf-8"),
     )
+
+
+@pytest.mark.asyncio
+async def test_reset_password_valid_token_increments_token_version(
+    client, session_maker, seeded_user
+):
+    async_client, _ = client
+    async with session_maker() as session:
+        token = await create_password_reset_token(session, seeded_user.id)
+        await session.commit()
+
+    response = await async_client.post(
+        "/api/v1/auth/reset-password",
+        json={"token": token, "new_password": "NewPassword@456"},
+    )
+
+    assert response.status_code == 200
+    async with session_maker() as session:
+        result = await session.execute(select(User).where(User.id == seeded_user.id))
+        updated_user = result.scalar_one()
+    assert updated_user.token_version == 1
+
+
+@pytest.mark.asyncio
+async def test_reset_password_valid_token_emits_audit_log(
+    client, session_maker, seeded_user
+):
+    async_client, _ = client
+    async with session_maker() as session:
+        token = await create_password_reset_token(session, seeded_user.id)
+        await session.commit()
+
+    response = await async_client.post(
+        "/api/v1/auth/reset-password",
+        json={"token": token, "new_password": "NewPassword@456"},
+    )
+
+    assert response.status_code == 200
+    async with session_maker() as session:
+        result = await session.execute(
+            select(AuditLog).where(AuditLog.resource_id == str(seeded_user.id))
+        )
+        audit_log = result.scalar_one()
+    assert audit_log.action == AuditAction.PASSWORD_RESET.value
 
 
 @pytest.mark.asyncio

--- a/tests/api/auth/test_token_version_auth.py
+++ b/tests/api/auth/test_token_version_auth.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import importlib
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Annotated
+
+import pytest
+import pytest_asyncio
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.auth.routers.dependencies import get_current_user
+from dev_health_ops.api.middleware.rate_limit import limiter as rate_limiter
+from dev_health_ops.api.services.auth import AuthenticatedUser, AuthService
+from dev_health_ops.api.services.users import UserService
+from dev_health_ops.models.audit import AuditLog
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.refresh_token import RefreshToken
+from dev_health_ops.models.users import Membership, Organization, User
+from tests._helpers import tables_of
+
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "token-version-auth.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(
+                    User,
+                    Organization,
+                    Membership,
+                    AuditLog,
+                    RefreshToken,
+                ),
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_state(session_maker):
+    user = User(
+        id=uuid.uuid4(),
+        email="tv@example.com",
+        password_hash="old-hash",
+        is_active=True,
+        is_verified=True,
+        token_version=3,
+    )
+    org = Organization(id=uuid.uuid4(), slug="tv-org", name="Token Version Org")
+    membership = Membership(user_id=user.id, org_id=org.id, role="admin")
+    async with session_maker() as session:
+        session.add_all([user, org, membership])
+        await session.commit()
+    return {"user_id": user.id, "org_id": org.id, "email": str(user.email)}
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch: pytest.MonkeyPatch, session_maker):
+    app = FastAPI()
+    app.include_router(auth_router_module.router)
+
+    @app.get("/protected")
+    async def protected(
+        user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+    ) -> dict[str, str]:
+        return {"user_id": user.user_id}
+
+    @asynccontextmanager
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+
+    auth_service = AuthService(secret_key="token-version-test-secret-key-123456")
+    monkeypatch.setattr(auth_router_module, "get_postgres_session", _session_override)
+    monkeypatch.setattr(auth_router_module, "get_auth_service", lambda: auth_service)
+    monkeypatch.setattr(rate_limiter, "enabled", False)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client, auth_service
+
+    app.dependency_overrides.clear()
+
+
+def _issue_access_token(
+    auth_service: AuthService,
+    seeded_state: dict[str, object],
+    token_version: int,
+) -> str:
+    return auth_service.create_access_token(
+        user_id=str(seeded_state["user_id"]),
+        email=str(seeded_state["email"]),
+        org_id=str(seeded_state["org_id"]),
+        role="admin",
+        token_version=token_version,
+    )
+
+
+@pytest.mark.asyncio
+async def test_token_with_current_token_version_validates(client, seeded_state):
+    async_client, auth_service = client
+    token = _issue_access_token(auth_service, seeded_state, token_version=3)
+
+    payload = auth_service.validate_token(token)
+    assert payload is not None
+    assert payload["tv"] == 3
+
+    response = await async_client.post("/api/v1/auth/validate", json={"token": token})
+
+    assert response.status_code == 200
+    assert response.json()["valid"] is True
+
+
+@pytest.mark.asyncio
+async def test_stale_token_version_invalidates_validate_and_protected_route(
+    client,
+    session_maker,
+    seeded_state,
+):
+    async_client, auth_service = client
+    token = _issue_access_token(auth_service, seeded_state, token_version=3)
+    async with session_maker() as session:
+        user = await session.get(User, seeded_state["user_id"])
+        assert user is not None
+        user.token_version = 4
+        await session.commit()
+
+    validate_response = await async_client.post(
+        "/api/v1/auth/validate", json={"token": token}
+    )
+    protected_response = await async_client.get(
+        "/protected", headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert validate_response.status_code == 200
+    assert validate_response.json() == {
+        "valid": False,
+        "user_id": None,
+        "email": None,
+        "org_id": None,
+        "role": None,
+        "expires_at": None,
+    }
+    assert protected_response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_set_password_increments_token_version(session_maker, seeded_state):
+    async with session_maker() as session:
+        svc = UserService(session)
+        success = await svc.set_password(
+            str(seeded_state["user_id"]), "NewPassword@123"
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(User).where(User.id == seeded_state["user_id"])
+        )
+        user = result.scalar_one()
+
+    assert success is True
+    assert user.token_version == 4

--- a/tests/api/auth/test_user_service_credentials.py
+++ b/tests/api/auth/test_user_service_credentials.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.services.users import UserService
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.refresh_token import RefreshToken
+from dev_health_ops.models.users import User
+from tests._helpers import tables_of
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "user-service-credentials.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(User, RefreshToken),
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_create_empty_string_password_raises(session_maker):
+    async with session_maker() as session:
+        svc = UserService(session)
+        with pytest.raises(ValueError, match="Password must be at least 8 characters"):
+            await svc.create(email="empty-password@example.com", password="")
+
+
+@pytest.mark.asyncio
+async def test_create_none_password_creates_passwordless_user(session_maker):
+    async with session_maker() as session:
+        svc = UserService(session)
+        user = await svc.create(email="passwordless@example.com", password=None)
+        await session.commit()
+
+    async with session_maker() as session:
+        result = await session.execute(select(User).where(User.id == user.id))
+        created_user = result.scalar_one()
+
+    assert created_user.password_hash is None
+    assert created_user.token_version == 0

--- a/tests/api/graphql/test_context_impersonation.py
+++ b/tests/api/graphql/test_context_impersonation.py
@@ -14,6 +14,7 @@ service, so no DB or real JWT is required.
 from __future__ import annotations
 
 import types
+from contextlib import asynccontextmanager
 
 import pytest
 
@@ -43,8 +44,14 @@ def _stub_admin_auth(monkeypatch: pytest.MonkeyPatch, *, admin_org: str) -> None
         role="owner",
         is_superuser=True,
     )
+
+    async def _authenticate_access_token(
+        _token: str, _db: object
+    ) -> types.SimpleNamespace:
+        return fake_admin
+
     fake_service = types.SimpleNamespace(
-        get_authenticated_user=lambda _token: fake_admin
+        authenticate_access_token=_authenticate_access_token
     )
     monkeypatch.setattr(
         "dev_health_ops.api.services.auth.get_auth_service",
@@ -60,6 +67,12 @@ def _stub_admin_auth(monkeypatch: pytest.MonkeyPatch, *, admin_org: str) -> None
         _no_client,
     )
     monkeypatch.setenv("GRAPHQL_AUTH_REQUIRED", "true")
+
+    @asynccontextmanager
+    async def _fake_session():
+        yield object()
+
+    monkeypatch.setattr("dev_health_ops.db.get_postgres_session", _fake_session)
 
 
 @pytest.mark.asyncio

--- a/tests/api/graphql/test_graphql_auth.py
+++ b/tests/api/graphql/test_graphql_auth.py
@@ -2,10 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import jwt
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from dev_health_ops.api.services.auth import AuthService
+from dev_health_ops.api.services.auth import JWT_ALGORITHM, AuthService
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.users import User
+from tests._helpers import tables_of
 
 
 @pytest.fixture
@@ -14,9 +25,14 @@ def auth_service():
 
 
 @pytest.fixture
-def valid_token(auth_service):
+def seeded_user_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def valid_token(auth_service, seeded_user_id):
     return auth_service.create_access_token(
-        user_id="user-1",
+        user_id=str(seeded_user_id),
         email="test@example.com",
         org_id="test-org",
         role="member",
@@ -24,7 +40,48 @@ def valid_token(auth_service):
 
 
 @pytest.fixture
-def client_auth_required(monkeypatch):
+def graphql_auth_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, seeded_user_id):
+    db_path = tmp_path / "graphql-auth.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def _setup() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(
+                lambda sync_conn: Base.metadata.create_all(
+                    sync_conn,
+                    tables=tables_of(User),
+                )
+            )
+        async with maker() as session:
+            session.add(
+                User(
+                    id=seeded_user_id,
+                    email="test@example.com",
+                    password_hash="hash",
+                    is_active=True,
+                    is_verified=True,
+                    token_version=0,
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_setup())
+
+    @asynccontextmanager
+    async def _session_override():
+        async with maker() as session:
+            yield session
+
+    monkeypatch.setattr("dev_health_ops.db.get_postgres_session", _session_override)
+    try:
+        yield maker
+    finally:
+        asyncio.run(engine.dispose())
+
+
+@pytest.fixture
+def client_auth_required(monkeypatch, graphql_auth_db):
     """TestClient with auth enforcement enabled (default)."""
     monkeypatch.setenv("GRAPHQL_AUTH_REQUIRED", "true")
     monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-graphql-auth")
@@ -89,4 +146,97 @@ class TestGraphQLOrgIdFromJWT:
             headers={"Authorization": f"Bearer {valid_token}"},
         )
         # The request should pass auth; org_id is "test-org" from the token.
+        assert response.status_code != 401
+
+
+class TestGraphQLTokenVersionAuth:
+    def test_bumped_token_version_rejects_previously_valid_graphql_token(
+        self,
+        client_auth_required,
+        valid_token,
+        graphql_auth_db,
+        seeded_user_id,
+    ):
+        async def _bump() -> None:
+            async with graphql_auth_db() as session:
+                user = await session.get(User, seeded_user_id)
+                assert user is not None
+                user.token_version = 1
+                await session.commit()
+
+        asyncio.run(_bump())
+
+        response = client_auth_required.post(
+            "/graphql",
+            json={"query": "{ __typename }"},
+            headers={"Authorization": f"Bearer {valid_token}"},
+        )
+
+        assert response.status_code == 401
+
+    def test_bumped_token_version_rejects_stale_superuser_graphql_token(
+        self,
+        client_auth_required,
+        auth_service,
+        graphql_auth_db,
+        seeded_user_id,
+    ):
+        superuser_token = auth_service.create_access_token(
+            user_id=str(seeded_user_id),
+            email="test@example.com",
+            org_id="test-org",
+            role="owner",
+            is_superuser=True,
+            token_version=0,
+        )
+
+        async def _promote_and_bump() -> None:
+            async with graphql_auth_db() as session:
+                user = await session.get(User, seeded_user_id)
+                assert user is not None
+                user.is_superuser = True
+                user.token_version = 1
+                await session.commit()
+
+        asyncio.run(_promote_and_bump())
+
+        response = client_auth_required.post(
+            "/graphql",
+            json={"query": "{ __typename }"},
+            headers={"Authorization": f"Bearer {superuser_token}"},
+        )
+
+        assert response.status_code == 401
+
+    def test_missing_token_version_claim_allows_version_zero_user(
+        self,
+        client_auth_required,
+        auth_service,
+        seeded_user_id,
+    ):
+        now = datetime.now(timezone.utc)
+        legacy_token = jwt.encode(
+            {
+                "sub": str(seeded_user_id),
+                "email": "test@example.com",
+                "org_id": "test-org",
+                "role": "member",
+                "is_superuser": False,
+                "type": "access",
+                "iss": auth_service.issuer,
+                "aud": auth_service.audience,
+                "exp": now + timedelta(minutes=5),
+                "iat": now,
+                "jti": str(uuid.uuid4()),
+            },
+            auth_service.secret_key,
+            algorithm=JWT_ALGORITHM,
+        )
+
+        response = client_auth_required.post(
+            "/graphql",
+            json={"query": "{ __typename }"},
+            headers={"Authorization": f"Bearer {legacy_token}"},
+        )
+
         assert response.status_code != 401

--- a/tests/api/test_impersonation_middleware.py
+++ b/tests/api/test_impersonation_middleware.py
@@ -463,7 +463,7 @@ async def test_impersonation_overrides_orgid_when_inner():
 
     with (
         patch(_PATCH_TARGET, AsyncMock(return_value=session)),
-        patch(_ORGID_USER_PATCH, return_value=state_user),
+        patch(_ORGID_USER_PATCH, AsyncMock(return_value=state_user)),
     ):
         try:
             async with httpx.AsyncClient(
@@ -506,7 +506,7 @@ async def test_orgid_clobbers_impersonation_when_orgid_inner():
 
     with (
         patch(_PATCH_TARGET, AsyncMock(return_value=session)),
-        patch(_ORGID_USER_PATCH, return_value=state_user),
+        patch(_ORGID_USER_PATCH, AsyncMock(return_value=state_user)),
     ):
         try:
             async with httpx.AsyncClient(

--- a/tests/api/test_org_id_middleware_membership.py
+++ b/tests/api/test_org_id_middleware_membership.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import uuid
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -59,7 +59,7 @@ async def test_header_for_non_member_org_is_rejected():
     with (
         patch(
             "dev_health_ops.api.middleware.get_authenticated_user_from_headers",
-            return_value=user,
+            AsyncMock(return_value=user),
         ),
         patch(
             "dev_health_ops.api.middleware.user_is_member_of_org",
@@ -99,7 +99,7 @@ async def test_header_for_member_org_is_accepted():
     with (
         patch(
             "dev_health_ops.api.middleware.get_authenticated_user_from_headers",
-            return_value=user,
+            AsyncMock(return_value=user),
         ),
         patch(
             "dev_health_ops.api.middleware.user_is_member_of_org",
@@ -144,7 +144,7 @@ async def test_superuser_with_header_bypasses_membership_check():
 
     with patch(
         "dev_health_ops.api.middleware.get_authenticated_user_from_headers",
-        return_value=super_user,
+        AsyncMock(return_value=super_user),
     ):
         try:
             async with httpx.AsyncClient(
@@ -179,7 +179,7 @@ async def test_anonymous_request_with_header_passes_through():
 
     with patch(
         "dev_health_ops.api.middleware.get_authenticated_user_from_headers",
-        return_value=None,
+        AsyncMock(return_value=None),
     ):
         try:
             async with httpx.AsyncClient(
@@ -206,7 +206,7 @@ async def test_missing_header_falls_back_to_jwt_org():
 
     with patch(
         "dev_health_ops.api.middleware.get_authenticated_user_from_headers",
-        return_value=user,
+        AsyncMock(return_value=user),
     ):
         try:
             async with httpx.AsyncClient(

--- a/tests/test_auth_db_check.py
+++ b/tests/test_auth_db_check.py
@@ -93,7 +93,9 @@ async def test_get_current_user_rejects_nonexistent_user(auth_service):
         with pytest.raises(HTTPException) as exc_info:
             await get_current_user(authorization=header)
         assert exc_info.value.status_code == 401
-        assert "no longer exists" in _detail_message(exc_info.value.detail)
+        # Centralized validator returns a generic 401 for all auth failures
+        # (missing/inactive/stale) to avoid user-enumeration disclosure.
+        assert "Invalid or expired token" in _detail_message(exc_info.value.detail)
 
 
 @pytest.mark.asyncio
@@ -124,7 +126,7 @@ async def test_get_current_user_rejects_inactive_user(auth_service):
         with pytest.raises(HTTPException) as exc_info:
             await get_current_user(authorization=header)
         assert exc_info.value.status_code == 401
-        assert "disabled" in _detail_message(exc_info.value.detail)
+        assert "Invalid or expired token" in _detail_message(exc_info.value.detail)
 
 
 @pytest.mark.asyncio
@@ -135,7 +137,7 @@ async def test_get_current_user_accepts_active_user(auth_service):
     token = _make_token(auth_service, user_id=str(user_id))
     header = f"Bearer {token}"
 
-    active_row = SimpleNamespace(id=user_id, is_active=True)
+    active_row = SimpleNamespace(id=user_id, is_active=True, token_version=0)
     session = _mock_session(_FakeResult(row=active_row))
 
     from contextlib import asynccontextmanager


### PR DESCRIPTION
Part of **CHAOS-2458** (auth incident remediation). One of three workstreams.

## Problem
A password reset/change revoked only **refresh** tokens; already-issued stateless **access** tokens stayed valid until `exp` because `/auth/validate` checked only signature/exp + `is_active` and the JWT carried no credential-version claim ("session that never expired").

## Change
- Add `User.token_version` (Integer, NOT NULL, default 0, server_default "0") + Alembic migration `0012`.
- Embed a `tv` claim in access tokens, threaded through **all** issuance paths (login/common, refresh rotation, switch-org, OAuth, SSO).
- Centralized `AuthService.authenticate_access_token(token, db)` — single DB-backed validator (signature/exp/type + active user + `tv == User.token_version`) — wired into `get_current_user`, `get_current_user_optional`, `/api/v1/auth/validate`, **GraphQL `get_context`**, `OrgIdMiddleware`, and impersonation middleware.
- Missing `tv` claim treated as 0 (no mass-logout of pre-change sessions on deploy); a present mismatch rejects.
- Increment `token_version` on `set_password` and `reset_password_with_token`.
- Fix `UserService.create(password="")` footgun: empty string now hits min-length validation; `None` stays passwordless/SSO-safe.
- Emit `AuditAction.PASSWORD_RESET` on password reset.

## Adversarial review
Reviewed via `/codex:adversarial-review --model gpt-5.5`. First pass caught a **[high]**: enforcement was missing on the GraphQL auth path (stale tokens still authorized GraphQL). Fixed by the centralized validator; re-review: **approve, no material findings**.

## Verification
- ruff + lsp clean; targeted auth/GraphQL/middleware suite: **47 passed**.

Closes CHAOS-2458