### PR TITLE
feat(teams): auto-import teams/projects/members + ownership dims during sync (CHAOS-2544/2545/2546/2547)

### DIFF
--- a/docs/architecture/team-attribution.md
+++ b/docs/architecture/team-attribution.md
@@ -219,6 +219,38 @@ flowchart LR
 
 **Key boundary differences**
 
+### Manual QA: auto-imported ownership coverage
+
+Use this check when validating CHAOS-2401/2547 against a real tenant. It proves
+the sync surface fills the ClickHouse ownership dimensions that the attribution
+resolver reads, then verifies the user-visible Investment → Allocation coverage
+does not collapse to `unassigned`.
+
+1. In Admin → Sync, create or edit a real Linear work-items sync and enable
+   **Auto-import teams, projects & members** (`sync_options.auto_import_teams=true`).
+2. Trigger the sync through the sync-config UI or worker-backed trigger endpoint
+   so the configured worker credentials are used.
+3. After the sync succeeds, run daily metrics with the same analytics database:
+
+   ```bash
+   CLICKHOUSE_URI=clickhouse://... dev-hops metrics daily
+   ```
+
+4. Open `dev-health-web` in a real browser (Playwright is preferred for evidence)
+   and navigate to **Investment → Allocation**.
+5. Verify team coverage is greater than 0% and the allocation view includes named
+   teams from the Linear import, not only `unassigned`.
+6. Optional SQL spot-checks against ClickHouse before opening the browser
+   (replace `<org_id>` with the tenant being verified):
+
+   ```sql
+   SELECT count() FROM projects WHERE org_id = '<org_id>' AND provider = 'linear';
+   SELECT count() FROM members WHERE org_id = '<org_id>';
+   SELECT count() FROM team_memberships WHERE org_id = '<org_id>' AND provider = 'linear';
+   SELECT count() FROM team_project_ownership WHERE org_id = '<org_id>' AND provider = 'linear';
+   SELECT team_id, count() FROM work_item_cycle_times WHERE org_id = '<org_id>' GROUP BY team_id;
+   ```
+
 | Aspect | `job_work_items` (sync) | `job_daily` (recompute) |
 |---|---|---|
 | Edge source | freshly extracted (authoritative) | persisted, `FINAL`, bounded by run-window source ids |

--- a/src/dev_health_ops/backfill/runner.py
+++ b/src/dev_health_ops/backfill/runner.py
@@ -9,6 +9,7 @@ from dev_health_ops.db import get_postgres_session_sync
 from dev_health_ops.metrics.job_work_items import run_work_items_sync_job
 from dev_health_ops.models.settings import SyncConfiguration
 from dev_health_ops.workers.task_utils import _jira_query_options
+from dev_health_ops.workers.team_autoimport import run_team_autoimport
 
 from .chunker import chunk_date_range
 
@@ -68,6 +69,34 @@ def _as_utc_datetime(value: date | datetime, *, end_of_day: bool) -> datetime:
         return value.astimezone(timezone.utc)
     boundary = time.max if end_of_day else time.min
     return datetime.combine(value, boundary, tzinfo=timezone.utc)
