### PR TITLE
fix(backfill): resolve fan-out planner integration id via migrated link (CHAOS-2535)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -1234,12 +1234,32 @@ async def trigger_sync_config_backfill(
     from dev_health_ops.models.backfill import BackfillJob as BackfillJobModel
 
     windows = chunk_date_range(since=payload.since, before=payload.before, chunk_days=7)
-    fanout_backfill = os.getenv("SYNC_FANOUT_BACKFILL", "").strip().lower() in {
+    fanout_env = os.getenv("SYNC_FANOUT_BACKFILL", "").strip().lower() in {
         "1",
         "true",
         "yes",
         "on",
     }
+    # The worker only routes through the fan-out planner when the config was
+    # migrated to an Integration (config_migration.py) AND fan-out is enabled
+    # (global env override or the per-org migrated-routing flag). Mirror that
+    # decision here so the BackfillJob's initial chunk count and the response
+    # "mode" reflect the path the task will actually take.
+    migrated = getattr(config, "migrated_integration_id", None) is not None
+
+    def _routing_enabled(sync_session) -> bool:
+        from dev_health_ops.sync.trigger_routing import (
+            is_migrated_trigger_routing_enabled,
+        )
+
+        return is_migrated_trigger_routing_enabled(sync_session, org_id)
+
+    if not migrated:
+        fanout_backfill = False
+    elif fanout_env:
+        fanout_backfill = True
+    else:
+        fanout_backfill = await session.run_sync(_routing_enabled)
     backfill_job = BackfillJobModel(
         org_id=org_id,
         sync_config_id=uuid.UUID(config_id),

--- a/src/dev_health_ops/workers/sync_backfill.py
+++ b/src/dev_health_ops/workers/sync_backfill.py
@@ -107,6 +107,10 @@ def run_backfill(
     )
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.models.settings import IntegrationCredential, SyncConfiguration
+    from dev_health_ops.sync.trigger_routing import (
+        is_migrated_trigger_routing_enabled,
+        plan_request_for_config,
+    )
 
     sync_config_uuid = uuid.UUID(sync_config_id)
     started_at = datetime.now(timezone.utc)
@@ -114,7 +118,10 @@ def run_backfill(
     try:
         provider = ""
         sync_targets: list[str] = []
-        integration_id = sync_config_id
+        use_fanout = False
+        planner_integration_id = ""
+        planner_source_ids: tuple[str, ...] | None = None
+        planner_dataset_keys: tuple[str, ...] | None = None
         with get_postgres_session_sync() as session:
             config = (
                 session.query(SyncConfiguration)
@@ -128,8 +135,6 @@ def run_backfill(
                 raise ValueError(f"Sync configuration not found: {sync_config_id}")
 
             provider = str(config.provider or "").strip().lower()
-            sync_options = dict(config.sync_options or {})
-            integration_id = str(sync_options.get("integration_id") or sync_config_id)
             sync_targets = _normalize_sync_targets(
                 provider,
                 _as_str_list(config.sync_targets),
@@ -151,18 +156,33 @@ def run_backfill(
                     )
                 credentials = _credential_mapping(credential)
 
+            plan_req = plan_request_for_config(
+                config, triggered_by="backfill", mode="backfill"
+            )
+            fanout_requested = (
+                _sync_fanout_backfill_enabled()
+                or is_migrated_trigger_routing_enabled(session, org_id)
+            )
+            if plan_req is not None and fanout_requested:
+                use_fanout = True
+                planner_integration_id = plan_req.integration_id
+                planner_source_ids = plan_req.source_ids
+                planner_dataset_keys = plan_req.dataset_keys
+
         if backfill_job_id:
             _mark_backfill_job_running(backfill_job_id, started_at)
 
         since_date = date.fromisoformat(since)
         before_date = date.fromisoformat(before)
 
-        if _sync_fanout_backfill_enabled():
+        if use_fanout:
             result_payload = run_backfill_via_planner(
-                integration_id,
+                planner_integration_id,
                 since_date,
                 before_date,
                 org_id=org_id,
+                source_ids=planner_source_ids,
+                dataset_keys=planner_dataset_keys,
                 triggered_by="backfill",
             )
             if backfill_job_id:

--- a/tests/test_backfill_fanout.py
+++ b/tests/test_backfill_fanout.py
@@ -372,3 +372,189 @@ def test_run_backfill_uses_legacy_path_when_feature_flag_off(db_session, monkeyp
     assert legacy_calls[0]["sync_config_id"] == str(config.id)
     assert legacy_calls[0]["since"] == date(2026, 6, 1)
     assert legacy_calls[0]["before"] == date(2026, 6, 7)
+
+
+def test_run_backfill_task_fanout_resolves_migrated_integration_id(
+    db_session, monkeypatch
+):
+    """Fan-out backfill must plan against the migrated Integration id, not the
+    SyncConfiguration id (regression: the worker used to fall back to
+    sync_config_id and crash with 'Integration not found')."""
+    from dev_health_ops.backfill import runner
+    from dev_health_ops.workers import sync_backfill
+
+    integration = _create_integration(db_session)
+    _create_source(db_session, integration, "full-chaos/dev-health")
+    _create_dataset(db_session, integration, "commits")
+    config = SyncConfiguration(
+        name="migrated parent backfill",
+        provider="github",
+        org_id=ORG_ID,
+        sync_targets=["git"],
+        sync_options={},
+        is_active=True,
+        migrated_integration_id=integration.id,
+    )
+    db_session.add(config)
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setenv("SYNC_FANOUT_BACKFILL", "1")
+
+    captured: dict = {}
+
+    def _fake_planner(
+        integration_id,
+        since,
+        before,
+        *,
+        org_id,
+        source_ids=None,
+        dataset_keys=None,
+        triggered_by,
+    ):
+        captured.update(
+            integration_id=integration_id,
+            since=since,
+            before=before,
+            org_id=org_id,
+            source_ids=source_ids,
+            dataset_keys=dataset_keys,
+            triggered_by=triggered_by,
+        )
+        return {
+            "status": "success",
+            "sync_run_id": str(uuid.uuid4()),
+            "unit_count": 0,
+        }
+
+    monkeypatch.setattr(runner, "run_backfill_via_planner", _fake_planner)
+    monkeypatch.setattr(
+        runner,
+        "run_backfill_for_config",
+        lambda **kwargs: pytest.fail(
+            "legacy path should not run for a migrated config"
+        ),
+    )
+
+    run_backfill_task = getattr(sync_backfill.run_backfill, "run")
+    result = run_backfill_task(
+        sync_config_id=str(config.id),
+        since="2026-06-01",
+        before="2026-06-07",
+        org_id=ORG_ID,
+    )
+
+    assert result["status"] == "success"
+    assert captured["integration_id"] == str(integration.id)
+    assert captured["integration_id"] != str(config.id)
+    assert captured["source_ids"] is None  # parent => whole integration
+    assert captured["since"] == date(2026, 6, 1)
+    assert captured["before"] == date(2026, 6, 7)
+    assert captured["triggered_by"] == "backfill"
+
+
+def test_run_backfill_task_fanout_child_config_scopes_source(db_session, monkeypatch):
+    """A migrated child config must scope the planned run to its own source
+    (and the datasets derived from its legacy targets), mirroring
+    trigger_routing.plan_request_for_config."""
+    from dev_health_ops.backfill import runner
+    from dev_health_ops.sync.trigger_routing import _dataset_keys_for_config
+    from dev_health_ops.workers import sync_backfill
+
+    integration = _create_integration(db_session)
+    source = _create_source(db_session, integration, "full-chaos/dev-health")
+    _create_dataset(db_session, integration, "commits")
+    config = SyncConfiguration(
+        name="migrated child backfill",
+        provider="github",
+        org_id=ORG_ID,
+        sync_targets=["git"],
+        sync_options={},
+        is_active=True,
+        migrated_integration_id=integration.id,
+        migrated_source_id=source.id,
+    )
+    db_session.add(config)
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setenv("SYNC_FANOUT_BACKFILL", "1")
+
+    expected_dataset_keys = _dataset_keys_for_config(config) or None
+    captured: dict = {}
+
+    def _fake_planner(integration_id, since, before, **kwargs):
+        captured.update(integration_id=integration_id, **kwargs)
+        return {
+            "status": "success",
+            "sync_run_id": str(uuid.uuid4()),
+            "unit_count": 0,
+        }
+
+    monkeypatch.setattr(runner, "run_backfill_via_planner", _fake_planner)
+
+    run_backfill_task = getattr(sync_backfill.run_backfill, "run")
+    result = run_backfill_task(
+        sync_config_id=str(config.id),
+        since="2026-06-01",
+        before="2026-06-07",
+        org_id=ORG_ID,
+    )
+
+    assert result["status"] == "success"
+    assert captured["integration_id"] == str(integration.id)
+    assert captured["source_ids"] == (str(source.id),)
+    assert captured["dataset_keys"] == expected_dataset_keys
+
+
+def test_run_backfill_task_unmigrated_config_falls_back_to_legacy(
+    db_session, monkeypatch
+):
+    """Even with the global fan-out flag on, an un-migrated config (no
+    migrated_integration_id) must use the legacy per-config path instead of
+    crashing in the planner. This is the exact regression scenario."""
+    from dev_health_ops.backfill import runner
+    from dev_health_ops.workers import sync_backfill, sync_runtime
+
+    config = SyncConfiguration(
+        name="unmigrated backfill",
+        provider="github",
+        org_id=ORG_ID,
+        sync_targets=["git"],
+        sync_options={},
+        is_active=True,
+    )
+    db_session.add(config)
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setenv("SYNC_FANOUT_BACKFILL", "1")  # fan-out requested...
+    monkeypatch.setattr(sync_backfill, "_get_db_url", lambda: "clickhouse://test")
+    monkeypatch.setattr(
+        sync_runtime, "_dispatch_post_sync_tasks", lambda **kwargs: None
+    )
+
+    legacy_calls: list = []
+
+    def _fake_legacy(**kwargs):
+        legacy_calls.append(kwargs)
+        return {"status": "success"}
+
+    monkeypatch.setattr(runner, "run_backfill_for_config", _fake_legacy)
+    monkeypatch.setattr(
+        runner,
+        "run_backfill_via_planner",
+        lambda *args, **kwargs: pytest.fail(
+            "planner must not run for an un-migrated config"
+        ),
+    )
+
+    run_backfill_task = getattr(sync_backfill.run_backfill, "run")
+    result = run_backfill_task(
+        sync_config_id=str(config.id),
+        since="2026-06-01",
+        before="2026-06-07",
+        org_id=ORG_ID,
+    )
+
+    assert result["status"] == "success"
+    assert len(legacy_calls) == 1
+    assert legacy_calls[0]["sync_config_id"] == str(config.id)


### PR DESCRIPTION
## Summary

The work-item backfill **fan-out** path crashed on every run with `ValueError: Integration not found for org ...: <id>`. The failing `integration_id` was identical to the `sync_config_id`, revealing the root cause.

`run_backfill` resolved the planner's `integration_id` from `sync_options.get("integration_id")`, **which is never populated**. It fell back to `sync_config_id`, so `plan_sync_run` → `_load_integration` queried the `integrations` table by a `sync_configurations` PK and raised. The canonical config→integration link is the `SyncConfiguration.migrated_integration_id` column (written by `config_migration.py`), and routing already exists in `trigger_routing.plan_request_for_config`.

## Changes

- **`workers/sync_backfill.py`** — route fan-out through `plan_request_for_config(config, triggered_by="backfill", mode="backfill")`, which reads `migrated_integration_id` and scopes parent vs child configs. Fan-out fires only when the config is migrated **and** enabled (per-org `sync.migrated_trigger_routing_enabled` flag or `SYNC_FANOUT_BACKFILL` env override). Un-migrated configs fall back to the legacy per-config path instead of crashing. Removed the dead `sync_options` lookup.
- **`api/admin/routers/sync.py`** — align the backfill endpoint's `fanout`/`total_chunks`/`mode` decision with the worker (migrated + env-or-flag) instead of env-only, so the `BackfillJob` chunk count and the 202 `mode` field are truthful.
- **`tests/test_backfill_fanout.py`** — regression tests: planner receives the `Integration` id (not the config id); child configs scope to their source/datasets; un-migrated configs fall back to legacy without crashing.

## Verification

- `mypy` — clean (1135 source files)
- `ruff format` + `ruff check` — clean
- `pytest tests/test_backfill_fanout.py` — 8 passed (5 existing + 3 new)
- Adjacent suites (`test_trigger_routing`, `test_backfill_integration`, `test_sync_scheduler_routing`, `api/admin/test_sync_trigger_routing`) — 49 passed

SCREENSHOT-WAIVER: backend-only change (Celery worker + admin API routing logic); no rendered frontend output.

Closes CHAOS-2535