### PR TITLE
feat(github): honor Sync Target selections in work-items provider (CHAOS-646)

### DIFF
--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -235,6 +235,10 @@ def run_work_items_sync_job(
     jira_project_keys: list[str] | None = None,
     jira_jql: str | None = None,
     jira_fetch_all: bool | None = None,
+    include_issues: bool | None = None,
+    include_pull_requests: bool | None = None,
+    fetch_comments: bool | None = None,
+    fetch_milestones: bool | None = None,
 ) -> None:
     """
     Sync work tracking facts from provider APIs and write derived work item tables.
@@ -373,7 +377,11 @@ def run_work_items_sync_job(
         if "github" in provider_set:
             from uuid import UUID
 
-            from dev_health_ops.providers.base import IngestionContext, IngestionWindow
+            from dev_health_ops.providers.base import (
+                IngestionContext,
+                IngestionWindow,
+                WorkItemIngestionOptions,
+            )
             from dev_health_ops.providers.github.provider import GitHubProvider
 
             github_provider = GitHubProvider(
@@ -395,6 +403,12 @@ def run_work_items_sync_job(
                     repo=discovered_repo.full_name,
                     repo_id=discovered_repo.repo_id,
                     org_id=github_org_id,
+                    work_item_options=WorkItemIngestionOptions(
+                        include_issues=include_issues,
+                        include_pull_requests=include_pull_requests,
+                        fetch_comments=fetch_comments,
+                        fetch_milestones=fetch_milestones,
+                    ),
                 )
                 for batch in github_provider.iter_ingest(ctx):
                     work_items.extend(batch.work_items)

--- a/src/dev_health_ops/providers/base.py
+++ b/src/dev_health_ops/providers/base.py
@@ -58,6 +58,23 @@ class IngestionWindow:
 
 
 @dataclass(frozen=True)
+class WorkItemIngestionOptions:
+    """Per-target/sub-data toggles for work-item ingestion.
+
+    Tri-state: ``None`` means "not specified — the provider falls back to its
+    environment-default behavior", which preserves current behavior for callers
+    that pass nothing (CLI, backfill, webhooks, batch, tests). Config-aware sync
+    paths set these explicitly to honor the admin Sync Target / dataset
+    selections (e.g. "Pull Requests" unchecked -> include_pull_requests=False).
+    """
+
+    include_issues: bool | None = None
+    include_pull_requests: bool | None = None
+    fetch_comments: bool | None = None
+    fetch_milestones: bool | None = None
+
+
+@dataclass(frozen=True)
 class IngestionContext:
     """
     Context passed to provider.ingest() describing what to fetch.
@@ -78,6 +95,9 @@ class IngestionContext:
     org_id: UUID | None = None
     group: str | None = None  # gitlab
     limit: int | None = None
+    work_item_options: WorkItemIngestionOptions = field(
+        default_factory=WorkItemIngestionOptions
+    )
 
 
 @dataclass

--- a/src/dev_health_ops/providers/github/provider.py
+++ b/src/dev_health_ops/providers/github/provider.py
@@ -122,9 +122,25 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
         interactions: list[WorkItemInteractionEvent] = []
         sprints: list[Sprint] = []
         ai_attributions: list[AIAttributionRecord] = []
-        include_prs = _env_flag("GITHUB_INCLUDE_PRS", True)
-        fetch_comments = _env_flag("GITHUB_FETCH_COMMENTS", True)
-        fetch_milestones = _env_flag("GITHUB_FETCH_MILESTONES", True)
+        _wi_opts = ctx.work_item_options
+        include_issues = (
+            True if _wi_opts.include_issues is None else _wi_opts.include_issues
+        )
+        include_prs = (
+            _env_flag("GITHUB_INCLUDE_PRS", True)
+            if _wi_opts.include_pull_requests is None
+            else _wi_opts.include_pull_requests
+        )
+        fetch_comments = (
+            _env_flag("GITHUB_FETCH_COMMENTS", True)
+            if _wi_opts.fetch_comments is None
+            else _wi_opts.fetch_comments
+        )
+        fetch_milestones = (
+            _env_flag("GITHUB_FETCH_MILESTONES", True)
+            if _wi_opts.fetch_milestones is None
+            else _wi_opts.fetch_milestones
+        )
 
         comments_limit = env_int("GITHUB_COMMENTS_LIMIT", 500)
 
