### PR TITLE
CS3 (CHAOS-2604): manual_fallback resolver + per-scope ownership dedup

### DIFF
--- a/docs/architecture/team-attribution.md
+++ b/docs/architecture/team-attribution.md
@@ -88,8 +88,10 @@ flowchart TD
 **Invariants:** the **winner is the highest-precedence matching source** (all matching sources are
 still persisted as candidates — precedence decides `is_primary`, not which sources are computed);
 `linked_issue` (5) requires a real `work_item_dependencies` donor row resolving to a `work_items`
-row that itself has a team (a bare prefix falls through to 6); `manual_fallback` (6) can only beat
-`unassigned`; a whole org at `unassigned` usually means the ClickHouse `teams` dimension is empty.
+row whose **own team came from a first-class fact (sources 0–4)** — a donor resolved only by
+`manual_fallback` is NOT a valid donor, so a bare prefix can never be laundered into rank-5
+inheritance (it falls through to 6); `manual_fallback` (6) can only beat `unassigned`; a whole org
+at `unassigned` usually means the ClickHouse `teams` dimension is empty.
 
 ### 0.2 Source reference matrix
 
@@ -112,7 +114,10 @@ row that itself has a team (a bare prefix falls through to 6); `manual_fallback`
 | PR attributed to a surprising team via `linked_issue` | 5 | which `work_item_dependencies` edge? donor's own team? extkey ambiguous? | confirm donor row + `_canonical_target`; check `_INHERITABLE_RELATIONSHIP_TYPES` |
 | `manual_fallback` beats a real team | precedence | `_SOURCE_ORDER` has `manual_fallback=6`? loader merging manual at the wrong rank? | restore rank — manual is the lowest non-unassigned tier |
 | A bare prefix (e.g. `CHAOS`) attributes as `linked_issue` | 5 vs 6 | did a full key resolve to a real `work_items` row, or did a prefix shortcut leak in? | no prefix→team in `linked_issue`; route to manual `issue_key_prefix` |
-| Team flips back and forth after a re-org | RMT dedup | duplicate ownership rows; read lacks `FINAL`/`argMax` | add `FINAL`/`argMax` to ownership + manual reads |
+| A PR inherits via `linked_issue` from a donor that only has a `manual_fallback` (e.g. `issue_key_prefix`) rule | 5 (donor) | is the donor's *primary* source in 0–4? a rank-6 fallback must never be relabeled rank-5 | donors gated to `_DONOR_SOURCES` (0–4) in `build_linked_issue_team_resolver`; a manual-only donor is never a linked_issue donor (done CS3) |
+| Same scope shows duplicate ownership candidates / bloats over time | RMT read | `valid_from` is in the ownership tables' `ORDER BY`, so `FINAL` cannot collapse re-imports (each daily run is a new sort key) | reads dedup per *logical* scope via `argMax((updated_at, valid_from))`, NOT `FINAL` (done CS3, `load_team_attribution_context`); manual-fallback read keeps `FINAL` (its sort key has no `valid_from`) |
+| Team flips / stale team lingers after a re-org | write side | ownership writers set `valid_from=now` but never `valid_to`, so a reassigned scope keeps the old-team row active; readers can't tell stale from co-ownership | needs writer-side `valid_to` expiry on re-derivation — tracked **CHAOS-2610** (read-side `argMax` already makes the newest the primary by recency tiebreak) |
+| `manual_fallback` resolves the wrong team | scope match | which `manual_attribution_fallbacks` row matched (repo/project/member/issue_key_prefix)? | check `_manual_fallback_candidates` scope match + rule `priority`; manual is rank 6 (done CS3) |
 | Provenance absent in the API | GraphQL | resolver SELECTs the provenance columns? SDL has the fields? | expose `source/confidence/evidence` |
 | Web shows a different team than the backend | client recompute | any client-side mapping derived from `evidence`? | render-only; delete client derivation |
 

--- a/src/dev_health_ops/metrics/compute_work_items.py
+++ b/src/dev_health_ops/metrics/compute_work_items.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta, timezone
@@ -86,6 +87,23 @@ class TeamAttributionCandidate:
 
 
 @dataclass(frozen=True)
