### PR TITLE
fix(rate-limit): honor Retry-After end-to-end; defer sync jobs instead of killing them (CHAOS-2644)

### DIFF
--- a/src/dev_health_ops/api/queries/aggregated_flame.py
+++ b/src/dev_health_ops/api/queries/aggregated_flame.py
@@ -186,7 +186,7 @@ async def fetch_throughput(
             coalesce(nullIf(team_name, ''), 'Unassigned') AS team_name,
             sum(items_completed) AS items_completed,
             sum(items_started) AS items_started
-        FROM work_item_metrics_daily
+        FROM work_item_metrics_daily FINAL
         WHERE {where_clause}
         GROUP BY team_name
         HAVING items_completed > 0

--- a/src/dev_health_ops/api/queries/filters.py
+++ b/src/dev_health_ops/api/queries/filters.py
@@ -42,7 +42,7 @@ async def fetch_filter_options(
             UNION ALL
 
             SELECT team_id AS value
-            FROM work_item_user_metrics_daily
+            FROM work_item_user_metrics_daily FINAL
             WHERE team_id != ''
               AND org_id = %(org_id)s
         )

--- a/src/dev_health_ops/api/queries/metrics.py
+++ b/src/dev_health_ops/api/queries/metrics.py
@@ -12,11 +12,12 @@ def _date_params(start_day: date, end_day: date) -> dict[str, Any]:
     return {"start_day": start_day, "end_day": end_day}
 
 
-# CHAOS-2377: tables that the daily job appends to per-run (plain MergeTree, one
-# fresh row per (natural key, computed_at)). Reading them with a top-level
-# sum() double-counts re-runs/backfills, so the table read must be wrapped in a
-# per-key argMax(..., computed_at) dedup subquery before aggregating — matching
-# the operating_review / sankey / aggregated_flame readers on this branch.
+# CHAOS-2377 / CHAOS-2645: daily-rollup tables the sync job re-writes per run.
+# work_item_metrics_daily and work_item_user_metrics_daily are
+# ReplacingMergeTree(computed_at) (migration 055); work_item_state_durations_daily
+# stays MergeTree. In all cases a top-level sum() double-counts re-runs/backfills,
+# so the table read is wrapped in a per-key argMax(..., computed_at) dedup subquery
+# before aggregating (the FINAL-equivalent for the metric-config read path).
 _DEDUP_BY_COMPUTED_AT: dict[str, tuple[str, ...]] = {
     "work_item_state_durations_daily": (
         "day",
@@ -24,6 +25,18 @@ _DEDUP_BY_COMPUTED_AT: dict[str, tuple[str, ...]] = {
         "work_scope_id",
         "team_id",
         "status",
+    ),
+    "work_item_metrics_daily": (
+        "day",
+        "provider",
+        "work_scope_id",
+        "team_id",
+    ),
+    "work_item_user_metrics_daily": (
+        "day",
+        "provider",
+        "work_scope_id",
+        "user_identity",
     ),
 }
 

--- a/src/dev_health_ops/api/queries/people.py
+++ b/src/dev_health_ops/api/queries/people.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from datetime import date, datetime
 from typing import Any
 
+from dev_health_ops.clickhouse_dedup import dedup_from
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 from .client import query_dicts
@@ -88,7 +89,7 @@ async def fetch_person_metric_value(
 ) -> float:
     template = load_sql("people/person_summary_deltas.sql")
     sql = template.format(
-        table=table,
+        table=dedup_from(table),
         column=column,
         aggregator=aggregator,
         identity_column=identity_column,
@@ -121,7 +122,7 @@ async def fetch_person_metric_series(
 ) -> list[dict[str, Any]]:
     template = load_sql("people/person_metric_timeseries.sql")
     sql = template.format(
-        table=table,
+        table=dedup_from(table),
         column=column,
         aggregator=aggregator,
         identity_column=identity_column,
@@ -154,7 +155,7 @@ async def fetch_person_breakdown(
 ) -> list[dict[str, Any]]:
     template = load_sql("people/person_metric_breakdowns.sql")
     sql = template.format(
-        table=table,
+        table=dedup_from(table),
         column=column,
         aggregator=aggregator,
         identity_column=identity_column,

--- a/src/dev_health_ops/api/queries/quadrant.py
+++ b/src/dev_health_ops/api/queries/quadrant.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any
 
+from dev_health_ops.clickhouse_dedup import dedup_from
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 from .client import query_dicts
@@ -40,7 +41,7 @@ async def fetch_quadrant_metric(
             {entity_expr} AS entity_id,
             {label_expr} AS entity_label,
             {value_expr} AS value
-        FROM {table}
+        FROM {dedup_from(table)}
         {join_sql}
         WHERE day >= %(start_day)s AND day < %(end_day)s
         {where_sql}

--- a/src/dev_health_ops/api/queries/sankey.py
+++ b/src/dev_health_ops/api/queries/sankey.py
@@ -55,7 +55,7 @@ async def fetch_expense_counts(
             sum(new_items_count) AS new_items,
             sum(new_bugs_count) AS new_bugs,
             sum(items_completed * bug_completed_ratio) AS bug_completed_estimate
-        FROM work_item_metrics_daily
+        FROM work_item_metrics_daily FINAL
         WHERE day >= %(start_day)s AND day < %(end_day)s
           AND org_id = %(org_id)s
             {scope_filter}

--- a/src/dev_health_ops/api/sql/people/people_search.sql
+++ b/src/dev_health_ops/api/sql/people/people_search.sql
@@ -12,7 +12,7 @@ WITH identities AS (
     SELECT
         user_identity AS identity,
         max(day) AS last_seen
-    FROM work_item_user_metrics_daily
+    FROM work_item_user_metrics_daily FINAL
     WHERE user_identity != ''
       AND org_id = %(org_id)s
     GROUP BY user_identity

--- a/src/dev_health_ops/api/sql/people/person_identity_coverage.sql
+++ b/src/dev_health_ops/api/sql/people/person_identity_coverage.sql
@@ -9,7 +9,7 @@ FROM (
     UNION ALL
 
     SELECT 'work' AS source
-    FROM work_item_user_metrics_daily
+    FROM work_item_user_metrics_daily FINAL
     WHERE user_identity IN %(identities)s
       AND org_id = %(org_id)s
     LIMIT 1

--- a/src/dev_health_ops/api/sql/people/person_lookup.sql
+++ b/src/dev_health_ops/api/sql/people/person_lookup.sql
@@ -7,7 +7,7 @@ WITH identities AS (
     UNION DISTINCT
 
     SELECT user_identity AS identity
-    FROM work_item_user_metrics_daily
+    FROM work_item_user_metrics_daily FINAL
     WHERE user_identity != ''
       AND org_id = %(org_id)s
 )

--- a/src/dev_health_ops/api/sql/people/person_summary_collaboration.sql
+++ b/src/dev_health_ops/api/sql/people/person_summary_collaboration.sql
@@ -46,7 +46,7 @@ SELECT
     'handoff_points' AS section,
     'Items started' AS label,
     sum(items_started) AS value
-FROM work_item_user_metrics_daily
+FROM work_item_user_metrics_daily FINAL
 WHERE day >= %(start_day)s AND day < %(end_day)s
   AND user_identity IN %(identities)s
   AND org_id = %(org_id)s
@@ -57,7 +57,7 @@ SELECT
     'handoff_points' AS section,
     'Items completed' AS label,
     sum(items_completed) AS value
-FROM work_item_user_metrics_daily
+FROM work_item_user_metrics_daily FINAL
 WHERE day >= %(start_day)s AND day < %(end_day)s
   AND user_identity IN %(identities)s
   AND org_id = %(org_id)s

--- a/src/dev_health_ops/api/sql/people/person_team.sql
+++ b/src/dev_health_ops/api/sql/people/person_team.sql
@@ -11,7 +11,7 @@ FROM (
     UNION ALL
 
     SELECT team_id, day
-    FROM work_item_user_metrics_daily
+    FROM work_item_user_metrics_daily FINAL
     WHERE user_identity IN %(identities)s
       AND org_id = %(org_id)s
       AND team_id IS NOT NULL

--- a/src/dev_health_ops/clickhouse_dedup.py
+++ b/src/dev_health_ops/clickhouse_dedup.py
@@ -1,0 +1,40 @@
+"""Canonical dedup source for re-run-safe daily rollup tables (CHAOS-2645).
+
+``work_item_metrics_daily`` and ``work_item_user_metrics_daily`` are
+``ReplacingMergeTree(computed_at)`` (see ClickHouse migration 055). A sync that
+restarts from scratch (a Celery retry, or a rate-limit deferral re-enqueue from
+CHAOS-2644) re-writes a fresh row per ``(sorting-key, day)``; duplicate versions
+are only collapsed by ``FINAL`` (or an eventual background merge).
+
+Therefore EVERY read of these tables must deduplicate to the latest
+``computed_at`` per sorting key, otherwise re-runs are double-counted. Use
+:func:`dedup_from` in the ``FROM`` / ``JOIN`` clause of any read. The
+metric-config read path in ``api/queries/metrics.py`` instead wraps these tables
+in an ``argMax(..., computed_at)`` subquery (the established CHAOS-2377 pattern);
+both approaches yield one logical row per key.
+
+A static guard test (``tests/test_rerun_dedup_guard.py``) fails CI if a raw
+``FROM``/``JOIN`` of these tables is introduced without ``FINAL``.
+"""
+
+from __future__ import annotations
+
+# Tables converted to ReplacingMergeTree(computed_at) in CH migration 055.
+RERUN_DEDUPED_DAILY_TABLES = frozenset(
+    {
+        "work_item_metrics_daily",
+        "work_item_user_metrics_daily",
+    }
+)
+
+
+def dedup_from(table: str) -> str:
+    """Return the ``FROM`` / ``JOIN`` source for ``table``.
+
+    Appends ``FINAL`` when ``table`` is a re-run-deduplicated
+    ReplacingMergeTree rollup so a single re-run does not double-count; returns
+    the bare name otherwise.
+    """
+    if table in RERUN_DEDUPED_DAILY_TABLES:
+        return f"{table} FINAL"
+    return table

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -1852,25 +1852,25 @@ def run_fixtures_validation(ns: argparse.Namespace) -> int:
             return 1
 
         metrics_count = int(
-            client.query("SELECT count() FROM work_item_metrics_daily").result_rows[0][
-                0
-            ]
+            client.query(
+                "SELECT count() FROM work_item_metrics_daily FINAL"
+            ).result_rows[0][0]
         )
         metrics_with_predictability = int(
             client.query(
-                "SELECT count() FROM work_item_metrics_daily "
+                "SELECT count() FROM work_item_metrics_daily FINAL "
                 "WHERE predictability_score > 0"
             ).result_rows[0][0]
         )
         metrics_with_congestion = int(
             client.query(
-                "SELECT count() FROM work_item_metrics_daily "
+                "SELECT count() FROM work_item_metrics_daily FINAL "
                 "WHERE wip_congestion_ratio > 0"
             ).result_rows[0][0]
         )
         metrics_with_new_items = int(
             client.query(
-                "SELECT count() FROM work_item_metrics_daily WHERE new_items_count > 0"
+                "SELECT count() FROM work_item_metrics_daily FINAL WHERE new_items_count > 0"
             ).result_rows[0][0]
         )
         logging.info(

--- a/src/dev_health_ops/metrics/compute_capacity.py
+++ b/src/dev_health_ops/metrics/compute_capacity.py
@@ -407,7 +407,7 @@ async def load_throughput_history_clickhouse(
         SELECT
             day,
             sum(items_completed) as items_completed
-        FROM work_item_metrics_daily
+        FROM work_item_metrics_daily FINAL
         WHERE {where_clause}
         GROUP BY day
         ORDER BY day
@@ -465,7 +465,7 @@ async def load_throughput_history_sqlalchemy(
     query = text(
         f"""
         SELECT day, SUM(items_completed) as items_completed
-        FROM work_item_metrics_daily
+        FROM work_item_metrics_daily FINAL
         WHERE {where_clause}
         GROUP BY day
         ORDER BY day

--- a/src/dev_health_ops/metrics/job_capacity.py
+++ b/src/dev_health_ops/metrics/job_capacity.py
@@ -76,7 +76,7 @@ async def load_throughput_from_sink(
 
     query = f"""
         SELECT day, SUM(items_completed) as items_completed
-        FROM work_item_metrics_daily
+        FROM work_item_metrics_daily FINAL
         WHERE {where_clause}
         GROUP BY day
         ORDER BY day
@@ -128,7 +128,7 @@ async def get_backlog_from_sink(
 
     query = f"""
         SELECT wip_count_end_of_day
-        FROM work_item_metrics_daily
+        FROM work_item_metrics_daily FINAL
         WHERE {where_clause}
         ORDER BY day DESC
         LIMIT 1
@@ -151,7 +151,7 @@ async def discover_team_scopes(sink: Any) -> list[tuple[str | None, str | None]]
 
     query = """
         SELECT DISTINCT team_id, work_scope_id
-        FROM work_item_metrics_daily
+        FROM work_item_metrics_daily FINAL
         WHERE day >= today() - 30
     """
 

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -1438,7 +1438,9 @@ async def run_daily_metrics_finalize(
             except Exception:
                 logger.debug("Skipping malformed user_metrics row: %s", row)
 
-        wi_query = "SELECT * FROM work_item_user_metrics_daily WHERE day = {day:Date}"
+        wi_query = (
+            "SELECT * FROM work_item_user_metrics_daily FINAL WHERE day = {day:Date}"
+        )
         wi_params: dict[str, Any] = {"day": day}
         if org_id:
             wi_query += " AND org_id = {org_id:String}"

--- a/src/dev_health_ops/migrations/clickhouse/055_work_item_daily_rollups_replacing_merge_tree.py
+++ b/src/dev_health_ops/migrations/clickhouse/055_work_item_daily_rollups_replacing_merge_tree.py
@@ -1,0 +1,306 @@
+"""Migration 055: Make work-item daily rollups idempotent under re-runs (CHAOS-2645).
+
+``work_item_metrics_daily`` and ``work_item_user_metrics_daily`` are written
+append-only by the work-item sync job. A sync that restarts from scratch
+(today's Celery retry, or a rate-limit deferral re-enqueue from CHAOS-2644)
+re-writes the same ``(grain, day)`` rows, leaving DUPLICATE versions that
+flat-aggregating readers then double-count (inflated metrics).
+
+This migration converts both tables in place from ``MergeTree`` to
+``ReplacingMergeTree(computed_at)`` so duplicate versions of the same sorting
+key collapse to the newest ``computed_at``. The ORDER BY (already org_id-first
+after migration 027) is the dedup key and is preserved exactly; only the engine
+changes. Reads must still use ``FINAL`` / argMax to see one row per key before
+background merges run — that is handled in the application layer.
+
+``work_item_state_durations_daily`` is intentionally NOT converted here: its
+readers already deduplicate with ``argMax(metric, computed_at)`` grouped by the
+natural key (with dedicated tests), so it does not double-count. A separate
+storage-hygiene follow-up may convert it later.
+
+Rebuild uses the same shadow-table pattern as migrations 027/042 (Altinity):
+
+    1. SHOW CREATE TABLE to get the live DDL (preserves columns, partitioning,
+       the existing ORDER BY, settings, codecs, TTL).
+    2. Rewrite DDL: rename to ``<table>_new`` and swap the engine to
+       ``ReplacingMergeTree(computed_at)``.
+    3. Verify via system.tables that the shadow is ReplacingMergeTree AND that
+       its sorting key is byte-for-byte the original key — abort (dropping the
+       shadow) on any mismatch, so a regex miss fails closed.
+    4. INSERT INTO <table>_new SELECT * FROM <table> (snapshot copy).
+    5. Verify the distinct sorting-key tuple counts match between original and
+       shadow (raw row counts may legitimately differ: the copy can collapse
+       not-yet-merged same-key duplicate versions — that is exactly the bug we
+       are fixing, not data loss).
+    6. EXCHANGE TABLES <table> AND <table>_new (atomic swap).
+    7. CATCH-UP: INSERT INTO <table> SELECT * FROM <table>_new — the shadow now
+       holds the OLD table, including rows written between snapshot (4) and swap
+       (6). Re-inserting is idempotent under RMT: already-copied rows dedup away
+       on the key with the newest version winning; late rows survive.
+    8. DROP TABLE <table>_new — only after the catch-up succeeded.
+
+Crash convergence: if a run crashes after EXCHANGE but before catch-up/DROP, the
+main table is already ReplacingMergeTree, so a rerun takes the skip path; that
+path finishes the catch-up + DROP of any leftover ``<table>_new`` before
+declaring done. A crash before EXCHANGE leaves a disposable shadow the next run
+drops and recreates.
+
+Ops note: run during a quiet period / with sync workers stopped — writes that
+race the EXCHANGE resolve their version tie arbitrarily (benign: same logical
+day, newest ``computed_at`` wins).
+
+Idempotent: tables already ReplacingMergeTree are skipped (after converging any
+leftover shadow).
+
+NOTE: this file is loaded standalone by the migration runner
+(importlib.util.spec_from_file_location), so it must not import from other
+migration modules — helpers are intentionally duplicated from 027/042.
+"""
+
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tables to convert to ReplacingMergeTree(computed_at). The ORDER BY is left
+# unchanged; ``computed_at`` is the RMT version column (newest wins).
+# ---------------------------------------------------------------------------
+
+TABLES = (
+    "work_item_metrics_daily",
+    "work_item_user_metrics_daily",
+)
+
+RMT_VERSION_COLUMN = "computed_at"
+
+# Match a plain MergeTree engine clause (NOT ReplacingMergeTree / others):
+# ``ENGINE = MergeTree`` immediately followed by a non-identifier char.
+_ENGINE_RE = re.compile(r"ENGINE\s*=\s*MergeTree\b", re.IGNORECASE)
+
+
+def _table_name_re(table: str) -> re.Pattern:
+    """Regex for the table name in a CREATE TABLE statement."""
+    return re.compile(
+        rf"(CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+        rf"(?:`?[\w\d_]+`?\.)?`?){re.escape(table)}(`?\s|`?\()",
+        re.IGNORECASE,
+    )
+
+
+def _replace_table_name(ddl: str, old_name: str, new_name: str) -> str:
+    """Replace the table name in a CREATE TABLE DDL string."""
+    pattern = _table_name_re(old_name)
+    result, count = pattern.subn(rf"\g<1>{new_name}\g<2>", ddl, count=1)
+    if count == 0:
+        raise ValueError(
+            f"Could not replace table name '{old_name}' in DDL: {ddl[:300]}..."
+        )
+    return result
+
+
+def _replace_engine_with_rmt(ddl: str) -> str:
+    """Swap a plain ``MergeTree`` engine for ``ReplacingMergeTree(computed_at)``."""
+    result, count = _ENGINE_RE.subn(
+        f"ENGINE = ReplacingMergeTree({RMT_VERSION_COLUMN})", ddl, count=1
+    )
+    if count == 0:
+        raise ValueError(
+            f"Could not find a plain 'ENGINE = MergeTree' clause in DDL: {ddl[:300]}..."
+        )
+    return result
+
+
+def _table_exists(client, table: str) -> bool:
+    try:
+        res = client.query(
+            "SELECT count() FROM system.tables "
+            "WHERE database = currentDatabase() AND name = {name:String}",
+            parameters={"name": table},
+        )
+        rows = getattr(res, "result_rows", None) or []
+        return bool(rows and rows[0] and rows[0][0] > 0)
+    except Exception:
+        return False
+
+
+def _engine_name(client, table: str) -> str:
+    res = client.query(
+        "SELECT engine FROM system.tables "
+        "WHERE database = currentDatabase() AND name = {name:String}",
+        parameters={"name": table},
+    )
+    rows = getattr(res, "result_rows", None) or []
+    return str(rows[0][0]) if rows and rows[0] else ""
+
+
+def _has_column(client, table: str, column: str) -> bool:
+    res = client.query(
+        "SELECT count() FROM system.columns "
+        "WHERE database = currentDatabase() AND table = {t:String} AND name = {c:String}",
+        parameters={"t": table, "c": column},
+    )
+    rows = getattr(res, "result_rows", None) or []
+    return bool(rows and rows[0] and rows[0][0] > 0)
+
+
+def _normalize_sorting_key(key: str) -> str:
+    """Normalize a sorting key for string comparison (backticks, spacing)."""
+    return re.sub(r"\s*,\s*", ", ", re.sub(r"\s+", " ", key.replace("`", ""))).strip(
+        " ()"
+    )
+
+
+def _sorting_key(client, table: str) -> str:
+    """Read a table's actual sorting key from system.tables."""
+    res = client.query(
+        "SELECT sorting_key FROM system.tables "
+        "WHERE database = currentDatabase() AND name = {name:String}",
+        parameters={"name": table},
+    )
+    rows = getattr(res, "result_rows", None) or []
+    if not rows or not rows[0]:
+        raise RuntimeError(f"{table}: could not read sorting_key from system.tables")
+    return str(rows[0][0])
+
+
+def _key_columns(sorting_key: str) -> list[str]:
+    """Parse 'org_id, provider, day, ...' into its column names."""
+    return [c.strip() for c in sorting_key.strip("() ").split(",") if c.strip()]
+
+
+def _distinct_key_count(client, table: str, key_columns: list[str]) -> int:
+    """Count distinct sorting-key tuples (stable under RMT merges)."""
+    key_tuple = ", ".join(f"`{c}`" for c in key_columns)
+    res = client.query(f"SELECT uniqExact(({key_tuple})) FROM `{table}`")
+    rows = getattr(res, "result_rows", None) or []
+    return int(rows[0][0]) if rows and rows[0] else 0
+
+
+def _catch_up_and_drop(client, table: str, shadow: str) -> None:
+    """Post-EXCHANGE catch-up: re-insert the old table's rows, then drop it.
+
+    After EXCHANGE TABLES, *shadow* holds the OLD table — including any rows
+    written between the snapshot copy and the swap. Re-inserting ALL of its
+    rows is idempotent under ReplacingMergeTree: rows already present dedup away
+    on the key with the newest version winning, while late-written rows survive.
+    Only after the catch-up succeeds is the old table dropped; on failure the
+    shadow is left in place so a rerun can converge (see the skip path).
+    """
+    log.info(f"  {table}: catch-up copy of post-snapshot writes from `{shadow}`")
+    client.command(f"INSERT INTO `{table}` SELECT * FROM `{shadow}`")
+    client.command(f"DROP TABLE `{shadow}`")
+
+
+def _rebuild_table(client, table: str) -> None:
+    """Convert a single table to ReplacingMergeTree(computed_at) in place."""
+    shadow = f"{table}_new"
+
+    if not _table_exists(client, table):
+        log.warning(f"  {table}: table does not exist, skipping")
+        return
+
+    if _engine_name(client, table) == "ReplacingMergeTree":
+        # Convergence: a previous run may have crashed after EXCHANGE but before
+        # its catch-up/DROP. The leftover shadow then holds the OLD table —
+        # finish the catch-up before skipping so post-snapshot writes survive.
+        if _table_exists(client, shadow):
+            log.info(
+                f"  {table}: already ReplacingMergeTree but leftover `{shadow}` "
+                f"found — converging interrupted run"
+            )
+            _catch_up_and_drop(client, table, shadow)
+        else:
+            log.info(f"  {table}: already ReplacingMergeTree, skipping")
+        return
+
+    if not _has_column(client, table, RMT_VERSION_COLUMN):
+        raise ValueError(
+            f"{table}: required RMT version column '{RMT_VERSION_COLUMN}' not "
+            f"found; cannot convert to ReplacingMergeTree"
+        )
+
+    res = client.query(f"SHOW CREATE TABLE `{table}`")
+    ddl = res.result_rows[0][0]
+
+    new_ddl = _replace_table_name(ddl, table, shadow)
+    new_ddl = _replace_engine_with_rmt(new_ddl)
+
+    log.info(f"  {table}: creating shadow table")
+    client.command(f"DROP TABLE IF EXISTS `{shadow}`")
+    client.command(new_ddl)
+
+    # Everything before EXCHANGE is safely retryable: on any failure drop the
+    # (disposable, pre-swap) shadow and re-raise. After EXCHANGE the shadow
+    # holds real data and must NOT be dropped without a catch-up.
+    try:
+        # Fail closed if the DDL rewrite did not produce the intended engine,
+        # or if it disturbed the sorting key (the dedup key MUST be unchanged:
+        # a different key would silently collapse distinct rows).
+        if _engine_name(client, shadow) != "ReplacingMergeTree":
+            raise RuntimeError(
+                f"{table}: shadow engine is not ReplacingMergeTree after rewrite; "
+                f"aborting"
+            )
+        old_key = _normalize_sorting_key(_sorting_key(client, table))
+        shadow_key = _normalize_sorting_key(_sorting_key(client, shadow))
+        if shadow_key != old_key:
+            raise RuntimeError(
+                f"{table}: shadow sorting key changed during engine swap "
+                f"(expected {old_key!r}, got {shadow_key!r}); aborting"
+            )
+
+        log.info(f"  {table}: copying data")
+        client.command(f"INSERT INTO `{shadow}` SELECT * FROM `{table}`")
+
+        # Verify no logical rows were lost before swapping. Raw row counts may
+        # legitimately differ (the RMT copy collapses not-yet-merged duplicate
+        # versions of the SAME key — exactly the dedup we want), so compare the
+        # number of distinct sorting-key tuples, which must be identical.
+        key_columns = _key_columns(old_key)
+        src_keys = _distinct_key_count(client, table, key_columns)
+        dst_keys = _distinct_key_count(client, shadow, key_columns)
+        if dst_keys != src_keys:
+            raise RuntimeError(
+                f"{table}: shadow copy distinct-key mismatch "
+                f"(source={src_keys}, shadow={dst_keys}); aborting before swap"
+            )
+        log.info(
+            f"  {table}: distinct sorting-key tuples verified "
+            f"(source={src_keys}, shadow={dst_keys})"
+        )
+    except Exception:
+        try:
+            client.command(f"DROP TABLE IF EXISTS `{shadow}`")
+        except Exception as cleanup_err:  # pragma: no cover - best effort
+            log.warning(f"  {table}: shadow table cleanup failed: {cleanup_err}")
+        raise
+
+    log.info(f"  {table}: atomic swap via EXCHANGE TABLES")
+    client.command(f"EXCHANGE TABLES `{table}` AND `{shadow}`")
+
+    # From here on the shadow is the OLD table; never drop it without the
+    # catch-up. If this fails, the rerun skip path converges it.
+    _catch_up_and_drop(client, table, shadow)
+
+    log.info(f"  {table}: done")
+
+
+def upgrade(client):
+    """Convert work-item daily rollups to ReplacingMergeTree(computed_at)."""
+    log.info("=== Migration 055: idempotent work-item daily rollups (CHAOS-2645) ===")
+
+    total = len(TABLES)
+    for i, table in enumerate(TABLES, 1):
+        log.info(f"[{i}/{total}] {table}")
+        try:
+            _rebuild_table(client, table)
+        except Exception as exc:
+            # No blanket shadow cleanup: pre-EXCHANGE failures already dropped
+            # their disposable shadow inside _rebuild_table; a post-EXCHANGE
+            # failure leaves `<table>_new` holding the OLD data — dropping it
+            # would lose the catch-up delta. The rerun skip path converges it.
+            log.error(f"FAILED on {table}: {exc}")
+            raise
+
+    log.info("=== Migration 055: Complete ===")

--- a/src/dev_health_ops/providers/_ratelimit.py
+++ b/src/dev_health_ops/providers/_ratelimit.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any
 
 from dev_health_ops.connectors.utils.rate_limit_queue import RateLimitGate
@@ -62,6 +64,41 @@ def gate_call(
         gate.reset()
 
 
+def parse_retry_after_header(headers: Any) -> float | None:
+    """Parse an HTTP ``Retry-After`` header into seconds.
+
+    Handles both supported forms: a delta in seconds (e.g. ``"120"``) and an
+    HTTP-date (e.g. ``"Wed, 21 Oct 2025 07:28:00 GMT"``). Returns ``None`` when
+    the header is absent or unparseable. Negative results are clamped to 0.
+    """
+    if headers is None:
+        return None
+    try:
+        raw = headers.get("Retry-After")
+    except AttributeError:
+        return None
+    if raw is None:
+        return None
+    raw = str(raw).strip()
+    if not raw:
+        return None
+    # Delta-seconds form.
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        pass
+    # HTTP-date form.
+    try:
+        when = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if when is None:
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
+
+
 def penalize_from_response(
     gate: RateLimitGate, response: Any, *, default: float | None = None
 ) -> float:
@@ -70,11 +107,8 @@ def penalize_from_response(
     Returns the applied delay (seconds). ``response`` is any object with a
     ``headers`` mapping. Invalid / missing headers fall back to ``default``.
     """
-    retry_after = default
-    try:
-        raw = response.headers.get("Retry-After") if response is not None else None
-        if raw is not None:
-            retry_after = float(raw)
-    except (TypeError, ValueError):
+    headers = getattr(response, "headers", None) if response is not None else None
+    retry_after = parse_retry_after_header(headers)
+    if retry_after is None:
         retry_after = default
     return gate.penalize(retry_after)

--- a/src/dev_health_ops/providers/gitlab/client.py
+++ b/src/dev_health_ops/providers/gitlab/client.py
@@ -12,10 +12,56 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitGate,
     create_rate_limit_gate,
 )
-from dev_health_ops.providers._ratelimit import gate_call
+from dev_health_ops.exceptions import RateLimitException
+from dev_health_ops.providers._ratelimit import gate_call, parse_retry_after_header
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 
 logger = logging.getLogger(__name__)
+
+
+def _maybe_raise_gitlab_rate_limit(exc: BaseException) -> None:
+    """Raise RateLimitException if exc is a GitLab rate-limit error (HTTP 429,
+    or 403 carrying rate-limit headers); otherwise return None so callers
+    continue their existing handling."""
+    import gitlab  # python-gitlab; keep lazy to match existing import semantics
+
+    if isinstance(exc, RateLimitException):
+        raise exc
+    if not isinstance(exc, gitlab.exceptions.GitlabError):
+        return None
+    status = getattr(exc, "response_code", None)
+    headers = getattr(exc, "response_headers", None) or {}
+    retry_after = parse_retry_after_header(headers)
+
+    def _hdr(name: str) -> str | None:
+        try:
+            return headers.get(name)
+        except AttributeError:
+            return None
+
+    is_rate_limited = status == 429 or (
+        status == 403
+        and (
+            retry_after is not None
+            or str(_hdr("RateLimit-Remaining")) == "0"
+            or _hdr("Retry-After") is not None
+        )
+    )
+    if not is_rate_limited:
+        return None
+    # Prefer Retry-After; else derive from RateLimit-Reset (epoch seconds) if present.
+    if retry_after is None:
+        reset_raw = _hdr("RateLimit-Reset")
+        if reset_raw is not None:
+            try:
+                import time as _t
+
+                retry_after = max(0.0, float(reset_raw) - _t.time())
+            except (TypeError, ValueError):
+                retry_after = None
+    raise RateLimitException(
+        f"GitLab rate limited (HTTP {status})", retry_after_seconds=retry_after
+    ) from exc
 
 
 class _ListManager(Protocol):
@@ -95,8 +141,12 @@ class GitLabWorkClient:
         )
 
     def get_project(self, project_id_or_path: str) -> Any:
-        with gate_call(self.gate):
-            return self.gl.projects.get(project_id_or_path)
+        try:
+            with gate_call(self.gate):
+                return self.gl.projects.get(project_id_or_path)
+        except Exception as exc:
+            _maybe_raise_gitlab_rate_limit(exc)
+            raise
 
     def _gated_iter(self, iterable: Any) -> Iterator[Any]:
         """Consume a python-gitlab lazy iterator with each page fetch routed
@@ -107,11 +157,17 @@ class GitLabWorkClient:
         """
         iterator = iter(iterable)
         while True:
-            with gate_call(self.gate):
-                try:
-                    item = next(iterator)
-                except StopIteration:
-                    return
+            try:
+                with gate_call(self.gate):
+                    try:
+                        item = next(iterator)
+                    except StopIteration:
+                        return
+            except StopIteration:
+                return
+            except Exception as exc:
+                _maybe_raise_gitlab_rate_limit(exc)
+                raise
             yield item
 
     def iter_project_issues(
@@ -169,6 +225,7 @@ class GitLabWorkClient:
                 notes = list(issue.notes.list(per_page=100, iterator=True))[:limit]
             return notes
         except Exception as exc:
+            _maybe_raise_gitlab_rate_limit(exc)
             logger.debug("Failed to fetch issue notes: %s", exc)
             return []
 
@@ -184,6 +241,7 @@ class GitLabWorkClient:
                 notes = list(mr.notes.list(per_page=100, iterator=True))[:limit]
             return notes
         except Exception as exc:
+            _maybe_raise_gitlab_rate_limit(exc)
             logger.debug("Failed to fetch MR notes: %s", exc)
             return []
 
@@ -201,6 +259,7 @@ class GitLabWorkClient:
                 )[:limit]
             return events
         except Exception as exc:
+            _maybe_raise_gitlab_rate_limit(exc)
             logger.debug("Failed to fetch issue label events: %s", exc)
             return []
 
@@ -218,6 +277,7 @@ class GitLabWorkClient:
                 )[:limit]
             return events
         except Exception as exc:
+            _maybe_raise_gitlab_rate_limit(exc)
             logger.debug("Failed to fetch issue state events: %s", exc)
             return []
 
@@ -235,6 +295,7 @@ class GitLabWorkClient:
                 )[:limit]
             return events
         except Exception as exc:
+            _maybe_raise_gitlab_rate_limit(exc)
             logger.debug("Failed to fetch MR state events: %s", exc)
             return []
 
@@ -248,6 +309,7 @@ class GitLabWorkClient:
                 links = list(issue.links.list(per_page=100, iterator=True))
             return links
         except Exception as exc:
+            _maybe_raise_gitlab_rate_limit(exc)
             logger.debug("Failed to fetch issue links: %s", exc)
             return []
 
@@ -277,6 +339,7 @@ class GitLabWorkClient:
                 milestones = group.milestones.list(state=state, iterator=True)
             yield from self._gated_iter(milestones)
         except Exception as exc:
+            _maybe_raise_gitlab_rate_limit(exc)
             logger.debug("Failed to fetch group milestones: %s", exc)
             return
 
@@ -286,8 +349,12 @@ class GitLabWorkClient:
 
     def get_group(self, group_id_or_path: str) -> Any:
         """Get a GitLab group by ID or path."""
-        with gate_call(self.gate):
-            return self.gl.groups.get(group_id_or_path)
+        try:
+            with gate_call(self.gate):
+                return self.gl.groups.get(group_id_or_path)
+        except Exception as exc:
+            _maybe_raise_gitlab_rate_limit(exc)
+            raise
 
     def iter_group_epics(
         self,
@@ -328,6 +395,7 @@ class GitLabWorkClient:
                 if limit is not None and count >= int(limit):
                     return
         except Exception as exc:
+            _maybe_raise_gitlab_rate_limit(exc)
             # Epics require GitLab Premium/Ultimate - gracefully handle
             if "403" in str(exc) or "404" in str(exc):
                 logger.debug(
@@ -351,6 +419,7 @@ class GitLabWorkClient:
                 notes = list(epic.notes.list(per_page=100, iterator=True))[:limit]
             return notes
         except Exception as exc:
+            _maybe_raise_gitlab_rate_limit(exc)
             logger.debug("Failed to fetch epic notes: %s", exc)
             return []
 
@@ -368,6 +437,7 @@ class GitLabWorkClient:
                 issues = list(epic.issues.list(per_page=100, iterator=True))
             return issues
         except Exception as exc:
+            _maybe_raise_gitlab_rate_limit(exc)
             logger.debug("Failed to fetch epic issues: %s", exc)
             return []
 
@@ -385,5 +455,6 @@ class GitLabWorkClient:
                 )[:limit]
             return events
         except Exception as exc:
+            _maybe_raise_gitlab_rate_limit(exc)
             logger.debug("Failed to fetch epic state events: %s", exc)
             return []

--- a/src/dev_health_ops/providers/jira/client.py
+++ b/src/dev_health_ops/providers/jira/client.py
@@ -11,7 +11,11 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitGate,
     create_rate_limit_gate,
 )
-from dev_health_ops.providers._ratelimit import penalize_from_response
+from dev_health_ops.exceptions import RateLimitException
+from dev_health_ops.providers._ratelimit import (
+    parse_retry_after_header,
+    penalize_from_response,
+)
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 
 logger = logging.getLogger(__name__)
@@ -140,6 +144,7 @@ class JiraClient:
                     url, params=params, timeout=self.timeout_seconds
                 )
                 if resp.status_code == 429:
+                    retry_after = parse_retry_after_header(resp.headers)
                     applied = penalize_from_response(self.gate, resp)
                     logger.info(
                         "Jira rate limited; backoff %.1fs (HTTP 429, attempt %d/%d)",
@@ -149,6 +154,10 @@ class JiraClient:
                     )
                     if attempt + 1 < attempts:
                         continue
+                    raise RateLimitException(
+                        f"Jira rate limited: giving up after {attempts} attempts (HTTP 429)",
+                        retry_after_seconds=retry_after,
+                    )
                 resp.raise_for_status()
                 self.gate.reset()
                 data = resp.json()

--- a/src/dev_health_ops/providers/linear/client.py
+++ b/src/dev_health_ops/providers/linear/client.py
@@ -15,6 +15,7 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitGate,
     create_rate_limit_gate,
 )
+from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.providers._ratelimit import gate_call
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 
@@ -41,7 +42,7 @@ class LinearComplexityLimitError(LinearGraphQLError):
     """
 
 
-class LinearRateLimitError(RuntimeError):
+class LinearRateLimitError(RateLimitException):
     """Linear kept returning HTTP 429 after exhausting all retry attempts."""
 
 
@@ -428,6 +429,7 @@ class LinearClient:
             payload["variables"] = variables
 
         last_delay = 0.0
+        last_server_retry_after: float | None = None
         for attempt in range(1, self.max_attempts + 1):
             try:
                 with gate_call(self.gate):
@@ -437,6 +439,8 @@ class LinearClient:
                     if response.status_code == 429:
                         raise _LinearHTTPRateLimit(self._retry_after_seconds(response))
             except _LinearHTTPRateLimit as exc:
+                if exc.retry_after_seconds is not None:
+                    last_server_retry_after = exc.retry_after_seconds
                 last_delay = self._last_applied_delay(exc.retry_after_seconds)
                 logger.warning(
                     "Linear rate limit hit (attempt %d/%d), backing off %.1fs",
@@ -460,7 +464,10 @@ class LinearClient:
 
         raise LinearRateLimitError(
             f"Linear API rate limited: giving up after {self.max_attempts} "
-            f"attempts (last backoff {last_delay:.1f}s)"
+            f"attempts (last backoff {last_delay:.1f}s)",
+            retry_after_seconds=last_server_retry_after
+            if last_server_retry_after is not None
+            else last_delay,
         )
 
     def _last_applied_delay(self, retry_after_seconds: float | None) -> float:

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -412,7 +412,7 @@ class ClickHouseStore:
           day, provider, work_scope_id, user_identity, team_id, team_name,
           items_started, items_completed, wip_count_end_of_day,
           cycle_time_p50_hours, cycle_time_p90_hours, computed_at
-        FROM work_item_user_metrics_daily
+        FROM work_item_user_metrics_daily FINAL
         {where}
         """
 

--- a/src/dev_health_ops/workers/rate_limit_defer.py
+++ b/src/dev_health_ops/workers/rate_limit_defer.py
@@ -1,0 +1,209 @@
+"""Rate-limit deferral helpers for Celery sync tasks.
+
+Provider rate-limit signals (HTTP 429 / ``Retry-After``) are treated as
+*deferred work*, not task failures. Instead of consuming the genuine-failure
+retry budget (Celery's single ``self.request.retries`` counter) and stamping
+the run ``FAILED``, the sync tasks re-enqueue a fresh invocation with the
+server-provided delay and explicit rate-limit budget metadata.
+
+Two budgets bound the deferral so a permanently rate-limited provider still
+eventually surfaces as a real failure:
+
+* a **count** budget (:data:`RATE_LIMIT_MAX_DEFERRALS`), incremented once per
+  provider 429, and
+* a **wall-clock** budget (:data:`RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS`) measured
+  from the first deferral.
+
+Long server delays (e.g. GitHub primary-limit resets up to ~1h) are *chunked*:
+a single Celery countdown is capped at :data:`RATE_LIMIT_MAX_COUNTDOWN_SECONDS`
+and an absolute ``not_before`` timestamp is carried forward so the task
+re-defers **without calling the provider again** until the window elapses.
+Chunk re-defers do not count against the count budget.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from dev_health_ops.exceptions import RateLimitException
+
+logger = logging.getLogger(__name__)
+
+# Bound total deferral by count AND wall-clock so a permanently rate-limited
+# provider eventually becomes a real failure rather than looping forever.
+RATE_LIMIT_MAX_DEFERRALS = 10
+RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS = 2 * 60 * 60  # 2 hours
+
+# A single Celery countdown chunk. Kept at/below the distributed gate's Redis
+# TTL (``RateLimitConfig.max_backoff_seconds * 2`` == 600s) so a deferral never
+# outlives the shared cooldown key. Longer server delays are chunked via
+# ``not_before`` and re-deferred without re-calling the provider.
+RATE_LIMIT_MAX_COUNTDOWN_SECONDS = 600.0
+
+# Used when the provider signalled a rate limit without a usable delay value.
+RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS = 60.0
+
+# Additive jitter (0..N seconds) de-correlates many orgs/tasks waking against
+# the same provider at once (thundering-herd mitigation at the re-enqueue
+# layer, keeping the frozen ``connectors`` gate untouched).
+RATE_LIMIT_JITTER_SECONDS = 5.0
+
+
+@dataclass(frozen=True)
+class RateLimitDeferral:
+    """A planned re-enqueue of a rate-limited sync task."""
+
+    countdown: float
+    """Seconds to pass to ``apply_async(countdown=...)`` (jittered, chunked)."""
+
+    attempts: int
+    """Updated deferral count to carry forward in task kwargs."""
+
+    first_seen_at: str
+    """ISO-8601 timestamp of the first deferral, carried forward unchanged."""
+
+    not_before: str
+    """ISO-8601 absolute time before which the provider must not be called."""
+
+
+def _now(now: datetime | None) -> datetime:
+    return now or datetime.now(timezone.utc)
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _jittered(seconds: float) -> float:
+    # Not security-sensitive: jitter only de-correlates retry timing.
+    return max(0.0, seconds + random.uniform(0.0, RATE_LIMIT_JITTER_SECONDS))  # noqa: S311
+
+
+def plan_rate_limit_deferral(
+    *,
+    retry_after_seconds: float | None,
+    attempts: int,
+    first_seen_at: str | None,
+    now: datetime | None = None,
+) -> RateLimitDeferral | None:
+    """Plan the next deferral for a provider 429, or ``None`` when exhausted.
+
+    ``None`` means the count/wall-clock budget is spent: callers must fall
+    through to normal failure handling (stamp the run failed, etc.).
+    """
+    current = _now(now)
+    first_seen = _parse_iso(first_seen_at) or current
+    elapsed = (current - first_seen).total_seconds()
+
+    if attempts >= RATE_LIMIT_MAX_DEFERRALS:
+        return None
+    if elapsed >= RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS:
+        return None
+
+    delay = retry_after_seconds
+    if delay is None or delay <= 0:
+        delay = RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS
+
+    # Never schedule a wait that runs past the wall-clock deadline.
+    remaining_budget = RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS - elapsed
+    delay = min(float(delay), remaining_budget)
+
+    not_before_ts = current.timestamp() + delay
+    countdown = _jittered(min(delay, RATE_LIMIT_MAX_COUNTDOWN_SECONDS))
+
+    return RateLimitDeferral(
+        countdown=countdown,
+        attempts=attempts + 1,
+        first_seen_at=first_seen.isoformat(),
+        not_before=datetime.fromtimestamp(not_before_ts, tz=timezone.utc).isoformat(),
+    )
+
+
+def plan_not_before_wait(
+    not_before: str | None,
+    *,
+    now: datetime | None = None,
+) -> float | None:
+    """Countdown to re-defer a chunked wait, or ``None`` to proceed now.
+
+    Called at the top of a sync task: if a carried ``not_before`` is still in
+    the future, return the (chunked, jittered) countdown so the task
+    re-enqueues itself **without calling the provider**; otherwise ``None``.
+    """
+    target = _parse_iso(not_before)
+    if target is None:
+        return None
+    remaining = (target - _now(now)).total_seconds()
+    if remaining <= 0:
+        return None
+    return _jittered(min(remaining, RATE_LIMIT_MAX_COUNTDOWN_SECONDS))
+
+
+def rate_limit_metadata(deferral: RateLimitDeferral) -> dict[str, object]:
+    """Build the ``_rate_limit_*`` kwargs to carry into the re-enqueued task."""
+    return {
+        "_rate_limit_attempts": deferral.attempts,
+        "_rate_limit_first_seen_at": deferral.first_seen_at,
+        "_rate_limit_not_before": deferral.not_before,
+    }
+
+
+def maybe_plan_rate_limit_deferral(
+    exc: BaseException,
+    *,
+    attempts: int,
+    first_seen_at: str | None,
+    now: datetime | None = None,
+) -> RateLimitDeferral | None:
+    """Plan a deferral for a caught exception, or ``None``.
+
+    Returns ``None`` when ``exc`` is not a rate-limit error OR the deferral
+    budget is exhausted; in both cases the caller must run its normal failure
+    handling. Returns a :class:`RateLimitDeferral` when the task should be
+    re-enqueued instead of failed.
+    """
+    if not isinstance(exc, RateLimitException):
+        return None
+    return plan_rate_limit_deferral(
+        retry_after_seconds=getattr(exc, "retry_after_seconds", None),
+        attempts=attempts,
+        first_seen_at=first_seen_at,
+        now=now,
+    )
+
+
+def reenqueue_after_rate_limit(task: Any, deferral: RateLimitDeferral) -> None:
+    """Re-enqueue a fresh run of ``task`` carrying updated deferral metadata."""
+    request = task.request
+    task.apply_async(
+        args=list(request.args or []),
+        kwargs={**(request.kwargs or {}), **rate_limit_metadata(deferral)},
+        countdown=deferral.countdown,
+    )
+
+
+def reenqueue_rate_limit_chunk(task: Any, countdown: float) -> None:
+    """Re-enqueue ``task`` unchanged to wait out a chunked ``not_before`` window.
+
+    Used when a carried ``not_before`` is still in the future: the provider is
+    NOT called; the task simply re-defers itself. Deferral metadata is
+    preserved as-is (the count budget is not consumed by chunk waits).
+    """
+    request = task.request
+    task.apply_async(
+        args=list(request.args or []),
+        kwargs=dict(request.kwargs or {}),
+        countdown=countdown,
+    )

--- a/src/dev_health_ops/workers/recommendations_tasks.py
+++ b/src/dev_health_ops/workers/recommendations_tasks.py
@@ -125,7 +125,7 @@ def _discover_team_ids(client: Any, org_id: str) -> list[str]:
     """
     query = """
         SELECT DISTINCT team_id
-        FROM work_item_metrics_daily
+        FROM work_item_metrics_daily FINAL
         WHERE day >= today() - 30
           AND team_id != ''
     """

--- a/src/dev_health_ops/workers/sync_backfill.py
+++ b/src/dev_health_ops/workers/sync_backfill.py
@@ -7,6 +7,12 @@ from typing import Any
 
 from dev_health_ops.exceptions import AuthenticationException
 from dev_health_ops.workers.celery_app import celery_app
+from dev_health_ops.workers.rate_limit_defer import (
+    maybe_plan_rate_limit_deferral,
+    plan_not_before_wait,
+    reenqueue_after_rate_limit,
+    reenqueue_rate_limit_chunk,
+)
 from dev_health_ops.workers.task_utils import (
     _as_str_list,
     _credential_mapping,
@@ -219,6 +225,10 @@ def run_backfill(
     org_id: str,
     backfill_job_id: str | None = None,
     pending_run_id: str | None = None,
+    *,
+    _rate_limit_attempts: int = 0,
+    _rate_limit_first_seen_at: str | None = None,
+    _rate_limit_not_before: str | None = None,
 ) -> dict:
     from dev_health_ops.backfill.runner import (
         run_backfill_for_config,
@@ -230,6 +240,11 @@ def run_backfill(
 
     sync_config_uuid = uuid.UUID(sync_config_id)
     started_at = datetime.now(timezone.utc)
+
+    wait = plan_not_before_wait(_rate_limit_not_before)
+    if wait is not None:
+        reenqueue_rate_limit_chunk(self, wait)
+        return {"status": "rate_limited_deferred", "reason": "not_before"}
 
     try:
         provider = ""
@@ -439,6 +454,24 @@ def run_backfill(
             "result": result_payload,
         }
     except Exception as exc:
+        deferral = maybe_plan_rate_limit_deferral(
+            exc,
+            attempts=_rate_limit_attempts,
+            first_seen_at=_rate_limit_first_seen_at,
+        )
+        if deferral is not None:
+            logger.warning(
+                "Backfill rate-limited (sync_config_id=%s); deferring %.1fs "
+                "(deferral %d)",
+                sync_config_id,
+                deferral.countdown,
+                deferral.attempts,
+            )
+            reenqueue_after_rate_limit(self, deferral)
+            return {
+                "status": "rate_limited_deferred",
+                "retry_after_seconds": deferral.countdown,
+            }
         logger.exception(
             "Backfill task failed: sync_config_id=%s org_id=%s error=%s",
             sync_config_id,

--- a/src/dev_health_ops/workers/sync_misc.py
+++ b/src/dev_health_ops/workers/sync_misc.py
@@ -4,6 +4,12 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 from dev_health_ops.workers.celery_app import celery_app
+from dev_health_ops.workers.rate_limit_defer import (
+    maybe_plan_rate_limit_deferral,
+    plan_not_before_wait,
+    reenqueue_after_rate_limit,
+    reenqueue_rate_limit_chunk,
+)
 from dev_health_ops.workers.task_utils import _get_db_url, _invalidate_sync_cache
 
 logger = logging.getLogger(__name__)
@@ -21,6 +27,10 @@ def run_work_items_sync(
     provider: str = "auto",
     since_days: int = 30,
     org_id: str = "",
+    *,
+    _rate_limit_attempts: int = 0,
+    _rate_limit_first_seen_at: str | None = None,
+    _rate_limit_not_before: str | None = None,
 ) -> dict:
     """
     Sync work items from external providers.
@@ -33,6 +43,11 @@ def run_work_items_sync(
     Returns:
         dict with sync status and counts
     """
+
+    wait = plan_not_before_wait(_rate_limit_not_before)
+    if wait is not None:
+        reenqueue_rate_limit_chunk(self, wait)
+        return {"status": "rate_limited_deferred", "reason": "not_before"}
 
     db_url = db_url or _get_db_url()
     since = datetime.now(timezone.utc) - timedelta(days=since_days)
@@ -64,5 +79,24 @@ def run_work_items_sync(
             "since_days": since_days,
         }
     except Exception as exc:
+        deferral = maybe_plan_rate_limit_deferral(
+            exc,
+            attempts=_rate_limit_attempts,
+            first_seen_at=_rate_limit_first_seen_at,
+        )
+        if deferral is not None:
+            logger.warning(
+                "Work items sync rate-limited (provider=%s); deferring %.1fs "
+                "(deferral %d)",
+                provider,
+                deferral.countdown,
+                deferral.attempts,
+            )
+            reenqueue_after_rate_limit(self, deferral)
+            return {
+                "status": "rate_limited_deferred",
+                "provider": provider,
+                "retry_after_seconds": deferral.countdown,
+            }
         logger.exception("Work items sync task failed: %s", exc)
         raise self.retry(exc=exc, countdown=60 * (2**self.request.retries))

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -22,6 +22,12 @@ from dev_health_ops.utils.datetime import utc_today
 from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.org_guard import organization_exists_sync
+from dev_health_ops.workers.rate_limit_defer import (
+    maybe_plan_rate_limit_deferral,
+    plan_not_before_wait,
+    reenqueue_after_rate_limit,
+    reenqueue_rate_limit_chunk,
+)
 from dev_health_ops.workers.task_utils import (
     _GIT_TARGETS,
     _WORK_ITEM_TARGETS,
@@ -684,7 +690,16 @@ def run_sync_config(
     org_id: str,
     triggered_by: str = "manual",
     pending_run_id: str | None = None,
+    *,
+    _rate_limit_attempts: int = 0,
+    _rate_limit_first_seen_at: str | None = None,
+    _rate_limit_not_before: str | None = None,
 ) -> dict:
+    wait = plan_not_before_wait(_rate_limit_not_before)
+    if wait is not None:
+        reenqueue_rate_limit_chunk(self, wait)
+        return {"status": "rate_limited_deferred", "reason": "not_before"}
+
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.metrics.job_work_items import run_work_items_sync_job
     from dev_health_ops.models.settings import (
@@ -1163,6 +1178,24 @@ def run_sync_config(
         }
 
     except Exception as exc:
+        deferral = maybe_plan_rate_limit_deferral(
+            exc,
+            attempts=_rate_limit_attempts,
+            first_seen_at=_rate_limit_first_seen_at,
+        )
+        if deferral is not None:
+            logger.warning(
+                "Sync config rate-limited (config_id=%s); deferring %.1fs "
+                "(deferral %d)",
+                config_id,
+                deferral.countdown,
+                deferral.attempts,
+            )
+            reenqueue_after_rate_limit(self, deferral)
+            return {
+                "status": "rate_limited_deferred",
+                "retry_after_seconds": deferral.countdown,
+            }
         logger.exception(
             "Sync config task failed: config_id=%s org_id=%s error=%s",
             config_id,

--- a/tests/api/queries/test_rerun_rollup_dedup.py
+++ b/tests/api/queries/test_rerun_rollup_dedup.py
@@ -1,0 +1,149 @@
+"""CHAOS-2645: variable-table readers must dedup the ReplacingMergeTree rollups.
+
+The static guard (``tests/test_rerun_dedup_guard.py``) catches literal
+``FROM <table>`` reads, but the quadrant and people query builders take the
+table name as a parameter (``FROM {table}``), so the guard cannot see them.
+These tests invoke those builders and assert the emitted SQL applies ``FINAL``
+for the two re-run-deduplicated tables (and NOT for a plain ``MergeTree``
+table), and that the metric-config path dedups via ``argMax(..., computed_at)``.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, cast
+
+import pytest
+
+import dev_health_ops.connectors  # noqa: F401  # break providers<->connectors cycle
+from dev_health_ops.api.queries import metrics, people, quadrant
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+
+def _capture(monkeypatch: pytest.MonkeyPatch, module: Any) -> dict[str, str]:
+    captured: dict[str, str] = {}
+
+    async def fake_query_dicts(
+        _sink: Any, query: str, _params: Any = None
+    ) -> list[Any]:
+        captured["query"] = query
+        return []
+
+    monkeypatch.setattr(module, "query_dicts", fake_query_dicts)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_quadrant_metric_dedups_rmt_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _capture(monkeypatch, quadrant)
+    await quadrant.fetch_quadrant_metric(
+        cast(BaseMetricsSink, object()),
+        table="work_item_metrics_daily",
+        value_expr="sum(items_completed)",
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        bucket="week",
+        entity_expr="team_id",
+        label_expr="team_name",
+        org_id="org-a",
+    )
+    assert "work_item_metrics_daily FINAL" in captured["query"]
+
+
+@pytest.mark.asyncio
+async def test_quadrant_metric_leaves_plain_mergetree_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _capture(monkeypatch, quadrant)
+    await quadrant.fetch_quadrant_metric(
+        cast(BaseMetricsSink, object()),
+        table="repo_metrics_daily",
+        value_expr="sum(commits)",
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        bucket="week",
+        entity_expr="repo_id",
+        label_expr="repo_id",
+        org_id="org-a",
+    )
+    assert "FINAL" not in captured["query"]
+
+
+@pytest.mark.asyncio
+async def test_person_metric_value_dedups_rmt_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _capture(monkeypatch, people)
+    await people.fetch_person_metric_value(
+        cast(BaseMetricsSink, object()),
+        table="work_item_user_metrics_daily",
+        column="items_completed",
+        aggregator="sum",
+        identity_column="user_identity",
+        identities=["alice"],
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        org_id="org-a",
+    )
+    assert "work_item_user_metrics_daily FINAL" in captured["query"]
+
+
+@pytest.mark.asyncio
+async def test_person_metric_series_dedups_rmt_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _capture(monkeypatch, people)
+    await people.fetch_person_metric_series(
+        cast(BaseMetricsSink, object()),
+        table="work_item_user_metrics_daily",
+        column="items_completed",
+        aggregator="sum",
+        identity_column="user_identity",
+        identities=["alice"],
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        org_id="org-a",
+    )
+    assert "work_item_user_metrics_daily FINAL" in captured["query"]
+
+
+@pytest.mark.asyncio
+async def test_person_breakdown_dedups_rmt_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _capture(monkeypatch, people)
+    await people.fetch_person_breakdown(
+        cast(BaseMetricsSink, object()),
+        table="work_item_user_metrics_daily",
+        column="items_completed",
+        aggregator="sum",
+        identity_column="user_identity",
+        identities=["alice"],
+        group_expr="team_id",
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        org_id="org-a",
+    )
+    assert "work_item_user_metrics_daily FINAL" in captured["query"]
+
+
+@pytest.mark.asyncio
+async def test_metric_series_argmax_dedups_rmt_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _capture(monkeypatch, metrics)
+    await metrics.fetch_metric_series(
+        cast(BaseMetricsSink, object()),
+        table="work_item_metrics_daily",
+        column="items_completed",
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        scope_filter="",
+        scope_params={},
+        aggregator="sum",
+        org_id="org-a",
+    )
+    normalized = " ".join(captured["query"].split())
+    assert "argMax(items_completed, computed_at)" in normalized

--- a/tests/api/queries/test_state_durations_dedup.py
+++ b/tests/api/queries/test_state_durations_dedup.py
@@ -210,6 +210,7 @@ async def test_fetch_metric_value_leaves_other_tables_flat(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # The generic reader must NOT add argMax dedup for unaffected tables.
+    # (repo_metrics_daily is plain MergeTree, not in _DEDUP_BY_COMPUTED_AT.)
     captured: dict[str, str] = {}
 
     async def fake_query_dicts(_client: Any, query: str, _params: Any) -> list[Any]:
@@ -220,7 +221,7 @@ async def test_fetch_metric_value_leaves_other_tables_flat(
 
     await metrics.fetch_metric_value(
         cast(BaseMetricsSink, object()),
-        table="work_item_metrics_daily",
+        table="repo_metrics_daily",
         column="items_completed",
         start_day=date(2026, 5, 1),
         end_day=date(2026, 5, 2),
@@ -233,7 +234,7 @@ async def test_fetch_metric_value_leaves_other_tables_flat(
     normalized = " ".join(captured["query"].split())
     assert "argMax" not in normalized
     assert _NATURAL_KEY_GROUP_BY not in normalized
-    assert "FROM work_item_metrics_daily WHERE" in normalized
+    assert "FROM repo_metrics_daily WHERE" in normalized
 
 
 # --- /explain root-cause readers (CHAOS-2377 re-review) ----------------------

--- a/tests/providers/test_gitlab_client_ratelimit.py
+++ b/tests/providers/test_gitlab_client_ratelimit.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 
 from dev_health_ops.connectors.utils.rate_limit_queue import RateLimitGate
+from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.providers.gitlab.client import GitLabAuth, GitLabWorkClient
 
 
@@ -54,3 +55,68 @@ def test_gated_iter_penalizes_when_a_later_page_fetch_raises() -> None:
 
     assert collected == [{"id": 1}]
     gate.penalize.assert_called()
+
+
+def _gitlab_error(status: int = 429) -> Exception:
+    import gitlab
+
+    # python-gitlab (8.x) exposes response_code/response_body but NOT
+    # response_headers, so a real GitLab 429 carries no Retry-After we can read;
+    # detection is by status and the worker defers with its default backoff.
+    # (python-gitlab already does header-aware sleeping internally before it
+    # raises, so the precise server delay is consumed there.)
+    return gitlab.exceptions.GitlabError("rate limited", response_code=status)
+
+
+def test_gated_iter_raises_rate_limit_on_gitlab_429() -> None:
+    # A python-gitlab 429 during page consumption must surface as the canonical
+    # RateLimitException, not the raw GitlabError (and must not be swallowed).
+    gate = MagicMock(spec=RateLimitGate)
+    gate.penalize.return_value = 5.0
+    client = _make_client(gate)
+    err = _gitlab_error(status=429)
+
+    def _lazy_pages() -> Any:
+        yield {"id": 1}
+        raise err
+
+    with pytest.raises(RateLimitException):
+        list(client._gated_iter(_lazy_pages()))
+
+    gate.penalize.assert_called()
+
+
+def test_enrichment_reraises_rate_limit_instead_of_swallowing() -> None:
+    # Enrichment getters must NOT swallow a 429 as "missing optional data".
+    gate = MagicMock(spec=RateLimitGate)
+    client = _make_client(gate)
+    issue = MagicMock()
+    issue.notes.list.side_effect = _gitlab_error(status=429)
+
+    with pytest.raises(RateLimitException):
+        client.get_issue_notes(issue)
+
+
+def test_enrichment_still_swallows_non_rate_limit_errors() -> None:
+    # Non-rate-limit failures keep the existing graceful-degradation behavior.
+    gate = MagicMock(spec=RateLimitGate)
+    client = _make_client(gate)
+    issue = MagicMock()
+    issue.notes.list.side_effect = RuntimeError("transient parse error")
+
+    assert client.get_issue_notes(issue) == []
+
+
+def test_iter_group_epics_reraises_rate_limit_before_premium_gating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A 429 must raise even though the epics path otherwise swallows 403/404
+    # (Premium/Ultimate gating).
+    gate = MagicMock(spec=RateLimitGate)
+    client = _make_client(gate)
+    group = MagicMock()
+    group.epics.list.side_effect = _gitlab_error(status=429)
+    monkeypatch.setattr(client.gl.groups, "get", MagicMock(return_value=group))
+
+    with pytest.raises(RateLimitException):
+        list(client.iter_group_epics(group_id_or_path="g/sub"))

--- a/tests/providers/test_jira_client_ratelimit.py
+++ b/tests/providers/test_jira_client_ratelimit.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 
 from dev_health_ops.connectors.utils.rate_limit_queue import RateLimitGate
+from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.providers.jira.client import JiraAuth, JiraClient
 
 
@@ -78,16 +79,19 @@ def test_jira_search_page_persistent_429_exhausts_retries_and_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # When 429s never clear, the request is penalized once per attempt and then
-    # surfaces as an HTTPError after the bounded retries are exhausted.
+    # surfaces as a RateLimitException carrying the server Retry-After so the
+    # worker layer can defer (instead of a bare HTTPError that drops the delay).
     gate = MagicMock(spec=RateLimitGate)
     gate.penalize.return_value = 2.0
     client = _make_client(gate, max_retries_429=2)
     mock_get = MagicMock(return_value=_FakeJira429Response())
     monkeypatch.setattr(client.session, "get", mock_get)
 
-    with pytest.raises(requests.HTTPError):
+    with pytest.raises(RateLimitException) as exc_info:
         client.search_issues_page(jql="project = ENG", start_at=0, max_results=50)
 
+    # The Retry-After header ("2") is preserved on the exception.
+    assert exc_info.value.retry_after_seconds == 2.0
     assert mock_get.call_count == 3
     assert gate.wait_sync.call_count == 3
     assert gate.penalize.call_count == 3

--- a/tests/providers/test_ratelimit.py
+++ b/tests/providers/test_ratelimit.py
@@ -10,7 +10,10 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitConfig,
     RateLimitGate,
 )
-from dev_health_ops.providers._ratelimit import gate_call
+from dev_health_ops.providers._ratelimit import (
+    gate_call,
+    parse_retry_after_header,
+)
 
 
 class TestGateCall:
@@ -55,3 +58,43 @@ class TestGateCall:
         with gate_call(gate):
             value = 42
         assert value == 42
+
+
+class TestParseRetryAfterHeader:
+    def test_delta_seconds(self) -> None:
+        assert parse_retry_after_header({"Retry-After": "120"}) == 120.0
+
+    def test_delta_seconds_float(self) -> None:
+        assert parse_retry_after_header({"Retry-After": "12.5"}) == 12.5
+
+    def test_negative_seconds_clamped_to_zero(self) -> None:
+        assert parse_retry_after_header({"Retry-After": "-5"}) == 0.0
+
+    def test_missing_header_returns_none(self) -> None:
+        assert parse_retry_after_header({}) is None
+
+    def test_none_headers_returns_none(self) -> None:
+        assert parse_retry_after_header(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert parse_retry_after_header({"Retry-After": "   "}) is None
+
+    def test_garbage_returns_none(self) -> None:
+        assert parse_retry_after_header({"Retry-After": "soon"}) is None
+
+    def test_http_date_future(self) -> None:
+        from datetime import datetime, timedelta, timezone
+        from email.utils import format_datetime
+
+        future = datetime.now(timezone.utc) + timedelta(seconds=300)
+        result = parse_retry_after_header({"Retry-After": format_datetime(future)})
+        assert result is not None
+        # Allow scheduling slack; should be close to 300s and strictly positive.
+        assert 280.0 <= result <= 300.0
+
+    def test_http_date_past_clamped_to_zero(self) -> None:
+        from datetime import datetime, timedelta, timezone
+        from email.utils import format_datetime
+
+        past = datetime.now(timezone.utc) - timedelta(seconds=300)
+        assert parse_retry_after_header({"Retry-After": format_datetime(past)}) == 0.0

--- a/tests/test_linear_provider.py
+++ b/tests/test_linear_provider.py
@@ -1062,6 +1062,25 @@ class TestLinearClientRetry:
 
         assert client._client.post.call_count == 5
 
+    def test_429_exhaustion_preserves_retry_after(self, sleeps: list[float]) -> None:
+        # On exhaustion the terminal error must carry the server Retry-After as a
+        # canonical RateLimitException so the worker layer can defer on it.
+        from dev_health_ops.exceptions import RateLimitException
+        from dev_health_ops.providers.linear.client import LinearRateLimitError
+
+        client = self._make_client()
+        client._client.post = MagicMock(
+            side_effect=lambda *a, **kw: self._response(
+                429, headers={"Retry-After": "7"}
+            )
+        )
+
+        with pytest.raises(LinearRateLimitError) as exc_info:
+            client._execute("query { viewer { id } }")
+
+        assert isinstance(exc_info.value, RateLimitException)
+        assert exc_info.value.retry_after_seconds == 7.0
+
     def test_429_backoff_grows_exponentially(self, sleeps: list[float]) -> None:
         from dev_health_ops.providers.linear.client import LinearRateLimitError
 

--- a/tests/test_rerun_dedup_guard.py
+++ b/tests/test_rerun_dedup_guard.py
@@ -1,0 +1,77 @@
+"""Static guard: re-run-deduplicated daily rollups must be read with FINAL.
+
+``work_item_metrics_daily`` and ``work_item_user_metrics_daily`` are
+``ReplacingMergeTree(computed_at)`` (ClickHouse migration 055). A sync re-run
+writes a fresh row per ``(sorting-key, day)``; any raw ``FROM`` / ``JOIN`` of
+these tables that is not immediately followed by ``FINAL`` silently
+double-counts those re-runs.
+
+New reads must use :func:`dev_health_ops.clickhouse_dedup.dedup_from` (which
+appends ``FINAL``) or an explicit ``FINAL``. The metric-config read path in
+``api/queries/metrics.py`` instead wraps the tables in a tested
+``argMax(..., computed_at)`` subquery and is allow-listed below.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from dev_health_ops.clickhouse_dedup import RERUN_DEDUPED_DAILY_TABLES
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "dev_health_ops"
+
+# Files allowed to reference these tables in a FROM/JOIN without an adjacent
+# FINAL (they dedup another tested way, or define the helper itself).
+_ALLOWLIST_FILES = {
+    "clickhouse_dedup.py",
+    "api/queries/metrics.py",  # argMax(..., computed_at) dedup subquery (tested)
+}
+# Directories whose files are exempt (migrations operate on backtick-quoted,
+# variable table names, never a literal ``FROM work_item_metrics_daily``).
+_ALLOWLIST_DIRS = ("migrations/",)
+
+
+def _iter_source_files():
+    for ext in ("*.py", "*.sql"):
+        for path in _SRC.rglob(ext):
+            rel = path.relative_to(_SRC).as_posix()
+            if rel in _ALLOWLIST_FILES:
+                continue
+            if any(rel.startswith(d) for d in _ALLOWLIST_DIRS):
+                continue
+            yield rel, path
+
+
+def test_rerun_deduped_rollups_are_read_with_final() -> None:
+    # FROM/JOIN <table> NOT immediately followed by FINAL. \s spans newlines, so
+    # multi-line FROM clauses and a FINAL on the next line are both handled.
+    patterns = {
+        table: re.compile(
+            rf"\b(?:FROM|JOIN)\s+{re.escape(table)}\b(?!\s+FINAL\b)",
+            re.IGNORECASE,
+        )
+        for table in RERUN_DEDUPED_DAILY_TABLES
+    }
+
+    violations: list[str] = []
+    for rel, path in _iter_source_files():
+        text = path.read_text(encoding="utf-8")
+        for table, pattern in patterns.items():
+            for match in pattern.finditer(text):
+                # A FROM/JOIN without an adjacent FINAL is still safe if the
+                # enclosing SELECT deduplicates via argMax(..., computed_at)
+                # (the established CHAOS-2377 pattern). Accept that mechanism.
+                window = text[max(0, match.start() - 800) : match.start()].lower()
+                if "argmax(" in window and "computed_at" in window:
+                    continue
+                line = text.count("\n", 0, match.start()) + 1
+                violations.append(
+                    f"{rel}:{line}: `{match.group(0).strip()}` is missing FINAL "
+                    f"({table} is ReplacingMergeTree; use clickhouse_dedup.dedup_from)"
+                )
+
+    assert not violations, (
+        "Re-run-deduplicated daily rollups read without FINAL "
+        "(double-counts sync re-runs):\n  " + "\n  ".join(sorted(violations))
+    )

--- a/tests/workers/test_rate_limit_defer.py
+++ b/tests/workers/test_rate_limit_defer.py
@@ -1,0 +1,226 @@
+"""Tests for workers.rate_limit_defer deferral planning + re-enqueue glue."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from dev_health_ops.exceptions import RateLimitException
+from dev_health_ops.workers.rate_limit_defer import (
+    RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS,
+    RATE_LIMIT_JITTER_SECONDS,
+    RATE_LIMIT_MAX_COUNTDOWN_SECONDS,
+    RATE_LIMIT_MAX_DEFERRALS,
+    RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS,
+    RateLimitDeferral,
+    maybe_plan_rate_limit_deferral,
+    plan_not_before_wait,
+    plan_rate_limit_deferral,
+    rate_limit_metadata,
+    reenqueue_after_rate_limit,
+    reenqueue_rate_limit_chunk,
+)
+
+NOW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _within_jitter(value: float, base: float) -> bool:
+    return base <= value <= base + RATE_LIMIT_JITTER_SECONDS
+
+
+class TestPlanRateLimitDeferral:
+    def test_basic_uses_server_delay(self) -> None:
+        d = plan_rate_limit_deferral(
+            retry_after_seconds=42.0, attempts=0, first_seen_at=None, now=NOW
+        )
+        assert d is not None
+        assert _within_jitter(d.countdown, 42.0)
+        assert d.attempts == 1
+        # first_seen_at defaults to now on the first deferral.
+        assert d.first_seen_at == NOW.isoformat()
+        # not_before is the absolute time the provider may be called again.
+        expected_not_before = (NOW + timedelta(seconds=42.0)).isoformat()
+        assert d.not_before == expected_not_before
+
+    def test_default_countdown_when_no_server_delay(self) -> None:
+        d = plan_rate_limit_deferral(
+            retry_after_seconds=None, attempts=0, first_seen_at=None, now=NOW
+        )
+        assert d is not None
+        assert _within_jitter(d.countdown, RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS)
+
+    def test_zero_or_negative_delay_uses_default(self) -> None:
+        d = plan_rate_limit_deferral(
+            retry_after_seconds=0.0, attempts=0, first_seen_at=None, now=NOW
+        )
+        assert d is not None
+        assert _within_jitter(d.countdown, RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS)
+
+    def test_count_budget_exhausted_returns_none(self) -> None:
+        assert (
+            plan_rate_limit_deferral(
+                retry_after_seconds=10.0,
+                attempts=RATE_LIMIT_MAX_DEFERRALS,
+                first_seen_at=NOW.isoformat(),
+                now=NOW,
+            )
+            is None
+        )
+
+    def test_wall_clock_budget_exhausted_returns_none(self) -> None:
+        first_seen = NOW - timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS + 1)
+        assert (
+            plan_rate_limit_deferral(
+                retry_after_seconds=10.0,
+                attempts=1,
+                first_seen_at=first_seen.isoformat(),
+                now=NOW,
+            )
+            is None
+        )
+
+    def test_long_delay_is_chunked_but_not_before_is_full(self) -> None:
+        # A 1-hour server delay: countdown is capped to one chunk, while
+        # not_before carries the full window so the task re-defers without
+        # re-calling the provider.
+        d = plan_rate_limit_deferral(
+            retry_after_seconds=3600.0, attempts=0, first_seen_at=None, now=NOW
+        )
+        assert d is not None
+        assert _within_jitter(d.countdown, RATE_LIMIT_MAX_COUNTDOWN_SECONDS)
+        assert d.not_before == (NOW + timedelta(seconds=3600.0)).isoformat()
+
+    def test_first_seen_at_is_preserved(self) -> None:
+        first_seen = (NOW - timedelta(seconds=120)).isoformat()
+        d = plan_rate_limit_deferral(
+            retry_after_seconds=10.0, attempts=2, first_seen_at=first_seen, now=NOW
+        )
+        assert d is not None
+        assert d.first_seen_at == first_seen
+        assert d.attempts == 3
+
+    def test_delay_clamped_to_remaining_wall_clock_budget(self) -> None:
+        # Only 30s of wall-clock budget remains; a 5-min server delay must not
+        # schedule a wait past the deadline.
+        first_seen = NOW - timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS - 30)
+        d = plan_rate_limit_deferral(
+            retry_after_seconds=300.0,
+            attempts=1,
+            first_seen_at=first_seen.isoformat(),
+            now=NOW,
+        )
+        assert d is not None
+        # not_before may not exceed first_seen + total budget.
+        deadline = first_seen + timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS)
+        assert datetime.fromisoformat(d.not_before) <= deadline
+
+
+class TestPlanNotBeforeWait:
+    def test_future_not_before_returns_countdown(self) -> None:
+        not_before = (NOW + timedelta(seconds=45)).isoformat()
+        wait = plan_not_before_wait(not_before, now=NOW)
+        assert wait is not None
+        assert _within_jitter(wait, 45.0)
+
+    def test_future_not_before_is_chunked(self) -> None:
+        not_before = (NOW + timedelta(seconds=3600)).isoformat()
+        wait = plan_not_before_wait(not_before, now=NOW)
+        assert wait is not None
+        assert _within_jitter(wait, RATE_LIMIT_MAX_COUNTDOWN_SECONDS)
+
+    def test_past_not_before_returns_none(self) -> None:
+        not_before = (NOW - timedelta(seconds=1)).isoformat()
+        assert plan_not_before_wait(not_before, now=NOW) is None
+
+    def test_none_returns_none(self) -> None:
+        assert plan_not_before_wait(None, now=NOW) is None
+
+    def test_invalid_returns_none(self) -> None:
+        assert plan_not_before_wait("not-a-timestamp", now=NOW) is None
+
+
+class TestMaybePlanRateLimitDeferral:
+    def test_non_rate_limit_exception_returns_none(self) -> None:
+        assert (
+            maybe_plan_rate_limit_deferral(
+                ValueError("nope"), attempts=0, first_seen_at=None, now=NOW
+            )
+            is None
+        )
+
+    def test_rate_limit_exception_returns_deferral(self) -> None:
+        exc = RateLimitException("throttled", retry_after_seconds=30.0)
+        d = maybe_plan_rate_limit_deferral(exc, attempts=0, first_seen_at=None, now=NOW)
+        assert d is not None
+        assert _within_jitter(d.countdown, 30.0)
+
+    def test_rate_limit_exception_budget_exhausted_returns_none(self) -> None:
+        exc = RateLimitException("throttled", retry_after_seconds=30.0)
+        assert (
+            maybe_plan_rate_limit_deferral(
+                exc,
+                attempts=RATE_LIMIT_MAX_DEFERRALS,
+                first_seen_at=NOW.isoformat(),
+                now=NOW,
+            )
+            is None
+        )
+
+    def test_rate_limit_exception_without_delay_uses_default(self) -> None:
+        exc = RateLimitException("throttled")
+        d = maybe_plan_rate_limit_deferral(exc, attempts=0, first_seen_at=None, now=NOW)
+        assert d is not None
+        assert _within_jitter(d.countdown, RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS)
+
+
+class TestReenqueue:
+    def _task(self) -> MagicMock:
+        task = MagicMock()
+        task.request.args = ["cfg-1", "org-1"]
+        task.request.kwargs = {"pending_run_id": "run-1"}
+        return task
+
+    def test_reenqueue_after_rate_limit_carries_metadata(self) -> None:
+        task = self._task()
+        deferral = RateLimitDeferral(
+            countdown=123.0,
+            attempts=2,
+            first_seen_at=NOW.isoformat(),
+            not_before=(NOW + timedelta(seconds=300)).isoformat(),
+        )
+        reenqueue_after_rate_limit(task, deferral)
+
+        task.apply_async.assert_called_once()
+        kwargs = task.apply_async.call_args.kwargs
+        assert kwargs["countdown"] == 123.0
+        assert kwargs["args"] == ["cfg-1", "org-1"]
+        # Original kwargs preserved + rate-limit metadata merged in.
+        assert kwargs["kwargs"]["pending_run_id"] == "run-1"
+        assert kwargs["kwargs"] == {
+            "pending_run_id": "run-1",
+            **rate_limit_metadata(deferral),
+        }
+
+    def test_reenqueue_chunk_preserves_kwargs_unchanged(self) -> None:
+        task = self._task()
+        reenqueue_rate_limit_chunk(task, 77.0)
+
+        task.apply_async.assert_called_once()
+        kwargs = task.apply_async.call_args.kwargs
+        assert kwargs["countdown"] == 77.0
+        assert kwargs["args"] == ["cfg-1", "org-1"]
+        assert kwargs["kwargs"] == {"pending_run_id": "run-1"}
+
+
+def test_rate_limit_metadata_keys() -> None:
+    deferral = RateLimitDeferral(
+        countdown=1.0,
+        attempts=3,
+        first_seen_at="2026-01-01T12:00:00+00:00",
+        not_before="2026-01-01T12:05:00+00:00",
+    )
+    assert rate_limit_metadata(deferral) == {
+        "_rate_limit_attempts": 3,
+        "_rate_limit_first_seen_at": "2026-01-01T12:00:00+00:00",
+        "_rate_limit_not_before": "2026-01-01T12:05:00+00:00",
+    }


### PR DESCRIPTION
## Summary

Fixes **CHAOS-2644** and **CHAOS-2645** (folded in). Provider rate-limit signals (HTTP 429 / `Retry-After`) now flow end-to-end to the Celery worker layer, which defers the job as bounded **"deferred work"** instead of burning a fixed retry budget and killing the sync after 3 attempts. The re-run-safety of those deferrals is then guaranteed by making the work-item daily rollups idempotent (CHAOS-2645).

Before: a sustained 429 exhausted a provider client's small internal cap, bubbled up as an exception whose delay was dropped, and the worker retried on a fixed `60 * 2^n` countdown blind to the server's actual wait — killing the job after `max_retries=3`.

After: the server delay is preserved on a canonical `RateLimitException`, and the worker re-enqueues a fresh run honoring it, **without marking the run failed** and **without consuming the genuine-failure retry budget**.

Investigation + plan reviewed by Oracle (verdict: APPROVE-WITH-CHANGES); all required changes incorporated.

## Changes

### Providers — preserve the server signal on terminal rate-limit
- **Linear** (`providers/linear/client.py`): `LinearRateLimitError` now subclasses the canonical `RateLimitException` and carries `retry_after_seconds` (last server `Retry-After` observed).
- **Jira** (`providers/jira/client.py`): terminal 429 raises `RateLimitException(retry_after_seconds=…)` instead of a bare `requests.HTTPError` that dropped the delay.
- **GitLab** (`providers/gitlab/client.py`): a 429 `GitlabError` is translated to `RateLimitException`; enrichment getters (notes, label/state events, links, epics, milestones) **re-raise** rate-limit errors instead of swallowing them as "missing optional data" via `except Exception: return []`. The epics path raises a 429 **before** its Premium/Ultimate 403/404 gating.
- **`providers/_ratelimit.py`**: shared `parse_retry_after_header` handling both delta-seconds and HTTP-date forms.
- **GitHub / LaunchDarkly**: already compliant (verified, unchanged).

### Workers — treat rate limits as deferred work, not failures
- **New `workers/rate_limit_defer.py`**: plans a deferral bounded by **count (10)** AND **wall-clock (2h)**; chunks long waits via an absolute `not_before` so the task re-defers **without re-calling the provider**; adds jitter at the re-enqueue layer (keeps the frozen `connectors/` gate untouched).
- **`sync_misc` / `sync_backfill` / `sync_runtime`**: catch `RateLimitException` **before** any `JobRun` / backfill failure stamping and re-enqueue a fresh run carrying `_rate_limit_*` metadata. The run is not marked failed; the failure-retry budget is not consumed. Budget exhaustion falls through to the existing failure path.

## Oracle-required changes incorporated
- ✅ Deferral via fresh re-enqueue with explicit budget metadata — **not** `self.retry()` (Celery's retry counter is a single global counter and cannot give a separate budget).
- ✅ Rate-limit handling runs **before** failed-run/backfill/JobRun stamping.
- ✅ Normalized on the existing canonical root `RateLimitException`; **no** new exception module; frozen `connectors/` untouched.
- ✅ Long waits become worker deferrals with `not_before` + jitter + bounded total budget.
- ✅ GitLab enrichment paths no longer swallow rate-limit exceptions.

## Idempotent daily rollups (CHAOS-2645 — folded in)

Resolves limitation #1 below **at the source**: a restart-from-scratch re-run (Celery retry or a rate-limit deferral re-enqueue) no longer double-counts work-item daily metrics.

- **Migration 055**: `work_item_metrics_daily` and `work_item_user_metrics_daily` converted in place to `ReplacingMergeTree(computed_at)` (org_id-first ORDER BY preserved) via the shadow-table `SHOW CREATE` + `EXCHANGE TABLES` + catch-up pattern (mirrors 027/042; re-run safe with crash convergence). `work_item_state_durations_daily` left as `MergeTree` — its readers already `argMax`-dedup (tested).
- **`clickhouse_dedup.dedup_from()`**: canonical `FINAL` source for the two tables.
- **Read-side dedup**: every flat reader now reads with `FINAL` (metrics/, api/queries/, api/sql/people/*.sql, storage, workers, fixtures). The variable-table quadrant/people builders apply `dedup_from()`; the metric-config path extends the existing `argMax(..., computed_at)` dedup in `api/queries/metrics.py`.
- **Guard test** (`tests/test_rerun_dedup_guard.py`): fails CI on any new naive `FROM`/`JOIN` of these tables without `FINAL` (argMax dedup also accepted). Behavioral tests cover the variable-table builders + the argMax path.
- Oracle-reviewed strategy: in-place RMT + canonical read-side dedup + guard, **not** a transparent `FINAL` view (perf foot-gun in hot people/quadrant paths) nor delete-on-write (mutation churn + non-atomic gaps).


## Known limitations (out of scope — tracked follow-ups)
- ~~**Sink idempotency on restart-from-scratch.**~~ **RESOLVED in this PR (CHAOS-2645) — see the "Idempotent daily rollups" section above.** The two double-counting daily rollups are now `ReplacingMergeTree(computed_at)` with FINAL/argMax reads enforced by a guard test.
- **GitLab exact `Retry-After`.** python-gitlab (8.x) exceptions expose `response_code`/`response_body` but not `response_headers`, so GitLab 429s defer with the worker default rather than the exact server delay (python-gitlab already performs header-aware sleeping internally before raising). The header parse is kept as forward-compatible defensive code.

## Tests
- `tests/workers/test_rate_limit_defer.py` (new): deferral planning — count/wall-clock budgets, long-wait chunking, `not_before` re-defer, re-enqueue metadata.
- `tests/providers/test_ratelimit.py`: `parse_retry_after_header` (seconds, HTTP-date, missing/invalid, negative-clamp).
- Per-provider terminal-429 → `RateLimitException`: Linear (preserves `retry_after_seconds`), Jira (updated to assert new behavior + preserved delay), GitLab (`_gated_iter` + enrichment re-raise, non-rate-limit still returns `[]`, epics-before-gating).

## Validation
`bash ci/local_validate.sh` — **GATE PASSED**: ruff format + check, mypy, ClickHouse migrate (applies migration 055 against a live engine), full unit suite (**5797 passed, 47 skipped**), and the live argMax engine proof.

SCREENSHOT-WAIVER: backend-only change (provider clients + Celery workers); no rendered UI surface.

