### PR TITLE
feat(llm): retry parity for gemini/qwen + adaptive concurrency (CHAOS-2539)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/settings.py
+++ b/src/dev_health_ops/api/admin/routers/settings.py
@@ -119,7 +119,11 @@ async def list_settings_by_category(
     )
 
 
-@router.get("/llm-settings", response_model=LLMSettingsResponse)
+@router.get(
+    "/llm-settings",
+    response_model=LLMSettingsResponse,
+    response_model_exclude_none=True,
+)
 async def get_llm_settings(
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
@@ -129,7 +133,11 @@ async def get_llm_settings(
     return await _llm_settings_response(svc)
 
 
-@router.put("/llm-settings", response_model=LLMSettingsResponse)
+@router.put(
+    "/llm-settings",
+    response_model=LLMSettingsResponse,
+    response_model_exclude_none=True,
+)
 async def upsert_llm_settings(
     payload: LLMSettingsUpsert,
     session: AsyncSession = Depends(get_session),

--- a/src/dev_health_ops/api/admin/routers/settings.py
+++ b/src/dev_health_ops/api/admin/routers/settings.py
@@ -24,7 +24,7 @@ from dev_health_ops.models.settings import SettingCategory
 from .common import get_session
 
 router = APIRouter()
-_LLM_SETTING_KEYS = ("provider", "model", "api_key", "base_url")
+_LLM_SETTING_KEYS = ("provider", "model", "api_key", "base_url", "concurrency")
 _BYO_LLM_MIN_TIER = LicenseTier.TEAM
 
 
@@ -89,11 +89,13 @@ async def _llm_settings_response(svc: SettingsService) -> LLMSettingsResponse:
     model = await svc.get("model", SettingCategory.LLM.value)
     api_key = await svc.get("api_key", SettingCategory.LLM.value)
     base_url = await svc.get("base_url", SettingCategory.LLM.value)
+    concurrency = await svc.get("concurrency", SettingCategory.LLM.value)
     return LLMSettingsResponse(
         provider=provider,
         model=model,
         api_key=_mask_api_key(api_key),
         base_url=base_url,
+        concurrency=int(concurrency) if concurrency else None,
     )
 
 
@@ -161,6 +163,13 @@ async def upsert_llm_settings(
         SettingCategory.LLM.value,
         description="BYO LLM base URL for this organization",
     )
+    if payload.concurrency is not None:
+        await svc.set(
+            "concurrency",
+            str(payload.concurrency),
+            SettingCategory.LLM.value,
+            description="BYO LLM maximum concurrent categorizations for this organization",
+        )
     return await _llm_settings_response(svc)
 
 

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -48,7 +48,7 @@ class LLMSettingsUpsert(BaseModel):
     model: str | None = None
     api_key: str | None = None
     base_url: str | None = None
-    concurrency: int | None = Field(default=None, ge=1)
+    concurrency: int | None = Field(default=None, ge=1, le=32)
 
 
 class IntegrationCredentialResponse(BaseModel):

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -40,6 +40,7 @@ class LLMSettingsResponse(BaseModel):
     model: str | None = None
     api_key: str | None = None
     base_url: str | None = None
+    concurrency: int | None = None
 
 
 class LLMSettingsUpsert(BaseModel):
@@ -47,6 +48,7 @@ class LLMSettingsUpsert(BaseModel):
     model: str | None = None
     api_key: str | None = None
     base_url: str | None = None
+    concurrency: int | None = Field(default=None, ge=1)
 
 
 class IntegrationCredentialResponse(BaseModel):

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -42,6 +42,7 @@ _LLM_PROVIDER_KEY = "provider"
 _LLM_MODEL_KEY = "model"
 _LLM_API_KEY_KEY = "api_key"
 _LLM_BASE_URL_KEY = "base_url"
+_LLM_CONCURRENCY_KEY = "concurrency"
 
 
 def _first_env(names: tuple[str, ...]) -> str:
@@ -105,6 +106,16 @@ def resolve_llm_org_settings_model(provider: str, *, org_id: str | None = None) 
     if configured_provider and requested_provider not in {"auto", configured_provider}:
         return ""
     return settings.get(_LLM_MODEL_KEY, "")
+
+
+def resolve_llm_org_settings_concurrency(*, org_id: str | None = None) -> int | None:
+    raw = _load_org_llm_settings(org_id).get(_LLM_CONCURRENCY_KEY, "")
+    if not raw:
+        return None
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return None
 
 
 def resolve_llm_org_settings_credentials(

--- a/src/dev_health_ops/llm/providers/gemini.py
+++ b/src/dev_health_ops/llm/providers/gemini.py
@@ -24,6 +24,8 @@ class GeminiProvider(LocalProvider):
     - GEMINI_BASE_URL: Optional endpoint override
     """
 
+    provider_name = "gemini"
+
     def __init__(
         self,
         api_key: str | None = None,

--- a/src/dev_health_ops/llm/providers/local.py
+++ b/src/dev_health_ops/llm/providers/local.py
@@ -6,11 +6,17 @@ Supports Ollama, LMStudio, vLLM, and other OpenAI-compatible endpoints.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from urllib.parse import urlsplit, urlunsplit
 
-from dev_health_ops.llm.errors import classify_provider_error
+from dev_health_ops.llm.errors import (
+    LLMRateLimitError,
+    classify_provider_error,
+    is_retryable,
+    retry_delay,
+)
 
 from .base import (
     DEFAULT_MODEL_BY_PROVIDER,
@@ -78,6 +84,8 @@ class LocalProvider(LLMProviderBase):
     - LOCAL_LLM_API_KEY: API key if required (default: "not-needed")
     """
 
+    provider_name = "local"
+
     def __init__(
         self,
         base_url: str | None = None,
@@ -116,6 +124,7 @@ class LocalProvider(LLMProviderBase):
                 self._client = AsyncOpenAI(
                     api_key=self.api_key,
                     base_url=self.base_url,
+                    max_retries=0,
                 )
             except ImportError:
                 raise ImportError(
@@ -200,7 +209,24 @@ class LocalProvider(LLMProviderBase):
                     continue
 
                 model_name = self.model or "local-model"
-                llm_exc = classify_provider_error(e, provider="local", model=model_name)
+                llm_exc = classify_provider_error(
+                    e, provider=self.provider_name, model=model_name
+                )
+                if is_retryable(llm_exc) and retry_count < max_retries:
+                    delay = retry_delay(retry_count)
+                    if isinstance(llm_exc, LLMRateLimitError) and llm_exc.retry_after:
+                        delay = llm_exc.retry_after
+                    logger.warning(
+                        "%s LLM API transient error on attempt %d/%d; retrying in %.1fs: %s",
+                        self.provider_name,
+                        retry_count + 1,
+                        max_retries + 1,
+                        delay,
+                        llm_exc,
+                    )
+                    retry_count += 1
+                    await asyncio.sleep(delay)
+                    continue
                 logger.error(
                     "Local LLM API error url=%s error=%s classified=%s",
                     _redact_url(self.base_url or ""),

--- a/src/dev_health_ops/llm/providers/qwen.py
+++ b/src/dev_health_ops/llm/providers/qwen.py
@@ -31,6 +31,8 @@ class QwenProvider(LocalProvider):
     - DASHSCOPE_BASE_URL: Optional regional endpoint override
     """
 
+    provider_name = "qwen"
+
     def __init__(
         self,
         api_key: str | None = None,

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -66,6 +66,8 @@ from dev_health_ops.work_graph.investment.utils import (
 
 logger = logging.getLogger(__name__)
 
+_MAX_LLM_CONCURRENCY = 32
+
 NodeKey = tuple[str, str]
 
 
@@ -698,10 +700,20 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
 
         from dev_health_ops.llm.credentials import resolve_llm_org_settings_concurrency
 
-        configured_concurrency = (
+        requested_concurrency = (
             resolve_llm_org_settings_concurrency(org_id=config.org_id or None)
             or config.llm_concurrency
         )
+        configured_concurrency = min(
+            max(1, requested_concurrency), _MAX_LLM_CONCURRENCY
+        )
+        if configured_concurrency != requested_concurrency:
+            logger.warning(
+                "LLM concurrency %d exceeds maximum %d; clamping to %d",
+                requested_concurrency,
+                _MAX_LLM_CONCURRENCY,
+                configured_concurrency,
+            )
 
         class _AdaptiveLLMConcurrency:
             def __init__(self, limit: int) -> None:

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -696,13 +696,74 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
                     len(skipped_existing),
                 )
 
-        # Parallel LLM categorization with concurrency limit
-        semaphore = asyncio.Semaphore(config.llm_concurrency)
+        from dev_health_ops.llm.credentials import resolve_llm_org_settings_concurrency
+
+        configured_concurrency = (
+            resolve_llm_org_settings_concurrency(org_id=config.org_id or None)
+            or config.llm_concurrency
+        )
+
+        class _AdaptiveLLMConcurrency:
+            def __init__(self, limit: int) -> None:
+                self.base_limit = max(1, int(limit))
+                self.effective_limit = self.base_limit
+                self.active = 0
+                self.rate_limit_streak = 0
+                self.success_streak = 0
+                self.condition = asyncio.Condition()
+
+            async def acquire(self) -> None:
+                async with self.condition:
+                    while self.active >= self.effective_limit:
+                        await self.condition.wait()
+                    self.active += 1
+
+            async def release(self) -> None:
+                async with self.condition:
+                    self.active = max(0, self.active - 1)
+                    self.condition.notify_all()
+
+            async def record_success(self) -> None:
+                async with self.condition:
+                    self.rate_limit_streak = 0
+                    if self.effective_limit < self.base_limit:
+                        self.success_streak += 1
+                        if self.success_streak >= 2:
+                            self.effective_limit = min(
+                                self.base_limit, self.effective_limit + 1
+                            )
+                            self.success_streak = 0
+                            logger.info(
+                                "LLM adaptive concurrency recovered to %d/%d",
+                                self.effective_limit,
+                                self.base_limit,
+                            )
+                            self.condition.notify_all()
+
+            async def record_failure(self, failure_class: str) -> None:
+                async with self.condition:
+                    if failure_class == "rate_limit":
+                        self.rate_limit_streak += 1
+                        self.success_streak = 0
+                        if self.rate_limit_streak >= 2 and self.effective_limit > 1:
+                            self.effective_limit = max(1, self.effective_limit // 2)
+                            self.rate_limit_streak = 0
+                            logger.warning(
+                                "LLM adaptive concurrency reduced to %d/%d after sustained rate limits",
+                                self.effective_limit,
+                                self.base_limit,
+                            )
+                            self.condition.notify_all()
+                    else:
+                        self.rate_limit_streak = 0
+
+        adaptive_concurrency = _AdaptiveLLMConcurrency(configured_concurrency)
         llm_results: dict[int, Any] = {}
         llm_failure_counts: Counter[str] = Counter()
 
         async def categorize_with_limit(idx: int, bundle: Any) -> tuple[int, Any]:
-            async with semaphore:
+            await adaptive_concurrency.acquire()
+            try:
                 outcome = await categorize_text_bundle(
                     bundle,
                     llm_provider=resolved_llm_provider,
@@ -710,12 +771,14 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
                     provider=provider_instance,
                 )
                 return (idx, outcome)
+            finally:
+                await adaptive_concurrency.release()
 
         if pending_llm:
             logger.info(
                 "Starting parallel LLM categorization (%d tasks, concurrency=%d)",
                 len(pending_llm),
-                config.llm_concurrency,
+                configured_concurrency,
             )
             tasks = [
                 asyncio.create_task(categorize_with_limit(idx, bundle))
@@ -732,6 +795,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
                     )
                     failure_class = _llm_failure_class(classified)
                     llm_failure_counts[failure_class] += 1
+                    await adaptive_concurrency.record_failure(failure_class)
                     if _is_deterministic_llm_failure(classified):
                         for pending_task in tasks:
                             if not pending_task.done():
@@ -752,6 +816,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
                 if not isinstance(result, tuple) or len(result) != 2:
                     logger.warning("Unexpected LLM task result: %r", result)
                     continue
+                await adaptive_concurrency.record_success()
                 idx, outcome = result
                 llm_results[idx] = outcome
             logger.info(

--- a/tests/api/admin/test_llm_settings.py
+++ b/tests/api/admin/test_llm_settings.py
@@ -136,6 +136,21 @@ async def test_admin_llm_settings_encrypts_and_masks_api_key(session_maker):
 
 
 @pytest.mark.asyncio
+async def test_admin_llm_settings_rejects_excessive_concurrency(session_maker):
+    state = await _seed_org(session_maker, "team")
+    app = _make_app(session_maker, state)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.put(
+            "/api/v1/admin/llm-settings",
+            json={"provider": "openai", "concurrency": 33},
+        )
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_admin_llm_settings_requires_team_or_enterprise(session_maker):
     state = await _seed_org(session_maker, "community")
     app = _make_app(session_maker, state)

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -3,8 +3,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from dev_health_ops.llm import LLMRateLimitError
 from dev_health_ops.llm.providers import get_provider
 from dev_health_ops.llm.providers.gemini import DEFAULT_GEMINI_BASE_URL, GeminiProvider
+
+
+class _RateLimitError(Exception):
+    status_code = 429
+
+    def __init__(self, retry_after: str = "0.25") -> None:
+        super().__init__("429 too many requests")
+        self.headers = {"Retry-After": retry_after}
 
 
 def test_gemini_provider_registration():
@@ -66,8 +75,54 @@ async def test_gemini_provider_completion():
         assert response.input_tokens == 5
         assert response.output_tokens == 3
         mock_openai_class.assert_called_once_with(
-            api_key="sk-123", base_url=DEFAULT_GEMINI_BASE_URL
+            api_key="sk-123", base_url=DEFAULT_GEMINI_BASE_URL, max_retries=0
         )
         mock_client.chat.completions.create.assert_called_once()
         _, kwargs = mock_client.chat.completions.create.call_args
         assert kwargs["model"] == "gemini-3"
+
+
+@pytest.mark.asyncio
+async def test_gemini_retries_429_and_honors_retry_after():
+    with (
+        patch("openai.AsyncOpenAI") as mock_openai_class,
+        patch(
+            "dev_health_ops.llm.providers.local.asyncio.sleep", new_callable=AsyncMock
+        ) as sleep,
+    ):
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Gemini response"
+        mock_response.usage = None
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=[_RateLimitError("0.75"), mock_response]
+        )
+
+        response = await GeminiProvider(api_key="sk-123").complete("Hello")
+
+        assert response.text == "Gemini response"
+        assert mock_client.chat.completions.create.call_count == 2
+        sleep.assert_awaited_once_with(0.75)
+
+
+@pytest.mark.asyncio
+async def test_gemini_gives_up_after_max_retries():
+    with (
+        patch("openai.AsyncOpenAI") as mock_openai_class,
+        patch(
+            "dev_health_ops.llm.providers.local.asyncio.sleep", new_callable=AsyncMock
+        ),
+    ):
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=[_RateLimitError(), _RateLimitError()]
+        )
+
+        with pytest.raises(LLMRateLimitError):
+            await GeminiProvider(api_key="sk-123").complete("Hello")
+
+        assert mock_client.chat.completions.create.call_count == 2

--- a/tests/test_qwen_provider.py
+++ b/tests/test_qwen_provider.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from dev_health_ops.llm import LLMRateLimitError
 from dev_health_ops.llm.providers import get_provider
 from dev_health_ops.llm.providers.qwen import (
     DEFAULT_DASHSCOPE_BASE_URL,
@@ -10,6 +11,14 @@ from dev_health_ops.llm.providers.qwen import (
     QwenLocalProvider,
     QwenProvider,
 )
+
+
+class _RateLimitError(Exception):
+    status_code = 429
+
+    def __init__(self, retry_after: str = "0.25") -> None:
+        super().__init__("429 too many requests")
+        self.headers = {"Retry-After": retry_after}
 
 
 def test_qwen_provider_registration():
@@ -95,9 +104,55 @@ async def test_qwen_provider_completion():
         assert response.output_tokens == 4
         # Verify client was initialized with correct base_url
         mock_openai_class.assert_called_once_with(
-            api_key="sk-123", base_url=DEFAULT_DASHSCOPE_BASE_URL
+            api_key="sk-123", base_url=DEFAULT_DASHSCOPE_BASE_URL, max_retries=0
         )
         # Verify completion was called with correct model
         mock_client.chat.completions.create.assert_called_once()
         args, kwargs = mock_client.chat.completions.create.call_args
         assert kwargs["model"] == "qwen-plus"
+
+
+@pytest.mark.asyncio
+async def test_qwen_retries_429_and_honors_retry_after():
+    with (
+        patch("openai.AsyncOpenAI") as mock_openai_class,
+        patch(
+            "dev_health_ops.llm.providers.local.asyncio.sleep", new_callable=AsyncMock
+        ) as sleep,
+    ):
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Qwen response"
+        mock_response.usage = None
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=[_RateLimitError("0.5"), mock_response]
+        )
+
+        response = await QwenProvider(api_key="sk-123").complete("Hello")
+
+        assert response.text == "Qwen response"
+        assert mock_client.chat.completions.create.call_count == 2
+        sleep.assert_awaited_once_with(0.5)
+
+
+@pytest.mark.asyncio
+async def test_qwen_gives_up_after_max_retries():
+    with (
+        patch("openai.AsyncOpenAI") as mock_openai_class,
+        patch(
+            "dev_health_ops.llm.providers.local.asyncio.sleep", new_callable=AsyncMock
+        ),
+    ):
+        mock_client = MagicMock()
+        mock_openai_class.return_value = mock_client
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=[_RateLimitError(), _RateLimitError()]
+        )
+
+        with pytest.raises(LLMRateLimitError):
+            await QwenProvider(api_key="sk-123").complete("Hello")
+
+        assert mock_client.chat.completions.create.call_count == 2

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -470,6 +470,64 @@ async def test_materialize_uses_org_llm_concurrency_override(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_materialize_clamps_excessive_org_llm_concurrency(monkeypatch, caplog):
+    repo_ids, edges, work_items, commits = _multi_component_data(40)
+    sink = FakeSink()
+    active = 0
+    max_active = 0
+
+    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        try:
+            await asyncio.sleep(0.02)
+            return CategorizationOutcome(
+                subcategories={"feature_delivery.roadmap": 1.0},
+                evidence_quotes=[],
+                uncertainty="Limited evidence.",
+                status="ok",
+                errors=[],
+            )
+        finally:
+            active -= 1
+
+    caplog.set_level(logging.WARNING)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.llm.credentials.resolve_llm_org_settings_concurrency",
+        lambda *, org_id=None: 99 if org_id == "org-123" else None,
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _fake_categorize,
+    )
+
+    now = datetime.now(timezone.utc)
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=repo_ids,
+            llm_provider="mock",
+            persist_evidence_snippets=False,
+            llm_model="test-model",
+            llm_concurrency=3,
+            org_id="org-123",
+        )
+    )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert stats["records"] == 40
+    assert max_active == 32
+    assert any("LLM concurrency 99 exceeds maximum 32" in msg for msg in messages)
+
+
+@pytest.mark.asyncio
 async def test_materialize_fatal_llm_error_cancels_and_writes_no_rows(monkeypatch):
     repo_one = str(uuid.uuid4())
     repo_two = str(uuid.uuid4())

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import builtins
 import json
+import logging
 import uuid
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
@@ -10,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from dev_health_ops.llm import LLMAuthError
+from dev_health_ops.llm import LLMAuthError, LLMRateLimitError
 from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
@@ -102,6 +103,54 @@ def _sample_data():
         }
     ]
     return repo_id, [edge], work_items, commits
+
+
+def _multi_component_data(count: int):
+    now = datetime.now(timezone.utc)
+    repo_ids = [str(uuid.uuid4()) for _ in range(count)]
+    edges = []
+    work_items = []
+    commits = []
+    for idx, repo_id in enumerate(repo_ids, start=1):
+        issue_id = f"jira:ABC-{idx}"
+        commit_hash = f"abc{idx}"
+        edges.append(
+            {
+                "edge_id": f"edge-{idx}",
+                "source_type": "issue",
+                "source_id": issue_id,
+                "target_type": "commit",
+                "target_id": f"{repo_id}@{commit_hash}",
+                "repo_id": repo_id,
+                "confidence": 0.9,
+            }
+        )
+        work_items.append(
+            {
+                "work_item_id": issue_id,
+                "provider": "jira",
+                "repo_id": repo_id,
+                "title": f"Work item {idx}",
+                "description": f"Ship workflow improvement {idx}. " * 20,
+                "type": "task",
+                "labels": ["feature"],
+                "parent_id": "",
+                "epic_id": "",
+                "created_at": now - timedelta(days=2),
+                "updated_at": now - timedelta(days=1),
+                "completed_at": now - timedelta(days=1),
+            }
+        )
+        commits.append(
+            {
+                "repo_id": repo_id,
+                "hash": commit_hash,
+                "message": f"Work item {idx}",
+                "author_when": now - timedelta(days=1),
+                "committer_when": now - timedelta(days=1),
+            }
+        )
+    return repo_ids, edges, work_items, commits
 
 
 def _patch_queries(monkeypatch, edges, work_items, commits):
@@ -309,6 +358,114 @@ async def test_materialize_llm_concurrency_one_serializes(monkeypatch):
 
     stats = await materialize_investments(config)
     assert stats["records"] == 2
+    assert max_active == 1
+
+
+@pytest.mark.asyncio
+async def test_materialize_adaptive_concurrency_halves_and_recovers(
+    monkeypatch, caplog
+):
+    repo_ids, edges, work_items, commits = _multi_component_data(6)
+    sink = FakeSink()
+    call_count = 0
+
+    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise LLMRateLimitError("rate limited", provider="mock", model="test-model")
+        await asyncio.sleep(0.01)
+        return CategorizationOutcome(
+            subcategories={"feature_delivery.roadmap": 1.0},
+            evidence_quotes=[],
+            uncertainty="Limited evidence.",
+            status="ok",
+            errors=[],
+        )
+
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _fake_categorize,
+    )
+
+    now = datetime.now(timezone.utc)
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=repo_ids,
+            llm_provider="mock",
+            persist_evidence_snippets=False,
+            llm_model="test-model",
+            llm_concurrency=4,
+        )
+    )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert stats["records"] == 6
+    assert stats["llm_failure_counts"] == {"rate_limit": 2}
+    assert any("adaptive concurrency reduced to 2/4" in msg for msg in messages)
+    assert any("adaptive concurrency recovered to 3/4" in msg for msg in messages)
+
+
+@pytest.mark.asyncio
+async def test_materialize_uses_org_llm_concurrency_override(monkeypatch):
+    repo_ids, edges, work_items, commits = _multi_component_data(3)
+    sink = FakeSink()
+    active = 0
+    max_active = 0
+
+    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        try:
+            await asyncio.sleep(0.01)
+            return CategorizationOutcome(
+                subcategories={"feature_delivery.roadmap": 1.0},
+                evidence_quotes=[],
+                uncertainty="Limited evidence.",
+                status="ok",
+                errors=[],
+            )
+        finally:
+            active -= 1
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.llm.credentials.resolve_llm_org_settings_concurrency",
+        lambda *, org_id=None: 1 if org_id == "org-123" else None,
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _fake_categorize,
+    )
+
+    now = datetime.now(timezone.utc)
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=repo_ids,
+            llm_provider="mock",
+            persist_evidence_snippets=False,
+            llm_model="test-model",
+            llm_concurrency=3,
+            org_id="org-123",
+        )
+    )
+
+    assert stats["records"] == 3
     assert max_active == 1
 
 


### PR DESCRIPTION
## Summary
- Add Retry-After-aware transient retry handling for OpenAI-compatible Gemini/Qwen providers.
- Add org-scoped LLM concurrency setting and materialize-time override.
- Add adaptive materialize concurrency reduction on sustained 429s with recovery after successful calls.

## Verification
- CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/test_gemini_provider.py tests/test_qwen_provider.py tests/api/test_openai_retry_logic.py tests/work_graph/test_investment_materialize.py tests/work_graph/test_investment_categorize.py -q
- uv run --extra dev --python 3.11 mypy src/dev_health_ops/llm/providers/gemini.py src/dev_health_ops/llm/providers/qwen.py src/dev_health_ops/work_graph/investment/materialize.py
- uv run --extra dev --python 3.11 ruff check src/dev_health_ops/llm src/dev_health_ops/work_graph
- lsp_diagnostics clean on changed Python files

## Notes
- This branch shares materialize.py with the FU-1 P1 stream, which merges first. This PR may need a rebase on main and a trivial conflict resolution before merge.
- SCREENSHOT-WAIVER: backend/API-only reliability change; no rendered UI modified.

Closes CHAOS-2539