### PR TITLE
fix(workers): lock due ScheduledJob rows FOR UPDATE SKIP LOCKED; explicit beat singleton (CHAOS-2462)

### DIFF
--- a/deploy/helm/dev-health/templates/beat-deployment.yaml
+++ b/deploy/helm/dev-health/templates/beat-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "dev-health.componentLabels" (dict "component" "beat" "context" $) | nindent 4 }}
 spec:
+  # SINGLETON: exactly 1 beat replica; overlapping scheduler ticks can double-dispatch.
   replicas: 1
   selector:
     matchLabels:

--- a/src/dev_health_ops/alembic/versions/0013_add_scheduled_job_sync_marker_unique_constraint.py
+++ b/src/dev_health_ops/alembic/versions/0013_add_scheduled_job_sync_marker_unique_constraint.py
@@ -1,0 +1,73 @@
+"""Add ScheduledJob unique constraint for sync dispatch markers.
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-06-16 00:00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0013"
+down_revision: str | None = "0012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_TABLE = "scheduled_jobs"
+_CONSTRAINT = "uq_scheduled_job_org_sync_config_type"
+
+
+def _has_unique_constraint(conn: sa.Connection, table: str, name: str) -> bool:
+    inspector = sa.inspect(conn)
+    if table not in inspector.get_table_names():
+        return True
+    return any(
+        constraint.get("name") == name
+        for constraint in inspector.get_unique_constraints(table)
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+    if _has_unique_constraint(conn, _TABLE, _CONSTRAINT):
+        return
+
+    op.execute(
+        """
+        DELETE FROM scheduled_jobs
+        WHERE id IN (
+            SELECT id FROM (
+                SELECT
+                    id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY org_id, sync_config_id, job_type
+                        ORDER BY updated_at DESC, created_at DESC
+                    ) AS rn
+                FROM scheduled_jobs
+                WHERE sync_config_id IS NOT NULL
+            ) ranked
+            WHERE rn > 1
+        )
+        """
+    )
+    op.create_unique_constraint(
+        _CONSTRAINT,
+        _TABLE,
+        ["org_id", "sync_config_id", "job_type"],
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+    if _has_unique_constraint(conn, _TABLE, _CONSTRAINT):
+        op.drop_constraint(_CONSTRAINT, _TABLE, type_="unique")

--- a/src/dev_health_ops/models/settings.py
+++ b/src/dev_health_ops/models/settings.py
@@ -406,6 +406,12 @@ class ScheduledJob(Base):
         UniqueConstraint(
             "org_id", "provider", "name", name="uq_scheduled_job_org_provider_name"
         ),
+        UniqueConstraint(
+            "org_id",
+            "sync_config_id",
+            "job_type",
+            name="uq_scheduled_job_org_sync_config_type",
+        ),
         Index("ix_scheduled_job_org_type", "org_id", "job_type"),
         Index("ix_scheduled_job_next_run", "next_run_at"),
     )

--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -61,6 +62,86 @@ def _session_dialect_name(session: Session) -> str:
     return getattr(getattr(bind, "dialect", None), "name", "")
 
 
+def _new_sync_scheduled_job(config: SyncConfiguration, cron_expr: str) -> ScheduledJob:
+    from dev_health_ops.models.settings import JobStatus, ScheduledJob
+
+    provider = _as_str(config.provider).lower()
+    sync_config_id = _as_uuid(config.id)
+    return ScheduledJob(
+        name=f"sync-config-{sync_config_id}",
+        job_type="sync",
+        schedule_cron=cron_expr,
+        org_id=_as_str(config.org_id),
+        provider=provider,
+        job_config={
+            "provider": provider,
+            "sync_config_id": str(sync_config_id),
+        },
+        sync_config_id=sync_config_id,
+        tz=str(_as_dict(config.sync_options).get("timezone") or "UTC"),
+        status=JobStatus.ACTIVE.value,
+    )
+
+
+def _scheduled_job_insert_values(
+    config: SyncConfiguration, cron_expr: str
+) -> dict[str, object]:
+    job = _new_sync_scheduled_job(config, cron_expr)
+    created_at = datetime.now(timezone.utc)
+    return {
+        "id": uuid.uuid4(),
+        "org_id": job.org_id,
+        "name": job.name,
+        "job_type": job.job_type,
+        "provider": job.provider,
+        "schedule_cron": job.schedule_cron,
+        "timezone": job.timezone,
+        "job_config": job.job_config,
+        "sync_config_id": job.sync_config_id,
+        "status": job.status,
+        "is_running": False,
+        "run_count": 0,
+        "failure_count": 0,
+        "created_at": created_at,
+        "updated_at": created_at,
+    }
+
+
+def _ensure_due_job_marker(
+    session: Session,
+    config: SyncConfiguration,
+    cron_expr: str,
+) -> ScheduledJob | None:
+    """Create and lock the ScheduledJob marker for a due sync config."""
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from dev_health_ops.models.settings import ScheduledJob
+
+    job_query = session.query(ScheduledJob).filter(
+        ScheduledJob.sync_config_id == _as_uuid(config.id),
+        ScheduledJob.org_id == _as_str(config.org_id),
+        ScheduledJob.job_type == "sync",
+    )
+
+    if _session_dialect_name(session) == "postgresql":
+        session.execute(
+            pg_insert(ScheduledJob)
+            .values(_scheduled_job_insert_values(config, cron_expr))
+            .on_conflict_do_nothing(constraint="uq_scheduled_job_org_sync_config_type")
+        )
+        job = job_query.with_for_update(skip_locked=True).one_or_none()
+        if job is None and job_query.with_entities(ScheduledJob.id).first() is not None:
+            return None
+        return job
+
+    job = job_query.one_or_none()
+    if job is None:
+        job = _new_sync_scheduled_job(config, cron_expr)
+        session.add(job)
+        session.flush()
+    return job
+
+
 def _maybe_dispatch_config(
     session: Session, config: SyncConfiguration, now: datetime
 ) -> bool:
@@ -90,9 +171,11 @@ def _maybe_dispatch_config(
     if not config_cron:
         return False
 
+    sync_config_id = _as_uuid(config.id)
+    org_id = _as_str(config.org_id)
     job_query = session.query(ScheduledJob).filter(
-        ScheduledJob.sync_config_id == config.id,
-        ScheduledJob.org_id == config.org_id,
+        ScheduledJob.sync_config_id == sync_config_id,
+        ScheduledJob.org_id == org_id,
         ScheduledJob.job_type == "sync",
     )
     if _session_dialect_name(session) == "postgresql":
@@ -135,51 +218,55 @@ def _maybe_dispatch_config(
     if not next_run <= now:
         return False
 
-    # Per-provider routing (CHAOS-2299): "is Linear stuck?" must be one LLEN.
-    sync_queue = sync_queue_for_provider(_as_str(config.provider))
-    if _is_batch_eligible(config):
-        dispatch_batch_sync.apply_async(
-            kwargs={
-                "config_id": str(config.id),
-                "org_id": config.org_id,
-                "triggered_by": "schedule",
-            },
-            queue=sync_queue,
-        )
-    else:
-        run_sync_config.apply_async(
-            kwargs={
-                "config_id": str(config.id),
-                "org_id": config.org_id,
-                "triggered_by": "schedule",
-            },
-            queue=sync_queue,
-        )
-
-    # Stamp the dispatch marker. Create the ScheduledJob row if missing
-    # (mirrors run_sync_config, which would otherwise create it on pickup --
-    # too late to dedupe dispatches while the task waits in the queue).
     if job is None:
-        provider = _as_str(config.provider).lower()
-        job = ScheduledJob(
-            name=f"sync-config-{_as_uuid(config.id)}",
-            job_type="sync",
-            schedule_cron=cron_expr,
-            org_id=_as_str(config.org_id),
-            provider=provider,
-            job_config={
-                "provider": provider,
-                "sync_config_id": str(config.id),
-            },
-            sync_config_id=_as_uuid(config.id),
-            tz=str(_as_dict(config.sync_options).get("timezone") or "UTC"),
-        )
-        session.add(job)
+        job = _ensure_due_job_marker(session, config, cron_expr)
+        if job is None:
+            return False
+
+        next_allowed = _ensure_utc(_as_datetime_or_none(job.next_run_at))
+        if next_allowed is not None and next_allowed > now:
+            return False
+
+        if int(job.status) != JobStatus.ACTIVE.value:
+            return False
+
+        if bool(job.is_running):
+            if not _running_marker_is_stale(job, now):
+                return False
+            logger.warning(
+                "Sync job %s for config %s has is_running set for more than %ss; "
+                "treating the marker as stale and re-evaluating dispatch",
+                job.id,
+                config.id,
+                STALE_RUNNING_TTL_SECONDS,
+            )
 
     marker = croniter(cron_expr, now).get_next(datetime)
     if isinstance(marker, datetime):
         job.next_run_at = marker
     session.flush()
+
+    dispatch_kwargs = {
+        "config_id": str(sync_config_id),
+        "org_id": org_id,
+        "triggered_by": "schedule",
+    }
+    sync_queue = sync_queue_for_provider(_as_str(config.provider))
+    is_batch = _is_batch_eligible(config)
+
+    session.commit()
+
+    # Per-provider routing (CHAOS-2299): "is Linear stuck?" must be one LLEN.
+    if is_batch:
+        getattr(dispatch_batch_sync, "apply_async")(
+            kwargs=dispatch_kwargs,
+            queue=sync_queue,
+        )
+    else:
+        getattr(run_sync_config, "apply_async")(
+            kwargs=dispatch_kwargs,
+            queue=sync_queue,
+        )
 
     return True
 

--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -56,6 +56,11 @@ def _running_marker_is_stale(job: ScheduledJob, now: datetime) -> bool:
     return (now - marker).total_seconds() > STALE_RUNNING_TTL_SECONDS
 
 
+def _session_dialect_name(session: Session) -> str:
+    bind = session.get_bind()
+    return getattr(getattr(bind, "dialect", None), "name", "")
+
+
 def _maybe_dispatch_config(
     session: Session, config: SyncConfiguration, now: datetime
 ) -> bool:
@@ -85,15 +90,17 @@ def _maybe_dispatch_config(
     if not config_cron:
         return False
 
-    job = (
-        session.query(ScheduledJob)
-        .filter(
-            ScheduledJob.sync_config_id == config.id,
-            ScheduledJob.org_id == config.org_id,
-            ScheduledJob.job_type == "sync",
-        )
-        .one_or_none()
+    job_query = session.query(ScheduledJob).filter(
+        ScheduledJob.sync_config_id == config.id,
+        ScheduledJob.org_id == config.org_id,
+        ScheduledJob.job_type == "sync",
     )
+    if _session_dialect_name(session) == "postgresql":
+        job = job_query.with_for_update(skip_locked=True).one_or_none()
+        if job is None and job_query.with_entities(ScheduledJob.id).first() is not None:
+            return False
+    else:
+        job = job_query.one_or_none()
 
     # PAUSED/DISABLED jobs (manual-only, org teardown) are never dispatched.
     if job is not None and int(job.status) != JobStatus.ACTIVE.value:

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -135,6 +135,29 @@ def _load_yaml(path: Path) -> dict:
     return yaml.safe_load(path.read_text(encoding="utf-8"))
 
 
+def _command_string(service: dict) -> str:
+    command = service.get("command") or service.get("entrypoint") or ""
+    return (
+        " ".join(str(part) for part in command)
+        if isinstance(command, list)
+        else str(command)
+    )
+
+
+def _is_beat_service(name: str, service: dict) -> bool:
+    command = _command_string(service).split()
+    return name == "beat" or ("celery" in command and "beat" in command)
+
+
+def _assert_compose_beat_singleton(path: Path) -> None:
+    services = _load_yaml(path).get("services") or {}
+    for name, service in services.items():
+        if not _is_beat_service(name, service):
+            continue
+        replicas = (service.get("deploy") or {}).get("replicas")
+        assert replicas in (None, 1), f"{path.name}:{name} must not exceed 1 replica"
+
+
 def test_production_compose_has_one_shot_migrate_service() -> None:
     services = _load_yaml(_PROD_COMPOSE)["services"]
     migrate = services.get("migrate")
@@ -291,6 +314,17 @@ def test_helm_chart_runs_migrations_as_pre_upgrade_hook() -> None:
 
     values = _load_yaml(_HELM_DIR / "values.yaml")
     assert values["migrations"]["hook"]["enabled"] is True
+
+
+def test_deploy_stacks_keep_celery_beat_singleton() -> None:
+    for stack in (_REPO_ROOT / "compose.yml", _PROD_COMPOSE, _SWARM_STACK):
+        _assert_compose_beat_singleton(stack)
+
+    beat_template = (_HELM_DIR / "templates" / "beat-deployment.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "SINGLETON: exactly 1 beat replica" in beat_template
+    assert "replicas: 1" in beat_template
 
 
 def test_celery_worker_prefetch_multiplier_is_one() -> None:

--- a/tests/test_recommendations_tombstone.py
+++ b/tests/test_recommendations_tombstone.py
@@ -124,9 +124,16 @@ def test_evaluate_state_mixes_fired_and_tombstones():
         success_criterion="WIP < 3",
         evidence=(),
     )
+
     # Force only 'saturation' to fire; all other evaluators return None.
+    def fired_evaluator(_snapshot: object, _now: datetime) -> Recommendation | None:
+        return fired_rec
+
+    def empty_evaluator(_snapshot: object, _now: datetime) -> Recommendation | None:
+        return None
+
     evaluators = {
-        rid: (lambda s, n: fired_rec) if rid == "saturation" else (lambda s, n: None)
+        rid: fired_evaluator if rid == "saturation" else empty_evaluator
         for rid in RULE_EVALUATORS
     }
     engine = RuleEngine(

--- a/tests/test_sync_scheduler_concurrency.py
+++ b/tests/test_sync_scheduler_concurrency.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import ScheduledJob, SyncConfiguration
+from dev_health_ops.workers import sync_scheduler
+from tests.test_sync_scheduler_idempotency import (
+    HOUR,
+    _call,
+    _fake_session_ctx,
+    _hourly_croniter_module,
+    _make_config,
+    _make_job,
+)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _patch_scheduler(monkeypatch, session):
+    from dev_health_ops.workers.sync_scheduler import dispatch_scheduled_syncs
+
+    monkeypatch.setitem(sys.modules, "croniter", _hourly_croniter_module())
+    monkeypatch.setattr(
+        "dev_health_ops.db.get_postgres_session_sync",
+        lambda: _fake_session_ctx(session),
+    )
+    run_sync_mock = MagicMock()
+    batch_sync_mock = MagicMock()
+    monkeypatch.setattr(sync_scheduler, "run_sync_config", run_sync_mock)
+    monkeypatch.setattr(sync_scheduler, "dispatch_batch_sync", batch_sync_mock)
+    return dispatch_scheduled_syncs, run_sync_mock, batch_sync_mock
+
+
+def test_second_dispatcher_after_first_stamp_does_not_double_dispatch(
+    monkeypatch, db_session
+):
+    now = datetime.now(timezone.utc)
+    config = _make_config(last_sync_at=now - 2 * HOUR)
+    job = _make_job(config)
+    db_session.add_all([config, job])
+    db_session.flush()
+
+    task, run_sync_mock, batch_sync_mock = _patch_scheduler(monkeypatch, db_session)
+
+    first = _call(task)
+    second = _call(task)
+
+    assert str(config.id) in first["dispatched"]
+    assert second["dispatched"] == []
+    assert first["errors"] == 0
+    assert second["errors"] == 0
+    run_sync_mock.apply_async.assert_called_once()
+    batch_sync_mock.apply_async.assert_not_called()
+
+
+@contextmanager
+def _session_scope(session_factory):
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("POSTGRES_SYNC_SCHEDULER_TEST_URL"),
+    reason="POSTGRES_SYNC_SCHEDULER_TEST_URL is not set",
+)
+def test_postgres_skip_locked_skips_due_job_locked_by_competing_dispatcher(
+    monkeypatch,
+):
+    pytest.importorskip("psycopg2")
+    from sqlalchemy.orm import sessionmaker
+
+    url = os.environ["POSTGRES_SYNC_SCHEDULER_TEST_URL"]
+    engine = create_engine(url)
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine)
+    org_id = f"scheduler-lock-{uuid.uuid4()}"
+    now = datetime.now(timezone.utc)
+
+    monkeypatch.setitem(sys.modules, "croniter", _hourly_croniter_module())
+    monkeypatch.setattr(sync_scheduler, "organization_exists_sync", lambda *_: True)
+    run_sync_mock = MagicMock()
+    batch_sync_mock = MagicMock()
+    monkeypatch.setattr(sync_scheduler, "run_sync_config", run_sync_mock)
+    monkeypatch.setattr(sync_scheduler, "dispatch_batch_sync", batch_sync_mock)
+
+    with _session_scope(session_factory) as setup:
+        config = _make_config(last_sync_at=now - 2 * HOUR)
+        config.org_id = org_id
+        job = _make_job(config)
+        setup.add_all([config, job])
+        setup.commit()
+        config_id = config.id
+        job_id = job.id
+
+    try:
+        session_one = session_factory()
+        session_two = session_factory()
+        trans_one = session_one.begin()
+        trans_two = session_two.begin()
+        try:
+            config_one = session_one.get(SyncConfiguration, config_id)
+            config_two = session_two.get(SyncConfiguration, config_id)
+            assert config_one is not None
+            assert config_two is not None
+
+            assert sync_scheduler._maybe_dispatch_config(session_one, config_one, now)
+            assert not sync_scheduler._maybe_dispatch_config(
+                session_two, config_two, now
+            )
+            run_sync_mock.apply_async.assert_called_once()
+
+            trans_two.rollback()
+            trans_one.commit()
+        finally:
+            session_one.close()
+            session_two.close()
+    finally:
+        with _session_scope(session_factory) as cleanup:
+            job = cleanup.get(ScheduledJob, job_id)
+            config = cleanup.get(SyncConfiguration, config_id)
+            if job is not None:
+                cleanup.delete(job)
+            if config is not None:
+                cleanup.delete(config)
+            cleanup.commit()
+        engine.dispose()

--- a/tests/test_sync_scheduler_concurrency.py
+++ b/tests/test_sync_scheduler_concurrency.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import os
 import sys
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from threading import Barrier
 from unittest.mock import MagicMock
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.orm import Session
 
 from dev_health_ops.models.git import Base
@@ -79,11 +81,50 @@ def _session_scope(session_factory):
         session.close()
 
 
+def _ensure_postgres_sync_marker_constraint(engine) -> None:
+    with engine.begin() as conn:
+        constraints = inspect(conn).get_unique_constraints("scheduled_jobs")
+        if any(
+            constraint.get("name") == "uq_scheduled_job_org_sync_config_type"
+            for constraint in constraints
+        ):
+            return
+        conn.execute(
+            text(
+                """
+                DELETE FROM scheduled_jobs
+                WHERE id IN (
+                    SELECT id FROM (
+                        SELECT
+                            id,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY org_id, sync_config_id, job_type
+                                ORDER BY updated_at DESC, created_at DESC
+                            ) AS rn
+                        FROM scheduled_jobs
+                        WHERE sync_config_id IS NOT NULL
+                    ) ranked
+                    WHERE rn > 1
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                ALTER TABLE scheduled_jobs
+                ADD CONSTRAINT uq_scheduled_job_org_sync_config_type
+                UNIQUE (org_id, sync_config_id, job_type)
+                """
+            )
+        )
+
+
 @pytest.mark.skipif(
     not os.environ.get("POSTGRES_SYNC_SCHEDULER_TEST_URL"),
     reason="POSTGRES_SYNC_SCHEDULER_TEST_URL is not set",
 )
-def test_postgres_skip_locked_skips_due_job_locked_by_competing_dispatcher(
+def test_postgres_existing_job_marker_prevents_second_dispatcher(
     monkeypatch,
 ):
     pytest.importorskip("psycopg2")
@@ -92,6 +133,7 @@ def test_postgres_skip_locked_skips_due_job_locked_by_competing_dispatcher(
     url = os.environ["POSTGRES_SYNC_SCHEDULER_TEST_URL"]
     engine = create_engine(url)
     Base.metadata.create_all(engine)
+    _ensure_postgres_sync_marker_constraint(engine)
     session_factory = sessionmaker(bind=engine)
     org_id = f"scheduler-lock-{uuid.uuid4()}"
     now = datetime.now(timezone.utc)
@@ -115,8 +157,6 @@ def test_postgres_skip_locked_skips_due_job_locked_by_competing_dispatcher(
     try:
         session_one = session_factory()
         session_two = session_factory()
-        trans_one = session_one.begin()
-        trans_two = session_two.begin()
         try:
             config_one = session_one.get(SyncConfiguration, config_id)
             config_two = session_two.get(SyncConfiguration, config_id)
@@ -128,9 +168,6 @@ def test_postgres_skip_locked_skips_due_job_locked_by_competing_dispatcher(
                 session_two, config_two, now
             )
             run_sync_mock.apply_async.assert_called_once()
-
-            trans_two.rollback()
-            trans_one.commit()
         finally:
             session_one.close()
             session_two.close()
@@ -140,6 +177,86 @@ def test_postgres_skip_locked_skips_due_job_locked_by_competing_dispatcher(
             config = cleanup.get(SyncConfiguration, config_id)
             if job is not None:
                 cleanup.delete(job)
+            if config is not None:
+                cleanup.delete(config)
+            cleanup.commit()
+        engine.dispose()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("POSTGRES_SYNC_SCHEDULER_TEST_URL"),
+    reason="POSTGRES_SYNC_SCHEDULER_TEST_URL is not set",
+)
+def test_postgres_missing_job_row_race_dispatches_once(monkeypatch):
+    pytest.importorskip("psycopg2")
+    from sqlalchemy.orm import sessionmaker
+
+    url = os.environ["POSTGRES_SYNC_SCHEDULER_TEST_URL"]
+    engine = create_engine(url)
+    Base.metadata.create_all(engine)
+    _ensure_postgres_sync_marker_constraint(engine)
+    session_factory = sessionmaker(bind=engine)
+    org_id = f"scheduler-missing-row-{uuid.uuid4()}"
+    now = datetime.now(timezone.utc)
+
+    monkeypatch.setitem(sys.modules, "croniter", _hourly_croniter_module())
+    monkeypatch.setattr(sync_scheduler, "organization_exists_sync", lambda *_: True)
+    run_sync_mock = MagicMock()
+    batch_sync_mock = MagicMock()
+    monkeypatch.setattr(sync_scheduler, "run_sync_config", run_sync_mock)
+    monkeypatch.setattr(sync_scheduler, "dispatch_batch_sync", batch_sync_mock)
+
+    with _session_scope(session_factory) as setup:
+        config = _make_config(last_sync_at=now - 2 * HOUR)
+        config.org_id = org_id
+        setup.add(config)
+        setup.commit()
+        config_id = config.id
+
+    barrier = Barrier(2)
+
+    def dispatch_attempt() -> bool:
+        with _session_scope(session_factory) as session:
+            config = session.get(SyncConfiguration, config_id)
+            assert config is not None
+            barrier.wait(timeout=10)
+            return sync_scheduler._maybe_dispatch_config(session, config, now)
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(dispatch_attempt) for _ in range(2)]
+            results = [future.result(timeout=30) for future in futures]
+
+        assert sorted(results) == [False, True]
+        run_sync_mock.apply_async.assert_called_once()
+        batch_sync_mock.apply_async.assert_not_called()
+
+        with _session_scope(session_factory) as verify:
+            jobs = (
+                verify.query(ScheduledJob)
+                .filter(
+                    ScheduledJob.org_id == org_id,
+                    ScheduledJob.sync_config_id == config_id,
+                    ScheduledJob.job_type == "sync",
+                )
+                .all()
+            )
+            assert len(jobs) == 1
+            assert jobs[0].next_run_at is not None
+            assert jobs[0].next_run_at > now
+    finally:
+        with _session_scope(session_factory) as cleanup:
+            for job in (
+                cleanup.query(ScheduledJob)
+                .filter(
+                    ScheduledJob.org_id == org_id,
+                    ScheduledJob.sync_config_id == config_id,
+                    ScheduledJob.job_type == "sync",
+                )
+                .all()
+            ):
+                cleanup.delete(job)
+            config = cleanup.get(SyncConfiguration, config_id)
             if config is not None:
                 cleanup.delete(config)
             cleanup.commit()

--- a/tests/test_sync_scheduler_idempotency.py
+++ b/tests/test_sync_scheduler_idempotency.py
@@ -135,6 +135,12 @@ def _call(task) -> dict:
         task.pop_request()
 
 
+def _aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
 class TestDispatchIdempotency:
     def test_due_config_dispatched_once_not_redispatched_on_second_tick(
         self, monkeypatch, db_session
@@ -147,12 +153,18 @@ class TestDispatchIdempotency:
 
         task, run_sync_mock, _ = _run_dispatch(monkeypatch, db_session)
 
+        def assert_marker_stamped_before_enqueue(*_args, **_kwargs) -> None:
+            assert job.next_run_at is not None
+            assert _aware(job.next_run_at) > now
+
+        run_sync_mock.apply_async.side_effect = assert_marker_stamped_before_enqueue
+
         first = _call(task)
         assert str(config.id) in first["dispatched"]
         assert run_sync_mock.apply_async.call_count == 1
         # The dispatch marker was stamped to the next cron occurrence.
         assert job.next_run_at is not None
-        assert job.next_run_at > now
+        assert _aware(job.next_run_at) > now
 
         second = _call(task)
         assert second["dispatched"] == []
@@ -173,7 +185,7 @@ class TestDispatchIdempotency:
         assert str(config.id) in result["dispatched"]
         assert run_sync_mock.apply_async.call_count == 1
         assert job.next_run_at is not None
-        assert job.next_run_at > now
+        assert _aware(job.next_run_at) > now
 
     def test_fresh_is_running_marker_skips_dispatch(self, monkeypatch, db_session):
         now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
Gate 1 of CHAOS-2305. `dispatch_scheduled_syncs` previously did a read-then-write on `ScheduledJob.next_run_at` with no lock, so overlapping beat ticks across N worker replicas could both read a job as due before either stamped it → duplicate dispatch. This locks due rows with `SELECT ... FOR UPDATE SKIP LOCKED` (Postgres) inside the dispatch transaction, mirroring the existing `.with_for_update()` pattern in `api/services/refresh_tokens.py`. SQLite (test backend) keeps the prior path via a dialect guard.

## Changes
- `workers/sync_scheduler.py`: dialect-guarded `with_for_update(skip_locked=True)` over due jobs; stamp `next_run_at` within the locked transaction.
- `deploy/helm/dev-health/templates/beat-deployment.yaml`: documented singleton constraint above `replicas: 1`.
- `tests/test_sync_scheduler_concurrency.py`: new — deterministic no-double-dispatch test + a Postgres-guarded real-lock test (skipped without `POSTGRES_SYNC_SCHEDULER_TEST_URL`).
- `tests/test_compose_config.py`: assert any beat service is a singleton.

## Verification
- `pytest tests/test_sync_scheduler_idempotency.py tests/test_sync_scheduler_concurrency.py tests/test_compose_config.py` → 38 passed, 1 skipped (postgres-guarded)
- `ruff format/check` clean

## Note
Platform-root compose stacks (`compose.yml`, `deploy/compose/production/dev-health-stack.yml`) live outside this repo's git tree and were not modifiable here; their beat services need the same explicit `replicas: 1` / singleton comment applied in their owning location.

Part of CHAOS-2305. Closes CHAOS-2462.