### PR TITLE
feat(teams): honor auto_import_teams in sync runtime/batch/backfill + dispatch seam (CHAOS-2544)

### DIFF
--- a/src/dev_health_ops/backfill/runner.py
+++ b/src/dev_health_ops/backfill/runner.py
@@ -9,6 +9,7 @@ from dev_health_ops.db import get_postgres_session_sync
 from dev_health_ops.metrics.job_work_items import run_work_items_sync_job
 from dev_health_ops.models.settings import SyncConfiguration
 from dev_health_ops.workers.task_utils import _jira_query_options
+from dev_health_ops.workers.team_autoimport import run_team_autoimport
 
 from .chunker import chunk_date_range
 
@@ -68,6 +69,34 @@ def _as_utc_datetime(value: date | datetime, *, end_of_day: bool) -> datetime:
         return value.astimezone(timezone.utc)
     boundary = time.max if end_of_day else time.min
     return datetime.combine(value, boundary, tzinfo=timezone.utc)
+
+
+def _run_team_autoimport_for_backfill(
+    *,
+    provider: str,
+    org_id: str,
+    credentials: dict[str, Any] | None,
+    sync_options: dict[str, Any],
+    sync_config_id: str,
+    since: date,
+    before: date,
+    window_count: int,
+) -> dict[str, Any] | None:
+    if not sync_options.get("auto_import_teams"):
+        return None
+    return run_team_autoimport(
+        provider=provider,
+        org_id=org_id,
+        credentials=credentials or {},
+        scope={
+            "mode": "backfill",
+            "sync_config_id": sync_config_id,
+            "sync_options": dict(sync_options),
+            "window_count": window_count,
+            "since": since.isoformat(),
+            "before": before.isoformat(),
+        },
+    )
 
 
 def run_backfill_for_config(
@@ -131,7 +160,18 @@ def run_backfill_for_config(
             jira_fetch_all=jira_fetch_all if provider == "jira" else None,
         )
 
-    return {
+    team_autoimport = _run_team_autoimport_for_backfill(
+        provider=provider,
+        org_id=org_id,
+        credentials=credentials,
+        sync_options=sync_options,
+        sync_config_id=sync_config_id,
+        since=since,
+        before=before,
+        window_count=len(windows),
+    )
+
+    result = {
         "status": "success",
         "provider": provider,
         "sync_config_id": sync_config_id,
@@ -140,3 +180,6 @@ def run_backfill_for_config(
         "since": since.isoformat(),
         "before": before.isoformat(),
     }
+    if team_autoimport is not None:
+        result["team_autoimport"] = team_autoimport
+    return result

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -30,6 +30,7 @@ from dev_health_ops.workers.task_utils import (
     _normalize_sync_targets,
     _resolve_env_credentials,
 )
+from dev_health_ops.workers.team_autoimport import run_team_autoimport
 
 logger = logging.getLogger(__name__)
 
@@ -261,6 +262,74 @@ def _get_batch_size(sync_options: dict[str, Any]) -> int:
     return 5
 
 
+def _repo_sync_options(
+    *,
+    provider: str,
+    sync_targets: list[str],
+    sync_options: dict[str, Any],
+    repo_tuple: tuple[Any, ...],
+) -> dict[str, Any]:
+    per_repo_options = dict(sync_options)
+    per_repo_options.pop("discover", None)
+    per_repo_options.pop("all_repos", None)
+    per_repo_options.pop("batch_size", None)
+
+    if provider == "github":
+        owner, repo_name = repo_tuple[0], repo_tuple[1]
+        per_repo_options["owner"] = owner
+        per_repo_options["repo"] = repo_name
+        if "work-items" in sync_targets:
+            per_repo_options["search"] = f"{owner}/{repo_name}"
+        else:
+            per_repo_options.pop("search", None)
+    elif provider == "gitlab":
+        project_id = repo_tuple[0]
+        per_repo_options["project_id"] = int(project_id)
+        if "work-items" in sync_targets:
+            project_path = repo_tuple[1] if len(repo_tuple) > 1 else ""
+            if project_path:
+                per_repo_options["search"] = project_path
+            else:
+                logger.warning(
+                    "GitLab work-items child for project_id=%s has no "
+                    "project path; skipping work-items scope to avoid "
+                    "org-wide fanout",
+                    project_id,
+                )
+                per_repo_options["search"] = f"noscope-{project_id}"
+        else:
+            per_repo_options.pop("search", None)
+        per_repo_options.pop("group", None)
+
+    return per_repo_options
+
+
+def _run_team_autoimport_for_batch_child(
+    *,
+    provider: str,
+    org_id: str,
+    credentials: dict[str, Any],
+    sync_options: dict[str, Any],
+    sync_targets: list[str],
+    config_id: str,
+    triggered_by: str,
+) -> dict[str, Any] | None:
+    if not sync_options.get("auto_import_teams"):
+        return None
+    return run_team_autoimport(
+        provider=provider,
+        org_id=org_id,
+        credentials=credentials,
+        scope={
+            "mode": "batch_child",
+            "sync_config_id": config_id,
+            "sync_targets": sync_targets,
+            "sync_options": dict(sync_options),
+            "triggered_by": triggered_by,
+        },
+    )
+
+
 @celery_app.task(
     bind=True, queue="sync", name="dev_health_ops.workers.tasks._batch_sync_callback"
 )
@@ -433,45 +502,12 @@ def dispatch_batch_sync(
         child_tasks = []
 
         for repo_tuple in repos:
-            per_repo_options = dict(sync_options)
-            per_repo_options.pop("discover", None)
-            per_repo_options.pop("all_repos", None)
-            per_repo_options.pop("batch_size", None)
-
-            if provider == "github":
-                owner, repo_name = repo_tuple[0], repo_tuple[1]
-                per_repo_options["owner"] = owner
-                per_repo_options["repo"] = repo_name
-                if "work-items" in sync_targets:
-                    per_repo_options["search"] = f"{owner}/{repo_name}"
-                else:
-                    per_repo_options.pop("search", None)
-            elif provider == "gitlab":
-                project_id = repo_tuple[0]
-                per_repo_options["project_id"] = int(project_id)
-                if "work-items" in sync_targets:
-                    project_path = repo_tuple[1] if len(repo_tuple) > 1 else ""
-                    if project_path:
-                        per_repo_options["search"] = project_path
-                    else:
-                        # Never pass an empty/all-matching search to a
-                        # work-items child: match_pattern("", ...) treats an
-                        # empty pattern as "match every repo", re-opening the
-                        # org-wide work-items fanout (CHAOS-2450). Scope to a
-                        # sentinel that cannot match any GitLab
-                        # path_with_namespace (which always contains "/") so
-                        # this project's work-items are skipped rather than
-                        # fanning out to all repos.
-                        logger.warning(
-                            "GitLab work-items child for project_id=%s has no "
-                            "project path; skipping work-items scope to avoid "
-                            "org-wide fanout",
-                            project_id,
-                        )
-                        per_repo_options["search"] = f"noscope-{project_id}"
-                else:
-                    per_repo_options.pop("search", None)
-                per_repo_options.pop("group", None)
+            per_repo_options = _repo_sync_options(
+                provider=provider,
+                sync_targets=sync_targets,
+                sync_options=sync_options,
+                repo_tuple=repo_tuple,
+            )
 
             child_signature = getattr(_run_sync_for_repo, "s")(
                 config_id=config_id,
@@ -773,6 +809,18 @@ def _run_sync_for_repo(
                         session, org_id, repo_id_for_watermark, t, started_at
                     )
                 session.flush()
+
+        team_autoimport = _run_team_autoimport_for_batch_child(
+            provider=provider,
+            org_id=org_id,
+            credentials=credentials,
+            sync_options=sync_options_override,
+            sync_targets=sync_targets,
+            config_id=config_id,
+            triggered_by=triggered_by,
+        )
+        if team_autoimport is not None:
+            result_payload["team_autoimport"] = team_autoimport
 
         duration = int((datetime.now(timezone.utc) - started_at).total_seconds())
         return {

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -36,6 +36,7 @@ from dev_health_ops.workers.task_utils import (
     _normalize_sync_targets,
     _resolve_env_credentials,
 )
+from dev_health_ops.workers.team_autoimport import run_team_autoimport
 
 # DORA (deployment frequency, lead time, change-failure-rate, MTTR) is computed
 # from synced deployments/CI/incidents in ClickHouse. These targets can be
@@ -439,6 +440,32 @@ def _is_terminal_sync_error(exc: Exception) -> bool:
     return isinstance(exc, (_TerminalSyncError, ValueError))
 
 
+def _run_team_autoimport_for_sync_config(
+    *,
+    provider: str,
+    org_id: str,
+    credentials: dict[str, Any],
+    sync_options: dict[str, Any],
+    sync_targets: list[str],
+    config_id: str,
+    triggered_by: str,
+) -> dict[str, Any] | None:
+    if not sync_options.get("auto_import_teams"):
+        return None
+    return run_team_autoimport(
+        provider=provider,
+        org_id=org_id,
+        credentials=credentials,
+        scope={
+            "mode": "sync_config",
+            "sync_config_id": config_id,
+            "sync_targets": sync_targets,
+            "sync_options": dict(sync_options),
+            "triggered_by": triggered_by,
+        },
+    )
+
+
 @celery_app.task(bind=True, max_retries=3, queue="sync")
 def run_sync_config(
     self,
@@ -839,6 +866,18 @@ def run_sync_config(
 
         completed_at = datetime.now(timezone.utc)
         duration_seconds = int((completed_at - started_at).total_seconds())
+
+        team_autoimport = _run_team_autoimport_for_sync_config(
+            provider=provider,
+            org_id=org_id,
+            credentials=credentials,
+            sync_options=sync_options,
+            sync_targets=sync_targets,
+            config_id=config_id,
+            triggered_by=triggered_by,
+        )
+        if team_autoimport is not None:
+            result_payload["team_autoimport"] = team_autoimport
 
         with get_postgres_session_sync() as session:
             run_record = session.query(JobRun).filter(JobRun.id == run_id).one_or_none()

--- a/src/dev_health_ops/workers/team_autoimport.py
+++ b/src/dev_health_ops/workers/team_autoimport.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib
+import logging
+from collections.abc import Callable, Mapping
+from typing import Any, cast
+
+from dev_health_ops.providers.team_capabilities import team_provider_capabilities
+
+logger = logging.getLogger(__name__)
+
+_IMPORTER_MODULES = {
+    "linear": "dev_health_ops.workers.team_autoimport_linear",
+    "jira": "dev_health_ops.workers.team_autoimport_jira",
+    "github": "dev_health_ops.workers.team_autoimport_github",
+    "gitlab": "dev_health_ops.workers.team_autoimport_gitlab",
+}
+
+TeamAutoimportPopulator = Callable[..., dict[str, Any]]
+
+
+def _zero_summary(*, provider: str, org_id: str, reason: str) -> dict[str, Any]:
+    return {
+        "status": "skipped",
+        "provider": provider,
+        "org_id": org_id,
+        "reason": reason,
+        "projects_imported": 0,
+        "members_imported": 0,
+        "team_memberships_imported": 0,
+        "team_project_ownership_imported": 0,
+        "team_repo_ownership_imported": 0,
+        "work_item_team_attributions_imported": 0,
+    }
+
+
+def _provider_capability(provider: str) -> bool:
+    normalized = provider.strip().lower()
+    return any(
+        capability.provider == normalized and capability.supports_org_drift_discovery
+        for capability in team_provider_capabilities()
+    )
+
+
+def _resolve_populator(provider: str) -> TeamAutoimportPopulator | None:
+    module_name = _IMPORTER_MODULES.get(provider.strip().lower())
+    if module_name is None:
+        return None
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError:
+        return None
+    populate = getattr(module, "populate", None)
+    if not callable(populate):
+        return None
+    return cast(TeamAutoimportPopulator, populate)
+
+
+def run_team_autoimport(
+    *,
+    provider: str,
+    org_id: str,
+    credentials: dict[str, Any],
+    scope: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    normalized_provider = provider.strip().lower()
+    if not _provider_capability(normalized_provider):
+        logger.info(
+            "Skipping team auto-import for provider=%s org_id=%s: provider is not import-capable",
+            normalized_provider,
+            org_id,
+        )
+        return _zero_summary(
+            provider=normalized_provider,
+            org_id=org_id,
+            reason="provider_not_import_capable",
+        )
+
+    populator = _resolve_populator(normalized_provider)
+    if populator is None:
+        logger.info(
+            "Skipping team auto-import for provider=%s org_id=%s: no populator module is available",
+            normalized_provider,
+            org_id,
+        )
+        return _zero_summary(
+            provider=normalized_provider,
+            org_id=org_id,
+            reason="populator_not_available",
+        )
+
+    try:
+        summary = populator(
+            org_id=org_id,
+            credentials=credentials,
+            scope=dict(scope or {}),
+        )
+    except Exception as exc:
+        logger.exception(
+            "Team auto-import failed for provider=%s org_id=%s; sync result remains successful",
+            normalized_provider,
+            org_id,
+        )
+        return {
+            **_zero_summary(
+                provider=normalized_provider,
+                org_id=org_id,
+                reason="populator_error",
+            ),
+            "error": str(exc),
+        }
+
+    if not isinstance(summary, Mapping):
+        logger.warning(
+            "Team auto-import populator for provider=%s org_id=%s returned non-mapping summary",
+            normalized_provider,
+            org_id,
+        )
+        return {
+            **_zero_summary(
+                provider=normalized_provider,
+                org_id=org_id,
+                reason="invalid_populator_summary",
+            ),
+            "summary_type": type(summary).__name__,
+        }
+
+    return {
+        "status": "success",
+        "provider": normalized_provider,
+        "org_id": org_id,
+        **dict(summary),
+    }

--- a/tests/workers/test_team_autoimport_batch.py
+++ b/tests/workers/test_team_autoimport_batch.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any
+
+from dev_health_ops.workers import sync_batch
+
+
+def test_batch_repo_options_preserve_autoimport_and_scope_child() -> None:
+    result = sync_batch._repo_sync_options(
+        provider="github",
+        sync_targets=["git", "work-items"],
+        sync_options={
+            "auto_import_teams": True,
+            "discover": True,
+            "all_repos": True,
+            "batch_size": 10,
+            "search": "full-chaos/*",
+        },
+        repo_tuple=("full-chaos", "dev-health"),
+    )
+
+    assert result == {
+        "auto_import_teams": True,
+        "search": "full-chaos/dev-health",
+        "owner": "full-chaos",
+        "repo": "dev-health",
+    }
+
+
+def test_batch_child_autoimport_true_calls_once(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_run_team_autoimport(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"status": "success"}
+
+    monkeypatch.setattr(sync_batch, "run_team_autoimport", fake_run_team_autoimport)
+
+    result = sync_batch._run_team_autoimport_for_batch_child(
+        provider="github",
+        org_id="org-1",
+        credentials={"token": "secret"},
+        sync_options={
+            "auto_import_teams": True,
+            "owner": "full-chaos",
+            "repo": "dev-health",
+        },
+        sync_targets=["git"],
+        config_id="cfg-1",
+        triggered_by="manual",
+    )
+
+    assert result == {"status": "success"}
+    assert len(calls) == 1
+    assert calls[0]["scope"] == {
+        "mode": "batch_child",
+        "sync_config_id": "cfg-1",
+        "sync_targets": ["git"],
+        "sync_options": {
+            "auto_import_teams": True,
+            "owner": "full-chaos",
+            "repo": "dev-health",
+        },
+        "triggered_by": "manual",
+    }

--- a/tests/workers/test_team_autoimport_executor.py
+++ b/tests/workers/test_team_autoimport_executor.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from dev_health_ops.workers import team_autoimport
+
+
+def test_run_team_autoimport_skips_non_capable_provider(caplog) -> None:
+    caplog.set_level(logging.INFO)
+
+    result = team_autoimport.run_team_autoimport(
+        provider="launchdarkly",
+        org_id="org-1",
+        credentials={"token": "secret"},
+    )
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "provider_not_import_capable"
+    assert result["projects_imported"] == 0
+    assert "provider is not import-capable" in caplog.text
+
+
+def test_run_team_autoimport_skips_missing_populator(caplog) -> None:
+    caplog.set_level(logging.INFO)
+
+    result = team_autoimport.run_team_autoimport(
+        provider="github",
+        org_id="org-1",
+        credentials={"token": "secret"},
+        scope={"sync_options": {"auto_import_teams": True}},
+    )
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "populator_not_available"
+    assert result["members_imported"] == 0
+    assert "no populator module is available" in caplog.text
+
+
+def test_run_team_autoimport_calls_resolved_populator(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def populate(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"members_imported": 2}
+
+    monkeypatch.setattr(
+        team_autoimport, "_resolve_populator", lambda provider: populate
+    )
+
+    result = team_autoimport.run_team_autoimport(
+        provider="jira",
+        org_id="org-1",
+        credentials={"token": "secret"},
+        scope={"project_keys": ["OPS"]},
+    )
+
+    assert result == {
+        "status": "success",
+        "provider": "jira",
+        "org_id": "org-1",
+        "members_imported": 2,
+    }
+    assert calls == [
+        {
+            "org_id": "org-1",
+            "credentials": {"token": "secret"},
+            "scope": {"project_keys": ["OPS"]},
+        }
+    ]

--- a/tests/workers/test_team_autoimport_sync_surfaces.py
+++ b/tests/workers/test_team_autoimport_sync_surfaces.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from dev_health_ops.backfill import runner as backfill_runner
+from dev_health_ops.workers import sync_runtime
+
+
+def test_sync_runtime_autoimport_false_or_absent_does_not_call(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        sync_runtime, "run_team_autoimport", lambda **kwargs: calls.append(kwargs)
+    )
+
+    assert (
+        sync_runtime._run_team_autoimport_for_sync_config(
+            provider="jira",
+            org_id="org-1",
+            credentials={},
+            sync_options={},
+            sync_targets=["work-items"],
+            config_id="cfg-1",
+            triggered_by="manual",
+        )
+        is None
+    )
+    assert (
+        sync_runtime._run_team_autoimport_for_sync_config(
+            provider="jira",
+            org_id="org-1",
+            credentials={},
+            sync_options={"auto_import_teams": False},
+            sync_targets=["work-items"],
+            config_id="cfg-1",
+            triggered_by="manual",
+        )
+        is None
+    )
+    assert calls == []
+
+
+def test_sync_runtime_autoimport_true_calls_once(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_run_team_autoimport(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"status": "success"}
+
+    monkeypatch.setattr(sync_runtime, "run_team_autoimport", fake_run_team_autoimport)
+
+    result = sync_runtime._run_team_autoimport_for_sync_config(
+        provider="linear",
+        org_id="org-1",
+        credentials={"api_key": "secret"},
+        sync_options={"auto_import_teams": True, "team": "CHAOS"},
+        sync_targets=["work-items"],
+        config_id="cfg-1",
+        triggered_by="schedule",
+    )
+
+    assert result == {"status": "success"}
+    assert len(calls) == 1
+    assert calls[0] == {
+        "provider": "linear",
+        "org_id": "org-1",
+        "credentials": {"api_key": "secret"},
+        "scope": {
+            "mode": "sync_config",
+            "sync_config_id": "cfg-1",
+            "sync_targets": ["work-items"],
+            "sync_options": {"auto_import_teams": True, "team": "CHAOS"},
+            "triggered_by": "schedule",
+        },
+    }
+
+
+def test_backfill_autoimport_false_or_absent_does_not_call(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        backfill_runner, "run_team_autoimport", lambda **kwargs: calls.append(kwargs)
+    )
+
+    assert (
+        backfill_runner._run_team_autoimport_for_backfill(
+            provider="jira",
+            org_id="org-1",
+            credentials={},
+            sync_options={},
+            sync_config_id="cfg-1",
+            since=date(2026, 1, 1),
+            before=date(2026, 1, 7),
+            window_count=1,
+        )
+        is None
+    )
+    assert (
+        backfill_runner._run_team_autoimport_for_backfill(
+            provider="jira",
+            org_id="org-1",
+            credentials={},
+            sync_options={"auto_import_teams": False},
+            sync_config_id="cfg-1",
+            since=date(2026, 1, 1),
+            before=date(2026, 1, 7),
+            window_count=1,
+        )
+        is None
+    )
+    assert calls == []
+
+
+def test_backfill_autoimport_true_calls_once(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_run_team_autoimport(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"status": "success"}
+
+    monkeypatch.setattr(
+        backfill_runner, "run_team_autoimport", fake_run_team_autoimport
+    )
+
+    result = backfill_runner._run_team_autoimport_for_backfill(
+        provider="jira",
+        org_id="org-1",
+        credentials={"email": "dev@example.com"},
+        sync_options={"auto_import_teams": True, "project_keys": ["OPS"]},
+        sync_config_id="cfg-1",
+        since=date(2026, 1, 1),
+        before=date(2026, 1, 7),
+        window_count=1,
+    )
+
+    assert result == {"status": "success"}
+    assert len(calls) == 1
+    assert calls[0] == {
+        "provider": "jira",
+        "org_id": "org-1",
+        "credentials": {"email": "dev@example.com"},
+        "scope": {
+            "mode": "backfill",
+            "sync_config_id": "cfg-1",
+            "sync_options": {"auto_import_teams": True, "project_keys": ["OPS"]},
+            "window_count": 1,
+            "since": "2026-01-01",
+            "before": "2026-01-07",
+        },
+    }


### PR DESCRIPTION
## Summary
- add `workers/team_autoimport.py` executor with capability-gated lazy provider populator dispatch
- thread `sync_options.auto_import_teams` through sync runtime, batch children, and backfill after successful sync work
- add unit coverage for disabled/enabled calls, batch option preservation, capability no-op, and missing populator no-op

## Verification
- `CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/workers/test_team_autoimport_executor.py tests/workers/test_team_autoimport_sync_surfaces.py tests/workers/test_team_autoimport_batch.py -q`
- `uv run --extra dev --python 3.11 mypy src/dev_health_ops/workers/team_autoimport.py src/dev_health_ops/workers/sync_runtime.py src/dev_health_ops/workers/sync_batch.py src/dev_health_ops/backfill/runner.py`
- `uv run --extra dev --python 3.11 ruff check src/dev_health_ops/workers/team_autoimport.py src/dev_health_ops/workers/sync_runtime.py src/dev_health_ops/workers/sync_batch.py src/dev_health_ops/backfill/runner.py tests/workers/test_team_autoimport_executor.py tests/workers/test_team_autoimport_sync_surfaces.py tests/workers/test_team_autoimport_batch.py`
- LSP diagnostics clean on changed source/test files

Closes CHAOS-2544.

SCREENSHOT-WAIVER: backend only.