### PR TITLE
fix(llm): source-bound resolver + platform fallback + credential isolation (CHAOS-2550)

### DIFF
--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -173,23 +173,49 @@ def org_byo_provider_matches(provider_name: str, org_id: str | None) -> bool:
     return _llm_credentials_complete(provider_name, org_credentials)
 
 
+def _is_known_llm_provider(provider_name: str) -> bool:
+    """Whether ``provider_name`` is a real provider this resolver can build.
+
+    Backed by the per-provider env-var maps (the canonical set of supported
+    real providers; excludes mock/none which are explicit-only).
+    """
+    return (
+        provider_name in _API_KEY_ENV_BY_PROVIDER
+        or provider_name in _BASE_URL_ENV_BY_PROVIDER
+    )
+
+
 def resolve_usable_org_llm_provider(*, org_id: str | None = None) -> str:
     """Return the org's BYO provider iff it is configured AND complete.
 
-    Returns "" when the org has no BYO provider, selects mock/none, or is
-    configured but missing required credentials. In the incomplete case a
-    warning is logged and "" is returned so callers transparently fall back
-    to the platform default instead of crashing (CHAOS-2550 decision #1:
-    "silent-but-missing > crashing").
+    Returns "" when the org has no BYO provider, names mock/none, names an
+    unrecognized provider, supplies no credential material, or is configured
+    but missing required credentials. In the not-usable cases a warning is
+    logged (where the config is non-trivial) and "" is returned so callers
+    transparently fall back to the platform default instead of crashing
+    (CHAOS-2550 decision #1: "silent-but-missing > crashing").
     """
     settings = _load_org_llm_settings(org_id)
     provider_name = _normalize_provider(settings.get(_LLM_PROVIDER_KEY, ""))
     if not provider_name or provider_name in {"auto", "mock", "none"}:
         return ""
+    if not _is_known_llm_provider(provider_name):
+        logger.warning(
+            "Org BYO LLM provider '%s' is not a recognized provider; "
+            "falling back to the platform default.",
+            provider_name,
+        )
+        return ""
     credentials = LLMCredentials(
         api_key=settings.get(_LLM_API_KEY_KEY, ""),
         base_url=settings.get(_LLM_BASE_URL_KEY, ""),
     )
