### PR TITLE
CHAOS-2608 (CS7 ops): add workUnitTeamAttributions GraphQL field

### DIFF
--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -569,6 +569,34 @@ class WorkItemTeamAttribution:
 
 
 @strawberry.type
+class WorkUnitTeamAttribution:
+    """The team a work UNIT rolls up to, with provenance (CHAOS-2600 CS7).
+
+    A work unit (investment cluster) is an aggregation of many work items, each
+    with its own per-item ``WorkItemTeamAttribution``. This type collapses those
+    member attributions to the ONE team the unit is owned by, chosen by the same
+    source precedence the per-item resolver uses (``native_team`` strongest down
+    to ``unassigned``; ties broken by how many member items back the team). The
+    web renders this as the unit's team badge in the Investment view — it cannot
+    derive it client-side because ``work_unit_id`` (a content hash) and
+    ``work_item_id`` (a provider key) are disjoint id spaces joined only by
+    ``work_unit_membership`` in ClickHouse.
+    """
+
+    work_unit_id: str
+    team_id: str | None
+    team_name: str | None
+    source: TeamAttributionSource
+    confidence: TeamAttributionConfidence
+    # Always true: this IS the unit's selected team. Kept for shape-symmetry with
+    # WorkItemTeamAttribution and so the web can reuse its primary-selection hook.
+    is_primary: bool
+    # Number of member work items whose primary attribution backs the chosen team.
+    member_count: int
+    evidence: str
+
+
+@strawberry.type
 class WorkGraphEdgeResult:
     """A single edge in the work graph.
 

--- a/src/dev_health_ops/api/graphql/resolvers/_membership_run_scope.py
+++ b/src/dev_health_ops/api/graphql/resolvers/_membership_run_scope.py
@@ -1,0 +1,78 @@
+"""Shared latest-complete-run scoping for ``work_unit_membership`` reads (CHAOS-2433).
+
+Every reader of ``work_unit_membership`` MUST scope identically: select the latest
+COMPLETE run via ``work_unit_membership_runs`` (a run is complete only once its
+marker row exists), recognise the seeded ``__legacy__`` marker (migration 048) and
+map it back to each node's latest pre-migration (``run_id = ''``) row, and treat an
+org with NO complete run as having no membership (the empty-string guard
+``latest_run.latest_run_id != ''`` is the caller's responsibility).
+
+These were originally private to ``resolvers/work_graph.py``. They live here now so
+the work-graph annotation reader and the work-unit team-attribution reader cannot
+drift: a partial reimplementation that scopes with a plain
+``run_id = argMax(run_id, completed_at)`` silently drops results for migrated/idle
+tenants whose latest marker is still ``__legacy__`` while their rows are
+``run_id = ''`` (CHAOS-2608 codex finding).
+
+Usage (mirror work_graph.py)::
+
+    WITH latest_run AS ({LATEST_COMPLETE_RUN_SUBQUERY})
+    SELECT ...
+    FROM work_unit_membership AS m
+    INNER JOIN latest_run ON 1 = 1
+    {LEGACY_NODE_MAX_JOIN}
+    WHERE m.org_id = %(org_id)s
+      AND latest_run.latest_run_id != ''
+      AND ({RUN_SCOPE_PREDICATE})
+
+The aliases are fixed: ``m`` = ``work_unit_membership``, ``latest_run`` =
+``LATEST_COMPLETE_RUN_SUBQUERY``, ``lnm`` = ``LEGACY_NODE_MAX_JOIN``. The
+subqueries are org-scoped via ``%(org_id)s``.
+"""
+
+from __future__ import annotations
+
+LEGACY_RUN_ID = "__legacy__"
+
+LATEST_COMPLETE_RUN_SUBQUERY = """
+        SELECT argMax(run_id, completed_at) AS latest_run_id
+        FROM work_unit_membership_runs
+        WHERE org_id = %(org_id)s
+"""
+
+# LEFT JOIN to an inline derived table computing, per (org, node), the MAX
+# computed_at among LEGACY rows (run_id = '').  Bound to ``m`` by (org, node) and
+# aliased ``lnm`` so the scope predicate can restrict the legacy branch to each
+# node's most recent pre-migration row — the exact old per-node-latest behavior.
+# Inlined (not a top-level CTE) so it works identically in every reader.  Only
+# meaningful when the latest run is the legacy marker; harmless (unmatched LEFT
+# JOIN) otherwise.  Org-scoped via %(org_id)s.
+LEGACY_NODE_MAX_JOIN = """
+            LEFT JOIN (
+                SELECT
+                    org_id,
+                    node_type,
+                    node_id,
+                    max(computed_at) AS legacy_max_computed_at
+                FROM work_unit_membership
+                WHERE org_id = %(org_id)s AND run_id = ''
+                GROUP BY org_id, node_type, node_id
+            ) AS lnm
+                ON lnm.org_id = m.org_id
+                AND lnm.node_type = m.node_type
+                AND lnm.node_id = m.node_id
+"""
+
+# Scope predicate (legacy-vs-real conditional).  REAL run -> run_id equality (one
+# generation per run_id).  LEGACY run -> the node's latest pre-migration row only
+# (run_id='' AND computed_at == that node's legacy max), NOT a blanket run_id=''
+# match (which would resurface stale rows from earlier re-materializations whose
+# distinct category values survived the old non-run_id dedup key).  The
+# empty-string guard (latest_run.latest_run_id != '') stays the caller's
+# responsibility so orgs with no complete run resolve to "no membership".
+RUN_SCOPE_PREDICATE = (
+    f"(latest_run.latest_run_id != '{LEGACY_RUN_ID}' "
+    "AND m.run_id = latest_run.latest_run_id) "
+    f"OR (latest_run.latest_run_id = '{LEGACY_RUN_ID}' AND m.run_id = '' "
+    "AND m.computed_at = lnm.legacy_max_computed_at)"
+)

--- a/src/dev_health_ops/api/graphql/resolvers/team_attribution.py
+++ b/src/dev_health_ops/api/graphql/resolvers/team_attribution.py
@@ -18,6 +18,12 @@ from ..models.outputs import (
     TeamAttributionConfidence,
     TeamAttributionSource,
     WorkItemTeamAttribution,
+    WorkUnitTeamAttribution,
+)
+from ._membership_run_scope import (
+    LATEST_COMPLETE_RUN_SUBQUERY,
+    LEGACY_NODE_MAX_JOIN,
+    RUN_SCOPE_PREDICATE,
 )
 
 logger = logging.getLogger(__name__)
@@ -122,3 +128,171 @@ async def resolve_work_item_team_attributions(
 
     rows = await query_dicts(client, query, params)
     return [_row_to_attribution(row) for row in rows]
+
+
+# CHAOS-2600 CS7: staged source precedence as a SQL CASE, mirroring
+# compute_work_items._SOURCE_ORDER. A unit's owning team is the one backed by the
+# strongest (lowest-rank) member-item source; an unrecognised source degrades to
+# the floor (8) so it never out-ranks a real signal. Keep in lockstep with the
+# enum in models/outputs.py and the Python map in compute_work_items.py.
+_SOURCE_RANK_SQL = (
+    "multiIf("
+    "a.source='native_team',0,"
+    "a.source='issue_project',1,"
+    "a.source='project_ownership',2,"
+    "a.source='repo_ownership',3,"
+    "a.source='assignee_membership',4,"
+    "a.source='linked_issue',5,"
+    "a.source='manual_fallback',6,"
+    "a.source='unassigned',7,"
+    "8)"
+)
+
+
+def _row_to_unit_attribution(row: dict[str, Any]) -> WorkUnitTeamAttribution:
+    team_id = str(row["team_id"]) if row.get("team_id") else None
+    team_name = str(row["team_name"]) if row.get("team_name") else None
+    source = _map_source(str(row.get("source", "unassigned")))
+    member_count = int(row.get("member_count", 0) or 0)
+    # Synthesised here (not in SQL) so the evidence string stays a presentation
+    # concern: how many member items back the team and via which signal.
+    target = team_name or team_id or "no team"
+    evidence = (
+        f"{member_count} member work item(s) attributed to {target} via {source.value}"
+    )
+    return WorkUnitTeamAttribution(
+        work_unit_id=str(row.get("work_unit_id", "")),
+        team_id=team_id,
+        team_name=team_name,
+        source=source,
+        confidence=_map_confidence(str(row.get("confidence", "none"))),
+        is_primary=True,
+        member_count=member_count,
+        evidence=evidence,
+    )
+
+
+async def resolve_work_unit_team_attributions(
+    context: GraphQLContext,
+    work_unit_ids: list[str] | None = None,
+    team_id: str | None = None,
+) -> list[WorkUnitTeamAttribution]:
+    """Return the ONE owning team per work unit, with provenance.
+
+    A work unit is an aggregation of work items; this collapses each unit's member
+    ``work_item_team_attributions`` to a single team by the staged source
+    precedence (strongest member-item source wins; ties → most member items, then
+    team_id for determinism). ``work_unit_ids`` bounds the read to the units a view
+    is rendering (the expected call shape); ``team_id`` optionally filters to units
+    that roll up to one team.
+
+    The join key is ``work_unit_membership.node_id = work_item_team_attributions``
+    ``.work_item_id``: both live in the provider-qualified id space (``linear:`` /
+    ``ghpr:`` / ``gh:``). Cross-provider ``extkey:`` reference nodes never match —
+    correctly, since they carry no attribution of their own and are covered by the
+    sibling PR/issue nodes in the same unit.
+    """
+    from dev_health_ops.api.queries.client import query_dicts
+
+    org_id = require_org_id(context)
+    client = context.client
+    if client is None:
+        raise RuntimeError("Database client not available")
+
+    params: dict[str, Any] = {"org_id": org_id, "limit": _MAX_ROWS}
+
+    # Member nodes are scoped to the latest COMPLETE membership run via the SHARED
+    # protocol (LATEST_COMPLETE_RUN_SUBQUERY + LEGACY_NODE_MAX_JOIN +
+    # RUN_SCOPE_PREDICATE) — identical to the work-graph reader. This handles the
+    # seeded '__legacy__' marker (migration 048): a migrated/idle org whose latest
+    # marker is '__legacy__' keeps its pre-migration (run_id='') rows readable,
+    # mapped to each node's latest legacy row. The empty-string guard
+    # (latest_run.latest_run_id != '') makes an org with NO complete run resolve to
+    # "no membership" rather than over-matching empty-run_id rows.
+    # work_unit_ids bounds the unit set when the caller supplies it.
+    work_unit_filter = ""
+    if work_unit_ids:
+        work_unit_filter = "AND m.work_unit_id IN %(work_unit_ids)s"
+        params["work_unit_ids"] = list(work_unit_ids)
+
+    # team_id filters the FINAL per-unit winner (a unit whose owning team is
+    # team_id), not the candidate set — mirrors the per-item "filter after pick"
+    # rule. It must wrap the winner subquery: team_id is an aggregate (argMin), so
+    # it can't be filtered with a WHERE/HAVING at the GROUP BY level.
+    team_filter = ""
+    if team_id:
+        team_filter = "WHERE team_id = %(team_id)s"
+        params["team_id"] = team_id
+
+    # See work_item_team_attributions resolver for the latest-snapshot rationale:
+    # candidates are appended (never deleted), so a re-org's retired rows survive
+    # FINAL and must be excluded by constraining to each item's max(computed_at).
+    query = f"""
+        WITH latest_run AS ({LATEST_COMPLETE_RUN_SUBQUERY})
+        SELECT
+            work_unit_id,
+            team_id,
+            team_name,
+            source,
+            confidence,
+            member_count
+        FROM (
+            SELECT
+                work_unit_id,
+                argMin(team_id, sort_key) AS team_id,
+                argMin(team_name, sort_key) AS team_name,
+                argMin(source, sort_key) AS source,
+                argMin(confidence, sort_key) AS confidence,
+                argMin(member_count, sort_key) AS member_count
+            FROM (
+                SELECT
+                    work_unit_id,
+                    team_id,
+                    argMin(team_name, src_rank) AS team_name,
+                    argMin(source, src_rank) AS source,
+                    argMin(confidence, src_rank) AS confidence,
+                    count() AS member_count,
+                    (min(src_rank), -toInt64(count()), team_id) AS sort_key
+                FROM (
+                    SELECT
+                        m.work_unit_id AS work_unit_id,
+                        a.team_id AS team_id,
+                        a.team_name AS team_name,
+                        a.source AS source,
+                        a.confidence AS confidence,
+                        {_SOURCE_RANK_SQL} AS src_rank
+                    FROM (
+                        SELECT DISTINCT m.work_unit_id AS work_unit_id, m.node_id AS node_id
+                        FROM work_unit_membership AS m
+                        INNER JOIN latest_run ON 1 = 1
+                        {LEGACY_NODE_MAX_JOIN}
+                        WHERE m.org_id = %(org_id)s
+                          {work_unit_filter}
+                          AND latest_run.latest_run_id != ''
+                          AND ({RUN_SCOPE_PREDICATE})
+                    ) AS m
+                    INNER JOIN (
+                        SELECT work_item_id, team_id, team_name, source, confidence
+                        FROM work_item_team_attributions FINAL
+                        WHERE org_id = %(org_id)s
+                          AND is_primary = 1
+                          AND (work_item_id, computed_at) IN (
+                              SELECT work_item_id, max(computed_at)
+                              FROM work_item_team_attributions
+                              WHERE org_id = %(org_id)s
+                              GROUP BY work_item_id
+                          )
+                    ) AS a
+                    ON m.node_id = a.work_item_id
+                )
+                GROUP BY work_unit_id, team_id
+            )
+            GROUP BY work_unit_id
+        )
+        {team_filter}
+        ORDER BY member_count DESC, work_unit_id
+        LIMIT %(limit)s
+    """
+
+    rows = await query_dicts(client, query, params)
+    return [_row_to_unit_attribution(row) for row in rows]

--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -24,6 +24,11 @@ from ..models.outputs import (
     WorkGraphNodeType,
     WorkGraphProvenance,
 )
+from ._membership_run_scope import (
+    LATEST_COMPLETE_RUN_SUBQUERY as _LATEST_COMPLETE_RUN_SUBQUERY,
+)
+from ._membership_run_scope import LEGACY_NODE_MAX_JOIN as _LEGACY_NODE_MAX_JOIN
+from ._membership_run_scope import RUN_SCOPE_PREDICATE as _RUN_SCOPE_PREDICATE
 
 logger = logging.getLogger(__name__)
 
@@ -367,51 +372,12 @@ def _row_to_edge(
 # protocol guarantees one generation per run_id, so no per-node-max is needed).
 # As soon as a real org-wide run publishes a marker, its completed_at exceeds the
 # legacy marker's, argMax selects it, and the legacy path retires automatically.
-_LEGACY_RUN_ID = "__legacy__"
-
-_LATEST_COMPLETE_RUN_SUBQUERY = """
-        SELECT argMax(run_id, completed_at) AS latest_run_id
-        FROM work_unit_membership_runs
-        WHERE org_id = %(org_id)s
-"""
-
-# LEFT JOIN to an inline derived table computing, per (org, node), the MAX
-# computed_at among LEGACY rows (run_id = '').  Bound to ``m`` by (org, node) and
-# aliased ``lnm`` so the scope predicate can restrict the legacy branch to each
-# node's most recent pre-migration row — the exact old per-node-latest behavior.
-# Inlined (not a top-level CTE) so it works identically in the annotation query
-# AND inside the correlated EXISTS semi-join.  Only meaningful when the latest
-# run is the legacy marker; harmless (unmatched LEFT JOIN) otherwise.  The
-# scoping subquery is org-scoped via %(org_id)s.
-_LEGACY_NODE_MAX_JOIN = """
-            LEFT JOIN (
-                SELECT
-                    org_id,
-                    node_type,
-                    node_id,
-                    max(computed_at) AS legacy_max_computed_at
-                FROM work_unit_membership
-                WHERE org_id = %(org_id)s AND run_id = ''
-                GROUP BY org_id, node_type, node_id
-            ) AS lnm
-                ON lnm.org_id = m.org_id
-                AND lnm.node_type = m.node_type
-                AND lnm.node_id = m.node_id
-"""
-
-# Scope predicate (legacy-vs-real conditional).  ``m`` = work_unit_membership
-# alias, ``latest_run`` = _LATEST_COMPLETE_RUN_SUBQUERY alias, ``lnm`` =
-# _LEGACY_NODE_MAX_JOIN alias.  REAL run -> run_id equality (one generation per
-# run_id).  LEGACY run -> the node's latest pre-migration row only (run_id='' AND
-# computed_at == that node's legacy max), NOT a blanket run_id='' match.  The
-# empty-string guard (latest_run.latest_run_id != '') stays the caller's
-# responsibility so orgs with no complete run resolve to "no membership".
-_RUN_SCOPE_PREDICATE = (
-    f"(latest_run.latest_run_id != '{_LEGACY_RUN_ID}' "
-    "AND m.run_id = latest_run.latest_run_id) "
-    f"OR (latest_run.latest_run_id = '{_LEGACY_RUN_ID}' AND m.run_id = '' "
-    "AND m.computed_at = lnm.legacy_max_computed_at)"
-)
+#
+# The four scoping constants (_LEGACY_RUN_ID, _LATEST_COMPLETE_RUN_SUBQUERY,
+# _LEGACY_NODE_MAX_JOIN, _RUN_SCOPE_PREDICATE) are imported at the top of this
+# module from ``_membership_run_scope`` — shared with the work-unit
+# team-attribution resolver so the two membership readers cannot drift (a partial
+# reimplementation drops results for migrated tenants — CHAOS-2608 codex finding).
 
 
 async def _batch_resolve_membership(

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -53,6 +53,7 @@ from .models.outputs import (
     WorkGraphEdgesResult,
     WorkGraphFlowResult,
     WorkItemTeamAttribution,
+    WorkUnitTeamAttribution,
 )
 from .models.recommendations import (
     Recommendation,
@@ -315,6 +316,28 @@ class Query:
         context = get_context(info)
         return await resolve_work_item_team_attributions(
             context, work_item_ids=work_item_ids, team_id=team_id
+        )
+
+    @strawberry.field(
+        description=(
+            "The owning team per work UNIT (investment cluster), collapsed from "
+            "its member work-item attributions by source precedence — CHAOS-2600"
+        )
+    )
+    async def work_unit_team_attributions(
+        self,
+        info: Info,
+        org_id: str,
+        work_unit_ids: list[str] | None = None,
+        team_id: str | None = None,
+    ) -> list[WorkUnitTeamAttribution]:
+        from .resolvers.team_attribution import (
+            resolve_work_unit_team_attributions,
+        )
+
+        context = get_context(info)
+        return await resolve_work_unit_team_attributions(
+            context, work_unit_ids=work_unit_ids, team_id=team_id
         )
 
     @strawberry.field(description="Paginated list of security alerts")

--- a/tests/graphql/test_work_unit_attribution_graphql.py
+++ b/tests/graphql/test_work_unit_attribution_graphql.py
@@ -1,0 +1,167 @@
+"""Unit tests for the work-UNIT team-attribution resolver (CHAOS-2600 CS7).
+
+The SQL does the cross-id-space join + precedence collapse; these tests pin the
+Python mapping and the query SHAPE (org scoping, latest-complete-run guard, the
+node_id=work_item_id join key, the source-precedence CASE, latest-compute
+snapshot, and filter wiring). The actual aggregation correctness is proven in
+``tests/test_work_unit_attribution_live.py`` against real ClickHouse, because a
+mock that returns pre-aggregated rows cannot exercise the GROUP BY / argMin.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.models.outputs import (
+    TeamAttributionConfidence,
+    TeamAttributionSource,
+)
+from dev_health_ops.api.graphql.resolvers.team_attribution import (
+    resolve_work_unit_team_attributions,
+)
+
+_QUERY_DICTS = "dev_health_ops.api.queries.client.query_dicts"
+
+# Realistic, DISTINCT id shapes so a matching-id mock can never paper over the
+# work_unit_id-vs-work_item_id bug again: a unit id is a 64-char content hash, a
+# member work item id is a provider key.
+_UNIT_ID = "fb3a1e0094" + "0" * 54
+_WORK_ITEM_ID = "linear:CHAOS-1053"
+
+
+class MockClient:
+    pass
+
+
+@pytest.fixture
+def mock_context():
+    return GraphQLContext(
+        org_id="test-org",
+        db_url="clickhouse://localhost:8123/default",
+        client=MockClient(),
+    )
+
+
+def _row(
+    work_unit_id: str = _UNIT_ID,
+    team_id: str | None = "CHAOS",
+    team_name: str | None = "Fullchaos",
+    source: str = "native_team",
+    confidence: str = "high",
+    member_count: int = 5,
+) -> dict[str, Any]:
+    return {
+        "work_unit_id": work_unit_id,
+        "team_id": team_id,
+        "team_name": team_name,
+        "source": source,
+        "confidence": confidence,
+        "member_count": member_count,
+    }
+
+
+@pytest.mark.asyncio
+async def test_maps_row_to_unit_attribution(mock_context):
+    with patch(_QUERY_DICTS, new_callable=AsyncMock) as mock_query:
+        mock_query.return_value = [_row()]
+        result = await resolve_work_unit_team_attributions(
+            mock_context, work_unit_ids=[_UNIT_ID]
+        )
+    assert len(result) == 1
+    attr = result[0]
+    assert attr.work_unit_id == _UNIT_ID
+    assert attr.team_id == "CHAOS"
+    assert attr.team_name == "Fullchaos"
+    assert attr.source == TeamAttributionSource.NATIVE_TEAM
+    assert attr.confidence == TeamAttributionConfidence.HIGH
+    # is_primary is always True — this IS the unit's selected team.
+    assert attr.is_primary is True
+    assert attr.member_count == 5
+    # Evidence is synthesised from the count + team + source.
+    assert "5 member work item(s)" in attr.evidence
+    assert "Fullchaos" in attr.evidence
+    assert "native_team" in attr.evidence
+
+
+@pytest.mark.asyncio
+async def test_null_team_becomes_none_and_evidence_degrades(mock_context):
+    with patch(_QUERY_DICTS, new_callable=AsyncMock) as mock_query:
+        mock_query.return_value = [
+            _row(team_id=None, team_name=None, source="unassigned", confidence="none")
+        ]
+        result = await resolve_work_unit_team_attributions(mock_context)
+    assert result[0].team_id is None
+    assert result[0].team_name is None
+    assert result[0].source == TeamAttributionSource.UNASSIGNED
+    assert "no team" in result[0].evidence
+
+
+@pytest.mark.asyncio
+async def test_unknown_enum_values_degrade_safely(mock_context):
+    with patch(_QUERY_DICTS, new_callable=AsyncMock) as mock_query:
+        mock_query.return_value = [
+            _row(source="some_future_source", confidence="ultra")
+        ]
+        result = await resolve_work_unit_team_attributions(mock_context)
+    assert result[0].source == TeamAttributionSource.UNASSIGNED
+    assert result[0].confidence == TeamAttributionConfidence.NONE
+
+
+@pytest.mark.asyncio
+async def test_query_joins_id_spaces_scoped_and_bounded(mock_context):
+    with patch(_QUERY_DICTS, new_callable=AsyncMock) as mock_query:
+        mock_query.return_value = []
+        await resolve_work_unit_team_attributions(
+            mock_context, work_unit_ids=[_UNIT_ID], team_id="CHAOS"
+        )
+    _client, sql, params = mock_query.call_args.args
+    # The cross-id-space join that the CS7 bug got wrong: membership node_id to
+    # attribution work_item_id (NOT work_unit_id to work_item_id).
+    assert "ON m.node_id = a.work_item_id" in sql
+    # Latest COMPLETE membership run guard via the SHARED protocol (CHAOS-2433):
+    # argMax marker, the seeded '__legacy__' branch (migration 048 — migrated
+    # tenants), and the empty-string guard (no complete run -> no membership). A
+    # plain run_id=argMax reimplementation drops badges for migrated orgs.
+    assert "work_unit_membership_runs" in sql
+    assert "argMax(run_id, completed_at)" in sql
+    assert "__legacy__" in sql
+    assert "latest_run.latest_run_id != ''" in sql
+    # Attribution read mirrors the per-item resolver: FINAL + latest-compute
+    # snapshot so a re-org's retired candidate rows can't surface.
+    assert "work_item_team_attributions FINAL" in sql
+    assert "is_primary = 1" in sql
+    assert "max(computed_at)" in sql
+    # Source precedence collapse + org scope + caller filters.
+    assert "multiIf(" in sql
+    assert "org_id = %(org_id)s" in sql
+    assert "m.work_unit_id IN %(work_unit_ids)s" in sql
+    assert "team_id = %(team_id)s" in sql
+    assert "LIMIT %(limit)s" in sql
+    assert params["org_id"] == "test-org"
+    assert params["work_unit_ids"] == [_UNIT_ID]
+    assert params["team_id"] == "CHAOS"
+
+
+@pytest.mark.asyncio
+async def test_team_filter_applies_to_winner_not_snapshot(mock_context):
+    # The team filter must constrain the FINAL per-unit winner, never the
+    # latest-compute snapshot subquery (else a re-org that moved a unit off a team
+    # could be masked by an old same-team row) — mirrors the per-item rule.
+    with patch(_QUERY_DICTS, new_callable=AsyncMock) as mock_query:
+        mock_query.return_value = []
+        await resolve_work_unit_team_attributions(mock_context, team_id="CHAOS")
+    _client, sql, _params = mock_query.call_args.args
+    # Isolate the latest-compute snapshot SUBQUERY by its distinctive header
+    # (anchoring on plain "max(computed_at)" is ambiguous — the legacy run join
+    # also uses it). The team filter is applied at the outermost per-unit level, so
+    # it must NOT appear inside this subquery.
+    anchor = "SELECT work_item_id, max(computed_at)"
+    assert anchor in sql
+    snapshot_subquery = sql.split(anchor, 1)[1].split("GROUP BY work_item_id", 1)[0]
+    assert "team_id" not in snapshot_subquery
+    # But it IS present overall — on the final winner.
+    assert "team_id = %(team_id)s" in sql

--- a/tests/test_work_unit_attribution_live.py
+++ b/tests/test_work_unit_attribution_live.py
@@ -1,0 +1,323 @@
+"""Live-ClickHouse regression for work-UNIT team attribution (CHAOS-2600 CS7).
+
+Proves the cross-id-space collapse the per-unit resolver does in SQL:
+``work_unit_membership.node_id`` (provider key) JOIN
+``work_item_team_attributions.work_item_id`` → one owning team per unit by source
+precedence. Uses DISTINCT id shapes (unit = 64-char hash, member = provider key)
+so the bug that shipped green — passing a ``work_unit_id`` to a ``work_item_id``-
+keyed query — is reproduced and pinned, not hidden by a matching-id mock.
+
+Opt-in (filtered from unit/CI): ``pytest -m clickhouse`` with ``CLICKHOUSE_URI``
+pointing at a SCRATCH db (never the dev ``default``).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/ci_local_validate)",
+    ),
+]
+
+# Unit ids are 64-char content hashes; member ids are provider keys. Keeping them
+# structurally distinct is the whole point of this regression.
+_UNIT_SOURCE_WINS = "a" * 64  # stronger source must beat a higher member count
+_UNIT_COUNT_TIEBREAK = "b" * 64  # same source → most member items wins
+_DAY = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="module")
+def sink():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
+    s = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    s.ensure_schema(force=True)
+    yield s
+    s.close()
+
+
+def _membership(org_id, unit_id, node_id, run_id, *, node_type="issue"):
+    from dev_health_ops.metrics.schemas import WorkUnitMembershipRecord
+
+    return WorkUnitMembershipRecord(
+        org_id=org_id,
+        node_type=node_type,
+        node_id=node_id,
+        work_unit_id=unit_id,
+        category_kind="theme",
+        category="feature_delivery",
+        weight=1.0,
+        is_dominant=1,
+        categorization_status="complete",
+        computed_at=_DAY,
+        run_id=run_id,
+    )
+
+
+def _attr(org_id, repo_id, work_item_id, team_id, team_name, source):
+    from dev_health_ops.metrics.schemas import WorkItemTeamAttributionRecord
+
+    return WorkItemTeamAttributionRecord(
+        work_item_id=work_item_id,
+        provider="linear",
+        source=source,
+        is_primary=1,
+        confidence="high",
+        evidence=f"{source}={team_id}",
+        computed_at=_DAY,
+        repo_id=repo_id,
+        team_id=team_id,
+        team_name=team_name,
+        org_id=org_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_unit_attribution_collapses_members_by_precedence(sink):
+    from dev_health_ops.api.graphql.context import GraphQLContext
+    from dev_health_ops.api.graphql.models.outputs import TeamAttributionSource
+    from dev_health_ops.api.graphql.resolvers.team_attribution import (
+        resolve_work_item_team_attributions,
+        resolve_work_unit_team_attributions,
+    )
+    from dev_health_ops.metrics.schemas import WorkUnitMembershipRunRecord
+
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
+    org_id = f"test-cs7-{uuid.uuid4()}"
+    repo_id = uuid.uuid4()
+    run_id = "run-complete"
+
+    # Unit A — strongest source wins over member count:
+    #   CHAOS via native_team (rank 0, 1 member) beats PLATFORM via
+    #   assignee_membership (rank 4, 2 members). One member is a cross-provider
+    #   extkey: node with NO attribution row (must be ignored, not crash).
+    # Unit B — same source, most members wins: PLATFORM (2) over CHAOS (1).
+    sink.write_work_unit_memberships(
+        [
+            _membership(org_id, _UNIT_SOURCE_WINS, "linear:CHAOS-10", run_id),
+            _membership(org_id, _UNIT_SOURCE_WINS, "linear:CHAOS-11", run_id),
+            _membership(org_id, _UNIT_SOURCE_WINS, "linear:CHAOS-12", run_id),
+            _membership(org_id, _UNIT_SOURCE_WINS, "extkey:ACTIONS-3", run_id),
+            _membership(org_id, _UNIT_COUNT_TIEBREAK, "linear:CHAOS-20", run_id),
+            _membership(org_id, _UNIT_COUNT_TIEBREAK, "linear:CHAOS-21", run_id),
+            _membership(org_id, _UNIT_COUNT_TIEBREAK, "linear:CHAOS-22", run_id),
+            # Incomplete run (no completion marker) — must be invisible. If the run
+            # guard regressed, this row would inject team GHOST into unit A.
+            _membership(org_id, _UNIT_SOURCE_WINS, "linear:CHAOS-99", "run-incomplete"),
+        ]
+    )
+    sink.write_membership_run(
+        WorkUnitMembershipRunRecord(org_id=org_id, run_id=run_id, completed_at=_DAY)
+    )
+    sink.write_work_item_team_attributions(
+        [
+            _attr(
+                org_id, repo_id, "linear:CHAOS-10", "CHAOS", "Fullchaos", "native_team"
+            ),
+            _attr(
+                org_id,
+                repo_id,
+                "linear:CHAOS-11",
+                "PLATFORM",
+                "Platform",
+                "assignee_membership",
+            ),
+            _attr(
+                org_id,
+                repo_id,
+                "linear:CHAOS-12",
+                "PLATFORM",
+                "Platform",
+                "assignee_membership",
+            ),
+            _attr(
+                org_id, repo_id, "linear:CHAOS-20", "CHAOS", "Fullchaos", "native_team"
+            ),
+            _attr(
+                org_id,
+                repo_id,
+                "linear:CHAOS-21",
+                "PLATFORM",
+                "Platform",
+                "native_team",
+            ),
+            _attr(
+                org_id,
+                repo_id,
+                "linear:CHAOS-22",
+                "PLATFORM",
+                "Platform",
+                "native_team",
+            ),
+            _attr(org_id, repo_id, "linear:CHAOS-99", "GHOST", "Ghost", "native_team"),
+        ]
+    )
+
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink.client)
+    result = await resolve_work_unit_team_attributions(
+        context, work_unit_ids=[_UNIT_SOURCE_WINS, _UNIT_COUNT_TIEBREAK]
+    )
+    by_unit = {r.work_unit_id: r for r in result}
+
+    # Unit A: stronger source (native_team) wins despite fewer members.
+    a = by_unit[_UNIT_SOURCE_WINS]
+    assert a.team_id == "CHAOS"
+    assert a.source == TeamAttributionSource.NATIVE_TEAM
+    assert a.member_count == 1  # only CHAOS-10 backs CHAOS
+    assert a.is_primary is True
+    # Incomplete-run row never leaked in.
+    assert a.team_id != "GHOST"
+
+    # Unit B: same source for both teams → most member items wins.
+    b = by_unit[_UNIT_COUNT_TIEBREAK]
+    assert b.team_id == "PLATFORM"
+    assert b.member_count == 2
+
+    # PIN THE BUG (CHAOS-2608): the original code passed the unit's 64-char hash to
+    # the work_item-keyed resolver. That id is NOT a work_item_id, so it resolves
+    # NOTHING — which is exactly why the badge never rendered. The unit resolver
+    # above is the fix.
+    wrong = await resolve_work_item_team_attributions(
+        context, work_item_ids=[_UNIT_SOURCE_WINS]
+    )
+    assert wrong == []
+
+
+@pytest.mark.asyncio
+async def test_team_filter_selects_units_for_that_team(sink):
+    from dev_health_ops.api.graphql.context import GraphQLContext
+    from dev_health_ops.api.graphql.resolvers.team_attribution import (
+        resolve_work_unit_team_attributions,
+    )
+
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
+    org_id = f"test-cs7-filter-{uuid.uuid4()}"
+    repo_id = uuid.uuid4()
+    run_id = "run-complete"
+    unit_chaos = "c" * 64
+    unit_platform = "d" * 64
+
+    from dev_health_ops.metrics.schemas import WorkUnitMembershipRunRecord
+
+    sink.write_work_unit_memberships(
+        [
+            _membership(org_id, unit_chaos, "linear:CHAOS-30", run_id),
+            _membership(org_id, unit_platform, "linear:CHAOS-31", run_id),
+        ]
+    )
+    sink.write_membership_run(
+        WorkUnitMembershipRunRecord(org_id=org_id, run_id=run_id, completed_at=_DAY)
+    )
+    sink.write_work_item_team_attributions(
+        [
+            _attr(
+                org_id, repo_id, "linear:CHAOS-30", "CHAOS", "Fullchaos", "native_team"
+            ),
+            _attr(
+                org_id,
+                repo_id,
+                "linear:CHAOS-31",
+                "PLATFORM",
+                "Platform",
+                "native_team",
+            ),
+        ]
+    )
+
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink.client)
+    only_chaos = await resolve_work_unit_team_attributions(context, team_id="CHAOS")
+    assert {r.work_unit_id for r in only_chaos} == {unit_chaos}
+    assert all(r.team_id == "CHAOS" for r in only_chaos)
+
+
+@pytest.mark.asyncio
+async def test_legacy_marker_keeps_migrated_membership_readable(sink):
+    """Migrated tenants (CHAOS-2608 codex HIGH): pre-migration membership rows carry
+    run_id='' and migration 048 seeds a '__legacy__' marker. The resolver must map
+    the legacy marker to each node's latest run_id='' row — a plain
+    run_id=argMax(...) would filter to run_id='__legacy__' and match NOTHING,
+    silently dropping the unit's badge.
+    """
+    from dev_health_ops.api.graphql.context import GraphQLContext
+    from dev_health_ops.api.graphql.resolvers.team_attribution import (
+        resolve_work_unit_team_attributions,
+    )
+    from dev_health_ops.metrics.schemas import WorkUnitMembershipRunRecord
+
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
+    org_id = f"test-cs7-legacy-{uuid.uuid4()}"
+    repo_id = uuid.uuid4()
+    unit_legacy = "e" * 64
+
+    # Pre-migration rows: run_id='' (the default migration 047 backfilled).
+    sink.write_work_unit_memberships(
+        [
+            _membership(org_id, unit_legacy, "linear:CHAOS-40", ""),
+            _membership(org_id, unit_legacy, "linear:CHAOS-41", ""),
+        ]
+    )
+    # Migration 048's seeded legacy marker: run_id='__legacy__'.
+    sink.write_membership_run(
+        WorkUnitMembershipRunRecord(
+            org_id=org_id, run_id="__legacy__", completed_at=_DAY
+        )
+    )
+    sink.write_work_item_team_attributions(
+        [
+            _attr(
+                org_id, repo_id, "linear:CHAOS-40", "CHAOS", "Fullchaos", "native_team"
+            ),
+            _attr(
+                org_id, repo_id, "linear:CHAOS-41", "CHAOS", "Fullchaos", "native_team"
+            ),
+        ]
+    )
+
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink.client)
+    result = await resolve_work_unit_team_attributions(
+        context, work_unit_ids=[unit_legacy]
+    )
+    assert len(result) == 1
+    assert result[0].work_unit_id == unit_legacy
+    assert result[0].team_id == "CHAOS"
+    assert result[0].member_count == 2
+
+
+@pytest.mark.asyncio
+async def test_no_complete_run_resolves_to_no_membership(sink):
+    """No completion marker (in-flight or pre-048 with no real run) → the org has no
+    complete run, so the empty-string guard must yield NOTHING rather than
+    over-matching empty-run_id rows.
+    """
+    from dev_health_ops.api.graphql.context import GraphQLContext
+    from dev_health_ops.api.graphql.resolvers.team_attribution import (
+        resolve_work_unit_team_attributions,
+    )
+
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
+    org_id = f"test-cs7-norun-{uuid.uuid4()}"
+    repo_id = uuid.uuid4()
+    unit_orphan = "f" * 64
+
+    # Membership rows exist (run_id='') but NO marker was ever written.
+    sink.write_work_unit_memberships(
+        [_membership(org_id, unit_orphan, "linear:CHAOS-50", "")]
+    )
+    sink.write_work_item_team_attributions(
+        [_attr(org_id, repo_id, "linear:CHAOS-50", "CHAOS", "Fullchaos", "native_team")]
+    )
+
+    context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink.client)
+    result = await resolve_work_unit_team_attributions(context)
+    assert result == []


### PR DESCRIPTION
## Why
The Investment view's team-attribution badge **never renders**. The client passes a `work_unit_id` (64-char content hash) to `workItemTeamAttributions`, which is keyed by `work_item_id` (`linear:CHAOS-xxxx`). The two id spaces are disjoint (0 overlap, confirmed in ClickHouse), so the query always returns nothing. Component tests passed only because the mock used matching ids.

The client has no unit→item mapping (work units arrive via REST with no member ids; `work_unit_membership` lives only in ClickHouse), so the collapse must happen **server-side**.

## What
New `workUnitTeamAttributions(orgId, workUnitIds, teamId)` field returning one owning team per work unit:
- Joins `work_unit_membership` → `work_item_team_attributions` on `node_id = work_item_id` (the `extkey:` cross-provider nodes correctly don't match; `linear:`/`ghpr:`/`gh:` do).
- Picks one team per unit by the existing **source precedence** (`native_team` strongest .. `unassigned` floor; ties → member count, then team_id).
- `FINAL` + latest-compute snapshot on the attribution read (re-org staleness, per CHAOS-2605).
- Membership-run scoping **reuses the canonical protocol** — factored `LATEST_COMPLETE_RUN_SUBQUERY` + `LEGACY_NODE_MAX_JOIN` + `RUN_SCOPE_PREDICATE` out of `work_graph.py` into a shared `_membership_run_scope` module imported by both readers. Handles migration 048's seeded `__legacy__` marker (migrated/idle tenants keep `run_id=''` rows readable) + the empty-string guard (no complete run → no membership).

## Tests
- Mocked: Python mapping + query shape (join key, precedence CASE, FINAL+snapshot, legacy/empty-guard, team-filter placement).
- Live (`@pytest.mark.clickhouse`): **distinct id shapes** (unit=hash, item=provider key) so a matching-id mock can't hide the bug again; **pins the bug** (raw work_unit_id resolves nothing); proves source precedence, member-count tie-break, run-completion guard, **legacy-marker readability**, **no-complete-run**, and the team filter.
- Verified on real org `70d529e0` — identical results pre/post the scoping refactor; `work_graph` theme-filter regression (30 tests) still green.

Gate (`ci/local_validate.sh`): ruff/mypy/5678 unit/ch-migrate/argMax live ✓. Codex adversarial review: clean (1 HIGH found & fixed at root).

Unblocks the CS7 web wire. Parent: CHAOS-2600.