### PR TITLE
fix(analytics): honor (or reject) filters for same-dim flow matrix (CHAOS-2487)

### DIFF
--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -193,7 +193,12 @@ def _has_active_filters(filters: FilterInput | None) -> bool:
         return False
 
     if filters.scope and filters.scope.ids:
-        if filters.scope.level.value not in {"org", "service"}:
+        # Any non-org scope with ids would change the result set, but the
+        # same-dim TEAM/REPO/WORK_TYPE templates apply no scope predicate
+        # (incl. service, which translate_scope_filter no-ops). Treat all of
+        # them as active so we reject honestly instead of silently returning
+        # org-wide data (CHAOS-2487).
+        if filters.scope.level.value != "org":
             return True
 
     return any(

--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from dev_health_ops.api.queries.investment import LATEST_WORK_UNIT_INVESTMENTS_CTE
 
 from ..authz import enforce_org_scope
+from ..errors import ValidationError
 from .filter_translation import translate_filters
 from .templates import (
     breakdown_template,
@@ -185,6 +186,24 @@ def _needs_team_join(filters: FilterInput | None) -> bool:
     if not filters or not filters.scope or not filters.scope.ids:
         return False
     return filters.scope.level.value == "team"
+
+
+def _has_active_filters(filters: FilterInput | None) -> bool:
+    if filters is None:
+        return False
+
+    if filters.scope and filters.scope.ids:
+        if filters.scope.level.value not in {"org", "service"}:
+            return True
+
+    return any(
+        (
+            filters.who and (filters.who.developers or filters.who.roles),
+            filters.what and (filters.what.repos or filters.what.services),
+            filters.why and (filters.why.work_category or filters.why.issue_type),
+            filters.how and filters.how.flow_stage,
+        )
+    )
 
 
 def compile_timeseries(
@@ -387,14 +406,8 @@ def compile_flow_matrix(
         "timeout": timeout,
     }
 
-    # The TEAM / REPO / WORK_TYPE branches intentionally do not thread
-    # `filter_clause`; those templates source from work_item_cycle_times +
-    # work_items where the filter column set (investment_area etc.) doesn't
-    # apply. Only the sankey fallback — which queries investment_metrics_daily —
-    # uses filters. Callers that need filtered flow matrices for same-dim TEAM /
-    # REPO / WORK_TYPE should open a follow-up to wire filter columns into the
-    # two underlying tables first.
     if dimension == Dimension.TEAM:
+        _reject_filtered_same_dimension_flow_matrix(dimension, filters)
         nodes_sql = flow_matrix_team_nodes_template()
         edge_sql = flow_matrix_team_edges_template()
         nodes_params = {**common_params, "limit_per_dim": request.max_nodes}
@@ -402,6 +415,7 @@ def compile_flow_matrix(
         edge_params = {**common_params, "max_edges": request.max_edges}
         edge_params = enforce_org_scope(org_id, edge_params)
     elif dimension == Dimension.REPO:
+        _reject_filtered_same_dimension_flow_matrix(dimension, filters)
         nodes_sql = flow_matrix_repo_nodes_template()
         edge_sql = flow_matrix_repo_edges_template()
         nodes_params = {**common_params, "limit_per_dim": request.max_nodes}
@@ -409,6 +423,7 @@ def compile_flow_matrix(
         edge_params = {**common_params, "max_edges": request.max_edges}
         edge_params = enforce_org_scope(org_id, edge_params)
     elif dimension == Dimension.WORK_TYPE:
+        _reject_filtered_same_dimension_flow_matrix(dimension, filters)
         nodes_sql = flow_matrix_work_type_nodes_template()
         edge_sql = flow_matrix_work_type_edges_template()
         nodes_params = {**common_params, "limit_per_dim": request.max_nodes}
@@ -431,6 +446,22 @@ def compile_flow_matrix(
         edge_params = enforce_org_scope(org_id, edge_params)
 
     return [(nodes_sql, nodes_params)], [(edge_sql, edge_params)]
+
+
+def _reject_filtered_same_dimension_flow_matrix(
+    dimension: Dimension,
+    filters: FilterInput | None,
+) -> None:
+    if not _has_active_filters(filters):
+        return
+
+    raise ValidationError(
+        "flowMatrix filters are not supported for same-dimension "
+        f"{dimension.value} queries yet (CHAOS-2487); remove filters or use "
+        "theme/subcategory.",
+        field="filters",
+        value=dimension.value,
+    )
 
 
 def compile_catalog_values(

--- a/tests/graphql/test_flow_matrix.py
+++ b/tests/graphql/test_flow_matrix.py
@@ -22,6 +22,12 @@ from dev_health_ops.api.graphql.cost import (
     validate_sub_request_count,
 )
 from dev_health_ops.api.graphql.errors import ValidationError
+from dev_health_ops.api.graphql.models.inputs import (
+    FilterInput,
+    ScopeFilterInput,
+    ScopeLevelInput,
+    WhatFilterInput,
+)
 from dev_health_ops.api.graphql.sql.compiler import (
     FlowMatrixRequest,
     compile_flow_matrix,
@@ -126,6 +132,47 @@ class TestCompileFlowMatrix:
         assert "'WORK_TYPE' AS source_dimension" in edges_sql
         assert "INNER JOIN work_items" in edges_sql
         assert "'WORK_TYPE' AS dimension" in nodes_sql
+
+    @pytest.mark.parametrize(
+        ("dim", "filters"),
+        [
+            ("repo", FilterInput(what=WhatFilterInput(repos=["repo-1"]))),
+            (
+                "repo",
+                FilterInput(
+                    scope=ScopeFilterInput(
+                        level=ScopeLevelInput.REPO,
+                        ids=["repo-1"],
+                    )
+                ),
+            ),
+            ("team", FilterInput(what=WhatFilterInput(repos=["repo-1"]))),
+            ("work_type", FilterInput(what=WhatFilterInput(repos=["repo-1"]))),
+        ],
+    )
+    def test_same_dimension_templates_reject_active_filters(
+        self,
+        dim: str,
+        filters: FilterInput,
+    ) -> None:
+        with pytest.raises(ValidationError, match="CHAOS-2487") as exc_info:
+            compile_flow_matrix(_req(dim), org_id="org-1", filters=filters)
+
+        assert exc_info.value.field == "filters"
+        assert exc_info.value.value == dim
+
+    def test_same_dimension_templates_allow_empty_filters(self) -> None:
+        filters = FilterInput(
+            scope=ScopeFilterInput(level=ScopeLevelInput.REPO, ids=[]),
+            what=WhatFilterInput(repos=[]),
+        )
+
+        nodes_queries, edges_queries = compile_flow_matrix(
+            _req("repo"), org_id="org-1", filters=filters
+        )
+
+        assert len(nodes_queries) == 1
+        assert len(edges_queries) == 1
 
 
 class TestRepoEdgesTemplate:

--- a/tests/graphql/test_flow_matrix.py
+++ b/tests/graphql/test_flow_matrix.py
@@ -146,6 +146,15 @@ class TestCompileFlowMatrix:
                     )
                 ),
             ),
+            (
+                "repo",
+                FilterInput(
+                    scope=ScopeFilterInput(
+                        level=ScopeLevelInput.SERVICE,
+                        ids=["svc-1"],
+                    )
+                ),
+            ),
             ("team", FilterInput(what=WhatFilterInput(repos=["repo-1"]))),
             ("work_type", FilterInput(what=WhatFilterInput(repos=["repo-1"]))),
         ],


### PR DESCRIPTION
## Summary
- Reject active filters for same-dimension `flowMatrix` TEAM/REPO/WORK_TYPE queries instead of silently dropping them.
- Keep unfiltered same-dim flow matrix behavior unchanged.
- Add compiler coverage for `what.repos` and `scope=repo` filtered requests raising a clear validation error.

## Approach
Chose approach B for CHAOS-2487. The existing same-dim templates read from `work_item_cycle_times` plus `work_items`; ClickHouse schema supports some repo/team columns, but full filter parity would require alias-specific filtering across self-joins and still leaves unsupported category/developer semantics. Explicit rejection is the minimal safe fix and avoids org-wide false results.

## Verification
- `ruff format src/dev_health_ops/api/graphql/sql/compiler.py tests/graphql/test_flow_matrix.py`
- `ruff check src/dev_health_ops/api/graphql/sql/compiler.py tests/graphql/test_flow_matrix.py`
- `PYTHONPATH=src python -m pytest tests/graphql/test_flow_matrix.py tests/graphql/test_sankey_parallel.py`
- LSP diagnostics clean for changed files

SCREENSHOT-WAIVER: Backend GraphQL compiler behavior only; no rendered frontend output changed.

Closes CHAOS-2487