### PR TITLE
refactor(teams): route CLI org sync through shared projection; drop CLI duplicates (CHAOS-2402, CHAOS-2403)

### DIFF
--- a/src/dev_health_ops/api/services/configuration/team_drift_sync.py
+++ b/src/dev_health_ops/api/services/configuration/team_drift_sync.py
@@ -7,9 +7,11 @@ for review (``sync_policy == 1``).
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.models.settings import TeamMapping
@@ -19,6 +21,18 @@ from .team_mapping import TeamMappingService
 if TYPE_CHECKING:
     from dev_health_ops.api.admin.schemas import DiscoveredTeam
 
+PROVIDER_MANAGED_FIELDS = ["name", "description", "repo_patterns", "project_keys"]
+
+
+@dataclass
+class _ProviderDiscoveredTeam:
+    provider_type: str
+    provider_team_id: str
+    name: str
+    description: str | None = None
+    member_count: int | None = None
+    associations: dict[str, Any] = field(default_factory=dict)
+
 
 class TeamDriftSyncService:
     """Compares discovered teams against stored TeamMappings and flags/merges changes."""
@@ -27,10 +41,97 @@ class TeamDriftSyncService:
         self.session = session
         self.org_id = org_id
 
+    async def project_provider_teams(
+        self,
+        provider: str,
+        teams_data: list[Any],
+        *,
+        replace_empty_provider_values: bool = False,
+    ) -> dict[str, Any]:
+        normalized_provider = str(provider or "config").lower()
+        discovered_teams = [
+            self._provider_team_to_discovered(normalized_provider, team)
+            for team in teams_data
+        ]
+        discovered_teams = [
+            team for team in discovered_teams if team.associations.get("team_id")
+        ]
+        if not discovered_teams:
+            return {
+                "provider": normalized_provider,
+                "projected": 0,
+                "created": 0,
+                "auto_applied": 0,
+                "flagged": 0,
+                "new_available": 0,
+                "provider_removed": 0,
+            }
+
+        team_svc = TeamMappingService(self.session, self.org_id)
+        existing_teams = await team_svc.list_all(active_only=True)
+        provider_lookup: dict[str, Any] = {}
+        team_lookup: dict[str, Any] = {}
+        for team in existing_teams:
+            ed = dict(team.extra_data or {})
+            if ed.get("provider_type") == normalized_provider:
+                provider_lookup[ed.get("provider_team_id", "")] = team
+            team_lookup[str(team.team_id)] = team
+
+        now = datetime.now(timezone.utc)
+        created = 0
+        for discovered in discovered_teams:
+            team_id = str(discovered.associations.get("team_id", "")).strip()
+            existing = provider_lookup.get(
+                discovered.provider_team_id
+            ) or team_lookup.get(team_id)
+            extra_data = self._provider_extra_data(
+                existing,
+                provider=normalized_provider,
+                provider_team_id=discovered.provider_team_id,
+                now=now,
+            )
+            if existing is None:
+                associations = discovered.associations or {}
+                self.session.add(
+                    TeamMapping(
+                        team_id=team_id,
+                        name=discovered.name,
+                        org_id=self.org_id,
+                        description=discovered.description,
+                        repo_patterns=list(associations.get("repo_patterns", [])),
+                        project_keys=list(associations.get("project_keys", [])),
+                        extra_data=extra_data,
+                        managed_fields=list(PROVIDER_MANAGED_FIELDS),
+                        is_active=True,
+                    )
+                )
+                created += 1
+                continue
+            existing.extra_data = extra_data
+            existing.is_active = True
+            existing.last_drift_sync_at = now
+
+        await self.session.flush()
+        result = await self.run_drift_sync(
+            normalized_provider,
+            discovered_teams,
+            replace_empty_provider_values=replace_empty_provider_values,
+        )
+        result["created"] = created
+        result["projected"] = await self._count_projected_team_ids(
+            [
+                str(team.associations.get("team_id", "")).strip()
+                for team in discovered_teams
+            ]
+        )
+        return result
+
     async def run_drift_sync(
         self,
         provider: str,
         discovered_teams: list[DiscoveredTeam],
+        *,
+        replace_empty_provider_values: bool = False,
     ) -> dict[str, Any]:
         team_svc = TeamMappingService(self.session, self.org_id)
         existing_teams: list[Any] = await team_svc.list_all(active_only=True)
@@ -57,7 +158,11 @@ class TeamDriftSyncService:
                 new_available += 1
                 continue
 
-            changes = self._compute_field_diffs(existing, disc_team)
+            changes = self._compute_field_diffs(
+                existing,
+                disc_team,
+                replace_empty_provider_values=replace_empty_provider_values,
+            )
             if not changes:
                 existing.last_drift_sync_at = now
                 continue
@@ -104,6 +209,8 @@ class TeamDriftSyncService:
         self,
         existing: TeamMapping,
         discovered: DiscoveredTeam,
+        *,
+        replace_empty_provider_values: bool = False,
     ) -> list[dict[str, Any]]:
         changes: list[dict[str, Any]] = []
         managed: list[str] = list(existing.managed_fields or [])
@@ -122,6 +229,16 @@ class TeamDriftSyncService:
             new_val = field_map[field_name]
             old_val = getattr(existing, field_name, None)
 
+            if (
+                field_name in {"repo_patterns", "project_keys"}
+                and not replace_empty_provider_values
+                and isinstance(old_val, list)
+                and old_val
+                and isinstance(new_val, list)
+                and not new_val
+            ):
+                continue
+
             if isinstance(old_val, list) and isinstance(new_val, list):
                 if sorted(old_val) == sorted(new_val):
                     continue
@@ -138,6 +255,92 @@ class TeamDriftSyncService:
             )
 
         return changes
