### PR TITLE
fix(teams): pass resolved analytics DSN into auto-import populators (CHAOS-2544)

### DIFF
--- a/src/dev_health_ops/backfill/runner.py
+++ b/src/dev_health_ops/backfill/runner.py
@@ -81,6 +81,7 @@ def _run_team_autoimport_for_backfill(
     since: date,
     before: date,
     window_count: int,
+    analytics_db_url: str | None,
 ) -> dict[str, Any] | None:
     if not sync_options.get("auto_import_teams"):
         return None
@@ -96,6 +97,7 @@ def _run_team_autoimport_for_backfill(
             "since": since.isoformat(),
             "before": before.isoformat(),
         },
+        analytics_db_url=analytics_db_url,
     )
 
 
@@ -169,6 +171,7 @@ def run_backfill_for_config(
         since=since,
         before=before,
         window_count=len(windows),
+        analytics_db_url=db_url,
     )
 
     result = {

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -313,6 +313,7 @@ def _run_team_autoimport_for_batch_child(
     sync_targets: list[str],
     config_id: str,
     triggered_by: str,
+    analytics_db_url: str | None,
 ) -> dict[str, Any] | None:
     if not sync_options.get("auto_import_teams"):
         return None
@@ -327,6 +328,7 @@ def _run_team_autoimport_for_batch_child(
             "sync_options": dict(sync_options),
             "triggered_by": triggered_by,
         },
+        analytics_db_url=analytics_db_url,
     )
 
 
@@ -818,6 +820,7 @@ def _run_sync_for_repo(
             sync_targets=sync_targets,
             config_id=config_id,
             triggered_by=triggered_by,
+            analytics_db_url=db_url,
         )
         if team_autoimport is not None:
             result_payload["team_autoimport"] = team_autoimport

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -449,6 +449,7 @@ def _run_team_autoimport_for_sync_config(
     sync_targets: list[str],
     config_id: str,
     triggered_by: str,
+    analytics_db_url: str | None,
 ) -> dict[str, Any] | None:
     if not sync_options.get("auto_import_teams"):
         return None
@@ -463,6 +464,7 @@ def _run_team_autoimport_for_sync_config(
             "sync_options": dict(sync_options),
             "triggered_by": triggered_by,
         },
+        analytics_db_url=analytics_db_url,
     )
 
 
@@ -875,6 +877,7 @@ def run_sync_config(
             sync_targets=sync_targets,
             config_id=config_id,
             triggered_by=triggered_by,
+            analytics_db_url=db_url,
         )
         if team_autoimport is not None:
             result_payload["team_autoimport"] = team_autoimport

--- a/src/dev_health_ops/workers/team_autoimport.py
+++ b/src/dev_health_ops/workers/team_autoimport.py
@@ -62,6 +62,7 @@ def run_team_autoimport(
     org_id: str,
     credentials: dict[str, Any],
     scope: dict[str, Any] | None = None,
+    analytics_db_url: str | None = None,
 ) -> dict[str, Any]:
     normalized_provider = provider.strip().lower()
     if not _provider_capability(normalized_provider):
@@ -90,10 +91,14 @@ def run_team_autoimport(
         )
 
     try:
+        populator_scope = dict(scope or {})
+        if analytics_db_url:
+            populator_scope["analytics_db"] = analytics_db_url
+
         summary = populator(
             org_id=org_id,
             credentials=credentials,
-            scope=dict(scope or {}),
+            scope=populator_scope,
         )
     except Exception as exc:
         logger.exception(

--- a/src/dev_health_ops/workers/team_autoimport_jira.py
+++ b/src/dev_health_ops/workers/team_autoimport_jira.py
@@ -66,11 +66,13 @@ def _run(coro: Coroutine[Any, Any, _T]) -> _T:
     return cast(_T, result)
 
 
-def _sink_from_kwargs(kwargs: dict[str, Any]) -> tuple[_DimensionSink, bool]:
+def _sink_from_kwargs(
+    scope: dict[str, Any], kwargs: dict[str, Any]
+) -> tuple[_DimensionSink, bool]:
     injected = kwargs.get("sink")
     if injected is not None:
         return cast(_DimensionSink, injected), False
-    dsn = str(kwargs.get("clickhouse_uri") or os.getenv("CLICKHOUSE_URI") or "")
+    dsn = str(scope.get("analytics_db") or os.getenv("CLICKHOUSE_URI") or "")
     if not dsn:
         raise ValueError("ClickHouse DSN is required for Jira team auto-import")
     return cast(_DimensionSink, ClickHouseMetricsSink(dsn=dsn)), True
@@ -267,7 +269,7 @@ def populate(
                 )
             )
 
