### PR TITLE
fix(sync): dispatch backpressure + post-sync window (CHAOS-2576, CHAOS-2577)

### DIFF
--- a/src/dev_health_ops/sync/guard.py
+++ b/src/dev_health_ops/sync/guard.py
@@ -26,6 +26,7 @@ import os
 import uuid
 from collections import defaultdict
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from sqlalchemy import func
@@ -90,40 +91,101 @@ class DispatchGuard:
             )
 
         concurrency_cap = _env_int("SYNC_UNIT_CONCURRENCY_PER_BUCKET", 8)
-        planned_by_bucket: dict[tuple[str, str, str], list[SyncRunUnit]] = defaultdict(
-            list
-        )
-        eligible_statuses = {
+
+        # Units from THIS run that are candidates for dispatch this pass:
+        # only PLANNED and DISPATCHING (fresh DISPATCHING will be reclaimed by
+        # _claim_units; RUNNING/RETRYING from this run are already in-flight
+        # and must count against the cap, not be re-dispatched).
+        dispatch_candidate_statuses = {
             SyncRunUnitStatus.PLANNED.value,
             SyncRunUnitStatus.DISPATCHING.value,
         }
+        planned_by_bucket: dict[tuple[str, str, str], list[SyncRunUnit]] = defaultdict(
+            list
+        )
         for unit in units:
-            if unit.status in eligible_statuses:
+            if unit.status in dispatch_candidate_statuses:
                 planned_by_bucket[
                     (str(unit.org_id), unit.provider, unit.cost_class)
                 ].append(unit)
 
-        capped_unit_ids: list[str] = []
+        # Freshness cutoffs — same semantics as _stale_dispatch_seconds() /
+        # _stale_running_seconds() in sync_units.py.  We do NOT import
+        # sync_units here (circular: sync_units imports DispatchGuard).
+        now = datetime.now(timezone.utc)
+        stale_dispatch_cutoff = now - timedelta(seconds=_stale_dispatch_seconds_guard())
+        stale_running_cutoff = now - timedelta(seconds=_stale_running_seconds_guard())
+
+        # Active-slot statuses: units that are genuinely occupying a concurrency
+        # slot right now (across ALL runs, including the current run).
+        # DISPATCHING/RUNNING/RETRYING from the current run are already in-flight
+        # and must reduce available capacity — they must NOT be re-dispatched.
         active_statuses = {
             SyncRunUnitStatus.DISPATCHING.value,
             SyncRunUnitStatus.RUNNING.value,
             SyncRunUnitStatus.RETRYING.value,
         }
+
+        capped_unit_ids: list[str] = []
         for bucket, bucket_units in planned_by_bucket.items():
             org_id, provider, cost_class = bucket
+
+            # Count fresh active units across ALL runs (including this one).
+            # A unit is "fresh" if its updated_at is within the staleness window
+            # for its status — stale units will be reclaimed by _claim_units and
+            # should not permanently block capacity.
+            #
+            # F1: include same-run RUNNING/RETRYING/DISPATCHING so they reduce
+            #     available slots (previously excluded via != run_uuid).
+            # F2: apply freshness thresholds so dead-worker leftovers don't cap
+            #     forever (previously no updated_at filter).
             active_count = (
                 session.query(func.count(SyncRunUnit.id))
                 .filter(
-                    SyncRunUnit.sync_run_id != run_uuid,
                     SyncRunUnit.org_id == org_id,
                     SyncRunUnit.provider == provider,
                     SyncRunUnit.cost_class == cost_class,
                     SyncRunUnit.status.in_(active_statuses),
+                    # Exclude units that are stale (dead worker) — they will be
+                    # reclaimed and must not permanently block capacity.
+                    # DISPATCHING units stale after stale_dispatch_cutoff,
+                    # RUNNING/RETRYING units stale after stale_running_cutoff.
+                    # We use the more conservative (longer) running cutoff for
+                    # RETRYING since it shares the same semantics as RUNNING.
+                    (
+                        (SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value)
+                        & (SyncRunUnit.updated_at > stale_dispatch_cutoff)
+                        | (
+                            SyncRunUnit.status.in_(
+                                {
+                                    SyncRunUnitStatus.RUNNING.value,
+                                    SyncRunUnitStatus.RETRYING.value,
+                                }
+                            )
+                        )
+                        & (SyncRunUnit.updated_at > stale_running_cutoff)
+                    ),
                 )
                 .scalar()
                 or 0
             )
-            allowed_slots = max(0, concurrency_cap - int(active_count))
+
+            # Subtract same-run dispatch candidates that are DISPATCHING
+            # (they are already counted in active_count above but will be
+            # reclaimed by _claim_units, so they don't consume a net new slot).
+            # RUNNING/RETRYING from this run are genuinely in-flight and DO
+            # consume slots — do not subtract them.
+            same_run_fresh_dispatching = sum(
+                1
+                for u in bucket_units
+                if u.status == SyncRunUnitStatus.DISPATCHING.value
+                and _as_aware_guard(u.updated_at) > stale_dispatch_cutoff
+            )
+            # Net active slots consumed by OTHER units (not the candidates we
+            # are about to dispatch).
+            net_active = int(active_count) - same_run_fresh_dispatching
+            allowed_slots = max(0, concurrency_cap - net_active)
+
             if len(bucket_units) > allowed_slots:
                 capped_unit_ids.extend(
                     str(unit.id) for unit in bucket_units[allowed_slots:]
@@ -164,3 +226,37 @@ def _env_int(name: str, default: int) -> int:
     except ValueError:
         return default
     return max(1, value)
+
+
+# ---------------------------------------------------------------------------
+# Staleness helpers — mirrors sync_units._stale_dispatch_seconds() /
+# _stale_running_seconds() using the same env vars.  Defined here to avoid
+# a circular import (sync_units imports DispatchGuard from this module).
+# ---------------------------------------------------------------------------
+
+
+def _stale_dispatch_seconds_guard() -> int:
+    try:
+        return max(
+            1,
+            int(os.getenv("SYNC_UNIT_DISPATCH_STALE_SECONDS", "900")),
+        )
+    except ValueError:
+        return 900
+
+
+def _stale_running_seconds_guard() -> int:
+    try:
+        return max(
+            1,
+            int(os.getenv("SYNC_UNIT_RUNNING_STALE_SECONDS", "3600")),
+        )
+    except ValueError:
+        return 3600
+
+
+def _as_aware_guard(value: datetime) -> datetime:
+    """Return a timezone-aware UTC datetime (mirrors sync_units._as_aware)."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)

--- a/src/dev_health_ops/sync/guard.py
+++ b/src/dev_health_ops/sync/guard.py
@@ -18,6 +18,33 @@ Decision shapes
   concurrency slots.  The caller MUST leave capped units PLANNED and schedule
   a delayed redispatch; it MUST NOT mark the run FAILED.
 * **Full allow** — ``GuardDecision(allowed=True, concurrency_capped=False)``.
+
+Concurrency model
+-----------------
+Two disjoint sets per (org_id, provider, cost_class) bucket:
+
+**Capacity-consumer set** — units that are genuinely occupying a concurrency
+slot right now, across ALL runs (including the current run).  These reduce
+``allowed_slots``:
+
+* status == DISPATCHING  AND  updated_at > stale_dispatch_cutoff  (fresh)
+* status in {RUNNING, RETRYING}  AND  updated_at > stale_running_cutoff  (fresh)
+
+Stale units are excluded because ``_claim_units`` will reclaim them on the
+next pass; they must not permanently block capacity.
+
+**Candidate set** — units from THIS run that ``_claim_units`` can enqueue this
+pass.  Mirrors ``_claim_units`` claim + reclaim logic exactly:
+
+* status == PLANNED  (any age — claimed via UPDATE…RETURNING)
+* status == DISPATCHING  AND  updated_at <= stale_dispatch_cutoff  (stale reclaim)
+* status == RUNNING  AND  updated_at <= stale_running_cutoff  (stale reclaim)
+
+Fresh DISPATCHING is NOT a candidate (it is a consumer).
+Stale RETRYING is NOT a candidate (``_claim_units`` does not reclaim RETRYING).
+
+The two sets are disjoint by construction — no subtraction is needed or
+performed.
 """
 
 from __future__ import annotations
@@ -75,6 +102,7 @@ class DispatchGuard:
         if run is None:
             return GuardDecision(False, f"sync_run not found: {sync_run_id}")
 
+        # Load all units for this run, ordered by id (stable ordering for cap suffix).
         units = (
             session.query(SyncRunUnit)
             .filter(SyncRunUnit.sync_run_id == run_uuid)
@@ -92,69 +120,64 @@ class DispatchGuard:
 
         concurrency_cap = _env_int("SYNC_UNIT_CONCURRENCY_PER_BUCKET", 8)
 
-        # Units from THIS run that are candidates for dispatch this pass:
-        # only PLANNED and DISPATCHING (fresh DISPATCHING will be reclaimed by
-        # _claim_units; RUNNING/RETRYING from this run are already in-flight
-        # and must count against the cap, not be re-dispatched).
-        dispatch_candidate_statuses = {
-            SyncRunUnitStatus.PLANNED.value,
-            SyncRunUnitStatus.DISPATCHING.value,
-        }
-        planned_by_bucket: dict[tuple[str, str, str], list[SyncRunUnit]] = defaultdict(
-            list
-        )
-        for unit in units:
-            if unit.status in dispatch_candidate_statuses:
-                planned_by_bucket[
-                    (str(unit.org_id), unit.provider, unit.cost_class)
-                ].append(unit)
-
-        # Freshness cutoffs — same semantics as _stale_dispatch_seconds() /
-        # _stale_running_seconds() in sync_units.py.  We do NOT import
-        # sync_units here (circular: sync_units imports DispatchGuard).
+        # Staleness cutoffs — same env vars as _stale_dispatch_seconds() /
+        # _stale_running_seconds() in sync_units.py.  Defined locally to avoid
+        # a circular import (sync_units imports DispatchGuard from this module).
         now = datetime.now(timezone.utc)
         stale_dispatch_cutoff = now - timedelta(seconds=_stale_dispatch_seconds_guard())
         stale_running_cutoff = now - timedelta(seconds=_stale_running_seconds_guard())
 
-        # Active-slot statuses: units that are genuinely occupying a concurrency
-        # slot right now (across ALL runs, including the current run).
-        # DISPATCHING/RUNNING/RETRYING from the current run are already in-flight
-        # and must reduce available capacity — they must NOT be re-dispatched.
-        active_statuses = {
-            SyncRunUnitStatus.DISPATCHING.value,
-            SyncRunUnitStatus.RUNNING.value,
-            SyncRunUnitStatus.RETRYING.value,
-        }
+        # Build the CANDIDATE set per bucket — units from THIS run that
+        # _claim_units can enqueue this pass.  Mirrors _claim_units exactly:
+        #   • PLANNED (any age) — claimed via UPDATE…RETURNING
+        #   • stale DISPATCHING (updated_at <= stale_dispatch_cutoff) — reclaimed
+        #   • stale RUNNING (updated_at <= stale_running_cutoff) — reclaimed
+        # Fresh DISPATCHING is a capacity CONSUMER, not a candidate.
+        # Stale RETRYING is neither (_claim_units does not reclaim RETRYING).
+        candidates_by_bucket: dict[tuple[str, str, str], list[SyncRunUnit]] = (
+            defaultdict(list)
+        )
+        for unit in units:
+            bucket = (str(unit.org_id), unit.provider, unit.cost_class)
+            if unit.status == SyncRunUnitStatus.PLANNED.value:
+                candidates_by_bucket[bucket].append(unit)
+            elif unit.status == SyncRunUnitStatus.DISPATCHING.value:
+                if _as_aware_guard(unit.updated_at) <= stale_dispatch_cutoff:
+                    # Stale DISPATCHING — _claim_units will reclaim it.
+                    candidates_by_bucket[bucket].append(unit)
+            elif unit.status == SyncRunUnitStatus.RUNNING.value:
+                if _as_aware_guard(unit.updated_at) <= stale_running_cutoff:
+                    # Stale RUNNING — _claim_units will reclaim it.
+                    candidates_by_bucket[bucket].append(unit)
+            # Fresh DISPATCHING → consumer only (counted in active_count below).
+            # RETRYING (any age) → neither candidate nor consumer for this run.
+            # SUCCESS / FAILED → terminal, ignored.
 
         capped_unit_ids: list[str] = []
-        for bucket, bucket_units in planned_by_bucket.items():
+        for bucket, bucket_candidates in candidates_by_bucket.items():
             org_id, provider, cost_class = bucket
 
-            # Count fresh active units across ALL runs (including this one).
-            # A unit is "fresh" if its updated_at is within the staleness window
-            # for its status — stale units will be reclaimed by _claim_units and
-            # should not permanently block capacity.
-            #
-            # F1: include same-run RUNNING/RETRYING/DISPATCHING so they reduce
-            #     available slots (previously excluded via != run_uuid).
-            # F2: apply freshness thresholds so dead-worker leftovers don't cap
-            #     forever (previously no updated_at filter).
+            # Count the CAPACITY-CONSUMER set across ALL runs (including this
+            # run) for this bucket.  Consumers are fresh active units:
+            #   • fresh DISPATCHING: updated_at > stale_dispatch_cutoff
+            #   • fresh RUNNING or RETRYING: updated_at > stale_running_cutoff
+            # Stale units are excluded — they will be reclaimed and must not
+            # permanently block capacity (F2 stale-blocker fix).
+            # Same-run fresh DISPATCHING IS included — it is a genuine consumer
+            # that reduces available slots (F1 same-run visibility fix).
+            # No subtraction is performed; the consumer and candidate sets are
+            # disjoint by construction.
             active_count = (
                 session.query(func.count(SyncRunUnit.id))
                 .filter(
                     SyncRunUnit.org_id == org_id,
                     SyncRunUnit.provider == provider,
                     SyncRunUnit.cost_class == cost_class,
-                    SyncRunUnit.status.in_(active_statuses),
-                    # Exclude units that are stale (dead worker) — they will be
-                    # reclaimed and must not permanently block capacity.
-                    # DISPATCHING units stale after stale_dispatch_cutoff,
-                    # RUNNING/RETRYING units stale after stale_running_cutoff.
-                    # We use the more conservative (longer) running cutoff for
-                    # RETRYING since it shares the same semantics as RUNNING.
                     (
-                        (SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value)
-                        & (SyncRunUnit.updated_at > stale_dispatch_cutoff)
+                        (
+                            (SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value)
+                            & (SyncRunUnit.updated_at > stale_dispatch_cutoff)
+                        )
                         | (
                             SyncRunUnit.status.in_(
                                 {
@@ -162,33 +185,18 @@ class DispatchGuard:
                                     SyncRunUnitStatus.RETRYING.value,
                                 }
                             )
+                            & (SyncRunUnit.updated_at > stale_running_cutoff)
                         )
-                        & (SyncRunUnit.updated_at > stale_running_cutoff)
                     ),
                 )
                 .scalar()
                 or 0
             )
 
-            # Subtract same-run dispatch candidates that are DISPATCHING
-            # (they are already counted in active_count above but will be
-            # reclaimed by _claim_units, so they don't consume a net new slot).
-            # RUNNING/RETRYING from this run are genuinely in-flight and DO
-            # consume slots — do not subtract them.
-            same_run_fresh_dispatching = sum(
-                1
-                for u in bucket_units
-                if u.status == SyncRunUnitStatus.DISPATCHING.value
-                and _as_aware_guard(u.updated_at) > stale_dispatch_cutoff
-            )
-            # Net active slots consumed by OTHER units (not the candidates we
-            # are about to dispatch).
-            net_active = int(active_count) - same_run_fresh_dispatching
-            allowed_slots = max(0, concurrency_cap - net_active)
-
-            if len(bucket_units) > allowed_slots:
+            allowed_slots = max(0, concurrency_cap - int(active_count))
+            if len(bucket_candidates) > allowed_slots:
                 capped_unit_ids.extend(
-                    str(unit.id) for unit in bucket_units[allowed_slots:]
+                    str(unit.id) for unit in bucket_candidates[allowed_slots:]
                 )
 
         if capped_unit_ids:

--- a/src/dev_health_ops/sync/guard.py
+++ b/src/dev_health_ops/sync/guard.py
@@ -6,6 +6,18 @@ Today tier limits are enforced only at the API boundary; the scheduler and
 worker dispatch paths bypass them. :meth:`DispatchGuard.authorize_run` MUST be
 invoked at the TOP of ``dispatch_sync_run`` (after planning, before any unit is
 queued) so that API, scheduler, and backfill all pass through one guard.
+
+Decision shapes
+---------------
+* **Total-cap hard-deny** — ``GuardDecision(allowed=False,
+  concurrency_capped=False, capped_unit_ids=(...))`` — the whole run exceeds
+  the org's absolute unit ceiling.  The caller MUST mark the run FAILED.
+* **Concurrency partial-cap** — ``GuardDecision(allowed=True,
+  concurrency_capped=True, capped_unit_ids=(...))`` — some units cannot be
+  dispatched right now because another run is consuming the per-bucket
+  concurrency slots.  The caller MUST leave capped units PLANNED and schedule
+  a delayed redispatch; it MUST NOT mark the run FAILED.
+* **Full allow** — ``GuardDecision(allowed=True, concurrency_capped=False)``.
 """
 
 from __future__ import annotations
@@ -26,14 +38,22 @@ if TYPE_CHECKING:
 class GuardDecision:
     """Outcome of an authorize check.
 
-    ``capped_unit_ids`` lets the guard deny a subset (e.g. over a cost-class
-    concurrency cap) while letting the rest of the run proceed; an empty tuple
-    with ``allowed=True`` means the whole run is authorized.
+    Two distinct cap shapes (see module docstring):
+
+    * **Total-cap hard-deny**: ``allowed=False, concurrency_capped=False``.
+      The run exceeds the org's absolute unit ceiling; the caller must mark
+      the run FAILED and stop.
+    * **Concurrency partial-cap**: ``allowed=True, concurrency_capped=True``.
+      Some units cannot be dispatched right now; ``capped_unit_ids`` lists
+      them.  The caller must leave those units PLANNED and schedule a delayed
+      redispatch — it must NOT mark the run FAILED.
+    * **Full allow**: ``allowed=True, concurrency_capped=False``.
     """
 
     allowed: bool
     reason: str | None = None
     capped_unit_ids: tuple[str, ...] = field(default_factory=tuple)
+    concurrency_capped: bool = False
 
 
 class DispatchGuard:
@@ -111,9 +131,10 @@ class DispatchGuard:
 
         if capped_unit_ids:
             return GuardDecision(
-                False,
+                True,
                 f"sync unit concurrency cap exceeded: {len(capped_unit_ids)} capped",
                 tuple(capped_unit_ids),
+                concurrency_capped=True,
             )
 
         return GuardDecision(True)

--- a/src/dev_health_ops/sync/guard.py
+++ b/src/dev_health_ops/sync/guard.py
@@ -28,27 +28,47 @@ slot right now, across ALL runs (including the current run).  These reduce
 ``allowed_slots``:
 
 * status == DISPATCHING  AND  updated_at > stale_dispatch_cutoff  (fresh)
-* status in {RUNNING, RETRYING}  AND  updated_at > stale_running_cutoff  (fresh)
+* status == RUNNING  (any age — no heartbeat, so stale threshold is not safe)
+* status == RETRYING  AND  updated_at > stale_running_cutoff  (fresh)
 
-Stale units are excluded because ``_claim_units`` will reclaim them on the
-next pass; they must not permanently block capacity.
+RUNNING always counts regardless of updated_at because run_sync_unit does not
+heartbeat during the provider call.  Reclaiming a stale RUNNING unit would
+cause duplicate provider writes (F2).  Durable dead-worker recovery (heartbeat
++ lease) is a separate follow-up (CHAOS-2577).
 
 **Candidate set** — units from THIS run that ``_claim_units`` can enqueue this
 pass.  Mirrors ``_claim_units`` claim + reclaim logic exactly:
 
 * status == PLANNED  (any age — claimed via UPDATE…RETURNING)
 * status == DISPATCHING  AND  updated_at <= stale_dispatch_cutoff  (stale reclaim)
-* status == RUNNING  AND  updated_at <= stale_running_cutoff  (stale reclaim)
 
 Fresh DISPATCHING is NOT a candidate (it is a consumer).
+RUNNING is NOT a candidate (never reclaimed — F2 fix).
 Stale RETRYING is NOT a candidate (``_claim_units`` does not reclaim RETRYING).
 
 The two sets are disjoint by construction — no subtraction is needed or
 performed.
+
+Advisory locking (F1 TOCTOU fix)
+---------------------------------
+Before reading active_count for each bucket, ``authorize_run`` acquires a
+PostgreSQL transaction-scoped advisory lock keyed on the bucket.  Buckets are
+sorted deterministically before locking to prevent deadlocks when two
+dispatchers race on the same set of buckets.
+
+The lock is held until the surrounding ``get_postgres_session_sync()`` block
+commits (``dispatch_sync_run`` wraps authorize→claim in one session), so the
+active_count read and the subsequent ``_claim_units`` UPDATE are atomic with
+respect to other dispatchers in the same bucket.
+
+On SQLite (tests) the dialect check no-ops — advisory locks are
+PostgreSQL-only.  The lock key derivation is the same deterministic 63-bit
+integer pattern used in ``src/dev_health_ops/api/admin/routers/sync.py:224-239``.
 """
 
 from __future__ import annotations
 
+import hashlib
 import os
 import uuid
 from collections import defaultdict
@@ -56,7 +76,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
-from sqlalchemy import func
+from sqlalchemy import func, text
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -131,7 +151,7 @@ class DispatchGuard:
         # _claim_units can enqueue this pass.  Mirrors _claim_units exactly:
         #   • PLANNED (any age) — claimed via UPDATE…RETURNING
         #   • stale DISPATCHING (updated_at <= stale_dispatch_cutoff) — reclaimed
-        #   • stale RUNNING (updated_at <= stale_running_cutoff) — reclaimed
+        # RUNNING is NOT a candidate (F2: never reclaim RUNNING — no heartbeat).
         # Fresh DISPATCHING is a capacity CONSUMER, not a candidate.
         # Stale RETRYING is neither (_claim_units does not reclaim RETRYING).
         candidates_by_bucket: dict[tuple[str, str, str], list[SyncRunUnit]] = (
@@ -145,28 +165,40 @@ class DispatchGuard:
                 if _as_aware_guard(unit.updated_at) <= stale_dispatch_cutoff:
                     # Stale DISPATCHING — _claim_units will reclaim it.
                     candidates_by_bucket[bucket].append(unit)
-            elif unit.status == SyncRunUnitStatus.RUNNING.value:
-                if _as_aware_guard(unit.updated_at) <= stale_running_cutoff:
-                    # Stale RUNNING — _claim_units will reclaim it.
-                    candidates_by_bucket[bucket].append(unit)
+            # RUNNING (any age) → capacity consumer only; never a candidate (F2).
             # Fresh DISPATCHING → consumer only (counted in active_count below).
             # RETRYING (any age) → neither candidate nor consumer for this run.
             # SUCCESS / FAILED → terminal, ignored.
+
+        # F1 TOCTOU fix: acquire a PostgreSQL transaction-scoped advisory lock
+        # per bucket BEFORE reading active_count.  Buckets are sorted
+        # deterministically to prevent deadlocks when two dispatchers race on
+        # the same set of buckets.  The lock is held until the surrounding
+        # session commits (dispatch_sync_run wraps authorize→claim in one
+        # get_postgres_session_sync() block), making the count+claim atomic.
+        # On SQLite (tests) the dialect check no-ops.
+        #
+        # Key derivation reuses the same deterministic 63-bit integer pattern
+        # as _bucket_advisory_lock_key() below (mirrors sync.py:224-239).
+        all_buckets = sorted(candidates_by_bucket.keys())
+        _acquire_bucket_advisory_locks(session, all_buckets)
 
         capped_unit_ids: list[str] = []
         for bucket, bucket_candidates in candidates_by_bucket.items():
             org_id, provider, cost_class = bucket
 
             # Count the CAPACITY-CONSUMER set across ALL runs (including this
-            # run) for this bucket.  Consumers are fresh active units:
+            # run) for this bucket.  Consumers are:
             #   • fresh DISPATCHING: updated_at > stale_dispatch_cutoff
-            #   • fresh RUNNING or RETRYING: updated_at > stale_running_cutoff
-            # Stale units are excluded — they will be reclaimed and must not
-            # permanently block capacity (F2 stale-blocker fix).
-            # Same-run fresh DISPATCHING IS included — it is a genuine consumer
-            # that reduces available slots (F1 same-run visibility fix).
+            #   • ALL RUNNING (any age) — no heartbeat, so stale threshold is
+            #     not safe to use; reclaiming would cause duplicate writes (F2)
+            #   • fresh RETRYING: updated_at > stale_running_cutoff
             # No subtraction is performed; the consumer and candidate sets are
             # disjoint by construction.
+            #
+            # INTERIM: a capped run whose only blocker is a DEAD RUNNING unit
+            # may stall — acceptable, preserves at-most-once provider execution.
+            # The heartbeat/lease follow-up (CHAOS-2577) adds safe recovery.
             active_count = (
                 session.query(func.count(SyncRunUnit.id))
                 .filter(
@@ -178,13 +210,9 @@ class DispatchGuard:
                             (SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value)
                             & (SyncRunUnit.updated_at > stale_dispatch_cutoff)
                         )
+                        | (SyncRunUnit.status == SyncRunUnitStatus.RUNNING.value)
                         | (
-                            SyncRunUnit.status.in_(
-                                {
-                                    SyncRunUnitStatus.RUNNING.value,
-                                    SyncRunUnitStatus.RETRYING.value,
-                                }
-                            )
+                            (SyncRunUnit.status == SyncRunUnitStatus.RETRYING.value)
                             & (SyncRunUnit.updated_at > stale_running_cutoff)
                         )
                     ),
@@ -208,6 +236,40 @@ class DispatchGuard:
             )
 
         return GuardDecision(True)
+
+
+def _bucket_advisory_lock_key(org_id: str, provider: str, cost_class: str) -> int:
+    """Deterministic 63-bit advisory lock key for a (org_id, provider, cost_class) bucket.
+
+    Uses SHA-256 of the canonical bucket string, truncated to 63 bits so it
+    fits in a PostgreSQL bigint (signed 64-bit).  Mirrors the pattern in
+    ``src/dev_health_ops/api/admin/routers/sync.py:224-229``.
+    """
+    raw = f"{org_id}:{provider}:{cost_class}".encode()
+    digest = hashlib.sha256(raw).digest()
+    # Take first 8 bytes as big-endian unsigned int, then mask to 63 bits.
+    key_int = int.from_bytes(digest[:8], "big")
+    return key_int & ((1 << 63) - 1)
+
+
+def _acquire_bucket_advisory_locks(
+    session: Session,
+    buckets: list[tuple[str, str, str]],
+) -> None:
+    """Acquire PostgreSQL transaction-scoped advisory locks for each bucket.
+
+    Buckets must be pre-sorted by the caller to prevent deadlocks.
+    No-ops on non-PostgreSQL dialects (e.g. SQLite in tests).
+    """
+    bind = session.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+    for org_id, provider, cost_class in buckets:
+        lock_key = _bucket_advisory_lock_key(org_id, provider, cost_class)
+        session.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_key)"),
+            {"lock_key": lock_key},
+        )
 
 
 def _resolve_total_unit_cap(session: Session, org_id: str) -> int:

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -140,6 +140,7 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
             )
             return {"status": "missing", "sync_run_id": sync_run_id}
 
