### PR TITLE
feat(llm): Bring Your Own LLM — credentials, models, error handling, spend controls (CHAOS-2349)

### DIFF
--- a/docs/architecture/byo-llm-architecture.md
+++ b/docs/architecture/byo-llm-architecture.md
@@ -1,0 +1,81 @@
+# BYO-LLM Architecture
+
+This page describes the architecture of the Bring Your Own LLM (BYO-LLM) system in the Dev Health platform.
+
+## Component Overview
+
+The BYO-LLM system integrates multiple entry points, a provider factory, and dual database storage.
+
+```mermaid
+flowchart TD
+    subgraph Callers [Entry Points]
+        CLI[CLI: dev-hops sync]
+        Worker[Celery Worker: work_graph_tasks]
+        API[API: explain endpoints]
+    end
+
+    subgraph Factory [Provider Factory]
+        GP[get_provider]
+        RP[resolve_provider_name]
+        RM[resolve_model_name]
+    end
+
+    subgraph Providers [LLM Providers]
+        OpenAI[OpenAIProvider]
+        Anthropic[AnthropicProvider]
+        Gemini[GeminiProvider]
+        Local[LocalProvider / Ollama / LMStudio]
+        Mock[MockProvider]
+        NoneP[NoneProvider]
+    end
+
+    subgraph Storage [Storage Layer]
+        Postgres[(Postgres: Org Settings)]
+        ClickHouse[(ClickHouse: Categorization Sink)]
+    end
+
+    CLI --> GP
+    Worker --> GP
+    API --> GP
+
+    GP --> RP
+    GP --> RM
+    
+    RP -.-> Postgres
+    RM -.-> Postgres
+
+    GP --> OpenAI
+    GP --> Anthropic
+    GP --> Gemini
+    GP --> Local
+    GP --> Mock
+    GP --> NoneP
+
+    API -.-> Postgres
+    Worker -.-> ClickHouse
+```
+
+## Core Components
+
+### 1. Entry Points
+- **CLI**: Operators run commands like `dev-hops sync` to trigger manual synchronization.
+- **Celery Worker**: Background tasks run partitioned materialization jobs.
+- **API**: Endpoints like `/api/v1/work-units/{work_unit_id}/explain` generate explanations on demand.
+
+### 2. Provider Factory
+The `get_provider` function acts as a central factory. It resolves the provider name and model, retrieves credentials, and instantiates the correct provider class.
+- **resolve_provider_name**: Determines which provider to use. It checks the requested name, the `LLM_PROVIDER` environment variable, and organization settings.
+- **resolve_model_name**: Resolves the model name. It checks the requested model, environment variables, organization settings, and provider defaults.
+
+### 3. LLM Providers
+The platform supports multiple provider implementations:
+- **OpenAIProvider**: Connects to OpenAI APIs.
+- **AnthropicProvider**: Connects to Anthropic APIs.
+- **GeminiProvider**: Connects to Google Gemini APIs.
+- **LocalProvider / Ollama / LMStudio**: Connects to local or custom OpenAI-compatible endpoints.
+- **MockProvider**: Returns deterministic mock responses for testing.
+- **NoneProvider**: Represents an unconfigured state and fails closed for materialization.
+
+### 4. Storage Layer
+- **Postgres**: Stores organization-scoped settings. The `SettingsService` encrypts sensitive values like API keys before saving them.
+- **ClickHouse**: Stores computed investment distributions and evidence quotes. The materializer writes directly to ClickHouse sinks.

--- a/docs/llm/byo-llm-credentials.md
+++ b/docs/llm/byo-llm-credentials.md
@@ -1,0 +1,54 @@
+# BYO-LLM Credential Resolution
+
+This page describes how the Dev Health platform resolves credentials for Bring Your Own LLM (BYO-LLM) configurations.
+
+## Resolution Precedence
+
+When a component requests an LLM provider, the system resolves the API key and base URL using a strict precedence order. The first source that provides a value wins.
+
+```mermaid
+flowchart TD
+    Start([Resolve Credentials]) --> CheckPerCall{Per-Call / CLI Flags?}
+    CheckPerCall -- Yes --> UsePerCall[Use api_key / base_url from arguments]
+    CheckPerCall -- No --> CheckEnv{Process Environment?}
+    
+    CheckEnv -- Yes --> UseEnv[Use provider-specific env variables]
+    CheckEnv -- No --> CheckOrg{Org Settings in Postgres?}
+    
+    CheckOrg -- Yes --> UseOrg[Decrypt and use org-scoped settings]
+    CheckOrg -- No --> CheckRequired{API Key Required?}
+    
+    UsePerCall --> CheckRequired
+    UseEnv --> CheckRequired
+    UseOrg --> CheckRequired
+    
+    CheckRequired -- Yes, but missing --> RaiseAuthError[Raise LLMAuthError]
+    CheckRequired -- No, or present --> ReturnCreds([Return LLMCredentials])
+```
+
+## Precedence Details
+
+1. **Per-Call Arguments / CLI Flags**:
+   Values passed directly to the function call (e.g., `--llm-api-key` or `--llm-base-url` from the CLI) take the highest priority.
+2. **Process Environment Variables**:
+   If no per-call arguments are present, the system checks the environment. Each provider has a list of environment variables it checks in order. For example, the `openai` provider checks `LLM_API_KEY` first, then `OPENAI_API_KEY`.
+3. **Organization Settings**:
+   If neither per-call arguments nor environment variables are set, the system queries the Postgres database for organization-scoped settings. These settings are stored under the `llm` category and decrypted using the `SettingsService`.
+
+## Provider Environment Variable Mapping
+
+The system maps providers to specific environment variables.
+
+| Provider | API Key Environment Variables | Base URL Environment Variables |
+|---|---|---|
+| `openai` | `LLM_API_KEY`, `OPENAI_API_KEY` | `LLM_BASE_URL`, `OPENAI_BASE_URL` |
+| `anthropic` | `LLM_API_KEY`, `ANTHROPIC_API_KEY` | `LLM_BASE_URL`, `ANTHROPIC_BASE_URL` |
+| `gemini` | `LLM_API_KEY`, `GEMINI_API_KEY` | `LLM_BASE_URL`, `GEMINI_BASE_URL` |
+| `qwen` | `LLM_API_KEY`, `QWEN_API_KEY`, `DASHSCOPE_API_KEY` | `LLM_BASE_URL`, `DASHSCOPE_BASE_URL` |
+| `local` | `LLM_API_KEY`, `LOCAL_LLM_API_KEY` | `LLM_BASE_URL`, `LOCAL_LLM_BASE_URL` |
+| `ollama` | `LLM_API_KEY`, `LOCAL_LLM_API_KEY` | `LLM_BASE_URL`, `OLLAMA_BASE_URL` |
+| `lmstudio` | `LLM_API_KEY`, `LOCAL_LLM_API_KEY` | `LLM_BASE_URL`, `LMSTUDIO_BASE_URL` |
+
+## Validation and Errors
+
+If a provider requires an API key (such as `openai`, `anthropic`, `gemini`, or `qwen`) and none is found after checking all sources, the system raises an `LLMAuthError`. This error lists the missing configuration options to help operators resolve the issue.

--- a/docs/llm/errors-circuit-breaker.md
+++ b/docs/llm/errors-circuit-breaker.md
@@ -1,0 +1,65 @@
+# LLM Error Taxonomy and Circuit-Breaker
+
+This page describes the unified LLM error hierarchy and the circuit-breaker behavior during investment materialization.
+
+## Error Taxonomy
+
+All provider implementations raise exceptions from a unified hierarchy. This allows callers to catch a single base exception instead of importing provider-specific classes.
+
+```
+LLMError (base)
+├── LLMAuthError          : Invalid or missing API key
+├── LLMRateLimitError     : Rate limit or quota exceeded (HTTP 429)
+├── LLMContextLengthError : Prompt exceeds model context window
+├── LLMServerError        : Transient server-side error (HTTP 5xx)
+└── LLMOutputError        : Empty or invalid output from model
+```
+
+## Circuit-Breaker Behavior
+
+During parallel investment materialization, the system uses a circuit-breaker pattern to fail fast on deterministic-fatal errors. This prevents wasting API tokens and avoids writing partial or fabricated data to the database.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant M as Materializer
+    participant T1 as LLM Task 1
+    participant T2 as LLM Task 2 (Pending)
+    participant S as ClickHouse Sink
+
+    M->>T1: Execute categorization
+    M->>T2: Execute categorization
+    
+    Note over T1: Deterministic-Fatal Error<br/>(e.g., invalid_api_key, quota_exceeded)
+    T1-->>M: Raise LLMAuthError / LLMError
+    
+    Note over M: Circuit Breaker Triggered
+    M->>T2: Cancel pending task
+    T2-->>M: TaskCancelled
+    
+    Note over M: Clean up and abort
+    M->>S: Close sink (no rows written)
+    M-->>M: Raise classified exception
+```
+
+## Failure Classification
+
+The system classifies failures into two categories:
+
+### 1. Deterministic-Fatal Failures
+These errors indicate a configuration or billing issue that will not resolve on retry. The circuit breaker triggers immediately, cancels all pending tasks, and aborts the run.
+- `invalid_api_key` / `missing_key`
+- `model_not_found`
+- `quota_exceeded`
+- Any `LLMAuthError`
+
+### 2. Transient Failures
+These errors are temporary and may resolve on retry. The system logs a warning and continues processing other tasks in the batch.
+- `rate_limit` (without quota exhaustion)
+- `server_error` (HTTP 5xx)
+- `output_error` (empty or invalid JSON)
+- `context_length` (specific to a single large prompt)
+
+## Retry-After Clamping
+
+For rate limit errors, the system respects the provider's `Retry-After` header. However, to prevent a worker from being pinned for an excessive duration, the system clamps the backoff delay to a maximum of 60 seconds.

--- a/docs/llm/materialize-fanout.md
+++ b/docs/llm/materialize-fanout.md
@@ -1,0 +1,92 @@
+# Materialize Fan-Out and Partitioning
+
+This page describes the partitioned fan-out and caching mechanisms used during investment materialization.
+
+## Partitioned Fan-Out Flow
+
+To handle large work graphs efficiently, the system partitions components and processes them in parallel using Celery chords.
+
+```mermaid
+flowchart TD
+    Start([Post-Sync Sync Trigger]) --> Dispatch[dispatch_investment_materialize_partitioned]
+    Dispatch --> FetchEdges[Fetch Work Graph Edges]
+    FetchEdges --> BuildComp[Build Components]
+    BuildComp --> Chunk[Split into Chunks of Size N]
+    
+    subgraph ChordHeader [Celery Chord Header]
+        Chunk1[run_investment_materialize_chunk 0]
+        Chunk2[run_investment_materialize_chunk 1]
+        ChunkN[run_investment_materialize_chunk N]
+    end
+    
+    Chunk --> ChordHeader
+    
+    subgraph ChunkExecution [Per-Chunk Execution]
+        CheckCP{Already Completed?}
+        CheckCP -- Yes --> SkipChunk[Skip Chunk]
+        CheckCP -- No --> MarkRunning[Mark Checkpoint Running]
+        MarkRunning --> Materialize[materialize_investments]
+        Materialize --> MarkDone[Mark Checkpoint Completed]
+    end
+    
+    ChordHeader --> ChunkExecution
+    
+    subgraph ChordCallback [Celery Chord Callback]
+        Finalize[finalize_investment_materialize_partitioned]
+        CheckBackfill{Run Membership Backfill?}
+        CheckBackfill -- Yes --> Backfill[backfill_memberships]
+        CheckBackfill -- No --> End([End])
+        Backfill --> End
+    end
+    
+    ChunkExecution --> Finalize
+    Finalize --> CheckBackfill
+```
+
+## Sequence of Execution
+
+The sequence diagram below shows the interaction between the dispatcher, chunk tasks, checkpoints, and the finalizer.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant D as Dispatcher
+    participant C as Celery Worker (Chunk)
+    participant P as Postgres (Checkpoints)
+    participant CH as ClickHouse (Sink)
+    participant F as Finalizer
+
+    D->>D: Fetch edges and build components
+    D->>D: Partition component indexes into chunks
+    D->>C: Dispatch chunks via Celery Chord
+    
+    Note over C: For each chunk task
+    C->>P: Check if already completed (is_completed)
+    P-->>C: Not completed
+    C->>P: Mark checkpoint running (mark_running)
+    
+    C->>CH: Query existing input hashes (if force=False)
+    CH-->>C: Return existing hashes
+    Note over C: Skip LLM for matching hashes
+    
+    C->>C: Run LLM for new/changed components
+    C->>CH: Write work_unit_investments
+    C->>P: Mark checkpoint completed (mark_completed)
+    
+    C->>F: Send chunk stats
+    Note over F: After all chunks complete
+    F->>F: Aggregate run statistics
+    F->>CH: Run membership backfill (if full run)
+    F-->>D: Return final summary
+```
+
+## Key Mechanisms
+
+### 1. Checkpoint Protocol
+Each chunk task is tracked in Postgres using a unique checkpoint scope ID derived from the `run_id` and `chunk_index`. If a task fails and retries, or if the worker restarts, the system checks the checkpoint table. Completed chunks are skipped, preventing redundant LLM calls.
+
+### 2. Input Hash Caching
+Before calling the LLM, the materializer computes a SHA-256 hash of the serialized evidence bundle for each component. If `force` is `False`, the system queries ClickHouse for existing valid records with the same hash and model version. Matching components are skipped. If `force` is `True`, the system bypasses this check and forces a fresh LLM call.
+
+### 3. Membership Backfill Unification
+To prevent partial-coverage bugs, the windowed materializer does not write `work_unit_membership` rows or completion markers. Instead, the finalizer triggers `backfill_memberships` at the end of a full run. This projection runs without the LLM, rebuilding the full work graph and projecting membership rows from the already persisted investments.

