### PR TITLE
fix(llm): make investment_mix_explain org-aware (CHAOS-2549)

### DIFF
--- a/src/dev_health_ops/api/services/investment_mix_explain.py
+++ b/src/dev_health_ops/api/services/investment_mix_explain.py
@@ -187,7 +187,7 @@ async def explain_investment_mix(
         )
         theme = theme_of(subcategory)
 
-    if not is_llm_available(llm_provider):
+    if not is_llm_available(llm_provider, org_id=org_id or None):
         return InvestmentMixExplanation(
             summary="",
             top_findings=[],
@@ -362,7 +362,7 @@ async def explain_investment_mix(
     full_prompt = build_prompt(base_prompt=prompt_text, payload=payload)
 
     resolved_llm_provider = resolve_provider_name(llm_provider, org_id=org_id)
-    provider = get_provider(llm_provider, model=llm_model)
+    provider = get_provider(llm_provider, model=llm_model, org_id=org_id or None)
     completion = await provider.complete(full_prompt)
     raw = completion.text
     if llm_provider != "mock":

--- a/tests/api/test_investment_explain_cache.py
+++ b/tests/api/test_investment_explain_cache.py
@@ -305,3 +305,67 @@ async def test_explain_forwards_org_id_to_work_unit_evidence():
         assert build_call.kwargs["org_id"] == real_org
         # ...and so is the work-unit evidence reader (the bug: it defaulted to "").
         assert units_call.kwargs["org_id"] == real_org
+
+
+@pytest.mark.asyncio
+async def test_explain_forwards_org_id_to_provider_resolution():
+    """Regression (CHAOS-2549): the explanation path must forward the caller's
+    org_id into both is_llm_available and get_provider.
+
+    Org-scoped BYO-LLM resolution keys provider/credential selection on org_id.
+    If explain_investment_mix omits org_id, both the availability probe and the
+    provider build default to the global/platform context, so an org with a
+    configured BYO provider is silently ignored (wrong provider, wrong creds).
+    """
+    real_org = "org-7c2f1a9e"
+
+    with (
+        patch(
+            "dev_health_ops.api.services.investment_mix_explain.build_investment_response"
+        ) as mock_build,
+        patch(
+            "dev_health_ops.api.services.investment_mix_explain.build_work_unit_investments"
+        ) as mock_units,
+        patch(
+            "dev_health_ops.api.services.investment_mix_explain.is_llm_available"
+        ) as mock_is_available,
+        patch(
+            "dev_health_ops.api.services.investment_mix_explain.get_provider"
+        ) as mock_get_provider,
+    ):
+        mock_investment = MagicMock()
+        mock_investment.theme_distribution = {"feature_delivery": 1.0}
+        mock_investment.subcategory_distribution = {"feature_delivery.customer": 1.0}
+        mock_build.return_value = mock_investment
+
+        mock_units.return_value = []
+        mock_is_available.return_value = True
+
+        mock_provider = MagicMock()
+        mock_provider.complete = AsyncMock(
+            return_value=CompletionResult(
+                text='{"summary": "Test summary", "top_findings": [], "confidence": {"level": "moderate"}, "what_to_check_next": [], "anti_claims": []}',
+                input_tokens=10,
+                output_tokens=20,
+                model="mock",
+            )
+        )
+        mock_get_provider.return_value = mock_provider
+
+        class MockFilters:
+            def model_dump(self, mode=None):
+                return {"scope": {"level": "org"}}
+
+        await explain_investment_mix(
+            db_url="clickhouse://localhost:9000/test",
+            filters=MockFilters(),
+            org_id=real_org,
+            llm_provider="mock",
+        )
+
+        # Availability probe must be org-scoped (the bug: defaulted to global).
+        assert mock_is_available.call_args is not None
+        assert mock_is_available.call_args.kwargs["org_id"] == real_org
+        # Provider build must be org-scoped too, so BYO creds resolve correctly.
+        assert mock_get_provider.call_args is not None
+        assert mock_get_provider.call_args.kwargs["org_id"] == real_org


### PR DESCRIPTION
## Summary

Threads `org_id` into the LLM availability probe and provider build inside `explain_investment_mix`, so org-scoped BYO-LLM resolution selects the correct provider/credentials.

- `is_llm_available(llm_provider)` → `is_llm_available(llm_provider, org_id=org_id or None)`
- `get_provider(llm_provider, model=llm_model)` → `get_provider(llm_provider, model=llm_model, org_id=org_id or None)`

`resolve_provider_name` already received `org_id`; the availability check and provider construction did not, so an org with a configured BYO provider was silently resolved against the global/platform context.

This is the smallest, independent slice of the BYO-LLM follow-on (parent CHAOS-2548) and merges first.

## Test plan

- New regression test `test_explain_forwards_org_id_to_provider_resolution` asserts `org_id` reaches both `is_llm_available` and `get_provider`.
- `pytest tests/api/test_investment_explain_cache.py` — 11 passed (Python 3.11 and 3.13).
- Sibling explain suites (`test_investment_explain_mismatch`, `test_provenance_warnings`, `test_investment_mix_parsing`, `test_investment_mix_explainer`) — 17 passed, no regression.
- `mypy` clean; `ruff check` + `ruff format --check` clean.

SCREENSHOT-WAIVER: backend-only change; no rendered frontend output altered.

Closes CHAOS-2549