### PR TITLE
fix(metrics): inherit linked issue team from external key prefix

### DIFF
--- a/src/dev_health_ops/metrics/compute_work_items.py
+++ b/src/dev_health_ops/metrics/compute_work_items.py
@@ -433,11 +433,26 @@ def build_linked_issue_team_resolver(
             else:
                 key_index[k] = wid
 
+    def _external_issue_key(target_id: str) -> str | None:
+        if not target_id.startswith("extkey:"):
+            return None
+        return target_id.split(":", 1)[1].strip().upper()
+
     def _canonical_target(target_id: str) -> str | None:
-        if target_id.startswith("extkey:"):
-            # Missing or ambiguous keys both return None → no inheritance.
-            return key_index.get(target_id.split(":", 1)[1].strip().upper())
+        issue_key = _external_issue_key(target_id)
+        if issue_key is not None:
+            # Missing or ambiguous keys both return None → no donor-row lookup.
+            return key_index.get(issue_key)
         return target_id
+
+    def _team_from_issue_key_prefix(issue_key: str) -> tuple[str, str] | None:
+        if project_key_resolver is None or "-" not in issue_key:
+            return None
+        project_key = issue_key.rsplit("-", 1)[0]
+        team_id, team_name = project_key_resolver.resolve(project_key)
+        if team_id is None:
+            return None
+        return team_id, team_name or team_id
 
     def _recency(dep: WorkItemDependency) -> float:
         last = dep.last_synced
@@ -483,11 +498,20 @@ def build_linked_issue_team_resolver(
         if base_resolved.get(source_id) is not None:
             continue
         target_id = _canonical_target(dep.target_work_item_id)
-        if not target_id:
+        if target_id:
+            donor = donor_team.get(target_id)
+            if donor is not None:
+                candidates.setdefault(source_id, []).append((target_id, donor))
             continue
-        donor = donor_team.get(target_id)
+
+        issue_key = _external_issue_key(dep.target_work_item_id)
+        if issue_key is None or issue_key in ambiguous_keys:
+            continue
+        donor = _team_from_issue_key_prefix(issue_key)
         if donor is not None:
-            candidates.setdefault(source_id, []).append((target_id, donor))
+            candidates.setdefault(source_id, []).append(
+                (dep.target_work_item_id, donor)
+            )
 
     inherited: dict[str, tuple[str, str]] = {
         source_id: min(cands, key=lambda c: c[0])[1]

--- a/tests/test_linked_issue_team_inheritance.py
+++ b/tests/test_linked_issue_team_inheritance.py
@@ -214,6 +214,18 @@ def test_ambiguous_extkey_across_providers_is_dropped() -> None:
         assert resolver.resolve(pr.work_item_id) == (None, None)
 
 
+def test_ambiguous_extkey_does_not_fall_back_to_key_prefix() -> None:
+    linear = _wi("linear:CHAOS-1", "linear")
+    jira = _wi("jira:CHAOS-1", "jira")
+    pr = _wi("ghpr:x/y#1", "github", type="pr", project_id="x/y")
+    deps = [WorkItemDependency(pr.work_item_id, "extkey:CHAOS-1", "relates_to", "k")]
+    pkr = ProjectKeyTeamResolver(project_key_to_team={"CHAOS": ("CHAOS", "Chaos Team")})
+    resolver = build_linked_issue_team_resolver(
+        work_items=[linear, jira, pr], dependencies=deps, project_key_resolver=pkr
+    )
+    assert resolver.resolve(pr.work_item_id) == (None, None)
+
+
 def test_unresolvable_extkey_yields_no_inheritance() -> None:
     pr = _wi("ghpr:x/y#1", "github", type="pr", project_id="x/y")
     deps = [
@@ -228,6 +240,62 @@ def test_unresolvable_extkey_yields_no_inheritance() -> None:
         work_items=[pr], dependencies=deps, project_key_resolver=_chaos_resolver()
     )
     assert resolver.resolve(pr.work_item_id) == (None, None)
+
+
+def test_github_pr_inherits_from_extkey_prefix_without_donor_item() -> None:
+    # GitHub-token-only syncs can capture a Linear issue key from the PR body or
+    # branch before the Linear issue itself has been synced into work_items. The
+    # key prefix still maps to a known team, so the PR should inherit that team.
+    pr = _wi(
+        "ghpr:full-chaos/dev-health#12",
+        "github",
+        type="pr",
+        project_id="full-chaos/dev-health",
+    )
+    deps = [WorkItemDependency(pr.work_item_id, "extkey:CHAOS-2400", "relates_to", "k")]
+    resolver = build_linked_issue_team_resolver(
+        work_items=[pr], dependencies=deps, project_key_resolver=_chaos_resolver()
+    )
+    assert resolver.resolve(pr.work_item_id) == ("CHAOS", "Chaos Team")
+
+
+def test_gitlab_mr_inherits_from_extkey_prefix_without_donor_item() -> None:
+    mr = _wi(
+        "gitlab:full-chaos/dev-health!12",
+        "gitlab",
+        type="merge_request",
+        project_id="full-chaos/dev-health",
+    )
+    deps = [WorkItemDependency(mr.work_item_id, "extkey:CHAOS-2400", "relates_to", "k")]
+    resolver = build_linked_issue_team_resolver(
+        work_items=[mr], dependencies=deps, project_key_resolver=_chaos_resolver()
+    )
+    assert resolver.resolve(mr.work_item_id) == ("CHAOS", "Chaos Team")
+
+
+def test_gitlab_mr_prefix_fallback_stamps_cycle_time_team() -> None:
+    day = date(2026, 6, 1)
+    mr = _wi(
+        "gitlab:full-chaos/dev-health!12",
+        "gitlab",
+        type="merge_request",
+        project_id="full-chaos/dev-health",
+    )
+    deps = [WorkItemDependency(mr.work_item_id, "extkey:CHAOS-2400", "relates_to", "k")]
+    pkr = _chaos_resolver()
+    resolver = build_linked_issue_team_resolver(
+        work_items=[mr], dependencies=deps, project_key_resolver=pkr
+    )
+    _, _, cycle_times = compute_work_item_metrics_daily(
+        day=day,
+        work_items=[mr],
+        transitions=[],
+        computed_at=START,
+        project_key_resolver=pkr,
+        linked_issue_resolver=resolver,
+    )
+    assert cycle_times[0].team_id == "CHAOS"
+    assert cycle_times[0].team_name == "Chaos Team"
 
 
 def test_multiple_donors_resolved_deterministically_regardless_of_order() -> None:


### PR DESCRIPTION
## Summary
- let linked-issue inheritance resolve extkey issue prefixes through configured team project keys when the donor issue row is absent
- keep ambiguous Linear/Jira extkeys and unmapped prefixes from inheriting
- cover both GitHub PR and GitLab MR no-donor fallback paths, including GitLab cycle-time attribution

## Verification
- pytest tests/test_linked_issue_team_inheritance.py tests/test_pr_issue_link_capture.py tests/test_team_autoimport_executor.py -q
- ruff check src/dev_health_ops/metrics/compute_work_items.py tests/test_linked_issue_team_inheritance.py
- mypy src/dev_health_ops/metrics/compute_work_items.py tests/test_linked_issue_team_inheritance.py
- PYTHONPATH=src python - <<'PY'
from datetime import datetime, timezone
from dev_health_ops.metrics.compute_work_items import build_linked_issue_team_resolver
from dev_health_ops.models.work_items import WorkItem, WorkItemDependency
from dev_health_ops.providers.teams import ProjectKeyTeamResolver
now = datetime(2026, 6, 1, tzinfo=timezone.utc)
resolver = ProjectKeyTeamResolver(project_key_to_team={"CHAOS": ("CHAOS", "Chaos Team")})
for work_item_id, provider, item_type in (("ghpr:full-chaos/dev-health#12", "github", "pr"), ("gitlab:full-chaos/dev-health!12", "gitlab", "merge_request")):
    item = WorkItem(work_item_id=work_item_id, provider=provider, type=item_type, title="Implement mapping fix", status="done", status_raw="merged", created_at=now, updated_at=now, started_at=now, completed_at=now, project_id="full-chaos/dev-health")
    linked = build_linked_issue_team_resolver(work_items=[item], dependencies=[WorkItemDependency(item.work_item_id, "extkey:CHAOS-2400", "relates_to", "k")], project_key_resolver=resolver)
    print(work_item_id, linked.resolve(work_item_id))
PY

SCREENSHOT-WAIVER: backend metrics-only change; no rendered frontend output.