### PR TITLE
fix(github): classify provider rate-limit failures

### DIFF
--- a/docs/runbooks/github-rate-limit-validation-handoff.md
+++ b/docs/runbooks/github-rate-limit-validation-handoff.md
@@ -1,0 +1,99 @@
+# GitHub rate-limit validation handoff
+
+Context: PR #1011 (`fix/github-worker-app-credentials`) validates the GitHub provider fix for GitHub App auth and rate-limit observability.
+
+## What was validated
+
+- Database credential `3c840245-0e3f-4beb-961f-2d7403cddd43` decrypts to GitHub App fields:
+  - `app_id`
+  - `private_key`
+  - `installation_id`
+  - `auth_mode`
+  - `setup_action`
+- `github_credentials_from_mapping()` returns app-auth credentials with:
+  - `is_app_auth=True`
+  - app id/private key/installation id present
+  - no PAT token required
+- Direct worker probe using the same credential reached GitHub and exchanged an installation token:
+  - `POST /app/installations/141773132/access_tokens` returned `201`
+  - `GET /repos/full-chaos/dev-health-web` returned `403`
+  - response indicated primary rate limit exhaustion for installation `141773132`
+- The running worker containers were using the current branch code:
+  - source file: `/app/src/dev_health_ops/providers/github/client.py`
+  - classifier present: `has_classifier=True`
+  - `get_repo()` source contains the classifier path
+
+## Runtime queue work
+
+- Cleared Celery/Valkey queue keys only; databases, Docker volumes, and persisted sync/backfill rows were not cleared.
+- Deleted queue keys included:
+  - `default`
+  - `sync`
+  - `sync.github`
+  - `sync.github.light`
+  - `sync.github.heavy`
+  - `sync.gitlab`
+  - `sync.gitlab.light`
+  - `sync.gitlab.heavy`
+  - `sync.linear`
+  - `metrics`
+  - `backfill`
+  - `monitoring`
+  - `ingest`
+  - `unacked`
+  - `unacked_index`
+- Restarted `beat`, `worker`, `worker-heavy`, and `worker-ingest`.
+
+## Trigger attempts
+
+- Legacy direct `run_sync_config.delay(config_id)` failed because `org_id` is required.
+- Retried with:
+  - config id: `b7a78c07-577c-4d43-b4d0-1486371392d5`
+  - org id: `70d529e0-3c06-4597-8480-794fd02328b6`
+  - task id: `be9b07f5-ecac-4f37-a013-6a653d407dcf`
+- Legacy direct task path was not the desired planner-managed route; it surfaced missing owner/repo config.
+- Manual planner run inspected:
+  - sync run id: `85d7a225-ad95-4337-ad40-28ba97d68ccb`
+  - status: `planned`
+  - total units: `75`
+- Dispatch task:
+  - task id: `bcab93e1-2225-4e05-a8eb-8b4d2bedf9b3`
+  - full dispatch remained concurrency-capped, and units stayed planned.
+
+## Forced unit validation
+
+- Forced unit:
+  - unit id: `6a3ffab3-42d5-4302-a959-16213bd303c2`
+  - source: `full-chaos/dev-health-web`
+  - dataset: `work-items`
+- Manually moved the unit from `planned` to `dispatching` and queued:
+  - task id: `d83bcae6-027f-4763-a8bd-b0b442147443`
+- Worker log evidence after the PR fix showed the provider now emits an actionable classified rate-limit message, not the old generic PyGithub retry/backoff message:
+  - `GitHub: failed to fetch milestones for full-chaos/dev-health-ops: GitHub rate limit on GET /repos/full-chaos/dev-health-ops: 403 {"message": "API rate limit exceeded for installation ID 141773132...`
+- Later persisted state after waiting:
+  - unit id: `6a3ffab3-42d5-4302-a959-16213bd303c2`
+  - status: `running`
+  - attempts: `1`
+  - error: empty
+  - lease expires at: `2026-06-22 02:43:28.133488+00`
+  - last heartbeat at: `2026-06-22 01:43:28.133488+00`
+- Recent queue check showed named queues empty, with unacked entries still present:
+  - `default`, `sync`, `sync.github`, `sync.github.light`, `sync.github.heavy`, `sync.linear`, `backfill`, `monitoring`: empty/missing
+  - `unacked`: hash with `162` entries
+  - `unacked_index`: zset with `162` entries
+
+## Residual blockers
+
+- GitHub terminal success is blocked by real GitHub App installation primary rate-limit exhaustion:
+  - installation id: `141773132`
+  - `X-RateLimit-Remaining: 0`
+- Full planner dispatch is also affected by concurrency caps/stale active work:
+  - observed `dispatch_sync_run.concurrency_capped`
+- Linear Sync Now remains independently blocked by:
+  - `{"error":"No active subscription"}`
+- PR #1011 intentionally fixed only the observed provider `get_repo()` boundary. Lazy PyGithub calls from returned repository objects still need broader wrapper coverage, tracked separately in `CHAOS-2598`.
+
+## Follow-up issue
+
+- `CHAOS-2598 Complete GitHub provider PyGithub error handling across lazy REST calls`
+- URL: `https://linear.app/fullchaos/issue/CHAOS-2598/complete-github-provider-pygithub-error-handling-across-lazy-rest`

