### PR TITLE
docs(sync): backfill→incremental composition contract — no date gap (CHAOS-2570)

### DIFF
--- a/docs/architecture/data-pipeline.md
+++ b/docs/architecture/data-pipeline.md
@@ -258,16 +258,18 @@ rather than a 1-day window.
 long as the first incremental runs within `initial_sync_depth` of the backfill's
 `before`. In the canonical onboarding flow (backfill up to ~now, then daily
 incrementals) the cold-start window `[now - depth, now]` overlaps the backfill's
-upper bound, so coverage is continuous. Continuity is **depth-driven, not
-marker-driven**, so backfill stays watermark-free and no `backfilled-through`
-marker (or migration) is required.
+upper bound, so coverage is continuous. The no-gap guarantee is **bounded to the
+cold-start depth**: backfill stays watermark-free (CHAOS-2514) and no
+`backfilled-through` marker is introduced. Closing the paused-then-resumed
+residual below would require such a marker and is deliberately deferred
+(CHAOS-2588).
 
 **Residual edges (intentional / tracked):**
 
 1. *Paused-then-resumed* -- if the first incremental runs **more than
    `initial_sync_depth` days** after the backfill's `before` (e.g. scheduling
    paused for >30d immediately after a backfill), a gap `[before, now - depth]`
-   remains. Narrow operational residual, tracked as a follow-up.
+   remains. Narrow operational residual, tracked in CHAOS-2588.
 2. *Deliberate historical backfill* -- backfilling a window whose `before` is
    far in the past does **not** trigger a giant `[before, now]` first
    incremental; the user chose a historical window, and auto-filling to now

--- a/docs/architecture/data-pipeline.md
+++ b/docs/architecture/data-pipeline.md
@@ -246,6 +246,33 @@ Backfill depth is gated by organization billing tier:
 - `models/backfill.py` -- `BackfillJob` PostgreSQL model for progress tracking
 - `api/services/backfill.py` -- `BackfillJobService` async CRUD for API layer
 
+### Composition with Incremental Sync (no date gap)
+
+Backfill **never seeds the watermark** (CHAOS-2514), so the first incremental
+sync after a backfill cold-starts. Continuity across the seam is provided by the
+incremental **cold-start depth** (CHAOS-2569): with no watermark, the planner
+resolves `window_start = now - initial_sync_depth` (default 30d, tier-capped)
+rather than a 1-day window.
+
+**Contract:** a `backfill` followed by `Sync Now` produces **no date gap** as
+long as the first incremental runs within `initial_sync_depth` of the backfill's
+`before`. In the canonical onboarding flow (backfill up to ~now, then daily
+incrementals) the cold-start window `[now - depth, now]` overlaps the backfill's
+upper bound, so coverage is continuous. Continuity is **depth-driven, not
+marker-driven**, so backfill stays watermark-free and no `backfilled-through`
+marker (or migration) is required.
+
+**Residual edges (intentional / tracked):**
+
+1. *Paused-then-resumed* -- if the first incremental runs **more than
+   `initial_sync_depth` days** after the backfill's `before` (e.g. scheduling
+   paused for >30d immediately after a backfill), a gap `[before, now - depth]`
+   remains. Narrow operational residual, tracked as a follow-up.
+2. *Deliberate historical backfill* -- backfilling a window whose `before` is
+   far in the past does **not** trigger a giant `[before, now]` first
+   incremental; the user chose a historical window, and auto-filling to now
+   would be surprising and expensive. This is **intended**, not a gap to close.
+
 ## Storage Schema Highlights
 
 ### ClickHouse Tables

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -17,6 +17,14 @@ Responsibilities (CHAOS-2511):
 Invariants:
   * Disabled source -> zero units. Disabled dataset -> zero units.
   * Backfill units carry mode="backfill" and must never update watermarks.
