### PR TITLE
fix(sync): preserve planner repo-selection tag on catalog rediscovery (CHAOS-2635)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -666,6 +666,26 @@ def _planner_source_rows(
     return rows
 
 
+async def _assert_single_planner_parent_for_integration(
+    session: AsyncSession,
+    org_id: str,
+    integration_id: uuid.UUID,
+) -> None:
+    count_stmt = select(func.count(SyncConfiguration.id)).where(
+        SyncConfiguration.org_id == org_id,
+        SyncConfiguration.planner_managed.is_(True),
+        SyncConfiguration.migrated_integration_id == integration_id,
+        SyncConfiguration.parent_id.is_(None),
+    )
+    planner_parent_count = (await session.execute(count_stmt)).scalar_one()
+    if planner_parent_count > 1:
+        raise RuntimeError(
+            "Planner-managed integration invariant violated: "
+            f"integration {integration_id} is linked to {planner_parent_count} "
+            "planner-managed parent sync configurations"
+        )
+
+
 @router.get("/sync-targets")
 async def get_provider_sync_targets() -> dict[str, list[str]]:
     return PROVIDER_SYNC_TARGETS
@@ -1024,6 +1044,7 @@ async def batch_create_sync_configs(
     )
     session.add(parent)
     await session.flush()
+    await _assert_single_planner_parent_for_integration(session, org_id, integration.id)
 
     source_rows = _planner_source_rows(
         payload,

--- a/src/dev_health_ops/audit/planner_configs.py
+++ b/src/dev_health_ops/audit/planner_configs.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from dev_health_ops.db import get_postgres_session_sync_for_uri, resolve_db_uri
+from dev_health_ops.sync.planner_config_audit import (
+    audit_active_planner_managed_configs,
+)
+
+
+def register_commands(audit_subparsers: argparse._SubParsersAction) -> None:
+    audit_parser = audit_subparsers.add_parser(
+        "planner-configs",
+        help="Audit active planner-managed sync configs for source tag drift.",
+    )
+    audit_parser.add_argument(
+        "--format", choices=["json"], default="json", help="Output format."
+    )
+    audit_parser.set_defaults(func=_cmd_audit_planner_configs)
+
+
+def _cmd_audit_planner_configs(ns: argparse.Namespace) -> int:
+    with get_postgres_session_sync_for_uri(resolve_db_uri(ns)) as session:
+        findings = audit_active_planner_managed_configs(
+            session,
+            org_id=getattr(ns, "org", None),
+        )
+    print(json.dumps([finding.to_dict() for finding in findings], indent=2))
+    return 1 if findings else 0

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -360,6 +360,13 @@ def _suppress_parser_construction_noise():
 def _should_resolve_org(ns: argparse.Namespace) -> bool:
     if getattr(ns, "org", None) is not None:
         return False
+    # The planner-config audit defaults to ALL orgs; never auto-resolve it to a
+    # single (first) org, or the cross-org audit silently scans only one org.
+    if (
+        getattr(ns, "command", None) == "audit"
+        and getattr(ns, "audit_command", None) == "planner-configs"
+    ):
+        return False
     return not (
         getattr(ns, "command", None) == "migrate"
         and getattr(ns, "migrate_command", None) == "clickhouse"
@@ -421,6 +428,7 @@ _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     # --- audit (read ClickHouse analytics store) ---
     ("audit", "perf"): frozenset({_REQ_CLICKHOUSE}),
     ("audit", "schema"): frozenset({_REQ_CLICKHOUSE}),
+    ("audit", "planner-configs"): frozenset({_REQ_POSTGRES}),
     # --- other ClickHouse-backed commands ---
     ("recommendations", "compute"): frozenset({_REQ_CLICKHOUSE}),
     ("investment", "materialize"): frozenset({_REQ_CLICKHOUSE}),
@@ -589,7 +597,13 @@ def build_parser() -> argparse.ArgumentParser:
     from dev_health_ops import migrate as migrate_mod
     from dev_health_ops.api import runner as api_runner
     from dev_health_ops.api.admin import cli as admin_cli
-    from dev_health_ops.audit import completeness, coverage, perf, schema
+    from dev_health_ops.audit import (
+        completeness,
+        coverage,
+        perf,
+        planner_configs,
+        schema,
+    )
     from dev_health_ops.audit.ai_governance import cli as ai_governance_cli
     from dev_health_ops.fixtures import runner as fixtures_runner
     from dev_health_ops.metrics import (
@@ -670,6 +684,7 @@ def build_parser() -> argparse.ArgumentParser:
     schema.register_commands(audit_subparsers)
     perf.register_commands(audit_subparsers)
     coverage.register_commands(audit_subparsers)
+    planner_configs.register_commands(audit_subparsers)
 
     # ---- fixtures ----
     fixtures_runner.register_commands(sub)

--- a/src/dev_health_ops/sync/discovery.py
+++ b/src/dev_health_ops/sync/discovery.py
@@ -182,7 +182,10 @@ def discover_sources_for_integration(
     constraint ``(org_id, integration_id, provider, external_id)``.
 
     On re-discovery:
-    - ``last_seen_at``, ``name``, ``full_name``, and ``metadata_`` are updated.
+    - ``last_seen_at``, ``name``, and ``full_name`` are updated.
+    - ``metadata_`` is merged: fresh discovery values win, while keys the
+      discovery payload lacks (including ``planner_managed_sync_config_id``)
+      are preserved.
     - ``is_enabled`` is **not** changed for existing rows (preserves operator
       intent).  Only brand-new sources get ``is_enabled = auto_enable``.
     - ``discovered_at`` is **not** changed for existing rows.
@@ -240,7 +243,7 @@ def discover_sources_for_integration(
             existing.last_seen_at = now
             existing.name = fields["name"]
             existing.full_name = fields["full_name"]
-            existing.metadata_ = fields["metadata_"]
+            existing.metadata_ = {**(existing.metadata_ or {}), **fields["metadata_"]}
             upserted.append(existing)
         else:
             source = IntegrationSource(

--- a/src/dev_health_ops/sync/planner_config_audit.py
+++ b/src/dev_health_ops/sync/planner_config_audit.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.integrations import IntegrationSource
+from dev_health_ops.models.settings import SyncConfiguration
+
+PlannerConfigAuditReason = Literal[
+    "missing_migrated_integration_id", "zero_tagged_enabled_sources"
+]
+
+_PLANNER_TAG_KEY = "planner_managed_sync_config_id"
+
+
+@dataclass(frozen=True)
+class PlannerManagedConfigAuditFinding:
+    config_id: str
+    org_id: str
+    provider: str
+    name: str
+    reason: PlannerConfigAuditReason
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "config_id": self.config_id,
+            "org_id": self.org_id,
+            "provider": self.provider,
+            "name": self.name,
+            "reason": self.reason,
+        }
+
+
+def audit_active_planner_managed_configs(
+    session: Session,
+    *,
+    org_id: str | None = None,
+) -> list[PlannerManagedConfigAuditFinding]:
+    query = session.query(SyncConfiguration).filter(
+        SyncConfiguration.planner_managed.is_(True),
+        SyncConfiguration.is_active.is_(True),
+        SyncConfiguration.parent_id.is_(None),
+    )
+    if org_id:
+        query = query.filter(SyncConfiguration.org_id == org_id)
+
+    findings: list[PlannerManagedConfigAuditFinding] = []
+    for config in query.order_by(
+        SyncConfiguration.created_at, SyncConfiguration.id
+    ).all():
+        config_id = str(config.id)
+        base = {
+            "config_id": config_id,
+            "org_id": str(config.org_id),
+            "provider": str(config.provider),
+            "name": str(config.name),
+        }
+        if config.migrated_integration_id is None:
+            findings.append(
+                PlannerManagedConfigAuditFinding(
+                    **base,
+                    reason="missing_migrated_integration_id",
+                )
+            )
+            continue
+
+        enabled_sources = (
+            session.query(IntegrationSource)
+            .filter(
+                IntegrationSource.org_id == config.org_id,
+                IntegrationSource.integration_id == config.migrated_integration_id,
+                IntegrationSource.is_enabled.is_(True),
+            )
+            .all()
+        )
+        tagged_count = sum(
+            1
+            for source in enabled_sources
+            if str((source.metadata_ or {}).get(_PLANNER_TAG_KEY)) == config_id
+        )
+        if tagged_count == 0:
+            findings.append(
+                PlannerManagedConfigAuditFinding(
+                    **base,
+                    reason="zero_tagged_enabled_sources",
+                )
+            )
+
+    return findings

--- a/tests/api/admin/test_sync_config_deprecation.py
+++ b/tests/api/admin/test_sync_config_deprecation.py
@@ -44,6 +44,7 @@ from tests._helpers import tables_of
 
 admin_router_module = importlib.import_module("dev_health_ops.api.admin")
 auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+sync_router_module = importlib.import_module("dev_health_ops.api.admin.routers.sync")
 
 _TABLES = tables_of(
     User,
@@ -389,6 +390,48 @@ async def test_batch_creates_planner_parent_when_planner_flag_inactive(
         "files",
         "repo-metadata",
     }
+
+
+@pytest.mark.asyncio
+async def test_planner_parent_integration_invariant_rejects_second_parent(
+    session_maker, seeded_state
+):
+    org_id = seeded_state["org_id"]
+    async with session_maker() as session:
+        integration = Integration(
+            org_id=org_id,
+            provider="github",
+            name="shared-integration",
+            config={"owner": "myorg"},
+            is_active=True,
+        )
+        session.add(integration)
+        await session.flush()
+        session.add_all(
+            [
+                SyncConfiguration(
+                    name="planner-parent-a",
+                    provider="github",
+                    org_id=org_id,
+                    sync_targets=["git"],
+                    migrated_integration_id=integration.id,
+                    planner_managed=True,
+                ),
+                SyncConfiguration(
+                    name="planner-parent-b",
+                    provider="github",
+                    org_id=org_id,
+                    sync_targets=["git"],
+                    migrated_integration_id=integration.id,
+                    planner_managed=True,
+                ),
+            ]
+        )
+        await session.flush()
+        with pytest.raises(RuntimeError, match="invariant violated"):
+            await sync_router_module._assert_single_planner_parent_for_integration(
+                session, org_id, integration.id
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -126,6 +126,12 @@ class TestMigrateRouting:
         assert getattr(ns, "org", None) is None
         assert _should_resolve_org(ns)
 
+    def test_audit_planner_configs_without_org_does_not_auto_resolve(self):
+        ns = self.parser.parse_args(["audit", "planner-configs"])
+
+        assert getattr(ns, "org", None) is None
+        assert not _should_resolve_org(ns)
+
     def test_upgrade_flat_defaults_to_head(self):
         ns = self.parser.parse_args(["migrate", "upgrade"])
         assert ns.revision == "head"

--- a/tests/test_planner_config_audit.py
+++ b/tests/test_planner_config_audit.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.integrations import Integration, IntegrationSource
+from dev_health_ops.models.settings import SyncConfiguration
+from dev_health_ops.sync.planner_config_audit import (
+    audit_active_planner_managed_configs,
+)
+from tests._helpers import tables_of
+
+_TABLES = tables_of(SyncConfiguration, Integration, IntegrationSource)
+
+
+@pytest.fixture()
+def session(tmp_path: Path) -> Iterator[Session]:
+    engine = create_engine(f"sqlite:///{tmp_path / 'planner-config-audit.db'}")
+    Base.metadata.create_all(engine, tables=_TABLES)
+    maker = sessionmaker(engine, expire_on_commit=False)
+    try:
+        with maker() as db_session:
+            yield db_session
+    finally:
+        engine.dispose()
+
+
+def _integration(session: Session, org_id: str, name: str) -> Integration:
+    integration = Integration(
+        org_id=org_id,
+        provider="github",
+        name=name,
+        config={"owner": "acme"},
+        is_active=True,
+    )
+    session.add(integration)
+    session.flush()
+    return integration
+
+
+def _planner_config(
+    session: Session,
+    org_id: str,
+    name: str,
+    integration_id: uuid.UUID | None,
+) -> SyncConfiguration:
+    config = SyncConfiguration(
+        name=name,
+        provider="github",
+        org_id=org_id,
+        sync_targets=["git"],
+        migrated_integration_id=integration_id,
+        planner_managed=True,
+        is_active=True,
+    )
+    session.add(config)
+    session.flush()
+    return config
+
+
+def _tagged_source(
+    session: Session,
+    org_id: str,
+    integration_id: uuid.UUID,
+    config_id: uuid.UUID,
+    name: str,
+) -> IntegrationSource:
+    source = IntegrationSource(
+        org_id=org_id,
+        integration_id=integration_id,
+        provider="github",
+        source_type="repository",
+        external_id=f"acme/{name}",
+        name=name,
+        full_name=f"acme/{name}",
+        metadata_={"planner_managed_sync_config_id": str(config_id), "owner": "acme"},
+        is_enabled=True,
+    )
+    session.add(source)
+    session.flush()
+    return source
+
+
+def test_audit_active_planner_configs_lists_offenders(session: Session):
+    org_id = "org-test"
+    no_tag_integration = _integration(session, org_id, "no-tag-integration")
+    zero_tagged = _planner_config(session, org_id, "zero-tagged", no_tag_integration.id)
+    missing_integration = _planner_config(session, org_id, "missing-integration", None)
+    session.add(
+        IntegrationSource(
+            org_id=org_id,
+            integration_id=no_tag_integration.id,
+            provider="github",
+            source_type="repository",
+            external_id="acme/untagged",
+            name="untagged",
+            full_name="acme/untagged",
+            metadata_={"owner": "acme"},
+            is_enabled=True,
+        )
+    )
+    session.commit()
+
+    findings = audit_active_planner_managed_configs(session, org_id=org_id)
+
+    assert {(finding.config_id, finding.reason) for finding in findings} == {
+        (str(zero_tagged.id), "zero_tagged_enabled_sources"),
+        (str(missing_integration.id), "missing_migrated_integration_id"),
+    }
+
+
+def test_audit_active_planner_configs_is_clean_for_good_fixture(session: Session):
+    org_id = "org-test"
+    integration = _integration(session, org_id, "good-integration")
+    config = _planner_config(session, org_id, "good-config", integration.id)
+    _tagged_source(session, org_id, integration.id, config.id, "api")
+    session.commit()
+
+    assert audit_active_planner_managed_configs(session, org_id=org_id) == []
+
+
+def test_audit_without_org_scans_all_orgs(session: Session):
+    # Regression: the audit must default to ALL orgs (org_id=None), not a single
+    # org, so offenders in any org are surfaced.
+    integration_a = _integration(session, "org-a", "int-a")
+    zero_tagged_a = _planner_config(session, "org-a", "cfg-a", integration_a.id)
+    missing_b = _planner_config(session, "org-b", "cfg-b", None)
+    session.commit()
+
+    findings = audit_active_planner_managed_configs(session)
+
+    assert {(finding.config_id, finding.reason) for finding in findings} == {
+        (str(zero_tagged_a.id), "zero_tagged_enabled_sources"),
+        (str(missing_b.id), "missing_migrated_integration_id"),
+    }

--- a/tests/test_source_discovery.py
+++ b/tests/test_source_discovery.py
@@ -227,6 +227,95 @@ def test_rediscovery_updates_last_seen_at_no_duplicates(
         )
 
 
+def test_github_rediscovery_preserves_planner_tag_and_updates_fields(
+    session: Session, github_integration: Integration
+):
+    from dev_health_ops.sync.discovery import discover_sources_for_integration
+
+    config_id = uuid.uuid4()
+    t_before = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    source = IntegrationSource(
+        org_id="org-test",
+        integration_id=github_integration.id,
+        provider="github",
+        source_type="repository",
+        external_id="acme/api",
+        name="old-name",
+        full_name="old/full-name",
+        metadata_={
+            "owner": "old-owner",
+            "planner_managed_sync_config_id": str(config_id),
+        },
+        is_enabled=True,
+        discovered_at=t_before,
+        last_seen_at=t_before,
+    )
+    session.add(source)
+    session.commit()
+
+    with patch(DISCOVERY_PATH, return_value=[("acme", "api")]):
+        updated = discover_sources_for_integration(session, github_integration.id)
+
+    assert len(updated) == 1
+    assert updated[0].name == "api"
+    assert updated[0].full_name == "acme/api"
+    assert updated[0].last_seen_at > t_before
+    assert updated[0].metadata_ == {
+        "owner": "acme",
+        "planner_managed_sync_config_id": str(config_id),
+    }
+
+
+def test_gitlab_rediscovery_preserves_planner_tag_and_updates_fields(
+    session: Session, gitlab_integration: Integration
+):
+    from dev_health_ops.sync.discovery import discover_sources_for_integration
+
+    config_id = uuid.uuid4()
+    t_before = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    source = IntegrationSource(
+        org_id="org-test",
+        integration_id=gitlab_integration.id,
+        provider="gitlab",
+        source_type="project",
+        external_id="42",
+        name="old-name",
+        full_name="old/full-name",
+        metadata_={
+            "path_with_namespace": "old/full-name",
+            "planner_managed_sync_config_id": str(config_id),
+        },
+        is_enabled=True,
+        discovered_at=t_before,
+        last_seen_at=t_before,
+    )
+    session.add(source)
+    session.commit()
+
+    with patch(DISCOVERY_PATH, return_value=[("42", "acme/api")]):
+        updated = discover_sources_for_integration(session, gitlab_integration.id)
+
+    assert len(updated) == 1
+    assert updated[0].name == "api"
+    assert updated[0].full_name == "acme/api"
+    assert updated[0].last_seen_at > t_before
+    assert updated[0].metadata_ == {
+        "path_with_namespace": "acme/api",
+        "planner_managed_sync_config_id": str(config_id),
+    }
+
+
+def test_new_github_discovery_row_has_only_fresh_metadata(
+    session: Session, github_integration: Integration
+):
+    from dev_health_ops.sync.discovery import discover_sources_for_integration
+
+    with patch(DISCOVERY_PATH, return_value=[("acme", "api")]):
+        sources = discover_sources_for_integration(session, github_integration.id)
+
+    assert sources[0].metadata_ == {"owner": "acme"}
+
+
 # ---------------------------------------------------------------------------
 # Test 5: Disabled source stays disabled after re-discovery
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Prerequisite (Issue 0 of epic CHAOS-2634) for the planner source-scoping fix (CHAOS-2636).

Catalog re-discovery (`sync/discovery.py::discover_sources_for_integration`) overwrote `IntegrationSource.metadata_` **wholesale** on rediscovery, erasing the `planner_managed_sync_config_id` tag that scopes a config to its user-selected repos. Once CHAOS-2636 starts filtering by that tag, a rediscovered config would silently drop to **zero repos**.

## Changes

- **`sync/discovery.py`** — MERGE metadata on rediscovery instead of replacing: fresh discovery values (`owner` / `path_with_namespace`, `name`, `full_name`) win, while keys the discovery payload lacks (notably `planner_managed_sync_config_id`) are preserved. `is_enabled` / `discovered_at` preservation unchanged.
- **`api/admin/routers/sync.py`** — add a one-planner-parent-per-integration invariant guard after the parent flush in batch-create, so the scalar tag stays unambiguous (filtered to parent configs).
- **`sync/planner_config_audit.py`** + **`audit/planner_configs.py`** + **`cli.py`** — reusable audit of active planner-managed configs flagging `missing_migrated_integration_id` or `zero_tagged_enabled_sources`, exposed as `dev-hops audit planner-configs` (defaults to ALL orgs; exits non-zero when offenders exist).

## Tests

- github + gitlab rediscovery preserve the tag and still update name/full_name/last_seen_at; brand-new rows carry only fresh metadata.
- invariant guard rejects a second planner parent on one integration.
- audit lists offenders (single-org + cross-org) and is clean on a good fixture.
- `audit planner-configs` does not auto-resolve to a single org.

## Validation

`bash ci/local_validate.sh` green: ruff format+check, mypy, FULL unit suite (5751 passed, 47 skipped), live-ClickHouse argMax proof.

No schema change (reuses `integration_sources`); no Alembic migration.

SCREENSHOT-WAIVER: backend-only change, no rendered UI.

Linear: CHAOS-2635