--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Protocol, TypedDict, TypeVar, cast
 from urllib.parse import urlparse
 
+from dev_health_ops.connectors.exceptions import (
+    APIException,
+    AuthenticationException,
+    NotFoundException,
+    RateLimitException,
+)
 from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
 from dev_health_ops.connectors.utils.graphql import GitHubGraphQLClient
 from dev_health_ops.connectors.utils.rate_limit_queue import (
@@ -23,6 +30,14 @@ from dev_health_ops.credentials.types import GitHubCredentials
 from dev_health_ops.providers._ratelimit import gate_call
 
 logger = logging.getLogger(__name__)
+
+_DIAGNOSTIC_HEADER_NAMES = (
+    "x-ratelimit-remaining",
+    "x-ratelimit-reset",
+    "retry-after",
+    "x-github-request-id",
+    "x-accepted-github-permissions",
+)
 
 _TItem = TypeVar("_TItem")
 
@@ -41,6 +56,40 @@ def _parse_github_datetime(value: object) -> datetime | None:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
+
+
+def _diagnostic_headers(headers: object) -> dict[str, str]:
+    if not isinstance(headers, dict):
+        return {}
+    lowered = {str(k).lower(): str(v) for k, v in headers.items()}
+    return {name: lowered[name] for name in _DIAGNOSTIC_HEADER_NAMES if name in lowered}
+
+
+def _github_error_message(data: object) -> str:
+    if isinstance(data, dict):
+        message = data.get("message")
+        if message is not None:
+            return str(message)
+    if data is None:
+        return ""
+    return str(data)
+
+
+def _retry_after_seconds(headers: dict[str, str]) -> float | None:
+    retry_after = headers.get("retry-after")
+    if retry_after is not None:
+        try:
+            return float(retry_after)
+        except ValueError:
+            return None
+
+    reset = headers.get("x-ratelimit-reset")
+    if reset is not None:
+        try:
+            return max(0.0, float(reset) - time.time())
+        except ValueError:
+            return None
+    return None
 
 
 class _GitHubLabelLike(Protocol):
@@ -206,7 +255,7 @@ class GitHubWorkClient:
         gate: RateLimitGate | None = None,
         org_id: str | None = None,
     ) -> None:
-        from github import Github  # PyGithub
+        from github import Auth, Github  # PyGithub
 
         self.auth = auth
         self.per_page = max(1, min(100, int(per_page)))
@@ -221,29 +270,39 @@ class GitHubWorkClient:
         self._app_token_provider: GitHubAppTokenProvider | None = None
 
         token = auth.token
+        pygithub_auth: Any | None = None
         if auth.is_app_auth:
             assert auth.app_id is not None
             assert auth.private_key is not None
             assert auth.installation_id is not None
+            app_auth = Auth.AppAuth(auth.app_id, auth.private_key)
+            pygithub_auth = Auth.AppInstallationAuth(
+                app_auth, int(auth.installation_id)
+            )
             self._app_token_provider = GitHubAppTokenProvider(
                 app_id=auth.app_id,
                 private_key=auth.private_key,
                 installation_id=auth.installation_id,
+                api_base_url=base_url,
             )
             token = self._app_token_provider.get_token()
+        elif token:
+            pygithub_auth = Auth.Token(token)
         if not token:
             raise ValueError("GitHubWorkClient requires token or GitHub App auth")
 
         if auth.base_url:
             self.github = Github(
                 base_url=auth.base_url,
-                login_or_token=token,
+                auth=pygithub_auth,
                 per_page=self.per_page,
+                retry=None,
             )
         else:
             self.github = Github(
-                login_or_token=token,
+                auth=pygithub_auth,
                 per_page=self.per_page,
+                retry=None,
             )
 
         # GraphQL client (api.github.com only for now).
