### PR TITLE
fix(workers): isolate work-items sync credentials

### DIFF
--- a/src/dev_health_ops/backfill/runner.py
+++ b/src/dev_health_ops/backfill/runner.py
@@ -8,6 +8,7 @@ from typing import Any
 from dev_health_ops.db import get_postgres_session_sync
 from dev_health_ops.metrics.job_work_items import run_work_items_sync_job
 from dev_health_ops.models.settings import SyncConfiguration
+from dev_health_ops.workers.task_utils import _jira_query_options
 
 from .chunker import chunk_date_range
 
@@ -59,6 +60,7 @@ def run_backfill_for_config(
             progress_cb(idx, len(windows), window_since, window_before)
 
         backfill_days = (window_before - window_since).days + 1
+        jira_project_keys, jira_jql, jira_fetch_all = _jira_query_options(sync_options)
         run_work_items_sync_job(
             db_url=db_url,
             day=window_before,
@@ -69,6 +71,9 @@ def run_backfill_for_config(
             search_pattern=sync_options.get("search"),
             org_id=org_id,
             credentials=credentials,
+            jira_project_keys=jira_project_keys if provider == "jira" else None,
+            jira_jql=jira_jql if provider == "jira" else None,
+            jira_fetch_all=jira_fetch_all if provider == "jira" else None,
         )
 
     return {

--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -318,6 +318,51 @@ def gitlab_credentials_from_mapping(
         return None
 
 
+def jira_credentials_from_mapping(
+    cred_dict: dict[str, Any],
+    *,
+    source: CredentialSource = CredentialSource.DATABASE,
+    credential_name: str = "default",
+) -> JiraCredentials | None:
+    api_token = str(cred_dict.get("api_token") or cred_dict.get("apiToken") or "")
+    email = str(cred_dict.get("email") or "")
+    base_url = str(
+        cred_dict.get("base_url")
+        or cred_dict.get("baseUrl")
+        or cred_dict.get("url")
+        or ""
+    )
+    try:
+        return JiraCredentials(
+            api_token=api_token,
+            email=email,
+            base_url=base_url,
+            source=source,
+            credential_name=credential_name,
+        )
+    except (ValueError, TypeError):
+        logger.debug("Jira credentials mapping was incomplete or invalid")
+        return None
+
+
+def linear_credentials_from_mapping(
+    cred_dict: dict[str, Any],
+    *,
+    source: CredentialSource = CredentialSource.DATABASE,
+    credential_name: str = "default",
+) -> LinearCredentials | None:
+    api_key = str(cred_dict.get("api_key") or cred_dict.get("apiKey") or "")
+    try:
+        return LinearCredentials(
+            api_key=api_key,
+            source=source,
+            credential_name=credential_name,
+        )
+    except (ValueError, TypeError):
+        logger.debug("Linear credentials mapping was incomplete or invalid")
+        return None
+
+
 def resolve_gitlab_url(
     sync_options: dict[str, Any],
     gitlab_credentials: GitLabCredentials | None,

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -147,6 +147,76 @@ def _build_gitlab_work_client(
     return resolved_credentials.token, resolved_credentials.base_url or None
 
 
+def _build_jira_work_client(
+    *, org_id: str, credentials: dict[str, Any] | None = None
+) -> Any:
+    from dev_health_ops.credentials.resolver import (
+        jira_credentials_from_mapping,
+        resolve_credentials_sync,
+    )
+    from dev_health_ops.credentials.types import JiraCredentials
+    from dev_health_ops.providers.jira.client import (
+        JiraAuth,
+        JiraClient,
+        _normalize_jira_base_url,
+    )
+
+    if credentials:
+        jira_credentials = jira_credentials_from_mapping(credentials)
+        if jira_credentials is None:
+            raise ValueError(
+                "Missing Jira credentials for work-items sync configuration"
+            )
+    elif org_id:
+        resolved_credentials = resolve_credentials_sync(
+            "jira", org_id=org_id, allow_env_fallback=True
+        )
+        if not isinstance(resolved_credentials, JiraCredentials):
+            raise ValueError("Resolved credentials are not Jira credentials")
+        jira_credentials = resolved_credentials
+    else:
+        return JiraClient.from_env()
+
+    return JiraClient(
+        auth=JiraAuth(
+            base_url=_normalize_jira_base_url(jira_credentials.base_url),
+            email=jira_credentials.email,
+            api_token=jira_credentials.api_token,
+        ),
+        org_id=org_id or None,
+    )
+
+
+def _build_linear_work_client(
+    *, org_id: str, credentials: dict[str, Any] | None = None
+) -> Any:
+    from dev_health_ops.credentials.resolver import (
+        linear_credentials_from_mapping,
+        resolve_credentials_sync,
+    )
+    from dev_health_ops.credentials.types import LinearCredentials
+    from dev_health_ops.providers.linear.client import LinearAuth, LinearClient
+
+    if credentials:
+        linear_credentials = linear_credentials_from_mapping(credentials)
+        if linear_credentials is None:
+            raise ValueError("Missing Linear API key for work-items sync configuration")
+    elif org_id:
+        resolved_credentials = resolve_credentials_sync(
+            "linear", org_id=org_id, allow_env_fallback=True
+        )
+        if not isinstance(resolved_credentials, LinearCredentials):
+            raise ValueError("Resolved credentials are not Linear credentials")
+        linear_credentials = resolved_credentials
+    else:
+        return LinearClient.from_env()
+
+    return LinearClient(
+        auth=LinearAuth(api_key=linear_credentials.api_key),
+        org_id=org_id or None,
+    )
+
+
 def run_work_items_sync_job(
     *,
     db_url: str,
@@ -159,6 +229,9 @@ def run_work_items_sync_job(
     search_pattern: str | None = None,
     org_id: str = "",
     credentials: dict[str, Any] | None = None,
+    jira_project_keys: list[str] | None = None,
+    jira_jql: str | None = None,
+    jira_fetch_all: bool | None = None,
 ) -> None:
     """
     Sync work tracking facts from provider APIs and write derived work item tables.
@@ -281,6 +354,11 @@ def run_work_items_sync_job(
                 until=until_dt,
                 status_mapping=status_mapping,
                 identity=identity,
+                client=_build_jira_work_client(org_id=org_id, credentials=credentials),
+                project_keys=jira_project_keys,
+                jql_override=jira_jql,
+                fetch_all=jira_fetch_all,
+                use_env_query_options=not bool(org_id or credentials),
             )
             work_items.extend(items)
             transitions.extend(tr)
@@ -387,6 +465,9 @@ def run_work_items_sync_job(
             linear_provider = LinearProvider(
                 status_mapping=status_mapping,
                 identity=identity,
+                client=_build_linear_work_client(
+                    org_id=org_id, credentials=credentials
+                ),
             )
             ctx = IngestionContext(
                 window=IngestionWindow(updated_since=since_dt, active_until=until_dt),

--- a/src/dev_health_ops/metrics/work_items.py
+++ b/src/dev_health_ops/metrics/work_items.py
@@ -7,6 +7,7 @@ import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from dev_health_ops.metrics.dependencies import get_metrics_dependencies
 from dev_health_ops.models.ai_attribution import AIAttributionRecord
@@ -85,6 +86,10 @@ def fetch_jira_work_items_with_extras(
     status_mapping: StatusMapping,
     identity: IdentityResolver,
     project_keys: Sequence[str] | None = None,
+    client: Any | None = None,
+    jql_override: str | None = None,
+    fetch_all: bool | None = None,
+    use_env_query_options: bool = True,
 ) -> tuple[
     list[WorkItem],
     list[WorkItemStatusTransition],
@@ -102,19 +107,26 @@ def fetch_jira_work_items_with_extras(
     """
     deps = get_metrics_dependencies()
 
-    if project_keys is None:
+    if project_keys is None and use_env_query_options:
         raw_keys = os.getenv("JIRA_PROJECT_KEYS") or ""
         project_keys = [k.strip() for k in raw_keys.split(",") if k.strip()] or None
 
-    jql_override = (os.getenv("JIRA_JQL") or "").strip()
-    fetch_all = (os.getenv("JIRA_FETCH_ALL") or "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
+    jql_override = (
+        str(jql_override or "").strip()
+        if jql_override is not None or not use_env_query_options
+        else (os.getenv("JIRA_JQL") or "").strip()
+    )
+    if fetch_all is None:
+        fetch_all = use_env_query_options and (
+            os.getenv("JIRA_FETCH_ALL") or ""
+        ).strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
 
-    if _env_flag("JIRA_USE_PROVIDER", False):
+    if client is None and _env_flag("JIRA_USE_PROVIDER", False):
         if project_keys:
             if len(project_keys) != 1:
                 logger.warning(
@@ -151,7 +163,7 @@ def fetch_jira_work_items_with_extras(
             batch_sprints,
         )
 
-    client = deps.jira_client_factory()
+    jira_client: Any = client or deps.jira_client_factory()
     work_items: list[WorkItem] = []
     transitions: list[WorkItemStatusTransition] = []
     dependencies: list[WorkItemDependency] = []
@@ -209,7 +221,7 @@ def fetch_jira_work_items_with_extras(
 
     for jql in jqls:
         logger.debug("Jira: JQL=%s", jql)
-        for issue in client.iter_issues(jql=jql, expand_changelog=True):
+        for issue in jira_client.iter_issues(jql=jql, expand_changelog=True):
             issue_key = issue.get("key") if isinstance(issue, dict) else None
             wi, wi_transitions = deps.jira_issue_to_work_item(
                 issue=issue,
@@ -234,7 +246,7 @@ def fetch_jira_work_items_with_extras(
             if fetch_comments and issue_key:
                 try:
                     comment_count = 0
-                    for comment in client.iter_issue_comments(
+                    for comment in jira_client.iter_issue_comments(
                         issue_id_or_key=str(issue_key)
                     ):
                         if comments_limit > 0 and comment_count >= comments_limit:
@@ -262,7 +274,7 @@ def fetch_jira_work_items_with_extras(
         if sprint_id in sprint_cache:
             continue
         try:
-            payload = client.get_sprint(sprint_id=str(sprint_id))
+            payload = jira_client.get_sprint(sprint_id=str(sprint_id))
         except Exception as exc:
             logger.warning("Jira: failed to fetch sprint %s: %s", sprint_id, exc)
             continue
@@ -273,7 +285,7 @@ def fetch_jira_work_items_with_extras(
 
     logger.info("Fetched %d Jira work items (since %s)", len(work_items), updated_since)
     try:
-        client.close()
+        jira_client.close()
     except Exception as exc:
         logger.warning("Failed to close Jira client: %s", exc)
     return work_items, transitions, dependencies, reopen_events, interactions, sprints

--- a/src/dev_health_ops/providers/linear/provider.py
+++ b/src/dev_health_ops/providers/linear/provider.py
@@ -91,13 +91,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
             linear_issue_to_work_item,
         )
 
-        client = (
-            self._client
-            if self._client is not None
-            else self.client_cls.from_env(
-                org_id=str(ctx.org_id) if ctx.org_id is not None else None
-            )
-        )
+        client = self._make_client()
 
         def _issue_dependencies(
             issue: dict, work_item_id: str

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -31,6 +31,7 @@ from dev_health_ops.workers.task_utils import (
     _credential_mapping,
     _extract_owner_repo,
     _get_db_url,
+    _jira_query_options,
     _merge_sync_flags,
     _normalize_sync_targets,
     _resolve_env_credentials,
@@ -742,12 +743,19 @@ def run_sync_config(
 
         elif provider == "jira":
             backfill_days = int(sync_options.get("backfill_days", 1))
+            jira_project_keys, jira_jql, jira_fetch_all = _jira_query_options(
+                sync_options
+            )
             run_work_items_sync_job(
                 db_url=db_url,
                 day=utc_today(),
                 backfill_days=backfill_days,
                 provider="jira",
                 org_id=org_id,
+                credentials=credentials or None,
+                jira_project_keys=jira_project_keys,
+                jira_jql=jira_jql,
+                jira_fetch_all=jira_fetch_all,
             )
             result_payload["backfill_days"] = backfill_days
 

--- a/src/dev_health_ops/workers/task_utils.py
+++ b/src/dev_health_ops/workers/task_utils.py
@@ -189,6 +189,37 @@ def _as_str_list(value: object | None) -> list[str]:
     return [str(item) for item in value if item is not None]
 
 
+def _jira_query_options(
+    sync_options: dict[str, Any],
+) -> tuple[list[str] | None, str | None, bool | None]:
+    project_keys_raw = sync_options.get("project_keys")
+    if project_keys_raw is None:
+        project_key = sync_options.get("project_key")
+        project_keys = [str(project_key)] if project_key else None
+    elif isinstance(project_keys_raw, str):
+        project_keys = [
+            key.strip() for key in project_keys_raw.split(",") if key.strip()
+        ]
+    else:
+        project_keys = _as_str_list(project_keys_raw) or None
+
+    jql_raw = sync_options.get("jql") or sync_options.get("jira_jql")
+    fetch_all_raw = sync_options.get("fetch_all")
+    if fetch_all_raw is None:
+        fetch_all_raw = sync_options.get("jira_fetch_all")
+
+    fetch_all = None
+    if fetch_all_raw is not None:
+        fetch_all = str(fetch_all_raw).strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+    return project_keys, str(jql_raw) if jql_raw else None, fetch_all
+
+
 def _as_dict(value: object | None) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -112,11 +112,16 @@ def test_run_backfill_for_config_raises_when_config_missing(
 
 
 class _FakeConfig:
-    def __init__(self, org_id: str) -> None:
+    def __init__(
+        self,
+        org_id: str,
+        provider: str = "github",
+        sync_options: dict[str, object] | None = None,
+    ) -> None:
         self.id = org_id
         self.org_id = org_id
-        self.provider = "github"
-        self.sync_options: dict[str, object] = {}
+        self.provider = provider
+        self.sync_options = sync_options or {}
 
 
 def _patch_session_with_config(monkeypatch: pytest.MonkeyPatch, config: object) -> None:
@@ -191,3 +196,38 @@ def test_run_backfill_raises_on_org_mismatch(
             since=date(2026, 1, 1),
             before=date(2026, 1, 3),
         )
+
+
+def test_run_backfill_forwards_jira_query_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_org = "55555555-5555-5555-5555-555555555555"
+    _patch_session_with_config(
+        monkeypatch,
+        _FakeConfig(
+            config_org,
+            provider="jira",
+            sync_options={"project_keys": ["OPS"], "jql": "project = OPS"},
+        ),
+    )
+    captured: dict[str, object] = {}
+
+    def _fake_sync_job(*args, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "dev_health_ops.backfill.runner.run_work_items_sync_job",
+        _fake_sync_job,
+    )
+
+    run_backfill_for_config(
+        db_url="clickhouse://local",
+        sync_config_id="66666666-6666-6666-6666-666666666666",
+        org_id=None,
+        since=date(2026, 1, 1),
+        before=date(2026, 1, 3),
+    )
+
+    assert captured["provider"] == "jira"
+    assert captured["jira_project_keys"] == ["OPS"]
+    assert captured["jira_jql"] == "project = OPS"

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -2862,3 +2862,192 @@ class TestGitLabWorkItemsUrlInjection:
             task.pop_request()
 
         mock_set_watermark.assert_not_called()
+
+
+class TestWorkItemsProviderCredentialIsolation:
+    def _run_sync_config_with_credential(
+        self,
+        db_session,
+        *,
+        provider: str,
+        decrypted: dict,
+        config: dict | None = None,
+        sync_options: dict | None = None,
+    ):
+        import uuid as _uuid
+
+        from dev_health_ops.models.settings import IntegrationCredential
+        from dev_health_ops.workers.sync_runtime import run_sync_config
+
+        credential = IntegrationCredential(
+            org_id="default",
+            provider=provider,
+            name="default",
+            credentials_encrypted="ciphertext",
+            config=config or {},
+        )
+        db_session.add(credential)
+        db_session.flush()
+
+        sync_config = _make_config(
+            provider=provider,
+            sync_options={"backfill_days": 1, **(sync_options or {})},
+            sync_targets=["work-items"],
+            org_id="default",
+        )
+        sync_config.credential_id = credential.id
+        db_session.add(sync_config)
+        db_session.flush()
+
+        with (
+            patch(
+                "dev_health_ops.workers.sync_runtime._get_db_url",
+                return_value="clickhouse://localhost/dev",
+            ),
+            patch("dev_health_ops.workers.sync_runtime._dispatch_post_sync_tasks"),
+            patch(
+                "dev_health_ops.metrics.job_work_items.run_work_items_sync_job"
+            ) as mock_run_work_items,
+            patch(
+                "dev_health_ops.workers.task_utils._decrypt_credential_sync",
+                return_value=decrypted,
+            ),
+            patch(
+                "dev_health_ops.db.get_postgres_session_sync",
+                side_effect=lambda *a, **k: _fake_session_ctx(db_session),
+            ),
+        ):
+            task = run_sync_config
+            task.push_request(id=f"{provider}-runtime-cred-{_uuid.uuid4()}")
+            try:
+                result = task(config_id=str(sync_config.id), org_id="default")
+            finally:
+                task.pop_request()
+
+        return result, mock_run_work_items
+
+    def test_run_sync_config_forwards_linear_credentials(self, db_session):
+        result, mock_run_work_items = self._run_sync_config_with_credential(
+            db_session,
+            provider="linear",
+            decrypted={"api_key": "lin_runtime"},
+        )
+
+        assert result["status"] == "success"
+        assert mock_run_work_items.call_args.kwargs["credentials"] == {
+            "api_key": "lin_runtime"
+        }
+
+    def test_run_sync_config_forwards_jira_credentials(self, db_session):
+        result, mock_run_work_items = self._run_sync_config_with_credential(
+            db_session,
+            provider="jira",
+            decrypted={
+                "base_url": "https://tenant.atlassian.net",
+                "email": "tenant@example.com",
+                "api_token": "jira_runtime",
+            },
+            sync_options={"project_keys": ["OPS"], "jql": "project = OPS"},
+        )
+
+        assert result["status"] == "success"
+        assert mock_run_work_items.call_args.kwargs["credentials"] == {
+            "base_url": "https://tenant.atlassian.net",
+            "email": "tenant@example.com",
+            "api_token": "jira_runtime",
+        }
+        assert mock_run_work_items.call_args.kwargs["jira_project_keys"] == ["OPS"]
+        assert mock_run_work_items.call_args.kwargs["jira_jql"] == "project = OPS"
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("dev_health_ops.metrics.job_work_items.ClickHouseMetricsSink")
+    @patch("dev_health_ops.providers.linear.client.LinearClient.from_env")
+    def test_linear_work_items_use_explicit_credentials_not_env(
+        self, mock_from_env, mock_sink_class
+    ):
+        from dev_health_ops.metrics.job_work_items import run_work_items_sync_job
+        from dev_health_ops.providers.linear.client import LinearClient
+
+        sink = MagicMock()
+        sink.query_dicts.return_value = []
+        mock_sink_class.return_value = sink
+
+        captured_clients: list[object] = []
+
+        def _fake_iter_ingest(self, ctx):
+            client = self._make_client()
+            captured_clients.append(client)
+            return iter(())
+
+        with patch(
+            "dev_health_ops.providers.linear.provider.LinearProvider.iter_ingest",
+            new=_fake_iter_ingest,
+        ):
+            run_work_items_sync_job(
+                db_url="clickhouse://localhost/dev",
+                day=datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+                backfill_days=1,
+                provider="linear",
+                org_id="00000000-0000-0000-0000-000000000001",
+                credentials={"api_key": "lin_explicit"},
+            )
+
+        mock_from_env.assert_not_called()
+        assert captured_clients
+        assert isinstance(captured_clients[0], LinearClient)
+        assert captured_clients[0].auth.api_key == "lin_explicit"
+
+    @patch.dict(
+        os.environ,
+        {"JIRA_JQL": "project = ENV", "JIRA_PROJECT_KEYS": "ENV"},
+        clear=True,
+    )
+    @patch("dev_health_ops.metrics.job_work_items.ClickHouseMetricsSink")
+    @patch("dev_health_ops.providers.jira.client.JiraClient.from_env")
+    def test_jira_work_items_use_explicit_credentials_not_env(
+        self, mock_from_env, mock_sink_class
+    ):
+        from dev_health_ops.metrics.job_work_items import run_work_items_sync_job
+
+        sink = MagicMock()
+        sink.query_dicts.return_value = []
+        mock_sink_class.return_value = sink
+
+        captured_clients: list[object] = []
+        captured_jqls: list[str] = []
+
+        class FakeJiraClient:
+            def iter_issues(self, **kwargs):
+                captured_clients.append(self)
+                captured_jqls.append(kwargs["jql"])
+                return iter(())
+
+            def close(self):
+                pass
+
+        with patch(
+            "dev_health_ops.providers.jira.client.JiraClient",
+            return_value=FakeJiraClient(),
+        ) as mock_jira_client:
+            run_work_items_sync_job(
+                db_url="clickhouse://localhost/dev",
+                day=datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+                backfill_days=1,
+                provider="jira",
+                org_id="00000000-0000-0000-0000-000000000001",
+                credentials={
+                    "base_url": "https://tenant.atlassian.net",
+                    "email": "tenant@example.com",
+                    "api_token": "jira_explicit",
+                },
+            )
+
+        mock_from_env.assert_not_called()
+        assert captured_clients
+        kwargs = mock_jira_client.call_args.kwargs
+        assert isinstance(captured_clients[0], FakeJiraClient)
+        assert captured_jqls
+        assert all("ENV" not in jql for jql in captured_jqls)
+        assert kwargs["auth"].base_url == "https://tenant.atlassian.net"
+        assert kwargs["auth"].email == "tenant@example.com"
+        assert kwargs["auth"].api_token == "jira_explicit"


### PR DESCRIPTION
## Summary
- build Jira and Linear work-items clients from tenant-scoped sync config credentials instead of ambient environment credentials
- forward Jira query scope options from Sync Now and backfill into work-items sync
- prevent tenant-scoped Jira jobs from inheriting hostile ambient Jira query environment variables

## Verification
- PYTHONPATH=src python -m pytest tests/test_sync_partitioning.py tests/test_backfill.py tests/test_sync_runtime.py tests/test_credentials_resolver.py
- PYTHONPATH=src python -m ruff check src/dev_health_ops/backfill/runner.py src/dev_health_ops/credentials/resolver.py src/dev_health_ops/metrics/job_work_items.py src/dev_health_ops/metrics/work_items.py src/dev_health_ops/providers/linear/provider.py src/dev_health_ops/workers/sync_runtime.py src/dev_health_ops/workers/task_utils.py tests/test_backfill.py tests/test_sync_partitioning.py
- PYTHONPATH=src python -m ruff format --check src/dev_health_ops/backfill/runner.py src/dev_health_ops/credentials/resolver.py src/dev_health_ops/metrics/job_work_items.py src/dev_health_ops/metrics/work_items.py src/dev_health_ops/providers/linear/provider.py src/dev_health_ops/workers/sync_runtime.py src/dev_health_ops/workers/task_utils.py tests/test_backfill.py tests/test_sync_partitioning.py
- Manual driver checks for Jira and Linear tenant credential paths