### PR TITLE
perf(ci): parallelize tests with xdist, move coverage off PR path, drop 3.11 (CHAOS-2586)

### DIFF
--- a/.github/workflows/docs-guards.yml
+++ b/.github/workflows/docs-guards.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Check generated taxonomy is up to date
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,18 @@ jobs:
               - 'Makefile'
               - 'scripts/**'
 
+  # Fast, pytest-xdist-parallelized unit suite across the supported Python
+  # versions. This is the per-PR signal that the required `test` gate (below)
+  # aggregates. Coverage is intentionally NOT gated here so the iterative PR
+  # loop stays fast — the coverage-gated full suite runs in the `coverage` job
+  # at merge time and on main (CHAOS-2586).
   test-matrix:
     needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    # On merge_group, dorny/paths-filter has no PR base/head diff to compute and
+    # can report code=false, which would skip every test job; the `test`
+    # aggregator then treats the skip as a pass and an untested change reaches
+    # main. Always run in the merge queue regardless of the path filter.
+    if: github.event_name == 'merge_group' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04-arm
     # Test matrix needs package read access for dependency installs.
     permissions:
@@ -49,7 +58,7 @@ jobs:
       packages: read
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     services:
       postgres:
@@ -88,26 +97,26 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run tiered test contract
+      - name: Run parallel unit test contract
         env:
           DATABASE_URI: clickhouse://ch:ch@localhost:8123/default
           CLICKHOUSE_URI: clickhouse://ch:ch@localhost:8123/default
           POSTGRES_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
           SECONDARY_DATABASE_URI: mongodb://localhost:27017
-          COVERAGE_THRESHOLD: "70"
           # No OTLP collector runs in CI; with OTEL on, the exporter retries to
           # localhost:4317 with backoff on every span/metric, flooding logs and
           # slowing the suite into timeouts. We don't assert OTEL stats in CI.
           OTEL_ENABLED: "false"
+          # Cap xdist workers so parallelism does not contend on the single
+          # postgres/clickhouse service container. The standard arm runner has
+          # 4 vCPUs, so this matches `-n auto` there while staying predictable on
+          # larger runners. Override PYTEST_XDIST_WORKERS to tune.
+          PYTEST_XDIST_WORKERS: "4"
         run: |
           chmod +x ci/run_tests.sh
           mkdir -p test-results/logs
           set -o pipefail
-          if [ "${{ matrix.python-version }}" = "3.11" ]; then
-            ./ci/run_tests.sh ci 2>&1 | tee test-results/logs/ci-${{ matrix.python-version }}.log
-          else
-            ./ci/run_tests.sh unit 2>&1 | tee test-results/logs/unit-${{ matrix.python-version }}.log
-          fi
+          ./ci/run_tests.sh unit 2>&1 | tee test-results/logs/unit-${{ matrix.python-version }}.log
 
       - name: Upload junit test reports
         if: always()
@@ -129,34 +138,126 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  # Full coverage-gated suite (ruff/mypy gates + unit tests with coverage
+  # threshold + integration/e2e). Kept OFF the per-PR iterative path: it runs in
+  # the merge queue (before code reaches main) and on push to main (post-merge
+  # verification + Codecov upload), never on pull_request. Reassigned from the
+  # retired 3.11 leg to 3.12 and parallelized with xdist (CHAOS-2586).
+  coverage:
+    needs: [changes]
+    if: >-
+      github.event_name != 'pull_request' &&
+      (github.event_name == 'merge_group' || needs.changes.outputs.code == 'true')
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: read
+
+    services:
+      postgres:
+        image: postgres:17.4
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+      clickhouse:
+        image: clickhouse/clickhouse-server:25.1
+        env:
+          CLICKHOUSE_DB: default
+          CLICKHOUSE_USER: ch
+          CLICKHOUSE_PASSWORD: ch
+        ports:
+          - 8123:8123
+        options: >-
+          --health-cmd "clickhouse-client --user ch --password ch --query 'SELECT 1'" --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run coverage-gated test contract
+        env:
+          DATABASE_URI: clickhouse://ch:ch@localhost:8123/default
+          CLICKHOUSE_URI: clickhouse://ch:ch@localhost:8123/default
+          POSTGRES_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
+          SECONDARY_DATABASE_URI: mongodb://localhost:27017
+          COVERAGE_THRESHOLD: "70"
+          OTEL_ENABLED: "false"
+          PYTEST_XDIST_WORKERS: "4"
+        run: |
+          chmod +x ci/run_tests.sh
+          mkdir -p test-results/logs
+          set -o pipefail
+          ./ci/run_tests.sh ci 2>&1 | tee test-results/logs/ci-3.12.log
+
+      - name: Upload junit test reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: junit-coverage
+          path: test-results/junit/*.xml
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload pytest logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pytest-logs-coverage
+          path: |
+            test-results/logs/*.log
+            **/pytest.log
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Upload coverage reports
-        if: matrix.python-version == '3.11'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
 
   # Required-status-check gate. Branch protection requires a check named
