### PR TITLE
fix(work-graph): require non-empty org for investment materialize (CHAOS-2538)

### DIFF
--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -266,6 +266,7 @@ class MaterializeConfig:
     run_id: str | None = None
     computed_at: datetime | None = None
     component_indexes: list[int] | None = None
+    allow_unscoped: bool = False
 
 
 def _build_components(
@@ -501,6 +502,16 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
         resolved_llm_provider = resolve_provider_name(
             config.llm_provider, org_id=config.org_id or None
         )
+        if (
+            not (config.org_id or "").strip()
+            and resolved_llm_provider not in {"mock", "none"}
+            and not config.allow_unscoped
+        ):
+            raise ValueError(
+                "Investment materialize requires a non-empty org for real LLM "
+                "providers. Pass --org <org_id> or --allow-unscoped to write "
+                "empty-org rows intentionally."
+            )
         provider_instance = get_provider(
             resolved_llm_provider,
             org_id=config.org_id or None,

--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -232,6 +232,7 @@ def run_investment_materialization(ns: argparse.Namespace) -> int:
         team_ids=team_ids or None,
         force=getattr(ns, "force", False),
         org_id=org_id,
+        allow_unscoped=getattr(ns, "allow_unscoped", False),
     )
 
     # CHAOS-2433 round-4 finding #1: the materializer writes work_unit_investments
@@ -457,5 +458,10 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
     )
     investment_materialize.add_argument(
         "--force", action="store_true", help="Force re-materialization."
+    )
+    investment_materialize.add_argument(
+        "--allow-unscoped",
+        action="store_true",
+        help="Allow real LLM materialization without --org, writing empty-org rows.",
     )
     investment_materialize.set_defaults(func=run_investment_materialization)

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -493,31 +493,34 @@ def dispatch_investment_materialize_partitioned(
     run_id = uuid.uuid4().hex
     computed_at = datetime.now(timezone.utc).isoformat()
 
-    header = [
-        celery_app.signature(
-            "dev_health_ops.workers.tasks.run_investment_materialize_chunk",
-            kwargs={
-                "db_url": db_url,
-                "from_date": from_date,
-                "to_date": to_date,
-                "window_days": window_days,
-                "repo_ids": repo_ids,
-                "team_ids": team_ids,
-                "llm_provider": llm_provider,
-                "llm_model": llm_model,
-                "llm_concurrency": llm_concurrency,
-                "force": force,
-                "org_id": org_id,
-                "allow_unscoped": allow_unscoped,
-                "run_id": run_id,
-                "computed_at": computed_at,
-                "component_indexes": chunk_indexes,
-                "chunk_index": chunk_index,
-            },
-            queue="metrics",
+    header = []
+    for chunk_index, chunk_indexes in enumerate(chunks):
+        chunk_kwargs = {
+            "db_url": db_url,
+            "from_date": from_date,
+            "to_date": to_date,
+            "window_days": window_days,
+            "repo_ids": repo_ids,
+            "team_ids": team_ids,
+            "llm_provider": llm_provider,
+            "llm_model": llm_model,
+            "llm_concurrency": llm_concurrency,
+            "force": force,
+            "org_id": org_id,
+            "run_id": run_id,
+            "computed_at": computed_at,
+            "component_indexes": chunk_indexes,
+            "chunk_index": chunk_index,
+        }
+        if allow_unscoped:
+            chunk_kwargs["allow_unscoped"] = True
+        header.append(
+            celery_app.signature(
+                "dev_health_ops.workers.tasks.run_investment_materialize_chunk",
+                kwargs=chunk_kwargs,
+                queue="metrics",
+            )
         )
-        for chunk_index, chunk_indexes in enumerate(chunks)
-    ]
     callback = celery_app.signature(
         "dev_health_ops.workers.tasks.finalize_investment_materialize_partitioned",
         kwargs={

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -169,6 +169,7 @@ def run_investment_materialize(
     llm_concurrency: int | None = None,
     force: bool = False,
     org_id: str = "",
+    allow_unscoped: bool = False,
 ) -> dict:
     """Materialize investment distributions from work graph.
 
@@ -184,6 +185,7 @@ def run_investment_materialize(
         llm_concurrency: Maximum concurrent LLM categorizations
         force: Force recomputation even if cached
         org_id: Organization scope for work-graph/investment queries
+        allow_unscoped: Allow real LLM materialization without an org scope
 
     Returns:
         dict with materialization status and stats
@@ -230,6 +232,7 @@ def run_investment_materialize(
             team_ids=team_ids,
             force=force,
             org_id=org_id or None,
+            allow_unscoped=allow_unscoped,
         )
         stats = run_async(materialize_investments(config))
         return {"status": "success", "stats": stats}
@@ -265,6 +268,7 @@ def run_investment_materialize_chunk(
     llm_concurrency: int | None = None,
     force: bool = False,
     org_id: str = "",
+    allow_unscoped: bool = False,
     run_id: str = "",
     computed_at: str = "",
     component_indexes: list[int] | None = None,
@@ -341,6 +345,7 @@ def run_investment_materialize_chunk(
             team_ids=team_ids,
             force=force,
             org_id=org_id or None,
+            allow_unscoped=allow_unscoped,
             run_id=run_id,
             computed_at=shared_computed_at,
             component_indexes=component_indexes,
@@ -452,6 +457,7 @@ def dispatch_investment_materialize_partitioned(
     llm_concurrency: int | None = None,
     force: bool = False,
     org_id: str = "",
+    allow_unscoped: bool = False,
     chunk_size: int | None = None,
 ) -> dict:
     from dev_health_ops.metrics.sinks.factory import create_sink
@@ -502,6 +508,7 @@ def dispatch_investment_materialize_partitioned(
                 "llm_concurrency": llm_concurrency,
                 "force": force,
                 "org_id": org_id,
+                "allow_unscoped": allow_unscoped,
                 "run_id": run_id,
                 "computed_at": computed_at,
                 "component_indexes": chunk_indexes,

--- a/tests/test_investment_materialize_partitioned.py
+++ b/tests/test_investment_materialize_partitioned.py
@@ -67,6 +67,8 @@ def test_dispatch_partitioned_materialize_chunks_components_with_shared_run() ->
     second_kwargs = header[1].sig_kwargs["kwargs"]
     assert first_kwargs["component_indexes"] == [0, 1]
     assert second_kwargs["component_indexes"] == [2]
+    assert "allow_unscoped" not in first_kwargs
+    assert "allow_unscoped" not in second_kwargs
     assert first_kwargs["run_id"] == second_kwargs["run_id"] == result["run_id"]
     assert first_kwargs["computed_at"] == second_kwargs["computed_at"]
     assert callback.task_name == (
@@ -75,6 +77,36 @@ def test_dispatch_partitioned_materialize_chunks_components_with_shared_run() ->
     assert callback.sig_kwargs["kwargs"]["run_membership_backfill_after"] is True
     chord_instance.apply_async.assert_called_once_with()
     assert mock_signature.call_count == 3
+
+
+def test_dispatch_partitioned_materialize_includes_allow_unscoped_when_true() -> None:
+    with (
+        patch(
+            "dev_health_ops.metrics.sinks.factory.create_sink",
+            return_value=_FakeSink(),
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.queries.fetch_work_graph_edges",
+            return_value=[_edge(1)],
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks.celery_app.signature",
+            side_effect=_signature_factory,
+        ),
+        patch("dev_health_ops.workers.work_graph_tasks.chord") as mock_chord,
+    ):
+        mock_chord.return_value = MagicMock()
+        task = cast(Any, dispatch_investment_materialize_partitioned)
+        task.run(
+            db_url="clickhouse://x",
+            org_id="",
+            chunk_size=2,
+            allow_unscoped=True,
+        )
+
+    header = mock_chord.call_args.args[0]
+    chunk_kwargs = header[0].sig_kwargs["kwargs"]
+    assert chunk_kwargs["allow_unscoped"] is True
 
 
 def test_dispatch_partitioned_materialize_skips_marker_for_windowed_run() -> None:

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -141,6 +141,127 @@ def _patch_queries(monkeypatch, edges, work_items, commits):
     )
 
 
+async def _ok_categorize(bundle, llm_provider, llm_model=None, provider=None):
+    return CategorizationOutcome(
+        subcategories={"feature_delivery.roadmap": 1.0},
+        evidence_quotes=[],
+        uncertainty="Limited evidence.",
+        status="ok",
+        errors=[],
+    )
+
+
+def _patch_successful_materialize(monkeypatch, sink, edges, work_items, commits):
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.get_provider",
+        lambda *args, **kwargs: FakeProvider(),
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _ok_categorize,
+    )
+
+
+@pytest.mark.asyncio
+async def test_materialize_requires_org_for_real_provider(monkeypatch):
+    sink = FakeSink()
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    now = datetime.now(timezone.utc)
+
+    with pytest.raises(ValueError, match=r"--org.*--allow-unscoped"):
+        await materialize_investments(
+            MaterializeConfig(
+                dsn="clickhouse://localhost:8123/default",
+                from_ts=now - timedelta(days=5),
+                to_ts=now,
+                repo_ids=None,
+                llm_provider="openai",
+                persist_evidence_snippets=False,
+                llm_model="test-model",
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_materialize_allow_unscoped_permits_empty_org_real_provider(monkeypatch):
+    repo_id, edges, work_items, commits = _sample_data()
+    work_items[0]["description"] = "Resolve authentication failures. " * 20
+    sink = FakeSink()
+    _patch_successful_materialize(monkeypatch, sink, edges, work_items, commits)
+    now = datetime.now(timezone.utc)
+
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=[repo_id],
+            llm_provider="openai",
+            persist_evidence_snippets=False,
+            llm_model="test-model",
+            allow_unscoped=True,
+        )
+    )
+
+    assert stats["records"] == 1
+    assert sink.investment_rows[0].org_id == ""
+
+
+@pytest.mark.asyncio
+async def test_materialize_mock_provider_permits_empty_org(monkeypatch):
+    repo_id, edges, work_items, commits = _sample_data()
+    work_items[0]["description"] = "Resolve authentication failures. " * 20
+    sink = FakeSink()
+    _patch_successful_materialize(monkeypatch, sink, edges, work_items, commits)
+    now = datetime.now(timezone.utc)
+
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=[repo_id],
+            llm_provider="mock",
+            persist_evidence_snippets=False,
+            llm_model="test-model",
+        )
+    )
+
+    assert stats["records"] == 1
+    assert sink.investment_rows[0].org_id == ""
+
+
+@pytest.mark.asyncio
+async def test_materialize_real_provider_with_org_unaffected(monkeypatch):
+    repo_id, edges, work_items, commits = _sample_data()
+    work_items[0]["description"] = "Resolve authentication failures. " * 20
+    sink = FakeSink()
+    _patch_successful_materialize(monkeypatch, sink, edges, work_items, commits)
+    now = datetime.now(timezone.utc)
+
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=[repo_id],
+            llm_provider="openai",
+            persist_evidence_snippets=False,
+            llm_model="test-model",
+            org_id="org-123",
+        )
+    )
+
+    assert stats["records"] == 1
+    assert sink.investment_rows[0].org_id == "org-123"
+
+
 @pytest.mark.asyncio
 async def test_materialize_invokes_sink(monkeypatch):
     repo_id, edges, work_items, commits = _sample_data()
@@ -496,6 +617,7 @@ async def test_materialize_passes_configured_llm_credentials(monkeypatch):
         llm_model="gpt-4o-mini",
         llm_api_key="sk-inline-secret",
         llm_base_url="https://inline.invalid/v1",
+        allow_unscoped=True,
     )
 
     stats = await materialize_investments(config)

--- a/tests/work_graph/test_runner.py
+++ b/tests/work_graph/test_runner.py
@@ -133,6 +133,7 @@ def _materialize_ns(**overrides) -> argparse.Namespace:
         llm_base_url=None,
         llm_concurrency=None,
         force=False,
+        allow_unscoped=False,
     )
     base.update(overrides)
     return argparse.Namespace(**base)
@@ -268,6 +269,33 @@ def test_cli_materialize_threads_inline_llm_credentials_and_concurrency():
     assert config.llm_base_url == "https://inline.invalid/v1"
     assert config.llm_concurrency == 1
     assert "sk-inline-secret" not in repr(config)
+    backfill_mock.assert_not_called()
+
+
+def test_cli_materialize_threads_allow_unscoped():
+    fake_materialize, materialize_mock, backfill_mock = (
+        _patch_materialize_and_projection()
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.runner.materialize_investments",
+            fake_materialize,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.backfill_memberships",
+            backfill_mock,
+        ),
+    ):
+        rc = run_investment_materialization(
+            _materialize_ns(org=None, allow_unscoped=True, repo_id=["repo-uuid-1"])
+        )
+
+    assert rc == 0
+    materialize_mock.assert_called_once()
+    config = materialize_mock.call_args.args[0]
+    assert config.org_id is None
+    assert config.allow_unscoped is True
     backfill_mock.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- Require non-empty --org for real investment materialize runs unless --allow-unscoped is explicit
- Keep mock provider empty-org materialization allowed for tests/fixtures
- Thread allow_unscoped through CLI runner and Celery materialize paths

## Verification
- CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/work_graph/test_investment_materialize.py tests/work_graph/test_runner.py -q
- uv run --extra dev --python 3.11 mypy src/dev_health_ops/work_graph/investment/materialize.py src/dev_health_ops/work_graph/runner.py src/dev_health_ops/workers/work_graph_tasks.py src/dev_health_ops/cli.py
- uv run --extra dev --python 3.11 ruff check src/dev_health_ops/work_graph src/dev_health_ops/cli.py

SCREENSHOT-WAIVER: backend/CLI behavior only; no rendered frontend output changed.

Closes CHAOS-2538