### PR TITLE
fix(analytics): apply repo filter to sankey coverage (CHAOS-2488)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -55,6 +55,7 @@ from ..sql.compiler import (
     compile_sankey,
     compile_timeseries,
 )
+from ..sql.filter_translation import translate_filters
 
 logger = logging.getLogger(__name__)
 
@@ -643,10 +644,12 @@ async def resolve_analytics(
                         LEFT JOIN (
                             SELECT
                                 work_unit_id,
-                                argMax(team, cnt) AS team_label
+                                argMax(team, cnt) AS team_label,
+                                argMax(team_id, cnt) AS team_id
                             FROM (
                                 SELECT
                                     work_unit_investments.work_unit_id AS work_unit_id,
+                                    t.team_id AS team_id,
                                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
                                     countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
                                 FROM latest_work_unit_investments AS work_unit_investments
@@ -663,7 +666,7 @@ async def resolve_analytics(
                                     WHERE org_id = %(org_id)s
                                     GROUP BY work_item_id
                                 ) AS t ON t.work_item_id = issue_id
-                                GROUP BY work_unit_id, team
+                                GROUP BY work_unit_id, team_id, team
                             )
                             GROUP BY work_unit_id
                         ) AS ut ON ut.work_unit_id = work_unit_investments.work_unit_id
@@ -692,6 +695,26 @@ async def resolve_analytics(
                     else "org_id = %(org_id)s"
                 )
 
+                coverage_filters = (
+                    FilterInput(
+                        scope=resolved_filters.scope,
+                        what=resolved_filters.what,
+                    )
+                    if resolved_filters is not None
+                    else None
+                )
+                coverage_filter_clause, coverage_filter_params = translate_filters(
+                    coverage_filters,
+                    use_investment=bool(request.use_investment),
+                    team_column=team_col,
+                    repo_column="work_unit_investments.repo_id"
+                    if request.use_investment
+                    else repo_col,
+                    author_column="work_unit_investments.author_id"
+                    if request.use_investment
+                    else "author_id",
+                )
+
                 coverage_sql = f"""
                     {with_clause}
                     SELECT
@@ -702,6 +725,7 @@ async def resolve_analytics(
                     {joins}
                     WHERE {date_filter}
                       AND {org_filter}
+                      {coverage_filter_clause}
                 """
 
                 cov_params = {
@@ -709,6 +733,7 @@ async def resolve_analytics(
                     "end_date": request.end_date,
                     "org_id": org_id,
                 }
+                cov_params.update(coverage_filter_params)
 
                 try:
                     c_rows = await query_dicts(client, coverage_sql, cov_params)

--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -174,6 +174,26 @@ def _analytics_quality_window(batch: AnalyticsRequestInput) -> tuple[date, date]
     return None
 
 
+def _has_investment_author_filter(filters: FilterInput | None) -> bool:
+    if filters is None:
+        return False
+    if (
+        filters.scope is not None
+        and filters.scope.level.value == "developer"
+        and bool(filters.scope.ids)
+    ):
+        return True
+    return filters.who is not None and bool(filters.who.developers)
+
+
+def _has_work_category_filter(filters: FilterInput | None) -> bool:
+    return (
+        filters is not None
+        and filters.why is not None
+        and bool(filters.why.work_category)
+    )
+
+
 async def _resolve_evidence_quality_stats(
     client: Any,
     batch: AnalyticsRequestInput,
@@ -675,8 +695,20 @@ async def resolve_analytics(
 
                 assigned_team_expr = f"lower(ifNull(nullIf({team_col}, ''), 'unassigned')) != 'unassigned'"
                 assigned_repo_expr = f"{repo_col} IS NOT NULL"
+                total_expr = "count()"
+                assigned_team_count_expr = f"countIf({assigned_team_expr})"
+                assigned_repo_count_expr = f"countIf({assigned_repo_expr})"
                 if request.use_investment:
                     assigned_repo_expr = f"lower({repo_col}) != 'unassigned'"
+                    total_expr = "uniqExact(work_unit_investments.work_unit_id)"
+                    assigned_team_count_expr = (
+                        "uniqExactIf(work_unit_investments.work_unit_id, "
+                        f"{assigned_team_expr})"
+                    )
+                    assigned_repo_count_expr = (
+                        "uniqExactIf(work_unit_investments.work_unit_id, "
+                        f"{assigned_repo_expr})"
+                    )
 
                 with_clause = (
                     f"WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}"
@@ -695,61 +727,65 @@ async def resolve_analytics(
                     else "org_id = %(org_id)s"
                 )
 
-                coverage_filters = (
-                    FilterInput(
-                        scope=resolved_filters.scope,
-                        what=resolved_filters.what,
+                if request.use_investment and _has_investment_author_filter(
+                    resolved_filters
+                ):
+                    logger.info(
+                        "Sankey coverage unavailable for investment author filters; "
+                        "work_unit_investments does not expose author_id"
                     )
-                    if resolved_filters is not None
-                    else None
-                )
-                coverage_filter_clause, coverage_filter_params = translate_filters(
-                    coverage_filters,
-                    use_investment=bool(request.use_investment),
-                    team_column=team_col,
-                    repo_column="work_unit_investments.repo_id"
-                    if request.use_investment
-                    else repo_col,
-                    author_column="work_unit_investments.author_id"
-                    if request.use_investment
-                    else "author_id",
-                )
+                else:
+                    if request.use_investment and _has_work_category_filter(
+                        resolved_filters
+                    ):
+                        joins += """
+                        ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
+                        """
 
-                coverage_sql = f"""
-                    {with_clause}
-                    SELECT
-                        count() as total,
-                        countIf({assigned_team_expr}) as assigned_team,
-                        countIf({assigned_repo_expr}) as assigned_repo
-                    FROM {base_table}
-                    {joins}
-                    WHERE {date_filter}
-                      AND {org_filter}
-                      {coverage_filter_clause}
-                """
+                    coverage_filter_clause, coverage_filter_params = translate_filters(
+                        resolved_filters,
+                        use_investment=bool(request.use_investment),
+                        team_column=team_col,
+                        repo_column="work_unit_investments.repo_id"
+                        if request.use_investment
+                        else repo_col,
+                        author_column="author_id",
+                    )
 
-                cov_params = {
-                    "start_date": request.start_date,
-                    "end_date": request.end_date,
-                    "org_id": org_id,
-                }
-                cov_params.update(coverage_filter_params)
+                    coverage_sql = f"""
+                        {with_clause}
+                        SELECT
+                            {total_expr} as total,
+                            {assigned_team_count_expr} as assigned_team,
+                            {assigned_repo_count_expr} as assigned_repo
+                        FROM {base_table}
+                        {joins}
+                        WHERE {date_filter}
+                          AND {org_filter}
+                          {coverage_filter_clause}
+                    """
 
-                try:
-                    c_rows = await query_dicts(client, coverage_sql, cov_params)
-                    if c_rows:
-                        total = float(c_rows[0].get("total", 0))
-                        assigned_team = float(c_rows[0].get("assigned_team", 0))
-                        assigned_repo = float(c_rows[0].get("assigned_repo", 0))
+                    cov_params = {
+                        "start_date": request.start_date,
+                        "end_date": request.end_date,
+                        "org_id": org_id,
+                    }
+                    cov_params.update(coverage_filter_params)
 
-                        coverage = SankeyCoverage(
-                            team_coverage=assigned_team / total if total > 0 else 0,
-                            repo_coverage=assigned_repo / total if total > 0 else 0,
-                        )
-                except Exception as e:
-                    logger.error("Coverage query failed: %s", e)
-                    # Don't fail the whole request for metrics
-                    coverage = SankeyCoverage(team_coverage=0, repo_coverage=0)
+                    try:
+                        c_rows = await query_dicts(client, coverage_sql, cov_params)
+                        if c_rows:
+                            total = float(c_rows[0].get("total", 0))
+                            assigned_team = float(c_rows[0].get("assigned_team", 0))
+                            assigned_repo = float(c_rows[0].get("assigned_repo", 0))
+
+                            coverage = SankeyCoverage(
+                                team_coverage=assigned_team / total if total > 0 else 0,
+                                repo_coverage=assigned_repo / total if total > 0 else 0,
+                            )
+                    except Exception as e:
+                        logger.error("Coverage query failed: %s", e)
+                        coverage = None
 
             sankey_result = SankeyResult(nodes=nodes, edges=edges, coverage=coverage)
 

--- a/tests/api/test_analytics_repo_filter_resolution.py
+++ b/tests/api/test_analytics_repo_filter_resolution.py
@@ -13,6 +13,7 @@ from dev_health_ops.api.graphql.models.inputs import (
     DimensionInput,
     FilterInput,
     MeasureInput,
+    SankeyRequestInput,
     ScopeFilterInput,
     ScopeLevelInput,
     WhatFilterInput,
@@ -36,6 +37,22 @@ def _breakdown_batch(filters: FilterInput) -> AnalyticsRequestInput:
                 ),
             )
         ],
+        use_investment=True,
+        filters=filters,
+    )
+
+
+def _sankey_batch(filters: FilterInput | None = None) -> AnalyticsRequestInput:
+    return AnalyticsRequestInput(
+        sankey=SankeyRequestInput(
+            path=[DimensionInput.THEME, DimensionInput.REPO],
+            measure=MeasureInput.COUNT,
+            date_range=DateRangeInput(
+                start_date=date(2026, 6, 1),
+                end_date=date(2026, 6, 17),
+            ),
+            use_investment=True,
+        ),
         use_investment=True,
         filters=filters,
     )
@@ -104,3 +121,48 @@ async def test_analytics_resolves_repo_name_filters_to_repo_ids(
     assert matching_params
     assert all(params[param_name] == [REPO_UUID] for params in matching_params)
     assert result.breakdowns[0].items[0].value == 1.0
+
+
+@pytest.mark.asyncio
+async def test_sankey_coverage_respects_resolved_repo_name_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_coverage_params: list[dict[str, Any]] = []
+
+    async def fake_query_dicts(_client: object, sql: str, params: dict[str, Any]):
+        if "FROM repos" in sql:
+            assert params["repo_names"] == [REPO_FULL_NAME]
+            return [{"repo_id": REPO_UUID, "repo": REPO_FULL_NAME}]
+        if "countIf(" in sql and "assigned_team" in sql:
+            captured_coverage_params.append(dict(params))
+            if params.get("repo_filter_ids") == [REPO_UUID]:
+                return [{"total": 2, "assigned_team": 1, "assigned_repo": 2}]
+            return [{"total": 4, "assigned_team": 4, "assigned_repo": 4}]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts",
+        fake_query_dicts,
+    )
+
+    context = GraphQLContext(
+        org_id="org-1", db_url="clickhouse://test", client=object()
+    )
+
+    org_wide = await analytics_resolver.resolve_analytics(
+        context,
+        _sankey_batch(),
+    )
+    filtered = await analytics_resolver.resolve_analytics(
+        context,
+        _sankey_batch(FilterInput(what=WhatFilterInput(repos=[REPO_FULL_NAME]))),
+    )
+
+    assert captured_coverage_params[0].get("repo_filter_ids") is None
+    assert captured_coverage_params[1]["repo_filter_ids"] == [REPO_UUID]
+    assert org_wide.sankey is not None
+    assert org_wide.sankey.coverage is not None
+    assert filtered.sankey is not None
+    assert filtered.sankey.coverage is not None
+    assert org_wide.sankey.coverage.team_coverage == 1.0
+    assert filtered.sankey.coverage.team_coverage == 0.5

--- a/tests/api/test_analytics_repo_filter_resolution.py
+++ b/tests/api/test_analytics_repo_filter_resolution.py
@@ -17,6 +17,8 @@ from dev_health_ops.api.graphql.models.inputs import (
     ScopeFilterInput,
     ScopeLevelInput,
     WhatFilterInput,
+    WhoFilterInput,
+    WhyFilterInput,
 )
 from dev_health_ops.api.graphql.resolvers import analytics as analytics_resolver
 from dev_health_ops.api.queries import investment as investment_queries
@@ -133,7 +135,7 @@ async def test_sankey_coverage_respects_resolved_repo_name_filter(
         if "FROM repos" in sql:
             assert params["repo_names"] == [REPO_FULL_NAME]
             return [{"repo_id": REPO_UUID, "repo": REPO_FULL_NAME}]
-        if "countIf(" in sql and "assigned_team" in sql:
+        if "assigned_team" in sql:
             captured_coverage_params.append(dict(params))
             if params.get("repo_filter_ids") == [REPO_UUID]:
                 return [{"total": 2, "assigned_team": 1, "assigned_repo": 2}]
@@ -160,6 +162,92 @@ async def test_sankey_coverage_respects_resolved_repo_name_filter(
 
     assert captured_coverage_params[0].get("repo_filter_ids") is None
     assert captured_coverage_params[1]["repo_filter_ids"] == [REPO_UUID]
+    assert org_wide.sankey is not None
+    assert org_wide.sankey.coverage is not None
+    assert filtered.sankey is not None
+    assert filtered.sankey.coverage is not None
+    assert org_wide.sankey.coverage.team_coverage == 1.0
+    assert filtered.sankey.coverage.team_coverage == 0.5
+
+
+@pytest.mark.asyncio
+async def test_sankey_coverage_unavailable_for_investment_developer_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    developer_id = "dev-1"
+    captured_sankey_params: list[dict[str, Any]] = []
+    captured_coverage_params: list[dict[str, Any]] = []
+
+    async def fake_query_dicts(_client: object, sql: str, params: dict[str, Any]):
+        if "assigned_team" in sql:
+            captured_coverage_params.append(dict(params))
+            return [{"total": 4, "assigned_team": 4, "assigned_repo": 4}]
+        if "developer_ids" in params:
+            captured_sankey_params.append(dict(params))
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts",
+        fake_query_dicts,
+    )
+
+    result = await analytics_resolver.resolve_analytics(
+        GraphQLContext(org_id="org-1", db_url="clickhouse://test", client=object()),
+        _sankey_batch(FilterInput(who=WhoFilterInput(developers=[developer_id]))),
+    )
+
+    assert captured_sankey_params
+    assert all(
+        params["developer_ids"] == [developer_id] for params in captured_sankey_params
+    )
+    assert captured_coverage_params == []
+    assert result.sankey is not None
+    assert result.sankey.coverage is None
+
+
+@pytest.mark.asyncio
+async def test_sankey_coverage_respects_work_category_filter_domain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    work_category = "Feature Delivery"
+    captured_sankey_params: list[dict[str, Any]] = []
+    captured_coverage_params: list[dict[str, Any]] = []
+
+    async def fake_query_dicts(_client: object, sql: str, params: dict[str, Any]):
+        if "assigned_team" in sql:
+            captured_coverage_params.append(dict(params))
+            if params.get("work_categories") == [work_category]:
+                return [{"total": 2, "assigned_team": 1, "assigned_repo": 2}]
+            return [{"total": 4, "assigned_team": 4, "assigned_repo": 4}]
+        if "work_categories" in params:
+            captured_sankey_params.append(dict(params))
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts",
+        fake_query_dicts,
+    )
+
+    context = GraphQLContext(
+        org_id="org-1", db_url="clickhouse://test", client=object()
+    )
+
+    org_wide = await analytics_resolver.resolve_analytics(
+        context,
+        _sankey_batch(),
+    )
+    filtered = await analytics_resolver.resolve_analytics(
+        context,
+        _sankey_batch(FilterInput(why=WhyFilterInput(work_category=[work_category]))),
+    )
+
+    assert captured_sankey_params
+    assert all(
+        params["work_categories"] == [work_category]
+        for params in captured_sankey_params
+    )
+    assert captured_coverage_params[0].get("work_categories") is None
+    assert captured_coverage_params[1]["work_categories"] == [work_category]
     assert org_wide.sankey is not None
     assert org_wide.sankey.coverage is not None
     assert filtered.sankey is not None


### PR DESCRIPTION
## Summary
- Apply resolved repo/scope filters to the Sankey coverage query using the existing filter translator.
- Preserve team-scope support in the investment coverage path by exposing team_id in the local coverage join.
- Add regression coverage for repo full-name filters changing Sankey coverage params/results.

## Verification
- ruff format src/dev_health_ops/api/graphql/resolvers/analytics.py tests/api/test_analytics_repo_filter_resolution.py
- ruff check src/dev_health_ops/api/graphql/resolvers/analytics.py tests/api/test_analytics_repo_filter_resolution.py
- PYTHONPATH=src python -m pytest tests/api/test_analytics_repo_filter_resolution.py
- LSP diagnostics clean on changed files

SCREENSHOT-WAIVER: backend-only GraphQL resolver behavior; no rendered UI changed.

Closes CHAOS-2488