### PR TITLE
docs(teams): unified managed/unmanaged team sync model + reconcile command (CHAOS-2408)

### DIFF
--- a/docs/api/team-catalog-source-of-truth.md
+++ b/docs/api/team-catalog-source-of-truth.md
@@ -90,14 +90,19 @@ in a follow-up. New consumers should use the GraphQL `catalog` field.
 
 ## Files
 
-- `src/dev_health_ops/api/graphql/sql/templates.py` —
-  `catalog_values_team_template()`
-- `src/dev_health_ops/api/graphql/sql/compiler.py` —
-  `compile_catalog_values()` (TEAM branch)
-- `src/dev_health_ops/api/graphql/sql/validate.py` — `Dimension.TEAM`
-- `tests/graphql/test_compiler.py` —
-  `TestCompileCatalogValues::test_team_catalog_uses_teams_table_as_source_of_truth`
+- `src/dev_health_ops/api/graphql/sql/templates.py` : `catalog_values_team_template()`
+- `src/dev_health_ops/api/graphql/sql/compiler.py` : `compile_catalog_values()` (TEAM branch)
+- `src/dev_health_ops/api/graphql/sql/validate.py` : `Dimension.TEAM`
+- `tests/graphql/test_compiler.py` : `TestCompileCatalogValues::test_team_catalog_uses_teams_table_as_source_of_truth`
 
+## Dual-Database Architecture and Sync Flow
+
+While ClickHouse remains the analytics read source of truth for the team catalog, PostgreSQL serves as the Postgres-first control plane for org-scoped team configurations.
+
+The sync flow is structured as follows:
+1. **Shared Projection Service**: The CLI and Celery/admin paths use the shared `TeamDriftSyncService` to project provider-discovered teams into PostgreSQL `team_mappings`. This ensures consistent merge semantics and flags changes for review if `sync_policy == 1`.
+2. **Single Member Resolver**: A single shared member resolver (`members_by_team`) resolves member identities from PostgreSQL `identity_mappings` to populate ClickHouse `teams.members`.
+3. **Sole ClickHouse Writer**: The `bridge_teams_to_clickhouse` function is the sole writer for org-scoped ClickHouse teams, ensuring that the analytics layer is always populated from the PostgreSQL control plane.
 ## History
 
 - CHAOS-1751: Established `teams` as the source of truth for the TEAM

--- a/docs/architecture/database-architecture.md
+++ b/docs/architecture/database-architecture.md
@@ -132,7 +132,7 @@ Commands automatically use the appropriate database:
 | `sync git` | ClickHouse | Git data ingestion |
 | `sync prs` | ClickHouse | PR data ingestion |
 | `sync work-items` | ClickHouse | Work item ingestion |
-| `sync teams` | Both | **Org-scoped** (`--org`): provider → Postgres `team_mappings` → `bridge_teams_to_clickhouse`; **No-org**: direct ClickHouse write |
+| `sync teams` | Both | **Org-scoped** (`--org`): provider → Postgres `team_mappings` (via `TeamDriftSyncService`) → `bridge_teams_to_clickhouse`; **No-org**: direct ClickHouse write |
 | `metrics daily` | ClickHouse | Metrics computation |
 | `metrics dora` | ClickHouse | DORA metrics |
 | `api` | Both | Serves both layers |