@@ -269,8 +328,81 @@ class GitHubWorkClient:
         return cls(auth=GitHubAuth.from_credentials(credentials), org_id=org_id)
 
     def get_repo(self, *, owner: str, repo: str) -> Any:
+        operation = f"GET /repos/{owner}/{repo}"
         with gate_call(self.gate):
-            return self.github.get_repo(f"{owner}/{repo}")
+            try:
+                return self.github.get_repo(f"{owner}/{repo}")
+            except Exception as exc:
+                self._raise_github_exception(exc, operation=operation)
+
+    def _raise_github_exception(self, exc: Exception, *, operation: str) -> None:
+        from github import GithubException, RateLimitExceededException
+
+        if isinstance(exc, (APIException, AuthenticationException, NotFoundException)):
+            raise exc
+        if isinstance(exc, RateLimitException):
+            raise exc
+        if isinstance(exc, RateLimitExceededException):
+            raise RateLimitException(
+                f"GitHub rate limit on {operation}: {exc}",
+                retry_after_seconds=self._rate_limit_reset_delay_seconds(),
+            )
+        if not isinstance(exc, GithubException):
+            raise APIException(f"GitHub API error on {operation}: {exc}") from exc
+
+        status = getattr(exc, "status", None)
+        headers = _diagnostic_headers(getattr(exc, "headers", None))
+        message = _github_error_message(getattr(exc, "data", None))
+        if status == 401:
+            raise AuthenticationException(
+                f"GitHub authentication failed on {operation}: {message} (headers={headers})"
+            ) from exc
+        if status == 404:
+            raise NotFoundException(
+                f"GitHub resource not found on {operation}: {message} (headers={headers})"
+            ) from exc
+        if status == 403:
+            lowered = message.lower()
+            is_rate_limit = (
+                headers.get("x-ratelimit-remaining") == "0"
+                or "retry-after" in headers
+                or "rate limit" in lowered
+                or "abuse" in lowered
+                or "secondary" in lowered
+            )
+            if is_rate_limit:
+                retry_after = _retry_after_seconds(headers)
+                logger.warning(
+                    "GitHub rate limit (403) on %s headers=%s message=%s",
+                    operation,
+                    headers,
+                    message,
+                )
+                raise RateLimitException(
+                    f"GitHub rate limit (403) on {operation}: {message} (headers={headers})",
+                    retry_after_seconds=retry_after,
+                ) from exc
+            logger.warning(
+                "GitHub 403 on %s headers=%s message=%s",
+                operation,
+                headers,
+                message,
+            )
+            raise AuthenticationException(
+                f"GitHub 403 on {operation}: {message} (headers={headers})"
+            ) from exc
+        raise APIException(
+            f"GitHub API error on {operation}: HTTP {status} {message} (headers={headers})"
+        ) from exc
+
+    def _rate_limit_reset_delay_seconds(self) -> float | None:
+        reset = getattr(self.github, "rate_limiting_resettime", None)
+        if reset is None:
+            return None
+        try:
+            return max(0.0, float(reset) - time.time())
+        except (TypeError, ValueError):
+            return None
 
     def _iter_with_limit(
         self,

--- a/tests/providers/test_github_pr_social_batch.py
+++ b/tests/providers/test_github_pr_social_batch.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from dev_health_ops.connectors.exceptions import APIException, RateLimitException
+from dev_health_ops.connectors.exceptions import (
+    APIException,
+    AuthenticationException,
+    RateLimitException,
+)
 from dev_health_ops.providers.github.client import GitHubAuth, GitHubWorkClient
 
 
@@ -19,6 +24,99 @@ def _client() -> tuple[GitHubWorkClient, MagicMock, MagicMock]:
     ):
         client = GitHubWorkClient(auth=GitHubAuth(token="token"), gate=gate)
     return client, graphql_cls.return_value, gate
