### PR TITLE
fix(db): normalize Postgres URLs for transaction poolers

### DIFF
--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -130,7 +130,7 @@ services:
       migrate:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/ready"]
       interval: 15s
       timeout: 10s
       retries: 3
@@ -274,7 +274,9 @@ services:
 
   pgbouncer:
     # CHAOS-2065: optional transaction-mode pooler in front of a managed
-    # Postgres. Disabled unless explicitly enabled:
+    # Postgres. Do not enable this for Neon hosted -pooler endpoints; point
+    # app services directly at Neon and set PGBOUNCER_TRANSACTION_MODE=true.
+    # Disabled unless explicitly enabled:
     #   docker compose --profile pooler up -d
     # Then point Postgres consumers at it and flip the app flag:
     #   POSTGRES_URI=postgresql+asyncpg://USER:PASS@pgbouncer:6432/DB

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -274,8 +274,9 @@ services:
 
   pgbouncer:
     # CHAOS-2065: optional transaction-mode pooler in front of a managed
-    # Postgres. Do not enable this for Neon hosted -pooler endpoints; point
-    # app services directly at Neon and set PGBOUNCER_TRANSACTION_MODE=true.
+    # Postgres. If the provider already supplies a hosted transaction pooler,
+    # point app services directly at that endpoint and set
+    # PGBOUNCER_TRANSACTION_MODE=true.
     # Disabled unless explicitly enabled:
     #   docker compose --profile pooler up -d
     # Then point Postgres consumers at it and flip the app flag:

--- a/docs/ops/database-connection-pooling.md
+++ b/docs/ops/database-connection-pooling.md
@@ -10,9 +10,11 @@
 
 ## TL;DR
 
-- Put **PgBouncer (transaction pooling)** in front of Postgres.
-- Point the app's `DATABASE_URI` / `POSTGRES_URI` at PgBouncer and set
-  **`PGBOUNCER_TRANSACTION_MODE=true`**.
+- Put a **transaction pooler** in front of Postgres. This can be a local
+  PgBouncer service, a sidecar/shared PgBouncer tier, or a managed hosted
+  pooler such as Neon `-pooler`.
+- Point the app's `DATABASE_URI` / `POSTGRES_URI` at that transaction-pooling
+  endpoint and set **`PGBOUNCER_TRANSACTION_MODE=true`**.
 - Run **schema migrations against Postgres directly** (bypass PgBouncer).
 
 ## The connection-budget math
@@ -51,16 +53,21 @@ large and cheap.
 ## App configuration
 
 `src/dev_health_ops/db.py` chooses the engine strategy from
-`PGBOUNCER_TRANSACTION_MODE`:
+`PGBOUNCER_TRANSACTION_MODE` or, unless disabled, a Neon `-pooler` hostname:
 
-- **`true`** (behind PgBouncer transaction mode): the async engine uses
-  `NullPool` (PgBouncer owns the pool) and disables asyncpg prepared-statement
-  caching/naming via
-  `connect_args={"statement_cache_size": 0, "prepared_statement_name_func": <uuid>}`.
+- **`true`** / Neon `-pooler` (upstream endpoint behaves like transaction
+  pooling): the async engine uses `NullPool` and disables asyncpg
+  prepared-statement caching/naming via
+  `connect_args={"timeout": 10.0, "statement_cache_size": 0, "prepared_statement_name_func": <uuid>}`.
   The sync engine uses `NullPool`.
 - **unset / `false`** (direct connection): the async/sync engines use a
   SQLAlchemy `QueuePool` with `pool_pre_ping` and `POSTGRES_POOL_SIZE` /
   `POSTGRES_MAX_OVERFLOW` (defaults 20 / 10).
+
+`POSTGRES_CONNECT_TIMEOUT_SECONDS` controls the asyncpg connection timeout
+(default `10`). Invalid or non-positive values fall back to `10`. Set
+`POSTGRES_DISABLE_POOLER_AUTODETECT=true` only if a `-pooler` hostname should not
+trigger transaction-pooler-safe asyncpg settings.
 
 ### Why prepared statements must be disabled
 
@@ -105,9 +112,27 @@ The same pattern is mirrored in the platform stack (`dev-health/compose.yml`).
 
 ## Production topology
 
-Production typically uses a **managed Postgres**; deploy PgBouncer either as a
-sidecar next to each app/worker node or as a small shared tier, in transaction
-mode, in front of it. Required PgBouncer settings:
+Production typically uses a **managed Postgres**. If the provider has a hosted
+transaction pooler, point the app directly at that hosted endpoint. For Neon,
+the hostname includes `-pooler`; a local `pgbouncer` compose service is not
+required.
+
+For Neon hosted pooler:
+
+```env
+POSTGRES_URI=postgresql+asyncpg://neondb_owner:<pw>@<neon-pooler-host>/devhealth?sslmode=require
+DATABASE_URI=postgresql+asyncpg://neondb_owner:<pw>@<neon-pooler-host>/devhealth?sslmode=require
+PGBOUNCER_TRANSACTION_MODE=true
+POSTGRES_CONNECT_TIMEOUT_SECONDS=10
+```
+
+`PGBOUNCER_TRANSACTION_MODE=true` means the upstream endpoint behaves like
+transaction pooling. It does not mean a local `pgbouncer` container must be
+running.
+
+If you operate PgBouncer yourself, deploy it either as a sidecar next to each
+app/worker node or as a small shared tier, in transaction mode, in front of
+managed Postgres. Required PgBouncer settings:
 
 ```ini
 pool_mode = transaction
@@ -116,11 +141,15 @@ default_pool_size = 25        ; size so Σ server pools < Postgres max_connectio
 auth_type = scram-sha-256
 ```
 