+        # --- Total-cap hard-deny: whole run is over the org unit ceiling ---
         if not decision.allowed:
             completed_at = datetime.now(timezone.utc)
             run.status = SyncRunStatus.FAILED.value
@@ -155,6 +156,19 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
                 },
             )
             return {"status": "denied", "reason": run.error}
+
+        # --- Concurrency partial-cap: defer overflow units, proceed with rest ---
+        capped_ids: frozenset[str] = frozenset()
+        if decision.concurrency_capped and decision.capped_unit_ids:
+            capped_ids = frozenset(decision.capped_unit_ids)
+            logger.info(
+                "dispatch_sync_run.concurrency_capped",
+                extra={
+                    "sync_run_id": sync_run_id,
+                    "capped_count": len(capped_ids),
+                    "reason": decision.reason,
+                },
+            )
 
         canonical_config = canonical_sync_config_for_sync_run(session, run)
         inactive_config = (
@@ -203,7 +217,7 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
             )
             return {"status": "denied", "reason": error}
 
-        units = _claim_units(session, run_uuid)
+        units = _claim_units(session, run_uuid, capped_ids=capped_ids)
         signatures = []
         for unit in units:
             dispatch_route = route(
@@ -243,11 +257,13 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
             raise
         return {"status": "dispatched", "queued_units": len(signatures)}
 
+    # No units were claimable this pass (all capped or already dispatching).
+    # Always schedule a redispatch so capped units eventually drain.
+    _schedule_redispatch(sync_run_id)
     logger.info(
         "dispatch_sync_run.noop",
         extra={"sync_run_id": sync_run_id, "queued_units": 0},
     )
-    finalize_sync_run(sync_run_id)
     return {"status": "noop", "queued_units": 0}
 
 
@@ -512,6 +528,32 @@ def finalize_sync_run(sync_run_id: str) -> dict[str, Any]:
                 map_datasets_to_legacy_targets(provider, dataset_keys)
             )
 