+  * Backfill -> incremental composition (CHAOS-2570): because backfill never
+    seeds a watermark, the first incremental after a backfill cold-starts;
+    continuity is provided by the cold-start depth (CHAOS-2569,
+    ``window_start = now - initial_sync_depth``). No date gap results as long as
+    the first incremental runs within ``initial_sync_depth`` of the backfill's
+    ``before``. This is depth-driven, not marker-driven, so backfill stays
+    watermark-free (CHAOS-2514) with no ``backfilled-through`` marker/migration.
+    See docs/architecture/data-pipeline.md (Composition with Incremental Sync).
   * total_units on the persisted SyncRun equals len(unit_ids).
 """
 

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -22,9 +22,12 @@ Invariants:
     continuity is provided by the cold-start depth (CHAOS-2569,
     ``window_start = now - initial_sync_depth``). No date gap results as long as
     the first incremental runs within ``initial_sync_depth`` of the backfill's
-    ``before``. This is depth-driven, not marker-driven, so backfill stays
-    watermark-free (CHAOS-2514) with no ``backfilled-through`` marker/migration.
-    See docs/architecture/data-pipeline.md (Composition with Incremental Sync).
+    ``before``. The no-gap guarantee is therefore BOUNDED to that depth window:
+    backfill stays watermark-free (CHAOS-2514) and no ``backfilled-through``
+    marker is introduced. If the first incremental is delayed beyond
+    ``initial_sync_depth`` after ``before``, the residual gap
+    ``[before, now - depth]`` is an accepted, tracked limitation (CHAOS-2588)
+    whose fix would require such a marker. See docs/architecture/data-pipeline.md.
   * total_units on the persisted SyncRun equals len(unit_ids).
 """
 

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -696,3 +696,38 @@ def test_incremental_cold_start_seam_is_depth_bounded(db_session):
     assert abs((since - boundary).total_seconds()) < 5
     # A backfill ending at/after the boundary is covered (no gap).
     assert since <= boundary + timedelta(seconds=5)
+
+
+def test_cold_start_does_not_cover_backfill_before_older_than_depth(db_session):
+    """CHAOS-2588 residual (documented boundary): a backfill whose ``before`` is
+    OLDER than ``now - initial_sync_depth`` is NOT covered by the incremental
+    cold-start window, so a gap ``[before, now - depth]`` remains. This proves the
+    no-gap guarantee is BOUNDED (depth-driven, marker-less), not universal -- it
+    is the accepted, tracked limit handed off to CHAOS-2588.
+    """
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, "commits")
+
+    now = datetime.now(timezone.utc)
+    backfill_before = now - timedelta(days=90)  # older than depth (30d)
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+        ),
+    )
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert units[0].since_at is not None
+    since = units[0].since_at.replace(tzinfo=timezone.utc)
+    # Cold-start starts at now-depth, which is AFTER the old backfill `before`,
+    # so the residual gap [backfill_before, since] is non-empty.
+    assert since > backfill_before

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -18,7 +18,7 @@ from dev_health_ops.models import (
     SyncRunUnitStatus,
 )
 from dev_health_ops.sync.planner import SyncPlanRequest, plan_sync_run
-from dev_health_ops.sync.watermarks import set_watermark
+from dev_health_ops.sync.watermarks import get_watermark, set_watermark
 
 ORG_ID = "planner-org"
 
