### PR TITLE
fix(metrics): UUID-safe org_id filter for AI loaders (CHAOS-2537)

### DIFF
--- a/src/dev_health_ops/metrics/loaders/ai_impact.py
+++ b/src/dev_health_ops/metrics/loaders/ai_impact.py
@@ -51,7 +51,7 @@ class AIImpactClickHouseLoader:
                 "\n              AND toString(pr.repo_id) IN {repo_ids:Array(String)}"
             )
         params = self._scope.inject(params)
-        org_filter_attr = self._scope.filter(alias="attr")
+        org_filter_attr = self._scope.filter_uuid(alias="attr")
         org_filter_pr = self._scope.filter(alias="pr")
         limit_clause = ""
         if limit is not None and int(limit) > 0:
@@ -256,7 +256,7 @@ class AIImpactClickHouseLoader:
         # repo are included, but reviewers from purely-human repos are excluded.
         # A full per-PR-reviewer join requires a separate PR-review events table
         # and is deferred to a future wave.
-        org_filter_ai_attr = self._scope.filter(alias="attr")
+        org_filter_ai_attr = self._scope.filter_uuid(alias="attr")
         query = f"""
         SELECT sum(reviews_given) AS reviews_given
         FROM (
@@ -305,7 +305,7 @@ class AIImpactClickHouseLoader:
         (including multi-repo work items). Only repo-pinned records are
         constrained to their own repo's links.
         """
-        org_filter_attr = self._scope.filter(alias="attr")
+        org_filter_attr = self._scope.filter_uuid(alias="attr")
         org_filter_link = self._scope.filter(alias="link")
         return f"""
             SELECT repo_id, number, any(kind) AS kind

--- a/src/dev_health_ops/metrics/opportunities/ai_detector.py
+++ b/src/dev_health_ops/metrics/opportunities/ai_detector.py
@@ -346,7 +346,7 @@ class AIOpportunityDetector:
             filters.append("pr.repo_id = {repo_id:UUID}")
         org_scope = OrgScopedQuery(org_id)
         params = org_scope.inject(params)
-        org_expr = org_scope.expression(alias="attr")
+        org_expr = org_scope.expression_uuid(alias="attr")
         if org_expr:
             filters.append(org_expr)
         # CHAOS-2396: scope the driving git_pull_requests side too. The

--- a/src/dev_health_ops/metrics/query_builder.py
+++ b/src/dev_health_ops/metrics/query_builder.py
@@ -60,6 +60,49 @@ class OrgScopedQuery:
         col = f"{alias}.org_id" if alias else "org_id"
         return f"{col} = {{org_id:String}}"
 
+    def filter_uuid(self, *, alias: str = "") -> str:
+        """Return ``" AND toString({alias?.}org_id) = {org_id:String}"`` or ``""``.
+
+        UUID-safe variant of :meth:`filter` for tables whose ``org_id`` column
+        is typed ``UUID`` (e.g. ``ai_attribution_resolved``, ``ai_attribution``,
+        ``ai_workgraph``).  Casting the column to String via ``toString()`` is
+        always valid; casting the String constant ``'default'`` to UUID is not.
+
+        Same identifier safety check and empty-org short-circuit as
+        :meth:`filter`.  Callers do NOT need to change their :meth:`inject`
+        calls — the param binding name ``org_id`` is unchanged.
+        """
+        if alias and not alias.isidentifier():
+            raise ValueError(
+                "OrgScopedQuery.filter_uuid: alias must be a valid identifier, "
+                f"got {alias!r}"
+            )
+        if not self.org_id:
+            return ""
+        col = f"{alias}.org_id" if alias else "org_id"
+        return f" AND toString({col}) = {{org_id:String}}"
+
+    def expression_uuid(self, *, alias: str = "") -> str:
+        """Return ``"toString({alias?.}org_id) = {org_id:String}"`` or ``""``.
+
+        UUID-safe companion to :meth:`expression` for tables whose ``org_id``
+        column is typed ``UUID``.  Use in filter-list callers (join with
+        ``" AND "``) targeting ``ai_attribution_resolved``, ``ai_attribution``,
+        or ``ai_workgraph`` tables.
+
+        Same identifier safety check as :meth:`expression`.  The param binding
+        name ``org_id`` is unchanged so :meth:`inject` calls are unaffected.
+        """
+        if alias and not alias.isidentifier():
+            raise ValueError(
+                "OrgScopedQuery.expression_uuid: alias must be a valid identifier, "
+                f"got {alias!r}"
+            )
+        if not self.org_id:
+            return ""
+        col = f"{alias}.org_id" if alias else "org_id"
+        return f"toString({col}) = {{org_id:String}}"
+
     def inject(self, params: dict[str, Any]) -> dict[str, Any]:
         """Return a new params dict with ``org_id`` added when set.
 

