### PR TITLE
feat(metrics): resolve team attribution at compute time (CHAOS-2469)

### DIFF
--- a/src/dev_health_ops/metrics/compute_work_item_state_durations.py
+++ b/src/dev_health_ops/metrics/compute_work_item_state_durations.py
@@ -4,7 +4,10 @@ from collections import defaultdict
 from collections.abc import Sequence
 from datetime import date, datetime, time, timedelta, timezone
 
-from dev_health_ops.metrics.compute_work_items import resolve_base_team
+from dev_health_ops.metrics.compute_work_items import (
+    TeamAttributionContext,
+    resolve_team_attribution,
+)
 from dev_health_ops.metrics.schemas import WorkItemStateDurationDailyRecord
 from dev_health_ops.models.work_items import (
     WorkItem,
@@ -32,17 +35,21 @@ def _resolve_team(
     team_resolver: TeamResolver | None,
     project_key_resolver: ProjectKeyTeamResolver | None,
     linked_issue_resolver: LinkedIssueTeamResolver | None,
+    attribution_context: TeamAttributionContext | None,
 ) -> tuple[str, str]:
     """Resolve an item's team using the same cascade as the cycle-time compute.
 
-    Shares ``resolve_base_team`` (scope key → project_key → assignee) and the
-    linked-issue inheritance fallback so a PR is attributed to the SAME team in
-    state-duration rows as in ``work_item_cycle_times`` — otherwise the same
-    item could read as a donor team in one table and ``unassigned`` in another.
+    Shares the attribution resolver used by cycle-time compute so a PR is
+    attributed to the same team in state-duration rows as in
+    ``work_item_cycle_times``.
     """
-    team_id, team_name = resolve_base_team(item, team_resolver, project_key_resolver)
-    if team_id is None and linked_issue_resolver is not None:
-        team_id, team_name = linked_issue_resolver.resolve(item.work_item_id)
+    team_id, team_name, _ = resolve_team_attribution(
+        item,
+        team_resolver,
+        project_key_resolver,
+        linked_issue_resolver=linked_issue_resolver,
+        attribution_context=attribution_context,
+    )
     return normalize_team_id(team_id), normalize_team_name(team_name)
 
 
@@ -107,6 +114,7 @@ def compute_work_item_state_durations_daily(
     team_resolver: TeamResolver | None = None,
     project_key_resolver: ProjectKeyTeamResolver | None = None,
     linked_issue_resolver: LinkedIssueTeamResolver | None = None,
+    attribution_context: TeamAttributionContext | None = None,
 ) -> list[WorkItemStateDurationDailyRecord]:
     """
     Compute per-day time-in-state totals from status transitions.
@@ -142,6 +150,7 @@ def compute_work_item_state_durations_daily(
             team_resolver,
             project_key_resolver,
             linked_issue_resolver,
+            attribution_context,
         )
         work_scope_id = item.work_scope_id or ""
         team_name_by_key[(item.provider, work_scope_id, team_id)] = team_name

--- a/src/dev_health_ops/metrics/compute_work_items.py
+++ b/src/dev_health_ops/metrics/compute_work_items.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta, timezone
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 from dev_health_ops.metrics.schemas import (
     WorkItemCycleTimeRecord,
     WorkItemMetricsDailyRecord,
+    WorkItemTeamAttributionRecord,
     WorkItemUserMetricsDailyRecord,
 )
 from dev_health_ops.models.work_items import (
@@ -56,6 +58,288 @@ def _resolve_team(
     return team_resolver.resolve(identity)
 
 
+TeamAttributionSource = Literal[
+    "native_team",
+    "linked_issue",
+    "project_ownership",
+    "repo_ownership",
+    "assignee_membership",
+    "unassigned",
+]
+
+
+@dataclass(frozen=True)
+class TeamAttributionCandidate:
+    source: TeamAttributionSource
+    team_id: str | None
+    team_name: str | None
+    confidence: str
+    evidence: str
+    is_primary: int = 0
+    specificity: int = 0
+    priority: int = 0
+    updated_at: datetime = field(
+        default_factory=lambda: datetime.min.replace(tzinfo=timezone.utc)
+    )
+
+
+@dataclass(frozen=True)
+class TeamAttributionContext:
+    project_by_id: dict[tuple[str, str], list[TeamAttributionCandidate]] = field(
+        default_factory=dict
+    )
+    project_by_key: dict[tuple[str, str], list[TeamAttributionCandidate]] = field(
+        default_factory=dict
+    )
+    repo_by_id: dict[tuple[str, str], list[TeamAttributionCandidate]] = field(
+        default_factory=dict
+    )
+    repo_by_name: dict[tuple[str, str], list[TeamAttributionCandidate]] = field(
+        default_factory=dict
+    )
+    member_by_identity: dict[tuple[str, str], list[TeamAttributionCandidate]] = field(
+        default_factory=dict
+    )
+
+
+_SOURCE_ORDER: dict[TeamAttributionSource, int] = {
+    "native_team": 0,
+    "linked_issue": 1,
+    "project_ownership": 2,
+    "repo_ownership": 3,
+    "assignee_membership": 4,
+    "unassigned": 5,
+}
+
+
+def _identity_key(value: str | None) -> str:
+    return " ".join((value or "").strip().lower().split())
+
+
+def _candidate_sort_key(
+    candidate: TeamAttributionCandidate,
+) -> tuple[int, int, int, float, str]:
+    updated_at = to_utc(candidate.updated_at)
+    return (
+        -int(candidate.is_primary),
+        -int(candidate.specificity),
+        int(candidate.priority),
+        -updated_at.timestamp(),
+        candidate.team_id or "",
+    )
+
+
+def _ranked(
+    candidates: Sequence[TeamAttributionCandidate],
+) -> list[TeamAttributionCandidate]:
+    return sorted(candidates, key=_candidate_sort_key)
+
+
+def _dedupe_candidates(
+    candidates: Sequence[TeamAttributionCandidate],
+) -> list[TeamAttributionCandidate]:
+    seen: set[tuple[object, ...]] = set()
+    deduped: list[TeamAttributionCandidate] = []
+    for candidate in candidates:
+        key = (
+            candidate.source,
+            candidate.team_id,
+            candidate.team_name,
+            candidate.confidence,
+            candidate.evidence,
+            candidate.is_primary,
+            candidate.specificity,
+            candidate.priority,
+            to_utc(candidate.updated_at),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(candidate)
+    return deduped
+
+
+def _context_candidates(
+    mapping: dict[tuple[str, str], list[TeamAttributionCandidate]],
+    provider: str,
+    key: object,
+) -> list[TeamAttributionCandidate]:
+    if key is None:
+        return []
+    return list(mapping.get((provider, str(key)), []))
+
+
+def _native_team_candidate(
+    item: WorkItem,
+    project_key_resolver: ProjectKeyTeamResolver | None,
+) -> TeamAttributionCandidate | None:
+    if project_key_resolver is None or not item.native_team_key:
+        return None
+    native_key = str(item.native_team_key)
+    team_id, team_name = project_key_resolver.resolve(native_key)
+    if team_id is None:
+        return None
+    return TeamAttributionCandidate(
+        source="native_team",
+        team_id=team_id,
+        team_name=team_name or team_id,
+        confidence="high",
+        evidence=f"native_team_key={native_key}",
+        is_primary=1,
+        specificity=100,
+    )
+
+
+def _legacy_project_candidate(
+    item: WorkItem,
+    project_key_resolver: ProjectKeyTeamResolver | None,
+) -> TeamAttributionCandidate | None:
+    if project_key_resolver is None:
+        return None
+    keys = [item.work_scope_id or ""]
+    if item.project_key:
+        project_key = str(item.project_key)
+        if project_key not in keys:
+            keys.append(project_key)
+    for key in keys:
+        team_id, team_name = project_key_resolver.resolve(key)
+        if team_id is not None:
+            return TeamAttributionCandidate(
+                source="project_ownership",
+                team_id=team_id,
+                team_name=team_name or team_id,
+                confidence="medium",
+                evidence=f"project_key={key}",
+                is_primary=1,
+                specificity=50,
+            )
+    return None
+
+
+def resolve_team_attribution(
+    item: WorkItem,
+    team_resolver: TeamResolver | None,
+    project_key_resolver: ProjectKeyTeamResolver | None,
+    linked_issue_resolver: LinkedIssueTeamResolver | None = None,
+    attribution_context: TeamAttributionContext | None = None,
+) -> tuple[str | None, str | None, list[TeamAttributionCandidate]]:
+    candidates_by_source: dict[
+        TeamAttributionSource, list[TeamAttributionCandidate]
+    ] = {
+        "native_team": [],
+        "linked_issue": [],
+        "project_ownership": [],
+        "repo_ownership": [],
+        "assignee_membership": [],
+        "unassigned": [],
+    }
+
+    native = _native_team_candidate(item, project_key_resolver)
+    if native is not None:
+        candidates_by_source["native_team"].append(native)
+
+    if linked_issue_resolver is not None:
+        linked_team_id, linked_team_name = linked_issue_resolver.resolve(
+            item.work_item_id
+        )
+        if linked_team_id is not None:
+            candidates_by_source["linked_issue"].append(
+                TeamAttributionCandidate(
+                    source="linked_issue",
+                    team_id=linked_team_id,
+                    team_name=linked_team_name or linked_team_id,
+                    confidence="medium",
+                    evidence=f"linked_issue={item.work_item_id}",
+                    is_primary=1,
+                    specificity=90,
+                )
+            )
+
+    legacy_project = _legacy_project_candidate(item, project_key_resolver)
+    if legacy_project is not None:
+        candidates_by_source["project_ownership"].append(legacy_project)
+
+    if attribution_context is not None:
+        candidates_by_source["project_ownership"].extend(
+            _context_candidates(
+                attribution_context.project_by_id, item.provider, item.project_id
+            )
+        )
+        candidates_by_source["project_ownership"].extend(
+            _context_candidates(
+                attribution_context.project_by_key, item.provider, item.project_key
+            )
+        )
+        candidates_by_source["repo_ownership"].extend(
+            _context_candidates(
+                attribution_context.repo_by_id, item.provider, item.repo_id
+            )
+        )
+        candidates_by_source["repo_ownership"].extend(
+            _context_candidates(
+                attribution_context.repo_by_name, item.provider, item.project_id
+            )
+        )
+        for assignee in item.assignees:
+            candidates_by_source["assignee_membership"].extend(
+                _context_candidates(
+                    attribution_context.member_by_identity,
+                    item.provider,
+                    _identity_key(assignee),
+                )
+            )
+
+    assignee = item.assignees[0] if item.assignees else None
+    team_id, team_name = _resolve_team(team_resolver, assignee)
+    if team_id is not None:
+        candidates_by_source["assignee_membership"].append(
+            TeamAttributionCandidate(
+                source="assignee_membership",
+                team_id=team_id,
+                team_name=team_name or team_id,
+                confidence="medium",
+                evidence=f"assignee={assignee}",
+                is_primary=1,
+                specificity=50,
+            )
+        )
+
+    primary: TeamAttributionCandidate | None = None
+    rows: list[TeamAttributionCandidate] = []
+    for source in sorted(candidates_by_source, key=lambda s: _SOURCE_ORDER[s]):
+        ranked = _ranked(_dedupe_candidates(candidates_by_source[source]))
+        if primary is None and ranked:
+            primary = ranked[0]
+        rows.extend(ranked)
+
+    if primary is None:
+        primary = TeamAttributionCandidate(
+            source="unassigned",
+            team_id=None,
+            team_name=None,
+            confidence="low",
+            evidence="no_candidate",
+            is_primary=1,
+        )
+        rows.append(primary)
+
+    marked_rows = [
+        TeamAttributionCandidate(
+            source=c.source,
+            team_id=c.team_id,
+            team_name=c.team_name,
+            confidence=c.confidence,
+            evidence=c.evidence,
+            is_primary=1 if c is primary else 0,
+            specificity=c.specificity,
+            priority=c.priority,
+            updated_at=c.updated_at,
+        )
+        for c in rows
+    ]
+    return primary.team_id, primary.team_name, marked_rows
+
+
 def resolve_base_team(
     item: WorkItem,
     team_resolver: TeamResolver | None,
@@ -70,21 +354,15 @@ def resolve_base_team(
     apply identical rules — an item only becomes an inheritance donor if it
     resolves to a real team here.
     """
-    work_scope_id = item.work_scope_id or ""
-    team_id: str | None = None
-    team_name: str | None = None
-    if project_key_resolver is not None:
-        team_id, team_name = project_key_resolver.resolve(work_scope_id)
-        # Linear: work_scope_id is the project name when the issue sits in a
-        # project, but team mappings carry the TEAM key (the item's
-        # project_key) — retry with it before the membership fallback.
-        if team_id is None and item.project_key:
-            project_key = str(item.project_key)
-            if project_key != work_scope_id:
-                team_id, team_name = project_key_resolver.resolve(project_key)
-    if team_id is None:
-        assignee = item.assignees[0] if item.assignees else None
-        team_id, team_name = _resolve_team(team_resolver, assignee)
+    team_id, team_name, _ = resolve_team_attribution(
+        item,
+        team_resolver,
+        project_key_resolver,
+        linked_issue_resolver=None,
+        attribution_context=None,
+    )
+    if team_id == "unassigned":
+        return None, None
     return team_id, team_name
 
 
@@ -105,6 +383,7 @@ def build_linked_issue_team_resolver(
     dependencies: Sequence[WorkItemDependency],
     team_resolver: TeamResolver | None = None,
     project_key_resolver: ProjectKeyTeamResolver | None = None,
+    attribution_context: TeamAttributionContext | None = None,
 ) -> LinkedIssueTeamResolver:
     """Build the cross-item team-inheritance fallback from dependency edges.
 
@@ -132,10 +411,15 @@ def build_linked_issue_team_resolver(
 
     for item in work_items:
         wid = item.work_item_id
-        team_id, team_name = resolve_base_team(
-            item, team_resolver, project_key_resolver
+        native = _native_team_candidate(item, project_key_resolver)
+        team_id, team_name, _ = resolve_team_attribution(
+            item,
+            team_resolver,
+            project_key_resolver,
+            linked_issue_resolver=None,
+            attribution_context=attribution_context,
         )
-        base_resolved[wid] = team_id
+        base_resolved[wid] = native.team_id if native is not None else None
         if team_id:
             donor_team[wid] = (team_id, team_name or team_id)
         if item.provider in ("linear", "jira") and ":" in wid:
@@ -331,6 +615,7 @@ def compute_work_item_metrics_daily(
     team_resolver: TeamResolver | None = None,
     project_key_resolver: ProjectKeyTeamResolver | None = None,
     linked_issue_resolver: LinkedIssueTeamResolver | None = None,
+    attribution_context: TeamAttributionContext | None = None,
 ) -> tuple[
     list[WorkItemMetricsDailyRecord],
     list[WorkItemUserMetricsDailyRecord],
@@ -372,14 +657,13 @@ def compute_work_item_metrics_daily(
             continue
 
         assignee = item.assignees[0] if item.assignees else None
-        team_id, team_name = resolve_base_team(
-            item, team_resolver, project_key_resolver
+        team_id, team_name, _ = resolve_team_attribution(
+            item,
+            team_resolver,
+            project_key_resolver,
+            linked_issue_resolver=linked_issue_resolver,
+            attribution_context=attribution_context,
         )
-        # Final fallback: inherit team from a linked issue (e.g. a PR that
-        # closes a Linear/Jira issue). Provider-agnostic; only fills items
-        # that resolved to no team of their own.
-        if team_id is None and linked_issue_resolver is not None:
-            team_id, team_name = linked_issue_resolver.resolve(item.work_item_id)
         team_id_norm = normalize_team_id(team_id)
         team_name_norm = normalize_team_name(team_name)
 
@@ -669,3 +953,41 @@ def compute_work_item_metrics_daily(
         )
 
     return group_records, user_records, cycle_time_records
+
+
+def compute_work_item_team_attributions(
+    *,
+    work_items: Sequence[WorkItem],
+    computed_at: datetime,
+    team_resolver: TeamResolver | None = None,
+    project_key_resolver: ProjectKeyTeamResolver | None = None,
+    linked_issue_resolver: LinkedIssueTeamResolver | None = None,
+    attribution_context: TeamAttributionContext | None = None,
+) -> list[WorkItemTeamAttributionRecord]:
+    computed_at_utc = to_utc(computed_at)
+    records: list[WorkItemTeamAttributionRecord] = []
+    for item in work_items:
+        _, _, candidates = resolve_team_attribution(
+            item,
+            team_resolver,
+            project_key_resolver,
+            linked_issue_resolver=linked_issue_resolver,
+            attribution_context=attribution_context,
+        )
+        for candidate in candidates:
+            records.append(
+                WorkItemTeamAttributionRecord(
+                    repo_id=item.repo_id,
+                    work_item_id=item.work_item_id,
+                    provider=item.provider,
+                    team_id=candidate.team_id,
+                    team_name=candidate.team_name,
+                    source=candidate.source,
+                    is_primary=candidate.is_primary,
+                    confidence=candidate.confidence,
+                    evidence=candidate.evidence,
+                    computed_at=computed_at_utc,
+                    org_id=item.org_id,
+                )
+            )
+    return records

--- a/src/dev_health_ops/metrics/compute_work_items.py
+++ b/src/dev_health_ops/metrics/compute_work_items.py
@@ -280,16 +280,16 @@ def resolve_team_attribution(
                 attribution_context.repo_by_name, item.provider, item.project_id
             )
         )
-        for assignee in item.assignees:
+        for assignee_identity in item.assignees:
             candidates_by_source["assignee_membership"].extend(
                 _context_candidates(
                     attribution_context.member_by_identity,
                     item.provider,
-                    _identity_key(assignee),
+                    _identity_key(assignee_identity),
                 )
             )
 
-    assignee = item.assignees[0] if item.assignees else None
+    assignee: str | None = item.assignees[0] if item.assignees else None
     team_id, team_name = _resolve_team(team_resolver, assignee)
     if team_id is not None:
         candidates_by_source["assignee_membership"].append(

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -43,6 +43,7 @@ from dev_health_ops.metrics.compute_work_item_state_durations import (
 from dev_health_ops.metrics.compute_work_items import (
     build_linked_issue_team_resolver,
     compute_work_item_metrics_daily,
+    compute_work_item_team_attributions,
 )
 from dev_health_ops.metrics.dependencies import get_metrics_dependencies
 from dev_health_ops.metrics.hotspots import (
@@ -755,6 +756,7 @@ async def run_daily_metrics_job(
     # table) simply skip inheritance instead of failing the daily job.
     work_item_dependencies: list[Any] = []
     linked_issue_resolver = None
+    team_attribution_context = None
     # Linked-issue inheritance reads org-wide (repo_id=None), so it is only
     # safe under an explicit tenant scope: without org_id the loader's filter
     # is empty and the donor/edge queries would span every tenant, letting a
@@ -768,6 +770,15 @@ async def run_daily_metrics_job(
         # aborting the daily job. A PR can reference a donor that completed
         # before any metrics day, or a repo-less Linear/Jira issue, so the
         # bounded lookup is org-wide and window-independent.
+        _load_attr_context = getattr(loader, "load_team_attribution_context", None)
+        if _load_attr_context is not None:
+            try:
+                team_attribution_context = await _load_attr_context(as_of=computed_at)
+            except Exception:
+                logger.warning(
+                    "Team attribution context load failed; using legacy resolvers only",
+                    exc_info=True,
+                )
         _load_deps = getattr(loader, "load_work_item_dependencies", None)
         _load_donors = getattr(loader, "load_work_item_dependencies_donors", None)
         if _load_deps is not None and _load_donors is not None:
@@ -799,6 +810,7 @@ async def run_daily_metrics_job(
                     dependencies=work_item_dependencies,
                     team_resolver=team_resolver,
                     project_key_resolver=project_key_resolver,
+                    attribution_context=team_attribution_context,
                 )
             except Exception:
                 logger.warning(
@@ -978,6 +990,7 @@ async def run_daily_metrics_job(
         wi_metrics: list[Any] = []
         wi_user_metrics: list[Any] = []
         wi_cycle_times: list[Any] = []
+        wi_team_attributions: list[Any] = []
         wi_state_durations: list[Any] = []
         if work_items:
             wi_metrics, wi_user_metrics, wi_cycle_times = (
@@ -989,7 +1002,16 @@ async def run_daily_metrics_job(
                     team_resolver=team_resolver,
                     project_key_resolver=project_key_resolver,
                     linked_issue_resolver=linked_issue_resolver,
+                    attribution_context=team_attribution_context,
                 )
+            )
+            wi_team_attributions = compute_work_item_team_attributions(
+                work_items=work_items,
+                computed_at=computed_at,
+                team_resolver=team_resolver,
+                project_key_resolver=project_key_resolver,
+                linked_issue_resolver=linked_issue_resolver,
+                attribution_context=team_attribution_context,
             )
             # CHAOS-2377: the state-duration rollup powers /metrics Flow Sankey +
             # Flame and the Operating Review state-duration panel. The compute
@@ -1005,6 +1027,7 @@ async def run_daily_metrics_job(
                 team_resolver=team_resolver,
                 project_key_resolver=project_key_resolver,
                 linked_issue_resolver=linked_issue_resolver,
+                attribution_context=team_attribution_context,
             )
 
         review_edges = compute_review_edges_daily(
@@ -1212,6 +1235,8 @@ async def run_daily_metrics_job(
                 s.write_work_item_user_metrics(wi_user_metrics)
             if wi_cycle_times:
                 s.write_work_item_cycle_times(wi_cycle_times)
+            if wi_team_attributions and hasattr(s, "write_work_item_team_attributions"):
+                s.write_work_item_team_attributions(wi_team_attributions)
             if wi_state_durations:
                 s.write_work_item_state_durations(wi_state_durations)
             s.write_review_edges(review_edges)

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import logging
 import uuid
 from dataclasses import replace
@@ -15,7 +16,8 @@ from dev_health_ops.metrics.compute_work_item_state_durations import (
 from dev_health_ops.metrics.compute_work_items import (
     build_linked_issue_team_resolver,
     compute_work_item_metrics_daily,
-    resolve_base_team,
+    compute_work_item_team_attributions,
+    resolve_team_attribution,
 )
 from dev_health_ops.metrics.job_daily import (
     REPO_ROOT,
@@ -23,6 +25,7 @@ from dev_health_ops.metrics.job_daily import (
     _to_utc,
 )
 from dev_health_ops.metrics.loaders.base import to_dataclass
+from dev_health_ops.metrics.loaders.clickhouse import ClickHouseDataLoader
 from dev_health_ops.metrics.schemas import (
     InvestmentClassificationRecord,
     InvestmentMetricsRecord,
@@ -641,11 +644,26 @@ def run_work_items_sync_job(
         for wi in work_items:
             donor_by_id[wi.work_item_id] = wi
 
+        team_attribution_context = None
+        if org_id:
+            try:
+                team_attribution_context = asyncio.run(
+                    ClickHouseDataLoader(
+                        primary_sink.client, org_id=org_id
+                    ).load_team_attribution_context(as_of=computed_at)
+                )
+            except Exception:
+                logger.warning(
+                    "Team attribution context load failed; using legacy resolvers only",
+                    exc_info=True,
+                )
+
         linked_issue_resolver = build_linked_issue_team_resolver(
             work_items=list(donor_by_id.values()),
             dependencies=list(merged_deps.values()),
             team_resolver=team_resolver,
             project_key_resolver=pk_resolver,
+            attribution_context=team_attribution_context,
         )
 
         for d in days:
@@ -658,7 +676,16 @@ def run_work_items_sync_job(
                     team_resolver=team_resolver,
                     project_key_resolver=pk_resolver,
                     linked_issue_resolver=linked_issue_resolver,
+                    attribution_context=team_attribution_context,
                 )
+            )
+            wi_team_attributions = compute_work_item_team_attributions(
+                work_items=work_items,
+                computed_at=computed_at,
+                team_resolver=team_resolver,
+                project_key_resolver=pk_resolver,
+                linked_issue_resolver=linked_issue_resolver,
+                attribution_context=team_attribution_context,
             )
             wi_state_durations = compute_work_item_state_durations_daily(
                 day=d,
@@ -668,6 +695,7 @@ def run_work_items_sync_job(
                 team_resolver=team_resolver,
                 project_key_resolver=pk_resolver,
                 linked_issue_resolver=linked_issue_resolver,
+                attribution_context=team_attribution_context,
             )
 
             # --- Issue Type Metrics ---
@@ -676,14 +704,13 @@ def run_work_items_sync_job(
             ] = {}
 
             def _get_team(wi: Any) -> str:
-                # Same cascade as cycle-time / state-duration compute, including
-                # the linked-issue inheritance fallback, so issue-type and
-                # investment tables never disagree with the others on a PR's team.
-                team_id, _ = resolve_base_team(wi, team_resolver, pk_resolver)
-                if team_id is None:
-                    team_id, _ = linked_issue_resolver.resolve(
-                        getattr(wi, "work_item_id", None)
-                    )
+                team_id, _, _ = resolve_team_attribution(
+                    wi,
+                    team_resolver,
+                    pk_resolver,
+                    linked_issue_resolver=linked_issue_resolver,
+                    attribution_context=team_attribution_context,
+                )
                 return normalize_team_id(team_id)
 
             def _normalize_investment_team_id(team_id: str | None) -> str | None:
@@ -847,6 +874,10 @@ def run_work_items_sync_job(
                     s.write_work_item_user_metrics(wi_user_metrics)
                 if wi_cycle_times:
                     s.write_work_item_cycle_times(wi_cycle_times)
+                if wi_team_attributions and hasattr(
+                    s, "write_work_item_team_attributions"
+                ):
+                    s.write_work_item_team_attributions(wi_team_attributions)
                 if wi_state_durations:
                     s.write_work_item_state_durations(wi_state_durations)
 

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -7,6 +7,11 @@ import uuid
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, cast
 
+from dev_health_ops.metrics.compute_work_items import (
+    TeamAttributionCandidate,
+    TeamAttributionContext,
+    TeamAttributionSource,
+)
 from dev_health_ops.metrics.loaders.ai_impact import AIImpactClickHouseLoader
 from dev_health_ops.metrics.loaders.base import (
     DataLoader,
@@ -350,6 +355,141 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
             )
             return []
         return [to_dataclass(WorkItemDependency, d) for d in dep_dicts]
+
+    async def load_team_attribution_context(
+        self, *, as_of: datetime
+    ) -> TeamAttributionContext:
+        org_filter = self._org_filter(alias="o")
+        params = self._inject_org_id({"as_of": naive_utc(as_of)})
+
+        def _candidate(
+            row: dict[str, Any], source: str, evidence: str
+        ) -> TeamAttributionCandidate:
+            return TeamAttributionCandidate(
+                source=cast(TeamAttributionSource, source),
+                team_id=str(row.get("team_id") or ""),
+                team_name=str(row.get("team_name") or row.get("team_id") or ""),
+                confidence="high" if int(row.get("is_primary") or 0) else "medium",
+                evidence=evidence,
+                is_primary=int(row.get("is_primary") or 0),
+                specificity=int(row.get("specificity") or 0),
+                priority=int(row.get("priority") or 0),
+                updated_at=row.get("updated_at") or as_of,
+            )
+
+        project_rows = await _clickhouse_query_dicts(
+            self.client,
+            f"""
+            SELECT
+                o.provider,
+                o.team_id,
+                ifNull(nullIf(t.name, ''), o.team_id) AS team_name,
+                o.project_id,
+                o.project_key,
+                o.is_primary,
+                o.specificity,
+                o.priority,
+                o.updated_at
+            FROM team_project_ownership AS o
+            LEFT JOIN teams AS t ON t.org_id = o.org_id AND t.id = o.team_id
+            WHERE o.valid_from <= {{as_of:DateTime}}
+              AND (o.valid_to IS NULL OR o.valid_to > {{as_of:DateTime}})
+              {org_filter}
+            """,
+            params,
+        )
+        repo_rows = await _clickhouse_query_dicts(
+            self.client,
+            f"""
+            SELECT
+                o.provider,
+                o.team_id,
+                ifNull(nullIf(t.name, ''), o.team_id) AS team_name,
+                o.repo_id,
+                o.repo_full_name,
+                o.is_primary,
+                o.specificity,
+                o.priority,
+                o.updated_at
+            FROM team_repo_ownership AS o
+            LEFT JOIN teams AS t ON t.org_id = o.org_id AND t.id = o.team_id
+            WHERE o.valid_from <= {{as_of:DateTime}}
+              AND (o.valid_to IS NULL OR o.valid_to > {{as_of:DateTime}})
+              {org_filter}
+            """,
+            params,
+        )
+        member_rows = await _clickhouse_query_dicts(
+            self.client,
+            f"""
+            SELECT
+                o.provider,
+                o.team_id,
+                ifNull(nullIf(t.name, ''), o.team_id) AS team_name,
+                o.member_id,
+                o.raw_provider_user_id,
+                o.raw_email,
+                o.is_primary,
+                o.specificity,
+                o.priority,
+                o.updated_at
+            FROM team_memberships AS o
+            LEFT JOIN teams AS t ON t.org_id = o.org_id AND t.id = o.team_id
+            WHERE o.valid_from <= {{as_of:DateTime}}
+              AND (o.valid_to IS NULL OR o.valid_to > {{as_of:DateTime}})
+              {org_filter}
+            """,
+            params,
+        )
+
+        context = TeamAttributionContext()
+        for row in project_rows:
+            candidate = _candidate(
+                row,
+                "project_ownership",
+                f"project_ownership={row.get('project_id') or row.get('project_key')}",
+            )
+            if row.get("project_id"):
+                context.project_by_id.setdefault(
+                    (str(row.get("provider") or ""), str(row["project_id"])), []
+                ).append(candidate)
+            if row.get("project_key"):
+                context.project_by_key.setdefault(
+                    (str(row.get("provider") or ""), str(row["project_key"])), []
+                ).append(candidate)
+
+        for row in repo_rows:
+            candidate = _candidate(
+                row,
+                "repo_ownership",
+                f"repo_ownership={row.get('repo_id') or row.get('repo_full_name')}",
+            )
+            if row.get("repo_id"):
+                context.repo_by_id.setdefault(
+                    (str(row.get("provider") or ""), str(row["repo_id"])), []
+                ).append(candidate)
+            if row.get("repo_full_name"):
+                context.repo_by_name.setdefault(
+                    (str(row.get("provider") or ""), str(row["repo_full_name"])), []
+                ).append(candidate)
+
+        for row in member_rows:
+            candidate = _candidate(
+                row,
+                "assignee_membership",
+                f"assignee_membership={row.get('member_id') or row.get('raw_email')}",
+            )
+            for identity in (
+                row.get("member_id"),
+                row.get("raw_provider_user_id"),
+                row.get("raw_email"),
+            ):
+                key = " ".join(str(identity or "").strip().lower().split())
+                if key:
+                    context.member_by_identity.setdefault(
+                        (str(row.get("provider") or ""), key), []
+                    ).append(candidate)
+        return context
 
     async def load_cicd_data(
         self,

--- a/tests/test_linked_issue_team_inheritance.py
+++ b/tests/test_linked_issue_team_inheritance.py
@@ -17,9 +17,13 @@ from dev_health_ops.metrics.compute_work_item_state_durations import (
     compute_work_item_state_durations_daily,
 )
 from dev_health_ops.metrics.compute_work_items import (
+    TeamAttributionCandidate,
+    TeamAttributionContext,
     build_linked_issue_team_resolver,
     compute_work_item_metrics_daily,
+    compute_work_item_team_attributions,
     resolve_base_team,
+    resolve_team_attribution,
 )
 from dev_health_ops.models.work_items import (
     WorkItem,
@@ -105,9 +109,8 @@ def test_same_provider_github_pr_to_issue_inheritance() -> None:
     assert resolver.resolve(pr.work_item_id) == ("team-a", "Team A")
 
 
-def test_inheritance_never_overrides_a_real_team() -> None:
-    # Source already resolves to its own team; the edge must not change it.
-    owned_pr = _wi("ghpr:x/y#1", "github", project_id="x/y", project_key="CHAOS")
+def test_inheritance_never_overrides_native_team() -> None:
+    owned_pr = _wi("ghpr:x/y#1", "github", project_id="x/y", native_team_key="CHAOS")
     other = _wi("linear:OTHER-1", "linear", project_key="OTHER")
     deps = [
         WorkItemDependency(
@@ -123,8 +126,6 @@ def test_inheritance_never_overrides_a_real_team() -> None:
     resolver = build_linked_issue_team_resolver(
         work_items=[owned_pr, other], dependencies=deps, project_key_resolver=pkr
     )
-    # resolve_base_team already returns CHAOS, so the source isn't in the
-    # inherited map at all.
     assert resolver.resolve(owned_pr.work_item_id) == (None, None)
     assert resolve_base_team(owned_pr, None, pkr) == ("CHAOS", "Chaos Team")
 
@@ -374,9 +375,7 @@ def test_compute_without_resolver_leaves_pr_unassigned() -> None:
     assert cycle_times[0].team_id == "unassigned"
 
 
-def test_membership_team_still_wins_over_inheritance() -> None:
-    # A PR whose author is a team member resolves via membership; inheritance
-    # is only a fallback and must not run.
+def test_linked_issue_wins_over_assignee_membership() -> None:
     day = date(2026, 6, 1)
     pr = _wi(
         "ghpr:full-chaos/ops#12",
@@ -406,7 +405,229 @@ def test_membership_team_still_wins_over_inheritance() -> None:
         project_key_resolver=pkr,
         linked_issue_resolver=resolver,
     )
-    assert cycle_times[0].team_id == "platform"
+    assert cycle_times[0].team_id == "other"
+
+
+def test_state_duration_linked_issue_wins_over_assignee_membership() -> None:
+    day = date(2026, 6, 1)
+    pr = _wi(
+        "ghpr:full-chaos/ops#12",
+        "github",
+        type="pr",
+        project_id="full-chaos/ops",
+        assignees=["bob@example.com"],
+    )
+    other = _wi("linear:OTHER-1", "linear", project_key="OTHER")
+    deps = [WorkItemDependency(pr.work_item_id, "extkey:OTHER-1", "relates_to", "k")]
+    transitions = [
+        WorkItemStatusTransition(
+            work_item_id=pr.work_item_id,
+            provider="github",
+            occurred_at=START + timedelta(hours=1),
+            from_status_raw=None,
+            to_status_raw="closed",
+            from_status="in_progress",
+            to_status="done",
+        )
+    ]
+    pkr = ProjectKeyTeamResolver(project_key_to_team={"OTHER": ("other", "Other")})
+    team_resolver = TeamResolver(
+        member_to_team={"bob@example.com": ("platform", "Platform")}
+    )
+    resolver = build_linked_issue_team_resolver(
+        work_items=[pr, other],
+        dependencies=deps,
+        team_resolver=team_resolver,
+        project_key_resolver=pkr,
+    )
+
+    state_rows = compute_work_item_state_durations_daily(
+        day=day,
+        work_items=[pr],
+        transitions=transitions,
+        computed_at=START + timedelta(hours=6),
+        team_resolver=team_resolver,
+        project_key_resolver=pkr,
+        linked_issue_resolver=resolver,
+    )
+
+    assert state_rows
+    assert {row.team_id for row in state_rows} == {"other"}
+
+
+def test_compute_emits_attribution_candidates_and_primary_cycle_team() -> None:
+    day = date(2026, 6, 1)
+    linear = _wi("linear:CHAOS-2400", "linear", project_key="CHAOS")
+    pr = _wi(
+        "ghpr:full-chaos/ops#12",
+        "github",
+        type="pr",
+        project_id="full-chaos/ops",
+        assignees=["bob@example.com"],
+    )
+    deps = [WorkItemDependency(pr.work_item_id, "extkey:CHAOS-2400", "relates_to", "k")]
+    pkr = _chaos_resolver()
+    team_resolver = TeamResolver(
+        member_to_team={"bob@example.com": ("platform", "Platform")}
+    )
+    resolver = build_linked_issue_team_resolver(
+        work_items=[linear, pr],
+        dependencies=deps,
+        team_resolver=team_resolver,
+        project_key_resolver=pkr,
+    )
+
+    _, _, cycle_times = compute_work_item_metrics_daily(
+        day=day,
+        work_items=[pr],
+        transitions=[],
+        computed_at=START,
+        team_resolver=team_resolver,
+        project_key_resolver=pkr,
+        linked_issue_resolver=resolver,
+    )
+    attributions = compute_work_item_team_attributions(
+        work_items=[pr],
+        computed_at=START,
+        team_resolver=team_resolver,
+        project_key_resolver=pkr,
+        linked_issue_resolver=resolver,
+    )
+
+    assert cycle_times[0].team_id == "CHAOS"
+    by_source = {row.source: row for row in attributions}
+    assert by_source["linked_issue"].is_primary == 1
+    assert by_source["linked_issue"].team_id == "CHAOS"
+    assert by_source["assignee_membership"].is_primary == 0
+    assert by_source["assignee_membership"].team_id == "platform"
+
+
+def test_context_project_repo_membership_tiebreak_and_unassigned() -> None:
+    project_item = _wi(
+        "linear:PROJ-1",
+        "linear",
+        project_id="project-1",
+        project_key="PROJ",
+        native_team_key=None,
+    )
+    repo_item = _wi(
+        "gh:full-chaos/dev-health#9",
+        "github",
+        project_id="full-chaos/dev-health",
+    )
+    member_item = _wi(
+        "jira:MEM-1",
+        "jira",
+        project_key="MEM",
+        assignees=["ada@example.com"],
+    )
+    orphan = _wi("gh:unknown/repo#1", "github", project_id="unknown/repo")
+    older = START - timedelta(days=1)
+    newer = START
+    context = TeamAttributionContext(
+        project_by_id={
+            ("linear", "project-1"): [
+                TeamAttributionCandidate(
+                    source="project_ownership",
+                    team_id="team-b",
+                    team_name="Team B",
+                    confidence="high",
+                    evidence="project_id=project-1",
+                    is_primary=0,
+                    specificity=10,
+                    priority=10,
+                    updated_at=newer,
+                ),
+                TeamAttributionCandidate(
+                    source="project_ownership",
+                    team_id="team-a",
+                    team_name="Team A",
+                    confidence="high",
+                    evidence="project_id=project-1",
+                    is_primary=1,
+                    specificity=10,
+                    priority=10,
+                    updated_at=older,
+                ),
+            ]
+        },
+        repo_by_name={
+            ("github", "full-chaos/dev-health"): [
+                TeamAttributionCandidate(
+                    source="repo_ownership",
+                    team_id="repo-team",
+                    team_name="Repo Team",
+                    confidence="high",
+                    evidence="repo_full_name=full-chaos/dev-health",
+                )
+            ]
+        },
+        member_by_identity={
+            ("jira", "ada@example.com"): [
+                TeamAttributionCandidate(
+                    source="assignee_membership",
+                    team_id="member-team",
+                    team_name="Member Team",
+                    confidence="high",
+                    evidence="raw_email=ada@example.com",
+                )
+            ]
+        },
+    )
+
+    project_team_id, _, project_candidates = resolve_team_attribution(
+        project_item, None, None, attribution_context=context
+    )
+    repo_team_id, _, _ = resolve_team_attribution(
+        repo_item, None, None, attribution_context=context
+    )
+    member_team_id, _, _ = resolve_team_attribution(
+        member_item, None, None, attribution_context=context
+    )
+    orphan_team_id, orphan_team_name, orphan_candidates = resolve_team_attribution(
+        orphan, None, None, attribution_context=context
+    )
+
+    assert project_team_id == "team-a"
+    assert [c.team_id for c in project_candidates[:2]] == ["team-a", "team-b"]
+    assert repo_team_id == "repo-team"
+    assert member_team_id == "member-team"
+    assert orphan_team_id is None
+    assert orphan_team_name is None
+    assert orphan_candidates[0].source == "unassigned"
+
+
+def test_context_repo_candidate_dedupes_id_and_name_match() -> None:
+    repo_item = _wi(
+        "gh:full-chaos/dev-health#9",
+        "github",
+        project_id="full-chaos/dev-health",
+        repo_id="repo-1",
+    )
+    candidate = TeamAttributionCandidate(
+        source="repo_ownership",
+        team_id="repo-team",
+        team_name="Repo Team",
+        confidence="high",
+        evidence="repo_ownership=repo-1",
+        is_primary=1,
+        specificity=100,
+        priority=1,
+        updated_at=START,
+    )
+    context = TeamAttributionContext(
+        repo_by_id={("github", "repo-1"): [candidate]},
+        repo_by_name={("github", "full-chaos/dev-health"): [candidate]},
+    )
+
+    team_id, _, candidates = resolve_team_attribution(
+        repo_item, None, None, attribution_context=context
+    )
+
+    assert team_id == "repo-team"
+    assert [(c.team_id, c.source, c.is_primary) for c in candidates] == [
+        ("repo-team", "repo_ownership", 1)
+    ]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_team_autoimport_executor.py
+++ b/tests/test_team_autoimport_executor.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from dev_health_ops.metrics.loaders.clickhouse import ClickHouseDataLoader
+
+
+@pytest.mark.asyncio
+async def test_loader_builds_team_attribution_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    calls: list[str] = []
+
+    async def fake_query(_client: object, query: str, _params: dict[str, object]):
+        calls.append(query)
+        if "team_project_ownership" in query:
+            return [
+                {
+                    "provider": "linear",
+                    "team_id": "team-project",
+                    "team_name": "Project Team",
+                    "project_id": "project-1",
+                    "project_key": "PROJ",
+                    "is_primary": 1,
+                    "specificity": 80,
+                    "priority": 5,
+                    "updated_at": now,
+                }
+            ]
+        if "team_repo_ownership" in query:
+            return [
+                {
+                    "provider": "github",
+                    "team_id": "team-repo",
+                    "team_name": "Repo Team",
+                    "repo_id": None,
+                    "repo_full_name": "full-chaos/dev-health",
+                    "is_primary": 1,
+                    "specificity": 60,
+                    "priority": 10,
+                    "updated_at": now,
+                }
+            ]
+        return [
+            {
+                "provider": "jira",
+                "team_id": "team-member",
+                "team_name": "Member Team",
+                "member_id": "member-1",
+                "raw_provider_user_id": "jira-user-1",
+                "raw_email": "ADA@EXAMPLE.COM",
+                "is_primary": 1,
+                "specificity": 50,
+                "priority": 20,
+                "updated_at": now,
+            }
+        ]
+
+    monkeypatch.setattr(
+        "dev_health_ops.metrics.loaders.clickhouse._clickhouse_query_dicts",
+        fake_query,
+    )
+
+    context = await ClickHouseDataLoader(
+        object(), org_id="org-1"
+    ).load_team_attribution_context(as_of=now)
+
+    assert len(calls) == 3
+    assert context.project_by_id[("linear", "project-1")][0].team_id == "team-project"
+    assert context.project_by_key[("linear", "PROJ")][0].team_id == "team-project"
+    assert (
+        context.repo_by_name[("github", "full-chaos/dev-health")][0].team_id
+        == "team-repo"
+    )
+    assert (
+        context.member_by_identity[("jira", "ada@example.com")][0].team_id
+        == "team-member"
+    )


### PR DESCRIPTION
## Summary
- Add compute-time team attribution resolver with source precedence: native team, linked issue, project ownership, repo ownership, assignee membership, unassigned.
- Persist all work-item team attribution candidates while mirroring the primary team into cycle/state/downstream metrics.
- Load ClickHouse ownership/membership context for daily and sync jobs, with focused regression coverage.

## Verification
- `uv run --extra dev pytest tests/test_linked_issue_team_inheritance.py tests/test_team_autoimport_executor.py -v` (23 passed, 1 deprecation warning)
- `uv run --extra dev pytest tests/test_linked_issue_team_inheritance.py tests/test_team_autoimport_executor.py -q` after rebase (23 passed, 1 deprecation warning)
- `uv run --extra dev ruff check src/dev_health_ops/metrics/compute_work_items.py src/dev_health_ops/metrics/loaders/clickhouse.py src/dev_health_ops/metrics/job_daily.py src/dev_health_ops/metrics/job_work_items.py src/dev_health_ops/metrics/compute_work_item_state_durations.py tests/test_linked_issue_team_inheritance.py tests/test_team_autoimport_executor.py`
- LSP diagnostics clean on changed files
- Live ClickHouse smoke: loaded repo ownership context, resolved repo ownership, wrote `work_item_team_attributions`, and read back primary `repo_ownership` row
- Oracle review: PASS after fixes, 0 critical/0 warning findings

SCREENSHOT-WAIVER: Backend metrics persistence and resolver change; no rendered frontend output changed.

Closes CHAOS-2469