### PR TITLE
feat(clickhouse): manual_attribution_fallbacks table + source/confidence enum widening (CHAOS-2602)

### DIFF
--- a/src/dev_health_ops/metrics/schemas.py
+++ b/src/dev_health_ops/metrics/schemas.py
@@ -396,6 +396,31 @@ class WorkItemTeamAttributionRecord:
 
 
 @dataclass(frozen=True)
+class ManualAttributionFallbackRecord:
+    """Explicit manual fallback attribution record (ClickHouse-only).
+
+    A FALLBACK, never an override: the resolver consults these only after native/imported/linked
+    attribution fails. ``scope_type`` is one of ``repo`` | ``project`` | ``member`` |
+    ``issue_key_prefix`` (an ``issue_key_prefix`` is the only way a bare key prefix may map to a
+    team — and only as ``source = manual_fallback``, never ``linked_issue``).
+    """
+
+    provider: str
+    scope_type: str
+    scope_id: str
+    team_id: str
+    team_name: str
+    reason: str
+    updated_at: datetime
+    priority: int = 100
+    valid_from: datetime | None = None
+    valid_to: datetime | None = None
+    created_by: str | None = None
+    created_at: datetime | None = None
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
 class WorkItemCycleTimeRecord:
     work_item_id: str
     provider: str

