### PR TITLE
feat(providers): adopt DistributedRateLimitGate keyed (provider,org_id,host); collapse Jira double-retry (CHAOS-2463)

### DIFF
--- a/src/dev_health_ops/api/services/configuration/jira_activity_inference.py
+++ b/src/dev_health_ops/api/services/configuration/jira_activity_inference.py
@@ -64,7 +64,8 @@ class JiraActivityInferenceService:
         from dev_health_ops.providers.jira.client import JiraAuth, JiraClient
 
         client = JiraClient(
-            auth=JiraAuth(base_url=jira_url, email=email, api_token=api_token)
+            auth=JiraAuth(base_url=jira_url, email=email, api_token=api_token),
+            org_id=self.org_id,
         )
 
         def _fetch_issues() -> list[dict[str, Any]]:

--- a/src/dev_health_ops/api/services/configuration/team_discovery.py
+++ b/src/dev_health_ops/api/services/configuration/team_discovery.py
@@ -123,7 +123,9 @@ class TeamDiscoveryService:
             from dev_health_ops.providers.linear.client import LinearAuth, LinearClient
 
             DiscoveredTeam = _get_discovered_team_cls()
-            with LinearClient(auth=LinearAuth(api_key=api_key)) as client:
+            with LinearClient(
+                auth=LinearAuth(api_key=api_key), org_id=self.org_id
+            ) as client:
                 teams: list[Any] = []
                 for team in client.iter_teams():
                     teams.append(

--- a/src/dev_health_ops/api/services/configuration/team_membership.py
+++ b/src/dev_health_ops/api/services/configuration/team_membership.py
@@ -111,7 +111,9 @@ class TeamMembershipService:
 
             DiscoveredMember = _get_discovered_member_cls()
             normalized_key = team_key.removeprefix("linear:")
-            with LinearClient(auth=LinearAuth(api_key=api_key)) as client:
+            with LinearClient(
+                auth=LinearAuth(api_key=api_key), org_id=self.org_id
+            ) as client:
                 for team in client.iter_teams():
                     if team.get("key") != normalized_key:
                         continue

--- a/src/dev_health_ops/connectors/utils/rate_limit_queue.py
+++ b/src/dev_health_ops/connectors/utils/rate_limit_queue.py
@@ -15,7 +15,6 @@ unavailable.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import logging
 import os
 import threading
@@ -118,9 +117,9 @@ end
 """
 
 
-def _token_hash(token: str) -> str:
-    """Return first 8 hex chars of SHA-256 of *token*."""
-    return hashlib.sha256(token.encode()).hexdigest()[:8]
+def _key_part(value: str | None) -> str:
+    part = str(value or "").strip()
+    return part or "_"
 
 
 class DistributedRateLimitGate(RateLimitGate):
@@ -134,6 +133,8 @@ class DistributedRateLimitGate(RateLimitGate):
     def __init__(
         self,
         provider: str,
+        org_id: str | None = None,
+        host: str | None = None,
         token_hint: str = "",
         config: RateLimitConfig | None = None,
         *,
@@ -141,10 +142,11 @@ class DistributedRateLimitGate(RateLimitGate):
     ) -> None:
         super().__init__(config=config)
         self._provider = provider
+        self._org_id = _key_part(org_id)
+        self._host = _key_part(host or token_hint)
         self._token_hint = token_hint
 
-        token_part = f":{_token_hash(token_hint)}" if token_hint else ""
-        self._redis_key = f"rate_limit:{provider}{token_part}"
+        self._redis_key = f"rate_limit:{provider}:{self._org_id}:{self._host}"
         self._ttl = int((self._config.max_backoff_seconds or 300) * 2)
 
         self._redis: Any = None
@@ -293,6 +295,8 @@ _factory_lock = threading.Lock()
 
 def create_rate_limit_gate(
     provider: str,
+    org_id: str | None = None,
+    host: str | None = None,
     token_hint: str = "",
     config: RateLimitConfig | None = None,
 ) -> RateLimitGate:
@@ -312,6 +316,8 @@ def create_rate_limit_gate(
     try:
         gate = DistributedRateLimitGate(
             provider=provider,
+            org_id=org_id,
+            host=host,
             token_hint=token_hint,
             config=config,
         )

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -90,7 +90,9 @@ def _build_github_work_client(
             raise ValueError(
                 "Missing GitHub token or App credentials for work-items sync configuration"
             )
-        return GitHubWorkClient(auth=GitHubAuth.from_credentials(github_credentials))
+        return GitHubWorkClient(
+            auth=GitHubAuth.from_credentials(github_credentials), org_id=org_id
+        )
 
     if not org_id:
         return GitHubWorkClient.from_env()
@@ -100,7 +102,9 @@ def _build_github_work_client(
     )
     if not isinstance(resolved_credentials, GitHubCredentials):
         raise ValueError("Resolved credentials are not GitHub credentials")
-    return GitHubWorkClient(auth=GitHubAuth.from_credentials(resolved_credentials))
+    return GitHubWorkClient(
+        auth=GitHubAuth.from_credentials(resolved_credentials), org_id=org_id
+    )
 
 
 def run_work_items_sync_job(

--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -5,13 +5,15 @@ import logging
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Protocol, TypedDict, TypeVar
+from typing import Any, Protocol, TypedDict, TypeVar, cast
+from urllib.parse import urlparse
 
 from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
 from dev_health_ops.connectors.utils.graphql import GitHubGraphQLClient
 from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitConfig,
     RateLimitGate,
+    create_rate_limit_gate,
 )
 from dev_health_ops.credentials.resolver import (
     CredentialResolutionError,
@@ -126,8 +128,7 @@ class _GitHubIssueBaseLike(Protocol):
 
 
 class _GitHubIssueLike(_GitHubIssueBaseLike, Protocol):
-    def get_events(self) -> Iterable[_GitHubEventLike]:
-        pass
+    def get_events(self) -> Iterable[_GitHubEventLike]: ...
 
 
 class _GitHubPullRequestLike(_GitHubIssueBaseLike, Protocol):
@@ -203,12 +204,20 @@ class GitHubWorkClient:
         auth: GitHubAuth,
         per_page: int = 100,
         gate: RateLimitGate | None = None,
+        org_id: str | None = None,
     ) -> None:
         from github import Github  # PyGithub
 
         self.auth = auth
         self.per_page = max(1, min(100, int(per_page)))
-        self.gate = gate or RateLimitGate(RateLimitConfig(initial_backoff_seconds=1.0))
+        base_url = auth.base_url or "https://api.github.com"
+        host = urlparse(base_url).hostname or "api.github.com"
+        self.gate = gate or create_rate_limit_gate(
+            "github",
+            org_id=org_id,
+            host=host,
+            config=RateLimitConfig(initial_backoff_seconds=1.0),
+        )
         self._app_token_provider: GitHubAppTokenProvider | None = None
 
         token = auth.token
@@ -246,7 +255,7 @@ class GitHubWorkClient:
         self.graphql = GitHubGraphQLClient(token, token_provider=token_provider)
 
     @classmethod
-    def from_env(cls) -> GitHubWorkClient:
+    def from_env(cls, *, org_id: str | None = None) -> GitHubWorkClient:
         try:
             credentials = resolve_credentials_sync("github", allow_env_fallback=True)
         except CredentialResolutionError as exc:
@@ -257,10 +266,11 @@ class GitHubWorkClient:
             ) from exc
         if not isinstance(credentials, GitHubCredentials):
             raise ValueError("Resolved credentials are not GitHub credentials")
-        return cls(auth=GitHubAuth.from_credentials(credentials))
+        return cls(auth=GitHubAuth.from_credentials(credentials), org_id=org_id)
 
     def get_repo(self, *, owner: str, repo: str) -> Any:
-        return self.github.get_repo(f"{owner}/{repo}")
+        with gate_call(self.gate):
+            return self.github.get_repo(f"{owner}/{repo}")
 
     def _iter_with_limit(
         self,
@@ -295,7 +305,8 @@ class GitHubWorkClient:
         limit: int | None = None,
     ) -> Iterable[_GitHubIssueLike]:
         gh_repo = self.get_repo(owner=owner, repo=repo)
-        issues = gh_repo.get_issues(state=state, since=since)
+        with gate_call(self.gate):
+            issues = gh_repo.get_issues(state=state, since=since)
         yield from self._iter_with_limit(
             issues,
             limit=limit,
@@ -314,11 +325,17 @@ class GitHubWorkClient:
         Accepts both Issues and PullRequests: PyGithub's Issue exposes the
         endpoint as get_events(), PullRequest as get_issue_events().
         """
-        if hasattr(issue, "get_events"):
-            events = issue.get_events()
+        get_events = getattr(issue, "get_events", None)
+        if callable(get_events):
+            with gate_call(self.gate):
+                events = get_events()
         else:
-            events = issue.get_issue_events()
-        yield from self._iter_with_limit(events, limit=limit)
+            get_issue_events = getattr(issue, "get_issue_events")
+            with gate_call(self.gate):
+                events = get_issue_events()
+        yield from self._iter_with_limit(
+            cast(Iterable[_GitHubEventLike], events), limit=limit
+        )
 
     def iter_pull_requests(
         self,
@@ -334,7 +351,8 @@ class GitHubWorkClient:
         Iterate pull requests in a repository via REST.
         """
         gh_repo = self.get_repo(owner=owner, repo=repo)
-        pulls = gh_repo.get_pulls(state=state, sort=sort, direction=direction)
+        with gate_call(self.gate):
+            pulls = gh_repo.get_pulls(state=state, sort=sort, direction=direction)
         yield from self._iter_with_limit(pulls, limit=limit)
 
     def iter_issue_comments(
@@ -343,7 +361,9 @@ class GitHubWorkClient:
         """
         Iterate comments on an issue via REST.
         """
-        yield from self._iter_with_limit(issue.get_comments(), limit=limit)
+        with gate_call(self.gate):
+            comments = issue.get_comments()
+        yield from self._iter_with_limit(comments, limit=limit)
 
     def iter_pr_comments(
         self, pr: _GitHubPullRequestLike, *, limit: int | None = None
@@ -360,7 +380,9 @@ class GitHubWorkClient:
         """
         Iterate review comments on a pull request.
         """
-        yield from self._iter_with_limit(pr.get_review_comments(), limit=limit)
+        with gate_call(self.gate):
+            comments = pr.get_review_comments()
+        yield from self._iter_with_limit(comments, limit=limit)
 
     def iter_pr_social_data_batch(
         self,
@@ -740,9 +762,9 @@ class GitHubWorkClient:
         Iterate milestones in a repository via REST.
         """
         gh_repo = self.get_repo(owner=owner, repo=repo)
-        yield from self._iter_with_limit(
-            gh_repo.get_milestones(state=state), limit=limit
-        )
+        with gate_call(self.gate):
+            milestones = gh_repo.get_milestones(state=state)
+        yield from self._iter_with_limit(milestones, limit=limit)
 
     def iter_project_v2_items(
         self,

--- a/src/dev_health_ops/providers/gitlab/client.py
+++ b/src/dev_health_ops/providers/gitlab/client.py
@@ -5,10 +5,12 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Protocol
+from urllib.parse import urlparse
 
 from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitConfig,
     RateLimitGate,
+    create_rate_limit_gate,
 )
 from dev_health_ops.providers._ratelimit import gate_call
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
@@ -55,12 +57,19 @@ class GitLabWorkClient:
         auth: GitLabAuth,
         per_page: int = 100,
         gate: RateLimitGate | None = None,
+        org_id: str | None = None,
     ) -> None:
         import gitlab  # python-gitlab
 
         self.auth = auth
         self.per_page = max(1, min(100, int(per_page)))
-        self.gate = gate or RateLimitGate(RateLimitConfig(initial_backoff_seconds=1.0))
+        host = urlparse(auth.base_url).hostname or "gitlab.com"
+        self.gate = gate or create_rate_limit_gate(
+            "gitlab",
+            org_id=org_id,
+            host=host,
+            config=RateLimitConfig(initial_backoff_seconds=1.0),
+        )
 
         self.gl = gitlab.Gitlab(
             auth.base_url,
@@ -69,7 +78,7 @@ class GitLabWorkClient:
         )
 
     @classmethod
-    def from_env(cls) -> GitLabWorkClient:
+    def from_env(cls, *, org_id: str | None = None) -> GitLabWorkClient:
         env = read_env_spec(
             EnvSpec(
                 required={"token": "GITLAB_TOKEN"},
@@ -81,7 +90,8 @@ class GitLabWorkClient:
             auth=GitLabAuth(
                 token=str(env["token"]),
                 base_url=str(env["base_url"]),
-            )
+            ),
+            org_id=org_id,
         )
 
     def get_project(self, project_id_or_path: str) -> Any:
@@ -100,7 +110,8 @@ class GitLabWorkClient:
         params: dict[str, Any] = {"state": state}
         if updated_after is not None:
             params["updated_after"] = updated_after.isoformat()
-        issues = project.issues.list(iterator=True, **params)
+        with gate_call(self.gate):
+            issues = project.issues.list(iterator=True, **params)
         count = 0
         for issue in issues:
             yield issue
@@ -121,7 +132,8 @@ class GitLabWorkClient:
         params: dict[str, Any] = {"state": state}
         if updated_after is not None:
             params["updated_after"] = updated_after.isoformat()
-        mrs = project.mergerequests.list(iterator=True, **params)
+        with gate_call(self.gate):
+            mrs = project.mergerequests.list(iterator=True, **params)
         count = 0
         for mr in mrs:
             yield mr
@@ -231,7 +243,8 @@ class GitLabWorkClient:
     ) -> Iterable[Any]:
         """Iterate milestones for a project."""
         project = self.get_project(project_id_or_path)
