### PR TITLE
feat(llm): LMStudio key override + optional model-validation ping (CHAOS-2540)

### DIFF
--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -20,7 +20,7 @@ _API_KEY_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
     "qwen": ("LLM_API_KEY", "QWEN_API_KEY", "DASHSCOPE_API_KEY"),
     "local": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
     "ollama": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
-    "lmstudio": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
+    "lmstudio": ("LLM_API_KEY", "LMSTUDIO_API_KEY", "LOCAL_LLM_API_KEY"),
     "qwen-local": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
     "qwen-lmstudio": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
 }

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -20,7 +20,7 @@ _API_KEY_ENV_BY_PROVIDER: dict[str, tuple[str, ...]] = {
     "qwen": ("LLM_API_KEY", "QWEN_API_KEY", "DASHSCOPE_API_KEY"),
     "local": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
     "ollama": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
-    "lmstudio": ("LLM_API_KEY", "LMSTUDIO_API_KEY", "LOCAL_LLM_API_KEY"),
+    "lmstudio": ("LMSTUDIO_API_KEY", "LLM_API_KEY", "LOCAL_LLM_API_KEY"),
     "qwen-local": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
     "qwen-lmstudio": ("LLM_API_KEY", "LOCAL_LLM_API_KEY"),
 }

--- a/src/dev_health_ops/llm/providers/__init__.py
+++ b/src/dev_health_ops/llm/providers/__init__.py
@@ -52,6 +52,27 @@ def _normalize_provider_name(name: str) -> str:
     return (name or "auto").strip().lower()
 
 
