### PR TITLE
fix(workers): harden Celery sync lifecycle

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -131,6 +131,7 @@ services:
       --host 0.0.0.0 --port 8000 --reload
     environment: &env
       SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DEV_HEALTH_OPS: "0.0.0"
+      PYTHONPATH: /app/src
       # GraphQL analytics endpoint available at /graphql
       GRAPHQL_QUERY_TIMEOUT: "30"
       # CHAOS-2065: runtime DB traffic flows through PgBouncer (transaction mode).
@@ -252,7 +253,8 @@ services:
       args:
         SETUPTOOLS_SCM_PRETEND_VERSION: 0.0.0
     container_name: worker
-    command: celery -A workers.celery_app worker --loglevel=info -Q default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,monitoring --concurrency=${WORKER_CONCURRENCY:-4}
+    entrypoint: ["celery"]
+    command: -A dev_health_ops.workers.celery_app worker --loglevel=info --disable-prefetch -Q default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,monitoring --concurrency=${WORKER_CONCURRENCY:-4}
     environment:
       <<: *env
       CELERY_BROKER_URL: redis://valkey:6379/0
@@ -278,14 +280,14 @@ services:
   worker-ingest:
     <<: *worker-base
     container_name: worker-ingest
-    command: celery -A workers.celery_app worker --loglevel=info -Q ingest --concurrency=1
+    command: -A dev_health_ops.workers.celery_app worker --loglevel=info --disable-prefetch -Q ingest --concurrency=1
 
   worker-heavy:
     <<: *worker-base
     container_name: worker-heavy
     # `monitoring` is consumed here AND by `worker` above: queue telemetry
     # survives either pool being saturated or down.
-    command: celery -A workers.celery_app worker --loglevel=info -Q metrics,backfill,monitoring,sync.github.heavy,sync.gitlab.heavy --concurrency=${WORKER_HEAVY_CONCURRENCY:-2}
+    command: -A dev_health_ops.workers.celery_app worker --loglevel=info --disable-prefetch -Q metrics,backfill,monitoring,sync.github.heavy,sync.gitlab.heavy --concurrency=${WORKER_HEAVY_CONCURRENCY:-2}
 
   # ---------------------------------------------------------------------------
   # Observability — SigNoz (distributed tracing + metrics)

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -103,7 +103,9 @@ services:
       - "--port"
       - "8000"
     environment:
-      DATABASE_URI: clickhouse://${CLICKHOUSE_USER:-ch}:${CLICKHOUSE_PASSWORD:-ch}@clickhouse:8123/${CLICKHOUSE_DB:-default}
+      POSTGRES_URI: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/${POSTGRES_DB}
+      DATABASE_URI: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/${POSTGRES_DB}
+      CLICKHOUSE_URI: clickhouse://${CLICKHOUSE_USER:-ch}:${CLICKHOUSE_PASSWORD:-ch}@clickhouse:8123/${CLICKHOUSE_DB:-default}
       REDIS_URL: redis://valkey:6379/1
       CELERY_BROKER_URL: redis://valkey:6379/0
       CELERY_RESULT_BACKEND: redis://valkey:6379/0
@@ -199,17 +201,21 @@ services:
     restart: unless-stopped
     stop_signal: SIGTERM
     stop_grace_period: ${WORKER_STOP_GRACE_PERIOD:-3700s}
-    command:
+    entrypoint:
       - celery
+    command:
       - -A
       - dev_health_ops.workers.celery_app
       - worker
       - --loglevel=info
+      - --disable-prefetch
       - -Q
       - default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,monitoring
       - --concurrency=${WORKER_CONCURRENCY:-4}
     environment:
-      DATABASE_URI: clickhouse://${CLICKHOUSE_USER:-ch}:${CLICKHOUSE_PASSWORD:-ch}@clickhouse:8123/${CLICKHOUSE_DB:-default}
+      POSTGRES_URI: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/${POSTGRES_DB}
+      DATABASE_URI: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/${POSTGRES_DB}
+      CLICKHOUSE_URI: clickhouse://${CLICKHOUSE_USER:-ch}:${CLICKHOUSE_PASSWORD:-ch}@clickhouse:8123/${CLICKHOUSE_DB:-default}
       CELERY_BROKER_URL: redis://valkey:6379/0
       CELERY_RESULT_BACKEND: redis://valkey:6379/0
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
@@ -244,11 +250,11 @@ services:
     <<: *worker-base
     container_name: dev-health-worker-ingest
     command:
-      - celery
       - -A
       - dev_health_ops.workers.celery_app
       - worker
       - --loglevel=info
+      - --disable-prefetch
       - -Q
       - ingest
       - --concurrency=1
@@ -257,11 +263,11 @@ services:
     <<: *worker-base
     container_name: dev-health-worker-heavy
     command:
-      - celery
       - -A
       - dev_health_ops.workers.celery_app
       - worker
       - --loglevel=info
+      - --disable-prefetch
       - -Q
       - metrics,backfill,monitoring,sync.github.heavy,sync.gitlab.heavy
       - --concurrency=${WORKER_HEAVY_CONCURRENCY:-2}

--- a/deploy/docker-swarm/stack.yml
+++ b/deploy/docker-swarm/stack.yml
@@ -129,7 +129,9 @@ services:
       - "--port"
       - "8000"
     environment:
-      DATABASE_URI: clickhouse://ch:ch@clickhouse:8123/default
+      POSTGRES_URI: postgresql+asyncpg://devhealth:${POSTGRES_PASSWORD}@postgres:5432/devhealth
+      DATABASE_URI: postgresql+asyncpg://devhealth:${POSTGRES_PASSWORD}@postgres:5432/devhealth
+      CLICKHOUSE_URI: clickhouse://ch:ch@clickhouse:8123/default
       REDIS_URL: redis://valkey:6379/1
       CELERY_BROKER_URL: redis://valkey:6379/0
       CELERY_RESULT_BACKEND: redis://valkey:6379/0
