### PR TITLE
perf(github): batch legacy code-path PR reviews

### DIFF
--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -50,6 +50,7 @@ from dev_health_ops.processors.testops_ingest import (
     MAX_RUNS_PER_SYNC,
     ingest_report_members,
 )
+from dev_health_ops.providers.github.client import GitHubAuth, GitHubWorkClient
 from dev_health_ops.providers.pr_state import normalize_pr_state
 from dev_health_ops.utils import (
     AGGREGATE_STATS_MARKER,
@@ -623,6 +624,7 @@ def _enrich_prs_with_reviews_batch(
     raw_gh_prs: list[Any],
     ingestion_sink: IngestionSink,
     loop: asyncio.AbstractEventLoop,
+    gate: "RateLimitGate",
 ) -> list[GitPullRequestReview]:
     """Batch-fetch reviews for all PRs and enrich pr_objects in place.
 
@@ -630,13 +632,30 @@ def _enrich_prs_with_reviews_batch(
     replacing the N+1 pattern (one review API call per PR).
     """
     all_review_objects: list[GitPullRequestReview] = []
+    pr_objects_by_number = {int(pr.number): pr for pr in pr_objects}
+    reviews_by_pr = {}
 
-    for pr_obj, gh_pr in zip(pr_objects, raw_gh_prs):
-        try:
-            reviews = connector.get_pull_request_reviews(owner, repo_name, gh_pr.number)
-        except Exception as e:
-            logging.debug("Failed to fetch reviews for PR #%d: %s", gh_pr.number, e)
+    try:
+        review_client = _github_work_client_from_connector(connector, gate=gate)
+        for pr_number, reviews in review_client.iter_pr_reviews_batch(
+            owner=owner,
+            repo=repo_name,
+            prs=raw_gh_prs,
+            limit=None,
+        ):
+            reviews_by_pr[int(pr_number)] = reviews
+    except Exception as e:
+        logging.debug(
+            "Failed to batch-fetch reviews for %s/%s: %s", owner, repo_name, e
+        )
+
+    for gh_pr in raw_gh_prs:
+        pr_number = int(getattr(gh_pr, "number", 0) or 0)
+        pr_obj = pr_objects_by_number.get(pr_number)
+        if pr_obj is None:
             continue
+
+        reviews = reviews_by_pr.get(pr_number, ())
 
         if not reviews:
             continue
@@ -659,10 +678,10 @@ def _enrich_prs_with_reviews_batch(
             all_review_objects.append(
                 GitPullRequestReview(
                     repo_id=repo_id,
-                    number=gh_pr.number,
-                    review_id=r.id,
-                    reviewer=r.reviewer,
-                    state=r.state,
+                    number=pr_number,
+                    review_id=str(r.id),
+                    reviewer=str(r.reviewer or "Unknown"),
+                    state=str(r.state or ""),
                     submitted_at=review_at,
                 )
             )
@@ -678,6 +697,26 @@ def _enrich_prs_with_reviews_batch(
         pr_obj.changes_requested_count = changes_requested_count
 
     return all_review_objects
+
+
+def _github_work_client_from_connector(
+    connector,
+    *,
+    gate: "RateLimitGate",
+) -> GitHubWorkClient:
+    rest_base_url = getattr(connector, "_rest_base_url", None)
+    raw_base_url = rest_base_url() if callable(rest_base_url) else None
+    base_url = raw_base_url if isinstance(raw_base_url, str) else None
+    token = getattr(connector, "token", None)
+    client = GitHubWorkClient(
+        auth=GitHubAuth(token=token, base_url=base_url),
+        per_page=int(getattr(connector, "per_page", 100) or 100),
+        gate=gate,
+    )
+    connector_graphql = getattr(connector, "graphql", None)
+    if connector_graphql is not None:
+        client.graphql = connector_graphql
+    return client
 
 
 def _sync_github_prs_to_store(
@@ -734,6 +773,7 @@ def _sync_github_prs_to_store(
         raw_gh_prs=raw_gh_prs,
         ingestion_sink=ingestion_sink,
         loop=loop,
+        gate=gate,
     )
 
     # Phase 3: persist reviews in one bulk insert

--- a/tests/test_github_pr_changes_requested_sync.py
+++ b/tests/test_github_pr_changes_requested_sync.py
@@ -12,6 +12,7 @@ import asyncio
 import uuid
 from datetime import datetime, timezone
 from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
 
@@ -112,6 +113,8 @@ class _FakeReview:
         self.state = state
         self.reviewer = reviewer
         self.submitted_at = datetime(2020, 1, 2, tzinfo=timezone.utc)
+        self.body = f"review {review_id}"
+        self.url = f"https://github.test/reviews/{review_id}"
 
 
 @pytest.mark.asyncio
@@ -137,25 +140,47 @@ async def test_github_pr_sync_writes_changes_requested_count_from_reviews():
     class _Connector:
         def __init__(self):
             self.github = _FakeGithub(fake_repo)
+            self.token = "token"
+            self.per_page = 100
+            self.graphql = object()
+
+        def _rest_base_url(self):
+            return "https://api.github.com"
 
         def get_pull_request_reviews(self, owner, repo, number):
-            return reviews_by_pr.get(number, [])
+            raise AssertionError("per-PR review fetch should not be used")
 
-    total = await loop.run_in_executor(
-        None,
-        cast(Any, _sync_github_prs_to_store),
-        _Connector(),
-        "o",
-        "r",
-        repo_id,
-        store,
-        loop,
-        50,  # batch_size
-        "all",
-        _NoSleepGate(),
-    )
+    class _BatchReviewClient:
+        calls: list[tuple[str, str, list[int], int | None]] = []
+
+        def __init__(self, **_kwargs):
+            self.graphql = None
+
+        def iter_pr_reviews_batch(self, *, owner, repo, prs, limit):
+            self.calls.append((owner, repo, [pr.number for pr in prs], limit))
+            for pr in prs:
+                yield pr.number, tuple(reviews_by_pr.get(pr.number, []))
+
+    with patch(
+        "dev_health_ops.processors.github.GitHubWorkClient",
+        _BatchReviewClient,
+    ):
+        total = await loop.run_in_executor(
+            None,
+            cast(Any, _sync_github_prs_to_store),
+            _Connector(),
+            "o",
+            "r",
+            repo_id,
+            store,
+            loop,
+            50,  # batch_size
+            "all",
+            _NoSleepGate(),
+        )
 
     assert total == 2
+    assert _BatchReviewClient.calls == [("o", "r", [1, 2], None)]
 
     prs = {pr.number: pr for batch in store.pr_batches for pr in batch}
     assert prs[1].changes_requested_count == 2
@@ -167,3 +192,8 @@ async def test_github_pr_sync_writes_changes_requested_count_from_reviews():
     # Reviews themselves are still persisted for git_pull_request_reviews.
     persisted_reviews = [r for batch in store.review_batches for r in batch]
     assert len(persisted_reviews) == 5
+    first_review = persisted_reviews[0]
+    assert first_review.review_id == "101"
+    assert first_review.reviewer == "carol"
+    assert first_review.state == "CHANGES_REQUESTED"
+    assert first_review.submitted_at == datetime(2020, 1, 2, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- batch legacy GitHub code-processor PR review fetching through the provider GitHubWorkClient
- preserve review-derived PR metrics and persisted review rows
- add regression coverage proving no per-PR connector review calls

## Validation
- bash ci/local_validate.sh

## Tracking
- CHAOS-646

SCREENSHOT-WAIVER: backend-only change