### PR TITLE
feat(llm): byo_llm feature flag + admin gate + runtime gate (CHAOS-2551)

### DIFF
--- a/src/dev_health_ops/alembic/versions/0017_seed_byo_llm_feature_flag.py
+++ b/src/dev_health_ops/alembic/versions/0017_seed_byo_llm_feature_flag.py
@@ -1,0 +1,78 @@
+"""Seed the byo_llm feature flag.
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-06-19 00:00:00
+
+Adds the ``byo_llm`` feature flag (BYO LLM, analytics, min tier team) to the
+feature_flags table so org BYO-LLM configuration and runtime use of org
+credentials can be gated. Idempotent: INSERT ... WHERE NOT EXISTS, safe to
+re-run. Does NOT edit the historical 0007 seed migration.
+
+Downgrade deletes only the byo_llm row, leaving other flags untouched.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0017"
+down_revision: str | None = "0016"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Alembic reads the four names above via module introspection; declare them
+# as public to quiet `py/unused-global-variable`.
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+# (key, name, category, min_tier) — must stay in sync with STANDARD_FEATURES
+# in licensing/registry.py. Inlined to avoid importing app code at migration
+# runtime.
+_FEATURE_KEY = "byo_llm"
+_FEATURE_NAME = "BYO LLM"
+_FEATURE_CATEGORY = "analytics"
+_FEATURE_MIN_TIER = "team"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    now = datetime.now(timezone.utc)
+
+    # Idempotent: only insert if the key doesn't already exist.
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO feature_flags
+                (id, key, name, category, min_tier, is_enabled, is_beta,
+                 is_deprecated, created_at, updated_at)
+            SELECT :id, :key, :name, :category, :min_tier,
+                   TRUE, FALSE, FALSE, :created_at, :updated_at
+            WHERE NOT EXISTS (
+                SELECT 1 FROM feature_flags WHERE key = :key
+            )
+            """
+        ),
+        {
+            "id": str(uuid.uuid4()),
+            "key": _FEATURE_KEY,
+            "name": _FEATURE_NAME,
+            "category": _FEATURE_CATEGORY,
+            "min_tier": _FEATURE_MIN_TIER,
+            "created_at": now,
+            "updated_at": now,
+        },
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    # Delete only the row seeded by this migration.
+    conn.execute(
+        sa.text("DELETE FROM feature_flags WHERE key = :key"),
+        {"key": _FEATURE_KEY},
+    )

--- a/src/dev_health_ops/alembic/versions/0017_seed_byo_llm_feature_flag.py
+++ b/src/dev_health_ops/alembic/versions/0017_seed_byo_llm_feature_flag.py
@@ -70,9 +70,15 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-    # Delete only the row seeded by this migration.
-    conn.execute(
-        sa.text("DELETE FROM feature_flags WHERE key = :key"),
-        {"key": _FEATURE_KEY},
-    )
+    # Intentionally non-destructive (CHAOS-2551 review): this migration only
+    # idempotently seeds a single data row and creates no schema. Deleting the
+    # byo_llm feature_flags row on downgrade would be unsafe because:
+    #   1. the row may have pre-existed this migration (the upgrade skips insert
+    #      when it already exists), so a delete would remove state we did not
+    #      create; and
+    #   2. org_feature_overrides reference feature_flags.id with ON DELETE
+    #      CASCADE, so deleting the flag would erase admin-configured per-org
+    #      enable/disable state.
+    # Leaving the inert data row in place is the safe rollback; the reverted
+    # application code no longer gates on it.
+    pass

--- a/src/dev_health_ops/api/admin/cli.py
+++ b/src/dev_health_ops/api/admin/cli.py
@@ -161,11 +161,11 @@ def _get_llm_settings_service(
 
 
 async def _require_cli_byo_llm_access(
-    ns: argparse.Namespace, session: AsyncSession
+    ns: argparse.Namespace, session: AsyncSession, *, for_cleanup: bool = False
 ) -> None:
     from dev_health_ops.api.admin.llm_settings import require_byo_llm_access
 
-    await require_byo_llm_access(session, ns.org)
+    await require_byo_llm_access(session, ns.org, for_cleanup=for_cleanup)
 
 
 def _normalize_llm_provider(provider: str | None) -> str:
@@ -255,7 +255,9 @@ async def _llm_settings_delete_async(ns: argparse.Namespace) -> int:
 
     session = await _get_session(ns)
     try:
-        await _require_cli_byo_llm_access(ns, session)
+        # Cleanup must work even when the flag is disabled or the org has been
+        # downgraded below the BYO tier (CHAOS-2551 review).
+        await _require_cli_byo_llm_access(ns, session, for_cleanup=True)
         svc = _get_llm_settings_service(ns, session)
         deleted = await delete_llm_settings(svc)
         if not deleted:

--- a/src/dev_health_ops/api/admin/llm_settings.py
+++ b/src/dev_health_ops/api/admin/llm_settings.py
@@ -34,7 +34,9 @@ class LLMSettingsAccessError(Exception):
         return self.detail.get("message", "BYO LLM settings access denied")
 
 
-async def require_byo_llm_access(session: AsyncSession, org_id: str) -> None:
+async def require_byo_llm_access(
+    session: AsyncSession, org_id: str, *, allow_disabled_flag: bool = False
+) -> None:
     try:
         org_uuid = uuid.UUID(org_id)
     except ValueError as exc:
@@ -84,11 +86,15 @@ async def require_byo_llm_access(session: AsyncSession, org_id: str) -> None:
     # prior tier-only gate. Genuine flag-lookup errors are NOT swallowed -- they
     # propagate so the gate fails CLOSED (request denied) rather than silently
     # allowing BYO access while the licensing store is degraded.
+    #
+    # allow_disabled_flag is set by the DELETE path so an org admin can always
+    # clean up previously stored BYO secrets even after the flag is disabled (a
+    # kill switch must stop reads/writes/runtime use, not trap stored secrets).
     def _flag_state(sync_session):
         return byo_llm_flag_state(sync_session, org_uuid)
 
     state = await session.run_sync(_flag_state)
-    if state == "disabled":
+    if state == "disabled" and not allow_disabled_flag:
         raise LLMSettingsAccessError(
             status_code=403,
             detail={

--- a/src/dev_health_ops/api/admin/llm_settings.py
+++ b/src/dev_health_ops/api/admin/llm_settings.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.admin.schemas import LLMSettingsResponse, LLMSettingsUpsert
 from dev_health_ops.api.services.configuration import SettingsService
-from dev_health_ops.api.services.licensing import resolve_org_tier
+from dev_health_ops.api.services.licensing import FeatureService, resolve_org_tier
 from dev_health_ops.licensing.types import TIER_ORDER, LicenseTier
 from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import SettingCategory
@@ -77,6 +77,31 @@ async def require_byo_llm_access(session: AsyncSession, org_id: str) -> None:
                 "current_tier": tier.value,
             },
         )
+
+    # CHAOS-2551: in addition to the tier gate above, require the byo_llm
+    # feature flag to be enabled (global flag + per-org override). If the flag
+    # is not registered in this environment (pre-migration / minimal DB), skip
+    # this check so behavior matches the prior tier-only gate.
+    def _flag_access(sync_session):
+        return FeatureService(sync_session).check_feature_access(org_uuid, "byo_llm")
+
+    try:
+        access = await session.run_sync(_flag_access)
+    except Exception:
+        access = None
+    if access is not None and not access.allowed:
+        reason = access.reason or ""
+        # Tier already passed above, so a flag-registered denial here is a
+        # disabled global flag or a per-org override, not a tier shortfall.
+        if not reason.startswith("Unknown feature"):
+            raise LLMSettingsAccessError(
+                status_code=403,
+                detail={
+                    "error": "feature_not_enabled",
+                    "feature": "byo_llm",
+                    "message": "BYO LLM is not enabled for this organization",
+                },
+            )
 
 
 def mask_api_key(value: str | None) -> str | None:

--- a/src/dev_health_ops/api/admin/llm_settings.py
+++ b/src/dev_health_ops/api/admin/llm_settings.py
@@ -35,7 +35,7 @@ class LLMSettingsAccessError(Exception):
 
 
 async def require_byo_llm_access(
-    session: AsyncSession, org_id: str, *, allow_disabled_flag: bool = False
+    session: AsyncSession, org_id: str, *, for_cleanup: bool = False
 ) -> None:
     try:
         org_uuid = uuid.UUID(org_id)
@@ -59,6 +59,14 @@ async def require_byo_llm_access(
                 "message": "Organization not found",
             },
         )