--- a/tests/metrics/test_ai_impact_loader.py
+++ b/tests/metrics/test_ai_impact_loader.py
@@ -400,7 +400,7 @@ async def test_hotspot_overlap_org_scopes_every_joined_table():
         "link.org_id = {org_id:String}",
         "hs.org_id = {org_id:String}",
         "pr.org_id = {org_id:String}",
-        "attr.org_id = {org_id:String}",
+        "toString(attr.org_id) = {org_id:String}",
     ):
         assert clause in query, f"missing org scope: {clause}"
     assert params["org_id"] == ORG_ID
@@ -418,7 +418,7 @@ async def test_complexity_overlap_org_scopes_every_joined_table():
         "link.org_id = {org_id:String}",
         "fc.org_id = {org_id:String}",
         "pr.org_id = {org_id:String}",
-        "attr.org_id = {org_id:String}",
+        "toString(attr.org_id) = {org_id:String}",
     ):
         assert clause in query, f"missing org scope: {clause}"
 
@@ -440,7 +440,7 @@ async def test_review_engagement_org_scoped_and_uses_event_day():
     assert "pr.created_at >= {start:DateTime} AND pr.created_at <" not in query
     for clause in (
         "pr.org_id = {org_id:String}",
-        "attr.org_id = {org_id:String}",
+        "toString(attr.org_id) = {org_id:String}",
         "link.org_id = {org_id:String}",
     ):
         assert clause in query, f"missing org scope: {clause}"

--- a/tests/metrics/test_ai_opportunity_detector.py
+++ b/tests/metrics/test_ai_opportunity_detector.py
@@ -388,4 +388,4 @@ async def test_repetitive_changes_query_scopes_pull_requests_by_org(
     ]
     assert repetitive, "repetitive-changes query was not issued"
     assert "pr.org_id = {org_id:String}" in repetitive[0]
-    assert "attr.org_id = {org_id:String}" in repetitive[0]
+    assert "toString(attr.org_id) = {org_id:String}" in repetitive[0]

--- a/tests/metrics/test_query_builder.py
+++ b/tests/metrics/test_query_builder.py
@@ -114,3 +114,95 @@ class TestOrgScopedQuery:
         q = OrgScopedQuery("acme")
         sql = "SELECT 1 FROM t WHERE foo = 1" + q.filter()
         assert sql == "SELECT 1 FROM t WHERE foo = 1 AND org_id = {org_id:String}"