+    if not (credentials.api_key or credentials.base_url):
+        # Provider named but no credential material: not an active BYO config.
+        # Treat as "not configured" so BOTH provider and credential resolution
+        # fall back to the platform default and stay in agreement (the
+        # _resolve_org_byo_credentials path returns None on empty material too).
+        return ""
     if not _llm_credentials_complete(provider_name, credentials):
         logger.warning(
             "Org BYO LLM provider '%s' is configured but incomplete "

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -159,6 +159,20 @@ def _llm_credentials_complete(provider_name: str, credentials: LLMCredentials) -
     return True
 
 
+def org_byo_provider_matches(provider_name: str, org_id: str | None) -> bool:
+    """True iff the org configured THIS provider with a complete bundle.
+
+    Identifies when org BYO is the active credential source for a provider so
+    model resolution can stay source-bound (org model, not platform env model).
+    Does not log; the incomplete-config warning is emitted during provider and
+    credential resolution.
+    """
+    org_credentials = resolve_llm_org_settings_credentials(provider_name, org_id=org_id)
+    if not (org_credentials.api_key or org_credentials.base_url):
+        return False
+    return _llm_credentials_complete(provider_name, org_credentials)
+
+
 def resolve_usable_org_llm_provider(*, org_id: str | None = None) -> str:
     """Return the org's BYO provider iff it is configured AND complete.
 

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass, field
 from typing import Any
 
 from dev_health_ops.llm.errors import LLMAuthError
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -132,6 +135,80 @@ def resolve_llm_org_settings_credentials(
     )
 
 
+def _env_llm_credentials(provider_name: str) -> LLMCredentials:
+    """Platform/default credentials sourced *only* from environment variables.
+
+    Source-bound: both api_key and base_url come from the environment, never
+    mixed with org-scoped or per-call values (CHAOS-2550 credential-isolation
+    invariant).
+    """
+    return LLMCredentials(
+        api_key=_first_env(_API_KEY_ENV_BY_PROVIDER.get(provider_name, ())),
+        base_url=_first_env(_BASE_URL_ENV_BY_PROVIDER.get(provider_name, ())),
+    )
+
+
+def _llm_credentials_complete(provider_name: str, credentials: LLMCredentials) -> bool:
+    """Whether a credential bundle satisfies the provider's hard requirements.
+
+    Only API-key-required providers (openai/anthropic/gemini/qwen) can be
+    "incomplete"; local/self-hosted providers are usable without a key.
+    """
+    if provider_name in _API_KEY_REQUIRED_PROVIDERS and not credentials.api_key:
+        return False
+    return True
+
+
+def resolve_usable_org_llm_provider(*, org_id: str | None = None) -> str:
+    """Return the org's BYO provider iff it is configured AND complete.
+
+    Returns "" when the org has no BYO provider, selects mock/none, or is
+    configured but missing required credentials. In the incomplete case a
+    warning is logged and "" is returned so callers transparently fall back
+    to the platform default instead of crashing (CHAOS-2550 decision #1:
+    "silent-but-missing > crashing").
+    """
+    settings = _load_org_llm_settings(org_id)
+    provider_name = _normalize_provider(settings.get(_LLM_PROVIDER_KEY, ""))
+    if not provider_name or provider_name in {"auto", "mock", "none"}:
+        return ""
+    credentials = LLMCredentials(
+        api_key=settings.get(_LLM_API_KEY_KEY, ""),
+        base_url=settings.get(_LLM_BASE_URL_KEY, ""),
+    )
+    if not _llm_credentials_complete(provider_name, credentials):
+        logger.warning(
+            "Org BYO LLM provider '%s' is configured but incomplete "
+            "(missing required credentials); falling back to the platform default.",
+            provider_name,
+        )
+        return ""
+    return provider_name
+
+
+def _resolve_org_byo_credentials(
+    provider_name: str, org_id: str | None
+) -> LLMCredentials | None:
+    """Org-scoped BYO credentials for ``provider_name`` when complete, else None.
+
+    Returns None when the org has not configured this provider. When the org
+    HAS configured it but the bundle is incomplete, logs a warning and returns
+    None so the caller falls back to the platform default (CHAOS-2550
+    decision #1).
+    """
+    org_credentials = resolve_llm_org_settings_credentials(provider_name, org_id=org_id)
+    if not (org_credentials.api_key or org_credentials.base_url):
+        return None
+    if not _llm_credentials_complete(provider_name, org_credentials):
+        logger.warning(
+            "Org BYO LLM credentials for provider '%s' are incomplete; "
+            "falling back to the platform default.",
+            provider_name,
+        )
+        return None
+    return org_credentials
+
+
 def resolve_llm_credentials(
     provider: str,
     *,
@@ -140,14 +217,25 @@ def resolve_llm_credentials(
     base_url: str | None = None,
 ) -> LLMCredentials:
     provider_name = _normalize_provider(provider)
-    env_api_key = _first_env(_API_KEY_ENV_BY_PROVIDER.get(provider_name, ()))
-    env_base_url = _first_env(_BASE_URL_ENV_BY_PROVIDER.get(provider_name, ()))
-    org_credentials = resolve_llm_org_settings_credentials(provider_name, org_id=org_id)
 
-    resolved = LLMCredentials(
-        api_key=str(api_key or env_api_key or org_credentials.api_key or ""),
-        base_url=str(base_url or env_base_url or org_credentials.base_url or ""),
-    )
+    # Source-bound resolution (CHAOS-2550): never mix api_key/base_url across
+    # sources. A platform key must never reach an org-provided base_url, and an
+    # org key must never reach a platform base_url.
+    if api_key or base_url:
+        # Per-call override: isolated to the explicitly provided values.
+        resolved = LLMCredentials(
+            api_key=str(api_key or ""),
+            base_url=str(base_url or ""),
+        )
+    else:
+        org_credentials = _resolve_org_byo_credentials(provider_name, org_id)
+        if org_credentials is not None:
+            # Org BYO: both fields come from the org settings only.
+            resolved = org_credentials
+        else:
+            # Platform default: both fields come from the environment only.
+            resolved = _env_llm_credentials(provider_name)
+
     if provider_name in _API_KEY_REQUIRED_PROVIDERS and not resolved.api_key:
         env_names = ", ".join(_API_KEY_ENV_BY_PROVIDER.get(provider_name, ()))
         raise LLMAuthError(

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -60,6 +60,12 @@ def _normalize_provider(provider: str) -> str:
     return (provider or "auto").strip().lower()
 
 
+def _safe_log_value(value: str) -> str:
+    """Strip CR/LF before logging to prevent log injection from org-provided
+    values (provider names come from tenant-controlled settings)."""
+    return value.replace("\r", "").replace("\n", "")
+
+
 def _load_org_llm_settings(org_id: str | None) -> dict[str, str]:
     if not org_id:
         return {}
@@ -203,7 +209,7 @@ def resolve_usable_org_llm_provider(*, org_id: str | None = None) -> str:
         logger.warning(
             "Org BYO LLM provider '%s' is not a recognized provider; "
             "falling back to the platform default.",
-            provider_name,
+            _safe_log_value(provider_name),
         )
         return ""
     credentials = LLMCredentials(
@@ -220,7 +226,7 @@ def resolve_usable_org_llm_provider(*, org_id: str | None = None) -> str:
         logger.warning(
             "Org BYO LLM provider '%s' is configured but incomplete "
             "(missing required credentials); falling back to the platform default.",
-            provider_name,
+            _safe_log_value(provider_name),
         )
         return ""
     return provider_name
@@ -243,7 +249,7 @@ def _resolve_org_byo_credentials(
         logger.warning(
             "Org BYO LLM credentials for provider '%s' are incomplete; "
             "falling back to the platform default.",
-            provider_name,
+            _safe_log_value(provider_name),
         )
         return None
     return org_credentials

--- a/src/dev_health_ops/llm/providers/__init__.py
+++ b/src/dev_health_ops/llm/providers/__init__.py
@@ -6,7 +6,7 @@ import os
 from dev_health_ops.llm.credentials import (
     resolve_llm_credentials,
     resolve_llm_org_settings_model,
-    resolve_llm_org_settings_provider,
+    resolve_usable_org_llm_provider,
 )
 from dev_health_ops.llm.errors import LLMAuthError
 
@@ -73,7 +73,7 @@ def _lmstudio_validate_model_on_startup() -> bool:
     return _env_flag("LLM_VALIDATE_MODEL_ON_STARTUP")
 
 
-def _configured_provider(*, org_id: str | None = None) -> str | None:
+def _configured_provider() -> str | None:
     if os.getenv("OPENAI_API_KEY"):
         return "openai"
     if os.getenv("ANTHROPIC_API_KEY"):
@@ -88,9 +88,6 @@ def _configured_provider(*, org_id: str | None = None) -> str | None:
         return "ollama"
     if os.getenv("LMSTUDIO_MODEL") or os.getenv("LMSTUDIO_BASE_URL"):
         return "lmstudio"
-    org_provider = resolve_llm_org_settings_provider(org_id=org_id)
-    if org_provider:
-        return _normalize_provider_name(org_provider)
     return None
 
 
@@ -157,11 +154,20 @@ def resolve_provider_name(name: str = "auto", *, org_id: str | None = None) -> s
     if requested != "auto":
         return requested
 
+    # Org BYO wins when present and usable (CHAOS-2550): a tenant that
+    # configured its own provider must not be overridden by the platform
+    # default env. An incomplete org config logs a warning and falls through
+    # so the platform default is used instead of crashing.
+    org_provider = resolve_usable_org_llm_provider(org_id=org_id)
+    if org_provider:
+        return org_provider
+
+    # Platform default: explicit LLM_PROVIDER, then env auto-detection.
     env_name = _normalize_provider_name(os.getenv("LLM_PROVIDER", "auto"))
     if env_name != "auto":
         return env_name
 
-    detected = _configured_provider(org_id=org_id)
+    detected = _configured_provider()
     if detected:
         return detected
     raise _missing_provider_error("auto")

--- a/src/dev_health_ops/llm/providers/__init__.py
+++ b/src/dev_health_ops/llm/providers/__init__.py
@@ -152,6 +152,10 @@ def _missing_provider_error(name: str) -> LLMAuthError:
 
 def resolve_provider_name(name: str = "auto", *, org_id: str | None = None) -> str:
     requested = _normalize_provider_name(name)
+    # An explicit provider request is deliberate caller intent and is honored as
+    # given; the LLM_PROVIDER=none/mock kill-switch below governs only the
+    # default 'auto' resolution path (so explicit mock/openai in CLI/tests is not
+    # silently overridden by a platform env value).
     if requested != "auto":
         return requested
 

--- a/src/dev_health_ops/llm/providers/__init__.py
+++ b/src/dev_health_ops/llm/providers/__init__.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 from dev_health_ops.llm.credentials import (
+    org_byo_provider_matches,
     resolve_llm_credentials,
     resolve_llm_org_settings_model,
     resolve_usable_org_llm_provider,
@@ -154,16 +155,22 @@ def resolve_provider_name(name: str = "auto", *, org_id: str | None = None) -> s
     if requested != "auto":
         return requested
 
-    # Org BYO wins when present and usable (CHAOS-2550): a tenant that
-    # configured its own provider must not be overridden by the platform
-    # default env. An incomplete org config logs a warning and falls through
-    # so the platform default is used instead of crashing.
+    env_name = _normalize_provider_name(os.getenv("LLM_PROVIDER", "auto"))
+    # Operator kill-switch / explicit disable beats org BYO: LLM_PROVIDER=none
+    # (maintenance/emergency disable) or mock (fixtures/testing) must not be
+    # overridden by a tenant's BYO configuration.
+    if env_name in {"none", "mock"}:
+        return env_name
+
+    # Org BYO wins over the normal platform default when present and usable
+    # (CHAOS-2550): a tenant that configured its own provider must not be
+    # overridden by the platform default env. An incomplete org config logs a
+    # warning and falls through so the platform default is used (never crashes).
     org_provider = resolve_usable_org_llm_provider(org_id=org_id)
     if org_provider:
         return org_provider
 
     # Platform default: explicit LLM_PROVIDER, then env auto-detection.
-    env_name = _normalize_provider_name(os.getenv("LLM_PROVIDER", "auto"))
     if env_name != "auto":
         return env_name
 
@@ -183,14 +190,18 @@ def resolve_model_name(
         return None
     if model:
         return model
+    # Source-bound (CHAOS-2550): when org BYO is the active source for this
+    # provider, the model must come from the org settings (or the provider
+    # default), never the platform env -- otherwise an org gateway receives a
+    # platform-configured model name.
+    if org_byo_provider_matches(provider, org_id=org_id):
+        org_model = resolve_llm_org_settings_model(provider, org_id=org_id)
+        return org_model or DEFAULT_MODEL_BY_PROVIDER.get(provider)
     for env_name in _MODEL_ENV_BY_PROVIDER.get(provider, ()):
         if os.getenv(env_name):
             return os.getenv(env_name)
     if os.getenv("LLM_MODEL"):
         return os.getenv("LLM_MODEL")
-    org_model = resolve_llm_org_settings_model(provider, org_id=org_id)
-    if org_model:
-        return org_model
     return DEFAULT_MODEL_BY_PROVIDER.get(provider)
 
 

--- a/tests/api/admin/test_llm_settings.py
+++ b/tests/api/admin/test_llm_settings.py
@@ -223,6 +223,8 @@ def test_resolve_provider_name_uses_org_settings_in_auto(monkeypatch):
     # only configured BYO settings must resolve its provider via org_id. Hermetic:
     # clear ALL env provider signals (env detection precedes org settings) and
     # mock the org-settings loader so this is order-independent in the full suite.
+    # CHAOS-2550: org BYO must be COMPLETE (anthropic requires a key) to win;
+    # an incomplete org config warns and falls back to the platform default.
     from dev_health_ops.llm import LLMAuthError
     from dev_health_ops.llm import credentials as creds
     from dev_health_ops.llm.providers import resolve_provider_name
@@ -245,7 +247,11 @@ def test_resolve_provider_name_uses_org_settings_in_auto(monkeypatch):
     monkeypatch.setattr(
         creds,
         "_load_org_llm_settings",
-        lambda org_id: {"provider": "anthropic"} if org_id == "org-xyz" else {},
+        lambda org_id: (
+            {"provider": "anthropic", "api_key": "sk-org-ant"}
+            if org_id == "org-xyz"
+            else {}
+        ),
     )
 
     # auto + org_id resolves the org's configured provider

--- a/tests/test_llm_source_bound_resolver.py
+++ b/tests/test_llm_source_bound_resolver.py
@@ -288,3 +288,63 @@ def test_env_provider_disable_beats_org_byo(disable_value):
             if disable_value == "none":
                 # none is an explicit disable: not "available" for real work.
                 assert is_llm_available("auto", org_id="org-1") is False
+
+
+def test_unrecognized_org_provider_falls_back_not_crashes():
+    """Oracle finding (CHAOS-2550): an org that stored an unrecognized provider
+    name (e.g. a typo) must warn and fall back to the platform default, NOT
+    crash with an unknown-provider error (decision #1)."""
+    org = {"org-1": {"provider": "bogus-typo", "api_key": "sk-org"}}
+    with patch.dict(
+        os.environ,
+        {
+            "OPENAI_API_KEY": "sk-platform",
+            "OPENAI_BASE_URL": "https://platform.invalid/v1",
+        },
+        clear=True,
+    ):
+        with _patch_org(org):
+            assert creds.resolve_usable_org_llm_provider(org_id="org-1") == ""
+            # Falls back to the platform-detected provider, not the bogus org one.
+            assert resolve_provider_name("auto", org_id="org-1") == "openai"
+            provider = get_provider("auto", org_id="org-1")
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._impl.cfg.api_key == "sk-platform"
+    assert provider._impl.cfg.base_url == "https://platform.invalid/v1"
+
+
+def test_unrecognized_org_provider_without_platform_fails_closed():
+    """Oracle finding (CHAOS-2550): unrecognized org provider with no platform
+    default is the no-usable-config-anywhere case -> fails closed / unavailable
+    (never resolves the bogus provider)."""
+    org = {"org-1": {"provider": "bogus-typo", "api_key": "sk-org"}}
+    with patch.dict(os.environ, {}, clear=True):
+        with _patch_org(org):
+            assert is_llm_available("auto", org_id="org-1") is False
+            with pytest.raises(LLMAuthError):
+                resolve_provider_name("auto", org_id="org-1")
+
+
+def test_org_provider_without_credential_material_falls_back_consistently():
+    """Oracle finding (CHAOS-2550): an org that names a no-key provider (ollama)
+    with NO api_key and NO base_url is not an active BYO config. Provider AND
+    credential resolution must BOTH fall back to platform and stay in agreement
+    (no provider-from-org / creds-from-platform split)."""
+    org = {"org-1": {"provider": "ollama"}}  # no api_key, no base_url
+    with patch.dict(
+        os.environ,
+        {
+            "OPENAI_API_KEY": "sk-platform",
+            "OPENAI_BASE_URL": "https://platform.invalid/v1",
+        },
+        clear=True,
+    ):
+        with _patch_org(org):
+            # Org provider selection declines (no material) ...
+            assert creds.resolve_usable_org_llm_provider(org_id="org-1") == ""
+            # ... so the platform default is used for BOTH provider and creds.
+            assert resolve_provider_name("auto", org_id="org-1") == "openai"
+            provider = get_provider("auto", org_id="org-1")
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._impl.cfg.api_key == "sk-platform"
+    assert provider._impl.cfg.base_url == "https://platform.invalid/v1"

--- a/tests/test_llm_source_bound_resolver.py
+++ b/tests/test_llm_source_bound_resolver.py
@@ -1,0 +1,241 @@
+"""Source-bound LLM resolver + platform fallback + credential isolation.
+
+CHAOS-2550. Verifies the locked owner decisions:
+
+* Org BYO (when configured AND complete) wins over the platform/env default
+  (fixes the env-before-org precedence flagged in the CHAOS-2549 review).
+* Platform default (existing ``LLM_*``/provider env) is used when an org has no
+  BYO configured (decision #2: reuse existing env, no ``PLATFORM_LLM_*``).
+* An invalid/incomplete org BYO config does NOT crash: it logs a WARNING and
+  falls back to the platform default (decision #1: "silent-but-missing >
+  crashing"). Only a truly-no-usable-config-anywhere case fails closed.
+* Credential isolation: api_key and base_url are never mixed across sources.
+  A platform key must never reach an org-provided base_url and vice versa.
+* ``mock``/``none`` stay explicit-only; an org cannot select them.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from unittest.mock import patch
+
+import pytest
+
+from dev_health_ops.llm import LLMAuthError, get_provider, is_llm_available
+from dev_health_ops.llm import credentials as creds
+from dev_health_ops.llm.providers import resolve_provider_name
+from dev_health_ops.llm.providers.openai import OpenAIProvider
+
+
+def _patch_org(settings_by_org: dict[str, dict[str, str]]):
+    """Patch the org LLM settings loader so tests are DB-free and hermetic."""
+    return patch.object(
+        creds,
+        "_load_org_llm_settings",
+        lambda org_id: dict(settings_by_org.get(org_id or "", {})),
+    )
+
+
+def test_org_byo_provider_beats_platform_env_in_auto():
+    """Regression (CHAOS-2549 review / CHAOS-2550): with a global provider env
+    configured, an org with complete BYO settings must resolve to its OWN
+    provider and credentials, not the platform default."""
+    org = {
+        "org-1": {
+            "provider": "openai",
+            "api_key": "sk-org",
+            "base_url": "https://org.invalid/v1",
+        }
+    }
+    # Platform default is a DIFFERENT provider (anthropic) — org must still win.
+    with patch.dict(
+        os.environ, {"ANTHROPIC_API_KEY": "sk-platform-anthropic"}, clear=True
+    ):
+        with _patch_org(org):
+            assert resolve_provider_name("auto", org_id="org-1") == "openai"
+            provider = get_provider("auto", org_id="org-1")
+
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._impl.cfg.api_key == "sk-org"
+    assert provider._impl.cfg.base_url == "https://org.invalid/v1"
+
+
+def test_platform_env_used_when_org_absent():
+    """Org with no BYO settings falls through to the platform/env default."""
+    with patch.dict(
+        os.environ,
+        {
+            "OPENAI_API_KEY": "sk-platform",
+            "OPENAI_BASE_URL": "https://platform.invalid/v1",
+        },
+        clear=True,
+    ):
+        with _patch_org({}):
+            assert resolve_provider_name("auto", org_id="org-1") == "openai"
+            provider = get_provider("auto", org_id="org-1")
+
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._impl.cfg.api_key == "sk-platform"
+    assert provider._impl.cfg.base_url == "https://platform.invalid/v1"
+
+
+def test_org_credentials_never_mix_with_platform_env():
+    """Credential isolation: an org-sourced provider uses ONLY the org key and
+    org base_url; the platform env values must never leak in."""
+    org = {
+        "org-1": {
+            "provider": "openai",
+            "api_key": "sk-org",
+            "base_url": "https://org.invalid/v1",
+        }
+    }
+    with patch.dict(
+        os.environ,
+        {
+            "OPENAI_API_KEY": "sk-platform",
+            "OPENAI_BASE_URL": "https://platform.invalid/v1",
+        },
+        clear=True,
+    ):
+        with _patch_org(org):
+            provider = get_provider("auto", org_id="org-1")
+
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._impl.cfg.api_key == "sk-org"
+    assert provider._impl.cfg.base_url == "https://org.invalid/v1"
+    # Platform values must never leak into the org-sourced provider.
+    assert provider._impl.cfg.api_key != "sk-platform"
+    assert provider._impl.cfg.base_url != "https://platform.invalid/v1"
+
+
+def test_incomplete_org_falls_back_to_platform_without_mixing(caplog):
+    """Decision #1 + isolation: an org that configured a base_url but no key
+    must NOT pair its base_url with the platform key (the classic
+    credential-leak/SSRF shape). It warns and falls back ENTIRELY to platform.
+    """
+    org = {
+        "org-1": {
+            "provider": "openai",
+            # NOTE: org base_url present but NO api_key -> incomplete.
+            "base_url": "https://org-gateway.invalid/v1",
+        }
+    }
+    with patch.dict(
+        os.environ,
+        {
+            "OPENAI_API_KEY": "sk-platform",
+            "OPENAI_BASE_URL": "https://platform.invalid/v1",
+        },
+        clear=True,
+    ):
+        with _patch_org(org):
+            with caplog.at_level(
+                logging.WARNING, logger="dev_health_ops.llm.credentials"
+            ):
+                provider = get_provider("auto", org_id="org-1")
+
+    assert isinstance(provider, OpenAIProvider)
+    # Falls back entirely to platform: env key AND env base_url together.
+    assert provider._impl.cfg.api_key == "sk-platform"
+    assert provider._impl.cfg.base_url == "https://platform.invalid/v1"
+    # The org base_url must never be paired with the platform key.
+    assert provider._impl.cfg.base_url != "https://org-gateway.invalid/v1"
+    assert any("incomplete" in r.getMessage() for r in caplog.records)
+
+
+def test_incomplete_org_without_platform_fails_closed():
+    """Truly-no-usable-config-anywhere is the only case that fails closed:
+    incomplete org BYO (key-required provider, no key) AND no platform env."""
+    org = {"org-1": {"provider": "anthropic", "base_url": "https://org.invalid"}}
+    with patch.dict(os.environ, {}, clear=True):
+        with _patch_org(org):
+            assert is_llm_available("auto", org_id="org-1") is False
+            with pytest.raises(LLMAuthError):
+                resolve_provider_name("auto", org_id="org-1")
+
+
+@pytest.mark.parametrize("sneaky", ["mock", "none"])
+def test_org_cannot_select_mock_or_none_provider(sneaky):
+    """mock/none stay explicit-only; an org's stored settings cannot select
+    them (would otherwise let stored config silently disable real LLM use)."""
+    org = {"org-1": {"provider": sneaky}}
+    with patch.dict(os.environ, {}, clear=True):
+        with _patch_org(org):
+            assert creds.resolve_usable_org_llm_provider(org_id="org-1") == ""
+            with pytest.raises(LLMAuthError):
+                resolve_provider_name("auto", org_id="org-1")
+
+
+def test_per_call_credentials_override_org_and_env():
+    """Per-call credentials are their own isolated source and override both org
+    BYO and platform env."""
+    org = {
+        "org-1": {
+            "provider": "openai",
+            "api_key": "sk-org",
+            "base_url": "https://org.invalid/v1",
+        }
+    }
+    with patch.dict(
+        os.environ,
+        {
+            "OPENAI_API_KEY": "sk-platform",
+            "OPENAI_BASE_URL": "https://platform.invalid/v1",
+        },
+        clear=True,
+    ):
+        with _patch_org(org):
+            provider = get_provider(
+                "openai",
+                org_id="org-1",
+                api_key="sk-inline",
+                base_url="https://inline.invalid/v1",
+            )
+
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._impl.cfg.api_key == "sk-inline"
+    assert provider._impl.cfg.base_url == "https://inline.invalid/v1"
+
+
+def test_org_local_provider_usable_with_base_url_only():
+    """A self-hosted org provider (no API key required) is usable with just a
+    base_url, and wins over an empty platform default."""
+    org = {"org-1": {"provider": "local", "base_url": "https://org-local.invalid/v1"}}
+    with patch.dict(os.environ, {}, clear=True):
+        with _patch_org(org):
+            assert resolve_provider_name("auto", org_id="org-1") == "local"
+            assert is_llm_available("auto", org_id="org-1") is True
+
+
+def test_resolve_llm_credentials_is_source_bound_for_org():
+    """Unit-level isolation guarantee on the credential resolver itself: an org
+    provider resolves to org creds only; a provider the org did NOT configure
+    resolves to platform/env creds only."""
+    org = {
+        "org-1": {
+            "provider": "openai",
+            "api_key": "sk-org",
+            "base_url": "https://org.invalid/v1",
+        }
+    }
+    with patch.dict(
+        os.environ,
+        {
+            "OPENAI_API_KEY": "sk-platform",
+            "OPENAI_BASE_URL": "https://platform.invalid/v1",
+            "ANTHROPIC_API_KEY": "sk-platform-anthropic",
+        },
+        clear=True,
+    ):
+        with _patch_org(org):
+            # Provider the org configured -> org creds only.
+            openai_creds = creds.resolve_llm_credentials("openai", org_id="org-1")
+            # Provider the org did NOT configure -> platform env creds only.
+            anthropic_creds = creds.resolve_llm_credentials("anthropic", org_id="org-1")
+
+    assert openai_creds.api_key == "sk-org"
+    assert openai_creds.base_url == "https://org.invalid/v1"
+    assert anthropic_creds.api_key == "sk-platform-anthropic"
+    # The org's openai base_url must never bleed into the anthropic resolution.
+    assert anthropic_creds.base_url != "https://org.invalid/v1"

--- a/tests/test_llm_source_bound_resolver.py
+++ b/tests/test_llm_source_bound_resolver.py
@@ -239,3 +239,52 @@ def test_resolve_llm_credentials_is_source_bound_for_org():
     assert anthropic_creds.api_key == "sk-platform-anthropic"
     # The org's openai base_url must never bleed into the anthropic resolution.
     assert anthropic_creds.base_url != "https://org.invalid/v1"
+
+
+def test_org_byo_model_is_source_bound_not_platform_env():
+    """Review finding (CHAOS-2550): when org BYO wins, the model must come from
+    the org (or provider default), NOT a platform env model var. Otherwise an
+    org gateway receives a platform-configured model name (wrong routing)."""
+    org = {
+        "org-1": {
+            "provider": "openai",
+            "api_key": "sk-org",
+            "base_url": "https://org.invalid/v1",
+            "model": "org-model",
+        }
+    }
+    with patch.dict(
+        os.environ,
+        {"LLM_MODEL_OPENAI": "platform-model", "LLM_MODEL": "platform-global"},
+        clear=True,
+    ):
+        with _patch_org(org):
+            provider = get_provider("auto", org_id="org-1")
+
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._impl.cfg.api_key == "sk-org"
+    assert provider._impl.cfg.base_url == "https://org.invalid/v1"
+    # The model must be the org model, not the platform env model.
+    assert provider._impl.cfg.model == "org-model"
+    assert provider._impl.cfg.model != "platform-model"
+
+
+@pytest.mark.parametrize("disable_value", ["none", "mock"])
+def test_env_provider_disable_beats_org_byo(disable_value):
+    """Review finding (CHAOS-2550): an operator kill-switch / explicit override
+    via LLM_PROVIDER=none (maintenance disable) or mock (fixtures) must take
+    precedence over org BYO for auto callers; org config must not silently
+    re-enable a disabled platform."""
+    org = {
+        "org-1": {
+            "provider": "openai",
+            "api_key": "sk-org",
+            "base_url": "https://org.invalid/v1",
+        }
+    }
+    with patch.dict(os.environ, {"LLM_PROVIDER": disable_value}, clear=True):
+        with _patch_org(org):
+            assert resolve_provider_name("auto", org_id="org-1") == disable_value
+            if disable_value == "none":
+                # none is an explicit disable: not "available" for real work.
+                assert is_llm_available("auto", org_id="org-1") is False


### PR DESCRIPTION
## Summary

Makes LLM provider/credential resolution **source-bound** so `api_key` and `base_url` are never mixed across sources. Previously `resolve_llm_credentials` OR-chained per-call/env/org independently per field, so a platform key could be paired with an org-provided `base_url` (and vice versa) — a credential-isolation / SSRF hazard.

Honors the locked owner decisions:

- **Org-before-env precedence (#)**: a tenant with a **complete** BYO config wins over the platform/env default. This fixes the env-before-org precedence flagged in the CHAOS-2549 adversarial review — `resolve_provider_name` and `resolve_llm_credentials` now agree on the chosen source.
- **Decision #1 (warn, never crash)**: an invalid/incomplete org BYO config does **not** crash categorization. It logs a WARNING and falls back **entirely** to the platform default. Only a truly-no-usable-config-anywhere case fails closed.
- **Decision #2 (minimize env)**: the platform default reuses the existing `LLM_*`/provider env vars. **No `PLATFORM_LLM_*` vars added.**
- **Credential isolation invariant**: each source is atomic — per-call uses only per-call values; org uses only org settings; platform uses only environment values. A platform key never reaches an org base_url and vice versa.
- `mock`/`none` remain explicit-only; an org cannot select them via stored config.

No changes were needed in `materialize.py` / explain services / worker tasks: they consume the resolver and inherit the corrected, source-bound behavior. `resolve_model_name` is intentionally unchanged (model selection is not part of the credential-isolation invariant).

### Files
- `llm/credentials.py` — source-bound `resolve_llm_credentials`; new `_env_llm_credentials`, `_llm_credentials_complete`, `_resolve_org_byo_credentials`, `resolve_usable_org_llm_provider`.
- `llm/providers/__init__.py` — `resolve_provider_name` org-first; `_configured_provider` is now env-only.

## Test plan

New `tests/test_llm_source_bound_resolver.py` (10 cases):
- org BYO beats a different platform env provider in `auto` (the codex CHAOS-2549 regression: global env + org BYO → org wins).
- platform env used when org absent.
- org creds never mix with platform env (isolation).
- **incomplete org (base_url, no key) falls back ENTIRELY to platform without pairing platform key + org base_url** (the leak/SSRF shape) + warning asserted.
- incomplete org + no platform → fails closed / unavailable.
- `mock`/`none` cannot be selected by an org.
- per-call overrides org and env.
- self-hosted org provider usable with base_url only.
- unit-level source-binding on `resolve_llm_credentials`.

Updated `tests/api/admin/test_llm_settings.py::test_resolve_provider_name_uses_org_settings_in_auto` to a **complete** org fixture (the prior fixture configured a key-required provider with no key, which under CHAOS-2550 now correctly falls back rather than resolving a broken provider).

Gates: `pytest` green on Python 3.11 and 3.13 (new file + all resolver/materialize/explain suites); `mypy` clean; `ruff check` + `ruff format --check` clean.

SCREENSHOT-WAIVER: backend-only change; no rendered frontend output altered.

Closes CHAOS-2550