### PR TITLE
fix(sync): planner zero-child create, paused-trigger guard, planner last_sync stamp (CHAOS-2555/2556/2557)

### DIFF
--- a/src/dev_health_ops/alembic/versions/0018_add_sync_config_planner_managed.py
+++ b/src/dev_health_ops/alembic/versions/0018_add_sync_config_planner_managed.py
@@ -1,0 +1,37 @@
+"""Add explicit planner-managed sync config marker.
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-06-19 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0018"
+down_revision: str | None = "0017"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sync_configurations",
+        sa.Column(
+            "planner_managed",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sync_configurations", "planner_managed")

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -1354,7 +1354,8 @@ async def trigger_sync_config_backfill(
                     sync_session, config, org_id, "backfill"
                 )
             )
-            await session.commit()
+
+        await session.commit()
 
         result = getattr(run_backfill, "delay")(
             sync_config_id=str(config.id),
@@ -1365,7 +1366,7 @@ async def trigger_sync_config_backfill(
             pending_run_id=pending_run_id,
         )
         backfill_job.celery_task_id = result.id
-        await session.flush()
+        await session.commit()
         return {
             "status": "accepted",
             "config_id": str(config.id),

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -1283,6 +1283,11 @@ async def trigger_sync_config_backfill(
     config = await svc.get_by_id(config_id)
     if config is None:
         raise HTTPException(status_code=404, detail="Sync configuration not found")
+    if not bool(getattr(config, "is_active", False)):
+        raise HTTPException(
+            status_code=409,
+            detail="Sync configuration is paused and cannot be backfilled",
+        )
 
     requested_days = (payload.before - payload.since).days
 

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -77,6 +77,24 @@ def _mark_job_run_failed(sync_session, run_id: str, error: str) -> None:
     sync_session.flush()
 
 
+def _mark_backfill_job_failed(
+    sync_session, backfill_job_id: str, error: str, completed_at: datetime
+) -> None:
+    from dev_health_ops.models.backfill import BackfillJob as BackfillJobModel
+
+    bf_job = (
+        sync_session.query(BackfillJobModel)
+        .filter(BackfillJobModel.id == uuid.UUID(str(backfill_job_id)))
+        .one_or_none()
+    )
+    if bf_job is None:
+        return
+    bf_job.status = "failed"
+    bf_job.error_message = error
+    bf_job.completed_at = completed_at
+    sync_session.flush()
+
+
 def _ensure_pending_sync_job_run(
     sync_session, config, org_id: str, triggered_by: str
 ) -> str:
@@ -1357,14 +1375,31 @@ async def trigger_sync_config_backfill(
 
         await session.commit()
 
-        result = getattr(run_backfill, "delay")(
-            sync_config_id=str(config.id),
-            since=payload.since.isoformat(),
-            before=payload.before.isoformat(),
-            org_id=org_id,
-            backfill_job_id=backfill_job_id,
-            pending_run_id=pending_run_id,
-        )
+        try:
+            result = getattr(run_backfill, "delay")(
+                sync_config_id=str(config.id),
+                since=payload.since.isoformat(),
+                before=payload.before.isoformat(),
+                org_id=org_id,
+                backfill_job_id=backfill_job_id,
+                pending_run_id=pending_run_id,
+            )
+        except Exception as e:
+            error_message = f"enqueue failed: {e}"
+            completed_at = datetime.now(timezone.utc)
+            await session.run_sync(
+                lambda sync_session: _mark_backfill_job_failed(
+                    sync_session, backfill_job_id, error_message, completed_at
+                )
+            )
+            if pending_run_id is not None:
+                await session.run_sync(
+                    lambda sync_session: _mark_job_run_failed(
+                        sync_session, pending_run_id, error_message
+                    )
+                )
+            await session.commit()
+            raise HTTPException(status_code=503, detail=f"Task queue unavailable: {e}")
         backfill_job.celery_task_id = result.id
         await session.commit()
         return {
@@ -1376,6 +1411,8 @@ async def trigger_sync_config_backfill(
             "since": payload.since.isoformat(),
             "before": payload.before.isoformat(),
         }
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=503, detail=f"Task queue unavailable: {e}")
 

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -8,7 +8,7 @@ from typing import Any, Protocol, cast
 
 from croniter import croniter as Croniter
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.admin.middleware import get_admin_org_id
@@ -201,6 +201,24 @@ async def _active_repo_usage_count_for_limit(session: AsyncSession, org_id: str)
         )
     )
     return legacy_count + int(source_count or 0)
+
+
+def _repo_limit_advisory_lock_key(org_id: str) -> int:
+    try:
+        org_int = uuid.UUID(org_id).int
+    except ValueError:
+        org_int = uuid.uuid5(uuid.NAMESPACE_URL, org_id).int
+    return org_int & ((1 << 63) - 1)
+
+
+async def _acquire_repo_limit_create_lock(session: AsyncSession, org_id: str) -> None:
+    bind = session.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    await session.execute(
+        text("SELECT pg_advisory_xact_lock(:lock_key)"),
+        {"lock_key": _repo_limit_advisory_lock_key(org_id)},
+    )
 
 
 class _MutableSyncConfiguration(Protocol):
@@ -762,6 +780,7 @@ async def batch_create_sync_configs(
         This endpoint will create the parent config only (zero children) when
         the planner flag is enabled.
     """
+    await _acquire_repo_limit_create_lock(session, org_id)
     current_count = await _active_repo_usage_count_for_limit(session, org_id)
     new_count = len(payload.repos)
 
