### PR TITLE
refactor(teams): single member resolver in worker + provider capability registry (CHAOS-2405, CHAOS-2406)

### DIFF
--- a/src/dev_health_ops/api/services/configuration/team_drift_sync.py
+++ b/src/dev_health_ops/api/services/configuration/team_drift_sync.py
@@ -7,9 +7,11 @@ for review (``sync_policy == 1``).
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.models.settings import TeamMapping
@@ -19,6 +21,18 @@ from .team_mapping import TeamMappingService
 if TYPE_CHECKING:
     from dev_health_ops.api.admin.schemas import DiscoveredTeam
 
+PROVIDER_MANAGED_FIELDS = ["name", "description", "repo_patterns", "project_keys"]
+
+
+@dataclass
+class _ProviderDiscoveredTeam:
+    provider_type: str
+    provider_team_id: str
+    name: str
+    description: str | None = None
+    member_count: int | None = None
+    associations: dict[str, Any] = field(default_factory=dict)
+
 
 class TeamDriftSyncService:
     """Compares discovered teams against stored TeamMappings and flags/merges changes."""
@@ -27,10 +41,97 @@ class TeamDriftSyncService:
         self.session = session
         self.org_id = org_id
 
+    async def project_provider_teams(
+        self,
+        provider: str,
+        teams_data: list[Any],
+        *,
+        replace_empty_provider_values: bool = False,
+    ) -> dict[str, Any]:
+        normalized_provider = str(provider or "config").lower()
+        discovered_teams = [
+            self._provider_team_to_discovered(normalized_provider, team)
+            for team in teams_data
+        ]
+        discovered_teams = [
+            team for team in discovered_teams if team.associations.get("team_id")
+        ]
+        if not discovered_teams:
+            return {
+                "provider": normalized_provider,
+                "projected": 0,
+                "created": 0,
+                "auto_applied": 0,
+                "flagged": 0,
+                "new_available": 0,
+                "provider_removed": 0,
+            }
+
+        team_svc = TeamMappingService(self.session, self.org_id)
+        existing_teams = await team_svc.list_all(active_only=True)
+        provider_lookup: dict[str, Any] = {}
+        team_lookup: dict[str, Any] = {}
+        for team in existing_teams:
+            ed = dict(team.extra_data or {})
+            if ed.get("provider_type") == normalized_provider:
+                provider_lookup[ed.get("provider_team_id", "")] = team
+            team_lookup[str(team.team_id)] = team
+
+        now = datetime.now(timezone.utc)
+        created = 0
+        for discovered in discovered_teams:
+            team_id = str(discovered.associations.get("team_id", "")).strip()
+            existing = provider_lookup.get(
+                discovered.provider_team_id
+            ) or team_lookup.get(team_id)
+            extra_data = self._provider_extra_data(
+                existing,
+                provider=normalized_provider,
+                provider_team_id=discovered.provider_team_id,
+                now=now,
+            )
+            if existing is None:
+                associations = discovered.associations or {}
+                self.session.add(
+                    TeamMapping(
+                        team_id=team_id,
+                        name=discovered.name,
+                        org_id=self.org_id,
+                        description=discovered.description,
+                        repo_patterns=list(associations.get("repo_patterns", [])),
+                        project_keys=list(associations.get("project_keys", [])),
+                        extra_data=extra_data,
+                        managed_fields=list(PROVIDER_MANAGED_FIELDS),
+                        is_active=True,
+                    )
+                )
+                created += 1
+                continue
+            existing.extra_data = extra_data
+            existing.is_active = True
+            existing.last_drift_sync_at = now
+
+        await self.session.flush()
+        result = await self.run_drift_sync(
+            normalized_provider,
+            discovered_teams,
+            replace_empty_provider_values=replace_empty_provider_values,
+        )
+        result["created"] = created
+        result["projected"] = await self._count_projected_team_ids(
+            [
+                str(team.associations.get("team_id", "")).strip()
+                for team in discovered_teams
+            ]
+        )
+        return result
+
     async def run_drift_sync(
         self,
         provider: str,
         discovered_teams: list[DiscoveredTeam],
+        *,
+        replace_empty_provider_values: bool = False,
     ) -> dict[str, Any]:
         team_svc = TeamMappingService(self.session, self.org_id)
         existing_teams: list[Any] = await team_svc.list_all(active_only=True)
