### PR TITLE
docs(ops): document Celery-job trigger workaround for CLI credential gaps (CHAOS-2482)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,21 @@ Explanation format:
 * Daily rollups:
 
   * `CLICKHOUSE_URI=clickhouse://... dev-hops metrics daily`
+### 6.5 Interim Workaround: Trigger via Celery Jobs (CHAOS-2475)
+
+Bare CLI commands run inline. The CLI preflight does not enforce credentials like provider tokens, LLM keys, or Stripe keys. As an interim workaround, trigger the equivalent Celery job instead of running bare CLI commands. Workers carry the credentials that the bare CLI does not enforce.
+
+Start the worker process using:
+```bash
+dev-hops workers start-worker --queues default metrics sync reports
+```
+
+Triggered jobs run in the worker environment. Trigger them using:
+- The sync-config trigger or backfill endpoints for data syncs.
+- The `triggerReport` mutation for reports.
+
+This serves as a temporary workaround, not a permanent contract change. For details on worker setup and queues, see the runbook at [docs/ops/workers.md](docs/ops/workers.md). Tracked in CHAOS-2475 and CHAOS-2482.
+
 
 ---
 

--- a/docs/architecture/platform-sync-observability.md
+++ b/docs/architecture/platform-sync-observability.md
@@ -1,0 +1,110 @@
+# Design Doc: Platform (Superadmin) Sync Observability + Non-Impersonation Re-run
+
+_Date: 2026-06-12_
+_Status: Proposed_
+_Scope: dev-health-ops (backend), dev-health-web (frontend)_
+
+## One Sentence
+
+Give platform admins a single cross-org view of every organization's sync/job status and last error, and let them re-run a job for any org/user by passing explicit target IDs — without impersonating.
+
+## Problem
+
+Today, sync/job status and error logs are only visible **inside a single org's context**, so a platform admin has to **impersonate** each org to see whether its syncs are healthy. Worse, "global" jobs (LLM investment materialization, work-graph builds) run platform-wide but record **no queryable status** — their outcome lives only in SignOz traces/logs, which are hard to navigate. There is no operational answer to "which orgs' syncs are failing right now, and why?" and no clean way to kick a job for a specific org/user.
+
+## Key Finding: most of this already exists
+
+Two facts reframe the work as **surfacing + filling gaps**, not building from scratch.
+
+### 1. Sync status/errors are already persisted in Postgres, already org-tagged
+
+| Model (`models/settings.py`, `models/backfill.py`, `models/reports.py`) | Relevant fields |
+|---|---|
+| `SyncConfiguration` | `last_sync_at`, `last_sync_success`, `last_sync_error`, `last_sync_stats`, `org_id` |
+| `ScheduledJob` (`models/settings.py:363-454`) | `last_run_at`, `last_run_status`, `last_run_duration_seconds`, `last_run_error`, `run_count`, `failure_count` |
+| `JobRun` (`models/settings.py:485-535`) | `status`, `started_at`, `completed_at`, `duration_seconds`, `result`, `error`, `error_traceback`, `triggered_by` (scheduler/manual/webhook) |
+| `BackfillJob` (`models/backfill.py:12-50`) | `status`, `error_message`, `celery_task_id`, chunk counters |
+| `ReportRun` (`models/reports.py:174-246`) | `status`, `error_message`, `celery_task_id`, report metadata |
+
+Existing read paths: `api/admin/routers/platform.py` (aggregate stats, `require_superuser`), `api/admin/routers/sync.py` (per-config `JobRun` history). These are org-filtered, not cross-org.
+
+### 2. Workers already run on explicit `org_id` — impersonation was never required to execute
+
+Sync/metrics/work-graph Celery tasks accept `org_id` (and config/report IDs) as **explicit kwargs** and re-load org-scoped rows with `WHERE org_id = …`. `workers/org_guard.organization_exists_sync()` validates the org before dispatch. Workers never read the caller's web session. The Reports "Run Now" path (`trigger_report` GraphQL mutation → `ReportRun(triggered_by="api")` → `apply_async(queue="reports")`) is the canonical in-repo template. Impersonation is therefore purely a **read-path** convenience for per-org UIs — execution already takes explicit targets.
+
+### 3. On-Demand Trigger Endpoints
+
+Admins can trigger syncs, backfills, and reports using these endpoints:
+- POST `/api/v1/admin/sync-configs/{config_id}/trigger` (`api/admin/routers/sync.py:850-983`): Triggers a sync configuration run.
+- POST `/api/v1/admin/sync-configs/backfill` (`api/admin/routers/sync.py:986-1045`): Initiates a backfill job.
+- `triggerReport` mutation (`api/graphql/schema.py:720-727`): Triggers a report run.
+
+
+## Gaps (verified)
+
+1. **No cross-org read surface.** All status queries are `require_org_id`-scoped; only `product_telemetry` is `require_platform_admin` cross-org.
+2. **Global jobs record nothing queryable.** `workers/work_graph_tasks.py::run_investment_materialize` and `run_work_graph_build` only `logger.info/exception` and return a dict — **no `JobRun` row**. Their status/errors exist only in SignOz/logs. This is the core navigability pain.
+3. **`JobRun` has no actor or trace correlation.** `triggered_by` is a coarse string (`scheduler`/`manual`/`webhook`); there is no `actor_user_id`, `target_user_id`, or `trace_id`/`correlation_id`. Cannot answer "which admin re-ran this" or deep-link a run to its SignOz trace.
+4. **`JobRun` is FK-bound to `ScheduledJob`** (`job_id` non-null FK), so it cannot represent ad-hoc or global runs that are not scheduled jobs.
+
+## Storage Decision: Postgres (existing) + SignOz as drill-down — not a new ClickHouse table, not SignOz-as-source-of-truth
+
+The run-record-as-source-of-truth pattern is what mature OSS job tooling converges on (django-celery-results durable rows; Hatchet `v1_runs_olap`/`v1_statuses_olap`; Temporal UI run list + event-history drawer + gated write actions; django-rq staff-only requeue). Dev-health already has the relational run record — we extend it.
+
+- **Do not add a ClickHouse table for sync status.** It would duplicate the Postgres truth, and ClickHouse's append-only/eventual-consistency model is wrong for "current status / did-it-fail?" transactional reads. ClickHouse stays the analytics backend. (SignOz's own docs say raw ClickHouse SQL is for dashboards, not transactional reads.)
+- **Do not make SignOz the source of truth.** It is external infra (OTLP collector `signoz-otel-collector:4317`), has no in-code query path, and is already "hard to navigate." Use it as a **deep-link drill-down target** keyed by `trace_id`/`correlation_id`. BugSink/Sentry already captures exception detail and can be linked by event id.
+- **Do extend the existing Postgres run records** to close gaps 2–4, then read them cross-org.
+
+So: "ClickHouse or SignOz?" → **Postgres (already there) + SignOz/BugSink deep-link.**
+
+## Design
+
+### Track A — Make every job a first-class run record
+
+Generalize the run record so global/ad-hoc jobs report status the same way syncs do.
+
+- Relax `JobRun.job_id` to nullable and add a discriminator `job_kind` (e.g. `sync`, `backfill`, `investment_materialize`, `work_graph_build`, `report`) + optional `job_key`.
+- Add columns: `org_id` (indexed), `actor_user_id` (nullable, the triggering superadmin), `target_user_id` (nullable), `trace_id`/`correlation_id` (nullable, for SignOz/BugSink deep-link).
+- Have `run_investment_materialize` and `run_work_graph_build` open/close a `JobRun` (running → success/failed with `error`/`error_traceback`), mirroring `sync_runtime.run_sync_config`.
+- Alembic migration (Postgres). No analytics/ClickHouse change.
+
+_Alternative considered:_ register the globals as `ScheduledJob` rows so they emit `JobRun`s unchanged (smaller migration, but conflates "scheduled" with "global/ad-hoc"). Decision pending (see Open Decisions #1).
+
+### Track B — Cross-org Platform read view
+
+- Backend: a `require_platform_admin` GraphQL resolver (mirror `resolvers/product_telemetry.py`) returning, per org → per job/config: last status, last error excerpt, last run time, `failure_count`, last `trace_id`. Cross-org via superuser bypass; **no impersonation**.
+- Frontend: `/superadmin/syncs` page (mirror `/superadmin/product-telemetry`), with org → config drill-down reusing the existing `JobRun` history endpoint, plus a "View in SignOz / BugSink" deep-link. urql client, consistent with existing superadmin pages.
+
+### Track C — Re-run without impersonation
+
+Mirror `trigger_report`. A `require_platform_admin` mutation `rerunSync(orgId, configId)` (and `rerunGlobalJob(jobKey, orgId?)`) that:
+
+1. validates superuser + `organization_exists`,
+2. creates a `JobRun` with `actor_user_id = <superadmin>`, `triggered_by = "platform_admin"`, target org/user,
+3. enqueues the existing worker with explicit `org_id` (already supported),
+4. writes an `AuditService` entry with the real (admin) user id.
+
+Strictly better than impersonation-based re-runs: no session/JWT swap, and a complete "who ran what, for whom, why" audit trail that impersonation does not currently produce.
+
+## Security Guardrails
+
+- All new read/write surfaces gated by `require_platform_admin` / `require_superuser`.
+- Re-run never escalates into a target user's session; it runs under service identity with explicit target IDs.
+- Every re-run writes an audit log with the real admin id (reuse `AuditService`, which already supports impersonation metadata).
+- Error excerpts shown in the cross-org view should be truncated; full traceback stays behind the drill-down / observability link.
+
+## Open Decisions
+
+1. **Run-record model:** generalize `JobRun` (`job_kind` + nullable FK; cleaner) vs. register globals as `ScheduledJob`s (smaller migration). Recommendation: generalize.
+2. **Read path:** new GraphQL resolver (consistent with `product_telemetry`) vs. extend REST `platform.py`. Recommendation: GraphQL.
+3. **Drill-down target:** SignOz trace deep-link, BugSink issue deep-link, or both — requires adding `org_id`/`job_run_id` span/log attributes (not currently enriched).
+4. **Sequencing:** read-only view (A+B) first, then re-run (C); or A/B/C together.
+
+## References
+
+- Existing impersonation ADR: `ops/docs/architecture/middleware-impersonation.md`
+- Dual-DB contract: `ops/docs/architecture/database-architecture.md`
+- Models: `models/settings.py` (`SyncConfiguration`, `ScheduledJob`, `JobRun`), `models/backfill.py`
+- Trigger template: `api/graphql/resolvers/reports.py`, `api/admin/routers/sync.py`
+- Global jobs lacking run records: `workers/work_graph_tasks.py`
+- Cross-org guard template: `api/graphql/authz.py` (`require_platform_admin`), `api/graphql/resolvers/product_telemetry.py`

--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -21,6 +21,11 @@ The CLI entry point is `dev-hops` (module `dev_health_ops.cli`). Command groups:
 - `workers` — Celery worker and beat scheduler
 - `maintenance` — operational cleanup
 
+### Inline Execution vs. Celery-Backed Operations
+
+Bare CLI commands run inline, executing immediately in your terminal session. However, several commands have argument-enforcement gaps (CHAOS-2475). These operations require credentials or inputs that the CLI doesn't enforce at startup. Running them inline without these inputs can lead to silent failures or incomplete runs.
+
+Until these gaps are fixed, we recommend triggering the equivalent Celery jobs instead of running the commands inline. Celery workers run in a managed environment where credentials and configurations are fully validated. You can find the list of Celery tasks and queue configurations in [workers.md](workers.md).
 ---
 
 ## Global Arguments
@@ -94,6 +99,10 @@ Requires: ClickHouse (--analytics-db / CLICKHOUSE_URI), organization (--org / OR
 ---
 
 ## Sync Commands
+
+> ⚠️ **Warning (CHAOS-2475):** Sync commands run inline and require provider credentials (such as `GITHUB_TOKEN`, `GITLAB_TOKEN`, `JIRA_EMAIL`, `JIRA_API_TOKEN`, or `LINEAR_API_KEY`) that the CLI doesn't enforce at startup. Running them inline without these inputs can cause silent failures.
+>
+> **Interim Workaround:** We recommend triggering the sync via the API endpoint `POST /api/v1/admin/sync-configs/{config_id}/trigger` (which dispatches the `run_sync_config` task to the `sync` queue). See [workers.md](workers.md) for details on Celery worker configuration.
 
 ### `sync git`
 
@@ -285,6 +294,10 @@ sync is expected.
 ---
 
 ## Metrics Commands
+
+> ⚠️ **Warning (CHAOS-2475):** Metrics commands run inline and require database connections and configurations that the CLI doesn't enforce at startup. Running them inline can cause silent failures or incomplete computations.
+>
+> **Interim Workaround:** We recommend triggering the equivalent Celery jobs on the `metrics` queue. See [workers.md](workers.md) for details on Celery worker configuration.
 
 ### `metrics daily`
 
@@ -832,6 +845,10 @@ python -m dev_health_ops.cli admin bundles assign-org --org-id <uuid> --feature-
 
 ### `backfill run`
 
+> ⚠️ **Warning (CHAOS-2475):** The `backfill run` command runs inline and requires provider credentials that the CLI doesn't enforce at startup. Running it inline can cause silent failures. Additionally, there is a known preflight-token bug (CHAOS-2479) where the CLI fails to validate credentials correctly.
+>
+> **Interim Workaround:** We recommend triggering the backfill via the API endpoint `POST /api/v1/admin/sync-configs/{config_id}/backfill` (which dispatches the `run_backfill` task to the `backfill` queue). See [workers.md](workers.md) for details on Celery worker configuration.
+
 Run historical data backfill for a sync configuration. Data is synced in chunked 7-day windows. Uses `CLICKHOUSE_URI`.
 
 ```bash
@@ -985,6 +1002,10 @@ dev-hops ai allowlist list
 
 ### `work-graph build`
 
+> ⚠️ **Warning (CHAOS-2475):** The `work-graph build` command runs inline and requires configurations that the CLI doesn't enforce at startup. Running it inline can cause silent failures.
+>
+> **Interim Workaround:** We recommend triggering the equivalent Celery job on the `metrics` queue. See [workers.md](workers.md) for details on Celery worker configuration.
+
 Build work graph edges from raw data (issue → PR → commit linkages). Takes its ClickHouse DSN via its own **required** `--db` flag.
 
 ```bash
@@ -1040,6 +1061,10 @@ dev-hops investment materialize --window-days 30 --llm-provider none
 
 ### `recommendations compute`
 
+> ⚠️ **Warning (CHAOS-2475):** The `recommendations compute` command runs inline and requires configurations that the CLI doesn't enforce at startup. Running it inline can cause silent failures.
+>
+> **Interim Workaround:** We recommend triggering the equivalent Celery job on the `metrics` queue. See [workers.md](workers.md) for details on Celery worker configuration.
+
 Evaluate rule-based recommendations for a team and persist results to ClickHouse — both fired recommendations and explicit `fired=False` tombstones, so a recovered signal is cleared rather than left lingering. Uses `CLICKHOUSE_URI`.
 
 ```bash
@@ -1062,6 +1087,8 @@ dev-hops recommendations compute --team eng-core \
 ---
 
 ## Reports
+
+> ℹ️ **Note:** Reports are not managed or triggered via the CLI. They are managed entirely through the GraphQL API or the Report Center UI. See [reports.md](../user-guide/reports.md) for details.
 
 AI-generated reports are managed through the GraphQL API and executed as Celery tasks. Reports are not triggered via CLI — they are created, triggered, and scheduled through the Report Center UI or GraphQL mutations.
 

--- a/docs/ops/investment-materialization.md
+++ b/docs/ops/investment-materialization.md
@@ -50,6 +50,12 @@ reads these edges.
 
 ## Step 2 — Materialize investments
 
+> ⚠️ **Warning (CHAOS-2475, CHAOS-2476):** The `investment materialize` command defaults to `--llm-provider auto`. If an LLM API key (such as `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`) doesn't exist in the environment, the command silently falls back to a `MockProvider`. It then persists mock categorization data to ClickHouse and exits with code `0`.
+>
+> **Interim Workarounds:**
+> 1. **Trigger via Celery:** We recommend triggering the `run_investment_materialize` task via the worker (where worker-side API keys apply). See [workers.md](workers.md) for details on Celery worker configuration.
+> 2. **Explicit CLI Flags:** If running inline, explicitly set `--llm-provider` and ensure the corresponding API key is present in your environment.
+
 ```bash
 dev-hops investment materialize \
   --db "$CLICKHOUSE_URI" \

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -4,13 +4,65 @@ Background job processing for dev-health-ops, powered by Celery with Redis as br
 
 ---
 
+## Triggering operations via Celery jobs (interim workaround for CHAOS-2475)
+
+Until the CLI argument-enforcement gaps tracked in Linear CHAOS-2475 are fixed, operators must trigger affected operations through the Celery worker and job system rather than running the bare `dev-hops` CLI directly.
+
+### Why this workaround is required
+
+The bare CLI runs jobs inline within the caller's process. Preflight checks in the CLI only model database URIs and organization parameters, failing to enforce required credentials or inputs like provider tokens, LLM API keys, or Stripe keys. Because of this, inline CLI commands often fail deep in the execution path or fail silently.
+
+In contrast, Celery-triggered jobs run inside the worker process, which is started via `dev-hops workers start-worker` or `dev-hops workers start-scheduler`. The worker process is fully configured with the message broker and the worker-side environment and credentials. Routing operations through a Celery job request ensures the task runs with the worker's configured credentials.
+
+Key implementation details:
+- **Broker and Result Backend**: Configured in `workers/config.py:8-64` and initialized in `workers/celery_app.py:66-84`. The default broker and result backend URL is `redis://localhost:6379/0` (controlled by `CELERY_BROKER_URL` and `CELERY_RESULT_BACKEND`).
+- **Queue Routing**: Defined in `workers/queues.py:7-62`. The `PROVIDER_SYNC_QUEUES_ENABLED` flag gates whether tasks are routed to provider-specific queues.
+
+### On-Demand Trigger Paths
+
+Operators can trigger background operations on-demand through three primary API paths. These paths bypass the periodic scheduler and enqueue tasks directly onto the Celery broker. For detailed API specifications, refer to the [GraphQL API Overview](../api/graphql-overview.md) and the [AI Reports Architecture](../architecture/ai-reports-architecture.md).
+
+1. **Data Sync Trigger**
+   * **Endpoint**: `POST /api/v1/admin/sync-configs/{config_id}/trigger` (defined in `api/admin/routers/sync.py:850-983`)
+   * **Flow**: Creates a `ScheduledJob` and a `PENDING` `JobRun` record, then enqueues either `run_sync_config` or `dispatch_batch_sync` onto the `sync` queue.
+
+2. **Historical Backfill Trigger**
+   * **Endpoint**: `POST /api/v1/admin/sync-configs/{config_id}/backfill` (defined in `api/admin/routers/sync.py:986-1045`)
+   * **Flow**: Creates a `BackfillJob` record and triggers `run_backfill.delay` on the `backfill` queue.
+
+3. **Report Execution Trigger**
+   * **Trigger**: GraphQL `triggerReport` mutation or the "Run Now" button in the Report Center UI.
+   * **Flow**: Creates a `ReportRun` record and enqueues `execute_saved_report` onto the `reports` queue.
+
+### Affected Operations Quick Reference
+
+The following table maps bare CLI commands to their Celery task equivalents, trigger paths, and required worker environment variables.
+
+| CLI Command (Inline, May Fail) | Celery Task | Trigger Path | Required Worker Env |
+|---|---|---|---|
+| `dev-hops sync git/prs/cicd/deployments/incidents/security/tests` | `run_sync_config` | `POST /api/v1/admin/sync-configs/{config_id}/trigger` | `GITHUB_TOKEN`, `GITLAB_TOKEN`, `JIRA_API_TOKEN`, `JIRA_EMAIL` |
+| `dev-hops sync work-items` | `run_work_items_sync` | `POST /api/v1/admin/sync-configs/{config_id}/trigger` | `GITHUB_TOKEN`, `GITLAB_TOKEN`, `JIRA_API_TOKEN`, `JIRA_EMAIL` |
+| `dev-hops metrics daily` | `run_daily_metrics` / `dispatch_daily_metrics_partitioned` | Periodic Beat Schedule | `CLICKHOUSE_URI`, `DATABASE_URI` |
+| `dev-hops recommendations compute` | `run_recommendations_job` | Periodic Beat Schedule | `CLICKHOUSE_URI`, `DATABASE_URI` |
+| `dev-hops work-graph build` | `run_work_graph_build` | Periodic Beat Schedule | `CLICKHOUSE_URI`, `DATABASE_URI` |
+| `dev-hops investment materialize` | `run_investment_materialize` | Periodic Beat Schedule | `CLICKHOUSE_URI`, `DATABASE_URI`, `OPENAI_API_KEY` (or other LLM keys) |
+| `dev-hops backfill run` | `run_backfill` | `POST /api/v1/admin/sync-configs/{config_id}/backfill` | `CLICKHOUSE_URI`, `DATABASE_URI`, provider tokens |
+
+Triggering `run_investment_materialize` via the worker ensures the worker-side LLM API key applies. This avoids the silent `MockProvider` fallback that the bare CLI hits when no key is present in the caller's environment (tracked in Linear CHAOS-2476).
+
+### Observability Caveat
+
+Tasks like `run_work_graph_build` and `run_investment_materialize` don't persist a `JobRun` row in the database. Their execution status and progress can only be tracked through worker logs and distributed traces. For more details on sync observability, see the [Platform Sync Observability](../architecture/platform-sync-observability.md) documentation.
+
+---
+
 ## Architecture
 
 Workers execute long-running tasks (syncs, metrics computation, webhooks) asynchronously. The system consists of:
 
-- **Celery workers** -- consume tasks from Redis queues
-- **Celery beat** -- scheduler that dispatches periodic tasks on cron/interval schedules
-- **Redis** -- message broker and result backend
+- **Celery workers**: consume tasks from Redis queues
+- **Celery beat**: scheduler that dispatches periodic tasks on cron/interval schedules
+- **Redis**: message broker and result backend
 
 On startup, workers automatically apply pending Alembic migrations and initialize logging, Sentry, and OpenTelemetry tracing.
 See also: [Worker horizontal-scaling readiness](../architecture/worker-scaling-readiness.md)
@@ -48,80 +100,76 @@ celery -A dev_health_ops.workers.celery_app beat --loglevel=INFO
 |-------|---------|
 | `default` | Scheduling dispatchers, health checks, heartbeat |
 | `metrics` | Daily metrics, complexity, DORA, capacity forecast, investment |
-| `sync` | Git/PR/work-item syncs, team drift, batch sync |
+| `sync` | Git, PR, and work-item syncs, team drift, batch sync |
+| `sync.<provider>` | Provider-specific sync queues (e.g., `sync.github`, `sync.gitlab`, `sync.linear`, `sync.jira`, `sync.launchdarkly`) |
+| `backfill` | Historical data backfill operations |
+| `reports` | AI report execution (SavedReport to ReportRun) |
 | `webhooks` | Webhook event processing, billing notifications |
 | `ingest` | Stream ingestion consumer |
-| `backfill` | Historical data backfill operations |
-| `reports` | AI report execution (SavedReport → ReportRun) |
-
+| `monitoring` | Telemetry and queue depth monitoring |
 ---
 
-## Task Types
+## Task Registry
 
-### Sync Tasks
+The system registers 34 tasks under the `workers/` directory. All registered tasks, their wrapped CLI operations, and their target queues are listed in the table below.
 
-| Task | Queue | Description |
-|------|-------|-------------|
-| `run_sync_config` | sync | Sync a single repo configuration (git, PRs, CI/CD, etc.) |
-| `dispatch_batch_sync` | sync | Discover repos in an org and fan out per-repo sync tasks |
-| `run_work_items_sync` | sync | Sync work items from a provider (Jira, GitHub, GitLab, Linear) |
-| `sync_team_drift` | sync | Detect and reconcile team membership drift |
-| `reconcile_team_members` | sync | Full team member reconciliation from provider sources |
-
-### Metrics Tasks
-
-| Task | Queue | Description |
-|------|-------|-------------|
-| `run_daily_metrics` | metrics | Compute daily repo/user metrics for a date range |
-| `dispatch_daily_metrics_partitioned` | default | Partition daily metrics across orgs and fan out |
-| `run_daily_metrics_batch` | metrics | Process a batch of repos for daily metrics |
-| `run_complexity_job` | metrics | Analyze code complexity for repos |
-| `run_dora_metrics` | metrics | Compute DORA metrics (deployment frequency, lead time, etc.) |
-| `run_work_graph_build` | metrics | Build work graph edges linking issues, PRs, and commits |
-| `run_investment_materialize` | metrics | Classify work units into investment categories via LLM |
-| `run_capacity_forecast_job` | metrics | Weekly capacity forecasting |
-
-### Webhook & Other Tasks
-
-| Task | Queue | Description |
-|------|-------|-------------|
-| `process_webhook_event` | webhooks | Process inbound GitHub/GitLab/Jira webhook events |
-| `send_billing_notification` | webhooks | Send billing-related email notifications |
-| `run_ingest_consumer` | ingest | Consume from ingest streams (Redis) |
-| `health_check` | default | Worker health check |
-| `phone_home_heartbeat` | default | Daily heartbeat for deployment telemetry |
-
-### Report Tasks
-
-| Task | Queue | Description |
-|------|-------|-------------|
-| `execute_saved_report` | reports | Execute a SavedReport plan and persist the rendered markdown result |
-| `dispatch_scheduled_reports` | default | Fan out scheduled report executions based on cron expressions |
-
-### Backfill Tasks
-
-| Task | Queue | Description |
-|------|-------|-------------|
-| `run_backfill` | backfill | Chunked historical sync with BackfillJob progress tracking |
-
+| Task Name | Wrapped CLI Operation | Queue | Description |
+|---|---|---|---|
+| `run_sync_config` | `sync git/prs/cicd/deployments/incidents/security/tests` + work-items | `sync` (or `sync.<provider>`) | Syncs a single repository configuration. Source: `sync_runtime.py:408-527`. |
+| `dispatch_batch_sync` | None | `sync` | Discovers repositories in an organization and schedules syncs. Source: `sync_batch.py:301`. |
+| `_batch_sync_callback` | None | `sync` | Callback task for batch sync completion. Source: `sync_batch.py:267`. |
+| `_run_sync_for_repo` | None | `sync` | Runs sync for a single repository within a batch. Source: `sync_batch.py:550`. |
+| `run_work_items_sync` | `sync work-items` | `sync` | Syncs work items from a provider. Source: `sync_misc.py:12-68`. |
+| `sync_team_drift` | None | `sync` | Detects and reconciles team membership drift. Source: `sync_team.py:188-266`. |
+| `reconcile_team_members` | None | `sync` | Reconciles team members from provider sources. Source: `sync_team.py:188-266`. |
+| `run_daily_metrics` | `metrics daily` | `metrics` | Computes daily repository and user metrics. Source: `metrics_daily.py`. |
+| `dispatch_daily_metrics_partitioned` | `metrics daily` (partitioned) | `default` | Partitions daily metrics across organizations and fans out. Source: `metrics_partitioned.py`. |
+| `run_daily_metrics_batch` | None | `metrics` | Processes a batch of repositories for daily metrics. Source: `metrics_partitioned.py`. |
+| `run_daily_metrics_finalize_task` | None | `default` | Finalizes daily metrics computation. Source: `metrics_partitioned.py`. |
+| `run_complexity_job` | None | `metrics` | Analyzes code complexity for repositories. Source: `metrics_extra.py:16-319`. |
+| `run_dora_metrics` | None | `metrics` | Computes DORA metrics. Source: `metrics_extra.py:16-319`. |
+| `run_release_impact_job` | None | `metrics` | Computes release impact metrics. Source: `metrics_extra.py:16-319`. |
+| `dispatch_release_impact` | None | `default` | Fans out release impact computation. Source: `metrics_extra.py`. |
+| `run_work_graph_build` | `work-graph build` | `metrics` | Builds work graph edges linking issues, PRs, and commits. Source: `work_graph_tasks.py:17-334`. |
+| `run_investment_materialize` | `investment materialize` | `metrics` | Classifies work units into investment categories via LLM. Source: `work_graph_tasks.py`. |
+| `run_membership_backfill` | None | `metrics` | Backfills work unit membership. Source: `work_graph_tasks.py`. |
+| `dispatch_membership_backfill` | None | `default` | Fans out membership backfill. Source: `work_graph_tasks.py`. |
+| `run_capacity_forecast_job` | None | `metrics` | Computes weekly capacity forecasting. Source: `product_tasks.py`. |
+| `sync_teams_to_analytics` | None | `metrics` | Syncs teams to the analytics database. Source: `product_tasks.py`. |
+| `run_recommendations_job` | `recommendations compute` | `metrics` | Computes recommendations for organizations. Source: `recommendations_tasks.py:249-333`. |
+| `process_webhook_event` | None | `webhooks` | Processes inbound webhook events. Source: `system_webhooks.py`. |
+| `send_billing_notification` | None | `webhooks` | Sends billing-related email notifications. Source: `system_ops.py`. |
+| `run_ingest_consumer` | None | `ingest` | Consumes from ingest streams. Source: `system_ops.py`. |
+| `run_product_telemetry_consumer` | None | `ingest` | Consumes product telemetry streams. Source: `system_ops.py`. |
+| `health_check` | None | `default` | Worker health check. Source: `system_ops.py`. |
+| `phone_home_heartbeat` | None | `default` | Daily heartbeat for deployment telemetry. Source: `system_ops.py`. |
+| `execute_saved_report` | None | `reports` | Executes a SavedReport plan and persists markdown. Source: `report_task.py`. |
+| `dispatch_scheduled_reports` | None | `default` | Fans out scheduled report executions. Source: `report_scheduler.py`. |
+| `run_backfill` | `backfill run` | `backfill` | Runs chunked historical sync with progress tracking. Source: `sync_backfill.py:14-173`. |
+| `dispatch_scheduled_syncs` | None | `default` | Fans out organization sync configurations. Source: `sync_scheduler.py`. |
+| `dispatch_scheduled_metrics` | None | `default` | Fans out scheduled metrics. Source: `metrics_daily.py`. |
+| `monitor_queue_depths` | None | `monitoring` | Monitors queue depths. Source: `queue_monitor.py`. |
 ---
 
 ## Periodic Schedule (Beat)
 
-| Schedule | Task | Interval |
-|----------|------|----------|
-| `dispatch-scheduled-syncs` | Fan out org sync configs | Every 5 minutes |
-| `dispatch-scheduled-metrics` | Fan out scheduled metrics | Every 5 minutes |
-| `run-daily-metrics` | Full daily metrics pass | Daily at 01:00 UTC |
-| `sync-team-drift` | Detect team membership drift | Daily at 02:30 UTC |
-| `reconcile-team-members` | Full team reconciliation | Daily at 03:00 UTC |
-| `run-capacity-forecast` | Weekly capacity forecast | Mondays at 04:00 UTC |
-| `process-ingest-streams` | Consume ingest queue | Every 30 seconds |
-| `phone-home-heartbeat` | Deployment heartbeat | Daily at 00:00 UTC |
-| `dispatch-scheduled-reports` | Fan out scheduled report runs | Every 5 minutes |
-
+| Schedule | Task | Interval | Queue |
+|----------|------|----------|-------|
+| `dispatch-scheduled-syncs` | `dispatch_scheduled_syncs` | Every 300 seconds (5 minutes) | `default` |
+| `dispatch-scheduled-metrics` | `dispatch_scheduled_metrics` | Every 300 seconds (5 minutes) | `default` |
+| `run-daily-metrics` | `dispatch_daily_metrics_partitioned` | Daily at 01:00 UTC | `default` |
+| `run-recommendations` | `run_recommendations_job` | Daily at 02:00 UTC | `metrics` |
+| `run-release-impact-daily` | `dispatch_release_impact` | Daily at 01:30 UTC | `default` |
+| `sync-team-drift` | `sync_team_drift` | Daily at 02:30 UTC | `sync` |
+| `reconcile-team-members` | `reconcile_team_members` | Daily at 03:00 UTC | `sync` |
+| `run-capacity-forecast` | `run_capacity_forecast_job` | Mondays at 04:00 UTC | `metrics` |
+| `process-ingest-streams` | `run_ingest_consumer` | Every 30 seconds | `ingest` |
+| `process-product-telemetry-streams` | `run_product_telemetry_consumer` | Every 30 seconds | `ingest` |
+| `phone-home-heartbeat` | `phone_home_heartbeat` | Daily at 00:00 UTC | `default` |
+| `dispatch-scheduled-reports` | `dispatch_scheduled_reports` | Every 300 seconds (5 minutes) | `default` |
+| `monitor-queue-depths` | `monitor_queue_depths` | Every 60 seconds | `monitoring` |
+| `run-membership-backfill-daily` | `dispatch_membership_backfill` | Daily at 03:30 UTC | `default` |
 ---
-
 ## Configuration
 
 ### Environment Variables

--- a/docs/user-guide/reports.md
+++ b/docs/user-guide/reports.md
@@ -42,8 +42,7 @@ When a report is created without an explicit `ReportPlan`, the system generates 
 
 ### Manual Trigger
 
-Click **Run Now** on the report detail page. This creates a `ReportRun` with status `PENDING` and dispatches a Celery task to the `reports` queue.
-
+Clicking **Run Now** on the report detail page triggers the `triggerReport` mutation. This creates a `ReportRun` (with `triggered_by="api"` and status `PENDING`) and dispatches the `execute_saved_report` Celery task to the `reports` queue. The mutation serves as an example of the preferred Celery-job trigger pattern (CHAOS-2475, CHAOS-2482) to avoid running resource-intensive or credential-heavy operations inline. Using this pattern ensures credentials aren't exposed or bypassed. See [workers.md](../ops/workers.md) for details on Celery worker configuration.
 ### Scheduled Execution
 
 Reports with a schedule (Weekly or Monthly) are triggered automatically by the `dispatch_scheduled_reports` beat task, which runs every 5 minutes and checks for due reports based on their cron expression.


### PR DESCRIPTION
## Summary

The `dev-hops` CLI preflight (`src/dev_health_ops/cli.py`) enforces database URIs and org id only — **not credentials** (provider auth tokens, LLM API keys, Stripe keys). Affected commands pass preflight and then fail deep in the handler, or (for `investment materialize`) silently persist mock LLM output. Until the enforcement gaps are fixed (CHAOS-2475), this documents the **interim workaround**: trigger the equivalent Celery job so the operation runs in the **worker process**, where credentials are configured.

## Changes (docs only)

- `docs/ops/workers.md` — canonical runbook: on-demand trigger paths, CLI→Celery→required-env quick reference, full 34-task registry, beat schedule, observability caveat.
- `docs/ops/cli-reference.md` — inline-vs-Celery distinction + per-command workaround callouts (sync, backfill [CHAOS-2479], metrics, work-graph build, recommendations, reports).
- `docs/ops/investment-materialization.md` — warning on silent mock-LLM fallback (CHAOS-2476) + worker-trigger workaround.
- `docs/user-guide/reports.md` — Run Now → ReportRun → reports queue as the canonical trigger pattern.
- `docs/architecture/platform-sync-observability.md` — on-demand trigger endpoints + JobRun/BackfillJob/ReportRun records. (This file pre-existed untracked on the working branch; this PR augments and commits it.)
- `AGENTS.md` — interim-workaround note (§6) cross-linking the runbook.

## Verification

- `mkdocs build --strict` passes clean (exit 0, no warnings).
- All relative Markdown links in the edited docs resolve.

## Notes

- The platform-root `AGENTS.md` (one level above this repo) also received the same interim-workaround note, but it lives outside this git repo and is not part of this PR.
- Interim workaround only — not a permanent contract change. Tracking issues remain open for the underlying fixes.

SCREENSHOT-WAIVER: documentation-only change, no rendered UI output.

Refs CHAOS-2475
Closes CHAOS-2482