--- a/docs/llm/spend-observability.md
+++ b/docs/llm/spend-observability.md
@@ -1,0 +1,60 @@
+# LLM Spend Observability and Tracing
+
+This page describes how the Dev Health platform tracks LLM token usage, costs, and execution traces.
+
+## Observability Flow
+
+The system tracks token usage and execution details at both the individual call level and the aggregate run level.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant W as Celery Worker
+    participant M as Materializer
+    participant P as LLM Provider
+    participant O as OpenTelemetry (OTEL)
+    participant L as Logger / Sink
+
+    Note over W: Worker Bootstrap
+    W->>O: init_tracing() & instrument_celery()
+    
+    W->>M: run_investment_materialize_chunk()
+    
+    M->>P: complete(prompt)
+    Note over P: Call wrapped in OTEL span
+    P->>O: Start span (llm_call)
+    P-->>M: Return CompletionResult(text, input_tokens, output_tokens, model)
+    P->>O: End span with token attributes
+    
+    Note over M: Aggregate stats across all chunk tasks
+    M->>L: Log run-summary (calls, tokens, failures-by-class)
+    M-->>W: Return stats dictionary
+```
+
+## Token Tracking
+
+The `CompletionResult` dataclass captures token usage details returned by the provider APIs:
+- `input_tokens`: Number of tokens in the prompt.
+- `output_tokens`: Number of tokens in the response.
+- `model`: The exact model name used for the completion.
+
+Each provider implementation (e.g., OpenAI, Anthropic, Gemini) extracts these values from the raw API response and populates the `CompletionResult`.
+
+## OpenTelemetry Integration
+
+Tracing is initialized during the Celery worker bootstrap process. The `init_tracing` function configures the OpenTelemetry SDK with an OTLP gRPC exporter. The `instrument_celery` function then instruments all Celery tasks.
+
+Each LLM call is wrapped in an OpenTelemetry span. The span includes attributes for:
+- `llm.provider`: The provider name (e.g., `openai`).
+- `llm.model`: The model name (e.g., `gpt-5-mini`).
+- `llm.usage.input_tokens`: The prompt token count.
+- `llm.usage.output_tokens`: The completion token count.
+
+## Run-Summary Aggregation
+
+At the end of an investment materialization run, the system aggregates usage statistics across all processed components. The summary includes:
+- **Total Calls**: The sum of all successful and failed LLM calls.
+- **Token Counts**: Total input and output tokens consumed.
+- **Failures by Class**: A breakdown of errors categorized by class (e.g., `rate_limit`, `quota_exceeded`, `auth`, `server_error`, `context_length`, `output_error`).
+
+This summary is logged to the standard output and returned to the orchestrator for reporting.

--- a/docs/llm/user-flow.md
+++ b/docs/llm/user-flow.md
@@ -1,0 +1,65 @@
+# Bring Your Own Key (BYOK) User Flows
+
+This page describes the three primary user flows for configuring and using custom LLM credentials in the Dev Health platform.
+
+## Configuration Options
+
+Operators and administrators can configure LLM settings through three different channels.
+
+```mermaid
+flowchart TD
+    subgraph CLI [CLI Flow]
+        C1[Operator runs CLI command] --> C2[Pass flags: --llm-provider, --llm-api-key, --llm-base-url]
+        C2 --> C3[CLI passes values directly to MaterializeConfig]
+    end
+
+    subgraph Env [Environment Flow]
+        E1[Operator sets env variables] --> E2[Set LLM_PROVIDER, LLM_API_KEY, LLM_BASE_URL]
+        E2 --> E3[Credential resolver reads env variables]
+    end
+
+    subgraph API [Admin API Flow]
+        A1[Org Admin calls PUT /llm-settings] --> A2{License Tier >= TEAM?}
+        A2 -- No --> A3[Return HTTP 402 Payment Required]
+        A2 -- Yes --> A4[Encrypt API key and save to Postgres]
+        A4 --> A5[Celery worker loads and decrypts settings per-org]
+    end
+```
+
+## Detailed User Journeys
+
+### 1. Operator via CLI Flags
+This flow is ideal for local testing, one-off synchronizations, or debugging.
+- **Action**: The operator runs the sync command with explicit flags:
+  ```bash
+  dev-hops sync git --llm-provider openai --llm-api-key sk-... --llm-concurrency 10
+  ```
+- **Precedence**: These values bypass all environment variables and database settings.
+
+### 2. Operator via Environment Variables
+This flow is suitable for single-tenant deployments or containerized environments (e.g., Docker Compose, Kubernetes).
+- **Action**: The operator defines environment variables in the worker environment:
+  ```bash
+  export LLM_PROVIDER=anthropic
+  export ANTHROPIC_API_KEY=sk-ant-...
+  export INVESTMENT_LLM_CONCURRENCY=8
+  ```
+- **Precedence**: These values are used if no CLI flags are provided. They override database settings.
+
+### 3. Organization Admin via Admin API
+This flow is designed for multi-tenant SaaS deployments where individual organizations bring their own keys.
+- **Action**: The organization administrator configures settings through the admin dashboard, which calls the settings API:
+  ```http
+  PUT /api/v1/admin/llm-settings
+  Content-Type: application/json
+
+  {
+    "provider": "openai",
+    "model": "gpt-5-mini",
+    "api_key": "sk-...",
+    "base_url": "https://api.openai.com/v1"
+  }
+  ```
+- **Licensing Gate**: The API verifies that the organization's license tier is `TEAM` or higher. If the tier is lower (e.g., `FREE`), the request is rejected with an HTTP 402 error.
+- **Security**: The API key is encrypted before being stored in the Postgres database.
+- **Execution**: When a Celery task runs for the organization, the worker retrieves the settings from Postgres, decrypts the API key, and instantiates the provider.

--- a/docs/plans/code-review-action-plan-2026-05-17.md
+++ b/docs/plans/code-review-action-plan-2026-05-17.md
@@ -226,9 +226,9 @@ These were flagged in the review but couldn't be conclusively resolved without l
 
 The full review thread, including the parts that became these tickets, ran against:
 
-- [`AGENTS.md`](../../AGENTS.md) (canonical contract)
-- [`pyproject.toml`](../../pyproject.toml) (deps)
-- [`mkdocs.yml`](../../mkdocs.yml) (docs nav)
+- `AGENTS.md` (canonical contract)
+- `pyproject.toml` (deps)
+- `mkdocs.yml` (docs nav)
 - `src/dev_health_ops/api/auth/*`, `api/admin/*`, `api/graphql/*`, `api/ingest/*`, `api/middleware/*`
 - `src/dev_health_ops/connectors/*`, `providers/*`, `processors/*`
 - `src/dev_health_ops/metrics/sinks/*`, `storage/*`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,8 +18,8 @@ nav:
   - Home: index.md
   - Product:
       - PRD: product/prd.md
-      - Feature Flag and User Impact PRD: product/feature-flag-user-impact-prd.md
-      - Feature Flag PRD Review: product/feature-flag-prd-review.md
+      - Feature Flag and User Impact PRD: product/feature-flags/feature-flag-user-impact-prd.md
+      - Feature Flag PRD Review: product/feature-flags/feature-flag-prd-review.md
       - Product Brief: product/product-brief.md
       - Concepts: product/concepts.md
       - Investment Taxonomy: product/investment-taxonomy.md
@@ -50,6 +50,7 @@ nav:
       - Enterprise Overview: architecture/enterprise-overview.md
       - Licensing: architecture/licensing.md
       - ADR-001 Enterprise Edition: architecture/adr/001-enterprise-edition.md
+      - BYO-LLM Architecture: architecture/byo-llm-architecture.md
   - Operations:
       - Observability Tooling: ops/observability-tooling.md
       - Deployment Guide: ops/deployment-guide.md
@@ -109,7 +110,13 @@ nav:
       - Team Catalog Source of Truth: api/team-catalog-source-of-truth.md
       - Operating Review Aggregation: api/operating-review.md
   - Visualizations: visualizations/patterns.md
-  - LLM: llm/categorization-contract.md
+  - LLM:
+      - Categorization Contract: llm/categorization-contract.md
+      - Credential Resolution: llm/byo-llm-credentials.md
+      - Errors and Circuit-Breaker: llm/errors-circuit-breaker.md
+      - Materialize Fan-Out: llm/materialize-fanout.md
+      - Spend Observability: llm/spend-observability.md
+      - User Flows: llm/user-flow.md
   - Task Trackers: task_trackers.md
   - Roadmap: roadmap.md
   - Project Plan: project.md

--- a/src/dev_health_ops/api/admin/routers/settings.py
+++ b/src/dev_health_ops/api/admin/routers/settings.py
@@ -43,6 +43,24 @@ def _mask_api_key(value: str | None) -> str | None:
     return f"{value[:4]}…{value[-4:]}"
 
 
+def _reject_llm_category(category: str) -> None:
+    # LLM settings are tier-gated, force-encrypted, and masked; they must only
+    # be managed via the dedicated /llm-settings endpoints. The generic settings
+    # routes would otherwise let any org admin write/read category='llm' rows
+    # (bypassing the BYO-LLM tier gate and exposing the raw api_key).
+    if category == SettingCategory.LLM.value:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "use_llm_settings_endpoint",
+                "message": (
+                    "LLM settings must be managed via /admin/llm-settings "
+                    "(tier-gated, encrypted, masked)."
+                ),
+            },
+        )
+
+
 async def _require_byo_llm_tier(session: AsyncSession, org_id: str) -> None:
     org_uuid = uuid.UUID(org_id)
     result = await session.execute(
@@ -90,6 +108,7 @@ async def list_settings_by_category(
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> SettingsListResponse:
+    _reject_llm_category(category)
     svc = SettingsService(session, org_id)
     settings = await svc.list_by_category(category)
     return SettingsListResponse(
@@ -167,12 +186,22 @@ async def get_setting(
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> SettingResponse:
+    _reject_llm_category(category)
     svc = SettingsService(session, org_id)
-    value = await svc.get(key, category)
-    if value is None:
+    rows = await svc.list_by_category(category)
+    row = next((s for s in rows if s.get("key") == key), None)
+    if row is None:
         raise HTTPException(status_code=404, detail="Setting not found")
-    return SettingResponse(
-        key=key, value=value, category=category, is_encrypted=False, description=None
+    # Never return decrypted values from the generic endpoint; _setting_response
+    # masks encrypted settings as [ENCRYPTED].
+    return _setting_response(
+        SettingResponse(
+            key=key,
+            value=row.get("value"),
+            category=category,
+            is_encrypted=bool(row.get("is_encrypted", False)),
+            description=row.get("description"),
+        )
     )
 
 
@@ -184,6 +213,7 @@ async def set_setting(
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> SettingResponse:
+    _reject_llm_category(category)
     svc = SettingsService(session, org_id)
     setting = await svc.set(
         key=key,
@@ -201,6 +231,7 @@ async def create_setting(
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> SettingResponse:
+    _reject_llm_category(payload.category)
     svc = SettingsService(session, org_id)
     setting = await svc.set(
         key=payload.key,
@@ -219,6 +250,7 @@ async def delete_setting(
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> dict:
+    _reject_llm_category(category)
     svc = SettingsService(session, org_id)
     deleted = await svc.delete(key, category)
     if not deleted:

--- a/src/dev_health_ops/api/admin/routers/settings.py
+++ b/src/dev_health_ops/api/admin/routers/settings.py
@@ -1,21 +1,31 @@
 from __future__ import annotations
 
+import uuid
+
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.admin.middleware import get_admin_org_id
 from dev_health_ops.api.admin.schemas import (
+    LLMSettingsResponse,
+    LLMSettingsUpsert,
     SettingCreate,
     SettingResponse,
     SettingsListResponse,
     SettingUpdate,
 )
 from dev_health_ops.api.services.configuration import SettingsService
+from dev_health_ops.api.services.licensing import resolve_org_tier
+from dev_health_ops.licensing.types import TIER_ORDER, LicenseTier
+from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import SettingCategory
 
 from .common import get_session
 
 router = APIRouter()
+_LLM_SETTING_KEYS = ("provider", "model", "api_key", "base_url")
+_BYO_LLM_MIN_TIER = LicenseTier.TEAM
 
 
 def _setting_response(setting: object) -> SettingResponse:
@@ -23,6 +33,50 @@ def _setting_response(setting: object) -> SettingResponse:
     if response.is_encrypted:
         return response.model_copy(update={"value": "[ENCRYPTED]"})
     return response
+
+
+def _mask_api_key(value: str | None) -> str | None:
+    if not value:
+        return None
+    if len(value) <= 8:
+        return "********"
+    return f"{value[:4]}…{value[-4:]}"
+
+
+async def _require_byo_llm_tier(session: AsyncSession, org_id: str) -> None:
+    org_uuid = uuid.UUID(org_id)
+    result = await session.execute(
+        select(OrgLicense).where(OrgLicense.org_id == org_uuid)
+    )
+    org_license = result.scalar_one_or_none()
+
+    def _resolve(sync_session):
+        return resolve_org_tier(sync_session, org_uuid, org_license)
+
+    tier = await session.run_sync(_resolve)
+    if TIER_ORDER.index(tier) < TIER_ORDER.index(_BYO_LLM_MIN_TIER):
+        raise HTTPException(
+            status_code=402,
+            detail={
+                "error": "feature_not_licensed",
+                "feature": "byo_llm",
+                "required_tier": _BYO_LLM_MIN_TIER.value,
+                "current_tier": tier.value,
+            },
+        )
+
+
+async def _llm_settings_response(svc: SettingsService) -> LLMSettingsResponse:
+    provider = await svc.get("provider", SettingCategory.LLM.value)
+    model = await svc.get("model", SettingCategory.LLM.value)
+    api_key = await svc.get("api_key", SettingCategory.LLM.value)
+    base_url = await svc.get("base_url", SettingCategory.LLM.value)
+    return LLMSettingsResponse(
+        provider=provider,
+        model=model,
+        api_key=_mask_api_key(api_key),
+        base_url=base_url,
+    )
 
 
 @router.get("/settings/categories")
@@ -40,8 +94,70 @@ async def list_settings_by_category(
     settings = await svc.list_by_category(category)
     return SettingsListResponse(
         category=category,
-        settings=[SettingResponse(**s) for s in settings],
+        settings=[_setting_response(SettingResponse(**s)) for s in settings],
     )
+
+
+@router.get("/llm-settings", response_model=LLMSettingsResponse)
+async def get_llm_settings(
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> LLMSettingsResponse:
+    await _require_byo_llm_tier(session, org_id)
+    svc = SettingsService(session, org_id)
+    return await _llm_settings_response(svc)
+
+
+@router.put("/llm-settings", response_model=LLMSettingsResponse)
+async def upsert_llm_settings(
+    payload: LLMSettingsUpsert,
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> LLMSettingsResponse:
+    await _require_byo_llm_tier(session, org_id)
+    svc = SettingsService(session, org_id)
+    await svc.set(
+        "provider",
+        payload.provider.strip().lower(),
+        SettingCategory.LLM.value,
+        description="BYO LLM provider for this organization",
+    )
+    await svc.set(
+        "model",
+        payload.model,
+        SettingCategory.LLM.value,
+        description="BYO LLM model for this organization",
+    )
+    if payload.api_key is not None:
+        await svc.set(
+            "api_key",
+            payload.api_key,
+            SettingCategory.LLM.value,
+            encrypt=True,
+            description="Encrypted BYO LLM API key for this organization",
+        )
+    await svc.set(
+        "base_url",
+        payload.base_url,
+        SettingCategory.LLM.value,
+        description="BYO LLM base URL for this organization",
+    )
+    return await _llm_settings_response(svc)
+
+
+@router.delete("/llm-settings")
+async def delete_llm_settings(
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> dict[str, bool]:
+    await _require_byo_llm_tier(session, org_id)
+    svc = SettingsService(session, org_id)
+    deleted = False
+    for key in _LLM_SETTING_KEYS:
+        deleted = (await svc.delete(key, SettingCategory.LLM.value)) or deleted
+    if not deleted:
+        raise HTTPException(status_code=404, detail="LLM settings not found")
+    return {"deleted": True}
 
 
 @router.get("/settings/{category}/{key}", response_model=SettingResponse)

--- a/src/dev_health_ops/api/admin/schemas/__init__.py
+++ b/src/dev_health_ops/api/admin/schemas/__init__.py
@@ -51,6 +51,8 @@ from dev_health_ops.api.admin.schemas_flat import (  # noqa: F401
     IPCheckResponse,
     JiraActivityInferenceResponse,
     JobRunResponse,
+    LLMSettingsResponse,
+    LLMSettingsUpsert,
     MemberMatchResult,
     MembershipCreate,
     MembershipResponse,

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -35,6 +35,20 @@ class SettingsListResponse(BaseModel):
     settings: list[SettingResponse]
 
 
+class LLMSettingsResponse(BaseModel):
+    provider: str | None = None
+    model: str | None = None
+    api_key: str | None = None
+    base_url: str | None = None
+
+
+class LLMSettingsUpsert(BaseModel):
+    provider: str = Field(..., min_length=1)
+    model: str | None = None
+    api_key: str | None = None
+    base_url: str | None = None
+
+
 class IntegrationCredentialResponse(BaseModel):
     id: str
     provider: str

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -615,7 +615,9 @@ async def work_unit_explain_endpoint(
         # broken stream (the error would otherwise surface inside
         # keep_alive_wrapper after headers are already sent).
         try:
-            resolved_provider = get_provider(llm_provider, model=llm_model)
+            resolved_provider = get_provider(
+                llm_provider, model=llm_model, org_id=current_user.org_id
+            )
         except (ValueError, LLMError) as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 
@@ -653,6 +655,7 @@ async def work_unit_explain_endpoint(
                     llm_provider=llm_provider,
                     llm_model=llm_model,
                     provider=resolved_provider,
+                    org_id=current_user.org_id,
                 )
             ),
             media_type="application/json",

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -26,6 +26,7 @@ from dev_health_ops.api.middleware.rate_limit import limiter
 from dev_health_ops.api.product_telemetry import router as product_telemetry_router
 from dev_health_ops.api.telemetry.router import router as telemetry_router
 from dev_health_ops.llm import get_provider
+from dev_health_ops.llm.errors import LLMError
 
 from ._errors import (
     _generic_exception_handler as _generic_exception_handler,
@@ -615,7 +616,7 @@ async def work_unit_explain_endpoint(
         # keep_alive_wrapper after headers are already sent).
         try:
             resolved_provider = get_provider(llm_provider, model=llm_model)
-        except ValueError as exc:
+        except (ValueError, LLMError) as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 
         filters = _filters_from_query(

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -26,7 +26,12 @@ from dev_health_ops.api.middleware.rate_limit import limiter
 from dev_health_ops.api.product_telemetry import router as product_telemetry_router
 from dev_health_ops.api.telemetry.router import router as telemetry_router
 from dev_health_ops.llm import get_provider
-from dev_health_ops.llm.errors import LLMError
+from dev_health_ops.llm.errors import (
+    LLMAuthError,
+    LLMError,
+    LLMRateLimitError,
+    LLMServerError,
+)
 
 from ._errors import (
     _generic_exception_handler as _generic_exception_handler,
@@ -310,6 +315,16 @@ async def keep_alive_wrapper(coro):
                 "detail": "An internal streaming error occurred.",
             }
         )
+
+
+def _http_exception_from_llm_error(exc: LLMError) -> HTTPException:
+    if isinstance(exc, LLMAuthError):
+        return HTTPException(status_code=422, detail=str(exc))
+    if isinstance(exc, LLMRateLimitError):
+        return HTTPException(status_code=429, detail=str(exc))
+    if isinstance(exc, LLMServerError):
+        return HTTPException(status_code=503, detail=str(exc))
+    return HTTPException(status_code=422, detail=str(exc))
 
 
 @app.get("/api/v1/meta", response_model=MetaResponse)
@@ -641,25 +656,20 @@ async def work_unit_explain_endpoint(
 
         target_investment = investments[0]
         logger.info(
-            "Generating streaming explanation for work_unit_id=%s",
+            "Generating explanation for work_unit_id=%s",
             sanitize_for_log(work_unit_id),
         )
 
-        # Return streaming response with keep-alive pings.
-        # Provider is pre-resolved above; pass it in to avoid a second
-        # get_provider() call (and a second credential check) inside the stream.
-        return StreamingResponse(
-            keep_alive_wrapper(
-                explain_work_unit(
-                    investment=target_investment,
-                    llm_provider=llm_provider,
-                    llm_model=llm_model,
-                    provider=resolved_provider,
-                    org_id=current_user.org_id,
-                )
-            ),
-            media_type="application/json",
-        )
+        try:
+            return await explain_work_unit(
+                investment=target_investment,
+                llm_provider=llm_provider,
+                llm_model=llm_model,
+                provider=resolved_provider,
+                org_id=current_user.org_id,
+            )
+        except LLMError as exc:
+            raise _http_exception_from_llm_error(exc) from exc
 
     except HTTPException:
         raise

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -25,6 +25,7 @@ init_tracing()
 from dev_health_ops.api.middleware.rate_limit import limiter
 from dev_health_ops.api.product_telemetry import router as product_telemetry_router
 from dev_health_ops.api.telemetry.router import router as telemetry_router
+from dev_health_ops.llm import get_provider
 
 from ._errors import (
     _generic_exception_handler as _generic_exception_handler,
@@ -572,7 +573,9 @@ async def work_units(
     "/api/v1/work-units/{work_unit_id}/explain",
     response_model=WorkUnitExplanation,
 )
+@limiter.limit("20/minute")
 async def work_unit_explain_endpoint(
+    request: Request,
     work_unit_id: str,
     scope_type: str = "org",
     scope_id: str = "",
@@ -606,6 +609,15 @@ async def work_unit_explain_endpoint(
         WorkUnitExplanation with summary, rationale, and uncertainty disclosure
     """
     try:
+        # Validate provider credentials before opening the stream so that a
+        # missing API key returns a 4xx JSON response instead of HTTP 200 +
+        # broken stream (the error would otherwise surface inside
+        # keep_alive_wrapper after headers are already sent).
+        try:
+            resolved_provider = get_provider(llm_provider, model=llm_model)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
         filters = _filters_from_query(
             scope_type, scope_id, range_days, range_days, start_date, end_date
         )
@@ -630,13 +642,16 @@ async def work_unit_explain_endpoint(
             sanitize_for_log(work_unit_id),
         )
 
-        # Return streaming response with keep-alive pings
+        # Return streaming response with keep-alive pings.
+        # Provider is pre-resolved above; pass it in to avoid a second
+        # get_provider() call (and a second credential check) inside the stream.
         return StreamingResponse(
             keep_alive_wrapper(
                 explain_work_unit(
                     investment=target_investment,
                     llm_provider=llm_provider,
                     llm_model=llm_model,
+                    provider=resolved_provider,
                 )
             ),
             media_type="application/json",

--- a/src/dev_health_ops/api/services/investment_mix_explain.py
+++ b/src/dev_health_ops/api/services/investment_mix_explain.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import logging
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 
 from dev_health_ops.api.utils.logging import sanitize_for_log
 from dev_health_ops.investment_taxonomy import SUBCATEGORIES, THEMES, theme_of
@@ -55,7 +55,7 @@ def _dominant_subcategory(subcategories: dict[str, float]) -> str | None:
 
 def _determine_confidence_level(
     quality_mean: float | None, quality_stddev: float | None
-) -> str:
+) -> Literal["high", "moderate", "low", "unknown"]:
     if quality_mean is None:
         return "unknown"
     if quality_mean >= 0.7 and (quality_stddev is None or quality_stddev < 0.15):
@@ -297,7 +297,7 @@ async def explain_investment_mix(
     full_prompt = build_prompt(base_prompt=prompt_text, payload=payload)
 
     provider = get_provider(llm_provider, model=llm_model)
-    raw = await provider.complete(full_prompt)
+    raw = await provider.complete_text(full_prompt)
     raw_len = len(raw) if raw is not None else 0
     if logger.isEnabledFor(logging.DEBUG):
         # Sanitize and truncate the LLM response before logging to avoid log injection.

--- a/src/dev_health_ops/api/services/work_unit_explain.py
+++ b/src/dev_health_ops/api/services/work_unit_explain.py
@@ -15,7 +15,7 @@ import logging
 import re
 from functools import lru_cache
 
-from dev_health_ops.llm import get_provider, is_llm_available
+from dev_health_ops.llm import LLMProvider, get_provider, is_llm_available
 from dev_health_ops.llm.explainers.work_unit_explainer import (
     build_explanation_prompt,
     extract_allowed_inputs,
@@ -43,6 +43,8 @@ async def explain_work_unit(
     investment: WorkUnitInvestment,
     llm_provider: str = "auto",
     llm_model: str | None = None,
+    *,
+    provider: LLMProvider | None = None,
 ) -> WorkUnitExplanation:
     """
     Generate an LLM explanation for a work unit's precomputed investment view.
@@ -62,7 +64,7 @@ async def explain_work_unit(
     Returns:
         Structured WorkUnitExplanation with validated content
     """
-    if not is_llm_available(llm_provider):
+    if provider is None and not is_llm_available(llm_provider):
         return WorkUnitExplanation(
             work_unit_id=investment.work_unit_id,
             ai_generated=False,
@@ -101,8 +103,12 @@ async def explain_work_unit(
     )
 
     # 3. Call LLM provider
-    provider = get_provider(llm_provider, model=llm_model)
-    raw_response = await provider.complete(prompt)
+    resolved_provider = (
+        provider
+        if provider is not None
+        else get_provider(llm_provider, model=llm_model)
+    )
+    raw_response = await resolved_provider.complete(prompt)
     logger.debug(
         "Received LLM response for work_unit_id=%s, length=%d",
         investment.work_unit_id,

--- a/src/dev_health_ops/api/services/work_unit_explain.py
+++ b/src/dev_health_ops/api/services/work_unit_explain.py
@@ -15,7 +15,12 @@ import logging
 import re
 from functools import lru_cache
 
-from dev_health_ops.llm import LLMProvider, get_provider, is_llm_available
+from dev_health_ops.llm import (
+    LLMProvider,
+    get_provider,
+    is_llm_available,
+    resolve_provider_name,
+)
 from dev_health_ops.llm.explainers.work_unit_explainer import (
     build_explanation_prompt,
     extract_allowed_inputs,
@@ -45,6 +50,7 @@ async def explain_work_unit(
     llm_model: str | None = None,
     *,
     provider: LLMProvider | None = None,
+    org_id: str | None = None,
 ) -> WorkUnitExplanation:
     """
     Generate an LLM explanation for a work unit's precomputed investment view.
@@ -64,7 +70,11 @@ async def explain_work_unit(
     Returns:
         Structured WorkUnitExplanation with validated content
     """
-    if provider is None and not is_llm_available(llm_provider):
+    if _should_return_non_ai_explanation(
+        llm_provider=llm_provider,
+        provider=provider,
+        org_id=org_id,
+    ):
         return WorkUnitExplanation(
             work_unit_id=investment.work_unit_id,
             ai_generated=False,
@@ -106,7 +116,7 @@ async def explain_work_unit(
     resolved_provider = (
         provider
         if provider is not None
-        else get_provider(llm_provider, model=llm_model)
+        else get_provider(llm_provider, model=llm_model, org_id=org_id)
     )
     raw_response = await resolved_provider.complete_text(prompt)
     logger.debug(
@@ -127,6 +137,22 @@ async def explain_work_unit(
 
     # 5. Parse and structure the response
     return _parse_llm_response(investment.work_unit_id, raw_response, investment)
+
+
+def _should_return_non_ai_explanation(
+    *,
+    llm_provider: str,
+    provider: LLMProvider | None,
+    org_id: str | None,
+) -> bool:
+    if provider is not None:
+        return provider.__class__.__name__ == "NoneProvider"
+    try:
+        if resolve_provider_name(llm_provider, org_id=org_id) == "none":
+            return True
+    except Exception:
+        return not is_llm_available(llm_provider, org_id=org_id)
+    return not is_llm_available(llm_provider, org_id=org_id)
 
 
 def _parse_llm_response(

--- a/src/dev_health_ops/api/services/work_unit_explain.py
+++ b/src/dev_health_ops/api/services/work_unit_explain.py
@@ -102,7 +102,7 @@ async def explain_work_unit(
 
     # 3. Call LLM provider
     provider = get_provider(llm_provider, model=llm_model)
-    raw_response = await provider.complete(prompt)
+    raw_response = await provider.complete_text(prompt)
     logger.debug(
         "Received LLM response for work_unit_id=%s, length=%d",
         investment.work_unit_id,

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -356,9 +356,6 @@ def _should_resolve_org(ns: argparse.Namespace) -> bool:
 _REQ_CLICKHOUSE = "clickhouse"
 _REQ_POSTGRES = "postgres"
 _REQ_ORG = "org"
-# ClickHouse supplied via a command's own ``--db`` flag (not the global
-# ``--analytics-db``). Used by commands like ``investment materialize`` whose
-# ``--db`` carries the ClickHouse DSN (default: CLICKHOUSE_URI).
 _REQ_SINK_DB = "sink_db"
 
 # Stable display order for messages/epilogs.
@@ -396,7 +393,7 @@ _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     ("audit", "schema"): frozenset({_REQ_CLICKHOUSE}),
     # --- other ClickHouse-backed commands ---
     ("recommendations", "compute"): frozenset({_REQ_CLICKHOUSE}),
-    ("investment", "materialize"): frozenset({_REQ_SINK_DB}),
+    ("investment", "materialize"): frozenset({_REQ_CLICKHOUSE}),
     ("ai", "allowlist", "list"): frozenset({_REQ_CLICKHOUSE, _REQ_ORG}),
     ("ai", "allowlist", "set"): frozenset({_REQ_CLICKHOUSE, _REQ_ORG}),
     # --- PostgreSQL semantic store ---

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -8,10 +8,14 @@ import inspect
 import io
 import logging
 import os
+import re
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+_DOTENV_INTERPOLATION_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-(.*?))?\}")
+_DOTENV_MALFORMED_INTERPOLATION_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)?")
 
 
 def resolve_org_id(ns: argparse.Namespace) -> str | None:
@@ -22,6 +26,30 @@ def resolve_org_id(ns: argparse.Namespace) -> str | None:
     follow-up tracked per-function.
     """
     return getattr(ns, "org", None) or None
+
+
+def _expand_dotenv_value(key: str, value: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        fallback = match.group(2)
+        env_value = os.environ.get(name)
+        if env_value is not None and env_value != "":
+            return env_value
+        if fallback is not None:
+            return fallback
+        if env_value == "":
+            return ""
+        raise ValueError(
+            f".env value for {key} references {name}, but {name} is not set"
+        )
+
+    expanded = _DOTENV_INTERPOLATION_RE.sub(replace, value)
+    malformed = _DOTENV_MALFORMED_INTERPOLATION_RE.search(expanded)
+    if malformed:
+        name = malformed.group(1)
+        detail = f" for {name}" if name else ""
+        raise ValueError(f".env value for {key} has malformed interpolation{detail}")
+    return expanded
 
 
 def _load_dotenv(path: Path) -> int:
@@ -47,6 +75,7 @@ def _load_dotenv(path: Path) -> int:
             continue
         if (len(value) >= 2) and ((value[0] == value[-1]) and value[0] in {"'", '"'}):
             value = value[1:-1]
+        value = _expand_dotenv_value(key, value)
         os.environ[key] = value
         loaded += 1
     return loaded
@@ -707,7 +736,11 @@ def main(argv: list[str] | None = None) -> int:
         "yes",
         "on",
     }:
-        _load_dotenv(REPO_ROOT / ".env")
+        try:
+            _load_dotenv(REPO_ROOT / ".env")
+        except ValueError as exc:
+            print(f"dotenv error: {exc}", file=sys.stderr)
+            return 2
 
     quiet_json_inspect = _is_workers_inspect_json_invocation(argv)
     previous_otel_enabled = os.environ.get("OTEL_ENABLED")

--- a/src/dev_health_ops/llm/__init__.py
+++ b/src/dev_health_ops/llm/__init__.py
@@ -1,3 +1,8 @@
+from .credentials import (
+    LLMCredentials,
+    resolve_llm_credentials,
+    resolve_llm_org_settings_credentials,
+)
 from .errors import (
     LLMAuthError,
     LLMContextLengthError,
@@ -26,6 +31,9 @@ __all__ = [
     "is_llm_available",
     "resolve_model_name",
     "resolve_provider_name",
+    "LLMCredentials",
+    "resolve_llm_credentials",
+    "resolve_llm_org_settings_credentials",
     # Error types
     "LLMError",
     "LLMAuthError",

--- a/src/dev_health_ops/llm/__init__.py
+++ b/src/dev_health_ops/llm/__init__.py
@@ -10,12 +10,22 @@ from .errors import (
     is_retryable,
     retry_delay,
 )
-from .providers import LLMProvider, get_provider, is_llm_available
+from .providers import (
+    CompletionResult,
+    LLMProvider,
+    get_provider,
+    is_llm_available,
+    resolve_model_name,
+    resolve_provider_name,
+)
 
 __all__ = [
     "LLMProvider",
+    "CompletionResult",
     "get_provider",
     "is_llm_available",
+    "resolve_model_name",
+    "resolve_provider_name",
     # Error types
     "LLMError",
     "LLMAuthError",

--- a/src/dev_health_ops/llm/cli.py
+++ b/src/dev_health_ops/llm/cli.py
@@ -2,23 +2,31 @@ import argparse
 import os
 
 
-def add_llm_arguments(parser: argparse.ArgumentParser) -> None:
+def add_llm_arguments(
+    parser: argparse.ArgumentParser, *, leaf_mode: bool = False
+) -> None:
     """
     Standardize LLM provider and model arguments across the CLI.
 
     Args:
         parser: The argparse parser or subparser to add arguments to.
+        leaf_mode: Use ``default=SUPPRESS`` for subparsers that re-add these
+            global options so root-position values are not clobbered.
     """
+    provider_default = (
+        argparse.SUPPRESS if leaf_mode else os.getenv("LLM_PROVIDER", "auto")
+    )
+    model_default = argparse.SUPPRESS if leaf_mode else os.getenv("LLM_MODEL")
     parser.add_argument(
         "-l",
         "--llm-provider",
-        default=os.getenv("LLM_PROVIDER", "auto"),
+        default=provider_default,
         help="LLM provider (auto, openai, anthropic, local, mock, none). "
         "Use 'none' to compute distributions without LLM explanations.",
     )
     parser.add_argument(
         "-m",
         "--model",
-        default=os.getenv("LLM_MODEL"),
+        default=model_default,
         help="LLM model name (overrides provider default)",
     )

--- a/src/dev_health_ops/llm/cli.py
+++ b/src/dev_health_ops/llm/cli.py
@@ -2,6 +2,16 @@ import argparse
 import os
 
 
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
 def add_llm_arguments(
     parser: argparse.ArgumentParser, *, leaf_mode: bool = False
 ) -> None:
@@ -17,6 +27,11 @@ def add_llm_arguments(
         argparse.SUPPRESS if leaf_mode else os.getenv("LLM_PROVIDER", "auto")
     )
     model_default = argparse.SUPPRESS if leaf_mode else os.getenv("LLM_MODEL")
+    api_key_default = argparse.SUPPRESS if leaf_mode else os.getenv("LLM_API_KEY")
+    base_url_default = argparse.SUPPRESS if leaf_mode else os.getenv("LLM_BASE_URL")
+    concurrency_default = (
+        argparse.SUPPRESS if leaf_mode else _env_int("INVESTMENT_LLM_CONCURRENCY", 5)
+    )
     parser.add_argument(
         "-l",
         "--llm-provider",
@@ -29,4 +44,20 @@ def add_llm_arguments(
         "--model",
         default=model_default,
         help="LLM model name (overrides provider default)",
+    )
+    parser.add_argument(
+        "--llm-api-key",
+        default=api_key_default,
+        help="LLM API key for this inline invocation. Env: LLM_API_KEY.",
+    )
+    parser.add_argument(
+        "--llm-base-url",
+        default=base_url_default,
+        help="LLM provider base URL for this invocation. Env: LLM_BASE_URL.",
+    )
+    parser.add_argument(
+        "--llm-concurrency",
+        type=int,
+        default=concurrency_default,
+        help="Maximum concurrent LLM categorizations. Env: INVESTMENT_LLM_CONCURRENCY (default: 5).",
     )

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+from dev_health_ops.llm.errors import LLMAuthError
+
+
+@dataclass(frozen=True)
+class LLMCredentials:
+    api_key: str = field(default="", repr=False)
+    base_url: str = ""
+
+
+_API_KEY_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
+    "openai": ("LLM_API_KEY", "OPENAI_API_KEY"),
+    "anthropic": ("LLM_API_KEY", "ANTHROPIC_API_KEY"),
+    "gemini": ("LLM_API_KEY", "GEMINI_API_KEY"),
+    "qwen": ("LLM_API_KEY", "QWEN_API_KEY", "DASHSCOPE_API_KEY"),
+    "local": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
+    "ollama": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
+    "lmstudio": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
+    "qwen-local": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
+    "qwen-lmstudio": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
+}
+
+_BASE_URL_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
+    "openai": ("LLM_BASE_URL", "OPENAI_BASE_URL"),
+    "anthropic": ("LLM_BASE_URL", "ANTHROPIC_BASE_URL"),
+    "gemini": ("LLM_BASE_URL", "GEMINI_BASE_URL"),
+    "qwen": ("LLM_BASE_URL", "DASHSCOPE_BASE_URL"),
+    "local": ("LLM_BASE_URL", "LOCAL_LLM_BASE_URL"),
+    "ollama": ("LLM_BASE_URL", "OLLAMA_BASE_URL"),
+    "lmstudio": ("LLM_BASE_URL", "LMSTUDIO_BASE_URL"),
+    "qwen-local": ("LLM_BASE_URL", "OLLAMA_BASE_URL"),
+    "qwen-lmstudio": ("LLM_BASE_URL", "LMSTUDIO_BASE_URL"),
+}
+
+_API_KEY_REQUIRED_PROVIDERS = {"openai", "anthropic", "gemini", "qwen"}
+
+
+def _first_env(names: tuple[str, ...]) -> str:
+    for name in names:
+        value = os.getenv(name)
+        if value:
+            return value
+    return ""
+
+
+def _normalize_provider(provider: str) -> str:
+    return (provider or "auto").strip().lower()
+
+
+def resolve_llm_org_settings_credentials(
+    provider: str, *, org_id: str | None = None
+) -> LLMCredentials:
+    return LLMCredentials()
+
+
+def resolve_llm_credentials(
+    provider: str,
+    *,
+    org_id: str | None = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> LLMCredentials:
+    provider_name = _normalize_provider(provider)
+    env_api_key = _first_env(_API_KEY_ENV_BY_PROVIDER.get(provider_name, ()))
+    env_base_url = _first_env(_BASE_URL_ENV_BY_PROVIDER.get(provider_name, ()))
+    org_credentials = resolve_llm_org_settings_credentials(provider_name, org_id=org_id)
+
+    resolved = LLMCredentials(
+        api_key=str(api_key or env_api_key or org_credentials.api_key or ""),
+        base_url=str(base_url or env_base_url or org_credentials.base_url or ""),
+    )
+    if provider_name in _API_KEY_REQUIRED_PROVIDERS and not resolved.api_key:
+        env_names = ", ".join(_API_KEY_ENV_BY_PROVIDER.get(provider_name, ()))
+        raise LLMAuthError(
+            f"Missing API key for LLM provider '{provider_name}'. Set --llm-api-key, {env_names}, or org-scoped LLM settings.",
+            provider=provider_name,
+        )
+    return resolved

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from typing import Any
 
 from dev_health_ops.llm.errors import LLMAuthError
 
@@ -37,6 +38,11 @@ _BASE_URL_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
 }
 
 _API_KEY_REQUIRED_PROVIDERS = {"openai", "anthropic", "gemini", "qwen"}
+_LLM_SETTINGS_CATEGORY = "llm"
+_LLM_PROVIDER_KEY = "provider"
+_LLM_MODEL_KEY = "model"
+_LLM_API_KEY_KEY = "api_key"
+_LLM_BASE_URL_KEY = "base_url"
 
 
 def _first_env(names: tuple[str, ...]) -> str:
@@ -51,10 +57,69 @@ def _normalize_provider(provider: str) -> str:
     return (provider or "auto").strip().lower()
 
 
+def _load_org_llm_settings(org_id: str | None) -> dict[str, str]:
+    if not org_id:
+        return {}
+
+    try:
+        from sqlalchemy import select
+
+        from dev_health_ops.core.encryption import decrypt_value
+        from dev_health_ops.db import get_postgres_session_sync
+        from dev_health_ops.models.settings import Setting, SettingCategory
+    except Exception:
+        return {}
+
+    try:
+        with get_postgres_session_sync() as session:
+            result = session.execute(
+                select(Setting).where(
+                    Setting.org_id == org_id,
+                    Setting.category == SettingCategory.LLM.value,
+                )
+            )
+            rows: list[Any] = list(result.scalars().all())
+    except Exception:
+        return {}
+
+    settings: dict[str, str] = {}
+    for row in rows:
+        value = row.value or ""
+        if row.is_encrypted and value:
+            try:
+                value = decrypt_value(value)
+            except ValueError:
+                continue
+        if value:
+            settings[str(row.key)] = str(value)
+    return settings
+
+
+def resolve_llm_org_settings_provider(*, org_id: str | None = None) -> str:
+    return _load_org_llm_settings(org_id).get(_LLM_PROVIDER_KEY, "")
+
+
+def resolve_llm_org_settings_model(provider: str, *, org_id: str | None = None) -> str:
+    settings = _load_org_llm_settings(org_id)
+    configured_provider = _normalize_provider(settings.get(_LLM_PROVIDER_KEY, ""))
+    requested_provider = _normalize_provider(provider)
+    if configured_provider and requested_provider not in {"auto", configured_provider}:
+        return ""
+    return settings.get(_LLM_MODEL_KEY, "")
+
+
 def resolve_llm_org_settings_credentials(
     provider: str, *, org_id: str | None = None
 ) -> LLMCredentials:
-    return LLMCredentials()
+    settings = _load_org_llm_settings(org_id)
+    configured_provider = _normalize_provider(settings.get(_LLM_PROVIDER_KEY, ""))
+    requested_provider = _normalize_provider(provider)
+    if configured_provider and requested_provider not in {"auto", configured_provider}:
+        return LLMCredentials()
+    return LLMCredentials(
+        api_key=settings.get(_LLM_API_KEY_KEY, ""),
+        base_url=settings.get(_LLM_BASE_URL_KEY, ""),
+    )
 
 
 def resolve_llm_credentials(

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -38,7 +38,6 @@ _BASE_URL_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
 }
 
 _API_KEY_REQUIRED_PROVIDERS = {"openai", "anthropic", "gemini", "qwen"}
-_LLM_SETTINGS_CATEGORY = "llm"
 _LLM_PROVIDER_KEY = "provider"
 _LLM_MODEL_KEY = "model"
 _LLM_API_KEY_KEY = "api_key"

--- a/src/dev_health_ops/llm/errors.py
+++ b/src/dev_health_ops/llm/errors.py
@@ -99,12 +99,19 @@ def _header_value(exc: BaseException, name: str) -> str | None:
     return None
 
 
+# Upper bound on any provider-supplied Retry-After. A hostile or buggy provider
+# can send `Retry-After: 86400`; honoring it verbatim would pin a Celery worker
+# (or the materialize coroutine) for a day. Clamp so long backoffs surface as a
+# bounded retry instead of capacity starvation.
+_MAX_RETRY_AFTER_SECONDS = 60.0
+
+
 def _retry_after_seconds(exc: BaseException) -> float | None:
     raw = getattr(exc, "retry_after", None) or _header_value(exc, "Retry-After")
     if raw is None:
         return None
     try:
-        return max(0.0, float(raw))
+        return min(_MAX_RETRY_AFTER_SECONDS, max(0.0, float(raw)))
     except (TypeError, ValueError):
         pass
     try:
@@ -113,7 +120,10 @@ def _retry_after_seconds(exc: BaseException) -> float | None:
         return None
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
-    return max(0.0, (parsed - datetime.now(timezone.utc)).total_seconds())
+    return min(
+        _MAX_RETRY_AFTER_SECONDS,
+        max(0.0, (parsed - datetime.now(timezone.utc)).total_seconds()),
+    )
 
 
 def _default_model_for_provider(provider: str) -> str | None:

--- a/src/dev_health_ops/llm/errors.py
+++ b/src/dev_health_ops/llm/errors.py
@@ -23,8 +23,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
 
 logger = logging.getLogger(__name__)
+T = TypeVar("T")
 
 # ---------------------------------------------------------------------------
 # Error hierarchy
@@ -54,7 +57,7 @@ class LLMError(Exception):
         if self.model:
             parts.append(f"model={self.model}")
         if self.original:
-            parts.append(f"cause={self.original!r}")
+            parts.append(f"cause_type={type(self.original).__name__}")
         return " | ".join(parts)
 
 
@@ -194,9 +197,9 @@ def retry_delay(attempt: int) -> float:
 async def call_with_retry(
     provider_name: str,
     model: str,
-    call,
+    call: Callable[[], Awaitable[T]],
     max_retries: int = 1,
-) -> str:
+) -> T:
     """Execute an async LLM call with uniform retry / error handling.
 
     Args:
@@ -277,4 +280,4 @@ async def call_with_retry(
     # Should not be reached
     if last_exc:
         raise last_exc
-    return ""
+    raise RuntimeError("LLM retry loop exited without a result or exception")

--- a/src/dev_health_ops/llm/errors.py
+++ b/src/dev_health_ops/llm/errors.py
@@ -23,11 +23,106 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import TypeVar
 
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
+
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"sk-[A-Za-z0-9_-]{8,}"),
+    re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{8,}"),
+    re.compile(
+        r"(?i)((?:api[_-]?key|authorization|x-api-key|token)\s*[:=]\s*)"
+        r"['\"]?[^'\"\s,;}]+"
+    ),
+)
+
+
+def _sanitize_message(message: str) -> str:
+    text = str(message or "LLM provider error")
+    text = text.replace("\n", " ").replace("\r", " ").strip()
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub(
+            lambda m: f"{m.group(1)}<redacted>" if m.groups() else "<redacted>", text
+        )
+    return text[:500]
+
+
+def _exception_text(exc: BaseException) -> str:
+    fragments: list[str] = [str(exc)]
+    for attr_name in ("code", "type", "status_code", "message"):
+        value = getattr(exc, attr_name, None)
+        if value is not None:
+            fragments.append(str(value))
+    body = getattr(exc, "body", None)
+    if body is not None:
+        fragments.append(str(body))
+    response = getattr(exc, "response", None)
+    if response is not None:
+        status_code = getattr(response, "status_code", None)
+        if status_code is not None:
+            fragments.append(str(status_code))
+    return " ".join(fragments)
+
+
+def _status_code(exc: BaseException) -> int | None:
+    for source in (exc, getattr(exc, "response", None)):
+        if source is None:
+            continue
+        raw = getattr(source, "status_code", None)
+        if raw is None:
+            continue
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _header_value(exc: BaseException, name: str) -> str | None:
+    headers = getattr(exc, "headers", None)
+    if headers is None and getattr(exc, "response", None) is not None:
+        headers = getattr(getattr(exc, "response"), "headers", None)
+    if not headers:
+        return None
+    for key in (name, name.lower(), name.title()):
+        try:
+            value = headers.get(key)
+        except AttributeError:
+            value = None
+        if value:
+            return str(value)
+    return None
+
+
+def _retry_after_seconds(exc: BaseException) -> float | None:
+    raw = getattr(exc, "retry_after", None) or _header_value(exc, "Retry-After")
+    if raw is None:
+        return None
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        pass
+    try:
+        parsed = parsedate_to_datetime(str(raw))
+    except (TypeError, ValueError, IndexError, OverflowError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return max(0.0, (parsed - datetime.now(timezone.utc)).total_seconds())
+
+
+def _default_model_for_provider(provider: str) -> str | None:
+    try:
+        from dev_health_ops.llm.providers.base import DEFAULT_MODEL_BY_PROVIDER
+    except Exception:
+        return None
+    return DEFAULT_MODEL_BY_PROVIDER.get(provider)
+
 
 # ---------------------------------------------------------------------------
 # Error hierarchy
@@ -45,7 +140,7 @@ class LLMError(Exception):
         model: str = "",
         original: BaseException | None = None,
     ) -> None:
-        super().__init__(message)
+        super().__init__(_sanitize_message(message))
         self.provider = provider
         self.model = model
         self.original = original
@@ -126,30 +221,59 @@ def classify_provider_error(
     Returns:
         An appropriate LLMError subclass wrapping *exc*.
     """
-    msg = str(exc)
+    msg = _exception_text(exc)
     msg_lower = msg.lower()
+    status_code = _status_code(exc)
+
+    if any(k in msg_lower for k in ("insufficient_quota", "current quota")):
+        return LLMAuthError(
+            "LLM quota exhausted. Check provider billing/quota or use a different API key.",
+            provider=provider,
+            model=model,
+            original=exc,
+        )
+
+    if any(k in msg_lower for k in ("model_not_found", "model not found")):
+        default_model = _default_model_for_provider(provider)
+        hint = f" Provider default is '{default_model}'." if default_model else ""
+        configured = f" configured model '{model}'" if model else " configured model"
+        return LLMError(
+            f"LLM model not found for provider '{provider}' using{configured}.{hint} Check --model or provider defaults.",
+            provider=provider,
+            model=model,
+            original=exc,
+        )
 
     # Auth errors
     if any(
         k in msg_lower
         for k in ("401", "invalid_api_key", "authentication", "unauthorized")
+    ) or any(
+        k in msg_lower
+        for k in ("missing api key", "api key missing", "api_key is required")
     ):
-        return LLMAuthError(msg, provider=provider, model=model, original=exc)
+        return LLMAuthError(
+            "Invalid or missing LLM API key.",
+            provider=provider,
+            model=model,
+            original=exc,
+        )
 
     # Rate limit errors
-    if any(
-        k in msg_lower
-        for k in ("429", "rate_limit", "rate limit", "quota", "too many requests")
+    if (
+        any(
+            k in msg_lower
+            for k in ("429", "rate_limit", "rate limit", "too many requests")
+        )
+        or status_code == 429
     ):
-        retry_after: float | None = None
-        # Some SDKs expose retry_after on the exception object
-        if hasattr(exc, "retry_after"):
-            try:
-                retry_after = float(getattr(exc, "retry_after"))
-            except (TypeError, ValueError):
-                pass  # retry_after is not a valid number; leave as None
+        retry_after = _retry_after_seconds(exc)
         return LLMRateLimitError(
-            msg, retry_after=retry_after, provider=provider, model=model, original=exc
+            "Transient LLM rate limit from provider.",
+            retry_after=retry_after,
+            provider=provider,
+            model=model,
+            original=exc,
         )
 
     # Context length errors
@@ -163,14 +287,32 @@ def classify_provider_error(
             "reduce your prompt",
         )
     ):
-        return LLMContextLengthError(msg, provider=provider, model=model, original=exc)
+        return LLMContextLengthError(
+            "LLM prompt exceeds the model context window.",
+            provider=provider,
+            model=model,
+            original=exc,
+        )
 
     # Server errors
     if any(
         k in msg_lower
         for k in ("500", "502", "503", "504", "server error", "internal error")
-    ):
-        return LLMServerError(msg, provider=provider, model=model, original=exc)
+    ) or (status_code is not None and status_code >= 500):
+        return LLMServerError(
+            "Transient LLM provider server error.",
+            provider=provider,
+            model=model,
+            original=exc,
+        )
+
+    if any(k in msg_lower for k in ("timeout", "timed out", "connection error")):
+        return LLMServerError(
+            "Transient LLM provider transport error.",
+            provider=provider,
+            model=model,
+            original=exc,
+        )
 
     # Fallback: treat as generic LLM error (non-retryable)
     return LLMError(msg, provider=provider, model=model, original=exc)
@@ -231,7 +373,7 @@ async def call_with_retry(
                 if isinstance(exc, LLMRateLimitError) and exc.retry_after:
                     delay = exc.retry_after
                 logger.warning(
-                    "LLM %s error on attempt %d/%d; retrying in %.1fs — %r",
+                    "LLM %s error on attempt %d/%d; retrying in %.1fs — %s",
                     provider_name,
                     attempt + 1,
                     max_retries + 1,
@@ -243,7 +385,7 @@ async def call_with_retry(
                 continue
             # Non-retryable or exhausted
             logger.error(
-                "LLM %s/%s failed after %d attempt(s): %r",
+                "LLM %s/%s failed after %d attempt(s): %s",
                 provider_name,
                 model,
                 attempt + 1,
@@ -257,8 +399,10 @@ async def call_with_retry(
             last_exc = llm_exc
             if is_retryable(llm_exc) and attempt < max_retries:
                 delay = retry_delay(attempt)
+                if isinstance(llm_exc, LLMRateLimitError) and llm_exc.retry_after:
+                    delay = llm_exc.retry_after
                 logger.warning(
-                    "LLM %s transient error on attempt %d/%d; retrying in %.1fs — %r",
+                    "LLM %s transient error on attempt %d/%d; retrying in %.1fs — %s",
                     provider_name,
                     attempt + 1,
                     max_retries + 1,
@@ -269,7 +413,7 @@ async def call_with_retry(
                 attempt += 1
                 continue
             logger.error(
-                "LLM %s/%s failed after %d attempt(s): %r",
+                "LLM %s/%s failed after %d attempt(s): %s",
                 provider_name,
                 model,
                 attempt + 1,

--- a/src/dev_health_ops/llm/providers/__init__.py
+++ b/src/dev_health_ops/llm/providers/__init__.py
@@ -173,7 +173,9 @@ def _log_resolved_provider_model(provider: str, model: str | None) -> None:
         return
     _LOGGED_PROVIDER_MODELS.add(key)
     logger.info(
-        "Resolved LLM provider: provider=%s model=%s", provider, model or "none"
+        "Resolved LLM provider: provider=%s model=%s",
+        provider.replace("\r", "").replace("\n", ""),
+        (model or "none").replace("\r", "").replace("\n", ""),
     )
 
 

--- a/src/dev_health_ops/llm/providers/__init__.py
+++ b/src/dev_health_ops/llm/providers/__init__.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import logging
 import os
 
-from dev_health_ops.llm.credentials import resolve_llm_credentials
+from dev_health_ops.llm.credentials import (
+    resolve_llm_credentials,
+    resolve_llm_org_settings_model,
+    resolve_llm_org_settings_provider,
+)
 from dev_health_ops.llm.errors import LLMAuthError
 
 from .base import (
@@ -48,7 +52,7 @@ def _normalize_provider_name(name: str) -> str:
     return (name or "auto").strip().lower()
 
 
-def _configured_provider() -> str | None:
+def _configured_provider(*, org_id: str | None = None) -> str | None:
     if os.getenv("OPENAI_API_KEY"):
         return "openai"
     if os.getenv("ANTHROPIC_API_KEY"):
@@ -63,11 +67,18 @@ def _configured_provider() -> str | None:
         return "ollama"
     if os.getenv("LMSTUDIO_MODEL") or os.getenv("LMSTUDIO_BASE_URL"):
         return "lmstudio"
+    org_provider = resolve_llm_org_settings_provider(org_id=org_id)
+    if org_provider:
+        return _normalize_provider_name(org_provider)
     return None
 
 
 def _provider_has_required_config(
-    name: str, *, api_key: str | None = None, base_url: str | None = None
+    name: str,
+    *,
+    org_id: str | None = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
 ) -> bool:
     if name == "mock":
         return True
@@ -76,7 +87,7 @@ def _provider_has_required_config(
     if name not in _KNOWN_PROVIDERS:
         return False
     try:
-        resolve_llm_credentials(name, api_key=api_key, base_url=base_url)
+        resolve_llm_credentials(name, org_id=org_id, api_key=api_key, base_url=base_url)
         return True
     except LLMAuthError:
         return False
@@ -111,7 +122,7 @@ def _missing_provider_error(name: str) -> LLMAuthError:
     )
 
 
-def resolve_provider_name(name: str = "auto") -> str:
+def resolve_provider_name(name: str = "auto", *, org_id: str | None = None) -> str:
     requested = _normalize_provider_name(name)
     if requested != "auto":
         return requested
@@ -120,13 +131,15 @@ def resolve_provider_name(name: str = "auto") -> str:
     if env_name != "auto":
         return env_name
 
-    detected = _configured_provider()
+    detected = _configured_provider(org_id=org_id)
     if detected:
         return detected
     raise _missing_provider_error("auto")
 
 
-def resolve_model_name(provider: str, model: str | None = None) -> str | None:
+def resolve_model_name(
+    provider: str, model: str | None = None, *, org_id: str | None = None
+) -> str | None:
     provider = _normalize_provider_name(provider)
     if provider == "mock":
         return "mock"
@@ -139,6 +152,9 @@ def resolve_model_name(provider: str, model: str | None = None) -> str | None:
             return os.getenv(env_name)
     if os.getenv("LLM_MODEL"):
         return os.getenv("LLM_MODEL")
+    org_model = resolve_llm_org_settings_model(provider, org_id=org_id)
+    if org_model:
+        return org_model
     return DEFAULT_MODEL_BY_PROVIDER.get(provider)
 
 
@@ -152,23 +168,24 @@ def _log_resolved_provider_model(provider: str, model: str | None) -> None:
     )
 
 
-def is_llm_available(name: str = "auto") -> bool:
+def is_llm_available(name: str = "auto", *, org_id: str | None = None) -> bool:
     try:
-        resolved = resolve_provider_name(name)
+        resolved = resolve_provider_name(name, org_id=org_id)
     except LLMAuthError:
         return False
-    return _provider_has_required_config(resolved)
+    return _provider_has_required_config(resolved, org_id=org_id)
 
 
 def get_provider(
     name: str = "auto",
     model: str | None = None,
     *,
+    org_id: str | None = None,
     api_key: str | None = None,
     base_url: str | None = None,
 ) -> LLMProvider:
-    provider_name = resolve_provider_name(name)
-    model_name = resolve_model_name(provider_name, model)
+    provider_name = resolve_provider_name(name, org_id=org_id)
+    model_name = resolve_model_name(provider_name, model, org_id=org_id)
 
     if provider_name == "none":
         from .none import NoneProvider
@@ -177,13 +194,13 @@ def get_provider(
         return NoneProvider()
 
     if not _provider_has_required_config(
-        provider_name, api_key=api_key, base_url=base_url
+        provider_name, org_id=org_id, api_key=api_key, base_url=base_url
     ):
         raise _missing_provider_error(provider_name)
 
     _log_resolved_provider_model(provider_name, model_name)
     credentials = resolve_llm_credentials(
-        provider_name, api_key=api_key, base_url=base_url
+        provider_name, org_id=org_id, api_key=api_key, base_url=base_url
     )
 
     if provider_name == "mock":

--- a/src/dev_health_ops/llm/providers/__init__.py
+++ b/src/dev_health_ops/llm/providers/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 
+from dev_health_ops.llm.credentials import resolve_llm_credentials
 from dev_health_ops.llm.errors import LLMAuthError
 
 from .base import (
@@ -28,6 +29,20 @@ _MODEL_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
     "qwen-lmstudio": ("LLM_MODEL_QWEN_LMSTUDIO", "LMSTUDIO_MODEL"),
 }
 
+_KNOWN_PROVIDERS = {
+    "anthropic",
+    "gemini",
+    "lmstudio",
+    "local",
+    "mock",
+    "none",
+    "ollama",
+    "openai",
+    "qwen",
+    "qwen-lmstudio",
+    "qwen-local",
+}
+
 
 def _normalize_provider_name(name: str) -> str:
     return (name or "auto").strip().lower()
@@ -51,22 +66,20 @@ def _configured_provider() -> str | None:
     return None
 
 
-def _provider_has_required_config(name: str) -> bool:
+def _provider_has_required_config(
+    name: str, *, api_key: str | None = None, base_url: str | None = None
+) -> bool:
     if name == "mock":
         return True
     if name == "none":
         return False
-    if name == "openai":
-        return bool(os.getenv("OPENAI_API_KEY"))
-    if name == "anthropic":
-        return bool(os.getenv("ANTHROPIC_API_KEY"))
-    if name == "gemini":
-        return bool(os.getenv("GEMINI_API_KEY"))
-    if name == "qwen":
-        return bool(os.getenv("QWEN_API_KEY") or os.getenv("DASHSCOPE_API_KEY"))
-    if name in {"local", "ollama", "lmstudio", "qwen-local", "qwen-lmstudio"}:
+    if name not in _KNOWN_PROVIDERS:
+        return False
+    try:
+        resolve_llm_credentials(name, api_key=api_key, base_url=base_url)
         return True
-    return False
+    except LLMAuthError:
+        return False
 
 
 def _missing_provider_error(name: str) -> LLMAuthError:
@@ -147,7 +160,13 @@ def is_llm_available(name: str = "auto") -> bool:
     return _provider_has_required_config(resolved)
 
 
-def get_provider(name: str = "auto", model: str | None = None) -> LLMProvider:
+def get_provider(
+    name: str = "auto",
+    model: str | None = None,
+    *,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> LLMProvider:
     provider_name = resolve_provider_name(name)
     model_name = resolve_model_name(provider_name, model)
 
@@ -157,10 +176,15 @@ def get_provider(name: str = "auto", model: str | None = None) -> LLMProvider:
         _log_resolved_provider_model(provider_name, model_name)
         return NoneProvider()
 
-    if not _provider_has_required_config(provider_name):
+    if not _provider_has_required_config(
+        provider_name, api_key=api_key, base_url=base_url
+    ):
         raise _missing_provider_error(provider_name)
 
     _log_resolved_provider_model(provider_name, model_name)
+    credentials = resolve_llm_credentials(
+        provider_name, api_key=api_key, base_url=base_url
+    )
 
     if provider_name == "mock":
         from .mock import MockProvider
@@ -170,65 +194,78 @@ def get_provider(name: str = "auto", model: str | None = None) -> LLMProvider:
     if provider_name == "openai":
         from .openai import OpenAIProvider
 
-        api_key = os.getenv("OPENAI_API_KEY")
-        base_url = os.getenv("OPENAI_BASE_URL")
-        if not api_key:
-            raise _missing_provider_error(provider_name)
-        return OpenAIProvider(api_key=api_key, base_url=base_url, model=model_name)
+        return OpenAIProvider(
+            api_key=credentials.api_key,
+            base_url=credentials.base_url or None,
+            model=model_name,
+        )
 
     if provider_name == "anthropic":
         from .anthropic import AnthropicProvider
 
-        api_key = os.getenv("ANTHROPIC_API_KEY")
-        if not api_key:
-            raise _missing_provider_error(provider_name)
-        return AnthropicProvider(api_key=api_key, model=model_name)
+        return AnthropicProvider(
+            api_key=credentials.api_key,
+            base_url=credentials.base_url or None,
+            model=model_name,
+        )
 
     if provider_name == "gemini":
         from .gemini import GeminiProvider
 
-        api_key = os.getenv("GEMINI_API_KEY")
-        if not api_key:
-            raise _missing_provider_error(provider_name)
-        return GeminiProvider(api_key=api_key, model=model_name)
+        return GeminiProvider(
+            api_key=credentials.api_key,
+            base_url=credentials.base_url or None,
+            model=model_name,
+        )
 
     if provider_name == "local":
         from .local import LocalProvider
 
-        return LocalProvider(model=model_name)
+        return LocalProvider(
+            api_key=credentials.api_key or None,
+            base_url=credentials.base_url or None,
+            model=model_name,
+        )
 
     if provider_name == "ollama":
         from .local import OllamaProvider
 
-        return OllamaProvider(model=model_name)
+        return OllamaProvider(base_url=credentials.base_url or None, model=model_name)
 
     if provider_name == "lmstudio":
         if model_name and model_name.startswith("openai/gpt-oss"):
             from .local import LMStudioGPT5Provider
 
-            return LMStudioGPT5Provider(model=model_name)
+            return LMStudioGPT5Provider(
+                base_url=credentials.base_url or None, model=model_name
+            )
 
         from .local import LMStudioProvider
 
-        return LMStudioProvider(model=model_name)
+        return LMStudioProvider(base_url=credentials.base_url or None, model=model_name)
 
     if provider_name == "qwen":
         from .qwen import QwenProvider
 
-        api_key = os.getenv("QWEN_API_KEY") or os.getenv("DASHSCOPE_API_KEY")
-        if not api_key:
-            raise _missing_provider_error(provider_name)
-        return QwenProvider(api_key=api_key, model=model_name)
+        return QwenProvider(
+            api_key=credentials.api_key,
+            base_url=credentials.base_url or None,
+            model=model_name,
+        )
 
     if provider_name == "qwen-local":
         from .qwen import QwenLocalProvider
 
-        return QwenLocalProvider(model=model_name)
+        return QwenLocalProvider(
+            base_url=credentials.base_url or None, model=model_name
+        )
 
     if provider_name == "qwen-lmstudio":
         from .qwen import QwenLMStudioProvider
 
-        return QwenLMStudioProvider(model=model_name)
+        return QwenLMStudioProvider(
+            base_url=credentials.base_url or None, model=model_name
+        )
 
     raise ValueError(f"Unknown LLM provider: {provider_name}")
 

--- a/src/dev_health_ops/llm/providers/__init__.py
+++ b/src/dev_health_ops/llm/providers/__init__.py
@@ -84,6 +84,15 @@ def _provider_has_required_config(
 
 def _missing_provider_error(name: str) -> LLMAuthError:
     if name == "auto":
+        if os.getenv("LLM_API_KEY") or os.getenv("LLM_BASE_URL"):
+            return LLMAuthError(
+                "A generic LLM_API_KEY/LLM_BASE_URL was provided but no provider "
+                "could be auto-detected. A bare credential does not identify which "
+                "provider API to call. Set --llm-provider or LLM_PROVIDER "
+                "(e.g. openai, anthropic, gemini, qwen, local).",
+                provider="auto",
+                model="none",
+            )
         return LLMAuthError(
             "No LLM provider is configured for auto. Set --llm-provider mock for "
             "fixtures/testing, or configure LLM_PROVIDER plus provider credentials "
@@ -167,7 +176,18 @@ def get_provider(
     api_key: str | None = None,
     base_url: str | None = None,
 ) -> LLMProvider:
-    provider_name = resolve_provider_name(name)
+    try:
+        provider_name = resolve_provider_name(name)
+    except LLMAuthError:
+        if (api_key or base_url) and _normalize_provider_name(name) == "auto":
+            raise LLMAuthError(
+                "A per-call LLM credential (--llm-api-key/--llm-base-url) was "
+                "provided but no provider could be auto-detected. Set "
+                "--llm-provider or LLM_PROVIDER to choose the provider API.",
+                provider="auto",
+                model="none",
+            ) from None
+        raise
     model_name = resolve_model_name(provider_name, model)
 
     if provider_name == "none":

--- a/src/dev_health_ops/llm/providers/__init__.py
+++ b/src/dev_health_ops/llm/providers/__init__.py
@@ -1,198 +1,244 @@
-"""
-LLM Provider abstraction layer.
-
-Provides a unified interface for LLM completion, supporting multiple backends.
-"""
-
 from __future__ import annotations
 
+import logging
 import os
-from typing import Optional, Protocol, runtime_checkable
+
+from dev_health_ops.llm.errors import LLMAuthError
+
+from .base import (
+    DEFAULT_MODEL_BY_PROVIDER,
+    CompletionResult,
+    LLMProvider,
+    LLMProviderBase,
+)
+
+logger = logging.getLogger(__name__)
+
+_LOGGED_PROVIDER_MODELS: set[tuple[str, str | None]] = set()
+
+_MODEL_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
+    "openai": ("LLM_MODEL_OPENAI",),
+    "anthropic": ("LLM_MODEL_ANTHROPIC",),
+    "gemini": ("LLM_MODEL_GEMINI", "GEMINI_MODEL"),
+    "local": ("LLM_MODEL_LOCAL", "LOCAL_LLM_MODEL"),
+    "ollama": ("LLM_MODEL_OLLAMA", "OLLAMA_MODEL"),
+    "lmstudio": ("LLM_MODEL_LMSTUDIO", "LMSTUDIO_MODEL"),
+    "qwen": ("LLM_MODEL_QWEN", "QWEN_MODEL"),
+    "qwen-local": ("LLM_MODEL_QWEN_LOCAL", "QWEN_LOCAL_MODEL"),
+    "qwen-lmstudio": ("LLM_MODEL_QWEN_LMSTUDIO", "LMSTUDIO_MODEL"),
+}
 
 
-@runtime_checkable
-class LLMProvider(Protocol):
-    """Protocol for LLM providers."""
+def _normalize_provider_name(name: str) -> str:
+    return (name or "auto").strip().lower()
 
-    async def complete(self, prompt: str) -> str:
-        """
-        Generate a completion for the given prompt.
 
-        Args:
-            prompt: The prompt text to complete
+def _configured_provider() -> str | None:
+    if os.getenv("OPENAI_API_KEY"):
+        return "openai"
+    if os.getenv("ANTHROPIC_API_KEY"):
+        return "anthropic"
+    if os.getenv("GEMINI_API_KEY"):
+        return "gemini"
+    if os.getenv("LOCAL_LLM_BASE_URL"):
+        return "local"
+    if os.getenv("DASHSCOPE_API_KEY") or os.getenv("QWEN_API_KEY"):
+        return "qwen"
+    if os.getenv("OLLAMA_MODEL") or os.getenv("OLLAMA_BASE_URL"):
+        return "ollama"
+    if os.getenv("LMSTUDIO_MODEL") or os.getenv("LMSTUDIO_BASE_URL"):
+        return "lmstudio"
+    return None
 
-        Returns:
-            The generated completion text
-        """
-        raise NotImplementedError()
 
-    async def aclose(self) -> None:
-        """Close the underlying client and release resources."""
-        raise NotImplementedError()
+def _provider_has_required_config(name: str) -> bool:
+    if name == "mock":
+        return True
+    if name == "none":
+        return False
+    if name == "openai":
+        return bool(os.getenv("OPENAI_API_KEY"))
+    if name == "anthropic":
+        return bool(os.getenv("ANTHROPIC_API_KEY"))
+    if name == "gemini":
+        return bool(os.getenv("GEMINI_API_KEY"))
+    if name == "qwen":
+        return bool(os.getenv("QWEN_API_KEY") or os.getenv("DASHSCOPE_API_KEY"))
+    if name in {"local", "ollama", "lmstudio", "qwen-local", "qwen-lmstudio"}:
+        return True
+    return False
+
+
+def _missing_provider_error(name: str) -> LLMAuthError:
+    if name == "auto":
+        return LLMAuthError(
+            "No LLM provider is configured for auto. Set --llm-provider mock for "
+            "fixtures/testing, or configure LLM_PROVIDER plus provider credentials "
+            "such as OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, "
+            "QWEN_API_KEY/DASHSCOPE_API_KEY, LOCAL_LLM_BASE_URL, OLLAMA_BASE_URL, "
+            "or OLLAMA_MODEL.",
+            provider="auto",
+            model="none",
+        )
+    if name == "openai":
+        env_hint = "OPENAI_API_KEY"
+    elif name == "anthropic":
+        env_hint = "ANTHROPIC_API_KEY"
+    elif name == "gemini":
+        env_hint = "GEMINI_API_KEY"
+    elif name == "qwen":
+        env_hint = "QWEN_API_KEY or DASHSCOPE_API_KEY"
+    else:
+        env_hint = "LLM_PROVIDER"
+    return LLMAuthError(
+        f"LLM provider '{name}' is not configured. Set {env_hint} or choose "
+        "--llm-provider mock for fixtures/testing.",
+        provider=name,
+        model="none",
+    )
+
+
+def resolve_provider_name(name: str = "auto") -> str:
+    requested = _normalize_provider_name(name)
+    if requested != "auto":
+        return requested
+
+    env_name = _normalize_provider_name(os.getenv("LLM_PROVIDER", "auto"))
+    if env_name != "auto":
+        return env_name
+
+    detected = _configured_provider()
+    if detected:
+        return detected
+    raise _missing_provider_error("auto")
+
+
+def resolve_model_name(provider: str, model: str | None = None) -> str | None:
+    provider = _normalize_provider_name(provider)
+    if provider == "mock":
+        return "mock"
+    if provider == "none":
+        return None
+    if model:
+        return model
+    for env_name in _MODEL_ENV_BY_PROVIDER.get(provider, ()):
+        if os.getenv(env_name):
+            return os.getenv(env_name)
+    if os.getenv("LLM_MODEL"):
+        return os.getenv("LLM_MODEL")
+    return DEFAULT_MODEL_BY_PROVIDER.get(provider)
+
+
+def _log_resolved_provider_model(provider: str, model: str | None) -> None:
+    key = (provider, model)
+    if key in _LOGGED_PROVIDER_MODELS:
+        return
+    _LOGGED_PROVIDER_MODELS.add(key)
+    logger.info(
+        "Resolved LLM provider: provider=%s model=%s", provider, model or "none"
+    )
 
 
 def is_llm_available(name: str = "auto") -> bool:
-    """
-    Check whether a real (non-mock) LLM provider is configured.
-
-    Returns True if a real provider (openai, anthropic, local, ollama, etc.)
-    would be resolved. Returns False if the resolved provider is "mock" or "none".
-    """
-    if name == "none":
+    try:
+        resolved = resolve_provider_name(name)
+    except LLMAuthError:
         return False
-    resolved = name
-    if resolved == "auto":
-        env_name = os.getenv("LLM_PROVIDER")
-        if env_name and env_name != "auto":
-            resolved = env_name
-        else:
-            if os.getenv("OPENAI_API_KEY"):
-                resolved = "openai"
-            elif os.getenv("ANTHROPIC_API_KEY"):
-                resolved = "anthropic"
-            elif os.getenv("GEMINI_API_KEY"):
-                resolved = "gemini"
-            elif os.getenv("LOCAL_LLM_BASE_URL"):
-                resolved = "local"
-            elif os.getenv("DASHSCOPE_API_KEY") or os.getenv("QWEN_API_KEY"):
-                resolved = "qwen"
-            elif os.getenv("OLLAMA_MODEL") or os.getenv("OLLAMA_BASE_URL"):
-                resolved = "ollama"
-            else:
-                resolved = "mock"
-    if resolved == "none":
-        return False
-    if resolved == "mock":
-        # mock is explicitly requested — treat as available for dev/testing
-        return name == "mock"
-    return True
+    return _provider_has_required_config(resolved)
 
 
 def get_provider(name: str = "auto", model: str | None = None) -> LLMProvider:
-    """
-    Get an LLM provider by name.
+    provider_name = resolve_provider_name(name)
+    model_name = resolve_model_name(provider_name, model)
 
-    Args:
-        name: Provider name:
-              - "auto": Detect from environment (OPENAI_API_KEY, ANTHROPIC_API_KEY,
-                        GEMINI_API_KEY, LOCAL_LLM_BASE_URL, DASHSCOPE_API_KEY/QWEN_API_KEY,
-                        OLLAMA_* or fall back to mock)
-              - "openai": OpenAI API
-              - "anthropic": Anthropic API
-              - "gemini": Google Gemini 3 API (OpenAI-compatible)
-              - "local": Generic OpenAI-compatible local server
-              - "ollama": Ollama server (localhost:11434)
-              - "lmstudio": LMStudio server (localhost:1234)
-              - "qwen": Official Qwen / DashScope API
-              - "qwen-local": Local Qwen (Ollama)
-              - "qwen-lmstudio": LM Studio Qwen
-              - "mock": Deterministic mock for testing
-        model: Optional model name to override provider default.
+    if provider_name == "none":
+        from .none import NoneProvider
 
-    Returns:
-        An LLMProvider instance
+        _log_resolved_provider_model(provider_name, model_name)
+        return NoneProvider()
 
-    Raises:
-        ValueError: If the specified provider is not available
-    """
-    if name == "auto":
-        # Check LLM_PROVIDER env var first
-        env_name = os.getenv("LLM_PROVIDER")
-        if env_name and env_name != "auto":
-            name = env_name
-        else:
-            # Auto-detect based on other environment variables
-            if os.getenv("OPENAI_API_KEY"):
-                name = "openai"
-            elif os.getenv("ANTHROPIC_API_KEY"):
-                name = "anthropic"
-            elif os.getenv("GEMINI_API_KEY"):
-                name = "gemini"
-            elif os.getenv("LOCAL_LLM_BASE_URL"):
-                name = "local"
-            elif os.getenv("DASHSCOPE_API_KEY") or os.getenv("QWEN_API_KEY"):
-                name = "qwen"
-            elif os.getenv("OLLAMA_MODEL") or os.getenv("OLLAMA_BASE_URL"):
-                name = "ollama"
-            else:
-                # Fall back to mock for development/testing
-                name = "mock"
+    if not _provider_has_required_config(provider_name):
+        raise _missing_provider_error(provider_name)
 
-    if model is None:
-        model = os.getenv("LLM_MODEL")
+    _log_resolved_provider_model(provider_name, model_name)
 
-    if name == "none":
+    if provider_name == "mock":
         from .mock import MockProvider
 
         return MockProvider()
 
-    if name == "mock":
-        from .mock import MockProvider
-
-        return MockProvider()
-
-    if name == "openai":
+    if provider_name == "openai":
         from .openai import OpenAIProvider
 
         api_key = os.getenv("OPENAI_API_KEY")
         base_url = os.getenv("OPENAI_BASE_URL")
         if not api_key:
-            raise ValueError("OPENAI_API_KEY environment variable not set")
-        return OpenAIProvider(
-            api_key=api_key, base_url=base_url, model=model or "gpt-5-mini"
-        )
+            raise _missing_provider_error(provider_name)
+        return OpenAIProvider(api_key=api_key, base_url=base_url, model=model_name)
 
-    if name == "anthropic":
+    if provider_name == "anthropic":
         from .anthropic import AnthropicProvider
 
         api_key = os.getenv("ANTHROPIC_API_KEY")
         if not api_key:
-            raise ValueError("ANTHROPIC_API_KEY environment variable not set")
-        return AnthropicProvider(
-            api_key=api_key, model=model or "claude-3-haiku-20240307"
-        )
+            raise _missing_provider_error(provider_name)
+        return AnthropicProvider(api_key=api_key, model=model_name)
 
-    if name == "gemini":
+    if provider_name == "gemini":
         from .gemini import GeminiProvider
 
-        return GeminiProvider(model=model)
+        api_key = os.getenv("GEMINI_API_KEY")
+        if not api_key:
+            raise _missing_provider_error(provider_name)
+        return GeminiProvider(api_key=api_key, model=model_name)
 
-    if name == "local":
+    if provider_name == "local":
         from .local import LocalProvider
 
-        return LocalProvider(model=model)
+        return LocalProvider(model=model_name)
 
-    if name == "ollama":
+    if provider_name == "ollama":
         from .local import OllamaProvider
 
-        return OllamaProvider(model=model)
+        return OllamaProvider(model=model_name)
 
-    if name == "lmstudio":
-        if model and model.startswith("openai/gpt-oss"):
+    if provider_name == "lmstudio":
+        if model_name and model_name.startswith("openai/gpt-oss"):
             from .local import LMStudioGPT5Provider
 
-            return LMStudioGPT5Provider(model=model)
+            return LMStudioGPT5Provider(model=model_name)
 
         from .local import LMStudioProvider
 
-        return LMStudioProvider(model=model)
+        return LMStudioProvider(model=model_name)
 
-    if name == "qwen":
+    if provider_name == "qwen":
         from .qwen import QwenProvider
 
-        return QwenProvider(model=model)
+        api_key = os.getenv("QWEN_API_KEY") or os.getenv("DASHSCOPE_API_KEY")
+        if not api_key:
+            raise _missing_provider_error(provider_name)
+        return QwenProvider(api_key=api_key, model=model_name)
 
-    if name == "qwen-local":
+    if provider_name == "qwen-local":
         from .qwen import QwenLocalProvider
 
-        return QwenLocalProvider(model=model)
+        return QwenLocalProvider(model=model_name)
 
-    if name == "qwen-lmstudio":
+    if provider_name == "qwen-lmstudio":
         from .qwen import QwenLMStudioProvider
 
-        return QwenLMStudioProvider(model=model)
+        return QwenLMStudioProvider(model=model_name)
 
-    raise ValueError(f"Unknown LLM provider: {name}")
+    raise ValueError(f"Unknown LLM provider: {provider_name}")
 
 
-__all__ = ["LLMProvider", "get_provider", "is_llm_available"]
+__all__ = [
+    "CompletionResult",
+    "LLMProvider",
+    "LLMProviderBase",
+    "get_provider",
+    "is_llm_available",
+    "resolve_model_name",
+    "resolve_provider_name",
+]

--- a/src/dev_health_ops/llm/providers/anthropic.py
+++ b/src/dev_health_ops/llm/providers/anthropic.py
@@ -8,10 +8,17 @@ import logging
 
 from dev_health_ops.llm.errors import call_with_retry, classify_provider_error
 
+from .base import (
+    DEFAULT_MODEL_BY_PROVIDER,
+    CompletionResult,
+    LLMProviderBase,
+    usage_token_count,
+)
+
 logger = logging.getLogger(__name__)
 
 
-class AnthropicProvider:
+class AnthropicProvider(LLMProviderBase):
     """
     Anthropic LLM provider using the messages API.
     """
@@ -19,7 +26,7 @@ class AnthropicProvider:
     def __init__(
         self,
         api_key: str,
-        model: str = "claude-3-haiku-20240307",
+        model: str | None = None,
         max_tokens: int = 4096,
         temperature: float = 0.3,
     ) -> None:
@@ -33,7 +40,7 @@ class AnthropicProvider:
             temperature: Sampling temperature (lower = more deterministic)
         """
         self.api_key = api_key
-        self.model = model
+        self.model = model or DEFAULT_MODEL_BY_PROVIDER["anthropic"]
         self.max_tokens = max_tokens
         self.temperature = temperature
         self._client: object | None = None
@@ -51,7 +58,7 @@ class AnthropicProvider:
                 )
         return self._client
 
-    async def _call(self, prompt: str) -> str:
+    async def _call(self, prompt: str) -> CompletionResult:
         """Single attempt — called via call_with_retry."""
         client = self._get_client()
 
@@ -79,15 +86,24 @@ class AnthropicProvider:
                 messages=[{"role": "user", "content": prompt}],
             )
 
+            text = ""
             if response.content and len(response.content) > 0:
-                return response.content[0].text
-            return ""
+                text = response.content[0].text
+            usage = getattr(response, "usage", None)
+            return CompletionResult(
+                text=text,
+                input_tokens=usage_token_count(usage, "input_tokens", "prompt_tokens"),
+                output_tokens=usage_token_count(
+                    usage, "output_tokens", "completion_tokens"
+                ),
+                model=self.model,
+            )
         except Exception as exc:
             raise classify_provider_error(
                 exc, provider="anthropic", model=self.model
             ) from exc
 
-    async def complete(self, prompt: str) -> str:
+    async def complete(self, prompt: str) -> CompletionResult:
         """
         Generate a completion using Anthropic's API.
 

--- a/src/dev_health_ops/llm/providers/anthropic.py
+++ b/src/dev_health_ops/llm/providers/anthropic.py
@@ -26,6 +26,7 @@ class AnthropicProvider(LLMProviderBase):
     def __init__(
         self,
         api_key: str,
+        base_url: str | None = None,
         model: str | None = None,
         max_tokens: int = 4096,
         temperature: float = 0.3,
@@ -40,6 +41,7 @@ class AnthropicProvider(LLMProviderBase):
             temperature: Sampling temperature (lower = more deterministic)
         """
         self.api_key = api_key
+        self.base_url = base_url
         self.model = model or DEFAULT_MODEL_BY_PROVIDER["anthropic"]
         self.max_tokens = max_tokens
         self.temperature = temperature
@@ -51,7 +53,9 @@ class AnthropicProvider(LLMProviderBase):
             try:
                 from anthropic import AsyncAnthropic
 
-                self._client = AsyncAnthropic(api_key=self.api_key)
+                self._client = AsyncAnthropic(
+                    api_key=self.api_key, base_url=self.base_url
+                )
             except ImportError:
                 raise ImportError(
                     "Anthropic package not installed. Install with: pip install anthropic"

--- a/src/dev_health_ops/llm/providers/base.py
+++ b/src/dev_health_ops/llm/providers/base.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class CompletionResult:
+    text: str
+    input_tokens: int | None
+    output_tokens: int | None
+    model: str
+
+
+@runtime_checkable
+class LLMProvider(Protocol):
+    async def complete(self, prompt: str) -> CompletionResult:
+        raise NotImplementedError()
+
+    async def complete_text(self, prompt: str) -> str:
+        raise NotImplementedError()
+
+    async def aclose(self) -> None:
+        raise NotImplementedError()
+
+
+class LLMProviderBase:
+    async def complete(self, prompt: str) -> CompletionResult:
+        raise NotImplementedError()
+
+    async def complete_text(self, prompt: str) -> str:
+        return (await self.complete(prompt)).text
+
+
+DEFAULT_MODEL_BY_PROVIDER: dict[str, str] = {
+    "openai": "gpt-5-mini",
+    "anthropic": "claude-3-haiku-20240307",
+    "gemini": "gemini-3",
+    "local": "llama3.2",
+    "ollama": "llama3.2",
+    "lmstudio": "local-model",
+    "qwen": "qwen-plus",
+    "qwen-local": "qwen2.5:7b",
+    "qwen-lmstudio": "local-model",
+}
+
+
+def usage_token_count(usage: object | None, *field_names: str) -> int | None:
+    if usage is None:
+        return None
+
+    for field_name in field_names:
+        if isinstance(usage, dict):
+            raw_value = usage.get(field_name)
+        else:
+            raw_value = getattr(usage, field_name, None)
+
+        if isinstance(raw_value, bool) or raw_value is None:
+            continue
+        if isinstance(raw_value, int):
+            return raw_value
+        if isinstance(raw_value, float):
+            return int(raw_value)
+        if isinstance(raw_value, str):
+            try:
+                return int(raw_value)
+            except ValueError:
+                continue
+
+    return None

--- a/src/dev_health_ops/llm/providers/gemini.py
+++ b/src/dev_health_ops/llm/providers/gemini.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 
+from .base import DEFAULT_MODEL_BY_PROVIDER
 from .local import LocalProvider
 
 DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai"
@@ -33,6 +34,7 @@ class GeminiProvider(LocalProvider):
         super().__init__(
             api_key=api_key or os.getenv("GEMINI_API_KEY"),
             base_url=base_url or os.getenv("GEMINI_BASE_URL", DEFAULT_GEMINI_BASE_URL),
-            model=model or os.getenv("GEMINI_MODEL", "gemini-3"),
+            model=model
+            or os.getenv("GEMINI_MODEL", DEFAULT_MODEL_BY_PROVIDER["gemini"]),
             **kwargs,
         )

--- a/src/dev_health_ops/llm/providers/local.py
+++ b/src/dev_health_ops/llm/providers/local.py
@@ -11,6 +11,12 @@ import os
 
 from dev_health_ops.llm.errors import classify_provider_error
 
+from .base import (
+    DEFAULT_MODEL_BY_PROVIDER,
+    CompletionResult,
+    LLMProviderBase,
+    usage_token_count,
+)
 from .openai import (
     OpenAIGPT5Provider,
     OpenAIProviderConfig,
@@ -31,7 +37,7 @@ DEFAULT_ENDPOINTS = {
 }
 
 
-class LocalProvider:
+class LocalProvider(LLMProviderBase):
     """
     OpenAI-compatible provider for local LLM servers.
 
@@ -68,7 +74,9 @@ class LocalProvider:
         self.base_url = base_url or os.getenv(
             "LOCAL_LLM_BASE_URL", DEFAULT_ENDPOINTS["local"]
         )
-        self.model = model or os.getenv("LOCAL_LLM_MODEL", "llama3.2")
+        self.model: str = (
+            model or os.getenv("LOCAL_LLM_MODEL") or DEFAULT_MODEL_BY_PROVIDER["local"]
+        )
         self.api_key = api_key or os.getenv("LOCAL_LLM_API_KEY", "not-needed")
         self.max_completion_tokens = max_completion_tokens
         self.temperature = temperature
@@ -90,7 +98,7 @@ class LocalProvider:
                 )
         return self._client
 
-    async def complete(self, prompt: str) -> str:
+    async def complete(self, prompt: str) -> CompletionResult:
         """
         Generate a completion using the local LLM server.
 
@@ -140,7 +148,18 @@ class LocalProvider:
                 response = await client.chat.completions.create(**payload)  # type: ignore
 
                 content = response.choices[0].message.content or ""
-                return validate_json_or_empty(content) if is_schema_prompt else content
+                usage = getattr(response, "usage", None)
+                text = validate_json_or_empty(content) if is_schema_prompt else content
+                return CompletionResult(
+                    text=text,
+                    input_tokens=usage_token_count(
+                        usage, "prompt_tokens", "input_tokens"
+                    ),
+                    output_tokens=usage_token_count(
+                        usage, "completion_tokens", "output_tokens"
+                    ),
+                    model=self.model,
+                )
 
             except Exception as e:
                 # If we get a 400 error, it's likely that the server doesn't support
@@ -159,7 +178,9 @@ class LocalProvider:
                 llm_exc = classify_provider_error(e, provider="local", model=model_name)
                 logger.error("Local LLM API error (%s): %s", self.base_url, llm_exc)
                 raise llm_exc from e
-        return ""  # Should not be reachable
+        return CompletionResult(
+            text="", input_tokens=None, output_tokens=None, model=self.model
+        )
 
     async def aclose(self) -> None:
         if self._client:
@@ -178,7 +199,8 @@ class OllamaProvider(LocalProvider):
         super().__init__(
             base_url=base_url
             or os.getenv("OLLAMA_BASE_URL", DEFAULT_ENDPOINTS["ollama"]),
-            model=model or os.getenv("OLLAMA_MODEL", "llama3.2"),
+            model=model
+            or os.getenv("OLLAMA_MODEL", DEFAULT_MODEL_BY_PROVIDER["ollama"]),
             **kwargs,
         )
 
@@ -196,7 +218,8 @@ class LMStudioProvider(LocalProvider):
             base_url=base_url
             or os.getenv("LMSTUDIO_BASE_URL", DEFAULT_ENDPOINTS["lmstudio"]),
             # LMStudio typically serves whatever model is loaded
-            model=model or os.getenv("LMSTUDIO_MODEL", "local-model"),
+            model=model
+            or os.getenv("LMSTUDIO_MODEL", DEFAULT_MODEL_BY_PROVIDER["lmstudio"]),
             **kwargs,
         )
 

--- a/src/dev_health_ops/llm/providers/local.py
+++ b/src/dev_health_ops/llm/providers/local.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+from urllib.parse import urlsplit, urlunsplit
 
 from dev_health_ops.llm.errors import classify_provider_error
 
@@ -35,6 +36,30 @@ DEFAULT_ENDPOINTS = {
     "vllm": "http://localhost:8000/v1",
     "local": "http://localhost:11434/v1",  # Default to Ollama
 }
+
+
+def _redact_url(url: str) -> str:
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return "[invalid-url]"
+    host = parsed.hostname or ""
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+    return urlunsplit((parsed.scheme, host, parsed.path, "", ""))
+
+
+def _status_code(exc: BaseException) -> int | None:
+    status_code = getattr(exc, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code
+    response = getattr(exc, "response", None)
+    response_status = getattr(response, "status_code", None)
+    return response_status if isinstance(response_status, int) else None
+
+
+def _error_metadata(exc: BaseException) -> dict[str, str | int | None]:
+    return {"type": type(exc).__name__, "status_code": _status_code(exc)}
 
 
 class LocalProvider(LLMProviderBase):
@@ -166,8 +191,8 @@ class LocalProvider(LLMProviderBase):
                 # the requested response_format (common with local OpenAI-compatible APIs).
                 if "400" in str(e) and response_format and retry_count < max_retries:
                     logger.warning(
-                        "Local LLM API error (likely unsupported response_format). Retrying with text format. Error: %s",
-                        e,
+                        "Local LLM API rejected response_format; retrying with text format: %s",
+                        _error_metadata(e),
                     )
                     # Fallback to plain text JSON request
                     response_format = {"type": "text"}
@@ -176,7 +201,12 @@ class LocalProvider(LLMProviderBase):
 
                 model_name = self.model or "local-model"
                 llm_exc = classify_provider_error(e, provider="local", model=model_name)
-                logger.error("Local LLM API error (%s): %s", self.base_url, llm_exc)
+                logger.error(
+                    "Local LLM API error url=%s error=%s classified=%s",
+                    _redact_url(self.base_url or ""),
+                    _error_metadata(e),
+                    type(llm_exc).__name__,
+                )
                 raise llm_exc from e
         return CompletionResult(
             text="", input_tokens=None, output_tokens=None, model=self.model

--- a/src/dev_health_ops/llm/providers/mock.py
+++ b/src/dev_health_ops/llm/providers/mock.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 import json
 
+from .base import CompletionResult, LLMProviderBase
 
-class MockProvider:
+
+class MockProvider(LLMProviderBase):
     """
     Mock LLM provider that returns compliant explanation and categorization text.
 
@@ -17,19 +19,23 @@ class MockProvider:
     The mock responses follow the investment view language rules exactly.
     """
 
-    async def complete(self, prompt: str) -> str:
+    async def complete(self, prompt: str) -> CompletionResult:
         """
         Generate a mock response that follows Investment model rules.
 
         The response uses only approved language (appears, leans, suggests)
         and never uses forbidden language (is, was, detected, determined).
         """
+        text: str
         if (
             "Output schema" in prompt
             and '"subcategories"' in prompt
             and '"evidence_quotes"' in prompt
         ) or "matching the schema" in prompt:
-            return self._mock_categorization(prompt)
+            text = self._mock_categorization(prompt)
+            return CompletionResult(
+                text=text, input_tokens=None, output_tokens=None, model="mock"
+            )
 
         # Extract key info from prompt to make response contextual
         lines = prompt.split("\n")
@@ -79,7 +85,10 @@ class MockProvider:
             ],
             "confidence_note": confidence_note,
         }
-        return json.dumps(response_data)
+        text = json.dumps(response_data)
+        return CompletionResult(
+            text=text, input_tokens=None, output_tokens=None, model="mock"
+        )
 
     def _mock_categorization(self, prompt: str) -> str:
         # Extract the first available source block entry, which is formatted as:

--- a/src/dev_health_ops/llm/providers/none.py
+++ b/src/dev_health_ops/llm/providers/none.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .base import CompletionResult, LLMProviderBase
+
+
+class NoneProvider(LLMProviderBase):
+    async def complete(self, prompt: str) -> CompletionResult:
+        return CompletionResult(
+            text="", input_tokens=None, output_tokens=None, model="none"
+        )
+
+    async def aclose(self) -> None:
+        pass

--- a/src/dev_health_ops/llm/providers/openai.py
+++ b/src/dev_health_ops/llm/providers/openai.py
@@ -18,6 +18,12 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
+from dev_health_ops.llm.errors import (
+    LLMRateLimitError,
+    classify_provider_error,
+    is_retryable,
+    retry_delay,
+)
 from dev_health_ops.llm.json_utils import validate_json_or_empty
 
 from .base import (
@@ -187,7 +193,9 @@ class _OpenAIProviderBase(LLMProviderBase):
             from openai import AsyncOpenAI
 
             self._client = AsyncOpenAI(
-                api_key=self.cfg.api_key, base_url=self.cfg.base_url
+                api_key=self.cfg.api_key,
+                base_url=self.cfg.base_url,
+                max_retries=0,
             )
         return self._client
 
@@ -198,6 +206,32 @@ class _OpenAIProviderBase(LLMProviderBase):
 
     async def complete(self, prompt: str) -> CompletionResult:
         raise NotImplementedError
+
+    async def _retry_transient_error(
+        self,
+        exc: Exception,
+        *,
+        retry_count: int,
+        max_retries: int,
+        api_name: str,
+    ) -> bool:
+        llm_exc = classify_provider_error(exc, provider="openai", model=self.cfg.model)
+        if is_retryable(llm_exc) and retry_count < max_retries:
+            delay = retry_delay(retry_count)
+            if isinstance(llm_exc, LLMRateLimitError) and llm_exc.retry_after:
+                delay = llm_exc.retry_after
+            logger.warning(
+                "%s transient error on attempt %d/%d; retrying in %.1fs: %s",
+                api_name,
+                retry_count + 1,
+                max_retries + 1,
+                delay,
+                llm_exc,
+            )
+            await asyncio.sleep(delay)
+            return True
+        logger.error("%s error: %s", api_name, llm_exc)
+        raise llm_exc from exc
 
     def _completion_result(
         self, text: str, usage: object | None = None
@@ -299,10 +333,7 @@ class OpenAIGPT5Provider(_OpenAIProviderBase):
                 if cleaned:
                     return self._completion_result(cleaned, usage)
 
-                # If invalid/empty, retry once with more tokens if it looks truncated.
-                should_retry = (finish_reason == "max_output_tokens") or (
-                    not content.strip()
-                )
+                should_retry = finish_reason == "max_output_tokens"
 
                 if retry_count < max_retries and should_retry:
                     retry_count += 1
@@ -327,13 +358,14 @@ class OpenAIGPT5Provider(_OpenAIProviderBase):
                 return self._completion_result("", usage)
 
             except Exception as e:
-                logger.error("OpenAI Responses API error: %s", e)
-                if retry_count < max_retries:
+                if await self._retry_transient_error(
+                    e,
+                    retry_count=retry_count,
+                    max_retries=max_retries,
+                    api_name="OpenAI Responses API",
+                ):
                     retry_count += 1
-                    max_tokens = min(8192, max_tokens * 2)
-                    await asyncio.sleep(0.5)
                     continue
-                raise
 
         return self._completion_result("")
 
@@ -390,8 +422,10 @@ class OpenAIGPTLegacyProvider(_OpenAIProviderBase):
                 if cleaned:
                     return self._completion_result(cleaned, usage)
 
-                should_retry = (finish_reason in ("length", "max_tokens")) or (
-                    not content.strip()
+                should_retry = finish_reason in (
+                    "length",
+                    "max_tokens",
+                    "max_output_tokens",
                 )
 
                 if retry_count < max_retries and should_retry:
@@ -417,12 +451,13 @@ class OpenAIGPTLegacyProvider(_OpenAIProviderBase):
                 return self._completion_result("", usage)
 
             except Exception as e:
-                logger.error("OpenAI Chat Completions error: %s", e)
-                if retry_count < max_retries:
+                if await self._retry_transient_error(
+                    e,
+                    retry_count=retry_count,
+                    max_retries=max_retries,
+                    api_name="OpenAI Chat Completions",
+                ):
                     retry_count += 1
-                    max_tokens = min(8192, max_tokens * 2)
-                    await asyncio.sleep(0.5)
                     continue
-                raise
 
         return self._completion_result("")

--- a/src/dev_health_ops/llm/providers/openai.py
+++ b/src/dev_health_ops/llm/providers/openai.py
@@ -20,6 +20,13 @@ from typing import Any
 
 from dev_health_ops.llm.json_utils import validate_json_or_empty
 
+from .base import (
+    DEFAULT_MODEL_BY_PROVIDER,
+    CompletionResult,
+    LLMProviderBase,
+    usage_token_count,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -122,7 +129,7 @@ class OpenAIProviderConfig:
     temperature: float
 
 
-class OpenAIProvider:
+class OpenAIProvider(LLMProviderBase):
     """Public provider facade.
 
     Delegates to a model-specific implementation:
@@ -134,14 +141,14 @@ class OpenAIProvider:
         self,
         api_key: str,
         base_url: str | None = None,
-        model: str = "gpt-5-mini",
+        model: str | None = None,
         max_completion_tokens: int = 4096,
         temperature: float = 0.3,
     ) -> None:
         cfg = OpenAIProviderConfig(
             api_key=api_key,
             base_url=base_url,
-            model=model,
+            model=model or DEFAULT_MODEL_BY_PROVIDER["openai"],
             # keep param name stable at the facade; impl maps to correct API param
             max_output_tokens=max(4096, int(max_completion_tokens)),
             temperature=float(temperature),
@@ -149,7 +156,7 @@ class OpenAIProvider:
 
         self._impl = openai_provider_class_for(cfg.model)(cfg)
 
-    async def complete(self, prompt: str) -> str:
+    async def complete(self, prompt: str) -> CompletionResult:
         return await self._impl.complete(prompt)
 
     async def aclose(self) -> None:
@@ -170,7 +177,7 @@ def openai_provider_class_for(model: str) -> type[_OpenAIProviderBase]:
 # -----------------------------------------------------------------------------
 
 
-class _OpenAIProviderBase:
+class _OpenAIProviderBase(LLMProviderBase):
     def __init__(self, cfg: OpenAIProviderConfig) -> None:
         self.cfg = cfg
         self._client: Any | None = None
@@ -189,8 +196,20 @@ class _OpenAIProviderBase:
         m = (self.cfg.model or "").strip()
         return not m.startswith(("gpt-5", "o1", "o3"))
 
-    async def complete(self, prompt: str) -> str:
+    async def complete(self, prompt: str) -> CompletionResult:
         raise NotImplementedError
+
+    def _completion_result(
+        self, text: str, usage: object | None = None
+    ) -> CompletionResult:
+        return CompletionResult(
+            text=text,
+            input_tokens=usage_token_count(usage, "input_tokens", "prompt_tokens"),
+            output_tokens=usage_token_count(
+                usage, "output_tokens", "completion_tokens"
+            ),
+            model=self.cfg.model,
+        )
 
     async def aclose(self) -> None:
         if self._client:
@@ -204,7 +223,7 @@ class _OpenAIProviderBase:
 class OpenAIGPT5Provider(_OpenAIProviderBase):
     """GPT-5+ via Responses API."""
 
-    async def complete(self, prompt: str) -> str:
+    async def complete(self, prompt: str) -> CompletionResult:
         client = self._get_client()
 
         # Retry once on truncation / invalid JSON.
@@ -250,6 +269,7 @@ class OpenAIGPT5Provider(_OpenAIProviderBase):
                     kwargs["temperature"] = self.cfg.temperature
 
                 response = await client.responses.create(**kwargs)
+                usage = getattr(response, "usage", None)
 
                 # Best-effort extraction
                 content = getattr(response, "output_text", "") or ""
@@ -277,7 +297,7 @@ class OpenAIGPT5Provider(_OpenAIProviderBase):
                 )
 
                 if cleaned:
-                    return cleaned
+                    return self._completion_result(cleaned, usage)
 
                 # If invalid/empty, retry once with more tokens if it looks truncated.
                 should_retry = (finish_reason == "max_output_tokens") or (
@@ -304,7 +324,7 @@ class OpenAIGPT5Provider(_OpenAIProviderBase):
                     token_budget,
                     (content.strip()[:200] + "...") if content else "<empty>",
                 )
-                return ""
+                return self._completion_result("", usage)
 
             except Exception as e:
                 logger.error("OpenAI Responses API error: %s", e)
@@ -315,7 +335,7 @@ class OpenAIGPT5Provider(_OpenAIProviderBase):
                     continue
                 raise
 
-        return ""
+        return self._completion_result("")
 
 
 # -----------------------------------------------------------------------------
@@ -326,7 +346,7 @@ class OpenAIGPT5Provider(_OpenAIProviderBase):
 class OpenAIGPTLegacyProvider(_OpenAIProviderBase):
     """<= GPT-4 via Chat Completions."""
 
-    async def complete(self, prompt: str) -> str:
+    async def complete(self, prompt: str) -> CompletionResult:
         client = self._get_client()
 
         retry_count = 0
@@ -351,6 +371,7 @@ class OpenAIGPTLegacyProvider(_OpenAIProviderBase):
                     kwargs["temperature"] = self.cfg.temperature
 
                 response = await client.chat.completions.create(**kwargs)
+                usage = getattr(response, "usage", None)
 
                 choice = response.choices[0]
                 content = choice.message.content or ""
@@ -367,7 +388,7 @@ class OpenAIGPTLegacyProvider(_OpenAIProviderBase):
                 )
 
                 if cleaned:
-                    return cleaned
+                    return self._completion_result(cleaned, usage)
 
                 should_retry = (finish_reason in ("length", "max_tokens")) or (
                     not content.strip()
@@ -393,7 +414,7 @@ class OpenAIGPTLegacyProvider(_OpenAIProviderBase):
                     max_tokens,
                     (content.strip()[:200] + "...") if content else "<empty>",
                 )
-                return ""
+                return self._completion_result("", usage)
 
             except Exception as e:
                 logger.error("OpenAI Chat Completions error: %s", e)
@@ -404,4 +425,4 @@ class OpenAIGPTLegacyProvider(_OpenAIProviderBase):
                     continue
                 raise
 
-        return ""
+        return self._completion_result("")

--- a/src/dev_health_ops/llm/providers/qwen.py
+++ b/src/dev_health_ops/llm/providers/qwen.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 
+from .base import DEFAULT_MODEL_BY_PROVIDER
 from .local import DEFAULT_ENDPOINTS, LocalProvider
 
 # Default DashScope (China) OpenAI-compatible endpoint.
@@ -43,7 +44,7 @@ class QwenProvider(LocalProvider):
             or os.getenv("DASHSCOPE_API_KEY"),
             base_url=base_url
             or os.getenv("DASHSCOPE_BASE_URL", DEFAULT_DASHSCOPE_BASE_URL),
-            model=model or os.getenv("QWEN_MODEL", "qwen-plus"),
+            model=model or os.getenv("QWEN_MODEL", DEFAULT_MODEL_BY_PROVIDER["qwen"]),
             **kwargs,
         )
 
@@ -62,7 +63,8 @@ class QwenLocalProvider(LocalProvider):
         super().__init__(
             base_url=base_url
             or os.getenv("OLLAMA_BASE_URL", DEFAULT_ENDPOINTS["ollama"]),
-            model=model or os.getenv("QWEN_LOCAL_MODEL", "qwen2.5:7b"),
+            model=model
+            or os.getenv("QWEN_LOCAL_MODEL", DEFAULT_MODEL_BY_PROVIDER["qwen-local"]),
             **kwargs,
         )
 
@@ -81,6 +83,7 @@ class QwenLMStudioProvider(LocalProvider):
         super().__init__(
             base_url=base_url
             or os.getenv("LMSTUDIO_BASE_URL", DEFAULT_ENDPOINTS["lmstudio"]),
-            model=model or os.getenv("LMSTUDIO_MODEL", "local-model"),
+            model=model
+            or os.getenv("LMSTUDIO_MODEL", DEFAULT_MODEL_BY_PROVIDER["qwen-lmstudio"]),
             **kwargs,
         )

--- a/src/dev_health_ops/work_graph/investment/categorize.py
+++ b/src/dev_health_ops/work_graph/investment/categorize.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 import logging
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
+from typing import Any
 
-from dev_health_ops.llm import LLMProvider, get_provider
+from dev_health_ops.llm import CompletionResult, LLMProvider, get_provider
 from dev_health_ops.work_graph.investment.llm_schema import (
     EvidenceQuote,
     LLMValidationResult,
@@ -82,6 +84,26 @@ class CategorizationOutcome:
     status: str
     errors: list[str]
     warnings: list[str] = field(default_factory=list)
+    llm_calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    llm_model: str | None = None
+
+
+def _token_count(value: int | None) -> int:
+    return int(value or 0)
+
+
+def _llm_call_span(
+    *, provider_name: str, model: str | None
+) -> AbstractContextManager[Any]:
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        return nullcontext(None)
+    tracer = trace.get_tracer(__name__)
+    span = tracer.start_as_current_span("llm.complete")
+    return span
 
 
 def _fallback_distribution() -> dict[str, float]:
@@ -103,11 +125,36 @@ async def _complete(
     provider_name: str,
     model: str | None = None,
     provider: LLMProvider | None = None,
-) -> str:
-    if provider:
-        return await provider.complete_text(prompt)
-    provider_instance = get_provider(provider_name, model=model)
-    return await provider_instance.complete_text(prompt)
+) -> CompletionResult:
+    with _llm_call_span(provider_name=provider_name, model=model) as span:
+        try:
+            if provider:
+                result = await provider.complete(prompt)
+            else:
+                provider_instance = get_provider(provider_name, model=model)
+                result = await provider_instance.complete(prompt)
+        except Exception as exc:
+            if span is not None:
+                span.set_attribute("llm.provider", provider_name)
+                if model:
+                    span.set_attribute("llm.model", model)
+                span.set_attribute("llm.status", "error")
+                span.record_exception(exc)
+                try:
+                    from opentelemetry.trace import Status, StatusCode
+
+                    span.set_status(Status(StatusCode.ERROR, str(exc)[:200]))
+                except ImportError:
+                    pass
+            raise
+
+        if span is not None:
+            span.set_attribute("llm.provider", provider_name)
+            span.set_attribute("llm.model", result.model or model or "")
+            span.set_attribute("llm.input_tokens", _token_count(result.input_tokens))
+            span.set_attribute("llm.output_tokens", _token_count(result.output_tokens))
+            span.set_attribute("llm.status", "ok")
+        return result
 
 
 def _build_prompt(source_block: str) -> str:
@@ -133,10 +180,14 @@ async def categorize_text_bundle(
 ) -> CategorizationOutcome:
     prompt = _build_prompt(bundle.source_block)
 
-    raw_response = await _complete(
+    raw_completion = await _complete(
         prompt, llm_provider, model=llm_model, provider=provider
     )
-    payload, parse_errors = parse_llm_json(raw_response)
+    input_tokens = _token_count(raw_completion.input_tokens)
+    output_tokens = _token_count(raw_completion.output_tokens)
+    llm_calls = 1
+    resolved_model = raw_completion.model
+    payload, parse_errors = parse_llm_json(raw_completion.text)
     if parse_errors:
         validation = LLMValidationResult(
             ok=False,
@@ -158,13 +209,21 @@ async def categorize_text_bundle(
             status="ok",
             errors=[],
             warnings=validation.warnings,
+            llm_calls=llm_calls,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            llm_model=resolved_model,
         )
 
     repair_prompt = _build_repair_prompt(validation.errors, bundle.source_block)
-    repaired_response = await _complete(
+    repaired_completion = await _complete(
         repair_prompt, llm_provider, model=llm_model, provider=provider
     )
-    payload, parse_errors = parse_llm_json(repaired_response)
+    input_tokens += _token_count(repaired_completion.input_tokens)
+    output_tokens += _token_count(repaired_completion.output_tokens)
+    llm_calls += 1
+    resolved_model = repaired_completion.model or resolved_model
+    payload, parse_errors = parse_llm_json(repaired_completion.text)
     if parse_errors:
         validation = LLMValidationResult(
             ok=False,
@@ -186,6 +245,10 @@ async def categorize_text_bundle(
             status="repaired",
             errors=[],
             warnings=validation.warnings,
+            llm_calls=llm_calls,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            llm_model=resolved_model,
         )
 
     logger.warning(
@@ -200,4 +263,8 @@ async def categorize_text_bundle(
         status="invalid_llm_output",
         errors=validation.errors,
         warnings=validation.warnings,
+        llm_calls=llm_calls,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        llm_model=resolved_model,
     )

--- a/src/dev_health_ops/work_graph/investment/categorize.py
+++ b/src/dev_health_ops/work_graph/investment/categorize.py
@@ -21,6 +21,9 @@ from dev_health_ops.work_graph.investment.utils import ensure_full_subcategory_v
 
 logger = logging.getLogger(__name__)
 
+TAXONOMY_VERSION = "investment-taxonomy-v1"
+PROMPT_VERSION = "investment-categorization-v1"
+
 CANONICAL_PROMPT = """You are categorizing work unit evidence into canonical investment subcategories.
 
 Rules:

--- a/src/dev_health_ops/work_graph/investment/categorize.py
+++ b/src/dev_health_ops/work_graph/investment/categorize.py
@@ -105,9 +105,9 @@ async def _complete(
     provider: LLMProvider | None = None,
 ) -> str:
     if provider:
-        return await provider.complete(prompt)
+        return await provider.complete_text(prompt)
     provider_instance = get_provider(provider_name, model=model)
-    return await provider_instance.complete(prompt)
+    return await provider_instance.complete_text(prompt)
 
 
 def _build_prompt(source_block: str) -> str:

--- a/src/dev_health_ops/work_graph/investment/categorize.py
+++ b/src/dev_health_ops/work_graph/investment/categorize.py
@@ -148,6 +148,7 @@ async def _complete(
 
                     span.set_status(Status(StatusCode.ERROR, str(exc)[:200]))
                 except ImportError:
+                    # OpenTelemetry status API is optional; skip enrichment.
                     pass
             raise
 

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -498,9 +498,12 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
         sink.ensure_schema()
 
         # Initialize LLM provider once (reusing connection pool)
-        resolved_llm_provider = resolve_provider_name(config.llm_provider)
+        resolved_llm_provider = resolve_provider_name(
+            config.llm_provider, org_id=config.org_id or None
+        )
         provider_instance = get_provider(
             resolved_llm_provider,
+            org_id=config.org_id or None,
             model=config.llm_model,
             api_key=config.llm_api_key or None,
             base_url=config.llm_base_url or None,

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -659,6 +659,27 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
         for idx, outcome in fallback_results:
             llm_results[idx] = outcome
 
+        llm_calls = sum(
+            int(getattr(outcome, "llm_calls", 0)) for outcome in llm_results.values()
+        )
+        llm_input_tokens = sum(
+            int(getattr(outcome, "input_tokens", 0)) for outcome in llm_results.values()
+        )
+        llm_output_tokens = sum(
+            int(getattr(outcome, "output_tokens", 0))
+            for outcome in llm_results.values()
+        )
+        if llm_calls or llm_failure_counts:
+            logger.info(
+                "LLM usage summary: calls=%d input_tokens=%d output_tokens=%d %s",
+                llm_calls,
+                llm_input_tokens,
+                llm_output_tokens,
+                _format_llm_summary(
+                    len(llm_results) - len(fallback_results), llm_failure_counts
+                ),
+            )
+
         # Post-process: create records from outcomes
         for idx, data in preprocessed.items():
             outcome = llm_results.get(idx)
@@ -796,6 +817,9 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
             "components": len(components),
             "records": len(records),
             "quotes": len(quote_records),
+            "llm_calls": llm_calls,
+            "llm_input_tokens": llm_input_tokens,
+            "llm_output_tokens": llm_output_tokens,
             "llm_failures": sum(llm_failure_counts.values()),
             "llm_failure_counts": dict(llm_failure_counts),
         }

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -22,6 +22,7 @@ from dev_health_ops.llm import (
     classify_provider_error,
     get_provider,
 )
+from dev_health_ops.llm.providers.none import NoneProvider
 from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
@@ -440,6 +441,13 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
             api_key=config.llm_api_key or None,
             base_url=config.llm_base_url or None,
         )
+        if isinstance(provider_instance, NoneProvider):
+            raise LLMAuthError(
+                "LLM provider 'none' cannot materialize investment categorizations; "
+                "configure a real LLM provider or use --llm-provider mock for tests.",
+                provider=config.llm_provider,
+                model="none",
+            )
 
         repo_ids = _resolve_repo_ids(
             sink, config.repo_ids, config.team_ids, config_org_id=config.org_id or ""

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -7,7 +7,7 @@ import json
 import logging
 import uuid
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
@@ -131,6 +131,8 @@ class MaterializeConfig:
     llm_provider: str
     persist_evidence_snippets: bool
     llm_model: str | None
+    llm_api_key: str = field(default="", repr=False)
+    llm_base_url: str = ""
     force: bool = False
     team_ids: list[str] | None = None
     llm_concurrency: int = 5
@@ -367,7 +369,12 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
         sink.ensure_schema()
 
         # Initialize LLM provider once (reusing connection pool)
-        provider_instance = get_provider(config.llm_provider, model=config.llm_model)
+        provider_instance = get_provider(
+            config.llm_provider,
+            model=config.llm_model,
+            api_key=config.llm_api_key or None,
+            base_url=config.llm_base_url or None,
+        )
 
         repo_ids = _resolve_repo_ids(
             sink, config.repo_ids, config.team_ids, config_org_id=config.org_id or ""

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -6,12 +6,22 @@ import asyncio
 import json
 import logging
 import uuid
+from collections import Counter
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
-from dev_health_ops.llm import get_provider
+from dev_health_ops.llm import (
+    LLMAuthError,
+    LLMContextLengthError,
+    LLMError,
+    LLMOutputError,
+    LLMRateLimitError,
+    LLMServerError,
+    classify_provider_error,
+    get_provider,
+)
 from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
@@ -52,6 +62,61 @@ from dev_health_ops.work_graph.investment.utils import (
 logger = logging.getLogger(__name__)
 
 NodeKey = tuple[str, str]
+
+
+def _classify_llm_exception(
+    exc: BaseException,
+    *,
+    provider: str,
+    model: str,
+) -> LLMError:
+    if isinstance(exc, LLMError):
+        return exc
+    return classify_provider_error(exc, provider=provider, model=model)
+
+
+def _llm_failure_class(exc: BaseException) -> str:
+    text = str(exc).lower()
+    if "insufficient_quota" in text or "quota exhausted" in text:
+        return "quota_exceeded"
+    if "model_not_found" in text or "model not found" in text:
+        return "model_not_found"
+    if "missing" in text and "api key" in text:
+        return "missing_key"
+    if "invalid" in text and "api key" in text:
+        return "invalid_api_key"
+    if isinstance(exc, LLMAuthError):
+        return "auth"
+    if isinstance(exc, LLMRateLimitError):
+        return "rate_limit"
+    if isinstance(exc, LLMServerError):
+        return "server_error"
+    if isinstance(exc, LLMContextLengthError):
+        return "context_length"
+    if isinstance(exc, LLMOutputError):
+        return "output_error"
+    return "llm_error"
+
+
+def _is_deterministic_llm_failure(exc: BaseException) -> bool:
+    if isinstance(exc, LLMAuthError):
+        return True
+    return _llm_failure_class(exc) in {
+        "invalid_api_key",
+        "missing_key",
+        "model_not_found",
+        "quota_exceeded",
+    }
+
+
+def _format_llm_summary(ok: int, failure_counts: Counter[str]) -> str:
+    parts = [f"{ok} ok"]
+    parts.extend(
+        f"{count} {failure_class}"
+        for failure_class, count in sorted(failure_counts.items())
+        if count
+    )
+    return "llm: " + ", ".join(parts)
 
 
 @dataclass(frozen=True)
@@ -362,7 +427,7 @@ def _resolve_repo_ids(
     return None
 
 
-async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
+async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
     sink = create_sink(config.dsn)
     provider_instance = None
     try:
@@ -522,6 +587,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
         # Parallel LLM categorization with concurrency limit
         semaphore = asyncio.Semaphore(config.llm_concurrency)
         llm_results: dict[int, Any] = {}
+        llm_failure_counts: Counter[str] = Counter()
 
         async def categorize_with_limit(idx: int, bundle: Any) -> tuple[int, Any]:
             async with semaphore:
@@ -539,18 +605,47 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
                 len(pending_llm),
                 config.llm_concurrency,
             )
-            tasks = [categorize_with_limit(idx, bundle) for idx, bundle in pending_llm]
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            for result in results:
-                if isinstance(result, Exception):
-                    logger.warning("LLM task failed: %s", result)
+            tasks = [
+                asyncio.create_task(categorize_with_limit(idx, bundle))
+                for idx, bundle in pending_llm
+            ]
+            for task in asyncio.as_completed(tasks):
+                try:
+                    result = await task
+                except Exception as exc:
+                    classified = _classify_llm_exception(
+                        exc,
+                        provider=config.llm_provider,
+                        model=config.llm_model or config.llm_provider,
+                    )
+                    failure_class = _llm_failure_class(classified)
+                    llm_failure_counts[failure_class] += 1
+                    if _is_deterministic_llm_failure(classified):
+                        for pending_task in tasks:
+                            if not pending_task.done():
+                                pending_task.cancel()
+                        await asyncio.gather(*tasks, return_exceptions=True)
+                        verdict = _format_llm_summary(
+                            len(llm_results), llm_failure_counts
+                        )
+                        logger.error(
+                            "Investment materialization stopped on fatal LLM failure: %s",
+                            verdict,
+                        )
+                        raise classified
+                    logger.warning(
+                        "LLM task failed (%s): %s", failure_class, classified
+                    )
                     continue
                 if not isinstance(result, tuple) or len(result) != 2:
                     logger.warning("Unexpected LLM task result: %r", result)
                     continue
                 idx, outcome = result
                 llm_results[idx] = outcome
-            logger.info("Completed %d LLM categorizations", len(llm_results))
+            logger.info(
+                "Completed LLM categorizations: %s",
+                _format_llm_summary(len(llm_results), llm_failure_counts),
+            )
 
         # Merge fallback results
         for idx, outcome in fallback_results:
@@ -693,6 +788,8 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, int]:
             "components": len(components),
             "records": len(records),
             "quotes": len(quote_records),
+            "llm_failures": sum(llm_failure_counts.values()),
+            "llm_failure_counts": dict(llm_failure_counts),
         }
     finally:
         sink.close()

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -21,6 +21,8 @@ from dev_health_ops.llm import (
     LLMServerError,
     classify_provider_error,
     get_provider,
+    resolve_model_name,
+    resolve_provider_name,
 )
 from dev_health_ops.llm.providers.none import NoneProvider
 from dev_health_ops.metrics.schemas import (
@@ -31,6 +33,8 @@ from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 from dev_health_ops.metrics.sinks.factory import create_sink
 from dev_health_ops.work_graph.ids import parse_commit_from_id, parse_pr_from_id
 from dev_health_ops.work_graph.investment.categorize import (
+    PROMPT_VERSION,
+    TAXONOMY_VERSION,
     categorize_text_bundle,
     fallback_outcome,
 )
@@ -120,6 +124,62 @@ def _format_llm_summary(ok: int, failure_counts: Counter[str]) -> str:
     return "llm: " + ", ".join(parts)
 
 
+def _effective_model_version(provider: str, model: str | None) -> str:
+    resolved_model = resolve_model_name(provider, model) or model or provider
+    return (
+        f"provider={provider};model={resolved_model};"
+        f"taxonomy={TAXONOMY_VERSION};prompt={PROMPT_VERSION}"
+    )
+
+
+def _fetch_existing_investment_keys(
+    sink: BaseMetricsSink,
+    *,
+    org_id: str,
+    keys: Iterable[tuple[str, str]],
+    model_version: str,
+) -> set[tuple[str, str]]:
+    key_list = list(dict.fromkeys(keys))
+    if not key_list or not hasattr(sink, "query_dicts"):
+        return set()
+    work_unit_ids = sorted({work_unit_id for work_unit_id, _ in key_list})
+    input_hashes = sorted({input_hash for _, input_hash in key_list})
+    query = """
+        SELECT work_unit_id, categorization_input_hash
+        FROM (
+            SELECT
+                work_unit_id,
+                categorization_input_hash,
+                argMax(categorization_status, computed_at) AS latest_status
+            FROM work_unit_investments
+            WHERE org_id = %(org_id)s
+              AND work_unit_id IN %(work_unit_ids)s
+              AND categorization_input_hash IN %(input_hashes)s
+              AND categorization_model_version = %(model_version)s
+            GROUP BY work_unit_id, categorization_input_hash
+        )
+        WHERE latest_status IN %(valid_statuses)s
+    """
+    rows = sink.query_dicts(
+        query,
+        {
+            "org_id": org_id,
+            "work_unit_ids": work_unit_ids,
+            "input_hashes": input_hashes,
+            "model_version": model_version,
+            "valid_statuses": ["ok", "repaired"],
+        },
+    )
+    return {
+        (
+            str(row.get("work_unit_id") or ""),
+            str(row.get("categorization_input_hash") or ""),
+        )
+        for row in rows
+        if row.get("work_unit_id") and row.get("categorization_input_hash")
+    }
+
+
 @dataclass(frozen=True)
 class PreprocessedComponent:
     unit_id: str
@@ -203,6 +263,9 @@ class MaterializeConfig:
     team_ids: list[str] | None = None
     llm_concurrency: int = 5
     org_id: str | None = None
+    run_id: str | None = None
+    computed_at: datetime | None = None
+    component_indexes: list[int] | None = None
 
 
 def _build_components(
@@ -435,8 +498,9 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
         sink.ensure_schema()
 
         # Initialize LLM provider once (reusing connection pool)
+        resolved_llm_provider = resolve_provider_name(config.llm_provider)
         provider_instance = get_provider(
-            config.llm_provider,
+            resolved_llm_provider,
             model=config.llm_model,
             api_key=config.llm_api_key or None,
             base_url=config.llm_base_url or None,
@@ -445,7 +509,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
             raise LLMAuthError(
                 "LLM provider 'none' cannot materialize investment categorizations; "
                 "configure a real LLM provider or use --llm-provider mock for tests.",
-                provider=config.llm_provider,
+                provider=resolved_llm_provider,
                 model="none",
             )
 
@@ -456,11 +520,19 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
             sink, repo_ids=repo_ids, org_id=config.org_id or ""
         )
         components = _build_components(edges)
+        total_components = len(components)
         if not components:
             logger.info(
                 "No work graph components found for investment materialization."
             )
             return {"components": 0, "records": 0, "quotes": 0}
+        if config.component_indexes is not None:
+            wanted_indexes = set(config.component_indexes)
+            components = [
+                component
+                for component_index, component in enumerate(components)
+                if component_index in wanted_indexes
+            ]
 
         issue_ids = {
             node_id
@@ -518,9 +590,11 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
 
         records: list[WorkUnitInvestmentRecord] = []
         quote_records: list[WorkUnitInvestmentEvidenceQuoteRecord] = []
-        run_id = uuid.uuid4().hex
-        computed_at = datetime.now(timezone.utc)
-        model_version = config.llm_model or config.llm_provider
+        run_id = config.run_id or uuid.uuid4().hex
+        computed_at = config.computed_at or datetime.now(timezone.utc)
+        model_version = _effective_model_version(
+            resolved_llm_provider, config.llm_model
+        )
 
         logger.info(
             "Materializing investments for %d components (run_id=%s)",
@@ -592,6 +666,33 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
             len(fallback_results),
         )
 
+        skipped_existing: set[int] = set()
+        if pending_llm and not config.force:
+            pending_keys = {
+                idx: (preprocessed[idx].unit_id, bundle.input_hash)
+                for idx, bundle in pending_llm
+            }
+            existing_keys = await asyncio.to_thread(
+                _fetch_existing_investment_keys,
+                sink,
+                org_id=config.org_id or "",
+                keys=pending_keys.values(),
+                model_version=model_version,
+            )
+            skipped_existing = {
+                idx for idx, key in pending_keys.items() if key in existing_keys
+            }
+            if skipped_existing:
+                pending_llm = [
+                    (idx, bundle)
+                    for idx, bundle in pending_llm
+                    if idx not in skipped_existing
+                ]
+                logger.info(
+                    "Skipping %d unchanged investment bundle(s) with fresh categorization",
+                    len(skipped_existing),
+                )
+
         # Parallel LLM categorization with concurrency limit
         semaphore = asyncio.Semaphore(config.llm_concurrency)
         llm_results: dict[int, Any] = {}
@@ -601,7 +702,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
             async with semaphore:
                 outcome = await categorize_text_bundle(
                     bundle,
-                    llm_provider=config.llm_provider,
+                    llm_provider=resolved_llm_provider,
                     llm_model=config.llm_model,
                     provider=provider_instance,
                 )
@@ -682,6 +783,8 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
 
         # Post-process: create records from outcomes
         for idx, data in preprocessed.items():
+            if idx in skipped_existing:
+                continue
             outcome = llm_results.get(idx)
             if outcome is None:
                 outcome = fallback_outcome("llm_task_failed")
@@ -815,8 +918,10 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
 
         return {
             "components": len(components),
+            "total_components": total_components,
             "records": len(records),
             "quotes": len(quote_records),
+            "skipped_existing": len(skipped_existing),
             "llm_calls": llm_calls,
             "llm_input_tokens": llm_input_tokens,
             "llm_output_tokens": llm_output_tokens,

--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -40,6 +40,15 @@ def _component_count(edges: list[tuple[str, str, str, str]]) -> int:
     return count
 
 
+def _llm_concurrency(value: object | None = None) -> int:
+    raw = value if value is not None else os.getenv("INVESTMENT_LLM_CONCURRENCY", "5")
+    try:
+        concurrency = int(str(raw))
+    except (TypeError, ValueError):
+        concurrency = 5
+    return max(1, concurrency)
+
+
 def run_work_graph_build(ns: argparse.Namespace) -> int:
     # Parse dates
     from_date = None
@@ -217,6 +226,9 @@ def run_investment_materialization(ns: argparse.Namespace) -> int:
         llm_provider=getattr(ns, "llm_provider", "auto") or "auto",
         persist_evidence_snippets=getattr(ns, "persist_evidence_snippets", True),
         llm_model=getattr(ns, "model", None),
+        llm_api_key=str(getattr(ns, "llm_api_key", None) or ""),
+        llm_base_url=str(getattr(ns, "llm_base_url", None) or ""),
+        llm_concurrency=_llm_concurrency(getattr(ns, "llm_concurrency", None)),
         team_ids=team_ids or None,
         force=getattr(ns, "force", False),
         org_id=org_id,

--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -181,6 +181,9 @@ def run_work_graph_build(ns: argparse.Namespace) -> int:
 
 
 def run_investment_materialization(ns: argparse.Namespace) -> int:
+    analytics_db = str(
+        getattr(ns, "analytics_db", None) or os.getenv("CLICKHOUSE_URI") or ""
+    )
     now = datetime.now(timezone.utc)
     if ns.to_date:
         to_day = date.fromisoformat(ns.to_date)
@@ -207,7 +210,7 @@ def run_investment_materialization(ns: argparse.Namespace) -> int:
     org_id = getattr(ns, "org", None) or None
 
     config = MaterializeConfig(
-        dsn=ns.db,
+        dsn=analytics_db,
         from_ts=from_ts,
         to_ts=to_ts,
         repo_ids=repo_ids or None,
@@ -266,7 +269,7 @@ def run_investment_materialization(ns: argparse.Namespace) -> int:
         )
         try:
             mstats = backfill_memberships(
-                MembershipBackfillConfig(dsn=ns.db, org_id=org_id, repo_ids=None)
+                MembershipBackfillConfig(dsn=analytics_db, org_id=org_id, repo_ids=None)
             )
             logging.info(
                 "Membership projection complete. Components=%d Matched=%d "
@@ -384,9 +387,12 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         help="Materialize work unit investment categorization into sinks.",
     )
     investment_materialize.add_argument(
+        "--analytics-db",
         "--db",
-        default=os.getenv("CLICKHOUSE_URI"),
-        help="ClickHouse connection string (clickhouse://user:pass@host:port/db). Env: CLICKHOUSE_URI",
+        dest="analytics_db",
+        default=argparse.SUPPRESS,
+        help="ClickHouse connection string (clickhouse://user:pass@host:port/db). "
+        "Env: CLICKHOUSE_URI. Deprecated alias on this subcommand: --db.",
     )
     investment_materialize.add_argument(
         "--from",
@@ -423,7 +429,7 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
     )
     from dev_health_ops.llm.cli import add_llm_arguments
 
-    add_llm_arguments(investment_materialize)
+    add_llm_arguments(investment_materialize, leaf_mode=True)
     investment_materialize.add_argument(
         "--persist-evidence-snippets",
         dest="persist_evidence_snippets",

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -29,6 +29,7 @@ late_ack_excluded_tasks = (
     "dev_health_ops.workers.tasks.dispatch_scheduled_syncs",
     "dev_health_ops.workers.tasks.dispatch_scheduled_metrics",
     "dev_health_ops.workers.tasks.dispatch_daily_metrics_partitioned",
+    "dev_health_ops.workers.tasks.dispatch_investment_materialize_partitioned",
     "dev_health_ops.workers.tasks.dispatch_release_impact",
     "dev_health_ops.workers.tasks.dispatch_membership_backfill",
     "dev_health_ops.workers.tasks.dispatch_scheduled_reports",

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -375,16 +375,6 @@ def _dispatch_post_sync_tasks(
         # build *succeeds*. The links are immutable (.si()) so a parent's return
         # value is not injected as a positional arg into the next step.
         #
-        # CHAOS-2433 round-3 finding #2 — UNIFIED MEMBERSHIP WRITER:
-        # build -> materialize (LLM; writes work_unit_investments ONLY) ->
-        # project-membership (no-LLM; writes work_unit_membership + the
-        # completion marker with FULL current-component coverage).  The
-        # materializer no longer writes membership/markers, so a date-windowed
-        # materialize can never publish partial-coverage that would blank
-        # out-of-window components.  The projection iterates the whole current
-        # work graph and reads the investments materialize just persisted, so
-        # membership stays fresh AND full-coverage.  run_membership_backfill is
-        # the projection task (no-LLM, org-wide, full coverage).
         build_sig = celery_app.signature(
             "dev_health_ops.workers.tasks.run_work_graph_build",
             kwargs=build_kwargs,
@@ -392,15 +382,9 @@ def _dispatch_post_sync_tasks(
             immutable=has_work_items,
         )
         materialize_sig = celery_app.signature(
-            "dev_health_ops.workers.tasks.run_investment_materialize",
+            "dev_health_ops.workers.tasks.dispatch_investment_materialize_partitioned",
             kwargs=materialize_kwargs,
-            queue="metrics",
-            immutable=True,
-        )
-        project_membership_sig = celery_app.signature(
-            "dev_health_ops.workers.tasks.run_membership_backfill",
-            kwargs={"org_id": org_id},
-            queue="metrics",
+            queue="default",
             immutable=True,
         )
         if has_work_items:
@@ -420,13 +404,11 @@ def _dispatch_post_sync_tasks(
                 daily_metrics_sig,
                 build_sig,
                 materialize_sig,
-                project_membership_sig,
             ).apply_async()
         else:
-            chain(build_sig, materialize_sig, project_membership_sig).apply_async()
+            chain(build_sig, materialize_sig).apply_async()
         dispatched.append("run_work_graph_build")
-        dispatched.append("run_investment_materialize")
-        dispatched.append("run_membership_backfill")
+        dispatched.append("dispatch_investment_materialize_partitioned")
 
     if has_git or has_dora:
         # CHAOS-2382: DORA is provider-agnostic — computed from synced

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -50,8 +50,11 @@ from dev_health_ops.workers.task_utils import (
     _resolve_env_credentials,
 )
 from dev_health_ops.workers.work_graph_tasks import (
+    dispatch_investment_materialize_partitioned,
     dispatch_membership_backfill,
+    finalize_investment_materialize_partitioned,
     run_investment_materialize,
+    run_investment_materialize_chunk,
     run_membership_backfill,
     run_work_graph_build,
 )
@@ -68,6 +71,7 @@ __all__ = [
     "_run_sync_for_repo",
     "dispatch_batch_sync",
     "dispatch_daily_metrics_partitioned",
+    "dispatch_investment_materialize_partitioned",
     "dispatch_release_impact",
     "dispatch_scheduled_metrics",
     "dispatch_scheduled_reports",
@@ -88,6 +92,8 @@ __all__ = [
     "run_dora_metrics",
     "run_ingest_consumer",
     "run_investment_materialize",
+    "run_investment_materialize_chunk",
+    "finalize_investment_materialize_partitioned",
     "run_membership_backfill",
     "run_product_telemetry_consumer",
     "run_recommendations_job",

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -461,6 +461,9 @@ def dispatch_investment_materialize_partitioned(
     )
     from dev_health_ops.work_graph.investment.queries import fetch_work_graph_edges
 
+    # Hoisted to guarantee definite assignment on every return path (CodeQL).
+    run_membership = not (repo_ids or team_ids or from_date or to_date)
+
     db_url = db_url or _get_db_url()
     sink = create_sink(db_url)
     try:
@@ -483,7 +486,6 @@ def dispatch_investment_materialize_partitioned(
     chunks = [indexes[i : i + size] for i in range(0, len(indexes), size)]
     run_id = uuid.uuid4().hex
     computed_at = datetime.now(timezone.utc).isoformat()
-    run_membership = not (repo_ids or team_ids or from_date or to_date)
 
     header = [
         celery_app.signature(

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -14,6 +14,17 @@ from dev_health_ops.workers.task_utils import _get_db_url
 logger = logging.getLogger(__name__)
 
 
+def _llm_concurrency(value: object | None = None) -> int:
+    import os
+
+    raw = value if value is not None else os.getenv("INVESTMENT_LLM_CONCURRENCY", "5")
+    try:
+        concurrency = int(str(raw))
+    except (TypeError, ValueError):
+        concurrency = 5
+    return max(1, concurrency)
+
+
 @celery_app.task(
     bind=True,
     max_retries=3,
@@ -106,6 +117,7 @@ def run_investment_materialize(
     team_ids: list[str] | None = None,
     llm_provider: str = "auto",
     llm_model: str | None = None,
+    llm_concurrency: int | None = None,
     force: bool = False,
     org_id: str = "",
 ) -> dict:
@@ -120,6 +132,7 @@ def run_investment_materialize(
         team_ids: Optional list of team IDs to filter
         llm_provider: LLM provider (auto|openai|anthropic)
         llm_model: Optional specific LLM model
+        llm_concurrency: Maximum concurrent LLM categorizations
         force: Force recomputation even if cached
         org_id: Organization scope for work-graph/investment queries
 
@@ -127,6 +140,8 @@ def run_investment_materialize(
         dict with materialization status and stats
     """
 
+    from dev_health_ops.llm import LLMAuthError, resolve_provider_name
+    from dev_health_ops.llm.credentials import resolve_llm_credentials
     from dev_health_ops.work_graph.investment.materialize import (
         MaterializeConfig,
         materialize_investments,
@@ -164,20 +179,30 @@ def run_investment_materialize(
     )
 
     try:
+        resolved_provider = resolve_provider_name(llm_provider)
+        llm_credentials = resolve_llm_credentials(
+            resolved_provider, org_id=org_id or None
+        )
         config = MaterializeConfig(
             dsn=db_url,
             from_ts=parsed_from,
             to_ts=parsed_to,
             repo_ids=repo_ids,
-            llm_provider=llm_provider,
+            llm_provider=resolved_provider,
             persist_evidence_snippets=True,
             llm_model=llm_model,
+            llm_api_key=llm_credentials.api_key,
+            llm_base_url=llm_credentials.base_url,
+            llm_concurrency=_llm_concurrency(llm_concurrency),
             team_ids=team_ids,
             force=force,
             org_id=org_id or None,
         )
         stats = run_async(materialize_investments(config))
         return {"status": "success", "stats": stats}
+    except LLMAuthError as exc:
+        logger.error("Investment materialize task failed with LLM auth error: %s", exc)
+        raise
     except Exception as exc:
         logger.exception("Investment materialize task failed: %s", exc)
         raise self.retry(exc=exc, countdown=120 * (2**self.request.retries))

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -4,8 +4,9 @@ import logging
 import uuid
 from datetime import date, datetime, timedelta, timezone
 from datetime import time as dt_time
+from typing import Any
 
-from celery import chain
+from celery import chain, chord
 
 from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
@@ -23,6 +24,54 @@ def _llm_concurrency(value: object | None = None) -> int:
     except (TypeError, ValueError):
         concurrency = 5
     return max(1, concurrency)
+
+
+def _investment_chunk_size(value: object | None = None) -> int:
+    import os
+
+    raw = (
+        value
+        if value is not None
+        else os.getenv("INVESTMENT_MATERIALIZE_CHUNK_SIZE", "25")
+    )
+    try:
+        chunk_size = int(str(raw))
+    except (TypeError, ValueError):
+        chunk_size = 25
+    return max(1, chunk_size)
+
+
+def _parse_materialize_window(
+    *,
+    from_date: str | None,
+    to_date: str | None,
+    window_days: int,
+) -> tuple[datetime, datetime]:
+    now = datetime.now(timezone.utc)
+    if to_date:
+        parsed_to = datetime.combine(
+            date.fromisoformat(to_date) + timedelta(days=1),
+            dt_time.min,
+            tzinfo=timezone.utc,
+        )
+    else:
+        parsed_to = now
+
+    if from_date:
+        parsed_from = datetime.combine(
+            date.fromisoformat(from_date),
+            dt_time.min,
+            tzinfo=timezone.utc,
+        )
+    else:
+        parsed_from = parsed_to - timedelta(days=window_days)
+    return parsed_from, parsed_to
+
+
+def _investment_chunk_scope_id(run_id: str, chunk_index: int) -> uuid.UUID:
+    return uuid.uuid5(
+        uuid.NAMESPACE_URL, f"dev-health:investment:{run_id}:{chunk_index}"
+    )
 
 
 @celery_app.task(
@@ -148,27 +197,11 @@ def run_investment_materialize(
     )
 
     db_url = db_url or _get_db_url()
-    now = datetime.now(timezone.utc)
-
-    # Parse to_date
-    if to_date:
-        parsed_to = datetime.combine(
-            date.fromisoformat(to_date) + timedelta(days=1),
-            dt_time.min,
-            tzinfo=timezone.utc,
-        )
-    else:
-        parsed_to = now
-
-    # Parse from_date
-    if from_date:
-        parsed_from = datetime.combine(
-            date.fromisoformat(from_date),
-            dt_time.min,
-            tzinfo=timezone.utc,
-        )
-    else:
-        parsed_from = parsed_to - timedelta(days=window_days)
+    parsed_from, parsed_to = _parse_materialize_window(
+        from_date=from_date,
+        to_date=to_date,
+        window_days=window_days,
+    )
 
     logger.info(
         "Starting investment materialize task: from=%s to=%s repos=%s teams=%s",
@@ -211,6 +244,290 @@ def run_investment_materialize(
     except Exception as exc:
         logger.exception("Investment materialize task failed: %s", exc)
         raise self.retry(exc=exc, countdown=120 * (2**self.request.retries))
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=2,
+    queue="metrics",
+    name="dev_health_ops.workers.tasks.run_investment_materialize_chunk",
+)
+def run_investment_materialize_chunk(
+    self,
+    db_url: str | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    window_days: int = 30,
+    repo_ids: list[str] | None = None,
+    team_ids: list[str] | None = None,
+    llm_provider: str = "auto",
+    llm_model: str | None = None,
+    llm_concurrency: int | None = None,
+    force: bool = False,
+    org_id: str = "",
+    run_id: str = "",
+    computed_at: str = "",
+    component_indexes: list[int] | None = None,
+    chunk_index: int = 0,
+) -> dict:
+    from dev_health_ops.db import get_postgres_session_sync
+    from dev_health_ops.llm import LLMAuthError, LLMError, resolve_provider_name
+    from dev_health_ops.llm.credentials import resolve_llm_credentials
+    from dev_health_ops.metrics.checkpoints import (
+        is_completed,
+        mark_completed,
+        mark_failed,
+        mark_running,
+    )
+    from dev_health_ops.work_graph.investment.materialize import (
+        MaterializeConfig,
+        materialize_investments,
+    )
+
+    db_url = db_url or _get_db_url()
+    parsed_from, parsed_to = _parse_materialize_window(
+        from_date=from_date,
+        to_date=to_date,
+        window_days=window_days,
+    )
+    shared_computed_at = datetime.fromisoformat(computed_at)
+    if shared_computed_at.tzinfo is None:
+        shared_computed_at = shared_computed_at.replace(tzinfo=timezone.utc)
+    run_id = run_id or uuid.uuid4().hex
+    checkpoint_scope = _investment_chunk_scope_id(run_id, chunk_index)
+    checkpoint_id: uuid.UUID | None = None
+
+    try:
+        with get_postgres_session_sync() as session:
+            if is_completed(
+                session,
+                org_id or "default",
+                checkpoint_scope,
+                "investment_materialize_chunk",
+                shared_computed_at,
+            ):
+                return {
+                    "status": "skipped",
+                    "reason": "already_completed",
+                    "chunk_index": chunk_index,
+                    "records": 0,
+                    "quotes": 0,
+                }
+            checkpoint = mark_running(
+                session,
+                org_id or "default",
+                checkpoint_scope,
+                "investment_materialize_chunk",
+                shared_computed_at,
+                str(self.request.id or "unknown"),
+            )
+            checkpoint_id = uuid.UUID(str(checkpoint.id))
+
+        resolved_provider = resolve_provider_name(llm_provider)
+        llm_credentials = resolve_llm_credentials(
+            resolved_provider, org_id=org_id or None
+        )
+        config = MaterializeConfig(
+            dsn=db_url,
+            from_ts=parsed_from,
+            to_ts=parsed_to,
+            repo_ids=repo_ids,
+            llm_provider=resolved_provider,
+            persist_evidence_snippets=True,
+            llm_model=llm_model,
+            llm_api_key=llm_credentials.api_key,
+            llm_base_url=llm_credentials.base_url,
+            llm_concurrency=_llm_concurrency(llm_concurrency),
+            team_ids=team_ids,
+            force=force,
+            org_id=org_id or None,
+            run_id=run_id,
+            computed_at=shared_computed_at,
+            component_indexes=component_indexes,
+        )
+        stats = run_async(materialize_investments(config))
+
+        if checkpoint_id is not None:
+            with get_postgres_session_sync() as session:
+                mark_completed(session, checkpoint_id)
+        return {"status": "success", "chunk_index": chunk_index, "stats": stats}
+    except (LLMAuthError, LLMError):
+        if checkpoint_id is not None:
+            try:
+                with get_postgres_session_sync() as session:
+                    mark_failed(session, checkpoint_id, "classified LLM failure")
+            except Exception:
+                logger.exception("Failed to mark investment chunk checkpoint failed")
+        raise
+    except Exception as exc:
+        if checkpoint_id is not None:
+            try:
+                with get_postgres_session_sync() as session:
+                    mark_failed(session, checkpoint_id, str(exc))
+            except Exception:
+                logger.exception("Failed to mark investment chunk checkpoint failed")
+        logger.exception("Investment materialize chunk failed: %s", exc)
+        raise self.retry(exc=exc, countdown=120 * (2**self.request.retries))
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=2,
+    queue="metrics",
+    name="dev_health_ops.workers.tasks.finalize_investment_materialize_partitioned",
+)
+def finalize_investment_materialize_partitioned(
+    self,
+    chunk_results: list,
+    db_url: str | None = None,
+    org_id: str = "",
+    run_id: str = "",
+    run_membership_backfill_after: bool = False,
+) -> dict:
+    db_url = db_url or _get_db_url()
+    totals: dict[str, Any] = {
+        "status": "success",
+        "run_id": run_id,
+        "chunks": len(chunk_results or []),
+        "records": 0,
+        "quotes": 0,
+        "skipped_existing": 0,
+        "llm_calls": 0,
+        "llm_input_tokens": 0,
+        "llm_output_tokens": 0,
+        "llm_failures": 0,
+        "llm_failure_counts": {},
+    }
+    try:
+        for result in chunk_results or []:
+            stats = result.get("stats", {}) if isinstance(result, dict) else {}
+            for key in (
+                "records",
+                "quotes",
+                "skipped_existing",
+                "llm_calls",
+                "llm_input_tokens",
+                "llm_output_tokens",
+                "llm_failures",
+            ):
+                totals[key] += int(stats.get(key, 0) or 0)
+            for failure_class, count in dict(
+                stats.get("llm_failure_counts", {})
+            ).items():
+                current = totals["llm_failure_counts"].get(failure_class, 0)
+                totals["llm_failure_counts"][failure_class] = current + int(count or 0)
+
+        if run_membership_backfill_after:
+            from dev_health_ops.work_graph.investment.backfill import (
+                MembershipBackfillConfig,
+                backfill_memberships,
+            )
+
+            totals["membership"] = backfill_memberships(
+                MembershipBackfillConfig(
+                    dsn=db_url, org_id=org_id or None, repo_ids=None
+                )
+            )
+        return totals
+    except Exception as exc:
+        logger.exception("Investment materialize partition finalizer failed: %s", exc)
+        raise self.retry(exc=exc, countdown=120 * (2**self.request.retries))
+
+
+@celery_app.task(
+    bind=True,
+    queue="default",
+    name="dev_health_ops.workers.tasks.dispatch_investment_materialize_partitioned",
+)
+def dispatch_investment_materialize_partitioned(
+    self,
+    db_url: str | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    window_days: int = 30,
+    repo_ids: list[str] | None = None,
+    team_ids: list[str] | None = None,
+    llm_provider: str = "auto",
+    llm_model: str | None = None,
+    llm_concurrency: int | None = None,
+    force: bool = False,
+    org_id: str = "",
+    chunk_size: int | None = None,
+) -> dict:
+    from dev_health_ops.metrics.sinks.factory import create_sink
+    from dev_health_ops.work_graph.investment.materialize import (
+        _build_components,
+        _resolve_repo_ids,
+    )
+    from dev_health_ops.work_graph.investment.queries import fetch_work_graph_edges
+
+    db_url = db_url or _get_db_url()
+    sink = create_sink(db_url)
+    try:
+        sink.ensure_schema()
+        resolved_repo_ids = _resolve_repo_ids(
+            sink, repo_ids, team_ids, config_org_id=org_id or ""
+        )
+        edges = fetch_work_graph_edges(
+            sink, repo_ids=resolved_repo_ids, org_id=org_id or ""
+        )
+        components = _build_components(edges)
+    finally:
+        sink.close()
+
+    if not components:
+        return {"status": "no_components", "dispatched": 0, "chunks": 0}
+
+    size = _investment_chunk_size(chunk_size)
+    indexes = list(range(len(components)))
+    chunks = [indexes[i : i + size] for i in range(0, len(indexes), size)]
+    run_id = uuid.uuid4().hex
+    computed_at = datetime.now(timezone.utc).isoformat()
+    run_membership = not (repo_ids or team_ids or from_date or to_date)
+
+    header = [
+        celery_app.signature(
+            "dev_health_ops.workers.tasks.run_investment_materialize_chunk",
+            kwargs={
+                "db_url": db_url,
+                "from_date": from_date,
+                "to_date": to_date,
+                "window_days": window_days,
+                "repo_ids": repo_ids,
+                "team_ids": team_ids,
+                "llm_provider": llm_provider,
+                "llm_model": llm_model,
+                "llm_concurrency": llm_concurrency,
+                "force": force,
+                "org_id": org_id,
+                "run_id": run_id,
+                "computed_at": computed_at,
+                "component_indexes": chunk_indexes,
+                "chunk_index": chunk_index,
+            },
+            queue="metrics",
+        )
+        for chunk_index, chunk_indexes in enumerate(chunks)
+    ]
+    callback = celery_app.signature(
+        "dev_health_ops.workers.tasks.finalize_investment_materialize_partitioned",
+        kwargs={
+            "db_url": db_url,
+            "org_id": org_id,
+            "run_id": run_id,
+            "run_membership_backfill_after": run_membership,
+        },
+        queue="metrics",
+    )
+    chord(header, callback).apply_async()
+    return {
+        "status": "dispatched",
+        "components": len(components),
+        "chunks": len(chunks),
+        "run_id": run_id,
+        "computed_at": computed_at,
+        "membership_in_finalizer": run_membership,
+    }
 
 
 @celery_app.task(

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -212,7 +212,7 @@ def run_investment_materialize(
     )
 
     try:
-        resolved_provider = resolve_provider_name(llm_provider)
+        resolved_provider = resolve_provider_name(llm_provider, org_id=org_id or None)
         llm_credentials = resolve_llm_credentials(
             resolved_provider, org_id=org_id or None
         )
@@ -323,7 +323,7 @@ def run_investment_materialize_chunk(
             )
             checkpoint_id = uuid.UUID(str(checkpoint.id))
 
-        resolved_provider = resolve_provider_name(llm_provider)
+        resolved_provider = resolve_provider_name(llm_provider, org_id=org_id or None)
         llm_credentials = resolve_llm_credentials(
             resolved_provider, org_id=org_id or None
         )

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -140,7 +140,7 @@ def run_investment_materialize(
         dict with materialization status and stats
     """
 
-    from dev_health_ops.llm import LLMAuthError, resolve_provider_name
+    from dev_health_ops.llm import LLMAuthError, LLMError, resolve_provider_name
     from dev_health_ops.llm.credentials import resolve_llm_credentials
     from dev_health_ops.work_graph.investment.materialize import (
         MaterializeConfig,
@@ -202,6 +202,11 @@ def run_investment_materialize(
         return {"status": "success", "stats": stats}
     except LLMAuthError as exc:
         logger.error("Investment materialize task failed with LLM auth error: %s", exc)
+        raise
+    except LLMError as exc:
+        logger.error(
+            "Investment materialize task failed with classified LLM error: %s", exc
+        )
         raise
     except Exception as exc:
         logger.exception("Investment materialize task failed: %s", exc)

--- a/tests/api/admin/test_llm_settings.py
+++ b/tests/api/admin/test_llm_settings.py
@@ -208,8 +208,8 @@ def test_resolve_provider_name_uses_org_settings_in_auto(monkeypatch):
     # only configured BYO settings must resolve its provider via org_id. Hermetic:
     # clear ALL env provider signals (env detection precedes org settings) and
     # mock the org-settings loader so this is order-independent in the full suite.
-    import dev_health_ops.llm.credentials as creds
     from dev_health_ops.llm import LLMAuthError
+    from dev_health_ops.llm import credentials as creds
     from dev_health_ops.llm.providers import resolve_provider_name
 
     for var in (

--- a/tests/api/admin/test_llm_settings.py
+++ b/tests/api/admin/test_llm_settings.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import importlib
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.core.encryption import decrypt_value
+from dev_health_ops.llm.credentials import resolve_llm_org_settings_credentials
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.licensing import OrgLicense
+from dev_health_ops.models.settings import Setting, SettingCategory
+from dev_health_ops.models.users import Organization, User
+from tests._helpers import tables_of
+
+os.environ.setdefault("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+
+admin_router_module = importlib.import_module("dev_health_ops.api.admin")
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+_TABLES = tables_of(User, Organization, OrgLicense, Setting)
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    db_path = tmp_path / "llm-settings.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("POSTGRES_URI", sync_url)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    engine = create_async_engine(async_url)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def _seed_org(session_maker, tier: str = "team") -> dict[str, str]:
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    async with session_maker() as session:
+        session.add_all(
+            [
+                Organization(id=org_id, slug=f"{tier}-org", name="Test Org", tier=tier),
+                OrgLicense(org_id=org_id, tier=tier),
+                User(id=user_id, email="admin@example.com", is_active=True),
+            ]
+        )
+        await session.commit()
+    return {"org_id": str(org_id), "user_id": str(user_id)}
+
+
+def _make_app(session_maker, state: dict[str, str]) -> FastAPI:
+    app = FastAPI()
+    app.include_router(admin_router_module.router)
+
+    admin_user = AuthenticatedUser(
+        user_id=state["user_id"],
+        email="admin@example.com",
+        org_id=state["org_id"],
+        role="owner",
+        is_superuser=False,
+    )
+
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+            await session.commit()
+
+    app.dependency_overrides[auth_router_module.get_current_user] = lambda: admin_user
+    app.dependency_overrides[admin_router_module.get_session] = _session_override
+    return app
+
+
+@pytest.mark.asyncio
+async def test_admin_llm_settings_encrypts_and_masks_api_key(session_maker):
+    state = await _seed_org(session_maker, "team")
+    app = _make_app(session_maker, state)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.put(
+            "/api/v1/admin/llm-settings",
+            json={
+                "provider": "openai",
+                "model": "gpt-test",
+                "api_key": "sk-secret-value",
+                "base_url": "https://api.example.test/v1",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data == {
+            "provider": "openai",
+            "model": "gpt-test",
+            "api_key": "sk-s…alue",
+            "base_url": "https://api.example.test/v1",
+        }
+
+        get_resp = await ac.get("/api/v1/admin/llm-settings")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["api_key"] == "sk-s…alue"
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(Setting).where(
+                Setting.org_id == state["org_id"],
+                Setting.category == SettingCategory.LLM.value,
+                Setting.key == "api_key",
+            )
+        )
+        setting = result.scalar_one()
+        assert setting.is_encrypted is True
+        assert setting.value != "sk-secret-value"
+        assert decrypt_value(setting.value or "") == "sk-secret-value"
+
+    credentials = resolve_llm_org_settings_credentials("openai", org_id=state["org_id"])
+    assert credentials.api_key == "sk-secret-value"
+    assert credentials.base_url == "https://api.example.test/v1"
+
+
+@pytest.mark.asyncio
+async def test_admin_llm_settings_requires_team_or_enterprise(session_maker):
+    state = await _seed_org(session_maker, "community")
+    app = _make_app(session_maker, state)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.put(
+            "/api/v1/admin/llm-settings",
+            json={"provider": "openai", "api_key": "sk-secret"},
+        )
+
+    assert resp.status_code == 402
+    assert resp.json()["detail"]["required_tier"] == "team"

--- a/tests/api/admin/test_llm_settings.py
+++ b/tests/api/admin/test_llm_settings.py
@@ -149,3 +149,92 @@ async def test_admin_llm_settings_requires_team_or_enterprise(session_maker):
 
     assert resp.status_code == 402
     assert resp.json()["detail"]["required_tier"] == "team"
+
+
+@pytest.mark.asyncio
+async def test_generic_settings_routes_reject_llm_category(session_maker):
+    # Review finding: the generic settings routes must NOT be a back door for
+    # category='llm' (would bypass the BYO-LLM tier gate + forced encryption).
+    state = await _seed_org(session_maker, "team")
+    app = _make_app(session_maker, state)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        put_resp = await ac.put(
+            "/api/v1/admin/settings/llm/api_key",
+            json={"value": "sk-leak", "encrypt": False},
+        )
+        assert put_resp.status_code == 403
+        assert put_resp.json()["detail"]["error"] == "use_llm_settings_endpoint"
+        post_resp = await ac.post(
+            "/api/v1/admin/settings",
+            json={"key": "api_key", "value": "sk-leak", "category": "llm"},
+        )
+        assert post_resp.status_code == 403
+        get_resp = await ac.get("/api/v1/admin/settings/llm/api_key")
+        assert get_resp.status_code == 403
+        del_resp = await ac.delete("/api/v1/admin/settings/llm/api_key")
+        assert del_resp.status_code == 403
+        list_resp = await ac.get("/api/v1/admin/settings/llm")
+        assert list_resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_generic_get_setting_masks_encrypted_value(session_maker):
+    # Review finding: the generic single-setting GET must not return decrypted
+    # secrets in plaintext.
+    state = await _seed_org(session_maker, "team")
+    app = _make_app(session_maker, state)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        post_resp = await ac.post(
+            "/api/v1/admin/settings",
+            json={
+                "key": "token",
+                "value": "ghp-secret-value",
+                "category": "github",
+                "encrypt": True,
+            },
+        )
+        assert post_resp.status_code == 200, post_resp.text
+        get_resp = await ac.get("/api/v1/admin/settings/github/token")
+        assert get_resp.status_code == 200
+        body = get_resp.json()
+        assert body["value"] == "[ENCRYPTED]"
+        assert "ghp-secret-value" not in body["value"]
+
+
+def test_resolve_provider_name_uses_org_settings_in_auto(monkeypatch):
+    # Review finding: default worker path uses llm_provider='auto'; an org that
+    # only configured BYO settings must resolve its provider via org_id. Hermetic:
+    # clear ALL env provider signals (env detection precedes org settings) and
+    # mock the org-settings loader so this is order-independent in the full suite.
+    import dev_health_ops.llm.credentials as creds
+    from dev_health_ops.llm import LLMAuthError
+    from dev_health_ops.llm.providers import resolve_provider_name
+
+    for var in (
+        "LLM_PROVIDER",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "LLM_API_KEY",
+        "DASHSCOPE_API_KEY",
+        "QWEN_API_KEY",
+        "LOCAL_LLM_BASE_URL",
+        "OLLAMA_MODEL",
+        "OLLAMA_BASE_URL",
+        "LMSTUDIO_MODEL",
+        "LMSTUDIO_BASE_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(
+        creds,
+        "_load_org_llm_settings",
+        lambda org_id: {"provider": "anthropic"} if org_id == "org-xyz" else {},
+    )
+
+    # auto + org_id resolves the org's configured provider
+    assert resolve_provider_name("auto", org_id="org-xyz") == "anthropic"
+    # auto without org context (and no env) fails loud rather than guessing
+    with pytest.raises(LLMAuthError):
+        resolve_provider_name("auto", org_id=None)

--- a/tests/api/test_investment_explain_cache.py
+++ b/tests/api/test_investment_explain_cache.py
@@ -215,7 +215,7 @@ async def test_explain_investment_mix_mock_provider_skips_cache():
         mock_units.return_value = []
 
         mock_provider = MagicMock()
-        mock_provider.complete = AsyncMock(
+        mock_provider.complete_text = AsyncMock(
             return_value='{"summary": "Test summary", "top_findings": [], "confidence": {"level": "moderate"}, "what_to_check_next": [], "anti_claims": []}'
         )
         mock_get_provider.return_value = mock_provider
@@ -270,7 +270,7 @@ async def test_explain_forwards_org_id_to_work_unit_evidence():
         mock_units.return_value = []
 
         mock_provider = MagicMock()
-        mock_provider.complete = AsyncMock(
+        mock_provider.complete_text = AsyncMock(
             return_value='{"summary": "Test summary", "top_findings": [], "confidence": {"level": "moderate"}, "what_to_check_next": [], "anti_claims": []}'
         )
         mock_get_provider.return_value = mock_provider

--- a/tests/api/test_investment_explain_mismatch.py
+++ b/tests/api/test_investment_explain_mismatch.py
@@ -31,7 +31,7 @@ async def test_explain_investment_mix_mismatch_warning():
         mock_units.return_value = []
 
         mock_provider = MagicMock()
-        mock_provider.complete = AsyncMock(
+        mock_provider.complete_text = AsyncMock(
             return_value='{"summary": "test", "top_findings": [], "confidence": {"level": "low"}, "what_to_check_next": [], "anti_claims": []}'
         )
         mock_get_provider.return_value = mock_provider

--- a/tests/api/test_openai_provider_fix.py
+++ b/tests/api/test_openai_provider_fix.py
@@ -91,7 +91,7 @@ async def test_openai_provider_handles_empty_content_with_retry():
     assert "text" in captured["kwargs"]
 
     # Verify we got an empty result (as expected from our retry logic)
-    assert result == ""
+    assert result.text == ""
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_openai_provider_tokens.py
+++ b/tests/api/test_openai_provider_tokens.py
@@ -8,6 +8,7 @@ from dev_health_ops.llm.providers.openai import OpenAIProvider
 class _StubResponse:
     def __init__(self) -> None:
         self.output_text = '{"status": "ok"}'
+        self.usage = type("Usage", (), {"input_tokens": 11, "output_tokens": 7})()
 
 
 class _StubResponses:
@@ -33,7 +34,10 @@ async def test_openai_provider_uses_max_completion_tokens_for_gpt5():
     provider._impl._client = _StubClient(captured)
 
     result = await provider.complete("hello")
-    assert result == '{"status": "ok"}'
+    assert result.text == '{"status": "ok"}'
+    assert result.model == "gpt-5-mini"
+    assert result.input_tokens == 11
+    assert result.output_tokens == 7
     # GPT-5 internal parameter is max_output_tokens
     assert "max_output_tokens" in captured["kwargs"]
     assert (

--- a/tests/api/test_openai_retry_logic.py
+++ b/tests/api/test_openai_retry_logic.py
@@ -36,7 +36,7 @@ async def test_openai_retry_on_empty_content():
 
     result = await provider.complete("test prompt")
 
-    assert result == '{"summary": "test"}'
+    assert result.text == '{"summary": "test"}'
     assert mock_client.chat.completions.create.call_count == 2
 
     # Check that tokens were doubled on retry
@@ -72,7 +72,7 @@ async def test_gpt5_retry_on_finish_reason_truncation():
 
     result = await provider.complete("test prompt")
 
-    assert result == '{"summary": "complete"}'
+    assert result.text == '{"summary": "complete"}'
     assert mock_client.responses.create.call_count == 2
 
     # Verify token doubling in second call

--- a/tests/api/test_openai_retry_logic.py
+++ b/tests/api/test_openai_retry_logic.py
@@ -6,32 +6,49 @@ from dev_health_ops.llm.providers.openai import OpenAIProvider
 
 
 @pytest.mark.asyncio
-async def test_openai_retry_on_empty_content():
-    # Legacy models use chat completions
+async def test_openai_no_retry_on_empty_content_with_stop():
+    # CHAOS-2352: empty content with finish_reason="stop" is a genuine empty
+    # answer, not truncation. It must NOT trigger a token-doubling retry.
     provider = OpenAIProvider(api_key="test", model="gpt-4o")
 
-    # Mock client and response
     mock_client = AsyncMock()
-
-    # First response is empty, second is valid JSON
     mock_response_empty = AsyncMock()
     mock_response_empty.choices = [
         AsyncMock(message=AsyncMock(content=""), finish_reason="stop")
     ]
+    mock_client.chat.completions.create.return_value = mock_response_empty
 
+    provider._impl._client = mock_client
+
+    result = await provider.complete("test prompt")
+
+    assert result.text == ""
+    assert mock_client.chat.completions.create.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_openai_legacy_retry_on_truncation():
+    # finish_reason="length" signals truncation -> retry once with doubled tokens.
+    provider = OpenAIProvider(api_key="test", model="gpt-4o")
+
+    mock_client = AsyncMock()
+    mock_response_trunc = AsyncMock()
+    mock_response_trunc.choices = [
+        AsyncMock(
+            message=AsyncMock(content='{"summary": "trunc'), finish_reason="length"
+        )
+    ]
     mock_response_valid = AsyncMock()
     mock_response_valid.choices = [
         AsyncMock(
             message=AsyncMock(content='{"summary": "test"}'), finish_reason="stop"
         )
     ]
-
     mock_client.chat.completions.create.side_effect = [
-        mock_response_empty,
+        mock_response_trunc,
         mock_response_valid,
     ]
 
-    # Patch the internal implementation's client
     provider._impl._client = mock_client
 
     result = await provider.complete("test prompt")
@@ -39,7 +56,6 @@ async def test_openai_retry_on_empty_content():
     assert result.text == '{"summary": "test"}'
     assert mock_client.chat.completions.create.call_count == 2
 
-    # Check that tokens were doubled on retry
     second_call_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
     assert second_call_kwargs["max_completion_tokens"] == 8192
 

--- a/tests/api/test_work_unit_explain.py
+++ b/tests/api/test_work_unit_explain.py
@@ -21,8 +21,9 @@ from dev_health_ops.api.models.schemas import (
     WorkUnitTimeRange,
 )
 from dev_health_ops.api.services.work_unit_explain import explain_work_unit
-from dev_health_ops.llm import get_provider, is_llm_available
+from dev_health_ops.llm import LLMAuthError, get_provider, is_llm_available
 from dev_health_ops.llm.providers.mock import MockProvider
+from dev_health_ops.llm.providers.none import NoneProvider
 
 
 def _sample_investment() -> WorkUnitInvestment:
@@ -72,7 +73,7 @@ def test_mock_provider_returns_response():
 
     async def run_test():
         prompt = "Test prompt for work unit explanation."
-        response = await provider.complete(prompt)
+        response = await provider.complete_text(prompt)
         assert response
         assert len(response) > 50  # Should be a meaningful response
 
@@ -91,7 +92,7 @@ def test_mock_provider_uses_approved_language():
           - feature_delivery: 48.00%
           - maintenance: 30.00%
         """
-        response = await provider.complete(prompt)
+        response = await provider.complete_text(prompt)
 
         # Check for approved words
         response_lower = response.lower()
@@ -112,7 +113,7 @@ def test_mock_provider_avoids_forbidden_language():
 
     async def run_test():
         prompt = "Evidence Quality: 0.72 (moderate)"
-        response = await provider.complete(prompt)
+        response = await provider.complete_text(prompt)
 
         # The response should not contain these as standalone "certainty" words
         # Note: "is" might appear in words like "this", so we check for patterns
@@ -128,11 +129,10 @@ def test_mock_provider_avoids_forbidden_language():
     asyncio.run(run_test())
 
 
-def test_get_provider_returns_mock_without_api_keys():
-    """Test that get_provider returns mock when no API keys are set."""
+def test_get_provider_auto_without_api_keys_raises_classified_error():
     with patch.dict(os.environ, {}, clear=True):
-        provider = get_provider("auto")
-        assert isinstance(provider, MockProvider)
+        with pytest.raises(LLMAuthError, match="OPENAI_API_KEY"):
+            get_provider("auto")
 
 
 def test_get_provider_explicit_mock():
@@ -206,8 +206,14 @@ def test_is_llm_available_returns_false_for_auto_without_keys():
         assert is_llm_available("auto") is False
 
 
-def test_is_llm_available_returns_true_for_openai():
-    assert is_llm_available("openai") is True
+def test_is_llm_available_returns_false_for_openai_without_key():
+    with patch.dict(os.environ, {}, clear=True):
+        assert is_llm_available("openai") is False
+
+
+def test_is_llm_available_returns_true_for_openai_with_key():
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=True):
+        assert is_llm_available("openai") is True
 
 
 def test_is_llm_available_returns_true_for_auto_with_key():
@@ -215,9 +221,9 @@ def test_is_llm_available_returns_true_for_auto_with_key():
         assert is_llm_available("auto") is True
 
 
-def test_get_provider_none_returns_mock_provider():
+def test_get_provider_none_returns_none_provider():
     provider = get_provider("none")
-    assert isinstance(provider, MockProvider)
+    assert isinstance(provider, NoneProvider)
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_work_unit_explain.py
+++ b/tests/api/test_work_unit_explain.py
@@ -238,3 +238,31 @@ async def test_explain_work_unit_returns_blank_when_no_llm():
     assert explanation.evidence_highlights == []
     assert explanation.uncertainty_disclosure == ""
     assert explanation.evidence_quality_limits == ""
+
+
+@pytest.mark.asyncio
+async def test_explain_work_unit_returns_blank_for_preresolved_none_provider():
+    investment = _sample_investment()
+    explanation = await explain_work_unit(
+        investment,
+        llm_provider="none",
+        provider=NoneProvider(),
+    )
+
+    assert explanation.work_unit_id == investment.work_unit_id
+    assert explanation.ai_generated is False
+    assert explanation.summary == ""
+    assert explanation.category_rationale == {}
+    assert explanation.evidence_highlights == []
+
+
+@pytest.mark.asyncio
+async def test_explain_work_unit_returns_blank_when_env_provider_none(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "none")
+    investment = _sample_investment()
+    explanation = await explain_work_unit(investment, llm_provider="auto")
+
+    assert explanation.work_unit_id == investment.work_unit_id
+    assert explanation.ai_generated is False
+    assert explanation.summary == ""
+    assert explanation.category_rationale == {}

--- a/tests/api/test_work_unit_explain_hardening.py
+++ b/tests/api/test_work_unit_explain_hardening.py
@@ -1,0 +1,215 @@
+"""
+Tests for work-unit explain endpoint hardening (CHAOS-2351).
+
+Covers:
+  (a) Missing-key / invalid-provider returns 4xx JSON (not HTTP 200 + broken stream).
+  (b) Rate-limit decorator is present on the endpoint.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault("CLICKHOUSE_URI", "clickhouse://localhost:8123/default")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-explain-hardening")
+os.environ.setdefault("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from dev_health_ops.api.auth.router import get_current_user  # noqa: E402
+from dev_health_ops.api.main import app  # noqa: E402
+from dev_health_ops.api.services.auth import AuthenticatedUser  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Shared auth override
+# ---------------------------------------------------------------------------
+
+_FAKE_USER = AuthenticatedUser(
+    user_id="user-test-001",
+    email="test@example.com",
+    org_id="org-test-001",
+    role="member",
+    is_superuser=False,
+)
+
+
+def _override_get_current_user():
+    return _FAKE_USER
+
+
+# ---------------------------------------------------------------------------
+# (a) Provider credential validation returns 4xx before stream opens
+# ---------------------------------------------------------------------------
+
+
+def test_missing_openai_key_returns_422_not_200(monkeypatch):
+    """Explicit provider with no API key must return 422 JSON, not 200 + broken stream.
+
+    Before the fix, get_provider() raised ValueError inside keep_alive_wrapper
+    after the StreamingResponse headers were already sent, so the client saw
+    HTTP 200 followed by a JSON error body — indistinguishable from a valid
+    (empty) response.  After the fix, the ValueError is caught before
+    StreamingResponse is constructed and mapped to HTTP 422.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("LOCAL_LLM_BASE_URL", raising=False)
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.delenv("QWEN_API_KEY", raising=False)
+    monkeypatch.delenv("OLLAMA_MODEL", raising=False)
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+
+    app.dependency_overrides[get_current_user] = _override_get_current_user
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post(
+                "/api/v1/work-units/wu-abc123/explain",
+                params={"llm_provider": "openai"},
+            )
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    # Must be a proper 4xx, not 200
+    assert resp.status_code == 422, (
+        f"Expected 422 for missing OPENAI_API_KEY, got {resp.status_code}. "
+        "Provider validation must happen before StreamingResponse is opened."
+    )
+    body = resp.json()
+    assert "detail" in body
+    assert "OPENAI_API_KEY" in body["detail"]
+
+
+def test_missing_anthropic_key_returns_422_not_200(monkeypatch):
+    """Explicit anthropic provider with no key must return 422 JSON."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+
+    app.dependency_overrides[get_current_user] = _override_get_current_user
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post(
+                "/api/v1/work-units/wu-abc123/explain",
+                params={"llm_provider": "anthropic"},
+            )
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert resp.status_code == 422, (
+        f"Expected 422 for missing ANTHROPIC_API_KEY, got {resp.status_code}"
+    )
+    body = resp.json()
+    assert "ANTHROPIC_API_KEY" in body["detail"]
+
+
+def test_unknown_provider_returns_422_not_200():
+    """Unknown provider name must return 422 JSON, not 200 + broken stream."""
+    app.dependency_overrides[get_current_user] = _override_get_current_user
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post(
+                "/api/v1/work-units/wu-abc123/explain",
+                params={"llm_provider": "nonexistent-provider-xyz"},
+            )
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert resp.status_code == 422, (
+        f"Expected 422 for unknown provider, got {resp.status_code}"
+    )
+    body = resp.json()
+    assert "detail" in body
+
+
+def test_missing_key_response_is_json_not_stream():
+    """The 4xx error response must be a JSON object, not a streaming body."""
+    app.dependency_overrides[get_current_user] = _override_get_current_user
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post(
+                "/api/v1/work-units/wu-abc123/explain",
+                params={"llm_provider": "nonexistent-provider-xyz"},
+            )
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    # Must be parseable as JSON with a "detail" key (FastAPI HTTPException shape)
+    body = resp.json()
+    assert isinstance(body, dict)
+    assert "detail" in body
+
+
+def test_mock_provider_with_no_work_unit_returns_404():
+    """With a valid provider (mock) but non-existent work unit, expect 404.
+
+    This confirms the happy-path flow still works: provider validation passes,
+    then the DB lookup returns 404 for an unknown work_unit_id.
+    """
+    app.dependency_overrides[get_current_user] = _override_get_current_user
+    try:
+        with (
+            patch(
+                "dev_health_ops.api.main.build_work_unit_investments",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            TestClient(app, raise_server_exceptions=False) as client,
+        ):
+            resp = client.post(
+                "/api/v1/work-units/nonexistent-wu/explain",
+                params={"llm_provider": "mock"},
+            )
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# (b) Rate-limit decorator is present
+# ---------------------------------------------------------------------------
+
+
+def test_work_unit_explain_endpoint_has_rate_limit_decorator():
+    """work_unit_explain_endpoint must carry @limiter.limit('20/minute').
+
+    Uses source inspection — the same technique used in test_login_rate_limit.py
+    — because slowapi wraps the handler at decoration time, making runtime
+    reflection unreliable.
+    """
+    from dev_health_ops.api import main as main_module
+
+    source = inspect.getsource(main_module)
+
+    # Find the block around work_unit_explain_endpoint
+    # The decorator must appear between the @app.post and the async def.
+    endpoint_idx = source.find("async def work_unit_explain_endpoint(")
+    assert endpoint_idx != -1, "work_unit_explain_endpoint not found in main.py"
+
+    # Look at the 300 chars before the def for the decorator
+    preamble = source[max(0, endpoint_idx - 300) : endpoint_idx]
+    assert '@limiter.limit("20/minute")' in preamble, (
+        "work_unit_explain_endpoint is missing @limiter.limit('20/minute'). "
+        "Authenticated callers can amplify LLM spend without a rate limit."
+    )
+
+
+def test_work_unit_explain_endpoint_accepts_request_param():
+    """work_unit_explain_endpoint must accept a Request parameter for slowapi.
+
+    slowapi's @limiter.limit decorator requires the handler to accept a
+    fastapi.Request argument so it can extract the client IP / key.
+    """
+    import inspect as _inspect
+
+    from dev_health_ops.api.main import work_unit_explain_endpoint
+
+    sig = _inspect.signature(work_unit_explain_endpoint)
+    assert "request" in sig.parameters, (
+        "work_unit_explain_endpoint must have a 'request: Request' parameter "
+        "for the slowapi rate limiter to function."
+    )

--- a/tests/api/test_work_unit_explain_hardening.py
+++ b/tests/api/test_work_unit_explain_hardening.py
@@ -21,6 +21,8 @@ from fastapi.testclient import TestClient  # noqa: E402
 from dev_health_ops.api.auth.router import get_current_user  # noqa: E402
 from dev_health_ops.api.main import app  # noqa: E402
 from dev_health_ops.api.services.auth import AuthenticatedUser  # noqa: E402
+from dev_health_ops.llm.errors import LLMAuthError, LLMRateLimitError  # noqa: E402
+from tests.api.test_work_unit_explain import _sample_investment  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Shared auth override
@@ -33,6 +35,14 @@ _FAKE_USER = AuthenticatedUser(
     role="member",
     is_superuser=False,
 )
+
+
+class _FailingProvider:
+    def __init__(self, exc):
+        self.exc = exc
+
+    async def complete_text(self, prompt: str) -> str:
+        raise self.exc
 
 
 def _override_get_current_user():
@@ -167,6 +177,58 @@ def test_mock_provider_with_no_work_unit_returns_404():
         app.dependency_overrides.pop(get_current_user, None)
 
     assert resp.status_code == 404
+
+
+def test_runtime_invalid_key_returns_422_not_streaming_200():
+    app.dependency_overrides[get_current_user] = _override_get_current_user
+    try:
+        with (
+            patch(
+                "dev_health_ops.api.main.build_work_unit_investments",
+                new_callable=AsyncMock,
+                return_value=[_sample_investment()],
+            ),
+            patch(
+                "dev_health_ops.api.main.get_provider",
+                return_value=_FailingProvider(LLMAuthError("Invalid key")),
+            ),
+            TestClient(app, raise_server_exceptions=False) as client,
+        ):
+            resp = client.post(
+                "/api/v1/work-units/wu-runtime-auth/explain",
+                params={"llm_provider": "openai"},
+            )
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"]
+
+
+def test_runtime_rate_limit_returns_429_not_streaming_200():
+    app.dependency_overrides[get_current_user] = _override_get_current_user
+    try:
+        with (
+            patch(
+                "dev_health_ops.api.main.build_work_unit_investments",
+                new_callable=AsyncMock,
+                return_value=[_sample_investment()],
+            ),
+            patch(
+                "dev_health_ops.api.main.get_provider",
+                return_value=_FailingProvider(LLMRateLimitError("rate limit")),
+            ),
+            TestClient(app, raise_server_exceptions=False) as client,
+        ):
+            resp = client.post(
+                "/api/v1/work-units/wu-runtime-rate/explain",
+                params={"llm_provider": "openai"},
+            )
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert resp.status_code == 429
+    assert resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -8,7 +8,8 @@ from dev_health_ops.llm.providers.gemini import DEFAULT_GEMINI_BASE_URL, GeminiP
 
 
 def test_gemini_provider_registration():
-    assert isinstance(get_provider("gemini"), GeminiProvider)
+    with patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}, clear=True):
+        assert isinstance(get_provider("gemini"), GeminiProvider)
 
 
 def test_gemini_provider_config():
@@ -52,12 +53,18 @@ async def test_gemini_provider_completion():
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "Gemini response"
+        mock_response.usage = type(
+            "Usage", (), {"prompt_tokens": 5, "completion_tokens": 3}
+        )()
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         p = GeminiProvider(api_key="sk-123")
         response = await p.complete("Hello")
 
-        assert response == "Gemini response"
+        assert response.text == "Gemini response"
+        assert response.model == "gemini-3"
+        assert response.input_tokens == 5
+        assert response.output_tokens == 3
         mock_openai_class.assert_called_once_with(
             api_key="sk-123", base_url=DEFAULT_GEMINI_BASE_URL
         )

--- a/tests/test_investment_materialize_partitioned.py
+++ b/tests/test_investment_materialize_partitioned.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+from dev_health_ops.workers.work_graph_tasks import (
+    dispatch_investment_materialize_partitioned,
+    finalize_investment_materialize_partitioned,
+    run_investment_materialize_chunk,
+)
+
+
+class _FakeSink:
+    def ensure_schema(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+def _edge(component: int) -> dict[str, object]:
+    return {
+        "edge_id": f"edge-{component}",
+        "source_type": "issue",
+        "source_id": f"I-{component}",
+        "target_type": "commit",
+        "target_id": f"repo-{component}@abc{component}",
+        "repo_id": f"repo-{component}",
+    }
+
+
+def _signature_factory(name: str, **kwargs: Any) -> MagicMock:
+    sig = MagicMock(name=f"sig:{name}")
+    sig.task_name = name
+    sig.sig_kwargs = kwargs
+    return sig
+
+
+def test_dispatch_partitioned_materialize_chunks_components_with_shared_run() -> None:
+    with (
+        patch(
+            "dev_health_ops.metrics.sinks.factory.create_sink",
+            return_value=_FakeSink(),
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.queries.fetch_work_graph_edges",
+            return_value=[_edge(1), _edge(2), _edge(3)],
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks.celery_app.signature",
+            side_effect=_signature_factory,
+        ) as mock_signature,
+        patch("dev_health_ops.workers.work_graph_tasks.chord") as mock_chord,
+    ):
+        chord_instance = MagicMock()
+        mock_chord.return_value = chord_instance
+        task = cast(Any, dispatch_investment_materialize_partitioned)
+        result = task.run(db_url="clickhouse://x", org_id="org-1", chunk_size=2)
+
+    assert result["status"] == "dispatched"
+    assert result["components"] == 3
+    assert result["chunks"] == 2
+    header, callback = mock_chord.call_args.args
+    assert len(header) == 2
+    first_kwargs = header[0].sig_kwargs["kwargs"]
+    second_kwargs = header[1].sig_kwargs["kwargs"]
+    assert first_kwargs["component_indexes"] == [0, 1]
+    assert second_kwargs["component_indexes"] == [2]
+    assert first_kwargs["run_id"] == second_kwargs["run_id"] == result["run_id"]
+    assert first_kwargs["computed_at"] == second_kwargs["computed_at"]
+    assert callback.task_name == (
+        "dev_health_ops.workers.tasks.finalize_investment_materialize_partitioned"
+    )
+    assert callback.sig_kwargs["kwargs"]["run_membership_backfill_after"] is True
+    chord_instance.apply_async.assert_called_once_with()
+    assert mock_signature.call_count == 3
+
+
+def test_dispatch_partitioned_materialize_skips_marker_for_windowed_run() -> None:
+    with (
+        patch(
+            "dev_health_ops.metrics.sinks.factory.create_sink",
+            return_value=_FakeSink(),
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.queries.fetch_work_graph_edges",
+            return_value=[_edge(1)],
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks.celery_app.signature",
+            side_effect=_signature_factory,
+        ),
+        patch("dev_health_ops.workers.work_graph_tasks.chord") as mock_chord,
+    ):
+        mock_chord.return_value = MagicMock()
+        task = cast(Any, dispatch_investment_materialize_partitioned)
+        task.run(
+            db_url="clickhouse://x",
+            org_id="org-1",
+            from_date="2026-01-01",
+            to_date="2026-01-02",
+        )
+
+    callback = mock_chord.call_args.args[1]
+    assert callback.sig_kwargs["kwargs"]["run_membership_backfill_after"] is False
+
+
+def test_materialize_chunk_checkpoint_skips_completed_chunk() -> None:
+    session_cm = MagicMock()
+    session_cm.__enter__.return_value = MagicMock()
+    session_cm.__exit__.return_value = None
+    with (
+        patch("dev_health_ops.db.get_postgres_session_sync", return_value=session_cm),
+        patch("dev_health_ops.metrics.checkpoints.is_completed", return_value=True),
+        patch("dev_health_ops.metrics.checkpoints.mark_running") as mark_running,
+        patch("dev_health_ops.workers.work_graph_tasks.run_async") as run_async_mock,
+    ):
+        task = cast(Any, run_investment_materialize_chunk)
+        result = task.run(
+            db_url="clickhouse://x",
+            org_id="org-1",
+            run_id="run-1",
+            computed_at=datetime.now(timezone.utc).isoformat(),
+            component_indexes=[0],
+            chunk_index=0,
+            llm_provider="mock",
+        )
+
+    assert result["status"] == "skipped"
+    mark_running.assert_not_called()
+    run_async_mock.assert_not_called()
+
+
+def test_partitioned_finalizer_aggregates_and_runs_membership_once() -> None:
+    with patch(
+        "dev_health_ops.work_graph.investment.backfill.backfill_memberships",
+        return_value={"memberships": 4},
+    ) as backfill:
+        task = cast(Any, finalize_investment_materialize_partitioned)
+        result = task.run(
+            [
+                {
+                    "stats": {
+                        "records": 2,
+                        "quotes": 1,
+                        "skipped_existing": 3,
+                        "llm_calls": 4,
+                        "llm_input_tokens": 100,
+                        "llm_output_tokens": 20,
+                        "llm_failures": 1,
+                        "llm_failure_counts": {"rate_limit": 1},
+                    }
+                }
+            ],
+            db_url="clickhouse://x",
+            org_id="org-1",
+            run_id="run-1",
+            run_membership_backfill_after=True,
+        )
+
+    assert result["records"] == 2
+    assert result["quotes"] == 1
+    assert result["skipped_existing"] == 3
+    assert result["llm_calls"] == 4
+    assert result["llm_failure_counts"] == {"rate_limit": 1}
+    assert result["membership"] == {"memberships": 4}
+    backfill.assert_called_once()

--- a/tests/test_llm_errors.py
+++ b/tests/test_llm_errors.py
@@ -72,3 +72,36 @@ def test_model_not_found_names_provider_default() -> None:
     assert not is_retryable(err)
     assert "bogus-model" in str(err)
     assert "gpt-5-mini" in str(err)
+
+
+class HugeNumericRetryAfterError(Exception):
+    status_code = 429
+    headers = {"Retry-After": "86400"}
+
+
+class FarFutureDateRetryAfterError(Exception):
+    status_code = 429
+    headers = {"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"}
+
+
+def test_huge_numeric_retry_after_is_clamped() -> None:
+    err = classify_provider_error(
+        HugeNumericRetryAfterError("rate_limit_exceeded"),
+        provider="openai",
+        model="gpt-5-mini",
+    )
+
+    assert isinstance(err, LLMRateLimitError)
+    # A day-long Retry-After must be clamped, not honored verbatim.
+    assert err.retry_after == 60.0
+
+
+def test_far_future_http_date_retry_after_is_clamped() -> None:
+    err = classify_provider_error(
+        FarFutureDateRetryAfterError("rate_limit_exceeded"),
+        provider="openai",
+        model="gpt-5-mini",
+    )
+
+    assert isinstance(err, LLMRateLimitError)
+    assert err.retry_after == 60.0

--- a/tests/test_llm_errors.py
+++ b/tests/test_llm_errors.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dev_health_ops.llm.errors import (
+    LLMAuthError,
+    LLMError,
+    LLMRateLimitError,
+    classify_provider_error,
+    is_retryable,
+)
+
+
+class SecretException(Exception):
+    def __repr__(self) -> str:
+        return "SecretException(api_key='sk-secret-value')"
+
+
+class FakeRateLimitError(Exception):
+    status_code = 429
+    headers = {"Retry-After": "2.5"}
+
+
+def test_llm_error_string_omits_original_repr() -> None:
+    err = LLMError(
+        "clean failure",
+        provider="openai",
+        model="gpt-5-mini",
+        original=SecretException(),
+    )
+
+    rendered = str(err)
+
+    assert "sk-secret-value" not in rendered
+    assert "cause_type=SecretException" in rendered
+    assert "provider=openai" in rendered
+    assert "model=gpt-5-mini" in rendered
+
+
+def test_llm_error_message_redacts_keys() -> None:
+    err = LLMError("Authorization: Bearer sk-secret-value-1234567890")
+
+    assert "sk-secret-value" not in str(err)
+    assert "<redacted>" in str(err)
+
+
+def test_insufficient_quota_is_deterministic_auth_error() -> None:
+    raw = RuntimeError("Error code: insufficient_quota; api_key=sk-secret-value")
+
+    err = classify_provider_error(raw, provider="openai", model="gpt-5-mini")
+
+    assert isinstance(err, LLMAuthError)
+    assert not is_retryable(err)
+    assert "sk-secret-value" not in str(err)
+    assert "quota exhausted" in str(err)
+
+
+def test_rate_limit_exceeded_is_retryable_with_retry_after() -> None:
+    raw = FakeRateLimitError("rate_limit_exceeded")
+
+    err = classify_provider_error(raw, provider="openai", model="gpt-5-mini")
+
+    assert isinstance(err, LLMRateLimitError)
+    assert is_retryable(err)
+    assert err.retry_after == 2.5
+
+
+def test_model_not_found_names_provider_default() -> None:
+    err = classify_provider_error(
+        RuntimeError("model_not_found"), provider="openai", model="bogus-model"
+    )
+
+    assert type(err) is LLMError
+    assert not is_retryable(err)
+    assert "bogus-model" in str(err)
+    assert "gpt-5-mini" in str(err)

--- a/tests/test_llm_provider_factory.py
+++ b/tests/test_llm_provider_factory.py
@@ -9,7 +9,6 @@ import pytest
 
 import dev_health_ops.llm.providers as provider_factory
 from dev_health_ops.llm import LLMAuthError, get_provider, is_llm_available
-from dev_health_ops.llm.providers import resolve_model_name
 from dev_health_ops.llm.providers.local import LocalProvider
 from dev_health_ops.llm.providers.mock import MockProvider
 from dev_health_ops.llm.providers.none import NoneProvider
@@ -88,7 +87,7 @@ def test_provider_specific_model_env_overrides_global_model():
         provider = get_provider("openai")
         assert isinstance(provider, OpenAIProvider)
         assert provider._impl.cfg.model == "openai-model"
-        assert resolve_model_name("openai") == "openai-model"
+        assert provider_factory.resolve_model_name("openai") == "openai-model"
 
 
 def test_mock_provider_stamps_mock_model():

--- a/tests/test_llm_provider_factory.py
+++ b/tests/test_llm_provider_factory.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from unittest.mock import patch
+
+import pytest
+
+import dev_health_ops.llm.providers as provider_factory
+from dev_health_ops.llm import LLMAuthError, get_provider, is_llm_available
+from dev_health_ops.llm.providers import resolve_model_name
+from dev_health_ops.llm.providers.mock import MockProvider
+from dev_health_ops.llm.providers.none import NoneProvider
+from dev_health_ops.llm.providers.openai import OpenAIProvider
+
+
+def test_auto_without_keys_raises_classified_error():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(LLMAuthError, match="--llm-provider mock"):
+            get_provider("auto")
+
+
+def test_explicit_openai_without_key_is_unavailable():
+    with patch.dict(os.environ, {}, clear=True):
+        assert is_llm_available("openai") is False
+        with pytest.raises(LLMAuthError, match="OPENAI_API_KEY"):
+            get_provider("openai")
+
+
+def test_provider_specific_model_env_overrides_global_model():
+    with patch.dict(
+        os.environ,
+        {
+            "OPENAI_API_KEY": "sk-test",
+            "LLM_MODEL": "global-model",
+            "LLM_MODEL_OPENAI": "openai-model",
+        },
+        clear=True,
+    ):
+        provider = get_provider("openai")
+        assert isinstance(provider, OpenAIProvider)
+        assert provider._impl.cfg.model == "openai-model"
+        assert resolve_model_name("openai") == "openai-model"
+
+
+def test_mock_provider_stamps_mock_model():
+    provider = get_provider("mock", model="gpt-5-mini")
+    assert isinstance(provider, MockProvider)
+    result = asyncio.run(provider.complete("hello"))
+    assert result.model == "mock"
+    assert result.input_tokens is None
+    assert result.output_tokens is None
+
+
+def test_none_provider_is_not_available_and_not_mock():
+    provider = get_provider("none", model="gpt-5-mini")
+    assert isinstance(provider, NoneProvider)
+    assert is_llm_available("none") is False
+    result = asyncio.run(provider.complete("hello"))
+    assert result.text == ""
+    assert result.model == "none"
+
+
+def test_resolved_provider_model_logged_once(caplog):
+    provider_factory._LOGGED_PROVIDER_MODELS.clear()
+    with patch.dict(
+        os.environ,
+        {"OPENAI_API_KEY": "sk-test", "LLM_MODEL_OPENAI": "openai-model"},
+        clear=True,
+    ):
+        with caplog.at_level(logging.INFO, logger="dev_health_ops.llm.providers"):
+            get_provider("openai")
+            get_provider("openai")
+
+    matching = [
+        record
+        for record in caplog.records
+        if "Resolved LLM provider" in record.getMessage()
+    ]
+    assert len(matching) == 1
+    assert "provider=openai model=openai-model" in matching[0].getMessage()

--- a/tests/test_llm_provider_factory.py
+++ b/tests/test_llm_provider_factory.py
@@ -10,6 +10,7 @@ import pytest
 import dev_health_ops.llm.providers as provider_factory
 from dev_health_ops.llm import LLMAuthError, get_provider, is_llm_available
 from dev_health_ops.llm.providers import resolve_model_name
+from dev_health_ops.llm.providers.local import LocalProvider
 from dev_health_ops.llm.providers.mock import MockProvider
 from dev_health_ops.llm.providers.none import NoneProvider
 from dev_health_ops.llm.providers.openai import OpenAIProvider
@@ -112,3 +113,33 @@ def test_resolved_provider_model_logged_once(caplog):
     ]
     assert len(matching) == 1
     assert "provider=openai model=openai-model" in matching[0].getMessage()
+
+
+def test_local_provider_failure_logs_redacted_url_and_error(caplog):
+    class _Completions:
+        async def create(self, **kwargs):
+            raise RuntimeError("401 invalid_api_key sk-secret-token query_token=abc123")
+
+    class _Chat:
+        completions = _Completions()
+
+    class _Client:
+        chat = _Chat()
+
+    provider = LocalProvider(
+        base_url="https://user:pass@llm.example.test/v1?api_key=secret&token=abc",
+        model="local-test",
+    )
+    provider._client = _Client()
+
+    with caplog.at_level(logging.ERROR, logger="dev_health_ops.llm.providers.local"):
+        with pytest.raises(LLMAuthError):
+            asyncio.run(provider.complete("hello"))
+
+    log_text = caplog.text
+    assert "https://llm.example.test/v1" in log_text
+    assert "LLMAuthError" in log_text
+    assert "user:pass" not in log_text
+    assert "api_key=secret" not in log_text
+    assert "sk-secret-token" not in log_text
+    assert "query_token=abc123" not in log_text

--- a/tests/test_llm_provider_factory.py
+++ b/tests/test_llm_provider_factory.py
@@ -28,6 +28,38 @@ def test_explicit_openai_without_key_is_unavailable():
             get_provider("openai")
 
 
+def test_openai_accepts_inline_credentials_over_env():
+    with patch.dict(
+        os.environ,
+        {"OPENAI_API_KEY": "sk-env", "OPENAI_BASE_URL": "https://env.invalid/v1"},
+        clear=True,
+    ):
+        provider = get_provider(
+            "openai",
+            model="gpt-4o-mini",
+            api_key="sk-inline",
+            base_url="https://inline.invalid/v1",
+        )
+
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._impl.cfg.api_key == "sk-inline"
+    assert provider._impl.cfg.base_url == "https://inline.invalid/v1"
+
+
+def test_generic_llm_env_credentials_are_available_for_explicit_provider():
+    with patch.dict(
+        os.environ,
+        {"LLM_API_KEY": "sk-generic", "LLM_BASE_URL": "https://generic.invalid/v1"},
+        clear=True,
+    ):
+        assert is_llm_available("openai") is True
+        provider = get_provider("openai")
+
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._impl.cfg.api_key == "sk-generic"
+    assert provider._impl.cfg.base_url == "https://generic.invalid/v1"
+
+
 def test_provider_specific_model_env_overrides_global_model():
     with patch.dict(
         os.environ,

--- a/tests/test_llm_provider_factory.py
+++ b/tests/test_llm_provider_factory.py
@@ -21,6 +21,20 @@ def test_auto_without_keys_raises_classified_error():
             get_provider("auto")
 
 
+def test_auto_with_generic_env_key_but_no_provider_names_llm_provider():
+    # A bare LLM_API_KEY cannot identify which provider API to call; fail loud
+    # with guidance to set LLM_PROVIDER rather than a generic auto-detect error.
+    with patch.dict(os.environ, {"LLM_API_KEY": "sk-generic"}, clear=True):
+        with pytest.raises(LLMAuthError, match="LLM_PROVIDER"):
+            get_provider("auto")
+
+
+def test_auto_with_inline_key_but_no_provider_names_llm_provider():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(LLMAuthError, match="--llm-provider"):
+            get_provider("auto", api_key="sk-inline")
+
+
 def test_explicit_openai_without_key_is_unavailable():
     with patch.dict(os.environ, {}, clear=True):
         assert is_llm_available("openai") is False

--- a/tests/test_openai_gpt5_reasoning_only.py
+++ b/tests/test_openai_gpt5_reasoning_only.py
@@ -34,7 +34,7 @@ async def test_gpt5_reasoning_only_empty_result(caplog):
 
         # Should return empty string after retries (if it retries on empty)
         # Actually it retries once on empty content.
-        assert result == ""
+        assert result.text == ""
 
         # Should have log entry for invalid JSON/empty
         assert "Invalid JSON returned from responses API" in caplog.text

--- a/tests/test_openai_gpt5_truncation_retry.py
+++ b/tests/test_openai_gpt5_truncation_retry.py
@@ -32,7 +32,8 @@ async def test_gpt5_truncation_retry_logic():
     # Inject mock client into implementation
     provider._impl._client = mock_client
 
-    result_json = await provider.complete("explain something")
+    result = await provider.complete("explain something")
+    result_json = result.text
 
     # Verify parsing
     result = json.loads(result_json)

--- a/tests/test_openai_gpt5_truncation_retry.py
+++ b/tests/test_openai_gpt5_truncation_retry.py
@@ -5,7 +5,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from dev_health_ops.llm.errors import LLMAuthError
 from dev_health_ops.llm.providers.openai import OpenAIProvider
+
+
+class FakeRateLimitError(Exception):
+    status_code = 429
+    headers = {"Retry-After": "2"}
+    code = "rate_limit_exceeded"
 
 
 @pytest.mark.asyncio
@@ -51,3 +58,56 @@ async def test_gpt5_truncation_retry_logic():
 
     # Verify validate_json_or_empty output is compact (json.dumps)
     assert result_json == json.dumps(result)
+
+
+@pytest.mark.asyncio
+async def test_gpt5_transient_error_retries_without_doubling_tokens(monkeypatch):
+    provider = OpenAIProvider(
+        api_key="test", model="gpt-5-mini", max_completion_tokens=1024
+    )
+    mock_client = AsyncMock()
+    resp = MagicMock()
+    resp.output_text = '{"summary": "ok"}'
+    resp.incomplete_details = None
+    mock_client.responses.create.side_effect = [
+        FakeRateLimitError("rate_limit_exceeded"),
+        resp,
+    ]
+    provider._impl._client = mock_client
+    sleeps: list[float] = []
+
+    async def _fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(
+        "dev_health_ops.llm.providers.openai.asyncio.sleep", _fake_sleep
+    )
+
+    result = await provider.complete("explain something")
+
+    assert json.loads(result.text)["summary"] == "ok"
+    assert sleeps == [2.0]
+    first_call_kwargs = mock_client.responses.create.call_args_list[0].kwargs
+    second_call_kwargs = mock_client.responses.create.call_args_list[1].kwargs
+    assert first_call_kwargs["max_output_tokens"] == 4096
+    assert second_call_kwargs["max_output_tokens"] == 4096
+
+
+@pytest.mark.asyncio
+async def test_gpt5_insufficient_quota_fails_without_retry_or_token_doubling():
+    provider = OpenAIProvider(
+        api_key="test", model="gpt-5-mini", max_completion_tokens=1024
+    )
+    mock_client = AsyncMock()
+    mock_client.responses.create.side_effect = RuntimeError(
+        "Error code: insufficient_quota; api_key=sk-secret-value"
+    )
+    provider._impl._client = mock_client
+
+    with pytest.raises(LLMAuthError) as exc_info:
+        await provider.complete("explain something")
+
+    assert "sk-secret-value" not in str(exc_info.value)
+    assert mock_client.responses.create.call_count == 1
+    first_call_kwargs = mock_client.responses.create.call_args_list[0].kwargs
+    assert first_call_kwargs["max_output_tokens"] == 4096

--- a/tests/test_openai_legacy_truncation_retry.py
+++ b/tests/test_openai_legacy_truncation_retry.py
@@ -36,7 +36,8 @@ async def test_openai_legacy_truncation_retry_success():
     # Inject mock client
     provider._impl._client = mock_client
 
-    result_json = await provider.complete("explain legacy")
+    result = await provider.complete("explain legacy")
+    result_json = result.text
 
     # Verify parsing
     result = json.loads(result_json)

--- a/tests/test_post_sync_investment_dispatch.py
+++ b/tests/test_post_sync_investment_dispatch.py
@@ -29,7 +29,9 @@ from unittest.mock import MagicMock, patch
 import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.workers.sync_runtime import _dispatch_post_sync_tasks
 
-_INVESTMENT_TASK = "dev_health_ops.workers.tasks.run_investment_materialize"
+_INVESTMENT_TASK = (
+    "dev_health_ops.workers.tasks.dispatch_investment_materialize_partitioned"
+)
 _WORK_GRAPH_TASK = "dev_health_ops.workers.tasks.run_work_graph_build"
 _PROJECTION_TASK = "dev_health_ops.workers.tasks.run_membership_backfill"
 _DAILY_METRICS_TASK = "dev_health_ops.workers.tasks.run_daily_metrics"
@@ -77,19 +79,12 @@ def test_investment_chain_dispatched_with_git_and_work_items() -> None:
         org_id="org-123",
     )
 
-    # The chain must be built build FIRST, materialize SECOND, project THIRD.
     assert mock_chain.call_count == 1
-    team_sig, daily_sig, build_sig, materialize_sig, project_sig = (
-        mock_chain.call_args.args
-    )
+    team_sig, daily_sig, build_sig, materialize_sig = mock_chain.call_args.args
     assert team_sig.task_name == _TEAM_SYNC_TASK
     assert daily_sig.task_name == _DAILY_METRICS_TASK
     assert build_sig.task_name == _WORK_GRAPH_TASK
     assert materialize_sig.task_name == _INVESTMENT_TASK
-    assert project_sig.task_name == _PROJECTION_TASK, (
-        "the membership PROJECTION (no-LLM, full coverage) must run last as the "
-        "sole membership writer (CHAOS-2433 round-3 #2)"
-    )
 
     # All signatures are org-scoped onto the metrics queue.
     assert team_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
@@ -100,14 +95,11 @@ def test_investment_chain_dispatched_with_git_and_work_items() -> None:
     assert build_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
     assert build_sig.sig_kwargs["queue"] == "metrics"
     assert materialize_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
-    assert materialize_sig.sig_kwargs["queue"] == "metrics"
-    assert project_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
-    assert project_sig.sig_kwargs["queue"] == "metrics"
+    assert materialize_sig.sig_kwargs["queue"] == "default"
 
     # Downstream steps are linked IMMUTABLE so a parent's return dict is not
     # injected as a positional arg (which would break the next task).
     assert materialize_sig.sig_kwargs.get("immutable") is True
-    assert project_sig.sig_kwargs.get("immutable") is True
     assert build_sig.sig_kwargs.get("immutable") is True
 
     # The chain is actually dispatched (not just constructed).
@@ -128,10 +120,9 @@ def test_investment_chain_dispatched_with_git_only() -> None:
     )
 
     assert mock_chain.call_count == 1
-    build_sig, materialize_sig, project_sig = mock_chain.call_args.args
+    build_sig, materialize_sig = mock_chain.call_args.args
     assert build_sig.task_name == _WORK_GRAPH_TASK
     assert materialize_sig.task_name == _INVESTMENT_TASK
-    assert project_sig.task_name == _PROJECTION_TASK
     chain_instance.apply_async.assert_called_once_with()
 
 
@@ -148,19 +139,15 @@ def test_investment_chain_dispatched_with_work_items_only_jira() -> None:
     )
 
     assert mock_chain.call_count == 1
-    team_sig, daily_sig, build_sig, materialize_sig, project_sig = (
-        mock_chain.call_args.args
-    )
+    team_sig, daily_sig, build_sig, materialize_sig = mock_chain.call_args.args
     assert team_sig.task_name == _TEAM_SYNC_TASK
     assert daily_sig.task_name == _DAILY_METRICS_TASK
     assert build_sig.task_name == _WORK_GRAPH_TASK
     assert materialize_sig.task_name == _INVESTMENT_TASK
-    assert project_sig.task_name == _PROJECTION_TASK
     assert team_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
     assert daily_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
     assert daily_sig.sig_kwargs.get("immutable") is True
     assert materialize_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
-    assert project_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
     chain_instance.apply_async.assert_called_once_with()
 
 
@@ -214,7 +201,7 @@ def test_post_sync_dispatch_forwards_backfill_window() -> None:
         )
 
     window_send_task.assert_not_called()
-    team_sig, daily_sig, build_sig, materialize_sig, _ = window_chain.call_args.args
+    team_sig, daily_sig, build_sig, materialize_sig = window_chain.call_args.args
     assert team_sig.task_name == _TEAM_SYNC_TASK
     assert team_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
     assert daily_sig.task_name == _DAILY_METRICS_TASK

--- a/tests/test_post_sync_investment_dispatch.py
+++ b/tests/test_post_sync_investment_dispatch.py
@@ -237,6 +237,26 @@ def test_post_sync_dispatch_forwards_backfill_window() -> None:
     }
 
 
+def test_post_sync_dispatch_does_not_serialize_llm_api_key(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_API_KEY", "sk-worker-secret")
+
+    mock_signature, _, _, _ = _run_dispatch(
+        provider="github",
+        sync_targets=["git"],
+        org_id="org-123",
+    )
+
+    materialize_calls = [
+        call
+        for call in mock_signature.call_args_list
+        if call.args[0] == _INVESTMENT_TASK
+    ]
+    assert len(materialize_calls) == 1
+    kwargs = materialize_calls[0].kwargs["kwargs"]
+    assert "llm_api_key" not in kwargs
+    assert "sk-worker-secret" not in repr(kwargs)
+
+
 def test_no_investment_chain_for_feature_flags_only() -> None:
     """A sync with neither git nor work-items (e.g. feature-flags) => no chain."""
     _, mock_chain, _, mock_send_task = _run_dispatch(
@@ -279,7 +299,9 @@ def test_run_investment_materialize_forwards_org_id_to_config() -> None:
         ),
     ):
         task = cast(Any, run_investment_materialize)
-        result = task.run(db_url="clickhouse://x", org_id="org-123")
+        result = task.run(
+            db_url="clickhouse://x", org_id="org-123", llm_provider="mock"
+        )
 
     assert result["status"] == "success"
     assert captured["org_id"] == "org-123"
@@ -312,6 +334,46 @@ def test_run_investment_materialize_empty_org_id_becomes_none() -> None:
         ),
     ):
         task = cast(Any, run_investment_materialize)
-        task.run(db_url="clickhouse://x")
+        task.run(db_url="clickhouse://x", llm_provider="mock")
 
     assert captured["org_id"] is None
+
+
+def test_run_investment_materialize_resolves_worker_llm_credentials(
+    monkeypatch,
+) -> None:
+    from typing import Any, cast
+
+    from dev_health_ops.workers.work_graph_tasks import run_investment_materialize
+
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_API_KEY", "sk-worker-secret")
+    monkeypatch.setenv("LLM_BASE_URL", "https://worker.invalid/v1")
+    captured: dict[str, Any] = {}
+
+    class _FakeConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.investment.materialize.MaterializeConfig",
+            _FakeConfig,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.materialize.materialize_investments",
+            return_value=None,
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks.run_async",
+            return_value={"components": 0, "records": 0, "quotes": 0},
+        ),
+    ):
+        task = cast(Any, run_investment_materialize)
+        result = task.run(db_url="clickhouse://x", org_id="org-123", llm_concurrency=1)
+
+    assert result["status"] == "success"
+    assert captured["llm_provider"] == "openai"
+    assert captured["llm_api_key"] == "sk-worker-secret"
+    assert captured["llm_base_url"] == "https://worker.invalid/v1"
+    assert captured["llm_concurrency"] == 1

--- a/tests/test_qwen_provider.py
+++ b/tests/test_qwen_provider.py
@@ -14,7 +14,8 @@ from dev_health_ops.llm.providers.qwen import (
 
 def test_qwen_provider_registration():
     # Test explicit names
-    assert isinstance(get_provider("qwen"), QwenProvider)
+    with patch.dict(os.environ, {"QWEN_API_KEY": "test-key"}, clear=True):
+        assert isinstance(get_provider("qwen"), QwenProvider)
     assert isinstance(get_provider("qwen-local"), QwenLocalProvider)
     assert isinstance(get_provider("qwen-lmstudio"), QwenLMStudioProvider)
 
@@ -80,12 +81,18 @@ async def test_qwen_provider_completion():
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "Qwen response"
+        mock_response.usage = type(
+            "Usage", (), {"prompt_tokens": 8, "completion_tokens": 4}
+        )()
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         p = QwenProvider(api_key="sk-123")
         response = await p.complete("Hello")
 
-        assert response == "Qwen response"
+        assert response.text == "Qwen response"
+        assert response.model == "qwen-plus"
+        assert response.input_tokens == 8
+        assert response.output_tokens == 4
         # Verify client was initialized with correct base_url
         mock_openai_class.assert_called_once_with(
             api_key="sk-123", base_url=DEFAULT_DASHSCOPE_BASE_URL

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from dev_health_ops.cli import build_parser
+from dev_health_ops.cli import _load_dotenv, build_parser
 from dev_health_ops.utils import SKIP_EXTENSIONS, is_skippable
 
 
@@ -529,3 +529,31 @@ class TestCLIPlumbing:
         args = parser.parse_args(["investment", "materialize", "--db", clickhouse_dsn])
 
         assert args.analytics_db == clickhouse_dsn
+
+    def test_load_dotenv_expands_compose_interpolation(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+        monkeypatch.delenv("CLICKHOUSE_USER", raising=False)
+        monkeypatch.setenv("CLICKHOUSE_PASSWORD", "secret")
+        dotenv_path = tmp_path / ".env"
+        dotenv_path.write_text(
+            "CLICKHOUSE_URI=clickhouse://${CLICKHOUSE_USER:-ch}:${CLICKHOUSE_PASSWORD:-ch}@localhost:8123/default\n",
+            encoding="utf-8",
+        )
+
+        assert _load_dotenv(dotenv_path) == 1
+        assert (
+            os.environ["CLICKHOUSE_URI"]
+            == "clickhouse://ch:secret@localhost:8123/default"
+        )
+
+    def test_load_dotenv_rejects_unresolved_interpolation(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+        monkeypatch.delenv("MISSING_DOTENV_VAR", raising=False)
+        dotenv_path = tmp_path / ".env"
+        dotenv_path.write_text(
+            "CLICKHOUSE_URI=clickhouse://${MISSING_DOTENV_VAR}@localhost:8123/default\n",
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="MISSING_DOTENV_VAR"):
+            _load_dotenv(dotenv_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -486,3 +486,46 @@ class TestGlobalFlagsPropagateToSubparsers:
         # Leaf parser uses default=SUPPRESS, so omitting --org on the leaf must
         # NOT clobber the value supplied before the subcommand.
         assert args.org == "from-root"
+
+
+class TestCLIPlumbing:
+    def test_investment_materialize_preserves_root_llm_arguments(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "-l",
+                "openai",
+                "-m",
+                "gpt-4o-mini",
+                "investment",
+                "materialize",
+            ]
+        )
+
+        assert args.llm_provider == "openai"
+        assert args.model == "gpt-4o-mini"
+
+    def test_investment_materialize_preserves_root_db_arguments(self):
+        parser = build_parser()
+        postgres_dsn = "postgresql+asyncpg://pg:pg@localhost:5432/devhealth"
+        clickhouse_dsn = "clickhouse://ch:ch@localhost:8123/default"
+        args = parser.parse_args(
+            [
+                "--db",
+                postgres_dsn,
+                "--analytics-db",
+                clickhouse_dsn,
+                "investment",
+                "materialize",
+            ]
+        )
+
+        assert args.db == postgres_dsn
+        assert args.analytics_db == clickhouse_dsn
+
+    def test_investment_materialize_accepts_deprecated_db_alias(self):
+        parser = build_parser()
+        clickhouse_dsn = "clickhouse://ch:ch@localhost:8123/default"
+        args = parser.parse_args(["investment", "materialize", "--db", clickhouse_dsn])
+
+        assert args.analytics_db == clickhouse_dsn

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -497,6 +497,12 @@ class TestCLIPlumbing:
                 "openai",
                 "-m",
                 "gpt-4o-mini",
+                "--llm-api-key",
+                "sk-inline",
+                "--llm-base-url",
+                "https://llm.invalid/v1",
+                "--llm-concurrency",
+                "1",
                 "investment",
                 "materialize",
             ]
@@ -504,6 +510,28 @@ class TestCLIPlumbing:
 
         assert args.llm_provider == "openai"
         assert args.model == "gpt-4o-mini"
+        assert args.llm_api_key == "sk-inline"
+        assert args.llm_base_url == "https://llm.invalid/v1"
+        assert args.llm_concurrency == 1
+
+    def test_investment_materialize_accepts_leaf_llm_arguments(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "investment",
+                "materialize",
+                "--llm-api-key",
+                "sk-leaf",
+                "--llm-base-url",
+                "https://leaf.invalid/v1",
+                "--llm-concurrency",
+                "1",
+            ]
+        )
+
+        assert args.llm_api_key == "sk-leaf"
+        assert args.llm_base_url == "https://leaf.invalid/v1"
+        assert args.llm_concurrency == 1
 
     def test_investment_materialize_preserves_root_db_arguments(self):
         parser = build_parser()

--- a/tests/work_graph/test_investment_categorize.py
+++ b/tests/work_graph/test_investment_categorize.py
@@ -12,7 +12,7 @@ class StubProvider:
         self.calls = 0
         self.prompts = []
 
-    async def complete(self, prompt: str) -> str:
+    async def complete_text(self, prompt: str) -> str:
         self.calls += 1
         self.prompts.append(prompt)
         return self.responses[self.calls - 1]

--- a/tests/work_graph/test_investment_categorize.py
+++ b/tests/work_graph/test_investment_categorize.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 
+from dev_health_ops.llm import CompletionResult
 from dev_health_ops.work_graph.investment.categorize import categorize_text_bundle
 from dev_health_ops.work_graph.investment.types import TextBundle
 
@@ -12,10 +13,18 @@ class StubProvider:
         self.calls = 0
         self.prompts = []
 
-    async def complete_text(self, prompt: str) -> str:
+    async def complete(self, prompt: str) -> CompletionResult:
         self.calls += 1
         self.prompts.append(prompt)
-        return self.responses[self.calls - 1]
+        return CompletionResult(
+            text=self.responses[self.calls - 1],
+            input_tokens=10 * self.calls,
+            output_tokens=5 * self.calls,
+            model="stub-model",
+        )
+
+    async def complete_text(self, prompt: str) -> str:
+        return (await self.complete(prompt)).text
 
 
 def _bundle() -> TextBundle:
@@ -44,6 +53,10 @@ def test_retry_limit_and_fallback(monkeypatch):
     assert provider.calls == 2
     assert outcome.status == "invalid_llm_output"
     assert outcome.subcategories.get("feature_delivery.roadmap") == 0.2
+    assert outcome.llm_calls == 2
+    assert outcome.input_tokens == 30
+    assert outcome.output_tokens == 15
+    assert outcome.llm_model == "stub-model"
 
 
 def test_repaired_status(monkeypatch):
@@ -71,3 +84,6 @@ def test_repaired_status(monkeypatch):
     assert "Output schema" in provider.prompts[1]
     assert outcome.status == "repaired"
     assert outcome.warnings == ["probability_sum_renormalized:0.9500"]
+    assert outcome.llm_calls == 2
+    assert outcome.input_tokens == 30
+    assert outcome.output_tokens == 15

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -4,6 +4,7 @@ import asyncio
 import builtins
 import json
 import uuid
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -31,6 +32,8 @@ class FakeSink:
         self.quote_rows: list[WorkUnitInvestmentEvidenceQuoteRecord] = []
         self.membership_rows: list = []
         self.membership_run_records: list = []
+        self.query_calls: list[tuple[str, dict]] = []
+        self.query_result_factory: Callable[[str, dict], list[dict]] | None = None
 
     def ensure_schema(self) -> None:
         return None
@@ -46,6 +49,12 @@ class FakeSink:
 
     def write_membership_run(self, record) -> None:
         self.membership_run_records.append(record)
+
+    def query_dicts(self, query: str, parameters: dict) -> list[dict]:
+        self.query_calls.append((query, parameters))
+        if self.query_result_factory is not None:
+            return self.query_result_factory(query, parameters)
+        return []
 
     def close(self) -> None:
         return None
@@ -599,6 +608,110 @@ async def test_materialize_records_default_org_id_empty(monkeypatch):
     await materialize_investments(config)
     assert sink.investment_rows
     assert all(r.org_id == "" for r in sink.investment_rows)
+
+
+@pytest.mark.asyncio
+async def test_materialize_skips_fresh_existing_input_hash_by_default(monkeypatch):
+    repo_id, edges, work_items, commits = _sample_data()
+    work_items[0]["description"] = "Resolve authentication failures. " * 20
+    sink = FakeSink()
+
+    def _existing_key(_query: str, parameters: dict) -> list[dict]:
+        return [
+            {
+                "work_unit_id": parameters["work_unit_ids"][0],
+                "categorization_input_hash": parameters["input_hashes"][0],
+            }
+        ]
+
+    async def _categorize_should_not_run(*args, **kwargs):
+        raise AssertionError("unchanged bundle should not call LLM")
+
+    sink.query_result_factory = _existing_key
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _categorize_should_not_run,
+    )
+
+    now = datetime.now(timezone.utc)
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=[repo_id],
+            llm_provider="mock",
+            persist_evidence_snippets=False,
+            llm_model="test-model",
+            org_id="org-123",
+        )
+    )
+
+    assert stats["records"] == 0
+    assert stats["skipped_existing"] == 1
+    assert sink.investment_rows == []
+    assert sink.query_calls
+
+
+@pytest.mark.asyncio
+async def test_materialize_force_recomputes_existing_input_hash(monkeypatch):
+    repo_id, edges, work_items, commits = _sample_data()
+    work_items[0]["description"] = "Resolve authentication failures. " * 20
+    sink = FakeSink()
+    categorize_calls = 0
+
+    def _existing_key(_query: str, parameters: dict) -> list[dict]:
+        return [
+            {
+                "work_unit_id": parameters["work_unit_ids"][0],
+                "categorization_input_hash": parameters["input_hashes"][0],
+            }
+        ]
+
+    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
+        nonlocal categorize_calls
+        categorize_calls += 1
+        return CategorizationOutcome(
+            subcategories={"feature_delivery.roadmap": 1.0},
+            evidence_quotes=[],
+            uncertainty="Limited evidence.",
+            status="ok",
+            errors=[],
+        )
+
+    sink.query_result_factory = _existing_key
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _fake_categorize,
+    )
+
+    now = datetime.now(timezone.utc)
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=[repo_id],
+            llm_provider="mock",
+            persist_evidence_snippets=False,
+            llm_model="test-model",
+            org_id="org-123",
+            force=True,
+        )
+    )
+
+    assert categorize_calls == 1
+    assert stats["records"] == 1
+    assert stats["skipped_existing"] == 0
+    assert len(sink.investment_rows) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from dev_health_ops.llm import LLMAuthError
 from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
@@ -292,6 +293,121 @@ async def test_materialize_llm_concurrency_one_serializes(monkeypatch):
     stats = await materialize_investments(config)
     assert stats["records"] == 2
     assert max_active == 1
+
+
+@pytest.mark.asyncio
+async def test_materialize_fatal_llm_error_cancels_and_writes_no_rows(monkeypatch):
+    repo_one = str(uuid.uuid4())
+    repo_two = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+    edges = [
+        {
+            "edge_id": "edge-1",
+            "source_type": "issue",
+            "source_id": "jira:ABC-1",
+            "target_type": "commit",
+            "target_id": f"{repo_one}@abc123",
+            "repo_id": repo_one,
+            "confidence": 0.9,
+        },
+        {
+            "edge_id": "edge-2",
+            "source_type": "issue",
+            "source_id": "jira:ABC-2",
+            "target_type": "commit",
+            "target_id": f"{repo_two}@def456",
+            "repo_id": repo_two,
+            "confidence": 0.9,
+        },
+    ]
+    work_items = [
+        {
+            "work_item_id": "jira:ABC-1",
+            "provider": "jira",
+            "repo_id": repo_one,
+            "title": "Fix billing outage",
+            "description": "Resolve customer billing failures. " * 20,
+            "type": "incident",
+            "labels": ["outage"],
+            "parent_id": "",
+            "epic_id": "",
+            "created_at": now - timedelta(days=2),
+            "updated_at": now - timedelta(days=1),
+            "completed_at": now - timedelta(days=1),
+        },
+        {
+            "work_item_id": "jira:ABC-2",
+            "provider": "jira",
+            "repo_id": repo_two,
+            "title": "Add checkout flow",
+            "description": "Ship checkout workflow improvements. " * 20,
+            "type": "task",
+            "labels": ["feature"],
+            "parent_id": "",
+            "epic_id": "",
+            "created_at": now - timedelta(days=2),
+            "updated_at": now - timedelta(days=1),
+            "completed_at": now - timedelta(days=1),
+        },
+    ]
+    commits = [
+        {
+            "repo_id": repo_one,
+            "hash": "abc123",
+            "message": "Fix billing outage",
+            "author_when": now - timedelta(days=1),
+            "committer_when": now - timedelta(days=1),
+        },
+        {
+            "repo_id": repo_two,
+            "hash": "def456",
+            "message": "Add checkout flow",
+            "author_when": now - timedelta(days=1),
+            "committer_when": now - timedelta(days=1),
+        },
+    ]
+    sink = FakeSink()
+    call_count = 0
+    sleeper_cancelled = False
+
+    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
+        nonlocal call_count, sleeper_cancelled
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("insufficient_quota: billing hard limit reached")
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            sleeper_cancelled = True
+            raise
+        raise AssertionError("pending LLM task was not cancelled")
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _fake_categorize,
+    )
+
+    config = MaterializeConfig(
+        dsn="clickhouse://localhost:8123/default",
+        from_ts=now - timedelta(days=5),
+        to_ts=now,
+        repo_ids=None,
+        llm_provider="mock",
+        persist_evidence_snippets=False,
+        llm_model="test-model",
+        llm_concurrency=2,
+    )
+
+    with pytest.raises(LLMAuthError, match="quota exhausted"):
+        await materialize_investments(config)
+
+    assert sleeper_cancelled is True
+    assert sink.investment_rows == []
+    assert sink.quote_rows == []
 
 
 @pytest.mark.asyncio

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -465,7 +465,9 @@ async def test_materialize_passes_configured_llm_credentials(monkeypatch):
     sink = FakeSink()
     captured = {}
 
-    def _fake_get_provider(name, model=None, *, api_key=None, base_url=None):
+    def _fake_get_provider(
+        name, model=None, *, org_id=None, api_key=None, base_url=None
+    ):
         captured.update(
             {"name": name, "model": model, "api_key": api_key, "base_url": base_url}
         )

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -411,6 +411,39 @@ async def test_materialize_fatal_llm_error_cancels_and_writes_no_rows(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_materialize_none_provider_fails_closed_before_writes(monkeypatch):
+    sink = FakeSink()
+
+    def _fetch_edges_should_not_run(*args, **kwargs):
+        raise AssertionError("none provider must fail before graph categorization")
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.fetch_work_graph_edges",
+        _fetch_edges_should_not_run,
+    )
+
+    now = datetime.now(timezone.utc)
+    config = MaterializeConfig(
+        dsn="clickhouse://localhost:8123/default",
+        from_ts=now - timedelta(days=5),
+        to_ts=now,
+        repo_ids=None,
+        llm_provider="none",
+        persist_evidence_snippets=False,
+        llm_model=None,
+    )
+
+    with pytest.raises(LLMAuthError, match="cannot materialize"):
+        await materialize_investments(config)
+
+    assert sink.investment_rows == []
+    assert sink.quote_rows == []
+
+
+@pytest.mark.asyncio
 async def test_materialize_passes_configured_llm_credentials(monkeypatch):
     sink = FakeSink()
     captured = {}

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import builtins
 import json
 import uuid
@@ -46,6 +47,11 @@ class FakeSink:
         self.membership_run_records.append(record)
 
     def close(self) -> None:
+        return None
+
+
+class FakeProvider:
+    async def aclose(self) -> None:
         return None
 
 
@@ -112,7 +118,7 @@ def _patch_queries(monkeypatch, edges, work_items, commits):
     monkeypatch.setattr(
         "dev_health_ops.work_graph.investment.materialize.fetch_commit_churn",
         lambda client, repo_commits, **kwargs: {
-            f"{commits[0]['repo_id']}@abc123": 10.0
+            f"{commit['repo_id']}@{commit['hash']}": 10.0 for commit in commits
         },
     )
     monkeypatch.setattr(
@@ -170,6 +176,170 @@ async def test_materialize_invokes_sink(monkeypatch):
     assert json.loads(record.categorization_errors_json) == [
         "probability_sum_renormalized:0.9500"
     ]
+
+
+@pytest.mark.asyncio
+async def test_materialize_llm_concurrency_one_serializes(monkeypatch):
+    repo_one = str(uuid.uuid4())
+    repo_two = str(uuid.uuid4())
+    edges = [
+        {
+            "edge_id": "edge-1",
+            "source_type": "issue",
+            "source_id": "jira:ABC-1",
+            "target_type": "commit",
+            "target_id": f"{repo_one}@abc123",
+            "repo_id": repo_one,
+            "confidence": 0.9,
+        },
+        {
+            "edge_id": "edge-2",
+            "source_type": "issue",
+            "source_id": "jira:ABC-2",
+            "target_type": "commit",
+            "target_id": f"{repo_two}@def456",
+            "repo_id": repo_two,
+            "confidence": 0.9,
+        },
+    ]
+    now = datetime.now(timezone.utc)
+    work_items = [
+        {
+            "work_item_id": "jira:ABC-1",
+            "provider": "jira",
+            "repo_id": repo_one,
+            "title": "Fix login outage",
+            "description": "Resolve authentication failures. " * 20,
+            "type": "incident",
+            "labels": ["outage"],
+            "parent_id": "",
+            "epic_id": "",
+            "created_at": now - timedelta(days=2),
+            "updated_at": now - timedelta(days=1),
+            "completed_at": now - timedelta(days=1),
+        },
+        {
+            "work_item_id": "jira:ABC-2",
+            "provider": "jira",
+            "repo_id": repo_two,
+            "title": "Add checkout flow",
+            "description": "Ship checkout workflow improvements. " * 20,
+            "type": "task",
+            "labels": ["feature"],
+            "parent_id": "",
+            "epic_id": "",
+            "created_at": now - timedelta(days=2),
+            "updated_at": now - timedelta(days=1),
+            "completed_at": now - timedelta(days=1),
+        },
+    ]
+    commits = [
+        {
+            "repo_id": repo_one,
+            "hash": "abc123",
+            "message": "Fix login outage",
+            "author_when": now - timedelta(days=1),
+            "committer_when": now - timedelta(days=1),
+        },
+        {
+            "repo_id": repo_two,
+            "hash": "def456",
+            "message": "Add checkout flow",
+            "author_when": now - timedelta(days=1),
+            "committer_when": now - timedelta(days=1),
+        },
+    ]
+    sink = FakeSink()
+    active = 0
+    max_active = 0
+
+    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        try:
+            await asyncio.sleep(0)
+            return CategorizationOutcome(
+                subcategories={"feature_delivery.roadmap": 1.0},
+                evidence_quotes=[],
+                uncertainty="Limited evidence.",
+                status="ok",
+                errors=[],
+            )
+        finally:
+            active -= 1
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _fake_categorize,
+    )
+
+    config = MaterializeConfig(
+        dsn="clickhouse://localhost:8123/default",
+        from_ts=now - timedelta(days=5),
+        to_ts=now,
+        repo_ids=None,
+        llm_provider="mock",
+        persist_evidence_snippets=False,
+        llm_model="test-model",
+        llm_concurrency=1,
+    )
+
+    stats = await materialize_investments(config)
+    assert stats["records"] == 2
+    assert max_active == 1
+
+
+@pytest.mark.asyncio
+async def test_materialize_passes_configured_llm_credentials(monkeypatch):
+    sink = FakeSink()
+    captured = {}
+
+    def _fake_get_provider(name, model=None, *, api_key=None, base_url=None):
+        captured.update(
+            {"name": name, "model": model, "api_key": api_key, "base_url": base_url}
+        )
+        return FakeProvider()
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.get_provider",
+        _fake_get_provider,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.fetch_work_graph_edges",
+        lambda client, repo_ids=None, **kwargs: [],
+    )
+
+    now = datetime.now(timezone.utc)
+    config = MaterializeConfig(
+        dsn="clickhouse://localhost:8123/default",
+        from_ts=now - timedelta(days=5),
+        to_ts=now,
+        repo_ids=None,
+        llm_provider="openai",
+        persist_evidence_snippets=False,
+        llm_model="gpt-4o-mini",
+        llm_api_key="sk-inline-secret",
+        llm_base_url="https://inline.invalid/v1",
+    )
+
+    stats = await materialize_investments(config)
+
+    assert stats == {"components": 0, "records": 0, "quotes": 0}
+    assert captured == {
+        "name": "openai",
+        "model": "gpt-4o-mini",
+        "api_key": "sk-inline-secret",
+        "base_url": "https://inline.invalid/v1",
+    }
+    assert "sk-inline-secret" not in repr(config)
 
 
 @pytest.mark.asyncio

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -146,6 +146,10 @@ async def test_materialize_invokes_sink(monkeypatch):
             status="ok",
             errors=[],
             warnings=["probability_sum_renormalized:0.9500"],
+            llm_calls=1,
+            input_tokens=123,
+            output_tokens=45,
+            llm_model="test-model",
         )
 
     monkeypatch.setattr(
@@ -170,6 +174,10 @@ async def test_materialize_invokes_sink(monkeypatch):
 
     stats = await materialize_investments(config)
     assert stats["records"] == 1
+    assert stats["llm_calls"] == 1
+    assert stats["llm_input_tokens"] == 123
+    assert stats["llm_output_tokens"] == 45
+    assert stats["llm_failure_counts"] == {}
     assert len(sink.investment_rows) == 1
     record = sink.investment_rows[0]
     assert record.work_unit_type == "incident"

--- a/tests/work_graph/test_runner.py
+++ b/tests/work_graph/test_runner.py
@@ -129,6 +129,9 @@ def _materialize_ns(**overrides) -> argparse.Namespace:
         llm_provider="auto",
         persist_evidence_snippets=True,
         model=None,
+        llm_api_key=None,
+        llm_base_url=None,
+        llm_concurrency=None,
         force=False,
     )
     base.update(overrides)
@@ -231,6 +234,40 @@ def test_cli_team_scoped_materialize_skips_org_marker():
         rc = run_investment_materialization(_materialize_ns(team_id=["team-1"]))
 
     assert rc == 0
+    backfill_mock.assert_not_called()
+
+
+def test_cli_materialize_threads_inline_llm_credentials_and_concurrency():
+    fake_materialize, materialize_mock, backfill_mock = (
+        _patch_materialize_and_projection()
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.runner.materialize_investments",
+            fake_materialize,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.backfill_memberships",
+            backfill_mock,
+        ),
+    ):
+        rc = run_investment_materialization(
+            _materialize_ns(
+                repo_id=["repo-uuid-1"],
+                llm_api_key="sk-inline-secret",
+                llm_base_url="https://inline.invalid/v1",
+                llm_concurrency=1,
+            )
+        )
+
+    assert rc == 0
+    materialize_mock.assert_called_once()
+    config = materialize_mock.call_args.args[0]
+    assert config.llm_api_key == "sk-inline-secret"
+    assert config.llm_base_url == "https://inline.invalid/v1"
+    assert config.llm_concurrency == 1
+    assert "sk-inline-secret" not in repr(config)
     backfill_mock.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

First-class **Bring Your Own LLM (BYO-LLM)** across CLI / worker / API: an org (or operator) supplies provider + model + API key + base URL at any level — CLI flag, env, or per-org encrypted settings — with precedence **per-call › env › org settings › classified error**. Failures are loud and classified, spend is observable, and results are tenant-scoped end-to-end.

Implements epic **CHAOS-2349** and all 11 sub-issues (CHAOS-2350…2360) on one integration branch.

## What's included

**LLM provider core**
- `complete() → CompletionResult` (+ `complete_text()` adapter) across every provider and all in-repo callers; token usage captured at the source (CHAOS-2357).
- Per-provider default-model table, env-overridable; removed hardcoded `gpt-5-mini` / `claude-3-haiku` (CHAOS-2356).
- Killed the silent mock fallback: `auto` resolves a real provider or fails loud; `none` is a non-categorizing mode (never mock, never a real model name); truthful `is_llm_available` (CHAOS-2355).
- Error taxonomy (`LLMAuthError` / `LLMRateLimitError` / `LLMContextLengthError` / `LLMServerError` / `LLMOutputError`) + fail-fast circuit-breaker; openai retry no longer inflates `max_output_tokens` on quota/transport errors; `Retry-After` honored and clamped (≤ 60s) so a hostile value can't pin a worker (CHAOS-2352).

**Credentials**
- `--llm-api-key` / `--llm-base-url` flags + `LLM_API_KEY` / `LLM_BASE_URL` env, threaded through `get_provider` / `MaterializeConfig` / worker kwargs (CHAOS-2353).
- Per-org encrypted credentials via `SettingCategory.LLM` (provider/model/api_key/base_url), encrypted with the existing `SettingsService`; admin REST `GET/PUT/DELETE /api/v1/admin/llm-settings`, tier-gated (Team+), API keys masked in all responses; resolution helper with the documented precedence (CHAOS-2354).
- Raw keys are never serialized through Celery kwargs — worker/chord tasks resolve credentials internally by `org_id`.

**CLI plumbing (CHAOS-2360)**
- argparse leaf-default `SUPPRESS` so root-position `-l/-m` survive subcommand parsing; `--db` → `--analytics-db` collision fix; `_load_dotenv` `${VAR}` / `${VAR:-default}` interpolation.
- `--llm-concurrency` flag / worker kwarg / env (CHAOS-2358).

**Materialize**
- Circuit-breaker: deterministic-fatal LLM errors cancel pending tasks and abort (exit ≠ 0) with a classified verdict — **zero fabricated rows**; `none`/unavailable provider fails closed rather than overwriting real categorization (CHAOS-2352).
- Run-summary token aggregation + per-class failure counts + per-call OTEL spans; tracing initialized at Celery worker bootstrap (CHAOS-2357).
- Chord fan-out (`dispatch_investment_materialize_partitioned`) with per-chunk checkpoints, input-hash idempotency skip (effective key includes provider/model/taxonomy/prompt), real `--force`, bulk hash prefetch off the event loop, membership backfill once in the finalizer (CHAOS-2359).

**API hardening (CHAOS-2351)**
- Work-unit explain endpoint rate-limited; provider/credential validation and runtime LLM failures map to proper HTTP status (422/429/503) before the stream opens — no more 200-then-broken-stream.
- Generic settings routes reject `category='llm'` (no tier-gate back door); generic single-setting GET masks encrypted values.

**Docs** — 6 MkDocs pages with Mermaid diagrams (credential precedence, architecture, error/circuit-breaker, fan-out, spend observability, user flow); `mkdocs build --strict` passes clean.

## Scope note

The 2026-06-12 audit is stale: `main` already contains the org write-path stamping + the ClickHouse `org_id` sort-key migration (`027_add_org_id_to_sorting_keys`), org-scoped explain cache (CHAOS-2393), the post-sync materialize producer (CHAOS-2374), and the NO-LLM membership/backfill split (CHAOS-2433). Those were verified, not re-implemented; the stale feature branches were intentionally not merged.

## Review & quality

- **3 adversarial review passes** (provider core, plumbing, materialize+creds); all findings triaged. Fixed blockers: generic-settings tier-gate bypass, encrypted-key plaintext readback, default-worker org-provider resolution, unbounded `Retry-After`, generic-key-without-provider error, `none`-provider fabrication, explain streaming runtime failures, local-provider log redaction.
- `mypy` clean (whole project); relevant test suite green; `mkdocs build --strict` clean. New tests cover the credential precedence, circuit-breaker (no fabricated rows), `none` fail-closed, idempotency/force, tier-gate enforcement, masked readback, and HTTP error classification.

## Visual evidence

SCREENSHOT-WAIVER: backend (dev-health-ops), admin REST API, and docs only — no `dev-health-web` rendering changes are shipped in this PR. The BYO-LLM admin UI is design-only at this stage; Penpot view artifacts (Org LLM Settings, LLM Spend Summary, Explain Error States) were authored in the "Dev Health IA Design System" file for the future web implementation.

Closes CHAOS-2349, CHAOS-2350, CHAOS-2351, CHAOS-2352, CHAOS-2353, CHAOS-2354, CHAOS-2355, CHAOS-2356, CHAOS-2357, CHAOS-2358, CHAOS-2359, CHAOS-2360
