### PR TITLE
fix(work-graph): log non-text-path providers in issue→PR lookup

### DIFF
--- a/src/dev_health_ops/work_graph/builder.py
+++ b/src/dev_health_ops/work_graph/builder.py
@@ -562,6 +562,12 @@ class WorkGraphBuilder:
         gh_issue_lookup: dict[tuple[str, str], str] = {}
         gl_issue_lookup: dict[tuple[str, str], str] = {}
 
+        # Providers not covered by PR text parsing (notably Linear): their
+        # issue<->PR links arrive as native attachments and become edges via
+        # the work_item_dependencies pass (_build_issue_issue_edges), not here.
+        # Counted so this log does not imply they were silently dropped.
+        non_text_path_counts: dict[str, int] = {}
+
         for wi_row in wi_rows:
             repo_id = wi_row.get("repo_id")
             work_item_id = wi_row.get("work_item_id")
@@ -581,12 +587,18 @@ class WorkGraphBuilder:
                 if "#" in str(work_item_id):
                     issue_num = str(work_item_id).split("#")[-1]
                     gl_issue_lookup[(str(repo_id), issue_num)] = str(work_item_id)
+            elif provider and provider not in ("jira", "github", "gitlab"):
+                non_text_path_counts[str(provider)] = (
+                    non_text_path_counts.get(str(provider), 0) + 1
+                )
 
         logger.info(
-            "Built lookups: jira=%d, github=%d, gitlab=%d",
+            "Built text-parse lookups: jira=%d, github=%d, gitlab=%d; "
+            "non-text-path providers (edges via dependency pass): %s",
             len(jira_key_lookup),
             len(gh_issue_lookup),
             len(gl_issue_lookup),
+            non_text_path_counts or "none",
         )
 
         # Collect unique repo_ids from PRs for comparison


### PR DESCRIPTION
## What

The issue→PR text-parse pass (`_build_issue_pr_edges`) only builds `jira` / `github` / `gitlab` work-item lookups, but logged:

```
Built lookups: jira=%d, github=%d, gitlab=%d
```

With Linear work items present this reads as if Linear was silently dropped (e.g. `jira=0, github=84, gitlab=0` for 93 work items). It isn't: Linear issue↔PR links arrive as native attachments and become edges via the `work_item_dependencies` pass (`_build_issue_issue_edges`), not the text-parse pass.

## Change

Count providers **not** covered by text parsing and log them, so the line no longer looks like a coverage gap:

```
Built text-parse lookups: jira=0, github=84, gitlab=0; non-text-path providers (edges via dependency pass): {'linear': 9}
```

Pure observability change — no behavior change to edge building.

## Why

Surfaced while investigating the feature-flag work-graph gap (CHAOS-2629). A reader of these logs could not tell that Linear coverage comes from a sibling pass; this removes that false alarm.

## Testing

- `bash ci/local_validate.sh` → GATE PASSED (ruff format/check, mypy on 1189 files, full unit suite 5682 passed). ClickHouse stage skipped (dev container not running; CI validates it).

SCREENSHOT-WAIVER: backend logging-only change, no rendered UI.
