### PR TITLE
feat(sync): route migrated configs through fan-out planner on trigger surfaces (CHAOS-2516)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -35,14 +35,21 @@ from dev_health_ops.models.settings import (
     SyncConfiguration,
 )
 from dev_health_ops.sync.datasets import supported_legacy_targets
+from dev_health_ops.sync.planner import plan_sync_run
+from dev_health_ops.sync.trigger_routing import (
+    is_migrated_trigger_routing_enabled,
+    mark_sync_run_failed,
+    plan_request_for_config,
+)
 from dev_health_ops.workers.queues import sync_queue_for_provider
 from dev_health_ops.workers.sync_batch import _is_batch_eligible
+from dev_health_ops.workers.sync_units import dispatch_sync_run
 
 from .common import get_session
 
-logger = logging.getLogger(__name__)
-
 router = APIRouter()
+
+logger = logging.getLogger(__name__)
 
 
 async def _is_planner_active(session: AsyncSession, org_id: str) -> bool:
@@ -1041,6 +1048,49 @@ async def trigger_sync_config(
             except Exception:
                 # ClickHouse unavailable — allow the sync to proceed rather than block it.
                 pass
+
+    # --- Migrated-trigger routing (CHAOS-2516) -----------------------------------
+    # After tier checks, before legacy dispatch: if the planner flag is on AND
+    # the config was migrated, route through the fan-out planner instead.
+    use_planner = await session.run_sync(
+        lambda s: is_migrated_trigger_routing_enabled(s, org_id)
+    )
+    if use_planner:
+        plan_request = plan_request_for_config(
+            config, triggered_by="manual", mode="incremental"
+        )
+        if plan_request is not None:
+            try:
+                plan = await session.run_sync(
+                    lambda sync_session: plan_sync_run(sync_session, plan_request)
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc))
+            await session.commit()
+            try:
+                getattr(dispatch_sync_run, "apply_async")(
+                    args=(plan.sync_run_id,), queue="sync"
+                )
+            except Exception as exc:
+                # The run + units are committed but never dispatched. Mark the
+                # run FAILED so it is not stranded PLANNED with no queued
+                # dispatcher (there is no periodic reconciler for such runs),
+                # then surface the queue outage to the caller.
+                await session.run_sync(
+                    lambda s: mark_sync_run_failed(
+                        s, plan.sync_run_id, "dispatch enqueue failed"
+                    )
+                )
+                raise HTTPException(
+                    status_code=503, detail=f"Task queue unavailable: {exc}"
+                )
+            return {
+                "status": "triggered",
+                "config_id": str(config.id),
+                "sync_run_id": plan.sync_run_id,
+                "total_units": plan.total_units,
+            }
+    # --- End migrated-trigger routing -------------------------------------------
 
     try:
         from dev_health_ops.workers.sync_tasks import (

--- a/src/dev_health_ops/sync/trigger_routing.py
+++ b/src/dev_health_ops/sync/trigger_routing.py
@@ -74,8 +74,11 @@ def is_migrated_trigger_routing_enabled(session: Session, org_id: str) -> bool:
         # (PENDING JobRun create, dispatch bookkeeping) runs on a clean session.
         try:
             session.rollback()
-        except Exception:
-            pass
+        except Exception as rollback_err:
+            logger.debug(
+                "Rollback failed after OperationalError while reading migrated trigger routing flag; proceeding with legacy-path fallback.",
+                exc_info=rollback_err,
+            )
         return False
     if row is None:
         return False

--- a/src/dev_health_ops/sync/trigger_routing.py
+++ b/src/dev_health_ops/sync/trigger_routing.py
@@ -1,0 +1,211 @@
+"""Migrated-config trigger routing (CHAOS-2516).
+
+The config migration (``config_migration.py``) links each legacy
+``SyncConfiguration`` to integration-era records:
+
+* a *parent* config gets ``migrated_integration_id`` set to its Integration;
+* a *child* config gets both ``migrated_integration_id`` (the parent's
+  Integration) and ``migrated_source_id`` (its own IntegrationSource).
+
+The migration also writes a per-org feature flag Setting
+(``sync.migrated_trigger_routing_enabled``). When that flag is enabled, the
+legacy trigger surfaces — the admin "Sync Now" endpoint and the scheduled-sync
+beat — must route a *migrated* config through the fan-out planner
+(``plan_sync_run`` + ``dispatch_sync_run``) instead of the old per-config path.
+
+This module is the single source of truth for that routing decision so the API
+(async session, via ``run_sync``) and the beat (sync session) share identical
+semantics. Rollback is purely the flag: when it is off, callers fall back to the
+legacy path and this module's :func:`plan_request_for_config` is never reached.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from dev_health_ops.sync.datasets import supported_datasets
+from dev_health_ops.sync.planner import SyncPlanRequest
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from dev_health_ops.models.settings import SyncConfiguration
+
+MIGRATED_TRIGGER_ROUTING_SETTING_KEY = "sync.migrated_trigger_routing_enabled"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+logger = logging.getLogger(__name__)
+
+
+def is_migrated_trigger_routing_enabled(session: Session, org_id: str) -> bool:
+    """Return True when the integration planner is active for ``org_id``.
+
+    Synchronous read of the ``sync.migrated_trigger_routing_enabled`` Setting
+    row written by the CHAOS-2516 migration helper. Missing row => disabled,
+    which keeps un-migrated orgs on the legacy path.
+
+    A read failure (``OperationalError``, e.g. the Setting table is absent or a
+    transient DB error) also returns ``False``: the flag is opt-in, so "cannot
+    determine" maps to the legacy path -- the rollback-safe default. This is
+    strictly safer than raising, which would make the beat skip the config
+    entirely (no sync at all) instead of falling back to the legacy per-config
+    path. The session is rolled back before returning so the caller can keep
+    using it: on PostgreSQL a failed statement aborts the transaction until
+    rollback, which would otherwise break the very legacy path we fall back to.
+    """
+    from sqlalchemy.exc import OperationalError
+
+    from dev_health_ops.models.settings import Setting, SettingCategory
+
+    try:
+        row = (
+            session.query(Setting)
+            .filter(
+                Setting.org_id == org_id,
+                Setting.category == SettingCategory.SYNC.value,
+                Setting.key == MIGRATED_TRIGGER_ROUTING_SETTING_KEY,
+            )
+            .one_or_none()
+        )
+    except OperationalError:
+        # Clear the aborted transaction so the caller's legacy-path DB work
+        # (PENDING JobRun create, dispatch bookkeeping) runs on a clean session.
+        try:
+            session.rollback()
+        except Exception:
+            pass
+        return False
+    if row is None:
+        return False
+    return str(getattr(row, "value", "") or "").strip().lower() in _TRUTHY
+
+
+def _dataset_keys_for_config(config: SyncConfiguration) -> tuple[str, ...]:
+    """Map a config's legacy ``sync_targets`` to integration dataset keys.
+
+    Mirrors ``config_migration._dataset_keys_for_config`` so a migrated child's
+    trigger replays exactly the datasets the legacy child used to cover.
+    """
+    targets = {str(t) for t in (config.sync_targets or []) if t is not None}
+    if not targets:
+        return ()
+    keys: list[str] = []
+    for spec in supported_datasets(config.provider):
+        if targets.intersection(spec.legacy_targets):
+            keys.append(spec.dataset_key)
+    return tuple(keys)
+
+
+def plan_request_for_config(
+    config: SyncConfiguration,
+    *,
+    triggered_by: str,
+    mode: str = "incremental",
+) -> SyncPlanRequest | None:
+    """Build a :class:`SyncPlanRequest` for a migrated config, else ``None``.
+
+    Returns ``None`` when the config was never migrated (no
+    ``migrated_integration_id``), signalling the caller to use the legacy path.
+
+    Routing semantics:
+
+    * **Parent config** (no ``migrated_source_id``): plan the *whole*
+      integration — all enabled sources and datasets — matching the admin
+      integration ``/sync`` endpoint's default fan-out.
+    * **Child config** (``migrated_source_id`` set): scope the run to that one
+      source, and to the dataset keys derived from the child's legacy targets so
+      the migrated trigger covers exactly what the child used to.
+    """
+    integration_id = getattr(config, "migrated_integration_id", None)
+    if integration_id is None:
+        return None
+
+    source_id = getattr(config, "migrated_source_id", None)
+    source_ids: tuple[str, ...] | None = None
+    dataset_keys: tuple[str, ...] | None = None
+    if source_id is not None:
+        source_ids = (str(source_id),)
+        child_dataset_keys = _dataset_keys_for_config(config)
+        # Empty => fall back to all enabled datasets rather than an empty run.
+        dataset_keys = child_dataset_keys or None
+
+    return SyncPlanRequest(
+        integration_id=str(integration_id),
+        org_id=str(config.org_id),
+        mode=mode,
+        triggered_by=triggered_by,
+        source_ids=source_ids,
+        dataset_keys=dataset_keys,
+    )
+
+
+def mark_sync_run_failed(session: Session, sync_run_id: str, error: str) -> None:
+    """Mark a committed-but-undispatched SyncRun FAILED so it is not stranded.
+
+    Both trigger surfaces (admin "Sync Now" and the scheduled beat) commit the
+    planned SyncRun + units before enqueueing ``dispatch_sync_run`` so a separate
+    worker session can see them. If that enqueue then fails, the run is committed
+    as PLANNED with no queued dispatcher and there is no periodic reconciler for
+    such runs -- so flip it to FAILED rather than leave it looking perpetually
+    in-flight.
+
+    The update is a CONDITIONAL compare-and-set: it only fires while the run (and
+    its units) are still PLANNED. Under an *ambiguous* enqueue failure (the broker
+    actually accepted the message before ``apply_async`` raised) the real
+    dispatcher may concurrently advance the run to DISPATCHING/SUCCESS; in that
+    case this no-ops rather than overwriting a live/finished run. It also flips the
+    run's still-PLANNED units to FAILED in the same transaction so a late
+    dispatcher (whose ``_claim_units`` only claims PLANNED units) finds nothing to
+    claim -- preventing a duplicate provider sync alongside the caller's legacy
+    fallback.
+
+    Best-effort: any error is logged and rolled back so the caller can proceed
+    with its own fallback / error response.
+    """
+    import uuid
+    from datetime import datetime, timezone
+
+    from dev_health_ops.models.integrations import (
+        SyncRun,
+        SyncRunStatus,
+        SyncRunUnit,
+        SyncRunUnitStatus,
+    )
+
+    try:
+        run_uuid = uuid.UUID(str(sync_run_id))
+        run = session.query(SyncRun).filter(SyncRun.id == run_uuid).one_or_none()
+        # Only act on a still-PLANNED run -- never overwrite one the real
+        # dispatcher already advanced past PLANNED.
+        if run is None or run.status != SyncRunStatus.PLANNED.value:
+            session.rollback()
+            return
+        now = datetime.now(timezone.utc)
+        run.status = SyncRunStatus.FAILED.value
+        run.error = error
+        run.completed_at = now
+        session.query(SyncRunUnit).filter(
+            SyncRunUnit.sync_run_id == run_uuid,
+            SyncRunUnit.status == SyncRunUnitStatus.PLANNED.value,
+        ).update(
+            {
+                SyncRunUnit.status: SyncRunUnitStatus.FAILED.value,
+                SyncRunUnit.error: error,
+                SyncRunUnit.updated_at: now,
+            },
+            synchronize_session=False,
+        )
+        session.commit()
+    except Exception:
+        logger.exception("Failed to mark stranded sync_run %s as failed", sync_run_id)
+        session.rollback()
+
+
+__all__ = [
+    "MIGRATED_TRIGGER_ROUTING_SETTING_KEY",
+    "is_migrated_trigger_routing_enabled",
+    "mark_sync_run_failed",
+    "plan_request_for_config",
+]

--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -256,6 +256,67 @@ def _maybe_dispatch_config(
 
     session.commit()
 
+    # Migrated-trigger routing (CHAOS-2516): when the feature flag is enabled
+    # for this org AND the config was migrated, route through the fan-out
+    # planner instead of the legacy per-config tasks.
+    from dev_health_ops.sync.planner import plan_sync_run
+    from dev_health_ops.sync.trigger_routing import (
+        is_migrated_trigger_routing_enabled,
+        mark_sync_run_failed,
+        plan_request_for_config,
+    )
+    from dev_health_ops.workers.sync_units import dispatch_sync_run
+
+    use_planner = is_migrated_trigger_routing_enabled(session, org_id)
+    if use_planner:
+        request = plan_request_for_config(
+            config, triggered_by="schedule", mode="incremental"
+        )
+        if request is not None:
+            logger.info(
+                "Routing config %s through fan-out planner (migrated trigger routing)",
+                config.id,
+            )
+            try:
+                plan = plan_sync_run(session, request)
+                session.commit()
+            except Exception:
+                # Stale migrated link or a transient planner/DB error must not
+                # suppress this scheduled sync. next_run_at was already committed
+                # above, so roll back the failed plan attempt and fall through to
+                # the legacy per-config path -- this tick still dispatches exactly
+                # once instead of going dark until the next cron occurrence.
+                logger.exception(
+                    "Fan-out planner failed for config %s; "
+                    "falling back to legacy dispatch",
+                    config.id,
+                )
+                session.rollback()
+            else:
+                try:
+                    getattr(dispatch_sync_run, "apply_async")(
+                        args=(plan.sync_run_id,), queue="sync"
+                    )
+                except Exception:
+                    # The run + units are committed but the dispatch enqueue
+                    # failed. There is no periodic sweeper for stranded PLANNED
+                    # runs (the intra-dispatch reclaim only runs once
+                    # dispatch_sync_run executes), so mark this run FAILED rather
+                    # than leave it silently PLANNED with no queued dispatcher,
+                    # then fall through to the legacy path so this tick still
+                    # attempts a sync.
+                    logger.exception(
+                        "Fan-out dispatch enqueue failed for config %s "
+                        "(sync_run=%s); marking run failed and falling back",
+                        config.id,
+                        plan.sync_run_id,
+                    )
+                    mark_sync_run_failed(
+                        session, plan.sync_run_id, "dispatch enqueue failed"
+                    )
+                else:
+                    return True
+
     # Per-provider routing (CHAOS-2299): "is Linear stuck?" must be one LLEN.
     if is_batch:
         getattr(dispatch_batch_sync, "apply_async")(

--- a/tests/api/admin/test_sync_trigger_routing.py
+++ b/tests/api/admin/test_sync_trigger_routing.py
@@ -1,0 +1,398 @@
+"""Tests for CHAOS-2516: trigger routing via migrated-trigger-routing flag.
+
+Covers:
+- flag ON + migrated config => planner path (plan_sync_run called,
+  dispatch_sync_run.apply_async called, legacy run_sync_config NOT called)
+- flag OFF => legacy path (run_sync_config called, planner NOT called)
+- flag ON + un-migrated config => legacy path (no migrated_integration_id)
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.licensing import OrgLicense
+from dev_health_ops.models.settings import (
+    IntegrationCredential,
+    JobRun,
+    ScheduledJob,
+    Setting,
+    SettingCategory,
+    SyncConfiguration,
+)
+from dev_health_ops.models.users import Organization, User
+from dev_health_ops.sync.trigger_routing import MIGRATED_TRIGGER_ROUTING_SETTING_KEY
+from tests._helpers import tables_of
+
+admin_router_module = importlib.import_module("dev_health_ops.api.admin")
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+_TABLES = tables_of(
+    User,
+    Organization,
+    OrgLicense,
+    IntegrationCredential,
+    SyncConfiguration,
+    ScheduledJob,
+    JobRun,
+    Setting,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "trigger-routing-test.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_state(session_maker):
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    org = Organization(id=org_id, slug="test-org", name="Test Org", tier="pro")
+    user = User(id=user_id, email="admin@example.com", is_active=True)
+
+    async with session_maker() as session:
+        session.add_all([org, user])
+        await session.commit()
+
+    return {
+        "org_id": str(org_id),
+        "user_id": str(user_id),
+    }
+
+
+@pytest_asyncio.fixture
+async def client(session_maker, seeded_state):
+    app = FastAPI()
+    app.include_router(admin_router_module.router)
+
+    admin_user = AuthenticatedUser(
+        user_id=seeded_state["user_id"],
+        email="admin@example.com",
+        org_id=seeded_state["org_id"],
+        role="owner",
+        is_superuser=False,
+    )
+
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+            await session.commit()
+
+    app.dependency_overrides[auth_router_module.get_current_user] = lambda: admin_user
+    app.dependency_overrides[admin_router_module.get_session] = _session_override
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, seeded_state
+
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_config(
+    session_maker,
+    org_id: str,
+    *,
+    migrated_integration_id: uuid.UUID | None = None,
+) -> str:
+    """Seed a SyncConfiguration and return its id."""
+    async with session_maker() as session:
+        config = SyncConfiguration(
+            name="test-config",
+            provider="github",
+            org_id=org_id,
+            sync_targets=["git"],
+            migrated_integration_id=migrated_integration_id,
+        )
+        session.add(config)
+        await session.commit()
+        return str(config.id)
+
+
+async def _seed_planner_flag(session_maker, org_id: str, value: str = "true"):
+    """Write the migrated_trigger_routing_enabled Setting row."""
+    async with session_maker() as session:
+        setting = Setting(
+            key=MIGRATED_TRIGGER_ROUTING_SETTING_KEY,
+            category=SettingCategory.SYNC.value,
+            value=value,
+            org_id=org_id,
+        )
+        session.add(setting)
+        await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flag_on_migrated_config_uses_planner_path(client, session_maker):
+    """Flag ON + migrated config => plan_sync_run + dispatch_sync_run called,
+    legacy run_sync_config NOT called."""
+    ac, seeded_state = client
+    org_id = seeded_state["org_id"]
+
+    integration_id = uuid.uuid4()
+    config_id = await _seed_config(
+        session_maker, org_id, migrated_integration_id=integration_id
+    )
+    await _seed_planner_flag(session_maker, org_id, value="true")
+
+    fake_plan = MagicMock()
+    fake_plan.sync_run_id = str(uuid.uuid4())
+    fake_plan.total_units = 3
+
+    fake_dispatch = MagicMock()
+    fake_dispatch.apply_async = MagicMock(return_value=MagicMock(id="task-abc"))
+
+    fake_run_sync_config = MagicMock()
+    fake_dispatch_batch_sync = MagicMock()
+
+    with (
+        patch(
+            "dev_health_ops.api.admin.routers.sync.plan_sync_run",
+            return_value=fake_plan,
+        ) as mock_plan,
+        patch(
+            "dev_health_ops.api.admin.routers.sync.dispatch_sync_run",
+            fake_dispatch,
+        ),
+        patch.dict(
+            "sys.modules",
+            {
+                "dev_health_ops.workers.sync_tasks": MagicMock(
+                    run_sync_config=fake_run_sync_config,
+                    dispatch_batch_sync=fake_dispatch_batch_sync,
+                )
+            },
+        ),
+    ):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["status"] == "triggered"
+    assert body["config_id"] == config_id
+    assert body["sync_run_id"] == fake_plan.sync_run_id
+    assert body["total_units"] == fake_plan.total_units
+
+    # Planner was called
+    mock_plan.assert_called_once()
+    fake_dispatch.apply_async.assert_called_once_with(
+        args=(fake_plan.sync_run_id,), queue="sync"
+    )
+
+    # Legacy tasks were NOT called
+    fake_run_sync_config.apply_async.assert_not_called()
+    fake_dispatch_batch_sync.apply_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_flag_off_uses_legacy_path(client, session_maker):
+    """Flag OFF => legacy path (run_sync_config called, planner NOT called)."""
+    ac, seeded_state = client
+    org_id = seeded_state["org_id"]
+
+    integration_id = uuid.uuid4()
+    config_id = await _seed_config(
+        session_maker, org_id, migrated_integration_id=integration_id
+    )
+    # No flag seeded => flag is off
+
+    fake_plan = MagicMock()
+    fake_plan.sync_run_id = str(uuid.uuid4())
+    fake_plan.total_units = 2
+
+    fake_dispatch = MagicMock()
+    fake_dispatch.apply_async = MagicMock(return_value=MagicMock(id="task-xyz"))
+
+    fake_task_result = MagicMock()
+    fake_task_result.id = "legacy-task-id"
+    fake_run_sync_config = MagicMock()
+    fake_run_sync_config.apply_async = MagicMock(return_value=fake_task_result)
+    fake_dispatch_batch_sync = MagicMock()
+    fake_dispatch_batch_sync.apply_async = MagicMock(return_value=fake_task_result)
+
+    with (
+        patch(
+            "dev_health_ops.api.admin.routers.sync.plan_sync_run",
+            return_value=fake_plan,
+        ) as mock_plan,
+        patch(
+            "dev_health_ops.api.admin.routers.sync.dispatch_sync_run",
+            fake_dispatch,
+        ),
+        patch.dict(
+            "sys.modules",
+            {
+                "dev_health_ops.workers.sync_tasks": MagicMock(
+                    run_sync_config=fake_run_sync_config,
+                    dispatch_batch_sync=fake_dispatch_batch_sync,
+                )
+            },
+        ),
+    ):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["status"] == "triggered"
+    assert body["config_id"] == config_id
+    # Legacy path returns task_id + run_id, not sync_run_id
+    assert "task_id" in body or "run_id" in body
+
+    # Planner was NOT called
+    mock_plan.assert_not_called()
+    fake_dispatch.apply_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_flag_on_unmigrated_config_uses_legacy_path(client, session_maker):
+    """Flag ON + un-migrated config (no migrated_integration_id) => legacy path."""
+    ac, seeded_state = client
+    org_id = seeded_state["org_id"]
+
+    # No migrated_integration_id => un-migrated config
+    config_id = await _seed_config(session_maker, org_id, migrated_integration_id=None)
+    await _seed_planner_flag(session_maker, org_id, value="true")
+
+    fake_plan = MagicMock()
+    fake_plan.sync_run_id = str(uuid.uuid4())
+    fake_plan.total_units = 1
+
+    fake_dispatch = MagicMock()
+    fake_dispatch.apply_async = MagicMock(return_value=MagicMock(id="task-nope"))
+
+    fake_task_result = MagicMock()
+    fake_task_result.id = "legacy-task-id-2"
+    fake_run_sync_config = MagicMock()
+    fake_run_sync_config.apply_async = MagicMock(return_value=fake_task_result)
+    fake_dispatch_batch_sync = MagicMock()
+    fake_dispatch_batch_sync.apply_async = MagicMock(return_value=fake_task_result)
+
+    with (
+        patch(
+            "dev_health_ops.api.admin.routers.sync.plan_sync_run",
+            return_value=fake_plan,
+        ) as mock_plan,
+        patch(
+            "dev_health_ops.api.admin.routers.sync.dispatch_sync_run",
+            fake_dispatch,
+        ),
+        patch.dict(
+            "sys.modules",
+            {
+                "dev_health_ops.workers.sync_tasks": MagicMock(
+                    run_sync_config=fake_run_sync_config,
+                    dispatch_batch_sync=fake_dispatch_batch_sync,
+                )
+            },
+        ),
+    ):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["status"] == "triggered"
+    assert body["config_id"] == config_id
+    # Legacy path returns task_id + run_id
+    assert "task_id" in body or "run_id" in body
+
+    # Planner was NOT called (plan_request_for_config returns None for un-migrated)
+    mock_plan.assert_not_called()
+    fake_dispatch.apply_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_planner_enqueue_failure_marks_run_failed_and_503(client, session_maker):
+    """Flag ON + migrated config, plan commits, but dispatch_sync_run.apply_async
+    raises => the committed run is marked FAILED (not stranded PLANNED) and the
+    queue outage is surfaced as 503; legacy path is NOT used."""
+    ac, seeded_state = client
+    org_id = seeded_state["org_id"]
+
+    integration_id = uuid.uuid4()
+    config_id = await _seed_config(
+        session_maker, org_id, migrated_integration_id=integration_id
+    )
+    await _seed_planner_flag(session_maker, org_id, value="true")
+
+    fake_plan = MagicMock()
+    fake_plan.sync_run_id = str(uuid.uuid4())
+    fake_plan.total_units = 2
+
+    fake_dispatch = MagicMock()
+    fake_dispatch.apply_async = MagicMock(side_effect=RuntimeError("broker down"))
+
+    fake_mark_failed = MagicMock()
+    fake_run_sync_config = MagicMock()
+    fake_dispatch_batch_sync = MagicMock()
+
+    with (
+        patch(
+            "dev_health_ops.api.admin.routers.sync.plan_sync_run",
+            return_value=fake_plan,
+        ),
+        patch(
+            "dev_health_ops.api.admin.routers.sync.dispatch_sync_run",
+            fake_dispatch,
+        ),
+        patch(
+            "dev_health_ops.api.admin.routers.sync.mark_sync_run_failed",
+            fake_mark_failed,
+        ),
+        patch.dict(
+            "sys.modules",
+            {
+                "dev_health_ops.workers.sync_tasks": MagicMock(
+                    run_sync_config=fake_run_sync_config,
+                    dispatch_batch_sync=fake_dispatch_batch_sync,
+                )
+            },
+        ),
+    ):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 503, resp.text
+    fake_dispatch.apply_async.assert_called_once()
+    # Committed run marked FAILED so it is not stranded PLANNED with no dispatcher.
+    fake_mark_failed.assert_called_once()
+    assert fake_mark_failed.call_args.args[1] == fake_plan.sync_run_id
+    # Legacy path NOT used -- we surfaced the queue outage instead.
+    fake_run_sync_config.apply_async.assert_not_called()
+    fake_dispatch_batch_sync.apply_async.assert_not_called()

--- a/tests/test_sync_scheduler_routing.py
+++ b/tests/test_sync_scheduler_routing.py
@@ -1,0 +1,485 @@
+"""Migrated-trigger routing in the sync scheduler beat (CHAOS-2516).
+
+Tests that `_maybe_dispatch_config` routes through the fan-out planner when:
+  (a) the migrated-trigger-routing flag is ON and the config is migrated
+      => plan_sync_run + dispatch_sync_run called; legacy tasks NOT called.
+  (b) the flag is OFF => legacy path unchanged.
+  (c) the flag is ON but the config is NOT migrated => legacy path unchanged.
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import (
+    JobStatus,
+    ScheduledJob,
+    Setting,
+    SettingCategory,
+    SyncConfiguration,
+)
+from dev_health_ops.sync.trigger_routing import MIGRATED_TRIGGER_ROUTING_SETTING_KEY
+
+HOUR = timedelta(hours=1)
+ORG_ID = "routing-test-org"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _fake_session_ctx(session):
+    yield session
+
+
+def _hourly_croniter_module() -> SimpleNamespace:
+    """Fake croniter: next occurrence = base + 1 hour."""
+
+    def _croniter(expr: str, base: datetime):
+        class _Iter:
+            def get_next(self, _kind):
+                return base + HOUR
+
+        return _Iter()
+
+    return SimpleNamespace(croniter=_croniter)
+
+
+def _make_config(
+    session: Session,
+    *,
+    last_sync_at: datetime | None = None,
+    migrated_integration_id: uuid.UUID | None = None,
+) -> SyncConfiguration:
+    config = SyncConfiguration(
+        name="routing-test-config",
+        provider="github",
+        org_id=ORG_ID,
+        sync_targets=["git", "prs"],
+        sync_options={"owner": "org", "repo": "repo", "schedule_cron": "0 * * * *"},
+        is_active=True,
+    )
+    if last_sync_at is not None:
+        config.last_sync_at = last_sync_at
+    if migrated_integration_id is not None:
+        config.migrated_integration_id = migrated_integration_id
+    session.add(config)
+    session.flush()
+    return config
+
+
+def _make_job(config: SyncConfiguration) -> ScheduledJob:
+    job = ScheduledJob(
+        name=f"sync-config-{config.id}",
+        job_type="sync",
+        schedule_cron="0 * * * *",
+        org_id=config.org_id,
+        provider=config.provider,
+        sync_config_id=config.id,
+    )
+    job.status = JobStatus.ACTIVE.value
+    return job
+
+
+def _enable_flag(session: Session) -> None:
+    """Insert the migrated-trigger-routing feature flag for ORG_ID."""
+    setting = Setting(
+        key=MIGRATED_TRIGGER_ROUTING_SETTING_KEY,
+        category=SettingCategory.SYNC.value,
+        value="true",
+        org_id=ORG_ID,
+    )
+    session.add(setting)
+    session.flush()
+
+
+def _call_maybe_dispatch(
+    monkeypatch, session: Session, config: SyncConfiguration, now: datetime
+) -> bool:
+    """Wire croniter stub and call _maybe_dispatch_config directly."""
+    from dev_health_ops.workers.sync_scheduler import _maybe_dispatch_config
+
+    monkeypatch.setitem(sys.modules, "croniter", _hourly_croniter_module())
+    return _maybe_dispatch_config(session, config, now)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPlannerRouting:
+    """Flag ON + migrated config => planner path."""
+
+    def test_flag_on_migrated_config_uses_planner(self, monkeypatch, db_session):
+        now = datetime.now(timezone.utc)
+        integration_id = uuid.uuid4()
+        config = _make_config(
+            db_session,
+            last_sync_at=now - 2 * HOUR,
+            migrated_integration_id=integration_id,
+        )
+        job = _make_job(config)
+        db_session.add(job)
+        db_session.flush()
+        _enable_flag(db_session)
+
+        fake_plan = SimpleNamespace(
+            sync_run_id=str(uuid.uuid4()), total_units=1, unit_ids=()
+        )
+        plan_sync_run_mock = MagicMock(return_value=fake_plan)
+        dispatch_sync_run_mock = MagicMock()
+        run_sync_config_mock = MagicMock()
+        batch_sync_mock = MagicMock()
+
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.run_sync_config",
+            run_sync_config_mock,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.dispatch_batch_sync",
+            batch_sync_mock,
+        )
+
+        # plan_sync_run and dispatch_sync_run are imported lazily inside
+        # _maybe_dispatch_config, so patch at their source modules.
+        with (
+            patch("dev_health_ops.sync.planner.plan_sync_run", plan_sync_run_mock),
+            patch(
+                "dev_health_ops.workers.sync_units.dispatch_sync_run",
+                dispatch_sync_run_mock,
+            ),
+        ):
+            result = _call_maybe_dispatch(monkeypatch, db_session, config, now)
+
+        assert result is True
+        plan_sync_run_mock.assert_called_once()
+        dispatch_sync_run_mock.apply_async.assert_called_once_with(
+            args=(fake_plan.sync_run_id,), queue="sync"
+        )
+        run_sync_config_mock.apply_async.assert_not_called()
+        batch_sync_mock.apply_async.assert_not_called()
+
+    def test_flag_on_migrated_config_stamps_idempotency_marker(
+        self, monkeypatch, db_session
+    ):
+        """next_run_at must be stamped before the planner commit."""
+        now = datetime.now(timezone.utc)
+        integration_id = uuid.uuid4()
+        config = _make_config(
+            db_session,
+            last_sync_at=now - 2 * HOUR,
+            migrated_integration_id=integration_id,
+        )
+        job = _make_job(config)
+        db_session.add(job)
+        db_session.flush()
+        _enable_flag(db_session)
+
+        fake_plan = SimpleNamespace(
+            sync_run_id=str(uuid.uuid4()), total_units=1, unit_ids=()
+        )
+        plan_sync_run_mock = MagicMock(return_value=fake_plan)
+        dispatch_sync_run_mock = MagicMock()
+
+        with (
+            patch("dev_health_ops.sync.planner.plan_sync_run", plan_sync_run_mock),
+            patch(
+                "dev_health_ops.workers.sync_units.dispatch_sync_run",
+                dispatch_sync_run_mock,
+            ),
+        ):
+            _call_maybe_dispatch(monkeypatch, db_session, config, now)
+
+        # Idempotency marker must have been stamped (next_run_at > now).
+        assert job.next_run_at is not None
+        marker = job.next_run_at
+        if marker.tzinfo is None:
+            marker = marker.replace(tzinfo=timezone.utc)
+        assert marker > now
+
+
+class TestLegacyPathFlagOff:
+    """Flag OFF => legacy path regardless of migration status."""
+
+    def test_flag_off_migrated_config_uses_legacy(self, monkeypatch, db_session):
+        now = datetime.now(timezone.utc)
+        integration_id = uuid.uuid4()
+        config = _make_config(
+            db_session,
+            last_sync_at=now - 2 * HOUR,
+            migrated_integration_id=integration_id,
+        )
+        job = _make_job(config)
+        db_session.add(job)
+        db_session.flush()
+        # No flag row => disabled.
+
+        plan_sync_run_mock = MagicMock()
+        dispatch_sync_run_mock = MagicMock()
+        run_sync_config_mock = MagicMock()
+        batch_sync_mock = MagicMock()
+
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.run_sync_config",
+            run_sync_config_mock,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.dispatch_batch_sync",
+            batch_sync_mock,
+        )
+
+        with (
+            patch("dev_health_ops.sync.planner.plan_sync_run", plan_sync_run_mock),
+            patch(
+                "dev_health_ops.workers.sync_units.dispatch_sync_run",
+                dispatch_sync_run_mock,
+            ),
+        ):
+            result = _call_maybe_dispatch(monkeypatch, db_session, config, now)
+
+        assert result is True
+        plan_sync_run_mock.assert_not_called()
+        dispatch_sync_run_mock.apply_async.assert_not_called()
+        # Legacy path: run_sync_config (not batch, because owner+repo set).
+        run_sync_config_mock.apply_async.assert_called_once()
+
+    def test_flag_off_unmigrated_config_uses_legacy(self, monkeypatch, db_session):
+        now = datetime.now(timezone.utc)
+        config = _make_config(
+            db_session,
+            last_sync_at=now - 2 * HOUR,
+            # No migrated_integration_id.
+        )
+        job = _make_job(config)
+        db_session.add(job)
+        db_session.flush()
+
+        run_sync_config_mock = MagicMock()
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.run_sync_config",
+            run_sync_config_mock,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.dispatch_batch_sync",
+            MagicMock(),
+        )
+
+        result = _call_maybe_dispatch(monkeypatch, db_session, config, now)
+
+        assert result is True
+        run_sync_config_mock.apply_async.assert_called_once()
+
+
+class TestLegacyPathFlagOnUnmigrated:
+    """Flag ON but config NOT migrated => legacy path (plan_request_for_config returns None)."""
+
+    def test_flag_on_unmigrated_config_uses_legacy(self, monkeypatch, db_session):
+        now = datetime.now(timezone.utc)
+        config = _make_config(
+            db_session,
+            last_sync_at=now - 2 * HOUR,
+            # migrated_integration_id is None => not migrated.
+        )
+        job = _make_job(config)
+        db_session.add(job)
+        db_session.flush()
+        _enable_flag(db_session)
+
+        plan_sync_run_mock = MagicMock()
+        dispatch_sync_run_mock = MagicMock()
+        run_sync_config_mock = MagicMock()
+        batch_sync_mock = MagicMock()
+
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.run_sync_config",
+            run_sync_config_mock,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.dispatch_batch_sync",
+            batch_sync_mock,
+        )
+
+        with (
+            patch("dev_health_ops.sync.planner.plan_sync_run", plan_sync_run_mock),
+            patch(
+                "dev_health_ops.workers.sync_units.dispatch_sync_run",
+                dispatch_sync_run_mock,
+            ),
+        ):
+            result = _call_maybe_dispatch(monkeypatch, db_session, config, now)
+
+        assert result is True
+        # plan_request_for_config returns None for un-migrated config => planner skipped.
+        plan_sync_run_mock.assert_not_called()
+        dispatch_sync_run_mock.apply_async.assert_not_called()
+        # Legacy path used.
+        run_sync_config_mock.apply_async.assert_called_once()
+        batch_sync_mock.apply_async.assert_not_called()
+
+
+class TestPlannerFailureFallback:
+    """Flag ON + migrated config, but the planner fails (e.g. a stale
+    migrated_integration_id raising ValueError, or a transient DB/queue error).
+    The scheduled sync must NOT go dark until the next cron occurrence: roll
+    back the failed plan attempt and fall through to the legacy per-config
+    dispatch so this tick still syncs exactly once."""
+
+    def test_planner_error_falls_back_to_legacy(self, monkeypatch, db_session):
+        now = datetime.now(timezone.utc)
+        config = _make_config(
+            db_session,
+            last_sync_at=now - 2 * HOUR,
+            migrated_integration_id=uuid.uuid4(),
+        )
+        job = _make_job(config)
+        db_session.add(job)
+        db_session.flush()
+        _enable_flag(db_session)
+
+        # Stale/invalid integration: plan_sync_run raises before committing a run.
+        plan_sync_run_mock = MagicMock(
+            side_effect=ValueError("Integration not found for org")
+        )
+        dispatch_sync_run_mock = MagicMock()
+        run_sync_config_mock = MagicMock()
+        batch_sync_mock = MagicMock()
+
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.run_sync_config",
+            run_sync_config_mock,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.dispatch_batch_sync",
+            batch_sync_mock,
+        )
+
+        with (
+            patch("dev_health_ops.sync.planner.plan_sync_run", plan_sync_run_mock),
+            patch(
+                "dev_health_ops.workers.sync_units.dispatch_sync_run",
+                dispatch_sync_run_mock,
+            ),
+        ):
+            result = _call_maybe_dispatch(monkeypatch, db_session, config, now)
+
+        # Planner attempted, failed, fell back to legacy -- sync still dispatched.
+        assert result is True
+        plan_sync_run_mock.assert_called_once()
+        dispatch_sync_run_mock.apply_async.assert_not_called()
+        run_sync_config_mock.apply_async.assert_called_once()
+
+
+class TestDispatchEnqueueFailure:
+    """Flag ON + migrated config, plan commits, but dispatch_sync_run.apply_async
+    raises (e.g. broker down). The committed run must not be left silently
+    PLANNED: it is marked FAILED and the tick falls through to legacy dispatch."""
+
+    def test_enqueue_failure_marks_run_failed_and_falls_back(
+        self, monkeypatch, db_session
+    ):
+        from dev_health_ops.models.integrations import (
+            Base as IntegrationsBase,
+        )
+        from dev_health_ops.models.integrations import (
+            Integration,
+            SyncRun,
+            SyncRunStatus,
+        )
+
+        # Ensure the integration/sync-run tables exist in this in-memory DB.
+        IntegrationsBase.metadata.create_all(db_session.get_bind())
+
+        now = datetime.now(timezone.utc)
+        integration = Integration(
+            org_id=ORG_ID,
+            provider="github",
+            name="acme",
+        )
+        db_session.add(integration)
+        db_session.flush()
+        config = _make_config(
+            db_session,
+            last_sync_at=now - 2 * HOUR,
+            migrated_integration_id=integration.id,
+        )
+        job = _make_job(config)
+        db_session.add(job)
+        db_session.flush()
+        _enable_flag(db_session)
+
+        # Real plan that persists a SyncRun, so we can assert it gets marked FAILED.
+        captured = {}
+
+        def _real_plan(session, request):
+            run = SyncRun(
+                org_id=ORG_ID,
+                integration_id=integration.id,
+                triggered_by=request.triggered_by,
+                mode=request.mode,
+                status=SyncRunStatus.PLANNED.value,
+                total_units=0,
+            )
+            session.add(run)
+            session.flush()
+            captured["run_id"] = str(run.id)
+            return SimpleNamespace(sync_run_id=str(run.id), total_units=0, unit_ids=())
+
+        plan_sync_run_mock = MagicMock(side_effect=_real_plan)
+        dispatch_sync_run_mock = MagicMock()
+        dispatch_sync_run_mock.apply_async.side_effect = RuntimeError("broker down")
+        run_sync_config_mock = MagicMock()
+        batch_sync_mock = MagicMock()
+
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.run_sync_config",
+            run_sync_config_mock,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.dispatch_batch_sync",
+            batch_sync_mock,
+        )
+
+        with (
+            patch("dev_health_ops.sync.planner.plan_sync_run", plan_sync_run_mock),
+            patch(
+                "dev_health_ops.workers.sync_units.dispatch_sync_run",
+                dispatch_sync_run_mock,
+            ),
+        ):
+            result = _call_maybe_dispatch(monkeypatch, db_session, config, now)
+
+        # Enqueue failed => fell back to legacy, sync still attempted this tick.
+        assert result is True
+        dispatch_sync_run_mock.apply_async.assert_called_once()
+        run_sync_config_mock.apply_async.assert_called_once()
+        # The committed run must be marked FAILED, not left PLANNED.
+        run = db_session.get(SyncRun, uuid.UUID(captured["run_id"]))
+        assert run is not None
+        assert run.status == SyncRunStatus.FAILED.value

--- a/tests/test_trigger_routing.py
+++ b/tests/test_trigger_routing.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models import (
+    Base,
+    Setting,
+    SettingCategory,
+    SyncConfiguration,
+)
+from dev_health_ops.sync.trigger_routing import (
+    MIGRATED_TRIGGER_ROUTING_SETTING_KEY,
+    is_migrated_trigger_routing_enabled,
+    mark_sync_run_failed,
+    plan_request_for_config,
+)
+
+ORG_ID = "routing-org"
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _config(
+    session: Session,
+    *,
+    provider: str = "github",
+    sync_targets: list[str] | None = None,
+    migrated_integration_id: uuid.UUID | None = None,
+    migrated_source_id: uuid.UUID | None = None,
+) -> SyncConfiguration:
+    config = SyncConfiguration(
+        org_id=ORG_ID,
+        name=f"{provider}-config",
+        provider=provider,
+        sync_targets=sync_targets if sync_targets is not None else ["git"],
+        sync_options={},
+        migrated_integration_id=migrated_integration_id,
+        migrated_source_id=migrated_source_id,
+    )
+    session.add(config)
+    session.flush()
+    return config
+
+
+def _set_flag(session: Session, value: str) -> None:
+    session.add(
+        Setting(
+            org_id=ORG_ID,
+            category=SettingCategory.SYNC.value,
+            key=MIGRATED_TRIGGER_ROUTING_SETTING_KEY,
+            value=value,
+        )
+    )
+    session.flush()
+
+
+# --- flag reader -----------------------------------------------------------
+
+
+def test_flag_missing_is_disabled(db_session):
+    assert is_migrated_trigger_routing_enabled(db_session, ORG_ID) is False
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "on", "TRUE", "On"])
+def test_flag_truthy_values_enable(db_session, value):
+    _set_flag(db_session, value)
+    assert is_migrated_trigger_routing_enabled(db_session, ORG_ID) is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off", ""])
+def test_flag_falsey_values_disable(db_session, value):
+    _set_flag(db_session, value)
+    assert is_migrated_trigger_routing_enabled(db_session, ORG_ID) is False
+
+
+def test_flag_is_scoped_per_org(db_session):
+    _set_flag(db_session, "true")
+    assert is_migrated_trigger_routing_enabled(db_session, "other-org") is False
+
+
+# --- plan request builder --------------------------------------------------
+
+
+def test_unmigrated_config_returns_none(db_session):
+    config = _config(db_session)
+    assert plan_request_for_config(config, triggered_by="manual") is None
+
+
+def test_parent_config_plans_whole_integration(db_session):
+    integration_id = uuid.uuid4()
+    config = _config(
+        db_session,
+        sync_targets=["git", "prs"],
+        migrated_integration_id=integration_id,
+    )
+    req = plan_request_for_config(config, triggered_by="schedule")
+
+    assert req is not None
+    assert req.integration_id == str(integration_id)
+    assert req.org_id == ORG_ID
+    assert req.mode == "incremental"
+    assert req.triggered_by == "schedule"
+    # Parent => whole integration: no source/dataset scoping.
+    assert req.source_ids is None
+    assert req.dataset_keys is None
+
+
+def test_child_config_scopes_to_source_and_datasets(db_session):
+    integration_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    config = _config(
+        db_session,
+        provider="github",
+        sync_targets=["prs"],
+        migrated_integration_id=integration_id,
+        migrated_source_id=source_id,
+    )
+    req = plan_request_for_config(config, triggered_by="manual")
+
+    assert req is not None
+    assert req.integration_id == str(integration_id)
+    assert req.source_ids == (str(source_id),)
+    # "prs" legacy target maps to the prs dataset key family.
+    assert req.dataset_keys is not None
+    assert "prs" in req.dataset_keys
+
+
+def test_child_config_without_targets_falls_back_to_all_datasets(db_session):
+    integration_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    config = _config(
+        db_session,
+        sync_targets=[],
+        migrated_integration_id=integration_id,
+        migrated_source_id=source_id,
+    )
+    req = plan_request_for_config(config, triggered_by="manual")
+
+    assert req is not None
+    assert req.source_ids == (str(source_id),)
+    # No mappable targets => all enabled datasets (None), never an empty run.
+    assert req.dataset_keys is None
+
+
+def test_mode_override(db_session):
+    config = _config(
+        db_session,
+        migrated_integration_id=uuid.uuid4(),
+    )
+    req = plan_request_for_config(config, triggered_by="manual", mode="backfill")
+    assert req is not None
+    assert req.mode == "backfill"
+
+
+def test_operational_error_rolls_back_and_disables(monkeypatch, db_session):
+    """A failed flag read (e.g. missing settings table on PG) must roll back
+    the aborted transaction and return False so the caller's legacy path runs
+    on a clean session."""
+    from sqlalchemy.exc import OperationalError
+
+    def _boom(*_args, **_kwargs):
+        raise OperationalError("SELECT settings", {}, Exception("no such table"))
+
+    rolled_back = {"count": 0}
+    real_rollback = db_session.rollback
+
+    def _spy_rollback(*args, **kwargs):
+        rolled_back["count"] += 1
+        return real_rollback(*args, **kwargs)
+
+    monkeypatch.setattr(db_session, "query", _boom)
+    monkeypatch.setattr(db_session, "rollback", _spy_rollback)
+
+    assert is_migrated_trigger_routing_enabled(db_session, ORG_ID) is False
+    assert rolled_back["count"] == 1
+
+
+# --- mark_sync_run_failed (conditional compare-and-set) --------------------
+
+
+def _make_sync_run(db_session, status):
+    import uuid as _uuid
+
+    from dev_health_ops.models import SyncRun
+
+    run = SyncRun(
+        org_id=ORG_ID,
+        integration_id=_uuid.uuid4(),
+        triggered_by="manual",
+        mode="incremental",
+        status=status,
+        total_units=0,
+    )
+    db_session.add(run)
+    db_session.flush()
+    return run
+
+
+def test_mark_sync_run_failed_marks_planned_run_and_units(db_session):
+    import uuid as _uuid
+
+    from dev_health_ops.models import (
+        SyncRunStatus,
+        SyncRunUnit,
+        SyncRunUnitStatus,
+    )
+
+    run = _make_sync_run(db_session, SyncRunStatus.PLANNED.value)
+    unit = SyncRunUnit(
+        org_id=ORG_ID,
+        sync_run_id=run.id,
+        integration_id=run.integration_id,
+        source_id=_uuid.uuid4(),
+        provider="github",
+        dataset_key="git",
+        cost_class="light",
+        mode="incremental",
+        status=SyncRunUnitStatus.PLANNED.value,
+        attempts=0,
+    )
+    db_session.add(unit)
+    db_session.commit()
+
+    mark_sync_run_failed(db_session, str(run.id), "dispatch enqueue failed")
+
+    db_session.refresh(run)
+    db_session.refresh(unit)
+    assert run.status == SyncRunStatus.FAILED.value
+    assert run.error == "dispatch enqueue failed"
+    assert run.completed_at is not None
+    # The still-PLANNED unit is failed so a late dispatcher claims nothing.
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+
+
+def test_mark_sync_run_failed_noop_when_run_already_advanced(db_session):
+    from dev_health_ops.models import SyncRunStatus
+
+    # An ambiguous enqueue failure where the dispatcher already advanced the run
+    # must NOT be overwritten back to FAILED.
+    run = _make_sync_run(db_session, SyncRunStatus.DISPATCHING.value)
+    db_session.commit()
+
+    mark_sync_run_failed(db_session, str(run.id), "should not overwrite")
+
+    db_session.refresh(run)
+    assert run.status == SyncRunStatus.DISPATCHING.value
+    assert run.error != "should not overwrite"
+
+
+def test_mark_sync_run_failed_missing_run_is_noop(db_session):
+    import uuid as _uuid
+
+    # No row for this id -> best-effort no-op, no exception.
+    mark_sync_run_failed(db_session, str(_uuid.uuid4()), "x")


### PR DESCRIPTION
## Summary

The CHAOS-2516 config migration shipped in #962, but the two **legacy trigger surfaces** still ran the old per-config path and never invoked the fan-out planner:

- the admin **"Sync Now"** endpoint (`trigger_sync_config`), and
- the **scheduled-sync beat** (`_maybe_dispatch_config`).

This PR wires both to route a **migrated** config through `plan_sync_run` + `dispatch_sync_run` when the `sync.migrated_trigger_routing_enabled` flag is enabled for the org. Rollback is purely the flag: **off ⇒ unchanged legacy path**.

## Changes

- **`sync/trigger_routing.py`** (new shared helper):
  - `is_migrated_trigger_routing_enabled()` — reads the per-org flag; on a read failure (e.g. missing `settings` table / transient DB error) it **rolls back and returns False** so the caller's legacy path runs on a clean session (rollback-safe default).
  - `plan_request_for_config()` — maps a migrated config to a `SyncPlanRequest` (**parent ⇒ whole integration**; **child ⇒ source-scoped + child datasets**); returns `None` for un-migrated configs.
  - `mark_sync_run_failed()` — **conditional compare-and-set** used when dispatch enqueue fails after the plan commit: only acts while the run is still `PLANNED` (never overwrites a run the dispatcher already advanced), stamps `completed_at`, and fails that run's `PLANNED` units so a late dispatcher claims nothing (no duplicate provider sync).
- **`api/admin/routers/sync.py`** (`trigger_sync_config`): plan + commit + dispatch when flag on & migrated; on enqueue failure marks the run failed before returning 503.
- **`workers/sync_scheduler.py`** (`_maybe_dispatch_config`): same routing for the beat; planner/commit failure rolls back and **falls through to legacy this tick**, and enqueue failure marks the run failed then falls back to legacy so a scheduled sync is never silently suppressed.

## Adversarial review (Codex)

Ran `/codex:adversarial-review` across multiple rounds; addressed every in-scope finding:

- OperationalError fallback now rolls back the session before returning False.
- Beat planner-failure now rolls back + falls through to legacy.
- Beat **and** API enqueue-failure now mark the committed run FAILED (not stranded `PLANNED`) via the shared helper.
- Helper hardened to a conditional compare-and-set + fails `PLANNED` units to avoid overwriting/duplicating under ambiguous broker-accept failures.

**Follow-up (out of scope):** Codex also suggested gating `dispatch_sync_run` on terminal run status before claiming units. That touches the frozen CHAOS-2512 dispatch contract and is deferred to a separate issue.

## Tests

47 passing across the changeset + regression suites:

```
PYTHONPATH=src python -m pytest tests/test_trigger_routing.py tests/test_sync_scheduler_routing.py tests/api/admin/test_sync_trigger_routing.py tests/test_config_migration.py tests/api/admin/test_sync_config_deprecation.py -q
```

Coverage: helper flag truthiness, parent/child/un-migrated mapping, OperationalError rollback, conditional fail + no-op-when-advanced; both trigger surfaces (planner path, legacy path, un-migrated, planner-failure fallback, enqueue-failure handling).

`ruff format` + `ruff check` clean on all changed files.

SCREENSHOT-WAIVER: backend-only change (sync trigger routing); no rendered UI output.

Closes CHAOS-2516