### PR TITLE
fix(deps): declare tzlocal explicitly to fix red main (test collection import error)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
   "strawberry-graphql[fastapi]>=0.315.4",
   "celery[redis]>=5.3.0",
   "croniter>=1.3.0",
+  "tzlocal>=5.0",
   "valkey>=6.0.0",
   # Shared Atlassian client library (Jira REST/GraphQL)
   "atlassian-gen-client>=0.1.0b3",

--- a/uv.lock
+++ b/uv.lock
@@ -897,6 +897,7 @@ dependencies = [
     { name = "stripe" },
     { name = "tqdm" },
     { name = "typing-extensions" },
+    { name = "tzlocal" },
     { name = "uvicorn" },
     { name = "valkey" },
 ]
@@ -975,6 +976,7 @@ requires-dist = [
     { name = "stripe", specifier = ">=7.0.0" },
     { name = "tqdm", specifier = ">=4.67.3" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
+    { name = "tzlocal", specifier = ">=5.0" },
     { name = "uvicorn", specifier = ">=0.46.0" },
     { name = "valkey", specifier = ">=6.0.0" },
 ]


### PR DESCRIPTION
## Summary

Fixes **red `main`** — both the unit test-matrix ("Tests") and "Integration Tests" workflows fail at collection/import with:

```
ModuleNotFoundError: No module named 'tzlocal'
  (ImportError while importing dev_health_ops.api.main → celery → tzlocal)
```

Every test module that imports `api.main` (e.g. `tests/api/admin/test_credential_fallback.py`, `test_identities.py`, `tests/test_connectors_integration.py`, `tests/test_private_repo_access.py`) errors at collection.

## Root cause

`tzlocal` is imported by `celery` at import time but is a **transitive** dependency, not declared by this project. Commit `a1dcfce71` (#905, starlette/instrumentator bump) regenerated `uv.lock` and resolved **celery 5.3.x → 5.6.3**. celery 5.6 dropped `tzlocal` from its declared `Requires-Dist`, so a clean install from `pyproject.toml` (CI uses `requirements.txt` = `-e .[dev]`) no longer reliably pulls it in. This is unrelated to the GitHub App work (#949/#950) — those touch no dependencies; the merge of #950 simply re-triggered the workflows on `main` and surfaced it.

## Fix

Declare `tzlocal>=5.0` as an explicit runtime dependency in `pyproject.toml` (+ `uv.lock` updated; `tzlocal 5.3.1` was already in the lock as a transitive dep, now with `dev-health-ops` as a direct dependent — no version changes).

## Verification

```
uv run python -c "import dev_health_ops.api.main"            → import OK
pytest tests/api/admin/test_credential_fallback.py \
       tests/api/admin/test_identities.py                    → 17 passed
pytest tests/api/admin/test_github_app_install.py \
       tests/api/integrations                                → 16 passed
pyproject.toml                                               → valid TOML
```