@@ -598,3 +598,101 @@ def test_plan_sync_run_succeeds_when_tier_limits_unavailable(db_session, monkeyp
     assert abs((since - expected_start).total_seconds()) < 2, (
         f"Expected depth=30 (community default), got since_at={since}"
     )
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2570: backfill -> incremental composition (no date gap)
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_then_incremental_has_no_date_gap(db_session):
+    """Canonical onboarding flow: a backfill (which never seeds a watermark per
+    CHAOS-2514) followed by an incremental must leave NO date gap.
+
+    With no watermark, the incremental cold-starts at ``now - initial_sync_depth``
+    (CHAOS-2569), which reaches back past a backfill whose ``before`` is ~now, so
+    coverage is continuous across the seam.
+    """
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    _create_dataset(db_session, integration, "commits")
+
+    now = datetime.now(timezone.utc)
+    backfill_before = now  # canonical onboarding: backfill up to ~now
+
+    # 1) Backfill plan: units are mode=backfill and NO watermark is seeded.
+    backfill_plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.BACKFILL.value,
+            triggered_by="backfill",
+            since=now - timedelta(days=14),
+            before=backfill_before,
+        ),
+    )
+    backfill_units = _planned_units(db_session, backfill_plan.sync_run_id)
+    assert {u.mode for u in backfill_units} == {SyncRunMode.BACKFILL.value}
+    assert get_watermark(db_session, ORG_ID, source.external_id, "commits") is None, (
+        "backfill must not seed a watermark (CHAOS-2514)"
+    )
+
+    # 2) First incremental cold-starts; window_start <= backfill `before` => no gap.
+    inc_plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+        ),
+    )
+    inc_units = _planned_units(db_session, inc_plan.sync_run_id)
+    assert len(inc_units) == 1
+    assert inc_units[0].since_at is not None
+    since = inc_units[0].since_at.replace(tzinfo=timezone.utc)
+    assert since <= backfill_before, (
+        "incremental cold-start must reach back to the backfill's `before` "
+        "so there is no date gap"
+    )
+
+
+def test_incremental_cold_start_seam_is_depth_bounded(db_session):
+    """The no-gap guarantee is depth-bounded: the first incremental cold-start
+    window_start is exactly ``now - initial_sync_depth``, so a backfill whose
+    ``before`` is at/after that boundary is seamlessly covered. A backfill whose
+    ``before`` is OLDER than the boundary is the documented residual edge
+    (paused-then-resumed) and is intentionally out of scope here.
+    """
+    from datetime import timedelta
+
+    integration = _create_integration(db_session)
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, "commits")
+
+    now = datetime.now(timezone.utc)
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+        ),
+    )
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert units[0].since_at is not None
+    since = units[0].since_at.replace(tzinfo=timezone.utc)
+    boundary = now - timedelta(days=30)
+    assert abs((since - boundary).total_seconds()) < 5
+    # A backfill ending at/after the boundary is covered (no gap).
+    assert since <= boundary + timedelta(seconds=5)


### PR DESCRIPTION
## Summary

CHAOS-2570 asks: `/backfill` then "Sync Now" must leave **no date gap**. After tracing the runtime path, the literal filed defect (first incremental pulling ~1 day) is **already closed by CHAOS-2569**: with no watermark, the incremental planner cold-starts at `window_start = now - initial_sync_depth` (default 30d) instead of a 1-day window.

This PR makes the **composition contract explicit and locks it with tests** — no behavior change, no migration. Backfill stays watermark-free (CHAOS-2514); continuity is **depth-driven, not marker-driven**, so no `backfilled-through` marker is introduced.

## Why option (a) (no marker/migration)

- The canonical onboarding flow (backfill up to ~now, then daily incrementals) is fully continuous: the cold-start window `[now - depth, now]` overlaps the backfill's `before` → no gap.
- A `backfilled-through` marker (option b) would add schema surface **and** regress the *deliberate historical backfill* case (it would force a giant `[before, now]` first incremental, which users do not want).

## Contract (documented + asserted)

A `backfill` followed by an incremental produces **no date gap** as long as the first incremental runs within `initial_sync_depth` of the backfill's `before`.

**Residual edges (documented):**
1. *Paused-then-resumed* — first incremental delayed > `initial_sync_depth` after `before` → gap `[before, now - depth]`. Narrow operational residual, tracked in **CHAOS-2588**.
2. *Deliberate historical backfill* — `before` far in the past is **intended** (no auto-fill to now); not a gap to close.

## Changes

- `sync/planner.py`: backfill→incremental invariant added to the contract docstring.
- `docs/architecture/data-pipeline.md`: new "Composition with Incremental Sync (no date gap)" section with the contract and both residual edges.
- `tests/test_sync_planner.py`: (1) backfill (no watermark seeded) → incremental cold-start reaches back to the backfill `before` (no gap); (2) the cold-start seam is depth-bounded.

## Deferred / tracked

Paused-then-resumed residual gap → **CHAOS-2588**.

Full suite green (`5553 passed, 102 skipped`); `ruff format`/`ruff check`/`mypy` clean.

SCREENSHOT-WAIVER: backend/docs/tests only; no rendered UI output.

Closes CHAOS-2570