-        milestones = project.milestones.list(state=state, iterator=True)
+        with gate_call(self.gate):
+            milestones = project.milestones.list(state=state, iterator=True)
         yield from milestones
 
     def iter_group_milestones(
@@ -244,7 +257,8 @@ class GitLabWorkClient:
         try:
             with gate_call(self.gate):
                 group = self.gl.groups.get(group_id_or_path)
-            milestones = group.milestones.list(state=state, iterator=True)
+            with gate_call(self.gate):
+                milestones = group.milestones.list(state=state, iterator=True)
             yield from milestones
         except Exception as exc:
             logger.debug("Failed to fetch group milestones: %s", exc)

--- a/src/dev_health_ops/providers/gitlab/client.py
+++ b/src/dev_health_ops/providers/gitlab/client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Protocol
@@ -98,6 +98,22 @@ class GitLabWorkClient:
         with gate_call(self.gate):
             return self.gl.projects.get(project_id_or_path)
 
+    def _gated_iter(self, iterable: Any) -> Iterator[Any]:
+        """Consume a python-gitlab lazy iterator with each page fetch routed
+        through the shared rate-limit gate. ``list(iterator=True)`` fetches
+        pages lazily as the iterator is consumed, so gating only the list()
+        creation leaves later page requests uncoordinated; gating each
+        ``next()`` keeps multi-page fetches under the distributed gate.
+        """
+        iterator = iter(iterable)
+        while True:
+            with gate_call(self.gate):
+                try:
+                    item = next(iterator)
+                except StopIteration:
+                    return
+            yield item
+
     def iter_project_issues(
         self,
         *,
@@ -113,7 +129,7 @@ class GitLabWorkClient:
         with gate_call(self.gate):
             issues = project.issues.list(iterator=True, **params)
         count = 0
-        for issue in issues:
+        for issue in self._gated_iter(issues):
             yield issue
             count += 1
             if limit is not None and count >= int(limit):
@@ -135,7 +151,7 @@ class GitLabWorkClient:
         with gate_call(self.gate):
             mrs = project.mergerequests.list(iterator=True, **params)
         count = 0
-        for mr in mrs:
+        for mr in self._gated_iter(mrs):
             yield mr
             count += 1
             if limit is not None and count >= int(limit):
@@ -245,7 +261,7 @@ class GitLabWorkClient:
         project = self.get_project(project_id_or_path)
         with gate_call(self.gate):
             milestones = project.milestones.list(state=state, iterator=True)
-        yield from milestones
+        yield from self._gated_iter(milestones)
 
     def iter_group_milestones(
         self,
@@ -259,7 +275,7 @@ class GitLabWorkClient:
                 group = self.gl.groups.get(group_id_or_path)
             with gate_call(self.gate):
                 milestones = group.milestones.list(state=state, iterator=True)
-            yield from milestones
+            yield from self._gated_iter(milestones)
         except Exception as exc:
             logger.debug("Failed to fetch group milestones: %s", exc)
             return
@@ -306,7 +322,7 @@ class GitLabWorkClient:
                 epics = group.epics.list(iterator=True, **params)
 
             count = 0
-            for epic in epics:
+            for epic in self._gated_iter(epics):
                 yield epic
                 count += 1
                 if limit is not None and count >= int(limit):

--- a/src/dev_health_ops/providers/jira/client.py
+++ b/src/dev_health_ops/providers/jira/client.py
@@ -76,6 +76,7 @@ class JiraClient:
         per_page: int = 100,
         gate: RateLimitGate | None = None,
         org_id: str | None = None,
+        max_retries_429: int = 3,
     ) -> None:
         import requests
 
@@ -89,6 +90,7 @@ class JiraClient:
             host=host,
             config=RateLimitConfig(initial_backoff_seconds=1.0),
         )
+        self.max_retries_429 = max(0, int(max_retries_429))
 
         self.session = requests.Session()
         self.session.auth = (auth.email, auth.api_token)
@@ -130,25 +132,41 @@ class JiraClient:
         import requests
 
         url = self._url(path)
-        self.gate.wait_sync()
-        try:
-            resp = self.session.get(url, params=params, timeout=self.timeout_seconds)
-            if resp.status_code == 429:
-                applied = penalize_from_response(self.gate, resp)
-                logger.info("Jira rate limited; backoff %.1fs (HTTP 429)", applied)
-            resp.raise_for_status()
-            self.gate.reset()
-            data = resp.json()
-            return data if isinstance(data, dict) else {}
-        except requests.HTTPError as exc:
+        attempts = self.max_retries_429 + 1
+        for attempt in range(attempts):
+            self.gate.wait_sync()
             try:
-                body = exc.response.text if exc.response is not None else ""
-            except Exception:
-                body = ""
-            logger.debug(
-                "Jira request failed: %s %s params=%s body=%s", "GET", url, params, body
-            )
-            raise
+                resp = self.session.get(
+                    url, params=params, timeout=self.timeout_seconds
+                )
+                if resp.status_code == 429:
+                    applied = penalize_from_response(self.gate, resp)
+                    logger.info(
+                        "Jira rate limited; backoff %.1fs (HTTP 429, attempt %d/%d)",
+                        applied,
+                        attempt + 1,
+                        attempts,
+                    )
+                    if attempt + 1 < attempts:
+                        continue
+                resp.raise_for_status()
+                self.gate.reset()
+                data = resp.json()
+                return data if isinstance(data, dict) else {}
+            except requests.HTTPError as exc:
+                try:
+                    body = exc.response.text if exc.response is not None else ""
+                except Exception:
+                    body = ""
+                logger.debug(
+                    "Jira request failed: %s %s params=%s body=%s",
+                    "GET",
+                    url,
+                    params,
+                    body,
+                )
+                raise
+        raise RuntimeError("Jira request retry loop exited without a result")
 
     def search_issues_page(
         self,

--- a/src/dev_health_ops/providers/jira/client.py
+++ b/src/dev_health_ops/providers/jira/client.py
@@ -4,11 +4,12 @@ import logging
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlparse
 
-from dev_health_ops.connectors.utils import retry_with_backoff
 from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitConfig,
     RateLimitGate,
+    create_rate_limit_gate,
 )
 from dev_health_ops.providers._ratelimit import penalize_from_response
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
@@ -74,20 +75,27 @@ class JiraClient:
         timeout_seconds: int = 30,
         per_page: int = 100,
         gate: RateLimitGate | None = None,
+        org_id: str | None = None,
     ) -> None:
         import requests
 
         self.auth = auth
         self.timeout_seconds = int(timeout_seconds)
         self.per_page = max(1, min(100, int(per_page)))
