### PR TITLE
feat(graphql): direct-read feature-flag resolvers + LD audit-log clamp (CHAOS-2629)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -706,6 +706,43 @@ class WorkGraphArtifactsResult:
     degraded_reason: str | None = None
 
 
+@strawberry.type
+class FeatureFlagItem:
+    flag_id: str
+    flag_key: str
+    provider: str
+    project_key: str
+    environment: str
+    flag_type: str
+    created_at: str
+    archived_at: str | None = None
+
+
+@strawberry.type
+class FeatureFlagRegistryResult:
+    flags: list[FeatureFlagItem]
+    total_count: int
+    degraded_reason: str | None = None
+
+
+@strawberry.type
+class FeatureFlagEventItem:
+    flag_key: str
+    event_type: str
+    prev_state: str
+    next_state: str
+    actor_type: str
+    environment: str
+    event_ts: str
+
+
+@strawberry.type
+class FeatureFlagEventsResult:
+    events: list[FeatureFlagEventItem]
+    total_count: int
+    degraded_reason: str | None = None
+
+
 # =============================================================================
 # Capacity Planning types
 # =============================================================================

--- a/src/dev_health_ops/api/graphql/resolvers/feature_flags.py
+++ b/src/dev_health_ops/api/graphql/resolvers/feature_flags.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from dev_health_ops.api.graphql.authz import require_org_id
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.models.outputs import (
+    FeatureFlagEventItem,
+    FeatureFlagEventsResult,
+    FeatureFlagItem,
+    FeatureFlagRegistryResult,
+)
+from dev_health_ops.work_graph.ids import generate_feature_flag_id
+
+FEATURE_FLAG_NOT_MATERIALIZED = "FEATURE_FLAG_NOT_MATERIALIZED"
+FEATURE_FLAG_EVENT_NOT_MATERIALIZED = "FEATURE_FLAG_EVENT_NOT_MATERIALIZED"
+
+FEATURE_FLAG_LIMIT_MAX = 1000
+
+
+def _clamp_limit(limit: int) -> int:
+    """Bound a caller-supplied limit to a safe 1..MAX range.
+
+    Negative values error in ClickHouse and arbitrarily large values force
+    expensive org-wide sorts, so clamp before building the query.
+    """
+    return max(1, min(int(limit), FEATURE_FLAG_LIMIT_MAX))
+
+
+def _isoformat(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _nullable_isoformat(value: Any) -> str | None:
+    if value is None:
+        return None
+    return _isoformat(value)
+
+
+def _is_missing_clickhouse_table_error(exc: BaseException, table_name: str) -> bool:
+    from dev_health_ops.api.graphql.resolvers.work_graph import _unknown_table_names
+
+    text = str(exc)
+    is_unknown_table = (
+        getattr(exc, "code", None) == 60
+        or "UNKNOWN_TABLE" in text
+        or "code: 60" in text
+    )
+    return is_unknown_table and table_name in _unknown_table_names(text)
+
+
+def _empty_feature_flags_result(
+    degraded_reason: str | None = None,
+) -> FeatureFlagRegistryResult:
+    return FeatureFlagRegistryResult(
+        flags=[], total_count=0, degraded_reason=degraded_reason
+    )
+
+
+def _empty_feature_flag_events_result(
+    degraded_reason: str | None = None,
+) -> FeatureFlagEventsResult:
+    return FeatureFlagEventsResult(
+        events=[], total_count=0, degraded_reason=degraded_reason
+    )
+
+
+async def resolve_feature_flags(
+    context: GraphQLContext,
+    *,
+    provider: str | None = None,
+    project: str | None = None,
+    include_archived: bool = False,
+    limit: int = 1000,
+) -> FeatureFlagRegistryResult:
+    from dev_health_ops.api.queries.client import query_dicts
+
+    org_id = require_org_id(context)
+    client = context.client
+
+    if client is None:
+        raise RuntimeError("Database client not available")
+
+    where_clauses = ["org_id = %(org_id)s"]
+    params: dict[str, Any] = {"org_id": org_id, "limit": _clamp_limit(limit)}
+    if provider is not None:
+        where_clauses.append("provider = %(provider)s")
+        params["provider"] = provider
+    if project is not None:
+        where_clauses.append("project_key = %(project)s")
+        params["project"] = project
+    if not include_archived:
+        where_clauses.append("archived_at IS NULL")
+
+    query = f"""
+        SELECT
+            provider,
+            flag_key,
+            project_key,
+            environment,
+            flag_type,
+            created_at,
+            archived_at
+        FROM feature_flag FINAL
+        WHERE {" AND ".join(where_clauses)}
+        ORDER BY provider, project_key, flag_key
+        LIMIT %(limit)s
+    """
+
+    try:
+        rows = await query_dicts(client, query, params)
+    except Exception as exc:
+        if _is_missing_clickhouse_table_error(exc, "feature_flag"):
+            return _empty_feature_flags_result(FEATURE_FLAG_NOT_MATERIALIZED)
+        raise
+
+    flags = [
+        FeatureFlagItem(
+            flag_id=generate_feature_flag_id(
+                org_id,
+                str(row.get("provider") or ""),
+                str(row.get("project_key") or ""),
+                str(row.get("flag_key") or ""),
+            ),
+            flag_key=str(row.get("flag_key") or ""),
+            provider=str(row.get("provider") or ""),
+            project_key=str(row.get("project_key") or ""),
+            environment=str(row.get("environment") or ""),
+            flag_type=str(row.get("flag_type") or ""),
+            created_at=_isoformat(row.get("created_at")),
+            archived_at=_nullable_isoformat(row.get("archived_at")),
+        )
+        for row in rows
+    ]
+    return FeatureFlagRegistryResult(flags=flags, total_count=len(flags))
+
+
+async def resolve_feature_flag_events(
+    context: GraphQLContext,
+    *,
+    flag_key: str | None = None,
+    environment: str | None = None,
+    limit: int = 1000,
+) -> FeatureFlagEventsResult:
+    from dev_health_ops.api.queries.client import query_dicts
+
+    org_id = require_org_id(context)
+    client = context.client
+
+    if client is None:
+        raise RuntimeError("Database client not available")
+
+    where_clauses = ["org_id = %(org_id)s"]
+    params: dict[str, Any] = {"org_id": org_id, "limit": _clamp_limit(limit)}
+    if flag_key is not None:
+        where_clauses.append("flag_key = %(flag_key)s")
+        params["flag_key"] = flag_key
+    if environment is not None:
+        where_clauses.append("environment = %(environment)s")
+        params["environment"] = environment
+
+    query = f"""
+        SELECT
+            flag_key,
+            event_type,
+            prev_state,
+            next_state,
+            actor_type,
+            environment,
+            event_ts
+        FROM feature_flag_event
+        WHERE {" AND ".join(where_clauses)}
+        ORDER BY event_ts ASC
+        LIMIT %(limit)s
+    """
+
+    try:
+        rows = await query_dicts(client, query, params)
+    except Exception as exc:
+        if _is_missing_clickhouse_table_error(exc, "feature_flag_event"):
+            return _empty_feature_flag_events_result(
+                FEATURE_FLAG_EVENT_NOT_MATERIALIZED
+            )
+        raise
+
+    events = [
+        FeatureFlagEventItem(
+            flag_key=str(row.get("flag_key") or ""),
+            event_type=str(row.get("event_type") or ""),
+            prev_state=str(row.get("prev_state") or ""),
+            next_state=str(row.get("next_state") or ""),
+            actor_type=str(row.get("actor_type") or ""),
+            environment=str(row.get("environment") or ""),
+            event_ts=_isoformat(row.get("event_ts")),
+        )
+        for row in rows
+    ]
+    return FeatureFlagEventsResult(events=events, total_count=len(events))

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -42,6 +42,8 @@ from .models.outputs import (
     CapacityForecast,
     CapacityForecastConnection,
     CatalogResult,
+    FeatureFlagEventsResult,
+    FeatureFlagRegistryResult,
     HomeResult,
     OperatingReview,
     ProductTelemetryDashboardType,
@@ -295,6 +297,46 @@ class Query:
 
         context = get_context(info)
         return await resolve_work_graph_artifacts(context, filters)
+
+    @strawberry.field(description="List feature flags from the ClickHouse registry")
+    async def feature_flags(
+        self,
+        info: Info,
+        org_id: str,
+        provider: str | None = None,
+        project: str | None = None,
+        include_archived: bool | None = False,
+        limit: int = 1000,
+    ) -> FeatureFlagRegistryResult:
+        from .resolvers.feature_flags import resolve_feature_flags
+
+        context = get_context(info)
+        return await resolve_feature_flags(
+            context,
+            provider=provider,
+            project=project,
+            include_archived=bool(include_archived),
+            limit=limit,
+        )
+
+    @strawberry.field(description="List feature flag state-change events")
+    async def feature_flag_events(
+        self,
+        info: Info,
+        org_id: str,
+        flag_key: str | None = None,
+        environment: str | None = None,
+        limit: int = 1000,
+    ) -> FeatureFlagEventsResult:
+        from .resolvers.feature_flags import resolve_feature_flag_events
+
+        context = get_context(info)
+        return await resolve_feature_flag_events(
+            context,
+            flag_key=flag_key,
+            environment=environment,
+            limit=limit,
+        )
 
     @strawberry.field(
         description=(

--- a/src/dev_health_ops/connectors/launchdarkly.py
+++ b/src/dev_health_ops/connectors/launchdarkly.py
@@ -22,6 +22,11 @@ logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://app.launchdarkly.com/api/v2"
 
+# LaunchDarkly hard-caps the audit-log `limit` at 20 entries per request; full
+# history is assembled by following the `_links.next` cursor across pages.
+_AUDIT_LOG_PAGE_SIZE = 20
+_API_V2_PREFIX = "/api/v2"
+
 
 def _parse_rate_limit_remaining(response: httpx.Response) -> int | None:
     """Extract remaining rate-limit budget from LD response headers."""
@@ -203,28 +208,55 @@ class LaunchDarklyConnector:
     async def get_audit_log(
         self,
         since: datetime | None = None,
-        limit: int = 20,
+        limit: int = 1000,
     ) -> list[dict]:
-        """Fetch audit log entries.
+        """Fetch audit log entries, paginating to assemble full history.
 
-        :param since: Only return entries after this timestamp.
-        :param limit: Maximum entries to return. LaunchDarkly caps this at
-            20 per request; values outside 0..20 are clamped to stay valid.
+        LaunchDarkly caps the audit-log endpoint at 20 entries per request, so
+        this pages via the ``_links.next`` cursor until the log is exhausted or
+        ``limit`` total entries have been collected.
+
+        :param since: Only return entries occurring after this timestamp.
+        :param limit: Maximum total entries to return across all pages.
         :returns: List of raw audit-log entry dicts.
         """
-        # LaunchDarkly rejects any audit-log `limit` outside 0..20 with HTTP
-        # 400 ("`limit` must be a valid integer between 0 and 20"), so clamp
-        # the caller-supplied value to the API's supported range.
-        params: dict[str, Any] = {"limit": max(0, min(int(limit), 20))}
-        if since is not None:
-            # LD expects epoch milliseconds for date filters
-            epoch_ms = int(since.timestamp() * 1000)
-            params["after"] = epoch_ms
+        max_total = max(0, int(limit))
+        if max_total == 0:
+            return []
 
+        params: dict[str, Any] = {"limit": _AUDIT_LOG_PAGE_SIZE}
+        if since is not None:
+            # LD expects epoch milliseconds for date filters.
+            params["after"] = int(since.timestamp() * 1000)
+
+        all_items: list[dict] = []
+        # Bound the page count defensively so a misbehaving cursor cannot loop
+        # forever; each page yields at most _AUDIT_LOG_PAGE_SIZE entries.
+        max_pages = max_total // _AUDIT_LOG_PAGE_SIZE + 2
         data = await self._request("GET", "/auditlog", params=params)
-        items = data.get("items", [])
-        logger.info("Fetched %d audit log entries", len(items))
-        return items
+        for _ in range(max_pages):
+            items = data.get("items", [])
+            if not items:
+                break
+            all_items.extend(items)
+            if len(all_items) >= max_total:
+                break
+            href = ((data.get("_links") or {}).get("next") or {}).get("href")
+            if not href:
+                break
+            # base_url already includes /api/v2; strip that prefix so a relative
+            # next-href resolves against base_url without duplicating it.
+            if href.startswith("http"):
+                next_path = href
+            elif href.startswith(_API_V2_PREFIX):
+                next_path = href[len(_API_V2_PREFIX) :]
+            else:
+                next_path = href
+            data = await self._request("GET", next_path)
+
+        result = all_items[:max_total]
+        logger.info("Fetched %d audit log entries", len(result))
+        return result
 
     async def close(self) -> None:
         """Close the underlying HTTP client."""

--- a/src/dev_health_ops/connectors/launchdarkly.py
+++ b/src/dev_health_ops/connectors/launchdarkly.py
@@ -208,10 +208,14 @@ class LaunchDarklyConnector:
         """Fetch audit log entries.
 
         :param since: Only return entries after this timestamp.
-        :param limit: Maximum entries to return (LD default is 20).
+        :param limit: Maximum entries to return. LaunchDarkly caps this at
+            20 per request; values outside 0..20 are clamped to stay valid.
         :returns: List of raw audit-log entry dicts.
         """
-        params: dict[str, Any] = {"limit": limit}
+        # LaunchDarkly rejects any audit-log `limit` outside 0..20 with HTTP
+        # 400 ("`limit` must be a valid integer between 0 and 20"), so clamp
+        # the caller-supplied value to the API's supported range.
+        params: dict[str, Any] = {"limit": max(0, min(int(limit), 20))}
         if since is not None:
             # LD expects epoch milliseconds for date filters
             epoch_ms = int(since.timestamp() * 1000)

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -111,7 +111,9 @@ def _sync_launchdarkly_feature_flags(
             api_key=api_key, project_key=project_key
         ) as connector:
             raw_flags = await connector.get_flags(project_key)
-            raw_events = await connector.get_audit_log(since=since_dt, limit=200)
+            # LaunchDarkly caps the audit-log page at 20 entries; full history
+            # accrues across incremental (since-bounded) syncs.
+            raw_events = await connector.get_audit_log(since=since_dt, limit=20)
 
         flags = normalize_flags(raw_flags, org_id)
         if environment:

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -111,9 +111,10 @@ def _sync_launchdarkly_feature_flags(
             api_key=api_key, project_key=project_key
         ) as connector:
             raw_flags = await connector.get_flags(project_key)
-            # LaunchDarkly caps the audit-log page at 20 entries; full history
-            # accrues across incremental (since-bounded) syncs.
-            raw_events = await connector.get_audit_log(since=since_dt, limit=20)
+            # LaunchDarkly caps each audit-log page at 20 entries; the
+            # connector paginates via _links.next to assemble full history
+            # since the last watermark.
+            raw_events = await connector.get_audit_log(since=since_dt, limit=1000)
 
         flags = normalize_flags(raw_flags, org_id)
         if environment:

--- a/tests/graphql/test_feature_flags.py
+++ b/tests/graphql/test_feature_flags.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.resolvers.feature_flags import (
+    FEATURE_FLAG_EVENT_NOT_MATERIALIZED,
+    FEATURE_FLAG_NOT_MATERIALIZED,
+    resolve_feature_flag_events,
+    resolve_feature_flags,
+)
+from dev_health_ops.work_graph.ids import generate_feature_flag_id
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+
+class MockClient:
+    pass
+
+
+class MissingTableError(Exception):
+    code = 60
+
+
+@pytest.fixture
+def mock_context() -> GraphQLContext:
+    return GraphQLContext(
+        org_id="test-org",
+        db_url="clickhouse://localhost:8123/default",
+        client=MockClient(),
+    )
+
+
+def _missing_table(table_name: str) -> MissingTableError:
+    return MissingTableError(
+        f"UNKNOWN_TABLE Unknown table expression identifier '{table_name}'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_feature_flags_query_scopes_org_filters_and_orders(
+    mock_context: GraphQLContext,
+) -> None:
+    created_at = datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+    ) as mock_query:
+        mock_query.return_value = [
+            {
+                "provider": "launchdarkly",
+                "flag_key": "checkout-v2",
+                "project_key": "web",
+                "environment": "prod",
+                "flag_type": "boolean",
+                "created_at": created_at,
+                "archived_at": None,
+            }
+        ]
+
+        result = await resolve_feature_flags(
+            mock_context,
+            provider="launchdarkly",
+            project="web",
+            include_archived=False,
+            limit=25,
+        )
+
+    sql = mock_query.call_args[0][1]
+    params = mock_query.call_args[0][2]
+    assert "FROM feature_flag FINAL" in sql
+    assert "WHERE org_id = %(org_id)s" in sql
+    assert "provider = %(provider)s" in sql
+    assert "project_key = %(project)s" in sql
+    assert "archived_at IS NULL" in sql
+    assert "ORDER BY provider, project_key, flag_key" in sql
+    assert "LIMIT %(limit)s" in sql
+    assert params == {
+        "org_id": "test-org",
+        "provider": "launchdarkly",
+        "project": "web",
+        "limit": 25,
+    }
+    assert result.total_count == 1
+    assert result.flags[0].flag_id == generate_feature_flag_id(
+        "test-org", "launchdarkly", "web", "checkout-v2"
+    )
+    assert result.flags[0].created_at == created_at.isoformat()
+    assert result.flags[0].archived_at is None
+
+
+@pytest.mark.asyncio
+async def test_feature_flags_include_archived_omits_archived_filter(
+    mock_context: GraphQLContext,
+) -> None:
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+    ) as mock_query:
+        mock_query.return_value = []
+
+        await resolve_feature_flags(mock_context, include_archived=True)
+
+    sql = mock_query.call_args[0][1]
+    params = mock_query.call_args[0][2]
+    assert "archived_at IS NULL" not in sql
+    assert params == {"org_id": "test-org", "limit": 1000}
+
+
+@pytest.mark.asyncio
+async def test_feature_flags_clamps_out_of_range_limits(
+    mock_context: GraphQLContext,
+) -> None:
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+    ) as mock_query:
+        mock_query.return_value = []
+        await resolve_feature_flags(mock_context, limit=10_000)
+        await resolve_feature_flags(mock_context, limit=-5)
+
+    huge_params = mock_query.call_args_list[0][0][2]
+    negative_params = mock_query.call_args_list[1][0][2]
+    assert huge_params["limit"] == 1000
+    assert negative_params["limit"] == 1
+
+
+@pytest.mark.asyncio
+async def test_feature_flag_events_clamps_out_of_range_limits(
+    mock_context: GraphQLContext,
+) -> None:
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+    ) as mock_query:
+        mock_query.return_value = []
+        await resolve_feature_flag_events(mock_context, limit=10_000)
+        await resolve_feature_flag_events(mock_context, limit=0)
+
+    huge_params = mock_query.call_args_list[0][0][2]
+    zero_params = mock_query.call_args_list[1][0][2]
+    assert huge_params["limit"] == 1000
+    assert zero_params["limit"] == 1
+
+
+@pytest.mark.asyncio
+async def test_feature_flag_events_query_scopes_org_filters_and_orders(
+    mock_context: GraphQLContext,
+) -> None:
+    event_ts = datetime(2026, 6, 1, 10, 1, tzinfo=timezone.utc)
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+    ) as mock_query:
+        mock_query.return_value = [
+            {
+                "flag_key": "checkout-v2",
+                "event_type": "enabled",
+                "prev_state": "off",
+                "next_state": "on",
+                "actor_type": "user",
+                "environment": "prod",
+                "event_ts": event_ts,
+            }
+        ]
+
+        result = await resolve_feature_flag_events(
+            mock_context,
+            flag_key="checkout-v2",
+            environment="prod",
+            limit=10,
+        )
+
+    sql = mock_query.call_args[0][1]
+    params = mock_query.call_args[0][2]
+    assert "FROM feature_flag_event" in sql
+    assert "FROM feature_flag_event FINAL" not in sql
+    assert "WHERE org_id = %(org_id)s" in sql
+    assert "flag_key = %(flag_key)s" in sql
+    assert "environment = %(environment)s" in sql
+    assert "provider" not in sql
+    assert "project_key" not in sql
+    assert "ORDER BY event_ts ASC" in sql
+    assert params == {
+        "org_id": "test-org",
+        "flag_key": "checkout-v2",
+        "environment": "prod",
+        "limit": 10,
+    }
+    assert result.total_count == 1
+    assert result.events[0].event_ts == event_ts.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_feature_flags_missing_table_degrades_but_other_errors_reraise(
+    mock_context: GraphQLContext,
+) -> None:
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+    ) as mock_query:
+        mock_query.side_effect = _missing_table("feature_flag")
+
+        result = await resolve_feature_flags(mock_context)
+
+    assert result.flags == []
+    assert result.total_count == 0
+    assert result.degraded_reason == FEATURE_FLAG_NOT_MATERIALIZED
+
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+    ) as mock_query:
+        mock_query.side_effect = _missing_table("other_table")
+
+        with pytest.raises(MissingTableError):
+            await resolve_feature_flags(mock_context)
+
+
+@pytest.mark.asyncio
+async def test_feature_flag_events_missing_table_degrades_but_other_errors_reraise(
+    mock_context: GraphQLContext,
+) -> None:
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+    ) as mock_query:
+        mock_query.side_effect = _missing_table("feature_flag_event")
+
+        result = await resolve_feature_flag_events(mock_context)
+
+    assert result.events == []
+    assert result.total_count == 0
+    assert result.degraded_reason == FEATURE_FLAG_EVENT_NOT_MATERIALIZED
+
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        new_callable=AsyncMock,
+    ) as mock_query:
+        mock_query.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await resolve_feature_flag_events(mock_context)
+
+
+@pytest.mark.clickhouse
+@pytest.mark.skipif(
+    not CLICKHOUSE_URI,
+    reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/default)",
+)
+@pytest.mark.asyncio
+async def test_feature_flag_registry_and_events_live_clickhouse() -> None:
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+    sink = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    sink.ensure_schema(force=True)
+    org_id = f"test-chaos-2629-{uuid.uuid4()}"
+    repo_id = str(uuid.uuid4())
+    base_ts = datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc)
+
+    flag_rows: list[list[Any]] = [
+        [
+            org_id,
+            "launchdarkly",
+            "checkout-v2",
+            "web",
+            repo_id,
+            "prod",
+            "boolean",
+            base_ts,
+            None,
+            base_ts,
+        ],
+        [
+            org_id,
+            "gitlab",
+            "search-rollout",
+            "platform",
+            repo_id,
+            "prod",
+            "percentage",
+            base_ts,
+            None,
+            base_ts,
+        ],
+    ]
+    event_rows: list[list[Any]] = [
+        [
+            org_id,
+            "created",
+            "checkout-v2",
+            "prod",
+            repo_id,
+            "system",
+            "missing",
+            "off",
+            base_ts,
+            base_ts,
+            "evt-1",
+            f"{org_id}:evt-1",
+        ],
+        [
+            org_id,
+            "enabled",
+            "search-rollout",
+            "prod",
+            repo_id,
+            "user",
+            "off",
+            "on",
+            base_ts + timedelta(minutes=1),
+            base_ts + timedelta(minutes=1),
+            "evt-2",
+            f"{org_id}:evt-2",
+        ],
+        [
+            org_id,
+            "disabled",
+            "checkout-v2",
+            "prod",
+            repo_id,
+            "user",
+            "on",
+            "off",
+            base_ts + timedelta(minutes=2),
+            base_ts + timedelta(minutes=2),
+            "evt-3",
+            f"{org_id}:evt-3",
+        ],
+    ]
+
+    try:
+        sink.client.insert(
+            "feature_flag",
+            flag_rows,
+            column_names=[
+                "org_id",
+                "provider",
+                "flag_key",
+                "project_key",
+                "repo_id",
+                "environment",
+                "flag_type",
+                "created_at",
+                "archived_at",
+                "last_synced",
+            ],
+        )
+        sink.client.insert(
+            "feature_flag_event",
+            event_rows,
+            column_names=[
+                "org_id",
+                "event_type",
+                "flag_key",
+                "environment",
+                "repo_id",
+                "actor_type",
+                "prev_state",
+                "next_state",
+                "event_ts",
+                "ingested_at",
+                "source_event_id",
+                "dedupe_key",
+            ],
+        )
+
+        context = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI, client=sink)
+        registry = await resolve_feature_flags(context, limit=10)
+        events = await resolve_feature_flag_events(context, limit=10)
+
+        assert registry.total_count == 2
+        assert {(f.provider, f.flag_key) for f in registry.flags} == {
+            ("gitlab", "search-rollout"),
+            ("launchdarkly", "checkout-v2"),
+        }
+        assert [event.flag_key for event in events.events] == [
+            "checkout-v2",
+            "search-rollout",
+            "checkout-v2",
+        ]
+        assert [event.event_type for event in events.events] == [
+            "created",
+            "enabled",
+            "disabled",
+        ]
+        assert events.total_count == 3
+    finally:
+        sink.client.command(
+            "ALTER TABLE feature_flag DELETE WHERE org_id = {o:String} "
+            "SETTINGS mutations_sync=2",
+            parameters={"o": org_id},
+        )
+        sink.client.command(
+            "ALTER TABLE feature_flag_event DELETE WHERE org_id = {o:String} "
+            "SETTINGS mutations_sync=2",
+            parameters={"o": org_id},
+        )
+        sink.close()

--- a/tests/test_launchdarkly.py
+++ b/tests/test_launchdarkly.py
@@ -158,6 +158,26 @@ class TestLaunchDarklyConnector:
         assert params["limit"] == 20
 
     @pytest.mark.asyncio
+    async def test_get_audit_log_clamps_limit_to_api_max(self, connector):
+        # LaunchDarkly returns HTTP 400 if `limit` exceeds 20; the connector
+        # must clamp any larger caller value to the API's supported range.
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.json.return_value = {"items": []}
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=mock_response)
+        connector._client = mock_client
+
+        await connector.get_audit_log(limit=200)
+
+        call_kwargs = mock_client.request.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        assert params["limit"] == 20
+
+    @pytest.mark.asyncio
     async def test_close_closes_client(self, connector):
         mock_client = AsyncMock(spec=httpx.AsyncClient)
         mock_client.is_closed = False

--- a/tests/test_launchdarkly.py
+++ b/tests/test_launchdarkly.py
@@ -178,6 +178,49 @@ class TestLaunchDarklyConnector:
         assert params["limit"] == 20
 
     @pytest.mark.asyncio
+    async def test_get_audit_log_paginates_via_next_link(self, connector):
+        # LaunchDarkly returns at most 20 entries per page; the connector must
+        # follow _links.next (with the /api/v2 prefix stripped) to assemble the
+        # full history.
+        def _page(items: list[dict], next_href: str | None = None) -> MagicMock:
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.headers = {}
+            body: dict[str, object] = {"items": items}
+            if next_href is not None:
+                body["_links"] = {"next": {"href": next_href}}
+            resp.json.return_value = body
+            return resp
+
+        page1 = _page(
+            [{"_id": f"a{i}"} for i in range(20)],
+            "/api/v2/auditlog?limit=20&before=2000",
+        )
+        page2 = _page(
+            [{"_id": f"b{i}"} for i in range(20)],
+            "/api/v2/auditlog?limit=20&before=1000",
+        )
+        page3 = _page([{"_id": f"c{i}"} for i in range(5)])
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(side_effect=[page1, page2, page3])
+        connector._client = mock_client
+
+        events = await connector.get_audit_log(limit=1000)
+
+        assert len(events) == 45
+        assert mock_client.request.await_count == 3
+        # First request caps the page at 20 entries.
+        first_call = mock_client.request.call_args_list[0]
+        first_params = first_call.kwargs.get("params") or first_call[1].get("params")
+        assert first_params["limit"] == 20
+        # Pagination follows _links.next with the /api/v2 prefix stripped.
+        assert mock_client.request.call_args_list[1].args[1] == (
+            "/auditlog?limit=20&before=2000"
+        )
+
+    @pytest.mark.asyncio
     async def test_close_closes_client(self, connector):
         mock_client = AsyncMock(spec=httpx.AsyncClient)
         mock_client.is_closed = False


### PR DESCRIPTION
## CHAOS-2629 — Feature-flag data: surface what we already persist (Phase A + B, ops side)

We pull LaunchDarkly + GitLab feature flags and persist full data to the `feature_flag` / `feature_flag_event` ClickHouse tables, but the `/feature-flags` page only ever read the work graph — where prod writes a single `CONFIG_CHANGED_BY` self-edge per flag. The rich history was stranded. This adds direct-read resolvers so the page can reach it.

### What changed
- **New resolvers** (`api/graphql/resolvers/feature_flags.py`): org-scoped `featureFlags` and `featureFlagEvents`, reading directly from `feature_flag` (`FINAL`) and `feature_flag_event`. Registered on the `Query` type; 4 new Strawberry output types.
  - Mirrors `resolve_work_graph_edges`: `require_org_id` scoping, parameterized SQL only, and the **narrow degraded-table contract** (only the resolver's own missing table → empty + `degradedReason`; every other error re-raises).
  - Limits clamped to `1..1000`; events ordered `event_ts ASC`; no raw `repo_id` surfaced.
- **LaunchDarkly audit-log fix** (folded in, CHAOS-2631):
  - `get_audit_log` was 400-looping prod sync (`limit` must be 0..20; caller passed 200). Clamp the per-request limit at the connector boundary.
  - **Paginate** via the LaunchDarkly `_links.next` cursor (per-page capped at 20, bounded page count) so the full since-bounded history is assembled instead of a single ≤20-entry page. The sync now requests `limit=1000`. This unblocks live capture of the event timeline.

### Verification
- `bash ci/local_validate.sh` → **GATE PASSED** (full unit suite + scratch-ClickHouse argMax proof), re-run after the pagination change.
- ClickHouse-marked live test seeds **both** a LaunchDarkly and a GitLab flag + 3 events and asserts the resolvers return the **full ordered history** + registry (provider-agnostic). Verified against a scratch CH db.
- Unit tests: resolver org-scoping/filters/ordering, `include_archived`, degraded-table-vs-reraise, limit clamping; LD clamp + **pagination** regression tests (45 events across 3 pages, no per-request limit > 20).

### SDL / web
SDL regenerated via `export_schema`; the web `schema.graphql` is synced in the companion web PR. Schema diff is exactly the 4 new types + 2 Query fields.

> **Merge order:** this ops PR must merge before web #703 — the web schema-drift gate exports the ops *main* schema, so #703's `live-e2e` stays red until these fields land on ops `main`.

### Out of scope / follow-ups
- **CHAOS-2630** — Phase-C associations (`GUARDS`/`IMPACTS`/`feature_flag_link`) need a real signal source (design-gated). No association edges are emitted here.
- **CHAOS-2632** — `feature_flag` `FINAL` collapses environments (sort key omits `environment`); `totalCount` is count-after-limit.

Companion web PR: full-chaos/dev-health-web#703.

Closes CHAOS-2629 (with Phase C tracked separately); resolves CHAOS-2631.
