### PR TITLE
fix(db): normalize postgres SSL params for asyncpg

### DIFF
--- a/src/dev_health_ops/db.py
+++ b/src/dev_health_ops/db.py
@@ -19,7 +19,7 @@ from typing import Any
 from uuid import uuid4
 
 from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Engine, make_url
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -108,10 +108,29 @@ def get_clickhouse_uri() -> str | None:
 def _ensure_async_postgres(uri: str) -> str:
     """Ensure semantic DB URIs use an async driver."""
     if uri.startswith("postgresql://"):
-        return uri.replace("postgresql://", "postgresql+asyncpg://", 1)
-    if uri.startswith("sqlite://") and not uri.startswith("sqlite+aiosqlite://"):
+        uri = uri.replace("postgresql://", "postgresql+asyncpg://", 1)
+    elif uri.startswith("sqlite://") and not uri.startswith("sqlite+aiosqlite://"):
         return uri.replace("sqlite://", "sqlite+aiosqlite://", 1)
-    return uri
+    return _normalize_asyncpg_postgres_query(uri)
+
+
+def _normalize_asyncpg_postgres_query(uri: str) -> str:
+    if not uri.startswith("postgresql+asyncpg://"):
+        return uri
+
+    url = make_url(uri)
+    query = dict(url.query)
+    original_query = query.copy()
+    sslmode = query.pop("sslmode", None)
+    query.pop("channel_binding", None)
+
+    if sslmode is not None and "ssl" not in query:
+        query["ssl"] = sslmode
+
+    if query == original_query:
+        return uri
+
+    return url.set(query=query).render_as_string(hide_password=False)
 
 
 def get_postgres_engine() -> AsyncEngine:

--- a/tests/test_db_pgbouncer.py
+++ b/tests/test_db_pgbouncer.py
@@ -76,6 +76,57 @@ class TestAsyncEngineKwargs:
         assert kw["max_overflow"] == 25
 
 
+class TestAsyncPostgresUrlNormalization:
+    def test_converts_plain_postgres_to_asyncpg(self):
+        uri = "postgresql://u:p@h/d"
+
+        assert db._ensure_async_postgres(uri) == "postgresql+asyncpg://u:p@h/d"
+
+    def test_translates_neon_sslmode_for_asyncpg(self):
+        uri = "postgresql://u:p@h/d?sslmode=require&channel_binding=require"
+
+        assert (
+            db._ensure_async_postgres(uri) == "postgresql+asyncpg://u:p@h/d?ssl=require"
+        )
+
+    def test_preserves_existing_asyncpg_ssl_query(self):
+        uri = "postgresql+asyncpg://u:p@h/d?ssl=true&sslmode=require"
+
+        assert db._ensure_async_postgres(uri) == "postgresql+asyncpg://u:p@h/d?ssl=true"
+
+    def test_strips_channel_binding_without_injecting_ssl(self):
+        uri = "postgresql://u:p@h/d?channel_binding=require"
+
+        assert db._ensure_async_postgres(uri) == "postgresql+asyncpg://u:p@h/d"
+
+    def test_preserves_asyncpg_uri_without_query(self):
+        uri = "postgresql+asyncpg://u:p@h/d"
+
+        assert db._ensure_async_postgres(uri) == uri
+
+    def test_preserves_asyncpg_ssl_query_without_sslmode(self):
+        uri = "postgresql+asyncpg://u:p@h/d?ssl=require"
+
+        assert db._ensure_async_postgres(uri) == uri
+
+    def test_existing_ssl_query_takes_precedence_over_sslmode(self):
+        uri = "postgresql+asyncpg://u:p@h/d?ssl=true&sslmode=verify-full"
+
+        assert db._ensure_async_postgres(uri) == "postgresql+asyncpg://u:p@h/d?ssl=true"
+
+    def test_preserves_asyncpg_supported_sslmode_values(self):
+        uri = "postgresql+asyncpg://u:p@h/d?sslmode=prefer"
+
+        assert (
+            db._ensure_async_postgres(uri) == "postgresql+asyncpg://u:p@h/d?ssl=prefer"
+        )
+
+    def test_preserves_non_postgres_uri(self):
+        uri = "clickhouse://u:p@h/d?sslmode=require"
+
+        assert db._ensure_async_postgres(uri) == uri
+
+
 class TestPoolSizeParsing:
     def test_defaults(self):
         assert db._pg_pool_size() == (20, 10)


### PR DESCRIPTION
## Summary
- normalize libpq-style `sslmode` to asyncpg-compatible `ssl` for semantic Postgres URLs
- strip `channel_binding` before SQLAlchemy passes query params into `asyncpg.connect()`
- add regression coverage for Neon-style URLs, existing `ssl` precedence, and non-Postgres passthrough

## Verification
- `PYTHONPATH=src pytest tests/test_db_pgbouncer.py tests/test_migrate.py -q`
- `ruff format --check src/dev_health_ops/db.py tests/test_db_pgbouncer.py`
- `ruff check src/dev_health_ops/db.py tests/test_db_pgbouncer.py`
- LSP diagnostics clean for changed files
- SQLAlchemy asyncpg dialect smoke check confirms no `sslmode` or `channel_binding` kwargs are passed through

## Review
- code-medium review completed; non-blocking suggestions were addressed with additional edge tests

SCREENSHOT-WAIVER: backend-only DB URL normalization; no rendered frontend output changes.