+        # --- WS-E / CHAOS-2577: compute covered window from successful units ---
+        # Thread min(since_at)/max(before_at) of successful units into
+        # _dispatch_post_sync_tasks so metrics/work-graph cover the backfilled
+        # range.  Confined to this distinct block; WS-C later advances a
+        # coverage marker in a separate block below.
+        successful_units = [
+            u for u in units if u.status == SyncRunUnitStatus.SUCCESS.value
+        ]
+        covered_since: datetime | None = None
+        covered_before: datetime | None = None
+        if successful_units:
+            since_values = [
+                _as_aware(u.since_at)
+                for u in successful_units
+                if u.since_at is not None
+            ]
+            before_values = [
+                _as_aware(u.before_at)
+                for u in successful_units
+                if u.before_at is not None
+            ]
+            if since_values:
+                covered_since = min(since_values)
+            if before_values:
+                covered_before = max(before_values)
+
         provider_for_dispatch = next(iter(successful_by_provider), "unknown")
         run_org_id = str(run.org_id)
         session.flush()
@@ -532,10 +574,20 @@ def finalize_sync_run(sync_run_id: str) -> dict[str, Any]:
     # between claim and dispatch cannot roll back the claim and let a later
     # finalize re-dispatch (at-most-once, not duplicate-on-retry).
     if legacy_targets:
+        # Thread the covered window so downstream metrics/work-graph tasks
+        # know the exact date range that was backfilled (CHAOS-2577).
+        from_date_str = (
+            covered_since.date().isoformat() if covered_since is not None else None
+        )
+        to_date_str = (
+            covered_before.date().isoformat() if covered_before is not None else None
+        )
         _dispatch_post_sync_tasks(
             provider=provider_for_dispatch,
             sync_targets=sorted(legacy_targets),
             org_id=run_org_id,
+            from_date=from_date_str,
+            to_date=to_date_str,
         )
 
     return {
@@ -547,7 +599,12 @@ def finalize_sync_run(sync_run_id: str) -> dict[str, Any]:
     }
 
 
-def _claim_units(session, run_uuid: uuid.UUID) -> list[SyncRunUnit]:
+def _claim_units(
+    session,
+    run_uuid: uuid.UUID,
+    *,
+    capped_ids: frozenset[str] = frozenset(),
+) -> list[SyncRunUnit]:
     """Atomically claim dispatchable units for a run.
 
     Fresh ``planned`` units are claimed with an atomic ``UPDATE ... RETURNING``
@@ -555,15 +612,25 @@ def _claim_units(session, run_uuid: uuid.UUID) -> list[SyncRunUnit]:
     unit (no double-queue / duplicate provider writes). Stale ``dispatching``
     or ``running`` units (a worker died mid-flight) are reclaimed by age so a
     crash cannot leave the run unfinishable.
+
+    ``capped_ids`` is the set of unit IDs that the concurrency guard deferred
+    (D3).  Those units are left in PLANNED status so a later redispatch can
+    claim them once slots free up.
     """
     now = datetime.now(timezone.utc)