-Set the app's `DATABASE_URI` / `POSTGRES_URI` to the PgBouncer endpoint and
-`PGBOUNCER_TRANSACTION_MODE=true`. If the managed provider already offers a
-transaction-mode pooler (e.g. RDS Proxy, Supabase pooler, Neon pooler), point at
-that instead and still set `PGBOUNCER_TRANSACTION_MODE=true` so asyncpg prepared
-statements are disabled.
+Set the app's `DATABASE_URI` / `POSTGRES_URI` to the transaction-pooling endpoint
+and `PGBOUNCER_TRANSACTION_MODE=true` so asyncpg prepared statements are
+disabled. Prefer `sslmode=require` in shared environment URLs: async app paths
+normalize it to asyncpg's `ssl=require`, while sync worker/helper paths keep or
+translate it to libpq-compatible `sslmode=require`.
+
+Production Docker readiness should call `/ready`. `/health` remains a deep
+dependency check for observability and may return 503 while Postgres,
+ClickHouse, or Redis is temporarily unavailable.
 
 ## Validation
 

--- a/docs/ops/database-connection-pooling.md
+++ b/docs/ops/database-connection-pooling.md
@@ -12,7 +12,7 @@
 
 - Put a **transaction pooler** in front of Postgres. This can be a local
   PgBouncer service, a sidecar/shared PgBouncer tier, or a managed hosted
-  pooler such as Neon `-pooler`.
+  pooler.
 - Point the app's `DATABASE_URI` / `POSTGRES_URI` at that transaction-pooling
   endpoint and set **`PGBOUNCER_TRANSACTION_MODE=true`**.
 - Run **schema migrations against Postgres directly** (bypass PgBouncer).
@@ -53,11 +53,10 @@ large and cheap.
 ## App configuration
 
 `src/dev_health_ops/db.py` chooses the engine strategy from
-`PGBOUNCER_TRANSACTION_MODE` or, unless disabled, a Neon `-pooler` hostname:
+`PGBOUNCER_TRANSACTION_MODE`:
 
-- **`true`** / Neon `-pooler` (upstream endpoint behaves like transaction
-  pooling): the async engine uses `NullPool` and disables asyncpg
-  prepared-statement caching/naming via
+- **`true`** (upstream endpoint behaves like transaction pooling): the async
+  engine uses `NullPool` and disables asyncpg prepared-statement caching/naming via
   `connect_args={"timeout": 10.0, "statement_cache_size": 0, "prepared_statement_name_func": <uuid>}`.
   The sync engine uses `NullPool`.
 - **unset / `false`** (direct connection): the async/sync engines use a
@@ -65,9 +64,7 @@ large and cheap.
   `POSTGRES_MAX_OVERFLOW` (defaults 20 / 10).
 
 `POSTGRES_CONNECT_TIMEOUT_SECONDS` controls the asyncpg connection timeout
-(default `10`). Invalid or non-positive values fall back to `10`. Set
-`POSTGRES_DISABLE_POOLER_AUTODETECT=true` only if a `-pooler` hostname should not
-trigger transaction-pooler-safe asyncpg settings.
+(default `10`). Invalid or non-positive values fall back to `10`.
 
 ### Why prepared statements must be disabled
 
@@ -113,15 +110,14 @@ The same pattern is mirrored in the platform stack (`dev-health/compose.yml`).
 ## Production topology
 
 Production typically uses a **managed Postgres**. If the provider has a hosted
-transaction pooler, point the app directly at that hosted endpoint. For Neon,
-the hostname includes `-pooler`; a local `pgbouncer` compose service is not
-required.
+transaction pooler, point the app directly at that hosted endpoint. A local
+`pgbouncer` compose service is not required in that topology.
 
-For Neon hosted pooler:
+For a hosted transaction pooler:
 
 ```env
-POSTGRES_URI=postgresql+asyncpg://neondb_owner:<pw>@<neon-pooler-host>/devhealth?sslmode=require
-DATABASE_URI=postgresql+asyncpg://neondb_owner:<pw>@<neon-pooler-host>/devhealth?sslmode=require
+POSTGRES_URI=postgresql+asyncpg://<user>:<pw>@<db-host>/devhealth?sslmode=require
+DATABASE_URI=postgresql+asyncpg://<user>:<pw>@<db-host>/devhealth?sslmode=require
 PGBOUNCER_TRANSACTION_MODE=true
 POSTGRES_CONNECT_TIMEOUT_SECONDS=10
 ```

--- a/src/dev_health_ops/api/_health.py
+++ b/src/dev_health_ops/api/_health.py
@@ -13,6 +13,7 @@ import os
 from urllib.parse import urlparse
 
 from dev_health_ops.api.middleware.rate_limit import LIMITER_BACKEND
+from dev_health_ops.db import get_postgres_uri
 
 from .queries.client import clickhouse_client, query_dicts
 
@@ -101,7 +102,9 @@ def _dsn_uses_async_driver(dsn: str) -> bool:
 
 async def _check_postgres_health() -> tuple[str, str]:
     """Check Postgres connectivity. Returns ``("postgres", status)``."""
-    uri = _postgres_url()
+    if not _postgres_url():
+        return "postgres", "not_configured"
+    uri = get_postgres_uri()
     if not uri:
         return "postgres", "not_configured"
     if _dsn_uses_async_driver(uri):

--- a/src/dev_health_ops/api/auth/routers/dependencies.py
+++ b/src/dev_health_ops/api/auth/routers/dependencies.py
@@ -1,14 +1,37 @@
 from __future__ import annotations
 
+import logging
 from typing import Annotated
 
 from fastapi import Header, HTTPException