+
+
+def _run_team_autoimport_for_backfill(
+    *,
+    provider: str,
+    org_id: str,
+    credentials: dict[str, Any] | None,
+    sync_options: dict[str, Any],
+    sync_config_id: str,
+    since: date,
+    before: date,
+    window_count: int,
+) -> dict[str, Any] | None:
+    if not sync_options.get("auto_import_teams"):
+        return None
+    return run_team_autoimport(
+        provider=provider,
+        org_id=org_id,
+        credentials=credentials or {},
+        scope={
+            "mode": "backfill",
+            "sync_config_id": sync_config_id,
+            "sync_options": dict(sync_options),
+            "window_count": window_count,
+            "since": since.isoformat(),
+            "before": before.isoformat(),
+        },
+    )
 
 
 def run_backfill_for_config(
@@ -131,7 +160,18 @@ def run_backfill_for_config(
             jira_fetch_all=jira_fetch_all if provider == "jira" else None,
         )
 
-    return {
+    team_autoimport = _run_team_autoimport_for_backfill(
+        provider=provider,
+        org_id=org_id,
+        credentials=credentials,
+        sync_options=sync_options,
+        sync_config_id=sync_config_id,
+        since=since,
+        before=before,
+        window_count=len(windows),
+    )
+
+    result = {
         "status": "success",
         "provider": provider,
         "sync_config_id": sync_config_id,
@@ -140,3 +180,6 @@ def run_backfill_for_config(
         "since": since.isoformat(),
         "before": before.isoformat(),
     }
+    if team_autoimport is not None:
+        result["team_autoimport"] = team_autoimport
+    return result

--- a/src/dev_health_ops/backfill/runner.py
+++ b/src/dev_health_ops/backfill/runner.py
@@ -81,6 +81,7 @@ def _run_team_autoimport_for_backfill(
     since: date,
     before: date,
     window_count: int,
+    analytics_db_url: str | None,
 ) -> dict[str, Any] | None:
     if not sync_options.get("auto_import_teams"):
         return None
@@ -96,6 +97,7 @@ def _run_team_autoimport_for_backfill(
             "since": since.isoformat(),
             "before": before.isoformat(),
         },
+        analytics_db_url=analytics_db_url,
     )
 
 
@@ -169,6 +171,7 @@ def run_backfill_for_config(
         since=since,
         before=before,
         window_count=len(windows),
+        analytics_db_url=db_url,
     )
 
     result = {

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -30,6 +30,7 @@ from dev_health_ops.workers.task_utils import (
     _normalize_sync_targets,
     _resolve_env_credentials,
 )
+from dev_health_ops.workers.team_autoimport import run_team_autoimport
 
 logger = logging.getLogger(__name__)
 
@@ -261,6 +262,74 @@ def _get_batch_size(sync_options: dict[str, Any]) -> int:
     return 5
 
 
+def _repo_sync_options(
+    *,
+    provider: str,
+    sync_targets: list[str],
+    sync_options: dict[str, Any],
+    repo_tuple: tuple[Any, ...],
+) -> dict[str, Any]:
+    per_repo_options = dict(sync_options)
+    per_repo_options.pop("discover", None)
+    per_repo_options.pop("all_repos", None)
+    per_repo_options.pop("batch_size", None)
+
+    if provider == "github":
+        owner, repo_name = repo_tuple[0], repo_tuple[1]
+        per_repo_options["owner"] = owner
+        per_repo_options["repo"] = repo_name
+        if "work-items" in sync_targets:
+            per_repo_options["search"] = f"{owner}/{repo_name}"
+        else:
+            per_repo_options.pop("search", None)
+    elif provider == "gitlab":
+        project_id = repo_tuple[0]
+        per_repo_options["project_id"] = int(project_id)
+        if "work-items" in sync_targets:
+            project_path = repo_tuple[1] if len(repo_tuple) > 1 else ""
+            if project_path:
+                per_repo_options["search"] = project_path
+            else:
+                logger.warning(
+                    "GitLab work-items child for project_id=%s has no "
+                    "project path; skipping work-items scope to avoid "
+                    "org-wide fanout",
+                    project_id,
+                )
+                per_repo_options["search"] = f"noscope-{project_id}"
+        else:
+            per_repo_options.pop("search", None)
+        per_repo_options.pop("group", None)
+
+    return per_repo_options
+
+
+def _run_team_autoimport_for_batch_child(
+    *,
+    provider: str,
+    org_id: str,
+    credentials: dict[str, Any],
+    sync_options: dict[str, Any],
+    sync_targets: list[str],
+    config_id: str,
+    triggered_by: str,
+) -> dict[str, Any] | None:
+    if not sync_options.get("auto_import_teams"):
+        return None
+    return run_team_autoimport(
+        provider=provider,
+        org_id=org_id,
+        credentials=credentials,
+        scope={
+            "mode": "batch_child",
+            "sync_config_id": config_id,
+            "sync_targets": sync_targets,
+            "sync_options": dict(sync_options),
+            "triggered_by": triggered_by,
+        },
+    )
+
+
 @celery_app.task(
     bind=True, queue="sync", name="dev_health_ops.workers.tasks._batch_sync_callback"
 )
@@ -433,45 +502,12 @@ def dispatch_batch_sync(
         child_tasks = []
 
         for repo_tuple in repos:
-            per_repo_options = dict(sync_options)
-            per_repo_options.pop("discover", None)
-            per_repo_options.pop("all_repos", None)
-            per_repo_options.pop("batch_size", None)
-
-            if provider == "github":
-                owner, repo_name = repo_tuple[0], repo_tuple[1]
-                per_repo_options["owner"] = owner
-                per_repo_options["repo"] = repo_name
-                if "work-items" in sync_targets:
-                    per_repo_options["search"] = f"{owner}/{repo_name}"
-                else:
-                    per_repo_options.pop("search", None)
-            elif provider == "gitlab":
-                project_id = repo_tuple[0]
-                per_repo_options["project_id"] = int(project_id)
-                if "work-items" in sync_targets:
-                    project_path = repo_tuple[1] if len(repo_tuple) > 1 else ""
-                    if project_path:
-                        per_repo_options["search"] = project_path
-                    else:
-                        # Never pass an empty/all-matching search to a
-                        # work-items child: match_pattern("", ...) treats an
-                        # empty pattern as "match every repo", re-opening the
-                        # org-wide work-items fanout (CHAOS-2450). Scope to a
-                        # sentinel that cannot match any GitLab
-                        # path_with_namespace (which always contains "/") so
-                        # this project's work-items are skipped rather than
-                        # fanning out to all repos.
-                        logger.warning(
-                            "GitLab work-items child for project_id=%s has no "
-                            "project path; skipping work-items scope to avoid "
-                            "org-wide fanout",
-                            project_id,
-                        )
-                        per_repo_options["search"] = f"noscope-{project_id}"
-                else:
-                    per_repo_options.pop("search", None)
-                per_repo_options.pop("group", None)
+            per_repo_options = _repo_sync_options(
+                provider=provider,
+                sync_targets=sync_targets,
+                sync_options=sync_options,
+                repo_tuple=repo_tuple,
+            )
 
             child_signature = getattr(_run_sync_for_repo, "s")(
                 config_id=config_id,
@@ -773,6 +809,18 @@ def _run_sync_for_repo(
                         session, org_id, repo_id_for_watermark, t, started_at
                     )
                 session.flush()
+
+        team_autoimport = _run_team_autoimport_for_batch_child(
+            provider=provider,
+            org_id=org_id,
+            credentials=credentials,
+            sync_options=sync_options_override,
+            sync_targets=sync_targets,
+            config_id=config_id,
+            triggered_by=triggered_by,
+        )
+        if team_autoimport is not None:
+            result_payload["team_autoimport"] = team_autoimport
 
         duration = int((datetime.now(timezone.utc) - started_at).total_seconds())
         return {

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -313,6 +313,7 @@ def _run_team_autoimport_for_batch_child(
     sync_targets: list[str],
     config_id: str,
     triggered_by: str,
+    analytics_db_url: str | None,
 ) -> dict[str, Any] | None:
     if not sync_options.get("auto_import_teams"):
         return None
@@ -327,6 +328,7 @@ def _run_team_autoimport_for_batch_child(
             "sync_options": dict(sync_options),
             "triggered_by": triggered_by,
         },
+        analytics_db_url=analytics_db_url,
     )
 
 
@@ -818,6 +820,7 @@ def _run_sync_for_repo(
             sync_targets=sync_targets,
             config_id=config_id,
             triggered_by=triggered_by,
+            analytics_db_url=db_url,
         )
         if team_autoimport is not None:
             result_payload["team_autoimport"] = team_autoimport

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -36,6 +36,7 @@ from dev_health_ops.workers.task_utils import (
     _normalize_sync_targets,
     _resolve_env_credentials,
 )
+from dev_health_ops.workers.team_autoimport import run_team_autoimport
 
 # DORA (deployment frequency, lead time, change-failure-rate, MTTR) is computed
 # from synced deployments/CI/incidents in ClickHouse. These targets can be
@@ -439,6 +440,32 @@ def _is_terminal_sync_error(exc: Exception) -> bool:
     return isinstance(exc, (_TerminalSyncError, ValueError))
 
 
+def _run_team_autoimport_for_sync_config(
+    *,
+    provider: str,
+    org_id: str,
+    credentials: dict[str, Any],
+    sync_options: dict[str, Any],
+    sync_targets: list[str],
+    config_id: str,
+    triggered_by: str,
+) -> dict[str, Any] | None:
+    if not sync_options.get("auto_import_teams"):
+        return None
+    return run_team_autoimport(
+        provider=provider,
+        org_id=org_id,
+        credentials=credentials,
+        scope={
+            "mode": "sync_config",
+            "sync_config_id": config_id,
+            "sync_targets": sync_targets,
+            "sync_options": dict(sync_options),
+            "triggered_by": triggered_by,
+        },
+    )
+
+
 @celery_app.task(bind=True, max_retries=3, queue="sync")
 def run_sync_config(
     self,
@@ -839,6 +866,18 @@ def run_sync_config(
 
         completed_at = datetime.now(timezone.utc)
         duration_seconds = int((completed_at - started_at).total_seconds())
+
+        team_autoimport = _run_team_autoimport_for_sync_config(
+            provider=provider,
+            org_id=org_id,
+            credentials=credentials,
+            sync_options=sync_options,
+            sync_targets=sync_targets,
+            config_id=config_id,
+            triggered_by=triggered_by,
+        )
+        if team_autoimport is not None:
+            result_payload["team_autoimport"] = team_autoimport
 
         with get_postgres_session_sync() as session:
             run_record = session.query(JobRun).filter(JobRun.id == run_id).one_or_none()

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -449,6 +449,7 @@ def _run_team_autoimport_for_sync_config(
     sync_targets: list[str],
     config_id: str,
     triggered_by: str,
+    analytics_db_url: str | None,
 ) -> dict[str, Any] | None:
     if not sync_options.get("auto_import_teams"):
         return None
@@ -463,6 +464,7 @@ def _run_team_autoimport_for_sync_config(
             "sync_options": dict(sync_options),
             "triggered_by": triggered_by,
         },
+        analytics_db_url=analytics_db_url,
     )
 
 
@@ -875,6 +877,7 @@ def run_sync_config(
             sync_targets=sync_targets,
             config_id=config_id,
             triggered_by=triggered_by,
+            analytics_db_url=db_url,
         )
         if team_autoimport is not None:
             result_payload["team_autoimport"] = team_autoimport

--- a/src/dev_health_ops/workers/team_autoimport.py
+++ b/src/dev_health_ops/workers/team_autoimport.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import importlib
+import logging
+from collections.abc import Callable, Mapping
+from typing import Any, cast
+
+from dev_health_ops.providers.team_capabilities import team_provider_capabilities
+
+logger = logging.getLogger(__name__)
+
+_IMPORTER_MODULES = {
+    "linear": "dev_health_ops.workers.team_autoimport_linear",
+    "jira": "dev_health_ops.workers.team_autoimport_jira",
+    "github": "dev_health_ops.workers.team_autoimport_github",
+    "gitlab": "dev_health_ops.workers.team_autoimport_gitlab",
+}
+
+TeamAutoimportPopulator = Callable[..., dict[str, Any]]
+
+
+def _zero_summary(*, provider: str, org_id: str, reason: str) -> dict[str, Any]:
+    return {
+        "status": "skipped",
+        "provider": provider,
+        "org_id": org_id,
+        "reason": reason,
+        "projects_imported": 0,
+        "members_imported": 0,
+        "team_memberships_imported": 0,
+        "team_project_ownership_imported": 0,
+        "team_repo_ownership_imported": 0,
+        "work_item_team_attributions_imported": 0,
+    }
+
+
+def _provider_capability(provider: str) -> bool:
+    normalized = provider.strip().lower()
+    return any(
+        capability.provider == normalized and capability.supports_org_drift_discovery
+        for capability in team_provider_capabilities()
+    )
+
+
+def _resolve_populator(provider: str) -> TeamAutoimportPopulator | None:
+    module_name = _IMPORTER_MODULES.get(provider.strip().lower())
+    if module_name is None:
+        return None
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError:
+        return None
+    populate = getattr(module, "populate", None)
+    if not callable(populate):
+        return None
+    return cast(TeamAutoimportPopulator, populate)
+
+
+def run_team_autoimport(
+    *,
+    provider: str,
+    org_id: str,
+    credentials: dict[str, Any],
+    scope: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    normalized_provider = provider.strip().lower()
+    if not _provider_capability(normalized_provider):
+        logger.info(
+            "Skipping team auto-import for provider=%s org_id=%s: provider is not import-capable",
+            normalized_provider,
+            org_id,
+        )
+        return _zero_summary(
+            provider=normalized_provider,
+            org_id=org_id,
+            reason="provider_not_import_capable",
+        )
+
+    populator = _resolve_populator(normalized_provider)
+    if populator is None:
+        logger.info(
+            "Skipping team auto-import for provider=%s org_id=%s: no populator module is available",
+            normalized_provider,
+            org_id,
+        )
+        return _zero_summary(
+            provider=normalized_provider,
+            org_id=org_id,
+            reason="populator_not_available",
+        )
+
+    try:
+        summary = populator(
+            org_id=org_id,
+            credentials=credentials,
+            scope=dict(scope or {}),
+        )
+    except Exception as exc:
+        logger.exception(
+            "Team auto-import failed for provider=%s org_id=%s; sync result remains successful",
+            normalized_provider,
+            org_id,
+        )
+        return {
+            **_zero_summary(
+                provider=normalized_provider,
+                org_id=org_id,
+                reason="populator_error",
+            ),
+            "error": str(exc),
+        }
+
+    if not isinstance(summary, Mapping):
+        logger.warning(
+            "Team auto-import populator for provider=%s org_id=%s returned non-mapping summary",
+            normalized_provider,
+            org_id,
+        )
+        return {
+            **_zero_summary(
+                provider=normalized_provider,
+                org_id=org_id,
+                reason="invalid_populator_summary",
+            ),
+            "summary_type": type(summary).__name__,
+        }
+
+    return {
+        "status": "success",
+        "provider": normalized_provider,
+        "org_id": org_id,
+        **dict(summary),
+    }

--- a/src/dev_health_ops/workers/team_autoimport.py
+++ b/src/dev_health_ops/workers/team_autoimport.py
@@ -62,6 +62,7 @@ def run_team_autoimport(
     org_id: str,
     credentials: dict[str, Any],
     scope: dict[str, Any] | None = None,
+    analytics_db_url: str | None = None,
 ) -> dict[str, Any]:
     normalized_provider = provider.strip().lower()
     if not _provider_capability(normalized_provider):
@@ -90,10 +91,14 @@ def run_team_autoimport(
         )
 
     try:
+        populator_scope = dict(scope or {})
+        if analytics_db_url:
+            populator_scope["analytics_db"] = analytics_db_url
+
         summary = populator(
             org_id=org_id,
             credentials=credentials,
-            scope=dict(scope or {}),
+            scope=populator_scope,
         )
     except Exception as exc:
         logger.exception(

--- a/src/dev_health_ops/workers/team_autoimport_github.py
+++ b/src/dev_health_ops/workers/team_autoimport_github.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from dev_health_ops.api.services.configuration.team_discovery import (
+    TeamDiscoveryService,
+)
+from dev_health_ops.api.services.configuration.team_membership import (
+    TeamMembershipService,
+)
+from dev_health_ops.metrics.schemas import TeamMembershipRecord, TeamRepoOwnershipRecord
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.providers.team_capabilities import team_provider_capabilities
+
+logger = logging.getLogger(__name__)
+
+PROVIDER = "github"
+PROVIDER_ACCESS_PRIORITY = 300
+BASE_SPECIFICITY = 100
+CHILD_SPECIFICITY_STEP = 10
+
+
+def populate(
+    *,
+    org_id: str,
+    credentials: dict[str, Any],
+    scope: dict[str, Any],
+    **_: Any,
+) -> dict[str, Any]:
+    return asyncio.run(
+        _populate_async(org_id=org_id, credentials=credentials, scope=scope)
+    )
+
+
+async def _populate_async(
+    *, org_id: str, credentials: dict[str, Any], scope: dict[str, Any]
+) -> dict[str, Any]:
+    if not _provider_capable():
+        return _zero_summary(org_id=org_id, reason="provider_not_import_capable")
+
+    token = _first_string(credentials, "token", "access_token", "github_token")
+    org_name = _github_org(credentials=credentials, scope=scope)
+    if not token or not org_name:
+        return _zero_summary(org_id=org_id, reason="missing_github_credentials_or_org")
+
+    discovery = TeamDiscoveryService(session=None, org_id=org_id)
+    try:
+        teams = await discovery.discover_github(token=token, org_name=org_name)
+    except Exception as exc:
+        logger.info(
+            "Skipping GitHub team auto-import for org_id=%s org=%s: discovery failed: %s",
+            org_id,
+            org_name,
+            exc,
+        )
+        return _zero_summary(org_id=org_id, reason="provider_discovery_skipped")
+
+    if not teams:
+        return _zero_summary(org_id=org_id, reason="no_provider_teams")
+
+    now = datetime.now(timezone.utc)
+    team_rows = _team_rows(org_id=org_id, teams=teams, now=now)
+    repo_rows = _repo_ownership_rows(org_id=org_id, teams=teams, now=now)
+    membership_rows = await _membership_rows(
+        org_id=org_id,
+        token=token,
+        org_name=org_name,
+        teams=teams,
+        now=now,
+    )
+
+    sink = _sink(scope)
+    await sink.insert_teams(team_rows)
+    sink.write_team_repo_ownership(repo_rows)
+    sink.write_team_memberships(membership_rows)
+
+    return {
+        "teams_imported": len(team_rows),
+        "projects_imported": 0,
+        "members_imported": len({row.member_id for row in membership_rows}),
+        "team_memberships_imported": len(membership_rows),
+        "team_project_ownership_imported": 0,
+        "team_repo_ownership_imported": len(repo_rows),
+        "work_item_team_attributions_imported": 0,
+    }
+
+
+def _provider_capable() -> bool:
+    return any(
+        capability.provider == PROVIDER and capability.supports_org_drift_discovery
+        for capability in team_provider_capabilities()
+    )
+
+
+def _zero_summary(*, org_id: str, reason: str) -> dict[str, Any]:
+    return {
+        "status": "skipped",
+        "provider": PROVIDER,
+        "org_id": org_id,
+        "reason": reason,
+        "teams_imported": 0,
+        "projects_imported": 0,
+        "members_imported": 0,
+        "team_memberships_imported": 0,
+        "team_project_ownership_imported": 0,
+        "team_repo_ownership_imported": 0,
+        "work_item_team_attributions_imported": 0,
+    }
+
+
+def _github_org(
+    *, credentials: Mapping[str, Any], scope: Mapping[str, Any]
+) -> str | None:
+    sync_options = _mapping(scope.get("sync_options"))
+    return _first_string(
+        credentials,
+        "org",
+        "organization",
+        "org_name",
+        "owner",
+    ) or _first_string(sync_options, "org", "organization", "org_name", "owner")
+
+
+def _team_rows(
+    *, org_id: str, teams: Iterable[Any], now: datetime
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for team in teams:
+        associations = _mapping(getattr(team, "associations", None))
+        team_id = _team_id(str(getattr(team, "provider_team_id")))
+        rows.append(
+            {
+                "id": team_id,
+                "name": str(getattr(team, "name", team_id)),
+                "description": getattr(team, "description", None),
+                "members": [],
+                "project_keys": [],
+                "repo_patterns": _strings(associations.get("repo_patterns")),
+                "is_active": True,
+                "updated_at": now,
+                "org_id": org_id,
+                "provider": PROVIDER,
+                "native_team_key": str(getattr(team, "provider_team_id")),
+                "parent_team_id": _parent_team_id(associations),
+            }
+        )
+    return rows
+
+
+def _repo_ownership_rows(
+    *, org_id: str, teams: Iterable[Any], now: datetime
+) -> list[TeamRepoOwnershipRecord]:
+    parent_by_team = _parent_by_team(teams)
+    rows: list[TeamRepoOwnershipRecord] = []
+    seen: set[tuple[str, str]] = set()
+    for team in teams:
+        associations = _mapping(getattr(team, "associations", None))
+        team_id = _team_id(str(getattr(team, "provider_team_id")))
+        specificity = BASE_SPECIFICITY + (
+            _depth(team_id, parent_by_team) * CHILD_SPECIFICITY_STEP
+        )
+        for repo_full_name in _strings(associations.get("repo_patterns")):
+            key = (team_id, repo_full_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append(
+                TeamRepoOwnershipRecord(
+                    org_id=org_id,
+                    provider=PROVIDER,
+                    team_id=team_id,
+                    repo_full_name=repo_full_name,
+                    match_type="exact",
+                    source="provider_access",
+                    is_primary=0,
+                    specificity=specificity,
+                    priority=PROVIDER_ACCESS_PRIORITY,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+    return rows
+
+
+async def _membership_rows(
+    *,
+    org_id: str,
+    token: str,
+    org_name: str,
+    teams: Iterable[Any],
+    now: datetime,
+) -> list[TeamMembershipRecord]:
+    service = TeamMembershipService(session=cast(Any, None), org_id=org_id)
+    rows: list[TeamMembershipRecord] = []
+    seen: set[tuple[str, str]] = set()
+    for team in teams:
+        team_slug = str(getattr(team, "provider_team_id"))
+        team_id = _team_id(team_slug)
+        try:
+            members = await service.discover_members_github(
+                token=token,
+                org_name=org_name,
+                team_slug=team_slug,
+            )
+        except Exception as exc:
+            logger.info(
+                "Skipping GitHub membership import for org_id=%s team=%s: %s",
+                org_id,
+                team_slug,
+                exc,
+            )
+            continue
+        for member in members:
+            raw_identity = str(getattr(member, "provider_identity", "")).strip()
+            if not raw_identity:
+                continue
+            member_id = f"gh:{raw_identity}"
+            key = (team_id, member_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append(
+                TeamMembershipRecord(
+                    org_id=org_id,
+                    provider=PROVIDER,
+                    team_id=team_id,
+                    member_id=member_id,
+                    raw_provider_user_id=raw_identity,
+                    raw_email=getattr(member, "email", None),
+                    source="provider_access",
+                    is_primary=0,
+                    specificity=BASE_SPECIFICITY,
+                    priority=PROVIDER_ACCESS_PRIORITY,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+    return rows
+
+
+def _sink(scope: Mapping[str, Any]) -> ClickHouseMetricsSink:
+    dsn = str(scope.get("analytics_db") or os.getenv("CLICKHOUSE_URI") or "")
+    if not dsn:
+        raise ValueError("CLICKHOUSE_URI is required for GitHub team auto-import")
+    return ClickHouseMetricsSink(dsn=dsn)
+
+
+def _team_id(provider_team_id: str) -> str:
+    return f"gh:{provider_team_id.removeprefix('gh:')}"
+
+
+def _parent_team_id(associations: Mapping[str, Any]) -> str | None:
+    parent = _first_string(associations, "parent_team_id", "parent_provider_team_id")
+    if parent is None:
+        return None
+    return _team_id(parent)
+
+
+def _parent_by_team(teams: Iterable[Any]) -> dict[str, str]:
+    parents: dict[str, str] = {}
+    for team in teams:
+        associations = _mapping(getattr(team, "associations", None))
+        parent = _parent_team_id(associations)
+        if parent:
+            parents[_team_id(str(getattr(team, "provider_team_id")))] = parent
+    return parents
+
+
+def _depth(team_id: str, parent_by_team: Mapping[str, str]) -> int:
+    depth = 0
+    current = team_id
+    visited: set[str] = set()
+    while current in parent_by_team and current not in visited:
+        visited.add(current)
+        current = parent_by_team[current]
+        depth += 1
+    return depth
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if not isinstance(value, Iterable):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def _first_string(mapping: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None

--- a/src/dev_health_ops/workers/team_autoimport_gitlab.py
+++ b/src/dev_health_ops/workers/team_autoimport_gitlab.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from dev_health_ops.api.services.configuration.team_discovery import (
+    TeamDiscoveryService,
+)
+from dev_health_ops.api.services.configuration.team_membership import (
+    TeamMembershipService,
+)
+from dev_health_ops.metrics.schemas import (
+    TeamMembershipRecord,
+    TeamProjectOwnershipRecord,
+)
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.providers.team_capabilities import team_provider_capabilities
+
+logger = logging.getLogger(__name__)
+
+PROVIDER = "gitlab"
+PROVIDER_ACCESS_PRIORITY = 300
+BASE_SPECIFICITY = 100
+CHILD_SPECIFICITY_STEP = 10
+DEFAULT_GITLAB_URL = "https://gitlab.com"
+
+
+def populate(
+    *,
+    org_id: str,
+    credentials: dict[str, Any],
+    scope: dict[str, Any],
+    **_: Any,
+) -> dict[str, Any]:
+    return asyncio.run(
+        _populate_async(org_id=org_id, credentials=credentials, scope=scope)
+    )
+
+
+async def _populate_async(
+    *, org_id: str, credentials: dict[str, Any], scope: dict[str, Any]
+) -> dict[str, Any]:
+    if not _provider_capable():
+        return _zero_summary(org_id=org_id, reason="provider_not_import_capable")
+
+    token = _first_string(credentials, "token", "access_token", "private_token")
+    group_path = _gitlab_group(credentials=credentials, scope=scope)
+    url = (
+        _first_string(credentials, "url", "base_url", "gitlab_url")
+        or DEFAULT_GITLAB_URL
+    )
+    if not token or not group_path:
+        return _zero_summary(
+            org_id=org_id, reason="missing_gitlab_credentials_or_group"
+        )
+
+    discovery = TeamDiscoveryService(session=None, org_id=org_id)
+    try:
+        result = await discovery.discover_gitlab(
+            token=token,
+            group_path=group_path,
+            url=url,
+        )
+    except Exception as exc:
+        logger.info(
+            "Skipping GitLab team auto-import for org_id=%s group=%s: discovery failed: %s",
+            org_id,
+            group_path,
+            exc,
+        )
+        return _zero_summary(org_id=org_id, reason="provider_discovery_skipped")
+
+    teams = result.teams
+    if not teams:
+        return _zero_summary(org_id=org_id, reason="no_provider_teams")
+
+    now = datetime.now(timezone.utc)
+    team_rows = _team_rows(org_id=org_id, teams=teams, now=now)
+    project_rows = _project_ownership_rows(org_id=org_id, teams=teams, now=now)
+    membership_rows = await _membership_rows(
+        org_id=org_id,
+        token=token,
+        url=url,
+        teams=teams,
+        now=now,
+    )
+
+    sink = _sink(scope)
+    await sink.insert_teams(team_rows)
+    sink.write_team_project_ownership(project_rows)
+    sink.write_team_memberships(membership_rows)
+
+    summary: dict[str, Any] = {
+        "teams_imported": len(team_rows),
+        "projects_imported": len({row.project_id for row in project_rows}),
+        "members_imported": len({row.member_id for row in membership_rows}),
+        "team_memberships_imported": len(membership_rows),
+        "team_project_ownership_imported": len(project_rows),
+        "team_repo_ownership_imported": 0,
+        "work_item_team_attributions_imported": 0,
+    }
+    if result.truncated:
+        summary["warnings"] = list(result.warnings)
+    return summary
+
+
+def _provider_capable() -> bool:
+    return any(
+        capability.provider == PROVIDER and capability.supports_org_drift_discovery
+        for capability in team_provider_capabilities()
+    )
+
+
+def _zero_summary(*, org_id: str, reason: str) -> dict[str, Any]:
+    return {
+        "status": "skipped",
+        "provider": PROVIDER,
+        "org_id": org_id,
+        "reason": reason,
+        "teams_imported": 0,
+        "projects_imported": 0,
+        "members_imported": 0,
+        "team_memberships_imported": 0,
+        "team_project_ownership_imported": 0,
+        "team_repo_ownership_imported": 0,
+        "work_item_team_attributions_imported": 0,
+    }
+
+
+def _gitlab_group(
+    *, credentials: Mapping[str, Any], scope: Mapping[str, Any]
+) -> str | None:
+    sync_options = _mapping(scope.get("sync_options"))
+    return _first_string(
+        credentials,
+        "group_path",
+        "group",
+        "owner",
+    ) or _first_string(sync_options, "group_path", "group", "owner")
+
+
+def _team_rows(
+    *, org_id: str, teams: Iterable[Any], now: datetime
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for team in teams:
+        associations = _mapping(getattr(team, "associations", None))
+        provider_team_id = str(getattr(team, "provider_team_id"))
+        team_id = _team_id(provider_team_id)
+        rows.append(
+            {
+                "id": team_id,
+                "name": str(getattr(team, "name", team_id)),
+                "description": getattr(team, "description", None),
+                "members": [],
+                "project_keys": _strings(associations.get("repo_patterns")),
+                "repo_patterns": [],
+                "is_active": True,
+                "updated_at": now,
+                "org_id": org_id,
+                "provider": PROVIDER,
+                "native_team_key": provider_team_id,
+                "parent_team_id": _parent_team_id(provider_team_id, associations),
+            }
+        )
+    return rows
+
+
+def _project_ownership_rows(
+    *, org_id: str, teams: Iterable[Any], now: datetime
+) -> list[TeamProjectOwnershipRecord]:
+    parent_by_team = _parent_by_team(teams)
+    rows: list[TeamProjectOwnershipRecord] = []
+    seen: set[tuple[str, str]] = set()
+    for team in teams:
+        associations = _mapping(getattr(team, "associations", None))
+        provider_team_id = str(getattr(team, "provider_team_id"))
+        team_id = _team_id(provider_team_id)
+        specificity = BASE_SPECIFICITY + (
+            _depth(team_id, parent_by_team) * CHILD_SPECIFICITY_STEP
+        )
+        for project_path in _strings(associations.get("repo_patterns")):
+            key = (team_id, project_path)
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append(
+                TeamProjectOwnershipRecord(
+                    org_id=org_id,
+                    provider=PROVIDER,
+                    team_id=team_id,
+                    project_id=project_path,
+                    project_key=project_path,
+                    source="provider_access",
+                    is_primary=0,
+                    specificity=specificity,
+                    priority=PROVIDER_ACCESS_PRIORITY,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+    return rows
+
+
+async def _membership_rows(
+    *,
+    org_id: str,
+    token: str,
+    url: str,
+    teams: Iterable[Any],
+    now: datetime,
+) -> list[TeamMembershipRecord]:
+    service = TeamMembershipService(session=cast(Any, None), org_id=org_id)
+    rows: list[TeamMembershipRecord] = []
+    seen: set[tuple[str, str]] = set()
+    for team in teams:
+        group_path = str(getattr(team, "provider_team_id"))
+        team_id = _team_id(group_path)
+        try:
+            members = await service.discover_members_gitlab(
+                token=token,
+                group_path=group_path,
+                url=url,
+            )
+        except Exception as exc:
+            logger.info(
+                "Skipping GitLab membership import for org_id=%s group=%s: %s",
+                org_id,
+                group_path,
+                exc,
+            )
+            continue
+        for member in members:
+            raw_identity = str(getattr(member, "provider_identity", "")).strip()
+            if not raw_identity:
+                continue
+            member_id = f"gl:{raw_identity}"
+            key = (team_id, member_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append(
+                TeamMembershipRecord(
+                    org_id=org_id,
+                    provider=PROVIDER,
+                    team_id=team_id,
+                    member_id=member_id,
+                    raw_provider_user_id=raw_identity,
+                    raw_email=getattr(member, "email", None),
+                    source="provider_access",
+                    is_primary=0,
+                    specificity=BASE_SPECIFICITY,
+                    priority=PROVIDER_ACCESS_PRIORITY,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+    return rows
+
+
+def _sink(scope: Mapping[str, Any]) -> ClickHouseMetricsSink:
+    dsn = str(scope.get("analytics_db") or os.getenv("CLICKHOUSE_URI") or "")
+    if not dsn:
+        raise ValueError("CLICKHOUSE_URI is required for GitLab team auto-import")
+    return ClickHouseMetricsSink(dsn=dsn)
+
+
+def _team_id(provider_team_id: str) -> str:
+    return f"gl:{provider_team_id.removeprefix('gl:')}"
+
+
+def _parent_team_id(
+    provider_team_id: str, associations: Mapping[str, Any]
+) -> str | None:
+    explicit_parent = _first_string(
+        associations, "parent_team_id", "parent_provider_team_id"
+    )
+    if explicit_parent:
+        return _team_id(explicit_parent)
+    if "/" not in provider_team_id:
+        return None
+    return _team_id(provider_team_id.rsplit("/", 1)[0])
+
+
+def _parent_by_team(teams: Iterable[Any]) -> dict[str, str]:
+    parents: dict[str, str] = {}
+    team_ids = {_team_id(str(getattr(team, "provider_team_id"))) for team in teams}
+    for team in teams:
+        provider_team_id = str(getattr(team, "provider_team_id"))
+        associations = _mapping(getattr(team, "associations", None))
+        team_id = _team_id(provider_team_id)
+        parent = _parent_team_id(provider_team_id, associations)
+        if parent and parent in team_ids:
+            parents[team_id] = parent
+    return parents
+
+
+def _depth(team_id: str, parent_by_team: Mapping[str, str]) -> int:
+    depth = 0
+    current = team_id
+    visited: set[str] = set()
+    while current in parent_by_team and current not in visited:
+        visited.add(current)
+        current = parent_by_team[current]
+        depth += 1
+    return depth
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if not isinstance(value, Iterable):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def _first_string(mapping: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None

--- a/src/dev_health_ops/workers/team_autoimport_jira.py
+++ b/src/dev_health_ops/workers/team_autoimport_jira.py
@@ -66,11 +66,13 @@ def _run(coro: Coroutine[Any, Any, _T]) -> _T:
     return cast(_T, result)
 
 
-def _sink_from_kwargs(kwargs: dict[str, Any]) -> tuple[_DimensionSink, bool]:
+def _sink_from_kwargs(
+    scope: dict[str, Any], kwargs: dict[str, Any]
+) -> tuple[_DimensionSink, bool]:
     injected = kwargs.get("sink")
     if injected is not None:
         return cast(_DimensionSink, injected), False
-    dsn = str(kwargs.get("clickhouse_uri") or os.getenv("CLICKHOUSE_URI") or "")
+    dsn = str(scope.get("analytics_db") or os.getenv("CLICKHOUSE_URI") or "")
     if not dsn:
         raise ValueError("ClickHouse DSN is required for Jira team auto-import")
     return cast(_DimensionSink, ClickHouseMetricsSink(dsn=dsn)), True
@@ -267,7 +269,7 @@ def populate(
                 )
             )
 
-    sink, should_close = _sink_from_kwargs(kwargs)
+    sink, should_close = _sink_from_kwargs(scope, kwargs)
     try:
         for link in _load_jira_legacy_links(sink, org_id=org_id):
             project_key = str(link.get("project_key") or "")

--- a/src/dev_health_ops/workers/team_autoimport_jira.py
+++ b/src/dev_health_ops/workers/team_autoimport_jira.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import Coroutine, Sequence
+from datetime import datetime, timezone
+from threading import Thread
+from typing import Any, Protocol, TypeVar, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.services.configuration.team_discovery import (
+    TeamDiscoveryService,
+)
+from dev_health_ops.api.services.configuration.team_membership import (
+    TeamMembershipService,
+)
+from dev_health_ops.credentials.resolver import jira_credentials_from_mapping
+from dev_health_ops.metrics.schemas import (
+    MemberRecord,
+    ProjectRecord,
+    TeamMembershipRecord,
+    TeamProjectOwnershipRecord,
+)
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+_T = TypeVar("_T")
+
+
+class _DimensionSink(Protocol):
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]: ...
+    def write_projects(self, rows: Sequence[ProjectRecord]) -> None: ...
+    def write_members(self, rows: Sequence[MemberRecord]) -> None: ...
+    def write_team_memberships(self, rows: Sequence[TeamMembershipRecord]) -> None: ...
+    def write_team_project_ownership(
+        self, rows: Sequence[TeamProjectOwnershipRecord]
+    ) -> None: ...
+    async def insert_teams(self, teams: list[dict[str, Any]]) -> None: ...
+    def close(self) -> None: ...
+
+
+def _run(coro: Coroutine[Any, Any, _T]) -> _T:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    result: _T | None = None
+    error: BaseException | None = None
+
+    def _target() -> None:
+        nonlocal result, error
+        try:
+            result = asyncio.run(coro)
+        except BaseException as exc:
+            error = exc
+
+    thread = Thread(target=_target)
+    thread.start()
+    thread.join()
+    if error is not None:
+        raise error
+    return cast(_T, result)
+
+
+def _sink_from_kwargs(kwargs: dict[str, Any]) -> tuple[_DimensionSink, bool]:
+    injected = kwargs.get("sink")
+    if injected is not None:
+        return cast(_DimensionSink, injected), False
+    dsn = str(kwargs.get("clickhouse_uri") or os.getenv("CLICKHOUSE_URI") or "")
+    if not dsn:
+        raise ValueError("ClickHouse DSN is required for Jira team auto-import")
+    return cast(_DimensionSink, ClickHouseMetricsSink(dsn=dsn)), True
+
+
+def _project_id(org_id: str, provider: str, project_key: str) -> str:
+    return f"{org_id}:{provider}:{project_key}"
+
+
+def _member_id(provider: str, provider_identity: str) -> str:
+    return f"{provider}:{provider_identity.strip().lower()}"
+
+
+def _provider_identities(provider: str, provider_identity: str) -> str:
+    return json.dumps({provider: [provider_identity]}, sort_keys=True)
+
+
+def _dedupe_projects(rows: list[ProjectRecord]) -> list[ProjectRecord]:
+    return list({(row.org_id, row.provider, row.id): row for row in rows}.values())
+
+
+def _dedupe_members(rows: list[MemberRecord]) -> list[MemberRecord]:
+    return list({(row.org_id, row.member_id): row for row in rows}.values())
+
+
+def _dedupe_memberships(
+    rows: list[TeamMembershipRecord],
+) -> list[TeamMembershipRecord]:
+    return list(
+        {
+            (row.org_id, row.provider, row.team_id, row.member_id, row.source): row
+            for row in rows
+        }.values()
+    )
+
+
+def _dedupe_ownership(
+    rows: list[TeamProjectOwnershipRecord],
+) -> list[TeamProjectOwnershipRecord]:
+    return list(
+        {
+            (row.org_id, row.provider, row.project_id, row.team_id, row.source): row
+            for row in rows
+        }.values()
+    )
+
+
+def _load_jira_legacy_links(
+    sink: _DimensionSink,
+    *,
+    org_id: str,
+) -> list[dict[str, Any]]:
+    try:
+        return sink.query_dicts(
+            """
+            SELECT project_key, ops_team_id, project_name, ops_team_name, updated_at
+            FROM jira_project_ops_team_links FINAL
+            WHERE org_id = {org_id:String}
+            """,
+            {"org_id": org_id},
+        )
+    except Exception:
+        return []
+
+
+def populate(
+    *,
+    org_id: str,
+    credentials: dict[str, Any],
+    scope: dict[str, Any],
+    **kwargs: Any,
+) -> dict[str, Any]:
+    jira_credentials = jira_credentials_from_mapping(credentials)
+    if jira_credentials is None:
+        return {
+            "status": "skipped",
+            "reason": "missing_jira_credentials",
+            "projects_imported": 0,
+            "members_imported": 0,
+            "team_memberships_imported": 0,
+            "team_project_ownership_imported": 0,
+        }
+
+    now = datetime.now(timezone.utc)
+    discovery = TeamDiscoveryService(None, org_id)
+    membership = TeamMembershipService(cast(AsyncSession, None), org_id)
+    teams = _run(
+        discovery.discover_jira(
+            email=jira_credentials.email,
+            api_token=jira_credentials.api_token,
+            url=jira_credentials.base_url,
+        )
+    )
+
+    team_rows: list[dict[str, Any]] = []
+    project_rows: list[ProjectRecord] = []
+    member_rows: list[MemberRecord] = []
+    membership_rows: list[TeamMembershipRecord] = []
+    ownership_rows: list[TeamProjectOwnershipRecord] = []
+
+    for team in teams:
+        team_id = str(team.provider_team_id)
+        associations = dict(team.associations or {})
+        project_keys = [str(key) for key in associations.get("project_keys", []) if key]
+        if not project_keys:
+            project_keys = [team_id]
+
+        team_rows.append(
+            {
+                "id": team_id,
+                "name": team.name,
+                "description": team.description,
+                "members": [],
+                "project_keys": project_keys,
+                "repo_patterns": [],
+                "is_active": True,
+                "updated_at": now,
+                "org_id": org_id,
+                "provider": "jira",
+                "native_team_key": team_id,
+                "parent_team_id": None,
+            }
+        )
+
+        for project_key in project_keys:
+            project_rows.append(
+                ProjectRecord(
+                    id=_project_id(org_id, "jira", project_key),
+                    org_id=org_id,
+                    provider="jira",
+                    project_key=project_key,
+                    name=team.name,
+                    is_active=1,
+                    updated_at=now,
+                    last_synced=now,
+                )
+            )
+            ownership_rows.append(
+                TeamProjectOwnershipRecord(
+                    org_id=org_id,
+                    provider="jira",
+                    team_id=team_id,
+                    project_id=_project_id(org_id, "jira", project_key),
+                    project_key=project_key,
+                    source="native",
+                    is_primary=1,
+                    specificity=100,
+                    priority=10,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+
+        discovered_members = _run(
+            membership.discover_members_jira_bulk(
+                email=jira_credentials.email,
+                api_token=jira_credentials.api_token,
+                url=jira_credentials.base_url,
+                project_keys=project_keys,
+            )
+        )
+        team_rows[-1]["members"] = [
+            member.provider_identity for member in discovered_members
+        ]
+        for member in discovered_members:
+            member_id = _member_id("jira", member.provider_identity)
+            member_rows.append(
+                MemberRecord(
+                    org_id=org_id,
+                    member_id=member_id,
+                    name=member.display_name or member.provider_identity,
+                    email=member.email,
+                    provider_identities=_provider_identities(
+                        "jira", member.provider_identity
+                    ),
+                    is_active=1,
+                    updated_at=now,
+                )
+            )
+            membership_rows.append(
+                TeamMembershipRecord(
+                    org_id=org_id,
+                    provider="jira",
+                    team_id=team_id,
+                    member_id=member_id,
+                    raw_provider_user_id=member.provider_identity,
+                    raw_email=member.email,
+                    source="native",
+                    is_primary=1 if member.role == "lead" else 0,
+                    specificity=100,
+                    priority=10,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+
+    sink, should_close = _sink_from_kwargs(kwargs)
+    try:
+        for link in _load_jira_legacy_links(sink, org_id=org_id):
+            project_key = str(link.get("project_key") or "")
+            ops_team_id = str(link.get("ops_team_id") or "")
+            if not project_key or not ops_team_id:
+                continue
+            project_id = _project_id(org_id, "jira", project_key)
+            if not any(row.id == project_id for row in project_rows):
+                project_rows.append(
+                    ProjectRecord(
+                        id=project_id,
+                        org_id=org_id,
+                        provider="jira",
+                        project_key=project_key,
+                        name=str(link.get("project_name") or project_key),
+                        is_active=1,
+                        updated_at=now,
+                        last_synced=now,
+                    )
+                )
+            ownership_rows.append(
+                TeamProjectOwnershipRecord(
+                    org_id=org_id,
+                    provider="jira",
+                    team_id=ops_team_id,
+                    project_id=project_id,
+                    project_key=project_key,
+                    source="jira_legacy",
+                    is_primary=1,
+                    specificity=90,
+                    priority=20,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+
+        _run(sink.insert_teams(team_rows))
+        projects = _dedupe_projects(project_rows)
+        members = _dedupe_members(member_rows)
+        memberships = _dedupe_memberships(membership_rows)
+        ownership = _dedupe_ownership(ownership_rows)
+        sink.write_projects(projects)
+        sink.write_members(members)
+        sink.write_team_memberships(memberships)
+        sink.write_team_project_ownership(ownership)
+    finally:
+        if should_close:
+            sink.close()
+
+    jira_legacy_count = sum(1 for row in ownership if row.source == "jira_legacy")
+    return {
+        "mode": scope.get("mode"),
+        "teams_imported": len(team_rows),
+        "projects_imported": len(projects),
+        "members_imported": len(members),
+        "team_memberships_imported": len(memberships),
+        "team_project_ownership_imported": len(ownership),
+        "jira_legacy_project_ownership_imported": jira_legacy_count,
+        "team_repo_ownership_imported": 0,
+        "work_item_team_attributions_imported": 0,
+    }

--- a/src/dev_health_ops/workers/team_autoimport_linear.py
+++ b/src/dev_health_ops/workers/team_autoimport_linear.py
@@ -63,11 +63,13 @@ def _run(coro: Coroutine[Any, Any, _T]) -> _T:
     return cast(_T, result)
 
 
-def _sink_from_kwargs(kwargs: dict[str, Any]) -> tuple[_DimensionSink, bool]:
+def _sink_from_kwargs(
+    scope: dict[str, Any], kwargs: dict[str, Any]
+) -> tuple[_DimensionSink, bool]:
     injected = kwargs.get("sink")
     if injected is not None:
         return cast(_DimensionSink, injected), False
-    dsn = str(kwargs.get("clickhouse_uri") or os.getenv("CLICKHOUSE_URI") or "")
+    dsn = str(scope.get("analytics_db") or os.getenv("CLICKHOUSE_URI") or "")
     if not dsn:
         raise ValueError("ClickHouse DSN is required for Linear team auto-import")
     return cast(_DimensionSink, ClickHouseMetricsSink(dsn=dsn)), True
@@ -242,7 +244,7 @@ def populate(
                 )
             )
 
-    sink, should_close = _sink_from_kwargs(kwargs)
+    sink, should_close = _sink_from_kwargs(scope, kwargs)
     try:
         _run(sink.insert_teams(team_rows))
         projects = _dedupe_projects(project_rows)

--- a/src/dev_health_ops/workers/team_autoimport_linear.py
+++ b/src/dev_health_ops/workers/team_autoimport_linear.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import Coroutine, Sequence
+from datetime import datetime, timezone
+from threading import Thread
+from typing import Any, Protocol, TypeVar, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.services.configuration.team_discovery import (
+    TeamDiscoveryService,
+)
+from dev_health_ops.api.services.configuration.team_membership import (
+    TeamMembershipService,
+)
+from dev_health_ops.credentials.resolver import linear_credentials_from_mapping
+from dev_health_ops.metrics.schemas import (
+    MemberRecord,
+    ProjectRecord,
+    TeamMembershipRecord,
+    TeamProjectOwnershipRecord,
+)
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+_T = TypeVar("_T")
+
+
+class _DimensionSink(Protocol):
+    def write_projects(self, rows: Sequence[ProjectRecord]) -> None: ...
+    def write_members(self, rows: Sequence[MemberRecord]) -> None: ...
+    def write_team_memberships(self, rows: Sequence[TeamMembershipRecord]) -> None: ...
+    def write_team_project_ownership(
+        self, rows: Sequence[TeamProjectOwnershipRecord]
+    ) -> None: ...
+    async def insert_teams(self, teams: list[dict[str, Any]]) -> None: ...
+    def close(self) -> None: ...
+
+
+def _run(coro: Coroutine[Any, Any, _T]) -> _T:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    result: _T | None = None
+    error: BaseException | None = None
+
+    def _target() -> None:
+        nonlocal result, error
+        try:
+            result = asyncio.run(coro)
+        except BaseException as exc:
+            error = exc
+
+    thread = Thread(target=_target)
+    thread.start()
+    thread.join()
+    if error is not None:
+        raise error
+    return cast(_T, result)
+
+
+def _sink_from_kwargs(kwargs: dict[str, Any]) -> tuple[_DimensionSink, bool]:
+    injected = kwargs.get("sink")
+    if injected is not None:
+        return cast(_DimensionSink, injected), False
+    dsn = str(kwargs.get("clickhouse_uri") or os.getenv("CLICKHOUSE_URI") or "")
+    if not dsn:
+        raise ValueError("ClickHouse DSN is required for Linear team auto-import")
+    return cast(_DimensionSink, ClickHouseMetricsSink(dsn=dsn)), True
+
+
+def _team_id(team: Any) -> str:
+    return str(team.provider_team_id)
+
+
+def _project_id(org_id: str, provider: str, project_key: str) -> str:
+    return f"{org_id}:{provider}:{project_key}"
+
+
+def _member_id(provider: str, provider_identity: str) -> str:
+    return f"{provider}:{provider_identity.strip().lower()}"
+
+
+def _provider_identities(provider: str, provider_identity: str) -> str:
+    return json.dumps({provider: [provider_identity]}, sort_keys=True)
+
+
+def _dedupe_projects(rows: list[ProjectRecord]) -> list[ProjectRecord]:
+    return list({(row.org_id, row.provider, row.id): row for row in rows}.values())
+
+
+def _dedupe_members(rows: list[MemberRecord]) -> list[MemberRecord]:
+    return list({(row.org_id, row.member_id): row for row in rows}.values())
+
+
+def _dedupe_memberships(
+    rows: list[TeamMembershipRecord],
+) -> list[TeamMembershipRecord]:
+    return list(
+        {
+            (row.org_id, row.provider, row.team_id, row.member_id, row.source): row
+            for row in rows
+        }.values()
+    )
+
+
+def _dedupe_ownership(
+    rows: list[TeamProjectOwnershipRecord],
+) -> list[TeamProjectOwnershipRecord]:
+    return list(
+        {
+            (row.org_id, row.provider, row.project_id, row.team_id, row.source): row
+            for row in rows
+        }.values()
+    )
+
+
+def populate(
+    *,
+    org_id: str,
+    credentials: dict[str, Any],
+    scope: dict[str, Any],
+    **kwargs: Any,
+) -> dict[str, Any]:
+    linear_credentials = linear_credentials_from_mapping(credentials)
+    if linear_credentials is None:
+        return {
+            "status": "skipped",
+            "reason": "missing_linear_credentials",
+            "projects_imported": 0,
+            "members_imported": 0,
+            "team_memberships_imported": 0,
+            "team_project_ownership_imported": 0,
+        }
+
+    now = datetime.now(timezone.utc)
+    discovery = TeamDiscoveryService(None, org_id)
+    membership = TeamMembershipService(cast(AsyncSession, None), org_id)
+    teams = _run(discovery.discover_linear(api_key=linear_credentials.api_key))
+
+    team_rows: list[dict[str, Any]] = []
+    project_rows: list[ProjectRecord] = []
+    member_rows: list[MemberRecord] = []
+    membership_rows: list[TeamMembershipRecord] = []
+    ownership_rows: list[TeamProjectOwnershipRecord] = []
+
+    for team in teams:
+        team_id = _team_id(team)
+        associations = dict(team.associations or {})
+        project_keys = [str(key) for key in associations.get("project_keys", []) if key]
+        if not project_keys:
+            project_keys = [team_id]
+
+        team_rows.append(
+            {
+                "id": team_id,
+                "name": team.name,
+                "description": team.description,
+                "members": [],
+                "project_keys": project_keys,
+                "repo_patterns": [],
+                "is_active": True,
+                "updated_at": now,
+                "org_id": org_id,
+                "provider": "linear",
+                "native_team_key": team_id,
+                "parent_team_id": None,
+            }
+        )
+
+        for project_key in project_keys:
+            project_rows.append(
+                ProjectRecord(
+                    id=_project_id(org_id, "linear", project_key),
+                    org_id=org_id,
+                    provider="linear",
+                    project_key=project_key,
+                    name=team.name,
+                    is_active=1,
+                    updated_at=now,
+                    last_synced=now,
+                )
+            )
+            ownership_rows.append(
+                TeamProjectOwnershipRecord(
+                    org_id=org_id,
+                    provider="linear",
+                    team_id=team_id,
+                    project_id=_project_id(org_id, "linear", project_key),
+                    project_key=project_key,
+                    source="native",
+                    is_primary=1,
+                    specificity=100,
+                    priority=10,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+
+        discovered_members = _run(
+            membership.discover_members_linear(
+                api_key=linear_credentials.api_key,
+                team_key=team_id,
+            )
+        )
+        team_rows[-1]["members"] = [
+            member.provider_identity for member in discovered_members
+        ]
+        for member in discovered_members:
+            member_id = _member_id("linear", member.provider_identity)
+            member_rows.append(
+                MemberRecord(
+                    org_id=org_id,
+                    member_id=member_id,
+                    name=member.display_name or member.provider_identity,
+                    email=member.email,
+                    provider_identities=_provider_identities(
+                        "linear", member.provider_identity
+                    ),
+                    is_active=1,
+                    updated_at=now,
+                )
+            )
+            membership_rows.append(
+                TeamMembershipRecord(
+                    org_id=org_id,
+                    provider="linear",
+                    team_id=team_id,
+                    member_id=member_id,
+                    raw_provider_user_id=member.provider_identity,
+                    raw_email=member.email,
+                    source="native",
+                    is_primary=1,
+                    specificity=100,
+                    priority=10,
+                    valid_from=now,
+                    updated_at=now,
+                )
+            )
+
+    sink, should_close = _sink_from_kwargs(kwargs)
+    try:
+        _run(sink.insert_teams(team_rows))
+        projects = _dedupe_projects(project_rows)
+        members = _dedupe_members(member_rows)
+        memberships = _dedupe_memberships(membership_rows)
+        ownership = _dedupe_ownership(ownership_rows)
+        sink.write_projects(projects)
+        sink.write_members(members)
+        sink.write_team_memberships(memberships)
+        sink.write_team_project_ownership(ownership)
+    finally:
+        if should_close:
+            sink.close()
+
+    return {
+        "mode": scope.get("mode"),
+        "teams_imported": len(team_rows),
+        "projects_imported": len(projects),
+        "members_imported": len(members),
+        "team_memberships_imported": len(memberships),
+        "team_project_ownership_imported": len(ownership),
+        "team_repo_ownership_imported": 0,
+        "work_item_team_attributions_imported": 0,
+    }

--- a/tests/test_distributed_rate_limit.py
+++ b/tests/test_distributed_rate_limit.py
@@ -258,30 +258,49 @@ class TestDistributedSleepSeconds:
 class TestDistributedWait:
     def test_wait_sync_sleeps(self):
         client = _make_redis_mock()
-        client.get.return_value = str(time.time() + 0.05)
+        # Freeze the module clock so the future-reset margin cannot be eroded by
+        # scheduler latency on a loaded runner. Real wall-clock here is a race:
+        # if >margin elapses before _sleep_seconds() reads the clock, the
+        # computed sleep is <=0 and sleep() is never called.
+        fixed_now = 1_000_000.0
+        client.get.return_value = str(fixed_now + 5.0)
         gate = DistributedRateLimitGate("gh", redis_client=client)
 
-        with patch(
-            "dev_health_ops.connectors.utils.rate_limit_queue.time.sleep"
-        ) as mock_sleep:
+        with (
+            patch(
+                "dev_health_ops.connectors.utils.rate_limit_queue.time.time",
+                return_value=fixed_now,
+            ),
+            patch(
+                "dev_health_ops.connectors.utils.rate_limit_queue.time.sleep"
+            ) as mock_sleep,
+        ):
             gate.wait_sync()
             mock_sleep.assert_called_once()
-            assert mock_sleep.call_args[0][0] > 0
+            assert mock_sleep.call_args[0][0] == pytest.approx(5.0)
 
     def test_wait_async_sleeps(self):
         client = _make_redis_mock()
-        client.get.return_value = str(time.time() + 0.05)
+        fixed_now = 1_000_000.0
+        client.get.return_value = str(fixed_now + 5.0)
         gate = DistributedRateLimitGate("gh", redis_client=client)
 
         async def _noop(*_args, **_kwargs):
             pass
 
-        with patch(
-            "dev_health_ops.connectors.utils.rate_limit_queue.asyncio.sleep",
-            side_effect=_noop,
-        ) as mock_sleep:
+        with (
+            patch(
+                "dev_health_ops.connectors.utils.rate_limit_queue.time.time",
+                return_value=fixed_now,
+            ),
+            patch(
+                "dev_health_ops.connectors.utils.rate_limit_queue.asyncio.sleep",
+                side_effect=_noop,
+            ) as mock_sleep,
+        ):
             asyncio.run(gate.wait_async())
             mock_sleep.assert_called_once()
+            assert mock_sleep.call_args[0][0] == pytest.approx(5.0)
 
 
 class TestDistributedReset:

--- a/tests/workers/test_team_autoimport_batch.py
+++ b/tests/workers/test_team_autoimport_batch.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any
+
+from dev_health_ops.workers import sync_batch
+
+
+def test_batch_repo_options_preserve_autoimport_and_scope_child() -> None:
+    result = sync_batch._repo_sync_options(
+        provider="github",
+        sync_targets=["git", "work-items"],
+        sync_options={
+            "auto_import_teams": True,
+            "discover": True,
+            "all_repos": True,
+            "batch_size": 10,
+            "search": "full-chaos/*",
+        },
+        repo_tuple=("full-chaos", "dev-health"),
+    )
+
+    assert result == {
+        "auto_import_teams": True,
+        "search": "full-chaos/dev-health",
+        "owner": "full-chaos",
+        "repo": "dev-health",
+    }
+
+
+def test_batch_child_autoimport_true_calls_once(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_run_team_autoimport(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"status": "success"}
+
+    monkeypatch.setattr(sync_batch, "run_team_autoimport", fake_run_team_autoimport)
+
+    result = sync_batch._run_team_autoimport_for_batch_child(
+        provider="github",
+        org_id="org-1",
+        credentials={"token": "secret"},
+        sync_options={
+            "auto_import_teams": True,
+            "owner": "full-chaos",
+            "repo": "dev-health",
+        },
+        sync_targets=["git"],
+        config_id="cfg-1",
+        triggered_by="manual",
+    )
+
+    assert result == {"status": "success"}
+    assert len(calls) == 1
+    assert calls[0]["scope"] == {
+        "mode": "batch_child",
+        "sync_config_id": "cfg-1",
+        "sync_targets": ["git"],
+        "sync_options": {
+            "auto_import_teams": True,
+            "owner": "full-chaos",
+            "repo": "dev-health",
+        },
+        "triggered_by": "manual",
+    }

--- a/tests/workers/test_team_autoimport_batch.py
+++ b/tests/workers/test_team_autoimport_batch.py
@@ -48,10 +48,12 @@ def test_batch_child_autoimport_true_calls_once(monkeypatch) -> None:
         sync_targets=["git"],
         config_id="cfg-1",
         triggered_by="manual",
+        analytics_db_url="clickhouse://batch-dsn",
     )
 
     assert result == {"status": "success"}
     assert len(calls) == 1
+    assert calls[0]["analytics_db_url"] == "clickhouse://batch-dsn"
     assert calls[0]["scope"] == {
         "mode": "batch_child",
         "sync_config_id": "cfg-1",

--- a/tests/workers/test_team_autoimport_e2e_sync_surface.py
+++ b/tests/workers/test_team_autoimport_e2e_sync_surface.py
@@ -1,0 +1,616 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, cast
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from dev_health_ops.api.admin.schemas_flat import DiscoveredMember, DiscoveredTeam
+from dev_health_ops.api.services.configuration.team_discovery import (
+    GitLabDiscoveryResult,
+)
+from dev_health_ops.metrics.compute_work_item_state_durations import (
+    compute_work_item_state_durations_daily,
+)
+from dev_health_ops.metrics.compute_work_items import (
+    TeamAttributionCandidate,
+    TeamAttributionContext,
+    TeamAttributionSource,
+)
+from dev_health_ops.metrics.schemas import (
+    MemberRecord,
+    ProjectRecord,
+    TeamMembershipRecord,
+    TeamProjectOwnershipRecord,
+    TeamRepoOwnershipRecord,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import JobRun, ScheduledJob, SyncConfiguration
+from dev_health_ops.models.work_items import (
+    WorkItem,
+    WorkItemProvider,
+    WorkItemStatusTransition,
+)
+from dev_health_ops.workers import (
+    sync_runtime,
+    team_autoimport_github,
+    team_autoimport_gitlab,
+    team_autoimport_jira,
+    team_autoimport_linear,
+)
+from tests._helpers import tables_of
+
+ORG_ID = "org-chaos-2547"
+DAY = date(2026, 6, 19)
+NOW = datetime(2026, 6, 19, 12, tzinfo=timezone.utc)
+
+
+@dataclass
+class RecordingClickHouseSink:
+    teams: dict[tuple[str, str], dict[str, Any]] = field(default_factory=dict)
+    projects: dict[tuple[str, str, str], ProjectRecord] = field(default_factory=dict)
+    members: dict[tuple[str, str], MemberRecord] = field(default_factory=dict)
+    memberships: dict[tuple[str, str, str, str, str], TeamMembershipRecord] = field(
+        default_factory=dict
+    )
+    project_ownership: dict[
+        tuple[str, str, str, str, str], TeamProjectOwnershipRecord
+    ] = field(default_factory=dict)
+    repo_ownership: dict[tuple[str, str, str, str], TeamRepoOwnershipRecord] = field(
+        default_factory=dict
+    )
+    work_items: list[dict[str, Any]] = field(default_factory=list)
+    closed: bool = False
+
+    async def insert_teams(self, teams: list[dict[str, Any]]) -> None:
+        for team in teams:
+            self.teams[(str(team["org_id"]), str(team["id"]))] = dict(team)
+
+    def write_projects(self, rows: Sequence[ProjectRecord]) -> None:
+        for row in rows:
+            self.projects[(row.org_id, row.provider, row.id)] = row
+
+    def write_members(self, rows: Sequence[MemberRecord]) -> None:
+        for row in rows:
+            self.members[(row.org_id, row.member_id)] = row
+
+    def write_team_memberships(self, rows: Sequence[TeamMembershipRecord]) -> None:
+        for row in rows:
+            self.memberships[
+                (row.org_id, row.provider, row.team_id, row.member_id, row.source)
+            ] = row
+
+    def write_team_project_ownership(
+        self, rows: Sequence[TeamProjectOwnershipRecord]
+    ) -> None:
+        for row in rows:
+            self.project_ownership[
+                (row.org_id, row.provider, row.project_id, row.team_id, row.source)
+            ] = row
+
+    def write_team_repo_ownership(
+        self, rows: Sequence[TeamRepoOwnershipRecord]
+    ) -> None:
+        for row in rows:
+            self.repo_ownership[
+                (row.org_id, row.provider, row.repo_full_name, row.team_id)
+            ] = row
+
+    def write_work_items(self, rows: Sequence[dict[str, Any]]) -> None:
+        self.work_items.extend(dict(row) for row in rows)
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        return []
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def sync_session_factory(tmp_path: Any) -> Iterator[Callable[[], Any]]:
+    db_path = tmp_path / "chaos-2547-sync.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(
+        engine,
+        tables=tables_of(SyncConfiguration, ScheduledJob, JobRun),
+    )
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def session_scope() -> Iterator[Session]:
+        session = factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    try:
+        yield session_scope
+    finally:
+        engine.dispose()
+
+
+def _seed_sync_config(
+    session_factory: Callable[[], Any], *, provider: str, sync_options: dict[str, Any]
+) -> str:
+    with session_factory() as session:
+        config = SyncConfiguration(
+            name=f"chaos-2547-{provider}",
+            provider=provider,
+            org_id=ORG_ID,
+            sync_targets=["work-items"],
+            sync_options=sync_options,
+        )
+        session.add(config)
+        session.flush()
+        return str(config.id)
+
+
+def _patch_runtime_surface(
+    monkeypatch: pytest.MonkeyPatch,
+    session_factory: Callable[[], Any],
+    sink: RecordingClickHouseSink,
+) -> None:
+    import dev_health_ops.db as db
+    import dev_health_ops.metrics.job_work_items as job_work_items
+
+    monkeypatch.setenv("CLICKHOUSE_URI", "clickhouse://test")
+    monkeypatch.setattr(db, "get_postgres_session_sync", session_factory)
+    monkeypatch.setattr(sync_runtime, "_get_db_url", lambda: "clickhouse://test")
+    monkeypatch.setattr(sync_runtime, "_dispatch_post_sync_tasks", lambda **_: None)
+
+    def fake_run_work_items_sync_job(**kwargs: Any) -> dict[str, Any]:
+        sink.write_work_items(
+            [
+                {
+                    "provider": kwargs["provider"],
+                    "org_id": kwargs["org_id"],
+                    "repo_name": kwargs.get("repo_name"),
+                    "search_pattern": kwargs.get("search_pattern"),
+                }
+            ]
+        )
+        return {"work_items_synced": 1}
+
+    monkeypatch.setattr(
+        job_work_items, "run_work_items_sync_job", fake_run_work_items_sync_job
+    )
+
+
+def _patch_clickhouse_sink(
+    monkeypatch: pytest.MonkeyPatch, sink: RecordingClickHouseSink
+) -> None:
+    def sink_factory(dsn: str) -> RecordingClickHouseSink:
+        return sink
+
+    monkeypatch.setattr(team_autoimport_linear, "ClickHouseMetricsSink", sink_factory)
+    monkeypatch.setattr(team_autoimport_jira, "ClickHouseMetricsSink", sink_factory)
+    monkeypatch.setattr(team_autoimport_github, "ClickHouseMetricsSink", sink_factory)
+    monkeypatch.setattr(team_autoimport_gitlab, "ClickHouseMetricsSink", sink_factory)
+
+
+def _patch_provider_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def discover_linear(self: object, api_key: str) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="linear",
+                provider_team_id="ENG",
+                name="Engineering",
+                associations={"project_keys": ["ENG"]},
+            )
+        ]
+
+    async def discover_members_linear(
+        self: object, api_key: str, team_key: str
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="linear",
+                provider_identity="linear-eng@example.com",
+                display_name="Linear Engineer",
+                email="linear-eng@example.com",
+            )
+        ]
+
+    async def discover_jira(
+        self: object, email: str, api_token: str, url: str
+    ) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="jira",
+                provider_team_id="OPS",
+                name="Operations",
+                associations={"project_keys": ["OPS"]},
+            )
+        ]
+
+    async def discover_members_jira_bulk(
+        self: object,
+        *,
+        email: str,
+        api_token: str,
+        url: str,
+        project_keys: list[str],
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="jira",
+                provider_identity="jira-ops-account",
+                display_name="Jira Ops",
+                email="jira-ops@example.com",
+                role="lead",
+            )
+        ]
+
+    async def discover_github(
+        self: object, token: str, org_name: str
+    ) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="github",
+                provider_team_id="platform",
+                name="Platform",
+                associations={"repo_patterns": ["full-chaos/dev-health"]},
+            )
+        ]
+
+    async def discover_members_github(
+        self: object, token: str, org_name: str, team_slug: str
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="github",
+                provider_identity="platform-lead",
+                display_name="Platform Lead",
+                email="platform@example.com",
+            )
+        ]
+
+    async def discover_gitlab(
+        self: object, token: str, group_path: str, url: str
+    ) -> GitLabDiscoveryResult:
+        return GitLabDiscoveryResult(
+            teams=[
+                DiscoveredTeam(
+                    provider_type="gitlab",
+                    provider_team_id="full-chaos/dev-health",
+                    name="Dev Health",
+                    associations={"repo_patterns": ["full-chaos/dev-health/api"]},
+                )
+            ]
+        )
+
+    async def discover_members_gitlab(
+        self: object, token: str, group_path: str, url: str
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="gitlab",
+                provider_identity="dev-health-maintainer",
+                display_name="Dev Health Maintainer",
+                email="gitlab@example.com",
+            )
+        ]
+
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamDiscoveryService,
+        "discover_linear",
+        discover_linear,
+    )
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamMembershipService,
+        "discover_members_linear",
+        discover_members_linear,
+    )
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamDiscoveryService,
+        "discover_jira",
+        discover_jira,
+    )
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamMembershipService,
+        "discover_members_jira_bulk",
+        discover_members_jira_bulk,
+    )
+    monkeypatch.setattr(
+        team_autoimport_github.TeamDiscoveryService,
+        "discover_github",
+        discover_github,
+    )
+    monkeypatch.setattr(
+        team_autoimport_github.TeamMembershipService,
+        "discover_members_github",
+        discover_members_github,
+    )
+    monkeypatch.setattr(
+        team_autoimport_gitlab.TeamDiscoveryService,
+        "discover_gitlab",
+        discover_gitlab,
+    )
+    monkeypatch.setattr(
+        team_autoimport_gitlab.TeamMembershipService,
+        "discover_members_gitlab",
+        discover_members_gitlab,
+    )
+
+
+def _credentials(provider: str) -> dict[str, str]:
+    return {
+        "linear": {"api_key": "linear-key"},
+        "jira": {
+            "email": "jira@example.com",
+            "api_token": "jira-token",
+            "base_url": "https://jira.example.com",
+        },
+        "github": {"token": "github-token", "org": "full-chaos"},
+        "gitlab": {"token": "gitlab-token", "group_path": "full-chaos"},
+    }[provider]
+
+
+def _sync_options(provider: str) -> dict[str, Any]:
+    provider_options: dict[str, dict[str, Any]] = {
+        "linear": {},
+        "jira": {"project_keys": ["OPS"]},
+        "github": {"owner": "full-chaos"},
+        "gitlab": {"group": "full-chaos"},
+    }
+    return {"auto_import_teams": True, **provider_options[provider]}
+
+
+def _run_sync_surface(
+    *,
+    provider: str,
+    monkeypatch: pytest.MonkeyPatch,
+    session_factory: Callable[[], Any],
+    sink: RecordingClickHouseSink,
+) -> dict[str, Any]:
+    _patch_runtime_surface(monkeypatch, session_factory, sink)
+    _patch_clickhouse_sink(monkeypatch, sink)
+    _patch_provider_stubs(monkeypatch)
+    monkeypatch.setattr(
+        sync_runtime,
+        "_resolve_env_credentials",
+        lambda provider_name: _credentials(provider_name),
+    )
+    config_id = _seed_sync_config(
+        session_factory, provider=provider, sync_options=_sync_options(provider)
+    )
+    return getattr(sync_runtime.run_sync_config, "run")(config_id, ORG_ID, "manual")
+
+
+def _candidate(
+    *, source: str, team_id: str, team_name: str, evidence: str, row: Any
+) -> TeamAttributionCandidate:
+    return TeamAttributionCandidate(
+        source=cast(TeamAttributionSource, source),
+        team_id=team_id,
+        team_name=team_name,
+        confidence="high" if int(row.is_primary) else "medium",
+        evidence=evidence,
+        is_primary=int(row.is_primary),
+        specificity=int(row.specificity),
+        priority=int(row.priority),
+        updated_at=row.updated_at,
+    )
+
+
+def _team_name(sink: RecordingClickHouseSink, org_id: str, team_id: str) -> str:
+    team = sink.teams.get((org_id, team_id))
+    if team is None:
+        return team_id
+    return str(team.get("name") or team_id)
+
+
+def _attribution_context_from_sink(
+    sink: RecordingClickHouseSink,
+) -> TeamAttributionContext:
+    context = TeamAttributionContext()
+    for project_row in sink.project_ownership.values():
+        candidate = _candidate(
+            source="project_ownership",
+            team_id=project_row.team_id,
+            team_name=_team_name(sink, project_row.org_id, project_row.team_id),
+            evidence=f"project_ownership={project_row.project_id}",
+            row=project_row,
+        )
+        context.project_by_id.setdefault(
+            (project_row.provider, project_row.project_id), []
+        ).append(candidate)
+        if project_row.project_key:
+            context.project_by_key.setdefault(
+                (project_row.provider, project_row.project_key), []
+            ).append(candidate)
+
+    for repo_row in sink.repo_ownership.values():
+        candidate = _candidate(
+            source="repo_ownership",
+            team_id=repo_row.team_id,
+            team_name=_team_name(sink, repo_row.org_id, repo_row.team_id),
+            evidence=f"repo_ownership={repo_row.repo_full_name}",
+            row=repo_row,
+        )
+        context.repo_by_name.setdefault(
+            (repo_row.provider, repo_row.repo_full_name), []
+        ).append(candidate)
+
+    for membership_row in sink.memberships.values():
+        candidate = _candidate(
+            source="assignee_membership",
+            team_id=membership_row.team_id,
+            team_name=_team_name(sink, membership_row.org_id, membership_row.team_id),
+            evidence=f"assignee_membership={membership_row.member_id}",
+            row=membership_row,
+        )
+        for identity in (
+            membership_row.member_id,
+            membership_row.raw_provider_user_id,
+            membership_row.raw_email,
+        ):
+            key = " ".join(str(identity or "").strip().lower().split())
+            if key:
+                context.member_by_identity.setdefault(
+                    (membership_row.provider, key), []
+                ).append(candidate)
+    return context
+
+
+def _work_item_for_provider(provider: str) -> WorkItem:
+    provider_fields: dict[str, dict[str, Any]] = {
+        "linear": {
+            "work_item_id": "linear:ENG-1",
+            "project_key": "ENG",
+            "project_id": "Engineering Project",
+        },
+        "jira": {
+            "work_item_id": "jira:OPS-1",
+            "project_key": "OPS",
+            "project_id": "Operations Project",
+        },
+        "github": {
+            "work_item_id": "gh:full-chaos/dev-health#1",
+            "project_key": None,
+            "project_id": "full-chaos/dev-health",
+        },
+        "gitlab": {
+            "work_item_id": "gitlab:full-chaos/dev-health/api#1",
+            "project_key": "full-chaos/dev-health/api",
+            "project_id": "full-chaos/dev-health/api",
+        },
+    }
+    fields = provider_fields[provider]
+    return WorkItem(
+        provider=cast(WorkItemProvider, provider),
+        title="Auto-import attribution probe",
+        type="task",
+        status="done",
+        status_raw="Done",
+        assignees=[],
+        reporter=None,
+        created_at=NOW - timedelta(days=1),
+        updated_at=NOW,
+        started_at=NOW - timedelta(hours=2),
+        completed_at=NOW,
+        closed_at=NOW,
+        labels=[],
+        **fields,
+    )
+
+
+def _assert_context_can_resolve_provider(
+    provider: str, context: TeamAttributionContext
+) -> None:
+    if provider == "linear":
+        assert ("linear", "ENG") in context.project_by_key
+    elif provider == "jira":
+        assert ("jira", "OPS") in context.project_by_key
+    elif provider == "github":
+        assert ("github", "full-chaos/dev-health") in context.repo_by_name
+    else:
+        assert ("gitlab", "full-chaos/dev-health/api") in context.project_by_key
+
+
+def _transition_for(item: WorkItem) -> WorkItemStatusTransition:
+    return WorkItemStatusTransition(
+        work_item_id=item.work_item_id,
+        provider=item.provider,
+        occurred_at=NOW - timedelta(hours=1),
+        from_status_raw="To Do",
+        to_status_raw="Done",
+        from_status="todo",
+        to_status="done",
+        actor=None,
+    )
+
+
+@pytest.mark.parametrize("provider", ["linear", "jira", "github", "gitlab"])
+def test_chaos_2401_2466_sync_surface_autoimport_populates_clickhouse_dims_and_named_attribution(
+    provider: str,
+    monkeypatch: pytest.MonkeyPatch,
+    sync_session_factory: Callable[[], Any],
+) -> None:
+    sink = RecordingClickHouseSink()
+
+    result = _run_sync_surface(
+        provider=provider,
+        monkeypatch=monkeypatch,
+        session_factory=sync_session_factory,
+        sink=sink,
+    )
+
+    assert result["status"] == "success"
+    if provider != "jira":
+        assert result["result"]["work_items_synced"] is True
+    else:
+        assert result["result"]["backfill_days"] == 1
+    assert result["result"]["team_autoimport"]["status"] == "success"
+    assert sink.work_items, "sync surface must write work_items before attribution QA"
+    assert sink.teams, "auto-import must populate ClickHouse teams"
+    assert sink.memberships, "auto-import must populate ClickHouse team_memberships"
+
+    if provider in {"linear", "jira"}:
+        assert sink.projects, "Linear/Jira auto-import must populate projects"
+        assert sink.members, "Linear/Jira auto-import must populate members"
+        assert sink.project_ownership, (
+            "Linear/Jira auto-import must populate team_project_ownership"
+        )
+    elif provider == "github":
+        assert sink.repo_ownership, (
+            "GitHub auto-import must populate team_repo_ownership"
+        )
+    else:
+        assert sink.project_ownership, (
+            "GitLab auto-import must populate team_project_ownership"
+        )
+
+    attribution_context = _attribution_context_from_sink(sink)
+    _assert_context_can_resolve_provider(provider, attribution_context)
+
+    item = _work_item_for_provider(provider)
+    rows = compute_work_item_state_durations_daily(
+        day=DAY,
+        work_items=[item],
+        transitions=[_transition_for(item)],
+        computed_at=NOW,
+        attribution_context=attribution_context,
+    )
+
+    assert rows, "downstream attribution-backed metrics should produce rows"
+    assert {row.team_id for row in rows} != {"unassigned"}
+    assert all(row.team_id != "unassigned" for row in rows)
+    assert all(row.team_name for row in rows)
+
+
+def test_chaos_2401_2466_regression_work_item_sync_cannot_skip_autoimport_ownership_tables(
+    monkeypatch: pytest.MonkeyPatch,
+    sync_session_factory: Callable[[], Any],
+) -> None:
+    sink = RecordingClickHouseSink()
+
+    result = _run_sync_surface(
+        provider="linear",
+        monkeypatch=monkeypatch,
+        session_factory=sync_session_factory,
+        sink=sink,
+    )
+
+    assert result["status"] == "success"
+    assert sink.work_items, "regression setup must prove the provider sync ran"
+    assert sink.project_ownership, (
+        "CHAOS-2401/2466 regression: a sync with auto_import_teams=true must not "
+        "write work_items while leaving ownership dimensions empty"
+    )
+    assert sink.memberships, (
+        "CHAOS-2401/2466 regression: auto-import dispatch must write "
+        "team_memberships for attribution"
+    )

--- a/tests/workers/test_team_autoimport_executor.py
+++ b/tests/workers/test_team_autoimport_executor.py
@@ -25,7 +25,7 @@ def test_run_team_autoimport_skips_missing_populator(caplog) -> None:
     caplog.set_level(logging.INFO)
 
     result = team_autoimport.run_team_autoimport(
-        provider="github",
+        provider="ms-teams",
         org_id="org-1",
         credentials={"token": "secret"},
         scope={"sync_options": {"auto_import_teams": True}},

--- a/tests/workers/test_team_autoimport_executor.py
+++ b/tests/workers/test_team_autoimport_executor.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from dev_health_ops.workers import team_autoimport
+
+
+def test_run_team_autoimport_skips_non_capable_provider(caplog) -> None:
+    caplog.set_level(logging.INFO)
+
+    result = team_autoimport.run_team_autoimport(
+        provider="launchdarkly",
+        org_id="org-1",
+        credentials={"token": "secret"},
+    )
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "provider_not_import_capable"
+    assert result["projects_imported"] == 0
+    assert "provider is not import-capable" in caplog.text
+
+
+def test_run_team_autoimport_skips_missing_populator(caplog) -> None:
+    caplog.set_level(logging.INFO)
+
+    result = team_autoimport.run_team_autoimport(
+        provider="github",
+        org_id="org-1",
+        credentials={"token": "secret"},
+        scope={"sync_options": {"auto_import_teams": True}},
+    )
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "populator_not_available"
+    assert result["members_imported"] == 0
+    assert "no populator module is available" in caplog.text
+
+
+def test_run_team_autoimport_calls_resolved_populator(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def populate(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"members_imported": 2}
+
+    monkeypatch.setattr(
+        team_autoimport, "_resolve_populator", lambda provider: populate
+    )
+
+    result = team_autoimport.run_team_autoimport(
+        provider="jira",
+        org_id="org-1",
+        credentials={"token": "secret"},
+        scope={"project_keys": ["OPS"]},
+    )
+
+    assert result == {
+        "status": "success",
+        "provider": "jira",
+        "org_id": "org-1",
+        "members_imported": 2,
+    }
+    assert calls == [
+        {
+            "org_id": "org-1",
+            "credentials": {"token": "secret"},
+            "scope": {"project_keys": ["OPS"]},
+        }
+    ]

--- a/tests/workers/test_team_autoimport_executor.py
+++ b/tests/workers/test_team_autoimport_executor.py
@@ -53,6 +53,7 @@ def test_run_team_autoimport_calls_resolved_populator(monkeypatch) -> None:
         org_id="org-1",
         credentials={"token": "secret"},
         scope={"project_keys": ["OPS"]},
+        analytics_db_url="clickhouse://config-dsn",
     )
 
     assert result == {
@@ -65,6 +66,9 @@ def test_run_team_autoimport_calls_resolved_populator(monkeypatch) -> None:
         {
             "org_id": "org-1",
             "credentials": {"token": "secret"},
-            "scope": {"project_keys": ["OPS"]},
+            "scope": {
+                "project_keys": ["OPS"],
+                "analytics_db": "clickhouse://config-dsn",
+            },
         }
     ]

--- a/tests/workers/test_team_autoimport_github_gitlab.py
+++ b/tests/workers/test_team_autoimport_github_gitlab.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.admin.schemas_flat import DiscoveredMember, DiscoveredTeam
+from dev_health_ops.api.services.configuration.team_discovery import (
+    GitLabDiscoveryResult,
+)
+from dev_health_ops.workers import team_autoimport_github, team_autoimport_gitlab
+
+
+@dataclass
+class RecordingSink:
+    teams: list[dict[str, Any]] = field(default_factory=list)
+    repo_ownership: list[Any] = field(default_factory=list)
+    project_ownership: list[Any] = field(default_factory=list)
+    memberships: list[Any] = field(default_factory=list)
+    manual_repo_ownership: list[dict[str, Any]] = field(
+        default_factory=lambda: [
+            {
+                "org_id": "org-1",
+                "provider": "github",
+                "team_id": "gh:manual",
+                "repo_full_name": "full-chaos/manual",
+                "source": "manual",
+            }
+        ]
+    )
+
+    async def insert_teams(self, rows: list[dict[str, Any]]) -> None:
+        self.teams.extend(rows)
+
+    def write_team_repo_ownership(self, rows: list[Any]) -> None:
+        self.repo_ownership.extend(rows)
+
+    def write_team_project_ownership(self, rows: list[Any]) -> None:
+        self.project_ownership.extend(rows)
+
+    def write_team_memberships(self, rows: list[Any]) -> None:
+        self.memberships.extend(rows)
+
+
+def test_github_org_import_writes_provider_access_repo_grants_and_nested_specificity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = RecordingSink()
+
+    async def discover_github(self, token: str, org_name: str) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="github",
+                provider_team_id="platform",
+                name="Platform",
+                associations={
+                    "repo_patterns": ["full-chaos/dev-health"],
+                    "provider_org": org_name,
+                },
+            ),
+            DiscoveredTeam(
+                provider_type="github",
+                provider_team_id="platform-api",
+                name="Platform API",
+                associations={
+                    "repo_patterns": ["full-chaos/dev-health"],
+                    "provider_org": org_name,
+                    "parent_team_id": "platform",
+                },
+            ),
+        ]
+
+    async def discover_members_github(
+        self, token: str, org_name: str, team_slug: str
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="github",
+                provider_identity=f"{team_slug}-lead",
+                display_name=f"{team_slug} lead",
+                email=f"{team_slug}@example.com",
+            )
+        ]
+
+    monkeypatch.setattr(
+        team_autoimport_github.TeamDiscoveryService,
+        "discover_github",
+        discover_github,
+    )
+    monkeypatch.setattr(
+        team_autoimport_github.TeamMembershipService,
+        "discover_members_github",
+        discover_members_github,
+    )
+    monkeypatch.setattr(
+        team_autoimport_github, "ClickHouseMetricsSink", lambda dsn: sink
+    )
+
+    summary = team_autoimport_github.populate(
+        org_id="org-1",
+        credentials={"token": "secret", "org": "full-chaos"},
+        scope={
+            "analytics_db": "clickhouse://test",
+            "sync_options": {"auto_import_teams": True},
+        },
+    )
+
+    assert summary["teams_imported"] == 2
+    assert summary["team_repo_ownership_imported"] == 2
+    assert summary["team_memberships_imported"] == 2
+    assert {row["id"] for row in sink.teams} == {"gh:platform", "gh:platform-api"}
+    child_team = next(row for row in sink.teams if row["id"] == "gh:platform-api")
+    assert child_team["parent_team_id"] == "gh:platform"
+    assert {row.source for row in sink.repo_ownership} == {"provider_access"}
+    parent_row = next(
+        row for row in sink.repo_ownership if row.team_id == "gh:platform"
+    )
+    child_row = next(
+        row for row in sink.repo_ownership if row.team_id == "gh:platform-api"
+    )
+    assert child_row.repo_full_name == parent_row.repo_full_name
+    assert child_row.specificity > parent_row.specificity
+
+
+def test_gitlab_group_import_writes_provider_access_project_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = RecordingSink()
+
+    async def discover_gitlab(
+        self, token: str, group_path: str, url: str
+    ) -> GitLabDiscoveryResult:
+        return GitLabDiscoveryResult(
+            teams=[
+                DiscoveredTeam(
+                    provider_type="gitlab",
+                    provider_team_id="full-chaos",
+                    name="Full Chaos",
+                    associations={
+                        "repo_patterns": ["full-chaos/platform"],
+                        "provider_org": group_path,
+                    },
+                ),
+                DiscoveredTeam(
+                    provider_type="gitlab",
+                    provider_team_id="full-chaos/dev-health",
+                    name="Dev Health",
+                    associations={
+                        "repo_patterns": ["full-chaos/dev-health/api"],
+                        "provider_org": group_path,
+                    },
+                ),
+            ]
+        )
+
+    async def discover_members_gitlab(
+        self, token: str, group_path: str, url: str
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="gitlab",
+                provider_identity=group_path.replace("/", "-"),
+                display_name=group_path,
+            )
+        ]
+
+    monkeypatch.setattr(
+        team_autoimport_gitlab.TeamDiscoveryService,
+        "discover_gitlab",
+        discover_gitlab,
+    )
+    monkeypatch.setattr(
+        team_autoimport_gitlab.TeamMembershipService,
+        "discover_members_gitlab",
+        discover_members_gitlab,
+    )
+    monkeypatch.setattr(
+        team_autoimport_gitlab, "ClickHouseMetricsSink", lambda dsn: sink
+    )
+
+    summary = team_autoimport_gitlab.populate(
+        org_id="org-1",
+        credentials={"token": "secret", "group_path": "full-chaos"},
+        scope={
+            "analytics_db": "clickhouse://test",
+            "sync_options": {"auto_import_teams": True},
+        },
+    )
+
+    assert summary["teams_imported"] == 2
+    assert summary["projects_imported"] == 2
+    assert summary["team_project_ownership_imported"] == 2
+    assert {row["id"] for row in sink.teams} == {
+        "gl:full-chaos",
+        "gl:full-chaos/dev-health",
+    }
+    subgroup = next(
+        row for row in sink.teams if row["id"] == "gl:full-chaos/dev-health"
+    )
+    assert subgroup["parent_team_id"] == "gl:full-chaos"
+    assert {row.source for row in sink.project_ownership} == {"provider_access"}
+    assert {row.project_key for row in sink.project_ownership} == {
+        "full-chaos/platform",
+        "full-chaos/dev-health/api",
+    }
+
+
+def test_github_personal_account_or_unsupported_response_skips_without_touching_manual_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sink = RecordingSink()
+    manual_before = list(sink.manual_repo_ownership)
+
+    async def discover_github(self, token: str, org_name: str) -> list[DiscoveredTeam]:
+        raise RuntimeError("404 Not Found")
+
+    def fail_if_sink_is_created(dsn: str) -> RecordingSink:
+        raise AssertionError(
+            "no-op personal account import must not write to ClickHouse"
+        )
+
+    monkeypatch.setattr(
+        team_autoimport_github.TeamDiscoveryService,
+        "discover_github",
+        discover_github,
+    )
+    monkeypatch.setattr(
+        team_autoimport_github, "ClickHouseMetricsSink", fail_if_sink_is_created
+    )
+
+    summary = team_autoimport_github.populate(
+        org_id="org-1",
+        credentials={"token": "secret", "org": "personal-user"},
+        scope={"sync_options": {"auto_import_teams": True}},
+    )
+
+    assert summary["status"] == "skipped"
+    assert summary["reason"] == "provider_discovery_skipped"
+    assert summary["team_repo_ownership_imported"] == 0
+    assert summary["team_memberships_imported"] == 0
+    assert sink.manual_repo_ownership == manual_before

--- a/tests/workers/test_team_autoimport_jira.py
+++ b/tests/workers/test_team_autoimport_jira.py
@@ -13,7 +13,7 @@ from dev_health_ops.metrics.schemas import (
     TeamMembershipRecord,
     TeamProjectOwnershipRecord,
 )
-from dev_health_ops.workers import team_autoimport_jira
+from dev_health_ops.workers import team_autoimport, team_autoimport_jira
 
 
 @dataclass
@@ -76,6 +76,22 @@ def _fake_sink(
         teams={},
         jira_legacy_links=list(jira_legacy_links or []),
     )
+
+
+class CapturingClickHouseSink(FakeDimensionSink):
+    instances: list[CapturingClickHouseSink] = []
+
+    def __init__(self, *, dsn: str) -> None:
+        super().__init__(
+            projects={},
+            members={},
+            memberships={},
+            ownership={},
+            teams={},
+            jira_legacy_links=[],
+        )
+        self.dsn = dsn
+        self.instances.append(self)
 
 
 def test_jira_populate_writes_native_and_jira_legacy_ownership_without_touching_links(
@@ -161,6 +177,89 @@ def test_jira_populate_writes_native_and_jira_legacy_ownership_without_touching_
         "jira_legacy",
     ) in sink.ownership
     assert ("org-1", "jira:account-1") in sink.members
+
+
+def test_chaos_2547_2544_jira_autoimport_uses_analytics_db_url_with_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def discover_jira(
+        self: object, email: str, api_token: str, url: str
+    ) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="jira",
+                provider_team_id="OPS",
+                name="Ops Project",
+                associations={"project_keys": ["OPS"]},
+            )
+        ]
+
+    async def discover_members_jira_bulk(
+        self: object,
+        *,
+        email: str,
+        api_token: str,
+        url: str,
+        project_keys: list[str],
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="jira",
+                provider_identity="account-1",
+                display_name="Ops Lead",
+                email="ops@example.com",
+                role="lead",
+            )
+        ]
+
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    CapturingClickHouseSink.instances = []
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamDiscoveryService,
+        "discover_jira",
+        discover_jira,
+    )
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamMembershipService,
+        "discover_members_jira_bulk",
+        discover_members_jira_bulk,
+    )
+    monkeypatch.setattr(
+        team_autoimport_jira,
+        "ClickHouseMetricsSink",
+        CapturingClickHouseSink,
+    )
+
+    summary = team_autoimport.run_team_autoimport(
+        provider="jira",
+        org_id="org-1",
+        credentials={
+            "email": "jira@example.com",
+            "api_token": "jira-token",
+            "base_url": "https://jira.example.com",
+        },
+        scope={"mode": "sync_config"},
+        analytics_db_url="clickhouse://jira-config-dsn",
+    )
+
+    assert summary["status"] == "success"
+    assert summary["projects_imported"] == 1
+    assert summary["members_imported"] == 1
+    assert summary["team_memberships_imported"] == 1
+    assert summary["team_project_ownership_imported"] == 1
+    assert len(CapturingClickHouseSink.instances) == 1
+    sink = CapturingClickHouseSink.instances[0]
+    assert sink.dsn == "clickhouse://jira-config-dsn"
+    assert sink.closed is True
+    assert ("org-1", "jira", "org-1:jira:OPS") in sink.projects
+    assert ("org-1", "jira:account-1") in sink.members
+    assert (
+        "org-1",
+        "jira",
+        "OPS",
+        "jira:account-1",
+        "native",
+    ) in sink.memberships
 
 
 def test_jira_populate_preserves_manual_project_ownership_row(

--- a/tests/workers/test_team_autoimport_jira.py
+++ b/tests/workers/test_team_autoimport_jira.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.admin.schemas_flat import DiscoveredMember, DiscoveredTeam
+from dev_health_ops.metrics.schemas import (
+    MemberRecord,
+    ProjectRecord,
+    TeamMembershipRecord,
+    TeamProjectOwnershipRecord,
+)
+from dev_health_ops.workers import team_autoimport_jira
+
+
+@dataclass
+class FakeDimensionSink:
+    projects: dict[tuple[str, str, str], ProjectRecord]
+    members: dict[tuple[str, str], MemberRecord]
+    memberships: dict[tuple[str, str, str, str, str], TeamMembershipRecord]
+    ownership: dict[tuple[str, str, str, str, str], TeamProjectOwnershipRecord]
+    teams: dict[tuple[str, str], dict[str, Any]]
+    jira_legacy_links: list[dict[str, Any]]
+    closed: bool = False
+
+    def write_projects(self, rows: list[ProjectRecord]) -> None:
+        for row in rows:
+            self.projects[(row.org_id, row.provider, row.id)] = row
+
+    def write_members(self, rows: list[MemberRecord]) -> None:
+        for row in rows:
+            self.members[(row.org_id, row.member_id)] = row
+
+    def write_team_memberships(self, rows: list[TeamMembershipRecord]) -> None:
+        for row in rows:
+            self.memberships[
+                (row.org_id, row.provider, row.team_id, row.member_id, row.source)
+            ] = row
+
+    def write_team_project_ownership(
+        self, rows: list[TeamProjectOwnershipRecord]
+    ) -> None:
+        for row in rows:
+            self.ownership[
+                (row.org_id, row.provider, row.project_id, row.team_id, row.source)
+            ] = row
+
+    async def insert_teams(self, teams: list[dict[str, Any]]) -> None:
+        for team in teams:
+            self.teams[(str(team["org_id"]), str(team["id"]))] = team
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        return [
+            row
+            for row in self.jira_legacy_links
+            if row.get("org_id") == parameters.get("org_id")
+        ]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _fake_sink(
+    *, jira_legacy_links: list[dict[str, Any]] | None = None
+) -> FakeDimensionSink:
+    return FakeDimensionSink(
+        projects={},
+        members={},
+        memberships={},
+        ownership={},
+        teams={},
+        jira_legacy_links=list(jira_legacy_links or []),
+    )
+
+
+def test_jira_populate_writes_native_and_jira_legacy_ownership_without_touching_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def discover_jira(
+        self: object, email: str, api_token: str, url: str
+    ) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="jira",
+                provider_team_id="OPS",
+                name="Ops Project",
+                associations={"project_keys": ["OPS"]},
+            )
+        ]
+
+    async def discover_members_jira_bulk(
+        self: object,
+        *,
+        email: str,
+        api_token: str,
+        url: str,
+        project_keys: list[str],
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="jira",
+                provider_identity="account-1",
+                display_name="Ops Lead",
+                email="ops@example.com",
+                role="lead",
+            )
+        ]
+
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamDiscoveryService,
+        "discover_jira",
+        discover_jira,
+    )
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamMembershipService,
+        "discover_members_jira_bulk",
+        discover_members_jira_bulk,
+    )
+    legacy_links = [
+        {
+            "org_id": "org-1",
+            "project_key": "OPS",
+            "ops_team_id": "ops-team-legacy",
+            "project_name": "Ops Project",
+            "ops_team_name": "Ops Legacy",
+        }
+    ]
+    sink = _fake_sink(jira_legacy_links=legacy_links)
+
+    summary = team_autoimport_jira.populate(
+        org_id="org-1",
+        credentials={
+            "email": "jira@example.com",
+            "api_token": "jira-token",
+            "base_url": "https://jira.example.com",
+        },
+        scope={"mode": "sync_config"},
+        sink=sink,
+    )
+
+    assert summary["team_project_ownership_imported"] == 2
+    assert summary["jira_legacy_project_ownership_imported"] == 1
+    assert legacy_links == sink.jira_legacy_links
+    assert (
+        "org-1",
+        "jira",
+        "org-1:jira:OPS",
+        "OPS",
+        "native",
+    ) in sink.ownership
+    assert (
+        "org-1",
+        "jira",
+        "org-1:jira:OPS",
+        "ops-team-legacy",
+        "jira_legacy",
+    ) in sink.ownership
+    assert ("org-1", "jira:account-1") in sink.members
+
+
+def test_jira_populate_preserves_manual_project_ownership_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def discover_jira(
+        self: object, email: str, api_token: str, url: str
+    ) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="jira",
+                provider_team_id="OPS",
+                name="Ops Project",
+                associations={"project_keys": ["OPS"]},
+            )
+        ]
+
+    async def discover_members_jira_bulk(
+        self: object,
+        *,
+        email: str,
+        api_token: str,
+        url: str,
+        project_keys: list[str],
+    ) -> list[DiscoveredMember]:
+        return []
+
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamDiscoveryService,
+        "discover_jira",
+        discover_jira,
+    )
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamMembershipService,
+        "discover_members_jira_bulk",
+        discover_members_jira_bulk,
+    )
+    sink = _fake_sink()
+    manual = TeamProjectOwnershipRecord(
+        org_id="org-1",
+        provider="jira",
+        team_id="manual-team",
+        project_id="org-1:jira:OPS",
+        project_key="OPS",
+        source="manual",
+        is_primary=1,
+        specificity=100,
+        priority=0,
+        valid_from=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    sink.write_team_project_ownership([manual])
+
+    team_autoimport_jira.populate(
+        org_id="org-1",
+        credentials={
+            "email": "jira@example.com",
+            "api_token": "jira-token",
+            "base_url": "https://jira.example.com",
+        },
+        scope={"mode": "sync_config"},
+        sink=sink,
+    )
+
+    assert (
+        "org-1",
+        "jira",
+        "org-1:jira:OPS",
+        "manual-team",
+        "manual",
+    ) in sink.ownership
+    assert (
+        "org-1",
+        "jira",
+        "org-1:jira:OPS",
+        "OPS",
+        "native",
+    ) in sink.ownership

--- a/tests/workers/test_team_autoimport_linear.py
+++ b/tests/workers/test_team_autoimport_linear.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.admin.schemas_flat import DiscoveredMember, DiscoveredTeam
+from dev_health_ops.metrics.schemas import (
+    MemberRecord,
+    ProjectRecord,
+    TeamMembershipRecord,
+    TeamProjectOwnershipRecord,
+)
+from dev_health_ops.workers import team_autoimport_linear
+
+
+@dataclass
+class FakeDimensionSink:
+    projects: dict[tuple[str, str, str], ProjectRecord]
+    members: dict[tuple[str, str], MemberRecord]
+    memberships: dict[tuple[str, str, str, str, str], TeamMembershipRecord]
+    ownership: dict[tuple[str, str, str, str, str], TeamProjectOwnershipRecord]
+    teams: dict[tuple[str, str], dict[str, Any]]
+    closed: bool = False
+
+    def write_projects(self, rows: list[ProjectRecord]) -> None:
+        for row in rows:
+            self.projects[(row.org_id, row.provider, row.id)] = row
+
+    def write_members(self, rows: list[MemberRecord]) -> None:
+        for row in rows:
+            self.members[(row.org_id, row.member_id)] = row
+
+    def write_team_memberships(self, rows: list[TeamMembershipRecord]) -> None:
+        for row in rows:
+            self.memberships[
+                (row.org_id, row.provider, row.team_id, row.member_id, row.source)
+            ] = row
+
+    def write_team_project_ownership(
+        self, rows: list[TeamProjectOwnershipRecord]
+    ) -> None:
+        for row in rows:
+            self.ownership[
+                (row.org_id, row.provider, row.project_id, row.team_id, row.source)
+            ] = row
+
+    async def insert_teams(self, teams: list[dict[str, Any]]) -> None:
+        for team in teams:
+            self.teams[(str(team["org_id"]), str(team["id"]))] = team
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _fake_sink() -> FakeDimensionSink:
+    return FakeDimensionSink(
+        projects={},
+        members={},
+        memberships={},
+        ownership={},
+        teams={},
+    )
+
+
+def test_linear_populate_writes_projects_memberships_and_project_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def discover_linear(self: object, api_key: str) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="linear",
+                provider_team_id="ENG",
+                name="Engineering",
+                associations={"project_keys": ["ENG"]},
+            )
+        ]
+
+    async def discover_members_linear(
+        self: object, api_key: str, team_key: str
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="linear",
+                provider_identity="dev@example.com",
+                display_name="Dev User",
+                email="dev@example.com",
+            )
+        ]
+
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamDiscoveryService,
+        "discover_linear",
+        discover_linear,
+    )
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamMembershipService,
+        "discover_members_linear",
+        discover_members_linear,
+    )
+    sink = _fake_sink()
+
+    summary = team_autoimport_linear.populate(
+        org_id="org-1",
+        credentials={"api_key": "lin-key"},
+        scope={"mode": "sync_config"},
+        sink=sink,
+    )
+
+    assert summary["projects_imported"] == 1
+    assert summary["members_imported"] == 1
+    assert summary["team_memberships_imported"] == 1
+    assert summary["team_project_ownership_imported"] == 1
+    assert ("org-1", "linear", "org-1:linear:ENG") in sink.projects
+    assert ("org-1", "linear:dev@example.com") in sink.members
+    assert (
+        "org-1",
+        "linear",
+        "ENG",
+        "linear:dev@example.com",
+        "native",
+    ) in sink.memberships
+    assert (
+        "org-1",
+        "linear",
+        "org-1:linear:ENG",
+        "ENG",
+        "native",
+    ) in sink.ownership
+    assert sink.teams[("org-1", "ENG")]["native_team_key"] == "ENG"
+
+
+def test_linear_populate_rerun_keeps_stable_logical_dimension_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def discover_linear(self: object, api_key: str) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="linear",
+                provider_team_id="ENG",
+                name="Engineering",
+                associations={"project_keys": ["ENG"]},
+            )
+        ]
+
+    async def discover_members_linear(
+        self: object, api_key: str, team_key: str
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="linear",
+                provider_identity="dev@example.com",
+                display_name="Dev User",
+                email="dev@example.com",
+            )
+        ]
+
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamDiscoveryService,
+        "discover_linear",
+        discover_linear,
+    )
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamMembershipService,
+        "discover_members_linear",
+        discover_members_linear,
+    )
+    sink = _fake_sink()
+
+    for _ in range(2):
+        team_autoimport_linear.populate(
+            org_id="org-1",
+            credentials={"api_key": "lin-key"},
+            scope={"mode": "sync_config"},
+            sink=sink,
+        )
+
+    assert len(sink.projects) == 1
+    assert len(sink.members) == 1
+    assert len(sink.memberships) == 1
+    assert len(sink.ownership) == 1
+    assert len(sink.teams) == 1

