### PR TITLE
feat(llm): mock-provenance warning + persisted per-org token sink (CHAOS-2542)

### DIFF
--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -667,6 +667,7 @@ async def work_unit_explain_endpoint(
                 llm_model=llm_model,
                 provider=resolved_provider,
                 org_id=current_user.org_id,
+                db_url=_analytics_db_url(),
             )
         except LLMError as exc:
             raise _http_exception_from_llm_error(exc) from exc

--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -33,6 +33,7 @@ LATEST_WORK_UNIT_INVESTMENTS_CTE = """
                 argMax(evidence_quality, computed_at) AS evidence_quality,
                 argMax(evidence_quality_band, computed_at) AS evidence_quality_band,
                 argMax(categorization_status, computed_at) AS categorization_status,
+                argMax(categorization_model_version, computed_at) AS categorization_model_version,
                 argMax(categorization_run_id, computed_at) AS categorization_run_id,
                 org_id,
                 -- Alias must NOT be ``computed_at``: that name is the ordering
@@ -89,6 +90,51 @@ async def fetch_investment_breakdown(
         ORDER BY value DESC
     """
     return await query_dicts(sink, query, params)
+
+
+async def fetch_mock_fixture_investment_row_count(
+    sink: BaseMetricsSink,
+    *,
+    start_ts: datetime,
+    end_ts: datetime,
+    scope_filter: str,
+    scope_params: dict[str, Any],
+    org_id: str = "",
+    themes: list[str] | None = None,
+    subcategories: list[str] | None = None,
+) -> int:
+    params: dict[str, Any] = {"start_ts": start_ts, "end_ts": end_ts}
+    params.update(scope_params)
+    params["org_id"] = org_id
+    filters: list[str] = []
+    if themes:
+        filters.append("splitByChar('.', subcategory_kv.1)[1] IN %(themes)s")
+        params["themes"] = themes
+    if subcategories:
+        filters.append("subcategory_kv.1 IN %(subcategories)s")
+        params["subcategories"] = subcategories
+    category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
+    query = f"""
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}
+        SELECT count() AS count
+        FROM latest_work_unit_investments AS work_unit_investments
+        ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
+        WHERE work_unit_investments.from_ts < %(end_ts)s
+          AND work_unit_investments.to_ts >= %(start_ts)s
+          AND work_unit_investments.org_id = %(org_id)s
+          AND (
+            lower(ifNull(work_unit_investments.provider, '')) IN ('mock', 'fixture', 'fixtures', 'synthetic')
+            OR lower(ifNull(work_unit_investments.categorization_model_version, '')) LIKE '%mock%'
+            OR lower(ifNull(work_unit_investments.categorization_model_version, '')) LIKE '%synthetic%'
+            OR lower(ifNull(work_unit_investments.categorization_model_version, '')) LIKE '%fixture%'
+          )
+        {scope_filter}
+        {category_filter}
+    """
+    rows = await query_dicts(sink, query, params)
+    if not rows:
+        return 0
+    return int(rows[0].get("count") or 0)
 
 
 async def fetch_investment_edges(

--- a/src/dev_health_ops/api/queries/work_unit_investments.py
+++ b/src/dev_health_ops/api/queries/work_unit_investments.py
@@ -52,6 +52,7 @@ async def fetch_work_unit_investments(
             argMax(evidence_quality, work_unit_investments.computed_at) AS evidence_quality,
             argMax(evidence_quality_band, work_unit_investments.computed_at) AS evidence_quality_band,
             argMax(categorization_status, work_unit_investments.computed_at) AS categorization_status,
+            argMax(categorization_model_version, work_unit_investments.computed_at) AS categorization_model_version,
             argMax(categorization_run_id, work_unit_investments.computed_at) AS categorization_run_id,
             max(work_unit_investments.computed_at) AS computed_at
         FROM work_unit_investments

--- a/src/dev_health_ops/api/services/investment.py
+++ b/src/dev_health_ops/api/services/investment.py
@@ -19,9 +19,11 @@ from ..queries.investment import (
     fetch_investment_breakdown,
     fetch_investment_quality_stats,
     fetch_investment_sunburst,
+    fetch_mock_fixture_investment_row_count,
 )
 from ..queries.scopes import build_scope_filter_multi
 from .filtering import resolve_repo_filter_ids, time_window
+from .provenance import warn_once_for_mock_fixture_rows
 
 
 def _split_category_filters(filters: MetricFilter) -> tuple[list[str], list[str]]:
@@ -186,6 +188,17 @@ async def build_investment_response(
             subcategories=subcategory_filters or None,
         )
 
+        mock_fixture_count = await fetch_mock_fixture_investment_row_count(
+            sink,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            scope_filter=scope_filter,
+            scope_params=scope_params,
+            org_id=org_id,
+            themes=theme_filters or None,
+            subcategories=subcategory_filters or None,
+        )
+
         # Fetch evidence quality stats
         quality_row = await fetch_investment_quality_stats(
             sink,
@@ -213,6 +226,13 @@ async def build_investment_response(
 
     # Compute evidence quality stats
     evidence_quality_stats = _compute_quality_stats(quality_row)
+    warn_once_for_mock_fixture_rows(
+        org_id=org_id,
+        surface="investment",
+        rows=[{"categorization_model_version": "synthetic"}]
+        if mock_fixture_count > 0
+        else [],
+    )
 
     return InvestmentResponse(
         theme_distribution=theme_distribution,
@@ -261,6 +281,23 @@ async def build_investment_sunburst(
             scope_filter, scope_params = build_scope_filter_multi(
                 "repo", repo_ids, repo_column="repo_id"
             )
+        mock_fixture_count = await fetch_mock_fixture_investment_row_count(
+            sink,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            scope_filter=scope_filter,
+            scope_params=scope_params,
+            org_id=org_id,
+            themes=theme_filters or None,
+            subcategories=subcategory_filters or None,
+        )
+        warn_once_for_mock_fixture_rows(
+            org_id=org_id,
+            surface="investment_sunburst",
+            rows=[{"categorization_model_version": "synthetic"}]
+            if mock_fixture_count > 0
+            else [],
+        )
         rows = await fetch_investment_sunburst(
             sink,
             start_ts=start_ts,

--- a/src/dev_health_ops/api/services/investment_mix_explain.py
+++ b/src/dev_health_ops/api/services/investment_mix_explain.py
@@ -365,14 +365,15 @@ async def explain_investment_mix(
     provider = get_provider(llm_provider, model=llm_model)
     completion = await provider.complete(full_prompt)
     raw = completion.text
-    await _persist_investment_mix_token_usage(
-        db_url=db_url,
-        org_id=org_id,
-        provider=resolved_llm_provider,
-        model=completion.model or llm_model,
-        input_tokens=completion.input_tokens,
-        output_tokens=completion.output_tokens,
-    )
+    if llm_provider != "mock":
+        await _persist_investment_mix_token_usage(
+            db_url=db_url,
+            org_id=org_id,
+            provider=resolved_llm_provider,
+            model=completion.model or llm_model,
+            input_tokens=completion.input_tokens,
+            output_tokens=completion.output_tokens,
+        )
     raw_len = len(raw) if raw is not None else 0
     if logger.isEnabledFor(logging.DEBUG):
         # Sanitize and truncate the LLM response before logging to avoid log injection.

--- a/src/dev_health_ops/api/services/investment_mix_explain.py
+++ b/src/dev_health_ops/api/services/investment_mix_explain.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -29,6 +30,69 @@ from .investment import build_investment_response
 from .work_units import build_work_unit_investments
 
 logger = logging.getLogger(__name__)
+
+_TOKEN_USAGE_WRITE_TIMEOUT_SECONDS = 2.0
+
+
+def _write_investment_mix_token_usage(
+    *,
+    db_url: str,
+    org_id: str,
+    provider: str,
+    model: str | None,
+    input_tokens: int | None,
+    output_tokens: int | None,
+) -> bool:
+    ch_sink = ClickHouseMetricsSink(db_url)
+    try:
+        return write_llm_token_usage(
+            ch_sink,
+            org_id=org_id,
+            provider=provider,
+            model=model,
+            source="investment_mix_explain",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+    finally:
+        ch_sink.close()
+
+
+async def _persist_investment_mix_token_usage(
+    *,
+    db_url: str,
+    org_id: str,
+    provider: str,
+    model: str | None,
+    input_tokens: int | None,
+    output_tokens: int | None,
+) -> None:
+    try:
+        persisted = await asyncio.wait_for(
+            asyncio.to_thread(
+                _write_investment_mix_token_usage,
+                db_url=db_url,
+                org_id=org_id,
+                provider=provider,
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            ),
+            timeout=_TOKEN_USAGE_WRITE_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        logger.warning(
+            "Token usage storage timed out source=investment_mix_explain",
+            exc_info=True,
+        )
+    except Exception:
+        logger.warning(
+            "Token usage storage failed source=investment_mix_explain",
+            exc_info=True,
+        )
+    else:
+        if not persisted:
+            logger.warning("Token usage storage failed source=investment_mix_explain")
 
 
 def _top_items(distribution: dict[str, float], limit: int) -> list[tuple[str, float]]:
@@ -301,22 +365,14 @@ async def explain_investment_mix(
     provider = get_provider(llm_provider, model=llm_model)
     completion = await provider.complete(full_prompt)
     raw = completion.text
-    try:
-        ch_sink = ClickHouseMetricsSink(db_url)
-        try:
-            write_llm_token_usage(
-                ch_sink,
-                org_id=org_id,
-                provider=resolved_llm_provider,
-                model=completion.model or llm_model,
-                source="investment_mix_explain",
-                input_tokens=completion.input_tokens,
-                output_tokens=completion.output_tokens,
-            )
-        finally:
-            ch_sink.close()
-    except Exception:
-        logger.debug("Token usage storage failed", exc_info=True)
+    await _persist_investment_mix_token_usage(
+        db_url=db_url,
+        org_id=org_id,
+        provider=resolved_llm_provider,
+        model=completion.model or llm_model,
+        input_tokens=completion.input_tokens,
+        output_tokens=completion.output_tokens,
+    )
     raw_len = len(raw) if raw is not None else 0
     if logger.isEnabledFor(logging.DEBUG):
         # Sanitize and truncate the LLM response before logging to avoid log injection.

--- a/src/dev_health_ops/api/services/investment_mix_explain.py
+++ b/src/dev_health_ops/api/services/investment_mix_explain.py
@@ -8,12 +8,13 @@ from typing import Any, Literal
 
 from dev_health_ops.api.utils.logging import sanitize_for_log
 from dev_health_ops.investment_taxonomy import SUBCATEGORIES, THEMES, theme_of
-from dev_health_ops.llm import get_provider, is_llm_available
+from dev_health_ops.llm import get_provider, is_llm_available, resolve_provider_name
 from dev_health_ops.llm.explainers.investment_mix_explainer import (
     build_prompt,
     load_prompt,
     parse_and_validate_response,
 )
+from dev_health_ops.metrics.llm_token_usage import write_llm_token_usage
 from dev_health_ops.metrics.schemas import InvestmentExplanationRecord
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 
@@ -296,8 +297,26 @@ async def explain_investment_mix(
     prompt_text = load_prompt()
     full_prompt = build_prompt(base_prompt=prompt_text, payload=payload)
 
+    resolved_llm_provider = resolve_provider_name(llm_provider, org_id=org_id)
     provider = get_provider(llm_provider, model=llm_model)
-    raw = await provider.complete_text(full_prompt)
+    completion = await provider.complete(full_prompt)
+    raw = completion.text
+    try:
+        ch_sink = ClickHouseMetricsSink(db_url)
+        try:
+            write_llm_token_usage(
+                ch_sink,
+                org_id=org_id,
+                provider=resolved_llm_provider,
+                model=completion.model or llm_model,
+                source="investment_mix_explain",
+                input_tokens=completion.input_tokens,
+                output_tokens=completion.output_tokens,
+            )
+        finally:
+            ch_sink.close()
+    except Exception:
+        logger.debug("Token usage storage failed", exc_info=True)
     raw_len = len(raw) if raw is not None else 0
     if logger.isEnabledFor(logging.DEBUG):
         # Sanitize and truncate the LLM response before logging to avoid log injection.

--- a/src/dev_health_ops/api/services/provenance.py
+++ b/src/dev_health_ops/api/services/provenance.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_WARNED_MOCK_FIXTURE_SURFACES: set[tuple[str, str]] = set()
+
+_MOCK_FIXTURE_MARKERS = ("mock", "synthetic", "fixture")
+
+
+def row_has_mock_fixture_provenance(row: Mapping[str, Any]) -> bool:
+    values = (
+        row.get("provider"),
+        row.get("categorization_model_version"),
+        row.get("llm_provider"),
+        row.get("source"),
+    )
+    return any(
+        marker in str(value or "").strip().lower()
+        for value in values
+        for marker in _MOCK_FIXTURE_MARKERS
+    )
+
+
+def warn_once_for_mock_fixture_rows(
+    *, org_id: str, surface: str, rows: Iterable[Mapping[str, Any]]
+) -> None:
+    if not any(row_has_mock_fixture_provenance(row) for row in rows):
+        return
+    key = (org_id or "", surface)
+    if key in _WARNED_MOCK_FIXTURE_SURFACES:
+        return
+    _WARNED_MOCK_FIXTURE_SURFACES.add(key)
+    logger.warning(
+        "Mock/fixture-sourced investment rows served to UI surface=%s org_id=%s",
+        surface,
+        org_id or "",
+    )
+
+
+def reset_mock_fixture_warning_state() -> None:
+    _WARNED_MOCK_FIXTURE_SURFACES.clear()

--- a/src/dev_health_ops/api/services/work_unit_explain.py
+++ b/src/dev_health_ops/api/services/work_unit_explain.py
@@ -124,7 +124,7 @@ async def explain_work_unit(
     completion = await resolved_provider.complete(prompt)
     raw_response = completion.text
     resolved_llm_provider = resolve_provider_name(llm_provider, org_id=org_id)
-    if db_url:
+    if db_url and llm_provider != "mock":
         try:
             ch_sink = ClickHouseMetricsSink(db_url)
             try:

--- a/src/dev_health_ops/api/services/work_unit_explain.py
+++ b/src/dev_health_ops/api/services/work_unit_explain.py
@@ -26,6 +26,8 @@ from dev_health_ops.llm.explainers.work_unit_explainer import (
     extract_allowed_inputs,
     validate_explanation_language,
 )
+from dev_health_ops.metrics.llm_token_usage import write_llm_token_usage
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 
 from ..models.schemas import EvidenceQuality, WorkUnitExplanation, WorkUnitInvestment
 
@@ -51,6 +53,7 @@ async def explain_work_unit(
     *,
     provider: LLMProvider | None = None,
     org_id: str | None = None,
+    db_url: str | None = None,
 ) -> WorkUnitExplanation:
     """
     Generate an LLM explanation for a work unit's precomputed investment view.
@@ -118,7 +121,26 @@ async def explain_work_unit(
         if provider is not None
         else get_provider(llm_provider, model=llm_model, org_id=org_id)
     )
-    raw_response = await resolved_provider.complete_text(prompt)
+    completion = await resolved_provider.complete(prompt)
+    raw_response = completion.text
+    resolved_llm_provider = resolve_provider_name(llm_provider, org_id=org_id)
+    if db_url:
+        try:
+            ch_sink = ClickHouseMetricsSink(db_url)
+            try:
+                write_llm_token_usage(
+                    ch_sink,
+                    org_id=org_id or "",
+                    provider=resolved_llm_provider,
+                    model=completion.model or llm_model,
+                    source="work_unit_explain",
+                    input_tokens=completion.input_tokens,
+                    output_tokens=completion.output_tokens,
+                )
+            finally:
+                ch_sink.close()
+        except Exception:
+            logger.debug("Token usage storage failed", exc_info=True)
     logger.debug(
         "Received LLM response for work_unit_id=%s, length=%d",
         investment.work_unit_id,

--- a/src/dev_health_ops/api/services/work_units.py
+++ b/src/dev_health_ops/api/services/work_units.py
@@ -4,6 +4,7 @@ import json
 import logging
 from collections.abc import Iterable
 from datetime import datetime, time, timezone
+from typing import Literal
 
 from ..models.filters import MetricFilter
 from ..models.schemas import (
@@ -22,8 +23,12 @@ from ..queries.work_unit_investments import (
     fetch_work_unit_investments,
 )
 from .filtering import resolve_repo_filter_ids, time_window
+from .provenance import warn_once_for_mock_fixture_rows
 
 logger = logging.getLogger(__name__)
+
+EffortMetric = Literal["churn_loc", "active_hours"]
+EvidenceQualityBand = Literal["high", "moderate", "low", "very_low", "unknown"]
 
 
 def _ensure_utc(dt: datetime | None) -> datetime | None:
@@ -39,6 +44,23 @@ def _clean_optional_text(value: object) -> str | None:
         return None
     text = str(value).strip()
     return text or None
+
+
+def _effort_metric(value: object) -> EffortMetric:
+    return "active_hours" if value == "active_hours" else "churn_loc"
+
+
+def _evidence_quality_band(value: object) -> EvidenceQualityBand:
+    text = str(value or "")
+    if text == "high":
+        return "high"
+    if text == "moderate":
+        return "moderate"
+    if text == "low":
+        return "low"
+    if text == "very_low":
+        return "very_low"
+    return "unknown"
 
 
 def _split_category_filters(filters: MetricFilter) -> tuple[list[str], list[str]]:
@@ -183,6 +205,8 @@ async def build_work_unit_investments(
                     filtered_rows.append(row)
             rows = filtered_rows
 
+        warn_once_for_mock_fixture_rows(org_id=org_id, surface="work_units", rows=rows)
+
         quote_rows: list[dict[str, object]] = []
         if include_text:
             unit_runs = [
@@ -232,7 +256,7 @@ async def build_work_unit_investments(
         subcategory_distribution = _parse_distribution(
             row.get("subcategory_distribution_json")
         )
-        effort_metric = str(row.get("effort_metric") or "churn_loc")
+        effort_metric = _effort_metric(row.get("effort_metric"))
         effort_value = float(row.get("effort_value") or 0.0)
 
         structural_evidence: list[dict[str, object]] = []
@@ -289,10 +313,8 @@ async def build_work_unit_investments(
         raw_quality = row.get("evidence_quality")
         evidence_quality_value = float(raw_quality) if raw_quality is not None else None
         raw_band = row.get("evidence_quality_band")
-        evidence_band = (
-            str(raw_band)
-            if raw_band
-            else ("unknown" if raw_quality is None else "very_low")
+        evidence_band = _evidence_quality_band(
+            raw_band if raw_band else ("unknown" if raw_quality is None else "very_low")
         )
 
         results.append(

--- a/src/dev_health_ops/metrics/llm_token_usage.py
+++ b/src/dev_health_ops/metrics/llm_token_usage.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from dev_health_ops.metrics.schemas import LLMTokenUsageRecord
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+logger = logging.getLogger(__name__)
+
+
+def token_count(value: int | None) -> int:
+    return int(value or 0)
+
+
+def write_llm_token_usage(
+    sink: BaseMetricsSink,
+    *,
+    org_id: str,
+    provider: str,
+    model: str | None,
+    source: str,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    calls: int = 1,
+    computed_at: datetime | None = None,
+) -> None:
+    input_count = token_count(input_tokens)
+    output_count = token_count(output_tokens)
+    call_count = int(calls or 0)
+    if call_count <= 0 and input_count <= 0 and output_count <= 0:
+        return
+    try:
+        sink.write_llm_token_usage(
+            [
+                LLMTokenUsageRecord(
+                    org_id=org_id or "",
+                    provider=provider or "unknown",
+                    model=model or "unknown",
+                    source=source,
+                    input_tokens=input_count,
+                    output_tokens=output_count,
+                    calls=max(0, call_count),
+                    computed_at=computed_at or datetime.now(timezone.utc),
+                )
+            ]
+        )
+    except Exception:
+        logger.debug("Failed to persist LLM token usage", exc_info=True)

--- a/src/dev_health_ops/metrics/llm_token_usage.py
+++ b/src/dev_health_ops/metrics/llm_token_usage.py
@@ -24,12 +24,12 @@ def write_llm_token_usage(
     output_tokens: int | None,
     calls: int = 1,
     computed_at: datetime | None = None,
-) -> None:
+) -> bool:
     input_count = token_count(input_tokens)
     output_count = token_count(output_tokens)
     call_count = int(calls or 0)
     if call_count <= 0 and input_count <= 0 and output_count <= 0:
-        return
+        return True
     try:
         sink.write_llm_token_usage(
             [
@@ -45,5 +45,7 @@ def write_llm_token_usage(
                 )
             ]
         )
+        return True
     except Exception:
         logger.debug("Failed to persist LLM token usage", exc_info=True)
+        return False

--- a/src/dev_health_ops/metrics/schemas.py
+++ b/src/dev_health_ops/metrics/schemas.py
@@ -898,6 +898,18 @@ class WorkUnitInvestmentEvidenceQuoteRecord:
 
 
 @dataclass(frozen=True)
+class LLMTokenUsageRecord:
+    org_id: str
+    provider: str
+    model: str
+    source: str
+    input_tokens: int
+    output_tokens: int
+    calls: int
+    computed_at: datetime
+
+
+@dataclass(frozen=True)
 class InvestmentExplanationRecord:
     """Cached LLM-generated explanation for investment mix views."""
 

--- a/src/dev_health_ops/metrics/sinks/base.py
+++ b/src/dev_health_ops/metrics/sinks/base.py
@@ -30,6 +30,7 @@ from dev_health_ops.metrics.schemas import (
     InvestmentExplanationRecord,
     InvestmentMetricsRecord,
     IssueTypeMetricsRecord,
+    LLMTokenUsageRecord,
     MemberRecord,
     ProjectRecord,
     ReleaseImpactDailyRecord,
@@ -400,6 +401,9 @@ class BaseMetricsSink(ABC):
 
     def write_investment_explanation(self, record: InvestmentExplanationRecord) -> None:
         """Write or replace an investment explanation to the cache."""
+        pass
+
+    def write_llm_token_usage(self, rows: Sequence[LLMTokenUsageRecord]) -> None:
         pass
 
     def read_investment_explanation(

--- a/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/__init__.py
@@ -49,6 +49,7 @@ from dev_health_ops.metrics.sinks.clickhouse.compounding_risk import (
 from dev_health_ops.metrics.sinks.clickhouse.core import ClickHouseCore
 from dev_health_ops.metrics.sinks.clickhouse.dora import DoraMixin
 from dev_health_ops.metrics.sinks.clickhouse.investment import InvestmentMixin
+from dev_health_ops.metrics.sinks.clickhouse.llm_tokens import LLMTokenUsageMixin
 from dev_health_ops.metrics.sinks.clickhouse.recommendations import RecommendationsMixin
 from dev_health_ops.metrics.sinks.clickhouse.wellbeing import WellbeingMixin
 from dev_health_ops.metrics.sinks.clickhouse.work_graph import WorkGraphMixin
@@ -67,6 +68,7 @@ class ClickHouseMetricsSink(
     DoraMixin,
     WellbeingMixin,
     InvestmentMixin,
+    LLMTokenUsageMixin,
     WorkGraphMixin,
     ClickHouseCore,
 ):

--- a/src/dev_health_ops/metrics/sinks/clickhouse/llm_tokens.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/llm_tokens.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from dev_health_ops.metrics.schemas import LLMTokenUsageRecord
+
+if TYPE_CHECKING:
+    from dev_health_ops.metrics.sinks.clickhouse._insert import _ClickHouseSinkBase
+else:
+
+    class _ClickHouseSinkBase:
+        pass
+
+
+class LLMTokenUsageMixin(_ClickHouseSinkBase):
+    def write_llm_token_usage(self, rows: Sequence[LLMTokenUsageRecord]) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "llm_token_usage",
+            [
+                "org_id",
+                "provider",
+                "model",
+                "source",
+                "input_tokens",
+                "output_tokens",
+                "calls",
+                "computed_at",
+            ],
+            rows,
+        )

--- a/src/dev_health_ops/migrations/clickhouse/052_llm_token_usage.sql
+++ b/src/dev_health_ops/migrations/clickhouse/052_llm_token_usage.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS llm_token_usage (
+    org_id String,
+    provider LowCardinality(String),
+    model String,
+    source LowCardinality(String),
+    input_tokens UInt64,
+    output_tokens UInt64,
+    calls UInt64,
+    computed_at DateTime
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(computed_at)
+ORDER BY (org_id, provider, model, source, computed_at);

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -25,6 +25,7 @@ from dev_health_ops.llm import (
     resolve_provider_name,
 )
 from dev_health_ops.llm.providers.none import NoneProvider
+from dev_health_ops.metrics.llm_token_usage import write_llm_token_usage
 from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
@@ -783,6 +784,17 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
                     len(llm_results) - len(fallback_results), llm_failure_counts
                 ),
             )
+        write_llm_token_usage(
+            sink,
+            org_id=config.org_id or "",
+            provider=resolved_llm_provider,
+            model=model_version,
+            source="investment_materialize",
+            input_tokens=llm_input_tokens,
+            output_tokens=llm_output_tokens,
+            calls=llm_calls,
+            computed_at=computed_at,
+        )
 
         # Post-process: create records from outcomes
         for idx, data in preprocessed.items():

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -701,6 +701,43 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
         semaphore = asyncio.Semaphore(config.llm_concurrency)
         llm_results: dict[int, Any] = {}
         llm_failure_counts: Counter[str] = Counter()
+        llm_token_usage_flushed = False
+
+        def flush_llm_token_usage() -> tuple[int, int, int]:
+            nonlocal llm_token_usage_flushed
+            llm_calls = sum(
+                int(getattr(outcome, "llm_calls", 0))
+                for outcome in llm_results.values()
+            )
+            llm_input_tokens = sum(
+                int(getattr(outcome, "input_tokens", 0))
+                for outcome in llm_results.values()
+            )
+            llm_output_tokens = sum(
+                int(getattr(outcome, "output_tokens", 0))
+                for outcome in llm_results.values()
+            )
+            if not llm_token_usage_flushed:
+                write_llm_token_usage(
+                    sink,
+                    org_id=config.org_id or "",
+                    provider=resolved_llm_provider,
+                    model=model_version,
+                    source="investment_materialize",
+                    input_tokens=llm_input_tokens,
+                    output_tokens=llm_output_tokens,
+                    calls=llm_calls,
+                    computed_at=computed_at,
+                )
+                llm_token_usage_flushed = True
+            return llm_calls, llm_input_tokens, llm_output_tokens
+
+        def record_completed_llm_task_result(result: Any) -> None:
+            if not isinstance(result, tuple) or len(result) != 2:
+                logger.warning("Unexpected LLM task result: %r", result)
+                return
+            idx, outcome = result
+            llm_results[idx] = outcome
 
         async def categorize_with_limit(idx: int, bundle: Any) -> tuple[int, Any]:
             async with semaphore:
@@ -737,7 +774,14 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
                         for pending_task in tasks:
                             if not pending_task.done():
                                 pending_task.cancel()
-                        await asyncio.gather(*tasks, return_exceptions=True)
+                        settled_results = await asyncio.gather(
+                            *tasks, return_exceptions=True
+                        )
+                        for settled_result in settled_results:
+                            if isinstance(settled_result, BaseException):
+                                continue
+                            record_completed_llm_task_result(settled_result)
+                        flush_llm_token_usage()
                         verdict = _format_llm_summary(
                             len(llm_results), llm_failure_counts
                         )
@@ -750,11 +794,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
                         "LLM task failed (%s): %s", failure_class, classified
                     )
                     continue
-                if not isinstance(result, tuple) or len(result) != 2:
-                    logger.warning("Unexpected LLM task result: %r", result)
-                    continue
-                idx, outcome = result
-                llm_results[idx] = outcome
+                record_completed_llm_task_result(result)
             logger.info(
                 "Completed LLM categorizations: %s",
                 _format_llm_summary(len(llm_results), llm_failure_counts),
@@ -764,16 +804,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
         for idx, outcome in fallback_results:
             llm_results[idx] = outcome
 
-        llm_calls = sum(
-            int(getattr(outcome, "llm_calls", 0)) for outcome in llm_results.values()
-        )
-        llm_input_tokens = sum(
-            int(getattr(outcome, "input_tokens", 0)) for outcome in llm_results.values()
-        )
-        llm_output_tokens = sum(
-            int(getattr(outcome, "output_tokens", 0))
-            for outcome in llm_results.values()
-        )
+        llm_calls, llm_input_tokens, llm_output_tokens = flush_llm_token_usage()
         if llm_calls or llm_failure_counts:
             logger.info(
                 "LLM usage summary: calls=%d input_tokens=%d output_tokens=%d %s",
@@ -784,18 +815,6 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
                     len(llm_results) - len(fallback_results), llm_failure_counts
                 ),
             )
-        write_llm_token_usage(
-            sink,
-            org_id=config.org_id or "",
-            provider=resolved_llm_provider,
-            model=model_version,
-            source="investment_materialize",
-            input_tokens=llm_input_tokens,
-            output_tokens=llm_output_tokens,
-            calls=llm_calls,
-            computed_at=computed_at,
-        )
-
         # Post-process: create records from outcomes
         for idx, data in preprocessed.items():
             if idx in skipped_existing:

--- a/tests/api/test_investment_explain_cache.py
+++ b/tests/api/test_investment_explain_cache.py
@@ -14,6 +14,7 @@ from dev_health_ops.api.services.investment_mix_explain import (
     _compute_cache_key,
     explain_investment_mix,
 )
+from dev_health_ops.llm.providers.base import CompletionResult
 
 
 def test_compute_cache_key_deterministic():
@@ -215,8 +216,13 @@ async def test_explain_investment_mix_mock_provider_skips_cache():
         mock_units.return_value = []
 
         mock_provider = MagicMock()
-        mock_provider.complete_text = AsyncMock(
-            return_value='{"summary": "Test summary", "top_findings": [], "confidence": {"level": "moderate"}, "what_to_check_next": [], "anti_claims": []}'
+        mock_provider.complete = AsyncMock(
+            return_value=CompletionResult(
+                text='{"summary": "Test summary", "top_findings": [], "confidence": {"level": "moderate"}, "what_to_check_next": [], "anti_claims": []}',
+                input_tokens=10,
+                output_tokens=20,
+                model="mock",
+            )
         )
         mock_get_provider.return_value = mock_provider
 
@@ -270,8 +276,13 @@ async def test_explain_forwards_org_id_to_work_unit_evidence():
         mock_units.return_value = []
 
         mock_provider = MagicMock()
-        mock_provider.complete_text = AsyncMock(
-            return_value='{"summary": "Test summary", "top_findings": [], "confidence": {"level": "moderate"}, "what_to_check_next": [], "anti_claims": []}'
+        mock_provider.complete = AsyncMock(
+            return_value=CompletionResult(
+                text='{"summary": "Test summary", "top_findings": [], "confidence": {"level": "moderate"}, "what_to_check_next": [], "anti_claims": []}',
+                input_tokens=10,
+                output_tokens=20,
+                model="mock",
+            )
         )
         mock_get_provider.return_value = mock_provider
 

--- a/tests/api/test_investment_explain_mismatch.py
+++ b/tests/api/test_investment_explain_mismatch.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from dev_health_ops.api.services.investment_mix_explain import explain_investment_mix
+from dev_health_ops.llm.providers.base import CompletionResult
 
 
 @pytest.mark.asyncio
@@ -31,8 +32,13 @@ async def test_explain_investment_mix_mismatch_warning():
         mock_units.return_value = []
 
         mock_provider = MagicMock()
-        mock_provider.complete_text = AsyncMock(
-            return_value='{"summary": "test", "top_findings": [], "confidence": {"level": "low"}, "what_to_check_next": [], "anti_claims": []}'
+        mock_provider.complete = AsyncMock(
+            return_value=CompletionResult(
+                text='{"summary": "test", "top_findings": [], "confidence": {"level": "low"}, "what_to_check_next": [], "anti_claims": []}',
+                input_tokens=1,
+                output_tokens=1,
+                model="mock",
+            )
         )
         mock_get_provider.return_value = mock_provider
 

--- a/tests/api/test_provenance_warnings.py
+++ b/tests/api/test_provenance_warnings.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+
+from dev_health_ops.api.queries import investment as investment_queries
+from dev_health_ops.api.services.provenance import (
+    reset_mock_fixture_warning_state,
+    warn_once_for_mock_fixture_rows,
+)
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+
+def test_mock_fixture_rows_emit_exactly_one_warning(caplog):
+    reset_mock_fixture_warning_state()
+    rows = [{"categorization_model_version": "synthetic-v1", "provider": "jira"}]
+
+    with caplog.at_level(logging.WARNING):
+        warn_once_for_mock_fixture_rows(org_id="org-a", surface="investment", rows=rows)
+        warn_once_for_mock_fixture_rows(org_id="org-a", surface="investment", rows=rows)
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "Mock/fixture-sourced investment rows served" in record.getMessage()
+    ]
+    assert len(warnings) == 1
+
+
+def test_real_rows_emit_no_warning(caplog):
+    reset_mock_fixture_warning_state()
+    rows = [{"categorization_model_version": "provider=openai;model=gpt-5-mini"}]
+
+    with caplog.at_level(logging.WARNING):
+        warn_once_for_mock_fixture_rows(org_id="org-a", surface="investment", rows=rows)
+
+    assert not [
+        record
+        for record in caplog.records
+        if "Mock/fixture-sourced investment rows served" in record.getMessage()
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mock_fixture_count_query_applies_category_filters(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    async def fake_query_dicts(
+        _sink: BaseMetricsSink, sql: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        captured["sql"] = sql
+        captured["params"] = params
+        return [{"count": 1}]
+
+    monkeypatch.setattr(investment_queries, "query_dicts", fake_query_dicts)
+
+    count = await investment_queries.fetch_mock_fixture_investment_row_count(
+        cast(BaseMetricsSink, object()),
+        start_ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        end_ts=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        scope_filter="",
+        scope_params={},
+        org_id="org-a",
+        themes=["feature_delivery"],
+        subcategories=["feature_delivery.customer"],
+    )
+
+    assert count == 1
+    assert "ARRAY JOIN" in captured["sql"]
+    assert "splitByChar('.', subcategory_kv.1)[1] IN %(themes)s" in captured["sql"]
+    assert "subcategory_kv.1 IN %(subcategories)s" in captured["sql"]
+    assert captured["params"]["themes"] == ["feature_delivery"]
+    assert captured["params"]["subcategories"] == ["feature_delivery.customer"]

--- a/tests/api/test_provenance_warnings.py
+++ b/tests/api/test_provenance_warnings.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 import pytest
 
 from dev_health_ops.api.queries import investment as investment_queries
+from dev_health_ops.api.services import investment_mix_explain
 from dev_health_ops.api.services.provenance import (
     reset_mock_fixture_warning_state,
     warn_once_for_mock_fixture_rows,
@@ -74,3 +75,35 @@ async def test_mock_fixture_count_query_applies_category_filters(monkeypatch):
     assert "subcategory_kv.1 IN %(subcategories)s" in captured["sql"]
     assert captured["params"]["themes"] == ["feature_delivery"]
     assert captured["params"]["subcategories"] == ["feature_delivery.customer"]
+
+
+@pytest.mark.asyncio
+async def test_investment_mix_token_write_is_offloaded_and_failure_warns(
+    monkeypatch, caplog
+):
+    called: dict[str, Any] = {}
+
+    async def fake_to_thread(func, /, *args, **kwargs):
+        called["func"] = func
+        called["kwargs"] = kwargs
+        raise RuntimeError("clickhouse unavailable")
+
+    monkeypatch.setattr(investment_mix_explain.asyncio, "to_thread", fake_to_thread)
+
+    with caplog.at_level(logging.WARNING):
+        await investment_mix_explain._persist_investment_mix_token_usage(
+            db_url="clickhouse://localhost:8123/default",
+            org_id="org-a",
+            provider="openai",
+            model="gpt-5-mini",
+            input_tokens=10,
+            output_tokens=5,
+        )
+
+    assert called["func"] is investment_mix_explain._write_investment_mix_token_usage
+    assert called["kwargs"]["org_id"] == "org-a"
+    assert any(
+        "Token usage storage failed source=investment_mix_explain"
+        in record.getMessage()
+        for record in caplog.records
+    )

--- a/tests/api/test_work_unit_explain_hardening.py
+++ b/tests/api/test_work_unit_explain_hardening.py
@@ -22,6 +22,7 @@ from dev_health_ops.api.auth.router import get_current_user  # noqa: E402
 from dev_health_ops.api.main import app  # noqa: E402
 from dev_health_ops.api.services.auth import AuthenticatedUser  # noqa: E402
 from dev_health_ops.llm.errors import LLMAuthError, LLMRateLimitError  # noqa: E402
+from dev_health_ops.llm.providers.base import CompletionResult  # noqa: E402
 from tests.api.test_work_unit_explain import _sample_investment  # noqa: E402
 
 # ---------------------------------------------------------------------------
@@ -41,7 +42,7 @@ class _FailingProvider:
     def __init__(self, exc):
         self.exc = exc
 
-    async def complete_text(self, prompt: str) -> str:
+    async def complete(self, prompt: str) -> CompletionResult:
         raise self.exc
 
 

--- a/tests/metrics/test_llm_token_usage_sink.py
+++ b/tests/metrics/test_llm_token_usage_sink.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from dev_health_ops.metrics.llm_token_usage import write_llm_token_usage
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+
+class FakeClickHouseClient:
+    def __init__(self) -> None:
+        self.inserts: list[tuple[str, list[list[object]], list[str]]] = []
+
+    def insert(
+        self, table: str, matrix: list[list[object]], column_names: list[str]
+    ) -> None:
+        self.inserts.append((table, matrix, column_names))
+
+
+def test_llm_token_sink_accrues_counts_per_org():
+    client = FakeClickHouseClient()
+    sink = ClickHouseMetricsSink("clickhouse://localhost:9000/default", client=client)
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    write_llm_token_usage(
+        sink,
+        org_id="org-a",
+        provider="openai",
+        model="gpt-5-mini",
+        source="investment_materialize",
+        input_tokens=10,
+        output_tokens=5,
+        calls=1,
+        computed_at=now,
+    )
+    write_llm_token_usage(
+        sink,
+        org_id="org-a",
+        provider="openai",
+        model="gpt-5-mini",
+        source="investment_materialize",
+        input_tokens=7,
+        output_tokens=3,
+        calls=2,
+        computed_at=now,
+    )
+    write_llm_token_usage(
+        sink,
+        org_id="org-b",
+        provider="openai",
+        model="gpt-5-mini",
+        source="investment_materialize",
+        input_tokens=100,
+        output_tokens=50,
+        calls=1,
+        computed_at=now,
+    )
+
+    def default_totals() -> dict[str, int]:
+        return {"input": 0, "output": 0, "calls": 0}
+
+    totals: defaultdict[object, dict[str, int]] = defaultdict(default_totals)
+    for table, matrix, columns in client.inserts:
+        assert table == "llm_token_usage"
+        for row in matrix:
+            values = dict(zip(columns, row))
+            org_totals = totals[values["org_id"]]
+            org_totals["input"] += int(cast(Any, values["input_tokens"]))
+            org_totals["output"] += int(cast(Any, values["output_tokens"]))
+            org_totals["calls"] += int(cast(Any, values["calls"]))
+
+    assert totals["org-a"] == {"input": 17, "output": 8, "calls": 3}
+    assert totals["org-b"] == {"input": 100, "output": 50, "calls": 1}

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -12,6 +12,7 @@ import pytest
 
 from dev_health_ops.llm import LLMAuthError
 from dev_health_ops.metrics.schemas import (
+    LLMTokenUsageRecord,
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
 )
@@ -30,6 +31,7 @@ class FakeSink:
         self.client = object()
         self.investment_rows: list[WorkUnitInvestmentRecord] = []
         self.quote_rows: list[WorkUnitInvestmentEvidenceQuoteRecord] = []
+        self.llm_token_rows: list[LLMTokenUsageRecord] = []
         self.membership_rows: list = []
         self.membership_run_records: list = []
         self.query_calls: list[tuple[str, dict]] = []
@@ -43,6 +45,9 @@ class FakeSink:
 
     def write_work_unit_investment_quotes(self, rows) -> None:
         self.quote_rows.extend(rows)
+
+    def write_llm_token_usage(self, rows) -> None:
+        self.llm_token_rows.extend(rows)
 
     def write_work_unit_memberships(self, rows) -> None:
         self.membership_rows.extend(rows)
@@ -425,6 +430,132 @@ async def test_materialize_fatal_llm_error_cancels_and_writes_no_rows(monkeypatc
     assert sleeper_cancelled is True
     assert sink.investment_rows == []
     assert sink.quote_rows == []
+
+
+@pytest.mark.asyncio
+async def test_materialize_fatal_llm_error_flushes_completed_token_usage(monkeypatch):
+    repo_one = str(uuid.uuid4())
+    repo_two = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+    edges = [
+        {
+            "edge_id": "edge-1",
+            "source_type": "issue",
+            "source_id": "jira:ABC-1",
+            "target_type": "commit",
+            "target_id": f"{repo_one}@abc123",
+            "repo_id": repo_one,
+            "confidence": 0.9,
+        },
+        {
+            "edge_id": "edge-2",
+            "source_type": "issue",
+            "source_id": "jira:ABC-2",
+            "target_type": "commit",
+            "target_id": f"{repo_two}@def456",
+            "repo_id": repo_two,
+            "confidence": 0.9,
+        },
+    ]
+    work_items = [
+        {
+            "work_item_id": "jira:ABC-1",
+            "provider": "jira",
+            "repo_id": repo_one,
+            "title": "Fix billing outage",
+            "description": "Resolve customer billing failures. " * 20,
+            "type": "incident",
+            "labels": ["outage"],
+            "parent_id": "",
+            "epic_id": "",
+            "created_at": now - timedelta(days=2),
+            "updated_at": now - timedelta(days=1),
+            "completed_at": now - timedelta(days=1),
+        },
+        {
+            "work_item_id": "jira:ABC-2",
+            "provider": "jira",
+            "repo_id": repo_two,
+            "title": "Add checkout flow",
+            "description": "Ship checkout workflow improvements. " * 20,
+            "type": "task",
+            "labels": ["feature"],
+            "parent_id": "",
+            "epic_id": "",
+            "created_at": now - timedelta(days=2),
+            "updated_at": now - timedelta(days=1),
+            "completed_at": now - timedelta(days=1),
+        },
+    ]
+    commits = [
+        {
+            "repo_id": repo_one,
+            "hash": "abc123",
+            "message": "Fix billing outage",
+            "author_when": now - timedelta(days=1),
+            "committer_when": now - timedelta(days=1),
+        },
+        {
+            "repo_id": repo_two,
+            "hash": "def456",
+            "message": "Add checkout flow",
+            "author_when": now - timedelta(days=1),
+            "committer_when": now - timedelta(days=1),
+        },
+    ]
+    sink = FakeSink()
+    call_count = 0
+
+    async def _fake_categorize(bundle, llm_provider, llm_model=None, provider=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return CategorizationOutcome(
+                subcategories={"feature_delivery.roadmap": 1.0},
+                evidence_quotes=[],
+                uncertainty="Limited evidence.",
+                status="ok",
+                errors=[],
+                warnings=[],
+                llm_calls=1,
+                input_tokens=123,
+                output_tokens=45,
+                llm_model="test-model",
+            )
+        raise RuntimeError("insufficient_quota: billing hard limit reached")
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _fake_categorize,
+    )
+
+    config = MaterializeConfig(
+        dsn="clickhouse://localhost:8123/default",
+        from_ts=now - timedelta(days=5),
+        to_ts=now,
+        repo_ids=None,
+        llm_provider="mock",
+        persist_evidence_snippets=False,
+        llm_model="test-model",
+        llm_concurrency=1,
+        org_id="org-token-test",
+    )
+
+    with pytest.raises(LLMAuthError, match="quota exhausted"):
+        await materialize_investments(config)
+
+    assert sink.investment_rows == []
+    assert len(sink.llm_token_rows) == 1
+    token_row = sink.llm_token_rows[0]
+    assert token_row.org_id == "org-token-test"
+    assert token_row.source == "investment_materialize"
+    assert token_row.input_tokens == 123
+    assert token_row.output_tokens == 45
+    assert token_row.calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Emit deduped one-time warnings when mock/fixture investment rows are served through investment/explain UI paths.
- Add a ClickHouse-backed per-org LLM token usage sink and wire existing LLM token counts into materialization and explain calls.
- Add tests for provenance warning dedupe/filtering and per-org token sink accrual/isolation.

## Verification
- CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/api/test_provenance_warnings.py tests/metrics/test_llm_token_usage_sink.py tests/api/test_investment_latest_row_queries.py tests/metrics/test_clickhouse_sink_query.py -q
- uv run --extra dev --python 3.11 mypy src/dev_health_ops/api/main.py src/dev_health_ops/api/services/investment.py src/dev_health_ops/api/services/work_units.py src/dev_health_ops/api/services/provenance.py src/dev_health_ops/api/services/investment_mix_explain.py src/dev_health_ops/api/services/work_unit_explain.py src/dev_health_ops/api/queries/investment.py src/dev_health_ops/api/queries/work_unit_investments.py src/dev_health_ops/metrics/llm_token_usage.py src/dev_health_ops/metrics/sinks/clickhouse/llm_tokens.py src/dev_health_ops/metrics/sinks/base.py src/dev_health_ops/metrics/sinks/clickhouse/__init__.py src/dev_health_ops/metrics/schemas.py src/dev_health_ops/work_graph/investment/materialize.py
- uv run --extra dev --python 3.11 ruff check src/dev_health_ops/metrics src/dev_health_ops/api src/dev_health_ops/work_graph

SCREENSHOT-WAIVER: backend-only, no rendered UI

Closes CHAOS-2542