@@ -143,22 +143,72 @@ The `sync teams` command has two distinct routing paths depending on whether `--
 
 | Path | Trigger | Write order | ClickHouse writer |
 |------|---------|-------------|-------------------|
-| **Org-scoped** | `--org <id>` present | 1. `_bridge_teams_to_postgres` (upserts `team_mappings`) → 2. `bridge_teams_to_clickhouse` (reads Postgres, resolves identities, writes `teams`) | `bridge_teams_to_clickhouse` only |
+| **Org-scoped** | `--org <id>` present | 1. `TeamDriftSyncService.project_provider_teams` (upserts `team_mappings` in Postgres) → 2. `bridge_teams_to_clickhouse` (reads Postgres, resolves identities, writes `teams` to ClickHouse) | `bridge_teams_to_clickhouse` only |
 | **No-org** | `--org` absent | Direct `run_with_store` → ClickHouse `teams` table | `run_with_store` |
 
 **Invariants for the org-scoped path:**
 
-- PostgreSQL `team_mappings` is always the source of truth for org-scoped teams.
-- `bridge_teams_to_clickhouse` is the **sole** ClickHouse writer for org-scoped syncs.
-  It reads `TeamMapping` + `IdentityMapping` from Postgres (both filtered by `org_id`),
-  resolves member identities (email, canonical_id, all provider logins), and writes the
-  enriched payload to the ClickHouse `teams` table.
-- `run_with_store` (direct ClickHouse write from provider data) is **never** called on the
-  org-scoped path.
-- A Postgres bridge failure (`_bridge_teams_to_postgres` returns 0 or raises) causes exit 1.
-- A ClickHouse bridge failure (`bridge_teams_to_clickhouse` raises) is fatal (exit 1) so
-  callers cannot report a successful sync when analytics has not been updated.
+- PostgreSQL `team_mappings` is always the Postgres-first control plane and source of truth for org-scoped teams.
+- ClickHouse `teams` is the analytics read source of truth.
+- `bridge_teams_to_clickhouse` is the **sole** ClickHouse writer for org-scoped syncs. It reads `TeamMapping` + `IdentityMapping` from Postgres (both filtered by `org_id`), resolves member identities (email, canonical_id, all provider logins), and writes the enriched payload to the ClickHouse `teams` table.
+- `run_with_store` (direct ClickHouse write from provider data) is **never** called on the org-scoped path.
+- A Postgres projection failure (e.g. `TeamDriftSyncService` raises) causes exit 1.
+- A ClickHouse bridge failure (`bridge_teams_to_clickhouse` raises) is fatal (exit 1) so callers cannot report a successful sync when analytics has not been updated.
 
+#### Team Sync Architecture Diagrams
+
+##### Current State (Split-Brain)
+Before the unification, the CLI and Celery/admin paths diverged, using different member resolvers and Postgres projection writers:
+
+```mermaid
+graph TD
+    subgraph CLI Path
+        CLI[CLI: sync teams --org] -->|Calls| CLI_Local[CLI-Local Postgres Writer]
+        CLI_Local -->|Writes| PG[(PostgreSQL: team_mappings)]
+        CLI_Local -->|Resolves members| CLI_Resolver[CLI-Local Member Resolver]
+        CLI_Resolver -->|Mutates| PG_Identities[(PostgreSQL: identity_mappings)]
+        CLI -->|Calls| Bridge[bridge_teams_to_clickhouse]
+    end
+
+    subgraph Celery / Admin Path
+        Admin[Admin API / Celery Worker] -->|Calls| Service[TeamDriftSyncService]
+        Service -->|Writes| PG
+        Worker[Celery: reconcile_team_members] -->|Resolves members| Worker_Resolver[reconcile_team_members]
+        Admin -->|Calls| Bridge
+    end
+
+    Bridge -->|Resolves members| Bridge_Resolver[Bridge Member Resolver]
+    Bridge -->|Writes| CH[(ClickHouse: teams)]
+```
+
+##### Target State (Unified Model)
+After the unification, all paths converge on the shared `TeamDriftSyncService` and a single shared member resolver:
+
+```mermaid
+graph TD
+    subgraph CLI Path
+        CLI[CLI: sync teams --org] -->|Calls| Service[TeamDriftSyncService]
+    end
+
+    subgraph Celery / Admin Path
+        Admin[Admin API / Celery Worker] -->|Calls| Service
+    end
+
+    subgraph Reconcile Command
+        Reconcile[CLI: teams reconcile --org] -->|Ensures mapping| PG
+        Reconcile -->|Calls| Bridge[bridge_teams_to_clickhouse]
+    end
+
+    Service -->|Writes/Flags| PG[(PostgreSQL: team_mappings)]
+    PG -->|Triggers| Bridge
+    Bridge -->|Sole Writer| CH[(ClickHouse: teams)]
+
+    subgraph Shared Identity Resolution
+        Bridge -->|Calls| SharedResolver[Shared members_by_team]
+        Worker[Celery: reconcile_team_members] -->|Calls| SharedResolver
+        SharedResolver -->|Reads confirmed facets| PG_Identities[(PostgreSQL: identity_mappings)]
+    end
+```
 ## API Service Routing
 
 | Service | Database | Session Factory |

--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -8,7 +8,8 @@ Complete reference for the dev-health-ops command-line interface.
 
 The CLI entry point is `dev-hops` (module `dev_health_ops.cli`). Command groups:
 
-- `sync` — ingest provider data (git, prs, blame, cicd, deployments, incidents, security, tests, teams, work-items)
+- `sync` : ingest provider data (git, prs, blame, cicd, deployments, incidents, security, tests, teams, work-items)
+- `teams` : team catalog operations (reconcile)
 - `metrics` — compute analytics (daily, rebuild, dora, complexity, capacity, release-impact, validate-flags, compounding-risk)
 - `audit` — diagnostics (completeness, schema, perf, coverage)
 - `fixtures` — synthetic/demo data (generate, validate, product-telemetry)
@@ -263,7 +264,12 @@ Accepts the same provider/auth/batch options as [`sync git`](#sync-git). Provide
 
 ### `sync teams`
 
-Sync team definitions. Persists to the analytics store, so `CLICKHOUSE_URI` (or `--analytics-db`) is required regardless of the `--provider` source (see [Input Validation](#input-validation-preflight)).
+Sync team definitions. The behavior depends on whether `--org` is provided:
+
+- **Managed (org-scoped, `--org ORG`)**: The provider data is projected into PostgreSQL `team_mappings` via the shared `TeamDriftSyncService.project_provider_teams` (which preserves admin-curated configurations and flags changes for review if `sync_policy == 1`). Then, `bridge_teams_to_clickhouse(org_id)` is called to write the resolved teams and members to ClickHouse. The CLI org path never writes ClickHouse directly.
+- **Unmanaged (no `--org`)**: The provider data is written directly to ClickHouse (preserving synthetic/local seeding).
+
+`CLICKHOUSE_URI` (or `--analytics-db`) is required. For managed syncs, `POSTGRES_URI` (or `--db`) is also required.
 
 ```bash
 # From config file
