### PR TITLE
fix(sync): recover dead running sync units (CHAOS-2585)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ dev = [
   "fakeredis[valkey]",
   "pip-audit>=2.7.0",
   "mako>=1.3.12",
+  "pandas-stubs>=3.0.3.260530",
 ]
 enterprise-sso = ["signxml>=3.0.0"]
 

--- a/src/dev_health_ops/alembic/versions/0019_add_sync_unit_lease_columns.py
+++ b/src/dev_health_ops/alembic/versions/0019_add_sync_unit_lease_columns.py
@@ -1,5 +1,10 @@
 """Add sync run unit lease columns.
 
+Retry safety: the lease columns are guarded individually so a rerun after a
+partial failure between column creation and concurrent index creation can resume
+instead of failing on duplicate columns. The downgrade mirrors this by dropping
+columns only when present.
+
 Revision ID: 0019
 Revises: 0018
 Create Date: 2026-06-20 00:00:00
@@ -22,12 +27,14 @@ __all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
 
 
 def upgrade() -> None:
-    op.add_column("sync_run_units", sa.Column("lease_owner", sa.Text(), nullable=True))
-    op.add_column(
+    _add_column_if_missing(
+        "sync_run_units", sa.Column("lease_owner", sa.Text(), nullable=True)
+    )
+    _add_column_if_missing(
         "sync_run_units",
         sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True),
     )
-    op.add_column(
+    _add_column_if_missing(
         "sync_run_units",
         sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True),
     )
@@ -49,6 +56,23 @@ def downgrade() -> None:
             postgresql_concurrently=True,
             if_exists=True,
         )
-    op.drop_column("sync_run_units", "last_heartbeat_at")
-    op.drop_column("sync_run_units", "lease_expires_at")
-    op.drop_column("sync_run_units", "lease_owner")
+    _drop_column_if_present("sync_run_units", "last_heartbeat_at")
+    _drop_column_if_present("sync_run_units", "lease_expires_at")
+    _drop_column_if_present("sync_run_units", "lease_owner")
+
+
+def _add_column_if_missing(table_name: str, column: sa.Column) -> None:
+    existing_columns = _column_names(table_name)
+    if column.name not in existing_columns:
+        op.add_column(table_name, column)
+
+
+def _drop_column_if_present(table_name: str, column_name: str) -> None:
+    existing_columns = _column_names(table_name)
+    if column_name in existing_columns:
+        op.drop_column(table_name, column_name)
+
+
+def _column_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    return {column["name"] for column in sa.inspect(bind).get_columns(table_name)}

--- a/src/dev_health_ops/alembic/versions/0019_add_sync_unit_lease_columns.py
+++ b/src/dev_health_ops/alembic/versions/0019_add_sync_unit_lease_columns.py
@@ -31,18 +31,22 @@ def upgrade() -> None:
         "sync_run_units",
         sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True),
     )
-    op.create_index(
-        "ix_sync_run_units_bucket_status_lease",
-        "sync_run_units",
-        ["org_id", "provider", "cost_class", "status", "lease_expires_at"],
-    )
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_sync_run_units_bucket_status_lease",
+            "sync_run_units",
+            ["org_id", "provider", "cost_class", "status", "lease_expires_at"],
+            postgresql_concurrently=True,
+        )
 
 
 def downgrade() -> None:
-    op.drop_index(
-        "ix_sync_run_units_bucket_status_lease",
-        table_name="sync_run_units",
-    )
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_sync_run_units_bucket_status_lease",
+            table_name="sync_run_units",
+            postgresql_concurrently=True,
+        )
     op.drop_column("sync_run_units", "last_heartbeat_at")
     op.drop_column("sync_run_units", "lease_expires_at")
     op.drop_column("sync_run_units", "lease_owner")

--- a/src/dev_health_ops/alembic/versions/0019_add_sync_unit_lease_columns.py
+++ b/src/dev_health_ops/alembic/versions/0019_add_sync_unit_lease_columns.py
@@ -37,6 +37,7 @@ def upgrade() -> None:
             "sync_run_units",
             ["org_id", "provider", "cost_class", "status", "lease_expires_at"],
             postgresql_concurrently=True,
+            if_not_exists=True,
         )
 
 
@@ -46,6 +47,7 @@ def downgrade() -> None:
             "ix_sync_run_units_bucket_status_lease",
             table_name="sync_run_units",
             postgresql_concurrently=True,
+            if_exists=True,
         )
     op.drop_column("sync_run_units", "last_heartbeat_at")
     op.drop_column("sync_run_units", "lease_expires_at")

--- a/src/dev_health_ops/alembic/versions/0019_add_sync_unit_lease_columns.py
+++ b/src/dev_health_ops/alembic/versions/0019_add_sync_unit_lease_columns.py
@@ -2,8 +2,27 @@
 
 Retry safety: the lease columns are guarded individually so a rerun after a
 partial failure between column creation and concurrent index creation can resume
-instead of failing on duplicate columns. The downgrade mirrors this by dropping
-columns only when present.
+instead of failing on duplicate columns.
+
+Concurrent-index retry safety: a ``CREATE INDEX CONCURRENTLY`` that fails midway
+leaves an INVALID index of the same name, and a plain
+``CREATE INDEX CONCURRENTLY IF NOT EXISTS`` would then silently SKIP it -- so the
+index would never actually be built on retry. The upgrade therefore drops any
+leftover index of that name with ``DROP INDEX CONCURRENTLY IF EXISTS`` (a no-op
+when absent) before creating, guaranteeing a retry always yields a VALID index.
+The downgrade mirrors the column handling by dropping columns only when present.
+
+Invalid-index retry proof (manual, requires Postgres -- not exercised by the
+SQLite test suite):
+  1. Plant a leftover INVALID index of the target name:
+       UPDATE pg_index SET indisvalid = false
+        WHERE indexrelid =
+          'ix_sync_run_units_bucket_status_lease'::regclass;
+  2. Run ``alembic upgrade head``.
+  3. Confirm the index is VALID again:
+       SELECT indisvalid FROM pg_index
+        WHERE indexrelid =
+          'ix_sync_run_units_bucket_status_lease'::regclass;  -- expect t
 
 Revision ID: 0019
 Revises: 0018
@@ -39,6 +58,14 @@ def upgrade() -> None:
         sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True),
     )
     with op.get_context().autocommit_block():
+        # Drop any leftover index of this name first.  A prior
+        # CREATE INDEX CONCURRENTLY that failed midway leaves an INVALID index;
+        # CREATE INDEX CONCURRENTLY IF NOT EXISTS would silently skip it and never
+        # rebuild it.  DROP INDEX CONCURRENTLY IF EXISTS is a no-op when absent, so
+        # this keeps the migration rerun-safe while guaranteeing a VALID index.
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_sync_run_units_bucket_status_lease"
+        )
         op.create_index(
             "ix_sync_run_units_bucket_status_lease",
             "sync_run_units",

--- a/src/dev_health_ops/alembic/versions/0019_add_sync_unit_lease_columns.py
+++ b/src/dev_health_ops/alembic/versions/0019_add_sync_unit_lease_columns.py
@@ -1,0 +1,48 @@
+"""Add sync run unit lease columns.
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-06-20 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0019"
+down_revision: str | None = "0018"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    op.add_column("sync_run_units", sa.Column("lease_owner", sa.Text(), nullable=True))
+    op.add_column(
+        "sync_run_units",
+        sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "sync_run_units",
+        sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_sync_run_units_bucket_status_lease",
+        "sync_run_units",
+        ["org_id", "provider", "cost_class", "status", "lease_expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_sync_run_units_bucket_status_lease",
+        table_name="sync_run_units",
+    )
+    op.drop_column("sync_run_units", "last_heartbeat_at")
+    op.drop_column("sync_run_units", "lease_expires_at")
+    op.drop_column("sync_run_units", "lease_owner")

--- a/src/dev_health_ops/models/integrations.py
+++ b/src/dev_health_ops/models/integrations.py
@@ -238,6 +238,13 @@ class SyncRunUnit(Base):
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
     result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     processor_flags: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    lease_owner: Mapped[str | None] = mapped_column(Text, nullable=True)
+    lease_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_heartbeat_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
@@ -257,6 +264,14 @@ class SyncRunUnit(Base):
         Index("ix_sync_run_units_run_status", "sync_run_id", "status"),
         Index("ix_sync_run_units_source_id", "source_id"),
         Index("ix_sync_run_units_dataset_key", "dataset_key"),
+        Index(
+            "ix_sync_run_units_bucket_status_lease",
+            "org_id",
+            "provider",
+            "cost_class",
+            "status",
+            "lease_expires_at",
+        ),
     )
 
 

--- a/src/dev_health_ops/sync/guard.py
+++ b/src/dev_health_ops/sync/guard.py
@@ -28,13 +28,13 @@ slot right now, across ALL runs (including the current run).  These reduce
 ``allowed_slots``:
 
 * status == DISPATCHING  AND  updated_at > stale_dispatch_cutoff  (fresh)
-* status == RUNNING  (any age — no heartbeat, so stale threshold is not safe)
+* status == RUNNING  AND  (lease_expires_at IS NULL OR lease_expires_at > now)
 * status == RETRYING  AND  updated_at > stale_running_cutoff  (fresh)
 
-RUNNING always counts regardless of updated_at because run_sync_unit does not
-heartbeat during the provider call.  Reclaiming a stale RUNNING unit would
-cause duplicate provider writes (F2).  Durable dead-worker recovery (heartbeat
-+ lease) is a separate follow-up (CHAOS-2577).
+RUNNING is split by lease state. A NULL lease is unknown/pre-migration and
+therefore LIVE. Only an explicit expired lease proves the worker is dead; those
+units no longer consume capacity and are transitioned to FAILED by the
+reconciler. Stale updated_at alone is never proof of death.
 
 **Candidate set** — units from THIS run that ``_claim_units`` can enqueue this
 pass.  Mirrors ``_claim_units`` claim + reclaim logic exactly:
@@ -43,7 +43,7 @@ pass.  Mirrors ``_claim_units`` claim + reclaim logic exactly:
 * status == DISPATCHING  AND  updated_at <= stale_dispatch_cutoff  (stale reclaim)
 
 Fresh DISPATCHING is NOT a candidate (it is a consumer).
-RUNNING is NOT a candidate (never reclaimed — F2 fix).
+RUNNING is NOT a candidate (expired leases are terminalized, not requeued).
 Stale RETRYING is NOT a candidate (``_claim_units`` does not reclaim RETRYING).
 
 The two sets are disjoint by construction — no subtraction is needed or
@@ -190,15 +190,11 @@ class DispatchGuard:
             # Count the CAPACITY-CONSUMER set across ALL runs (including this
             # run) for this bucket.  Consumers are:
             #   • fresh DISPATCHING: updated_at > stale_dispatch_cutoff
-            #   • ALL RUNNING (any age) — no heartbeat, so stale threshold is
-            #     not safe to use; reclaiming would cause duplicate writes (F2)
+            #   • live RUNNING: lease_expires_at is NULL (unknown/pre-migration)
+            #     or lease_expires_at > now
             #   • fresh RETRYING: updated_at > stale_running_cutoff
             # No subtraction is performed; the consumer and candidate sets are
             # disjoint by construction.