+def _env_flag(name: str, *, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _optional_env_flag(name: str) -> bool | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _lmstudio_validate_model_on_startup() -> bool:
+    provider_flag = _optional_env_flag("LMSTUDIO_VALIDATE_MODEL_ON_STARTUP")
+    if provider_flag is not None:
+        return provider_flag
+    return _env_flag("LLM_VALIDATE_MODEL_ON_STARTUP")
+
+
 def _configured_provider(*, org_id: str | None = None) -> str | None:
     if os.getenv("OPENAI_API_KEY"):
         return "openai"
@@ -276,7 +297,10 @@ def get_provider(
             from .local import LMStudioGPT5Provider
 
             return LMStudioGPT5Provider(
-                base_url=credentials.base_url or None, model=model_name
+                api_key=credentials.api_key or None,
+                base_url=credentials.base_url or None,
+                model=model_name,
+                validate_model_on_startup=_lmstudio_validate_model_on_startup(),
             )
 
         from .local import LMStudioProvider

--- a/src/dev_health_ops/llm/providers/local.py
+++ b/src/dev_health_ops/llm/providers/local.py
@@ -302,7 +302,7 @@ class LMStudioGPT5Provider(OpenAIGPT5Provider):
             "LMSTUDIO_BASE_URL", DEFAULT_ENDPOINTS["lmstudio"]
         )
         api_key = api_key or _first_env(
-            ("LLM_API_KEY", "LMSTUDIO_API_KEY", "LOCAL_LLM_API_KEY")
+            ("LMSTUDIO_API_KEY", "LLM_API_KEY", "LOCAL_LLM_API_KEY")
         )
         should_validate_model = (
             _lmstudio_validate_model_on_startup()

--- a/src/dev_health_ops/llm/providers/local.py
+++ b/src/dev_health_ops/llm/providers/local.py
@@ -62,6 +62,35 @@ def _error_metadata(exc: BaseException) -> dict[str, str | int | None]:
     return {"type": type(exc).__name__, "status_code": _status_code(exc)}
 
 
+def _first_env(names: tuple[str, ...]) -> str:
+    for name in names:
+        value = os.getenv(name)
+        if value:
+            return value
+    return ""
+
+
+def _env_flag(name: str, *, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _optional_env_flag(name: str) -> bool | None:
+    value = os.getenv(name)
+    if value is None:
+        return None
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _lmstudio_validate_model_on_startup() -> bool:
+    provider_flag = _optional_env_flag("LMSTUDIO_VALIDATE_MODEL_ON_STARTUP")
+    if provider_flag is not None:
+        return provider_flag
+    return _env_flag("LLM_VALIDATE_MODEL_ON_STARTUP")
+
+
 class LocalProvider(LLMProviderBase):
     """
     OpenAI-compatible provider for local LLM servers.
@@ -264,18 +293,29 @@ class LMStudioGPT5Provider(OpenAIGPT5Provider):
         self,
         model: str,
         base_url: str | None = None,
+        api_key: str | None = None,
         max_completion_tokens: int = 4096,
         temperature: float = 0.3,
+        validate_model_on_startup: bool | None = None,
     ) -> None:
         base_url = base_url or os.getenv(
             "LMSTUDIO_BASE_URL", DEFAULT_ENDPOINTS["lmstudio"]
         )
-        # Use dummy API key for local
+        api_key = api_key or _first_env(
+            ("LLM_API_KEY", "LMSTUDIO_API_KEY", "LOCAL_LLM_API_KEY")
+        )
+        should_validate_model = (
+            _lmstudio_validate_model_on_startup()
+            if validate_model_on_startup is None
+            else validate_model_on_startup
+        )
         cfg = OpenAIProviderConfig(
-            api_key="lm-studio",
+            api_key=api_key or "lm-studio",
             base_url=base_url,
             model=model,
             max_output_tokens=max_completion_tokens,
             temperature=temperature,
+            validate_model_on_startup=should_validate_model,
+            validation_provider_name="lmstudio",
         )
         super().__init__(cfg)

--- a/src/dev_health_ops/llm/providers/openai.py
+++ b/src/dev_health_ops/llm/providers/openai.py
@@ -133,6 +133,8 @@ class OpenAIProviderConfig:
     model: str
     max_output_tokens: int
     temperature: float
+    validate_model_on_startup: bool = False
+    validation_provider_name: str = "openai"
 
 
 class OpenAIProvider(LLMProviderBase):
@@ -187,6 +189,8 @@ class _OpenAIProviderBase(LLMProviderBase):
     def __init__(self, cfg: OpenAIProviderConfig) -> None:
         self.cfg = cfg
         self._client: Any | None = None
+        if cfg.validate_model_on_startup:
+            self._validate_model_on_startup()
 
     def _get_client(self) -> Any:
         if self._client is None:
@@ -198,6 +202,28 @@ class _OpenAIProviderBase(LLMProviderBase):
                 max_retries=0,
             )
         return self._client
+
+    def _validate_model_on_startup(self) -> None:
+        from openai import OpenAI
+
+        client = OpenAI(
+            api_key=self.cfg.api_key,
+            base_url=self.cfg.base_url,
+            max_retries=0,
+        )
+        try:
+            client.models.list()
+        except Exception as exc:
+            raise RuntimeError(
+                f"LLM startup model validation failed for provider "
+                f"'{self.cfg.validation_provider_name}' model '{self.cfg.model}'. "
+                "Check that the provider is reachable, the base URL points to an "
+                "OpenAI-compatible /v1 endpoint, and the configured model is loaded. "
+                "Disable the startup ping with LLM_VALIDATE_MODEL_ON_STARTUP=false "
+                "or LMSTUDIO_VALIDATE_MODEL_ON_STARTUP=false."
+            ) from exc
+        finally:
+            client.close()
 
     def _supports_temperature(self) -> bool:
         # GPT-5 ignores temperature; keep for legacy and future overrides.

--- a/src/dev_health_ops/llm/providers/openai.py
+++ b/src/dev_health_ops/llm/providers/openai.py
@@ -214,14 +214,21 @@ class _OpenAIProviderBase(LLMProviderBase):
         try:
             client.models.list()
         except Exception as exc:
-            raise RuntimeError(
-                f"LLM startup model validation failed for provider "
-                f"'{self.cfg.validation_provider_name}' model '{self.cfg.model}'. "
-                "Check that the provider is reachable, the base URL points to an "
-                "OpenAI-compatible /v1 endpoint, and the configured model is loaded. "
-                "Disable the startup ping with LLM_VALIDATE_MODEL_ON_STARTUP=false "
-                "or LMSTUDIO_VALIDATE_MODEL_ON_STARTUP=false."
-            ) from exc
+            llm_exc = classify_provider_error(
+                exc,
+                provider=self.cfg.validation_provider_name,
+                model=self.cfg.model,
+            )
+            logger.error(
+                "LLM startup model validation failed for provider '%s' model '%s'. "
+                "Check provider reachability, base URL, credentials, and loaded model. "
+                "Disable with LLM_VALIDATE_MODEL_ON_STARTUP=false or "
+                "LMSTUDIO_VALIDATE_MODEL_ON_STARTUP=false: %s",
+                self.cfg.validation_provider_name,
+                self.cfg.model,
+                llm_exc,
+            )
+            raise llm_exc from exc
         finally:
             client.close()
 

--- a/tests/test_llm_provider_factory.py
+++ b/tests/test_llm_provider_factory.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 
 import dev_health_ops.llm.providers as provider_factory
-from dev_health_ops.llm import LLMAuthError, get_provider, is_llm_available
+from dev_health_ops.llm import LLMAuthError, LLMError, get_provider, is_llm_available
 from dev_health_ops.llm.providers.local import LMStudioGPT5Provider, LocalProvider
 from dev_health_ops.llm.providers.mock import MockProvider
 from dev_health_ops.llm.providers.none import NoneProvider
@@ -153,24 +153,39 @@ def test_lmstudio_gpt5_validation_flag_on_passes_when_reachable():
     mock_client.close.assert_called_once_with()
 
 
-def test_lmstudio_gpt5_validation_flag_on_unreachable_fails_fast():
+def test_lmstudio_gpt5_validation_auth_failure_raises_classified_llm_error():
     with patch("openai.OpenAI") as mock_openai_class:
         mock_client = mock_openai_class.return_value
-        mock_client.models.list.side_effect = RuntimeError("connection refused")
+        mock_client.models.list.side_effect = RuntimeError("401 unauthorized")
 
-        with pytest.raises(
-            RuntimeError, match="startup model validation failed"
-        ) as exc:
+        with pytest.raises(LLMAuthError) as exc:
             LMStudioGPT5Provider(
                 model="openai/gpt-oss-20b",
                 api_key="sk-inline-lmstudio",
                 validate_model_on_startup=True,
             )
 
-    message = str(exc.value)
-    assert "provider 'lmstudio'" in message
-    assert "OpenAI-compatible /v1 endpoint" in message
-    assert "LMSTUDIO_VALIDATE_MODEL_ON_STARTUP=false" in message
+    assert not isinstance(exc.value, RuntimeError)
+    assert exc.value.provider == "lmstudio"
+    assert exc.value.model == "openai/gpt-oss-20b"
+    mock_client.close.assert_called_once_with()
+
+
+def test_lmstudio_gpt5_validation_connection_failure_raises_classified_llm_error():
+    with patch("openai.OpenAI") as mock_openai_class:
+        mock_client = mock_openai_class.return_value
+        mock_client.models.list.side_effect = RuntimeError("connection error")
+
+        with pytest.raises(LLMError) as exc:
+            LMStudioGPT5Provider(
+                model="openai/gpt-oss-20b",
+                api_key="sk-inline-lmstudio",
+                validate_model_on_startup=True,
+            )
+
+    assert not isinstance(exc.value, RuntimeError)
+    assert exc.value.provider == "lmstudio"
+    assert exc.value.model == "openai/gpt-oss-20b"
     mock_client.close.assert_called_once_with()
 
 

--- a/tests/test_llm_provider_factory.py
+++ b/tests/test_llm_provider_factory.py
@@ -91,12 +91,27 @@ def test_lmstudio_gpt5_accepts_inline_credentials_over_default():
 def test_lmstudio_gpt5_uses_lmstudio_api_key_env_before_default():
     with patch.dict(
         os.environ,
-        {"LMSTUDIO_API_KEY": "sk-env-lmstudio"},
+        {
+            "LLM_PROVIDER": "lmstudio",
+            "LLM_API_KEY": "sk-global",
+            "LMSTUDIO_API_KEY": "sk-env-lmstudio",
+        },
         clear=True,
     ):
-        provider = get_provider("lmstudio", model="openai/gpt-oss-20b")
+        provider = get_provider("auto", model="openai/gpt-oss-20b")
 
     assert isinstance(provider, LMStudioGPT5Provider)
+    assert provider.cfg.api_key == "sk-env-lmstudio"
+
+
+def test_lmstudio_gpt5_direct_constructor_prefers_lmstudio_api_key_env():
+    with patch.dict(
+        os.environ,
+        {"LLM_API_KEY": "sk-global", "LMSTUDIO_API_KEY": "sk-env-lmstudio"},
+        clear=True,
+    ):
+        provider = LMStudioGPT5Provider(model="openai/gpt-oss-20b")
+
     assert provider.cfg.api_key == "sk-env-lmstudio"
 
 

--- a/tests/test_llm_provider_factory.py
+++ b/tests/test_llm_provider_factory.py
@@ -9,7 +9,7 @@ import pytest
 
 import dev_health_ops.llm.providers as provider_factory
 from dev_health_ops.llm import LLMAuthError, get_provider, is_llm_available
-from dev_health_ops.llm.providers.local import LocalProvider
+from dev_health_ops.llm.providers.local import LMStudioGPT5Provider, LocalProvider
 from dev_health_ops.llm.providers.mock import MockProvider
 from dev_health_ops.llm.providers.none import NoneProvider
 from dev_health_ops.llm.providers.openai import OpenAIProvider
@@ -72,6 +72,91 @@ def test_generic_llm_env_credentials_are_available_for_explicit_provider():
     assert isinstance(provider, OpenAIProvider)
     assert provider._impl.cfg.api_key == "sk-generic"
     assert provider._impl.cfg.base_url == "https://generic.invalid/v1"
+
+
+def test_lmstudio_gpt5_accepts_inline_credentials_over_default():
+    with patch.dict(os.environ, {}, clear=True):
+        provider = get_provider(
+            "lmstudio",
+            model="openai/gpt-oss-20b",
+            api_key="sk-inline-lmstudio",
+            base_url="http://inline-lmstudio.invalid/v1",
+        )
+
+    assert isinstance(provider, LMStudioGPT5Provider)
+    assert provider.cfg.api_key == "sk-inline-lmstudio"
+    assert provider.cfg.base_url == "http://inline-lmstudio.invalid/v1"
+
+
+def test_lmstudio_gpt5_uses_lmstudio_api_key_env_before_default():
+    with patch.dict(
+        os.environ,
+        {"LMSTUDIO_API_KEY": "sk-env-lmstudio"},
+        clear=True,
+    ):
+        provider = get_provider("lmstudio", model="openai/gpt-oss-20b")
+
+    assert isinstance(provider, LMStudioGPT5Provider)
+    assert provider.cfg.api_key == "sk-env-lmstudio"
+
+
+def test_lmstudio_gpt5_falls_back_to_dummy_key_when_unset():
+    with patch.dict(os.environ, {}, clear=True):
+        provider = get_provider("lmstudio", model="openai/gpt-oss-20b")
+
+    assert isinstance(provider, LMStudioGPT5Provider)
+    assert provider.cfg.api_key == "lm-studio"
+
+
+def test_lmstudio_gpt5_validation_flag_off_skips_models_list():
+    with patch("openai.OpenAI") as mock_openai_class:
+        LMStudioGPT5Provider(
+            model="openai/gpt-oss-20b",
+            api_key="sk-inline-lmstudio",
+            validate_model_on_startup=False,
+        )
+
+    mock_openai_class.assert_not_called()
+
+
+def test_lmstudio_gpt5_validation_flag_on_passes_when_reachable():
+    with patch("openai.OpenAI") as mock_openai_class:
+        mock_client = mock_openai_class.return_value
+        provider = LMStudioGPT5Provider(
+            model="openai/gpt-oss-20b",
+            api_key="sk-inline-lmstudio",
+            validate_model_on_startup=True,
+        )
+
+    assert provider.cfg.validate_model_on_startup is True
+    mock_openai_class.assert_called_once_with(
+        api_key="sk-inline-lmstudio",
+        base_url="http://localhost:1234/v1",
+        max_retries=0,
+    )
+    mock_client.models.list.assert_called_once_with()
+    mock_client.close.assert_called_once_with()
+
+
+def test_lmstudio_gpt5_validation_flag_on_unreachable_fails_fast():
+    with patch("openai.OpenAI") as mock_openai_class:
+        mock_client = mock_openai_class.return_value
+        mock_client.models.list.side_effect = RuntimeError("connection refused")
+
+        with pytest.raises(
+            RuntimeError, match="startup model validation failed"
+        ) as exc:
+            LMStudioGPT5Provider(
+                model="openai/gpt-oss-20b",
+                api_key="sk-inline-lmstudio",
+                validate_model_on_startup=True,
+            )
+
+    message = str(exc.value)
+    assert "provider 'lmstudio'" in message
+    assert "OpenAI-compatible /v1 endpoint" in message
+    assert "LMSTUDIO_VALIDATE_MODEL_ON_STARTUP=false" in message
+    mock_client.close.assert_called_once_with()
 
 
 def test_provider_specific_model_env_overrides_global_model():


### PR DESCRIPTION
## Summary
- Resolve LMStudio GPT-OSS API keys from per-call credentials or env before falling back to `lm-studio`.
- Add opt-in startup `models.list` validation for OpenAI-compatible providers via existing provider config.
- Cover key resolution and validation ping success/failure behavior in provider factory tests.

## Verification
- `CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/test_llm_provider_factory.py tests/test_openai_provider_routing.py -q`
- `uv run --extra dev --python 3.11 mypy src/dev_health_ops/llm/providers/local.py src/dev_health_ops/llm/providers/__init__.py`
- `uv run --extra dev --python 3.11 ruff check src/dev_health_ops/llm`

SCREENSHOT-WAIVER: backend/provider behavior only; no rendered UI changes.

Closes CHAOS-2540