+
+
+class TestOrgScopedQueryUUID:
+    """Regression tests for UUID-safe filter_uuid / expression_uuid methods.
+
+    These guard against CANNOT_PARSE_UUID crashes when org_id is the
+    sentinel string 'default' and the target column is typed UUID
+    (ai_attribution_resolved, ai_attribution, ai_workgraph).
+    """
+
+    def test_filter_uuid_with_alias(self) -> None:
+        q = OrgScopedQuery("default")
+        assert (
+            q.filter_uuid(alias="attr")
+            == " AND toString(attr.org_id) = {org_id:String}"
+        )
+
+    def test_filter_uuid_no_alias(self) -> None:
+        q = OrgScopedQuery("default")
+        assert q.filter_uuid() == " AND toString(org_id) = {org_id:String}"
+
+    def test_filter_uuid_empty_org_returns_empty(self) -> None:
+        q = OrgScopedQuery("")
+        assert q.filter_uuid() == ""
+        assert q.filter_uuid(alias="attr") == ""
+
+    def test_filter_uuid_rejects_invalid_alias(self) -> None:
+        q = OrgScopedQuery("default")
+        with pytest.raises(ValueError, match="valid identifier"):
+            q.filter_uuid(alias="1bad")
+
+    def test_expression_uuid_with_alias(self) -> None:
+        q = OrgScopedQuery("default")
+        assert (
+            q.expression_uuid(alias="attr") == "toString(attr.org_id) = {org_id:String}"
+        )
+
+    def test_expression_uuid_no_alias(self) -> None:
+        q = OrgScopedQuery("default")
+        assert q.expression_uuid() == "toString(org_id) = {org_id:String}"
+
+    def test_expression_uuid_empty_org_returns_empty(self) -> None:
+        q = OrgScopedQuery("")
+        assert q.expression_uuid() == ""
+        assert q.expression_uuid(alias="attr") == ""
+
+    def test_expression_uuid_rejects_invalid_alias(self) -> None:
+        q = OrgScopedQuery("default")
+        with pytest.raises(ValueError, match="valid identifier"):
+            q.expression_uuid(alias="1bad")
+
+    def test_filter_uuid_uses_tostring_not_bare_column(self) -> None:
+        """Regression: must emit toString(col) not bare col = {org_id:String}.
+
+        A bare ``attr.org_id = {org_id:String}`` causes ClickHouse to cast the
+        String param to UUID, which fails for the sentinel value 'default'
+        (Code: 376 CANNOT_PARSE_UUID).
+        """
+        q = OrgScopedQuery("default")
+        result = q.filter_uuid(alias="attr")
+        assert "toString(attr.org_id)" in result
+        assert "attr.org_id = {org_id:String}" not in result
+
+    def test_expression_uuid_uses_tostring_not_bare_column(self) -> None:
+        q = OrgScopedQuery("default")
+        result = q.expression_uuid(alias="attr")
+        assert "toString(attr.org_id)" in result
+        assert "attr.org_id = {org_id:String}" not in result
+
+    def test_expression_uuid_composes_in_filter_list(self) -> None:
+        """UUID-safe expression composes cleanly in a filter list (no double-AND).
+
+        Mirrors the existing test_expression_composes_cleanly_in_filter_list
+        regression for the String variant.
+        """
+        q = OrgScopedQuery("default")
+        filters = ["day >= {start_day:Date}", "day <= {end_day:Date}"]
+        org_expr = q.expression_uuid(alias="attr")
+        if org_expr:
+            filters.append(org_expr)
+        where_clause = " AND ".join(filters)
+        assert where_clause == (
+            "day >= {start_day:Date} AND day <= {end_day:Date} "
+            "AND toString(attr.org_id) = {org_id:String}"
+        )
+        assert " AND  AND " not in where_clause
+
+    def test_inject_unchanged_for_uuid_methods(self) -> None:
+        """inject() is shared — UUID methods don't need a separate inject path."""
+        q = OrgScopedQuery("default")
+        params = q.inject({"x": 1})
+        assert params == {"x": 1, "org_id": "default"}


### PR DESCRIPTION
## Summary
Fixes a ClickHouse `CANNOT_PARSE_UUID` (code 376) crash during daily-metrics / backfill runs in single-tenant (`org_id="default"`) deployments.

```
Code: 376. Cannot parse uuid default: while converting 'default' to UUID:
while executing function equals on arguments __table5.org_id UUID = 'default'_String (CANNOT_PARSE_UUID)
```

## Root cause
`org_id` has a column-type split across ClickHouse tables:
- Core/metrics tables: `org_id String DEFAULT 'default'` (migration 024).
- AI / work-graph tables: `org_id UUID` — `ai_attribution` + the `ai_attribution_resolved` view (migrations 035/043/044) and `ai_workgraph` tables (037).

`OrgScopedQuery.filter()/expression()` always emitted `<col> = {org_id:String}`. For a `UUID` column ClickHouse implicitly casts the String constant to UUID; a real UUID casts fine, but the single-tenant sentinel `'default'` is not a valid UUID and crashes.

Crash path: `workers/metrics_partitioned.py::run_daily_metrics_batch` (org_id='default') → `metrics/job_daily.py::run_daily_metrics_job` → `metrics/loaders/ai_impact.py::load_ai_pr_attributions` (joins `ai_attribution_resolved`).

## Fix
- Add `filter_uuid()` / `expression_uuid()` to `OrgScopedQuery` (`metrics/query_builder.py`) emitting `toString(<col>) = {org_id:String}` — cast the UUID **column** to String (always valid) instead of the constant to UUID. Same param binding (`org_id` String), so `inject()` callers are unchanged. This mirrors the pre-existing precedent in `ai_detector._detect_title_pattern_toil`.
- Switch the `ai_attribution_resolved` (`attr`) org-filter call sites to the UUID-safe variants:
  - `metrics/loaders/ai_impact.py` (`load_ai_pr_attributions`, reviewer-concentration, `_pr_attribution_subquery`)
  - `metrics/opportunities/ai_detector.py` (`_detect_repetitive_changes`)
- String-table call sites (`pr`, `link`, `umd`, `c`, etc.) are intentionally unchanged.

## Tests
- +12 unit tests in `tests/metrics/test_query_builder.py` (exact SQL output, empty-org, invalid-alias `ValueError`, regression guard that `toString(attr.org_id)` is present and the bare form absent). **37 passed.**
- `ruff` clean, `mypy` clean.

## Schema
No model or migration changes. Query-string only.

Closes CHAOS-2537