+
+    async def _count_projected_team_ids(self, team_ids: list[str]) -> int:
+        expected_ids = {team_id for team_id in team_ids if team_id}
+        if not expected_ids:
+            return 0
+        result = await self.session.execute(
+            select(TeamMapping.team_id).where(
+                TeamMapping.org_id == self.org_id,
+                TeamMapping.team_id.in_(expected_ids),
+            )
+        )
+        return len(set(result.scalars()))
+
+    def _provider_team_to_discovered(self, provider: str, team: Any) -> Any:
+        team_id = str(self._team_value(team, "id", "") or "").strip()
+        team_name = str(self._team_value(team, "name", team_id) or team_id)
+        associations = {
+            "team_id": team_id,
+            "repo_patterns": self._team_string_list(team, "repo_patterns"),
+            "project_keys": self._project_keys_for_team(team_id, provider, team),
+        }
+        members = self._team_value(team, "members", []) or []
+        member_count = len(members) if isinstance(members, list) else None
+        return _ProviderDiscoveredTeam(
+            provider_type=provider,
+            provider_team_id=self._provider_team_id(team_id, provider),
+            name=team_name,
+            description=self._team_value(team, "description", None),
+            member_count=member_count,
+            associations=associations,
+        )
+
+    def _provider_extra_data(
+        self,
+        existing: Any | None,
+        *,
+        provider: str,
+        provider_team_id: str,
+        now: datetime,
+    ) -> dict[str, Any]:
+        extra_data = dict(getattr(existing, "extra_data", {}) or {})
+        extra_data.update(
+            {
+                "provider_type": provider,
+                "provider_team_id": provider_team_id,
+                "last_discovered_at": now.isoformat(),
+                "sync_source": "provider-projection",
+            }
+        )
+        return extra_data
+
+    @staticmethod
+    def _team_value(team: Any, field: str, default: Any = None) -> Any:
+        if isinstance(team, dict):
+            return team.get(field, default)
+        return getattr(team, field, default)
+
+    def _team_string_list(self, team: Any, field: str) -> list[str]:
+        value = self._team_value(team, field, [])
+        if not isinstance(value, list):
+            return []
+        return [str(item) for item in value if item]
+
+    def _project_keys_for_team(
+        self, team_id: str, provider: str, team: Any
+    ) -> list[str]:
+        configured = self._team_string_list(team, "project_keys")
+        if configured:
+            return configured
+        if provider == "jira":
+            return [team_id]
+        if provider == "linear" and team_id.startswith("linear:"):
+            return [team_id.removeprefix("linear:")]
+        return []
+
+    @staticmethod
+    def _provider_team_id(team_id: str, provider: str) -> str:
+        if provider == "github" and team_id.startswith("gh:"):
+            return team_id.removeprefix("gh:")
+        if provider == "gitlab" and team_id.startswith("gl:"):
+            return team_id.removeprefix("gl:")
+        if provider == "linear" and team_id.startswith("linear:"):
+            return team_id.removeprefix("linear:")
+        if provider == "ms-teams" and team_id.startswith("ms-teams:"):
+            return team_id.removeprefix("ms-teams:")
+        return team_id
 
     def _apply_changes(
         self,

--- a/src/dev_health_ops/api/services/configuration/team_member_resolver.py
+++ b/src/dev_health_ops/api/services/configuration/team_member_resolver.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def members_by_team(identity_mappings: Any) -> dict[str, set[str]]:
+    """Collect member identities per team from confirmed identity mappings.
+
+    The membership-based ``TeamResolver`` matches work-item assignees
+    (emails, provider logins/account ids) against ``teams.members`` in
+    ClickHouse, so every confirmed identity facet is included: email,
+    canonical_id, and all provider identities. ``display_name`` is used
+    only when no email exists (mirrors the worker ``sync_teams`` path and
+    avoids false-positive matches on common names).
+    """
+    members: dict[str, set[str]] = {}
+    for ident in identity_mappings:
+        identities: set[str] = set()
+        email = getattr(ident, "email", None)
+        if email:
+            identities.add(str(email))
+        canonical_id = getattr(ident, "canonical_id", None)
+        if canonical_id:
+            identities.add(str(canonical_id))
+        for values in (getattr(ident, "provider_identities", None) or {}).values():
+            if isinstance(values, list):
+                identities.update(str(v) for v in values if v)
+            elif values:
+                identities.add(str(values))
+        if not email:
+            display_name = getattr(ident, "display_name", None)
+            if display_name:
+                identities.add(str(display_name))
+        if not identities:
+            continue
+        for team_id in getattr(ident, "team_ids", None) or []:
+            key = str(team_id).strip()
+            if key:
+                members.setdefault(key, set()).update(identities)
+    return members

--- a/src/dev_health_ops/providers/team_bridge.py
+++ b/src/dev_health_ops/providers/team_bridge.py
@@ -8,49 +8,15 @@ from typing import Any
 
 from sqlalchemy import select
 
+from dev_health_ops.api.services.configuration.team_member_resolver import (
+    members_by_team as _members_by_team,
+)
 from dev_health_ops.db import (
     get_postgres_session_sync,
     get_postgres_session_sync_for_uri,
 )
 from dev_health_ops.models.settings import IdentityMapping, TeamMapping
 from dev_health_ops.storage.clickhouse import ClickHouseStore
-
-
-def _members_by_team(identity_mappings: Any) -> dict[str, set[str]]:
-    """Collect member identities per team from confirmed identity mappings.
-
-    The membership-based ``TeamResolver`` matches work-item assignees
-    (emails, provider logins/account ids) against ``teams.members`` in
-    ClickHouse, so every confirmed identity facet is included: email,
-    canonical_id, and all provider identities. ``display_name`` is used
-    only when no email exists (mirrors the worker ``sync_teams`` path and
-    avoids false-positive matches on common names).
-    """
-    members: dict[str, set[str]] = {}
-    for ident in identity_mappings:
-        identities: set[str] = set()
-        email = getattr(ident, "email", None)
-        if email:
-            identities.add(str(email))
-        canonical_id = getattr(ident, "canonical_id", None)
-        if canonical_id:
-            identities.add(str(canonical_id))
-        for values in (getattr(ident, "provider_identities", None) or {}).values():
-            if isinstance(values, list):
-                identities.update(str(v) for v in values if v)
-            elif values:
-                identities.add(str(values))
-        if not email:
-            display_name = getattr(ident, "display_name", None)
-            if display_name:
-                identities.add(str(display_name))
-        if not identities:
-            continue
-        for team_id in getattr(ident, "team_ids", None) or []:
-            key = str(team_id).strip()
-            if key:
-                members.setdefault(key, set()).update(identities)
-    return members
 
 
 def _parse_json_array(value: Any) -> list[str]:

--- a/src/dev_health_ops/providers/teams.py
+++ b/src/dev_health_ops/providers/teams.py
@@ -5,18 +5,16 @@ import importlib
 import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from dev_health_ops.db import (
-    get_postgres_session_sync_for_uri,
+    get_postgres_session,
     resolve_db_uri,
     resolve_sink_uri,
 )
-from dev_health_ops.models.settings import IdentityMapping, TeamMapping
 from dev_health_ops.models.teams import Team
 from dev_health_ops.storage import detect_db_type
 from dev_health_ops.utils.cli import add_sink_arg, validate_sink
@@ -643,10 +641,10 @@ def sync_teams(ns: argparse.Namespace) -> int:
         postgres_db_uri = resolve_db_uri(ns)
         postgres_bridge_count: int = 0
         try:
-            result = _bridge_teams_to_postgres(teams_data, ns)
-            postgres_bridge_count = result if result is not None else 0
-        except Exception as e:  # noqa: BLE001 - bridge failures must affect exit code
-            logging.error("Failed to bridge teams to PostgreSQL: %s", e)
+            projection_result = asyncio.run(_project_teams_to_postgres(teams_data, ns))
+            postgres_bridge_count = int(projection_result.get("projected", 0) or 0)
+        except Exception as e:  # noqa: BLE001 - projection failures must affect exit code
+            logging.error("Failed to project teams to PostgreSQL: %s", e)
             postgres_bridge_count = 0
 
         if postgres_bridge_count <= 0:
@@ -755,236 +753,34 @@ async def _count_persisted_teams(store: Any, teams_data: list) -> int:
     return len(expected_ids & persisted_ids)
 
 
-def _team_string_list(team: Any, field: str) -> list[str]:
-    value = team.get(field) if isinstance(team, dict) else getattr(team, field, [])
-    if not isinstance(value, list):
-        return []
-    return [str(item) for item in value if item]
-
-
-def _provider_team_id(team_id: str, provider: str) -> str:
-    if provider == "github" and team_id.startswith("gh:"):
-        return team_id.removeprefix("gh:")
-    if provider == "gitlab" and team_id.startswith("gl:"):
-        return team_id.removeprefix("gl:")
-    if provider == "linear" and team_id.startswith("linear:"):
-        return team_id.removeprefix("linear:")
-    if provider == "ms-teams" and team_id.startswith("ms-teams:"):
-        return team_id.removeprefix("ms-teams:")
-    return team_id
-
-
-def _project_keys_for_team(team_id: str, provider: str, team: Any) -> list[str]:
-    configured = _team_string_list(team, "project_keys")
-    if configured:
-        return configured
-    if provider == "jira":
-        return [team_id]
-    if provider == "linear" and team_id.startswith("linear:"):
-        return [team_id.removeprefix("linear:")]
-    return []
-
-
-def _team_members(team: Any) -> list[str]:
-    return [
-        str(member).strip()
-        for member in (getattr(team, "members", None) or [])
-        if str(member).strip()
-    ]
-
-
-def _team_members_complete(team: Any) -> bool:
-    return bool(getattr(team, "members_complete", False))
-
-
-def _identity_member_values(identity: Any) -> set[str]:
-    values: set[str] = set()
-    email = getattr(identity, "email", None)
-    if email:
-        values.add(str(email))
-    canonical_id = getattr(identity, "canonical_id", None)
-    if canonical_id:
-        values.add(str(canonical_id))
-    for provider_values in (
-        getattr(identity, "provider_identities", None) or {}
-    ).values():
-        if isinstance(provider_values, list):
-            values.update(str(value) for value in provider_values if value)
-        elif provider_values:
-            values.add(str(provider_values))
-    return values
-
-
-def _reconcile_team_member_identities(
-    session: Any,
-    *,
-    org_id: str,
-    team_id: str,
-    provider: str,
-    members: list[str],
-    members_complete: bool,
-) -> None:
-    desired_members = set(members)
-    if members_complete:
-        existing_identities = (
-            session.execute(
-                select(IdentityMapping).where(
-                    IdentityMapping.org_id == org_id,
-                    IdentityMapping.is_active.is_(True),
-                )
-            )
-            .scalars()
-            .all()
-        )
-        for identity in existing_identities:
-            provider_identities = dict(
-                getattr(identity, "provider_identities", {}) or {}
-            )
-            if provider not in provider_identities:
-                continue
-            team_ids = list(getattr(identity, "team_ids", []) or [])
-            if team_id not in team_ids:
-                continue
-            if _identity_member_values(identity) & desired_members:
-                continue
-            team_ids = [
-                existing_team_id
-                for existing_team_id in team_ids
-                if existing_team_id != team_id
-            ]
-            setattr(identity, "team_ids", team_ids)
-
-    for member in members:
-        existing = session.execute(
-            select(IdentityMapping).filter_by(org_id=org_id, canonical_id=member)
-        ).scalar_one_or_none()
-        if existing is None:
-            session.add(
-                IdentityMapping(
-                    org_id=org_id,
-                    canonical_id=member,
-                    email=member if "@" in member else None,
-                    display_name=None if "@" in member else member,
-                    provider_identities={provider: [member]},
-                    team_ids=[team_id],
-                    is_active=True,
-                )
-            )
-            continue
-
-        provider_identities = dict(getattr(existing, "provider_identities", {}) or {})
-        provider_members = list(provider_identities.get(provider) or [])
-        if member not in provider_members:
-            provider_members.append(member)
-        provider_identities[provider] = provider_members
-
-        team_ids = list(getattr(existing, "team_ids", []) or [])
-        if team_id not in team_ids:
-            team_ids.append(team_id)
-
-        setattr(existing, "provider_identities", provider_identities)
-        setattr(existing, "team_ids", team_ids)
-        setattr(existing, "is_active", True)
-
-
-def _bridge_teams_to_postgres(teams_data: list, ns: argparse.Namespace) -> int | None:
-    """Upsert provider-discovered teams into the org-scoped TeamMapping layer."""
-    import logging
+async def _project_teams_to_postgres(
+    teams_data: list, ns: argparse.Namespace
+) -> dict[str, Any]:
+    from dev_health_ops.api.services.configuration.team_drift_sync import (
+        TeamDriftSyncService,
+    )
 
     org_id = getattr(ns, "org", None)
     if org_id is None:
-        return None
+        return {"projected": 0}
     provider = str(getattr(ns, "provider", "config") or "config").lower()
+    if getattr(ns, "db", None):
+        engine = create_async_engine(resolve_db_uri(ns))
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        try:
+            async with factory() as session:
+                result = await TeamDriftSyncService(
+                    session, str(org_id)
+                ).project_provider_teams(provider, teams_data)
+                await session.commit()
+                return result
+        finally:
+            await engine.dispose()
 
-    expected_ids = {
-        str(getattr(team, "id", "") or "").strip() for team in teams_data
-    } - {""}
-    if not expected_ids:
-        return 0
-
-    try:
-        with get_postgres_session_sync_for_uri(resolve_db_uri(ns)) as session:
-            for team in teams_data:
-                team_id = str(getattr(team, "id", "")).strip()
-                if not team_id:
-                    continue
-
-                existing = session.execute(
-                    select(TeamMapping).filter_by(org_id=org_id, team_id=team_id)
-                ).scalar_one_or_none()
-
-                team_name = str(getattr(team, "name", team_id) or team_id)
-                team_description = getattr(team, "description", None)
-                repo_patterns = _team_string_list(team, "repo_patterns")
-                project_keys = _project_keys_for_team(team_id, provider, team)
-                members = _team_members(team)
-                members_complete = _team_members_complete(team)
-                extra_data = dict(getattr(existing, "extra_data", {}) or {})
-                extra_data.update(
-                    {
-                        "provider_type": provider,
-                        "provider_team_id": _provider_team_id(team_id, provider),
-                        "last_discovered_at": datetime.now(timezone.utc).isoformat(),
-                        "sync_source": "cli-sync-teams",
-                    }
-                )
-
-                if existing:
-                    managed_fields = set(getattr(existing, "managed_fields", []) or [])
-                    if getattr(existing, "sync_policy", 1) == 0:
-                        if "name" in managed_fields:
-                            setattr(existing, "name", team_name)
-                        if (
-                            "description" in managed_fields
-                            and team_description is not None
-                        ):
-                            setattr(existing, "description", team_description)
-                        if "repo_patterns" in managed_fields:
-                            setattr(existing, "repo_patterns", repo_patterns)
-                        if "project_keys" in managed_fields:
-                            setattr(existing, "project_keys", project_keys)
-                    setattr(existing, "is_active", True)
-                    setattr(existing, "extra_data", extra_data)
-                    setattr(existing, "last_drift_sync_at", datetime.now(timezone.utc))
-                else:
-                    session.add(
-                        TeamMapping(
-                            team_id=team_id,
-                            name=team_name,
-                            org_id=org_id,
-                            description=team_description,
-                            repo_patterns=repo_patterns,
-                            project_keys=project_keys,
-                            extra_data=extra_data,
-                            is_active=True,
-                        )
-                    )
-                _reconcile_team_member_identities(
-                    session,
-                    org_id=org_id,
-                    team_id=team_id,
-                    provider=provider,
-                    members=members,
-                    members_complete=members_complete,
-                )
-            session.flush()
-            persisted_ids = set(
-                session.execute(
-                    select(TeamMapping.team_id).where(
-                        TeamMapping.org_id == org_id,
-                        TeamMapping.team_id.in_(expected_ids),
-                    )
-                ).scalars()
-            )
-            logging.info(
-                "Bridged %d teams to PostgreSQL TeamMapping (org=%s).",
-                len(persisted_ids),
-                org_id,
-            )
-            return len(persisted_ids)
-    except Exception as e:
-        logging.error("Failed to bridge teams to PostgreSQL: %s", e)
-        return 0
+    async with get_postgres_session() as session:
+        return await TeamDriftSyncService(session, str(org_id)).project_provider_teams(
+            provider, teams_data
+        )
 
 
 def register_commands(sync_subparsers: argparse._SubParsersAction) -> None:

--- a/tests/api/admin/test_team_member_resolver.py
+++ b/tests/api/admin/test_team_member_resolver.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dev_health_ops.api.services.configuration.team_member_resolver import (
+    members_by_team,
+)
+from dev_health_ops.models.settings import IdentityMapping
+from dev_health_ops.providers.team_bridge import _members_by_team
+
+
+def test_members_by_team_preserves_confirmed_identity_facets():
+    identities = [
+        IdentityMapping(
+            canonical_id="u1",
+            org_id="org-1",
+            email="alice@example.com",
+            display_name="Alice Example",
+            provider_identities={"github": ["alice-gh"], "jira": ["alice-jira"]},
+            team_ids=["gh:platform"],
+        ),
+        IdentityMapping(
+            canonical_id="u2",
+            org_id="org-1",
+            display_name="Bob Example",
+            provider_identities={"github": ["bob-gh"]},
+            team_ids=["gh:platform"],
+        ),
+    ]
+
+    resolved = members_by_team(identities)
+
+    assert resolved == _members_by_team(identities)
+    assert resolved["gh:platform"] == {
+        "u1",
+        "alice@example.com",
+        "alice-gh",
+        "alice-jira",
+        "u2",
+        "bob-gh",
+        "Bob Example",
+    }
+    assert "unmapped-login" not in resolved["gh:platform"]

--- a/tests/api/admin/test_team_projection.py
+++ b/tests/api/admin/test_team_projection.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.services.configuration.team_drift_sync import (
+    PROVIDER_MANAGED_FIELDS,
+    TeamDriftSyncService,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import IdentityMapping, TeamMapping
+from tests._helpers import tables_of
+
+
+@dataclass
+class ProviderTeam:
+    id: str
+    name: str
+    description: str | None = None
+    repo_patterns: list[str] = field(default_factory=list)
+    project_keys: list[str] = field(default_factory=list)
+    members: list[str] = field(default_factory=list)
+    members_complete: bool = False
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "team_projection.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(TeamMapping, IdentityMapping),
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_project_provider_teams_creates_full_team_mapping(session_maker):
+    async with session_maker() as session:
+        service = TeamDriftSyncService(session, "org-1")
+        result = await service.project_provider_teams(
+            "github",
+            [
+                ProviderTeam(
+                    id="gh:platform",
+                    name="Platform",
+                    description="Platform team",
+                    repo_patterns=["platform/*"],
+                    project_keys=["PLAT"],
+                )
+            ],
+        )
+
+        mapping = await session.scalar(
+            select(TeamMapping).where(TeamMapping.team_id == "gh:platform")
+        )
+
+    assert result["created"] == 1
+    assert result["projected"] == 1
+    assert mapping is not None
+    assert mapping.name == "Platform"
+    assert mapping.description == "Platform team"
+    assert mapping.is_active is True
+    assert mapping.repo_patterns == ["platform/*"]
+    assert mapping.project_keys == ["PLAT"]
+    assert mapping.managed_fields == PROVIDER_MANAGED_FIELDS
+    assert mapping.extra_data == {
+        "provider_type": "github",
+        "provider_team_id": "platform",
+        "last_discovered_at": mapping.extra_data["last_discovered_at"],
+        "sync_source": "provider-projection",
+    }
+
+
+@pytest.mark.asyncio
+async def test_project_provider_teams_preserves_curated_empty_provider_values(
+    session_maker,
+):
+    async with session_maker() as session:
+        session.add(
+            TeamMapping(
+                team_id="gh:platform",
+                name="Old Platform",
+                org_id="org-1",
+                description="Old description",
+                repo_patterns=["curated/*"],
+                project_keys=["CUR"],
+                extra_data={"provider_type": "github", "provider_team_id": "platform"},
+                managed_fields=list(PROVIDER_MANAGED_FIELDS),
+                sync_policy=0,
+            )
+        )
+        await session.flush()
+
+        service = TeamDriftSyncService(session, "org-1")
+        await service.project_provider_teams(
+            "github",
+            [ProviderTeam(id="gh:platform", name="New Platform")],
+        )
+        mapping = await session.scalar(
+            select(TeamMapping).where(TeamMapping.team_id == "gh:platform")
+        )
+
+    assert mapping is not None
+    assert mapping.name == "New Platform"
+    assert mapping.description is None
+    assert mapping.repo_patterns == ["curated/*"]
+    assert mapping.project_keys == ["CUR"]
+
+
+@pytest.mark.asyncio
+async def test_project_provider_teams_explicit_replace_allows_empty_provider_values(
+    session_maker,
+):
+    async with session_maker() as session:
+        session.add(
+            TeamMapping(
+                team_id="gh:platform",
+                name="Old Platform",
+                org_id="org-1",
+                repo_patterns=["curated/*"],
+                project_keys=["CUR"],
+                extra_data={"provider_type": "github", "provider_team_id": "platform"},
+                managed_fields=list(PROVIDER_MANAGED_FIELDS),
+                sync_policy=0,
+            )
+        )
+        await session.flush()
+
+        service = TeamDriftSyncService(session, "org-1")
+        await service.project_provider_teams(
+            "github",
+            [ProviderTeam(id="gh:platform", name="New Platform")],
+            replace_empty_provider_values=True,
+        )
+        mapping = await session.scalar(
+            select(TeamMapping).where(TeamMapping.team_id == "gh:platform")
+        )
+
+    assert mapping is not None
+    assert mapping.repo_patterns == []
+    assert mapping.project_keys == []
+
+
+@pytest.mark.asyncio
+async def test_project_provider_teams_sync_policy_one_flags_without_applying(
+    session_maker,
+):
+    async with session_maker() as session:
+        session.add(
+            TeamMapping(
+                team_id="gh:platform",
+                name="Old Platform",
+                org_id="org-1",
+                repo_patterns=["curated/*"],
+                project_keys=["CUR"],
+                extra_data={"provider_type": "github", "provider_team_id": "platform"},
+                managed_fields=list(PROVIDER_MANAGED_FIELDS),
+                sync_policy=1,
+            )
+        )
+        await session.flush()
+
+        service = TeamDriftSyncService(session, "org-1")
+        result = await service.project_provider_teams(
+            "github",
+            [
+                ProviderTeam(
+                    id="gh:platform",
+                    name="New Platform",
+                    repo_patterns=["provider/*"],
+                    project_keys=["PROV"],
+                )
+            ],
+        )
+        mapping = await session.scalar(
+            select(TeamMapping).where(TeamMapping.team_id == "gh:platform")
+        )
+
+    assert result["flagged"] == 1
+    assert mapping is not None
+    assert mapping.name == "Old Platform"
+    assert mapping.repo_patterns == ["curated/*"]
+    assert mapping.project_keys == ["CUR"]
+    pending = mapping.flagged_changes["pending"]
+    assert {change["field"] for change in pending} == {
+        "name",
+        "repo_patterns",
+        "project_keys",
+    }
+
+
+@pytest.mark.asyncio
+async def test_project_provider_teams_does_not_seed_raw_member_identities(
+    session_maker,
+):
+    async with session_maker() as session:
+        service = TeamDriftSyncService(session, "org-1")
+        await service.project_provider_teams(
+            "github",
+            [ProviderTeam(id="gh:platform", name="Platform", members=["alice-gh"])],
+        )
+        identities = list((await session.execute(select(IdentityMapping))).scalars())
+
+    assert identities == []

--- a/tests/test_linear_team_sync.py
+++ b/tests/test_linear_team_sync.py
@@ -93,7 +93,7 @@ def _make_ns(
 class TestLinearTeamSync:
     """Tests for the linear branch inside sync_teams()."""
 
-    @patch("dev_health_ops.providers.teams._bridge_teams_to_postgres")
+    @patch("dev_health_ops.providers.teams._project_teams_to_postgres")
     @patch("dev_health_ops.providers.linear.client.LinearClient")
     def test_happy_path_two_teams(
         self,
@@ -102,7 +102,7 @@ class TestLinearTeamSync:
     ) -> None:
         """Happy path: two active teams with members → two Team objects created.
 
-        Org-scoped path (ns.org set): _bridge_teams_to_postgres is called directly;
+        Org-scoped path (ns.org set): _project_teams_to_postgres is called directly;
         asyncio.run is NOT called for the ClickHouse write (bridge_teams_to_clickhouse
         handles that internally).
         """
@@ -110,7 +110,7 @@ class TestLinearTeamSync:
 
         mock_client = MagicMock()
         mock_client_class.from_env.return_value = mock_client
-        mock_bridge.return_value = 2
+        mock_bridge.return_value = {"projected": 2}
         mock_client.iter_teams.return_value = [
             _mock_linear_team(
                 key="ENG",
@@ -141,7 +141,7 @@ class TestLinearTeamSync:
         assert "linear:ENG" in team_ids
         assert "linear:PROD" in team_ids
 
-    @patch("dev_health_ops.providers.teams._bridge_teams_to_postgres")
+    @patch("dev_health_ops.providers.teams._project_teams_to_postgres")
     @patch("dev_health_ops.providers.teams.resolve_sink_uri")
     @patch("dev_health_ops.providers.linear.client.LinearClient")
     def test_archived_teams_skipped(
@@ -156,7 +156,7 @@ class TestLinearTeamSync:
         mock_client = MagicMock()
         mock_client_class.from_env.return_value = mock_client
         mock_resolve_sink.return_value = "clickhouse://localhost:8123/default"
-        mock_bridge.return_value = 1
+        mock_bridge.return_value = {"projected": 1}
         mock_client.iter_teams.return_value = [
             _mock_linear_team(key="ARCH", name="Archived Team", archived=True),
             _mock_linear_team(
@@ -167,14 +167,10 @@ class TestLinearTeamSync:
         ]
 
         ns = _make_ns()
-        with (
-            patch("asyncio.run") as mock_run,
-            patch(
-                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
-                return_value=1,
-            ),
+        with patch(
+            "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+            return_value=1,
         ):
-            mock_run.side_effect = _close_coroutine
             result = sync_teams(ns)
 
         assert result == 0
@@ -182,7 +178,7 @@ class TestLinearTeamSync:
         assert len(teams_arg) == 1
         assert teams_arg[0].id == "linear:ENG"
 
-    @patch("dev_health_ops.providers.teams._bridge_teams_to_postgres")
+    @patch("dev_health_ops.providers.teams._project_teams_to_postgres")
     @patch("dev_health_ops.providers.teams.resolve_sink_uri")
     @patch("dev_health_ops.providers.linear.client.LinearClient")
     def test_empty_members_creates_team_with_empty_list(
@@ -197,20 +193,16 @@ class TestLinearTeamSync:
         mock_client = MagicMock()
         mock_client_class.from_env.return_value = mock_client
         mock_resolve_sink.return_value = "clickhouse://localhost:8123/default"
-        mock_bridge.return_value = 1
+        mock_bridge.return_value = {"projected": 1}
         mock_client.iter_teams.return_value = [
             _mock_linear_team(key="EMPTY", name="Empty Team", members=[]),
         ]
 
         ns = _make_ns()
-        with (
-            patch("asyncio.run") as mock_run,
-            patch(
-                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
-                return_value=1,
-            ),
+        with patch(
+            "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+            return_value=1,
         ):
-            mock_run.side_effect = _close_coroutine
             result = sync_teams(ns)
 
         assert result == 0
@@ -219,7 +211,7 @@ class TestLinearTeamSync:
         assert teams_arg[0].id == "linear:EMPTY"
         assert teams_arg[0].members == []
 
-    @patch("dev_health_ops.providers.teams._bridge_teams_to_postgres")
+    @patch("dev_health_ops.providers.teams._project_teams_to_postgres")
     @patch("dev_health_ops.providers.teams.resolve_sink_uri")
     @patch("dev_health_ops.providers.linear.client.LinearClient")
     def test_member_pagination_calls_get_team_members(
@@ -234,7 +226,7 @@ class TestLinearTeamSync:
         mock_client = MagicMock()
         mock_client_class.from_env.return_value = mock_client
         mock_resolve_sink.return_value = "clickhouse://localhost:8123/default"
-        mock_bridge.return_value = 1
+        mock_bridge.return_value = {"projected": 1}
 
         # Team with hasNextPage=True — only 1 member in initial nodes
         initial_member = _mock_member(name="Alice", email="alice@example.com")
@@ -253,14 +245,10 @@ class TestLinearTeamSync:
         mock_client.get_team_members.return_value = [initial_member, extra_member]
 
         ns = _make_ns()
-        with (
-            patch("asyncio.run") as mock_run,
-            patch(
-                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
-                return_value=1,
-            ),
+        with patch(
+            "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+            return_value=1,
         ):
-            mock_run.side_effect = _close_coroutine
             result = sync_teams(ns)
 
         assert result == 0
@@ -272,7 +260,7 @@ class TestLinearTeamSync:
         assert "alice@example.com" in teams_arg[0].members
         assert "bob@example.com" in teams_arg[0].members
 
-    @patch("dev_health_ops.providers.teams._bridge_teams_to_postgres")
+    @patch("dev_health_ops.providers.teams._project_teams_to_postgres")
     @patch("dev_health_ops.providers.teams.resolve_sink_uri")
     @patch("dev_health_ops.providers.linear.client.LinearClient")
     def test_partial_member_pagination_is_marked_incomplete(
@@ -286,7 +274,7 @@ class TestLinearTeamSync:
         mock_client = MagicMock()
         mock_client_class.from_env.return_value = mock_client
         mock_resolve_sink.return_value = "clickhouse://localhost:8123/default"
-        mock_bridge.return_value = 1
+        mock_bridge.return_value = {"projected": 1}
         initial_member = _mock_member(name="Alice", email="alice@example.com")
         mock_client.iter_teams.return_value = [
             _mock_linear_team(
@@ -300,14 +288,10 @@ class TestLinearTeamSync:
         mock_client.get_team_members.side_effect = RuntimeError("linear timeout")
 
         ns = _make_ns()
-        with (
-            patch("asyncio.run") as mock_run,
-            patch(
-                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
-                return_value=1,
-            ),
+        with patch(
+            "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+            return_value=1,
         ):
-            mock_run.side_effect = _close_coroutine
             result = sync_teams(ns)
 
         assert result == 0
@@ -330,7 +314,7 @@ class TestLinearTeamSync:
 
         assert result == 1
 
-    @patch("dev_health_ops.providers.teams._bridge_teams_to_postgres")
+    @patch("dev_health_ops.providers.teams._project_teams_to_postgres")
     @patch("dev_health_ops.providers.teams.resolve_sink_uri")
     @patch("dev_health_ops.providers.linear.client.LinearClient")
     def test_member_email_fallback_to_name(
@@ -345,7 +329,7 @@ class TestLinearTeamSync:
         mock_client = MagicMock()
         mock_client_class.from_env.return_value = mock_client
         mock_resolve_sink.return_value = "clickhouse://localhost:8123/default"
-        mock_bridge.return_value = 1
+        mock_bridge.return_value = {"projected": 1}
         mock_client.iter_teams.return_value = [
             _mock_linear_team(
                 key="ENG",
@@ -374,14 +358,10 @@ class TestLinearTeamSync:
         ]
 
         ns = _make_ns()
-        with (
-            patch("asyncio.run") as mock_run,
-            patch(
-                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
-                return_value=1,
-            ),
+        with patch(
+            "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+            return_value=1,
         ):
-            mock_run.side_effect = _close_coroutine
             result = sync_teams(ns)
 
         assert result == 0

--- a/tests/test_sync_teams_routing_invariants.py
+++ b/tests/test_sync_teams_routing_invariants.py
@@ -1,36 +1,9 @@
-"""Invariant tests for sync_teams routing (CHAOS-2401).
-
-Pins the two routing paths introduced by CHAOS-2401:
-
-Org-scoped path (``--org <id>`` present):
-    provider → _bridge_teams_to_postgres → bridge_teams_to_clickhouse
-    - run_with_store is NOT called (no direct ClickHouse write from provider data)
-    - _bridge_teams_to_postgres IS called and its count gates the exit code
-    - bridge_teams_to_clickhouse IS called with the correct org_id
-    - bridge_teams_to_clickhouse failure is fatal after PostgreSQL succeeds
-
-No-org path (``--org`` absent):
-    provider → run_with_store (direct ClickHouse write)
-    - _bridge_teams_to_postgres is NOT called
-    - bridge_teams_to_clickhouse is NOT called
-    - run_with_store IS called with org_id=None
-
-Membership invariants (bridge_teams_to_clickhouse):
-    - Reads TeamMapping + IdentityMapping from Postgres (org-scoped)
-    - Emits identity-resolved members (email, canonical_id, provider logins)
-    - Does not read from provider-supplied teams_data directly
-"""
-
 from __future__ import annotations
 
 import argparse
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 
 def _make_ns(
@@ -53,96 +26,10 @@ def _make_ns(
     return ns
 
 
-# ---------------------------------------------------------------------------
-# Org-scoped routing invariants
-# ---------------------------------------------------------------------------
-
-
 class TestOrgScopedRouting:
-    """Org-scoped sync must go through Postgres-first path."""
-
-    def test_org_scoped_does_not_call_run_with_store(self, tmp_path: Any) -> None:
-        """run_with_store must NOT be called for org-scoped syncs.
-
-        The org-scoped path is: _bridge_teams_to_postgres → bridge_teams_to_clickhouse.
-        run_with_store (direct ClickHouse write from provider data) must be bypassed.
-        """
-        import yaml
-
-        from dev_health_ops.providers.teams import sync_teams
-
-        config_file = tmp_path / "teams.yaml"
-        config_file.write_text(
-            yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
-        )
-
-        run_with_store_called = []
-
-        async def _spy_run_with_store(
-            _db_uri: str, _db_type: str, handler: Any, org_id: Any = None
-        ) -> int:
-            run_with_store_called.append(org_id)
-            return 1
-
-        with (
-            patch(
-                "dev_health_ops.providers.teams._bridge_teams_to_postgres",
-                return_value=1,
-            ),
-            patch(
-                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
-                return_value=1,
-            ),
-            patch(
-                "dev_health_ops.storage.run_with_store",
-                side_effect=_spy_run_with_store,
-            ),
-        ):
-            ns = _make_ns(org="org-1", path=str(config_file))
-            result = sync_teams(ns)
-
-        assert result == 0
-        assert run_with_store_called == [], (
-            "run_with_store must not be called on the org-scoped path"
-        )
-
-    def test_org_scoped_calls_bridge_to_postgres(self, tmp_path: Any) -> None:
-        """_bridge_teams_to_postgres must be called for org-scoped syncs."""
-        import yaml
-
-        from dev_health_ops.providers.teams import sync_teams
-
-        config_file = tmp_path / "teams.yaml"
-        config_file.write_text(
-            yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
-        )
-
-        pg_calls: list[Any] = []
-
-        def _spy_pg(teams_data: list, ns: Any) -> int:
-            pg_calls.append((teams_data, ns))
-            return len(teams_data)
-
-        with (
-            patch(
-                "dev_health_ops.providers.teams._bridge_teams_to_postgres",
-                side_effect=_spy_pg,
-            ),
-            patch(
-                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
-                return_value=1,
-            ),
-        ):
-            ns = _make_ns(org="org-1", path=str(config_file))
-            result = sync_teams(ns)
-
-        assert result == 0
-        assert len(pg_calls) == 1, "_bridge_teams_to_postgres must be called once"
-
-    def test_org_scoped_calls_bridge_to_clickhouse_with_org_id_and_db_url(
+    def test_org_scoped_projects_then_bridges_without_run_with_store(
         self, tmp_path: Any
     ) -> None:
-        """bridge_teams_to_clickhouse must receive org_id and requested DB URL."""
         import yaml
 
         from dev_health_ops.providers.teams import sync_teams
@@ -152,40 +39,117 @@ class TestOrgScopedRouting:
             yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
         )
 
-        captured_calls: list[tuple[str | None, str | None, str | None]] = []
+        projected_calls: list[tuple[str, list[Any]]] = []
+        ch_calls: list[tuple[str | None, str | None, str | None]] = []
+
+        class _FakeProjectionService:
+            def __init__(self, _session: Any, org_id: str) -> None:
+                self.org_id = org_id
+
+            async def project_provider_teams(
+                self,
+                provider: str,
+                teams_data: list[Any],
+                *,
+                replace_empty_provider_values: bool = False,
+            ) -> dict[str, Any]:
+                projected_calls.append((provider, teams_data))
+                return {"projected": len(teams_data)}
+
+        class _FakeSession:
+            async def __aenter__(self) -> _FakeSession:
+                return self
+
+            async def __aexit__(self, *args: Any) -> None:
+                pass
+
+            async def commit(self) -> None:
+                pass
+
+        class _FakeFactory:
+            def __call__(self) -> _FakeSession:
+                return _FakeSession()
+
+        class _FakeEngine:
+            async def dispose(self) -> None:
+                pass
 
         def _spy_ch(
             org_id: str | None = None,
             db_url: str | None = None,
             postgres_db_url: str | None = None,
         ) -> int:
-            captured_calls.append((org_id, db_url, postgres_db_url))
+            ch_calls.append((org_id, db_url, postgres_db_url))
             return 1
 
         with (
             patch(
-                "dev_health_ops.providers.teams._bridge_teams_to_postgres",
-                return_value=1,
+                "dev_health_ops.api.services.configuration.team_drift_sync.TeamDriftSyncService",
+                _FakeProjectionService,
             ),
             patch(
                 "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
                 side_effect=_spy_ch,
             ),
+            patch(
+                "dev_health_ops.storage.run_with_store",
+            ),
+            patch(
+                "dev_health_ops.providers.teams.create_async_engine",
+                return_value=_FakeEngine(),
+            ),
+            patch(
+                "dev_health_ops.providers.teams.async_sessionmaker",
+                return_value=_FakeFactory(),
+            ),
         ):
-            ns = _make_ns(org="org-42", path=str(config_file))
+            ns = _make_ns(org="org-1", path=str(config_file))
             result = sync_teams(ns)
 
         assert result == 0
-        assert captured_calls == [
+        assert len(projected_calls) == 1
+        provider, teams_arg = projected_calls[0]
+        assert provider == "config"
+        assert {getattr(team, "id", None) for team in teams_arg} == {"team-a"}
+        assert ch_calls == [
             (
-                "org-42",
+                "org-1",
                 "clickhouse://example.test:8123/default",
                 "sqlite+aiosqlite:///:memory:",
             )
-        ], "bridge_teams_to_clickhouse must receive the org_id and requested db URL"
+        ]
 
-    def test_org_scoped_postgres_bridge_failure_exits_one(self, tmp_path: Any) -> None:
-        """If _bridge_teams_to_postgres raises, exit code must be 1."""
+    def test_org_scoped_never_calls_run_with_store(self, tmp_path: Any) -> None:
+        import yaml
+
+        from dev_health_ops.providers.teams import sync_teams
+
+        config_file = tmp_path / "teams.yaml"
+        config_file.write_text(
+            yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
+        )
+
+        async def _projection(teams_data: list, ns: Any) -> dict[str, Any]:
+            return {"projected": len(teams_data)}
+
+        with (
+            patch(
+                "dev_health_ops.providers.teams._project_teams_to_postgres",
+                side_effect=_projection,
+            ),
+            patch(
+                "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+                return_value=1,
+            ),
+            patch("dev_health_ops.storage.run_with_store") as mock_run_with_store,
+        ):
+            ns = _make_ns(org="org-1", path=str(config_file))
+            result = sync_teams(ns)
+
+        assert result == 0
+        mock_run_with_store.assert_not_called()
+
+    def test_org_scoped_projection_failure_exits_one(self, tmp_path: Any) -> None:
         import yaml
 
         from dev_health_ops.providers.teams import sync_teams
@@ -196,7 +160,7 @@ class TestOrgScopedRouting:
         )
 
         with patch(
-            "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+            "dev_health_ops.providers.teams._project_teams_to_postgres",
             side_effect=RuntimeError("pg down"),
         ):
             ns = _make_ns(org="org-1", path=str(config_file))
@@ -204,10 +168,7 @@ class TestOrgScopedRouting:
 
         assert result == 1
 
-    def test_org_scoped_postgres_bridge_zero_count_exits_one(
-        self, tmp_path: Any
-    ) -> None:
-        """If _bridge_teams_to_postgres returns 0, exit code must be 1."""
+    def test_org_scoped_projection_zero_count_exits_one(self, tmp_path: Any) -> None:
         import yaml
 
         from dev_health_ops.providers.teams import sync_teams
@@ -218,8 +179,8 @@ class TestOrgScopedRouting:
         )
 
         with patch(
-            "dev_health_ops.providers.teams._bridge_teams_to_postgres",
-            return_value=0,
+            "dev_health_ops.providers.teams._project_teams_to_postgres",
+            return_value={"projected": 0},
         ):
             ns = _make_ns(org="org-1", path=str(config_file))
             result = sync_teams(ns)
@@ -240,8 +201,8 @@ class TestOrgScopedRouting:
 
         with (
             patch(
-                "dev_health_ops.providers.teams._bridge_teams_to_postgres",
-                return_value=1,
+                "dev_health_ops.providers.teams._project_teams_to_postgres",
+                return_value={"projected": 1},
             ),
             patch(
                 "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
@@ -253,10 +214,7 @@ class TestOrgScopedRouting:
 
         assert result == 1
 
-    def test_org_scoped_postgres_bridge_receives_provider_teams(
-        self, tmp_path: Any
-    ) -> None:
-        """_bridge_teams_to_postgres must receive the provider-built teams list."""
+    def test_org_scoped_projection_receives_provider_teams(self, tmp_path: Any) -> None:
         import yaml
 
         from dev_health_ops.providers.teams import sync_teams
@@ -275,14 +233,14 @@ class TestOrgScopedRouting:
 
         captured: list[Any] = []
 
-        def _spy_pg(teams_data: list, ns: Any) -> int:
+        async def _spy_projection(teams_data: list, ns: Any) -> dict[str, Any]:
             captured.extend(teams_data)
-            return len(teams_data)
+            return {"projected": len(teams_data)}
 
         with (
             patch(
-                "dev_health_ops.providers.teams._bridge_teams_to_postgres",
-                side_effect=_spy_pg,
+                "dev_health_ops.providers.teams._project_teams_to_postgres",
+                side_effect=_spy_projection,
             ),
             patch(
                 "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
@@ -297,16 +255,8 @@ class TestOrgScopedRouting:
         assert "ops" in team_ids
 
 
-# ---------------------------------------------------------------------------
-# No-org routing invariants
-# ---------------------------------------------------------------------------
-
-
 class TestNoOrgRouting:
-    """No-org sync must write directly to ClickHouse via run_with_store."""
-
-    def test_no_org_does_not_call_postgres_bridge(self, tmp_path: Any) -> None:
-        """_bridge_teams_to_postgres must NOT be called when org is absent."""
+    def test_no_org_calls_run_with_store_and_insert_teams(self, tmp_path: Any) -> None:
         import yaml
 
         from dev_health_ops.providers.teams import sync_teams
@@ -315,6 +265,7 @@ class TestNoOrgRouting:
         config_file.write_text(
             yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]})
         )
+        inserted: list[Any] = []
 
         async def _fake_run_with_store(
             _db_uri: str, _db_type: str, handler: Any, org_id: Any = None
@@ -324,7 +275,7 @@ class TestNoOrgRouting:
                     pass
 
                 async def insert_teams(self, teams: list) -> None:
-                    pass
+                    inserted.extend(teams)
 
                 async def get_all_teams(self) -> list:
                     return [SimpleNamespace(id="team-a", org_id=None)]
@@ -333,8 +284,8 @@ class TestNoOrgRouting:
 
         with (
             patch(
-                "dev_health_ops.providers.teams._bridge_teams_to_postgres"
-            ) as mock_pg,
+                "dev_health_ops.providers.teams._project_teams_to_postgres"
+            ) as mock_projection,
             patch(
                 "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse"
             ) as mock_ch,
@@ -356,11 +307,11 @@ class TestNoOrgRouting:
             result = sync_teams(ns)
 
         assert result == 0
-        mock_pg.assert_not_called()
+        assert [getattr(team, "id", None) for team in inserted] == ["team-a"]
+        mock_projection.assert_not_called()
         mock_ch.assert_not_called()
 
     def test_no_org_run_with_store_receives_org_id_none(self, tmp_path: Any) -> None:
-        """run_with_store must be called with org_id=None on the no-org path."""
         import yaml
 
         from dev_health_ops.providers.teams import sync_teams
@@ -403,7 +354,7 @@ class TestNoOrgRouting:
                 "dev_health_ops.providers.teams.detect_db_type",
                 return_value="clickhouse",
             ),
-            patch("dev_health_ops.providers.teams._bridge_teams_to_postgres"),
+            patch("dev_health_ops.providers.teams._project_teams_to_postgres"),
         ):
             ns = _make_ns(org=None, path=str(config_file))
             sync_teams(ns)
@@ -411,11 +362,6 @@ class TestNoOrgRouting:
         assert captured_org_ids == [None], (
             "run_with_store must be called with org_id=None on the no-org path"
         )
-
-
-# ---------------------------------------------------------------------------
-# bridge_teams_to_clickhouse membership invariants
-# ---------------------------------------------------------------------------
 
 
 class TestBridgeTeamsToClickhouseMembership:

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -349,7 +349,7 @@ def test_cli_sync_teams_org_bridge_failure_exits_one(tmp_path):
     )
 
     with patch(
-        "dev_health_ops.providers.teams._bridge_teams_to_postgres",
+        "dev_health_ops.providers.teams._project_teams_to_postgres",
         side_effect=RuntimeError("bridge down"),
     ):
         ns = MagicMock()
@@ -382,9 +382,9 @@ def test_cli_sync_teams_org_scoped_routes_through_postgres_then_clickhouse(tmp_p
 
     with (
         patch(
-            "dev_health_ops.providers.teams._bridge_teams_to_postgres",
-            return_value=1,
-        ) as mock_pg_bridge,
+            "dev_health_ops.providers.teams._project_teams_to_postgres",
+            return_value={"projected": 1},
+        ) as mock_projection,
         patch(
             "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
         ) as mock_ch_bridge,
@@ -402,354 +402,13 @@ def test_cli_sync_teams_org_scoped_routes_through_postgres_then_clickhouse(tmp_p
         result = _cmd_sync_teams(ns)
 
     assert result == 0
-    mock_pg_bridge.assert_called_once()
+    mock_projection.assert_called_once()
     mock_ch_bridge.assert_called_once_with(
         org_id="org-1",
         db_url=ns.analytics_db,
         postgres_db_url="sqlite+aiosqlite:///semantic.db",
     )
-    # Direct ClickHouse write must NOT be called for org-scoped runs.
     mock_run_with_store.assert_not_called()
-
-
-def test_bridge_teams_to_postgres_creates_full_mapping_metadata():
-    from argparse import Namespace
-
-    from dev_health_ops.models.settings import TeamMapping
-    from dev_health_ops.models.teams import Team
-    from dev_health_ops.providers.teams import _bridge_teams_to_postgres
-
-    added: list[TeamMapping] = []
-
-    class FakeScalarResult:
-        def __init__(self, rows):
-            self._rows = rows
-
-        def scalar_one_or_none(self):
-            return self._rows[0] if self._rows else None
-
-        def scalars(self):
-            return self
-
-        def __iter__(self):
-            return iter(self._rows)
-
-        def all(self):
-            return self._rows
-
-    class FakeSession:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            return None
-
-        def execute(self, _stmt):
-            if added:
-                return FakeScalarResult([team.team_id for team in added])
-            return FakeScalarResult([])
-
-        def add(self, item):
-            added.append(item)
-
-        def flush(self):
-            return None
-
-    team = Team(id="linear:ENG", name="Engineering", description="Eng team")
-    ns = Namespace(org="org-1", provider="linear")
-
-    with patch(
-        "dev_health_ops.providers.teams.get_postgres_session_sync_for_uri",
-        return_value=FakeSession(),
-    ):
-        count = _bridge_teams_to_postgres([team], ns)
-
-    assert count == 1
-    assert added[0].project_keys == ["ENG"]
-    added_extra = added[0].extra_data or {}
-    assert added_extra["provider_type"] == "linear"
-    assert added_extra["provider_team_id"] == "ENG"
-
-
-def test_bridge_teams_to_postgres_persists_provider_members_as_identities():
-    from argparse import Namespace
-
-    from dev_health_ops.models.settings import IdentityMapping, TeamMapping
-    from dev_health_ops.models.teams import Team
-    from dev_health_ops.providers.teams import _bridge_teams_to_postgres
-
-    added = []
-
-    class FakeScalarResult:
-        def __init__(self, rows):
-            self._rows = rows
-
-        def scalar_one_or_none(self):
-            return self._rows[0] if self._rows else None
-
-        def scalars(self):
-            return self
-
-        def __iter__(self):
-            return iter(self._rows)
-
-        def all(self):
-            return self._rows
-
-    class FakeSession:
-        def __init__(self):
-            self.calls = 0
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            return None
-
-        def execute(self, _stmt):
-            self.calls += 1
-            if self.calls in (1, 2):
-                return FakeScalarResult([])
-            return FakeScalarResult(["linear:ENG"])
-
-        def add(self, item):
-            added.append(item)
-
-        def flush(self):
-            return None
-
-    team = Team(
-        id="linear:ENG",
-        name="Engineering",
-        description="Eng team",
-        members=["alice@example.com"],
-    )
-    ns = Namespace(org="org-1", provider="linear")
-
-    with patch(
-        "dev_health_ops.providers.teams.get_postgres_session_sync_for_uri",
-        return_value=FakeSession(),
-    ):
-        count = _bridge_teams_to_postgres([team], ns)
-
-    assert count == 1
-    identity = next(item for item in added if isinstance(item, IdentityMapping))
-    assert any(isinstance(item, TeamMapping) for item in added)
-    assert identity.org_id == "org-1"
-    assert identity.canonical_id == "alice@example.com"
-    assert identity.email == "alice@example.com"
-    assert identity.provider_identities == {"linear": ["alice@example.com"]}
-    assert identity.team_ids == ["linear:ENG"]
-
-
-def test_bridge_teams_to_postgres_removes_absent_provider_members():
-    from argparse import Namespace
-
-    from dev_health_ops.models.settings import IdentityMapping, TeamMapping
-    from dev_health_ops.models.teams import Team
-    from dev_health_ops.providers.teams import _bridge_teams_to_postgres
-
-    existing_mapping = TeamMapping(
-        team_id="linear:ENG",
-        name="Engineering",
-        org_id="org-1",
-        extra_data={"provider_type": "linear"},
-    )
-    existing_identity = IdentityMapping(
-        org_id="org-1",
-        canonical_id="alice@example.com",
-        email="alice@example.com",
-        provider_identities={"linear": ["alice@example.com"]},
-        team_ids=["linear:ENG"],
-    )
-
-    class FakeScalarResult:
-        def __init__(self, rows):
-            self._rows = rows
-
-        def scalar_one_or_none(self):
-            return self._rows[0] if self._rows else None
-
-        def scalars(self):
-            return self
-
-        def __iter__(self):
-            return iter(self._rows)
-
-        def all(self):
-            return self._rows
-
-    class FakeSession:
-        def __init__(self):
-            self.calls = 0
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            return None
-
-        def execute(self, _stmt):
-            self.calls += 1
-            if self.calls == 1:
-                return FakeScalarResult([existing_mapping])
-            if self.calls == 2:
-                return FakeScalarResult([existing_identity])
-            return FakeScalarResult(["linear:ENG"])
-
-        def flush(self):
-            return None
-
-    team = Team(id="linear:ENG", name="Engineering", members=[])
-    setattr(team, "members_complete", True)
-    ns = Namespace(org="org-1", provider="linear")
-
-    with patch(
-        "dev_health_ops.providers.teams.get_postgres_session_sync_for_uri",
-        return_value=FakeSession(),
-    ):
-        count = _bridge_teams_to_postgres([team], ns)
-
-    assert count == 1
-    assert existing_identity.team_ids == []
-
-
-def test_bridge_teams_to_postgres_preserves_members_for_incomplete_snapshot():
-    from argparse import Namespace
-
-    from dev_health_ops.models.settings import IdentityMapping, TeamMapping
-    from dev_health_ops.models.teams import Team
-    from dev_health_ops.providers.teams import _bridge_teams_to_postgres
-
-    existing_mapping = TeamMapping(team_id="OPS", name="Ops", org_id="org-1")
-    existing_identity = IdentityMapping(
-        org_id="org-1",
-        canonical_id="alice@example.com",
-        email="alice@example.com",
-        provider_identities={"jira": ["alice-account"]},
-        team_ids=["OPS"],
-    )
-
-    class FakeScalarResult:
-        def __init__(self, rows):
-            self._rows = rows
-
-        def scalar_one_or_none(self):
-            return self._rows[0] if self._rows else None
-
-        def scalars(self):
-            return self
-
-        def __iter__(self):
-            return iter(self._rows)
-
-        def all(self):
-            return self._rows
-
-    class FakeSession:
-        def __init__(self):
-            self.calls = 0
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            return None
-
-        def execute(self, _stmt):
-            self.calls += 1
-            if self.calls == 1:
-                return FakeScalarResult([existing_mapping])
-            return FakeScalarResult(["OPS"])
-
-        def flush(self):
-            return None
-
-    team = Team(id="OPS", name="Ops", members=[])
-    ns = Namespace(org="org-1", provider="jira")
-
-    with patch(
-        "dev_health_ops.providers.teams.get_postgres_session_sync_for_uri",
-        return_value=FakeSession(),
-    ):
-        count = _bridge_teams_to_postgres([team], ns)
-
-    assert count == 1
-    assert existing_identity.team_ids == ["OPS"]
-
-
-def test_bridge_teams_to_postgres_preserves_curated_mapping_fields():
-    from argparse import Namespace
-
-    from dev_health_ops.models.settings import TeamMapping
-    from dev_health_ops.models.teams import Team
-    from dev_health_ops.providers.teams import _bridge_teams_to_postgres
-
-    existing = TeamMapping(
-        team_id="linear:ENG",
-        name="Curated Engineering",
-        org_id="org-1",
-        description="Curated description",
-        project_keys=["KEEP"],
-        repo_patterns=["full-chaos/*"],
-        extra_data={"owner": "admin"},
-        sync_policy=1,
-    )
-
-    class FakeScalarResult:
-        def __init__(self, rows):
-            self._rows = rows
-
-        def scalar_one_or_none(self):
-            return self._rows[0] if self._rows else None
-
-        def scalars(self):
-            return self
-
-        def __iter__(self):
-            return iter(self._rows)
-
-        def all(self):
-            return self._rows
-
-    class FakeSession:
-        def __init__(self):
-            self.calls = 0
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            return None
-
-        def execute(self, _stmt):
-            self.calls += 1
-            if self.calls == 1:
-                return FakeScalarResult([existing])
-            return FakeScalarResult([existing.team_id])
-
-        def flush(self):
-            return None
-
-    team = Team(
-        id="linear:ENG", name="Provider Engineering", description="Provider desc"
-    )
-    ns = Namespace(org="org-1", provider="linear")
-
-    with patch(
-        "dev_health_ops.providers.teams.get_postgres_session_sync_for_uri",
-        return_value=FakeSession(),
-    ):
-        count = _bridge_teams_to_postgres([team], ns)
-
-    assert count == 1
-    assert existing.name == "Curated Engineering"
-    assert existing.description == "Curated description"
-    assert existing.project_keys == ["KEEP"]
-    assert existing.repo_patterns == ["full-chaos/*"]
-    existing_extra = existing.extra_data or {}
-    assert existing_extra["owner"] == "admin"
-    assert existing_extra["provider_type"] == "linear"
 
 
 def test_cli_sync_teams_org_scoped_ch_bridge_failure_exits_one(tmp_path):
@@ -764,8 +423,8 @@ def test_cli_sync_teams_org_scoped_ch_bridge_failure_exits_one(tmp_path):
 
     with (
         patch(
-            "dev_health_ops.providers.teams._bridge_teams_to_postgres",
-            return_value=1,
+            "dev_health_ops.providers.teams._project_teams_to_postgres",
+            return_value={"projected": 1},
         ),
         patch(
             "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
@@ -830,8 +489,8 @@ def test_cli_sync_teams_org_scoped_jira_ops_links_written_after_bridge():
             return_value=iter([project]),
         ),
         patch(
-            "dev_health_ops.providers.teams._bridge_teams_to_postgres",
-            return_value=1,
+            "dev_health_ops.providers.teams._project_teams_to_postgres",
+            return_value={"projected": 1},
         ),
         patch(
             "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
@@ -857,39 +516,6 @@ def test_cli_sync_teams_org_scoped_jira_ops_links_written_after_bridge():
     assert len(captured) == 1
     assert captured[0].project_key == "OPS"
     assert captured[0].ops_team_id == "team-1"
-
-
-def test_bridge_teams_to_postgres_uses_requested_semantic_db_url():
-    from argparse import Namespace
-
-    from dev_health_ops.models.teams import Team
-    from dev_health_ops.providers.teams import _bridge_teams_to_postgres
-
-    class FakeSession:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *args):
-            return None
-
-        def execute(self, _stmt):
-            raise AssertionError("session should not be used in this routing test")
-
-    with patch(
-        "dev_health_ops.providers.teams.get_postgres_session_sync_for_uri",
-        return_value=FakeSession(),
-    ) as mock_session_for_uri:
-        _bridge_teams_to_postgres(
-            [Team(id="team-a", name="Team A")],
-            Namespace(
-                org="org-1",
-                provider="config",
-                db="sqlite:///semantic.db",
-                analytics_db="clickhouse://analytics.example/default",
-            ),
-        )
-
-    mock_session_for_uri.assert_called_once_with("sqlite+aiosqlite:///semantic.db")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Route org-scoped sync teams through TeamDriftSyncService.project_provider_teams before bridge_teams_to_clickhouse.
- Delete CLI-local Postgres projection and identity reconciliation helpers from providers/teams.py.
- Rewrite routing invariants to assert shared projection + bridge for org sync and direct run_with_store/insert_teams for no-org sync.

## Verification
- CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/test_sync_teams_routing_invariants.py tests/test_teams.py tests/test_linear_team_sync.py -q
- uv run --extra dev --python 3.11 mypy src/dev_health_ops/providers/teams.py
- uv run --extra dev --python 3.11 ruff check src/dev_health_ops/providers/teams.py tests/test_sync_teams_routing_invariants.py
- LSP diagnostics clean on changed files

Closes CHAOS-2402.
Closes CHAOS-2403.
Stacked on #976.