-  # exactly "test"; the matrix above produces "test (3.11)"..."test (3.14)"
-  # which never match. This aggregator always runs, treating skipped (path
-  # filter) as pass and failure/cancelled as fail. Do not remove.
+  # exactly "test"; the matrix above produces "test-matrix (3.12)".."(3.14)"
+  # and the coverage job produces "coverage", none of which match. This
+  # aggregator always runs, treating skipped (path filter, or coverage skipped
+  # on pull_request) as pass and failure/cancelled as fail. It is the single
+  # required check for both PRs and the merge queue. Do not remove.
   test:
     name: test
     if: always()
-    needs: [test-matrix]
+    needs: [test-matrix, coverage]
     runs-on: ubuntu-latest
     steps:
-      - name: Aggregate matrix result
+      - name: Aggregate test results
         env:
           MATRIX_RESULT: ${{ needs.test-matrix.result }}
+          COVERAGE_RESULT: ${{ needs.coverage.result }}
         run: |
           echo "test-matrix result: ${MATRIX_RESULT}"
-          case "${MATRIX_RESULT}" in
-            success|skipped)
-              echo "test gate passed"
-              ;;
-            failure|cancelled|*)
-              echo "test gate failed"
-              exit 1
-              ;;
-          esac
+          echo "coverage result: ${COVERAGE_RESULT}"
+          for result in "${MATRIX_RESULT}" "${COVERAGE_RESULT}"; do
+            case "${result}" in
+              success|skipped)
+                ;;
+              failure|cancelled|*)
+                echo "test gate failed (${result})"
+                exit 1
+                ;;
+            esac
+          done
+          echo "test gate passed"

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install dependencies

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ variables:
 
 pipeline:validate:
   stage: lint
-  image: python:3.11
+  image: python:3.12
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
     - if: $CI_PIPELINE_SOURCE == "merge_train"
@@ -103,6 +103,7 @@ pipeline:validate:
           "lint",
           "typecheck:mypy",
           "test",
+          "coverage",
           "integration",
           "live-e2e",
           "security:pip-audit",
@@ -120,7 +121,7 @@ pipeline:validate:
 lint:
   extends: .python_job
   stage: lint
-  image: python:3.11
+  image: python:3.12
   rules: &code_rules
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
@@ -148,7 +149,7 @@ lint:
 typecheck:mypy:
   extends: .python_job
   stage: lint
-  image: python:3.11
+  image: python:3.12
   rules: *code_rules
   script:
     - mypy --install-types --non-interactive .
@@ -161,7 +162,62 @@ test:
   rules: *code_rules
   parallel:
     matrix:
-      - PYTHON_VERSION: ["3.11", "3.12", "3.13", "3.14"]
+      - PYTHON_VERSION: ["3.12", "3.13", "3.14"]
+  services:
+    - name: postgres:17.4
+      alias: postgres
+    - name: clickhouse/clickhouse-server:25.1
+      alias: clickhouse
+  variables:
+    POSTGRES_USER: postgres
+    POSTGRES_PASSWORD: postgres
+    POSTGRES_DB: test_db
+    CLICKHOUSE_DB: default
+    CLICKHOUSE_USER: ch
+    CLICKHOUSE_PASSWORD: ch
+    DATABASE_URI: clickhouse://ch:ch@clickhouse:8123/default
+    CLICKHOUSE_URI: clickhouse://ch:ch@clickhouse:8123/default
+    CLICKHOUSE_HEALTH_URL: http://ch:ch@clickhouse:8123/?query=SELECT%201
+    POSTGRES_URI: postgresql+asyncpg://postgres:postgres@postgres:5432/test_db
+    SECONDARY_DATABASE_URI: mongodb://localhost:27017
+    OTEL_ENABLED: "false"
+    # Cap xdist workers so parallelism does not contend on the single
+    # postgres/clickhouse service container (CHAOS-2586).
+    PYTEST_XDIST_WORKERS: "4"
+  script:
+    - apt-get update -y
+    - apt-get install -y --no-install-recommends curl git build-essential
+    - pip install ruff
+    - *wait_test_services
+    - chmod +x ci/run_tests.sh
+    - mkdir -p test-results/logs
+    - |
+      set -o pipefail
+      ./ci/run_tests.sh unit 2>&1 | tee "test-results/logs/unit-${PYTHON_VERSION}.log"
+  artifacts:
+    when: always
+    expire_in: 14 days
+    paths:
+      - test-results/junit/*.xml
+      - test-results/logs/*.log
+    reports:
+      junit: test-results/junit/*.xml
+
+# Full coverage-gated suite (ruff/mypy gates + unit tests with coverage
+# threshold + integration/e2e). Kept OFF the per-MR critical path: runs on the
+# merge train (before code reaches the default branch) and on the default
+# branch (post-merge verification), never on a plain merge_request_event.
+# Reassigned from the retired 3.11 leg to 3.12 and parallelized (CHAOS-2586).
+coverage:
+  extends: .python_job
+  stage: test
+  image: python:3.12
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "merge_train"
+      changes: *code_changes
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      changes: *code_changes
   services:
     - name: postgres:17.4
       alias: postgres
@@ -180,6 +236,8 @@ test:
     POSTGRES_URI: postgresql+asyncpg://postgres:postgres@postgres:5432/test_db
     SECONDARY_DATABASE_URI: mongodb://localhost:27017
     COVERAGE_THRESHOLD: "70"
+    OTEL_ENABLED: "false"
+    PYTEST_XDIST_WORKERS: "4"
   script:
     - apt-get update -y
     - apt-get install -y --no-install-recommends curl git build-essential
@@ -189,11 +247,7 @@ test:
     - mkdir -p test-results/logs
     - |
       set -o pipefail
-      if [ "$PYTHON_VERSION" = "3.11" ]; then
-        ./ci/run_tests.sh ci 2>&1 | tee "test-results/logs/ci-${PYTHON_VERSION}.log"
-      else
-        ./ci/run_tests.sh unit 2>&1 | tee "test-results/logs/unit-${PYTHON_VERSION}.log"
-      fi
+      ./ci/run_tests.sh ci 2>&1 | tee "test-results/logs/ci-3.12.log"
   artifacts:
     when: always
     expire_in: 14 days

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -21,6 +21,8 @@ Environment:
   PYTEST_SINGLE_RETRY=1  Retry a failing pytest tier once
   PYTEST_DURATIONS=25    Emit the slowest N test durations in output
   TEST_RESULTS_DIR=...   Base directory for junit outputs (default: ./test-results)
+  PYTEST_XDIST_WORKERS=auto   pytest-xdist worker count (-n). Set 0 to disable parallelism.
+  PYTEST_DIST_MODE=loadscope  xdist distribution mode (loadscope keeps a module on one worker).
 EOF
 }
 
@@ -47,6 +49,15 @@ JUNIT_XML_E2E="${JUNIT_XML_E2E:-${JUNIT_RESULTS_DIR}/e2e.xml}"
 PYTEST_SINGLE_RETRY="${PYTEST_SINGLE_RETRY:-0}"
 PYTEST_DURATIONS="${PYTEST_DURATIONS:-25}"
 PYTEST_DIAGNOSTIC_OPTS=(-ra "--durations=${PYTEST_DURATIONS}")
+
+# pytest-xdist parallelization (CHAOS-2586). Defaults to `-n auto --dist
+# loadscope`. loadscope keeps every test in a module on a single worker so
+# intra-module ordering is preserved (this suite has ordering-sensitive tests:
+# importlib.reload module pollution, tier_limits MagicMock subset ordering).
+# xdist workers are separate processes, so module-level/env/reload state is
+# per-worker isolated. Set PYTEST_XDIST_WORKERS=0 to run serially.
+PYTEST_XDIST_WORKERS="${PYTEST_XDIST_WORKERS:-auto}"
+PYTEST_DIST_MODE="${PYTEST_DIST_MODE:-loadscope}"
 
 HAS_UV=0
 if command -v uv >/dev/null 2>&1; then
@@ -147,10 +158,13 @@ unit_tests() {
   # The `clickhouse` marker is opt-in (mirrors `benchmark`). Tests under
   # that marker require a live ClickHouse seeded with demo data and are
   # intended for local development via `pytest -m clickhouse`.
-  run_pytest_step "unit tests" "${JUNIT_XML_UNIT}" \
-    tests -v --tb=short -m "not benchmark and not clickhouse" \
-    --ignore=tests/test_connectors_integration.py \
-    --ignore=tests/test_private_repo_access.py
+  local pytest_args=(tests -v --tb=short -m "not benchmark and not clickhouse"
+    --ignore=tests/test_connectors_integration.py
+    --ignore=tests/test_private_repo_access.py)
+  if [ "${PYTEST_XDIST_WORKERS}" != "0" ]; then
+    pytest_args+=(-n "${PYTEST_XDIST_WORKERS}" --dist "${PYTEST_DIST_MODE}")
+  fi
+  run_pytest_step "unit tests" "${JUNIT_XML_UNIT}" "${pytest_args[@]}"
 }
 
 integration_tests() {
@@ -230,11 +244,17 @@ ci_tests() {
   run_step "ruff (lint gates)" ruff check --select=E9,F63,F7,F82 .
   # Mirror unit_tests()'s marker filter: skip `clickhouse`-marked tests that
   # need a seeded live ClickHouse (opt-in locally via `pytest -m clickhouse`).
-  run_pytest_step "unit tests with coverage >= ${coverage_threshold}" "${JUNIT_XML_UNIT}" \
-    tests -v --tb=short -m "not benchmark and not clickhouse" \
-    --ignore=tests/test_connectors_integration.py \
-    --ignore=tests/test_private_repo_access.py \
-    --cov=. --cov-report=xml --cov-report=term-missing --cov-fail-under="${coverage_threshold}"
+  local cov_args=(tests -v --tb=short -m "not benchmark and not clickhouse"
+    --ignore=tests/test_connectors_integration.py
+    --ignore=tests/test_private_repo_access.py
+    --cov=. --cov-report=xml --cov-report=term-missing
+    --cov-fail-under="${coverage_threshold}")
+  # pytest-cov aggregates per-worker coverage automatically under xdist, so the
+  # --cov-fail-under gate still evaluates the combined total across workers.
+  if [ "${PYTEST_XDIST_WORKERS}" != "0" ]; then
+    cov_args+=(-n "${PYTEST_XDIST_WORKERS}" --dist "${PYTEST_DIST_MODE}")
+  fi
+  run_pytest_step "unit tests with coverage >= ${coverage_threshold}" "${JUNIT_XML_UNIT}" "${cov_args[@]}"
   integration_tests
   e2e_tests
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,14 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
 keywords = ["metrics", "git", "analytics", "developer-experience"]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
   "tqdm>=4.67.3",
   "sqlalchemy[asyncio]>=2.0.49",

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,11 @@ pythonpath = src
 markers =
     benchmark: mark a test as a benchmark.
     clickhouse: requires a live ClickHouse connection (set CLICKHOUSE_URI).
+filterwarnings =
+    # unittest.mock's AsyncMock emits this when an auto-created async mock is
+    # called but its coroutine is discarded by the code under test. The name is
+    # mock-internal: a real missed await surfaces as `coroutine '<real_name>'`,
+    # so ignoring this exact message cannot hide a production bug. Genuine
+    # coroutine-runner orphans are fixed at source via tests._helpers
+    # .closing_coroutine_runner (CHAOS-2586).
+    ignore:coroutine 'AsyncMockMixin\._execute_mock_call' was never awaited:RuntimeWarning

--- a/src/dev_health_ops/db.py
+++ b/src/dev_health_ops/db.py
@@ -346,6 +346,21 @@ def get_postgres_sync_engine(uri: str | None = None) -> Engine:
     return _postgres_sync_engine
 
 
+def reset_sync_engine() -> None:
+    """Dispose and clear the cached global sync Postgres engine.
+
+    ``get_postgres_sync_engine()`` caches the engine keyed off POSTGRES_URI on
+    first use. Tests that monkeypatch POSTGRES_URI per test must reset it so the
+    next caller binds to the current env instead of a stale engine pointing at a
+    previous test's database -- the cross-test / cross-xdist-worker pollution
+    behind CHAOS-2586.
+    """
+    global _postgres_sync_engine
+    if _postgres_sync_engine is not None:
+        _postgres_sync_engine.dispose()
+        _postgres_sync_engine = None
+
+
 @contextmanager
 def get_postgres_session_sync() -> Generator[Session, None, None]:
     engine = get_postgres_sync_engine()

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -7,6 +7,8 @@ quirks.
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Callable
 from typing import Any, cast
 
 from sqlalchemy import Table
@@ -29,3 +31,25 @@ def tables_of(*models: Any) -> list[Table]:
     surface ``__table__`` to a plain ``type[...]`` view.
     """
     return [cast(Table, model.__table__) for model in models]
+
+
+def closing_asyncio_run(
+    return_value: Any = None, *, raises: BaseException | None = None
+) -> Callable[..., Any]:
+    """Build a ``side_effect`` for a mocked ``asyncio.run`` that closes the coroutine.
+
+    Mocking ``asyncio.run`` leaves the coroutine argument un-awaited, which emits
+    a ``RuntimeWarning: coroutine '...' was never awaited`` at garbage-collection
+    time. This side_effect closes the coroutine so it is consumed cleanly, while
+    the mock still records the call and honours the requested return/raise
+    behaviour (CHAOS-2586).
+    """
+
+    def _run(coro: Any = None, *args: Any, **kwargs: Any) -> Any:
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        if raises is not None:
+            raise raises
+        return return_value
+
+    return _run

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -33,13 +33,14 @@ def tables_of(*models: Any) -> list[Table]:
     return [cast(Table, model.__table__) for model in models]
 
 
-def closing_asyncio_run(
+def closing_coroutine_runner(
     return_value: Any = None, *, raises: BaseException | None = None
 ) -> Callable[..., Any]:
-    """Build a ``side_effect`` for a mocked ``asyncio.run`` that closes the coroutine.
+    """Build a ``side_effect`` for a mocked coroutine runner that closes the coroutine.
 
-    Mocking ``asyncio.run`` leaves the coroutine argument un-awaited, which emits
-    a ``RuntimeWarning: coroutine '...' was never awaited`` at garbage-collection
+    Mocking a coroutine runner (``asyncio.run``, ``workers.async_runner.run_async``,
+    etc.) leaves the coroutine argument un-awaited, which emits a
+    ``RuntimeWarning: coroutine '...' was never awaited`` at garbage-collection
     time. This side_effect closes the coroutine so it is consumed cleanly, while
     the mock still records the call and honours the requested return/raise
     behaviour (CHAOS-2586).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,24 @@ def mock_analytics_db_url(monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _reset_sync_db_engine():
+    """Reset the cached global sync Postgres engine around every test.
+
+    ``get_postgres_sync_engine()`` caches a process-global engine keyed off
+    POSTGRES_URI on first use. Without this, a test running earlier on an xdist
+    worker can leave a cached engine bound to its own database, so a later test
+    that monkeypatches POSTGRES_URI reads the wrong (empty) database and sees
+    missing rows (CHAOS-2586). Resetting before and after each test keeps every
+    test bound to its own env.
+    """
+    from dev_health_ops.db import reset_sync_engine
+
+    reset_sync_engine()
+    yield
+    reset_sync_engine()
+
+
 @pytest.fixture
 def repo_path():
     """Return the path to the current repository for testing."""

--- a/tests/recommendations/test_registry.py
+++ b/tests/recommendations/test_registry.py
@@ -137,7 +137,10 @@ def test_all_rules_tuple_is_immutable() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("rule_id", CANONICAL_IDS)
+# CANONICAL_IDS is a set; sort it so parametrized test IDs collect in a stable
+# order across xdist workers (xdist requires identical collection per worker;
+# unordered set iteration triggers "Different tests were collected" — CHAOS-2586).
+@pytest.mark.parametrize("rule_id", sorted(CANONICAL_IDS))
 def test_get_rule_returns_correct_ruledef(rule_id: str) -> None:
     rule = get_rule(rule_id)
     assert isinstance(rule, RuleDef)

--- a/tests/test_bugsink_regressions.py
+++ b/tests/test_bugsink_regressions.py
@@ -20,6 +20,7 @@ from dev_health_ops.models.settings import (  # noqa: E402
     ScheduledJob,
     SyncConfiguration,
 )
+from tests._helpers import closing_asyncio_run  # noqa: E402
 
 
 @pytest.fixture
@@ -152,7 +153,7 @@ def test_run_daily_metrics_batch_defaults_none_org_id(
     from dev_health_ops.workers.metrics_partitioned import run_daily_metrics_batch
 
     mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
-    mock_asyncio_run.return_value = None
+    mock_asyncio_run.side_effect = closing_asyncio_run()
 
     repo_id = uuid.uuid4()
     task = run_daily_metrics_batch
@@ -186,7 +187,7 @@ def test_run_daily_metrics_finalize_defaults_none_org_id(
     )
 
     mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
-    mock_asyncio_run.return_value = None
+    mock_asyncio_run.side_effect = closing_asyncio_run()
 
     task = run_daily_metrics_finalize_task
     task.push_request(id="bugsink-finalize-none-org", retries=0)

--- a/tests/test_bugsink_regressions.py
+++ b/tests/test_bugsink_regressions.py
@@ -20,7 +20,7 @@ from dev_health_ops.models.settings import (  # noqa: E402
     ScheduledJob,
     SyncConfiguration,
 )
-from tests._helpers import closing_asyncio_run  # noqa: E402
+from tests._helpers import closing_coroutine_runner  # noqa: E402
 
 
 @pytest.fixture
@@ -153,7 +153,7 @@ def test_run_daily_metrics_batch_defaults_none_org_id(
     from dev_health_ops.workers.metrics_partitioned import run_daily_metrics_batch
 
     mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
-    mock_asyncio_run.side_effect = closing_asyncio_run()
+    mock_asyncio_run.side_effect = closing_coroutine_runner()
 
     repo_id = uuid.uuid4()
     task = run_daily_metrics_batch
@@ -187,7 +187,7 @@ def test_run_daily_metrics_finalize_defaults_none_org_id(
     )
 
     mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
-    mock_asyncio_run.side_effect = closing_asyncio_run()
+    mock_asyncio_run.side_effect = closing_coroutine_runner()
 
     task = run_daily_metrics_finalize_task
     task.push_request(id="bugsink-finalize-none-org", retries=0)

--- a/tests/test_core_extraction.py
+++ b/tests/test_core_extraction.py
@@ -59,6 +59,17 @@ class TestCoreEncryption:
 class TestCoreCache:
     """Tests for core/cache.py."""
 
+    @pytest.fixture(autouse=True)
+    def _pin_cache_clock(self, monkeypatch):
+        # Pin core.cache's wall clock so a neighboring module that leaks a
+        # forward time.time() jump onto the same xdist worker cannot expire the
+        # entries these tests set moments earlier (CHAOS-2586). This class
+        # exercises cache set/get/invalidate behavior, not TTL expiry, which is
+        # covered separately by TestCoreCacheInvalidation.
+        import dev_health_ops.core.cache as cache_mod
+
+        monkeypatch.setattr(cache_mod.time, "time", lambda: 1_000_000.0)
+
     def test_memory_cache_set_get(self):
         from dev_health_ops.core.cache import create_cache
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -6,6 +6,12 @@ import argparse
 from pathlib import Path
 from unittest.mock import patch
 
+# Force-import the alembic.command submodule so `@patch("alembic.command")` in
+# TestCommandDispatch resolves regardless of test execution order. The submodule
+# is only lazily imported inside dev_health_ops.migrate functions, so without
+# this the patch target is missing when the module runs first on an xdist worker
+# or in isolation (CHAOS-2586).
+import alembic.command  # noqa: F401
 import pytest
 
 from dev_health_ops import migrate as migrate_mod

--- a/tests/test_parallel_metrics.py
+++ b/tests/test_parallel_metrics.py
@@ -14,7 +14,7 @@ from dev_health_ops.metrics.checkpoints import (
 )
 from dev_health_ops.models.checkpoints import CheckpointStatus
 from dev_health_ops.models.git import Base
-from tests._helpers import closing_asyncio_run
+from tests._helpers import closing_coroutine_runner
 
 
 @pytest.fixture
@@ -124,7 +124,7 @@ class TestRunDailyMetricsBatch:
         from dev_health_ops.workers.metrics_partitioned import run_daily_metrics_batch
 
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
-        mock_asyncio_run.side_effect = closing_asyncio_run()
+        mock_asyncio_run.side_effect = closing_coroutine_runner()
 
         repo_id = uuid.uuid4()
         task = run_daily_metrics_batch
@@ -159,7 +159,9 @@ class TestRunDailyMetricsBatch:
         from dev_health_ops.workers.metrics_partitioned import run_daily_metrics_batch
 
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
-        mock_asyncio_run.side_effect = closing_asyncio_run(raises=RuntimeError("boom"))
+        mock_asyncio_run.side_effect = closing_coroutine_runner(
+            raises=RuntimeError("boom")
+        )
 
         repo_id = uuid.uuid4()
         task = run_daily_metrics_batch
@@ -239,7 +241,7 @@ class TestRunDailyMetricsFinalizeTask:
         )
 
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
-        mock_asyncio_run.side_effect = closing_asyncio_run()
+        mock_asyncio_run.side_effect = closing_coroutine_runner()
 
         task = run_daily_metrics_finalize_task
         task.push_request(id="finalize-task-1", retries=0)
@@ -290,7 +292,7 @@ class TestRunDailyMetricsFinalizeTask:
         )
 
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
-        mock_asyncio_run.side_effect = closing_asyncio_run(
+        mock_asyncio_run.side_effect = closing_coroutine_runner(
             raises=RuntimeError("finalize exploded")
         )
 

--- a/tests/test_parallel_metrics.py
+++ b/tests/test_parallel_metrics.py
@@ -14,6 +14,7 @@ from dev_health_ops.metrics.checkpoints import (
 )
 from dev_health_ops.models.checkpoints import CheckpointStatus
 from dev_health_ops.models.git import Base
+from tests._helpers import closing_asyncio_run
 
 
 @pytest.fixture
@@ -123,7 +124,7 @@ class TestRunDailyMetricsBatch:
         from dev_health_ops.workers.metrics_partitioned import run_daily_metrics_batch
 
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
-        mock_asyncio_run.return_value = None
+        mock_asyncio_run.side_effect = closing_asyncio_run()
 
         repo_id = uuid.uuid4()
         task = run_daily_metrics_batch
@@ -158,7 +159,7 @@ class TestRunDailyMetricsBatch:
         from dev_health_ops.workers.metrics_partitioned import run_daily_metrics_batch
 
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
-        mock_asyncio_run.side_effect = RuntimeError("boom")
+        mock_asyncio_run.side_effect = closing_asyncio_run(raises=RuntimeError("boom"))
 
         repo_id = uuid.uuid4()
         task = run_daily_metrics_batch
@@ -238,7 +239,7 @@ class TestRunDailyMetricsFinalizeTask:
         )
 
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
-        mock_asyncio_run.return_value = None
+        mock_asyncio_run.side_effect = closing_asyncio_run()
 
         task = run_daily_metrics_finalize_task
         task.push_request(id="finalize-task-1", retries=0)
@@ -289,7 +290,9 @@ class TestRunDailyMetricsFinalizeTask:
         )
 
         mock_get_session.side_effect = lambda: _fake_session_ctx(db_session)
-        mock_asyncio_run.side_effect = RuntimeError("finalize exploded")
+        mock_asyncio_run.side_effect = closing_asyncio_run(
+            raises=RuntimeError("finalize exploded")
+        )
 
         task = run_daily_metrics_finalize_task
         task.push_request(id="finalize-task-2", retries=0)

--- a/tests/test_post_sync_investment_dispatch.py
+++ b/tests/test_post_sync_investment_dispatch.py
@@ -28,6 +28,7 @@ from unittest.mock import MagicMock, patch
 # import that otherwise ERRORs isolated collection (mirrors CHAOS-2370).
 import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.workers.sync_runtime import _dispatch_post_sync_tasks
+from tests._helpers import closing_coroutine_runner
 
 _INVESTMENT_TASK = (
     "dev_health_ops.workers.tasks.dispatch_investment_materialize_partitioned"
@@ -282,7 +283,9 @@ def test_run_investment_materialize_forwards_org_id_to_config() -> None:
         ),
         patch(
             "dev_health_ops.workers.work_graph_tasks.run_async",
-            return_value={"components": 0, "records": 0, "quotes": 0},
+            side_effect=closing_coroutine_runner(
+                {"components": 0, "records": 0, "quotes": 0}
+            ),
         ),
     ):
         task = cast(Any, run_investment_materialize)
@@ -317,7 +320,9 @@ def test_run_investment_materialize_empty_org_id_becomes_none() -> None:
         ),
         patch(
             "dev_health_ops.workers.work_graph_tasks.run_async",
-            return_value={"components": 0, "records": 0, "quotes": 0},
+            side_effect=closing_coroutine_runner(
+                {"components": 0, "records": 0, "quotes": 0}
+            ),
         ),
     ):
         task = cast(Any, run_investment_materialize)
@@ -353,7 +358,9 @@ def test_run_investment_materialize_resolves_worker_llm_credentials(
         ),
         patch(
             "dev_health_ops.workers.work_graph_tasks.run_async",
-            return_value={"components": 0, "records": 0, "quotes": 0},
+            side_effect=closing_coroutine_runner(
+                {"components": 0, "records": 0, "quotes": 0}
+            ),
         ),
     ):
         task = cast(Any, run_investment_materialize)


### PR DESCRIPTION
## Summary

Speeds up the merge-gating test matrix. The 3.11 `ci` leg (unit tests + coverage gate, ~20 min) was structurally the slowest job and the merge bottleneck. Three levers, all applied:

### 1. Parallelize tests with pytest-xdist
`pytest-xdist` was already a dependency but unused. `ci/run_tests.sh` now wires it into the `unit` and `ci`/coverage tiers via env knobs:
- `PYTEST_XDIST_WORKERS` (default `auto`; `0` disables)
- `PYTEST_DIST_MODE` (default `loadscope` — keeps each module on one worker to preserve intra-module ordering for this suite's ordering-sensitive tests)

xdist workers are separate processes, so module-level / `importlib.reload` / env state is per-worker isolated. **pytest-cov aggregates per-worker coverage**, so `--cov-fail-under` still gates the combined total — verified locally: serial and `-n 4` report identical coverage totals.

### 2. Get the coverage run off the PR critical path
The required PR/merge-queue check is now a **fast parallel unit matrix** (3.12/3.13/3.14). The coverage-gated full suite moved to a **separate `coverage` job** that runs only at merge time (`merge_group` / GitLab `merge_train`) and on `main` — never on the per-PR iterative loop. Coverage still runs before code reaches main (in the merge queue).

- Single required check stays named **`test`** (the aggregator) — branch-protection / merge-queue config unchanged.
- The aggregator treats coverage **skipped on PR** as pass and requires it on the merge queue.
- **Merge-queue safety**: test/coverage jobs always run on `merge_group` regardless of the path filter, so an empty merge-queue diff can't silently skip the gate and let the aggregator pass.
- CI caps xdist workers at 4 to avoid contention on the single postgres/clickhouse service container.

### 3. Drop the Python 3.11 floor → 3.12
- `pyproject.toml`: `requires-python >= 3.12`; classifiers updated to 3.12–3.14.
- `lint.yml` / `typecheck.yml` / `docs-guards.yml`: pinned `3.11` → `3.12`.
- Heavy coverage role reassigned `3.11` → `3.12` (GitHub + GitLab). Container image already on 3.14.
- `.gitlab-ci.yml` mirrors all of the above (parity validator updated for the new `coverage` job).

### Test-isolation fixes (required by xdist)
Two pre-existing isolation bugs that xdist surfaces:
- **`test_migrate.py`** patched `alembic.command` without importing the submodule — failed in isolation / when run first on a worker. Now force-imports it.
- **`TestCoreCache`** could observe a neighboring module's leaked forward `time.time()` jump, expiring just-set cache entries (assertion `None == 'value1'`). Now pins the cache clock for that class (it exercises cache behavior, not TTL expiry).

## Validation
- `ci/run_tests.sh` unit suite: **serial + 3× xdist all pass deterministically** (zero new flakiness) locally; ~3.2× wall-clock speedup (184s → ~56s).
- Coverage aggregation under `-n 4` confirmed (identical totals vs serial).
- `shellcheck` clean on `run_tests.sh`; `actionlint` clean on `test.yml`; `.gitlab-ci.yml` parity validator passes; `ruff` + whole-project `mypy` clean.

## Acceptance criteria
- [x] Required check goes green materially faster (fast parallel unit matrix; target < 10 min).
- [x] Unit tests run in parallel with zero new flakiness (serial + 3× xdist deterministic).
- [x] Full coverage-gated suite still runs before main (merge queue) + on main.
- [x] 3.11 fully removed (matrix, requires-python, classifiers, pinned workflows; container already 3.14); heavy runner reassigned to 3.12.
- [x] Required-check list unchanged (single `test` aggregator stays the gate).
- [x] CodeQL/Semgrep/Gitleaks/live-e2e unchanged.

SCREENSHOT-WAIVER: CI/tooling-only change; no rendered frontend output.

Closes CHAOS-2586