### PR TITLE
CS4 (CHAOS-2605): expose team-attribution provenance in GraphQL

### DIFF
--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -518,6 +518,56 @@ class WorkGraphProvenance(Enum):
     HEURISTIC = "heuristic"
 
 
+@strawberry.enum
+class TeamAttributionSource(Enum):
+    """Which signal attributed a work item to a team (CHAOS-2600).
+
+    Listed strongest-first (native_team) to the floor (unassigned). Mirrors
+    ``work_item_team_attributions.source`` (ClickHouse Enum8) and
+    ``compute_work_items.TeamAttributionSource`` — keep all three in lockstep.
+    """
+
+    NATIVE_TEAM = "native_team"
+    ISSUE_PROJECT = "issue_project"
+    PROJECT_OWNERSHIP = "project_ownership"
+    REPO_OWNERSHIP = "repo_ownership"
+    ASSIGNEE_MEMBERSHIP = "assignee_membership"
+    LINKED_ISSUE = "linked_issue"
+    MANUAL_FALLBACK = "manual_fallback"
+    UNASSIGNED = "unassigned"
+
+
+@strawberry.enum
+class TeamAttributionConfidence(Enum):
+    """Confidence of a team attribution. Mirrors
+    ``work_item_team_attributions.confidence`` (ClickHouse Enum8)."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    MANUAL = "manual"
+    NONE = "none"
+
+
+@strawberry.type
+class WorkItemTeamAttribution:
+    """One team-attribution candidate for a work item, with provenance (CHAOS-2600).
+
+    Every applicable source is persisted as a candidate; ``is_primary`` marks the
+    winner the precedence resolver selected. The web renders this to explain *why*
+    a work item maps to a team (replacing its client-side attribution).
+    """
+
+    work_item_id: str
+    provider: str
+    team_id: str | None
+    team_name: str | None
+    source: TeamAttributionSource
+    confidence: TeamAttributionConfidence
+    is_primary: bool
+    evidence: str
+
+
 @strawberry.type
 class WorkGraphEdgeResult:
     """A single edge in the work graph.

