### PR TITLE
chore(deploy): one-shot migrate + AUTO_RUN_MIGRATIONS=false on ops/compose.yml legacy stack (CHAOS-2464)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -95,7 +95,12 @@ services:
       start_period: 5s
 
   migrate:
-    image: ghcr.io/full-chaos/dev-hops-api:latest
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+      target: api
+      args:
+        SETUPTOOLS_SCM_PRETEND_VERSION: 0.0.0
     container_name: dev-health-migrate
     restart: "no"
     entrypoint:
@@ -109,6 +114,8 @@ services:
       CLICKHOUSE_URI: clickhouse://ch:ch@clickhouse:8123/${CLICKHOUSE_DB:-default}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
     depends_on:
+      postgres:
+        condition: service_healthy
       clickhouse:
         condition: service_healthy
 

--- a/compose.yml
+++ b/compose.yml
@@ -94,6 +94,24 @@ services:
       retries: 3
       start_period: 5s
 
+  migrate:
+    image: ghcr.io/full-chaos/dev-hops-api:latest
+    container_name: dev-health-migrate
+    restart: "no"
+    entrypoint:
+      - sh
+      - -c
+      - >-
+        if [ -n "$$POSTGRES_URI" ]; then dev-hops migrate postgres; fi
+        && dev-hops migrate clickhouse
+    environment:
+      POSTGRES_URI: postgresql+asyncpg://postgres:postgres@postgres:5432/${POSTGRES_DB:-postgres}
+      CLICKHOUSE_URI: clickhouse://ch:ch@clickhouse:8123/${CLICKHOUSE_DB:-default}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+
   api:
     build:
       context: .
@@ -120,6 +138,7 @@ services:
       # SAME change. Bare-image deployments must follow the two-phase rollout
       # in workers/queues.py: expand consumer -Q lists first, then flip this.
       PROVIDER_SYNC_QUEUES_ENABLED: "true"
+      AUTO_RUN_MIGRATIONS: "false"
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
       STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
       STRIPE_PRICE_ID_TEAM: ${STRIPE_PRICE_ID_TEAM:-}
@@ -145,6 +164,8 @@ services:
         condition: service_healthy
       valkey:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
       pgbouncer:
         condition: service_started
     ports:
@@ -183,9 +204,12 @@ services:
     environment:
       <<: *env
       POSTGRES_URI: "postgresql+asyncpg://postgres:postgres@pgbouncer:6432/postgres"
+      AUTO_RUN_MIGRATIONS: "false"
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
       pgbouncer:
         condition: service_started
     ports:
@@ -226,6 +250,7 @@ services:
       <<: *env
       CELERY_BROKER_URL: redis://valkey:6379/0
       CELERY_RESULT_BACKEND: redis://valkey:6379/0
+      AUTO_RUN_MIGRATIONS: "false"
       # Email (Resend) — worker sends billing emails via Celery task
       EMAIL_PROVIDER: ${EMAIL_PROVIDER:-console}
       EMAIL_API_KEY: ${EMAIL_API_KEY:-}
@@ -235,6 +260,8 @@ services:
         condition: service_healthy
       clickhouse:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
       pgbouncer:
         condition: service_started
     volumes:

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -126,6 +126,7 @@ def test_monitoring_queue_declared_and_consumed_redundantly() -> None:
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PROD_COMPOSE = _REPO_ROOT / "deploy" / "docker-compose" / "compose.production.yml"
+_LEGACY_COMPOSE = _REPO_ROOT / "compose.yml"
 _SWARM_STACK = _REPO_ROOT / "deploy" / "docker-swarm" / "stack.yml"
 _K8S_DIR = _REPO_ROOT / "deploy" / "kubernetes"
 _HELM_DIR = _REPO_ROOT / "deploy" / "helm" / "dev-health"
@@ -162,6 +163,35 @@ def test_production_compose_disables_ambient_migrations() -> None:
             f"{name} must set AUTO_RUN_MIGRATIONS=false — schema is applied by "
             f"the one-shot migrate service"
         )
