### PR TITLE
fix(sync): show planner sync runs in job history

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -77,6 +77,30 @@ def _mark_job_run_failed(sync_session, run_id: str, error: str) -> None:
     sync_session.flush()
 
 
+def _mark_job_run_success(
+    sync_session, run_id: str, result: dict[str, Any] | None = None
+) -> None:
+    completed_at = datetime.now(timezone.utc)
+    run = (
+        sync_session.query(JobRun)
+        .filter(JobRun.id == uuid.UUID(str(run_id)))
+        .one_or_none()
+    )
+    if run is None:
+        return
+    run.status = JobRunStatus.SUCCESS.value
+    run.completed_at = completed_at
+    if result is not None:
+        current = run.result if isinstance(run.result, dict) else {}
+        run.result = {**current, **result}
+    started_at = getattr(run, "started_at", None)
+    if started_at is not None:
+        if started_at.tzinfo is None:
+            started_at = started_at.replace(tzinfo=timezone.utc)
+        run.duration_seconds = max(0, int((completed_at - started_at).total_seconds()))
+    sync_session.flush()
+
+
 def _mark_backfill_job_failed(
     sync_session, backfill_job_id: str, error: str, completed_at: datetime
 ) -> None:
@@ -96,7 +120,11 @@ def _mark_backfill_job_failed(
 
 
 def _ensure_pending_sync_job_run(
-    sync_session, config, org_id: str, triggered_by: str
+    sync_session,
+    config,
+    org_id: str,
+    triggered_by: str,
+    result: dict[str, Any] | None = None,
 ) -> str:
     """Find-or-create the ScheduledJob anchor and create a PENDING JobRun.
 
@@ -147,6 +175,7 @@ def _ensure_pending_sync_job_run(
         triggered_by=triggered_by,
         status=JobRunStatus.PENDING.value,
     )
+    run.result = result
     sync_session.add(run)
     sync_session.flush()
     return str(run.id)
@@ -1238,24 +1267,48 @@ async def trigger_sync_config(
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc))
+        planner_pending_run_id = await session.run_sync(
+            lambda sync_session: _ensure_pending_sync_job_run(
+                sync_session,
+                config,
+                org_id,
+                "manual",
+                {"sync_run_id": plan.sync_run_id},
+            )
+        )
         await session.commit()
         try:
-            getattr(dispatch_sync_run, "apply_async")(
+            dispatch_result = getattr(dispatch_sync_run, "apply_async")(
                 args=(plan.sync_run_id,), queue="sync"
             )
         except Exception as exc:
+            error_message = f"dispatch enqueue failed: {exc}"
             await session.run_sync(
                 lambda s: mark_sync_run_failed(
                     s, plan.sync_run_id, "dispatch enqueue failed"
                 )
             )
+            await session.run_sync(
+                lambda s: _mark_job_run_failed(s, planner_pending_run_id, error_message)
+            )
+            await session.commit()
             raise HTTPException(
                 status_code=503, detail=f"Task queue unavailable: {exc}"
             )
+        dispatch_task_id = str(getattr(dispatch_result, "id", "") or "")
+        await session.run_sync(
+            lambda s: _mark_job_run_success(
+                s,
+                planner_pending_run_id,
+                {"dispatch_task_id": dispatch_task_id} if dispatch_task_id else None,
+            )
+        )
+        await session.commit()
         return {
             "status": "triggered",
             "config_id": str(config.id),
             "sync_run_id": plan.sync_run_id,
+            "run_id": planner_pending_run_id,
             "total_units": plan.total_units,
         }
 
@@ -1362,16 +1415,15 @@ async def trigger_sync_config_backfill(
     try:
         from dev_health_ops.workers.sync_tasks import run_backfill
 
-        # For the legacy path only: create a PENDING JobRun so the sync-activity
-        # list shows the backfill immediately (CHAOS-2536).  The fan-out path
-        # already produces a visible SyncRun, so we skip this there.
-        pending_run_id: str | None = None
-        if not fanout_backfill:
-            pending_run_id = await session.run_sync(
-                lambda sync_session: _ensure_pending_sync_job_run(
-                    sync_session, config, org_id, "backfill"
-                )
+        pending_run_id = await session.run_sync(
+            lambda sync_session: _ensure_pending_sync_job_run(
+                sync_session,
+                config,
+                org_id,
+                "backfill",
+                {"planner_managed": fanout_backfill},
             )
+        )
 
         await session.commit()
 

--- a/src/dev_health_ops/workers/sync_backfill.py
+++ b/src/dev_health_ops/workers/sync_backfill.py
@@ -101,7 +101,9 @@ def _mark_sync_job_run_running(
 
 
 def _mark_sync_job_run_success(
-    pending_run_id: str | None, completed_at: datetime
+    pending_run_id: str | None,
+    completed_at: datetime,
+    result: dict[str, Any] | None = None,
 ) -> None:
     if pending_run_id is None:
         return
@@ -118,6 +120,9 @@ def _mark_sync_job_run_success(
             if run:
                 setattr(run, "status", JobRunStatus.SUCCESS.value)
                 setattr(run, "completed_at", completed_at)
+                if result is not None:
+                    current = run.result if isinstance(run.result, dict) else {}
+                    setattr(run, "result", {**current, **result})
                 session.flush()
     except Exception:
         logger.debug("Failed to mark sync job run success: %s", pending_run_id)
@@ -294,6 +299,11 @@ def run_backfill(
                         datetime.now(timezone.utc) if status == "completed" else None
                     ),
                 )
+            _mark_sync_job_run_success(
+                pending_run_id,
+                datetime.now(timezone.utc),
+                {"sync_run_id": str(result_payload["sync_run_id"])},
+            )
             return {
                 "status": "success",
                 "result": result_payload,

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -3,7 +3,7 @@
 Covers:
 - Endpoint (legacy path): creates PENDING JobRun anchored to sync ScheduledJob.
 - Endpoint (legacy path): passes pending_run_id to run_backfill.delay().
-- Endpoint (fanout path): does NOT create a JobRun (passes pending_run_id=None).
+- Endpoint (fanout path): creates a JobRun anchor and passes pending_run_id.
 - Worker: run_backfill transitions JobRun RUNNING→SUCCESS on success.
 - Worker: run_backfill transitions JobRun RUNNING→FAILED on exception.
 """
@@ -316,10 +316,9 @@ async def test_backfill_legacy_enqueue_failure_marks_committed_records_failed(
 
 
 @pytest.mark.asyncio
-async def test_backfill_fanout_does_not_create_job_run(
+async def test_backfill_fanout_creates_job_run_anchor(
     client, session_maker, seeded_state
 ):
-    """Fan-out backfill must NOT create a JobRun (passes pending_run_id=None)."""
     ac, _ = client
 
     create_resp = await _create_sync_config(
@@ -359,15 +358,16 @@ async def test_backfill_fanout_does_not_create_job_run(
     data = resp.json()
     assert data["mode"] == "fanout"
 
-    # pending_run_id must be None for the fanout path.
     call_kwargs = mock_run_backfill.delay.call_args.kwargs
-    assert call_kwargs.get("pending_run_id") is None
+    pending_run_id = call_kwargs.get("pending_run_id")
+    assert pending_run_id is not None
 
-    # No JobRun rows should exist.
     async with session_maker() as session:
-        jr_result = await session.execute(select(JobRun))
-        runs = list(jr_result.scalars().all())
-    assert runs == []
+        run = await session.get(JobRun, uuid.UUID(pending_run_id))
+        assert run is not None
+        assert run.status == JobRunStatus.PENDING.value
+        assert run.triggered_by == "backfill"
+        assert run.result == {"planner_managed": True}
 
 
 @pytest.mark.asyncio
@@ -485,7 +485,10 @@ async def test_backfill_fanout_enqueue_failure_marks_backfill_job_failed(
     assert backfill_job.error_message == "enqueue failed: broker down"
     assert backfill_job.completed_at is not None
     assert backfill_job.celery_task_id is None
-    assert job_runs == []
+    assert len(job_runs) == 1
+    assert job_runs[0].status == JobRunStatus.FAILED.value
+    assert job_runs[0].error == "enqueue failed: broker down"
+    assert job_runs[0].completed_at is not None
     assert sync_runs == []
 
 
@@ -530,7 +533,14 @@ async def test_backfill_planner_managed_config_routes_to_fanout_without_flag(
     assert resp.status_code == 202, resp.text
     assert resp.json()["mode"] == "fanout"
     call_kwargs = mock_run_backfill.delay.call_args.kwargs
-    assert call_kwargs.get("pending_run_id") is None
+    pending_run_id = call_kwargs.get("pending_run_id")
+    assert pending_run_id is not None
+    async with session_maker() as session:
+        run = await session.get(JobRun, uuid.UUID(pending_run_id))
+        assert run is not None
+        assert run.status == JobRunStatus.PENDING.value
+        assert run.triggered_by == "backfill"
+        assert run.result == {"planner_managed": True}
 
 
 @pytest.mark.asyncio
@@ -664,6 +674,7 @@ async def test_run_backfill_worker_transitions_job_run_running_then_success(
             triggered_by="backfill",
             status=JobRunStatus.PENDING.value,
         )
+        run.result = {"planner_managed": True}
         session.add(run)
         session.commit()
         pending_run_id = str(run.id)
@@ -697,7 +708,11 @@ async def test_run_backfill_worker_transitions_job_run_running_then_success(
         "dev_health_ops.db.get_postgres_session_sync",
         _fake_pg_session,
     ):
-        _mark_sync_job_run_success(pending_run_id, completed_at)
+        _mark_sync_job_run_success(
+            pending_run_id,
+            completed_at,
+            {"sync_run_id": "planner-sync-run"},
+        )
 
     with SessionFactory() as session:
         run_row = (
@@ -705,6 +720,10 @@ async def test_run_backfill_worker_transitions_job_run_running_then_success(
         )
         assert run_row.status == JobRunStatus.SUCCESS.value
         assert run_row.completed_at is not None
+        assert run_row.result == {
+            "planner_managed": True,
+            "sync_run_id": "planner-sync-run",
+        }
 
     engine.dispose()
 

--- a/tests/api/admin/test_sync_trigger_routing.py
+++ b/tests/api/admin/test_sync_trigger_routing.py
@@ -18,15 +18,23 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.models.git import Base
-from dev_health_ops.models.integrations import Integration, IntegrationSource
+from dev_health_ops.models.integrations import (
+    Integration,
+    IntegrationDataset,
+    IntegrationSource,
+    SyncRun,
+    SyncRunUnit,
+)
 from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import (
     IntegrationCredential,
     JobRun,
+    JobRunStatus,
     ScheduledJob,
     Setting,
     SettingCategory,
@@ -50,6 +58,9 @@ _TABLES = tables_of(
     Setting,
     Integration,
     IntegrationSource,
+    IntegrationDataset,
+    SyncRun,
+    SyncRunUnit,
 )
 
 
@@ -541,6 +552,11 @@ async def test_planner_enqueue_failure_marks_run_failed_and_503(client, session_
     # Committed run marked FAILED so it is not stranded PLANNED with no dispatcher.
     fake_mark_failed.assert_called_once()
     assert fake_mark_failed.call_args.args[1] == fake_plan.sync_run_id
+    async with session_maker() as session:
+        job_run = (await session.execute(select(JobRun))).scalar_one()
+        assert job_run.status == JobRunStatus.FAILED.value
+        assert job_run.error == "dispatch enqueue failed: broker down"
+        assert job_run.completed_at is not None
     # Legacy path NOT used -- we surfaced the queue outage instead.
     fake_run_sync_config.apply_async.assert_not_called()
     fake_dispatch_batch_sync.apply_async.assert_not_called()
@@ -618,3 +634,78 @@ def test_plan_request_for_config_incremental_without_full_resync_flag():
 
     assert request is not None
     assert request.mode == SyncRunMode.INCREMENTAL.value
+
+
+@pytest.mark.asyncio
+async def test_planner_trigger_creates_jobrun_anchor_visible_in_jobs(
+    client, session_maker
+):
+    ac, seeded_state = client
+    org_id = seeded_state["org_id"]
+
+    integration_id = uuid.uuid4()
+    config_id = await _seed_config(
+        session_maker,
+        org_id,
+        migrated_integration_id=integration_id,
+        planner_managed=True,
+    )
+    await _seed_source(session_maker, org_id, integration_id)
+
+    fake_dispatch = MagicMock()
+    fake_dispatch.apply_async = MagicMock(return_value=MagicMock(id="task-real"))
+    fake_run_sync_config = MagicMock()
+    fake_dispatch_batch_sync = MagicMock()
+
+    with (
+        patch(
+            "dev_health_ops.api.admin.routers.sync.dispatch_sync_run",
+            fake_dispatch,
+        ),
+        patch.dict(
+            "sys.modules",
+            {
+                "dev_health_ops.workers.sync_tasks": MagicMock(
+                    run_sync_config=fake_run_sync_config,
+                    dispatch_batch_sync=fake_dispatch_batch_sync,
+                )
+            },
+        ),
+    ):
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    sync_run_id = body.get("sync_run_id")
+    job_run_id = body.get("run_id")
+    assert sync_run_id, f"planner trigger must return a sync_run_id: {body}"
+    assert job_run_id, f"planner trigger must return a JobRun run_id: {body}"
+    fake_dispatch.apply_async.assert_called_once()
+
+    async with session_maker() as session:
+        run = await session.get(SyncRun, uuid.UUID(sync_run_id))
+        assert run is not None, "trigger must create a SyncRun row"
+        assert str(run.integration_id) == str(integration_id)
+        assert run.org_id == org_id
+        job_run = await session.get(JobRun, uuid.UUID(job_run_id))
+        assert job_run is not None, "trigger must create a JobRun anchor"
+        assert job_run.triggered_by == "manual"
+        assert job_run.status == JobRunStatus.SUCCESS.value
+        assert job_run.completed_at is not None
+        assert job_run.result == {
+            "sync_run_id": sync_run_id,
+            "dispatch_task_id": "task-real",
+        }
+
+    jobs_resp = await ac.get(f"/api/v1/admin/sync-configs/{config_id}/jobs")
+    assert jobs_resp.status_code == 200, jobs_resp.text
+    jobs = jobs_resp.json()
+    ids = {job["id"] for job in jobs}
+    assert job_run_id in ids, f"planner JobRun anchor must appear in jobs: {ids}"
+    surfaced = next(job for job in jobs if job["id"] == job_run_id)
+    assert surfaced["triggered_by"] == "manual"
+    assert surfaced["status"] == "success"
+    assert surfaced["result"] == {
+        "sync_run_id": sync_run_id,
+        "dispatch_task_id": "task-real",
+    }


### PR DESCRIPTION
## Summary
- Create JobRun anchors for planner-managed Sync Now and Backfill paths so Job History has DB-backed rows.
- Mark planner Sync Now anchors success after dispatch enqueue, and failed when enqueue fails.
- Mark planner/fanout Backfill anchors success from the worker once the planner SyncRun is created, preserving the SyncRun id in the JobRun result.

## Verification
- uv run pytest tests/api/admin/test_sync_trigger_routing.py tests/api/admin/test_backfill_jobrun.py -q
- uv run ruff format --check src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/workers/sync_backfill.py tests/api/admin/test_sync_trigger_routing.py tests/api/admin/test_backfill_jobrun.py
- uv run ruff check src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/workers/sync_backfill.py tests/api/admin/test_sync_trigger_routing.py tests/api/admin/test_backfill_jobrun.py
- uv run mypy src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/workers/sync_backfill.py tests/api/admin/test_sync_trigger_routing.py tests/api/admin/test_backfill_jobrun.py
- Live compose QA: enqueued a planner backfill and confirmed the JobRun moved to success with planner_managed=true and sync_run_id in result.
- Oracle review: PASS, no blocking findings.

SCREENSHOT-WAIVER: Backend-only JobRun lifecycle/API behavior; no rendered UI changed.