### PR TITLE
fix(workers): register sync_units fan-out tasks for Celery autodiscovery (CHAOS-2567)

### DIFF
--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -35,6 +35,11 @@ from dev_health_ops.workers.sync_tasks import (
     run_work_items_sync,
     sync_team_drift,
 )
+from dev_health_ops.workers.sync_units import (
+    dispatch_sync_run,
+    finalize_sync_run,
+    run_sync_unit,
+)
 from dev_health_ops.workers.system_tasks import (
     health_check,
     phone_home_heartbeat,
@@ -76,6 +81,7 @@ __all__ = [
     "dispatch_scheduled_metrics",
     "dispatch_scheduled_reports",
     "dispatch_scheduled_syncs",
+    "dispatch_sync_run",
     "execute_saved_report",
     "health_check",
     "monitor_queue_depths",
@@ -94,11 +100,13 @@ __all__ = [
     "run_investment_materialize",
     "run_investment_materialize_chunk",
     "finalize_investment_materialize_partitioned",
+    "finalize_sync_run",
     "run_membership_backfill",
     "run_product_telemetry_consumer",
     "run_recommendations_job",
     "run_release_impact_job",
     "run_sync_config",
+    "run_sync_unit",
     "run_work_graph_build",
     "run_work_items_sync",
     "send_billing_notification",


### PR DESCRIPTION
## Summary

The fan-out planner sync tasks — `dispatch_sync_run`, `run_sync_unit`, `finalize_sync_run` — are defined in `src/dev_health_ops/workers/sync_units.py` but were **never imported at worker startup**. Celery's `autodiscover_tasks(["dev_health_ops.workers"])` imports only `workers/tasks.py`, and that module did not import `sync_units` (the only references were a lazy in-function import in the producer). As a result the consumer process had no strategy for these tasks and discarded every dispatch with:

```
Received unregistered task of type 'dev_health_ops.workers.tasks.dispatch_sync_run'.
KeyError: 'dev_health_ops.workers.tasks.dispatch_sync_run'
```

`dispatch_scheduled_syncs` (imported via `sync_tasks`) ran fine and enqueued children, so the failure was producer-registered / consumer-unregistered.

## Impact observed

- 22 `sync_runs` stuck in `planned`, 330 `sync_run_units` never executed.
- `finalize_sync_run` never ran, so the post-sync metrics chain (daily metrics, `run_complexity_job`, team/ownership auto-import, work-graph build, investment materialize) was never dispatched.

## Fix

Import the three tasks at module level in `workers/tasks.py` and add them to `__all__`, mirroring every other task module. No behavior change beyond registration.

## Verification

- `ruff format/check` + `mypy` (whole project) pass via pre-commit/pre-push hooks.
- In a worker container, importing `dev_health_ops.workers.tasks` registers all three (`celery_app.tasks` contains them).
- After restarting the worker services, the boot `[tasks]` banner lists all three and `Received unregistered task` count since restart is **0**.

## Scope note

Not migration-specific: the fan-out planner path underlies native integration syncs as well, so this registration is required regardless of any migrated configs.

Closes CHAOS-2567