-        self.gate = gate or RateLimitGate(RateLimitConfig(initial_backoff_seconds=1.0))
+        host = urlparse(auth.base_url).hostname or "_"
+        self.gate = gate or create_rate_limit_gate(
+            "jira",
+            org_id=org_id,
+            host=host,
+            config=RateLimitConfig(initial_backoff_seconds=1.0),
+        )
 
         self.session = requests.Session()
         self.session.auth = (auth.email, auth.api_token)
         self.session.headers.update({"Accept": "application/json"})
 
     @classmethod
-    def from_env(cls) -> JiraClient:
+    def from_env(cls, *, org_id: str | None = None) -> JiraClient:
         env = read_env_spec(
             EnvSpec(
                 required={
@@ -105,7 +113,8 @@ class JiraClient:
                 base_url=_normalize_jira_base_url(str(env["base_url"])),
                 email=str(env["email"]),
                 api_token=str(env["api_token"]),
-            )
+            ),
+            org_id=org_id,
         )
 
     def close(self) -> None:
@@ -141,7 +150,6 @@ class JiraClient:
             )
             raise
 
-    @retry_with_backoff(max_retries=5, initial_delay=1.0, max_delay=60.0)
     def search_issues_page(
         self,
         *,
@@ -220,7 +228,6 @@ class JiraClient:
                 logger.debug("Jira search complete (isLast=true); fetched=%d", fetched)
                 break
 
-    @retry_with_backoff(max_retries=5, initial_delay=1.0, max_delay=60.0)
     def fetch_issue_comments_page(
         self,
         *,
@@ -266,7 +273,6 @@ class JiraClient:
             if (page or {}).get("isLast") is True:
                 break
 
-    @retry_with_backoff(max_retries=5, initial_delay=1.0, max_delay=60.0)
     def get_sprint(self, *, sprint_id: str) -> dict[str, Any]:
         return self._request_json(
             path=f"/rest/agile/1.0/sprint/{sprint_id}",

--- a/src/dev_health_ops/providers/linear/client.py
+++ b/src/dev_health_ops/providers/linear/client.py
@@ -6,14 +6,16 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
 from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitConfig,
     RateLimitGate,
+    create_rate_limit_gate,
 )
-from dev_health_ops.providers._ratelimit import penalize_from_response
+from dev_health_ops.providers._ratelimit import gate_call
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 
 logger = logging.getLogger(__name__)
@@ -41,6 +43,12 @@ class LinearComplexityLimitError(LinearGraphQLError):
 
 class LinearRateLimitError(RuntimeError):
     """Linear kept returning HTTP 429 after exhausting all retry attempts."""
+
+
+class _LinearHTTPRateLimit(RuntimeError):
+    def __init__(self, retry_after_seconds: float | None) -> None:
+        super().__init__("Linear HTTP 429")
+        self.retry_after_seconds = retry_after_seconds
 
 
 ISSUES_QUERY = """
@@ -379,10 +387,17 @@ class LinearClient:
         per_page: int = 50,
         gate: RateLimitGate | None = None,
         max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+        org_id: str | None = None,
     ) -> None:
         self.auth = auth
         self.per_page = max(1, min(100, int(per_page)))
-        self.gate = gate or RateLimitGate(RateLimitConfig(initial_backoff_seconds=1.0))
+        host = urlparse(LINEAR_API_URL).hostname or "api.linear.app"
+        self.gate = gate or create_rate_limit_gate(
+            "linear",
+            org_id=org_id,
+            host=host,
+            config=RateLimitConfig(initial_backoff_seconds=1.0),
+        )
         self.max_attempts = max(1, int(max_attempts))
         self._rate_limit: RateLimitInfo | None = None
         self._client = httpx.Client(
@@ -394,14 +409,14 @@ class LinearClient:
         )
 
     @classmethod
-    def from_env(cls) -> LinearClient:
+    def from_env(cls, *, org_id: str | None = None) -> LinearClient:
         env = read_env_spec(
             EnvSpec(
                 required={"api_key": "LINEAR_API_KEY"},
                 missing_error="Linear API key required (set LINEAR_API_KEY)",
             )
         )
-        return cls(auth=LinearAuth(api_key=str(env["api_key"])))
+        return cls(auth=LinearAuth(api_key=str(env["api_key"])), org_id=org_id)
 
     def _execute(
         self,
@@ -414,17 +429,15 @@ class LinearClient:
 
         last_delay = 0.0
         for attempt in range(1, self.max_attempts + 1):
-            self.gate.wait_sync()
-            self._wait_for_rate_limit()
-
-            response = self._client.post(LINEAR_API_URL, json=payload)
-            self._update_rate_limit(response)
-
-            if response.status_code == 429:
-                # Respect Retry-After when present; otherwise the gate
-                # applies exponential backoff (1s * 2^n, capped at the
-                # gate's max_backoff_seconds).
-                last_delay = penalize_from_response(self.gate, response)
+            try:
+                with gate_call(self.gate):
+                    self._wait_for_rate_limit()
+                    response = self._client.post(LINEAR_API_URL, json=payload)
+                    self._update_rate_limit(response)
+                    if response.status_code == 429:
+                        raise _LinearHTTPRateLimit(self._retry_after_seconds(response))
+            except _LinearHTTPRateLimit as exc:
+                last_delay = self._last_applied_delay(exc.retry_after_seconds)
                 logger.warning(
                     "Linear rate limit hit (attempt %d/%d), backing off %.1fs",
                     attempt,
@@ -442,7 +455,6 @@ class LinearClient:
                 self._raise_graphql_errors(errors)
 
             response.raise_for_status()
-            self.gate.reset()
             data = body if isinstance(body, dict) else {}
             return data.get("data") or {}
 
@@ -450,6 +462,28 @@ class LinearClient:
             f"Linear API rate limited: giving up after {self.max_attempts} "
             f"attempts (last backoff {last_delay:.1f}s)"
         )
+
+    def _last_applied_delay(self, retry_after_seconds: float | None) -> float:
+        if retry_after_seconds is not None:
+            return max(
+                0.0,
+                min(float(retry_after_seconds), self.gate._config.max_backoff_seconds),
+            )
+        factor = self.gate._config.backoff_factor or 1.0
+        if factor <= 0:
+            return self.gate._config.initial_backoff_seconds
+        return min(
+            self.gate._current_backoff / factor,
+            self.gate._config.max_backoff_seconds,
+        )
+
+    @staticmethod
+    def _retry_after_seconds(response: httpx.Response) -> float | None:
+        try:
+            raw = response.headers.get("Retry-After")
+            return float(raw) if raw is not None else None
+        except (TypeError, ValueError):
+            return None
 
     @staticmethod
     def _parse_body(response: httpx.Response) -> Any:

--- a/src/dev_health_ops/providers/linear/provider.py
+++ b/src/dev_health_ops/providers/linear/provider.py
@@ -91,7 +91,13 @@ class LinearProvider(ProviderWithClient[LinearClient]):
             linear_issue_to_work_item,
         )
 
-        client = self._make_client()
+        client = (
+            self._client
+            if self._client is not None
+            else self.client_cls.from_env(
+                org_id=str(ctx.org_id) if ctx.org_id is not None else None
+            )
+        )
 
         def _issue_dependencies(
             issue: dict, work_item_id: str

--- a/tests/providers/test_gitlab_client_ratelimit.py
+++ b/tests/providers/test_gitlab_client_ratelimit.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from dev_health_ops.connectors.utils.rate_limit_queue import RateLimitGate
+from dev_health_ops.providers.gitlab.client import GitLabAuth, GitLabWorkClient
+
+
+def _make_client(gate: Any) -> GitLabWorkClient:
+    return GitLabWorkClient(
+        auth=GitLabAuth(token="test-token", base_url="https://gitlab.example.com"),
+        gate=gate,
+    )
+
+
+def test_gated_iter_passes_through_items_under_gate() -> None:
+    # Every page fetch (each next() on the lazy iterator) is coordinated through
+    # the shared gate, not just the iterator creation (CHAOS-2463).
+    gate = MagicMock(spec=RateLimitGate)
+    client = _make_client(gate)
+
+    def _lazy_pages() -> Any:
+        yield {"id": 1}
+        yield {"id": 2}
+
+    collected = list(client._gated_iter(_lazy_pages()))
+
+    assert collected == [{"id": 1}, {"id": 2}]
+    # wait_sync is called once per next(): two items plus the terminal
+    # StopIteration probe.
+    assert gate.wait_sync.call_count == 3
+    gate.penalize.assert_not_called()
+
+
+def test_gated_iter_penalizes_when_a_later_page_fetch_raises() -> None:
+    # A 429 raised while consuming a later page must flow through the gate so the
+    # whole worker fleet backs off, instead of the bulk path running uncoordinated.
+    gate = MagicMock(spec=RateLimitGate)
+    gate.penalize.return_value = 1.0
+    client = _make_client(gate)
+
+    def _lazy_pages() -> Any:
+        yield {"id": 1}
+        raise requests.HTTPError("429 Too Many Requests")
+
+    collected: list[Any] = []
+    with pytest.raises(requests.HTTPError):
+        for item in client._gated_iter(_lazy_pages()):
+            collected.append(item)
+
+    assert collected == [{"id": 1}]
+    gate.penalize.assert_called()

--- a/tests/providers/test_jira_client_ratelimit.py
+++ b/tests/providers/test_jira_client_ratelimit.py
@@ -10,21 +10,27 @@ from dev_health_ops.connectors.utils.rate_limit_queue import RateLimitGate
 from dev_health_ops.providers.jira.client import JiraAuth, JiraClient
 
 
-class _FakeJira429Response:
-    status_code = 429
-    headers = {"Retry-After": "2"}
-    text = "rate limited"
+class _FakeJira429Response(requests.Response):
+    """Minimal requests.Response subclass that simulates a 429 reply."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.status_code = 429
+        self.headers["Retry-After"] = "2"
+        self._content = b"rate limited"
 
     def raise_for_status(self) -> None:
         error = requests.HTTPError("429 Client Error")
         error.response = self
         raise error
 
-    def json(self) -> dict[str, Any]:
+    def json(self, **kwargs: Any) -> Any:
         return {}
 
 
-def test_jira_search_page_429_penalizes_once_without_outer_retry() -> None:
+def test_jira_search_page_429_penalizes_once_without_outer_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     gate = MagicMock(spec=RateLimitGate)
     gate.penalize.return_value = 2.0
     client = JiraClient(
@@ -35,12 +41,13 @@ def test_jira_search_page_429_penalizes_once_without_outer_retry() -> None:
         ),
         gate=gate,
     )
-    client.session.get = MagicMock(return_value=_FakeJira429Response())
+    mock_get = MagicMock(return_value=_FakeJira429Response())
+    monkeypatch.setattr(client.session, "get", mock_get)
 
     with pytest.raises(requests.HTTPError):
         client.search_issues_page(jql="project = ENG", start_at=0, max_results=50)
 
-    client.session.get.assert_called_once()
+    mock_get.assert_called_once()
     gate.wait_sync.assert_called_once()
     gate.penalize.assert_called_once_with(2.0)
     gate.reset.assert_not_called()

--- a/tests/providers/test_jira_client_ratelimit.py
+++ b/tests/providers/test_jira_client_ratelimit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -28,26 +29,66 @@ class _FakeJira429Response(requests.Response):
         return {}
 
 
-def test_jira_search_page_429_penalizes_once_without_outer_retry(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    gate = MagicMock(spec=RateLimitGate)
-    gate.penalize.return_value = 2.0
-    client = JiraClient(
+class _FakeJira200Response(requests.Response):
+    """Minimal requests.Response subclass that simulates a successful reply."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        super().__init__()
+        self.status_code = 200
+        self._content = json.dumps(payload).encode("utf-8")
+
+
+def _make_client(gate: Any, **kwargs: Any) -> JiraClient:
+    return JiraClient(
         auth=JiraAuth(
             base_url="https://example.atlassian.net",
             email="bot@example.com",
             api_token="token",
         ),
         gate=gate,
+        **kwargs,
     )
+
+
+def test_jira_search_page_retries_after_429_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A single 429 must back off through the shared gate and retry, NOT abort the
+    # whole sync (CHAOS-2463). The bounded retry lives only in _request_json, so
+    # there is exactly one retry owner (no decorator x gate stampede).
+    gate = MagicMock(spec=RateLimitGate)
+    gate.penalize.return_value = 2.0
+    client = _make_client(gate)
+    payload = {"issues": [], "total": 0}
+    mock_get = MagicMock(
+        side_effect=[_FakeJira429Response(), _FakeJira200Response(payload)]
+    )
+    monkeypatch.setattr(client.session, "get", mock_get)
+
+    result = client.search_issues_page(jql="project = ENG", start_at=0, max_results=50)
+
+    assert result == payload
+    assert mock_get.call_count == 2
+    assert gate.wait_sync.call_count == 2
+    gate.penalize.assert_called_once_with(2.0)
+    gate.reset.assert_called_once()
+
+
+def test_jira_search_page_persistent_429_exhausts_retries_and_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # When 429s never clear, the request is penalized once per attempt and then
+    # surfaces as an HTTPError after the bounded retries are exhausted.
+    gate = MagicMock(spec=RateLimitGate)
+    gate.penalize.return_value = 2.0
+    client = _make_client(gate, max_retries_429=2)
     mock_get = MagicMock(return_value=_FakeJira429Response())
     monkeypatch.setattr(client.session, "get", mock_get)
 
     with pytest.raises(requests.HTTPError):
         client.search_issues_page(jql="project = ENG", start_at=0, max_results=50)
 
-    mock_get.assert_called_once()
-    gate.wait_sync.assert_called_once()
-    gate.penalize.assert_called_once_with(2.0)
+    assert mock_get.call_count == 3
+    assert gate.wait_sync.call_count == 3
+    assert gate.penalize.call_count == 3
     gate.reset.assert_not_called()

--- a/tests/providers/test_jira_client_ratelimit.py
+++ b/tests/providers/test_jira_client_ratelimit.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from dev_health_ops.connectors.utils.rate_limit_queue import RateLimitGate
+from dev_health_ops.providers.jira.client import JiraAuth, JiraClient
+
+
+class _FakeJira429Response:
+    status_code = 429
+    headers = {"Retry-After": "2"}
+    text = "rate limited"
+
+    def raise_for_status(self) -> None:
+        error = requests.HTTPError("429 Client Error")
+        error.response = self
+        raise error
+
+    def json(self) -> dict[str, Any]:
+        return {}
+
+
+def test_jira_search_page_429_penalizes_once_without_outer_retry() -> None:
+    gate = MagicMock(spec=RateLimitGate)
+    gate.penalize.return_value = 2.0
+    client = JiraClient(
+        auth=JiraAuth(
+            base_url="https://example.atlassian.net",
+            email="bot@example.com",
+            api_token="token",
+        ),
+        gate=gate,
+    )
+    client.session.get = MagicMock(return_value=_FakeJira429Response())
+
+    with pytest.raises(requests.HTTPError):
+        client.search_issues_page(jql="project = ENG", start_at=0, max_results=50)
+
+    client.session.get.assert_called_once()
+    gate.wait_sync.assert_called_once()
+    gate.penalize.assert_called_once_with(2.0)
+    gate.reset.assert_not_called()

--- a/tests/test_distributed_rate_limit.py
+++ b/tests/test_distributed_rate_limit.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import hashlib
+import asyncio
 import time
 from unittest.mock import MagicMock, patch
 
@@ -12,7 +12,6 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
     DistributedRateLimitGate,
     RateLimitConfig,
     RateLimitGate,
-    _token_hash,
     create_rate_limit_gate,
 )
 
@@ -26,35 +25,54 @@ def _make_redis_mock(*, script_load_ok: bool = True) -> MagicMock:
     return client
 
 
+class _SharedRedisStub:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    def script_load(self, _script: str) -> str:
+        return "fake_sha"
+
+    def evalsha(
+        self, _sha: str, _num_keys: int, key: str, proposed: str, _ttl: str
+    ) -> str:
+        current = float(self.store.get(key, "0"))
+        value = max(current, float(proposed))
+        self.store[key] = str(value)
+        return str(value)
+
+    def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    def delete(self, key: str) -> None:
+        self.store.pop(key, None)
+
+
 class TestTokenHash:
-    def test_consistent_output(self):
-        assert _token_hash("my-secret") == _token_hash("my-secret")
+    def test_key_uses_provider_org_and_host(self):
+        client = _make_redis_mock()
+        gate = DistributedRateLimitGate(
+            "github", org_id="org-1", host="api.github.com", redis_client=client
+        )
+        assert gate._redis_key == "rate_limit:github:org-1:api.github.com"
 
-    def test_length_is_8(self):
-        assert len(_token_hash("anything")) == 8
-
-    def test_matches_sha256_prefix(self):
-        token = "ghp_abc123"
-        expected = hashlib.sha256(token.encode()).hexdigest()[:8]
-        assert _token_hash(token) == expected
-
-    def test_different_tokens_differ(self):
-        assert _token_hash("token-a") != _token_hash("token-b")
+    def test_key_uses_stable_sentinel_for_missing_parts(self):
+        client = _make_redis_mock()
+        gate = DistributedRateLimitGate("github", redis_client=client)
+        assert gate._redis_key == "rate_limit:github:_:_"
 
 
 class TestDistributedGateInit:
     def test_redis_key_without_token(self):
         client = _make_redis_mock()
         gate = DistributedRateLimitGate("github", redis_client=client)
-        assert gate._redis_key == "rate_limit:github"
+        assert gate._redis_key == "rate_limit:github:_:_"
 
     def test_redis_key_with_token(self):
         client = _make_redis_mock()
         gate = DistributedRateLimitGate(
             "github", token_hint="ghp_abc", redis_client=client
         )
-        expected_hash = _token_hash("ghp_abc")
-        assert gate._redis_key == f"rate_limit:github:{expected_hash}"
+        assert gate._redis_key == "rate_limit:github:_:ghp_abc"
 
     def test_ttl_is_2x_max_backoff(self):
         cfg = RateLimitConfig(max_backoff_seconds=600.0)
@@ -91,7 +109,7 @@ class TestDistributedPenalize:
         args = client.evalsha.call_args
         assert args[0][0] == "fake_sha"
         assert args[0][1] == 1
-        assert args[0][2] == "rate_limit:gh"
+        assert args[0][2] == "rate_limit:gh:_:_"
 
     def test_penalize_exponential_backoff(self):
         cfg = RateLimitConfig(initial_backoff_seconds=2.0, backoff_factor=3.0)
@@ -183,6 +201,32 @@ class TestDistributedGatePenalizeClamping:
 
 
 class TestDistributedSleepSeconds:
+    def test_same_provider_org_host_share_backoff_window(self):
+        redis = _SharedRedisStub()
+        first = DistributedRateLimitGate(
+            "github", org_id="org-1", host="api.github.com", redis_client=redis
+        )
+        second = DistributedRateLimitGate(
+            "github", org_id="org-1", host="api.github.com", redis_client=redis
+        )
+
+        first.penalize(10.0)
+
+        assert second._sleep_seconds() == pytest.approx(10.0, abs=0.5)
+
+    def test_different_org_has_independent_backoff_window(self):
+        redis = _SharedRedisStub()
+        first = DistributedRateLimitGate(
+            "github", org_id="org-1", host="api.github.com", redis_client=redis
+        )
+        second = DistributedRateLimitGate(
+            "github", org_id="org-2", host="api.github.com", redis_client=redis
+        )
+
+        first.penalize(10.0)
+
+        assert second._sleep_seconds() == 0.0
+
     def test_reads_from_redis(self):
         client = _make_redis_mock()
         future = time.time() + 5.0
@@ -191,7 +235,7 @@ class TestDistributedSleepSeconds:
 
         seconds = gate._sleep_seconds()
         assert 4.0 < seconds <= 5.0
-        client.get.assert_called_once_with("rate_limit:gh")
+        client.get.assert_called_once_with("rate_limit:gh:_:_")
 
     def test_returns_zero_when_key_missing(self):
         client = _make_redis_mock()
@@ -224,8 +268,7 @@ class TestDistributedWait:
             mock_sleep.assert_called_once()
             assert mock_sleep.call_args[0][0] > 0
 
-    @pytest.mark.asyncio
-    async def test_wait_async_sleeps(self):
+    def test_wait_async_sleeps(self):
         client = _make_redis_mock()
         client.get.return_value = str(time.time() + 0.05)
         gate = DistributedRateLimitGate("gh", redis_client=client)
@@ -237,7 +280,7 @@ class TestDistributedWait:
             "dev_health_ops.connectors.utils.rate_limit_queue.asyncio.sleep",
             side_effect=_noop,
         ) as mock_sleep:
-            await gate.wait_async()
+            asyncio.run(gate.wait_async())
             mock_sleep.assert_called_once()
 
 
@@ -246,7 +289,7 @@ class TestDistributedReset:
         client = _make_redis_mock()
         gate = DistributedRateLimitGate("gh", redis_client=client)
         gate.reset()
-        client.delete.assert_called_once_with("rate_limit:gh")
+        client.delete.assert_called_once_with("rate_limit:gh:_:_")
 
     def test_reset_falls_back_on_redis_error(self):
         client = _make_redis_mock()
@@ -282,7 +325,7 @@ class TestLuaScript:
         args = client.evalsha.call_args[0]
         assert args[0] == "fake_sha"
         assert args[1] == 1
-        assert args[2] == "rate_limit:gh"
+        assert args[2] == "rate_limit:gh:_:_"
         proposed = float(args[3])
         assert proposed > time.time()
         ttl = int(args[4])
@@ -333,9 +376,22 @@ class TestFactory:
 
         with patch.dict("os.environ", {"REDIS_URL": "redis://localhost:6379"}):
             with patch("valkey.from_url", return_value=mock_redis):
-                gate = create_rate_limit_gate("github", "token123")
+                gate = create_rate_limit_gate("github", token_hint="token123")
 
         assert isinstance(gate, DistributedRateLimitGate)
+
+    def test_factory_uses_provider_org_host_key(self):
+        mock_redis = _make_redis_mock()
+        mock_redis.ping.return_value = True
+
+        with patch.dict("os.environ", {"REDIS_URL": "redis://localhost:6379"}):
+            with patch("valkey.from_url", return_value=mock_redis):
+                gate = create_rate_limit_gate(
+                    "gitlab", org_id="org-a", host="gitlab.example.com"
+                )
+
+        assert isinstance(gate, DistributedRateLimitGate)
+        assert gate._redis_key == "rate_limit:gitlab:org-a:gitlab.example.com"
 
     def test_returns_local_when_no_redis_url(self):
         with patch.dict("os.environ", {}, clear=True):

--- a/tests/test_linear_provider.py
+++ b/tests/test_linear_provider.py
@@ -937,6 +937,34 @@ class TestLinearProviderIngest:
 class TestLinearClientRetry:
     """Retry/backoff behaviour of LinearClient._execute (CHAOS-2280)."""
 
+    def test_default_gate_uses_linear_org_host_scope(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dev_health_ops.connectors.utils.rate_limit_queue import RateLimitGate
+        from dev_health_ops.providers.linear import client as linear_client_module
+        from dev_health_ops.providers.linear.client import LinearAuth, LinearClient
+
+        gate = RateLimitGate()
+        calls: list[dict[str, Any]] = []
+
+        def fake_create_rate_limit_gate(*args: Any, **kwargs: Any) -> RateLimitGate:
+            calls.append({"args": args, "kwargs": kwargs})
+            return gate
+
+        monkeypatch.setattr(
+            linear_client_module,
+            "create_rate_limit_gate",
+            fake_create_rate_limit_gate,
+        )
+
+        client = LinearClient(auth=LinearAuth(api_key="test-key"), org_id="org-1")
+
+        assert client.gate is gate
+        assert calls[0]["args"] == ("linear",)
+        assert calls[0]["kwargs"]["org_id"] == "org-1"
+        assert calls[0]["kwargs"]["host"] == "api.linear.app"
+        assert calls[0]["kwargs"]["config"].initial_backoff_seconds == 1.0
+
     @staticmethod
     def _make_client() -> Any:
         from dev_health_ops.providers.linear.client import LinearAuth, LinearClient

--- a/tests/test_linear_team_sync.py
+++ b/tests/test_linear_team_sync.py
@@ -421,6 +421,7 @@ class TestDiscoverLinear:
         ]
 
         service = TeamDiscoveryService.__new__(TeamDiscoveryService)
+        service.org_id = "test-org"
         result = asyncio.run(service.discover_linear(api_key="test-key"))
 
         assert len(result) == 2
@@ -446,6 +447,7 @@ class TestDiscoverLinear:
         mock_client.iter_teams.return_value = []
 
         service = TeamDiscoveryService.__new__(TeamDiscoveryService)
+        service.org_id = "test-org"
         result = asyncio.run(service.discover_linear(api_key="test-key"))
 
         assert result == []
@@ -471,6 +473,7 @@ class TestDiscoverLinear:
         ]
 
         service = TeamDiscoveryService.__new__(TeamDiscoveryService)
+        service.org_id = "test-org"
         result = asyncio.run(service.discover_linear(api_key="test-key"))
 
         assert len(result) == 1
@@ -499,6 +502,7 @@ class TestDiscoverLinear:
         ]
 
         service = TeamDiscoveryService.__new__(TeamDiscoveryService)
+        service.org_id = "test-org"
         asyncio.run(service.discover_linear(api_key="test-key"))
 
         # Context-manager protocol guarantees cleanup via __exit__

--- a/tests/test_recommendations_tombstone.py
+++ b/tests/test_recommendations_tombstone.py
@@ -126,7 +126,7 @@ def test_evaluate_state_mixes_fired_and_tombstones():
     )
     # Force only 'saturation' to fire; all other evaluators return None.
     evaluators = {
-        rid: (lambda s, n: fired_rec) if rid == "saturation" else (lambda s, n: None)
+        rid: (lambda s, n: fired_rec) if rid == "saturation" else (lambda s, n: None)  # type: ignore[return-value]
         for rid in RULE_EVALUATORS
     }
     engine = RuleEngine(

--- a/tests/test_recommendations_tombstone.py
+++ b/tests/test_recommendations_tombstone.py
@@ -126,7 +126,7 @@ def test_evaluate_state_mixes_fired_and_tombstones():
     )
     # Force only 'saturation' to fire; all other evaluators return None.
     evaluators = {
-        rid: (lambda s, n: fired_rec) if rid == "saturation" else (lambda s, n: None)  # type: ignore[return-value]
+        rid: (lambda s, n: fired_rec) if rid == "saturation" else (lambda s, n: None)
         for rid in RULE_EVALUATORS
     }
     engine = RuleEngine(

--- a/tests/test_team_members_bridge.py
+++ b/tests/test_team_members_bridge.py
@@ -125,6 +125,7 @@ class TestDiscoverMembersLinear:
         ]
 
         service = TeamMembershipService.__new__(TeamMembershipService)
+        service.org_id = "test-org"
         members = asyncio.run(
             service.discover_members_linear(api_key="k", team_key="ENG")
         )
@@ -151,6 +152,7 @@ class TestDiscoverMembersLinear:
         ]
 
         service = TeamMembershipService.__new__(TeamMembershipService)
+        service.org_id = "test-org"
         members = asyncio.run(
             service.discover_members_linear(api_key="k", team_key="ENG")
         )
@@ -177,6 +179,7 @@ class TestDiscoverMembersLinear:
         ]
 
         service = TeamMembershipService.__new__(TeamMembershipService)
+        service.org_id = "test-org"
 
         prefixed = asyncio.run(
             service.discover_members_linear(api_key="k", team_key="linear:ENG")


### PR DESCRIPTION
## Summary
Gate 2 of CHAOS-2305 (also closes CHAOS-2289). Celery `rate_limit='30/m'` is per worker process, so N replicas = N×limit against provider APIs. This routes every provider's live HTTP through the shared Redis-backed `DistributedRateLimitGate`, re-keyed `(provider, org_id, host)`, so parallel batch children and N replicas share one backoff window per integration.

## Changes
- `connectors/utils/rate_limit_queue.py`: `create_rate_limit_gate(provider, org_id, host, ...)`; Redis key `rate_limit:{provider}:{org_id}:{host}` with `_` sentinel fallback.
- `providers/{github,gitlab,jira,linear}/client.py`: use the shared distributed gate (no bare local `RateLimitGate` for live HTTP); previously-ungated GitLab list calls now gated.
- Jira: removed the outer `@retry_with_backoff` from paged/sprint methods so a 429 yields one coordinated gate backoff (no decorator×gate stampede).
- Linear: HTTP routed through the shared gate; bounded retries preserved.
- `api/services/configuration/*` + `providers/linear/provider.py`: thread `org_id` into client construction.
- LaunchDarkly intentionally deferred (legacy connector, already exemplary).

## Verification
- `pytest tests/test_distributed_rate_limit.py tests/providers/test_ratelimit.py tests/test_linear_provider.py tests/providers/test_jira_client_ratelimit.py` → 104 passed
- new test proves two clients sharing `(provider, org_id, host)` share one Redis backoff window; Jira no-double-retry test added
- grep confirms no bare `RateLimitGate(` in providers; `ruff` clean

Part of CHAOS-2305. Closes CHAOS-2463, CHAOS-2289.