@@ -57,7 +158,11 @@ class TeamDriftSyncService:
                 new_available += 1
                 continue
 
-            changes = self._compute_field_diffs(existing, disc_team)
+            changes = self._compute_field_diffs(
+                existing,
+                disc_team,
+                replace_empty_provider_values=replace_empty_provider_values,
+            )
             if not changes:
                 existing.last_drift_sync_at = now
                 continue
@@ -104,6 +209,8 @@ class TeamDriftSyncService:
         self,
         existing: TeamMapping,
         discovered: DiscoveredTeam,
+        *,
+        replace_empty_provider_values: bool = False,
     ) -> list[dict[str, Any]]:
         changes: list[dict[str, Any]] = []
         managed: list[str] = list(existing.managed_fields or [])
@@ -122,6 +229,16 @@ class TeamDriftSyncService:
             new_val = field_map[field_name]
             old_val = getattr(existing, field_name, None)
 
+            if (
+                field_name in {"repo_patterns", "project_keys"}
+                and not replace_empty_provider_values
+                and isinstance(old_val, list)
+                and old_val
+                and isinstance(new_val, list)
+                and not new_val
+            ):
+                continue
+
             if isinstance(old_val, list) and isinstance(new_val, list):
                 if sorted(old_val) == sorted(new_val):
                     continue
@@ -138,6 +255,92 @@ class TeamDriftSyncService:
             )
 
         return changes
