### PR TITLE
fix(workers): refresh team labels after work-item backfills

### DIFF
--- a/src/dev_health_ops/providers/teams.py
+++ b/src/dev_health_ops/providers/teams.py
@@ -210,6 +210,7 @@ async def load_team_resolver_from_store(store: Any) -> TeamResolver:
 
 def build_project_key_resolver(teams_data: list) -> ProjectKeyTeamResolver:
     mapping: dict[str, tuple[str, str]] = {}
+    team_id_fallbacks: dict[str, tuple[str, str]] = {}
     for team in teams_data:
         team_id = str(
             team.get("id") if isinstance(team, dict) else getattr(team, "id", "")
@@ -223,13 +224,16 @@ def build_project_key_resolver(teams_data: list) -> ProjectKeyTeamResolver:
             team.get("project_keys")
             if isinstance(team, dict)
             else getattr(team, "project_keys", [])
-        )
-        if not team_id or not project_keys:
+        ) or []
+        if not team_id:
             continue
+        team_id_fallbacks.setdefault(team_id, (team_id, team_name))
         for pk in project_keys:
             key = str(pk).strip()
             if key and key not in mapping:
                 mapping[key] = (team_id, team_name)
+    for key, team in team_id_fallbacks.items():
+        mapping.setdefault(key, team)
     return ProjectKeyTeamResolver(project_key_to_team=mapping)
 
 

--- a/src/dev_health_ops/workers/sync_backfill.py
+++ b/src/dev_health_ops/workers/sync_backfill.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import date, datetime, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 
 from dev_health_ops.workers.celery_app import celery_app
