### PR TITLE
fix(sync): scope planner runs to selected sources (CHAOS-2636)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -666,6 +666,26 @@ def _planner_source_rows(
     return rows
 
 
+async def _assert_single_planner_parent_for_integration(
+    session: AsyncSession,
+    org_id: str,
+    integration_id: uuid.UUID,
+) -> None:
+    count_stmt = select(func.count(SyncConfiguration.id)).where(
+        SyncConfiguration.org_id == org_id,
+        SyncConfiguration.planner_managed.is_(True),
+        SyncConfiguration.migrated_integration_id == integration_id,
+        SyncConfiguration.parent_id.is_(None),
+    )
+    planner_parent_count = (await session.execute(count_stmt)).scalar_one()
+    if planner_parent_count > 1:
+        raise RuntimeError(
+            "Planner-managed integration invariant violated: "
+            f"integration {integration_id} is linked to {planner_parent_count} "
+            "planner-managed parent sync configurations"
+        )
+
+
 @router.get("/sync-targets")
 async def get_provider_sync_targets() -> dict[str, list[str]]:
     return PROVIDER_SYNC_TARGETS
@@ -1024,6 +1044,7 @@ async def batch_create_sync_configs(
     )
     session.add(parent)
     await session.flush()
+    await _assert_single_planner_parent_for_integration(session, org_id, integration.id)
 
     source_rows = _planner_source_rows(
         payload,

--- a/src/dev_health_ops/audit/planner_configs.py
+++ b/src/dev_health_ops/audit/planner_configs.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from dev_health_ops.db import get_postgres_session_sync_for_uri, resolve_db_uri
+from dev_health_ops.sync.planner_config_audit import (
+    audit_active_planner_managed_configs,
+)
+
+
+def register_commands(audit_subparsers: argparse._SubParsersAction) -> None:
+    audit_parser = audit_subparsers.add_parser(
+        "planner-configs",
+        help="Audit active planner-managed sync configs for source tag drift.",
+    )
+    audit_parser.add_argument(
+        "--format", choices=["json"], default="json", help="Output format."
+    )
+    audit_parser.set_defaults(func=_cmd_audit_planner_configs)
+
+
+def _cmd_audit_planner_configs(ns: argparse.Namespace) -> int:
+    with get_postgres_session_sync_for_uri(resolve_db_uri(ns)) as session:
+        findings = audit_active_planner_managed_configs(
+            session,
+            org_id=getattr(ns, "org", None),
+        )
+    print(json.dumps([finding.to_dict() for finding in findings], indent=2))
+    return 1 if findings else 0

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -360,6 +360,13 @@ def _suppress_parser_construction_noise():
 def _should_resolve_org(ns: argparse.Namespace) -> bool:
     if getattr(ns, "org", None) is not None:
         return False
+    # The planner-config audit defaults to ALL orgs; never auto-resolve it to a
+    # single (first) org, or the cross-org audit silently scans only one org.
+    if (
+        getattr(ns, "command", None) == "audit"
+        and getattr(ns, "audit_command", None) == "planner-configs"
+    ):
+        return False
     return not (
         getattr(ns, "command", None) == "migrate"
         and getattr(ns, "migrate_command", None) == "clickhouse"
@@ -421,6 +428,7 @@ _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     # --- audit (read ClickHouse analytics store) ---
     ("audit", "perf"): frozenset({_REQ_CLICKHOUSE}),
     ("audit", "schema"): frozenset({_REQ_CLICKHOUSE}),
+    ("audit", "planner-configs"): frozenset({_REQ_POSTGRES}),
     # --- other ClickHouse-backed commands ---
     ("recommendations", "compute"): frozenset({_REQ_CLICKHOUSE}),
     ("investment", "materialize"): frozenset({_REQ_CLICKHOUSE}),
@@ -589,7 +597,13 @@ def build_parser() -> argparse.ArgumentParser:
     from dev_health_ops import migrate as migrate_mod
     from dev_health_ops.api import runner as api_runner
     from dev_health_ops.api.admin import cli as admin_cli
-    from dev_health_ops.audit import completeness, coverage, perf, schema
+    from dev_health_ops.audit import (
+        completeness,
+        coverage,
+        perf,
+        planner_configs,
+        schema,
+    )
     from dev_health_ops.audit.ai_governance import cli as ai_governance_cli
     from dev_health_ops.fixtures import runner as fixtures_runner
     from dev_health_ops.metrics import (
@@ -670,6 +684,7 @@ def build_parser() -> argparse.ArgumentParser:
     schema.register_commands(audit_subparsers)
     perf.register_commands(audit_subparsers)
     coverage.register_commands(audit_subparsers)
+    planner_configs.register_commands(audit_subparsers)
 
     # ---- fixtures ----
     fixtures_runner.register_commands(sub)

--- a/src/dev_health_ops/sync/discovery.py
+++ b/src/dev_health_ops/sync/discovery.py
@@ -182,7 +182,10 @@ def discover_sources_for_integration(
     constraint ``(org_id, integration_id, provider, external_id)``.
 
     On re-discovery:
-    - ``last_seen_at``, ``name``, ``full_name``, and ``metadata_`` are updated.
+    - ``last_seen_at``, ``name``, and ``full_name`` are updated.
+    - ``metadata_`` is merged: fresh discovery values win, while keys the
+      discovery payload lacks (including ``planner_managed_sync_config_id``)
+      are preserved.
     - ``is_enabled`` is **not** changed for existing rows (preserves operator
       intent).  Only brand-new sources get ``is_enabled = auto_enable``.
     - ``discovered_at`` is **not** changed for existing rows.
@@ -240,7 +243,7 @@ def discover_sources_for_integration(
             existing.last_seen_at = now
             existing.name = fields["name"]
             existing.full_name = fields["full_name"]
-            existing.metadata_ = fields["metadata_"]
+            existing.metadata_ = {**(existing.metadata_ or {}), **fields["metadata_"]}
             upserted.append(existing)
         else:
             source = IntegrationSource(

--- a/src/dev_health_ops/sync/planner_config_audit.py
+++ b/src/dev_health_ops/sync/planner_config_audit.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.integrations import IntegrationSource
+from dev_health_ops.models.settings import SyncConfiguration
+
+PlannerConfigAuditReason = Literal[
+    "missing_migrated_integration_id", "zero_tagged_enabled_sources"
+]
+
+_PLANNER_TAG_KEY = "planner_managed_sync_config_id"
+
+
+@dataclass(frozen=True)
+class PlannerManagedConfigAuditFinding:
+    config_id: str
+    org_id: str
+    provider: str
+    name: str
+    reason: PlannerConfigAuditReason
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "config_id": self.config_id,
+            "org_id": self.org_id,
+            "provider": self.provider,
+            "name": self.name,
+            "reason": self.reason,
+        }
+
+
+def audit_active_planner_managed_configs(
+    session: Session,
+    *,
+    org_id: str | None = None,
+) -> list[PlannerManagedConfigAuditFinding]:
+    query = session.query(SyncConfiguration).filter(
+        SyncConfiguration.planner_managed.is_(True),
+        SyncConfiguration.is_active.is_(True),
+        SyncConfiguration.parent_id.is_(None),
+    )
+    if org_id:
+        query = query.filter(SyncConfiguration.org_id == org_id)
+
+    findings: list[PlannerManagedConfigAuditFinding] = []
+    for config in query.order_by(
+        SyncConfiguration.created_at, SyncConfiguration.id
+    ).all():
+        config_id = str(config.id)
+        base = {
+            "config_id": config_id,
+            "org_id": str(config.org_id),
+            "provider": str(config.provider),
+            "name": str(config.name),
+        }
+        if config.migrated_integration_id is None:
+            findings.append(
+                PlannerManagedConfigAuditFinding(
+                    **base,
+                    reason="missing_migrated_integration_id",
+                )
+            )
+            continue
+
+        enabled_sources = (
+            session.query(IntegrationSource)
+            .filter(
+                IntegrationSource.org_id == config.org_id,
+                IntegrationSource.integration_id == config.migrated_integration_id,
+                IntegrationSource.is_enabled.is_(True),
+            )
+            .all()
+        )
+        tagged_count = sum(
+            1
+            for source in enabled_sources
+            if str((source.metadata_ or {}).get(_PLANNER_TAG_KEY)) == config_id
+        )
+        if tagged_count == 0:
+            findings.append(
+                PlannerManagedConfigAuditFinding(
+                    **base,
+                    reason="zero_tagged_enabled_sources",
+                )
+            )
+
+    return findings

--- a/src/dev_health_ops/sync/trigger_routing.py
+++ b/src/dev_health_ops/sync/trigger_routing.py
@@ -23,6 +23,7 @@ The outbox and reconciler relay now recover committed PLANNED runs. This module'
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
@@ -41,6 +42,8 @@ MIGRATED_TRIGGER_ROUTING_SETTING_KEY = "sync.migrated_trigger_routing_enabled"
 _TRUTHY = {"1", "true", "yes", "on"}
 
 logger = logging.getLogger(__name__)
+
+_PLANNER_TAG_KEY = "planner_managed_sync_config_id"
 
 
 # ---------------------------------------------------------------------------
@@ -144,9 +147,11 @@ def plan_request_for_config(
 
     Routing semantics:
 
-    * **Parent config** (no ``migrated_source_id``): plan the *whole*
-      integration — all enabled sources and datasets — matching the admin
-      integration ``/sync`` endpoint's default fan-out.
+    * **Parent config** (no ``migrated_source_id``): leave source and dataset
+      scope unset. Callers that route planner-managed parents through
+      :func:`planner_request_for_config_if_routed` narrow sources to the
+      config-tagged ``IntegrationSource`` rows in that session-aware wrapper;
+      direct callers keep the historic all-enabled integration fan-out.
     * **Child config** (``migrated_source_id`` set): scope the run to that one
       source, and to the dataset keys derived from the child's legacy targets so
       the migrated trigger covers exactly what the child used to.
@@ -201,6 +206,34 @@ def should_route_config_to_planner(session: Session, config: SyncConfiguration) 
     return is_migrated_trigger_routing_enabled(session, str(config.org_id))
 
 
+def _planner_scoped_source_ids(
+    session: Session, config: SyncConfiguration
+) -> tuple[str, ...]:
+    """Return enabled source ids explicitly tagged for a planner-managed parent."""
+    from dev_health_ops.models.integrations import IntegrationSource
+
+    integration_id = getattr(config, "migrated_integration_id", None)
+    if integration_id is None:
+        return ()
+
+    config_id = str(config.id)
+    enabled_sources = (
+        session.query(IntegrationSource)
+        .filter(
+            IntegrationSource.org_id == config.org_id,
+            IntegrationSource.integration_id == integration_id,
+            IntegrationSource.is_enabled.is_(True),
+        )
+        .order_by(IntegrationSource.full_name, IntegrationSource.id)
+        .all()
+    )
+    return tuple(
+        str(source.id)
+        for source in enabled_sources
+        if str((source.metadata_ or {}).get(_PLANNER_TAG_KEY)) == config_id
+    )
+
+
 def planner_request_for_config_if_routed(
     session: Session,
     config: SyncConfiguration,
@@ -208,9 +241,26 @@ def planner_request_for_config_if_routed(
     triggered_by: str,
     mode: str = "incremental",
 ) -> SyncPlanRequest | None:
+    """Build a planner request if the config routes to the integration planner.
+
+    Planner-managed parent configs are session-scoped to enabled
+    ``IntegrationSource`` rows tagged with that config id. This preserves the
+    distinction between ``None`` (legacy all-enabled fan-out) and ``()`` (no
+    user-selected enabled sources) while leaving child configs and flag-routed
+    non-planner-managed parents on their existing semantics.
+    """
     if not should_route_config_to_planner(session, config):
         return None
-    return plan_request_for_config(config, triggered_by=triggered_by, mode=mode)
+    request = plan_request_for_config(config, triggered_by=triggered_by, mode=mode)
+    if (
+        request is not None
+        and bool(getattr(config, "planner_managed", False))
+        and getattr(config, "migrated_source_id", None) is None
+    ):
+        request = dataclasses.replace(
+            request, source_ids=_planner_scoped_source_ids(session, config)
+        )
+    return request
 
 
 def stamp_sync_run_canonical_config(

--- a/tests/api/admin/test_sync_config_deprecation.py
+++ b/tests/api/admin/test_sync_config_deprecation.py
@@ -44,6 +44,7 @@ from tests._helpers import tables_of
 
 admin_router_module = importlib.import_module("dev_health_ops.api.admin")
 auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+sync_router_module = importlib.import_module("dev_health_ops.api.admin.routers.sync")
 
 _TABLES = tables_of(
     User,
@@ -389,6 +390,48 @@ async def test_batch_creates_planner_parent_when_planner_flag_inactive(
         "files",
         "repo-metadata",
     }
+
+
+@pytest.mark.asyncio
+async def test_planner_parent_integration_invariant_rejects_second_parent(
+    session_maker, seeded_state
+):
+    org_id = seeded_state["org_id"]
+    async with session_maker() as session:
+        integration = Integration(
+            org_id=org_id,
+            provider="github",
+            name="shared-integration",
+            config={"owner": "myorg"},
+            is_active=True,
+        )
+        session.add(integration)
+        await session.flush()
+        session.add_all(
+            [
+                SyncConfiguration(
+                    name="planner-parent-a",
+                    provider="github",
+                    org_id=org_id,
+                    sync_targets=["git"],
+                    migrated_integration_id=integration.id,
+                    planner_managed=True,
+                ),
+                SyncConfiguration(
+                    name="planner-parent-b",
+                    provider="github",
+                    org_id=org_id,
+                    sync_targets=["git"],
+                    migrated_integration_id=integration.id,
+                    planner_managed=True,
+                ),
+            ]
+        )
+        await session.flush()
+        with pytest.raises(RuntimeError, match="invariant violated"):
+            await sync_router_module._assert_single_planner_parent_for_integration(
+                session, org_id, integration.id
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_backfill_fanout.py
+++ b/tests/test_backfill_fanout.py
@@ -34,6 +34,7 @@ from dev_health_ops.sync.trigger_routing import MIGRATED_TRIGGER_ROUTING_SETTING
 from dev_health_ops.sync.watermarks import get_watermark, set_watermark
 
 ORG_ID = "backfill-fanout-org"
+PLANNER_TAG_KEY = "planner_managed_sync_config_id"
 
 
 @pytest.fixture
@@ -538,7 +539,7 @@ def test_run_backfill_task_fanout_resolves_migrated_integration_id(
     from dev_health_ops.workers import sync_backfill
 
     integration = _create_integration(db_session)
-    _create_source(db_session, integration, "full-chaos/dev-health")
+    source = _create_source(db_session, integration, "full-chaos/dev-health")
     _create_dataset(db_session, integration, "commits")
     config = SyncConfiguration(
         name="migrated parent backfill",
@@ -551,6 +552,8 @@ def test_run_backfill_task_fanout_resolves_migrated_integration_id(
         planner_managed=True,
     )
     db_session.add(config)
+    db_session.flush()
+    source.metadata_ = {PLANNER_TAG_KEY: str(config.id)}
     db_session.flush()
     _patch_db_session(monkeypatch, db_session)
     monkeypatch.setenv("SYNC_FANOUT_BACKFILL", "1")
@@ -602,7 +605,7 @@ def test_run_backfill_task_fanout_resolves_migrated_integration_id(
     assert result["status"] == "success"
     assert captured["integration_id"] == str(integration.id)
     assert captured["integration_id"] != str(config.id)
-    assert captured["source_ids"] is None  # parent => whole integration
+    assert captured["source_ids"] == (str(source.id),)
     assert captured["since"] == date(2026, 6, 1)
     assert captured["before"] == date(2026, 6, 7)
     assert captured["triggered_by"] == "backfill"

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -126,6 +126,12 @@ class TestMigrateRouting:
         assert getattr(ns, "org", None) is None
         assert _should_resolve_org(ns)
 
+    def test_audit_planner_configs_without_org_does_not_auto_resolve(self):
+        ns = self.parser.parse_args(["audit", "planner-configs"])
+
+        assert getattr(ns, "org", None) is None
+        assert not _should_resolve_org(ns)
+
     def test_upgrade_flat_defaults_to_head(self):
         ns = self.parser.parse_args(["migrate", "upgrade"])
         assert ns.revision == "head"

--- a/tests/test_planner_config_audit.py
+++ b/tests/test_planner_config_audit.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.integrations import Integration, IntegrationSource
+from dev_health_ops.models.settings import SyncConfiguration
+from dev_health_ops.sync.planner_config_audit import (
+    audit_active_planner_managed_configs,
+)
+from tests._helpers import tables_of
+
+_TABLES = tables_of(SyncConfiguration, Integration, IntegrationSource)
+
+
+@pytest.fixture()
+def session(tmp_path: Path) -> Iterator[Session]:
+    engine = create_engine(f"sqlite:///{tmp_path / 'planner-config-audit.db'}")
+    Base.metadata.create_all(engine, tables=_TABLES)
+    maker = sessionmaker(engine, expire_on_commit=False)
+    try:
+        with maker() as db_session:
+            yield db_session
+    finally:
+        engine.dispose()
+
+
+def _integration(session: Session, org_id: str, name: str) -> Integration:
+    integration = Integration(
+        org_id=org_id,
+        provider="github",
+        name=name,
+        config={"owner": "acme"},
+        is_active=True,
+    )
+    session.add(integration)
+    session.flush()
+    return integration
+
+
+def _planner_config(
+    session: Session,
+    org_id: str,
+    name: str,
+    integration_id: uuid.UUID | None,
+) -> SyncConfiguration:
+    config = SyncConfiguration(
+        name=name,
+        provider="github",
+        org_id=org_id,
+        sync_targets=["git"],
+        migrated_integration_id=integration_id,
+        planner_managed=True,
+        is_active=True,
+    )
+    session.add(config)
+    session.flush()
+    return config
+
+
+def _tagged_source(
+    session: Session,
+    org_id: str,
+    integration_id: uuid.UUID,
+    config_id: uuid.UUID,
+    name: str,
+) -> IntegrationSource:
+    source = IntegrationSource(
+        org_id=org_id,
+        integration_id=integration_id,
+        provider="github",
+        source_type="repository",
+        external_id=f"acme/{name}",
+        name=name,
+        full_name=f"acme/{name}",
+        metadata_={"planner_managed_sync_config_id": str(config_id), "owner": "acme"},
+        is_enabled=True,
+    )
+    session.add(source)
+    session.flush()
+    return source
+
+
+def test_audit_active_planner_configs_lists_offenders(session: Session):
+    org_id = "org-test"
+    no_tag_integration = _integration(session, org_id, "no-tag-integration")
+    zero_tagged = _planner_config(session, org_id, "zero-tagged", no_tag_integration.id)
+    missing_integration = _planner_config(session, org_id, "missing-integration", None)
+    session.add(
+        IntegrationSource(
+            org_id=org_id,
+            integration_id=no_tag_integration.id,
+            provider="github",
+            source_type="repository",
+            external_id="acme/untagged",
+            name="untagged",
+            full_name="acme/untagged",
+            metadata_={"owner": "acme"},
+            is_enabled=True,
+        )
+    )
+    session.commit()
+
+    findings = audit_active_planner_managed_configs(session, org_id=org_id)
+
+    assert {(finding.config_id, finding.reason) for finding in findings} == {
+        (str(zero_tagged.id), "zero_tagged_enabled_sources"),
+        (str(missing_integration.id), "missing_migrated_integration_id"),
+    }
+
+
+def test_audit_active_planner_configs_is_clean_for_good_fixture(session: Session):
+    org_id = "org-test"
+    integration = _integration(session, org_id, "good-integration")
+    config = _planner_config(session, org_id, "good-config", integration.id)
+    _tagged_source(session, org_id, integration.id, config.id, "api")
+    session.commit()
+
+    assert audit_active_planner_managed_configs(session, org_id=org_id) == []
+
+
+def test_audit_without_org_scans_all_orgs(session: Session):
+    # Regression: the audit must default to ALL orgs (org_id=None), not a single
+    # org, so offenders in any org are surfaced.
+    integration_a = _integration(session, "org-a", "int-a")
+    zero_tagged_a = _planner_config(session, "org-a", "cfg-a", integration_a.id)
+    missing_b = _planner_config(session, "org-b", "cfg-b", None)
+    session.commit()
+
+    findings = audit_active_planner_managed_configs(session)
+
+    assert {(finding.config_id, finding.reason) for finding in findings} == {
+        (str(zero_tagged_a.id), "zero_tagged_enabled_sources"),
+        (str(missing_b.id), "missing_migrated_integration_id"),
+    }

--- a/tests/test_source_discovery.py
+++ b/tests/test_source_discovery.py
@@ -227,6 +227,95 @@ def test_rediscovery_updates_last_seen_at_no_duplicates(
         )
 
 
+def test_github_rediscovery_preserves_planner_tag_and_updates_fields(
+    session: Session, github_integration: Integration
+):
+    from dev_health_ops.sync.discovery import discover_sources_for_integration
+
+    config_id = uuid.uuid4()
+    t_before = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    source = IntegrationSource(
+        org_id="org-test",
+        integration_id=github_integration.id,
+        provider="github",
+        source_type="repository",
+        external_id="acme/api",
+        name="old-name",
+        full_name="old/full-name",
+        metadata_={
+            "owner": "old-owner",
+            "planner_managed_sync_config_id": str(config_id),
+        },
+        is_enabled=True,
+        discovered_at=t_before,
+        last_seen_at=t_before,
+    )
+    session.add(source)
+    session.commit()
+
+    with patch(DISCOVERY_PATH, return_value=[("acme", "api")]):
+        updated = discover_sources_for_integration(session, github_integration.id)
+
+    assert len(updated) == 1
+    assert updated[0].name == "api"
+    assert updated[0].full_name == "acme/api"
+    assert updated[0].last_seen_at > t_before
+    assert updated[0].metadata_ == {
+        "owner": "acme",
+        "planner_managed_sync_config_id": str(config_id),
+    }
+
+
+def test_gitlab_rediscovery_preserves_planner_tag_and_updates_fields(
+    session: Session, gitlab_integration: Integration
+):
+    from dev_health_ops.sync.discovery import discover_sources_for_integration
+
+    config_id = uuid.uuid4()
+    t_before = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    source = IntegrationSource(
+        org_id="org-test",
+        integration_id=gitlab_integration.id,
+        provider="gitlab",
+        source_type="project",
+        external_id="42",
+        name="old-name",
+        full_name="old/full-name",
+        metadata_={
+            "path_with_namespace": "old/full-name",
+            "planner_managed_sync_config_id": str(config_id),
+        },
+        is_enabled=True,
+        discovered_at=t_before,
+        last_seen_at=t_before,
+    )
+    session.add(source)
+    session.commit()
+
+    with patch(DISCOVERY_PATH, return_value=[("42", "acme/api")]):
+        updated = discover_sources_for_integration(session, gitlab_integration.id)
+
+    assert len(updated) == 1
+    assert updated[0].name == "api"
+    assert updated[0].full_name == "acme/api"
+    assert updated[0].last_seen_at > t_before
+    assert updated[0].metadata_ == {
+        "path_with_namespace": "acme/api",
+        "planner_managed_sync_config_id": str(config_id),
+    }
+
+
+def test_new_github_discovery_row_has_only_fresh_metadata(
+    session: Session, github_integration: Integration
+):
+    from dev_health_ops.sync.discovery import discover_sources_for_integration
+
+    with patch(DISCOVERY_PATH, return_value=[("acme", "api")]):
+        sources = discover_sources_for_integration(session, github_integration.id)
+
+    assert sources[0].metadata_ == {"owner": "acme"}
+
+
 # ---------------------------------------------------------------------------
 # Test 5: Disabled source stays disabled after re-discovery
 # ---------------------------------------------------------------------------

--- a/tests/test_trigger_routing.py
+++ b/tests/test_trigger_routing.py
@@ -25,6 +25,7 @@ from dev_health_ops.sync.trigger_routing import (
 )
 
 ORG_ID = "routing-org"
+PLANNER_TAG_KEY = "planner_managed_sync_config_id"
 
 
 @pytest.fixture
@@ -74,29 +75,51 @@ def _set_flag(session: Session, value: str) -> None:
     session.flush()
 
 
-def _source(session: Session, integration_id: uuid.UUID) -> IntegrationSource:
-    session.add(
-        Integration(
-            id=integration_id,
-            org_id=ORG_ID,
-            provider="github",
-            name="github-integration",
-            config={},
-        )
+def _integration(
+    session: Session, integration_id: uuid.UUID, *, provider: str = "github"
+) -> Integration:
+    integration = Integration(
+        id=integration_id,
+        org_id=ORG_ID,
+        provider=provider,
+        name=f"{provider}-integration-{integration_id}",
+        config={},
     )
+    session.add(integration)
+    session.flush()
+    return integration
+
+
+def _integration_source(
+    session: Session,
+    integration_id: uuid.UUID,
+    *,
+    provider: str = "github",
+    full_name: str,
+    metadata: dict[str, str] | None = None,
+    is_enabled: bool = True,
+) -> IntegrationSource:
     source = IntegrationSource(
         org_id=ORG_ID,
         integration_id=integration_id,
-        provider="github",
+        provider=provider,
         source_type="repository",
-        external_id="full-chaos/dev-health",
-        name="dev-health",
-        full_name="full-chaos/dev-health",
-        is_enabled=True,
+        external_id=full_name,
+        name=full_name.rsplit("/", 1)[-1],
+        full_name=full_name,
+        metadata_=metadata or {},
+        is_enabled=is_enabled,
     )
     session.add(source)
     session.flush()
     return source
+
+
+def _source(session: Session, integration_id: uuid.UUID) -> IntegrationSource:
+    _integration(session, integration_id)
+    return _integration_source(
+        session, integration_id, full_name="full-chaos/dev-health"
+    )
 
 
 # --- flag reader -----------------------------------------------------------
@@ -210,6 +233,133 @@ def test_planner_managed_parent_routes_without_flag(db_session):
 
     assert req is not None
     assert req.integration_id == str(integration_id)
+
+
+@pytest.mark.parametrize("provider", ["github", "gitlab"])
+def test_planner_managed_parent_scopes_to_tagged_enabled_sources(db_session, provider):
+    integration_id = uuid.uuid4()
+    _integration(db_session, integration_id, provider=provider)
+    config = _config(
+        db_session,
+        provider=provider,
+        migrated_integration_id=integration_id,
+        planner_managed=True,
+    )
+    tag = {PLANNER_TAG_KEY: str(config.id)}
+    selected = [
+        _integration_source(
+            db_session,
+            integration_id,
+            provider=provider,
+            full_name=f"acme/{provider}-selected-a",
+            metadata=tag,
+        ),
+        _integration_source(
+            db_session,
+            integration_id,
+            provider=provider,
+            full_name=f"acme/{provider}-selected-b",
+            metadata=tag,
+        ),
+        _integration_source(
+            db_session,
+            integration_id,
+            provider=provider,
+            full_name=f"acme/{provider}-selected-c",
+            metadata=tag,
+        ),
+    ]
+    _integration_source(
+        db_session,
+        integration_id,
+        provider=provider,
+        full_name=f"acme/{provider}-untagged",
+    )
+    _integration_source(
+        db_session,
+        integration_id,
+        provider=provider,
+        full_name=f"acme/{provider}-disabled",
+        metadata=tag,
+        is_enabled=False,
+    )
+
+    req = planner_request_for_config_if_routed(
+        db_session, config, triggered_by="manual"
+    )
+
+    assert req is not None
+    assert req.source_ids is not None
+    assert set(req.source_ids) == {str(source.id) for source in selected}
+    assert len(req.source_ids) == 3
+
+
+def test_planner_managed_child_keeps_single_source_scope(db_session):
+    integration_id = uuid.uuid4()
+    _integration(db_session, integration_id)
+    source = _integration_source(
+        db_session, integration_id, full_name="full-chaos/dev-health"
+    )
+    child = _config(
+        db_session,
+        migrated_integration_id=integration_id,
+        migrated_source_id=source.id,
+        planner_managed=True,
+    )
+
+    req = planner_request_for_config_if_routed(db_session, child, triggered_by="manual")
+
+    assert req is not None
+    assert req.source_ids == (str(source.id),)
+
+
+def test_planner_managed_parent_with_zero_tagged_enabled_sources_syncs_nothing(
+    db_session,
+):
+    integration_id = uuid.uuid4()
+    _integration(db_session, integration_id)
+    config = _config(
+        db_session,
+        migrated_integration_id=integration_id,
+        planner_managed=True,
+    )
+    _integration_source(db_session, integration_id, full_name="full-chaos/untagged")
+    _integration_source(
+        db_session,
+        integration_id,
+        full_name="full-chaos/disabled",
+        metadata={PLANNER_TAG_KEY: str(config.id)},
+        is_enabled=False,
+    )
+
+    req = planner_request_for_config_if_routed(
+        db_session, config, triggered_by="manual"
+    )
+
+    assert req is not None
+    assert req.source_ids == ()
+
+
+def test_flag_routed_parent_without_planner_marker_keeps_all_enabled_semantics(
+    db_session,
+):
+    integration_id = uuid.uuid4()
+    _integration(db_session, integration_id)
+    config = _config(db_session, migrated_integration_id=integration_id)
+    _integration_source(
+        db_session,
+        integration_id,
+        full_name="full-chaos/tagged-but-legacy",
+        metadata={PLANNER_TAG_KEY: str(config.id)},
+    )
+    _set_flag(db_session, "true")
+
+    req = planner_request_for_config_if_routed(
+        db_session, config, triggered_by="manual"
+    )
+
+    assert req is not None
+    assert req.source_ids is None
 
 
 def test_migrated_single_with_source_needs_flag_without_planner_marker(db_session):


### PR DESCRIPTION
## What

P0 fix for CHAOS-2636, stacked on prerequisite PR #1034 (CHAOS-2635).

Planner-managed parent sync configs were building `SyncPlanRequest(source_ids=None)`, and `None` means all enabled sources on the migrated integration. If catalog discovery had added all org repos to the integration, Sync Now/Backfill/Scheduler could ingest all enabled repos instead of the user-selected repos.

## Changes

- In `sync/trigger_routing.py`, planner-managed parent configs now resolve enabled `IntegrationSource` rows tagged with `metadata_["planner_managed_sync_config_id"] == str(config.id)` and pass an explicit `source_ids` tuple into the planner request.
- Empty tagged-enabled set becomes `source_ids=()` (sync nothing), preserving the distinction from `None` (legacy all-enabled fanout).
- Child configs keep their existing single-source `migrated_source_id` behavior.
- Flag-routed parents that are not `planner_managed` keep `source_ids=None` until the legacy path is removed.
- Tag filtering is provider-agnostic and done in Python after loading enabled sources for the config's org/integration, avoiding SQLite/Postgres JSON operator differences.

## Tests

- Planner-managed parent scopes to exactly tagged enabled sources for GitHub and GitLab.
- Untagged and disabled sources are excluded.
- Planner-managed child keeps the single source scope.
- Planner-managed parent with zero tagged enabled sources returns `()`.
- Non-planner flag-routed parent keeps `None` / all-enabled semantics.
- Backfill fanout now asserts the tagged selected source id is propagated.

## Validation

`bash ci/local_validate.sh` green: ruff format+check, mypy, FULL unit suite (5756 passed, 47 skipped), live-ClickHouse argMax proof.

Reviewed by Oracle: no blocking findings.

SCREENSHOT-WAIVER: backend-only change, no rendered UI.

Depends on: #1034
Linear: CHAOS-2636