--- a/tests/workers/test_team_autoimport_linear.py
+++ b/tests/workers/test_team_autoimport_linear.py
@@ -12,7 +12,7 @@ from dev_health_ops.metrics.schemas import (
     TeamMembershipRecord,
     TeamProjectOwnershipRecord,
 )
-from dev_health_ops.workers import team_autoimport_linear
+from dev_health_ops.workers import team_autoimport, team_autoimport_linear
 
 
 @dataclass
@@ -62,6 +62,21 @@ def _fake_sink() -> FakeDimensionSink:
         ownership={},
         teams={},
     )
+
+
+class CapturingClickHouseSink(FakeDimensionSink):
+    instances: list[CapturingClickHouseSink] = []
+
+    def __init__(self, *, dsn: str) -> None:
+        super().__init__(
+            projects={},
+            members={},
+            memberships={},
+            ownership={},
+            teams={},
+        )
+        self.dsn = dsn
+        self.instances.append(self)
 
 
 def test_linear_populate_writes_projects_memberships_and_project_ownership(
@@ -129,6 +144,77 @@ def test_linear_populate_writes_projects_memberships_and_project_ownership(
         "native",
     ) in sink.ownership
     assert sink.teams[("org-1", "ENG")]["native_team_key"] == "ENG"
+
+
+def test_chaos_2547_2544_autoimport_uses_analytics_db_url_with_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def discover_linear(self: object, api_key: str) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="linear",
+                provider_team_id="ENG",
+                name="Engineering",
+                associations={"project_keys": ["ENG"]},
+            )
+        ]
+
+    async def discover_members_linear(
+        self: object, api_key: str, team_key: str
+    ) -> list[DiscoveredMember]:
+        return [
+            DiscoveredMember(
+                provider_type="linear",
+                provider_identity="dev@example.com",
+                display_name="Dev User",
+                email="dev@example.com",
+            )
+        ]
+
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    CapturingClickHouseSink.instances = []
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamDiscoveryService,
+        "discover_linear",
+        discover_linear,
+    )
+    monkeypatch.setattr(
+        team_autoimport_linear.TeamMembershipService,
+        "discover_members_linear",
+        discover_members_linear,
+    )
+    monkeypatch.setattr(
+        team_autoimport_linear,
+        "ClickHouseMetricsSink",
+        CapturingClickHouseSink,
+    )
+
+    summary = team_autoimport.run_team_autoimport(
+        provider="linear",
+        org_id="org-1",
+        credentials={"api_key": "lin-key"},
+        scope={"mode": "sync_config"},
+        analytics_db_url="clickhouse://config-dsn",
+    )
+
+    assert summary["status"] == "success"
+    assert summary["projects_imported"] == 1
+    assert summary["members_imported"] == 1
+    assert summary["team_memberships_imported"] == 1
+    assert summary["team_project_ownership_imported"] == 1
+    assert len(CapturingClickHouseSink.instances) == 1
+    sink = CapturingClickHouseSink.instances[0]
+    assert sink.dsn == "clickhouse://config-dsn"
+    assert sink.closed is True
+    assert ("org-1", "linear", "org-1:linear:ENG") in sink.projects
+    assert ("org-1", "linear:dev@example.com") in sink.members
+    assert (
+        "org-1",
+        "linear",
+        "ENG",
+        "linear:dev@example.com",
+        "native",
+    ) in sink.memberships
 
 
 def test_linear_populate_rerun_keeps_stable_logical_dimension_rows(

--- a/tests/workers/test_team_autoimport_sync_surfaces.py
+++ b/tests/workers/test_team_autoimport_sync_surfaces.py
@@ -22,6 +22,7 @@ def test_sync_runtime_autoimport_false_or_absent_does_not_call(monkeypatch) -> N
             sync_targets=["work-items"],
             config_id="cfg-1",
             triggered_by="manual",
+            analytics_db_url=None,
         )
         is None
     )
