### PR TITLE
feat(integrations): frictionless GitHub App install + webhooks (CHAOS-2235, CHAOS-2236)

### DIFF
--- a/src/dev_health_ops/alembic/versions/0014_add_github_app_installations.py
+++ b/src/dev_health_ops/alembic/versions/0014_add_github_app_installations.py
@@ -1,0 +1,70 @@
+"""Add github_app_installations table for frictionless GitHub App install.
+
+Revision ID: 0014
+Revises: 0013
+Create Date: 2026-06-16 00:00:00
+
+Maps a GitHub App ``installation_id`` to a Dev Health organization so the
+one-click install flow (signed-state callback + ``installation`` webhook) can
+persist the installation lifecycle. The App-mode credential the sync pipeline
+consumes is still written to ``integration_credentials``; this table only tracks
+the installation -> org link and its suspended/active state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0014"
+down_revision: str | None = "0013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_TABLE = "github_app_installations"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("installation_id", sa.BigInteger(), nullable=False),
+        sa.Column("account_login", sa.Text(), nullable=True),
+        sa.Column("account_type", sa.Text(), nullable=True),
+        sa.Column("org_id", sa.Text(), nullable=True),
+        sa.Column("suspended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_github_app_installations_installation_id",
+        _TABLE,
+        ["installation_id"],
+        unique=True,
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_github_app_installations_org_id",
+        _TABLE,
+        ["org_id"],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_github_app_installations_org_id", table_name=_TABLE, if_exists=True
+    )
+    op.drop_index(
+        "ix_github_app_installations_installation_id",
+        table_name=_TABLE,
+        if_exists=True,
+    )
+    op.drop_table(_TABLE, if_exists=True)

--- a/src/dev_health_ops/api/admin/router.py
+++ b/src/dev_health_ops/api/admin/router.py
@@ -9,6 +9,7 @@ from .routers import (
     features_router,
     get_session,
     get_user_id,
+    github_app_router,
     governance_router,
     identities_router,
     orgs_router,
@@ -41,6 +42,7 @@ router.include_router(users_router)
 router.include_router(orgs_router)
 router.include_router(platform_router)
 router.include_router(features_router)
+router.include_router(github_app_router)
 router.include_router(governance_router)
 
 __all__ = [

--- a/src/dev_health_ops/api/admin/routers/__init__.py
+++ b/src/dev_health_ops/api/admin/routers/__init__.py
@@ -9,6 +9,7 @@ from .credentials import (
     router as credentials_router,
 )
 from .features import router as features_router
+from .github_app import router as github_app_router
 from .governance import router as governance_router
 from .identities import router as identities_router
 from .orgs import router as orgs_router
@@ -23,6 +24,7 @@ __all__ = [
     "features_router",
     "get_session",
     "get_user_id",
+    "github_app_router",
     "governance_router",
     "identities_router",
     "orgs_router",

--- a/src/dev_health_ops/api/admin/routers/github_app.py
+++ b/src/dev_health_ops/api/admin/routers/github_app.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import quote, urlencode
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import or_, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.admin.middleware import get_admin_org_id
+from dev_health_ops.api.integrations.github_app_config import (
+    github_app_client_id,
+    github_app_client_secret,
+    github_app_id,
+    github_app_private_key,
+    github_app_slug,
+)
+from dev_health_ops.api.integrations.github_app_state import (
+    GITHUB_APP_STATE_TTL_MINUTES,
+    GitHubAppStateError,
+    mint_github_app_install_state,
+    verify_github_app_install_state,
+)
+from dev_health_ops.api.services.configuration import IntegrationCredentialsService
+from dev_health_ops.core.cache import create_cache
+from dev_health_ops.models.settings import GithubAppInstallation
+
+from .common import get_session
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class GitHubInstallUrlResponse(BaseModel):
+    install_url: str
+
+
+class GitHubInstallCallbackRequest(BaseModel):
+    installation_id: int = Field(..., ge=1)
+    setup_action: str | None = None
+    state: str
+    code: str | None = None
+
+
+class GitHubInstallCallbackResponse(BaseModel):
+    connected: bool
+    installation_id: int
+    credential_name: str
+
+
+@router.post(
+    "/integrations/github/install-url",
+    response_model=GitHubInstallUrlResponse,
+)
+async def create_github_install_url(
+    org_id: str = Depends(get_admin_org_id),
+) -> GitHubInstallUrlResponse:
+    slug = github_app_slug()
+    if not slug:
+        raise HTTPException(status_code=400, detail="GITHUB_APP_SLUG is not configured")
+    state = mint_github_app_install_state(org_id)
+    query = urlencode({"state": state})
+    install_url = (
+        f"https://github.com/apps/{quote(slug, safe='')}/installations/new?{query}"
+    )
+    return GitHubInstallUrlResponse(install_url=install_url)
+
+
+@router.post(
+    "/integrations/github/install-callback",
+    response_model=GitHubInstallCallbackResponse,
+)
+async def complete_github_install(
+    body: GitHubInstallCallbackRequest,
+    session: AsyncSession = Depends(get_session),
+    admin_org_id: str = Depends(get_admin_org_id),
+) -> GitHubInstallCallbackResponse:
+    try:
+        verified_state = verify_github_app_install_state(body.state)
+    except GitHubAppStateError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if verified_state.org_id != admin_org_id:
+        raise HTTPException(status_code=403, detail="GitHub App state org mismatch")
+    if not body.code:
+        raise HTTPException(
+            status_code=400,
+            detail="GitHub user authorization is required to complete the install; enable 'Request user authorization (OAuth) during installation' on the App",
+        )
+    _consume_install_state_jti(verified_state.jti)
+
+    app_id = github_app_id()
+    try:
+        private_key = github_app_private_key()
+    except OSError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="GITHUB_APP_PRIVATE_KEY_PATH could not be read",
+        ) from exc
+    if not app_id or not private_key:
+        raise HTTPException(
+            status_code=500,
+            detail="GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY or GITHUB_APP_PRIVATE_KEY_PATH are required",
+        )
+    verified_installation = await _verify_installer_installation_access(
+        body.installation_id, body.code
+    )
+
+    await _upsert_installation(
+        session=session,
+        installation_id=body.installation_id,
+        org_id=admin_org_id,
+        account_login=_account_field(verified_installation, "login"),
+        account_type=_account_field(verified_installation, "type"),
+    )
+
+    svc = IntegrationCredentialsService(session, admin_org_id)
+    await svc.set(
+        provider="github",
+        name="github-app",
+        credentials={
+            "app_id": app_id,
+            "private_key": private_key,
+            "installation_id": str(body.installation_id),
+        },
+        config={
+            "auth_mode": "github_app",
+            "installation_id": body.installation_id,
+            "setup_action": body.setup_action,
+        },
+        is_active=True,
+    )
+    return GitHubInstallCallbackResponse(
+        connected=True,
+        installation_id=body.installation_id,
+        credential_name="github-app",
+    )
+
+
+async def _upsert_installation(
+    session: AsyncSession,
+    installation_id: int,
+    org_id: str,
+    account_login: str | None,
+    account_type: str | None,
+) -> GithubAppInstallation:
+    now = datetime.now(timezone.utc)
+    existing_id = (
+        await session.execute(
+            select(GithubAppInstallation.id).where(
+                GithubAppInstallation.installation_id == installation_id
+            )
+        )
+    ).scalar_one_or_none()
+    if existing_id is None:
+        try:
+            async with session.begin_nested():
+                installation = GithubAppInstallation()
+                installation.installation_id = installation_id
+                installation.created_at = now
+                installation.org_id = org_id
+                installation.account_login = account_login
+                installation.account_type = account_type
+                installation.suspended_at = None
+                installation.updated_at = now
+                session.add(installation)
+                await session.flush()
+                return installation
+        except IntegrityError as exc:
+            raced = (
+                await session.execute(
+                    select(GithubAppInstallation).where(
+                        GithubAppInstallation.installation_id == installation_id
+                    )
+                )
+            ).scalar_one_or_none()
+            if raced is None:
+                raise exc
+
+    claim_result = await session.execute(
+        update(GithubAppInstallation)
+        .where(
+            GithubAppInstallation.installation_id == installation_id,
+            or_(
+                GithubAppInstallation.org_id.is_(None),
+                GithubAppInstallation.org_id == org_id,
+            ),
+        )
+        .values(
+            org_id=org_id,
+            account_login=account_login,
+            account_type=account_type,
+            suspended_at=None,
+            updated_at=now,
+        )
+    )
+    if getattr(claim_result, "rowcount", 0) == 0:
+        raise HTTPException(
+            status_code=409,
+            detail="installation already linked to another organization",
+        )
+    await session.flush()
+    claimed = (
+        await session.execute(
+            select(GithubAppInstallation).where(
+                GithubAppInstallation.installation_id == installation_id
+            )
+        )
+    ).scalar_one()
+    return claimed
+
+
+def _consume_install_state_jti(jti: str) -> None:
+    # Primary replay protection is GitHub's single-use OAuth code; this cache is defense-in-depth.
+    cache_key = f"github_app_install_state:{jti}"
+    try:
+        cache = create_cache(ttl_seconds=GITHUB_APP_STATE_TTL_MINUTES * 60)
+        if cache.get(cache_key) is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="GitHub App installation state already used",
+            )
+        cache.set(cache_key, "used")
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "GitHub App installation state replay cache unavailable: %s", exc
+        )
+
+
+async def _verify_installer_installation_access(
+    installation_id: int,
+    code: str,
+) -> dict[str, Any]:
+    client_id = github_app_client_id()
+    client_secret = github_app_client_secret()
+    if not client_id or not client_secret:
+        raise HTTPException(
+            status_code=500,
+            detail="GitHub App OAuth client credentials are required",
+        )
+    async with httpx.AsyncClient(timeout=10) as client:
+        token_response = await client.post(
+            "https://github.com/login/oauth/access_token",
+            headers={"Accept": "application/json"},
+            data={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "code": code,
+            },
+        )
+        if token_response.status_code >= 400:
+            raise HTTPException(
+                status_code=400,
+                detail="GitHub user authorization could not be verified",
+            )
+        token_payload = token_response.json()
+        access_token = token_payload.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise HTTPException(
+                status_code=400,
+                detail="GitHub user authorization could not be verified",
+            )
+        return await _find_accessible_installation(
+            client, access_token, installation_id
+        )
+
+
+async def _find_accessible_installation(
+    client: httpx.AsyncClient,
+    access_token: str,
+    installation_id: int,
+) -> dict[str, Any]:
+    page = 1
+    while True:
+        response = await client.get(
+            "https://api.github.com/user/installations",
+            params={"per_page": 100, "page": page},
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        if response.status_code >= 400:
+            raise HTTPException(
+                status_code=400,
+                detail="GitHub user authorization could not be verified",
+            )
+        payload = response.json()
+        installations = payload.get("installations")
+        if not isinstance(installations, list):
+            raise HTTPException(
+                status_code=400,
+                detail="GitHub user authorization could not be verified",
+            )
+        for installation in installations:
+            if (
+                isinstance(installation, dict)
+                and installation.get("id") == installation_id
+            ):
+                return installation
+        if len(installations) < 100:
+            break
+        page += 1
+    raise HTTPException(
+        status_code=403,
+        detail="installer does not have access to this GitHub App installation",
+    )
+
+
+def _account_field(installation: dict[str, Any], field: str) -> str | None:
+    account = installation.get("account")
+    if not isinstance(account, dict):
+        return None
+    value = account.get(field)
+    return value if isinstance(value, str) else None

--- a/src/dev_health_ops/api/integrations/github_app_config.py
+++ b/src/dev_health_ops/api/integrations/github_app_config.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def github_app_slug() -> str | None:
+    return os.getenv("GITHUB_APP_SLUG")
+
+
+def github_app_id() -> str | None:
+    return os.getenv("GITHUB_APP_ID")
+
+
+def github_app_private_key() -> str | None:
+    inline_key = os.getenv("GITHUB_APP_PRIVATE_KEY")
+    if inline_key:
+        return inline_key
+    key_path = os.getenv("GITHUB_APP_PRIVATE_KEY_PATH")
+    if key_path:
+        return Path(key_path).read_text(encoding="utf-8")
+    return None
+
+
+def github_app_client_id() -> str | None:
+    return os.getenv("GITHUB_APP_CLIENT_ID")
+
+
+def github_app_client_secret() -> str | None:
+    return os.getenv("GITHUB_APP_CLIENT_SECRET")

--- a/src/dev_health_ops/api/integrations/github_app_state.py
+++ b/src/dev_health_ops/api/integrations/github_app_state.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import jwt
+from jwt.exceptions import InvalidTokenError
+
+from dev_health_ops.api.services.auth import (
+    JWT_ALGORITHM,
+    JWT_AUDIENCE,
+    JWT_ISSUER,
+    _get_jwt_secret,
+)
+
+GITHUB_APP_INSTALL_PURPOSE = "github_app_install"
+GITHUB_APP_STATE_TTL_MINUTES = 15
+
+
+class GitHubAppStateError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class GitHubAppInstallState:
+    org_id: str
+    jti: str
+
+
+def mint_github_app_install_state(org_id: str) -> str:
+    now = datetime.now(timezone.utc)
+    payload: dict[str, Any] = {
+        "org_id": org_id,
+        "jti": uuid.uuid4().hex,
+        "purpose": GITHUB_APP_INSTALL_PURPOSE,
+        "iss": JWT_ISSUER,
+        "aud": JWT_AUDIENCE,
+        "iat": now,
+        "exp": now + timedelta(minutes=GITHUB_APP_STATE_TTL_MINUTES),
+    }
+    return jwt.encode(payload, _get_jwt_secret(), algorithm=JWT_ALGORITHM)
+
+
+def verify_github_app_install_state(state: str) -> GitHubAppInstallState:
+    try:
+        payload = jwt.decode(
+            state,
+            _get_jwt_secret(),
+            algorithms=[JWT_ALGORITHM],
+            issuer=JWT_ISSUER,
+            audience=JWT_AUDIENCE,
+        )
+    except InvalidTokenError as exc:
+        raise GitHubAppStateError("Invalid GitHub App installation state") from exc
+
+    if payload.get("purpose") != GITHUB_APP_INSTALL_PURPOSE:
+        raise GitHubAppStateError("Invalid GitHub App installation state purpose")
+    org_id = payload.get("org_id")
+    if not isinstance(org_id, str) or not org_id:
+        raise GitHubAppStateError("Invalid GitHub App installation organization")
+    jti = payload.get("jti")
+    if not isinstance(jti, str) or not jti:
+        raise GitHubAppStateError("Invalid GitHub App installation state identifier")
+    return GitHubAppInstallState(org_id=org_id, jti=jti)

--- a/src/dev_health_ops/api/webhooks/models.py
+++ b/src/dev_health_ops/api/webhooks/models.py
@@ -42,6 +42,9 @@ class WebhookEventType(str, Enum):
     DEPLOYMENT = "deployment"
     CHECK_RUN = "check_run"
 
+    INSTALLATION = "installation"
+    MARKETPLACE_PURCHASE = "marketplace_purchase"
+
     # Unknown/unsupported
     UNKNOWN = "unknown"
 
@@ -129,6 +132,9 @@ GITHUB_EVENT_MAP: dict[str, WebhookEventType] = {
     "deployment_status": WebhookEventType.DEPLOYMENT,
     "check_run": WebhookEventType.CHECK_RUN,
     "check_suite": WebhookEventType.CHECK_RUN,
+    "installation": WebhookEventType.INSTALLATION,
+    "installation_repositories": WebhookEventType.INSTALLATION,
+    "marketplace_purchase": WebhookEventType.MARKETPLACE_PURCHASE,
 }
 
 GITLAB_EVENT_MAP: dict[str, WebhookEventType] = {

--- a/src/dev_health_ops/models/__init__.py
+++ b/src/dev_health_ops/models/__init__.py
@@ -38,6 +38,7 @@ from .retention import (
     RetentionResourceType,
 )
 from .settings import (
+    GithubAppInstallation,
     IdentityMapping,
     IntegrationCredential,
     IntegrationProvider,
@@ -96,6 +97,7 @@ __all__ = [
     "GitCommit",
     "GitCommitStat",
     "GitFile",
+    "GithubAppInstallation",
     "IdentityMapping",
     "IntegrationCredential",
     "IntegrationProvider",

--- a/src/dev_health_ops/models/settings.py
+++ b/src/dev_health_ops/models/settings.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     Boolean,
     DateTime,
     ForeignKey,
@@ -204,6 +205,42 @@ class IntegrationCredential(Base):
         self.config = config or {}
         self.created_at = datetime.now(timezone.utc)
         self.updated_at = datetime.now(timezone.utc)
+
+
+class GithubAppInstallation(Base):
+    """Mapping of a GitHub App installation to a Dev Health organization.
+
+    Captures the installation lifecycle (created / deleted / suspend /
+    unsuspend) reported via the ``installation`` webhook, plus the link from
+    ``installation_id`` to an org established by the signed-state install
+    callback. The App-mode credential the sync pipeline consumes is written
+    separately to ``integration_credentials`` using the server-held App
+    private key (never an end-user secret).
+    """
+
+    __tablename__ = "github_app_installations"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    installation_id: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, unique=True, index=True
+    )
+    account_login: Mapped[str | None] = mapped_column(Text, nullable=True)
+    account_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    org_id: Mapped[str | None] = mapped_column(Text, nullable=True, index=True)
+    suspended_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
 
 
 class SyncConfiguration(Base):

--- a/src/dev_health_ops/workers/system_webhooks.py
+++ b/src/dev_health_ops/workers/system_webhooks.py
@@ -66,7 +66,6 @@ def process_webhook_event(
                     "reason": "duplicate_delivery",
                     "delivery_id": delivery_id,
                 }
-            _record_delivery(provider, delivery_id)
 
         if provider == "github":
             result = _process_github_event(event_type, payload, org_id, repo_name)
@@ -80,6 +79,9 @@ def process_webhook_event(
 
         if org_id is not None:
             _invalidate_sync_cache(provider, org_id)
+
+        if delivery_id and result.get("processed") is not False:
+            _record_delivery(provider, delivery_id)
 
         return {
             "status": "success",
@@ -142,6 +144,13 @@ def _process_github_event(
     """Process a GitHub webhook event."""
     if not payload:
         return {"processed": False, "reason": "empty_payload"}
+
+    if event_type == "installation":
+        return _process_github_installation_event(payload)
+    if event_type == "marketplace_purchase":
+        logger.info("Received GitHub marketplace_purchase webhook")
+        # CHAOS-2236: entitlement mapping deferred
+        return {"processed": True, "event": event_type}
 
     # Import specialized sync processors
     from dev_health_ops.processors.github import process_github_repo
@@ -225,6 +234,84 @@ def _process_github_event(
     except Exception as e:
         logger.error("Failed to process GitHub webhook %s: %s", event_type, e)
         return {"processed": False, "error": str(e)}
+
+
+def _process_github_installation_event(payload: dict) -> dict:
+    installation_payload = payload.get("installation") or {}
+    installation_id = installation_payload.get("id")
+    if not isinstance(installation_id, int):
+        return {"processed": False, "reason": "missing_installation_id"}
+
+    account_payload = installation_payload.get("account") or {}
+    action = payload.get("action")
+    now = datetime.now(timezone.utc)
+
+    from sqlalchemy import select
+    from sqlalchemy.exc import IntegrityError
+
+    from dev_health_ops.db import get_postgres_session_sync
+    from dev_health_ops.models.settings import (
+        GithubAppInstallation,
+        IntegrationCredential,
+    )
+
+    with get_postgres_session_sync() as session:
+        result = session.execute(
+            select(GithubAppInstallation).where(
+                GithubAppInstallation.installation_id == installation_id
+            )
+        )
+        installation = result.scalar_one_or_none()
+        if installation is None:
+            try:
+                with session.begin_nested():
+                    installation = GithubAppInstallation()
+                    installation.installation_id = installation_id
+                    installation.created_at = now
+                    session.add(installation)
+                    session.flush()
+            except IntegrityError as exc:
+                result = session.execute(
+                    select(GithubAppInstallation).where(
+                        GithubAppInstallation.installation_id == installation_id
+                    )
+                )
+                installation = result.scalar_one_or_none()
+                if installation is None:
+                    raise exc
+
+        login = account_payload.get("login")
+        if isinstance(login, str):
+            installation.account_login = login
+        account_type = account_payload.get("type")
+        if isinstance(account_type, str):
+            installation.account_type = account_type
+        if action in {"created", "unsuspend"}:
+            installation.suspended_at = None
+        elif action in {"suspend", "deleted"}:
+            installation.suspended_at = now
+        installation.updated_at = now
+
+        if action == "deleted" and installation.org_id:
+            credential_result = session.execute(
+                select(IntegrationCredential).where(
+                    IntegrationCredential.org_id == installation.org_id,
+                    IntegrationCredential.provider == "github",
+                    IntegrationCredential.name == "github-app",
+                )
+            )
+            credential = credential_result.scalar_one_or_none()
+            if credential is not None:
+                credential.is_active = False
+                credential.updated_at = now
+        session.flush()
+
+    return {
+        "processed": True,
+        "event": "installation",
+        "installation_id": installation_id,
+        "action": action,
+    }
 
 
 def _process_gitlab_event(

--- a/tests/api/admin/test_github_app_install.py
+++ b/tests/api/admin/test_github_app_install.py
@@ -1,0 +1,543 @@
+from __future__ import annotations
+
+import importlib
+import uuid
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.integrations.github_app_state import (
+    mint_github_app_install_state,
+    verify_github_app_install_state,
+)
+from dev_health_ops.api.services.configuration import IntegrationCredentialsService
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import GithubAppInstallation, IntegrationCredential
+from tests._helpers import tables_of
+
+github_app_router_module = importlib.import_module(
+    "dev_health_ops.api.admin.routers.github_app"
+)
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "s" * 32)
+    monkeypatch.setenv("JWT_SECRET_KEY", "j" * 32)
+    db_path = tmp_path / "github-app-install.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(GithubAppInstallation, IntegrationCredential),
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+def _app(session_maker, org_id: str) -> FastAPI:
+    app = FastAPI()
+    app.include_router(github_app_router_module.router, prefix="/admin")
+
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+            await session.commit()
+
+    app.dependency_overrides[github_app_router_module.get_session] = _session_override
+    app.dependency_overrides[github_app_router_module.get_admin_org_id] = lambda: org_id
+    return app
+
+
+class FakeGitHubResponse:
+    def __init__(self, status_code: int, payload: dict | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class FakeGitHubClient:
+    def __init__(
+        self,
+        token_responses: list[FakeGitHubResponse],
+        installations_response: FakeGitHubResponse,
+    ):
+        self.token_responses = token_responses
+        self.installations_response = installations_response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def post(self, url: str, headers: dict, data: dict):
+        assert url == "https://github.com/login/oauth/access_token"
+        assert headers["Accept"] == "application/json"
+        assert data["client_id"] == "client-id"
+        assert data["client_secret"] == "client-secret"
+        return self.token_responses.pop(0)
+
+    async def get(self, url: str, params: dict, headers: dict):
+        assert url == "https://api.github.com/user/installations"
+        assert params == {"per_page": 100, "page": 1}
+        assert headers["Authorization"] == "Bearer user-token"
+        assert headers["Accept"] == "application/vnd.github+json"
+        assert headers["X-GitHub-Api-Version"] == "2022-11-28"
+        return self.installations_response
+
+
+class FakeStateCache:
+    def __init__(self):
+        self.values: dict[str, str] = {}
+
+    def get(self, key: str):
+        return self.values.get(key)
+
+    def set(self, key: str, value: str):
+        self.values[key] = value
+
+
+class FakeNoRowResult:
+    def scalar_one_or_none(self):
+        return None
+
+
+def _patch_cache(monkeypatch) -> FakeStateCache:
+    cache = FakeStateCache()
+    monkeypatch.setattr(
+        github_app_router_module, "create_cache", lambda ttl_seconds: cache
+    )
+    return cache
+
+
+def _patch_github_user_installations(
+    monkeypatch,
+    installations: list[dict],
+    token_responses: list[FakeGitHubResponse] | None = None,
+) -> None:
+    responses = token_responses or [
+        FakeGitHubResponse(200, {"access_token": "user-token"})
+    ]
+    monkeypatch.setattr(
+        github_app_router_module.httpx,
+        "AsyncClient",
+        lambda timeout: FakeGitHubClient(
+            responses,
+            FakeGitHubResponse(200, {"installations": installations}),
+        ),
+    )
+
+
+def _installation(installation_id: int = 987654) -> dict:
+    return {
+        "id": installation_id,
+        "account": {"login": "verified-org", "type": "Organization"},
+    }
+
+
+def _configure_github_app(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "dummy-test-app-key-not-a-pem")
+    monkeypatch.setenv("GITHUB_APP_CLIENT_ID", "client-id")
+    monkeypatch.setenv("GITHUB_APP_CLIENT_SECRET", "client-secret")
+
+
+@pytest.mark.asyncio
+async def test_install_url_returns_verifiable_state(session_maker, monkeypatch):
+    org_id = str(uuid.uuid4())
+    monkeypatch.setenv("GITHUB_APP_SLUG", "dev-health-test")
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/admin/integrations/github/install-url")
+
+    assert response.status_code == 200, response.text
+    install_url = response.json()["install_url"]
+    parsed = urlparse(install_url)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "github.com"
+    assert parsed.path == "/apps/dev-health-test/installations/new"
+    state = parse_qs(parsed.query)["state"][0]
+    assert verify_github_app_install_state(state).org_id == org_id
+
+
+@pytest.mark.asyncio
+async def test_install_callback_writes_credential_and_installation(
+    session_maker,
+    monkeypatch,
+):
+    org_id = str(uuid.uuid4())
+    _configure_github_app(monkeypatch)
+    _patch_cache(monkeypatch)
+    _patch_github_user_installations(monkeypatch, [_installation()])
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": "install",
+                "state": mint_github_app_install_state(org_id),
+                "code": "oauth-code",
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "connected": True,
+        "installation_id": 987654,
+        "credential_name": "github-app",
+    }
+    async with session_maker() as session:
+        installation = (
+            await session.execute(select(GithubAppInstallation))
+        ).scalar_one()
+        assert installation.installation_id == 987654
+        assert installation.org_id == org_id
+        assert installation.account_login == "verified-org"
+        assert installation.account_type == "Organization"
+        svc = IntegrationCredentialsService(session, org_id)
+        credentials = await svc.get_decrypted_credentials("github", "github-app")
+        credential = await svc.get("github", "github-app")
+
+    assert credentials == {
+        "app_id": "12345",
+        "private_key": "dummy-test-app-key-not-a-pem",
+        "installation_id": "987654",
+    }
+    assert credential is not None
+    assert credential.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_install_callback_recovers_when_webhook_created_row_concurrently(
+    session_maker,
+    monkeypatch,
+):
+    org_id = str(uuid.uuid4())
+    _configure_github_app(monkeypatch)
+    _patch_cache(monkeypatch)
+    _patch_github_user_installations(monkeypatch, [_installation()])
+    async with session_maker() as session:
+        installation = GithubAppInstallation()
+        installation.installation_id = 987654
+        session.add(installation)
+        await session.commit()
+
+    original_execute = AsyncSession.execute
+    stale_select_consumed = False
+
+    async def stale_first_execute(self, *args, **kwargs):
+        nonlocal stale_select_consumed
+        if not stale_select_consumed:
+            stale_select_consumed = True
+            return FakeNoRowResult()
+        return await original_execute(self, *args, **kwargs)
+
+    monkeypatch.setattr(AsyncSession, "execute", stale_first_execute)
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": "install",
+                "state": mint_github_app_install_state(org_id),
+                "code": "oauth-code",
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    async with session_maker() as session:
+        installation = (
+            await session.execute(select(GithubAppInstallation))
+        ).scalar_one()
+        credential = (
+            await session.execute(select(IntegrationCredential))
+        ).scalar_one_or_none()
+    assert installation.org_id == org_id
+    assert installation.account_login == "verified-org"
+    assert credential is not None
+
+
+@pytest.mark.asyncio
+async def test_install_callback_claims_null_org_once_and_rejects_different_org(
+    session_maker,
+    monkeypatch,
+):
+    org_a = str(uuid.uuid4())
+    org_b = str(uuid.uuid4())
+    _configure_github_app(monkeypatch)
+    _patch_cache(monkeypatch)
+    _patch_github_user_installations(
+        monkeypatch,
+        [_installation()],
+        token_responses=[
+            FakeGitHubResponse(200, {"access_token": "user-token"}),
+            FakeGitHubResponse(200, {"access_token": "user-token"}),
+        ],
+    )
+    async with session_maker() as session:
+        installation = GithubAppInstallation()
+        installation.installation_id = 987654
+        session.add(installation)
+        await session.commit()
+
+    app_a = _app(session_maker, org_a)
+    async with AsyncClient(
+        transport=ASGITransport(app=app_a), base_url="http://test"
+    ) as client:
+        first = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": "install",
+                "state": mint_github_app_install_state(org_a),
+                "code": "oauth-code-a",
+            },
+        )
+
+    app_b = _app(session_maker, org_b)
+    async with AsyncClient(
+        transport=ASGITransport(app=app_b), base_url="http://test"
+    ) as client:
+        second = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": "install",
+                "state": mint_github_app_install_state(org_b),
+                "code": "oauth-code-b",
+            },
+        )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 409, second.text
+    async with session_maker() as session:
+        installation = (
+            await session.execute(select(GithubAppInstallation))
+        ).scalar_one()
+        org_a_credential = await IntegrationCredentialsService(session, org_a).get(
+            "github", "github-app"
+        )
+        org_b_credential = await IntegrationCredentialsService(session, org_b).get(
+            "github", "github-app"
+        )
+    assert installation.org_id == org_a
+    assert org_a_credential is not None
+    assert org_b_credential is None
+
+
+@pytest.mark.asyncio
+async def test_install_callback_rejects_mismatched_org(session_maker, monkeypatch):
+    org_id = str(uuid.uuid4())
+    _configure_github_app(monkeypatch)
+    _patch_cache(monkeypatch)
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": None,
+                "state": mint_github_app_install_state(str(uuid.uuid4())),
+                "code": "oauth-code",
+            },
+        )
+
+    assert response.status_code == 403, response.text
+
+
+@pytest.mark.asyncio
+async def test_install_callback_requires_server_private_key(session_maker, monkeypatch):
+    org_id = str(uuid.uuid4())
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+    monkeypatch.delenv("GITHUB_APP_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("GITHUB_APP_PRIVATE_KEY_PATH", raising=False)
+    monkeypatch.setenv("GITHUB_APP_CLIENT_ID", "client-id")
+    monkeypatch.setenv("GITHUB_APP_CLIENT_SECRET", "client-secret")
+    _patch_cache(monkeypatch)
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": None,
+                "state": mint_github_app_install_state(org_id),
+                "code": "oauth-code",
+            },
+        )
+
+    assert response.status_code == 500, response.text
+
+
+@pytest.mark.asyncio
+async def test_install_callback_requires_code_without_credential(
+    session_maker,
+    monkeypatch,
+):
+    org_id = str(uuid.uuid4())
+    _configure_github_app(monkeypatch)
+    _patch_cache(monkeypatch)
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": None,
+                "state": mint_github_app_install_state(org_id),
+                "code": None,
+            },
+        )
+
+    assert response.status_code == 400, response.text
+    async with session_maker() as session:
+        credential = (
+            await session.execute(select(IntegrationCredential))
+        ).scalar_one_or_none()
+    assert credential is None
+
+
+@pytest.mark.asyncio
+async def test_install_callback_rejects_inaccessible_installation_without_credential(
+    session_maker,
+    monkeypatch,
+):
+    org_id = str(uuid.uuid4())
+    _configure_github_app(monkeypatch)
+    _patch_cache(monkeypatch)
+    _patch_github_user_installations(monkeypatch, [_installation(111111)])
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": None,
+                "state": mint_github_app_install_state(org_id),
+                "code": "oauth-code",
+            },
+        )
+
+    assert response.status_code == 403, response.text
+    async with session_maker() as session:
+        credential = (
+            await session.execute(select(IntegrationCredential))
+        ).scalar_one_or_none()
+    assert credential is None
+
+
+@pytest.mark.asyncio
+async def test_install_callback_rejects_installation_bound_to_other_org(
+    session_maker,
+    monkeypatch,
+):
+    org_id = str(uuid.uuid4())
+    _configure_github_app(monkeypatch)
+    _patch_cache(monkeypatch)
+    _patch_github_user_installations(monkeypatch, [_installation()])
+    async with session_maker() as session:
+        installation = GithubAppInstallation()
+        installation.installation_id = 987654
+        installation.org_id = str(uuid.uuid4())
+        session.add(installation)
+        await session.commit()
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": None,
+                "state": mint_github_app_install_state(org_id),
+                "code": "oauth-code",
+            },
+        )
+
+    assert response.status_code == 409, response.text
+    async with session_maker() as session:
+        credential = (
+            await session.execute(select(IntegrationCredential))
+        ).scalar_one_or_none()
+    assert credential is None
+
+
+@pytest.mark.asyncio
+async def test_install_callback_rejects_replayed_state(session_maker, monkeypatch):
+    org_id = str(uuid.uuid4())
+    _configure_github_app(monkeypatch)
+    _patch_cache(monkeypatch)
+    _patch_github_user_installations(
+        monkeypatch,
+        [_installation()],
+        token_responses=[
+            FakeGitHubResponse(200, {"access_token": "user-token"}),
+            FakeGitHubResponse(400, {"error": "bad_verification_code"}),
+        ],
+    )
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        first = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": None,
+                "state": mint_github_app_install_state(org_id),
+                "code": "oauth-code",
+            },
+        )
+        second = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": None,
+                "state": mint_github_app_install_state(org_id),
+                "code": "oauth-code",
+            },
+        )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 400, second.text
+    assert second.json()["detail"] == "GitHub user authorization could not be verified"

--- a/tests/api/webhooks/test_github_app_installation.py
+++ b/tests/api/webhooks/test_github_app_installation.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import GithubAppInstallation, IntegrationCredential
+from dev_health_ops.workers import system_webhooks
+from dev_health_ops.workers.system_webhooks import _process_github_event
+from tests._helpers import tables_of
+
+
+@pytest.fixture
+def session_maker(tmp_path: Path, monkeypatch):
+    db_path = tmp_path / "github-installation-webhook.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(
+        engine, tables=tables_of(GithubAppInstallation, IntegrationCredential)
+    )
+    maker = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def session_override():
+        session = maker()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    monkeypatch.setattr(
+        "dev_health_ops.db.get_postgres_session_sync",
+        session_override,
+    )
+    try:
+        yield maker
+    finally:
+        engine.dispose()
+
+
+def _payload(action: str, installation_id: int = 123) -> dict:
+    return {
+        "action": action,
+        "installation": {
+            "id": installation_id,
+            "account": {"login": "full-chaos", "type": "Organization"},
+        },
+    }
+
+
+def _installation(session_maker) -> GithubAppInstallation:
+    with session_maker() as session:
+        return session.execute(select(GithubAppInstallation)).scalar_one()
+
+
+class FakeNoRowResult:
+    def scalar_one_or_none(self):
+        return None
+
+
+def test_installation_webhook_upserts_and_tracks_transitions(session_maker):
+    created = _process_github_event("installation", _payload("created"), None, None)
+    assert created["processed"] is True
+    installation = _installation(session_maker)
+    assert installation.installation_id == 123
+    assert installation.account_login == "full-chaos"
+    assert installation.account_type == "Organization"
+    assert installation.suspended_at is None
+
+    suspended = _process_github_event("installation", _payload("suspend"), None, None)
+    assert suspended["processed"] is True
+    assert _installation(session_maker).suspended_at is not None
+
+    unsuspended = _process_github_event(
+        "installation", _payload("unsuspend"), None, None
+    )
+    assert unsuspended["processed"] is True
+    assert _installation(session_maker).suspended_at is None
+
+
+def test_installation_webhook_recovers_when_callback_created_row_concurrently(
+    session_maker,
+    monkeypatch,
+):
+    with session_maker() as session:
+        installation = GithubAppInstallation()
+        installation.installation_id = 123
+        session.add(installation)
+        session.commit()
+
+    original_execute = Session.execute
+    stale_select_consumed = False
+
+    def stale_first_execute(self, *args, **kwargs):
+        nonlocal stale_select_consumed
+        if not stale_select_consumed:
+            stale_select_consumed = True
+            return FakeNoRowResult()
+        return original_execute(self, *args, **kwargs)
+
+    monkeypatch.setattr(Session, "execute", stale_first_execute)
+
+    result = _process_github_event("installation", _payload("created"), None, None)
+
+    assert result["processed"] is True
+    installation = _installation(session_maker)
+    assert installation.account_login == "full-chaos"
+    assert installation.suspended_at is None
+
+
+def test_installation_deleted_deactivates_matching_app_credential(session_maker):
+    with session_maker() as session:
+        installation = GithubAppInstallation()
+        installation.installation_id = 999
+        installation.org_id = "org-1"
+        credential = IntegrationCredential(
+            provider="github",
+            name="github-app",
+            org_id="org-1",
+            credentials_encrypted="encrypted",
+            is_active=True,
+        )
+        session.add_all([installation, credential])
+        session.commit()
+
+    deleted = _process_github_event(
+        "installation", _payload("deleted", 999), None, None
+    )
+    assert deleted["processed"] is True
+
+    with session_maker() as session:
+        installation = session.execute(select(GithubAppInstallation)).scalar_one()
+        credential = session.execute(select(IntegrationCredential)).scalar_one()
+        assert installation.org_id == "org-1"
+        assert installation.suspended_at is not None
+        assert credential.is_active is False
+
+
+def test_installation_db_failure_raises_for_retry(monkeypatch):
+    @contextmanager
+    def broken_session():
+        raise RuntimeError("db unavailable")
+        yield
+
+    monkeypatch.setattr(
+        "dev_health_ops.db.get_postgres_session_sync",
+        broken_session,
+    )
+
+    with pytest.raises(RuntimeError, match="db unavailable"):
+        _process_github_event("installation", _payload("suspend"), None, None)
+
+
+def test_failed_delivery_is_not_recorded(monkeypatch):
+    recorded: list[str] = []
+
+    def failing_process(event_type, payload, org_id, repo_name):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(system_webhooks, "_is_duplicate_delivery", lambda p, d: False)
+    monkeypatch.setattr(
+        system_webhooks, "_record_delivery", lambda p, d: recorded.append(d)
+    )
+    monkeypatch.setattr(system_webhooks, "_process_github_event", failing_process)
+    monkeypatch.setattr(
+        system_webhooks.process_webhook_event,
+        "retry",
+        lambda exc, countdown: (_ for _ in ()).throw(exc),
+    )
+
+    with pytest.raises(RuntimeError, match="db unavailable"):
+        getattr(system_webhooks.process_webhook_event, "run")(
+            provider="github",
+            event_type="installation",
+            delivery_id="delivery-1",
+            payload=_payload("deleted"),
+            org_id=None,
+            repo_name=None,
+        )
+
+    assert recorded == []

--- a/tests/api/webhooks/test_models.py
+++ b/tests/api/webhooks/test_models.py
@@ -33,6 +33,21 @@ class TestGitHubEventMapping:
     def test_check_run(self):
         assert map_github_event("check_run") == WebhookEventType.CHECK_RUN
 
+    def test_installation(self):
+        assert map_github_event("installation") == WebhookEventType.INSTALLATION
+
+    def test_installation_repositories(self):
+        assert (
+            map_github_event("installation_repositories")
+            == WebhookEventType.INSTALLATION
+        )
+
+    def test_marketplace_purchase(self):
+        assert (
+            map_github_event("marketplace_purchase")
+            == WebhookEventType.MARKETPLACE_PURCHASE
+        )
+
     def test_unknown_event(self):
         assert map_github_event("unknown_event") == WebhookEventType.UNKNOWN
 
@@ -85,6 +100,10 @@ class TestWebhookEventModel:
             provider=WebhookProvider.GITHUB,
             event_type=WebhookEventType.PUSH,
             raw_event_type="push",
+            delivery_id=None,
+            org_id=None,
+            repo_id=None,
+            repo_name=None,
         )
         assert event.id is not None
 
@@ -93,6 +112,10 @@ class TestWebhookEventModel:
             provider=WebhookProvider.GITLAB,
             event_type=WebhookEventType.MERGE_REQUEST,
             raw_event_type="Merge Request Hook",
+            delivery_id=None,
+            org_id=None,
+            repo_id=None,
+            repo_name=None,
         )
         assert event.received_at is not None
 
@@ -102,6 +125,10 @@ class TestWebhookEventModel:
             provider=WebhookProvider.JIRA,
             event_type=WebhookEventType.ISSUE_CREATED,
             raw_event_type="jira:issue_created",
+            delivery_id=None,
+            org_id=None,
+            repo_id=None,
+            repo_name=None,
             payload=payload,
         )
         assert event.payload == payload


### PR DESCRIPTION
## Summary

Makes connecting GitHub one‑click: install the Dev Health **GitHub App** (which also provides OAuth identity — the A2 "unified app" model) instead of manually wiring `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY_PATH` / `GITHUB_APP_INSTALLATION_ID`. Backend half of **CHAOS-2235** (frictionless install) plus the **CHAOS-2236** webhook plumbing (marketplace entitlement deferred).

Web counterpart: full-chaos/dev-health-web#691 • Parent: CHAOS-2233 • Plan: `docs/plans/github-app-marketplace.md`

## What changed

- **Model + migration** — new `github_app_installations` table (`installation_id`→org link + lifecycle) and Alembic `0014` (chained after main's `0013`).
- **Signed-state install flow** — `POST /api/v1/admin/integrations/github/install-url` mints a short‑lived, single‑use (jti) JWT state; `POST /api/v1/admin/integrations/github/install-callback` completes the install.
- **Ownership proof** — the callback requires the GitHub OAuth `code`, exchanges it, and verifies the `installation_id` appears in the installer's `GET /user/installations` before writing any credential (existence ≠ ownership). Server‑held App PEM only — never an end‑user secret.
- **Tenant isolation** — atomic conditional claim (`UPDATE … WHERE installation_id=:id AND (org_id IS NULL OR org_id=:org)`, `rowcount==0 → 409`) + savepoint insert race handling, so concurrent cross‑org claims serialize.
- **Webhooks** — `installation` (created/suspend/unsuspend/deleted, with credential deactivation on delete) and `marketplace_purchase` events; lifecycle DB failures raise so Celery retries, and delivery is recorded only after successful processing. Marketplace entitlement mapping is intentionally deferred (CHAOS-2236).

## Review

- Code review + **`/codex:adversarial-review --model gpt-5.5`** on every change set. Five successive gpt‑5.5 findings were fixed and re‑verified: installation ownership proof, durable single‑use state, an Alembic revision collision (after rebase), an insert race, and a NULL‑row cross‑tenant claim race. Final gpt‑5.5 verdict: **approve, no material findings**.

## Verification

- `OTEL_SDK_DISABLED=true python -m pytest tests/api/admin/test_github_app_install.py tests/api/webhooks -q` → **73 passed**; broader `tests/api/admin tests/api/webhooks tests/api/auth` green.
- Alembic `0014` applied **and** rolled back against a real PostgreSQL (single head; correct types/indexes).
- `ruff format`/`ruff check` clean.

## Deploy-time configuration (operator)

Register a GitHub App with "Request user authorization (OAuth) during installation" enabled and Setup URL → `…/admin/integrations/github-app/callback`, then set: `GITHUB_APP_SLUG`, `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY` (or `_PATH`), `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`, `GITHUB_WEBHOOK_SECRET`. For unified social login set web `AUTH_GITHUB_ID`/`AUTH_GITHUB_SECRET` to the App's OAuth client creds.

## Visual evidence

End-user result (rendered by the web PR):

![Connect GitHub App CTA](https://github.com/user-attachments/assets/b82bcf1a-71c5-4868-a978-fc2106c74d45)

Refs CHAOS-2235, CHAOS-2236, CHAOS-2233