+
+
+def test_legacy_compose_has_one_shot_migrate_service() -> None:
+    services = _load_yaml(_LEGACY_COMPOSE)["services"]
+    migrate = services.get("migrate")
+    assert migrate is not None, "compose.yml must define a migrate service"
+    assert migrate.get("restart") == "no"
+    entrypoint = " ".join(str(p) for p in migrate["entrypoint"])
+    assert "dev-hops migrate clickhouse" in entrypoint
+    assert "dev-hops migrate postgres" in entrypoint
+
+
+def test_legacy_compose_disables_ambient_migrations() -> None:
+    services = _load_yaml(_LEGACY_COMPOSE)["services"]
+    for name in ("api", "billing-edge", "worker", "worker-ingest", "worker-heavy"):
+        env = services[name].get("environment") or {}
+        assert env.get("AUTO_RUN_MIGRATIONS") == "false", (
+            f"{name} must set AUTO_RUN_MIGRATIONS=false — schema is applied by "
+            f"the one-shot migrate service"
+        )
+
+
+def test_legacy_compose_app_services_gate_on_migrate() -> None:
+    services = _load_yaml(_LEGACY_COMPOSE)["services"]
+    for name in ("api", "billing-edge", "worker", "worker-ingest", "worker-heavy"):
+        deps = services[name].get("depends_on") or {}
+        assert (
+            deps.get("migrate", {}).get("condition") == "service_completed_successfully"
+        ), f"{name} must gate on migrate completing successfully"
 
 
 def test_swarm_stack_has_migrate_service_and_disables_ambient_migrations() -> None:

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -175,6 +175,25 @@ def test_legacy_compose_has_one_shot_migrate_service() -> None:
     assert "dev-hops migrate postgres" in entrypoint
 
 
+def test_legacy_compose_migrate_waits_for_postgres_health() -> None:
+    services = _load_yaml(_LEGACY_COMPOSE)["services"]
+    migrate = services["migrate"]
+
+    depends_on = migrate.get("depends_on") or {}
+    assert depends_on.get("postgres", {}).get("condition") == "service_healthy"
+    assert depends_on.get("clickhouse", {}).get("condition") == "service_healthy"
+
+
+def test_legacy_compose_migrate_uses_local_build_matching_api() -> None:
+    services = _load_yaml(_LEGACY_COMPOSE)["services"]
+    migrate = services["migrate"]
+    api = services["api"]
+
+    assert migrate.get("image") is None
+    assert isinstance(migrate.get("build"), dict)
+    assert migrate["build"] == api["build"]
+
+
 def test_legacy_compose_disables_ambient_migrations() -> None:
     services = _load_yaml(_LEGACY_COMPOSE)["services"]
     for name in ("api", "billing-edge", "worker", "worker-ingest", "worker-heavy"):


### PR DESCRIPTION
## Summary
Gate 3 of CHAOS-2305. CHAOS-2304 added a one-shot migrate step + `AUTO_RUN_MIGRATIONS=false` to the canonical stacks but missed the legacy `compose.yml`. N workers racing ambient migrations is data-loss territory. This brings `compose.yml` up to the canonical pattern.

## Changes
- `compose.yml`: one-shot `migrate` service (`dev-hops migrate postgres && dev-hops migrate clickhouse`, direct postgres), `AUTO_RUN_MIGRATIONS=false` on api/worker, `depends_on: migrate: service_completed_successfully`.
- `tests/test_compose_config.py`: assertions for the legacy stack's migrate service + flag + gating.

## Verification
- `pytest tests/test_compose_config.py` → 19 passed
- `ruff` clean

## Note
Two further legacy stacks (`deploy/compose/dev-health-stack.yml`, `deploy/k8s/dev-health-stack/stack.yml`) live at the platform root outside this repo's git tree. The equivalent migrate-gating was applied to them on disk but cannot be committed from this repo; they need to be committed in their owning location.

Part of CHAOS-2305. Closes CHAOS-2464.