### PR TITLE
fix(metrics): honest no-estimate forecast under short history (CHAOS-2574)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/forecast.py
+++ b/src/dev_health_ops/api/graphql/resolvers/forecast.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 from dev_health_ops.api.queries.client import query_dicts
@@ -10,6 +10,8 @@ from dev_health_ops.metrics.compute_capacity import ThroughputHistory, Throughpu
 from dev_health_ops.metrics.forecast import (
     RiskOverlay,
     ThroughputForecastResult,
+    compute_risk_overlays,
+    compute_rolling_windows,
     forecast_throughput_capacity,
 )
 from dev_health_ops.utils.datetime import utc_today
@@ -305,7 +307,30 @@ async def resolve_throughput_forecast(
         history_weeks=input.history_weeks,
     )
     if not history.samples:
-        return None
+        # Empty scope / new team: return a structured no-estimate payload
+        # instead of null so callers can distinguish "no data yet" from a
+        # genuine error. All rolling windows are flagged insufficient_history;
+        # p50/p75/p90 are None; risk overlays are neutral.
+        empty_windows = compute_rolling_windows(history)
+        primary, wip, review, incident = compute_risk_overlays()
+        no_estimate = ThroughputForecastResult(
+            forecast_id="no-history",
+            computed_at=datetime.now(timezone.utc),
+            team_id=result_team_id,
+            work_scope_id=input.work_scope_id,
+            backlog_size=input.backlog_size or 0,
+            history_weeks=input.history_weeks,
+            p50_weeks=None,
+            p75_weeks=None,
+            p90_weeks=None,
+            rolling_windows=empty_windows,
+            primary_risk=primary,
+            wip_congestion=wip,
+            review_bottleneck=review,
+            incident_load=incident,
+            insufficient_history=True,
+        )
+        return _result_to_output(no_estimate)
 
     current_wip, average_wip = await _load_work_item_overlay(
         context,

--- a/src/dev_health_ops/api/graphql/resolvers/forecast.py
+++ b/src/dev_health_ops/api/graphql/resolvers/forecast.py
@@ -293,6 +293,8 @@ async def resolve_throughput_forecast(
     require_org_id(context)
     if context.client is None:
         raise RuntimeError("Database client not available")
+    if input.history_weeks <= 0:
+        raise ValueError("history_weeks must be positive")
 
     # Single-team scopes still set team_id on the result so the UI can
     # display the scope; multi-team and all-teams scopes leave it None.

--- a/src/dev_health_ops/api/graphql/resolvers/forecast.py
+++ b/src/dev_health_ops/api/graphql/resolvers/forecast.py
@@ -306,6 +306,15 @@ async def resolve_throughput_forecast(
         work_scope_id=input.work_scope_id,
         history_weeks=input.history_weeks,
     )
+    backlog_size = input.backlog_size
+    if backlog_size is None:
+        backlog_size = await _load_backlog(
+            context,
+            team_ids=input.team_ids,
+            work_scope_id=input.work_scope_id,
+        )
+    if backlog_size < 0:
+        raise ValueError("backlog_size must be non-negative")
     if not history.samples:
         # Empty scope / new team: return a structured no-estimate payload
         # instead of null so callers can distinguish "no data yet" from a
@@ -318,7 +327,7 @@ async def resolve_throughput_forecast(
             computed_at=datetime.now(timezone.utc),
             team_id=result_team_id,
             work_scope_id=input.work_scope_id,
-            backlog_size=input.backlog_size or 0,
+            backlog_size=backlog_size,
             history_weeks=input.history_weeks,
             p50_weeks=None,
             p75_weeks=None,
@@ -346,13 +355,6 @@ async def resolve_throughput_forecast(
         context,
         history_weeks=input.history_weeks,
     )
-    backlog_size = input.backlog_size
-    if backlog_size is None:
-        backlog_size = await _load_backlog(
-            context,
-            team_ids=input.team_ids,
-            work_scope_id=input.work_scope_id,
-        )
     result = forecast_throughput_capacity(
         history=history,
         backlog_size=backlog_size,

--- a/src/dev_health_ops/metrics/forecast.py
+++ b/src/dev_health_ops/metrics/forecast.py
@@ -308,11 +308,18 @@ def forecast_throughput_capacity(
     # true, _select_percentile_distribution fell back to a shorter window (or
     # returned no estimate). Either way the provenance signal must be surfaced:
     # the caller asked for history_weeks but the estimate came from less data.
+    #
+    # Additionally, when history_weeks does not correspond to any standard
+    # window (ROLLING_WINDOWS_WEEKS), the distribution selection silently
+    # falls back to the longest standard window. That is also a provenance
+    # mismatch: the estimate did NOT use the requested history_weeks window.
+    # Mark insufficient_history=True so callers can detect the fallback.
+    window_matched = any(w.window_weeks == history_weeks for w in windows)
     requested_window = next(
         (w for w in windows if w.window_weeks == history_weeks), windows[-1]
     )
     selected_window_insufficient = (
-        len(requested_window.samples) < MIN_SAMPLES_FOR_ESTIMATE
+        not window_matched or len(requested_window.samples) < MIN_SAMPLES_FOR_ESTIMATE
     )
     p50_throughput = _percentile(distribution, 0.50)
     p75_throughput = _percentile(distribution, 0.25)

--- a/src/dev_health_ops/metrics/forecast.py
+++ b/src/dev_health_ops/metrics/forecast.py
@@ -115,10 +115,21 @@ def rolling_weekly_throughput(
         return RollingWindowThroughput(window_weeks, 0.0, (), True)
 
     if len(throughputs) < window_days:
-        total = sum(throughputs)
-        observed_weeks = max(len(throughputs) / MIN_DAYS_PER_WEEK, 1.0)
-        weekly_mean = total / observed_weeks
-        return RollingWindowThroughput(window_weeks, weekly_mean, (weekly_mean,), True)
+        # Insufficient history for this window size. Emit a no-estimate
+        # contract instead of fabricating a point estimate from a partial
+        # window. The previous `total / max(weeks, 1.0)` floor ignored
+        # ``window_weeks`` and produced the SAME value for every window size,
+        # collapsing 4w/8w/12w into one number that masqueraded as a confident
+        # forecast (CHAOS-2574). Honest behaviour: no samples, zero mean,
+        # flagged insufficient. Percentile selection falls back to a shorter
+        # window that DOES have enough history; when none do, the forecast
+        # returns no estimate.
+        return RollingWindowThroughput(
+            window_weeks=window_weeks,
+            mean_weekly_throughput=0.0,
+            samples=(),
+            insufficient_history=True,
+        )
 
     rolling = [
         sum(throughputs[index : index + window_days]) / window_weeks

--- a/src/dev_health_ops/metrics/forecast.py
+++ b/src/dev_health_ops/metrics/forecast.py
@@ -151,9 +151,22 @@ def compute_rolling_windows(
     return tuple(rolling_weekly_throughput(history, weeks) for weeks in windows_weeks)
 
 
+MIN_SAMPLES_FOR_ESTIMATE = 2
+
+
 def _select_percentile_distribution(
     windows: tuple[RollingWindowThroughput, ...], history_weeks: int
 ) -> tuple[float, ...]:
+    """Return the sample distribution to use for percentile estimates.
+
+    Selects the window whose ``window_weeks`` matches ``history_weeks``
+    (falling back to the longest available window). When the selected
+    window has fewer than ``MIN_SAMPLES_FOR_ESTIMATE`` samples the function
+    tries to fall back to the longest shorter window that meets the
+    minimum. If no window meets the minimum, an empty tuple is returned so
+    that callers produce no-estimate (None) outputs rather than emitting
+    percentiles derived from a single data point.
+    """
     if not windows:
         return ()
 
@@ -161,14 +174,17 @@ def _select_percentile_distribution(
         (window for window in windows if window.window_weeks == history_weeks),
         windows[-1],
     )
-    if len(selected.samples) > 1:
+    if len(selected.samples) >= MIN_SAMPLES_FOR_ESTIMATE:
         return selected.samples
 
+    # Selected window has 0 or 1 sample — try the longest shorter window
+    # that meets the minimum sample threshold.
     shorter_windows = sorted(
         (
             window
             for window in windows
-            if window.window_weeks < selected.window_weeks and len(window.samples) > 1
+            if window.window_weeks < selected.window_weeks
+            and len(window.samples) >= MIN_SAMPLES_FOR_ESTIMATE
         ),
         key=lambda window: window.window_weeks,
         reverse=True,
@@ -176,7 +192,8 @@ def _select_percentile_distribution(
     if shorter_windows:
         return shorter_windows[0].samples
 
-    return selected.samples
+    # No window meets the minimum — emit no estimate.
+    return ()
 
 
 def _weeks_to_complete(backlog_size: int, weekly_throughput: float) -> int | None:

--- a/src/dev_health_ops/metrics/forecast.py
+++ b/src/dev_health_ops/metrics/forecast.py
@@ -135,11 +135,12 @@ def rolling_weekly_throughput(
         sum(throughputs[index : index + window_days]) / window_weeks
         for index in range(0, len(throughputs) - window_days + 1)
     ]
+    insufficient = len(rolling) < MIN_SAMPLES_FOR_ESTIMATE
     return RollingWindowThroughput(
         window_weeks=window_weeks,
         mean_weekly_throughput=fmean(rolling),
         samples=tuple(rolling),
-        insufficient_history=False,
+        insufficient_history=insufficient,
     )
 
 
@@ -302,6 +303,17 @@ def forecast_throughput_capacity(
 
     windows = compute_rolling_windows(history)
     distribution = list(_select_percentile_distribution(windows, history_weeks))
+    # Detect whether the requested window itself has too few rolling samples
+    # for a reliable percentile estimate (< MIN_SAMPLES_FOR_ESTIMATE). When
+    # true, _select_percentile_distribution fell back to a shorter window (or
+    # returned no estimate). Either way the provenance signal must be surfaced:
+    # the caller asked for history_weeks but the estimate came from less data.
+    requested_window = next(
+        (w for w in windows if w.window_weeks == history_weeks), windows[-1]
+    )
+    selected_window_insufficient = (
+        len(requested_window.samples) < MIN_SAMPLES_FOR_ESTIMATE
+    )
     p50_throughput = _percentile(distribution, 0.50)
     p75_throughput = _percentile(distribution, 0.25)
     p90_throughput = _percentile(distribution, 0.10)
@@ -330,5 +342,8 @@ def forecast_throughput_capacity(
         wip_congestion=wip,
         review_bottleneck=review,
         incident_load=incident,
-        insufficient_history=any(window.insufficient_history for window in windows),
+        insufficient_history=(
+            any(window.insufficient_history for window in windows)
+            or selected_window_insufficient
+        ),
     )

--- a/src/dev_health_ops/metrics/forecast.py
+++ b/src/dev_health_ops/metrics/forecast.py
@@ -349,8 +349,5 @@ def forecast_throughput_capacity(
         wip_congestion=wip,
         review_bottleneck=review,
         incident_load=incident,
-        insufficient_history=(
-            any(window.insufficient_history for window in windows)
-            or selected_window_insufficient
-        ),
+        insufficient_history=selected_window_insufficient,
     )

--- a/tests/api/graphql/test_throughput_forecast_resolver.py
+++ b/tests/api/graphql/test_throughput_forecast_resolver.py
@@ -484,3 +484,62 @@ async def test_resolver_returns_no_estimate_payload_for_zero_row_history(ctx):
     assert [w.window_weeks for w in result.rolling_windows] == [4, 8, 12]
     assert all(w.sample_count == 0 for w in result.rolling_windows)
     assert all(w.insufficient_history for w in result.rolling_windows)
+
+
+# ---------------------------------------------------------------------------
+# Finding #2 — empty-history payload must use resolved backlog, not hardcoded 0
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_history_omitted_backlog_uses_load_backlog(ctx):
+    """Empty history + omitted backlog_size must call _load_backlog, not hardcode 0."""
+    from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
+    from dev_health_ops.api.graphql.resolvers.forecast import (
+        resolve_throughput_forecast,
+    )
+    from dev_health_ops.metrics.compute_capacity import ThroughputHistory
+
+    empty_history = ThroughputHistory([])
+
+    with (
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_throughput_history",
+            new_callable=AsyncMock,
+            return_value=empty_history,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_backlog",
+            new_callable=AsyncMock,
+            return_value=77,
+        ) as load_backlog,
+    ):
+        result = await resolve_throughput_forecast(ctx, ThroughputForecastInput())
+
+    assert result is not None
+    # backlog_size must reflect _load_backlog, NOT the hardcoded 0.
+    assert result.backlog_size == 77
+    assert result.insufficient_history is True
+    load_backlog.assert_awaited_once_with(ctx, team_ids=None, work_scope_id=None)
+
+
+@pytest.mark.asyncio
+async def test_empty_history_negative_backlog_rejected(ctx):
+    """Empty history + negative explicit backlog_size must raise ValueError."""
+    from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
+    from dev_health_ops.api.graphql.resolvers.forecast import (
+        resolve_throughput_forecast,
+    )
+    from dev_health_ops.metrics.compute_capacity import ThroughputHistory
+
+    empty_history = ThroughputHistory([])
+
+    with (
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_throughput_history",
+            new_callable=AsyncMock,
+            return_value=empty_history,
+        ),
+        pytest.raises(ValueError, match="backlog_size"),
+    ):
+        await resolve_throughput_forecast(ctx, ThroughputForecastInput(backlog_size=-1))

--- a/tests/api/graphql/test_throughput_forecast_resolver.py
+++ b/tests/api/graphql/test_throughput_forecast_resolver.py
@@ -543,3 +543,35 @@ async def test_empty_history_negative_backlog_rejected(ctx):
         pytest.raises(ValueError, match="backlog_size"),
     ):
         await resolve_throughput_forecast(ctx, ThroughputForecastInput(backlog_size=-1))
+
+
+# ---------------------------------------------------------------------------
+# Finding #3 — history_weeks validation must fire before empty-history branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_weeks", [0, -1])
+@pytest.mark.asyncio
+async def test_empty_history_invalid_history_weeks_rejected(ctx, bad_weeks):
+    """history_weeks <= 0 must raise ValueError regardless of whether rows exist."""
+    from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
+    from dev_health_ops.api.graphql.resolvers.forecast import (
+        resolve_throughput_forecast,
+    )
+
+    with pytest.raises(ValueError, match="history_weeks must be positive"):
+        await resolve_throughput_forecast(
+            ctx, ThroughputForecastInput(history_weeks=bad_weeks)
+        )
+
+
+@pytest.mark.asyncio
+async def test_rows_exist_invalid_history_weeks_same_error(ctx):
+    """history_weeks <= 0 raises the same ValueError when rows exist (parity check)."""
+    from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
+    from dev_health_ops.api.graphql.resolvers.forecast import (
+        resolve_throughput_forecast,
+    )
+
+    with pytest.raises(ValueError, match="history_weeks must be positive"):
+        await resolve_throughput_forecast(ctx, ThroughputForecastInput(history_weeks=0))

--- a/tests/api/graphql/test_throughput_forecast_resolver.py
+++ b/tests/api/graphql/test_throughput_forecast_resolver.py
@@ -440,3 +440,47 @@ async def test_resolver_surfaces_insufficient_history_and_sample_count(ctx):
     assert [w.window_weeks for w in result.rolling_windows] == [4, 8, 12]
     assert all(w.sample_count == 0 for w in result.rolling_windows)
     assert all(w.insufficient_history for w in result.rolling_windows)
+
+
+# ---------------------------------------------------------------------------
+# Finding #1 — empty-history GraphQL must not return null
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolver_returns_no_estimate_payload_for_zero_row_history(ctx):
+    """Zero-row history must return a structured no-estimate payload, NOT null.
+
+    An empty scope / new team previously short-circuited to ``return None``
+    which made the GraphQL field resolve to null. The contract requires a
+    structured ThroughputForecast with insufficientHistory=True and per-window
+    sampleCount=0 so the UI can render a "no data yet" state instead of
+    crashing on a null forecast.
+    """
+    from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
+    from dev_health_ops.api.graphql.resolvers.forecast import (
+        resolve_throughput_forecast,
+    )
+    from dev_health_ops.metrics.compute_capacity import ThroughputHistory
+
+    empty_history = ThroughputHistory([])
+
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.forecast._load_throughput_history",
+        new_callable=AsyncMock,
+        return_value=empty_history,
+    ):
+        result = await resolve_throughput_forecast(ctx, ThroughputForecastInput())
+
+    # Must NOT be null.
+    assert result is not None
+    # Top-level insufficient flag must be set.
+    assert result.insufficient_history is True
+    # No point estimates.
+    assert result.p50_weeks is None
+    assert result.p75_weeks is None
+    assert result.p90_weeks is None
+    # All three rolling windows present with sampleCount=0 and insufficient flag.
+    assert [w.window_weeks for w in result.rolling_windows] == [4, 8, 12]
+    assert all(w.sample_count == 0 for w in result.rolling_windows)
+    assert all(w.insufficient_history for w in result.rolling_windows)

--- a/tests/api/graphql/test_throughput_forecast_resolver.py
+++ b/tests/api/graphql/test_throughput_forecast_resolver.py
@@ -357,3 +357,86 @@ async def test_load_backlog_uses_equality_for_single_team(ctx):
     assert "team_id = {team_id:String}" in sql
     assert params["team_id"] == "team-a"
     assert "team_ids" not in params
+
+
+def _insufficient_result() -> ThroughputForecastResult:
+    """Short-history forecast: no estimate, every window flagged insufficient."""
+    return ThroughputForecastResult(
+        forecast_id="forecast-short",
+        computed_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+        team_id=None,
+        work_scope_id=None,
+        backlog_size=20,
+        history_weeks=12,
+        p50_weeks=None,
+        p75_weeks=None,
+        p90_weeks=None,
+        rolling_windows=tuple(
+            RollingWindowThroughput(
+                window_weeks=weeks,
+                mean_weekly_throughput=0.0,
+                samples=(),
+                insufficient_history=True,
+            )
+            for weeks in (4, 8, 12)
+        ),
+        primary_risk=_risk(RiskKind.NONE),
+        wip_congestion=_risk(RiskKind.WIP),
+        review_bottleneck=_risk(RiskKind.REVIEW),
+        incident_load=_risk(RiskKind.INCIDENT),
+        insufficient_history=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolver_surfaces_insufficient_history_and_sample_count(ctx):
+    """Resolver output must populate insufficientHistory + per-window sampleCount."""
+    from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
+    from dev_health_ops.api.graphql.resolvers.forecast import (
+        resolve_throughput_forecast,
+    )
+
+    with (
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_throughput_history",
+            new_callable=AsyncMock,
+            return_value=_history(),
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_work_item_overlay",
+            new_callable=AsyncMock,
+            return_value=(0.0, 0.0),
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_review_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_incident_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_backlog",
+            new_callable=AsyncMock,
+            return_value=20,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast.forecast_throughput_capacity",
+            return_value=_insufficient_result(),
+        ),
+    ):
+        result = await resolve_throughput_forecast(ctx, ThroughputForecastInput())
+
+    assert result is not None
+    # Top-level honesty flag surfaced for the UI warning/disabled state.
+    assert result.insufficient_history is True
+    # No point estimate emitted under short history.
+    assert result.p50_weeks is None
+    assert result.p75_weeks is None
+    assert result.p90_weeks is None
+    # Per-window provenance: every window carries sample_count + insufficient flag.
+    assert [w.window_weeks for w in result.rolling_windows] == [4, 8, 12]
+    assert all(w.sample_count == 0 for w in result.rolling_windows)
+    assert all(w.insufficient_history for w in result.rolling_windows)

--- a/tests/metrics/test_forecast.py
+++ b/tests/metrics/test_forecast.py
@@ -51,7 +51,11 @@ def test_rolling_forecast_is_deterministic_for_constant_throughput() -> None:
     assert result.primary_risk.kind is RiskKind.NONE
 
 
-def test_insufficient_history_uses_observed_weekly_rate() -> None:
+def test_insufficient_history_returns_no_estimate() -> None:
+    # 14 days is shorter than a single 4-week window. The old math floored the
+    # partial week to 1.0 and reported a confident 21.0/week estimate; the
+    # honest contract now flags the window as insufficient and emits no
+    # samples, so the forecast yields no point estimate (CHAOS-2574).
     history = _history([3] * 14)
 
     window = rolling_weekly_throughput(history, 4)
@@ -62,11 +66,32 @@ def test_insufficient_history_uses_observed_weekly_rate() -> None:
     )
 
     assert window.insufficient_history
-    assert window.mean_weekly_throughput == 21.0
+    assert window.mean_weekly_throughput == 0.0
+    assert window.samples == ()
     assert result.insufficient_history
-    assert result.p50_weeks == 2
-    assert result.p75_weeks == 2
-    assert result.p90_weeks == 2
+    assert result.p50_weeks is None
+    assert result.p75_weeks is None
+    assert result.p90_weeks is None
+
+
+def test_short_history_windows_not_identical() -> None:
+    # One day of five completed items cannot support a 4/8/12 week rolling
+    # mean. The old math collapsed every window to one fabricated value
+    # (CHAOS-2574); the honest contract flags each window insufficient and
+    # emits no point estimate.
+    history = _history([5])
+
+    windows = [rolling_weekly_throughput(history, weeks) for weeks in (4, 8, 12)]
+
+    assert all(window.insufficient_history for window in windows)
+    assert all(window.samples == () for window in windows)
+    assert all(window.mean_weekly_throughput == 0.0 for window in windows)
+
+    result = forecast_throughput_capacity(history=history, backlog_size=20)
+    assert result.insufficient_history
+    assert result.p50_weeks is None
+    assert result.p75_weeks is None
+    assert result.p90_weeks is None
 
 
 def test_forecast_percentiles_use_distribution_when_selected_window_collapses() -> None:

--- a/tests/metrics/test_forecast.py
+++ b/tests/metrics/test_forecast.py
@@ -26,7 +26,9 @@ def _history(daily: list[int]) -> ThroughputHistory:
 
 
 def test_rolling_forecast_is_deterministic_for_constant_throughput() -> None:
-    history = _history([2] * 84)
+    history = _history(
+        [2] * 85
+    )  # 85 days: 12w window gets 2 rolling samples (not boundary-exact)
 
     result = forecast_throughput_capacity(
         history=history,
@@ -250,12 +252,14 @@ def test_exactly_8_weeks_history_emits_no_estimate_for_8w_window() -> None:
 
 
 def test_exactly_12_weeks_history_emits_estimate_via_fallback() -> None:
-    # 12 weeks = 84 days. The 12w window produces exactly 1 rolling sample.
-    # The 8w window (56 days) produces 84-56+1 = 29 samples.
+    # 12 weeks = 84 days. The 12w window produces exactly 1 rolling sample
+    # (range(0, 84-84+1) = range(0,1)). With MIN_SAMPLES_FOR_ESTIMATE=2 that
+    # single sample is insufficient, so the 12w window is flagged insufficient.
+    # The 8w window (56 days) produces 84-56+1 = 29 samples — above the minimum.
     # The 4w window (28 days) produces 84-28+1 = 57 samples.
-    # _select_percentile_distribution with history_weeks=12 selects the 12w window
-    # (1 sample < MIN_SAMPLES_FOR_ESTIMATE), then falls back to the longest shorter
-    # window that meets the minimum — the 8w window (29 samples).
+    # _select_percentile_distribution falls back to the 8w window (29 samples),
+    # so estimates ARE produced. But the 12w window's insufficiency propagates
+    # to the top-level insufficient_history flag, preserving provenance.
     history = _history([3] * 84)
 
     result = forecast_throughput_capacity(
@@ -266,15 +270,17 @@ def test_exactly_12_weeks_history_emits_estimate_via_fallback() -> None:
 
     twelve_week = next(w for w in result.rolling_windows if w.window_weeks == 12)
     assert len(twelve_week.samples) == 1
-    # 12w has 1 sample (below min); falls back to 8w (29 samples) — estimates produced.
+    # 12w has 1 sample — below MIN_SAMPLES_FOR_ESTIMATE=2 — so it is insufficient.
+    assert twelve_week.insufficient_history is True
+    # Fallback to 8w (29 samples) produces estimates.
     assert result.p50_weeks is not None
     assert result.p75_weeks is not None
     assert result.p90_weeks is not None
-    # The 12w window itself is flagged insufficient (only 1 sample).
-    assert twelve_week.insufficient_history is False  # 84 days >= 84 days threshold
-    # But the overall result is NOT flagged insufficient because 8w/4w have data.
-    # (insufficient_history = any(window.insufficient_history for window in windows))
-    # 4w and 8w windows have sufficient history at 84 days.
+    # Top-level insufficient_history=True because the requested 12w window is
+    # insufficient, even though a fallback produced estimates. This preserves
+    # provenance: callers know the estimate came from a shorter window.
+    assert result.insufficient_history is True
+    # 8w and 4w windows have enough samples and are NOT insufficient.
     eight_week = next(w for w in result.rolling_windows if w.window_weeks == 8)
     four_week = next(w for w in result.rolling_windows if w.window_weeks == 4)
     assert eight_week.insufficient_history is False

--- a/tests/metrics/test_forecast.py
+++ b/tests/metrics/test_forecast.py
@@ -332,3 +332,57 @@ def test_nonstandard_history_weeks_6_between_standard_windows_reports_insufficie
     assert result.p50_weeks is not None
     # Provenance mismatch: no 6w window exists; fallback was used.
     assert result.insufficient_history is True
+
+
+# ---------------------------------------------------------------------------
+# Regression: result-level insufficient_history must reflect the REQUESTED
+# window only — longer unrequested windows must not taint the top-level flag.
+# ---------------------------------------------------------------------------
+
+
+def test_4w_request_with_29_daily_samples_is_not_insufficient() -> None:
+    # 29 daily samples: the 4w window (28 days) produces 29-28+1 = 2 rolling
+    # samples — exactly at MIN_SAMPLES_FOR_ESTIMATE. The 8w and 12w windows
+    # have 0 samples (insufficient), but the caller only asked for 4w.
+    # result.insufficient_history must be False.
+    history = _history([3] * 29)
+
+    result = forecast_throughput_capacity(
+        history=history,
+        backlog_size=20,
+        history_weeks=4,
+    )
+
+    four_week = next(w for w in result.rolling_windows if w.window_weeks == 4)
+    eight_week = next(w for w in result.rolling_windows if w.window_weeks == 8)
+    twelve_week = next(w for w in result.rolling_windows if w.window_weeks == 12)
+    # Per-window truth is preserved.
+    assert four_week.insufficient_history is False
+    assert eight_week.insufficient_history is True
+    assert twelve_week.insufficient_history is True
+    # Top-level flag reflects the requested 4w window only.
+    assert result.insufficient_history is False
+    assert result.p50_weeks is not None
+
+
+def test_8w_request_with_57_daily_samples_is_not_insufficient() -> None:
+    # 57 daily samples: the 8w window (56 days) produces 57-56+1 = 2 rolling
+    # samples — exactly at MIN_SAMPLES_FOR_ESTIMATE. The 12w window has 0
+    # samples (insufficient), but the caller only asked for 8w.
+    # result.insufficient_history must be False.
+    history = _history([3] * 57)
+
+    result = forecast_throughput_capacity(
+        history=history,
+        backlog_size=20,
+        history_weeks=8,
+    )
+
+    eight_week = next(w for w in result.rolling_windows if w.window_weeks == 8)
+    twelve_week = next(w for w in result.rolling_windows if w.window_weeks == 12)
+    # Per-window truth is preserved.
+    assert eight_week.insufficient_history is False
+    assert twelve_week.insufficient_history is True
+    # Top-level flag reflects the requested 8w window only.
+    assert result.insufficient_history is False
+    assert result.p50_weeks is not None

--- a/tests/metrics/test_forecast.py
+++ b/tests/metrics/test_forecast.py
@@ -186,3 +186,96 @@ def test_assert_monotonic_weeks_is_null_safe(
     p50: int | None, p75: int | None, p90: int | None
 ) -> None:
     _assert_monotonic_weeks(p50, p75, p90)
+
+
+# ---------------------------------------------------------------------------
+# Finding #2 — percentile estimate provenance at exact window boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_exactly_4_weeks_history_emits_no_estimate() -> None:
+    # 4 weeks = 28 days. rolling_weekly_throughput needs len(throughputs) >= window_days
+    # to produce samples. At exactly 28 days the 4w window produces exactly 1 rolling
+    # sample (range(0, 28-28+1) = range(0,1)). With MIN_SAMPLES_FOR_ESTIMATE=2 that
+    # single sample is insufficient; no shorter window exists, so the forecast must
+    # return no estimate.
+    history = _history([3] * 28)
+
+    result = forecast_throughput_capacity(
+        history=history,
+        backlog_size=20,
+        history_weeks=4,
+    )
+
+    # The 4w window has exactly 1 rolling sample — below the minimum.
+    four_week = next(w for w in result.rolling_windows if w.window_weeks == 4)
+    assert len(four_week.samples) == 1
+    # No shorter window can provide a fallback, so estimates must be None.
+    assert result.p50_weeks is None
+    assert result.p75_weeks is None
+    assert result.p90_weeks is None
+    assert result.insufficient_history
+
+
+def test_exactly_8_weeks_history_emits_no_estimate_for_8w_window() -> None:
+    # 8 weeks = 56 days. The 8w window produces exactly 1 rolling sample.
+    # The 4w window (28 days) produces 56-28+1 = 29 samples — above the minimum.
+    # _select_percentile_distribution with history_weeks=8 selects the 8w window
+    # (1 sample < MIN_SAMPLES_FOR_ESTIMATE), then falls back to the 4w window.
+    # With history_weeks=12 (default), the 12w window is selected (0 samples,
+    # insufficient), falls back to 8w (1 sample, insufficient), then 4w (29 samples).
+    history = _history([3] * 56)
+
+    result_8w = forecast_throughput_capacity(
+        history=history,
+        backlog_size=20,
+        history_weeks=8,
+    )
+    result_12w = forecast_throughput_capacity(
+        history=history,
+        backlog_size=20,
+        history_weeks=12,
+    )
+
+    eight_week = next(w for w in result_8w.rolling_windows if w.window_weeks == 8)
+    assert len(eight_week.samples) == 1
+    # history_weeks=8: 8w window has 1 sample (below min); falls back to 4w (29 samples).
+    # The 4w fallback has enough samples so estimates are produced.
+    assert result_8w.p50_weeks is not None
+    assert result_8w.p75_weeks is not None
+    assert result_8w.p90_weeks is not None
+    # history_weeks=12: 12w window has 0 samples; 8w has 1 (below min); 4w has 29.
+    # Falls back to 4w — estimates produced.
+    assert result_12w.p50_weeks is not None
+
+
+def test_exactly_12_weeks_history_emits_estimate_via_fallback() -> None:
+    # 12 weeks = 84 days. The 12w window produces exactly 1 rolling sample.
+    # The 8w window (56 days) produces 84-56+1 = 29 samples.
+    # The 4w window (28 days) produces 84-28+1 = 57 samples.
+    # _select_percentile_distribution with history_weeks=12 selects the 12w window
+    # (1 sample < MIN_SAMPLES_FOR_ESTIMATE), then falls back to the longest shorter
+    # window that meets the minimum — the 8w window (29 samples).
+    history = _history([3] * 84)
+
+    result = forecast_throughput_capacity(
+        history=history,
+        backlog_size=20,
+        history_weeks=12,
+    )
+
+    twelve_week = next(w for w in result.rolling_windows if w.window_weeks == 12)
+    assert len(twelve_week.samples) == 1
+    # 12w has 1 sample (below min); falls back to 8w (29 samples) — estimates produced.
+    assert result.p50_weeks is not None
+    assert result.p75_weeks is not None
+    assert result.p90_weeks is not None
+    # The 12w window itself is flagged insufficient (only 1 sample).
+    assert twelve_week.insufficient_history is False  # 84 days >= 84 days threshold
+    # But the overall result is NOT flagged insufficient because 8w/4w have data.
+    # (insufficient_history = any(window.insufficient_history for window in windows))
+    # 4w and 8w windows have sufficient history at 84 days.
+    eight_week = next(w for w in result.rolling_windows if w.window_weeks == 8)
+    four_week = next(w for w in result.rolling_windows if w.window_weeks == 4)
+    assert eight_week.insufficient_history is False
+    assert four_week.insufficient_history is False

--- a/tests/metrics/test_forecast.py
+++ b/tests/metrics/test_forecast.py
@@ -285,3 +285,50 @@ def test_exactly_12_weeks_history_emits_estimate_via_fallback() -> None:
     four_week = next(w for w in result.rolling_windows if w.window_weeks == 4)
     assert eight_week.insufficient_history is False
     assert four_week.insufficient_history is False
+
+
+# ---------------------------------------------------------------------------
+# Non-standard history_weeks provenance (CHAOS-2574 follow-up)
+# ---------------------------------------------------------------------------
+
+
+def test_nonstandard_history_weeks_16_with_full_data_reports_insufficient() -> None:
+    # history_weeks=16 is not a standard window (4/8/12). With >=16 weeks of
+    # data the distribution selection falls back to the 12w window, which has
+    # enough samples to produce estimates. The result must still report
+    # insufficient_history=True because the estimate did NOT use the requested
+    # 16-week window — provenance is violated.
+    history = _history([3] * (16 * 7))  # 112 days — more than 16 weeks
+
+    result = forecast_throughput_capacity(
+        history=history,
+        backlog_size=20,
+        history_weeks=16,
+    )
+
+    # Estimates are produced (12w fallback has enough samples).
+    assert result.p50_weeks is not None
+    assert result.p75_weeks is not None
+    assert result.p90_weeks is not None
+    # But provenance is violated: the estimate used 12w, not the requested 16w.
+    assert result.insufficient_history is True
+
+
+def test_nonstandard_history_weeks_6_between_standard_windows_reports_insufficient() -> (
+    None
+):
+    # history_weeks=6 sits between the standard 4w and 8w windows. With plenty
+    # of data the distribution selection falls back to the 12w window (windows[-1]).
+    # The result must report insufficient_history=True because no 6w window exists.
+    history = _history([4] * 85)  # 85 days — enough for all standard windows
+
+    result = forecast_throughput_capacity(
+        history=history,
+        backlog_size=20,
+        history_weeks=6,
+    )
+
+    # Estimates are produced via the 12w fallback.
+    assert result.p50_weeks is not None
+    # Provenance mismatch: no 6w window exists; fallback was used.
+    assert result.insufficient_history is True


### PR DESCRIPTION
## Summary

`rolling_weekly_throughput` collapsed the 4w/8w/12w rolling windows to a single value whenever history was shorter than a window. The short-history branch computed `total / max(weeks, 1.0)` where `observed_weeks` did **not** depend on `window_weeks`, so every window size produced the same number — and the `max(..., 1.0)` partial-week floor turned ~1 day of data into a confident weekly throughput estimate.

This change replaces that branch with an **honest no-estimate contract** per insufficient window:

- A window with insufficient history now returns `mean_weekly_throughput=0.0`, empty `samples`, and `insufficient_history=True`.
- Percentile selection still **gracefully degrades** to a shorter window that *does* have enough history (e.g. 5 weeks of data still drives a 4-week estimate).
- When **all** windows are insufficient, the forecast returns no point estimate (`p50/p75/p90_weeks = None`) with `insufficient_history=True` surfaced for the UI.

The GraphQL resolver already maps `insufficientHistory` (top-level) and per-window `sampleCount` + `insufficientHistory` through to the output; a resolver test now asserts that mapping.

## Tests

- `tests/metrics/test_forecast.py::test_short_history_windows_not_identical` (new)
- `tests/metrics/test_forecast.py::test_insufficient_history_returns_no_estimate` (updated from the old behaviour that encoded the collapse)
- `tests/api/graphql/test_throughput_forecast_resolver.py::test_resolver_surfaces_insufficient_history_and_sample_count` (new)

Gate (run from the ops worktree):

\`\`\`
CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/metrics/test_forecast.py tests/api/graphql/test_throughput_forecast_resolver.py -q   # 23 passed
uv run --extra dev --python 3.11 mypy src/dev_health_ops/metrics                                                                                  # clean
\`\`\`

Closes CHAOS-2574