+
+
+def test_work_client_uses_pygithub_token_auth_without_internal_retry() -> None:
+    gate = MagicMock()
+    with (
+        patch("github.Github") as github_cls,
+        patch("dev_health_ops.providers.github.client.GitHubGraphQLClient"),
+    ):
+        GitHubWorkClient(auth=GitHubAuth(token="token"), gate=gate)
+
+    _, kwargs = github_cls.call_args
+    assert kwargs["auth"].__class__.__name__ == "Token"
+    assert kwargs["retry"] is None
+    assert "login_or_token" not in kwargs
+
+
+def test_work_client_uses_pygithub_app_installation_auth_without_internal_retry() -> (
+    None
+):
+    gate = MagicMock()
+    with (
+        patch("github.Github") as github_cls,
+        patch("dev_health_ops.providers.github.client.GitHubGraphQLClient"),
+        patch(
+            "dev_health_ops.providers.github.client.GitHubAppTokenProvider"
+        ) as token_provider_cls,
+    ):
+        token_provider_cls.return_value.get_token.return_value = "installation-token"
+        GitHubWorkClient(
+            auth=GitHubAuth(
+                app_id="123",
+                private_key="not-a-real-private-key",
+                installation_id="456",
+            ),
+            gate=gate,
+        )
+
+    _, kwargs = github_cls.call_args
+    assert kwargs["auth"].__class__.__name__ == "AppInstallationAuth"
+    assert kwargs["auth"].installation_id == 456
+    assert kwargs["retry"] is None
+    assert "login_or_token" not in kwargs
+
+
+def test_work_client_get_repo_classifies_primary_rate_limit_403(monkeypatch) -> None:
+    from github.GithubException import GithubException
+
+    client, _graphql, gate = _client()
+    cast(Any, client.github).get_repo = MagicMock(
+        side_effect=GithubException(
+            403,
+            {"message": "API rate limit exceeded for installation ID 141773132."},
+            {
+                "x-ratelimit-remaining": "0",
+                "x-ratelimit-reset": "105",
+                "x-github-request-id": "REQ:5",
+            },
+        )
+    )
+    monkeypatch.setattr("dev_health_ops.providers.github.client.time.time", lambda: 100)
+
+    with pytest.raises(RateLimitException) as exc_info:
+        client.get_repo(owner="full-chaos", repo="dev-health-web")
+
+    message = str(exc_info.value)
+    assert "GitHub rate limit" in message
+    assert "GET /repos/full-chaos/dev-health-web" in message
+    assert "x-ratelimit-remaining" in message
+    assert "REQ:5" in message
+    assert exc_info.value.retry_after_seconds == pytest.approx(5.0)
+    gate.penalize.assert_called_once_with(5.0)
+
+
+def test_work_client_get_repo_classifies_permission_403() -> None:
+    from github.GithubException import GithubException
+
+    client, _graphql, gate = _client()
+    cast(Any, client.github).get_repo = MagicMock(
+        side_effect=GithubException(
+            403,
+            {"message": "Resource not accessible by integration"},
+            {"x-github-request-id": "REQ:9"},
+        )
+    )
+
+    with pytest.raises(AuthenticationException) as exc_info:
+        client.get_repo(owner="full-chaos", repo="private-repo")
+
+    message = str(exc_info.value)
+    assert "GitHub 403" in message
+    assert "GET /repos/full-chaos/private-repo" in message
+    assert "REQ:9" in message
+    gate.penalize.assert_called_once_with(None)
 
 
 def _pr(number: int) -> MagicMock:

--- a/tests/test_github_app_auth.py
+++ b/tests/test_github_app_auth.py
@@ -124,6 +124,7 @@ def test_github_work_client_branches_to_app_token_provider() -> None:
         app_id="12345",
         private_key="synthetic-private-key",
         installation_id="67890",
+        api_base_url="https://api.github.com",
     )
     github_cls.assert_called_once()
     graphql_cls.assert_called_once()


### PR DESCRIPTION
## Summary
- use documented PyGithub auth objects for provider REST calls and disable PyGithub's internal retry
- classify `GitHubWorkClient.get_repo()` PyGithub failures into typed rate-limit/auth/not-found/API exceptions with safe headers
- add provider regression coverage for PAT auth, GitHub App installation auth, primary rate-limit 403s, and permission 403s

## Verification
- `PYTHONPATH=src python -m pytest tests/test_github_403_observability.py tests/providers/test_github_pr_social_batch.py -q`
- `ruff check src/dev_health_ops/providers/github/client.py tests/providers/test_github_pr_social_batch.py`
- `ruff format --check src/dev_health_ops/providers/github/client.py tests/providers/test_github_pr_social_batch.py`
- pre-push hook: ruff format check, ruff check, mypy

## Follow-up
- Filed CHAOS-2598 for applying typed PyGithub error handling across lazy REST pagination paths.

SCREENSHOT-WAIVER: backend/provider error handling only; no rendered frontend output changed.