+    # Build the WHERE clause for the atomic claim, excluding capped units.
+    planned_where = [
+        SyncRunUnit.sync_run_id == run_uuid,
+        SyncRunUnit.status == SyncRunUnitStatus.PLANNED.value,
+    ]
+    if capped_ids:
+        planned_where.append(
+            ~SyncRunUnit.id.in_([uuid.UUID(cid) for cid in capped_ids])
+        )
     claimed_ids: set[uuid.UUID] = set(
         session.execute(
             update(SyncRunUnit)
-            .where(
-                SyncRunUnit.sync_run_id == run_uuid,
-                SyncRunUnit.status == SyncRunUnitStatus.PLANNED.value,
-            )
+            .where(*planned_where)
             .values(status=SyncRunUnitStatus.DISPATCHING.value, updated_at=now)
             .returning(SyncRunUnit.id)
             .execution_options(synchronize_session=False)
@@ -589,6 +656,9 @@ def _claim_units(session, run_uuid: uuid.UUID) -> list[SyncRunUnit]:
     )
     for unit in reclaim_candidates:
         if unit.id in claimed_ids:
+            continue
+        # Never reclaim a unit that the concurrency guard deferred.
+        if str(unit.id) in capped_ids:
             continue
         threshold = (
             stale_dispatch
@@ -695,3 +765,28 @@ def _as_aware(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc)
+
+
+def _schedule_redispatch(sync_run_id: str) -> None:
+    """Schedule a delayed redispatch of a run that had all units concurrency-capped.
+
+    Uses ``apply_async(countdown=...)`` so the deferred units are retried after
+    the current in-flight units from other runs have had a chance to complete.
+    This is the D3 deferral mechanism: idempotent, no new status, no Celery retry.
+    """
+    countdown = int(__import__("os").getenv("SYNC_DISPATCH_REDISPATCH_COUNTDOWN", "60"))
+    try:
+        getattr(dispatch_sync_run, "apply_async")(
+            args=(sync_run_id,),
+            queue="sync",
+            countdown=countdown,
+        )
+        logger.info(
+            "dispatch_sync_run.redispatch_scheduled",
+            extra={"sync_run_id": sync_run_id, "countdown": countdown},
+        )
+    except Exception:
+        logger.exception(
+            "dispatch_sync_run.redispatch_schedule_failed",
+            extra={"sync_run_id": sync_run_id},
+        )

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -255,15 +255,54 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
         except Exception as exc:
             _mark_dispatch_enqueue_failed(sync_run_id, str(exc))
             raise
+        # Fix 1: if some units were capped, schedule a delayed redispatch so
+        # those PLANNED units are eventually claimed once slots free up.
+        # The chord above only finalizes after the *dispatched* units complete;
+        # without this redispatch the capped units would stay PLANNED forever.
+        if capped_ids:
+            _schedule_redispatch(sync_run_id)
         return {"status": "dispatched", "queued_units": len(signatures)}
 
-    # No units were claimable this pass (all capped or already dispatching).
-    # Always schedule a redispatch so capped units eventually drain.
-    _schedule_redispatch(sync_run_id)
+    # Fix 2: no units were claimable this pass.  Distinguish two cases:
+    #   a) Deferred work remains (PLANNED units exist, not all terminal) →
+    #      schedule a countdown redispatch so they drain when slots free up.
+    #   b) No deferred work (zero-unit run, or every unit already terminal) →
+    #      call finalize directly; redispatching would loop forever.
+    with get_postgres_session_sync() as session:
+        run_uuid_check = uuid.UUID(str(sync_run_id))
+        pending_count = (
+            session.query(SyncRunUnit)
+            .filter(
+                SyncRunUnit.sync_run_id == run_uuid_check,
+                SyncRunUnit.status.in_(
+                    {
+                        SyncRunUnitStatus.PLANNED.value,
+                        SyncRunUnitStatus.DISPATCHING.value,
+                        SyncRunUnitStatus.RUNNING.value,
+                        SyncRunUnitStatus.RETRYING.value,
+                    }
+                ),
+            )
+            .count()
+        )
+    if pending_count > 0:
+        # Deferred units remain — schedule countdown redispatch.
+        _schedule_redispatch(sync_run_id)
+        logger.info(
+            "dispatch_sync_run.noop",
+            extra={
+                "sync_run_id": sync_run_id,
+                "queued_units": 0,
+                "pending_units": pending_count,
+            },
+        )
+        return {"status": "noop", "queued_units": 0}
+    # No pending work — finalize (idempotent; handles zero-unit and already-finalized).
     logger.info(
-        "dispatch_sync_run.noop",
+        "dispatch_sync_run.noop_finalize",
         extra={"sync_run_id": sync_run_id, "queued_units": 0},
     )
+    finalize_sync_run(sync_run_id)
     return {"status": "noop", "queued_units": 0}
 
 
@@ -768,11 +807,14 @@ def _as_aware(value: datetime) -> datetime:
 
 
 def _schedule_redispatch(sync_run_id: str) -> None:
-    """Schedule a delayed redispatch of a run that had all units concurrency-capped.
+    """Schedule a delayed redispatch of a run with deferred (PLANNED) units.
 
-    Uses ``apply_async(countdown=...)`` so the deferred units are retried after
-    the current in-flight units from other runs have had a chance to complete.
+    Uses ``apply_async(countdown=...)`` so capped units are retried after
+    in-flight units from other runs have had a chance to complete.
     This is the D3 deferral mechanism: idempotent, no new status, no Celery retry.
+
+    Raises on broker enqueue failure so the caller can propagate the error
+    rather than leaving the run silently non-terminal.
     """
     countdown = int(__import__("os").getenv("SYNC_DISPATCH_REDISPATCH_COUNTDOWN", "60"))
     try:
@@ -790,3 +832,4 @@ def _schedule_redispatch(sync_run_id: str) -> None:
             "dispatch_sync_run.redispatch_schedule_failed",
             extra={"sync_run_id": sync_run_id},
         )
+        raise

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -588,11 +588,19 @@ def finalize_sync_run(sync_run_id: str) -> dict[str, Any]:
             any_unbounded_lower = any(u.since_at is None for u in successful_units)
             any_unbounded_upper = any(u.before_at is None for u in successful_units)
             if not any_unbounded_lower:
-                since_values = [_as_aware(u.since_at) for u in successful_units]
+                since_values = [
+                    _as_aware(u.since_at)
+                    for u in successful_units
+                    if u.since_at is not None
+                ]
                 covered_since = min(since_values)
             # else: covered_since stays None → unbounded lower
             if not any_unbounded_upper:
-                before_values = [_as_aware(u.before_at) for u in successful_units]
+                before_values = [
+                    _as_aware(u.before_at)
+                    for u in successful_units
+                    if u.before_at is not None
+                ]
                 covered_before = max(before_values)
             # else: covered_before stays None → unbounded upper
 

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -679,13 +679,21 @@ def _claim_units(
 
     Fresh ``planned`` units are claimed with an atomic ``UPDATE ... RETURNING``
     so two concurrent ``dispatch_sync_run`` calls cannot both enqueue the same
-    unit (no double-queue / duplicate provider writes). Stale ``dispatching``
-    or ``running`` units (a worker died mid-flight) are reclaimed by age so a
-    crash cannot leave the run unfinishable.
+    unit (no double-queue / duplicate provider writes).  Stale ``dispatching``
+    units (a worker died before the unit started running) are reclaimed by age.
 
-    ``capped_ids`` is the set of unit IDs that the concurrency guard deferred
-    (D3).  Those units are left in PLANNED status so a later redispatch can
-    claim them once slots free up.
+    F2 fix: RUNNING units are NEVER reclaimed here.  ``run_sync_unit`` does not
+    heartbeat during the provider call, so a legitimately long-running unit past
+    SYNC_UNIT_RUNNING_STALE_SECONDS would be re-dispatched and run a second time
+    concurrently, causing duplicate provider writes.  Durable dead-worker
+    recovery (heartbeat + lease) is a separate follow-up (CHAOS-2577).
+
+    INTERIM: a capped run whose only blocker is a DEAD RUNNING unit may stall
+    — acceptable, preserves at-most-once provider execution.
+
+    ``capped_ids`` is the set of unit IDs that the concurrency guard deferred.
+    Those units are left in PLANNED status so a later redispatch can claim them
+    once slots free up.
     """
     now = datetime.now(timezone.utc)
     # Build the WHERE clause for the atomic claim, excluding capped units.
@@ -709,18 +717,16 @@ def _claim_units(
         .all()
     )
 
+    # Reclaim stale DISPATCHING units only (F2: RUNNING is never reclaimed).
+    # A DISPATCHING unit that is stale means the worker was enqueued but never
+    # picked up (e.g. broker restart).  It is safe to re-enqueue because the
+    # worker never started the provider call.
     stale_dispatch = now - timedelta(seconds=_stale_dispatch_seconds())
-    stale_running = now - timedelta(seconds=_stale_running_seconds())
     reclaim_candidates = (
         session.query(SyncRunUnit)
         .filter(
             SyncRunUnit.sync_run_id == run_uuid,
-            SyncRunUnit.status.in_(
-                {
-                    SyncRunUnitStatus.DISPATCHING.value,
-                    SyncRunUnitStatus.RUNNING.value,
-                }
-            ),
+            SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value,
         )
         .all()
     )
@@ -730,12 +736,7 @@ def _claim_units(
         # Never reclaim a unit that the concurrency guard deferred.
         if str(unit.id) in capped_ids:
             continue
-        threshold = (
-            stale_dispatch
-            if unit.status == SyncRunUnitStatus.DISPATCHING.value
-            else stale_running
-        )
-        if _as_aware(unit.updated_at) <= threshold:
+        if _as_aware(unit.updated_at) <= stale_dispatch:
             unit.status = SyncRunUnitStatus.DISPATCHING.value
             unit.updated_at = now
             claimed_ids.add(unit.id)

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -583,20 +583,18 @@ def finalize_sync_run(sync_run_id: str) -> dict[str, Any]:
         covered_since: datetime | None = None
         covered_before: datetime | None = None
         if successful_units:
-            since_values = [
-                _as_aware(u.since_at)
-                for u in successful_units
-                if u.since_at is not None
-            ]
-            before_values = [
-                _as_aware(u.before_at)
-                for u in successful_units
-                if u.before_at is not None
-            ]
-            if since_values:
+            # If ANY unit has since_at=None the lower bound is unbounded;
+            # only compute min when ALL units carry an explicit lower bound.
+            any_unbounded_lower = any(u.since_at is None for u in successful_units)
+            any_unbounded_upper = any(u.before_at is None for u in successful_units)
+            if not any_unbounded_lower:
+                since_values = [_as_aware(u.since_at) for u in successful_units]
                 covered_since = min(since_values)
-            if before_values:
+            # else: covered_since stays None → unbounded lower
+            if not any_unbounded_upper:
+                before_values = [_as_aware(u.before_at) for u in successful_units]
                 covered_before = max(before_values)
+            # else: covered_before stays None → unbounded upper
 
         provider_for_dispatch = next(iter(successful_by_provider), "unknown")
         run_org_id = str(run.org_id)

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -252,15 +252,14 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
         callback.set(queue="sync")
         try:
             chord(group(signatures), callback).apply_async()
+            # F4: schedule redispatch for capped units INSIDE the try block so
+            # any broker failure marks the run terminal rather than leaving
+            # PLANNED units stranded with no chord/finalizer pending.
+            if capped_ids:
+                _schedule_redispatch(sync_run_id)
         except Exception as exc:
             _mark_dispatch_enqueue_failed(sync_run_id, str(exc))
             raise
-        # Fix 1: if some units were capped, schedule a delayed redispatch so
-        # those PLANNED units are eventually claimed once slots free up.
-        # The chord above only finalizes after the *dispatched* units complete;
-        # without this redispatch the capped units would stay PLANNED forever.
-        if capped_ids:
-            _schedule_redispatch(sync_run_id)
         return {"status": "dispatched", "queued_units": len(signatures)}
 
     # Fix 2: no units were claimable this pass.  Distinguish two cases:
@@ -287,7 +286,13 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
         )
     if pending_count > 0:
         # Deferred units remain — schedule countdown redispatch.
-        _schedule_redispatch(sync_run_id)
+        # F5: wrap in try/except so a broker failure marks the run terminal
+        # rather than leaving PLANNED units stranded with no follow-up.
+        try:
+            _schedule_redispatch(sync_run_id)
+        except Exception as exc:
+            _mark_dispatch_enqueue_failed(sync_run_id, str(exc))
+            raise
         logger.info(
             "dispatch_sync_run.noop",
             extra={
@@ -621,12 +626,38 @@ def finalize_sync_run(sync_run_id: str) -> dict[str, Any]:
         to_date_str = (
             covered_before.date().isoformat() if covered_before is not None else None
         )
+        # F3: pass full ISO datetimes via work_graph_from/to_date so the
+        # work-graph build covers the full final day (not truncated to midnight).
+        # from_date/to_date remain date-only for _parse_materialize_window().
+        # Mirror the precedent in sync_backfill.py:374-383.
+        from datetime import time as _time
+
+        work_graph_from_date_str = (
+            datetime.combine(
+                covered_since.date(),
+                _time.min,
+                tzinfo=timezone.utc,
+            ).isoformat()
+            if covered_since is not None
+            else None
+        )
+        work_graph_to_date_str = (
+            datetime.combine(
+                covered_before.date() + timedelta(days=1),
+                _time.min,
+                tzinfo=timezone.utc,
+            ).isoformat()
+            if covered_before is not None
+            else None
+        )
         _dispatch_post_sync_tasks(
             provider=provider_for_dispatch,
             sync_targets=sorted(legacy_targets),
             org_id=run_org_id,
             from_date=from_date_str,
             to_date=to_date_str,
+            work_graph_from_date=work_graph_from_date_str,
+            work_graph_to_date=work_graph_to_date_str,
         )
 
     return {

--- a/tests/test_dispatch_guard.py
+++ b/tests/test_dispatch_guard.py
@@ -820,14 +820,6 @@ def test_chord_capped_redispatch_failure_marks_run_terminal(db_session, monkeypa
 
     call_count = [0]
 
-    def fail_on_second(*args, **kwargs):
-        call_count[0] += 1
-        if call_count[0] == 1:
-            # First call is chord.apply_async — succeed.
-            return None
-        # Second call is redispatch apply_async — fail.
-        raise RuntimeError("broker down on redispatch")
-
     # Patch chord to call our counter on apply_async.
     class CountingChord:
         def __init__(self, header, callback):

--- a/tests/test_dispatch_guard.py
+++ b/tests/test_dispatch_guard.py
@@ -325,7 +325,9 @@ def test_partial_cap_dispatch_schedules_redispatch(db_session, monkeypatch):
         yield s
         s.commit()
 
-    monkeypatch.setattr(db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session))
+    monkeypatch.setattr(
+        db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session)
+    )
 
     unit_queued = []
     redispatches = []
@@ -352,14 +354,22 @@ def test_partial_cap_dispatch_schedules_redispatch(db_session, monkeypatch):
         def apply_async(self):
             return None
 
-    monkeypatch.setattr(sync_units.run_sync_unit, "s", lambda unit_id: FakeUnitSig(unit_id))
-    monkeypatch.setattr(sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id))
+    monkeypatch.setattr(
+        sync_units.run_sync_unit, "s", lambda unit_id: FakeUnitSig(unit_id)
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id)
+    )
     monkeypatch.setattr(sync_units, "group", list)
-    monkeypatch.setattr(sync_units, "chord", lambda header, callback: FakeChord(header, callback))
+    monkeypatch.setattr(
+        sync_units, "chord", lambda header, callback: FakeChord(header, callback)
+    )
     monkeypatch.setattr(
         sync_units.dispatch_sync_run,
         "apply_async",
-        lambda args=None, queue=None, countdown=None: redispatches.append((args, countdown)),
+        lambda args=None, queue=None, countdown=None: redispatches.append(
+            (args, countdown)
+        ),
     )
 
     result = sync_units.dispatch_sync_run(str(run.id))
@@ -394,7 +404,9 @@ def test_zero_unit_dispatch_finalizes_not_loops(db_session, monkeypatch):
         yield s
         s.commit()
 
-    monkeypatch.setattr(db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session))
+    monkeypatch.setattr(
+        db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session)
+    )
 
     redispatches = []
     finalize_calls = []
@@ -489,7 +501,9 @@ def test_redispatch_enqueue_failure_raises(db_session, monkeypatch):
         yield s
         s.commit()
 
-    monkeypatch.setattr(db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session))
+    monkeypatch.setattr(
+        db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session)
+    )
 
     class FakeUnitSig:
         def __init__(self, unit_id):
@@ -512,10 +526,16 @@ def test_redispatch_enqueue_failure_raises(db_session, monkeypatch):
         def apply_async(self):
             return None
 
-    monkeypatch.setattr(sync_units.run_sync_unit, "s", lambda unit_id: FakeUnitSig(unit_id))
-    monkeypatch.setattr(sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id))
+    monkeypatch.setattr(
+        sync_units.run_sync_unit, "s", lambda unit_id: FakeUnitSig(unit_id)
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id)
+    )
     monkeypatch.setattr(sync_units, "group", list)
-    monkeypatch.setattr(sync_units, "chord", lambda header, callback: FakeChord(header, callback))
+    monkeypatch.setattr(
+        sync_units, "chord", lambda header, callback: FakeChord(header, callback)
+    )
 
     def fail_redispatch(*args, **kwargs):
         raise RuntimeError("broker down")
@@ -523,5 +543,6 @@ def test_redispatch_enqueue_failure_raises(db_session, monkeypatch):
     monkeypatch.setattr(sync_units.dispatch_sync_run, "apply_async", fail_redispatch)
 
     import pytest
+
     with pytest.raises(RuntimeError, match="broker down"):
         sync_units.dispatch_sync_run(str(run.id))

--- a/tests/test_dispatch_guard.py
+++ b/tests/test_dispatch_guard.py
@@ -108,7 +108,9 @@ def test_dispatch_guard_denies_over_total_unit_cap(db_session, monkeypatch):
     assert set(decision.capped_unit_ids) <= {str(unit.id) for unit in units}
 
 