+class ManualFallbackRule:
+    """An explicit `manual_attribution_fallbacks` row (rank 6, never an override).
+
+    Used only when no native/imported/linked source resolved. `scope_type` is one
+    of repo | project | member | issue_key_prefix.
+    """
+
+    provider: str
+    scope_type: str
+    scope_id: str
+    team_id: str
+    team_name: str
+    reason: str = ""
+    priority: int = 100
+
+
+@dataclass(frozen=True)
 class TeamAttributionContext:
     project_by_id: dict[tuple[str, str], list[TeamAttributionCandidate]] = field(
         default_factory=dict
@@ -102,6 +120,7 @@ class TeamAttributionContext:
     member_by_identity: dict[tuple[str, str], list[TeamAttributionCandidate]] = field(
         default_factory=dict
     )
+    manual_fallbacks: list[ManualFallbackRule] = field(default_factory=list)
 
 
 # CHAOS-2600: deterministic staged precedence. linked_issue is a TRUE FALLBACK
@@ -118,6 +137,24 @@ _SOURCE_ORDER: dict[TeamAttributionSource, int] = {
     "manual_fallback": 6,
     "unassigned": 7,
 }
+
+# Sources a work item may pass on when it acts as a linked-issue *donor*. A donor
+# may only contribute a team it earned from a first-class attribution fact
+# (sources 0-4). manual_fallback (rank 6) and unassigned are excluded so a
+# fallback rule — especially the provider-neutral `issue_key_prefix` scope —
+# can never be laundered into rank-5 `linked_issue` provenance on a dependent
+# item. linked_issue itself is absent here because donor resolution runs with
+# `linked_issue_resolver=None` (no transitive inheritance). See
+# docs/architecture/team-attribution.md §0.
+_DONOR_SOURCES: frozenset[TeamAttributionSource] = frozenset(
+    {
+        "native_team",
+        "issue_project",
+        "project_ownership",
+        "repo_ownership",
+        "assignee_membership",
+    }
+)
 
 
 def _identity_key(value: str | None) -> str:
@@ -230,6 +267,75 @@ def _issue_project_candidate(
     return None
 
 
+_ISSUE_KEY_RE = re.compile(r"^([A-Za-z]{2,})-\d+$")
+
+
+def _issue_key_prefix(item: WorkItem) -> str | None:
+    """The item's own issue-key prefix, e.g. linear:CHAOS-5 -> CHAOS. None for PRs/MRs."""
+    wid = item.work_item_id or ""
+    if ":" not in wid:
+        return None
+    match = _ISSUE_KEY_RE.match(wid.split(":", 1)[1].strip())
+    return match.group(1).upper() if match else None
+
+
+def _manual_fallback_candidates(
+    item: WorkItem, fallbacks: Sequence[ManualFallbackRule]
+) -> list[TeamAttributionCandidate]:
+    """Build manual_fallback candidates (rank 6) matching the item's scope.
+
+    The precedence loop ensures these only become primary when no native/imported/
+    linked source matched — manual fallback is never an override. An ``issue_key_prefix``
+    rule matches the item's OWN key prefix; it is provider-neutral (a prefix spans
+    providers) and is NEVER linked_issue inheritance.
+    """
+    if not fallbacks:
+        return []
+    repo_ids = {str(v).strip() for v in (item.repo_id, item.project_id) if v}
+    project_ids = {
+        str(v).strip()
+        for v in (item.project_id, item.project_key, item.work_scope_id)
+        if v
+    }
+    member_ids = {_identity_key(a) for a in item.assignees if a}
+    prefix = _issue_key_prefix(item)
+    out: list[TeamAttributionCandidate] = []
+    for rule in fallbacks:
+        # A rule matches its own provider, or any provider when its provider is blank.
+        # issue_key_prefix is provider-neutral, so it is not provider-gated.
+        if (
+            rule.provider
+            and rule.provider != item.provider
+            and rule.scope_type != "issue_key_prefix"
+        ):
+            continue
+        scope_id = rule.scope_id.strip()
+        if rule.scope_type == "repo":
+            matched = scope_id in repo_ids
+        elif rule.scope_type == "project":
+            matched = scope_id in project_ids
+        elif rule.scope_type == "member":
+            matched = _identity_key(scope_id) in member_ids
+        elif rule.scope_type == "issue_key_prefix":
+            matched = prefix is not None and prefix == scope_id.upper()
+        else:
+            matched = False
+        if matched:
+            out.append(
+                TeamAttributionCandidate(
+                    source="manual_fallback",
+                    team_id=rule.team_id,
+                    team_name=rule.team_name or rule.team_id,
+                    confidence="manual",
+                    evidence=f"manual_fallback:{rule.scope_type}={rule.scope_id}"
+                    + (f" ({rule.reason})" if rule.reason else ""),
+                    is_primary=1,
+                    priority=rule.priority,
+                )
+            )
+    return out
+
+
 def resolve_team_attribution(
     item: WorkItem,
     team_resolver: TeamResolver | None,
@@ -328,6 +434,11 @@ def resolve_team_attribution(
                 is_primary=1,
                 specificity=50,
             )
+        )
+
+    if attribution_context is not None and attribution_context.manual_fallbacks:
+        candidates_by_source["manual_fallback"].extend(
+            _manual_fallback_candidates(item, attribution_context.manual_fallbacks)
         )
 
     primary: TeamAttributionCandidate | None = None
@@ -438,7 +549,7 @@ def build_linked_issue_team_resolver(
     for item in work_items:
         wid = item.work_item_id
         native = _native_team_candidate(item, project_key_resolver)
-        team_id, team_name, _ = resolve_team_attribution(
+        team_id, team_name, marked = resolve_team_attribution(
             item,
             team_resolver,
             project_key_resolver,
@@ -446,7 +557,11 @@ def build_linked_issue_team_resolver(
             attribution_context=attribution_context,
         )
         base_resolved[wid] = native.team_id if native is not None else None
-        if team_id:
+        primary_source = next((r.source for r in marked if r.is_primary), None)
+        # Only register a donor when its *primary* team came from a first-class
+        # fact (sources 0-4). A team earned via manual_fallback must never be
+        # relabeled as rank-5 linked_issue inheritance on a dependent item.
+        if team_id and primary_source in _DONOR_SOURCES:
             donor_team[wid] = (team_id, team_name or team_id)
         if item.provider in ("linear", "jira") and ":" in wid:
             k = wid.split(":", 1)[1].strip().upper()

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -8,6 +8,7 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Any, cast
 
 from dev_health_ops.metrics.compute_work_items import (
+    ManualFallbackRule,
     TeamAttributionCandidate,
     TeamAttributionContext,
     TeamAttributionSource,
@@ -381,20 +382,33 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
             self.client,
             f"""
             SELECT
-                o.provider,
-                o.team_id,
-                ifNull(nullIf(t.name, ''), o.team_id) AS team_name,
-                o.project_id,
-                o.project_key,
-                o.is_primary,
-                o.specificity,
-                o.priority,
-                o.updated_at
-            FROM team_project_ownership AS o
-            LEFT JOIN teams AS t ON t.org_id = o.org_id AND t.id = o.team_id
-            WHERE o.valid_from <= {{as_of:DateTime}}
-              AND (o.valid_to IS NULL OR o.valid_to > {{as_of:DateTime}})
-              {org_filter}
+                g.provider,
+                g.team_id,
+                ifNull(nullIf(t.name, ''), g.team_id) AS team_name,
+                g.project_id,
+                g.project_key,
+                g.is_primary,
+                g.specificity,
+                g.priority,
+                g.updated_at
+            FROM (
+                SELECT
+                    o.org_id AS org_id,
+                    o.provider AS provider,
+                    o.project_id AS project_id,
+                    o.team_id AS team_id,
+                    argMax(o.project_key, (o.updated_at, o.valid_from)) AS project_key,
+                    argMax(o.is_primary, (o.updated_at, o.valid_from)) AS is_primary,
+                    argMax(o.specificity, (o.updated_at, o.valid_from)) AS specificity,
+                    argMax(o.priority, (o.updated_at, o.valid_from)) AS priority,
+                    max(o.updated_at) AS updated_at
+                FROM team_project_ownership AS o
+                WHERE o.valid_from <= {{as_of:DateTime}}
+                  AND (o.valid_to IS NULL OR o.valid_to > {{as_of:DateTime}})
+                  {org_filter}
+                GROUP BY o.org_id, o.provider, o.project_id, o.team_id
+            ) AS g
+            LEFT JOIN teams AS t ON t.org_id = g.org_id AND t.id = g.team_id
             """,
             params,
         )
@@ -402,20 +416,33 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
             self.client,
             f"""
             SELECT
-                o.provider,
-                o.team_id,
-                ifNull(nullIf(t.name, ''), o.team_id) AS team_name,
-                o.repo_id,
-                o.repo_full_name,
-                o.is_primary,
-                o.specificity,
-                o.priority,
-                o.updated_at
-            FROM team_repo_ownership AS o
-            LEFT JOIN teams AS t ON t.org_id = o.org_id AND t.id = o.team_id
-            WHERE o.valid_from <= {{as_of:DateTime}}
-              AND (o.valid_to IS NULL OR o.valid_to > {{as_of:DateTime}})
-              {org_filter}
+                g.provider,
+                g.team_id,
+                ifNull(nullIf(t.name, ''), g.team_id) AS team_name,
+                g.repo_id,
+                g.repo_full_name,
+                g.is_primary,
+                g.specificity,
+                g.priority,
+                g.updated_at
+            FROM (
+                SELECT
+                    o.org_id AS org_id,
+                    o.provider AS provider,
+                    o.repo_full_name AS repo_full_name,
+                    o.team_id AS team_id,
+                    argMax(o.repo_id, (o.updated_at, o.valid_from)) AS repo_id,
+                    argMax(o.is_primary, (o.updated_at, o.valid_from)) AS is_primary,
+                    argMax(o.specificity, (o.updated_at, o.valid_from)) AS specificity,
+                    argMax(o.priority, (o.updated_at, o.valid_from)) AS priority,
+                    max(o.updated_at) AS updated_at
+                FROM team_repo_ownership AS o
+                WHERE o.valid_from <= {{as_of:DateTime}}
+                  AND (o.valid_to IS NULL OR o.valid_to > {{as_of:DateTime}})
+                  {org_filter}
+                GROUP BY o.org_id, o.provider, o.repo_full_name, o.team_id
+            ) AS g
+            LEFT JOIN teams AS t ON t.org_id = g.org_id AND t.id = g.team_id
             """,
             params,
         )
@@ -423,18 +450,52 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
             self.client,
             f"""
             SELECT
+                g.provider,
+                g.team_id,
+                ifNull(nullIf(t.name, ''), g.team_id) AS team_name,
+                g.member_id,
+                g.raw_provider_user_id,
+                g.raw_email,
+                g.is_primary,
+                g.specificity,
+                g.priority,
+                g.updated_at
+            FROM (
+                SELECT
+                    o.org_id AS org_id,
+                    o.provider AS provider,
+                    o.team_id AS team_id,
+                    o.member_id AS member_id,
+                    argMax(o.raw_provider_user_id, (o.updated_at, o.valid_from))
+                        AS raw_provider_user_id,
+                    argMax(o.raw_email, (o.updated_at, o.valid_from)) AS raw_email,
+                    argMax(o.is_primary, (o.updated_at, o.valid_from)) AS is_primary,
+                    argMax(o.specificity, (o.updated_at, o.valid_from)) AS specificity,
+                    argMax(o.priority, (o.updated_at, o.valid_from)) AS priority,
+                    max(o.updated_at) AS updated_at
+                FROM team_memberships AS o
+                WHERE o.valid_from <= {{as_of:DateTime}}
+                  AND (o.valid_to IS NULL OR o.valid_to > {{as_of:DateTime}})
+                  {org_filter}
+                GROUP BY o.org_id, o.provider, o.team_id, o.member_id
+            ) AS g
+            LEFT JOIN teams AS t ON t.org_id = g.org_id AND t.id = g.team_id
+            """,
+            params,
+        )
+
+        manual_rows = await _clickhouse_query_dicts(
+            self.client,
+            f"""
+            SELECT
                 o.provider,
+                o.scope_type,
+                o.scope_id,
                 o.team_id,
-                ifNull(nullIf(t.name, ''), o.team_id) AS team_name,
-                o.member_id,
-                o.raw_provider_user_id,
-                o.raw_email,
-                o.is_primary,
-                o.specificity,
-                o.priority,
-                o.updated_at
-            FROM team_memberships AS o
-            LEFT JOIN teams AS t ON t.org_id = o.org_id AND t.id = o.team_id
+                ifNull(nullIf(o.team_name, ''), o.team_id) AS team_name,
+                o.reason,
+                o.priority
+            FROM manual_attribution_fallbacks AS o FINAL
             WHERE o.valid_from <= {{as_of:DateTime}}
               AND (o.valid_to IS NULL OR o.valid_to > {{as_of:DateTime}})
               {org_filter}
@@ -489,6 +550,19 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
                     context.member_by_identity.setdefault(
                         (str(row.get("provider") or ""), key), []
                     ).append(candidate)
+
+        for row in manual_rows:
+            context.manual_fallbacks.append(
+                ManualFallbackRule(
+                    provider=str(row.get("provider") or ""),
+                    scope_type=str(row.get("scope_type") or ""),
+                    scope_id=str(row.get("scope_id") or ""),
+                    team_id=str(row.get("team_id") or ""),
+                    team_name=str(row.get("team_name") or row.get("team_id") or ""),
+                    reason=str(row.get("reason") or ""),
+                    priority=int(row.get("priority") or 100),
+                )
+            )
         return context
 
     async def load_cicd_data(

--- a/src/dev_health_ops/migrations/clickhouse/053_manual_attribution_fallbacks.sql
+++ b/src/dev_health_ops/migrations/clickhouse/053_manual_attribution_fallbacks.sql
@@ -4,24 +4,24 @@
 -- and manual / none confidence without an insert failure. See team-attribution.md s0 (Schema
 -- prerequisite) and CHAOS-2600 ordering rule s4.1 (migrate enums BEFORE emitting new values).
 
--- Widen work_item_team_attributions.source. New codes 7/8 are appended; ranks (precedence) live in
+-- Widen work_item_team_attributions.source. New codes 7/8 are appended — ranks (precedence) live in
 -- compute_work_items._SOURCE_ORDER, NOT in these integer codes.
 ALTER TABLE work_item_team_attributions
     MODIFY COLUMN source Enum8('native_team' = 1, 'linked_issue' = 2, 'project_ownership' = 3, 'repo_ownership' = 4, 'assignee_membership' = 5, 'unassigned' = 6, 'issue_project' = 7, 'manual_fallback' = 8);
 
--- Widen confidence (only this table has a confidence column; the edge tables do not).
+-- Widen confidence (only this table has a confidence column — the edge tables do not).
 ALTER TABLE work_item_team_attributions
     MODIFY COLUMN confidence Enum8('high' = 1, 'medium' = 2, 'low' = 3, 'manual' = 4, 'none' = 5);
 
 -- Explicit manual fallback attribution records. These are FALLBACK config, never overrides:
 -- the resolver only consults them after native/imported/linked attribution fails (CS3).
 -- scope_type allowed values: repo | project | member | issue_key_prefix.
--- ReplacingMergeTree(updated_at); ORDER BY is the LOGICAL REPLACEMENT IDENTITY: one active
+-- ReplacingMergeTree(updated_at) — ORDER BY is the LOGICAL REPLACEMENT IDENTITY: one active
 -- fallback per (org_id, provider, scope_type, scope_id). team_id is deliberately NOT in the sort
 -- key — if it were, reassigning a scope to a different team would leave the old team row alive as a
 -- second active fallback (RMT only replaces rows sharing the full ORDER BY tuple). Reassigning a
--- scope's team now REPLACES the row; readers take the latest by updated_at (FINAL/argMax, CS3).
--- org_id leads the key (matches the 051 tables); no per-org PARTITION BY (avoids partition explosion).
+-- scope's team now REPLACES the row — readers take the latest by updated_at (FINAL/argMax, CS3).
+-- org_id leads the key (matches the 051 tables) — no per-org PARTITION BY (avoids partition explosion).
 CREATE TABLE IF NOT EXISTS manual_attribution_fallbacks (
     org_id String,
     provider LowCardinality(String),

--- a/tests/test_linked_issue_team_inheritance.py
+++ b/tests/test_linked_issue_team_inheritance.py
@@ -17,6 +17,7 @@ from dev_health_ops.metrics.compute_work_item_state_durations import (
     compute_work_item_state_durations_daily,
 )
 from dev_health_ops.metrics.compute_work_items import (
+    ManualFallbackRule,
     TeamAttributionCandidate,
     TeamAttributionContext,
     build_linked_issue_team_resolver,
@@ -722,6 +723,167 @@ def test_gitlab_mr_resolver_precedence_with_gitlab_donor() -> None:
         by_source["linked_issue"].team_id == "svc"
     )  # inherited from the GitLab issue donor
     assert by_source["linked_issue"].is_primary == 0
+
+
+def test_manual_fallback_applies_only_when_nothing_stronger() -> None:
+    # CHAOS-2600 CS3: a repo-scoped manual fallback resolves a PR that has no
+    # native/imported/linked team. It is rank 6 (just above unassigned).
+    item = _wi(
+        "ghpr:full-chaos/ops#30", "github", type="pr", project_id="full-chaos/ops"
+    )
+    ctx = TeamAttributionContext(
+        manual_fallbacks=[
+            ManualFallbackRule(
+                provider="github",
+                scope_type="repo",
+                scope_id="full-chaos/ops",
+                team_id="ops",
+                team_name="Ops",
+                reason="explicit",
+            )
+        ]
+    )
+    team_id, _, candidates = resolve_team_attribution(
+        item, None, None, attribution_context=ctx
+    )
+    by_source = {c.source: c for c in candidates}
+    assert team_id == "ops"
+    assert by_source["manual_fallback"].is_primary == 1
+    assert by_source["manual_fallback"].confidence == "manual"
+
+
+def test_manual_fallback_never_overrides_native_team() -> None:
+    item = _wi("ghpr:x/y#1", "github", project_id="x/y", native_team_key="CHAOS")
+    pkr = ProjectKeyTeamResolver(project_key_to_team={"CHAOS": ("CHAOS", "Chaos")})
+    ctx = TeamAttributionContext(
+        manual_fallbacks=[
+            ManualFallbackRule(
+                provider="github",
+                scope_type="repo",
+                scope_id="x/y",
+                team_id="ops",
+                team_name="Ops",
+            )
+        ]
+    )
+    team_id, _, candidates = resolve_team_attribution(
+        item, None, pkr, attribution_context=ctx
+    )
+    by_source = {c.source: c for c in candidates}
+    assert team_id == "CHAOS"
+    assert by_source["native_team"].is_primary == 1
+    assert by_source["manual_fallback"].is_primary == 0
+
+
+def test_manual_fallback_never_overrides_linked_issue_donor() -> None:
+    # linked_issue (rank 5) beats manual_fallback (rank 6).
+    pr = _wi("ghpr:full-chaos/ops#31", "github", type="pr", project_id="full-chaos/ops")
+    donor = _wi("linear:OTHER-1", "linear", project_key="OTHER")
+    deps = [WorkItemDependency(pr.work_item_id, "extkey:OTHER-1", "relates_to", "k")]
+    pkr = ProjectKeyTeamResolver(project_key_to_team={"OTHER": ("other", "Other")})
+    resolver = build_linked_issue_team_resolver(
+        work_items=[pr, donor], dependencies=deps, project_key_resolver=pkr
+    )
+    ctx = TeamAttributionContext(
+        manual_fallbacks=[
+            ManualFallbackRule(
+                provider="github",
+                scope_type="repo",
+                scope_id="full-chaos/ops",
+                team_id="ops",
+                team_name="Ops",
+            )
+        ]
+    )
+    team_id, _, candidates = resolve_team_attribution(
+        pr, None, pkr, linked_issue_resolver=resolver, attribution_context=ctx
+    )
+    by_source = {c.source: c for c in candidates}
+    assert team_id == "other"
+    assert by_source["linked_issue"].is_primary == 1
+    assert by_source["manual_fallback"].is_primary == 0
+
+
+def test_issue_key_prefix_without_donor_matches_manual_not_linked_issue() -> None:
+    # A Linear issue with key prefix CHAOS, no native/ownership team, no linked donor:
+    # it must NOT become linked_issue; an issue_key_prefix manual fallback resolves it.
+    item = _wi("linear:CHAOS-77", "linear")
+    ctx = TeamAttributionContext(
+        manual_fallbacks=[
+            ManualFallbackRule(
+                provider="linear",
+                scope_type="issue_key_prefix",
+                scope_id="CHAOS",
+                team_id="chaos",
+                team_name="Chaos",
+            )
+        ]
+    )
+    team_id, _, candidates = resolve_team_attribution(
+        item, None, None, attribution_context=ctx
+    )
+    by_source = {c.source: c for c in candidates}
+    assert team_id == "chaos"
+    assert by_source["manual_fallback"].is_primary == 1
+    assert "linked_issue" not in by_source
+
+
+def test_issue_key_prefix_is_provider_neutral_and_only_manual() -> None:
+    # issue_key_prefix is provider-neutral and only ever emits manual_fallback.
+    item = _wi("jira:OPS-5", "jira")
+    ctx = TeamAttributionContext(
+        manual_fallbacks=[
+            ManualFallbackRule(
+                provider="linear",
+                scope_type="issue_key_prefix",
+                scope_id="OPS",
+                team_id="ops",
+                team_name="Ops",
+            )
+        ]
+    )
+    team_id, _, candidates = resolve_team_attribution(
+        item, None, None, attribution_context=ctx
+    )
+    by_source = {c.source: c for c in candidates}
+    assert team_id == "ops"
+    assert by_source["manual_fallback"].source == "manual_fallback"
+
+
+def test_manual_fallback_donor_is_not_laundered_into_linked_issue() -> None:
+    # A donor whose ONLY resolution is manual_fallback (here an issue_key_prefix
+    # rule) must never become a linked-issue donor: that would relabel a rank-6
+    # fallback as rank-5 `linked_issue` provenance on the dependent. The PR links
+    # to that donor but has no team of its own, so it must stay unassigned with
+    # NO linked_issue candidate emitted.
+    donor = _wi("linear:CHAOS-77", "linear")
+    pr = _wi("ghpr:full-chaos/web#9", "github", type="pr", project_id="full-chaos/web")
+    deps = [
+        WorkItemDependency(pr.work_item_id, "extkey:CHAOS-77", "relates_to", "fixes")
+    ]
+    ctx = TeamAttributionContext(
+        manual_fallbacks=[
+            ManualFallbackRule(
+                provider="linear",
+                scope_type="issue_key_prefix",
+                scope_id="CHAOS",
+                team_id="chaos",
+                team_name="Chaos",
+            )
+        ]
+    )
+    resolver = build_linked_issue_team_resolver(
+        work_items=[donor, pr],
+        dependencies=deps,
+        attribution_context=ctx,
+    )
+    team_id, _, candidates = resolve_team_attribution(
+        pr, None, None, linked_issue_resolver=resolver, attribution_context=ctx
+    )
+    by_source = {c.source: c for c in candidates}
+    assert "linked_issue" not in by_source
+    assert team_id != "chaos"
+    assert by_source["unassigned"].is_primary == 1
 
 
 def test_context_project_repo_membership_tiebreak_and_unassigned() -> None:

--- a/tests/test_team_autoimport_executor.py
+++ b/tests/test_team_autoimport_executor.py
@@ -44,18 +44,31 @@ async def test_loader_builds_team_attribution_context(
                     "updated_at": now,
                 }
             ]
+        if "team_memberships" in query:
+            return [
+                {
+                    "provider": "jira",
+                    "team_id": "team-member",
+                    "team_name": "Member Team",
+                    "member_id": "member-1",
+                    "raw_provider_user_id": "jira-user-1",
+                    "raw_email": "ADA@EXAMPLE.COM",
+                    "is_primary": 1,
+                    "specificity": 50,
+                    "priority": 20,
+                    "updated_at": now,
+                }
+            ]
+        # manual_attribution_fallbacks
         return [
             {
-                "provider": "jira",
-                "team_id": "team-member",
-                "team_name": "Member Team",
-                "member_id": "member-1",
-                "raw_provider_user_id": "jira-user-1",
-                "raw_email": "ADA@EXAMPLE.COM",
-                "is_primary": 1,
-                "specificity": 50,
-                "priority": 20,
-                "updated_at": now,
+                "provider": "github",
+                "scope_type": "repo",
+                "scope_id": "full-chaos/dev-health",
+                "team_id": "team-manual",
+                "team_name": "Manual Team",
+                "reason": "ops override",
+                "priority": 5,
             }
         ]
 
@@ -68,7 +81,16 @@ async def test_loader_builds_team_attribution_context(
         object(), org_id="org-1"
     ).load_team_attribution_context(as_of=now)
 
-    assert len(calls) == 3
+    # Four reads now: project / repo / membership ownership + manual fallbacks.
+    assert len(calls) == 4
+    project_query = next(q for q in calls if "team_project_ownership" in q)
+    # Ownership reads dedup per logical scope via argMax (NOT FINAL, which is
+    # ineffective while valid_from is in the table sort key), and stay org-scoped.
+    assert "argMax" in project_query
+    assert "GROUP BY" in project_query
+    assert "FINAL" not in project_query
+    assert "org_id = {org_id:String}" in project_query
+
     assert context.project_by_id[("linear", "project-1")][0].team_id == "team-project"
     assert context.project_by_key[("linear", "PROJ")][0].team_id == "team-project"
     assert (
@@ -79,3 +101,13 @@ async def test_loader_builds_team_attribution_context(
         context.member_by_identity[("jira", "ada@example.com")][0].team_id
         == "team-member"
     )
+
+    assert len(context.manual_fallbacks) == 1
+    manual = context.manual_fallbacks[0]
+    assert manual.provider == "github"
+    assert manual.scope_type == "repo"
+    assert manual.scope_id == "full-chaos/dev-health"
+    assert manual.team_id == "team-manual"
+    assert manual.priority == 5
+    manual_query = next(q for q in calls if "manual_attribution_fallbacks" in q)
+    assert "FINAL" in manual_query


### PR DESCRIPTION
## CS3 (CHAOS-2604) — manual_fallback resolver + per-scope ownership dedup

Part of the CHAOS-2600 ClickHouse-only team-attribution epic. Stacks on the integration branch `fix/clickhouse-only-team-attribution` (CS0–CS2 already merged there).

### What this adds
- **`manual_fallback` resolver (rank 6).** `resolve_team_attribution` emits `manual_fallback` candidates matching the item's repo / project / member scope and `issue_key_prefix` (the item's OWN key prefix — provider-neutral, NEVER `linked_issue`). Precedence keeps manual below every first-class fact and `linked_issue`, above only `unassigned`.
- **`ManualFallbackRule`** + `manual_fallbacks` channel on `TeamAttributionContext`; `load_team_attribution_context` reads `manual_attribution_fallbacks` (temporal + org-scoped, `FINAL`).
- **Per-logical-scope ownership dedup.** The three ownership reads now dedupe via `argMax((updated_at, valid_from))` per logical scope instead of `FINAL`.

### Adversarial-gate (codex) round 1 → 3 findings, all fixed (round 2: approve)
1. **Donor laundering (high).** `build_linked_issue_team_resolver` now gates donors to `_DONOR_SOURCES` (0–4), so a donor resolved only by `manual_fallback` can never be relabeled as rank-5 `linked_issue` inheritance on a dependent item. + regression test.
2. **`FINAL` ineffective (high).** The ownership tables carry `valid_from` in their `ORDER BY`, so `FINAL` can never collapse daily re-imports (each is a new sort key). Replaced with `argMax((updated_at, valid_from))` per-scope dedup. The residual **cross-team reassignment** expiry needs writer-side `valid_to` and is tracked as **CHAOS-2610** (the read-side recency tiebreak already makes the newest team the primary).
3. **Loader test (medium).** `test_team_autoimport_executor.py` now expects the 4th (manual) read and asserts `argMax`/`GROUP BY`/org-scope on ownership reads + `FINAL` on the manual read.

### Tests & gates
ruff ✓ · format ✓ · mypy (1184 files) ✓ · **36 tests pass** (`test_linked_issue_team_inheritance.py`, `test_team_autoimport_executor.py`).

Docs: `team-attribution.md` off-the-rails matrix + invariants corrected (no more "FINAL hardening" overclaim).
