### PR TITLE
fix(teams): place FINAL after table alias in drift pending-changes query (CHAOS-2659)

### DIFF
--- a/src/dev_health_ops/api/services/configuration/clickhouse_team_drift.py
+++ b/src/dev_health_ops/api/services/configuration/clickhouse_team_drift.py
@@ -143,8 +143,8 @@ class ClickHouseTeamDriftService:
                 c.new_value_json,
                 c.first_seen_at,
                 c.last_seen_at
-            FROM team_drift_changes FINAL AS c
-            LEFT JOIN teams FINAL AS t
+            FROM team_drift_changes AS c FINAL
+            LEFT JOIN teams AS t FINAL
                 ON t.org_id = c.org_id AND t.id = c.entity_id
             WHERE {where}
             ORDER BY c.first_seen_at DESC, c.change_id

--- a/tests/api/services/configuration/test_clickhouse_team_drift_live.py
+++ b/tests/api/services/configuration/test_clickhouse_team_drift_live.py
@@ -1,0 +1,99 @@
+"""Live-ClickHouse regression for the drift pending-changes query.
+
+The service-level tests in ``test_clickhouse_team_drift_service.py`` back the
+store with an in-memory fake whose ``client.query`` *substring-matches* the SQL
+and returns canned rows — so a syntax error in the query string is invisible to
+them. That blind spot shipped a broken ``GET /admin/teams/pending-changes``: the
+``_pending_rows`` SELECT placed ``FINAL`` *before* the table alias
+(``team_drift_changes FINAL AS c`` / ``teams FINAL AS t``), which ClickHouse
+rejects with ``SYNTAX_ERROR`` (``FINAL`` must follow the alias:
+``team_drift_changes AS c FINAL``).
+
+This test executes the real query against a live engine so the grammar is
+actually parsed — the only thing that catches a ``FINAL``/alias ordering slip.
+
+Opt-in (filtered from unit/CI): ``pytest -m clickhouse`` with ``CLICKHOUSE_URI``
+pointing at a SCRATCH db (never the dev ``default``).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/ci_local_validate)",
+    ),
+]
+
+_NOW = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_get_pending_changes_executes_against_live_engine() -> None:
+    from dev_health_ops.api.services.configuration.clickhouse_team_drift import (
+        ClickHouseTeamDriftService,
+    )
+    from dev_health_ops.storage.clickhouse import ClickHouseStore
+
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
+    org_id = f"test-drift-final-{uuid.uuid4()}"
+    team_id = "team-platform"
+
+    async with ClickHouseStore(CLICKHOUSE_URI) as store:
+        store.org_id = org_id
+        # Seed the catalog team so the LEFT JOIN ... FINAL leg actually matches
+        # (exercises coalesce(t.name, c.entity_id) -> the joined name).
+        await store.insert_teams(
+            [
+                {
+                    "id": team_id,
+                    "name": "Platform",
+                    "org_id": org_id,
+                    "provider": "linear",
+                    "is_active": 1,
+                    "updated_at": _NOW,
+                }
+            ]
+        )
+        await store.insert_team_drift_changes(
+            [
+                {
+                    "org_id": org_id,
+                    "change_id": "chg-name",
+                    "entity_type": "team",
+                    "entity_id": team_id,
+                    "provider": "linear",
+                    "native_team_key": "PLATFORM",
+                    "change_type": "field_changed",
+                    "field": "name",
+                    "old_value_json": '"Old"',
+                    "new_value_json": '"Platform"',
+                    "status": "pending",
+                    "first_seen_at": _NOW,
+                    "last_seen_at": _NOW,
+                }
+            ]
+        )
+
+        service = ClickHouseTeamDriftService(store, org_id)
+        # Real engine parses + executes the FROM ... AS c FINAL / LEFT JOIN ... AS
+        # t FINAL query here; a FINAL/alias ordering regression raises
+        # clickhouse_connect.driver.exceptions.DatabaseError (SYNTAX_ERROR).
+        changes = await service.get_pending_changes()
+
+    matching = [c for c in changes if c.change_id == "chg-name"]
+    assert len(matching) == 1
+    change = matching[0]
+    assert change.team_id == team_id
+    assert change.team_name == "Platform"  # came through the LEFT JOIN ... FINAL
+    assert change.field == "name"
+    assert change.new_value == "Platform"


### PR DESCRIPTION
## Problem

`GET /api/v1/admin/teams/pending-changes` returns HTTP 500 with a ClickHouse `SYNTAX_ERROR` (code 62), breaking the **/org/admin/teams** page:

```
Code: 62. DB::Exception: Syntax error: failed at position 443 (AS) (line 14, col 43): AS c
    LEFT JOIN teams FINAL AS t ... (SYNTAX_ERROR)
```

## Root cause

In `ClickHouseTeamDriftService._pending_rows()`, the SELECT placed `FINAL` **before** the table alias:

- `FROM team_drift_changes FINAL AS c`
- `LEFT JOIN teams FINAL AS t`

ClickHouse requires `FINAL` **after** the alias (`team_drift_changes AS c FINAL`). The nearby single-table `team_provider_observations FINAL` (no alias) is valid, which likely misled the author when aliases were introduced.

Introduced by CHAOS-2622 (rebuild team drift-review on ClickHouse, #1044).

## Fix

Move `FINAL` after the alias in both the FROM and the LEFT JOIN. One-character-class change, no behavior change.

## Why existing tests missed it

The service unit tests (`test_clickhouse_team_drift_service.py`) back the store with an in-memory fake whose `client.query` **substring-matches** the SQL and returns canned rows. A real ClickHouse engine never parses the query, so a syntax regression is invisible — the same mock-based blind spot `ops/AGENTS.md` already calls out for `argMax`. There was no live-ClickHouse coverage for the drift pending-changes path.

## Regression guard

Adds `tests/api/services/configuration/test_clickhouse_team_drift_live.py` (`-m clickhouse`): seeds a catalog team + a pending drift change, then executes `get_pending_changes()` against a real engine, exercising both `FINAL` aliases and the `LEFT JOIN ... FINAL` leg.

Verified both directions against a live scratch ClickHouse:
- **Buggy form** → fails with the exact code-62 `SYNTAX_ERROR` at position 443.
- **Fixed form** → passes (returns the pending change with the joined team name).

## Validation

`bash ci/local_validate.sh` → **GATE PASSED**: ruff format/check, mypy, full unit suite (5683 passed, 45 skipped), CH migrate, and the live argMax proof all green.

Closes CHAOS-2659.

SCREENSHOT-WAIVER: backend-only SQL fix + test; no UI render change.