-            #
-            # INTERIM: a capped run whose only blocker is a DEAD RUNNING unit
-            # may stall — acceptable, preserves at-most-once provider execution.
-            # The heartbeat/lease follow-up (CHAOS-2577) adds safe recovery.
             active_count = (
                 session.query(func.count(SyncRunUnit.id))
                 .filter(
@@ -210,7 +206,13 @@ class DispatchGuard:
                             (SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value)
                             & (SyncRunUnit.updated_at > stale_dispatch_cutoff)
                         )
-                        | (SyncRunUnit.status == SyncRunUnitStatus.RUNNING.value)
+                        | (
+                            (SyncRunUnit.status == SyncRunUnitStatus.RUNNING.value)
+                            & (
+                                SyncRunUnit.lease_expires_at.is_(None)
+                                | (SyncRunUnit.lease_expires_at > now)
+                            )
+                        )
                         | (
                             (SyncRunUnit.status == SyncRunUnitStatus.RETRYING.value)
                             & (SyncRunUnit.updated_at > stale_running_cutoff)

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -150,6 +150,11 @@ beat_schedule = {
         "schedule": crontab(hour=3, minute=0),
         "options": {"queue": "sync"},
     },
+    "reconcile-sync-dispatch": {
+        "task": "dev_health_ops.workers.tasks.reconcile_sync_dispatch",
+        "schedule": 60.0,
+        "options": {"queue": "sync"},
+    },
     "run-capacity-forecast": {
         "task": "dev_health_ops.workers.tasks.run_capacity_forecast_job",
         "schedule": crontab(hour=4, minute=0, day_of_week="monday"),

--- a/src/dev_health_ops/workers/sync_reconciler.py
+++ b/src/dev_health_ops/workers/sync_reconciler.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import update
+
+from dev_health_ops.models import SyncRunUnit, SyncRunUnitStatus
+from dev_health_ops.sync.guard import _acquire_bucket_advisory_locks
+from dev_health_ops.workers.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    queue="sync", name="dev_health_ops.workers.tasks.reconcile_sync_dispatch"
+)
+def reconcile_sync_dispatch(limit: int = 100) -> dict[str, Any]:
+    from dev_health_ops.db import get_postgres_session_sync
+    from dev_health_ops.workers.sync_units import (
+        _stale_dispatch_seconds,
+        dispatch_sync_run,
+        finalize_sync_run,
+    )
+
+    now = datetime.now(timezone.utc)
+    stale_dispatch_cutoff = now - timedelta(seconds=_stale_dispatch_seconds())
+    with get_postgres_session_sync() as session:
+        expired_units = (
+            session.query(SyncRunUnit)
+            .filter(
+                SyncRunUnit.status == SyncRunUnitStatus.RUNNING.value,
+                SyncRunUnit.lease_owner.is_not(None),
+                SyncRunUnit.lease_expires_at.is_not(None),
+                SyncRunUnit.lease_expires_at <= now,
+            )
+            .order_by(SyncRunUnit.lease_expires_at.asc(), SyncRunUnit.id.asc())
+            .limit(max(1, int(limit)))
+            .all()
+        )
+        buckets = sorted(
+            {
+                (str(unit.org_id), str(unit.provider), str(unit.cost_class))
+                for unit in expired_units
+            }
+        )
+        _acquire_bucket_advisory_locks(session, buckets)
+        expired_run_ids: set[uuid.UUID] = set()
+        expired_count = 0
+        for unit in expired_units:
+            result: Any = session.execute(
+                update(SyncRunUnit)
+                .where(
+                    SyncRunUnit.id == unit.id,
+                    SyncRunUnit.status == SyncRunUnitStatus.RUNNING.value,
+                    SyncRunUnit.lease_owner.is_not(None),
+                    SyncRunUnit.lease_expires_at.is_not(None),
+                    SyncRunUnit.lease_expires_at <= now,
+                )
+                .values(
+                    status=SyncRunUnitStatus.FAILED.value,
+                    error="sync unit lease expired",
+                    result={
+                        "error_category": "worker_lost",
+                        "lease_expired_at": now.isoformat(),
+                    },
+                    updated_at=now,
+                    lease_owner=None,
+                    lease_expires_at=None,
+                )
+                .execution_options(synchronize_session=False)
+            )
+            if int(result.rowcount or 0) > 0:
+                expired_count += 1
+                expired_run_ids.add(unit.sync_run_id)
+        session.flush()
+        session.expire_all()
+        dispatch_run_ids: set[str] = set()
+        finalize_run_ids: set[str] = set()
+        for run_id in expired_run_ids:
+            units = (
+                session.query(SyncRunUnit)
+                .filter(SyncRunUnit.sync_run_id == run_id)
+                .all()
+            )
+            has_dispatchable = any(
+                unit.status == SyncRunUnitStatus.PLANNED.value
+                or (
+                    unit.status == SyncRunUnitStatus.DISPATCHING.value
+                    and _as_aware(unit.updated_at) <= stale_dispatch_cutoff
+                )
+                for unit in units
+            )
+            all_terminal = all(
+                unit.status
+                in {SyncRunUnitStatus.SUCCESS.value, SyncRunUnitStatus.FAILED.value}
+                for unit in units
+            )
+            if has_dispatchable:
+                dispatch_run_ids.add(str(run_id))
+            elif all_terminal:
+                finalize_run_ids.add(str(run_id))
+
+    dispatched = _enqueue_dispatches(dispatch_sync_run, dispatch_run_ids)
+    finalized = _enqueue_finalizers(finalize_sync_run, finalize_run_ids)
+    return {
+        "expired_units": expired_count,
+        "dispatches_enqueued": dispatched,
+        "finalizers_enqueued": finalized,
+    }
+
+
+def _enqueue_dispatches(task, run_ids: set[str]) -> int:
+    count = 0
+    for run_id in sorted(run_ids):
+        try:
+            getattr(task, "apply_async")(args=(run_id,), queue="sync")
+            count += 1
+        except Exception:
+            logger.exception(
+                "reconcile_sync_dispatch.dispatch_enqueue_failed",
+                extra={"sync_run_id": run_id},
+            )
+    return count
+
+
+def _enqueue_finalizers(task, run_ids: set[str]) -> int:
+    count = 0
+    for run_id in sorted(run_ids):
+        try:
+            getattr(task, "apply_async")(args=(run_id,), queue="sync")
+            count += 1
+        except Exception:
+            logger.exception(
+                "reconcile_sync_dispatch.finalize_enqueue_failed",
+                extra={"sync_run_id": run_id},
+            )
+    return count
+
+
+def _as_aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+__all__ = ["reconcile_sync_dispatch"]

--- a/src/dev_health_ops/workers/sync_reconciler.py
+++ b/src/dev_health_ops/workers/sync_reconciler.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from sqlalchemy import update
+from sqlalchemy import select, update
 
 from dev_health_ops.models import SyncRun, SyncRunStatus, SyncRunUnit, SyncRunUnitStatus
 from dev_health_ops.sync.guard import _acquire_bucket_advisory_locks
@@ -50,14 +50,17 @@ def reconcile_sync_dispatch(limit: int = 100) -> dict[str, Any]:
         expired_run_ids: set[uuid.UUID] = set()
         expired_count = 0
         for unit in expired_units:
+            observed_lease_owner = unit.lease_owner
             result: Any = session.execute(
                 update(SyncRunUnit)
                 .where(
                     SyncRunUnit.id == unit.id,
                     SyncRunUnit.status == SyncRunUnitStatus.RUNNING.value,
+                    SyncRunUnit.lease_owner == observed_lease_owner,
                     SyncRunUnit.lease_owner.is_not(None),
                     SyncRunUnit.lease_expires_at.is_not(None),
                     SyncRunUnit.lease_expires_at <= now,
+                    SyncRunUnit.sync_run_id.in_(_nonterminal_run_ids_select()),
                 )
                 .values(
                     status=SyncRunUnitStatus.FAILED.value,
@@ -205,6 +208,10 @@ _TERMINAL_RUN_STATUSES = {
     SyncRunStatus.PARTIAL_FAILED.value,
     SyncRunStatus.FAILED.value,
 }
+
+
+def _nonterminal_run_ids_select():
+    return select(SyncRun.id).where(SyncRun.status.not_in(_TERMINAL_RUN_STATUSES))
 
 
 __all__ = ["reconcile_sync_dispatch"]

--- a/src/dev_health_ops/workers/sync_reconciler.py
+++ b/src/dev_health_ops/workers/sync_reconciler.py
@@ -137,25 +137,33 @@ def _dispatchable_run_ids(
 
 
 def _finalizable_run_ids(session, limit: int) -> set[str]:
-    runs = (
-        session.query(SyncRun)
+    terminal_statuses = {
+        SyncRunUnitStatus.SUCCESS.value,
+        SyncRunUnitStatus.FAILED.value,
+    }
+    unit_exists = (
+        session.query(SyncRunUnit.id)
+        .filter(SyncRunUnit.sync_run_id == SyncRun.id)
+        .exists()
+    )
+    nonterminal_unit_exists = (
+        session.query(SyncRunUnit.id)
+        .filter(
+            SyncRunUnit.sync_run_id == SyncRun.id,
+            SyncRunUnit.status.not_in(terminal_statuses),
+        )
+        .exists()
+    )
+    rows = (
+        session.query(SyncRun.id)
         .filter(SyncRun.status.not_in(_TERMINAL_RUN_STATUSES))
+        .filter(unit_exists)
+        .filter(~nonterminal_unit_exists)
         .order_by(SyncRun.created_at.asc(), SyncRun.id.asc())
         .limit(max(1, int(limit)))
         .all()
     )
-    run_ids: set[str] = set()
-    for run in runs:
-        units = (
-            session.query(SyncRunUnit).filter(SyncRunUnit.sync_run_id == run.id).all()
-        )
-        if units and all(
-            unit.status
-            in {SyncRunUnitStatus.SUCCESS.value, SyncRunUnitStatus.FAILED.value}
-            for unit in units
-        ):
-            run_ids.add(str(run.id))
-    return run_ids
+    return {str(run_id) for (run_id,) in rows}
 
 
 def _enqueue_dispatches(task, run_ids: set[str]) -> int:

--- a/src/dev_health_ops/workers/sync_reconciler.py
+++ b/src/dev_health_ops/workers/sync_reconciler.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from sqlalchemy import update
 
-from dev_health_ops.models import SyncRunUnit, SyncRunUnitStatus
+from dev_health_ops.models import SyncRun, SyncRunStatus, SyncRunUnit, SyncRunUnitStatus
 from dev_health_ops.sync.guard import _acquire_bucket_advisory_locks
 from dev_health_ops.workers.celery_app import celery_app
 
@@ -77,8 +77,8 @@ def reconcile_sync_dispatch(limit: int = 100) -> dict[str, Any]:
                 expired_run_ids.add(unit.sync_run_id)
         session.flush()
         session.expire_all()
-        dispatch_run_ids: set[str] = set()
-        finalize_run_ids: set[str] = set()
+        dispatch_run_ids = _dispatchable_run_ids(session, stale_dispatch_cutoff, limit)
+        finalize_run_ids = _finalizable_run_ids(session, limit)
         for run_id in expired_run_ids:
             units = (
                 session.query(SyncRunUnit)
@@ -110,6 +110,52 @@ def reconcile_sync_dispatch(limit: int = 100) -> dict[str, Any]:
         "dispatches_enqueued": dispatched,
         "finalizers_enqueued": finalized,
     }
+
+
+def _dispatchable_run_ids(
+    session, stale_dispatch_cutoff: datetime, limit: int
+) -> set[str]:
+    rows = (
+        session.query(SyncRunUnit.sync_run_id)
+        .join(SyncRun, SyncRun.id == SyncRunUnit.sync_run_id)
+        .filter(
+            SyncRun.status.not_in(_TERMINAL_RUN_STATUSES),
+            (
+                (SyncRunUnit.status == SyncRunUnitStatus.PLANNED.value)
+                | (
+                    (SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value)
+                    & (SyncRunUnit.updated_at <= stale_dispatch_cutoff)
+                )
+            ),
+        )
+        .distinct()
+        .order_by(SyncRunUnit.sync_run_id.asc())
+        .limit(max(1, int(limit)))
+        .all()
+    )
+    return {str(run_id) for (run_id,) in rows}
+
+
+def _finalizable_run_ids(session, limit: int) -> set[str]:
+    runs = (
+        session.query(SyncRun)
+        .filter(SyncRun.status.not_in(_TERMINAL_RUN_STATUSES))
+        .order_by(SyncRun.created_at.asc(), SyncRun.id.asc())
+        .limit(max(1, int(limit)))
+        .all()
+    )
+    run_ids: set[str] = set()
+    for run in runs:
+        units = (
+            session.query(SyncRunUnit).filter(SyncRunUnit.sync_run_id == run.id).all()
+        )
+        if units and all(
+            unit.status
+            in {SyncRunUnitStatus.SUCCESS.value, SyncRunUnitStatus.FAILED.value}
+            for unit in units
+        ):
+            run_ids.add(str(run.id))
+    return run_ids
 
 
 def _enqueue_dispatches(task, run_ids: set[str]) -> int:
@@ -144,6 +190,13 @@ def _as_aware(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc)
+
+
+_TERMINAL_RUN_STATUSES = {
+    SyncRunStatus.SUCCESS.value,
+    SyncRunStatus.PARTIAL_FAILED.value,
+    SyncRunStatus.FAILED.value,
+}
 
 
 __all__ = ["reconcile_sync_dispatch"]

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -856,24 +856,28 @@ def _fail_planned_units(session, run_uuid: uuid.UUID, error: str) -> int:
 def _fail_stale_dispatching_units(session, run_uuid: uuid.UUID, error: str) -> int:
     now = datetime.now(timezone.utc)
     stale_dispatch_cutoff = now - timedelta(seconds=_stale_dispatch_seconds())
-    stale_units = (
-        session.query(SyncRunUnit)
-        .filter(
+    # Write-time CAS (NOT load-and-mutate): the ``status == 'dispatching'`` predicate
+    # is evaluated by the database at UPDATE time, so a stale row that a delayed
+    # ``run_sync_unit`` concurrently claimed to RUNNING (DISPATCHING->RUNNING + live
+    # lease) between our read and write is EXCLUDED -- we never overwrite a live
+    # worker's claim with FAILED.  ``updated_at <= cutoff`` scopes to genuinely stale
+    # rows exactly as the prior load-and-mutate did, still scoped to this run.
+    result = session.execute(
+        update(SyncRunUnit)
+        .where(
             SyncRunUnit.sync_run_id == run_uuid,
             SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value,
+            SyncRunUnit.updated_at <= stale_dispatch_cutoff,
         )
-        .all()
+        .values(
+            status=SyncRunUnitStatus.FAILED.value,
+            error=error,
+            result={"error_category": "dispatch_denied"},
+            updated_at=now,
+        )
+        .execution_options(synchronize_session=False)
     )
-    failed = 0
-    for unit in stale_units:
-        if _as_aware(unit.updated_at) > stale_dispatch_cutoff:
-            continue
-        unit.status = SyncRunUnitStatus.FAILED.value
-        unit.error = error
-        unit.result = {"error_category": "dispatch_denied"}
-        unit.updated_at = now
-        failed += 1
-    return failed
+    return int(result.rowcount or 0)
 
 
 def _enqueue_denied_active_finalize(sync_run_id: str) -> None:
@@ -968,47 +972,6 @@ def _claim_units(
         .order_by(SyncRunUnit.id)
         .all()
     )
-
-
-def _mark_dispatch_enqueue_failed(sync_run_id: str, error: str) -> None:
-    from dev_health_ops.db import get_postgres_session_sync
-
-    completed_at = datetime.now(timezone.utc)
-    run_uuid = uuid.UUID(str(sync_run_id))
-    with get_postgres_session_sync() as session:
-        run = session.query(SyncRun).filter(SyncRun.id == run_uuid).one_or_none()
-        if run is None:
-            return
-        run.status = SyncRunStatus.FAILED.value
-        run.completed_at = completed_at
-        run.error = error
-        run.result = {"error": error, "phase": "dispatch_enqueue"}
-        units = (
-            session.query(SyncRunUnit).filter(SyncRunUnit.sync_run_id == run_uuid).all()
-        )
-        for unit in units:
-            if unit.status not in {
-                SyncRunUnitStatus.SUCCESS.value,
-                SyncRunUnitStatus.FAILED.value,
-            }:
-                unit.status = SyncRunUnitStatus.FAILED.value
-                unit.error = error
-                unit.updated_at = completed_at
-        run.completed_units = sum(
-            1 for unit in units if unit.status == SyncRunUnitStatus.SUCCESS.value
-        )
-        run.failed_units = sum(
-            1 for unit in units if unit.status == SyncRunUnitStatus.FAILED.value
-        )
-        stamp_sync_run_canonical_config(
-            session,
-            run,
-            completed_at=completed_at,
-            success=False,
-            error=error,
-            stats={"error": error, "phase": "dispatch_enqueue"},
-        )
-        session.flush()
 
 
 def _load_unit(session, unit_id: str) -> SyncRunUnit:

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -360,13 +360,30 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                 }
             lease_owner = str(uuid.uuid4())
             lease_expires_at = started_at + timedelta(seconds=_running_lease_seconds())
-            unit.status = SyncRunUnitStatus.RUNNING.value
-            unit.attempts = int(unit.attempts or 0) + 1
-            unit.error = None
-            unit.lease_owner = lease_owner
-            unit.lease_expires_at = lease_expires_at
-            unit.last_heartbeat_at = started_at
+            claim_result: Any = session.execute(
+                update(SyncRunUnit)
+                .where(
+                    SyncRunUnit.id == unit.id,
+                    SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value,
+                )
+                .values(
+                    status=SyncRunUnitStatus.RUNNING.value,
+                    attempts=SyncRunUnit.attempts + 1,
+                    error=None,
+                    lease_owner=lease_owner,
+                    lease_expires_at=lease_expires_at,
+                    last_heartbeat_at=started_at,
+                )
+                .execution_options(synchronize_session=False)
+            )
+            if int(claim_result.rowcount or 0) == 0:
+                return {
+                    "status": "skipped",
+                    "unit_id": unit_id,
+                    "reason": "not_dispatchable",
+                }
             session.flush()
+            session.refresh(unit)
             should_finalize = True
             _log_ctx = {
                 "sync_run_id": ctx.sync_run_id,

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -44,7 +44,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from celery import chord, group
-from sqlalchemy import update
+from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 
 from dev_health_ops.models import (
@@ -335,6 +335,7 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
     should_finalize = False
     started_at = datetime.now(timezone.utc)
     lease_owner: str | None = None
+    terminal_txn_started = False
     heartbeat_stop: threading.Event | None = None
     heartbeat_thread: threading.Thread | None = None
     # Unit context fields for structured logging — populated once ctx is loaded.
@@ -342,6 +343,7 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
     try:
         with get_postgres_session_sync() as session:
             unit = _load_unit(session, unit_id)
+            sync_run_id = str(unit.sync_run_id)
             run = (
                 session.query(SyncRun)
                 .filter(SyncRun.id == unit.sync_run_id)
@@ -363,6 +365,7 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                 .where(
                     SyncRunUnit.id == unit.id,
                     SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value,
+                    SyncRunUnit.sync_run_id.in_(_nonterminal_run_ids_select()),
                 )
                 .values(
                     status=SyncRunUnitStatus.RUNNING.value,
@@ -371,6 +374,7 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     lease_owner=lease_owner,
                     lease_expires_at=lease_expires_at,
                     last_heartbeat_at=started_at,
+                    updated_at=started_at,
                 )
                 .execution_options(synchronize_session=False)
             )
@@ -381,8 +385,6 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     "reason": "not_dispatchable",
                 }
             session.flush()
-            session.refresh(unit)
-            should_finalize = True
 
         with get_postgres_session_sync() as session:
             ctx = SyncTaskBootstrap.load(session, unit_id)
@@ -406,35 +408,36 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
 
         completed_at = datetime.now(timezone.utc)
         duration_seconds = max(0, int((completed_at - started_at).total_seconds()))
+        terminal_txn_started = True
         with get_postgres_session_sync() as session:
-            unit = _load_unit(session, unit_id)
-            run = (
-                session.query(SyncRun)
-                .filter(SyncRun.id == unit.sync_run_id)
-                .one_or_none()
+            terminal_result: Any = session.execute(
+                update(SyncRunUnit)
+                .where(
+                    SyncRunUnit.id == uuid.UUID(str(unit_id)),
+                    SyncRunUnit.status == SyncRunUnitStatus.RUNNING.value,
+                    SyncRunUnit.lease_owner == lease_owner,
+                    SyncRunUnit.lease_expires_at.is_not(None),
+                    SyncRunUnit.lease_expires_at > completed_at,
+                    SyncRunUnit.sync_run_id.in_(_nonterminal_run_ids_select()),
+                )
+                .values(
+                    status=SyncRunUnitStatus.SUCCESS.value,
+                    duration_seconds=duration_seconds,
+                    result=dict(result or {}),
+                    error=None,
+                    lease_owner=None,
+                    lease_expires_at=None,
+                    last_heartbeat_at=completed_at,
+                    updated_at=completed_at,
+                )
+                .execution_options(synchronize_session=False)
             )
-            if unit.status in {
-                SyncRunUnitStatus.SUCCESS.value,
-                SyncRunUnitStatus.FAILED.value,
-            } or (run is not None and run.status in _TERMINAL_RUN_STATUSES):
-                return {
-                    "status": "skipped",
-                    "unit_id": unit_id,
-                    "reason": "terminal",
-                }
-            if not _unit_lease_is_owned_and_live(unit, lease_owner, completed_at):
+            if int(terminal_result.rowcount or 0) == 0:
                 return {
                     "status": "skipped",
                     "unit_id": unit_id,
                     "reason": "lease_lost",
                 }
-            unit.status = SyncRunUnitStatus.SUCCESS.value
-            unit.duration_seconds = duration_seconds
-            unit.result = dict(result or {})
-            unit.error = None
-            unit.lease_owner = None
-            unit.lease_expires_at = None
-            unit.last_heartbeat_at = completed_at
             if ctx.mode in {
                 SyncRunMode.INCREMENTAL.value,
                 SyncRunMode.FULL_RESYNC.value,  # full_resync stamps watermark on success
@@ -447,6 +450,8 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     started_at,
                 )
             session.flush()
+            should_finalize = True
+        terminal_txn_started = False
         logger.info(
             "run_sync_unit.success",
             extra={**_log_ctx, "duration_seconds": duration_seconds},
@@ -457,43 +462,44 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
             "duration_seconds": duration_seconds,
         }
     except Exception as exc:
+        if terminal_txn_started:
+            raise
         completed_at = datetime.now(timezone.utc)
         duration_seconds = max(0, int((completed_at - started_at).total_seconds()))
         error_category = _classify_error(exc)
+        terminal_txn_started = True
         with get_postgres_session_sync() as session:
-            unit = _load_unit(session, unit_id)
-            sync_run_id = str(unit.sync_run_id)
-            run = (
-                session.query(SyncRun)
-                .filter(SyncRun.id == unit.sync_run_id)
-                .one_or_none()
+            terminal_result = session.execute(
+                update(SyncRunUnit)
+                .where(
+                    SyncRunUnit.id == uuid.UUID(str(unit_id)),
+                    SyncRunUnit.status == SyncRunUnitStatus.RUNNING.value,
+                    SyncRunUnit.lease_owner == lease_owner,
+                    SyncRunUnit.lease_expires_at.is_not(None),
+                    SyncRunUnit.lease_expires_at > completed_at,
+                    SyncRunUnit.sync_run_id.in_(_nonterminal_run_ids_select()),
+                )
+                .values(
+                    status=SyncRunUnitStatus.FAILED.value,
+                    duration_seconds=duration_seconds,
+                    error=str(exc),
+                    result={"error_category": error_category},
+                    lease_owner=None,
+                    lease_expires_at=None,
+                    last_heartbeat_at=completed_at,
+                    updated_at=completed_at,
+                )
+                .execution_options(synchronize_session=False)
             )
-            if unit.status in {
-                SyncRunUnitStatus.SUCCESS.value,
-                SyncRunUnitStatus.FAILED.value,
-            } or (run is not None and run.status in _TERMINAL_RUN_STATUSES):
-                return {
-                    "status": "skipped",
-                    "unit_id": unit_id,
-                    "reason": "terminal",
-                }
-            if lease_owner is not None and not _unit_lease_is_owned_and_live(
-                unit, lease_owner, completed_at
-            ):
+            if int(terminal_result.rowcount or 0) == 0:
                 return {
                     "status": "skipped",
                     "unit_id": unit_id,
                     "reason": "lease_lost",
                 }
-            unit.status = SyncRunUnitStatus.FAILED.value
-            unit.duration_seconds = duration_seconds
-            unit.error = str(exc)
-            unit.result = {"error_category": error_category}
-            unit.lease_owner = None
-            unit.lease_expires_at = None
-            unit.last_heartbeat_at = completed_at
             session.flush()
             should_finalize = True
+        terminal_txn_started = False
         logger.exception(
             "run_sync_unit.failed",
             extra={
@@ -863,6 +869,10 @@ def _load_unit(session, unit_id: str) -> SyncRunUnit:
     return unit
 
 
+def _nonterminal_run_ids_select():
+    return select(SyncRun.id).where(SyncRun.status.not_in(_TERMINAL_RUN_STATUSES))
+
+
 def _aggregate_run_status(
     total_count: int, success_count: int, failed_count: int
 ) -> str:
@@ -949,13 +959,14 @@ def _heartbeat_unit_lease(
         lease_expires_at = now + timedelta(seconds=lease_seconds)
         try:
             with get_postgres_session_sync() as session:
-                session.execute(
+                heartbeat_result: Any = session.execute(
                     update(SyncRunUnit)
                     .where(
                         SyncRunUnit.id == uuid.UUID(str(unit_id)),
                         SyncRunUnit.status == SyncRunUnitStatus.RUNNING.value,
                         SyncRunUnit.lease_owner == lease_owner,
                         SyncRunUnit.lease_expires_at > now,
+                        SyncRunUnit.sync_run_id.in_(_nonterminal_run_ids_select()),
                     )
                     .values(
                         lease_expires_at=lease_expires_at,
@@ -963,6 +974,12 @@ def _heartbeat_unit_lease(
                     )
                     .execution_options(synchronize_session=False)
                 )
+                if int(heartbeat_result.rowcount or 0) == 0:
+                    logger.info(
+                        "run_sync_unit.heartbeat_lease_lost",
+                        extra={"unit_id": unit_id},
+                    )
+                    stop_event.set()
         except Exception:
             logger.exception(
                 "run_sync_unit.heartbeat_failed",

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -943,25 +943,34 @@ def _claim_units(
     # A DISPATCHING unit that is stale means the worker was enqueued but never
     # picked up (e.g. broker restart).  It is safe to re-enqueue because the
     # worker never started the provider call.
+    #
+    # Atomic CAS: this single UPDATE re-checks status='dispatching' AND
+    # updated_at <= stale_dispatch at write time, so a row that a delayed
+    # run_sync_unit concurrently claimed to RUNNING is excluded by
+    # construction -- it can never be reclaimed/requeued, and no status
+    # rewrite of a RUNNING row is possible.  status stays DISPATCHING; only
+    # updated_at is refreshed so a later redispatch re-enqueues the unit.
     stale_dispatch = now - timedelta(seconds=_stale_dispatch_seconds())
-    reclaim_candidates = (
-        session.query(SyncRunUnit)
-        .filter(
-            SyncRunUnit.sync_run_id == run_uuid,
-            SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value,
+    stale_where = [
+        SyncRunUnit.sync_run_id == run_uuid,
+        SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value,
+        SyncRunUnit.updated_at <= stale_dispatch,
+        ~SyncRunUnit.id.in_(claimed_ids),
+    ]
+    if capped_ids:
+        stale_where.append(~SyncRunUnit.id.in_([uuid.UUID(cid) for cid in capped_ids]))
+    stale_reclaimed: set[uuid.UUID] = set(
+        session.execute(
+            update(SyncRunUnit)
+            .where(*stale_where)
+            .values(updated_at=now)
+            .returning(SyncRunUnit.id)
+            .execution_options(synchronize_session=False)
         )
+        .scalars()
         .all()
     )
-    for unit in reclaim_candidates:
-        if unit.id in claimed_ids:
-            continue
-        # Never reclaim a unit that the concurrency guard deferred.
-        if str(unit.id) in capped_ids:
-            continue
-        if _as_aware(unit.updated_at) <= stale_dispatch:
-            unit.status = SyncRunUnitStatus.DISPATCHING.value
-            unit.updated_at = now
-            claimed_ids.add(unit.id)
+    claimed_ids.update(stale_reclaimed)
 
     session.flush()
     if not claimed_ids:

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -341,8 +341,6 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
     _log_ctx: dict[str, Any] = {"unit_id": unit_id}
     try:
         with get_postgres_session_sync() as session:
-            ctx = SyncTaskBootstrap.load(session, unit_id)
-            sync_run_id = ctx.sync_run_id
             unit = _load_unit(session, unit_id)
             run = (
                 session.query(SyncRun)
@@ -385,6 +383,8 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
             session.flush()
             session.refresh(unit)
             should_finalize = True
+            ctx = SyncTaskBootstrap.load(session, unit_id)
+            sync_run_id = ctx.sync_run_id
             _log_ctx = {
                 "sync_run_id": ctx.sync_run_id,
                 "unit_id": unit_id,

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -36,6 +36,8 @@ Observability (CHAOS-2519):
 from __future__ import annotations
 
 import logging
+import os
+import threading
 import uuid
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
@@ -252,13 +254,13 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
         callback.set(queue="sync")
         try:
             chord(group(signatures), callback).apply_async()
-            # F4: schedule redispatch for capped units INSIDE the try block so
-            # any broker failure marks the run terminal rather than leaving
-            # PLANNED units stranded with no chord/finalizer pending.
             if capped_ids:
                 _schedule_redispatch(sync_run_id)
         except Exception as exc:
-            _mark_dispatch_enqueue_failed(sync_run_id, str(exc))
+            logger.exception(
+                "dispatch_sync_run.publish_failed",
+                extra={"sync_run_id": sync_run_id, "error": str(exc)},
+            )
             raise
         return {"status": "dispatched", "queued_units": len(signatures)}
 
@@ -285,13 +287,13 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
             .count()
         )
     if pending_count > 0:
-        # Deferred units remain — schedule countdown redispatch.
-        # F5: wrap in try/except so a broker failure marks the run terminal
-        # rather than leaving PLANNED units stranded with no follow-up.
         try:
             _schedule_redispatch(sync_run_id)
         except Exception as exc:
-            _mark_dispatch_enqueue_failed(sync_run_id, str(exc))
+            logger.exception(
+                "dispatch_sync_run.redispatch_publish_failed",
+                extra={"sync_run_id": sync_run_id, "error": str(exc)},
+            )
             raise
         logger.info(
             "dispatch_sync_run.noop",
@@ -332,6 +334,9 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
     sync_run_id: str | None = None
     should_finalize = False
     started_at = datetime.now(timezone.utc)
+    lease_owner: str | None = None
+    heartbeat_stop: threading.Event | None = None
+    heartbeat_thread: threading.Thread | None = None
     # Unit context fields for structured logging — populated once ctx is loaded.
     _log_ctx: dict[str, Any] = {"unit_id": unit_id}
     try:
@@ -353,9 +358,14 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     "unit_id": unit_id,
                     "reason": "terminal",
                 }
+            lease_owner = str(uuid.uuid4())
+            lease_expires_at = started_at + timedelta(seconds=_running_lease_seconds())
             unit.status = SyncRunUnitStatus.RUNNING.value
             unit.attempts = int(unit.attempts or 0) + 1
             unit.error = None
+            unit.lease_owner = lease_owner
+            unit.lease_expires_at = lease_expires_at
+            unit.last_heartbeat_at = started_at
             session.flush()
             should_finalize = True
             _log_ctx = {
@@ -368,6 +378,8 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
             }
 
         logger.info("run_sync_unit.started", extra=_log_ctx)
+
+        heartbeat_stop, heartbeat_thread = _start_unit_heartbeat(unit_id, lease_owner)
 
         runtime = _runtime_cache.get(ctx)
         result = run_dataset_unit(ctx, runtime)
@@ -390,10 +402,19 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     "unit_id": unit_id,
                     "reason": "terminal",
                 }
+            if not _unit_lease_is_owned_and_live(unit, lease_owner, completed_at):
+                return {
+                    "status": "skipped",
+                    "unit_id": unit_id,
+                    "reason": "lease_lost",
+                }
             unit.status = SyncRunUnitStatus.SUCCESS.value
             unit.duration_seconds = duration_seconds
             unit.result = dict(result or {})
             unit.error = None
+            unit.lease_owner = None
+            unit.lease_expires_at = None
+            unit.last_heartbeat_at = completed_at
             if ctx.mode in {
                 SyncRunMode.INCREMENTAL.value,
                 SyncRunMode.FULL_RESYNC.value,  # full_resync stamps watermark on success
@@ -436,10 +457,21 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     "unit_id": unit_id,
                     "reason": "terminal",
                 }
+            if lease_owner is not None and not _unit_lease_is_owned_and_live(
+                unit, lease_owner, completed_at
+            ):
+                return {
+                    "status": "skipped",
+                    "unit_id": unit_id,
+                    "reason": "lease_lost",
+                }
             unit.status = SyncRunUnitStatus.FAILED.value
             unit.duration_seconds = duration_seconds
             unit.error = str(exc)
             unit.result = {"error_category": error_category}
+            unit.lease_owner = None
+            unit.lease_expires_at = None
+            unit.last_heartbeat_at = completed_at
             session.flush()
             should_finalize = True
         logger.exception(
@@ -457,6 +489,10 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
             "error_category": error_category,
         }
     finally:
+        if heartbeat_stop is not None:
+            heartbeat_stop.set()
+        if heartbeat_thread is not None:
+            heartbeat_thread.join(timeout=2)
         if should_finalize and sync_run_id is not None:
             try:
                 getattr(finalize_sync_run, "apply_async")(
@@ -821,9 +857,7 @@ def _aggregate_run_status(
 
 def _stale_dispatch_seconds() -> int:
     try:
-        return max(
-            1, int(__import__("os").getenv("SYNC_UNIT_DISPATCH_STALE_SECONDS", "900"))
-        )
+        return max(1, int(os.getenv("SYNC_UNIT_DISPATCH_STALE_SECONDS", "900")))
     except ValueError:
         return 900
 
@@ -832,7 +866,7 @@ def _stale_running_seconds() -> int:
     try:
         return max(
             1,
-            int(__import__("os").getenv("SYNC_UNIT_RUNNING_STALE_SECONDS", "3600")),
+            int(os.getenv("SYNC_UNIT_RUNNING_STALE_SECONDS", "3600")),
         )
     except ValueError:
         return 3600
@@ -842,6 +876,78 @@ def _as_aware(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc)
+
+
+def _running_lease_seconds() -> int:
+    return _stale_running_seconds()
+
+
+def _heartbeat_interval_seconds() -> int:
+    return max(1, min(60, _running_lease_seconds() // 4))
+
+
+def _unit_lease_is_owned_and_live(
+    unit: SyncRunUnit,
+    lease_owner: str | None,
+    now: datetime,
+) -> bool:
+    if lease_owner is None or unit.lease_owner != lease_owner:
+        return False
+    if unit.lease_expires_at is None:
+        return False
+    return _as_aware(unit.lease_expires_at) > now
+
+
+def _start_unit_heartbeat(
+    unit_id: str,
+    lease_owner: str | None,
+) -> tuple[threading.Event, threading.Thread] | tuple[None, None]:
+    if lease_owner is None:
+        return None, None
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_heartbeat_unit_lease,
+        args=(unit_id, lease_owner, stop_event),
+        name=f"sync-unit-heartbeat-{unit_id}",
+        daemon=True,
+    )
+    thread.start()
+    return stop_event, thread
+
+
+def _heartbeat_unit_lease(
+    unit_id: str,
+    lease_owner: str,
+    stop_event: threading.Event,
+) -> None:
+    from dev_health_ops.db import get_postgres_session_sync
+
+    interval = _heartbeat_interval_seconds()
+    lease_seconds = _running_lease_seconds()
+    while not stop_event.wait(interval):
+        now = datetime.now(timezone.utc)
+        lease_expires_at = now + timedelta(seconds=lease_seconds)
+        try:
+            with get_postgres_session_sync() as session:
+                session.execute(
+                    update(SyncRunUnit)
+                    .where(
+                        SyncRunUnit.id == uuid.UUID(str(unit_id)),
+                        SyncRunUnit.status == SyncRunUnitStatus.RUNNING.value,
+                        SyncRunUnit.lease_owner == lease_owner,
+                        SyncRunUnit.lease_expires_at > now,
+                    )
+                    .values(
+                        lease_expires_at=lease_expires_at,
+                        last_heartbeat_at=now,
+                    )
+                    .execution_options(synchronize_session=False)
+                )
+        except Exception:
+            logger.exception(
+                "run_sync_unit.heartbeat_failed",
+                extra={"unit_id": unit_id},
+            )
 
 
 def _schedule_redispatch(sync_run_id: str) -> None:
@@ -854,7 +960,7 @@ def _schedule_redispatch(sync_run_id: str) -> None:
     Raises on broker enqueue failure so the caller can propagate the error
     rather than leaving the run silently non-terminal.
     """
-    countdown = int(__import__("os").getenv("SYNC_DISPATCH_REDISPATCH_COUNTDOWN", "60"))
+    countdown = int(os.getenv("SYNC_DISPATCH_REDISPATCH_COUNTDOWN", "60"))
     try:
         getattr(dispatch_sync_run, "apply_async")(
             args=(sync_run_id,),

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -383,8 +383,11 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
             session.flush()
             session.refresh(unit)
             should_finalize = True
+
+        with get_postgres_session_sync() as session:
             ctx = SyncTaskBootstrap.load(session, unit_id)
             sync_run_id = ctx.sync_run_id
+            unit = _load_unit(session, unit_id)
             _log_ctx = {
                 "sync_run_id": ctx.sync_run_id,
                 "unit_id": unit_id,

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -144,20 +144,42 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
 
         # --- Total-cap hard-deny: whole run is over the org unit ceiling ---
         if not decision.allowed:
-            completed_at = datetime.now(timezone.utc)
-            run.status = SyncRunStatus.FAILED.value
-            run.completed_at = completed_at
-            run.error = decision.reason or "sync dispatch denied"
-            run.result = {"capped_unit_ids": list(decision.capped_unit_ids)}
-            session.flush()
+            error = decision.reason or "sync dispatch denied"
+            if _run_has_dispatching_or_running_units(session, run_uuid):
+                failed_planned = _fail_planned_units(session, run_uuid, error)
+                session.flush()
+                logger.warning(
+                    "dispatch_sync_run.denied_with_active_units",
+                    extra={
+                        "sync_run_id": sync_run_id,
+                        "reason": error,
+                        "failed_planned_units": failed_planned,
+                    },
+                )
+            else:
+                completed_at = datetime.now(timezone.utc)
+                run.status = SyncRunStatus.FAILED.value
+                run.completed_at = completed_at
+                run.error = error
+                run.result = {"capped_unit_ids": list(decision.capped_unit_ids)}
+                session.flush()
+                logger.warning(
+                    "dispatch_sync_run.denied",
+                    extra={
+                        "sync_run_id": sync_run_id,
+                        "reason": run.error,
+                    },
+                )
+                return {"status": "denied", "reason": run.error}
+
+        if not decision.allowed:
             logger.warning(
-                "dispatch_sync_run.denied",
+                "dispatch_sync_run.continuing_after_denial_for_active_units",
                 extra={
                     "sync_run_id": sync_run_id,
-                    "reason": run.error,
+                    "reason": decision.reason or "sync dispatch denied",
                 },
             )
-            return {"status": "denied", "reason": run.error}
 
         # --- Concurrency partial-cap: defer overflow units, proceed with rest ---
         capped_ids: frozenset[str] = frozenset()
@@ -184,40 +206,52 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
                 inactive_child_configs[0] if inactive_child_configs else None
             )
         if inactive_config is not None:
-            completed_at = datetime.now(timezone.utc)
             error = "sync configuration is paused"
-            run.status = SyncRunStatus.FAILED.value
-            run.completed_at = completed_at
-            run.error = error
-            run.result = {"reason": "inactive_sync_configuration"}
-            session.query(SyncRunUnit).filter(
-                SyncRunUnit.sync_run_id == run_uuid,
-                SyncRunUnit.status == SyncRunUnitStatus.PLANNED.value,
-            ).update(
-                {
-                    SyncRunUnit.status: SyncRunUnitStatus.FAILED.value,
-                    SyncRunUnit.error: error,
-                    SyncRunUnit.updated_at: completed_at,
-                },
-                synchronize_session=False,
-            )
-            stamp_sync_run_canonical_config(
-                session,
-                run,
-                completed_at=completed_at,
-                success=False,
-                error=error,
-                stats={"reason": "inactive_sync_configuration"},
-            )
-            session.flush()
-            logger.warning(
-                "dispatch_sync_run.inactive_config",
-                extra={
-                    "sync_run_id": sync_run_id,
-                    "config_id": str(inactive_config.id),
-                },
-            )
-            return {"status": "denied", "reason": error}
+            if _run_has_dispatching_or_running_units(session, run_uuid):
+                failed_planned = _fail_planned_units(session, run_uuid, error)
+                session.flush()
+                logger.warning(
+                    "dispatch_sync_run.inactive_config_with_active_units",
+                    extra={
+                        "sync_run_id": sync_run_id,
+                        "config_id": str(inactive_config.id),
+                        "failed_planned_units": failed_planned,
+                    },
+                )
+            else:
+                completed_at = datetime.now(timezone.utc)
+                run.status = SyncRunStatus.FAILED.value
+                run.completed_at = completed_at
+                run.error = error
+                run.result = {"reason": "inactive_sync_configuration"}
+                session.query(SyncRunUnit).filter(
+                    SyncRunUnit.sync_run_id == run_uuid,
+                    SyncRunUnit.status == SyncRunUnitStatus.PLANNED.value,
+                ).update(
+                    {
+                        SyncRunUnit.status: SyncRunUnitStatus.FAILED.value,
+                        SyncRunUnit.error: error,
+                        SyncRunUnit.updated_at: completed_at,
+                    },
+                    synchronize_session=False,
+                )
+                stamp_sync_run_canonical_config(
+                    session,
+                    run,
+                    completed_at=completed_at,
+                    success=False,
+                    error=error,
+                    stats={"reason": "inactive_sync_configuration"},
+                )
+                session.flush()
+                logger.warning(
+                    "dispatch_sync_run.inactive_config",
+                    extra={
+                        "sync_run_id": sync_run_id,
+                        "config_id": str(inactive_config.id),
+                    },
+                )
+                return {"status": "denied", "reason": error}
 
         units = _claim_units(session, run_uuid, capped_ids=capped_ids)
         signatures = []
@@ -386,6 +420,8 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                 }
             session.flush()
 
+        heartbeat_stop, heartbeat_thread = _start_unit_heartbeat(unit_id, lease_owner)
+
         with get_postgres_session_sync() as session:
             ctx = SyncTaskBootstrap.load(session, unit_id)
             sync_run_id = ctx.sync_run_id
@@ -398,10 +434,31 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                 "provider": ctx.provider,
                 "cost_class": ctx.cost_class,
             }
+            now = datetime.now(timezone.utc)
+            live_lease_refresh: Any = session.execute(
+                update(SyncRunUnit)
+                .where(
+                    SyncRunUnit.id == uuid.UUID(str(unit_id)),
+                    SyncRunUnit.status == SyncRunUnitStatus.RUNNING.value,
+                    SyncRunUnit.lease_owner == lease_owner,
+                    SyncRunUnit.lease_expires_at.is_not(None),
+                    SyncRunUnit.lease_expires_at > now,
+                    SyncRunUnit.sync_run_id.in_(_nonterminal_run_ids_select()),
+                )
+                .values(
+                    lease_expires_at=now + timedelta(seconds=_running_lease_seconds()),
+                    last_heartbeat_at=now,
+                )
+                .execution_options(synchronize_session=False)
+            )
+            if int(live_lease_refresh.rowcount or 0) == 0:
+                return {
+                    "status": "skipped",
+                    "unit_id": unit_id,
+                    "reason": "lease_lost",
+                }
 
         logger.info("run_sync_unit.started", extra=_log_ctx)
-
-        heartbeat_stop, heartbeat_thread = _start_unit_heartbeat(unit_id, lease_owner)
 
         runtime = _runtime_cache.get(ctx)
         result = run_dataset_unit(ctx, runtime)
@@ -735,6 +792,43 @@ def finalize_sync_run(sync_run_id: str) -> dict[str, Any]:
         "failed_units": failed_count,
         "post_sync_targets": sorted(legacy_targets),
     }
+
+
+def _run_has_dispatching_or_running_units(session, run_uuid: uuid.UUID) -> bool:
+    return (
+        session.query(SyncRunUnit.id)
+        .filter(
+            SyncRunUnit.sync_run_id == run_uuid,
+            SyncRunUnit.status.in_(
+                {
+                    SyncRunUnitStatus.DISPATCHING.value,
+                    SyncRunUnitStatus.RUNNING.value,
+                }
+            ),
+        )
+        .first()
+        is not None
+    )
+
+
+def _fail_planned_units(session, run_uuid: uuid.UUID, error: str) -> int:
+    now = datetime.now(timezone.utc)
+    result = (
+        session.query(SyncRunUnit)
+        .filter(
+            SyncRunUnit.sync_run_id == run_uuid,
+            SyncRunUnit.status == SyncRunUnitStatus.PLANNED.value,
+        )
+        .update(
+            {
+                SyncRunUnit.status: SyncRunUnitStatus.FAILED.value,
+                SyncRunUnit.error: error,
+                SyncRunUnit.updated_at: now,
+            },
+            synchronize_session=False,
+        )
+    )
+    return int(result or 0)
 
 
 def _claim_units(

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -147,6 +147,9 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
             error = decision.reason or "sync dispatch denied"
             if _run_has_dispatching_or_running_units(session, run_uuid):
                 failed_planned = _fail_planned_units(session, run_uuid, error)
+                failed_stale_dispatching = _fail_stale_dispatching_units(
+                    session, run_uuid, error
+                )
                 session.flush()
                 logger.warning(
                     "dispatch_sync_run.denied_with_active_units",
@@ -154,8 +157,16 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
                         "sync_run_id": sync_run_id,
                         "reason": error,
                         "failed_planned_units": failed_planned,
+                        "failed_stale_dispatching_units": failed_stale_dispatching,
                     },
                 )
+                _enqueue_denied_active_finalize(sync_run_id)
+                return {
+                    "status": "denied_active",
+                    "reason": error,
+                    "failed_planned_units": failed_planned,
+                    "failed_stale_dispatching_units": failed_stale_dispatching,
+                }
             else:
                 completed_at = datetime.now(timezone.utc)
                 run.status = SyncRunStatus.FAILED.value
@@ -209,6 +220,9 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
             error = "sync configuration is paused"
             if _run_has_dispatching_or_running_units(session, run_uuid):
                 failed_planned = _fail_planned_units(session, run_uuid, error)
+                failed_stale_dispatching = _fail_stale_dispatching_units(
+                    session, run_uuid, error
+                )
                 session.flush()
                 logger.warning(
                     "dispatch_sync_run.inactive_config_with_active_units",
@@ -216,8 +230,16 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
                         "sync_run_id": sync_run_id,
                         "config_id": str(inactive_config.id),
                         "failed_planned_units": failed_planned,
+                        "failed_stale_dispatching_units": failed_stale_dispatching,
                     },
                 )
+                _enqueue_denied_active_finalize(sync_run_id)
+                return {
+                    "status": "denied_active",
+                    "reason": error,
+                    "failed_planned_units": failed_planned,
+                    "failed_stale_dispatching_units": failed_stale_dispatching,
+                }
             else:
                 completed_at = datetime.now(timezone.utc)
                 run.status = SyncRunStatus.FAILED.value
@@ -829,6 +851,40 @@ def _fail_planned_units(session, run_uuid: uuid.UUID, error: str) -> int:
         )
     )
     return int(result or 0)
+
+
+def _fail_stale_dispatching_units(session, run_uuid: uuid.UUID, error: str) -> int:
+    now = datetime.now(timezone.utc)
+    stale_dispatch_cutoff = now - timedelta(seconds=_stale_dispatch_seconds())
+    stale_units = (
+        session.query(SyncRunUnit)
+        .filter(
+            SyncRunUnit.sync_run_id == run_uuid,
+            SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value,
+        )
+        .all()
+    )
+    failed = 0
+    for unit in stale_units:
+        if _as_aware(unit.updated_at) > stale_dispatch_cutoff:
+            continue
+        unit.status = SyncRunUnitStatus.FAILED.value
+        unit.error = error
+        unit.result = {"error_category": "dispatch_denied"}
+        unit.updated_at = now
+        failed += 1
+    return failed
+
+
+def _enqueue_denied_active_finalize(sync_run_id: str) -> None:
+    try:
+        getattr(finalize_sync_run, "apply_async")(args=(sync_run_id,), queue="sync")
+    except Exception:
+        logger.exception(
+            "dispatch_sync_run.denied_active_finalize_enqueue_failed",
+            extra={"sync_run_id": sync_run_id},
+        )
+        raise
 
 
 def _claim_units(

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -23,6 +23,7 @@ from dev_health_ops.workers.sync_batch import (
     _is_batch_eligible,
     _run_sync_for_repo,
 )
+from dev_health_ops.workers.sync_reconciler import reconcile_sync_dispatch
 from dev_health_ops.workers.sync_runtime import (
     _dispatch_post_sync_tasks,
     run_sync_config,
@@ -87,6 +88,7 @@ __all__ = [
     "monitor_queue_depths",
     "phone_home_heartbeat",
     "process_webhook_event",
+    "reconcile_sync_dispatch",
     "reconcile_team_members",
     "dispatch_membership_backfill",
     "run_backfill",

--- a/tests/test_backfill_fanout.py
+++ b/tests/test_backfill_fanout.py
@@ -232,6 +232,8 @@ def test_backfill_unit_does_not_write_watermark(db_session, monkeypatch):
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_single_unit_run(db_session, mode=SyncRunMode.BACKFILL.value)
+    unit.status = SyncRunUnitStatus.DISPATCHING.value
+    db_session.flush()
     initial_watermark = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
     set_watermark(
         db_session, ORG_ID, "full-chaos/dev-health", "commits", initial_watermark

--- a/tests/test_dispatch_guard.py
+++ b/tests/test_dispatch_guard.py
@@ -576,28 +576,15 @@ def test_same_run_running_units_count_against_cap(db_session, monkeypatch):
     assert str(units[2].id) in decision.capped_unit_ids
 
 
-def test_stale_other_run_running_always_consumes_cap(db_session, monkeypatch):
-    """F2 regression (b): RUNNING units always consume capacity regardless of age.
-
-    Under the new model RUNNING has no stale threshold — run_sync_unit does not
-    heartbeat, so a stale RUNNING unit may still be executing.  Reclaiming it
-    would cause duplicate provider writes.  Therefore a stale RUNNING unit from
-    another run MUST count as an active slot and cap the current run.
-
-    Durable dead-worker recovery (heartbeat + lease) is a separate follow-up
-    (CHAOS-2577).  Until then, a capped run whose only blocker is a dead RUNNING
-    unit may stall — acceptable, preserves at-most-once provider execution.
-    """
+def test_null_lease_running_counts_as_live(db_session, monkeypatch):
     from datetime import timedelta
 
     monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
     monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "1")
-    # Even with a very short staleness window, RUNNING must still consume a slot.
     monkeypatch.setenv("SYNC_UNIT_RUNNING_STALE_SECONDS", "60")
 
     run, units, integration, source = _seed_run(db_session, unit_count=1)
 
-    # Another run with a RUNNING unit that is stale (updated 2 hours ago).
     other_run = SyncRun(
         org_id=run.org_id,
         integration_id=integration.id,
@@ -631,12 +618,96 @@ def test_stale_other_run_running_always_consumes_cap(db_session, monkeypatch):
 
     decision = DispatchGuard.authorize_run(db_session, str(run.id))
 
-    # Stale RUNNING must still consume a slot — cap expected.
-    # (INTERIM: run may stall until heartbeat/lease follow-up lands.)
     assert decision.allowed is True
-    assert decision.concurrency_capped is True, (
-        "stale other-run RUNNING must still consume a slot (no heartbeat)"
+    assert decision.concurrency_capped is True
+    assert len(decision.capped_unit_ids) == 1
+
+
+def test_expired_running_lease_does_not_consume_cap(db_session, monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "1")
+    run, units, integration, source = _seed_run(db_session, unit_count=1)
+    other_run = SyncRun(
+        org_id=run.org_id,
+        integration_id=integration.id,
+        triggered_by="schedule",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunStatus.RUNNING.value,
+        total_units=1,
+        completed_units=0,
+        failed_units=0,
     )
+    db_session.add(other_run)
+    db_session.flush()
+    now = datetime.now(timezone.utc)
+    other_unit = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=other_run.id,
+        integration_id=integration.id,
+        source_id=source.id,
+        provider="github",
+        dataset_key="commits-expired",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.RUNNING.value,
+        attempts=1,
+        lease_owner="worker-dead",
+        lease_expires_at=now - timedelta(seconds=1),
+        last_heartbeat_at=now - timedelta(minutes=2),
+    )
+    db_session.add(other_unit)
+    db_session.flush()
+
+    decision = DispatchGuard.authorize_run(db_session, str(run.id))
+
+    assert decision.allowed is True
+    assert decision.concurrency_capped is False
+    assert decision.capped_unit_ids == ()
+
+
+def test_live_running_lease_consumes_cap(db_session, monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "10")
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "1")
+    run, units, integration, source = _seed_run(db_session, unit_count=1)
+    other_run = SyncRun(
+        org_id=run.org_id,
+        integration_id=integration.id,
+        triggered_by="schedule",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunStatus.RUNNING.value,
+        total_units=1,
+        completed_units=0,
+        failed_units=0,
+    )
+    db_session.add(other_run)
+    db_session.flush()
+    now = datetime.now(timezone.utc)
+    other_unit = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=other_run.id,
+        integration_id=integration.id,
+        source_id=source.id,
+        provider="github",
+        dataset_key="commits-live",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.RUNNING.value,
+        attempts=1,
+        lease_owner="worker-live",
+        lease_expires_at=now + timedelta(minutes=10),
+        last_heartbeat_at=now,
+    )
+    db_session.add(other_unit)
+    db_session.flush()
+
+    decision = DispatchGuard.authorize_run(db_session, str(run.id))
+
+    assert decision.allowed is True
+    assert decision.concurrency_capped is True
     assert len(decision.capped_unit_ids) == 1
 
 
@@ -773,13 +844,9 @@ def _make_dispatch_harness(db_session, monkeypatch, *, unit_count, cap, active_s
     return run, units, integration, source
 
 
-def test_chord_capped_redispatch_failure_marks_run_terminal(db_session, monkeypatch):
-    """F4 regression (d-chord): redispatch publish failure after chord dispatch
-    marks the run/units terminal — capped PLANNED units must not be stranded.
-
-    Scenario: cap=2, 1 active slot → 1 unit dispatched (chord), 1 unit capped.
-    Redispatch publish raises → _mark_dispatch_enqueue_failed must be called.
-    """
+def test_chord_capped_redispatch_failure_preserves_published_work(
+    db_session, monkeypatch
+):
     from dev_health_ops.workers import sync_units
 
     run, units, integration, source = _make_dispatch_harness(
@@ -820,7 +887,6 @@ def test_chord_capped_redispatch_failure_marks_run_terminal(db_session, monkeypa
 
     call_count = [0]
 
-    # Patch chord to call our counter on apply_async.
     class CountingChord:
         def __init__(self, header, callback):
             pass
@@ -847,24 +913,17 @@ def test_chord_capped_redispatch_failure_marks_run_terminal(db_session, monkeypa
     for unit in units:
         db_session.refresh(unit)
 
-    # Run must be terminal (FAILED) — not left in DISPATCHING/PLANNED.
-    assert run.status == SyncRunStatus.FAILED.value, (
-        f"run must be FAILED after redispatch enqueue failure, got {run.status}"
-    )
-    # All non-terminal units must be marked FAILED.
-    non_terminal = [u for u in units if u.status not in {"success", "failed"}]
-    assert len(non_terminal) == 0, (
-        f"all units must be terminal after enqueue failure, got {[u.status for u in non_terminal]}"
-    )
+    assert run.status == SyncRunStatus.DISPATCHING.value
+    assert run.completed_at is None
+    assert sorted(unit.status for unit in units) == [
+        SyncRunUnitStatus.DISPATCHING.value,
+        SyncRunUnitStatus.PLANNED.value,
+    ]
 
 
-def test_noop_redispatch_failure_marks_run_terminal(db_session, monkeypatch):
-    """F5 regression (d-noop): redispatch publish failure in the no-signatures
-    path marks the run/units terminal — PLANNED units must not be stranded.
-
-    Scenario: cap=1, 1 active slot → ALL units capped → noop path.
-    Redispatch publish raises → _mark_dispatch_enqueue_failed must be called.
-    """
+def test_noop_redispatch_failure_preserves_planned_for_reconciler(
+    db_session, monkeypatch
+):
     from dev_health_ops.workers import sync_units
 
     run, units, integration, source = _make_dispatch_harness(
@@ -883,14 +942,9 @@ def test_noop_redispatch_failure_marks_run_terminal(db_session, monkeypatch):
     for unit in units:
         db_session.refresh(unit)
 
-    # Run must be terminal (FAILED) — not left stranded.
-    assert run.status == SyncRunStatus.FAILED.value, (
-        f"run must be FAILED after noop redispatch failure, got {run.status}"
-    )
-    non_terminal = [u for u in units if u.status not in {"success", "failed"}]
-    assert len(non_terminal) == 0, (
-        f"all units must be terminal after noop enqueue failure, got {[u.status for u in non_terminal]}"
-    )
+    assert run.status == SyncRunStatus.PLANNED.value
+    assert run.completed_at is None
+    assert units[0].status == SyncRunUnitStatus.PLANNED.value
 
 
 def test_fresh_same_run_dispatching_caps_planned_unit(db_session, monkeypatch):

--- a/tests/test_run_diagnostics.py
+++ b/tests/test_run_diagnostics.py
@@ -113,6 +113,11 @@ def _seed_run(session, *, mode=SyncRunMode.INCREMENTAL.value):
     return run, unit
 
 
+def _mark_dispatching(session, unit):
+    unit.status = SyncRunUnitStatus.DISPATCHING.value
+    session.flush()
+
+
 def _patch_runtime(monkeypatch):
     from dev_health_ops.workers import sync_units
     from dev_health_ops.workers.sync_bootstrap import ProviderRuntime
@@ -180,6 +185,7 @@ def test_run_sync_unit_failure_persists_error_category(db_session, monkeypatch):
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     _patch_runtime(monkeypatch)
     _patch_finalize_apply(monkeypatch)
@@ -209,6 +215,7 @@ def test_run_sync_unit_failure_adapter_error_category(db_session, monkeypatch):
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     _patch_runtime(monkeypatch)
     _patch_finalize_apply(monkeypatch)
@@ -225,6 +232,7 @@ def test_run_sync_unit_failure_adapter_error_category(db_session, monkeypatch):
 
     assert result["error_category"] == "adapter_error"
     db_session.refresh(unit)
+    assert unit.result is not None
     assert unit.result["error_category"] == "adapter_error"
 
 
@@ -234,6 +242,7 @@ def test_run_sync_unit_success_result_has_no_error_category(db_session, monkeypa
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     _patch_runtime(monkeypatch)
     _patch_finalize_apply(monkeypatch)
@@ -248,6 +257,7 @@ def test_run_sync_unit_success_result_has_no_error_category(db_session, monkeypa
 
     assert result["status"] == "success"
     db_session.refresh(unit)
+    assert unit.result is not None
     assert "error_category" not in unit.result
 
 
@@ -262,6 +272,7 @@ def test_run_sync_unit_success_emits_structured_log(db_session, monkeypatch, cap
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     _patch_runtime(monkeypatch)
     _patch_finalize_apply(monkeypatch)
@@ -294,6 +305,7 @@ def test_run_sync_unit_failure_emits_structured_log(db_session, monkeypatch, cap
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     _patch_runtime(monkeypatch)
     _patch_finalize_apply(monkeypatch)

--- a/tests/test_sync_reconciler.py
+++ b/tests/test_sync_reconciler.py
@@ -31,8 +31,13 @@ def db_session():
 
 @contextmanager
 def _fake_session_ctx(session):
-    yield session
-    session.commit()
+    try:
+        yield session
+    except Exception:
+        session.rollback()
+        raise
+    else:
+        session.commit()
 
 
 def _patch_db_session(monkeypatch, session):

--- a/tests/test_sync_reconciler.py
+++ b/tests/test_sync_reconciler.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models import (
+    Base,
+    Integration,
+    IntegrationSource,
+    SyncRun,
+    SyncRunMode,
+    SyncRunStatus,
+    SyncRunUnit,
+    SyncRunUnitStatus,
+)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@contextmanager
+def _fake_session_ctx(session):
+    yield session
+    session.commit()
+
+
+def _patch_db_session(monkeypatch, session):
+    import dev_health_ops.db as db
+
+    monkeypatch.setattr(
+        db, "get_postgres_session_sync", lambda: _fake_session_ctx(session)
+    )
+
+
+def _seed_run(session, *, planned_units=0):
+    org_id = str(uuid.uuid4())
+    integration = Integration(
+        org_id=org_id,
+        provider="github",
+        name="demo",
+        config={},
+        is_active=True,
+    )
+    session.add(integration)
+    session.flush()
+    source = IntegrationSource(
+        org_id=org_id,
+        integration_id=integration.id,
+        provider="github",
+        source_type="repo",
+        external_id="full-chaos/dev-health",
+        name="dev-health",
+        full_name="full-chaos/dev-health",
+        metadata_={},
+        is_enabled=True,
+    )
+    run = SyncRun(
+        org_id=org_id,
+        integration_id=integration.id,
+        triggered_by="manual",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunStatus.DISPATCHING.value,
+        total_units=planned_units + 1,
+        completed_units=0,
+        failed_units=0,
+    )
+    session.add_all([source, run])
+    session.flush()
+    now = datetime.now(timezone.utc)
+    running = SyncRunUnit(
+        org_id=org_id,
+        sync_run_id=run.id,
+        integration_id=integration.id,
+        source_id=source.id,
+        provider="github",
+        dataset_key="commits",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.RUNNING.value,
+        attempts=1,
+        lease_owner="worker-dead",
+        lease_expires_at=now - timedelta(seconds=1),
+        last_heartbeat_at=now - timedelta(minutes=5),
+    )
+    session.add(running)
+    planned = []
+    for index in range(planned_units):
+        unit = SyncRunUnit(
+            org_id=org_id,
+            sync_run_id=run.id,
+            integration_id=integration.id,
+            source_id=source.id,
+            provider="github",
+            dataset_key=f"prs-{index}",
+            cost_class="medium",
+            mode=SyncRunMode.INCREMENTAL.value,
+            status=SyncRunUnitStatus.PLANNED.value,
+            attempts=0,
+        )
+        session.add(unit)
+        planned.append(unit)
+    session.flush()
+    return run, running, planned
+
+
+def test_reconciler_expires_dead_running_and_dispatches_pending(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler, sync_units
+
+    run, running, planned = _seed_run(db_session, planned_units=1)
+    _patch_db_session(monkeypatch, db_session)
+    dispatches = []
+    finalizers = []
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: dispatches.append((args, queue)),
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: finalizers.append((args, queue)),
+    )
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    db_session.refresh(running)
+    db_session.refresh(planned[0])
+    assert result["expired_units"] == 1
+    assert running.status == SyncRunUnitStatus.FAILED.value
+    assert running.error == "sync unit lease expired"
+    assert running.result is not None
+    assert running.result["error_category"] == "worker_lost"
+    assert running.lease_owner is None
+    assert running.lease_expires_at is None
+    assert planned[0].status == SyncRunUnitStatus.PLANNED.value
+    assert dispatches == [((str(run.id),), "sync")]
+    assert finalizers == []
+
+
+def test_reconciler_finalizes_when_dead_running_makes_run_terminal(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler, sync_units
+
+    run, running, planned = _seed_run(db_session, planned_units=0)
+    _patch_db_session(monkeypatch, db_session)
+    dispatches = []
+    finalizers = []
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: dispatches.append((args, queue)),
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: finalizers.append((args, queue)),
+    )
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    db_session.refresh(running)
+    assert result["expired_units"] == 1
+    assert running.status == SyncRunUnitStatus.FAILED.value
+    assert dispatches == []
+    assert finalizers == [((str(run.id),), "sync")]
+
+
+def test_reconciler_does_not_expire_live_lease(db_session, monkeypatch):
+    from dev_health_ops.workers import sync_reconciler, sync_units
+
+    run, running, planned = _seed_run(db_session, planned_units=1)
+    running.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    dispatches = []
+    finalizers = []
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: dispatches.append((args, queue)),
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: finalizers.append((args, queue)),
+    )
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    db_session.refresh(running)
+    assert result["expired_units"] == 0
+    assert running.status == SyncRunUnitStatus.RUNNING.value
+    assert dispatches == []
+    assert finalizers == []

--- a/tests/test_sync_reconciler.py
+++ b/tests/test_sync_reconciler.py
@@ -294,3 +294,43 @@ def test_reconciler_retries_finalizable_run_after_enqueue_failure(
 
     assert second["finalizers_enqueued"] == 1
     assert finalizers == [((str(run.id),), "sync")]
+
+
+def test_reconciler_finalizable_scan_skips_older_nonfinalizable_runs(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler, sync_units
+
+    _, blocker_unit_one, _ = _seed_run(db_session, planned_units=0)
+    _, blocker_unit_two, _ = _seed_run(db_session, planned_units=0)
+    blocker_unit_one.lease_expires_at = datetime.now(timezone.utc) + timedelta(
+        minutes=5
+    )
+    blocker_unit_two.lease_expires_at = datetime.now(timezone.utc) + timedelta(
+        minutes=5
+    )
+    finalizable, final_unit, final_planned = _seed_run(db_session, planned_units=0)
+    final_unit.status = SyncRunUnitStatus.FAILED.value
+    final_unit.error = "sync unit lease expired"
+    final_unit.lease_owner = None
+    final_unit.lease_expires_at = None
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    dispatches = []
+    finalizers = []
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: dispatches.append((args, queue)),
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: finalizers.append((args, queue)),
+    )
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=1)
+
+    assert result["finalizers_enqueued"] == 1
+    assert finalizers == [((str(finalizable.id),), "sync")]
+    assert dispatches == []

--- a/tests/test_sync_reconciler.py
+++ b/tests/test_sync_reconciler.py
@@ -182,7 +182,7 @@ def test_reconciler_finalizes_when_dead_running_makes_run_terminal(
 def test_reconciler_does_not_expire_live_lease(db_session, monkeypatch):
     from dev_health_ops.workers import sync_reconciler, sync_units
 
-    run, running, planned = _seed_run(db_session, planned_units=1)
+    run, running, planned = _seed_run(db_session, planned_units=0)
     running.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
     db_session.flush()
     _patch_db_session(monkeypatch, db_session)
@@ -206,3 +206,91 @@ def test_reconciler_does_not_expire_live_lease(db_session, monkeypatch):
     assert running.status == SyncRunUnitStatus.RUNNING.value
     assert dispatches == []
     assert finalizers == []
+
+
+def test_reconciler_retries_dispatchable_run_after_enqueue_failure(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler, sync_units
+
+    run, running, planned = _seed_run(db_session, planned_units=1)
+    running.status = SyncRunUnitStatus.FAILED.value
+    running.error = "sync unit lease expired"
+    running.lease_owner = None
+    running.lease_expires_at = None
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    dispatches = []
+    finalizers = []
+
+    def fail_dispatch(args=None, queue=None):
+        raise RuntimeError("broker down")
+
+    monkeypatch.setattr(sync_units.dispatch_sync_run, "apply_async", fail_dispatch)
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: finalizers.append((args, queue)),
+    )
+
+    first = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    db_session.refresh(planned[0])
+    assert first["expired_units"] == 0
+    assert first["dispatches_enqueued"] == 0
+    assert planned[0].status == SyncRunUnitStatus.PLANNED.value
+    assert finalizers == []
+
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: dispatches.append((args, queue)),
+    )
+
+    second = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    assert second["dispatches_enqueued"] == 1
+    assert dispatches == [((str(run.id),), "sync")]
+
+
+def test_reconciler_retries_finalizable_run_after_enqueue_failure(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler, sync_units
+
+    run, running, planned = _seed_run(db_session, planned_units=0)
+    running.status = SyncRunUnitStatus.FAILED.value
+    running.error = "sync unit lease expired"
+    running.lease_owner = None
+    running.lease_expires_at = None
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    dispatches = []
+    finalizers = []
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: dispatches.append((args, queue)),
+    )
+
+    def fail_finalize(args=None, queue=None):
+        raise RuntimeError("broker down")
+
+    monkeypatch.setattr(sync_units.finalize_sync_run, "apply_async", fail_finalize)
+
+    first = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    assert first["expired_units"] == 0
+    assert first["finalizers_enqueued"] == 0
+    assert dispatches == []
+
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: finalizers.append((args, queue)),
+    )
+
+    second = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    assert second["finalizers_enqueued"] == 1
+    assert finalizers == [((str(run.id),), "sync")]

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -59,6 +59,43 @@ def _patch_db_session(monkeypatch, session):
     )
 
 
+@contextmanager
+def _new_session_ctx(engine):
+    with Session(engine) as session:
+        try:
+            yield session
+        except Exception:
+            session.rollback()
+            raise
+        else:
+            session.commit()
+
+
+def _patch_db_session_factory(monkeypatch, engine):
+    import dev_health_ops.db as db
+
+    monkeypatch.setattr(
+        db, "get_postgres_session_sync", lambda: _new_session_ctx(engine)
+    )
+
+
+def _file_backed_engine(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'sync-unit-race.db'}")
+    Base.metadata.create_all(engine)
+    return engine
+
+
+def _commit_reconciler_failure(engine, unit_id):
+    with Session(engine) as session:
+        unit = session.query(SyncRunUnit).filter(SyncRunUnit.id == unit_id).one()
+        unit.status = SyncRunUnitStatus.FAILED.value
+        unit.error = "sync unit lease expired"
+        unit.result = {"error_category": "worker_lost"}
+        unit.lease_owner = None
+        unit.lease_expires_at = None
+        session.commit()
+
+
 def _seed_run(session, *, mode=SyncRunMode.INCREMENTAL.value):
     org_id = str(uuid.uuid4())
     integration = Integration(
@@ -390,6 +427,53 @@ def test_heartbeat_extends_live_matching_lease(db_session, monkeypatch):
     assert _aware(last_heartbeat_at) > now
 
 
+def test_heartbeat_loses_after_reconciler_terminalizes(tmp_path, monkeypatch):
+    import threading
+
+    from dev_health_ops.workers import sync_units
+
+    engine = _file_backed_engine(tmp_path)
+    try:
+        with Session(engine) as seed_session:
+            _, unit = _seed_run(seed_session)
+            now = datetime.now(timezone.utc)
+            unit.status = SyncRunUnitStatus.RUNNING.value
+            unit.lease_owner = "worker-1"
+            unit.lease_expires_at = now + timedelta(seconds=30)
+            unit.last_heartbeat_at = now
+            unit_id = unit.id
+            seed_session.commit()
+        _commit_reconciler_failure(engine, unit_id)
+        _patch_db_session_factory(monkeypatch, engine)
+        monkeypatch.setattr(sync_units, "_heartbeat_interval_seconds", lambda: 1)
+        monkeypatch.setattr(sync_units, "_running_lease_seconds", lambda: 120)
+
+        class OneHeartbeatStop(threading.Event):
+            def __init__(self):
+                super().__init__()
+                self.calls = 0
+
+            def wait(self, timeout=None):
+                self.calls += 1
+                return self.calls > 1
+
+        sync_units._heartbeat_unit_lease(str(unit_id), "worker-1", OneHeartbeatStop())
+
+        with Session(engine) as assert_session:
+            unit = (
+                assert_session.query(SyncRunUnit)
+                .filter(SyncRunUnit.id == unit_id)
+                .one()
+            )
+            assert unit.status == SyncRunUnitStatus.FAILED.value
+            assert unit.error == "sync unit lease expired"
+            assert unit.result == {"error_category": "worker_lost"}
+            assert unit.lease_owner is None
+            assert unit.lease_expires_at is None
+    finally:
+        engine.dispose()
+
+
 def test_worker_success_after_reconciler_failed_does_not_overwrite_terminal(
     db_session, monkeypatch
 ):
@@ -420,12 +504,108 @@ def test_worker_success_after_reconciler_failed_does_not_overwrite_terminal(
     assert result == {
         "status": "skipped",
         "unit_id": str(unit.id),
-        "reason": "terminal",
+        "reason": "lease_lost",
     }
     assert unit.status == SyncRunUnitStatus.FAILED.value
     assert unit.error == "sync unit lease expired"
     assert unit.result == {"error_category": "worker_lost"}
-    assert finalize_calls == [((str(run.id),), "sync")]
+    assert finalize_calls == []
+
+
+def test_worker_success_cas_loses_to_reconciler_does_not_overwrite_failed(
+    tmp_path, monkeypatch
+):
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    engine = _file_backed_engine(tmp_path)
+    try:
+        with Session(engine) as seed_session:
+            run, unit = _seed_run(seed_session)
+            _mark_dispatching(seed_session, unit)
+            run_id = run.id
+            unit_id = unit.id
+            seed_session.commit()
+        _patch_db_session_factory(monkeypatch, engine)
+        _patch_runtime(monkeypatch)
+        finalize_calls = _patch_finalize_apply(monkeypatch)
+        monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+        monkeypatch.delenv("DATABASE_URI", raising=False)
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+
+        def run_dataset(ctx, runtime):
+            _commit_reconciler_failure(engine, unit_id)
+            return {"ok": True}
+
+        monkeypatch.setattr(dataset_adapters, "run_dataset_unit", run_dataset)
+
+        result = getattr(run_sync_unit, "run")(str(unit_id))
+
+        with Session(engine) as assert_session:
+            unit = (
+                assert_session.query(SyncRunUnit)
+                .filter(SyncRunUnit.id == unit_id)
+                .one()
+            )
+            assert result == {
+                "status": "skipped",
+                "unit_id": str(unit_id),
+                "reason": "lease_lost",
+            }
+            assert unit.status == SyncRunUnitStatus.FAILED.value
+            assert unit.error == "sync unit lease expired"
+            assert unit.result == {"error_category": "worker_lost"}
+            assert unit.lease_owner is None
+            assert unit.lease_expires_at is None
+            assert assert_session.query(SyncWatermark).count() == 0
+            assert assert_session.get(SyncRun, run_id) is not None
+        assert finalize_calls == []
+    finally:
+        engine.dispose()
+
+
+def test_worker_failure_cas_loses_to_reconciler_does_not_overwrite_failed(
+    tmp_path, monkeypatch
+):
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    engine = _file_backed_engine(tmp_path)
+    try:
+        with Session(engine) as seed_session:
+            _, unit = _seed_run(seed_session)
+            _mark_dispatching(seed_session, unit)
+            unit_id = unit.id
+            seed_session.commit()
+        _patch_db_session_factory(monkeypatch, engine)
+        _patch_runtime(monkeypatch)
+        finalize_calls = _patch_finalize_apply(monkeypatch)
+
+        def run_dataset(ctx, runtime):
+            _commit_reconciler_failure(engine, unit_id)
+            raise RuntimeError("adapter failed after lease loss")
+
+        monkeypatch.setattr(dataset_adapters, "run_dataset_unit", run_dataset)
+
+        result = getattr(run_sync_unit, "run")(str(unit_id))
+
+        with Session(engine) as assert_session:
+            unit = (
+                assert_session.query(SyncRunUnit)
+                .filter(SyncRunUnit.id == unit_id)
+                .one()
+            )
+            assert result == {
+                "status": "skipped",
+                "unit_id": str(unit_id),
+                "reason": "lease_lost",
+            }
+            assert unit.status == SyncRunUnitStatus.FAILED.value
+            assert unit.error == "sync unit lease expired"
+            assert unit.result == {"error_category": "worker_lost"}
+        assert finalize_calls == []
+    finally:
+        engine.dispose()
 
 
 def test_run_sync_unit_bootstrap_failure_enqueues_finalize(db_session, monkeypatch):
@@ -490,6 +670,87 @@ def test_run_sync_unit_bootstrap_failure_survives_session_rollback(
     assert dispatch_calls == []
     assert finalize_calls == [((str(run.id),), "sync")]
     assert chord_calls == []
+
+
+def test_bootstrap_failure_cas_loses_to_reconciler(tmp_path, monkeypatch):
+    from dev_health_ops.workers.sync_bootstrap import SyncTaskBootstrap
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    engine = _file_backed_engine(tmp_path)
+    try:
+        with Session(engine) as seed_session:
+            _, unit = _seed_run(seed_session)
+            _mark_dispatching(seed_session, unit)
+            unit_id = unit.id
+            seed_session.commit()
+        _patch_db_session_factory(monkeypatch, engine)
+        dispatch_calls, finalize_calls, chord_calls = _patch_worker_enqueues(
+            monkeypatch
+        )
+
+        def fail_bootstrap(session, unit_id_arg):
+            assert unit_id_arg == str(unit_id)
+            _commit_reconciler_failure(engine, unit_id)
+            raise ValueError("missing source")
+
+        monkeypatch.setattr(SyncTaskBootstrap, "load", fail_bootstrap)
+
+        result = getattr(run_sync_unit, "run")(str(unit_id))
+
+        with Session(engine) as assert_session:
+            unit = (
+                assert_session.query(SyncRunUnit)
+                .filter(SyncRunUnit.id == unit_id)
+                .one()
+            )
+            assert result == {
+                "status": "skipped",
+                "unit_id": str(unit_id),
+                "reason": "lease_lost",
+            }
+            assert unit.status == SyncRunUnitStatus.FAILED.value
+            assert unit.error == "sync unit lease expired"
+            assert unit.result == {"error_category": "worker_lost"}
+        assert dispatch_calls == []
+        assert finalize_calls == []
+        assert chord_calls == []
+    finally:
+        engine.dispose()
+
+
+def test_success_cas_and_watermark_are_one_transaction(db_session, monkeypatch):
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    finalize_calls = _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters, "run_dataset_unit", lambda ctx, runtime: {"ok": True}
+    )
+
+    def fail_watermark(*_args, **_kwargs):
+        raise RuntimeError("watermark store down")
+
+    monkeypatch.setattr(sync_units, "set_watermark", fail_watermark)
+
+    with pytest.raises(RuntimeError, match="watermark store down"):
+        getattr(sync_units.run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.RUNNING.value
+    assert unit.lease_owner is not None
+    assert unit.lease_expires_at is not None
+    assert unit.result is None
+    assert unit.error is None
+    assert db_session.query(SyncWatermark).count() == 0
+    assert finalize_calls == []
+    assert run.id == unit.sync_run_id
 
 
 def test_run_sync_unit_bootstrap_failure_skips_duplicate_live_running_lease(

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -1189,7 +1189,12 @@ def test_paused_config_with_running_and_planned_units_does_not_strand(
     db_session.refresh(running)
     db_session.refresh(planned)
     db_session.refresh(config)
-    assert dispatch_result == {"status": "noop", "queued_units": 0}
+    assert dispatch_result == {
+        "status": "denied_active",
+        "reason": "sync configuration is paused",
+        "failed_planned_units": 1,
+        "failed_stale_dispatching_units": 0,
+    }
     assert run.status not in {
         SyncRunStatus.SUCCESS.value,
         SyncRunStatus.PARTIAL_FAILED.value,
@@ -1201,8 +1206,8 @@ def test_paused_config_with_running_and_planned_units_does_not_strand(
     assert planned.error == "sync configuration is paused"
     assert running.status == SyncRunUnitStatus.RUNNING.value
     assert running.lease_owner == "worker-live"
-    assert dispatch_calls == [((str(run.id),), "sync")]
-    assert finalize_calls == []
+    assert dispatch_calls == []
+    assert finalize_calls == [((str(run.id),), "sync")]
     assert chord_calls == []
 
     running.lease_expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
@@ -1213,7 +1218,7 @@ def test_paused_config_with_running_and_planned_units_does_not_strand(
     db_session.refresh(running)
     assert reconcile_result["expired_units"] == 1
     assert running.status == SyncRunUnitStatus.FAILED.value
-    assert finalize_calls == [((str(run.id),), "sync")]
+    assert finalize_calls == [((str(run.id),), "sync"), ((str(run.id),), "sync")]
 
     finalize_result = sync_units.finalize_sync_run(str(run.id))
 
@@ -1229,6 +1234,198 @@ def test_paused_config_with_running_and_planned_units_does_not_strand(
     assert run.status == SyncRunStatus.FAILED.value
     assert run.completed_at is not None
     assert run.failed_units == 2
+
+
+def test_paused_config_with_stale_dispatching_does_not_redispatch(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_units
+
+    run, stale_dispatching = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    stale_dispatching.status = SyncRunUnitStatus.DISPATCHING.value
+    stale_dispatching.updated_at = now - timedelta(minutes=30)
+    running = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=stale_dispatching.integration_id,
+        source_id=stale_dispatching.source_id,
+        provider="github",
+        dataset_key="prs",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.RUNNING.value,
+        attempts=1,
+        lease_owner="worker-live",
+        lease_expires_at=now + timedelta(minutes=5),
+        last_heartbeat_at=now,
+        processor_flags={"sync_prs": True},
+    )
+    planned = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=stale_dispatching.integration_id,
+        source_id=stale_dispatching.source_id,
+        provider="github",
+        dataset_key="issues",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.PLANNED.value,
+        attempts=0,
+        processor_flags={"sync_issues": True},
+    )
+    config = SyncConfiguration(
+        org_id=run.org_id,
+        name="paused-with-stale-dispatching",
+        provider="github",
+        sync_targets=["git", "prs", "issues"],
+        sync_options={},
+        migrated_integration_id=run.integration_id,
+        is_active=False,
+    )
+    run.status = SyncRunStatus.DISPATCHING.value
+    run.total_units = 3
+    db_session.add_all([running, planned, config])
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    dispatch_calls, finalize_calls, chord_calls = _patch_worker_enqueues(monkeypatch)
+
+    def fail_queue(*_args, **_kwargs):
+        raise AssertionError("paused config must not queue run_sync_unit")
+
+    monkeypatch.setattr(sync_units.run_sync_unit, "s", fail_queue)
+
+    dispatch_result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    db_session.refresh(stale_dispatching)
+    db_session.refresh(running)
+    db_session.refresh(planned)
+    assert dispatch_result == {
+        "status": "denied_active",
+        "reason": "sync configuration is paused",
+        "failed_planned_units": 1,
+        "failed_stale_dispatching_units": 1,
+    }
+    assert stale_dispatching.status == SyncRunUnitStatus.FAILED.value
+    assert stale_dispatching.error == "sync configuration is paused"
+    assert stale_dispatching.result == {"error_category": "dispatch_denied"}
+    assert planned.status == SyncRunUnitStatus.FAILED.value
+    assert running.status == SyncRunUnitStatus.RUNNING.value
+    assert running.lease_owner == "worker-live"
+    assert run.status not in {
+        SyncRunStatus.SUCCESS.value,
+        SyncRunStatus.PARTIAL_FAILED.value,
+        SyncRunStatus.FAILED.value,
+    }
+    assert run.completed_at is None
+    assert dispatch_calls == []
+    assert finalize_calls == [((str(run.id),), "sync")]
+    assert chord_calls == []
+
+    running.status = SyncRunUnitStatus.FAILED.value
+    running.error = "sync unit lease expired"
+    running.result = {"error_category": "worker_lost"}
+    running.lease_owner = None
+    running.lease_expires_at = None
+    running.updated_at = datetime.now(timezone.utc)
+    db_session.flush()
+
+    finalize_result = sync_units.finalize_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    assert finalize_result["status"] == "finalized"
+    assert run.status == SyncRunStatus.FAILED.value
+    assert run.failed_units == 3
+
+
+def test_total_cap_hard_deny_with_stale_dispatching_does_not_redispatch(
+    db_session, monkeypatch
+):
+    from dev_health_ops.sync.guard import GuardDecision
+    from dev_health_ops.workers import sync_units
+
+    run, stale_dispatching = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    stale_dispatching.status = SyncRunUnitStatus.DISPATCHING.value
+    stale_dispatching.updated_at = now - timedelta(minutes=30)
+    running = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=stale_dispatching.integration_id,
+        source_id=stale_dispatching.source_id,
+        provider="github",
+        dataset_key="prs",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.RUNNING.value,
+        attempts=1,
+        lease_owner="worker-live",
+        lease_expires_at=now + timedelta(minutes=5),
+        last_heartbeat_at=now,
+        processor_flags={"sync_prs": True},
+    )
+    planned = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=stale_dispatching.integration_id,
+        source_id=stale_dispatching.source_id,
+        provider="github",
+        dataset_key="issues",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.PLANNED.value,
+        attempts=0,
+        processor_flags={"sync_issues": True},
+    )
+    run.status = SyncRunStatus.DISPATCHING.value
+    run.total_units = 3
+    db_session.add_all([running, planned])
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    dispatch_calls, finalize_calls, chord_calls = _patch_worker_enqueues(monkeypatch)
+    reason = "sync run unit cap exceeded: 3/1"
+    monkeypatch.setattr(
+        sync_units.DispatchGuard,
+        "authorize_run",
+        lambda session, sync_run_id: GuardDecision(
+            False,
+            reason,
+            (str(stale_dispatching.id), str(running.id), str(planned.id)),
+        ),
+    )
+
+    def fail_queue(*_args, **_kwargs):
+        raise AssertionError("total-cap hard-deny must not queue run_sync_unit")
+
+    monkeypatch.setattr(sync_units.run_sync_unit, "s", fail_queue)
+
+    dispatch_result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    db_session.refresh(stale_dispatching)
+    db_session.refresh(running)
+    db_session.refresh(planned)
+    assert dispatch_result == {
+        "status": "denied_active",
+        "reason": reason,
+        "failed_planned_units": 1,
+        "failed_stale_dispatching_units": 1,
+    }
+    assert stale_dispatching.status == SyncRunUnitStatus.FAILED.value
+    assert stale_dispatching.error == reason
+    assert stale_dispatching.result == {"error_category": "dispatch_denied"}
+    assert planned.status == SyncRunUnitStatus.FAILED.value
+    assert running.status == SyncRunUnitStatus.RUNNING.value
+    assert run.status not in {
+        SyncRunStatus.SUCCESS.value,
+        SyncRunStatus.PARTIAL_FAILED.value,
+        SyncRunStatus.FAILED.value,
+    }
+    assert run.completed_at is None
+    assert dispatch_calls == []
+    assert finalize_calls == [((str(run.id),), "sync")]
+    assert chord_calls == []
 
 
 def test_dispatch_sync_run_denies_inactive_migrated_child_config(

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -1934,3 +1934,120 @@ def test_fail_stale_dispatching_fails_genuinely_stale_unit(tmp_path):
             assert unit.result == {"error_category": "dispatch_denied"}
     finally:
         engine.dispose()
+
+
+def test_claim_units_does_not_reclaim_concurrently_claimed_running(tmp_path):
+    """Write-time CAS in _claim_units stale-reclaim: a stale DISPATCHING row a
+    delayed run_sync_unit has concurrently claimed to RUNNING (with a live
+    lease) must NOT be reclaimed/requeued. A genuinely-stale DISPATCHING unit
+    with no concurrent claim IS reclaimed (returned, updated_at refreshed).
+    """
+    from sqlalchemy import update as sa_update
+
+    from dev_health_ops.workers.sync_units import (
+        _claim_units,
+        _stale_dispatch_seconds,
+    )
+
+    engine = _file_backed_engine(tmp_path)
+    try:
+        stale_age = timedelta(seconds=_stale_dispatch_seconds() + 600)
+        seeded_at = datetime.now(timezone.utc) - stale_age
+        with Session(engine) as seed_session:
+            run, reclaimable = _seed_run(seed_session)
+            run_id = run.id
+            reclaimable_id = reclaimable.id
+            # Second unit: stale DISPATCHING that a delayed run_sync_unit will
+            # concurrently claim to RUNNING below.
+            concurrent = SyncRunUnit(
+                org_id=reclaimable.org_id,
+                sync_run_id=run.id,
+                integration_id=reclaimable.integration_id,
+                source_id=reclaimable.source_id,
+                provider=reclaimable.provider,
+                dataset_key="pull_requests",
+                cost_class=reclaimable.cost_class,
+                mode=reclaimable.mode,
+                since_at=reclaimable.since_at,
+                before_at=reclaimable.before_at,
+                status=SyncRunUnitStatus.DISPATCHING.value,
+                attempts=0,
+                processor_flags=reclaimable.processor_flags,
+                updated_at=seeded_at,
+            )
+            run.total_units = 2
+            seed_session.add(concurrent)
+            # Explicit updated_at in the SET clause suppresses the column
+            # onupdate, so both rows are durably STALE DISPATCHING.
+            seed_session.execute(
+                sa_update(SyncRunUnit)
+                .where(SyncRunUnit.id == reclaimable_id)
+                .values(
+                    status=SyncRunUnitStatus.DISPATCHING.value,
+                    updated_at=seeded_at,
+                )
+                .execution_options(synchronize_session=False)
+            )
+            seed_session.commit()
+            concurrent_id = concurrent.id
+
+        # A delayed run_sync_unit atomically claims the SAME stale row
+        # DISPATCHING -> RUNNING with a live lease, in an independent session.
+        lease_owner = str(uuid.uuid4())
+        claimed_at = datetime.now(timezone.utc)
+        lease_expires_at = claimed_at + timedelta(seconds=3600)
+        with Session(engine) as claim_session:
+            claimed_count = (
+                claim_session.query(SyncRunUnit)
+                .filter(
+                    SyncRunUnit.id == concurrent_id,
+                    SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value,
+                )
+                .update(
+                    {
+                        SyncRunUnit.status: SyncRunUnitStatus.RUNNING.value,
+                        SyncRunUnit.error: None,
+                        SyncRunUnit.lease_owner: lease_owner,
+                        SyncRunUnit.lease_expires_at: lease_expires_at,
+                        SyncRunUnit.last_heartbeat_at: claimed_at,
+                        SyncRunUnit.updated_at: claimed_at,
+                    },
+                    synchronize_session=False,
+                )
+            )
+            assert claimed_count == 1
+            claim_session.commit()
+
+        # Now run the stale-reclaim path. The write-time status='dispatching'
+        # AND updated_at<=stale_dispatch predicates exclude the now-RUNNING row.
+        with Session(engine) as claim_units_session:
+            claimed = _claim_units(claim_units_session, run_id)
+            claimed_ids = {unit.id for unit in claimed}
+            claim_units_session.commit()
+
+        # The concurrently-claimed RUNNING unit was NOT reclaimed/requeued.
+        assert concurrent_id not in claimed_ids
+        # The genuinely-stale DISPATCHING unit WAS reclaimed.
+        assert reclaimable_id in claimed_ids
+
+        with Session(engine) as assert_session:
+            running_unit = (
+                assert_session.query(SyncRunUnit)
+                .filter(SyncRunUnit.id == concurrent_id)
+                .one()
+            )
+            reclaimed_unit = (
+                assert_session.query(SyncRunUnit)
+                .filter(SyncRunUnit.id == reclaimable_id)
+                .one()
+            )
+            # RUNNING row untouched: lease intact, never reclaimed.
+            assert running_unit.status == SyncRunUnitStatus.RUNNING.value
+            assert running_unit.lease_owner == lease_owner
+            assert running_unit.lease_expires_at is not None
+            assert _aware(running_unit.lease_expires_at) > datetime.now(timezone.utc)
+            # Reclaimed row stays DISPATCHING with a freshly-refreshed updated_at.
+            assert reclaimed_unit.status == SyncRunUnitStatus.DISPATCHING.value
+            assert _aware(reclaimed_unit.updated_at) > seeded_at
+    finally:
+        engine.dispose()

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -1772,3 +1772,165 @@ def test_post_sync_dispatch_none_window_unit_unbounds_lower(db_session, monkeypa
     # Upper bound: both units have before_at set, so to_date must be non-None.
     assert kwargs.get("to_date") is not None
     assert kwargs.get("work_graph_to_date") is not None
+
+
+def test_fail_stale_dispatching_does_not_overwrite_concurrent_claim(tmp_path):
+    """Write-time CAS: a stale DISPATCHING row a delayed run_sync_unit has
+    concurrently claimed to RUNNING (with a live lease) must NOT be clobbered to
+    FAILED by the dispatch-denial stale-fail path.
+    """
+    from sqlalchemy import update as sa_update
+
+    from dev_health_ops.workers.sync_units import (
+        _fail_stale_dispatching_units,
+        _stale_dispatch_seconds,
+    )
+
+    engine = _file_backed_engine(tmp_path)
+    try:
+        stale_age = timedelta(seconds=_stale_dispatch_seconds() + 600)
+        seeded_at = datetime.now(timezone.utc) - stale_age
+        with Session(engine) as seed_session:
+            run, unit = _seed_run(seed_session)
+            run_id = run.id
+            unit_id = unit.id
+            failed_unit = SyncRunUnit(
+                org_id=unit.org_id,
+                sync_run_id=run.id,
+                integration_id=unit.integration_id,
+                source_id=unit.source_id,
+                provider=unit.provider,
+                dataset_key="pull_requests",
+                cost_class=unit.cost_class,
+                mode=unit.mode,
+                since_at=unit.since_at,
+                before_at=unit.before_at,
+                status=SyncRunUnitStatus.DISPATCHING.value,
+                attempts=0,
+                processor_flags=unit.processor_flags,
+                updated_at=seeded_at,
+            )
+            run.total_units = 2
+            seed_session.add(failed_unit)
+            # Explicit updated_at in the SET clause suppresses the column onupdate,
+            # so the row is durably STALE DISPATCHING.
+            seed_session.execute(
+                sa_update(SyncRunUnit)
+                .where(SyncRunUnit.id == unit_id)
+                .values(
+                    status=SyncRunUnitStatus.DISPATCHING.value,
+                    updated_at=seeded_at,
+                )
+                .execution_options(synchronize_session=False)
+            )
+            seed_session.commit()
+            failed_unit_id = failed_unit.id
+
+        # A delayed run_sync_unit atomically claims the SAME stale row
+        # DISPATCHING -> RUNNING with a live lease, in an independent session.
+        lease_owner = str(uuid.uuid4())
+        claimed_at = datetime.now(timezone.utc)
+        lease_expires_at = claimed_at + timedelta(seconds=3600)
+        with Session(engine) as claim_session:
+            claimed_count = (
+                claim_session.query(SyncRunUnit)
+                .filter(
+                    SyncRunUnit.id == unit_id,
+                    SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value,
+                )
+                .update(
+                    {
+                        SyncRunUnit.status: SyncRunUnitStatus.RUNNING.value,
+                        SyncRunUnit.error: None,
+                        SyncRunUnit.lease_owner: lease_owner,
+                        SyncRunUnit.lease_expires_at: lease_expires_at,
+                        SyncRunUnit.last_heartbeat_at: claimed_at,
+                        SyncRunUnit.updated_at: claimed_at,
+                    },
+                    synchronize_session=False,
+                )
+            )
+            assert claimed_count == 1
+            claim_session.commit()
+
+        # The dispatch-denial path now runs the stale-fail helper.  The write-time
+        # status='dispatching' predicate excludes the now-RUNNING row.
+        with Session(engine) as fail_session:
+            failed = _fail_stale_dispatching_units(
+                fail_session, run_id, "sync dispatch denied"
+            )
+            fail_session.commit()
+
+        assert failed == 1
+        with Session(engine) as assert_session:
+            unit = (
+                assert_session.query(SyncRunUnit)
+                .filter(SyncRunUnit.id == unit_id)
+                .one()
+            )
+            stale_unit = (
+                assert_session.query(SyncRunUnit)
+                .filter(SyncRunUnit.id == failed_unit_id)
+                .one()
+            )
+            assert unit.status == SyncRunUnitStatus.RUNNING.value
+            assert unit.lease_owner == lease_owner
+            assert unit.lease_expires_at is not None
+            assert _aware(unit.lease_expires_at) > datetime.now(timezone.utc)
+            assert unit.error is None
+            assert unit.result is None
+            assert stale_unit.status == SyncRunUnitStatus.FAILED.value
+            assert stale_unit.error == "sync dispatch denied"
+            assert stale_unit.result == {"error_category": "dispatch_denied"}
+    finally:
+        engine.dispose()
+
+
+def test_fail_stale_dispatching_fails_genuinely_stale_unit(tmp_path):
+    """Control: a genuinely-stale DISPATCHING unit with no concurrent claim IS
+    failed by the write-time CAS.
+    """
+    from sqlalchemy import update as sa_update
+
+    from dev_health_ops.workers.sync_units import (
+        _fail_stale_dispatching_units,
+        _stale_dispatch_seconds,
+    )
+
+    engine = _file_backed_engine(tmp_path)
+    try:
+        stale_age = timedelta(seconds=_stale_dispatch_seconds() + 600)
+        seeded_at = datetime.now(timezone.utc) - stale_age
+        with Session(engine) as seed_session:
+            run, unit = _seed_run(seed_session)
+            run_id = run.id
+            unit_id = unit.id
+            seed_session.execute(
+                sa_update(SyncRunUnit)
+                .where(SyncRunUnit.id == unit_id)
+                .values(
+                    status=SyncRunUnitStatus.DISPATCHING.value,
+                    updated_at=seeded_at,
+                )
+                .execution_options(synchronize_session=False)
+            )
+            seed_session.commit()
+
+        with Session(engine) as fail_session:
+            failed = _fail_stale_dispatching_units(
+                fail_session, run_id, "sync dispatch denied"
+            )
+            fail_session.commit()
+
+        assert failed == 1
+        with Session(engine) as assert_session:
+            unit = (
+                assert_session.query(SyncRunUnit)
+                .filter(SyncRunUnit.id == unit_id)
+                .one()
+            )
+            assert unit.status == SyncRunUnitStatus.FAILED.value
+            assert unit.error == "sync dispatch denied"
+            assert unit.result == {"error_category": "dispatch_denied"}
+    finally:
+        engine.dispose()

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -114,6 +114,11 @@ def _seed_run(session, *, mode=SyncRunMode.INCREMENTAL.value):
     return run, unit
 
 
+def _mark_dispatching(session, unit):
+    unit.status = SyncRunUnitStatus.DISPATCHING.value
+    session.flush()
+
+
 def _seed_zero_unit_run(session):
     org_id = str(uuid.uuid4())
     integration = Integration(
@@ -170,6 +175,7 @@ def test_run_sync_unit_success_persists_status_and_incremental_watermark(
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     _patch_runtime(monkeypatch)
     finalize_calls = _patch_finalize_apply(monkeypatch)
@@ -204,6 +210,7 @@ def test_run_sync_unit_success_survives_finalize_enqueue_failure(
     from dev_health_ops.workers import sync_units
 
     run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     _patch_runtime(monkeypatch)
     monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
@@ -233,6 +240,7 @@ def test_run_sync_unit_success_skips_watermark_for_backfill(db_session, monkeypa
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_run(db_session, mode=SyncRunMode.BACKFILL.value)
+    _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     _patch_runtime(monkeypatch)
     finalize_calls = _patch_finalize_apply(monkeypatch)
@@ -257,6 +265,7 @@ def test_run_sync_unit_failure_persists_failed_and_error(db_session, monkeypatch
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     _patch_runtime(monkeypatch)
     finalize_calls = _patch_finalize_apply(monkeypatch)
@@ -287,6 +296,7 @@ def test_run_sync_unit_sets_and_clears_lease_around_provider_call(
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     _patch_runtime(monkeypatch)
     _patch_finalize_apply(monkeypatch)
@@ -318,6 +328,7 @@ def test_heartbeat_extends_live_matching_lease(db_session, monkeypatch):
     from dev_health_ops.workers import sync_units
 
     run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
     now = datetime.now(timezone.utc)
     unit.status = SyncRunUnitStatus.RUNNING.value
     unit.lease_owner = "worker-1"
@@ -355,6 +366,7 @@ def test_worker_success_after_reconciler_failed_does_not_overwrite_terminal(
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     _patch_runtime(monkeypatch)
     finalize_calls = _patch_finalize_apply(monkeypatch)
@@ -437,6 +449,41 @@ def test_run_sync_unit_skips_terminal_run_without_overwriting_unit(
     }
     assert unit.status == SyncRunUnitStatus.DISPATCHING.value
     assert unit.error == "broker down"
+    assert finalize_calls == []
+
+
+def test_run_sync_unit_skips_duplicate_delivery_with_live_running_lease(
+    db_session, monkeypatch
+):
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    unit.status = SyncRunUnitStatus.RUNNING.value
+    unit.lease_owner = "worker-live"
+    unit.lease_expires_at = now + timedelta(minutes=10)
+    unit.last_heartbeat_at = now
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    finalize_calls = _patch_finalize_apply(monkeypatch)
+
+    def fail_if_called(ctx, runtime):
+        raise AssertionError("duplicate delivery must not execute provider work")
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", fail_if_called)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    assert result == {
+        "status": "skipped",
+        "unit_id": str(unit.id),
+        "reason": "not_dispatchable",
+    }
+    assert unit.status == SyncRunUnitStatus.RUNNING.value
+    assert unit.lease_owner == "worker-live"
     assert finalize_calls == []
 
 
@@ -860,6 +907,7 @@ def test_run_sync_unit_success_stamps_watermark_for_full_resync(
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_run(db_session, mode=SyncRunMode.FULL_RESYNC.value)
+    _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     _patch_runtime(monkeypatch)
     _patch_finalize_apply(monkeypatch)

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -402,6 +402,7 @@ def test_run_sync_unit_bootstrap_failure_enqueues_finalize(db_session, monkeypat
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     finalize_calls = _patch_finalize_apply(monkeypatch)
 
@@ -417,6 +418,72 @@ def test_run_sync_unit_bootstrap_failure_enqueues_finalize(db_session, monkeypat
     assert unit.status == SyncRunUnitStatus.FAILED.value
     assert unit.error == "missing source"
     assert finalize_calls == [((str(run.id),), "sync")]
+
+
+def test_run_sync_unit_bootstrap_failure_skips_duplicate_live_running_lease(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.sync_bootstrap import SyncTaskBootstrap
+
+    run, unit = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    lease_expires_at = now + timedelta(minutes=10)
+    unit.status = SyncRunUnitStatus.RUNNING.value
+    unit.lease_owner = "other-worker"
+    unit.lease_expires_at = lease_expires_at
+    unit.last_heartbeat_at = now
+    unit.error = "existing error"
+    unit.result = {"existing": True}
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+
+    dispatch_calls = []
+    finalize_calls = []
+    chord_calls = []
+
+    class FakeChord:
+        def apply_async(self):
+            chord_calls.append("apply_async")
+
+    def fail_bootstrap(session, unit_id):
+        raise ValueError("missing source")
+
+    monkeypatch.setattr(SyncTaskBootstrap, "load", fail_bootstrap)
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: dispatch_calls.append((args, queue)),
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: finalize_calls.append((args, queue)),
+    )
+    monkeypatch.setattr(
+        sync_units,
+        "chord",
+        lambda *args, **kwargs: FakeChord(),
+    )
+
+    result = getattr(sync_units.run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    assert result == {
+        "status": "skipped",
+        "unit_id": str(unit.id),
+        "reason": "not_dispatchable",
+    }
+    assert unit.status == SyncRunUnitStatus.RUNNING.value
+    assert unit.lease_owner == "other-worker"
+    persisted_lease_expires_at = unit.lease_expires_at
+    assert persisted_lease_expires_at is not None
+    assert _aware(persisted_lease_expires_at) == lease_expires_at
+    assert unit.error == "existing error"
+    assert unit.result == {"existing": True}
+    assert dispatch_calls == []
+    assert finalize_calls == []
+    assert chord_calls == []
 
 
 def test_run_sync_unit_skips_terminal_run_without_overwriting_unit(

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -24,6 +24,12 @@ from dev_health_ops.models import (
 )
 
 
+def _aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
 @pytest.fixture
 def db_session():
     engine = create_engine("sqlite:///:memory:")
@@ -181,6 +187,9 @@ def test_run_sync_unit_success_persists_status_and_incremental_watermark(
     assert unit.status == SyncRunUnitStatus.SUCCESS.value
     assert unit.attempts == 1
     assert unit.result == {"ok": True}
+    assert unit.lease_owner is None
+    assert unit.lease_expires_at is None
+    assert unit.last_heartbeat_at is not None
     watermark = db_session.query(SyncWatermark).one()
     assert watermark.org_id == run.org_id
     assert watermark.source_id == "full-chaos/dev-health"
@@ -265,6 +274,114 @@ def test_run_sync_unit_failure_persists_failed_and_error(db_session, monkeypatch
     db_session.refresh(unit)
     assert unit.status == SyncRunUnitStatus.FAILED.value
     assert unit.error == "adapter failed"
+    assert unit.lease_owner is None
+    assert unit.lease_expires_at is None
+    assert unit.last_heartbeat_at is not None
+    assert finalize_calls == [((str(run.id),), "sync")]
+
+
+def test_run_sync_unit_sets_and_clears_lease_around_provider_call(
+    db_session, monkeypatch
+):
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.setenv("SYNC_UNIT_RUNNING_STALE_SECONDS", "120")
+
+    def run_dataset(ctx, runtime):
+        db_session.refresh(unit)
+        assert unit.status == SyncRunUnitStatus.RUNNING.value
+        assert unit.lease_owner is not None
+        assert unit.lease_expires_at is not None
+        assert _aware(unit.lease_expires_at) > datetime.now(timezone.utc)
+        assert unit.last_heartbeat_at is not None
+        return {"ok": True}
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", run_dataset)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    assert result["status"] == "success"
+    assert unit.status == SyncRunUnitStatus.SUCCESS.value
+    assert unit.lease_owner is None
+    assert unit.lease_expires_at is None
+
+
+def test_heartbeat_extends_live_matching_lease(db_session, monkeypatch):
+    import threading
+
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    unit.status = SyncRunUnitStatus.RUNNING.value
+    unit.lease_owner = "worker-1"
+    unit.lease_expires_at = now + timedelta(seconds=30)
+    unit.last_heartbeat_at = now
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setattr(sync_units, "_heartbeat_interval_seconds", lambda: 1)
+    monkeypatch.setattr(sync_units, "_running_lease_seconds", lambda: 120)
+
+    class OneHeartbeatStop(threading.Event):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def wait(self, timeout=None):
+            self.calls += 1
+            return self.calls > 1
+
+    sync_units._heartbeat_unit_lease(str(unit.id), "worker-1", OneHeartbeatStop())
+
+    db_session.refresh(unit)
+    lease_expires_at = unit.lease_expires_at
+    last_heartbeat_at = unit.last_heartbeat_at
+    assert lease_expires_at is not None
+    assert last_heartbeat_at is not None
+    assert _aware(lease_expires_at) > now + timedelta(seconds=30)
+    assert _aware(last_heartbeat_at) > now
+
+
+def test_worker_success_after_reconciler_failed_does_not_overwrite_terminal(
+    db_session, monkeypatch
+):
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    finalize_calls = _patch_finalize_apply(monkeypatch)
+
+    def run_dataset(ctx, runtime):
+        db_session.refresh(unit)
+        unit.status = SyncRunUnitStatus.FAILED.value
+        unit.error = "sync unit lease expired"
+        unit.result = {"error_category": "worker_lost"}
+        unit.lease_owner = None
+        unit.lease_expires_at = None
+        db_session.flush()
+        return {"ok": True}
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", run_dataset)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    assert result == {
+        "status": "skipped",
+        "unit_id": str(unit.id),
+        "reason": "terminal",
+    }
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert unit.error == "sync unit lease expired"
+    assert unit.result == {"error_category": "worker_lost"}
     assert finalize_calls == [((str(run.id),), "sync")]
 
 
@@ -582,7 +699,7 @@ def test_dispatch_sync_run_denies_inactive_migrated_child_config(
     assert parent_config.last_sync_error == "sync configuration is paused"
 
 
-def test_dispatch_sync_run_marks_run_failed_when_chord_enqueue_fails(
+def test_dispatch_sync_run_does_not_terminalize_when_chord_enqueue_fails(
     db_session, monkeypatch
 ):
     from dev_health_ops.workers import sync_units
@@ -619,13 +736,13 @@ def test_dispatch_sync_run_marks_run_failed_when_chord_enqueue_fails(
 
     db_session.refresh(run)
     db_session.refresh(unit)
-    assert run.status == SyncRunStatus.FAILED.value
-    assert run.completed_at is not None
-    assert run.error == "broker down"
-    assert run.result == {"error": "broker down", "phase": "dispatch_enqueue"}
-    assert run.failed_units == 1
-    assert unit.status == SyncRunUnitStatus.FAILED.value
-    assert unit.error == "broker down"
+    assert run.status == SyncRunStatus.DISPATCHING.value
+    assert run.completed_at is None
+    assert run.error is None
+    assert run.result is None
+    assert run.failed_units == 0
+    assert unit.status == SyncRunUnitStatus.DISPATCHING.value
+    assert unit.error is None
 
 
 def test_dispatch_sync_run_redispatches_stale_dispatching_units(
@@ -667,10 +784,6 @@ def test_dispatch_sync_run_redispatches_stale_dispatching_units(
 def test_dispatch_sync_run_does_not_reclaim_stale_running_units(
     db_session, monkeypatch
 ):
-    # F2 regression: a unit that is RUNNING (even stale) must NOT be reclaimed.
-    # run_sync_unit does not heartbeat during the provider call, so reclaiming
-    # a stale RUNNING unit would cause duplicate provider writes.  Durable
-    # dead-worker recovery is a separate follow-up (CHAOS-2577).
     from dev_health_ops.workers import sync_units
 
     run, unit = _seed_run(db_session)
@@ -695,10 +808,8 @@ def test_dispatch_sync_run_does_not_reclaim_stale_running_units(
     )
 
     result = sync_units.dispatch_sync_run(str(run.id))
-    # No units should be dispatched — stale RUNNING is not reclaimed.
     assert result["queued_units"] == 0
     db_session.refresh(unit)
-    # Unit must remain RUNNING, not flipped to DISPATCHING.
     assert unit.status == SyncRunUnitStatus.RUNNING.value
 
 

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -225,7 +225,7 @@ def _patch_worker_enqueues(monkeypatch):
     monkeypatch.setattr(
         sync_units.dispatch_sync_run,
         "apply_async",
-        lambda args=None, queue=None: dispatch_calls.append((args, queue)),
+        lambda args=None, queue=None, **kwargs: dispatch_calls.append((args, queue)),
     )
     monkeypatch.setattr(
         sync_units.finalize_sync_run,
@@ -718,6 +718,76 @@ def test_bootstrap_failure_cas_loses_to_reconciler(tmp_path, monkeypatch):
         engine.dispose()
 
 
+def test_slow_bootstrap_loses_lease_before_provider_does_not_execute(
+    tmp_path, monkeypatch
+):
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.sync_bootstrap import SyncTaskBootstrap
+
+    engine = _file_backed_engine(tmp_path)
+    try:
+        with Session(engine) as seed_session:
+            _, unit = _seed_run(seed_session)
+            _mark_dispatching(seed_session, unit)
+            unit_id = unit.id
+            seed_session.commit()
+        _patch_db_session_factory(monkeypatch, engine)
+        dispatch_calls, finalize_calls, chord_calls = _patch_worker_enqueues(
+            monkeypatch
+        )
+        heartbeat_started = []
+        original_load = SyncTaskBootstrap.load
+
+        def start_heartbeat(unit_id_arg, lease_owner):
+            heartbeat_started.append((unit_id_arg, lease_owner))
+            return None, None
+
+        monkeypatch.setattr(
+            sync_units,
+            "_start_unit_heartbeat",
+            start_heartbeat,
+        )
+
+        def load_then_lose_lease(session, unit_id_arg):
+            ctx = original_load(session, unit_id_arg)
+            session.commit()
+            _commit_reconciler_failure(engine, unit_id)
+            return ctx
+
+        def fail_if_provider_called(ctx, runtime):
+            raise AssertionError("provider work must not run after lease loss")
+
+        monkeypatch.setattr(SyncTaskBootstrap, "load", load_then_lose_lease)
+        monkeypatch.setattr(
+            dataset_adapters, "run_dataset_unit", fail_if_provider_called
+        )
+
+        result = getattr(sync_units.run_sync_unit, "run")(str(unit_id))
+
+        with Session(engine) as assert_session:
+            unit = (
+                assert_session.query(SyncRunUnit)
+                .filter(SyncRunUnit.id == unit_id)
+                .one()
+            )
+            assert result == {
+                "status": "skipped",
+                "unit_id": str(unit_id),
+                "reason": "lease_lost",
+            }
+            assert unit.status == SyncRunUnitStatus.FAILED.value
+            assert unit.error == "sync unit lease expired"
+            assert unit.result == {"error_category": "worker_lost"}
+            assert assert_session.query(SyncWatermark).count() == 0
+        assert heartbeat_started and heartbeat_started[0][0] == str(unit_id)
+        assert dispatch_calls == []
+        assert finalize_calls == []
+        assert chord_calls == []
+    finally:
+        engine.dispose()
+
+
 def test_success_cas_and_watermark_are_one_transaction(db_session, monkeypatch):
     from dev_health_ops.processors import dataset_adapters
     from dev_health_ops.workers import sync_units
@@ -1069,6 +1139,96 @@ def test_dispatch_sync_run_denies_inactive_planner_config(db_session, monkeypatc
     assert unit.error == "sync configuration is paused"
     assert config.last_sync_success is False
     assert config.last_sync_error == "sync configuration is paused"
+
+
+def test_paused_config_with_running_and_planned_units_does_not_strand(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler, sync_units
+
+    run, running = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    running.status = SyncRunUnitStatus.RUNNING.value
+    running.attempts = 1
+    running.lease_owner = "worker-live"
+    running.lease_expires_at = now + timedelta(minutes=5)
+    running.last_heartbeat_at = now
+    planned = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=running.integration_id,
+        source_id=running.source_id,
+        provider="github",
+        dataset_key="prs",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.PLANNED.value,
+        attempts=0,
+        processor_flags={"sync_prs": True},
+    )
+    config = SyncConfiguration(
+        org_id=run.org_id,
+        name="paused-with-running",
+        provider="github",
+        sync_targets=["git", "prs"],
+        sync_options={},
+        migrated_integration_id=run.integration_id,
+        is_active=False,
+    )
+    run.status = SyncRunStatus.DISPATCHING.value
+    run.total_units = 2
+    db_session.add_all([planned, config])
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    dispatch_calls, finalize_calls, chord_calls = _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setattr(sync_units, "_dispatch_post_sync_tasks", lambda **kwargs: None)
+
+    dispatch_result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    db_session.refresh(running)
+    db_session.refresh(planned)
+    db_session.refresh(config)
+    assert dispatch_result == {"status": "noop", "queued_units": 0}
+    assert run.status not in {
+        SyncRunStatus.SUCCESS.value,
+        SyncRunStatus.PARTIAL_FAILED.value,
+        SyncRunStatus.FAILED.value,
+    }
+    assert run.completed_at is None
+    assert config.last_sync_at is None
+    assert planned.status == SyncRunUnitStatus.FAILED.value
+    assert planned.error == "sync configuration is paused"
+    assert running.status == SyncRunUnitStatus.RUNNING.value
+    assert running.lease_owner == "worker-live"
+    assert dispatch_calls == [((str(run.id),), "sync")]
+    assert finalize_calls == []
+    assert chord_calls == []
+
+    running.lease_expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    db_session.flush()
+
+    reconcile_result = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    db_session.refresh(running)
+    assert reconcile_result["expired_units"] == 1
+    assert running.status == SyncRunUnitStatus.FAILED.value
+    assert finalize_calls == [((str(run.id),), "sync")]
+
+    finalize_result = sync_units.finalize_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    units = (
+        db_session.query(SyncRunUnit).filter(SyncRunUnit.sync_run_id == run.id).all()
+    )
+    assert finalize_result["status"] == "finalized"
+    assert all(
+        unit.status in {SyncRunUnitStatus.SUCCESS.value, SyncRunUnitStatus.FAILED.value}
+        for unit in units
+    )
+    assert run.status == SyncRunStatus.FAILED.value
+    assert run.completed_at is not None
+    assert run.failed_units == 2
 
 
 def test_dispatch_sync_run_denies_inactive_migrated_child_config(

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -41,13 +41,19 @@ def db_session():
 
 @contextmanager
 def _fake_session_ctx(session):
-    yield session
-    session.commit()
+    try:
+        yield session
+    except Exception:
+        session.rollback()
+        raise
+    else:
+        session.commit()
 
 
 def _patch_db_session(monkeypatch, session):
     import dev_health_ops.db as db
 
+    session.commit()
     monkeypatch.setattr(
         db, "get_postgres_session_sync", lambda: _fake_session_ctx(session)
     )
@@ -166,6 +172,31 @@ def _patch_finalize_apply(monkeypatch):
         lambda args=None, queue=None: calls.append((args, queue)),
     )
     return calls
+
+
+def _patch_worker_enqueues(monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    dispatch_calls = []
+    finalize_calls = []
+    chord_calls = []
+
+    class FakeChord:
+        def apply_async(self):
+            chord_calls.append("apply_async")
+
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: dispatch_calls.append((args, queue)),
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: finalize_calls.append((args, queue)),
+    )
+    monkeypatch.setattr(sync_units, "chord", lambda *args, **kwargs: FakeChord())
+    return dispatch_calls, finalize_calls, chord_calls
 
 
 def test_run_sync_unit_success_persists_status_and_incremental_watermark(
@@ -404,7 +435,7 @@ def test_run_sync_unit_bootstrap_failure_enqueues_finalize(db_session, monkeypat
     run, unit = _seed_run(db_session)
     _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
-    finalize_calls = _patch_finalize_apply(monkeypatch)
+    dispatch_calls, finalize_calls, chord_calls = _patch_worker_enqueues(monkeypatch)
 
     def fail_bootstrap(session, unit_id):
         raise ValueError("missing source")
@@ -416,8 +447,49 @@ def test_run_sync_unit_bootstrap_failure_enqueues_finalize(db_session, monkeypat
     db_session.refresh(unit)
     assert result["status"] == "failed"
     assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert unit.attempts == 1
     assert unit.error == "missing source"
+    assert unit.lease_owner is None
+    assert unit.lease_expires_at is None
+    assert unit.result == {"error_category": "adapter_error"}
+    assert dispatch_calls == []
     assert finalize_calls == [((str(run.id),), "sync")]
+    assert chord_calls == []
+
+
+def test_run_sync_unit_bootstrap_failure_survives_session_rollback(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers.sync_bootstrap import SyncTaskBootstrap
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    dispatch_calls, finalize_calls, chord_calls = _patch_worker_enqueues(monkeypatch)
+
+    def fail_bootstrap(session, unit_id):
+        db_session.refresh(unit)
+        assert unit.status == SyncRunUnitStatus.RUNNING.value
+        assert unit.lease_owner is not None
+        assert unit.lease_expires_at is not None
+        raise ValueError("missing source")
+
+    monkeypatch.setattr(SyncTaskBootstrap, "load", fail_bootstrap)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    assert result["status"] == "failed"
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert unit.attempts == 1
+    assert unit.error == "missing source"
+    assert unit.lease_owner is None
+    assert unit.lease_expires_at is None
+    assert unit.result == {"error_category": "adapter_error"}
+    assert dispatch_calls == []
+    assert finalize_calls == [((str(run.id),), "sync")]
+    assert chord_calls == []
 
 
 def test_run_sync_unit_bootstrap_failure_skips_duplicate_live_running_lease(
@@ -437,34 +509,12 @@ def test_run_sync_unit_bootstrap_failure_skips_duplicate_live_running_lease(
     unit.result = {"existing": True}
     db_session.flush()
     _patch_db_session(monkeypatch, db_session)
-
-    dispatch_calls = []
-    finalize_calls = []
-    chord_calls = []
-
-    class FakeChord:
-        def apply_async(self):
-            chord_calls.append("apply_async")
+    dispatch_calls, finalize_calls, chord_calls = _patch_worker_enqueues(monkeypatch)
 
     def fail_bootstrap(session, unit_id):
         raise ValueError("missing source")
 
     monkeypatch.setattr(SyncTaskBootstrap, "load", fail_bootstrap)
-    monkeypatch.setattr(
-        sync_units.dispatch_sync_run,
-        "apply_async",
-        lambda args=None, queue=None: dispatch_calls.append((args, queue)),
-    )
-    monkeypatch.setattr(
-        sync_units.finalize_sync_run,
-        "apply_async",
-        lambda args=None, queue=None: finalize_calls.append((args, queue)),
-    )
-    monkeypatch.setattr(
-        sync_units,
-        "chord",
-        lambda *args, **kwargs: FakeChord(),
-    )
 
     result = getattr(sync_units.run_sync_unit, "run")(str(unit.id))
 

--- a/uv.lock
+++ b/uv.lock
@@ -907,6 +907,7 @@ dev = [
     { name = "fakeredis", extra = ["valkey"] },
     { name = "mako" },
     { name = "mypy" },
+    { name = "pandas-stubs" },
     { name = "pip-audit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -948,6 +949,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.45b0" },
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.45b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.24.0" },
+    { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=3.0.3.260530" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7.0" },
     { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=8.0.0" },
@@ -2209,6 +2211,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas-stubs"
+version = "3.0.3.260530"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/aa/c41a8a0ff86fd85dbb3ec0c1f3fa488ca64a8b5f82654ae1b07d84acefe5/pandas_stubs-3.0.3.260530.tar.gz", hash = "sha256:d1efe47b2e5a312c047d7feabec5cb7a55365747983420077e9fcbe9ab74f714", size = 113183, upload-time = "2026-05-30T17:47:40.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/e0/99ec5b02203c4e9ce878bc63d8caa06ac1f891e4d63bded9a5ced70fcb4f/pandas_stubs-3.0.3.260530-py3-none-any.whl", hash = "sha256:a6277eb1c8cebf48d9b2413fcd2e9a6b4ff479c934a223c29eacbc3058c4cb55", size = 173780, upload-time = "2026-05-30T17:47:39.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add explicit sync unit lease columns and index for RUNNING worker liveness.
- Heartbeat RUNNING units starting immediately after the DISPATCHING→RUNNING claim, and require a matching live lease before provider execution and terminal writes.
- Split dispatch capacity accounting so NULL leases count live and only expired explicit leases stop consuming cap.
- Keep redispatch denial from terminalizing runs that already have DISPATCHING/RUNNING units; planned units fail while in-flight units reconcile/finalize normally.
- Add a periodic sync reconciler that fails expired RUNNING leases and best-effort re-drives dispatch/finalize.
- Stop terminalizing possibly-published sync work on redispatch publish failure; PR-2 will move redispatch to durable outbox.
- Make migration 0019's concurrent lease index create/drop idempotent.

## Deferred / tracked
- CHAOS-2590 tracks deploy-window pre-migration NULL-lease RUNNING units that can remain unrecoverable and leak bucket capacity.
- CHAOS-2581 (PR-2) covers the chord-publish-failure / dead `_mark_dispatch_enqueue_failed` low-risk follow-up.
- The migration invalid-index rerun caveat is mitigated here with `CREATE INDEX CONCURRENTLY IF NOT EXISTS` / `DROP INDEX CONCURRENTLY IF EXISTS`.

## Verification
- `CLICKHOUSE_URI= uv run --extra dev --python 3.11 pytest tests/ -q` (5572 passed, 102 skipped)
- `ruff format --check && ruff check && mypy`
- `uv run --extra dev --python 3.11 pytest tests/test_sync_units.py -q` (32 passed)
- `dev-hops migrate upgrade 0019 && dev-hops migrate downgrade 0018 && dev-hops migrate upgrade 0019` against a temporary local PostgreSQL database
- Read-only review agents: lease/code review PASS; QA regression review PASS

Closes CHAOS-2585