+
+    async def _count_projected_team_ids(self, team_ids: list[str]) -> int:
+        expected_ids = {team_id for team_id in team_ids if team_id}
+        if not expected_ids:
+            return 0
+        result = await self.session.execute(
+            select(TeamMapping.team_id).where(
+                TeamMapping.org_id == self.org_id,
+                TeamMapping.team_id.in_(expected_ids),
+            )
+        )
+        return len(set(result.scalars()))
+
+    def _provider_team_to_discovered(self, provider: str, team: Any) -> Any:
+        team_id = str(self._team_value(team, "id", "") or "").strip()
+        team_name = str(self._team_value(team, "name", team_id) or team_id)
+        associations = {
+            "team_id": team_id,
+            "repo_patterns": self._team_string_list(team, "repo_patterns"),
+            "project_keys": self._project_keys_for_team(team_id, provider, team),
+        }
+        members = self._team_value(team, "members", []) or []
+        member_count = len(members) if isinstance(members, list) else None
+        return _ProviderDiscoveredTeam(
+            provider_type=provider,
+            provider_team_id=self._provider_team_id(team_id, provider),
+            name=team_name,
+            description=self._team_value(team, "description", None),
+            member_count=member_count,
+            associations=associations,
+        )
+
+    def _provider_extra_data(
+        self,
+        existing: Any | None,
+        *,
+        provider: str,
+        provider_team_id: str,
+        now: datetime,
+    ) -> dict[str, Any]:
+        extra_data = dict(getattr(existing, "extra_data", {}) or {})
+        extra_data.update(
+            {
+                "provider_type": provider,
+                "provider_team_id": provider_team_id,
+                "last_discovered_at": now.isoformat(),
+                "sync_source": "provider-projection",
+            }
+        )
+        return extra_data
+
+    @staticmethod
+    def _team_value(team: Any, field: str, default: Any = None) -> Any:
+        if isinstance(team, dict):
+            return team.get(field, default)
+        return getattr(team, field, default)
+
+    def _team_string_list(self, team: Any, field: str) -> list[str]:
+        value = self._team_value(team, field, [])
+        if not isinstance(value, list):
+            return []
+        return [str(item) for item in value if item]
+
+    def _project_keys_for_team(
+        self, team_id: str, provider: str, team: Any
+    ) -> list[str]:
+        configured = self._team_string_list(team, "project_keys")
+        if configured:
+            return configured
+        if provider == "jira":
+            return [team_id]
+        if provider == "linear" and team_id.startswith("linear:"):
+            return [team_id.removeprefix("linear:")]
+        return []
+
+    @staticmethod
+    def _provider_team_id(team_id: str, provider: str) -> str:
+        if provider == "github" and team_id.startswith("gh:"):
+            return team_id.removeprefix("gh:")
+        if provider == "gitlab" and team_id.startswith("gl:"):
+            return team_id.removeprefix("gl:")
+        if provider == "linear" and team_id.startswith("linear:"):
+            return team_id.removeprefix("linear:")
+        if provider == "ms-teams" and team_id.startswith("ms-teams:"):
+            return team_id.removeprefix("ms-teams:")
+        return team_id
 
     def _apply_changes(
         self,

--- a/src/dev_health_ops/api/services/configuration/team_member_resolver.py
+++ b/src/dev_health_ops/api/services/configuration/team_member_resolver.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def members_by_team(identity_mappings: Any) -> dict[str, set[str]]:
+    """Collect member identities per team from confirmed identity mappings.
+
+    The membership-based ``TeamResolver`` matches work-item assignees
+    (emails, provider logins/account ids) against ``teams.members`` in
+    ClickHouse, so every confirmed identity facet is included: email,
+    canonical_id, and all provider identities. ``display_name`` is used
+    only when no email exists (mirrors the worker ``sync_teams`` path and
+    avoids false-positive matches on common names).
+    """
+    members: dict[str, set[str]] = {}
+    for ident in identity_mappings:
+        identities: set[str] = set()
+        email = getattr(ident, "email", None)
+        if email:
+            identities.add(str(email))
+        canonical_id = getattr(ident, "canonical_id", None)
+        if canonical_id:
+            identities.add(str(canonical_id))
+        for values in (getattr(ident, "provider_identities", None) or {}).values():
+            if isinstance(values, list):
+                identities.update(str(v) for v in values if v)
+            elif values:
+                identities.add(str(values))
+        if not email:
+            display_name = getattr(ident, "display_name", None)
+            if display_name:
+                identities.add(str(display_name))
+        if not identities:
+            continue
+        for team_id in getattr(ident, "team_ids", None) or []:
+            key = str(team_id).strip()
+            if key:
+                members.setdefault(key, set()).update(identities)
+    return members

--- a/src/dev_health_ops/providers/team_bridge.py
+++ b/src/dev_health_ops/providers/team_bridge.py
@@ -8,49 +8,15 @@ from typing import Any
 
 from sqlalchemy import select
 
+from dev_health_ops.api.services.configuration.team_member_resolver import (
+    members_by_team as _members_by_team,
+)
 from dev_health_ops.db import (
     get_postgres_session_sync,
     get_postgres_session_sync_for_uri,
 )
 from dev_health_ops.models.settings import IdentityMapping, TeamMapping
 from dev_health_ops.storage.clickhouse import ClickHouseStore
-
-
-def _members_by_team(identity_mappings: Any) -> dict[str, set[str]]:
-    """Collect member identities per team from confirmed identity mappings.
-
-    The membership-based ``TeamResolver`` matches work-item assignees
-    (emails, provider logins/account ids) against ``teams.members`` in
-    ClickHouse, so every confirmed identity facet is included: email,
-    canonical_id, and all provider identities. ``display_name`` is used
-    only when no email exists (mirrors the worker ``sync_teams`` path and
-    avoids false-positive matches on common names).
-    """
-    members: dict[str, set[str]] = {}
-    for ident in identity_mappings:
-        identities: set[str] = set()
-        email = getattr(ident, "email", None)
-        if email:
-            identities.add(str(email))
-        canonical_id = getattr(ident, "canonical_id", None)
-        if canonical_id:
-            identities.add(str(canonical_id))
-        for values in (getattr(ident, "provider_identities", None) or {}).values():
-            if isinstance(values, list):
-                identities.update(str(v) for v in values if v)
-            elif values:
-                identities.add(str(values))
-        if not email:
-            display_name = getattr(ident, "display_name", None)
-            if display_name:
-                identities.add(str(display_name))
-        if not identities:
-            continue
-        for team_id in getattr(ident, "team_ids", None) or []:
-            key = str(team_id).strip()
-            if key:
-                members.setdefault(key, set()).update(identities)
-    return members
 
 
 def _parse_json_array(value: Any) -> list[str]:

--- a/src/dev_health_ops/providers/team_capabilities.py
+++ b/src/dev_health_ops/providers/team_capabilities.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TeamProviderCapability:
+    provider: str
+    supports_org_drift_discovery: bool
+    unsupported_reason: str | None = None
+
+
+ORG_TEAM_DRIFT_CAPABILITIES: tuple[TeamProviderCapability, ...] = (
+    TeamProviderCapability("github", True),
+    TeamProviderCapability("gitlab", True),
+    TeamProviderCapability("jira", True),
+    TeamProviderCapability("linear", True),
+    TeamProviderCapability("ms-teams", True),
+)
+
+
+def team_provider_capabilities() -> tuple[TeamProviderCapability, ...]:
+    return ORG_TEAM_DRIFT_CAPABILITIES
+
+
+def org_drift_capable_providers() -> tuple[str, ...]:
+    return tuple(
+        capability.provider
+        for capability in ORG_TEAM_DRIFT_CAPABILITIES
+        if capability.supports_org_drift_discovery
+    )

--- a/src/dev_health_ops/workers/sync_team.py
+++ b/src/dev_health_ops/workers/sync_team.py
@@ -13,12 +13,6 @@ from dev_health_ops.workers.celery_app import celery_app
 logger = logging.getLogger(__name__)
 
 
-def _string_list(value: object | None) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    return [str(item) for item in value if item]
-
-
 def _uuid_value(value: object) -> uuid.UUID:
     if isinstance(value, uuid.UUID):
         return value
@@ -51,15 +45,10 @@ async def _discover_and_sync_all(org_id: str | None) -> dict:
         TeamDriftSyncService,
     )
     from dev_health_ops.db import get_postgres_session