--- a/src/dev_health_ops/metrics/sinks/base.py
+++ b/src/dev_health_ops/metrics/sinks/base.py
@@ -31,6 +31,7 @@ from dev_health_ops.metrics.schemas import (
     InvestmentMetricsRecord,
     IssueTypeMetricsRecord,
     LLMTokenUsageRecord,
+    ManualAttributionFallbackRecord,
     MemberRecord,
     ProjectRecord,
     ReleaseImpactDailyRecord,
@@ -477,6 +478,11 @@ class BaseMetricsSink(ABC):
 
     def write_work_item_team_attributions(
         self, rows: Sequence[WorkItemTeamAttributionRecord]
+    ) -> None:
+        pass
+
+    def write_manual_attribution_fallbacks(
+        self, rows: Sequence[ManualAttributionFallbackRecord]
     ) -> None:
         pass
 

--- a/src/dev_health_ops/metrics/sinks/clickhouse/core.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/core.py
@@ -21,6 +21,7 @@ from typing import Any
 import clickhouse_connect
 
 from dev_health_ops.metrics.schemas import (
+    ManualAttributionFallbackRecord,
     MemberRecord,
     ProjectRecord,
     TeamMembershipRecord,
@@ -323,6 +324,60 @@ class ClickHouseCore(BaseMetricsSink):
             matrix = [[row[col] for col in column_names] for row in chunk]
             self.client.insert(
                 "work_item_team_attributions", matrix, column_names=column_names
+            )
+
+    def write_manual_attribution_fallbacks(
+        self, rows: Sequence[ManualAttributionFallbackRecord]
+    ) -> None:
+        if not rows:
+            return
+        org_id = getattr(self, "org_id", None) or ""
+        column_names = [
+            "org_id",
+            "provider",
+            "scope_type",
+            "scope_id",
+            "team_id",
+            "team_name",
+            "reason",
+            "priority",
+            "valid_from",
+            "valid_to",
+            "created_by",
+            "created_at",
+            "updated_at",
+        ]
+        data = []
+        for row in rows:
+            updated_at = _dt_to_clickhouse_datetime(row.updated_at)
+            data.append(
+                {
+                    "org_id": row.org_id or org_id,
+                    "provider": row.provider,
+                    "scope_type": row.scope_type,
+                    "scope_id": row.scope_id,
+                    "team_id": row.team_id,
+                    "team_name": row.team_name,
+                    "reason": row.reason,
+                    "priority": row.priority,
+                    # non-nullable DB columns fall back to updated_at when unset
+                    "valid_from": _dt_to_clickhouse_datetime(row.valid_from)
+                    if row.valid_from
+                    else updated_at,
+                    "valid_to": _dt_to_clickhouse_datetime(row.valid_to)
+                    if row.valid_to
+                    else None,
+                    "created_by": row.created_by,
+                    "created_at": _dt_to_clickhouse_datetime(row.created_at)
+                    if row.created_at
+                    else updated_at,
+                    "updated_at": updated_at,
+                }
+            )
+        for chunk in _chunked(data, DEFAULT_BATCH_SIZE):
+            matrix = [[row[col] for col in column_names] for row in chunk]
+            self.client.insert(
+                "manual_attribution_fallbacks", matrix, column_names=column_names
             )
 
     def _apply_sql_migrations(self) -> None:

--- a/src/dev_health_ops/migrations/clickhouse/053_manual_attribution_fallbacks.sql
+++ b/src/dev_health_ops/migrations/clickhouse/053_manual_attribution_fallbacks.sql
@@ -1,0 +1,40 @@
+-- CHAOS-2600 CS1: ClickHouse-only team attribution — storage foundations.
+-- Additive only, no behavior change: existing source/confidence integer codes are preserved and
+-- new values are appended so the resolver (CS2/CS3) can later emit issue_project / manual_fallback
+-- and manual / none confidence without an insert failure. See team-attribution.md s0 (Schema
+-- prerequisite) and CHAOS-2600 ordering rule s4.1 (migrate enums BEFORE emitting new values).
+
+-- Widen work_item_team_attributions.source. New codes 7/8 are appended; ranks (precedence) live in
+-- compute_work_items._SOURCE_ORDER, NOT in these integer codes.
+ALTER TABLE work_item_team_attributions
+    MODIFY COLUMN source Enum8('native_team' = 1, 'linked_issue' = 2, 'project_ownership' = 3, 'repo_ownership' = 4, 'assignee_membership' = 5, 'unassigned' = 6, 'issue_project' = 7, 'manual_fallback' = 8);
+
+-- Widen confidence (only this table has a confidence column; the edge tables do not).
+ALTER TABLE work_item_team_attributions
+    MODIFY COLUMN confidence Enum8('high' = 1, 'medium' = 2, 'low' = 3, 'manual' = 4, 'none' = 5);
+
+-- Explicit manual fallback attribution records. These are FALLBACK config, never overrides:
+-- the resolver only consults them after native/imported/linked attribution fails (CS3).
+-- scope_type allowed values: repo | project | member | issue_key_prefix.
+-- ReplacingMergeTree(updated_at); ORDER BY is the LOGICAL REPLACEMENT IDENTITY: one active
+-- fallback per (org_id, provider, scope_type, scope_id). team_id is deliberately NOT in the sort
+-- key — if it were, reassigning a scope to a different team would leave the old team row alive as a
+-- second active fallback (RMT only replaces rows sharing the full ORDER BY tuple). Reassigning a
+-- scope's team now REPLACES the row; readers take the latest by updated_at (FINAL/argMax, CS3).
+-- org_id leads the key (matches the 051 tables); no per-org PARTITION BY (avoids partition explosion).
+CREATE TABLE IF NOT EXISTS manual_attribution_fallbacks (
+    org_id String,
+    provider LowCardinality(String),
+    scope_type LowCardinality(String),
+    scope_id String,
+    team_id String,
+    team_name String,
+    reason String,
+    priority Int32 DEFAULT 100,
+    valid_from DateTime64(3, 'UTC') DEFAULT now64(3),
+    valid_to Nullable(DateTime64(3, 'UTC')),
+    created_by Nullable(String),
+    created_at DateTime64(3, 'UTC') DEFAULT now64(3),
+    updated_at DateTime64(3, 'UTC') DEFAULT now64(3)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (org_id, provider, scope_type, scope_id);

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -1757,6 +1757,56 @@ class ClickHouseStore:
             payload,
         )
 
+    async def insert_manual_attribution_fallbacks(self, rows: list[Any]) -> None:
+        if not rows:
+            return
+        now = self._normalize_datetime(datetime.now(timezone.utc))
+        payload: list[dict[str, Any]] = []
+        for item in rows:
+            get = self._item_getter(item)
+            payload.append(
+                {
+                    "org_id": get("org_id") or self.org_id or "",
+                    "provider": str(get("provider") or ""),
+                    "scope_type": str(get("scope_type") or ""),
+                    "scope_id": str(get("scope_id") or ""),
+                    "team_id": str(get("team_id") or ""),
+                    "team_name": str(get("team_name") or ""),
+                    "reason": str(get("reason") or ""),
+                    # Default ONLY on missing/None — an explicit priority=0 must survive
+                    # (lower value = higher precedence; falsy-coercion would corrupt it).
+                    "priority": 100
+                    if get("priority") is None
+                    else int(get("priority")),
+                    # valid_from / created_at / updated_at are non-nullable (DB DEFAULT now64);
+                    # _normalize_datetime(None) is None, so fall back to `now` to avoid a null insert.
+                    "valid_from": self._normalize_datetime(get("valid_from")) or now,
+                    "valid_to": self._normalize_datetime(get("valid_to")),
+                    "created_by": get("created_by"),
+                    "created_at": self._normalize_datetime(get("created_at")) or now,
+                    "updated_at": self._normalize_datetime(get("updated_at")) or now,
+                }
+            )
+        await self._insert_rows(
+            "manual_attribution_fallbacks",
+            [
+                "org_id",
+                "provider",
+                "scope_type",
+                "scope_id",
+                "team_id",
+                "team_name",
+                "reason",
+                "priority",
+                "valid_from",
+                "valid_to",
+                "created_by",
+                "created_at",
+                "updated_at",
+            ],
+            payload,
+        )
+
     async def _insert_team_edge_rows(
         self, table: str, columns: list[str], rows: list[Any]
     ) -> None:


### PR DESCRIPTION
## CHAOS-2602 — CS1 of CHAOS-2600

**Additive ClickHouse foundations. No behavior change** — the new table/writers are unreferenced by any resolver until CS3; the enum widening is append-only.

### Changes
- **Migration `053_manual_attribution_fallbacks.sql`:**
  - `CREATE TABLE manual_attribution_fallbacks` — `ReplacingMergeTree(updated_at)`, `ORDER BY (org_id, provider, scope_type, scope_id)` (the logical replacement identity; `team_id` deliberately **not** in the sort key so reassigning a scope's team replaces the row rather than leaving a stale second active fallback).
  - Widen `work_item_team_attributions.source` (+`issue_project`=7, +`manual_fallback`=8) and `confidence` (+`manual`=4, +`none`=5) — append-only, existing integer codes preserved. Prereq for CS2/CS3 emitting these values (ordering rule §4.1).
- `ManualAttributionFallbackRecord` schema; async `insert_manual_attribution_fallbacks` (storage) + `write_manual_attribution_fallbacks` (sink protocol + ClickHouse impl). Explicit `priority=0` preserved (defaults only on None).

### Gates
ruff + format + mypy green; migration splits into 3 statements. Codex adversarial review run 2×: v1 found a stale-fallback RMT key + a `priority=0` coercion bug → both fixed → **v2: approve, no material findings.** Live migrate round-trip deferred (no local ClickHouse) — covered by CI / live validation.

SCREENSHOT-WAIVER: backend schema/no-render change.