--- a/src/dev_health_ops/api/graphql/resolvers/team_attribution.py
+++ b/src/dev_health_ops/api/graphql/resolvers/team_attribution.py
@@ -1,0 +1,124 @@
+"""GraphQL resolver for team-attribution provenance (CHAOS-2600 CS4).
+
+Surfaces the per-candidate provenance the precedence resolver persists to
+``work_item_team_attributions`` so the web can explain *why* a work item maps to a
+team (and stop deriving attribution client-side). Mirrors the work_graph edge
+resolver: org-scoped, FINAL-deduped (ReplacingMergeTree), enum-mapped with a safe
+fallback so a future enum value degrades instead of 500ing the query.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..authz import require_org_id
+from ..context import GraphQLContext
+from ..models.outputs import (
+    TeamAttributionConfidence,
+    TeamAttributionSource,
+    WorkItemTeamAttribution,
+)
+
+logger = logging.getLogger(__name__)
+
+# Cap a single provenance read so an unfiltered call can't top-sort a large
+# tenant's entire attribution set.
+_MAX_ROWS = 5000
+
+
+def _map_source(value: str) -> TeamAttributionSource:
+    try:
+        return TeamAttributionSource(str(value).lower())
+    except ValueError:
+        # A source the API predates degrades to the floor rather than 500ing.
+        return TeamAttributionSource.UNASSIGNED
+
+
+def _map_confidence(value: str) -> TeamAttributionConfidence:
+    try:
+        return TeamAttributionConfidence(str(value).lower())
+    except ValueError:
+        return TeamAttributionConfidence.NONE
+
+
+def _row_to_attribution(row: dict[str, Any]) -> WorkItemTeamAttribution:
+    return WorkItemTeamAttribution(
+        work_item_id=str(row.get("work_item_id", "")),
+        provider=str(row.get("provider", "")),
+        team_id=str(row["team_id"]) if row.get("team_id") else None,
+        team_name=str(row["team_name"]) if row.get("team_name") else None,
+        source=_map_source(str(row.get("source", "unassigned"))),
+        confidence=_map_confidence(str(row.get("confidence", "none"))),
+        is_primary=bool(int(row.get("is_primary", 0) or 0)),
+        evidence=str(row.get("evidence", "")),
+    )
+
+
+async def resolve_work_item_team_attributions(
+    context: GraphQLContext,
+    work_item_ids: list[str] | None = None,
+    team_id: str | None = None,
+) -> list[WorkItemTeamAttribution]:
+    """Return team-attribution candidates (with provenance) for work items.
+
+    Org-scoped and FINAL-deduped. ``work_item_ids`` bounds the read to the items a
+    view is rendering (the expected call shape); ``team_id`` optionally filters to
+    one team's attributions. Rows are ordered primary-first per work item.
+    """
+    from dev_health_ops.api.queries.client import query_dicts
+
+    org_id = require_org_id(context)
+    client = context.client
+    if client is None:
+        raise RuntimeError("Database client not available")
+
+    # The snapshot subquery scopes by org + work_item_ids only — NOT team_id: a
+    # work item's latest compute spans all candidate teams, and the team filter is
+    # applied afterward so a re-org that moved the item to another team can't be
+    # masked by an old same-team row.
+    base_where = ["org_id = %(org_id)s"]
+    params: dict[str, Any] = {"org_id": org_id, "limit": _MAX_ROWS}
+    if work_item_ids:
+        base_where.append("work_item_id IN %(work_item_ids)s")
+        params["work_item_ids"] = list(work_item_ids)
+    snapshot_where = " AND ".join(base_where)
+
+    outer_where = list(base_where)
+    if team_id:
+        outer_where.append("team_id = %(team_id)s")
+        params["team_id"] = team_id
+
+    # compute_work_item_team_attributions stamps EVERY candidate of one compute
+    # with a single computed_at and APPENDS them (never deletes prior ones). The
+    # RMT key is (org_id, repo_id, work_item_id, team_id, source), so a re-org that
+    # drops a candidate or moves a work item to another team leaves the old
+    # (team_id, source) rows alive — FINAL can't retire them (different key). Read
+    # back raw, they would surface as a second is_primary=true row / a stale
+    # higher-precedence source. Constrain the read to each work item's LATEST
+    # compute snapshot (max computed_at) so retired candidates drop out. (FINAL
+    # still collapses exact-key duplicates within that snapshot.)
+    query = f"""
+        SELECT
+            work_item_id,
+            provider,
+            team_id,
+            team_name,
+            source,
+            confidence,
+            is_primary,
+            evidence
+        FROM work_item_team_attributions FINAL
+        WHERE {" AND ".join(outer_where)}
+          AND (work_item_id, computed_at) IN (
+              SELECT work_item_id, max(computed_at)
+              FROM work_item_team_attributions
+              WHERE {snapshot_where}
+              GROUP BY work_item_id
+          )
+        ORDER BY work_item_id, is_primary DESC, source
+        LIMIT %(limit)s
+    """
+
+    rows = await query_dicts(client, query, params)
+    return [_row_to_attribution(row) for row in rows]

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -52,6 +52,7 @@ from .models.outputs import (
     WorkGraphArtifactsResult,
     WorkGraphEdgesResult,
     WorkGraphFlowResult,
+    WorkItemTeamAttribution,
 )
 from .models.recommendations import (
     Recommendation,
@@ -293,6 +294,28 @@ class Query:
 
         context = get_context(info)
         return await resolve_work_graph_artifacts(context, filters)
+
+    @strawberry.field(
+        description=(
+            "Team-attribution provenance per work item (source/confidence/"
+            "evidence/is_primary) — CHAOS-2600"
+        )
+    )
+    async def work_item_team_attributions(
+        self,
+        info: Info,
+        org_id: str,
+        work_item_ids: list[str] | None = None,
+        team_id: str | None = None,
+    ) -> list[WorkItemTeamAttribution]:
+        from .resolvers.team_attribution import (
+            resolve_work_item_team_attributions,
+        )
+
+        context = get_context(info)
+        return await resolve_work_item_team_attributions(
+            context, work_item_ids=work_item_ids, team_id=team_id
+        )
 
     @strawberry.field(description="Paginated list of security alerts")
     async def security_alerts(

--- a/tests/graphql/test_team_attribution_graphql.py
+++ b/tests/graphql/test_team_attribution_graphql.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.models.outputs import (
+    TeamAttributionConfidence,
+    TeamAttributionSource,
+)
+from dev_health_ops.api.graphql.resolvers.team_attribution import (
+    resolve_work_item_team_attributions,
+)
+
+_QUERY_DICTS = "dev_health_ops.api.queries.client.query_dicts"
+
+
+class MockClient:
+    pass
+
+
+@pytest.fixture
+def mock_context():
+    return GraphQLContext(
+        org_id="test-org",
+        db_url="clickhouse://localhost:8123/default",
+        client=MockClient(),
+    )
+
+
+def _row(
+    work_item_id: str = "linear:CHAOS-1",
+    provider: str = "linear",
+    team_id: str | None = "team-a",
+    team_name: str | None = "Team A",
+    source: str = "native_team",
+    confidence: str = "high",
+    is_primary: int = 1,
+    evidence: str = "native_team_key=CHAOS",
+) -> dict[str, Any]:
+    return {
+        "work_item_id": work_item_id,
+        "provider": provider,
+        "team_id": team_id,
+        "team_name": team_name,
+        "source": source,
+        "confidence": confidence,
+        "is_primary": is_primary,
+        "evidence": evidence,
+    }
+
+
+@pytest.mark.asyncio
+async def test_maps_rows_to_provenance(mock_context):
+    rows = [
+        _row(source="native_team", confidence="high", is_primary=1),
+        _row(
+            source="manual_fallback",
+            confidence="manual",
+            is_primary=0,
+            evidence="scope_type=repo",
+        ),
+    ]
+    with patch(_QUERY_DICTS, new_callable=AsyncMock) as mock_query:
+        mock_query.return_value = rows
+        result = await resolve_work_item_team_attributions(
+            mock_context, work_item_ids=["linear:CHAOS-1"]
+        )
+    assert len(result) == 2
+    assert result[0].source == TeamAttributionSource.NATIVE_TEAM
+    assert result[0].confidence == TeamAttributionConfidence.HIGH
+    assert result[0].is_primary is True
+    assert result[0].team_id == "team-a"
+    assert result[1].source == TeamAttributionSource.MANUAL_FALLBACK
+    assert result[1].confidence == TeamAttributionConfidence.MANUAL
+    assert result[1].is_primary is False
+    assert result[1].evidence == "scope_type=repo"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "ch_value,expected",
+    [
+        ("native_team", TeamAttributionSource.NATIVE_TEAM),
+        ("issue_project", TeamAttributionSource.ISSUE_PROJECT),
+        ("project_ownership", TeamAttributionSource.PROJECT_OWNERSHIP),
+        ("repo_ownership", TeamAttributionSource.REPO_OWNERSHIP),
+        ("assignee_membership", TeamAttributionSource.ASSIGNEE_MEMBERSHIP),
+        ("linked_issue", TeamAttributionSource.LINKED_ISSUE),
+        ("manual_fallback", TeamAttributionSource.MANUAL_FALLBACK),
+        ("unassigned", TeamAttributionSource.UNASSIGNED),
+    ],
+)
+async def test_every_source_enum_maps(mock_context, ch_value, expected):
+    with patch(_QUERY_DICTS, new_callable=AsyncMock) as mock_query:
+        mock_query.return_value = [_row(source=ch_value)]
+        result = await resolve_work_item_team_attributions(mock_context)
+    assert result[0].source == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "ch_value,expected",
+    [
+        ("high", TeamAttributionConfidence.HIGH),
+        ("medium", TeamAttributionConfidence.MEDIUM),
+        ("low", TeamAttributionConfidence.LOW),
+        ("manual", TeamAttributionConfidence.MANUAL),
+        ("none", TeamAttributionConfidence.NONE),
+    ],
+)
+async def test_every_confidence_enum_maps(mock_context, ch_value, expected):
+    with patch(_QUERY_DICTS, new_callable=AsyncMock) as mock_query:
+        mock_query.return_value = [_row(confidence=ch_value)]
+        result = await resolve_work_item_team_attributions(mock_context)
+    assert result[0].confidence == expected
+
+
+@pytest.mark.asyncio
+async def test_unknown_enum_values_degrade_safely(mock_context):
+    # A future ClickHouse enum value the API predates must not 500 the query.
+    with patch(_QUERY_DICTS, new_callable=AsyncMock) as mock_query:
+        mock_query.return_value = [
+            _row(source="some_future_source", confidence="ultra")
+        ]
+        result = await resolve_work_item_team_attributions(mock_context)
+    assert result[0].source == TeamAttributionSource.UNASSIGNED
+    assert result[0].confidence == TeamAttributionConfidence.NONE
+
+
+@pytest.mark.asyncio
+async def test_null_team_id_becomes_none(mock_context):
+    with patch(_QUERY_DICTS, new_callable=AsyncMock) as mock_query:
+        mock_query.return_value = [
+            _row(team_id=None, team_name=None, source="unassigned", confidence="none")
+        ]
+        result = await resolve_work_item_team_attributions(mock_context)
+    assert result[0].team_id is None
+    assert result[0].team_name is None
+
+
+@pytest.mark.asyncio
+async def test_query_is_org_scoped_final_and_bounded(mock_context):
+    with patch(_QUERY_DICTS, new_callable=AsyncMock) as mock_query:
+        mock_query.return_value = []
+        await resolve_work_item_team_attributions(
+            mock_context, work_item_ids=["a", "b"], team_id="team-x"
+        )
+    _client, sql, params = mock_query.call_args.args
+    assert "work_item_team_attributions FINAL" in sql
+    assert "org_id = %(org_id)s" in sql
+    assert "work_item_id IN %(work_item_ids)s" in sql
+    assert "team_id = %(team_id)s" in sql
+    assert "LIMIT %(limit)s" in sql
+    # Latest-compute snapshot guard: stale (team_id, source) candidate rows from an
+    # older compute must not surface as a second is_primary / stale source
+    # (CHAOS-2605 codex finding). The team filter must NOT scope the snapshot.
+    assert "max(computed_at)" in sql
+    assert "GROUP BY work_item_id" in sql
+    snapshot = sql.split("max(computed_at)", 1)[1]
+    assert "team_id = %(team_id)s" not in snapshot
+    assert params["org_id"] == "test-org"
+    assert params["work_item_ids"] == ["a", "b"]
+    assert params["team_id"] == "team-x"

--- a/tests/test_team_attribution_provenance_live.py
+++ b/tests/test_team_attribution_provenance_live.py
@@ -1,0 +1,114 @@
+"""Live-ClickHouse regression for team-attribution provenance staleness (CHAOS-2605).
+
+A re-org appends a NEW candidate set (new ``computed_at``) without deleting prior
+candidates, and the RMT key includes ``team_id``/``source`` so FINAL cannot retire
+the old ``(team_id, source)`` rows. The provenance resolver must therefore return
+only each work item's LATEST compute snapshot — never a stale second
+``is_primary`` row or a higher-precedence source that no longer applies.
+
+Opt-in (filtered from unit/CI): ``pytest -m clickhouse`` with ``CLICKHOUSE_URI``
+pointing at a SCRATCH db (never the dev ``default``).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/ci_local_validate)",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def sink():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
+    s = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    s.ensure_schema(force=True)
+    yield s
+    s.close()
+
+
+@pytest.mark.asyncio
+async def test_latest_compute_snapshot_drops_stale_candidates(sink):
+    from dev_health_ops.api.graphql.context import GraphQLContext
+    from dev_health_ops.api.graphql.models.outputs import TeamAttributionSource
+    from dev_health_ops.api.graphql.resolvers.team_attribution import (
+        resolve_work_item_team_attributions,
+    )
+    from dev_health_ops.metrics.schemas import WorkItemTeamAttributionRecord
+
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
+    org_id = f"test-2605-{uuid.uuid4()}"
+    repo_id = uuid.uuid4()
+    wid = "linear:CHAOS-REORG-1"
+    day1 = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    day2 = day1 + timedelta(days=1)
+
+    # Day 1: native_team -> team-old (primary) + an assignee side candidate.
+    # Day 2 (re-org): native_team -> team-new (primary). The day-1 rows linger in
+    # the RMT because their (team_id, source) key differs from the day-2 row.
+    sink.write_work_item_team_attributions(
+        [
+            WorkItemTeamAttributionRecord(
+                work_item_id=wid,
+                provider="linear",
+                source="native_team",
+                is_primary=1,
+                confidence="high",
+                evidence="native_team_key=OLD",
+                computed_at=day1,
+                repo_id=repo_id,
+                team_id="team-old",
+                team_name="Old",
+                org_id=org_id,
+            ),
+            WorkItemTeamAttributionRecord(
+                work_item_id=wid,
+                provider="linear",
+                source="assignee_membership",
+                is_primary=0,
+                confidence="medium",
+                evidence="assignee=x",
+                computed_at=day1,
+                repo_id=repo_id,
+                team_id="team-side",
+                team_name="Side",
+                org_id=org_id,
+            ),
+            WorkItemTeamAttributionRecord(
+                work_item_id=wid,
+                provider="linear",
+                source="native_team",
+                is_primary=1,
+                confidence="high",
+                evidence="native_team_key=NEW",
+                computed_at=day2,
+                repo_id=repo_id,
+                team_id="team-new",
+                team_name="New",
+                org_id=org_id,
+            ),
+        ]
+    )
+
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink.client)
+    result = await resolve_work_item_team_attributions(context, work_item_ids=[wid])
+
+    # Only the day-2 snapshot survives: exactly one candidate, the new team, one
+    # primary — the stale day-1 team-old / team-side rows are gone.
+    assert [r.team_id for r in result] == ["team-new"]
+    assert [r.is_primary for r in result].count(True) == 1
+    assert result[0].source == TeamAttributionSource.NATIVE_TEAM
+    assert all(r.team_id != "team-old" for r in result)


