### PR TITLE
feat(teams): populate GitHub/GitLab team repo ownership on auto-import (CHAOS-2546)

### DIFF
--- a/src/dev_health_ops/workers/team_autoimport_github.py
+++ b/src/dev_health_ops/workers/team_autoimport_github.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from dev_health_ops.api.services.configuration.team_discovery import (
+    TeamDiscoveryService,
+)
+from dev_health_ops.api.services.configuration.team_membership import (
+    TeamMembershipService,
+)
+from dev_health_ops.metrics.schemas import TeamMembershipRecord, TeamRepoOwnershipRecord
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.providers.team_capabilities import team_provider_capabilities
+
+logger = logging.getLogger(__name__)
+
+PROVIDER = "github"
+PROVIDER_ACCESS_PRIORITY = 300
+BASE_SPECIFICITY = 100
+CHILD_SPECIFICITY_STEP = 10
+
+
+def populate(
+    *,
+    org_id: str,
+    credentials: dict[str, Any],
+    scope: dict[str, Any],
+    **_: Any,
+) -> dict[str, Any]:
+    return asyncio.run(
+        _populate_async(org_id=org_id, credentials=credentials, scope=scope)
+    )
+
+
+async def _populate_async(
+    *, org_id: str, credentials: dict[str, Any], scope: dict[str, Any]
+) -> dict[str, Any]:
+    if not _provider_capable():
+        return _zero_summary(org_id=org_id, reason="provider_not_import_capable")
+
+    token = _first_string(credentials, "token", "access_token", "github_token")
+    org_name = _github_org(credentials=credentials, scope=scope)
+    if not token or not org_name:
+        return _zero_summary(org_id=org_id, reason="missing_github_credentials_or_org")
+
+    discovery = TeamDiscoveryService(session=None, org_id=org_id)
+    try:
+        teams = await discovery.discover_github(token=token, org_name=org_name)
+    except Exception as exc:
+        logger.info(
+            "Skipping GitHub team auto-import for org_id=%s org=%s: discovery failed: %s",
+            org_id,
+            org_name,
+            exc,
+        )
+        return _zero_summary(org_id=org_id, reason="provider_discovery_skipped")
+
+    if not teams:
+        return _zero_summary(org_id=org_id, reason="no_provider_teams")
+
+    now = datetime.now(timezone.utc)
+    team_rows = _team_rows(org_id=org_id, teams=teams, now=now)
+    repo_rows = _repo_ownership_rows(org_id=org_id, teams=teams, now=now)
+    membership_rows = await _membership_rows(
+        org_id=org_id,
+        token=token,
+        org_name=org_name,
+        teams=teams,
+        now=now,
+    )
+
+    sink = _sink(scope)
+    await sink.insert_teams(team_rows)
+    sink.write_team_repo_ownership(repo_rows)
+    sink.write_team_memberships(membership_rows)
+
+    return {
+        "teams_imported": len(team_rows),
+        "projects_imported": 0,
+        "members_imported": len({row.member_id for row in membership_rows}),
+        "team_memberships_imported": len(membership_rows),
+        "team_project_ownership_imported": 0,
+        "team_repo_ownership_imported": len(repo_rows),
+        "work_item_team_attributions_imported": 0,
+    }
+
+
+def _provider_capable() -> bool:
+    return any(
+        capability.provider == PROVIDER and capability.supports_org_drift_discovery
+        for capability in team_provider_capabilities()
+    )
+
+
+def _zero_summary(*, org_id: str, reason: str) -> dict[str, Any]:
+    return {
+        "status": "skipped",
+        "provider": PROVIDER,
+        "org_id": org_id,
+        "reason": reason,
+        "teams_imported": 0,
+        "projects_imported": 0,
+        "members_imported": 0,
+        "team_memberships_imported": 0,
+        "team_project_ownership_imported": 0,
+        "team_repo_ownership_imported": 0,
+        "work_item_team_attributions_imported": 0,
+    }
+
+
+def _github_org(
+    *, credentials: Mapping[str, Any], scope: Mapping[str, Any]
+) -> str | None:
+    sync_options = _mapping(scope.get("sync_options"))
+    return _first_string(
+        credentials,
+        "org",
+        "organization",
+        "org_name",
+        "owner",
+    ) or _first_string(sync_options, "org", "organization", "org_name", "owner")
+
+
+def _team_rows(
+    *, org_id: str, teams: Iterable[Any], now: datetime
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for team in teams:
+        associations = _mapping(getattr(team, "associations", None))
+        team_id = _team_id(str(getattr(team, "provider_team_id")))
+        rows.append(
+            {
+                "id": team_id,
+                "name": str(getattr(team, "name", team_id)),
+                "description": getattr(team, "description", None),
+                "members": [],
+                "project_keys": [],
+                "repo_patterns": _strings(associations.get("repo_patterns")),
+                "is_active": True,
+                "updated_at": now,
+                "org_id": org_id,
+                "provider": PROVIDER,
+                "native_team_key": str(getattr(team, "provider_team_id")),
+                "parent_team_id": _parent_team_id(associations),
+            }
+        )
+    return rows
+
+
+def _repo_ownership_rows(
+    *, org_id: str, teams: Iterable[Any], now: datetime
+) -> list[TeamRepoOwnershipRecord]:
+    parent_by_team = _parent_by_team(teams)
+    rows: list[TeamRepoOwnershipRecord] = []
+    seen: set[tuple[str, str]] = set()
+    for team in teams:
+        associations = _mapping(getattr(team, "associations", None))
+        team_id = _team_id(str(getattr(team, "provider_team_id")))
+        specificity = BASE_SPECIFICITY + (
+            _depth(team_id, parent_by_team) * CHILD_SPECIFICITY_STEP
+        )
+        for repo_full_name in _strings(associations.get("repo_patterns")):
+            key = (team_id, repo_full_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append(
+                TeamRepoOwnershipRecord(
+                    org_id=org_id,
+                    provider=PROVIDER,
+                    team_id=team_id,
+                    repo_full_name=repo_full_name,
+                    match_type="exact",
+                    source="provider_access",
+                    is_primary=0,
+                    specificity=specificity,
+                    priority=PROVIDER_ACCESS_PRIORITY,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+    return rows
+
+
+async def _membership_rows(
+    *,
+    org_id: str,
+    token: str,
+    org_name: str,
+    teams: Iterable[Any],
+    now: datetime,
+) -> list[TeamMembershipRecord]:
+    service = TeamMembershipService(session=cast(Any, None), org_id=org_id)
+    rows: list[TeamMembershipRecord] = []
+    seen: set[tuple[str, str]] = set()
+    for team in teams:
+        team_slug = str(getattr(team, "provider_team_id"))
+        team_id = _team_id(team_slug)
+        try:
+            members = await service.discover_members_github(
+                token=token,
+                org_name=org_name,
+                team_slug=team_slug,
+            )
+        except Exception as exc:
+            logger.info(
+                "Skipping GitHub membership import for org_id=%s team=%s: %s",
+                org_id,
+                team_slug,
+                exc,
+            )
+            continue
+        for member in members:
+            raw_identity = str(getattr(member, "provider_identity", "")).strip()
+            if not raw_identity:
+                continue
+            member_id = f"gh:{raw_identity}"
+            key = (team_id, member_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append(
+                TeamMembershipRecord(
+                    org_id=org_id,
+                    provider=PROVIDER,
+                    team_id=team_id,
+                    member_id=member_id,
+                    raw_provider_user_id=raw_identity,
+                    raw_email=getattr(member, "email", None),
+                    source="provider_access",
+                    is_primary=0,
+                    specificity=BASE_SPECIFICITY,
+                    priority=PROVIDER_ACCESS_PRIORITY,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+    return rows
+
+
+def _sink(scope: Mapping[str, Any]) -> ClickHouseMetricsSink:
+    dsn = str(scope.get("analytics_db") or os.getenv("CLICKHOUSE_URI") or "")
+    if not dsn:
+        raise ValueError("CLICKHOUSE_URI is required for GitHub team auto-import")
+    return ClickHouseMetricsSink(dsn=dsn)
+
+
+def _team_id(provider_team_id: str) -> str:
+    return f"gh:{provider_team_id.removeprefix('gh:')}"
+
+
+def _parent_team_id(associations: Mapping[str, Any]) -> str | None:
+    parent = _first_string(associations, "parent_team_id", "parent_provider_team_id")
+    if parent is None:
+        return None
+    return _team_id(parent)
+
+
+def _parent_by_team(teams: Iterable[Any]) -> dict[str, str]:
+    parents: dict[str, str] = {}
+    for team in teams:
+        associations = _mapping(getattr(team, "associations", None))
+        parent = _parent_team_id(associations)
+        if parent:
+            parents[_team_id(str(getattr(team, "provider_team_id")))] = parent
+    return parents
+
+
+def _depth(team_id: str, parent_by_team: Mapping[str, str]) -> int:
+    depth = 0
+    current = team_id
+    visited: set[str] = set()
+    while current in parent_by_team and current not in visited:
+        visited.add(current)
+        current = parent_by_team[current]
+        depth += 1
+    return depth
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if not isinstance(value, Iterable):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def _first_string(mapping: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None

--- a/src/dev_health_ops/workers/team_autoimport_gitlab.py
+++ b/src/dev_health_ops/workers/team_autoimport_gitlab.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from dev_health_ops.api.services.configuration.team_discovery import (
+    TeamDiscoveryService,
+)
+from dev_health_ops.api.services.configuration.team_membership import (
+    TeamMembershipService,
+)
+from dev_health_ops.metrics.schemas import (
+    TeamMembershipRecord,
+    TeamProjectOwnershipRecord,
+)
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.providers.team_capabilities import team_provider_capabilities
+
+logger = logging.getLogger(__name__)
+
+PROVIDER = "gitlab"
+PROVIDER_ACCESS_PRIORITY = 300
+BASE_SPECIFICITY = 100
+CHILD_SPECIFICITY_STEP = 10
+DEFAULT_GITLAB_URL = "https://gitlab.com"
+
+
+def populate(
+    *,
+    org_id: str,
+    credentials: dict[str, Any],
+    scope: dict[str, Any],
+    **_: Any,
+) -> dict[str, Any]:
+    return asyncio.run(
+        _populate_async(org_id=org_id, credentials=credentials, scope=scope)
+    )
+
+
+async def _populate_async(
+    *, org_id: str, credentials: dict[str, Any], scope: dict[str, Any]
+) -> dict[str, Any]:
+    if not _provider_capable():
+        return _zero_summary(org_id=org_id, reason="provider_not_import_capable")
+
+    token = _first_string(credentials, "token", "access_token", "private_token")
+    group_path = _gitlab_group(credentials=credentials, scope=scope)
+    url = (
+        _first_string(credentials, "url", "base_url", "gitlab_url")
+        or DEFAULT_GITLAB_URL
+    )
+    if not token or not group_path:
+        return _zero_summary(
+            org_id=org_id, reason="missing_gitlab_credentials_or_group"
+        )
+
+    discovery = TeamDiscoveryService(session=None, org_id=org_id)
+    try:
+        result = await discovery.discover_gitlab(
+            token=token,
+            group_path=group_path,
+            url=url,
+        )
+    except Exception as exc:
+        logger.info(
+            "Skipping GitLab team auto-import for org_id=%s group=%s: discovery failed: %s",
+            org_id,
+            group_path,
+            exc,
+        )
+        return _zero_summary(org_id=org_id, reason="provider_discovery_skipped")
+
+    teams = result.teams
+    if not teams:
+        return _zero_summary(org_id=org_id, reason="no_provider_teams")
+
+    now = datetime.now(timezone.utc)
+    team_rows = _team_rows(org_id=org_id, teams=teams, now=now)
+    project_rows = _project_ownership_rows(org_id=org_id, teams=teams, now=now)
+    membership_rows = await _membership_rows(
+        org_id=org_id,
+        token=token,
+        url=url,
+        teams=teams,
+        now=now,
+    )
+
+    sink = _sink(scope)
+    await sink.insert_teams(team_rows)
+    sink.write_team_project_ownership(project_rows)
+    sink.write_team_memberships(membership_rows)
+
+    summary: dict[str, Any] = {
+        "teams_imported": len(team_rows),
+        "projects_imported": len({row.project_id for row in project_rows}),
+        "members_imported": len({row.member_id for row in membership_rows}),
+        "team_memberships_imported": len(membership_rows),
+        "team_project_ownership_imported": len(project_rows),
+        "team_repo_ownership_imported": 0,
+        "work_item_team_attributions_imported": 0,
+    }
+    if result.truncated:
+        summary["warnings"] = list(result.warnings)
+    return summary
+
+
+def _provider_capable() -> bool:
+    return any(
+        capability.provider == PROVIDER and capability.supports_org_drift_discovery
+        for capability in team_provider_capabilities()
+    )
+
+
+def _zero_summary(*, org_id: str, reason: str) -> dict[str, Any]:
+    return {
+        "status": "skipped",
+        "provider": PROVIDER,
+        "org_id": org_id,
+        "reason": reason,
+        "teams_imported": 0,
+        "projects_imported": 0,
+        "members_imported": 0,
+        "team_memberships_imported": 0,
+        "team_project_ownership_imported": 0,
+        "team_repo_ownership_imported": 0,
+        "work_item_team_attributions_imported": 0,
+    }
+
+
+def _gitlab_group(
+    *, credentials: Mapping[str, Any], scope: Mapping[str, Any]
+) -> str | None:
+    sync_options = _mapping(scope.get("sync_options"))
+    return _first_string(
+        credentials,
+        "group_path",
+        "group",
+        "owner",
+    ) or _first_string(sync_options, "group_path", "group", "owner")
+
+
+def _team_rows(
+    *, org_id: str, teams: Iterable[Any], now: datetime
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for team in teams:
+        associations = _mapping(getattr(team, "associations", None))
+        provider_team_id = str(getattr(team, "provider_team_id"))
+        team_id = _team_id(provider_team_id)
+        rows.append(
+            {
+                "id": team_id,
+                "name": str(getattr(team, "name", team_id)),
+                "description": getattr(team, "description", None),
+                "members": [],
+                "project_keys": _strings(associations.get("repo_patterns")),
+                "repo_patterns": [],
+                "is_active": True,
+                "updated_at": now,
+                "org_id": org_id,
+                "provider": PROVIDER,
+                "native_team_key": provider_team_id,
+                "parent_team_id": _parent_team_id(provider_team_id, associations),
+            }
+        )
+    return rows
+
+
+def _project_ownership_rows(
+    *, org_id: str, teams: Iterable[Any], now: datetime
+) -> list[TeamProjectOwnershipRecord]:
+    parent_by_team = _parent_by_team(teams)
+    rows: list[TeamProjectOwnershipRecord] = []
+    seen: set[tuple[str, str]] = set()
+    for team in teams:
+        associations = _mapping(getattr(team, "associations", None))
+        provider_team_id = str(getattr(team, "provider_team_id"))
+        team_id = _team_id(provider_team_id)
+        specificity = BASE_SPECIFICITY + (
+            _depth(team_id, parent_by_team) * CHILD_SPECIFICITY_STEP
+        )
+        for project_path in _strings(associations.get("repo_patterns")):
+            key = (team_id, project_path)
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append(
+                TeamProjectOwnershipRecord(
+                    org_id=org_id,
+                    provider=PROVIDER,
+                    team_id=team_id,
+                    project_id=project_path,
+                    project_key=project_path,
+                    source="provider_access",
+                    is_primary=0,
+                    specificity=specificity,
+                    priority=PROVIDER_ACCESS_PRIORITY,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+    return rows
+
+
+async def _membership_rows(
+    *,
+    org_id: str,
+    token: str,
+    url: str,
+    teams: Iterable[Any],
+    now: datetime,
+) -> list[TeamMembershipRecord]:
+    service = TeamMembershipService(session=cast(Any, None), org_id=org_id)
+    rows: list[TeamMembershipRecord] = []
+    seen: set[tuple[str, str]] = set()
+    for team in teams:
+        group_path = str(getattr(team, "provider_team_id"))
+        team_id = _team_id(group_path)
+        try:
+            members = await service.discover_members_gitlab(
+                token=token,
+                group_path=group_path,
+                url=url,
+            )
+        except Exception as exc:
+            logger.info(
+                "Skipping GitLab membership import for org_id=%s group=%s: %s",
+                org_id,
+                group_path,
+                exc,
+            )
+            continue
+        for member in members:
+            raw_identity = str(getattr(member, "provider_identity", "")).strip()
+            if not raw_identity:
+                continue
+            member_id = f"gl:{raw_identity}"
+            key = (team_id, member_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append(
+                TeamMembershipRecord(
+                    org_id=org_id,
+                    provider=PROVIDER,
+                    team_id=team_id,
+                    member_id=member_id,
+                    raw_provider_user_id=raw_identity,
+                    raw_email=getattr(member, "email", None),
+                    source="provider_access",
+                    is_primary=0,
+                    specificity=BASE_SPECIFICITY,
+                    priority=PROVIDER_ACCESS_PRIORITY,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+    return rows
+
+
+def _sink(scope: Mapping[str, Any]) -> ClickHouseMetricsSink:
+    dsn = str(scope.get("analytics_db") or os.getenv("CLICKHOUSE_URI") or "")
+    if not dsn:
+        raise ValueError("CLICKHOUSE_URI is required for GitLab team auto-import")
+    return ClickHouseMetricsSink(dsn=dsn)
+
+
+def _team_id(provider_team_id: str) -> str:
+    return f"gl:{provider_team_id.removeprefix('gl:')}"
+
+
+def _parent_team_id(
+    provider_team_id: str, associations: Mapping[str, Any]
+) -> str | None:
+    explicit_parent = _first_string(
+        associations, "parent_team_id", "parent_provider_team_id"
+    )
+    if explicit_parent:
+        return _team_id(explicit_parent)
+    if "/" not in provider_team_id:
+        return None
+    return _team_id(provider_team_id.rsplit("/", 1)[0])
+
+
+def _parent_by_team(teams: Iterable[Any]) -> dict[str, str]:
+    parents: dict[str, str] = {}
+    team_ids = {_team_id(str(getattr(team, "provider_team_id"))) for team in teams}
+    for team in teams:
+        provider_team_id = str(getattr(team, "provider_team_id"))
+        associations = _mapping(getattr(team, "associations", None))
+        team_id = _team_id(provider_team_id)
+        parent = _parent_team_id(provider_team_id, associations)
+        if parent and parent in team_ids:
+            parents[team_id] = parent
+    return parents
+
+
+def _depth(team_id: str, parent_by_team: Mapping[str, str]) -> int:
+    depth = 0
+    current = team_id
+    visited: set[str] = set()
+    while current in parent_by_team and current not in visited:
+        visited.add(current)
+        current = parent_by_team[current]
+        depth += 1
+    return depth
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if not isinstance(value, Iterable):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def _first_string(mapping: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None

--- a/tests/workers/test_team_autoimport_executor.py
+++ b/tests/workers/test_team_autoimport_executor.py
@@ -25,7 +25,7 @@ def test_run_team_autoimport_skips_missing_populator(caplog) -> None:
     caplog.set_level(logging.INFO)
 
     result = team_autoimport.run_team_autoimport(
-        provider="github",
+        provider="ms-teams",
         org_id="org-1",
         credentials={"token": "secret"},
         scope={"sync_options": {"auto_import_teams": True}},

--- a/tests/workers/test_team_autoimport_github_gitlab.py
+++ b/tests/workers/test_team_autoimport_github_gitlab.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.admin.schemas_flat import DiscoveredMember, DiscoveredTeam
+from dev_health_ops.api.services.configuration.team_discovery import (
+    GitLabDiscoveryResult,
+)
+from dev_health_ops.workers import team_autoimport_github, team_autoimport_gitlab
+
+
+@dataclass
+class RecordingSink:
+    teams: list[dict[str, Any]] = field(default_factory=list)
+    repo_ownership: list[Any] = field(default_factory=list)
+    project_ownership: list[Any] = field(default_factory=list)
+    memberships: list[Any] = field(default_factory=list)
+    manual_repo_ownership: list[dict[str, Any]] = field(
+        default_factory=lambda: [
+            {
+                "org_id": "org-1",
+                "provider": "github",
+                "team_id": "gh:manual",
+                "repo_full_name": "full-chaos/manual",
+                "source": "manual",
+            }
+        ]
+    )
+
+    async def insert_teams(self, rows: list[dict[str, Any]]) -> None:
+        self.teams.extend(rows)
+
+    def write_team_repo_ownership(self, rows: list[Any]) -> None:
+        self.repo_ownership.extend(rows)
+
+    def write_team_project_ownership(self, rows: list[Any]) -> None:
+        self.project_ownership.extend(rows)
+
+    def write_team_memberships(self, rows: list[Any]) -> None:
+        self.memberships.extend(rows)
+
+
+def test_github_org_import_writes_provider_access_repo_grants_and_nested_specificity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = RecordingSink()
+
+    async def discover_github(self, token: str, org_name: str) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="github",
+                provider_team_id="platform",
+                name="Platform",
+                associations={
+                    "repo_patterns": ["full-chaos/dev-health"],
+                    "provider_org": org_name,
+                },
+            ),
+            DiscoveredTeam(
+                provider_type="github",
+                provider_team_id="platform-api",
+                name="Platform API",
+                associations={
+                    "repo_patterns": ["full-chaos/dev-health"],
+                    "provider_org": org_name,
+                    "parent_team_id": "platform",
+                },
+            ),
+        ]
+
+    async def discover_members_github(
+        self, token: str, org_name: str, team_slug: str
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="github",
+                provider_identity=f"{team_slug}-lead",
+                display_name=f"{team_slug} lead",
+                email=f"{team_slug}@example.com",
+            )
+        ]
+
+    monkeypatch.setattr(
+        team_autoimport_github.TeamDiscoveryService,
+        "discover_github",
+        discover_github,
+    )
+    monkeypatch.setattr(
+        team_autoimport_github.TeamMembershipService,
+        "discover_members_github",
+        discover_members_github,
+    )
+    monkeypatch.setattr(
+        team_autoimport_github, "ClickHouseMetricsSink", lambda dsn: sink
+    )
+
+    summary = team_autoimport_github.populate(
+        org_id="org-1",
+        credentials={"token": "secret", "org": "full-chaos"},
+        scope={
+            "analytics_db": "clickhouse://test",
+            "sync_options": {"auto_import_teams": True},
+        },
+    )
+
+    assert summary["teams_imported"] == 2
+    assert summary["team_repo_ownership_imported"] == 2
+    assert summary["team_memberships_imported"] == 2
+    assert {row["id"] for row in sink.teams} == {"gh:platform", "gh:platform-api"}
+    child_team = next(row for row in sink.teams if row["id"] == "gh:platform-api")
+    assert child_team["parent_team_id"] == "gh:platform"
+    assert {row.source for row in sink.repo_ownership} == {"provider_access"}
+    parent_row = next(
+        row for row in sink.repo_ownership if row.team_id == "gh:platform"
+    )
+    child_row = next(
+        row for row in sink.repo_ownership if row.team_id == "gh:platform-api"
+    )
+    assert child_row.repo_full_name == parent_row.repo_full_name
+    assert child_row.specificity > parent_row.specificity
+
+
+def test_gitlab_group_import_writes_provider_access_project_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = RecordingSink()
+
+    async def discover_gitlab(
+        self, token: str, group_path: str, url: str
+    ) -> GitLabDiscoveryResult:
+        return GitLabDiscoveryResult(
+            teams=[
+                DiscoveredTeam(
+                    provider_type="gitlab",
+                    provider_team_id="full-chaos",
+                    name="Full Chaos",
+                    associations={
+                        "repo_patterns": ["full-chaos/platform"],
+                        "provider_org": group_path,
+                    },
+                ),
+                DiscoveredTeam(
+                    provider_type="gitlab",
+                    provider_team_id="full-chaos/dev-health",
+                    name="Dev Health",
+                    associations={
+                        "repo_patterns": ["full-chaos/dev-health/api"],
+                        "provider_org": group_path,
+                    },
+                ),
+            ]
+        )
+
+    async def discover_members_gitlab(
+        self, token: str, group_path: str, url: str
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="gitlab",
+                provider_identity=group_path.replace("/", "-"),
+                display_name=group_path,
+            )
+        ]
+
+    monkeypatch.setattr(
+        team_autoimport_gitlab.TeamDiscoveryService,
+        "discover_gitlab",
+        discover_gitlab,
+    )
+    monkeypatch.setattr(
+        team_autoimport_gitlab.TeamMembershipService,
+        "discover_members_gitlab",
+        discover_members_gitlab,
+    )
+    monkeypatch.setattr(
+        team_autoimport_gitlab, "ClickHouseMetricsSink", lambda dsn: sink
+    )
+
+    summary = team_autoimport_gitlab.populate(
+        org_id="org-1",
+        credentials={"token": "secret", "group_path": "full-chaos"},
+        scope={
+            "analytics_db": "clickhouse://test",
+            "sync_options": {"auto_import_teams": True},
+        },
+    )
+
+    assert summary["teams_imported"] == 2
+    assert summary["projects_imported"] == 2
+    assert summary["team_project_ownership_imported"] == 2
+    assert {row["id"] for row in sink.teams} == {
+        "gl:full-chaos",
+        "gl:full-chaos/dev-health",
+    }
+    subgroup = next(
+        row for row in sink.teams if row["id"] == "gl:full-chaos/dev-health"
+    )
+    assert subgroup["parent_team_id"] == "gl:full-chaos"
+    assert {row.source for row in sink.project_ownership} == {"provider_access"}
+    assert {row.project_key for row in sink.project_ownership} == {
+        "full-chaos/platform",
+        "full-chaos/dev-health/api",
+    }
+
+
+def test_github_personal_account_or_unsupported_response_skips_without_touching_manual_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = RecordingSink()
+    manual_before = list(sink.manual_repo_ownership)
+
+    async def discover_github(self, token: str, org_name: str) -> list[DiscoveredTeam]:
+        raise RuntimeError("404 Not Found")
+
+    def fail_if_sink_is_created(dsn: str) -> RecordingSink:
+        raise AssertionError(
+            "no-op personal account import must not write to ClickHouse"
+        )
+
+    monkeypatch.setattr(
+        team_autoimport_github.TeamDiscoveryService,
+        "discover_github",
+        discover_github,
+    )
+    monkeypatch.setattr(
+        team_autoimport_github, "ClickHouseMetricsSink", fail_if_sink_is_created
+    )
+
+    summary = team_autoimport_github.populate(
+        org_id="org-1",
+        credentials={"token": "secret", "org": "personal-user"},
+        scope={"sync_options": {"auto_import_teams": True}},
+    )
+
+    assert summary["status"] == "skipped"
+    assert summary["reason"] == "provider_discovery_skipped"
+    assert summary["team_repo_ownership_imported"] == 0
+    assert summary["team_memberships_imported"] == 0
+    assert sink.manual_repo_ownership == manual_before


### PR DESCRIPTION
## Summary
- Add GitHub and GitLab team auto-import populators for the Stream A dispatch seam.
- Persist provider_access teams, memberships, and repo/project ownership via ClickHouse sink writers.
- Cover org/group imports, personal-account skip, manual-row preservation, and nested specificity with provider stubs.

## Verification
- CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/workers/test_team_autoimport_github_gitlab.py -q
- CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/workers/test_team_autoimport_github_gitlab.py tests/workers/test_team_autoimport_executor.py -q
- uv run --extra dev --python 3.11 mypy src/dev_health_ops/workers/team_autoimport_github.py src/dev_health_ops/workers/team_autoimport_gitlab.py
- uv run --extra dev --python 3.11 ruff check src/dev_health_ops/workers/team_autoimport_github.py src/dev_health_ops/workers/team_autoimport_gitlab.py tests/workers/test_team_autoimport_github_gitlab.py tests/workers/test_team_autoimport_executor.py
- mcp_Lsp_diagnostics clean on changed files

Closes CHAOS-2546.
Stacked on #984.
SCREENSHOT-WAIVER: backend only.