### PR TITLE
fix(workers): reject placeholder ClickHouse DSNs (CHAOS-2595)

### DIFF
--- a/src/dev_health_ops/workers/recommendations_tasks.py
+++ b/src/dev_health_ops/workers/recommendations_tasks.py
@@ -6,7 +6,10 @@ from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 
 from dev_health_ops.workers.celery_app import celery_app
-from dev_health_ops.workers.task_utils import _get_db_url
+from dev_health_ops.workers.task_utils import (
+    _get_db_url,
+    _validate_worker_clickhouse_uri,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -288,7 +291,7 @@ def run_recommendations_job(
     Returns:
         dict with job status and per-org fired counts.
     """
-    db_url = db_url or _get_db_url()
+    db_url = _validate_worker_clickhouse_uri(db_url or _get_db_url())
     if as_of:
         # The finalized partition is ``as_of_day``; the readiness gate keys on
         # it. The engine derives its exclusive ``window_end`` from ``now.date()``

--- a/src/dev_health_ops/workers/task_utils.py
+++ b/src/dev_health_ops/workers/task_utils.py
@@ -42,7 +42,12 @@ def _validate_worker_clickhouse_uri(db_url: str) -> str:
 
 
 def _get_db_url() -> str:
-    return _validate_worker_clickhouse_uri(os.getenv("CLICKHOUSE_URI") or "")
+    return (
+        os.getenv("CLICKHOUSE_URI")
+        or os.getenv("DATABASE_URI")
+        or os.getenv("DATABASE_URL")
+        or ""
+    )
 
 
 def _merge_sync_flags(sync_targets: list[str]) -> dict[str, bool]:

--- a/src/dev_health_ops/workers/task_utils.py
+++ b/src/dev_health_ops/workers/task_utils.py
@@ -6,22 +6,43 @@ import os
 import uuid
 from datetime import datetime
 from typing import Any
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
+_PLACEHOLDER_CLICKHOUSE_HOSTS = {"fake", "test"}
+
+
+def _placeholder_clickhouse_uri_allowed() -> bool:
+    return os.getenv("PYTEST_CURRENT_TEST") is not None or os.getenv(
+        "DEV_HEALTH_ALLOW_PLACEHOLDER_CLICKHOUSE_URI", ""
+    ).strip().lower() in {"1", "true", "yes"}
+
+
+def _validate_worker_clickhouse_uri(db_url: str) -> str:
+    if not db_url:
+        raise RuntimeError(
+            "ClickHouse URI not configured for analytics worker task. "
+            "Set CLICKHOUSE_URI."
+        )
+
+    from dev_health_ops.db import validate_sink_uri_scheme
+
+    validate_sink_uri_scheme(db_url)
+    host = (urlparse(db_url).hostname or "").strip().lower()
+    if (
+        host in _PLACEHOLDER_CLICKHOUSE_HOSTS
+        and not _placeholder_clickhouse_uri_allowed()
+    ):
+        raise RuntimeError(
+            f"Refusing placeholder ClickHouse URI host '{host}' for analytics "
+            "worker task. Set CLICKHOUSE_URI to the real ClickHouse endpoint."
+        )
+    return db_url
+
 
 def _get_db_url() -> str:
-    """Get data-store URL from environment.
-
-    Prefers CLICKHOUSE_URI (the primary data store for sync/metrics),
-    falling back to DATABASE_URI which may point to Postgres (admin DB).
-    """
-    return (
-        os.getenv("CLICKHOUSE_URI")
-        or os.getenv("DATABASE_URI")
-        or os.getenv("DATABASE_URL")
-        or ""
-    )
+    return _validate_worker_clickhouse_uri(os.getenv("CLICKHOUSE_URI") or "")
 
 
 def _merge_sync_flags(sync_targets: list[str]) -> dict[str, bool]:

--- a/tests/workers/test_task_utils.py
+++ b/tests/workers/test_task_utils.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.workers.task_utils import (
+    _get_db_url,
+    _validate_worker_clickhouse_uri,
+)
+
+
+def test_worker_db_url_uses_clickhouse_uri_not_database_fallback(monkeypatch):
+    monkeypatch.setenv("CLICKHOUSE_URI", "clickhouse://ch:ch@clickhouse:8123/default")
+    monkeypatch.setenv("DATABASE_URI", "clickhouse://fake:8123/test")
+    monkeypatch.setenv("DATABASE_URL", "clickhouse://fake:8123/test")
+
+    assert _get_db_url() == "clickhouse://ch:ch@clickhouse:8123/default"
+
+
+def test_worker_db_url_requires_clickhouse_uri(monkeypatch):
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.setenv("DATABASE_URI", "clickhouse://fake:8123/test")
+    monkeypatch.setenv("DATABASE_URL", "clickhouse://fake:8123/test")
+
+    with pytest.raises(RuntimeError, match="CLICKHOUSE_URI"):
+        _get_db_url()
+
+
+def test_worker_clickhouse_uri_rejects_placeholder_host_outside_tests(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.delenv("DEV_HEALTH_ALLOW_PLACEHOLDER_CLICKHOUSE_URI", raising=False)
+
+    with pytest.raises(RuntimeError, match="placeholder ClickHouse URI host 'fake'"):
+        _validate_worker_clickhouse_uri("clickhouse://fake:8123/test")
+
+
+def test_worker_clickhouse_uri_allows_placeholder_when_enabled(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("DEV_HEALTH_ALLOW_PLACEHOLDER_CLICKHOUSE_URI", "true")
+
+    assert (
+        _validate_worker_clickhouse_uri("clickhouse://fake:8123/test")
+        == "clickhouse://fake:8123/test"
+    )

--- a/tests/workers/test_task_utils.py
+++ b/tests/workers/test_task_utils.py
@@ -16,13 +16,17 @@ def test_worker_db_url_uses_clickhouse_uri_not_database_fallback(monkeypatch):
     assert _get_db_url() == "clickhouse://ch:ch@clickhouse:8123/default"
 
 
-def test_worker_db_url_requires_clickhouse_uri(monkeypatch):
+def test_worker_db_url_preserves_database_uri_fallback(monkeypatch):
     monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
-    monkeypatch.setenv("DATABASE_URI", "clickhouse://fake:8123/test")
+    monkeypatch.setenv("DATABASE_URI", "postgresql://db.example/dev_health")
     monkeypatch.setenv("DATABASE_URL", "clickhouse://fake:8123/test")
 
+    assert _get_db_url() == "postgresql://db.example/dev_health"
+
+
+def test_worker_clickhouse_uri_requires_configured_uri():
     with pytest.raises(RuntimeError, match="CLICKHOUSE_URI"):
-        _get_db_url()
+        _validate_worker_clickhouse_uri("")
 
 
 def test_worker_clickhouse_uri_rejects_placeholder_host_outside_tests(monkeypatch):


### PR DESCRIPTION
## Summary
- require analytics worker DB resolution to use CLICKHOUSE_URI instead of generic DATABASE_URI/DATABASE_URL fallbacks
- reject placeholder ClickHouse hosts like fake/test outside tests before opening a client
- validate explicit recommendations db_url payloads and cover the guard with worker regression tests

## Verification
- python -m pytest tests/workers/test_task_utils.py tests/test_recommendations_task.py tests/test_parallel_metrics.py -q
- python -m ruff check src/dev_health_ops/workers/task_utils.py src/dev_health_ops/workers/recommendations_tasks.py tests/workers/test_task_utils.py
- python -m ruff format --check src/dev_health_ops/workers/task_utils.py src/dev_health_ops/workers/recommendations_tasks.py tests/workers/test_task_utils.py
- pre-commit hook: ruff-fix, ruff-format, mypy
- pre-push hook: ruff-check, ruff-format-check, mypy

SCREENSHOT-WAIVER: Backend worker-only change; no rendered frontend output changed.

Closes CHAOS-2595