### PR DESCRIPTION
## CS4 (CHAOS-2605) — expose team-attribution provenance in GraphQL

Part of the CHAOS-2600 ClickHouse-only team-attribution epic. Targets the integration branch `fix/clickhouse-only-team-attribution`. **Must reach ops `main` before CS7** (web does an exact-diff of `schema.graphql` against ops `export_schema`).

### What this adds
A standalone query surfacing the per-candidate provenance the precedence resolver persists, so the web (CS7) can explain *why* a work item maps to a team and stop deriving attribution client-side.
- **`outputs.py`**: `WorkItemTeamAttribution` type + `TeamAttributionSource` (8 widened values) / `TeamAttributionConfidence` (5 values) Strawberry enums — kept in lockstep with the ClickHouse Enum8 (migrations 051+053) and `compute_work_items.TeamAttributionSource`.
- **`resolvers/team_attribution.py`**: `resolve_work_item_team_attributions` — org-scoped, latest-compute-snapshot read, optional `workItemIds`/`teamId` filters, `_MAX_ROWS` cap; enum mapping degrades a future value to `unassigned`/`none` instead of 500ing.
- **`schema.py`**: `workItemTeamAttributions(orgId, workItemIds, teamId)` Query field.

### Adversarial-gate (codex) round 1 → fixed → round 2: approve
**[high] stale-row read.** The writer appends each compute's candidate set (one `computed_at`) and never deletes prior rows; the RMT key includes `team_id`+`source`, so a re-org leaves stale `(team_id, source)` rows that `FINAL` can't retire — a raw read could surface a **second `is_primary=true`** / a stale higher-precedence source. **Fix:** the resolver constrains the read to each work item's **latest compute snapshot** (`computed_at = max per work item`, team-filter applied *after* the snapshot). Proven on a real ClickHouse — `tests/test_team_attribution_provenance_live.py` (clickhouse-marked) seeds stale + fresh candidate sets and asserts only the latest snapshot returns.

### Tests & gates
ruff ✓ · mypy ✓ · **full unit suite ✓** (5636) · `export_schema` clean · `argMax` live proof ✓ (`ci/local_validate.sh`) · live stale-row regression ✓ on real CH. 18 attribution-GraphQL tests (every source + confidence enum, fallback, null team_id, org-scoped/FINAL/latest-snapshot/bounded SQL contract).

Web `schema.graphql` regen + exact-diff is CS7.