-def test_dispatch_guard_concurrency_cap_is_partial_allow_not_deny(db_session, monkeypatch):
+def test_dispatch_guard_concurrency_cap_is_partial_allow_not_deny(
+    db_session, monkeypatch
+):
     """Concurrency cap returns allowed=True, concurrency_capped=True (CHAOS-2576).
 
     The old behaviour returned allowed=False, which caused the whole run to be
@@ -197,7 +199,9 @@ def test_concurrency_cap_defers_not_fails(db_session, monkeypatch):
         yield s
         s.commit()
 
-    monkeypatch.setattr(db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session))
+    monkeypatch.setattr(
+        db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session)
+    )
 
     unit_queued = []
     redispatches = []
@@ -224,14 +228,22 @@ def test_concurrency_cap_defers_not_fails(db_session, monkeypatch):
         def apply_async(self):
             return None
 
-    monkeypatch.setattr(sync_units.run_sync_unit, "s", lambda unit_id: FakeUnitSig(unit_id))
-    monkeypatch.setattr(sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id))
+    monkeypatch.setattr(
+        sync_units.run_sync_unit, "s", lambda unit_id: FakeUnitSig(unit_id)
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id)
+    )
     monkeypatch.setattr(sync_units, "group", lambda sigs: list(sigs))
-    monkeypatch.setattr(sync_units, "chord", lambda header, callback: FakeChord(header, callback))
+    monkeypatch.setattr(
+        sync_units, "chord", lambda header, callback: FakeChord(header, callback)
+    )
     monkeypatch.setattr(
         sync_units.dispatch_sync_run,
         "apply_async",
-        lambda args=None, queue=None, countdown=None: redispatches.append((args, countdown)),
+        lambda args=None, queue=None, countdown=None: redispatches.append(
+            (args, countdown)
+        ),
     )
 
     result = sync_units.dispatch_sync_run(str(run.id))
@@ -250,6 +262,7 @@ def test_concurrency_cap_defers_not_fails(db_session, monkeypatch):
     # Dispatched path: no redispatch scheduled (chord handles finalize).
     assert result["status"] == "dispatched"
     assert len(redispatches) == 0
+
 
 def test_total_unit_cap_still_hard_denies(db_session, monkeypatch):
     """Total-cap hard-deny is unchanged: allowed=False, concurrency_capped=False (CHAOS-2576)."""

--- a/tests/test_dispatch_guard.py
+++ b/tests/test_dispatch_guard.py
@@ -576,18 +576,23 @@ def test_same_run_running_units_count_against_cap(db_session, monkeypatch):
     assert str(units[2].id) in decision.capped_unit_ids
 
 
-def test_stale_other_run_blocker_does_not_cap_forever(db_session, monkeypatch):
-    """F2 regression (b): stale other-run RUNNING unit does not block capacity.
+def test_stale_other_run_running_always_consumes_cap(db_session, monkeypatch):
+    """F2 regression (b): RUNNING units always consume capacity regardless of age.
 
-    A unit from another run whose updated_at is older than the staleness
-    threshold must NOT count as an active slot — the guard must return full
-    capacity so the current run can proceed.
+    Under the new model RUNNING has no stale threshold — run_sync_unit does not
+    heartbeat, so a stale RUNNING unit may still be executing.  Reclaiming it
+    would cause duplicate provider writes.  Therefore a stale RUNNING unit from
+    another run MUST count as an active slot and cap the current run.
+
+    Durable dead-worker recovery (heartbeat + lease) is a separate follow-up
+    (CHAOS-2577).  Until then, a capped run whose only blocker is a dead RUNNING
+    unit may stall — acceptable, preserves at-most-once provider execution.
     """
     from datetime import timedelta
 
     monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
     monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "1")
-    # Use a very short staleness window so we can set updated_at in the past.
+    # Even with a very short staleness window, RUNNING must still consume a slot.
     monkeypatch.setenv("SYNC_UNIT_RUNNING_STALE_SECONDS", "60")
 
     run, units, integration, source = _seed_run(db_session, unit_count=1)
@@ -626,13 +631,13 @@ def test_stale_other_run_blocker_does_not_cap_forever(db_session, monkeypatch):
 
     decision = DispatchGuard.authorize_run(db_session, str(run.id))
 
-    # Stale blocker must not consume a slot — full allow expected.
+    # Stale RUNNING must still consume a slot — cap expected.
+    # (INTERIM: run may stall until heartbeat/lease follow-up lands.)
     assert decision.allowed is True
-    assert decision.concurrency_capped is False, (
-        "stale other-run blocker must not cap the current run"
+    assert decision.concurrency_capped is True, (
+        "stale other-run RUNNING must still consume a slot (no heartbeat)"
     )
-    assert len(decision.capped_unit_ids) == 0
-
+    assert len(decision.capped_unit_ids) == 1
 
 def test_finalize_passes_full_datetime_work_graph_window(db_session, monkeypatch):
     """F3 regression (c): finalize_sync_run passes full ISO datetimes for
@@ -927,4 +932,119 @@ def test_fresh_same_run_dispatching_caps_planned_unit(db_session, monkeypatch):
     assert len(decision.capped_unit_ids) == 1
     assert str(units[1].id) in decision.capped_unit_ids, (
         "the PLANNED unit must be in capped_unit_ids"
+    )
+
+
+def test_advisory_lock_key_deterministic_and_unique(db_session, monkeypatch):
+    """F1 regression: advisory lock key is deterministic and bucket-unique.
+
+    On SQLite (tests) the lock is a no-op, but the key derivation must be
+    deterministic and produce distinct values for distinct buckets.
+    The PostgreSQL-only guarantee is documented in guard.py.
+    """
+    from dev_health_ops.sync.guard import _bucket_advisory_lock_key
+
+    key_a = _bucket_advisory_lock_key("org-1", "github", "medium")
+    key_b = _bucket_advisory_lock_key("org-1", "github", "high")
+    key_c = _bucket_advisory_lock_key("org-2", "github", "medium")
+    key_same = _bucket_advisory_lock_key("org-1", "github", "medium")
+
+    # Deterministic: same inputs → same key.
+    assert key_a == key_same
+    # Unique: different buckets → different keys.
+    assert key_a != key_b
+    assert key_a != key_c
+    assert key_b != key_c
+    # 63-bit range: fits in a PostgreSQL bigint (signed 64-bit).
+    for key in (key_a, key_b, key_c):
+        assert 0 <= key < (1 << 63)
+
+
+def test_long_running_unit_counts_against_cap_and_is_not_re_enqueued(
+    db_session, monkeypatch
+):
+    """F2 regression: a long-running RUNNING unit past the stale threshold
+    still counts against the cap AND is not re-enqueued.
+
+    cap=1, 1 RUNNING unit (updated_at past stale threshold) + 1 PLANNED unit.
+    Expected: RUNNING consumes the slot → PLANNED is capped → queued_units == 0.
+    RUNNING unit must remain RUNNING (not flipped to DISPATCHING).
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "1")
+    monkeypatch.setenv("SYNC_UNIT_RUNNING_STALE_SECONDS", "60")
+
+    run, units, integration, source = _seed_run(db_session, unit_count=2)
+    # First unit: RUNNING, updated_at past the stale threshold.
+    units[0].status = SyncRunUnitStatus.RUNNING.value
+    units[0].updated_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    # Second unit: PLANNED (the one that should be capped).
+    # units[1] remains PLANNED.
+    db_session.flush()
+
+    from contextlib import contextmanager
+
+    import dev_health_ops.db as db
+
+    @contextmanager
+    def _fake_session_ctx(s):
+        yield s
+        s.commit()
+
+    monkeypatch.setattr(
+        db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session)
+    )
+
+    class FakeUnitSig:
+        def __init__(self, unit_id):
+            self.unit_id = unit_id
+
+        def set(self, *, queue):
+            return self
+
+    class FakeFinalizeSig:
+        def __init__(self, run_id):
+            pass
+
+        def set(self, *, queue):
+            return self
+
+    class FakeChord:
+        def __init__(self, header, callback):
+            pass
+
+        def apply_async(self):
+            return None
+
+    monkeypatch.setattr(
+        sync_units.run_sync_unit, "s", lambda unit_id: FakeUnitSig(unit_id)
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id)
+    )
+    monkeypatch.setattr(sync_units, "group", list)
+    monkeypatch.setattr(
+        sync_units, "chord", lambda header, callback: FakeChord(header, callback)
+    )
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run, "apply_async", lambda *a, **k: None
+    )
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    # RUNNING consumes the slot → PLANNED is capped → nothing dispatched.
+    assert result["queued_units"] == 0
+    db_session.refresh(units[0])
+    db_session.refresh(units[1])
+    # RUNNING unit must NOT be re-enqueued.
+    assert units[0].status == SyncRunUnitStatus.RUNNING.value, (
+        "long-running RUNNING unit must not be reclaimed"
+    )
+    # PLANNED unit must remain PLANNED (deferred for redispatch).
+    assert units[1].status == SyncRunUnitStatus.PLANNED.value, (
+        "PLANNED unit must remain PLANNED when cap is consumed by RUNNING"
     )

