### PR TITLE
fix(workers): own ClickHouse store lifecycle in fan-out runtime cache (CHAOS-2592)

### DIFF
--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -23,11 +23,11 @@ Key implementation details:
 Operators can trigger background operations on-demand through three primary API paths. These paths bypass the periodic scheduler and enqueue tasks directly onto the Celery broker. For detailed API specifications, refer to the [GraphQL API Overview](../api/graphql-overview.md) and the [AI Reports Architecture](../architecture/ai-reports-architecture.md).
 
 1. **Data Sync Trigger**
-   * **Endpoint**: `POST /api/v1/admin/sync-configs/{config_id}/trigger` (defined in `api/admin/routers/sync.py:850-983`)
-   * **Flow**: Creates a `ScheduledJob` and a `PENDING` `JobRun` record, then enqueues either `run_sync_config` or `dispatch_batch_sync` onto the `sync` queue.
+   * **Endpoint**: `POST /api/v1/admin/sync-configs/{config_id}/trigger` (defined in `api/admin/routers/sync.py:997-1164`)
+   * **Flow**: For migrated sync configurations with `sync.migrated_trigger_routing_enabled`, builds a `SyncPlanRequest`, creates a `SyncRun`, and enqueues `dispatch_sync_run` onto the `sync` queue. Legacy configurations still create a `ScheduledJob` and a `PENDING` `JobRun`, then enqueue either `run_sync_config` or `dispatch_batch_sync` onto the `sync` queue.
 
 2. **Historical Backfill Trigger**
-   * **Endpoint**: `POST /api/v1/admin/sync-configs/{config_id}/backfill` (defined in `api/admin/routers/sync.py:986-1045`)
+   * **Endpoint**: `POST /api/v1/admin/sync-configs/{config_id}/backfill` (defined in `api/admin/routers/sync.py:1167-1233`)
    * **Flow**: Creates a `BackfillJob` record and triggers `run_backfill.delay` on the `backfill` queue.
 
 3. **Report Execution Trigger**
@@ -38,10 +38,10 @@ Operators can trigger background operations on-demand through three primary API 
 
 The following table maps bare CLI commands to their Celery task equivalents, trigger paths, and required worker environment variables.
 
-| CLI Command (Inline, May Fail) | Celery Task | Trigger Path | Required Worker Env |
+| CLI Command (Inline, May Fail) | Celery Task Equivalent | Trigger Path | Required Worker Env |
 |---|---|---|---|
-| `dev-hops sync git/prs/cicd/deployments/incidents/security/tests` | `run_sync_config` | `POST /api/v1/admin/sync-configs/{config_id}/trigger` | `GITHUB_TOKEN`, `GITLAB_TOKEN`, `JIRA_API_TOKEN`, `JIRA_EMAIL` |
-| `dev-hops sync work-items` | `run_work_items_sync` | `POST /api/v1/admin/sync-configs/{config_id}/trigger` | `GITHUB_TOKEN`, `GITLAB_TOKEN`, `JIRA_API_TOKEN`, `JIRA_EMAIL` |
+| `dev-hops sync git/prs/cicd/deployments/incidents/security/tests` | Migrated configs: `dispatch_sync_run` → `run_sync_unit` → `finalize_sync_run`; legacy configs: `run_sync_config` / `dispatch_batch_sync` | `POST /api/v1/admin/sync-configs/{config_id}/trigger` | `GITHUB_TOKEN`, `GITLAB_TOKEN`, `JIRA_API_TOKEN`, `JIRA_EMAIL` |
+| `dev-hops sync work-items` | Migrated configs: `dispatch_sync_run` → `run_sync_unit` → `finalize_sync_run`; legacy sync-config trigger: `run_sync_config` / `dispatch_batch_sync` with work-items handled inside the worker; standalone worker wrapper: `run_work_items_sync` | `POST /api/v1/admin/sync-configs/{config_id}/trigger` | `GITHUB_TOKEN`, `GITLAB_TOKEN`, `JIRA_API_TOKEN`, `JIRA_EMAIL` |
 | `dev-hops metrics daily` | `run_daily_metrics` / `dispatch_daily_metrics_partitioned` | Periodic Beat Schedule | `CLICKHOUSE_URI`, `DATABASE_URI` |
 | `dev-hops recommendations compute` | `run_recommendations_job` | Periodic Beat Schedule | `CLICKHOUSE_URI`, `DATABASE_URI` |
 | `dev-hops work-graph build` | `run_work_graph_build` | Periodic Beat Schedule | `CLICKHOUSE_URI`, `DATABASE_URI` |
