### PR TITLE
perf(github): batch PR timeline events via GraphQL to fix installation 403s (CHAOS-646)

### DIFF
--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -42,6 +42,13 @@ _DIAGNOSTIC_HEADER_NAMES = (
 _TItem = TypeVar("_TItem")
 
 
+_TIMELINE_TYPENAME_TO_EVENT = {
+    "MergedEvent": "merged",
+    "ClosedEvent": "closed",
+    "ReopenedEvent": "reopened",
+}
+
+
 def _parse_github_datetime(value: object) -> datetime | None:
     if isinstance(value, datetime):
         if value.tzinfo is None:
@@ -127,12 +134,21 @@ class GitHubGraphQLReview:
     url: object
 
 
+@dataclass
+class GitHubGraphQLEvent:
+    created_at: object
+    event: object
+    actor: object = None
+    label: object = None
+
+
 @dataclass(frozen=True)
 class BatchedPRPayload:
     number: int
     issue_comments: tuple[GitHubGraphQLComment, ...]
     review_comments: tuple[GitHubGraphQLComment, ...]
     reviews: tuple[GitHubGraphQLReview, ...]
+    events: tuple[GitHubGraphQLEvent, ...] = ()
 
 
 class _GitHubEventLike(Protocol):
@@ -554,6 +570,7 @@ class GitHubWorkClient:
         comments_limit: int | None = None,
         review_comments_limit: int | None = None,
         reviews_limit: int | None = None,
+        events_limit: int | None = 0,
         batch_size: int = 50,
     ) -> Iterable[BatchedPRPayload]:
         """Fetch PR issue comments, reviews, and review comments in GraphQL batches.
@@ -585,6 +602,7 @@ class GitHubWorkClient:
                 comments_first=self._connection_first(comments_limit),
                 review_comments_first=self._connection_first(review_comments_limit),
                 reviews_first=self._connection_first(reviews_limit),
+                events_first=self._connection_first(events_limit),
             )
             yield from self._complete_pr_social_payloads(
                 owner=owner,
@@ -593,6 +611,7 @@ class GitHubWorkClient:
                 comments_limit=comments_limit,
                 review_comments_limit=review_comments_limit,
                 reviews_limit=reviews_limit,
+                events_limit=events_limit,
             )
 
     def iter_pr_comments_batch(
@@ -710,6 +729,18 @@ class GitHubWorkClient:
             url=node.get("url"),
         )
 
+    @classmethod
+    def _event_from_graphql(cls, node: dict[str, Any]) -> GitHubGraphQLEvent:
+        actor_node = node.get("actor") if isinstance(node.get("actor"), dict) else {}
+        actor = GitHubGraphQLUser(login=(actor_node or {}).get("login"))
+        typename = str(node.get("__typename") or "")
+        return GitHubGraphQLEvent(
+            created_at=_parse_github_datetime(node.get("createdAt")),
+            event=_TIMELINE_TYPENAME_TO_EVENT.get(typename, ""),
+            actor=actor,
+            label=None,
+        )
+
     def _fetch_pr_social_data_page(
         self,
         *,
@@ -721,6 +752,8 @@ class GitHubWorkClient:
         reviews_first: int,
         comments_after: str | None = None,
         reviews_after: str | None = None,
+        events_first: int = 0,
+        events_after: str | None = None,
     ) -> dict[int, dict[str, Any]]:
         aliases: list[str] = []
         for idx, number in enumerate(numbers):
@@ -746,6 +779,18 @@ class GitHubWorkClient:
                 fields.append(
                     f"reviews(first: {reviews_first}, after: {reviews_after_arg}) "
                     f"{{ nodes {{ {' '.join(review_fields)} }} pageInfo {{ hasNextPage endCursor }} }}"
+                )
+            if events_first > 0:
+                events_after_arg = self._graphql_arg(events_after)
+                fields.append(
+                    "timelineItems(itemTypes: [MERGED_EVENT, CLOSED_EVENT, "
+                    "REOPENED_EVENT], "
+                    f"first: {events_first}, after: {events_after_arg}) "
+                    "{ nodes { __typename "
+                    "... on MergedEvent { createdAt actor { login } } "
+                    "... on ClosedEvent { createdAt actor { login } } "
+                    "... on ReopenedEvent { createdAt actor { login } } } "
+                    "pageInfo { hasNextPage endCursor } }"
                 )
             aliases.append(
                 f"pr{idx}: pullRequest(number: {int(number)}) {{ {' '.join(fields)} }}"
@@ -809,6 +854,7 @@ class GitHubWorkClient:
         comments_limit: int | None,
         review_comments_limit: int | None,
         reviews_limit: int | None,
+        events_limit: int | None = 0,
     ) -> Iterable[BatchedPRPayload]:
         for number, pr_node in initial.items():
             comments_connection = pr_node.get("comments")
@@ -904,11 +950,41 @@ class GitHubWorkClient:
             if review_comments_limit is not None:
                 review_comments = review_comments[: int(review_comments_limit)]
 
+            events_connection = pr_node.get("timelineItems")
+            events_nodes = self._connection_nodes(events_connection)
+            events_cursor = self._connection_cursor(events_connection)
+            while (
+                events_cursor
+                and self._remaining_limit(events_limit, len(events_nodes)) != 0
+            ):
+                remaining_events = self._remaining_limit(
+                    events_limit, len(events_nodes)
+                )
+                more = self._fetch_pr_social_data_page(
+                    owner=owner,
+                    repo=repo,
+                    numbers=[number],
+                    comments_first=0,
+                    review_comments_first=0,
+                    reviews_first=0,
+                    events_first=self._connection_first(remaining_events),
+                    events_after=events_cursor,
+                ).get(number, {})
+                more_events = (
+                    more.get("timelineItems") if isinstance(more, dict) else None
+                )
+                events_nodes.extend(self._connection_nodes(more_events))
+                events_cursor = self._connection_cursor(more_events)
+            events = [self._event_from_graphql(node) for node in events_nodes]
+            if events_limit is not None:
+                events = events[: int(events_limit)]
+
             yield BatchedPRPayload(
                 number=number,
                 issue_comments=tuple(comments),
                 review_comments=tuple(review_comments),
                 reviews=tuple(reviews),
+                events=tuple(events),
             )
 
     def iter_repo_milestones(

--- a/src/dev_health_ops/providers/github/provider.py
+++ b/src/dev_health_ops/providers/github/provider.py
@@ -28,6 +28,7 @@ from dev_health_ops.providers.base import (
 )
 from dev_health_ops.providers.github.client import (
     GitHubGraphQLComment,
+    GitHubGraphQLEvent,
     GitHubWorkClient,
 )
 from dev_health_ops.providers.normalize_common import to_utc as _to_utc
@@ -35,6 +36,12 @@ from dev_health_ops.providers.utils import env_flag as _env_flag
 from dev_health_ops.providers.utils import env_int
 
 logger = logging.getLogger(__name__)
+
+
+# Max PR timeline events fetched per PR via GraphQL. Only MERGED/CLOSED/
+# REOPENED items are requested, so this is effectively unbounded in practice;
+# mirrors the prior REST iter_issue_events(limit=1000) intent.
+_PR_EVENTS_LIMIT = 1000
 
 
 class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
@@ -253,24 +260,35 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                         limit=remaining_limit,
                     )
                 )
+                # Batch PR timeline events and comments via GraphQL (one query
+                # per <=50 PRs) instead of a per-PR REST issue-events call.
+                # The per-PR REST events fetch exhausted the GitHub App
+                # installation's REST primary rate limit (403). Events drive
+                # status transitions + reopen detection; comments drive
+                # interaction events + the Linear linkback dependency capture.
                 pr_comments_by_number: dict[int, tuple[GitHubGraphQLComment, ...]] = {}
-                if fetch_comments:
-                    pr_comments_by_number = {
-                        number: comments
-                        for number, comments in client.iter_pr_comments_batch(
-                            owner=owner,
-                            repo=repo,
-                            prs=prs,
-                            limit=comments_limit,
-                        )
-                    }
+                pr_events_by_number: dict[int, tuple[GitHubGraphQLEvent, ...]] = {}
+                for payload in client.iter_pr_social_data_batch(
+                    owner=owner,
+                    repo=repo,
+                    prs=prs,
+                    comments_limit=comments_limit if fetch_comments else 0,
+                    review_comments_limit=0,
+                    reviews_limit=0,
+                    events_limit=_PR_EVENTS_LIMIT,
+                ):
+                    pr_events_by_number[payload.number] = payload.events
+                    if fetch_comments:
+                        pr_comments_by_number[payload.number] = payload.issue_comments
 
                 for pr in prs:
                     if ctx.limit is not None and fetched_count >= ctx.limit:
                         break
 
-                    # Get events for transitions and reopen detection
-                    events = list(client.iter_issue_events(pr, limit=1000))
+                    # Events for transitions/reopen detection, from the batch.
+                    events = list(
+                        pr_events_by_number.get(int(getattr(pr, "number", 0) or 0), ())
+                    )
 
                     wi, wi_transitions = github_pr_to_work_item(
                         pr=pr,

--- a/tests/providers/test_github_pr_social_batch.py
+++ b/tests/providers/test_github_pr_social_batch.py
@@ -444,3 +444,87 @@ def test_batched_pr_reviews_preserve_rest_consumed_fields() -> None:
     assert reviews[0].submitted_at == datetime(2026, 1, 3, 3, 4, 5, tzinfo=timezone.utc)
     assert reviews[0].body == "LGTM"
     assert reviews[0].url == "https://github.test/review/10"
+
+
+def _timeline_node(typename: str, created_at: str, login: str) -> dict[str, object]:
+    return {
+        "__typename": typename,
+        "createdAt": created_at,
+        "actor": {"login": login},
+    }
+
+
+def test_batched_pr_events_fetched_and_mapped() -> None:
+    """PR timeline events (merged/closed/reopened) are batched into the same
+    GraphQL call as comments and mapped to the event shape the normalizers
+    consume (event string, created_at, actor.login). This replaces the per-PR
+    REST iter_issue_events call that exhausted the installation rate limit."""
+    client, graphql, _gate = _client()
+    prs = [_pr(number) for number in range(1, 4)]
+    graphql.query.return_value = {
+        "repository": {
+            f"pr{idx}": {
+                "number": number,
+                "timelineItems": {
+                    "nodes": [
+                        _timeline_node("MergedEvent", "2026-02-01T00:00:00Z", "merger"),
+                        _timeline_node("ClosedEvent", "2026-02-02T00:00:00Z", "closer"),
+                        _timeline_node(
+                            "ReopenedEvent", "2026-02-03T00:00:00Z", "reopener"
+                        ),
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                },
+            }
+            for idx, number in enumerate(range(1, 4))
+        }
+    }
+
+    payloads = {
+        payload.number: payload
+        for payload in client.iter_pr_social_data_batch(
+            owner="owner", repo="repo", prs=prs, events_limit=1000
+        )
+    }
+
+    # One GraphQL call covers all three PRs' events (no per-PR REST fan-out).
+    assert graphql.query.call_count == 1
+    query_str = graphql.query.call_args.args[0]
+    assert "timelineItems" in query_str
+    for pr in prs:
+        pr.get_issue_events.assert_not_called()
+
+    events = payloads[1].events
+    assert [e.event for e in events] == ["merged", "closed", "reopened"]
+    assert events[0].created_at == datetime(2026, 2, 1, tzinfo=timezone.utc)
+    assert getattr(events[0].actor, "login") == "merger"
+    assert getattr(events[2].actor, "login") == "reopener"
+
+
+def test_batched_pr_events_omitted_when_events_limit_zero() -> None:
+    """Existing comment/review batches default events_limit=0, so the
+    timelineItems connection must not be added to their query (no extra cost)."""
+    client, graphql, _gate = _client()
+    graphql.query.return_value = {
+        "repository": {
+            "pr0": {
+                "number": 1,
+                "comments": {
+                    "nodes": [_comment_node(1)],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                },
+            }
+        }
+    }
+
+    payload = next(
+        iter(
+            client.iter_pr_comments_batch(
+                owner="owner", repo="repo", prs=[_pr(1)], limit=100
+            )
+        )
+    )
+
+    assert payload  # consumed
+    query_str = graphql.query.call_args.args[0]
+    assert "timelineItems" not in query_str


### PR DESCRIPTION
## Summary

Fixes the `403 "API rate limit exceeded for installation ID …"` errors that hit **only the PR fetch** during GitHub work-items sync.

Root cause: the work-items provider fetched PR events with **one REST `iter_issue_events` call per PR** (N+1). For a repo with ~331 PRs that is ~331 REST calls, draining the GitHub App installation's shared REST primary budget; because PRs are fetched last and most heavily, the 403 surfaced there.

## Fix

Fold PR timeline events (`MergedEvent` / `ClosedEvent` / `ReopenedEvent`) into the **existing GraphQL PR social-data batch** (one query per ≤50 PRs), collapsing ~N REST calls into ~`ceil(N/50)` GraphQL calls — on GitHub's **separate** GraphQL point budget, not the exhausted REST `core` bucket.

- `providers/github/client.py`: add `GitHubGraphQLEvent` + `_event_from_graphql` mapper, request `timelineItems(itemTypes: [MERGED_EVENT, CLOSED_EVENT, REOPENED_EVENT], …)` in `_fetch_pr_social_data_page`, thread `events_limit` through `iter_pr_social_data_batch` / `_complete_pr_social_payloads` (with pagination), add `events` to `BatchedPRPayload` (default `()`).
- `providers/github/provider.py`: PR loop now reads events from the batch instead of per-PR REST `iter_issue_events`.
- `events_limit` defaults to `0`, so existing comment/review batch callers are unchanged (no `timelineItems`, no added cost).

The mapped events satisfy exactly what `github_pr_to_work_item` (status transitions) and `detect_github_reopen_events` consume (`event`, `created_at`, `actor.login`).

## Scope / follow-ups

- Comments were **already** batched (`iter_pr_comments_batch`); this PR adds the missing **events** batching, which was the actual 403 amplifier.
- Per-PR reviews in the **legacy code-processor path** (`processors/github.py` → `get_pull_request_reviews`) are unchanged and remain a possible follow-up.
- Not addressed here (separate items): wiring selected Sync Targets into the work-items provider, and the duplicate `/pulls` fetch across the code + work-items paths.

## Validation

- `ci/local_validate.sh` → **GATE PASSED**: ruff format/check, mypy, full unit suite (5804 passed, 47 skipped), ClickHouse migrate + argMax live-exec proof.
- Added tests proving events are batched into one GraphQL call and mapped correctly, and that `timelineItems` is omitted when `events_limit=0`.

SCREENSHOT-WAIVER: backend-only change (provider/client ingest); no UI render affected.

Part of CHAOS-646 (events N+1 — the 403 cause); see scope notes for remaining items.
