### PR TITLE
fix(github): classify lazy PyGithub rate-limit failures

### DIFF
--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -6,7 +6,7 @@ import time
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Protocol, TypedDict, TypeVar, cast
+from typing import Any, NoReturn, Protocol, TypedDict, TypeVar, cast
 from urllib.parse import urlparse
 
 from dev_health_ops.connectors.exceptions import (
@@ -329,13 +329,18 @@ class GitHubWorkClient:
 
     def get_repo(self, *, owner: str, repo: str) -> Any:
         operation = f"GET /repos/{owner}/{repo}"
+        return self._call_github(
+            operation, lambda: self.github.get_repo(f"{owner}/{repo}")
+        )
+
+    def _call_github(self, operation: str, call: Callable[[], _TItem]) -> _TItem:
         with gate_call(self.gate):
             try:
-                return self.github.get_repo(f"{owner}/{repo}")
+                return call()
             except Exception as exc:
                 self._raise_github_exception(exc, operation=operation)
 
-    def _raise_github_exception(self, exc: Exception, *, operation: str) -> None:
+    def _raise_github_exception(self, exc: Exception, *, operation: str) -> NoReturn:
         from github import GithubException, RateLimitExceededException
 
         if isinstance(exc, (APIException, AuthenticationException, NotFoundException)):
@@ -427,6 +432,20 @@ class GitHubWorkClient:
             if limit is not None and count >= int(limit):
                 return
 
+    def _iter_github_items(
+        self,
+        source: Iterable[_TItem],
+        *,
+        operation: str,
+        limit: int | None,
+        skip: Callable[[_TItem], bool] | None = None,
+    ) -> Iterable[_TItem]:
+        with gate_call(self.gate):
+            try:
+                yield from self._iter_with_limit(source, limit=limit, skip=skip)
+            except Exception as exc:
+                self._raise_github_exception(exc, operation=operation)
+
     def iter_issues(
         self,
         *,
@@ -437,10 +456,13 @@ class GitHubWorkClient:
         limit: int | None = None,
     ) -> Iterable[_GitHubIssueLike]:
         gh_repo = self.get_repo(owner=owner, repo=repo)
-        with gate_call(self.gate):
-            issues = gh_repo.get_issues(state=state, since=since)
-        yield from self._iter_with_limit(
+        operation = f"GET /repos/{owner}/{repo}/issues"
+        issues = self._call_github(
+            operation, lambda: gh_repo.get_issues(state=state, since=since)
+        )
+        yield from self._iter_github_items(
             issues,
+            operation=operation,
             limit=limit,
             skip=lambda issue: getattr(issue, "pull_request", None) is not None,
         )
@@ -457,16 +479,18 @@ class GitHubWorkClient:
         Accepts both Issues and PullRequests: PyGithub's Issue exposes the
         endpoint as get_events(), PullRequest as get_issue_events().
         """
+        issue_number = getattr(issue, "number", "?")
+        operation = f"GET issue events for #{issue_number}"
         get_events = getattr(issue, "get_events", None)
         if callable(get_events):
-            with gate_call(self.gate):
-                events = get_events()
+            events = self._call_github(operation, get_events)
         else:
             get_issue_events = getattr(issue, "get_issue_events")
-            with gate_call(self.gate):
-                events = get_issue_events()
-        yield from self._iter_with_limit(
-            cast(Iterable[_GitHubEventLike], events), limit=limit
+            events = self._call_github(operation, get_issue_events)
+        yield from self._iter_github_items(
+            cast(Iterable[_GitHubEventLike], events),
+            operation=operation,
+            limit=limit,
         )
 
     def iter_pull_requests(
@@ -483,9 +507,12 @@ class GitHubWorkClient:
         Iterate pull requests in a repository via REST.
         """
         gh_repo = self.get_repo(owner=owner, repo=repo)
-        with gate_call(self.gate):
-            pulls = gh_repo.get_pulls(state=state, sort=sort, direction=direction)
-        yield from self._iter_with_limit(pulls, limit=limit)
+        operation = f"GET /repos/{owner}/{repo}/pulls"
+        pulls = self._call_github(
+            operation,
+            lambda: gh_repo.get_pulls(state=state, sort=sort, direction=direction),
+        )
+        yield from self._iter_github_items(pulls, operation=operation, limit=limit)
 
     def iter_issue_comments(
         self, issue: _GitHubIssueBaseLike, *, limit: int | None = None
@@ -493,9 +520,10 @@ class GitHubWorkClient:
         """
         Iterate comments on an issue via REST.
         """
-        with gate_call(self.gate):
-            comments = issue.get_comments()
-        yield from self._iter_with_limit(comments, limit=limit)
+        issue_number = getattr(issue, "number", "?")
+        operation = f"GET issue comments for #{issue_number}"
+        comments = self._call_github(operation, issue.get_comments)
+        yield from self._iter_github_items(comments, operation=operation, limit=limit)
 
     def iter_pr_comments(
         self, pr: _GitHubPullRequestLike, *, limit: int | None = None
@@ -512,9 +540,10 @@ class GitHubWorkClient:
         """
         Iterate review comments on a pull request.
         """
-        with gate_call(self.gate):
-            comments = pr.get_review_comments()
-        yield from self._iter_with_limit(comments, limit=limit)
+        pr_number = getattr(pr, "number", "?")
+        operation = f"GET pull request review comments for #{pr_number}"
+        comments = self._call_github(operation, pr.get_review_comments)
+        yield from self._iter_github_items(comments, operation=operation, limit=limit)
 
     def iter_pr_social_data_batch(
         self,
@@ -894,9 +923,11 @@ class GitHubWorkClient:
         Iterate milestones in a repository via REST.
         """
         gh_repo = self.get_repo(owner=owner, repo=repo)
-        with gate_call(self.gate):
-            milestones = gh_repo.get_milestones(state=state)
-        yield from self._iter_with_limit(milestones, limit=limit)
+        operation = f"GET /repos/{owner}/{repo}/milestones"
+        milestones = self._call_github(
+            operation, lambda: gh_repo.get_milestones(state=state)
+        )
+        yield from self._iter_github_items(milestones, operation=operation, limit=limit)
 
     def iter_project_v2_items(
         self,

--- a/tests/providers/test_github_pr_social_batch.py
+++ b/tests/providers/test_github_pr_social_batch.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
@@ -117,6 +118,133 @@ def test_work_client_get_repo_classifies_permission_403() -> None:
     assert "GET /repos/full-chaos/private-repo" in message
     assert "REQ:9" in message
     gate.penalize.assert_called_once_with(None)
+
+
+def _lazy_rate_limit_iterable() -> Iterable[object]:
+    from github.GithubException import GithubException
+
+    raise GithubException(
+        403,
+        {"message": "API rate limit exceeded for installation ID 141773132."},
+        {
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": "105",
+            "x-github-request-id": "REQ:lazy",
+        },
+    )
+    yield object()
+
+
+def test_work_client_iter_issues_classifies_lazy_primary_rate_limit_403(
+    monkeypatch,
+) -> None:
+    client, _graphql, gate = _client()
+    repo = MagicMock()
+    repo.get_issues.return_value = _lazy_rate_limit_iterable()
+    cast(Any, client.github).get_repo.return_value = repo
+    monkeypatch.setattr("dev_health_ops.providers.github.client.time.time", lambda: 100)
+
+    with pytest.raises(RateLimitException) as exc_info:
+        list(client.iter_issues(owner="full-chaos", repo="dev-health-web"))
+
+    message = str(exc_info.value)
+    assert "GitHub rate limit" in message
+    assert "GET /repos/full-chaos/dev-health-web/issues" in message
+    assert "REQ:lazy" in message
+    assert exc_info.value.retry_after_seconds == pytest.approx(5.0)
+    gate.penalize.assert_called_once_with(5.0)
+
+
+def test_work_client_iter_milestones_classifies_lazy_primary_rate_limit_403(
+    monkeypatch,
+) -> None:
+    client, _graphql, gate = _client()
+    repo = MagicMock()
+    repo.get_milestones.return_value = _lazy_rate_limit_iterable()
+    cast(Any, client.github).get_repo.return_value = repo
+    monkeypatch.setattr("dev_health_ops.providers.github.client.time.time", lambda: 100)
+
+    with pytest.raises(RateLimitException) as exc_info:
+        list(client.iter_repo_milestones(owner="full-chaos", repo="dev-health-ops"))
+
+    message = str(exc_info.value)
+    assert "GitHub rate limit" in message
+    assert "GET /repos/full-chaos/dev-health-ops/milestones" in message
+    assert "REQ:lazy" in message
+    assert exc_info.value.retry_after_seconds == pytest.approx(5.0)
+    gate.penalize.assert_called_once_with(5.0)
+
+
+def test_work_client_iter_pull_requests_classifies_lazy_primary_rate_limit_403(
+    monkeypatch,
+) -> None:
+    client, _graphql, gate = _client()
+    repo = MagicMock()
+    repo.get_pulls.return_value = _lazy_rate_limit_iterable()
+    cast(Any, client.github).get_repo.return_value = repo
+    monkeypatch.setattr("dev_health_ops.providers.github.client.time.time", lambda: 100)
+
+    with pytest.raises(RateLimitException) as exc_info:
+        list(client.iter_pull_requests(owner="full-chaos", repo="dev-health-web"))
+
+    message = str(exc_info.value)
+    assert "GET /repos/full-chaos/dev-health-web/pulls" in message
+    assert "REQ:lazy" in message
+    gate.penalize.assert_called_once_with(5.0)
+
+
+def test_work_client_iter_issue_events_classifies_lazy_primary_rate_limit_403(
+    monkeypatch,
+) -> None:
+    client, _graphql, gate = _client()
+    issue = MagicMock()
+    issue.number = 123
+    issue.get_events.return_value = _lazy_rate_limit_iterable()
+    monkeypatch.setattr("dev_health_ops.providers.github.client.time.time", lambda: 100)
+
+    with pytest.raises(RateLimitException) as exc_info:
+        list(client.iter_issue_events(issue))
+
+    message = str(exc_info.value)
+    assert "GET issue events for #123" in message
+    assert "REQ:lazy" in message
+    gate.penalize.assert_called_once_with(5.0)
+
+
+def test_work_client_iter_issue_comments_classifies_lazy_primary_rate_limit_403(
+    monkeypatch,
+) -> None:
+    client, _graphql, gate = _client()
+    issue = MagicMock()
+    issue.number = 456
+    issue.get_comments.return_value = _lazy_rate_limit_iterable()
+    monkeypatch.setattr("dev_health_ops.providers.github.client.time.time", lambda: 100)
+
+    with pytest.raises(RateLimitException) as exc_info:
+        list(client.iter_issue_comments(issue))
+
+    message = str(exc_info.value)
+    assert "GET issue comments for #456" in message
+    assert "REQ:lazy" in message
+    gate.penalize.assert_called_once_with(5.0)
+
+
+def test_work_client_iter_pr_review_comments_classifies_lazy_primary_rate_limit_403(
+    monkeypatch,
+) -> None:
+    client, _graphql, gate = _client()
+    pr = MagicMock()
+    pr.number = 789
+    pr.get_review_comments.return_value = _lazy_rate_limit_iterable()
+    monkeypatch.setattr("dev_health_ops.providers.github.client.time.time", lambda: 100)
+
+    with pytest.raises(RateLimitException) as exc_info:
+        list(client.iter_pr_review_comments(pr))
+
+    message = str(exc_info.value)
+    assert "GET pull request review comments for #789" in message
+    assert "REQ:lazy" in message
+    gate.penalize.assert_called_once_with(5.0)
 
 
 def _pr(number: int) -> MagicMock:


### PR DESCRIPTION
## Summary
- Route lazy PyGithub REST iterators through the existing GitHub exception classifier and rate-limit gate.
- Cover issues, pulls, milestones, issue events, issue comments, and PR review comments.
- Add regression tests for lazy 403 rate-limit failures across those paths.

## Validation
- pytest tests/test_github_403_observability.py tests/providers/test_github_pr_social_batch.py tests/providers/test_github_iter_issue_events.py -q
- ruff check src/dev_health_ops/providers/github/client.py tests/providers/test_github_pr_social_batch.py
- mypy src/dev_health_ops/providers/github/client.py tests/providers/test_github_pr_social_batch.py
- pre-commit hook: ruff-fix, ruff-format, mypy
- pre-push hook: ruff format --check, ruff check, mypy
- Manual driver exercised lazy milestone iteration and observed classified RateLimitException.
- Live validation triggered sync config 13bbdc4d-4e1e-4a53-881b-1a06a68029b1 and returned sync run 76dfa3e7-824d-4935-ab8e-5f475194c485; local pre-existing sync backlog/concurrency caps kept that run planned, while a worktree-mounted worker processed other GitHub units with this branch code.

Closes CHAOS-2598