-from dev_health_ops.workers.task_utils import _credential_mapping, _get_db_url
+from dev_health_ops.workers.task_utils import (
+    _as_str_list,
+    _credential_mapping,
+    _get_db_url,
+    _normalize_sync_targets,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +38,8 @@ def run_backfill(
     started_at = datetime.now(timezone.utc)
 
     try:
+        provider = ""
+        sync_targets: list[str] = []
         with get_postgres_session_sync() as session:
             config = (
                 session.query(SyncConfiguration)
@@ -44,6 +51,12 @@ def run_backfill(
             )
             if config is None:
                 raise ValueError(f"Sync configuration not found: {sync_config_id}")
+
+            provider = str(config.provider or "").strip().lower()
+            sync_targets = _normalize_sync_targets(
+                provider,
+                _as_str_list(config.sync_targets),
+            )
 
             credentials: dict[str, Any] | None = None
             if config.credential_id:
@@ -136,6 +149,37 @@ def run_backfill(
                 logger.debug(
                     "Failed to mark backfill job completed: %s", backfill_job_id
                 )
+
+        try:
+            from dev_health_ops.workers.sync_runtime import _dispatch_post_sync_tasks
+
+            since_date = date.fromisoformat(since)
+            before_date = date.fromisoformat(before)
+            _dispatch_post_sync_tasks(
+                provider=provider,
+                sync_targets=sync_targets,
+                org_id=org_id,
+                metrics_day=before_date.isoformat(),
+                metrics_backfill_days=(before_date - since_date).days + 1,
+                from_date=since_date.isoformat(),
+                to_date=before_date.isoformat(),
+                work_graph_from_date=datetime.combine(
+                    since_date,
+                    time.min,
+                    tzinfo=timezone.utc,
+                ).isoformat(),
+                work_graph_to_date=datetime.combine(
+                    before_date + timedelta(days=1),
+                    time.min,
+                    tzinfo=timezone.utc,
+                ).isoformat(),
+            )
+        except Exception:
+            logger.exception(
+                "Failed to dispatch post-backfill tasks: sync_config_id=%s org_id=%s",
+                sync_config_id,
+                org_id,
+            )
 
         return {
             "status": "success",

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -307,6 +307,12 @@ def _dispatch_post_sync_tasks(
     provider: str,
     sync_targets: list[str],
     org_id: str,
+    metrics_day: str | None = None,
+    metrics_backfill_days: int | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    work_graph_from_date: str | None = None,
+    work_graph_to_date: str | None = None,
 ) -> None:
     target_set = set(sync_targets)
     has_git = bool(target_set & _GIT_TARGETS)
@@ -314,14 +320,25 @@ def _dispatch_post_sync_tasks(
     has_dora = bool(target_set & _DORA_TARGETS)
     dispatched: list[str] = []
 
-    if has_git:
+    daily_metrics_kwargs: dict[str, Any] = {"org_id": org_id}
+    if metrics_day is not None:
+        daily_metrics_kwargs["day"] = metrics_day
+    if metrics_backfill_days is not None:
+        daily_metrics_kwargs["backfill_days"] = metrics_backfill_days
+
+    if has_git and not has_work_items:
         celery_app.send_task(
             "dev_health_ops.workers.tasks.run_daily_metrics",
-            kwargs={"org_id": org_id},
+            kwargs=daily_metrics_kwargs,
             queue="metrics",
         )
         dispatched.append("run_daily_metrics")
 
+    if has_work_items:
+        dispatched.append("sync_teams_to_analytics")
+        dispatched.append("run_daily_metrics")
+
+    if has_git:
         celery_app.send_task(
             "dev_health_ops.workers.tasks.run_complexity_job",
             kwargs={"org_id": org_id},
@@ -336,6 +353,20 @@ def _dispatch_post_sync_tasks(
     # work-items-only providers (Jira/Linear) and separately scheduled code vs
     # work-item syncs with a permanently empty /investment view (CHAOS-2374).
     if has_git or has_work_items:
+        build_kwargs: dict[str, Any] = {"org_id": org_id}
+        graph_from_date = work_graph_from_date or from_date
+        if graph_from_date is not None:
+            build_kwargs["from_date"] = graph_from_date
+        graph_to_date = work_graph_to_date or to_date
+        if graph_to_date is not None:
+            build_kwargs["to_date"] = graph_to_date
+
+        materialize_kwargs: dict[str, Any] = {"org_id": org_id}
+        if from_date is not None:
+            materialize_kwargs["from_date"] = from_date
+        if to_date is not None:
+            materialize_kwargs["to_date"] = to_date
+
         # Investment distributions depend on the freshly rebuilt work graph.
         # Enqueueing two independent tasks on the same queue only preserves
         # publish order, not completion order: with multiple metrics workers
@@ -356,12 +387,13 @@ def _dispatch_post_sync_tasks(
         # the projection task (no-LLM, org-wide, full coverage).
         build_sig = celery_app.signature(
             "dev_health_ops.workers.tasks.run_work_graph_build",
-            kwargs={"org_id": org_id},
+            kwargs=build_kwargs,
             queue="metrics",
+            immutable=has_work_items,
         )
         materialize_sig = celery_app.signature(
             "dev_health_ops.workers.tasks.run_investment_materialize",
-            kwargs={"org_id": org_id},
+            kwargs=materialize_kwargs,
             queue="metrics",
             immutable=True,
         )
@@ -371,7 +403,27 @@ def _dispatch_post_sync_tasks(
             queue="metrics",
             immutable=True,
         )
-        chain(build_sig, materialize_sig, project_membership_sig).apply_async()
+        if has_work_items:
+            sync_teams_sig = celery_app.signature(
+                "dev_health_ops.workers.tasks.sync_teams_to_analytics",
+                kwargs={"org_id": org_id},
+                queue="metrics",
+            )
+            daily_metrics_sig = celery_app.signature(
+                "dev_health_ops.workers.tasks.run_daily_metrics",
+                kwargs=daily_metrics_kwargs,
+                queue="metrics",
+                immutable=True,
+            )
+            chain(
+                sync_teams_sig,
+                daily_metrics_sig,
+                build_sig,
+                materialize_sig,
+                project_membership_sig,
+            ).apply_async()
+        else:
+            chain(build_sig, materialize_sig, project_membership_sig).apply_async()
         dispatched.append("run_work_graph_build")
         dispatched.append("run_investment_materialize")
         dispatched.append("run_membership_backfill")

--- a/tests/test_backfill_integration.py
+++ b/tests/test_backfill_integration.py
@@ -341,6 +341,170 @@ def test_run_backfill_does_not_create_scheduled_job(
     engine.dispose()
 
 
+def test_run_backfill_dispatches_post_sync_tasks_once_after_completion(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        engine,
+        tables=tables_of(SyncConfiguration, ScheduledJob, JobRun, BackfillJob),
+    )
+
+    org_id = str(uuid.uuid4())
+    sync_config_id = uuid.uuid4()
+
+    with Session(engine) as session:
+        config = SyncConfiguration(
+            org_id=org_id,
+            name="linear-backfill",
+            provider="linear",
+            sync_targets=[],
+            sync_options={},
+            is_active=True,
+        )
+        config.id = sync_config_id
+        session.add(config)
+        session.commit()
+
+    @contextmanager
+    def _session_ctx():
+        with Session(engine) as session:
+            try:
+                yield session
+                session.commit()
+            except Exception:
+                session.rollback()
+                raise
+
+    monkeypatch.setattr(
+        "dev_health_ops.db.get_postgres_session_sync",
+        lambda: _session_ctx(),
+    )
+
+    def _fake_run_backfill_for_config(**kwargs):
+        progress_cb = kwargs["progress_cb"]
+        progress_cb(1, 2, date(2026, 1, 1), date(2026, 1, 7))
+        progress_cb(2, 2, date(2026, 1, 8), date(2026, 1, 14))
+        return {"status": "success", "window_count": 2}
+
+    monkeypatch.setattr(
+        "dev_health_ops.backfill.runner.run_backfill_for_config",
+        _fake_run_backfill_for_config,
+    )
+    dispatch = MagicMock()
+    monkeypatch.setattr(
+        "dev_health_ops.workers.sync_runtime._dispatch_post_sync_tasks",
+        dispatch,
+    )
+
+    from dev_health_ops.workers.sync_backfill import run_backfill
+
+    task: Any = run_backfill
+    task.push_request(id="backfill-post-sync-dispatch")
+    try:
+        result = task(
+            sync_config_id=str(sync_config_id),
+            since="2026-01-01",
+            before="2026-01-14",
+            org_id=org_id,
+        )
+    finally:
+        task.pop_request()
+
+    assert result["status"] == "success"
+    dispatch.assert_called_once_with(
+        provider="linear",
+        sync_targets=["work-items"],
+        org_id=org_id,
+        metrics_day="2026-01-14",
+        metrics_backfill_days=14,
+        from_date="2026-01-01",
+        to_date="2026-01-14",
+        work_graph_from_date="2026-01-01T00:00:00+00:00",
+        work_graph_to_date="2026-01-15T00:00:00+00:00",
+    )
+
+    engine.dispose()
+
+
+def test_run_backfill_dispatch_failure_does_not_retry_ingestion(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(
+        engine,
+        tables=tables_of(SyncConfiguration, ScheduledJob, JobRun, BackfillJob),
+    )
+
+    org_id = str(uuid.uuid4())
+    sync_config_id = uuid.uuid4()
+
+    with Session(engine) as session:
+        config = SyncConfiguration(
+            org_id=org_id,
+            name="linear-backfill",
+            provider="linear",
+            sync_targets=[],
+            sync_options={},
+            is_active=True,
+        )
+        config.id = sync_config_id
+        session.add(config)
+        session.commit()
+
+    @contextmanager
+    def _session_ctx():
+        with Session(engine) as session:
+            try:
+                yield session
+                session.commit()
+            except Exception:
+                session.rollback()
+                raise
+
+    monkeypatch.setattr(
+        "dev_health_ops.db.get_postgres_session_sync",
+        lambda: _session_ctx(),
+    )
+
+    backfill_call_count = 0
+
+    def _fake_run_backfill_for_config(**kwargs):
+        nonlocal backfill_call_count
+        backfill_call_count += 1
+        return {"status": "success", "window_count": 1}
+
+    monkeypatch.setattr(
+        "dev_health_ops.backfill.runner.run_backfill_for_config",
+        _fake_run_backfill_for_config,
+    )
+    dispatch = MagicMock(side_effect=RuntimeError("broker unavailable"))
+    monkeypatch.setattr(
+        "dev_health_ops.workers.sync_runtime._dispatch_post_sync_tasks",
+        dispatch,
+    )
+
+    from dev_health_ops.workers.sync_backfill import run_backfill
+
+    task: Any = run_backfill
+    task.push_request(id="backfill-dispatch-failure")
+    try:
+        result = task(
+            sync_config_id=str(sync_config_id),
+            since="2026-01-01",
+            before="2026-01-14",
+            org_id=org_id,
+        )
+    finally:
+        task.pop_request()
+
+    assert result["status"] == "success"
+    assert backfill_call_count == 1
+    dispatch.assert_called_once()
+
+    engine.dispose()
+
+
 def test_dispatch_scheduled_syncs_ignores_backfill_jobs(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/test_post_sync_investment_dispatch.py
+++ b/tests/test_post_sync_investment_dispatch.py
@@ -32,6 +32,8 @@ from dev_health_ops.workers.sync_runtime import _dispatch_post_sync_tasks
 _INVESTMENT_TASK = "dev_health_ops.workers.tasks.run_investment_materialize"
 _WORK_GRAPH_TASK = "dev_health_ops.workers.tasks.run_work_graph_build"
 _PROJECTION_TASK = "dev_health_ops.workers.tasks.run_membership_backfill"
+_DAILY_METRICS_TASK = "dev_health_ops.workers.tasks.run_daily_metrics"
+_TEAM_SYNC_TASK = "dev_health_ops.workers.tasks.sync_teams_to_analytics"
 
 
 def _run_dispatch(provider: str, sync_targets: list[str], org_id: str):
@@ -77,7 +79,11 @@ def test_investment_chain_dispatched_with_git_and_work_items() -> None:
 
     # The chain must be built build FIRST, materialize SECOND, project THIRD.
     assert mock_chain.call_count == 1
-    build_sig, materialize_sig, project_sig = mock_chain.call_args.args
+    team_sig, daily_sig, build_sig, materialize_sig, project_sig = (
+        mock_chain.call_args.args
+    )
+    assert team_sig.task_name == _TEAM_SYNC_TASK
+    assert daily_sig.task_name == _DAILY_METRICS_TASK
     assert build_sig.task_name == _WORK_GRAPH_TASK
     assert materialize_sig.task_name == _INVESTMENT_TASK
     assert project_sig.task_name == _PROJECTION_TASK, (
@@ -86,6 +92,11 @@ def test_investment_chain_dispatched_with_git_and_work_items() -> None:
     )
 
     # All signatures are org-scoped onto the metrics queue.
+    assert team_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    assert team_sig.sig_kwargs["queue"] == "metrics"
+    assert daily_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    assert daily_sig.sig_kwargs["queue"] == "metrics"
+    assert daily_sig.sig_kwargs.get("immutable") is True
     assert build_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
     assert build_sig.sig_kwargs["queue"] == "metrics"
     assert materialize_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
@@ -97,7 +108,7 @@ def test_investment_chain_dispatched_with_git_and_work_items() -> None:
     # injected as a positional arg (which would break the next task).
     assert materialize_sig.sig_kwargs.get("immutable") is True
     assert project_sig.sig_kwargs.get("immutable") is True
-    assert build_sig.sig_kwargs.get("immutable") is not True
+    assert build_sig.sig_kwargs.get("immutable") is True
 
     # The chain is actually dispatched (not just constructed).
     chain_instance.apply_async.assert_called_once_with()
@@ -137,13 +148,93 @@ def test_investment_chain_dispatched_with_work_items_only_jira() -> None:
     )
 
     assert mock_chain.call_count == 1
-    build_sig, materialize_sig, project_sig = mock_chain.call_args.args
+    team_sig, daily_sig, build_sig, materialize_sig, project_sig = (
+        mock_chain.call_args.args
+    )
+    assert team_sig.task_name == _TEAM_SYNC_TASK
+    assert daily_sig.task_name == _DAILY_METRICS_TASK
     assert build_sig.task_name == _WORK_GRAPH_TASK
     assert materialize_sig.task_name == _INVESTMENT_TASK
     assert project_sig.task_name == _PROJECTION_TASK
+    assert team_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    assert daily_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    assert daily_sig.sig_kwargs.get("immutable") is True
     assert materialize_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
     assert project_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
     chain_instance.apply_async.assert_called_once_with()
+
+
+def test_daily_metrics_dispatched_with_work_items_only_jira() -> None:
+    _, mock_chain, _, mock_send_task = _run_dispatch(
+        provider="jira",
+        sync_targets=["work-items"],
+        org_id="org-123",
+    )
+
+    mock_send_task.assert_not_called()
+    team_sig, daily_sig, *_ = mock_chain.call_args.args
+    assert team_sig.task_name == _TEAM_SYNC_TASK
+    assert daily_sig.task_name == _DAILY_METRICS_TASK
+    assert team_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    assert daily_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    assert daily_sig.sig_kwargs["queue"] == "metrics"
+    assert daily_sig.sig_kwargs.get("immutable") is True
+
+
+def test_post_sync_dispatch_forwards_backfill_window() -> None:
+    from dev_health_ops.workers.sync_runtime import _dispatch_post_sync_tasks
+
+    with (
+        patch(
+            "dev_health_ops.workers.sync_runtime.celery_app.signature"
+        ) as window_signature,
+        patch("dev_health_ops.workers.sync_runtime.chain") as window_chain,
+        patch(
+            "dev_health_ops.workers.sync_runtime.celery_app.send_task"
+        ) as window_send_task,
+    ):
+
+        def _make_sig(name, **kwargs):
+            sig = MagicMock(name=f"sig:{name}")
+            sig.task_name = name
+            sig.sig_kwargs = kwargs
+            return sig
+
+        window_signature.side_effect = _make_sig
+        _dispatch_post_sync_tasks(
+            provider="linear",
+            sync_targets=["work-items"],
+            org_id="org-123",
+            metrics_day="2026-01-14",
+            metrics_backfill_days=14,
+            from_date="2026-01-01",
+            to_date="2026-01-14",
+            work_graph_from_date="2026-01-01T00:00:00+00:00",
+            work_graph_to_date="2026-01-15T00:00:00+00:00",
+        )
+
+    window_send_task.assert_not_called()
+    team_sig, daily_sig, build_sig, materialize_sig, _ = window_chain.call_args.args
+    assert team_sig.task_name == _TEAM_SYNC_TASK
+    assert team_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    assert daily_sig.task_name == _DAILY_METRICS_TASK
+    assert daily_sig.sig_kwargs["kwargs"] == {
+        "org_id": "org-123",
+        "day": "2026-01-14",
+        "backfill_days": 14,
+    }
+    assert daily_sig.sig_kwargs.get("immutable") is True
+
+    assert build_sig.sig_kwargs["kwargs"] == {
+        "org_id": "org-123",
+        "from_date": "2026-01-01T00:00:00+00:00",
+        "to_date": "2026-01-15T00:00:00+00:00",
+    }
+    assert materialize_sig.sig_kwargs["kwargs"] == {
+        "org_id": "org-123",
+        "from_date": "2026-01-01",
+        "to_date": "2026-01-14",
+    }
 
 
 def test_no_investment_chain_for_feature_flags_only() -> None:

--- a/tests/test_work_item_metrics_compute.py
+++ b/tests/test_work_item_metrics_compute.py
@@ -135,3 +135,45 @@ def test_linear_item_in_project_attributes_team_via_project_key() -> None:
     assert group_rows[0].work_scope_id == "Q1 Platform Revamp"
     assert group_rows[0].team_id == "ENG"
     assert cycle_rows[0].team_id == "ENG"
+
+
+def test_linear_native_team_key_resolves_from_team_id_without_project_keys() -> None:
+    from dev_health_ops.providers.teams import build_project_key_resolver
+
+    day = date(2025, 2, 1)
+    start = datetime(2025, 2, 1, tzinfo=timezone.utc)
+    item = WorkItem(
+        work_item_id="linear:CHAOS-1",
+        provider="linear",
+        project_key=None,
+        project_id="Ops Board",
+        native_team_key="CHAOS",
+        title="Team-only issue",
+        type="task",
+        status="done",
+        status_raw="Done",
+        assignees=[],
+        reporter=None,
+        created_at=start - timedelta(days=2),
+        updated_at=start + timedelta(hours=2),
+        started_at=start,
+        completed_at=start + timedelta(hours=2),
+        closed_at=start + timedelta(hours=2),
+        labels=[],
+    )
+    resolver = build_project_key_resolver(
+        [{"id": "CHAOS", "name": "Fullchaos", "project_keys": []}]
+    )
+
+    group_rows, _, cycle_rows = compute_work_item_metrics_daily(
+        day=day,
+        work_items=[item],
+        transitions=[],
+        computed_at=start,
+        team_resolver=TeamResolver(member_to_team={}),
+        project_key_resolver=resolver,
+    )
+
+    assert group_rows[0].team_id == "CHAOS"
+    assert group_rows[0].team_name == "Fullchaos"
+    assert cycle_rows[0].team_id == "CHAOS"


### PR DESCRIPTION
## Summary
- resolve Linear native team keys from ClickHouse team IDs when project keys are absent
- run the ClickHouse team bridge before metrics recompute for work-item sync/backfill follow-ups
- dispatch window-aware post-backfill recompute once after UX/provider backfills complete

## Verification
- uv run --extra dev pytest tests/test_post_sync_investment_dispatch.py tests/test_post_sync_dora_dispatch.py tests/test_backfill.py tests/test_backfill_integration.py tests/test_work_item_metrics_compute.py -q
- pre-push hook: ruff check + ruff format --check

SCREENSHOT-WAIVER: backend-only worker/metrics dispatch change; no rendered UI changed.