@@ -112,10 +112,13 @@ celery -A dev_health_ops.workers.celery_app beat --loglevel=INFO
 
 ## Task Registry
 
-The system registers 34 tasks under the `workers/` directory. All registered tasks, their wrapped CLI operations, and their target queues are listed in the table below.
+The system registers Celery tasks under the `workers/` directory. The primary registered tasks, their wrapped CLI-equivalent operations, and their target queues are listed in the table below.
 
 | Task Name | Wrapped CLI Operation | Queue | Description |
 |---|---|---|---|
+| `dispatch_sync_run` | None | `sync` | Authorizes a planned `SyncRun`, routes each pending unit, and fans out `run_sync_unit` tasks. Source: `sync_units.py:113-190`. |
+| `run_sync_unit` | None | `sync` (or `sync.<provider>` / cost-class queue) | Executes exactly one planned source/dataset/window unit and updates its status. Source: `sync_units.py:193-293`. |
+| `finalize_sync_run` | None | `sync` | Aggregates unit statuses and dispatches post-sync work once all units are terminal. Source: `sync_units.py:295-513`. |
 | `run_sync_config` | `sync git/prs/cicd/deployments/incidents/security/tests` + work-items | `sync` (or `sync.<provider>`) | Syncs a single repository configuration. Source: `sync_runtime.py:408-527`. |
 | `dispatch_batch_sync` | None | `sync` | Discovers repositories in an organization and schedules syncs. Source: `sync_batch.py:301`. |
 | `_batch_sync_callback` | None | `sync` | Callback task for batch sync completion. Source: `sync_batch.py:267`. |

--- a/src/dev_health_ops/workers/sync_bootstrap.py
+++ b/src/dev_health_ops/workers/sync_bootstrap.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import logging
 import threading
 import uuid
 from collections import OrderedDict
@@ -30,6 +31,9 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -281,6 +285,6 @@ async def _enter_store(store: Any) -> None:
         if aexit is not None:
             try:
                 await aexit(None, None, None)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Best-effort store __aexit__ failed after __aenter__ error", exc_info=exc)
         raise

--- a/src/dev_health_ops/workers/sync_bootstrap.py
+++ b/src/dev_health_ops/workers/sync_bootstrap.py
@@ -286,5 +286,8 @@ async def _enter_store(store: Any) -> None:
             try:
                 await aexit(None, None, None)
             except Exception as exc:
-                logger.debug("Best-effort store __aexit__ failed after __aenter__ error", exc_info=exc)
+                logger.debug(
+                    "Best-effort store __aexit__ failed after __aenter__ error",
+                    exc_info=exc,
+                )
         raise

--- a/src/dev_health_ops/workers/sync_bootstrap.py
+++ b/src/dev_health_ops/workers/sync_bootstrap.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import threading
 import uuid
 from collections import OrderedDict
 from dataclasses import dataclass, field
@@ -78,16 +79,27 @@ class ProviderRuntime:
     extra: dict[str, Any] = field(default_factory=dict)
 
     def close(self) -> None:
-        """Close the connector and store. Implemented in CHAOS-2512/2513."""
+        """Close the connector and store (CHAOS-2592).
 
-        for resource in (self.connector, self.store):
-            close = getattr(resource, "close", None)
-            if close is None:
-                continue
+        The store is an async context manager entered once at creation time
+        (see ``_create_store``); exit it so the underlying client (e.g. the
+        ClickHouse connection) is released on cache eviction. The connector
+        is closed via its own ``close`` hook.
+        """
+
+        from dev_health_ops.workers.async_runner import run_async
+
+        store = self.store
+        if store is not None:
+            aexit = getattr(store, "__aexit__", None)
+            if aexit is not None:
+                run_async(aexit(None, None, None))
+
+        connector = self.connector
+        close = getattr(connector, "close", None)
+        if close is not None:
             result = close()
             if inspect.iscoroutine(result):
-                from dev_health_ops.workers.async_runner import run_async
-
                 run_async(result)
 
 
@@ -186,9 +198,17 @@ class ProviderRuntimeCache:
     def __init__(self, max_size: int = 32) -> None:
         self.max_size = max_size
         self._runtimes: OrderedDict[RuntimeCacheKey, ProviderRuntime] = OrderedDict()
+        self._lock = threading.Lock()
 
     def get(self, context: SyncTaskContext) -> ProviderRuntime:
-        """Return a reusable runtime for the context's scope. CHAOS-2512."""
+        """Return a reusable runtime for the context's scope. CHAOS-2512.
+
+        Creation/eviction is serialized (CHAOS-2592): without the lock two
+        worker threads missing the same key could both build and enter a
+        store, leaking the loser's live client. The lock + re-check guarantees
+        exactly one store is entered per key; evicted runtimes are closed
+        outside the lock so their async ``__aexit__`` does not run under it.
+        """
 
         key = RuntimeCacheKey(
             org_id=context.org_id,
@@ -200,16 +220,20 @@ class ProviderRuntimeCache:
             provider=context.provider,
             db_url=context.db_url,
         )
-        runtime = self._runtimes.get(key)
-        if runtime is not None:
-            self._runtimes.move_to_end(key)
-            return runtime
+        evicted_runtimes: list[ProviderRuntime] = []
+        with self._lock:
+            runtime = self._runtimes.get(key)
+            if runtime is not None:
+                self._runtimes.move_to_end(key)
+                return runtime
 
-        runtime = ProviderRuntime(store=_create_store(context))
-        self._runtimes[key] = runtime
-        self._runtimes.move_to_end(key)
-        while len(self._runtimes) > self.max_size:
-            _, evicted = self._runtimes.popitem(last=False)
+            runtime = ProviderRuntime(store=_create_store(context))
+            self._runtimes[key] = runtime
+            self._runtimes.move_to_end(key)
+            while len(self._runtimes) > self.max_size:
+                _, evicted = self._runtimes.popitem(last=False)
+                evicted_runtimes.append(evicted)
+        for evicted in evicted_runtimes:
             evicted.close()
         return runtime
 
@@ -224,8 +248,39 @@ def _credential_fingerprint(credentials: Any) -> str:
 def _create_store(context: SyncTaskContext) -> Any:
     if not context.db_url:
         return None
-    from dev_health_ops.storage import create_store
+    from dev_health_ops.storage import create_store, detect_db_type
+
+    # The runtime cache reuses one store across many units, each run in its own
+    # transient run_async() event loop. Only the ClickHouse client is
+    # loop-agnostic (a sync client wrapped in asyncio.to_thread); SQLAlchemy
+    # stores hold async sessions/connections bound to the loop that opened
+    # them, so entering one here and reusing it from later per-unit loops would
+    # break (CHAOS-2592). Leave non-ClickHouse stores unset so
+    # _run_with_reused_or_new_store falls back to the per-unit run_with_store()
+    # lifecycle (enter + exit within the handler's own loop).
+    if detect_db_type(context.db_url) != "clickhouse":
+        return None
 
     store = create_store(context.db_url)
     setattr(store, "org_id", context.org_id)
+    # Enter the store's async context once so the client is connected before
+    # the cached runtime reuses it across units. If __aenter__ opens the client
+    # and then fails (e.g. table-ensure raises), best-effort exit so this
+    # uncached, failed runtime does not leak a live connection.
+    from dev_health_ops.workers.async_runner import run_async
+
+    run_async(_enter_store(store))
     return store
