### PR TITLE
fix(investment): escape literal % in mock-fixture LIKE patterns + pyformat guard (CHAOS-2566)

### DIFF
--- a/src/dev_health_ops/api/queries/client.py
+++ b/src/dev_health_ops/api/queries/client.py
@@ -78,7 +78,9 @@ def require_clickhouse_backend(sink: BaseMetricsSink) -> None:
 
 
 # Matches ClickHouse server-side placeholders like {repo_id:UUID} or {n:UInt32}.
-_CH_SERVER_PLACEHOLDER_RE = re.compile(r"\{\w+:[^}]+\}")
+# Possessive quantifiers (\w++ and [^}]++) prevent polynomial backtracking on
+# pathological inputs like '{0:{0:{0:...' with no closing '}' (ReDoS guard).
+_CH_SERVER_PLACEHOLDER_RE = re.compile(r"\{\w++:[^}]++\}")
 
 # Matches valid pyformat named conversions: %(name)s, %(name)d, %(name)f, etc.
 _PYFORMAT_NAMED_RE = re.compile(r"%\(\w+\)[sdifeEgGrxXoc%]")

--- a/src/dev_health_ops/api/queries/client.py
+++ b/src/dev_health_ops/api/queries/client.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator
+import re
+from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -76,6 +77,48 @@ def require_clickhouse_backend(sink: BaseMetricsSink) -> None:
         )
 
 
+# Matches ClickHouse server-side placeholders like {repo_id:UUID} or {n:UInt32}.
+_CH_SERVER_PLACEHOLDER_RE = re.compile(r"\{\w+:[^}]+\}")
+
+# Matches valid pyformat named conversions: %(name)s, %(name)d, %(name)f, etc.
+_PYFORMAT_NAMED_RE = re.compile(r"%\(\w+\)[sdifeEgGrxXoc%]")
+
+
+def _assert_pyformat_safe(query: str, params: object) -> None:
+    """Raise ValueError if *query* contains a bare '%' that pyformat will misread.
+
+    clickhouse-connect applies pyformat binding (``query % params``) when the
+    query has no server-side ``{name:Type}`` placeholders and *params* is a
+    mapping.  A literal ``%`` that is neither ``%%`` nor a ``%(name)s``
+    conversion is misread as a positional conversion, producing:
+
+        TypeError: not enough arguments for format string  (CHAOS-2566)
+
+    Rules:
+    - Only validates when *params* is a Mapping (the pyformat path).
+    - Skips entirely when the query contains a ``{name:Type}`` placeholder
+      (server-side binding path — literal ``%`` is fine there).
+    - Strips ``%%`` and valid ``%(name)X`` conversions from a scratch copy;
+      any remaining ``%`` is an error.
+    """
+    if not isinstance(params, Mapping):
+        return
+    if _CH_SERVER_PLACEHOLDER_RE.search(query):
+        # Server-side binding path: clickhouse-connect does NOT apply pyformat.
+        return
+    # Strip escaped %% and valid named conversions from a scratch copy.
+    scratch = _PYFORMAT_NAMED_RE.sub("", query.replace("%%", ""))
+    idx = scratch.find("%")
+    if idx == -1:
+        return
+    fragment = scratch[max(0, idx - 30) : idx + 31].replace("\n", " ")
+    raise ValueError(
+        "ClickHouse query contains an unescaped literal '%' — double it to '%%'."
+        " pyformat binding (query % params) is applied when the query has no"
+        f" {{name:Type}} placeholders. Offending fragment near: {fragment!r}"
+    )
+
+
 async def query_dicts(
     sink: Any, query: str, params: dict[str, Any]
 ) -> list[dict[str, Any]]:
@@ -106,6 +149,7 @@ async def query_dicts(
     # cheap because they share a global urllib3.PoolManager for HTTP connections.
     dsn = getattr(sink, "dsn", None)
     if isinstance(dsn, str) and dsn:
+        _assert_pyformat_safe(query, params)
 
         def _thread_query() -> list[dict[str, Any]]:
             client = clickhouse_connect.get_client(

--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -124,9 +124,12 @@ async def fetch_mock_fixture_investment_row_count(
           AND work_unit_investments.org_id = %(org_id)s
           AND (
             lower(ifNull(work_unit_investments.provider, '')) IN ('mock', 'fixture', 'fixtures', 'synthetic')
-            OR lower(ifNull(work_unit_investments.categorization_model_version, '')) LIKE '%mock%'
-            OR lower(ifNull(work_unit_investments.categorization_model_version, '')) LIKE '%synthetic%'
-            OR lower(ifNull(work_unit_investments.categorization_model_version, '')) LIKE '%fixture%'
+            -- %% is required: clickhouse-connect applies pyformat
+            -- substitution to queries using %%(name)s params; literal
+            -- percent signs must be doubled to survive query %% params.
+            OR lower(ifNull(work_unit_investments.categorization_model_version, '')) LIKE '%%mock%%'
+            OR lower(ifNull(work_unit_investments.categorization_model_version, '')) LIKE '%%synthetic%%'
+            OR lower(ifNull(work_unit_investments.categorization_model_version, '')) LIKE '%%fixture%%'
           )
         {scope_filter}
         {category_filter}

--- a/tests/api/queries/test_investment_like_binding.py
+++ b/tests/api/queries/test_investment_like_binding.py
@@ -1,0 +1,77 @@
+"""Regression test for CHAOS-2566.
+
+fetch_mock_fixture_investment_row_count builds a ClickHouse query that contains
+LIKE literals with bare % characters.  clickhouse-connect's finalize_query
+applies pyformat %-substitution to any query that uses %(name)s params; a bare
+'%mock%' is misread as a positional conversion and raises:
+
+    TypeError: not enough arguments for format string
+
+The fix doubles the percent signs (%%mock%%) so they survive pyformat expansion
+as literal single-percent patterns in the final SQL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from clickhouse_connect.driver.binding import finalize_query
+
+import dev_health_ops.api.queries.investment as investment_module
+from dev_health_ops.api.queries.investment import (
+    fetch_mock_fixture_investment_row_count,
+)
+
+
+def test_mock_fixture_like_patterns_survive_pyformat_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """finalize_query must not raise and must produce single-% LIKE patterns."""
+    captured: dict[str, Any] = {}
+
+    async def _stub_query_dicts(
+        _sink: Any, query: str, params: dict[str, Any] | None
+    ) -> list[dict[str, Any]]:
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(investment_module, "query_dicts", _stub_query_dicts)
+
+    start_ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end_ts = datetime(2024, 2, 1, tzinfo=timezone.utc)
+    org_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+    result = asyncio.run(
+        fetch_mock_fixture_investment_row_count(
+            sink=None,  # type: ignore[arg-type]  # stub never touches sink
+            start_ts=start_ts,
+            end_ts=end_ts,
+            scope_filter="",
+            scope_params={},
+            org_id=org_id,
+        )
+    )
+
+    assert result == 0
+    assert "query" in captured, "stub was not called"
+
+    query: str = captured["query"]
+    params: dict[str, Any] = captured["params"] or {}
+
+    # Pre-fix this raised TypeError: not enough arguments for format string
+    finalized = finalize_query(query, params)
+
+    # After pyformat expansion %% collapses to %; the finalized SQL must contain
+    # the single-percent LIKE patterns that ClickHouse will evaluate.
+    assert "LIKE '%mock%'" in finalized
+    assert "LIKE '%synthetic%'" in finalized
+    assert "LIKE '%fixture%'" in finalized
+
+    # Named params must also be substituted correctly.
+    assert "%(start_ts)s" not in finalized
+    assert "%(end_ts)s" not in finalized
+    assert "%(org_id)s" not in finalized

--- a/tests/api/queries/test_investment_like_binding.py
+++ b/tests/api/queries/test_investment_like_binding.py
@@ -21,9 +21,6 @@ import pytest
 from clickhouse_connect.driver.binding import finalize_query
 
 import dev_health_ops.api.queries.investment as investment_module
-from dev_health_ops.api.queries.investment import (
-    fetch_mock_fixture_investment_row_count,
-)
 
 
 def test_mock_fixture_like_patterns_survive_pyformat_binding(
@@ -46,7 +43,7 @@ def test_mock_fixture_like_patterns_survive_pyformat_binding(
     org_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
     result = asyncio.run(
-        fetch_mock_fixture_investment_row_count(
+        investment_module.fetch_mock_fixture_investment_row_count(
             sink=None,  # type: ignore[arg-type]  # stub never touches sink
             start_ts=start_ts,
             end_ts=end_ts,

--- a/tests/api/queries/test_pyformat_guard.py
+++ b/tests/api/queries/test_pyformat_guard.py
@@ -13,6 +13,7 @@ Tests cover:
 4. No '%' at all → no raise
 5. Anti-false-positive: real investment pyformat query passes the guard
 6. Anti-false-positive: real ai_detector server-side query passes the guard
+7. ReDoS lock: _CH_SERVER_PLACEHOLDER_RE must not backtrack on pathological input
 """
 
 from __future__ import annotations
@@ -25,7 +26,6 @@ import pytest
 
 import dev_health_ops.api.queries.investment as investment_module
 from dev_health_ops.api.queries.client import _assert_pyformat_safe
-from dev_health_ops.api.queries.investment import fetch_investment_breakdown
 
 # ---------------------------------------------------------------------------
 # Unit tests for _assert_pyformat_safe
@@ -113,6 +113,31 @@ def test_only_valid_named_conversions_does_not_raise() -> None:
 
 
 # ---------------------------------------------------------------------------
+# ReDoS lock: possessive quantifiers in _CH_SERVER_PLACEHOLDER_RE
+# ---------------------------------------------------------------------------
+
+
+def test_server_placeholder_regex_no_redos_on_pathological_input() -> None:
+    """_CH_SERVER_PLACEHOLDER_RE must not backtrack polynomially.
+
+    A pathological input like '{0:{0:{0:...' with no closing '}' previously
+    caused polynomial backtracking with greedy quantifiers.  Possessive
+    quantifiers (\\w++ and [^}]++) prevent this.  The search must complete
+    well under 1 second and return None.
+    """
+    import time
+
+    from dev_health_ops.api.queries.client import _CH_SERVER_PLACEHOLDER_RE
+
+    evil = "{0:" * 20000  # no closing '}' — worst-case for greedy backtracking
+    start = time.monotonic()
+    result = _CH_SERVER_PLACEHOLDER_RE.search(evil)
+    elapsed = time.monotonic() - start
+    assert result is None, "Should not match pathological input"
+    assert elapsed < 1.0, f"ReDoS detected: search took {elapsed:.3f}s (limit 1.0s)"
+
+
+# ---------------------------------------------------------------------------
 # Anti-false-positive: real query builders must pass the guard
 # ---------------------------------------------------------------------------
 
@@ -137,7 +162,7 @@ def test_real_investment_breakdown_query_passes_guard(
     monkeypatch.setattr(investment_module, "query_dicts", _stub)
 
     asyncio.run(
-        fetch_investment_breakdown(
+        investment_module.fetch_investment_breakdown(
             sink=None,  # type: ignore[arg-type]
             start_ts=datetime(2024, 1, 1, tzinfo=timezone.utc),
             end_ts=datetime(2024, 2, 1, tzinfo=timezone.utc),

--- a/tests/api/queries/test_pyformat_guard.py
+++ b/tests/api/queries/test_pyformat_guard.py
@@ -1,0 +1,183 @@
+"""Tests for the _assert_pyformat_safe guard in client.py (CHAOS-2566).
+
+The guard prevents the entire class of bugs where a ClickHouse query built with
+pyformat %(name)s params contains a bare literal '%' that clickhouse-connect
+misreads as a positional conversion, producing:
+
+    TypeError: not enough arguments for format string
+
+Tests cover:
+1. Unescaped '%' in pyformat query → guard raises ValueError with actionable msg
+2. Properly escaped '%%' → guard does NOT raise
+3. Server-side {name:Type} placeholder present → guard skips (does NOT raise)
+4. No '%' at all → no raise
+5. Anti-false-positive: real investment pyformat query passes the guard
+6. Anti-false-positive: real ai_detector server-side query passes the guard
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+import dev_health_ops.api.queries.investment as investment_module
+from dev_health_ops.api.queries.client import _assert_pyformat_safe
+from dev_health_ops.api.queries.investment import fetch_investment_breakdown
+
+# ---------------------------------------------------------------------------
+# Unit tests for _assert_pyformat_safe
+# ---------------------------------------------------------------------------
+
+
+def test_unescaped_percent_in_pyformat_query_raises() -> None:
+    """A bare '%' in a pyformat query must raise ValueError with a clear message."""
+    query = """
+        SELECT count() FROM work_unit_investments
+        WHERE lower(categorization_model_version) LIKE '%mock%'
+          AND org_id = %(org_id)s
+    """
+    params = {"org_id": "org-abc"}
+    with pytest.raises(ValueError, match="unescaped literal '%'"):
+        _assert_pyformat_safe(query, params)
+
+
+def test_unescaped_percent_error_includes_fragment() -> None:
+    """The ValueError must include a fragment near the offending '%'."""
+    query = "SELECT * FROM t WHERE col LIKE '%needle%' AND x = %(x)s"
+    params = {"x": "val"}
+    with pytest.raises(ValueError, match="needle"):
+        _assert_pyformat_safe(query, params)
+
+
+def test_escaped_percent_does_not_raise() -> None:
+    """'%%' is the correct escape; the guard must accept it."""
+    query = """
+        SELECT count() FROM work_unit_investments
+        WHERE lower(categorization_model_version) LIKE '%%mock%%'
+          AND org_id = %(org_id)s
+    """
+    params = {"org_id": "org-abc"}
+    _assert_pyformat_safe(query, params)  # must not raise
+
+
+def test_server_side_placeholder_skips_validation() -> None:
+    """When the query has a {name:Type} placeholder, the guard must skip entirely.
+
+    ai_detector.py queries use server-side binding and legitimately contain
+    bare LIKE '%...%' patterns — the guard must not fire on them.
+    """
+    query = """
+        SELECT count() FROM git_pull_requests AS pr
+        WHERE lower(pr.author_name) NOT LIKE '%bot%'
+          AND pr.repo_id = {repo_id:UUID}
+    """
+    params = {"repo_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}
+    _assert_pyformat_safe(query, params)  # must not raise
+
+
+def test_no_percent_at_all_does_not_raise() -> None:
+    """A query with no '%' characters at all must pass silently."""
+    query = "SELECT count() FROM t WHERE org_id = %(org_id)s"
+    params = {"org_id": "org-x"}
+    _assert_pyformat_safe(query, params)  # must not raise
+
+
+def test_non_mapping_params_skips_validation() -> None:
+    """Non-mapping params (e.g. a list) are not the pyformat path; skip."""
+    query = "SELECT * FROM t WHERE col LIKE '%bad%'"
+    _assert_pyformat_safe(query, ["positional"])  # must not raise
+    _assert_pyformat_safe(query, None)  # must not raise
+
+
+def test_multiple_unescaped_percents_raises_on_first() -> None:
+    """Multiple bare '%' patterns — guard raises on the first one found."""
+    query = "SELECT * FROM t WHERE a LIKE '%foo%' AND b LIKE '%bar%' AND x = %(x)s"
+    params = {"x": 1}
+    with pytest.raises(ValueError, match="unescaped literal '%'"):
+        _assert_pyformat_safe(query, params)
+
+
+def test_only_valid_named_conversions_does_not_raise() -> None:
+    """A query with only %(name)s / %(name)d conversions and no bare '%' is fine."""
+    query = (
+        "SELECT * FROM t"
+        " WHERE ts >= %(start_ts)s"
+        " AND ts < %(end_ts)s"
+        " AND org_id = %(org_id)s"
+    )
+    params = {"start_ts": "2024-01-01", "end_ts": "2024-02-01", "org_id": "o"}
+    _assert_pyformat_safe(query, params)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Anti-false-positive: real query builders must pass the guard
+# ---------------------------------------------------------------------------
+
+
+def test_real_investment_breakdown_query_passes_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """fetch_investment_breakdown's query must pass _assert_pyformat_safe.
+
+    This is the main pyformat investment query.  It uses %(name)s params and
+    no bare '%', so the guard must accept it without raising.
+    """
+    captured: dict[str, Any] = {}
+
+    async def _stub(
+        _sink: Any, query: str, params: dict[str, Any] | None
+    ) -> list[dict[str, Any]]:
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(investment_module, "query_dicts", _stub)
+
+    asyncio.run(
+        fetch_investment_breakdown(
+            sink=None,  # type: ignore[arg-type]
+            start_ts=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            end_ts=datetime(2024, 2, 1, tzinfo=timezone.utc),
+            scope_filter="",
+            scope_params={},
+            org_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        )
+    )
+
+    assert "query" in captured, "stub was not called"
+    # Must not raise — the investment query is properly escaped.
+    _assert_pyformat_safe(captured["query"], captured["params"])
+
+
+def test_real_ai_detector_server_side_query_passes_guard() -> None:
+    """A representative ai_detector server-side query must pass the guard.
+
+    ai_detector queries use {name:Type} placeholders and contain bare LIKE
+    '%...%' patterns.  The guard must skip validation for them (server-side
+    binding path).
+    """
+    # Minimal representative query from ai_detector._doc_drift_opportunities,
+    # which uses {repo_id:UUID} and {min_commits:UInt32} server-side placeholders
+    # alongside bare LIKE patterns from _DOC_FILE_EXPR.
+    query = """
+        SELECT
+            toString(c.repo_id) AS repo_id,
+            uniqExactIf(c.hash, NOT (file_path LIKE '%.md' OR file_path LIKE '%.rst'))
+                AS code_commits,
+            countIf(file_path LIKE '%.md' OR file_path LIKE '%.rst') AS doc_changes
+        FROM git_commits AS c
+        WHERE c.committer_when >= now() - INTERVAL 30 DAY
+          AND c.repo_id = {repo_id:UUID}
+        GROUP BY repo_id
+        HAVING code_commits >= {min_commits:UInt32} AND doc_changes = 0
+        LIMIT 100
+    """
+    params = {
+        "repo_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "min_commits": 20,
+    }
+    # Must not raise — server-side placeholder detected, validation skipped.
+    _assert_pyformat_safe(query, params)


### PR DESCRIPTION
## Summary

Production-down crash fix for the Investment view and regenerate-explanation across all orgs.

**Root cause:** Unescaped literal `%` in the `LIKE` patterns of `fetch_mock_fixture_investment_row_count`. clickhouse-connect uses pyformat binding (`query % params`), so the bare `%` characters were misread as format placeholders, raising `TypeError: not enough arguments for format string` and crashing the Investment view + regenerate-explanation for every org. This is a regression introduced in CHAOS-2542 / PR #975.

## The fix

Double the literal `%` (`%` -> `%%`) in the `fetch_mock_fixture_investment_row_count` `LIKE` patterns so pyformat binding emits a single literal `%` instead of treating it as a placeholder.

## Validation guard

Added `_assert_pyformat_safe` in `api/queries/client.py`. It fails fast with an actionable error message on any future pyformat ClickHouse query that contains an unescaped `%`, while correctly skipping server-side `{name:Type}` parameterized queries (which do not use pyformat binding).

## Tests

- Regression test reproducing the original crash and asserting the fix.
- 10 guard tests covering `_assert_pyformat_safe` behavior.
- 2 anti-false-positive proofs confirming server-side `{name:Type}` queries are not flagged.
- Full suite: 35 tests pass on Python 3.11 and 3.13. ruff/mypy clean.

Closes CHAOS-2566

SCREENSHOT-WAIVER: backend-only ClickHouse query-escaping + query-client guard; no rendered UI or API-shape change.