### PR TITLE
feat(launchdarkly): ingest code references into work graph (CHAOS-2633)

### DIFF
--- a/docs/product/feature-flags/feature-flag-user-impact-prd.md
+++ b/docs/product/feature-flags/feature-flag-user-impact-prd.md
@@ -74,7 +74,7 @@ Existing assets this plan builds on:
   - `org_id`, `event_type`, `flag_key`, `environment`, `repo_id`, `actor_type`, `prev_state`, `next_state`, `event_ts`, `ingested_at`, `source_event_id`, `dedupe_key`
 
 - `feature_flag_link` (raw linkage — flag-to-entity relationships)
-  - `org_id`, `flag_key`, `target_type` (`issue`/`pr`/`release`), `target_id`, `provider`, `link_source`, `link_type` (`code_reference`/`configuration`/`issue_tag`/`rollout_issue`), `evidence_type`, `confidence`, `valid_from`, `valid_to`, `last_synced`
+  - `org_id`, `flag_key`, `target_type` (`file`/`issue`/`pr`/`release`), `target_id`, `provider`, `link_source`, `link_type` (`code_reference`/`configuration`/`issue_tag`/`rollout_issue`), `evidence_type`, `confidence`, `valid_from`, `valid_to`, `last_synced`
 
 - `telemetry_signal_bucket` (raw event — aggregated user impact counters)
   - `org_id`, `signal_type`, `signal_count`, `session_count`, `unique_pseudonymous_count` (nullable, k-anonymity gated), `endpoint_group`, `environment`, `repo_id`, `release_ref`, `bucket_start`, `bucket_end`, `ingested_at`, `is_sampled`, `schema_version`, `dedupe_key`
