### PR TITLE
fix(sync): stabilize planner-managed terminal state

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -114,6 +114,29 @@ def _mark_backfill_job_failed(
     sync_session.flush()
 
 
+def _preflight_planner_credential(sync_session, config) -> None:
+    credential_id = getattr(config, "credential_id", None)
+    if credential_id is None:
+        return
+    from dev_health_ops.models.settings import IntegrationCredential
+
+    credential = (
+        sync_session.query(IntegrationCredential)
+        .filter(
+            IntegrationCredential.id == credential_id,
+            IntegrationCredential.org_id == getattr(config, "org_id"),
+        )
+        .one_or_none()
+    )
+    if credential is None:
+        raise HTTPException(status_code=400, detail="Credential not found")
+    if not bool(credential.is_active):
+        raise HTTPException(status_code=409, detail="Credential is inactive")
+    if credential.last_test_success is False:
+        detail = credential.last_test_error or "Credential preflight failed"
+        raise HTTPException(status_code=409, detail=detail)
+
+
 def _ensure_pending_sync_job_run(
     sync_session,
     config,
@@ -1367,6 +1390,9 @@ async def trigger_sync_config(
         )
     )
     if plan_request is not None:
+        await session.run_sync(
+            lambda sync_session: _preflight_planner_credential(sync_session, config)
+        )
         try:
             plan = await session.run_sync(
                 lambda sync_session: plan_sync_run(sync_session, plan_request)
@@ -1506,6 +1532,10 @@ async def trigger_sync_config_backfill(
         )
     )
     fanout_backfill = planner_backfill_request is not None
+    if fanout_backfill:
+        await session.run_sync(
+            lambda sync_session: _preflight_planner_credential(sync_session, config)
+        )
     backfill_job = BackfillJobModel(
         org_id=org_id,
         sync_config_id=uuid.UUID(config_id),

--- a/src/dev_health_ops/workers/sync_backfill.py
+++ b/src/dev_health_ops/workers/sync_backfill.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 
+from dev_health_ops.exceptions import AuthenticationException
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.task_utils import (
     _as_str_list,
@@ -14,6 +15,10 @@ from dev_health_ops.workers.task_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _is_terminal_backfill_error(exc: Exception) -> bool:
+    return isinstance(exc, (ValueError, AuthenticationException))
 
 
 def _mark_backfill_job_running(backfill_job_id: str, started_at: datetime) -> None:
@@ -126,6 +131,30 @@ def _mark_sync_job_run_success(
                 session.flush()
     except Exception:
         logger.debug("Failed to mark sync job run success: %s", pending_run_id)
+
+
+def _merge_sync_job_run_result(
+    pending_run_id: str | None,
+    result: dict[str, Any],
+) -> None:
+    if pending_run_id is None:
+        return
+    try:
+        from dev_health_ops.db import get_postgres_session_sync
+        from dev_health_ops.models.settings import JobRun
+
+        with get_postgres_session_sync() as session:
+            run = (
+                session.query(JobRun)
+                .filter(JobRun.id == uuid.UUID(pending_run_id))
+                .one_or_none()
+            )
+            if run:
+                current = run.result if isinstance(run.result, dict) else {}
+                setattr(run, "result", {**current, **result})
+                session.flush()
+    except Exception:
+        logger.debug("Failed to merge sync job run result: %s", pending_run_id)
 
 
 def _mark_sync_job_run_failed(
@@ -282,8 +311,8 @@ def run_backfill(
                 dataset_keys=planner_dataset_keys,
                 triggered_by="backfill",
             )
+            unit_count = int(result_payload.get("unit_count") or 0)
             if backfill_job_id:
-                unit_count = int(result_payload.get("unit_count") or 0)
                 status = "completed" if unit_count == 0 else "running"
                 _update_backfill_job_counts(
                     backfill_job_id,
@@ -299,11 +328,17 @@ def run_backfill(
                         datetime.now(timezone.utc) if status == "completed" else None
                     ),
                 )
-            _mark_sync_job_run_success(
-                pending_run_id,
-                datetime.now(timezone.utc),
-                {"sync_run_id": str(result_payload["sync_run_id"])},
-            )
+            if unit_count == 0:
+                _mark_sync_job_run_success(
+                    pending_run_id,
+                    datetime.now(timezone.utc),
+                    {"sync_run_id": str(result_payload["sync_run_id"])},
+                )
+            else:
+                _merge_sync_job_run_result(
+                    pending_run_id,
+                    {"sync_run_id": str(result_payload["sync_run_id"])},
+                )
             return {
                 "status": "success",
                 "result": result_payload,
@@ -433,4 +468,6 @@ def run_backfill(
                 logger.debug("Failed to mark backfill job failed: %s", backfill_job_id)
         _mark_sync_job_run_failed(pending_run_id, str(exc), completed_at)
 
+        if _is_terminal_backfill_error(exc):
+            raise
         raise self.retry(exc=exc, countdown=60 * (2**self.request.retries))

--- a/src/dev_health_ops/workers/sync_reconciler.py
+++ b/src/dev_health_ops/workers/sync_reconciler.py
@@ -7,7 +7,15 @@ from typing import Any
 
 from sqlalchemy import select, update
 
-from dev_health_ops.models import SyncRun, SyncRunStatus, SyncRunUnit, SyncRunUnitStatus
+from dev_health_ops.models import (
+    BackfillJob,
+    JobRun,
+    JobRunStatus,
+    SyncRun,
+    SyncRunStatus,
+    SyncRunUnit,
+    SyncRunUnitStatus,
+)
 from dev_health_ops.sync.guard import _acquire_bucket_advisory_locks
 from dev_health_ops.workers.celery_app import celery_app
 
@@ -23,6 +31,7 @@ def reconcile_sync_dispatch(limit: int = 100) -> dict[str, Any]:
         _stale_dispatch_seconds,
         dispatch_sync_run,
         finalize_sync_run,
+        sync_observers_for_terminal_sync_run,
     )
 
     now = datetime.now(timezone.utc)
@@ -80,6 +89,11 @@ def reconcile_sync_dispatch(limit: int = 100) -> dict[str, Any]:
                 expired_run_ids.add(unit.sync_run_id)
         session.flush()
         session.expire_all()
+        repaired_observers = 0
+        for run in _terminal_runs_with_stale_observers(session, limit):
+            sync_observers_for_terminal_sync_run(session, run)
+            repaired_observers += 1
+        session.flush()
         dispatch_run_ids = _dispatchable_run_ids(session, stale_dispatch_cutoff, limit)
         finalize_run_ids = _finalizable_run_ids(session, limit)
         for run_id in expired_run_ids:
@@ -112,6 +126,7 @@ def reconcile_sync_dispatch(limit: int = 100) -> dict[str, Any]:
         "expired_units": expired_count,
         "dispatches_enqueued": dispatched,
         "finalizers_enqueued": finalized,
+        "observer_repairs": repaired_observers,
     }
 
 
@@ -167,6 +182,73 @@ def _finalizable_run_ids(session, limit: int) -> set[str]:
         .all()
     )
     return {str(run_id) for (run_id,) in rows}
+
+
+def _terminal_runs_with_stale_observers(session, limit: int) -> list[SyncRun]:
+    max_repairs = max(1, int(limit))
+    runs: list[SyncRun] = []
+    seen_run_ids: set[uuid.UUID] = set()
+
+    job_runs = (
+        session.query(JobRun)
+        .filter(
+            JobRun.status.in_({JobRunStatus.PENDING.value, JobRunStatus.RUNNING.value})
+        )
+        .order_by(JobRun.created_at.asc(), JobRun.id.asc())
+        .all()
+    )
+    for job_run in job_runs:
+        result = job_run.result if isinstance(job_run.result, dict) else {}
+        sync_run_id = result.get("sync_run_id")
+        if sync_run_id is None:
+            continue
+        _append_terminal_observer_run(session, runs, seen_run_ids, sync_run_id)
+        if len(runs) >= max_repairs:
+            break
+
+    if len(runs) < max_repairs:
+        backfill_jobs = (
+            session.query(BackfillJob)
+            .filter(BackfillJob.status.in_({"pending", "running"}))
+            .order_by(BackfillJob.created_at.asc(), BackfillJob.id.asc())
+            .all()
+        )
+        for job in backfill_jobs:
+            sync_run_id = _backfill_job_sync_run_id(job)
+            if sync_run_id is None:
+                continue
+            _append_terminal_observer_run(session, runs, seen_run_ids, sync_run_id)
+            if len(runs) >= max_repairs:
+                break
+
+    return runs
+
+
+def _append_terminal_observer_run(
+    session,
+    runs: list[SyncRun],
+    seen_run_ids: set[uuid.UUID],
+    sync_run_id: object,
+) -> None:
+    try:
+        run_id = uuid.UUID(str(sync_run_id))
+    except ValueError:
+        return
+    if run_id in seen_run_ids:
+        return
+    run = session.get(SyncRun, run_id)
+    if run is None or run.status not in _TERMINAL_RUN_STATUSES:
+        return
+    seen_run_ids.add(run_id)
+    runs.append(run)
+
+
+def _backfill_job_sync_run_id(job: BackfillJob) -> str | None:
+    task_id = str(job.celery_task_id or "")
+    marker = "sync_run:"
+    if marker not in task_id:
+        return None
+    return task_id.rsplit(marker, 1)[-1] or None
 
 
 def _enqueue_dispatches(task, run_ids: set[str]) -> int:

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -437,7 +437,7 @@ def _dispatch_post_sync_tasks(
 
 
 def _is_terminal_sync_error(exc: Exception) -> bool:
-    return isinstance(exc, (_TerminalSyncError, ValueError))
+    return isinstance(exc, (_TerminalSyncError, ValueError, AuthenticationException))
 
 
 def _run_team_autoimport_for_sync_config(

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -48,6 +48,9 @@ from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 
 from dev_health_ops.models import (
+    BackfillJob,
+    JobRun,
+    JobRunStatus,
     SyncRun,
     SyncRunMode,
     SyncRunPostDispatch,
@@ -59,8 +62,6 @@ from dev_health_ops.sync.dispatch_policy import route
 from dev_health_ops.sync.guard import DispatchGuard
 from dev_health_ops.sync.planner import map_datasets_to_legacy_targets
 from dev_health_ops.sync.trigger_routing import (
-    canonical_sync_config_for_sync_run,
-    inactive_child_configs_for_sync_run,
     stamp_sync_run_canonical_config,
 )
 from dev_health_ops.sync.watermarks import set_watermark
@@ -173,6 +174,7 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
                 run.completed_at = completed_at
                 run.error = error
                 run.result = {"capped_unit_ids": list(decision.capped_unit_ids)}
+                sync_observers_for_terminal_sync_run(session, run)
                 session.flush()
                 logger.warning(
                     "dispatch_sync_run.denied",
@@ -204,76 +206,6 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
                     "reason": decision.reason,
                 },
             )
-
-        canonical_config = canonical_sync_config_for_sync_run(session, run)
-        inactive_config = (
-            canonical_config
-            if canonical_config is not None and not bool(canonical_config.is_active)
-            else None
-        )
-        if inactive_config is None:
-            inactive_child_configs = inactive_child_configs_for_sync_run(session, run)
-            inactive_config = (
-                inactive_child_configs[0] if inactive_child_configs else None
-            )
-        if inactive_config is not None:
-            error = "sync configuration is paused"
-            if _run_has_dispatching_or_running_units(session, run_uuid):
-                failed_planned = _fail_planned_units(session, run_uuid, error)
-                failed_stale_dispatching = _fail_stale_dispatching_units(
-                    session, run_uuid, error
-                )
-                session.flush()
-                logger.warning(
-                    "dispatch_sync_run.inactive_config_with_active_units",
-                    extra={
-                        "sync_run_id": sync_run_id,
-                        "config_id": str(inactive_config.id),
-                        "failed_planned_units": failed_planned,
-                        "failed_stale_dispatching_units": failed_stale_dispatching,
-                    },
-                )
-                _enqueue_denied_active_finalize(sync_run_id)
-                return {
-                    "status": "denied_active",
-                    "reason": error,
-                    "failed_planned_units": failed_planned,
-                    "failed_stale_dispatching_units": failed_stale_dispatching,
-                }
-            else:
-                completed_at = datetime.now(timezone.utc)
-                run.status = SyncRunStatus.FAILED.value
-                run.completed_at = completed_at
-                run.error = error
-                run.result = {"reason": "inactive_sync_configuration"}
-                session.query(SyncRunUnit).filter(
-                    SyncRunUnit.sync_run_id == run_uuid,
-                    SyncRunUnit.status == SyncRunUnitStatus.PLANNED.value,
-                ).update(
-                    {
-                        SyncRunUnit.status: SyncRunUnitStatus.FAILED.value,
-                        SyncRunUnit.error: error,
-                        SyncRunUnit.updated_at: completed_at,
-                    },
-                    synchronize_session=False,
-                )
-                stamp_sync_run_canonical_config(
-                    session,
-                    run,
-                    completed_at=completed_at,
-                    success=False,
-                    error=error,
-                    stats={"reason": "inactive_sync_configuration"},
-                )
-                session.flush()
-                logger.warning(
-                    "dispatch_sync_run.inactive_config",
-                    extra={
-                        "sync_run_id": sync_run_id,
-                        "config_id": str(inactive_config.id),
-                    },
-                )
-                return {"status": "denied", "reason": error}
 
         units = _claim_units(session, run_uuid, capped_ids=capped_ids)
         signatures = []
@@ -327,22 +259,8 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
     #      call finalize directly; redispatching would loop forever.
     with get_postgres_session_sync() as session:
         run_uuid_check = uuid.UUID(str(sync_run_id))
-        pending_count = (
-            session.query(SyncRunUnit)
-            .filter(
-                SyncRunUnit.sync_run_id == run_uuid_check,
-                SyncRunUnit.status.in_(
-                    {
-                        SyncRunUnitStatus.PLANNED.value,
-                        SyncRunUnitStatus.DISPATCHING.value,
-                        SyncRunUnitStatus.RUNNING.value,
-                        SyncRunUnitStatus.RETRYING.value,
-                    }
-                ),
-            )
-            .count()
-        )
-    if pending_count > 0:
+        pending_counts = _pending_unit_counts(session, run_uuid_check)
+    if pending_counts["dispatchable"] > 0:
         try:
             _schedule_redispatch(sync_run_id)
         except Exception as exc:
@@ -356,10 +274,24 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
             extra={
                 "sync_run_id": sync_run_id,
                 "queued_units": 0,
-                "pending_units": pending_count,
+                "pending_units": pending_counts["dispatchable"],
             },
         )
         return {"status": "noop", "queued_units": 0}
+    if pending_counts["in_flight"] > 0:
+        logger.info(
+            "dispatch_sync_run.waiting_inflight",
+            extra={
+                "sync_run_id": sync_run_id,
+                "queued_units": 0,
+                "in_flight_units": pending_counts["in_flight"],
+            },
+        )
+        return {
+            "status": "waiting_inflight",
+            "queued_units": 0,
+            "in_flight_units": pending_counts["in_flight"],
+        }
     # No pending work — finalize (idempotent; handles zero-unit and already-finalized).
     logger.info(
         "dispatch_sync_run.noop_finalize",
@@ -683,6 +615,7 @@ def finalize_sync_run(sync_run_id: str) -> dict[str, Any]:
             error=run_error,
             stats=result_payload,
         )
+        sync_observers_for_terminal_sync_run(session, run)
         session.flush()
 
         nested = session.begin_nested()
@@ -831,6 +764,92 @@ def _run_has_dispatching_or_running_units(session, run_uuid: uuid.UUID) -> bool:
         .first()
         is not None
     )
+
+
+def _pending_unit_counts(session, run_uuid: uuid.UUID) -> dict[str, int]:
+    now = datetime.now(timezone.utc)
+    stale_dispatch_cutoff = now - timedelta(seconds=_stale_dispatch_seconds())
+    units = (
+        session.query(SyncRunUnit.status, SyncRunUnit.updated_at)
+        .filter(
+            SyncRunUnit.sync_run_id == run_uuid,
+            SyncRunUnit.status.in_(
+                {
+                    SyncRunUnitStatus.PLANNED.value,
+                    SyncRunUnitStatus.DISPATCHING.value,
+                    SyncRunUnitStatus.RUNNING.value,
+                    SyncRunUnitStatus.RETRYING.value,
+                }
+            ),
+        )
+        .all()
+    )
+    dispatchable = 0
+    in_flight = 0
+    for status, updated_at in units:
+        if status == SyncRunUnitStatus.PLANNED.value:
+            dispatchable += 1
+        elif status == SyncRunUnitStatus.DISPATCHING.value:
+            if (
+                updated_at is not None
+                and _as_aware(updated_at) <= stale_dispatch_cutoff
+            ):
+                dispatchable += 1
+            else:
+                in_flight += 1
+        else:
+            in_flight += 1
+    return {"dispatchable": dispatchable, "in_flight": in_flight}
+
+
+def sync_observers_for_terminal_sync_run(session, run: SyncRun) -> None:
+    if run.status not in _TERMINAL_RUN_STATUSES:
+        return
+    completed_at = run.completed_at or datetime.now(timezone.utc)
+    run.completed_at = completed_at
+    success = run.status == SyncRunStatus.SUCCESS.value
+    job_run_status = (
+        JobRunStatus.SUCCESS.value if success else JobRunStatus.FAILED.value
+    )
+    backfill_status = "completed" if success else "failed"
+    error = None if success else (run.error or "Sync run completed with failed units")
+    result_patch = {
+        "sync_run_status": run.status,
+        "total_units": int(run.total_units or 0),
+        "completed_units": int(run.completed_units or 0),
+        "failed_units": int(run.failed_units or 0),
+    }
+
+    marker = f"sync_run:{run.id}"
+    backfill_jobs = (
+        session.query(BackfillJob)
+        .filter(BackfillJob.org_id == str(run.org_id))
+        .filter(BackfillJob.celery_task_id.contains(marker))
+        .all()
+    )
+    for job in backfill_jobs:
+        job.status = backfill_status
+        job.total_chunks = int(run.total_units or 0)
+        job.completed_chunks = int(run.completed_units or 0)
+        job.failed_chunks = int(run.failed_units or 0)
+        job.completed_at = completed_at
+        job.error_message = error
+
+    job_runs = (
+        session.query(JobRun)
+        .filter(
+            JobRun.status.in_({JobRunStatus.PENDING.value, JobRunStatus.RUNNING.value})
+        )
+        .all()
+    )
+    for job_run in job_runs:
+        result = job_run.result if isinstance(job_run.result, dict) else {}
+        if str(result.get("sync_run_id") or "") != str(run.id):
+            continue
+        job_run.status = job_run_status
+        job_run.completed_at = completed_at
+        job_run.error = error
+        job_run.result = {**result, **result_patch}
 
 
 def _fail_planned_units(session, run_uuid: uuid.UUID, error: str) -> int:

--- a/tests/api/admin/test_sync_trigger_routing.py
+++ b/tests/api/admin/test_sync_trigger_routing.py
@@ -144,6 +144,7 @@ async def _seed_config(
     *,
     migrated_integration_id: uuid.UUID | None = None,
     planner_managed: bool = False,
+    credential_id: uuid.UUID | None = None,
 ) -> str:
     """Seed a SyncConfiguration and return its id."""
     async with session_maker() as session:
@@ -152,6 +153,7 @@ async def _seed_config(
             provider="github",
             org_id=org_id,
             sync_targets=["git"],
+            credential_id=credential_id,
             migrated_integration_id=migrated_integration_id,
             planner_managed=planner_managed,
         )
@@ -280,6 +282,47 @@ async def test_flag_on_migrated_config_uses_planner_path(client, session_maker):
     # Legacy tasks were NOT called
     fake_run_sync_config.apply_async.assert_not_called()
     fake_dispatch_batch_sync.apply_async.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_planner_trigger_rejects_known_bad_credential_before_planning(
+    client, session_maker
+):
+    ac, seeded_state = client
+    org_id = seeded_state["org_id"]
+    integration_id = uuid.uuid4()
+    credential_id = uuid.uuid4()
+    async with session_maker() as session:
+        credential = IntegrationCredential(
+            provider="github",
+            name="bad-github",
+            org_id=org_id,
+            is_active=True,
+        )
+        credential.id = credential_id
+        credential.last_test_success = False
+        credential.last_test_error = "GitHub authentication failed"
+        session.add(credential)
+        await session.commit()
+
+    config_id = await _seed_config(
+        session_maker,
+        org_id,
+        migrated_integration_id=integration_id,
+        credential_id=credential_id,
+    )
+    await _seed_source(session_maker, org_id, integration_id)
+    await _seed_planner_flag(session_maker, org_id, value="true")
+
+    with patch("dev_health_ops.api.admin.routers.sync.plan_sync_run") as plan_mock:
+        resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "GitHub authentication failed"
+    plan_mock.assert_not_called()
+    async with session_maker() as session:
+        sync_runs = (await session.execute(select(SyncRun))).scalars().all()
+        assert sync_runs == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_backfill_fanout.py
+++ b/tests/test_backfill_fanout.py
@@ -226,6 +226,67 @@ def test_run_backfill_via_planner_creates_backfill_units_per_source_dataset_wind
     }
 
 
+def test_finalize_sync_run_terminalizes_backfill_job_and_job_run(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_single_unit_run(db_session, mode=SyncRunMode.BACKFILL.value)
+    unit.status = SyncRunUnitStatus.FAILED.value
+    unit.error = "bad credentials"
+    unit.result = {"error_category": "auth"}
+    backfill_job = BackfillJob(
+        org_id=ORG_ID,
+        sync_config_id=uuid.uuid4(),
+        celery_task_id=f"worker|sync_run:{run.id}",
+        status="running",
+        since_date=date(2026, 6, 1),
+        before_date=date(2026, 6, 7),
+        total_chunks=1,
+        completed_chunks=0,
+        failed_chunks=0,
+    )
+    scheduled = ScheduledJob(
+        org_id=ORG_ID,
+        name=f"sync-config-{uuid.uuid4()}",
+        job_type="sync",
+        provider="github",
+        schedule_cron="0 * * * *",
+        job_config={},
+        sync_config_id=backfill_job.sync_config_id,
+        tz="UTC",
+        status=1,
+    )
+    db_session.add(scheduled)
+    db_session.flush()
+    job_run = JobRun(
+        job_id=scheduled.id,
+        triggered_by="backfill",
+        status=JobRunStatus.RUNNING.value,
+    )
+    job_run.result = {"sync_run_id": str(run.id)}
+    db_session.add_all([backfill_job, job_run])
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setattr(sync_units, "_dispatch_post_sync_tasks", lambda **kwargs: None)
+
+    result = sync_units.finalize_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    db_session.refresh(backfill_job)
+    db_session.refresh(job_run)
+    assert result["status"] == "finalized"
+    assert run.status == SyncRunStatus.FAILED.value
+    assert backfill_job.status == "failed"
+    assert backfill_job.total_chunks == 1
+    assert backfill_job.failed_chunks == 1
+    assert backfill_job.completed_at is not None
+    assert job_run.status == JobRunStatus.FAILED.value
+    assert job_run.completed_at is not None
+    job_run_result: dict[str, object] = dict(job_run.result or {})
+    assert job_run_result.get("sync_run_status") == SyncRunStatus.FAILED.value
+
+
 def test_backfill_unit_does_not_write_watermark(db_session, monkeypatch):
     from dev_health_ops.processors import dataset_adapters
     from dev_health_ops.workers import sync_units
@@ -542,6 +603,84 @@ def test_run_backfill_task_fanout_resolves_migrated_integration_id(
     assert captured["since"] == date(2026, 6, 1)
     assert captured["before"] == date(2026, 6, 7)
     assert captured["triggered_by"] == "backfill"
+
+
+def test_run_backfill_task_fanout_job_run_remains_running_after_planning(
+    db_session, monkeypatch
+):
+    from dev_health_ops.backfill import runner
+    from dev_health_ops.workers import sync_backfill
+
+    integration = _create_integration(db_session)
+    _create_source(db_session, integration, "full-chaos/dev-health")
+    _create_dataset(db_session, integration, "commits")
+    config = SyncConfiguration(
+        name="migrated parent backfill jobrun",
+        provider="github",
+        org_id=ORG_ID,
+        sync_targets=["git"],
+        sync_options={},
+        is_active=True,
+        migrated_integration_id=integration.id,
+        planner_managed=True,
+    )
+    scheduled = ScheduledJob(
+        org_id=ORG_ID,
+        name=f"sync-config-{uuid.uuid4()}",
+        job_type="sync",
+        provider="github",
+        schedule_cron="0 * * * *",
+        job_config={},
+        sync_config_id=uuid.uuid4(),
+        tz="UTC",
+        status=1,
+    )
+    db_session.add_all([config, scheduled])
+    db_session.flush()
+    job_run = JobRun(
+        job_id=scheduled.id,
+        triggered_by="backfill",
+        status=JobRunStatus.PENDING.value,
+    )
+    backfill_job = BackfillJob(
+        org_id=ORG_ID,
+        sync_config_id=config.id,
+        status="pending",
+        since_date=date(2026, 6, 1),
+        before_date=date(2026, 6, 7),
+    )
+    db_session.add_all([job_run, backfill_job])
+    db_session.flush()
+    sync_run_id = str(uuid.uuid4())
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setattr(
+        runner,
+        "run_backfill_via_planner",
+        lambda *args, **kwargs: {
+            "status": "success",
+            "sync_run_id": sync_run_id,
+            "unit_count": 1,
+        },
+    )
+
+    run_backfill_task = getattr(sync_backfill.run_backfill, "run")
+    result = run_backfill_task(
+        sync_config_id=str(config.id),
+        since="2026-06-01",
+        before="2026-06-07",
+        org_id=ORG_ID,
+        backfill_job_id=str(backfill_job.id),
+        pending_run_id=str(job_run.id),
+    )
+
+    db_session.refresh(backfill_job)
+    db_session.refresh(job_run)
+    assert result["status"] == "success"
+    assert backfill_job.status == "running"
+    assert backfill_job.total_chunks == 1
+    assert job_run.status == JobRunStatus.RUNNING.value
+    assert job_run.completed_at is None
+    assert dict(job_run.result or {})["sync_run_id"] == sync_run_id
 
 
 def test_run_backfill_task_fanout_child_config_scopes_source(db_session, monkeypatch):

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -13,6 +13,9 @@ from dev_health_ops.models import (
     Integration,
     IntegrationDataset,
     IntegrationSource,
+    JobRun,
+    JobRunStatus,
+    ScheduledJob,
     SyncConfiguration,
     SyncRun,
     SyncRunMode,
@@ -1040,6 +1043,129 @@ def test_finalize_zero_unit_run_does_not_report_success(db_session, monkeypatch)
     assert db_session.query(SyncRunPostDispatch).count() == 1
 
 
+def test_finalize_sync_run_only_syncs_nonterminal_job_run_observers(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    unit.status = SyncRunUnitStatus.SUCCESS.value
+    scheduled = ScheduledJob(
+        org_id=run.org_id,
+        name=f"sync-config-{uuid.uuid4()}",
+        job_type="sync",
+        provider="github",
+        schedule_cron="0 * * * *",
+        job_config={},
+        sync_config_id=uuid.uuid4(),
+        tz="UTC",
+        status=1,
+    )
+    db_session.add(scheduled)
+    db_session.flush()
+    running_observer = JobRun(
+        job_id=scheduled.id,
+        triggered_by="manual",
+        status=JobRunStatus.RUNNING.value,
+    )
+    running_observer.result = {"sync_run_id": str(run.id)}
+    terminal_observer = JobRun(
+        job_id=scheduled.id,
+        triggered_by="manual",
+        status=JobRunStatus.FAILED.value,
+    )
+    terminal_observer.error = "already terminal"
+    terminal_observer.result = {"sync_run_id": str(run.id), "sentinel": "preserved"}
+    db_session.add_all([running_observer, terminal_observer])
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setattr(sync_units, "_dispatch_post_sync_tasks", lambda **kwargs: None)
+
+    result = sync_units.finalize_sync_run(str(run.id))
+
+    db_session.refresh(running_observer)
+    db_session.refresh(terminal_observer)
+    assert result["status"] == "finalized"
+    assert running_observer.status == JobRunStatus.SUCCESS.value
+    assert running_observer.completed_at == run.completed_at
+    assert terminal_observer.status == JobRunStatus.FAILED.value
+    assert terminal_observer.error == "already terminal"
+    assert terminal_observer.result == {
+        "sync_run_id": str(run.id),
+        "sentinel": "preserved",
+    }
+
+
+def test_reconciler_repairs_stale_observer_for_older_terminal_run_with_limit(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler
+
+    active_run, active_unit = _seed_run(db_session)
+    older_run, older_unit = _seed_run(db_session)
+    newer_run, newer_unit = _seed_run(db_session)
+    active_unit.status = SyncRunUnitStatus.RUNNING.value
+    active_run.status = SyncRunStatus.RUNNING.value
+    older_unit.status = SyncRunUnitStatus.FAILED.value
+    older_run.status = SyncRunStatus.FAILED.value
+    older_run.completed_at = datetime.now(timezone.utc) - timedelta(days=1)
+    older_run.error = "provider auth failed"
+    older_run.failed_units = 1
+    newer_unit.status = SyncRunUnitStatus.SUCCESS.value
+    newer_run.status = SyncRunStatus.SUCCESS.value
+    newer_run.completed_at = datetime.now(timezone.utc)
+    newer_run.completed_units = 1
+    active_scheduled = ScheduledJob(
+        org_id=active_run.org_id,
+        name=f"sync-config-{uuid.uuid4()}",
+        job_type="sync",
+        provider="github",
+        schedule_cron="0 * * * *",
+        job_config={},
+        sync_config_id=uuid.uuid4(),
+        tz="UTC",
+        status=1,
+    )
+    scheduled = ScheduledJob(
+        org_id=older_run.org_id,
+        name=f"sync-config-{uuid.uuid4()}",
+        job_type="sync",
+        provider="github",
+        schedule_cron="0 * * * *",
+        job_config={},
+        sync_config_id=uuid.uuid4(),
+        tz="UTC",
+        status=1,
+    )
+    db_session.add_all([active_scheduled, scheduled])
+    db_session.flush()
+    active_job_run = JobRun(
+        job_id=active_scheduled.id,
+        triggered_by="manual",
+        status=JobRunStatus.RUNNING.value,
+    )
+    active_job_run.result = {"sync_run_id": str(active_run.id)}
+    active_job_run.created_at = datetime.now(timezone.utc) - timedelta(days=2)
+    job_run = JobRun(
+        job_id=scheduled.id,
+        triggered_by="manual",
+        status=JobRunStatus.RUNNING.value,
+    )
+    job_run.result = {"sync_run_id": str(older_run.id)}
+    job_run.created_at = datetime.now(timezone.utc) - timedelta(days=1)
+    db_session.add_all([active_job_run, job_run])
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=1)
+
+    db_session.refresh(job_run)
+    assert result["observer_repairs"] == 1
+    assert job_run.status == JobRunStatus.FAILED.value
+    assert job_run.error == "provider auth failed"
+    assert job_run.completed_at == older_run.completed_at
+
+
 def test_dispatch_sync_run_redispatches_only_planned_units(db_session, monkeypatch):
     from dev_health_ops.workers import sync_units
 
@@ -1103,7 +1229,9 @@ def test_dispatch_sync_run_redispatches_only_planned_units(db_session, monkeypat
     assert recent_dispatching.status == SyncRunUnitStatus.DISPATCHING.value
 
 
-def test_dispatch_sync_run_denies_inactive_planner_config(db_session, monkeypatch):
+def test_dispatch_sync_run_continues_accepted_run_after_planner_config_pause(
+    db_session, monkeypatch
+):
     from dev_health_ops.workers import sync_units
 
     run, unit = _seed_run(db_session)
@@ -1120,28 +1248,23 @@ def test_dispatch_sync_run_denies_inactive_planner_config(db_session, monkeypatc
     db_session.flush()
     _patch_db_session(monkeypatch, db_session)
 
-    def fail_queue(*_args, **_kwargs):
-        raise AssertionError("inactive planner config must not queue units")
-
-    monkeypatch.setattr(sync_units.run_sync_unit, "s", fail_queue)
-    monkeypatch.setattr(sync_units, "chord", fail_queue)
+    _patch_worker_enqueues(monkeypatch)
 
     result = sync_units.dispatch_sync_run(str(run.id))
 
     db_session.refresh(run)
     db_session.refresh(unit)
     db_session.refresh(config)
-    assert result == {"status": "denied", "reason": "sync configuration is paused"}
-    assert run.status == SyncRunStatus.FAILED.value
-    assert run.error == "sync configuration is paused"
-    assert run.result == {"reason": "inactive_sync_configuration"}
-    assert unit.status == SyncRunUnitStatus.FAILED.value
-    assert unit.error == "sync configuration is paused"
-    assert config.last_sync_success is False
-    assert config.last_sync_error == "sync configuration is paused"
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert run.status == SyncRunStatus.DISPATCHING.value
+    assert run.error is None
+    assert unit.status == SyncRunUnitStatus.DISPATCHING.value
+    assert unit.error is None
+    assert config.last_sync_success is None
+    assert config.last_sync_error is None
 
 
-def test_paused_config_with_running_and_planned_units_does_not_strand(
+def test_paused_config_with_running_and_planned_units_dispatches_planned(
     db_session, monkeypatch
 ):
     from dev_health_ops.workers import sync_reconciler, sync_units
@@ -1189,12 +1312,7 @@ def test_paused_config_with_running_and_planned_units_does_not_strand(
     db_session.refresh(running)
     db_session.refresh(planned)
     db_session.refresh(config)
-    assert dispatch_result == {
-        "status": "denied_active",
-        "reason": "sync configuration is paused",
-        "failed_planned_units": 1,
-        "failed_stale_dispatching_units": 0,
-    }
+    assert dispatch_result == {"status": "dispatched", "queued_units": 1}
     assert run.status not in {
         SyncRunStatus.SUCCESS.value,
         SyncRunStatus.PARTIAL_FAILED.value,
@@ -1202,13 +1320,13 @@ def test_paused_config_with_running_and_planned_units_does_not_strand(
     }
     assert run.completed_at is None
     assert config.last_sync_at is None
-    assert planned.status == SyncRunUnitStatus.FAILED.value
-    assert planned.error == "sync configuration is paused"
+    assert planned.status == SyncRunUnitStatus.DISPATCHING.value
+    assert planned.error is None
     assert running.status == SyncRunUnitStatus.RUNNING.value
     assert running.lease_owner == "worker-live"
     assert dispatch_calls == []
-    assert finalize_calls == [((str(run.id),), "sync")]
-    assert chord_calls == []
+    assert finalize_calls == []
+    assert len(chord_calls) == 1
 
     running.lease_expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
     db_session.flush()
@@ -1218,7 +1336,10 @@ def test_paused_config_with_running_and_planned_units_does_not_strand(
     db_session.refresh(running)
     assert reconcile_result["expired_units"] == 1
     assert running.status == SyncRunUnitStatus.FAILED.value
-    assert finalize_calls == [((str(run.id),), "sync"), ((str(run.id),), "sync")]
+    assert finalize_calls == []
+    planned.status = SyncRunUnitStatus.SUCCESS.value
+    planned.updated_at = datetime.now(timezone.utc)
+    db_session.flush()
 
     finalize_result = sync_units.finalize_sync_run(str(run.id))
 
@@ -1231,12 +1352,12 @@ def test_paused_config_with_running_and_planned_units_does_not_strand(
         unit.status in {SyncRunUnitStatus.SUCCESS.value, SyncRunUnitStatus.FAILED.value}
         for unit in units
     )
-    assert run.status == SyncRunStatus.FAILED.value
+    assert run.status == SyncRunStatus.PARTIAL_FAILED.value
     assert run.completed_at is not None
-    assert run.failed_units == 2
+    assert run.failed_units == 1
 
 
-def test_paused_config_with_stale_dispatching_does_not_redispatch(
+def test_paused_config_with_stale_dispatching_reclaims_accepted_work(
     db_session, monkeypatch
 ):
     from dev_health_ops.workers import sync_units
@@ -1290,27 +1411,16 @@ def test_paused_config_with_stale_dispatching_does_not_redispatch(
     _patch_db_session(monkeypatch, db_session)
     dispatch_calls, finalize_calls, chord_calls = _patch_worker_enqueues(monkeypatch)
 
-    def fail_queue(*_args, **_kwargs):
-        raise AssertionError("paused config must not queue run_sync_unit")
-
-    monkeypatch.setattr(sync_units.run_sync_unit, "s", fail_queue)
-
     dispatch_result = sync_units.dispatch_sync_run(str(run.id))
 
     db_session.refresh(run)
     db_session.refresh(stale_dispatching)
     db_session.refresh(running)
     db_session.refresh(planned)
-    assert dispatch_result == {
-        "status": "denied_active",
-        "reason": "sync configuration is paused",
-        "failed_planned_units": 1,
-        "failed_stale_dispatching_units": 1,
-    }
-    assert stale_dispatching.status == SyncRunUnitStatus.FAILED.value
-    assert stale_dispatching.error == "sync configuration is paused"
-    assert stale_dispatching.result == {"error_category": "dispatch_denied"}
-    assert planned.status == SyncRunUnitStatus.FAILED.value
+    assert dispatch_result == {"status": "dispatched", "queued_units": 2}
+    assert stale_dispatching.status == SyncRunUnitStatus.DISPATCHING.value
+    assert stale_dispatching.error is None
+    assert planned.status == SyncRunUnitStatus.DISPATCHING.value
     assert running.status == SyncRunUnitStatus.RUNNING.value
     assert running.lease_owner == "worker-live"
     assert run.status not in {
@@ -1320,8 +1430,8 @@ def test_paused_config_with_stale_dispatching_does_not_redispatch(
     }
     assert run.completed_at is None
     assert dispatch_calls == []
-    assert finalize_calls == [((str(run.id),), "sync")]
-    assert chord_calls == []
+    assert finalize_calls == []
+    assert len(chord_calls) == 1
 
     running.status = SyncRunUnitStatus.FAILED.value
     running.error = "sync unit lease expired"
@@ -1329,14 +1439,18 @@ def test_paused_config_with_stale_dispatching_does_not_redispatch(
     running.lease_owner = None
     running.lease_expires_at = None
     running.updated_at = datetime.now(timezone.utc)
+    stale_dispatching.status = SyncRunUnitStatus.FAILED.value
+    stale_dispatching.error = "provider auth failed"
+    stale_dispatching.result = {"error_category": "auth"}
+    planned.status = SyncRunUnitStatus.SUCCESS.value
     db_session.flush()
 
     finalize_result = sync_units.finalize_sync_run(str(run.id))
 
     db_session.refresh(run)
     assert finalize_result["status"] == "finalized"
-    assert run.status == SyncRunStatus.FAILED.value
-    assert run.failed_units == 3
+    assert run.status == SyncRunStatus.PARTIAL_FAILED.value
+    assert run.failed_units == 2
 
 
 def test_total_cap_hard_deny_with_stale_dispatching_does_not_redispatch(
@@ -1428,7 +1542,52 @@ def test_total_cap_hard_deny_with_stale_dispatching_does_not_redispatch(
     assert chord_calls == []
 
 
-def test_dispatch_sync_run_denies_inactive_migrated_child_config(
+def test_total_cap_hard_deny_terminalizes_linked_job_run(db_session, monkeypatch):
+    from dev_health_ops.sync.guard import GuardDecision
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    scheduled = ScheduledJob(
+        org_id=run.org_id,
+        name=f"sync-config-{uuid.uuid4()}",
+        job_type="sync",
+        provider="github",
+        schedule_cron="0 * * * *",
+        job_config={},
+        sync_config_id=uuid.uuid4(),
+        tz="UTC",
+        status=1,
+    )
+    db_session.add(scheduled)
+    db_session.flush()
+    job_run = JobRun(
+        job_id=scheduled.id,
+        triggered_by="manual",
+        status=JobRunStatus.PENDING.value,
+    )
+    job_run.result = {"sync_run_id": str(run.id)}
+    db_session.add(job_run)
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    reason = "sync run unit cap exceeded: 1/0"
+    monkeypatch.setattr(
+        sync_units.DispatchGuard,
+        "authorize_run",
+        lambda session, sync_run_id: GuardDecision(False, reason, (str(unit.id),)),
+    )
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    db_session.refresh(job_run)
+    assert result == {"status": "denied", "reason": reason}
+    assert run.status == SyncRunStatus.FAILED.value
+    assert job_run.status == JobRunStatus.FAILED.value
+    assert job_run.error == reason
+    assert job_run.completed_at is not None
+
+
+def test_dispatch_sync_run_continues_accepted_run_after_child_config_pause(
     db_session, monkeypatch
 ):
     from dev_health_ops.workers import sync_units
@@ -1460,25 +1619,20 @@ def test_dispatch_sync_run_denies_inactive_migrated_child_config(
     db_session.flush()
     _patch_db_session(monkeypatch, db_session)
 
-    def fail_queue(*_args, **_kwargs):
-        raise AssertionError("inactive child config must not queue units")
-
-    monkeypatch.setattr(sync_units.run_sync_unit, "s", fail_queue)
-    monkeypatch.setattr(sync_units, "chord", fail_queue)
+    _patch_worker_enqueues(monkeypatch)
 
     result = sync_units.dispatch_sync_run(str(run.id))
 
     db_session.refresh(run)
     db_session.refresh(unit)
     db_session.refresh(parent_config)
-    assert result == {"status": "denied", "reason": "sync configuration is paused"}
-    assert run.status == SyncRunStatus.FAILED.value
-    assert run.error == "sync configuration is paused"
-    assert run.result == {"reason": "inactive_sync_configuration"}
-    assert unit.status == SyncRunUnitStatus.FAILED.value
-    assert unit.error == "sync configuration is paused"
-    assert parent_config.last_sync_success is False
-    assert parent_config.last_sync_error == "sync configuration is paused"
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert run.status == SyncRunStatus.DISPATCHING.value
+    assert run.error is None
+    assert unit.status == SyncRunUnitStatus.DISPATCHING.value
+    assert unit.error is None
+    assert parent_config.last_sync_success is None
+    assert parent_config.last_sync_error is None
 
 
 def test_dispatch_sync_run_does_not_terminalize_when_chord_enqueue_fails(
@@ -1590,7 +1744,11 @@ def test_dispatch_sync_run_does_not_reclaim_stale_running_units(
     )
 
     result = sync_units.dispatch_sync_run(str(run.id))
-    assert result["queued_units"] == 0
+    assert result == {
+        "status": "waiting_inflight",
+        "queued_units": 0,
+        "in_flight_units": 1,
+    }
     db_session.refresh(unit)
     assert unit.status == SyncRunUnitStatus.RUNNING.value
 
@@ -1624,7 +1782,11 @@ def test_dispatch_sync_run_does_not_reclaim_fresh_running_units(
     )
 
     result = sync_units.dispatch_sync_run(str(run.id))
-    assert result["queued_units"] == 0
+    assert result == {
+        "status": "waiting_inflight",
+        "queued_units": 0,
+        "in_flight_units": 1,
+    }
     db_session.refresh(unit)
     assert unit.status == SyncRunUnitStatus.RUNNING.value
 


### PR DESCRIPTION
## Summary
- Stabilizes accepted planner-managed SyncRun dispatch/finalization so pause blocks new starts without cancelling accepted work.
- Preserves BackfillJob and JobRun observer lifecycle through planner fanout/finalizer/reconciler paths.
- Adds credential preflight and terminal auth handling for planner-managed Sync Now and Backfill.

## Linear
- Refs CHAOS-2611 epic
- Completes CHAOS-2612, CHAOS-2613, CHAOS-2614, CHAOS-2615, CHAOS-2616, CHAOS-2617, CHAOS-2618, CHAOS-2619
- Leaves CHAOS-2620 open for live validation

## Verification
- `uv run --frozen --extra dev pytest tests/test_sync_units.py tests/test_backfill_fanout.py tests/api/admin/test_sync_trigger_routing.py` (63 passed)
- `uv run --frozen --extra dev ruff check ...`
- LSP diagnostics clean on changed source files
- Pre-push hooks: ruff format check, ruff check, mypy
- Oracle final review: PASS
- unspecified-high code reviewer final pass: PASS

SCREENSHOT-WAIVER: backend-only worker/API changes; no rendered UI surface changed.