### PR TITLE
fix(fixtures): guard auth seeding from overwriting/injecting credentials (CHAOS-2458)

### DIFF
--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -262,7 +262,7 @@ async def _merge_fixture_user(
     - overwrite_real_users=True: explicit opt-in to the previous destructive
       merge behavior for demo/dev refreshes.
     """
-    from sqlalchemy import or_, select
+    from sqlalchemy import func, or_, select
 
     from dev_health_ops.models.users import User
 
@@ -271,9 +271,17 @@ async def _merge_fixture_user(
         await session.merge(user)
         return "inserted"
 
-    natural_key_checks = [User.id == user.id, User.email == user.email]
+    # Match the auth layer's case-insensitive identity semantics (it stores and
+    # looks up email/username via lower()), so a real row like Admin@Host or
+    # username "Admin" is detected and never duplicated by a lowercase demo user.
+    natural_key_checks = [
+        User.id == user.id,
+        func.lower(User.email) == user.email.lower().strip(),
+    ]
     if user.username is not None:
-        natural_key_checks.append(User.username == user.username)
+        natural_key_checks.append(
+            func.lower(User.username) == user.username.lower().strip()
+        )
 
     existing: User | None = (
         await session.execute(select(User).where(or_(*natural_key_checks)).limit(1))

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -432,6 +432,12 @@ async def _seed_auth_data(
     # injection/overwrite/duplicate path (incl. the known-password superuser)
     # in one place. overwrite_real_users=True opts into seeding a populated DB
     # (fully-isolated demo/CI only).
+    #
+    # NOTE: this is a best-effort, non-atomic check (TOCTOU): a concurrent
+    # first-ever registration racing in during the seed pass is not covered.
+    # An atomic advisory-lock + single-transaction hardening is tracked as a
+    # follow-up. In practice this seeder is an operator/CI tool and must not be
+    # run against a live production DB; the check blocks the realistic case.
     if not overwrite_real_users:
         has_org = (await session.execute(select(Organization.id).limit(1))).first()
         has_user = (await session.execute(select(User.id).limit(1))).first()

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -408,22 +408,42 @@ async def _seed_auth_data(
 
     Credential guard (CHAOS-2458)
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    By default (``overwrite_real_users=False``) this function treats any
-    existing user/org/license row matched by primary or natural key as
-    pre-existing real data and never mutates it.  Membership and license writes
-    are filtered to users and orgs inserted by this invocation, so skipped users
-    cannot be added to fixture tenants and skipped orgs cannot have owners or
-    licenses replaced.  Pass ``overwrite_real_users=True`` only in fully-isolated
-    demo/CI environments where clobbering existing auth graph state is
-    explicitly acceptable.
+    By default (``overwrite_real_users=False``) fixture auth seeding only runs
+    against an EMPTY auth database: if any organization or user already exists,
+    the whole pass is skipped and nothing is written.  This is the primary guard
+    and closes every injection/overwrite/duplicate path at once (including the
+    known-password admin superuser).  Per-entity insert-if-absent checks remain
+    as defense-in-depth.  Pass ``overwrite_real_users=True`` only in
+    fully-isolated demo/CI environments where seeding or refreshing auth data in
+    a populated database is explicitly acceptable.
     """
+    from sqlalchemy import select
     from sqlalchemy.dialects.postgresql import insert as pg_insert
     from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
-    from dev_health_ops.models.users import Membership
+    from dev_health_ops.models.users import Membership, Organization, User
 
     bind = await session.connection()
     dialect = bind.dialect.name
+
+    # Primary credential guard (CHAOS-2458): fixture auth seeding must never
+    # write into a populated auth database on the default path. If ANY org or
+    # user already exists, refuse to seed auth data at all -- this closes every
+    # injection/overwrite/duplicate path (incl. the known-password superuser)
+    # in one place. overwrite_real_users=True opts into seeding a populated DB
+    # (fully-isolated demo/CI only).
+    if not overwrite_real_users:
+        has_org = (await session.execute(select(Organization.id).limit(1))).first()
+        has_user = (await session.execute(select(User.id).limit(1))).first()
+        if has_org is not None or has_user is not None:
+            logging.warning(
+                "FIXTURES-GUARD: refusing to seed fixture auth data into a "
+                "non-empty auth database (existing organizations/users found). "
+                "No users, orgs, memberships, or licenses were written. Pass "
+                "overwrite_real_users=True to seed/refresh in a populated DB "
+                "(demo/CI only)."
+            )
+            return
 
     safe_org_ids: set[Any] = set()
     for org in user_data["organizations"]:

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -436,8 +436,31 @@ async def _seed_auth_data(
             safe_org_ids.add(org.id)
     await session.commit()
 
+    # Gate fixture-user insertion on safe-org insertion (CHAOS-2458): on the
+    # default path, never introduce a fixture account (e.g. the known-password
+    # admin@devhealth.example superuser) for a tenant that already exists. A
+    # fixture user is eligible only if it belongs to at least one org that was
+    # freshly inserted this run; users tied only to pre-existing (skipped) orgs
+    # are left out entirely. overwrite_real_users=True keeps the full pass.
+    all_memberships = user_data.get("memberships") or []
+    user_org_map: dict[Any, set[Any]] = {}
+    for membership in all_memberships:
+        user_org_map.setdefault(membership.user_id, set()).add(membership.org_id)
+
     safe_user_ids: set[Any] = set()
     for user in user_data["users"]:
+        if not overwrite_real_users and not (
+            user_org_map.get(user.id, set()) & safe_org_ids
+        ):
+            logging.warning(
+                "FIXTURES-GUARD: skipping fixture user %s (%s) because it is not "
+                "tied to any newly-seeded fixture org; refusing to inject a "
+                "fixture account next to existing tenant data. Pass "
+                "overwrite_real_users=True to bypass (demo/CI only).",
+                user.id,
+                user.email,
+            )
+            continue
         status = await _merge_fixture_user(
             session,
             user,

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -251,59 +251,127 @@ async def _merge_fixture_user(
     session,
     user,
     *,
-    default_password: str | None,
     overwrite_real_users: bool,
-) -> None:
-    """Safely merge a single fixture user, guarding real credentials.
+) -> str:
+    """Safely write a single fixture user and report whether dependents are safe.
 
     Rules (CHAOS-2458):
-    - Row absent → INSERT via merge (safe, new fixture user).
-    - Row present, password verifies against fixture default_password → it is
-      a fixture-owned row; merge to refresh non-credential fields.
-    - Row present, password does NOT verify → real user; skip entirely and
-      emit a warning.  Pass overwrite_real_users=True to bypass (CI/demo
-      only).
+    - overwrite_real_users=False: insert only when neither the primary key nor
+      natural keys already exist. Any existing row is treated as real and left
+      untouched; dependents must not be written for skipped users.
+    - overwrite_real_users=True: explicit opt-in to the previous destructive
+      merge behavior for demo/dev refreshes.
     """
-    import bcrypt
+    from sqlalchemy import or_, select
 
     from dev_health_ops.models.users import User
-
-    existing: User | None = await session.get(User, user.id)
-    if existing is None:
-        # No collision — safe to insert.
-        await session.merge(user)
-        return
 
     if overwrite_real_users:
         # Explicit opt-in: caller accepts credential clobber risk.
         await session.merge(user)
-        return
+        return "inserted"
 
-    # Row exists.  Determine whether it is fixture-owned by checking whether
-    # its stored hash verifies against the known fixture password.
-    existing_hash: str | None = existing.password_hash
-    is_fixture_owned = False
-    if default_password is not None and existing_hash is not None:
-        try:
-            is_fixture_owned = bcrypt.checkpw(
-                default_password.encode("utf-8"),
-                existing_hash.encode("utf-8"),
-            )
-        except Exception:
-            # Malformed hash or bcrypt error — treat as non-fixture.
-            is_fixture_owned = False
+    natural_key_checks = [User.id == user.id, User.email == user.email]
+    if user.username is not None:
+        natural_key_checks.append(User.username == user.username)
 
-    if is_fixture_owned:
+    existing: User | None = (
+        await session.execute(select(User).where(or_(*natural_key_checks)).limit(1))
+    ).scalar_one_or_none()
+    if existing is None:
         await session.merge(user)
-    else:
-        logging.warning(
-            "FIXTURES-GUARD: skipping password_hash overwrite for user %s (%s) —"
-            " existing row was not created by the fixture seeder"
-            " (password does not match fixture default)."
-            " Pass overwrite_real_users=True to bypass (demo/CI only).",
-            user.id,
-            user.email,
+        return "inserted"
+
+    logging.warning(
+        "FIXTURES-GUARD: skipping fixture user %s (%s) because an existing "
+        "user row matched by id/email/username. No user fields, password_hash, "
+        "memberships, org ownership, or tenant data will be mutated. Pass "
+        "overwrite_real_users=True to bypass (demo/CI only).",
+        user.id,
+        user.email,
+    )
+    return "skipped_existing"
+
+
+async def _merge_fixture_org(
+    session,
+    org,
+    *,
+    overwrite_real_users: bool,
+) -> str:
+    """Insert a fixture org only when absent unless destructive merge is enabled."""
+    from sqlalchemy import or_, select
+
+    from dev_health_ops.models.users import Organization
+
+    if overwrite_real_users:
+        await session.merge(org)
+        return "inserted"
+
+    existing: Organization | None = (
+        await session.execute(
+            select(Organization)
+            .where(or_(Organization.id == org.id, Organization.slug == org.slug))
+            .limit(1)
         )
+    ).scalar_one_or_none()
+    if existing is None:
+        await session.merge(org)
+        return "inserted"
+
+    logging.warning(
+        "FIXTURES-GUARD: skipping fixture org %s (%s) because an existing "
+        "tenant matched by id/slug. No org fields, owner memberships, or "
+        "license rows will be mutated. Pass overwrite_real_users=True to "
+        "bypass (demo/CI only).",
+        org.id,
+        org.slug,
+    )
+    return "skipped_existing"
+
+
+async def _add_fixture_license_if_absent(
+    session,
+    org_license,
+    *,
+    overwrite_real_users: bool,
+) -> str:
+    """Insert fixture license without replacing existing tenant license by default."""
+    from sqlalchemy import delete, or_, select
+
+    from dev_health_ops.models.licensing import OrgLicense
+
+    existing: OrgLicense | None = (
+        await session.execute(
+            select(OrgLicense)
+            .where(
+                or_(
+                    OrgLicense.id == org_license.id,
+                    OrgLicense.org_id == org_license.org_id,
+                )
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    if existing is not None:
+        if overwrite_real_users:
+            await session.execute(
+                delete(OrgLicense).where(OrgLicense.org_id == org_license.org_id)
+            )
+            session.add(org_license)
+            return "inserted"
+
+        logging.warning(
+            "FIXTURES-GUARD: skipping fixture license for org %s because an "
+            "existing license matched by id/org_id. Pass overwrite_real_users=True "
+            "to bypass (demo/CI only).",
+            org_license.org_id,
+        )
+        return "skipped_existing"
+
+    session.add(org_license)
+    return "inserted"
 
 
 async def _seed_auth_data(
@@ -312,7 +380,7 @@ async def _seed_auth_data(
     *,
     overwrite_real_users: bool = False,
 ) -> None:
-    """Merge orgs/users, upsert memberships, replace licenses into Postgres.
+    """Seed auth orgs/users/memberships/licenses into Postgres.
 
     Idempotent against re-runs. Memberships use an explicit
     ``INSERT ... ON CONFLICT (user_id, org_id) DO NOTHING`` because
@@ -327,40 +395,52 @@ async def _seed_auth_data(
 
     Credential guard (CHAOS-2458)
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    By default (``overwrite_real_users=False``) this function will NEVER
-    overwrite the ``password_hash`` of a user row that was not itself
-    created by the fixture seeder.  For each fixture user it checks
-    whether an existing row's hash verifies against the fixture
-    ``default_password``; if it does not, the row is skipped and a
-    warning is logged.  Pass ``overwrite_real_users=True`` only in
-    fully-isolated demo/CI environments where clobbering credentials is
+    By default (``overwrite_real_users=False``) this function treats any
+    existing user/org/license row matched by primary or natural key as
+    pre-existing real data and never mutates it.  Membership and license writes
+    are filtered to users and orgs inserted by this invocation, so skipped users
+    cannot be added to fixture tenants and skipped orgs cannot have owners or
+    licenses replaced.  Pass ``overwrite_real_users=True`` only in fully-isolated
+    demo/CI environments where clobbering existing auth graph state is
     explicitly acceptable.
     """
-    from sqlalchemy import delete
     from sqlalchemy.dialects.postgresql import insert as pg_insert
     from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
-    from dev_health_ops.models.licensing import OrgLicense
     from dev_health_ops.models.users import Membership
 
     bind = await session.connection()
     dialect = bind.dialect.name
 
+    safe_org_ids: set[Any] = set()
     for org in user_data["organizations"]:
-        await session.merge(org)
-    await session.commit()
-
-    default_password: str | None = user_data.get("default_password")
-    for user in user_data["users"]:
-        await _merge_fixture_user(
+        status = await _merge_fixture_org(
             session,
-            user,
-            default_password=default_password,
+            org,
             overwrite_real_users=overwrite_real_users,
         )
+        if status == "inserted":
+            safe_org_ids.add(org.id)
+    await session.commit()
+
+    safe_user_ids: set[Any] = set()
+    for user in user_data["users"]:
+        status = await _merge_fixture_user(
+            session,
+            user,
+            overwrite_real_users=overwrite_real_users,
+        )
+        if status == "inserted":
+            safe_user_ids.add(user.id)
     await session.commit()
 
     memberships = user_data.get("memberships") or []
+    if not overwrite_real_users:
+        memberships = [
+            membership
+            for membership in memberships
+            if membership.user_id in safe_user_ids and membership.org_id in safe_org_ids
+        ]
     if memberships:
         rows = [
             {
@@ -400,10 +480,13 @@ async def _seed_auth_data(
     await session.commit()
 
     for org_license in user_data.get("licenses", []):
-        await session.execute(
-            delete(OrgLicense).where(OrgLicense.org_id == org_license.org_id)
+        if not overwrite_real_users and org_license.org_id not in safe_org_ids:
+            continue
+        await _add_fixture_license_if_absent(
+            session,
+            org_license,
+            overwrite_real_users=overwrite_real_users,
         )
-        session.add(org_license)
     await session.commit()
 
 

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -308,7 +308,7 @@ async def _merge_fixture_org(
     overwrite_real_users: bool,
 ) -> str:
     """Insert a fixture org only when absent unless destructive merge is enabled."""
-    from sqlalchemy import or_, select
+    from sqlalchemy import func, or_, select
 
     from dev_health_ops.models.users import Organization
 
@@ -319,7 +319,12 @@ async def _merge_fixture_org(
     existing: Organization | None = (
         await session.execute(
             select(Organization)
-            .where(or_(Organization.id == org.id, Organization.slug == org.slug))
+            .where(
+                or_(
+                    Organization.id == org.id,
+                    func.lower(Organization.slug) == org.slug.lower().strip(),
+                )
+            )
             .limit(1)
         )
     ).scalar_one_or_none()

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -247,7 +247,71 @@ def validate_work_unit_investment_density_and_coverage(
     return True
 
 
-async def _seed_auth_data(session, user_data: dict) -> None:
+async def _merge_fixture_user(
+    session,
+    user,
+    *,
+    default_password: str | None,
+    overwrite_real_users: bool,
+) -> None:
+    """Safely merge a single fixture user, guarding real credentials.
+
+    Rules (CHAOS-2458):
+    - Row absent → INSERT via merge (safe, new fixture user).
+    - Row present, password verifies against fixture default_password → it is
+      a fixture-owned row; merge to refresh non-credential fields.
+    - Row present, password does NOT verify → real user; skip entirely and
+      emit a warning.  Pass overwrite_real_users=True to bypass (CI/demo
+      only).
+    """
+    import bcrypt
+
+    from dev_health_ops.models.users import User
+
+    existing: User | None = await session.get(User, user.id)
+    if existing is None:
+        # No collision — safe to insert.
+        await session.merge(user)
+        return
+
+    if overwrite_real_users:
+        # Explicit opt-in: caller accepts credential clobber risk.
+        await session.merge(user)
+        return
+
+    # Row exists.  Determine whether it is fixture-owned by checking whether
+    # its stored hash verifies against the known fixture password.
+    existing_hash: str | None = existing.password_hash
+    is_fixture_owned = False
+    if default_password is not None and existing_hash is not None:
+        try:
+            is_fixture_owned = bcrypt.checkpw(
+                default_password.encode("utf-8"),
+                existing_hash.encode("utf-8"),
+            )
+        except Exception:
+            # Malformed hash or bcrypt error — treat as non-fixture.
+            is_fixture_owned = False
+
+    if is_fixture_owned:
+        await session.merge(user)
+    else:
+        logging.warning(
+            "FIXTURES-GUARD: skipping password_hash overwrite for user %s (%s) —"
+            " existing row was not created by the fixture seeder"
+            " (password does not match fixture default)."
+            " Pass overwrite_real_users=True to bypass (demo/CI only).",
+            user.id,
+            user.email,
+        )
+
+
+async def _seed_auth_data(
+    session,
+    user_data: dict,
+    *,
+    overwrite_real_users: bool = False,
+) -> None:
     """Merge orgs/users, upsert memberships, replace licenses into Postgres.
 
     Idempotent against re-runs. Memberships use an explicit
@@ -260,6 +324,17 @@ async def _seed_auth_data(session, user_data: dict) -> None:
     even though the merging row has a deterministic id (CHAOS-1717).
     Existing licenses already use a delete + add idempotency dance for
     similar reasons.
+
+    Credential guard (CHAOS-2458)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    By default (``overwrite_real_users=False``) this function will NEVER
+    overwrite the ``password_hash`` of a user row that was not itself
+    created by the fixture seeder.  For each fixture user it checks
+    whether an existing row's hash verifies against the fixture
+    ``default_password``; if it does not, the row is skipped and a
+    warning is logged.  Pass ``overwrite_real_users=True`` only in
+    fully-isolated demo/CI environments where clobbering credentials is
+    explicitly acceptable.
     """
     from sqlalchemy import delete
     from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -275,8 +350,14 @@ async def _seed_auth_data(session, user_data: dict) -> None:
         await session.merge(org)
     await session.commit()
 
+    default_password: str | None = user_data.get("default_password")
     for user in user_data["users"]:
-        await session.merge(user)
+        await _merge_fixture_user(
+            session,
+            user,
+            default_password=default_password,
+            overwrite_real_users=overwrite_real_users,
+        )
     await session.commit()
 
     memberships = user_data.get("memberships") or []

--- a/tests/test_fixtures_credential_guard.py
+++ b/tests/test_fixtures_credential_guard.py
@@ -1,11 +1,11 @@
-"""Tests for CHAOS-2458: fixture seeder must not clobber real users' password_hash.
+"""Tests for CHAOS-2458: fixture seeder must not clobber real auth graph rows.
 
 Covers:
 1. Seeding into a DB with an existing NON-fixture user of the same id/email does
    NOT change that user's password_hash.
-2. Seeding still correctly creates/refreshes genuine fixture users.
+2. Seeding still correctly creates genuine fixture users and memberships.
 3. overwrite_real_users=True bypasses the guard (explicit opt-in).
-4. _merge_fixture_user handles missing default_password gracefully (skips).
+4. Existing users/orgs/licenses are treated as real without bcrypt ownership checks.
 """
 
 from __future__ import annotations
@@ -17,6 +17,7 @@ from pathlib import Path
 import bcrypt
 import pytest
 import pytest_asyncio
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.fixtures.runner import _merge_fixture_user, _seed_auth_data
@@ -38,6 +39,9 @@ _REAL_PASSWORD = "s3cr3t-real-password-not-demo"
 _REAL_HASH = bcrypt.hashpw(_REAL_PASSWORD.encode("utf-8"), bcrypt.gensalt()).decode(
     "utf-8"
 )
+_REAL_DEMO_PASSWORD_HASH = bcrypt.hashpw(
+    _FIXTURE_PASSWORD.encode("utf-8"), bcrypt.gensalt()
+).decode("utf-8")
 
 
 @pytest_asyncio.fixture
@@ -176,28 +180,182 @@ async def test_real_user_password_not_overwritten(session_maker):
 
 
 @pytest.mark.asyncio
+async def test_real_user_not_added_to_fixture_org_or_membership(session_maker):
+    """A skipped real user must not receive fixture org membership."""
+    user_id = _fixture_user_id()
+    org = _make_org()
+
+    async with session_maker() as session:
+        session.add(
+            User(
+                id=user_id,
+                email="admin@devhealth.example",
+                username="admin",
+                password_hash=_REAL_HASH,
+                full_name="Real Admin",
+                auth_provider="local",
+                is_active=True,
+                is_verified=True,
+                is_superuser=False,
+            )
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    async with session_maker() as session:
+        memberships = (
+            (
+                await session.execute(
+                    select(Membership).where(
+                        Membership.user_id == user_id,
+                        Membership.org_id == org.id,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        user = await session.get(User, user_id)
+
+    assert user is not None
+    assert user.is_superuser is False
+    assert memberships == []
+
+
+@pytest.mark.asyncio
+async def test_real_user_with_demo_password_is_still_not_overwritten(session_maker):
+    """Password equality is not an ownership signal for existing rows."""
+    user_id = _fixture_user_id()
+
+    async with session_maker() as session:
+        session.add(
+            User(
+                id=user_id,
+                email="admin@devhealth.example",
+                username="admin",
+                password_hash=_REAL_DEMO_PASSWORD_HASH,
+                full_name="Real Admin Using Demo Password",
+                auth_provider="local",
+                is_active=True,
+                is_verified=False,
+                is_superuser=False,
+            )
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    async with session_maker() as session:
+        user = await session.get(User, user_id)
+        memberships = (
+            (
+                await session.execute(
+                    select(Membership).where(Membership.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert user is not None
+    assert user.password_hash == _REAL_DEMO_PASSWORD_HASH
+    assert user.full_name == "Real Admin Using Demo Password"
+    assert user.is_verified is False
+    assert user.is_superuser is False
+    assert memberships == []
+
+
+@pytest.mark.asyncio
+async def test_existing_org_license_not_replaced(session_maker):
+    """A pre-existing tenant keeps its org and license state by default."""
+    from dev_health_ops.licensing.types import LicenseTier
+
+    org = _make_org()
+    real_license_id = uuid.uuid5(org.id, "real-license")
+
+    async with session_maker() as session:
+        session.add(
+            Organization(
+                id=org.id,
+                slug=org.slug,
+                name="Real Tenant",
+                tier="community",
+                is_active=True,
+            )
+        )
+        real_license = OrgLicense(
+            org_id=org.id,
+            tier=LicenseTier.COMMUNITY.value,
+            license_type="self-hosted",
+            licensed_users=3,
+            licensed_repos=2,
+            issued_at=datetime.now(timezone.utc),
+        )
+        real_license.id = real_license_id
+        session.add(real_license)
+        await session.commit()
+
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    async with session_maker() as session:
+        saved_org = await session.get(Organization, org.id)
+        licenses = (
+            (
+                await session.execute(
+                    select(OrgLicense).where(OrgLicense.org_id == org.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert saved_org is not None
+    assert saved_org.name == "Real Tenant"
+    assert saved_org.tier == "community"
+    assert len(licenses) == 1
+    assert licenses[0].id == real_license_id
+    assert licenses[0].tier == LicenseTier.COMMUNITY.value
+    assert licenses[0].license_type == "self-hosted"
+    assert licenses[0].licensed_users == 3
+
+
+@pytest.mark.asyncio
 async def test_fixture_user_created_when_absent(session_maker):
-    """Seeding into an empty DB must create the fixture user correctly."""
+    """Seeding into an empty DB must create the fixture user auth graph."""
     async with session_maker() as session:
         await _seed_auth_data(session, _build_user_data())
 
     async with session_maker() as session:
         user = await session.get(User, _fixture_user_id())
         assert user is not None
+        memberships = (
+            (
+                await session.execute(
+                    select(Membership).where(Membership.user_id == user.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        licenses = (await session.execute(select(OrgLicense))).scalars().all()
         assert user.email == "admin@devhealth.example"
         # The stored hash must verify against the fixture password.
         assert bcrypt.checkpw(
             _FIXTURE_PASSWORD.encode("utf-8"), user.password_hash.encode("utf-8")
         )
+        assert len(memberships) == 1
+        assert memberships[0].role == "owner"
+        assert len(licenses) == 1
+        assert licenses[0].tier == "enterprise"
 
 
 @pytest.mark.asyncio
-async def test_fixture_user_refreshed_on_reseed(session_maker):
-    """Re-seeding a genuine fixture user (same fixture hash) must succeed.
-
-    This covers the idempotent re-seed path: the existing row has the fixture
-    hash, so the guard recognises it as fixture-owned and allows the merge.
-    """
+async def test_fixture_user_not_refreshed_on_default_reseed(session_maker):
+    """Re-seeding existing rows is a safe no-op by default."""
     async with session_maker() as session:
         await _seed_auth_data(session, _build_user_data())
 
@@ -207,14 +365,14 @@ async def test_fixture_user_refreshed_on_reseed(session_maker):
         user.full_name = "Mutated Name"
         await session.commit()
 
-    # Re-seed — should restore full_name and keep the fixture hash.
+    # Re-seed — should not mutate any existing user fields by default.
     async with session_maker() as session:
         await _seed_auth_data(session, _build_user_data())
 
     async with session_maker() as session:
         user = await session.get(User, _fixture_user_id())
         assert user is not None
-        assert user.full_name == "Admin User"
+        assert user.full_name == "Mutated Name"
         assert bcrypt.checkpw(
             _FIXTURE_PASSWORD.encode("utf-8"), user.password_hash.encode("utf-8")
         )
@@ -223,9 +381,21 @@ async def test_fixture_user_refreshed_on_reseed(session_maker):
 @pytest.mark.asyncio
 async def test_overwrite_real_users_opt_in_clobbers_hash(session_maker):
     """overwrite_real_users=True must bypass the guard (explicit opt-in path)."""
+    from dev_health_ops.licensing.types import LicenseTier
+
     user_id = _fixture_user_id()
+    org = _make_org()
 
     async with session_maker() as session:
+        session.add(
+            Organization(
+                id=org.id,
+                slug=org.slug,
+                name="Real Tenant",
+                tier="community",
+                is_active=True,
+            )
+        )
         real_user = User(
             id=user_id,
             email="admin@devhealth.example",
@@ -234,10 +404,20 @@ async def test_overwrite_real_users_opt_in_clobbers_hash(session_maker):
             full_name="Real Admin",
             auth_provider="local",
             is_active=True,
-            is_verified=True,
-            is_superuser=True,
+            is_verified=False,
+            is_superuser=False,
         )
         session.add(real_user)
+        real_license = OrgLicense(
+            org_id=org.id,
+            tier=LicenseTier.COMMUNITY.value,
+            license_type="self-hosted",
+            licensed_users=3,
+            licensed_repos=2,
+            issued_at=datetime.now(timezone.utc),
+        )
+        real_license.id = uuid.uuid5(org.id, "real-license")
+        session.add(real_license)
         await session.commit()
 
     # Explicit opt-in: caller accepts credential clobber.
@@ -246,11 +426,42 @@ async def test_overwrite_real_users_opt_in_clobbers_hash(session_maker):
 
     async with session_maker() as session:
         user = await session.get(User, user_id)
+        saved_org = await session.get(Organization, org.id)
+        memberships = (
+            (
+                await session.execute(
+                    select(Membership).where(Membership.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        licenses = (
+            (
+                await session.execute(
+                    select(OrgLicense).where(OrgLicense.org_id == org.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
         assert user is not None
         # Hash must now be the fixture hash (clobbered).
         assert bcrypt.checkpw(
             _FIXTURE_PASSWORD.encode("utf-8"), user.password_hash.encode("utf-8")
         )
+        assert user.full_name == "Admin User"
+        assert user.is_verified is True
+        assert user.is_superuser is True
+        assert saved_org is not None
+        assert saved_org.name == "Demo Org"
+        assert saved_org.tier == "enterprise"
+        assert len(memberships) == 1
+        assert memberships[0].role == "owner"
+        assert len(licenses) == 1
+        assert licenses[0].tier == LicenseTier.ENTERPRISE.value
+        assert licenses[0].license_type == "saas"
+        assert licenses[0].licensed_users is None
 
 
 # ---------------------------------------------------------------------------
@@ -268,13 +479,13 @@ async def test_merge_fixture_user_inserts_when_absent(session_maker):
         await session.merge(org)
         await session.commit()
 
-        await _merge_fixture_user(
+        status = await _merge_fixture_user(
             session,
             user,
-            default_password=_FIXTURE_PASSWORD,
             overwrite_real_users=False,
         )
         await session.commit()
+        assert status == "inserted"
 
     async with session_maker() as session:
         result = await session.get(User, user.id)
@@ -304,13 +515,13 @@ async def test_merge_fixture_user_skips_real_user(session_maker):
 
     fixture_user = _make_fixture_user()  # has _FIXTURE_HASH
     async with session_maker() as session:
-        await _merge_fixture_user(
+        status = await _merge_fixture_user(
             session,
             fixture_user,
-            default_password=_FIXTURE_PASSWORD,
             overwrite_real_users=False,
         )
         await session.commit()
+        assert status == "skipped_existing"
 
     async with session_maker() as session:
         user = await session.get(User, user_id)
@@ -318,8 +529,8 @@ async def test_merge_fixture_user_skips_real_user(session_maker):
 
 
 @pytest.mark.asyncio
-async def test_merge_fixture_user_no_default_password_skips_existing(session_maker):
-    """When default_password is None, existing rows must not be overwritten."""
+async def test_merge_fixture_user_skips_existing_without_password_check(session_maker):
+    """Existing rows are skipped without using password ownership checks."""
     user_id = _fixture_user_id()
 
     async with session_maker() as session:
@@ -339,13 +550,13 @@ async def test_merge_fixture_user_no_default_password_skips_existing(session_mak
 
     fixture_user = _make_fixture_user()
     async with session_maker() as session:
-        await _merge_fixture_user(
+        status = await _merge_fixture_user(
             session,
             fixture_user,
-            default_password=None,  # no password provided
             overwrite_real_users=False,
         )
         await session.commit()
+        assert status == "skipped_existing"
 
     async with session_maker() as session:
         user = await session.get(User, user_id)

--- a/tests/test_fixtures_credential_guard.py
+++ b/tests/test_fixtures_credential_guard.py
@@ -741,3 +741,45 @@ async def test_mixed_case_real_identity_not_duplicated(session_maker):
         assert rows[0].password_hash == _REAL_HASH
         # The lowercase fixture UUID must NOT have been inserted as a new row.
         assert await session.get(User, _fixture_user_id()) is None
+
+
+@pytest.mark.asyncio
+async def test_mixed_case_real_org_slug_not_duplicated(session_maker):
+    """A real org with a mixed-case slug must be detected case-insensitively
+    (matching the org service's lower(slug) lookup) so the seeder does not
+    insert a duplicate tenant + fixture license/memberships (CHAOS-2458
+    review follow-up)."""
+    real_org_id = uuid.uuid4()  # distinct from the deterministic fixture uuid5
+    async with session_maker() as session:
+        real_org = Organization(
+            id=real_org_id,
+            slug="Default-Org",
+            name="Real Tenant",
+            tier="enterprise",
+            is_active=True,
+        )
+        session.add(real_org)
+        await session.commit()
+
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    async with session_maker() as session:
+        orgs = (
+            (
+                await session.execute(
+                    select(Organization).where(
+                        func.lower(Organization.slug) == "default-org"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(orgs) == 1, "Seeder must not duplicate a mixed-case real org slug"
+        assert orgs[0].id == real_org_id
+        # The deterministic fixture org id must NOT have been inserted.
+        assert await session.get(Organization, _make_org().id) is None
+        # No fixture license rows should exist for the duplicate tenant.
+        licenses = (await session.execute(select(OrgLicense))).scalars().all()
+        assert all(lic.org_id == real_org_id for lic in licenses) or not licenses

--- a/tests/test_fixtures_credential_guard.py
+++ b/tests/test_fixtures_credential_guard.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import bcrypt
 import pytest
 import pytest_asyncio
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.fixtures.runner import _merge_fixture_user, _seed_auth_data
@@ -697,3 +697,47 @@ async def test_multiple_users_partial_guard(session_maker):
     assert bcrypt.checkpw(
         _FIXTURE_PASSWORD.encode("utf-8"), b.password_hash.encode("utf-8")
     ), "Fixture user B must be seeded with the fixture hash"
+
+
+@pytest.mark.asyncio
+async def test_mixed_case_real_identity_not_duplicated(session_maker):
+    """A real user with mixed-case email/username must be detected
+    case-insensitively (matching the auth layer's lower() semantics) so the
+    seeder does not insert a duplicate lowercase demo account for the same
+    identity (CHAOS-2458 review follow-up)."""
+    real_id = uuid.uuid4()  # distinct from the deterministic fixture uuid5
+    async with session_maker() as session:
+        real_user = User(
+            id=real_id,
+            email="Admin@DevHealth.example",
+            username="Admin",
+            password_hash=_REAL_HASH,
+            full_name="Real Admin",
+            auth_provider="local",
+            is_active=True,
+            is_verified=True,
+            is_superuser=True,
+        )
+        session.add(real_user)
+        await session.commit()
+
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    async with session_maker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(User).where(
+                        func.lower(User.email) == "admin@devhealth.example"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1, "Seeder must not duplicate a mixed-case real identity"
+        assert rows[0].id == real_id
+        assert rows[0].password_hash == _REAL_HASH
+        # The lowercase fixture UUID must NOT have been inserted as a new row.
+        assert await session.get(User, _fixture_user_id()) is None

--- a/tests/test_fixtures_credential_guard.py
+++ b/tests/test_fixtures_credential_guard.py
@@ -1,0 +1,488 @@
+"""Tests for CHAOS-2458: fixture seeder must not clobber real users' password_hash.
+
+Covers:
+1. Seeding into a DB with an existing NON-fixture user of the same id/email does
+   NOT change that user's password_hash.
+2. Seeding still correctly creates/refreshes genuine fixture users.
+3. overwrite_real_users=True bypasses the guard (explicit opt-in).
+4. _merge_fixture_user handles missing default_password gracefully (skips).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import bcrypt
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.fixtures.runner import _merge_fixture_user, _seed_auth_data
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.licensing import OrgLicense
+from dev_health_ops.models.users import Membership, Organization, User
+from tests._helpers import tables_of
+
+_NS = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+# Fixed fixture password used by the generator.
+_FIXTURE_PASSWORD = "devhealth123"
+_FIXTURE_HASH = bcrypt.hashpw(
+    _FIXTURE_PASSWORD.encode("utf-8"), bcrypt.gensalt()
+).decode("utf-8")
+
+# A completely different password representing a real user's credential.
+_REAL_PASSWORD = "s3cr3t-real-password-not-demo"
+_REAL_HASH = bcrypt.hashpw(_REAL_PASSWORD.encode("utf-8"), bcrypt.gensalt()).decode(
+    "utf-8"
+)
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "credential-guard.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(User, Organization, Membership, OrgLicense),
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+def _fixture_user_id() -> uuid.UUID:
+    """Deterministic UUID matching what the generator produces for admin@devhealth.example."""
+    return uuid.uuid5(_NS, "admin@devhealth.example")
+
+
+def _make_fixture_user(password_hash: str = _FIXTURE_HASH) -> User:
+    """Build a fixture User object as the seeder would."""
+    return User(
+        id=_fixture_user_id(),
+        email="admin@devhealth.example",
+        username="admin",
+        password_hash=password_hash,
+        full_name="Admin User",
+        auth_provider="local",
+        is_active=True,
+        is_verified=True,
+        is_superuser=True,
+    )
+
+
+def _make_org() -> Organization:
+    org_id = uuid.uuid5(_NS, "default-org")
+    return Organization(
+        id=org_id,
+        slug="default-org",
+        name="Demo Org",
+        tier="enterprise",
+        is_active=True,
+    )
+
+
+def _build_user_data(password_hash: str = _FIXTURE_HASH) -> dict:
+    """Build a minimal user_data dict matching the generator's output shape."""
+    org = _make_org()
+    user = _make_fixture_user(password_hash)
+    now = datetime.now(timezone.utc)
+    from dev_health_ops.licensing.types import LicenseTier
+
+    membership = Membership(
+        id=uuid.uuid5(user.id, str(org.id)),
+        user_id=user.id,
+        org_id=org.id,
+        role="owner",
+        joined_at=now,
+    )
+    license_row = OrgLicense(
+        org_id=org.id,
+        tier=LicenseTier.ENTERPRISE.value,
+        license_type="saas",
+        licensed_users=None,
+        licensed_repos=None,
+        issued_at=now,
+    )
+    license_row.id = uuid.uuid5(org.id, "org-license")
+    return {
+        "organizations": [org],
+        "users": [user],
+        "memberships": [membership],
+        "licenses": [license_row],
+        "default_password": _FIXTURE_PASSWORD,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core guard tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_real_user_password_not_overwritten(session_maker):
+    """Seeding must NOT overwrite password_hash of a pre-existing real user.
+
+    Scenario: a real user was registered with a strong password.  Their UUID
+    happens to collide with the fixture admin UUID (e.g. the DB was previously
+    seeded and the user kept that id).  Re-running the seeder must leave their
+    credential intact.
+    """
+    user_id = _fixture_user_id()
+
+    # Pre-populate DB with a "real" user at the fixture UUID but with a
+    # non-fixture password hash.
+    async with session_maker() as session:
+        real_user = User(
+            id=user_id,
+            email="admin@devhealth.example",
+            username="admin",
+            password_hash=_REAL_HASH,
+            full_name="Real Admin",
+            auth_provider="local",
+            is_active=True,
+            is_verified=True,
+            is_superuser=True,
+        )
+        session.add(real_user)
+        await session.commit()
+
+    # Run the fixture seeder (default: overwrite_real_users=False).
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    # The password_hash must be unchanged.
+    async with session_maker() as session:
+        user = await session.get(User, user_id)
+        assert user is not None
+        assert user.password_hash == _REAL_HASH, (
+            "Fixture seeder must not overwrite a real user's password_hash"
+        )
+        # Verify the real hash still works for the real password.
+        assert bcrypt.checkpw(
+            _REAL_PASSWORD.encode("utf-8"), user.password_hash.encode("utf-8")
+        )
+        # And does NOT work for the fixture password.
+        assert not bcrypt.checkpw(
+            _FIXTURE_PASSWORD.encode("utf-8"), user.password_hash.encode("utf-8")
+        )
+
+
+@pytest.mark.asyncio
+async def test_fixture_user_created_when_absent(session_maker):
+    """Seeding into an empty DB must create the fixture user correctly."""
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    async with session_maker() as session:
+        user = await session.get(User, _fixture_user_id())
+        assert user is not None
+        assert user.email == "admin@devhealth.example"
+        # The stored hash must verify against the fixture password.
+        assert bcrypt.checkpw(
+            _FIXTURE_PASSWORD.encode("utf-8"), user.password_hash.encode("utf-8")
+        )
+
+
+@pytest.mark.asyncio
+async def test_fixture_user_refreshed_on_reseed(session_maker):
+    """Re-seeding a genuine fixture user (same fixture hash) must succeed.
+
+    This covers the idempotent re-seed path: the existing row has the fixture
+    hash, so the guard recognises it as fixture-owned and allows the merge.
+    """
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    # Mutate a non-credential field to verify the merge actually ran.
+    async with session_maker() as session:
+        user = await session.get(User, _fixture_user_id())
+        user.full_name = "Mutated Name"
+        await session.commit()
+
+    # Re-seed — should restore full_name and keep the fixture hash.
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    async with session_maker() as session:
+        user = await session.get(User, _fixture_user_id())
+        assert user is not None
+        assert user.full_name == "Admin User"
+        assert bcrypt.checkpw(
+            _FIXTURE_PASSWORD.encode("utf-8"), user.password_hash.encode("utf-8")
+        )
+
+
+@pytest.mark.asyncio
+async def test_overwrite_real_users_opt_in_clobbers_hash(session_maker):
+    """overwrite_real_users=True must bypass the guard (explicit opt-in path)."""
+    user_id = _fixture_user_id()
+
+    async with session_maker() as session:
+        real_user = User(
+            id=user_id,
+            email="admin@devhealth.example",
+            username="admin",
+            password_hash=_REAL_HASH,
+            full_name="Real Admin",
+            auth_provider="local",
+            is_active=True,
+            is_verified=True,
+            is_superuser=True,
+        )
+        session.add(real_user)
+        await session.commit()
+
+    # Explicit opt-in: caller accepts credential clobber.
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data(), overwrite_real_users=True)
+
+    async with session_maker() as session:
+        user = await session.get(User, user_id)
+        assert user is not None
+        # Hash must now be the fixture hash (clobbered).
+        assert bcrypt.checkpw(
+            _FIXTURE_PASSWORD.encode("utf-8"), user.password_hash.encode("utf-8")
+        )
+
+
+# ---------------------------------------------------------------------------
+# _merge_fixture_user unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_fixture_user_inserts_when_absent(session_maker):
+    """_merge_fixture_user inserts a new row when no collision exists."""
+    user = _make_fixture_user()
+    async with session_maker() as session:
+        # Ensure org exists so FK is satisfied (if enforced).
+        org = _make_org()
+        await session.merge(org)
+        await session.commit()
+
+        await _merge_fixture_user(
+            session,
+            user,
+            default_password=_FIXTURE_PASSWORD,
+            overwrite_real_users=False,
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        result = await session.get(User, user.id)
+        assert result is not None
+        assert result.email == "admin@devhealth.example"
+
+
+@pytest.mark.asyncio
+async def test_merge_fixture_user_skips_real_user(session_maker):
+    """_merge_fixture_user must not touch a row whose hash is not the fixture hash."""
+    user_id = _fixture_user_id()
+
+    async with session_maker() as session:
+        real_user = User(
+            id=user_id,
+            email="admin@devhealth.example",
+            username="admin",
+            password_hash=_REAL_HASH,
+            full_name="Real Admin",
+            auth_provider="local",
+            is_active=True,
+            is_verified=True,
+            is_superuser=True,
+        )
+        session.add(real_user)
+        await session.commit()
+
+    fixture_user = _make_fixture_user()  # has _FIXTURE_HASH
+    async with session_maker() as session:
+        await _merge_fixture_user(
+            session,
+            fixture_user,
+            default_password=_FIXTURE_PASSWORD,
+            overwrite_real_users=False,
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        user = await session.get(User, user_id)
+        assert user.password_hash == _REAL_HASH
+
+
+@pytest.mark.asyncio
+async def test_merge_fixture_user_no_default_password_skips_existing(session_maker):
+    """When default_password is None, existing rows must not be overwritten."""
+    user_id = _fixture_user_id()
+
+    async with session_maker() as session:
+        real_user = User(
+            id=user_id,
+            email="admin@devhealth.example",
+            username="admin",
+            password_hash=_REAL_HASH,
+            full_name="Real Admin",
+            auth_provider="local",
+            is_active=True,
+            is_verified=True,
+            is_superuser=True,
+        )
+        session.add(real_user)
+        await session.commit()
+
+    fixture_user = _make_fixture_user()
+    async with session_maker() as session:
+        await _merge_fixture_user(
+            session,
+            fixture_user,
+            default_password=None,  # no password provided
+            overwrite_real_users=False,
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        user = await session.get(User, user_id)
+        assert user.password_hash == _REAL_HASH
+
+
+@pytest.mark.asyncio
+async def test_seed_auth_data_default_is_safe(session_maker):
+    """Calling _seed_auth_data without keyword args must use the safe default."""
+    import inspect
+
+    sig = inspect.signature(_seed_auth_data)
+    param = sig.parameters.get("overwrite_real_users")
+    assert param is not None, "_seed_auth_data must have overwrite_real_users param"
+    assert param.default is False, (
+        "overwrite_real_users must default to False (safe default)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_guard_emits_warning_for_real_user(session_maker, caplog):
+    """The guard must log a warning when it skips a real user."""
+    import logging
+
+    user_id = _fixture_user_id()
+
+    async with session_maker() as session:
+        real_user = User(
+            id=user_id,
+            email="admin@devhealth.example",
+            username="admin",
+            password_hash=_REAL_HASH,
+            full_name="Real Admin",
+            auth_provider="local",
+            is_active=True,
+            is_verified=True,
+            is_superuser=True,
+        )
+        session.add(real_user)
+        await session.commit()
+
+    with caplog.at_level(logging.WARNING, logger="dev_health_ops.fixtures.runner"):
+        async with session_maker() as session:
+            await _seed_auth_data(session, _build_user_data())
+
+    assert any("FIXTURES-GUARD" in record.message for record in caplog.records), (
+        f"Expected FIXTURES-GUARD warning; got: {[r.message for r in caplog.records]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_multiple_users_partial_guard(session_maker):
+    """When user_data has multiple users, guard applies per-user independently.
+
+    - user A: real user (different hash) → must be skipped
+    - user B: absent → must be inserted
+    """
+    from dev_health_ops.licensing.types import LicenseTier
+
+    ns = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+    org = _make_org()
+    now = datetime.now(timezone.utc)
+
+    user_a_id = uuid.uuid5(ns, "alice@example.com")
+    user_b_id = uuid.uuid5(ns, "bob@example.com")
+
+    # Pre-seed user A with a real (non-fixture) hash.
+    async with session_maker() as session:
+        await session.merge(org)
+        real_a = User(
+            id=user_a_id,
+            email="alice@example.com",
+            username="alice",
+            password_hash=_REAL_HASH,
+            full_name="Real Alice",
+            auth_provider="local",
+            is_active=True,
+            is_verified=True,
+            is_superuser=False,
+        )
+        session.add(real_a)
+        await session.commit()
+
+    fixture_a = User(
+        id=user_a_id,
+        email="alice@example.com",
+        username="alice",
+        password_hash=_FIXTURE_HASH,
+        full_name="Fixture Alice",
+        auth_provider="local",
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
+    fixture_b = User(
+        id=user_b_id,
+        email="bob@example.com",
+        username="bob",
+        password_hash=_FIXTURE_HASH,
+        full_name="Fixture Bob",
+        auth_provider="local",
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+    )
+
+    license_row = OrgLicense(
+        org_id=org.id,
+        tier=LicenseTier.ENTERPRISE.value,
+        license_type="saas",
+        licensed_users=None,
+        licensed_repos=None,
+        issued_at=now,
+    )
+    license_row.id = uuid.uuid5(org.id, "org-license")
+
+    user_data = {
+        "organizations": [org],
+        "users": [fixture_a, fixture_b],
+        "memberships": [],
+        "licenses": [license_row],
+        "default_password": _FIXTURE_PASSWORD,
+    }
+
+    async with session_maker() as session:
+        await _seed_auth_data(session, user_data)
+
+    async with session_maker() as session:
+        a = await session.get(User, user_a_id)
+        b = await session.get(User, user_b_id)
+
+    # User A: real hash must be preserved.
+    assert a is not None
+    assert a.password_hash == _REAL_HASH, "Real user A's hash must not be overwritten"
+
+    # User B: fixture user must be created.
+    assert b is not None
+    assert bcrypt.checkpw(
+        _FIXTURE_PASSWORD.encode("utf-8"), b.password_hash.encode("utf-8")
+    ), "Fixture user B must be seeded with the fixture hash"

--- a/tests/test_fixtures_credential_guard.py
+++ b/tests/test_fixtures_credential_guard.py
@@ -611,8 +611,10 @@ async def test_guard_emits_warning_for_real_user(session_maker, caplog):
 async def test_multiple_users_partial_guard(session_maker):
     """When user_data has multiple users, guard applies per-user independently.
 
-    - user A: real user (different hash) → must be skipped
-    - user B: absent → must be inserted
+    The fixture org is fresh (safe-inserted this run) and both users are members
+    of it, so the org-safety gate is satisfied and per-user guarding decides:
+    - user A: real user (different hash) already exists -> identity match -> skipped
+    - user B: absent -> inserted
     """
     from dev_health_ops.licensing.types import LicenseTier
 
@@ -625,7 +627,8 @@ async def test_multiple_users_partial_guard(session_maker):
 
     # Pre-seed user A with a real (non-fixture) hash.
     async with session_maker() as session:
-        await session.merge(org)
+        # NB: do not pre-seed the org -- it must be freshly inserted (safe) so
+        # the org-safety gate permits inserting new fixture user B.
         real_a = User(
             id=user_a_id,
             email="alice@example.com",
@@ -673,10 +676,25 @@ async def test_multiple_users_partial_guard(session_maker):
     )
     license_row.id = uuid.uuid5(org.id, "org-license")
 
+    membership_a = Membership(
+        id=uuid.uuid5(user_a_id, str(org.id)),
+        user_id=user_a_id,
+        org_id=org.id,
+        role="owner",
+        joined_at=now,
+    )
+    membership_b = Membership(
+        id=uuid.uuid5(user_b_id, str(org.id)),
+        user_id=user_b_id,
+        org_id=org.id,
+        role="member",
+        joined_at=now,
+    )
+
     user_data = {
         "organizations": [org],
         "users": [fixture_a, fixture_b],
-        "memberships": [],
+        "memberships": [membership_a, membership_b],
         "licenses": [license_row],
         "default_password": _FIXTURE_PASSWORD,
     }
@@ -783,3 +801,46 @@ async def test_mixed_case_real_org_slug_not_duplicated(session_maker):
         # No fixture license rows should exist for the duplicate tenant.
         licenses = (await session.execute(select(OrgLicense))).scalars().all()
         assert all(lic.org_id == real_org_id for lic in licenses) or not licenses
+
+
+@pytest.mark.asyncio
+async def test_existing_org_blocks_fixture_superuser_injection(session_maker):
+    """If a real org pre-exists (matched by slug) but the fixture admin identity
+    does NOT collide, the seeder must NOT inject the known-password fixture
+    superuser next to the real tenant (CHAOS-2458 review follow-up)."""
+    real_org_id = uuid.uuid4()
+    async with session_maker() as session:
+        real_org = Organization(
+            id=real_org_id,
+            slug="default-org",  # same slug as fixture, different id
+            name="Real Tenant",
+            tier="enterprise",
+            is_active=True,
+        )
+        session.add(real_org)
+        await session.commit()
+
+    async with session_maker() as session:
+        await _seed_auth_data(session, _build_user_data())
+
+    async with session_maker() as session:
+        # The fixture superuser must NOT have been inserted.
+        assert await session.get(User, _fixture_user_id()) is None, (
+            "Fixture superuser must not be injected next to an existing tenant"
+        )
+        users = (
+            (
+                await session.execute(
+                    select(User).where(
+                        func.lower(User.email) == "admin@devhealth.example"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert users == []
+        # No fixture org/membership created for the real tenant.
+        assert await session.get(Organization, _make_org().id) is None
+        memberships = (await session.execute(select(Membership))).scalars().all()
+        assert memberships == []

--- a/tests/test_fixtures_credential_guard.py
+++ b/tests/test_fixtures_credential_guard.py
@@ -609,12 +609,12 @@ async def test_guard_emits_warning_for_real_user(session_maker, caplog):
 
 @pytest.mark.asyncio
 async def test_multiple_users_partial_guard(session_maker):
-    """When user_data has multiple users, guard applies per-user independently.
+    """Default-path auth seeding is all-or-nothing on a populated DB.
 
-    The fixture org is fresh (safe-inserted this run) and both users are members
-    of it, so the org-safety gate is satisfied and per-user guarding decides:
-    - user A: real user (different hash) already exists -> identity match -> skipped
-    - user B: absent -> inserted
+    With a pre-existing real user the empty-graph guard skips the ENTIRE auth
+    seeding pass (no new fixture users/orgs/memberships), leaving the real user
+    untouched. overwrite_real_users=True is the explicit opt-in to seed/refresh
+    into a populated database.
     """
     from dev_health_ops.licensing.types import LicenseTier
 
@@ -627,8 +627,6 @@ async def test_multiple_users_partial_guard(session_maker):
 
     # Pre-seed user A with a real (non-fixture) hash.
     async with session_maker() as session:
-        # NB: do not pre-seed the org -- it must be freshly inserted (safe) so
-        # the org-safety gate permits inserting new fixture user B.
         real_a = User(
             id=user_a_id,
             email="alice@example.com",
@@ -699,6 +697,8 @@ async def test_multiple_users_partial_guard(session_maker):
         "default_password": _FIXTURE_PASSWORD,
     }
 
+    # Default path: a pre-existing real user makes the auth graph non-empty, so
+    # the seeder writes NOTHING -- real user A untouched, fixture user B absent.
     async with session_maker() as session:
         await _seed_auth_data(session, user_data)
 
@@ -706,15 +706,22 @@ async def test_multiple_users_partial_guard(session_maker):
         a = await session.get(User, user_a_id)
         b = await session.get(User, user_b_id)
 
-    # User A: real hash must be preserved.
     assert a is not None
     assert a.password_hash == _REAL_HASH, "Real user A's hash must not be overwritten"
+    assert b is None, (
+        "Default path must not seed fixture users into a non-empty auth DB"
+    )
 
-    # User B: fixture user must be created.
+    # Explicit opt-in: overwrite_real_users=True seeds into the populated DB.
+    async with session_maker() as session:
+        await _seed_auth_data(session, user_data, overwrite_real_users=True)
+
+    async with session_maker() as session:
+        b = await session.get(User, user_b_id)
     assert b is not None
     assert bcrypt.checkpw(
         _FIXTURE_PASSWORD.encode("utf-8"), b.password_hash.encode("utf-8")
-    ), "Fixture user B must be seeded with the fixture hash"
+    ), "Fixture user B must be seeded with the fixture hash under opt-in"
 
 
 @pytest.mark.asyncio

--- a/tests/test_fixtures_seed_auth_idempotent.py
+++ b/tests/test_fixtures_seed_auth_idempotent.py
@@ -46,22 +46,11 @@ async def session_maker(tmp_path: Path):
         await engine.dispose()
 
 
-_IDEMPOTENT_TEST_PASSWORD = "devhealth-idempotent-test"
-_IDEMPOTENT_TEST_HASH = (
-    __import__("bcrypt")
-    .hashpw(_IDEMPOTENT_TEST_PASSWORD.encode("utf-8"), __import__("bcrypt").gensalt())
-    .decode("utf-8")
-)
-
-
 def _build_user_data() -> dict:
     """Build the same user_data shape the fixtures generator produces.
 
     Two users (admin + alice) bound to one org, one license. Deterministic
     UUIDs so a second invocation lands on identical PKs.
-
-    Uses a real bcrypt hash + default_password so the CHAOS-2458 credential
-    guard recognises these rows as fixture-owned on re-seed.
     """
     target_org_id = uuid.UUID("ae600a94-76bc-4166-bf36-051ee4247c73")
 
@@ -69,7 +58,7 @@ def _build_user_data() -> dict:
         id=uuid.uuid5(_NS, "admin@devhealth.example"),
         email="admin@devhealth.example",
         username="admin",
-        password_hash=_IDEMPOTENT_TEST_HASH,
+        password_hash="$2b$12$dummy",
         full_name="Admin",
         auth_provider="local",
         is_active=True,
@@ -80,7 +69,7 @@ def _build_user_data() -> dict:
         id=uuid.uuid5(_NS, "alice@example.com"),
         email="alice@example.com",
         username="alice",
-        password_hash=_IDEMPOTENT_TEST_HASH,
+        password_hash="$2b$12$dummy",
         full_name="Alice",
         auth_provider="local",
         is_active=True,
@@ -123,7 +112,6 @@ def _build_user_data() -> dict:
         "users": [admin, alice],
         "memberships": [admin_membership, alice_membership],
         "licenses": [license_row],
-        "default_password": _IDEMPOTENT_TEST_PASSWORD,
     }
 
 

--- a/tests/test_fixtures_seed_auth_idempotent.py
+++ b/tests/test_fixtures_seed_auth_idempotent.py
@@ -46,11 +46,22 @@ async def session_maker(tmp_path: Path):
         await engine.dispose()
 
 
+_IDEMPOTENT_TEST_PASSWORD = "devhealth-idempotent-test"
+_IDEMPOTENT_TEST_HASH = (
+    __import__("bcrypt")
+    .hashpw(_IDEMPOTENT_TEST_PASSWORD.encode("utf-8"), __import__("bcrypt").gensalt())
+    .decode("utf-8")
+)
+
+
 def _build_user_data() -> dict:
     """Build the same user_data shape the fixtures generator produces.
 
     Two users (admin + alice) bound to one org, one license. Deterministic
     UUIDs so a second invocation lands on identical PKs.
+
+    Uses a real bcrypt hash + default_password so the CHAOS-2458 credential
+    guard recognises these rows as fixture-owned on re-seed.
     """
     target_org_id = uuid.UUID("ae600a94-76bc-4166-bf36-051ee4247c73")
 
@@ -58,7 +69,7 @@ def _build_user_data() -> dict:
         id=uuid.uuid5(_NS, "admin@devhealth.example"),
         email="admin@devhealth.example",
         username="admin",
-        password_hash="$2b$12$dummy",
+        password_hash=_IDEMPOTENT_TEST_HASH,
         full_name="Admin",
         auth_provider="local",
         is_active=True,
@@ -69,7 +80,7 @@ def _build_user_data() -> dict:
         id=uuid.uuid5(_NS, "alice@example.com"),
         email="alice@example.com",
         username="alice",
-        password_hash="$2b$12$dummy",
+        password_hash=_IDEMPOTENT_TEST_HASH,
         full_name="Alice",
         auth_provider="local",
         is_active=True,
@@ -112,6 +123,7 @@ def _build_user_data() -> dict:
         "users": [admin, alice],
         "memberships": [admin_membership, alice_membership],
         "licenses": [license_row],
+        "default_password": _IDEMPOTENT_TEST_PASSWORD,
     }
 
 


### PR DESCRIPTION
Part of **CHAOS-2458** (auth incident remediation). One of three workstreams.

## Problem
Fixture auth seeding called `session.merge(user)` keyed on the PK UUID, which could silently overwrite a real user's `password_hash` with the fixed demo bcrypt hash on a shared/prod DB (data destruction + potential credential compromise — the highest-severity item in the incident).

## Change
Default path (`overwrite_real_users=False`) is now **non-destructive** and **all-or-nothing**:
- **Primary guard:** `_seed_auth_data` refuses to seed if the auth DB already contains **any** organization or user — it writes nothing. This closes every injection/overwrite/duplicate path at once (including the known-password `admin@devhealth.example` superuser).
- **Defense-in-depth:** per-entity insert-if-absent for users + orgs + memberships + licenses; ownership decided by **existence** (not bcrypt password-equality); identity matched **case-insensitively** (`func.lower(email/username/slug)`) to mirror the auth layer.
- `overwrite_real_users=True` is the explicit opt-in to seed/refresh a populated DB (fully-isolated demo/CI only).

## Adversarial review
Reviewed iteratively via `/codex:adversarial-review --model gpt-5.5` (6 rounds). Each pass hardened a real gap: column-only guard → auth-graph; bcrypt-equality ownership → existence; exact-case → case-insensitive (user + org); per-entity → empty-graph all-or-nothing.

## Documented residuals (accepted follow-ups, tracked separately)
- **TOCTOU:** the empty-graph guard is a best-effort non-atomic check; a concurrent first-ever registration racing the seed pass isn't covered. Atomic advisory-lock + single-transaction hardening is a follow-up. (The seeder is an operator/CI tool and must not run against live prod.)
- **Partial-commit recovery:** a crash between the user/org commit and membership/license writes isn't auto-repaired on the default path.

## Verification
- ruff + lsp clean; fixtures suites: **47 passed** (incl. new regressions for mixed-case user/org identity, superuser-injection block, and opt-in seeding).

Relates to CHAOS-2458