+    from dev_health_ops.providers.team_capabilities import org_drift_capable_providers
 
     effective_org_id = org_id or ""
-
-    # Capability registry: all org-scoped providers that support drift discovery.
-    # Entries are ordered; the set is the single source of truth for which
-    # providers the worker covers. Adding a provider here is sufficient to
-    # include it in Phase 1 credential lookup, Phase 2 concurrent discovery,
-    # and Phase 3 drift persistence.
-    providers = ("github", "gitlab", "jira", "linear", "ms-teams")
+    providers = org_drift_capable_providers()
 
     # Phase 1: read + decrypt credentials in one short-lived session. These are
     # fast local reads; the connection is released before any network I/O.
@@ -206,23 +195,33 @@ def sync_team_drift(self, org_id: str | None = None) -> dict:
     name="dev_health_ops.workers.tasks.reconcile_team_members",
 )
 def reconcile_team_members(self, org_id: str | None = None) -> dict:
+    from dev_health_ops.api.services.configuration.team_member_resolver import (
+        members_by_team,
+    )
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.models.settings import IdentityMapping
 
-    team_members: dict[str, set[str]] = {}
+    if org_id is not None:
+        from dev_health_ops.providers.team_bridge import bridge_teams_to_clickhouse
+
+        teams_synced = bridge_teams_to_clickhouse(
+            org_id=org_id, db_url=require_clickhouse_uri()
+        )
+        return {
+            "status": "success",
+            "teams_scanned": teams_synced,
+            "teams_updated": teams_synced,
+            "mapped_teams": teams_synced,
+        }
+
     with get_postgres_session_sync() as session:
-        mappings = (
+        identity_mappings = (
             session.query(IdentityMapping)
             .filter(IdentityMapping.org_id == org_id)
+            .filter(IdentityMapping.is_active.is_(True))
             .all()
         )
-
-        for mapping in mappings:
-            canonical_id = str(mapping.canonical_id)
-            for team_id in _string_list(mapping.team_ids):
-                if not team_id:
-                    continue
-                team_members.setdefault(str(team_id), set()).add(canonical_id)
+        team_members = members_by_team(identity_mappings)
 
     async def _run() -> dict:
         from dev_health_ops.models.teams import Team

--- a/tests/api/admin/test_team_member_resolver.py
+++ b/tests/api/admin/test_team_member_resolver.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dev_health_ops.api.services.configuration.team_member_resolver import (
+    members_by_team,
+)
+from dev_health_ops.models.settings import IdentityMapping
+from dev_health_ops.providers.team_bridge import _members_by_team
+
+
+def test_members_by_team_preserves_confirmed_identity_facets():
+    identities = [
+        IdentityMapping(
+            canonical_id="u1",
+            org_id="org-1",
+            email="alice@example.com",
+            display_name="Alice Example",
+            provider_identities={"github": ["alice-gh"], "jira": ["alice-jira"]},
+            team_ids=["gh:platform"],
+        ),
+        IdentityMapping(
+            canonical_id="u2",
+            org_id="org-1",
+            display_name="Bob Example",
+            provider_identities={"github": ["bob-gh"]},
+            team_ids=["gh:platform"],
+        ),
+    ]
+
+    resolved = members_by_team(identities)
+
+    assert resolved == _members_by_team(identities)
+    assert resolved["gh:platform"] == {
+        "u1",
+        "alice@example.com",
+        "alice-gh",
+        "alice-jira",
+        "u2",
+        "bob-gh",
+        "Bob Example",
+    }
+    assert "unmapped-login" not in resolved["gh:platform"]

--- a/tests/api/admin/test_team_projection.py
+++ b/tests/api/admin/test_team_projection.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.services.configuration.team_drift_sync import (
+    PROVIDER_MANAGED_FIELDS,
+    TeamDriftSyncService,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import IdentityMapping, TeamMapping
+from tests._helpers import tables_of
+
+
+@dataclass
+class ProviderTeam:
+    id: str
+    name: str
+    description: str | None = None
+    repo_patterns: list[str] = field(default_factory=list)
+    project_keys: list[str] = field(default_factory=list)
+    members: list[str] = field(default_factory=list)
+    members_complete: bool = False
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "team_projection.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(TeamMapping, IdentityMapping),
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_project_provider_teams_creates_full_team_mapping(session_maker):
+    async with session_maker() as session:
+        service = TeamDriftSyncService(session, "org-1")
+        result = await service.project_provider_teams(
+            "github",
+            [
+                ProviderTeam(
+                    id="gh:platform",
+                    name="Platform",
+                    description="Platform team",
+                    repo_patterns=["platform/*"],
+                    project_keys=["PLAT"],
+                )
+            ],
+        )
+
+        mapping = await session.scalar(
+            select(TeamMapping).where(TeamMapping.team_id == "gh:platform")
+        )
+
+    assert result["created"] == 1
+    assert result["projected"] == 1
+    assert mapping is not None
+    assert mapping.name == "Platform"
+    assert mapping.description == "Platform team"
+    assert mapping.is_active is True
+    assert mapping.repo_patterns == ["platform/*"]
+    assert mapping.project_keys == ["PLAT"]
+    assert mapping.managed_fields == PROVIDER_MANAGED_FIELDS
+    assert mapping.extra_data == {
+        "provider_type": "github",
+        "provider_team_id": "platform",
+        "last_discovered_at": mapping.extra_data["last_discovered_at"],
+        "sync_source": "provider-projection",
+    }
+
+
+@pytest.mark.asyncio
+async def test_project_provider_teams_preserves_curated_empty_provider_values(
+    session_maker,
+):
+    async with session_maker() as session:
+        session.add(
+            TeamMapping(
+                team_id="gh:platform",
+                name="Old Platform",
+                org_id="org-1",
+                description="Old description",
+                repo_patterns=["curated/*"],
+                project_keys=["CUR"],
+                extra_data={"provider_type": "github", "provider_team_id": "platform"},
+                managed_fields=list(PROVIDER_MANAGED_FIELDS),
+                sync_policy=0,
+            )
+        )
+        await session.flush()
+
+        service = TeamDriftSyncService(session, "org-1")
+        await service.project_provider_teams(
+            "github",
+            [ProviderTeam(id="gh:platform", name="New Platform")],
+        )
+        mapping = await session.scalar(
+            select(TeamMapping).where(TeamMapping.team_id == "gh:platform")
+        )
+
+    assert mapping is not None
+    assert mapping.name == "New Platform"
+    assert mapping.description is None
+    assert mapping.repo_patterns == ["curated/*"]
+    assert mapping.project_keys == ["CUR"]
+
+
+@pytest.mark.asyncio
+async def test_project_provider_teams_explicit_replace_allows_empty_provider_values(
+    session_maker,
+):
+    async with session_maker() as session:
+        session.add(
+            TeamMapping(
+                team_id="gh:platform",
+                name="Old Platform",
+                org_id="org-1",
+                repo_patterns=["curated/*"],
+                project_keys=["CUR"],
+                extra_data={"provider_type": "github", "provider_team_id": "platform"},
+                managed_fields=list(PROVIDER_MANAGED_FIELDS),
+                sync_policy=0,
+            )
+        )
+        await session.flush()
+
+        service = TeamDriftSyncService(session, "org-1")
+        await service.project_provider_teams(
+            "github",
+            [ProviderTeam(id="gh:platform", name="New Platform")],
+            replace_empty_provider_values=True,
+        )
+        mapping = await session.scalar(
+            select(TeamMapping).where(TeamMapping.team_id == "gh:platform")
+        )
+
+    assert mapping is not None
+    assert mapping.repo_patterns == []
+    assert mapping.project_keys == []
+
+
+@pytest.mark.asyncio
+async def test_project_provider_teams_sync_policy_one_flags_without_applying(
+    session_maker,
+):
+    async with session_maker() as session:
+        session.add(
+            TeamMapping(
+                team_id="gh:platform",
+                name="Old Platform",
+                org_id="org-1",
+                repo_patterns=["curated/*"],
+                project_keys=["CUR"],
+                extra_data={"provider_type": "github", "provider_team_id": "platform"},
+                managed_fields=list(PROVIDER_MANAGED_FIELDS),
+                sync_policy=1,
+            )
+        )
+        await session.flush()
+
+        service = TeamDriftSyncService(session, "org-1")
+        result = await service.project_provider_teams(
+            "github",
+            [
+                ProviderTeam(
+                    id="gh:platform",
+                    name="New Platform",
+                    repo_patterns=["provider/*"],
+                    project_keys=["PROV"],
+                )
+            ],
+        )
+        mapping = await session.scalar(
+            select(TeamMapping).where(TeamMapping.team_id == "gh:platform")
+        )
+
+    assert result["flagged"] == 1
+    assert mapping is not None
+    assert mapping.name == "Old Platform"
+    assert mapping.repo_patterns == ["curated/*"]
+    assert mapping.project_keys == ["CUR"]
+    pending = mapping.flagged_changes["pending"]
+    assert {change["field"] for change in pending} == {
+        "name",
+        "repo_patterns",
+        "project_keys",
+    }
+
+
+@pytest.mark.asyncio
+async def test_project_provider_teams_does_not_seed_raw_member_identities(
+    session_maker,
+):
+    async with session_maker() as session:
+        service = TeamDriftSyncService(session, "org-1")
+        await service.project_provider_teams(
+            "github",
+            [ProviderTeam(id="gh:platform", name="Platform", members=["alice-gh"])],
+        )
+        identities = list((await session.execute(select(IdentityMapping))).scalars())
+
+    assert identities == []

--- a/tests/test_sync_team_parallel.py
+++ b/tests/test_sync_team_parallel.py
@@ -6,6 +6,8 @@ Covers the full capability registry: github, gitlab, jira, linear, ms-teams.
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -115,22 +117,14 @@ async def test_providers_discovered_concurrently(monkeypatch):
     assert sessions["open"] == 0, "Session leaked (not closed)"
 
 
-@pytest.mark.asyncio
-async def test_capability_registry_covers_all_supported_providers():
-    """The capability registry in _discover_and_sync_all must cover all 5 org-scoped providers.
-
-    This test is a static invariant: if a provider is added to providers/teams.py
-    sync_teams() but not to the worker registry, this test catches the drift.
-    """
+def test_worker_reads_team_capability_registry():
     import inspect
 
     from dev_health_ops.workers import sync_team as mod
 
     source = inspect.getsource(mod._discover_and_sync_all)
-    for provider in ("github", "gitlab", "jira", "linear", "ms-teams"):
-        assert provider in source, (
-            f"Provider '{provider}' missing from _discover_and_sync_all capability registry"
-        )
+    assert "org_drift_capable_providers()" in source
+    assert '("github", "gitlab", "jira", "linear", "ms-teams")' not in source
 
 
 def test_reconcile_team_members_uses_clickhouse_uri_and_preserves_org_scope():
@@ -140,5 +134,108 @@ def test_reconcile_team_members_uses_clickhouse_uri_and_preserves_org_scope():
 
     source = inspect.getsource(mod.reconcile_team_members)
     assert "require_clickhouse_uri()" in source
+    assert "bridge_teams_to_clickhouse" in source
     assert "_get_db_url" not in source
     assert 'org_id=str(getattr(team, "org_id"' in source
+
+
+def test_reconcile_team_members_matches_bridge_member_facets(monkeypatch):
+    from dev_health_ops.providers import team_bridge
+    from dev_health_ops.workers import sync_team as mod
+
+    identity_mappings = [
+        SimpleNamespace(
+            canonical_id="u1",
+            email="alice@example.com",
+            display_name="Alice Example",
+            provider_identities={"github": ["alice-gh"], "jira": ["alice-jira"]},
+            team_ids=["team-1"],
+        ),
+        SimpleNamespace(
+            canonical_id="u2",
+            email=None,
+            display_name="Bob Example",
+            provider_identities={"linear": ["bob-linear"]},
+            team_ids=["team-1"],
+        ),
+    ]
+    team_mapping = SimpleNamespace(
+        team_id="team-1",
+        name="Team One",
+        description="A team",
+        project_keys=[],
+        repo_patterns=[],
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    class Scalars:
+        def __init__(self, rows):
+            self.rows = rows
+
+        def scalars(self):
+            return self
+
+        def all(self):
+            return self.rows
+
+    class BridgeSession:
+        def __init__(self):
+            self.calls = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def execute(self, *_args):
+            self.calls += 1
+            return Scalars([team_mapping] if self.calls == 1 else identity_mappings)
+
+    class FakeStore:
+        inserted: list[list[dict[str, object]]] = []
+
+        def __init__(self, _uri):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+        async def insert_teams(self, teams: list[dict[str, object]]):
+            self.__class__.inserted.append(list(teams))
+
+    monkeypatch.setattr(
+        team_bridge, "get_postgres_session_sync", lambda: BridgeSession()
+    )
+    monkeypatch.setattr(team_bridge, "ClickHouseStore", FakeStore)
+    monkeypatch.setattr(
+        team_bridge, "_clickhouse_uri", lambda _db_url=None: "clickhouse://test"
+    )
+    monkeypatch.setattr(mod, "require_clickhouse_uri", lambda: "clickhouse://test")
+
+    getattr(mod.reconcile_team_members, "run")(org_id="org-1")
+    reconcile_payload_members = FakeStore.inserted.pop()[0]["members"]
+    assert isinstance(reconcile_payload_members, list)
+    reconcile_members = set(reconcile_payload_members)
+
+    team_bridge.bridge_teams_to_clickhouse(org_id="org-1")
+    bridge_payload_members = FakeStore.inserted.pop()[0]["members"]
+    assert isinstance(bridge_payload_members, list)
+    bridge_members = set(bridge_payload_members)
+
+    assert (
+        reconcile_members
+        == bridge_members
+        == {
+            "u1",
+            "alice@example.com",
+            "alice-gh",
+            "alice-jira",
+            "u2",
+            "bob-linear",
+            "Bob Example",
+        }
+    )

--- a/tests/test_team_capabilities.py
+++ b/tests/test_team_capabilities.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.providers.team_capabilities import (
+    org_drift_capable_providers,
+    team_provider_capabilities,
+)
+
+
+def test_org_team_drift_capability_registry_enumerates_supported_providers():
+    capabilities = {item.provider: item for item in team_provider_capabilities()}
+    assert tuple(capabilities) == ("github", "gitlab", "jira", "linear", "ms-teams")
+
+    for provider in ("github", "gitlab", "jira", "linear", "ms-teams"):
+        capability = capabilities[provider]
+        if not capability.supports_org_drift_discovery:
+            pytest.xfail(capability.unsupported_reason or f"{provider} unsupported")
+        assert provider in org_drift_capable_providers()


### PR DESCRIPTION
## Summary
- add `dev_health_ops.providers.team_capabilities` as the shared org-scoped team drift provider registry
- wire `sync_team_drift` to read drift-capable providers from the registry
- route org-scoped `reconcile_team_members` through `bridge_teams_to_clickhouse`, with the unscoped fallback using the shared `members_by_team` resolver
- add tests for registry coverage and reconcile/bridge member-facet equality

## Audit
- Admin create/import/approve routes enqueue `sync_teams_to_analytics`, which terminates in `bridge_teams_to_clickhouse`.
- `sync_teams_to_analytics` directly calls `bridge_teams_to_clickhouse`.
- Drift discovery persists Postgres drift state only; org-scoped CH refresh now goes through the bridge via reconciliation/task paths.
- `reconcile_team_members(org_id=...)` was aligned to terminate in `bridge_teams_to_clickhouse`.

## Verification
- `CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/test_sync_team_parallel.py tests/api/admin/test_teams.py tests/test_team_capabilities.py -q`
- `uv run --extra dev --python 3.11 mypy src/dev_health_ops/workers/sync_team.py src/dev_health_ops/workers/product_tasks.py src/dev_health_ops/providers/team_capabilities.py`
- `uv run --extra dev --python 3.11 ruff check src/dev_health_ops/workers/sync_team.py src/dev_health_ops/workers/product_tasks.py src/dev_health_ops/providers/team_capabilities.py tests/test_sync_team_parallel.py tests/test_team_capabilities.py`
- LSP diagnostics clean on changed files

Closes CHAOS-2406. Advances CHAOS-2405. Stacked on #976.

SCREENSHOT-WAIVER: backend worker/provider registry change only; no rendered UI impact.