### PR TITLE
feat(teams): populate Linear/Jira project/member/ownership dims on auto-import (CHAOS-2545)

### DIFF
--- a/src/dev_health_ops/workers/team_autoimport_jira.py
+++ b/src/dev_health_ops/workers/team_autoimport_jira.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import Coroutine, Sequence
+from datetime import datetime, timezone
+from threading import Thread
+from typing import Any, Protocol, TypeVar, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.services.configuration.team_discovery import (
+    TeamDiscoveryService,
+)
+from dev_health_ops.api.services.configuration.team_membership import (
+    TeamMembershipService,
+)
+from dev_health_ops.credentials.resolver import jira_credentials_from_mapping
+from dev_health_ops.metrics.schemas import (
+    MemberRecord,
+    ProjectRecord,
+    TeamMembershipRecord,
+    TeamProjectOwnershipRecord,
+)
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+_T = TypeVar("_T")
+
+
+class _DimensionSink(Protocol):
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]: ...
+    def write_projects(self, rows: Sequence[ProjectRecord]) -> None: ...
+    def write_members(self, rows: Sequence[MemberRecord]) -> None: ...
+    def write_team_memberships(self, rows: Sequence[TeamMembershipRecord]) -> None: ...
+    def write_team_project_ownership(
+        self, rows: Sequence[TeamProjectOwnershipRecord]
+    ) -> None: ...
+    async def insert_teams(self, teams: list[dict[str, Any]]) -> None: ...
+    def close(self) -> None: ...
+
+
+def _run(coro: Coroutine[Any, Any, _T]) -> _T:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    result: _T | None = None
+    error: BaseException | None = None
+
+    def _target() -> None:
+        nonlocal result, error
+        try:
+            result = asyncio.run(coro)
+        except BaseException as exc:
+            error = exc
+
+    thread = Thread(target=_target)
+    thread.start()
+    thread.join()
+    if error is not None:
+        raise error
+    return cast(_T, result)
+
+
+def _sink_from_kwargs(kwargs: dict[str, Any]) -> tuple[_DimensionSink, bool]:
+    injected = kwargs.get("sink")
+    if injected is not None:
+        return cast(_DimensionSink, injected), False
+    dsn = str(kwargs.get("clickhouse_uri") or os.getenv("CLICKHOUSE_URI") or "")
+    if not dsn:
+        raise ValueError("ClickHouse DSN is required for Jira team auto-import")
+    return cast(_DimensionSink, ClickHouseMetricsSink(dsn=dsn)), True
+
+
+def _project_id(org_id: str, provider: str, project_key: str) -> str:
+    return f"{org_id}:{provider}:{project_key}"
+
+
+def _member_id(provider: str, provider_identity: str) -> str:
+    return f"{provider}:{provider_identity.strip().lower()}"
+
+
+def _provider_identities(provider: str, provider_identity: str) -> str:
+    return json.dumps({provider: [provider_identity]}, sort_keys=True)
+
+
+def _dedupe_projects(rows: list[ProjectRecord]) -> list[ProjectRecord]:
+    return list({(row.org_id, row.provider, row.id): row for row in rows}.values())
+
+
+def _dedupe_members(rows: list[MemberRecord]) -> list[MemberRecord]:
+    return list({(row.org_id, row.member_id): row for row in rows}.values())
+
+
+def _dedupe_memberships(
+    rows: list[TeamMembershipRecord],
+) -> list[TeamMembershipRecord]:
+    return list(
+        {
+            (row.org_id, row.provider, row.team_id, row.member_id, row.source): row
+            for row in rows
+        }.values()
+    )
+
+
+def _dedupe_ownership(
+    rows: list[TeamProjectOwnershipRecord],
+) -> list[TeamProjectOwnershipRecord]:
+    return list(
+        {
+            (row.org_id, row.provider, row.project_id, row.team_id, row.source): row
+            for row in rows
+        }.values()
+    )
+
+
+def _load_jira_legacy_links(
+    sink: _DimensionSink,
+    *,
+    org_id: str,
+) -> list[dict[str, Any]]:
+    try:
+        return sink.query_dicts(
+            """
+            SELECT project_key, ops_team_id, project_name, ops_team_name, updated_at
+            FROM jira_project_ops_team_links FINAL
+            WHERE org_id = {org_id:String}
+            """,
+            {"org_id": org_id},
+        )
+    except Exception:
+        return []
+
+
+def populate(
+    *,
+    org_id: str,
+    credentials: dict[str, Any],
+    scope: dict[str, Any],
+    **kwargs: Any,
+) -> dict[str, Any]:
+    jira_credentials = jira_credentials_from_mapping(credentials)
+    if jira_credentials is None:
+        return {
+            "status": "skipped",
+            "reason": "missing_jira_credentials",
+            "projects_imported": 0,
+            "members_imported": 0,
+            "team_memberships_imported": 0,
+            "team_project_ownership_imported": 0,
+        }
+
+    now = datetime.now(timezone.utc)
+    discovery = TeamDiscoveryService(None, org_id)
+    membership = TeamMembershipService(cast(AsyncSession, None), org_id)
+    teams = _run(
+        discovery.discover_jira(
+            email=jira_credentials.email,
+            api_token=jira_credentials.api_token,
+            url=jira_credentials.base_url,
+        )
+    )
+
+    team_rows: list[dict[str, Any]] = []
+    project_rows: list[ProjectRecord] = []
+    member_rows: list[MemberRecord] = []
+    membership_rows: list[TeamMembershipRecord] = []
+    ownership_rows: list[TeamProjectOwnershipRecord] = []
+
+    for team in teams:
+        team_id = str(team.provider_team_id)
+        associations = dict(team.associations or {})
+        project_keys = [str(key) for key in associations.get("project_keys", []) if key]
+        if not project_keys:
+            project_keys = [team_id]
+
+        team_rows.append(
+            {
+                "id": team_id,
+                "name": team.name,
+                "description": team.description,
+                "members": [],
+                "project_keys": project_keys,
+                "repo_patterns": [],
+                "is_active": True,
+                "updated_at": now,
+                "org_id": org_id,
+                "provider": "jira",
+                "native_team_key": team_id,
+                "parent_team_id": None,
+            }
+        )
+
+        for project_key in project_keys:
+            project_rows.append(
+                ProjectRecord(
+                    id=_project_id(org_id, "jira", project_key),
+                    org_id=org_id,
+                    provider="jira",
+                    project_key=project_key,
+                    name=team.name,
+                    is_active=1,
+                    updated_at=now,
+                    last_synced=now,
+                )
+            )
+            ownership_rows.append(
+                TeamProjectOwnershipRecord(
+                    org_id=org_id,
+                    provider="jira",
+                    team_id=team_id,
+                    project_id=_project_id(org_id, "jira", project_key),
+                    project_key=project_key,
+                    source="native",
+                    is_primary=1,
+                    specificity=100,
+                    priority=10,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+
+        discovered_members = _run(
+            membership.discover_members_jira_bulk(
+                email=jira_credentials.email,
+                api_token=jira_credentials.api_token,
+                url=jira_credentials.base_url,
+                project_keys=project_keys,
+            )
+        )
+        team_rows[-1]["members"] = [
+            member.provider_identity for member in discovered_members
+        ]
+        for member in discovered_members:
+            member_id = _member_id("jira", member.provider_identity)
+            member_rows.append(
+                MemberRecord(
+                    org_id=org_id,
+                    member_id=member_id,
+                    name=member.display_name or member.provider_identity,
+                    email=member.email,
+                    provider_identities=_provider_identities(
+                        "jira", member.provider_identity
+                    ),
+                    is_active=1,
+                    updated_at=now,
+                )
+            )
+            membership_rows.append(
+                TeamMembershipRecord(
+                    org_id=org_id,
+                    provider="jira",
+                    team_id=team_id,
+                    member_id=member_id,
+                    raw_provider_user_id=member.provider_identity,
+                    raw_email=member.email,
+                    source="native",
+                    is_primary=1 if member.role == "lead" else 0,
+                    specificity=100,
+                    priority=10,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+
+    sink, should_close = _sink_from_kwargs(kwargs)
+    try:
+        for link in _load_jira_legacy_links(sink, org_id=org_id):
+            project_key = str(link.get("project_key") or "")
+            ops_team_id = str(link.get("ops_team_id") or "")
+            if not project_key or not ops_team_id:
+                continue
+            project_id = _project_id(org_id, "jira", project_key)
+            if not any(row.id == project_id for row in project_rows):
+                project_rows.append(
+                    ProjectRecord(
+                        id=project_id,
+                        org_id=org_id,
+                        provider="jira",
+                        project_key=project_key,
+                        name=str(link.get("project_name") or project_key),
+                        is_active=1,
+                        updated_at=now,
+                        last_synced=now,
+                    )
+                )
+            ownership_rows.append(
+                TeamProjectOwnershipRecord(
+                    org_id=org_id,
+                    provider="jira",
+                    team_id=ops_team_id,
+                    project_id=project_id,
+                    project_key=project_key,
+                    source="jira_legacy",
+                    is_primary=1,
+                    specificity=90,
+                    priority=20,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+
+        _run(sink.insert_teams(team_rows))
+        projects = _dedupe_projects(project_rows)
+        members = _dedupe_members(member_rows)
+        memberships = _dedupe_memberships(membership_rows)
+        ownership = _dedupe_ownership(ownership_rows)
+        sink.write_projects(projects)
+        sink.write_members(members)
+        sink.write_team_memberships(memberships)
+        sink.write_team_project_ownership(ownership)
+    finally:
+        if should_close:
+            sink.close()
+
+    jira_legacy_count = sum(1 for row in ownership if row.source == "jira_legacy")
+    return {
+        "mode": scope.get("mode"),
+        "teams_imported": len(team_rows),
+        "projects_imported": len(projects),
+        "members_imported": len(members),
+        "team_memberships_imported": len(memberships),
+        "team_project_ownership_imported": len(ownership),
+        "jira_legacy_project_ownership_imported": jira_legacy_count,
+        "team_repo_ownership_imported": 0,
+        "work_item_team_attributions_imported": 0,
+    }

--- a/src/dev_health_ops/workers/team_autoimport_linear.py
+++ b/src/dev_health_ops/workers/team_autoimport_linear.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import Coroutine, Sequence
+from datetime import datetime, timezone
+from threading import Thread
+from typing import Any, Protocol, TypeVar, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.services.configuration.team_discovery import (
+    TeamDiscoveryService,
+)
+from dev_health_ops.api.services.configuration.team_membership import (
+    TeamMembershipService,
+)
+from dev_health_ops.credentials.resolver import linear_credentials_from_mapping
+from dev_health_ops.metrics.schemas import (
+    MemberRecord,
+    ProjectRecord,
+    TeamMembershipRecord,
+    TeamProjectOwnershipRecord,
+)
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+_T = TypeVar("_T")
+
+
+class _DimensionSink(Protocol):
+    def write_projects(self, rows: Sequence[ProjectRecord]) -> None: ...
+    def write_members(self, rows: Sequence[MemberRecord]) -> None: ...
+    def write_team_memberships(self, rows: Sequence[TeamMembershipRecord]) -> None: ...
+    def write_team_project_ownership(
+        self, rows: Sequence[TeamProjectOwnershipRecord]
+    ) -> None: ...
+    async def insert_teams(self, teams: list[dict[str, Any]]) -> None: ...
+    def close(self) -> None: ...
+
+
+def _run(coro: Coroutine[Any, Any, _T]) -> _T:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    result: _T | None = None
+    error: BaseException | None = None
+
+    def _target() -> None:
+        nonlocal result, error
+        try:
+            result = asyncio.run(coro)
+        except BaseException as exc:
+            error = exc
+
+    thread = Thread(target=_target)
+    thread.start()
+    thread.join()
+    if error is not None:
+        raise error
+    return cast(_T, result)
+
+
+def _sink_from_kwargs(kwargs: dict[str, Any]) -> tuple[_DimensionSink, bool]:
+    injected = kwargs.get("sink")
+    if injected is not None:
+        return cast(_DimensionSink, injected), False
+    dsn = str(kwargs.get("clickhouse_uri") or os.getenv("CLICKHOUSE_URI") or "")
+    if not dsn:
+        raise ValueError("ClickHouse DSN is required for Linear team auto-import")
+    return cast(_DimensionSink, ClickHouseMetricsSink(dsn=dsn)), True
+
+
+def _team_id(team: Any) -> str:
+    return str(team.provider_team_id)
+
+
+def _project_id(org_id: str, provider: str, project_key: str) -> str:
+    return f"{org_id}:{provider}:{project_key}"
+
+
+def _member_id(provider: str, provider_identity: str) -> str:
+    return f"{provider}:{provider_identity.strip().lower()}"
+
+
+def _provider_identities(provider: str, provider_identity: str) -> str:
+    return json.dumps({provider: [provider_identity]}, sort_keys=True)
+
+
+def _dedupe_projects(rows: list[ProjectRecord]) -> list[ProjectRecord]:
+    return list({(row.org_id, row.provider, row.id): row for row in rows}.values())
+
+
+def _dedupe_members(rows: list[MemberRecord]) -> list[MemberRecord]:
+    return list({(row.org_id, row.member_id): row for row in rows}.values())
+
+
+def _dedupe_memberships(
+    rows: list[TeamMembershipRecord],
+) -> list[TeamMembershipRecord]:
+    return list(
+        {
+            (row.org_id, row.provider, row.team_id, row.member_id, row.source): row
+            for row in rows
+        }.values()
+    )
+
+
+def _dedupe_ownership(
+    rows: list[TeamProjectOwnershipRecord],
+) -> list[TeamProjectOwnershipRecord]:
+    return list(
+        {
+            (row.org_id, row.provider, row.project_id, row.team_id, row.source): row
+            for row in rows
+        }.values()
+    )
+
+
+def populate(
+    *,
+    org_id: str,
+    credentials: dict[str, Any],
+    scope: dict[str, Any],
+    **kwargs: Any,
+) -> dict[str, Any]:
+    linear_credentials = linear_credentials_from_mapping(credentials)
+    if linear_credentials is None:
+        return {
+            "status": "skipped",
+            "reason": "missing_linear_credentials",
+            "projects_imported": 0,
+            "members_imported": 0,
+            "team_memberships_imported": 0,
+            "team_project_ownership_imported": 0,
+        }
+
+    now = datetime.now(timezone.utc)
+    discovery = TeamDiscoveryService(None, org_id)
+    membership = TeamMembershipService(cast(AsyncSession, None), org_id)
+    teams = _run(discovery.discover_linear(api_key=linear_credentials.api_key))
+
+    team_rows: list[dict[str, Any]] = []
+    project_rows: list[ProjectRecord] = []
+    member_rows: list[MemberRecord] = []
+    membership_rows: list[TeamMembershipRecord] = []
+    ownership_rows: list[TeamProjectOwnershipRecord] = []
+
+    for team in teams:
+        team_id = _team_id(team)
+        associations = dict(team.associations or {})
+        project_keys = [str(key) for key in associations.get("project_keys", []) if key]
+        if not project_keys:
+            project_keys = [team_id]
+
+        team_rows.append(
+            {
+                "id": team_id,
+                "name": team.name,
+                "description": team.description,
+                "members": [],
+                "project_keys": project_keys,
+                "repo_patterns": [],
+                "is_active": True,
+                "updated_at": now,
+                "org_id": org_id,
+                "provider": "linear",
+                "native_team_key": team_id,
+                "parent_team_id": None,
+            }
+        )
+
+        for project_key in project_keys:
+            project_rows.append(
+                ProjectRecord(
+                    id=_project_id(org_id, "linear", project_key),
+                    org_id=org_id,
+                    provider="linear",
+                    project_key=project_key,
+                    name=team.name,
+                    is_active=1,
+                    updated_at=now,
+                    last_synced=now,
+                )
+            )
+            ownership_rows.append(
+                TeamProjectOwnershipRecord(
+                    org_id=org_id,
+                    provider="linear",
+                    team_id=team_id,
+                    project_id=_project_id(org_id, "linear", project_key),
+                    project_key=project_key,
+                    source="native",
+                    is_primary=1,
+                    specificity=100,
+                    priority=10,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+
+        discovered_members = _run(
+            membership.discover_members_linear(
+                api_key=linear_credentials.api_key,
+                team_key=team_id,
+            )
+        )
+        team_rows[-1]["members"] = [
+            member.provider_identity for member in discovered_members
+        ]
+        for member in discovered_members:
+            member_id = _member_id("linear", member.provider_identity)
+            member_rows.append(
+                MemberRecord(
+                    org_id=org_id,
+                    member_id=member_id,
+                    name=member.display_name or member.provider_identity,
+                    email=member.email,
+                    provider_identities=_provider_identities(
+                        "linear", member.provider_identity
+                    ),
+                    is_active=1,
+                    updated_at=now,
+                )
+            )
+            membership_rows.append(
+                TeamMembershipRecord(
+                    org_id=org_id,
+                    provider="linear",
+                    team_id=team_id,
+                    member_id=member_id,
+                    raw_provider_user_id=member.provider_identity,
+                    raw_email=member.email,
+                    source="native",
+                    is_primary=1,
+                    specificity=100,
+                    priority=10,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+
+    sink, should_close = _sink_from_kwargs(kwargs)
+    try:
+        _run(sink.insert_teams(team_rows))
+        projects = _dedupe_projects(project_rows)
+        members = _dedupe_members(member_rows)
+        memberships = _dedupe_memberships(membership_rows)
+        ownership = _dedupe_ownership(ownership_rows)
+        sink.write_projects(projects)
+        sink.write_members(members)
+        sink.write_team_memberships(memberships)
+        sink.write_team_project_ownership(ownership)
+    finally:
+        if should_close:
+            sink.close()
+
+    return {
+        "mode": scope.get("mode"),
+        "teams_imported": len(team_rows),
+        "projects_imported": len(projects),
+        "members_imported": len(members),
+        "team_memberships_imported": len(memberships),
+        "team_project_ownership_imported": len(ownership),
+        "team_repo_ownership_imported": 0,
+        "work_item_team_attributions_imported": 0,
+    }

--- a/tests/workers/test_team_autoimport_jira.py
+++ b/tests/workers/test_team_autoimport_jira.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.admin.schemas_flat import DiscoveredMember, DiscoveredTeam
+from dev_health_ops.metrics.schemas import (
+    MemberRecord,
+    ProjectRecord,
+    TeamMembershipRecord,
+    TeamProjectOwnershipRecord,
+)
+from dev_health_ops.workers import team_autoimport_jira
+
+
+@dataclass
+class FakeDimensionSink:
+    projects: dict[tuple[str, str, str], ProjectRecord]
+    members: dict[tuple[str, str], MemberRecord]
+    memberships: dict[tuple[str, str, str, str, str], TeamMembershipRecord]
+    ownership: dict[tuple[str, str, str, str, str], TeamProjectOwnershipRecord]
+    teams: dict[tuple[str, str], dict[str, Any]]
+    jira_legacy_links: list[dict[str, Any]]
+    closed: bool = False
+
+    def write_projects(self, rows: list[ProjectRecord]) -> None:
+        for row in rows:
+            self.projects[(row.org_id, row.provider, row.id)] = row
+
+    def write_members(self, rows: list[MemberRecord]) -> None:
+        for row in rows:
+            self.members[(row.org_id, row.member_id)] = row
+
+    def write_team_memberships(self, rows: list[TeamMembershipRecord]) -> None:
+        for row in rows:
+            self.memberships[
+                (row.org_id, row.provider, row.team_id, row.member_id, row.source)
+            ] = row
+
+    def write_team_project_ownership(
+        self, rows: list[TeamProjectOwnershipRecord]
+    ) -> None:
+        for row in rows:
+            self.ownership[
+                (row.org_id, row.provider, row.project_id, row.team_id, row.source)
+            ] = row
+
+    async def insert_teams(self, teams: list[dict[str, Any]]) -> None:
+        for team in teams:
+            self.teams[(str(team["org_id"]), str(team["id"]))] = team
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        return [
+            row
+            for row in self.jira_legacy_links
+            if row.get("org_id") == parameters.get("org_id")
+        ]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _fake_sink(
+    *, jira_legacy_links: list[dict[str, Any]] | None = None
+) -> FakeDimensionSink:
+    return FakeDimensionSink(
+        projects={},
+        members={},
+        memberships={},
+        ownership={},
+        teams={},
+        jira_legacy_links=list(jira_legacy_links or []),
+    )
+
+
+def test_jira_populate_writes_native_and_jira_legacy_ownership_without_touching_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def discover_jira(
+        self: object, email: str, api_token: str, url: str
+    ) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="jira",
+                provider_team_id="OPS",
+                name="Ops Project",
+                associations={"project_keys": ["OPS"]},
+            )
+        ]
+
+    async def discover_members_jira_bulk(
+        self: object,
+        *,
+        email: str,
+        api_token: str,
+        url: str,
+        project_keys: list[str],
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="jira",
+                provider_identity="account-1",
+                display_name="Ops Lead",
+                email="ops@example.com",
+                role="lead",
+            )
+        ]
+
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamDiscoveryService,
+        "discover_jira",
+        discover_jira,
+    )
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamMembershipService,
+        "discover_members_jira_bulk",
+        discover_members_jira_bulk,
+    )
+    legacy_links = [
+        {
+            "org_id": "org-1",
+            "project_key": "OPS",
+            "ops_team_id": "ops-team-legacy",
+            "project_name": "Ops Project",
+            "ops_team_name": "Ops Legacy",
+        }
+    ]
+    sink = _fake_sink(jira_legacy_links=legacy_links)
+
+    summary = team_autoimport_jira.populate(
+        org_id="org-1",
+        credentials={
+            "email": "jira@example.com",
+            "api_token": "jira-token",
+            "base_url": "https://jira.example.com",
+        },
+        scope={"mode": "sync_config"},
+        sink=sink,
+    )
+
+    assert summary["team_project_ownership_imported"] == 2
+    assert summary["jira_legacy_project_ownership_imported"] == 1
+    assert legacy_links == sink.jira_legacy_links
+    assert (
+        "org-1",
+        "jira",
+        "org-1:jira:OPS",
+        "OPS",
+        "native",
+    ) in sink.ownership
+    assert (
+        "org-1",
+        "jira",
+        "org-1:jira:OPS",
+        "ops-team-legacy",
+        "jira_legacy",
+    ) in sink.ownership
+    assert ("org-1", "jira:account-1") in sink.members
+
+
+def test_jira_populate_preserves_manual_project_ownership_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def discover_jira(
+        self: object, email: str, api_token: str, url: str
+    ) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="jira",
+                provider_team_id="OPS",
+                name="Ops Project",
+                associations={"project_keys": ["OPS"]},
+            )
+        ]
+
+    async def discover_members_jira_bulk(
+        self: object,
+        *,
+        email: str,
+        api_token: str,
+        url: str,
+        project_keys: list[str],
+    ) -> list[DiscoveredMember]:
+        return []
+
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamDiscoveryService,
+        "discover_jira",
+        discover_jira,
+    )
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamMembershipService,
+        "discover_members_jira_bulk",
+        discover_members_jira_bulk,
+    )
+    sink = _fake_sink()
+    manual = TeamProjectOwnershipRecord(
+        org_id="org-1",
+        provider="jira",
+        team_id="manual-team",
+        project_id="org-1:jira:OPS",
+        project_key="OPS",
+        source="manual",
+        is_primary=1,
+        specificity=100,
+        priority=0,
+        valid_from=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    sink.write_team_project_ownership([manual])
+
+    team_autoimport_jira.populate(
+        org_id="org-1",
+        credentials={
+            "email": "jira@example.com",
+            "api_token": "jira-token",
+            "base_url": "https://jira.example.com",
+        },
+        scope={"mode": "sync_config"},
+        sink=sink,
+    )
+
+    assert (
+        "org-1",
+        "jira",
+        "org-1:jira:OPS",
+        "manual-team",
+        "manual",
+    ) in sink.ownership
+    assert (
+        "org-1",
+        "jira",
+        "org-1:jira:OPS",
+        "OPS",
+        "native",
+    ) in sink.ownership

--- a/tests/workers/test_team_autoimport_linear.py
+++ b/tests/workers/test_team_autoimport_linear.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.admin.schemas_flat import DiscoveredMember, DiscoveredTeam
+from dev_health_ops.metrics.schemas import (
+    MemberRecord,
+    ProjectRecord,
+    TeamMembershipRecord,
+    TeamProjectOwnershipRecord,
+)
+from dev_health_ops.workers import team_autoimport_linear
+
+
+@dataclass
+class FakeDimensionSink:
+    projects: dict[tuple[str, str, str], ProjectRecord]
+    members: dict[tuple[str, str], MemberRecord]
+    memberships: dict[tuple[str, str, str, str, str], TeamMembershipRecord]
+    ownership: dict[tuple[str, str, str, str, str], TeamProjectOwnershipRecord]
+    teams: dict[tuple[str, str], dict[str, Any]]
+    closed: bool = False
+
+    def write_projects(self, rows: list[ProjectRecord]) -> None:
+        for row in rows:
+            self.projects[(row.org_id, row.provider, row.id)] = row
+
+    def write_members(self, rows: list[MemberRecord]) -> None:
+        for row in rows:
+            self.members[(row.org_id, row.member_id)] = row
+
+    def write_team_memberships(self, rows: list[TeamMembershipRecord]) -> None:
+        for row in rows:
+            self.memberships[
+                (row.org_id, row.provider, row.team_id, row.member_id, row.source)
+            ] = row
+
+    def write_team_project_ownership(
+        self, rows: list[TeamProjectOwnershipRecord]
+    ) -> None:
+        for row in rows:
+            self.ownership[
+                (row.org_id, row.provider, row.project_id, row.team_id, row.source)
+            ] = row
+
+    async def insert_teams(self, teams: list[dict[str, Any]]) -> None:
+        for team in teams:
+            self.teams[(str(team["org_id"]), str(team["id"]))] = team
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _fake_sink() -> FakeDimensionSink:
+    return FakeDimensionSink(
+        projects={},
+        members={},
+        memberships={},
+        ownership={},
+        teams={},
+    )
+
+
+def test_linear_populate_writes_projects_memberships_and_project_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def discover_linear(self: object, api_key: str) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="linear",
+                provider_team_id="ENG",
+                name="Engineering",
+                associations={"project_keys": ["ENG"]},
+            )
+        ]
+
+    async def discover_members_linear(
+        self: object, api_key: str, team_key: str
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="linear",
+                provider_identity="dev@example.com",
+                display_name="Dev User",
+                email="dev@example.com",
+            )
+        ]
+
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamDiscoveryService,
+        "discover_linear",
+        discover_linear,
+    )
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamMembershipService,
+        "discover_members_linear",
+        discover_members_linear,
+    )
+    sink = _fake_sink()
+
+    summary = team_autoimport_linear.populate(
+        org_id="org-1",
+        credentials={"api_key": "lin-key"},
+        scope={"mode": "sync_config"},
+        sink=sink,
+    )
+
+    assert summary["projects_imported"] == 1
+    assert summary["members_imported"] == 1
+    assert summary["team_memberships_imported"] == 1
+    assert summary["team_project_ownership_imported"] == 1
+    assert ("org-1", "linear", "org-1:linear:ENG") in sink.projects
+    assert ("org-1", "linear:dev@example.com") in sink.members
+    assert (
+        "org-1",
+        "linear",
+        "ENG",
+        "linear:dev@example.com",
+        "native",
+    ) in sink.memberships
+    assert (
+        "org-1",
+        "linear",
+        "org-1:linear:ENG",
+        "ENG",
+        "native",
+    ) in sink.ownership
+    assert sink.teams[("org-1", "ENG")]["native_team_key"] == "ENG"
+
+
+def test_linear_populate_rerun_keeps_stable_logical_dimension_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def discover_linear(self: object, api_key: str) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="linear",
+                provider_team_id="ENG",
+                name="Engineering",
+                associations={"project_keys": ["ENG"]},
+            )
+        ]
+
+    async def discover_members_linear(
+        self: object, api_key: str, team_key: str
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="linear",
+                provider_identity="dev@example.com",
+                display_name="Dev User",
+                email="dev@example.com",
+            )
+        ]
+
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamDiscoveryService,
+        "discover_linear",
+        discover_linear,
+    )
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamMembershipService,
+        "discover_members_linear",
+        discover_members_linear,
+    )
+    sink = _fake_sink()
+
+    for _ in range(2):
+        team_autoimport_linear.populate(
+            org_id="org-1",
+            credentials={"api_key": "lin-key"},
+            scope={"mode": "sync_config"},
+            sink=sink,
+        )
+
+    assert len(sink.projects) == 1
+    assert len(sink.members) == 1
+    assert len(sink.memberships) == 1
+    assert len(sink.ownership) == 1
+    assert len(sink.teams) == 1


### PR DESCRIPTION
## Summary
- Add Linear team auto-import populator for projects, members, memberships, project ownership, and team rows through existing ClickHouse sink writers.
- Add Jira team auto-import populator with native project ownership plus jira_project_ops_team_links folded into team_project_ownership as source='jira_legacy'.
- Cover provider-stubbed Linear/Jira population, idempotent rerun behavior, manual ownership preservation, and legacy Jira link non-regression.

## Verification
- CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/workers/test_team_autoimport_linear.py tests/workers/test_team_autoimport_jira.py -q
- uv run --extra dev --python 3.11 mypy src/dev_health_ops/workers/team_autoimport_linear.py src/dev_health_ops/workers/team_autoimport_jira.py
- uv run --extra dev --python 3.11 ruff check src/dev_health_ops/workers/team_autoimport_linear.py src/dev_health_ops/workers/team_autoimport_jira.py tests/workers/test_team_autoimport_linear.py tests/workers/test_team_autoimport_jira.py
- LSP diagnostics clean on changed files

Closes CHAOS-2545.
Stacked on #984.
SCREENSHOT-WAIVER: backend only.