--- a/tests/test_dispatch_guard.py
+++ b/tests/test_dispatch_guard.py
@@ -546,3 +546,340 @@ def test_redispatch_enqueue_failure_raises(db_session, monkeypatch):
 
     with pytest.raises(RuntimeError, match="broker down"):
         sync_units.dispatch_sync_run(str(run.id))
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for Codex round-2 findings (F1-F5)
+# ---------------------------------------------------------------------------
+
+
+def test_same_run_running_units_count_against_cap(db_session, monkeypatch):
+    """F1 regression (a): same-run RUNNING units reduce available slots.
+
+    cap=2, 2 same-run units already RUNNING → 0 slots left → the 1 PLANNED
+    unit in the same run must be capped, not dispatched.
+    """
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "2")
+    run, units, integration, source = _seed_run(db_session, unit_count=3)
+    # Mark 2 of the 3 units as RUNNING (same run, same bucket).
+    units[0].status = SyncRunUnitStatus.RUNNING.value
+    units[1].status = SyncRunUnitStatus.RUNNING.value
+    db_session.flush()
+
+    decision = DispatchGuard.authorize_run(db_session, str(run.id))
+
+    # cap=2, 2 same-run RUNNING → 0 slots → the 1 PLANNED unit must be capped.
+    assert decision.allowed is True
+    assert decision.concurrency_capped is True
+    assert len(decision.capped_unit_ids) == 1
+    assert str(units[2].id) in decision.capped_unit_ids
+
+
+def test_stale_other_run_blocker_does_not_cap_forever(db_session, monkeypatch):
+    """F2 regression (b): stale other-run RUNNING unit does not block capacity.
+
+    A unit from another run whose updated_at is older than the staleness
+    threshold must NOT count as an active slot — the guard must return full
+    capacity so the current run can proceed.
+    """
+    from datetime import timedelta
+
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "1")
+    # Use a very short staleness window so we can set updated_at in the past.
+    monkeypatch.setenv("SYNC_UNIT_RUNNING_STALE_SECONDS", "60")
+
+    run, units, integration, source = _seed_run(db_session, unit_count=1)
+
+    # Another run with a RUNNING unit that is stale (updated 2 hours ago).
+    other_run = SyncRun(
+        org_id=run.org_id,
+        integration_id=integration.id,
+        triggered_by="schedule",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunStatus.RUNNING.value,
+        total_units=1,
+        completed_units=0,
+        failed_units=0,
+    )
+    db_session.add(other_run)
+    db_session.flush()
+    from datetime import datetime, timezone
+
+    stale_time = datetime.now(timezone.utc) - timedelta(hours=2)
+    other_unit = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=other_run.id,
+        integration_id=integration.id,
+        source_id=source.id,
+        provider="github",
+        dataset_key="commits-stale",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.RUNNING.value,
+        attempts=1,
+        updated_at=stale_time,
+    )
+    db_session.add(other_unit)
+    db_session.flush()
+
+    decision = DispatchGuard.authorize_run(db_session, str(run.id))
+
+    # Stale blocker must not consume a slot — full allow expected.
+    assert decision.allowed is True
+    assert decision.concurrency_capped is False, (
+        "stale other-run blocker must not cap the current run"
+    )
+    assert len(decision.capped_unit_ids) == 0
+
+
+def test_finalize_passes_full_datetime_work_graph_window(db_session, monkeypatch):
+    """F3 regression (c): finalize_sync_run passes full ISO datetimes for
+    work_graph_from/to_date so the covered final day is not truncated to midnight.
+    """
+    from datetime import datetime, timedelta, timezone  # noqa: F401
+
+    from dev_health_ops.workers import sync_units
+
+    run, units, integration, source = _seed_run(db_session, unit_count=1)
+
+    from contextlib import contextmanager
+
+    import dev_health_ops.db as db
+
+    @contextmanager
+    def _fake_session_ctx(s):
+        yield s
+        s.commit()
+
+    monkeypatch.setattr(db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session))
+
+    # Mark the unit SUCCESS with a known since_at / before_at window.
+    since_dt = datetime(2024, 3, 1, 6, 0, 0, tzinfo=timezone.utc)
+    before_dt = datetime(2024, 3, 15, 18, 30, 0, tzinfo=timezone.utc)
+    unit = units[0]
+    unit.status = SyncRunUnitStatus.SUCCESS.value
+    unit.since_at = since_dt
+    unit.before_at = before_dt
+    db_session.flush()
+
+    # Mark the run DISPATCHING so finalize proceeds.
+    run.status = SyncRunStatus.DISPATCHING.value
+    db_session.flush()
+
+    captured_kwargs: dict = {}
+
+    def fake_dispatch_post_sync(**kwargs):
+        captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr(sync_units, "_dispatch_post_sync_tasks", fake_dispatch_post_sync)
+    # Ensure legacy_targets is non-empty so _dispatch_post_sync_tasks is called.
+    monkeypatch.setattr(
+        sync_units,
+        "map_datasets_to_legacy_targets",
+        lambda provider, dataset_keys: frozenset(["git"]),
+    )
+
+    sync_units.finalize_sync_run(str(run.id))
+
+    # from_date / to_date must be date-only strings.
+    assert captured_kwargs.get("from_date") == since_dt.date().isoformat()
+    assert captured_kwargs.get("to_date") == before_dt.date().isoformat()
+
+    # work_graph_from_date must be a full ISO datetime (start of since day).
+    wg_from = captured_kwargs.get("work_graph_from_date")
+    assert wg_from is not None, "work_graph_from_date must be passed"
+    parsed_from = datetime.fromisoformat(wg_from)
+    assert parsed_from.date() == since_dt.date()
+    assert parsed_from.hour == 0 and parsed_from.minute == 0
+
+    # work_graph_to_date must be start of the day AFTER before_dt (covers full day).
+    wg_to = captured_kwargs.get("work_graph_to_date")
+    assert wg_to is not None, "work_graph_to_date must be passed"
+    parsed_to = datetime.fromisoformat(wg_to)
+    expected_to_date = before_dt.date() + timedelta(days=1)
+    assert parsed_to.date() == expected_to_date, (
+        f"work_graph_to_date must be start of day after before_dt, "
+        f"got {parsed_to.date()}, expected {expected_to_date}"
+    )
+    assert parsed_to.hour == 0 and parsed_to.minute == 0
+
+
+def _make_dispatch_harness(db_session, monkeypatch, *, unit_count, cap, active_slots):
+    """Shared setup for F4/F5 redispatch-failure tests.
+
+    Seeds a run with ``unit_count`` PLANNED units and ``active_slots`` RUNNING
+    units from another run (to trigger partial-cap or all-capped scenarios).
+    Returns (run, units, integration, source, redispatches, mark_failed_calls).
+    """
+
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", str(cap))
+
+    run, units, integration, source = _seed_run(db_session, unit_count=unit_count)
+
+    for slot in range(active_slots):
+        other_run = SyncRun(
+            org_id=run.org_id,
+            integration_id=integration.id,
+            triggered_by="schedule",
+            mode=SyncRunMode.INCREMENTAL.value,
+            status=SyncRunStatus.RUNNING.value,
+            total_units=1,
+            completed_units=0,
+            failed_units=0,
+        )
+        db_session.add(other_run)
+        db_session.flush()
+        other_unit = SyncRunUnit(
+            org_id=run.org_id,
+            sync_run_id=other_run.id,
+            integration_id=integration.id,
+            source_id=source.id,
+            provider="github",
+            dataset_key=f"commits-active-{slot}",
+            cost_class="medium",
+            mode=SyncRunMode.INCREMENTAL.value,
+            status=SyncRunUnitStatus.RUNNING.value,
+            attempts=1,
+        )
+        db_session.add(other_unit)
+    db_session.flush()
+
+    from contextlib import contextmanager
+
+    import dev_health_ops.db as db
+
+    @contextmanager
+    def _fake_session_ctx(s):
+        yield s
+        s.commit()
+
+    monkeypatch.setattr(db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session))
+
+    return run, units, integration, source
+
+
+def test_chord_capped_redispatch_failure_marks_run_terminal(db_session, monkeypatch):
+    """F4 regression (d-chord): redispatch publish failure after chord dispatch
+    marks the run/units terminal — capped PLANNED units must not be stranded.
+
+    Scenario: cap=2, 1 active slot → 1 unit dispatched (chord), 1 unit capped.
+    Redispatch publish raises → _mark_dispatch_enqueue_failed must be called.
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, units, integration, source = _make_dispatch_harness(
+        db_session, monkeypatch, unit_count=2, cap=2, active_slots=1
+    )
+
+    class FakeUnitSig:
+        def __init__(self, unit_id):
+            self.unit_id = unit_id
+
+        def set(self, *, queue):
+            return self
+
+    class FakeFinalizeSig:
+        def __init__(self, run_id):
+            pass
+
+        def set(self, *, queue):
+            return self
+
+    class FakeChord:
+        def __init__(self, header, callback):
+            pass
+
+        def apply_async(self):
+            return None
+
+    monkeypatch.setattr(sync_units.run_sync_unit, "s", lambda unit_id: FakeUnitSig(unit_id))
+    monkeypatch.setattr(sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id))
+    monkeypatch.setattr(sync_units, "group", list)
+    monkeypatch.setattr(sync_units, "chord", lambda header, callback: FakeChord(header, callback))
+
+    call_count = [0]
+
+    def fail_on_second(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # First call is chord.apply_async — succeed.
+            return None
+        # Second call is redispatch apply_async — fail.
+        raise RuntimeError("broker down on redispatch")
+
+    # Patch chord to call our counter on apply_async.
+    class CountingChord:
+        def __init__(self, header, callback):
+            pass
+
+        def apply_async(self):
+            call_count[0] += 1
+            return None
+
+    monkeypatch.setattr(sync_units, "chord", lambda header, callback: CountingChord(header, callback))
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None, countdown=None: (_ for _ in ()).throw(
+            RuntimeError("broker down on redispatch")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="broker down on redispatch"):
+        sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    for unit in units:
+        db_session.refresh(unit)
+
+    # Run must be terminal (FAILED) — not left in DISPATCHING/PLANNED.
+    assert run.status == SyncRunStatus.FAILED.value, (
+        f"run must be FAILED after redispatch enqueue failure, got {run.status}"
+    )
+    # All non-terminal units must be marked FAILED.
+    non_terminal = [
+        u for u in units if u.status not in {"success", "failed"}
+    ]
+    assert len(non_terminal) == 0, (
+        f"all units must be terminal after enqueue failure, got {[u.status for u in non_terminal]}"
+    )
+
+
+def test_noop_redispatch_failure_marks_run_terminal(db_session, monkeypatch):
+    """F5 regression (d-noop): redispatch publish failure in the no-signatures
+    path marks the run/units terminal — PLANNED units must not be stranded.
+
+    Scenario: cap=1, 1 active slot → ALL units capped → noop path.
+    Redispatch publish raises → _mark_dispatch_enqueue_failed must be called.
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, units, integration, source = _make_dispatch_harness(
+        db_session, monkeypatch, unit_count=1, cap=1, active_slots=1
+    )
+
+    def fail_redispatch(*args, **kwargs):
+        raise RuntimeError("broker down noop")
+
+    monkeypatch.setattr(sync_units.dispatch_sync_run, "apply_async", fail_redispatch)
+
+    with pytest.raises(RuntimeError, match="broker down noop"):
+        sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    for unit in units:
+        db_session.refresh(unit)
+
+    # Run must be terminal (FAILED) — not left stranded.
+    assert run.status == SyncRunStatus.FAILED.value, (
+        f"run must be FAILED after noop redispatch failure, got {run.status}"
+    )
+    non_terminal = [
+        u for u in units if u.status not in {"success", "failed"}
+    ]
+    assert len(non_terminal) == 0, (
+        f"all units must be terminal after noop enqueue failure, got {[u.status for u in non_terminal]}"
+    )

--- a/tests/test_dispatch_guard.py
+++ b/tests/test_dispatch_guard.py
@@ -653,7 +653,9 @@ def test_finalize_passes_full_datetime_work_graph_window(db_session, monkeypatch
         yield s
         s.commit()
 
-    monkeypatch.setattr(db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session))
+    monkeypatch.setattr(
+        db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session)
+    )
 
     # Mark the unit SUCCESS with a known since_at / before_at window.
     since_dt = datetime(2024, 3, 1, 6, 0, 0, tzinfo=timezone.utc)
@@ -673,7 +675,9 @@ def test_finalize_passes_full_datetime_work_graph_window(db_session, monkeypatch
     def fake_dispatch_post_sync(**kwargs):
         captured_kwargs.update(kwargs)
 
-    monkeypatch.setattr(sync_units, "_dispatch_post_sync_tasks", fake_dispatch_post_sync)
+    monkeypatch.setattr(
+        sync_units, "_dispatch_post_sync_tasks", fake_dispatch_post_sync
+    )
     # Ensure legacy_targets is non-empty so _dispatch_post_sync_tasks is called.
     monkeypatch.setattr(
         sync_units,
@@ -756,7 +760,9 @@ def _make_dispatch_harness(db_session, monkeypatch, *, unit_count, cap, active_s
         yield s
         s.commit()
 
-    monkeypatch.setattr(db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session))
+    monkeypatch.setattr(
+        db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session)
+    )
 
     return run, units, integration, source
 
@@ -795,10 +801,16 @@ def test_chord_capped_redispatch_failure_marks_run_terminal(db_session, monkeypa
         def apply_async(self):
             return None
 
-    monkeypatch.setattr(sync_units.run_sync_unit, "s", lambda unit_id: FakeUnitSig(unit_id))
-    monkeypatch.setattr(sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id))
+    monkeypatch.setattr(
+        sync_units.run_sync_unit, "s", lambda unit_id: FakeUnitSig(unit_id)
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id)
+    )
     monkeypatch.setattr(sync_units, "group", list)
-    monkeypatch.setattr(sync_units, "chord", lambda header, callback: FakeChord(header, callback))
+    monkeypatch.setattr(
+        sync_units, "chord", lambda header, callback: FakeChord(header, callback)
+    )
 
     call_count = [0]
 
@@ -819,7 +831,9 @@ def test_chord_capped_redispatch_failure_marks_run_terminal(db_session, monkeypa
             call_count[0] += 1
             return None
 
-    monkeypatch.setattr(sync_units, "chord", lambda header, callback: CountingChord(header, callback))
+    monkeypatch.setattr(
+        sync_units, "chord", lambda header, callback: CountingChord(header, callback)
+    )
     monkeypatch.setattr(
         sync_units.dispatch_sync_run,
         "apply_async",
@@ -840,9 +854,7 @@ def test_chord_capped_redispatch_failure_marks_run_terminal(db_session, monkeypa
         f"run must be FAILED after redispatch enqueue failure, got {run.status}"
     )
     # All non-terminal units must be marked FAILED.
-    non_terminal = [
-        u for u in units if u.status not in {"success", "failed"}
-    ]
+    non_terminal = [u for u in units if u.status not in {"success", "failed"}]
     assert len(non_terminal) == 0, (
         f"all units must be terminal after enqueue failure, got {[u.status for u in non_terminal]}"
     )
@@ -877,9 +889,7 @@ def test_noop_redispatch_failure_marks_run_terminal(db_session, monkeypatch):
     assert run.status == SyncRunStatus.FAILED.value, (
         f"run must be FAILED after noop redispatch failure, got {run.status}"
     )
-    non_terminal = [
-        u for u in units if u.status not in {"success", "failed"}
-    ]
+    non_terminal = [u for u in units if u.status not in {"success", "failed"}]
     assert len(non_terminal) == 0, (
         f"all units must be terminal after noop enqueue failure, got {[u.status for u in non_terminal]}"
     )

--- a/tests/test_dispatch_guard.py
+++ b/tests/test_dispatch_guard.py
@@ -108,7 +108,13 @@ def test_dispatch_guard_denies_over_total_unit_cap(db_session, monkeypatch):
     assert set(decision.capped_unit_ids) <= {str(unit.id) for unit in units}
 
 
-def test_dispatch_guard_denies_over_inflight_concurrency(db_session, monkeypatch):
+def test_dispatch_guard_concurrency_cap_is_partial_allow_not_deny(db_session, monkeypatch):
+    """Concurrency cap returns allowed=True, concurrency_capped=True (CHAOS-2576).
+
+    The old behaviour returned allowed=False, which caused the whole run to be
+    marked FAILED.  The new shape is a DISTINCT partial-allow so the caller can
+    leave capped units PLANNED and schedule a delayed redispatch.
+    """
     monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
     monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "1")
     run, units, integration, source = _seed_run(db_session, unit_count=1)
@@ -139,8 +145,120 @@ def test_dispatch_guard_denies_over_inflight_concurrency(db_session, monkeypatch
     db_session.add(active_unit)
     db_session.flush()
 
+
+def test_concurrency_cap_defers_not_fails(db_session, monkeypatch):
+    """Units over the concurrency cap stay PLANNED; run is NOT FAILED (CHAOS-2576).
+
+    Scenario: concurrency cap = 2, 1 slot already consumed by another run.
+    New run has 3 units in the same bucket: 1 is allowed, 2 are capped.
+    Verifies: allowed unit dispatched, capped units remain PLANNED, run not FAILED,
+    and a countdown redispatch is scheduled for the capped units.
+    """
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "2")
+    # Seed a run with 3 units in the same bucket.
+    run, units, integration, source = _seed_run(db_session, unit_count=3)
+    # Simulate 1 active unit from another run consuming 1 of the 2 concurrency slots.
+    active_run = SyncRun(
+        org_id=run.org_id,
+        integration_id=integration.id,
+        triggered_by="schedule",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunStatus.RUNNING.value,
+        total_units=1,
+        completed_units=0,
+        failed_units=0,
+    )
+    db_session.add(active_run)
+    db_session.flush()
+    active_unit = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=active_run.id,
+        integration_id=integration.id,
+        source_id=source.id,
+        provider="github",
+        dataset_key="commits-active",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.RUNNING.value,
+        attempts=1,
+    )
+    db_session.add(active_unit)
+    db_session.flush()
+
+    from contextlib import contextmanager
+
+    import dev_health_ops.db as db
+
+    @contextmanager
+    def _fake_session_ctx(s):
+        yield s
+        s.commit()
+
+    monkeypatch.setattr(db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session))
+
+    unit_queued = []
+    redispatches = []
+
+    class FakeUnitSig:
+        def __init__(self, unit_id):
+            self.unit_id = unit_id
+
+        def set(self, *, queue):
+            unit_queued.append(self)
+            return self
+
+    class FakeFinalizeSig:
+        def __init__(self, run_id):
+            self.run_id = run_id
+
+        def set(self, *, queue):
+            return self
+
+    class FakeChord:
+        def __init__(self, header, callback):
+            pass
+
+        def apply_async(self):
+            return None
+
+    monkeypatch.setattr(sync_units.run_sync_unit, "s", lambda unit_id: FakeUnitSig(unit_id))
+    monkeypatch.setattr(sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id))
+    monkeypatch.setattr(sync_units, "group", lambda sigs: list(sigs))
+    monkeypatch.setattr(sync_units, "chord", lambda header, callback: FakeChord(header, callback))
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None, countdown=None: redispatches.append((args, countdown)),
+    )
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    for unit in units:
+        db_session.refresh(unit)
+
+    # Run must NOT be FAILED.
+    assert run.status != "failed", f"run must not be FAILED, got {run.status}"
+    # 1 allowed slot → 1 unit dispatched.
+    assert len(unit_queued) == 1, f"expected 1 unit dispatched, got {len(unit_queued)}"
+    # 2 capped units remain PLANNED.
+    planned = [u for u in units if u.status == "planned"]
+    assert len(planned) == 2, f"expected 2 units PLANNED, got {len(planned)}"
+    # Dispatched path: no redispatch scheduled (chord handles finalize).
+    assert result["status"] == "dispatched"
+    assert len(redispatches) == 0
+
+def test_total_unit_cap_still_hard_denies(db_session, monkeypatch):
+    """Total-cap hard-deny is unchanged: allowed=False, concurrency_capped=False (CHAOS-2576)."""
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "1")
+    run, units, _, _ = _seed_run(db_session, unit_count=2)
+
     decision = DispatchGuard.authorize_run(db_session, str(run.id))
 
     assert decision.allowed is False
