### PR TITLE
CHAOS-2609 (CS-COV): close provider×entity attribution coverage gaps

### DIFF
--- a/docs/architecture/chaos-2600-implementation-plan.md
+++ b/docs/architecture/chaos-2600-implementation-plan.md
@@ -1,0 +1,861 @@
+# CHAOS-2600 — Implementation Plan: ClickHouse-Only Team Attribution
+
+> Source of intent: `team-realignment.md` (the CHAOS-2600 corrective plan).
+> This document converts that 12-phase corrective plan into a **gated changeset sequence**,
+> grounded in the *actual* current code (verified by a 10-agent parallel codebase sweep, all
+> findings `high` confidence). Every changeset has a `/codex:adversarial-review` gate and an
+> alignment check so we cannot drift from the invariants.
+
+---
+
+## 0. What the grounding sweep changed about the plan
+
+The corrective doc hedges ("models *similar to*", "*likely* target areas"). The sweep replaced
+those guesses with anchored facts. Three of them reshape the plan:
+
+1. **Query-time attribution already reads only ClickHouse.** The runtime resolvers
+   (`ops/src/dev_health_ops/providers/teams.py:61-142`) are built from `store.get_all_teams()` —
+   they have **no Postgres import**. Postgres `TeamMapping`/`IdentityMapping`
+   (`models/settings.py:571-730`) is an *upstream config layer* bridged into the ClickHouse
+   `teams` dimension by `bridge_teams_to_clickhouse` (`providers/team_bridge.py:49-111`).
+   → The work is "delete the bridge + make CH the system of record", **not** "rewrite the resolvers".
+
+2. **The CH ownership tables already exist.** Migration `051_team_attribution_dimensions.sql`
+   created `team_memberships`, `team_project_ownership`, `team_repo_ownership`,
+   `work_item_team_attributions`; `team_autoimport_{github,gitlab,jira,linear}.py` already write
+   them CH-native (no Postgres). → Phase 3 is mostly built; what remains is **re-homing the
+   `teams`-dimension population** (`members`, `project_keys`, `repo_patterns`) off the bridge.
+
+3. **The precedence fix is bigger than a one-dict edit.** The doc's target `_SOURCE_ORDER`
+   adds **two new sources** (`issue_project`, `manual_fallback`) that do not exist today, and the
+   ClickHouse `work_item_team_attributions.source` **and** `confidence` `Enum8`s must be ALTERed
+   (current `confidence` is `Enum8('high'=1,'medium'=2,'low'=3)` — a `manual`/`none` insert throws).
+
+### The current (buggy) state, anchored
+
+| Concern | Truth on disk | Anchor |
+| --- | --- | --- |
+| Precedence dict | `{native_team:0, linked_issue:1, project_ownership:2, repo_ownership:3, assignee_membership:4, unassigned:5}` — `linked_issue` outranks ownership+assignee (the bug) | `metrics/compute_work_items.py:105-112` |
+| Winner selection | iterate sources sorted by `_SOURCE_ORDER`; first non-empty source wins; **full candidate set still emitted** with `is_primary` | `compute_work_items.py:307-340` |
+| Postgres→CH bridge | single fn, 4 lazy import sites + admin/sync_runtime dispatchers; sits **first** in the daily Celery chain | `providers/team_bridge.py:49`; `sync_runtime.py:392-408` |
+| Manual fallback | **does not exist** — zero hits for `manual_attribution_fallback*` anywhere in ops | (grep, verified) |
+| `issue_project` source | **does not exist** — `TeamAttributionSource` has only 6 values | `compute_work_items.py:61-68` |
+| Donor-row enforcement | already enforced: extkey must resolve to a real `work_items` row; missing/ambiguous → no inheritance | `compute_work_items.py:380-496` |
+| Provenance in GraphQL | provenance exists on the CH record but is **never** SELECTed or in the Strawberry SDL | `metrics/schemas.py:384-395`; `api/graphql/resolvers/analytics.py:640-712` |
+| Web client-side attribution | orphaned dead code derives teams from `evidence` JSON — a latent boundary violation, **no live caller** | `web/src/lib/investment/transforms.ts:374-523` |
+
+---
+
+## 1. Target invariant contract (the north star)
+
+Every changeset is judged against this. Do not let any PR weaken it.
+
+### 1.1 Source of truth
+- ClickHouse is the **only** persistence layer read *or written* for team/project/member/repo/manual attribution.
+- Postgres stores auth/org/config only. **No attribution code reads Postgres.**
+
+### 1.2 Precedence (deterministic staged resolution)
+```
+0 native_team          (native issue team)
+1 issue_project        (native issue project ownership)   ← NEW
+2 project_ownership    (imported provider project ownership)
+3 repo_ownership       (imported provider repo ownership)
+4 assignee_membership  (imported team membership)
+5 linked_issue         (actual linked donor issue row)    ← DEMOTED (was 1)
+6 manual_fallback      (explicit ClickHouse fallback)      ← NEW
+7 unassigned
+```
+- `linked_issue` must **lose** to every native/imported fact and **beat only** `manual_fallback`/`unassigned`.
+- `manual_fallback` must **never** override any native/imported/linked fact.
+- Selection still emits the **full candidate set** (provenance rows); only the *winner* changes.
+
+### 1.3 Linked-issue & prefix rules
+- `linked_issue` requires an **actual donor `work_items` row** (already enforced — preserve it).
+- An external issue-key *prefix* with **no** resolved donor row is **not** linked-issue inheritance.
+  It may only match an explicit `manual_fallback` record with `scope_type = issue_key_prefix`,
+  emitting `source = manual_fallback`, low/manual confidence.
+
+### 1.4 Provenance everywhere
+Every final attribution carries: `org_id, work_item_id, provider, team_id, team_name, source,
+confidence, evidence, is_primary, computed_at`.
+`source ∈ {native_team, issue_project, project_ownership, repo_ownership, assignee_membership,
+linked_issue, manual_fallback, unassigned}`; `confidence ∈ {high, medium, low, manual, none}`.
+
+### 1.5 Resolution decision tree (navigation + off-the-rails fallback)
+
+This is the single canonical picture of *how a work item gets a team*. **To debug a surprising
+attribution:** read `team_attribution_source` from the persisted provenance, jump to that node, and
+verify every stage **above** it correctly returned "no". The first stage that returns "yes" wins
+and the walk stops — nothing below can override it.
+
+```mermaid
+flowchart TD
+    Start(["Work item needs a team"]) --> NT{"0 · native_team?<br/>WorkItem.native_team_key → teams"}
+    NT -->|"yes"| NTout["native_team · high"]
+    NT -->|"no"| IP{"1 · issue_project?<br/>native issue project → owning team"}
+    IP -->|"yes"| IPout["issue_project · high"]
+    IP -->|"no"| PO{"2 · project_ownership?<br/>team_project_ownership"}
+    PO -->|"yes"| POout["project_ownership · high"]
+    PO -->|"no"| RO{"3 · repo_ownership?<br/>team_repo_ownership"}
+    RO -->|"yes"| ROout["repo_ownership · medium"]
+    RO -->|"no"| AM{"4 · assignee_membership?<br/>team_memberships"}
+    AM -->|"yes"| AMout["assignee_membership · medium"]
+    AM -->|"no"| LK{"5 · linked to an ACTUAL donor issue row?<br/>work_item_dependencies"}
+    LK -->|"yes"| DR{"donor issue resolves to a team?"}
+    LK -->|"no donor row"| PFX{"only issue-key prefix text exists?"}
+    DR -->|"yes"| LKout["linked_issue · high<br/>evidence: donor_work_item_id"]
+    DR -->|"no"| MF{"6 · manual fallback matches?<br/>repo / project / member / issue_key_prefix"}
+    PFX -->|"yes"| PFXout["NOT linked_issue —<br/>a bare prefix is not donor evidence (R1)"]
+    PFX -->|"no"| MF
+    PFXout --> MF
+    MF -->|"yes"| MFout["manual_fallback · manual/low<br/>evidence: matched record"]
+    MF -->|"no"| UN["7 · unassigned · none"]
+
+    NTout --> P["Persist work_item_team_attributions<br/>full candidate set; is_primary on winner"]
+    IPout --> P
+    POout --> P
+    ROout --> P
+    AMout --> P
+    LKout --> P
+    MFout --> P
+    UN --> P
+    P --> API["Expose source / confidence / evidence via GraphQL"]
+    API --> UI["Frontend renders only — no recompute"]
+```
+
+**Invariants encoded in the tree (do not let any PR break these):**
+- The walk is **top-down and short-circuits** — stage *N* only runs if stages `0..N-1` all returned "no".
+- **`linked_issue` (5)** requires a real `work_item_dependencies` donor row whose target resolves to
+  an actual `work_items` row *that itself has a team*. A bare issue-key prefix with no donor falls
+  through to stage 6 (verified: `compute_work_items.py:412-496`; D1/R1).
+- **`manual_fallback` (6)** can only beat `unassigned`. If it ever beats a native/imported/linked
+  team, that is a precedence **bug** — check `_SOURCE_ORDER`.
+- **`unassigned` (7)** is the floor. A *whole org* landing here usually means the ClickHouse `teams`
+  dimension is empty (a CS5 regression), not a resolver bug.
+
+### 1.6 Attribution data flow (WTI → ClickHouse → resolver → consumers)
+
+Shows *where the data comes from* and the one hard boundary: **Postgres must not feed attribution.**
+
+```mermaid
+flowchart LR
+    subgraph WTI["Work Tracking Integrations"]
+        GH["GitHub"]
+        GL["GitLab"]
+        LI["Linear"]
+        JI["Jira"]
+    end
+
+    subgraph SourceObjects["Provider objects"]
+        Issue["Issue<br/>canonical work unit"]
+        PRMR["PR / MR<br/>code-change evidence"]
+        Commit["Commit<br/>lower-level evidence"]
+        Team["Team"]
+        Project["Project"]
+        Member["Member"]
+    end
+
+    subgraph Normalize["Normalization (WTI → CH)"]
+        WorkItem["normalize → work_items"]
+        Dependency["normalize → work_item_dependencies"]
+        Ownership["normalize ownership facts"]
+    end
+
+    subgraph CH["ClickHouse — single attribution store"]
+        Teams["teams"]
+        Memberships["team_memberships"]
+        ProjectOwnership["team_project_ownership"]
+        RepoOwnership["team_repo_ownership"]
+        WorkItems["work_items"]
+        Dependencies["work_item_dependencies"]
+        ManualFallbacks["manual_attribution_fallbacks"]
+        Attributions["work_item_team_attributions"]
+    end
+
+    subgraph Resolver["Attribution resolver (staged, short-circuit)"]
+        R0["1 · WTI-native facts<br/>native_team, issue_project"]
+        R1["2 · imported ownership<br/>project, repo, assignee"]
+        R2["3 · actual linked donor issue"]
+        R3["4 · manual fallback"]
+        R4["5 · unassigned"]
+    end
+
+    subgraph Consumers["Consumers"]
+        API["Backend GraphQL"]
+        Web["dev-health-web"]
+        Reports["Investment / Flow / Confidence views"]
+    end
+
+    Admin["Manual admin/config input"] --> ManualFallbacks
+
+    GH --> SourceObjects
+    GL --> SourceObjects
+    LI --> SourceObjects
+    JI --> SourceObjects
+
+    Issue --> WorkItem
+    PRMR --> WorkItem
+    Commit -. "linked through PR/MR" .-> PRMR
+    PRMR --> Dependency
+    Team --> Ownership
+    Project --> Ownership
+    Member --> Ownership
+
+    WorkItem --> WorkItems
+    Dependency --> Dependencies
+    Ownership --> Teams
+    Ownership --> Memberships
+    Ownership --> ProjectOwnership
+    Ownership --> RepoOwnership
+
+    WorkItems --> R0
+    Teams --> R0
+    ProjectOwnership --> R1
+    RepoOwnership --> R1
+    Memberships --> R1
+    Dependencies --> R2
+    WorkItems --> R2
+    ManualFallbacks --> R3
+
+    R0 --> Attributions
+    R1 --> Attributions
+    R2 --> Attributions
+    R3 --> Attributions
+    R4 --> Attributions
+
+    Attributions --> API
+    API --> Web
+    Web --> Reports
+
+    PG["Postgres<br/>auth / org / config only"] -. "must NOT feed attribution" .-> Resolver
+```
+
+### 1.7 Data object hierarchy
+
+```mermaid
+flowchart TD
+    Org["Organization"]
+
+    Org --> Providers["WTI providers"]
+    Providers --> GitHub["GitHub"]
+    Providers --> GitLab["GitLab"]
+    Providers --> Linear["Linear"]
+    Providers --> Jira["Jira"]
+
+    Org --> Identity["Identity & ownership facts (ClickHouse)"]
+    Identity --> Teams["teams"]
+    Identity --> Members["members"]
+    Identity --> Projects["projects"]
+    Identity --> Repos["repos"]
+
+    Teams --> TeamMemberships["team_memberships"]
+    Projects --> ProjectOwnership["team_project_ownership"]
+    Repos --> RepoOwnership["team_repo_ownership"]
+
+    Org --> WorkGraph["Work graph"]
+    WorkGraph --> Issues["issues<br/>canonical work units"]
+    WorkGraph --> PRMR["pull / merge requests<br/>code-change evidence"]
+    WorkGraph --> Commits["commits<br/>lower-level evidence"]
+
+    Issues --> IssueFacts["native issue facts<br/>team / project / member"]
+    PRMR --> PRFacts["PR/MR facts<br/>repo / author / linked issue refs"]
+    Commits --> CommitFacts["commit facts<br/>author / repo / parent PR when available"]
+
+    PRMR --> DependsOnIssue["work_item_dependencies<br/>PR/MR → issue (actual donor row)"]
+    Commits --> DependsOnPR["work_item_dependencies<br/>commit → PR/MR"]
+
+    Org --> Manual["manual_attribution_fallbacks"]
+    Manual --> ManualScopes["scope<br/>repo / project / member / issue_key_prefix"]
+
+    Org --> Attribution["work_item_team_attributions"]
+    Attribution --> AttributionSource["source (8-level precedence)"]
+    Attribution --> AttributionConfidence["confidence"]
+    Attribution --> AttributionEvidence["evidence"]
+    Attribution --> PrimaryTeam["is_primary winner"]
+
+    IssueFacts --> Attribution
+    ProjectOwnership --> Attribution
+    RepoOwnership --> Attribution
+    TeamMemberships --> Attribution
+    DependsOnIssue --> Attribution
+    Manual --> Attribution
+```
+
+### 1.8 Source reference matrix (forward navigation)
+
+| # | `source` | Resolves from (ClickHouse) | Confidence | Beats | Never overrides | Evidence keys |
+|--:|---|---|---|---|---|---|
+| 0 | `native_team` | `WorkItem.native_team_key` → `teams` | high | all below | — (top) | `native_team_key` |
+| 1 | `issue_project` | native issue project → owning team | high | 2–7 | 0 | `project_id, owner_team` |
+| 2 | `project_ownership` | `team_project_ownership` | high | 3–7 | 0–1 | `project_id, provider` |
+| 3 | `repo_ownership` | `team_repo_ownership` | medium | 4–7 | 0–2 | `repo_full_name` |
+| 4 | `assignee_membership` | `team_memberships` (assignee identity) | medium | 5–7 | 0–3 | `member_id, identity` |
+| 5 | `linked_issue` | `work_item_dependencies` donor → donor's team | high (donor's) | 6–7 | 0–4 | `dependency_type, donor_work_item_id, donor_provider` |
+| 6 | `manual_fallback` | `manual_attribution_fallbacks` (repo/project/member/issue_key_prefix) | manual\|low | 7 only | 0–5 | `scope_type, scope_id, reason` |
+| 7 | `unassigned` | — (nothing matched) | none | — (floor) | — | `reason` |
+
+### 1.9 Off-the-rails matrix (symptom → diagnosis → fix)
+
+When attribution looks wrong, find the symptom, jump to the stage, apply the fix.
+
+| Symptom | Likely stage | Diagnose | Fix / owning CS |
+|---|---|---|---|
+| A whole org is `unassigned` | 7 (floor) | `get_all_teams()` empty? CH `teams` populated for `org_id`? | CS5 regression — re-home teams population; verify daily-chain order |
+| PR attributed to a surprising team via `linked_issue` | 5 | which `work_item_dependencies` edge? donor's own team? extkey ambiguous? | confirm donor row + `_canonical_target`; check `_INHERITABLE_RELATIONSHIP_TYPES` |
+| `manual_fallback` beats a real team | precedence | `_SOURCE_ORDER` has `manual_fallback=6`? loader merging manual at the wrong rank? | restore rank — manual is the lowest non-unassigned tier (CS2/CS3) |
+| A bare prefix (e.g. `CHAOS`) attributes as `linked_issue` | 5 vs 6 | did a full key resolve to a real `work_items` row, or did a prefix shortcut leak in? | **R1 invariant** — no prefix→team in `linked_issue`; route to manual `issue_key_prefix` (CS3) |
+| Team flips back and forth after a re-org | RMT dedup | duplicate ownership rows; read lacks `FINAL`/`argMax` | add `FINAL`/`argMax` to ownership + manual reads (CS3 §4.6) |
+| Provenance absent in the API | GraphQL | resolver SELECTs the provenance columns? SDL has the fields? | CS4 — expose `source/confidence/evidence` |
+| Web shows a different team than the backend | client recompute | any client-side mapping derived from `evidence`? | CS7 — delete `buildRepoTeamSankey`; render-only |
+
+### 1.10 Provider × entity test-coverage contract
+
+Attribution is **provider-agnostic** (the resolver never branches on provider) — so it must be
+**tested** that way. Every WTI provider × normalized entity must be covered; **no Linear-only
+coverage.** Current state (5-agent audit, 2026-06-22):
+
+| provider \ entity | teams | projects | members | issues |
+|---|---|---|---|---|
+| jira   | partial | partial | partial | yes |
+| gitlab | partial | yes     | **no**  | yes |
+| github | yes     | n/a¹    | yes     | yes |
+| linear | yes     | partial | yes     | yes |
+
+`yes` = normalized + asserted · `partial` = sink/integration only (no normalizer unit test) · `no` =
+normalized but never asserted · `n/a` = provider lacks the entity. ¹ GitHub has no native Project.
+
+> **This matrix tracks TEST coverage, not consumption.** We functionally pull teams, projects, and
+> members for every provider that supports them (auto-import). A `partial`/`no` cell = "not yet
+> asserted," NOT "not consumed." (Conflating the two produced a false "Linear projects not ingested"
+> reading 2026-06-22.)
+
+**Consumption matrix (functional — what `run_team_autoimport` pulls):**
+
+| provider | teams | projects | members | repo ownership | member store |
+|---|---|---|---|---|---|
+| linear | ✓ `discover_linear` | ✓ `assoc.project_keys` | ✓ `discover_members_linear` | — | edges + roster |
+| jira   | ✓ `discover_jira` | ✓ `assoc.project_keys` | ✓ `discover_members_jira_bulk` | — | edges + roster |
+| github | ✓ `discover_github` | n/a (repo = scope) | ✓ `discover_members_github` | ✓ `team_repo_ownership` | edges (+ roster, CS-COV) |
+| gitlab | ✓ `discover_gitlab` | ✓ (project paths) | ✓ `discover_members_gitlab` | — | edges (+ roster, CS-COV) |
+
+Two member stores: **`team_memberships` (edges)** — written by all 4, read by the ladder
+(`loaders/clickhouse.py:449-485` → `member_by_identity` → `assignee_membership`,
+`compute_work_items.py:415-422`); this is the canonical attribution source, all 4 consume here.
+**`teams.members` (roster)** — linear/jira auto-import + admin surgical-replacement (CS5); read by the
+secondary `TeamResolver` + admin/display. **CS-COV adds github/gitlab roster population** ("pull
+members of orgs and teams from github and gitlab", user decision 2026-06-22). Chain: members →
+assignee → issues → PRs/MRs → (maybe) commits; commit authors are a separate git-side source,
+member↔author reconciliation deferred.
+
+- The **resolver row** is multi-provider (CS2: `test_jira_issue_project_wins_over_linked_issue`,
+  `test_assignee_membership_wins_over_jira_linked_donor`, plus GitHub/GitLab/Linear donor + ownership
+  tests). The **dimension** (team/project/member autoimport) is the gap — and because jira/github/
+  gitlab carry `native_team_key=None`, it is the single point of failure for non-Linear attribution.
+- **Gaps → CHAOS-2609 (CS-COV):** gitlab/members normalized-but-never-asserted (high), gitlab epics
+  untested (high), jira team/project/member sink-only (medium), linear native projects not ingested
+  (medium). The matrix must reach all-`yes`/`n/a` (acceptance §6).
+- Canonical, ships-in-repo copy: `team-attribution.md §0.4`; guardrail in root + ops `AGENTS.md`.
+
+---
+
+## 2. Decision gates (resolve BEFORE writing code)
+
+### D1 — `external_issue_key` re-routing — **RESOLVED: R1 (verified in code 2026-06-22)**
+
+Phase 5 forbids `PR text "CHAOS-123" → prefix "CHAOS" → team` as `linked_issue`. The concern was
+that `external_issue_key` text-parsed edges are **today the only** cross-provider PR→issue donor
+mechanism for GitHub PRs and GitLab MRs (only Linear has a native-attachment donor row;
+`linear/normalize.py:152-187`), so dropping them would silently zero non-Linear PR→issue
+inheritance.
+
+**Code verification (`build_linked_issue_team_resolver`, `compute_work_items.py:412-496`):**
+- `key_index` is built **only** from real Linear/Jira `work_items` rows (`:425-434`).
+- `_canonical_target("extkey:CHAOS-2400")` → `key_index.get("CHAOS-2400")` → **None** when no such
+  work item exists (`:436-440`).
+- The candidate loop **skips** any falsy target (`:486 if not target_id: continue`) **and** any
+  target whose donor work item did not itself resolve to a real team (`:488-489`).
+- Therefore a `linked_issue` attribution is **impossible** without (a) an inheritable edge, (b) the
+  bare key resolving to an actual `work_items` row, and (c) that row having its own resolved team.
+- The forbidden `"CHAOS" prefix → team` shortcut **does not exist** in the `linked_issue` path.
+  Prefix→team only lives in `ProjectKeyTeamResolver` (`providers/teams.py:76-93`), which feeds
+  `native_team`/`issue_project`/`project_ownership` — never `linked_issue`.
+
+**Conclusion (R1).** Phase 5's "linked issue requires an actual donor row" and "issue-key prefix is
+not linked-issue inheritance" are **already satisfied** by the existing donor-row enforcement. So:
+- **No extraction-layer change.** `external_issue_key` stays in `_INHERITABLE_RELATIONSHIP_TYPES`
+  (`:375-377`); it already demands a real donor → emits `linked_issue` (now demoted to rank 5).
+- The **only** net-new prefix work is CS3's `manual_fallback` `issue_key_prefix` scope, used only
+  when **no** donor row resolves (the case that today falls to `unassigned`).
+- R2 (drop all text-parsed edges) was rejected: it would *remove* a satisfied-and-intended
+  capability (the Linear branch-convention recovery, `github/normalize.py:860`) and reduce
+  attribution coverage for **no** correctness gain.
+
+### D2 — staged functions vs. re-ranked dict — **DECIDED**
+The doc prefers explicit staged resolution; the current code uses a numeric `_SOURCE_ORDER` loop
+that **emits all candidates** (the schema persists the full set). A naive staged short-circuit
+would regress provenance rows (`test_team_attribution_schema.py`). **Decision:** keep full
+candidate emission; express precedence as staged winner-selection backed by the (re-ranked,
+8-value) `_SOURCE_ORDER`. Best of both; no provenance regression.
+
+---
+
+## 3. Changeset sequence
+
+Eight changesets (= eight PRs), ordered to respect the migration/runtime ordering risks in §4.
+`ops` and `web` are separate repos; ops changes (CS4) must reach **ops main** before the web
+changeset (CS7) can pass the schema exact-diff. Each CS lists: **Goal · Files · Validation ·
+Codex gate · Alignment check.**
+
+> **Branch strategy.** Cut an integration branch per repo
+> (`fix/clickhouse-only-team-attribution`) off `origin/main`; stack each CS as its own PR onto the
+> integration branch (squash), merge integration → main at the end. Never push to `main`
+> (project rule). Push the branch *then* `gh pr create --head <branch> --base <integration>`.
+
+---
+
+### CS0 — Contract & guardrails (ops + web + root AGENTS)  ·  *low risk, lands first*
+
+**Goal.** Establish the north-star contract and the doc-freshness gate that holds every later PR.
+**Files.**
+- `AGENTS.md` (root), `ops/AGENTS.md`, `web/AGENTS.md`: add the **"Team attribution source of
+  truth"** invariant (§1.1/1.3) and the **"Documentation freshness requirement"** guardrail +
+  PR-checklist items (Phase 9/11 text).
+- `ops/docs/architecture/team-attribution.md`: add the **target** precedence + provenance contract
+  (§1.2/1.4), clearly marked *"target state — implemented across CHAOS-2600 CS1–CS7"* so it does
+  not claim not-yet-shipped behavior as done.
+
+**Validation.** Markdown only; `ci/run_tests.sh format` (web) / docs lint if present. No code.
+**Codex gate.**
+```
+/codex:adversarial-review --base fix/clickhouse-only-team-attribution --background \
+  "Challenge whether this contract is internally consistent and complete: precedence order,
+   provenance enum, source-of-truth statement, and whether the doc-freshness guardrail is
+   enforceable. Find any invariant that later code cannot actually satisfy."
+```
+**Alignment check.** Contract text == §1 of this plan, verbatim where possible.
+
+---
+
+### CS1 — ClickHouse schema foundations (ops)  ·  *additive, no behavior change*
+
+**Goal.** Land the storage the later resolver needs, with **zero** behavior change (table empty,
+enums merely widened).
+**Files.**
+- `ops/src/dev_health_ops/migrations/clickhouse/053_manual_attribution_fallbacks.sql` (next free
+  number; lexicographic order). `CREATE TABLE IF NOT EXISTS manual_attribution_fallbacks` per
+  Phase 2 DDL, `ReplacingMergeTree(updated_at)`, **`org_id` leading in `ORDER BY`**
+  (`PARTITION BY org_id`, `ORDER BY (org_id, provider, scope_type, scope_id, team_id)`).
+- Same migration: `ALTER TABLE work_item_team_attributions MODIFY COLUMN source Enum8(...)` to add
+  `issue_project` and `manual_fallback`; `MODIFY COLUMN confidence Enum8(...)` to add `manual`,
+  `none` (apply the same `confidence` widening to the three edge tables if they share the enum).
+- `ops/src/dev_health_ops/storage/clickhouse.py`: add `insert_manual_attribution_fallbacks`
+  (mirror `_insert_team_edge_rows` / `insert_work_item_team_attributions`, explicit column list,
+  `org_id` auto-injection).
+- `ops/src/dev_health_ops/metrics/sinks/base.py`: add `write_manual_attribution_fallbacks` to the
+  sink protocol + base impl.
+
+**Validation.**
+- `cd ops && dev-hops migrate clickhouse upgrade` (force path) then `... status --check` (the wait primitive).
+- Insert a fallback row; round-trip read; assert the new `source`/`confidence` enum values accept
+  inserts (an INSERT of `source='manual_fallback'` must **not** throw).
+- **Rebuild the worker/beat image** before any worker-path verification (`worker_stale_image` —
+  baked site-packages); `AUTO_RUN_MIGRATIONS=false` in workers, so the ALTER must be applied
+  explicitly.
+- `cd ops && mypy --install-types --non-interactive .` + `ci/run_tests.sh ... unit` (CI-parity).
+**Codex gate.**
+```
+/codex:adversarial-review --base fix/clickhouse-only-team-attribution --background \
+  "Migration safety: is the Enum8 ALTER on work_item_team_attributions.source/confidence safe and
+   backward-compatible? Will any in-flight writer emit a value the pre-ALTER enum rejects? Does the
+   new manual_attribution_fallbacks table put org_id first in ORDER BY, dedup correctly under
+   ReplacingMergeTree, and avoid the empty top-level migrations/ decoy dir? Idempotency of
+   CREATE/ALTER on re-run."
+```
+**Alignment check.** `grep` confirms migration lives under
+`src/dev_health_ops/migrations/clickhouse/` (not the empty top-level decoy). Enum values match §1.4 exactly.
+
+---
+
+### CS2 — Precedence rewrite + `issue_project` + `linked_issue` demotion (ops)  ·  *core fix*
+
+**Goal.** Make `linked_issue` a true low-precedence fallback; introduce `issue_project`; preserve
+full candidate emission.
+**Files.**
+- `ops/src/dev_health_ops/metrics/compute_work_items.py`:
+  - Extend `TeamAttributionSource` Literal (`:61-68`) with `issue_project`, `manual_fallback`.
+  - Re-rank `_SOURCE_ORDER` (`:105-112`) to the 8-value order in §1.2.
+  - Add an `issue_project` candidate constructor (native issue's project; distinct from imported
+    `project_ownership`). `WorkItem` already separates `native_team_key`/`project_key`
+    (`models/work_items.py:59-60`).
+  - Reconcile the misleading `specificity` values (`linked_issue=90`, `project=50`, `native=100`)
+    so within-source tiebreaks don't imply cross-source strength.
+  - Keep emitting **all** candidates; only winner selection changes (D2).
+- Tests (`ops/tests/test_linked_issue_team_inheritance.py`):
+  - **Invert** the three precedence tests that encode the bug:
+    `test_linked_issue_wins_over_assignee_membership` (`:378`),
+    `test_state_duration_linked_issue_wins_over_assignee_membership` (`:411`),
+    the `is_primary` assertions in `test_compute_emits_attribution_candidates_and_primary_cycle_team` (`:458-503`).
+  - **Add** new coverage the suite lacks: `project_ownership` beats `linked_issue`,
+    `repo_ownership` beats `linked_issue`, `assignee_membership` beats `linked_issue`,
+    `issue_project` beats `linked_issue`.
+  - Keep `test_inheritance_never_overrides_native_team` (`:112`) **green** (native stays rank 0).
+  - **Do not touch** `test_team_reconcile_guards.py` (unrelated — reconcile, not precedence) or
+    `test_team_attribution_schema.py` (sink shape).
+- Docs (same PR): `ops/docs/architecture/data-pipeline.md` §4 + `team-attribution.md` cascade —
+  reorder so `linked_issue` is below imported ownership; stop citing `IdentityMapping.team_ids` as
+  the membership source (it becomes CH ownership).
+
+**Validation.** `mypy` + full `ci/run_tests.sh ... unit` incl. `@pytest.mark.clickhouse` where the
+resolver hits live CH; assert provenance candidate rows still emit (no regression vs schema test).
+**Codex gate.**
+```
+/codex:adversarial-review --base fix/clickhouse-only-team-attribution --background \
+  "Precedence correctness: does the new _SOURCE_ORDER make linked_issue lose to native/imported
+   AND still beat unassigned? Does any path still let linked_issue or a bare prefix win over
+   ownership? Did full candidate emission (is_primary on the full set) survive the winner-selection
+   rewrite, or did we silently drop provenance rows? Is issue_project distinct from project_ownership
+   and not double-counting? Tenant org_id scoping intact on every read?"
+```
+**Alignment check.** Drift grep: `_SOURCE_ORDER` equals §1.2 byte-for-byte; no test asserts
+`linked_issue` winning over any imported/native source.
+
+---
+
+### CS3 — Manual-fallback resolver (ops)  ·  *net-new resolution path*
+
+**Goal.** Read `manual_attribution_fallbacks`, match scopes, emit `source = manual_fallback` as the
+lowest non-unassigned tier — never an override.
+**Files.**
+- `ops/src/dev_health_ops/metrics/loaders/clickhouse.py`: extend `load_team_attribution_context`
+  (`:359-443`) to SELECT manual fallbacks **with `FINAL`/`argMax(...) GROUP BY` dedup** (the
+  existing ownership reads lack dedup — see §4; harden them in the same PR). Implement scope
+  matching for `repo`/`project`/`member` and the **new** `issue_key_prefix` matcher (match a work
+  item's *referenced* keys' prefix → team) — this is the most novel logic; it only fires when no
+  donor row resolved.
+- `ops/src/dev_health_ops/metrics/compute_work_items.py`: emit a `manual_fallback` candidate
+  (rank 6) with `confidence ∈ {manual, low}` and `evidence` showing the matched fallback record
+  (Phase 6 example shape).
+- Tests: `manual_fallback` does **not** override native/linked; manual applies only when nothing
+  stronger exists; `issue_key_prefix` **without** a donor does not inherit `linked_issue`;
+  `issue_key_prefix` **can** match `manual_fallback` only (Phase 7 replacement test names).
+
+**Validation.** `mypy` + unit + clickhouse-marked; verify a seeded prefix fallback resolves to
+`manual_fallback` and a real donor still wins over it.
+**Codex gate.**
+```
+/codex:adversarial-review --base fix/clickhouse-only-team-attribution --background \
+  "Manual fallback must never override: prove no scope (repo/project/member/issue_key_prefix) can
+   beat native/imported/linked. Does the issue_key_prefix matcher match the right work items and
+   not over-match (e.g. CHAOS vs CHAOSX)? Is the new read FINAL/argMax-deduped so a stale RMT row
+   can't win? org_id in every predicate? Does a dangling extkey with no donor correctly fall to
+   manual_fallback rather than silently inheriting linked_issue?"
+```
+**Alignment check.** Re-run §5 drift checklist; confirm `evidence` populated for every
+`manual_fallback`/`linked_issue`/`unassigned` per Phase 6 examples.
+
+---
+
+### CS4 — Provenance in GraphQL (ops)  ·  *must reach ops main before CS7*
+
+**Goal.** Expose the persisted provenance the data layer already has.
+**Files.**
+- `ops/src/dev_health_ops/api/graphql/models/outputs.py`: new `@strawberry.type` provenance fields
+  (`team_attribution_source/confidence/evidence`, `is_primary`) — mirror the existing
+  `WorkGraphProvenance` pattern (`outputs.py:544`).
+- `ops/src/dev_health_ops/api/graphql/resolvers/analytics.py` (and/or `data_health.py`): SELECT the
+  provenance columns from `work_item_team_attributions` (persisted but never read today).
+- `ops/src/dev_health_ops/api/graphql/export_schema.py`: regenerate the SDL (driver for CS7).
+
+**Validation.** `mypy` + GraphQL resolver tests; `python -m dev_health_ops...export_schema`
+produces the SDL the web side will diff against.
+**Codex gate.**
+```
+/codex:adversarial-review --base fix/clickhouse-only-team-attribution --background \
+  "Does exposing provenance leak cross-tenant data or over-expose internal evidence? Are the new
+   Strawberry fields nullable-correct and ordered so the SDL is deterministic? Does the resolver
+   SELECT keep org scoping and argMax-dedup on work_item_team_attributions?"
+```
+**Alignment check.** SDL captured for CS7; provenance fields == §1.4.
+
+---
+
+### CS5 — Re-home team population, remove the bridge (ops)  ·  *highest structural risk*
+
+**Goal.** Delete the Postgres→CH bridge (`sync_teams_to_analytics` / `bridge_teams_to_clickhouse`)
+and make org-scoped team population write the ClickHouse `teams` dimension **directly** — **without**
+emptying the dimension the resolvers read. **Nothing else changes:** the sync operations (`sync
+teams` and the per-entity team/project/member sync) and the **"Auto Import" UX option** (checkboxes
+that run `run_team_autoimport` to import teams/projects/members CH-native) stay as-is — they already
+write ClickHouse directly. This CS removes *only* the Postgres-bridge path. Manual fallback (CS3) is
+the separate explicit-override option.
+**Files.**
+- `ops/src/dev_health_ops/providers/teams.py`: rewrite the org-scoped path (`:635-720`) to write CH
+  `teams` directly via the existing CH-native write (the no-org direct path `:722-745` already does
+  this), dropping `_project_teams_to_postgres` + `bridge_teams_to_clickhouse`. Preserve the row shape
+  exactly (deterministic `team_uuid = uuid5("team:{org}:{team_id}")`, `members`, `project_keys`,
+  `repo_patterns`) or `get_all_teams()`-based resolvers break.
+- Neutralize the bridge's other callers **first**: `workers/product_tasks.py:sync_teams_to_analytics`
+  (in the daily chain `sync_runtime.py:392-408`) → repoint to a CH-native team refresh or remove
+  from the chain; admin enqueues in `api/admin/routers/teams.py` + `identities.py`.
+- Hard-deprecate `dev-hops teams reconcile` (`providers/team_reconcile.py`) → exit-non-zero stub
+  ("Team attribution is ClickHouse-only"); remove its `_COMMAND_REQUIREMENTS` entry (`cli.py:420`).
+- Triage `api/services/configuration/jira_activity_inference.py` (uses `IdentityMappingService`) —
+  it will ImportError when CS6 deletes the service; decide here (rewrite to CH or remove).
+- **Delete `providers/team_bridge.py`** only after all four import sites are re-homed.
+- Docs (same PR): `ops/docs/ops/cli-reference.md` (`sync teams` is CH-only; drop `teams reconcile`)
+  + `ops/docs/architecture/database-architecture.md` (remove the "Postgres-first source of truth"
+  section + both Mermaid bridge diagrams `:140-211`).
+
+**Validation.**
+- Live proof on a real org via host `dev-hops` (`.venv/bin/dev-hops`, explicit DSNs): run
+  `sync teams --org <org>`, assert ClickHouse `teams` is **populated** (members/project_keys/
+  repo_patterns non-empty), then run the daily metrics chain and assert team attribution is
+  **non-empty** (no silent degrade to unassigned). Use a control org with `org_id=''` checks.
+- Rebuild worker/beat/web images before verifying the chain.
+- `mypy` + `ci/run_tests.sh ... unit`; update `test_team_members_bridge.py`,
+  `test_team_reconcile_guards.py`, `test_sync_teams_routing_invariants.py`.
+**Codex gate.**
+```
+/codex:adversarial-review --base fix/clickhouse-only-team-attribution --background \
+  "Data-loss hunt: after deleting the bridge, can the ClickHouse teams dimension end up empty or
+   stale for an org-scoped sync, silently zeroing attribution? Are ALL bridge import sites
+   (teams.py, team_reconcile.py, product_tasks.py, sync_team.py) and the daily Celery chain
+   re-homed, or does run_daily_metrics now run before teams are populated? Does the direct-CH write
+   reproduce the exact team_uuid/members/project_keys/repo_patterns shape the resolvers require?
+   Any dangling import or broken admin enqueue?"
+```
+**Alignment check.** `grep -R "bridge_teams_to_clickhouse" ops/src` → no runtime callers;
+daily chain populates `teams` before metrics.
+
+---
+
+### CS6 — Delete Postgres mapping models & admin surface (ops)
+
+**Goal.** Remove the now-unread Postgres attribution layer entirely.
+**Files.**
+- Delete `TeamMapping`/`IdentityMapping` (`models/settings.py:571-730`) + re-exports
+  (`models/__init__.py:53/64/112/159`).
+- Delete config-CRUD that exists only to feed them: `api/services/configuration/{team_mapping,
+  identity_mapping,team_drift_sync,team_discovery,team_member_resolver}.py` and the mapping
+  portions of `team_membership.py`; admin endpoints in `routers/teams.py` + `identities.py`;
+  schemas in `admin/schemas_flat.py:210-321` + re-exports.
+- Rewrite `api/graphql/resolvers/data_health.py` `IdentityMappingHealth` (`:157-219`) — drop or
+  re-source off CH.
+- Rewrite `api/services/org_deletion.py` — remove the `team_mappings`/`identity_mappings`
+  `PostgresDeletionTarget` entries (`:275-282`) + model imports (`:33/41`); keep the CH `teams`
+  purge.
+- **New Alembic migration** to `DROP TABLE team_mappings, identity_mappings` (created only in
+  `alembic/versions/0001_initial_schema.py:278-371`; do not edit that inert history). The DROP must
+  run after the ORM models leave metadata.
+- Docs (same PR): finalize `database-architecture.md` (tables removed from the Postgres list).
+
+**Validation.** `grep -R "TeamMapping\|IdentityMapping" ops/src ops/tests` → no runtime/admin
+attribution usage (inert migration refs OK); `mypy` clean (no dangling imports);
+`alembic upgrade head` then `downgrade` round-trips; admin + org-deletion tests pass.
+**Codex gate.**
+```
+/codex:adversarial-review --base fix/clickhouse-only-team-attribution --background \
+  "Deletion safety: is there ANY remaining runtime/admin/worker importer of TeamMapping or
+   IdentityMapping (e.g. jira_activity_inference, data_health, _helpers re-exports)? Does the
+   Alembic DROP run after the models leave metadata, and is downgrade coherent? Does org_deletion
+   still purge correctly without the dropped tables/imports? Any admin route now 500s?"
+```
+**Alignment check.** §5 drift checklist: the three `grep` acceptance commands return no runtime hits.
+
+---
+
+### CS7 — Web: provenance render + boundary + dead-code deletion (web)  ·  *after CS4 on ops main*
+
+**Goal.** Render backend provenance; delete the client-side attribution; document the boundary.
+**Files.**
+- Regenerate `web/src/lib/graphql/schema.graphql` from **ops `export_schema` on ops main**
+  (never hand-edit — exact-diff incl. docstrings + ordering); regenerate `__generated__/*`.
+- Surface provenance (render-only) in the investment/data-health surfaces; show `manual_fallback`
+  as a distinct lower-confidence label (never as issue/team truth).
+- **Delete** `web/src/lib/investment/transforms.ts:buildRepoTeamSankey` (`:374-523`) + its
+  `repoTeamMap`/evidence-derivation block (orphaned boundary violation; verified no live caller).
+- **Create** `web/docs/architecture/team-attribution-boundary.md` — **ready-to-drop content in
+  Appendix A** (Phase 10 text + a frontend-facing compact decision tree so the boundary is visible
+  to web devs "for insurance"); link it from `web/AGENTS.md` and
+  `web/docs/user-journeys/investment-view.md`.
+
+**Validation.** `web` gate = tsc + vitest + **Playwright e2e** (copy/label/nav changes break specs;
+self-contained harness) + design-lint + **prettier-write before push** (Format check). Confirm the
+schema exact-diff is green (only possible once CS4 is on ops main).
+**Codex gate.**
+```
+/codex:adversarial-review --base fix/clickhouse-only-team-attribution --background \
+  "Boundary enforcement: does ANY client path still recompute team attribution after deleting
+   buildRepoTeamSankey? Is web/schema.graphql byte-exact with ops main export_schema (docstrings +
+   ordering), or will the live-e2e exact-diff fail? Does manual_fallback render as fallback, not as
+   team truth? Any e2e spec asserting removed text?"
+```
+**Alignment check.** `grep` web for client-side team derivation → none; boundary doc linked.
+
+---
+
+## 4. Cross-cutting ordering rules (must not be reordered)
+
+1. **Enum ALTER before any new-value write** (CS1 → CS2/CS3). Workers run
+   `AUTO_RUN_MIGRATIONS=false`; apply the ALTER explicitly and **rebuild worker/beat**. Emitting
+   `source='manual_fallback'`/`confidence='manual'` before the ALTER → CH INSERT throws.
+2. **`manual_attribution_fallbacks` table before its reader** (CS1 → CS3). A missing table → throw
+   or silent `[]` degrade.
+3. **Re-home bridge callers before deleting the bridge** (CS5 internal order). The bridge sits
+   *first* in the daily chain; delete-before-rehome breaks per-org daily metrics at runtime.
+4. **Delete models only after they're unread** (CS5 → CS6). CS5 makes Postgres mappings
+   written-but-unread; CS6 removes the write surface + models + Alembic DROP together.
+5. **ops schema → ops main before web SDL regen** (CS4 → CS7). The live-e2e exact-diff fails if web
+   SDL is regenerated from an ops *branch*. → ops-first, web-second is mandatory (overrides any
+   naive "same-PR" reading of Phase 11; the two-repo split is the same-PR unit per repo).
+6. **Harden RMT dedup on ownership + manual reads.** `load_team_attribution_context` reads
+   ownership with **no `FINAL`/`argMax`** today; once ownership outranks `linked_issue`, a stale
+   duplicate wins *more often*. Add dedup to the manual read (CS3) and harden the three ownership
+   reads in the same PR.
+
+---
+
+## 5. Standing alignment checklist (run on EVERY PR before its codex gate)
+
+This is the "stay aligned" harness — a fast drift scan plus the doc-freshness rule.
+
+```bash
+# Precedence is exactly the target (after CS2)
+grep -n "_SOURCE_ORDER" -A10 ops/src/dev_health_ops/metrics/compute_work_items.py
+#   → native_team0 issue_project1 project_ownership2 repo_ownership3
+#     assignee_membership4 linked_issue5 manual_fallback6 unassigned7
+
+# No runtime Postgres attribution (after CS6)
+grep -RIn "TeamMapping\|IdentityMapping" ops/src        # → no runtime/admin attribution hits
+grep -RIn "bridge_teams_to_clickhouse" ops/src          # → no callers (after CS5)
+
+# No client-side attribution (after CS7)
+grep -RIn "buildRepoTeamSankey\|repoTeamMap" web/src     # → none
+
+# Provider × entity coverage is multi-provider, not Linear-only (matrix: team-attribution.md §0.4)
+grep -REc 'jira:|gitlab:|"jira"|"gitlab"|"github"' ops/tests/test_linked_issue_team_inheritance.py
+#   → attribution tests exercise jira/gitlab/github donors+items, not just linear
+
+# Docs changed in the same PR as behavior (Phase 11)
+git diff --name-only <base>...HEAD | grep -q '^ops/docs/\|AGENTS.md' || echo "DOC DRIFT: behavior change without doc update"
+```
+
+Plus, every PR must satisfy:
+- [ ] Tests assert the documented precedence order (not the old one).
+- [ ] **Provider × entity matrix kept green** — attribution tests cover `{jira,gitlab,github,linear} × {teams,projects,members,issues}`; no Linear-only coverage (matrix: `team-attribution.md §0.4`).
+- [ ] Attribution output carries `source` + `confidence` + `evidence`.
+- [ ] CI-parity gates run **locally** before push (ops: `mypy --install-types --non-interactive .`
+      + `ci/run_tests.sh format quality unit`; web: tsc + vitest + Playwright e2e + design-lint +
+      prettier-write).
+- [ ] `/codex:adversarial-review` run for the changeset; output captured to
+      `/tmp/claude/codex-review-<branch>.md`; every blocking finding fixed or explicitly waived
+      with rationale.
+- [ ] Relevant architecture/CLI/boundary docs updated **in this PR**.
+
+---
+
+## 6. Final acceptance gate (maps Phase-13 acceptance criteria → proof)
+
+CHAOS-2600 is done only when each row passes:
+
+| # | Acceptance criterion | Proof |
+| --: | --- | --- |
+| 1 | No runtime attribution reads Postgres team mappings | `grep` (CS6) + CS5/CS6 codex gates |
+| 2 | No runtime attribution reads Postgres identity mappings | `grep` (CS6) |
+| 3 | `team_bridge.py` deleted (or hard-deprecation only) | CS5 — file removed |
+| 4 | No Postgres→CH team bridge remains | CS5 grep |
+| 5 | Manual mappings stored in ClickHouse only | CS1 table + CS3 reader |
+| 6 | Manual mappings emit `source = manual_fallback` | CS3 test |
+| 7 | `linked_issue` lower precedence than native/imported | CS2 `_SOURCE_ORDER` + tests |
+| 8 | `linked_issue` requires an actual donor row | preserved `build_linked_issue_team_resolver`; CS3 test |
+| 9 | Issue-key prefix is **not** linked-issue inheritance | CS3 test (D1/R1) |
+| 10 | Issue-key-prefix fallback emits `manual_fallback` | CS3 test |
+| 11 | Output includes source + confidence + evidence | CS2/CS3 + CS4 GraphQL |
+| 12 | Tests explicitly protect the precedence model | CS2/CS3 inverted + new tests |
+| 13 | Backend docs state ClickHouse-only attribution | CS0/CS2/CS5/CS6 docs |
+| 14 | Frontend docs state UI never resolves attribution | CS7 boundary doc |
+| 15 | Doc-freshness enforced in AGENTS/PR checklist | CS0 guardrail |
+| 16 | Any attribution change updates docs in same PR | §5 drift check, every PR |
+| 17 | Tests and docs describe the same precedence | CS2 alignment check |
+| 18 | No backfill/migration-retention/compat path for PG attribution | CS5/CS6 — none added |
+| 19 | Provider × entity test matrix all `yes`/`n/a` (no Linear-only coverage) | `team-attribution.md §0.4` matrix green; CS-COV (CHAOS-2609) |
+
+**Final adversarial pass.** Before declaring done, run one full-branch
+`/codex:adversarial-review --base origin/main --background "Whole-epic ship/no-ship: is ClickHouse
+truly the only attribution store, is precedence correct end-to-end, and is there any silent
+attribution-coverage regression for GitHub/GitLab PR→issue inheritance under R1?"`
+
+---
+
+## 7. Risk register
+
+| Risk | Mitigation |
+| --- | --- |
+| Deleting bridge silently empties CH `teams` → attribution → unassigned | CS5 live-org proof (populate → daily → non-empty); codex data-loss gate |
+| `external_issue_key` re-routing severs GitHub/GitLab PR→issue inheritance | D1/R1 keeps donor-resolving extkeys; only bare-prefix-no-donor → manual; codex coverage gate |
+| Enum ALTER vs. worker emitting new values | Ordering rule §4.1; rebuild worker/beat; explicit migrate |
+| Stale RMT duplicate wins now that ownership outranks linked | §4.6 add `FINAL`/`argMax` dedup |
+| web schema exact-diff fails (regen from ops branch) | §4.5 ops-main-first; never hand-edit SDL |
+| `jira_activity_inference` ImportError on model delete | CS5 triage before CS6 deletion |
+| Provenance regression (dropped candidate rows in staged rewrite) | D2 keep full candidate emission; codex CS2 gate |
+
+---
+
+## 8. Suggested commit/PR titles (per the doc's sequence)
+
+```
+CS0  docs: define clickhouse-only team attribution contract + doc-freshness guardrail
+CS1  feat(clickhouse): manual_attribution_fallbacks table + source/confidence enum widening
+CS2  fix(metrics): demote linked_issue, add issue_project, lock precedence
+CS3  feat(metrics): manual_fallback resolver (incl. issue_key_prefix) with provenance
+CS4  feat(graphql): expose team attribution provenance (source/confidence/evidence)
+CS5  refactor(teams): write ClickHouse directly; remove postgres team bridge
+CS6  chore(models): delete postgres team/identity mappings + admin surface + alembic drop
+CS7    feat(web): render provenance, delete client-side attribution, add boundary doc
+CS-COV test(providers): close team/project/member dimension gaps; provider×entity matrix all-green
+```
+
+> **CS-COV (CHAOS-2609)** is the provider-coverage hardening changeset — it makes the §1.10 matrix
+> green (gitlab/members, gitlab epics, jira dimension, linear projects). Mostly test-only; can run
+> in parallel with CS3–CS4 since it touches the autoimport/normalize dimension, not the resolver.
+
+---
+
+## Appendix A — `web/docs/architecture/team-attribution-boundary.md` (CS7, ready to drop in)
+
+This is the exact file CS7 creates. The compact tree is the frontend-facing "insurance" copy of
+the backend decision tree (§1.5): web devs see *where the decision is made* and that the UI's only
+job is to render it.
+
+````markdown
+# Team Attribution Boundary
+
+dev-health-web **never resolves team attribution.** The backend (ClickHouse-only, staged
+precedence) decides the team and persists the provenance; the frontend renders it and nothing more.
+
+If team coverage is low or `unassigned` is high, **do not** add frontend mapping logic. Fix it
+upstream: backend sync, linked-issue capture, ClickHouse ownership data, or a ClickHouse
+`manual_attribution_fallbacks` record. Manual fallbacks must render as `manual_fallback`
+(lower-confidence), never disguised as issue/team truth.
+
+## Where the decision is made (and where it is NOT)
+
+```mermaid
+flowchart TD
+    BE["Backend resolves team<br/>ClickHouse · staged precedence (native → … → manual → unassigned)"] --> P["work_item_team_attributions<br/>team_id · source · confidence · evidence"]
+    P --> API["GraphQL exposes source / confidence / evidence"]
+    API --> WEB["dev-health-web"]
+    WEB --> R{"render only"}
+    R -->|"team_id present"| Show["show team name + provenance<br/>manual_fallback → lower-confidence badge"]
+    R -->|"source = unassigned"| Un["show 'unassigned' — do NOT infer a team"]
+    WEB -. "NEVER" .-> X["client-side mapping / repo→team derivation<br/>(deleted: buildRepoTeamSankey)"]
+```
+
+## Rules
+
+- Render `team_name` as today; surface `team_attribution_source` / `confidence` / `evidence` when useful.
+- Never recompute attribution client-side. There is no repo→team or prefix→team logic in web.
+- `source = unassigned` renders as unassigned — the frontend must not guess a team.
+- The full backend decision tree + precedence + off-the-rails matrix live in
+  `dev-health-ops` `docs/architecture/team-attribution.md` (mirror of the CHAOS-2600 plan §1.5–1.9).
+````

--- a/docs/architecture/team-attribution.md
+++ b/docs/architecture/team-attribution.md
@@ -166,6 +166,17 @@ not natively produce this entity. ¹ GitHub has no native Project entity (the re
 
 One path: `run_team_autoimport` → `team_autoimport_<provider>.populate()` → `discover_*` → ClickHouse. (`LinearClient.iter_projects` is vestigial dead code, never a path.) **Two member representations — do not conflate:** `team_memberships` (edges) = canonical attribution source, read by the ladder, all 4 providers; `teams.members` (roster) = secondary resolver + admin/display, this CS populates it for github/gitlab too. **Chain:** members → assignee identity → issues → PRs/MRs → (maybe) commits; commit authors are a separate git-side source, member↔author reconciliation deferred (not CHAOS-2600).
 
+> **Identity must match what the assignee path produces (CHAOS-2609).** Both consumers key on the
+> *resolver-consumed* identity, so auto-import writes that exact string — `github:<login>` /
+> `gitlab:<username>` / `jira:accountid:<account_id>`, the same value `IdentityResolver.resolve`
+> returns for a no-email assignee (single source: `providers/identity.py::provider_qualified_identity`).
+> It lands in **both** `team_memberships.raw_provider_user_id` (a facet the ladder's
+> `member_by_identity` indexes) **and** the `teams.members` roster (read by `TeamResolver`). The
+> `member_id` **primary** keeps its `gh:`/`gl:`/`jira:<id>` form (untouched — it is the
+> ReplacingMergeTree dedup key). A `members` cell is `yes` only when this end-to-end resolution is
+> **proven** (a no-email assignee resolves to the auto-imported team via *both* paths —
+> `tests/workers/test_team_autoimport_e2e_sync_surface.py`), not when a row is merely written.
+
 - **Resolver row (CS2):** the precedence resolver (`resolve_team_attribution`) is exercised for all
   four providers — Linear (`test_issue_project_wins_over_linked_issue`,
   `test_assignee_membership_wins_over_linked_issue`), GitHub (`gh:` items in
@@ -185,8 +196,12 @@ One path: `run_team_autoimport` → `team_autoimport_<provider>.populate()` → 
   gitlab/members (was normalized but never asserted), gitlab epics (`gitlab_epic_to_work_item`), jira
   team/member coverage (403-skip + member de-dupe), linear **and** jira native `ProjectRecord` fields
   (linear native projects ARE ingested via `team.associations.project_keys` — the prior "not ingested"
-  note was wrong; it was only a *test* gap, now closed), and gitlab nested-subgroup specificity. The
-  matrix above is the source of truth for what is/ isn't proven.
+  note was wrong; it was only a *test* gap, now closed), and gitlab nested-subgroup specificity.
+  **Plus an attribution-correctness fix:** github/gitlab/jira auto-import now write the
+  *resolver-consumed* member identity (see the §0.4a identity callout), so a no-email assignee actually
+  resolves to its team via both the canonical ladder and the roster — previously the roster stored a
+  bare login the resolver never matched, so member attribution silently missed for no-email
+  github/gitlab/jira assignees. The matrix above is the source of truth for what is/ isn't proven.
 
 ---
 

--- a/docs/architecture/team-attribution.md
+++ b/docs/architecture/team-attribution.md
@@ -175,8 +175,11 @@ One path: `run_team_autoimport` → `team_autoimport_<provider>.populate()` → 
 > `gitlab:<username>` / `jira:accountid:<account_id>`. Deriving the identity directly (bypassing the
 > alias map) is the bug that broke aliased orgs. The alias-resolved identity lands in **both**
 > `team_memberships.raw_provider_user_id` (the one facet the ladder's `member_by_identity` indexes that
-> is free) **and** the `teams.members` roster (read by `TeamResolver`; the roster also carries the
-> provider-qualified id for robustness). The `member_id` **primary** keeps its `gh:`/`gl:`/`jira:<id>`
+> is free) **and** the `teams.members` roster (read by `TeamResolver`). `membership_facets` returns
+> *every* identity an assignee for this member could resolve to — the no-email identity, the
+> provider-qualified id, AND (when the member has an email) the resolver-mapped + normalized **email** —
+> so the roster matches an email-bearing assignee too (the ladder already matched it via `raw_email`,
+> but the roster used to miss). The `member_id` **primary** keeps its `gh:`/`gl:`/`jira:<id>`
 > form (untouched — it is the ReplacingMergeTree dedup key). A `members` cell is `yes` only when this
 > end-to-end resolution is **proven** (a no-email assignee — aliased AND non-aliased — resolves to the
 > auto-imported team via *both* paths —

--- a/docs/architecture/team-attribution.md
+++ b/docs/architecture/team-attribution.md
@@ -144,14 +144,27 @@ just Linear. **Attribution changes MUST keep this matrix green; never add Linear
 
 | provider \ entity | teams | projects | members | issues |
 |---|---|---|---|---|
-| jira   | partial | partial | partial | yes |
-| gitlab | partial | yes     | **no**  | yes |
+| jira   | yes | yes | yes | yes |
+| gitlab | yes | yes     | yes  | yes |
 | github | yes     | n/a¹    | yes     | yes |
-| linear | yes     | partial | yes     | yes |
+| linear | yes     | yes | yes     | yes |
 
 `yes` = normalized in src AND asserted in tests · `partial` = only sink/integration assertion (no
 unit test of the normalizer) · `no` = normalized but output never asserted · `n/a` = provider does
 not natively produce this entity. ¹ GitHub has no native Project entity (the repo is the scope).
+
+> **The matrix above tracks TEST coverage, not whether the data is pulled.** Functionally we ingest teams, projects, and members for *every* provider that supports them (auto-import, when the option is selected). Don't read a `partial`/`no` cell as "not consumed" — it means "not yet asserted."
+
+#### 0.4a Provider × entity **consumption** (functional — what `run_team_autoimport` actually pulls)
+
+| provider | teams | projects | members | repo ownership | member store written |
+|---|---|---|---|---|---|
+| linear | ✓ `discover_linear` | ✓ `associations.project_keys` | ✓ `discover_members_linear` | — | edges **+ roster** |
+| jira   | ✓ `discover_jira` | ✓ `associations.project_keys` | ✓ `discover_members_jira_bulk` | — | edges **+ roster** |
+| github | ✓ `discover_github` | n/a (repo = scope) | ✓ `discover_members_github` | ✓ `team_repo_ownership` | edges **+ roster** (this CS) |
+| gitlab | ✓ `discover_gitlab` | ✓ (GitLab project paths) | ✓ `discover_members_gitlab` | — | edges **+ roster** (this CS) |
+
+One path: `run_team_autoimport` → `team_autoimport_<provider>.populate()` → `discover_*` → ClickHouse. (`LinearClient.iter_projects` is vestigial dead code, never a path.) **Two member representations — do not conflate:** `team_memberships` (edges) = canonical attribution source, read by the ladder, all 4 providers; `teams.members` (roster) = secondary resolver + admin/display, this CS populates it for github/gitlab too. **Chain:** members → assignee identity → issues → PRs/MRs → (maybe) commits; commit authors are a separate git-side source, member↔author reconciliation deferred (not CHAOS-2600).
 
 - **Resolver row (CS2):** the precedence resolver (`resolve_team_attribution`) is exercised for all
   four providers — Linear (`test_issue_project_wins_over_linked_issue`,
@@ -168,10 +181,12 @@ not natively produce this entity. ¹ GitHub has no native Project entity (the re
   `native_team_key = None` (only Linear sets it real), non-Linear attribution depends *entirely* on
   this dimension — so its coverage cells are the highest-risk. (CHAOS-2600 does not change these
   sync ops; CS5 removes only the Postgres bridge.)
-- **Open gaps → CHAOS-2609 (CS-COV):** the dimension has holes — **gitlab/members normalized but
-  never asserted (high)**, gitlab epics untested (high), jira team/project/member sink-only
-  (medium), linear native projects not ingested (medium). Until those land, do **not** assume
-  non-Linear dimension coverage. The matrix above is the source of truth for what is/ isn't proven.
+- **Open gaps → CLOSED by CHAOS-2609 (CS-COV):** the dimension's test holes are now asserted —
+  gitlab/members (was normalized but never asserted), gitlab epics (`gitlab_epic_to_work_item`), jira
+  team/member coverage (403-skip + member de-dupe), linear **and** jira native `ProjectRecord` fields
+  (linear native projects ARE ingested via `team.associations.project_keys` — the prior "not ingested"
+  note was wrong; it was only a *test* gap, now closed), and gitlab nested-subgroup specificity. The
+  matrix above is the source of truth for what is/ isn't proven.
 
 ---
 

--- a/docs/architecture/team-attribution.md
+++ b/docs/architecture/team-attribution.md
@@ -166,15 +166,20 @@ not natively produce this entity. ¹ GitHub has no native Project entity (the re
 
 One path: `run_team_autoimport` → `team_autoimport_<provider>.populate()` → `discover_*` → ClickHouse. (`LinearClient.iter_projects` is vestigial dead code, never a path.) **Two member representations — do not conflate:** `team_memberships` (edges) = canonical attribution source, read by the ladder, all 4 providers; `teams.members` (roster) = secondary resolver + admin/display, this CS populates it for github/gitlab too. **Chain:** members → assignee identity → issues → PRs/MRs → (maybe) commits; commit authors are a separate git-side source, member↔author reconciliation deferred (not CHAOS-2600).
 
-> **Identity must match what the assignee path produces (CHAOS-2609).** Both consumers key on the
-> *resolver-consumed* identity, so auto-import writes that exact string — `github:<login>` /
-> `gitlab:<username>` / `jira:accountid:<account_id>`, the same value `IdentityResolver.resolve`
-> returns for a no-email assignee (single source: `providers/identity.py::provider_qualified_identity`).
-> It lands in **both** `team_memberships.raw_provider_user_id` (a facet the ladder's
-> `member_by_identity` indexes) **and** the `teams.members` roster (read by `TeamResolver`). The
-> `member_id` **primary** keeps its `gh:`/`gl:`/`jira:<id>` form (untouched — it is the
-> ReplacingMergeTree dedup key). A `members` cell is `yes` only when this end-to-end resolution is
-> **proven** (a no-email assignee resolves to the auto-imported team via *both* paths —
+> **Identity must match what the assignee path produces — UNDER THE ORG ALIAS MAP (CHAOS-2609).**
+> Both consumers key on the *resolver-consumed* identity. Auto-import resolves each member through the
+> **same** `IdentityResolver` the assignee path uses — `load_identity_resolver()` (the global
+> `identity_mapping.yaml` / `IDENTITY_MAPPING_PATH`) — via `IdentityResolver.membership_facets`, so an
+> **aliased** member resolves to the **same canonical identity** an aliased assignee does (e.g.
+> `github:lead` → `lead@example.com`), and a non-aliased member stays `github:<login>` /
+> `gitlab:<username>` / `jira:accountid:<account_id>`. Deriving the identity directly (bypassing the
+> alias map) is the bug that broke aliased orgs. The alias-resolved identity lands in **both**
+> `team_memberships.raw_provider_user_id` (the one facet the ladder's `member_by_identity` indexes that
+> is free) **and** the `teams.members` roster (read by `TeamResolver`; the roster also carries the
+> provider-qualified id for robustness). The `member_id` **primary** keeps its `gh:`/`gl:`/`jira:<id>`
+> form (untouched — it is the ReplacingMergeTree dedup key). A `members` cell is `yes` only when this
+> end-to-end resolution is **proven** (a no-email assignee — aliased AND non-aliased — resolves to the
+> auto-imported team via *both* paths —
 > `tests/workers/test_team_autoimport_e2e_sync_surface.py`), not when a row is merely written.
 
 - **Resolver row (CS2):** the precedence resolver (`resolve_team_attribution`) is exercised for all

--- a/docs/architecture/team-realignment.md
+++ b/docs/architecture/team-realignment.md
@@ -1,0 +1,734 @@
+# Corrective Plan: ClickHouse-Only Team Attribution
+
+## Purpose
+
+Eliminate recurring team-attribution regressions by removing the split-brain model where Postgres stores team mappings while ClickHouse stores analytics attribution.
+
+This environment is not production. There is no legacy data-preservation requirement. Old Postgres team attribution paths can be removed outright.
+
+## Target outcome
+
+After this change:
+
+- ClickHouse is the only persistence layer used for team, project, member, repo, and manual fallback attribution.
+- Postgres is not used for team attribution in any runtime, sync, analytics, or resolver path.
+- Legacy Postgres team mapping models, services, bridge code, CLI paths, tests, and docs are removed or rewritten.
+- Manual mappings become explicit ClickHouse fallback records, not hidden overrides.
+- WTI-native issue facts outrank all fallback logic.
+- PR/MR attribution comes from actual linked issue donors.
+- External issue-key prefixes do not count as linked-issue inheritance.
+- Attribution emits provenance everywhere.
+
+## Core model
+
+```text
+WTI issue = canonical work unit
+PR/MR = code-change evidence linked to the issue
+commit = lower-level evidence linked through PR/MR when possible
+manual mapping = explicit fallback only
+ClickHouse = single attribution store
+Postgres = auth/org/config only
+```
+
+## Non-negotiable invariants
+
+### 1. ClickHouse owns attribution
+
+ClickHouse owns all data used to resolve work attribution:
+
+- teams
+- team memberships
+- project ownership
+- repo ownership
+- work items
+- work item dependencies
+- work item team attributions
+- manual attribution fallbacks
+
+Postgres must not be read by attribution code.
+
+### 2. Manual fallback is not an override
+
+Manual mappings are fallback attribution records.
+
+They are only used when WTI-native attribution and linked issue attribution fail.
+
+Manual mappings must never override:
+
+- issue team
+- issue project
+- issue assignee/member
+- actual linked issue donor attribution
+- imported provider ownership facts
+
+### 3. Issues are the canonical unit of work
+
+Work Tracking Integrations include:
+
+- GitHub
+- GitLab
+- Linear
+- Jira
+
+Normalized WTI entities:
+
+- team
+- project
+- member
+- issue
+
+Provider-specific quality varies. Linear and Jira generally provide stronger issue/project semantics. GitHub and GitLab may require repo/project/group/member normalization.
+
+### 4. PRs/MRs connect code to work
+
+PRs and MRs are not the canonical unit of work. They are code-change evidence linked to an issue.
+
+Correct attribution flow:
+
+```text
+Issue carries team/project/member/work intent
+PR/MR carries implementation/change evidence
+PR/MR links to issue
+Commits link to PR/MR
+Work attribution flows issue -> PR/MR -> commits/evidence
+```
+
+Allowed:
+
+```text
+PR/MR -> actual linked Linear/Jira/GitHub/GitLab issue -> donor team/project/member
+```
+
+Not allowed as linked-issue inheritance:
+
+```text
+PR/MR -> text CHAOS-123 -> prefix CHAOS -> team
+```
+
+If prefix-based mapping is needed, it must be represented as explicit manual fallback with low confidence.
+
+## Attribution precedence
+
+Implement deterministic staged resolution in this order:
+
+1. WTI-native work item facts
+   - native issue team
+   - native issue project
+   - native member/assignee
+2. Imported provider ownership facts
+   - provider project ownership
+   - provider repo ownership
+   - provider team/member ownership
+3. Linked issue fallback
+   - only from an actual linked donor issue row
+   - only if the PR/MR has no stronger attribution
+4. Manual fallback mapping
+   - ClickHouse-only
+   - explicit source
+   - lower precedence than all imported/native facts
+5. Unassigned
+
+Preferred source order:
+
+```python
+_SOURCE_ORDER = {
+    "native_team": 0,
+    "issue_project": 1,
+    "project_ownership": 2,
+    "repo_ownership": 3,
+    "assignee_membership": 4,
+    "linked_issue": 5,
+    "manual_fallback": 6,
+    "unassigned": 7,
+}
+```
+
+Prefer explicit staged resolution over relying only on numeric ranking.
+
+## Provider × entity consumption (what we pull, and from where)
+
+We pull **teams, projects, and members** for every integration that supports them (auto-import,
+when the option is selected). One ingestion path: `run_team_autoimport(provider, org_id)` →
+`team_autoimport_<provider>.populate()` → `discover_*` → writes ClickHouse directly. The Postgres
+bridge/reconcile/`TeamMapping` were the *separate* path and are deleted (CHAOS-2600 CS5/CS6).
+
+| provider | teams | projects | members | repo ownership | member store |
+|---|---|---|---|---|---|
+| linear | yes (`discover_linear`) | yes (`associations.project_keys`) | yes (`discover_members_linear`) | — | edges + roster |
+| jira   | yes (`discover_jira`) | yes (`associations.project_keys`) | yes (`discover_members_jira_bulk`) | — | edges + roster |
+| github | yes (`discover_github`) | n/a (repo = scope) | yes (`discover_members_github`) | yes (`team_repo_ownership`) | edges (+ roster, CS-COV) |
+| gitlab | yes (`discover_gitlab`) | yes (GitLab project paths) | yes (`discover_members_gitlab`) | — | edges (+ roster, CS-COV) |
+
+**Members are stored two ways — do not conflate:**
+- `team_memberships` (edge table) — written by all four; this is what the **attribution precedence
+  ladder reads** (`load_team_attribution_context` → `member_by_identity` → `assignee_membership`).
+  All four providers' members are consumed here.
+- `teams.members` (roster on the team row) — written by linear/jira auto-import + the admin
+  surgical-replacement surface; read by the secondary resolver + admin/display. **We also pull
+  members of orgs and teams from github and gitlab into this roster** (CS-COV) for display +
+  secondary-resolver consistency.
+
+**Chain & deferred reconciliation:** members → assignee identity → issues → PRs/MRs → (maybe)
+commits. Commit **authors** are pulled separately from the git side; reconciling commit-author
+identity against team-member identity is acknowledged future work, **not** part of CHAOS-2600.
+
+## Phase 1: Remove Postgres attribution model
+
+Delete or neutralize Postgres team attribution components.
+
+Remove runtime dependency on models similar to:
+
+```text
+TeamMapping
+IdentityMapping
+```
+
+Remove code paths that:
+
+- read team mappings from Postgres
+- read identity mappings from Postgres for attribution
+- bridge Postgres team mappings into ClickHouse
+- treat Postgres team mappings as source of truth
+- expose CLI commands that sync teams through Postgres first
+
+Likely target areas:
+
+```text
+src/dev_health_ops/providers/team_bridge.py
+src/dev_health_ops/models/settings.py
+src/dev_health_ops/api/services/configuration/
+src/dev_health_ops/cli/
+docs/architecture/database-architecture.md
+docs/ops/cli-reference.md
+tests/test_team_reconcile_guards.py
+```
+
+Expected result:
+
+```text
+grep -R "TeamMapping" src tests docs
+grep -R "IdentityMapping" src tests docs
+grep -R "bridge_teams_to_clickhouse" src tests docs
+```
+
+These should return no runtime attribution usage. Deleted-code references in removed migrations are acceptable only if they are inert and not imported.
+
+## Phase 2: Add ClickHouse manual fallback table
+
+Create a ClickHouse table for manual fallback attribution.
+
+```sql
+CREATE TABLE IF NOT EXISTS manual_attribution_fallbacks
+(
+    org_id String,
+    provider LowCardinality(String),
+    scope_type LowCardinality(String),
+    scope_id String,
+    team_id String,
+    team_name String,
+    reason String,
+    priority Int32 DEFAULT 100,
+    valid_from DateTime DEFAULT now(),
+    valid_to Nullable(DateTime),
+    created_by Nullable(String),
+    created_at DateTime DEFAULT now(),
+    updated_at DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(updated_at)
+PARTITION BY org_id
+ORDER BY (org_id, provider, scope_type, scope_id, team_id);
+```
+
+Allowed `scope_type` values:
+
+```text
+repo
+project
+member
+issue_key_prefix
+```
+
+Rules:
+
+- `issue_key_prefix` is manual fallback only.
+- It must never be treated as linked-issue inheritance.
+- It must emit `source = manual_fallback`.
+- It must emit low/manual confidence.
+- It must include evidence showing the matched fallback record.
+
+## Phase 3: Create ClickHouse-native team and ownership writers
+
+Ensure the system can write these directly to ClickHouse:
+
+```text
+teams
+team_memberships
+team_project_ownership
+team_repo_ownership
+manual_attribution_fallbacks
+```
+
+Do not write these to Postgres.
+
+Do not bridge these from Postgres.
+
+Do not use a Postgres staging table.
+
+Expected service boundary:
+
+```text
+WTI connector -> normalization -> ClickHouse writer
+manual admin/config input -> ClickHouse writer
+metrics resolver -> ClickHouse loader -> attribution result
+```
+
+## Phase 4: Fix attribution resolver behavior
+
+Update attribution resolver logic so linked issue inheritance and manual fallback cannot override stronger attribution.
+
+Required behavior:
+
+```python
+def resolve_team_attribution(...):
+    native = resolve_native_issue_facts(...)
+    if native:
+        return native
+
+    ownership = resolve_imported_provider_ownership(...)
+    if ownership:
+        return ownership
+
+    linked_issue = resolve_actual_linked_issue_donor(...)
+    if linked_issue:
+        return linked_issue
+
+    manual = resolve_manual_fallback(...)
+    if manual:
+        return manual
+
+    return unassigned()
+```
+
+Remove bad behavior:
+
+```python
+_SOURCE_ORDER = {
+    "native_team": 0,
+    "linked_issue": 1,
+    "project_ownership": 2,
+    "repo_ownership": 3,
+    "assignee_membership": 4,
+    "unassigned": 5,
+}
+```
+
+Remove any resolver behavior where linked issue wins over:
+
+- project ownership
+- repo ownership
+- assignee membership
+- native provider team/project/member facts
+
+## Phase 5: Fix linked issue inheritance
+
+Linked issue inheritance requires an actual donor work item.
+
+Allowed donor path:
+
+```text
+work_item_dependencies.source_work_item_id = PR/MR
+work_item_dependencies.target_work_item_id = issue
+target issue exists in work_items
+target issue has resolved team attribution
+PR/MR inherits target issue attribution only if PR/MR has no stronger attribution
+```
+
+Not allowed:
+
+```text
+PR/MR body contains CHAOS-123
+CHAOS prefix maps to team
+PR/MR inherits linked_issue source
+```
+
+If no donor issue row exists, attribution remains unresolved until manual fallback runs.
+
+If manual fallback matches, source must be:
+
+```text
+manual_fallback
+```
+
+not:
+
+```text
+linked_issue
+```
+
+## Phase 6: Persist provenance
+
+Every final attribution should include provenance.
+
+Required fields:
+
+```text
+org_id
+work_item_id
+provider
+team_id
+team_name
+source
+confidence
+evidence
+is_primary
+computed_at
+```
+
+Required source enum:
+
+```text
+native_team
+issue_project
+project_ownership
+repo_ownership
+assignee_membership
+linked_issue
+manual_fallback
+unassigned
+```
+
+Recommended confidence enum:
+
+```text
+high
+medium
+low
+manual
+none
+```
+
+Examples:
+
+```json
+{
+  "source": "linked_issue",
+  "confidence": "high",
+  "evidence": {
+    "dependency_type": "implements",
+    "donor_work_item_id": "linear:issue:CHAOS-123",
+    "donor_provider": "linear"
+  }
+}
+```
+
+```json
+{
+  "source": "manual_fallback",
+  "confidence": "manual",
+  "evidence": {
+    "scope_type": "repo",
+    "scope_id": "full-chaos/dev-health-ops",
+    "reason": "explicit manual fallback configured"
+  }
+}
+```
+
+```json
+{
+  "source": "unassigned",
+  "confidence": "none",
+  "evidence": {
+    "reason": "no native issue facts, linked issue donor, ownership, or manual fallback matched"
+  }
+}
+```
+
+## Phase 7: Delete or invert incorrect tests
+
+Delete or invert tests that encode linked issue as stronger than real attribution.
+
+Search for tests with names or assertions similar to:
+
+```text
+test_linked_issue_wins_over_assignee_membership
+test_state_duration_linked_issue_wins_over_assignee_membership
+linked_issue primary over assignee
+linked_issue wins over project
+linked_issue wins over repo
+```
+
+Replacement tests:
+
+```python
+def test_native_issue_team_wins_over_everything():
+    ...
+
+def test_project_ownership_wins_over_linked_issue():
+    ...
+
+def test_repo_ownership_wins_over_linked_issue():
+    ...
+
+def test_assignee_membership_wins_over_linked_issue():
+    ...
+
+def test_linked_issue_applies_when_no_stronger_attribution_exists():
+    ...
+
+def test_linked_issue_requires_actual_donor_issue_row():
+    ...
+
+def test_issue_key_prefix_without_donor_does_not_inherit_linked_issue():
+    ...
+
+def test_issue_key_prefix_can_match_manual_fallback_only():
+    ...
+
+def test_manual_fallback_does_not_override_native_issue_team():
+    ...
+
+def test_manual_fallback_does_not_override_linked_issue_donor():
+    ...
+
+def test_unassigned_when_no_native_linked_ownership_or_manual_fallback():
+    ...
+```
+
+## Phase 8: Delete obsolete legacy pathways
+
+Because this is not production, do not preserve compatibility for legacy Postgres attribution.
+
+Delete rather than migrate:
+
+- Postgres team mapping models
+- Postgres identity mapping models used for attribution
+- Postgres-to-ClickHouse bridge code
+- CLI bridge commands
+- tests that validate bridge behavior
+- docs that describe Postgres team mappings as active attribution infrastructure
+
+If import deletion causes admin/API tests to fail, either:
+
+1. remove the obsolete admin surface, or
+2. rewrite it to write directly to ClickHouse.
+
+Do not add a backfill command.
+
+Do not keep a compatibility shim unless required only to print a hard deprecation error.
+
+Acceptable shim behavior:
+
+```text
+This command was removed. Team attribution is ClickHouse-only.
+```
+
+Unacceptable shim behavior:
+
+```text
+Read Postgres mappings and write them to ClickHouse.
+```
+
+## Phase 9: Documentation updates
+
+Update backend docs:
+
+```text
+docs/architecture/team-attribution.md
+docs/architecture/database-architecture.md
+docs/architecture/data-pipeline.md
+docs/ops/cli-reference.md
+AGENTS.md
+```
+
+Add this invariant prominently:
+
+```md
+## Team attribution source of truth
+
+ClickHouse is the only source used for analytics attribution.
+
+Postgres does not store or resolve team attribution mappings.
+
+Manual mappings are ClickHouse fallback records only. They are never overrides and never outrank WTI-native facts.
+
+PR/MR attribution comes from actual linked issue donors. An external issue key prefix alone is not linked-issue inheritance.
+```
+
+Remove language implying:
+
+- Postgres owns `team_mappings`
+- Postgres owns `identity_mappings` for attribution
+- team sync writes to Postgres before bridging to ClickHouse
+- Postgres manual mappings are part of normal attribution resolution
+
+## Phase 10: Frontend boundary documentation
+
+In `dev-health-web`, add:
+
+```text
+docs/architecture/team-attribution-boundary.md
+```
+
+Content:
+
+```md
+# Team Attribution Boundary
+
+dev-health-web never resolves team attribution.
+
+The frontend renders persisted backend attribution and provenance only.
+
+If team coverage is low or unassigned is high, do not add frontend mapping logic. Fix backend sync, linked issue capture, ClickHouse ownership data, or ClickHouse manual fallback records.
+
+Manual fallback mappings must be visible as `manual_fallback`, not hidden as issue/team truth.
+```
+
+Link it from:
+
+```text
+AGENTS.md
+docs/user-journeys/investment-view.md
+```
+
+## Phase 11: Documentation freshness and drift prevention
+
+Documentation must be updated as part of the implementation, not after the fact.
+
+Any code change that affects team attribution, WTI normalization, PR/MR issue linking, manual fallback behavior, ClickHouse attribution tables, API response provenance, or frontend attribution display must update the relevant docs in the same PR.
+
+Required backend documentation updates:
+
+```text
+docs/architecture/team-attribution.md
+docs/architecture/database-architecture.md
+docs/architecture/data-pipeline.md
+docs/ops/cli-reference.md
+AGENTS.md
+```
+
+Required frontend documentation updates:
+
+```text
+docs/architecture/team-attribution-boundary.md
+docs/user-journeys/investment-view.md
+AGENTS.md
+```
+
+Add or update a documentation guardrail in `AGENTS.md`:
+
+```md
+## Documentation freshness requirement
+
+When changing attribution behavior, update the matching architecture and product docs in the same PR.
+
+Do not change team attribution code without updating:
+
+- backend attribution contract docs
+- database ownership docs
+- CLI/admin behavior docs
+- frontend attribution boundary docs, if API or display behavior changes
+
+If docs and code disagree, the implementation is incomplete.
+```
+
+Add this to the PR checklist or developer notes if one exists:
+
+```md
+- [ ] Team attribution docs updated
+- [ ] Database ownership docs updated
+- [ ] CLI/admin docs updated, if behavior changed
+- [ ] Frontend attribution boundary docs updated, if API/display behavior changed
+- [ ] Tests assert the documented attribution precedence
+```
+
+Documentation acceptance criteria:
+
+- Every removed Postgres attribution path is removed from docs.
+- Every new ClickHouse attribution table is documented.
+- Manual fallback behavior is documented as fallback, not override.
+- Linked issue inheritance is documented as requiring an actual donor issue row.
+- Issue-key-prefix attribution is documented only as manual fallback.
+- API provenance fields are documented.
+- Frontend docs state that web never resolves attribution.
+- Tests and docs describe the same precedence order.
+
+
+## Phase 12: API and UI expectations
+
+Backend APIs should expose attribution provenance when returning team-attributed work.
+
+Minimum response shape:
+
+```json
+{
+  "team_id": "platform",
+  "team_name": "Platform",
+  "team_attribution_source": "linked_issue",
+  "team_attribution_confidence": "high",
+  "team_attribution_evidence": {
+    "donor_work_item_id": "linear:issue:CHAOS-123"
+  }
+}
+```
+
+Frontend should:
+
+- display team name as today
+- avoid recomputing attribution
+- optionally surface manual fallback as lower-confidence attribution
+- show unassigned when backend says unassigned
+- not implement repo/team mapping logic
+
+## Acceptance criteria
+
+Codex is complete only when all are true:
+
+- No runtime attribution code reads Postgres team mappings.
+- No runtime attribution code reads Postgres identity mappings.
+- `team_bridge.py` is deleted or converted to a hard deprecation error.
+- No Postgres-to-ClickHouse team bridge remains.
+- Manual mappings are stored in ClickHouse only.
+- Manual mappings emit `source = manual_fallback`.
+- Linked issue inheritance is lower precedence than native/imported ownership attribution.
+- Linked issue inheritance requires an actual donor issue row.
+- Issue-key-prefix matching is not linked-issue inheritance.
+- Issue-key-prefix fallback, if implemented, emits `manual_fallback`.
+- Attribution output includes source, confidence, and evidence.
+- Tests explicitly protect the precedence model.
+- Backend docs state ClickHouse-only attribution.
+- Frontend docs state the UI never resolves team attribution.
+- Documentation freshness is enforced in `AGENTS.md` or the repo PR checklist.
+- Any attribution behavior change updates docs in the same PR.
+- Tests and docs describe the same attribution precedence order.
+- No backfill, migration-retention, or legacy compatibility path exists for Postgres team attribution.
+
+## Suggested branch
+
+```bash
+git checkout -b fix/clickhouse-only-team-attribution
+```
+
+## Suggested commit sequence
+
+```text
+docs: define clickhouse-only team attribution contract
+feat(clickhouse): add manual attribution fallback storage
+refactor(metrics): remove postgres attribution dependency
+fix(metrics): make linked issue attribution a true fallback
+feat(metrics): persist attribution provenance
+test(metrics): lock team attribution precedence
+docs(web): document attribution rendering boundary
+chore: remove legacy postgres team mapping paths
+```
+
+## Final warning for Codex
+
+Do not preserve the old Postgres attribution path.
+
+Do not write a backfill.
+
+Do not add a compatibility bridge.
+
+Do not make manual mappings an override.
+
+Do not infer team attribution from issue-key prefixes unless the result is explicit `manual_fallback` provenance.

--- a/src/dev_health_ops/providers/identity.py
+++ b/src/dev_health_ops/providers/identity.py
@@ -4,6 +4,7 @@ import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 import yaml
 
@@ -110,6 +111,40 @@ class IdentityResolver:
         if display_name:
             return display_name.strip() or "unknown"
         return "unknown"
+
+    def membership_facets(
+        self,
+        *,
+        provider: WorkItemProvider | str,
+        username: str | None = None,
+        account_id: str | None = None,
+    ) -> list[str]:
+        """Identities to store on a team membership so a no-email assignee for
+        this member matches on resolution — under THIS org's alias map.
+
+        Returns the **alias-resolved** identity FIRST (the canonical string a
+        no-email assignee resolves to via :meth:`resolve` with the same alias
+        map, e.g. ``lead@example.com`` when ``github:lead`` is aliased), then the
+        provider-qualified id (``github:lead``) as a robustness fallback,
+        de-duplicated. The first element is the one that MUST match; auto-import
+        stores it in ``team_memberships.raw_provider_user_id`` and the
+        ``teams.members`` roster so BOTH attribution paths resolve aliased and
+        non-aliased members alike (CHAOS-2609). ``display_name`` is intentionally
+        omitted — it is never a stable membership facet.
+        """
+        primary = self.resolve(
+            provider=cast(WorkItemProvider, provider),
+            username=username,
+            account_id=account_id,
+        )
+        qualified = provider_qualified_identity(
+            provider, username=username, account_id=account_id
+        )
+        facets: list[str] = []
+        for candidate in (primary, qualified):
+            if candidate and candidate != "unknown" and candidate not in facets:
+                facets.append(candidate)
+        return facets
 
 
 def load_identity_resolver(path: Path | None = None) -> IdentityResolver:

--- a/src/dev_health_ops/providers/identity.py
+++ b/src/dev_health_ops/providers/identity.py
@@ -118,21 +118,29 @@ class IdentityResolver:
         provider: WorkItemProvider | str,
         username: str | None = None,
         account_id: str | None = None,
+        email: str | None = None,
     ) -> list[str]:
-        """Identities to store on a team membership so a no-email assignee for
-        this member matches on resolution — under THIS org's alias map.
+        """Every identity an assignee for this member could resolve to — under
+        THIS org's alias map — so both attribution paths match.
 
-        Returns the **alias-resolved** identity FIRST (the canonical string a
-        no-email assignee resolves to via :meth:`resolve` with the same alias
-        map, e.g. ``lead@example.com`` when ``github:lead`` is aliased), then the
-        provider-qualified id (``github:lead``) as a robustness fallback,
-        de-duplicated. The first element is the one that MUST match; auto-import
-        stores it in ``team_memberships.raw_provider_user_id`` and the
-        ``teams.members`` roster so BOTH attribution paths resolve aliased and
-        non-aliased members alike (CHAOS-2609). ``display_name`` is intentionally
-        omitted — it is never a stable membership facet.
+        Order (de-duplicated, ``unknown``/empty dropped):
+
+        1. The **no-email** identity FIRST — what an assignee WITHOUT an email
+           resolves to: the alias-resolved canonical (``lead@example.com`` when
+           ``github:lead`` is aliased) else the provider-qualified id. This is the
+           element auto-import stores in the single ``raw_provider_user_id`` edge
+           facet (``raw_email`` already covers the email case on the ladder).
+        2. The provider-qualified id (``github:lead``) as a robustness fallback.
+        3. If the member has an email: what an assignee WITH that email resolves
+           to (``resolve(email=…)`` — alias-mapped if the email is aliased) AND
+           the normalized raw email — so the ``teams.members`` roster (read by
+           ``TeamResolver``) matches an email-bearing assignee too. Without this,
+           an email+provider-id member matched on the ladder via ``raw_email`` but
+           MISSED on the roster (CHAOS-2609).
+
+        ``display_name`` is intentionally omitted — never a stable facet.
         """
-        primary = self.resolve(
+        no_email_identity = self.resolve(
             provider=cast(WorkItemProvider, provider),
             username=username,
             account_id=account_id,
@@ -140,8 +148,14 @@ class IdentityResolver:
         qualified = provider_qualified_identity(
             provider, username=username, account_id=account_id
         )
+        candidates = [no_email_identity, qualified]
+        if email:
+            candidates.append(
+                self.resolve(provider=cast(WorkItemProvider, provider), email=email)
+            )
+            candidates.append(_norm_email(email))
         facets: list[str] = []
-        for candidate in (primary, qualified):
+        for candidate in candidates:
             if candidate and candidate != "unknown" and candidate not in facets:
                 facets.append(candidate)
         return facets

--- a/src/dev_health_ops/providers/identity.py
+++ b/src/dev_health_ops/providers/identity.py
@@ -20,6 +20,34 @@ def _norm_email(email: str) -> str:
     return (email or "").strip().lower()
 
 
+def provider_qualified_identity(
+    provider: WorkItemProvider | str,
+    *,
+    username: str | None = None,
+    account_id: str | None = None,
+) -> str | None:
+    """The provider-qualified identity for a user lacking a usable email.
+
+    Single source of truth shared by two sides that MUST agree (CHAOS-2609):
+
+    * the work-item assignee path — ``IdentityResolver.resolve`` returns this
+      string as its stable fallback when no email/alias matches; and
+    * team auto-import — writes this exact string into
+      ``team_memberships.raw_provider_user_id`` (a facet the canonical ladder's
+      ``member_by_identity`` indexes) and the ``teams.members`` roster (read by
+      the secondary ``TeamResolver``).
+
+    Priority mirrors ``resolve``: ``provider:username`` before
+    ``provider:accountid:account_id`` (GitHub/GitLab carry a username; Jira
+    carries only an accountId). Returns ``None`` when neither is present.
+    """
+    if username and str(username).strip():
+        return f"{provider}:{str(username).strip()}"
+    if account_id and str(account_id).strip():
+        return f"{provider}:accountid:{str(account_id).strip()}"
+    return None
+
+
 @dataclass(frozen=True)
 class IdentityResolver:
     """
@@ -66,9 +94,19 @@ class IdentityResolver:
             if mapped:
                 return mapped
 
-        # Stable fallbacks.
-        if username:
-            return f"{provider}:{username}"
+        # Stable fallbacks. A provider-qualified identity (username, then
+        # accountId) takes precedence over the unreliable display name so a
+        # no-email assignee resolves to the SAME facet team auto-import writes
+        # into team_memberships / teams.members — otherwise member-based
+        # attribution silently misses for no-email assignees (CHAOS-2609). This
+        # mirrors the candidate priority above (provider:accountid: outranks
+        # display_name) and shares provider_qualified_identity as the single
+        # derivation used by the auto-import writer.
+        qualified = provider_qualified_identity(
+            provider, username=username, account_id=account_id
+        )
+        if qualified:
+            return qualified
         if display_name:
             return display_name.strip() or "unknown"
         return "unknown"

--- a/src/dev_health_ops/workers/team_autoimport_github.py
+++ b/src/dev_health_ops/workers/team_autoimport_github.py
@@ -73,6 +73,7 @@ async def _populate_async(
         teams=teams,
         now=now,
     )
+    _apply_member_roster(team_rows=team_rows, membership_rows=membership_rows)
 
     sink = _sink(scope)
     await sink.insert_teams(team_rows)
@@ -241,6 +242,27 @@ async def _membership_rows(
                 )
             )
     return rows
+
+
+def _apply_member_roster(
+    *,
+    team_rows: list[dict[str, Any]],
+    membership_rows: Iterable[TeamMembershipRecord],
+) -> None:
+    """Populate each team row's ``members`` roster from discovered memberships.
+
+    Mirrors the linear/jira auto-import (which set ``teams.members`` from the
+    discovered roster) so github teams also carry a non-empty roster column, not
+    just the ``team_memberships`` edge rows.
+    """
+    roster: dict[str, list[str]] = {}
+    for row in membership_rows:
+        identity = row.raw_provider_user_id
+        if not identity:
+            continue
+        roster.setdefault(row.team_id, []).append(identity)
+    for team_row in team_rows:
+        team_row["members"] = roster.get(str(team_row["id"]), [])
 
 
 def _sink(scope: Mapping[str, Any]) -> ClickHouseMetricsSink:

--- a/src/dev_health_ops/workers/team_autoimport_github.py
+++ b/src/dev_health_ops/workers/team_autoimport_github.py
@@ -15,7 +15,7 @@ from dev_health_ops.api.services.configuration.team_membership import (
 )
 from dev_health_ops.metrics.schemas import TeamMembershipRecord, TeamRepoOwnershipRecord
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
-from dev_health_ops.providers.identity import provider_qualified_identity
+from dev_health_ops.providers.identity import IdentityResolver, load_identity_resolver
 from dev_health_ops.providers.team_capabilities import team_provider_capabilities
 
 logger = logging.getLogger(__name__)
@@ -65,16 +65,22 @@ async def _populate_async(
         return _zero_summary(org_id=org_id, reason="no_provider_teams")
 
     now = datetime.now(timezone.utc)
+    # Same alias map the assignee/compute path uses (load_identity_resolver in
+    # job_work_items / providers.base), so an aliased member resolves to the SAME
+    # canonical identity an aliased assignee does (CHAOS-2609).
+    resolver = load_identity_resolver()
     team_rows = _team_rows(org_id=org_id, teams=teams, now=now)
     repo_rows = _repo_ownership_rows(org_id=org_id, teams=teams, now=now)
-    membership_rows = await _membership_rows(
+    membership_rows, member_roster = await _membership_rows(
         org_id=org_id,
         token=token,
         org_name=org_name,
         teams=teams,
         now=now,
+        resolver=resolver,
     )
-    _apply_member_roster(team_rows=team_rows, membership_rows=membership_rows)
+    for team_row in team_rows:
+        team_row["members"] = member_roster.get(str(team_row["id"]), [])
 
     sink = _sink(scope)
     await sink.insert_teams(team_rows)
@@ -196,9 +202,11 @@ async def _membership_rows(
     org_name: str,
     teams: Iterable[Any],
     now: datetime,
-) -> list[TeamMembershipRecord]:
+    resolver: IdentityResolver,
+) -> tuple[list[TeamMembershipRecord], dict[str, list[str]]]:
     service = TeamMembershipService(session=cast(Any, None), org_id=org_id)
     rows: list[TeamMembershipRecord] = []
+    roster: dict[str, list[str]] = {}
     seen: set[tuple[str, str]] = set()
     for team in teams:
         team_slug = str(getattr(team, "provider_team_id"))
@@ -226,22 +234,28 @@ async def _membership_rows(
             if key in seen:
                 continue
             seen.add(key)
-            # raw_provider_user_id carries the RESOLVER-CONSUMED identity
-            # (github:<login>), not the bare login: that is the facet a no-email
-            # assignee resolves to (IdentityResolver fallback) and the only
-            # member_by_identity slot free to hold it (member_id is the PK). The
-            # bare login is still preserved inside member_id. (CHAOS-2609)
-            qualified_identity = (
-                provider_qualified_identity(PROVIDER, username=raw_identity)
-                or raw_identity
-            )
+            # Resolve the member through the SAME org alias map an assignee uses:
+            # facets[0] is the alias-resolved identity (canonical email when the
+            # github:<login> is aliased, else github:<login>) — the facet a
+            # no-email assignee resolves to. It goes into raw_provider_user_id
+            # (the only member_by_identity slot free; member_id is the PK and
+            # keeps the bare login) AND, with the provider-qualified id, into the
+            # teams.members roster so BOTH attribution paths match aliased and
+            # non-aliased members (CHAOS-2609).
+            facets = resolver.membership_facets(
+                provider=PROVIDER, username=raw_identity
+            ) or [raw_identity]
+            roster_for_team = roster.setdefault(team_id, [])
+            for facet in facets:
+                if facet not in roster_for_team:
+                    roster_for_team.append(facet)
             rows.append(
                 TeamMembershipRecord(
                     org_id=org_id,
                     provider=PROVIDER,
                     team_id=team_id,
                     member_id=member_id,
-                    raw_provider_user_id=qualified_identity,
+                    raw_provider_user_id=facets[0],
                     raw_email=getattr(member, "email", None),
                     source="provider_access",
                     is_primary=0,
@@ -251,28 +265,7 @@ async def _membership_rows(
                     updated_at=now,
                 )
             )
-    return rows
-
-
-def _apply_member_roster(
-    *,
-    team_rows: list[dict[str, Any]],
-    membership_rows: Iterable[TeamMembershipRecord],
-) -> None:
-    """Populate each team row's ``members`` roster from discovered memberships.
-
-    Mirrors the linear/jira auto-import (which set ``teams.members`` from the
-    discovered roster) so github teams also carry a non-empty roster column, not
-    just the ``team_memberships`` edge rows.
-    """
-    roster: dict[str, list[str]] = {}
-    for row in membership_rows:
-        identity = row.raw_provider_user_id
-        if not identity:
-            continue
-        roster.setdefault(row.team_id, []).append(identity)
-    for team_row in team_rows:
-        team_row["members"] = roster.get(str(team_row["id"]), [])
+    return rows, roster
 
 
 def _sink(scope: Mapping[str, Any]) -> ClickHouseMetricsSink:

--- a/src/dev_health_ops/workers/team_autoimport_github.py
+++ b/src/dev_health_ops/workers/team_autoimport_github.py
@@ -243,7 +243,9 @@ async def _membership_rows(
             # teams.members roster so BOTH attribution paths match aliased and
             # non-aliased members (CHAOS-2609).
             facets = resolver.membership_facets(
-                provider=PROVIDER, username=raw_identity
+                provider=PROVIDER,
+                username=raw_identity,
+                email=getattr(member, "email", None),
             ) or [raw_identity]
             roster_for_team = roster.setdefault(team_id, [])
             for facet in facets:

--- a/src/dev_health_ops/workers/team_autoimport_github.py
+++ b/src/dev_health_ops/workers/team_autoimport_github.py
@@ -15,6 +15,7 @@ from dev_health_ops.api.services.configuration.team_membership import (
 )
 from dev_health_ops.metrics.schemas import TeamMembershipRecord, TeamRepoOwnershipRecord
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.providers.identity import provider_qualified_identity
 from dev_health_ops.providers.team_capabilities import team_provider_capabilities
 
 logger = logging.getLogger(__name__)
@@ -225,13 +226,22 @@ async def _membership_rows(
             if key in seen:
                 continue
             seen.add(key)
+            # raw_provider_user_id carries the RESOLVER-CONSUMED identity
+            # (github:<login>), not the bare login: that is the facet a no-email
+            # assignee resolves to (IdentityResolver fallback) and the only
+            # member_by_identity slot free to hold it (member_id is the PK). The
+            # bare login is still preserved inside member_id. (CHAOS-2609)
+            qualified_identity = (
+                provider_qualified_identity(PROVIDER, username=raw_identity)
+                or raw_identity
+            )
             rows.append(
                 TeamMembershipRecord(
                     org_id=org_id,
                     provider=PROVIDER,
                     team_id=team_id,
                     member_id=member_id,
-                    raw_provider_user_id=raw_identity,
+                    raw_provider_user_id=qualified_identity,
                     raw_email=getattr(member, "email", None),
                     source="provider_access",
                     is_primary=0,

--- a/src/dev_health_ops/workers/team_autoimport_gitlab.py
+++ b/src/dev_health_ops/workers/team_autoimport_gitlab.py
@@ -88,6 +88,7 @@ async def _populate_async(
         teams=teams,
         now=now,
     )
+    _apply_member_roster(team_rows=team_rows, membership_rows=membership_rows)
 
     sink = _sink(scope)
     await sink.insert_teams(team_rows)
@@ -260,6 +261,27 @@ async def _membership_rows(
                 )
             )
     return rows
+
+
+def _apply_member_roster(
+    *,
+    team_rows: list[dict[str, Any]],
+    membership_rows: Iterable[TeamMembershipRecord],
+) -> None:
+    """Populate each team row's ``members`` roster from discovered memberships.
+
+    Mirrors the linear/jira auto-import (which set ``teams.members`` from the
+    discovered roster) so gitlab teams also carry a non-empty roster column, not
+    just the ``team_memberships`` edge rows.
+    """
+    roster: dict[str, list[str]] = {}
+    for row in membership_rows:
+        identity = row.raw_provider_user_id
+        if not identity:
+            continue
+        roster.setdefault(row.team_id, []).append(identity)
+    for team_row in team_rows:
+        team_row["members"] = roster.get(str(team_row["id"]), [])
 
 
 def _sink(scope: Mapping[str, Any]) -> ClickHouseMetricsSink:

--- a/src/dev_health_ops/workers/team_autoimport_gitlab.py
+++ b/src/dev_health_ops/workers/team_autoimport_gitlab.py
@@ -262,7 +262,9 @@ async def _membership_rows(
             # the teams.members roster so BOTH attribution paths match aliased and
             # non-aliased members (CHAOS-2609).
             facets = resolver.membership_facets(
-                provider=PROVIDER, username=raw_identity
+                provider=PROVIDER,
+                username=raw_identity,
+                email=getattr(member, "email", None),
             ) or [raw_identity]
             roster_for_team = roster.setdefault(team_id, [])
             for facet in facets:

--- a/src/dev_health_ops/workers/team_autoimport_gitlab.py
+++ b/src/dev_health_ops/workers/team_autoimport_gitlab.py
@@ -18,6 +18,7 @@ from dev_health_ops.metrics.schemas import (
     TeamProjectOwnershipRecord,
 )
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.providers.identity import provider_qualified_identity
 from dev_health_ops.providers.team_capabilities import team_provider_capabilities
 
 logger = logging.getLogger(__name__)
@@ -244,13 +245,22 @@ async def _membership_rows(
             if key in seen:
                 continue
             seen.add(key)
+            # raw_provider_user_id carries the RESOLVER-CONSUMED identity
+            # (gitlab:<username>), not the bare username: that is the facet a
+            # no-email assignee resolves to (IdentityResolver fallback) and the
+            # only member_by_identity slot free to hold it (member_id is the PK).
+            # The bare username is still preserved inside member_id. (CHAOS-2609)
+            qualified_identity = (
+                provider_qualified_identity(PROVIDER, username=raw_identity)
+                or raw_identity
+            )
             rows.append(
                 TeamMembershipRecord(
                     org_id=org_id,
                     provider=PROVIDER,
                     team_id=team_id,
                     member_id=member_id,
-                    raw_provider_user_id=raw_identity,
+                    raw_provider_user_id=qualified_identity,
                     raw_email=getattr(member, "email", None),
                     source="provider_access",
                     is_primary=0,

--- a/src/dev_health_ops/workers/team_autoimport_gitlab.py
+++ b/src/dev_health_ops/workers/team_autoimport_gitlab.py
@@ -18,7 +18,7 @@ from dev_health_ops.metrics.schemas import (
     TeamProjectOwnershipRecord,
 )
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
-from dev_health_ops.providers.identity import provider_qualified_identity
+from dev_health_ops.providers.identity import IdentityResolver, load_identity_resolver
 from dev_health_ops.providers.team_capabilities import team_provider_capabilities
 
 logger = logging.getLogger(__name__)
@@ -80,16 +80,22 @@ async def _populate_async(
         return _zero_summary(org_id=org_id, reason="no_provider_teams")
 
     now = datetime.now(timezone.utc)
+    # Same alias map the assignee/compute path uses (load_identity_resolver in
+    # job_work_items / providers.base), so an aliased member resolves to the SAME
+    # canonical identity an aliased assignee does (CHAOS-2609).
+    resolver = load_identity_resolver()
     team_rows = _team_rows(org_id=org_id, teams=teams, now=now)
     project_rows = _project_ownership_rows(org_id=org_id, teams=teams, now=now)
-    membership_rows = await _membership_rows(
+    membership_rows, member_roster = await _membership_rows(
         org_id=org_id,
         token=token,
         url=url,
         teams=teams,
         now=now,
+        resolver=resolver,
     )
-    _apply_member_roster(team_rows=team_rows, membership_rows=membership_rows)
+    for team_row in team_rows:
+        team_row["members"] = member_roster.get(str(team_row["id"]), [])
 
     sink = _sink(scope)
     await sink.insert_teams(team_rows)
@@ -215,9 +221,11 @@ async def _membership_rows(
     url: str,
     teams: Iterable[Any],
     now: datetime,
-) -> list[TeamMembershipRecord]:
+    resolver: IdentityResolver,
+) -> tuple[list[TeamMembershipRecord], dict[str, list[str]]]:
     service = TeamMembershipService(session=cast(Any, None), org_id=org_id)
     rows: list[TeamMembershipRecord] = []
+    roster: dict[str, list[str]] = {}
     seen: set[tuple[str, str]] = set()
     for team in teams:
         group_path = str(getattr(team, "provider_team_id"))
@@ -245,22 +253,28 @@ async def _membership_rows(
             if key in seen:
                 continue
             seen.add(key)
-            # raw_provider_user_id carries the RESOLVER-CONSUMED identity
-            # (gitlab:<username>), not the bare username: that is the facet a
-            # no-email assignee resolves to (IdentityResolver fallback) and the
-            # only member_by_identity slot free to hold it (member_id is the PK).
-            # The bare username is still preserved inside member_id. (CHAOS-2609)
-            qualified_identity = (
-                provider_qualified_identity(PROVIDER, username=raw_identity)
-                or raw_identity
-            )
+            # Resolve the member through the SAME org alias map an assignee uses:
+            # facets[0] is the alias-resolved identity (canonical email when the
+            # gitlab:<username> is aliased, else gitlab:<username>) — the facet a
+            # no-email assignee resolves to. It goes into raw_provider_user_id
+            # (the only member_by_identity slot free; member_id is the PK and
+            # keeps the bare username) AND, with the provider-qualified id, into
+            # the teams.members roster so BOTH attribution paths match aliased and
+            # non-aliased members (CHAOS-2609).
+            facets = resolver.membership_facets(
+                provider=PROVIDER, username=raw_identity
+            ) or [raw_identity]
+            roster_for_team = roster.setdefault(team_id, [])
+            for facet in facets:
+                if facet not in roster_for_team:
+                    roster_for_team.append(facet)
             rows.append(
                 TeamMembershipRecord(
                     org_id=org_id,
                     provider=PROVIDER,
                     team_id=team_id,
                     member_id=member_id,
-                    raw_provider_user_id=qualified_identity,
+                    raw_provider_user_id=facets[0],
                     raw_email=getattr(member, "email", None),
                     source="provider_access",
                     is_primary=0,
@@ -270,28 +284,7 @@ async def _membership_rows(
                     updated_at=now,
                 )
             )
-    return rows
-
-
-def _apply_member_roster(
-    *,
-    team_rows: list[dict[str, Any]],
-    membership_rows: Iterable[TeamMembershipRecord],
-) -> None:
-    """Populate each team row's ``members`` roster from discovered memberships.
-
-    Mirrors the linear/jira auto-import (which set ``teams.members`` from the
-    discovered roster) so gitlab teams also carry a non-empty roster column, not
-    just the ``team_memberships`` edge rows.
-    """
-    roster: dict[str, list[str]] = {}
-    for row in membership_rows:
-        identity = row.raw_provider_user_id
-        if not identity:
-            continue
-        roster.setdefault(row.team_id, []).append(identity)
-    for team_row in team_rows:
-        team_row["members"] = roster.get(str(team_row["id"]), [])
+    return rows, roster
 
 
 def _sink(scope: Mapping[str, Any]) -> ClickHouseMetricsSink:

--- a/src/dev_health_ops/workers/team_autoimport_jira.py
+++ b/src/dev_health_ops/workers/team_autoimport_jira.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 from collections.abc import Coroutine, Sequence
 from datetime import datetime, timezone
@@ -24,6 +25,7 @@ from dev_health_ops.metrics.schemas import (
     TeamProjectOwnershipRecord,
 )
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.providers.identity import provider_qualified_identity
 
 _T = TypeVar("_T")
 
@@ -159,13 +161,34 @@ def populate(
     now = datetime.now(timezone.utc)
     discovery = TeamDiscoveryService(None, org_id)
     membership = TeamMembershipService(cast(AsyncSession, None), org_id)
-    teams = _run(
-        discovery.discover_jira(
-            email=jira_credentials.email,
-            api_token=jira_credentials.api_token,
-            url=jira_credentials.base_url,
+    try:
+        teams = _run(
+            discovery.discover_jira(
+                email=jira_credentials.email,
+                api_token=jira_credentials.api_token,
+                url=jira_credentials.base_url,
+            )
         )
-    )
+    except Exception as exc:
+        # Mirror github/gitlab: a discovery failure (e.g. HTTP 403) skips the
+        # import INTERNALLY without writing anything, so a manual ownership row
+        # is never clobbered and the sync stays successful (CHAOS-2609).
+        logging.getLogger(__name__).info(
+            "Skipping Jira team auto-import for org_id=%s: discovery failed: %s",
+            org_id,
+            exc,
+        )
+        return {
+            "status": "skipped",
+            "reason": "provider_discovery_skipped",
+            "teams_imported": 0,
+            "projects_imported": 0,
+            "members_imported": 0,
+            "team_memberships_imported": 0,
+            "team_project_ownership_imported": 0,
+            "team_repo_ownership_imported": 0,
+            "work_item_team_attributions_imported": 0,
+        }
 
     team_rows: list[dict[str, Any]] = []
     project_rows: list[ProjectRecord] = []
@@ -234,11 +257,20 @@ def populate(
                 project_keys=project_keys,
             )
         )
+        # Roster carries the RESOLVER-CONSUMED identity (jira:accountid:<id>) so
+        # the secondary TeamResolver matches a no-email assignee, which
+        # IdentityResolver resolves to that same facet (CHAOS-2609).
         team_rows[-1]["members"] = [
-            member.provider_identity for member in discovered_members
+            provider_qualified_identity("jira", account_id=member.provider_identity)
+            or member.provider_identity
+            for member in discovered_members
         ]
         for member in discovered_members:
             member_id = _member_id("jira", member.provider_identity)
+            qualified_identity = (
+                provider_qualified_identity("jira", account_id=member.provider_identity)
+                or member.provider_identity
+            )
             member_rows.append(
                 MemberRecord(
                     org_id=org_id,
@@ -258,7 +290,7 @@ def populate(
                     provider="jira",
                     team_id=team_id,
                     member_id=member_id,
-                    raw_provider_user_id=member.provider_identity,
+                    raw_provider_user_id=qualified_identity,
                     raw_email=member.email,
                     source="native",
                     is_primary=1 if member.role == "lead" else 0,

--- a/src/dev_health_ops/workers/team_autoimport_jira.py
+++ b/src/dev_health_ops/workers/team_autoimport_jira.py
@@ -25,7 +25,7 @@ from dev_health_ops.metrics.schemas import (
     TeamProjectOwnershipRecord,
 )
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
-from dev_health_ops.providers.identity import provider_qualified_identity
+from dev_health_ops.providers.identity import load_identity_resolver
 
 _T = TypeVar("_T")
 
@@ -190,6 +190,11 @@ def populate(
             "work_item_team_attributions_imported": 0,
         }
 
+    # Same alias map the assignee/compute path uses (load_identity_resolver in
+    # job_work_items / providers.base), so an aliased member resolves to the SAME
+    # canonical identity an aliased assignee does (CHAOS-2609).
+    resolver = load_identity_resolver()
+
     team_rows: list[dict[str, Any]] = []
     project_rows: list[ProjectRecord] = []
     member_rows: list[MemberRecord] = []
@@ -257,20 +262,21 @@ def populate(
                 project_keys=project_keys,
             )
         )
-        # Roster carries the RESOLVER-CONSUMED identity (jira:accountid:<id>) so
-        # the secondary TeamResolver matches a no-email assignee, which
-        # IdentityResolver resolves to that same facet (CHAOS-2609).
-        team_rows[-1]["members"] = [
-            provider_qualified_identity("jira", account_id=member.provider_identity)
-            or member.provider_identity
-            for member in discovered_members
-        ]
+        # Resolve each member through the SAME org alias map an assignee uses:
+        # facets[0] is the alias-resolved identity (canonical email when the
+        # accountId is aliased, else jira:accountid:<id>) — the facet a no-email
+        # assignee resolves to. raw_provider_user_id stores it (member_id PK keeps
+        # the jira:<id> form); the roster carries all facets so BOTH attribution
+        # paths match aliased and non-aliased members (CHAOS-2609).
+        roster_facets: list[str] = []
         for member in discovered_members:
             member_id = _member_id("jira", member.provider_identity)
-            qualified_identity = (
-                provider_qualified_identity("jira", account_id=member.provider_identity)
-                or member.provider_identity
-            )
+            facets = resolver.membership_facets(
+                provider="jira", account_id=member.provider_identity
+            ) or [member.provider_identity]
+            for facet in facets:
+                if facet not in roster_facets:
+                    roster_facets.append(facet)
             member_rows.append(
                 MemberRecord(
                     org_id=org_id,
@@ -290,7 +296,7 @@ def populate(
                     provider="jira",
                     team_id=team_id,
                     member_id=member_id,
-                    raw_provider_user_id=qualified_identity,
+                    raw_provider_user_id=facets[0],
                     raw_email=member.email,
                     source="native",
                     is_primary=1 if member.role == "lead" else 0,
@@ -300,6 +306,7 @@ def populate(
                     updated_at=now,
                 )
             )
+        team_rows[-1]["members"] = roster_facets
 
     sink, should_close = _sink_from_kwargs(scope, kwargs)
     try:

--- a/src/dev_health_ops/workers/team_autoimport_jira.py
+++ b/src/dev_health_ops/workers/team_autoimport_jira.py
@@ -272,7 +272,9 @@ def populate(
         for member in discovered_members:
             member_id = _member_id("jira", member.provider_identity)
             facets = resolver.membership_facets(
-                provider="jira", account_id=member.provider_identity
+                provider="jira",
+                account_id=member.provider_identity,
+                email=member.email,
             ) or [member.provider_identity]
             for facet in facets:
                 if facet not in roster_facets:

--- a/tests/test_gitlab_provider.py
+++ b/tests/test_gitlab_provider.py
@@ -11,6 +11,7 @@ from dev_health_ops.providers.gitlab.normalize import (
     detect_gitlab_reopen_events,
     enrich_work_item_with_priority,
     extract_gitlab_dependencies,
+    gitlab_epic_to_work_item,
     gitlab_issue_to_work_item,
     gitlab_milestone_to_sprint,
     gitlab_mr_to_work_item,
@@ -149,6 +150,120 @@ class TestGitLabIssueToWorkItem:
         assert work_item.sprint_id == "5"
         assert work_item.sprint_name == "Sprint 1"
         assert work_item.closed_at is not None
+
+
+class TestGitLabEpicToWorkItem:
+    """Tests for gitlab_epic_to_work_item (CHAOS-2609 CS-COV item 2).
+
+    Epics are gated behind GITLAB_FETCH_EPICS (default true) and were previously
+    untested. Epics are group-level, so the work item is keyed by group path.
+    """
+
+    def test_basic_epic_type_and_ids(
+        self, mock_identity: IdentityResolver, mock_status_mapping: StatusMapping
+    ) -> None:
+        epic = {
+            "iid": 7,
+            "title": "Platform Epic",
+            "description": "Epic body",
+            "state": "opened",
+            "created_at": "2025-01-01T10:00:00Z",
+            "updated_at": "2025-01-15T12:00:00Z",
+            "labels": ["roadmap"],
+            "author": {"username": "lead1", "name": "Lead One"},
+            "web_url": "https://gitlab.com/groups/my-group/-/epics/7",
+        }
+
+        work_item, transitions = gitlab_epic_to_work_item(
+            epic=epic,
+            group_full_path="my-group",
+            status_mapping=mock_status_mapping,
+            identity=mock_identity,
+        )
+
+        assert work_item.work_item_id == "gitlab:my-group:epic:7"
+        assert work_item.type == "epic"
+        assert work_item.provider == "gitlab"
+        assert work_item.project_id == "my-group"
+        assert work_item.repo_id is None
+        assert work_item.reporter == "user:lead1"
+        assert transitions == []
+
+    def test_state_event_status_mapping_closed_and_opened(
+        self, mock_identity: IdentityResolver, mock_status_mapping: StatusMapping
+    ) -> None:
+        epic = {
+            "iid": 8,
+            "title": "Lifecycle Epic",
+            "state": "closed",
+            "created_at": "2025-01-01T10:00:00Z",
+            "updated_at": "2025-02-01T10:00:00Z",
+            "closed_at": "2025-02-01T10:00:00Z",
+            "labels": [],
+            "author": None,
+        }
+        state_events = [
+            {"state": "opened", "created_at": "2025-01-01T10:00:00Z"},
+            {"state": "closed", "created_at": "2025-02-01T10:00:00Z"},
+        ]
+
+        work_item, transitions = gitlab_epic_to_work_item(
+            epic=epic,
+            group_full_path="my-group",
+            status_mapping=mock_status_mapping,
+            identity=mock_identity,
+            state_events=state_events,
+        )
+
+        assert work_item.work_item_id == "gitlab:my-group:epic:8"
+        assert [t.to_status for t in transitions] == ["todo", "done"]
+        assert [t.to_status_raw for t in transitions] == ["opened", "closed"]
+
+    def test_epic_id_parent_linkage(
+        self, mock_identity: IdentityResolver, mock_status_mapping: StatusMapping
+    ) -> None:
+        epic = {
+            "iid": 9,
+            "title": "Child Epic",
+            "state": "opened",
+            "created_at": "2025-01-01T10:00:00Z",
+            "updated_at": "2025-01-02T10:00:00Z",
+            "labels": [],
+            "author": None,
+            "parent_iid": 3,
+        }
+
+        work_item, _ = gitlab_epic_to_work_item(
+            epic=epic,
+            group_full_path="my-group",
+            status_mapping=mock_status_mapping,
+            identity=mock_identity,
+        )
+
+        assert work_item.epic_id == "gitlab:my-group:epic:3"
+
+    def test_priority_from_labels(
+        self, mock_identity: IdentityResolver, mock_status_mapping: StatusMapping
+    ) -> None:
+        epic = {
+            "iid": 10,
+            "title": "Urgent Epic",
+            "state": "opened",
+            "created_at": "2025-01-01T10:00:00Z",
+            "updated_at": "2025-01-02T10:00:00Z",
+            "labels": ["priority::high"],
+            "author": None,
+        }
+
+        work_item, _ = gitlab_epic_to_work_item(
+            epic=epic,
+            group_full_path="my-group",
+            status_mapping=mock_status_mapping,
+            identity=mock_identity,
+        )
+
+        assert work_item.priority_raw == "high"
+        assert work_item.service_class == "fixed_date"
 
 
 class TestGitLabMRToWorkItem:

--- a/tests/test_jira_extras.py
+++ b/tests/test_jira_extras.py
@@ -166,7 +166,12 @@ def test_jira_comment_to_interaction_event() -> None:
     assert event.provider == "jira"
     assert event.interaction_type == "comment"
     assert event.body_length == 5
-    assert event.actor == "Alice"
+    # CHAOS-2609: a no-email Jira actor now resolves to the STABLE, provider-
+    # qualified accountId facet (jira:accountid:<id>) rather than the unreliable
+    # display name. This is the same identity team auto-import writes into
+    # team_memberships, so actors/assignees can be attributed to a team; the
+    # display name could collide or change and never matched membership.
+    assert event.actor == "jira:accountid:acct-123"
 
 
 def test_jira_sprint_payload_to_model() -> None:

--- a/tests/workers/test_team_autoimport_e2e_sync_surface.py
+++ b/tests/workers/test_team_autoimport_e2e_sync_surface.py
@@ -633,6 +633,8 @@ _NO_EMAIL_ASSIGNEE: dict[str, dict[str, Any]] = {
         "no_alias_identity": "github:platform-lead",
         "alias_key": "github:platform-lead",
         "canonical": "gh-lead@example.com",
+        # The member's email from _patch_provider_stubs.discover_members_github.
+        "member_email": "platform@example.com",
         "team_id": "gh:platform",
     },
     "gitlab": {
@@ -640,6 +642,7 @@ _NO_EMAIL_ASSIGNEE: dict[str, dict[str, Any]] = {
         "no_alias_identity": "gitlab:dev-health-maintainer",
         "alias_key": "gitlab:dev-health-maintainer",
         "canonical": "gl-lead@example.com",
+        "member_email": "gitlab@example.com",
         "team_id": "gl:full-chaos/dev-health",
     },
     "jira": {
@@ -647,6 +650,7 @@ _NO_EMAIL_ASSIGNEE: dict[str, dict[str, Any]] = {
         "no_alias_identity": "jira:accountid:jira-ops-account",
         "alias_key": "jira:accountid:jira-ops-account",
         "canonical": "jira-lead@example.com",
+        "member_email": "jira-ops@example.com",
         "team_id": "OPS",
     },
 }
@@ -690,11 +694,20 @@ def _membership_probe_work_item(provider: str, assignee: str) -> WorkItem:
     )
 
 
-@pytest.mark.parametrize("aliased", [False, True], ids=["no_alias", "aliased"])
+# scenario → (alias file aliased?, builds an email-bearing assignee?)
+#   no_alias : no alias map, no-email assignee → resolves to provider-qualified id
+#   aliased  : alias map present, no-email assignee → resolves to canonical email
+#   email    : no alias map, assignee carries the member's EMAIL → resolves to that
+#              email (regression for the email+provider-id member: the ladder
+#              matched via raw_email but the roster used to MISS — CHAOS-2609 r4)
+_E2E_SCENARIOS = ["no_alias", "aliased", "email"]
+
+
+@pytest.mark.parametrize("scenario", _E2E_SCENARIOS, ids=_E2E_SCENARIOS)
 @pytest.mark.parametrize("provider", ["github", "gitlab", "jira"])
 def test_chaos_2609_no_email_assignee_resolves_to_autoimported_team_via_both_paths(
     provider: str,
-    aliased: bool,
+    scenario: str,
     monkeypatch: pytest.MonkeyPatch,
     sync_session_factory: Callable[[], Any],
     tmp_path: Any,
@@ -703,7 +716,7 @@ def test_chaos_2609_no_email_assignee_resolves_to_autoimported_team_via_both_pat
     # it, and the assignee path resolves the assignee through it. Point both at
     # the SAME file via IDENTITY_MAPPING_PATH so the aliased case is faithful.
     mapping_path = tmp_path / "identity_mapping.yaml"
-    _write_identity_mapping(mapping_path, aliased=aliased)
+    _write_identity_mapping(mapping_path, aliased=(scenario == "aliased"))
     monkeypatch.setenv("IDENTITY_MAPPING_PATH", str(mapping_path))
 
     sink = RecordingClickHouseSink()
@@ -717,12 +730,21 @@ def test_chaos_2609_no_email_assignee_resolves_to_autoimported_team_via_both_pat
     assert sink.memberships, "auto-import must populate team_memberships"
 
     spec = _NO_EMAIL_ASSIGNEE[provider]
-    expected_identity = spec["canonical"] if aliased else spec["no_alias_identity"]
+    if scenario == "email":
+        # An assignee that carries the member's email — resolves BY email.
+        resolve_kwargs = {**spec["resolve_kwargs"], "email": spec["member_email"]}
+        expected_identity = spec["member_email"]
+    elif scenario == "aliased":
+        resolve_kwargs = spec["resolve_kwargs"]
+        expected_identity = spec["canonical"]
+    else:
+        resolve_kwargs = spec["resolve_kwargs"]
+        expected_identity = spec["no_alias_identity"]
 
-    # 1. The REAL resolver (same alias map auto-import used) turns a no-email
-    #    assignee into the alias-resolved identity — a canonical email when
-    #    aliased, the provider-qualified id otherwise.
-    assignee = load_identity_resolver().resolve(**spec["resolve_kwargs"])
+    # 1. The REAL resolver (same alias map auto-import used) turns the assignee
+    #    into the identity it resolves to: provider-qualified id (no_alias),
+    #    canonical email (aliased), or the member's email (email scenario).
+    assignee = load_identity_resolver().resolve(**resolve_kwargs)
     assert assignee == expected_identity
 
     item = _membership_probe_work_item(provider, assignee)
@@ -738,14 +760,15 @@ def test_chaos_2609_no_email_assignee_resolves_to_autoimported_team_via_both_pat
         attribution_context=context,
     )
     assert ladder_team_id == spec["team_id"], (
-        f"{provider} (aliased={aliased}): no-email assignee {assignee!r} must "
-        f"resolve to the auto-imported team via the canonical ladder"
+        f"{provider} ({scenario}): assignee {assignee!r} must resolve to the "
+        f"auto-imported team via the canonical ladder"
     )
     assert ladder_team_name
     assert any(c.source == "assignee_membership" for c in candidates)
 
     # 3. Secondary TeamResolver: the teams.members roster resolves the SAME
-    #    assignee to the SAME team (the path the cosmetic roster fix missed).
+    #    assignee to the SAME team (the path the cosmetic roster fix missed, and
+    #    the path the email-bearing member used to miss before r4).
     team_resolver = TeamResolver(
         member_to_team=_build_member_to_team(list(sink.teams.values()))
     )
@@ -756,6 +779,6 @@ def test_chaos_2609_no_email_assignee_resolves_to_autoimported_team_via_both_pat
         attribution_context=None,
     )
     assert roster_team_id == spec["team_id"], (
-        f"{provider} (aliased={aliased}): teams.members roster must resolve "
-        f"no-email assignee {assignee!r} to the auto-imported team via TeamResolver"
+        f"{provider} ({scenario}): teams.members roster must resolve assignee "
+        f"{assignee!r} to the auto-imported team via TeamResolver"
     )

--- a/tests/workers/test_team_autoimport_e2e_sync_surface.py
+++ b/tests/workers/test_team_autoimport_e2e_sync_surface.py
@@ -37,7 +37,7 @@ from dev_health_ops.models.work_items import (
     WorkItemProvider,
     WorkItemStatusTransition,
 )
-from dev_health_ops.providers.identity import IdentityResolver
+from dev_health_ops.providers.identity import load_identity_resolver
 from dev_health_ops.providers.teams import TeamResolver, _build_member_to_team
 from dev_health_ops.workers import (
     sync_runtime,
@@ -619,31 +619,51 @@ def test_chaos_2401_2466_regression_work_item_sync_cannot_skip_autoimport_owners
     )
 
 
-# CHAOS-2609: a no-email assignee carries the resolver-consumed, provider-
-# qualified identity (github:<login> / gitlab:<username> / jira:accountid:<id>),
-# NOT a bare login or email. The auto-import writer must put that SAME identity
-# into the team_memberships facet the canonical ladder indexes AND the
-# teams.members roster the secondary TeamResolver reads — otherwise member-based
-# attribution silently misses for no-email assignees. Each entry pairs the
-# IdentityResolver kwargs for a no-email assignee with the team that auto-import
-# created for that member in _patch_provider_stubs.
+# CHAOS-2609: a no-email assignee carries the resolver-consumed identity — the
+# string IdentityResolver.resolve returns UNDER THE ORG'S ALIAS MAP. With no
+# alias that is the provider-qualified id (github:<login> / gitlab:<username> /
+# jira:accountid:<id>); with an alias mapping that id to a canonical email, it is
+# that email. Auto-import must store whatever the resolver produces, so the
+# match holds either way. Each entry: the resolve() kwargs for a no-email
+# assignee, the no-alias identity, the alias key + canonical the alias maps it
+# to, and the team auto-import created for that member in _patch_provider_stubs.
 _NO_EMAIL_ASSIGNEE: dict[str, dict[str, Any]] = {
     "github": {
         "resolve_kwargs": {"provider": "github", "username": "platform-lead"},
-        "expected_identity": "github:platform-lead",
+        "no_alias_identity": "github:platform-lead",
+        "alias_key": "github:platform-lead",
+        "canonical": "gh-lead@example.com",
         "team_id": "gh:platform",
     },
     "gitlab": {
         "resolve_kwargs": {"provider": "gitlab", "username": "dev-health-maintainer"},
-        "expected_identity": "gitlab:dev-health-maintainer",
+        "no_alias_identity": "gitlab:dev-health-maintainer",
+        "alias_key": "gitlab:dev-health-maintainer",
+        "canonical": "gl-lead@example.com",
         "team_id": "gl:full-chaos/dev-health",
     },
     "jira": {
         "resolve_kwargs": {"provider": "jira", "account_id": "jira-ops-account"},
-        "expected_identity": "jira:accountid:jira-ops-account",
+        "no_alias_identity": "jira:accountid:jira-ops-account",
+        "alias_key": "jira:accountid:jira-ops-account",
+        "canonical": "jira-lead@example.com",
         "team_id": "OPS",
     },
 }
+
+
+def _write_identity_mapping(path: Any, *, aliased: bool) -> None:
+    """Write the global identity_mapping.yaml that BOTH the auto-import path and
+    the assignee path read via load_identity_resolver() (IDENTITY_MAPPING_PATH)."""
+    if not aliased:
+        path.write_text("identities: []\n")
+        return
+    lines = ["identities:"]
+    for spec in _NO_EMAIL_ASSIGNEE.values():
+        lines.append(f"  - canonical: {spec['canonical']}")
+        lines.append("    aliases:")
+        lines.append(f"      - {spec['alias_key']}")
+    path.write_text("\n".join(lines) + "\n")
 
 
 def _membership_probe_work_item(provider: str, assignee: str) -> WorkItem:
@@ -670,14 +690,23 @@ def _membership_probe_work_item(provider: str, assignee: str) -> WorkItem:
     )
 
 
+@pytest.mark.parametrize("aliased", [False, True], ids=["no_alias", "aliased"])
 @pytest.mark.parametrize("provider", ["github", "gitlab", "jira"])
 def test_chaos_2609_no_email_assignee_resolves_to_autoimported_team_via_both_paths(
     provider: str,
+    aliased: bool,
     monkeypatch: pytest.MonkeyPatch,
     sync_session_factory: Callable[[], Any],
+    tmp_path: Any,
 ) -> None:
-    sink = RecordingClickHouseSink()
+    # The org's alias map drives BOTH sides: auto-import resolves members through
+    # it, and the assignee path resolves the assignee through it. Point both at
+    # the SAME file via IDENTITY_MAPPING_PATH so the aliased case is faithful.
+    mapping_path = tmp_path / "identity_mapping.yaml"
+    _write_identity_mapping(mapping_path, aliased=aliased)
+    monkeypatch.setenv("IDENTITY_MAPPING_PATH", str(mapping_path))
 
+    sink = RecordingClickHouseSink()
     result = _run_sync_surface(
         provider=provider,
         monkeypatch=monkeypatch,
@@ -688,11 +717,13 @@ def test_chaos_2609_no_email_assignee_resolves_to_autoimported_team_via_both_pat
     assert sink.memberships, "auto-import must populate team_memberships"
 
     spec = _NO_EMAIL_ASSIGNEE[provider]
+    expected_identity = spec["canonical"] if aliased else spec["no_alias_identity"]
 
-    # 1. The REAL IdentityResolver turns a no-email assignee into the
-    #    provider-qualified facet (proves what the assignee path produces).
-    assignee = IdentityResolver(alias_to_canonical={}).resolve(**spec["resolve_kwargs"])
-    assert assignee == spec["expected_identity"]
+    # 1. The REAL resolver (same alias map auto-import used) turns a no-email
+    #    assignee into the alias-resolved identity — a canonical email when
+    #    aliased, the provider-qualified id otherwise.
+    assignee = load_identity_resolver().resolve(**spec["resolve_kwargs"])
+    assert assignee == expected_identity
 
     item = _membership_probe_work_item(provider, assignee)
 
@@ -707,8 +738,8 @@ def test_chaos_2609_no_email_assignee_resolves_to_autoimported_team_via_both_pat
         attribution_context=context,
     )
     assert ladder_team_id == spec["team_id"], (
-        f"{provider}: no-email assignee {assignee!r} must resolve to the "
-        f"auto-imported team via the canonical ladder"
+        f"{provider} (aliased={aliased}): no-email assignee {assignee!r} must "
+        f"resolve to the auto-imported team via the canonical ladder"
     )
     assert ladder_team_name
     assert any(c.source == "assignee_membership" for c in candidates)
@@ -725,6 +756,6 @@ def test_chaos_2609_no_email_assignee_resolves_to_autoimported_team_via_both_pat
         attribution_context=None,
     )
     assert roster_team_id == spec["team_id"], (
-        f"{provider}: teams.members roster must resolve no-email assignee "
-        f"{assignee!r} to the auto-imported team via TeamResolver"
+        f"{provider} (aliased={aliased}): teams.members roster must resolve "
+        f"no-email assignee {assignee!r} to the auto-imported team via TeamResolver"
     )

--- a/tests/workers/test_team_autoimport_e2e_sync_surface.py
+++ b/tests/workers/test_team_autoimport_e2e_sync_surface.py
@@ -21,6 +21,7 @@ from dev_health_ops.metrics.compute_work_items import (
     TeamAttributionCandidate,
     TeamAttributionContext,
     TeamAttributionSource,
+    resolve_team_attribution,
 )
 from dev_health_ops.metrics.schemas import (
     MemberRecord,
@@ -36,6 +37,8 @@ from dev_health_ops.models.work_items import (
     WorkItemProvider,
     WorkItemStatusTransition,
 )
+from dev_health_ops.providers.identity import IdentityResolver
+from dev_health_ops.providers.teams import TeamResolver, _build_member_to_team
 from dev_health_ops.workers import (
     sync_runtime,
     team_autoimport_github,
@@ -613,4 +616,115 @@ def test_chaos_2401_2466_regression_work_item_sync_cannot_skip_autoimport_owners
     assert sink.memberships, (
         "CHAOS-2401/2466 regression: auto-import dispatch must write "
         "team_memberships for attribution"
+    )
+
+
+# CHAOS-2609: a no-email assignee carries the resolver-consumed, provider-
+# qualified identity (github:<login> / gitlab:<username> / jira:accountid:<id>),
+# NOT a bare login or email. The auto-import writer must put that SAME identity
+# into the team_memberships facet the canonical ladder indexes AND the
+# teams.members roster the secondary TeamResolver reads — otherwise member-based
+# attribution silently misses for no-email assignees. Each entry pairs the
+# IdentityResolver kwargs for a no-email assignee with the team that auto-import
+# created for that member in _patch_provider_stubs.
+_NO_EMAIL_ASSIGNEE: dict[str, dict[str, Any]] = {
+    "github": {
+        "resolve_kwargs": {"provider": "github", "username": "platform-lead"},
+        "expected_identity": "github:platform-lead",
+        "team_id": "gh:platform",
+    },
+    "gitlab": {
+        "resolve_kwargs": {"provider": "gitlab", "username": "dev-health-maintainer"},
+        "expected_identity": "gitlab:dev-health-maintainer",
+        "team_id": "gl:full-chaos/dev-health",
+    },
+    "jira": {
+        "resolve_kwargs": {"provider": "jira", "account_id": "jira-ops-account"},
+        "expected_identity": "jira:accountid:jira-ops-account",
+        "team_id": "OPS",
+    },
+}
+
+
+def _membership_probe_work_item(provider: str, assignee: str) -> WorkItem:
+    """A work item whose ONLY attribution signal is its assignee — project_key,
+    project_id and repo deliberately match no ownership row, so the resolution
+    winner can only be assignee_membership."""
+    return WorkItem(
+        work_item_id=f"{provider}:no-email-assignee-probe#1",
+        provider=cast(WorkItemProvider, provider),
+        title="No-email assignee attribution probe",
+        type="task",
+        status="done",
+        status_raw="Done",
+        assignees=[assignee],
+        reporter=None,
+        created_at=NOW - timedelta(days=1),
+        updated_at=NOW,
+        started_at=NOW - timedelta(hours=2),
+        completed_at=NOW,
+        closed_at=NOW,
+        labels=[],
+        project_key=None,
+        project_id="zzz-unowned-scope-no-ownership-match",
+    )
+
+
+@pytest.mark.parametrize("provider", ["github", "gitlab", "jira"])
+def test_chaos_2609_no_email_assignee_resolves_to_autoimported_team_via_both_paths(
+    provider: str,
+    monkeypatch: pytest.MonkeyPatch,
+    sync_session_factory: Callable[[], Any],
+) -> None:
+    sink = RecordingClickHouseSink()
+
+    result = _run_sync_surface(
+        provider=provider,
+        monkeypatch=monkeypatch,
+        session_factory=sync_session_factory,
+        sink=sink,
+    )
+    assert result["status"] == "success"
+    assert sink.memberships, "auto-import must populate team_memberships"
+
+    spec = _NO_EMAIL_ASSIGNEE[provider]
+
+    # 1. The REAL IdentityResolver turns a no-email assignee into the
+    #    provider-qualified facet (proves what the assignee path produces).
+    assignee = IdentityResolver(alias_to_canonical={}).resolve(**spec["resolve_kwargs"])
+    assert assignee == spec["expected_identity"]
+
+    item = _membership_probe_work_item(provider, assignee)
+
+    # 2. Canonical ladder: member_by_identity built EXACTLY as production builds
+    #    it (member_id / raw_provider_user_id / raw_email) resolves the assignee
+    #    to the auto-imported team via assignee_membership.
+    context = _attribution_context_from_sink(sink)
+    ladder_team_id, ladder_team_name, candidates = resolve_team_attribution(
+        item,
+        team_resolver=None,
+        project_key_resolver=None,
+        attribution_context=context,
+    )
+    assert ladder_team_id == spec["team_id"], (
+        f"{provider}: no-email assignee {assignee!r} must resolve to the "
+        f"auto-imported team via the canonical ladder"
+    )
+    assert ladder_team_name
+    assert any(c.source == "assignee_membership" for c in candidates)
+
+    # 3. Secondary TeamResolver: the teams.members roster resolves the SAME
+    #    assignee to the SAME team (the path the cosmetic roster fix missed).
+    team_resolver = TeamResolver(
+        member_to_team=_build_member_to_team(list(sink.teams.values()))
+    )
+    roster_team_id, _, _ = resolve_team_attribution(
+        item,
+        team_resolver=team_resolver,
+        project_key_resolver=None,
+        attribution_context=None,
+    )
+    assert roster_team_id == spec["team_id"], (
+        f"{provider}: teams.members roster must resolve no-email assignee "
+        f"{assignee!r} to the auto-imported team via TeamResolver"
     )

--- a/tests/workers/test_team_autoimport_github_gitlab.py
+++ b/tests/workers/test_team_autoimport_github_gitlab.py
@@ -122,15 +122,20 @@ def test_github_org_import_writes_provider_access_repo_grants_and_nested_specifi
     assert child_row.repo_full_name == parent_row.repo_full_name
     assert child_row.specificity > parent_row.specificity
     # CHAOS-2609 (CS-COV): github teams carry a non-empty members roster whose
-    # entries are the RESOLVER-CONSUMED identity (github:<login>) — exactly what
-    # a no-email assignee resolves to — so the secondary TeamResolver matches.
+    # entries are EVERY identity an assignee could resolve to — the
+    # resolver-consumed github:<login> (no-email assignee) AND the member's email
+    # (email-bearing assignee) — so the secondary TeamResolver matches both.
     rosters = {row["id"]: row["members"] for row in sink.teams}
-    assert rosters["gh:platform"] == ["github:platform-lead"]
-    assert rosters["gh:platform-api"] == ["github:platform-api-lead"]
-    # The canonical-ladder facet (member_by_identity indexes raw_provider_user_id)
-    # carries the same github:<login> identity; member_id (PK) keeps the gh: form.
+    assert rosters["gh:platform"] == ["github:platform-lead", "platform@example.com"]
+    assert rosters["gh:platform-api"] == [
+        "github:platform-api-lead",
+        "platform-api@example.com",
+    ]
+    # The single canonical-ladder facet (raw_provider_user_id) carries the
+    # no-email identity; raw_email carries the email; member_id (PK) keeps gh:.
     by_member = {row.member_id: row for row in sink.memberships}
     assert by_member["gh:platform-lead"].raw_provider_user_id == "github:platform-lead"
+    assert by_member["gh:platform-lead"].raw_email == "platform@example.com"
 
 
 def test_gitlab_group_import_writes_provider_access_project_ownership(

--- a/tests/workers/test_team_autoimport_github_gitlab.py
+++ b/tests/workers/test_team_autoimport_github_gitlab.py
@@ -121,6 +121,11 @@ def test_github_org_import_writes_provider_access_repo_grants_and_nested_specifi
     )
     assert child_row.repo_full_name == parent_row.repo_full_name
     assert child_row.specificity > parent_row.specificity
+    # CHAOS-2609 (CS-COV) Part B: github teams also carry a non-empty members
+    # roster (teams.members), not just team_memberships edges.
+    rosters = {row["id"]: row["members"] for row in sink.teams}
+    assert rosters["gh:platform"] == ["platform-lead"]
+    assert rosters["gh:platform-api"] == ["platform-api-lead"]
 
 
 def test_gitlab_group_import_writes_provider_access_project_ownership(
@@ -204,6 +209,33 @@ def test_gitlab_group_import_writes_provider_access_project_ownership(
         "full-chaos/platform",
         "full-chaos/dev-health/api",
     }
+    # CHAOS-2609 (CS-COV) item 1: gitlab members are normalized AND asserted.
+    assert summary["team_memberships_imported"] == 2
+    assert summary["members_imported"] == 2
+    assert {row.member_id for row in sink.memberships} == {
+        "gl:full-chaos",
+        "gl:full-chaos-dev-health",
+    }
+    assert {row.source for row in sink.memberships} == {"provider_access"}
+    assert {row.priority for row in sink.memberships} == {
+        team_autoimport_gitlab.PROVIDER_ACCESS_PRIORITY
+    }
+    # CHAOS-2609 (CS-COV) Part B: gitlab teams also carry a non-empty members
+    # roster (teams.members), not just team_memberships edges.
+    rosters = {row["id"]: row["members"] for row in sink.teams}
+    assert rosters["gl:full-chaos"] == ["full-chaos"]
+    assert rosters["gl:full-chaos/dev-health"] == ["full-chaos-dev-health"]
+    # CHAOS-2609 (CS-COV) item 7: a nested subgroup's ownership is more specific
+    # than its parent group's, so it wins on specificity tie-breaks.
+    parent_proj = next(
+        row for row in sink.project_ownership if row.team_id == "gl:full-chaos"
+    )
+    subgroup_proj = next(
+        row
+        for row in sink.project_ownership
+        if row.team_id == "gl:full-chaos/dev-health"
+    )
+    assert subgroup_proj.specificity > parent_proj.specificity
 
 
 def test_github_personal_account_or_unsupported_response_skips_without_touching_manual_rows(

--- a/tests/workers/test_team_autoimport_github_gitlab.py
+++ b/tests/workers/test_team_autoimport_github_gitlab.py
@@ -121,11 +121,16 @@ def test_github_org_import_writes_provider_access_repo_grants_and_nested_specifi
     )
     assert child_row.repo_full_name == parent_row.repo_full_name
     assert child_row.specificity > parent_row.specificity
-    # CHAOS-2609 (CS-COV) Part B: github teams also carry a non-empty members
-    # roster (teams.members), not just team_memberships edges.
+    # CHAOS-2609 (CS-COV): github teams carry a non-empty members roster whose
+    # entries are the RESOLVER-CONSUMED identity (github:<login>) — exactly what
+    # a no-email assignee resolves to — so the secondary TeamResolver matches.
     rosters = {row["id"]: row["members"] for row in sink.teams}
-    assert rosters["gh:platform"] == ["platform-lead"]
-    assert rosters["gh:platform-api"] == ["platform-api-lead"]
+    assert rosters["gh:platform"] == ["github:platform-lead"]
+    assert rosters["gh:platform-api"] == ["github:platform-api-lead"]
+    # The canonical-ladder facet (member_by_identity indexes raw_provider_user_id)
+    # carries the same github:<login> identity; member_id (PK) keeps the gh: form.
+    by_member = {row.member_id: row for row in sink.memberships}
+    assert by_member["gh:platform-lead"].raw_provider_user_id == "github:platform-lead"
 
 
 def test_gitlab_group_import_writes_provider_access_project_ownership(
@@ -220,11 +225,14 @@ def test_gitlab_group_import_writes_provider_access_project_ownership(
     assert {row.priority for row in sink.memberships} == {
         team_autoimport_gitlab.PROVIDER_ACCESS_PRIORITY
     }
-    # CHAOS-2609 (CS-COV) Part B: gitlab teams also carry a non-empty members
-    # roster (teams.members), not just team_memberships edges.
+    # CHAOS-2609 (CS-COV): gitlab teams carry a non-empty members roster whose
+    # entries are the RESOLVER-CONSUMED identity (gitlab:<username>), and the
+    # canonical-ladder facet (raw_provider_user_id) carries the same identity.
     rosters = {row["id"]: row["members"] for row in sink.teams}
-    assert rosters["gl:full-chaos"] == ["full-chaos"]
-    assert rosters["gl:full-chaos/dev-health"] == ["full-chaos-dev-health"]
+    assert rosters["gl:full-chaos"] == ["gitlab:full-chaos"]
+    assert rosters["gl:full-chaos/dev-health"] == ["gitlab:full-chaos-dev-health"]
+    by_member = {row.member_id: row for row in sink.memberships}
+    assert by_member["gl:full-chaos"].raw_provider_user_id == "gitlab:full-chaos"
     # CHAOS-2609 (CS-COV) item 7: a nested subgroup's ownership is more specific
     # than its parent group's, so it wins on specificity tie-breaks.
     parent_proj = next(

--- a/tests/workers/test_team_autoimport_jira.py
+++ b/tests/workers/test_team_autoimport_jira.py
@@ -177,6 +177,12 @@ def test_jira_populate_writes_native_and_jira_legacy_ownership_without_touching_
         "jira_legacy",
     ) in sink.ownership
     assert ("org-1", "jira:account-1") in sink.members
+    # CHAOS-2609 (CS-COV) item 6: assert the emitted native ProjectRecord fields.
+    project = sink.projects[("org-1", "jira", "org-1:jira:OPS")]
+    assert project.project_key == "OPS"
+    assert project.name == "Ops Project"
+    assert project.org_id == "org-1"
+    assert project.provider == "jira"
 
 
 def test_chaos_2547_2544_jira_autoimport_uses_analytics_db_url_with_env_unset(
@@ -338,3 +344,141 @@ def test_jira_populate_preserves_manual_project_ownership_row(
         "OPS",
         "native",
     ) in sink.ownership
+
+
+def test_jira_discovery_failure_does_not_clobber_manual_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-2609 (CS-COV) item 3: a jira team-discovery failure (e.g. HTTP 403)
+    surfaces and writes nothing, so a pre-existing manual ownership row is left
+    intact (populate fails before any sink write; run_team_autoimport wraps the
+    error into a skipped sync result)."""
+
+    async def discover_jira(
+        self: object, email: str, api_token: str, url: str
+    ) -> list[DiscoveredTeam]:
+        raise RuntimeError("403")
+
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamDiscoveryService,
+        "discover_jira",
+        discover_jira,
+    )
+    sink = _fake_sink()
+    manual = TeamProjectOwnershipRecord(
+        org_id="org-1",
+        provider="jira",
+        team_id="manual-team",
+        project_id="org-1:jira:OPS",
+        project_key="OPS",
+        source="manual",
+        is_primary=1,
+        specificity=100,
+        priority=0,
+        valid_from=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    sink.write_team_project_ownership([manual])
+
+    with pytest.raises(RuntimeError, match="403"):
+        team_autoimport_jira.populate(
+            org_id="org-1",
+            credentials={
+                "email": "jira@example.com",
+                "api_token": "jira-token",
+                "base_url": "https://jira.example.com",
+            },
+            scope={"mode": "sync_config"},
+            sink=sink,
+        )
+
+    # The manual ownership row is untouched and no native rows were written.
+    assert (
+        "org-1",
+        "jira",
+        "org-1:jira:OPS",
+        "manual-team",
+        "manual",
+    ) in sink.ownership
+    assert len(sink.ownership) == 1
+    assert sink.teams == {}
+
+
+def test_jira_members_dedupe_to_one_row_per_member_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-2609 (CS-COV) item 4: the same account_id surfaced for multiple
+    projects de-dupes to a single member/membership row with a stable
+    ``jira:<account_id>`` id, and an email-less member is still imported."""
+
+    async def discover_jira(
+        self: object, email: str, api_token: str, url: str
+    ) -> list[DiscoveredTeam]:
+        return [
+            DiscoveredTeam(
+                provider_type="jira",
+                provider_team_id="OPS",
+                name="Ops Project",
+                associations={"project_keys": ["PROJ1", "PROJ2"]},
+            )
+        ]
+
+    async def discover_members_jira_bulk(
+        self: object,
+        *,
+        email: str,
+        api_token: str,
+        url: str,
+        project_keys: list[str],
+    ) -> list[DiscoveredMember]:
+        # Same account_id seen across two projects, plus an email-less member.
+        return [
+            DiscoveredMember(
+                provider_type="jira",
+                provider_identity="acc-1",
+                display_name="Shared Member",
+                email="shared@example.com",
+            ),
+            DiscoveredMember(
+                provider_type="jira",
+                provider_identity="acc-1",
+                display_name="Shared Member",
+                email="shared@example.com",
+            ),
+            DiscoveredMember(
+                provider_type="jira",
+                provider_identity="acc-2",
+                display_name="No Email Member",
+                email=None,
+            ),
+        ]
+
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamDiscoveryService,
+        "discover_jira",
+        discover_jira,
+    )
+    monkeypatch.setattr(
+        team_autoimport_jira.TeamMembershipService,
+        "discover_members_jira_bulk",
+        discover_members_jira_bulk,
+    )
+    sink = _fake_sink()
+
+    summary = team_autoimport_jira.populate(
+        org_id="org-1",
+        credentials={
+            "email": "jira@example.com",
+            "api_token": "jira-token",
+            "base_url": "https://jira.example.com",
+        },
+        scope={"mode": "sync_config"},
+        sink=sink,
+    )
+
+    assert summary["members_imported"] == 2
+    assert summary["team_memberships_imported"] == 2
+    assert set(sink.members) == {("org-1", "jira:acc-1"), ("org-1", "jira:acc-2")}
+    assert sink.members[("org-1", "jira:acc-2")].email is None
+    assert ("org-1", "jira", "OPS", "jira:acc-1", "native") in sink.memberships
+    assert ("org-1", "jira", "OPS", "jira:acc-2", "native") in sink.memberships

--- a/tests/workers/test_team_autoimport_jira.py
+++ b/tests/workers/test_team_autoimport_jira.py
@@ -346,13 +346,13 @@ def test_jira_populate_preserves_manual_project_ownership_row(
     ) in sink.ownership
 
 
-def test_jira_discovery_failure_does_not_clobber_manual_ownership(
+def test_jira_discovery_failure_skips_internally_without_clobbering_manual_ownership(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """CHAOS-2609 (CS-COV) item 3: a jira team-discovery failure (e.g. HTTP 403)
-    surfaces and writes nothing, so a pre-existing manual ownership row is left
-    intact (populate fails before any sink write; run_team_autoimport wraps the
-    error into a skipped sync result)."""
+    is caught INSIDE populate (matching github/gitlab) and returns a skipped
+    summary with reason ``provider_discovery_skipped`` — nothing is written, so a
+    pre-existing manual ownership row is left intact."""
 
     async def discover_jira(
         self: object, email: str, api_token: str, url: str
@@ -380,18 +380,20 @@ def test_jira_discovery_failure_does_not_clobber_manual_ownership(
     )
     sink.write_team_project_ownership([manual])
 
-    with pytest.raises(RuntimeError, match="403"):
-        team_autoimport_jira.populate(
-            org_id="org-1",
-            credentials={
-                "email": "jira@example.com",
-                "api_token": "jira-token",
-                "base_url": "https://jira.example.com",
-            },
-            scope={"mode": "sync_config"},
-            sink=sink,
-        )
+    summary = team_autoimport_jira.populate(
+        org_id="org-1",
+        credentials={
+            "email": "jira@example.com",
+            "api_token": "jira-token",
+            "base_url": "https://jira.example.com",
+        },
+        scope={"mode": "sync_config"},
+        sink=sink,
+    )
 
+    assert summary["status"] == "skipped"
+    assert summary["reason"] == "provider_discovery_skipped"
+    assert summary["team_project_ownership_imported"] == 0
     # The manual ownership row is untouched and no native rows were written.
     assert (
         "org-1",
@@ -482,3 +484,11 @@ def test_jira_members_dedupe_to_one_row_per_member_id(
     assert sink.members[("org-1", "jira:acc-2")].email is None
     assert ("org-1", "jira", "OPS", "jira:acc-1", "native") in sink.memberships
     assert ("org-1", "jira", "OPS", "jira:acc-2", "native") in sink.memberships
+    # CHAOS-2609: the canonical-ladder facet carries the resolver-consumed
+    # identity jira:accountid:<account_id> (member_id PK keeps the jira:<id> form).
+    assert (
+        sink.memberships[
+            ("org-1", "jira", "OPS", "jira:acc-2", "native")
+        ].raw_provider_user_id
+        == "jira:accountid:acc-2"
+    )

--- a/tests/workers/test_team_autoimport_linear.py
+++ b/tests/workers/test_team_autoimport_linear.py
@@ -144,6 +144,14 @@ def test_linear_populate_writes_projects_memberships_and_project_ownership(
         "native",
     ) in sink.ownership
     assert sink.teams[("org-1", "ENG")]["native_team_key"] == "ENG"
+    # CHAOS-2609 (CS-COV) item 5: linear native projects ARE ingested via
+    # team.associations.project_keys — assert the emitted ProjectRecord fields.
+    project = sink.projects[("org-1", "linear", "org-1:linear:ENG")]
+    assert project.id == "org-1:linear:ENG"
+    assert project.project_key == "ENG"
+    assert project.name == "Engineering"
+    assert project.org_id == "org-1"
+    assert project.provider == "linear"
 
 
 def test_chaos_2547_2544_autoimport_uses_analytics_db_url_with_env_unset(


### PR DESCRIPTION
## Why
CHAOS-2600 made ClickHouse the sole team-attribution store, but the provider×entity coverage matrix had gaps: members imported from GitHub/GitLab/Jira were written to the roster in a format the canonical identity resolver never consumes, so **no-email assignees on those providers never attributed to a team**.

## What (converged core)
- `provider_qualified_identity()` (`email > provider:username > provider:accountid:account_id`) wired into `IdentityResolver.resolve()`; `membership_facets()` emits every identity an assignee could resolve to (provider-qualified, alias-resolved canonical, email).
- `team_autoimport_{github,gitlab,jira}` populate the roster + `raw_provider_user_id` with resolver-consumed identities; Jira `populate()` now catches discovery errors → `provider_discovery_skipped` (parity with github/gitlab).
- `member_id` PRIMARY (gh:/gl:/jira:<id>) deliberately untouched (RMT dedup key — no migration).
- Docs: §0.4 matrix all-`yes` (members proven end-to-end) + §0.4a consumption matrix + identity callout in `team-attribution.md`.
- Also versions the epic's plan + realignment docs into `ops/docs/architecture/` (they were unversioned at the container root).

## Scope decision
Ships the converged core (no-email + alias-aware + email-bearing member attribution, proven by e2e cases). The **email-alias-distinct-canonical** edge — a near-misconfiguration whose fix is an architecture-class membership identity-facets path — is **deferred** as **CHAOS-2625** (severity × likelihood × fix-cost; see `feedback_draw_line_on_adversarial_descent`). Prior adversarial review (4 rounds) drove the core; rebased conflict-free onto current main.

Gate (`ci/local_validate.sh`): ruff/mypy/full unit suite/ch-migrate/argMax live ✓. Parent: CHAOS-2600.