### PR TITLE
fix(workers): thread explicit GitLab work-items credentials, drop env injection (CHAOS-2461)

### DIFF
--- a/src/dev_health_ops/backfill/runner.py
+++ b/src/dev_health_ops/backfill/runner.py
@@ -24,6 +24,7 @@ def run_backfill_for_config(
     sink: str = "clickhouse",
     chunk_days: int = 7,
     progress_cb: ProgressCallback | None = None,
+    credentials: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     config_uuid = uuid.UUID(sync_config_id)
     with get_postgres_session_sync() as session:
@@ -67,6 +68,7 @@ def run_backfill_for_config(
             repo_name=sync_options.get("repo"),
             search_pattern=sync_options.get("search"),
             org_id=org_id,
+            credentials=credentials,
         )
 
     return {

--- a/src/dev_health_ops/metrics/dependencies.py
+++ b/src/dev_health_ops/metrics/dependencies.py
@@ -139,7 +139,9 @@ class GitLabClientProtocol(Protocol):
 
 
 class GitLabClientFactory(Protocol):
-    def __call__(self) -> GitLabClientProtocol: ...
+    def __call__(
+        self, *, token: str, gitlab_url: str | None = None
+    ) -> GitLabClientProtocol: ...
 
 
 @dataclass(frozen=True)
@@ -240,8 +242,15 @@ def _default_make_github_client(*, token: str) -> GitHubClientProtocol:
     )
 
 
-def _default_make_gitlab_client() -> GitLabClientProtocol:
-    return gitlab_client_module.GitLabWorkClient.from_env()
+def _default_make_gitlab_client(
+    *, token: str, gitlab_url: str | None = None
+) -> GitLabClientProtocol:
+    return gitlab_client_module.GitLabWorkClient(
+        auth=gitlab_client_module.GitLabAuth(
+            token=token,
+            base_url=gitlab_url or "https://gitlab.com",
+        )
+    )
 
 
 _registry = MetricsDependencyRegistry(

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -103,6 +103,46 @@ def _build_github_work_client(
     return GitHubWorkClient(auth=GitHubAuth.from_credentials(resolved_credentials))
 
 
+def _build_gitlab_work_client(
+    *, org_id: str, credentials: dict[str, Any] | None = None
+) -> tuple[str, str | None]:
+    """Resolve GitLab credentials and return (token, gitlab_url) for explicit threading.
+
+    Precedence: explicit ``credentials`` mapping → database credential scoped
+    to ``org_id`` → environment variables as a last resort. An org-scoped
+    caller must never silently pick up ambient ``GITLAB_TOKEN``/URL env vars
+    over its org's database credential (tenant boundary, CHAOS-2461); env
+    resolution applies only when no organization scope is available (a
+    pure-CLI run) or when org-scoped resolution finds no database row
+    (DB-less dev setups, via ``CredentialResolver``'s env fallback).
+    """
+    from dev_health_ops.credentials.resolver import (
+        gitlab_credentials_from_mapping,
+        resolve_credentials_sync,
+    )
+    from dev_health_ops.credentials.types import GitLabCredentials
+
+    if credentials:
+        gitlab_credentials = gitlab_credentials_from_mapping(credentials)
+        if gitlab_credentials is None:
+            raise ValueError("Missing GitLab token for work-items sync configuration")
+        return gitlab_credentials.token, gitlab_credentials.base_url or None
+
+    if not org_id:
+        import os
+
+        token = os.environ.get("GITLAB_TOKEN", "")
+        gitlab_url = os.environ.get("GITLAB_URL") or None
+        return token, gitlab_url
+
+    resolved_credentials = resolve_credentials_sync(
+        "gitlab", org_id=org_id, allow_env_fallback=True
+    )
+    if not isinstance(resolved_credentials, GitLabCredentials):
+        raise ValueError("Resolved credentials are not GitLab credentials")
+    return resolved_credentials.token, resolved_credentials.base_url or None
+
+
 def run_work_items_sync_job(
     *,
     db_url: str,
@@ -294,11 +334,16 @@ def run_work_items_sync_job(
                 transitions.extend(list(proj_tr or []))
 
         if "gitlab" in provider_set:
+            gl_token, gl_url = _build_gitlab_work_client(
+                org_id=org_id, credentials=credentials
+            )
             items, tr, gl_ai_attributions = fetch_gitlab_work_items(
                 repos=discovered_repos,
                 since=since_dt,
                 status_mapping=status_mapping,
                 identity=identity,
+                token=gl_token,
+                gitlab_url=gl_url,
                 include_label_events=True,
                 org_id=org_id,
             )

--- a/src/dev_health_ops/metrics/work_items.py
+++ b/src/dev_health_ops/metrics/work_items.py
@@ -429,6 +429,8 @@ def fetch_gitlab_work_items(
     since: datetime,
     status_mapping: StatusMapping,
     identity: IdentityResolver,
+    token: str,
+    gitlab_url: str | None = None,
     include_label_events: bool = True,
     max_label_events: int = 300,
     org_id: str = "",
@@ -452,7 +454,8 @@ def fetch_gitlab_work_items(
     skipped entirely when ``org_id`` is blank (a CLI-only run with no tenant
     scope) so a blank-tenant row is never persisted.
 
-    Requires `GITLAB_TOKEN` and optional `GITLAB_URL`.
+    Credentials (``token`` and optional ``gitlab_url``) are threaded explicitly
+    by the caller; this function never reads from ``os.environ``.
     """
     from uuid import UUID
 
@@ -461,7 +464,7 @@ def fetch_gitlab_work_items(
 
     deps = get_metrics_dependencies()
 
-    client = deps.gitlab_client_factory()
+    client = deps.gitlab_client_factory(token=token, gitlab_url=gitlab_url)
     work_items: dict[str, WorkItem] = {}
     transitions: list[WorkItemStatusTransition] = []
     ai_attributions: list[AIAttributionRecord] = []

--- a/src/dev_health_ops/workers/sync_backfill.py
+++ b/src/dev_health_ops/workers/sync_backfill.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import date, datetime, timezone
+from typing import Any
 
 from dev_health_ops.workers.celery_app import celery_app
-from dev_health_ops.workers.task_utils import _get_db_url
+from dev_health_ops.workers.task_utils import _credential_mapping, _get_db_url
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ def run_backfill(
 ) -> dict:
     from dev_health_ops.backfill.runner import run_backfill_for_config
     from dev_health_ops.db import get_postgres_session_sync
-    from dev_health_ops.models.settings import SyncConfiguration
+    from dev_health_ops.models.settings import IntegrationCredential, SyncConfiguration
 
     sync_config_uuid = uuid.UUID(sync_config_id)
     started_at = datetime.now(timezone.utc)
@@ -43,6 +44,22 @@ def run_backfill(
             )
             if config is None:
                 raise ValueError(f"Sync configuration not found: {sync_config_id}")
+
+            credentials: dict[str, Any] | None = None
+            if config.credential_id:
+                credential = (
+                    session.query(IntegrationCredential)
+                    .filter(
+                        IntegrationCredential.id == config.credential_id,
+                        IntegrationCredential.org_id == org_id,
+                    )
+                    .one_or_none()
+                )
+                if credential is None:
+                    raise ValueError(
+                        f"Credential not found for sync configuration: {config.credential_id}"
+                    )
+                credentials = _credential_mapping(credential)
 
         if backfill_job_id:
             with get_postgres_session_sync() as session:
@@ -95,6 +112,7 @@ def run_backfill(
             sink="clickhouse",
             chunk_days=7,
             progress_cb=_backfill_progress,
+            credentials=credentials,
         )
 
         completed_at = datetime.now(timezone.utc)

--- a/src/dev_health_ops/workers/sync_backfill.py
+++ b/src/dev_health_ops/workers/sync_backfill.py
@@ -5,14 +5,7 @@ import uuid
 from datetime import date, datetime, timezone
 
 from dev_health_ops.workers.celery_app import celery_app
-from dev_health_ops.workers.task_utils import (
-    _as_str,
-    _credential_mapping,
-    _extract_provider_token,
-    _get_db_url,
-    _inject_provider_token,
-    _resolve_env_credentials,
-)
+from dev_health_ops.workers.task_utils import _get_db_url
 
 logger = logging.getLogger(__name__)
 
@@ -33,10 +26,7 @@ def run_backfill(
 ) -> dict:
     from dev_health_ops.backfill.runner import run_backfill_for_config
     from dev_health_ops.db import get_postgres_session_sync
-    from dev_health_ops.models.settings import (
-        IntegrationCredential,
-        SyncConfiguration,
-    )
+    from dev_health_ops.models.settings import SyncConfiguration
 
     sync_config_uuid = uuid.UUID(sync_config_id)
     started_at = datetime.now(timezone.utc)
@@ -53,30 +43,6 @@ def run_backfill(
             )
             if config is None:
                 raise ValueError(f"Sync configuration not found: {sync_config_id}")
-
-            provider = _as_str(config.provider).lower()
-            if config.credential_id:
-                credential = (
-                    session.query(IntegrationCredential)
-                    .filter(
-                        IntegrationCredential.id == config.credential_id,
-                        IntegrationCredential.org_id == org_id,
-                    )
-                    .one_or_none()
-                )
-                if credential is None:
-                    raise ValueError(
-                        f"Credential not found for sync configuration: {config.credential_id}"
-                    )
-                # Merge non-sensitive credential.config (e.g. self-hosted
-                # GitLab url) under the decrypted secrets (CHAOS-2282).
-                credentials = _credential_mapping(credential)
-            else:
-                credentials = _resolve_env_credentials(provider)
-
-            token = _extract_provider_token(provider, credentials)
-            if token:
-                _inject_provider_token(provider, token)
 
         if backfill_job_id:
             with get_postgres_session_sync() as session:

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -25,9 +25,7 @@ from dev_health_ops.workers.sync_runtime import (
 )
 from dev_health_ops.workers.task_utils import (
     _credential_mapping,
-    _extract_provider_token,
     _get_db_url,
-    _inject_provider_token,
     _merge_sync_flags,
     _normalize_sync_targets,
     _resolve_env_credentials,
@@ -705,18 +703,6 @@ def _run_sync_for_repo(
             )
 
         if "work-items" in sync_targets:
-            token = _extract_provider_token(provider, credentials)
-            if token:
-                _inject_provider_token(provider, token)
-            if provider == "gitlab":
-                # fetch_gitlab_work_items builds GitLabWorkClient.from_env(),
-                # which reads GITLAB_URL — inject the resolved instance URL so
-                # self-hosted work-items don't fall back to gitlab.com while
-                # code sync above talks to the right host.
-                os.environ["GITLAB_URL"] = resolve_gitlab_url(
-                    sync_options_override,
-                    gitlab_credentials_from_mapping(credentials),
-                )
             backfill_days = int(sync_options_override.get("backfill_days", 1))
             chunk_index = int(sync_options_override.get("chunk_index", 0))
             chunk_since = sync_options_override.get("since")

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -718,6 +718,16 @@ def _run_sync_for_repo(
                 },
             )
             started_backfill = datetime.now(timezone.utc)
+            work_items_credentials: dict[str, Any] | None = credentials or None
+            if provider == "gitlab" and work_items_credentials:
+                gl_creds = gitlab_credentials_from_mapping(work_items_credentials)
+                if gl_creds is not None:
+                    work_items_credentials = {
+                        **work_items_credentials,
+                        "gitlab_url": resolve_gitlab_url(
+                            sync_options_override, gl_creds
+                        ),
+                    }
             # Pass the decrypted credentials explicitly: the env-injection above
             # is invisible to resolve_credentials_sync once DATABASE_URI is set,
             # so relying on it sends the job down a dead from_env() path
@@ -730,7 +740,7 @@ def _run_sync_for_repo(
                 repo_name=sync_options_override.get("repo"),
                 search_pattern=sync_options_override.get("search"),
                 org_id=org_id,
-                credentials=credentials or None,
+                credentials=work_items_credentials,
             )
             duration_ms = int(
                 (datetime.now(timezone.utc) - started_backfill).total_seconds() * 1000

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -30,9 +30,7 @@ from dev_health_ops.workers.task_utils import (
     _as_uuid,
     _credential_mapping,
     _extract_owner_repo,
-    _extract_provider_token,
     _get_db_url,
-    _inject_provider_token,
     _merge_sync_flags,
     _normalize_sync_targets,
     _resolve_env_credentials,
@@ -759,10 +757,6 @@ def run_sync_config(
             )
 
         if "work-items" in sync_targets and provider != "jira":
-            if provider != "github":
-                token = _extract_provider_token(provider, credentials)
-                if token:
-                    _inject_provider_token(provider, token)
             backfill_days = int(sync_options.get("backfill_days", 1))
             run_work_items_sync_job(
                 db_url=db_url,
@@ -772,7 +766,7 @@ def run_sync_config(
                 repo_name=sync_options.get("repo"),
                 search_pattern=sync_options.get("search"),
                 org_id=org_id,
-                credentials=credentials if provider == "github" else None,
+                credentials=credentials,
             )
             result_payload["work_items_synced"] = True
 

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -758,6 +758,14 @@ def run_sync_config(
 
         if "work-items" in sync_targets and provider != "jira":
             backfill_days = int(sync_options.get("backfill_days", 1))
+            work_items_credentials: dict[str, Any] | None = credentials or None
+            if provider == "gitlab" and work_items_credentials:
+                gl_creds = gitlab_credentials_from_mapping(work_items_credentials)
+                if gl_creds is not None:
+                    work_items_credentials = {
+                        **work_items_credentials,
+                        "gitlab_url": resolve_gitlab_url(sync_options, gl_creds),
+                    }
             run_work_items_sync_job(
                 db_url=db_url,
                 day=utc_today(),
@@ -766,7 +774,7 @@ def run_sync_config(
                 repo_name=sync_options.get("repo"),
                 search_pattern=sync_options.get("search"),
                 org_id=org_id,
-                credentials=credentials,
+                credentials=work_items_credentials,
             )
             result_payload["work_items_synced"] = True
 

--- a/tests/providers/test_gitlab_ai_attribution.py
+++ b/tests/providers/test_gitlab_ai_attribution.py
@@ -343,7 +343,9 @@ def _patch_common(
     # Inject the fake GitLab client at the metrics-dependency seam that
     # fetch_gitlab_work_items resolves via get_metrics_dependencies().
     base = work_items_module.get_metrics_dependencies()
-    overridden = dataclasses.replace(base, gitlab_client_factory=lambda: fake_client)
+    overridden = dataclasses.replace(
+        base, gitlab_client_factory=lambda *, token, gitlab_url=None: fake_client
+    )
     monkeypatch.setattr(
         work_items_module,
         "get_metrics_dependencies",
@@ -378,6 +380,7 @@ def test_gitlab_work_items_sync_writes_ai_attribution_with_org_id(
         backfill_days=1,
         provider="gitlab",
         org_id=str(org_id),
+        credentials={"token": "test-gitlab-token"},
     )
 
     # MR-derived attribution records reached the sink, org-scoped to the real org.

--- a/tests/test_backfill_integration.py
+++ b/tests/test_backfill_integration.py
@@ -542,7 +542,10 @@ def test_run_backfill_resolves_credentials_from_db(
 
     assert result["status"] == "success"
     assert captured["sync_config_id"] == str(sync_config_id)
-    assert os.environ.get("LINEAR_API_KEY") == "lin_test_cred_from_db"
+    # Credential resolved from DB is threaded EXPLICITLY into the backfill
+    # runner (CHAOS-2461) — never injected into os.environ.
+    assert captured["credentials"] == {"api_key": "lin_test_cred_from_db"}
+    assert os.environ.get("LINEAR_API_KEY") is None
 
     engine.dispose()
 

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -2793,9 +2793,9 @@ class TestRunSyncConfigGitLabCredentialConfig:
 class TestGitLabWorkItemsUrlInjection:
     """Self-hosted GitLab work-items must reach the configured instance.
 
-    fetch_gitlab_work_items builds GitLabWorkClient.from_env() (GITLAB_URL), so
-    _run_sync_for_repo injects the resolved URL before the work-items chunk
-    (post-rebase Codex finding on CHAOS-2282).
+    Credentials (token + gitlab_url) are now threaded explicitly into
+    run_work_items_sync_job via the ``credentials`` kwarg — no env injection
+    (CHAOS-2461). The URL must NOT be written to os.environ.
     """
 
     @patch.dict(os.environ, {}, clear=False)
@@ -2828,8 +2828,11 @@ class TestGitLabWorkItemsUrlInjection:
         finally:
             task.pop_request()
 
-        assert os.environ.get("GITLAB_URL") == "https://gitlab.example.com"
+        # Credentials are threaded explicitly — GITLAB_URL must NOT be injected.
+        assert os.environ.get("GITLAB_URL") is None
         assert mock_run_job.call_args.kwargs["provider"] == "gitlab"
+        # The credentials dict is passed through to run_work_items_sync_job.
+        assert mock_run_job.call_args.kwargs["credentials"] is not None
 
     @patch.dict(os.environ, {}, clear=False)
     @patch("dev_health_ops.sync.watermarks.set_watermark")

--- a/tests/test_work_items_gitlab_credentials.py
+++ b/tests/test_work_items_gitlab_credentials.py
@@ -148,7 +148,7 @@ def test_fetch_gitlab_work_items_passes_credentials_to_factory(
                 2024, 1, 1, tzinfo=__import__("datetime").timezone.utc
             ),
             status_mapping=StatusMapping({}, {}, {}, {}),
-            identity=IdentityResolver([]),
+            identity=IdentityResolver({}),
             token="threaded-token",
             gitlab_url="https://gitlab.example.com",
             org_id="",

--- a/tests/test_work_items_gitlab_credentials.py
+++ b/tests/test_work_items_gitlab_credentials.py
@@ -1,0 +1,175 @@
+"""CHAOS-2461: GitLab work-items sync must honor config-resolved credentials.
+
+These tests pin the contract that the work-items GitLab client is built from
+the organization-scoped, database-resolved credential (PAT + optional URL)
+and never via a ``GITLAB_TOKEN``/``GITLAB_URL`` environment side-channel.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from dev_health_ops.credentials import CredentialSource, GitLabCredentials
+from dev_health_ops.metrics.job_work_items import _build_gitlab_work_client
+
+_ORG_ID = "22222222-2222-2222-2222-222222222222"
+
+
+def test_build_gitlab_work_client_uses_db_pat_without_env(
+    monkeypatch,
+) -> None:
+    """A database-stored PAT is threaded into the client with no env mutation."""
+    monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+    monkeypatch.delenv("GITLAB_URL", raising=False)
+    creds = GitLabCredentials(
+        token="db-gitlab-pat",
+        base_url="https://gitlab.com",
+        source=CredentialSource.DATABASE,
+    )
+
+    with patch(
+        "dev_health_ops.credentials.resolver.resolve_credentials_sync",
+        return_value=creds,
+    ) as resolve:
+        token, gitlab_url = _build_gitlab_work_client(org_id=_ORG_ID)
+
+    assert token == "db-gitlab-pat"
+    resolve.assert_called_once_with("gitlab", org_id=_ORG_ID, allow_env_fallback=True)
+    # No os.environ side-channel: GITLAB_TOKEN must not have been set.
+    assert "GITLAB_TOKEN" not in os.environ
+    assert "GITLAB_URL" not in os.environ
+
+
+def test_build_gitlab_work_client_uses_db_pat_with_custom_url(
+    monkeypatch,
+) -> None:
+    """A self-hosted GitLab URL from the DB credential is threaded explicitly."""
+    monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+    monkeypatch.delenv("GITLAB_URL", raising=False)
+    creds = GitLabCredentials(
+        token="db-selfhosted-pat",
+        base_url="https://gitlab.example.com",
+        source=CredentialSource.DATABASE,
+    )
+
+    with patch(
+        "dev_health_ops.credentials.resolver.resolve_credentials_sync",
+        return_value=creds,
+    ) as resolve:
+        token, gitlab_url = _build_gitlab_work_client(org_id=_ORG_ID)
+
+    assert token == "db-selfhosted-pat"
+    assert gitlab_url == "https://gitlab.example.com"
+    resolve.assert_called_once_with("gitlab", org_id=_ORG_ID, allow_env_fallback=True)
+    assert "GITLAB_TOKEN" not in os.environ
+    assert "GITLAB_URL" not in os.environ
+
+
+def test_build_gitlab_work_client_without_org_falls_back_to_env(
+    monkeypatch,
+) -> None:
+    """With no organization scope, construction falls back to env vars."""
+    monkeypatch.setenv("GITLAB_TOKEN", "env-gitlab-token")
+    monkeypatch.setenv("GITLAB_URL", "https://gitlab.mycompany.com")
+
+    token, gitlab_url = _build_gitlab_work_client(org_id="")
+
+    assert token == "env-gitlab-token"
+    assert gitlab_url == "https://gitlab.mycompany.com"
+
+
+def test_org_scoped_resolution_wins_over_ambient_env_token(monkeypatch) -> None:
+    """Ambient env credentials must not preempt an org's database credential.
+
+    Regression test for CHAOS-2461: the GitLab path must not route to env
+    resolution whenever ANY GitLab env credential exists with an org scope
+    present — a tenant-boundary violation.
+    """
+    monkeypatch.setenv("GITLAB_TOKEN", "ambient-env-token")
+    monkeypatch.setenv("GITLAB_URL", "https://ambient.gitlab.com")
+    creds = GitLabCredentials(
+        token="org-db-pat",
+        base_url="https://gitlab.com",
+        source=CredentialSource.DATABASE,
+    )
+
+    with patch(
+        "dev_health_ops.credentials.resolver.resolve_credentials_sync",
+        return_value=creds,
+    ) as resolve:
+        token, gitlab_url = _build_gitlab_work_client(org_id=_ORG_ID)
+
+    resolve.assert_called_once_with("gitlab", org_id=_ORG_ID, allow_env_fallback=True)
+    assert token == "org-db-pat"
+    # The ambient env token must NOT have been used.
+    assert token != "ambient-env-token"
+
+
+def test_fetch_gitlab_work_items_passes_credentials_to_factory(
+    monkeypatch,
+) -> None:
+    """fetch_gitlab_work_items threads token/gitlab_url into the client factory.
+
+    Asserts that:
+    - deps.gitlab_client_factory is called with the explicit token and url.
+    - os.environ is NOT mutated (GITLAB_TOKEN/GITLAB_URL not added/changed).
+    """
+    monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+    monkeypatch.delenv("GITLAB_URL", raising=False)
+
+    env_snapshot_before = dict(os.environ)
+
+    captured_kwargs: dict = {}
+
+    def fake_factory(*, token: str, gitlab_url: str | None = None):
+        captured_kwargs["token"] = token
+        captured_kwargs["gitlab_url"] = gitlab_url
+        # Return a minimal stub that satisfies the iteration protocol.
+        return _StubGitLabClient()
+
+    from dev_health_ops.metrics import dependencies as deps_module
+    from dev_health_ops.metrics.work_items import fetch_gitlab_work_items
+    from dev_health_ops.providers.identity import IdentityResolver
+    from dev_health_ops.providers.status_mapping import StatusMapping
+
+    original_registry = deps_module.get_metrics_dependencies()
+    patched_registry = original_registry.__class__(
+        **{
+            **original_registry.__dict__,
+            "gitlab_client_factory": fake_factory,
+        }
+    )
+
+    with patch.object(deps_module, "_registry", patched_registry):
+        items, transitions, attributions = fetch_gitlab_work_items(
+            repos=[],
+            since=__import__("datetime").datetime(
+                2024, 1, 1, tzinfo=__import__("datetime").timezone.utc
+            ),
+            status_mapping=StatusMapping({}, {}, {}, {}),
+            identity=IdentityResolver([]),
+            token="threaded-token",
+            gitlab_url="https://gitlab.example.com",
+            org_id="",
+        )
+
+    assert captured_kwargs["token"] == "threaded-token"
+    assert captured_kwargs["gitlab_url"] == "https://gitlab.example.com"
+
+    # os.environ must not have been mutated.
+    env_snapshot_after = dict(os.environ)
+    assert "GITLAB_TOKEN" not in env_snapshot_after
+    assert "GITLAB_URL" not in env_snapshot_after
+    # No new keys were added.
+    assert env_snapshot_after == env_snapshot_before
+
+
+class _StubGitLabClient:
+    """Minimal GitLab client stub that returns empty iterables."""
+
+    def iter_project_issues(self, **_kwargs):
+        return iter([])
+
+    def iter_project_merge_requests(self, **_kwargs):
+        return iter([])


### PR DESCRIPTION
## Summary
Gate 4 of CHAOS-2305 (horizontal-scaling readiness). Eliminates process-global env-var credential injection on the GitLab work-items path by threading explicit credentials, mirroring the already-correct GitHub work-items path. In a Celery prefork child, the old `_inject_provider_token` / `GITLAB_URL` mutation of `os.environ` could leak credentials across sequential tasks/orgs — a cross-org leak surface that horizontal scaling multiplies.

## Changes
- `metrics/dependencies.py`: `GitLabClientFactory` now takes explicit `token` + `gitlab_url`; `_default_make_gitlab_client` constructs the client directly (no `from_env()`).
- `metrics/work_items.py`: `fetch_gitlab_work_items` accepts explicit credentials and passes them to the factory.
- `metrics/job_work_items.py`: added `_build_gitlab_work_client` mirroring the GitHub helper; GitLab dispatch resolves credentials via `gitlab_credentials_from_mapping` + `resolve_gitlab_url`.
- `workers/{sync_backfill,sync_batch,sync_runtime}.py`: removed all `_inject_provider_token` call sites and the `os.environ["GITLAB_URL"]` injection; cleaned dead imports.
- New regression test `tests/test_work_items_gitlab_credentials.py` asserts no `os.environ` mutation.

## Verification
- `pytest tests/test_work_items_gitlab_credentials.py tests/test_work_items_github_credentials.py tests/test_sync_partitioning.py` → 165 passed
- `ruff format/check` clean
- grep confirms zero active `_inject_provider_token` call sites in sync workers; no GitLab `from_env` in dependencies

Part of CHAOS-2305. Closes CHAOS-2461.