@@ -162,13 +178,18 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
 
         # Fetch issues
         try:
-            for issue in client.iter_issues(
-                owner=owner,
-                repo=repo,
-                state="all",
-                since=since,
-                limit=ctx.limit,
-            ):
+            issues_iter = (
+                client.iter_issues(
+                    owner=owner,
+                    repo=repo,
+                    state="all",
+                    since=since,
+                    limit=ctx.limit,
+                )
+                if include_issues
+                else ()
+            )
+            for issue in issues_iter:
                 if ctx.limit is not None and fetched_count >= ctx.limit:
                     break
 

--- a/src/dev_health_ops/workers/sync_batch.py
+++ b/src/dev_health_ops/workers/sync_batch.py
@@ -800,6 +800,9 @@ def _run_sync_for_repo(
                 search_pattern=sync_options_override.get("search"),
                 org_id=org_id,
                 credentials=work_items_credentials,
+                include_pull_requests=(
+                    ("prs" in sync_targets) if provider == "github" else None
+                ),
             )
             duration_ms = int(
                 (datetime.now(timezone.utc) - started_backfill).total_seconds() * 1000

--- a/src/dev_health_ops/workers/sync_runtime.py
+++ b/src/dev_health_ops/workers/sync_runtime.py
@@ -1101,6 +1101,9 @@ def run_sync_config(
                 search_pattern=sync_options.get("search"),
                 org_id=org_id,
                 credentials=work_items_credentials,
+                include_pull_requests=(
+                    ("prs" in sync_targets) if provider == "github" else None
+                ),
             )
             result_payload["work_items_synced"] = True
 

--- a/tests/test_github_provider.py
+++ b/tests/test_github_provider.py
@@ -978,3 +978,106 @@ def test_github_provider_invalid_repo_format():
     # Will fail before token check due to format validation
     with pytest.raises(ValueError, match="expected owner/repo"):
         provider.ingest(ctx)
+
+
+# ============================================================================
+# Work-item ingestion options (Sync Target toggles) — CHAOS-646
+# ============================================================================
+
+
+def _options_client() -> MagicMock:
+    """A GitHub work client whose iterators all yield nothing."""
+    client = MagicMock()
+    client.iter_repo_milestones.return_value = []
+    client.iter_issues.return_value = []
+    client.iter_issue_events.return_value = []
+    client.iter_pull_requests.return_value = []
+    client.iter_pr_comments_batch.return_value = []
+    return client
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_work_item_options_include_pull_requests_false_skips_prs(
+    mock_status_mapping, mock_identity
+):
+    """include_pull_requests=False must skip the PR fetch entirely."""
+    from dev_health_ops.providers.base import WorkItemIngestionOptions
+
+    client = _options_client()
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(
+        repo="owner/repo",
+        window=IngestionWindow(),
+        work_item_options=WorkItemIngestionOptions(include_pull_requests=False),
+    )
+    provider.ingest(ctx)
+    client.iter_pull_requests.assert_not_called()
+    client.iter_issues.assert_called_once()
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_work_item_options_include_issues_false_skips_issues(
+    mock_status_mapping, mock_identity
+):
+    """include_issues=False must skip the issues fetch entirely."""
+    from dev_health_ops.providers.base import WorkItemIngestionOptions
+
+    client = _options_client()
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(
+        repo="owner/repo",
+        window=IngestionWindow(),
+        work_item_options=WorkItemIngestionOptions(include_issues=False),
+    )
+    provider.ingest(ctx)
+    client.iter_issues.assert_not_called()
+    client.iter_pull_requests.assert_called_once()
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_work_item_options_default_none_uses_env_defaults(
+    mock_status_mapping, mock_identity
+):
+    """With no options and no env overrides, both issues and PRs are fetched."""
+    client = _options_client()
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(repo="owner/repo", window=IngestionWindow())
+    provider.ingest(ctx)
+    client.iter_issues.assert_called_once()
+    client.iter_pull_requests.assert_called_once()
+
+
+@patch.dict(os.environ, {"GITHUB_INCLUDE_PRS": "false"}, clear=True)
+def test_work_item_options_none_falls_back_to_env(mock_status_mapping, mock_identity):
+    """A None option falls back to the env flag (GITHUB_INCLUDE_PRS=false)."""
+    client = _options_client()
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(repo="owner/repo", window=IngestionWindow())
+    provider.ingest(ctx)
+    client.iter_pull_requests.assert_not_called()
+
+
+@patch.dict(os.environ, {"GITHUB_INCLUDE_PRS": "false"}, clear=True)
+def test_work_item_options_ctx_overrides_env(mock_status_mapping, mock_identity):
+    """An explicit ctx option beats the env flag (True overrides env false)."""
+    from dev_health_ops.providers.base import WorkItemIngestionOptions
+
+    client = _options_client()
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(
+        repo="owner/repo",
+        window=IngestionWindow(),
+        work_item_options=WorkItemIngestionOptions(include_pull_requests=True),
+    )
+    provider.ingest(ctx)
+    client.iter_pull_requests.assert_called_once()


### PR DESCRIPTION
## Summary

The GitHub **work-items** provider ignored the admin **Sync Target** selections: it always fetched issues + PRs + comments + milestones based on env defaults (`GITHUB_INCLUDE_PRS` / `GITHUB_FETCH_COMMENTS` / `GITHUB_FETCH_MILESTONES`, all default `True`). Unchecking "Pull Requests" did **not** stop the provider from calling `iter_pull_requests`.

This wires the config selections into the work-items provider.

## Design (per architecture review)

PRs-as-work-items belong to the `WORK_ITEMS` dataset in the canonical model, but the legacy/batch dispatch paths carry the coarse `sync_targets` set, so we honor the user-visible intent there: unchecking **"Pull Requests"** (`prs` target) sets `include_pull_requests=False` for the GitHub work-items provider.

- **`providers/base.py`**: add tri-state `WorkItemIngestionOptions` (`include_issues` / `include_pull_requests` / `fetch_comments` / `fetch_milestones`) on `IngestionContext`. `None` = "fall back to the provider's env default", so every caller that passes nothing (CLI, backfill, webhooks, batch, tests) keeps current behavior.
- **`providers/github/provider.py`**: resolve each toggle as **ctx-option-else-env**, and gate the issues fetch behind `include_issues` (skips the REST call entirely when off).
- **`metrics/job_work_items.py`**: `run_work_items_sync_job` gains `None`-default kwargs and forwards them into the GitHub `IngestionContext`.
- **`workers/sync_runtime.py`** (legacy `run_sync_config`) + **`workers/sync_batch.py`** (`_run_sync_for_repo`): pass `include_pull_requests=("prs" in sync_targets)` for GitHub.

## Scope / follow-ups

- **Planner path (`processors/dataset_adapters.py`) intentionally left on env defaults.** It fans out one task per `WORK_ITEM_*` dataset and `run_work_items_sync_job` currently does a full provider run per dataset — wiring per-dataset options there without **coalescing** would worsen the existing duplicate-run. Tracked as a follow-up (planner work-item dataset coalescing + option scoping). Planner behavior is unchanged by this PR.
- Comment/milestone toggles are not driven from the coarse legacy `sync_targets` (no granular token there); they remain env-default until the planner path is wired.
- Not applied to Jira/GitLab/Linear providers yet.

## Validation

- 5 new provider tests prove the precedence: `include_pull_requests=False` skips PRs, `include_issues=False` skips issues, `None` falls back to env, and an explicit ctx option overrides env.
- `ci/local_validate.sh` → **GATE PASSED**: ruff format/check, mypy, full unit suite (5807 passed, 47 skipped), ClickHouse migrate + argMax live-exec.

SCREENSHOT-WAIVER: backend-only change (provider/ingest plumbing); no UI render affected.

Part of CHAOS-646.
