### PR TITLE
fix(workers): add deploy-safe Celery baseline (CHAOS-2522)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -449,7 +449,7 @@ linear-cli issues update CHAOS-123 --state "Done"
 
 ---
 
-## 11. Pre-commit + pre-push hooks (lefthook + ruff)
+## 11. Pre-commit + pre-push hooks (lefthook + ruff + mypy)
 
 Lefthook drives three hooks:
 
@@ -461,10 +461,12 @@ Lefthook drives three hooks:
   Implementation: `scripts/strip_agent_attribution.py`. Tests:
   `tests/scripts/test_strip_agent_attribution.py`.
 - **pre-commit** auto-fixes formatting and lint on staged `.py` files and
-  re-stages the fixes (`stage_fixed: true`). The resulting commit is clean.
+  re-stages the fixes (`stage_fixed: true`), then runs `mypy` as a non-fixable
+  gate over the whole project. The resulting commit is clean and type-checked.
 - **pre-push** is a final gate: `ruff format --check` + `ruff check` on the
-  files being pushed. No auto-fix here — pre-push cannot modify the commits
-  it's gating, so blocking with an instruction is the only correct shape.
+  files being pushed, plus `mypy` over the whole project. No auto-fix here —
+  pre-push cannot modify the commits it's gating, so blocking with an
+  instruction is the only correct shape.
 
 ### One-time install
 
@@ -506,6 +508,7 @@ If `lefthook install` (without `--force`) warns about `core.hooksPath`, add `--f
 |------|---------|-----------|
 | 1 | `ruff format {staged_files}` | Auto-formats + re-stages |
 | 2 | `ruff check --fix {staged_files}` | Auto-fixes lint issues + re-stages |
+| 3 | `mypy` | **Gate**: blocks commit if type errors remain (whole-project per `[tool.mypy] files`, not just staged files) |
 
 **pre-push** (on every `git push`, for `.py` files in commits being pushed):
 
@@ -513,9 +516,11 @@ If `lefthook install` (without `--force`) warns about `core.hooksPath`, add `--f
 |------|---------|-----------|
 | 1 | `ruff format --check {push_files}` | **Gate**: blocks if formatting issues remain |
 | 2 | `ruff check {push_files}` | **Gate**: blocks if lint issues remain |
+| 3 | `mypy` | **Gate**: blocks push if type errors remain (whole-project) |
 
 If pre-push blocks you, the failure message tells you exactly what to run
-(`ruff format .` or `ruff check --fix .`), then commit and re-push.
+(`ruff format .`, `ruff check --fix .`, or `mypy` to surface the type errors),
+then fix, commit, and re-push.
 
 ### Escape hatch
 
@@ -524,7 +529,8 @@ git commit --no-verify   # skip pre-commit (use sparingly, e.g. WIP)
 git push --no-verify     # skip pre-push (emergency pushes)
 ```
 
-### No ruff config changes
+### No ruff/mypy config changes
 
-The hooks use the existing `[tool.ruff]` settings from `pyproject.toml`.
-Do not add new rules or exclusions to satisfy the hook — fix the code instead.
+The hooks use the existing `[tool.ruff]` and `[tool.mypy]` settings from
+`pyproject.toml`. Do not add new rules, exclusions, or `# type: ignore`
+suppressions to satisfy the hook — fix the code instead.

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -197,10 +197,12 @@ services:
     image: ${DEV_HEALTH_IMAGE:-ghcr.io/your-org/dev-health-ops:latest}
     container_name: dev-health-worker
     restart: unless-stopped
+    stop_signal: SIGTERM
+    stop_grace_period: ${WORKER_STOP_GRACE_PERIOD:-3700s}
     command:
       - celery
       - -A
-      - workers.celery_app
+      - dev_health_ops.workers.celery_app
       - worker
       - --loglevel=info
       - -Q
@@ -244,7 +246,7 @@ services:
     command:
       - celery
       - -A
-      - workers.celery_app
+      - dev_health_ops.workers.celery_app
       - worker
       - --loglevel=info
       - -Q
@@ -257,7 +259,7 @@ services:
     command:
       - celery
       - -A
-      - workers.celery_app
+      - dev_health_ops.workers.celery_app
       - worker
       - --loglevel=info
       - -Q

