### PR TITLE
feat(integrations): GitHub App setup follow-ups — redirect_uri, inline PEM, setup guide (CHAOS-2235)

### DIFF
--- a/docs/user-guide/github-app-setup.md
+++ b/docs/user-guide/github-app-setup.md
@@ -1,0 +1,180 @@
+# GitHub App setup (frictionless install)
+
+This guide creates the **Dev Health GitHub App** that powers one‑click "Connect
+GitHub" (install the App instead of pasting a PAT) and unified GitHub sign‑in.
+It is the operator counterpart to [GitHub App auth](github-app-auth.md) and the
+plan in [`docs/plans/github-app-marketplace.md`](../plans/github-app-marketplace.md).
+
+> Replace `YOUR_HOST` with your public base URL. In the Docker stack, web and the
+> ops API sit behind the same host via Traefik. For purely local testing you do
+> **not** need a public URL for the core flow — see
+> [Local testing without a tunnel](#local-testing-without-a-tunnel).
+
+## 1. Create the App
+
+GitHub → **Settings → Developer settings → GitHub Apps → New GitHub App**.
+
+### Identifying and authorizing users
+
+| Field | Value |
+| --- | --- |
+| **User authorization callback URL** | `https://YOUR_HOST/admin/integrations/github-app/callback` |
+| **Request user authorization (OAuth) during installation** | ✅ **Checked** |
+| **Expire user authorization tokens** | ✅ leave checked (the code is used once at install) |
+| **Enable Device Flow** | ⬜ unchecked |
+
+GitHub Apps support up to 10 registered callback URLs. If you register more than
+one (e.g. a localhost URL and a production URL), set `GITHUB_APP_CALLBACK_URL` to
+the exact URL for the current environment so the install flow redirects
+deterministically — otherwise GitHub uses the first registered callback URL.
+
+Because OAuth‑during‑install is on, GitHub greys out **Setup URL** and uses the
+callback URL above instead — that is expected; leave Setup URL blank.
+
+### Post installation
+
+- **Setup URL** — blank (unavailable).
+- **Redirect on update** — ⬜ **leave unchecked.** The callback requires the
+  signed `state` that only our "Connect" button supplies; GitHub's update‑redirect
+  would omit it and land on `?github_app=error`. Repo changes are picked up by the
+  scheduled sync.
+
+### Webhook
+
+| Field | Value |
+| --- | --- |
+| **Active** | ✅ (uncheck for [local testing](#local-testing-without-a-tunnel)) |
+| **Webhook URL** | `https://YOUR_HOST/api/v1/webhooks/github` |
+| **Secret** | a random value — generate with `openssl rand -hex 32` |
+
+The same secret must be set as `GITHUB_WEBHOOK_SECRET` on the ops backend; the
+`X-Hub-Signature-256` check rejects deliveries that don't match.
+
+### Permissions — all **Read‑only** (this App never writes)
+
+**Repository**
+
+| Permission | Access | Why |
+| --- | --- | --- |
+| Metadata | Read‑only | Mandatory baseline |
+| Contents | Read‑only | Commit history, blame, complexity |
+| Pull requests | Read‑only | Review flow, cycle time, rework |
+| Issues | Read‑only | Work items + incidents |
+| Checks | Read‑only | CI check runs |
+| Actions | Read‑only | Workflow runs (CI/CD, DORA) |
+| Deployments | Read‑only | Delivery / change‑failure signals |
+| Commit statuses | Read‑only | CI status (optional) |
+
+**Organization**
+
+| Permission | Access | Why |
+| --- | --- | --- |
+| Members | Read‑only | Group activity by team / identity mapping |
+
+**Account** (granted per‑user via the OAuth flow)
+
+| Permission | Access | Why |
+| --- | --- | --- |
+| Email addresses | Read‑only | Link the installer to their Dev Health account |
+
+### Subscribe to events
+
+Leave **Installation target / Meta / Security advisory** unchecked. The
+`installation` event (install / uninstall / suspend / unsuspend) is delivered
+automatically and is what the lifecycle handler consumes. (Optional: tick **Meta**
+for a ping when the App is deleted.)
+
+Do **not** subscribe to `push` / `pull_request` here — those drive the legacy
+real‑time webhook‑sync path that expects a `GITHUB_TOKEN` PAT, not the
+per‑installation App token. App installs rely on the scheduled sync.
+
+### Where can this GitHub App be installed?
+
+- **"Only on this account"** for internal testing.
+- **"Any account"** when onboarding external orgs (also required for the deferred
+  Marketplace listing, CHAOS‑2236).
+
+Click **Create GitHub App**, then on the App page **generate a private key**
+(downloads a `.pem`) and **generate a client secret** — neither is shown until you
+generate it.
+
+## 2. Wire the credentials
+
+```bash
+# ops backend
+GITHUB_APP_SLUG=<app URL slug, e.g. dev-health>
+GITHUB_APP_ID=<App ID>
+GITHUB_APP_CLIENT_ID=<Client ID>
+GITHUB_APP_CLIENT_SECRET=<generated client secret>
+GITHUB_WEBHOOK_SECRET=<the webhook secret from step 1>
+GITHUB_APP_CALLBACK_URL=https://YOUR_HOST/admin/integrations/github-app/callback
+# private key — choose ONE (see below)
+GITHUB_APP_PRIVATE_KEY_PATH=/run/secrets/github-app.pem
+# GITHUB_APP_PRIVATE_KEY="<single-line PEM with \n escapes — see 'Providing the private key' below>"
+
+# web (unified social login on the same App)
+AUTH_GITHUB_ID=<same Client ID>
+AUTH_GITHUB_SECRET=<same client secret>
+```
+
+### Providing the private key (PEM)
+
+The PEM is multi‑line, which env files handle inconsistently. Two supported ways:
+
+**A. File path (recommended).** Mount the `.pem` and point at it. No escaping:
+
+```bash
+GITHUB_APP_PRIVATE_KEY_PATH=/run/secrets/github-app.pem
+```
+
+**B. Inline `GITHUB_APP_PRIVATE_KEY`.** The value may be a single line with
+escaped `\n` (what `.env` files, Docker env, and most secret managers store);
+the backend converts `\n` back to real newlines, and a PEM that already has real
+newlines is left unchanged. Produce the one‑liner with:
+
+```bash
+# turns the multi-line .pem into a single \n-escaped line
+awk 'NF {printf "%s\\n", $0}' github-app.pem
+```
+
+Then in the env file (quote it):
+
+```dotenv
+GITHUB_APP_PRIVATE_KEY="<paste the \n-escaped one-liner from the awk command above>"
+```
+
+> Docker Compose `env_file` does not interpret quotes or multi‑line values, so the
+> `\n`‑escaped single line is the form to use there. Alternatively inject it from a
+> shell that preserves real newlines: `export GITHUB_APP_PRIVATE_KEY="$(cat github-app.pem)"`.
+
+## 3. Connect
+
+In the app: **Admin → Integrations → GitHub → "Connect GitHub App"**. You're sent
+to GitHub to install + pick repositories, then returned connected — no tokens to
+paste. The callback verifies the installation against `GET /user/installations`
+(installer must have access), links it to your org, and writes the App‑mode
+credential the sync pipeline uses.
+
+## Local testing without a tunnel
+
+Only the **webhook** needs a publicly reachable URL (GitHub POSTs to it). The
+install + OAuth callback works on `localhost` because GitHub redirects the
+**browser** (which is on your machine), and the backend's OAuth/`/user/installations`
+calls are outbound:
+
+- Set **User authorization callback URL** = `http://localhost:3000/admin/integrations/github-app/callback`.
+- Set `GITHUB_APP_CALLBACK_URL=http://localhost:3000/admin/integrations/github-app/callback` so
+  the install flow returns to localhost even if a production callback URL is also registered.
+- In **Webhook**, **uncheck "Active"** (drops the required URL). You lose only
+  automatic credential‑deactivation on uninstall during the test.
+
+The full Connect → install → credential → sync happy path is testable this way.
+
+Reach for a tunnel (e.g. `cloudflared`) **only** to exercise the webhook lifecycle:
+
+```bash
+cloudflared tunnel --url http://localhost:8000   # ops API
+# Webhook URL = https://<tunnel-host>/api/v1/webhooks/github  (+ matching GITHUB_WEBHOOK_SECRET)
+```
+
+The callback can stay on `localhost`, or move it to the tunnel host too.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Usage: connectors/usage.md
       - Private Repos: connectors/private-repo-testing.md
       - GitHub App Auth: user-guide/github-app-auth.md
+      - GitHub App Setup: user-guide/github-app-setup.md
   - Metrics:
       - Overview: metrics.md
       - Inventory: metrics-inventory.md

--- a/src/dev_health_ops/api/admin/routers/github_app.py
+++ b/src/dev_health_ops/api/admin/routers/github_app.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.admin.middleware import get_admin_org_id
 from dev_health_ops.api.integrations.github_app_config import (
+    github_app_callback_url,
     github_app_client_id,
     github_app_client_secret,
     github_app_id,
@@ -65,7 +66,11 @@ async def create_github_install_url(
     if not slug:
         raise HTTPException(status_code=400, detail="GITHUB_APP_SLUG is not configured")
     state = mint_github_app_install_state(org_id)
-    query = urlencode({"state": state})
+    params: dict[str, str] = {"state": state}
+    callback_url = github_app_callback_url()
+    if callback_url:
+        params["redirect_uri"] = callback_url
+    query = urlencode(params)
     install_url = (
         f"https://github.com/apps/{quote(slug, safe='')}/installations/new?{query}"
     )

--- a/src/dev_health_ops/api/integrations/github_app_config.py
+++ b/src/dev_health_ops/api/integrations/github_app_config.py
@@ -15,7 +15,11 @@ def github_app_id() -> str | None:
 def github_app_private_key() -> str | None:
     inline_key = os.getenv("GITHUB_APP_PRIVATE_KEY")
     if inline_key:
-        return inline_key
+        # Accept a single-line PEM with escaped newlines (how .env files,
+        # Docker env, and most secret managers store multi-line values). A
+        # real multi-line PEM contains no literal "\n", so this is a no-op
+        # for keys that already have real newlines.
+        return inline_key.replace("\\n", "\n")
     key_path = os.getenv("GITHUB_APP_PRIVATE_KEY_PATH")
     if key_path:
         return Path(key_path).read_text(encoding="utf-8")
@@ -28,3 +32,7 @@ def github_app_client_id() -> str | None:
 
 def github_app_client_secret() -> str | None:
     return os.getenv("GITHUB_APP_CLIENT_SECRET")
+
+
+def github_app_callback_url() -> str | None:
+    return os.getenv("GITHUB_APP_CALLBACK_URL")

--- a/tests/api/admin/test_github_app_install.py
+++ b/tests/api/admin/test_github_app_install.py
@@ -541,3 +541,53 @@ async def test_install_callback_rejects_replayed_state(session_maker, monkeypatc
     assert first.status_code == 200, first.text
     assert second.status_code == 400, second.text
     assert second.json()["detail"] == "GitHub user authorization could not be verified"
+
+
+@pytest.mark.asyncio
+async def test_install_url_includes_redirect_uri_when_configured(
+    session_maker, monkeypatch
+):
+    org_id = str(uuid.uuid4())
+    monkeypatch.setenv("GITHUB_APP_SLUG", "dev-health-test")
+    monkeypatch.setenv(
+        "GITHUB_APP_CALLBACK_URL",
+        "http://localhost:3000/admin/integrations/github-app/callback",
+    )
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/admin/integrations/github/install-url")
+
+    assert response.status_code == 200, response.text
+    install_url = response.json()["install_url"]
+    parsed = urlparse(install_url)
+    qs = parse_qs(parsed.query)
+    assert qs["redirect_uri"] == [
+        "http://localhost:3000/admin/integrations/github-app/callback"
+    ]
+    assert "state" in qs
+    assert verify_github_app_install_state(qs["state"][0]).org_id == org_id
+
+
+@pytest.mark.asyncio
+async def test_install_url_omits_redirect_uri_when_not_configured(
+    session_maker, monkeypatch
+):
+    org_id = str(uuid.uuid4())
+    monkeypatch.setenv("GITHUB_APP_SLUG", "dev-health-test")
+    monkeypatch.delenv("GITHUB_APP_CALLBACK_URL", raising=False)
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/admin/integrations/github/install-url")
+
+    assert response.status_code == 200, response.text
+    install_url = response.json()["install_url"]
+    parsed = urlparse(install_url)
+    qs = parse_qs(parsed.query)
+    assert "redirect_uri" not in qs
+    assert "state" in qs

--- a/tests/api/integrations/test_github_app_config.py
+++ b/tests/api/integrations/test_github_app_config.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dev_health_ops.api.integrations.github_app_config import github_app_private_key
+
+_ESCAPED = "line-one\\nline-two\\nline-three\\n"
+_REAL = "line-one\nline-two\nline-three\n"
+
+
+def test_inline_escaped_newlines_are_normalized(monkeypatch):
+    monkeypatch.delenv("GITHUB_APP_PRIVATE_KEY_PATH", raising=False)
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", _ESCAPED)
+    assert github_app_private_key() == _REAL
+
+
+def test_inline_real_newlines_are_unchanged(monkeypatch):
+    monkeypatch.delenv("GITHUB_APP_PRIVATE_KEY_PATH", raising=False)
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", _REAL)
+    assert github_app_private_key() == _REAL
+
+
+def test_path_is_read_when_inline_absent(monkeypatch, tmp_path):
+    monkeypatch.delenv("GITHUB_APP_PRIVATE_KEY", raising=False)
+    pem = tmp_path / "app.pem"
+    pem.write_text(_REAL, encoding="utf-8")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_PATH", str(pem))
+    assert github_app_private_key() == _REAL
+
+
+def test_none_when_unconfigured(monkeypatch):
+    monkeypatch.delenv("GITHUB_APP_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("GITHUB_APP_PRIVATE_KEY_PATH", raising=False)
+    assert github_app_private_key() is None


### PR DESCRIPTION
## Summary

Follow-up to the merged frictionless GitHub App install (#949). Three operator-facing improvements:

1. **Explicit `redirect_uri`** — `install-url` now appends `redirect_uri` (from the new `GITHUB_APP_CALLBACK_URL` env) to the `installations/new` URL. A GitHub App can register up to 10 callback URLs, and without an explicit `redirect_uri` GitHub redirects to the **first registered** one ([docs](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/about-the-user-authorization-callback-url)). That caused the post-install redirect to land on the wrong URL when both a localhost and a production callback are registered. When `GITHUB_APP_CALLBACK_URL` is unset, behavior is unchanged (no `redirect_uri`).
2. **Inline PEM support** — `GITHUB_APP_PRIVATE_KEY` may now be a single-line PEM with escaped `\n` (how `.env` files, Docker `env_file`, and most secret managers store multi-line values). The backend converts `\n` back to real newlines before signing; a real multi-line PEM is left unchanged (no-op).
3. **Setup guide** — `docs/user-guide/github-app-setup.md`: operator runbook for creating the App (callback URL + `redirect_uri` note, OAuth-during-install, webhook, read-only permissions, event subscriptions, install scope), env wiring (both PEM forms + `GITHUB_APP_CALLBACK_URL`), and **local testing without a tunnel**. Registered in the docs nav.

## Verification

- `tests/api/admin/test_github_app_install.py` — `redirect_uri` present when configured / absent when not, `state` still verifiable.
- `tests/api/integrations/test_github_app_config.py` — `\n` normalization (escaped → real; real unchanged; path fallback; unconfigured → None).
- `make docs:check` (link + drift), `ruff`, `mypy` clean; no secrets (gitleaks clean).

Refs CHAOS-2235
