### PR TITLE
fix(auth): persist login-failure audit + lockout counter; audit forgot-password request (CHAOS-2498)

### DIFF
--- a/src/dev_health_ops/api/auth/routers/login.py
+++ b/src/dev_health_ops/api/auth/routers/login.py
@@ -102,7 +102,14 @@ async def login(
                     status="failure",
                     error_message="Account temporarily locked due to failed login attempts",
                 )
-
+                # Persist the failure audit row before raising. get_postgres_session()
+                # rolls back on exception, so without an explicit commit the
+                # db.add()'d audit entry would be discarded on the raise below.
+                # Only commit when an audit row was actually emitted — on this
+                # already-locked path there is nothing else pending, so an
+                # unconditional commit would be a wasted round-trip that could
+                # turn the 429 into a 500 on a transient DB error.
+                await db.commit()
             raise HTTPException(
                 status_code=429,
                 detail=error_detail(
@@ -191,6 +198,11 @@ async def login(
                 logger.warning(
                     "Invalid password for user: %s", sanitize_for_log(payload.email)
                 )
+            # Commit before raising: get_postgres_session() rolls back on
+            # exception, which would otherwise discard BOTH the LOGIN_FAILED
+            # audit row and the record_failed_attempt() counter increment that
+            # drives account lockout. Both must survive the raise below.
+            await db.commit()
             raise HTTPException(
                 status_code=401,
                 detail=error_detail("Invalid credentials"),
@@ -256,6 +268,35 @@ async def login(
 
         if payload.org_id and not membership:
             if memberships:
+                # Credentials were valid (clear_attempts ran above) but the user
+                # picked an org they do not belong to. Audit the denied access
+                # and commit before raising so the cleared failed-attempt counter
+                # — and this audit row — survive get_postgres_session()'s
+                # rollback-on-exception, matching the other failure paths.
+                failure_org_id = await _resolve_login_audit_org_id(
+                    db, user, payload.org_id
+                )
+                if failure_org_id is not None:
+                    user_id = _require_uuid(user.id, "user.id")
+                    emit_audit_log(
+                        db,
+                        org_id=failure_org_id,
+                        action=AuditAction.LOGIN_FAILED,
+                        resource_type=AuditResourceType.SESSION,
+                        resource_id=str(user_id),
+                        user_id=user_id,
+                        description=(
+                            "Login failed: not a member of the selected organization"
+                        ),
+                        changes={
+                            "email": email_normalized,
+                            "requested_org_id": payload.org_id,
+                        },
+                        request=request,
+                        status="failure",
+                        error_message="User is not a member of the selected organization",
+                    )
+                await db.commit()
                 raise HTTPException(
                     status_code=401,
                     detail=error_detail(

--- a/src/dev_health_ops/api/auth/routers/password_reset.py
+++ b/src/dev_health_ops/api/auth/routers/password_reset.py
@@ -55,9 +55,28 @@ async def forgot_password(
         )
         user = result.scalar_one_or_none()
         if user is None:
+            # Deliberately emit no audit row for unknown emails: AuditLog.org_id
+            # is required and we will not leak account existence via a side
+            # channel. The enumeration-resistant generic response is preserved.
             return generic_response
 
         reset_token = await create_reset_token(db, user.id)
+
+        membership_result = await db.execute(
+            select(Membership.org_id).where(Membership.user_id == user.id).limit(1)
+        )
+        audit_org_id = membership_result.scalar_one_or_none()
+        if audit_org_id is not None:
+            emit_audit_log(
+                db,
+                org_id=audit_org_id,
+                action=AuditAction.PASSWORD_RESET_REQUESTED,
+                resource_type=AuditResourceType.USER,
+                resource_id=str(user.id),
+                user_id=uuid.UUID(str(user.id)),
+                description="Password reset requested",
+                request=request,
+            )
         await db.commit()
 
         try:

--- a/src/dev_health_ops/models/audit.py
+++ b/src/dev_health_ops/models/audit.py
@@ -48,6 +48,7 @@ class AuditAction(str, Enum):
     LOGIN_FAILED = "login_failed"
     PASSWORD_CHANGED = "password_changed"
     PASSWORD_RESET = "password_reset"
+    PASSWORD_RESET_REQUESTED = "password_reset_requested"
 
     # SSO events
     SSO_LOGIN = "sso_login"

--- a/tests/api/admin/test_set_password_audit.py
+++ b/tests/api/admin/test_set_password_audit.py
@@ -1,0 +1,154 @@
+"""CHAOS-2498: admin set_password must emit a PASSWORD_CHANGED audit row.
+
+The emit lives in admin/routers/users.py (set_user_password). This test mirrors
+tests/api/auth/test_password_reset.py::test_reset_password_valid_token_emits_audit_log
+and asserts the audit row actually lands in the DB on the success path.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.middleware.rate_limit import limiter as rate_limiter
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.models.audit import AuditAction, AuditLog
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.refresh_token import RefreshToken
+from dev_health_ops.models.users import Membership, Organization, User
+from tests._helpers import tables_of
+
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+admin_router_module = importlib.import_module("dev_health_ops.api.admin")
+
+_TABLES = tables_of(User, Organization, Membership, AuditLog, RefreshToken)
+
+# Pre-computed bcrypt hash (cost=4) of ADMIN_PASSWORD to avoid hashing at import.
+# This is a test fixture hash, not a real credential.
+ADMIN_PASSWORD = "OldPassword@123"
+# nosemgrep: generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash
+ADMIN_PASSWORD_HASH = "$2b$04$tgxalfE5Q58OGJE/0M0piOakqY90AzLsIFaz178yu6eMEkjMuYeJe"
+# gitleaks:allow — test fixture password, not a credential. The literal trips
+# gitleaks' generic-api-key entropy heuristic (16 alphanumerics, no symbols).
+NEW_PASSWORD = "BrandNewPass1234"  # gitleaks:allow (>=12 chars, letter+digit)
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "set-password-audit.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_state(session_maker):
+    org_id = uuid.uuid4()
+    admin_id = uuid.uuid4()
+    target_id = uuid.uuid4()
+
+    org = Organization(id=org_id, slug="test-org", name="Test Org")
+    admin = User(
+        id=admin_id,
+        email="admin@example.com",
+        password_hash=ADMIN_PASSWORD_HASH,
+        is_active=True,
+    )
+    target = User(id=target_id, email="target@example.com", is_active=True)
+
+    async with session_maker() as session:
+        session.add_all([org, admin, target])
+        session.add(Membership(org_id=org_id, user_id=admin_id, role="owner"))
+        session.add(Membership(org_id=org_id, user_id=target_id, role="member"))
+        await session.commit()
+
+    return {
+        "org_id": str(org_id),
+        "admin_id": str(admin_id),
+        "target_id": str(target_id),
+        "admin_email": "admin@example.com",
+    }
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch: pytest.MonkeyPatch, session_maker, seeded_state):
+    app = FastAPI()
+    app.include_router(admin_router_module.router)
+
+    current_user = AuthenticatedUser(
+        user_id=seeded_state["admin_id"],
+        email=seeded_state["admin_email"],
+        org_id=seeded_state["org_id"],
+        role="owner",
+        is_superuser=False,
+    )
+
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+            await session.commit()
+
+    monkeypatch.setattr(rate_limiter, "enabled", False)
+    app.dependency_overrides[auth_router_module.get_current_user] = lambda: current_user
+    app.dependency_overrides[admin_router_module.get_session] = _session_override
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_set_password_emits_audit_log(client, session_maker, seeded_state):
+    resp = await client.post(
+        f"/api/v1/admin/users/{seeded_state['target_id']}/password",
+        json={"admin_password": ADMIN_PASSWORD, "password": NEW_PASSWORD},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["success"] is True
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(AuditLog).where(AuditLog.resource_id == seeded_state["target_id"])
+        )
+        audit_log = result.scalar_one()
+
+    assert audit_log.action == AuditAction.PASSWORD_CHANGED.value
+    assert audit_log.org_id == uuid.UUID(seeded_state["org_id"])
+    assert audit_log.user_id == uuid.UUID(seeded_state["admin_id"])
+    assert audit_log.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_set_password_wrong_admin_password_emits_no_audit(
+    client, session_maker, seeded_state
+):
+    """A failed admin-password check must not write a PASSWORD_CHANGED row."""
+    resp = await client.post(
+        f"/api/v1/admin/users/{seeded_state['target_id']}/password",
+        json={"admin_password": "WrongAdminPass99", "password": NEW_PASSWORD},
+    )
+    assert resp.status_code == 403
+
+    async with session_maker() as session:
+        result = await session.execute(select(AuditLog))
+        rows = result.scalars().all()
+    assert rows == []

--- a/tests/api/auth/test_login_audit.py
+++ b/tests/api/auth/test_login_audit.py
@@ -1,0 +1,246 @@
+"""CHAOS-2498: login-failure audit + lockout-counter persistence.
+
+The login failure paths call emit_audit_log() (db.add) and record_failed_attempt()
+(db.flush) and then `raise HTTPException(...)`. Because get_postgres_session()
+rolls back on exception, both the LOGIN_FAILED audit row and the failed-attempt
+counter were being discarded on the raise. The fix commits before raising.
+
+These tests use a session override that MIRRORS production rollback-on-exception
+semantics (commit on clean exit, rollback on exception); without that, the bug
+would be invisible to the test because the bare session would not roll back.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.middleware.rate_limit import limiter as rate_limiter
+from dev_health_ops.api.services.login_attempts import LOCKOUT_FAILURE_THRESHOLD
+from dev_health_ops.models.audit import AuditAction, AuditLog
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.refresh_token import RefreshToken
+from dev_health_ops.models.users import LoginAttempt, Membership, Organization, User
+from tests._helpers import tables_of
+
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+_TABLES = tables_of(
+    User, Organization, Membership, AuditLog, LoginAttempt, RefreshToken
+)
+
+KNOWN_PASSWORD = "OldPassword@123"
+# nosemgrep: generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash
+KNOWN_PASSWORD_HASH = "$2b$04$tgxalfE5Q58OGJE/0M0piOakqY90AzLsIFaz178yu6eMEkjMuYeJe"
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "login-audit.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_user(session_maker):
+    user = User(
+        id=uuid.uuid4(),
+        email="loginuser@example.com",
+        password_hash=KNOWN_PASSWORD_HASH,
+        is_active=True,
+        is_verified=True,
+    )
+    org = Organization(id=uuid.uuid4(), slug="login-org", name="Login Org")
+    membership = Membership(user_id=user.id, org_id=org.id, role="member")
+    async with session_maker() as session:
+        session.add_all([user, org, membership])
+        await session.commit()
+    return user
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch: pytest.MonkeyPatch, session_maker, seeded_user):
+    app = FastAPI()
+    app.include_router(auth_router_module.router)
+
+    @asynccontextmanager
+    async def _session_override():
+        # Mirror production get_postgres_session: commit on success, rollback on
+        # exception. This is what makes the failure-path audit/counter rollback
+        # observable in the test.
+        async with session_maker() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    monkeypatch.setattr(auth_router_module, "get_postgres_session", _session_override)
+    monkeypatch.setattr(rate_limiter, "enabled", False)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_failed_login_persists_audit_row(client, session_maker, seeded_user):
+    resp = await client.post(
+        "/api/v1/auth/login",
+        json={"email": seeded_user.email, "password": "WrongPassword@999"},
+    )
+    assert resp.status_code == 401
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(AuditLog).where(AuditLog.action == AuditAction.LOGIN_FAILED.value)
+        )
+        audit_log = result.scalar_one()
+
+    assert audit_log.status == "failure"
+    assert audit_log.resource_id == str(seeded_user.id)
+
+
+@pytest.mark.asyncio
+async def test_failed_login_persists_attempt_counter(
+    client, session_maker, seeded_user
+):
+    """The lockout counter must survive the raise — otherwise lockout never fires."""
+    await client.post(
+        "/api/v1/auth/login",
+        json={"email": seeded_user.email, "password": "WrongPassword@999"},
+    )
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(LoginAttempt).where(
+                func.lower(LoginAttempt.email) == seeded_user.email.lower()
+            )
+        )
+        attempt = result.scalar_one()
+    assert attempt.attempt_count == 1
+
+
+@pytest.mark.asyncio
+async def test_repeated_failures_accumulate_persisted_counter(
+    client, session_maker, seeded_user
+):
+    """The counter accumulates across requests now that each failure commits.
+
+    NOTE: we assert the persisted counter rather than driving an end-to-end 429.
+    Reaching the lockout threshold makes check_lockout() read back
+    LoginAttempt.locked_until, and aiosqlite returns it tz-naive (production
+    Postgres keeps it tz-aware), which would raise on the naive/aware compare.
+    That is a SQLite test-infra quirk, not a production code path.
+    """
+    for _ in range(LOCKOUT_FAILURE_THRESHOLD - 1):
+        await client.post(
+            "/api/v1/auth/login",
+            json={"email": seeded_user.email, "password": "WrongPassword@999"},
+        )
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(LoginAttempt).where(
+                func.lower(LoginAttempt.email) == seeded_user.email.lower()
+            )
+        )
+        attempt = result.scalar_one()
+    assert attempt.attempt_count == LOCKOUT_FAILURE_THRESHOLD - 1
+
+
+@pytest.mark.asyncio
+async def test_successful_login_after_failures_clears_counter(
+    client, session_maker, seeded_user
+):
+    """A correct password clears the persisted failed-attempt counter."""
+    await client.post(
+        "/api/v1/auth/login",
+        json={"email": seeded_user.email, "password": "WrongPassword@999"},
+    )
+    resp = await client.post(
+        "/api/v1/auth/login",
+        json={"email": seeded_user.email, "password": KNOWN_PASSWORD},
+    )
+    assert resp.status_code == 200
+
+    async with session_maker() as session:
+        count = (
+            await session.execute(select(func.count()).select_from(LoginAttempt))
+        ).scalar_one()
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_wrong_org_after_valid_credentials_persists_clear_and_audit(
+    client, session_maker, seeded_user
+):
+    """Valid password + non-member org → 401, but the cleared counter and a
+    LOGIN_FAILED audit row must survive the raise (the auth-pushback path)."""
+    other_org_id = uuid.uuid4()
+    async with session_maker() as session:
+        session.add(Organization(id=other_org_id, slug="other-org", name="Other Org"))
+        await session.commit()
+
+    # Accumulate a failed attempt so there is a counter to clear.
+    await client.post(
+        "/api/v1/auth/login",
+        json={"email": seeded_user.email, "password": "WrongPassword@999"},
+    )
+
+    # Correct password, but an org the user is not a member of.
+    resp = await client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": seeded_user.email,
+            "password": KNOWN_PASSWORD,
+            "org_id": str(other_org_id),
+        },
+    )
+    assert resp.status_code == 401
+    assert "not a member" in resp.json()["detail"]["message"]
+
+    async with session_maker() as session:
+        # clear_attempts() ran on the valid-password check and must have persisted.
+        attempt_count = (
+            await session.execute(select(func.count()).select_from(LoginAttempt))
+        ).scalar_one()
+        audit = (
+            (
+                await session.execute(
+                    select(AuditLog).where(
+                        AuditLog.action == AuditAction.LOGIN_FAILED.value
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert attempt_count == 0
+    assert any(
+        a.status == "failure"
+        and a.description == "Login failed: not a member of the selected organization"
+        for a in audit
+    )

--- a/tests/api/auth/test_password_reset.py
+++ b/tests/api/auth/test_password_reset.py
@@ -31,6 +31,7 @@ password_reset_module = importlib.import_module(
 
 KNOWN_PASSWORD = "OldPassword@123"
 # Pre-computed bcrypt hash of KNOWN_PASSWORD (cost=4) to avoid hashing at import time.
+# nosemgrep: generic.secrets.security.detected-bcrypt-hash.detected-bcrypt-hash
 KNOWN_PASSWORD_HASH = "$2b$04$tgxalfE5Q58OGJE/0M0piOakqY90AzLsIFaz178yu6eMEkjMuYeJe"
 GENERIC_MSG = "If the account exists, a password reset email has been sent"
 
@@ -155,6 +156,41 @@ async def test_forgot_password_email_send_failure_does_not_expose_error(
     )
     assert response.status_code == 200
     assert response.json()["message"] == GENERIC_MSG
+
+
+@pytest.mark.asyncio
+async def test_forgot_password_known_email_emits_request_audit(
+    client, session_maker, seeded_user
+):
+    """CHAOS-2498: forgot-password for a known user emits PASSWORD_RESET_REQUESTED."""
+    async_client, _ = client
+    await async_client.post(
+        "/api/v1/auth/forgot-password",
+        json={"email": seeded_user.email},
+    )
+    async with session_maker() as session:
+        result = await session.execute(
+            select(AuditLog).where(
+                AuditLog.action == AuditAction.PASSWORD_RESET_REQUESTED.value
+            )
+        )
+        audit_log = result.scalar_one()
+    assert audit_log.resource_id == str(seeded_user.id)
+    assert audit_log.user_id == seeded_user.id
+
+
+@pytest.mark.asyncio
+async def test_forgot_password_unknown_email_emits_no_audit(client, session_maker):
+    """Unknown emails must not write an audit row (no enumeration side channel)."""
+    async_client, _ = client
+    await async_client.post(
+        "/api/v1/auth/forgot-password",
+        json={"email": "nobody@example.com"},
+    )
+    async with session_maker() as session:
+        result = await session.execute(select(AuditLog))
+        rows = result.scalars().all()
+    assert rows == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Audit-logging hardening split out of CHAOS-2458 (core remediation A/B/C/D already complete). Resolves all three CHAOS-2498 items.

### Item 1 — Forgot-password request auditing
- New `AuditAction.PASSWORD_RESET_REQUESTED` enum value.
- `forgot_password` now emits an audit row **only when the user exists and a membership `org_id` resolves** (mirrors `reset_password`). Unknown emails emit nothing — preserving the enumeration-resistant generic response (`AuditLog.org_id` is `NOT NULL`).

### Item 2 — Admin set_password audit test
- New `tests/api/admin/test_set_password_audit.py`: asserts the `PASSWORD_CHANGED` row persists on success (org, actor, status), plus a negative test that a failed admin-password check (403) writes no row.

### Item 3 — Login-failure persistence (confirmed bug, fixed)
`get_postgres_session()` rolls back on exception (`db.py:165-175`). The login failure paths call `emit_audit_log()` (`db.add`) **and** `record_failed_attempt()` (`db.flush`) and then `raise HTTPException(...)` — so on every failed login **both the `LOGIN_FAILED` audit row and the failed-attempt counter increment were rolled back**. This silently broke account lockout (the counter never accumulated past 1).

- Fix: `await db.commit()` before each `raise` in the failure paths.
  - **401** (invalid creds / disabled / no-password): unconditional — `record_failed_attempt()` always leaves a pending write that lockout depends on.
  - **429** (already locked): only when an audit row was emitted — nothing else is pending there, so an unconditional commit would be a wasted round-trip that could turn the 429 into a 500.
- New `tests/api/auth/test_login_audit.py` uses a session override that **mirrors production rollback-on-exception**, so the tests genuinely fail without the production change. Covers audit-row persistence, counter persistence/accumulation, and counter-clear on success.

## Verification
- New/changed tests pass (22); full `tests/api/auth` + `tests/api/admin` suites pass. The 16 `test_credential_repos.py` failures are **pre-existing on `main`** (confirmed by re-running with changes stashed) and unrelated.
- CI-parity gates green: `ruff format --check`, `ruff check`, `mypy --install-types --non-interactive`.
- Adversarial Codex review: **approved**, no CRITICAL/HIGH. Its one MEDIUM (unconditional 429 commit) is addressed above.

Closes CHAOS-2498.