+from sqlalchemy.exc import DBAPIError, OperationalError
 
 from dev_health_ops.api.services.auth import (
     AuthenticatedUser,
     extract_token_from_header,
 )
 from dev_health_ops.api.utils.errors import error_detail
+
+logger = logging.getLogger(__name__)
+
+
+def _db_temporarily_unavailable(exc: BaseException) -> bool:
+    if isinstance(exc, (TimeoutError, OperationalError)):
+        return True
+    if isinstance(exc, DBAPIError) and exc.connection_invalidated:
+        return True
+    original = getattr(exc, "orig", None)
+    text = f"{type(exc).__name__} {exc} {type(original).__name__} {original}".lower()
+    return "timeout" in text and any(
+        marker in text for marker in ("connect", "connection", "asyncpg", "ssl")
+    )
+
+
+def _database_unavailable() -> HTTPException:
+    return HTTPException(
+        status_code=503,
+        detail=error_detail("Database temporarily unavailable"),
+    )
 
 
 async def get_current_user(
@@ -32,8 +55,14 @@ async def get_current_user(
         )
 
     auth_service = get_auth_service()
-    async with get_postgres_session() as db:
-        user = await auth_service.authenticate_access_token(token, db)
+    try:
+        async with get_postgres_session() as db:
+            user = await auth_service.authenticate_access_token(token, db)
+    except Exception as exc:
+        if _db_temporarily_unavailable(exc):
+            logger.warning("Database unavailable during access-token authentication")
+            raise _database_unavailable() from exc
+        raise
 
     if not user:
         raise HTTPException(
@@ -58,8 +87,14 @@ async def get_current_user_optional(
         return None
 
     auth_service = get_auth_service()
-    async with get_postgres_session() as db:
-        return await auth_service.authenticate_access_token(token, db)
+    try:
+        async with get_postgres_session() as db:
+            return await auth_service.authenticate_access_token(token, db)
+    except Exception as exc:
+        if _db_temporarily_unavailable(exc):
+            logger.warning("Database unavailable during optional token authentication")
+            raise _database_unavailable() from exc
+        raise
 
 
 __all__ = ["get_current_user", "get_current_user_optional"]

--- a/src/dev_health_ops/db.py
+++ b/src/dev_health_ops/db.py
@@ -50,19 +50,8 @@ def _pgbouncer_transaction_mode() -> bool:
     return _is_truthy(os.getenv("PGBOUNCER_TRANSACTION_MODE"))
 
 
-def _pooler_autodetect_disabled() -> bool:
-    return _is_truthy(os.getenv("POSTGRES_DISABLE_POOLER_AUTODETECT"))
-
-
-def _neon_pooler_endpoint(uri: str) -> bool:
-    if _pooler_autodetect_disabled() or not uri.startswith("postgresql"):
-        return False
-    host = make_url(uri).host or ""
-    return "-pooler" in host
-
-
-def _transaction_pooler_mode(uri: str) -> bool:
-    return _pgbouncer_transaction_mode() or _neon_pooler_endpoint(uri)
+def _transaction_pooler_mode() -> bool:
+    return _pgbouncer_transaction_mode()
 
 
 def _postgres_connect_timeout_seconds() -> float:
@@ -103,7 +92,7 @@ def _async_postgres_engine_kwargs(uri: str) -> dict[str, Any]:
         return {"pool_pre_ping": True}
 
     connect_args: dict[str, Any] = {"timeout": _postgres_connect_timeout_seconds()}
-    if _transaction_pooler_mode(uri):
+    if _transaction_pooler_mode():
         connect_args.update(
             {
                 "statement_cache_size": 0,
@@ -135,7 +124,7 @@ def _log_postgres_connection_posture(uri: str, kwargs: dict[str, Any]) -> None:
             "driver": url.drivername,
             "host": url.host,
             "database": url.database,
-            "transaction_pooler_mode": _transaction_pooler_mode(uri),
+            "transaction_pooler_mode": _transaction_pooler_mode(),
             "null_pool": uses_null_pool,
             "pool_size": None if uses_null_pool else kwargs.get("pool_size"),
             "max_overflow": None if uses_null_pool else kwargs.get("max_overflow"),
@@ -388,7 +377,7 @@ def get_postgres_sync_engine(uri: str | None = None) -> Engine:
     global _postgres_sync_engine
     if uri is not None:
         sync_uri = _ensure_sync_postgres(uri)
-        if _transaction_pooler_mode(sync_uri):
+        if _transaction_pooler_mode():
             return create_engine(sync_uri, poolclass=NullPool)
         if not sync_uri.startswith("postgresql"):
             return create_engine(sync_uri)
@@ -405,7 +394,7 @@ def get_postgres_sync_engine(uri: str | None = None) -> Engine:
             raise RuntimeError(
                 "PostgreSQL URI not configured. Set POSTGRES_URI environment variable."
             )
-        if _transaction_pooler_mode(uri):
+        if _transaction_pooler_mode():
             # PgBouncer owns the pool; psycopg keeps no server-side prepared
             # statements by default, so only the pool class needs to change.
             _postgres_sync_engine = create_engine(uri, poolclass=NullPool)

--- a/src/dev_health_ops/db.py
+++ b/src/dev_health_ops/db.py
@@ -12,6 +12,7 @@ Environment Variables:
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
@@ -31,6 +32,7 @@ from sqlalchemy.pool import NullPool
 
 _postgres_engine: AsyncEngine | None = None
 _clickhouse_engine: AsyncEngine | None = None
+logger = logging.getLogger(__name__)
 
 
 def _is_truthy(value: str | None) -> bool:
@@ -46,6 +48,32 @@ def _pgbouncer_transaction_mode() -> bool:
     prepared statements. See docs/ops/database-connection-pooling.md.
     """
     return _is_truthy(os.getenv("PGBOUNCER_TRANSACTION_MODE"))
+
+
+def _pooler_autodetect_disabled() -> bool:
+    return _is_truthy(os.getenv("POSTGRES_DISABLE_POOLER_AUTODETECT"))
+
+
+def _neon_pooler_endpoint(uri: str) -> bool:
+    if _pooler_autodetect_disabled() or not uri.startswith("postgresql"):
+        return False
+    host = make_url(uri).host or ""
+    return "-pooler" in host
+
+
+def _transaction_pooler_mode(uri: str) -> bool:
+    return _pgbouncer_transaction_mode() or _neon_pooler_endpoint(uri)
+
+
+def _postgres_connect_timeout_seconds() -> float:
+    raw = os.getenv("POSTGRES_CONNECT_TIMEOUT_SECONDS")
+    if not raw:
+        return 10.0
+    try:
+        timeout = float(raw)
+    except ValueError:
+        return 10.0
+    return timeout if timeout > 0 else 10.0
 
 
 def _pg_pool_size() -> tuple[int, int]:
@@ -71,20 +99,49 @@ def _async_postgres_engine_kwargs(uri: str) -> dict[str, Any]:
     Otherwise: a SQLAlchemy QueuePool with pre-ping and env-tunable sizing.
     """
     is_postgres = uri.startswith("postgresql+")
-    if is_postgres and _pgbouncer_transaction_mode():
-        return {
-            "poolclass": NullPool,
-            "connect_args": {
+    if not is_postgres:
+        return {"pool_pre_ping": True}
+
+    connect_args: dict[str, Any] = {"timeout": _postgres_connect_timeout_seconds()}
+    if _transaction_pooler_mode(uri):
+        connect_args.update(
+            {
                 "statement_cache_size": 0,
                 "prepared_statement_name_func": lambda: f"__asyncpg_{uuid4()}__",
-            },
+            }
+        )
+        return {
+            "poolclass": NullPool,
+            "connect_args": connect_args,
         }
-    kwargs: dict[str, Any] = {"pool_pre_ping": True}
-    if is_postgres:
-        pool_size, max_overflow = _pg_pool_size()
-        kwargs["pool_size"] = pool_size
-        kwargs["max_overflow"] = max_overflow
+
+    pool_size, max_overflow = _pg_pool_size()
+    kwargs: dict[str, Any] = {
+        "pool_pre_ping": True,
+        "pool_size": pool_size,
+        "max_overflow": max_overflow,
+        "connect_args": connect_args,
+    }
     return kwargs
+
+
+def _log_postgres_connection_posture(uri: str, kwargs: dict[str, Any]) -> None:
+    url = make_url(uri)
+    connect_args = kwargs.get("connect_args") or {}
+    uses_null_pool = kwargs.get("poolclass") is NullPool
+    logger.info(
+        "postgres_connection_posture",
+        extra={
+            "driver": url.drivername,
+            "host": url.host,
+            "database": url.database,
+            "transaction_pooler_mode": _transaction_pooler_mode(uri),
+            "null_pool": uses_null_pool,
+            "pool_size": None if uses_null_pool else kwargs.get("pool_size"),
+            "max_overflow": None if uses_null_pool else kwargs.get("max_overflow"),
+            "connect_timeout_seconds": connect_args.get("timeout"),
+        },
+    )
 
 
 def get_postgres_uri() -> str | None:
@@ -167,9 +224,9 @@ def get_postgres_engine() -> AsyncEngine:
             raise RuntimeError(
                 "PostgreSQL URI not configured. Set POSTGRES_URI environment variable."
             )
-        _postgres_engine = create_async_engine(
-            uri, **_async_postgres_engine_kwargs(uri)
-        )
+        kwargs = _async_postgres_engine_kwargs(uri)
+        _log_postgres_connection_posture(uri, kwargs)
+        _postgres_engine = create_async_engine(uri, **kwargs)
     return _postgres_engine
 
 
@@ -331,7 +388,7 @@ def get_postgres_sync_engine(uri: str | None = None) -> Engine:
     global _postgres_sync_engine
     if uri is not None:
         sync_uri = _ensure_sync_postgres(uri)
-        if _pgbouncer_transaction_mode():
+        if _transaction_pooler_mode(sync_uri):
             return create_engine(sync_uri, poolclass=NullPool)
         if not sync_uri.startswith("postgresql"):
             return create_engine(sync_uri)
@@ -348,7 +405,7 @@ def get_postgres_sync_engine(uri: str | None = None) -> Engine:
             raise RuntimeError(
                 "PostgreSQL URI not configured. Set POSTGRES_URI environment variable."
             )
-        if _pgbouncer_transaction_mode():
+        if _transaction_pooler_mode(uri):
             # PgBouncer owns the pool; psycopg keeps no server-side prepared
             # statements by default, so only the pool class needs to change.
             _postgres_sync_engine = create_engine(uri, poolclass=NullPool)

--- a/src/dev_health_ops/db.py
+++ b/src/dev_health_ops/db.py
@@ -91,11 +91,11 @@ def get_postgres_uri() -> str | None:
     """Get PostgreSQL connection URI with fallback chain."""
     uri = os.getenv("POSTGRES_URI")
     if uri:
-        return _ensure_async_postgres(uri)
+        return normalize_async_postgres_uri(uri)
 
     fallback = os.getenv("DATABASE_URI") or os.getenv("DATABASE_URL")
     if fallback:
-        return _ensure_async_postgres(fallback)
+        return normalize_async_postgres_uri(fallback)
 
     return None
 
@@ -105,10 +105,12 @@ def get_clickhouse_uri() -> str | None:
     return os.getenv("CLICKHOUSE_URI")
 
 
-def _ensure_async_postgres(uri: str) -> str:
-    """Ensure semantic DB URIs use an async driver."""
+def normalize_async_postgres_uri(uri: str) -> str:
     if uri.startswith("postgresql://"):
-        uri = uri.replace("postgresql://", "postgresql+asyncpg://", 1)
+        url = make_url(uri)
+        uri = url.set(drivername="postgresql+asyncpg").render_as_string(
+            hide_password=False
+        )
     elif uri.startswith("sqlite://") and not uri.startswith("sqlite+aiosqlite://"):
         return uri.replace("sqlite://", "sqlite+aiosqlite://", 1)
     return _normalize_asyncpg_postgres_query(uri)
@@ -131,6 +133,29 @@ def _normalize_asyncpg_postgres_query(uri: str) -> str:
         return uri
 
     return url.set(query=query).render_as_string(hide_password=False)
+
+
+def _ensure_async_postgres(uri: str) -> str:
+    return normalize_async_postgres_uri(uri)
+
+
+def normalize_sync_postgres_uri(uri: str) -> str:
+    if uri.startswith("postgresql"):
+        url = make_url(uri)
+        query = dict(url.query)
+        ssl = query.pop("ssl", None)
+        query.pop("channel_binding", None)
+        if ssl is not None and "sslmode" not in query:
+            query["sslmode"] = ssl
+        drivername = (
+            "postgresql" if url.drivername == "postgresql+asyncpg" else url.drivername
+        )
+        return url.set(drivername=drivername, query=query).render_as_string(
+            hide_password=False
+        )
+    if uri.startswith("sqlite+aiosqlite://"):
+        return uri.replace("sqlite+aiosqlite://", "sqlite://", 1)
+    return uri
 
 
 def get_postgres_engine() -> AsyncEngine:
@@ -253,7 +278,7 @@ def require_clickhouse_uri() -> str:
 def resolve_db_uri(ns) -> str:
     uri = getattr(ns, "db", None)
     if uri:
-        return _ensure_async_postgres(uri)
+        return normalize_async_postgres_uri(uri)
     return require_postgres_uri()
 
 
@@ -289,25 +314,17 @@ _postgres_sync_engine: Engine | None = None
 def _get_sync_postgres_uri() -> str | None:
     uri = os.getenv("POSTGRES_URI")
     if uri:
-        if uri.startswith("postgresql+asyncpg://"):
-            return uri.replace("postgresql+asyncpg://", "postgresql://", 1)
-        return uri
+        return normalize_sync_postgres_uri(uri)
 
     fallback = os.getenv("DATABASE_URI") or os.getenv("DATABASE_URL")
     if fallback:
-        if "asyncpg" in fallback:
-            return fallback.replace("+asyncpg", "", 1)
-        return fallback
+        return normalize_sync_postgres_uri(fallback)
 
     return None
 
 
 def _ensure_sync_postgres(uri: str) -> str:
-    if uri.startswith("postgresql+asyncpg://"):
-        return uri.replace("postgresql+asyncpg://", "postgresql://", 1)
-    if uri.startswith("sqlite+aiosqlite://"):
-        return uri.replace("sqlite+aiosqlite://", "sqlite://", 1)
-    return uri
+    return normalize_sync_postgres_uri(uri)
 
 
 def get_postgres_sync_engine(uri: str | None = None) -> Engine:

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,0 +1,31 @@
+import pytest
+from sqlalchemy.engine import make_url
+
+from dev_health_ops.api import _health
+
+
+@pytest.mark.asyncio
+async def test_postgres_health_uses_normalized_async_uri(monkeypatch):
+    captured: dict[str, str] = {}
+
+    async def check(dsn: str) -> bool:
+        captured["dsn"] = dsn
+        return True
+
+    monkeypatch.setenv(
+        "POSTGRES_URI",
+        "postgresql+asyncpg://u:p@ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech/db?sslmode=require&channel_binding=require",
+    )
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(_health, "_check_sqlalchemy_health_async", check)
+
+    service, status = await _health._check_postgres_health()
+
+    assert service == "postgres"
+    assert status == "ok"
+    url = make_url(captured["dsn"])
+    assert url.drivername == "postgresql+asyncpg"
+    assert url.query["ssl"] == "require"
+    assert "sslmode" not in url.query
+    assert "channel_binding" not in url.query

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -14,7 +14,7 @@ async def test_postgres_health_uses_normalized_async_uri(monkeypatch):
 
     monkeypatch.setenv(
         "POSTGRES_URI",
-        "postgresql+asyncpg://u:p@ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech/db?sslmode=require&channel_binding=require",
+        "postgresql+asyncpg://u:p@pooler.example.com/db?sslmode=require&channel_binding=require",
     )
     monkeypatch.delenv("DATABASE_URI", raising=False)
     monkeypatch.delenv("DATABASE_URL", raising=False)

--- a/tests/test_auth_db_check.py
+++ b/tests/test_auth_db_check.py
@@ -99,6 +99,38 @@ async def test_get_current_user_rejects_nonexistent_user(auth_service):
 
 
 @pytest.mark.asyncio
+async def test_get_current_user_returns_503_for_db_connect_timeout(auth_service):
+    from contextlib import asynccontextmanager
+
+    from fastapi import HTTPException
+
+    from dev_health_ops.api.auth.router import get_current_user
+
+    token = _make_token(auth_service)
+    header = f"Bearer {token}"
+    session = _mock_session(_FakeResult(row=None))
+    session.execute = AsyncMock(
+        side_effect=TimeoutError("asyncpg connect timeout while opening SSL connection")
+    )
+
+    @asynccontextmanager
+    async def fake_ctx():
+        yield session
+
+    with (
+        patch(
+            "dev_health_ops.api.auth.router.get_auth_service", return_value=auth_service
+        ),
+        patch("dev_health_ops.api.auth.router.get_postgres_session", fake_ctx),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(authorization=header)
+
+    assert exc_info.value.status_code == 503
+    assert "Database temporarily unavailable" in _detail_message(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_get_current_user_rejects_inactive_user(auth_service):
     from fastapi import HTTPException
 

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -192,6 +192,14 @@ def test_production_compose_disables_ambient_migrations() -> None:
         )
 
 
+def test_production_api_healthcheck_uses_ready_probe() -> None:
+    services = _load_yaml(_PROD_COMPOSE)["services"]
+    command = " ".join(str(part) for part in services["api"]["healthcheck"]["test"])
+
+    assert "/ready" in command
+    assert "/health" not in command
+
+
 def test_legacy_compose_has_one_shot_migrate_service() -> None:
     services = _load_yaml(_LEGACY_COMPOSE)["services"]
     migrate = services.get("migrate")

--- a/tests/test_db_pgbouncer.py
+++ b/tests/test_db_pgbouncer.py
@@ -21,7 +21,6 @@ def _clear_pool_env(monkeypatch):
     for var in (
         "PGBOUNCER_TRANSACTION_MODE",
         "POSTGRES_CONNECT_TIMEOUT_SECONDS",
-        "POSTGRES_DISABLE_POOLER_AUTODETECT",
         "POSTGRES_POOL_SIZE",
         "POSTGRES_MAX_OVERFLOW",
     ):
@@ -42,16 +41,8 @@ class TestPgbouncerTransactionModeFlag:
         monkeypatch.setenv("PGBOUNCER_TRANSACTION_MODE", val)
         assert db._pgbouncer_transaction_mode() is False
 
-    def test_neon_pooler_host_enables_transaction_pooler_mode(self):
-        uri = "postgresql+asyncpg://u:p@ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech/d"
-
-        assert db._transaction_pooler_mode(uri) is True
-
-    def test_neon_pooler_autodetect_can_be_disabled(self, monkeypatch):
-        monkeypatch.setenv("POSTGRES_DISABLE_POOLER_AUTODETECT", "true")
-        uri = "postgresql+asyncpg://u:p@ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech/d"
-
-        assert db._transaction_pooler_mode(uri) is False
+    def test_pooler_hostname_does_not_enable_transaction_pooler_mode(self):
+        assert db._transaction_pooler_mode() is False
 
 
 class TestAsyncEngineKwargs:
@@ -110,15 +101,16 @@ class TestAsyncEngineKwargs:
 
         assert kw["connect_args"]["timeout"] == 10.0
 
-    def test_neon_pooler_autodetect_uses_nullpool(self):
-        uri = "postgresql+asyncpg://u:p@ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech/d"
+    def test_pooler_hostname_without_flag_uses_queue_pool(self):
+        uri = "postgresql+asyncpg://u:p@pooler.example.com/d"
 
         kw = db._async_postgres_engine_kwargs(uri)
 
-        assert kw["poolclass"] is NullPool
-        assert kw["connect_args"]["statement_cache_size"] == 0
+        assert "poolclass" not in kw
+        assert kw["pool_pre_ping"] is True
+        assert "statement_cache_size" not in kw["connect_args"]
 
-    def test_neon_pooler_autodetect_uses_nullpool_for_sync_engine(self, monkeypatch):
+    def test_pooler_flag_uses_nullpool_for_sync_engine(self, monkeypatch):
         captured: dict[str, object] = {}
 
         def create_engine(dsn: str, **kwargs):
@@ -127,15 +119,17 @@ class TestAsyncEngineKwargs:
             return object()
 
         monkeypatch.setattr(db, "create_engine", create_engine)
+        monkeypatch.setenv("PGBOUNCER_TRANSACTION_MODE", "true")
 
         db.get_postgres_sync_engine(
-            "postgresql+asyncpg://u:p@ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech/d?ssl=require"
+            "postgresql+asyncpg://u:p@pooler.example.com/d?ssl=require"
         )
 
         assert captured["poolclass"] is NullPool
 
-    def test_connection_posture_log_is_sanitized(self, caplog):
-        uri = "postgresql+asyncpg://u:secret@ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech/d"
+    def test_connection_posture_log_is_sanitized(self, monkeypatch, caplog):
+        monkeypatch.setenv("PGBOUNCER_TRANSACTION_MODE", "true")
+        uri = "postgresql+asyncpg://u:secret@pooler.example.com/d"
         kw = db._async_postgres_engine_kwargs(uri)
 
         with caplog.at_level(logging.INFO, logger="dev_health_ops.db"):
@@ -145,7 +139,7 @@ class TestAsyncEngineKwargs:
             r for r in caplog.records if r.message == "postgres_connection_posture"
         )
         assert record.driver == "postgresql+asyncpg"
-        assert record.host == "ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech"
+        assert record.host == "pooler.example.com"
         assert record.database == "d"
         assert record.transaction_pooler_mode is True
         assert record.null_pool is True
@@ -159,7 +153,7 @@ class TestAsyncPostgresUrlNormalization:
 
         assert db._ensure_async_postgres(uri) == "postgresql+asyncpg://u:p@h/d"
 
-    def test_translates_neon_sslmode_for_asyncpg(self):
+    def test_translates_sslmode_for_asyncpg(self):
         uri = "postgresql://u:p@h/d?sslmode=require&channel_binding=require"
 
         assert (

--- a/tests/test_db_pgbouncer.py
+++ b/tests/test_db_pgbouncer.py
@@ -8,6 +8,8 @@ naming -- otherwise pooled server connections raise
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from sqlalchemy.pool import NullPool
 
@@ -18,6 +20,8 @@ from dev_health_ops import db
 def _clear_pool_env(monkeypatch):
     for var in (
         "PGBOUNCER_TRANSACTION_MODE",
+        "POSTGRES_CONNECT_TIMEOUT_SECONDS",
+        "POSTGRES_DISABLE_POOLER_AUTODETECT",
         "POSTGRES_POOL_SIZE",
         "POSTGRES_MAX_OVERFLOW",
     ):
@@ -38,11 +42,27 @@ class TestPgbouncerTransactionModeFlag:
         monkeypatch.setenv("PGBOUNCER_TRANSACTION_MODE", val)
         assert db._pgbouncer_transaction_mode() is False
 
+    def test_neon_pooler_host_enables_transaction_pooler_mode(self):
+        uri = "postgresql+asyncpg://u:p@ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech/d"
+
+        assert db._transaction_pooler_mode(uri) is True
+
+    def test_neon_pooler_autodetect_can_be_disabled(self, monkeypatch):
+        monkeypatch.setenv("POSTGRES_DISABLE_POOLER_AUTODETECT", "true")
+        uri = "postgresql+asyncpg://u:p@ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech/d"
+
+        assert db._transaction_pooler_mode(uri) is False
+
 
 class TestAsyncEngineKwargs:
     def test_direct_postgres_uses_queue_pool(self):
         kw = db._async_postgres_engine_kwargs("postgresql+asyncpg://u:p@h:5432/d")
-        assert kw == {"pool_pre_ping": True, "pool_size": 20, "max_overflow": 10}
+        assert kw == {
+            "pool_pre_ping": True,
+            "pool_size": 20,
+            "max_overflow": 10,
+            "connect_args": {"timeout": 10.0},
+        }
         assert "poolclass" not in kw
 
     def test_pgbouncer_uses_nullpool_and_disables_prepared_statements(
@@ -56,6 +76,7 @@ class TestAsyncEngineKwargs:
         assert "pool_size" not in kw and "max_overflow" not in kw
 
         connect_args = kw["connect_args"]
+        assert connect_args["timeout"] == 10.0
         assert connect_args["statement_cache_size"] == 0
         name_func = connect_args["prepared_statement_name_func"]
         # Unique per call so names never collide across multiplexed server conns.
@@ -74,6 +95,62 @@ class TestAsyncEngineKwargs:
         kw = db._async_postgres_engine_kwargs("postgresql+asyncpg://u:p@h/d")
         assert kw["pool_size"] == 50
         assert kw["max_overflow"] == 25
+
+    def test_connect_timeout_env_overridable(self, monkeypatch):
+        monkeypatch.setenv("POSTGRES_CONNECT_TIMEOUT_SECONDS", "15")
+
+        kw = db._async_postgres_engine_kwargs("postgresql+asyncpg://u:p@h/d")
+
+        assert kw["connect_args"]["timeout"] == 15.0
+
+    def test_invalid_connect_timeout_falls_back(self, monkeypatch):
+        monkeypatch.setenv("POSTGRES_CONNECT_TIMEOUT_SECONDS", "nope")
+
+        kw = db._async_postgres_engine_kwargs("postgresql+asyncpg://u:p@h/d")
+
+        assert kw["connect_args"]["timeout"] == 10.0
+
+    def test_neon_pooler_autodetect_uses_nullpool(self):
+        uri = "postgresql+asyncpg://u:p@ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech/d"
+
+        kw = db._async_postgres_engine_kwargs(uri)
+
+        assert kw["poolclass"] is NullPool
+        assert kw["connect_args"]["statement_cache_size"] == 0
+
+    def test_neon_pooler_autodetect_uses_nullpool_for_sync_engine(self, monkeypatch):
+        captured: dict[str, object] = {}
+
+        def create_engine(dsn: str, **kwargs):
+            captured["dsn"] = dsn
+            captured.update(kwargs)
+            return object()
+
+        monkeypatch.setattr(db, "create_engine", create_engine)
+
+        db.get_postgres_sync_engine(
+            "postgresql+asyncpg://u:p@ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech/d?ssl=require"
+        )
+
+        assert captured["poolclass"] is NullPool
+
+    def test_connection_posture_log_is_sanitized(self, caplog):
+        uri = "postgresql+asyncpg://u:secret@ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech/d"
+        kw = db._async_postgres_engine_kwargs(uri)
+
+        with caplog.at_level(logging.INFO, logger="dev_health_ops.db"):
+            db._log_postgres_connection_posture(uri, kw)
+
+        record = next(
+            r for r in caplog.records if r.message == "postgres_connection_posture"
+        )
+        assert record.driver == "postgresql+asyncpg"
+        assert record.host == "ep-cool-boat-af967qaf-pooler.c-2.us-west-2.aws.neon.tech"
+        assert record.database == "d"
+        assert record.transaction_pooler_mode is True
+        assert record.null_pool is True
+        assert record.connect_timeout_seconds == 10.0
+        assert "secret" not in caplog.text
 
 
 class TestAsyncPostgresUrlNormalization:

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,3 +1,6 @@
+from sqlalchemy.engine import make_url
+
+from dev_health_ops import db
 from dev_health_ops.metrics.db_utils import (
     normalize_db_url,
     normalize_postgres_url,
@@ -67,3 +70,90 @@ class TestNormalizeDbUrl:
         result = normalize_db_url(url)
         assert result == "sqlite:///path/sqlite+aiosqlite/data.db"
         assert result.count("sqlite+aiosqlite") == 1
+
+
+class TestPostgresRuntimeUrlNormalization:
+    def test_async_normalizer_converts_plain_postgres_sslmode_to_asyncpg_ssl(self):
+        result = db.normalize_async_postgres_uri(
+            "postgresql://u:p@h/db?sslmode=require"
+        )
+
+        url = make_url(result)
+        assert url.drivername == "postgresql+asyncpg"
+        assert url.query["ssl"] == "require"
+        assert "sslmode" not in url.query
+
+    def test_async_normalizer_removes_channel_binding(self):
+        result = db.normalize_async_postgres_uri(
+            "postgresql+asyncpg://u:p@h/db?sslmode=require&channel_binding=require"
+        )
+
+        url = make_url(result)
+        assert url.drivername == "postgresql+asyncpg"
+        assert url.query["ssl"] == "require"
+        assert "channel_binding" not in url.query
+
+    def test_sync_normalizer_converts_asyncpg_ssl_to_libpq_sslmode(self):
+        result = db.normalize_sync_postgres_uri(
+            "postgresql+asyncpg://u:p@h/db?ssl=require"
+        )
+
+        url = make_url(result)
+        assert url.drivername == "postgresql"
+        assert url.query["sslmode"] == "require"
+        assert "ssl" not in url.query
+
+    def test_sync_normalizer_keeps_existing_sslmode_compatible(self):
+        result = db.normalize_sync_postgres_uri(
+            "postgresql+asyncpg://u:p@h/db?sslmode=require"
+        )
+
+        url = make_url(result)
+        assert url.drivername == "postgresql"
+        assert url.query["sslmode"] == "require"
+        assert "ssl" not in url.query
+
+    def test_sync_normalizer_preserves_unrelated_query_params(self):
+        result = db.normalize_sync_postgres_uri(
+            "postgresql+asyncpg://u:p@h/db?ssl=require&application_name=worker"
+        )
+
+        url = make_url(result)
+        assert url.query["sslmode"] == "require"
+        assert url.query["application_name"] == "worker"
+
+    def test_get_sync_postgres_uri_normalizes_env_uri(self, monkeypatch):
+        monkeypatch.setenv(
+            "POSTGRES_URI",
+            "postgresql+asyncpg://u:p@h/db?ssl=require&channel_binding=require",
+        )
+        monkeypatch.delenv("DATABASE_URI", raising=False)
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+
+        result = db._get_sync_postgres_uri()
+
+        assert result is not None
+        url = make_url(result)
+        assert url.drivername == "postgresql"
+        assert url.query["sslmode"] == "require"
+        assert "ssl" not in url.query
+        assert "channel_binding" not in url.query
+
+    def test_sync_engine_explicit_uri_uses_normalized_dsn(self, monkeypatch):
+        captured: dict[str, str] = {}
+
+        def create_engine(dsn: str, **kwargs):
+            captured["dsn"] = dsn
+            return object()
+
+        monkeypatch.setattr(db, "create_engine", create_engine)
+
+        db.get_postgres_sync_engine(
+            "postgresql+asyncpg://u:p@h/db?ssl=require&application_name=worker"
+        )
+
+        url = make_url(captured["dsn"])
+        assert url.drivername == "postgresql"
+        assert url.query["sslmode"] == "require"
+        assert url.query["application_name"] == "worker"
+        assert "ssl" not in url.query

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -93,6 +93,15 @@ class TestPostgresRuntimeUrlNormalization:
         assert url.query["ssl"] == "require"
         assert "channel_binding" not in url.query
 
+    def test_async_normalizer_preserves_unrelated_query_params(self):
+        result = db.normalize_async_postgres_uri(
+            "postgresql://u:p@h/db?sslmode=require&application_name=api"
+        )
+
+        url = make_url(result)
+        assert url.query["ssl"] == "require"
+        assert url.query["application_name"] == "api"
+
     def test_sync_normalizer_converts_asyncpg_ssl_to_libpq_sslmode(self):
         result = db.normalize_sync_postgres_uri(
             "postgresql+asyncpg://u:p@h/db?ssl=require"
@@ -112,6 +121,15 @@ class TestPostgresRuntimeUrlNormalization:
         assert url.drivername == "postgresql"
         assert url.query["sslmode"] == "require"
         assert "ssl" not in url.query
+
+    def test_sync_normalizer_removes_channel_binding(self):
+        result = db.normalize_sync_postgres_uri(
+            "postgresql+asyncpg://u:p@h/db?sslmode=require&channel_binding=require"
+        )
+
+        url = make_url(result)
+        assert url.query["sslmode"] == "require"
+        assert "channel_binding" not in url.query
 
     def test_sync_normalizer_preserves_unrelated_query_params(self):
         result = db.normalize_sync_postgres_uri(


### PR DESCRIPTION
## Summary
- normalize Postgres DSNs per runtime so asyncpg receives ssl=require while sync/libpq paths keep sslmode=require
- require PGBOUNCER_TRANSACTION_MODE=true for transaction-pooler-safe asyncpg settings, NullPool, connection timeout config, and sanitized posture logging
- return 503 for auth DB connect timeouts instead of surfacing internal failures
- use /ready for the production API container healthcheck and document hosted transaction pooler setup generically

## Verification
- bash ci/local_validate.sh passed: ruff format/check, mypy, full unit suite, ClickHouse live argMax proof
- Focused pytest passed for DB URL/pooler, health, auth timeout, and compose config coverage
- Manual driver exercised generic pooler hostname behavior: hostname alone keeps QueuePool; PGBOUNCER_TRANSACTION_MODE=true switches to NullPool and disables asyncpg statement caching
- unspecified-high follow-up review: PASS, no blocking findings

SCREENSHOT-WAIVER: backend/config/docs-only change; no rendered UI changed.