@@ -869,6 +888,7 @@ async def create_sync_config(
     svc = SyncConfigurationService(session, org_id)
 
     # Fix 1 (HIGH): Enforce repo limit before creating a new sync config.
+    await _acquire_repo_limit_create_lock(session, org_id)
     current_count = await _active_repo_usage_count_for_limit(session, org_id)
 
     def _check_repo_limit(sync_session) -> tuple[bool, str | None]:

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -44,7 +44,6 @@ from dev_health_ops.sync.datasets import supported_datasets, supported_legacy_ta
 from dev_health_ops.sync.planner import plan_sync_run
 from dev_health_ops.sync.trigger_routing import (
     mark_sync_run_failed,
-    plan_request_for_config,
     planner_request_for_config_if_routed,
 )
 from dev_health_ops.workers.queues import sync_queue_for_provider
@@ -168,10 +167,7 @@ async def _is_planner_active(session: AsyncSession, org_id: str) -> bool:
     return await session.run_sync(_check)
 
 
-async def _active_repo_count_for_batch_limit(
-    session: AsyncSession, org_id: str, provider: str
-) -> int:
-    _ = provider
+async def _active_repo_usage_count_for_limit(session: AsyncSession, org_id: str) -> int:
     active_configs = await session.execute(
         select(SyncConfiguration).where(
             SyncConfiguration.org_id == org_id,
@@ -179,17 +175,12 @@ async def _active_repo_count_for_batch_limit(
         )
     )
     active_config_rows = list(active_configs.scalars().all())
-    parent_ids_with_children = {
-        config.parent_id
-        for config in active_config_rows
-        if config.parent_id is not None
-    }
     planner_parent_ids = [
         config.id
         for config in active_config_rows
         if config.parent_id is None
+        and bool(config.planner_managed)
         and config.migrated_integration_id is not None
-        and config.id not in parent_ids_with_children
     ]
     planner_integration_ids = [
         config.migrated_integration_id
@@ -771,9 +762,7 @@ async def batch_create_sync_configs(
         This endpoint will create the parent config only (zero children) when
         the planner flag is enabled.
     """
-    current_count = await _active_repo_count_for_batch_limit(
-        session, org_id, payload.provider
-    )
+    current_count = await _active_repo_usage_count_for_limit(session, org_id)
     new_count = len(payload.repos)
 
     def _check_limit(sync_session) -> tuple[bool, str | None]:
@@ -836,6 +825,7 @@ async def batch_create_sync_configs(
         sync_options=parent_options,
         is_active=True,
         migrated_integration_id=integration.id,
+        planner_managed=True,
     )
     session.add(parent)
     await session.flush()
@@ -879,8 +869,7 @@ async def create_sync_config(
     svc = SyncConfigurationService(session, org_id)
 
     # Fix 1 (HIGH): Enforce repo limit before creating a new sync config.
-    existing_configs = await svc.list_all(active_only=True)
-    current_count = len(existing_configs)
+    current_count = await _active_repo_usage_count_for_limit(session, org_id)
 
     def _check_repo_limit(sync_session) -> tuple[bool, str | None]:
         tier_svc = TierLimitService(sync_session)
@@ -1309,21 +1298,11 @@ async def trigger_sync_config_backfill(
     from dev_health_ops.models.backfill import BackfillJob as BackfillJobModel
 
     windows = chunk_date_range(since=payload.since, before=payload.before, chunk_days=7)
-    fanout_env = os.getenv("SYNC_FANOUT_BACKFILL", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
     planner_backfill_request = await session.run_sync(
         lambda sync_session: planner_request_for_config_if_routed(
             sync_session, config, triggered_by="backfill", mode="backfill"
         )
     )
-    if planner_backfill_request is None and fanout_env:
-        planner_backfill_request = plan_request_for_config(
-            config, triggered_by="backfill", mode="backfill"
-        )
     fanout_backfill = planner_backfill_request is not None
     backfill_job = BackfillJobModel(
         org_id=org_id,

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -8,7 +8,7 @@ from typing import Any, Protocol, cast
 
 from croniter import croniter as Croniter
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.admin.middleware import get_admin_org_id
@@ -44,6 +44,7 @@ from dev_health_ops.sync.datasets import supported_datasets, supported_legacy_ta
 from dev_health_ops.sync.planner import plan_sync_run
 from dev_health_ops.sync.trigger_routing import (
     mark_sync_run_failed,
+    plan_request_for_config,
     planner_request_for_config_if_routed,
 )
 from dev_health_ops.workers.queues import sync_queue_for_provider
@@ -165,6 +166,51 @@ async def _is_planner_active(session: AsyncSession, org_id: str) -> bool:
         }
 
     return await session.run_sync(_check)
+
+
+async def _active_repo_count_for_batch_limit(
+    session: AsyncSession, org_id: str, provider: str
+) -> int:
+    provider_normalized = provider.lower()
+    active_configs = await session.execute(
+        select(SyncConfiguration).where(
+            SyncConfiguration.org_id == org_id,
+            SyncConfiguration.is_active.is_(True),
+        )
+    )
+    active_config_rows = list(active_configs.scalars().all())
+    parent_ids_with_children = {
+        config.parent_id
+        for config in active_config_rows
+        if config.parent_id is not None
+    }
+    planner_parent_ids = [
+        config.id
+        for config in active_config_rows
+        if str(config.provider or "").lower() == provider_normalized
+        and config.parent_id is None
+        and config.migrated_integration_id is not None
+        and config.id not in parent_ids_with_children
+    ]
+    legacy_count = sum(
+        1 for config in active_config_rows if config.id not in planner_parent_ids
+    )
+    if not planner_parent_ids:
+        return legacy_count
+
+    source_count = await session.scalar(
+        select(func.count(IntegrationSource.id)).where(
+            IntegrationSource.org_id == org_id,
+            func.lower(IntegrationSource.provider) == provider_normalized,
+            IntegrationSource.integration_id.in_(
+                select(SyncConfiguration.migrated_integration_id).where(
+                    SyncConfiguration.id.in_(planner_parent_ids)
+                )
+            ),
+            IntegrationSource.is_enabled.is_(True),
+        )
+    )
+    return legacy_count + int(source_count or 0)
 
 
 class _MutableSyncConfiguration(Protocol):
@@ -726,11 +772,9 @@ async def batch_create_sync_configs(
         This endpoint will create the parent config only (zero children) when
         the planner flag is enabled.
     """
-    svc = SyncConfigurationService(session, org_id)
-
-    # Enforce repo limit (existing + new repos)
-    existing_configs = await svc.list_all(active_only=True)
-    current_count = len(existing_configs)
+    current_count = await _active_repo_count_for_batch_limit(
+        session, org_id, payload.provider
+    )
     new_count = len(payload.repos)
 
     def _check_limit(sync_session) -> tuple[bool, str | None]:
@@ -1272,26 +1316,16 @@ async def trigger_sync_config_backfill(
         "yes",
         "on",
     }
-    # The worker only routes through the fan-out planner when the config was
-    # migrated to an Integration (config_migration.py) AND fan-out is enabled
-    # (global env override or the per-org migrated-routing flag). Mirror that
-    # decision here so the BackfillJob's initial chunk count and the response
-    # "mode" reflect the path the task will actually take.
-    migrated = getattr(config, "migrated_integration_id", None) is not None
-
-    def _routing_enabled(sync_session) -> bool:
-        from dev_health_ops.sync.trigger_routing import (
-            is_migrated_trigger_routing_enabled,
+    planner_backfill_request = await session.run_sync(
+        lambda sync_session: planner_request_for_config_if_routed(
+            sync_session, config, triggered_by="backfill", mode="backfill"
         )
-
-        return is_migrated_trigger_routing_enabled(sync_session, org_id)
-
-    if not migrated:
-        fanout_backfill = False
-    elif fanout_env:
-        fanout_backfill = True
-    else:
-        fanout_backfill = await session.run_sync(_routing_enabled)
+    )
+    if planner_backfill_request is None and fanout_env:
+        planner_backfill_request = plan_request_for_config(
+            config, triggered_by="backfill", mode="backfill"
+        )
+    fanout_backfill = planner_backfill_request is not None
     backfill_job = BackfillJobModel(
         org_id=org_id,
         sync_config_id=uuid.UUID(config_id),

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -28,6 +28,11 @@ from dev_health_ops.api.services.configuration import (
 )
 from dev_health_ops.api.services.licensing import TierLimitService
 from dev_health_ops.models import SyncRun
+from dev_health_ops.models.integrations import (
+    Integration,
+    IntegrationDataset,
+    IntegrationSource,
+)
 from dev_health_ops.models.settings import (
     JobRun,
     JobRunStatus,
@@ -35,12 +40,11 @@ from dev_health_ops.models.settings import (
     ScheduledJob,
     SyncConfiguration,
 )
-from dev_health_ops.sync.datasets import supported_legacy_targets
+from dev_health_ops.sync.datasets import supported_datasets, supported_legacy_targets
 from dev_health_ops.sync.planner import plan_sync_run
 from dev_health_ops.sync.trigger_routing import (
-    is_migrated_trigger_routing_enabled,
     mark_sync_run_failed,
-    plan_request_for_config,
+    planner_request_for_config_if_routed,
 )
 from dev_health_ops.workers.queues import sync_queue_for_provider
 from dev_health_ops.workers.sync_batch import _is_batch_eligible
@@ -372,6 +376,66 @@ async def _upsert_scheduled_job(
     job.status = status
 
 
+def _planner_dataset_keys(provider: str, sync_targets: list[str]) -> list[str]:
+    targets = {str(target) for target in sync_targets if target is not None}
+    return [
+        spec.dataset_key
+        for spec in supported_datasets(provider)
+        if targets.intersection(spec.legacy_targets)
+    ]
+
+
+def _planner_source_rows(
+    payload: SyncConfigBatchCreate,
+    parent_options: dict[str, Any],
+    gitlab_projects: dict[str, tuple[int, str]],
+    org_id: str,
+    integration_id: uuid.UUID,
+    config_id: uuid.UUID,
+) -> list[IntegrationSource]:
+    provider = payload.provider.lower()
+    rows: list[IntegrationSource] = []
+    owner = str(
+        payload.sync_options.get("owner")
+        or payload.sync_options.get("group")
+        or payload.name
+    )
+    for repo_name in payload.repos:
+        if provider == "gitlab":
+            project_id, full_name = gitlab_projects[repo_name]
+            source_type = "project"
+            external_id = str(project_id)
+            source_name = full_name.rsplit("/", 1)[-1] if full_name else str(project_id)
+            metadata = {
+                "path_with_namespace": full_name,
+                "planner_managed_sync_config_id": str(config_id),
+            }
+        else:
+            source_type = "repository" if provider == "github" else "source"
+            full_name = f"{owner}/{repo_name}" if provider == "github" else repo_name
+            external_id = full_name
+            source_name = repo_name
+            metadata = {
+                "planner_managed_sync_config_id": str(config_id),
+            }
+            if provider == "github":
+                metadata["owner"] = owner
+        rows.append(
+            IntegrationSource(
+                org_id=org_id,
+                integration_id=integration_id,
+                provider=payload.provider,
+                source_type=source_type,
+                external_id=external_id,
+                name=source_name,
+                full_name=full_name,
+                metadata_=metadata,
+                is_enabled=True,
+            )
+        )
+    return rows
+
+
 @router.get("/sync-targets")
 async def get_provider_sync_targets() -> dict[str, list[str]]:
     return PROVIDER_SYNC_TARGETS
@@ -681,21 +745,6 @@ async def batch_create_sync_configs(
         )
 
     provider = payload.provider.lower()
-    parent_is_active = provider in NON_REPO_SYNC_PROVIDERS
-
-    # Child sync configs are deprecated. When the integration planner is active
-    # for this org, reject batch child creation BEFORE writing an inert legacy
-    # parent (which would return 201 with zero syncable repos and block the
-    # name on retry) and direct the caller to the integration admin API.
-    if await _is_planner_active(session, org_id):
-        raise HTTPException(
-            status_code=409,
-            detail=(
-                "Child sync configs are deprecated for this organization. "
-                "Use the integration admin API: POST /admin/integrations, then "
-                "POST /admin/integrations/{id}/discover and /sync."
-            ),
-        )
 
     parent_options = dict(payload.sync_options)
     parent_options.pop("repo", None)  # parent has no single repo
@@ -718,6 +767,21 @@ async def batch_create_sync_configs(
         if effective_gitlab_url != DEFAULT_GITLAB_URL:
             parent_options["gitlab_url"] = effective_gitlab_url
 
+    integration = Integration(
+        org_id=org_id,
+        provider=payload.provider,
+        credential_id=uuid.UUID(payload.credential_id)
+        if payload.credential_id
+        else None,
+        name=payload.name,
+        config=parent_options,
+        is_active=True,
+        schedule_cron=payload.schedule_cron,
+        timezone=payload.timezone,
+    )
+    session.add(integration)
+    await session.flush()
+
     parent = SyncConfiguration(
         name=payload.name,
         provider=payload.provider,
@@ -727,79 +791,39 @@ async def batch_create_sync_configs(
         else None,
         sync_targets=payload.sync_targets,
         sync_options=parent_options,
-        is_active=parent_is_active,
+        is_active=True,
+        migrated_integration_id=integration.id,
     )
     session.add(parent)
-    await session.flush()  # need parent.id for children
+    await session.flush()
 
-    # Child-config creation is the legacy (rollback) path. Planner-active
-    # requests were already rejected with 409 above, so children are always
-    # created here.
-    _planner_active = False
+    source_rows = _planner_source_rows(
+        payload,
+        parent_options,
+        gitlab_projects,
+        org_id,
+        integration.id,
+        parent.id,
+    )
+    dataset_rows = [
+        IntegrationDataset(
+            org_id=org_id,
+            integration_id=integration.id,
+            dataset_key=dataset_key,
+            is_enabled=True,
+            options={"legacy_targets": list(payload.sync_targets)},
+        )
+        for dataset_key in _planner_dataset_keys(payload.provider, payload.sync_targets)
+    ]
+    session.add_all([*source_rows, *dataset_rows])
 
-    # Create child configs (one per repo) — skipped when planner is active.
-    children = []
-    if not _planner_active:
-        for repo_name in payload.repos:
-            child_options = dict(parent_options)
-            if provider == "gitlab":
-                project_id, child_name = gitlab_projects[repo_name]
-                # GitLab children are keyed by integer project_id (what the sync
-                # runtime dispatches on), not by GitHub-shaped owner/repo keys.
-                child_options.pop("owner", None)
-                child_options.pop("repo", None)
-                child_options.pop("search", None)
-                child_options["project_id"] = project_id
-                group = _gitlab_group_from_options(payload.sync_options)
-                if group:
-                    child_options["group"] = group
-                # gitlab_url passes through via the dict(parent_options) copy
-                # above — including the credential-derived URL persisted into
-                # parent_options before parent creation.
-            else:
-                child_options["repo"] = repo_name
-                owner = (
-                    payload.sync_options.get("owner")
-                    or payload.sync_options.get("group")
-                    or payload.name
-                )
-                child_name = f"{owner}/{repo_name}"
-            if payload.initial_sync_depth is not None:
-                child_options["initial_sync_depth"] = payload.initial_sync_depth
-            if payload.schedule_cron is not None:
-                child_options["schedule_cron"] = payload.schedule_cron
-            if payload.timezone is not None:
-                child_options["timezone"] = payload.timezone
-
-            child = SyncConfiguration(
-                name=child_name,
-                provider=payload.provider,
-                org_id=org_id,
-                credential_id=uuid.UUID(payload.credential_id)
-                if payload.credential_id
-                else None,
-                sync_targets=payload.sync_targets,
-                sync_options=child_options,
-                is_active=True,
-                parent_id=getattr(parent, "id"),
-            )
-            children.append(child)
-
-    if children:
-        session.add_all(children)
-        await session.flush()
-
-    if parent_is_active:
-        await _upsert_scheduled_job(session, parent, org_id)
-    for child in children:
-        await _upsert_scheduled_job(session, child, org_id)
-    if children or parent_is_active:
-        await session.flush()
+    await _upsert_scheduled_job(session, parent, org_id)
+    await session.flush()
 
     return SyncConfigBatchResponse(
-        parent=_sync_config_to_response(parent, children_count=len(children)),
-        children=[_sync_config_to_response(c) for c in children],
-        total_created=len(children),
+        parent=_sync_config_to_response(parent, children_count=0),
+        children=[],
+        total_created=0,
     )
 
 
@@ -1085,6 +1109,11 @@ async def trigger_sync_config(
         raise HTTPException(status_code=404, detail="Sync configuration not found")
     if str(getattr(config, "org_id", "")) != org_id:
         raise HTTPException(status_code=404, detail="Sync configuration not found")
+    if not bool(getattr(config, "is_active", False)):
+        raise HTTPException(
+            status_code=409,
+            detail="Sync configuration is paused and cannot be triggered",
+        )
 
     # Fix 6 (LOW-MEDIUM): Check work items count against tier limit before triggering.
     if "work-items" in (config.sync_targets or []):
@@ -1127,48 +1156,38 @@ async def trigger_sync_config(
                 # ClickHouse unavailable — allow the sync to proceed rather than block it.
                 pass
 
-    # --- Migrated-trigger routing (CHAOS-2516) -----------------------------------
-    # After tier checks, before legacy dispatch: if the planner flag is on AND
-    # the config was migrated, route through the fan-out planner instead.
-    use_planner = await session.run_sync(
-        lambda s: is_migrated_trigger_routing_enabled(s, org_id)
-    )
-    if use_planner:
-        plan_request = plan_request_for_config(
-            config, triggered_by="manual", mode="incremental"
+    plan_request = await session.run_sync(
+        lambda sync_session: planner_request_for_config_if_routed(
+            sync_session, config, triggered_by="manual", mode="incremental"
         )
-        if plan_request is not None:
-            try:
-                plan = await session.run_sync(
-                    lambda sync_session: plan_sync_run(sync_session, plan_request)
+    )
+    if plan_request is not None:
+        try:
+            plan = await session.run_sync(
+                lambda sync_session: plan_sync_run(sync_session, plan_request)
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        await session.commit()
+        try:
+            getattr(dispatch_sync_run, "apply_async")(
+                args=(plan.sync_run_id,), queue="sync"
+            )
+        except Exception as exc:
+            await session.run_sync(
+                lambda s: mark_sync_run_failed(
+                    s, plan.sync_run_id, "dispatch enqueue failed"
                 )
-            except ValueError as exc:
-                raise HTTPException(status_code=400, detail=str(exc))
-            await session.commit()
-            try:
-                getattr(dispatch_sync_run, "apply_async")(
-                    args=(plan.sync_run_id,), queue="sync"
-                )
-            except Exception as exc:
-                # The run + units are committed but never dispatched. Mark the
-                # run FAILED so it is not stranded PLANNED with no queued
-                # dispatcher (there is no periodic reconciler for such runs),
-                # then surface the queue outage to the caller.
-                await session.run_sync(
-                    lambda s: mark_sync_run_failed(
-                        s, plan.sync_run_id, "dispatch enqueue failed"
-                    )
-                )
-                raise HTTPException(
-                    status_code=503, detail=f"Task queue unavailable: {exc}"
-                )
-            return {
-                "status": "triggered",
-                "config_id": str(config.id),
-                "sync_run_id": plan.sync_run_id,
-                "total_units": plan.total_units,
-            }
-    # --- End migrated-trigger routing -------------------------------------------
+            )
+            raise HTTPException(
+                status_code=503, detail=f"Task queue unavailable: {exc}"
+            )
+        return {
+            "status": "triggered",
+            "config_id": str(config.id),
+            "sync_run_id": plan.sync_run_id,
+            "total_units": plan.total_units,
+        }
 
     try:
         from dev_health_ops.workers.sync_tasks import (

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -171,7 +171,7 @@ async def _is_planner_active(session: AsyncSession, org_id: str) -> bool:
 async def _active_repo_count_for_batch_limit(
     session: AsyncSession, org_id: str, provider: str
 ) -> int:
-    provider_normalized = provider.lower()
+    _ = provider
     active_configs = await session.execute(
         select(SyncConfiguration).where(
             SyncConfiguration.org_id == org_id,
@@ -187,26 +187,25 @@ async def _active_repo_count_for_batch_limit(
     planner_parent_ids = [
         config.id
         for config in active_config_rows
-        if str(config.provider or "").lower() == provider_normalized
-        and config.parent_id is None
+        if config.parent_id is None
         and config.migrated_integration_id is not None
         and config.id not in parent_ids_with_children
+    ]
+    planner_integration_ids = [
+        config.migrated_integration_id
+        for config in active_config_rows
+        if config.id in planner_parent_ids
     ]
     legacy_count = sum(
         1 for config in active_config_rows if config.id not in planner_parent_ids
     )
-    if not planner_parent_ids:
+    if not planner_integration_ids:
         return legacy_count
 
     source_count = await session.scalar(
         select(func.count(IntegrationSource.id)).where(
             IntegrationSource.org_id == org_id,
-            func.lower(IntegrationSource.provider) == provider_normalized,
-            IntegrationSource.integration_id.in_(
-                select(SyncConfiguration.migrated_integration_id).where(
-                    SyncConfiguration.id.in_(planner_parent_ids)
-                )
-            ),
+            IntegrationSource.integration_id.in_(planner_integration_ids),
             IntegrationSource.is_enabled.is_(True),
         )
     )

--- a/src/dev_health_ops/models/settings.py
+++ b/src/dev_health_ops/models/settings.py
@@ -285,6 +285,9 @@ class SyncConfiguration(Base):
     )
 
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    planner_managed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
     last_sync_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
@@ -360,6 +363,7 @@ class SyncConfiguration(Base):
         parent_id: uuid.UUID | None = None,
         migrated_integration_id: uuid.UUID | None = None,
         migrated_source_id: uuid.UUID | None = None,
+        planner_managed: bool = False,
     ) -> None:
         self.id = uuid.uuid4()
         self.org_id = org_id or ""
@@ -372,6 +376,7 @@ class SyncConfiguration(Base):
         self.parent_id = parent_id
         self.migrated_integration_id = migrated_integration_id
         self.migrated_source_id = migrated_source_id
+        self.planner_managed = planner_managed
         self.created_at = datetime.now(timezone.utc)
         self.updated_at = datetime.now(timezone.utc)
 

--- a/src/dev_health_ops/sync/trigger_routing.py
+++ b/src/dev_health_ops/sync/trigger_routing.py
@@ -150,16 +150,7 @@ def should_route_config_to_planner(session: Session, config: SyncConfiguration) 
     if integration_id is None:
         return False
 
-    parent_id = getattr(config, "parent_id", None)
-    source_id = getattr(config, "migrated_source_id", None)
-    child_eligible = parent_id is not None and source_id is not None
-    parent_or_single_eligible = parent_id is None
-    if not (parent_or_single_eligible or child_eligible):
-        return False
-
-    if parent_or_single_eligible and _integration_has_enabled_sources(
-        session, integration_id
-    ):
+    if bool(getattr(config, "planner_managed", False)):
         return True
 
     return is_migrated_trigger_routing_enabled(session, str(config.org_id))
@@ -229,37 +220,6 @@ def canonical_sync_config_for_sync_run(session: Session, sync_run: Any) -> Any |
             configs[0].id,
         )
     return configs[0]
-
-
-def _config_has_children(session: Session, config: SyncConfiguration) -> bool:
-    import uuid
-
-    from dev_health_ops.models.settings import SyncConfiguration
-
-    config_id = uuid.UUID(str(config.id))
-    return (
-        session.query(SyncConfiguration.id)
-        .filter(SyncConfiguration.parent_id == config_id)
-        .first()
-        is not None
-    )
-
-
-def _integration_has_enabled_sources(session: Session, integration_id: Any) -> bool:
-    import uuid
-
-    from dev_health_ops.models.integrations import IntegrationSource
-
-    integration_uuid = uuid.UUID(str(integration_id))
-    return (
-        session.query(IntegrationSource.id)
-        .filter(
-            IntegrationSource.integration_id == integration_uuid,
-            IntegrationSource.is_enabled.is_(True),
-        )
-        .first()
-        is not None
-    )
 
 
 def mark_sync_run_failed(session: Session, sync_run_id: str, error: str) -> None:

--- a/src/dev_health_ops/sync/trigger_routing.py
+++ b/src/dev_health_ops/sync/trigger_routing.py
@@ -184,25 +184,7 @@ def stamp_sync_run_canonical_config(
     error: str | None,
     stats: dict[str, Any] | None = None,
 ) -> None:
-    import uuid
-
-    from dev_health_ops.models.settings import SyncConfiguration
-
-    integration_id = getattr(sync_run, "integration_id", None)
-    org_id = getattr(sync_run, "org_id", None)
-    if integration_id is None or org_id is None:
-        return
-
-    integration_uuid = uuid.UUID(str(integration_id))
-    config = (
-        session.query(SyncConfiguration)
-        .filter(
-            SyncConfiguration.org_id == str(org_id),
-            SyncConfiguration.migrated_integration_id == integration_uuid,
-            SyncConfiguration.parent_id.is_(None),
-        )
-        .one_or_none()
-    )
+    config = canonical_sync_config_for_sync_run(session, sync_run)
     if config is None:
         return
 
@@ -211,6 +193,40 @@ def stamp_sync_run_canonical_config(
     config.last_sync_error = error
     if stats is not None:
         config.last_sync_stats = stats
+
+
+def canonical_sync_config_for_sync_run(session: Session, sync_run: Any) -> Any | None:
+    import uuid
+
+    from dev_health_ops.models.settings import SyncConfiguration
+
+    integration_id = getattr(sync_run, "integration_id", None)
+    org_id = getattr(sync_run, "org_id", None)
+    if integration_id is None or org_id is None:
+        return None
+
+    integration_uuid = uuid.UUID(str(integration_id))
+    configs = (
+        session.query(SyncConfiguration)
+        .filter(
+            SyncConfiguration.org_id == str(org_id),
+            SyncConfiguration.migrated_integration_id == integration_uuid,
+            SyncConfiguration.parent_id.is_(None),
+        )
+        .order_by(SyncConfiguration.created_at.asc(), SyncConfiguration.id.asc())
+        .limit(2)
+        .all()
+    )
+    if not configs:
+        return None
+    if len(configs) > 1:
+        logger.warning(
+            "Multiple parent SyncConfigurations found for integration %s in org %s; using %s as canonical",
+            integration_uuid,
+            org_id,
+            configs[0].id,
+        )
+    return configs[0]
 
 
 def _config_has_children(session: Session, config: SyncConfiguration) -> bool:
@@ -299,6 +315,7 @@ def mark_sync_run_failed(session: Session, sync_run_id: str, error: str) -> None
 
 __all__ = [
     "MIGRATED_TRIGGER_ROUTING_SETTING_KEY",
+    "canonical_sync_config_for_sync_run",
     "is_migrated_trigger_routing_enabled",
     "mark_sync_run_failed",
     "planner_request_for_config_if_routed",

--- a/src/dev_health_ops/sync/trigger_routing.py
+++ b/src/dev_health_ops/sync/trigger_routing.py
@@ -157,7 +157,9 @@ def should_route_config_to_planner(session: Session, config: SyncConfiguration) 
     if not (parent_or_single_eligible or child_eligible):
         return False
 
-    if parent_or_single_eligible and not _config_has_children(session, config):
+    if parent_or_single_eligible and _integration_has_enabled_sources(
+        session, integration_id
+    ):
         return True
 
     return is_migrated_trigger_routing_enabled(session, str(config.org_id))
@@ -238,6 +240,23 @@ def _config_has_children(session: Session, config: SyncConfiguration) -> bool:
     return (
         session.query(SyncConfiguration.id)
         .filter(SyncConfiguration.parent_id == config_id)
+        .first()
+        is not None
+    )
+
+
+def _integration_has_enabled_sources(session: Session, integration_id: Any) -> bool:
+    import uuid
+
+    from dev_health_ops.models.integrations import IntegrationSource
+
+    integration_uuid = uuid.UUID(str(integration_id))
+    return (
+        session.query(IntegrationSource.id)
+        .filter(
+            IntegrationSource.integration_id == integration_uuid,
+            IntegrationSource.is_enabled.is_(True),
+        )
         .first()
         is not None
     )

--- a/src/dev_health_ops/sync/trigger_routing.py
+++ b/src/dev_health_ops/sync/trigger_routing.py
@@ -222,6 +222,42 @@ def canonical_sync_config_for_sync_run(session: Session, sync_run: Any) -> Any |
     return configs[0]
 
 
+def inactive_child_configs_for_sync_run(session: Session, sync_run: Any) -> list[Any]:
+    import uuid
+
+    from dev_health_ops.models.integrations import SyncRunUnit
+    from dev_health_ops.models.settings import SyncConfiguration
+
+    org_id = getattr(sync_run, "org_id", None)
+    sync_run_id = getattr(sync_run, "id", None)
+    if org_id is None or sync_run_id is None:
+        return []
+
+    run_uuid = uuid.UUID(str(sync_run_id))
+    source_ids = [
+        source_id
+        for (source_id,) in session.query(SyncRunUnit.source_id)
+        .filter(SyncRunUnit.sync_run_id == run_uuid)
+        .distinct()
+        .all()
+        if source_id is not None
+    ]
+    if not source_ids:
+        return []
+
+    return (
+        session.query(SyncConfiguration)
+        .filter(
+            SyncConfiguration.org_id == str(org_id),
+            SyncConfiguration.parent_id.is_not(None),
+            SyncConfiguration.migrated_source_id.in_(source_ids),
+            SyncConfiguration.is_active.is_(False),
+        )
+        .order_by(SyncConfiguration.created_at.asc(), SyncConfiguration.id.asc())
+        .all()
+    )
+
+
 def mark_sync_run_failed(session: Session, sync_run_id: str, error: str) -> None:
     """Mark a committed-but-undispatched SyncRun FAILED so it is not stranded.
 

--- a/src/dev_health_ops/sync/trigger_routing.py
+++ b/src/dev_health_ops/sync/trigger_routing.py
@@ -22,7 +22,8 @@ legacy path and this module's :func:`plan_request_for_config` is never reached.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
 
 from dev_health_ops.sync.datasets import supported_datasets
 from dev_health_ops.sync.planner import SyncPlanRequest
@@ -144,6 +145,88 @@ def plan_request_for_config(
     )
 
 
+def should_route_config_to_planner(session: Session, config: SyncConfiguration) -> bool:
+    integration_id = getattr(config, "migrated_integration_id", None)
+    if integration_id is None:
+        return False
+
+    parent_id = getattr(config, "parent_id", None)
+    source_id = getattr(config, "migrated_source_id", None)
+    child_eligible = parent_id is not None and source_id is not None
+    parent_or_single_eligible = parent_id is None
+    if not (parent_or_single_eligible or child_eligible):
+        return False
+
+    if parent_or_single_eligible and not _config_has_children(session, config):
+        return True
+
+    return is_migrated_trigger_routing_enabled(session, str(config.org_id))
+
+
+def planner_request_for_config_if_routed(
+    session: Session,
+    config: SyncConfiguration,
+    *,
+    triggered_by: str,
+    mode: str = "incremental",
+) -> SyncPlanRequest | None:
+    if not should_route_config_to_planner(session, config):
+        return None
+    return plan_request_for_config(config, triggered_by=triggered_by, mode=mode)
+
+
+def stamp_sync_run_canonical_config(
+    session: Session,
+    sync_run: Any,
+    *,
+    completed_at: datetime | None = None,
+    success: bool,
+    error: str | None,
+    stats: dict[str, Any] | None = None,
+) -> None:
+    import uuid
+
+    from dev_health_ops.models.settings import SyncConfiguration
+
+    integration_id = getattr(sync_run, "integration_id", None)
+    org_id = getattr(sync_run, "org_id", None)
+    if integration_id is None or org_id is None:
+        return
+
+    integration_uuid = uuid.UUID(str(integration_id))
+    config = (
+        session.query(SyncConfiguration)
+        .filter(
+            SyncConfiguration.org_id == str(org_id),
+            SyncConfiguration.migrated_integration_id == integration_uuid,
+            SyncConfiguration.parent_id.is_(None),
+        )
+        .one_or_none()
+    )
+    if config is None:
+        return
+
+    config.last_sync_at = completed_at or datetime.now(timezone.utc)
+    config.last_sync_success = success
+    config.last_sync_error = error
+    if stats is not None:
+        config.last_sync_stats = stats
+
+
+def _config_has_children(session: Session, config: SyncConfiguration) -> bool:
+    import uuid
+
+    from dev_health_ops.models.settings import SyncConfiguration
+
+    config_id = uuid.UUID(str(config.id))
+    return (
+        session.query(SyncConfiguration.id)
+        .filter(SyncConfiguration.parent_id == config_id)
+        .first()
+        is not None
+    )
+
+
 def mark_sync_run_failed(session: Session, sync_run_id: str, error: str) -> None:
     """Mark a committed-but-undispatched SyncRun FAILED so it is not stranded.
 
@@ -200,6 +283,14 @@ def mark_sync_run_failed(session: Session, sync_run_id: str, error: str) -> None
             },
             synchronize_session=False,
         )
+        stamp_sync_run_canonical_config(
+            session,
+            run,
+            completed_at=now,
+            success=False,
+            error=error,
+            stats={"error": error, "phase": "dispatch_enqueue"},
+        )
         session.commit()
     except Exception:
         logger.exception("Failed to mark stranded sync_run %s as failed", sync_run_id)
@@ -210,5 +301,8 @@ __all__ = [
     "MIGRATED_TRIGGER_ROUTING_SETTING_KEY",
     "is_migrated_trigger_routing_enabled",
     "mark_sync_run_failed",
+    "planner_request_for_config_if_routed",
     "plan_request_for_config",
+    "should_route_config_to_planner",
+    "stamp_sync_run_canonical_config",
 ]

--- a/src/dev_health_ops/workers/sync_backfill.py
+++ b/src/dev_health_ops/workers/sync_backfill.py
@@ -147,6 +147,30 @@ def _mark_sync_job_run_failed(
         logger.debug("Failed to mark sync job run failed: %s", pending_run_id)
 
 
+def _mark_sync_job_run_cancelled(
+    pending_run_id: str | None, error: str, completed_at: datetime
+) -> None:
+    if pending_run_id is None:
+        return
+    try:
+        from dev_health_ops.db import get_postgres_session_sync
+        from dev_health_ops.models.settings import JobRun, JobRunStatus
+
+        with get_postgres_session_sync() as session:
+            run = (
+                session.query(JobRun)
+                .filter(JobRun.id == uuid.UUID(pending_run_id))
+                .one_or_none()
+            )
+            if run:
+                setattr(run, "status", JobRunStatus.CANCELLED.value)
+                setattr(run, "error", error)
+                setattr(run, "completed_at", completed_at)
+                session.flush()
+    except Exception:
+        logger.debug("Failed to mark sync job run cancelled: %s", pending_run_id)
+
+
 @celery_app.task(
     bind=True,
     max_retries=3,
@@ -191,6 +215,19 @@ def run_backfill(
             )
             if config is None:
                 raise ValueError(f"Sync configuration not found: {sync_config_id}")
+            if not bool(config.is_active):
+                completed_at = datetime.now(timezone.utc)
+                if backfill_job_id:
+                    _update_backfill_job_counts(
+                        backfill_job_id,
+                        status="cancelled",
+                        completed_at=completed_at,
+                        error_message="Sync configuration is paused",
+                    )
+                _mark_sync_job_run_cancelled(
+                    pending_run_id, "Sync configuration is paused", completed_at
+                )
+                return {"status": "skipped", "reason": "sync_config_inactive"}
 
             provider = str(config.provider or "").strip().lower()
             sync_targets = _normalize_sync_targets(

--- a/src/dev_health_ops/workers/sync_backfill.py
+++ b/src/dev_health_ops/workers/sync_backfill.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import uuid
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
@@ -15,15 +14,6 @@ from dev_health_ops.workers.task_utils import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _sync_fanout_backfill_enabled() -> bool:
-    return os.getenv("SYNC_FANOUT_BACKFILL", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
 
 
 def _mark_backfill_job_running(backfill_job_id: str, started_at: datetime) -> None:
@@ -178,10 +168,7 @@ def run_backfill(
     )
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.models.settings import IntegrationCredential, SyncConfiguration
-    from dev_health_ops.sync.trigger_routing import (
-        plan_request_for_config,
-        planner_request_for_config_if_routed,
-    )
+    from dev_health_ops.sync.trigger_routing import planner_request_for_config_if_routed
 
     sync_config_uuid = uuid.UUID(sync_config_id)
     started_at = datetime.now(timezone.utc)
@@ -230,10 +217,6 @@ def run_backfill(
             plan_req = planner_request_for_config_if_routed(
                 session, config, triggered_by="backfill", mode="backfill"
             )
-            if plan_req is None and _sync_fanout_backfill_enabled():
-                plan_req = plan_request_for_config(
-                    config, triggered_by="backfill", mode="backfill"
-                )
             if plan_req is not None:
                 use_fanout = True
                 planner_integration_id = plan_req.integration_id

--- a/src/dev_health_ops/workers/sync_backfill.py
+++ b/src/dev_health_ops/workers/sync_backfill.py
@@ -179,8 +179,8 @@ def run_backfill(
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.models.settings import IntegrationCredential, SyncConfiguration
     from dev_health_ops.sync.trigger_routing import (
-        is_migrated_trigger_routing_enabled,
         plan_request_for_config,
+        planner_request_for_config_if_routed,
     )
 
     sync_config_uuid = uuid.UUID(sync_config_id)
@@ -227,14 +227,14 @@ def run_backfill(
                     )
                 credentials = _credential_mapping(credential)
 
-            plan_req = plan_request_for_config(
-                config, triggered_by="backfill", mode="backfill"
+            plan_req = planner_request_for_config_if_routed(
+                session, config, triggered_by="backfill", mode="backfill"
             )
-            fanout_requested = (
-                _sync_fanout_backfill_enabled()
-                or is_migrated_trigger_routing_enabled(session, org_id)
-            )
-            if plan_req is not None and fanout_requested:
+            if plan_req is None and _sync_fanout_backfill_enabled():
+                plan_req = plan_request_for_config(
+                    config, triggered_by="backfill", mode="backfill"
+                )
+            if plan_req is not None:
                 use_fanout = True
                 planner_integration_id = plan_req.integration_id
                 planner_source_ids = plan_req.source_ids

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -423,6 +423,21 @@ def dispatch_batch_sync(
             )
             if config is None:
                 raise _TerminalSyncError(f"Sync configuration not found: {config_id}")
+            if not bool(config.is_active):
+                if pending_run_id is not None:
+                    from dev_health_ops.models.settings import JobRun, JobRunStatus
+
+                    run_record = (
+                        session.query(JobRun)
+                        .filter(JobRun.id == uuid.UUID(pending_run_id))
+                        .one_or_none()
+                    )
+                    if run_record is not None:
+                        run_record.status = JobRunStatus.CANCELLED.value
+                        run_record.completed_at = datetime.now(timezone.utc)
+                        run_record.error = "Sync configuration is paused"
+                session.flush()
+                return {"status": "skipped", "reason": "sync_config_inactive"}
 
             provider = (config.provider or "").lower()
             sync_targets = _normalize_sync_targets(

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -530,6 +530,19 @@ def run_sync_config(
             )
             if config is None:
                 raise _TerminalSyncError(f"Sync configuration not found: {config_id}")
+            if not bool(config.is_active):
+                if pending_run_id is not None:
+                    run_record = (
+                        session.query(JobRun)
+                        .filter(JobRun.id == uuid.UUID(pending_run_id))
+                        .one_or_none()
+                    )
+                    if run_record is not None:
+                        run_record.status = JobRunStatus.CANCELLED.value
+                        run_record.completed_at = datetime.now(timezone.utc)
+                        run_record.error = "Sync configuration is paused"
+                session.flush()
+                return {"status": "skipped", "reason": "sync_config_inactive"}
 
             provider = _as_str(config.provider).lower()
             config_name = _as_str(config.name)

--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -270,6 +270,7 @@ def _maybe_dispatch_config(
         session, config, triggered_by="schedule", mode="incremental"
     )
     if request is not None:
+        planner_managed = bool(getattr(config, "planner_managed", False))
         logger.info(
             "Routing config %s through fan-out planner (migrated trigger routing)",
             config.id,
@@ -279,10 +280,12 @@ def _maybe_dispatch_config(
             session.commit()
         except Exception:
             logger.exception(
-                "Fan-out planner failed for config %s; falling back to legacy dispatch",
+                "Fan-out planner failed for config %s",
                 config.id,
             )
             session.rollback()
+            if planner_managed:
+                return False
         else:
             try:
                 getattr(dispatch_sync_run, "apply_async")(
@@ -291,13 +294,16 @@ def _maybe_dispatch_config(
             except Exception:
                 logger.exception(
                     "Fan-out dispatch enqueue failed for config %s "
-                    "(sync_run=%s); marking run failed and falling back",
+                    "(sync_run=%s); marking run failed",
                     config.id,
                     plan.sync_run_id,
                 )
                 mark_sync_run_failed(
                     session, plan.sync_run_id, "dispatch enqueue failed"
                 )
+                session.commit()
+                if planner_managed:
+                    return False
             else:
                 return True
 

--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -261,61 +261,45 @@ def _maybe_dispatch_config(
     # planner instead of the legacy per-config tasks.
     from dev_health_ops.sync.planner import plan_sync_run
     from dev_health_ops.sync.trigger_routing import (
-        is_migrated_trigger_routing_enabled,
         mark_sync_run_failed,
-        plan_request_for_config,
+        planner_request_for_config_if_routed,
     )
     from dev_health_ops.workers.sync_units import dispatch_sync_run
 
-    use_planner = is_migrated_trigger_routing_enabled(session, org_id)
-    if use_planner:
-        request = plan_request_for_config(
-            config, triggered_by="schedule", mode="incremental"
+    request = planner_request_for_config_if_routed(
+        session, config, triggered_by="schedule", mode="incremental"
+    )
+    if request is not None:
+        logger.info(
+            "Routing config %s through fan-out planner (migrated trigger routing)",
+            config.id,
         )
-        if request is not None:
-            logger.info(
-                "Routing config %s through fan-out planner (migrated trigger routing)",
+        try:
+            plan = plan_sync_run(session, request)
+            session.commit()
+        except Exception:
+            logger.exception(
+                "Fan-out planner failed for config %s; falling back to legacy dispatch",
                 config.id,
             )
+            session.rollback()
+        else:
             try:
-                plan = plan_sync_run(session, request)
-                session.commit()
-            except Exception:
-                # Stale migrated link or a transient planner/DB error must not
-                # suppress this scheduled sync. next_run_at was already committed
-                # above, so roll back the failed plan attempt and fall through to
-                # the legacy per-config path -- this tick still dispatches exactly
-                # once instead of going dark until the next cron occurrence.
-                logger.exception(
-                    "Fan-out planner failed for config %s; "
-                    "falling back to legacy dispatch",
-                    config.id,
+                getattr(dispatch_sync_run, "apply_async")(
+                    args=(plan.sync_run_id,), queue="sync"
                 )
-                session.rollback()
+            except Exception:
+                logger.exception(
+                    "Fan-out dispatch enqueue failed for config %s "
+                    "(sync_run=%s); marking run failed and falling back",
+                    config.id,
+                    plan.sync_run_id,
+                )
+                mark_sync_run_failed(
+                    session, plan.sync_run_id, "dispatch enqueue failed"
+                )
             else:
-                try:
-                    getattr(dispatch_sync_run, "apply_async")(
-                        args=(plan.sync_run_id,), queue="sync"
-                    )
-                except Exception:
-                    # The run + units are committed but the dispatch enqueue
-                    # failed. There is no periodic sweeper for stranded PLANNED
-                    # runs (the intra-dispatch reclaim only runs once
-                    # dispatch_sync_run executes), so mark this run FAILED rather
-                    # than leave it silently PLANNED with no queued dispatcher,
-                    # then fall through to the legacy path so this tick still
-                    # attempts a sync.
-                    logger.exception(
-                        "Fan-out dispatch enqueue failed for config %s "
-                        "(sync_run=%s); marking run failed and falling back",
-                        config.id,
-                        plan.sync_run_id,
-                    )
-                    mark_sync_run_failed(
-                        session, plan.sync_run_id, "dispatch enqueue failed"
-                    )
-                else:
-                    return True
+                return True
 
     # Per-provider routing (CHAOS-2299): "is Linear stuck?" must be one LLEN.
     if is_batch:

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -56,7 +56,10 @@ from dev_health_ops.models import (
 from dev_health_ops.sync.dispatch_policy import route
 from dev_health_ops.sync.guard import DispatchGuard
 from dev_health_ops.sync.planner import map_datasets_to_legacy_targets
-from dev_health_ops.sync.trigger_routing import stamp_sync_run_canonical_config
+from dev_health_ops.sync.trigger_routing import (
+    canonical_sync_config_for_sync_run,
+    stamp_sync_run_canonical_config,
+)
 from dev_health_ops.sync.watermarks import set_watermark
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.queues import _cost_class_queues_enabled
@@ -151,6 +154,43 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
                 },
             )
             return {"status": "denied", "reason": run.error}
+
+        canonical_config = canonical_sync_config_for_sync_run(session, run)
+        if canonical_config is not None and not bool(canonical_config.is_active):
+            completed_at = datetime.now(timezone.utc)
+            error = "sync configuration is paused"
+            run.status = SyncRunStatus.FAILED.value
+            run.completed_at = completed_at
+            run.error = error
+            run.result = {"reason": "inactive_sync_configuration"}
+            session.query(SyncRunUnit).filter(
+                SyncRunUnit.sync_run_id == run_uuid,
+                SyncRunUnit.status == SyncRunUnitStatus.PLANNED.value,
+            ).update(
+                {
+                    SyncRunUnit.status: SyncRunUnitStatus.FAILED.value,
+                    SyncRunUnit.error: error,
+                    SyncRunUnit.updated_at: completed_at,
+                },
+                synchronize_session=False,
+            )
+            stamp_sync_run_canonical_config(
+                session,
+                run,
+                completed_at=completed_at,
+                success=False,
+                error=error,
+                stats={"reason": "inactive_sync_configuration"},
+            )
+            session.flush()
+            logger.warning(
+                "dispatch_sync_run.inactive_config",
+                extra={
+                    "sync_run_id": sync_run_id,
+                    "config_id": str(canonical_config.id),
+                },
+            )
+            return {"status": "denied", "reason": error}
 
         units = _claim_units(session, run_uuid)
         signatures = []

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -58,6 +58,7 @@ from dev_health_ops.sync.guard import DispatchGuard
 from dev_health_ops.sync.planner import map_datasets_to_legacy_targets
 from dev_health_ops.sync.trigger_routing import (
     canonical_sync_config_for_sync_run,
+    inactive_child_configs_for_sync_run,
     stamp_sync_run_canonical_config,
 )
 from dev_health_ops.sync.watermarks import set_watermark
@@ -156,7 +157,17 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
             return {"status": "denied", "reason": run.error}
 
         canonical_config = canonical_sync_config_for_sync_run(session, run)
-        if canonical_config is not None and not bool(canonical_config.is_active):
+        inactive_config = (
+            canonical_config
+            if canonical_config is not None and not bool(canonical_config.is_active)
+            else None
+        )
+        if inactive_config is None:
+            inactive_child_configs = inactive_child_configs_for_sync_run(session, run)
+            inactive_config = (
+                inactive_child_configs[0] if inactive_child_configs else None
+            )
+        if inactive_config is not None:
             completed_at = datetime.now(timezone.utc)
             error = "sync configuration is paused"
             run.status = SyncRunStatus.FAILED.value
@@ -187,7 +198,7 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
                 "dispatch_sync_run.inactive_config",
                 extra={
                     "sync_run_id": sync_run_id,
-                    "config_id": str(canonical_config.id),
+                    "config_id": str(inactive_config.id),
                 },
             )
             return {"status": "denied", "reason": error}

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -56,6 +56,7 @@ from dev_health_ops.models import (
 from dev_health_ops.sync.dispatch_policy import route
 from dev_health_ops.sync.guard import DispatchGuard
 from dev_health_ops.sync.planner import map_datasets_to_legacy_targets
+from dev_health_ops.sync.trigger_routing import stamp_sync_run_canonical_config
 from dev_health_ops.sync.watermarks import set_watermark
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.queues import _cost_class_queues_enabled
@@ -413,6 +414,20 @@ def finalize_sync_run(sync_run_id: str) -> dict[str, Any]:
             run.error = "No sync units planned"
             result_payload["reason"] = "no_sync_units_planned"
         run.result = result_payload
+        run_success = run.status == SyncRunStatus.SUCCESS.value
+        run_error = (
+            None
+            if run_success
+            else (run.error or "Sync run completed with failed units")
+        )
+        stamp_sync_run_canonical_config(
+            session,
+            run,
+            completed_at=run.completed_at,
+            success=run_success,
+            error=run_error,
+            stats=result_payload,
+        )
         session.flush()
 
         nested = session.begin_nested()
@@ -571,6 +586,14 @@ def _mark_dispatch_enqueue_failed(sync_run_id: str, error: str) -> None:
         )
         run.failed_units = sum(
             1 for unit in units if unit.status == SyncRunUnitStatus.FAILED.value
+        )
+        stamp_sync_run_canonical_config(
+            session,
+            run,
+            completed_at=completed_at,
+            success=False,
+            error=error,
+            stats={"error": error, "phase": "dispatch_enqueue"},
         )
         session.flush()
 

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -11,6 +11,7 @@ Covers:
 from __future__ import annotations
 
 import importlib
+import sqlite3
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -316,6 +317,72 @@ async def test_backfill_fanout_does_not_create_job_run(
         jr_result = await session.execute(select(JobRun))
         runs = list(jr_result.scalars().all())
     assert runs == []
+
+
+@pytest.mark.asyncio
+async def test_backfill_fanout_commits_backfill_job_before_dispatch(
+    client, session_maker, seeded_state
+):
+    ac, _ = client
+
+    create_resp = await _create_sync_config(
+        ac, name="bf-fanout-committed-before-dispatch", provider="github"
+    )
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(SyncConfiguration).where(
+                SyncConfiguration.id == uuid.UUID(config_id)
+            )
+        )
+        cfg = result.scalar_one()
+        integration_id = uuid.uuid4()
+        setattr(cfg, "migrated_integration_id", integration_id)
+        cfg.planner_managed = True
+        await session.commit()
+    await _seed_source(session_maker, seeded_state["org_id"], integration_id)
+
+    db_path = session_maker.kw["bind"].url.database
+    visible_at_dispatch: list[tuple[str, int, str | None]] = []
+
+    def _delay_side_effect(**kwargs):
+        backfill_job_id = uuid.UUID(kwargs["backfill_job_id"])
+        assert db_path is not None
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT status, total_chunks, celery_task_id
+                FROM backfill_jobs
+                WHERE id = ?
+                """,
+                (backfill_job_id.hex,),
+            ).fetchone()
+        assert row is not None, "BackfillJob must be committed before dispatch"
+        visible_at_dispatch.append(row)
+        return MagicMock(id="bf-fanout-visible-task-id")
+
+    mock_run_backfill = MagicMock()
+    mock_run_backfill.delay.side_effect = _delay_side_effect
+
+    with (
+        patch("dev_health_ops.workers.sync_tasks.run_backfill", mock_run_backfill),
+        patch.dict("os.environ", {"SYNC_FANOUT_BACKFILL": ""}),
+    ):
+        resp = await ac.post(
+            f"/api/v1/admin/sync-configs/{config_id}/backfill",
+            json={"since": "2026-01-01", "before": "2026-01-08"},
+        )
+
+    assert resp.status_code == 202, resp.text
+    assert resp.json()["mode"] == "fanout"
+    assert visible_at_dispatch == [("pending", 0, None)]
+
+    async with session_maker() as session:
+        result = await session.execute(select(BackfillJob))
+        backfill_job = result.scalar_one()
+    assert backfill_job.celery_task_id == "bf-fanout-visible-task-id"
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -26,6 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.models.backfill import BackfillJob
 from dev_health_ops.models.git import Base
+from dev_health_ops.models.integrations import Integration, IntegrationSource
 from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import (
     IntegrationCredential,
@@ -51,6 +52,8 @@ _TABLES = tables_of(
     ScheduledJob,
     JobRun,
     Setting,
+    Integration,
+    IntegrationSource,
     BackfillJob,
 )
 
@@ -129,6 +132,32 @@ async def _create_sync_config(ac, name: str = "my-sync", provider: str = "github
     )
 
 
+async def _seed_source(session_maker, org_id: str, integration_id: uuid.UUID) -> None:
+    async with session_maker() as session:
+        session.add(
+            Integration(
+                id=integration_id,
+                org_id=org_id,
+                provider="github",
+                name="github-integration",
+                config={},
+            )
+        )
+        session.add(
+            IntegrationSource(
+                org_id=org_id,
+                integration_id=integration_id,
+                provider="github",
+                source_type="repository",
+                external_id="full-chaos/dev-health",
+                name="dev-health",
+                full_name="full-chaos/dev-health",
+                is_enabled=True,
+            )
+        )
+        await session.commit()
+
+
 # ---------------------------------------------------------------------------
 # Endpoint tests — legacy path (fanout disabled)
 # ---------------------------------------------------------------------------
@@ -137,7 +166,7 @@ async def _create_sync_config(ac, name: str = "my-sync", provider: str = "github
 @pytest.mark.asyncio
 async def test_backfill_legacy_creates_pending_job_run(client, session_maker):
     """Legacy backfill must persist a PENDING JobRun before dispatching."""
-    ac, _ = client
+    ac, seeded_state = client
 
     create_resp = await _create_sync_config(ac, name="bf-legacy-run", provider="github")
     assert create_resp.status_code == 201
@@ -220,7 +249,9 @@ async def test_backfill_legacy_passes_pending_run_id_to_task(client):
 
 
 @pytest.mark.asyncio
-async def test_backfill_fanout_does_not_create_job_run(client, session_maker):
+async def test_backfill_fanout_does_not_create_job_run(
+    client, session_maker, seeded_state
+):
     """Fan-out backfill must NOT create a JobRun (passes pending_run_id=None)."""
     ac, _ = client
 
@@ -238,8 +269,10 @@ async def test_backfill_fanout_does_not_create_job_run(client, session_maker):
             )
         )
         cfg = result.scalar_one()
-        setattr(cfg, "migrated_integration_id", uuid.uuid4())
+        integration_id = uuid.uuid4()
+        setattr(cfg, "migrated_integration_id", integration_id)
         await session.commit()
+    await _seed_source(session_maker, seeded_state["org_id"], integration_id)
 
     mock_task = MagicMock(id="bf-fanout-task-id")
     mock_run_backfill = MagicMock()
@@ -271,7 +304,7 @@ async def test_backfill_fanout_does_not_create_job_run(client, session_maker):
 
 @pytest.mark.asyncio
 async def test_backfill_planner_managed_config_routes_to_fanout_without_flag(
-    client, session_maker
+    client, session_maker, seeded_state
 ):
     ac, _ = client
 
@@ -288,8 +321,10 @@ async def test_backfill_planner_managed_config_routes_to_fanout_without_flag(
             )
         )
         cfg = result.scalar_one()
-        setattr(cfg, "migrated_integration_id", uuid.uuid4())
+        integration_id = uuid.uuid4()
+        setattr(cfg, "migrated_integration_id", integration_id)
         await session.commit()
+    await _seed_source(session_maker, seeded_state["org_id"], integration_id)
 
     mock_task = MagicMock(id="bf-planner-managed-task-id")
     mock_run_backfill = MagicMock()
@@ -308,6 +343,47 @@ async def test_backfill_planner_managed_config_routes_to_fanout_without_flag(
     assert resp.json()["mode"] == "fanout"
     call_kwargs = mock_run_backfill.delay.call_args.kwargs
     assert call_kwargs.get("pending_run_id") is None
+
+
+@pytest.mark.asyncio
+async def test_backfill_sourceless_migrated_config_without_flag_uses_legacy_path(
+    client, session_maker
+):
+    ac, _ = client
+
+    create_resp = await _create_sync_config(
+        ac, name="bf-sourceless-migrated", provider="github"
+    )
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(SyncConfiguration).where(
+                SyncConfiguration.id == uuid.UUID(config_id)
+            )
+        )
+        cfg = result.scalar_one()
+        setattr(cfg, "migrated_integration_id", uuid.uuid4())
+        await session.commit()
+
+    mock_task = MagicMock(id="bf-sourceless-task-id")
+    mock_run_backfill = MagicMock()
+    mock_run_backfill.delay.return_value = mock_task
+
+    with (
+        patch("dev_health_ops.workers.sync_tasks.run_backfill", mock_run_backfill),
+        patch.dict("os.environ", {"SYNC_FANOUT_BACKFILL": ""}),
+    ):
+        resp = await ac.post(
+            f"/api/v1/admin/sync-configs/{config_id}/backfill",
+            json={"since": "2026-01-01", "before": "2026-01-08"},
+        )
+
+    assert resp.status_code == 202, resp.text
+    assert resp.json()["mode"] == "legacy"
+    call_kwargs = mock_run_backfill.delay.call_args.kwargs
+    assert call_kwargs.get("pending_run_id") is not None
 
 
 # ---------------------------------------------------------------------------
@@ -495,7 +571,7 @@ def test_run_backfill_signature_has_pending_run_id():
 
     from dev_health_ops.workers.sync_backfill import run_backfill
 
-    params = inspect.signature(run_backfill.run).parameters
+    params = inspect.signature(getattr(run_backfill, "run")).parameters
     assert "pending_run_id" in params, (
         "run_backfill is missing pending_run_id parameter"
     )

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -34,9 +34,11 @@ from dev_health_ops.models.settings import (
     JobRunStatus,
     ScheduledJob,
     Setting,
+    SettingCategory,
     SyncConfiguration,
 )
 from dev_health_ops.models.users import Organization, User
+from dev_health_ops.sync.trigger_routing import MIGRATED_TRIGGER_ROUTING_SETTING_KEY
 from tests._helpers import tables_of
 
 admin_router_module = importlib.import_module("dev_health_ops.api.admin")
@@ -158,6 +160,19 @@ async def _seed_source(session_maker, org_id: str, integration_id: uuid.UUID) ->
         await session.commit()
 
 
+async def _seed_planner_flag(session_maker, org_id: str) -> None:
+    async with session_maker() as session:
+        session.add(
+            Setting(
+                key=MIGRATED_TRIGGER_ROUTING_SETTING_KEY,
+                category=SettingCategory.SYNC.value,
+                value="true",
+                org_id=org_id,
+            )
+        )
+        await session.commit()
+
+
 # ---------------------------------------------------------------------------
 # Endpoint tests — legacy path (fanout disabled)
 # ---------------------------------------------------------------------------
@@ -273,6 +288,7 @@ async def test_backfill_fanout_does_not_create_job_run(
         setattr(cfg, "migrated_integration_id", integration_id)
         await session.commit()
     await _seed_source(session_maker, seeded_state["org_id"], integration_id)
+    await _seed_planner_flag(session_maker, seeded_state["org_id"])
 
     mock_task = MagicMock(id="bf-fanout-task-id")
     mock_run_backfill = MagicMock()
@@ -280,7 +296,7 @@ async def test_backfill_fanout_does_not_create_job_run(
 
     with (
         patch("dev_health_ops.workers.sync_tasks.run_backfill", mock_run_backfill),
-        patch.dict("os.environ", {"SYNC_FANOUT_BACKFILL": "true"}),
+        patch.dict("os.environ", {"SYNC_FANOUT_BACKFILL": ""}),
     ):
         resp = await ac.post(
             f"/api/v1/admin/sync-configs/{config_id}/backfill",
@@ -323,6 +339,7 @@ async def test_backfill_planner_managed_config_routes_to_fanout_without_flag(
         cfg = result.scalar_one()
         integration_id = uuid.uuid4()
         setattr(cfg, "migrated_integration_id", integration_id)
+        cfg.planner_managed = True
         await session.commit()
     await _seed_source(session_maker, seeded_state["org_id"], integration_id)
 

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -269,6 +269,47 @@ async def test_backfill_fanout_does_not_create_job_run(client, session_maker):
     assert runs == []
 
 
+@pytest.mark.asyncio
+async def test_backfill_planner_managed_config_routes_to_fanout_without_flag(
+    client, session_maker
+):
+    ac, _ = client
+
+    create_resp = await _create_sync_config(
+        ac, name="bf-planner-managed", provider="github"
+    )
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(SyncConfiguration).where(
+                SyncConfiguration.id == uuid.UUID(config_id)
+            )
+        )
+        cfg = result.scalar_one()
+        setattr(cfg, "migrated_integration_id", uuid.uuid4())
+        await session.commit()
+
+    mock_task = MagicMock(id="bf-planner-managed-task-id")
+    mock_run_backfill = MagicMock()
+    mock_run_backfill.delay.return_value = mock_task
+
+    with (
+        patch("dev_health_ops.workers.sync_tasks.run_backfill", mock_run_backfill),
+        patch.dict("os.environ", {"SYNC_FANOUT_BACKFILL": ""}),
+    ):
+        resp = await ac.post(
+            f"/api/v1/admin/sync-configs/{config_id}/backfill",
+            json={"since": "2026-01-01", "before": "2026-01-08"},
+        )
+
+    assert resp.status_code == 202, resp.text
+    assert resp.json()["mode"] == "fanout"
+    call_kwargs = mock_run_backfill.delay.call_args.kwargs
+    assert call_kwargs.get("pending_run_id") is None
+
+
 # ---------------------------------------------------------------------------
 # Worker-level tests — JobRun state transitions
 # ---------------------------------------------------------------------------

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -27,7 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.models.backfill import BackfillJob
 from dev_health_ops.models.git import Base
-from dev_health_ops.models.integrations import Integration, IntegrationSource
+from dev_health_ops.models.integrations import Integration, IntegrationSource, SyncRun
 from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import (
     IntegrationCredential,
@@ -57,6 +57,7 @@ _TABLES = tables_of(
     Setting,
     Integration,
     IntegrationSource,
+    SyncRun,
     BackfillJob,
 )
 
@@ -265,6 +266,56 @@ async def test_backfill_legacy_passes_pending_run_id_to_task(client):
 
 
 @pytest.mark.asyncio
+async def test_backfill_legacy_enqueue_failure_marks_committed_records_failed(
+    client, session_maker
+):
+    ac, _ = client
+
+    create_resp = await _create_sync_config(
+        ac, name="bf-legacy-enqueue-fails", provider="github"
+    )
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+
+    mock_run_backfill = MagicMock()
+    mock_run_backfill.delay.side_effect = RuntimeError("broker down")
+
+    with (
+        patch("dev_health_ops.workers.sync_tasks.run_backfill", mock_run_backfill),
+        patch.dict("os.environ", {"SYNC_FANOUT_BACKFILL": ""}),
+    ):
+        resp = await ac.post(
+            f"/api/v1/admin/sync-configs/{config_id}/backfill",
+            json={"since": "2026-01-01", "before": "2026-01-08"},
+        )
+
+    assert resp.status_code == 503
+    assert "Task queue unavailable: broker down" in resp.json()["detail"]
+
+    async with session_maker() as session:
+        backfill_job = (await session.execute(select(BackfillJob))).scalar_one()
+        sched_job = (
+            await session.execute(
+                select(ScheduledJob).where(
+                    ScheduledJob.sync_config_id == uuid.UUID(config_id),
+                    ScheduledJob.job_type == "sync",
+                )
+            )
+        ).scalar_one()
+        job_run = (
+            await session.execute(select(JobRun).where(JobRun.job_id == sched_job.id))
+        ).scalar_one()
+
+    assert backfill_job.status == "failed"
+    assert backfill_job.error_message == "enqueue failed: broker down"
+    assert backfill_job.completed_at is not None
+    assert backfill_job.celery_task_id is None
+    assert job_run.status == JobRunStatus.FAILED.value
+    assert job_run.error == "enqueue failed: broker down"
+    assert job_run.completed_at is not None
+
+
+@pytest.mark.asyncio
 async def test_backfill_fanout_does_not_create_job_run(
     client, session_maker, seeded_state
 ):
@@ -383,6 +434,59 @@ async def test_backfill_fanout_commits_backfill_job_before_dispatch(
         result = await session.execute(select(BackfillJob))
         backfill_job = result.scalar_one()
     assert backfill_job.celery_task_id == "bf-fanout-visible-task-id"
+
+
+@pytest.mark.asyncio
+async def test_backfill_fanout_enqueue_failure_marks_backfill_job_failed(
+    client, session_maker, seeded_state
+):
+    ac, _ = client
+
+    create_resp = await _create_sync_config(
+        ac, name="bf-fanout-enqueue-fails", provider="github"
+    )
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(SyncConfiguration).where(
+                SyncConfiguration.id == uuid.UUID(config_id)
+            )
+        )
+        cfg = result.scalar_one()
+        integration_id = uuid.uuid4()
+        setattr(cfg, "migrated_integration_id", integration_id)
+        cfg.planner_managed = True
+        await session.commit()
+    await _seed_source(session_maker, seeded_state["org_id"], integration_id)
+
+    mock_run_backfill = MagicMock()
+    mock_run_backfill.delay.side_effect = RuntimeError("broker down")
+
+    with (
+        patch("dev_health_ops.workers.sync_tasks.run_backfill", mock_run_backfill),
+        patch.dict("os.environ", {"SYNC_FANOUT_BACKFILL": ""}),
+    ):
+        resp = await ac.post(
+            f"/api/v1/admin/sync-configs/{config_id}/backfill",
+            json={"since": "2026-01-01", "before": "2026-01-08"},
+        )
+
+    assert resp.status_code == 503
+    assert "Task queue unavailable: broker down" in resp.json()["detail"]
+
+    async with session_maker() as session:
+        backfill_job = (await session.execute(select(BackfillJob))).scalar_one()
+        job_runs = list((await session.execute(select(JobRun))).scalars().all())
+        sync_runs = list((await session.execute(select(SyncRun))).scalars().all())
+
+    assert backfill_job.status == "failed"
+    assert backfill_job.error_message == "enqueue failed: broker down"
+    assert backfill_job.completed_at is not None
+    assert backfill_job.celery_task_id is None
+    assert job_runs == []
+    assert sync_runs == []
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -403,6 +403,46 @@ async def test_backfill_sourceless_migrated_config_without_flag_uses_legacy_path
     assert call_kwargs.get("pending_run_id") is not None
 
 
+@pytest.mark.asyncio
+async def test_backfill_paused_config_returns_409_without_dispatch(
+    client, session_maker
+):
+    ac, _ = client
+
+    create_resp = await _create_sync_config(
+        ac, name="bf-paused-rejected", provider="github"
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = create_resp.json()["id"]
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(SyncConfiguration).where(
+                SyncConfiguration.id == uuid.UUID(config_id)
+            )
+        )
+        cfg = result.scalar_one()
+        cfg.is_active = False
+        await session.commit()
+
+    mock_run_backfill = MagicMock()
+    with patch("dev_health_ops.workers.sync_tasks.run_backfill", mock_run_backfill):
+        resp = await ac.post(
+            f"/api/v1/admin/sync-configs/{config_id}/backfill",
+            json={"since": "2026-01-01", "before": "2026-01-08"},
+        )
+
+    assert resp.status_code == 409
+    assert "paused" in resp.json()["detail"]
+    mock_run_backfill.delay.assert_not_called()
+
+    async with session_maker() as session:
+        job_runs = (await session.execute(select(JobRun))).scalars().all()
+        backfill_jobs = (await session.execute(select(BackfillJob))).scalars().all()
+    assert job_runs == []
+    assert backfill_jobs == []
+
+
 # ---------------------------------------------------------------------------
 # Worker-level tests — JobRun state transitions
 # ---------------------------------------------------------------------------
@@ -568,6 +608,7 @@ async def test_run_backfill_worker_transitions_job_run_running_then_failed(
 def test_run_backfill_helpers_noop_on_none():
     """All three JobRun helpers must silently no-op when pending_run_id is None."""
     from dev_health_ops.workers.sync_backfill import (
+        _mark_sync_job_run_cancelled,
         _mark_sync_job_run_failed,
         _mark_sync_job_run_running,
         _mark_sync_job_run_success,
@@ -579,6 +620,7 @@ def test_run_backfill_helpers_noop_on_none():
         _mark_sync_job_run_running(None, now)
         _mark_sync_job_run_success(None, now)
         _mark_sync_job_run_failed(None, "err", now)
+        _mark_sync_job_run_cancelled(None, "err", now)
     mock_pg.assert_not_called()
 
 

--- a/tests/api/admin/test_org_deletion.py
+++ b/tests/api/admin/test_org_deletion.py
@@ -269,7 +269,8 @@ async def test_org_deletion_dry_run_returns_contract_without_deleting(session_ma
         assert payload["postgres"]["tables"]["organizations"] == 1
         assert payload["postgres"]["tables"]["settings"] == 1
         assert payload["postgres"]["tables"]["scheduled_jobs"] == 2
-        assert payload["clickhouse"] == {"total": 0, "tables": {}}
+        assert payload["clickhouse"]["total"] == 0
+        assert all(count == 0 for count in payload["clickhouse"]["tables"].values())
         assert payload["disabled_jobs"] == 2
         assert payload["credentials_deleted"] == 3
         # Warnings depend on whether ClickHouse is reachable in the environment

--- a/tests/api/admin/test_sync_config_deprecation.py
+++ b/tests/api/admin/test_sync_config_deprecation.py
@@ -4,8 +4,7 @@ Covers:
 - HIDE_MIGRATED_CHILD_CONFIGS flag hides migrated children from default list
 - ?include_migrated=true bypasses the filter (support/rollback)
 - Flag OFF → legacy list unchanged
-- Planner flag ON → batch endpoint creates zero child SyncConfiguration rows
-- Planner flag OFF → batch endpoint creates children (legacy path)
+- Batch endpoint creates one planner-managed parent plus Integration rows
 - Legacy single-config endpoints (get/create/update/delete) still work
 """
 
@@ -25,6 +24,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.models.git import Base
+from dev_health_ops.models.integrations import (
+    Integration,
+    IntegrationDataset,
+    IntegrationSource,
+)
 from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import (
     IntegrationCredential,
@@ -50,6 +54,9 @@ _TABLES = tables_of(
     ScheduledJob,
     JobRun,
     Setting,
+    Integration,
+    IntegrationSource,
+    IntegrationDataset,
 )
 
 
@@ -270,13 +277,10 @@ async def test_list_include_migrated_false_with_flag_off_returns_all(
 
 
 # ---------------------------------------------------------------------------
-# Planner flag gates new child-config creation
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
-async def test_batch_rejects_with_409_when_planner_active(client, session_maker):
-    """When planner flag is ON, batch rejects with 409 (no inert legacy parent)."""
+async def test_batch_creates_planner_parent_when_planner_flag_active(
+    client, session_maker
+):
     ac, seeded_state = client
     org_id = seeded_state["org_id"]
     await _seed_planner_flag(session_maker, org_id, value="true")
@@ -292,9 +296,12 @@ async def test_batch_rejects_with_409_when_planner_active(client, session_maker)
         },
     )
 
-    assert resp.status_code == 409
-    # planner-active rejects the deprecated child-config batch BEFORE writing
-    # an inert legacy parent; nothing is created.
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["total_created"] == 0
+    assert data["children"] == []
+    assert data["parent"]["name"] == "planner-active-batch"
+
     async with session_maker() as session:
         result = await session.execute(
             select(SyncConfiguration).where(
@@ -302,16 +309,35 @@ async def test_batch_rejects_with_409_when_planner_active(client, session_maker)
                 SyncConfiguration.name == "planner-active-batch",
             )
         )
-        created = result.scalars().all()
-    assert created == []
+        parent = result.scalar_one()
+
+        child_result = await session.execute(
+            select(SyncConfiguration).where(SyncConfiguration.parent_id == parent.id)
+        )
+        children = child_result.scalars().all()
+
+        source_result = await session.execute(
+            select(IntegrationSource).where(
+                IntegrationSource.integration_id == parent.migrated_integration_id
+            )
+        )
+        sources = source_result.scalars().all()
+
+    assert parent.planner_managed is True
+    assert parent.migrated_integration_id is not None
+    assert children == []
+    assert {source.external_id for source in sources} == {
+        "myorg/repo-a",
+        "myorg/repo-b",
+    }
 
 
 @pytest.mark.asyncio
-async def test_batch_creates_children_when_planner_inactive(client, session_maker):
-    """When planner flag is OFF (no Setting row), batch creates children normally."""
+async def test_batch_creates_planner_parent_when_planner_flag_inactive(
+    client, session_maker
+):
     ac, seeded_state = client
     org_id = seeded_state["org_id"]
-    # No planner flag seeded → legacy path
 
     resp = await ac.post(
         "/api/v1/admin/sync-configs/batch",
@@ -326,19 +352,43 @@ async def test_batch_creates_children_when_planner_inactive(client, session_make
 
     assert resp.status_code == 201
     data = resp.json()
-    assert data["total_created"] == 2
-    assert len(data["children"]) == 2
+    assert data["total_created"] == 0
+    assert data["children"] == []
+    assert data["parent"]["name"] == "legacy-batch"
 
-    # Verify child rows in DB
     async with session_maker() as session:
         result = await session.execute(
             select(SyncConfiguration).where(
                 SyncConfiguration.org_id == org_id,
-                SyncConfiguration.parent_id.isnot(None),
+                SyncConfiguration.name == "legacy-batch",
             )
         )
-        children = result.scalars().all()
-    assert len(children) == 2
+        parent = result.scalar_one()
+
+        child_result = await session.execute(
+            select(SyncConfiguration).where(SyncConfiguration.parent_id == parent.id)
+        )
+        children = child_result.scalars().all()
+
+        integration = await session.get(Integration, parent.migrated_integration_id)
+
+        dataset_result = await session.execute(
+            select(IntegrationDataset).where(
+                IntegrationDataset.integration_id == parent.migrated_integration_id
+            )
+        )
+        datasets = dataset_result.scalars().all()
+
+    assert parent.planner_managed is True
+    assert parent.migrated_integration_id is not None
+    assert children == []
+    assert integration is not None
+    assert {dataset.dataset_key for dataset in datasets} == {
+        "commits",
+        "commit-stats",
+        "files",
+        "repo-metadata",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -348,6 +348,50 @@ async def test_batch_create_counts_cross_provider_planner_sources_for_repo_limit
 
 
 @pytest.mark.asyncio
+async def test_single_create_counts_existing_planner_sources_for_repo_limit(
+    client, monkeypatch
+):
+    ac, _ = client
+    requested_counts = []
+
+    class TierLimitStub:
+        def __init__(self, _session):
+            pass
+
+        def check_repo_limit(self, _org_id, requested_count):
+            requested_counts.append(requested_count)
+            if requested_count > 2:
+                return False, "Repo limit exceeded"
+            return True, None
+
+    monkeypatch.setattr(sync_router_module, "TierLimitService", TierLimitStub)
+
+    batch = await ac.post(
+        "/api/v1/admin/sync-configs/batch",
+        json={
+            "name": "repo-cap-batch",
+            "provider": "github",
+            "sync_targets": ["git"],
+            "sync_options": {"owner": "full-chaos"},
+            "repos": ["one", "two"],
+        },
+    )
+    single = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": "repo-cap-single",
+            "provider": "github",
+            "sync_targets": ["git"],
+            "sync_options": {"owner": "full-chaos", "repo": "three"},
+        },
+    )
+
+    assert batch.status_code == 201, batch.text
+    assert single.status_code == 403, single.text
+    assert requested_counts == [2, 3]
+
+
+@pytest.mark.asyncio
 async def test_get_sync_config_by_id(client):
     ac, _ = client
 

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -392,6 +392,104 @@ async def test_single_create_counts_existing_planner_sources_for_repo_limit(
 
 
 @pytest.mark.asyncio
+async def test_create_sync_config_acquires_repo_limit_lock_before_count(
+    client, monkeypatch
+):
+    ac, _ = client
+    calls: list[str] = []
+
+    async def acquire_lock(_session, _org_id):
+        calls.append("lock")
+
+    async def count_repos(_session, _org_id):
+        calls.append("count")
+        return 0
+
+    monkeypatch.setattr(
+        sync_router_module, "_acquire_repo_limit_create_lock", acquire_lock
+    )
+    monkeypatch.setattr(
+        sync_router_module, "_active_repo_usage_count_for_limit", count_repos
+    )
+
+    resp = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": "lock-before-count-single",
+            "provider": "github",
+            "sync_targets": ["git"],
+            "sync_options": {"owner": "full-chaos", "repo": "dev-health"},
+        },
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert calls[:2] == ["lock", "count"]
+
+
+@pytest.mark.asyncio
+async def test_batch_create_sync_configs_acquires_repo_limit_lock_before_count(
+    client, monkeypatch
+):
+    ac, _ = client
+    calls: list[str] = []
+
+    async def acquire_lock(_session, _org_id):
+        calls.append("lock")
+
+    async def count_repos(_session, _org_id):
+        calls.append("count")
+        return 0
+
+    monkeypatch.setattr(
+        sync_router_module, "_acquire_repo_limit_create_lock", acquire_lock
+    )
+    monkeypatch.setattr(
+        sync_router_module, "_active_repo_usage_count_for_limit", count_repos
+    )
+
+    resp = await ac.post(
+        "/api/v1/admin/sync-configs/batch",
+        json={
+            "name": "lock-before-count-batch",
+            "provider": "github",
+            "sync_targets": ["git"],
+            "sync_options": {"owner": "full-chaos"},
+            "repos": ["dev-health"],
+        },
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert calls[:2] == ["lock", "count"]
+
+
+@pytest.mark.asyncio
+async def test_repo_limit_advisory_lock_key_is_deterministic_and_sqlite_noops(
+    session_maker,
+):
+    org_uuid = str(uuid.uuid4())
+    slug = "full-chaos/test-org"
+
+    assert sync_router_module._repo_limit_advisory_lock_key(
+        org_uuid
+    ) == sync_router_module._repo_limit_advisory_lock_key(org_uuid)
+    assert sync_router_module._repo_limit_advisory_lock_key(
+        slug
+    ) == sync_router_module._repo_limit_advisory_lock_key(slug)
+    assert 0 <= sync_router_module._repo_limit_advisory_lock_key(slug) < 2**63
+    assert sync_router_module._repo_limit_advisory_lock_key(
+        org_uuid
+    ) != sync_router_module._repo_limit_advisory_lock_key(slug)
+
+    async with session_maker() as session:
+        execute = AsyncMock()
+        session.execute = execute
+
+        await sync_router_module._acquire_repo_limit_create_lock(session, org_uuid)
+
+    execute.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_sync_config_by_id(client):
     ac, _ = client
 

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -14,6 +14,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.models.git import Base
+from dev_health_ops.models.integrations import (
+    Integration,
+    IntegrationDataset,
+    IntegrationSource,
+    SyncRun,
+)
 from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import (
     IntegrationCredential,
@@ -39,6 +45,10 @@ _TABLES = tables_of(
     ScheduledJob,
     JobRun,
     Setting,
+    Integration,
+    IntegrationSource,
+    IntegrationDataset,
+    SyncRun,
 )
 
 
@@ -1012,6 +1022,63 @@ async def test_trigger_marks_pending_job_run_failed_when_enqueue_fails(
     assert run.error == "dispatch enqueue failed: broker down"
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("trigger_child", [False, True])
+async def test_trigger_inactive_config_returns_409_without_execution(
+    client, session_maker, trigger_child
+):
+    ac, seeded_state = client
+    org_id = seeded_state["org_id"]
+
+    async with session_maker() as session:
+        parent = SyncConfiguration(
+            name="paused-parent",
+            provider="github",
+            org_id=org_id,
+            sync_targets=["git"],
+            is_active=False,
+        )
+        session.add(parent)
+        await session.flush()
+        target_id = parent.id
+        if trigger_child:
+            child = SyncConfiguration(
+                name="paused-parent/repo",
+                provider="github",
+                org_id=org_id,
+                sync_targets=["git"],
+                sync_options={"owner": "paused-parent", "repo": "repo"},
+                is_active=False,
+                parent_id=parent.id,
+            )
+            session.add(child)
+            await session.flush()
+            target_id = child.id
+        await session.commit()
+
+    mock_run = MagicMock()
+    mock_batch = MagicMock()
+    mock_dispatch = MagicMock()
+    with (
+        patch("dev_health_ops.workers.sync_tasks.run_sync_config", mock_run),
+        patch("dev_health_ops.workers.sync_tasks.dispatch_batch_sync", mock_batch),
+        patch("dev_health_ops.api.admin.routers.sync.dispatch_sync_run", mock_dispatch),
+    ):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{target_id}/trigger")
+
+    assert resp.status_code == 409
+    assert "paused" in resp.json()["detail"]
+    mock_run.apply_async.assert_not_called()
+    mock_batch.apply_async.assert_not_called()
+    mock_dispatch.apply_async.assert_not_called()
+
+    async with session_maker() as session:
+        job_runs = (await session.execute(select(JobRun))).scalars().all()
+        sync_runs = (await session.execute(select(SyncRun))).scalars().all()
+    assert job_runs == []
+    assert sync_runs == []
+
+
 def test_sync_tasks_accept_pending_run_id_kwarg():
     """The dispatched Celery tasks must accept every kwarg the trigger endpoint
     passes. Celery validates kwargs against the task signature at dispatch time,
@@ -1099,9 +1166,10 @@ def _gitlab_project(project_id: int, name: str, full_name: str):
 
 
 @pytest.mark.asyncio
-async def test_batch_create_github_children_keep_owner_repo_options(client):
-    """Regression: GitHub child options remain owner/repo-shaped, unchanged."""
-    ac, _ = client
+async def test_batch_create_github_creates_planner_config_without_children(
+    client, session_maker
+):
+    ac, seeded_state = client
 
     resp = await ac.post(
         "/api/v1/admin/sync-configs/batch",
@@ -1117,18 +1185,56 @@ async def test_batch_create_github_children_keep_owner_repo_options(client):
 
     assert resp.status_code == 201, resp.text
     data = resp.json()
-    assert data["total_created"] == 2
-    assert [c["name"] for c in data["children"]] == ["acme/alpha", "acme/beta"]
-    for child, repo in zip(data["children"], ["alpha", "beta"]):
-        assert child["sync_options"] == {
-            "owner": "acme",
-            "schedule_cron": "0 3 * * *",
-            "repo": repo,
-        }
+    assert data["total_created"] == 0
+    assert data["children"] == []
+    assert data["parent"]["is_active"] is True
+
+    async with session_maker() as session:
+        config_id = uuid.UUID(data["parent"]["id"])
+        children = (
+            (
+                await session.execute(
+                    select(SyncConfiguration).where(
+                        SyncConfiguration.parent_id == config_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        integrations = (
+            (
+                await session.execute(
+                    select(Integration).where(
+                        Integration.org_id == seeded_state["org_id"]
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        sources = (await session.execute(select(IntegrationSource))).scalars().all()
+        datasets = (await session.execute(select(IntegrationDataset))).scalars().all()
+        jobs = (await session.execute(select(ScheduledJob))).scalars().all()
+
+    assert children == []
+    assert len(integrations) == 1
+    assert str(data["parent"]["id"])
+    assert len(sources) == 2
+    assert {source.external_id for source in sources} == {"acme/alpha", "acme/beta"}
+    assert {dataset.dataset_key for dataset in datasets} >= {
+        "repo-metadata",
+        "commits",
+        "prs",
+    }
+    assert len(jobs) == 1
+    assert jobs[0].status == JobStatus.ACTIVE.value
 
 
 @pytest.mark.asyncio
-async def test_batch_create_gitlab_children_get_project_id_and_group(client):
+async def test_batch_create_gitlab_children_get_project_id_and_group(
+    client, session_maker
+):
     """GitLab children carry int project_id + group (+ gitlab_url), not repo."""
     ac, _ = client
     credential_id = str(uuid.uuid4())
@@ -1173,28 +1279,21 @@ async def test_batch_create_gitlab_children_get_project_id_and_group(client):
 
     assert resp.status_code == 201, resp.text
     data = resp.json()
-    assert data["total_created"] == 2
+    assert data["total_created"] == 0
+    assert data["children"] == []
 
     mock_connector_cls.assert_called_once_with(
         url="https://gitlab.example.com", private_token="glpat-test"
     )
     mock_connector.list_repositories.assert_called_once_with(org_name="acme-group")
 
-    # Child names use path_with_namespace.
-    assert [c["name"] for c in data["children"]] == [
+    async with session_maker() as session:
+        sources = (await session.execute(select(IntegrationSource))).scalars().all()
+    assert {source.external_id for source in sources} == {"101", "202"}
+    assert {source.full_name for source in sources} == {
         "acme-group/alpha",
         "acme-group/sub/beta",
-    ]
-    for child, project_id in zip(data["children"], [101, 202]):
-        assert child["sync_options"] == {
-            "gitlab_url": "https://gitlab.example.com",
-            "schedule_cron": "0 3 * * *",
-            "project_id": project_id,
-            "group": "acme-group",
-        }
-        assert isinstance(child["sync_options"]["project_id"], int)
-        assert "repo" not in child["sync_options"]
-        assert "owner" not in child["sync_options"]
+    }
 
 
 @pytest.mark.asyncio
@@ -1215,16 +1314,8 @@ async def test_batch_create_gitlab_numeric_ids_skip_resolution(client):
 
     assert resp.status_code == 201, resp.text
     data = resp.json()
-    assert data["total_created"] == 2
-    assert [c["name"] for c in data["children"]] == [
-        "acme-group/123",
-        "acme-group/456",
-    ]
-    for child, project_id in zip(data["children"], [123, 456]):
-        assert child["sync_options"] == {
-            "group": "acme-group",
-            "project_id": project_id,
-        }
+    assert data["total_created"] == 0
+    assert data["children"] == []
 
 
 @pytest.mark.asyncio
@@ -1287,7 +1378,9 @@ async def test_batch_create_gitlab_names_without_credential_returns_400(client):
 
 
 @pytest.mark.asyncio
-async def test_batch_create_gitlab_credential_url_persisted_into_children(client):
+async def test_batch_create_gitlab_credential_url_persisted_into_children(
+    client, session_maker
+):
     """Self-hosted URL from the credential lands in parent + child options.
 
     Regression: name resolution used the credential's self-hosted URL but
@@ -1345,17 +1438,16 @@ async def test_batch_create_gitlab_credential_url_persisted_into_children(client
         data["parent"]["sync_options"]["gitlab_url"]
         == "https://gitlab.internal.example.com"
     )
-    child = data["children"][0]
-    assert child["sync_options"] == {
-        "gitlab_url": "https://gitlab.internal.example.com",
-        "project_id": 101,
-        "group": "acme-group",
-    }
+    assert data["children"] == []
+    async with session_maker() as session:
+        source = (await session.execute(select(IntegrationSource))).scalar_one()
+    assert source.external_id == "101"
+    assert source.full_name == "acme-group/alpha"
 
 
 @pytest.mark.asyncio
 async def test_batch_create_gitlab_numeric_entry_matching_name_resolves_as_name(
-    client,
+    client, session_maker
 ):
     """A numeric entry that matches a listed project NAME is a name, not an id."""
     ac, _ = client
@@ -1398,14 +1490,17 @@ async def test_batch_create_gitlab_numeric_entry_matching_name_resolves_as_name(
     data = resp.json()
     mock_connector.list_repositories.assert_called_once_with(org_name="acme-group")
 
-    child = data["children"][0]
-    # Resolved via the listing as the project named "007" — NOT project id 7.
-    assert child["name"] == "acme-group/007"
-    assert child["sync_options"]["project_id"] == 7007
+    assert data["children"] == []
+    async with session_maker() as session:
+        source = (await session.execute(select(IntegrationSource))).scalar_one()
+    assert source.full_name == "acme-group/007"
+    assert source.external_id == "7007"
 
 
 @pytest.mark.asyncio
-async def test_batch_create_gitlab_numeric_entry_not_in_listing_used_as_id(client):
+async def test_batch_create_gitlab_numeric_entry_not_in_listing_used_as_id(
+    client, session_maker
+):
     """A numeric entry matching no listed name keeps project-id semantics."""
     ac, _ = client
     credential_id = str(uuid.uuid4())
@@ -1447,7 +1542,8 @@ async def test_batch_create_gitlab_numeric_entry_not_in_listing_used_as_id(clien
     # The listing WAS consulted (credential + group present)...
     mock_connector.list_repositories.assert_called_once_with(org_name="acme-group")
 
-    child = data["children"][0]
-    # ...but "12345" matched no listed name, so it stays an id.
-    assert child["sync_options"]["project_id"] == 12345
-    assert child["name"] == "acme-group/12345"
+    assert data["children"] == []
+    async with session_maker() as session:
+        source = (await session.execute(select(IntegrationSource))).scalar_one()
+    assert source.external_id == "12345"
+    assert source.full_name == "acme-group/12345"

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -303,6 +303,49 @@ async def test_batch_create_linear_without_repos_creates_active_config_and_job(
 
 
 @pytest.mark.asyncio
+async def test_batch_create_counts_planner_sources_for_repo_limit(client, monkeypatch):
+    ac, _ = client
+    requested_counts = []
+
+    class TierLimitStub:
+        def __init__(self, _session):
+            pass
+
+        def check_repo_limit(self, _org_id, requested_count):
+            requested_counts.append(requested_count)
+            if requested_count > 3:
+                return False, "Repo limit exceeded"
+            return True, None
+
+    monkeypatch.setattr(sync_router_module, "TierLimitService", TierLimitStub)
+
+    first = await ac.post(
+        "/api/v1/admin/sync-configs/batch",
+        json={
+            "name": "repo-cap-one",
+            "provider": "github",
+            "sync_targets": ["git"],
+            "sync_options": {"owner": "full-chaos"},
+            "repos": ["one", "two"],
+        },
+    )
+    second = await ac.post(
+        "/api/v1/admin/sync-configs/batch",
+        json={
+            "name": "repo-cap-two",
+            "provider": "github",
+            "sync_targets": ["git"],
+            "sync_options": {"owner": "full-chaos"},
+            "repos": ["three", "four"],
+        },
+    )
+
+    assert first.status_code == 201, first.text
+    assert second.status_code == 403, second.text
+    assert requested_counts == [2, 4]
+
+
+@pytest.mark.asyncio
 async def test_get_sync_config_by_id(client):
     ac, _ = client
 

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -303,7 +303,9 @@ async def test_batch_create_linear_without_repos_creates_active_config_and_job(
 
 
 @pytest.mark.asyncio
-async def test_batch_create_counts_planner_sources_for_repo_limit(client, monkeypatch):
+async def test_batch_create_counts_cross_provider_planner_sources_for_repo_limit(
+    client, monkeypatch
+):
     ac, _ = client
     requested_counts = []
 
@@ -332,11 +334,11 @@ async def test_batch_create_counts_planner_sources_for_repo_limit(client, monkey
     second = await ac.post(
         "/api/v1/admin/sync-configs/batch",
         json={
-            "name": "repo-cap-two",
-            "provider": "github",
+            "name": "repo-cap-gitlab",
+            "provider": "gitlab",
             "sync_targets": ["git"],
-            "sync_options": {"owner": "full-chaos"},
-            "repos": ["three", "four"],
+            "sync_options": {"group": "full-chaos"},
+            "repos": ["3", "4"],
         },
     )
 

--- a/tests/api/admin/test_sync_trigger_routing.py
+++ b/tests/api/admin/test_sync_trigger_routing.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.models.git import Base
+from dev_health_ops.models.integrations import Integration, IntegrationSource
 from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import (
     IntegrationCredential,
@@ -47,6 +48,8 @@ _TABLES = tables_of(
     ScheduledJob,
     JobRun,
     Setting,
+    Integration,
+    IntegrationSource,
 )
 
 
@@ -168,6 +171,32 @@ async def _seed_planner_flag(session_maker, org_id: str, value: str = "true"):
         await session.commit()
 
 
+async def _seed_source(session_maker, org_id: str, integration_id: uuid.UUID) -> None:
+    async with session_maker() as session:
+        session.add(
+            Integration(
+                id=integration_id,
+                org_id=org_id,
+                provider="github",
+                name="github-integration",
+                config={},
+            )
+        )
+        session.add(
+            IntegrationSource(
+                org_id=org_id,
+                integration_id=integration_id,
+                provider="github",
+                source_type="repository",
+                external_id="full-chaos/dev-health",
+                name="dev-health",
+                full_name="full-chaos/dev-health",
+                is_enabled=True,
+            )
+        )
+        await session.commit()
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -184,6 +213,7 @@ async def test_flag_on_migrated_config_uses_planner_path(client, session_maker):
     config_id = await _seed_config(
         session_maker, org_id, migrated_integration_id=integration_id
     )
+    await _seed_source(session_maker, org_id, integration_id)
     await _seed_planner_flag(session_maker, org_id, value="true")
 
     fake_plan = MagicMock()
@@ -304,6 +334,7 @@ async def test_planner_managed_config_routes_without_flag(client, session_maker)
     config_id = await _seed_config(
         session_maker, org_id, migrated_integration_id=integration_id
     )
+    await _seed_source(session_maker, org_id, integration_id)
 
     fake_plan = MagicMock()
     fake_plan.sync_run_id = str(uuid.uuid4())
@@ -339,6 +370,54 @@ async def test_planner_managed_config_routes_without_flag(client, session_maker)
     )
     fake_run_sync_config.apply_async.assert_not_called()
     fake_dispatch_batch_sync.apply_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sourceless_migrated_config_without_flag_uses_legacy_path(
+    client, session_maker
+):
+    ac, seeded_state = client
+    org_id = seeded_state["org_id"]
+
+    config_id = await _seed_config(
+        session_maker, org_id, migrated_integration_id=uuid.uuid4()
+    )
+
+    fake_plan = MagicMock()
+    fake_plan.sync_run_id = str(uuid.uuid4())
+    fake_plan.total_units = 2
+    fake_dispatch = MagicMock()
+    fake_dispatch.apply_async = MagicMock(return_value=MagicMock(id="task-planner"))
+    fake_task_result = MagicMock()
+    fake_task_result.id = "legacy-task-id"
+    fake_run_sync_config = MagicMock()
+    fake_run_sync_config.apply_async = MagicMock(return_value=fake_task_result)
+    fake_dispatch_batch_sync = MagicMock()
+    fake_dispatch_batch_sync.apply_async = MagicMock(return_value=fake_task_result)
+
+    with (
+        patch(
+            "dev_health_ops.api.admin.routers.sync.plan_sync_run",
+            return_value=fake_plan,
+        ) as mock_plan,
+        patch("dev_health_ops.api.admin.routers.sync.dispatch_sync_run", fake_dispatch),
+        patch.dict(
+            "sys.modules",
+            {
+                "dev_health_ops.workers.sync_tasks": MagicMock(
+                    run_sync_config=fake_run_sync_config,
+                    dispatch_batch_sync=fake_dispatch_batch_sync,
+                )
+            },
+        ),
+    ):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 202, resp.text
+    assert "sync_run_id" not in resp.json()
+    mock_plan.assert_not_called()
+    fake_dispatch.apply_async.assert_not_called()
+    fake_run_sync_config.apply_async.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_sync_trigger_routing.py
+++ b/tests/api/admin/test_sync_trigger_routing.py
@@ -142,6 +142,19 @@ async def _seed_config(
         return str(config.id)
 
 
+async def _seed_child(session_maker, org_id: str, parent_id: str) -> None:
+    async with session_maker() as session:
+        child = SyncConfiguration(
+            name="test-config/child",
+            provider="github",
+            org_id=org_id,
+            sync_targets=["git"],
+            parent_id=uuid.UUID(parent_id),
+        )
+        session.add(child)
+        await session.commit()
+
+
 async def _seed_planner_flag(session_maker, org_id: str, value: str = "true"):
     """Write the migrated_trigger_routing_enabled Setting row."""
     async with session_maker() as session:
@@ -232,6 +245,7 @@ async def test_flag_off_uses_legacy_path(client, session_maker):
     config_id = await _seed_config(
         session_maker, org_id, migrated_integration_id=integration_id
     )
+    await _seed_child(session_maker, org_id, config_id)
     # No flag seeded => flag is off
 
     fake_plan = MagicMock()
@@ -279,6 +293,52 @@ async def test_flag_off_uses_legacy_path(client, session_maker):
     # Planner was NOT called
     mock_plan.assert_not_called()
     fake_dispatch.apply_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_planner_managed_config_routes_without_flag(client, session_maker):
+    ac, seeded_state = client
+    org_id = seeded_state["org_id"]
+
+    integration_id = uuid.uuid4()
+    config_id = await _seed_config(
+        session_maker, org_id, migrated_integration_id=integration_id
+    )
+
+    fake_plan = MagicMock()
+    fake_plan.sync_run_id = str(uuid.uuid4())
+    fake_plan.total_units = 2
+    fake_dispatch = MagicMock()
+    fake_dispatch.apply_async = MagicMock(return_value=MagicMock(id="task-planner"))
+    fake_run_sync_config = MagicMock()
+    fake_dispatch_batch_sync = MagicMock()
+
+    with (
+        patch(
+            "dev_health_ops.api.admin.routers.sync.plan_sync_run",
+            return_value=fake_plan,
+        ) as mock_plan,
+        patch("dev_health_ops.api.admin.routers.sync.dispatch_sync_run", fake_dispatch),
+        patch.dict(
+            "sys.modules",
+            {
+                "dev_health_ops.workers.sync_tasks": MagicMock(
+                    run_sync_config=fake_run_sync_config,
+                    dispatch_batch_sync=fake_dispatch_batch_sync,
+                )
+            },
+        ),
+    ):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 202, resp.text
+    assert resp.json()["sync_run_id"] == fake_plan.sync_run_id
+    mock_plan.assert_called_once()
+    fake_dispatch.apply_async.assert_called_once_with(
+        args=(fake_plan.sync_run_id,), queue="sync"
+    )
+    fake_run_sync_config.apply_async.assert_not_called()
+    fake_dispatch_batch_sync.apply_async.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_sync_trigger_routing.py
+++ b/tests/api/admin/test_sync_trigger_routing.py
@@ -130,6 +130,7 @@ async def _seed_config(
     org_id: str,
     *,
     migrated_integration_id: uuid.UUID | None = None,
+    planner_managed: bool = False,
 ) -> str:
     """Seed a SyncConfiguration and return its id."""
     async with session_maker() as session:
@@ -139,6 +140,7 @@ async def _seed_config(
             org_id=org_id,
             sync_targets=["git"],
             migrated_integration_id=migrated_integration_id,
+            planner_managed=planner_managed,
         )
         session.add(config)
         await session.commit()
@@ -211,7 +213,9 @@ async def test_flag_on_migrated_config_uses_planner_path(client, session_maker):
 
     integration_id = uuid.uuid4()
     config_id = await _seed_config(
-        session_maker, org_id, migrated_integration_id=integration_id
+        session_maker,
+        org_id,
+        migrated_integration_id=integration_id,
     )
     await _seed_source(session_maker, org_id, integration_id)
     await _seed_planner_flag(session_maker, org_id, value="true")
@@ -273,7 +277,9 @@ async def test_flag_off_uses_legacy_path(client, session_maker):
 
     integration_id = uuid.uuid4()
     config_id = await _seed_config(
-        session_maker, org_id, migrated_integration_id=integration_id
+        session_maker,
+        org_id,
+        migrated_integration_id=integration_id,
     )
     await _seed_child(session_maker, org_id, config_id)
     # No flag seeded => flag is off
@@ -332,7 +338,10 @@ async def test_planner_managed_config_routes_without_flag(client, session_maker)
 
     integration_id = uuid.uuid4()
     config_id = await _seed_config(
-        session_maker, org_id, migrated_integration_id=integration_id
+        session_maker,
+        org_id,
+        migrated_integration_id=integration_id,
+        planner_managed=True,
     )
     await _seed_source(session_maker, org_id, integration_id)
 

--- a/tests/test_backfill_fanout.py
+++ b/tests/test_backfill_fanout.py
@@ -22,7 +22,14 @@ from dev_health_ops.models import (
     SyncWatermark,
 )
 from dev_health_ops.models.backfill import BackfillJob
-from dev_health_ops.models.settings import Setting, SettingCategory, SyncConfiguration
+from dev_health_ops.models.settings import (
+    JobRun,
+    JobRunStatus,
+    ScheduledJob,
+    Setting,
+    SettingCategory,
+    SyncConfiguration,
+)
 from dev_health_ops.sync.trigger_routing import MIGRATED_TRIGGER_ROUTING_SETTING_KEY
 from dev_health_ops.sync.watermarks import get_watermark, set_watermark
 
@@ -373,6 +380,86 @@ def test_run_backfill_uses_legacy_path_when_feature_flag_off(db_session, monkeyp
     assert legacy_calls[0]["sync_config_id"] == str(config.id)
     assert legacy_calls[0]["since"] == date(2026, 6, 1)
     assert legacy_calls[0]["before"] == date(2026, 6, 7)
+
+
+def test_run_backfill_paused_config_marks_backfill_and_job_run_cancelled(
+    db_session, monkeypatch
+):
+    from dev_health_ops.backfill import runner
+    from dev_health_ops.workers import sync_backfill
+
+    config = SyncConfiguration(
+        name="paused backfill",
+        provider="github",
+        org_id=ORG_ID,
+        sync_targets=["git"],
+        sync_options={},
+        is_active=False,
+    )
+    db_session.add(config)
+    db_session.flush()
+    scheduled_job = ScheduledJob(
+        name=f"sync-config-{config.id}",
+        job_type="sync",
+        schedule_cron="0 * * * *",
+        org_id=ORG_ID,
+        provider="github",
+        job_config={},
+        sync_config_id=config.id,
+        tz="UTC",
+        status=1,
+    )
+    db_session.add(scheduled_job)
+    db_session.flush()
+    job_run = JobRun(
+        job_id=scheduled_job.id,
+        triggered_by="backfill",
+        status=JobRunStatus.PENDING.value,
+    )
+    backfill_job = BackfillJob(
+        org_id=ORG_ID,
+        sync_config_id=config.id,
+        status="queued",
+        since_date=date(2026, 6, 1),
+        before_date=date(2026, 6, 7),
+        total_chunks=0,
+        completed_chunks=0,
+        failed_chunks=0,
+    )
+    db_session.add_all([job_run, backfill_job])
+    db_session.commit()
+    _patch_db_session(monkeypatch, db_session)
+
+    monkeypatch.setattr(
+        runner,
+        "run_backfill_for_config",
+        lambda **kwargs: pytest.fail("paused config must not run legacy backfill"),
+    )
+    monkeypatch.setattr(
+        runner,
+        "run_backfill_via_planner",
+        lambda *args, **kwargs: pytest.fail("paused config must not run planner"),
+    )
+
+    run_backfill_task = getattr(sync_backfill.run_backfill, "run")
+    result = run_backfill_task(
+        sync_config_id=str(config.id),
+        since="2026-06-01",
+        before="2026-06-07",
+        org_id=ORG_ID,
+        backfill_job_id=str(backfill_job.id),
+        pending_run_id=str(job_run.id),
+    )
+
+    db_session.refresh(backfill_job)
+    db_session.refresh(job_run)
+    assert result == {"status": "skipped", "reason": "sync_config_inactive"}
+    assert backfill_job.status == "cancelled"
+    assert backfill_job.error_message == "Sync configuration is paused"
+    assert backfill_job.completed_at is not None
+    assert job_run.status == JobRunStatus.CANCELLED.value
+    assert job_run.error == "Sync configuration is paused"
+    assert job_run.completed_at is not None
 
 
 def test_run_backfill_task_fanout_resolves_migrated_integration_id(

--- a/tests/test_backfill_fanout.py
+++ b/tests/test_backfill_fanout.py
@@ -22,7 +22,8 @@ from dev_health_ops.models import (
     SyncWatermark,
 )
 from dev_health_ops.models.backfill import BackfillJob
-from dev_health_ops.models.settings import SyncConfiguration
+from dev_health_ops.models.settings import Setting, SettingCategory, SyncConfiguration
+from dev_health_ops.sync.trigger_routing import MIGRATED_TRIGGER_ROUTING_SETTING_KEY
 from dev_health_ops.sync.watermarks import get_watermark, set_watermark
 
 ORG_ID = "backfill-fanout-org"
@@ -394,6 +395,7 @@ def test_run_backfill_task_fanout_resolves_migrated_integration_id(
         sync_options={},
         is_active=True,
         migrated_integration_id=integration.id,
+        planner_managed=True,
     )
     db_session.add(config)
     db_session.flush()
@@ -473,6 +475,7 @@ def test_run_backfill_task_fanout_child_config_scopes_source(db_session, monkeyp
         is_active=True,
         migrated_integration_id=integration.id,
         migrated_source_id=source.id,
+        planner_managed=True,
     )
     db_session.add(config)
     db_session.flush()
@@ -555,6 +558,70 @@ def test_run_backfill_task_unmigrated_config_falls_back_to_legacy(
         org_id=ORG_ID,
     )
 
+    assert result["status"] == "success"
+    assert len(legacy_calls) == 1
+    assert legacy_calls[0]["sync_config_id"] == str(config.id)
+
+
+def test_run_backfill_task_migrated_non_planner_config_with_source_needs_flag(
+    db_session, monkeypatch
+):
+    from dev_health_ops.backfill import runner
+    from dev_health_ops.workers import sync_backfill, sync_runtime
+
+    integration = _create_integration(db_session)
+    _create_source(db_session, integration, "full-chaos/dev-health")
+    config = SyncConfiguration(
+        name="migrated legacy backfill",
+        provider="github",
+        org_id=ORG_ID,
+        sync_targets=["git"],
+        sync_options={},
+        is_active=True,
+        migrated_integration_id=integration.id,
+    )
+    db_session.add_all(
+        [
+            config,
+            Setting(
+                org_id=ORG_ID,
+                category=SettingCategory.SYNC.value,
+                key=MIGRATED_TRIGGER_ROUTING_SETTING_KEY,
+                value="false",
+            ),
+        ]
+    )
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setattr(sync_backfill, "_get_db_url", lambda: "clickhouse://test")
+    monkeypatch.setattr(
+        sync_runtime, "_dispatch_post_sync_tasks", lambda **kwargs: None
+    )
+
+    legacy_calls: list = []
+
+    def _fake_legacy(**kwargs):
+        legacy_calls.append(kwargs)
+        return {"status": "success"}
+
+    monkeypatch.setattr(runner, "run_backfill_for_config", _fake_legacy)
+    monkeypatch.setattr(
+        runner,
+        "run_backfill_via_planner",
+        lambda *args, **kwargs: pytest.fail(
+            "planner must not run when planner_managed is false and flag is off"
+        ),
+    )
+
+    run_backfill_task = getattr(sync_backfill.run_backfill, "run")
+    result = run_backfill_task(
+        sync_config_id=str(config.id),
+        since="2026-06-01",
+        before="2026-06-07",
+        org_id=ORG_ID,
+    )
+
+    assert config.planner_managed is False
     assert result["status"] == "success"
     assert len(legacy_calls) == 1
     assert legacy_calls[0]["sync_config_id"] == str(config.id)

--- a/tests/test_sync_scheduler_routing.py
+++ b/tests/test_sync_scheduler_routing.py
@@ -76,6 +76,7 @@ def _make_config(
     *,
     last_sync_at: datetime | None = None,
     migrated_integration_id: uuid.UUID | None = None,
+    planner_managed: bool = False,
 ) -> SyncConfiguration:
     config = SyncConfiguration(
         name="routing-test-config",
@@ -84,6 +85,7 @@ def _make_config(
         sync_targets=["git", "prs"],
         sync_options={"owner": "org", "repo": "repo", "schedule_cron": "0 * * * *"},
         is_active=True,
+        planner_managed=planner_managed,
     )
     if last_sync_at is not None:
         config.last_sync_at = last_sync_at
@@ -395,6 +397,52 @@ class TestPlannerFailureFallback:
         dispatch_sync_run_mock.apply_async.assert_not_called()
         run_sync_config_mock.apply_async.assert_called_once()
 
+    def test_planner_managed_planner_error_fails_closed_without_legacy_dispatch(
+        self, monkeypatch, db_session
+    ):
+        now = datetime.now(timezone.utc)
+        config = _make_config(
+            db_session,
+            last_sync_at=now - 2 * HOUR,
+            migrated_integration_id=uuid.uuid4(),
+            planner_managed=True,
+        )
+        job = _make_job(config)
+        db_session.add(job)
+        db_session.flush()
+        _enable_flag(db_session)
+
+        plan_sync_run_mock = MagicMock(
+            side_effect=ValueError("Integration not found for org")
+        )
+        dispatch_sync_run_mock = MagicMock()
+        run_sync_config_mock = MagicMock()
+        batch_sync_mock = MagicMock()
+
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.run_sync_config",
+            run_sync_config_mock,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.dispatch_batch_sync",
+            batch_sync_mock,
+        )
+
+        with (
+            patch("dev_health_ops.sync.planner.plan_sync_run", plan_sync_run_mock),
+            patch(
+                "dev_health_ops.workers.sync_units.dispatch_sync_run",
+                dispatch_sync_run_mock,
+            ),
+        ):
+            result = _call_maybe_dispatch(monkeypatch, db_session, config, now)
+
+        assert result is False
+        plan_sync_run_mock.assert_called_once()
+        dispatch_sync_run_mock.apply_async.assert_not_called()
+        run_sync_config_mock.apply_async.assert_not_called()
+        batch_sync_mock.apply_async.assert_not_called()
+
 
 class TestDispatchEnqueueFailure:
     """Flag ON + migrated config, plan commits, but dispatch_sync_run.apply_async
@@ -480,6 +528,87 @@ class TestDispatchEnqueueFailure:
         dispatch_sync_run_mock.apply_async.assert_called_once()
         run_sync_config_mock.apply_async.assert_called_once()
         # The committed run must be marked FAILED, not left PLANNED.
+        run = db_session.get(SyncRun, uuid.UUID(captured["run_id"]))
+        assert run is not None
+        assert run.status == SyncRunStatus.FAILED.value
+
+    def test_planner_managed_enqueue_failure_marks_run_failed_without_legacy_dispatch(
+        self, monkeypatch, db_session
+    ):
+        from dev_health_ops.models.integrations import (
+            Base as IntegrationsBase,
+        )
+        from dev_health_ops.models.integrations import (
+            Integration,
+            SyncRun,
+            SyncRunStatus,
+        )
+
+        IntegrationsBase.metadata.create_all(db_session.get_bind())
+
+        now = datetime.now(timezone.utc)
+        integration = Integration(
+            org_id=ORG_ID,
+            provider="github",
+            name="acme-planner-managed",
+        )
+        db_session.add(integration)
+        db_session.flush()
+        config = _make_config(
+            db_session,
+            last_sync_at=now - 2 * HOUR,
+            migrated_integration_id=integration.id,
+            planner_managed=True,
+        )
+        job = _make_job(config)
+        db_session.add(job)
+        db_session.flush()
+        _enable_flag(db_session)
+
+        captured = {}
+
+        def _real_plan(session, request):
+            run = SyncRun(
+                org_id=ORG_ID,
+                integration_id=integration.id,
+                triggered_by=request.triggered_by,
+                mode=request.mode,
+                status=SyncRunStatus.PLANNED.value,
+                total_units=0,
+            )
+            session.add(run)
+            session.flush()
+            captured["run_id"] = str(run.id)
+            return SimpleNamespace(sync_run_id=str(run.id), total_units=0, unit_ids=())
+
+        plan_sync_run_mock = MagicMock(side_effect=_real_plan)
+        dispatch_sync_run_mock = MagicMock()
+        dispatch_sync_run_mock.apply_async.side_effect = RuntimeError("broker down")
+        run_sync_config_mock = MagicMock()
+        batch_sync_mock = MagicMock()
+
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.run_sync_config",
+            run_sync_config_mock,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_scheduler.dispatch_batch_sync",
+            batch_sync_mock,
+        )
+
+        with (
+            patch("dev_health_ops.sync.planner.plan_sync_run", plan_sync_run_mock),
+            patch(
+                "dev_health_ops.workers.sync_units.dispatch_sync_run",
+                dispatch_sync_run_mock,
+            ),
+        ):
+            result = _call_maybe_dispatch(monkeypatch, db_session, config, now)
+
+        assert result is False
+        dispatch_sync_run_mock.apply_async.assert_called_once()
+        run_sync_config_mock.apply_async.assert_not_called()
+        batch_sync_mock.apply_async.assert_not_called()
         run = db_session.get(SyncRun, uuid.UUID(captured["run_id"]))
         assert run is not None
         assert run.status == SyncRunStatus.FAILED.value

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -491,6 +491,44 @@ def test_dispatch_sync_run_redispatches_only_planned_units(db_session, monkeypat
     assert recent_dispatching.status == SyncRunUnitStatus.DISPATCHING.value
 
 
+def test_dispatch_sync_run_denies_inactive_planner_config(db_session, monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    config = SyncConfiguration(
+        org_id=run.org_id,
+        name="paused-planner",
+        provider="github",
+        sync_targets=["git"],
+        sync_options={},
+        migrated_integration_id=run.integration_id,
+        is_active=False,
+    )
+    db_session.add(config)
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+
+    def fail_queue(*_args, **_kwargs):
+        raise AssertionError("inactive planner config must not queue units")
+
+    monkeypatch.setattr(sync_units.run_sync_unit, "s", fail_queue)
+    monkeypatch.setattr(sync_units, "chord", fail_queue)
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    db_session.refresh(unit)
+    db_session.refresh(config)
+    assert result == {"status": "denied", "reason": "sync configuration is paused"}
+    assert run.status == SyncRunStatus.FAILED.value
+    assert run.error == "sync configuration is paused"
+    assert run.result == {"reason": "inactive_sync_configuration"}
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert unit.error == "sync configuration is paused"
+    assert config.last_sync_success is False
+    assert config.last_sync_error == "sync configuration is paused"
+
+
 def test_dispatch_sync_run_marks_run_failed_when_chord_enqueue_fails(
     db_session, monkeypatch
 ):

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -13,6 +13,7 @@ from dev_health_ops.models import (
     Integration,
     IntegrationDataset,
     IntegrationSource,
+    SyncConfiguration,
     SyncRun,
     SyncRunMode,
     SyncRunPostDispatch,
@@ -326,6 +327,14 @@ def test_finalize_once_only_dispatches_metrics_once(db_session, monkeypatch):
     from dev_health_ops.workers import sync_units
 
     run, unit = _seed_run(db_session)
+    config = SyncConfiguration(
+        org_id=run.org_id,
+        name="canonical",
+        provider="github",
+        sync_targets=["git"],
+        migrated_integration_id=run.integration_id,
+    )
+    db_session.add(config)
     unit.status = SyncRunUnitStatus.SUCCESS.value
     db_session.flush()
     _patch_db_session(monkeypatch, db_session)
@@ -340,18 +349,31 @@ def test_finalize_once_only_dispatches_metrics_once(db_session, monkeypatch):
     second = sync_units.finalize_sync_run(str(run.id))
 
     db_session.refresh(run)
+    db_session.refresh(config)
     assert first["status"] == "finalized"
     assert second["status"] == "already_dispatched"
     assert run.status == SyncRunStatus.SUCCESS.value
     assert db_session.query(SyncRunPostDispatch).count() == 1
     assert len(dispatches) == 1
     assert dispatches[0]["sync_targets"] == ["git"]
+    assert config.last_sync_at is not None
+    assert config.last_sync_success is True
+    assert config.last_sync_error is None
+    assert config.last_sync_stats == {"completed_units": 1, "failed_units": 0}
 
 
 def test_finalize_aggregates_partial_failed(db_session, monkeypatch):
     from dev_health_ops.workers import sync_units
 
     run, unit = _seed_run(db_session)
+    config = SyncConfiguration(
+        org_id=run.org_id,
+        name="canonical-partial",
+        provider="github",
+        sync_targets=["git", "prs"],
+        migrated_integration_id=run.integration_id,
+    )
+    db_session.add(config)
     unit.status = SyncRunUnitStatus.SUCCESS.value
     failed = SyncRunUnit(
         org_id=run.org_id,
@@ -374,10 +396,13 @@ def test_finalize_aggregates_partial_failed(db_session, monkeypatch):
     result = sync_units.finalize_sync_run(str(run.id))
 
     db_session.refresh(run)
+    db_session.refresh(config)
     assert result["status"] == "finalized"
     assert run.status == SyncRunStatus.PARTIAL_FAILED.value
     assert run.completed_units == 1
     assert run.failed_units == 1
+    assert config.last_sync_success is False
+    assert config.last_sync_error == "Sync run completed with failed units"
 
 
 def test_finalize_zero_unit_run_does_not_report_success(db_session, monkeypatch):

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -529,6 +529,59 @@ def test_dispatch_sync_run_denies_inactive_planner_config(db_session, monkeypatc
     assert config.last_sync_error == "sync configuration is paused"
 
 
+def test_dispatch_sync_run_denies_inactive_migrated_child_config(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    parent_config = SyncConfiguration(
+        org_id=run.org_id,
+        name="active-parent",
+        provider="github",
+        sync_targets=["git"],
+        sync_options={},
+        migrated_integration_id=run.integration_id,
+        is_active=True,
+    )
+    db_session.add(parent_config)
+    db_session.flush()
+    child_config = SyncConfiguration(
+        org_id=run.org_id,
+        parent_id=parent_config.id,
+        name="paused-child",
+        provider="github",
+        sync_targets=["git"],
+        sync_options={},
+        migrated_integration_id=run.integration_id,
+        migrated_source_id=unit.source_id,
+        is_active=False,
+    )
+    db_session.add(child_config)
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+
+    def fail_queue(*_args, **_kwargs):
+        raise AssertionError("inactive child config must not queue units")
+
+    monkeypatch.setattr(sync_units.run_sync_unit, "s", fail_queue)
+    monkeypatch.setattr(sync_units, "chord", fail_queue)
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    db_session.refresh(unit)
+    db_session.refresh(parent_config)
+    assert result == {"status": "denied", "reason": "sync configuration is paused"}
+    assert run.status == SyncRunStatus.FAILED.value
+    assert run.error == "sync configuration is paused"
+    assert run.result == {"reason": "inactive_sync_configuration"}
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert unit.error == "sync configuration is paused"
+    assert parent_config.last_sync_success is False
+    assert parent_config.last_sync_error == "sync configuration is paused"
+
+
 def test_dispatch_sync_run_marks_run_failed_when_chord_enqueue_fails(
     db_session, monkeypatch
 ):

--- a/tests/test_trigger_routing.py
+++ b/tests/test_trigger_routing.py
@@ -13,6 +13,7 @@ from dev_health_ops.models import (
     SettingCategory,
     SyncConfiguration,
 )
+from dev_health_ops.models.integrations import Integration, IntegrationSource
 from dev_health_ops.sync.trigger_routing import (
     MIGRATED_TRIGGER_ROUTING_SETTING_KEY,
     is_migrated_trigger_routing_enabled,
@@ -67,6 +68,31 @@ def _set_flag(session: Session, value: str) -> None:
         )
     )
     session.flush()
+
+
+def _source(session: Session, integration_id: uuid.UUID) -> IntegrationSource:
+    session.add(
+        Integration(
+            id=integration_id,
+            org_id=ORG_ID,
+            provider="github",
+            name="github-integration",
+            config={},
+        )
+    )
+    source = IntegrationSource(
+        org_id=ORG_ID,
+        integration_id=integration_id,
+        provider="github",
+        source_type="repository",
+        external_id="full-chaos/dev-health",
+        name="dev-health",
+        full_name="full-chaos/dev-health",
+        is_enabled=True,
+    )
+    session.add(source)
+    session.flush()
+    return source
 
 
 # --- flag reader -----------------------------------------------------------
@@ -170,6 +196,7 @@ def test_mode_override(db_session):
 def test_planner_managed_parent_routes_without_flag(db_session):
     integration_id = uuid.uuid4()
     config = _config(db_session, migrated_integration_id=integration_id)
+    _source(db_session, integration_id)
 
     req = planner_request_for_config_if_routed(
         db_session, config, triggered_by="manual"
@@ -177,6 +204,20 @@ def test_planner_managed_parent_routes_without_flag(db_session):
 
     assert req is not None
     assert req.integration_id == str(integration_id)
+
+
+def test_sourceless_migrated_single_needs_flag(db_session):
+    integration_id = uuid.uuid4()
+    config = _config(db_session, migrated_integration_id=integration_id)
+
+    assert (
+        planner_request_for_config_if_routed(db_session, config, triggered_by="manual")
+        is None
+    )
+    _set_flag(db_session, "true")
+    assert planner_request_for_config_if_routed(
+        db_session, config, triggered_by="manual"
+    )
 
 
 def test_migrated_parent_with_children_needs_flag(db_session):

--- a/tests/test_trigger_routing.py
+++ b/tests/test_trigger_routing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import create_engine
@@ -302,6 +303,41 @@ def test_mark_sync_run_failed_stamps_canonical_config(db_session):
         "error": "dispatch enqueue failed",
         "phase": "dispatch_enqueue",
     }
+
+
+def test_mark_sync_run_failed_stamps_oldest_duplicate_parent_config(db_session):
+    from dev_health_ops.models import SyncRunStatus
+
+    run = _make_sync_run(db_session, SyncRunStatus.PLANNED.value)
+    older = SyncConfiguration(
+        org_id=ORG_ID,
+        name="canonical-older",
+        provider="github",
+        sync_targets=["git"],
+        migrated_integration_id=run.integration_id,
+    )
+    newer = SyncConfiguration(
+        org_id=ORG_ID,
+        name="canonical-newer",
+        provider="github",
+        sync_targets=["git"],
+        migrated_integration_id=run.integration_id,
+    )
+    older.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    newer.created_at = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    db_session.add_all([newer, older])
+    db_session.commit()
+
+    mark_sync_run_failed(db_session, str(run.id), "dispatch enqueue failed")
+
+    db_session.refresh(older)
+    db_session.refresh(newer)
+    assert older.last_sync_at is not None
+    assert older.last_sync_success is False
+    assert older.last_sync_error == "dispatch enqueue failed"
+    assert newer.last_sync_at is None
+    assert newer.last_sync_success is None
+    assert newer.last_sync_error is None
 
 
 def test_mark_sync_run_failed_noop_when_run_already_advanced(db_session):

--- a/tests/test_trigger_routing.py
+++ b/tests/test_trigger_routing.py
@@ -17,6 +17,7 @@ from dev_health_ops.sync.trigger_routing import (
     is_migrated_trigger_routing_enabled,
     mark_sync_run_failed,
     plan_request_for_config,
+    planner_request_for_config_if_routed,
 )
 
 ORG_ID = "routing-org"
@@ -38,15 +39,17 @@ def _config(
     sync_targets: list[str] | None = None,
     migrated_integration_id: uuid.UUID | None = None,
     migrated_source_id: uuid.UUID | None = None,
+    parent_id: uuid.UUID | None = None,
 ) -> SyncConfiguration:
     config = SyncConfiguration(
         org_id=ORG_ID,
-        name=f"{provider}-config",
+        name=f"{provider}-config-{uuid.uuid4()}",
         provider=provider,
         sync_targets=sync_targets if sync_targets is not None else ["git"],
         sync_options={},
         migrated_integration_id=migrated_integration_id,
         migrated_source_id=migrated_source_id,
+        parent_id=parent_id,
     )
     session.add(config)
     session.flush()
@@ -163,6 +166,38 @@ def test_mode_override(db_session):
     assert req.mode == "backfill"
 
 
+def test_planner_managed_parent_routes_without_flag(db_session):
+    integration_id = uuid.uuid4()
+    config = _config(db_session, migrated_integration_id=integration_id)
+
+    req = planner_request_for_config_if_routed(
+        db_session, config, triggered_by="manual"
+    )
+
+    assert req is not None
+    assert req.integration_id == str(integration_id)
+
+
+def test_migrated_parent_with_children_needs_flag(db_session):
+    integration_id = uuid.uuid4()
+    parent = _config(db_session, migrated_integration_id=integration_id)
+    _config(
+        db_session,
+        migrated_integration_id=integration_id,
+        migrated_source_id=uuid.uuid4(),
+        parent_id=parent.id,
+    )
+
+    assert (
+        planner_request_for_config_if_routed(db_session, parent, triggered_by="manual")
+        is None
+    )
+    _set_flag(db_session, "true")
+    assert planner_request_for_config_if_routed(
+        db_session, parent, triggered_by="manual"
+    )
+
+
 def test_operational_error_rolls_back_and_disables(monkeypatch, db_session):
     """A failed flag read (e.g. missing settings table on PG) must roll back
     the aborted transaction and return False so the caller's legacy path runs
@@ -241,6 +276,32 @@ def test_mark_sync_run_failed_marks_planned_run_and_units(db_session):
     assert run.completed_at is not None
     # The still-PLANNED unit is failed so a late dispatcher claims nothing.
     assert unit.status == SyncRunUnitStatus.FAILED.value
+
+
+def test_mark_sync_run_failed_stamps_canonical_config(db_session):
+    from dev_health_ops.models import SyncRunStatus
+
+    run = _make_sync_run(db_session, SyncRunStatus.PLANNED.value)
+    config = SyncConfiguration(
+        org_id=ORG_ID,
+        name="canonical",
+        provider="github",
+        sync_targets=["git"],
+        migrated_integration_id=run.integration_id,
+    )
+    db_session.add(config)
+    db_session.commit()
+
+    mark_sync_run_failed(db_session, str(run.id), "dispatch enqueue failed")
+
+    db_session.refresh(config)
+    assert config.last_sync_at is not None
+    assert config.last_sync_success is False
+    assert config.last_sync_error == "dispatch enqueue failed"
+    assert config.last_sync_stats == {
+        "error": "dispatch enqueue failed",
+        "phase": "dispatch_enqueue",
+    }
 
 
 def test_mark_sync_run_failed_noop_when_run_already_advanced(db_session):

--- a/tests/test_trigger_routing.py
+++ b/tests/test_trigger_routing.py
@@ -14,12 +14,14 @@ from dev_health_ops.models import (
     SyncConfiguration,
 )
 from dev_health_ops.models.integrations import Integration, IntegrationSource
+from dev_health_ops.sync.config_migration import migrate_configs_to_integrations
 from dev_health_ops.sync.trigger_routing import (
     MIGRATED_TRIGGER_ROUTING_SETTING_KEY,
     is_migrated_trigger_routing_enabled,
     mark_sync_run_failed,
     plan_request_for_config,
     planner_request_for_config_if_routed,
+    should_route_config_to_planner,
 )
 
 ORG_ID = "routing-org"
@@ -42,6 +44,7 @@ def _config(
     migrated_integration_id: uuid.UUID | None = None,
     migrated_source_id: uuid.UUID | None = None,
     parent_id: uuid.UUID | None = None,
+    planner_managed: bool = False,
 ) -> SyncConfiguration:
     config = SyncConfiguration(
         org_id=ORG_ID,
@@ -52,6 +55,7 @@ def _config(
         migrated_integration_id=migrated_integration_id,
         migrated_source_id=migrated_source_id,
         parent_id=parent_id,
+        planner_managed=planner_managed,
     )
     session.add(config)
     session.flush()
@@ -195,7 +199,9 @@ def test_mode_override(db_session):
 
 def test_planner_managed_parent_routes_without_flag(db_session):
     integration_id = uuid.uuid4()
-    config = _config(db_session, migrated_integration_id=integration_id)
+    config = _config(
+        db_session, migrated_integration_id=integration_id, planner_managed=True
+    )
     _source(db_session, integration_id)
 
     req = planner_request_for_config_if_routed(
@@ -206,9 +212,10 @@ def test_planner_managed_parent_routes_without_flag(db_session):
     assert req.integration_id == str(integration_id)
 
 
-def test_sourceless_migrated_single_needs_flag(db_session):
+def test_migrated_single_with_source_needs_flag_without_planner_marker(db_session):
     integration_id = uuid.uuid4()
     config = _config(db_session, migrated_integration_id=integration_id)
+    _source(db_session, integration_id)
 
     assert (
         planner_request_for_config_if_routed(db_session, config, triggered_by="manual")
@@ -237,6 +244,57 @@ def test_migrated_parent_with_children_needs_flag(db_session):
     _set_flag(db_session, "true")
     assert planner_request_for_config_if_routed(
         db_session, parent, triggered_by="manual"
+    )
+
+
+def test_migrated_parent_with_sources_stays_legacy_for_all_triggers(db_session):
+    _set_flag(db_session, "false")
+
+    parent = SyncConfiguration(
+        org_id=ORG_ID,
+        name="legacy parent",
+        provider="github",
+        sync_targets=["git"],
+        sync_options={"owner": "full-chaos"},
+        is_active=True,
+    )
+    db_session.add(parent)
+    db_session.flush()
+    child = SyncConfiguration(
+        org_id=ORG_ID,
+        name="full-chaos/dev-health",
+        provider="github",
+        sync_targets=["git"],
+        sync_options={"owner": "full-chaos", "repo": "dev-health"},
+        parent_id=parent.id,
+        is_active=True,
+    )
+    db_session.add(child)
+    db_session.flush()
+
+    migrate_configs_to_integrations(db_session)
+    db_session.flush()
+
+    assert parent.planner_managed is False
+    assert child.planner_managed is False
+    assert parent.migrated_integration_id is not None
+    assert child.migrated_source_id is not None
+    assert should_route_config_to_planner(db_session, parent) is False
+    assert (
+        planner_request_for_config_if_routed(db_session, parent, triggered_by="manual")
+        is None
+    )
+    assert (
+        planner_request_for_config_if_routed(
+            db_session, parent, triggered_by="schedule"
+        )
+        is None
+    )
+    assert (
+        planner_request_for_config_if_routed(
+            db_session, parent, triggered_by="backfill", mode="backfill"
+        )
+        is None
     )
 
 


### PR DESCRIPTION
## Summary
- Create batch/all-repos sync configs as planner-managed single parent configs with zero child SyncConfiguration rows.
- Centralize planner trigger routing so new planner-managed configs route without the org flag while migrated legacy configs still respect the canary flag.
- Stamp canonical parent SyncConfiguration last_sync_* fields from planner SyncRun terminal/failure paths.
- Reject paused manual triggers before execution and add worker-side inactive guards for stale queued tasks.

## Verification
- CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/test_trigger_routing.py tests/test_sync_units.py tests/api/admin/test_sync_trigger_routing.py tests/api/admin/test_sync_configs.py -q
- uv run --extra dev --python 3.11 mypy src/dev_health_ops/sync/trigger_routing.py src/dev_health_ops/workers/sync_units.py src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/workers/sync_scheduler.py src/dev_health_ops/workers/sync_runtime.py src/dev_health_ops/workers/sync_batch.py
- uv run --extra dev --python 3.11 ruff check src/dev_health_ops/sync/trigger_routing.py src/dev_health_ops/workers/sync_units.py src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/workers/sync_scheduler.py src/dev_health_ops/workers/sync_runtime.py src/dev_health_ops/workers/sync_batch.py tests/test_trigger_routing.py tests/test_sync_units.py tests/api/admin/test_sync_trigger_routing.py tests/api/admin/test_sync_configs.py
- git push pre-push hook: ruff format --check, ruff check, mypy

SCREENSHOT-WAIVER: Backend-only sync execution/API behavior; no rendered frontend output changed.

Closes CHAOS-2555
Closes CHAOS-2556
Partially addresses CHAOS-2557 (2557b backend)