-    sink, should_close = _sink_from_kwargs(kwargs)
+    sink, should_close = _sink_from_kwargs(scope, kwargs)
     try:
         for link in _load_jira_legacy_links(sink, org_id=org_id):
             project_key = str(link.get("project_key") or "")

--- a/src/dev_health_ops/workers/team_autoimport_linear.py
+++ b/src/dev_health_ops/workers/team_autoimport_linear.py
@@ -63,11 +63,13 @@ def _run(coro: Coroutine[Any, Any, _T]) -> _T:
     return cast(_T, result)
 
 
-def _sink_from_kwargs(kwargs: dict[str, Any]) -> tuple[_DimensionSink, bool]:
+def _sink_from_kwargs(
+    scope: dict[str, Any], kwargs: dict[str, Any]
+) -> tuple[_DimensionSink, bool]:
     injected = kwargs.get("sink")
     if injected is not None:
         return cast(_DimensionSink, injected), False
-    dsn = str(kwargs.get("clickhouse_uri") or os.getenv("CLICKHOUSE_URI") or "")
+    dsn = str(scope.get("analytics_db") or os.getenv("CLICKHOUSE_URI") or "")
     if not dsn:
         raise ValueError("ClickHouse DSN is required for Linear team auto-import")
     return cast(_DimensionSink, ClickHouseMetricsSink(dsn=dsn)), True
@@ -242,7 +244,7 @@ def populate(
                 )
             )
 
-    sink, should_close = _sink_from_kwargs(kwargs)
+    sink, should_close = _sink_from_kwargs(scope, kwargs)
     try:
         _run(sink.insert_teams(team_rows))
         projects = _dedupe_projects(project_rows)

--- a/tests/workers/test_team_autoimport_batch.py
+++ b/tests/workers/test_team_autoimport_batch.py
@@ -48,10 +48,12 @@ def test_batch_child_autoimport_true_calls_once(monkeypatch) -> None:
         sync_targets=["git"],
         config_id="cfg-1",
         triggered_by="manual",
+        analytics_db_url="clickhouse://batch-dsn",
     )
 
     assert result == {"status": "success"}
     assert len(calls) == 1
+    assert calls[0]["analytics_db_url"] == "clickhouse://batch-dsn"
     assert calls[0]["scope"] == {
         "mode": "batch_child",
         "sync_config_id": "cfg-1",

--- a/tests/workers/test_team_autoimport_executor.py
+++ b/tests/workers/test_team_autoimport_executor.py
@@ -53,6 +53,7 @@ def test_run_team_autoimport_calls_resolved_populator(monkeypatch) -> None:
         org_id="org-1",
         credentials={"token": "secret"},
         scope={"project_keys": ["OPS"]},
+        analytics_db_url="clickhouse://config-dsn",
     )
 
     assert result == {
@@ -65,6 +66,9 @@ def test_run_team_autoimport_calls_resolved_populator(monkeypatch) -> None:
         {
             "org_id": "org-1",
             "credentials": {"token": "secret"},
-            "scope": {"project_keys": ["OPS"]},
+            "scope": {
+                "project_keys": ["OPS"],
+                "analytics_db": "clickhouse://config-dsn",
+            },
         }
     ]

--- a/tests/workers/test_team_autoimport_jira.py
+++ b/tests/workers/test_team_autoimport_jira.py
@@ -13,7 +13,7 @@ from dev_health_ops.metrics.schemas import (
     TeamMembershipRecord,
     TeamProjectOwnershipRecord,
 )
-from dev_health_ops.workers import team_autoimport_jira
+from dev_health_ops.workers import team_autoimport, team_autoimport_jira
 
 
 @dataclass
@@ -76,6 +76,22 @@ def _fake_sink(
         teams={},
         jira_legacy_links=list(jira_legacy_links or []),
     )
+
+
+class CapturingClickHouseSink(FakeDimensionSink):
+    instances: list[CapturingClickHouseSink] = []
+
+    def __init__(self, *, dsn: str) -> None:
+        super().__init__(
+            projects={},
+            members={},
+            memberships={},
+            ownership={},
+            teams={},
+            jira_legacy_links=[],
+        )
+        self.dsn = dsn
+        self.instances.append(self)
 
 
 def test_jira_populate_writes_native_and_jira_legacy_ownership_without_touching_links(
@@ -161,6 +177,89 @@ def test_jira_populate_writes_native_and_jira_legacy_ownership_without_touching_
         "jira_legacy",
     ) in sink.ownership
     assert ("org-1", "jira:account-1") in sink.members
