### PR TITLE
fix(sync): derive planner job history from sync runs

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import uuid
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Any, Protocol, cast
 
@@ -32,6 +33,7 @@ from dev_health_ops.models.integrations import (
     Integration,
     IntegrationDataset,
     IntegrationSource,
+    SyncRunStatus,
 )
 from dev_health_ops.models.settings import (
     JobRun,
@@ -77,10 +79,11 @@ def _mark_job_run_failed(sync_session, run_id: str, error: str) -> None:
     sync_session.flush()
 
 
-def _mark_job_run_success(
+def _merge_job_run_result(
     sync_session, run_id: str, result: dict[str, Any] | None = None
 ) -> None:
-    completed_at = datetime.now(timezone.utc)
+    if result is None:
+        return
     run = (
         sync_session.query(JobRun)
         .filter(JobRun.id == uuid.UUID(str(run_id)))
@@ -88,16 +91,8 @@ def _mark_job_run_success(
     )
     if run is None:
         return
-    run.status = JobRunStatus.SUCCESS.value
-    run.completed_at = completed_at
-    if result is not None:
-        current = run.result if isinstance(run.result, dict) else {}
-        run.result = {**current, **result}
-    started_at = getattr(run, "started_at", None)
-    if started_at is not None:
-        if started_at.tzinfo is None:
-            started_at = started_at.replace(tzinfo=timezone.utc)
-        run.duration_seconds = max(0, int((completed_at - started_at).total_seconds()))
+    current = run.result if isinstance(run.result, dict) else {}
+    run.result = {**current, **result}
     sync_session.flush()
 
 
@@ -306,18 +301,129 @@ def _sync_config_to_response(
     )
 
 
-def _job_run_response(run: object) -> JobRunResponse:
+def _aware_datetime(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def _elapsed_seconds(
+    started_at: datetime | None, completed_at: datetime | None
+) -> int | None:
+    started = _aware_datetime(started_at)
+    completed = _aware_datetime(completed_at)
+    if started is None or completed is None:
+        return None
+    return max(0, int((completed - started).total_seconds()))
+
+
+def _items_synced_from_result(result: dict[str, Any] | None) -> int:
+    if not result:
+        return 0
+    for key in ("items_synced", "rows_ingested", "rows", "items", "count"):
+        if key in result:
+            try:
+                return int(result.get(key) or 0)
+            except (TypeError, ValueError):
+                return 0
+    return 0
+
+
+def _planner_job_run_sync_run_id(run: object) -> uuid.UUID | None:
+    result = getattr(run, "result", None)
+    if not isinstance(result, dict):
+        return None
+    sync_run_id = result.get("sync_run_id")
+    if sync_run_id is None:
+        return None
+    try:
+        return uuid.UUID(str(sync_run_id))
+    except ValueError:
+        return None
+
+
+def _planner_job_run_status(run_status: str) -> int:
+    if run_status == SyncRunStatus.PLANNED.value:
+        return JobRunStatus.PENDING.value
+    if run_status in {
+        SyncRunStatus.DISPATCHING.value,
+        SyncRunStatus.RUNNING.value,
+    }:
+        return JobRunStatus.RUNNING.value
+    if run_status == SyncRunStatus.SUCCESS.value:
+        return JobRunStatus.SUCCESS.value
+    if run_status in {
+        SyncRunStatus.PARTIAL_FAILED.value,
+        SyncRunStatus.FAILED.value,
+    }:
+        return JobRunStatus.FAILED.value
+    return JobRunStatus.RUNNING.value
+
+
+async def _planner_sync_runs_for_job_runs(
+    session: AsyncSession, runs: Sequence[object], org_id: str
+) -> dict[str, SyncRun]:
+    sync_run_ids = {
+        sync_run_id
+        for run in runs
+        if (sync_run_id := _planner_job_run_sync_run_id(run)) is not None
+    }
+    if not sync_run_ids:
+        return {}
+    result = await session.execute(
+        select(SyncRun).where(
+            SyncRun.id.in_(sync_run_ids),
+            SyncRun.org_id == org_id,
+        )
+    )
+    return {str(sync_run.id): sync_run for sync_run in result.scalars().all()}
+
+
+def _job_run_response(
+    run: object, planner_sync_run: SyncRun | None = None
+) -> JobRunResponse:
     status_value = int(getattr(run, "status"))
+    started_at = getattr(run, "started_at")
+    completed_at = getattr(run, "completed_at")
+    duration_seconds = getattr(run, "duration_seconds")
+    error = getattr(run, "error")
+    result = getattr(run, "result")
+    items_synced = _items_synced_from_result(
+        result if isinstance(result, dict) else None
+    )
+
+    if planner_sync_run is not None:
+        # Planner-managed JobRun rows are visibility anchors for Job History.
+        # The linked SyncRun owns execution lifecycle and runtime stats.
+        sync_result = getattr(planner_sync_run, "result")
+        result = {
+            **(result if isinstance(result, dict) else {}),
+            **(sync_result if isinstance(sync_result, dict) else {}),
+            "sync_run_status": str(getattr(planner_sync_run, "status")),
+            "total_units": int(getattr(planner_sync_run, "total_units")),
+            "completed_units": int(getattr(planner_sync_run, "completed_units")),
+            "failed_units": int(getattr(planner_sync_run, "failed_units")),
+        }
+        status_value = _planner_job_run_status(str(getattr(planner_sync_run, "status")))
+        started_at = getattr(planner_sync_run, "started_at")
+        completed_at = getattr(planner_sync_run, "completed_at")
+        duration_seconds = _elapsed_seconds(started_at, completed_at)
+        error = getattr(planner_sync_run, "error") or error
+        items_synced = int(getattr(planner_sync_run, "completed_units"))
+
     return JobRunResponse.model_validate(
         {
             "id": str(getattr(run, "id")),
             "job_id": str(getattr(run, "job_id")),
             "status": JOB_RUN_STATUS_LABELS.get(status_value, "unknown"),
-            "started_at": getattr(run, "started_at"),
-            "completed_at": getattr(run, "completed_at"),
-            "duration_seconds": getattr(run, "duration_seconds"),
-            "result": getattr(run, "result"),
-            "error": getattr(run, "error"),
+            "started_at": started_at,
+            "completed_at": completed_at,
+            "duration_seconds": duration_seconds,
+            "items_synced": items_synced,
+            "result": result,
+            "error": error,
             "triggered_by": getattr(run, "triggered_by"),
             "created_at": getattr(run, "created_at"),
         }
@@ -1297,7 +1403,7 @@ async def trigger_sync_config(
             )
         dispatch_task_id = str(getattr(dispatch_result, "id", "") or "")
         await session.run_sync(
-            lambda s: _mark_job_run_success(
+            lambda s: _merge_job_run_result(
                 s,
                 planner_pending_run_id,
                 {"dispatch_task_id": dispatch_task_id} if dispatch_task_id else None,
@@ -1505,8 +1611,16 @@ async def list_sync_config_jobs(
     )
     runs_result = await session.execute(runs_stmt)
     runs = list(runs_result.scalars().all())
+    planner_sync_runs = await _planner_sync_runs_for_job_runs(session, runs, org_id)
 
-    return [_job_run_response(run) for run in runs]
+    return [
+        _job_run_response(
+            run,
+            planner_sync_runs.get(str(sync_run_id)) if sync_run_id else None,
+        )
+        for run in runs
+        for sync_run_id in [_planner_job_run_sync_run_id(run)]
+    ]
 
 
 @router.get("/backfill-jobs")

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -198,6 +198,7 @@ class JobRunResponse(BaseModel):
     started_at: datetime | None = None
     completed_at: datetime | None = None
     duration_seconds: int | None = None
+    items_synced: int = 0
     result: dict[str, Any] | None = None
     error: str | None = None
     triggered_by: str

--- a/tests/api/admin/test_sync_trigger_routing.py
+++ b/tests/api/admin/test_sync_trigger_routing.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import importlib
 import uuid
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -28,6 +29,7 @@ from dev_health_ops.models.integrations import (
     IntegrationDataset,
     IntegrationSource,
     SyncRun,
+    SyncRunStatus,
     SyncRunUnit,
 )
 from dev_health_ops.models.licensing import OrgLicense
@@ -690,8 +692,8 @@ async def test_planner_trigger_creates_jobrun_anchor_visible_in_jobs(
         job_run = await session.get(JobRun, uuid.UUID(job_run_id))
         assert job_run is not None, "trigger must create a JobRun anchor"
         assert job_run.triggered_by == "manual"
-        assert job_run.status == JobRunStatus.SUCCESS.value
-        assert job_run.completed_at is not None
+        assert job_run.status == JobRunStatus.PENDING.value
+        assert job_run.completed_at is None
         assert job_run.result == {
             "sync_run_id": sync_run_id,
             "dispatch_task_id": "task-real",
@@ -704,8 +706,75 @@ async def test_planner_trigger_creates_jobrun_anchor_visible_in_jobs(
     assert job_run_id in ids, f"planner JobRun anchor must appear in jobs: {ids}"
     surfaced = next(job for job in jobs if job["id"] == job_run_id)
     assert surfaced["triggered_by"] == "manual"
+    assert surfaced["status"] == "pending"
+    assert surfaced["started_at"] is None
+    assert surfaced["completed_at"] is None
+    assert surfaced["duration_seconds"] is None
+    assert surfaced["items_synced"] == 0
+    assert surfaced["result"]["sync_run_id"] == sync_run_id
+    assert surfaced["result"]["dispatch_task_id"] == "task-real"
+    assert surfaced["result"]["sync_run_status"] == SyncRunStatus.PLANNED.value
+    assert surfaced["result"]["total_units"] == run.total_units
+    assert surfaced["result"]["completed_units"] == 0
+    assert surfaced["result"]["failed_units"] == 0
+
+    started_at = datetime.now(timezone.utc) - timedelta(seconds=42)
+    async with session_maker() as session:
+        dispatching_run = await session.get(SyncRun, uuid.UUID(sync_run_id))
+        assert dispatching_run is not None
+        dispatching_run.status = SyncRunStatus.DISPATCHING.value
+        dispatching_run.started_at = started_at
+        await session.commit()
+
+    jobs_resp = await ac.get(f"/api/v1/admin/sync-configs/{config_id}/jobs")
+    assert jobs_resp.status_code == 200, jobs_resp.text
+    surfaced = next(job for job in jobs_resp.json() if job["id"] == job_run_id)
+    assert surfaced["status"] == "running"
+    assert surfaced["started_at"] is not None
+    assert surfaced["completed_at"] is None
+    assert surfaced["duration_seconds"] is None
+    assert surfaced["result"]["sync_run_status"] == SyncRunStatus.DISPATCHING.value
+
+    completed_at = datetime.now(timezone.utc)
+    async with session_maker() as session:
+        completed_run = await session.get(SyncRun, uuid.UUID(sync_run_id))
+        assert completed_run is not None
+        completed_run.status = SyncRunStatus.SUCCESS.value
+        completed_run.started_at = started_at
+        completed_run.completed_at = completed_at
+        completed_run.completed_units = 3
+        completed_run.failed_units = 0
+        completed_run.result = {"completed_units": 3, "failed_units": 0}
+        await session.commit()
+
+    jobs_resp = await ac.get(f"/api/v1/admin/sync-configs/{config_id}/jobs")
+    assert jobs_resp.status_code == 200, jobs_resp.text
+    surfaced = next(job for job in jobs_resp.json() if job["id"] == job_run_id)
     assert surfaced["status"] == "success"
-    assert surfaced["result"] == {
-        "sync_run_id": sync_run_id,
-        "dispatch_task_id": "task-real",
-    }
+    assert surfaced["started_at"] is not None
+    assert surfaced["completed_at"] is not None
+    assert surfaced["duration_seconds"] == 42
+    assert surfaced["items_synced"] == 3
+    assert surfaced["result"]["sync_run_status"] == SyncRunStatus.SUCCESS.value
+    assert surfaced["result"]["completed_units"] == 3
+    assert surfaced["result"]["failed_units"] == 0
+
+    async with session_maker() as session:
+        partial_run = await session.get(SyncRun, uuid.UUID(sync_run_id))
+        assert partial_run is not None
+        partial_run.status = SyncRunStatus.PARTIAL_FAILED.value
+        partial_run.completed_units = 1
+        partial_run.failed_units = 2
+        partial_run.error = "unit failure"
+        partial_run.result = {"completed_units": 999, "failed_units": 999}
+        await session.commit()
+
+    jobs_resp = await ac.get(f"/api/v1/admin/sync-configs/{config_id}/jobs")
+    assert jobs_resp.status_code == 200, jobs_resp.text
+    surfaced = next(job for job in jobs_resp.json() if job["id"] == job_run_id)
+    assert surfaced["status"] == "failed"
+    assert surfaced["error"] == "unit failure"
+    assert surfaced["items_synced"] == 1
+    assert surfaced["result"]["sync_run_status"] == SyncRunStatus.PARTIAL_FAILED.value
+    assert surfaced["result"]["completed_units"] == 1
+    assert surfaced["result"]["failed_units"] == 2


### PR DESCRIPTION
## Summary
- Keep planner-managed JobRun rows as Job History anchors instead of marking enqueue success as run success.
- Enrich `/sync-configs/{config_id}/jobs` from linked `SyncRun` lifecycle fields so status, timing, unit counts, and `items_synced` come from the planner source of truth.
- Add regression coverage for planned, dispatching, success, and partial-failed projections, including stale `SyncRun.result` counts losing to canonical columns.

## Verification
- `uv run --extra dev pytest tests/api/admin/test_sync_trigger_routing.py tests/api/admin/test_sync_configs.py -q` -> 64 passed
- `uv run --extra dev ruff format --check src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/api/admin/schemas_flat.py tests/api/admin/test_sync_trigger_routing.py`
- `uv run --extra dev ruff check src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/api/admin/schemas_flat.py tests/api/admin/test_sync_trigger_routing.py`
- `uv run --extra dev mypy src/dev_health_ops/api/admin/routers/sync.py src/dev_health_ops/api/admin/schemas_flat.py tests/api/admin/test_sync_trigger_routing.py`
- Live API QA against reported config `b7a78c07-577c-4d43-b4d0-1486371392d5`: reported JobRun rows now return `status=running`, `sync_run_status=dispatching`, `total_units=75` instead of false `success` with empty stats.

## Reviews
- Oracle review: PASS; confirmed `SyncRun` remains lifecycle source of truth and `JobRun` remains only the history anchor.
- Code review agent: found result merge-order issue; fixed so canonical `SyncRun` columns override stale JSON result counts.

SCREENSHOT-WAIVER: Backend API lifecycle fix only; no frontend component/style changes. Rendered behavior was verified through the live Job History API response used by the existing UI.