### PR TITLE
feat(work-graph): real flag-key GUARDS associations from text references (CHAOS-2630 Phase C1)

### DIFF
--- a/src/dev_health_ops/work_graph/builder.py
+++ b/src/dev_health_ops/work_graph/builder.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 from dev_health_ops.metrics.schemas import (
+    FeatureFlagLinkRecord,
     WorkGraphEdgeRecord,
     WorkGraphIssuePRRecord,
     WorkGraphPRCommitRecord,
@@ -24,6 +25,7 @@ from dev_health_ops.metrics.schemas import (
 from dev_health_ops.metrics.sinks.factory import create_sink
 from dev_health_ops.work_graph.extractors.text_parser import (
     RefType,
+    extract_flag_key_refs,
     extract_github_issue_refs,
     extract_gitlab_issue_refs,
     extract_jira_keys,
@@ -68,6 +70,12 @@ DEPENDENCY_TYPE_MAP: dict[str, EdgeType] = {
     "is_parent_of": EdgeType.PARENT_OF,
     "is_child_of": EdgeType.CHILD_OF,
 }
+
+# CHAOS-2630 Phase C1: confidence ceiling for flag associations inferred from a
+# flag key literally appearing in PR/issue/commit text. Kept well below the 0.9
+# used for structured PROJECT-123 issue refs (flag keys are noisier free-form
+# strings) and strictly below NATIVE, per the design sign-off.
+FLAG_TEXT_REF_CONFIDENCE = 0.6
 
 
 @dataclass
@@ -367,6 +375,7 @@ class WorkGraphBuilder:
             "pr_commit_edges": 0,
             "commit_file_edges": 0,
             "heuristic_edges": 0,
+            "flag_guards_edges": 0,
         }
 
         logger.info("Starting work graph build...")
@@ -403,12 +412,134 @@ class WorkGraphBuilder:
         # 6. Commit->file edges are handled by view over git_commit_stats
         stats["commit_file_edges"] = self._count_commit_file_edges()
 
+        # 7. Build feature-flag GUARDS edges (flag -> issue) from real flag-key
+        #    references in issue text. CHAOS-2630 Phase C1: the only non-fixture
+        #    source of flag associations; registry-validated + confidence-gated.
+        stats["flag_guards_edges"] = self._build_flag_guards_edges()
+
         logger.info(
             "Work graph build complete: %s",
             ", ".join(f"{k}={v}" for k, v in stats.items()),
         )
 
         return stats
+
+    def _build_flag_guards_edges(self) -> int:
+        """Build GUARDS edges (feature_flag -> issue) from real flag-key text refs.
+
+        CHAOS-2630 Phase C1 -- the only non-fixture source of feature-flag
+        associations. A flag key that literally appears in an issue's title or
+        description is an evidence-backed signal that the issue is guarded by
+        that flag. Matching is **registry-validated** (only keys present in the
+        ``feature_flag`` table for the org can match) and emitted as
+        ``EXPLICIT_TEXT`` with a confidence ceiling strictly below ``NATIVE``;
+        an unknown flag key never produces an edge or a link.
+        """
+        logger.info("Building feature-flag GUARDS edges from issue text references...")
+
+        # 1. Load the org's real flag registry (env-agnostic identity).
+        flag_query = "SELECT flag_key, provider, project_key FROM feature_flag FINAL"
+        if self.config.org_id:
+            flag_query += f" WHERE org_id = '{self.config.org_id}'"
+        flag_rows = self.sink.query_dicts(flag_query, {})
+        if not flag_rows:
+            logger.info("No feature flags in registry; skipping GUARDS edges")
+            return 0
+
+        # flag_key -> list of (provider, project_key, flag_id). A key can in
+        # principle exist under more than one provider/project; emit for each.
+        flag_identities: dict[str, list[tuple[str, str, str]]] = {}
+        for row in flag_rows:
+            flag_key = str(row.get("flag_key") or "")
+            if not flag_key:
+                continue
+            provider = str(row.get("provider") or "")
+            project_key = str(row.get("project_key") or "")
+            flag_id = generate_feature_flag_id(
+                self.config.org_id, provider, project_key, flag_key
+            )
+            flag_identities.setdefault(flag_key, []).append(
+                (provider, project_key, flag_id)
+            )
+
+        known_keys = list(flag_identities.keys())
+
+        # 2. Load issue text (work_items title + description).
+        wi_query = "SELECT work_item_id, title, description FROM work_items"
+        if self.config.org_id:
+            wi_query += f" WHERE org_id = '{self.config.org_id}'"
+        wi_rows = self.sink.query_dicts(wi_query, {})
+        if not wi_rows:
+            return 0
+
+        edges: list[WorkGraphEdge] = []
+        links: list[FeatureFlagLinkRecord] = []
+        seen_edges: set[str] = set()
+        now = self._now
+
+        for wi_row in wi_rows:
+            work_item_id = str(wi_row.get("work_item_id") or "")
+            if not work_item_id:
+                continue
+            text = " ".join(
+                str(wi_row.get(col) or "") for col in ("title", "description")
+            ).strip()
+            if not text:
+                continue
+            for ref in extract_flag_key_refs(text, known_keys):
+                for provider, _project_key, flag_id in flag_identities[ref.flag_key]:
+                    edge_id = generate_edge_id(
+                        NodeType.FEATURE_FLAG,
+                        flag_id,
+                        EdgeType.GUARDS,
+                        NodeType.ISSUE,
+                        work_item_id,
+                    )
+                    if edge_id in seen_edges:
+                        continue
+                    seen_edges.add(edge_id)
+                    edges.append(
+                        WorkGraphEdge(
+                            edge_id=edge_id,
+                            source_type=NodeType.FEATURE_FLAG,
+                            source_id=flag_id,
+                            target_type=NodeType.ISSUE,
+                            target_id=work_item_id,
+                            edge_type=EdgeType.GUARDS,
+                            provenance=Provenance.EXPLICIT_TEXT,
+                            confidence=FLAG_TEXT_REF_CONFIDENCE,
+                            evidence=f"flagref:{ref.raw_match}",
+                            provider=provider or None,
+                            event_ts=now,
+                        )
+                    )
+                    links.append(
+                        FeatureFlagLinkRecord(
+                            flag_key=ref.flag_key,
+                            target_type="issue",
+                            target_id=work_item_id,
+                            provider=provider,
+                            link_source="explicit_text",
+                            link_type="tracks",
+                            evidence_type="issue_text",
+                            confidence=FLAG_TEXT_REF_CONFIDENCE,
+                            valid_from=now,
+                            valid_to=None,
+                            last_synced=now,
+                            org_id=self.config.org_id,
+                        )
+                    )
+
+        if edges:
+            self._write_edges(edges)
+        if links:
+            self.sink.write_feature_flag_links(links)
+        logger.info(
+            "Created %d feature-flag GUARDS edges (%d links) from text references",
+            len(edges),
+            len(links),
+        )
+        return len(edges)
 
     def _build_issue_issue_edges(self) -> int:
         """

--- a/src/dev_health_ops/work_graph/extractors/text_parser.py
+++ b/src/dev_health_ops/work_graph/extractors/text_parser.py
@@ -5,6 +5,7 @@ Text parsing utilities for extracting issue references from PR titles and bodies
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 
@@ -394,4 +395,78 @@ def extract_gitlab_issue_refs(text: str) -> list[ParsedIssueRef]:
                     )
                 )
 
+    return results
+
+
+# Feature-flag keys are free-form identifiers (e.g. "checkout-v2",
+# "search_rollout") with no canonical shape, unlike PROJECT-123 issue keys.
+# A reference can therefore only be recognised by matching against the org's
+# real registry of flag keys. We also require a minimum length and reject
+# purely-numeric keys to keep false positives down (CHAOS-2630 Phase C1).
+FLAG_KEY_MIN_LENGTH = 4
+
+# Characters that count as part of a flag-key token. A match must not be
+# flanked by any of these, so "search" does not match inside "searching" or
+# "search-rollout", and "checkout-v2" is matched as a single unit.
+_FLAG_KEY_BOUNDARY = r"[\w./:-]"
+
+
+@dataclass(frozen=True)
+class ParsedFlagRef:
+    """A feature-flag key reference found in free-form text.
+
+    Attributes:
+        flag_key: The registry flag key that matched.
+        raw_match: The exact text span that matched.
+    """
+
+    flag_key: str
+    raw_match: str
+
+
+def extract_flag_key_refs(
+    text: str,
+    known_flag_keys: Iterable[str],
+    *,
+    min_length: int = FLAG_KEY_MIN_LENGTH,
+) -> list[ParsedFlagRef]:
+    """Extract references to known feature-flag keys from free-form text.
+
+    Feature-flag keys have no canonical shape (unlike ``PROJECT-123`` issue
+    keys), so a reference can only be recognised by matching against the
+    caller-supplied registry of real flag keys for the org. Matching is:
+
+    - **registry-validated**: only keys in ``known_flag_keys`` can match; an
+      unknown token is never surfaced as a flag reference;
+    - **whole-token**: the key must appear on identifier boundaries, so
+      ``search`` does not match inside ``searching`` and ``checkout-v2`` is
+      matched as a unit (never as the shorter ``checkout``);
+    - **guarded**: keys shorter than ``min_length`` and purely-numeric keys are
+      skipped, since they are too noisy to attribute confidently.
+
+    Args:
+        text: The PR/issue/commit text to scan.
+        known_flag_keys: The org's real flag keys (from the feature_flag registry).
+        min_length: Minimum key length to consider (default 4).
+
+    Returns:
+        De-duplicated ``ParsedFlagRef`` list, in first-seen order of the keys.
+    """
+    if not text:
+        return []
+
+    seen: set[str] = set()
+    results: list[ParsedFlagRef] = []
+    for raw_key in known_flag_keys:
+        key = (raw_key or "").strip()
+        if len(key) < min_length or key.isdigit() or key in seen:
+            continue
+        pattern = re.compile(
+            rf"(?<!{_FLAG_KEY_BOUNDARY}){re.escape(key)}(?!{_FLAG_KEY_BOUNDARY})"
+        )
+        match = pattern.search(text)
+        if match is None:
+            continue
+        seen.add(key)
+        results.append(ParsedFlagRef(flag_key=key, raw_match=match.group(0)))
     return results

--- a/tests/work_graph/test_builder.py
+++ b/tests/work_graph/test_builder.py
@@ -885,3 +885,133 @@ class TestWorkGraphBuilderIntegration:
     def test_incremental_build(self):
         """Incremental build with from_date parameter."""
         pass
+
+
+class TestFlagGuardsEdges:
+    """CHAOS-2630 Phase C1: flag -> issue GUARDS edges from real text references."""
+
+    def _run(self, flag_rows, wi_rows, *, org_id="org-1"):
+        fake_sink = MagicMock()
+        fake_sink.backend_type = "clickhouse"
+
+        def mock_query(query, params):
+            if "feature_flag" in query:
+                return flag_rows
+            if "work_items" in query:
+                return wi_rows
+            return []
+
+        fake_sink.query_dicts = MagicMock(side_effect=mock_query)
+        fake_sink.write_work_graph_edges = MagicMock()
+        fake_sink.write_feature_flag_links = MagicMock()
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default", org_id=org_id)
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._build_flag_guards_edges()
+            builder.close()
+        return count, fake_sink
+
+    @pytest.mark.parametrize(
+        "flag_provider,work_item_id",
+        [
+            ("launchdarkly", "jira:ABC-1"),
+            ("launchdarkly", "gh:org/repo#5"),
+            ("gitlab", "gl:grp/proj#9"),
+            ("gitlab", "linear:TEAM-3"),
+        ],
+    )
+    def test_known_flag_in_issue_text_emits_guards_edge(
+        self, flag_provider, work_item_id
+    ):
+        flag_rows = [
+            {
+                "flag_key": "checkout-v2",
+                "provider": flag_provider,
+                "project_key": "web",
+            },
+        ]
+        wi_rows = [
+            {
+                "work_item_id": work_item_id,
+                "title": "Roll out checkout-v2",
+                "description": "Gate the new flow behind the flag",
+            },
+        ]
+        count, sink = self._run(flag_rows, wi_rows)
+
+        assert count == 1
+        edges = sink.write_work_graph_edges.call_args[0][0]
+        assert len(edges) == 1
+        edge = edges[0]
+        assert edge.edge_type == "guards"
+        assert edge.source_type == "feature_flag"
+        assert edge.target_type == "issue"
+        assert edge.target_id == work_item_id
+        assert edge.provenance == "explicit_text"
+        assert edge.confidence == 0.6
+        assert edge.provider == flag_provider
+        assert edge.evidence == "flagref:checkout-v2"
+
+        links = sink.write_feature_flag_links.call_args[0][0]
+        assert len(links) == 1
+        link = links[0]
+        assert link.flag_key == "checkout-v2"
+        assert link.target_type == "issue"
+        assert link.target_id == work_item_id
+        assert link.link_source == "explicit_text"
+        assert link.link_type == "tracks"
+        assert link.evidence_type == "issue_text"
+        assert link.confidence == 0.6
+        assert link.provider == flag_provider
+        assert link.org_id == "org-1"
+
+    def test_unknown_flag_key_emits_nothing(self):
+        flag_rows = [
+            {
+                "flag_key": "checkout-v2",
+                "provider": "launchdarkly",
+                "project_key": "web",
+            },
+        ]
+        wi_rows = [
+            {
+                "work_item_id": "jira:ABC-1",
+                "title": "Toggle mystery-flag",
+                "description": "not a registered flag",
+            },
+        ]
+        count, sink = self._run(flag_rows, wi_rows)
+        assert count == 0
+        sink.write_work_graph_edges.assert_not_called()
+        sink.write_feature_flag_links.assert_not_called()
+
+    def test_empty_registry_skips_emission(self):
+        count, sink = self._run(
+            [],
+            [{"work_item_id": "jira:ABC-1", "title": "x", "description": "y"}],
+        )
+        assert count == 0
+        sink.write_work_graph_edges.assert_not_called()
+        sink.write_feature_flag_links.assert_not_called()
+
+    def test_substring_reference_does_not_emit(self):
+        flag_rows = [
+            {
+                "flag_key": "search",
+                "provider": "launchdarkly",
+                "project_key": "web",
+            },
+        ]
+        wi_rows = [
+            {
+                "work_item_id": "jira:ABC-1",
+                "title": "we are searching the logs",
+                "description": "",
+            },
+        ]
+        count, sink = self._run(flag_rows, wi_rows)
+        assert count == 0
+        sink.write_work_graph_edges.assert_not_called()

--- a/tests/work_graph/test_text_parser.py
+++ b/tests/work_graph/test_text_parser.py
@@ -5,8 +5,10 @@ from typing import cast
 import pytest
 
 from dev_health_ops.work_graph.extractors.text_parser import (
+    ParsedFlagRef,
     ParsedIssueRef,
     RefType,
+    extract_flag_key_refs,
     extract_github_issue_refs,
     extract_gitlab_issue_refs,
     extract_jira_keys,
@@ -345,3 +347,67 @@ class TestParsedIssueRef:
         )
         with pytest.raises(Exception):  # FrozenInstanceError
             setattr(ref, "issue_key", "DEF-456")
+
+
+class TestExtractFlagKeyRefs:
+    """Tests for registry-validated feature-flag key extraction (CHAOS-2630)."""
+
+    def test_matches_known_key_on_word_boundary(self):
+        refs = extract_flag_key_refs(
+            "Rolling out checkout-v2 to 50% of traffic",
+            ["checkout-v2", "search-rollout"],
+        )
+        assert refs == [ParsedFlagRef(flag_key="checkout-v2", raw_match="checkout-v2")]
+
+    def test_unknown_key_never_matches(self):
+        # A flag-like token that is NOT in the registry must not be surfaced.
+        refs = extract_flag_key_refs(
+            "Toggling mystery-flag in prod",
+            ["checkout-v2"],
+        )
+        assert refs == []
+
+    def test_substring_inside_larger_token_is_not_matched(self):
+        # 'search' must not match inside 'searching' or 'search-rollout'.
+        assert extract_flag_key_refs("we are searching logs", ["search"]) == []
+        assert extract_flag_key_refs("enable search-rollout now", ["search"]) == []
+
+    def test_longer_key_matched_not_its_prefix(self):
+        # When both 'checkout' and 'checkout-v2' are known, text containing
+        # 'checkout-v2' yields the full key, never the bare 'checkout' prefix.
+        refs = extract_flag_key_refs(
+            "ship checkout-v2 today",
+            ["checkout", "checkout-v2"],
+        )
+        assert [r.flag_key for r in refs] == ["checkout-v2"]
+
+    def test_min_length_guard_skips_short_keys(self):
+        assert extract_flag_key_refs("set ab here", ["ab"]) == []
+        assert extract_flag_key_refs("set abcd here", ["abcd"]) == [
+            ParsedFlagRef(flag_key="abcd", raw_match="abcd")
+        ]
+
+    def test_numeric_key_is_skipped(self):
+        assert extract_flag_key_refs("value 1234 seen", ["1234"]) == []
+
+    def test_regex_special_chars_in_key_are_literal(self):
+        refs = extract_flag_key_refs(
+            "toggling a.b.c rollout",
+            ["a.b.c"],
+        )
+        assert [r.flag_key for r in refs] == ["a.b.c"]
+        # The '.' must be literal: 'aXbYc' must NOT match 'a.b.c'.
+        assert extract_flag_key_refs("aXbYc rollout", ["a.b.c"]) == []
+
+    def test_deduplicates_repeated_keys(self):
+        refs = extract_flag_key_refs(
+            "flag-one and flag-one again, plus flag-two",
+            ["flag-one", "flag-two"],
+        )
+        assert [r.flag_key for r in refs] == ["flag-one", "flag-two"]
+
+    def test_empty_text_returns_empty(self):
+        assert extract_flag_key_refs("", ["checkout-v2"]) == []
+
+    def test_empty_registry_returns_empty(self):
+        assert extract_flag_key_refs("checkout-v2 here", []) == []


### PR DESCRIPTION
Implements **Phase C1** of the CHAOS-2630 design (signed off on the issue): the first real, non-fixture source of feature-flag associations.

## Problem
Flag→issue/PR/release association edges (`GUARDS`, `IMPACTS`, `INTRODUCED_BY`) and `feature_flag_link` rows were emitted **only in fixtures** (random targets, random confidence). In production `write_feature_flag_links` had no non-fixture caller and no real path emitted flag `GUARDS` edges, so real orgs saw empty release-impact / coverage tiles while demos looked complete.

## Signal (Phase C1)
A flag key that **literally appears** in an issue's title/description is an evidence-backed signal that the issue is guarded by that flag.

- `text_parser.extract_flag_key_refs(text, known_flag_keys, *, min_length=4)` — flag keys are free-form (no `PROJECT-123` shape), so a reference can only be recognised by matching against the org's **real `feature_flag` registry**. Matching is registry-validated (unknown tokens never surface), whole-token (identifier-boundary, so `search` ≠ `searching`/`search-rollout`, and `checkout-v2` is matched as a unit not the bare `checkout`), and guarded (skips keys shorter than 4 and purely-numeric keys).
- `WorkGraphBuilder._build_flag_guards_edges()` — loads the org `feature_flag` registry + `work_items` issue text and emits `GUARDS` (feature_flag → issue) work-graph edges + `feature_flag_link` rows as **`EXPLICIT_TEXT`, confidence 0.6** (strictly below `NATIVE`; below the 0.9 used for structured issue refs), evidence = the matched snippet. Wired as `build()` step 7.

`GUARDS` edges are observable via the generic `workGraphEdges` resolver; `feature_flag_link` is populated as the canonical association store.

## Provider-agnostic
The `GUARDS` target is any issue provider (jira/github/gitlab/linear); the flag source is whichever provider owns the flag (LaunchDarkly/GitLab). These are developer feature-flagging flags (the `feature_flag` analytics table, written by `processors/launchdarkly.py` + `processors/gitlab_feature_flags.py`) — **not** internal plan/entitlement keys (`licensing/`, which never touches `feature_flag`).

## Deferred (per design sign-off — no emission without a real signal)
- `IMPACTS` (release→flag), `DEPLOYS`, `LINKED_INCIDENT` — no real signal source exists; tiles stay empty rather than fabricated.
- LaunchDarkly code-references API (**Phase C2**) — stronger NATIVE signal; needs a new connector + customer enabling `ld-find-code-refs`.

## Fixtures
Left unchanged: the synthetic `native`/`api_link` link profile represents the future C2 code-refs signal, which the design's acceptance criterion explicitly permits. The real emitter added here only ever produces `EXPLICIT_TEXT` ≤ 0.6.

## Tests / verification
- 10 `extract_flag_key_refs` unit tests (registry validation, boundary, min-length, numeric, regex-literal, dedup).
- 7 `_build_flag_guards_edges` tests across the flag-provider × issue-provider matrix, incl. unknown-key / substring / empty-registry guards and the confidence/provenance contract.
- Full `ci/local_validate.sh` gate green (ruff, mypy, full unit suite, ch-migrate, argMax live-exec proof).
- Live-ClickHouse smoke: a registry-known flag referenced in one issue emits exactly one GUARDS edge (`explicit_text`, 0.6, `flagref:checkout-v2`) + one link; a second issue referencing an unknown key emits nothing.