+
+
+def test_chaos_2547_2544_jira_autoimport_uses_analytics_db_url_with_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def discover_jira(
+        self: object, email: str, api_token: str, url: str
+    ) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="jira",
+                provider_team_id="OPS",
+                name="Ops Project",
+                associations={"project_keys": ["OPS"]},
+            )
+        ]
+
+    async def discover_members_jira_bulk(
+        self: object,
+        *,
+        email: str,
+        api_token: str,
+        url: str,
+        project_keys: list[str],
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="jira",
+                provider_identity="account-1",
+                display_name="Ops Lead",
+                email="ops@example.com",
+                role="lead",
+            )
+        ]
+
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    CapturingClickHouseSink.instances = []
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamDiscoveryService,
+        "discover_jira",
+        discover_jira,
+    )
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamMembershipService,
+        "discover_members_jira_bulk",
+        discover_members_jira_bulk,
+    )
+    monkeypatch.setattr(
+        team_autoimport_jira,
+        "ClickHouseMetricsSink",
+        CapturingClickHouseSink,
+    )
+
+    summary = team_autoimport.run_team_autoimport(
+        provider="jira",
+        org_id="org-1",
+        credentials={
+            "email": "jira@example.com",
+            "api_token": "jira-token",
+            "base_url": "https://jira.example.com",
+        },
+        scope={"mode": "sync_config"},
+        analytics_db_url="clickhouse://jira-config-dsn",
+    )
+
+    assert summary["status"] == "success"
+    assert summary["projects_imported"] == 1
+    assert summary["members_imported"] == 1
+    assert summary["team_memberships_imported"] == 1
+    assert summary["team_project_ownership_imported"] == 1
+    assert len(CapturingClickHouseSink.instances) == 1
+    sink = CapturingClickHouseSink.instances[0]
+    assert sink.dsn == "clickhouse://jira-config-dsn"
+    assert sink.closed is True
+    assert ("org-1", "jira", "org-1:jira:OPS") in sink.projects
+    assert ("org-1", "jira:account-1") in sink.members
+    assert (
+        "org-1",
+        "jira",
+        "OPS",
+        "jira:account-1",
+        "native",
+    ) in sink.memberships
 
 
 def test_jira_populate_preserves_manual_project_ownership_row(

--- a/tests/workers/test_team_autoimport_linear.py
+++ b/tests/workers/test_team_autoimport_linear.py
@@ -12,7 +12,7 @@ from dev_health_ops.metrics.schemas import (
     TeamMembershipRecord,
     TeamProjectOwnershipRecord,
 )
-from dev_health_ops.workers import team_autoimport_linear
+from dev_health_ops.workers import team_autoimport, team_autoimport_linear
 
 
 @dataclass
@@ -62,6 +62,21 @@ def _fake_sink() -> FakeDimensionSink:
         ownership={},
         teams={},
     )