+
+    # CHAOS-2551: DELETE/cleanup must always be able to remove previously
+    # stored BYO secrets once org/admin scope is validated. A disabled kill
+    # switch OR a license downgrade (sub-TEAM tier) must stop
+    # reads/writes/runtime use but must NOT trap stored credentials, so cleanup
+    # skips both the tier and feature-flag gates below.
+    if for_cleanup:
+        return
 
     license_result = await session.execute(
         select(OrgLicense).where(OrgLicense.org_id == org_uuid)
@@ -85,16 +93,13 @@ async def require_byo_llm_access(
     # table or an unseeded flag) report "unregistered" and fall back to the
     # prior tier-only gate. Genuine flag-lookup errors are NOT swallowed -- they
     # propagate so the gate fails CLOSED (request denied) rather than silently
-    # allowing BYO access while the licensing store is degraded.
-    #
-    # allow_disabled_flag is set by the DELETE path so an org admin can always
-    # clean up previously stored BYO secrets even after the flag is disabled (a
-    # kill switch must stop reads/writes/runtime use, not trap stored secrets).
+    # allowing BYO access while the licensing store is degraded. (Cleanup/DELETE
+    # returns above and never reaches this gate.)
     def _flag_state(sync_session):
         return byo_llm_flag_state(sync_session, org_uuid)
 
     state = await session.run_sync(_flag_state)
-    if state == "disabled" and not allow_disabled_flag:
+    if state == "disabled":
         raise LLMSettingsAccessError(
             status_code=403,
             detail={

--- a/src/dev_health_ops/api/admin/llm_settings.py
+++ b/src/dev_health_ops/api/admin/llm_settings.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.admin.schemas import LLMSettingsResponse, LLMSettingsUpsert
 from dev_health_ops.api.services.configuration import SettingsService
-from dev_health_ops.api.services.licensing import FeatureService, resolve_org_tier
+from dev_health_ops.api.services.licensing import byo_llm_flag_state, resolve_org_tier
 from dev_health_ops.licensing.types import TIER_ORDER, LicenseTier
 from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import SettingCategory
@@ -79,29 +79,24 @@ async def require_byo_llm_access(session: AsyncSession, org_id: str) -> None:
         )
 
     # CHAOS-2551: in addition to the tier gate above, require the byo_llm
-    # feature flag to be enabled (global flag + per-org override). If the flag
-    # is not registered in this environment (pre-migration / minimal DB), skip
-    # this check so behavior matches the prior tier-only gate.
-    def _flag_access(sync_session):
-        return FeatureService(sync_session).check_feature_access(org_uuid, "byo_llm")
+    # feature flag to be enabled. Pre-migration / minimal DBs (no feature_flags
+    # table or an unseeded flag) report "unregistered" and fall back to the
+    # prior tier-only gate. Genuine flag-lookup errors are NOT swallowed -- they
+    # propagate so the gate fails CLOSED (request denied) rather than silently
+    # allowing BYO access while the licensing store is degraded.
+    def _flag_state(sync_session):
+        return byo_llm_flag_state(sync_session, org_uuid)
 
-    try:
-        access = await session.run_sync(_flag_access)
-    except Exception:
-        access = None
-    if access is not None and not access.allowed:
-        reason = access.reason or ""
-        # Tier already passed above, so a flag-registered denial here is a
-        # disabled global flag or a per-org override, not a tier shortfall.
-        if not reason.startswith("Unknown feature"):
-            raise LLMSettingsAccessError(
-                status_code=403,
-                detail={
-                    "error": "feature_not_enabled",
-                    "feature": "byo_llm",
-                    "message": "BYO LLM is not enabled for this organization",
-                },
-            )
+    state = await session.run_sync(_flag_state)
+    if state == "disabled":
+        raise LLMSettingsAccessError(
+            status_code=403,
+            detail={
+                "error": "feature_not_enabled",
+                "feature": "byo_llm",
+                "message": "BYO LLM is not enabled for this organization",
+            },
+        )
 
 
 def mask_api_key(value: str | None) -> str | None:

--- a/src/dev_health_ops/api/admin/routers/settings.py
+++ b/src/dev_health_ops/api/admin/routers/settings.py
@@ -57,12 +57,10 @@ def _reject_llm_category(category: str) -> None:
 
 
 async def _require_byo_llm_tier(
-    session: AsyncSession, org_id: str, *, allow_disabled_flag: bool = False
+    session: AsyncSession, org_id: str, *, for_cleanup: bool = False
 ) -> None:
     try:
-        await require_byo_llm_access(
-            session, org_id, allow_disabled_flag=allow_disabled_flag
-        )
+        await require_byo_llm_access(session, org_id, for_cleanup=for_cleanup)
     except LLMSettingsAccessError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
@@ -122,8 +120,9 @@ async def delete_llm_settings(
     org_id: str = Depends(get_admin_org_id),
 ) -> dict[str, bool]:
     # DELETE must remain available so an admin can clean up stored BYO secrets
-    # even when the byo_llm flag is disabled (CHAOS-2551 review).
-    await _require_byo_llm_tier(session, org_id, allow_disabled_flag=True)
+    # even when the byo_llm flag is disabled or the org has been downgraded
+    # below the BYO tier (CHAOS-2551 review).
+    await _require_byo_llm_tier(session, org_id, for_cleanup=True)
     svc = SettingsService(session, org_id)
     deleted = await delete_llm_settings_values(svc)
     if not deleted:

--- a/src/dev_health_ops/api/admin/routers/settings.py
+++ b/src/dev_health_ops/api/admin/routers/settings.py
@@ -56,9 +56,13 @@ def _reject_llm_category(category: str) -> None:
         )
 
 
-async def _require_byo_llm_tier(session: AsyncSession, org_id: str) -> None:
+async def _require_byo_llm_tier(
+    session: AsyncSession, org_id: str, *, allow_disabled_flag: bool = False
+) -> None:
     try:
-        await require_byo_llm_access(session, org_id)
+        await require_byo_llm_access(
+            session, org_id, allow_disabled_flag=allow_disabled_flag
+        )
     except LLMSettingsAccessError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
@@ -117,7 +121,9 @@ async def delete_llm_settings(
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> dict[str, bool]:
-    await _require_byo_llm_tier(session, org_id)
+    # DELETE must remain available so an admin can clean up stored BYO secrets
+    # even when the byo_llm flag is disabled (CHAOS-2551 review).
+    await _require_byo_llm_tier(session, org_id, allow_disabled_flag=True)
     svc = SettingsService(session, org_id)
     deleted = await delete_llm_settings_values(svc)
     if not deleted:

--- a/src/dev_health_ops/api/services/licensing.py
+++ b/src/dev_health_ops/api/services/licensing.py
@@ -377,6 +377,27 @@ class FeatureService:
         self._override_cache.clear()
 
 
+def byo_llm_flag_state(session: Session, org_id: uuid.UUID) -> str:
+    """Return the byo_llm flag state: 'enabled' | 'disabled' | 'unregistered'.
+
+    'unregistered' covers pre-migration / minimal DBs where the feature_flags
+    table is absent or the byo_llm row has not been seeded; callers treat it as
+    backward-compatible (ungated). Genuine lookup errors are NOT swallowed --
+    they propagate so callers can fail CLOSED (a kill switch must survive
+    degraded licensing storage rather than silently allow).
+    """
+    import sqlalchemy as sa
+
+    if not sa.inspect(session.get_bind()).has_table("feature_flags"):
+        return "unregistered"
+    access = FeatureService(session).check_feature_access(org_id, "byo_llm")
+    if access.allowed:
+        return "enabled"
+    if (access.reason or "").startswith("Unknown feature"):
+        return "unregistered"
+    return "disabled"
+
+
 class TierLimitService:
     """Tier limit checking and enforcement service.
 

--- a/src/dev_health_ops/api/services/licensing.py
+++ b/src/dev_health_ops/api/services/licensing.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 import jwt
 from jwt.exceptions import InvalidTokenError
 
-from dev_health_ops.licensing.types import LicenseTier
+from dev_health_ops.licensing.types import TIER_ORDER, LicenseTier
 from dev_health_ops.models.licensing import (
     STANDARD_FEATURES,
     TIER_LIMITS_DEFAULTS,
@@ -390,7 +390,17 @@ def byo_llm_flag_state(session: Session, org_id: uuid.UUID) -> str:
 
     if not sa.inspect(session.get_bind()).has_table("feature_flags"):
         return "unregistered"
-    access = FeatureService(session).check_feature_access(org_id, "byo_llm")
+    svc = FeatureService(session)
+    # byo_llm enforces a hard TEAM-tier floor that positive per-org overrides
+    # must NOT bypass (matching the admin gate's tier check). Resolve the tier
+    # directly: check_feature_access honors a positive override before comparing
+    # tier, which would otherwise let a stale override keep BYO active at runtime
+    # for an org downgraded below TEAM.
+    org_license = svc._get_org_license(org_id)
+    org_tier = resolve_org_tier(session, org_id, org_license)
+    if TIER_ORDER.index(org_tier) < TIER_ORDER.index(LicenseTier.TEAM):
+        return "disabled"
+    access = svc.check_feature_access(org_id, "byo_llm")
     if access.allowed:
         return "enabled"
     if (access.reason or "").startswith("Unknown feature"):

--- a/src/dev_health_ops/licensing/registry.py
+++ b/src/dev_health_ops/licensing/registry.py
@@ -202,4 +202,11 @@ STANDARD_FEATURES: list[STANDARD_FEATURE_ROW] = [
         LicenseTier.ENTERPRISE,
         "Priority support SLA",
     ),
+    (
+        "byo_llm",
+        "BYO LLM",
+        FeatureCategory.ANALYTICS,
+        LicenseTier.TEAM,
+        "Bring-your-own LLM provider credentials",
+    ),
 ]

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -66,25 +66,40 @@ def _safe_log_value(value: str) -> str:
     return value.replace("\r", "").replace("\n", "")
 
 
-def _org_byo_llm_enabled(session: Any, org_id: str) -> bool:
-    """Whether the byo_llm feature flag is enabled for this org (CHAOS-2551).
+def _apply_byo_llm_flag_gate(
+    session: Any, org_id: str, settings: dict[str, str]
+) -> dict[str, str]:
+    """Apply the byo_llm feature-flag gate to already-loaded org BYO settings.
 
-    Returns True when the flag is enabled OR unregistered (pre-migration /
-    minimal DB) so behavior matches the prior, ungated resolver. Returns False
-    only when the flag is explicitly disabled (global flag, per-org override,
-    or insufficient tier).
+    Called only when the org HAS BYO settings. Returns the settings unchanged
+    when the flag is enabled OR unregistered (pre-migration / minimal DB), and
+    {} when the flag is explicitly disabled (global flag, per-org override, or
+    insufficient tier) -- the org reverts to the platform default.
 
-    Genuine flag-lookup failures are NOT swallowed here: they propagate to the
-    caller (_load_org_llm_settings), which returns {} so the resolver ignores
-    stored org BYO and falls back to the platform default. A runtime kill
-    switch must fail CLOSED rather than keep using tenant BYO credentials when
-    the licensing store is degraded.
+    A genuine flag-lookup failure for a BYO-configured org is NOT swallowed: it
+    raises LLMAuthError so the resolver fails loudly instead of silently
+    rerouting the tenant's BYO traffic to the platform LLM (a data-residency
+    boundary). Orgs without BYO settings never reach this path, so transient
+    licensing-store errors do not disrupt them.
     """
     import uuid as _uuid
 
     from dev_health_ops.api.services.licensing import byo_llm_flag_state
 
-    return byo_llm_flag_state(session, _uuid.UUID(org_id)) != "disabled"
+    try:
+        state = byo_llm_flag_state(session, _uuid.UUID(org_id))
+    except Exception as exc:
+        raise LLMAuthError(
+            "Unable to determine the byo_llm feature flag state for an "
+            "organization with BYO LLM settings; refusing to resolve so the "
+            "tenant's BYO traffic is not silently rerouted to the platform "
+            "default LLM.",
+            provider="auto",
+            model="none",
+        ) from exc
+    if state == "disabled":
+        return {}
+    return settings
 
 
 def _load_org_llm_settings(org_id: str | None) -> dict[str, str]:
@@ -102,10 +117,6 @@ def _load_org_llm_settings(org_id: str | None) -> dict[str, str]:
 
     try:
         with get_postgres_session_sync() as session:
-            if not _org_byo_llm_enabled(session, org_id):
-                # byo_llm disabled for this org: ignore stored BYO settings so
-                # the resolver falls back to the platform default (CHAOS-2551).
-                return {}
             result = session.execute(
                 select(Setting).where(
                     Setting.org_id == org_id,
@@ -113,20 +124,31 @@ def _load_org_llm_settings(org_id: str | None) -> dict[str, str]:
                 )
             )
             rows: list[Any] = list(result.scalars().all())
+
+            settings: dict[str, str] = {}
+            for row in rows:
+                value = row.value or ""
+                if row.is_encrypted and value:
+                    try:
+                        value = decrypt_value(value)
+                    except ValueError:
+                        continue
+                if value:
+                    settings[str(row.key)] = str(value)
+
+            if not settings:
+                # No org BYO configured: nothing to gate and no data-residency
+                # concern -> platform default (skip the flag lookup entirely).
+                return {}
+
+            # Org HAS BYO settings: gate on the byo_llm feature flag.
+            return _apply_byo_llm_flag_gate(session, org_id, settings)
+    except LLMAuthError:
+        # Controlled flag-lookup failure for a BYO-configured org: propagate so
+        # the resolver does NOT silently reroute the tenant to the platform LLM.
+        raise
     except Exception:
         return {}
-
-    settings: dict[str, str] = {}
-    for row in rows:
-        value = row.value or ""
-        if row.is_encrypted and value:
-            try:
-                value = decrypt_value(value)
-            except ValueError:
-                continue
-        if value:
-            settings[str(row.key)] = str(value)
-    return settings
 
 
 def resolve_llm_org_settings_provider(*, org_id: str | None = None) -> str:

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -69,26 +69,22 @@ def _safe_log_value(value: str) -> str:
 def _org_byo_llm_enabled(session: Any, org_id: str) -> bool:
     """Whether the byo_llm feature flag is enabled for this org (CHAOS-2551).
 
-    Returns True (do NOT gate) when the flag is not registered in this
-    environment (pre-migration / minimal DB) so behavior matches the prior,
-    ungated resolver. Returns False only when the flag exists AND access is
-    denied for this org (global disable, per-org override, or insufficient
-    tier) -- in which case stored org BYO settings are ignored at runtime.
+    Returns True when the flag is enabled OR unregistered (pre-migration /
+    minimal DB) so behavior matches the prior, ungated resolver. Returns False
+    only when the flag is explicitly disabled (global flag, per-org override,
+    or insufficient tier).
+
+    Genuine flag-lookup failures are NOT swallowed here: they propagate to the
+    caller (_load_org_llm_settings), which returns {} so the resolver ignores
+    stored org BYO and falls back to the platform default. A runtime kill
+    switch must fail CLOSED rather than keep using tenant BYO credentials when
+    the licensing store is degraded.
     """
-    try:
-        import uuid as _uuid
+    import uuid as _uuid
 
-        from dev_health_ops.api.services.licensing import FeatureService
+    from dev_health_ops.api.services.licensing import byo_llm_flag_state
 
-        access = FeatureService(session).check_feature_access(
-            _uuid.UUID(org_id), "byo_llm"
-        )
-    except Exception:
-        return True
-    if access.allowed:
-        return True
-    # Unknown feature => flag not registered => do not gate.
-    return (access.reason or "").startswith("Unknown feature")
+    return byo_llm_flag_state(session, _uuid.UUID(org_id)) != "disabled"
 
 
 def _load_org_llm_settings(org_id: str | None) -> dict[str, str]:

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -66,6 +66,31 @@ def _safe_log_value(value: str) -> str:
     return value.replace("\r", "").replace("\n", "")
 
 
+def _org_byo_llm_enabled(session: Any, org_id: str) -> bool:
+    """Whether the byo_llm feature flag is enabled for this org (CHAOS-2551).
+
+    Returns True (do NOT gate) when the flag is not registered in this
+    environment (pre-migration / minimal DB) so behavior matches the prior,
+    ungated resolver. Returns False only when the flag exists AND access is
+    denied for this org (global disable, per-org override, or insufficient
+    tier) -- in which case stored org BYO settings are ignored at runtime.
+    """
+    try:
+        import uuid as _uuid
+
+        from dev_health_ops.api.services.licensing import FeatureService
+
+        access = FeatureService(session).check_feature_access(
+            _uuid.UUID(org_id), "byo_llm"
+        )
+    except Exception:
+        return True
+    if access.allowed:
+        return True
+    # Unknown feature => flag not registered => do not gate.
+    return (access.reason or "").startswith("Unknown feature")
+
+
 def _load_org_llm_settings(org_id: str | None) -> dict[str, str]:
     if not org_id:
         return {}
@@ -81,6 +106,10 @@ def _load_org_llm_settings(org_id: str | None) -> dict[str, str]:
 
     try:
         with get_postgres_session_sync() as session:
+            if not _org_byo_llm_enabled(session, org_id):
+                # byo_llm disabled for this org: ignore stored BYO settings so
+                # the resolver falls back to the platform default (CHAOS-2551).
+                return {}
             result = session.execute(
                 select(Setting).where(
                     Setting.org_id == org_id,

--- a/tests/api/admin/test_byo_llm_feature_flag.py
+++ b/tests/api/admin/test_byo_llm_feature_flag.py
@@ -321,3 +321,30 @@ async def test_admin_gate_allows_cleanup_for_downgraded_org(session_maker):
     async with session_maker() as session:
         # Cleanup bypasses the tier gate too.
         await require_byo_llm_access(session, org_id, for_cleanup=True)
+
+
+@pytest.mark.asyncio
+async def test_runtime_flag_state_tier_floor_beats_positive_override(session_maker):
+    # codex finding: byo_llm enforces a hard TEAM-tier floor at runtime that a
+    # positive per-org override must NOT bypass. A COMMUNITY org with a stale
+    # enabled byo_llm override must resolve to 'disabled' (runtime BYO off),
+    # matching the admin gate which blocks sub-TEAM regardless of override.
+    org_id = await _seed(
+        session_maker, tier="community", flag_enabled=True, override_enabled=True
+    )
+    async with session_maker() as session:
+        state = await session.run_sync(
+            lambda s: licensing_module.byo_llm_flag_state(s, uuid.UUID(org_id))
+        )
+    assert state == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_runtime_flag_state_team_with_override_enabled(session_maker):
+    # Sanity: a TEAM org with the flag enabled resolves to 'enabled' at runtime.
+    org_id = await _seed(session_maker, tier="team", flag_enabled=True)
+    async with session_maker() as session:
+        state = await session.run_sync(
+            lambda s: licensing_module.byo_llm_flag_state(s, uuid.UUID(org_id))
+        )
+    assert state == "enabled"

--- a/tests/api/admin/test_byo_llm_feature_flag.py
+++ b/tests/api/admin/test_byo_llm_feature_flag.py
@@ -56,8 +56,11 @@ def test_byo_llm_registered_at_team_tier():
 
 
 # ---------------------------------------------------------------------------
-# Runtime gate: _org_byo_llm_enabled
+# Runtime gate: _apply_byo_llm_flag_gate / _load_org_llm_settings
 # ---------------------------------------------------------------------------
+
+
+from dev_health_ops.llm.errors import LLMAuthError  # noqa: E402
 
 
 def _patch_flag_state(state_or_exc):
@@ -69,58 +72,99 @@ def _patch_flag_state(state_or_exc):
     return patch.object(licensing_module, "byo_llm_flag_state", _fake)
 
 
-def test_runtime_gate_allows_when_flag_enabled():
+_SETTINGS = {"provider": "openai", "api_key": "sk-org"}
+
+
+def test_flag_gate_returns_settings_when_enabled():
     with _patch_flag_state("enabled"):
-        assert creds._org_byo_llm_enabled(object(), str(uuid.uuid4())) is True
+        out = creds._apply_byo_llm_flag_gate(object(), str(uuid.uuid4()), _SETTINGS)
+    assert out == _SETTINGS
 
 
-def test_runtime_gate_blocks_when_flag_disabled():
-    with _patch_flag_state("disabled"):
-        assert creds._org_byo_llm_enabled(object(), str(uuid.uuid4())) is False
-
-
-def test_runtime_gate_does_not_gate_when_flag_unregistered():
+def test_flag_gate_returns_settings_when_unregistered():
     with _patch_flag_state("unregistered"):
-        assert creds._org_byo_llm_enabled(object(), str(uuid.uuid4())) is True
+        out = creds._apply_byo_llm_flag_gate(object(), str(uuid.uuid4()), _SETTINGS)
+    assert out == _SETTINGS
 
 
-def test_runtime_gate_propagates_real_errors_to_fail_closed():
-    # A genuine flag-lookup error must NOT be swallowed: it propagates so the
-    # caller (_load_org_llm_settings) returns {} -> org BYO ignored (fail closed).
-    with _patch_flag_state(RuntimeError("connection reset mid-query")):
-        with pytest.raises(RuntimeError):
-            creds._org_byo_llm_enabled(object(), str(uuid.uuid4()))
+def test_flag_gate_returns_empty_when_disabled():
+    with _patch_flag_state("disabled"):
+        out = creds._apply_byo_llm_flag_gate(object(), str(uuid.uuid4()), _SETTINGS)
+    assert out == {}
 
 
-def test_load_org_llm_settings_returns_empty_when_flag_disabled():
+def test_flag_gate_raises_on_lookup_error_for_byo_org():
+    # Data-residency: a BYO-configured org must NOT be silently rerouted to the
+    # platform when the flag lookup fails -> raise (fail loudly), not return {}.
+    with _patch_flag_state(RuntimeError("licensing store down")):
+        with pytest.raises(LLMAuthError):
+            creds._apply_byo_llm_flag_gate(object(), str(uuid.uuid4()), _SETTINGS)
+
+
+class _FakeRow:
+    def __init__(self, key, value, is_encrypted=False):
+        self.key = key
+        self.value = value
+        self.is_encrypted = is_encrypted
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._rows
+
+
+class _FakeSession:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def execute(self, *_a, **_k):
+        return _FakeResult(self._rows)
+
+
+def _patch_session(rows):
     @contextlib.contextmanager
-    def _fake_session():
-        yield object()
+    def _cm():
+        yield _FakeSession(rows)
 
-    with (
-        patch.object(creds, "_org_byo_llm_enabled", return_value=False),
-        patch("dev_health_ops.db.get_postgres_session_sync", _fake_session),
-    ):
-        # A real org_id with the flag disabled -> stored BYO settings ignored.
-        assert creds._load_org_llm_settings(str(uuid.uuid4())) == {}
+    return patch("dev_health_ops.db.get_postgres_session_sync", _cm)
 
 
-def test_load_org_llm_settings_fails_closed_when_flag_lookup_errors():
-    # If the flag lookup raises, _load_org_llm_settings must return {} (fail
-    # closed: ignore stored org BYO; the resolver uses the platform default).
-    @contextlib.contextmanager
-    def _fake_session():
-        yield object()
+def test_load_settings_byo_org_flag_enabled_returns_settings():
+    rows = [_FakeRow("provider", "openai"), _FakeRow("api_key", "sk-org")]
+    with _patch_session(rows), _patch_flag_state("enabled"):
+        out = creds._load_org_llm_settings(str(uuid.uuid4()))
+    assert out == {"provider": "openai", "api_key": "sk-org"}
 
-    with (
-        patch.object(
-            creds,
-            "_org_byo_llm_enabled",
-            side_effect=RuntimeError("flag store down"),
-        ),
-        patch("dev_health_ops.db.get_postgres_session_sync", _fake_session),
-    ):
-        assert creds._load_org_llm_settings(str(uuid.uuid4())) == {}
+
+def test_load_settings_byo_org_flag_disabled_returns_empty():
+    rows = [_FakeRow("provider", "openai"), _FakeRow("api_key", "sk-org")]
+    with _patch_session(rows), _patch_flag_state("disabled"):
+        out = creds._load_org_llm_settings(str(uuid.uuid4()))
+    assert out == {}
+
+
+def test_load_settings_byo_org_flag_error_raises_no_silent_reroute():
+    # codex finding: a BYO-configured org hitting a flag-lookup error must raise
+    # (no silent reroute to the platform LLM), NOT return {}.
+    rows = [_FakeRow("provider", "openai"), _FakeRow("api_key", "sk-org")]
+    with _patch_session(rows), _patch_flag_state(RuntimeError("store down")):
+        with pytest.raises(LLMAuthError):
+            creds._load_org_llm_settings(str(uuid.uuid4()))
+
+
+def test_load_settings_non_byo_org_flag_error_returns_empty():
+    # An org with NO BYO settings is unaffected by a flag-lookup error: there is
+    # nothing to gate and no residency concern, so it returns {} (no raise) and
+    # never even performs the flag lookup.
+    with _patch_session([]), _patch_flag_state(RuntimeError("store down")):
+        out = creds._load_org_llm_settings(str(uuid.uuid4()))
+    assert out == {}
 
 
 # ---------------------------------------------------------------------------
@@ -246,3 +290,19 @@ async def test_admin_gate_fails_closed_when_flag_lookup_errors(session_maker):
         async with session_maker() as session:
             with pytest.raises(RuntimeError):
                 await require_byo_llm_access(session, org_id)
+
+
+@pytest.mark.asyncio
+async def test_admin_gate_allows_cleanup_when_flag_disabled(session_maker):
+    # codex finding: a kill switch must stop reads/writes/runtime use but must
+    # NOT trap stored secrets. The DELETE path passes allow_disabled_flag=True
+    # so an admin can clean up BYO settings even when the flag is disabled.
+    org_id = await _seed(session_maker, tier="team", flag_enabled=False)
+    async with session_maker() as session:
+        # Default (PUT/GET) still denied ...
+        with pytest.raises(LLMSettingsAccessError) as exc:
+            await require_byo_llm_access(session, org_id)
+        assert exc.value.detail["error"] == "feature_not_enabled"
+    async with session_maker() as session:
+        # ... but cleanup (DELETE) is allowed.
+        await require_byo_llm_access(session, org_id, allow_disabled_flag=True)

--- a/tests/api/admin/test_byo_llm_feature_flag.py
+++ b/tests/api/admin/test_byo_llm_feature_flag.py
@@ -1,0 +1,232 @@
+"""CHAOS-2551: byo_llm feature flag + admin gate + runtime gate.
+
+Verifies:
+- The byo_llm flag is registered at TEAM tier in the canonical registry.
+- The admin gate (require_byo_llm_access) enforces BOTH tier and the byo_llm
+  flag, with distinct errors: feature_not_licensed (tier) vs feature_not_enabled
+  (flag disabled). When the flag is not registered (minimal/legacy DB) it falls
+  back to the prior tier-only behavior.
+- The runtime gate (_org_byo_llm_enabled / _load_org_llm_settings) ignores
+  stored org BYO settings when the flag is disabled for the org, and is
+  graceful (does not gate) when the flag is unregistered/unverifiable.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.admin.llm_settings import (
+    LLMSettingsAccessError,
+    require_byo_llm_access,
+)
+from dev_health_ops.api.services import licensing as licensing_module
+from dev_health_ops.licensing.registry import get_features_for_tier
+from dev_health_ops.licensing.types import LicenseTier
+from dev_health_ops.llm import credentials as creds
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.licensing import FeatureFlag, OrgFeatureOverride, OrgLicense
+from dev_health_ops.models.users import Organization, User
+from tests._helpers import tables_of
+
+os.environ.setdefault("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+
+_TABLES = tables_of(User, Organization, OrgLicense, FeatureFlag, OrgFeatureOverride)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_byo_llm_registered_at_team_tier():
+    community = get_features_for_tier(LicenseTier.COMMUNITY)
+    team = get_features_for_tier(LicenseTier.TEAM)
+    enterprise = get_features_for_tier(LicenseTier.ENTERPRISE)
+    assert community.get("byo_llm") is False
+    assert team.get("byo_llm") is True
+    assert enterprise.get("byo_llm") is True
+
+
+# ---------------------------------------------------------------------------
+# Runtime gate: _org_byo_llm_enabled
+# ---------------------------------------------------------------------------
+
+
+class _Access:
+    def __init__(self, allowed: bool, reason: str = ""):
+        self.allowed = allowed
+        self.reason = reason
+
+
+def _patch_feature_service(access_or_exc):
+    class _Svc:
+        def __init__(self, _session):
+            pass
+
+        def check_feature_access(self, _org, _key):
+            if isinstance(access_or_exc, Exception):
+                raise access_or_exc
+            return access_or_exc
+
+    return patch.object(licensing_module, "FeatureService", _Svc)
+
+
+def test_runtime_gate_allows_when_flag_enabled():
+    with _patch_feature_service(_Access(True)):
+        assert creds._org_byo_llm_enabled(object(), str(uuid.uuid4())) is True
+
+
+def test_runtime_gate_blocks_when_flag_disabled():
+    with _patch_feature_service(_Access(False, "Feature is globally disabled")):
+        assert creds._org_byo_llm_enabled(object(), str(uuid.uuid4())) is False
+
+
+def test_runtime_gate_blocks_when_org_override_disabled():
+    with _patch_feature_service(
+        _Access(False, "Feature disabled for this organization")
+    ):
+        assert creds._org_byo_llm_enabled(object(), str(uuid.uuid4())) is False
+
+
+def test_runtime_gate_does_not_gate_when_flag_unregistered():
+    with _patch_feature_service(_Access(False, "Unknown feature: byo_llm")):
+        assert creds._org_byo_llm_enabled(object(), str(uuid.uuid4())) is True
+
+
+def test_runtime_gate_graceful_on_error():
+    with _patch_feature_service(RuntimeError("no such table: feature_flags")):
+        assert creds._org_byo_llm_enabled(object(), str(uuid.uuid4())) is True
+
+
+def test_load_org_llm_settings_returns_empty_when_flag_disabled():
+    @contextlib.contextmanager
+    def _fake_session():
+        yield object()
+
+    with (
+        patch.object(creds, "_org_byo_llm_enabled", return_value=False),
+        patch(
+            "dev_health_ops.db.get_postgres_session_sync",
+            _fake_session,
+        ),
+    ):
+        # A real org_id with the flag disabled -> stored BYO settings ignored.
+        assert creds._load_org_llm_settings(str(uuid.uuid4())) == {}
+
+
+# ---------------------------------------------------------------------------
+# Admin gate: require_byo_llm_access
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    db_path = tmp_path / "byo-llm-flag.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("POSTGRES_URI", f"sqlite:///{db_path}")
+    engine = create_async_engine(async_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def _seed(
+    session_maker,
+    *,
+    tier: str = "team",
+    flag_enabled: bool | None = True,
+    override_enabled: bool | None = None,
+) -> str:
+    """Seed an org (+license) and optionally the byo_llm flag/override.
+
+    flag_enabled=None omits the FeatureFlag row entirely (unregistered).
+    """
+    org_id = uuid.uuid4()
+    async with session_maker() as session:
+        session.add_all(
+            [
+                Organization(id=org_id, slug=f"{tier}-org", name="Org", tier=tier),
+                OrgLicense(org_id=org_id, tier=tier),
+            ]
+        )
+        if flag_enabled is not None:
+            flag = FeatureFlag(
+                key="byo_llm",
+                name="BYO LLM",
+                category="analytics",
+                min_tier="team",
+                is_enabled=flag_enabled,
+            )
+            session.add(flag)
+            await session.flush()
+            if override_enabled is not None:
+                session.add(
+                    OrgFeatureOverride(
+                        org_id=org_id,
+                        feature_id=flag.id,
+                        is_enabled=override_enabled,
+                    )
+                )
+        await session.commit()
+    return str(org_id)
+
+
+@pytest.mark.asyncio
+async def test_admin_gate_allows_team_with_flag_enabled(session_maker):
+    org_id = await _seed(session_maker, tier="team", flag_enabled=True)
+    async with session_maker() as session:
+        await require_byo_llm_access(session, org_id)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_admin_gate_blocks_when_flag_globally_disabled(session_maker):
+    org_id = await _seed(session_maker, tier="team", flag_enabled=False)
+    async with session_maker() as session:
+        with pytest.raises(LLMSettingsAccessError) as exc:
+            await require_byo_llm_access(session, org_id)
+    assert exc.value.status_code == 403
+    assert exc.value.detail["error"] == "feature_not_enabled"
+
+
+@pytest.mark.asyncio
+async def test_admin_gate_blocks_when_org_override_disables(session_maker):
+    org_id = await _seed(
+        session_maker, tier="team", flag_enabled=True, override_enabled=False
+    )
+    async with session_maker() as session:
+        with pytest.raises(LLMSettingsAccessError) as exc:
+            await require_byo_llm_access(session, org_id)
+    assert exc.value.status_code == 403
+    assert exc.value.detail["error"] == "feature_not_enabled"
+
+
+@pytest.mark.asyncio
+async def test_admin_gate_blocks_community_tier_as_not_licensed(session_maker):
+    org_id = await _seed(session_maker, tier="community", flag_enabled=True)
+    async with session_maker() as session:
+        with pytest.raises(LLMSettingsAccessError) as exc:
+            await require_byo_llm_access(session, org_id)
+    assert exc.value.status_code == 402
+    assert exc.value.detail["error"] == "feature_not_licensed"
+
+
+@pytest.mark.asyncio
+async def test_admin_gate_falls_back_to_tier_when_flag_unregistered(session_maker):
+    # No FeatureFlag row at all: behaves like the prior tier-only gate.
+    org_id = await _seed(session_maker, tier="team", flag_enabled=None)
+    async with session_maker() as session:
+        await require_byo_llm_access(session, org_id)  # must not raise

--- a/tests/api/admin/test_byo_llm_feature_flag.py
+++ b/tests/api/admin/test_byo_llm_feature_flag.py
@@ -295,8 +295,8 @@ async def test_admin_gate_fails_closed_when_flag_lookup_errors(session_maker):
 @pytest.mark.asyncio
 async def test_admin_gate_allows_cleanup_when_flag_disabled(session_maker):
     # codex finding: a kill switch must stop reads/writes/runtime use but must
-    # NOT trap stored secrets. The DELETE path passes allow_disabled_flag=True
-    # so an admin can clean up BYO settings even when the flag is disabled.
+    # NOT trap stored secrets. The DELETE path passes for_cleanup=True so an
+    # admin can clean up BYO settings even when the flag is disabled.
     org_id = await _seed(session_maker, tier="team", flag_enabled=False)
     async with session_maker() as session:
         # Default (PUT/GET) still denied ...
@@ -305,4 +305,19 @@ async def test_admin_gate_allows_cleanup_when_flag_disabled(session_maker):
         assert exc.value.detail["error"] == "feature_not_enabled"
     async with session_maker() as session:
         # ... but cleanup (DELETE) is allowed.
-        await require_byo_llm_access(session, org_id, allow_disabled_flag=True)
+        await require_byo_llm_access(session, org_id, for_cleanup=True)
+
+
+@pytest.mark.asyncio
+async def test_admin_gate_allows_cleanup_for_downgraded_org(session_maker):
+    # codex finding: a license downgrade must not trap stored secrets either.
+    # A COMMUNITY-tier org (downgraded below the BYO tier) is denied PUT/GET
+    # (feature_not_licensed) but can still DELETE/clean up via for_cleanup.
+    org_id = await _seed(session_maker, tier="community", flag_enabled=True)
+    async with session_maker() as session:
+        with pytest.raises(LLMSettingsAccessError) as exc:
+            await require_byo_llm_access(session, org_id)
+        assert exc.value.detail["error"] == "feature_not_licensed"
+    async with session_maker() as session:
+        # Cleanup bypasses the tier gate too.
+        await require_byo_llm_access(session, org_id, for_cleanup=True)

--- a/tests/api/admin/test_byo_llm_feature_flag.py
+++ b/tests/api/admin/test_byo_llm_feature_flag.py
@@ -60,50 +60,36 @@ def test_byo_llm_registered_at_team_tier():
 # ---------------------------------------------------------------------------
 
 
-class _Access:
-    def __init__(self, allowed: bool, reason: str = ""):
-        self.allowed = allowed
-        self.reason = reason
+def _patch_flag_state(state_or_exc):
+    def _fake(_session, _org_id):
+        if isinstance(state_or_exc, Exception):
+            raise state_or_exc
+        return state_or_exc
 
-
-def _patch_feature_service(access_or_exc):
-    class _Svc:
-        def __init__(self, _session):
-            pass
-
-        def check_feature_access(self, _org, _key):
-            if isinstance(access_or_exc, Exception):
-                raise access_or_exc
-            return access_or_exc
-
-    return patch.object(licensing_module, "FeatureService", _Svc)
+    return patch.object(licensing_module, "byo_llm_flag_state", _fake)
 
 
 def test_runtime_gate_allows_when_flag_enabled():
-    with _patch_feature_service(_Access(True)):
+    with _patch_flag_state("enabled"):
         assert creds._org_byo_llm_enabled(object(), str(uuid.uuid4())) is True
 
 
 def test_runtime_gate_blocks_when_flag_disabled():
-    with _patch_feature_service(_Access(False, "Feature is globally disabled")):
-        assert creds._org_byo_llm_enabled(object(), str(uuid.uuid4())) is False
-
-
-def test_runtime_gate_blocks_when_org_override_disabled():
-    with _patch_feature_service(
-        _Access(False, "Feature disabled for this organization")
-    ):
+    with _patch_flag_state("disabled"):
         assert creds._org_byo_llm_enabled(object(), str(uuid.uuid4())) is False
 
 
 def test_runtime_gate_does_not_gate_when_flag_unregistered():
-    with _patch_feature_service(_Access(False, "Unknown feature: byo_llm")):
+    with _patch_flag_state("unregistered"):
         assert creds._org_byo_llm_enabled(object(), str(uuid.uuid4())) is True
 
 
-def test_runtime_gate_graceful_on_error():
-    with _patch_feature_service(RuntimeError("no such table: feature_flags")):
-        assert creds._org_byo_llm_enabled(object(), str(uuid.uuid4())) is True
+def test_runtime_gate_propagates_real_errors_to_fail_closed():
+    # A genuine flag-lookup error must NOT be swallowed: it propagates so the
+    # caller (_load_org_llm_settings) returns {} -> org BYO ignored (fail closed).
+    with _patch_flag_state(RuntimeError("connection reset mid-query")):
+        with pytest.raises(RuntimeError):
+            creds._org_byo_llm_enabled(object(), str(uuid.uuid4()))
 
 
 def test_load_org_llm_settings_returns_empty_when_flag_disabled():
@@ -113,12 +99,27 @@ def test_load_org_llm_settings_returns_empty_when_flag_disabled():
 
     with (
         patch.object(creds, "_org_byo_llm_enabled", return_value=False),
-        patch(
-            "dev_health_ops.db.get_postgres_session_sync",
-            _fake_session,
-        ),
+        patch("dev_health_ops.db.get_postgres_session_sync", _fake_session),
     ):
         # A real org_id with the flag disabled -> stored BYO settings ignored.
+        assert creds._load_org_llm_settings(str(uuid.uuid4())) == {}
+
+
+def test_load_org_llm_settings_fails_closed_when_flag_lookup_errors():
+    # If the flag lookup raises, _load_org_llm_settings must return {} (fail
+    # closed: ignore stored org BYO; the resolver uses the platform default).
+    @contextlib.contextmanager
+    def _fake_session():
+        yield object()
+
+    with (
+        patch.object(
+            creds,
+            "_org_byo_llm_enabled",
+            side_effect=RuntimeError("flag store down"),
+        ),
+        patch("dev_health_ops.db.get_postgres_session_sync", _fake_session),
+    ):
         assert creds._load_org_llm_settings(str(uuid.uuid4())) == {}
 
 
@@ -230,3 +231,18 @@ async def test_admin_gate_falls_back_to_tier_when_flag_unregistered(session_make
     org_id = await _seed(session_maker, tier="team", flag_enabled=None)
     async with session_maker() as session:
         await require_byo_llm_access(session, org_id)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_admin_gate_fails_closed_when_flag_lookup_errors(session_maker):
+    # codex finding: the admin gate must NOT swallow a genuine flag-lookup
+    # error and then allow the request. A real error propagates -> the request
+    # is denied (fail closed), even for a TEAM-tier org.
+    org_id = await _seed(session_maker, tier="team", flag_enabled=True)
+    with patch(
+        "dev_health_ops.api.admin.llm_settings.byo_llm_flag_state",
+        side_effect=RuntimeError("licensing store unavailable"),
+    ):
+        async with session_maker() as session:
+            with pytest.raises(RuntimeError):
+                await require_byo_llm_access(session, org_id)

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -855,7 +855,7 @@ def test_validate_bundle_feature_keys_empty_succeeds():
 
 
 def test_validate_bundle_feature_keys_all_standard():
-    """All 25 STANDARD_FEATURES keys pass validation."""
+    """All STANDARD_FEATURES keys pass validation."""
     from dev_health_ops.api.billing.bundle_validation import (
         validate_bundle_feature_keys,
     )

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -1224,9 +1224,9 @@ class TestGetFeaturesForTier:
         enterprise = get_features_for_tier(LicenseTier.ENTERPRISE)
         assert set(community.keys()) == set(team.keys()) == set(enterprise.keys())
 
-    def test_returns_25_features(self):
+    def test_returns_26_features(self):
         features = get_features_for_tier(LicenseTier.COMMUNITY)
-        assert len(features) == 25
+        assert len(features) == 26
 
     def test_sign_license_uses_canonical_registry(self):
         """sign_license() with no explicit features uses get_features_for_tier."""


### PR DESCRIPTION
## Summary

Adds a new **`byo_llm`** feature flag (not a reuse of `llm_categorization`, per locked decision #3) that gates both org BYO-LLM configuration and runtime use of org credentials. Builds on CHAOS-2550's source-bound resolver.

- **`licensing/registry.py`**: register `byo_llm` (BYO LLM, ANALYTICS, min tier TEAM).
- **`alembic/versions/0017_seed_byo_llm_feature_flag.py`**: idempotent seed (`down_revision = 0016`), mirrors the `0007` `INSERT ... WHERE NOT EXISTS` pattern; does **not** edit historical `0007`.
- **`api/admin/llm_settings.py`** (`require_byo_llm_access`): now enforces tier **AND** the `byo_llm` flag (`FeatureService.check_feature_access`), with distinct errors:
  - `feature_not_licensed` (402) — tier below TEAM.
  - `feature_not_enabled` (403) — flag disabled globally or via per-org override.
  - Falls back to the prior **tier-only** gate when the flag is not registered (pre-migration / minimal DB) — backward compatible.
  Gates GET/PUT/DELETE `/admin/llm-settings` (the router already routes all three through this helper).
- **`llm/credentials.py`** (`_load_org_llm_settings`): returns `{}` when `byo_llm` is disabled for the org, so the resolver transparently falls back to the platform default at runtime. Graceful (does not gate) when the flag is unregistered/unverifiable.

## Test plan

New `tests/api/admin/test_byo_llm_feature_flag.py` (12 cases):
- Registry: `byo_llm` is TEAM-tier (COMMUNITY false, TEAM/ENTERPRISE true).
- Runtime gate `_org_byo_llm_enabled`: enabled→allow, globally-disabled→gate, override-disabled→gate, unknown-feature→don't gate, error→don't gate; `_load_org_llm_settings` returns `{}` when disabled.
- Admin gate `require_byo_llm_access`: TEAM+enabled allowed; globally-disabled and override-disabled → `feature_not_enabled` (403); COMMUNITY → `feature_not_licensed` (402); unregistered flag → tier-only (allowed).

Updated the canonical feature-count assertion (25 → 26) and a billing docstring.

Gates: `pytest` green on Python 3.11 and 3.13 (new file + licensing/billing/admin/resolver regression suites, 187 passed on 3.11); `mypy` clean; `ruff` clean.

SCREENSHOT-WAIVER: backend-only change (feature flag + API gate); no rendered frontend output altered. (Web gating is the optional follow-on CHAOS-2553.)

Closes CHAOS-2551