+
+
+async def _enter_store(store: Any) -> None:
+    try:
+        await store.__aenter__()
+    except BaseException:
+        aexit = getattr(store, "__aexit__", None)
+        if aexit is not None:
+            try:
+                await aexit(None, None, None)
+            except Exception:
+                pass
+        raise

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -332,3 +332,64 @@ def test_registry_flags_make_split_git_datasets_actually_sync(
     split_flags = {"sync_commits", "sync_commit_stats", "sync_files", "sync_blame"}
     for other in split_flags - {own_flag}:
         assert kwargs[other] is False
+
+
+class _ClientAssertingStore:
+    """Store double that replicates ClickHouseStore's client invariant.
+
+    ``insert_repo`` asserts ``client is not None`` exactly like
+    ``ClickHouseStore.insert_repo`` (storage/clickhouse.py:260), and ``client``
+    is assigned only inside ``__aenter__``. A store handed to a processor
+    WITHOUT being entered therefore reproduces the CHAOS-2592 AssertionError.
+    """
+
+    def __init__(self) -> None:
+        self.client: object | None = None
+        self.org_id: str | None = None
+        self.entered = 0
+        self.inserted: list[object] = []
+
+    async def __aenter__(self) -> _ClientAssertingStore:
+        self.client = object()
+        self.entered += 1
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self.client = None
+
+    async def insert_repo(self, repo: object) -> None:
+        assert self.client is not None
+        self.inserted.append(repo)
+
+
+def test_github_dataset_through_runtime_cache_enters_store_before_insert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Integration regression (CHAOS-2592): a store obtained through the REAL
+    # ProviderRuntimeCache and threaded into run_dataset_unit must be entered,
+    # so a processor that writes to it hits a live client instead of asserting.
+    # The other adapter tests use a Mock() store, which masks this entire class
+    # of "store handed over un-entered" bugs -- this test exercises the actual
+    # cache -> adapter -> handler -> sink seam end to end.
+    from dev_health_ops.workers.sync_bootstrap import ProviderRuntimeCache
+
+    store = _ClientAssertingStore()
+    monkeypatch.setattr("dev_health_ops.storage.create_store", lambda *a, **k: store)
+
+    async def _fake_process_github_repo(**kwargs: object) -> None:
+        # Mimic process_github_repo's first persistence call against the store.
+        await kwargs["store"].insert_repo({"id": "repo-1"})  # type: ignore[attr-defined]
+
+    ctx = _context(dataset_key="repo-metadata")
+    runtime = ProviderRuntimeCache().get(ctx)
+
+    with patch(
+        "dev_health_ops.processors.github.process_github_repo",
+        _fake_process_github_repo,
+    ):
+        result = run_dataset_unit(ctx, runtime)
+
+    assert store.entered == 1
+    assert store.client is not None
+    assert store.inserted == [{"id": "repo-1"}]
+    assert result["dataset"] == "repo-metadata"

--- a/tests/test_sync_bootstrap_store_lifecycle.py
+++ b/tests/test_sync_bootstrap_store_lifecycle.py
@@ -1,0 +1,182 @@
+"""Regression tests for the unit-worker runtime store lifecycle (CHAOS-2592).
+
+The fan-out runtime cache (``ProviderRuntimeCache``) reuses one store across
+many units. Before CHAOS-2592 the store was created but never entered, so
+``ClickHouseStore.client`` stayed ``None`` and ``insert_repo`` asserted. These
+tests lock the contract: ``_create_store`` enters the store's async context on
+creation, and ``ProviderRuntime.close`` exits it on eviction.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from dev_health_ops.workers.sync_bootstrap import (
+    ProviderRuntime,
+    SyncTaskContext,
+    _create_store,
+)
+
+
+class _FakeStore:
+    """Async-context-manager store double mirroring ClickHouseStore's contract.
+
+    ``client`` is only assigned inside ``__aenter__`` -- exactly the invariant
+    the regression violated when the cache reused an un-entered store.
+    """
+
+    def __init__(self) -> None:
+        self.client: Any | None = None
+        self.org_id: str | None = None
+        self.entered = 0
+        self.exited = 0
+
+    async def __aenter__(self) -> _FakeStore:
+        self.client = object()
+        self.entered += 1
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self.client = None
+        self.exited += 1
+
+
+def _context(db_url: str = "clickhouse://localhost/default") -> SyncTaskContext:
+    return SyncTaskContext(
+        unit_id="unit-1",
+        sync_run_id="run-1",
+        org_id="org-1",
+        integration_id="integration-1",
+        source_id="source-1",
+        source_external_id="full-chaos/dev-health",
+        provider="github",
+        dataset_key="repo-metadata",
+        cost_class="medium",
+        mode="incremental",
+        window_start=None,
+        window_end=None,
+        processor_flags={},
+        credential_id="credential-1",
+        decrypted_credentials={"token": "secret"},
+        db_url=db_url,
+    )
+
+
+def test_create_store_enters_async_context_so_client_is_connected() -> None:
+    store = _FakeStore()
+    with patch("dev_health_ops.storage.create_store", return_value=store):
+        created = _create_store(_context())
+
+    assert created is store
+    # Regression (CHAOS-2592): the store must be entered so ``client`` is set
+    # before the cached runtime reuses it across units.
+    assert store.entered == 1
+    assert store.client is not None
+    assert store.org_id == "org-1"
+
+
+def test_create_store_returns_none_without_db_url() -> None:
+    assert _create_store(_context(db_url="")) is None
+
+
+def test_provider_runtime_close_exits_store_context() -> None:
+    store = _FakeStore()
+    with patch("dev_health_ops.storage.create_store", return_value=store):
+        runtime = ProviderRuntime(store=_create_store(_context()))
+
+    assert store.client is not None
+    runtime.close()
+    # Regression (CHAOS-2592): eviction must release the underlying client.
+    assert store.exited == 1
+    assert store.client is None
+
+
+def test_create_store_skips_non_clickhouse_stores() -> None:
+    # Hardening (CHAOS-2592, review finding 1): SQLAlchemy-backed analytics
+    # stores hold loop-bound async sessions and MUST NOT be eager-entered and
+    # cached for cross-loop reuse. _create_store returns None for them so the
+    # per-unit run_with_store() path handles their lifecycle. create_store is
+    # never even constructed for non-ClickHouse URLs.
+    create_store = Mock(name="create_store")
+    with patch("dev_health_ops.storage.create_store", create_store):
+        result = _create_store(_context(db_url="postgresql://user@host/analytics"))
+
+    assert result is None
+    create_store.assert_not_called()
+
+
+class _FailOnEnterStore:
+    """Store whose __aenter__ opens the client and THEN fails, like a
+    ClickHouseStore that connects then raises in _ensure_tables."""
+
+    def __init__(self) -> None:
+        self.client: object | None = None
+        self.org_id: str | None = None
+        self.exited = 0
+
+    async def __aenter__(self) -> _FailOnEnterStore:
+        self.client = object()
+        raise RuntimeError("ensure_tables failed")
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self.client = None
+        self.exited += 1
+
+
+def test_create_store_cleans_up_when_enter_fails_after_opening_client() -> None:
+    # Hardening (CHAOS-2592, review finding 3): if __aenter__ opens the client
+    # and then raises, the runtime is never cached and close() never runs, so
+    # _create_store must best-effort __aexit__ to avoid leaking a live client.
+    store = _FailOnEnterStore()
+    with patch("dev_health_ops.storage.create_store", return_value=store):
+        with pytest.raises(RuntimeError, match="ensure_tables failed"):
+            _create_store(_context())
+
+    assert store.exited == 1
+    assert store.client is None
+
+
+def test_concurrent_get_enters_exactly_one_store_per_key() -> None:
+    # Hardening (CHAOS-2592, review finding 2): two worker threads missing the
+    # same key must not both build + enter a store (leaking the loser's live
+    # client). The lock + re-check guarantees exactly one creation per key.
+    from dev_health_ops.workers.sync_bootstrap import ProviderRuntimeCache
+
+    created: list[_FakeStore] = []
+    created_lock = threading.Lock()
+
+    def _factory(*args: Any, **kwargs: Any) -> _FakeStore:
+        # Widen the race window so an unlocked get() would create two stores.
+        time.sleep(0.02)
+        store = _FakeStore()
+        with created_lock:
+            created.append(store)
+        return store
+
+    cache = ProviderRuntimeCache()
+    ctx = _context()
+    barrier = threading.Barrier(2)
+    results: list[ProviderRuntime] = []
+    results_lock = threading.Lock()
+
+    def _worker() -> None:
+        barrier.wait()
+        runtime = cache.get(ctx)
+        with results_lock:
+            results.append(runtime)
+
+    with patch("dev_health_ops.storage.create_store", _factory):
+        threads = [threading.Thread(target=_worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert len(created) == 1
+    assert created[0].entered == 1
+    assert results[0] is results[1]


### PR DESCRIPTION
## Summary

The fan-out worker refactor (CHAOS-2512) introduced `ProviderRuntimeCache`, which built a `ClickHouseStore` via `_create_store()` but **never entered its async context**. Since `ClickHouseStore.client` is assigned only in `__aenter__`, the cached store reached `process_github_repo → insert_repo` with `client = None`, tripping `assert self.client is not None`. Every GitHub repo dataset unit failed as `adapter_error`.

```
File "src/dev_health_ops/processors/github.py", line 1458, in process_github_repo
  await ingestion_sink.insert_repo(db_repo)
File "src/dev_health_ops/metrics/sinks/ingestion.py", line 32, in insert_repo
  await self._store.insert_repo(repo)
File "src/dev_health_ops/storage/clickhouse.py", line 260, in insert_repo
  assert self.client is not None
AssertionError
```

## Fix

The runtime cache now **owns the store lifecycle**:

- `_create_store` enters the store once (`run_async(store.__aenter__())`) so the client is connected before reuse; `ProviderRuntime.close` exits it via `__aexit__` on eviction (previously it only looked for a `.close` method, which `ClickHouseStore` does not have — so cached stores were also never closed).
- **Eager-enter+cache is gated to ClickHouse** (`detect_db_type`). SQLAlchemy-backed stores hold loop-bound async sessions and cannot be safely entered in a transient `run_async` loop and reused cross-loop; they fall back to the per-unit `run_with_store()` lifecycle (reachable when `CLICKHOUSE_URI` is unset and `DATABASE_URI` points at Postgres).
- `ProviderRuntimeCache.get()` is serialized with a `threading.Lock` + re-check so concurrent cache misses cannot leak a second entered store; evicted runtimes are closed outside the lock.
- `_enter_store` best-effort `__aexit__` if `__aenter__` opens the client and then fails (e.g. table-ensure raises), so a failed, uncached runtime does not leak a live connection.

Safe because the ClickHouse client is loop-agnostic (a sync client wrapped in `asyncio.to_thread`), which the per-unit `run_async` (fresh event loop per call) reuse model already relies on.

## Tests

- Unit lifecycle: enter-on-create / exit-on-evict.
- Integration: through the real `ProviderRuntimeCache → run_dataset_unit → insert_repo` seam (the existing adapter tests used a `Mock()` store that masked this entire class of bug).
- Hardening regressions: non-ClickHouse skip, enter-failure cleanup, and concurrent-`get` single-entry.
- The original fix and the concurrency test are **proven non-vacuous**: disabling the enter line reproduces the original AssertionError; neutralizing the lock makes the concurrent test create 2 stores instead of 1.

Full worker suite: **93 passed**; `mypy` (whole project) and `lsp` clean. The implementation was vetted with an adversarial Codex review; all three findings are addressed in this PR.

SCREENSHOT-WAIVER: backend-only change (worker store lifecycle); no rendered UI output.

Closes CHAOS-2592