@@ -34,6 +35,7 @@ def test_sync_runtime_autoimport_false_or_absent_does_not_call(monkeypatch) -> N
             sync_targets=["work-items"],
             config_id="cfg-1",
             triggered_by="manual",
+            analytics_db_url=None,
         )
         is None
     )
@@ -57,6 +59,7 @@ def test_sync_runtime_autoimport_true_calls_once(monkeypatch) -> None:
         sync_targets=["work-items"],
         config_id="cfg-1",
         triggered_by="schedule",
+        analytics_db_url="clickhouse://config-dsn",
     )
 
     assert result == {"status": "success"}
@@ -65,6 +68,7 @@ def test_sync_runtime_autoimport_true_calls_once(monkeypatch) -> None:
         "provider": "linear",
         "org_id": "org-1",
         "credentials": {"api_key": "secret"},
+        "analytics_db_url": "clickhouse://config-dsn",
         "scope": {
             "mode": "sync_config",
             "sync_config_id": "cfg-1",
@@ -91,6 +95,7 @@ def test_backfill_autoimport_false_or_absent_does_not_call(monkeypatch) -> None:
             since=date(2026, 1, 1),
             before=date(2026, 1, 7),
             window_count=1,
+            analytics_db_url=None,
         )
         is None
     )
@@ -104,6 +109,7 @@ def test_backfill_autoimport_false_or_absent_does_not_call(monkeypatch) -> None:
             since=date(2026, 1, 1),
             before=date(2026, 1, 7),
             window_count=1,