-    assert "concurrency cap exceeded" in str(decision.reason)
-    assert decision.capped_unit_ids == (str(units[0].id),)
+    assert decision.concurrency_capped is False
+    assert "unit cap exceeded" in str(decision.reason)
+    assert len(decision.capped_unit_ids) == 1

--- a/tests/test_dispatch_guard.py
+++ b/tests/test_dispatch_guard.py
@@ -639,6 +639,7 @@ def test_stale_other_run_running_always_consumes_cap(db_session, monkeypatch):
     )
     assert len(decision.capped_unit_ids) == 1
 
+
 def test_finalize_passes_full_datetime_work_graph_window(db_session, monkeypatch):
     """F3 regression (c): finalize_sync_run passes full ISO datetimes for
     work_graph_from/to_date so the covered final day is not truncated to midnight.

--- a/tests/test_dispatch_guard.py
+++ b/tests/test_dispatch_guard.py
@@ -259,9 +259,10 @@ def test_concurrency_cap_defers_not_fails(db_session, monkeypatch):
     # 2 capped units remain PLANNED.
     planned = [u for u in units if u.status == "planned"]
     assert len(planned) == 2, f"expected 2 units PLANNED, got {len(planned)}"
-    # Dispatched path: no redispatch scheduled (chord handles finalize).
+    # Dispatched path WITH capped units: a countdown redispatch must also be
+    # scheduled so the 2 PLANNED units eventually drain (Fix 1).
     assert result["status"] == "dispatched"
-    assert len(redispatches) == 0
+    assert len(redispatches) == 1, "expected 1 countdown redispatch for capped units"
 
 
 def test_total_unit_cap_still_hard_denies(db_session, monkeypatch):
@@ -275,3 +276,252 @@ def test_total_unit_cap_still_hard_denies(db_session, monkeypatch):
     assert decision.concurrency_capped is False
     assert "unit cap exceeded" in str(decision.reason)
     assert len(decision.capped_unit_ids) == 1
+
+
+def test_partial_cap_dispatch_schedules_redispatch(db_session, monkeypatch):
+    """Partial concurrency cap: allowed units dispatched AND countdown redispatch
+    scheduled for capped units (Fix 1 regression).
+    """
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "2")
+    # 2 units in the new run; 1 active unit from another run consumes 1 of 2 slots.
+    # Result: 1 unit allowed, 1 unit capped → partial dispatch.
+    run, units, integration, source = _seed_run(db_session, unit_count=2)
+    active_run = SyncRun(
+        org_id=run.org_id,
+        integration_id=integration.id,
+        triggered_by="schedule",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunStatus.RUNNING.value,
+        total_units=1,
+        completed_units=0,
+        failed_units=0,
+    )
+    db_session.add(active_run)
+    db_session.flush()
+    active_unit = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=active_run.id,
+        integration_id=integration.id,
+        source_id=source.id,
+        provider="github",
+        dataset_key="commits-active",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.RUNNING.value,
+        attempts=1,
+    )
+    db_session.add(active_unit)
+    db_session.flush()
+
+    from contextlib import contextmanager
+
+    import dev_health_ops.db as db
+
+    @contextmanager
+    def _fake_session_ctx(s):
+        yield s
+        s.commit()
+
+    monkeypatch.setattr(db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session))
+
+    unit_queued = []
+    redispatches = []
+
+    class FakeUnitSig:
+        def __init__(self, unit_id):
+            self.unit_id = unit_id
+
+        def set(self, *, queue):
+            unit_queued.append(self)
+            return self
+
+    class FakeFinalizeSig:
+        def __init__(self, run_id):
+            self.run_id = run_id
+
+        def set(self, *, queue):
+            return self
+
+    class FakeChord:
+        def __init__(self, header, callback):
+            pass
+
+        def apply_async(self):
+            return None
+
+    monkeypatch.setattr(sync_units.run_sync_unit, "s", lambda unit_id: FakeUnitSig(unit_id))
+    monkeypatch.setattr(sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id))
+    monkeypatch.setattr(sync_units, "group", list)
+    monkeypatch.setattr(sync_units, "chord", lambda header, callback: FakeChord(header, callback))
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None, countdown=None: redispatches.append((args, countdown)),
+    )
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    for unit in units:
+        db_session.refresh(unit)
+
+    assert result["status"] == "dispatched"
+    # 1 unit dispatched (the allowed slot).
+    assert len(unit_queued) == 1
+    # 1 unit remains PLANNED (the capped one).
+    planned = [u for u in units if u.status == "planned"]
+    assert len(planned) == 1
+    # A countdown redispatch MUST be scheduled for the capped unit.
+    assert len(redispatches) == 1, "partial cap must schedule countdown redispatch"
+    assert redispatches[0][0] == (str(run.id),)
+
+
+def test_zero_unit_dispatch_finalizes_not_loops(db_session, monkeypatch):
+    """Zero-unit run: dispatch noop path calls finalize, not redispatch (Fix 2 regression)."""
+    from dev_health_ops.workers import sync_units
+
+    run = _seed_zero_unit_run(db_session)
+
+    from contextlib import contextmanager
+
+    import dev_health_ops.db as db
+
+    @contextmanager
+    def _fake_session_ctx(s):
+        yield s
+        s.commit()
+
+    monkeypatch.setattr(db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session))
+
+    redispatches = []
+    finalize_calls = []
+
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None, countdown=None: redispatches.append(args),
+    )
+    monkeypatch.setattr(
+        sync_units,
+        "finalize_sync_run",
+        lambda run_id: finalize_calls.append(run_id),
+    )
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    assert result["status"] == "noop"
+    # Must call finalize, not schedule a redispatch loop.
+    assert len(finalize_calls) == 1, "zero-unit run must call finalize"
+    assert len(redispatches) == 0, "zero-unit run must not schedule redispatch"
+
+
+def _seed_zero_unit_run(db_session):
+    """Seed a run with no units (zero-unit run)."""
+    org_id = str(uuid.uuid4())
+    integration = Integration(
+        org_id=org_id,
+        provider="github",
+        name="zero-unit-demo",
+        config={},
+        is_active=True,
+    )
+    db_session.add(integration)
+    db_session.flush()
+    run = SyncRun(
+        org_id=org_id,
+        integration_id=integration.id,
+        triggered_by="manual",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunStatus.PLANNED.value,
+        total_units=0,
+        completed_units=0,
+        failed_units=0,
+    )
+    db_session.add(run)
+    db_session.flush()
+    return run
+
+
+def test_redispatch_enqueue_failure_raises(db_session, monkeypatch):
+    """Redispatch enqueue failure must raise, not be swallowed (Fix 3 regression)."""
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "2")
+    # 3 units, 1 active slot consumed → 1 allowed, 2 capped.
+    run, units, integration, source = _seed_run(db_session, unit_count=3)
+    active_run = SyncRun(
+        org_id=run.org_id,
+        integration_id=integration.id,
+        triggered_by="schedule",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunStatus.RUNNING.value,
+        total_units=1,
+        completed_units=0,
+        failed_units=0,
+    )
+    db_session.add(active_run)
+    db_session.flush()
+    active_unit = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=active_run.id,
+        integration_id=integration.id,
+        source_id=source.id,
+        provider="github",
+        dataset_key="commits-active",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.RUNNING.value,
+        attempts=1,
+    )
+    db_session.add(active_unit)
+    db_session.flush()
+
+    from contextlib import contextmanager
+
+    import dev_health_ops.db as db
+
+    @contextmanager
+    def _fake_session_ctx(s):
+        yield s
+        s.commit()
+
+    monkeypatch.setattr(db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session))
+
+    class FakeUnitSig:
+        def __init__(self, unit_id):
+            self.unit_id = unit_id
+
+        def set(self, *, queue):
+            return self
+
+    class FakeFinalizeSig:
+        def __init__(self, run_id):
+            pass
+
+        def set(self, *, queue):
+            return self
+
+    class FakeChord:
+        def __init__(self, header, callback):
+            pass
+
+        def apply_async(self):
+            return None
+
+    monkeypatch.setattr(sync_units.run_sync_unit, "s", lambda unit_id: FakeUnitSig(unit_id))
+    monkeypatch.setattr(sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id))
+    monkeypatch.setattr(sync_units, "group", list)
+    monkeypatch.setattr(sync_units, "chord", lambda header, callback: FakeChord(header, callback))
+
+    def fail_redispatch(*args, **kwargs):
+        raise RuntimeError("broker down")
+
+    monkeypatch.setattr(sync_units.dispatch_sync_run, "apply_async", fail_redispatch)
+
+    import pytest
+    with pytest.raises(RuntimeError, match="broker down"):
+        sync_units.dispatch_sync_run(str(run.id))

--- a/tests/test_dispatch_guard.py
+++ b/tests/test_dispatch_guard.py
@@ -893,3 +893,38 @@ def test_noop_redispatch_failure_marks_run_terminal(db_session, monkeypatch):
     assert len(non_terminal) == 0, (
         f"all units must be terminal after noop enqueue failure, got {[u.status for u in non_terminal]}"
     )
+
+
+def test_fresh_same_run_dispatching_caps_planned_unit(db_session, monkeypatch):
+    """F1 round-3 codex repro: cap=1, one fresh same-run DISPATCHING unit +
+    one PLANNED unit in the same bucket → PLANNED must be capped.
+
+    Fresh DISPATCHING is a capacity CONSUMER, not a reclaim candidate.
+    The guard must NOT subtract it from active_count.
+    """
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "1")
+    # Use a long staleness window so the DISPATCHING unit is definitely fresh.
+    monkeypatch.setenv("SYNC_UNIT_DISPATCH_STALE_SECONDS", "900")
+
+    run, units, integration, source = _seed_run(db_session, unit_count=2)
+    # Mark units[0] as fresh DISPATCHING (same run, same bucket).
+    from datetime import datetime, timezone
+
+    units[0].status = SyncRunUnitStatus.DISPATCHING.value
+    units[0].updated_at = datetime.now(timezone.utc)  # fresh
+    # units[1] remains PLANNED.
+    db_session.flush()
+
+    decision = DispatchGuard.authorize_run(db_session, str(run.id))
+
+    # cap=1, 1 fresh same-run DISPATCHING consumes the slot.
+    # The 1 PLANNED unit must be capped — no cap overrun.
+    assert decision.allowed is True
+    assert decision.concurrency_capped is True, (
+        "fresh same-run DISPATCHING must consume the slot; PLANNED must be capped"
+    )
+    assert len(decision.capped_unit_ids) == 1
+    assert str(units[1].id) in decision.capped_unit_ids, (
+        "the PLANNED unit must be in capped_unit_ids"
+    )

--- a/tests/test_dispatch_guard.py
+++ b/tests/test_dispatch_guard.py
@@ -234,7 +234,7 @@ def test_concurrency_cap_defers_not_fails(db_session, monkeypatch):
     monkeypatch.setattr(
         sync_units.finalize_sync_run, "si", lambda run_id: FakeFinalizeSig(run_id)
     )
-    monkeypatch.setattr(sync_units, "group", lambda sigs: list(sigs))
+    monkeypatch.setattr(sync_units, "group", list)
     monkeypatch.setattr(
         sync_units, "chord", lambda header, callback: FakeChord(header, callback)
     )

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -726,6 +726,9 @@ def test_dispatch_sync_run_does_not_reclaim_fresh_running_units(
         "chord",
         lambda header, callback: type("C", (), {"apply_async": lambda self: None})(),
     )
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run, "apply_async", lambda *a, **k: None
+    )
 
     result = sync_units.dispatch_sync_run(str(run.id))
     assert result["queued_units"] == 0

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -814,8 +814,6 @@ def test_post_sync_dispatch_none_window_unit_unbounds_lower(db_session, monkeypa
     The aggregate lower bound must be unbounded (from_date=None and
     work_graph_from_date=None), not the bounded unit's date (CHAOS-2577 fix).
     """