@@ -184,17 +186,21 @@ services:
   # (CHAOS-2517) ride along: light/medium on `worker`, heavy on `worker-heavy`.
   worker: &worker-base
     image: ghcr.io/your-org/dev-health-ops:latest
-    command:
+    entrypoint:
       - celery
+    command:
       - -A
       - dev_health_ops.workers.celery_app
       - worker
       - --loglevel=info
+      - --disable-prefetch
       - -Q
       - default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,monitoring
       - --concurrency=4
     environment:
-      DATABASE_URI: clickhouse://ch:ch@clickhouse:8123/default
+      POSTGRES_URI: postgresql+asyncpg://devhealth:${POSTGRES_PASSWORD}@postgres:5432/devhealth
+      DATABASE_URI: postgresql+asyncpg://devhealth:${POSTGRES_PASSWORD}@postgres:5432/devhealth
+      CLICKHOUSE_URI: clickhouse://ch:ch@clickhouse:8123/default
       CELERY_BROKER_URL: redis://valkey:6379/0
       CELERY_RESULT_BACKEND: redis://valkey:6379/0
       LOG_LEVEL: INFO
@@ -229,11 +235,11 @@ services:
   worker-ingest:
     <<: *worker-base
     command:
-      - celery
       - -A
       - dev_health_ops.workers.celery_app
       - worker
       - --loglevel=info
+      - --disable-prefetch
       - -Q
       - ingest
       - --concurrency=1
@@ -241,11 +247,11 @@ services:
   worker-heavy:
     <<: *worker-base
     command:
-      - celery
       - -A
       - dev_health_ops.workers.celery_app
       - worker
       - --loglevel=info
+      - --disable-prefetch
       - -Q
       - metrics,backfill,monitoring,sync.github.heavy,sync.gitlab.heavy
       - --concurrency=2

--- a/deploy/helm/dev-health/templates/worker-deployment.yaml
+++ b/deploy/helm/dev-health/templates/worker-deployment.yaml
@@ -42,6 +42,7 @@ spec:
             - dev_health_ops.workers.celery_app
             - worker
             - --loglevel={{ .Values.worker.logLevel }}
+            - --disable-prefetch
             - -Q
             - {{ .Values.worker.queues }}
             - --concurrency={{ .Values.worker.concurrency }}

--- a/deploy/helm/dev-health/templates/worker-pools.yaml
+++ b/deploy/helm/dev-health/templates/worker-pools.yaml
@@ -46,6 +46,7 @@ spec:
             - dev_health_ops.workers.celery_app
             - worker
             - --loglevel={{ .Values.workerIngest.logLevel }}
+            - --disable-prefetch
             - -Q
             - {{ .Values.workerIngest.queues }}
             - --concurrency={{ .Values.workerIngest.concurrency }}
@@ -116,6 +117,7 @@ spec:
             - dev_health_ops.workers.celery_app
             - worker
             - --loglevel={{ .Values.workerHeavy.logLevel }}
+            - --disable-prefetch
             - -Q
             - {{ .Values.workerHeavy.queues }}
             - --concurrency={{ .Values.workerHeavy.concurrency }}

--- a/deploy/kubernetes/worker.yaml
+++ b/deploy/kubernetes/worker.yaml
@@ -68,6 +68,7 @@ spec:
             - dev_health_ops.workers.celery_app
             - worker
             - --loglevel=info
+            - --disable-prefetch
             - -Q
             - default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,monitoring
           envFrom:
@@ -178,6 +179,7 @@ spec:
             - dev_health_ops.workers.celery_app
             - worker
             - --loglevel=info
+            - --disable-prefetch
             - -Q
             - ingest
             - --concurrency
@@ -268,6 +270,7 @@ spec:
             - dev_health_ops.workers.celery_app
             - worker
             - --loglevel=info
+            - --disable-prefetch
             - -Q
             - metrics,backfill,monitoring,sync.github.heavy,sync.gitlab.heavy
           envFrom:

--- a/src/dev_health_ops/api/admin/routers/integrations.py
+++ b/src/dev_health_ops/api/admin/routers/integrations.py
@@ -33,6 +33,7 @@ from dev_health_ops.api.services.integrations import (
 )
 from dev_health_ops.sync.discovery import discover_sources_for_integration
 from dev_health_ops.sync.planner import SyncPlanRequest, plan_sync_run
+from dev_health_ops.sync.trigger_routing import mark_sync_run_failed
 from dev_health_ops.workers.sync_units import dispatch_sync_run
 
 from .common import get_session
@@ -418,7 +419,15 @@ async def trigger_integration_sync(
             queue="sync",
         )
     except Exception as exc:
-        raise HTTPException(status_code=503, detail=f"Task queue unavailable: {exc}")
+        error = f"Task queue unavailable: {exc}"
+        await session.run_sync(
+            lambda sync_session: mark_sync_run_failed(
+                sync_session,
+                plan.sync_run_id,
+                error,
+            )
+        )
+        raise HTTPException(status_code=503, detail=error)
 
     return SyncTriggerResponse(
         status="accepted",
@@ -475,7 +484,15 @@ async def trigger_integration_backfill(
             queue="sync",
         )
     except Exception as exc:
-        raise HTTPException(status_code=503, detail=f"Task queue unavailable: {exc}")
+        error = f"Task queue unavailable: {exc}"
+        await session.run_sync(
+            lambda sync_session: mark_sync_run_failed(
+                sync_session,
+                plan.sync_run_id,
+                error,
+            )
+        )
+        raise HTTPException(status_code=503, detail=error)
 
     return SyncTriggerResponse(
         status="accepted",

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import uuid
+from datetime import datetime, timezone
 from typing import Any, Protocol, cast
 
 from croniter import croniter as Croniter
@@ -50,6 +51,26 @@ from .common import get_session
 router = APIRouter()
 
 logger = logging.getLogger(__name__)
+
+
+def _mark_job_run_failed(sync_session, run_id: str, error: str) -> None:
+    completed_at = datetime.now(timezone.utc)
+    run = (
+        sync_session.query(JobRun)
+        .filter(JobRun.id == uuid.UUID(str(run_id)))
+        .one_or_none()
+    )
+    if run is None:
+        return
+    run.status = JobRunStatus.FAILED.value
+    run.completed_at = completed_at
+    run.error = error
+    started_at = getattr(run, "started_at", None)
+    if started_at is not None:
+        if started_at.tzinfo is None:
+            started_at = started_at.replace(tzinfo=timezone.utc)
+        run.duration_seconds = max(0, int((completed_at - started_at).total_seconds()))
+    sync_session.flush()
 
 
 async def _is_planner_active(session: AsyncSession, org_id: str) -> bool:
@@ -1150,26 +1171,39 @@ async def trigger_sync_config(
             return str(run.id)
 
         pending_run_id: str = await session.run_sync(_create_pending_run)
+        await session.commit()
 
         is_batch = _is_batch_eligible(config)
         task = dispatch_batch_sync if is_batch else run_sync_config
         # Per-provider queue routing (CHAOS-2299): an explicit apply_async
         # queue overrides the task decorator's queue="sync" default.
-        result = getattr(task, "apply_async")(
-            kwargs={
-                "config_id": str(config.id),
-                "org_id": str(config.org_id),
-                "triggered_by": "manual",
-                "pending_run_id": pending_run_id,
-            },
-            queue=sync_queue_for_provider(str(config.provider or "")),
-        )
+        try:
+            result = getattr(task, "apply_async")(
+                kwargs={
+                    "config_id": str(config.id),
+                    "org_id": str(config.org_id),
+                    "triggered_by": "manual",
+                    "pending_run_id": pending_run_id,
+                },
+                queue=sync_queue_for_provider(str(config.provider or "")),
+            )
+        except Exception as e:
+            error_message = f"dispatch enqueue failed: {e}"
+            await session.run_sync(
+                lambda sync_session: _mark_job_run_failed(
+                    sync_session, pending_run_id, error_message
+                )
+            )
+            await session.commit()
+            raise HTTPException(status_code=503, detail=f"Task queue unavailable: {e}")
         return {
             "status": "triggered",
             "config_id": str(config.id),
             "task_id": result.id,
             "run_id": pending_run_id,
         }
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=503, detail=f"Task queue unavailable: {e}")
 

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -51,6 +51,12 @@ task_annotations = {
 # One-at-a-time fetching keeps cross-queue round-robin fair (CHAOS-2277).
 worker_prefetch_multiplier = 1
 
+worker_disable_prefetch = True
+
+stream_consumer_schedule_seconds = 30.0
+stream_consumer_max_iterations = 5
+stream_consumer_expires_seconds = 30
+
 # Retry settings
 task_default_retry_delay = 60  # 1 minute between retries
 task_max_retries = 3
@@ -151,15 +157,15 @@ beat_schedule = {
     },
     "process-ingest-streams": {
         "task": "dev_health_ops.workers.tasks.run_ingest_consumer",
-        "schedule": 30.0,
-        "kwargs": {"max_iterations": 50},
-        "options": {"queue": "ingest"},
+        "schedule": stream_consumer_schedule_seconds,
+        "kwargs": {"max_iterations": stream_consumer_max_iterations},
+        "options": {"queue": "ingest", "expires": stream_consumer_expires_seconds},
     },
     "process-product-telemetry-streams": {
         "task": "dev_health_ops.workers.tasks.run_product_telemetry_consumer",
-        "schedule": 30.0,
-        "kwargs": {"max_iterations": 50},
-        "options": {"queue": "ingest"},
+        "schedule": stream_consumer_schedule_seconds,
+        "kwargs": {"max_iterations": stream_consumer_max_iterations},
+        "options": {"queue": "ingest", "expires": stream_consumer_expires_seconds},
     },
     "phone-home-heartbeat": {
         "task": "dev_health_ops.workers.tasks.phone_home_heartbeat",

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -67,6 +67,11 @@ from dev_health_ops.workers.sync_runtime import _dispatch_post_sync_tasks
 
 logger = logging.getLogger(__name__)
 _runtime_cache = ProviderRuntimeCache()
+_TERMINAL_RUN_STATUSES = {
+    SyncRunStatus.SUCCESS.value,
+    SyncRunStatus.PARTIAL_FAILED.value,
+    SyncRunStatus.FAILED.value,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -179,14 +184,18 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
         )
         callback = getattr(finalize_sync_run, "si")(sync_run_id)
         callback.set(queue="sync")
-        chord(group(signatures), callback).apply_async()
+        try:
+            chord(group(signatures), callback).apply_async()
+        except Exception as exc:
+            _mark_dispatch_enqueue_failed(sync_run_id, str(exc))
+            raise
         return {"status": "dispatched", "queued_units": len(signatures)}
 
     logger.info(
         "dispatch_sync_run.noop",
         extra={"sync_run_id": sync_run_id, "queued_units": 0},
     )
-    getattr(finalize_sync_run, "apply_async")(args=(sync_run_id,), queue="sync")
+    finalize_sync_run(sync_run_id)
     return {"status": "noop", "queued_units": 0}
 
 
@@ -209,6 +218,7 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
     from dev_health_ops.processors.dataset_adapters import run_dataset_unit
 
     sync_run_id: str | None = None
+    should_finalize = False
     started_at = datetime.now(timezone.utc)
     # Unit context fields for structured logging — populated once ctx is loaded.
     _log_ctx: dict[str, Any] = {"unit_id": unit_id}
@@ -217,10 +227,25 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
             ctx = SyncTaskBootstrap.load(session, unit_id)
             sync_run_id = ctx.sync_run_id
             unit = _load_unit(session, unit_id)
+            run = (
+                session.query(SyncRun)
+                .filter(SyncRun.id == unit.sync_run_id)
+                .one_or_none()
+            )
+            if unit.status in {
+                SyncRunUnitStatus.SUCCESS.value,
+                SyncRunUnitStatus.FAILED.value,
+            } or (run is not None and run.status in _TERMINAL_RUN_STATUSES):
+                return {
+                    "status": "skipped",
+                    "unit_id": unit_id,
+                    "reason": "terminal",
+                }
             unit.status = SyncRunUnitStatus.RUNNING.value
             unit.attempts = int(unit.attempts or 0) + 1
             unit.error = None
             session.flush()
+            should_finalize = True
             _log_ctx = {
                 "sync_run_id": ctx.sync_run_id,
                 "unit_id": unit_id,
@@ -239,6 +264,20 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
         duration_seconds = max(0, int((completed_at - started_at).total_seconds()))
         with get_postgres_session_sync() as session:
             unit = _load_unit(session, unit_id)
+            run = (
+                session.query(SyncRun)
+                .filter(SyncRun.id == unit.sync_run_id)
+                .one_or_none()
+            )
+            if unit.status in {
+                SyncRunUnitStatus.SUCCESS.value,
+                SyncRunUnitStatus.FAILED.value,
+            } or (run is not None and run.status in _TERMINAL_RUN_STATUSES):
+                return {
+                    "status": "skipped",
+                    "unit_id": unit_id,
+                    "reason": "terminal",
+                }
             unit.status = SyncRunUnitStatus.SUCCESS.value
             unit.duration_seconds = duration_seconds
             unit.result = dict(result or {})
@@ -268,6 +307,20 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
         with get_postgres_session_sync() as session:
             unit = _load_unit(session, unit_id)
             sync_run_id = str(unit.sync_run_id)
+            run = (
+                session.query(SyncRun)
+                .filter(SyncRun.id == unit.sync_run_id)
+                .one_or_none()
+            )
+            if unit.status in {
+                SyncRunUnitStatus.SUCCESS.value,
+                SyncRunUnitStatus.FAILED.value,
+            } or (run is not None and run.status in _TERMINAL_RUN_STATUSES):
+                return {
+                    "status": "skipped",
+                    "unit_id": unit_id,
+                    "reason": "terminal",
+                }
             unit.status = SyncRunUnitStatus.FAILED.value
             unit.duration_seconds = duration_seconds
             unit.error = str(exc)
@@ -288,8 +341,16 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
             "error_category": error_category,
         }
     finally:
-        if sync_run_id is not None:
-            getattr(finalize_sync_run, "apply_async")(args=(sync_run_id,), queue="sync")
+        if should_finalize and sync_run_id is not None:
+            try:
+                getattr(finalize_sync_run, "apply_async")(
+                    args=(sync_run_id,), queue="sync"
+                )
+            except Exception:
+                logger.exception(
+                    "run_sync_unit.finalize_enqueue_failed",
+                    extra={"sync_run_id": sync_run_id, "unit_id": unit_id},
+                )
 
 
 @celery_app.task(queue="sync", name="dev_health_ops.workers.tasks.finalize_sync_run")
@@ -337,12 +398,20 @@ def finalize_sync_run(sync_run_id: str) -> dict[str, Any]:
         failed_count = sum(
             1 for unit in units if unit.status == SyncRunUnitStatus.FAILED.value
         )
+        total_count = len(units)
         completed_at = datetime.now(timezone.utc)
         run.completed_units = success_count
         run.failed_units = failed_count
         run.completed_at = run.completed_at or completed_at
-        run.status = _aggregate_run_status(success_count, failed_count)
-        run.result = {"completed_units": success_count, "failed_units": failed_count}
+        run.status = _aggregate_run_status(total_count, success_count, failed_count)
+        result_payload: dict[str, Any] = {
+            "completed_units": success_count,
+            "failed_units": failed_count,
+        }
+        if total_count == 0:
+            run.error = "No sync units planned"
+            result_payload["reason"] = "no_sync_units_planned"
+        run.result = result_payload
         session.flush()
 
         nested = session.begin_nested()
@@ -377,7 +446,7 @@ def finalize_sync_run(sync_run_id: str) -> dict[str, Any]:
         run_org_id = str(run.org_id)
         session.flush()
 
-    run_status = _aggregate_run_status(success_count, failed_count)
+    run_status = _aggregate_run_status(len(units), success_count, failed_count)
     logger.info(
         "finalize_sync_run.finalized",
         extra={
@@ -472,6 +541,39 @@ def _claim_units(session, run_uuid: uuid.UUID) -> list[SyncRunUnit]:
     )
 
 
+def _mark_dispatch_enqueue_failed(sync_run_id: str, error: str) -> None:
+    from dev_health_ops.db import get_postgres_session_sync
+
+    completed_at = datetime.now(timezone.utc)
+    run_uuid = uuid.UUID(str(sync_run_id))
+    with get_postgres_session_sync() as session:
+        run = session.query(SyncRun).filter(SyncRun.id == run_uuid).one_or_none()
+        if run is None:
+            return
+        run.status = SyncRunStatus.FAILED.value
+        run.completed_at = completed_at
+        run.error = error
+        run.result = {"error": error, "phase": "dispatch_enqueue"}
+        units = (
+            session.query(SyncRunUnit).filter(SyncRunUnit.sync_run_id == run_uuid).all()
+        )
+        for unit in units:
+            if unit.status not in {
+                SyncRunUnitStatus.SUCCESS.value,
+                SyncRunUnitStatus.FAILED.value,
+            }:
+                unit.status = SyncRunUnitStatus.FAILED.value
+                unit.error = error
+                unit.updated_at = completed_at
+        run.completed_units = sum(
+            1 for unit in units if unit.status == SyncRunUnitStatus.SUCCESS.value
+        )
+        run.failed_units = sum(
+            1 for unit in units if unit.status == SyncRunUnitStatus.FAILED.value
+        )
+        session.flush()
+
+
 def _load_unit(session, unit_id: str) -> SyncRunUnit:
     unit_uuid = uuid.UUID(str(unit_id))
     unit = session.query(SyncRunUnit).filter(SyncRunUnit.id == unit_uuid).one_or_none()
@@ -480,7 +582,11 @@ def _load_unit(session, unit_id: str) -> SyncRunUnit:
     return unit
 
 
-def _aggregate_run_status(success_count: int, failed_count: int) -> str:
+def _aggregate_run_status(
+    total_count: int, success_count: int, failed_count: int
+) -> str:
+    if total_count == 0:
+        return SyncRunStatus.FAILED.value
     if failed_count == 0:
         return SyncRunStatus.SUCCESS.value
     if success_count == 0:

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -326,6 +326,7 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
             unit.error = str(exc)
             unit.result = {"error_category": error_category}
             session.flush()
+            should_finalize = True
         logger.exception(
             "run_sync_unit.failed",
             extra={

--- a/tests/api/admin/test_integrations.py
+++ b/tests/api/admin/test_integrations.py
@@ -530,6 +530,41 @@ async def test_trigger_sync_org_scoped(client, seeded_state):
 
 
 @pytest.mark.asyncio
+async def test_trigger_sync_marks_run_failed_when_enqueue_fails(
+    client,
+    session_maker,
+):
+    ac, _ = client
+    created = await _create_integration(ac)
+    integration_id = created["id"]
+
+    mock_dispatch = MagicMock()
+    mock_dispatch.apply_async = MagicMock(side_effect=RuntimeError("broker down"))
+
+    with patch(
+        "dev_health_ops.api.admin.routers.integrations.dispatch_sync_run",
+        mock_dispatch,
+    ):
+        resp = await ac.post(
+            f"/api/v1/admin/integrations/{integration_id}/sync",
+            json={},
+        )
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "Task queue unavailable: broker down"
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(SyncRun).where(SyncRun.integration_id == uuid.UUID(integration_id))
+        )
+        run = result.scalar_one()
+
+    assert run.status == "failed"
+    assert run.error == "Task queue unavailable: broker down"
+    assert run.completed_at is not None
+
+
+@pytest.mark.asyncio
 async def test_trigger_sync_not_found(client):
     ac, _ = client
     resp = await ac.post(
@@ -584,6 +619,45 @@ async def test_trigger_backfill_org_scoped(client, seeded_state):
     assert data["status"] == "accepted"
     assert captured_request["org_id"] == seeded_state["org_id"]
     assert captured_request["mode"] == "backfill"
+
+
+@pytest.mark.asyncio
+async def test_trigger_backfill_marks_run_failed_when_enqueue_fails(
+    client,
+    session_maker,
+):
+    ac, _ = client
+    created = await _create_integration(ac)
+    integration_id = created["id"]
+
+    mock_dispatch = MagicMock()
+    mock_dispatch.apply_async = MagicMock(side_effect=RuntimeError("broker down"))
+
+    with patch(
+        "dev_health_ops.api.admin.routers.integrations.dispatch_sync_run",
+        mock_dispatch,
+    ):
+        resp = await ac.post(
+            f"/api/v1/admin/integrations/{integration_id}/backfill",
+            json={
+                "since": "2024-01-01T00:00:00Z",
+                "before": "2024-02-01T00:00:00Z",
+            },
+        )
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "Task queue unavailable: broker down"
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(SyncRun).where(SyncRun.integration_id == uuid.UUID(integration_id))
+        )
+        run = result.scalar_one()
+
+    assert run.status == "failed"
+    assert run.mode == "backfill"
+    assert run.error == "Task queue unavailable: broker down"
+    assert run.completed_at is not None
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -946,6 +946,72 @@ async def test_trigger_passes_pending_run_id_to_task(client):
     assert call_kwargs.get("pending_run_id") == run_id
 
 
+@pytest.mark.asyncio
+async def test_trigger_commits_pending_job_run_before_enqueue(client, session_maker):
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session
+
+    ac, _ = client
+
+    create_resp = await _create_sync_config(
+        ac, name="pre-enqueue-commit-test", provider="github"
+    )
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+    sync_url = str(session_maker.kw["bind"].url).replace("sqlite+aiosqlite", "sqlite")
+
+    def assert_pending_run_is_visible(**_kwargs):
+        engine = create_engine(sync_url)
+        try:
+            with Session(engine) as session:
+                assert session.query(JobRun).count() == 1
+        finally:
+            engine.dispose()
+        return MagicMock(id="visible-task-id")
+
+    mock_run = MagicMock()
+    mock_run.apply_async.side_effect = assert_pending_run_is_visible
+
+    with patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_trigger_marks_pending_job_run_failed_when_enqueue_fails(
+    client, session_maker
+):
+    from dev_health_ops.models.settings import JobRunStatus
+
+    ac, _ = client
+
+    create_resp = await _create_sync_config(
+        ac, name="enqueue-failure-test", provider="github"
+    )
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+
+    mock_run = MagicMock()
+    mock_run.apply_async.side_effect = RuntimeError("broker down")
+
+    with patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 503
+    assert "broker down" in resp.json()["detail"]
+
+    async with session_maker() as session:
+        result = await session.execute(select(JobRun))
+        runs = list(result.scalars().all())
+
+    assert len(runs) == 1
+    run = runs[0]
+    assert run.status == JobRunStatus.FAILED.value
+    assert run.completed_at is not None
+    assert run.error == "dispatch enqueue failed: broker down"
+
+
 def test_sync_tasks_accept_pending_run_id_kwarg():
     """The dispatched Celery tasks must accept every kwarg the trigger endpoint
     passes. Celery validates kwargs against the task signature at dispatch time,

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -466,6 +466,9 @@ def test_local_compose_workers_import_mounted_source() -> None:
 
 def test_platform_compose_workers_and_beat_import_mounted_source() -> None:
     compose_path = _REPO_ROOT.parent / "compose.yml"
+    if not compose_path.exists():
+        pytest.skip("platform compose.yml is only present in the monorepo checkout")
+
     services = _load_yaml(compose_path).get("services") or {}
 
     for service_name in ("worker", "worker-ingest", "worker-heavy", "beat"):

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -23,6 +23,23 @@ def _parse_queues(command_str: str) -> set[str]:
     return queues
 
 
+def _stringify_command(value: object) -> str:
+    return (
+        " ".join(str(part) for part in value) if isinstance(value, list) else str(value)
+    )
+
+
+def _container_command_string(service: dict) -> str:
+    parts = []
+    entrypoint = service.get("entrypoint")
+    command = service.get("command")
+    if entrypoint:
+        parts.append(_stringify_command(entrypoint))
+    if command:
+        parts.append(_stringify_command(command))
+    return " ".join(parts)
+
+
 def test_compose_workers_cover_every_celery_queue() -> None:
     """CHAOS-2278: the union of -Q lists across all compose celery worker
     services must cover every queue declared in workers.config.task_queues.
@@ -41,11 +58,7 @@ def test_compose_workers_cover_every_celery_queue() -> None:
         command = service.get("command")
         if command is None:
             continue
-        command_str = (
-            " ".join(str(part) for part in command)
-            if isinstance(command, list)
-            else str(command)
-        )
+        command_str = _container_command_string(service)
         tokens = command_str.split()
         if "celery" not in tokens or "worker" not in tokens:
             continue
@@ -102,11 +115,7 @@ def test_monitoring_queue_declared_and_consumed_redundantly() -> None:
         command = service.get("command")
         if command is None:
             continue
-        command_str = (
-            " ".join(str(part) for part in command)
-            if isinstance(command, list)
-            else str(command)
-        )
+        command_str = _container_command_string(service)
         tokens = command_str.split()
         if "celery" not in tokens or "worker" not in tokens:
             continue
@@ -137,12 +146,7 @@ def _load_yaml(path: Path) -> dict:
 
 
 def _command_string(service: dict) -> str:
-    command = service.get("command") or service.get("entrypoint") or ""
-    return (
-        " ".join(str(part) for part in command)
-        if isinstance(command, list)
-        else str(command)
-    )
+    return _container_command_string(service)
 
 
 def _is_beat_service(name: str, service: dict) -> bool:
@@ -385,6 +389,110 @@ def test_celery_worker_prefetch_multiplier_is_one() -> None:
     from dev_health_ops.workers.config import worker_prefetch_multiplier
 
     assert worker_prefetch_multiplier == 1
+
+
+def test_celery_worker_prefetch_is_disabled_for_redis() -> None:
+    from dev_health_ops.workers.config import worker_disable_prefetch
+
+    assert worker_disable_prefetch is True
+
+
+def test_stream_consumer_beat_ticks_do_not_outlive_cadence() -> None:
+    from dev_health_ops.api.ingest.consumer import BLOCK_MS as INGEST_BLOCK_MS
+    from dev_health_ops.api.product_telemetry.consumer import (
+        BLOCK_MS as PRODUCT_TELEMETRY_BLOCK_MS,
+    )
+    from dev_health_ops.workers.config import beat_schedule
+
+    cases = {
+        "process-ingest-streams": INGEST_BLOCK_MS,
+        "process-product-telemetry-streams": PRODUCT_TELEMETRY_BLOCK_MS,
+    }
+
+    for entry_name, block_ms in cases.items():
+        entry = beat_schedule[entry_name]
+        schedule_seconds = float(entry["schedule"])
+        max_iterations = int(entry["kwargs"]["max_iterations"])
+
+        assert (max_iterations * block_ms) / 1000 < schedule_seconds
+        assert entry["options"] == {"queue": "ingest", "expires": 30}
+
+
+def test_worker_commands_disable_prefetch_for_redis() -> None:
+    for path in (_REPO_ROOT / "compose.yml", _PROD_COMPOSE, _SWARM_STACK):
+        services = _load_yaml(path).get("services") or {}
+        worker_commands = [
+            _command_string(service).split()
+            for service in services.values()
+            if "worker" in _command_string(service).split()
+        ]
+
+        assert worker_commands
+        for command in worker_commands:
+            assert "--disable-prefetch" in command
+
+    k8s_commands: list[list[str]] = []
+    for doc in yaml.safe_load_all((_K8S_DIR / "worker.yaml").read_text()):
+        if not doc or doc.get("kind") != "Deployment":
+            continue
+        for container in doc["spec"]["template"]["spec"].get("containers") or []:
+            command = container.get("command") or []
+            if "worker" in command:
+                k8s_commands.append(command)
+
+    assert k8s_commands
+    for command in k8s_commands:
+        assert "--disable-prefetch" in command
+
+    helm_templates = [
+        _HELM_DIR / "templates" / "worker-deployment.yaml",
+        _HELM_DIR / "templates" / "worker-pools.yaml",
+    ]
+    for template in helm_templates:
+        text = template.read_text(encoding="utf-8")
+        assert "--disable-prefetch" in text
+
+
+def test_local_compose_workers_import_mounted_source() -> None:
+    services = _load_yaml(_REPO_ROOT / "compose.yml").get("services") or {}
+
+    for service_name in ("worker", "worker-ingest", "worker-heavy"):
+        service = services[service_name]
+        command = _command_string(service).split()
+        assert "worker" in command
+        assert service["environment"]["PYTHONPATH"] == "/app/src"
+        assert "./:/app" in service["volumes"]
+
+
+def test_platform_compose_workers_and_beat_import_mounted_source() -> None:
+    compose_path = _REPO_ROOT.parent / "compose.yml"
+    services = _load_yaml(compose_path).get("services") or {}
+
+    for service_name in ("worker", "worker-ingest", "worker-heavy", "beat"):
+        service = services[service_name]
+        assert service["environment"]["PYTHONPATH"] == "/app/src"
+        assert "./ops:/app" in service["volumes"]
+
+
+def test_compose_workers_override_runner_entrypoint() -> None:
+    for path in (_LEGACY_COMPOSE, _PROD_COMPOSE, _SWARM_STACK):
+        services = _load_yaml(path).get("services") or {}
+        for service_name in ("worker", "worker-ingest", "worker-heavy"):
+            service = services[service_name]
+            assert service["entrypoint"] == ["celery"]
+            command = _stringify_command(service["command"])
+            assert command.split()[0] != "celery"
+            assert "dev_health_ops.workers.celery_app" in command
+
+
+def test_production_workers_use_semantic_postgres_uri() -> None:
+    for path in (_PROD_COMPOSE, _SWARM_STACK):
+        services = _load_yaml(path).get("services") or {}
+        for service_name in ("api", "worker", "worker-ingest", "worker-heavy"):
+            environment = services[service_name]["environment"]
+            assert environment["POSTGRES_URI"].startswith("postgresql+asyncpg://")
+            assert environment["DATABASE_URI"].startswith("postgresql+asyncpg://")
+            assert environment["CLICKHOUSE_URI"].startswith("clickhouse://")
 
 
 def test_production_stacks_consume_monitoring_queue() -> None:

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -267,6 +267,28 @@ def test_run_sync_unit_failure_persists_failed_and_error(db_session, monkeypatch
     assert finalize_calls == [((str(run.id),), "sync")]
 
 
+def test_run_sync_unit_bootstrap_failure_enqueues_finalize(db_session, monkeypatch):
+    from dev_health_ops.workers.sync_bootstrap import SyncTaskBootstrap
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _patch_db_session(monkeypatch, db_session)
+    finalize_calls = _patch_finalize_apply(monkeypatch)
+
+    def fail_bootstrap(session, unit_id):
+        raise ValueError("missing source")
+
+    monkeypatch.setattr(SyncTaskBootstrap, "load", fail_bootstrap)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    assert result["status"] == "failed"
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert unit.error == "missing source"
+    assert finalize_calls == [((str(run.id),), "sync")]
+
+
 def test_run_sync_unit_skips_terminal_run_without_overwriting_unit(
     db_session, monkeypatch
 ):

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -493,7 +493,7 @@ def test_dispatch_sync_run_marks_run_failed_when_chord_enqueue_fails(
     monkeypatch.setattr(
         sync_units.finalize_sync_run, "si", lambda run_id: FakeSig(run_id)
     )
-    monkeypatch.setattr(sync_units, "group", lambda signatures: list(signatures))
+    monkeypatch.setattr(sync_units, "group", list)
     monkeypatch.setattr(
         sync_units, "chord", lambda header, callback: FailingChord(header, callback)
     )

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -107,6 +107,32 @@ def _seed_run(session, *, mode=SyncRunMode.INCREMENTAL.value):
     return run, unit
 
 
+def _seed_zero_unit_run(session):
+    org_id = str(uuid.uuid4())
+    integration = Integration(
+        org_id=org_id,
+        provider="linear",
+        name="linear-demo",
+        config={},
+        is_active=True,
+    )
+    session.add(integration)
+    session.flush()
+    run = SyncRun(
+        org_id=org_id,
+        integration_id=integration.id,
+        triggered_by="manual",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunStatus.PLANNED.value,
+        total_units=0,
+        completed_units=0,
+        failed_units=0,
+    )
+    session.add(run)
+    session.flush()
+    return run
+
+
 def _patch_runtime(monkeypatch):
     from dev_health_ops.workers import sync_units
     from dev_health_ops.workers.sync_bootstrap import ProviderRuntime
@@ -161,6 +187,37 @@ def test_run_sync_unit_success_persists_status_and_incremental_watermark(
     assert finalize_calls == [((str(run.id),), "sync")]
 
 
+def test_run_sync_unit_success_survives_finalize_enqueue_failure(
+    db_session, monkeypatch
+):
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters, "run_dataset_unit", lambda ctx, runtime: {"ok": True}
+    )
+
+    def fail_finalize_enqueue(*_args, **_kwargs):
+        raise RuntimeError("broker down")
+
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run, "apply_async", fail_finalize_enqueue
+    )
+
+    result = getattr(sync_units.run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    assert result["status"] == "success"
+    assert unit.status == SyncRunUnitStatus.SUCCESS.value
+    assert unit.result == {"ok": True}
+
+
 def test_run_sync_unit_success_skips_watermark_for_backfill(db_session, monkeypatch):
     from dev_health_ops.processors import dataset_adapters
     from dev_health_ops.workers.sync_units import run_sync_unit
@@ -208,6 +265,39 @@ def test_run_sync_unit_failure_persists_failed_and_error(db_session, monkeypatch
     assert unit.status == SyncRunUnitStatus.FAILED.value
     assert unit.error == "adapter failed"
     assert finalize_calls == [((str(run.id),), "sync")]
+
+
+def test_run_sync_unit_skips_terminal_run_without_overwriting_unit(
+    db_session, monkeypatch
+):
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    run.status = SyncRunStatus.FAILED.value
+    unit.status = SyncRunUnitStatus.DISPATCHING.value
+    unit.error = "broker down"
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    finalize_calls = _patch_finalize_apply(monkeypatch)
+
+    def fail_if_called(ctx, runtime):
+        raise AssertionError("terminal unit should not execute")
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", fail_if_called)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    assert result == {
+        "status": "skipped",
+        "unit_id": str(unit.id),
+        "reason": "terminal",
+    }
+    assert unit.status == SyncRunUnitStatus.DISPATCHING.value
+    assert unit.error == "broker down"
+    assert finalize_calls == []
 
 
 def test_finalize_once_only_dispatches_metrics_once(db_session, monkeypatch):
@@ -266,6 +356,29 @@ def test_finalize_aggregates_partial_failed(db_session, monkeypatch):
     assert run.status == SyncRunStatus.PARTIAL_FAILED.value
     assert run.completed_units == 1
     assert run.failed_units == 1
+
+
+def test_finalize_zero_unit_run_does_not_report_success(db_session, monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    run = _seed_zero_unit_run(db_session)
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setattr(sync_units, "_dispatch_post_sync_tasks", lambda **kwargs: None)
+
+    result = sync_units.finalize_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    assert result["status"] == "finalized"
+    assert run.status == SyncRunStatus.FAILED.value
+    assert run.completed_units == 0
+    assert run.failed_units == 0
+    assert run.error == "No sync units planned"
+    assert run.result == {
+        "completed_units": 0,
+        "failed_units": 0,
+        "reason": "no_sync_units_planned",
+    }
+    assert db_session.query(SyncRunPostDispatch).count() == 1
 
 
 def test_dispatch_sync_run_redispatches_only_planned_units(db_session, monkeypatch):
@@ -329,6 +442,52 @@ def test_dispatch_sync_run_redispatches_only_planned_units(db_session, monkeypat
     ]
     assert planned.status == SyncRunUnitStatus.DISPATCHING.value
     assert recent_dispatching.status == SyncRunUnitStatus.DISPATCHING.value
+
+
+def test_dispatch_sync_run_marks_run_failed_when_chord_enqueue_fails(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    _patch_db_session(monkeypatch, db_session)
+
+    class FakeSig:
+        def __init__(self, unit_id):
+            self.unit_id = unit_id
+
+        def set(self, *, queue):
+            return self
+
+    class FailingChord:
+        def __init__(self, header, callback):
+            self.header = header
+            self.callback = callback
+
+        def apply_async(self):
+            raise RuntimeError("broker down")
+
+    monkeypatch.setattr(sync_units.run_sync_unit, "s", lambda unit_id: FakeSig(unit_id))
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run, "si", lambda run_id: FakeSig(run_id)
+    )
+    monkeypatch.setattr(sync_units, "group", lambda signatures: list(signatures))
+    monkeypatch.setattr(
+        sync_units, "chord", lambda header, callback: FailingChord(header, callback)
+    )
+
+    with pytest.raises(RuntimeError, match="broker down"):
+        sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    db_session.refresh(unit)
+    assert run.status == SyncRunStatus.FAILED.value
+    assert run.completed_at is not None
+    assert run.error == "broker down"
+    assert run.result == {"error": "broker down", "phase": "dispatch_enqueue"}
+    assert run.failed_units == 1
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert unit.error == "broker down"
 
 
 def test_dispatch_sync_run_redispatches_stale_dispatching_units(


### PR DESCRIPTION
## Summary
- disable worker prefetch across local and deployment worker entrypoints
- bound stream-consumer beat ticks so ingest work cannot monopolize workers
- make sync trigger enqueue failures terminal instead of leaving runs/jobs planned or syncing
- prevent zero-unit SyncRuns, including Linear Sync Now no-work cases, from reporting success
- fix compose/swam API and worker database env split: Postgres semantic DB plus ClickHouse analytics DB

## Verification
- python -m pytest tests/api/admin/test_integrations.py tests/test_sync_units.py tests/api/admin/test_sync_configs.py tests/test_compose_config.py tests/test_worker_deploy_safety.py
- ruff format --check src/dev_health_ops/api/admin/routers/integrations.py src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/workers/config.py src/dev_health_ops/workers/sync_units.py tests/api/admin/test_integrations.py tests/api/admin/test_sync_configs.py tests/test_compose_config.py tests/test_sync_units.py
- ruff check src/dev_health_ops/api/admin/routers/integrations.py src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/workers/config.py src/dev_health_ops/workers/sync_units.py tests/api/admin/test_integrations.py tests/api/admin/test_sync_configs.py tests/test_compose_config.py tests/test_sync_units.py
- mypy src/dev_health_ops/api/admin/routers/integrations.py src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/workers/config.py src/dev_health_ops/workers/sync_units.py
- docker compose config worker worker-ingest worker-heavy
- docker compose -f deploy/docker-compose/compose.production.yml config api worker worker-ingest worker-heavy
- docker compose -f deploy/docker-swarm/stack.yml config api worker worker-ingest worker-heavy
- helm template dev-health deploy/helm/dev-health

Fixes CHAOS-2534