### PR TITLE
feat(teams): reconcile command + invariant guard tests + projection hardening (CHAOS-2407, CHAOS-2409)

### DIFF
--- a/src/dev_health_ops/api/services/configuration/team_drift_sync.py
+++ b/src/dev_health_ops/api/services/configuration/team_drift_sync.py
@@ -7,6 +7,7 @@ for review (``sync_policy == 1``).
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
     from dev_health_ops.api.admin.schemas import DiscoveredTeam
 
 PROVIDER_MANAGED_FIELDS = ["name", "description", "repo_patterns", "project_keys"]
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -48,14 +50,30 @@ class TeamDriftSyncService:
         *,
         replace_empty_provider_values: bool = False,
     ) -> dict[str, Any]:
+        """Project provider-discovered teams into Postgres TeamMapping rows.
+
+        This entrypoint intentionally creates missing TeamMapping rows for CLI
+        provider projections so org-scoped syncs have a control-plane record to
+        bridge into ClickHouse. Worker/admin drift discovery keeps its approval
+        workflow: missing provider teams are reported as ``new_available`` by
+        ``run_drift_sync`` until an admin imports them. Both paths share the
+        same field diff and merge implementation for existing mappings.
+        """
         normalized_provider = str(provider or "config").lower()
-        discovered_teams = [
-            self._provider_team_to_discovered(normalized_provider, team)
-            for team in teams_data
-        ]
-        discovered_teams = [
-            team for team in discovered_teams if team.associations.get("team_id")
-        ]
+        discovered_teams: list[Any] = []
+        for team in teams_data:
+            discovered = self._provider_team_to_discovered(normalized_provider, team)
+            if not discovered.associations.get("team_id"):
+                logger.warning(
+                    "Dropping provider team without derivable team_id "
+                    "(provider=%s, provider_team_id=%r, name=%r, item=%r)",
+                    normalized_provider,
+                    getattr(discovered, "provider_team_id", None),
+                    getattr(discovered, "name", None),
+                    team,
+                )
+                continue
+            discovered_teams.append(discovered)
         if not discovered_teams:
             return {
                 "provider": normalized_provider,
@@ -269,18 +287,39 @@ class TeamDriftSyncService:
         return len(set(result.scalars()))
 
     def _provider_team_to_discovered(self, provider: str, team: Any) -> Any:
-        team_id = str(self._team_value(team, "id", "") or "").strip()
+        input_associations = self._team_value(team, "associations", {}) or {}
+        associations = (
+            dict(input_associations) if isinstance(input_associations, dict) else {}
+        )
+        team_id = str(
+            self._team_value(
+                team,
+                "id",
+                associations.get(
+                    "team_id", self._team_value(team, "provider_team_id", "")
+                ),
+            )
+            or ""
+        ).strip()
+        provider_team_id = str(
+            self._team_value(team, "provider_team_id", "")
+            or self._provider_team_id(team_id, provider)
+        ).strip()
         team_name = str(self._team_value(team, "name", team_id) or team_id)
-        associations = {
-            "team_id": team_id,
-            "repo_patterns": self._team_string_list(team, "repo_patterns"),
-            "project_keys": self._project_keys_for_team(team_id, provider, team),
-        }
+        associations.setdefault("team_id", team_id)
+        associations.setdefault(
+            "repo_patterns", self._team_string_list(team, "repo_patterns")
+        )
+        associations.setdefault(
+            "project_keys", self._project_keys_for_team(team_id, provider, team)
+        )
         members = self._team_value(team, "members", []) or []
-        member_count = len(members) if isinstance(members, list) else None
+        member_count = self._team_value(team, "member_count", None)
+        if member_count is None:
+            member_count = len(members) if isinstance(members, list) else None
         return _ProviderDiscoveredTeam(
             provider_type=provider,
-            provider_team_id=self._provider_team_id(team_id, provider),
+            provider_team_id=provider_team_id,
             name=team_name,
             description=self._team_value(team, "description", None),
             member_count=member_count,

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -417,6 +417,7 @@ _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     ("sync", "tests"): frozenset({_REQ_CLICKHOUSE}),
     ("sync", "work-items"): frozenset({_REQ_CLICKHOUSE}),
     ("sync", "teams"): frozenset({_REQ_CLICKHOUSE}),
+    ("teams", "reconcile"): frozenset({_REQ_CLICKHOUSE, _REQ_POSTGRES, _REQ_ORG}),
     # --- audit (read ClickHouse analytics store) ---
     ("audit", "perf"): frozenset({_REQ_CLICKHOUSE}),
     ("audit", "schema"): frozenset({_REQ_CLICKHOUSE}),
@@ -599,6 +600,7 @@ def build_parser() -> argparse.ArgumentParser:
         job_work_items,
     )
     from dev_health_ops.processors import sync as sync_processor
+    from dev_health_ops.providers import team_reconcile
     from dev_health_ops.providers import teams as teams_provider
     from dev_health_ops.work_graph import runner as work_graph_runner
     from dev_health_ops.workers import runner as workers_runner
@@ -674,6 +676,8 @@ def build_parser() -> argparse.ArgumentParser:
     api_runner.register_commands(sub)
 
     billing_cli.register_commands(sub)
+
+    team_reconcile.register_commands(sub)
 
     # ---- admin (user/org management) ----
     admin_cli.register_commands(sub)

--- a/src/dev_health_ops/providers/team_reconcile.py
+++ b/src/dev_health_ops/providers/team_reconcile.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from dev_health_ops.db import resolve_db_uri, resolve_sink_uri
+from dev_health_ops.models.settings import TeamMapping
+from dev_health_ops.storage.clickhouse import ClickHouseStore
+from dev_health_ops.utils.cli import validate_sink
+
+logger = logging.getLogger(__name__)
+
+
+def _team_value(team: Any, field: str, default: Any = None) -> Any:
+    if isinstance(team, dict):
+        return team.get(field, default)
+    return getattr(team, field, default)
+
+
+def _team_list(team: Any, field: str) -> list[str]:
+    value = _team_value(team, field, []) or []
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if item]
+
+
+async def _clickhouse_org_teams(org_id: str, db_url: str) -> list[Any]:
+    async with ClickHouseStore(db_url) as store:
+        store.org_id = org_id
+        teams = await store.get_all_teams()
+    return [
+        team for team in teams if str(_team_value(team, "org_id", "") or "") == org_id
+    ]
+
+
+async def find_unmapped_clickhouse_teams(
+    org_id: str,
+    *,
+    db_url: str,
+    postgres_db_url: str,
+) -> list[str]:
+    ch_teams = await _clickhouse_org_teams(org_id, db_url)
+    ch_team_ids = {
+        str(_team_value(team, "id", "") or "").strip()
+        for team in ch_teams
+        if str(_team_value(team, "id", "") or "").strip()
+    }
+    if not ch_team_ids:
+        return []
+
+    engine = create_async_engine(postgres_db_url)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with factory() as session:
+            result = await session.execute(
+                select(TeamMapping.team_id).where(
+                    TeamMapping.org_id == org_id,
+                    TeamMapping.team_id.in_(ch_team_ids),
+                )
+            )
+            mapped_ids = {str(team_id) for team_id in result.scalars()}
+    finally:
+        await engine.dispose()
+    return sorted(ch_team_ids - mapped_ids)
+
+
+async def reconcile_clickhouse_teams_to_postgres(
+    org_id: str,
+    *,
+    db_url: str,
+    postgres_db_url: str,
+) -> dict[str, Any]:
+    ch_teams = await _clickhouse_org_teams(org_id, db_url)
+    engine = create_async_engine(postgres_db_url)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    created = 0
+    existing = 0
+    unmanaged: list[str] = []
+    missing_before: list[str] = []
+
+    try:
+        async with factory() as session:
+            for team in ch_teams:
+                team_id = str(_team_value(team, "id", "") or "").strip()
+                if not team_id:
+                    unmanaged.append(
+                        str(_team_value(team, "name", "<unnamed>") or "<unnamed>")
+                    )
+                    continue
+
+                mapping = await session.scalar(
+                    select(TeamMapping).where(
+                        TeamMapping.org_id == org_id,
+                        TeamMapping.team_id == team_id,
+                    )
+                )
+                if mapping is not None:
+                    existing += 1
+                    continue
+
+                missing_before.append(team_id)
+                session.add(
+                    TeamMapping(
+                        team_id=team_id,
+                        name=str(_team_value(team, "name", team_id) or team_id),
+                        org_id=org_id,
+                        description=_team_value(team, "description", None),
+                        repo_patterns=_team_list(team, "repo_patterns"),
+                        project_keys=_team_list(team, "project_keys"),
+                        extra_data={
+                            "provider_type": "clickhouse",
+                            "provider_team_id": team_id,
+                            "sync_source": "teams-reconcile",
+                        },
+                        managed_fields=[],
+                        sync_policy=2,
+                        is_active=True,
+                    )
+                )
+                created += 1
+            await session.commit()
+    finally:
+        await engine.dispose()
+
+    from dev_health_ops.providers.team_bridge import bridge_teams_to_clickhouse
+
+    bridged = bridge_teams_to_clickhouse(
+        org_id=org_id,
+        db_url=db_url,
+        postgres_db_url=postgres_db_url,
+    )
+    missing_after = await find_unmapped_clickhouse_teams(
+        org_id,
+        db_url=db_url,
+        postgres_db_url=postgres_db_url,
+    )
+    return {
+        "org_id": org_id,
+        "clickhouse_teams": len(ch_teams),
+        "created": created,
+        "existing": existing,
+        "unmanaged": unmanaged,
+        "missing_before": missing_before,
+        "missing_after": missing_after,
+        "bridged": bridged,
+    }
+
+
+def reconcile_teams(ns: argparse.Namespace) -> int:
+    validate_sink(ns)
+    org_id = str(getattr(ns, "org", "") or "").strip()
+    result = asyncio.run(
+        reconcile_clickhouse_teams_to_postgres(
+            org_id,
+            db_url=resolve_sink_uri(ns),
+            postgres_db_url=resolve_db_uri(ns),
+        )
+    )
+    logger.info(
+        "teams reconcile complete: org=%s ch=%d created=%d existing=%d bridged=%d missing_after=%d unmanaged=%d",
+        org_id,
+        result["clickhouse_teams"],
+        result["created"],
+        result["existing"],
+        result["bridged"],
+        len(result["missing_after"]),
+        len(result["unmanaged"]),
+    )
+    if result["unmanaged"]:
+        logger.warning(
+            "teams reconcile skipped unmanaged ClickHouse rows without team ids: %s",
+            ", ".join(result["unmanaged"]),
+        )
+    return 0 if not result["missing_after"] else 1
+
+
+def register_commands(subparsers: argparse._SubParsersAction) -> None:
+    teams = subparsers.add_parser("teams", help="Team catalog operations.")
+    teams_subparsers = teams.add_subparsers(dest="teams_command", required=True)
+    reconcile = teams_subparsers.add_parser(
+        "reconcile",
+        help="Reconcile org-scoped ClickHouse teams into Postgres TeamMappings.",
+    )
+    reconcile.set_defaults(func=reconcile_teams)