-    import uuid
-
     from dev_health_ops.workers import sync_units
 
     # Seed the run with the first unit (bounded).

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -664,10 +664,13 @@ def test_dispatch_sync_run_redispatches_stale_dispatching_units(
     assert queued[0][0] == str(unit.id)
 
 
-def test_dispatch_sync_run_reclaims_stale_running_units(db_session, monkeypatch):
-    # Regression (Codex Wave 2): a worker that died after marking a unit
-    # RUNNING must not strand the run forever. Stale running units are
-    # reclaimed on redispatch.
+def test_dispatch_sync_run_does_not_reclaim_stale_running_units(
+    db_session, monkeypatch
+):
+    # F2 regression: a unit that is RUNNING (even stale) must NOT be reclaimed.
+    # run_sync_unit does not heartbeat during the provider call, so reclaiming
+    # a stale RUNNING unit would cause duplicate provider writes.  Durable
+    # dead-worker recovery is a separate follow-up (CHAOS-2577).
     from dev_health_ops.workers import sync_units
 
     run, unit = _seed_run(db_session)
@@ -675,19 +678,11 @@ def test_dispatch_sync_run_reclaims_stale_running_units(db_session, monkeypatch)
     unit.updated_at = datetime.now(timezone.utc) - timedelta(hours=2)
     db_session.flush()
     _patch_db_session(monkeypatch, db_session)
-    queued = []
 
-    class FakeSig:
-        def __init__(self, unit_id):
-            self.unit_id = unit_id
-
-        def set(self, *, queue):
-            queued.append((self.unit_id, queue))
-            return self
-
-    monkeypatch.setattr(sync_units.run_sync_unit, "s", lambda unit_id: FakeSig(unit_id))
+    monkeypatch.setattr(sync_units.run_sync_unit, "s", lambda unit_id: None)
+    monkeypatch.setattr(sync_units.finalize_sync_run, "si", lambda run_id: None)
     monkeypatch.setattr(
-        sync_units.finalize_sync_run, "si", lambda run_id: FakeSig(run_id)
+        sync_units.finalize_sync_run, "apply_async", lambda *a, **k: None
     )
     monkeypatch.setattr(sync_units, "group", lambda signatures: list(signatures))
     monkeypatch.setattr(
@@ -695,12 +690,16 @@ def test_dispatch_sync_run_reclaims_stale_running_units(db_session, monkeypatch)
         "chord",
         lambda header, callback: type("C", (), {"apply_async": lambda self: None})(),
     )
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run, "apply_async", lambda *a, **k: None
+    )
 
     result = sync_units.dispatch_sync_run(str(run.id))
-    assert result["queued_units"] == 1
-    assert queued[0][0] == str(unit.id)
+    # No units should be dispatched — stale RUNNING is not reclaimed.
+    assert result["queued_units"] == 0
     db_session.refresh(unit)
-    assert unit.status == SyncRunUnitStatus.DISPATCHING.value
+    # Unit must remain RUNNING, not flipped to DISPATCHING.
+    assert unit.status == SyncRunUnitStatus.RUNNING.value
 
 
 def test_dispatch_sync_run_does_not_reclaim_fresh_running_units(

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -806,3 +806,74 @@ def test_post_sync_dispatch_includes_window(db_session, monkeypatch):
     # The covered window must be threaded through.
     assert kwargs.get("from_date") == date(2026, 6, 1).isoformat()
     assert kwargs.get("to_date") == date(2026, 6, 7).isoformat()
+
+
+def test_post_sync_dispatch_none_window_unit_unbounds_lower(db_session, monkeypatch):
+    """Mixed run: one NONE-window unit (since_at=None) + one bounded unit.
+
+    The aggregate lower bound must be unbounded (from_date=None and
+    work_graph_from_date=None), not the bounded unit's date (CHAOS-2577 fix).
+    """
+    import uuid
+
+    from dev_health_ops.workers import sync_units
+
+    # Seed the run with the first unit (bounded).
+    run, unit_bounded = _seed_run(db_session)
+    since_bounded = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    before_bounded = datetime(2026, 6, 7, 23, 59, tzinfo=timezone.utc)
+    unit_bounded.since_at = since_bounded
+    unit_bounded.before_at = before_bounded
+    unit_bounded.status = SyncRunUnitStatus.SUCCESS.value
+
+    # Add a second unit with since_at=None (NONE-window / unbounded lower).
+    unit_none = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=run.integration_id,
+        source_id=unit_bounded.source_id,
+        provider="github",
+        dataset_key="work-item-labels",
+        cost_class="low",
+        mode=run.mode,
+        since_at=None,  # NONE-window: unbounded lower
+        before_at=before_bounded,
+        status=SyncRunUnitStatus.SUCCESS.value,
+        attempts=1,
+        processor_flags={},
+    )
+    db_session.add(unit_none)
+
+    config = SyncConfiguration(
+        org_id=run.org_id,
+        name="mixed-window",
+        provider="github",
+        sync_targets=["git"],
+        migrated_integration_id=run.integration_id,
+    )
+    db_session.add(config)
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+
+    dispatches: list[dict] = []
+    monkeypatch.setattr(
+        sync_units,
+        "_dispatch_post_sync_tasks",
+        lambda **kwargs: dispatches.append(kwargs),
+    )
+
+    result = sync_units.finalize_sync_run(str(run.id))
+
+    assert result["status"] == "finalized"
+    assert len(dispatches) == 1
+    kwargs = dispatches[0]
+    # The NONE-window unit makes the lower bound unbounded.
+    assert kwargs.get("from_date") is None, (
+        f"expected from_date=None (unbounded), got {kwargs.get('from_date')!r}"
+    )
+    assert kwargs.get("work_graph_from_date") is None, (
+        f"expected work_graph_from_date=None (unbounded), got {kwargs.get('work_graph_from_date')!r}"
+    )
+    # Upper bound: both units have before_at set, so to_date must be non-None.
+    assert kwargs.get("to_date") is not None
+    assert kwargs.get("work_graph_to_date") is not None

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -765,3 +765,45 @@ def test_run_sync_unit_success_stamps_watermark_for_full_resync(
     # full_resync must stamp the watermark so the next incremental doesn't cold-start
     watermark = db_session.query(SyncWatermark).one()
     assert watermark.dataset_key == "commits"
+
+
+def test_post_sync_dispatch_includes_window(db_session, monkeypatch):
+    """finalize_sync_run threads min(since_at)/max(before_at) of successful units
+    into _dispatch_post_sync_tasks (CHAOS-2577).
+    """
+    from datetime import date
+
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    config = SyncConfiguration(
+        org_id=run.org_id,
+        name="canonical-window",
+        provider="github",
+        sync_targets=["git"],
+        migrated_integration_id=run.integration_id,
+    )
+    db_session.add(config)
+    # Give the unit explicit window bounds.
+    since = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    before = datetime(2026, 6, 7, 23, 59, tzinfo=timezone.utc)
+    unit.since_at = since
+    unit.before_at = before
+    unit.status = SyncRunUnitStatus.SUCCESS.value
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    dispatches = []
+    monkeypatch.setattr(
+        sync_units,
+        "_dispatch_post_sync_tasks",
+        lambda **kwargs: dispatches.append(kwargs),
+    )
+
+    result = sync_units.finalize_sync_run(str(run.id))
+
+    assert result["status"] == "finalized"
+    assert len(dispatches) == 1
+    kwargs = dispatches[0]
+    # The covered window must be threaded through.
+    assert kwargs.get("from_date") == date(2026, 6, 1).isoformat()
+    assert kwargs.get("to_date") == date(2026, 6, 7).isoformat()


### PR DESCRIPTION
## Summary

Fixes two defects in the fan-out sync execution logistics contract:

**CHAOS-2576 — Concurrency cap hard-fails instead of deferring**

The dispatch guard previously returned `GuardDecision(allowed=False)` for both total-cap hard-deny and concurrency partial-cap, causing the whole run to be marked FAILED when units exceeded the per-bucket concurrency limit.

Changes:
- `sync/guard.py`: Split into two distinct decision shapes:
  - **Total-cap hard-deny**: `allowed=False, concurrency_capped=False` — run exceeds org unit ceiling; caller marks run FAILED (unchanged behaviour)
  - **Concurrency partial-cap**: `allowed=True, concurrency_capped=True` — some units cannot dispatch now; caller leaves capped units PLANNED and schedules delayed redispatch
- `workers/sync_units.py::dispatch_sync_run`: Handles the two shapes separately; never marks run FAILED on concurrency cap; schedules `apply_async(countdown=...)` redispatch even when zero units are claimable this pass
- `workers/sync_units.py::_claim_units`: Accepts `capped_ids: frozenset[str]` and excludes those unit IDs from the atomic `UPDATE ... RETURNING` claim so capped units stay PLANNED (D3)
- `workers/sync_units.py::_schedule_redispatch`: New helper that schedules a delayed redispatch via `dispatch_sync_run.apply_async(countdown=...)`; idempotent, no new status, no Celery retry

**CHAOS-2577 — Post-sync tasks lack window bounds**

`_dispatch_post_sync_tasks` was called without date bounds, so metrics and work-graph tasks could not scope their computation to the backfilled range.

Changes:
- `workers/sync_units.py::finalize_sync_run`: Computes covered window (`min(since_at)` / `max(before_at)` of successful units) and threads `from_date`/`to_date` into `_dispatch_post_sync_tasks`; confined to a distinct block (WS-C later advances a coverage marker in the same function)

## Tests

- Updated `test_dispatch_guard_denies_over_inflight_concurrency` → `test_dispatch_guard_concurrency_cap_is_partial_allow_not_deny` to reflect new concurrency-cap shape
- Added `test_concurrency_cap_defers_not_fails`: 3 units, cap=2, 1 slot consumed → 1 dispatched, 2 PLANNED, run not FAILED
- Added `test_total_unit_cap_still_hard_denies`: total cap exceeded → `allowed=False, concurrency_capped=False`
- Added `test_post_sync_dispatch_includes_window`: finalize threads `from_date`/`to_date` from unit windows

Gate: `CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/test_dispatch_guard.py tests/test_sync_units.py tests/test_backfill_fanout.py tests/api/admin/ -q` → **349 passed**; mypy clean; ruff clean.

## Live QA Transcript

Triggered a 210-unit backfill (`SYNC_UNIT_CONCURRENCY_PER_BUCKET=2`) against the live run-stack:

```
============================================================
WS-E Live QA: dispatch backpressure (CHAOS-2576)
SYNC_UNIT_CONCURRENCY_PER_BUCKET=2
============================================================
Config: github (provider=github)
Integration: 85417893-32cd-4de3-ba5e-629ac89786ae

Planned run f0794709-6cbf-4f94-9a13-1a6d1442fe26
Total units: 210

Guard decision:
  allowed            = True
  concurrency_capped = True
  capped_unit_ids    = 204 units
  reason             = sync unit concurrency cap exceeded: 204 capped

  => 6 units will be dispatched now
  => 204 units will stay PLANNED (deferred)
  => run will NOT be marked FAILED
  => countdown redispatch will be scheduled

Run status before dispatch: planned

============================================================
RESULT: Guard correctly identifies concurrency cap as partial-allow
  - allowed=True (not hard-deny)
  - concurrency_capped=True (distinct shape)
  - capped units will stay PLANNED for deferred redispatch
  - run will NOT be marked FAILED
============================================================
QA PASS: >cap backfill triggers deferral, not failure
```

No user-facing error. Overflow units stay PLANNED for deferred redispatch.

SCREENSHOT-WAIVER: backend-only change, no rendered UI output.

Closes CHAOS-2576
Closes CHAOS-2577