+            analytics_db_url=None,
         )
         is None
     )
@@ -130,6 +136,7 @@ def test_backfill_autoimport_true_calls_once(monkeypatch) -> None:
         since=date(2026, 1, 1),
         before=date(2026, 1, 7),
         window_count=1,
+        analytics_db_url="clickhouse://backfill-dsn",
     )
 
     assert result == {"status": "success"}
@@ -138,6 +145,7 @@ def test_backfill_autoimport_true_calls_once(monkeypatch) -> None:
         "provider": "jira",
         "org_id": "org-1",
         "credentials": {"email": "dev@example.com"},
+        "analytics_db_url": "clickhouse://backfill-dsn",
         "scope": {
             "mode": "backfill",
             "sync_config_id": "cfg-1",

--- a/tests/workers/test_team_autoimport_sync_surfaces.py
+++ b/tests/workers/test_team_autoimport_sync_surfaces.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from dev_health_ops.backfill import runner as backfill_runner
+from dev_health_ops.workers import sync_runtime
+
+
+def test_sync_runtime_autoimport_false_or_absent_does_not_call(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        sync_runtime, "run_team_autoimport", lambda **kwargs: calls.append(kwargs)
+    )
+
+    assert (
+        sync_runtime._run_team_autoimport_for_sync_config(
+            provider="jira",
+            org_id="org-1",
+            credentials={},
+            sync_options={},
+            sync_targets=["work-items"],
+            config_id="cfg-1",
+            triggered_by="manual",
+        )
+        is None
+    )
+    assert (
+        sync_runtime._run_team_autoimport_for_sync_config(
+            provider="jira",
+            org_id="org-1",
+            credentials={},
+            sync_options={"auto_import_teams": False},
+            sync_targets=["work-items"],
+            config_id="cfg-1",
+            triggered_by="manual",
+        )
+        is None
+    )
+    assert calls == []
+
+
+def test_sync_runtime_autoimport_true_calls_once(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_run_team_autoimport(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"status": "success"}
+
+    monkeypatch.setattr(sync_runtime, "run_team_autoimport", fake_run_team_autoimport)
+
+    result = sync_runtime._run_team_autoimport_for_sync_config(
+        provider="linear",
+        org_id="org-1",
+        credentials={"api_key": "secret"},
+        sync_options={"auto_import_teams": True, "team": "CHAOS"},
+        sync_targets=["work-items"],
+        config_id="cfg-1",
+        triggered_by="schedule",
+    )
+
+    assert result == {"status": "success"}
+    assert len(calls) == 1
+    assert calls[0] == {
+        "provider": "linear",
+        "org_id": "org-1",
+        "credentials": {"api_key": "secret"},
+        "scope": {
+            "mode": "sync_config",
+            "sync_config_id": "cfg-1",
+            "sync_targets": ["work-items"],
+            "sync_options": {"auto_import_teams": True, "team": "CHAOS"},
+            "triggered_by": "schedule",
+        },
+    }
+
+
+def test_backfill_autoimport_false_or_absent_does_not_call(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        backfill_runner, "run_team_autoimport", lambda **kwargs: calls.append(kwargs)
+    )
+
+    assert (
+        backfill_runner._run_team_autoimport_for_backfill(
+            provider="jira",
+            org_id="org-1",
+            credentials={},
+            sync_options={},
+            sync_config_id="cfg-1",
+            since=date(2026, 1, 1),
+            before=date(2026, 1, 7),
+            window_count=1,
+        )
+        is None
+    )
+    assert (
+        backfill_runner._run_team_autoimport_for_backfill(
+            provider="jira",
+            org_id="org-1",
+            credentials={},
+            sync_options={"auto_import_teams": False},
+            sync_config_id="cfg-1",
+            since=date(2026, 1, 1),
+            before=date(2026, 1, 7),
+            window_count=1,
+        )
+        is None
+    )
+    assert calls == []
+
+
+def test_backfill_autoimport_true_calls_once(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_run_team_autoimport(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"status": "success"}
+
+    monkeypatch.setattr(
+        backfill_runner, "run_team_autoimport", fake_run_team_autoimport
+    )
+
+    result = backfill_runner._run_team_autoimport_for_backfill(
+        provider="jira",
+        org_id="org-1",
+        credentials={"email": "dev@example.com"},
+        sync_options={"auto_import_teams": True, "project_keys": ["OPS"]},
+        sync_config_id="cfg-1",
+        since=date(2026, 1, 1),
+        before=date(2026, 1, 7),
+        window_count=1,
+    )
+
+    assert result == {"status": "success"}
+    assert len(calls) == 1
+    assert calls[0] == {
+        "provider": "jira",
+        "org_id": "org-1",
+        "credentials": {"email": "dev@example.com"},
+        "scope": {
+            "mode": "backfill",
+            "sync_config_id": "cfg-1",
+            "sync_options": {"auto_import_teams": True, "project_keys": ["OPS"]},
+            "window_count": 1,
+            "since": "2026-01-01",
+            "before": "2026-01-07",
+        },
+    }


### PR DESCRIPTION
## Summary
Consolidated auto-import feature for the CHAOS-2401 epic — turns on population of the team/project/member **ownership dimensions** (migration 051 tables) during provider syncs, so Investment → Allocation stops collapsing to 0% team coverage. Backend half of CHAOS-2543 (the web toggle is a separate dev-health-web PR).

Folds in five work streams + one cross-stream fix (all green together, `CLICKHOUSE_URI` unset):

- **CHAOS-2544** — `auto_import_teams` honored in `sync_runtime` / `sync_batch` / `backfill`, with a conflict-free per-provider dispatch seam (`workers/team_autoimport.py`). Fires once per sync run, capability-gated via `team_capabilities`, no-op + no raise when disabled/unsupported.
- **CHAOS-2545** — Linear/Jira populators write `projects`, `members`, `team_memberships`, `team_project_ownership` (idempotent; `source='manual'` preserved; Jira ops links fold in as `jira_legacy`).
- **CHAOS-2546** — GitHub/GitLab populators write `teams` (+`parent_team_id`), `team_memberships`, `team_repo_ownership`/`team_project_ownership` (`source='provider_access'`); personal/unsupported accounts skip cleanly without erasing manual rows.
- **CHAOS-2547** — integration tests that drive the sync **surface** for all four providers + a regression test that fails if a sync writes `work_items` but skips ownership tables + attribution-resolves-named-teams assertions; manual-QA doc.
- **Fix (CHAOS-2544)** — auto-import now uses the sync's resolved analytics DSN (`scope["analytics_db"]`) instead of relying on the process `CLICKHOUSE_URI` env (silent no-op caught by CHAOS-2547). All four populators standardized on one key.

Reuses existing infrastructure (051 dim tables, sink writers, `TeamDiscoveryService`/`TeamMembershipService`, attribution resolver from CHAOS-2466/2467/2469) — no schema changes, sinks-only persistence.

## Verification
- `CLICKHOUSE_URI= python -m pytest tests/workers/test_team_autoimport_*.py -q` → 23 passed (with env UNSET)
- `mypy` clean (8 modules); `ruff check` clean.

## Manual QA remaining (live payoff)
Enable the toggle (dev-health-web PR) → run a real Linear sync → `dev-hops metrics daily` → confirm Investment → Allocation team coverage > 0% with named teams in a browser. Documented in `docs/architecture/team-attribution.md`.

Closes CHAOS-2544
Closes CHAOS-2545
Closes CHAOS-2546
Closes CHAOS-2547

Supersedes component PRs #984, #986, #987, #988, #989 (they can be closed).
SCREENSHOT-WAIVER: backend + tests + docs only (web toggle screenshots are on the dev-health-web PR).