--- a/src/dev_health_ops/providers/teams.py
+++ b/src/dev_health_ops/providers/teams.py
@@ -633,6 +633,29 @@ def sync_teams(ns: argparse.Namespace) -> int:
     org_id = getattr(ns, "org", None)
 
     if org_id is not None:
+        from dev_health_ops.providers.team_capabilities import (
+            org_drift_capable_providers,
+            team_provider_capabilities,
+        )
+
+        capabilities = {
+            capability.provider: capability
+            for capability in team_provider_capabilities()
+        }
+        capable_providers = set(org_drift_capable_providers())
+        if provider not in capable_providers:
+            capability = capabilities.get(provider)
+            reason = (
+                capability.unsupported_reason
+                if capability and capability.unsupported_reason
+                else "provider is not registered for org drift discovery"
+            )
+            logging.info(
+                "Provider %s is unsupported for org drift discovery: %s. "
+                "Continuing org-scoped projection path.",
+                provider,
+                reason,
+            )
         # Org-scoped path: provider -> Postgres TeamMapping -> bridge_teams_to_clickhouse.
         # Never write ClickHouse directly; the bridge reads from Postgres so the
         # semantic layer is always the source of truth for org-scoped teams.

--- a/tests/api/admin/test_team_projection.py
+++ b/tests/api/admin/test_team_projection.py
@@ -8,6 +8,7 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from dev_health_ops.api.admin.schemas_flat import DiscoveredTeam
 from dev_health_ops.api.services.configuration.team_drift_sync import (
     PROVIDER_MANAGED_FIELDS,
     TeamDriftSyncService,
@@ -217,3 +218,124 @@ async def test_project_provider_teams_does_not_seed_raw_member_identities(
         identities = list((await session.execute(select(IdentityMapping))).scalars())
 
     assert identities == []
+
+
+@pytest.mark.asyncio
+async def test_project_provider_teams_accepts_discovered_team_shape(session_maker):
+    async with session_maker() as session:
+        service = TeamDriftSyncService(session, "org-1")
+        result = await service.project_provider_teams(
+            "github",
+            [
+                DiscoveredTeam(
+                    provider_type="github",
+                    provider_team_id="platform",
+                    name="Platform",
+                    description="Platform team",
+                    associations={
+                        "team_id": "gh:platform",
+                        "repo_patterns": ["platform/*"],
+                        "project_keys": ["PLAT"],
+                    },
+                )
+            ],
+        )
+        mapping = await session.scalar(
+            select(TeamMapping).where(TeamMapping.team_id == "gh:platform")
+        )
+
+    assert result["created"] == 1
+    assert result["projected"] == 1
+    assert mapping is not None
+    assert mapping.extra_data["provider_team_id"] == "platform"
+    assert mapping.repo_patterns == ["platform/*"]
+    assert mapping.project_keys == ["PLAT"]
+
+
+@pytest.mark.asyncio
+async def test_project_provider_teams_and_drift_sync_share_merge_results(
+    session_maker,
+):
+    async with session_maker() as session:
+        session.add(
+            TeamMapping(
+                team_id="gh:platform",
+                name="Old Platform",
+                org_id="org-1",
+                description="Old description",
+                repo_patterns=["old/*"],
+                project_keys=["OLD"],
+                extra_data={"provider_type": "github", "provider_team_id": "platform"},
+                managed_fields=list(PROVIDER_MANAGED_FIELDS),
+                sync_policy=0,
+            )
+        )
+        await session.flush()
+
+        service = TeamDriftSyncService(session, "org-1")
+        await service.project_provider_teams(
+            "github",
+            [
+                ProviderTeam(
+                    id="gh:platform",
+                    name="New Platform",
+                    description="New description",
+                    repo_patterns=["new/*"],
+                    project_keys=["NEW"],
+                )
+            ],
+        )
+        mapping = await session.scalar(
+            select(TeamMapping).where(TeamMapping.team_id == "gh:platform")
+        )
+        project_result = {
+            "name": mapping.name,
+            "description": mapping.description,
+            "repo_patterns": mapping.repo_patterns,
+            "project_keys": mapping.project_keys,
+        }
+
+    async with session_maker() as session:
+        session.add(
+            TeamMapping(
+                team_id="gh:platform",
+                name="Old Platform",
+                org_id="org-1",
+                description="Old description",
+                repo_patterns=["old/*"],
+                project_keys=["OLD"],
+                extra_data={"provider_type": "github", "provider_team_id": "platform"},
+                managed_fields=list(PROVIDER_MANAGED_FIELDS),
+                sync_policy=0,
+            )
+        )
+        await session.flush()
+
+        service = TeamDriftSyncService(session, "org-1")
+        await service.run_drift_sync(
+            "github",
+            [
+                DiscoveredTeam(
+                    provider_type="github",
+                    provider_team_id="platform",
+                    name="New Platform",
+                    description="New description",
+                    associations={
+                        "team_id": "gh:platform",
+                        "repo_patterns": ["new/*"],
+                        "project_keys": ["NEW"],
+                    },
+                )
+            ],
+        )
+        mapping = await session.scalar(
+            select(TeamMapping).where(TeamMapping.team_id == "gh:platform")
+        )
+        drift_result = {
+            "name": mapping.name,
+            "description": mapping.description,
+            "repo_patterns": mapping.repo_patterns,
+            "project_keys": mapping.project_keys,
+        }
+
+    assert project_result == drift_result

--- a/tests/test_team_reconcile_guards.py
+++ b/tests/test_team_reconcile_guards.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import IdentityMapping, TeamMapping
+from tests._helpers import tables_of
+
+
+def _make_ns(
+    *,
+    provider: str = "config",
+    org: str | None = None,
+    allow_empty: bool = False,
+    path: str | None = None,
+) -> argparse.Namespace:
+    ns = argparse.Namespace()
+    ns.provider = provider
+    ns.org = org
+    ns.allow_empty = allow_empty
+    ns.path = path
+    ns.db = "sqlite+aiosqlite:///:memory:"
+    ns.sink = "clickhouse"
+    ns.analytics_db = "clickhouse://example.test:8123/default"
+    ns.owner = None
+    ns.auth = None
+    return ns
+
+
+def _write_config(path: Path) -> None:
+    import yaml
+
+    path.write_text(
+        yaml.dump({"teams": [{"team_id": "team-a", "team_name": "Team A"}]}),
+        encoding="utf-8",
+    )
+
+
+def _seed_sync_sqlite(db_path: Path, rows: list[Any]) -> str:
+    uri = f"sqlite:///{db_path}"
+    engine = create_engine(uri)
+    Base.metadata.create_all(engine, tables=tables_of(TeamMapping, IdentityMapping))
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    with Session() as session:
+        session.add_all(rows)
+        session.commit()
+    engine.dispose()
+    return f"sqlite+aiosqlite:///{db_path}"
+
+
+class _FakeClickHouseStore:
+    teams: list[Any] = []
+    inserted_batches: list[list[Any]] = []
+
+    def __init__(self, _db_url: str) -> None:
+        self.org_id: str | None = None
+
+    async def __aenter__(self) -> _FakeClickHouseStore:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def get_all_teams(self) -> list[Any]:
+        return list(self.teams)
+
+    async def insert_teams(self, teams: list[Any]) -> None:
+        self.inserted_batches.append(list(teams))
+
+
+def test_guard_org_sync_projects_before_clickhouse_bridge(tmp_path: Path) -> None:
+    from dev_health_ops.providers.teams import sync_teams
+
+    config_file = tmp_path / "teams.yaml"
+    _write_config(config_file)
+    order: list[str] = []
+
+    async def _projection(teams_data: list[Any], ns: Any) -> dict[str, Any]:
+        order.append("projection")
+        return {"projected": len(teams_data)}
+
+    def _bridge(**_kwargs: Any) -> int:
+        order.append("bridge")
+        return 1
+
+    with (
+        patch("dev_health_ops.providers.teams._project_teams_to_postgres", _projection),
+        patch(
+            "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse", _bridge
+        ),
+        patch("dev_health_ops.storage.run_with_store") as run_with_store,
+    ):
+        result = sync_teams(_make_ns(org="org-1", path=str(config_file)))
+
+    assert result == 0
+    assert order == ["projection", "bridge"]
+    run_with_store.assert_not_called()
+
+
+def test_guard_no_org_sync_writes_clickhouse_directly(tmp_path: Path) -> None:
+    from dev_health_ops.providers import teams as teams_provider
+
+    config_file = tmp_path / "teams.yaml"
+    _write_config(config_file)
+    inserted: list[Any] = []
+
+    class _Store:
+        async def ensure_tables(self) -> None:
+            return None
+
+        async def insert_teams(self, teams: list[Any]) -> None:
+            inserted.extend(teams)
+
+        async def get_all_teams(self) -> list[Any]:
+            return inserted
+
+    async def _run_with_store(
+        _db_uri: str,
+        _db_type: str,
+        handler: Any,
+        *,
+        org_id: str | None = None,
+    ) -> int:
+        return await handler(_Store())
+
+    with patch("dev_health_ops.storage.run_with_store", _run_with_store):
+        result = teams_provider.sync_teams(_make_ns(path=str(config_file)))
+
+    assert result == 0
+    assert [team.id for team in inserted] == ["team-a"]
+
+
+def test_guard_org_bridge_members_use_confirmed_identity_facets_only(
+    tmp_path: Path,
+) -> None:
+    from dev_health_ops.providers.team_bridge import bridge_teams_to_clickhouse
+
+    pg_url = _seed_sync_sqlite(
+        tmp_path / "members.db",
+        [
+            TeamMapping(team_id="team-a", name="Team A", org_id="org-1"),
+            IdentityMapping(
+                canonical_id="u1",
+                org_id="org-1",
+                email="alice@example.com",
+                provider_identities={"github": ["alice-gh"]},
+                team_ids=["team-a"],
+            ),
+        ],
+    )
+    _FakeClickHouseStore.inserted_batches = []
+
+    with patch(
+        "dev_health_ops.providers.team_bridge.ClickHouseStore", _FakeClickHouseStore
+    ):
+        bridge_teams_to_clickhouse(
+            org_id="org-1",
+            db_url="clickhouse://example.test:8123/default",
+            postgres_db_url=pg_url,
+        )
+
+    members = set(_FakeClickHouseStore.inserted_batches[-1][0]["members"])
+    assert {"u1", "alice-gh", "alice@example.com"}.issubset(members)
+    assert "unmapped-login" not in members
+
+
+def test_guard_last_writer_keeps_identity_members_and_curated_fields(
+    tmp_path: Path,
+) -> None:
+    from dev_health_ops.providers.teams import sync_teams
+
+    pg_url = _seed_sync_sqlite(
+        tmp_path / "last-writer.db",
+        [
+            TeamMapping(
+                team_id="team-a",
+                name="Team A",
+                org_id="org-1",
+                repo_patterns=["curated/*"],
+                project_keys=["CUR"],
+                extra_data={"provider_type": "config", "provider_team_id": "team-a"},
+                managed_fields=["name", "description", "repo_patterns", "project_keys"],
+                sync_policy=0,
+            ),
+            IdentityMapping(
+                canonical_id="u1",
+                org_id="org-1",
+                provider_identities={"github": ["alice-gh"]},
+                team_ids=["team-a"],
+            ),
+        ],
+    )
+    config_file = tmp_path / "teams.yaml"
+    _write_config(config_file)
+    _FakeClickHouseStore.inserted_batches = []
+
+    with patch(
+        "dev_health_ops.providers.team_bridge.ClickHouseStore", _FakeClickHouseStore
+    ):
+        ns = _make_ns(org="org-1", path=str(config_file))
+        ns.db = pg_url
+        result = sync_teams(ns)
+
+    assert result == 0
+    payload = _FakeClickHouseStore.inserted_batches[-1][0]
+    assert set(payload["members"]) == {"u1", "alice-gh"}
+    assert payload["project_keys"] == ["CUR"]
+    assert payload["repo_patterns"] == ["curated/*"]
+
+
+@pytest.mark.asyncio
+async def test_guard_health_check_flags_org_clickhouse_rows_without_mapping(
+    tmp_path: Path,
+) -> None:
+    from types import SimpleNamespace
+
+    from dev_health_ops.providers.team_reconcile import find_unmapped_clickhouse_teams
+
+    pg_url = _seed_sync_sqlite(
+        tmp_path / "health.db",
+        [TeamMapping(team_id="mapped", name="Mapped", org_id="org-1")],
+    )
+    _FakeClickHouseStore.teams = [
+        SimpleNamespace(id="mapped", name="Mapped", org_id="org-1"),
+        SimpleNamespace(id="missing", name="Missing", org_id="org-1"),
+        SimpleNamespace(id="other", name="Other", org_id="org-2"),
+    ]
+
+    with patch(
+        "dev_health_ops.providers.team_reconcile.ClickHouseStore", _FakeClickHouseStore
+    ):
+        missing = await find_unmapped_clickhouse_teams(
+            "org-1",
+            db_url="clickhouse://example.test:8123/default",
+            postgres_db_url=pg_url,
+        )
+
+    assert missing == ["missing"]
+
+
+def test_guard_drift_provider_registry_covers_required_providers() -> None:
+    from dev_health_ops.providers.team_capabilities import team_provider_capabilities
+
+    capabilities = {c.provider: c for c in team_provider_capabilities()}
+    required = {"github", "gitlab", "jira", "linear", "ms-teams"}
+
+    assert required.issubset(capabilities)
+    unsupported = [
+        provider
+        for provider in required
+        if not capabilities[provider].supports_org_drift_discovery
+    ]
+    assert unsupported == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_command_creates_missing_mapping_then_rerun_is_noop(
+    tmp_path: Path,
+) -> None:
+    from types import SimpleNamespace
+
+    from dev_health_ops.providers.team_reconcile import (
+        reconcile_clickhouse_teams_to_postgres,
+    )
+
+    pg_url = _seed_sync_sqlite(tmp_path / "reconcile.db", [])
+    _FakeClickHouseStore.teams = [
+        SimpleNamespace(
+            id="team-a",
+            name="Team A",
+            description="From ClickHouse",
+            org_id="org-1",
+            project_keys=["A"],
+            repo_patterns=["a/*"],
+        )
+    ]
+
+    with (
+        patch(
+            "dev_health_ops.providers.team_reconcile.ClickHouseStore",
+            _FakeClickHouseStore,
+        ),
+        patch(
+            "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+            return_value=1,
+        ),
+    ):
+        first = await reconcile_clickhouse_teams_to_postgres(
+            "org-1",
+            db_url="clickhouse://example.test:8123/default",
+            postgres_db_url=pg_url,
+        )
+        second = await reconcile_clickhouse_teams_to_postgres(
+            "org-1",
+            db_url="clickhouse://example.test:8123/default",
+            postgres_db_url=pg_url,
+        )
+
+    engine = create_engine(pg_url.replace("sqlite+aiosqlite://", "sqlite://"))
+    Session = sessionmaker(bind=engine, expire_on_commit=False)
+    with Session() as session:
+        mappings = session.query(TeamMapping).all()
+    engine.dispose()
+
+    assert first["created"] == 1
+    assert first["missing_after"] == []
+    assert second["created"] == 0
+    assert second["existing"] == 1
+    assert second["missing_before"] == []
+    assert [(m.team_id, m.project_keys, m.repo_patterns) for m in mappings] == [
+        ("team-a", ["A"], ["a/*"])
+    ]
+
+
+def test_cli_org_path_consults_team_capability_registry(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    from dev_health_ops.providers.teams import sync_teams
+
+    config_file = tmp_path / "teams.yaml"
+    _write_config(config_file)
+
+    async def _projection(teams_data: list[Any], ns: Any) -> dict[str, Any]:
+        return {"projected": len(teams_data)}
+
+    with (
+        patch("dev_health_ops.providers.teams._project_teams_to_postgres", _projection),
+        patch(
+            "dev_health_ops.providers.team_bridge.bridge_teams_to_clickhouse",
+            return_value=1,
+        ),
+        patch(
+            "dev_health_ops.providers.team_capabilities.org_drift_capable_providers",
+            return_value=(),
+        ) as capable,
+        patch(
+            "dev_health_ops.providers.team_capabilities.team_provider_capabilities",
+            return_value=(),
+        ) as capabilities,
+        caplog.at_level("INFO"),
+    ):
+        result = sync_teams(_make_ns(org="org-1", path=str(config_file)))
+
+    assert result == 0
+    capable.assert_called_once()
+    capabilities.assert_called_once()
+    assert "unsupported for org drift discovery" in caplog.text


### PR DESCRIPTION
## Summary
- Add dev-hops teams reconcile --org ORG to backfill org-scoped ClickHouse teams into Postgres TeamMappings, then bridge back through the existing ClickHouse writer.
- Harden provider projection to accept both provider Team shapes and DiscoveredTeam(provider_team_id/associations) without silently dropping non-empty inputs.
- Add guard tests for org/no-org routing, identity-only members, last-writer stability, CH-to-PG health checks, registry coverage, idempotent reconcile, and shared merge behavior.
- Wire org-scoped CLI sync to consult the shared team capability registry and log unsupported provider reasons without changing routing.

## Verification
- CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/test_team_reconcile_guards.py tests/api/admin/test_team_projection.py tests/test_sync_teams_routing_invariants.py tests/test_teams.py tests/test_sync_team_parallel.py tests/test_team_capabilities.py -q
- uv run --extra dev --python 3.11 mypy src/dev_health_ops/cli.py src/dev_health_ops/providers/teams.py src/dev_health_ops/providers/team_reconcile.py src/dev_health_ops/api/services/configuration/team_drift_sync.py
- uv run --extra dev --python 3.11 ruff check src/dev_health_ops/cli.py src/dev_health_ops/providers/teams.py src/dev_health_ops/providers/team_reconcile.py src/dev_health_ops/api/services/configuration/team_drift_sync.py tests/test_team_reconcile_guards.py tests/api/admin/test_team_projection.py
- LSP diagnostics clean on changed files

Closes CHAOS-2407.
Closes CHAOS-2409.
Addresses Codex adversarial-review HIGH findings (DiscoveredTeam shape, shared-merge proof).
Stacked on integration/chaos-2401.

SCREENSHOT-WAIVER: backend CLI/service/test changes only; no rendered UI impact.