@@ -171,8 +171,10 @@ Telemetry and flag events may arrive late (mobile clients, batch exports, retrie
 ### Edge types (proposed)
 - `introduced_by` (release <- PR): evidence = provider release/deployment API linking PR to release
 - `config_changed_by` (feature_flag <- flag_event): evidence = provider audit log event ID; only created when explicit provider evidence links a flag change to a release or PR (e.g., GitLab `introduced_by_url`). **Not created from time-window heuristics alone.**
-- `guards` (feature_flag -> issue/epic/scope): evidence = provider `rollout_issue_url` or explicit tag/label
+- `guards` (feature_flag -> file/PR/issue/epic/scope): evidence = provider code-reference payload, provider `rollout_issue_url`, or explicit tag/label. LaunchDarkly code references are provider-native and may emit `native` high-confidence file links plus PR links when existing PR→commit→file facts touched the referenced path.
 - `impacts` (release/feature_flag -> telemetry_signal_bucket): evidence = `release_ref` + environment match; note: `telemetry_signal_bucket` is joined at query-time, not stored as a first-class work graph node
+
+Phase C2 implemented LaunchDarkly code-reference ingestion from `GET /api/v2/code-refs/repositories` with default-branch references filtered by project key. This signal only exists when customers run LaunchDarkly code-reference scanning in CI. `IMPACTS`, `DEPLOYS`, and `LINKED_INCIDENT` remain intentionally un-emitted in production until release/deploy/incident signal sources are designed and connected.
 
 > **Design decision:** The originally proposed `rolls_out` edge (release -> feature_flag) is removed. Flag rollouts are config changes that happen independently of code releases. The `config_changed_by` edge captures the narrower, evidence-backed relationship. Reuse existing `REFERENCES` edge type for "PR/commit mentions flag key" relationships detected via code search.
 

--- a/src/dev_health_ops/providers/launchdarkly/__init__.py
+++ b/src/dev_health_ops/providers/launchdarkly/__init__.py
@@ -1,0 +1,17 @@
+from dev_health_ops.providers.launchdarkly.code_refs import (
+    LD_CODE_REFERENCE_CONFIDENCE,
+    LaunchDarklyCodeReference,
+    LaunchDarklyCodeReferencesClient,
+    build_code_reference_links,
+    index_repo_rows,
+    parse_code_reference_repositories,
+)
+
+__all__ = [
+    "LD_CODE_REFERENCE_CONFIDENCE",
+    "LaunchDarklyCodeReference",
+    "LaunchDarklyCodeReferencesClient",
+    "build_code_reference_links",
+    "index_repo_rows",
+    "parse_code_reference_repositories",
+]

--- a/src/dev_health_ops/providers/launchdarkly/code_refs.py
+++ b/src/dev_health_ops/providers/launchdarkly/code_refs.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from dev_health_ops.api.utils.logging import sanitize_for_log
+from dev_health_ops.connectors.exceptions import (
+    APIException,
+    AuthenticationException,
+    RateLimitException,
+)
+from dev_health_ops.metrics.schemas import FeatureFlagLinkRecord
+from dev_health_ops.work_graph.ids import generate_feature_flag_id, generate_file_id
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://app.launchdarkly.com/api/v2"
+LD_CODE_REFERENCE_CONFIDENCE = 0.95
+
+
+@dataclass(frozen=True)
+class LaunchDarklyCodeReference:
+    flag_key: str
+    project_key: str
+    repo_name: str
+    repo_source_link: str | None
+    branch_name: str
+    branch_head: str | None
+    file_path: str
+    starting_line_number: int
+    lines: str
+    aliases: tuple[str, ...] = ()
+
+    @property
+    def evidence(self) -> str:
+        return (
+            f"ld_code_ref:{self.repo_name}:{self.branch_name}:"
+            f"{self.file_path}:L{self.starting_line_number}"
+        )
+
+    @property
+    def file_target_id(self) -> str:
+        return f"{self.repo_name}:{self.file_path}"
+
+    def repo_match_keys(self) -> tuple[str, ...]:
+        keys: list[str] = []
+        if self.repo_source_link:
+            parsed = urlparse(self.repo_source_link)
+            path = parsed.path.strip("/")
+            if path.endswith(".git"):
+                path = path[:-4]
+            _append_key(keys, path)
+            if path:
+                _append_key(keys, path.rsplit("/", 1)[-1])
+        _append_key(keys, self.repo_name)
+        return tuple(keys)
+
+
+def _append_key(keys: list[str], value: str | None) -> None:
+    key = (value or "").strip().strip("/").lower()
+    if key and key not in keys:
+        keys.append(key)
+
+
+def _normalize_path(path: str, branch_name: str) -> str:
+    normalized = path.strip().lstrip("/")
+    branch_prefix = f"{branch_name.strip().strip('/')}/" if branch_name else ""
+    if branch_prefix and normalized.startswith(branch_prefix):
+        normalized = normalized[len(branch_prefix) :]
+    return normalized
+
+
+def _raise_for_status(response: httpx.Response) -> None:
+    status = response.status_code
+    if status == 401:
+        raise AuthenticationException("LaunchDarkly authentication failed")
+    if status == 429:
+        retry_after = response.headers.get("Retry-After")
+        raise RateLimitException(
+            "LaunchDarkly rate limit exceeded",
+            retry_after_seconds=float(retry_after) if retry_after else None,
+        )
+    if status == 403:
+        raise APIException(f"LaunchDarkly code references forbidden: {response.text}")
+    if status == 404:
+        raise APIException(f"LaunchDarkly code references not found: {response.url}")
+    if status >= 500:
+        raise APIException(
+            f"LaunchDarkly code references server error: {status} - {response.text}"
+        )
+    if status >= 400:
+        raise APIException(
+            f"LaunchDarkly code references API error: {status} - {response.text}"
+        )
+
+
+class LaunchDarklyCodeReferencesClient:
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str = _BASE_URL,
+        timeout: int = 30,
+        max_retries: int = 5,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self._client: httpx.AsyncClient | None = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                base_url=self.base_url,
+                headers={"Authorization": self.api_key},
+                timeout=self.timeout,
+            )
+        return self._client
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        client = await self._get_client()
+        delay = 1.0
+        last_exc: Exception | None = None
+        for attempt in range(self.max_retries):
+            try:
+                response = await client.request(method, path, params=params)
+                if response.status_code == 429 or response.status_code >= 500:
+                    if attempt < self.max_retries - 1:
+                        retry_after = response.headers.get("Retry-After")
+                        wait_seconds = float(retry_after) if retry_after else delay
+                        logger.warning(
+                            "LaunchDarkly %d on %s (attempt %d/%d), retrying in %.1fs",
+                            response.status_code,
+                            sanitize_for_log(path),
+                            attempt + 1,
+                            self.max_retries,
+                            wait_seconds,
+                        )
+                        await asyncio.sleep(wait_seconds)
+                        delay = min(delay * 2, 60.0)
+                        continue
+                _raise_for_status(response)
+                return response.json()
+            except (httpx.TimeoutException, httpx.ConnectError) as exc:
+                last_exc = exc
+                if attempt < self.max_retries - 1:
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, 60.0)
+                    continue
+                raise APIException(
+                    f"LaunchDarkly code references request failed: {exc}"
+                ) from exc
+        raise APIException("LaunchDarkly code references request failed") from last_exc
+
+    async def list_default_branch_references(
+        self,
+        *,
+        project_key: str,
+        flag_key: str | None = None,
+    ) -> list[LaunchDarklyCodeReference]:
+        params: dict[str, Any] = {
+            "withReferencesForDefaultBranch": "1",
+            "projKey": project_key,
+        }
+        if flag_key:
+            params["flagKey"] = flag_key
+        data = await self._request("GET", "/code-refs/repositories", params=params)
+        refs = parse_code_reference_repositories(data)
+        logger.info(
+            "Fetched %d LaunchDarkly code references for project %s",
+            len(refs),
+            sanitize_for_log(project_key),
+        )
+        return refs
+
+    async def close(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    async def __aenter__(self) -> LaunchDarklyCodeReferencesClient:
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
+
+
+def parse_code_reference_repositories(
+    data: dict[str, Any],
+) -> list[LaunchDarklyCodeReference]:
+    refs: list[LaunchDarklyCodeReference] = []
+    for repo in data.get("items") or []:
+        if not isinstance(repo, dict):
+            continue
+        repo_name = str(repo.get("name") or "").strip()
+        if not repo_name:
+            continue
+        source_link = repo.get("sourceLink")
+        for branch in repo.get("branches") or []:
+            if not isinstance(branch, dict):
+                continue
+            branch_name = str(branch.get("name") or repo.get("defaultBranch") or "")
+            branch_head = branch.get("head")
+            for reference in branch.get("references") or []:
+                if not isinstance(reference, dict):
+                    continue
+                path = str(reference.get("path") or "")
+                normalized_path = _normalize_path(path, branch_name)
+                if not normalized_path:
+                    continue
+                for hunk in reference.get("hunks") or []:
+                    if not isinstance(hunk, dict):
+                        continue
+                    flag_key = str(hunk.get("flagKey") or "").strip()
+                    project_key = str(hunk.get("projKey") or "").strip()
+                    if not flag_key or not project_key:
+                        continue
+                    refs.append(
+                        LaunchDarklyCodeReference(
+                            flag_key=flag_key,
+                            project_key=project_key,
+                            repo_name=repo_name,
+                            repo_source_link=str(source_link) if source_link else None,
+                            branch_name=branch_name,
+                            branch_head=str(branch_head) if branch_head else None,
+                            file_path=normalized_path,
+                            starting_line_number=int(
+                                hunk.get("startingLineNumber") or 0
+                            ),
+                            lines=str(hunk.get("lines") or ""),
+                            aliases=tuple(str(a) for a in hunk.get("aliases") or ()),
+                        )
+                    )
+    return refs
+
+
+def index_repo_rows(repo_rows: list[dict[str, Any]]) -> dict[str, uuid.UUID]:
+    indexed: dict[str, uuid.UUID] = {}
+    for row in repo_rows:
+        repo_id = row.get("id")
+        repo_name = str(row.get("repo") or "").strip().strip("/")
+        if not repo_id or not repo_name:
+            continue
+        repo_uuid = uuid.UUID(str(repo_id))
+        keys = [repo_name, repo_name.rsplit("/", 1)[-1]]
+        for key in keys:
+            _append_repo_index(indexed, key, repo_uuid)
+    return indexed
+
+
+def _append_repo_index(
+    indexed: dict[str, uuid.UUID], key: str, repo_id: uuid.UUID
+) -> None:
+    normalized = key.strip().strip("/").lower()
+    if normalized and normalized not in indexed:
+        indexed[normalized] = repo_id
+
+
+def resolve_repo_id(
+    ref: LaunchDarklyCodeReference,
+    repo_index: dict[str, uuid.UUID],
+) -> uuid.UUID | None:
+    for key in ref.repo_match_keys():
+        repo_id = repo_index.get(key)
+        if repo_id is not None:
+            return repo_id
+    return None
+
+
+def build_code_reference_links(
+    refs: list[LaunchDarklyCodeReference],
+    *,
+    org_id: str,
+    repo_index: dict[str, uuid.UUID],
+    pr_ids_by_repo_path: dict[tuple[str, str], set[str]],
+    now: datetime | None = None,
+) -> tuple[list[FeatureFlagLinkRecord], list[dict[str, Any]]]:
+    synced_at = now or datetime.now(tz=timezone.utc)
+    links: list[FeatureFlagLinkRecord] = []
+    edges: list[dict[str, Any]] = []
+    seen_links: set[tuple[str, str, str]] = set()
+    seen_edges: set[tuple[str, str, str]] = set()
+
+    for ref in refs:
+        flag_id = generate_feature_flag_id(
+            org_id, "launchdarkly", ref.project_key, ref.flag_key
+        )
+        repo_id = resolve_repo_id(ref, repo_index)
+        if repo_id is not None:
+            file_targets: list[tuple[str, uuid.UUID | None]] = [
+                (generate_file_id(repo_id, ref.file_path), repo_id)
+            ]
+        else:
+            file_targets = [(ref.file_target_id, None)]
+
+        for target_id, target_repo_id in file_targets:
+            link_key = (ref.flag_key, "file", target_id)
+            if link_key not in seen_links:
+                seen_links.add(link_key)
+                links.append(_make_link(ref, "file", target_id, synced_at, org_id))
+            if target_repo_id is not None:
+                edge_key = (flag_id, "file", target_id)
+                if edge_key not in seen_edges:
+                    seen_edges.add(edge_key)
+                    edges.append(
+                        {
+                            "flag_id": flag_id,
+                            "target_type": "file",
+                            "target_id": target_id,
+                            "repo_id": target_repo_id,
+                            "evidence": ref.evidence,
+                        }
+                    )
+
+        if repo_id is None:
+            continue
+        for pr_id in sorted(
+            pr_ids_by_repo_path.get((str(repo_id), ref.file_path), set())
+        ):
+            link_key = (ref.flag_key, "pr", pr_id)
+            if link_key not in seen_links:
+                seen_links.add(link_key)
+                links.append(_make_link(ref, "pr", pr_id, synced_at, org_id))
+            edge_key = (flag_id, "pr", pr_id)
+            if edge_key not in seen_edges:
+                seen_edges.add(edge_key)
+                edges.append(
+                    {
+                        "flag_id": flag_id,
+                        "target_type": "pr",
+                        "target_id": pr_id,
+                        "repo_id": repo_id,
+                        "evidence": ref.evidence,
+                    }
+                )
+
+    return links, edges
+
+
+def _make_link(
+    ref: LaunchDarklyCodeReference,
+    target_type: str,
+    target_id: str,
+    synced_at: datetime,
+    org_id: str,
+) -> FeatureFlagLinkRecord:
+    return FeatureFlagLinkRecord(
+        flag_key=ref.flag_key,
+        target_type=target_type,
+        target_id=target_id,
+        provider="launchdarkly",
+        link_source="native",
+        link_type="code_reference",
+        evidence_type="ld_code_ref",
+        confidence=LD_CODE_REFERENCE_CONFIDENCE,
+        valid_from=synced_at,
+        valid_to=None,
+        last_synced=synced_at,
+        org_id=org_id,
+    )

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -72,6 +72,52 @@ def _as_aware(value: datetime) -> datetime:
     return value.astimezone(timezone.utc)
 
 
+def _ch_string(value: str) -> str:
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def _load_pr_ids_by_repo_path(
+    sink: Any,
+    *,
+    org_id: str,
+    repo_paths: set[tuple[str, str]],
+) -> dict[tuple[str, str], set[str]]:
+    if not repo_paths:
+        return {}
+
+    from dev_health_ops.work_graph.ids import generate_pr_id
+
+    repo_ids = sorted({repo_id for repo_id, _path in repo_paths})
+    paths = sorted({path for _repo_id, path in repo_paths})
+    query = f"""
+        SELECT DISTINCT
+            p.repo_id AS repo_id,
+            p.pr_number AS pr_number,
+            s.file_path AS file_path
+        FROM work_graph_pr_commit AS p
+        INNER JOIN git_commit_stats AS s ON (
+            toString(p.repo_id) = toString(s.repo_id)
+            AND p.commit_hash = s.commit_hash
+            AND toString(p.org_id) = toString(s.org_id)
+        )
+        WHERE p.org_id = {_ch_string(org_id)}
+          AND toString(p.repo_id) IN ({", ".join(_ch_string(v) for v in repo_ids)})
+          AND s.file_path IN ({", ".join(_ch_string(v) for v in paths)})
+    """
+    rows = sink.query_dicts(query, {})
+    matches: dict[tuple[str, str], set[str]] = {}
+    for row in rows:
+        repo_id = str(row.get("repo_id") or "")
+        file_path = str(row.get("file_path") or "")
+        pr_number = row.get("pr_number")
+        if not repo_id or not file_path or pr_number is None:
+            continue
+        matches.setdefault((repo_id, file_path), set()).add(
+            generate_pr_id(uuid.UUID(repo_id), int(pr_number))
+        )
+    return matches
+
+
 def _sync_launchdarkly_feature_flags(
     *,
     db_url: str,
@@ -80,11 +126,19 @@ def _sync_launchdarkly_feature_flags(
     sync_options: dict[str, Any],
     since_dt: datetime | None,
 ) -> dict[str, Any]:
+    from dev_health_ops.connectors.exceptions import ConnectorException
     from dev_health_ops.connectors.launchdarkly import LaunchDarklyConnector
     from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
     from dev_health_ops.processors.launchdarkly import (
         normalize_audit_events,
         normalize_flags,
+    )
+    from dev_health_ops.providers.launchdarkly.code_refs import (
+        LD_CODE_REFERENCE_CONFIDENCE,
+        LaunchDarklyCodeReferencesClient,
+        build_code_reference_links,
+        index_repo_rows,
+        resolve_repo_id,
     )
     from dev_health_ops.work_graph.builder import BuildConfig, WorkGraphBuilder
     from dev_health_ops.work_graph.ids import generate_feature_flag_id
@@ -115,6 +169,20 @@ def _sync_launchdarkly_feature_flags(
             # connector paginates via _links.next to assemble full history
             # since the last watermark.
             raw_events = await connector.get_audit_log(since=since_dt, limit=1000)
+        try:
+            async with LaunchDarklyCodeReferencesClient(api_key=api_key) as code_refs:
+                raw_code_refs = await code_refs.list_default_branch_references(
+                    project_key=project_key
+                )
+            code_references_error = None
+        except ConnectorException as exc:
+            logger.warning(
+                "Skipping LaunchDarkly code references for project %s: %s",
+                project_key,
+                exc,
+            )
+            raw_code_refs = []
+            code_references_error = str(exc)
 
         flags = normalize_flags(raw_flags, org_id)
         if environment:
@@ -159,6 +227,44 @@ def _sync_launchdarkly_feature_flags(
         try:
             sink.write_feature_flags(flags)
             sink.write_feature_flag_events(events)
+
+            repo_rows = sink.query_dicts(
+                "SELECT id, repo FROM repos WHERE org_id = " + _ch_string(org_id),
+                {},
+            )
+            repo_index = index_repo_rows(repo_rows)
+            repo_paths = {
+                (str(repo_id), ref.file_path)
+                for ref in raw_code_refs
+                if (repo_id := resolve_repo_id(ref, repo_index)) is not None
+            }
+            pr_ids_by_repo_path = _load_pr_ids_by_repo_path(
+                sink,
+                org_id=org_id,
+                repo_paths=repo_paths,
+            )
+            code_ref_links, code_ref_edges = build_code_reference_links(
+                raw_code_refs,
+                org_id=org_id,
+                repo_index=repo_index,
+                pr_ids_by_repo_path=pr_ids_by_repo_path,
+            )
+            sink.write_feature_flag_links(code_ref_links)
+            for edge in code_ref_edges:
+                target_type = (
+                    NodeType.FILE if edge["target_type"] == "file" else NodeType.PR
+                )
+                builder.add_feature_flag_edge(
+                    flag_id=str(edge["flag_id"]),
+                    target_type=target_type,
+                    target_id=str(edge["target_id"]),
+                    edge_type=EdgeType.GUARDS,
+                    confidence=LD_CODE_REFERENCE_CONFIDENCE,
+                    evidence=str(edge["evidence"]),
+                    provenance=Provenance.NATIVE,
+                    repo_id=edge["repo_id"],
+                    provider="launchdarkly",
+                )
 
             latest_events: dict[str, Any] = {}
             for event in events:
@@ -205,6 +311,10 @@ def _sync_launchdarkly_feature_flags(
         return {
             "flags_synced": len(flags),
             "events_synced": len(events),
+            "code_references_synced": len(raw_code_refs),
+            "code_reference_links_synced": len(code_ref_links),
+            "code_reference_edges_synced": len(code_ref_edges),
+            "code_references_error": code_references_error,
             "project_key": project_key,
             "environment": environment or None,
         }

--- a/tests/test_launchdarkly.py
+++ b/tests/test_launchdarkly.py
@@ -1,5 +1,6 @@
 """Tests for LaunchDarkly connector and processor normalization."""
 
+import uuid
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
@@ -22,6 +23,19 @@ from dev_health_ops.processors.launchdarkly import (
     _parse_iso,
     normalize_audit_events,
     normalize_flags,
+)
+from dev_health_ops.providers.launchdarkly.code_refs import (
+    LD_CODE_REFERENCE_CONFIDENCE,
+    LaunchDarklyCodeReference,
+    LaunchDarklyCodeReferencesClient,
+    build_code_reference_links,
+    index_repo_rows,
+    parse_code_reference_repositories,
+)
+from dev_health_ops.work_graph.ids import (
+    generate_feature_flag_id,
+    generate_file_id,
+    generate_pr_id,
 )
 
 # ---------------------------------------------------------------------------
@@ -233,6 +247,171 @@ class TestLaunchDarklyConnector:
     async def test_context_manager(self):
         async with LaunchDarklyConnector(api_key="key", project_key="p") as conn:
             assert conn.api_key == "key"
+
+
+class TestLaunchDarklyCodeReferences:
+    @pytest.mark.asyncio
+    async def test_list_default_branch_references_uses_project_filter(self):
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {}
+        response.json.return_value = {"items": []}
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=response)
+
+        client = LaunchDarklyCodeReferencesClient(api_key="key")
+        client._client = mock_client
+
+        refs = await client.list_default_branch_references(project_key="web")
+
+        assert refs == []
+        mock_client.request.assert_called_once_with(
+            "GET",
+            "/code-refs/repositories",
+            params={"withReferencesForDefaultBranch": "1", "projKey": "web"},
+        )
+
+    def test_parse_code_reference_repositories_flattens_hunks(self):
+        refs = parse_code_reference_repositories(
+            {
+                "items": [
+                    {
+                        "name": "dev-health",
+                        "sourceLink": "https://github.com/full-chaos/dev-health",
+                        "defaultBranch": "main",
+                        "branches": [
+                            {
+                                "name": "main",
+                                "head": "abc123",
+                                "references": [
+                                    {
+                                        "path": "/main/web/src/checkout.ts",
+                                        "hunks": [
+                                            {
+                                                "startingLineNumber": 42,
+                                                "lines": "variation('checkout-v2')",
+                                                "projKey": "web",
+                                                "flagKey": "checkout-v2",
+                                                "aliases": ["checkoutV2"],
+                                            }
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+        assert refs == [
+            LaunchDarklyCodeReference(
+                flag_key="checkout-v2",
+                project_key="web",
+                repo_name="dev-health",
+                repo_source_link="https://github.com/full-chaos/dev-health",
+                branch_name="main",
+                branch_head="abc123",
+                file_path="web/src/checkout.ts",
+                starting_line_number=42,
+                lines="variation('checkout-v2')",
+                aliases=("checkoutV2",),
+            )
+        ]
+
+    def test_build_code_reference_links_emits_native_file_and_pr_artifacts(self):
+        repo_id = "11111111-1111-1111-1111-111111111111"
+        ref = LaunchDarklyCodeReference(
+            flag_key="checkout-v2",
+            project_key="web",
+            repo_name="dev-health",
+            repo_source_link="https://github.com/full-chaos/dev-health",
+            branch_name="main",
+            branch_head="abc123",
+            file_path="web/src/checkout.ts",
+            starting_line_number=42,
+            lines="variation('checkout-v2')",
+        )
+        repo_index = index_repo_rows([{"id": repo_id, "repo": "full-chaos/dev-health"}])
+        pr_id = generate_pr_id(uuid.UUID(repo_id), 17)
+
+        links, edges = build_code_reference_links(
+            [ref],
+            org_id="org-1",
+            repo_index=repo_index,
+            pr_ids_by_repo_path={(repo_id, "web/src/checkout.ts"): {pr_id}},
+            now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
+        assert {(link.target_type, link.target_id) for link in links} == {
+            ("file", generate_file_id(uuid.UUID(repo_id), "web/src/checkout.ts")),
+            ("pr", pr_id),
+        }
+        assert all(link.org_id == "org-1" for link in links)
+        assert all(link.link_source == "native" for link in links)
+        assert all(link.link_type == "code_reference" for link in links)
+        assert all(link.confidence == LD_CODE_REFERENCE_CONFIDENCE for link in links)
+
+        flag_id = generate_feature_flag_id(
+            "org-1", "launchdarkly", "web", "checkout-v2"
+        )
+        assert edges == [
+            {
+                "flag_id": flag_id,
+                "target_type": "file",
+                "target_id": generate_file_id(
+                    uuid.UUID(repo_id), "web/src/checkout.ts"
+                ),
+                "repo_id": uuid.UUID(repo_id),
+                "evidence": "ld_code_ref:dev-health:main:web/src/checkout.ts:L42",
+            },
+            {
+                "flag_id": flag_id,
+                "target_type": "pr",
+                "target_id": pr_id,
+                "repo_id": uuid.UUID(repo_id),
+                "evidence": "ld_code_ref:dev-health:main:web/src/checkout.ts:L42",
+            },
+        ]
+
+    def test_source_link_wins_over_bare_repo_name_collision(self):
+        wrong_repo_id = "11111111-1111-1111-1111-111111111111"
+        correct_repo_id = "22222222-2222-2222-2222-222222222222"
+        ref = LaunchDarklyCodeReference(
+            flag_key="checkout-v2",
+            project_key="web",
+            repo_name="dev-health",
+            repo_source_link="https://github.com/full-chaos/dev-health",
+            branch_name="main",
+            branch_head="abc123",
+            file_path="web/src/checkout.ts",
+            starting_line_number=42,
+            lines="variation('checkout-v2')",
+        )
+        repo_index = index_repo_rows(
+            [
+                {"id": wrong_repo_id, "repo": "other/dev-health"},
+                {"id": correct_repo_id, "repo": "full-chaos/dev-health"},
+            ]
+        )
+
+        links, edges = build_code_reference_links(
+            [ref],
+            org_id="org-1",
+            repo_index=repo_index,
+            pr_ids_by_repo_path={},
+            now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
+        assert [(link.target_type, link.target_id) for link in links] == [
+            (
+                "file",
+                generate_file_id(uuid.UUID(correct_repo_id), "web/src/checkout.ts"),
+            )
+        ]
+        assert edges[0]["repo_id"] == uuid.UUID(correct_repo_id)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add provider-owned LaunchDarkly code-reference client/parser for default-branch references
- persist native high-confidence feature_flag_link rows for file and PR targets
- emit GUARDS work-graph edges for code-reference file links and touched-path PR links
- document Phase C2 behavior and intentionally deferred IMPACTS/DEPLOYS/LINKED_INCIDENT edges

## Validation
- python -m pytest tests/test_launchdarkly.py -q: 41 passed
- manual PYTHONPATH=src driver: sample LaunchDarkly payload produced native file + PR links/edges
- python -m ruff check ...: passed
- python -m ruff format --check ...: passed
- bash ci/local_validate.sh: 5743 passed, 47 skipped
- pre-push hook: ruff format check, ruff check, mypy passed
- Oracle final review: PASS, 0 critical/0 warning

SCREENSHOT-WAIVER: backend-only/no-render changes

Linear: CHAOS-2633