### PR TITLE
fix(sync): persist selected GitHub repo full names (CHAOS-2637)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -642,14 +642,21 @@ def _planner_source_rows(
             }
         else:
             source_type = "repository" if provider == "github" else "source"
-            full_name = f"{owner}/{repo_name}" if provider == "github" else repo_name
+            if provider == "github" and "/" in repo_name:
+                source_owner, source_name = repo_name.split("/", 1)
+                full_name = repo_name
+            else:
+                source_owner = owner
+                source_name = repo_name
+                full_name = (
+                    f"{owner}/{repo_name}" if provider == "github" else repo_name
+                )
             external_id = full_name
-            source_name = repo_name
             metadata = {
                 "planner_managed_sync_config_id": str(config_id),
             }
             if provider == "github":
-                metadata["owner"] = owner
+                metadata["owner"] = source_owner
         rows.append(
             IntegrationSource(
                 org_id=org_id,

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -143,7 +143,10 @@ class SyncConfigBatchCreate(BaseModel):
     credential_id: str | None = None
     sync_targets: list[str] = Field(default_factory=list)
     sync_options: dict[str, Any] = Field(default_factory=dict)
-    repos: list[str] = Field(default_factory=list, description="Repo names to sync")
+    repos: list[str] = Field(
+        default_factory=list,
+        description="Repo names or full names to sync",
+    )
     schedule_cron: str | None = None
     timezone: str | None = None
     initial_sync_depth: int | None = None

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -61,6 +61,66 @@ class _CroniterStub:
         return self._next
 
 
+def test_planner_source_rows_accepts_github_full_name():
+    integration_id = uuid.uuid4()
+    config_id = uuid.uuid4()
+    payload = sync_router_module.SyncConfigBatchCreate(
+        name="Full Chaos",
+        provider="github",
+        sync_options={"owner": "fallback-owner"},
+        repos=["acme/web"],
+    )
+
+    rows = sync_router_module._planner_source_rows(
+        payload,
+        {},
+        {},
+        "org-test",
+        integration_id,
+        config_id,
+    )
+
+    assert len(rows) == 1
+    source = rows[0]
+    assert source.external_id == "acme/web"
+    assert source.full_name == "acme/web"
+    assert source.name == "web"
+    assert source.metadata_ == {
+        "owner": "acme",
+        "planner_managed_sync_config_id": str(config_id),
+    }
+
+
+def test_planner_source_rows_keeps_gitlab_slash_path_unchanged():
+    integration_id = uuid.uuid4()
+    config_id = uuid.uuid4()
+    payload = sync_router_module.SyncConfigBatchCreate(
+        name="GitLab",
+        provider="gitlab",
+        sync_options={"group": "fallback-group"},
+        repos=["group/subgroup/project"],
+    )
+
+    rows = sync_router_module._planner_source_rows(
+        payload,
+        {},
+        {"group/subgroup/project": (42, "group/subgroup/project")},
+        "org-test",
+        integration_id,
+        config_id,
+    )
+
+    assert len(rows) == 1
+    source = rows[0]
+    assert source.external_id == "42"
+    assert source.full_name == "group/subgroup/project"
+    assert source.name == "project"
+    assert source.metadata_ == {
+        "path_with_namespace": "group/subgroup/project",
+        "planner_managed_sync_config_id": str(config_id),
+    }
+
+
 @pytest_asyncio.fixture
 async def session_maker(tmp_path: Path):
     db_path = tmp_path / "sync-configs.db"


### PR DESCRIPTION
## Summary
- Allow sync batch repo payloads to carry GitHub full names as owner/repo.
- Persist selected GitHub repos with full_name/external_id as owner/repo, repo-only name, and parsed owner metadata.
- Preserve GitLab slash-containing namespace paths unchanged.

## Validation
- env -u ALL_PROXY -u all_proxy .venv/bin/python -m pytest tests/api/admin/test_sync_configs.py -q (56 passed, 1 warning)
- bash ci/local_validate.sh (passed)
- LSP diagnostics clean for changed files
- git diff --check (passed)

Linear: CHAOS-2637