+
+
+class CapturingClickHouseSink(FakeDimensionSink):
+    instances: list[CapturingClickHouseSink] = []
+
+    def __init__(self, *, dsn: str) -> None:
+        super().__init__(
+            projects={},
+            members={},
+            memberships={},
+            ownership={},
+            teams={},
+        )
+        self.dsn = dsn
+        self.instances.append(self)
 
 
 def test_linear_populate_writes_projects_memberships_and_project_ownership(
@@ -129,6 +144,77 @@ def test_linear_populate_writes_projects_memberships_and_project_ownership(
         "native",
     ) in sink.ownership
     assert sink.teams[("org-1", "ENG")]["native_team_key"] == "ENG"
+
+
+def test_chaos_2547_2544_autoimport_uses_analytics_db_url_with_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def discover_linear(self: object, api_key: str) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="linear",
+                provider_team_id="ENG",
+                name="Engineering",
+                associations={"project_keys": ["ENG"]},
+            )
+        ]
+
+    async def discover_members_linear(
+        self: object, api_key: str, team_key: str
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="linear",
+                provider_identity="dev@example.com",
+                display_name="Dev User",
+                email="dev@example.com",
+            )
+        ]
+
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    CapturingClickHouseSink.instances = []
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamDiscoveryService,
+        "discover_linear",
+        discover_linear,
+    )
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamMembershipService,
+        "discover_members_linear",
+        discover_members_linear,
+    )
+    monkeypatch.setattr(
+        team_autoimport_linear,
+        "ClickHouseMetricsSink",
+        CapturingClickHouseSink,
+    )
+
+    summary = team_autoimport.run_team_autoimport(
+        provider="linear",
+        org_id="org-1",
+        credentials={"api_key": "lin-key"},
+        scope={"mode": "sync_config"},
+        analytics_db_url="clickhouse://config-dsn",
+    )
+
+    assert summary["status"] == "success"
+    assert summary["projects_imported"] == 1
+    assert summary["members_imported"] == 1
+    assert summary["team_memberships_imported"] == 1
+    assert summary["team_project_ownership_imported"] == 1
+    assert len(CapturingClickHouseSink.instances) == 1
+    sink = CapturingClickHouseSink.instances[0]
+    assert sink.dsn == "clickhouse://config-dsn"
+    assert sink.closed is True
+    assert ("org-1", "linear", "org-1:linear:ENG") in sink.projects
+    assert ("org-1", "linear:dev@example.com") in sink.members
+    assert (
+        "org-1",
+        "linear",
+        "ENG",
+        "linear:dev@example.com",
+        "native",
+    ) in sink.memberships
 
 
 def test_linear_populate_rerun_keeps_stable_logical_dimension_rows(

--- a/tests/workers/test_team_autoimport_sync_surfaces.py
+++ b/tests/workers/test_team_autoimport_sync_surfaces.py
@@ -22,6 +22,7 @@ def test_sync_runtime_autoimport_false_or_absent_does_not_call(monkeypatch) -> N
             sync_targets=["work-items"],
             config_id="cfg-1",
             triggered_by="manual",
+            analytics_db_url=None,
         )
         is None
     )
@@ -34,6 +35,7 @@ def test_sync_runtime_autoimport_false_or_absent_does_not_call(monkeypatch) -> N
             sync_targets=["work-items"],
             config_id="cfg-1",
             triggered_by="manual",
+            analytics_db_url=None,
         )
         is None
     )
@@ -57,6 +59,7 @@ def test_sync_runtime_autoimport_true_calls_once(monkeypatch) -> None:
         sync_targets=["work-items"],
         config_id="cfg-1",
         triggered_by="schedule",
+        analytics_db_url="clickhouse://config-dsn",
     )
 
     assert result == {"status": "success"}
@@ -65,6 +68,7 @@ def test_sync_runtime_autoimport_true_calls_once(monkeypatch) -> None:
         "provider": "linear",
         "org_id": "org-1",
         "credentials": {"api_key": "secret"},
+        "analytics_db_url": "clickhouse://config-dsn",
         "scope": {
             "mode": "sync_config",
             "sync_config_id": "cfg-1",
@@ -91,6 +95,7 @@ def test_backfill_autoimport_false_or_absent_does_not_call(monkeypatch) -> None:
             since=date(2026, 1, 1),
             before=date(2026, 1, 7),
             window_count=1,
+            analytics_db_url=None,
         )
         is None
     )
@@ -104,6 +109,7 @@ def test_backfill_autoimport_false_or_absent_does_not_call(monkeypatch) -> None:
             since=date(2026, 1, 1),
             before=date(2026, 1, 7),
             window_count=1,
+            analytics_db_url=None,
         )
         is None
     )
@@ -130,6 +136,7 @@ def test_backfill_autoimport_true_calls_once(monkeypatch) -> None:
         since=date(2026, 1, 1),
         before=date(2026, 1, 7),
         window_count=1,
+        analytics_db_url="clickhouse://backfill-dsn",
     )
 
     assert result == {"status": "success"}
@@ -138,6 +145,7 @@ def test_backfill_autoimport_true_calls_once(monkeypatch) -> None:
         "provider": "jira",
         "org_id": "org-1",
         "credentials": {"email": "dev@example.com"},
+        "analytics_db_url": "clickhouse://backfill-dsn",
         "scope": {
             "mode": "backfill",
             "sync_config_id": "cfg-1",


### PR DESCRIPTION
## Summary
- Pass the resolved analytics DSN into auto-import from sync-config, batch-child, and backfill paths.
- Canonicalize populator DSN lookup on scope["analytics_db"] with CLICKHOUSE_URI as fallback.
- Add CHAOS-2547/2544 regressions proving env-unset auto-import writes dimension rows using the config DSN.

Fixes the silent no-op found by CHAOS-2547: auto-import relied on the process CLICKHOUSE_URI env instead of the sync's resolved analytics DSN.

SCREENSHOT-WAIVER: backend only.