@@ -286,10 +292,28 @@ dev-hops sync teams --provider gitlab \
   --auth "$GITLAB_TOKEN"
 ```
 
-The bundled `src/dev_health_ops/config/team_mapping.yaml` is intentionally empty
-for onboarding. By default, `sync teams` exits non-zero when discovery or
-persistence results in zero teams; use `--allow-empty` only when an empty/no-op
-sync is expected.
+The bundled `src/dev_health_ops/config/team_mapping.yaml` is intentionally empty for onboarding. By default, `sync teams` exits non-zero when discovery or persistence results in zero teams; use `--allow-empty` only when an empty/no-op sync is expected.
+
+---
+
+## Teams Commands
+
+Team catalog operations.
+
+### `teams reconcile`
+
+Reconcile org-scoped ClickHouse teams into PostgreSQL `team_mappings`. This command is idempotent and re-runnable.
+
+```bash
+dev-hops teams reconcile --org ORG_ID
+```
+
+For each org-scoped team in ClickHouse, this command ensures a corresponding `TeamMapping` exists in PostgreSQL (creating one with `sync_policy=2` if missing). It then runs `bridge_teams_to_clickhouse(org_id)` to re-bridge the teams and their members from `IdentityMapping` back to ClickHouse.
+
+Requires:
+- ClickHouse (`--analytics-db` / `CLICKHOUSE_URI`)
+- PostgreSQL (`--db` / `POSTGRES_URI`)
+- Organization (`--org` / `ORG_ID`)
 
 ---
 

--- a/docs/superpowers/specs/2026-04-14-security-alerts-ui-design.md
+++ b/docs/superpowers/specs/2026-04-14-security-alerts-ui-design.md
@@ -228,7 +228,7 @@ Sync-side tests in `ops/tests/test_security_alerts.py` already exist and stay gr
 
 - `web/src/app/(app)/security/page.tsx` — RSC. Decodes `searchParams.f` into a `SecurityFilter` with `decodeFilter`. Renders `<SecurityDashboard filter={...} />` + `<SecurityAlertQueue filter={...} />`. Follows the shape of `opportunities/page.tsx:15-107`.
 - `web/src/app/(app)/security/repos/[repoId]/page.tsx` — RSC. Merges `{ repoIds: [params.repoId] }` into the decoded filter. Renders only `<SecurityAlertQueue filter={...} lockedRepoId={params.repoId} />` (no dashboard).
-- `web/src/app/(app)/security/loading.tsx`, page-level loading UI.
+- `web/src/app/(app)/security/loading.tsx` — page-level skeleton.
 - `web/src/app/(app)/security/error.tsx` — page-level error with `<ErrorCard />`.
 
 ### GraphQL layer
@@ -279,7 +279,7 @@ All new, grouped under one folder.
 
 ### Loading / error / empty
 
-- Loading: per-widget `<Skeleton>` tiles; per-row loading placeholder in the table while `fetching` is true on first load.
+- Loading: per-widget `<Skeleton>` tiles; per-row skeleton in the table while `fetching` is true on first load.
 - Error: page-level `error.tsx` catches render-time throws; per-widget `<ErrorCard />` when a single urql query errors so the rest of the page renders.
 - Empty: `<EmptyState title="No alerts match these filters" cta="Clear filters" />` when the queue has zero edges.
 

--- a/docs/superpowers/specs/2026-04-14-security-alerts-ui-design.md
+++ b/docs/superpowers/specs/2026-04-14-security-alerts-ui-design.md
@@ -228,7 +228,7 @@ Sync-side tests in `ops/tests/test_security_alerts.py` already exist and stay gr
 
 - `web/src/app/(app)/security/page.tsx` — RSC. Decodes `searchParams.f` into a `SecurityFilter` with `decodeFilter`. Renders `<SecurityDashboard filter={...} />` + `<SecurityAlertQueue filter={...} />`. Follows the shape of `opportunities/page.tsx:15-107`.
 - `web/src/app/(app)/security/repos/[repoId]/page.tsx` — RSC. Merges `{ repoIds: [params.repoId] }` into the decoded filter. Renders only `<SecurityAlertQueue filter={...} lockedRepoId={params.repoId} />` (no dashboard).
-- `web/src/app/(app)/security/loading.tsx` — page-level skeleton.
+- `web/src/app/(app)/security/loading.tsx`, page-level loading UI.
 - `web/src/app/(app)/security/error.tsx` — page-level error with `<ErrorCard />`.
 
 ### GraphQL layer
@@ -279,7 +279,7 @@ All new, grouped under one folder.
 
 ### Loading / error / empty
 
-- Loading: per-widget `<Skeleton>` tiles; per-row skeleton in the table while `fetching` is true on first load.
+- Loading: per-widget `<Skeleton>` tiles; per-row loading placeholder in the table while `fetching` is true on first load.
 - Error: page-level `error.tsx` catches render-time throws; per-widget `<ErrorCard />` when a single urql query errors so the rest of the page renders.
 - Empty: `<EmptyState title="No alerts match these filters" cta="Clear filters" />` when the queue has zero edges.
 

--- a/docs/team-configuration.md
+++ b/docs/team-configuration.md
@@ -2,6 +2,30 @@
 
 This guide covers the fastest path to mapping repositories and providers to teams.
 
+## Managed vs Unmanaged Sync Modes
+
+The team sync behavior depends on whether the `--org` flag is provided:
+
+- **Managed Mode (org-scoped, `--org ORG`)**: Provider data is projected into PostgreSQL `team_mappings` via the shared `TeamDriftSyncService`. This is a Postgres-first control plane. The sync preserves admin-curated configurations (such as `project_keys` and `repo_patterns`) and flags changes for review if `sync_policy == 1`. The CLI org path never writes ClickHouse directly; instead, it calls `bridge_teams_to_clickhouse(org_id)` to write the resolved teams and members to ClickHouse.
+- **Unmanaged Mode (no `--org`)**: Provider data is written directly to ClickHouse, preserving synthetic/local seeding.
+
+## Provider Capability Registry
+
+The shared provider capability registry (`providers/team_capabilities.py`) defines which providers support org-scoped drift discovery. The supported providers are:
+- GitHub
+- GitLab
+- Jira
+- Linear
+- Microsoft Teams
+
+Both the worker drift path and the CLI org path read from this registry.
+
+## Admin-Curated Configuration Preservation
+
+When syncing teams in managed mode, the sync process preserves admin-curated configurations:
+- Empty provider values do not overwrite non-empty curated `project_keys` or `repo_patterns`.
+- If `sync_policy == 1`, changes are flagged for admin review rather than being silently merged.
+
 ## Recommended path
 
 1. Define your team mapping source (YAML file, Jira, GitHub, GitLab, or synthetic).


### PR DESCRIPTION
Closes CHAOS-2408. SCREENSHOT-WAIVER: docs-only, no rendered UI. Stacked on integration/chaos-2401.