### PR TITLE
fix(drift): harden team drift lifecycle (CHAOS-2657)

### DIFF
--- a/src/dev_health_ops/api/services/configuration/clickhouse_team_drift.py
+++ b/src/dev_health_ops/api/services/configuration/clickhouse_team_drift.py
@@ -173,11 +173,18 @@ class ClickHouseTeamDriftService:
         if not field:
             return
         observation = await self._observation_for(row)
+        if not observation:
+            raise ValueError(
+                "Cannot approve drift change without a provider observation"
+            )
+        observed_column = _JSON_FIELD_COLUMNS.get(str(field), str(field))
+        if observed_column not in observation:
+            raise ValueError(
+                f"Cannot approve drift change without observed field {field!s}"
+            )
         observed_value = self._observed_field_value(
             field=str(field), observation=observation
         )
-        if observed_value is None:
-            observed_value = _loads_json(row.get("new_value_json"))
 
         team_id = str(row["team_id"])
         existing = await self.team_admin.get(team_id)
@@ -192,7 +199,7 @@ class ClickHouseTeamDriftService:
         repo_patterns = existing.repo_patterns if existing is not None else []
 
         if field == "name":
-            name = str(observed_value or name)
+            name = str(observed_value) if observed_value is not None else name
         elif field == "description":
             description = None if observed_value is None else str(observed_value)
         elif field == "members":

--- a/src/dev_health_ops/api/services/configuration/clickhouse_team_drift_projector.py
+++ b/src/dev_health_ops/api/services/configuration/clickhouse_team_drift_projector.py
@@ -96,9 +96,11 @@ async def project_provider_team_rows(
     *,
     dsn: str,
     org_id: str,
+    provider: str | None = None,
     team_rows: list[dict[str, Any]],
     team_writer: TeamWriter,
     discovered_at: datetime | None = None,
+    resolve_missing_provider_changes: bool = False,
 ) -> None:
     from dev_health_ops.storage.clickhouse import ClickHouseStore
 
@@ -107,9 +109,11 @@ async def project_provider_team_rows(
         await project_team_rows_with_store(
             store=store,
             org_id=org_id,
+            provider=provider,
             team_rows=team_rows,
             team_writer=team_writer,
             discovered_at=discovered_at,
+            resolve_missing_provider_changes=resolve_missing_provider_changes,
         )
 
 
@@ -117,16 +121,23 @@ async def project_team_rows_with_store(
     *,
     store: ClickHouseStore,
     org_id: str,
+    provider: str | None = None,
     team_rows: list[dict[str, Any]],
     team_writer: TeamWriter | None = None,
     discovered_at: datetime | None = None,
+    resolve_missing_provider_changes: bool = False,
 ) -> None:
     projector = ClickHouseTeamDriftProjector(
         store=store,
         org_id=org_id,
         team_writer=team_writer,
     )
-    await projector.project_many(team_rows, discovered_at=discovered_at)
+    await projector.project_many(
+        team_rows,
+        provider=provider,
+        discovered_at=discovered_at,
+        resolve_missing_provider_changes=resolve_missing_provider_changes,
+    )
 
 
 class ClickHouseTeamDriftProjector:
@@ -145,10 +156,22 @@ class ClickHouseTeamDriftProjector:
         self,
         team_rows: Sequence[dict[str, Any]],
         *,
+        provider: str | None = None,
         discovered_at: datetime | None = None,
+        resolve_missing_provider_changes: bool = False,
     ) -> None:
+        observed: list[dict[str, Any]] = []
         for team_row in team_rows:
-            await self.project_team(team_row, discovered_at=discovered_at)
+            observed.append(
+                await self.project_team(team_row, discovered_at=discovered_at)
+            )
+        provider_name = provider or _provider_from_observed(observed)
+        if provider_name and resolve_missing_provider_changes:
+            await self.resolve_missing_provider_changes(
+                provider=provider_name,
+                observed=observed,
+                now=_utc_now(),
+            )
 
     async def project_team(
         self,
@@ -158,7 +181,7 @@ class ClickHouseTeamDriftProjector:
         discovered_at: datetime | None = None,
         apply_catalog: bool = True,
         detect_drift: bool = True,
-    ) -> None:
+    ) -> dict[str, Any]:
         now = _utc_now()
         observed = _observed_row(
             self.org_id,
@@ -169,27 +192,27 @@ class ClickHouseTeamDriftProjector:
         await self._insert_observation(observed)
 
         if not apply_catalog and not detect_drift:
-            return
+            return observed
 
         policy, managed_fields = await self._sync_policy(observed["team_id"])
         pending_changes = await self._change_rows(
             team_id=observed["team_id"],
-            provider=observed["provider"],
-            native_team_key=observed["native_team_key"],
         )
 
         if policy == AUTO_APPLY_POLICY:
             if apply_catalog:
-                await self.team_writer([catalog_row or team_row])
+                await self.team_writer(
+                    [_catalog_row_for_write(self.org_id, catalog_row or team_row)]
+                )
             await self._mark_pending(
                 pending_changes,
                 status=STATUS_RESOLVED,
                 now=now,
             )
-            return
+            return observed
 
         if policy != FLAG_FOR_REVIEW_POLICY or not detect_drift:
-            return
+            return observed
 
         existing = await self._team_row(observed["team_id"])
         await self._project_field_changes(
@@ -199,6 +222,7 @@ class ClickHouseTeamDriftProjector:
             existing_changes=pending_changes,
             now=now,
         )
+        return observed
 
     async def record_observation(
         self,
@@ -214,6 +238,35 @@ class ClickHouseTeamDriftProjector:
                 discovered_at=discovered_at or now,
                 updated_at=now,
             )
+        )
+
+    async def resolve_missing_provider_changes(
+        self,
+        *,
+        provider: str,
+        observed: Sequence[dict[str, Any]],
+        now: datetime,
+    ) -> None:
+        pending = await self._pending_provider_changes(provider=provider)
+        if not pending:
+            return
+        observed_team_ids = {str(row.get("team_id") or "") for row in observed}
+        observed_native_keys = {
+            str(row.get("native_team_key") or "")
+            for row in observed
+            if row.get("native_team_key")
+        }
+        missing = [
+            row
+            for row in pending
+            if not _change_observed(
+                row,
+                observed_team_ids=observed_team_ids,
+                observed_native_keys=observed_native_keys,
+            )
+        ]
+        await self._insert_changes(
+            _status_rows(missing, status=STATUS_RESOLVED, now=now)
         )
 
     async def _project_field_changes(
@@ -339,29 +392,32 @@ class ClickHouseTeamDriftProjector:
         self,
         *,
         team_id: str,
-        provider: str,
-        native_team_key: str,
     ) -> list[dict[str, Any]]:
-        rows = await self._query_dicts(
+        return await self._query_dicts(
             f"""
             SELECT {", ".join(_CHANGE_COLUMNS)}
             FROM team_drift_changes FINAL
             WHERE org_id = {{org_id:String}}
               AND entity_type = 'team'
               AND entity_id = {{team_id:String}}
-              AND provider = {{provider:String}}
               AND change_type = 'field_changed'
             """,
-            {"org_id": self.org_id, "team_id": team_id, "provider": provider},
+            {"org_id": self.org_id, "team_id": team_id},
         )
-        if native_team_key:
-            return [
-                row
-                for row in rows
-                if not row.get("native_team_key")
-                or str(row.get("native_team_key")) == native_team_key
-            ]
-        return rows
+
+    async def _pending_provider_changes(self, *, provider: str) -> list[dict[str, Any]]:
+        return await self._query_dicts(
+            f"""
+            SELECT {", ".join(_CHANGE_COLUMNS)}
+            FROM team_drift_changes FINAL
+            WHERE org_id = {{org_id:String}}
+              AND entity_type = 'team'
+              AND provider = {{provider:String}}
+              AND change_type = 'field_changed'
+              AND status = 'pending'
+            """,
+            {"org_id": self.org_id, "provider": provider},
+        )
 
     async def _query_dicts(
         self, query: str, parameters: dict[str, Any]
@@ -392,7 +448,7 @@ def _observed_row(
     updated_at: datetime,
 ) -> dict[str, Any]:
     return {
-        "org_id": str(team_row.get("org_id") or org_id),
+        "org_id": org_id,
         "provider": str(team_row.get("provider") or ""),
         "native_team_key": str(
             team_row.get("native_team_key") or team_row.get("id") or ""
@@ -412,7 +468,7 @@ def _observed_row(
 
 def _field_json(row: dict[str, Any] | None, field: str) -> str:
     if field in JSON_FIELDS:
-        value: Any = _list_field(None if row is None else row.get(field))
+        value: Any = _comparison_list_field(None if row is None else row.get(field))
     else:
         value = None if row is None else row.get(field)
     return _canonical_json(value)
@@ -430,6 +486,35 @@ def _list_field(value: Any) -> list[str]:
     if isinstance(value, list | tuple | set):
         return [str(item) for item in value if item is not None]
     return []
+
+
+def _comparison_list_field(value: Any) -> list[str]:
+    return sorted(set(_list_field(value)))
+
+
+def _catalog_row_for_write(org_id: str, team_row: dict[str, Any]) -> dict[str, Any]:
+    row = dict(team_row)
+    row["org_id"] = org_id
+    return row
+
+
+def _provider_from_observed(observed: Sequence[dict[str, Any]]) -> str | None:
+    providers = {str(row.get("provider") or "") for row in observed}
+    providers.discard("")
+    if len(providers) == 1:
+        return next(iter(providers))
+    return None
+
+
+def _change_observed(
+    row: dict[str, Any],
+    *,
+    observed_team_ids: set[str],
+    observed_native_keys: set[str],
+) -> bool:
+    entity_id = str(row.get("entity_id") or row.get("team_id") or "")
+    native_team_key = str(row.get("native_team_key") or "")
+    return entity_id in observed_team_ids or native_team_key in observed_native_keys
 
 
 def _managed_fields(value: Any) -> tuple[str, ...]:

--- a/src/dev_health_ops/workers/team_autoimport_github.py
+++ b/src/dev_health_ops/workers/team_autoimport_github.py
@@ -309,6 +309,7 @@ async def _project_team_rows(
         await project_team_rows_with_store(
             store=team_store,
             org_id=org_id,
+            provider="github",
             team_rows=team_rows,
             team_writer=sink.insert_teams,
             discovered_at=discovered_at,
@@ -318,6 +319,7 @@ async def _project_team_rows(
         await project_provider_team_rows(
             dsn=sink.dsn,
             org_id=org_id,
+            provider="github",
             team_rows=team_rows,
             team_writer=sink.insert_teams,
             discovered_at=discovered_at,

--- a/src/dev_health_ops/workers/team_autoimport_gitlab.py
+++ b/src/dev_health_ops/workers/team_autoimport_gitlab.py
@@ -328,6 +328,7 @@ async def _project_team_rows(
         await project_team_rows_with_store(
             store=team_store,
             org_id=org_id,
+            provider="gitlab",
             team_rows=team_rows,
             team_writer=sink.insert_teams,
             discovered_at=discovered_at,
@@ -337,6 +338,7 @@ async def _project_team_rows(
         await project_provider_team_rows(
             dsn=sink.dsn,
             org_id=org_id,
+            provider="gitlab",
             team_rows=team_rows,
             team_writer=sink.insert_teams,
             discovered_at=discovered_at,

--- a/src/dev_health_ops/workers/team_autoimport_jira.py
+++ b/src/dev_health_ops/workers/team_autoimport_jira.py
@@ -368,6 +368,7 @@ def populate(
                 project_team_rows_with_store(
                     store=team_store,
                     org_id=org_id,
+                    provider="jira",
                     team_rows=team_rows,
                     team_writer=sink.insert_teams,
                     discovered_at=now,
@@ -378,6 +379,7 @@ def populate(
                 project_provider_team_rows(
                     dsn=_clickhouse_dsn(scope),
                     org_id=org_id,
+                    provider="jira",
                     team_rows=team_rows,
                     team_writer=sink.insert_teams,
                     discovered_at=now,

--- a/src/dev_health_ops/workers/team_autoimport_linear.py
+++ b/src/dev_health_ops/workers/team_autoimport_linear.py
@@ -267,6 +267,7 @@ def populate(
                 project_team_rows_with_store(
                     store=team_store,
                     org_id=org_id,
+                    provider="linear",
                     team_rows=team_rows,
                     team_writer=sink.insert_teams,
                     discovered_at=now,
@@ -277,6 +278,7 @@ def populate(
                 project_provider_team_rows(
                     dsn=_clickhouse_dsn(scope),
                     org_id=org_id,
+                    provider="linear",
                     team_rows=team_rows,
                     team_writer=sink.insert_teams,
                     discovered_at=now,

--- a/src/dev_health_ops/workers/team_drift_sync.py
+++ b/src/dev_health_ops/workers/team_drift_sync.py
@@ -39,18 +39,33 @@ async def _sync_team_drift_async(org_id: str) -> dict[str, Any]:
     db_url = _validate_worker_clickhouse_uri(_get_db_url())
     configs = _configured_provider_syncs(org_id)
     provider_results: list[dict[str, Any]] = []
+    team_rows_by_provider: dict[str, list[dict[str, Any]]] = {}
+    discovered_at_by_provider: dict[str, datetime] = {}
+    complete_by_provider: dict[str, bool] = {}
     async with ClickHouseStore(db_url) as store:
         store.org_id = org_id
         for config in configs:
+            complete_by_provider.setdefault(config.provider, True)
             result = await _discover_provider_team_rows(org_id=org_id, config=config)
             provider_results.append(result)
             if result.get("status") != "success":
+                complete_by_provider[config.provider] = False
                 continue
+            if not _provider_scan_complete(result):
+                complete_by_provider[config.provider] = False
+            team_rows_by_provider.setdefault(config.provider, []).extend(
+                list(result["team_rows"])
+            )
+            discovered_at_by_provider[config.provider] = result["discovered_at"]
+
+        for provider, team_rows in team_rows_by_provider.items():
             await project_team_rows_with_store(
                 store=store,
                 org_id=org_id,
-                team_rows=list(result["team_rows"]),
-                discovered_at=result["discovered_at"],
+                provider=provider,
+                team_rows=team_rows,
+                discovered_at=discovered_at_by_provider[provider],
+                resolve_missing_provider_changes=complete_by_provider[provider],
             )
     return {
         "status": "success",
@@ -196,6 +211,7 @@ async def _discover_gitlab(*, org_id: str, config: _DriftSyncConfig) -> dict[str
     response = _success(
         config, _team_rows(org_id=org_id, teams=result.teams, now=now), now
     )
+    response["complete"] = not result.truncated
     if result.truncated:
         response["warnings"] = list(result.warnings)
     return response
@@ -217,7 +233,10 @@ async def _discover_jira(*, org_id: str, config: _DriftSyncConfig) -> dict[str, 
         api_token=jira_credentials.api_token,
         url=jira_credentials.base_url,
     )
-    return _success(config, _generic_team_rows(org_id, "jira", teams, now), now)
+    response = _success(config, _generic_team_rows(org_id, "jira", teams, now), now)
+    response["complete"] = False
+    response["warnings"] = ["jira_project_discovery_is_bounded"]
+    return response
 
 
 async def _discover_linear(*, org_id: str, config: _DriftSyncConfig) -> dict[str, Any]:
@@ -275,6 +294,14 @@ def _success(
         "teams_discovered": len(team_rows),
         "discovered_at": discovered_at,
     }
+
+
+def _provider_scan_complete(result: dict[str, Any]) -> bool:
+    return bool(
+        result.get("status") == "success"
+        and result.get("complete", True)
+        and not result.get("warnings")
+    )
 
 
 def _skipped(

--- a/tests/_clickhouse_team_store.py
+++ b/tests/_clickhouse_team_store.py
@@ -191,7 +191,7 @@ class FakeClickHouseTeamStore:
             self.rows[(org_id, team_id)] = {
                 "id": team_id,
                 "team_uuid": team_uuid,
-                "name": str(get("name") or team_id),
+                "name": str(get("name")) if get("name") is not None else team_id,
                 "description": get("description"),
                 "members": _as_list(get("members")),
                 "project_keys": _as_list(get("project_keys")),
@@ -295,6 +295,7 @@ class FakeClickHouseTeamStore:
         if "team_drift_changes" in query:
             team_id = params.get("team_id")
             provider = params.get("provider")
+            pending_only = "status = 'pending'" in query
             changes: list[dict[str, Any]] = []
             for (row_org, _change_id), row in self.drift_changes.items():
                 if row_org != org_id:
@@ -306,6 +307,8 @@ class FakeClickHouseTeamStore:
                 if provider is not None and str(row.get("provider") or "") != str(
                     provider
                 ):
+                    continue
+                if pending_only and row.get("status") != "pending":
                     continue
                 changes.append(dict(row))
             return changes

--- a/tests/api/services/configuration/test_clickhouse_team_drift_projector.py
+++ b/tests/api/services/configuration/test_clickhouse_team_drift_projector.py
@@ -44,12 +44,16 @@ class FakeProjectorStore:
             row = self.team_rows.get(str(parameters["team_id"]))
             return [dict(row)] if row else []
         if "FROM team_drift_changes" in query:
+            team_id = parameters.get("team_id")
+            provider = parameters.get("provider")
+            pending_only = "status = 'pending'" in query
             return [
                 dict(row)
                 for row in self.drift_rows.values()
                 if row["org_id"] == parameters["org_id"]
-                and row["entity_id"] == parameters["team_id"]
-                and row["provider"] == parameters["provider"]
+                and (team_id is None or row["entity_id"] == team_id)
+                and (provider is None or row["provider"] == provider)
+                and (not pending_only or row["status"] == "pending")
             ]
         return []
 
@@ -74,6 +78,26 @@ def test_auto_apply_policy_writes_observation_and_catalog() -> None:
     assert store.observations[0]["name"] == "Platform"
     assert team_writes == [row]
     assert store.drift_inserts == []
+
+
+def test_auto_apply_forces_org_id_on_observation_and_catalog_write() -> None:
+    store = FakeProjectorStore()
+    team_writes: list[dict[str, Any]] = []
+
+    async def write_teams(rows: list[dict[str, Any]]) -> None:
+        team_writes.extend(dict(row) for row in rows)
+
+    row = {**_team_row(name="Platform"), "org_id": "wrong-org"}
+    asyncio.run(
+        ClickHouseTeamDriftProjector(
+            store=cast(Any, store),
+            org_id="org-1",
+            team_writer=write_teams,
+        ).project_team(row)
+    )
+
+    assert store.observations[0]["org_id"] == "org-1"
+    assert team_writes[0]["org_id"] == "org-1"
 
 
 def test_flag_policy_emits_value_fingerprinted_pending_change() -> None:
@@ -113,6 +137,25 @@ def test_decided_change_is_not_reinserted_as_pending() -> None:
     assert [row["status"] for row in store.drift_inserts] == ["pending"]
 
 
+def test_decided_change_is_not_reinserted_when_native_key_changes() -> None:
+    store = _store_with_flag_policy()
+    store.team_rows["team-1"] = _catalog_row(name="Old")
+
+    asyncio.run(_project(store, _team_row(name="New")))
+    change_id = store.drift_inserts[0]["change_id"]
+    store.drift_rows[change_id] = {
+        **store.drift_rows[change_id],
+        "status": "dismissed",
+        "native_team_key": "OLD",
+        "updated_at": datetime.now(timezone.utc),
+    }
+
+    asyncio.run(_project(store, {**_team_row(name="New"), "native_team_key": "NEW"}))
+
+    assert store.drift_rows[change_id]["status"] == "dismissed"
+    assert [row["status"] for row in store.drift_inserts] == ["pending"]
+
+
 def test_changed_provider_value_supersedes_prior_pending_change() -> None:
     store = _store_with_flag_policy()
     store.team_rows["team-1"] = _catalog_row(name="Old")
@@ -143,17 +186,78 @@ def test_disappeared_drift_resolves_prior_pending_change() -> None:
     assert [row["status"] for row in store.drift_inserts] == ["pending", "resolved"]
 
 
+def test_empty_provider_discovery_resolves_pending_provider_changes() -> None:
+    store = _store_with_flag_policy()
+    store.team_rows["team-1"] = _catalog_row(name="Old")
+
+    asyncio.run(_project(store, _team_row(name="New")))
+    change_id = store.drift_inserts[0]["change_id"]
+    asyncio.run(
+        ClickHouseTeamDriftProjector(
+            store=cast(Any, store), org_id="org-1"
+        ).project_many([], provider="linear", resolve_missing_provider_changes=True)
+    )
+
+    assert store.drift_rows[change_id]["status"] == "resolved"
+    assert [row["status"] for row in store.drift_inserts] == ["pending", "resolved"]
+
+
+def test_missing_team_in_provider_discovery_resolves_pending_change() -> None:
+    store = _store_with_flag_policy()
+    store.team_rows["team-1"] = _catalog_row(name="Old")
+    store.team_rows["team-2"] = {**_catalog_row(name="Stable"), "id": "team-2"}
+    store.policy_rows["team-2"] = {
+        "sync_policy": 1,
+        "managed_fields": ["name"],
+    }
+
+    asyncio.run(_project(store, _team_row(name="New")))
+    change_id = store.drift_inserts[0]["change_id"]
+    asyncio.run(
+        ClickHouseTeamDriftProjector(
+            store=cast(Any, store), org_id="org-1"
+        ).project_many(
+            [{**_team_row(name="Stable"), "id": "team-2", "native_team_key": "TEAM2"}],
+            provider="linear",
+            resolve_missing_provider_changes=True,
+        )
+    )
+
+    assert store.drift_rows[change_id]["status"] == "resolved"
+
+
+def test_list_field_change_id_is_order_stable() -> None:
+    store = _store_with_flag_policy(managed_fields=["members"])
+    store.team_rows["team-1"] = _catalog_row(name="Platform")
+
+    asyncio.run(_project(store, {**_team_row(name="Platform"), "members": ["b", "a"]}))
+    first_change_id = store.drift_inserts[0]["change_id"]
+    store.drift_rows[first_change_id] = {
+        **store.drift_rows[first_change_id],
+        "status": "dismissed",
+        "updated_at": datetime.now(timezone.utc),
+    }
+    asyncio.run(
+        _project(store, {**_team_row(name="Platform"), "members": ["a", "b", "a"]})
+    )
+
+    assert store.drift_rows[first_change_id]["status"] == "dismissed"
+    assert [row["status"] for row in store.drift_inserts] == ["pending"]
+
+
 async def _project(store: FakeProjectorStore, row: dict[str, Any]) -> None:
     await ClickHouseTeamDriftProjector(
         store=cast(Any, store), org_id="org-1"
     ).project_team(row)
 
 
-def _store_with_flag_policy() -> FakeProjectorStore:
+def _store_with_flag_policy(
+    *, managed_fields: list[str] | None = None
+) -> FakeProjectorStore:
     store = FakeProjectorStore()
     store.policy_rows["team-1"] = {
         "sync_policy": 1,
-        "managed_fields": ["name"],
+        "managed_fields": managed_fields or ["name"],
     }
     return store
 

--- a/tests/api/services/configuration/test_clickhouse_team_drift_service.py
+++ b/tests/api/services/configuration/test_clickhouse_team_drift_service.py
@@ -29,6 +29,8 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, cast
 
+import pytest
+
 from dev_health_ops.api.services.configuration.clickhouse_team_admin import (
     _TEAM_COLUMNS,
 )
@@ -119,7 +121,9 @@ class FakeDriftStore:
             self.teams[team_id] = {
                 "id": team_id,
                 "team_uuid": team_uuid,
-                "name": str(row.get("name") or team_id),
+                "name": str(row.get("name"))
+                if row.get("name") is not None
+                else team_id,
                 "description": row.get("description"),
                 "members": list(row.get("members") or []),
                 "project_keys": list(row.get("project_keys") or []),
@@ -287,6 +291,38 @@ def test_change_ids_decides_only_the_requested_subset() -> None:
     assert store.teams["team-1"]["description"] == "Old desc"
     assert result == {"approved": 1, "change_ids": ["chg-name"]}
     assert [row["change_id"] for row in store.drift_inserts] == ["chg-name"]
+
+
+def test_approve_uses_empty_observed_name_instead_of_falling_back() -> None:
+    store = FakeDriftStore()
+    _seed_catalog_team(store, name="Old", description="Observed description")
+    _seed_observation(store, name="")
+    store.pending = [_pending("chg-name", field="name", old="Old", new="")]
+
+    result = asyncio.run(
+        _service(store).approve(
+            team_id="team-1", change_ids=["chg-name"], decided_by="admin"
+        )
+    )
+
+    assert store.teams["team-1"]["name"] == ""
+    assert result == {"approved": 1, "change_ids": ["chg-name"]}
+
+
+def test_approve_fails_without_provider_observation() -> None:
+    store = FakeDriftStore()
+    _seed_catalog_team(store, name="Old", description="Observed description")
+    store.pending = [_pending("chg-name", field="name", old="Old", new="Platform")]
+
+    with pytest.raises(ValueError, match="provider observation"):
+        asyncio.run(
+            _service(store).approve(
+                team_id="team-1", change_ids=["chg-name"], decided_by="admin"
+            )
+        )
+
+    assert store.teams["team-1"]["name"] == "Old"
+    assert store.drift_inserts == []
 
 
 def test_approve_without_change_ids_and_not_all_is_a_noop() -> None:

--- a/tests/workers/test_team_drift_sync.py
+++ b/tests/workers/test_team_drift_sync.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from dev_health_ops.workers.team_drift_sync import _provider_scan_complete
+
+
+def test_provider_scan_complete_accepts_plain_success() -> None:
+    assert _provider_scan_complete({"status": "success"})
+
+
+def test_provider_scan_complete_rejects_truncated_or_warning_results() -> None:
+    assert not _provider_scan_complete({"status": "success", "complete": False})
+    assert not _provider_scan_complete({"status": "success", "warnings": ["bounded"]})
+    assert not _provider_scan_complete({"status": "skipped"})


### PR DESCRIPTION
## Summary
- harden ClickHouse team drift lifecycle lookups so decided changes do not resurrect across provider/native-key changes
- normalize list-field drift comparison and force org_id on observation/catalog writes
- require provider observations for approval, preserve empty-string names, and resolve disappeared-team drift only after complete provider scans
- tag provider auto-import projection calls and cover complete-scan worker reconciliation in tests

## Validation
- bash ci/local_validate.sh: GATE PASSED (5683 passed, 45 skipped)
- lsp_diagnostics: clean on changed files
- pre-push hook: ruff format/check + mypy passed

SCREENSHOT-WAIVER: backend-only/no-render change