--- a/deploy/docker-swarm/stack.yml
+++ b/deploy/docker-swarm/stack.yml
@@ -187,7 +187,7 @@ services:
     command:
       - celery
       - -A
-      - workers.celery_app
+      - dev_health_ops.workers.celery_app
       - worker
       - --loglevel=info
       - -Q
@@ -231,7 +231,7 @@ services:
     command:
       - celery
       - -A
-      - workers.celery_app
+      - dev_health_ops.workers.celery_app
       - worker
       - --loglevel=info
       - -Q
@@ -243,7 +243,7 @@ services:
     command:
       - celery
       - -A
-      - workers.celery_app
+      - dev_health_ops.workers.celery_app
       - worker
       - --loglevel=info
       - -Q

--- a/deploy/helm/dev-health/templates/worker-deployment.yaml
+++ b/deploy/helm/dev-health/templates/worker-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "dev-health.componentLabels" (dict "component" "worker" "context" $) | nindent 4 }}
 spec:
+  progressDeadlineSeconds: {{ .Values.worker.progressDeadlineSeconds }}
   {{- if not .Values.worker.autoscaling.enabled }}
   replicas: {{ .Values.worker.replicas }}
   {{- end }}
@@ -21,6 +22,7 @@ spec:
       labels:
         {{- include "dev-health.componentSelectorLabels" (dict "component" "worker" "context" $) | nindent 8 }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
       {{- include "dev-health.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "dev-health.serviceAccountName" . }}
       securityContext:

--- a/deploy/helm/dev-health/templates/worker-pools.yaml
+++ b/deploy/helm/dev-health/templates/worker-pools.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     {{- include "dev-health.componentLabels" (dict "component" "worker-ingest" "context" $) | nindent 4 }}
 spec:
+  progressDeadlineSeconds: {{ .Values.workerIngest.progressDeadlineSeconds }}
   replicas: {{ .Values.workerIngest.replicas }}
   selector:
     matchLabels:
@@ -25,6 +26,7 @@ spec:
       labels:
         {{- include "dev-health.componentSelectorLabels" (dict "component" "worker-ingest" "context" $) | nindent 8 }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.workerIngest.terminationGracePeriodSeconds }}
       {{- include "dev-health.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "dev-health.serviceAccountName" . }}
       securityContext:
@@ -81,6 +83,7 @@ metadata:
   labels:
     {{- include "dev-health.componentLabels" (dict "component" "worker-heavy" "context" $) | nindent 4 }}
 spec:
+  progressDeadlineSeconds: {{ .Values.workerHeavy.progressDeadlineSeconds }}
   replicas: {{ .Values.workerHeavy.replicas }}
   selector:
     matchLabels:
@@ -93,6 +96,7 @@ spec:
       labels:
         {{- include "dev-health.componentSelectorLabels" (dict "component" "worker-heavy" "context" $) | nindent 8 }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.workerHeavy.terminationGracePeriodSeconds }}
       {{- include "dev-health.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "dev-health.serviceAccountName" . }}
       securityContext:

--- a/deploy/helm/dev-health/values.yaml
+++ b/deploy/helm/dev-health/values.yaml
@@ -98,6 +98,8 @@ worker:
   queues: "default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,monitoring"
   concurrency: 4
   logLevel: info
+  terminationGracePeriodSeconds: 3700
+  progressDeadlineSeconds: 7600
   resources:
     requests:
       memory: "256Mi"
@@ -136,6 +138,8 @@ workerIngest:
   queues: "ingest"
   concurrency: 1
   logLevel: info
+  terminationGracePeriodSeconds: 3700
+  progressDeadlineSeconds: 7600
   resources:
     requests:
       memory: "256Mi"
@@ -155,6 +159,8 @@ workerHeavy:
   queues: "metrics,backfill,monitoring,sync.github.heavy,sync.gitlab.heavy"
   concurrency: 2
   logLevel: info
+  terminationGracePeriodSeconds: 3700
+  progressDeadlineSeconds: 7600
   resources:
     requests:
       memory: "512Mi"

--- a/deploy/kubernetes/worker.yaml
+++ b/deploy/kubernetes/worker.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/component: worker
     app.kubernetes.io/part-of: dev-health-ops
 spec:
+  progressDeadlineSeconds: 7600
   replicas: 2
   selector:
     matchLabels:
@@ -19,6 +20,7 @@ spec:
       labels:
         app.kubernetes.io/name: dev-health-worker
     spec:
+      terminationGracePeriodSeconds: 3700
       securityContext:
         runAsNonRoot: true
       # CHAOS-2304 safety net: see api.yaml — blocks worker start until all
@@ -63,7 +65,7 @@ spec:
           command:
             - celery
             - -A
-            - workers.celery_app
+            - dev_health_ops.workers.celery_app
             - worker
             - --loglevel=info
             - -Q
@@ -86,7 +88,7 @@ spec:
               command:
                 - celery
                 - -A
-                - workers.celery_app
+                - dev_health_ops.workers.celery_app
                 - inspect
                 - ping
                 - --timeout
@@ -128,6 +130,7 @@ metadata:
     app.kubernetes.io/component: worker
     app.kubernetes.io/part-of: dev-health-ops
 spec:
+  progressDeadlineSeconds: 7600
   replicas: 1
   selector:
     matchLabels:
@@ -137,6 +140,7 @@ spec:
       labels:
         app.kubernetes.io/name: dev-health-worker-ingest
     spec:
+      terminationGracePeriodSeconds: 3700
       securityContext:
         runAsNonRoot: true
       initContainers:
@@ -171,7 +175,7 @@ spec:
           command:
             - celery
             - -A
-            - workers.celery_app
+            - dev_health_ops.workers.celery_app
             - worker
             - --loglevel=info
             - -Q
@@ -195,7 +199,7 @@ spec:
               command:
                 - celery
                 - -A
-                - workers.celery_app
+                - dev_health_ops.workers.celery_app
                 - inspect
                 - ping
                 - --timeout
@@ -216,6 +220,7 @@ metadata:
     app.kubernetes.io/component: worker
     app.kubernetes.io/part-of: dev-health-ops
 spec:
+  progressDeadlineSeconds: 7600
   replicas: 2
   selector:
     matchLabels:
@@ -225,6 +230,7 @@ spec:
       labels:
         app.kubernetes.io/name: dev-health-worker-heavy
     spec:
+      terminationGracePeriodSeconds: 3700
       securityContext:
         runAsNonRoot: true
       initContainers:
@@ -259,7 +265,7 @@ spec:
           command:
             - celery
             - -A
-            - workers.celery_app
+            - dev_health_ops.workers.celery_app
             - worker
             - --loglevel=info
             - -Q
@@ -281,7 +287,7 @@ spec:
               command:
                 - celery
                 - -A
-                - workers.celery_app
+                - dev_health_ops.workers.celery_app
                 - inspect
                 - ping
                 - --timeout

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -219,6 +219,43 @@ celery -A dev_health_ops.workers.celery_app inspect ping
 
 The `health_check` task can also be invoked to verify worker responsiveness.
 
+## Deploying with Active Workers
+
+Worker deploys must assume a rollout can overlap with active sync, metrics,
+report, ingest, or webhook tasks. The production Compose stack and Kubernetes
+manifests give workers a 3700 second graceful termination window, which exceeds
+the current 3600 second Celery hard task time limit. Keep that budget intact in
+environment-specific overlays unless task limits are reduced first.
+Kubernetes worker Deployments also set a 7600 second progress deadline. Helm,
+Argo CD, Flux, and other rollout controllers must use timeouts above the same
+window or they can mark a healthy drain as failed before old workers finish.
+
+### Safe rollout sequence
+
+1. Confirm the migration job has completed before restarting workers.
+2. Inspect active and reserved work without printing task args or kwargs:
+
+   ```bash
+   dev-hops workers inspect --state active --output json
+   dev-hops workers inspect --state reserved --output json
+   dev-hops workers inspect --state scheduled --output json
+   ```
+
+3. If active tasks are present, start the rollout but keep the worker graceful
+   shutdown budget above the hard task time limit so Celery can finish in-flight
+   work after receiving `SIGTERM`.
+4. Watch the same sanitized inspect commands until old workers report no active
+   tasks, then allow the deployment to complete.
+5. Do not enable global `task_acks_late` or `task_reject_on_worker_lost` during
+   rollout. Dispatchers, heartbeat, billing email, and stream-consumer tasks are
+   explicitly annotated as late-ack excluded until their child replay-safety
+   issues are complete.
+
+The inspect command intentionally omits task args, kwargs, headers, and request
+properties. It returns only task identity, worker metadata, timing, and routing
+keys so operators can drain workers without exposing provider tokens or other
+credentials.
+
 ## Queue Cleanup and Stale Jobs
 
 Celery uses Valkey as both broker and result backend on database 0 by default:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,4 +1,4 @@
-# Pre-commit + pre-push hooks for ruff format + lint.
+# Pre-commit + pre-push hooks for ruff format + lint, plus a mypy type-check gate.
 #
 # Design rationale:
 #   - pre-commit hook auto-fixes formatting + lint on staged files and
@@ -10,6 +10,11 @@
 #     cannot modify the commits being pushed (git's model), so auto-fix would
 #     leave uncommitted changes in the working tree and block the push without
 #     resolving anything. Final-gate-without-auto-fix is the correct shape here.
+#   - mypy runs as a non-fixable gate in BOTH pre-commit and pre-push. It type-
+#     checks the whole project (the `files` set in [tool.mypy], not just staged
+#     files) because per-file mypy is unreliable — it needs full module context.
+#     The glob "*.py" means it only fires when Python files are involved, and the
+#     incremental cache (.mypy_cache/) keeps warm runs well under a second.
 #   - Either hook can be skipped with `--no-verify` for WIP or emergency pushes.
 #
 # Install: `make install` (wires `lefthook install` into the bootstrap).
@@ -34,6 +39,10 @@ pre-commit:
       glob: "*.py"
       run: ruff check --fix {staged_files}
       stage_fixed: true
+    mypy:
+      glob: "*.py"
+      run: mypy
+      fail_text: "mypy found type errors. Fix them, or `git commit --no-verify` to bypass (discouraged)."
 
 pre-push:
   parallel: true
@@ -46,3 +55,7 @@ pre-push:
       glob: "*.py"
       run: ruff check {push_files}
       fail_text: "Run `ruff check --fix .` locally, commit the result, push again. Or `git push --no-verify` to bypass."
+    mypy:
+      glob: "*.py"
+      run: mypy
+      fail_text: "mypy found type errors. Run `mypy` locally, fix them, commit, push again. Or `git push --no-verify` to bypass."

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -302,6 +302,18 @@ def _is_help_invocation(argv: list[str] | None) -> bool:
     return any(arg in {"-h", "--help"} for arg in args)
 
 
+def _is_workers_inspect_json_invocation(argv: list[str] | None) -> bool:
+    args = sys.argv[1:] if argv is None else argv
+    if "workers" not in args or "inspect" not in args:
+        return False
+    if "--output=json" in args:
+        return True
+    return any(
+        arg == "--output" and index + 1 < len(args) and args[index + 1] == "json"
+        for index, arg in enumerate(args)
+    )
+
+
 @contextlib.contextmanager
 def _suppress_parser_construction_noise():
     previous_disable_level = logging.root.manager.disable
@@ -700,35 +712,54 @@ def main(argv: list[str] | None = None) -> int:
     }:
         _load_dotenv(REPO_ROOT / ".env")
 
-    if _is_help_invocation(argv):
-        with _suppress_parser_construction_noise():
+    quiet_json_inspect = _is_workers_inspect_json_invocation(argv)
+    previous_otel_enabled = os.environ.get("OTEL_ENABLED")
+    if quiet_json_inspect:
+        os.environ["OTEL_ENABLED"] = "false"
+
+    try:
+        if _is_help_invocation(argv) or quiet_json_inspect:
+            with _suppress_parser_construction_noise():
+                parser = build_parser()
+        else:
             parser = build_parser()
-    else:
-        parser = build_parser()
-    ns = parser.parse_args(argv)
+        ns = parser.parse_args(argv)
 
-    if _should_resolve_org(ns):
-        ns.org = _resolve_first_org_id(getattr(ns, "db", None))
+        if _should_resolve_org(ns):
+            ns.org = _resolve_first_org_id(getattr(ns, "db", None))
 
-    run_preflight_checks(parser, ns)
+        run_preflight_checks(parser, ns)
 
-    level_name = str(getattr(ns, "log_level", "") or "INFO").upper()
-    level = getattr(logging, level_name, logging.INFO)
-    logging.basicConfig(
-        level=level, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
-    )
+        level_name = str(getattr(ns, "log_level", "") or "INFO").upper()
+        level = getattr(logging, level_name, logging.INFO)
+        logging.basicConfig(
+            level=level, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+        )
 
-    from dev_health_ops.api.middleware.rate_limit import log_rate_limit_configuration
+        from dev_health_ops.api.middleware.rate_limit import (
+            log_rate_limit_configuration,
+        )
 
-    log_rate_limit_configuration()
+        if not (
+            getattr(ns, "command", None) == "workers"
+            and getattr(ns, "workers_command", None) == "inspect"
+            and getattr(ns, "output", None) == "json"
+        ):
+            log_rate_limit_configuration()
 
-    func = getattr(ns, "func", None)
-    if func is None:
-        parser.print_help()
-        return 2
-    if inspect.iscoroutinefunction(func):
-        return asyncio.run(func(ns))
-    return int(func(ns))
+        func = getattr(ns, "func", None)
+        if func is None:
+            parser.print_help()
+            return 2
+        if inspect.iscoroutinefunction(func):
+            return asyncio.run(func(ns))
+        return int(func(ns))
+    finally:
+        if quiet_json_inspect:
+            if previous_otel_enabled is None:
+                os.environ.pop("OTEL_ENABLED", None)
+            else:
+                os.environ["OTEL_ENABLED"] = previous_otel_enabled
 
 
 if __name__ == "__main__":

--- a/src/dev_health_ops/workers/__init__.py
+++ b/src/dev_health_ops/workers/__init__.py
@@ -3,6 +3,7 @@
 from dev_health_ops.workers import (
     metrics_tasks,
     product_tasks,
+    report_scheduler,
     sync_tasks,
     system_tasks,
     work_graph_tasks,
@@ -11,6 +12,7 @@ from dev_health_ops.workers import (
 __all__ = [
     "metrics_tasks",
     "product_tasks",
+    "report_scheduler",
     "sync_tasks",
     "system_tasks",
     "work_graph_tasks",

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -22,6 +22,25 @@ enable_utc = True
 task_track_started = True
 task_time_limit = 3600  # 1 hour max per task
 task_soft_time_limit = 3300  # Soft limit at 55 minutes
+task_acks_late = False
+task_reject_on_worker_lost = False
+
+late_ack_excluded_tasks = (
+    "dev_health_ops.workers.tasks.dispatch_scheduled_syncs",
+    "dev_health_ops.workers.tasks.dispatch_scheduled_metrics",
+    "dev_health_ops.workers.tasks.dispatch_daily_metrics_partitioned",
+    "dev_health_ops.workers.tasks.dispatch_release_impact",
+    "dev_health_ops.workers.tasks.dispatch_membership_backfill",
+    "dev_health_ops.workers.tasks.dispatch_scheduled_reports",
+    "dev_health_ops.workers.tasks.phone_home_heartbeat",
+    "dev_health_ops.workers.system_ops.send_billing_notification",
+    "dev_health_ops.workers.tasks.run_ingest_consumer",
+    "dev_health_ops.workers.tasks.run_product_telemetry_consumer",
+)
+task_annotations = {
+    task_name: {"acks_late": False, "reject_on_worker_lost": False}
+    for task_name in late_ack_excluded_tasks
+}
 
 # Worker settings
 # Long-running tasks (sync, stream consumers) make prefetching dangerous:

--- a/src/dev_health_ops/workers/runner.py
+++ b/src/dev_health_ops/workers/runner.py
@@ -28,11 +28,11 @@ def _sanitize_task(task: object) -> dict[str, object]:
 
     request = task.get("request")
     if isinstance(request, dict):
-        sanitized = _sanitize_task(request)
+        scheduled_task = _sanitize_task(request)
         for key in ("eta", "priority"):
             if key in task:
-                sanitized[key] = task[key]
-        return sanitized
+                scheduled_task[key] = task[key]
+        return scheduled_task
 
     sanitized: dict[str, object] = {}
     for key in ("id", "name", "hostname", "time_start", "acknowledged", "worker_pid"):

--- a/src/dev_health_ops/workers/runner.py
+++ b/src/dev_health_ops/workers/runner.py
@@ -1,11 +1,91 @@
 """CLI runner for background workers."""
 
 import argparse
+import contextlib
+import io
+import json
 import logging
+import os
 import subprocess
 import sys
 
 logger = logging.getLogger(__name__)
+
+_INSPECT_STATES = ("active", "reserved", "scheduled")
+
+
+def _sanitize_delivery_info(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {}
+
+    safe_keys = {"exchange", "routing_key", "priority", "redelivered"}
+    return {key: value[key] for key in safe_keys if key in value}
+
+
+def _sanitize_task(task: object) -> dict[str, object]:
+    if not isinstance(task, dict):
+        return {"raw_type": type(task).__name__}
+
+    request = task.get("request")
+    if isinstance(request, dict):
+        sanitized = _sanitize_task(request)
+        for key in ("eta", "priority"):
+            if key in task:
+                sanitized[key] = task[key]
+        return sanitized
+
+    sanitized: dict[str, object] = {}
+    for key in ("id", "name", "hostname", "time_start", "acknowledged", "worker_pid"):
+        if key in task:
+            sanitized[key] = task[key]
+
+    delivery_info = _sanitize_delivery_info(task.get("delivery_info"))
+    if delivery_info:
+        sanitized["delivery_info"] = delivery_info
+
+    return sanitized
+
+
+def _inspect_worker_tasks(
+    state: str, timeout: float
+) -> dict[str, list[dict[str, object]]]:
+    if state not in _INSPECT_STATES:
+        raise ValueError(f"unsupported inspect state: {state}")
+
+    from dev_health_ops.workers.celery_app import celery_app
+
+    inspector = celery_app.control.inspect(timeout=timeout)
+    raw = getattr(inspector, state)() or {}
+    if not isinstance(raw, dict):
+        return {}
+
+    sanitized: dict[str, list[dict[str, object]]] = {}
+    for worker, tasks in raw.items():
+        if not isinstance(tasks, list):
+            sanitized[str(worker)] = []
+            continue
+        sanitized[str(worker)] = [_sanitize_task(task) for task in tasks]
+    return sanitized
+
+
+def _print_inspect_text(tasks_by_worker: dict[str, list[dict[str, object]]]) -> None:
+    if not tasks_by_worker:
+        print("No workers responded.")
+        return
+
+    for worker in sorted(tasks_by_worker):
+        tasks = tasks_by_worker[worker]
+        print(f"{worker}: {len(tasks)} task(s)")
+        for task in tasks:
+            delivery_info = task.get("delivery_info")
+            queue = ""
+            if isinstance(delivery_info, dict):
+                routing_key = delivery_info.get("routing_key")
+                if routing_key:
+                    queue = f" queue={routing_key}"
+            task_name = task.get("name", "<unknown>")
+            task_id = task.get("id", "<unknown>")
+            print(f"  - {task_name} id={task_id}{queue}")
 
 
 def _cmd_start_worker(ns: argparse.Namespace) -> int:
@@ -47,6 +127,28 @@ def _cmd_start_scheduler(ns: argparse.Namespace) -> int:
     return subprocess.run(cmd).returncode
 
 
+def _cmd_inspect(ns: argparse.Namespace) -> int:
+    if ns.output == "json":
+        previous_disable = logging.root.manager.disable
+        previous_otel_enabled = os.environ.get("OTEL_ENABLED")
+        with contextlib.redirect_stdout(io.StringIO()):
+            logging.disable(logging.CRITICAL)
+            os.environ["OTEL_ENABLED"] = "false"
+            try:
+                tasks_by_worker = _inspect_worker_tasks(ns.state, ns.timeout)
+            finally:
+                if previous_otel_enabled is None:
+                    os.environ.pop("OTEL_ENABLED", None)
+                else:
+                    os.environ["OTEL_ENABLED"] = previous_otel_enabled
+                logging.disable(previous_disable)
+        print(json.dumps(tasks_by_worker, sort_keys=True))
+    else:
+        tasks_by_worker = _inspect_worker_tasks(ns.state, ns.timeout)
+        _print_inspect_text(tasks_by_worker)
+    return 0
+
+
 def register_commands(subparsers: argparse._SubParsersAction) -> None:
     """Register worker commands."""
     worker_parser = subparsers.add_parser("start-worker", help="Start a Celery worker.")
@@ -64,3 +166,27 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         "start-scheduler", help="Start the Celery beat scheduler."
     )
     beat_parser.set_defaults(func=_cmd_start_scheduler)
+
+    inspect_parser = subparsers.add_parser(
+        "inspect",
+        help="Show sanitized active/reserved/scheduled Celery task state.",
+    )
+    inspect_parser.add_argument(
+        "--state",
+        choices=_INSPECT_STATES,
+        default="active",
+        help="Worker task state to inspect (default: active).",
+    )
+    inspect_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Seconds to wait for worker inspect replies (default: 5).",
+    )
+    inspect_parser.add_argument(
+        "--output",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text).",
+    )
+    inspect_parser.set_defaults(func=_cmd_inspect)

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -37,6 +37,7 @@ def _run_cli_help(*args: str) -> subprocess.CompletedProcess[str]:
         ("migrate", "--help"),
         ("migrate", "clickhouse", "repair", "--help"),
         ("workers", "--help"),
+        ("workers", "inspect", "--help"),
         ("maintenance", "--help"),
     ],
 )

--- a/tests/test_worker_deploy_safety.py
+++ b/tests/test_worker_deploy_safety.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+
+
+def test_worker_inspect_sanitizes_task_arguments(monkeypatch, capsys) -> None:
+    from dev_health_ops.workers import runner
+    from dev_health_ops.workers.celery_app import celery_app
+
+    class FakeInspector:
+        def active(self) -> dict[str, list[dict[str, object]]]:
+            return {
+                "worker@node": [
+                    {
+                        "id": "task-1",
+                        "name": "dev_health_ops.workers.tasks.run_sync_config",
+                        "args": ["sensitive-value"],
+                        "kwargs": {"credential": "sensitive-value"},
+                        "argsrepr": "('sensitive-value',)",
+                        "kwargsrepr": "{'credential': 'sensitive-value'}",
+                        "headers": {"x-provider-credential": "sensitive-value"},
+                        "properties": {"correlation_id": "sensitive-value"},
+                        "delivery_info": {
+                            "routing_key": "sync.github",
+                            "redelivered": False,
+                        },
+                    }
+                ]
+            }
+
+    def fake_inspect(timeout: float) -> FakeInspector:
+        assert timeout == 0.1
+        return FakeInspector()
+
+    monkeypatch.setattr(celery_app.control, "inspect", fake_inspect)
+
+    ns = Namespace(state="active", timeout=0.1, output="json")
+
+    assert runner._cmd_inspect(ns) == 0
+
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    task = payload["worker@node"][0]
+    assert task == {
+        "delivery_info": {"redelivered": False, "routing_key": "sync.github"},
+        "id": "task-1",
+        "name": "dev_health_ops.workers.tasks.run_sync_config",
+    }
+    assert "sensitive-value" not in output
+    assert "args" not in task
+    assert "kwargs" not in task
+    assert "headers" not in task
+    assert "properties" not in task
+
+
+def test_worker_inspect_quiet_json_restores_otel_on_parse_error(monkeypatch) -> None:
+    from dev_health_ops import cli
+
+    monkeypatch.setenv("OTEL_ENABLED", "true")
+
+    try:
+        cli.main(["workers", "inspect", "--state", "bogus", "--output", "json"])
+    except SystemExit:
+        pass
+
+    assert cli.os.environ["OTEL_ENABLED"] == "true"
+
+
+def test_worker_inspect_sanitizes_nested_scheduled_request(monkeypatch, capsys) -> None:
+    from dev_health_ops.workers import runner
+    from dev_health_ops.workers.celery_app import celery_app
+
+    class FakeInspector:
+        def scheduled(self) -> dict[str, list[dict[str, object]]]:
+            return {
+                "worker@node": [
+                    {
+                        "eta": "2026-01-01T00:00:00+00:00",
+                        "priority": 3,
+                        "request": {
+                            "id": "task-2",
+                            "name": "dev_health_ops.workers.tasks.run_sync_config",
+                            "args": ["sensitive-value"],
+                            "kwargs": {"credential": "sensitive-value"},
+                            "headers": {"x-provider-credential": "sensitive-value"},
+                            "delivery_info": {"routing_key": "sync.github"},
+                        },
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(celery_app.control, "inspect", lambda timeout: FakeInspector())
+
+    ns = Namespace(state="scheduled", timeout=0.1, output="json")
+
+    assert runner._cmd_inspect(ns) == 0
+
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    task = payload["worker@node"][0]
+    assert task == {
+        "delivery_info": {"routing_key": "sync.github"},
+        "eta": "2026-01-01T00:00:00+00:00",
+        "id": "task-2",
+        "name": "dev_health_ops.workers.tasks.run_sync_config",
+        "priority": 3,
+    }
+    assert "sensitive-value" not in output
+    assert "args" not in task
+    assert "kwargs" not in task
+    assert "headers" not in task
+
+
+def test_worker_late_ack_exclusions_are_explicit() -> None:
+    from dev_health_ops.workers import config
+    from dev_health_ops.workers.celery_app import celery_app
+
+    assert config.task_acks_late is False
+    assert config.task_reject_on_worker_lost is False
+    assert celery_app.conf.task_acks_late is False
+    assert celery_app.conf.task_reject_on_worker_lost is False
+    assert (
+        "dev_health_ops.workers.tasks.phone_home_heartbeat"
+        in config.late_ack_excluded_tasks
+    )
+    assert config.task_annotations[
+        "dev_health_ops.workers.tasks.phone_home_heartbeat"
+    ] == {"acks_late": False, "reject_on_worker_lost": False}
+    assert celery_app.conf.task_annotations[
+        "dev_health_ops.workers.tasks.phone_home_heartbeat"
+    ] == {"acks_late": False, "reject_on_worker_lost": False}
+
+
+def test_worker_late_ack_exclusions_match_registered_tasks(monkeypatch) -> None:
+    monkeypatch.setenv("OTEL_ENABLED", "false")
+
+    from dev_health_ops.workers import config
+    from dev_health_ops.workers.celery_app import celery_app
+
+    missing = set(config.late_ack_excluded_tasks) - set(celery_app.tasks)
+    assert missing == set()

--- a/tests/test_worker_deploy_safety.py
+++ b/tests/test_worker_deploy_safety.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from argparse import Namespace
 
+import pytest
+
 
 def test_worker_inspect_sanitizes_task_arguments(monkeypatch, capsys) -> None:
     from dev_health_ops.workers import runner
@@ -59,10 +61,8 @@ def test_worker_inspect_quiet_json_restores_otel_on_parse_error(monkeypatch) -> 
 
     monkeypatch.setenv("OTEL_ENABLED", "true")
 
-    try:
+    with pytest.raises(SystemExit):
         cli.main(["workers", "inspect", "--state", "bogus", "--output", "json"])
-    except SystemExit:
-        pass
 
     assert cli.os.environ["OTEL_ENABLED"] == "true"
 


### PR DESCRIPTION
## Summary
- add sanitized `dev-hops workers inspect` output for active/reserved/scheduled Celery work
- make worker ack/requeue defaults explicit and register late-ack exclusion annotations
- extend worker drain and rollout budgets across Compose, Swarm, raw Kubernetes, and Helm manifests
- document safe worker rollout/drain procedure

## Verification
- `PYTHONPATH=src python -m pytest tests/test_worker_deploy_safety.py tests/test_cli_help.py -q`
- `ruff format --check src/dev_health_ops/cli.py src/dev_health_ops/workers/__init__.py src/dev_health_ops/workers/config.py src/dev_health_ops/workers/runner.py tests/test_cli_help.py tests/test_worker_deploy_safety.py`
- `ruff check src/dev_health_ops/cli.py src/dev_health_ops/workers/__init__.py src/dev_health_ops/workers/config.py src/dev_health_ops/workers/runner.py tests/test_cli_help.py tests/test_worker_deploy_safety.py`
- `helm template chaos-2522 deploy/helm/dev-health >/dev/null`
- `docker compose -f deploy/docker-compose/compose.production.yml config >/dev/null` with dummy/blank secret env
- `docker compose -f deploy/docker-swarm/stack.yml config >/dev/null`
- `OTEL_ENABLED=false PYTHONPATH=src python -m dev_health_ops.cli workers inspect --output json` parsed with `python -m json.tool`
- live inspect JSON redaction check found no args/kwargs/header/property keys

SCREENSHOT-WAIVER: backend/docs/deploy config only; no rendered UI impact.

Closes CHAOS-2522